### PR TITLE
[codex] Add deployment readiness contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker compose up --build
 | Walk through a local end-to-end flow | [Getting started](docs/start/getting-started.md) |
 | Understand runtime shape and stores | [Architecture](docs/reference/architecture.md) |
 | Configure auth, tenancy, stores, MCP, or device auth | [Configuration variables](docs/reference/config-env-vars.md) and [.env.example](.env.example) |
-| Host or operate Cerebro | [Hosting](docs/operations/hosting.md), [cloud deployment](docs/operations/cloud-deployment.md), [deployment examples](docs/operations/deployment-examples.md), and [operations runbook](docs/operations/operations-runbook.md) |
+| Host or operate Cerebro | [Hosting](docs/operations/hosting.md), [runtime profiles](docs/operations/runtime-profiles.md), [deployment readiness](docs/operations/deployment-readiness.md), [cloud deployment](docs/operations/cloud-deployment.md), [deployment examples](docs/operations/deployment-examples.md), and [operations runbook](docs/operations/operations-runbook.md) |
 | Explore JSON HTTP or Connect APIs | [API reference](docs/reference/api-reference.md), `api/openapi.yaml`, and `proto/cerebro/v1/bootstrap.proto` |
 | Use the CLI | [CLI reference](docs/reference/cli.md) |
 | Browse built-in integrations | [Source catalog](docs/reference/sources.md) |
@@ -98,6 +98,7 @@ make verify         # CI-parity local verification
 make readme-check   # README and docs drift checks
 make docs-drift-check
 make oss-audit      # public repository hygiene scan
+cerebro deploy preflight  # emit a redacted deployment readiness receipt
 ```
 
 Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -99,11 +99,32 @@ func TestWritePreflightReceiptJSONRedactsToBoundedDetail(t *testing.T) {
 	}
 }
 
+func TestPreflightErrorDetailRedactsCredentialBearingDetails(t *testing.T) {
+	credential := "credential-" + "value"
+	detail := preflightErrorDetail(fmt.Errorf(
+		"connect nats://user:%[1]s@nats.example:4222?token=%[1]s failed; postgres://db:%[1]s@db.example/cerebro?password=%[1]s&sslmode=require; client_secret=%[1]s",
+		credential,
+	))
+
+	if strings.Contains(detail, credential) {
+		t.Fatalf("preflight detail leaked credential %q in %q", credential, detail)
+	}
+	for _, want := range []string{
+		"nats://nats.example:4222?token=<redacted>",
+		"postgres://db.example/cerebro?password=<redacted>&sslmode=require",
+		"client_secret=<redacted>",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("preflight detail = %q, want redacted fragment %q", detail, want)
+		}
+	}
+}
+
 func TestExecuteDeployPreflightReportsDependencyCloseFailure(t *testing.T) {
 	closeErr := errors.New("close failed")
 	receipt := executeDeployPreflightWith(context.Background(), preflightRuntime{
 		loadConfig: func() (appconfig.Config, error) {
-			return appconfig.Config{}, nil
+			return preflightReadyConfig(), nil
 		},
 		openDependencies: func(context.Context, appconfig.Config) (bootstrap.Dependencies, func() error, error) {
 			return bootstrap.Dependencies{}, func() error { return closeErr }, nil
@@ -116,13 +137,144 @@ func TestExecuteDeployPreflightReportsDependencyCloseFailure(t *testing.T) {
 	if receipt.Status != "fail" {
 		t.Fatalf("receipt status = %q, want fail", receipt.Status)
 	}
-	if got := len(receipt.Checks); got != 4 {
-		t.Fatalf("check count = %d, want 4: %#v", got, receipt.Checks)
+	if got := len(receipt.Checks); got != 5 {
+		t.Fatalf("check count = %d, want 5: %#v", got, receipt.Checks)
 	}
-	closeCheck := receipt.Checks[3]
+	closeCheck := receipt.Checks[4]
 	if closeCheck.Name != "dependencies.close" || closeCheck.Status != "fail" || closeCheck.Detail == "" {
 		t.Fatalf("close check = %#v, want failed dependencies.close detail", closeCheck)
 	}
+}
+
+func TestExecuteDeployPreflightAnnotatesReadinessReceipt(t *testing.T) {
+	receipt := executeDeployPreflightWith(context.Background(), preflightRuntime{
+		loadConfig: func() (appconfig.Config, error) {
+			cfg := preflightReadyConfig()
+			cfg.StateStore = appconfig.StateStoreConfig{Driver: appconfig.StateStoreDriverPostgres, PostgresDSN: "postgres://user@example.invalid/cerebro?sslmode=require"}
+			cfg.AppendLog = appconfig.AppendLogConfig{
+				Driver:                       appconfig.AppendLogDriverJetStream,
+				JetStreamURL:                 "nats://example.invalid:4222",
+				JetStreamRuntimeIndexEnabled: true,
+			}
+			cfg.GraphStore = appconfig.GraphStoreConfig{
+				Driver:        appconfig.GraphStoreDriverNeo4j,
+				Neo4jURI:      "neo4j+s://graph.example.invalid",
+				Neo4jUsername: "neo4j",
+				Neo4jPassword: "secret",
+			}
+			cfg.Auth.CapabilityTokenSecrets = []string{"capability-secret"}
+			cfg.Auth.MCPOAuth = appconfig.MCPOAuthConfig{
+				Enabled: true,
+				Clients: []appconfig.MCPOAuthClient{{
+					ClientID:     "mcp-client",
+					ClientSecret: "mcp-secret",
+				}},
+				Upstream: appconfig.MCPOAuthUpstreamConfig{
+					Issuer:       "https://identity.example.invalid",
+					ClientID:     "upstream-client",
+					ClientSecret: "upstream-secret",
+					RedirectURI:  "https://cerebro.example.com/oauth/callback",
+				},
+			}
+			cfg.Auth.DeviceAuth = appconfig.DeviceAuthConfig{
+				Enabled: true,
+				SigningKeys: []appconfig.DeviceAuthSigningKey{{
+					KID:        "current",
+					PublicPEM:  "public",
+					PrivatePEM: "private",
+				}},
+				CurrentKID: "current",
+			}
+			cfg.Auth.RequestOrigin.PublicOrigin = "https://cerebro.example.com"
+			cfg.Auth.RequestOrigin.TrustedProxyCIDRs = []string{"10.0.0.0/8"}
+			cfg.OTEL.Enabled = true
+			return cfg, nil
+		},
+		openDependencies: func(context.Context, appconfig.Config) (bootstrap.Dependencies, func() error, error) {
+			return bootstrap.Dependencies{}, func() error { return nil }, nil
+		},
+		probeLLM: func(context.Context, graphagent.LLMClient) error {
+			return nil
+		},
+	})
+
+	if receipt.Status != "pass" {
+		t.Fatalf("receipt status = %q, want pass: %#v", receipt.Status, receipt.Checks)
+	}
+	if receipt.RuntimeProfile != "graph-enabled" {
+		t.Fatalf("runtime profile = %q, want graph-enabled", receipt.RuntimeProfile)
+	}
+	for _, want := range []string{"api.auth", "append_log.jetstream", "append_log.runtime_index", "device_auth", "graph_store.neo4j", "mcp.oauth", "otel.export", "state_store.postgres"} {
+		if !containsString(receipt.EnabledCapabilities, want) {
+			t.Fatalf("enabled capabilities %v missing %q", receipt.EnabledCapabilities, want)
+		}
+	}
+	for _, want := range []string{"CEREBRO_API_KEYS", "CEREBRO_CAPABILITY_TOKEN_SECRETS", "CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", "CEREBRO_MCP_OAUTH_CLIENTS_JSON", "CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "CEREBRO_POSTGRES_DSN", "CEREBRO_JETSTREAM_URL", "CEREBRO_NEO4J_PASSWORD"} {
+		if !containsString(receipt.RequiredSecretNames, want) {
+			t.Fatalf("required secret names %v missing %q", receipt.RequiredSecretNames, want)
+		}
+	}
+	if len(receipt.RequiredBackingServices) != 5 {
+		t.Fatalf("required backing services = %#v, want postgres, nats, neo4j, upstream oauth, otlp", receipt.RequiredBackingServices)
+	}
+	if !containsString(receipt.OperatorActions, "run graph health after rollout and before graph-dependent workflows") {
+		t.Fatalf("operator actions = %#v", receipt.OperatorActions)
+	}
+}
+
+func TestExecuteDeployPreflightFailsUnsafeServeConfigBeforeOpeningDependencies(t *testing.T) {
+	opened := false
+	receipt := executeDeployPreflightWith(context.Background(), preflightRuntime{
+		loadConfig: func() (appconfig.Config, error) {
+			return appconfig.Config{
+				Auth:      appconfig.AuthConfig{Enabled: true},
+				RateLimit: appconfig.RateLimitConfig{Enabled: true},
+			}, nil
+		},
+		openDependencies: func(context.Context, appconfig.Config) (bootstrap.Dependencies, func() error, error) {
+			opened = true
+			return bootstrap.Dependencies{}, func() error { return nil }, nil
+		},
+		probeLLM: func(context.Context, graphagent.LLMClient) error {
+			return nil
+		},
+	})
+
+	if receipt.Status != "fail" {
+		t.Fatalf("receipt status = %q, want fail", receipt.Status)
+	}
+	if opened {
+		t.Fatal("dependencies opened after serve config failed")
+	}
+	if got := receipt.Checks[len(receipt.Checks)-1].Name; got != "serve_config.validate" {
+		t.Fatalf("last check = %q, want serve_config.validate", got)
+	}
+	if !containsString(receipt.RequiredSecretNames, "one of CEREBRO_API_KEYS, CEREBRO_API_CREDENTIALS_JSON, or CEREBRO_CAPABILITY_TOKEN_SECRETS") {
+		t.Fatalf("required secret names = %#v", receipt.RequiredSecretNames)
+	}
+}
+
+func preflightReadyConfig() appconfig.Config {
+	return appconfig.Config{
+		Auth: appconfig.AuthConfig{
+			Enabled: true,
+			APIKeys: []appconfig.APIKey{{
+				Key:       "token",
+				Principal: "ci",
+				TenantID:  "example",
+			}},
+		},
+		RateLimit: appconfig.RateLimitConfig{Enabled: true},
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSourceRuntimeCommandSignalsIncludeSIGTERM(t *testing.T) {

--- a/cmd/cerebro/preflight.go
+++ b/cmd/cerebro/preflight.go
@@ -6,7 +6,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,16 +19,27 @@ import (
 )
 
 type preflightReceipt struct {
-	Kind        string           `json:"kind"`
-	Status      string           `json:"status"`
-	GeneratedAt string           `json:"generated_at"`
-	Checks      []preflightCheck `json:"checks"`
+	Kind                    string                    `json:"kind"`
+	Status                  string                    `json:"status"`
+	GeneratedAt             string                    `json:"generated_at"`
+	RuntimeProfile          string                    `json:"runtime_profile,omitempty"`
+	EnabledCapabilities     []string                  `json:"enabled_capabilities,omitempty"`
+	RequiredBackingServices []preflightBackingService `json:"required_backing_services,omitempty"`
+	RequiredSecretNames     []string                  `json:"required_secret_names,omitempty"`
+	OperatorActions         []string                  `json:"operator_actions,omitempty"`
+	Checks                  []preflightCheck          `json:"checks"`
 }
 
 type preflightCheck struct {
 	Name   string `json:"name"`
 	Status string `json:"status"`
 	Detail string `json:"detail,omitempty"`
+}
+
+type preflightBackingService struct {
+	Name        string   `json:"name"`
+	RequiredFor string   `json:"required_for"`
+	ConfigVars  []string `json:"config_vars,omitempty"`
 }
 
 type preflightOptions struct {
@@ -38,6 +52,11 @@ type preflightRuntime struct {
 	openDependencies func(context.Context, appconfig.Config) (bootstrap.Dependencies, func() error, error)
 	probeLLM         func(context.Context, graphagent.LLMClient) error
 }
+
+var (
+	preflightDetailURLRe              = regexp.MustCompile(`[A-Za-z][A-Za-z0-9+.-]*://[^\s"'<>]+`)
+	preflightDetailSecretAssignmentRe = regexp.MustCompile(`(?i)\b(access[_-]?token|api[_-]?key|authorization|client[_-]?secret|key|password|secret|token)=([^\s,;)&]+)`)
+)
 
 func runDeploy(args []string) error {
 	if len(args) == 0 {
@@ -104,6 +123,12 @@ func executeDeployPreflightWith(ctx context.Context, runtime preflightRuntime) (
 	if err != nil {
 		return receipt
 	}
+	annotatePreflightReceipt(&receipt, cfg)
+	serveConfigErr := validateServeConfig(cfg)
+	addCheck("serve_config.validate", serveConfigErr)
+	if serveConfigErr != nil {
+		return receipt
+	}
 	deps, closeDeps, err := runtime.openDependencies(ctx, cfg)
 	addCheck("dependencies.open", err)
 	if err != nil {
@@ -136,19 +161,319 @@ func writePreflightReceipt(w io.Writer, receipt preflightReceipt, format string)
 				return err
 			}
 		}
+		if receipt.RuntimeProfile != "" {
+			if _, err := fmt.Fprintf(w, "runtime profile: %s\n", receipt.RuntimeProfile); err != nil {
+				return err
+			}
+		}
+		writeTextList := func(title string, values []string) error {
+			if len(values) == 0 {
+				return nil
+			}
+			if _, err := fmt.Fprintln(w, title+":"); err != nil {
+				return err
+			}
+			for _, value := range values {
+				if _, err := fmt.Fprintln(w, "- "+value); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		if err := writeTextList("enabled capabilities", receipt.EnabledCapabilities); err != nil {
+			return err
+		}
+		if len(receipt.RequiredBackingServices) > 0 {
+			if _, err := fmt.Fprintln(w, "required backing services:"); err != nil {
+				return err
+			}
+			for _, service := range receipt.RequiredBackingServices {
+				line := fmt.Sprintf("- %s: %s", service.Name, service.RequiredFor)
+				if len(service.ConfigVars) > 0 {
+					line += " (" + strings.Join(service.ConfigVars, ", ") + ")"
+				}
+				if _, err := fmt.Fprintln(w, line); err != nil {
+					return err
+				}
+			}
+		}
+		if err := writeTextList("required secret names", receipt.RequiredSecretNames); err != nil {
+			return err
+		}
+		if err := writeTextList("operator actions", receipt.OperatorActions); err != nil {
+			return err
+		}
 		return nil
 	default:
 		return fmt.Errorf("unsupported preflight output format %q", format)
 	}
 }
 
+func annotatePreflightReceipt(receipt *preflightReceipt, cfg appconfig.Config) {
+	receipt.RuntimeProfile = preflightRuntimeProfile(cfg)
+	receipt.EnabledCapabilities = preflightEnabledCapabilities(cfg)
+	receipt.RequiredBackingServices = preflightRequiredBackingServices(cfg)
+	receipt.RequiredSecretNames = preflightRequiredSecretNames(cfg)
+	receipt.OperatorActions = preflightOperatorActions(cfg)
+}
+
+func preflightRuntimeProfile(cfg appconfig.Config) string {
+	if cfg.GraphStore.Driver == appconfig.GraphStoreDriverNeo4j {
+		return "graph-enabled"
+	}
+	if cfg.AppendLog.Driver == appconfig.AppendLogDriverJetStream {
+		return "durable-sync"
+	}
+	if cfg.StateStore.Driver == appconfig.StateStoreDriverPostgres {
+		return "durable-api"
+	}
+	return "lightweight-api"
+}
+
+func preflightEnabledCapabilities(cfg appconfig.Config) []string {
+	capabilities := map[string]struct{}{}
+	if cfg.Auth.Enabled {
+		capabilities["api.auth"] = struct{}{}
+	}
+	if cfg.RateLimit.Enabled {
+		capabilities["api.rate_limit"] = struct{}{}
+	}
+	if cfg.StateStore.Driver == appconfig.StateStoreDriverPostgres {
+		capabilities["state_store.postgres"] = struct{}{}
+	}
+	if cfg.AppendLog.Driver == appconfig.AppendLogDriverJetStream {
+		capabilities["append_log.jetstream"] = struct{}{}
+		if cfg.AppendLog.JetStreamRuntimeIndexEnabled {
+			capabilities["append_log.runtime_index"] = struct{}{}
+		}
+	}
+	if cfg.GraphStore.Driver == appconfig.GraphStoreDriverNeo4j {
+		capabilities["graph_store.neo4j"] = struct{}{}
+	}
+	switch cfg.Cache.Driver {
+	case appconfig.CacheDriverMemory:
+		capabilities["cache.memory"] = struct{}{}
+	case appconfig.CacheDriverRedis, appconfig.CacheDriverValkey:
+		capabilities["cache."+cfg.Cache.Driver] = struct{}{}
+	}
+	if cfg.Auth.MCPOAuth.Enabled {
+		capabilities["mcp.oauth"] = struct{}{}
+	}
+	if cfg.Auth.DeviceAuth.Enabled {
+		capabilities["device_auth"] = struct{}{}
+	}
+	if cfg.OTEL.Enabled {
+		capabilities["otel.export"] = struct{}{}
+	}
+	if strings.TrimSpace(cfg.GraphAgentLLM.Provider) != "" || strings.TrimSpace(cfg.GraphAgentLLM.OpenRouterAPIKey) != "" || strings.TrimSpace(cfg.GraphAgentLLM.BedrockRegion) != "" {
+		capabilities["graph_agent.llm"] = struct{}{}
+	}
+	if strings.TrimSpace(cfg.GraphActions.AccessApprovals.BaseURL) != "" {
+		capabilities["graph_actions.access_approvals"] = struct{}{}
+	}
+	return sortedPreflightSet(capabilities)
+}
+
+func preflightRequiredBackingServices(cfg appconfig.Config) []preflightBackingService {
+	var services []preflightBackingService
+	if cfg.StateStore.Driver == appconfig.StateStoreDriverPostgres {
+		services = append(services, preflightBackingService{
+			Name:        "postgres",
+			RequiredFor: "durable runtime state, claims, findings, reports, OAuth, and device auth",
+			ConfigVars:  []string{"CEREBRO_STATE_STORE_DRIVER", "CEREBRO_POSTGRES_DSN"},
+		})
+	}
+	if cfg.AppendLog.Driver == appconfig.AppendLogDriverJetStream {
+		services = append(services, preflightBackingService{
+			Name:        "nats-jetstream",
+			RequiredFor: "append-log sync, replay, and source runtime workflows",
+			ConfigVars:  []string{"CEREBRO_APPEND_LOG_DRIVER", "CEREBRO_JETSTREAM_URL"},
+		})
+	}
+	if cfg.GraphStore.Driver == appconfig.GraphStoreDriverNeo4j {
+		services = append(services, preflightBackingService{
+			Name:        "neo4j",
+			RequiredFor: "graph projection, graph queries, graph health, and graph-agent flows",
+			ConfigVars:  []string{"CEREBRO_GRAPH_STORE_DRIVER", "CEREBRO_NEO4J_URI", "CEREBRO_NEO4J_USERNAME", "CEREBRO_NEO4J_PASSWORD"},
+		})
+	}
+	if cfg.Auth.MCPOAuth.Enabled {
+		services = append(services, preflightBackingService{
+			Name:        "upstream-oauth-provider",
+			RequiredFor: "MCP OAuth authorization-code exchange and entitlement checks",
+			ConfigVars:  []string{"CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", "CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID", "CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI"},
+		})
+	}
+	if cfg.Cache.Driver == appconfig.CacheDriverRedis || cfg.Cache.Driver == appconfig.CacheDriverValkey {
+		services = append(services, preflightBackingService{
+			Name:        cfg.Cache.Driver,
+			RequiredFor: "shared query cache",
+			ConfigVars:  []string{"CEREBRO_CACHE_MODE", "CEREBRO_CACHE_URL"},
+		})
+	}
+	if cfg.OTEL.Enabled {
+		services = append(services, preflightBackingService{
+			Name:        "otlp-collector",
+			RequiredFor: "OpenTelemetry export",
+			ConfigVars:  []string{"CEREBRO_OTEL_EXPORTER_OTLP_ENDPOINT"},
+		})
+	}
+	if strings.TrimSpace(cfg.GraphActions.AccessApprovals.BaseURL) != "" {
+		services = append(services, preflightBackingService{
+			Name:        "access-approvals",
+			RequiredFor: "provider-backed graph actions and reconciliation",
+			ConfigVars:  []string{"CEREBRO_GRAPH_ACTIONS_ACCESS_APPROVALS_BASE_URL", "CEREBRO_GRAPH_ACTIONS_ACCESS_APPROVALS_BEARER_TOKEN"},
+		})
+	}
+	return services
+}
+
+func preflightRequiredSecretNames(cfg appconfig.Config) []string {
+	secrets := map[string]struct{}{}
+	if cfg.Auth.Enabled {
+		if len(cfg.Auth.APIKeys) > 0 {
+			secrets["CEREBRO_API_KEYS"] = struct{}{}
+		}
+		if len(cfg.Auth.APICredentials) > 0 {
+			secrets["CEREBRO_API_CREDENTIALS_JSON"] = struct{}{}
+		}
+		if len(cfg.Auth.CapabilityTokenSecrets) > 0 || cfg.Auth.MCPOAuth.Enabled {
+			secrets["CEREBRO_CAPABILITY_TOKEN_SECRETS"] = struct{}{}
+		}
+		if !cfg.Auth.HasCredentialMaterial() {
+			secrets["one of CEREBRO_API_KEYS, CEREBRO_API_CREDENTIALS_JSON, or CEREBRO_CAPABILITY_TOKEN_SECRETS"] = struct{}{}
+		}
+	}
+	if cfg.Auth.MCPOAuth.Enabled {
+		if len(cfg.Auth.MCPOAuth.Clients) > 0 {
+			secrets["CEREBRO_MCP_OAUTH_CLIENTS_JSON"] = struct{}{}
+		}
+		secrets["CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET"] = struct{}{}
+	}
+	if cfg.Auth.DeviceAuth.Enabled {
+		secrets["CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON"] = struct{}{}
+	}
+	if cfg.StateStore.Driver == appconfig.StateStoreDriverPostgres {
+		secrets["CEREBRO_POSTGRES_DSN"] = struct{}{}
+	}
+	if cfg.AppendLog.Driver == appconfig.AppendLogDriverJetStream {
+		secrets["CEREBRO_JETSTREAM_URL"] = struct{}{}
+	}
+	if cfg.GraphStore.Driver == appconfig.GraphStoreDriverNeo4j {
+		secrets["CEREBRO_NEO4J_URI"] = struct{}{}
+		secrets["CEREBRO_NEO4J_USERNAME"] = struct{}{}
+		secrets["CEREBRO_NEO4J_PASSWORD"] = struct{}{}
+	}
+	if cfg.Cache.Driver == appconfig.CacheDriverRedis || cfg.Cache.Driver == appconfig.CacheDriverValkey {
+		secrets["CEREBRO_CACHE_URL"] = struct{}{}
+	}
+	if strings.TrimSpace(cfg.ConnectorCredentials.Key) != "" {
+		secrets["CEREBRO_CONNECTOR_CREDENTIAL_KEY"] = struct{}{}
+	}
+	if strings.TrimSpace(cfg.ConnectorCredentials.TransitPrivateKey) != "" {
+		secrets["CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY"] = struct{}{}
+	}
+	if strings.TrimSpace(cfg.GraphActions.AccessApprovals.BaseURL) != "" {
+		secrets["CEREBRO_GRAPH_ACTIONS_ACCESS_APPROVALS_BEARER_TOKEN"] = struct{}{}
+	}
+	if cfg.OTEL.Enabled && len(cfg.OTEL.Headers) > 0 {
+		secrets["CEREBRO_OTEL_EXPORTER_OTLP_HEADERS"] = struct{}{}
+	}
+	if strings.TrimSpace(cfg.GraphAgentLLM.OpenRouterAPIKey) != "" {
+		secrets["CEREBRO_OPENROUTER_API_KEY"] = struct{}{}
+	}
+	return sortedPreflightSet(secrets)
+}
+
+func preflightOperatorActions(cfg appconfig.Config) []string {
+	actions := []string{
+		"wire liveness to /livez or /healthz and readiness to /health",
+		"record the immutable image tag and config version before rollout",
+		"keep account IDs, hostnames, schedules, secret paths, and tenant assignments in deployment records",
+	}
+	if cfg.Auth.Enabled {
+		actions = append(actions, "rotate API credentials through the deployment secret manager")
+	}
+	if cfg.StateStore.Driver == appconfig.StateStoreDriverPostgres {
+		actions = append(actions, "enable Postgres backups and test restore before broad rollout")
+	}
+	if cfg.AppendLog.Driver == appconfig.AppendLogDriverJetStream {
+		actions = append(actions, "monitor JetStream stream health, storage, and consumer lag")
+		actions = append(actions, "forbid overlapping source sync jobs for cursor-sensitive runtimes")
+	}
+	if cfg.GraphStore.Driver == appconfig.GraphStoreDriverNeo4j {
+		actions = append(actions, "run graph health after rollout and before graph-dependent workflows")
+	}
+	if cfg.OTEL.Enabled {
+		actions = append(actions, "confirm traces, metrics, and structured logs reach the deployed collector")
+	}
+	return actions
+}
+
+func sortedPreflightSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 func preflightErrorDetail(err error) string {
 	if err == nil {
 		return ""
 	}
-	detail := sanitizeLogValue(err.Error())
+	detail := redactPreflightErrorDetail(sanitizeLogValue(err.Error()))
 	if len(detail) > 240 {
 		detail = detail[:240]
 	}
 	return detail
+}
+
+func redactPreflightErrorDetail(detail string) string {
+	detail = preflightDetailURLRe.ReplaceAllStringFunc(detail, redactPreflightDetailURL)
+	return preflightDetailSecretAssignmentRe.ReplaceAllString(detail, "$1=<redacted>")
+}
+
+func redactPreflightDetailURL(raw string) string {
+	trailing := ""
+	trimmed := strings.TrimRightFunc(raw, func(r rune) bool {
+		switch r {
+		case '.', ',', ';', ')', ']':
+			trailing = string(r) + trailing
+			return true
+		default:
+			return false
+		}
+	})
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "<redacted-url>" + trailing
+	}
+	parsed.User = nil
+	if parsed.RawQuery != "" {
+		query := parsed.Query()
+		for key, values := range query {
+			if preflightSensitiveQueryKey(key) {
+				for i := range values {
+					values[i] = "<redacted>"
+				}
+				query[key] = values
+			}
+		}
+		parsed.RawQuery = query.Encode()
+	}
+	return parsed.String() + trailing
+}
+
+func preflightSensitiveQueryKey(key string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+	switch normalized {
+	case "access_token", "api_key", "apikey", "auth", "authorization", "client_secret", "key", "password", "secret", "token":
+		return true
+	default:
+		return false
+	}
 }

--- a/deploy/pulumi/README.md
+++ b/deploy/pulumi/README.md
@@ -2,6 +2,8 @@
 
 These Pulumi templates deploy the public Cerebro runtime on AWS, Google Cloud, or Azure using environment-agnostic defaults. They intentionally use placeholder names and caller-owned configuration only. Do not put live account IDs, hostnames, tenant names, source schedules, provider tokens, or secret values in this directory.
 
+Use these templates with [`docs/operations/runtime-profiles.md`](../../docs/operations/runtime-profiles.md) and [`docs/operations/deployment-readiness.md`](../../docs/operations/deployment-readiness.md). The templates wire the API service and scheduled job runners; the deployment environment owns backing stores, schedules, secret paths, approval gates, and rollback records.
+
 The stack entrypoint creates one reusable `CerebroService` component. That component chooses a provider-specific child component from the shared `cerebro:cloud` config:
 
 - AWS: ECS Fargate service behind an Application Load Balancer, with optional ACM HTTPS, private subnets, NAT, and EventBridge Scheduler jobs.

--- a/deploy/pulumi/tests/test_components.py
+++ b/deploy/pulumi/tests/test_components.py
@@ -138,6 +138,22 @@ def test_azure_key_vault_secret_ref_enables_system_identity() -> None:
     assert len(secrets) == 1
 
 
+def test_checked_in_example_stacks_stay_preview_safe() -> None:
+    root = Path(__file__).resolve().parents[1]
+    expectations = {
+        "Pulumi.aws.yaml": "cerebro:cloud: aws",
+        "Pulumi.gcp.yaml": "cerebro:cloud: gcp",
+        "Pulumi.azure.yaml": "cerebro:cloud: azure",
+    }
+
+    for filename, cloud_marker in expectations.items():
+        body = (root / filename).read_text(encoding="utf-8")
+        assert cloud_marker in body
+        assert "cerebro:deploymentProfile: preview" in body
+        assert 'cerebro:apiAuthEnabled: "false"' in body
+        assert "cerebro:publicOrigin: https://cerebro.example.com" in body
+
+
 def _scheduled_job(schedule: str = "rate(15 minutes)") -> ScheduledJob:
     return ScheduledJob(
         name="sync-example",

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ docker compose up --build
 | Local end-to-end walkthrough | [Getting started](start/getting-started.md) |
 | Runtime shape and dependency boundaries | [Architecture](reference/architecture.md) |
 | Runtime configuration | [Configuration variables](reference/config-env-vars.md) |
-| Hosting and operations | [Hosting](operations/hosting.md), [cloud deployment](operations/cloud-deployment.md), [deployment examples](operations/deployment-examples.md), [operations runbook](operations/operations-runbook.md), and [troubleshooting](operations/troubleshooting.md) |
+| Hosting and operations | [Hosting](operations/hosting.md), [runtime profiles](operations/runtime-profiles.md), [deployment readiness](operations/deployment-readiness.md), [cloud deployment](operations/cloud-deployment.md), [deployment examples](operations/deployment-examples.md), [operations runbook](operations/operations-runbook.md), and [troubleshooting](operations/troubleshooting.md) |
 | API contracts | [API reference](reference/api-reference.md), [generated API contracts](reference/api-contracts.md), `../api/openapi.yaml`, and `../proto/cerebro/v1/bootstrap.proto` |
 | CLI usage | [CLI reference](reference/cli.md) |
 | Built-in source integrations | [Source catalog](reference/sources.md) |

--- a/docs/operations/cloud-deployment.md
+++ b/docs/operations/cloud-deployment.md
@@ -5,6 +5,8 @@ This guide explains how to deploy Cerebro on AWS, Google Cloud, or Azure without
 Use it with:
 
 - [`docs/operations/hosting.md`](hosting.md) for the runtime hosting contract.
+- [`docs/operations/runtime-profiles.md`](runtime-profiles.md) for profile-specific dependencies, config, and checks.
+- [`docs/operations/deployment-readiness.md`](deployment-readiness.md) for rollout gates and the preflight receipt.
 - [`docs/reference/config-env-vars.md`](../reference/config-env-vars.md) for all supported environment variables.
 - [`docs/operations/operations-runbook.md`](operations-runbook.md) for health checks, rollout, rollback, and incident handling.
 - [`deploy/pulumi`](../../deploy/pulumi) for validated Pulumi templates.
@@ -338,6 +340,7 @@ The templates should be validated with `pulumi preview --refresh=false` for all 
 After deploying to a real environment, verify:
 
 ```bash
+cerebro deploy preflight
 curl -fsS https://cerebro.example.com/livez
 curl -fsS https://cerebro.example.com/health
 curl -fsS -H "Authorization: Bearer ${CEREBRO_API_KEY}" \

--- a/docs/operations/deployment-readiness.md
+++ b/docs/operations/deployment-readiness.md
@@ -1,0 +1,120 @@
+# Deployment Readiness
+
+This guide turns the hosting contract into a rollout checklist. It uses public, environment-agnostic names only. Keep real account IDs, hostnames, tenant IDs, secret paths, source schedules, approval gates, and incident contacts in the deployment repository or platform records for the environment.
+
+Use it with:
+
+- [Hosting](hosting.md) for the runtime contract.
+- [Runtime profiles](runtime-profiles.md) for profile-specific config and checks.
+- [Cloud deployment](cloud-deployment.md) for the Pulumi templates.
+- [Operations runbook](operations-runbook.md) for rollout, rollback, and incident handling.
+- [Release contract](release-contract.md) for source runtime and deployment metadata.
+
+## Operator Journey
+
+1. Pick the runtime profile: lightweight API, durable API, durable sync, or graph-enabled.
+2. Add capability layers such as MCP OAuth, device auth, OTEL, cache, or graph-agent LLM when the rollout needs them.
+3. Select an immutable image tag and record the config version that will run with it.
+4. Provision the backing stores required by the profile and capability layers.
+5. Put every secret-bearing value in a secret manager or orchestrator secret object.
+6. Configure API auth, tenant scope, public origin, and trusted proxy settings.
+7. Configure liveness on `/livez` or `/healthz` and readiness on `/health`.
+8. Add scheduled jobs separately from the API service when source sync or graph ingest is needed.
+9. Run `cerebro deploy preflight` from the same image and config that will serve traffic.
+10. Shift traffic only after readiness passes and the preflight receipt has no failed checks.
+11. Run the profile-specific post-deploy checks and save the final image tag plus config version in deployment records.
+
+## Readiness Receipt
+
+Run:
+
+```bash
+cerebro deploy preflight --format json
+```
+
+The receipt reports variable names and service names instead of secret values. Failed-check details redact URL credentials and credential-shaped key/value fields before output.
+
+Important fields:
+
+| Field | Use |
+| --- | --- |
+| `runtime_profile` | Confirms which profile the current config activates. |
+| `enabled_capabilities` | Shows enabled runtime surfaces such as API auth, Postgres state, JetStream append log, Neo4j graph, MCP OAuth, device auth, OTEL, cache, or graph-agent LLM. |
+| `required_backing_services` | Lists backing services the deployment must operate for the selected config. |
+| `required_secret_names` | Lists secret-bearing environment variable names. Values stay in the secret manager. |
+| `operator_actions` | Lists deployment tasks that cannot be verified from process config alone. |
+| `checks` | Records pass/fail checks for config load, serve safety, dependency open, dependency close, and configured probes. |
+
+Text output is available for terminal use:
+
+```bash
+cerebro deploy preflight --format text
+```
+
+## Required Gates
+
+Before a shared deployment receives traffic:
+
+| Gate | Command or evidence | Blocks rollout when |
+| --- | --- | --- |
+| Image selected | immutable image tag in deployment record | image is untagged or mutable in a production stack |
+| Config loads | `cerebro deploy preflight` | `config.load` fails |
+| Serve safety | `cerebro deploy preflight` | auth or rate limiting is unsafe outside acknowledged dev mode |
+| Dependencies open | `cerebro deploy preflight` | configured stores or provider probes fail |
+| Liveness | `curl -fsS https://cerebro.example.com/livez` | process does not serve HTTP |
+| Readiness | `curl -fsS https://cerebro.example.com/health` | configured dependency is unavailable |
+| Auth smoke | authenticated request to `/sources` | protected route rejects the intended credential |
+| Profile smoke | command from [Runtime profiles](runtime-profiles.md) | selected profile cannot perform its expected work |
+| Observability | log, metric, and trace arrival in the collector | operators cannot see route, dependency, or job failures |
+| Rollback record | previous image tag and config version | rollback path is unknown |
+
+## Private And Public Docs
+
+Public docs in this repository should contain:
+
+- runtime profiles and required backing services,
+- environment variable names,
+- command shapes,
+- placeholder hostnames and secret refs,
+- generic failure modes,
+- checks that can run without private account state.
+
+Deployment repositories or platform records should contain:
+
+- account IDs, projects, subscriptions, regions, and clusters,
+- real hostnames, DNS zones, and certificate ARNs,
+- secret names, secret paths, and credential rotation records,
+- tenant assignments, runtime IDs, source schedules, and provider rate-limit choices,
+- production approval gates, emergency contacts, and incident links,
+- environment-specific dashboards, alert thresholds, and paging routes.
+
+When a private value is needed to explain an operation, write the public doc with a placeholder and link to the owning deployment record from the private repository.
+
+## Schedule Readiness
+
+Source sync and graph ingest jobs use the same image but should not run inside the API service process. For each scheduled job, deployment records should capture:
+
+| Field | Why it matters |
+| --- | --- |
+| Runtime ID | Stable cursor and graph projection identity. |
+| Tenant ID | Scope for events, claims, findings, and graph entities. |
+| Command | Exact CLI command and page limits. |
+| Cadence | Provider rate limit, freshness, and cost control. |
+| Overlap policy | Cursor-sensitive runtimes should forbid concurrent runs. |
+| Retry policy | Provider failures should not create unbounded traffic. |
+| Resource limits | Background work should not starve the API service. |
+| Failure route | Operators need a ticket, page, or follow-up path. |
+
+Do not publish live runtime IDs, tenant IDs, provider credentials, or cadence values in this repository.
+
+## Release Handoff
+
+Deployment automation should consume:
+
+- the selected image tag,
+- the signed `cerebro-runtime-contract-<target>.json` when produced,
+- the deployment-owned config version,
+- the `cerebro deploy preflight` receipt,
+- post-deploy health check results.
+
+The release contract names required source secrets, runtime profiles, backing services, optional capability gates, and post-deploy checks. It does not define live schedules, concrete secrets, account state, hostnames, or approval gates.

--- a/docs/operations/hosting.md
+++ b/docs/operations/hosting.md
@@ -5,6 +5,8 @@ This guide describes how to host the Cerebro bootstrap service using public, env
 Use it with:
 
 - [`README.md`](../../README.md) for the current runtime overview and quick start.
+- [`docs/operations/runtime-profiles.md`](runtime-profiles.md) for profile-specific dependencies, config, and checks.
+- [`docs/operations/deployment-readiness.md`](deployment-readiness.md) for the operator journey and readiness receipt.
 - [`docs/operations/cloud-deployment.md`](cloud-deployment.md) for AWS, GCP, Azure, and Pulumi templates.
 - [`docs/reference/configuration.md`](../reference/configuration.md) for a short configuration baseline.
 - [`docs/reference/config-env-vars.md`](../reference/config-env-vars.md) for the current environment variable reference.
@@ -35,7 +37,7 @@ By default the service listens on `:8080`. Override that with `CEREBRO_HTTP_ADDR
 
 ## Hosting profiles
 
-Choose the smallest profile that matches the operations you need.
+Choose the smallest profile that matches the operations you need. See [Runtime profiles](runtime-profiles.md) for profile recipes and post-deploy checks.
 
 | Profile | Dependencies | Good for | Not enough for |
 | --- | --- | --- | --- |
@@ -466,6 +468,7 @@ Before first traffic:
 13. Run a low-risk source preview or source runtime check.
 14. Verify logs and metrics reach your observability platform.
 15. Document rollback as image tag revert plus config revert.
+16. Run `cerebro deploy preflight` and store the redacted receipt with deployment records.
 
 During rollout:
 

--- a/docs/operations/release-contract.md
+++ b/docs/operations/release-contract.md
@@ -6,6 +6,8 @@ Use it with:
 
 - [`README.md`](../../README.md) "Release and deploy artifacts".
 - [`docs/operations/hosting.md`](hosting.md) for how to run the image.
+- [`docs/operations/runtime-profiles.md`](runtime-profiles.md) for profile-specific dependencies, config, and checks.
+- [`docs/operations/deployment-readiness.md`](deployment-readiness.md) for rollout gates and preflight receipts.
 - [`docs/domains/source-runtime-guide.md`](../domains/source-runtime-guide.md) for source runtime manifests.
 - [`tools/sourcedeploy`](../../tools/sourcedeploy) for contract rendering code.
 
@@ -115,6 +117,12 @@ Top-level shape:
   "environment": "<environment>",
   "tenant_id": "<tenant-id>",
   "required_secrets": ["PROVIDER_API_TOKEN"],
+  "runtime_profiles": [],
+  "required_env_vars": [],
+  "required_backing_services": [],
+  "optional_capabilities": [],
+  "post_deploy_health_checks": [],
+  "compatibility_notes": [],
   "sources": []
 }
 ```
@@ -128,7 +136,29 @@ Top-level fields:
 | `environment` | caller-supplied environment label |
 | `tenant_id` | caller-supplied tenant identifier |
 | `required_secrets` | union of source runtime secret env vars needed by rendered manifests |
+| `runtime_profiles` | portable profiles and their backing-service requirements |
+| `required_env_vars` | conditional environment variable names needed by hosted deployments |
+| `required_backing_services` | Postgres, JetStream, Neo4j/Aura, or other services required by runtime capabilities |
+| `optional_capabilities` | config gates, dependencies, and health checks for optional surfaces |
+| `post_deploy_health_checks` | public-safe commands or probes deployment automation should run after rollout |
+| `compatibility_notes` | deployment compatibility and source-of-truth notes for contract consumers |
 | `sources` | per-source capability and runtime metadata |
+
+Environment variable entries:
+
+| Field | Meaning |
+| --- | --- |
+| `name` | environment variable name |
+| `required_for` | profile or capability that needs the variable |
+| `secret` | whether the value must stay in a secret manager or orchestrator secret |
+
+Backing-service entries:
+
+| Field | Meaning |
+| --- | --- |
+| `name` | service identifier such as `postgres`, `nats-jetstream`, or `neo4j` |
+| `required_for` | runtime behavior that depends on the service |
+| `config_vars` | environment variable names that wire the service |
 
 Per-source fields:
 

--- a/docs/operations/runtime-profiles.md
+++ b/docs/operations/runtime-profiles.md
@@ -1,0 +1,189 @@
+# Runtime Profiles
+
+Choose the smallest Cerebro profile that supports the work. Each profile adds operational duties. Do not configure a backing service until an API route, source runtime, graph operation, or client flow needs it.
+
+The preflight receipt reports one of four `runtime_profile` values: `lightweight-api`, `durable-api`, `durable-sync`, or `graph-enabled`. Capability layers such as MCP OAuth appear in `enabled_capabilities`.
+
+## Lightweight API
+
+Use this profile for metadata routes, source catalog inspection, OpenAPI access, and provider-free source previews.
+
+Required backing services: none.
+
+Required config:
+
+```bash
+CEREBRO_HTTP_ADDR=:8080
+CEREBRO_API_AUTH_ENABLED=true
+CEREBRO_API_KEYS=<random-key>:<principal>:<tenant-id>
+CEREBRO_PUBLIC_ORIGIN=https://cerebro.example.com
+CEREBRO_TRUSTED_PROXY_CIDRS=10.0.0.0/8
+CEREBRO_TRUSTED_PROXY_COUNT=1
+```
+
+Checks:
+
+```bash
+cerebro deploy preflight
+curl -fsS https://cerebro.example.com/livez
+curl -fsS https://cerebro.example.com/health
+curl -fsS -H "Authorization: Bearer ${CEREBRO_API_KEY}" https://cerebro.example.com/sources
+```
+
+Not enough for: persisted source runtimes, claims, findings, reports, workflow replay, MCP OAuth, device auth, source sync, or graph operations.
+
+## Durable API
+
+Use this profile when Cerebro must persist runtime state, claims, findings, reports, OAuth state, or device-auth state.
+
+Required backing services:
+
+- Postgres with TLS, backups, restore procedure, and least-privilege credentials.
+
+Add this config:
+
+```bash
+CEREBRO_STATE_STORE_DRIVER=postgres
+CEREBRO_POSTGRES_DSN=<postgres-dsn-with-tls>
+```
+
+Checks:
+
+```bash
+cerebro deploy preflight
+cerebro source-runtime list tenant_id=<tenant-id> limit=20
+curl -fsS https://cerebro.example.com/health
+```
+
+Operator duties:
+
+- Monitor connection pool wait, query failures, storage, CPU, and locks.
+- Test restore before broad rollout.
+- Size `CEREBRO_POSTGRES_MAX_OPEN_CONNS` against database limits and replica count.
+
+Not enough for: append-log replay, source sync workflows, graph ingest, or graph queries.
+
+## Durable Sync
+
+Use this profile when source runtime sync, append-log-backed replay, or workflow replay is required.
+
+Required backing services:
+
+- Postgres.
+- NATS JetStream with persistent storage and retention that matches replay needs.
+
+Add the Durable API config, then add:
+
+```bash
+CEREBRO_APPEND_LOG_DRIVER=jetstream
+CEREBRO_JETSTREAM_URL=<nats-jetstream-url>
+CEREBRO_JETSTREAM_SUBJECT_PREFIX=events
+```
+
+Checks:
+
+```bash
+cerebro deploy preflight
+cerebro source-runtime list tenant_id=<tenant-id> limit=20
+cerebro source-runtime sync <runtime-id> page_limit=1
+```
+
+Operator duties:
+
+- Run source sync as scheduled jobs outside the API service.
+- Forbid overlapping jobs for cursor-sensitive runtimes.
+- Monitor stream health, storage pressure, publish errors, and consumer lag.
+- Keep provider credentials and schedules in deployment records.
+
+Not enough for: graph ingest, graph queries, graph health, or graph-agent workflows.
+
+## Graph-Enabled
+
+Use this profile when Cerebro needs graph projection, graph queries, graph health, graph-agent workflows, or graph-backed reports.
+
+Required backing services:
+
+- Postgres.
+- NATS JetStream.
+- Neo4j or Aura with encrypted connections where supported.
+
+Add the Durable Sync config, then add:
+
+```bash
+CEREBRO_GRAPH_STORE_DRIVER=neo4j
+CEREBRO_NEO4J_URI=<neo4j-or-aura-uri>
+CEREBRO_NEO4J_USERNAME=<neo4j-user>
+CEREBRO_NEO4J_PASSWORD=<neo4j-password>
+```
+
+Checks:
+
+```bash
+cerebro deploy preflight
+cerebro graph health
+cerebro graph counts
+cerebro graph ingest-runs limit=20
+```
+
+Operator duties:
+
+- Treat Neo4j/Aura as a projection, not the source of truth.
+- Run graph ingest jobs separately from the API service.
+- Use dry-run rebuilds before broad projection changes.
+- Monitor ingest failures, stale-running ingest, query latency, index health, and storage growth.
+
+## MCP/OAuth Capability Layer
+
+Use this capability layer when MCP clients need OAuth-issued capability tokens.
+
+Required backing services:
+
+- Postgres.
+- Public origin and trusted proxy config.
+- Capability-token HMAC secrets.
+- MCP OAuth client, entitlement, and upstream OAuth settings.
+
+Add the Durable API config, then add:
+
+```bash
+CEREBRO_MCP_OAUTH_ENABLED=true
+CEREBRO_CAPABILITY_TOKEN_SECRETS=<hmac-secret-1>,<hmac-secret-2>
+CEREBRO_MCP_OAUTH_CLIENTS_JSON=<oauth-clients-json>
+CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON=<oauth-entitlements-json>
+CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER=https://identity.example.com
+CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID=<oauth-client-id>
+CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET=<oauth-client-secret>
+CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI=https://cerebro.example.com/oauth/callback
+CEREBRO_MCP_OAUTH_SECURITY_GROUPS=<group-1>,<group-2>
+CEREBRO_PUBLIC_ORIGIN=https://cerebro.example.com
+```
+
+Checks:
+
+```bash
+cerebro deploy preflight
+curl -fsS https://cerebro.example.com/.well-known/oauth-authorization-server
+curl -fsS https://cerebro.example.com/health
+```
+
+Operator duties:
+
+- Keep redirect URIs exact-match.
+- Keep client secrets and HMAC material in the secret manager.
+- Review tenant and scope entitlements before enabling new clients.
+- Rotate capability token secrets with overlap.
+
+## Profile Selection Table
+
+| Need | Smallest profile |
+| --- | --- |
+| Health checks and source catalog | Lightweight API |
+| Persist source runtime definitions | Durable API |
+| Persist claims, findings, reports, OAuth, or device-auth state | Durable API |
+| Sync source runtimes on a schedule | Durable sync |
+| Replay append-log events | Durable sync |
+| Run graph ingest or graph queries | Graph-enabled |
+| Use graph-agent workflows | Graph-enabled |
+| Issue MCP OAuth tokens | Durable API with MCP OAuth enabled |
+
+Run `cerebro deploy preflight --format json` after changing profile config. The `runtime_profile`, `enabled_capabilities`, `required_backing_services`, and `required_secret_names` fields should match the intended profile and capability layers before traffic moves.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,7 +20,10 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-
 
 ```bash
 ./bin/cerebro deploy preflight
+./bin/cerebro deploy preflight --format text
 ```
+
+`deploy preflight` emits a redacted readiness receipt. The JSON output includes the selected runtime profile, enabled capabilities, required backing services, required secret variable names, operator actions, and pass/fail checks. Store the receipt with deployment records; keep concrete secret values, hostnames, schedules, and tenant assignments in the deployment system.
 
 ## Source Catalog And Previews
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,8 @@ nav:
       - Packages: reference/packages.md
   - Operations:
       - Hosting: operations/hosting.md
+      - Runtime Profiles: operations/runtime-profiles.md
+      - Deployment Readiness: operations/deployment-readiness.md
       - Cloud Deployment: operations/cloud-deployment.md
       - Deployment Examples: operations/deployment-examples.md
       - Operations Runbook: operations/operations-runbook.md

--- a/scripts/oss_audit.py
+++ b/scripts/oss_audit.py
@@ -17,6 +17,7 @@ from urllib.parse import parse_qs, urlparse
 EXCLUDED_DIRS = {
     ".git",
     ".idea",
+    ".venv",
     ".vscode",
     "bin",
     "dist",
@@ -29,6 +30,28 @@ EXCLUDED_FILES = {
     "go.sum",
     "scripts/leak_patterns.txt",
 }
+
+PUBLIC_DOC_PREFIXES = (
+    "README.md",
+    "docs/",
+    "deploy/pulumi/",
+)
+
+PUBLIC_DOC_ALLOWED_ACCOUNT_IDS = {
+    "111122223333",
+}
+
+PUBLIC_DOC_FORBIDDEN_MARKERS = tuple(sorted((
+    "WriterInternal",
+    "writerinternal",
+    "sec-dev",
+    "go-prod",
+    "cerebro-sec-dev",
+    "cerebro-go-production",
+    "writer-sec",
+    "adm.prod.writer.com",
+    "prod.writer.com",
+), key=len, reverse=True))
 
 ALLOWED_FIXTURE_EMAIL_DOMAINS = {
     "example.com",
@@ -68,6 +91,7 @@ SENSITIVE_QUERY_KEYS = {
 EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@([A-Za-z0-9.-]+\.[A-Za-z]{2,})\b")
 IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 URL_RE = re.compile(r"https?://[^\s\"']+")
+ACCOUNT_ID_RE = re.compile(r"\b\d{12}\b")
 NESTED_QUANTIFIER_RE = re.compile(
     r"\((?:\?:)?[^)]*(?:\+|\*|\{\d+(?:,\d*)?\})[^)]*\)(?:\+|\*|\{\d+(?:,\d*)?\})"
 )
@@ -202,6 +226,38 @@ def scan_fixture_semantics(root: Path) -> list[str]:
     return findings
 
 
+def scan_public_doc_infrastructure_markers(root: Path) -> list[str]:
+    findings: list[str] = []
+    for path, rel in iter_files(root):
+        if not is_public_doc_path(rel) or not is_probably_text(path):
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError as exc:
+            findings.append(f"{rel}: read failed: {exc}")
+            continue
+        for line_number, line in enumerate(lines, start=1):
+            for marker in PUBLIC_DOC_FORBIDDEN_MARKERS:
+                if marker in line:
+                    findings.append(f"{rel}:{line_number}: public docs must not include deployment marker {redact(marker)}")
+                    break
+            for match in ACCOUNT_ID_RE.finditer(line):
+                account_id = match.group(0)
+                if account_id not in PUBLIC_DOC_ALLOWED_ACCOUNT_IDS:
+                    findings.append(f"{rel}:{line_number}: public docs must not include account id {redact(account_id)}")
+    return findings
+
+
+def is_public_doc_path(rel: str) -> bool:
+    for prefix in PUBLIC_DOC_PREFIXES:
+        if prefix.endswith("/"):
+            if rel.startswith(prefix):
+                return True
+        elif rel == prefix:
+            return True
+    return False
+
+
 def walk_json_strings(value, prefix: str = "$"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -276,6 +332,7 @@ def main() -> int:
     else:
         print("oss-audit: no leak patterns configured", file=sys.stderr)
     findings.extend(scan_fixture_semantics(root))
+    findings.extend(scan_public_doc_infrastructure_markers(root))
     if findings:
         print("oss-audit: public hygiene findings detected", file=sys.stderr)
         for finding in findings:

--- a/scripts/tests/test_oss_audit.py
+++ b/scripts/tests/test_oss_audit.py
@@ -1,0 +1,85 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import scripts.oss_audit as oss_audit
+
+
+class OSSAuditTests(unittest.TestCase):
+    def test_public_doc_infrastructure_markers_reject_private_targets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs = root / "docs" / "operations"
+            docs.mkdir(parents=True)
+            (docs / "hosting.md").write_text(
+                "Deploy to sec-dev in account 123456789012.\n",
+                encoding="utf-8",
+            )
+
+            findings = oss_audit.scan_public_doc_infrastructure_markers(root)
+
+        self.assertEqual(len(findings), 2)
+        self.assertTrue(any("deployment marker" in finding for finding in findings))
+        self.assertTrue(any("account id" in finding for finding in findings))
+
+    def test_public_doc_infrastructure_markers_allow_placeholders(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs = root / "docs" / "operations"
+            docs.mkdir(parents=True)
+            (docs / "cloud-deployment.md").write_text(
+                "Use arn:aws:secretsmanager:us-east-1:111122223333:secret:cerebro/postgres.\n",
+                encoding="utf-8",
+            )
+
+            findings = oss_audit.scan_public_doc_infrastructure_markers(root)
+
+        self.assertEqual(findings, [])
+
+    def test_public_doc_infrastructure_markers_deduplicate_overlapping_markers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs = root / "docs" / "operations"
+            docs.mkdir(parents=True)
+            (docs / "hosting.md").write_text(
+                "Do not publish cerebro-sec-dev here.\n",
+                encoding="utf-8",
+            )
+
+            findings = oss_audit.scan_public_doc_infrastructure_markers(root)
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn("deployment marker", findings[0])
+
+    def test_public_doc_infrastructure_markers_scan_pulumi_stacks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pulumi = root / "deploy" / "pulumi"
+            pulumi.mkdir(parents=True)
+            (pulumi / "Pulumi.aws.yaml").write_text(
+                "config:\n  account: 123456789012\n",
+                encoding="utf-8",
+            )
+
+            findings = oss_audit.scan_public_doc_infrastructure_markers(root)
+
+        self.assertEqual(len(findings), 1)
+        self.assertIn("account id", findings[0])
+
+    def test_public_doc_infrastructure_markers_ignore_code_fixtures(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = root / "internal" / "example"
+            fixture.mkdir(parents=True)
+            (fixture / "example_test.go").write_text(
+                'package example\nconst fixture = "sec-dev"\n',
+                encoding="utf-8",
+            )
+
+            findings = oss_audit.scan_public_doc_infrastructure_markers(root)
+
+        self.assertEqual(findings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sourcedeploy/contract.go
+++ b/tools/sourcedeploy/contract.go
@@ -22,12 +22,18 @@ type ContractOptions struct {
 }
 
 type Contract struct {
-	SchemaVersion   string           `json:"schema_version"`
-	ImageTag        string           `json:"image_tag,omitempty"`
-	Environment     string           `json:"environment"`
-	TenantID        string           `json:"tenant_id"`
-	RequiredSecrets []string         `json:"required_secrets"`
-	Sources         []ContractSource `json:"sources"`
+	SchemaVersion           string                   `json:"schema_version"`
+	ImageTag                string                   `json:"image_tag,omitempty"`
+	Environment             string                   `json:"environment"`
+	TenantID                string                   `json:"tenant_id"`
+	RequiredSecrets         []string                 `json:"required_secrets"`
+	RuntimeProfiles         []ContractRuntimeProfile `json:"runtime_profiles"`
+	RequiredEnvVars         []ContractEnvVar         `json:"required_env_vars"`
+	RequiredBackingServices []ContractBackingService `json:"required_backing_services"`
+	OptionalCapabilities    []ContractCapability     `json:"optional_capabilities"`
+	PostDeployHealthChecks  []ContractHealthCheck    `json:"post_deploy_health_checks"`
+	CompatibilityNotes      []string                 `json:"compatibility_notes"`
+	Sources                 []ContractSource         `json:"sources"`
 }
 
 type ContractSource struct {
@@ -54,6 +60,38 @@ type ContractRuntime struct {
 type RoleAssumption struct {
 	ConfigKey string `json:"config_key"`
 	RoleARN   string `json:"role_arn"`
+}
+
+type ContractRuntimeProfile struct {
+	Name         string   `json:"name"`
+	Requires     []string `json:"requires,omitempty"`
+	Enables      []string `json:"enables,omitempty"`
+	NotEnoughFor []string `json:"not_enough_for,omitempty"`
+}
+
+type ContractEnvVar struct {
+	Name        string `json:"name"`
+	RequiredFor string `json:"required_for"`
+	Secret      bool   `json:"secret,omitempty"`
+}
+
+type ContractBackingService struct {
+	Name        string   `json:"name"`
+	RequiredFor string   `json:"required_for"`
+	ConfigVars  []string `json:"config_vars"`
+}
+
+type ContractCapability struct {
+	Name         string   `json:"name"`
+	EnabledWhen  string   `json:"enabled_when"`
+	Requires     []string `json:"requires,omitempty"`
+	HealthChecks []string `json:"health_checks,omitempty"`
+}
+
+type ContractHealthCheck struct {
+	Name        string `json:"name"`
+	Command     string `json:"command"`
+	RequiredFor string `json:"required_for"`
 }
 
 type contractCatalog struct {
@@ -116,12 +154,18 @@ func RenderContract(sourcesRoot string, manifests []Manifest, opts ContractOptio
 	sort.Slice(sources, func(i, j int) bool { return sources[i].SourceID < sources[j].SourceID })
 
 	return Contract{
-		SchemaVersion:   ContractSchemaVersion,
-		ImageTag:        strings.TrimSpace(opts.ImageTag),
-		Environment:     strings.TrimSpace(opts.Environment),
-		TenantID:        strings.TrimSpace(opts.TenantID),
-		RequiredSecrets: sortedStrings(fragment.SourceSecretKeys),
-		Sources:         sources,
+		SchemaVersion:           ContractSchemaVersion,
+		ImageTag:                strings.TrimSpace(opts.ImageTag),
+		Environment:             strings.TrimSpace(opts.Environment),
+		TenantID:                strings.TrimSpace(opts.TenantID),
+		RequiredSecrets:         sortedStrings(fragment.SourceSecretKeys),
+		RuntimeProfiles:         contractRuntimeProfiles(),
+		RequiredEnvVars:         contractRequiredEnvVars(),
+		RequiredBackingServices: contractRequiredBackingServices(),
+		OptionalCapabilities:    contractOptionalCapabilities(),
+		PostDeployHealthChecks:  contractPostDeployHealthChecks(),
+		CompatibilityNotes:      contractCompatibilityNotes(),
+		Sources:                 sources,
 	}, nil
 }
 
@@ -268,6 +312,146 @@ func roleAssumptionConfigKeys(sourceID string) []string {
 		return []string{"role_arn"}
 	}
 	return nil
+}
+
+func contractRuntimeProfiles() []ContractRuntimeProfile {
+	return []ContractRuntimeProfile{
+		{
+			Name:         "lightweight-api",
+			Enables:      []string{"liveness", "readiness", "OpenAPI metadata", "source catalog", "provider-free source previews"},
+			NotEnoughFor: []string{"durable runtimes", "claims", "findings", "reports", "workflow replay", "graph operations"},
+		},
+		{
+			Name:         "durable-api",
+			Requires:     []string{"postgres"},
+			Enables:      []string{"persisted source runtime state", "claims", "findings", "reports", "MCP OAuth", "device auth"},
+			NotEnoughFor: []string{"append-log replay", "source sync workflows", "graph projection"},
+		},
+		{
+			Name:         "durable-sync",
+			Requires:     []string{"postgres", "nats-jetstream"},
+			Enables:      []string{"source runtime sync", "append-log-backed workflow replay"},
+			NotEnoughFor: []string{"graph queries", "graph ingest", "graph-agent workflows"},
+		},
+		{
+			Name:     "graph-enabled",
+			Requires: []string{"postgres", "nats-jetstream", "neo4j"},
+			Enables:  []string{"graph projection", "graph queries", "graph health", "graph-agent workflows"},
+		},
+	}
+}
+
+func contractRequiredEnvVars() []ContractEnvVar {
+	return []ContractEnvVar{
+		{Name: "CEREBRO_HTTP_ADDR", RequiredFor: "all hosted profiles"},
+		{Name: "CEREBRO_API_AUTH_ENABLED", RequiredFor: "shared deployments"},
+		{Name: "CEREBRO_API_KEYS", RequiredFor: "API auth when simple bearer credentials are used", Secret: true},
+		{Name: "CEREBRO_API_CREDENTIALS_JSON", RequiredFor: "API auth when structured credentials are used", Secret: true},
+		{Name: "CEREBRO_PUBLIC_ORIGIN", RequiredFor: "shared deployments, MCP OAuth, and DPoP validation"},
+		{Name: "CEREBRO_TRUSTED_PROXY_CIDRS", RequiredFor: "hosted deployments behind a proxy or load balancer"},
+		{Name: "CEREBRO_TRUSTED_PROXY_COUNT", RequiredFor: "hosted deployments behind a proxy or load balancer"},
+		{Name: "CEREBRO_STATE_STORE_DRIVER", RequiredFor: "durable-api, durable-sync, graph-enabled"},
+		{Name: "CEREBRO_POSTGRES_DSN", RequiredFor: "durable-api, durable-sync, graph-enabled", Secret: true},
+		{Name: "CEREBRO_APPEND_LOG_DRIVER", RequiredFor: "durable-sync and graph-enabled"},
+		{Name: "CEREBRO_JETSTREAM_URL", RequiredFor: "durable-sync and graph-enabled", Secret: true},
+		{Name: "CEREBRO_GRAPH_STORE_DRIVER", RequiredFor: "graph-enabled"},
+		{Name: "CEREBRO_NEO4J_URI", RequiredFor: "graph-enabled", Secret: true},
+		{Name: "CEREBRO_NEO4J_USERNAME", RequiredFor: "graph-enabled", Secret: true},
+		{Name: "CEREBRO_NEO4J_PASSWORD", RequiredFor: "graph-enabled", Secret: true},
+		{Name: "CEREBRO_CAPABILITY_TOKEN_SECRETS", RequiredFor: "MCP OAuth and capability-token auth", Secret: true},
+		{Name: "CEREBRO_MCP_OAUTH_ENABLED", RequiredFor: "MCP OAuth"},
+		{Name: "CEREBRO_MCP_OAUTH_CLIENTS_JSON", RequiredFor: "MCP OAuth clients when dynamic registration is disabled", Secret: true},
+		{Name: "CEREBRO_MCP_OAUTH_ENTITLEMENTS_JSON", RequiredFor: "MCP OAuth tenant, scope, and role entitlements"},
+		{Name: "CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", RequiredFor: "MCP OAuth upstream identity provider"},
+		{Name: "CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID", RequiredFor: "MCP OAuth upstream identity provider"},
+		{Name: "CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", RequiredFor: "MCP OAuth upstream identity provider", Secret: true},
+		{Name: "CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI", RequiredFor: "MCP OAuth upstream identity provider"},
+		{Name: "CEREBRO_MCP_OAUTH_SECURITY_GROUPS", RequiredFor: "MCP OAuth upstream entitlement filtering"},
+		{Name: "CEREBRO_DEVICE_AUTH_ENABLED", RequiredFor: "device auth"},
+		{Name: "CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", RequiredFor: "device auth access and refresh tokens", Secret: true},
+		{Name: "CEREBRO_DEVICE_AUTH_CURRENT_KID", RequiredFor: "device auth signing key selection"},
+	}
+}
+
+func contractRequiredBackingServices() []ContractBackingService {
+	return []ContractBackingService{
+		{
+			Name:        "postgres",
+			RequiredFor: "durable runtime state, claims, findings, reports, OAuth, and device auth",
+			ConfigVars:  []string{"CEREBRO_STATE_STORE_DRIVER", "CEREBRO_POSTGRES_DSN"},
+		},
+		{
+			Name:        "nats-jetstream",
+			RequiredFor: "append-log sync, replay, source runtime workflows, and graph-enabled deployments",
+			ConfigVars:  []string{"CEREBRO_APPEND_LOG_DRIVER", "CEREBRO_JETSTREAM_URL"},
+		},
+		{
+			Name:        "neo4j",
+			RequiredFor: "graph projection, graph queries, graph health, and graph-agent workflows",
+			ConfigVars:  []string{"CEREBRO_GRAPH_STORE_DRIVER", "CEREBRO_NEO4J_URI", "CEREBRO_NEO4J_USERNAME", "CEREBRO_NEO4J_PASSWORD"},
+		},
+		{
+			Name:        "upstream-oauth-provider",
+			RequiredFor: "MCP OAuth authorization-code exchange and entitlement checks",
+			ConfigVars:  []string{"CEREBRO_MCP_OAUTH_UPSTREAM_ISSUER", "CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_ID", "CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", "CEREBRO_MCP_OAUTH_UPSTREAM_REDIRECT_URI"},
+		},
+	}
+}
+
+func contractOptionalCapabilities() []ContractCapability {
+	return []ContractCapability{
+		{
+			Name:         "mcp-oauth",
+			EnabledWhen:  "CEREBRO_MCP_OAUTH_ENABLED=true",
+			Requires:     []string{"api-auth", "postgres", "CEREBRO_PUBLIC_ORIGIN", "CEREBRO_CAPABILITY_TOKEN_SECRETS"},
+			HealthChecks: []string{"GET /health", "GET /.well-known/oauth-authorization-server"},
+		},
+		{
+			Name:         "device-auth",
+			EnabledWhen:  "CEREBRO_DEVICE_AUTH_ENABLED=true",
+			Requires:     []string{"api-auth", "postgres", "CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", "CEREBRO_DEVICE_AUTH_CURRENT_KID"},
+			HealthChecks: []string{"GET /health"},
+		},
+		{
+			Name:         "query-cache",
+			EnabledWhen:  "CEREBRO_CACHE_MODE=redis or CEREBRO_CACHE_MODE=valkey",
+			Requires:     []string{"Redis or Valkey URL"},
+			HealthChecks: []string{"GET /health", "cache dependency telemetry"},
+		},
+		{
+			Name:         "graph-agent-llm",
+			EnabledWhen:  "CEREBRO_GRAPH_AGENT_LLM_PROVIDER or provider credentials are set",
+			Requires:     []string{"graph-enabled profile", "configured LLM provider credentials"},
+			HealthChecks: []string{"cerebro deploy preflight", "graph-agent LLM probe"},
+		},
+		{
+			Name:         "otel-export",
+			EnabledWhen:  "CEREBRO_OTEL_ENABLED=true or an OTLP endpoint is set",
+			Requires:     []string{"OTLP collector endpoint"},
+			HealthChecks: []string{"trace and metric arrival in the collector"},
+		},
+	}
+}
+
+func contractPostDeployHealthChecks() []ContractHealthCheck {
+	return []ContractHealthCheck{
+		{Name: "liveness", Command: "curl -fsS https://cerebro.example.com/livez", RequiredFor: "all hosted profiles"},
+		{Name: "readiness", Command: "curl -fsS https://cerebro.example.com/health", RequiredFor: "all hosted profiles"},
+		{Name: "source catalog", Command: "curl -fsS -H 'Authorization: Bearer ${CEREBRO_API_KEY}' https://cerebro.example.com/sources", RequiredFor: "shared deployments with API auth"},
+		{Name: "source runtime health", Command: "cerebro source-runtime list tenant_id=<tenant-id> limit=20", RequiredFor: "durable-api, durable-sync, graph-enabled"},
+		{Name: "graph health", Command: "cerebro graph health", RequiredFor: "graph-enabled"},
+		{Name: "deploy preflight", Command: "cerebro deploy preflight", RequiredFor: "every rollout before traffic shift"},
+	}
+}
+
+func contractCompatibilityNotes() []string {
+	return []string{
+		"Deployment systems should ignore unknown JSON fields within this schema version.",
+		"Concrete secret values, secret manager paths, schedules, hostnames, account IDs, and approval gates are intentionally outside this public contract.",
+		"Postgres is the durable current-state store; NATS JetStream is the append log; Neo4j or Aura is a rebuildable graph projection, not a source of truth.",
+		"Routes that require a missing dependency fail closed instead of switching to in-memory or embedded production storage.",
+		"Source sync and graph ingest jobs should run separately from the API service with deployment-owned cadence, retries, and overlap prevention.",
+	}
 }
 
 func sortedStrings(values []string) []string {

--- a/tools/sourcedeploy/contract_test.go
+++ b/tools/sourcedeploy/contract_test.go
@@ -72,6 +72,33 @@ runtimes:
 	if contract.ImageTag != "v2.1.60" {
 		t.Fatalf("image tag = %q", contract.ImageTag)
 	}
+	if !contractHasProfile(contract.RuntimeProfiles, "graph-enabled") {
+		t.Fatalf("runtime profiles = %#v, want graph-enabled", contract.RuntimeProfiles)
+	}
+	if !contractHasEnvVar(contract.RequiredEnvVars, "CEREBRO_POSTGRES_DSN", true) {
+		t.Fatalf("required env vars = %#v, want secret CEREBRO_POSTGRES_DSN", contract.RequiredEnvVars)
+	}
+	if !contractHasEnvVar(contract.RequiredEnvVars, "CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", true) {
+		t.Fatalf("required env vars = %#v, want secret CEREBRO_MCP_OAUTH_UPSTREAM_CLIENT_SECRET", contract.RequiredEnvVars)
+	}
+	if !contractHasEnvVar(contract.RequiredEnvVars, "CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", true) {
+		t.Fatalf("required env vars = %#v, want secret CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", contract.RequiredEnvVars)
+	}
+	if !contractHasBackingService(contract.RequiredBackingServices, "nats-jetstream") {
+		t.Fatalf("required backing services = %#v, want nats-jetstream", contract.RequiredBackingServices)
+	}
+	if !contractHasBackingService(contract.RequiredBackingServices, "upstream-oauth-provider") {
+		t.Fatalf("required backing services = %#v, want upstream-oauth-provider", contract.RequiredBackingServices)
+	}
+	if !contractHasCapability(contract.OptionalCapabilities, "mcp-oauth") {
+		t.Fatalf("optional capabilities = %#v, want mcp-oauth", contract.OptionalCapabilities)
+	}
+	if !contractHasHealthCheck(contract.PostDeployHealthChecks, "deploy preflight") {
+		t.Fatalf("post deploy checks = %#v, want deploy preflight", contract.PostDeployHealthChecks)
+	}
+	if len(contract.CompatibilityNotes) == 0 {
+		t.Fatal("compatibility notes are empty")
+	}
 	if len(contract.Sources) != 2 {
 		t.Fatalf("sources = %d, want 2", len(contract.Sources))
 	}
@@ -376,4 +403,49 @@ func mkSource(t *testing.T, root string, name string, catalog string, deploy str
 			t.Fatalf("WriteFile(deploy): %v", err)
 		}
 	}
+}
+
+func contractHasProfile(profiles []ContractRuntimeProfile, name string) bool {
+	for _, profile := range profiles {
+		if profile.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func contractHasEnvVar(vars []ContractEnvVar, name string, secret bool) bool {
+	for _, variable := range vars {
+		if variable.Name == name && variable.Secret == secret {
+			return true
+		}
+	}
+	return false
+}
+
+func contractHasBackingService(services []ContractBackingService, name string) bool {
+	for _, service := range services {
+		if service.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func contractHasCapability(capabilities []ContractCapability, name string) bool {
+	for _, capability := range capabilities {
+		if capability.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func contractHasHealthCheck(checks []ContractHealthCheck, name string) bool {
+	for _, check := range checks {
+		if check.Name == name {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- Add redacted deployment readiness metadata to `cerebro deploy preflight`.
- Extend runtime deploy contracts with profiles, backing services, optional capabilities, health checks, and compatibility notes.
- Add deployment readiness/profile docs plus public-doc infrastructure hygiene and Pulumi example guards.

## Validation
- `make contracts-check`
- `make oss-audit`
- `make script-test`
- Focused Go tests for deploy preflight and source deploy contracts
- Pulumi component tests for checked-in preview examples
- Deployment preflight CLI smoke with placeholder config
- Source deploy contract render smoke with placeholder inputs
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->