### PR TITLE
[codex] Wire catalog integrations into Source CDK runtime

### DIFF
--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -369,13 +369,13 @@ func Builtin() (*sourcecdk.Registry, error) {
 		}
 		sources = append(sources, source)
 	}
-	catalog, err := connectorcatalog.Builtin()
+	catalog, err := connectorcatalog.BuiltinRuntime()
 	if err != nil {
 		return nil, fmt.Errorf("load connector definition catalog: %w", err)
 	}
 	for _, entry := range catalog.Entries {
 		sourceID := entry.Definition.SourceID
-		if _, ok := registered[sourceID]; ok || entry.Status != connectorcatalog.StatusGenerateable {
+		if _, ok := registered[sourceID]; ok || entry.Report.Verdict != connectordefinitions.SupportVerdictSupported {
 			continue
 		}
 		source, err := catalogruntimesource.New(entry)

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -199,6 +199,40 @@ func TestBuiltinRegistersEveryGenerateableCatalogSource(t *testing.T) {
 	}
 }
 
+func TestBuiltinRegistersEverySupportedRuntimeCatalogSource(t *testing.T) {
+	registry, err := Builtin()
+	if err != nil {
+		t.Fatalf("Builtin() error = %v", err)
+	}
+	catalog, err := connectorcatalog.BuiltinRuntime()
+	if err != nil {
+		t.Fatalf("connectorcatalog.BuiltinRuntime() error = %v", err)
+	}
+	supported := 0
+	var missing []string
+	for _, entry := range catalog.Entries {
+		if entry.Report.Verdict != connectordefinitions.SupportVerdictSupported {
+			continue
+		}
+		supported++
+		sourceID := entry.Definition.SourceID
+		source, ok := registry.Get(sourceID)
+		if !ok {
+			missing = append(missing, sourceID)
+			continue
+		}
+		if source.Spec().Id != sourceID {
+			t.Fatalf("%s Spec().Id = %q, want %q", sourceID, source.Spec().Id, sourceID)
+		}
+	}
+	if len(missing) != 0 {
+		t.Fatalf("registry missing supported runtime catalog sources: %#v", missing)
+	}
+	if got := len(registry.List()); got < supported {
+		t.Fatalf("registry.List() len = %d, want at least %d supported runtime catalog sources", got, supported)
+	}
+}
+
 func TestDynamicDefinitionSourceRejectsBlockedDefinition(t *testing.T) {
 	_, err := DynamicDefinitionSource(connectordefinitions.Definition{
 		ID:          "example",


### PR DESCRIPTION
## Summary
- Build the in-process Source CDK registry from the runtime connector catalog instead of the sourcegen proof catalog.
- Register every supported catalog definition as a catalog-runtime Source CDK source unless a bespoke source already owns the same source_id.
- Add a registry contract test that fails if any supported runtime catalog integration is missing from Source CDK.

## Validation
- `go test ./internal/sourceregistry`
- `go test ./internal/sourceregistry ./internal/connectorcatalog ./internal/sourceprojection ./sources/catalogruntime ./sources/internal/catalogruntime`
- `go test ./internal/bootstrap -run 'TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled|TestConnectorSchemaForGenerateableCatalogDefinition'`
- `make catalog-check`
- `make sourcegen-check`
- `git diff --check`
- `make test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->