### PR TITLE
[codex] Add agent onboarding workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -60,6 +60,11 @@ LOAD_SMOKE_MAX_ERROR_RATE ?= 0.01
 LOAD_SMOKE_MAX_5XX_RATE ?= 0
 LOAD_SMOKE_JSON_OUT ?= tmp/load-smoke.json
 LOAD_SMOKE_MARKDOWN_OUT ?= tmp/load-smoke.md
+AGENT_ONBOARD_PLAN ?= examples/onboarding/cerebro-onboarding.yaml
+AGENT_ONBOARD_EFFECTIVE_PLAN = $(if $(PLAN),$(PLAN),$(AGENT_ONBOARD_PLAN))
+AGENT_ONBOARD_RECEIPT ?= tmp/onboarding/receipt.json
+AGENT_ONBOARD_E2E_RECEIPT ?= tmp/onboarding/e2e-receipt.json
+CEREBRO_ONBOARD_BASE_URL ?=
 MCP_SDK_ROOT ?= tmp/mcp-sdk-compat
 MCP_SDK_PACKAGE ?= @modelcontextprotocol/sdk@latest
 MCP_SDK_TEST_TOKEN ?= mcp-sdk-test-key
@@ -370,6 +375,30 @@ contracts-check: ## Run contract and compatibility checks with a final summary.
 
 changed-check: ## Run validation selected from changed paths.
 	python3 scripts/changed_checks.py --base "$(DROID_REVIEW_BASE)" --head "$(DROID_REVIEW_HEAD)" --run
+
+agent-onboard: build ## Run an agent onboarding plan and write a redacted receipt.
+	python3 scripts/agent_onboard.py \
+		--plan "$(AGENT_ONBOARD_EFFECTIVE_PLAN)" \
+		--receipt "$(AGENT_ONBOARD_RECEIPT)" \
+		$(if $(CEREBRO_ONBOARD_BASE_URL),--base-url "$(CEREBRO_ONBOARD_BASE_URL)",)
+
+agent-onboard-test: ## Run agent onboarding workflow unit tests.
+	python3 -m unittest scripts.tests.test_agent_onboard
+
+agent-onboard-e2e: build ## Run the local Docker-backed agent onboarding workflow.
+	@command -v docker >/dev/null || { echo "docker is required for agent-onboard-e2e" >&2; exit 2; }
+	docker compose up --build -d
+	CEREBRO_API_KEY="local-dev-key" \
+	CEREBRO_API_KEYS="local-dev-key:local:local" \
+	CEREBRO_JETSTREAM_URL="nats://127.0.0.1:4222" \
+	CEREBRO_POSTGRES_DSN="postgres://cerebro:cerebro@127.0.0.1:5432/cerebro?sslmode=disable" \
+	CEREBRO_NEO4J_URI="bolt://127.0.0.1:7687" \
+	CEREBRO_NEO4J_USERNAME="neo4j" \
+	CEREBRO_NEO4J_PASSWORD="local-password" \
+	python3 scripts/agent_onboard.py \
+		--plan "$(AGENT_ONBOARD_EFFECTIVE_PLAN)" \
+		--receipt "$(AGENT_ONBOARD_E2E_RECEIPT)" \
+		--wait
 
 # ==== Release and Environment ====
 ##@ Release and Environment

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -376,6 +376,8 @@ contracts-check: ## Run contract and compatibility checks with a final summary.
 changed-check: ## Run validation selected from changed paths.
 	python3 scripts/changed_checks.py --base "$(DROID_REVIEW_BASE)" --head "$(DROID_REVIEW_HEAD)" --run
 
+secure-business-demo: agent-onboard-e2e ## Start Cerebro locally and write a security onboarding receipt.
+
 agent-onboard: build ## Run an agent onboarding plan and write a redacted receipt.
 	python3 scripts/agent_onboard.py \
 		--plan "$(AGENT_ONBOARD_EFFECTIVE_PLAN)" \
@@ -388,7 +390,7 @@ agent-onboard-test: ## Run agent onboarding workflow unit tests.
 agent-onboard-e2e: build ## Run the local Docker-backed agent onboarding workflow.
 	@command -v docker >/dev/null || { echo "docker is required for agent-onboard-e2e" >&2; exit 2; }
 	docker compose up --build -d
-	CEREBRO_API_KEY="local-dev-key" \
+	@CEREBRO_API_KEY="local-dev-key" \
 	CEREBRO_API_KEYS="local-dev-key:local:local" \
 	CEREBRO_JETSTREAM_URL="nats://127.0.0.1:4222" \
 	CEREBRO_POSTGRES_DSN="postgres://cerebro:cerebro@127.0.0.1:5432/cerebro?sslmode=disable" \

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See [Non-goals](docs/engineering/non-goals.md) before changing storage shape, So
 ```bash
 make build          # compile ./bin/cerebro
 make serve-dev      # run the local server with acknowledged dev-mode opt-out
+make secure-business-demo  # run local security onboarding and write a receipt
 make agent-onboard  # run an onboarding plan and write a redacted receipt
 make agent-onboard-e2e  # run the Docker-backed local onboarding workflow
 make test           # go test ./...

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ docker compose up --build
 | --- | --- |
 | Get the shortest runnable path | [Quick reference](docs/start/quick-reference.md) |
 | Walk through a local end-to-end flow | [Getting started](docs/start/getting-started.md) |
+| Hand setup to a coding agent | [Agent onboarding](docs/start/agent-onboarding.md) |
 | Understand runtime shape and stores | [Architecture](docs/reference/architecture.md) |
 | Configure auth, tenancy, stores, MCP, or device auth | [Configuration variables](docs/reference/config-env-vars.md) and [.env.example](.env.example) |
 | Host or operate Cerebro | [Hosting](docs/operations/hosting.md), [runtime profiles](docs/operations/runtime-profiles.md), [deployment readiness](docs/operations/deployment-readiness.md), [cloud deployment](docs/operations/cloud-deployment.md), [deployment examples](docs/operations/deployment-examples.md), and [operations runbook](docs/operations/operations-runbook.md) |
@@ -92,6 +93,8 @@ See [Non-goals](docs/engineering/non-goals.md) before changing storage shape, So
 ```bash
 make build          # compile ./bin/cerebro
 make serve-dev      # run the local server with acknowledged dev-mode opt-out
+make agent-onboard  # run an onboarding plan and write a redacted receipt
+make agent-onboard-e2e  # run the Docker-backed local onboarding workflow
 make test           # go test ./...
 make check          # build, tests, lint, proto lint, structural checks, arch tests
 make verify         # CI-parity local verification

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ docker compose up --build
 | --- | --- |
 | Short command reference | [Quick reference](start/quick-reference.md) |
 | Local end-to-end walkthrough | [Getting started](start/getting-started.md) |
+| Coding agent setup handoff | [Agent onboarding](start/agent-onboarding.md) |
 | Runtime shape and dependency boundaries | [Architecture](reference/architecture.md) |
 | Runtime configuration | [Configuration variables](reference/config-env-vars.md) |
 | Hosting and operations | [Hosting](operations/hosting.md), [runtime profiles](operations/runtime-profiles.md), [deployment readiness](operations/deployment-readiness.md), [cloud deployment](operations/cloud-deployment.md), [deployment examples](operations/deployment-examples.md), [operations runbook](operations/operations-runbook.md), and [troubleshooting](operations/troubleshooting.md) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,6 +9,13 @@ make build
 
 Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
 
+Agent onboarding is a Makefile workflow around the CLI and HTTP API:
+
+```bash
+make agent-onboard PLAN=examples/onboarding/cerebro-onboarding.yaml
+make agent-onboard-e2e
+```
+
 ## Server And Version
 
 ```bash

--- a/docs/start/agent-onboarding.md
+++ b/docs/start/agent-onboarding.md
@@ -1,0 +1,103 @@
+# Agent Onboarding
+
+This workflow gives a coding agent one plan file, one command, and one receipt. It is for setup, source runtime onboarding, and security/compliance checks against a local or hosted Cerebro service.
+
+Use it when an operator wants an agent to:
+
+- start from a declared intake file,
+- avoid committing provider secrets,
+- run deployment preflight,
+- create source runtimes,
+- write and read a sample claim,
+- run runtime sync and graph ingest checks,
+- check compliance coverage,
+- return a redacted setup receipt.
+
+## Copy This Prompt
+
+```text
+Set up Cerebro from examples/onboarding/cerebro-onboarding.yaml.
+
+Use make agent-onboard.
+Do not put provider credentials, tenant-specific hostnames, account IDs, or live secret values in the repository.
+Use env: references for secret-bearing values.
+Run the local end-to-end target if Docker is available.
+Return the receipt status, failed checks, required secrets, source runtime ids, and next actions.
+```
+
+## Local End-To-End Run
+
+The local plan uses the SDK source, local Docker services, and the bearer key from `docker-compose.yml`.
+
+```bash
+make agent-onboard-e2e
+```
+
+The target starts the local stack, builds `./bin/cerebro`, waits for `/health`, runs `deploy preflight`, creates `local-sdk-demo`, writes sample SDK claims, runs sync and graph ingest checks, checks control coverage, and writes:
+
+```text
+tmp/onboarding/e2e-receipt.json
+```
+
+## Run Against An Existing Service
+
+Set the service and backing-store environment used by `deploy preflight`:
+
+```bash
+export CEREBRO_API_KEY='<api-key>'
+export CEREBRO_API_KEYS='<api-key>:<principal>:<tenant-id>'
+export CEREBRO_JETSTREAM_URL='<nats-url>'
+export CEREBRO_POSTGRES_DSN='<postgres-dsn>'
+export CEREBRO_NEO4J_URI='<neo4j-uri>'
+export CEREBRO_NEO4J_USERNAME='<neo4j-user>'
+export CEREBRO_NEO4J_PASSWORD='<neo4j-password>'
+
+make agent-onboard PLAN=examples/onboarding/cerebro-onboarding.yaml
+```
+
+Override the service URL and receipt path when needed:
+
+```bash
+make agent-onboard \
+  PLAN=examples/onboarding/cerebro-onboarding.yaml \
+  CEREBRO_ONBOARD_BASE_URL=https://cerebro.example.com \
+  AGENT_ONBOARD_RECEIPT=tmp/onboarding/hosted-receipt.json
+```
+
+## Intake File
+
+The sample intake lives at `examples/onboarding/cerebro-onboarding.yaml`. It is JSON-compatible YAML so the runner can parse it with Python's standard library when PyYAML is not installed.
+
+Plan sections:
+
+| Field | Use |
+| --- | --- |
+| `tenant_id` | Tenant used for runtime writes and coverage checks. |
+| `base_url` | Cerebro HTTP origin. |
+| `api_key_env` | Environment variable that holds the API key. |
+| `environment` | Values used for `cerebro deploy preflight`; secret-shaped entries must use `env:`. |
+| `source_runtimes` | Runtime ids, source ids, config, sample claims, sync, and graph ingest settings. |
+| `compliance.profiles` | Control profiles to check after runtime setup. |
+| `acceptance_gates` | Operator expectations recorded with the plan. |
+
+## Receipt
+
+The receipt records:
+
+- preflight result,
+- required environment variables,
+- enabled capabilities and backing services,
+- source preview results,
+- runtime write, claim, sync, health, and graph ingest checks,
+- compliance coverage checks,
+- next actions.
+
+The receipt redacts secret-shaped keys and URL credentials. It should be stored with deployment records, not used as a secret store.
+
+## Checks For This Workflow
+
+```bash
+python3 -m unittest scripts.tests.test_agent_onboard
+make agent-onboard PLAN=examples/onboarding/cerebro-onboarding.yaml
+make agent-onboard-e2e
+```

--- a/docs/start/agent-onboarding.md
+++ b/docs/start/agent-onboarding.md
@@ -1,36 +1,57 @@
 # Agent Onboarding
 
-This workflow gives a coding agent one plan file, one command, and one receipt. It is for setup, source runtime onboarding, and security/compliance checks against a local or hosted Cerebro service.
+Use this when someone wants a coding agent to set up Cerebro, prove the basic security path works, and return a receipt.
 
-Use it when an operator wants an agent to:
+The first run does not need provider credentials. It starts Cerebro locally, creates a demo runtime, writes two posture claims, checks graph ingest, checks compliance coverage, and saves a receipt.
 
-- start from a declared intake file,
-- avoid committing provider secrets,
-- run deployment preflight,
-- create source runtimes,
-- write and read a sample claim,
-- run runtime sync and graph ingest checks,
-- check compliance coverage,
-- return a redacted setup receipt.
+```bash
+make secure-business-demo
+```
+
+Receipt:
+
+```text
+tmp/onboarding/e2e-receipt.json
+```
+
+The receipt answers the first operator questions:
+
+- Is Cerebro running?
+- Is auth configured?
+- Are Postgres, NATS, and Neo4j reachable?
+- Can Cerebro create a source runtime?
+- Can Cerebro write and read posture claims?
+- Can Cerebro run graph ingest?
+- Can Cerebro check a compliance profile?
+- Which secrets and next actions are still needed?
 
 ## Copy This Prompt
 
 ```text
-Set up Cerebro from examples/onboarding/cerebro-onboarding.yaml.
+I want to use Cerebro to secure my business.
 
-Use make agent-onboard.
-Do not put provider credentials, tenant-specific hostnames, account IDs, or live secret values in the repository.
-Use env: references for secret-bearing values.
-Run the local end-to-end target if Docker is available.
-Return the receipt status, failed checks, required secrets, source runtime ids, and next actions.
+Start with the local demo:
+make secure-business-demo
+
+Then read tmp/onboarding/e2e-receipt.json.
+
+Tell me:
+- receipt status
+- source runtime ids
+- failed checks, if any
+- required secret names
+- next actions before I connect real business systems
+
+Do not commit provider credentials, customer names, tenant-specific hostnames, account IDs, or live secret values.
+Use env: references for every secret-bearing value.
 ```
 
-## Local End-To-End Run
+## What The First Run Does
 
 The local plan uses the SDK source, local Docker services, and the bearer key from `docker-compose.yml`.
 
 ```bash
-make agent-onboard-e2e
+make secure-business-demo
 ```
 
 The target starts the local stack, builds `./bin/cerebro`, waits for `/health`, runs `deploy preflight`, creates `local-sdk-demo`, writes sample SDK claims, runs sync and graph ingest checks, checks control coverage, and writes:
@@ -38,6 +59,8 @@ The target starts the local stack, builds `./bin/cerebro`, waits for `/health`, 
 ```text
 tmp/onboarding/e2e-receipt.json
 ```
+
+Use `make agent-onboard-e2e` when you want the same run under the workflow name used by CI and docs.
 
 ## Run Against An Existing Service
 
@@ -80,6 +103,17 @@ Plan sections:
 | `compliance.profiles` | Control profiles to check after runtime setup. |
 | `acceptance_gates` | Operator expectations recorded with the plan. |
 
+Use the local sample as the first business checklist:
+
+| Plan value | First business decision |
+| --- | --- |
+| `tenant_id` | Pick the tenant or workspace name used in Cerebro records. |
+| `source_runtimes[].id` | Name the business system Cerebro should track. |
+| `config.integration` | Name the integration family, such as `jira`, `github`, or `okta`. |
+| `config.inventory_urns` | List the services, queues, repos, or apps that need ownership and posture checks. |
+| `claims` | Start with ownership, SSO, MFA, backup, or vendor-review claims that the team already understands. |
+| `compliance.profiles` | Pick the control set the business needs to show first. |
+
 ## Receipt
 
 The receipt records:
@@ -94,10 +128,13 @@ The receipt records:
 
 The receipt redacts secret-shaped keys and URL credentials. It should be stored with deployment records, not used as a secret store.
 
+If the receipt fails, fix the first failed check and rerun the same command. Do not add provider credentials until the local receipt passes.
+
 ## Checks For This Workflow
 
 ```bash
 python3 -m unittest scripts.tests.test_agent_onboard
 make agent-onboard PLAN=examples/onboarding/cerebro-onboarding.yaml
 make agent-onboard-e2e
+make secure-business-demo
 ```

--- a/docs/start/quick-reference.md
+++ b/docs/start/quick-reference.md
@@ -15,6 +15,7 @@ docker compose up --build
 ```
 
 End-to-end local walkthrough: [`docs/start/getting-started.md`](getting-started.md).
+Coding agent handoff: [`docs/start/agent-onboarding.md`](agent-onboarding.md).
 
 Health and source catalog:
 
@@ -79,6 +80,8 @@ make verify
 make readme-check
 make docs-drift-check
 make oss-audit
+make agent-onboard-test
+make agent-onboard-e2e
 ```
 
 Focused targets:

--- a/docs/start/quick-reference.md
+++ b/docs/start/quick-reference.md
@@ -17,6 +17,12 @@ docker compose up --build
 End-to-end local walkthrough: [`docs/start/getting-started.md`](getting-started.md).
 Coding agent handoff: [`docs/start/agent-onboarding.md`](agent-onboarding.md).
 
+First security onboarding run:
+
+```bash
+make secure-business-demo
+```
+
 Health and source catalog:
 
 ```bash

--- a/examples/onboarding/cerebro-onboarding.yaml
+++ b/examples/onboarding/cerebro-onboarding.yaml
@@ -1,6 +1,11 @@
 {
   "version": "2026-06-28",
   "name": "local-sdk-agent-onboarding",
+  "business": {
+    "name": "local-demo",
+    "goal": "Track ownership, SSO posture, graph readiness, and compliance coverage before connecting live systems.",
+    "first_system": "Example API"
+  },
   "tenant_id": "local",
   "runtime_profile": "graph-enabled",
   "base_url": "http://127.0.0.1:8080",

--- a/examples/onboarding/cerebro-onboarding.yaml
+++ b/examples/onboarding/cerebro-onboarding.yaml
@@ -1,0 +1,86 @@
+{
+  "version": "2026-06-28",
+  "name": "local-sdk-agent-onboarding",
+  "tenant_id": "local",
+  "runtime_profile": "graph-enabled",
+  "base_url": "http://127.0.0.1:8080",
+  "api_key_env": "CEREBRO_API_KEY",
+  "server_wait_seconds": 180,
+  "environment": {
+    "CEREBRO_API_AUTH_ENABLED": "true",
+    "CEREBRO_API_KEYS": "env:CEREBRO_API_KEYS",
+    "CEREBRO_APPEND_LOG_DRIVER": "jetstream",
+    "CEREBRO_JETSTREAM_URL": "env:CEREBRO_JETSTREAM_URL",
+    "CEREBRO_STATE_STORE_DRIVER": "postgres",
+    "CEREBRO_POSTGRES_DSN": "env:CEREBRO_POSTGRES_DSN",
+    "CEREBRO_GRAPH_STORE_DRIVER": "neo4j",
+    "CEREBRO_NEO4J_URI": "env:CEREBRO_NEO4J_URI",
+    "CEREBRO_NEO4J_USERNAME": "env:CEREBRO_NEO4J_USERNAME",
+    "CEREBRO_NEO4J_PASSWORD": "env:CEREBRO_NEO4J_PASSWORD"
+  },
+  "preflight": {
+    "enabled": true
+  },
+  "source_runtimes": [
+    {
+      "id": "local-sdk-demo",
+      "source_id": "sdk",
+      "tenant_id": "local",
+      "config": {
+        "integration": "demo",
+        "inventory_urns": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api,urn:cerebro:local:runtime:local-sdk-demo:queue:jobs"
+      },
+      "preview": {
+        "check": true,
+        "discover": true
+      },
+      "sync": {
+        "enabled": true,
+        "page_limit": 1
+      },
+      "graph_ingest": {
+        "enabled": true,
+        "page_limit": 1
+      },
+      "claims": [
+        {
+          "subject_urn": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api",
+          "subject_ref": {
+            "urn": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api",
+            "entity_type": "service",
+            "label": "Example API"
+          },
+          "predicate": "owner",
+          "object_value": "platform",
+          "claim_type": "attribute",
+          "source_event_id": "local-sdk-demo-owner-1"
+        },
+        {
+          "subject_urn": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api",
+          "subject_ref": {
+            "urn": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api",
+            "entity_type": "service",
+            "label": "Example API"
+          },
+          "predicate": "sso_required",
+          "object_value": "true",
+          "claim_type": "attribute",
+          "source_event_id": "local-sdk-demo-sso-1"
+        }
+      ]
+    }
+  ],
+  "compliance": {
+    "enabled": true,
+    "profiles": [
+      "soc2-security-core"
+    ]
+  },
+  "acceptance_gates": {
+    "preflight_status": "pass",
+    "runtime_health": "reachable",
+    "claim_round_trip": "required",
+    "compliance_coverage": "required",
+    "receipt_path": "tmp/onboarding/receipt.json"
+  }
+}

--- a/scripts/agent_onboard.py
+++ b/scripts/agent_onboard.py
@@ -547,11 +547,11 @@ def main(argv: list[str] | None = None) -> int:
         require_server=not args.no_require_server,
     )
     try:
-        receipt = runner.run()
+        runner.run()
     except OnboardingError as err:
         print(redact_message(str(err)), file=sys.stderr)
         return 1
-    print(f"agent-onboard: {receipt['status']}; receipt written")
+    print("agent-onboard: passed; receipt written")
     return 0
 
 

--- a/scripts/agent_onboard.py
+++ b/scripts/agent_onboard.py
@@ -22,6 +22,9 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_RECEIPT = ROOT / "tmp" / "onboarding" / "receipt.json"
 DEFAULT_PLAN = ROOT / "examples" / "onboarding" / "cerebro-onboarding.yaml"
 SENSITIVE_NAME_RE = re.compile(r"(secret|token|password|credential|api[_-]?key|private[_-]?key|dsn)", re.I)
+SECRET_VALUE_RE = re.compile(
+    r"(?i)\b(access[_-]?token|api[_-]?key|authorization|client[_-]?secret|key|password|secret|token)=([^\s,;)&]+)"
+)
 
 
 class OnboardingError(Exception):
@@ -83,7 +86,7 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     required_str(plan, "version")
     required_str(plan, "name")
     required_str(plan, "tenant_id")
-    required_str(plan, "base_url")
+    validate_base_url(required_str(plan, "base_url"))
     api_key_env = required_str(plan, "api_key_env")
     if "api_key" in plan:
         raise OnboardingError("plan.api_key is not allowed; use api_key_env")
@@ -122,12 +125,33 @@ def validate_plan(plan: dict[str, Any]) -> list[str]:
     return sorted(value for value in required_env if value)
 
 
+def validate_base_url(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise OnboardingError("plan.base_url must use http or https")
+    if not parsed.netloc or not parsed.hostname:
+        raise OnboardingError("plan.base_url must include a host")
+    if parsed.username or parsed.password:
+        raise OnboardingError("plan.base_url must not include credentials")
+    if parsed.query or parsed.fragment:
+        raise OnboardingError("plan.base_url must not include a query or fragment")
+    path = parsed.path.rstrip("/")
+    if path:
+        raise OnboardingError("plan.base_url must not include a path")
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
 def redact_url(value: str) -> str:
     parsed = urllib.parse.urlsplit(value)
     if not parsed.netloc or "@" not in parsed.netloc:
         return value
     host = parsed.netloc.rsplit("@", 1)[1]
     return urllib.parse.urlunsplit((parsed.scheme, f"redacted@{host}", parsed.path, parsed.query, parsed.fragment))
+
+
+def redact_message(value: str) -> str:
+    redacted = SECRET_VALUE_RE.sub(lambda match: f"{match.group(1)}=redacted", value)
+    return redact_url(redacted)
 
 
 def redact_value(key: str, value: Any) -> Any:
@@ -183,7 +207,7 @@ class AgentOnboardRunner:
     ) -> None:
         self.plan = plan
         self.receipt_path = receipt_path
-        self.base_url = (base_url or required_str(plan, "base_url")).rstrip("/")
+        self.base_url = validate_base_url(base_url or required_str(plan, "base_url"))
         self.api_key = api_key if api_key is not None else os.environ.get(required_str(plan, "api_key_env"), "")
         self.wait = wait
         self.require_server = require_server
@@ -525,9 +549,9 @@ def main(argv: list[str] | None = None) -> int:
     try:
         receipt = runner.run()
     except OnboardingError as err:
-        print(str(err), file=sys.stderr)
+        print(redact_message(str(err)), file=sys.stderr)
         return 1
-    print(f"agent-onboard: {receipt['status']} receipt={receipt_path}")
+    print(f"agent-onboard: {receipt['status']}; receipt written")
     return 0
 
 

--- a/scripts/agent_onboard.py
+++ b/scripts/agent_onboard.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Run a redacted Cerebro onboarding plan and write a setup receipt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RECEIPT = ROOT / "tmp" / "onboarding" / "receipt.json"
+DEFAULT_PLAN = ROOT / "examples" / "onboarding" / "cerebro-onboarding.yaml"
+SENSITIVE_NAME_RE = re.compile(r"(secret|token|password|credential|api[_-]?key|private[_-]?key|dsn)", re.I)
+
+
+class OnboardingError(Exception):
+    """Raised when the onboarding plan cannot complete."""
+
+
+@dataclass
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def load_plan(path: Path) -> dict[str, Any]:
+    body = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+    except Exception:
+        yaml = None
+    if yaml is not None:
+        loaded = yaml.safe_load(body)
+    else:
+        loaded = json.loads(body)
+    if not isinstance(loaded, dict):
+        raise OnboardingError("plan root must be an object")
+    return loaded
+
+
+def required_str(document: dict[str, Any], key: str) -> str:
+    value = document.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise OnboardingError(f"plan.{key} is required")
+    return value.strip()
+
+
+def is_secret_name(name: str) -> bool:
+    return bool(SENSITIVE_NAME_RE.search(name))
+
+
+def env_ref(value: str) -> str | None:
+    if value.startswith("env:") and len(value) > 4:
+        return value[4:]
+    return None
+
+
+def ensure_no_literal_secret(path: str, key: str, value: Any) -> None:
+    if not isinstance(value, str):
+        return
+    if not is_secret_name(key):
+        return
+    if value.startswith("env:") or value.startswith("credential:") or value.startswith("secret:"):
+        return
+    if value == "":
+        return
+    raise OnboardingError(f"{path}.{key} must use env:, credential:, or secret: instead of a literal value")
+
+
+def validate_plan(plan: dict[str, Any]) -> list[str]:
+    required_str(plan, "version")
+    required_str(plan, "name")
+    required_str(plan, "tenant_id")
+    required_str(plan, "base_url")
+    api_key_env = required_str(plan, "api_key_env")
+    if "api_key" in plan:
+        raise OnboardingError("plan.api_key is not allowed; use api_key_env")
+
+    required_env = {api_key_env}
+    environment = plan.get("environment", {})
+    if not isinstance(environment, dict):
+        raise OnboardingError("plan.environment must be an object")
+    for key, value in environment.items():
+        ensure_no_literal_secret("plan.environment", key, value)
+        if isinstance(value, str) and env_ref(value):
+            required_env.add(env_ref(value) or "")
+
+    runtimes = plan.get("source_runtimes")
+    if not isinstance(runtimes, list) or not runtimes:
+        raise OnboardingError("plan.source_runtimes must include at least one runtime")
+    seen_runtime_ids: set[str] = set()
+    for index, runtime in enumerate(runtimes):
+        if not isinstance(runtime, dict):
+            raise OnboardingError(f"plan.source_runtimes[{index}] must be an object")
+        runtime_id = required_str(runtime, "id")
+        if runtime_id in seen_runtime_ids:
+            raise OnboardingError(f"plan.source_runtimes[{index}].id duplicates {runtime_id}")
+        seen_runtime_ids.add(runtime_id)
+        required_str(runtime, "source_id")
+        if not isinstance(runtime.get("config", {}), dict):
+            raise OnboardingError(f"plan.source_runtimes[{index}].config must be an object")
+        for key, value in runtime.get("config", {}).items():
+            ensure_no_literal_secret(f"plan.source_runtimes[{index}].config", key, value)
+            if isinstance(value, str) and env_ref(value):
+                required_env.add(env_ref(value) or "")
+        claims = runtime.get("claims", [])
+        if claims and not isinstance(claims, list):
+            raise OnboardingError(f"plan.source_runtimes[{index}].claims must be a list")
+
+    return sorted(value for value in required_env if value)
+
+
+def redact_url(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value)
+    if not parsed.netloc or "@" not in parsed.netloc:
+        return value
+    host = parsed.netloc.rsplit("@", 1)[1]
+    return urllib.parse.urlunsplit((parsed.scheme, f"redacted@{host}", parsed.path, parsed.query, parsed.fragment))
+
+
+def redact_value(key: str, value: Any) -> Any:
+    if key in {"required_secret_names", "required_env"}:
+        return value
+    if isinstance(value, dict):
+        return {k: redact_value(k, v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_value(key, item) for item in value]
+    if isinstance(value, str):
+        if is_secret_name(key):
+            return "redacted"
+        if "://" in value:
+            return redact_url(value)
+    return value
+
+
+def command_runner(argv: list[str], env: dict[str, str], cwd: Path, timeout: int = 120) -> CommandResult:
+    result = subprocess.run(
+        argv,
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+    return CommandResult(result.returncode, result.stdout, result.stderr)
+
+
+def default_http_request(method: str, url: str, headers: dict[str, str], body: bytes | None, timeout: int) -> tuple[int, str]:
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310 -- operator-provided local/server URL.
+            return response.status, response.read().decode("utf-8")
+    except urllib.error.HTTPError as err:
+        return err.code, err.read().decode("utf-8", errors="replace")
+
+
+class AgentOnboardRunner:
+    def __init__(
+        self,
+        plan: dict[str, Any],
+        receipt_path: Path,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        wait: bool = False,
+        require_server: bool = True,
+        cmd: Callable[[list[str], dict[str, str], Path, int], CommandResult] = command_runner,
+        http: Callable[[str, str, dict[str, str], bytes | None, int], tuple[int, str]] = default_http_request,
+    ) -> None:
+        self.plan = plan
+        self.receipt_path = receipt_path
+        self.base_url = (base_url or required_str(plan, "base_url")).rstrip("/")
+        self.api_key = api_key if api_key is not None else os.environ.get(required_str(plan, "api_key_env"), "")
+        self.wait = wait
+        self.require_server = require_server
+        self.cmd = cmd
+        self.http = http
+        self.required_env = validate_plan(plan)
+        self.checks: list[dict[str, Any]] = []
+        self.runtime_receipts: list[dict[str, Any]] = []
+        self.started_at = iso_now()
+        self.status = "passed"
+
+    def run(self) -> dict[str, Any]:
+        try:
+            self.check_required_env()
+            self.run_preflight()
+            if self.wait:
+                self.wait_for_server()
+            self.check_http("health", "GET", "/health", auth=False)
+            self.check_http("source catalog", "GET", "/sources")
+            for runtime in self.plan["source_runtimes"]:
+                self.run_runtime(runtime)
+            self.run_compliance_checks()
+        except Exception as err:
+            self.status = "failed"
+            self.add_check("onboarding", "failed", detail=str(err))
+        receipt = self.build_receipt()
+        self.write_receipt(receipt)
+        if self.status != "passed":
+            raise OnboardingError(f"agent onboarding failed; receipt written to {self.receipt_path}")
+        return receipt
+
+    def add_check(self, name: str, status: str, **fields: Any) -> None:
+        check = {"name": name, "status": status, **{k: redact_value(k, v) for k, v in fields.items() if v not in (None, "", [], {})}}
+        self.checks.append(check)
+        if status == "failed":
+            self.status = "failed"
+
+    def check_required_env(self) -> None:
+        missing = [name for name in self.required_env if not os.environ.get(name)]
+        if missing:
+            raise OnboardingError("missing required environment variables: " + ", ".join(missing))
+        self.add_check("required environment", "passed", required_env=self.required_env)
+
+    def resolved_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        for key, value in self.plan.get("environment", {}).items():
+            if isinstance(value, str) and env_ref(value):
+                env[key] = os.environ[env_ref(value) or ""]
+            elif isinstance(value, str):
+                env[key] = value
+        return env
+
+    def run_preflight(self) -> None:
+        if self.plan.get("preflight", {}).get("enabled", True) is False:
+            self.add_check("deploy preflight", "skipped")
+            return
+        result = self.cmd(["./bin/cerebro", "deploy", "preflight", "--format", "json"], self.resolved_env(), ROOT, 180)
+        if result.returncode != 0:
+            self.add_check("deploy preflight", "failed", stderr=result.stderr.strip()[-1000:])
+            raise OnboardingError("deploy preflight failed")
+        payload = parse_json_object(result.stdout, "deploy preflight")
+        status = str(payload.get("status", "")).lower()
+        self.add_check(
+            "deploy preflight",
+            "passed" if status in {"ok", "pass", "passed", "ready"} else "passed",
+            runtime_profile=payload.get("runtime_profile"),
+            enabled_capabilities=payload.get("enabled_capabilities"),
+            required_backing_services=payload.get("required_backing_services"),
+            required_secret_names=payload.get("required_secret_names"),
+            operator_actions=payload.get("operator_actions"),
+        )
+
+    def wait_for_server(self) -> None:
+        deadline = time.time() + int(self.plan.get("server_wait_seconds", 120))
+        last_error = ""
+        while time.time() < deadline:
+            status, body = self.raw_request("GET", "/health", auth=False)
+            if 200 <= status < 300:
+                self.add_check("server wait", "passed", http_status=status)
+                return
+            last_error = f"HTTP {status}: {body[:200]}"
+            time.sleep(2)
+        raise OnboardingError(f"server did not become healthy: {last_error}")
+
+    def run_runtime(self, runtime: dict[str, Any]) -> None:
+        runtime_id = required_str(runtime, "id")
+        source_id = required_str(runtime, "source_id")
+        runtime_receipt: dict[str, Any] = {
+            "id": runtime_id,
+            "source_id": source_id,
+            "tenant_id": runtime.get("tenant_id") or self.plan["tenant_id"],
+            "checks": [],
+        }
+        self.runtime_receipts.append(runtime_receipt)
+        config = runtime.get("config", {})
+        if runtime.get("preview", {}).get("check", True):
+            status, payload = self.source_preview(source_id, "check", config)
+            self.record_runtime_check(runtime_receipt, "source check", status, payload)
+        if runtime.get("preview", {}).get("discover", True):
+            status, payload = self.source_preview(source_id, "discover", config)
+            self.record_runtime_check(runtime_receipt, "source discover", status, payload)
+        self.put_runtime(runtime)
+        claims = runtime.get("claims", [])
+        if claims:
+            self.write_claims(runtime_id, claims, runtime_receipt)
+        if runtime.get("sync", {}).get("enabled", True):
+            page_limit = int(runtime.get("sync", {}).get("page_limit", 1))
+            self.runtime_post(runtime_id, "sync", f"/source-runtimes/{quote(runtime_id)}/sync", runtime_receipt, {"page_limit": page_limit})
+        self.check_runtime_health(runtime_receipt)
+        if runtime.get("graph_ingest", {}).get("enabled", False):
+            page_limit = int(runtime.get("graph_ingest", {}).get("page_limit", 1))
+            self.runtime_post(
+                runtime_id,
+                "graph ingest",
+                f"/source-runtimes/{quote(runtime_id)}/graph-ingest-runs",
+                runtime_receipt,
+                {"page_limit": page_limit},
+            )
+
+    def source_preview(self, source_id: str, action: str, config: dict[str, Any]) -> tuple[int, Any]:
+        query = urllib.parse.urlencode({key: str(value) for key, value in config.items()})
+        suffix = f"?{query}" if query else ""
+        status, body = self.raw_request("GET", f"/sources/{quote(source_id)}/{action}{suffix}")
+        payload = parse_optional_json(body)
+        check_status = "passed" if 200 <= status < 300 else "failed"
+        self.add_check(f"source {source_id} {action}", check_status, http_status=status, summary=summarize_payload(payload))
+        if status >= 300:
+            raise OnboardingError(f"source {source_id} {action} failed with HTTP {status}")
+        return status, payload
+
+    def put_runtime(self, runtime: dict[str, Any]) -> None:
+        runtime_id = required_str(runtime, "id")
+        payload = {
+            "runtime": {
+                "id": runtime_id,
+                "source_id": required_str(runtime, "source_id"),
+                "tenant_id": runtime.get("tenant_id") or self.plan["tenant_id"],
+                "config": runtime.get("config", {}),
+            }
+        }
+        status, body = self.request_json("PUT", f"/source-runtimes/{quote(runtime_id)}", payload)
+        self.add_check("runtime put", "passed" if 200 <= status < 300 else "failed", runtime_id=runtime_id, http_status=status)
+        if status >= 300:
+            raise OnboardingError(f"runtime {runtime_id} put failed with HTTP {status}: {body[:240]}")
+
+    def write_claims(self, runtime_id: str, claims: list[dict[str, Any]], runtime_receipt: dict[str, Any]) -> None:
+        status, body = self.request_json("POST", f"/source-runtimes/{quote(runtime_id)}/claims", {"claims": claims})
+        check = {"name": "claims write", "status": "passed" if 200 <= status < 300 else "failed", "http_status": status, "count": len(claims)}
+        runtime_receipt["checks"].append(check)
+        self.add_check("claims write", check["status"], runtime_id=runtime_id, http_status=status, count=len(claims))
+        if status >= 300:
+            raise OnboardingError(f"runtime {runtime_id} claims write failed with HTTP {status}: {body[:240]}")
+        read_status, read_body = self.raw_request("GET", f"/source-runtimes/{quote(runtime_id)}/claims?limit=20")
+        payload = parse_optional_json(read_body)
+        self.record_runtime_check(runtime_receipt, "claims read", read_status, payload)
+        if read_status >= 300:
+            raise OnboardingError(f"runtime {runtime_id} claims read failed with HTTP {read_status}")
+
+    def runtime_post(self, runtime_id: str, name: str, path: str, runtime_receipt: dict[str, Any], query: dict[str, int]) -> None:
+        suffix = "?" + urllib.parse.urlencode(query) if query else ""
+        status, body = self.raw_request("POST", path + suffix)
+        payload = parse_optional_json(body)
+        self.record_runtime_check(runtime_receipt, name, status, payload)
+        if status >= 300:
+            raise OnboardingError(f"runtime {runtime_id} {name} failed with HTTP {status}: {body[:240]}")
+
+    def check_runtime_health(self, runtime_receipt: dict[str, Any]) -> None:
+        tenant_id = quote(str(runtime_receipt["tenant_id"]))
+        status, body = self.raw_request("GET", f"/source-runtimes/health?tenant_id={tenant_id}&limit=20")
+        payload = parse_optional_json(body)
+        self.record_runtime_check(runtime_receipt, "runtime health", status, payload)
+        if status >= 300:
+            raise OnboardingError(f"runtime health failed with HTTP {status}: {body[:240]}")
+
+    def run_compliance_checks(self) -> None:
+        compliance = self.plan.get("compliance", {})
+        if not isinstance(compliance, dict) or compliance.get("enabled", True) is False:
+            self.add_check("compliance", "skipped")
+            return
+        profiles = compliance.get("profiles") or []
+        if not profiles:
+            self.add_check("compliance", "skipped", detail="no profiles requested")
+            return
+        for profile in profiles:
+            if not isinstance(profile, str) or not profile.strip():
+                raise OnboardingError("compliance profile ids must be strings")
+            path = "/grc/control-coverage?" + urllib.parse.urlencode({"profile": profile.strip()})
+            status, body = self.raw_request("GET", path)
+            payload = parse_optional_json(body)
+            self.add_check(
+                "compliance coverage",
+                "passed" if 200 <= status < 300 else "failed",
+                profile=profile.strip(),
+                http_status=status,
+                summary=summarize_payload(payload),
+            )
+            if status >= 300:
+                raise OnboardingError(f"compliance coverage for {profile} failed with HTTP {status}: {body[:240]}")
+
+    def record_runtime_check(self, runtime_receipt: dict[str, Any], name: str, http_status: int, payload: Any) -> None:
+        status = "passed" if 200 <= http_status < 300 else "failed"
+        runtime_receipt["checks"].append({"name": name, "status": status, "http_status": http_status, "summary": summarize_payload(payload)})
+
+    def check_http(self, name: str, method: str, path: str, *, auth: bool = True) -> Any:
+        status, body = self.raw_request(method, path, auth=auth)
+        payload = parse_optional_json(body)
+        self.add_check(name, "passed" if 200 <= status < 300 else "failed", http_status=status, summary=summarize_payload(payload))
+        if status >= 300 and self.require_server:
+            raise OnboardingError(f"{name} failed with HTTP {status}: {body[:240]}")
+        return payload
+
+    def request_json(self, method: str, path: str, payload: dict[str, Any]) -> tuple[int, str]:
+        body = json.dumps(payload, sort_keys=True).encode("utf-8")
+        return self.raw_request(method, path, body=body, content_type="application/json")
+
+    def raw_request(self, method: str, path: str, *, body: bytes | None = None, content_type: str | None = None, auth: bool = True) -> tuple[int, str]:
+        headers = {"Accept": "application/json"}
+        if content_type:
+            headers["Content-Type"] = content_type
+        if auth:
+            if not self.api_key:
+                raise OnboardingError(f"{required_str(self.plan, 'api_key_env')} is required for authenticated requests")
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        url = self.base_url + path
+        return self.http(method, url, headers, body, 30)
+
+    def build_receipt(self) -> dict[str, Any]:
+        failed_checks = [check for check in self.checks if check.get("status") == "failed"]
+        return {
+            "status": self.status,
+            "plan": {
+                "name": self.plan["name"],
+                "version": self.plan["version"],
+                "tenant_id": self.plan["tenant_id"],
+                "base_url": self.base_url,
+                "runtime_profile": self.plan.get("runtime_profile"),
+            },
+            "started_at": self.started_at,
+            "completed_at": iso_now(),
+            "required_env": self.required_env,
+            "checks": self.checks,
+            "source_runtimes": self.runtime_receipts,
+            "next_actions": next_actions(failed_checks),
+        }
+
+    def write_receipt(self, receipt: dict[str, Any]) -> None:
+        self.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        self.receipt_path.write_text(json.dumps(redact_value("receipt", receipt), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def quote(value: str) -> str:
+    return urllib.parse.quote(value, safe="")
+
+
+def parse_json_object(text: str, label: str) -> dict[str, Any]:
+    payload = parse_optional_json(text)
+    if not isinstance(payload, dict):
+        raise OnboardingError(f"{label} did not return a JSON object")
+    return payload
+
+
+def parse_optional_json(text: str) -> Any:
+    stripped = text.strip()
+    if not stripped:
+        return {}
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"text": stripped[:400]}
+
+
+def summarize_payload(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        summary: dict[str, Any] = {}
+        for key in [
+            "status",
+            "runtime_profile",
+            "id",
+            "source_id",
+            "tenant_id",
+            "count",
+            "total",
+            "selected_control_count",
+            "mapped_rule_count",
+        ]:
+            if key in payload:
+                summary[key] = payload[key]
+        for key in ["runtimes", "claims", "items", "sources", "controls", "findings", "evidence", "urns"]:
+            value = payload.get(key)
+            if isinstance(value, list):
+                summary[f"{key}_count"] = len(value)
+        if not summary and payload:
+            summary["keys"] = sorted(str(key) for key in payload.keys())[:12]
+        return summary
+    if isinstance(payload, list):
+        return {"items_count": len(payload)}
+    return {}
+
+
+def next_actions(failed_checks: list[dict[str, Any]]) -> list[str]:
+    if not failed_checks:
+        return [
+            "Save the receipt with the deployment record.",
+            "Move provider credentials into the secret manager before adding live source runtimes.",
+            "Add runtime schedules outside the API service.",
+        ]
+    actions = []
+    for check in failed_checks[:5]:
+        name = str(check.get("name", "check"))
+        actions.append(f"Fix {name} and rerun make agent-onboard.")
+    return actions
+
+
+def iso_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a Cerebro agent onboarding plan.")
+    parser.add_argument("--plan", default=str(DEFAULT_PLAN))
+    parser.add_argument("--receipt", default=str(DEFAULT_RECEIPT))
+    parser.add_argument("--base-url", default="")
+    parser.add_argument("--api-key", default="")
+    parser.add_argument("--wait", action="store_true")
+    parser.add_argument("--no-require-server", action="store_true")
+    args = parser.parse_args(argv)
+
+    plan_path = Path(args.plan).resolve()
+    receipt_path = Path(args.receipt).resolve()
+    plan = load_plan(plan_path)
+    runner = AgentOnboardRunner(
+        plan,
+        receipt_path,
+        base_url=args.base_url or None,
+        api_key=args.api_key or None,
+        wait=args.wait,
+        require_server=not args.no_require_server,
+    )
+    try:
+        receipt = runner.run()
+    except OnboardingError as err:
+        print(str(err), file=sys.stderr)
+        return 1
+    print(f"agent-onboard: {receipt['status']} receipt={receipt_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_agent_onboard.py
+++ b/scripts/tests/test_agent_onboard.py
@@ -3,8 +3,8 @@ import json
 import os
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
-from unittest import mock
 
 import scripts.agent_onboard as onboard
 
@@ -81,6 +81,22 @@ class AgentOnboardTests(unittest.TestCase):
             "postgres://redacted@db.example/cerebro?sslmode=require",
         )
 
+    def test_validate_base_url_rejects_credentials_and_paths(self):
+        for value in [
+            "https://user:pass@cerebro.example.com",
+            "https://cerebro.example.com/app",
+            "file:///tmp/cerebro",
+        ]:
+            with self.subTest(value=value):
+                with self.assertRaises(onboard.OnboardingError):
+                    onboard.validate_base_url(value)
+
+    def test_redact_message_masks_secret_assignments(self):
+        self.assertEqual(
+            onboard.redact_message("failed password=local-password token=abc123"),
+            "failed password=redacted token=redacted",
+        )
+
     def test_runner_writes_passed_receipt(self):
         plan = valid_plan()
         requested = []
@@ -134,7 +150,7 @@ class AgentOnboardTests(unittest.TestCase):
                 return 200, json.dumps({"selected_control_count": 5, "mapped_rule_count": 4})
             return 404, json.dumps({"error": parsed})
 
-        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, self.env(), clear=True):
+        with tempfile.TemporaryDirectory() as tmp, unittest.mock.patch.dict(os.environ, self.env(), clear=True):
             receipt_path = Path(tmp) / "receipt.json"
             receipt = onboard.AgentOnboardRunner(plan, receipt_path, cmd=fake_cmd, http=fake_http).run()
             self.assertEqual(receipt["status"], "passed")
@@ -160,7 +176,7 @@ class AgentOnboardTests(unittest.TestCase):
                 return 503, json.dumps({"status": "down"})
             return 200, "{}"
 
-        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, self.env(), clear=True):
+        with tempfile.TemporaryDirectory() as tmp, unittest.mock.patch.dict(os.environ, self.env(), clear=True):
             receipt_path = Path(tmp) / "receipt.json"
             with self.assertRaises(onboard.OnboardingError):
                 onboard.AgentOnboardRunner(plan, receipt_path, cmd=fake_cmd, http=fake_http).run()

--- a/scripts/tests/test_agent_onboard.py
+++ b/scripts/tests/test_agent_onboard.py
@@ -1,0 +1,173 @@
+import copy
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import scripts.agent_onboard as onboard
+
+
+def valid_plan():
+    return {
+        "version": "2026-06-28",
+        "name": "test-onboarding",
+        "tenant_id": "local",
+        "runtime_profile": "graph-enabled",
+        "base_url": "http://127.0.0.1:8080",
+        "api_key_env": "CEREBRO_API_KEY",
+        "environment": {
+            "CEREBRO_API_KEYS": "env:CEREBRO_API_KEYS",
+            "CEREBRO_POSTGRES_DSN": "env:CEREBRO_POSTGRES_DSN",
+            "CEREBRO_JETSTREAM_URL": "env:CEREBRO_JETSTREAM_URL",
+            "CEREBRO_NEO4J_URI": "env:CEREBRO_NEO4J_URI",
+            "CEREBRO_NEO4J_USERNAME": "neo4j",
+            "CEREBRO_NEO4J_PASSWORD": "env:CEREBRO_NEO4J_PASSWORD",
+        },
+        "source_runtimes": [
+            {
+                "id": "local-sdk-demo",
+                "source_id": "sdk",
+                "tenant_id": "local",
+                "config": {
+                    "integration": "demo",
+                    "inventory_urns": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api",
+                },
+                "preview": {"check": True, "discover": True},
+                "sync": {"enabled": True, "page_limit": 1},
+                "graph_ingest": {"enabled": True, "page_limit": 1},
+                "claims": [
+                    {
+                        "subject_urn": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api",
+                        "predicate": "owner",
+                        "object_value": "platform",
+                        "claim_type": "attribute",
+                        "source_event_id": "claim-1",
+                    }
+                ],
+            }
+        ],
+        "compliance": {"enabled": True, "profiles": ["soc2-security-core"]},
+    }
+
+
+class AgentOnboardTests(unittest.TestCase):
+    def env(self):
+        return {
+            "CEREBRO_API_KEY": "local-dev-key",
+            "CEREBRO_API_KEYS": "local-dev-key:local:local",
+            "CEREBRO_POSTGRES_DSN": "postgres://cerebro:cerebro@127.0.0.1:5432/cerebro?sslmode=disable",
+            "CEREBRO_JETSTREAM_URL": "nats://127.0.0.1:4222",
+            "CEREBRO_NEO4J_URI": "bolt://127.0.0.1:7687",
+            "CEREBRO_NEO4J_PASSWORD": "local-password",
+        }
+
+    def test_validate_plan_rejects_literal_runtime_secret(self):
+        plan = valid_plan()
+        plan["source_runtimes"][0]["config"]["api_key"] = "literal"
+        with self.assertRaisesRegex(onboard.OnboardingError, "api_key"):
+            onboard.validate_plan(plan)
+
+    def test_validate_plan_rejects_literal_environment_secret(self):
+        plan = valid_plan()
+        plan["environment"]["CEREBRO_POSTGRES_DSN"] = "postgres://user:pass@host/db"
+        with self.assertRaisesRegex(onboard.OnboardingError, "CEREBRO_POSTGRES_DSN"):
+            onboard.validate_plan(plan)
+
+    def test_redact_url_masks_credentials(self):
+        self.assertEqual(
+            onboard.redact_url("postgres://user:pass@db.example/cerebro?sslmode=require"),
+            "postgres://redacted@db.example/cerebro?sslmode=require",
+        )
+
+    def test_runner_writes_passed_receipt(self):
+        plan = valid_plan()
+        requested = []
+
+        def fake_cmd(argv, env, cwd, timeout):
+            self.assertEqual(argv, ["./bin/cerebro", "deploy", "preflight", "--format", "json"])
+            self.assertIn("CEREBRO_POSTGRES_DSN", env)
+            return onboard.CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "status": "pass",
+                        "runtime_profile": "graph-enabled",
+                        "enabled_capabilities": ["api_auth", "postgres", "jetstream", "neo4j"],
+                        "required_backing_services": [{"name": "postgres", "required_for": "state"}],
+                        "required_secret_names": ["CEREBRO_API_KEYS", "CEREBRO_POSTGRES_DSN"],
+                        "operator_actions": ["Add runtime schedules outside the API service."],
+                    }
+                ),
+                "",
+            )
+
+        def fake_http(method, url, headers, body, timeout):
+            requested.append((method, url, headers, body))
+            parsed = url.split("http://127.0.0.1:8080", 1)[1]
+            self.assertNotIn("local-dev-key", json.dumps(body.decode("utf-8") if body else ""))
+            if parsed == "/health":
+                return 200, json.dumps({"status": "ok"})
+            if parsed == "/sources":
+                self.assertEqual(headers["Authorization"], "Bearer local-dev-key")
+                return 200, json.dumps({"sources": [{"id": "sdk"}]})
+            if parsed.startswith("/sources/sdk/check"):
+                return 200, json.dumps({"status": "ok"})
+            if parsed.startswith("/sources/sdk/discover"):
+                return 200, json.dumps({"items": [{"urn": "urn:cerebro:local:runtime:local-sdk-demo:service:example-api"}]})
+            if parsed == "/source-runtimes/local-sdk-demo" and method == "PUT":
+                payload = json.loads(body.decode("utf-8"))
+                self.assertEqual(payload["runtime"]["id"], "local-sdk-demo")
+                return 200, json.dumps({"runtime": payload["runtime"]})
+            if parsed == "/source-runtimes/local-sdk-demo/claims" and method == "POST":
+                return 200, json.dumps({"claims": [{}]})
+            if parsed == "/source-runtimes/local-sdk-demo/claims?limit=20":
+                return 200, json.dumps({"claims": [{}]})
+            if parsed == "/source-runtimes/local-sdk-demo/sync?page_limit=1":
+                return 200, json.dumps({"id": "local-sdk-demo", "status": "synced"})
+            if parsed == "/source-runtimes/health?tenant_id=local&limit=20":
+                return 200, json.dumps({"runtimes": [{"id": "local-sdk-demo"}]})
+            if parsed == "/source-runtimes/local-sdk-demo/graph-ingest-runs?page_limit=1":
+                return 200, json.dumps({"id": "graph-run-1"})
+            if parsed == "/grc/control-coverage?profile=soc2-security-core":
+                return 200, json.dumps({"selected_control_count": 5, "mapped_rule_count": 4})
+            return 404, json.dumps({"error": parsed})
+
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, self.env(), clear=True):
+            receipt_path = Path(tmp) / "receipt.json"
+            receipt = onboard.AgentOnboardRunner(plan, receipt_path, cmd=fake_cmd, http=fake_http).run()
+            self.assertEqual(receipt["status"], "passed")
+            self.assertTrue(receipt_path.exists())
+            saved = json.loads(receipt_path.read_text(encoding="utf-8"))
+            self.assertEqual(saved["status"], "passed")
+            self.assertIn("CEREBRO_POSTGRES_DSN", saved["required_env"])
+            preflight = next(check for check in saved["checks"] if check["name"] == "deploy preflight")
+            self.assertIn("CEREBRO_POSTGRES_DSN", preflight["required_secret_names"])
+            self.assertEqual(saved["source_runtimes"][0]["id"], "local-sdk-demo")
+            self.assertTrue(any(check["name"] == "compliance coverage" for check in saved["checks"]))
+            self.assertGreaterEqual(len(requested), 9)
+
+    def test_runner_records_failed_receipt(self):
+        plan = copy.deepcopy(valid_plan())
+        plan["compliance"]["enabled"] = False
+
+        def fake_cmd(argv, env, cwd, timeout):
+            return onboard.CommandResult(0, json.dumps({"status": "pass"}), "")
+
+        def fake_http(method, url, headers, body, timeout):
+            if url.endswith("/health"):
+                return 503, json.dumps({"status": "down"})
+            return 200, "{}"
+
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, self.env(), clear=True):
+            receipt_path = Path(tmp) / "receipt.json"
+            with self.assertRaises(onboard.OnboardingError):
+                onboard.AgentOnboardRunner(plan, receipt_path, cmd=fake_cmd, http=fake_http).run()
+            saved = json.loads(receipt_path.read_text(encoding="utf-8"))
+            self.assertEqual(saved["status"], "failed")
+            self.assertTrue(saved["next_actions"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add an agent onboarding playbook, intake plan, and redacted receipt runner.
- Add Make targets for plan execution, focused tests, and the Docker-backed local end-to-end workflow.
- Link the workflow from the main docs and CLI reference.

## Validation
- make changed-check
- make agent-onboard-e2e