### PR TITLE
Add policy document register support

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2086,7 +2086,7 @@ paths:
         - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':
-          description: Policy templates, versions, approvals, attestations, reviews, exceptions, reminders, work queue items, and control/evidence mappings.
+          description: Policy templates, documents, risk-register records, versions, approvals, attestations, reviews, exceptions, reminders, work queue items, and control/evidence mappings.
           content:
             application/json:
               schema:
@@ -8174,10 +8174,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GRCPolicyLifecyclePolicy'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyDocument'
+        risk_register:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyRiskRegisterItem'
         work_queue:
           type: array
           items:
             $ref: '#/components/schemas/GRCPolicyLifecycleWork'
+        document_work_queue:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyDocumentWork'
         reminders:
           type: array
           items:
@@ -8217,7 +8229,16 @@ components:
         lifecycle_events:
           type: integer
           minimum: 0
+        policy_documents:
+          type: integer
+          minimum: 0
+        risk_register_items:
+          type: integer
+          minimum: 0
         draft_versions:
+          type: integer
+          minimum: 0
+        draft_documents:
           type: integer
           minimum: 0
         pending_approvals:
@@ -8226,10 +8247,19 @@ components:
         overdue_reviews:
           type: integer
           minimum: 0
+        documents_due_for_review:
+          type: integer
+          minimum: 0
         open_exceptions:
           type: integer
           minimum: 0
         expiring_exceptions:
+          type: integer
+          minimum: 0
+        open_risks:
+          type: integer
+          minimum: 0
+        high_risks:
           type: integer
           minimum: 0
         attestation_coverage_pct:
@@ -8267,6 +8297,126 @@ components:
             type: string
         owner:
           type: string
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyControlRef'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyEvidenceRef'
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+    GRCPolicyDocument:
+      type: object
+      properties:
+        id:
+          type: string
+        urn:
+          type: string
+        title:
+          type: string
+        document_type:
+          type: string
+        document_class:
+          type: string
+        status:
+          type: string
+        owner:
+          type: string
+        version:
+          type: string
+        review_cadence:
+          type: string
+        next_review_due_at:
+          type: string
+        approved_at:
+          type: string
+        effective_at:
+          type: string
+        source_url:
+          type: string
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyDocumentRef'
+        risks:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyRiskRef'
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyControlRef'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyEvidenceRef'
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+    GRCPolicyDocumentRef:
+      type: object
+      properties:
+        id:
+          type: string
+        urn:
+          type: string
+        title:
+          type: string
+        reference:
+          type: string
+    GRCPolicyRiskRef:
+      type: object
+      properties:
+        id:
+          type: string
+        urn:
+          type: string
+        title:
+          type: string
+        status:
+          type: string
+    GRCPolicyRiskRegisterItem:
+      type: object
+      properties:
+        id:
+          type: string
+        urn:
+          type: string
+        title:
+          type: string
+        status:
+          type: string
+        owner:
+          type: string
+        category:
+          type: string
+        inherent_risk:
+          type: string
+        residual_risk:
+          type: string
+        likelihood:
+          type: string
+        impact:
+          type: string
+        treatment:
+          type: string
+        review_due_at:
+          type: string
+        treatment_due_at:
+          type: string
+        source_document_id:
+          type: string
+        source_document_title:
+          type: string
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyDocumentRef'
         controls:
           type: array
           items:
@@ -8799,6 +8949,31 @@ components:
         due_at:
           type: string
         action:
+          type: string
+    GRCPolicyDocumentWork:
+      type: object
+      properties:
+        id:
+          type: string
+        document_id:
+          type: string
+        document:
+          type: string
+        record_urn:
+          type: string
+        type:
+          type: string
+        status:
+          type: string
+        owner:
+          type: string
+        due_at:
+          type: string
+        action:
+          type: string
+        policy_id:
+          type: string
+        risk_id:
           type: string
     GRCPolicyAcceptanceSummary:
       type: object

--- a/docs/domains/policy-lifecycle.md
+++ b/docs/domains/policy-lifecycle.md
@@ -39,6 +39,8 @@ Policy lifecycle should model these records:
 | Policy exception | `exception_id` or `waiver_id` | Time-bound waiver, deferral, or scoped exception. |
 | Policy reminder | `reminder_id` | Reminder or escalation record for an approval, review, exception, or employee attestation. |
 | Policy assignment | policy or version plus group/user | Employee group or user population required to accept the policy. |
+| Policy document | `document_id` | Approved policy, standard, procedure, risk register, exception register, or training document evidence. |
+| Risk register item | `risk_id` | One risk scenario with owner, treatment, review date, residual risk, controls, and source document links. |
 
 Lifecycle states should stay concrete:
 
@@ -77,6 +79,8 @@ The source projection layer now accepts imported policy lifecycle event kinds. T
 | `grc.policy_review` | `review_id` or derived policy/version/review date | `policy.review` |
 | `grc.policy_exception` | `exception_id`, `waiver_id`, or derived policy/target/expiration | `policy.exception` |
 | `grc.policy_reminder` | `reminder_id`, `policy_reminder_id`, `escalation_id`, or derived policy/target/date | `policy.reminder` |
+| `grc.document` | `document_id` | `document` |
+| `grc.risk_scenario` | `risk_id` | `claim` with `claim_type=risk_scenario` |
 
 Common attributes:
 
@@ -94,7 +98,10 @@ Common attributes:
 | `person_id`, `user_id`, `email` | Employee acceptance subject. |
 | `group_id`, `employee_group_id`, `acceptance_group_id` | Assigned employee group. |
 | `control_id`, `control_ids`, `control_references` | Explicit policy-to-control mappings. |
-| `document_id`, `approved_document_id`, `url` | Approved document evidence. |
+| `document_id`, `approved_document_id`, `url` | Approved document evidence or source document identity. |
+| `document_type`, `document_class` | Policy document class such as `policy`, `standard`, `procedure`, `risk_register`, `control_narrative`, `exception_register`, or `training_material`. |
+| `risk_id`, `risk_ids`, `risk_register_id` | Risk scenario or risk register identity. |
+| `risk_category`, `inherent_risk_level`, `residual_risk_level`, `likelihood`, `impact`, `treatment`, `treatment_due_at` | Risk register posture and treatment metadata. |
 | `evidence_id`, `evidence_cas_uri` | Runtime evidence packet link. |
 | `target_id`, `resource_id`, `asset_id`, `service_id`, `system_id`, `person_id`, `user_id` | Scoped exception target. |
 
@@ -116,6 +123,10 @@ Graph relationships:
 | Sender or escalation owner | `acted_on` | Reminder |
 | Policy exception | `targeted` | Scoped asset, service, system, resource, or user target |
 | Policy exception | `associated_with` | Control |
+| Document | `associated_with` | Policy, policy version, or risk scenario |
+| Document | `supports` | Control |
+| Risk scenario | `associated_with` | Policy or control |
+| Risk scenario | `has_evidence` | Source risk register document or runtime evidence |
 
 ## Readiness Semantics
 
@@ -156,7 +167,7 @@ Implemented endpoints:
 
 | Endpoint | Purpose |
 | --- | --- |
-| `GET /grc/policy-lifecycle` | Tenant-scoped aggregate of policy templates, policy records, versions, approvals, attestations, reviews, exceptions, reminders, work queue items, and explicit control/evidence mappings. |
+| `GET /grc/policy-lifecycle` | Tenant-scoped aggregate of policy templates, policy records, documents, risk-register records, versions, approvals, attestations, reviews, exceptions, reminders, work queue items, and explicit control/evidence mappings. |
 | `POST /grc/policy-lifecycle/actions` | Append and project a lifecycle action event for template, draft, approval, publish, attestation, review, exception, reminder, or escalation work. |
 | `GET /grc/policy-lifecycle/export` | CSV export of policy versions, approvals, attestations, reviews, exceptions, lifecycle events, and control/evidence mappings, with optional `start` and `end` date filters. |
 

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -74,6 +74,15 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	document := grcPolicyLifecycleTestNode("urn:cerebro:writer:document:policyops:doc-1", "document", "Access Control PDF", map[string]string{
 		"document_id":   "doc-1",
 		"document_type": "policy_pdf",
+		"status":        "draft",
+		"review_due_at": "2026-01-01",
+	})
+	risk := grcPolicyLifecycleTestNode("urn:cerebro:writer:claim:policyops:risk_scenario:risk-1", "claim", "Access review risk", map[string]string{
+		"claim_type":          "risk_scenario",
+		"risk_id":             "risk-1",
+		"status":              "open",
+		"residual_risk_level": "high",
+		"review_due_at":       "2026-01-01",
 	})
 	group := grcPolicyLifecycleTestNode("urn:cerebro:writer:grc_group:policyops:employees", "grc.group", "All employees", map[string]string{"group_id": "employees"})
 	owner := grcPolicyLifecycleTestNode("urn:cerebro:writer:user:policyops:owner-1", "user", "owner@example.com", map[string]string{"user_id": "owner-1"})
@@ -83,11 +92,13 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	asset := grcPolicyLifecycleTestNode("urn:cerebro:writer:device:device-1", "device", "laptop-1", map[string]string{"device_id": "device-1"})
 
 	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{
-		{policy, template, version, approval, acceptance, review, exception, reminder},
+		{policy, template, version, approval, acceptance, review, exception, reminder, document, risk},
 		{
 			grcPolicyLifecycleTestRelation(policy, fabriccontract.RelationOwnedBy, nil, owner),
 			grcPolicyLifecycleTestRelation(policy, fabriccontract.RelationSupports, nil, control),
 			grcPolicyLifecycleTestRelation(policy, fabriccontract.RelationHasEvidence, nil, document),
+			grcPolicyLifecycleTestRelation(document, fabriccontract.RelationAssociatedWith, nil, policy),
+			grcPolicyLifecycleTestRelation(document, fabriccontract.RelationAssociatedWith, nil, risk),
 			grcPolicyLifecycleTestRelation(template, fabriccontract.RelationSupports, nil, control),
 			grcPolicyLifecycleTestRelation(version, fabriccontract.RelationBelongsTo, nil, policy),
 			grcPolicyLifecycleTestRelation(version, fabriccontract.RelationSupports, nil, control),
@@ -103,6 +114,10 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 			grcPolicyLifecycleTestRelation(exception, fabriccontract.RelationAssociatedWith, nil, policy),
 			grcPolicyLifecycleTestRelation(exception, fabriccontract.RelationAssociatedWith, nil, control),
 			grcPolicyLifecycleTestRelation(exception, fabriccontract.RelationTargeted, nil, asset),
+			grcPolicyLifecycleTestRelation(risk, fabriccontract.RelationHasEvidence, nil, document),
+			grcPolicyLifecycleTestRelation(risk, fabriccontract.RelationAssociatedWith, nil, policy),
+			grcPolicyLifecycleTestRelation(risk, fabriccontract.RelationAssociatedWith, nil, control),
+			grcPolicyLifecycleTestRelation(risk, fabriccontract.RelationAssignedTo, nil, owner),
 			grcPolicyLifecycleTestRelation(reminder, fabriccontract.RelationAssociatedWith, nil, policy),
 			grcPolicyLifecycleTestRelation(reminder, fabriccontract.RelationAssignedTo, nil, group),
 		},
@@ -123,9 +138,15 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 		Summary struct {
 			Policies               int `json:"policies"`
 			Templates              int `json:"templates"`
+			PolicyDocuments        int `json:"policy_documents"`
+			RiskRegisterItems      int `json:"risk_register_items"`
 			DraftVersions          int `json:"draft_versions"`
+			DraftDocuments         int `json:"draft_documents"`
 			PendingApprovals       int `json:"pending_approvals"`
 			OverdueReviews         int `json:"overdue_reviews"`
+			DocumentsDueForReview  int `json:"documents_due_for_review"`
+			OpenRisks              int `json:"open_risks"`
+			HighRisks              int `json:"high_risks"`
 			AttestationCoveragePct int `json:"attestation_coverage_pct"`
 			OverdueAttestations    int `json:"overdue_attestations"`
 			MappedControls         int `json:"mapped_controls"`
@@ -141,8 +162,20 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 			Exceptions    []any  `json:"exceptions"`
 			Reviews       []any  `json:"reviews"`
 		} `json:"policies"`
-		WorkQueue []any `json:"work_queue"`
-		Templates []struct {
+		Documents []struct {
+			ID       string `json:"id"`
+			Status   string `json:"status"`
+			Policies []any  `json:"policies"`
+			Risks    []any  `json:"risks"`
+		} `json:"documents"`
+		RiskRegister []struct {
+			ID               string `json:"id"`
+			ResidualRisk     string `json:"residual_risk"`
+			SourceDocumentID string `json:"source_document_id"`
+		} `json:"risk_register"`
+		WorkQueue         []any `json:"work_queue"`
+		DocumentWorkQueue []any `json:"document_work_queue"`
+		Templates         []struct {
 			Controls []any `json:"controls"`
 		} `json:"templates"`
 		Reminders []struct {
@@ -154,6 +187,9 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	}
 	if payload.Summary.Policies != 1 || payload.Summary.Templates != 1 {
 		t.Fatalf("summary = %+v, want one policy and one template", payload.Summary)
+	}
+	if payload.Summary.PolicyDocuments != 1 || payload.Summary.RiskRegisterItems != 1 || payload.Summary.DraftDocuments != 1 || payload.Summary.DocumentsDueForReview != 1 || payload.Summary.OpenRisks != 1 || payload.Summary.HighRisks != 1 {
+		t.Fatalf("summary document/risk rollups = %+v, want document and risk counts", payload.Summary)
 	}
 	if payload.Summary.DraftVersions != 1 || payload.Summary.PendingApprovals != 1 || payload.Summary.OverdueReviews != 1 || payload.Summary.OverdueAttestations != 1 {
 		t.Fatalf("summary queues = %+v, want draft, approval, review, and attestation work", payload.Summary)
@@ -173,6 +209,15 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	}
 	if len(payload.WorkQueue) < 4 {
 		t.Fatalf("work queue len = %d, want draft, approval, review, attestation, exception work", len(payload.WorkQueue))
+	}
+	if len(payload.Documents) != 1 || payload.Documents[0].ID != "doc-1" || len(payload.Documents[0].Policies) != 1 || len(payload.Documents[0].Risks) != 1 {
+		t.Fatalf("documents = %+v, want linked policy document", payload.Documents)
+	}
+	if len(payload.RiskRegister) != 1 || payload.RiskRegister[0].ID != "risk-1" || payload.RiskRegister[0].ResidualRisk != "high" || payload.RiskRegister[0].SourceDocumentID != "doc-1" {
+		t.Fatalf("risk register = %+v, want linked high risk", payload.RiskRegister)
+	}
+	if len(payload.DocumentWorkQueue) < 2 {
+		t.Fatalf("document work queue len = %d, want draft document and risk work", len(payload.DocumentWorkQueue))
 	}
 	if len(payload.Templates) != 1 || len(payload.Templates[0].Controls) != 1 {
 		t.Fatalf("templates = %+v, want template control mapping", payload.Templates)

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -188,9 +188,9 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	if payload.Summary.Policies != 1 || payload.Summary.Templates != 1 {
 		t.Fatalf("summary = %+v, want one policy and one template", payload.Summary)
 	}
-	if payload.Summary.PolicyDocuments != 1 || payload.Summary.RiskRegisterItems != 1 || payload.Summary.DraftDocuments != 1 || payload.Summary.DocumentsDueForReview != 1 || payload.Summary.OpenRisks != 1 || payload.Summary.HighRisks != 1 {
-		t.Fatalf("summary document/risk rollups = %+v, want document and risk counts", payload.Summary)
-	}
+		if payload.Summary.PolicyDocuments != 1 || payload.Summary.RiskRegisterItems != 1 || payload.Summary.DraftDocuments != 1 || payload.Summary.DocumentsDueForReview != 0 || payload.Summary.OpenRisks != 1 || payload.Summary.HighRisks != 1 {
+			t.Fatalf("summary document/risk rollups = %+v, want document and risk counts", payload.Summary)
+		}
 	if payload.Summary.DraftVersions != 1 || payload.Summary.PendingApprovals != 1 || payload.Summary.OverdueReviews != 1 || payload.Summary.OverdueAttestations != 1 {
 		t.Fatalf("summary queues = %+v, want draft, approval, review, and attestation work", payload.Summary)
 	}

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -188,9 +188,9 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	if payload.Summary.Policies != 1 || payload.Summary.Templates != 1 {
 		t.Fatalf("summary = %+v, want one policy and one template", payload.Summary)
 	}
-		if payload.Summary.PolicyDocuments != 1 || payload.Summary.RiskRegisterItems != 1 || payload.Summary.DraftDocuments != 1 || payload.Summary.DocumentsDueForReview != 0 || payload.Summary.OpenRisks != 1 || payload.Summary.HighRisks != 1 {
-			t.Fatalf("summary document/risk rollups = %+v, want document and risk counts", payload.Summary)
-		}
+	if payload.Summary.PolicyDocuments != 1 || payload.Summary.RiskRegisterItems != 1 || payload.Summary.DraftDocuments != 1 || payload.Summary.DocumentsDueForReview != 0 || payload.Summary.OpenRisks != 1 || payload.Summary.HighRisks != 1 {
+		t.Fatalf("summary document/risk rollups = %+v, want document and risk counts", payload.Summary)
+	}
 	if payload.Summary.DraftVersions != 1 || payload.Summary.PendingApprovals != 1 || payload.Summary.OverdueReviews != 1 || payload.Summary.OverdueAttestations != 1 {
 		t.Fatalf("summary queues = %+v, want draft, approval, review, and attestation work", payload.Summary)
 	}

--- a/internal/grccatalog/catalog.go
+++ b/internal/grccatalog/catalog.go
@@ -273,7 +273,7 @@ func buildCatalog() []Source {
 			ID:          "policy-lifecycle",
 			Domain:      "policies",
 			Title:       "Policy lifecycle",
-			Description: "Policy templates, versions, approvals, attestations, exceptions, reminders, and control mappings.",
+			Description: "Policy documents, risk-register rows, versions, approvals, attestations, exceptions, reminders, and control mappings.",
 			Method:      "GET",
 			Path:        "/grc/policy-lifecycle",
 			Params: []Param{

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -1963,6 +1963,9 @@ func grcPolicyRiskTitle(node *grcPolicyGraphNode) string {
 }
 
 func grcPolicyDocumentDueForReview(document grcPolicyDocumentItem, now time.Time) bool {
+	if grcPolicyDraftStatus(document.Status) {
+		return false
+	}
 	return grcPolicyOverdue(document.NextReviewDueAt, document.Status, now)
 }
 
@@ -1971,7 +1974,7 @@ func grcPolicyRiskOpen(status string) bool {
 	if normalized == "" {
 		return false
 	}
-	return !grcPolicyAcceptedStatus(normalized) && normalized != "closed" && normalized != "resolved" && normalized != "retired"
+	return !grcPolicyAcceptedStatus(normalized) && !grcPolicyClosedStatus(normalized) && normalized != "resolved"
 }
 
 func grcPolicyHighRisk(values ...string) bool {

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -39,6 +39,46 @@ var grcPolicyLifecycleEntityTypes = []string{
 	"policy.lifecycle.event",
 }
 
+var grcPolicyLifecycleAnchorEntityTypes = []string{
+	"policy",
+	"policy.template",
+	"policy.version",
+	"policy.approval",
+	"policy.acceptance",
+	"policy.review",
+	"policy.exception",
+	"policy.reminder",
+}
+
+const grcPolicyLifecycleRiskScenarioAttrFragment = `"claim_type":"risk_scenario"`
+
+var grcPolicyLifecycleDocumentAttrFragments = []string{
+	`"category":"policy"`,
+	`"category":"procedure"`,
+	`"category":"risk_register"`,
+	`"category":"standard"`,
+	`"control_id":"`,
+	`"control_ids":`,
+	`"document_class":"policy"`,
+	`"document_class":"procedure"`,
+	`"document_class":"risk_register"`,
+	`"document_class":"standard"`,
+	`"document_type":"policy`,
+	`"document_type":"procedure`,
+	`"document_type":"risk_assessment`,
+	`"document_type":"risk_register`,
+	`"document_type":"standard`,
+	`"evidence_id":"`,
+	`"evidence_ids":`,
+	`"policy_document_type":"`,
+	`"policy_id":"`,
+	`"policy_ids":`,
+	`"policy_urn":"`,
+	`"risk_id":"`,
+	`"risk_ids":`,
+	`"risk_scenario_id":"`,
+}
+
 const grcPolicyLifecycleEntitiesQuery = `UNWIND $entity_types AS entity_type
 CALL {
   WITH entity_type
@@ -47,6 +87,9 @@ CALL {
     AND ($source_id = '' OR e.source_id = $source_id)
     AND ($runtime_id = '' OR coalesce(e.runtime_id, '') = $runtime_id)
     AND e.entity_type = entity_type
+  WITH entity_type, e, toLower(coalesce(e.attributes_json, '')) AS attrs
+  WHERE (entity_type <> 'claim' OR attrs CONTAINS $risk_scenario_attr_fragment)
+    AND (entity_type <> 'document' OR ANY(fragment IN $document_attr_fragments WHERE attrs CONTAINS fragment))
   RETURN e
   ORDER BY coalesce(e.label, e.urn), e.urn
   LIMIT $type_limit
@@ -74,6 +117,21 @@ WHERE ($tenant_id = '' OR left.tenant_id = $tenant_id)
     (right.entity_type IN $entity_types AND coalesce(right.runtime_id, '') = $runtime_id)
   )
   AND (left.entity_type IN $entity_types OR right.entity_type IN $entity_types)
+WITH left, r, right,
+     toLower(coalesce(left.attributes_json, '')) AS left_attrs,
+     toLower(coalesce(right.attributes_json, '')) AS right_attrs
+WHERE (left.entity_type <> 'claim' OR left_attrs CONTAINS $risk_scenario_attr_fragment)
+  AND (right.entity_type <> 'claim' OR right_attrs CONTAINS $risk_scenario_attr_fragment)
+  AND (
+    left.entity_type <> 'document' OR
+    ANY(fragment IN $document_attr_fragments WHERE left_attrs CONTAINS fragment) OR
+    right.entity_type IN $policy_anchor_entity_types
+  )
+  AND (
+    right.entity_type <> 'document' OR
+    ANY(fragment IN $document_attr_fragments WHERE right_attrs CONTAINS fragment) OR
+    left.entity_type IN $policy_anchor_entity_types
+  )
 RETURN left.urn AS left_urn,
        left.tenant_id AS left_tenant_id,
        left.source_id AS left_source_id,
@@ -489,11 +547,13 @@ func Build(ctx context.Context, store ports.GraphQueryStore, scope Scope) (Respo
 	entityRows, err := store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query: grcPolicyLifecycleEntitiesQuery,
 		Params: map[string]any{
-			"tenant_id":    scope.TenantID,
-			"source_id":    scope.SourceID,
-			"runtime_id":   scope.RuntimeID,
-			"entity_types": grcPolicyLifecycleEntityTypes,
-			"type_limit":   entityTypeLimit,
+			"tenant_id":                   scope.TenantID,
+			"source_id":                   scope.SourceID,
+			"runtime_id":                  scope.RuntimeID,
+			"entity_types":                grcPolicyLifecycleEntityTypes,
+			"type_limit":                  entityTypeLimit,
+			"risk_scenario_attr_fragment": grcPolicyLifecycleRiskScenarioAttrFragment,
+			"document_attr_fragments":     grcPolicyLifecycleDocumentAttrFragments,
 		},
 		RowLimit: entityRowLimit,
 	})
@@ -510,11 +570,14 @@ func Build(ctx context.Context, store ports.GraphQueryStore, scope Scope) (Respo
 	relationRows, err := store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query: grcPolicyLifecycleRelationsQuery,
 		Params: map[string]any{
-			"tenant_id":    scope.TenantID,
-			"source_id":    scope.SourceID,
-			"runtime_id":   scope.RuntimeID,
-			"entity_types": grcPolicyLifecycleEntityTypes,
-			"limit":        relationLimit,
+			"tenant_id":                   scope.TenantID,
+			"source_id":                   scope.SourceID,
+			"runtime_id":                  scope.RuntimeID,
+			"entity_types":                grcPolicyLifecycleEntityTypes,
+			"limit":                       relationLimit,
+			"risk_scenario_attr_fragment": grcPolicyLifecycleRiskScenarioAttrFragment,
+			"document_attr_fragments":     grcPolicyLifecycleDocumentAttrFragments,
+			"policy_anchor_entity_types":  grcPolicyLifecycleAnchorEntityTypes,
 		},
 		RowLimit: relationLimit,
 	})

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -26,6 +26,8 @@ type Scope struct {
 }
 
 var grcPolicyLifecycleEntityTypes = []string{
+	"claim",
+	"document",
 	"policy",
 	"policy.template",
 	"policy.version",
@@ -92,28 +94,37 @@ ORDER BY left.urn, r.relation, right.urn
 LIMIT $limit`
 
 type Response struct {
-	Summary          grcPolicyLifecycleSummary     `json:"summary"`
-	Templates        []grcPolicyTemplateItem       `json:"templates"`
-	Policies         []grcPolicyLifecyclePolicy    `json:"policies"`
-	WorkQueue        []grcPolicyLifecycleWork      `json:"work_queue"`
-	Reminders        []grcPolicyReminderItem       `json:"reminders"`
-	Events           []grcPolicyLifecycleEventItem `json:"events,omitempty"`
-	AvailableActions []ActionDefinition            `json:"available_actions,omitempty"`
-	VersionDiffs     []grcPolicyVersionDiffItem    `json:"version_diffs,omitempty"`
-	ReminderPlan     []grcPolicyReminderPlanItem   `json:"reminder_plan,omitempty"`
-	Mappings         []grcPolicyLifecycleMapping   `json:"mappings"`
-	GeneratedAt      time.Time                     `json:"generated_at"`
+	Summary           grcPolicyLifecycleSummary     `json:"summary"`
+	Templates         []grcPolicyTemplateItem       `json:"templates"`
+	Policies          []grcPolicyLifecyclePolicy    `json:"policies"`
+	Documents         []grcPolicyDocumentItem       `json:"documents"`
+	RiskRegister      []grcPolicyRiskRegisterItem   `json:"risk_register"`
+	WorkQueue         []grcPolicyLifecycleWork      `json:"work_queue"`
+	DocumentWorkQueue []grcPolicyDocumentWork       `json:"document_work_queue"`
+	Reminders         []grcPolicyReminderItem       `json:"reminders"`
+	Events            []grcPolicyLifecycleEventItem `json:"events,omitempty"`
+	AvailableActions  []ActionDefinition            `json:"available_actions,omitempty"`
+	VersionDiffs      []grcPolicyVersionDiffItem    `json:"version_diffs,omitempty"`
+	ReminderPlan      []grcPolicyReminderPlanItem   `json:"reminder_plan,omitempty"`
+	Mappings          []grcPolicyLifecycleMapping   `json:"mappings"`
+	GeneratedAt       time.Time                     `json:"generated_at"`
 }
 
 type grcPolicyLifecycleSummary struct {
 	Policies               int `json:"policies"`
 	Templates              int `json:"templates"`
 	LifecycleEvents        int `json:"lifecycle_events"`
+	PolicyDocuments        int `json:"policy_documents"`
+	RiskRegisterItems      int `json:"risk_register_items"`
 	DraftVersions          int `json:"draft_versions"`
+	DraftDocuments         int `json:"draft_documents"`
 	PendingApprovals       int `json:"pending_approvals"`
 	OverdueReviews         int `json:"overdue_reviews"`
+	DocumentsDueForReview  int `json:"documents_due_for_review"`
 	OpenExceptions         int `json:"open_exceptions"`
 	ExpiringExceptions     int `json:"expiring_exceptions"`
+	OpenRisks              int `json:"open_risks"`
+	HighRisks              int `json:"high_risks"`
 	AttestationCoveragePct int `json:"attestation_coverage_pct"`
 	OverdueAttestations    int `json:"overdue_attestations"`
 	NextReminders          int `json:"next_reminders"`
@@ -132,6 +143,63 @@ type grcPolicyTemplateItem struct {
 	Controls   []grcPolicyControlRef  `json:"controls,omitempty"`
 	Evidence   []grcPolicyEvidenceRef `json:"evidence,omitempty"`
 	Attributes map[string]string      `json:"attributes,omitempty"`
+}
+
+type grcPolicyDocumentItem struct {
+	ID              string                 `json:"id"`
+	URN             string                 `json:"urn"`
+	Title           string                 `json:"title"`
+	DocumentType    string                 `json:"document_type,omitempty"`
+	DocumentClass   string                 `json:"document_class,omitempty"`
+	Status          string                 `json:"status,omitempty"`
+	Owner           string                 `json:"owner,omitempty"`
+	Version         string                 `json:"version,omitempty"`
+	ReviewCadence   string                 `json:"review_cadence,omitempty"`
+	NextReviewDueAt string                 `json:"next_review_due_at,omitempty"`
+	ApprovedAt      string                 `json:"approved_at,omitempty"`
+	EffectiveAt     string                 `json:"effective_at,omitempty"`
+	SourceURL       string                 `json:"source_url,omitempty"`
+	Policies        []grcPolicyDocumentRef `json:"policies,omitempty"`
+	Risks           []grcPolicyRiskRef     `json:"risks,omitempty"`
+	Controls        []grcPolicyControlRef  `json:"controls,omitempty"`
+	Evidence        []grcPolicyEvidenceRef `json:"evidence,omitempty"`
+	Attributes      map[string]string      `json:"attributes,omitempty"`
+}
+
+type grcPolicyDocumentRef struct {
+	ID        string `json:"id,omitempty"`
+	URN       string `json:"urn"`
+	Title     string `json:"title"`
+	Reference string `json:"reference,omitempty"`
+}
+
+type grcPolicyRiskRef struct {
+	ID     string `json:"id,omitempty"`
+	URN    string `json:"urn"`
+	Title  string `json:"title"`
+	Status string `json:"status,omitempty"`
+}
+
+type grcPolicyRiskRegisterItem struct {
+	ID                  string                 `json:"id"`
+	URN                 string                 `json:"urn"`
+	Title               string                 `json:"title"`
+	Status              string                 `json:"status,omitempty"`
+	Owner               string                 `json:"owner,omitempty"`
+	Category            string                 `json:"category,omitempty"`
+	InherentRisk        string                 `json:"inherent_risk,omitempty"`
+	ResidualRisk        string                 `json:"residual_risk,omitempty"`
+	Likelihood          string                 `json:"likelihood,omitempty"`
+	Impact              string                 `json:"impact,omitempty"`
+	Treatment           string                 `json:"treatment,omitempty"`
+	ReviewDueAt         string                 `json:"review_due_at,omitempty"`
+	TreatmentDueAt      string                 `json:"treatment_due_at,omitempty"`
+	SourceDocumentID    string                 `json:"source_document_id,omitempty"`
+	SourceDocumentTitle string                 `json:"source_document_title,omitempty"`
+	Policies            []grcPolicyDocumentRef `json:"policies,omitempty"`
+	Controls            []grcPolicyControlRef  `json:"controls,omitempty"`
+	Evidence            []grcPolicyEvidenceRef `json:"evidence,omitempty"`
+	Attributes          map[string]string      `json:"attributes,omitempty"`
 }
 
 type grcPolicyLifecyclePolicy struct {
@@ -339,6 +407,20 @@ type grcPolicyLifecycleWork struct {
 	Action    string `json:"action"`
 }
 
+type grcPolicyDocumentWork struct {
+	ID         string `json:"id"`
+	DocumentID string `json:"document_id,omitempty"`
+	Document   string `json:"document,omitempty"`
+	RecordURN  string `json:"record_urn"`
+	Type       string `json:"type"`
+	Status     string `json:"status,omitempty"`
+	Owner      string `json:"owner,omitempty"`
+	DueAt      string `json:"due_at,omitempty"`
+	Action     string `json:"action"`
+	PolicyID   string `json:"policy_id,omitempty"`
+	RiskID     string `json:"risk_id,omitempty"`
+}
+
 type grcPolicyAcceptanceSummary struct {
 	Accepted int `json:"accepted"`
 	Overdue  int `json:"overdue"`
@@ -537,6 +619,8 @@ func grcPolicyLifecycleFromGraph(entityRows []ports.CypherRow, relationRows []po
 	}
 
 	templates := []grcPolicyTemplateItem{}
+	documents := []grcPolicyDocumentItem{}
+	riskRegister := []grcPolicyRiskRegisterItem{}
 	reminders := []grcPolicyReminderItem{}
 	events := []grcPolicyLifecycleEventItem{}
 	mappings := []grcPolicyLifecycleMapping{}
@@ -545,6 +629,18 @@ func grcPolicyLifecycleFromGraph(entityRows []ports.CypherRow, relationRows []po
 			continue
 		}
 		switch node.EntityType {
+		case "document":
+			item := grcPolicyDocumentFromNode(node, relations, policyURNToID)
+			if grcPolicyDocumentInScope(item) {
+				documents = append(documents, item)
+				mappings = append(mappings, grcPolicyDocumentMappings(item)...)
+			}
+		case "claim":
+			if !grcPolicyIsRiskScenarioNode(node) {
+				continue
+			}
+			item := grcPolicyRiskRegisterFromNode(node, relations, policyURNToID)
+			riskRegister = append(riskRegister, item)
 		case "policy.template":
 			templates = append(templates, grcPolicyTemplateFromNode(node, relations))
 			mappings = append(mappings, grcPolicyMappingForNode(node, "", "", relations)...)
@@ -609,6 +705,17 @@ func grcPolicyLifecycleFromGraph(entityRows []ports.CypherRow, relationRows []po
 	sort.Slice(templates, func(i, j int) bool {
 		return strings.ToLower(templates[i].Title) < strings.ToLower(templates[j].Title)
 	})
+	sort.Slice(documents, func(i, j int) bool {
+		return strings.ToLower(documents[i].Title) < strings.ToLower(documents[j].Title)
+	})
+	sort.Slice(riskRegister, func(i, j int) bool {
+		left := grcPolicySortDate(riskRegister[i].ReviewDueAt, riskRegister[i].TreatmentDueAt)
+		right := grcPolicySortDate(riskRegister[j].ReviewDueAt, riskRegister[j].TreatmentDueAt)
+		if left.Equal(right) {
+			return strings.ToLower(riskRegister[i].Title) < strings.ToLower(riskRegister[j].Title)
+		}
+		return left.Before(right)
+	})
 	sort.Slice(reminders, func(i, j int) bool {
 		return grcPolicySortDate(reminders[i].DueAt, reminders[i].SentAt).Before(grcPolicySortDate(reminders[j].DueAt, reminders[j].SentAt))
 	})
@@ -637,17 +744,20 @@ func grcPolicyLifecycleFromGraph(entityRows []ports.CypherRow, relationRows []po
 		return left.Before(right)
 	})
 	return Response{
-		Summary:          grcPolicyLifecycleSummaryFrom(policies, templates, mappings, generatedAt),
-		Templates:        templates,
-		Policies:         policies,
-		WorkQueue:        grcPolicyLifecycleWorkQueue(policies, generatedAt),
-		Reminders:        reminders,
-		Events:           events,
-		AvailableActions: ActionDefinitions(),
-		VersionDiffs:     versionDiffs,
-		ReminderPlan:     reminderPlan,
-		Mappings:         grcPolicyDeduplicateMappings(mappings),
-		GeneratedAt:      generatedAt,
+		Summary:           grcPolicyLifecycleSummaryFrom(policies, templates, documents, riskRegister, mappings, generatedAt),
+		Templates:         templates,
+		Policies:          policies,
+		Documents:         documents,
+		RiskRegister:      riskRegister,
+		WorkQueue:         grcPolicyLifecycleWorkQueue(policies, generatedAt),
+		DocumentWorkQueue: grcPolicyDocumentWorkQueue(documents, riskRegister, generatedAt),
+		Reminders:         reminders,
+		Events:            events,
+		AvailableActions:  ActionDefinitions(),
+		VersionDiffs:      versionDiffs,
+		ReminderPlan:      reminderPlan,
+		Mappings:          grcPolicyDeduplicateMappings(mappings),
+		GeneratedAt:       generatedAt,
 	}
 }
 
@@ -679,6 +789,60 @@ func grcPolicyTemplateFromNode(node *grcPolicyGraphNode, relations []grcPolicyGr
 		Controls:   grcPolicyControlsFor(node.URN, relations),
 		Evidence:   grcPolicyEvidenceFor(node.URN, relations),
 		Attributes: grcPolicyPublicAttrs(node.Attrs),
+	}
+}
+
+func grcPolicyDocumentFromNode(node *grcPolicyGraphNode, relations []grcPolicyGraphRelation, policyURNToID map[string]string) grcPolicyDocumentItem {
+	return grcPolicyDocumentItem{
+		ID:              grcPolicyNodeID(node, "document_id", "policy_document_id", "external_id"),
+		URN:             node.URN,
+		Title:           grcPolicyNodeTitle(node),
+		DocumentType:    firstNonEmpty(grcPolicyAttr(node, "document_type", "file_type", "policy_document_type"), grcPolicyAttr(node, "category")),
+		DocumentClass:   grcPolicyDocumentClass(node),
+		Status:          grcPolicyAttr(node, "status", "document_status", "lifecycle_state"),
+		Owner:           firstNonEmpty(grcPolicyRelatedLabel(node.URN, relations, fabriccontract.RelationOwnedBy, true), grcPolicyAttr(node, "owner", "owner_email")),
+		Version:         grcPolicyAttr(node, "version", "version_number"),
+		ReviewCadence:   grcPolicyAttr(node, "review_cadence", "cadence"),
+		NextReviewDueAt: grcPolicyAttr(node, "next_review_due_at", "review_due_at", "due_at"),
+		ApprovedAt:      grcPolicyAttr(node, "approved_at"),
+		EffectiveAt:     grcPolicyAttr(node, "effective_at"),
+		SourceURL:       grcPolicyAttr(node, "url", "document_url", "file_url", "download_url", "source_url"),
+		Policies:        grcPolicyDocumentPoliciesFor(node.URN, relations, policyURNToID),
+		Risks:           grcPolicyDocumentRisksFor(node.URN, relations),
+		Controls:        grcPolicyControlsFor(node.URN, relations),
+		Evidence:        grcPolicyEvidenceFor(node.URN, relations),
+		Attributes:      grcPolicyPublicAttrs(node.Attrs),
+	}
+}
+
+func grcPolicyRiskRegisterFromNode(node *grcPolicyGraphNode, relations []grcPolicyGraphRelation, policyURNToID map[string]string) grcPolicyRiskRegisterItem {
+	documents := grcPolicyRiskDocumentsFor(node.URN, relations)
+	sourceDocumentID := ""
+	sourceDocumentTitle := ""
+	if len(documents) > 0 {
+		sourceDocumentID = documents[0].ID
+		sourceDocumentTitle = documents[0].Title
+	}
+	return grcPolicyRiskRegisterItem{
+		ID:                  grcPolicyNodeID(node, "risk_id", "risk_register_id", "external_id"),
+		URN:                 node.URN,
+		Title:               grcPolicyRiskTitle(node),
+		Status:              grcPolicyAttr(node, "status", "risk_status", "review_status", "lifecycle_state"),
+		Owner:               firstNonEmpty(grcPolicyRelatedLabel(node.URN, relations, fabriccontract.RelationAssignedTo, true), grcPolicyRelatedLabel(node.URN, relations, fabriccontract.RelationOwnedBy, true), grcPolicyAttr(node, "owner", "risk_owner", "owner_email")),
+		Category:            grcPolicyAttr(node, "risk_category", "category", "domain"),
+		InherentRisk:        grcPolicyAttr(node, "inherent_risk_level", "inherent_risk", "risk_level"),
+		ResidualRisk:        grcPolicyAttr(node, "residual_risk_level", "residual_risk"),
+		Likelihood:          grcPolicyAttr(node, "likelihood", "likelihood_level"),
+		Impact:              grcPolicyAttr(node, "impact", "impact_level"),
+		Treatment:           grcPolicyAttr(node, "treatment", "treatment_plan", "response", "mitigation"),
+		ReviewDueAt:         grcPolicyAttr(node, "review_due_at", "next_review_due_at", "due_at"),
+		TreatmentDueAt:      grcPolicyAttr(node, "treatment_due_at", "mitigation_due_at", "target_due_at"),
+		SourceDocumentID:    sourceDocumentID,
+		SourceDocumentTitle: sourceDocumentTitle,
+		Policies:            grcPolicyRiskPoliciesFor(node.URN, relations, policyURNToID),
+		Controls:            grcPolicyControlsFor(node.URN, relations),
+		Evidence:            grcPolicyEvidenceFor(node.URN, relations),
+		Attributes:          grcPolicyPublicAttrs(node.Attrs),
 	}
 }
 
@@ -875,8 +1039,8 @@ func grcPolicyFinalize(policy *grcPolicyLifecyclePolicy, now time.Time) {
 	policy.Evidence = uniqueEvidence(policy.Evidence)
 }
 
-func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, templates []grcPolicyTemplateItem, mappings []grcPolicyLifecycleMapping, now time.Time) grcPolicyLifecycleSummary {
-	summary := grcPolicyLifecycleSummary{Policies: len(policies), Templates: len(templates)}
+func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, templates []grcPolicyTemplateItem, documents []grcPolicyDocumentItem, riskRegister []grcPolicyRiskRegisterItem, mappings []grcPolicyLifecycleMapping, now time.Time) grcPolicyLifecycleSummary {
+	summary := grcPolicyLifecycleSummary{Policies: len(policies), Templates: len(templates), PolicyDocuments: len(documents), RiskRegisterItems: len(riskRegister)}
 	accepted := 0
 	totalAttestations := 0
 	mappedControls := map[string]struct{}{}
@@ -888,6 +1052,42 @@ func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, template
 			}
 		}
 		for _, item := range template.Evidence {
+			if item.URN != "" {
+				evidence[item.URN] = struct{}{}
+			}
+		}
+	}
+	for _, document := range documents {
+		if grcPolicyDraftStatus(document.Status) {
+			summary.DraftDocuments++
+		}
+		if grcPolicyDocumentDueForReview(document, now) {
+			summary.DocumentsDueForReview++
+		}
+		for _, control := range document.Controls {
+			if control.ControlID != "" {
+				mappedControls[control.ControlID] = struct{}{}
+			}
+		}
+		for _, item := range document.Evidence {
+			if item.URN != "" {
+				evidence[item.URN] = struct{}{}
+			}
+		}
+	}
+	for _, risk := range riskRegister {
+		if grcPolicyRiskOpen(risk.Status) {
+			summary.OpenRisks++
+		}
+		if grcPolicyHighRisk(risk.ResidualRisk, risk.InherentRisk) {
+			summary.HighRisks++
+		}
+		for _, control := range risk.Controls {
+			if control.ControlID != "" {
+				mappedControls[control.ControlID] = struct{}{}
+			}
+		}
+		for _, item := range risk.Evidence {
 			if item.URN != "" {
 				evidence[item.URN] = struct{}{}
 			}
@@ -978,6 +1178,40 @@ func grcPolicyLifecycleWorkQueue(policies []grcPolicyLifecyclePolicy, now time.T
 				}
 				items = append(items, grcPolicyLifecycleWork{ID: exception.URN + ":exception", PolicyID: policy.ID, Policy: policy.Title, RecordURN: exception.URN, Type: "exception", Status: exception.Status, Owner: firstNonEmpty(exception.Owner, firstNonEmpty(exception.Approvers...)), DueAt: exception.ExpiresAt, Action: action})
 			}
+		}
+	}
+	sort.Slice(items, func(i, j int) bool {
+		left := grcPolicySortDate(items[i].DueAt)
+		right := grcPolicySortDate(items[j].DueAt)
+		if left.Equal(right) {
+			return items[i].RecordURN < items[j].RecordURN
+		}
+		return left.Before(right)
+	})
+	return items
+}
+
+func grcPolicyDocumentWorkQueue(documents []grcPolicyDocumentItem, riskRegister []grcPolicyRiskRegisterItem, now time.Time) []grcPolicyDocumentWork {
+	items := []grcPolicyDocumentWork{}
+	for _, document := range documents {
+		policyID := ""
+		if len(document.Policies) > 0 {
+			policyID = document.Policies[0].ID
+		}
+		if grcPolicyDraftStatus(document.Status) {
+			items = append(items, grcPolicyDocumentWork{ID: document.URN + ":draft", DocumentID: document.ID, Document: document.Title, RecordURN: document.URN, Type: "document", Status: document.Status, Owner: document.Owner, DueAt: firstNonEmpty(document.EffectiveAt, document.NextReviewDueAt), Action: "Review draft document", PolicyID: policyID})
+		}
+		if grcPolicyDocumentDueForReview(document, now) {
+			items = append(items, grcPolicyDocumentWork{ID: document.URN + ":review", DocumentID: document.ID, Document: document.Title, RecordURN: document.URN, Type: "document", Status: document.Status, Owner: document.Owner, DueAt: document.NextReviewDueAt, Action: "Complete document review", PolicyID: policyID})
+		}
+	}
+	for _, risk := range riskRegister {
+		if !grcPolicyRiskOpen(risk.Status) {
+			continue
+		}
+		if grcPolicyOverdue(risk.ReviewDueAt, risk.Status, now) || grcPolicyOverdue(risk.TreatmentDueAt, risk.Status, now) || grcPolicyHighRisk(risk.ResidualRisk, risk.InherentRisk) {
+			dueAt := firstNonEmpty(risk.TreatmentDueAt, risk.ReviewDueAt)
+			items = append(items, grcPolicyDocumentWork{ID: risk.URN + ":risk", DocumentID: risk.SourceDocumentID, Document: firstNonEmpty(risk.SourceDocumentTitle, risk.Title), RecordURN: risk.URN, Type: "risk", Status: risk.Status, Owner: risk.Owner, DueAt: dueAt, Action: "Review risk treatment", RiskID: risk.ID})
 		}
 	}
 	sort.Slice(items, func(i, j int) bool {
@@ -1335,6 +1569,35 @@ func grcPolicyMappingForNode(node *grcPolicyGraphNode, policyID string, policyTi
 	return mappings
 }
 
+func grcPolicyDocumentMappings(document grcPolicyDocumentItem) []grcPolicyLifecycleMapping {
+	if len(document.Controls) == 0 && len(document.Evidence) == 0 && len(document.Risks) == 0 {
+		return nil
+	}
+	targets := []grcPolicyTargetRef{{URN: document.URN, EntityType: "document", Label: document.Title}}
+	for _, risk := range document.Risks {
+		targets = append(targets, grcPolicyTargetRef{URN: risk.URN, EntityType: "claim", Label: risk.Title})
+	}
+	policyID := ""
+	policyTitle := ""
+	if len(document.Policies) > 0 {
+		policyID = document.Policies[0].ID
+		policyTitle = document.Policies[0].Title
+	}
+	mappings := make([]grcPolicyLifecycleMapping, 0, len(targets))
+	for _, target := range uniqueTargets(targets) {
+		mappings = append(mappings, grcPolicyLifecycleMapping{
+			PolicyID:    policyID,
+			PolicyTitle: policyTitle,
+			SourceURN:   document.URN,
+			SourceType:  "document",
+			Target:      target,
+			Controls:    document.Controls,
+			Evidence:    document.Evidence,
+		})
+	}
+	return mappings
+}
+
 func grcPolicyPolicyIDFromRelations(urn string, relations []grcPolicyGraphRelation, policyURNToID map[string]string) string {
 	for _, relation := range relations {
 		if relation.From == nil || relation.To == nil || relation.From.URN != urn {
@@ -1428,6 +1691,101 @@ func grcPolicyTargetsFor(urn string, relations []grcPolicyGraphRelation) []grcPo
 	return uniqueTargets(targets)
 }
 
+func grcPolicyDocumentPoliciesFor(urn string, relations []grcPolicyGraphRelation, policyURNToID map[string]string) []grcPolicyDocumentRef {
+	refs := []grcPolicyDocumentRef{}
+	for _, relation := range relations {
+		if relation.From == nil || relation.To == nil {
+			continue
+		}
+		switch {
+		case relation.From.URN == urn && (relation.Relation == fabriccontract.RelationAssociatedWith || relation.Relation == fabriccontract.RelationBelongsTo):
+			if ref, ok := grcPolicyDocumentRefForNode(relation.To, policyURNToID); ok {
+				refs = append(refs, ref)
+			}
+		case relation.To.URN == urn && relation.Relation == fabriccontract.RelationHasEvidence:
+			if ref, ok := grcPolicyDocumentRefForNode(relation.From, policyURNToID); ok {
+				refs = append(refs, ref)
+			}
+		}
+	}
+	return uniqueDocumentRefs(refs)
+}
+
+func grcPolicyRiskPoliciesFor(urn string, relations []grcPolicyGraphRelation, policyURNToID map[string]string) []grcPolicyDocumentRef {
+	refs := []grcPolicyDocumentRef{}
+	for _, relation := range relations {
+		if relation.From == nil || relation.To == nil {
+			continue
+		}
+		if relation.From.URN == urn && (relation.Relation == fabriccontract.RelationAssociatedWith || relation.Relation == fabriccontract.RelationBelongsTo) {
+			if ref, ok := grcPolicyDocumentRefForNode(relation.To, policyURNToID); ok {
+				refs = append(refs, ref)
+			}
+		}
+	}
+	return uniqueDocumentRefs(refs)
+}
+
+func grcPolicyDocumentRefForNode(node *grcPolicyGraphNode, policyURNToID map[string]string) (grcPolicyDocumentRef, bool) {
+	if node == nil {
+		return grcPolicyDocumentRef{}, false
+	}
+	if grcPolicyIsPolicyNode(node) {
+		return grcPolicyDocumentRef{ID: firstNonEmpty(policyURNToID[node.URN], grcPolicyPolicyID(node)), URN: node.URN, Title: grcPolicyNodeTitle(node), Reference: "policy"}, true
+	}
+	if node.EntityType == "policy.version" {
+		return grcPolicyDocumentRef{ID: grcPolicyAttr(node, "policy_id"), URN: node.URN, Title: grcPolicyNodeTitle(node), Reference: "policy_version"}, true
+	}
+	if node.EntityType == "policy.template" {
+		return grcPolicyDocumentRef{ID: grcPolicyAttr(node, "policy_id"), URN: node.URN, Title: grcPolicyNodeTitle(node), Reference: "policy_template"}, true
+	}
+	if node.EntityType == "policy.exception" {
+		return grcPolicyDocumentRef{ID: grcPolicyAttr(node, "policy_id"), URN: node.URN, Title: grcPolicyNodeTitle(node), Reference: "policy_exception"}, true
+	}
+	return grcPolicyDocumentRef{}, false
+}
+
+func grcPolicyDocumentRisksFor(urn string, relations []grcPolicyGraphRelation) []grcPolicyRiskRef {
+	refs := []grcPolicyRiskRef{}
+	for _, relation := range relations {
+		if relation.From == nil || relation.To == nil {
+			continue
+		}
+		if relation.From.URN == urn && (relation.Relation == fabriccontract.RelationAssociatedWith || relation.Relation == fabriccontract.RelationHasEvidence) && grcPolicyIsRiskScenarioNode(relation.To) {
+			refs = append(refs, grcPolicyRiskRefFromNode(relation.To))
+		}
+		if relation.To.URN == urn && (relation.Relation == fabriccontract.RelationAssociatedWith || relation.Relation == fabriccontract.RelationHasEvidence) && grcPolicyIsRiskScenarioNode(relation.From) {
+			refs = append(refs, grcPolicyRiskRefFromNode(relation.From))
+		}
+	}
+	return uniqueRiskRefs(refs)
+}
+
+func grcPolicyRiskDocumentsFor(urn string, relations []grcPolicyGraphRelation) []grcPolicyDocumentRef {
+	refs := []grcPolicyDocumentRef{}
+	for _, relation := range relations {
+		if relation.From == nil || relation.To == nil {
+			continue
+		}
+		if relation.From.URN == urn && relation.To.EntityType == "document" && (relation.Relation == fabriccontract.RelationHasEvidence || relation.Relation == fabriccontract.RelationAssociatedWith) {
+			refs = append(refs, grcPolicyDocumentRef{ID: grcPolicyNodeID(relation.To, "document_id", "policy_document_id"), URN: relation.To.URN, Title: grcPolicyNodeTitle(relation.To), Reference: firstNonEmpty(grcPolicyDocumentClass(relation.To), "document")})
+		}
+		if relation.To.URN == urn && relation.From.EntityType == "document" && (relation.Relation == fabriccontract.RelationHasEvidence || relation.Relation == fabriccontract.RelationAssociatedWith) {
+			refs = append(refs, grcPolicyDocumentRef{ID: grcPolicyNodeID(relation.From, "document_id", "policy_document_id"), URN: relation.From.URN, Title: grcPolicyNodeTitle(relation.From), Reference: firstNonEmpty(grcPolicyDocumentClass(relation.From), "document")})
+		}
+	}
+	return uniqueDocumentRefs(refs)
+}
+
+func grcPolicyRiskRefFromNode(node *grcPolicyGraphNode) grcPolicyRiskRef {
+	return grcPolicyRiskRef{
+		ID:     grcPolicyNodeID(node, "risk_id", "risk_register_id"),
+		URN:    node.URN,
+		Title:  grcPolicyRiskTitle(node),
+		Status: grcPolicyAttr(node, "status", "risk_status", "review_status"),
+	}
+}
+
 func grcPolicyActionActors(urn string, relations []grcPolicyGraphRelation, action string) []string {
 	actors := []string{}
 	for _, relation := range relations {
@@ -1469,6 +1827,78 @@ func grcPolicyIsControlNode(node *grcPolicyGraphNode) bool {
 		return false
 	}
 	return strings.EqualFold(grcPolicyAttr(node, "policy_type"), "control")
+}
+
+func grcPolicyIsRiskScenarioNode(node *grcPolicyGraphNode) bool {
+	if node == nil || node.EntityType != "claim" {
+		return false
+	}
+	return strings.EqualFold(grcPolicyAttr(node, "claim_type"), "risk_scenario")
+}
+
+func grcPolicyDocumentClass(node *grcPolicyGraphNode) string {
+	raw := strings.ToLower(strings.TrimSpace(firstNonEmpty(
+		grcPolicyAttr(node, "document_class", "document_type", "file_type", "category", "policy_document_type"),
+		node.Label,
+	)))
+	normalized := strings.NewReplacer("-", "_", " ", "_", "/", "_").Replace(raw)
+	for strings.Contains(normalized, "__") {
+		normalized = strings.ReplaceAll(normalized, "__", "_")
+	}
+	switch {
+	case strings.Contains(normalized, "risk_register"):
+		return "risk_register"
+	case strings.Contains(normalized, "procedure"):
+		return "procedure"
+	case strings.Contains(normalized, "standard"):
+		return "standard"
+	case strings.Contains(normalized, "control_narrative"):
+		return "control_narrative"
+	case strings.Contains(normalized, "exception_register") || strings.Contains(normalized, "waiver_register"):
+		return "exception_register"
+	case strings.Contains(normalized, "training"):
+		return "training_material"
+	case strings.Contains(normalized, "policy"):
+		return "policy"
+	default:
+		return firstNonEmpty(grcPolicyAttr(node, "document_class"), "document")
+	}
+}
+
+func grcPolicyDocumentInScope(item grcPolicyDocumentItem) bool {
+	if item.URN == "" {
+		return false
+	}
+	if item.DocumentClass == "risk_register" || item.DocumentClass == "policy" || item.DocumentClass == "standard" || item.DocumentClass == "procedure" || item.DocumentClass == "control_narrative" || item.DocumentClass == "exception_register" || item.DocumentClass == "training_material" {
+		return true
+	}
+	return len(item.Policies) > 0 || len(item.Risks) > 0 || len(item.Controls) > 0
+}
+
+func grcPolicyRiskTitle(node *grcPolicyGraphNode) string {
+	return firstNonEmpty(grcPolicyAttr(node, "title", "description", "risk_statement", "name"), node.Label, grcPolicyNodeID(node, "risk_id"))
+}
+
+func grcPolicyDocumentDueForReview(document grcPolicyDocumentItem, now time.Time) bool {
+	return grcPolicyOverdue(document.NextReviewDueAt, firstNonEmpty(document.Status, "pending"), now)
+}
+
+func grcPolicyRiskOpen(status string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	if normalized == "" {
+		return false
+	}
+	return normalized != "closed" && normalized != "resolved" && normalized != "accepted" && normalized != "retired"
+}
+
+func grcPolicyHighRisk(values ...string) bool {
+	for _, value := range values {
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "critical", "high", "very_high", "very high", "severe":
+			return true
+		}
+	}
+	return false
 }
 
 func grcPolicyNodeID(node *grcPolicyGraphNode, keys ...string) string {
@@ -1530,7 +1960,7 @@ func grcPolicyListAttr(node *grcPolicyGraphNode, keys ...string) []string {
 
 func grcPolicyPublicAttrs(attrs map[string]string) map[string]string {
 	allowed := map[string]string{}
-	for _, key := range []string{"category", "framework", "frameworks", "review_cadence", "status", "source_system"} {
+	for _, key := range []string{"category", "document_class", "document_type", "framework", "frameworks", "impact", "inherent_risk", "inherent_risk_level", "likelihood", "residual_risk", "residual_risk_level", "review_cadence", "risk_category", "source_system", "status", "treatment"} {
 		if value := strings.TrimSpace(attrs[key]); value != "" {
 			allowed[key] = value
 		}
@@ -1753,6 +2183,46 @@ func uniqueTargets(items []grcPolicyTargetRef) []grcPolicyTargetRef {
 		seen[key] = struct{}{}
 		out = append(out, item)
 	}
+	return out
+}
+
+func uniqueDocumentRefs(items []grcPolicyDocumentRef) []grcPolicyDocumentRef {
+	seen := map[string]struct{}{}
+	out := []grcPolicyDocumentRef{}
+	for _, item := range items {
+		key := firstNonEmpty(item.URN, item.ID, item.Title)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(firstNonEmpty(out[i].Title, out[i].ID, out[i].URN)) < strings.ToLower(firstNonEmpty(out[j].Title, out[j].ID, out[j].URN))
+	})
+	return out
+}
+
+func uniqueRiskRefs(items []grcPolicyRiskRef) []grcPolicyRiskRef {
+	seen := map[string]struct{}{}
+	out := []grcPolicyRiskRef{}
+	for _, item := range items {
+		key := firstNonEmpty(item.URN, item.ID, item.Title)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(firstNonEmpty(out[i].Title, out[i].ID, out[i].URN)) < strings.ToLower(firstNonEmpty(out[j].Title, out[j].ID, out[j].URN))
+	})
 	return out
 }
 

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -1943,7 +1943,7 @@ func grcPolicyRiskTitle(node *grcPolicyGraphNode) string {
 }
 
 func grcPolicyDocumentDueForReview(document grcPolicyDocumentItem, now time.Time) bool {
-	return grcPolicyOverdue(document.NextReviewDueAt, firstNonEmpty(document.Status, "pending"), now)
+	return grcPolicyOverdue(document.NextReviewDueAt, document.Status, now)
 }
 
 func grcPolicyRiskOpen(status string) bool {

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -1974,7 +1974,12 @@ func grcPolicyRiskOpen(status string) bool {
 	if normalized == "" {
 		return false
 	}
-	return !grcPolicyAcceptedStatus(normalized) && !grcPolicyClosedStatus(normalized) && normalized != "resolved"
+	switch normalized {
+	case "resolved", "mitigated", "remediated", "transferred", "treated":
+		return false
+	default:
+		return !grcPolicyAcceptedStatus(normalized) && !grcPolicyClosedStatus(normalized)
+	}
 }
 
 func grcPolicyHighRisk(values ...string) bool {

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -1139,11 +1139,12 @@ func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, template
 		}
 	}
 	for _, risk := range riskRegister {
-		if grcPolicyRiskOpen(risk.Status) {
+		openRisk := grcPolicyRiskOpen(risk.Status)
+		if openRisk {
 			summary.OpenRisks++
-		}
-		if grcPolicyHighRisk(risk.ResidualRisk, risk.InherentRisk) {
-			summary.HighRisks++
+			if grcPolicyHighRisk(risk.ResidualRisk, risk.InherentRisk) {
+				summary.HighRisks++
+			}
 		}
 		for _, control := range risk.Controls {
 			if control.ControlID != "" {

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -1275,7 +1275,11 @@ func grcPolicyDocumentWorkQueue(documents []grcPolicyDocumentItem, riskRegister 
 		}
 		if grcPolicyOverdue(risk.ReviewDueAt, risk.Status, now) || grcPolicyOverdue(risk.TreatmentDueAt, risk.Status, now) || grcPolicyHighRisk(risk.ResidualRisk, risk.InherentRisk) {
 			dueAt := firstNonEmpty(risk.TreatmentDueAt, risk.ReviewDueAt)
-			items = append(items, grcPolicyDocumentWork{ID: risk.URN + ":risk", DocumentID: risk.SourceDocumentID, Document: firstNonEmpty(risk.SourceDocumentTitle, risk.Title), RecordURN: risk.URN, Type: "risk", Status: risk.Status, Owner: risk.Owner, DueAt: dueAt, Action: "Review risk treatment", RiskID: risk.ID})
+			policyID := ""
+			if len(risk.Policies) > 0 {
+				policyID = risk.Policies[0].ID
+			}
+			items = append(items, grcPolicyDocumentWork{ID: risk.URN + ":risk", DocumentID: risk.SourceDocumentID, Document: firstNonEmpty(risk.SourceDocumentTitle, risk.Title), RecordURN: risk.URN, Type: "risk", Status: risk.Status, Owner: risk.Owner, DueAt: dueAt, Action: "Review risk treatment", RiskID: risk.ID, PolicyID: policyID})
 		}
 	}
 	sort.Slice(items, func(i, j int) bool {

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -53,21 +53,36 @@ var grcPolicyLifecycleAnchorEntityTypes = []string{
 const grcPolicyLifecycleRiskScenarioAttrFragment = `"claim_type":"risk_scenario"`
 
 var grcPolicyLifecycleDocumentAttrFragments = []string{
+	`"category":"control_narrative"`,
+	`"category":"exception_register"`,
 	`"category":"policy"`,
 	`"category":"procedure"`,
 	`"category":"risk_register"`,
 	`"category":"standard"`,
+	`"category":"training"`,
+	`"category":"training_material"`,
+	`"category":"waiver_register"`,
 	`"control_id":"`,
 	`"control_ids":`,
+	`"document_class":"control_narrative"`,
+	`"document_class":"exception_register"`,
 	`"document_class":"policy"`,
 	`"document_class":"procedure"`,
 	`"document_class":"risk_register"`,
 	`"document_class":"standard"`,
+	`"document_class":"training"`,
+	`"document_class":"training_material"`,
+	`"document_class":"waiver_register"`,
+	`"document_type":"control_narrative`,
+	`"document_type":"exception_register`,
 	`"document_type":"policy`,
 	`"document_type":"procedure`,
 	`"document_type":"risk_assessment`,
 	`"document_type":"risk_register`,
 	`"document_type":"standard`,
+	`"document_type":"training`,
+	`"document_type":"training_material`,
+	`"document_type":"waiver_register`,
 	`"evidence_id":"`,
 	`"evidence_ids":`,
 	`"policy_document_type":"`,
@@ -1956,7 +1971,7 @@ func grcPolicyRiskOpen(status string) bool {
 	if normalized == "" {
 		return false
 	}
-	return normalized != "closed" && normalized != "resolved" && normalized != "accepted" && normalized != "retired"
+	return !grcPolicyAcceptedStatus(normalized) && normalized != "closed" && normalized != "resolved" && normalized != "retired"
 }
 
 func grcPolicyHighRisk(values ...string) bool {

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -200,6 +200,30 @@ func TestMissingDocumentStatusDoesNotCreateReviewWork(t *testing.T) {
 	}
 }
 
+func TestDraftDocumentDoesNotCreateReviewWork(t *testing.T) {
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	document := grcPolicyDocumentItem{
+		ID:              "secure-development-draft",
+		URN:             "urn:document:secure-development-draft",
+		Title:           "Secure Development Draft",
+		DocumentClass:   "policy",
+		Status:          "draft",
+		NextReviewDueAt: "2026-01-15",
+	}
+
+	if grcPolicyDocumentDueForReview(document, now) {
+		t.Fatalf("draft document should not be due for review")
+	}
+	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document}, nil, nil, now)
+	if summary.DraftDocuments != 1 || summary.DocumentsDueForReview != 0 {
+		t.Fatalf("summary = %+v, want one draft document and no due review", summary)
+	}
+	items := grcPolicyDocumentWorkQueue([]grcPolicyDocumentItem{document}, nil, now)
+	if len(items) != 1 || items[0].Action != "Review draft document" {
+		t.Fatalf("document work queue = %+v, want only draft review work", items)
+	}
+}
+
 func TestHighRiskSummaryCountsOpenRisksOnly(t *testing.T) {
 	summary := grcPolicyLifecycleSummaryFrom(nil, nil, nil, []grcPolicyRiskRegisterItem{
 		{ID: "open-high", Status: "open", ResidualRisk: "high"},
@@ -207,6 +231,8 @@ func TestHighRiskSummaryCountsOpenRisksOnly(t *testing.T) {
 		{ID: "accepted-high", Status: "accepted", InherentRisk: "high"},
 		{ID: "completed-high", Status: "completed", ResidualRisk: "high"},
 		{ID: "acknowledged-high", Status: "acknowledged", ResidualRisk: "high"},
+		{ID: "expired-high", Status: "expired", ResidualRisk: "high"},
+		{ID: "rejected-high", Status: "rejected", ResidualRisk: "high"},
 		{ID: "open-medium", Status: "open", ResidualRisk: "medium"},
 	}, nil, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
 

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -203,6 +203,28 @@ func TestHighRiskSummaryCountsOpenRisksOnly(t *testing.T) {
 	}
 }
 
+func TestRiskWorkQueueIncludesLinkedPolicy(t *testing.T) {
+	items := grcPolicyDocumentWorkQueue(nil, []grcPolicyRiskRegisterItem{
+		{
+			ID:           "privileged-access",
+			URN:          "urn:risk:privileged-access",
+			Title:        "Privileged access drift",
+			Status:       "open",
+			ResidualRisk: "high",
+			Policies: []grcPolicyDocumentRef{
+				{ID: "access", URN: "urn:policy:access", Title: "Access Control Policy"},
+			},
+		},
+	}, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+
+	if len(items) != 1 {
+		t.Fatalf("risk work queue = %+v, want one high-risk work item", items)
+	}
+	if items[0].RiskID != "privileged-access" || items[0].PolicyID != "access" {
+		t.Fatalf("risk work item = %+v, want linked risk and policy IDs", items[0])
+	}
+}
+
 func TestExceptionRollupSkipsMissingStatus(t *testing.T) {
 	summary := grcPolicyExceptionRollup([]grcPolicyExceptionItem{
 		{ID: "missing", Status: "", ExpiresAt: "2026-03-01"},

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -233,6 +233,9 @@ func TestHighRiskSummaryCountsOpenRisksOnly(t *testing.T) {
 		{ID: "acknowledged-high", Status: "acknowledged", ResidualRisk: "high"},
 		{ID: "expired-high", Status: "expired", ResidualRisk: "high"},
 		{ID: "rejected-high", Status: "rejected", ResidualRisk: "high"},
+		{ID: "mitigated-high", Status: "mitigated", ResidualRisk: "high"},
+		{ID: "remediated-high", Status: "remediated", ResidualRisk: "high"},
+		{ID: "transferred-high", Status: "transferred", ResidualRisk: "high"},
 		{ID: "open-medium", Status: "open", ResidualRisk: "medium"},
 	}, nil, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
 

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -55,6 +55,36 @@ func TestBuildAppliesEntityLimitPerLifecycleType(t *testing.T) {
 	if !foundLifecycleEvent {
 		t.Fatalf("entity types = %#v, want policy.lifecycle.event", entityRequest.Params["entity_types"])
 	}
+	if entityRequest.Params["risk_scenario_attr_fragment"] != grcPolicyLifecycleRiskScenarioAttrFragment {
+		t.Fatalf("entity params = %#v, want risk scenario filter", entityRequest.Params)
+	}
+	documentFragments, ok := entityRequest.Params["document_attr_fragments"].([]string)
+	if !ok || !stringSliceContains(documentFragments, `"policy_id":"`) || !stringSliceContains(documentFragments, `"risk_scenario_id":"`) {
+		t.Fatalf("entity params = %#v, want document attr filters", entityRequest.Params)
+	}
+	if !strings.Contains(entityRequest.Query, "entity_type <> 'claim'") || !strings.Contains(entityRequest.Query, "entity_type <> 'document'") {
+		t.Fatalf("entity query %q does not filter broad claim/document types", entityRequest.Query)
+	}
+	relationRequest := store.requests[1]
+	if relationRequest.Params["risk_scenario_attr_fragment"] != grcPolicyLifecycleRiskScenarioAttrFragment {
+		t.Fatalf("relation params = %#v, want risk scenario filter", relationRequest.Params)
+	}
+	anchorTypes, ok := relationRequest.Params["policy_anchor_entity_types"].([]string)
+	if !ok || !stringSliceContains(anchorTypes, "policy.version") {
+		t.Fatalf("relation params = %#v, want policy anchor types", relationRequest.Params)
+	}
+	if !strings.Contains(relationRequest.Query, "left.entity_type <> 'claim'") || !strings.Contains(relationRequest.Query, "right.entity_type <> 'document'") {
+		t.Fatalf("relation query %q does not filter broad claim/document types", relationRequest.Query)
+	}
+}
+
+func stringSliceContains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestEntityTypeLimitStaysWithinGraphRowCeiling(t *testing.T) {

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -190,6 +190,19 @@ func TestMissingDocumentStatusDoesNotCreateReviewWork(t *testing.T) {
 	}
 }
 
+func TestHighRiskSummaryCountsOpenRisksOnly(t *testing.T) {
+	summary := grcPolicyLifecycleSummaryFrom(nil, nil, nil, []grcPolicyRiskRegisterItem{
+		{ID: "open-high", Status: "open", ResidualRisk: "high"},
+		{ID: "closed-critical", Status: "closed", ResidualRisk: "critical"},
+		{ID: "accepted-high", Status: "accepted", InherentRisk: "high"},
+		{ID: "open-medium", Status: "open", ResidualRisk: "medium"},
+	}, nil, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+
+	if summary.OpenRisks != 2 || summary.HighRisks != 1 {
+		t.Fatalf("risk summary = %+v, want two open risks and one open high risk", summary)
+	}
+}
+
 func TestExceptionRollupSkipsMissingStatus(t *testing.T) {
 	summary := grcPolicyExceptionRollup([]grcPolicyExceptionItem{
 		{ID: "missing", Status: "", ExpiresAt: "2026-03-01"},

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -168,6 +168,28 @@ func TestMissingReviewStatusDoesNotCreateOverdueWork(t *testing.T) {
 	}
 }
 
+func TestMissingDocumentStatusDoesNotCreateReviewWork(t *testing.T) {
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	document := grcPolicyDocumentItem{
+		ID:              "risk-register",
+		URN:             "urn:document:risk-register",
+		Title:           "Risk Register",
+		DocumentClass:   "risk_register",
+		NextReviewDueAt: "2026-01-15",
+	}
+
+	if grcPolicyDocumentDueForReview(document, now) {
+		t.Fatalf("missing document status should not be due for review")
+	}
+	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document}, nil, nil, now)
+	if summary.DocumentsDueForReview != 0 {
+		t.Fatalf("summary = %+v, want missing-status document excluded from due count", summary)
+	}
+	if items := grcPolicyDocumentWorkQueue([]grcPolicyDocumentItem{document}, nil, now); len(items) != 0 {
+		t.Fatalf("document work queue = %+v, want missing-status document excluded", items)
+	}
+}
+
 func TestExceptionRollupSkipsMissingStatus(t *testing.T) {
 	summary := grcPolicyExceptionRollup([]grcPolicyExceptionItem{
 		{ID: "missing", Status: "", ExpiresAt: "2026-03-01"},

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -129,7 +129,7 @@ func TestMissingReviewStatusDoesNotCreateOverdueWork(t *testing.T) {
 			{URN: "urn:review:missing-status", ReviewDueAt: "2026-01-15"},
 		},
 	}
-	summary := grcPolicyLifecycleSummaryFrom([]grcPolicyLifecyclePolicy{policy}, nil, nil, now)
+	summary := grcPolicyLifecycleSummaryFrom([]grcPolicyLifecyclePolicy{policy}, nil, nil, nil, nil, now)
 	if summary.OverdueReviews != 0 {
 		t.Fatalf("summary = %+v, want missing-status review excluded from overdue count", summary)
 	}

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -62,6 +62,16 @@ func TestBuildAppliesEntityLimitPerLifecycleType(t *testing.T) {
 	if !ok || !stringSliceContains(documentFragments, `"policy_id":"`) || !stringSliceContains(documentFragments, `"risk_scenario_id":"`) {
 		t.Fatalf("entity params = %#v, want document attr filters", entityRequest.Params)
 	}
+	for _, fragment := range []string{
+		`"document_class":"control_narrative"`,
+		`"document_class":"exception_register"`,
+		`"document_class":"training_material"`,
+		`"document_class":"waiver_register"`,
+	} {
+		if !stringSliceContains(documentFragments, fragment) {
+			t.Fatalf("document fragments = %#v, want %s", documentFragments, fragment)
+		}
+	}
 	if !strings.Contains(entityRequest.Query, "entity_type <> 'claim'") || !strings.Contains(entityRequest.Query, "entity_type <> 'document'") {
 		t.Fatalf("entity query %q does not filter broad claim/document types", entityRequest.Query)
 	}
@@ -195,11 +205,30 @@ func TestHighRiskSummaryCountsOpenRisksOnly(t *testing.T) {
 		{ID: "open-high", Status: "open", ResidualRisk: "high"},
 		{ID: "closed-critical", Status: "closed", ResidualRisk: "critical"},
 		{ID: "accepted-high", Status: "accepted", InherentRisk: "high"},
+		{ID: "completed-high", Status: "completed", ResidualRisk: "high"},
+		{ID: "acknowledged-high", Status: "acknowledged", ResidualRisk: "high"},
 		{ID: "open-medium", Status: "open", ResidualRisk: "medium"},
 	}, nil, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
 
 	if summary.OpenRisks != 2 || summary.HighRisks != 1 {
 		t.Fatalf("risk summary = %+v, want two open risks and one open high risk", summary)
+	}
+}
+
+func TestCompletedRiskDoesNotCreateWork(t *testing.T) {
+	items := grcPolicyDocumentWorkQueue(nil, []grcPolicyRiskRegisterItem{
+		{
+			ID:             "completed-high",
+			URN:            "urn:risk:completed-high",
+			Title:          "Completed high risk",
+			Status:         "completed",
+			ResidualRisk:   "high",
+			TreatmentDueAt: "2026-01-15",
+		},
+	}, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+
+	if len(items) != 0 {
+		t.Fatalf("risk work queue = %+v, want completed risk excluded", items)
 	}
 }
 

--- a/internal/sourceprojection/grc_assurance.go
+++ b/internal/sourceprojection/grc_assurance.go
@@ -20,12 +20,29 @@ func grcDocumentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 	ctx.addResourceEntity(
 		documentURN,
 		"document",
-		firstAttribute(ctx.attrs, "title", "document_id"),
-		map[string]string{"document_id": documentID, "source_system": ctx.provider},
+		firstAttribute(ctx.attrs, "title", "name", "document_title", "document_id"),
+		map[string]string{
+			"approved_at":          firstAttribute(ctx.attrs, "approved_at"),
+			"document_class":       firstAttribute(ctx.attrs, "document_class", "document_type", "category"),
+			"document_id":          documentID,
+			"document_type":        firstAttribute(ctx.attrs, "document_type", "file_type", "category"),
+			"effective_at":         firstAttribute(ctx.attrs, "effective_at"),
+			"next_review_due_at":   firstAttribute(ctx.attrs, "next_review_due_at", "review_due_at", "due_at"),
+			"policy_document_type": firstAttribute(ctx.attrs, "policy_document_type"),
+			"review_cadence":       firstAttribute(ctx.attrs, "review_cadence", "cadence"),
+			"source_system":        ctx.provider,
+			"status":               firstAttribute(ctx.attrs, "status", "document_status", "lifecycle_state"),
+			"url":                  firstAttribute(ctx.attrs, "url", "document_url", "file_url", "download_url"),
+			"version":              firstAttribute(ctx.attrs, "version", "version_number"),
+		},
 	)
-	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id"))
-	addInternetHostLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, relationHasIdentifier, firstAttribute(ctx.attrs, "url"), "grc_document_url_host", "0.9")
-	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, "grc_category", firstAttribute(ctx.attrs, "category"))
+	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id", "policy_owner_user_id", "document_owner_user_id"))
+	addInternetHostLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, relationHasIdentifier, firstAttribute(ctx.attrs, "url", "document_url", "file_url", "download_url"), "grc_document_url_host", "0.9")
+	addGRCPolicyLifecycleSubjectLinks(ctx, documentURN, firstAttribute(ctx.attrs, "policy_id"), firstAttribute(ctx.attrs, "policy_version_id", "version_id"))
+	addGRCPolicyRiskScenarioReferenceLinks(ctx, documentURN)
+	addGRCControlSupportLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, ctx.provider)
+	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, ctx.provider, ctx.attrs)
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, documentURN, "grc_category", strings.Join([]string{ctx.attrs["category"], ctx.attrs["document_type"], ctx.attrs["document_class"]}, ","))
 	entities, links := ctx.done()
 	return entities, links, nil
 }

--- a/internal/sourceprojection/grc_assurance_test.go
+++ b/internal/sourceprojection/grc_assurance_test.go
@@ -239,11 +239,16 @@ func TestProjectGRCDocumentLinksURLAndCategory(t *testing.T) {
 		SourceId: "grc",
 		Kind:     "grc.document",
 		Attributes: map[string]string{
-			"provider":    "vanta",
-			"document_id": "doc-1",
-			"title":       "AWS Architecture",
-			"category":    "Infrastructure",
-			"url":         "https://docs.writer.com/security/aws-architecture",
+			"provider":      "vanta",
+			"document_id":   "doc-1",
+			"title":         "Risk Register",
+			"category":      "Risk register",
+			"document_type": "risk_register",
+			"policy_id":     "access",
+			"risk_id":       "risk-1",
+			"control_ids":   "CC6.1",
+			"status":        "draft",
+			"url":           "https://docs.writer.com/security/risk-register",
 		},
 	})
 	if err != nil {
@@ -252,9 +257,18 @@ func TestProjectGRCDocumentLinksURLAndCategory(t *testing.T) {
 
 	documentURN := "urn:cerebro:writer:document:vanta:doc-1"
 	hostURN := "urn:cerebro:writer:internet_host:docs.writer.com"
-	categoryURN := "urn:cerebro:writer:asset_tag:grc_category:infrastructure"
+	categoryURN := "urn:cerebro:writer:asset_tag:grc_category:risk_register"
+	policyURN := "urn:cerebro:writer:policy:vanta:policy:access"
+	riskURN := "urn:cerebro:writer:claim:vanta:risk_scenario:risk-1"
+	controlURN := "urn:cerebro:writer:policy:vanta:control:CC6.1"
 	assertProjectedLink(t, state, documentURN, relationHasIdentifier, hostURN)
 	assertProjectedLink(t, state, documentURN, relationTaggedAs, categoryURN)
+	assertProjectedLink(t, state, documentURN, relationAssociatedWith, policyURN)
+	assertProjectedLink(t, state, documentURN, relationAssociatedWith, riskURN)
+	assertProjectedLink(t, state, documentURN, relationSupports, controlURN)
+	if got := state.entities[documentURN].Attributes["document_type"]; got != "risk_register" {
+		t.Fatalf("document_type = %q, want risk_register", got)
+	}
 }
 
 func TestProjectGRCContractLinksVendorControlsOwnerAndEvidence(t *testing.T) {

--- a/internal/sourceprojection/grc_identity_access_test.go
+++ b/internal/sourceprojection/grc_identity_access_test.go
@@ -46,10 +46,15 @@ func TestProjectGRCRiskScenarioOwnerDoesNotCreatePersonIdentityBridge(t *testing
 		SourceId: "grc",
 		Kind:     "grc.risk_scenario",
 		Attributes: map[string]string{
-			"provider":    "vanta",
-			"risk_id":     "risk-1",
-			"description": "AI vendor risk",
-			"owner":       "alice@writer.com",
+			"provider":            "vanta",
+			"risk_id":             "risk-1",
+			"description":         "AI vendor risk",
+			"owner":               "alice@writer.com",
+			"policy_id":           "vendor-risk",
+			"document_id":         "risk-register",
+			"document_type":       "risk_register",
+			"control_ids":         "VR-1",
+			"residual_risk_level": "high",
 		},
 	})
 	if err != nil {
@@ -58,9 +63,15 @@ func TestProjectGRCRiskScenarioOwnerDoesNotCreatePersonIdentityBridge(t *testing
 
 	riskURN := "urn:cerebro:writer:claim:vanta:risk_scenario:risk-1"
 	contactURN := "urn:cerebro:writer:contact:vanta:owner:alice@writer.com"
+	policyURN := "urn:cerebro:writer:policy:vanta:policy:vendor-risk"
+	documentURN := "urn:cerebro:writer:document:vanta:risk-register"
+	controlURN := "urn:cerebro:writer:policy:vanta:control:VR-1"
 	personURN := "urn:cerebro:writer:person:vanta:owner:alice@writer.com"
 	identityURN := "urn:cerebro:writer:identity:email:alice@writer.com"
 	assertProjectedLink(t, state, riskURN, relationAssignedTo, contactURN)
+	assertProjectedLink(t, state, riskURN, relationAssociatedWith, policyURN)
+	assertProjectedLink(t, state, riskURN, relationHasEvidence, documentURN)
+	assertProjectedLink(t, state, riskURN, relationAssociatedWith, controlURN)
 	if _, ok := state.entities[personURN]; ok {
 		t.Fatalf("risk owner projected as GRC person: %#v", state.entities[personURN])
 	}

--- a/internal/sourceprojection/grc_identity_access_test.go
+++ b/internal/sourceprojection/grc_identity_access_test.go
@@ -79,6 +79,38 @@ func TestProjectGRCRiskScenarioOwnerDoesNotCreatePersonIdentityBridge(t *testing
 	assertProjectedLink(t, state, contactURN, relationAssociatedWith, identityURN)
 }
 
+func TestProjectGRCRiskScenarioPrefersReviewStatus(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-risk-risk-status",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.risk_scenario",
+		Attributes: map[string]string{
+			"provider":      "vanta",
+			"risk_id":       "risk-status",
+			"description":   "Conflicting risk status fields",
+			"status":        "open",
+			"risk_status":   "active",
+			"review_status": "accepted",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	riskURN := "urn:cerebro:writer:claim:vanta:risk_scenario:risk-status"
+	entity := state.entities[riskURN]
+	if entity == nil {
+		t.Fatalf("risk entity missing: %#v", state.entities)
+	}
+	if got := entity.Attributes["status"]; got != "accepted" {
+		t.Fatalf("risk status = %q, want review_status precedence", got)
+	}
+}
+
 func TestProjectGRCPersonIdentifier(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_policy_lifecycle.go
+++ b/internal/sourceprojection/grc_policy_lifecycle.go
@@ -397,6 +397,32 @@ func addGRCPolicyDocumentLinks(entities map[string]*ports.ProjectedEntity, links
 	addInternetHostLink(entities, links, tenantID, sourceID, event, fromURN, relationHasIdentifier, firstAttribute(attrs, "url", "document_url", "file_url", "download_url"), "grc_policy_document_url_host", "0.90")
 }
 
+func addGRCPolicyRiskScenarioReferenceLinks(ctx *grcProjectionContext, fromURN string) {
+	if fromURN == "" {
+		return
+	}
+	rawRiskIDs := strings.Join([]string{
+		ctx.attrs["risk_id"],
+		ctx.attrs["risk_ids"],
+		ctx.attrs["risk_register_id"],
+		ctx.attrs["risk_register_item_ids"],
+	}, ",")
+	for _, riskID := range grcAttributeSequence(rawRiskIDs) {
+		riskURN := projectionURN(ctx.tenantID, "claim", ctx.provider, "risk_scenario", riskID)
+		ctx.addReferenceEntity(
+			riskURN,
+			"claim",
+			firstAttribute(ctx.attrs, "risk_statement", "description", "risk_title", "title", "risk_id"),
+			map[string]string{
+				"claim_type":    "risk_scenario",
+				"risk_id":       riskID,
+				"source_system": ctx.provider,
+			},
+		)
+		ctx.addEventLink(fromURN, riskURN, relationAssociatedWith)
+	}
+}
+
 func addGRCPolicyAssignmentLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, provider string, attrs map[string]string) {
 	if fromURN == "" {
 		return

--- a/internal/sourceprojection/grc_risk.go
+++ b/internal/sourceprojection/grc_risk.go
@@ -30,7 +30,7 @@ func grcRiskScenarioProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 			"risk_category":       firstAttribute(ctx.attrs, "risk_category", "category", "domain"),
 			"risk_id":             riskID,
 			"source_system":       ctx.provider,
-			"status":              firstAttribute(ctx.attrs, "status", "risk_status", "review_status"),
+			"status":              firstAttribute(ctx.attrs, "review_status", "risk_status", "status"),
 			"treatment":           firstAttribute(ctx.attrs, "treatment", "treatment_plan", "response", "mitigation"),
 			"treatment_due_at":    firstAttribute(ctx.attrs, "treatment_due_at", "mitigation_due_at", "target_due_at"),
 		},

--- a/internal/sourceprojection/grc_risk.go
+++ b/internal/sourceprojection/grc_risk.go
@@ -6,47 +6,51 @@ import (
 )
 
 func grcRiskScenarioProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
+	ctx, err := newGRCProjectionContext(event)
 	if err != nil {
 		return nil, nil, err
 	}
-	attrs := event.GetAttributes()
-	riskID := firstAttribute(attrs, "risk_id", "external_id")
+	riskID := firstAttribute(ctx.attrs, "risk_id", "risk_register_id", "external_id")
 	if riskID == "" {
 		return nil, nil, nil
 	}
-	provider := grcProvider(attrs)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	riskURN := projectionURN(tenantID, "claim", provider, "risk_scenario", riskID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        riskURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "claim",
-		Label:      firstAttribute(attrs, "description", "risk_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
-			"claim_type":    "risk_scenario",
-			"predicate":     firstAttribute(attrs, "description"),
-			"source_system": provider,
-			"status":        firstAttribute(attrs, "review_status"),
-		}),
-	})
-	if owner := firstAttribute(attrs, "owner"); owner != "" {
-		ownerURN := projectionURN(tenantID, "contact", provider, "owner", owner)
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        ownerURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "contact",
-			Label:      owner,
-			Attributes: map[string]string{"source_system": provider, "owner": owner},
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), riskURN, ownerURN, relationAssignedTo, map[string]string{"event_id": event.GetId()}))
-		addGRCRiskOwnerEmailLink(entities, links, tenantID, event.GetSourceId(), event, ownerURN, owner)
+	riskURN := projectionURN(ctx.tenantID, "claim", ctx.provider, "risk_scenario", riskID)
+	ctx.addResourceEntity(
+		riskURN,
+		"claim",
+		firstAttribute(ctx.attrs, "title", "description", "risk_statement", "risk_id"),
+		map[string]string{
+			"claim_type":          "risk_scenario",
+			"impact":              firstAttribute(ctx.attrs, "impact", "impact_level"),
+			"inherent_risk_level": firstAttribute(ctx.attrs, "inherent_risk_level", "inherent_risk", "risk_level"),
+			"likelihood":          firstAttribute(ctx.attrs, "likelihood", "likelihood_level"),
+			"predicate":           firstAttribute(ctx.attrs, "risk_statement", "description"),
+			"residual_risk_level": firstAttribute(ctx.attrs, "residual_risk_level", "residual_risk"),
+			"review_due_at":       firstAttribute(ctx.attrs, "review_due_at", "next_review_due_at", "due_at"),
+			"risk_category":       firstAttribute(ctx.attrs, "risk_category", "category", "domain"),
+			"risk_id":             riskID,
+			"source_system":       ctx.provider,
+			"status":              firstAttribute(ctx.attrs, "status", "risk_status", "review_status"),
+			"treatment":           firstAttribute(ctx.attrs, "treatment", "treatment_plan", "response", "mitigation"),
+			"treatment_due_at":    firstAttribute(ctx.attrs, "treatment_due_at", "mitigation_due_at", "target_due_at"),
+		},
+	)
+	if owner := firstAttribute(ctx.attrs, "owner", "risk_owner", "owner_email"); owner != "" {
+		ownerURN := projectionURN(ctx.tenantID, "contact", ctx.provider, "owner", owner)
+		ctx.addReferenceEntity(ownerURN, "contact", owner, map[string]string{"source_system": ctx.provider, "owner": owner})
+		ctx.addEventLink(riskURN, ownerURN, relationAssignedTo)
+		addGRCRiskOwnerEmailLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, ownerURN, owner)
 	}
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
+	addGRCUserOwnerLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, riskURN, ctx.provider, firstAttribute(ctx.attrs, "owner_id", "risk_owner_user_id"))
+	addGRCPolicyLifecycleSubjectLinks(ctx, riskURN, firstAttribute(ctx.attrs, "policy_id"), firstAttribute(ctx.attrs, "policy_version_id", "version_id"))
+	addGRCControlAssociationLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, riskURN, ctx.provider, relationAssociatedWith, "grc_risk_scenario")
+	addGRCPolicyDocumentLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, riskURN, ctx.provider, ctx.attrs)
+	addGRCEvidenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, riskURN, ctx.provider, ctx.attrs)
+	addGRCTargetReferenceLink(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, riskURN, ctx.provider, ctx.attrs, relationTargeted, "grc_risk_scenario")
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, riskURN, "grc_risk_category", firstAttribute(ctx.attrs, "risk_category", "category", "domain"))
+	addGRCAssetTagLinks(ctx.entities, ctx.links, ctx.tenantID, ctx.sourceID, ctx.event, riskURN, "grc_risk_level", firstAttribute(ctx.attrs, "residual_risk_level", "residual_risk", "inherent_risk_level", "inherent_risk", "risk_level"))
+	entities, links := ctx.done()
+	return entities, links, nil
 }
 
 func addGRCRiskOwnerEmailLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, contactURN string, owner string) {


### PR DESCRIPTION
## Summary
- Add policy document, risk-register, and document-work queue records to the policy lifecycle aggregate.
- Project policy documents and risk scenarios with owners, statuses, review dates, linked policies, controls, evidence, and related records.
- Extend the OpenAPI contract and policy lifecycle documentation for source onboarding.

## Validation
- `go test ./internal/grcpolicylifecycle ./internal/bootstrap ./internal/sourceprojection ./internal/grccatalog -count=1`
- `make openapi-check`
- `make openapi-lint`
- `make docs-drift-check`

Companion web PR: writer/cerebro-web#145.