### PR TITLE
Deepen vendor risk management

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2831,9 +2831,19 @@ paths:
           schema:
             type: string
             enum: [assigned, missing, all]
+        - name: lifecycle_state
+          in: query
+          schema:
+            type: string
+            enum: [discovered, candidate, active, in_review, approved, conditionally_approved, restricted, offboarding, retired, rejected, ignored, unknown, all]
+        - name: queue
+          in: query
+          description: Return vendors with open queue reasons.
+          schema:
+            type: boolean
       responses:
         '200':
-          description: Canonical vendor rows with owner, security review, contract, assurance, finding, and evidence counts.
+          description: Canonical vendor rows with lifecycle, explainable risk scoring, exposure, packet readiness, assessment posture, remediation posture, monitoring signals, owner, security review, freshness, renewal, offboarding, queue, contract, assurance, finding, and evidence counts.
   /grc/vendors/{vendorID}:
     get:
       summary: Vendor detail
@@ -2856,7 +2866,7 @@ paths:
         - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':
-          description: Vendor detail with relationships, open findings, evidence, and graph context.
+          description: Vendor detail with packet, relationships, open findings, evidence, and graph context.
   /grc/vendors/{vendorID}/packet:
     get:
       summary: Vendor packet
@@ -2879,7 +2889,7 @@ paths:
         - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':
-          description: Vendor packet with relationships, open findings, evidence, and graph context.
+          description: Vendor packet with lifecycle, risk inputs, score factors, exposure, packet readiness, assessment posture, remediation posture, monitoring signals, control posture, commercial context, freshness clocks, obligations, contacts, fourth parties, related records, open findings, evidence, and graph context.
   /grc/vendor-discoveries:
     get:
       summary: Vendor discoveries
@@ -2913,7 +2923,7 @@ paths:
             enum: [discovered, approved, rejected, ignored, linked, all]
       responses:
         '200':
-          description: Discovered vendor candidates with source status and local decision overlay state.
+          description: Discovered vendor candidates with source status, current local decision overlay state, and append-only local decision events.
   /grc/vendor-discoveries/{discoveryID}/decision:
     post:
       summary: Update vendor discovery decision
@@ -2953,7 +2963,7 @@ paths:
                     type: string
       responses:
         '200':
-          description: Updated local discovery decision. Source systems are not written by this endpoint.
+          description: Updated local discovery decision with decision_event_id and version. Source systems are not written by this endpoint.
   /grc/vendor-risk/vendors:
     get:
       summary: Vendor risk vendors
@@ -2988,9 +2998,19 @@ paths:
           schema:
             type: string
             enum: [assigned, missing, all]
+        - name: lifecycle_state
+          in: query
+          schema:
+            type: string
+            enum: [discovered, candidate, active, in_review, approved, conditionally_approved, restricted, offboarding, retired, rejected, ignored, unknown, all]
+        - name: queue
+          in: query
+          description: Return vendors with open queue reasons when true.
+          schema:
+            type: boolean
       responses:
         '200':
-          description: Vendors with owner, security review, contract, assurance, finding, and evidence counts.
+          description: Vendors with open queue reasons, lifecycle, risk score, exposure, packet readiness, assessment posture, remediation posture, monitoring signals, owner, security review, renewal, offboarding, contract, assurance, finding, and evidence counts.
   /grc/vendor-risk/vendors/detail:
     get:
       summary: Vendor risk vendor detail

--- a/docs/domains/grc-architecture.md
+++ b/docs/domains/grc-architecture.md
@@ -153,9 +153,10 @@ Dependencies: `graphquery`, `grcfindings`, `ports`
 
 Key exports:
 
-- `ListVendors(ctx, request)` — returns graph-backed vendor rows with normalized risk level, owner state, review state, and linked GRC record counts
-- `GetVendor(ctx, request)` — returns one vendor, bounded graph neighborhood, and grouped related records
-- `Summarize(vendors)` — aggregates vendor counts, owner gaps, review posture, risk posture, finding counts, and evidence counts
+- `ListVendors(ctx, request)` — returns graph-backed vendor rows with normalized lifecycle, explainable risk score, exposure, packet readiness, owner state, review state, assessment state, remediation state, monitoring state, freshness state, commercial context, offboarding state, queue posture, and linked GRC record counts
+- `GetVendor(ctx, request)` — returns one vendor, bounded graph neighborhood, grouped related records, and review packet
+- `BuildVendorPacket(vendor, relationships)` — builds the vendor review packet with lifecycle, risk inputs, risk score factors, exposure, packet readiness, assessment posture, remediation posture, monitoring signals, control posture, commercial context, freshness clocks, obligations, owners, contacts, identifiers, fourth parties, finding counts, and closeout actions
+- `Summarize(vendors)` — aggregates vendor counts, owner gaps, review posture, risk posture, exposure, packet readiness, assessment work, remediation work, monitoring alerts, renewal pressure, offboarding work, freshness posture, queue posture, finding counts, and evidence counts
 - `ListDiscoveries(ctx, request)` — returns `vendor.discovery` candidates with source status
 - `ApplyDiscoveryDecisions(discoveries, records)` — overlays local approve, reject, ignore, or link decisions without writing back to the source provider
 - `SummarizeDiscoveries(discoveries)` — aggregates discovery decision state counts
@@ -170,6 +171,12 @@ Canonical vendor field precedence:
 | Website | `website_url`, `website`, `url`, `domain` |
 | Owner | `security_owner_user_id`, `business_owner_user_id` |
 | Risk level | `residual_risk_level`, `inherent_risk_level`, `risk_level`, `unknown` |
+| Lifecycle | `lifecycle_state`, `vendor_lifecycle_state`, `status`, `vendor_status` |
+| Risk score | `risk_score`, `vendor_risk_score`, `current_risk_score`, otherwise derived from risk inputs, controls, findings, freshness, and lifecycle |
+| Assessment | `assessment_state`, `assessment_status`, `vendor_assessment_status`, review dates, questionnaires, and assessment counts |
+| Monitoring | source monitoring state, external security rating, material changes, incidents, breached credentials, findings, freshness, and lifecycle conditions |
+| Commercial | spend, contract value, renewal notice date, primary contact, business unit, and cost center attributes |
+| Operations | exposure from data/access/dependency attributes, packet readiness from required review items, remediation due dates and counts, offboarding due dates, and data deletion state |
 
 Vendor review states:
 
@@ -187,10 +194,38 @@ Owner states:
 | `assigned` | Security owner or business owner is present |
 | `missing` | No security owner or business owner is projected |
 
+Queue reasons:
+
+| Reason family | Closing state |
+| --- | --- |
+| Owner missing | Security owner or business owner is present |
+| Review overdue | Review completed or next security review due date moved forward |
+| DPA missing or expired | Current DPA attached or DPA marked not applicable |
+| Evidence stale or expired | Fresh source/runtime, artifact, review, document, or control evidence timestamps are projected |
+| Critical or high findings open | Linked high-severity findings are resolved or risk accepted |
+| Restricted or conditional lifecycle | Vendor moves to approved, retired, rejected, ignored, or another non-queue lifecycle |
+| Packet blocked or needs work | Required packet items are attached, accepted, or marked not applicable |
+| Remediation overdue or due soon | Remediation due date moves forward or open remediation items are closed |
+| Assessment overdue, in progress, or missing | Assessment completed, started, or due date moved forward |
+| Monitoring alert | Monitoring signal resolved, accepted, or source state returns to clear |
+| Renewal due | Renewal notice date moves out of the due window or renewal decision is recorded upstream |
+| Vendor contact missing | Primary vendor contact is projected for Tier 1 or Tier 2 vendors |
+| Offboarding incomplete | Access revocation, data deletion, or offboarding deadline state is completed or marked not applicable |
+
+Freshness clocks:
+
+| Clock | Source attributes |
+| --- | --- |
+| Source runtime | `source_runtime_fresh_at`, `last_source_sync_at`, `last_synced_at`, `source_last_seen_at`, `last_observed_at` |
+| Artifact age | `artifact_created_at`, `assurance_document_created_at`, `document_created_at`, `evidence_created_at` |
+| Review completion | `last_security_review_completion_date`, `last_review_completed_at`, `review_completed_at` |
+| Document expiry | `document_expiry_date`, `assurance_document_expiry_date`, `dpa_expiry_date`, `soc2_expiry_date`, `certificate_expiry_date` |
+| Control evidence | `last_control_evidence_at`, `control_evidence_updated_at`, `last_evidence_at` |
+
 Boundaries:
 
 - Vendor posture classification and graph relationship grouping remain in this package
-- Discovery decisions are local overlay records in the state store. Approve, reject, ignore, and link do not write back to Vanta or any other source provider from this repo.
+- Discovery decisions are local overlay records in the state store with append-only decision events. Approve, reject, ignore, and link do not write back to source providers from this repo.
 - Evidence freshness is not guessed from the UI. Source runtime freshness, artifact age, review completion date, document expiry, and control evidence recency must be explicit source attributes or finding/evidence filters.
 - Finding and evidence enrichment remains in bootstrap because it reuses the existing GRC finding/evidence stores and runtime filters
 - Source runtimes still own raw collection; source projection still owns graph facts

--- a/internal/bootstrap/grc_catalog_test.go
+++ b/internal/bootstrap/grc_catalog_test.go
@@ -111,19 +111,44 @@ func TestDispatchGRCQueryBindsPathParameter(t *testing.T) {
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 	}
 	request := customDashboardTestRequest(http.MethodPost, "/grc/query", "")
-	query := grccatalog.WidgetQuery{SourceID: "vendor-detail", Params: map[string]string{"vendor_id": "vanta:acme", "runtime_id": "rt-1"}, Limit: 10}
+	query := grccatalog.WidgetQuery{SourceID: "vendor-detail", Params: map[string]string{"vendor_id": "vrm:acme", "runtime_id": "rt-1"}, Limit: 10}
 	captured := dispatchGRCQuery(stub, request, source, query)
 	if captured.statusCode != http.StatusOK {
 		t.Fatalf("dispatch status = %d, want 200", captured.statusCode)
 	}
-	if capturedPath != "/grc/vendors/vanta:acme" {
-		t.Fatalf("captured path = %q, want /grc/vendors/vanta:acme", capturedPath)
+	if capturedPath != "/grc/vendors/vrm:acme" {
+		t.Fatalf("captured path = %q, want /grc/vendors/vrm:acme", capturedPath)
 	}
 	values, err := url.ParseQuery(capturedQuery)
 	if err != nil {
 		t.Fatalf("parse forwarded query: %v", err)
 	}
 	if values.Get("vendor_id") != "" || values.Get("runtime_id") != "rt-1" || values.Get("limit") != "10" {
+		t.Fatalf("unexpected forwarded query %q", capturedQuery)
+	}
+}
+
+func TestDispatchGRCQueryPreservesVendorRiskQueueParams(t *testing.T) {
+	source, ok := grccatalog.Lookup("vendor-risk-queue")
+	if !ok {
+		t.Fatal("vendor-risk-queue source missing from catalog")
+	}
+	var capturedQuery string
+	stub := func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}
+	request := customDashboardTestRequest(http.MethodPost, "/grc/query", "")
+	query := grccatalog.WidgetQuery{SourceID: "vendor-risk-queue", Params: map[string]string{"lifecycle_state": "restricted"}, Limit: 25}
+	captured := dispatchGRCQuery(stub, request, source, query)
+	if captured.statusCode != http.StatusOK {
+		t.Fatalf("dispatch status = %d, want 200", captured.statusCode)
+	}
+	values, err := url.ParseQuery(capturedQuery)
+	if err != nil {
+		t.Fatalf("parse forwarded query: %v", err)
+	}
+	if values.Has("queue") || values.Get("lifecycle_state") != "restricted" || values.Get("limit") != "25" {
 		t.Fatalf("unexpected forwarded query %q", capturedQuery)
 	}
 }

--- a/internal/bootstrap/grc_vendor.go
+++ b/internal/bootstrap/grc_vendor.go
@@ -22,6 +22,7 @@ type grcVendorsResponse struct {
 type grcVendorDetailResponse struct {
 	Vendor        grcvendor.Vendor              `json:"vendor"`
 	Relationships grcvendor.VendorRelationships `json:"relationships"`
+	Packet        grcvendor.VendorPacket        `json:"packet"`
 	Graph         any                           `json:"graph,omitempty"`
 	Findings      []grcFindingItem              `json:"findings"`
 	Evidence      []grcEvidenceItem             `json:"evidence"`
@@ -29,10 +30,11 @@ type grcVendorDetailResponse struct {
 }
 
 type grcVendorDiscoveriesResponse struct {
-	Summary     grcvendor.DiscoverySummary                `json:"summary"`
-	Discoveries []grcvendor.VendorDiscovery               `json:"discoveries"`
-	Decisions   []*ports.GRCVendorDiscoveryDecisionRecord `json:"decisions,omitempty"`
-	GeneratedAt time.Time                                 `json:"generated_at"`
+	Summary        grcvendor.DiscoverySummary                     `json:"summary"`
+	Discoveries    []grcvendor.VendorDiscovery                    `json:"discoveries"`
+	Decisions      []*ports.GRCVendorDiscoveryDecisionRecord      `json:"decisions,omitempty"`
+	DecisionEvents []*ports.GRCVendorDiscoveryDecisionEventRecord `json:"decision_events,omitempty"`
+	GeneratedAt    time.Time                                      `json:"generated_at"`
 }
 
 type grcVendorDiscoveryDecisionRequest struct {
@@ -63,6 +65,11 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
+	queueOnly, err := boolQueryParam(r, "queue")
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
 	vendors, err := grcvendor.New(graphQueryStore(a.deps.GraphStore)).ListVendors(r.Context(), grcvendor.ListVendorsRequest{
 		TenantID:    scope.TenantID,
 		RuntimeID:   scope.RuntimeID,
@@ -72,6 +79,9 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		RiskLevel:   strings.TrimSpace(r.URL.Query().Get("risk_level")),
 		ReviewState: strings.TrimSpace(r.URL.Query().Get("review_state")),
 		OwnerState:  strings.TrimSpace(r.URL.Query().Get("owner_state")),
+		Lifecycle:   strings.TrimSpace(r.URL.Query().Get("lifecycle_state")),
+		QueueOnly:   queueOnly,
+		DeferLimit:  queueOnly,
 		Limit:       scope.Limit,
 	})
 	if err != nil {
@@ -83,6 +93,10 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
+	if queueOnly {
+		vendors = grcvendor.FilterVendorsByQueue(vendors)
+	}
+	vendors = grcvendor.SortAndLimitVendors(vendors, scope.Limit)
 	writeJSON(w, http.StatusOK, grcVendorsResponse{
 		Summary:     grcvendor.Summarize(vendors),
 		Vendors:     vendors,
@@ -166,9 +180,12 @@ func (a *App) grcVendorDetailResponse(r *http.Request) (grcVendorDetailResponse,
 	detail.Vendor.CriticalFindings = metrics[urn].CriticalFindings
 	detail.Vendor.HighFindings = metrics[urn].HighFindings
 	detail.Vendor.EvidenceItems = metrics[urn].EvidenceItems
+	detail.Vendor = grcvendor.RefreshVendorQueuePosture(detail.Vendor)
+	detail.Packet = grcvendor.BuildVendorPacket(detail.Vendor, detail.Relationships)
 	return grcVendorDetailResponse{
 		Vendor:        detail.Vendor,
 		Relationships: detail.Relationships,
+		Packet:        detail.Packet,
 		Graph:         detail.Graph,
 		Findings:      findingItems,
 		Evidence:      evidenceItems,
@@ -212,11 +229,18 @@ func (a *App) handleGRCVendorDiscoveries(w http.ResponseWriter, r *http.Request)
 	}
 	discoveries = grcvendor.ApplyDiscoveryDecisions(discoveries, decisions)
 	discoveries = grcvendor.FilterDiscoveriesByDecisionState(discoveries, decisionState)
+	decisions = filterGRCVendorDiscoveryDecisions(decisions, grcDiscoveryURNs(discoveries))
+	decisionEvents, err := a.listGRCVendorDiscoveryDecisionEvents(r, scope, grcDiscoveryURNs(discoveries))
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, grcVendorDiscoveriesResponse{
-		Summary:     grcvendor.SummarizeDiscoveries(discoveries),
-		Discoveries: discoveries,
-		Decisions:   decisions,
-		GeneratedAt: time.Now().UTC(),
+		Summary:        grcvendor.SummarizeDiscoveries(discoveries),
+		Discoveries:    discoveries,
+		Decisions:      decisions,
+		DecisionEvents: decisionEvents,
+		GeneratedAt:    time.Now().UTC(),
 	})
 }
 
@@ -334,6 +358,7 @@ func (a *App) enrichGRCVendors(r *http.Request, scope grcScope, vendors []grcven
 		vendors[index].CriticalFindings = item.CriticalFindings
 		vendors[index].HighFindings = item.HighFindings
 		vendors[index].EvidenceItems = item.EvidenceItems
+		vendors[index] = grcvendor.RefreshVendorQueuePosture(vendors[index])
 	}
 	return vendors, nil
 }
@@ -406,6 +431,39 @@ func (a *App) listGRCVendorDiscoveryDecisions(r *http.Request, scope grcScope, d
 		SourceID:      scope.SourceID,
 		Limit:         boundedUint32(len(discoveryURNs)),
 	})
+}
+
+func (a *App) listGRCVendorDiscoveryDecisionEvents(r *http.Request, scope grcScope, discoveryURNs []string) ([]*ports.GRCVendorDiscoveryDecisionEventRecord, error) {
+	store := grcVendorDiscoveryDecisionStore(a.deps.StateStore)
+	if store == nil || len(discoveryURNs) == 0 {
+		return nil, nil
+	}
+	return store.ListGRCVendorDiscoveryDecisionEvents(r.Context(), ports.GRCVendorDiscoveryDecisionEventFilter{
+		TenantID:      scope.TenantID,
+		DiscoveryURNs: discoveryURNs,
+		SourceID:      scope.SourceID,
+		Limit:         boundedUint32(len(discoveryURNs) * 10),
+	})
+}
+
+func filterGRCVendorDiscoveryDecisions(records []*ports.GRCVendorDiscoveryDecisionRecord, discoveryURNs []string) []*ports.GRCVendorDiscoveryDecisionRecord {
+	if len(records) == 0 || len(discoveryURNs) == 0 {
+		return nil
+	}
+	visible := make(map[string]struct{}, len(discoveryURNs))
+	for _, urn := range discoveryURNs {
+		visible[strings.TrimSpace(urn)] = struct{}{}
+	}
+	filtered := records[:0]
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		if _, ok := visible[strings.TrimSpace(record.DiscoveryURN)]; ok {
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered
 }
 
 func grcVendorFindingLimit(vendorCount int, scopeLimit uint32) uint32 {

--- a/internal/findings/grc_signal_rule.go
+++ b/internal/findings/grc_signal_rule.go
@@ -73,33 +73,70 @@ func newGRCVulnerabilitySLAOverdueRule() Rule {
 	}})
 }
 
+type grcVendorReviewOverdueRule struct {
+	Rule
+	definition RuleDefinition
+}
+
+var grcVendorReviewOverdueDefinition = RuleDefinition{
+	ID:                 grcVendorReviewOverdueRuleID,
+	Name:               "GRC Vendor Review Overdue",
+	Description:        "Detect provider-neutral GRC vendors with overdue security reviews or missing owners.",
+	SourceID:           "grc",
+	EventKinds:         []string{"grc.vendor"},
+	OutputKind:         "finding.grc_vendor_review_overdue",
+	Severity:           "MEDIUM",
+	Status:             findingStatusOpen,
+	Maturity:           "test",
+	Tags:               []string{"grc", "vendor-risk"},
+	References:         []string{"https://www.aicpa-cima.com/resources/landing/system-and-organization-controls-soc-suite-of-services", "https://www.iso.org/standard/27001"},
+	FalsePositives:     []string{"Vendor review has an approved deferral, owner is tracked outside the provider, or provider sync has not reflected the latest review."},
+	Runbook:            "Confirm vendor owner and review status, request updated security review evidence, and document exceptions or offboarding decisions.",
+	RequiredAttributes: []string{"vendor_id"},
+	FingerprintFields:  []string{"tenant_id", "runtime_id", "provider", "vendor_id"},
+	ControlRefs: []ports.FindingControlRef{
+		{FrameworkName: "SOC 2", ControlID: "CC9.2"},
+		{FrameworkName: "ISO 27001:2022", ControlID: "A.5.19"},
+	},
+	Lifecycle: Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
+}
+
+var grcVendorReviewOverdueKindMatcher = eventKindMatcher(grcVendorReviewOverdueDefinition.EventKinds...)
+
 func newGRCVendorReviewOverdueRule() Rule {
-	definition := RuleDefinition{
-		ID:                 grcVendorReviewOverdueRuleID,
-		Name:               "GRC Vendor Review Overdue",
-		Description:        "Detect provider-neutral GRC vendors with overdue security reviews or missing owners.",
-		SourceID:           "grc",
-		EventKinds:         []string{"grc.vendor"},
-		OutputKind:         "finding.grc_vendor_review_overdue",
-		Severity:           "MEDIUM",
-		Status:             findingStatusOpen,
-		Maturity:           "test",
-		Tags:               []string{"grc", "vendor-risk"},
-		References:         []string{"https://www.aicpa-cima.com/resources/landing/system-and-organization-controls-soc-suite-of-services", "https://www.iso.org/standard/27001"},
-		FalsePositives:     []string{"Vendor review has an approved deferral, owner is tracked outside the provider, or provider sync has not reflected the latest review."},
-		Runbook:            "Confirm vendor owner and review status, request updated security review evidence, and document exceptions or offboarding decisions.",
-		RequiredAttributes: []string{"vendor_id"},
-		FingerprintFields:  []string{"tenant_id", "runtime_id", "provider", "vendor_id"},
-		ControlRefs: []ports.FindingControlRef{
-			{FrameworkName: "SOC 2", ControlID: "CC9.2"},
-			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.19"},
-		},
-		Lifecycle: Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
-	}
-	return newEventRule(eventRuleConfig{definition: definition, match: matchesGRCVendorReviewOverdue, build: func(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+	rule := newEventRule(eventRuleConfig{definition: grcVendorReviewOverdueDefinition, match: matchesGRCVendorReviewOverdue, build: func(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
 		attrs := event.GetAttributes()
-		return buildGRCFinding(ctx, runtime, event, definition, "GRC vendor review overdue", grcVendorSummary(attrs), "vendor_id", "MEDIUM")
+		return buildGRCFinding(ctx, runtime, event, grcVendorReviewOverdueDefinition, "GRC vendor review overdue", grcVendorSummary(attrs), "vendor_id", "MEDIUM")
 	}})
+	return &grcVendorReviewOverdueRule{
+		Rule:       rule,
+		definition: grcVendorReviewOverdueDefinition,
+	}
+}
+
+func (r *grcVendorReviewOverdueRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *grcVendorReviewOverdueRule) OpenAnchor(attributes map[string]string) string {
+	return grcVendorReviewAnchor(attributes)
+}
+
+func (r *grcVendorReviewOverdueRule) CloseOnEvent(event Event) (string, bool) {
+	if !grcVendorReviewOverdueKindMatcher(event) || !hasRequiredAttributes(event, grcVendorReviewOverdueDefinition.RequiredAttributes...) {
+		return "", false
+	}
+	if matchesGRCVendorReviewOverdue(event) {
+		return "", false
+	}
+	if !matchesGRCVendorReviewRestored(event) {
+		return "", false
+	}
+	anchor := grcVendorReviewAnchor(eventAttributes(event))
+	return anchor, anchor != ""
 }
 
 func matchesGRCControlTestNeedsAttention(event *cerebrov1.EventEnvelope) bool {
@@ -123,15 +160,38 @@ func matchesGRCVulnerabilitySLAOverdue(event *cerebrov1.EventEnvelope) bool {
 }
 
 func matchesGRCVendorReviewOverdue(event *cerebrov1.EventEnvelope) bool {
-	if !eventKindMatcher("grc.vendor")(event) || !hasRequiredAttributes(event, "vendor_id") {
+	if !grcVendorReviewOverdueKindMatcher(event) || !hasRequiredAttributes(event, "vendor_id") {
 		return false
 	}
 	attrs := event.GetAttributes()
+	if grcVendorInactiveLifecycle(attrs) {
+		return false
+	}
 	if firstNonEmpty(attrs["security_owner_user_id"], attrs["business_owner_user_id"]) == "" {
 		return true
 	}
 	due, ok := parseGRCTime(attrs["next_security_review_due_date"])
 	return ok && due.Before(time.Now().UTC())
+}
+
+func matchesGRCVendorReviewRestored(event *cerebrov1.EventEnvelope) bool {
+	if !grcVendorReviewOverdueKindMatcher(event) || !hasRequiredAttributes(event, "vendor_id") {
+		return false
+	}
+	attrs := event.GetAttributes()
+	if grcVendorInactiveLifecycle(attrs) {
+		return true
+	}
+	if firstNonEmpty(attrs["security_owner_user_id"], attrs["business_owner_user_id"]) == "" {
+		return false
+	}
+	if due, ok := parseGRCTime(attrs["next_security_review_due_date"]); ok && !due.Before(time.Now().UTC()) {
+		return true
+	}
+	if _, ok := parseGRCTime(firstNonEmpty(attrs["last_security_review_completion_date"], attrs["last_review_completed_at"], attrs["review_completed_at"])); ok {
+		return true
+	}
+	return false
 }
 
 func buildGRCFinding(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope, definition RuleDefinition, title string, summary string, policyKey string, severity string) (*ports.FindingRecord, error) {
@@ -230,10 +290,32 @@ func grcVulnerabilitySummary(attrs map[string]string) string {
 }
 
 func grcVendorSummary(attrs map[string]string) string {
-	if strings.TrimSpace(attrs["security_owner_user_id"]) == "" {
+	if firstNonEmpty(attrs["security_owner_user_id"], attrs["business_owner_user_id"]) == "" {
 		return fmt.Sprintf("GRC vendor %s is missing a security owner", firstNonEmpty(attrs["name"], attrs["vendor_id"], "unknown vendor"))
 	}
 	return fmt.Sprintf("GRC vendor %s has overdue security review due %s", firstNonEmpty(attrs["name"], attrs["vendor_id"], "unknown vendor"), firstNonEmpty(attrs["next_security_review_due_date"], "unknown"))
+}
+
+func grcVendorReviewAnchor(attrs map[string]string) string {
+	vendorID := firstNonEmpty(attrs["vendor_id"], attrs["external_id"])
+	if vendorID == "" {
+		return ""
+	}
+	provider := firstNonEmpty(attrs["provider"], attrs["source_system"], attrs["source_id"])
+	if provider == "" {
+		return identityCounterEventAnchor(map[string]string{"vendor_id": vendorID}, "vendor_id")
+	}
+	return identityCounterEventAnchor(map[string]string{"provider": provider, "vendor_id": vendorID}, "provider", "vendor_id")
+}
+
+func grcVendorInactiveLifecycle(attrs map[string]string) bool {
+	state := strings.ToLower(strings.TrimSpace(firstNonEmpty(attrs["lifecycle_state"], attrs["vendor_lifecycle_state"], attrs["status"], attrs["vendor_status"])))
+	switch state {
+	case "archived", "deleted", "disabled", "ignored", "inactive", "rejected", "denied", "retired", "terminated", "offboarding", "offboarded", "terminating", "decommissioning":
+		return true
+	default:
+		return false
+	}
 }
 
 func parseGRCTime(raw string) (time.Time, bool) {

--- a/internal/findings/grc_signal_rule_test.go
+++ b/internal/findings/grc_signal_rule_test.go
@@ -14,13 +14,13 @@ func TestGRCControlTestNeedsAttentionRule(t *testing.T) {
 	rule := newGRCControlTestNeedsAttentionRule()
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-grc", SourceId: "grc"}
 	event := &cerebrov1.EventEnvelope{
-		Id:         "grc-vanta-control_test-ai-training",
+		Id:         "grc-vrm-control_test-ai-training",
 		TenantId:   "writer",
 		SourceId:   "grc",
 		Kind:       "grc.control_test",
 		OccurredAt: timestamppb.New(time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)),
 		Attributes: map[string]string{
-			"provider": "vanta",
+			"provider": "vrm",
 			"test_id":  "ai-risk-security-training-records",
 			"name":     "AI risk security awareness training selected",
 			"status":   "NEEDS_ATTENTION",
@@ -50,12 +50,12 @@ func TestGRCControlTestNeedsAttentionRuleFingerprintSeparatesTenants(t *testing.
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-grc", SourceId: "grc"}
 	eventForTenant := func(tenantID string) *cerebrov1.EventEnvelope {
 		return &cerebrov1.EventEnvelope{
-			Id:       "grc-vanta-control_test-ai-training",
+			Id:       "grc-vrm-control_test-ai-training",
 			TenantId: tenantID,
 			SourceId: "grc",
 			Kind:     "grc.control_test",
 			Attributes: map[string]string{
-				"provider": "vanta",
+				"provider": "vrm",
 				"test_id":  "ai-risk-security-training-records",
 				"name":     "AI risk security awareness training selected",
 				"status":   "NEEDS_ATTENTION",
@@ -82,12 +82,12 @@ func TestGRCControlTestNeedsAttentionRuleFingerprintSeparatesTenants(t *testing.
 func TestGRCControlTestNeedsAttentionRuleFingerprintSeparatesRuntimes(t *testing.T) {
 	rule := newGRCControlTestNeedsAttentionRule()
 	event := &cerebrov1.EventEnvelope{
-		Id:       "grc-vanta-control_test-ai-training",
+		Id:       "grc-vrm-control_test-ai-training",
 		TenantId: "writer",
 		SourceId: "grc",
 		Kind:     "grc.control_test",
 		Attributes: map[string]string{
-			"provider": "vanta",
+			"provider": "vrm",
 			"test_id":  "ai-risk-security-training-records",
 			"name":     "AI risk security awareness training selected",
 			"status":   "NEEDS_ATTENTION",
@@ -114,13 +114,13 @@ func TestGRCVulnerabilitySLAOverdueRule(t *testing.T) {
 	rule := newGRCVulnerabilitySLAOverdueRule()
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-grc", SourceId: "grc"}
 	event := &cerebrov1.EventEnvelope{
-		Id:         "grc-vanta-vulnerability-vuln-1",
+		Id:         "grc-vrm-vulnerability-vuln-1",
 		TenantId:   "writer",
 		SourceId:   "grc",
 		Kind:       "grc.vulnerability",
 		OccurredAt: timestamppb.New(time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)),
 		Attributes: map[string]string{
-			"provider":          "vanta",
+			"provider":          "vrm",
 			"vulnerability_id":  "vuln-1",
 			"name":              "CVE-2026-4242",
 			"package":           "pkg:golang/example/module@1.2.3",
@@ -155,7 +155,7 @@ func TestGRCVulnerabilitySLAOverdueRuleFingerprintSeparatesPackageAndTarget(t *t
 			SourceId: "grc",
 			Kind:     "grc.vulnerability",
 			Attributes: map[string]string{
-				"provider":          "vanta",
+				"provider":          "vrm",
 				"vulnerability_id":  id,
 				"name":              "CVE-2026-4242",
 				"package":           packageName,
@@ -186,13 +186,13 @@ func TestGRCVendorReviewOverdueRule(t *testing.T) {
 	rule := newGRCVendorReviewOverdueRule()
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-grc", SourceId: "grc"}
 	event := &cerebrov1.EventEnvelope{
-		Id:         "grc-vanta-vendor-vendor-1",
+		Id:         "grc-vrm-vendor-vendor-1",
 		TenantId:   "writer",
 		SourceId:   "grc",
 		Kind:       "grc.vendor",
 		OccurredAt: timestamppb.New(time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)),
 		Attributes: map[string]string{
-			"provider":                      "vanta",
+			"provider":                      "vrm",
 			"vendor_id":                     "vendor-1",
 			"name":                          "Acme SaaS",
 			"security_owner_user_id":        "user-1",
@@ -210,7 +210,7 @@ func TestGRCVendorReviewOverdueRule(t *testing.T) {
 	if got := findings[0].RuleID; got != grcVendorReviewOverdueRuleID {
 		t.Fatalf("RuleID = %q, want %q", got, grcVendorReviewOverdueRuleID)
 	}
-	if got := findings[0].Attributes["primary_resource_urn"]; got != "urn:cerebro:writer:vendor:vanta:vendor-1" {
+	if got := findings[0].Attributes["primary_resource_urn"]; got != "urn:cerebro:writer:vendor:vrm:vendor-1" {
 		t.Fatalf("primary_resource_urn = %q, want vendor", got)
 	}
 }
@@ -219,12 +219,12 @@ func TestGRCVendorReviewRuleIgnoresCurrentVendor(t *testing.T) {
 	rule := newGRCVendorReviewOverdueRule()
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-grc", SourceId: "grc"}
 	event := &cerebrov1.EventEnvelope{
-		Id:       "grc-vanta-vendor-vendor-1",
+		Id:       "grc-vrm-vendor-vendor-1",
 		TenantId: "writer",
 		SourceId: "grc",
 		Kind:     "grc.vendor",
 		Attributes: map[string]string{
-			"provider":                      "vanta",
+			"provider":                      "vrm",
 			"vendor_id":                     "vendor-1",
 			"name":                          "Acme SaaS",
 			"security_owner_user_id":        "user-1",
@@ -238,5 +238,176 @@ func TestGRCVendorReviewRuleIgnoresCurrentVendor(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Fatalf("len(findings) = %d, want 0", len(findings))
+	}
+}
+
+func TestGRCVendorReviewRuleClosesOnRestoredPosture(t *testing.T) {
+	rule := newGRCVendorReviewOverdueRule()
+	counterRule, ok := rule.(CounterEventRule)
+	if !ok {
+		t.Fatal("grc-vendor-review-overdue does not implement CounterEventRule")
+	}
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-grc", SourceId: "grc"}
+	openEvent := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-vendor-vendor-1-open",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":  "vrm",
+			"vendor_id": "vendor-1",
+			"name":      "Acme SaaS",
+		},
+	}
+	findings, err := rule.Evaluate(context.Background(), runtime, openEvent)
+	if err != nil {
+		t.Fatalf("Evaluate(open) error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("len(open findings) = %d, want 1", len(findings))
+	}
+	openAnchor := counterRule.OpenAnchor(findings[0].Attributes)
+	if openAnchor == "" {
+		t.Fatalf("OpenAnchor(%v) = empty, want vendor anchor", findings[0].Attributes)
+	}
+
+	restored := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-vendor-vendor-1-restored",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":                      "vrm",
+			"vendor_id":                     "vendor-1",
+			"name":                          "Acme SaaS",
+			"business_owner_user_id":        "user-1",
+			"next_security_review_due_date": "2999-01-01T00:00:00Z",
+		},
+	}
+	closeAnchor, closes := counterRule.CloseOnEvent(restored)
+	if !closes || closeAnchor != openAnchor {
+		t.Fatalf("CloseOnEvent(restored) = (%q, %v), want (%q, true)", closeAnchor, closes, openAnchor)
+	}
+
+	missingDueDate := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-vendor-vendor-1-missing-due-date",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":               "vrm",
+			"vendor_id":              "vendor-1",
+			"name":                   "Acme SaaS",
+			"business_owner_user_id": "user-1",
+		},
+	}
+	closeAnchor, closes = counterRule.CloseOnEvent(missingDueDate)
+	if closes || closeAnchor != "" {
+		t.Fatalf("CloseOnEvent(missingDueDate) = (%q, %v), want no close", closeAnchor, closes)
+	}
+
+	unrelated := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-vendor-vendor-2-restored",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":                      "vrm",
+			"vendor_id":                     "vendor-2",
+			"name":                          "Other SaaS",
+			"business_owner_user_id":        "user-2",
+			"next_security_review_due_date": "2999-01-01T00:00:00Z",
+		},
+	}
+	closeAnchor, closes = counterRule.CloseOnEvent(unrelated)
+	if !closes || closeAnchor == openAnchor {
+		t.Fatalf("CloseOnEvent(unrelated) = (%q, %v), want different close anchor", closeAnchor, closes)
+	}
+
+	wrongKind := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-asset-vendor-1-restored",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.asset",
+		Attributes: map[string]string{
+			"provider":                      "vrm",
+			"vendor_id":                     "vendor-1",
+			"name":                          "Acme SaaS",
+			"business_owner_user_id":        "user-1",
+			"next_security_review_due_date": "2999-01-01T00:00:00Z",
+		},
+	}
+	closeAnchor, closes = counterRule.CloseOnEvent(wrongKind)
+	if closes || closeAnchor != "" {
+		t.Fatalf("CloseOnEvent(wrongKind) = (%q, %v), want no close", closeAnchor, closes)
+	}
+
+	contextless := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-vendor-missing-id-restored",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":                      "vrm",
+			"name":                          "No ID SaaS",
+			"business_owner_user_id":        "user-3",
+			"next_security_review_due_date": "2999-01-01T00:00:00Z",
+		},
+	}
+	closeAnchor, closes = counterRule.CloseOnEvent(contextless)
+	if closes || closeAnchor != "" {
+		t.Fatalf("CloseOnEvent(contextless) = (%q, %v), want no close", closeAnchor, closes)
+	}
+
+	completed := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-vendor-vendor-1-completed",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":                             "vrm",
+			"vendor_id":                            "vendor-1",
+			"name":                                 "Acme SaaS",
+			"business_owner_user_id":               "user-1",
+			"last_security_review_completion_date": "2026-01-01T00:00:00Z",
+		},
+	}
+	closeAnchor, closes = counterRule.CloseOnEvent(completed)
+	if !closes || closeAnchor != openAnchor {
+		t.Fatalf("CloseOnEvent(completed) = (%q, %v), want (%q, true)", closeAnchor, closes, openAnchor)
+	}
+
+	inactive := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-vendor-vendor-1-retired",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":  "vrm",
+			"vendor_id": "vendor-1",
+			"name":      "Acme SaaS",
+			"status":    "retired",
+		},
+	}
+	closeAnchor, closes = counterRule.CloseOnEvent(inactive)
+	if !closes || closeAnchor != openAnchor {
+		t.Fatalf("CloseOnEvent(inactive) = (%q, %v), want (%q, true)", closeAnchor, closes, openAnchor)
+	}
+
+	inactiveSynonym := &cerebrov1.EventEnvelope{
+		Id:       "grc-vrm-vendor-vendor-1-decommissioning",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":  "vrm",
+			"vendor_id": "vendor-1",
+			"name":      "Acme SaaS",
+			"status":    "decommissioning",
+		},
+	}
+	closeAnchor, closes = counterRule.CloseOnEvent(inactiveSynonym)
+	if !closes || closeAnchor != openAnchor {
+		t.Fatalf("CloseOnEvent(inactiveSynonym) = (%q, %v), want (%q, true)", closeAnchor, closes, openAnchor)
 	}
 }

--- a/internal/grccatalog/catalog.go
+++ b/internal/grccatalog/catalog.go
@@ -204,6 +204,8 @@ func vendorListParams() []Param {
 		Param{ID: "risk_level", Type: ParamEnum, AllowedValues: []string{"critical", "high", "medium", "low", "unknown", "all"}, Description: "Filter by normalized vendor risk level."},
 		Param{ID: "review_state", Type: ParamEnum, AllowedValues: []string{"current", "due_soon", "overdue", "not_scheduled", "all"}, Description: "Filter by security review state."},
 		Param{ID: "owner_state", Type: ParamEnum, AllowedValues: []string{"assigned", "missing", "all"}, Description: "Filter by vendor owner assignment."},
+		Param{ID: "lifecycle_state", Type: ParamEnum, AllowedValues: []string{"discovered", "candidate", "active", "in_review", "approved", "conditionally_approved", "restricted", "offboarding", "retired", "rejected", "ignored", "unknown", "all"}, Description: "Filter by normalized vendor lifecycle state."},
+		Param{ID: "queue", Type: ParamBool, Description: "Return vendors with open queue reasons."},
 	)
 }
 
@@ -354,7 +356,7 @@ func buildCatalog() []Source {
 			ID:             "vendors",
 			Domain:         "vendors",
 			Title:          "Vendors",
-			Description:    "Canonical vendor rows with owners, review dates, contract counts, assurance counts, and open risk.",
+			Description:    "Canonical vendor rows with lifecycle, score factors, exposure, packet readiness, assessment state, remediation state, monitoring state, owners, renewals, offboarding, evidence freshness, and open risk.",
 			Method:         "GET",
 			Path:           "/grc/vendors",
 			Params:         vendorListParams(),
@@ -368,7 +370,7 @@ func buildCatalog() []Source {
 			ID:          "vendor-detail",
 			Domain:      "vendors",
 			Title:       "Vendor detail",
-			Description: "One vendor packet with linked contracts, reviews, questionnaires, assurance records, findings, evidence, and graph context.",
+			Description: "One vendor packet with exposure, packet readiness, remediation posture, linked contracts, reviews, questionnaires, assurance records, findings, evidence, and graph context.",
 			Method:      "GET",
 			Path:        "/grc/vendors/{vendorID}",
 			Params: withRuntimeScope(
@@ -401,7 +403,7 @@ func buildCatalog() []Source {
 			ID:             "vendor-risk-queue",
 			Domain:         "vendors",
 			Title:          "Vendor risk queue",
-			Description:    "Vendor rows for owner gaps, overdue reviews, due-soon reviews, and high residual risk work.",
+			Description:    "Vendor rows with queue reasons for owner gaps, stale evidence, packet blockers, remediation deadlines, assessments, monitoring alerts, renewals, offboarding, missing agreements, restricted lifecycle, and open high-severity findings.",
 			Method:         "GET",
 			Path:           "/grc/vendors",
 			Params:         vendorListParams(),

--- a/internal/grccatalog/catalog_test.go
+++ b/internal/grccatalog/catalog_test.go
@@ -76,6 +76,7 @@ func TestCatalogAdvertisesOnlyHonoredParams(t *testing.T) {
 		{name: "inventory-categories source_id", query: WidgetQuery{SourceID: "inventory-categories", Params: map[string]string{"source_id": "aws"}}},
 		{name: "inventory-assets filters", query: WidgetQuery{SourceID: "inventory-assets", Params: map[string]string{"source_id": "aws", "category_id": "compute", "q": "db", "scope_state": "in_scope"}}},
 		{name: "policy-lifecycle runtime scope", query: WidgetQuery{SourceID: "policy-lifecycle", Params: map[string]string{"source_id": "grc", "runtime_id": "rt-1"}}},
+		{name: "vendor queue filters", query: WidgetQuery{SourceID: "vendor-risk-queue", Params: map[string]string{"queue": "true", "lifecycle_state": "restricted"}}},
 	}
 	for _, tc := range accepted {
 		t.Run("accepts "+tc.name, func(t *testing.T) {

--- a/internal/grcvendor/service.go
+++ b/internal/grcvendor/service.go
@@ -26,6 +26,25 @@ const (
 	ReviewStateOverdue      = "overdue"
 	ReviewStateNotScheduled = "not_scheduled"
 
+	LifecycleStateDiscovered            = "discovered"
+	LifecycleStateCandidate             = "candidate"
+	LifecycleStateActive                = "active"
+	LifecycleStateInReview              = "in_review"
+	LifecycleStateApproved              = "approved"
+	LifecycleStateConditionallyApproved = "conditionally_approved"
+	LifecycleStateRestricted            = "restricted"
+	LifecycleStateOffboarding           = "offboarding"
+	LifecycleStateRetired               = "retired"
+	LifecycleStateRejected              = "rejected"
+	LifecycleStateIgnored               = "ignored"
+	LifecycleStateUnknown               = "unknown"
+
+	FreshnessStateCurrent = "current"
+	FreshnessStateStale   = "stale"
+	FreshnessStateExpired = "expired"
+	FreshnessStateUnknown = "unknown"
+	FreshnessStateMissing = "missing"
+
 	DiscoveryStateDiscovered = "discovered"
 	DiscoveryStateApproved   = ports.GRCVendorDiscoveryDecisionApproved
 	DiscoveryStateRejected   = ports.GRCVendorDiscoveryDecisionRejected
@@ -54,6 +73,9 @@ type ListVendorsRequest struct {
 	RiskLevel   string
 	ReviewState string
 	OwnerState  string
+	Lifecycle   string
+	QueueOnly   bool
+	DeferLimit  bool
 	Limit       uint32
 }
 
@@ -94,12 +116,22 @@ type ListDiscoveriesRequest struct {
 // modeled as explicit source attributes or finding/evidence filters.
 type Vendor struct {
 	VendorIdentity
+	VendorLifecycle
 	VendorOwnership
 	VendorRiskPosture
+	VendorRiskInputs
+	VendorRiskScoring
+	VendorControlPosture
 	VendorReviewPosture
+	VendorAssessmentPosture
+	VendorFreshnessPosture
+	VendorMonitoringPosture
+	VendorCommercialPosture
+	VendorOperationalPosture
 	VendorContractDates
 	VendorRecordCounts
 	VendorFindingCounts
+	VendorQueuePosture
 	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
@@ -116,6 +148,12 @@ type VendorIdentity struct {
 	ServicesProvided string `json:"services_provided,omitempty"`
 }
 
+type VendorLifecycle struct {
+	SourceStatus    string `json:"source_status,omitempty"`
+	LifecycleState  string `json:"lifecycle_state"`
+	LifecycleReason string `json:"lifecycle_reason,omitempty"`
+}
+
 type VendorOwnership struct {
 	SecurityOwnerUserID string `json:"security_owner_user_id,omitempty"`
 	BusinessOwnerUserID string `json:"business_owner_user_id,omitempty"`
@@ -129,10 +167,120 @@ type VendorRiskPosture struct {
 	RiskLevel         string `json:"risk_level"`
 }
 
+type VendorRiskInputs struct {
+	DataSensitivity  string   `json:"data_sensitivity,omitempty"`
+	AccessLevel      string   `json:"access_level,omitempty"`
+	Criticality      string   `json:"criticality,omitempty"`
+	Subprocessor     string   `json:"subprocessor,omitempty"`
+	Geography        string   `json:"geography,omitempty"`
+	SystemDependency string   `json:"system_dependency,omitempty"`
+	RiskDrivers      []string `json:"risk_drivers,omitempty"`
+}
+
+type VendorRiskScoring struct {
+	RiskScore         int               `json:"risk_score,omitempty"`
+	RiskScoreLevel    string            `json:"risk_score_level,omitempty"`
+	RiskScoreSource   string            `json:"risk_score_source,omitempty"`
+	RiskTier          string            `json:"risk_tier,omitempty"`
+	ReviewCadenceDays int               `json:"review_cadence_days,omitempty"`
+	ScoreFactors      []RiskScoreFactor `json:"score_factors,omitempty"`
+}
+
+type RiskScoreFactor struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Score  int    `json:"score"`
+	Weight int    `json:"weight"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type VendorControlPosture struct {
+	DPAStatus            string `json:"dpa_status,omitempty"`
+	BAAStatus            string `json:"baa_status,omitempty"`
+	SOC2Status           string `json:"soc2_status,omitempty"`
+	ISO27001Status       string `json:"iso27001_status,omitempty"`
+	SecurityReviewStatus string `json:"security_review_status,omitempty"`
+	PrivacyReviewStatus  string `json:"privacy_review_status,omitempty"`
+	DocumentStatus       string `json:"document_status,omitempty"`
+}
+
 type VendorReviewPosture struct {
 	ReviewState           string     `json:"review_state"`
 	ReviewDueAt           *time.Time `json:"review_due_at,omitempty"`
 	LastReviewCompletedAt *time.Time `json:"last_review_completed_at,omitempty"`
+}
+
+type VendorAssessmentPosture struct {
+	AssessmentState       string     `json:"assessment_state,omitempty"`
+	AssessmentProgress    int        `json:"assessment_progress,omitempty"`
+	OpenAssessments       int        `json:"open_assessments,omitempty"`
+	CompletedAssessments  int        `json:"completed_assessments,omitempty"`
+	AssessmentTypes       []string   `json:"assessment_types,omitempty"`
+	QuestionnaireState    string     `json:"questionnaire_state,omitempty"`
+	QuestionnaireProgress int        `json:"questionnaire_progress,omitempty"`
+	LastAssessmentAt      *time.Time `json:"last_assessment_at,omitempty"`
+	NextAssessmentAt      *time.Time `json:"next_assessment_at,omitempty"`
+}
+
+type VendorFreshnessPosture struct {
+	EvidenceFreshnessState string           `json:"evidence_freshness_state"`
+	EvidenceFreshness      []FreshnessClock `json:"evidence_freshness,omitempty"`
+}
+
+type VendorMonitoringPosture struct {
+	MonitoringState         string                   `json:"monitoring_state,omitempty"`
+	MonitoringSignals       []VendorMonitoringSignal `json:"monitoring_signals,omitempty"`
+	ExternalRating          string                   `json:"external_rating,omitempty"`
+	ExternalRatingUpdatedAt *time.Time               `json:"external_rating_updated_at,omitempty"`
+	LastMaterialChangeAt    *time.Time               `json:"last_material_change_at,omitempty"`
+}
+
+type VendorMonitoringSignal struct {
+	ID         string     `json:"id"`
+	Label      string     `json:"label"`
+	Severity   string     `json:"severity"`
+	Source     string     `json:"source,omitempty"`
+	ObservedAt *time.Time `json:"observed_at,omitempty"`
+	Reason     string     `json:"reason,omitempty"`
+}
+
+type VendorCommercialPosture struct {
+	SpendAmount      string     `json:"spend_amount,omitempty"`
+	SpendCurrency    string     `json:"spend_currency,omitempty"`
+	ContractValue    string     `json:"contract_value,omitempty"`
+	ContractCurrency string     `json:"contract_currency,omitempty"`
+	RenewalNoticeAt  *time.Time `json:"renewal_notice_at,omitempty"`
+	RenewalState     string     `json:"renewal_state,omitempty"`
+	PrimaryContact   string     `json:"primary_contact,omitempty"`
+	BusinessUnit     string     `json:"business_unit,omitempty"`
+	CostCenter       string     `json:"cost_center,omitempty"`
+}
+
+type VendorOperationalPosture struct {
+	ExposureLevel           string     `json:"exposure_level,omitempty"`
+	ExposureReasons         []string   `json:"exposure_reasons,omitempty"`
+	PacketState             string     `json:"packet_state,omitempty"`
+	PacketReadyItems        []string   `json:"packet_ready_items,omitempty"`
+	PacketMissingItems      []string   `json:"packet_missing_items,omitempty"`
+	RemediationState        string     `json:"remediation_state,omitempty"`
+	RemediationDueAt        *time.Time `json:"remediation_due_at,omitempty"`
+	OpenRemediationItems    int        `json:"open_remediation_items,omitempty"`
+	OverdueRemediationItems int        `json:"overdue_remediation_items,omitempty"`
+	OffboardingState        string     `json:"offboarding_state,omitempty"`
+	OffboardingDueAt        *time.Time `json:"offboarding_due_at,omitempty"`
+	DataDeletionState       string     `json:"data_deletion_state,omitempty"`
+}
+
+type FreshnessClock struct {
+	ID             string     `json:"id"`
+	Label          string     `json:"label"`
+	Source         string     `json:"source"`
+	Status         string     `json:"status"`
+	ObservedAt     *time.Time `json:"observed_at,omitempty"`
+	ExpiresAt      *time.Time `json:"expires_at,omitempty"`
+	AgeDays        int        `json:"age_days,omitempty"`
+	StaleAfterDays int        `json:"stale_after_days,omitempty"`
+	Reason         string     `json:"reason,omitempty"`
 }
 
 type VendorContractDates struct {
@@ -155,6 +303,29 @@ type VendorFindingCounts struct {
 	EvidenceItems    int `json:"evidence_items,omitempty"`
 }
 
+type VendorQueuePosture struct {
+	RiskQueueRank int                 `json:"risk_queue_rank,omitempty"`
+	QueueReasons  []string            `json:"queue_reasons,omitempty"`
+	NextActions   []VendorAction      `json:"next_actions,omitempty"`
+	CloseActions  []VendorCloseAction `json:"close_actions,omitempty"`
+}
+
+type VendorAction struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Reason      string `json:"reason,omitempty"`
+	ActionType  string `json:"action_type,omitempty"`
+	TargetState string `json:"target_state,omitempty"`
+	Priority    int    `json:"priority,omitempty"`
+}
+
+type VendorCloseAction struct {
+	ID         string `json:"id"`
+	Label      string `json:"label"`
+	ClosesWhen string `json:"closes_when"`
+	FindingKey string `json:"finding_key,omitempty"`
+}
+
 type VendorDiscovery struct {
 	URN               string            `json:"urn"`
 	DiscoveryID       string            `json:"discovery_id,omitempty"`
@@ -175,17 +346,28 @@ type VendorDiscovery struct {
 }
 
 type Summary struct {
-	TotalVendors         int `json:"total_vendors"`
-	ActiveVendors        int `json:"active_vendors"`
-	HighRiskVendors      int `json:"high_risk_vendors"`
-	OwnerMissingVendors  int `json:"owner_missing_vendors"`
-	ReviewOverdueVendors int `json:"review_overdue_vendors"`
-	ReviewDueSoonVendors int `json:"review_due_soon_vendors"`
-	ReviewNotScheduled   int `json:"review_not_scheduled"`
-	OpenFindings         int `json:"open_findings"`
-	CriticalFindings     int `json:"critical_findings"`
-	HighFindings         int `json:"high_findings"`
-	EvidenceItems        int `json:"evidence_items"`
+	TotalVendors           int `json:"total_vendors"`
+	ActiveVendors          int `json:"active_vendors"`
+	HighRiskVendors        int `json:"high_risk_vendors"`
+	OwnerMissingVendors    int `json:"owner_missing_vendors"`
+	ReviewOverdueVendors   int `json:"review_overdue_vendors"`
+	ReviewDueSoonVendors   int `json:"review_due_soon_vendors"`
+	ReviewNotScheduled     int `json:"review_not_scheduled"`
+	RiskQueueVendors       int `json:"risk_queue_vendors"`
+	StaleEvidenceVendors   int `json:"stale_evidence_vendors"`
+	RestrictedVendors      int `json:"restricted_vendors"`
+	CriticalTierVendors    int `json:"critical_tier_vendors"`
+	AssessmentDueVendors   int `json:"assessment_due_vendors"`
+	MonitoringAlertVendors int `json:"monitoring_alert_vendors"`
+	RenewalDueVendors      int `json:"renewal_due_vendors"`
+	PacketBlockedVendors   int `json:"packet_blocked_vendors"`
+	HighExposureVendors    int `json:"high_exposure_vendors"`
+	RemediationDueVendors  int `json:"remediation_due_vendors"`
+	OffboardingDueVendors  int `json:"offboarding_due_vendors"`
+	OpenFindings           int `json:"open_findings"`
+	CriticalFindings       int `json:"critical_findings"`
+	HighFindings           int `json:"high_findings"`
+	EvidenceItems          int `json:"evidence_items"`
 }
 
 type DiscoverySummary struct {
@@ -200,6 +382,7 @@ type DiscoverySummary struct {
 type VendorDetail struct {
 	Vendor        Vendor                    `json:"vendor"`
 	Relationships VendorRelationships       `json:"relationships"`
+	Packet        VendorPacket              `json:"packet"`
 	Graph         *ports.EntityNeighborhood `json:"graph,omitempty"`
 }
 
@@ -208,8 +391,58 @@ type VendorRelationships struct {
 	SecurityReviews        []RelatedRecord `json:"security_reviews,omitempty"`
 	SecurityQuestionnaires []RelatedRecord `json:"security_questionnaires,omitempty"`
 	AssuranceDocuments     []RelatedRecord `json:"assurance_documents,omitempty"`
+	Assessments            []RelatedRecord `json:"assessments,omitempty"`
 	Owners                 []RelatedRecord `json:"owners,omitempty"`
 	Hosts                  []RelatedRecord `json:"hosts,omitempty"`
+	Aliases                []RelatedRecord `json:"aliases,omitempty"`
+	Contacts               []RelatedRecord `json:"contacts,omitempty"`
+	FourthParties          []RelatedRecord `json:"fourth_parties,omitempty"`
+}
+
+type VendorPacket struct {
+	Version           string                   `json:"version"`
+	VendorURN         string                   `json:"vendor_urn"`
+	Lifecycle         VendorLifecycle          `json:"lifecycle"`
+	Risk              VendorPacketRisk         `json:"risk"`
+	RiskScore         VendorRiskScoring        `json:"risk_score"`
+	Controls          VendorControlPosture     `json:"controls"`
+	Assessments       VendorAssessmentPosture  `json:"assessments"`
+	Monitoring        VendorMonitoringPosture  `json:"monitoring"`
+	Commercial        VendorCommercialPosture  `json:"commercial"`
+	Operations        VendorOperationalPosture `json:"operations"`
+	EvidenceFreshness []FreshnessClock         `json:"evidence_freshness,omitempty"`
+	ReviewHistory     []RelatedRecord          `json:"review_history,omitempty"`
+	Obligations       []VendorObligation       `json:"obligations,omitempty"`
+	Owners            []RelatedRecord          `json:"owners,omitempty"`
+	Contacts          []RelatedRecord          `json:"contacts,omitempty"`
+	Identifiers       []RelatedRecord          `json:"identifiers,omitempty"`
+	FourthParties     []RelatedRecord          `json:"fourth_parties,omitempty"`
+	FindingCounts     VendorFindingCounts      `json:"finding_counts"`
+	NextActions       []VendorAction           `json:"next_actions,omitempty"`
+	CloseActions      []VendorCloseAction      `json:"close_actions,omitempty"`
+}
+
+type VendorPacketRisk struct {
+	InherentRiskLevel string   `json:"inherent_risk_level,omitempty"`
+	ResidualRiskLevel string   `json:"residual_risk_level,omitempty"`
+	RiskLevel         string   `json:"risk_level"`
+	DataSensitivity   string   `json:"data_sensitivity,omitempty"`
+	AccessLevel       string   `json:"access_level,omitempty"`
+	Criticality       string   `json:"criticality,omitempty"`
+	Subprocessor      string   `json:"subprocessor,omitempty"`
+	Geography         string   `json:"geography,omitempty"`
+	SystemDependency  string   `json:"system_dependency,omitempty"`
+	Drivers           []string `json:"drivers,omitempty"`
+}
+
+type VendorObligation struct {
+	ID        string     `json:"id"`
+	Label     string     `json:"label"`
+	Status    string     `json:"status"`
+	Source    string     `json:"source,omitempty"`
+	DueAt     *time.Time `json:"due_at,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Reason    string     `json:"reason,omitempty"`
 }
 
 type RelatedRecord struct {
@@ -262,7 +495,7 @@ func (s *Service) ListVendors(ctx context.Context, request ListVendorsRequest) (
 		vendors = append(vendors, vendor)
 	}
 	sortVendors(vendors)
-	if len(vendors) > limit {
+	if !request.DeferLimit && len(vendors) > limit {
 		vendors = vendors[:limit]
 	}
 	return vendors, nil
@@ -359,13 +592,15 @@ func (s *Service) GetVendor(ctx context.Context, request VendorDetailRequest) (*
 	if err != nil {
 		return nil, err
 	}
+	relationships := relationshipsFromRows(relatedRows)
 	graph, err := s.store.GetEntityNeighborhood(ctx, urn, normalizeNeighborhoodLimit(request.Limit))
 	if err != nil {
 		return nil, err
 	}
 	return &VendorDetail{
 		Vendor:        vendor,
-		Relationships: relationshipsFromRows(relatedRows),
+		Relationships: relationships,
+		Packet:        BuildVendorPacket(vendor, relationships),
 		Graph:         graph,
 	}, nil
 }
@@ -374,7 +609,7 @@ func Summarize(vendors []Vendor) Summary {
 	var summary Summary
 	summary.TotalVendors = len(vendors)
 	for _, vendor := range vendors {
-		if vendorIsActive(vendor.Status) {
+		if vendorLifecycleIsActive(vendor) {
 			summary.ActiveVendors++
 		}
 		if vendor.RiskLevel == "high" || vendor.RiskLevel == "critical" {
@@ -390,6 +625,39 @@ func Summarize(vendors []Vendor) Summary {
 			summary.ReviewDueSoonVendors++
 		case ReviewStateNotScheduled:
 			summary.ReviewNotScheduled++
+		}
+		if len(vendor.QueueReasons) > 0 {
+			summary.RiskQueueVendors++
+		}
+		if vendor.EvidenceFreshnessState == FreshnessStateStale || vendor.EvidenceFreshnessState == FreshnessStateExpired {
+			summary.StaleEvidenceVendors++
+		}
+		if vendor.LifecycleState == LifecycleStateRestricted || vendor.LifecycleState == LifecycleStateConditionallyApproved {
+			summary.RestrictedVendors++
+		}
+		if vendor.RiskTier == "tier_1" || vendor.RiskTier == "critical" {
+			summary.CriticalTierVendors++
+		}
+		if vendor.AssessmentState == ReviewStateOverdue || vendor.AssessmentState == ReviewStateDueSoon || vendor.AssessmentState == "in_progress" {
+			summary.AssessmentDueVendors++
+		}
+		if vendor.MonitoringState == "alert" || vendor.MonitoringState == "critical" {
+			summary.MonitoringAlertVendors++
+		}
+		if vendor.RenewalState == ReviewStateOverdue || vendor.RenewalState == ReviewStateDueSoon {
+			summary.RenewalDueVendors++
+		}
+		if vendor.PacketState == "blocked" || vendor.PacketState == "needs_work" {
+			summary.PacketBlockedVendors++
+		}
+		if vendor.ExposureLevel == "critical" || vendor.ExposureLevel == "high" {
+			summary.HighExposureVendors++
+		}
+		if vendor.RemediationState == ReviewStateOverdue || vendor.RemediationState == ReviewStateDueSoon {
+			summary.RemediationDueVendors++
+		}
+		if vendor.OffboardingState == ReviewStateOverdue || vendor.OffboardingState == ReviewStateDueSoon {
+			summary.OffboardingDueVendors++
 		}
 		summary.OpenFindings += vendor.OpenFindings
 		summary.CriticalFindings += vendor.CriticalFindings
@@ -480,7 +748,8 @@ func (s *Service) vendorFromRow(row ports.CypherRow) Vendor {
 	residualRisk := normalizeRiskLevel(attrs["residual_risk_level"])
 	riskLevel := firstNonEmpty(residualRisk, inherentRisk, normalizeRiskLevel(attrs["risk_level"]), "unknown")
 	urn := rowString(row, "urn")
-	return Vendor{
+	now := s.now()
+	vendor := Vendor{
 		VendorIdentity: VendorIdentity{
 			URN:              urn,
 			VendorID:         firstNonEmpty(attrs["vendor_id"], attrs["external_id"], urnTail(urn)),
@@ -488,10 +757,15 @@ func (s *Service) vendorFromRow(row ports.CypherRow) Vendor {
 			SourceID:         rowString(row, "source_id"),
 			RuntimeID:        rowString(row, "runtime_id"),
 			Provider:         firstNonEmpty(attrs["source_system"], attrs["provider"], rowString(row, "source_id")),
-			Status:           attrs["status"],
+			Status:           firstNonEmpty(attrs["status"], attrs["vendor_status"]),
 			Category:         attrs["category"],
 			WebsiteURL:       firstNonEmpty(attrs["website_url"], attrs["website"], attrs["url"], attrs["domain"]),
 			ServicesProvided: attrs["services_provided"],
+		},
+		VendorLifecycle: VendorLifecycle{
+			SourceStatus:    firstNonEmpty(attrs["source_status"], attrs["status"], attrs["vendor_status"]),
+			LifecycleState:  normalizeVendorLifecycleState(firstNonEmpty(attrs["lifecycle_state"], attrs["vendor_lifecycle_state"], attrs["status"], attrs["vendor_status"])),
+			LifecycleReason: firstNonEmpty(attrs["lifecycle_reason"], attrs["status_reason"], attrs["vendor_status_reason"]),
 		},
 		VendorOwnership: VendorOwnership{
 			SecurityOwnerUserID: attrs["security_owner_user_id"],
@@ -504,11 +778,30 @@ func (s *Service) vendorFromRow(row ports.CypherRow) Vendor {
 			ResidualRiskLevel: residualRisk,
 			RiskLevel:         riskLevel,
 		},
+		VendorRiskInputs: VendorRiskInputs{
+			DataSensitivity:  normalizeRiskInput(firstNonEmpty(attrs["data_sensitivity"], attrs["data_classification"], attrs["data_access_level"])),
+			AccessLevel:      normalizeRiskInput(firstNonEmpty(attrs["access_level"], attrs["access_type"], attrs["system_access"])),
+			Criticality:      normalizeRiskInput(firstNonEmpty(attrs["criticality"], attrs["business_criticality"], attrs["service_criticality"])),
+			Subprocessor:     normalizeBooleanish(firstNonEmpty(attrs["subprocessor"], attrs["is_subprocessor"], attrs["processor"])),
+			Geography:        firstNonEmpty(attrs["geography"], attrs["processing_region"], attrs["country"], attrs["region"]),
+			SystemDependency: normalizeRiskInput(firstNonEmpty(attrs["system_dependency"], attrs["dependency_level"], attrs["service_dependency"])),
+			RiskDrivers:      vendorRiskDrivers(attrs),
+		},
+		VendorControlPosture: VendorControlPosture{
+			DPAStatus:            normalizeDocumentStatus(attrs, now, "dpa", "data_processing_agreement"),
+			BAAStatus:            normalizeDocumentStatus(attrs, now, "baa", "business_associate_agreement"),
+			SOC2Status:           normalizeDocumentStatus(attrs, now, "soc2", "soc_2"),
+			ISO27001Status:       normalizeDocumentStatus(attrs, now, "iso27001", "iso_27001"),
+			SecurityReviewStatus: normalizeReviewPosture(firstNonEmpty(attrs["security_review_status"], attrs["review_status"]), reviewDueAt, lastReviewCompletedAt, now),
+			PrivacyReviewStatus:  normalizeReviewPosture(firstNonEmpty(attrs["privacy_review_status"], attrs["privacy_review_state"]), parseDateAttribute(attrs, "next_privacy_review_due_date"), parseDateAttribute(attrs, "last_privacy_review_completion_date"), now),
+			DocumentStatus:       normalizeDocumentStatus(attrs, now, "assurance_document", "document"),
+		},
 		VendorReviewPosture: VendorReviewPosture{
-			ReviewState:           reviewState(reviewDueAt, s.now()),
+			ReviewState:           reviewState(reviewDueAt, now),
 			ReviewDueAt:           reviewDueAt,
 			LastReviewCompletedAt: lastReviewCompletedAt,
 		},
+		VendorFreshnessPosture: vendorFreshnessPosture(attrs, now),
 		VendorContractDates: VendorContractDates{
 			ContractStartAt:       parseDateAttribute(attrs, "contract_start_date"),
 			ContractRenewalAt:     parseDateAttribute(attrs, "contract_renewal_date"),
@@ -522,6 +815,12 @@ func (s *Service) vendorFromRow(row ports.CypherRow) Vendor {
 		},
 		Attributes: attrs,
 	}
+	if vendor.LifecycleState == "" {
+		vendor.LifecycleState = LifecycleStateUnknown
+	}
+	vendor.VendorAssessmentPosture = vendorAssessmentPosture(vendor, now)
+	vendor.VendorCommercialPosture = vendorCommercialPosture(attrs, now)
+	return RefreshVendorQueuePosture(vendor, now)
 }
 
 func discoveryFromRow(row ports.CypherRow) VendorDiscovery {
@@ -549,7 +848,9 @@ func discoveryFromRow(row ports.CypherRow) VendorDiscovery {
 func hasDerivedFilter(request ListVendorsRequest) bool {
 	return strings.TrimSpace(request.RiskLevel) != "" ||
 		strings.TrimSpace(request.ReviewState) != "" ||
-		strings.TrimSpace(request.OwnerState) != ""
+		strings.TrimSpace(request.OwnerState) != "" ||
+		strings.TrimSpace(request.Lifecycle) != "" ||
+		request.QueueOnly
 }
 
 func hasDiscoveryDerivedFilter(request ListDiscoveriesRequest) bool {
@@ -570,6 +871,10 @@ func matchesVendorFilter(vendor Vendor, request ListVendorsRequest) bool {
 	if ownerState != "" && ownerState != "all" && vendor.OwnerState != ownerState {
 		return false
 	}
+	lifecycle := normalizeVendorLifecycleState(request.Lifecycle)
+	if lifecycle != "" && lifecycle != "all" && vendor.LifecycleState != lifecycle {
+		return false
+	}
 	return true
 }
 
@@ -583,6 +888,9 @@ func matchesDiscoveryFilter(discovery VendorDiscovery, request ListDiscoveriesRe
 
 func sortVendors(vendors []Vendor) {
 	sort.Slice(vendors, func(i, j int) bool {
+		if vendors[i].RiskQueueRank != vendors[j].RiskQueueRank {
+			return vendors[i].RiskQueueRank > vendors[j].RiskQueueRank
+		}
 		if riskRank(vendors[i].RiskLevel) != riskRank(vendors[j].RiskLevel) {
 			return riskRank(vendors[i].RiskLevel) > riskRank(vendors[j].RiskLevel)
 		}
@@ -613,6 +921,119 @@ func sortDiscoveries(discoveries []VendorDiscovery) {
 	})
 }
 
+func BuildVendorPacket(vendor Vendor, relationships VendorRelationships) VendorPacket {
+	reviewHistory := append([]RelatedRecord{}, relationships.SecurityReviews...)
+	reviewHistory = append(reviewHistory, relationships.SecurityQuestionnaires...)
+	reviewHistory = append(reviewHistory, relationships.AssuranceDocuments...)
+	reviewHistory = append(reviewHistory, relationships.Assessments...)
+	return VendorPacket{
+		Version:           "2026-06-28",
+		VendorURN:         vendor.URN,
+		Lifecycle:         vendor.VendorLifecycle,
+		Risk:              vendorPacketRisk(vendor),
+		RiskScore:         vendor.VendorRiskScoring,
+		Controls:          vendor.VendorControlPosture,
+		Assessments:       vendor.VendorAssessmentPosture,
+		Monitoring:        vendor.VendorMonitoringPosture,
+		Commercial:        vendor.VendorCommercialPosture,
+		Operations:        vendor.VendorOperationalPosture,
+		EvidenceFreshness: vendor.EvidenceFreshness,
+		ReviewHistory:     reviewHistory,
+		Obligations:       vendorObligations(vendor),
+		Owners:            append([]RelatedRecord{}, relationships.Owners...),
+		Contacts:          append([]RelatedRecord{}, relationships.Contacts...),
+		Identifiers:       append(append([]RelatedRecord{}, relationships.Hosts...), relationships.Aliases...),
+		FourthParties:     append([]RelatedRecord{}, relationships.FourthParties...),
+		FindingCounts:     vendor.VendorFindingCounts,
+		NextActions:       append([]VendorAction{}, vendor.NextActions...),
+		CloseActions:      append([]VendorCloseAction{}, vendor.CloseActions...),
+	}
+}
+
+func RefreshVendorQueuePosture(vendor Vendor, at ...time.Time) Vendor {
+	now := time.Now().UTC()
+	if len(at) > 0 && !at[0].IsZero() {
+		now = at[0].UTC()
+	}
+	vendor.VendorRiskScoring = vendorRiskScoring(vendor)
+	vendor.VendorMonitoringPosture = vendorMonitoringPosture(vendor)
+	vendor.VendorOperationalPosture = vendorOperationalPosture(vendor, now)
+	vendor.VendorQueuePosture = vendorQueuePosture(vendor)
+	return vendor
+}
+
+func SortAndLimitVendors(vendors []Vendor, limit uint32) []Vendor {
+	sortVendors(vendors)
+	normalized := normalizeVendorLimit(limit)
+	if len(vendors) > normalized {
+		return vendors[:normalized]
+	}
+	return vendors
+}
+
+func FilterVendorsByQueue(vendors []Vendor) []Vendor {
+	filtered := vendors[:0]
+	for _, vendor := range vendors {
+		vendor = RefreshVendorQueuePosture(vendor)
+		if len(vendor.QueueReasons) != 0 {
+			filtered = append(filtered, vendor)
+		}
+	}
+	return filtered
+}
+
+func vendorPacketRisk(vendor Vendor) VendorPacketRisk {
+	return VendorPacketRisk{
+		InherentRiskLevel: vendor.InherentRiskLevel,
+		ResidualRiskLevel: vendor.ResidualRiskLevel,
+		RiskLevel:         vendor.RiskLevel,
+		DataSensitivity:   vendor.DataSensitivity,
+		AccessLevel:       vendor.AccessLevel,
+		Criticality:       vendor.Criticality,
+		Subprocessor:      vendor.Subprocessor,
+		Geography:         vendor.Geography,
+		SystemDependency:  vendor.SystemDependency,
+		Drivers:           append([]string{}, vendor.RiskDrivers...),
+	}
+}
+
+func vendorObligations(vendor Vendor) []VendorObligation {
+	obligations := []VendorObligation{
+		vendorObligation("security_review", "Security review", vendor.SecurityReviewStatus, "review", vendor.ReviewDueAt, nil),
+		vendorObligation("dpa", "DPA", vendor.DPAStatus, "contract", nil, firstDate(vendor.Attributes, "dpa_expiry_date", "data_processing_agreement_expiry_date")),
+		vendorObligation("soc2", "SOC 2", vendor.SOC2Status, "assurance", nil, firstDate(vendor.Attributes, "soc2_expiry_date", "soc_2_expiry_date", "soc2_report_end_date")),
+		vendorObligation("iso27001", "ISO 27001", vendor.ISO27001Status, "assurance", nil, firstDate(vendor.Attributes, "iso27001_expiry_date", "iso_27001_expiry_date")),
+	}
+	if status := strings.TrimSpace(vendor.BAAStatus); status != "" && status != FreshnessStateUnknown {
+		obligations = append(obligations, vendorObligation("baa", "BAA", status, "contract", nil, firstDate(vendor.Attributes, "baa_expiry_date", "business_associate_agreement_expiry_date")))
+	}
+	return obligations
+}
+
+func vendorObligation(id string, label string, status string, source string, dueAt *time.Time, expiresAt *time.Time) VendorObligation {
+	normalized := strings.TrimSpace(status)
+	if normalized == "" {
+		normalized = FreshnessStateUnknown
+	}
+	obligation := VendorObligation{
+		ID:        id,
+		Label:     label,
+		Status:    normalized,
+		Source:    source,
+		DueAt:     dueAt,
+		ExpiresAt: expiresAt,
+	}
+	switch normalized {
+	case FreshnessStateMissing:
+		obligation.Reason = label + " is not attached"
+	case FreshnessStateExpired:
+		obligation.Reason = label + " is expired"
+	case ReviewStateOverdue:
+		obligation.Reason = label + " is overdue"
+	}
+	return obligation
+}
+
 func relationshipsFromRows(rows []ports.CypherRow) VendorRelationships {
 	var result VendorRelationships
 	for _, row := range rows {
@@ -629,10 +1050,18 @@ func relationshipsFromRows(rows []ports.CypherRow) VendorRelationships {
 			result.SecurityQuestionnaires = append(result.SecurityQuestionnaires, record)
 		case "assurance.document":
 			result.AssuranceDocuments = append(result.AssuranceDocuments, record)
+		case "vendor.assessment", "privacy.assessment", "security.assessment", "risk.assessment", "legal.assessment":
+			result.Assessments = append(result.Assessments, record)
 		case "grc.user", "user":
 			result.Owners = append(result.Owners, record)
 		case "internet.host":
 			result.Hosts = append(result.Hosts, record)
+		case "vendor.alias":
+			result.Aliases = append(result.Aliases, record)
+		case "vendor.contact", "contact":
+			result.Contacts = append(result.Contacts, record)
+		case "vendor.fourth_party", "fourth_party.vendor", "subprocessor":
+			result.FourthParties = append(result.FourthParties, record)
 		}
 	}
 	return result
@@ -648,6 +1077,895 @@ func relatedRecordFromRow(row ports.CypherRow) RelatedRecord {
 		Relation:   rowString(row, "relation"),
 		Attributes: parseAttributes(rowString(row, "attributes_json")),
 	}
+}
+
+func vendorRiskScoring(vendor Vendor) VendorRiskScoring {
+	factors := []RiskScoreFactor{
+		riskScoreFactor("risk_level", "Risk level", scoreForRiskLevel(vendor.RiskLevel), 16, firstNonEmpty(vendor.ResidualRiskLevel, vendor.InherentRiskLevel, vendor.RiskLevel)),
+		riskScoreFactor("data", "Data access", scoreForRiskInput(vendor.DataSensitivity), 14, vendor.DataSensitivity),
+		riskScoreFactor("access", "System access", scoreForRiskInput(vendor.AccessLevel), 12, vendor.AccessLevel),
+		riskScoreFactor("criticality", "Business criticality", maxInt(scoreForRiskInput(vendor.Criticality), scoreForRiskInput(vendor.SystemDependency)), 14, firstNonEmpty(vendor.Criticality, vendor.SystemDependency)),
+		riskScoreFactor("subprocessor", "Subprocessor", scoreForBooleanish(vendor.Subprocessor), 6, vendor.Subprocessor),
+		riskScoreFactor("controls", "Control gaps", scoreForControlPosture(vendor), 12, vendorControlRiskReason(vendor)),
+		riskScoreFactor("findings", "Open findings", scoreForFindings(vendor), 14, vendorFindingRiskReason(vendor)),
+		riskScoreFactor("freshness", "Evidence freshness", scoreForFreshness(vendor.EvidenceFreshnessState), 8, vendor.EvidenceFreshnessState),
+		riskScoreFactor("lifecycle", "Lifecycle", scoreForLifecycle(vendor.LifecycleState), 4, vendor.LifecycleState),
+	}
+	score := weightedRiskScore(factors)
+	source := "derived"
+	if explicit := intAttribute(vendor.Attributes, "risk_score", "vendor_risk_score", "current_risk_score"); explicit >= 0 {
+		score = clampPercent(explicit)
+		source = "attribute"
+	}
+	level := firstNonEmpty(normalizeRiskLevel(scoreLevel(score)), vendor.RiskLevel, "unknown")
+	tier := vendorRiskTier(score, vendor)
+	return VendorRiskScoring{
+		RiskScore:         score,
+		RiskScoreLevel:    level,
+		RiskScoreSource:   source,
+		RiskTier:          tier,
+		ReviewCadenceDays: reviewCadenceDays(tier, score),
+		ScoreFactors:      factors,
+	}
+}
+
+func riskScoreFactor(id string, label string, score int, weight int, reason string) RiskScoreFactor {
+	return RiskScoreFactor{ID: id, Label: label, Score: clampPercent(score), Weight: weight, Reason: strings.TrimSpace(reason)}
+}
+
+func weightedRiskScore(factors []RiskScoreFactor) int {
+	totalWeight := 0
+	total := 0
+	for _, factor := range factors {
+		if factor.Weight <= 0 {
+			continue
+		}
+		totalWeight += factor.Weight
+		total += clampPercent(factor.Score) * factor.Weight
+	}
+	if totalWeight == 0 {
+		return 0
+	}
+	return clampPercent((total + (totalWeight / 2)) / totalWeight)
+}
+
+func scoreForRiskLevel(level string) int {
+	switch normalizeRiskLevel(level) {
+	case "critical":
+		return 95
+	case "high":
+		return 78
+	case "medium":
+		return 52
+	case "low":
+		return 22
+	default:
+		return 38
+	}
+}
+
+func scoreForRiskInput(value string) int {
+	normalized := normalizeRiskInput(value)
+	switch normalized {
+	case "critical", "tier_1", "tier_0", "mission_critical", "admin", "privileged", "restricted", "sensitive", "confidential", "phi", "pii", "pci", "production", "write":
+		return 90
+	case "high", "tier_2", "important", "internal", "personal_data", "read_write", "sso":
+		return 72
+	case "medium", "moderate", "tier_3", "business":
+		return 50
+	case "low", "minimal", "public", "none", "read_only", "false":
+		return 18
+	case "":
+		return 35
+	default:
+		if strings.Contains(normalized, "sensitive") || strings.Contains(normalized, "critical") || strings.Contains(normalized, "admin") {
+			return 84
+		}
+		return 45
+	}
+}
+
+func scoreForBooleanish(value string) int {
+	switch normalizeBooleanish(value) {
+	case "true":
+		return 68
+	case "false":
+		return 10
+	case "":
+		return 30
+	default:
+		return scoreForRiskInput(value)
+	}
+}
+
+func scoreForControlPosture(vendor Vendor) int {
+	score := 0
+	for _, status := range []string{vendor.DPAStatus, vendor.SOC2Status, vendor.ISO27001Status, vendor.SecurityReviewStatus, vendor.PrivacyReviewStatus} {
+		switch status {
+		case FreshnessStateExpired, ReviewStateOverdue:
+			score = maxInt(score, 86)
+		case FreshnessStateMissing, ReviewStateNotScheduled:
+			score = maxInt(score, 72)
+		case FreshnessStateStale, ReviewStateDueSoon:
+			score = maxInt(score, 52)
+		}
+	}
+	return score
+}
+
+func vendorControlRiskReason(vendor Vendor) string {
+	reasons := []string{}
+	for _, item := range []struct {
+		label  string
+		status string
+	}{
+		{"DPA", vendor.DPAStatus},
+		{"SOC 2", vendor.SOC2Status},
+		{"ISO 27001", vendor.ISO27001Status},
+		{"Security review", vendor.SecurityReviewStatus},
+		{"Privacy review", vendor.PrivacyReviewStatus},
+	} {
+		if item.status == FreshnessStateMissing || item.status == FreshnessStateExpired || item.status == ReviewStateOverdue {
+			reasons = append(reasons, item.label+" "+item.status)
+		}
+	}
+	return strings.Join(reasons, ", ")
+}
+
+func scoreForFindings(vendor Vendor) int {
+	switch {
+	case vendor.CriticalFindings > 0:
+		return 100
+	case vendor.HighFindings > 0:
+		return 82
+	case vendor.OpenFindings > 0:
+		return 55
+	default:
+		return 0
+	}
+}
+
+func vendorFindingRiskReason(vendor Vendor) string {
+	switch {
+	case vendor.CriticalFindings > 0:
+		return fmt.Sprintf("%d critical open", vendor.CriticalFindings)
+	case vendor.HighFindings > 0:
+		return fmt.Sprintf("%d high open", vendor.HighFindings)
+	case vendor.OpenFindings > 0:
+		return fmt.Sprintf("%d open", vendor.OpenFindings)
+	default:
+		return "no open findings"
+	}
+}
+
+func scoreForFreshness(state string) int {
+	switch state {
+	case FreshnessStateExpired:
+		return 80
+	case FreshnessStateStale:
+		return 62
+	case FreshnessStateMissing:
+		return 40
+	case FreshnessStateCurrent:
+		return 8
+	default:
+		return 32
+	}
+}
+
+func scoreForLifecycle(state string) int {
+	switch state {
+	case LifecycleStateRestricted:
+		return 72
+	case LifecycleStateConditionallyApproved:
+		return 55
+	case LifecycleStateCandidate, LifecycleStateDiscovered, LifecycleStateInReview:
+		return 42
+	case LifecycleStateApproved, LifecycleStateActive:
+		return 10
+	case LifecycleStateRetired, LifecycleStateRejected, LifecycleStateIgnored:
+		return 0
+	default:
+		return 30
+	}
+}
+
+func scoreLevel(score int) string {
+	switch {
+	case score >= 85:
+		return "critical"
+	case score >= 65:
+		return "high"
+	case score >= 35:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func vendorRiskTier(score int, vendor Vendor) string {
+	if explicit := normalizeRiskInput(firstNonEmpty(vendor.Attributes["risk_tier"], vendor.Attributes["vendor_tier"], vendor.Attributes["tier"])); explicit != "" {
+		return explicit
+	}
+	if score >= 80 || scoreForRiskInput(vendor.Criticality) >= 90 || scoreForRiskInput(vendor.SystemDependency) >= 90 {
+		return "tier_1"
+	}
+	if score >= 60 || scoreForRiskInput(vendor.DataSensitivity) >= 72 || scoreForRiskInput(vendor.AccessLevel) >= 72 {
+		return "tier_2"
+	}
+	if score >= 35 {
+		return "tier_3"
+	}
+	return "tier_4"
+}
+
+func reviewCadenceDays(tier string, score int) int {
+	switch normalizeRiskInput(tier) {
+	case "tier_1", "critical":
+		return 180
+	case "tier_2", "high":
+		return 365
+	case "tier_3", "medium":
+		return 730
+	case "tier_4", "low":
+		return 1095
+	default:
+		if score >= 80 {
+			return 180
+		}
+		if score >= 60 {
+			return 365
+		}
+		if score >= 35 {
+			return 730
+		}
+		return 1095
+	}
+}
+
+func vendorAssessmentPosture(vendor Vendor, now time.Time) VendorAssessmentPosture {
+	attrs := vendor.Attributes
+	openAssessments := maxInt(intAttribute(attrs, "open_assessment_count", "open_assessments"), 0)
+	completedAssessments := maxInt(intAttribute(attrs, "completed_assessment_count", "completed_assessments"), 0)
+	if vendor.SecurityReviewCount > completedAssessments {
+		completedAssessments = vendor.SecurityReviewCount
+	}
+	if vendor.QuestionnaireCount > 0 && completedAssessments == 0 {
+		completedAssessments = vendor.QuestionnaireCount
+	}
+	state := normalizeAssessmentState(firstNonEmpty(attrs["assessment_state"], attrs["assessment_status"], attrs["vendor_assessment_status"]))
+	if state == "" {
+		state = vendor.ReviewState
+		if openAssessments > 0 {
+			state = "in_progress"
+		}
+		if state == ReviewStateCurrent && completedAssessments == 0 && vendor.QuestionnaireCount == 0 {
+			state = FreshnessStateMissing
+		}
+	}
+	progress := intAttribute(attrs, "assessment_progress", "assessment_progress_pct", "assessment_progress_percent")
+	if progress < 0 {
+		progress = inferredProgressForState(state)
+	}
+	questionnaireState := normalizeAssessmentState(firstNonEmpty(attrs["questionnaire_state"], attrs["questionnaire_status"]))
+	if questionnaireState == "" && vendor.QuestionnaireCount > 0 {
+		questionnaireState = FreshnessStateCurrent
+	}
+	questionnaireProgress := intAttribute(attrs, "questionnaire_progress", "questionnaire_progress_pct", "questionnaire_progress_percent")
+	if questionnaireProgress < 0 {
+		questionnaireProgress = inferredProgressForState(questionnaireState)
+	}
+	nextAssessmentAt := firstDate(attrs, "next_assessment_due_date", "assessment_due_date", "next_vendor_review_due_date")
+	if nextAssessmentAt == nil {
+		nextAssessmentAt = vendor.ReviewDueAt
+	}
+	if state == ReviewStateCurrent && nextAssessmentAt != nil {
+		state = dateState(nextAssessmentAt, now, dueSoonDays)
+	}
+	return VendorAssessmentPosture{
+		AssessmentState:       state,
+		AssessmentProgress:    clampPercent(progress),
+		OpenAssessments:       openAssessments,
+		CompletedAssessments:  completedAssessments,
+		AssessmentTypes:       dedupeStrings(splitAttribute(firstNonEmpty(attrs["assessment_types"], attrs["assessment_type"], attrs["review_types"]))),
+		QuestionnaireState:    questionnaireState,
+		QuestionnaireProgress: clampPercent(questionnaireProgress),
+		LastAssessmentAt:      firstDate(attrs, "last_assessment_completed_at", "last_assessment_date", "last_security_review_completion_date"),
+		NextAssessmentAt:      nextAssessmentAt,
+	}
+}
+
+func normalizeAssessmentState(value string) string {
+	normalized := normalizeDocumentStatusValue(value)
+	switch normalized {
+	case "open", "pending", "started", "in_review", "review":
+		return "in_progress"
+	case "passed", "approved", "complete", "completed":
+		return FreshnessStateCurrent
+	default:
+		return normalized
+	}
+}
+
+func inferredProgressForState(state string) int {
+	switch state {
+	case FreshnessStateCurrent:
+		return 100
+	case "in_progress":
+		return 50
+	case ReviewStateDueSoon:
+		return 25
+	case ReviewStateOverdue, FreshnessStateMissing, "":
+		return 0
+	default:
+		return 0
+	}
+}
+
+func vendorCommercialPosture(attrs map[string]string, now time.Time) VendorCommercialPosture {
+	renewalNoticeAt := firstDate(attrs, "renewal_notice_date", "contract_notice_date", "renewal_notice_at")
+	return VendorCommercialPosture{
+		SpendAmount:      firstNonEmpty(attrs["annual_spend"], attrs["spend_amount"], attrs["vendor_spend"]),
+		SpendCurrency:    firstNonEmpty(attrs["spend_currency"], attrs["currency"]),
+		ContractValue:    firstNonEmpty(attrs["contract_value"], attrs["annual_contract_value"]),
+		ContractCurrency: firstNonEmpty(attrs["contract_currency"], attrs["currency"]),
+		RenewalNoticeAt:  renewalNoticeAt,
+		RenewalState:     dateState(renewalNoticeAt, now, 90),
+		PrimaryContact:   firstNonEmpty(attrs["primary_contact"], attrs["vendor_contact"], attrs["account_manager"], attrs["contact_email"]),
+		BusinessUnit:     firstNonEmpty(attrs["business_unit"], attrs["department"]),
+		CostCenter:       attrs["cost_center"],
+	}
+}
+
+func vendorMonitoringPosture(vendor Vendor) VendorMonitoringPosture {
+	attrs := vendor.Attributes
+	signals := []VendorMonitoringSignal{}
+	add := func(signal VendorMonitoringSignal) {
+		if strings.TrimSpace(signal.ID) == "" || strings.TrimSpace(signal.Label) == "" {
+			return
+		}
+		if strings.TrimSpace(signal.Severity) == "" {
+			signal.Severity = "medium"
+		}
+		signals = append(signals, signal)
+	}
+	if vendor.CriticalFindings > 0 {
+		add(vendorMonitoringSignal("critical_findings", "Critical findings open", "critical", "findings", nil, fmt.Sprintf("%d critical findings", vendor.CriticalFindings)))
+	} else if vendor.HighFindings > 0 {
+		add(vendorMonitoringSignal("high_findings", "High findings open", "high", "findings", nil, fmt.Sprintf("%d high findings", vendor.HighFindings)))
+	}
+	if vendor.EvidenceFreshnessState == FreshnessStateExpired || vendor.EvidenceFreshnessState == FreshnessStateStale {
+		add(vendorMonitoringSignal("freshness", "Evidence "+vendor.EvidenceFreshnessState, "medium", "evidence", nil, "Freshness clock requires review"))
+	}
+	if vendor.LifecycleState == LifecycleStateRestricted || vendor.LifecycleState == LifecycleStateConditionallyApproved {
+		add(vendorMonitoringSignal("lifecycle", "Vendor "+strings.ReplaceAll(vendor.LifecycleState, "_", " "), "medium", "lifecycle", nil, "Lifecycle condition requires review"))
+	}
+	externalRating := firstNonEmpty(attrs["external_security_rating"], attrs["security_rating"], attrs["external_rating"])
+	if badExternalRating(externalRating) {
+		add(vendorMonitoringSignal("external_rating", "External rating "+externalRating, "high", "external_rating", firstDate(attrs, "external_rating_updated_at", "security_rating_updated_at"), "External monitoring rating requires review"))
+	}
+	if count := intAttribute(attrs, "breached_credential_count", "leaked_credential_count"); count > 0 {
+		add(vendorMonitoringSignal("breached_credentials", "Breached credentials", "high", "external_intel", firstDate(attrs, "breached_credentials_observed_at"), fmt.Sprintf("%d exposed credentials", count)))
+	}
+	if count := intAttribute(attrs, "security_incident_count", "public_incident_count"); count > 0 {
+		add(vendorMonitoringSignal("public_incidents", "Public incidents", "high", "external_intel", firstDate(attrs, "last_security_incident_at", "last_public_incident_at"), fmt.Sprintf("%d incidents", count)))
+	}
+	if materialChangeAt := firstDate(attrs, "last_material_change_at", "last_vendor_change_at", "material_change_at"); materialChangeAt != nil {
+		add(vendorMonitoringSignal("material_change", "Material change", "medium", "source", materialChangeAt, "Vendor profile changed"))
+	}
+	state := "clear"
+	for _, signal := range signals {
+		switch signal.Severity {
+		case "critical":
+			state = "critical"
+		case "high":
+			if state != "critical" {
+				state = "alert"
+			}
+		case "medium":
+			if state == "clear" {
+				state = "watch"
+			}
+		}
+	}
+	if override := normalizeRiskInput(attrs["monitoring_state"]); override != "" {
+		state = override
+	}
+	return VendorMonitoringPosture{
+		MonitoringState:         state,
+		MonitoringSignals:       signals,
+		ExternalRating:          externalRating,
+		ExternalRatingUpdatedAt: firstDate(attrs, "external_rating_updated_at", "security_rating_updated_at"),
+		LastMaterialChangeAt:    firstDate(attrs, "last_material_change_at", "last_vendor_change_at", "material_change_at"),
+	}
+}
+
+func vendorMonitoringSignal(id string, label string, severity string, source string, observedAt *time.Time, reason string) VendorMonitoringSignal {
+	return VendorMonitoringSignal{ID: id, Label: label, Severity: severity, Source: source, ObservedAt: observedAt, Reason: reason}
+}
+
+func vendorOperationalPosture(vendor Vendor, now time.Time) VendorOperationalPosture {
+	exposureLevel, exposureReasons := vendorExposurePosture(vendor)
+	packetReadyItems, packetMissingItems := vendorPacketReadiness(vendor)
+	remediationDueAt := firstDate(vendor.Attributes, "next_remediation_due_date", "remediation_due_date", "risk_treatment_due_date", "finding_sla_due_date")
+	openRemediationItems := maxInt(intAttribute(vendor.Attributes, "open_remediation_count", "open_remediation_items", "open_risk_treatment_count"), 0)
+	if openRemediationItems == 0 {
+		openRemediationItems = vendor.OpenFindings
+	}
+	overdueRemediationItems := maxInt(intAttribute(vendor.Attributes, "overdue_remediation_count", "overdue_remediation_items", "overdue_risk_treatment_count"), 0)
+	remediationState := normalizeOperationalState(firstNonEmpty(vendor.Attributes["remediation_state"], vendor.Attributes["risk_treatment_state"], vendor.Attributes["remediation_status"]))
+	if remediationState == "" {
+		remediationState = remediationStateFromCounts(openRemediationItems, remediationDueAt, now)
+	}
+	if remediationState == ReviewStateOverdue && overdueRemediationItems == 0 && openRemediationItems > 0 {
+		overdueRemediationItems = openRemediationItems
+	}
+	offboardingDueAt := firstDate(vendor.Attributes, "offboarding_due_date", "termination_due_date", "vendor_offboarding_due_date", "data_deletion_due_date")
+	dataDeletionState := normalizeOperationalState(firstNonEmpty(vendor.Attributes["data_deletion_state"], vendor.Attributes["data_deletion_status"], vendor.Attributes["data_return_status"]))
+	if dataDeletionState == "" {
+		dataDeletionState = FreshnessStateUnknown
+	}
+	offboardingState := normalizeOperationalState(firstNonEmpty(vendor.Attributes["offboarding_state"], vendor.Attributes["offboarding_status"]))
+	if offboardingState == "" {
+		offboardingState = offboardingStateFromLifecycle(vendor, offboardingDueAt, now)
+	}
+	return VendorOperationalPosture{
+		ExposureLevel:           exposureLevel,
+		ExposureReasons:         exposureReasons,
+		PacketState:             vendorPacketState(vendor, packetMissingItems),
+		PacketReadyItems:        packetReadyItems,
+		PacketMissingItems:      packetMissingItems,
+		RemediationState:        remediationState,
+		RemediationDueAt:        remediationDueAt,
+		OpenRemediationItems:    openRemediationItems,
+		OverdueRemediationItems: overdueRemediationItems,
+		OffboardingState:        offboardingState,
+		OffboardingDueAt:        offboardingDueAt,
+		DataDeletionState:       dataDeletionState,
+	}
+}
+
+func vendorExposurePosture(vendor Vendor) (string, []string) {
+	score := 0
+	reasons := []string{}
+	add := func(reason string, value int) {
+		if strings.TrimSpace(reason) != "" {
+			reasons = append(reasons, reason)
+		}
+		score = maxInt(score, value)
+	}
+	if value := scoreForRiskInput(vendor.DataSensitivity); value >= 72 {
+		add("Sensitive data", value)
+	}
+	if value := scoreForRiskInput(vendor.AccessLevel); value >= 72 {
+		add("Privileged access", value)
+	}
+	if value := maxInt(scoreForRiskInput(vendor.Criticality), scoreForRiskInput(vendor.SystemDependency)); value >= 72 {
+		add("Business-critical service", value)
+	}
+	if normalizeBooleanish(vendor.Subprocessor) == "true" {
+		add("Fourth-party dependency", 68)
+	}
+	for _, item := range []struct {
+		key    string
+		label  string
+		weight int
+	}{
+		{"internet_exposed", "Internet-facing service", 72},
+		{"customer_data", "Customer data", 72},
+		{"regulated_data", "Regulated data", 86},
+		{"payment_data", "Payment data", 86},
+		{"health_data", "Health data", 86},
+		{"employee_data", "Employee data", 64},
+		{"ai_data_use", "AI data use", 58},
+	} {
+		if normalizeBooleanish(vendor.Attributes[item.key]) == "true" {
+			add(item.label, item.weight)
+		}
+	}
+	if explicit := normalizeRiskLevel(firstNonEmpty(vendor.Attributes["exposure_level"], vendor.Attributes["vendor_exposure_level"])); explicit != "" {
+		return explicit, dedupeStrings(reasons)
+	}
+	score = maxInt(score, vendor.RiskScore)
+	switch {
+	case score >= 85:
+		return "critical", dedupeStrings(reasons)
+	case score >= 65:
+		return "high", dedupeStrings(reasons)
+	case score >= 35:
+		return "medium", dedupeStrings(reasons)
+	default:
+		return "low", dedupeStrings(reasons)
+	}
+}
+
+func vendorPacketReadiness(vendor Vendor) ([]string, []string) {
+	ready := []string{}
+	missing := []string{}
+	add := func(label string, ok bool) {
+		if ok {
+			ready = append(ready, label)
+			return
+		}
+		missing = append(missing, label)
+	}
+	add("Owner", vendor.OwnerState == OwnerStateAssigned)
+	add("Security review", vendor.ReviewState == ReviewStateCurrent || vendor.ReviewState == ReviewStateDueSoon)
+	add("DPA", vendor.DPAStatus == FreshnessStateCurrent || vendor.DPAStatus == "not_applicable")
+	add("Fresh evidence", vendor.EvidenceFreshnessState == FreshnessStateCurrent)
+	if vendor.RiskTier == "tier_1" || vendor.RiskTier == "tier_2" {
+		add("Assessment", vendor.AssessmentState == FreshnessStateCurrent || vendor.AssessmentState == ReviewStateDueSoon)
+		add("Vendor contact", strings.TrimSpace(vendor.PrimaryContact) != "")
+	}
+	add("Monitoring", vendor.MonitoringState == "clear" || vendor.MonitoringState == "watch" || vendor.MonitoringState == "")
+	add("Critical findings", vendor.CriticalFindings == 0)
+	return dedupeStrings(ready), dedupeStrings(missing)
+}
+
+func vendorPacketState(vendor Vendor, missing []string) string {
+	if len(missing) == 0 {
+		return "ready"
+	}
+	blocking := map[string]struct{}{
+		"Owner":             {},
+		"Security review":   {},
+		"DPA":               {},
+		"Critical findings": {},
+	}
+	if vendor.EvidenceFreshnessState == FreshnessStateExpired || vendor.MonitoringState == "critical" {
+		return "blocked"
+	}
+	for _, item := range missing {
+		if _, ok := blocking[item]; ok {
+			return "blocked"
+		}
+	}
+	return "needs_work"
+}
+
+func remediationStateFromCounts(openRemediationItems int, remediationDueAt *time.Time, now time.Time) string {
+	if openRemediationItems == 0 {
+		return FreshnessStateCurrent
+	}
+	if remediationDueAt == nil {
+		return "in_progress"
+	}
+	state := dateState(remediationDueAt, now, 14)
+	if state == ReviewStateCurrent {
+		return "in_progress"
+	}
+	return state
+}
+
+func offboardingStateFromLifecycle(vendor Vendor, offboardingDueAt *time.Time, now time.Time) string {
+	switch vendor.LifecycleState {
+	case LifecycleStateRetired:
+		return FreshnessStateCurrent
+	case LifecycleStateOffboarding:
+		state := dateState(offboardingDueAt, now, 14)
+		if state == "" || state == ReviewStateCurrent {
+			state = "in_progress"
+		}
+		return state
+	default:
+		return ""
+	}
+}
+
+func normalizeOperationalState(value string) string {
+	normalized := normalizeDocumentStatusValue(value)
+	switch normalized {
+	case "open", "pending", "started", "review", "in_review":
+		return "in_progress"
+	case "resolved", "closed", "complete", "completed":
+		return FreshnessStateCurrent
+	default:
+		return normalized
+	}
+}
+
+func badExternalRating(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "f", "d", "poor", "bad", "low", "critical", "high", "at_risk", "watch":
+		return true
+	default:
+		return false
+	}
+}
+
+func vendorFreshnessPosture(attrs map[string]string, now time.Time) VendorFreshnessPosture {
+	clocks := []FreshnessClock{
+		observedFreshnessClock("source_runtime", "Source runtime", "runtime", firstDate(attrs, "source_runtime_fresh_at", "last_source_sync_at", "last_synced_at", "source_last_seen_at", "last_observed_at"), daysAttribute(attrs, 2, "source_runtime_stale_after_days", "source_stale_after_days"), now),
+		observedFreshnessClock("artifact_age", "Artifact age", "artifact", firstDate(attrs, "artifact_created_at", "assurance_document_created_at", "document_created_at", "evidence_created_at"), daysAttribute(attrs, 365, "artifact_stale_after_days", "document_stale_after_days"), now),
+		observedFreshnessClock("review_completion", "Review completion", "review", firstDate(attrs, "last_security_review_completion_date", "last_review_completed_at", "review_completed_at"), daysAttribute(attrs, 365, "review_stale_after_days", "security_review_stale_after_days"), now),
+		expiryFreshnessClock("document_expiry", "Document expiry", "document", firstDate(attrs, "document_expiry_date", "assurance_document_expiry_date", "dpa_expiry_date", "soc2_expiry_date", "certificate_expiry_date"), now),
+		observedFreshnessClock("control_evidence", "Control evidence", "control", firstDate(attrs, "last_control_evidence_at", "control_evidence_updated_at", "last_evidence_at"), daysAttribute(attrs, 90, "control_evidence_stale_after_days", "evidence_stale_after_days"), now),
+	}
+	return VendorFreshnessPosture{
+		EvidenceFreshnessState: overallFreshnessState(clocks),
+		EvidenceFreshness:      clocks,
+	}
+}
+
+func observedFreshnessClock(id string, label string, source string, observedAt *time.Time, staleAfterDays int, now time.Time) FreshnessClock {
+	clock := FreshnessClock{
+		ID:             id,
+		Label:          label,
+		Source:         source,
+		Status:         FreshnessStateMissing,
+		ObservedAt:     observedAt,
+		StaleAfterDays: staleAfterDays,
+	}
+	if observedAt == nil {
+		clock.Reason = label + " timestamp is missing"
+		return clock
+	}
+	clock.AgeDays = ageDays(*observedAt, now)
+	clock.Status = FreshnessStateCurrent
+	clock.Reason = label + " is within freshness window"
+	if staleAfterDays > 0 && clock.AgeDays > staleAfterDays {
+		clock.Status = FreshnessStateStale
+		clock.Reason = fmt.Sprintf("%s is %d days old", label, clock.AgeDays)
+	}
+	return clock
+}
+
+func expiryFreshnessClock(id string, label string, source string, expiresAt *time.Time, now time.Time) FreshnessClock {
+	clock := FreshnessClock{
+		ID:        id,
+		Label:     label,
+		Source:    source,
+		Status:    FreshnessStateMissing,
+		ExpiresAt: expiresAt,
+	}
+	if expiresAt == nil {
+		clock.Reason = label + " date is missing"
+		return clock
+	}
+	clock.Status = FreshnessStateCurrent
+	clock.Reason = label + " is current"
+	if dateBefore(*expiresAt, now) {
+		clock.Status = FreshnessStateExpired
+		clock.Reason = label + " is expired"
+	}
+	return clock
+}
+
+func overallFreshnessState(clocks []FreshnessClock) string {
+	hasStale := false
+	hasMissing := false
+	hasCurrent := false
+	for _, clock := range clocks {
+		switch clock.Status {
+		case FreshnessStateExpired:
+			return FreshnessStateExpired
+		case FreshnessStateStale:
+			hasStale = true
+		case FreshnessStateMissing:
+			hasMissing = true
+		case FreshnessStateCurrent:
+			hasCurrent = true
+		}
+	}
+	switch {
+	case hasStale:
+		return FreshnessStateStale
+	case hasMissing:
+		return FreshnessStateMissing
+	case hasCurrent:
+		return FreshnessStateCurrent
+	default:
+		return FreshnessStateUnknown
+	}
+}
+
+func vendorQueuePosture(vendor Vendor) VendorQueuePosture {
+	var posture VendorQueuePosture
+	if !vendorLifecycleIsQueueable(vendor) {
+		return posture
+	}
+	addQueueItem := func(rank int, reason string, action VendorAction, closeAction VendorCloseAction) {
+		if strings.TrimSpace(reason) == "" {
+			return
+		}
+		if rank > posture.RiskQueueRank {
+			posture.RiskQueueRank = rank
+		}
+		posture.QueueReasons = append(posture.QueueReasons, reason)
+		if action.ID != "" {
+			posture.NextActions = append(posture.NextActions, action)
+		}
+		if closeAction.ID != "" {
+			posture.CloseActions = append(posture.CloseActions, closeAction)
+		}
+	}
+	if vendor.OwnerState == OwnerStateMissing {
+		addQueueItem(80, "owner missing", vendorAction("assign_owner", "Assign owner", "Owner missing", "owner", OwnerStateAssigned, 80), vendorCloseAction("owner_restored", "Owner restored", "Set security_owner_user_id or business_owner_user_id", "grc-vendor-review-overdue"))
+	}
+	switch vendor.ReviewState {
+	case ReviewStateOverdue:
+		addQueueItem(75, "review overdue", vendorAction("complete_review", "Complete review", "Security review overdue", "review", ReviewStateCurrent, 75), vendorCloseAction("review_current", "Review current", "Complete review or move next_security_review_due_date forward", "grc-vendor-review-overdue"))
+	case ReviewStateDueSoon:
+		addQueueItem(45, "review due soon", vendorAction("schedule_review", "Schedule review", "Security review due soon", "review", ReviewStateCurrent, 45), VendorCloseAction{})
+	case ReviewStateNotScheduled:
+		addQueueItem(35, "review not scheduled", vendorAction("set_review_due_date", "Set review date", "No review due date", "review", ReviewStateCurrent, 35), VendorCloseAction{})
+	}
+	if vendor.DPAStatus == FreshnessStateMissing || vendor.DPAStatus == FreshnessStateExpired {
+		addQueueItem(65, "DPA "+vendor.DPAStatus, vendorAction("attach_dpa", "Attach DPA", "DPA "+vendor.DPAStatus, "document", FreshnessStateCurrent, 65), vendorCloseAction("dpa_attached", "DPA attached", "Attach a current DPA or mark DPA not applicable", "vendor-dpa"))
+	}
+	if vendor.EvidenceFreshnessState == FreshnessStateStale || vendor.EvidenceFreshnessState == FreshnessStateExpired {
+		addQueueItem(60, "evidence "+vendor.EvidenceFreshnessState, vendorAction("refresh_evidence", "Refresh evidence", "Evidence "+vendor.EvidenceFreshnessState, "evidence", FreshnessStateCurrent, 60), vendorCloseAction("evidence_refreshed", "Evidence refreshed", "Attach fresh evidence or update source freshness timestamps", "vendor-evidence"))
+	}
+	if vendor.CriticalFindings > 0 {
+		addQueueItem(90, "critical findings open", vendorAction("resolve_critical_findings", "Resolve critical findings", "Critical findings open", "finding", "resolved", 90), vendorCloseAction("critical_findings_resolved", "Critical findings resolved", "Resolve or risk-accept all linked critical findings", "vendor-findings"))
+	} else if vendor.HighFindings > 0 {
+		addQueueItem(70, "high findings open", vendorAction("resolve_high_findings", "Resolve high findings", "High findings open", "finding", "resolved", 70), vendorCloseAction("high_findings_resolved", "High findings resolved", "Resolve or risk-accept all linked high findings", "vendor-findings"))
+	}
+	if vendor.LifecycleState == LifecycleStateRestricted || vendor.LifecycleState == LifecycleStateConditionallyApproved {
+		addQueueItem(55, vendor.LifecycleState, vendorAction("clear_vendor_condition", "Clear condition", "Vendor "+strings.ReplaceAll(vendor.LifecycleState, "_", " "), "lifecycle", LifecycleStateApproved, 55), vendorCloseAction("condition_cleared", "Condition cleared", "Move vendor to approved, offboarding, retired, or accepted restricted state", "vendor-lifecycle"))
+	}
+	switch vendor.AssessmentState {
+	case ReviewStateOverdue:
+		addQueueItem(72, "assessment overdue", vendorAction("complete_assessment", "Complete assessment", "Assessment overdue", "assessment", FreshnessStateCurrent, 72), vendorCloseAction("assessment_current", "Assessment current", "Complete the assessment or move next_assessment_due_date forward", "vendor-assessment"))
+	case "in_progress":
+		addQueueItem(50, "assessment in progress", vendorAction("finish_assessment", "Finish assessment", "Assessment in progress", "assessment", FreshnessStateCurrent, 50), vendorCloseAction("assessment_completed", "Assessment completed", "Complete the open assessment", "vendor-assessment"))
+	case FreshnessStateMissing:
+		addQueueItem(48, "assessment missing", vendorAction("start_assessment", "Start assessment", "Assessment missing", "assessment", "in_progress", 48), vendorCloseAction("assessment_started", "Assessment started", "Start or attach a vendor assessment", "vendor-assessment"))
+	}
+	if vendor.MonitoringState == "critical" || vendor.MonitoringState == "alert" {
+		addQueueItem(85, "monitoring alert", vendorAction("review_monitoring", "Review monitoring", "Monitoring alert", "monitoring", "clear", 85), vendorCloseAction("monitoring_clear", "Monitoring clear", "Resolve or accept active monitoring signals", "vendor-monitoring"))
+	}
+	switch vendor.PacketState {
+	case "blocked":
+		addQueueItem(82, "packet blocked", vendorAction("complete_vendor_packet", "Complete packet", "Vendor packet blocked", "packet", "ready", 82), vendorCloseAction("packet_ready", "Packet ready", "Clear missing packet items", "vendor-packet"))
+	case "needs_work":
+		addQueueItem(44, "packet needs work", vendorAction("finish_vendor_packet", "Finish packet", "Vendor packet needs work", "packet", "ready", 44), vendorCloseAction("packet_ready", "Packet ready", "Clear missing packet items", "vendor-packet"))
+	}
+	switch vendor.RemediationState {
+	case ReviewStateOverdue:
+		addQueueItem(88, "remediation overdue", vendorAction("complete_remediation", "Complete remediation", "Remediation overdue", "remediation", FreshnessStateCurrent, 88), vendorCloseAction("remediation_current", "Remediation current", "Resolve, accept, or move remediation due date forward", "vendor-remediation"))
+	case ReviewStateDueSoon:
+		addQueueItem(58, "remediation due soon", vendorAction("review_remediation", "Review remediation", "Remediation due soon", "remediation", FreshnessStateCurrent, 58), VendorCloseAction{})
+	}
+	if vendor.RenewalState == ReviewStateOverdue || vendor.RenewalState == ReviewStateDueSoon {
+		addQueueItem(42, "renewal "+vendor.RenewalState, vendorAction("review_renewal", "Review renewal", "Renewal "+vendor.RenewalState, "contract", ReviewStateCurrent, 42), VendorCloseAction{})
+	}
+	if vendor.OffboardingState == ReviewStateOverdue || vendor.OffboardingState == ReviewStateDueSoon || (vendor.LifecycleState == LifecycleStateOffboarding && vendor.DataDeletionState != FreshnessStateCurrent && vendor.DataDeletionState != "not_applicable") {
+		addQueueItem(62, "offboarding incomplete", vendorAction("complete_offboarding", "Complete offboarding", "Offboarding incomplete", "offboarding", FreshnessStateCurrent, 62), vendorCloseAction("offboarding_complete", "Offboarding complete", "Revoke access and complete data deletion or return", "vendor-offboarding"))
+	}
+	if vendor.PrimaryContact == "" && (vendor.RiskTier == "tier_1" || vendor.RiskTier == "tier_2") {
+		addQueueItem(38, "vendor contact missing", vendorAction("set_vendor_contact", "Set vendor contact", "Vendor contact missing", "contact", "assigned", 38), VendorCloseAction{})
+	}
+	return posture
+}
+
+func vendorAction(id string, label string, reason string, actionType string, targetState string, priority int) VendorAction {
+	return VendorAction{ID: id, Label: label, Reason: reason, ActionType: actionType, TargetState: targetState, Priority: priority}
+}
+
+func vendorCloseAction(id string, label string, closesWhen string, findingKey string) VendorCloseAction {
+	return VendorCloseAction{ID: id, Label: label, ClosesWhen: closesWhen, FindingKey: findingKey}
+}
+
+func normalizeVendorLifecycleState(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "":
+		return ""
+	case "all":
+		return "all"
+	case "new", "discovered", "shadow", "unreviewed":
+		return LifecycleStateDiscovered
+	case "candidate", "pending", "pending_review", "needs_review":
+		return LifecycleStateCandidate
+	case "active", "enabled", "current", "monitored":
+		return LifecycleStateActive
+	case "in_review", "review", "under_review":
+		return LifecycleStateInReview
+	case "approved", "complete", "completed":
+		return LifecycleStateApproved
+	case "conditionally_approved", "conditional", "approved_with_conditions":
+		return LifecycleStateConditionallyApproved
+	case "restricted", "limited":
+		return LifecycleStateRestricted
+	case "offboarding", "terminating", "decommissioning":
+		return LifecycleStateOffboarding
+	case "retired", "terminated", "offboarded", "inactive", "archived", "deleted", "disabled":
+		return LifecycleStateRetired
+	case "rejected", "denied":
+		return LifecycleStateRejected
+	case "ignored":
+		return LifecycleStateIgnored
+	default:
+		return normalized
+	}
+}
+
+func normalizeRiskInput(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return ""
+	}
+	return strings.ReplaceAll(normalized, " ", "_")
+}
+
+func normalizeBooleanish(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "true", "1", "yes", "y":
+		return "true"
+	case "false", "0", "no", "n":
+		return "false"
+	default:
+		return normalizeRiskInput(value)
+	}
+}
+
+func vendorRiskDrivers(attrs map[string]string) []string {
+	drivers := splitAttribute(firstNonEmpty(attrs["risk_drivers"], attrs["risk_reason"], attrs["risk_reasons"]))
+	for _, key := range []string{"data_sensitivity", "access_level", "criticality", "subprocessor", "geography", "system_dependency"} {
+		if value := strings.TrimSpace(attrs[key]); value != "" {
+			drivers = append(drivers, key+":"+normalizeRiskInput(value))
+		}
+	}
+	return dedupeStrings(drivers)
+}
+
+func normalizeDocumentStatus(attrs map[string]string, now time.Time, keys ...string) string {
+	for _, key := range keys {
+		if status := normalizeDocumentStatusValue(firstNonEmpty(attrs[key+"_status"], attrs[key+"_state"])); status != "" {
+			return status
+		}
+		if expiresAt := firstDate(attrs, key+"_expiry_date", key+"_expires_at", key+"_expiration_date"); expiresAt != nil && dateBefore(*expiresAt, now) {
+			return FreshnessStateExpired
+		}
+		if value := strings.ToLower(strings.TrimSpace(firstNonEmpty(attrs[key+"_attached"], attrs[key+"_signed"], attrs[key+"_available"], attrs[key]))); value != "" {
+			switch value {
+			case "true", "1", "yes", "signed", "attached", "available", "current", "complete", "completed":
+				return FreshnessStateCurrent
+			case "false", "0", "no", "missing", "not_found", "none":
+				return FreshnessStateMissing
+			case "not_applicable", "not applicable", "n/a", "na":
+				return "not_applicable"
+			}
+			return normalizeDocumentStatusValue(value)
+		}
+	}
+	return FreshnessStateUnknown
+}
+
+func normalizeDocumentStatusValue(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "":
+		return ""
+	case "attached", "signed", "available", "complete", "completed", "current", "valid":
+		return FreshnessStateCurrent
+	case "missing", "not_found", "none", "required":
+		return FreshnessStateMissing
+	case "expired":
+		return FreshnessStateExpired
+	case "stale":
+		return FreshnessStateStale
+	case "not_applicable", "not applicable", "n/a", "na":
+		return "not_applicable"
+	default:
+		return normalized
+	}
+}
+
+func normalizeReviewPosture(value string, dueAt *time.Time, completedAt *time.Time, now time.Time) string {
+	if status := normalizeDocumentStatusValue(value); status != "" {
+		return status
+	}
+	if dueAt != nil {
+		return reviewState(dueAt, now)
+	}
+	if completedAt != nil {
+		return FreshnessStateCurrent
+	}
+	return FreshnessStateMissing
 }
 
 func reviewState(dueAt *time.Time, now time.Time) string {
@@ -716,6 +2034,30 @@ func vendorIsActive(status string) bool {
 		return false
 	default:
 		return true
+	}
+}
+
+func vendorLifecycleIsActive(vendor Vendor) bool {
+	switch strings.ToLower(strings.TrimSpace(vendor.LifecycleState)) {
+	case LifecycleStateDiscovered, LifecycleStateCandidate, LifecycleStateActive, LifecycleStateInReview, LifecycleStateApproved, LifecycleStateConditionallyApproved, LifecycleStateRestricted, LifecycleStateUnknown:
+		return true
+	case LifecycleStateOffboarding, LifecycleStateRetired, LifecycleStateRejected, LifecycleStateIgnored:
+		return false
+	case "":
+		return vendorIsActive(vendor.Status)
+	default:
+		return vendorIsActive(firstNonEmpty(vendor.Status, vendor.LifecycleState))
+	}
+}
+
+func vendorLifecycleIsQueueable(vendor Vendor) bool {
+	switch strings.ToLower(strings.TrimSpace(vendor.LifecycleState)) {
+	case LifecycleStateRetired, LifecycleStateRejected, LifecycleStateIgnored:
+		return false
+	case LifecycleStateOffboarding:
+		return true
+	default:
+		return vendorLifecycleIsActive(vendor)
 	}
 }
 
@@ -825,6 +2167,122 @@ func parseDateAttribute(attrs map[string]string, key string) *time.Time {
 		return &utc
 	}
 	return nil
+}
+
+func firstDate(attrs map[string]string, keys ...string) *time.Time {
+	for _, key := range keys {
+		if parsed := parseDateAttribute(attrs, key); parsed != nil {
+			return parsed
+		}
+	}
+	return nil
+}
+
+func daysAttribute(attrs map[string]string, fallback int, keys ...string) int {
+	for _, key := range keys {
+		value := strings.TrimSpace(attrs[key])
+		if value == "" {
+			continue
+		}
+		var parsed int
+		if _, err := fmt.Sscanf(value, "%d", &parsed); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func intAttribute(attrs map[string]string, keys ...string) int {
+	for _, key := range keys {
+		value := strings.TrimSpace(attrs[key])
+		if value == "" {
+			continue
+		}
+		var parsed int
+		if _, err := fmt.Sscanf(value, "%d", &parsed); err == nil {
+			return parsed
+		}
+	}
+	return -1
+}
+
+func dateState(value *time.Time, now time.Time, dueSoonWindowDays int) string {
+	if value == nil {
+		return ""
+	}
+	today := time.Date(now.UTC().Year(), now.UTC().Month(), now.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	valueDay := time.Date(value.UTC().Year(), value.UTC().Month(), value.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	if valueDay.Before(today) {
+		return ReviewStateOverdue
+	}
+	if dueSoonWindowDays > 0 && !valueDay.After(today.AddDate(0, 0, dueSoonWindowDays)) {
+		return ReviewStateDueSoon
+	}
+	return ReviewStateCurrent
+}
+
+func ageDays(observedAt time.Time, now time.Time) int {
+	if now.IsZero() || observedAt.IsZero() || observedAt.After(now) {
+		return 0
+	}
+	return int(now.Sub(observedAt).Hours() / 24)
+}
+
+func dateBefore(left time.Time, right time.Time) bool {
+	if left.IsZero() || right.IsZero() {
+		return false
+	}
+	leftDay := time.Date(left.UTC().Year(), left.UTC().Month(), left.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	rightDay := time.Date(right.UTC().Year(), right.UTC().Month(), right.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	return leftDay.Before(rightDay)
+}
+
+func clampPercent(value int) int {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}
+
+func maxInt(left int, right int) int {
+	if left > right {
+		return left
+	}
+	return right
+}
+
+func splitAttribute(value string) []string {
+	fields := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';' || r == '|'
+	})
+	result := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if trimmed := strings.TrimSpace(field); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func dedupeStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
 }
 
 func normalizeVendorLimit(limit uint32) int {
@@ -1036,7 +2494,7 @@ LIMIT 1`
 
 const vendorRelationshipsQuery = `MATCH (v:Entity {urn: $urn})<-[rel:RELATION]-(e:Entity)
 WHERE rel.relation = 'associated_with'
-  AND e.entity_type IN ['contract', 'security.review', 'security.questionnaire', 'assurance.document']
+  AND e.entity_type IN ['contract', 'security.review', 'security.questionnaire', 'assurance.document', 'vendor.assessment', 'privacy.assessment', 'security.assessment', 'risk.assessment', 'legal.assessment']
 RETURN e.urn AS urn,
        e.entity_type AS entity_type,
        e.label AS label,
@@ -1046,8 +2504,8 @@ RETURN e.urn AS urn,
        coalesce(e.attributes_json, '{}') AS attributes_json
 UNION
 MATCH (v:Entity {urn: $urn})-[rel:RELATION]->(e:Entity)
-WHERE rel.relation IN ['owned_by', 'has_identifier']
-  AND e.entity_type IN ['grc.user', 'user', 'internet.host']
+WHERE rel.relation IN ['owned_by', 'has_identifier', 'has_contact', 'uses_subprocessor', 'depends_on']
+  AND e.entity_type IN ['grc.user', 'user', 'internet.host', 'vendor.alias', 'vendor.contact', 'contact', 'vendor.fourth_party', 'fourth_party.vendor', 'subprocessor']
 RETURN e.urn AS urn,
        e.entity_type AS entity_type,
        e.label AS label,

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -48,8 +48,8 @@ func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string
 func TestListVendorsDerivesPostureAndAppliesFilters(t *testing.T) {
 	store := &stubGraphStore{
 		rows: [][]ports.CypherRow{{
-			vendorRow("urn:cerebro:writer:vendor:vanta:acme", "Acme", `{"vendor_id":"acme","source_system":"vanta","status":"active","category":"analytics","inherent_risk_level":"High","next_security_review_due_date":"2026-01-10","services_provided":"Analytics processing"}`, 2, 1, 0, 1),
-			vendorRow("urn:cerebro:writer:vendor:vanta:beta", "Beta", `{"vendor_id":"beta","source_system":"vanta","status":"active","business_owner_user_id":"user-2","residual_risk_level":"Low","next_security_review_due_date":"2026-04-01"}`, 0, 0, 0, 0),
+			vendorRow("urn:cerebro:writer:vendor:vrm:acme", "Acme", `{"vendor_id":"acme","source_system":"vrm","status":"active","lifecycle_state":"conditionally_approved","category":"analytics","inherent_risk_level":"High","next_security_review_due_date":"2026-01-10","last_security_review_completion_date":"2024-01-01","review_stale_after_days":"365","source_runtime_fresh_at":"2026-01-19","artifact_created_at":"2026-01-01","document_expiry_date":"2026-05-01","last_control_evidence_at":"2026-01-15","data_sensitivity":"Restricted","access_level":"Admin","criticality":"Tier 1","subprocessor":"true","internet_exposed":"true","customer_data":"true","dpa_attached":"false","assessment_state":"in_progress","assessment_progress":"40","open_assessment_count":"1","assessment_types":"security,privacy","external_security_rating":"D","last_material_change_at":"2026-01-18","annual_spend":"120000","spend_currency":"USD","renewal_notice_date":"2026-02-01","open_remediation_count":"3","overdue_remediation_count":"1","remediation_due_date":"2026-01-18","services_provided":"Analytics processing"}`, 2, 1, 0, 1),
+			vendorRow("urn:cerebro:writer:vendor:vrm:beta", "Beta", `{"vendor_id":"beta","source_system":"vrm","status":"active","business_owner_user_id":"user-2","residual_risk_level":"Low","next_security_review_due_date":"2026-04-01"}`, 0, 0, 0, 0),
 		}},
 	}
 	service := New(store)
@@ -72,6 +72,33 @@ func TestListVendorsDerivesPostureAndAppliesFilters(t *testing.T) {
 	if vendor.Name != "Acme" || vendor.RiskLevel != "high" || vendor.OwnerState != OwnerStateMissing || vendor.ReviewState != ReviewStateOverdue {
 		t.Fatalf("vendor posture = %#v", vendor)
 	}
+	if vendor.LifecycleState != LifecycleStateConditionallyApproved || vendor.DataSensitivity != "restricted" || vendor.Subprocessor != "true" {
+		t.Fatalf("vendor lifecycle/risk inputs = %#v", vendor)
+	}
+	if vendor.EvidenceFreshnessState != FreshnessStateStale {
+		t.Fatalf("evidence freshness state = %q, want stale (%#v)", vendor.EvidenceFreshnessState, vendor.EvidenceFreshness)
+	}
+	if vendor.RiskScore == 0 || vendor.RiskTier != "tier_1" || len(vendor.ScoreFactors) == 0 {
+		t.Fatalf("risk scoring = %#v", vendor.VendorRiskScoring)
+	}
+	if vendor.AssessmentState != "in_progress" || vendor.AssessmentProgress != 40 || vendor.OpenAssessments != 1 {
+		t.Fatalf("assessment posture = %#v", vendor.VendorAssessmentPosture)
+	}
+	if vendor.MonitoringState != "alert" || len(vendor.MonitoringSignals) == 0 || vendor.ExternalRating != "D" {
+		t.Fatalf("monitoring posture = %#v", vendor.VendorMonitoringPosture)
+	}
+	if vendor.SpendAmount != "120000" || vendor.RenewalState != ReviewStateDueSoon {
+		t.Fatalf("commercial posture = %#v", vendor.VendorCommercialPosture)
+	}
+	if vendor.ExposureLevel != "critical" || len(vendor.ExposureReasons) == 0 || vendor.PacketState != "blocked" {
+		t.Fatalf("operational posture = %#v", vendor.VendorOperationalPosture)
+	}
+	if vendor.RemediationState != ReviewStateOverdue || vendor.OpenRemediationItems != 3 || vendor.OverdueRemediationItems != 1 {
+		t.Fatalf("remediation posture = %#v", vendor.VendorOperationalPosture)
+	}
+	if vendor.RiskQueueRank == 0 || len(vendor.QueueReasons) == 0 || len(vendor.NextActions) == 0 || len(vendor.CloseActions) == 0 {
+		t.Fatalf("vendor queue posture = %#v", vendor.VendorQueuePosture)
+	}
 	if vendor.ContractCount != 2 || vendor.SecurityReviewCount != 1 || vendor.AssuranceDocumentCount != 1 {
 		t.Fatalf("vendor counts = contracts %d reviews %d docs %d", vendor.ContractCount, vendor.SecurityReviewCount, vendor.AssuranceDocumentCount)
 	}
@@ -88,25 +115,125 @@ func TestListVendorsDerivesPostureAndAppliesFilters(t *testing.T) {
 	vendor.OpenFindings = 2
 	vendor.CriticalFindings = 1
 	vendor.EvidenceItems = 3
+	vendor = RefreshVendorQueuePosture(vendor)
 	summary := Summarize([]Vendor{vendor})
 	if summary.TotalVendors != 1 || summary.HighRiskVendors != 1 || summary.OwnerMissingVendors != 1 || summary.ReviewOverdueVendors != 1 {
 		t.Fatalf("summary posture = %#v", summary)
+	}
+	if summary.RiskQueueVendors != 1 || summary.StaleEvidenceVendors != 1 || summary.RestrictedVendors != 1 || summary.CriticalTierVendors != 1 || summary.AssessmentDueVendors != 1 || summary.MonitoringAlertVendors != 1 || summary.RenewalDueVendors != 1 {
+		t.Fatalf("summary queue posture = %#v", summary)
+	}
+	if summary.PacketBlockedVendors != 1 || summary.HighExposureVendors != 1 || summary.RemediationDueVendors != 1 {
+		t.Fatalf("summary operational posture = %#v", summary)
 	}
 	if summary.OpenFindings != 2 || summary.CriticalFindings != 1 || summary.EvidenceItems != 3 {
 		t.Fatalf("summary finding counts = %#v", summary)
 	}
 }
 
+func TestListVendorsCanDeferLimitUntilAfterEnrichment(t *testing.T) {
+	store := &stubGraphStore{
+		rows: [][]ports.CypherRow{{
+			vendorRow("urn:cerebro:writer:vendor:vrm:low", "Low", `{"vendor_id":"low","source_system":"vrm","status":"active","business_owner_user_id":"user-1","residual_risk_level":"Low","next_security_review_due_date":"2026-04-01"}`, 0, 0, 0, 0),
+			vendorRow("urn:cerebro:writer:vendor:vrm:critical-finding", "Critical Finding", `{"vendor_id":"critical-finding","source_system":"vrm","status":"active","business_owner_user_id":"user-2","residual_risk_level":"Low","next_security_review_due_date":"2026-04-01"}`, 0, 0, 0, 0),
+		}},
+	}
+	service := New(store)
+	service.now = func() time.Time { return time.Date(2026, 1, 20, 12, 0, 0, 0, time.UTC) }
+
+	vendors, err := service.ListVendors(context.Background(), ListVendorsRequest{
+		TenantID:   "writer",
+		QueueOnly:  true,
+		DeferLimit: true,
+		Limit:      1,
+	})
+	if err != nil {
+		t.Fatalf("ListVendors() error = %v", err)
+	}
+	if len(vendors) != 2 {
+		t.Fatalf("vendors len = %d, want deferred untruncated rows", len(vendors))
+	}
+	if store.requests[0].RowLimit != maxVendorLimit {
+		t.Fatalf("row limit = %d, want queue prefetch limit %d", store.requests[0].RowLimit, maxVendorLimit)
+	}
+	for index := range vendors {
+		if vendors[index].VendorID == "critical-finding" {
+			vendors[index].CriticalFindings = 1
+			vendors[index] = RefreshVendorQueuePosture(vendors[index], service.now())
+		}
+	}
+	final := SortAndLimitVendors(FilterVendorsByQueue(vendors), 1)
+	if len(final) != 1 || final[0].VendorID != "critical-finding" || final[0].RiskQueueRank < 90 {
+		t.Fatalf("final vendors = %#v, want critical finding vendor first", final)
+	}
+}
+
+func TestOverallFreshnessStateMissingOverridesCurrent(t *testing.T) {
+	state := overallFreshnessState([]FreshnessClock{
+		{ID: "source_runtime", Status: FreshnessStateCurrent},
+		{ID: "artifact_age", Status: FreshnessStateMissing},
+		{ID: "review_completion", Status: FreshnessStateMissing},
+	})
+	if state != FreshnessStateMissing {
+		t.Fatalf("overallFreshnessState = %q, want missing", state)
+	}
+}
+
+func TestOffboardingVendorStaysInQueue(t *testing.T) {
+	vendor := RefreshVendorQueuePosture(Vendor{
+		VendorIdentity: VendorIdentity{Name: "Offboarding", Status: "offboarding"},
+		VendorLifecycle: VendorLifecycle{
+			LifecycleState: LifecycleStateOffboarding,
+		},
+		VendorOwnership: VendorOwnership{OwnerState: OwnerStateAssigned},
+		VendorReviewPosture: VendorReviewPosture{
+			ReviewState: ReviewStateCurrent,
+		},
+		VendorFreshnessPosture: VendorFreshnessPosture{
+			EvidenceFreshnessState: FreshnessStateCurrent,
+		},
+		VendorOperationalPosture: VendorOperationalPosture{
+			DataDeletionState: FreshnessStateMissing,
+		},
+		Attributes: map[string]string{
+			"data_deletion_state": "missing",
+		},
+	}, time.Date(2026, 1, 20, 12, 0, 0, 0, time.UTC))
+	if len(vendor.QueueReasons) == 0 {
+		t.Fatalf("queue reasons empty for offboarding vendor: %#v", vendor)
+	}
+	found := false
+	for _, reason := range vendor.QueueReasons {
+		if reason == "offboarding incomplete" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("queue reasons = %#v, want offboarding incomplete", vendor.QueueReasons)
+	}
+}
+
+func TestNormalizeVendorLifecycleStateTreatsOffboardedAsTerminal(t *testing.T) {
+	if got := normalizeVendorLifecycleState("offboarded"); got != LifecycleStateRetired {
+		t.Fatalf("normalizeVendorLifecycleState(offboarded) = %q, want %q", got, LifecycleStateRetired)
+	}
+}
+
 func TestGetVendorReturnsRelationshipsAndGraph(t *testing.T) {
-	urn := "urn:cerebro:writer:vendor:vanta:acme"
+	urn := "urn:cerebro:writer:vendor:vrm:acme"
 	store := &stubGraphStore{
 		rows: [][]ports.CypherRow{
-			{vendorRow(urn, "Acme", `{"vendor_id":"acme","source_system":"vanta","security_owner_user_id":"user-1","residual_risk_level":"Medium","next_security_review_due_date":"2026-02-01"}`, 1, 1, 1, 1)},
+			{vendorRow(urn, "Acme", `{"vendor_id":"acme","source_system":"vrm","security_owner_user_id":"user-1","residual_risk_level":"Medium","next_security_review_due_date":"2026-02-01","last_security_review_completion_date":"2026-01-01","dpa_attached":"true","source_runtime_fresh_at":"2026-01-19","artifact_created_at":"2026-01-01","document_expiry_date":"2026-05-01","last_control_evidence_at":"2026-01-15","primary_contact":"risk@example.com"}`, 1, 1, 1, 1)},
 			{
-				relatedRow("urn:cerebro:writer:contract:vanta:msa", "contract", "MSA", "associated_with"),
-				relatedRow("urn:cerebro:writer:security_review:vanta:review-1", "security.review", "Review", "associated_with"),
-				relatedRow("urn:cerebro:writer:user:vanta:user-1", "grc.user", "user-1", "owned_by"),
+				relatedRow("urn:cerebro:writer:contract:vrm:msa", "contract", "MSA", "associated_with"),
+				relatedRow("urn:cerebro:writer:security_review:vrm:review-1", "security.review", "Review", "associated_with"),
+				relatedRow("urn:cerebro:writer:user:vrm:user-1", "grc.user", "user-1", "owned_by"),
 				relatedRow("urn:cerebro:writer:internet_host:acme.example", "internet.host", "acme.example", "has_identifier"),
+				relatedRow("urn:cerebro:writer:vendor_alias:vrm:acme-inc", "vendor.alias", "Acme Inc", "has_identifier"),
+				relatedRow("urn:cerebro:writer:vendor_assessment:vrm:assessment-1", "vendor.assessment", "Assessment", "associated_with"),
+				relatedRow("urn:cerebro:writer:vendor_contact:vrm:contact-1", "vendor.contact", "vendor@example.com", "has_contact"),
+				relatedRow("urn:cerebro:writer:subprocessor:vrm:sub-1", "subprocessor", "Subprocessor", "uses_subprocessor"),
 			},
 		},
 		neighborhood: &ports.EntityNeighborhood{Root: &ports.NeighborhoodNode{URN: urn, EntityType: "vendor", Label: "Acme"}},
@@ -121,19 +248,55 @@ func TestGetVendorReturnsRelationshipsAndGraph(t *testing.T) {
 	if detail.Vendor.URN != urn || detail.Vendor.OwnerState != OwnerStateAssigned || detail.Vendor.ReviewState != ReviewStateDueSoon {
 		t.Fatalf("vendor detail = %#v", detail.Vendor)
 	}
-	if len(detail.Relationships.Contracts) != 1 || len(detail.Relationships.SecurityReviews) != 1 || len(detail.Relationships.Owners) != 1 || len(detail.Relationships.Hosts) != 1 {
+	if len(detail.Relationships.Contracts) != 1 || len(detail.Relationships.SecurityReviews) != 1 || len(detail.Relationships.Owners) != 1 || len(detail.Relationships.Hosts) != 1 || len(detail.Relationships.Aliases) != 1 || len(detail.Relationships.Assessments) != 1 || len(detail.Relationships.Contacts) != 1 || len(detail.Relationships.FourthParties) != 1 {
 		t.Fatalf("relationships = %#v", detail.Relationships)
+	}
+	if detail.Packet.VendorURN != urn || detail.Packet.Risk.RiskLevel != "medium" || len(detail.Packet.Identifiers) != 2 || len(detail.Packet.ReviewHistory) != 2 || len(detail.Packet.Contacts) != 1 || len(detail.Packet.FourthParties) != 1 {
+		t.Fatalf("packet = %#v", detail.Packet)
+	}
+	if detail.Packet.Operations.PacketState != "ready" || detail.Packet.Operations.ExposureLevel == "" {
+		t.Fatalf("packet operations = %#v", detail.Packet.Operations)
 	}
 	if store.rootURN != urn || store.limit != relatedLimit {
 		t.Fatalf("neighborhood request = %q/%d, want %q/%d", store.rootURN, store.limit, urn, relatedLimit)
 	}
 }
 
+func TestFilterVendorsByQueueSkipsRetiredVendors(t *testing.T) {
+	vendors := []Vendor{
+		{
+			VendorIdentity: VendorIdentity{Name: "Retired", Status: "retired"},
+			VendorLifecycle: VendorLifecycle{
+				LifecycleState: LifecycleStateRetired,
+			},
+			VendorOwnership: VendorOwnership{OwnerState: OwnerStateMissing},
+			VendorReviewPosture: VendorReviewPosture{
+				ReviewState: ReviewStateOverdue,
+			},
+		},
+		{
+			VendorIdentity: VendorIdentity{Name: "Active", Status: "active"},
+			VendorLifecycle: VendorLifecycle{
+				LifecycleState: LifecycleStateActive,
+			},
+			VendorOwnership: VendorOwnership{OwnerState: OwnerStateMissing},
+			VendorReviewPosture: VendorReviewPosture{
+				ReviewState: ReviewStateOverdue,
+			},
+		},
+	}
+
+	filtered := FilterVendorsByQueue(vendors)
+	if len(filtered) != 1 || filtered[0].Name != "Active" {
+		t.Fatalf("filtered vendors = %#v", filtered)
+	}
+}
+
 func TestGetVendorAcceptsVendorID(t *testing.T) {
-	urn := "urn:cerebro:writer:vendor:vanta:acme"
+	urn := "urn:cerebro:writer:vendor:vrm:acme"
 	store := &stubGraphStore{
 		rows: [][]ports.CypherRow{
-			{vendorRow(urn, "Acme", `{"vendor_id":"acme","source_system":"vanta"}`, 0, 0, 0, 0)},
+			{vendorRow(urn, "Acme", `{"vendor_id":"acme","source_system":"vrm"}`, 0, 0, 0, 0)},
 			{},
 		},
 		neighborhood: &ports.EntityNeighborhood{Root: &ports.NeighborhoodNode{URN: urn, EntityType: "vendor", Label: "Acme"}},
@@ -167,8 +330,8 @@ func TestListDiscoveriesAppliesSourceStatusAndOverlay(t *testing.T) {
 	decisionTime := time.Date(2026, 1, 21, 12, 0, 0, 0, time.UTC)
 	store := &stubGraphStore{
 		rows: [][]ports.CypherRow{{
-			discoveryRow("urn:cerebro:writer:vendor_discovery:grc:shadow", "Shadow SaaS", `{"discovered_vendor_id":"shadow","normalized_name":"shadow saas","source_system":"vanta","status":"discovered","category":"analytics"}`),
-			discoveryRow("urn:cerebro:writer:vendor_discovery:grc:ignored", "Ignored SaaS", `{"discovered_vendor_id":"ignored","source_system":"vanta","status":"ignored"}`),
+			discoveryRow("urn:cerebro:writer:vendor_discovery:grc:shadow", "Shadow SaaS", `{"discovered_vendor_id":"shadow","normalized_name":"shadow saas","source_system":"vrm","status":"discovered","category":"analytics"}`),
+			discoveryRow("urn:cerebro:writer:vendor_discovery:grc:ignored", "Ignored SaaS", `{"discovered_vendor_id":"ignored","source_system":"vrm","status":"ignored"}`),
 		}},
 	}
 	service := New(store)
@@ -184,7 +347,7 @@ func TestListDiscoveriesAppliesSourceStatusAndOverlay(t *testing.T) {
 		TenantID:        "writer",
 		DiscoveryURN:    discoveries[0].URN,
 		Decision:        ports.GRCVendorDiscoveryDecisionLinked,
-		LinkedVendorURN: "urn:cerebro:writer:vendor:vanta:shadow",
+		LinkedVendorURN: "urn:cerebro:writer:vendor:vrm:shadow",
 		Reason:          "Existing vendor row",
 		UpdatedBy:       "operator",
 		UpdatedAt:       decisionTime,
@@ -207,7 +370,7 @@ func vendorRow(urn string, label string, attrs string, contracts int64, reviews 
 		"urn":                      urn,
 		"label":                    label,
 		"source_id":                "grc",
-		"runtime_id":               "writer-vanta",
+		"runtime_id":               "writer-vrm",
 		"attributes_json":          attrs,
 		"contract_count":           contracts,
 		"security_review_count":    reviews,
@@ -221,7 +384,7 @@ func discoveryRow(urn string, label string, attrs string) ports.CypherRow {
 		"urn":             urn,
 		"label":           label,
 		"source_id":       "grc",
-		"runtime_id":      "writer-vanta",
+		"runtime_id":      "writer-vrm",
 		"attributes_json": attrs,
 	}}
 }
@@ -232,7 +395,7 @@ func relatedRow(urn string, entityType string, label string, relation string) po
 		"entity_type":     entityType,
 		"label":           label,
 		"source_id":       "grc",
-		"runtime_id":      "writer-vanta",
+		"runtime_id":      "writer-vrm",
 		"relation":        relation,
 		"attributes_json": "{}",
 	}}

--- a/internal/ports/grc_vendor.go
+++ b/internal/ports/grc_vendor.go
@@ -20,6 +20,8 @@ type GRCVendorDiscoveryDecisionRecord struct {
 	TenantID        string            `json:"tenant_id"`
 	DiscoveryURN    string            `json:"discovery_urn"`
 	SourceID        string            `json:"source_id,omitempty"`
+	DecisionEventID string            `json:"decision_event_id,omitempty"`
+	Version         int               `json:"version,omitempty"`
 	Decision        string            `json:"decision"`
 	Reason          string            `json:"reason,omitempty"`
 	LinkedVendorURN string            `json:"linked_vendor_urn,omitempty"`
@@ -29,7 +31,30 @@ type GRCVendorDiscoveryDecisionRecord struct {
 	UpdatedAt       time.Time         `json:"updated_at"`
 }
 
+type GRCVendorDiscoveryDecisionEventRecord struct {
+	ID                string            `json:"id"`
+	TenantID          string            `json:"tenant_id"`
+	DiscoveryURN      string            `json:"discovery_urn"`
+	SourceID          string            `json:"source_id,omitempty"`
+	Decision          string            `json:"decision"`
+	Reason            string            `json:"reason,omitempty"`
+	LinkedVendorURN   string            `json:"linked_vendor_urn,omitempty"`
+	UpdatedBy         string            `json:"updated_by,omitempty"`
+	Attributes        map[string]string `json:"attributes,omitempty"`
+	Version           int               `json:"version"`
+	SupersedesEventID string            `json:"supersedes_event_id,omitempty"`
+	CreatedAt         time.Time         `json:"created_at"`
+}
+
 type GRCVendorDiscoveryDecisionFilter struct {
+	TenantID      string
+	DiscoveryURNs []string
+	SourceID      string
+	Decision      string
+	Limit         uint32
+}
+
+type GRCVendorDiscoveryDecisionEventFilter struct {
 	TenantID      string
 	DiscoveryURNs []string
 	SourceID      string
@@ -41,6 +66,7 @@ type GRCVendorDiscoveryDecisionStore interface {
 	StateStore
 	UpsertGRCVendorDiscoveryDecision(context.Context, GRCVendorDiscoveryDecisionRecord) (*GRCVendorDiscoveryDecisionRecord, error)
 	ListGRCVendorDiscoveryDecisions(context.Context, GRCVendorDiscoveryDecisionFilter) ([]*GRCVendorDiscoveryDecisionRecord, error)
+	ListGRCVendorDiscoveryDecisionEvents(context.Context, GRCVendorDiscoveryDecisionEventFilter) ([]*GRCVendorDiscoveryDecisionEventRecord, error)
 }
 
 func IsGRCVendorDiscoveryDecision(value string) bool {

--- a/internal/statestore/postgres/grc_vendor.go
+++ b/internal/statestore/postgres/grc_vendor.go
@@ -2,11 +2,14 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -19,14 +22,39 @@ var ensureGRCVendorDiscoveryDecisionStatements = []string{
   decision TEXT NOT NULL,
   reason TEXT NOT NULL DEFAULT '',
   linked_vendor_urn TEXT NOT NULL DEFAULT '',
+  decision_event_id TEXT NOT NULL DEFAULT '',
+  version INTEGER NOT NULL DEFAULT 1,
   updated_by TEXT NOT NULL DEFAULT '',
   attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (tenant_id, discovery_urn)
 )`,
+	`ALTER TABLE grc_vendor_discovery_decisions ADD COLUMN IF NOT EXISTS decision_event_id TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE grc_vendor_discovery_decisions ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1`,
 	`CREATE INDEX IF NOT EXISTS grc_vendor_discovery_decisions_tenant_source_decision_idx ON grc_vendor_discovery_decisions (tenant_id, source_id, decision, updated_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS grc_vendor_discovery_decisions_tenant_decision_idx ON grc_vendor_discovery_decisions (tenant_id, decision, updated_at DESC)`,
+	`CREATE TABLE IF NOT EXISTS grc_vendor_discovery_decision_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  discovery_urn TEXT NOT NULL,
+  source_id TEXT NOT NULL DEFAULT '',
+  decision TEXT NOT NULL,
+  reason TEXT NOT NULL DEFAULT '',
+  linked_vendor_urn TEXT NOT NULL DEFAULT '',
+  updated_by TEXT NOT NULL DEFAULT '',
+  attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  version INTEGER NOT NULL,
+  supersedes_event_id TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS grc_vendor_discovery_decision_events_tenant_discovery_version_uidx ON grc_vendor_discovery_decision_events (tenant_id, discovery_urn, version)`,
+	`CREATE INDEX IF NOT EXISTS grc_vendor_discovery_decision_events_tenant_discovery_idx ON grc_vendor_discovery_decision_events (tenant_id, discovery_urn, version DESC)`,
+	`CREATE INDEX IF NOT EXISTS grc_vendor_discovery_decision_events_tenant_source_decision_idx ON grc_vendor_discovery_decision_events (tenant_id, source_id, decision, created_at DESC)`,
+}
+
+func grcVendorDiscoveryDecisionAdvisoryLockSQL() string {
+	return `SELECT pg_advisory_xact_lock(hashtext('grc_vendor_discovery_decision'), hashtext($1))`
 }
 
 func (s *Store) UpsertGRCVendorDiscoveryDecision(ctx context.Context, record ports.GRCVendorDiscoveryDecisionRecord) (*ports.GRCVendorDiscoveryDecisionRecord, error) {
@@ -56,20 +84,69 @@ func (s *Store) UpsertGRCVendorDiscoveryDecision(ctx context.Context, record por
 	if err != nil {
 		return nil, fmt.Errorf("marshal vendor discovery decision attributes: %w", err)
 	}
-	row := s.db.QueryRowContext(ctx, `
-INSERT INTO grc_vendor_discovery_decisions (tenant_id, discovery_urn, source_id, decision, reason, linked_vendor_urn, updated_by, attributes_json)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin vendor discovery decision upsert: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, grcVendorDiscoveryDecisionAdvisoryLockSQL(), record.TenantID+"\x00"+record.DiscoveryURN); err != nil {
+		return nil, fmt.Errorf("lock vendor discovery decision: %w", err)
+	}
+	var supersedesEventID string
+	var previousVersion int
+	err = tx.QueryRowContext(ctx, `
+SELECT decision_event_id, version
+FROM grc_vendor_discovery_decisions
+WHERE tenant_id = $1 AND discovery_urn = $2
+FOR UPDATE`, record.TenantID, record.DiscoveryURN).Scan(&supersedesEventID, &previousVersion)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("load previous vendor discovery decision: %w", err)
+	}
+	version := previousVersion + 1
+	if version <= 0 {
+		version = 1
+	}
+	eventID := strings.TrimSpace(record.DecisionEventID)
+	if eventID == "" {
+		eventID = grcVendorDiscoveryDecisionEventID(record, version)
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO grc_vendor_discovery_decision_events (
+  id, tenant_id, discovery_urn, source_id, decision, reason, linked_vendor_urn,
+  updated_by, attributes_json, version, supersedes_event_id
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11)`,
+		eventID, record.TenantID, record.DiscoveryURN, record.SourceID, record.Decision, record.Reason,
+		record.LinkedVendorURN, record.UpdatedBy, string(attrs), version, supersedesEventID); err != nil {
+		return nil, fmt.Errorf("insert vendor discovery decision event: %w", err)
+	}
+	row := tx.QueryRowContext(ctx, `
+INSERT INTO grc_vendor_discovery_decisions (
+  tenant_id, discovery_urn, source_id, decision, reason, linked_vendor_urn,
+  decision_event_id, version, updated_by, attributes_json
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
 ON CONFLICT (tenant_id, discovery_urn)
 DO UPDATE SET source_id = EXCLUDED.source_id,
               decision = EXCLUDED.decision,
               reason = EXCLUDED.reason,
               linked_vendor_urn = EXCLUDED.linked_vendor_urn,
+              decision_event_id = EXCLUDED.decision_event_id,
+              version = EXCLUDED.version,
               updated_by = EXCLUDED.updated_by,
               attributes_json = EXCLUDED.attributes_json,
               updated_at = NOW()
-RETURNING tenant_id, discovery_urn, source_id, decision, reason, linked_vendor_urn, updated_by, attributes_json::text, created_at, updated_at`,
-		record.TenantID, record.DiscoveryURN, record.SourceID, record.Decision, record.Reason, record.LinkedVendorURN, record.UpdatedBy, string(attrs))
-	return scanGRCVendorDiscoveryDecision(row)
+RETURNING tenant_id, discovery_urn, source_id, decision_event_id, version, decision, reason, linked_vendor_urn, updated_by, attributes_json::text, created_at, updated_at`,
+		record.TenantID, record.DiscoveryURN, record.SourceID, record.Decision, record.Reason,
+		record.LinkedVendorURN, eventID, version, record.UpdatedBy, string(attrs))
+	result, err := scanGRCVendorDiscoveryDecision(row)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit vendor discovery decision upsert: %w", err)
+	}
+	return result, nil
 }
 
 func (s *Store) ListGRCVendorDiscoveryDecisions(ctx context.Context, filter ports.GRCVendorDiscoveryDecisionFilter) ([]*ports.GRCVendorDiscoveryDecisionRecord, error) {
@@ -92,7 +169,7 @@ func (s *Store) ListGRCVendorDiscoveryDecisions(ctx context.Context, filter port
 	args = append(args, limit)
 	// #nosec G201 -- clauses are assembled from fixed column predicates and values remain parameterized.
 	query := fmt.Sprintf(`
-SELECT tenant_id, discovery_urn, source_id, decision, reason, linked_vendor_urn, updated_by, attributes_json::text, created_at, updated_at
+SELECT tenant_id, discovery_urn, source_id, decision_event_id, version, decision, reason, linked_vendor_urn, updated_by, attributes_json::text, created_at, updated_at
 FROM grc_vendor_discovery_decisions
 WHERE %s
 ORDER BY updated_at DESC, discovery_urn ASC
@@ -113,6 +190,47 @@ LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
 	return records, rows.Err()
 }
 
+func (s *Store) ListGRCVendorDiscoveryDecisionEvents(ctx context.Context, filter ports.GRCVendorDiscoveryDecisionEventFilter) ([]*ports.GRCVendorDiscoveryDecisionEventRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCVendorDiscoveryDecisionTables(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	addTextFilter(&clauses, &args, "tenant_id", filter.TenantID)
+	addTextFilter(&clauses, &args, "source_id", filter.SourceID)
+	addTextFilter(&clauses, &args, "decision", filter.Decision)
+	addStringInFilter(&clauses, &args, "discovery_urn", filter.DiscoveryURNs)
+	limit := filter.Limit
+	if limit == 0 || limit > 500 {
+		limit = 500
+	}
+	args = append(args, limit)
+	// #nosec G201 -- clauses are assembled from fixed column predicates and values remain parameterized.
+	query := fmt.Sprintf(`
+SELECT id, tenant_id, discovery_urn, source_id, decision, reason, linked_vendor_urn, updated_by, attributes_json::text, version, supersedes_event_id, created_at
+FROM grc_vendor_discovery_decision_events
+WHERE %s
+ORDER BY created_at DESC, version DESC, id ASC
+LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list vendor discovery decision events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := []*ports.GRCVendorDiscoveryDecisionEventRecord{}
+	for rows.Next() {
+		record, err := scanGRCVendorDiscoveryDecisionEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
 func (s *Store) ensureGRCVendorDiscoveryDecisionTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.grc.vendorDiscovery, "grc vendor discovery decision", ensureGRCVendorDiscoveryDecisionStatements)
 }
@@ -120,7 +238,7 @@ func (s *Store) ensureGRCVendorDiscoveryDecisionTables(ctx context.Context) erro
 func scanGRCVendorDiscoveryDecision(row scanner) (*ports.GRCVendorDiscoveryDecisionRecord, error) {
 	record := &ports.GRCVendorDiscoveryDecisionRecord{}
 	var attrs string
-	if err := row.Scan(&record.TenantID, &record.DiscoveryURN, &record.SourceID, &record.Decision, &record.Reason, &record.LinkedVendorURN, &record.UpdatedBy, &attrs, &record.CreatedAt, &record.UpdatedAt); err != nil {
+	if err := row.Scan(&record.TenantID, &record.DiscoveryURN, &record.SourceID, &record.DecisionEventID, &record.Version, &record.Decision, &record.Reason, &record.LinkedVendorURN, &record.UpdatedBy, &attrs, &record.CreatedAt, &record.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, err
 		}
@@ -129,4 +247,33 @@ func scanGRCVendorDiscoveryDecision(row scanner) (*ports.GRCVendorDiscoveryDecis
 	record.Attributes = map[string]string{}
 	_ = json.Unmarshal([]byte(attrs), &record.Attributes)
 	return record, nil
+}
+
+func scanGRCVendorDiscoveryDecisionEvent(row scanner) (*ports.GRCVendorDiscoveryDecisionEventRecord, error) {
+	record := &ports.GRCVendorDiscoveryDecisionEventRecord{}
+	var attrs string
+	if err := row.Scan(&record.ID, &record.TenantID, &record.DiscoveryURN, &record.SourceID, &record.Decision, &record.Reason, &record.LinkedVendorURN, &record.UpdatedBy, &attrs, &record.Version, &record.SupersedesEventID, &record.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		return nil, err
+	}
+	record.Attributes = map[string]string{}
+	_ = json.Unmarshal([]byte(attrs), &record.Attributes)
+	return record, nil
+}
+
+func grcVendorDiscoveryDecisionEventID(record ports.GRCVendorDiscoveryDecisionRecord, version int) string {
+	seed := strings.Join([]string{
+		"grc_vendor_discovery_decision_event",
+		record.TenantID,
+		record.DiscoveryURN,
+		record.SourceID,
+		record.Decision,
+		record.LinkedVendorURN,
+		fmt.Sprint(version),
+		time.Now().UTC().Format(time.RFC3339Nano),
+	}, "\x00")
+	sum := sha256.Sum256([]byte(seed))
+	return "grc-vendor-decision-" + hex.EncodeToString(sum[:12])
 }

--- a/internal/statestore/postgres/grc_vendor_test.go
+++ b/internal/statestore/postgres/grc_vendor_test.go
@@ -1,0 +1,31 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGRCVendorDiscoveryDecisionSchemaSerializesEvents(t *testing.T) {
+	joined := strings.Join(ensureGRCVendorDiscoveryDecisionStatements, "\n")
+	for _, fragment := range []string{
+		"grc_vendor_discovery_decision_events_tenant_discovery_version_uidx",
+		"(tenant_id, discovery_urn, version)",
+	} {
+		if !strings.Contains(joined, fragment) {
+			t.Fatalf("vendor discovery decision schema missing %q:\n%s", fragment, joined)
+		}
+	}
+}
+
+func TestGRCVendorDiscoveryDecisionAdvisoryLockSerializesUpserts(t *testing.T) {
+	query := grcVendorDiscoveryDecisionAdvisoryLockSQL()
+	for _, fragment := range []string{
+		"pg_advisory_xact_lock",
+		"hashtext('grc_vendor_discovery_decision')",
+		"hashtext($1)",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("vendor discovery decision advisory lock query missing %q:\n%s", fragment, query)
+		}
+	}
+}

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -1070,6 +1070,220 @@ export type GRCDashboardResponse = {
   summary?: Record<string, unknown>;
 };
 
+export type GRCPolicyAcceptanceSummary = {
+  accepted?: number;
+  overdue?: number;
+  pending?: number;
+  total?: number;
+};
+
+export type GRCPolicyApproval = {
+  approved_at?: string;
+  approvers?: string[];
+  due_at?: string;
+  id?: string;
+  policy_id?: string;
+  policy_version_id?: string;
+  requested_at?: string;
+  requested_by?: string;
+  status?: string;
+  step?: string;
+  urn?: string;
+};
+
+export type GRCPolicyAssignment = {
+  label?: string;
+  scope?: string;
+  target_type?: string;
+  target_urn?: string;
+};
+
+export type GRCPolicyAttestation = {
+  accepted_at?: string;
+  assignees?: string[];
+  due_at?: string;
+  id?: string;
+  person?: string;
+  policy_id?: string;
+  policy_version_id?: string;
+  status?: string;
+  urn?: string;
+};
+
+export type GRCPolicyControlRef = {
+  control_id?: string;
+  framework?: string;
+  title?: string;
+  urn?: string;
+};
+
+export type GRCPolicyEvidenceRef = {
+  document_id?: string;
+  entity_type?: string;
+  evidence_type?: string;
+  title?: string;
+  urn?: string;
+};
+
+export type GRCPolicyException = {
+  approved_at?: string;
+  approvers?: string[];
+  controls?: GRCPolicyControlRef[];
+  expires_at?: string;
+  id?: string;
+  owner?: string;
+  policy_id?: string;
+  policy_version_id?: string;
+  reason?: string;
+  status?: string;
+  targets?: GRCPolicyTargetRef[];
+  title?: string;
+  urn?: string;
+};
+
+export type GRCPolicyExceptionSummary = {
+  active?: number;
+  expired?: number;
+  expiring?: number;
+};
+
+export type GRCPolicyLifecycleMapping = {
+  controls?: GRCPolicyControlRef[];
+  evidence?: GRCPolicyEvidenceRef[];
+  policy_id?: string;
+  policy_title?: string;
+  source_type?: string;
+  source_urn?: string;
+  target?: GRCPolicyTargetRef;
+};
+
+export type GRCPolicyLifecyclePolicy = {
+  acceptance_summary?: GRCPolicyAcceptanceSummary;
+  approval_status?: string;
+  approvals?: GRCPolicyApproval[];
+  assignments?: GRCPolicyAssignment[];
+  attestations?: GRCPolicyAttestation[];
+  attributes?: Record<string, string>;
+  controls?: GRCPolicyControlRef[];
+  evidence?: GRCPolicyEvidenceRef[];
+  exception_summary?: GRCPolicyExceptionSummary;
+  exceptions?: GRCPolicyException[];
+  id?: string;
+  latest_version?: string;
+  next_review_due_at?: string;
+  owner?: string;
+  review_cadence?: string;
+  reviewer?: string;
+  reviews?: GRCPolicyReview[];
+  status?: string;
+  title?: string;
+  urn?: string;
+  version_status?: string;
+  versions?: GRCPolicyVersion[];
+};
+
+export type GRCPolicyLifecycleResponse = {
+  generated_at?: string;
+  mappings?: GRCPolicyLifecycleMapping[];
+  policies?: GRCPolicyLifecyclePolicy[];
+  reminders?: GRCPolicyReminder[];
+  summary?: GRCPolicyLifecycleSummary;
+  templates?: GRCPolicyTemplate[];
+  work_queue?: GRCPolicyLifecycleWork[];
+};
+
+export type GRCPolicyLifecycleSummary = {
+  attestation_coverage_pct?: number;
+  draft_versions?: number;
+  evidence_items?: number;
+  expiring_exceptions?: number;
+  mapped_controls?: number;
+  open_exceptions?: number;
+  overdue_attestations?: number;
+  overdue_reviews?: number;
+  pending_approvals?: number;
+  policies?: number;
+  templates?: number;
+};
+
+export type GRCPolicyLifecycleWork = {
+  action?: string;
+  due_at?: string;
+  id?: string;
+  owner?: string;
+  policy?: string;
+  policy_id?: string;
+  record_urn?: string;
+  status?: string;
+  type?: string;
+};
+
+export type GRCPolicyReminder = {
+  channel?: string;
+  due_at?: string;
+  escalated_to?: string[];
+  id?: string;
+  policy_id?: string;
+  policy_version_id?: string;
+  recipients?: string[];
+  sent_at?: string;
+  status?: string;
+  title?: string;
+  urn?: string;
+};
+
+export type GRCPolicyReview = {
+  cadence?: string;
+  id?: string;
+  owner?: string;
+  policy_id?: string;
+  policy_version_id?: string;
+  review_due_at?: string;
+  reviewed_at?: string;
+  reviewers?: string[];
+  status?: string;
+  urn?: string;
+};
+
+export type GRCPolicyTargetRef = {
+  entity_type?: string;
+  label?: string;
+  urn?: string;
+};
+
+export type GRCPolicyTemplate = {
+  attributes?: Record<string, string>;
+  category?: string;
+  controls?: GRCPolicyControlRef[];
+  evidence?: GRCPolicyEvidenceRef[];
+  frameworks?: string[];
+  id?: string;
+  owner?: string;
+  status?: string;
+  title?: string;
+  urn?: string;
+};
+
+export type GRCPolicyVersion = {
+  approved_at?: string;
+  assignments?: GRCPolicyAssignment[];
+  author?: string;
+  change_summary?: string;
+  controls?: GRCPolicyControlRef[];
+  created_at?: string;
+  diff_summary?: string;
+  diff_url?: string;
+  effective_at?: string;
+  evidence?: GRCPolicyEvidenceRef[];
+  id?: string;
+  owner?: string;
+  policy_id?: string;
+  status?: string;
+  title?: string;
+  urn?: string;
+  version?: string;
+};
+
 export type GRCProductArea = {
   blind_spots?: SourceCoverageRecord[];
   control_domains?: string[];


### PR DESCRIPTION
## Summary
- Add durable vendor discovery decision overlays and append-only event history without source-provider writes.
- Expand canonical vendor semantics with lifecycle, queue posture, explainable risk scoring, assessments, monitoring, commercial posture, contacts, fourth parties, and packet closeout actions.
- Add deeper operational posture for exposure, packet readiness, remediation deadlines, offboarding, and data deletion state.
- Update report catalog entries, API documentation, architecture docs, and rule close-on-good-state behavior.

## Validation
- go test ./...
- make lint
- go run ./scripts/openapi_route_parity.go
- make check-structural check-structural-test check-arch
- make openapi-ts-check openapi-lint docs-drift-check
- git diff --check