### PR TITLE
fix: Harden policy lifecycle actions

### DIFF
--- a/internal/bootstrap/grc_policy_lifecycle.go
+++ b/internal/bootstrap/grc_policy_lifecycle.go
@@ -59,9 +59,7 @@ func (a *App) handleGRCPolicyLifecycleAction(w http.ResponseWriter, r *http.Requ
 	if strings.TrimSpace(request.RuntimeID) == "" {
 		request.RuntimeID = scope.RuntimeID
 	}
-	if strings.TrimSpace(request.ActorUserID) == "" {
-		request.ActorUserID = customDashboardActorID(r.Context())
-	}
+	request.ActorUserID = customDashboardActorID(r.Context())
 	if a.deps.AppendLog == nil {
 		writeGRCError(w, grcpolicylifecycle.ErrRuntimeUnavailable)
 		return
@@ -84,6 +82,7 @@ func (a *App) handleGRCPolicyLifecycleAction(w http.ResponseWriter, r *http.Requ
 		writeGRCError(w, fmt.Errorf("%w: project policy lifecycle event: %w", grcpolicylifecycle.ErrRuntimeUnavailable, err))
 		return
 	}
+	a.bumpGRCCacheVersions(r.Context(), request.TenantID, grcCacheScopeGraph)
 	writeJSON(w, http.StatusAccepted, response)
 }
 

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/fabriccontract"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/querycache"
 )
 
 func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
@@ -190,6 +192,80 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 		if !strings.Contains(request.Query, "$source_id") || !strings.Contains(request.Query, "$runtime_id") {
 			t.Fatalf("cypher query %q does not reference source and runtime filters", request.Query)
 		}
+	}
+}
+
+func TestGRCPolicyLifecycleActionUsesAuthenticatedActor(t *testing.T) {
+	cache := querycache.NewMemory(querycache.Options{Namespace: "test"})
+	appendLog := &failAfterAppendLog{failAfter: 10}
+	graph := &stubGraphStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  appendLog,
+		GraphStore: graph,
+		QueryCache: cache,
+	}, nil)
+	body := `{
+		"action":"review.complete",
+		"tenant_id":"writer",
+		"source_id":"grc",
+		"runtime_id":"writer-grc",
+		"policy_id":"access",
+		"record_id":"review-1",
+		"actor_user_id":"spoofed-user"
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/grc/policy-lifecycle/actions?tenant_id=writer&source_id=grc&runtime_id=writer-grc", strings.NewReader(body))
+	request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{Name: "authenticated-user", TenantID: "writer"},
+	}))
+	recorder := httptest.NewRecorder()
+
+	app.handleGRCPolicyLifecycleAction(recorder, request)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("POST /grc/policy-lifecycle/actions status = %d, want %d; body = %s", recorder.Code, http.StatusAccepted, recorder.Body.String())
+	}
+	if len(appendLog.events) != 1 {
+		t.Fatalf("append log events = %d, want 1", len(appendLog.events))
+	}
+	attrs := appendLog.events[0].GetAttributes()
+	if got := attrs["actor_user_id"]; got != "authenticated-user" {
+		t.Fatalf("actor_user_id = %q, want authenticated-user", got)
+	}
+	if got := attrs["created_by_user_id"]; got != "authenticated-user" {
+		t.Fatalf("created_by_user_id = %q, want authenticated-user", got)
+	}
+}
+
+func TestGRCPolicyLifecycleActionBumpsGraphCacheVersion(t *testing.T) {
+	cache := querycache.NewMemory(querycache.Options{Namespace: "test"})
+	appendLog := &failAfterAppendLog{failAfter: 10}
+	graph := &stubGraphStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  appendLog,
+		GraphStore: graph,
+		QueryCache: cache,
+	}, nil)
+	body := `{
+		"action":"review.complete",
+		"tenant_id":"writer",
+		"source_id":"grc",
+		"runtime_id":"writer-grc",
+		"policy_id":"access",
+		"record_id":"review-1"
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/grc/policy-lifecycle/actions?tenant_id=writer&source_id=grc&runtime_id=writer-grc", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	app.handleGRCPolicyLifecycleAction(recorder, request)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("POST /grc/policy-lifecycle/actions status = %d, want %d; body = %s", recorder.Code, http.StatusAccepted, recorder.Body.String())
+	}
+	if got, err := cache.Version(context.Background(), grcGlobalCacheVersionScope()); err != nil || got != "1" {
+		t.Fatalf("global cache version = %q, %v; want 1, nil", got, err)
+	}
+	if got, err := cache.Version(context.Background(), grcTenantCacheVersionScope("writer", grcCacheScopeGraph)); err != nil || got != "1" {
+		t.Fatalf("tenant graph cache version = %q, %v; want 1, nil", got, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Ignore caller-supplied `actor_user_id` for policy lifecycle actions and use the authenticated principal instead.
- Bump the tenant graph GRC cache after policy lifecycle action projection succeeds.
- Add regression coverage for actor spoofing and graph cache invalidation.

## Test Plan

- `go test ./internal/bootstrap ./internal/grcpolicylifecycle -count=1`
- `make test`
- `make lint`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Addresses remaining review feedback from #1508 after #1513.
- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->