### PR TITLE
Position Cerebro as agent compliance context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,39 @@
 # Cerebro
 
-**Operations data platform for cloud, SaaS, identity, workflow, finding, compliance, and graph signals.**
+**Compliance superpowers for coding agents.**
 
 [![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-Cerebro ingests operational and security signals, turns them into source runtime events, claims, findings, reports, workflow events, compliance evidence, and graph context, then exposes that substrate through a Go CLI, JSON HTTP, Connect RPC, SDK helpers, and MCP.
+Cerebro turns security, identity, cloud, SaaS, workflow, policy, and compliance signals into evidence-backed context that coding agents can query through a Go CLI, JSON HTTP, Connect RPC, SDK helpers, and MCP.
+
+Use it to help agents answer:
+
+- Can this change ship?
+- Which controls, policies, findings, or approvals apply?
+- What evidence already exists?
+- What remediation or next action is safe to propose?
+- Which systems, identities, and risks are connected?
+
+## Give Your Coding Agent Compliance Context
+
+The fastest path is to run the local onboarding flow, then hand the receipt to your agent:
+
+```bash
+make secure-business-demo
+```
+
+```text
+Use Cerebro as compliance context for this change.
+Read tmp/onboarding/e2e-receipt.json, then tell me which checks passed,
+which evidence exists, which controls apply, and what must happen before
+this can ship.
+
+Do not commit provider credentials, customer names, tenant-specific hostnames,
+account IDs, or live secret values.
+```
+
+For a live agent integration, connect your MCP client to `POST /api/v1/mcp` and expose Cerebro as the source for policy memory, compliance evidence, graph context, and safe action planning. See [Agent onboarding](docs/start/agent-onboarding.md), [MCP native Droid setup](docs/domains/mcp-droid-setup.md), and [Agent platform contract](docs/domains/agent-platform-contract.md).
 
 ## Start Here
 
@@ -42,7 +70,7 @@ docker compose up --build
 - A Go bootstrap service built around `net/http`, Connect RPC, and `cmd/cerebro`.
 - Built-in source integrations for cloud, SaaS, identity, endpoint, vulnerability, compliance, and workflow signals.
 - Source runtime sync, append-log replay, claim/finding/report workflows, compliance control coverage, and optional graph projection, query, and action tooling.
-- Optional MCP, graph-agent, and device-authenticated telemetry surfaces.
+- Optional MCP, graph-agent, and device-authenticated telemetry surfaces for agent-readable evidence and control context.
 - Policy and FindingRule YAML DSL catalogs, generated detection catalogs, SDK helpers, OpenAPI/Connect contracts, release artifacts, and local validation tooling.
 
 ## Choose A Path

--- a/docs/engineering/non-goals.md
+++ b/docs/engineering/non-goals.md
@@ -202,7 +202,7 @@ Each section lists what Cerebro will not do, why that boundary exists, where in 
   - It does not own response automation as its primary product surface; runtime response is a constrained subsystem with explicit gates, not a SOAR.
   - It does not author cloud posture from Cerebro's own scanners as the source of truth; cloud posture findings come from typed sources whose budgets are explicit.
 - Why: Cerebro's value is the typed substrate (events, claims, evidence, decisions, workflows, the read graph, and the safety boundary). Promising a replacement promise would force the codebase to take on operational scope that is incompatible with that substrate.
-- Enforced in: [`README.md`](../../README.md) "Operations data platform" and the current route surface in [`docs/reference/api-reference.md`](../reference/api-reference.md).
+- Enforced in: [`README.md`](../../README.md) "Runtime Boundaries" and the current route surface in [`docs/reference/api-reference.md`](../reference/api-reference.md).
 - What would change this: nothing in this repo. Category-shaped products belong on top of Cerebro, not inside it.
 
 ## Operational And Distribution
@@ -211,7 +211,7 @@ Each section lists what Cerebro will not do, why that boundary exists, where in 
 
 - The repo exposes JSON HTTP, Connect RPC, and CLI surfaces. It will not host an end-user web console, a dashboarding UI, an investigation workbench, or a chat surface.
 - Why: a console is a separate product with separate distribution, accessibility, and security constraints. Pulling it into the bootstrap repo would couple every release of either to the other.
-- Enforced in: cmd/cerebro entrypoints and the documented HTTP route surface in [`README.md`](../../README.md) "HTTP and Connect API surface".
+- Enforced in: cmd/cerebro entrypoints and the documented CLI, JSON HTTP, Connect RPC, SDK, and MCP surfaces in [`README.md`](../../README.md).
 - What would change this: nothing. Console-shaped products consume Cerebro through its typed APIs from a separate repository.
 
 ### Cerebro does not host or proxy LLM providers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Cerebro Documentation
 
-Cerebro is an operations data platform for cloud, SaaS, identity, workflow, finding, compliance, and graph signals.
+Cerebro gives coding agents compliance superpowers.
 
-The current `main` branch is centered on a Go bootstrap service with JSON HTTP and Connect APIs, built-in source integrations, source runtime sync, finding and report workflows, compliance-control coverage, append-log replay, MCP access, device-authenticated telemetry, and optional graph projection/query tooling.
+The current `main` branch is centered on a Go bootstrap service that turns security, identity, cloud, SaaS, workflow, policy, and compliance signals into evidence-backed context. Agents and operators can query that context through JSON HTTP, Connect APIs, CLI workflows, SDK helpers, MCP access, and optional graph projection/query tooling.
 
 ## Mental Model
 
@@ -43,6 +43,23 @@ For a durable local stack:
 ```bash
 docker compose up --build
 ```
+
+## Agent Compliance Quickstart
+
+Run the local onboarding flow, then give the receipt to your coding agent:
+
+```bash
+make secure-business-demo
+```
+
+```text
+Use Cerebro as compliance context for this change.
+Read tmp/onboarding/e2e-receipt.json, then tell me which checks passed,
+which evidence exists, which controls apply, and what must happen before
+this can ship.
+```
+
+For live integrations, connect an MCP client to `POST /api/v1/mcp` so agents can query policy memory, compliance evidence, graph context, and safe action-planning contracts.
 
 ## Main Docs
 

--- a/docs/start/agent-onboarding.md
+++ b/docs/start/agent-onboarding.md
@@ -1,6 +1,8 @@
 # Agent Onboarding
 
-Use this when someone wants a coding agent to set up Cerebro, prove the basic security path works, and return a receipt.
+Use this when someone wants to give a coding agent compliance superpowers with Cerebro.
+
+The flow sets up local Cerebro context, proves the basic security and compliance path works, and returns a receipt the agent can use before it reviews, changes, or ships code.
 
 The first run does not need provider credentials. It starts Cerebro locally, creates a demo runtime, writes two posture claims, checks graph ingest, checks compliance coverage, and saves a receipt.
 
@@ -28,7 +30,7 @@ The receipt answers the first operator questions:
 ## Copy This Prompt
 
 ```text
-I want to use Cerebro to secure my business.
+I want to use Cerebro as compliance context for my coding agent.
 
 Start with the local demo:
 make secure-business-demo
@@ -37,10 +39,12 @@ Then read tmp/onboarding/e2e-receipt.json.
 
 Tell me:
 - receipt status
+- whether this Cerebro setup is ready to answer ship/no-ship questions
 - source runtime ids
+- available compliance evidence and control coverage
 - failed checks, if any
 - required secret names
-- next actions before I connect real business systems
+- next actions before I connect real business systems or ask the agent to review a real PR
 
 Do not commit provider credentials, customer names, tenant-specific hostnames, account IDs, or live secret values.
 Use env: references for every secret-bearing value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Cerebro
-site_description: Operations data platform for cloud, SaaS, identity, workflow, finding, compliance, and graph signals.
+site_description: Compliance superpowers for coding agents.
 repo_url: https://github.com/writer/cerebro
 theme:
   name: mkdocs
@@ -12,6 +12,7 @@ nav:
   - Start:
       - Quick Reference: start/quick-reference.md
       - Getting Started: start/getting-started.md
+      - Agent Onboarding: start/agent-onboarding.md
   - Reference:
       - Architecture: reference/architecture.md
       - CLI Reference: reference/cli.md


### PR DESCRIPTION
## Summary
- Reframe README and docs metadata around coding-agent compliance context
- Add a README and docs quickstart for handing Cerebro receipts to agents
- Surface agent onboarding in the docs navigation and refresh related boundary references

## Validation
- make readme-check docs-drift-check oss-audit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->