### PR TITLE
[codex] Fix policy lifecycle export review items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ new-aws-collector: ## Wire an implemented AWS collector (FAMILY=foo_bar RECORD_T
 	@test -n "$(URN_EXPR)" || (echo "URN_EXPR is required" && exit 1)
 	go run ./tools/awscollectorgen --family="$(FAMILY)" --title="$(TITLE)" --label="$(LABEL)" --const-name="$(CONST_NAME)" --record-type="$(RECORD_TYPE)" --list-func="$(LIST_FUNC)" --event-func="$(EVENT_FUNC)" --urn-type="$(URN_TYPE)" --urn-expr="$(URN_EXPR)" --cursor-expr="$(CURSOR_EXPR)" --projector="$(PROJECTOR)" $(if $(DRY_RUN),--dry-run,)
 
-docs-autogen: openapi-sync proto-generate graph-action-generate policy-rule-generate control-index-generate detection-catalog-generate openapi-ts-generate ## Regenerate checked-in generated docs and catalogs.
+docs-autogen: openapi-sync proto-generate graph-action-generate policy-rule-generate policy-mapping-export control-index-generate detection-catalog-generate openapi-ts-generate ## Regenerate checked-in generated docs and catalogs.
 
 docs-drift-check: ## Check documentation drift rules.
 	python3 scripts/docs_drift_check.py

--- a/internal/bootstrap/grc_policy_lifecycle.go
+++ b/internal/bootstrap/grc_policy_lifecycle.go
@@ -126,30 +126,14 @@ func grcPolicyLifecycleExportWindowFromRequest(r *http.Request) (grcpolicylifecy
 	if r == nil || r.URL == nil {
 		return window, nil
 	}
-	start, err := grcPolicyLifecycleExportTime(r.URL.Query().Get("start"))
+	start, err := grcpolicylifecycle.ParseExportWindowTime(r.URL.Query().Get("start"), false)
 	if err != nil {
 		return window, fmt.Errorf("%w: invalid start", grcpolicylifecycle.ErrInvalidRequest)
 	}
-	end, err := grcPolicyLifecycleExportTime(r.URL.Query().Get("end"))
+	end, err := grcpolicylifecycle.ParseExportWindowTime(r.URL.Query().Get("end"), true)
 	if err != nil {
 		return window, fmt.Errorf("%w: invalid end", grcpolicylifecycle.ErrInvalidRequest)
 	}
-	window.Start = start
-	window.End = end
+	window.Start, window.End = start, end
 	return window, nil
-}
-
-func grcPolicyLifecycleExportTime(raw string) (*time.Time, error) {
-	value := strings.TrimSpace(raw)
-	if value == "" {
-		return nil, nil
-	}
-	for _, layout := range []string{time.RFC3339, "2006-01-02"} {
-		parsed, err := time.Parse(layout, value)
-		if err == nil {
-			utc := parsed.UTC()
-			return &utc, nil
-		}
-	}
-	return nil, fmt.Errorf("invalid time")
 }

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -193,6 +193,35 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	}
 }
 
+func TestGRCPolicyLifecycleExportWindowIncludesDateOnlyEndDay(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/grc/policy-lifecycle/export?start=2026-01-01&end=2026-01-15", nil)
+
+	window, err := grcPolicyLifecycleExportWindowFromRequest(request)
+	if err != nil {
+		t.Fatalf("grcPolicyLifecycleExportWindowFromRequest() error = %v", err)
+	}
+	if window.Start == nil || !window.Start.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("start = %v, want 2026-01-01 midnight UTC", window.Start)
+	}
+	wantEnd := time.Date(2026, 1, 15, 23, 59, 59, int(time.Second/time.Nanosecond)-1, time.UTC)
+	if window.End == nil || !window.End.Equal(wantEnd) {
+		t.Fatalf("end = %v, want %v", window.End, wantEnd)
+	}
+}
+
+func TestGRCPolicyLifecycleExportWindowKeepsTimestampEnd(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/grc/policy-lifecycle/export?end=2026-01-15T10:30:00Z", nil)
+
+	window, err := grcPolicyLifecycleExportWindowFromRequest(request)
+	if err != nil {
+		t.Fatalf("grcPolicyLifecycleExportWindowFromRequest() error = %v", err)
+	}
+	wantEnd := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	if window.End == nil || !window.End.Equal(wantEnd) {
+		t.Fatalf("end = %v, want %v", window.End, wantEnd)
+	}
+}
+
 func grcPolicyLifecycleTestNode(urn string, entityType string, label string, attrs map[string]string) ports.CypherRow {
 	rawAttrs, _ := json.Marshal(attrs)
 	return ports.CypherRow{Values: map[string]any{

--- a/internal/grcpolicylifecycle/actions.go
+++ b/internal/grcpolicylifecycle/actions.go
@@ -415,6 +415,26 @@ type ExportWindow struct {
 	End   *time.Time
 }
 
+func ParseExportWindowTime(raw string, endOfDay bool) (*time.Time, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil, nil
+	}
+	if parsed, err := time.Parse(time.RFC3339, value); err == nil {
+		utc := parsed.UTC()
+		return &utc, nil
+	}
+	parsed, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid time")
+	}
+	utc := parsed.UTC()
+	if endOfDay {
+		utc = utc.AddDate(0, 0, 1).Add(-time.Nanosecond)
+	}
+	return &utc, nil
+}
+
 func AuditExportHeader() []string {
 	return []string{
 		"record_type", "record_id", "policy_id", "policy_title", "version_id",


### PR DESCRIPTION
## Summary
- include the policy mapping CSV export in docs-autogen
- make date-only policy lifecycle export end filters include the full end date
- move export window parsing into the lifecycle package and keep bootstrap focused on request mapping
- add regression coverage for date-only and timestamp export windows

## Tests
- go test ./internal/bootstrap ./internal/grcpolicylifecycle -run 'TestGRCPolicyLifecycleExportWindow|TestGRCPolicyLifecycle|TestBuildActionEvent|TestLifecycleAggregate' -count=1\n- make check-arch\n- make policy-mapping-check\n- make docs-drift-check\n- git diff --check