### PR TITLE
fix: Align MCP claim verification coverage

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1740,6 +1740,7 @@ func (app *App) mcpAgentClaimVerify(r *http.Request, args map[string]any) (any, 
 	}
 	request.TenantID = resolved.TenantID
 	request.ActorID = resolved.ActorID
+	request.CoverageContext = app.agentCoverageContext(r.Context(), request.TenantID)
 	if err := authorizeMCPClaimVerificationURNs(r.Context(), request); err != nil {
 		return nil, err
 	}

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
 func TestMCPRequiresAuth(t *testing.T) {
@@ -2364,7 +2365,11 @@ func TestMCPAgentControlPlaneAndWorkContract(t *testing.T) {
 }
 
 func TestMCPAgentClaimVerifyDowngradesStalePartialClaim(t *testing.T) {
-	server := newMCPTestServerWithGraphReasoning(t, &stubRuntimeStore{}, &stubGraphStore{}, graphagent.NewStubLLMClient())
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	server := newMCPTestServerWithGraphReasoningAndSources(t, &stubRuntimeStore{}, &stubGraphStore{}, graphagent.NewStubLLMClient(), registry)
 	defer server.Close()
 
 	response, _ := postMCP(t, server, "", map[string]any{
@@ -2408,9 +2413,37 @@ func TestMCPAgentClaimVerifyDowngradesStalePartialClaim(t *testing.T) {
 		t.Fatalf("claim verification warnings = %#v, want stale/coverage warnings", warnings)
 	}
 
-	crossTenantMissingResponse, _ := postMCP(t, server, "", map[string]any{
+	serverCoverageResponse, _ := postMCP(t, server, "", map[string]any{
 		"jsonrpc": "2.0",
 		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.agent.claims.verify",
+			"arguments": map[string]any{
+				"claim":                    "Finding finding-1 is supported by current evidence.",
+				"scope_urn":                "urn:cerebro:writer:finding:finding-1",
+				"supporting_evidence_urns": []any{"urn:cerebro:writer:evidence:evidence-1"},
+				"freshness_state":          "fresh",
+				"requested_action_stage":   "recommend",
+			},
+		},
+	})
+	serverCoverageContent := serverCoverageResponse["result"].(map[string]any)["structuredContent"].(map[string]any)
+	serverCoverageVerifiers := serverCoverageContent["verifier_results"].([]any)
+	var coverageEvidence []any
+	for _, raw := range serverCoverageVerifiers {
+		verifier := raw.(map[string]any)
+		if verifier["id"] == "coverage" {
+			coverageEvidence, _ = verifier["evidence"].([]any)
+		}
+	}
+	if len(coverageEvidence) == 0 || coverageEvidence[0] != "writer" {
+		t.Fatalf("coverage verifier = %#v, want server-computed tenant evidence", serverCoverageVerifiers)
+	}
+
+	crossTenantMissingResponse, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
 		"method":  "tools/call",
 		"params": map[string]any{
 			"name": "cerebro.agent.claims.verify",
@@ -2430,7 +2463,7 @@ func TestMCPAgentClaimVerifyDowngradesStalePartialClaim(t *testing.T) {
 
 	overrideResponse, _ := postMCP(t, server, "", map[string]any{
 		"jsonrpc": "2.0",
-		"id":      3,
+		"id":      4,
 		"method":  "tools/call",
 		"params": map[string]any{
 			"name": "cerebro.agent.claims.verify",
@@ -2694,6 +2727,11 @@ func newMCPTestServerWithGraph(t *testing.T, store *stubRuntimeStore, graph *stu
 
 func newMCPTestServerWithGraphReasoning(t *testing.T, store *stubRuntimeStore, graph *stubGraphStore, llm graphagent.LLMClient) *httptest.Server {
 	t.Helper()
+	return newMCPTestServerWithGraphReasoningAndSources(t, store, graph, llm, nil)
+}
+
+func newMCPTestServerWithGraphReasoningAndSources(t *testing.T, store *stubRuntimeStore, graph *stubGraphStore, llm graphagent.LLMClient, sources *sourcecdk.Registry) *httptest.Server {
+	t.Helper()
 	app := New(config.Config{
 		HTTPAddr:        "127.0.0.1:0",
 		ShutdownTimeout: time.Second,
@@ -2705,7 +2743,7 @@ func newMCPTestServerWithGraphReasoning(t *testing.T, store *stubRuntimeStore, g
 				TenantID:  "writer",
 			}},
 		},
-	}, Dependencies{StateStore: store, GraphStore: graph, GraphAgentLLM: llm}, nil)
+	}, Dependencies{StateStore: store, GraphStore: graph, GraphAgentLLM: llm}, sources)
 	return httptest.NewServer(app.Handler())
 }
 

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -65,7 +65,7 @@ import (
 // policy lifecycle adds route/scope/error mapping plus action and CSV export
 // adapters; graph aggregation, action event construction, audit row shaping,
 // and response shaping live in internal/grcpolicylifecycle.
-const bootstrapProductionGoLineBudget = 26424
+const bootstrapProductionGoLineBudget = 26425
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary

- Align MCP claim verification with HTTP by server-computing coverage context at the authenticated boundary.
- Add regression coverage proving MCP verifier results include server-derived coverage evidence.
- Update the bootstrap surface budget for the one-line transport mapping increase.

## Test Plan

- `go test ./internal/bootstrap -run 'TestMCPAgentClaimVerify' -count=1`
- `make check-structural`
- `make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on MCP claim verification coverage parity and the bootstrap budget update.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->