### PR TITLE
[codex] Expand AI provider governance catalog

### DIFF
--- a/internal/connectorcatalog/ai_governance_catalog_test.go
+++ b/internal/connectorcatalog/ai_governance_catalog_test.go
@@ -12,16 +12,24 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 		entries[entry.Definition.SourceID] = entry
 	}
 	expected := map[string][]string{
-		"cerebras":     {"api_keys", "model_deployments", "projects", "usage_reports"},
-		"databricks":   {"audit_events", "assets", "model_serving_endpoints", "vulnerabilities"},
-		"fireworks_ai": {"audit_logs", "billing_metrics", "model_deployments", "service_accounts"},
-		"huggingface":  {"audit_logs", "organization_members", "repositories", "resource_groups"},
-		"mistral":      {"api_keys", "audit_logs", "usage_reports", "workspaces"},
-		"openrouter":   {"api_keys", "organization_members", "provider_keys", "usage_reports"},
-		"perplexity":   {"api_groups", "api_keys", "team_members", "usage_reports"},
-		"snowflake":    {"assets", "audit_events", "cortex_search_services", "vulnerabilities"},
-		"together_ai":  {"api_keys", "fine_tuning_jobs", "projects", "usage_reports"},
-		"xai":          {"api_keys", "audit_logs", "model_access", "usage_reports"},
+		"anthropic":         {"api_keys", "model_catalog", "organization_invites", "organization_members", "workspaces"},
+		"aws_bedrock":       {"custom_models", "foundation_models", "guardrails", "model_customization_jobs", "provisioned_model_throughputs"},
+		"cerebras":          {"api_keys", "model_deployments", "projects", "usage_reports"},
+		"cohere":            {"connectors", "datasets", "fine_tuned_models", "model_catalog"},
+		"databricks":        {"audit_events", "assets", "model_serving_endpoints", "vulnerabilities"},
+		"fireworks_ai":      {"audit_logs", "billing_metrics", "model_deployments", "service_accounts"},
+		"google_vertex_ai":  {"batch_prediction_jobs", "custom_jobs", "endpoints", "indexes", "models", "reasoning_engines"},
+		"groq":              {"batch_jobs", "files", "fine_tuning_jobs", "model_catalog"},
+		"huggingface":       {"audit_logs", "organization_members", "repositories", "resource_groups"},
+		"microsoft_foundry": {"agents", "connections", "datasets", "evaluations", "indexes"},
+		"mistral":           {"api_keys", "audit_logs", "usage_reports", "workspaces"},
+		"openrouter":        {"api_keys", "organization_members", "provider_keys", "usage_reports"},
+		"perplexity":        {"api_groups", "api_keys", "team_members", "usage_reports"},
+		"replicate":         {"collections", "deployments", "models", "predictions"},
+		"snowflake":         {"assets", "audit_events", "cortex_search_services", "vulnerabilities"},
+		"stability_ai":      {"account", "account_balance", "engines"},
+		"together_ai":       {"api_keys", "fine_tuning_jobs", "projects", "usage_reports"},
+		"xai":               {"api_keys", "audit_logs", "model_access", "usage_reports"},
 	}
 	directProviders := map[string]struct{}{
 		"cerebras":     {},
@@ -72,11 +80,38 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 	if got := repositories.ConfigQuery["author"]; got != "organization" {
 		t.Fatalf("huggingface repositories author config query = %q, want organization", got)
 	}
+	anthropic := entries["anthropic"]
+	if anthropic.Definition.Auth.TokenHeader != "x-api-key" {
+		t.Fatalf("anthropic token header = %q, want x-api-key", anthropic.Definition.Auth.TokenHeader)
+	}
+	if got := anthropic.Definition.Transport.Headers["anthropic-version"]; got != "2023-06-01" {
+		t.Fatalf("anthropic version header = %q, want 2023-06-01", got)
+	}
+	microsoftFoundry := entries["microsoft_foundry"]
+	if microsoftFoundry.Definition.Auth.TokenHeader != "api-key" {
+		t.Fatalf("microsoft_foundry token header = %q, want api-key", microsoftFoundry.Definition.Auth.TokenHeader)
+	}
+	agents := catalogFamily(t, microsoftFoundry.Definition.ResourceFamilies, "agents")
+	if got := agents.StaticQuery["api-version"]; got != "v1" {
+		t.Fatalf("microsoft_foundry agents api-version = %q, want v1", got)
+	}
+	stability := entries["stability_ai"]
+	for _, familyID := range []string{"account", "account_balance"} {
+		if family := catalogFamily(t, stability.Definition.ResourceFamilies, familyID); !family.Singleton {
+			t.Fatalf("stability_ai family %q singleton = false, want true", familyID)
+		}
+	}
 	for _, test := range []struct {
 		sourceID string
 		field    string
 	}{
+		{sourceID: "aws_bedrock", field: "region"},
+		{sourceID: "aws_bedrock", field: "service"},
 		{sourceID: "databricks", field: "workspace_url"},
+		{sourceID: "google_vertex_ai", field: "project_id"},
+		{sourceID: "google_vertex_ai", field: "location"},
+		{sourceID: "microsoft_foundry", field: "endpoint"},
+		{sourceID: "microsoft_foundry", field: "project_name"},
 		{sourceID: "snowflake", field: "account"},
 	} {
 		fields := map[string]struct{}{}

--- a/internal/connectorcatalog/catalog/ai-governance.yaml
+++ b/internal/connectorcatalog/catalog/ai-governance.yaml
@@ -4,6 +4,339 @@ entries:
   - classifier_output: supported
     definition:
       schema_version: cerebro.integration/v1
+      id: builtin-anthropic
+      tenant_id: builtin_catalog
+      source_id: anthropic
+      display_name: Anthropic
+      description: "Anthropic connector definition for models, organization members, API keys, workspaces, and organization invites."
+      categories:
+        - ai
+        - governance
+      auth:
+        model: api_key
+        token_header: x-api-key
+        credential_fields:
+          - key: api_key
+            label: API key
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.anthropic.com"
+        headers:
+          anthropic-version: "2023-06-01"
+        verification:
+          method: GET
+          path: /v1/models
+          expect_status: [200]
+      resource_families:
+        - id: model_catalog
+          label: Model catalog
+          path: /v1/models
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: display_name
+          event:
+            kind: anthropic.model_catalog
+            schema_ref: anthropic/model_catalog/v1
+          projection:
+            template: asset
+          coverage:
+            - id: model_catalog
+              type: entity_family
+              title: Model catalog
+              families: [model_catalog]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: organization_members
+          label: Organization members
+          path: /v1/organizations/users
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: email
+          event:
+            kind: anthropic.organization_members
+            schema_ref: anthropic/organization_members/v1
+          projection:
+            template: identity_user
+          coverage:
+            - id: organization_members
+              type: entity_family
+              title: Organization members
+              families: [organization_members]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory, identity_access]
+          pagination:
+            type: cursor
+            cursor_param: after_id
+            cursor_json_path: "$.last_id"
+            page_size_param: limit
+            page_size: 100
+        - id: api_keys
+          label: API keys
+          path: /v1/organizations/api_keys
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: anthropic.api_keys
+            schema_ref: anthropic/api_keys/v1
+          projection:
+            template: secret
+          coverage:
+            - id: api_keys
+              type: app_entitlement
+              title: API keys
+              families: [api_keys]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
+          pagination:
+            type: cursor
+            cursor_param: after_id
+            cursor_json_path: "$.last_id"
+            page_size_param: limit
+            page_size: 100
+        - id: workspaces
+          label: Workspaces
+          path: /v1/organizations/workspaces
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: anthropic.workspaces
+            schema_ref: anthropic/workspaces/v1
+          projection:
+            template: asset
+          coverage:
+            - id: workspaces
+              type: entity_family
+              title: Workspaces
+              families: [workspaces]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: cursor
+            cursor_param: after_id
+            cursor_json_path: "$.last_id"
+            page_size_param: limit
+            page_size: 100
+        - id: organization_invites
+          label: Organization invites
+          path: /v1/organizations/invites
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: email
+          event:
+            kind: anthropic.organization_invites
+            schema_ref: anthropic/organization_invites/v1
+          projection:
+            template: identity_user
+          coverage:
+            - id: organization_invites
+              type: app_entitlement
+              title: Organization invites
+              families: [organization_invites]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
+          pagination:
+            type: cursor
+            cursor_param: after_id
+            cursor_json_path: "$.last_id"
+            page_size_param: limit
+            page_size: 100
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-aws-bedrock
+      tenant_id: builtin_catalog
+      source_id: aws_bedrock
+      display_name: AWS Bedrock
+      description: "AWS Bedrock connector definition for foundation models, custom models, provisioned throughput, customization jobs, and guardrails."
+      categories:
+        - ai
+        - governance
+      config_fields:
+        - key: region
+          label: AWS region
+          required: true
+          placeholder: us-east-1
+        - key: service
+          label: AWS signing service
+          required: true
+          help: "Use bedrock for AWS Bedrock control-plane APIs."
+          placeholder: bedrock
+      auth:
+        model: aws_sigv4
+        credential_fields:
+          - key: access_key
+            label: Access key ID
+            secret: true
+            reference_only: true
+          - key: secret_key
+            label: Secret access key
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://bedrock.${config.region}.amazonaws.com"
+        verification:
+          method: GET
+          path: /foundation-models
+          expect_status: [200]
+      resource_families:
+        - id: foundation_models
+          label: Foundation models
+          path: /foundation-models
+          method: GET
+          record_selector: "$.modelSummaries[*]"
+          id_field: modelId
+          name_field: modelName
+          event:
+            kind: aws_bedrock.foundation_models
+            schema_ref: aws_bedrock/foundation_models/v1
+          projection:
+            template: asset
+          coverage:
+            - id: foundation_models
+              type: entity_family
+              title: Foundation models
+              families: [foundation_models]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: custom_models
+          label: Custom models
+          path: /custom-models
+          method: GET
+          record_selector: "$.modelSummaries[*]"
+          id_field: modelArn
+          name_field: modelName
+          event:
+            kind: aws_bedrock.custom_models
+            schema_ref: aws_bedrock/custom_models/v1
+          projection:
+            template: asset
+          coverage:
+            - id: custom_models
+              type: entity_family
+              title: Custom models
+              families: [custom_models]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: cursor
+            cursor_param: nextToken
+            cursor_json_path: "$.nextToken"
+            page_size_param: maxResults
+            page_size: 100
+        - id: provisioned_model_throughputs
+          label: Provisioned model throughputs
+          path: /provisioned-model-throughputs
+          method: GET
+          record_selector: "$.provisionedModelSummaries[*]"
+          id_field: provisionedModelArn
+          name_field: provisionedModelName
+          event:
+            kind: aws_bedrock.provisioned_model_throughputs
+            schema_ref: aws_bedrock/provisioned_model_throughputs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: provisioned_model_throughputs
+              type: deployment_state
+              title: Provisioned model throughputs
+              families: [provisioned_model_throughputs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: nextToken
+            cursor_json_path: "$.nextToken"
+            page_size_param: maxResults
+            page_size: 100
+        - id: model_customization_jobs
+          label: Model customization jobs
+          path: /model-customization-jobs
+          method: GET
+          record_selector: "$.modelCustomizationJobSummaries[*]"
+          id_field: jobArn
+          name_field: jobName
+          event:
+            kind: aws_bedrock.model_customization_jobs
+            schema_ref: aws_bedrock/model_customization_jobs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: model_customization_jobs
+              type: deployment_state
+              title: Model customization jobs
+              families: [model_customization_jobs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: nextToken
+            cursor_json_path: "$.nextToken"
+            page_size_param: maxResults
+            page_size: 100
+        - id: guardrails
+          label: Guardrails
+          path: /guardrails
+          method: GET
+          record_selector: "$.guardrails[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: aws_bedrock.guardrails
+            schema_ref: aws_bedrock/guardrails/v1
+          projection:
+            template: policy
+          coverage:
+            - id: guardrails
+              type: lifecycle_state
+              title: Guardrails
+              families: [guardrails]
+              support: partial
+              high_value: true
+              evidence_types: [policy_configuration]
+              control_domains: [policy_management]
+          pagination:
+            type: cursor
+            cursor_param: nextToken
+            cursor_json_path: "$.nextToken"
+            page_size_param: maxResults
+            page_size: 100
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
       id: builtin-cerebras
       tenant_id: builtin_catalog
       source_id: cerebras
@@ -113,6 +446,131 @@ entries:
               type: deployment_state
               title: Model deployments
               families: [model_deployments]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-cohere
+      tenant_id: builtin_catalog
+      source_id: cohere
+      display_name: Cohere
+      description: "Cohere connector definition for models, connectors, datasets, and fine-tuned models."
+      categories:
+        - ai
+        - governance
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.cohere.com"
+        verification:
+          method: GET
+          path: /v1/models
+          expect_status: [200]
+      resource_families:
+        - id: model_catalog
+          label: Model catalog
+          path: /v1/models
+          method: GET
+          list_key: models
+          record_selector: "$.models[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: cohere.model_catalog
+            schema_ref: cohere/model_catalog/v1
+          projection:
+            template: asset
+          coverage:
+            - id: model_catalog
+              type: entity_family
+              title: Model catalog
+              families: [model_catalog]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: connectors
+          label: Connectors
+          path: /v1/connectors
+          method: GET
+          list_key: connectors
+          record_selector: "$.connectors[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: cohere.connectors
+            schema_ref: cohere/connectors/v1
+          projection:
+            template: asset
+          coverage:
+            - id: connectors
+              type: entity_family
+              title: Connectors
+              families: [connectors]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: datasets
+          label: Datasets
+          path: /v1/datasets
+          method: GET
+          list_key: datasets
+          record_selector: "$.datasets[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: cohere.datasets
+            schema_ref: cohere/datasets/v1
+          projection:
+            template: asset
+          coverage:
+            - id: datasets
+              type: entity_family
+              title: Datasets
+              families: [datasets]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: fine_tuned_models
+          label: Fine-tuned models
+          path: /v1/finetuning/finetuned-models
+          method: GET
+          list_key: finetuned_models
+          record_selector: "$.finetuned_models[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: cohere.fine_tuned_models
+            schema_ref: cohere/fine_tuned_models/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: fine_tuned_models
+              type: deployment_state
+              title: Fine-tuned models
+              families: [fine_tuned_models]
               support: partial
               high_value: true
               evidence_types: [change_management]
@@ -247,6 +705,319 @@ entries:
   - classifier_output: supported
     definition:
       schema_version: cerebro.integration/v1
+      id: builtin-google-vertex-ai
+      tenant_id: builtin_catalog
+      source_id: google_vertex_ai
+      display_name: Google Vertex AI
+      description: "Google Vertex AI connector definition for models, endpoints, custom jobs, batch prediction jobs, indexes, and reasoning engines."
+      categories:
+        - ai
+        - governance
+      config_fields:
+        - key: project_id
+          label: Project ID
+          required: true
+        - key: location
+          label: Location
+          required: true
+          placeholder: us-central1
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://${config.location}-aiplatform.googleapis.com"
+        verification:
+          method: GET
+          path: /v1/projects/${config.project_id}/locations/${config.location}/models
+          expect_status: [200]
+      resource_families:
+        - id: models
+          label: Models
+          path: /v1/projects/${config.project_id}/locations/${config.location}/models
+          method: GET
+          record_selector: "$.models[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_vertex_ai.models
+            schema_ref: google_vertex_ai/models/v1
+          projection:
+            template: asset
+          coverage:
+            - id: models
+              type: entity_family
+              title: Models
+              families: [models]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: endpoints
+          label: Endpoints
+          path: /v1/projects/${config.project_id}/locations/${config.location}/endpoints
+          method: GET
+          record_selector: "$.endpoints[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_vertex_ai.endpoints
+            schema_ref: google_vertex_ai/endpoints/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: endpoints
+              type: deployment_state
+              title: Endpoints
+              families: [endpoints]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: custom_jobs
+          label: Custom jobs
+          path: /v1/projects/${config.project_id}/locations/${config.location}/customJobs
+          method: GET
+          record_selector: "$.customJobs[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_vertex_ai.custom_jobs
+            schema_ref: google_vertex_ai/custom_jobs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: custom_jobs
+              type: deployment_state
+              title: Custom jobs
+              families: [custom_jobs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: batch_prediction_jobs
+          label: Batch prediction jobs
+          path: /v1/projects/${config.project_id}/locations/${config.location}/batchPredictionJobs
+          method: GET
+          record_selector: "$.batchPredictionJobs[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_vertex_ai.batch_prediction_jobs
+            schema_ref: google_vertex_ai/batch_prediction_jobs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: batch_prediction_jobs
+              type: deployment_state
+              title: Batch prediction jobs
+              families: [batch_prediction_jobs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: indexes
+          label: Indexes
+          path: /v1/projects/${config.project_id}/locations/${config.location}/indexes
+          method: GET
+          record_selector: "$.indexes[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_vertex_ai.indexes
+            schema_ref: google_vertex_ai/indexes/v1
+          projection:
+            template: asset
+          coverage:
+            - id: indexes
+              type: entity_family
+              title: Indexes
+              families: [indexes]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: reasoning_engines
+          label: Reasoning engines
+          path: /v1/projects/${config.project_id}/locations/${config.location}/reasoningEngines
+          method: GET
+          record_selector: "$.reasoningEngines[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_vertex_ai.reasoning_engines
+            schema_ref: google_vertex_ai/reasoning_engines/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: reasoning_engines
+              type: deployment_state
+              title: Reasoning engines
+              families: [reasoning_engines]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-groq
+      tenant_id: builtin_catalog
+      source_id: groq
+      display_name: Groq
+      description: "Groq connector definition for model catalog, files, batch jobs, and fine-tuning jobs."
+      categories:
+        - ai
+        - governance
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.groq.com/openai/v1"
+        verification:
+          method: GET
+          path: /models
+          expect_status: [200]
+      resource_families:
+        - id: model_catalog
+          label: Model catalog
+          path: /models
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          event:
+            kind: groq.model_catalog
+            schema_ref: groq/model_catalog/v1
+          projection:
+            template: asset
+          coverage:
+            - id: model_catalog
+              type: entity_family
+              title: Model catalog
+              families: [model_catalog]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: files
+          label: Files
+          path: /files
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: filename
+          event:
+            kind: groq.files
+            schema_ref: groq/files/v1
+          projection:
+            template: asset
+          coverage:
+            - id: files
+              type: entity_family
+              title: Files
+              families: [files]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: batch_jobs
+          label: Batch jobs
+          path: /batches
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          event:
+            kind: groq.batch_jobs
+            schema_ref: groq/batch_jobs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: batch_jobs
+              type: deployment_state
+              title: Batch jobs
+              families: [batch_jobs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: fine_tuning_jobs
+          label: Fine-tuning jobs
+          path: /fine_tuning/jobs
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          event:
+            kind: groq.fine_tuning_jobs
+            schema_ref: groq/fine_tuning_jobs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: fine_tuning_jobs
+              type: deployment_state
+              title: Fine-tuning jobs
+              families: [fine_tuning_jobs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
       id: builtin-huggingface
       tenant_id: builtin_catalog
       source_id: huggingface
@@ -372,6 +1143,171 @@ entries:
             link_header: Link
             page_size_param: limit
             page_size: 100
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-microsoft-foundry
+      tenant_id: builtin_catalog
+      source_id: microsoft_foundry
+      display_name: Microsoft Foundry
+      description: "Microsoft Foundry connector definition for agents, datasets, indexes, evaluations, and project connections."
+      categories:
+        - ai
+        - governance
+      config_fields:
+        - key: endpoint
+          label: Foundry endpoint
+          required: true
+          help: "Host name for the Foundry project endpoint."
+        - key: project_name
+          label: Project name
+          required: true
+      auth:
+        model: api_key
+        token_header: api-key
+        credential_fields:
+          - key: api_key
+            label: API key
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://${config.endpoint}/api/projects/${config.project_name}"
+        verification:
+          method: GET
+          path: /agents?api-version=v1
+          expect_status: [200]
+      resource_families:
+        - id: agents
+          label: Agents
+          path: /agents
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: name
+          static_query:
+            api-version: v1
+          event:
+            kind: microsoft_foundry.agents
+            schema_ref: microsoft_foundry/agents/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: agents
+              type: deployment_state
+              title: Agents
+              families: [agents]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: datasets
+          label: Datasets
+          path: /datasets
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: name
+          static_query:
+            api-version: v1
+          event:
+            kind: microsoft_foundry.datasets
+            schema_ref: microsoft_foundry/datasets/v1
+          projection:
+            template: asset
+          coverage:
+            - id: datasets
+              type: entity_family
+              title: Datasets
+              families: [datasets]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: indexes
+          label: Indexes
+          path: /indexes
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: name
+          static_query:
+            api-version: v1
+          event:
+            kind: microsoft_foundry.indexes
+            schema_ref: microsoft_foundry/indexes/v1
+          projection:
+            template: asset
+          coverage:
+            - id: indexes
+              type: entity_family
+              title: Indexes
+              families: [indexes]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: evaluations
+          label: Evaluations
+          path: /evaluations
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: name
+          static_query:
+            api-version: v1
+          event:
+            kind: microsoft_foundry.evaluations
+            schema_ref: microsoft_foundry/evaluations/v1
+          projection:
+            template: audit_event
+          coverage:
+            - id: evaluations
+              type: audit_event
+              title: Evaluations
+              families: [evaluations]
+              support: partial
+              high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: connections
+          label: Connections
+          path: /connections
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: name
+          static_query:
+            api-version: v1
+          event:
+            kind: microsoft_foundry.connections
+            schema_ref: microsoft_foundry/connections/v1
+          projection:
+            template: asset
+          coverage:
+            - id: connections
+              type: entity_family
+              title: Connections
+              families: [connections]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
 
   - classifier_output: supported
     definition:
@@ -724,6 +1660,222 @@ entries:
               type: entity_family
               title: Usage reports
               families: [usage_reports]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-replicate
+      tenant_id: builtin_catalog
+      source_id: replicate
+      display_name: Replicate
+      description: "Replicate connector definition for models, deployments, collections, and predictions."
+      categories:
+        - ai
+        - governance
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.replicate.com"
+        verification:
+          method: GET
+          path: /v1/models
+          expect_status: [200]
+      resource_families:
+        - id: models
+          label: Models
+          path: /v1/models
+          method: GET
+          record_selector: "$.results[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: replicate.models
+            schema_ref: replicate/models/v1
+          projection:
+            template: asset
+          coverage:
+            - id: models
+              type: entity_family
+              title: Models
+              families: [models]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: deployments
+          label: Deployments
+          path: /v1/deployments
+          method: GET
+          record_selector: "$.results[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: replicate.deployments
+            schema_ref: replicate/deployments/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: deployments
+              type: deployment_state
+              title: Deployments
+              families: [deployments]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: collections
+          label: Collections
+          path: /v1/collections
+          method: GET
+          record_selector: "$.results[*]"
+          id_field: slug
+          name_field: name
+          event:
+            kind: replicate.collections
+            schema_ref: replicate/collections/v1
+          projection:
+            template: asset
+          coverage:
+            - id: collections
+              type: entity_family
+              title: Collections
+              families: [collections]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: predictions
+          label: Predictions
+          path: /v1/predictions
+          method: GET
+          record_selector: "$.results[*]"
+          id_field: id
+          event:
+            kind: replicate.predictions
+            schema_ref: replicate/predictions/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: predictions
+              type: deployment_state
+              title: Predictions
+              families: [predictions]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-stability-ai
+      tenant_id: builtin_catalog
+      source_id: stability_ai
+      display_name: Stability AI
+      description: "Stability AI connector definition for engines, account profile, and account balance."
+      categories:
+        - ai
+        - governance
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.stability.ai"
+        verification:
+          method: GET
+          path: /v1/engines/list
+          expect_status: [200]
+      resource_families:
+        - id: engines
+          label: Engines
+          path: /v1/engines/list
+          method: GET
+          record_selector: "$[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: stability_ai.engines
+            schema_ref: stability_ai/engines/v1
+          projection:
+            template: asset
+          coverage:
+            - id: engines
+              type: entity_family
+              title: Engines
+              families: [engines]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: account
+          label: Account
+          path: /v1/user/account
+          method: GET
+          singleton: true
+          id_field: id
+          name_field: email
+          event:
+            kind: stability_ai.account
+            schema_ref: stability_ai/account/v1
+          projection:
+            template: asset
+          coverage:
+            - id: account
+              type: entity_family
+              title: Account
+              families: [account]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: account_balance
+          label: Account balance
+          path: /v1/user/balance
+          method: GET
+          singleton: true
+          id_field: id
+          event:
+            kind: stability_ai.account_balance
+            schema_ref: stability_ai/account_balance/v1
+          projection:
+            template: asset
+          coverage:
+            - id: account_balance
+              type: entity_family
+              title: Account balance
+              families: [account_balance]
               support: partial
               high_value: true
               evidence_types: [source_snapshot]

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/writer/cerebro/internal/connectordefinitions"
 )
 
-const wantBuiltinCatalogEntries = 780
+const wantBuiltinCatalogEntries = 788
 
 func TestAnalyzeDirAcceptsGenerateableCatalogEntry(t *testing.T) {
 	root := t.TempDir()

--- a/internal/connectordefinitions/classifier.go
+++ b/internal/connectordefinitions/classifier.go
@@ -180,7 +180,7 @@ func Classify(definition Definition, grammar Grammar) (SupportReport, error) {
 			}
 			check("incremental", state, contains(incremental, state), fmt.Sprintf("family %s", family.ID))
 		}
-		if family.RecordSelector == "" && family.ListKey == "" {
+		if family.RecordSelector == "" && family.ListKey == "" && !family.Singleton {
 			check("record_selector", "jsonpath_or_list_key", false, fmt.Sprintf("family %s needs record_selector or list_key", family.ID))
 		} else {
 			check("record_selector", "jsonpath_or_list_key", true, fmt.Sprintf("family %s", family.ID))

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -145,6 +145,8 @@ type Field struct {
 type AuthSpec struct {
 	Model                         string            `json:"model"`
 	CredentialFields              []Field           `json:"credential_fields,omitempty"`
+	TokenHeader                   string            `json:"token_header,omitempty"`
+	TokenScheme                   string            `json:"token_scheme,omitempty"`
 	SupportedStoreIDs             []string          `json:"supported_store_ids,omitempty"`
 	RequiresReferences            bool              `json:"requires_references,omitempty"`
 	AuthorizationURL              string            `json:"authorization_url,omitempty"`
@@ -282,6 +284,7 @@ type ResourceFamily struct {
 	Method                string                  `json:"method,omitempty"`
 	RecordSelector        string                  `json:"record_selector,omitempty"`
 	ListKey               string                  `json:"list_key,omitempty"`
+	Singleton             bool                    `json:"singleton,omitempty"`
 	IDField               string                  `json:"id_field"`
 	NameField             string                  `json:"name_field,omitempty"`
 	UpdatedAtField        string                  `json:"updated_at_field,omitempty"`
@@ -395,6 +398,8 @@ func Normalize(definition Definition) (Definition, error) {
 	definition.Auth.ScopeSeparator = strings.TrimSpace(definition.Auth.ScopeSeparator)
 	definition.Auth.TokenRequestAuthMethod = strings.TrimSpace(definition.Auth.TokenRequestAuthMethod)
 	definition.Auth.PKCE = strings.TrimSpace(definition.Auth.PKCE)
+	definition.Auth.TokenHeader = strings.TrimSpace(definition.Auth.TokenHeader)
+	definition.Auth.TokenScheme = strings.TrimSpace(definition.Auth.TokenScheme)
 	definition.Auth.AlternateAccessTokenJSONPath = strings.TrimSpace(definition.Auth.AlternateAccessTokenJSONPath)
 	definition.Auth.AlternateRefreshTokenJSONPath = strings.TrimSpace(definition.Auth.AlternateRefreshTokenJSONPath)
 	definition.Auth.Scopes = normalizeStringList(definition.Auth.Scopes)
@@ -690,6 +695,12 @@ func validateAuthModelDetails(auth AuthSpec, add func(ValidationCheck)) {
 	}
 	if auth.TokenExpirationBufferSeconds < 0 {
 		add(blocking("auth_token_expiration_buffer", "Token expiration buffer", "Token expiration buffer must not be negative."))
+	}
+	if header := strings.TrimSpace(auth.TokenHeader); header != "" && strings.ContainsAny(header, "\r\n\t :") {
+		add(blocking("auth_token_header", "Token header", "Token header must be an HTTP header name such as Authorization or x-api-key."))
+	}
+	if scheme := strings.TrimSpace(auth.TokenScheme); scheme != "" && strings.ContainsAny(scheme, "\r\n\t") {
+		add(blocking("auth_token_scheme", "Token scheme", "Token scheme must not contain whitespace or control characters."))
 	}
 }
 

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -48,6 +48,36 @@ func TestNormalizeBuildsValidatedDefinition(t *testing.T) {
 	}
 }
 
+func TestNormalizeTrimsTokenHeaderAndScheme(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID:    "tenant-a",
+		SourceID:    "example",
+		DisplayName: "Example",
+		Auth: AuthSpec{ //nolint:gosec // Test auth descriptor only; no credential value is stored.
+			Model:       "api_key",
+			TokenHeader: " x-api-key ",
+			TokenScheme: " Token ",
+			CredentialFields: []Field{{
+				Key:           "api_key",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:             "assets",
+			Path:           "/v1/assets",
+			IDField:        "id",
+			RecordSelector: "$.data[*]",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if definition.Auth.TokenHeader != "x-api-key" || definition.Auth.TokenScheme != "Token" {
+		t.Fatalf("auth header/scheme = %q/%q, want trimmed values", definition.Auth.TokenHeader, definition.Auth.TokenScheme)
+	}
+}
+
 func TestNormalizeBackfillsEventKindFromLegacyField(t *testing.T) {
 	definition, err := Normalize(Definition{
 		TenantID:    "tenant-a",
@@ -120,6 +150,37 @@ func TestValidateBlocksUnsafeDynamicDefinition(t *testing.T) {
 	}
 	if len(blocked) < 2 {
 		t.Fatalf("blocking checks = %#v, want secret/path blockers", blocked)
+	}
+}
+
+func TestValidateBlocksUnsafeTokenHeader(t *testing.T) {
+	definition, err := Normalize(Definition{
+		ID:          "example",
+		TenantID:    "tenant-a",
+		SourceID:    "example",
+		DisplayName: "Example",
+		Runtime:     RuntimeJSONAPI,
+		Auth: AuthSpec{ //nolint:gosec // Test auth descriptor only; no credential value is stored.
+			Model:       "api_key",
+			TokenHeader: "x-api-key: bad",
+			CredentialFields: []Field{{
+				Key:    "api_key",
+				Secret: true,
+			}},
+		},
+		Transport: &TransportSpec{BaseURL: "https://api.example.test"},
+		ResourceFamilies: []ResourceFamily{{
+			ID:             "assets",
+			Path:           "/v1/assets",
+			IDField:        "id",
+			RecordSelector: "$.data[*]",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if !hasBlockingCheck(definition.Validation.Checks, "auth_token_header") {
+		t.Fatalf("validation checks = %#v, want auth_token_header blocker", definition.Validation.Checks)
 	}
 }
 
@@ -724,6 +785,52 @@ func TestClassifyReportsMissingFeatures(t *testing.T) {
 		if !containsString(report.MissingFeatures, want) {
 			t.Fatalf("missing features = %#v, want %q", report.MissingFeatures, want)
 		}
+	}
+}
+
+func TestClassifyAcceptsSingletonWithoutRecordSelector(t *testing.T) {
+	report, err := Classify(Definition{
+		SchemaVersion: SchemaVersionIntegrationV1,
+		ID:            "example",
+		TenantID:      "tenant-a",
+		SourceID:      "example",
+		DisplayName:   "Example",
+		Auth: AuthSpec{
+			Model: "bearer_token",
+			CredentialFields: []Field{{
+				Key:           "token",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		Transport: &TransportSpec{
+			BaseURL:      "https://api.example.test",
+			Verification: &VerificationSpec{Path: "/v1/account"},
+		},
+		ResourceFamilies: []ResourceFamily{{
+			ID:        "account",
+			Path:      "/v1/account",
+			IDField:   "id",
+			Singleton: true,
+			Event: EventMappingSpec{
+				Kind:      "example.account",
+				SchemaRef: "example/account/v1",
+			},
+			Projection: &ProjectionSpec{Template: "asset"},
+			Coverage: []CoverageDimensionSpec{{
+				Type:    "entity_family",
+				Support: "partial",
+			}},
+		}},
+	}, DefaultGrammar())
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if report.Verdict != SupportVerdictSupported {
+		t.Fatalf("verdict = %q missing=%#v, want supported", report.Verdict, report.MissingFeatures)
+	}
+	if !containsString(report.SupportedFeatures, "record_selector.jsonpath_or_list_key") {
+		t.Fatalf("supported features = %#v, want singleton record selector support", report.SupportedFeatures)
 	}
 }
 

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -83,6 +83,7 @@ type Result struct {
 type normalizedRequest struct {
 	Request
 	FreshnessDuration time.Duration
+	TokenHeader       string
 	TokenScheme       string
 	TokenConfigKey    string
 	AuthTokenURL      string
@@ -94,6 +95,7 @@ type normalizedRequest struct {
 	DefaultFamily     string
 	DefaultPath       string
 	BaseURLTemplate   string
+	StaticHeaders     map[string]string
 	ConfigKeys        []string
 	CredentialKeys    []string
 	OAuth             *oauthClientCredentialsData
@@ -113,6 +115,7 @@ type familyData struct {
 	SchemaRef             string
 	IDKeys                []string
 	ListKeys              []string
+	Singleton             bool
 	CursorParam           string
 	NextCursorKeys        []string
 	LinkHeader            string
@@ -225,6 +228,9 @@ func normalizeDefinitionRequest(request DefinitionRequest) (normalizedRequest, e
 	if err != nil {
 		return normalizedRequest{}, err
 	}
+	if customScheme := strings.TrimSpace(definition.Auth.TokenScheme); customScheme != "" {
+		tokenScheme = customScheme
+	}
 	oauth, err := oauthClientCredentialsForDefinition(definition.Auth)
 	if err != nil {
 		return normalizedRequest{}, err
@@ -270,6 +276,7 @@ func normalizeDefinitionRequest(request DefinitionRequest) (normalizedRequest, e
 			Force:                request.Force,
 		},
 		FreshnessDuration: freshness,
+		TokenHeader:       strings.TrimSpace(definition.Auth.TokenHeader),
 		TokenScheme:       tokenScheme,
 		TokenConfigKey:    tokenConfigKey,
 		AuthTokenURL:      strings.TrimSpace(definition.Auth.TokenURL),
@@ -279,6 +286,7 @@ func normalizeDefinitionRequest(request DefinitionRequest) (normalizedRequest, e
 		EnvPrefix:         strings.ToUpper(strings.NewReplacer("-", "_").Replace(sourceID)),
 		PackageName:       packageName(sourceID),
 		BaseURLTemplate:   transportBaseURL(definition.Transport),
+		StaticHeaders:     transportHeaders(definition.Transport),
 		ConfigKeys:        fieldKeys(definition.ConfigFields),
 		CredentialKeys:    fieldKeys(definition.Auth.CredentialFields),
 		OAuth:             oauth,
@@ -490,6 +498,13 @@ func transportBaseURL(transport *connectordefinitions.TransportSpec) string {
 	return strings.TrimSpace(transport.BaseURL)
 }
 
+func transportHeaders(transport *connectordefinitions.TransportSpec) map[string]string {
+	if transport == nil || len(transport.Headers) == 0 {
+		return nil
+	}
+	return cloneStringMap(transport.Headers)
+}
+
 func fieldKeys(fields []connectordefinitions.Field) []string {
 	keys := make([]string, 0, len(fields))
 	seen := map[string]struct{}{}
@@ -657,6 +672,7 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			SchemaRef:             schemaRef,
 			IDKeys:                idKeysForResource(resource),
 			ListKeys:              listKeysForResource(resource),
+			Singleton:             resource.Singleton,
 			CursorParam:           cursorParamForResource(resource),
 			NextCursorKeys:        nextCursorKeysForResource(resource),
 			LinkHeader:            linkHeaderForResource(resource),
@@ -944,6 +960,7 @@ func renderDeploy(request normalizedRequest) string {
 	if request.TokenConfigKey == "api_token" {
 		tokenEnv = request.EnvPrefix + "_API_TOKEN"
 	}
+	authConfigKeys := deployAuthConfigKeys(request)
 	var b strings.Builder
 	fmt.Fprintf(&b, "sourceId: %s\n", request.SourceID)
 	fmt.Fprintf(&b, "secretKeys:\n")
@@ -954,12 +971,12 @@ func renderDeploy(request normalizedRequest) string {
 	for _, key := range request.ConfigKeys {
 		secretKeys = append(secretKeys, envNameForConfigKey(request, key))
 	}
-	if request.OAuth != nil {
-		for _, key := range request.CredentialKeys {
-			secretKeys = append(secretKeys, envNameForConfigKey(request, key))
+	for _, key := range authConfigKeys {
+		envName := envNameForConfigKey(request, key)
+		if request.OAuth == nil && request.AuthModel != AuthModelAWSSigV4 {
+			envName = tokenEnv
 		}
-	} else {
-		secretKeys = append(secretKeys, tokenEnv)
+		secretKeys = append(secretKeys, envName)
 	}
 	for _, key := range uniqueStrings(secretKeys) {
 		fmt.Fprintf(&b, "  - %s\n", key)
@@ -979,14 +996,41 @@ func renderDeploy(request normalizedRequest) string {
 	fmt.Fprintf(&b, "      expected_cadence_seconds: %q\n", strconv.FormatInt(int64(request.FreshnessDuration.Seconds()), 10))
 	fmt.Fprintf(&b, "      stale_after_seconds: %q\n", strconv.FormatInt(int64(request.FreshnessDuration.Seconds()), 10))
 	fmt.Fprintf(&b, "      per_page: %q\n", "100")
-	if request.OAuth != nil {
-		for _, key := range request.CredentialKeys {
-			fmt.Fprintf(&b, "      %s: env:%s\n", key, envNameForConfigKey(request, key))
+	for _, key := range authConfigKeys {
+		envName := envNameForConfigKey(request, key)
+		if request.OAuth == nil && request.AuthModel != AuthModelAWSSigV4 {
+			envName = tokenEnv
 		}
-	} else {
-		fmt.Fprintf(&b, "      %s: env:%s\n", request.TokenConfigKey, tokenEnv)
+		fmt.Fprintf(&b, "      %s: env:%s\n", key, envName)
 	}
 	return b.String()
+}
+
+func deployAuthConfigKeys(request normalizedRequest) []string {
+	if request.OAuth != nil {
+		return uniqueStrings(request.CredentialKeys)
+	}
+	if request.AuthModel == AuthModelAWSSigV4 {
+		keys := uniqueStrings(request.CredentialKeys)
+		hasAccessKey := false
+		hasSecretKey := false
+		for _, key := range keys {
+			switch strings.TrimSpace(key) {
+			case "access_key", "client_id":
+				hasAccessKey = true
+			case "secret_key", "client_secret":
+				hasSecretKey = true
+			}
+		}
+		if !hasAccessKey {
+			keys = append(keys, "access_key")
+		}
+		if !hasSecretKey {
+			keys = append(keys, "secret_key")
+		}
+		return uniqueStrings(keys)
+	}
+	return []string{request.TokenConfigKey}
 }
 
 func envNameForConfigKey(request normalizedRequest, key string) string {
@@ -1018,6 +1062,7 @@ func renderSourceGo(request normalizedRequest) string {
 	fmt.Fprintf(&b, "\tdefaultFamily = %s\n", request.Families[0].ConstName)
 	fmt.Fprintf(&b, "\tdefaultHealthPath = %s\n", strconv.Quote(request.HealthPath))
 	fmt.Fprintf(&b, "\tdefaultBaseURLTemplate = %s\n", strconv.Quote(request.BaseURLTemplate))
+	fmt.Fprintf(&b, "\ttokenHeader = %s\n", strconv.Quote(request.TokenHeader))
 	fmt.Fprintf(&b, "\ttokenScheme = %s\n", strconv.Quote(request.TokenScheme))
 	if request.OAuth != nil {
 		fmt.Fprintf(&b, "\toauthTokenURLTemplate = %s // #nosec G101 -- token endpoint URL template, not credential material.\n", strconv.Quote(request.OAuth.TokenURLTemplate))
@@ -1044,7 +1089,7 @@ func renderSourceGo(request normalizedRequest) string {
 	fmt.Fprintf(&b, "func New() (*Source, error) {\n")
 	fmt.Fprintf(&b, "\tspec, err := loadSpec()\n\tif err != nil {\n\t\treturn nil, err\n\t}\n")
 	fmt.Fprintf(&b, "\tinner, err := jsonapi.New(spec, jsonapi.Options{\n")
-	fmt.Fprintf(&b, "\t\tSourceID: sourceID,\n\t\tDefaultFamily: defaultFamily,\n\t\tRequireTenantID: true,\n\t\tAuthModel: %s,\n\t\tTokenScheme: tokenScheme,\n", strconv.Quote(request.AuthModel))
+	fmt.Fprintf(&b, "\t\tSourceID: sourceID,\n\t\tDefaultFamily: defaultFamily,\n\t\tRequireTenantID: true,\n\t\tAuthModel: %s,\n\t\tTokenHeader: tokenHeader,\n\t\tTokenScheme: tokenScheme,\n", strconv.Quote(request.AuthModel))
 	if strings.TrimSpace(request.AuthTokenURL) != "" {
 		fmt.Fprintf(&b, "\t\tOAuthTokenURL: %s,\n", strconv.Quote(request.AuthTokenURL))
 	}
@@ -1056,6 +1101,9 @@ func renderSourceGo(request normalizedRequest) string {
 	}
 	if strings.TrimSpace(request.OAuthTokenMethod) != "" {
 		fmt.Fprintf(&b, "\t\tOAuthTokenRequestAuthMethod: %s,\n", strconv.Quote(request.OAuthTokenMethod))
+	}
+	if len(request.StaticHeaders) != 0 {
+		fmt.Fprintf(&b, "\t\tStaticHeaders: map[string]string{%s},\n", renderedAttributeMap(request.StaticHeaders))
 	}
 	fmt.Fprintf(&b, "\t\tFamilies: []jsonapi.Family{\n")
 	for _, family := range request.Families {
@@ -1084,6 +1132,9 @@ func renderSourceGo(request normalizedRequest) string {
 		}
 		if len(family.ListKeys) != 0 {
 			fmt.Fprintf(&b, "\t\t\t\tListKeys: []string{%s},\n", quotedStrings(family.ListKeys))
+		}
+		if family.Singleton {
+			fmt.Fprintf(&b, "\t\t\t\tSingleton: true,\n")
 		}
 		fmt.Fprintf(&b, "\t\t\t\tTimestampKeys: []string{%s},\n", quotedStrings([]string{"observed_at", "updated_at", "last_seen_at", "created_at"}))
 		fmt.Fprintf(&b, "\t\t\t\tAttributes: map[string]string{%s},\n", renderedAttributeMap(attributePathsForFamily(family)))
@@ -1291,7 +1342,7 @@ func renderSourceTestGo(request normalizedRequest) string {
 	if request.OAuth != nil {
 		fmt.Fprintf(&b, "\t\tif r.URL.Path == \"/oauth/token\" {\n\t\t\ttokenRequests++\n\t\t\tif r.Method != http.MethodPost {\n\t\t\t\tt.Fatalf(\"token method = %%s\", r.Method)\n\t\t\t}\n\t\t\tr.Body = http.MaxBytesReader(w, r.Body, 1<<20)\n\t\t\tif err := r.ParseForm(); err != nil {\n\t\t\t\tt.Fatalf(\"ParseForm() error = %%v\", err)\n\t\t\t}\n\t\t\tif got := r.Form.Get(\"grant_type\"); got != \"client_credentials\" {\n\t\t\t\tt.Fatalf(\"grant_type = %%q\", got)\n\t\t\t}\n\t\t\tif got := r.Form.Get(\"client_id\"); got != \"client-id\" {\n\t\t\t\tt.Fatalf(\"client_id = %%q\", got)\n\t\t\t}\n\t\t\tif got := r.Form.Get(\"client_secret\"); got != \"client-secret\" {\n\t\t\t\tt.Fatalf(\"client_secret = %%q\", got)\n\t\t\t}\n\t\t\tw.Header().Set(\"Content-Type\", \"application/json\")\n\t\t\t_ = json.NewEncoder(w).Encode(map[string]any{\"access_token\": \"test-token\", \"expires_in\": 600})\n\t\t\treturn\n\t\t}\n")
 	}
-	fmt.Fprintf(&b, "\t\tif r.Header.Get(\"Authorization\") != %s {\n\t\t\tt.Fatalf(\"Authorization = %%q\", r.Header.Get(\"Authorization\"))\n\t\t}\n", strconv.Quote(request.TokenScheme+" test-token"))
+	fmt.Fprint(&b, generatedTestAuthAssertion(request))
 	if request.HealthPath != request.DefaultPath {
 		fmt.Fprintf(&b, "\t\tif r.URL.RequestURI() == %s {\n\t\t\tw.WriteHeader(http.StatusNoContent)\n\t\t\treturn\n\t\t}\n", strconv.Quote(renderTestPath(request.HealthPath)))
 	}
@@ -1316,6 +1367,9 @@ func renderSourceTestGo(request normalizedRequest) string {
 		emitCfgValue("token_url", "server.URL + \"/oauth/token\"")
 		emitCfgValue("client_id", strconv.Quote("client-id"))
 		emitCfgValue("client_secret", strconv.Quote("client-secret"))
+	} else if request.AuthModel == AuthModelAWSSigV4 {
+		emitCfgValue("access_key", strconv.Quote("test-access-key"))
+		emitCfgValue("secret_key", strconv.Quote("test-secret-key"))
 	} else {
 		emitCfgValue(request.TokenConfigKey, strconv.Quote("test-token"))
 	}
@@ -1350,6 +1404,32 @@ func testConfigValue(key string) string {
 	default:
 		return "test-" + strings.TrimSpace(key)
 	}
+}
+
+func generatedTestAuthHeader(request normalizedRequest) (string, string) {
+	header := strings.TrimSpace(request.TokenHeader)
+	if header == "" {
+		header = "Authorization"
+	}
+	if !strings.EqualFold(header, "Authorization") {
+		return header, "test-token"
+	}
+	scheme := strings.TrimSpace(request.TokenScheme)
+	if scheme == "" {
+		return header, "test-token"
+	}
+	if strings.HasSuffix(scheme, "=") {
+		return header, scheme + "test-token"
+	}
+	return header, scheme + " test-token"
+}
+
+func generatedTestAuthAssertion(request normalizedRequest) string {
+	header, value := generatedTestAuthHeader(request)
+	if request.AuthModel != AuthModelAWSSigV4 {
+		return fmt.Sprintf("\t\tif r.Header.Get(%s) != %s {\n\t\t\tt.Fatalf(%s+\" = %%q\", r.Header.Get(%s))\n\t\t}\n", strconv.Quote(header), strconv.Quote(value), strconv.Quote(header), strconv.Quote(header))
+	}
+	return fmt.Sprintf("\t\tauth := r.Header.Get(%s)\n\t\tif !strings.HasPrefix(auth, %s) {\n\t\t\tt.Fatalf(%s+\" = %%q\", auth)\n\t\t}\n\t\tif !strings.Contains(auth, %s) {\n\t\t\tt.Fatalf(%s+\" missing credential scope: %%q\", auth)\n\t\t}\n", strconv.Quote(header), strconv.Quote("AWS4-HMAC-SHA256 "), strconv.Quote(header), strconv.Quote("Credential=test-access-key/"), strconv.Quote(header))
 }
 
 // renderTestPath substitutes ${config.key}/${credential.key}/${connection.key}

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -715,6 +715,178 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 	}
 }
 
+func TestGenerateDefinitionSupportsCustomTokenHeader(t *testing.T) {
+	outputDir := t.TempDir()
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			ID:          "tenant-anthropic",
+			TenantID:    "tenant",
+			SourceID:    "anthropic",
+			DisplayName: "Anthropic",
+			Auth: connectordefinitions.AuthSpec{
+				Model:       "api_key",
+				TokenHeader: "x-api-key",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "api_key",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://api.anthropic.com",
+				Headers: map[string]string{
+					"anthropic-version": "2023-06-01",
+				},
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/v1/organizations/users",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "organization_members",
+				Path:           "/v1/organizations/users",
+				RecordSelector: "$.data[*]",
+				IDField:        "id",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "anthropic.organization_members",
+					SchemaRef: "anthropic/organization_members/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "identity_user",
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "partial"}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	source := readGeneratedFile(t, outputDir, "sources/anthropic/source.go")
+	for _, want := range []string{`tokenHeader`, `"x-api-key"`, `TokenHeader:`, `tokenHeader`, `StaticHeaders:`, `"anthropic-version": "2023-06-01"`} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("source.go missing %q:\n%s", want, source)
+		}
+	}
+	sourceTest := readGeneratedFile(t, outputDir, "sources/anthropic/source_test.go")
+	if !strings.Contains(sourceTest, `r.Header.Get("x-api-key")`) {
+		t.Fatalf("source_test.go missing custom header assertion:\n%s", sourceTest)
+	}
+}
+
+func TestGenerateDefinitionSupportsAWSSigV4Auth(t *testing.T) {
+	outputDir := t.TempDir()
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			ID:          "tenant-aws-bedrock",
+			TenantID:    "tenant",
+			SourceID:    "aws_bedrock",
+			DisplayName: "AWS Bedrock",
+			ConfigFields: []connectordefinitions.Field{{
+				Key:      "region",
+				Required: true,
+			}, {
+				Key:      "service",
+				Required: true,
+			}},
+			Auth: connectordefinitions.AuthSpec{ //nolint:gosec // Test auth descriptor only; no credential value is stored.
+				Model: "aws_sigv4",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "access_key",
+					Secret:        true,
+					ReferenceOnly: true,
+				}, {
+					Key:           "secret_key",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://bedrock.${config.region}.amazonaws.com",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/foundation-models",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "foundation_models",
+				Path:           "/foundation-models",
+				RecordSelector: "$.modelSummaries[*]",
+				IDField:        "modelId",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "aws_bedrock.foundation_models",
+					SchemaRef: "aws_bedrock/foundation_models/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "asset",
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "partial"}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	sourceTest := readGeneratedFile(t, outputDir, "sources/aws_bedrock/source_test.go")
+	for _, want := range []string{`strings.HasPrefix(auth, "AWS4-HMAC-SHA256 ")`, `strings.Contains(auth, "Credential=test-access-key/")`, `"access_key": "test-access-key"`, `"secret_key": "test-secret-key"`} {
+		if !strings.Contains(sourceTest, want) {
+			t.Fatalf("source_test.go missing %q:\n%s", want, sourceTest)
+		}
+	}
+	if strings.Contains(sourceTest, `"AWS4-HMAC-SHA256 test-token"`) {
+		t.Fatalf("source_test.go contains static SigV4 authorization assertion:\n%s", sourceTest)
+	}
+	deploy := readGeneratedFile(t, outputDir, "sources/aws_bedrock/deploy.yaml")
+	for _, want := range []string{`access_key: env:AWS_BEDROCK_ACCESS_KEY`, `secret_key: env:AWS_BEDROCK_SECRET_KEY`} {
+		if !strings.Contains(deploy, want) {
+			t.Fatalf("deploy.yaml missing %q:\n%s", want, deploy)
+		}
+	}
+}
+
+func TestGenerateDefinitionSupportsSingletonFamily(t *testing.T) {
+	outputDir := t.TempDir()
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			ID:          "tenant-stability",
+			TenantID:    "tenant",
+			SourceID:    "stability_ai",
+			DisplayName: "Stability AI",
+			Auth: connectordefinitions.AuthSpec{
+				Model: "bearer_token",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "token",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL:      "https://api.stability.ai",
+				Verification: &connectordefinitions.VerificationSpec{Path: "/v1/user/account"},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:        "account",
+				Path:      "/v1/user/account",
+				IDField:   "id",
+				Singleton: true,
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "stability_ai.account",
+					SchemaRef: "stability_ai/account/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{Template: "asset"},
+				Coverage:   []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "partial"}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	source := readGeneratedFile(t, outputDir, "sources/stability_ai/source.go")
+	if !strings.Contains(source, `Singleton:`) || !strings.Contains(source, `true`) {
+		t.Fatalf("source.go missing singleton family:\n%s", source)
+	}
+}
+
 func TestGenerateRejectsMissingSchemas(t *testing.T) {
 	_, err := Generate(Request{SourceID: "demo_source"})
 	if err == nil {

--- a/sources/internal/catalogruntime/source.go
+++ b/sources/internal/catalogruntime/source.go
@@ -59,6 +59,8 @@ func NewDefinition(definition connectordefinitions.Definition) (*Source, error) 
 		DefaultFamily:               families[0].Name,
 		RequireTenantID:             true,
 		AuthModel:                   definition.Auth.Model,
+		TokenHeader:                 definition.Auth.TokenHeader,
+		TokenScheme:                 definition.Auth.TokenScheme,
 		OAuthTokenURL:               definition.Auth.TokenURL,
 		OAuthScopes:                 definition.Auth.Scopes,
 		OAuthTokenParams:            definition.Auth.TokenParams,
@@ -134,6 +136,7 @@ func jsonapiFamily(sourceID string, resource connectordefinitions.ResourceFamily
 		PageSizeParams:   pageSizeParams(resource.Pagination),
 		DisablePageSize:  disablePageSize(resource.Pagination),
 		ListKeys:         listKeys(resource),
+		Singleton:        resource.Singleton,
 		Config: jsonapi.FamilyConfig{
 			StaticQuery: resource.StaticQuery,
 			ConfigQuery: resource.ConfigQuery,

--- a/sources/internal/catalogruntime/source_test.go
+++ b/sources/internal/catalogruntime/source_test.go
@@ -81,6 +81,48 @@ func TestSourceCheckAndReadDefinition(t *testing.T) {
 	}
 }
 
+func TestSourceDefinitionReadsSingletonFamily(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/account" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "account", "name": "Primary account"})
+	}))
+	defer server.Close()
+
+	source, err := NewDefinition(connectordefinitions.Definition{
+		ID:          "tenant-example",
+		TenantID:    "tenant",
+		SourceID:    "example",
+		DisplayName: "Example",
+		Auth:        connectordefinitions.AuthSpec{Model: "bearer_token"},
+		Transport:   &connectordefinitions.TransportSpec{BaseURL: server.URL},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:        "account",
+			Path:      "/account",
+			IDField:   "id",
+			Singleton: true,
+			Event: connectordefinitions.EventMappingSpec{
+				Kind:      "example.account",
+				SchemaRef: "example/account/v1",
+			},
+			Projection: &connectordefinitions.ProjectionSpec{Template: "asset"},
+			Coverage:   []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "partial"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewDefinition() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{"tenant_id": "tenant", "token": "token"}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.Events[0].Kind != "example.account" {
+		t.Fatalf("events = %#v, want example.account event", pull.Events)
+	}
+}
+
 func TestSourceDefinitionUsesPagePagination(t *testing.T) {
 	requests := make([]*http.Request, 0, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -408,7 +450,10 @@ func TestSourceAuthModels(t *testing.T) {
 	tests := []struct {
 		name           string
 		authModel      string
+		tokenHeader    string
+		tokenScheme    string
 		config         map[string]string
+		wantHeaderName string
 		wantAuthHeader string
 		wantGrantType  string
 	}{
@@ -423,6 +468,14 @@ func TestSourceAuthModels(t *testing.T) {
 			authModel:      "api_key",
 			config:         map[string]string{"api_key": "api-token"},
 			wantAuthHeader: "Token api-token",
+		},
+		{
+			name:           "custom api key header",
+			authModel:      "api_key",
+			tokenHeader:    "x-api-key",
+			config:         map[string]string{"api_key": "api-token"},
+			wantHeaderName: "x-api-key",
+			wantAuthHeader: "api-token",
 		},
 		{
 			name:           "basic",
@@ -483,8 +536,9 @@ func TestSourceAuthModels(t *testing.T) {
 						"expires_in":   3600,
 					})
 				case "/me":
-					if got := r.Header.Get("Authorization"); got != test.wantAuthHeader {
-						t.Fatalf("Authorization = %q, want %q", got, test.wantAuthHeader)
+					headerName := firstNonEmpty(test.wantHeaderName, "Authorization")
+					if got := r.Header.Get(headerName); got != test.wantAuthHeader {
+						t.Fatalf("%s = %q, want %q", headerName, got, test.wantAuthHeader)
 					}
 					w.WriteHeader(http.StatusNoContent)
 				default:
@@ -494,6 +548,8 @@ func TestSourceAuthModels(t *testing.T) {
 			defer server.Close()
 
 			definition := authTestDefinition(server.URL, test.authModel)
+			definition.Auth.TokenHeader = test.tokenHeader
+			definition.Auth.TokenScheme = test.tokenScheme
 			if test.wantGrantType != "" {
 				definition.Auth.TokenURL = server.URL + "/oauth/token"
 				definition.Auth.TokenRequestAuthMethod = "client_secret_post"


### PR DESCRIPTION
## Summary
- Adds deeper AI governance catalog coverage for Anthropic, AWS Bedrock, Cohere, Google Vertex AI, Groq, Microsoft Foundry, Replicate, and Stability AI.
- Adds declarative support for custom token headers, static transport headers in generated sources, and singleton resource families.
- Updates AI governance tests and built-in catalog counts for 788 generateable connector definitions.

## Impact
- More provider resources can be modeled through the generic JSON API runtime without bespoke source code.
- API key providers can declare their real token header.
- Account-level singleton endpoints can be represented as first-class resource families.

## Validation
- go test ./internal/connectordefinitions ./internal/sourcegen ./internal/connectorcatalog ./internal/sourceregistry ./internal/sourceprojection ./sources/internal/catalogruntime ./sources/internal/jsonapi -count=1
- make catalog-check
- make sourcegen-check
- go test ./... -count=1