### PR TITLE
[codex] Add connector catalog maintenance review

### DIFF
--- a/.github/workflows/connector-catalog-maintenance.yml
+++ b/.github/workflows/connector-catalog-maintenance.yml
@@ -1,0 +1,70 @@
+name: Connector Catalog Maintenance
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/connector-catalog-maintenance.yml"
+      - "Makefile"
+      - "internal/connectorcatalog/**"
+      - "internal/connectordefinitions/**"
+      - "internal/sourcegen/**"
+      - "tools/catalogcheck/**"
+      - "tools/connectorcatalogreview/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/connector-catalog-maintenance.yml"
+      - "Makefile"
+      - "internal/connectorcatalog/**"
+      - "internal/connectordefinitions/**"
+      - "internal/sourcegen/**"
+      - "tools/catalogcheck/**"
+      - "tools/connectorcatalogreview/**"
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: connector-catalog-maintenance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  maintenance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run connector catalog maintenance
+        run: make connector-catalog-maintenance
+
+      - name: Publish report summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f tmp/connector-catalog-review.md ]; then
+            cat tmp/connector-catalog-review.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Connector catalog review report was not generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload review artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: connector-catalog-review
+          path: |
+            tmp/connector-catalog-review.md
+            tmp/connector-catalog-review.json
+          if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-catalog-review connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -78,6 +78,9 @@ DROID_SAST_OUT ?= tmp/droid-sast-context.md
 DROID_SAST_JSON_OUT ?= tmp/droid-sast-context.json
 DROID_CI_OUT ?= tmp/droid-ci-context.md
 DROID_CI_JSON_OUT ?= tmp/droid-ci-context.json
+CONNECTOR_CATALOG_REVIEW_MD ?= tmp/connector-catalog-review.md
+CONNECTOR_CATALOG_REVIEW_JSON ?= tmp/connector-catalog-review.json
+CONNECTOR_CATALOG_REVIEW_MAX_ITEMS ?= 80
 DROID_CONTEXT_OUT ?= tmp/droid-review-context.md
 DROID_CONTEXT_JSON_OUT ?= tmp/droid-review-context.json
 DROID_POST_MERGE_OUT ?= tmp/droid-post-merge-health.md
@@ -278,6 +281,11 @@ control-index-check: ## Verify compliance control coverage index is current.
 
 sourcegen-check: ## Verify connector definitions remain sourcegen-ready.
 	go run ./tools/catalogcheck -require-sourcegen-ready -summary=true
+
+connector-catalog-review: ## Generate connector catalog cleanup, promotion, and Q&A review artifacts.
+	go run ./tools/connectorcatalogreview -markdown-out "$(CONNECTOR_CATALOG_REVIEW_MD)" -json-out "$(CONNECTOR_CATALOG_REVIEW_JSON)" -max-items "$(CONNECTOR_CATALOG_REVIEW_MAX_ITEMS)"
+
+connector-catalog-maintenance: catalog-check sourcegen-check connector-catalog-review ## Validate connector catalog state and publish maintenance review artifacts.
 
 connector-contract-check: ## Validate declarative connector evidence, fixtures, and security lint.
 	go run ./tools/connectorcontractcheck

--- a/internal/connectorcatalog/catalog/README.md
+++ b/internal/connectorcatalog/catalog/README.md
@@ -32,6 +32,25 @@ as supported. Use `make sourcegen-check` when the change should prove that every
 built-in connector definition remains sourcegen-ready. The checker prints the
 catalog status summary that should be used in PR notes.
 
+Use `make connector-catalog-maintenance` before promoting or cleaning catalog
+entries. It runs the catalog proof gates and writes:
+
+- `tmp/connector-catalog-review.md`
+- `tmp/connector-catalog-review.json`
+
+The report is the review queue for this catalog. It lists sourcegen promotion
+candidates, graph projection coverage, cleanup findings such as duplicate
+provider roots, and review Q&A for each source. Treat cleanup findings as
+actionable before adding another broad connector wave. Treat Q&A as the
+operator checklist for creation and usage: graph targets, coverage value,
+auth scope, and promotion state should be answerable from the catalog entry or
+the linked Source CDK runtime.
+
+The repository also runs connector catalog maintenance on catalog PRs, on
+`main`, and every six hours. The scheduled job publishes the Markdown and JSON
+review artifacts so catalog drift, promotion backlog, and cleanup candidates
+stay visible even when no connector PR is open.
+
 Generateable entries can be promoted one integration at a time from the catalog:
 
 ```sh

--- a/internal/connectorcatalog/review.go
+++ b/internal/connectorcatalog/review.go
@@ -1,0 +1,531 @@
+package connectorcatalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/writer/cerebro/internal/connectordefinitions"
+)
+
+// ReviewReport is the repository-level maintenance view for the connector
+// catalog. It turns validation output into promotion queues, cleanup actions,
+// and review questions that can be published by CI without mutating catalog
+// files.
+type ReviewReport struct {
+	Summary            ReviewSummary        `json:"summary"`
+	PromotionQueues    []PromotionQueue     `json:"promotion_queues,omitempty"`
+	CleanupFindings    []ReviewFinding      `json:"cleanup_findings,omitempty"`
+	Questions          []ReviewQuestion     `json:"questions,omitempty"`
+	SourceReviews      []SourceReview       `json:"source_reviews,omitempty"`
+	ProjectionCoverage []ProjectionCoverage `json:"projection_coverage,omitempty"`
+}
+
+type ReviewSummary struct {
+	Total                    int            `json:"total"`
+	Generateable             int            `json:"generateable"`
+	CatalogReady             int            `json:"catalog_ready"`
+	NeedsAuthExtension       int            `json:"needs_auth_extension"`
+	NeedsBespokeRuntime      int            `json:"needs_bespoke_runtime"`
+	ResourceFamilies         int            `json:"resource_families"`
+	ProjectedFamilies        int            `json:"projected_families"`
+	HighValueFamilies        int            `json:"high_value_families"`
+	CoverageDimensions       int            `json:"coverage_dimensions"`
+	ProjectionTemplates      int            `json:"projection_templates"`
+	SourcesWithProjection    int            `json:"sources_with_projection"`
+	SourcesWithProjectionGap int            `json:"sources_with_projection_gap"`
+	CleanupFindings          int            `json:"cleanup_findings"`
+	Questions                int            `json:"questions"`
+	ByStatus                 map[string]int `json:"by_status,omitempty"`
+	ByProjectionTemplate     map[string]int `json:"by_projection_template,omitempty"`
+}
+
+type PromotionQueue struct {
+	ID      string               `json:"id"`
+	Label   string               `json:"label"`
+	Count   int                  `json:"count"`
+	Entries []PromotionCandidate `json:"entries,omitempty"`
+}
+
+type PromotionCandidate struct {
+	SourceID    string `json:"source_id"`
+	DisplayName string `json:"display_name,omitempty"`
+	Path        string `json:"path,omitempty"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	NextAction  string `json:"next_action"`
+}
+
+type ReviewFinding struct {
+	Level      string `json:"level"`
+	SourceID   string `json:"source_id,omitempty"`
+	Path       string `json:"path,omitempty"`
+	Category   string `json:"category"`
+	Message    string `json:"message"`
+	NextAction string `json:"next_action"`
+}
+
+type ReviewQuestion struct {
+	ID         string `json:"id"`
+	SourceID   string `json:"source_id,omitempty"`
+	Path       string `json:"path,omitempty"`
+	Category   string `json:"category"`
+	Question   string `json:"question"`
+	Answer     string `json:"answer"`
+	NextAction string `json:"next_action"`
+}
+
+type SourceReview struct {
+	SourceID              string   `json:"source_id"`
+	DisplayName           string   `json:"display_name,omitempty"`
+	Path                  string   `json:"path,omitempty"`
+	Status                string   `json:"status"`
+	ClassifierOutput      string   `json:"classifier_output,omitempty"`
+	ResourceFamilies      int      `json:"resource_families"`
+	ProjectedFamilies     int      `json:"projected_families"`
+	HighValueFamilies     int      `json:"high_value_families"`
+	CoverageDimensions    int      `json:"coverage_dimensions"`
+	ProjectionTemplates   []string `json:"projection_templates,omitempty"`
+	PromotionQueue        string   `json:"promotion_queue,omitempty"`
+	NextAction            string   `json:"next_action,omitempty"`
+	ReviewQuestionCount   int      `json:"review_question_count"`
+	CleanupFindingCount   int      `json:"cleanup_finding_count"`
+	SourcegenDryRun       bool     `json:"sourcegen_dry_run,omitempty"`
+	SourcegenError        string   `json:"sourcegen_error,omitempty"`
+	VerificationPath      string   `json:"verification_path,omitempty"`
+	ResourceFamilyIDs     []string `json:"resource_family_ids,omitempty"`
+	ProjectionGapFamilies []string `json:"projection_gap_families,omitempty"`
+}
+
+type ProjectionCoverage struct {
+	Template string `json:"template"`
+	Sources  int    `json:"sources"`
+	Families int    `json:"families"`
+}
+
+// ReviewAnalysis builds a deterministic maintenance report from a catalog
+// analysis. It does not re-read files or run source generation.
+func ReviewAnalysis(analysis Analysis) ReviewReport {
+	review := ReviewReport{
+		Summary: ReviewSummary{
+			ByStatus:             map[string]int{},
+			ByProjectionTemplate: map[string]int{},
+		},
+	}
+	sourceIDs := map[string]Entry{}
+	displayNames := map[string][]Entry{}
+	templateSources := map[string]map[string]struct{}{}
+	queueEntries := map[string][]PromotionCandidate{}
+	findingsBySource := map[string]int{}
+	questionsBySource := map[string]int{}
+
+	for _, entry := range analysis.Entries {
+		sourceID := strings.TrimSpace(entry.Definition.SourceID)
+		if sourceID != "" {
+			sourceIDs[sourceID] = entry
+		}
+		if key := normalizedDisplayName(entry.Definition.DisplayName); key != "" {
+			displayNames[key] = append(displayNames[key], entry)
+		}
+
+		sourceReview := buildSourceReview(entry)
+		review.SourceReviews = append(review.SourceReviews, sourceReview)
+		review.Summary.Total++
+		review.Summary.ResourceFamilies += sourceReview.ResourceFamilies
+		review.Summary.ProjectedFamilies += sourceReview.ProjectedFamilies
+		review.Summary.HighValueFamilies += sourceReview.HighValueFamilies
+		review.Summary.CoverageDimensions += sourceReview.CoverageDimensions
+		review.Summary.ByStatus[entry.Status]++
+		if sourceReview.ProjectedFamilies > 0 {
+			review.Summary.SourcesWithProjection++
+		}
+		if len(sourceReview.ProjectionGapFamilies) > 0 {
+			review.Summary.SourcesWithProjectionGap++
+		}
+		for _, template := range sourceReview.ProjectionTemplates {
+			review.Summary.ByProjectionTemplate[template] += countTemplateFamilies(entry, template)
+			if templateSources[template] == nil {
+				templateSources[template] = map[string]struct{}{}
+			}
+			templateSources[template][sourceID] = struct{}{}
+		}
+
+		queueID, candidate := promotionCandidate(entry)
+		if queueID != "" {
+			queueEntries[queueID] = append(queueEntries[queueID], candidate)
+		}
+		for _, question := range sourceQuestions(sourceReview, entry) {
+			review.Questions = append(review.Questions, question)
+			questionsBySource[question.SourceID]++
+		}
+	}
+
+	review.CleanupFindings = append(review.CleanupFindings, duplicateRootFindings(sourceIDs)...)
+	review.CleanupFindings = append(review.CleanupFindings, duplicateDisplayNameFindings(displayNames)...)
+	for _, finding := range review.CleanupFindings {
+		findingsBySource[finding.SourceID]++
+		review.Questions = append(review.Questions, cleanupQuestion(finding))
+		questionsBySource[finding.SourceID]++
+	}
+	for i := range review.SourceReviews {
+		sourceID := review.SourceReviews[i].SourceID
+		review.SourceReviews[i].CleanupFindingCount = findingsBySource[sourceID]
+		review.SourceReviews[i].ReviewQuestionCount = questionsBySource[sourceID]
+	}
+
+	review.PromotionQueues = promotionQueues(queueEntries)
+	review.ProjectionCoverage = projectionCoverage(review.Summary.ByProjectionTemplate, templateSources)
+	review.Summary.ProjectionTemplates = len(review.Summary.ByProjectionTemplate)
+	review.Summary.CleanupFindings = len(review.CleanupFindings)
+	review.Summary.Questions = len(review.Questions)
+	review.Summary.Generateable = analysis.Summary.Generateable
+	review.Summary.CatalogReady = analysis.Summary.CatalogReady
+	review.Summary.NeedsAuthExtension = analysis.Summary.NeedsAuthExtension
+	review.Summary.NeedsBespokeRuntime = analysis.Summary.NeedsBespokeRuntime
+	sortReview(&review)
+	return review
+}
+
+func buildSourceReview(entry Entry) SourceReview {
+	review := SourceReview{
+		SourceID:          entry.Definition.SourceID,
+		DisplayName:       entry.Definition.DisplayName,
+		Path:              entry.Path,
+		Status:            entry.Status,
+		ClassifierOutput:  entry.ClassifierOutput,
+		SourcegenDryRun:   entry.SourcegenDryRun,
+		SourcegenError:    entry.SourcegenError,
+		VerificationPath:  entry.VerificationPath,
+		ResourceFamilyIDs: append([]string(nil), entry.ResourceFamilyIDs...),
+	}
+	templates := map[string]struct{}{}
+	for _, family := range entry.Definition.ResourceFamilies {
+		review.ResourceFamilies++
+		if family.Projection != nil && strings.TrimSpace(family.Projection.Template) != "" {
+			review.ProjectedFamilies++
+			templates[strings.TrimSpace(family.Projection.Template)] = struct{}{}
+		} else if strings.TrimSpace(family.ID) != "" {
+			review.ProjectionGapFamilies = append(review.ProjectionGapFamilies, family.ID)
+		}
+		if familyHasHighValueCoverage(family) {
+			review.HighValueFamilies++
+		}
+		review.CoverageDimensions += len(family.Coverage)
+	}
+	for template := range templates {
+		review.ProjectionTemplates = append(review.ProjectionTemplates, template)
+	}
+	sort.Strings(review.ProjectionTemplates)
+	sort.Strings(review.ProjectionGapFamilies)
+	review.PromotionQueue, review.NextAction = promotionQueueAndAction(entry)
+	return review
+}
+
+func sourceQuestions(source SourceReview, entry Entry) []ReviewQuestion {
+	var questions []ReviewQuestion
+	if source.ResourceFamilies > 0 {
+		questions = append(questions, ReviewQuestion{
+			ID:         questionID(source.SourceID, "graph_projection"),
+			SourceID:   source.SourceID,
+			Path:       source.Path,
+			Category:   "graph_projection",
+			Question:   fmt.Sprintf("Do %s resource families project into the graph items operators use?", displayName(source)),
+			Answer:     fmt.Sprintf("%d of %d families project through %s.", source.ProjectedFamilies, source.ResourceFamilies, listOrNone(source.ProjectionTemplates)),
+			NextAction: "Open the source detail data view after activation and confirm the projected graph items match the intended evidence and inventory use cases.",
+		})
+	}
+	if len(source.ProjectionGapFamilies) > 0 {
+		questions = append(questions, ReviewQuestion{
+			ID:         questionID(source.SourceID, "projection_gap"),
+			SourceID:   source.SourceID,
+			Path:       source.Path,
+			Category:   "projection_gap",
+			Question:   "Which collected families should stay collection-only, and which need graph templates?",
+			Answer:     "Families without graph templates: " + strings.Join(source.ProjectionGapFamilies, ", ") + ".",
+			NextAction: "Add projection templates for graph-worthy families or mark the family as intentionally collection-only in the source review notes.",
+		})
+	}
+	if source.HighValueFamilies == 0 {
+		questions = append(questions, ReviewQuestion{
+			ID:         questionID(source.SourceID, "coverage_value"),
+			SourceID:   source.SourceID,
+			Path:       source.Path,
+			Category:   "coverage_value",
+			Question:   "Which collected family carries the highest evidence value?",
+			Answer:     "No resource family has high-value coverage in the catalog entry.",
+			NextAction: "Mark the primary evidence or inventory family as high value and include evidence types plus control domains.",
+		})
+	}
+	if source.CoverageDimensions < source.ResourceFamilies {
+		questions = append(questions, ReviewQuestion{
+			ID:         questionID(source.SourceID, "coverage_depth"),
+			SourceID:   source.SourceID,
+			Path:       source.Path,
+			Category:   "coverage_depth",
+			Question:   "Does every collected family explain why it matters?",
+			Answer:     fmt.Sprintf("%d coverage dimensions are declared for %d families.", source.CoverageDimensions, source.ResourceFamilies),
+			NextAction: "Add coverage dimensions for each family that should appear in evidence, inventory, access, or finding workflows.",
+		})
+	}
+	if strings.HasPrefix(entry.Definition.Auth.Model, "oauth_") && len(entry.Definition.Auth.Scopes) == 0 {
+		questions = append(questions, ReviewQuestion{
+			ID:         questionID(source.SourceID, "oauth_scope"),
+			SourceID:   source.SourceID,
+			Path:       source.Path,
+			Category:   "auth_scope",
+			Question:   "Which OAuth scopes are required for read-only collection?",
+			Answer:     "The auth model is " + entry.Definition.Auth.Model + " and the catalog entry does not list scopes.",
+			NextAction: "Declare the narrow read scopes required for setup, or document why scopes are tenant-specific.",
+		})
+	}
+	if source.PromotionQueue != "" {
+		questions = append(questions, ReviewQuestion{
+			ID:         questionID(source.SourceID, "promotion"),
+			SourceID:   source.SourceID,
+			Path:       source.Path,
+			Category:   "promotion",
+			Question:   "What is the next promotion step for this source?",
+			Answer:     source.NextAction,
+			NextAction: source.NextAction,
+		})
+	}
+	return questions
+}
+
+func familyHasHighValueCoverage(family connectordefinitions.ResourceFamily) bool {
+	for _, dimension := range family.Coverage {
+		if dimension.HighValue {
+			return true
+		}
+	}
+	return false
+}
+
+func countTemplateFamilies(entry Entry, template string) int {
+	count := 0
+	for _, family := range entry.Definition.ResourceFamilies {
+		if family.Projection != nil && strings.TrimSpace(family.Projection.Template) == template {
+			count++
+		}
+	}
+	return count
+}
+
+func promotionCandidate(entry Entry) (string, PromotionCandidate) {
+	queueID, nextAction := promotionQueueAndAction(entry)
+	if queueID == "" {
+		return "", PromotionCandidate{}
+	}
+	return queueID, PromotionCandidate{
+		SourceID:    entry.Definition.SourceID,
+		DisplayName: entry.Definition.DisplayName,
+		Path:        entry.Path,
+		Status:      entry.Status,
+		Reason:      promotionReason(entry),
+		NextAction:  nextAction,
+	}
+}
+
+func promotionQueueAndAction(entry Entry) (string, string) {
+	switch entry.Status {
+	case StatusGenerateable:
+		return "sourcegen_ready", "Generate the runtime package, add source package fixtures, then enable setup when runtime validation passes."
+	case StatusNeedsAuthExtension:
+		return "auth_extension", "Add or select the auth adapter required by this provider, then rerun sourcegen and catalog checks."
+	case StatusNeedsBespokeRuntime:
+		return "bespoke_runtime", "Plan a bespoke runtime or trim unsupported transport and projection features before promotion."
+	case StatusCatalogReady:
+		return "catalog_ready", "Keep the catalog entry reviewed and promote after sourcegen support is available."
+	default:
+		return "review", "Review classifier status and decide whether this source belongs in the catalog."
+	}
+}
+
+func promotionReason(entry Entry) string {
+	if entry.SourcegenError != "" {
+		return entry.SourcegenError
+	}
+	switch entry.Status {
+	case StatusGenerateable:
+		return "Sourcegen dry run passed."
+	case StatusNeedsAuthExtension:
+		return "Classifier or sourcegen requires auth support before runtime generation."
+	case StatusNeedsBespokeRuntime:
+		return "Transport, pagination, projection, or runtime behavior exceeds the generic engine."
+	default:
+		return "Cataloged but not yet runtime-promoted."
+	}
+}
+
+func promotionQueues(entries map[string][]PromotionCandidate) []PromotionQueue {
+	labels := map[string]string{
+		"sourcegen_ready": "Sourcegen ready",
+		"auth_extension":  "Needs auth extension",
+		"bespoke_runtime": "Needs bespoke runtime",
+		"catalog_ready":   "Catalog ready",
+		"review":          "Needs review",
+	}
+	order := []string{"sourcegen_ready", "auth_extension", "bespoke_runtime", "catalog_ready", "review"}
+	queues := make([]PromotionQueue, 0, len(entries))
+	for _, id := range order {
+		candidates := entries[id]
+		if len(candidates) == 0 {
+			continue
+		}
+		sort.SliceStable(candidates, func(i int, j int) bool {
+			return candidates[i].SourceID < candidates[j].SourceID
+		})
+		queues = append(queues, PromotionQueue{
+			ID:      id,
+			Label:   labels[id],
+			Count:   len(candidates),
+			Entries: candidates,
+		})
+	}
+	return queues
+}
+
+func duplicateRootFindings(sourceIDs map[string]Entry) []ReviewFinding {
+	var findings []ReviewFinding
+	for sourceID, entry := range sourceIDs {
+		root, ok := sourceIDSuffixRoot(sourceID)
+		if !ok {
+			continue
+		}
+		if _, exists := sourceIDs[root]; !exists {
+			continue
+		}
+		findings = append(findings, ReviewFinding{
+			Level:      "action",
+			SourceID:   sourceID,
+			Path:       entry.Path,
+			Category:   "source_id_cleanup",
+			Message:    fmt.Sprintf("source_id %q shares provider root %q with an existing connector", sourceID, root),
+			NextAction: "Consolidate under the existing provider connector unless this file represents a distinct product surface with separate auth and data ownership.",
+		})
+	}
+	return findings
+}
+
+func duplicateDisplayNameFindings(displayNames map[string][]Entry) []ReviewFinding {
+	var findings []ReviewFinding
+	for _, entries := range displayNames {
+		if len(entries) < 2 {
+			continue
+		}
+		sort.SliceStable(entries, func(i int, j int) bool {
+			return entries[i].Definition.SourceID < entries[j].Definition.SourceID
+		})
+		ids := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			ids = append(ids, entry.Definition.SourceID)
+		}
+		for _, entry := range entries {
+			findings = append(findings, ReviewFinding{
+				Level:      "question",
+				SourceID:   entry.Definition.SourceID,
+				Path:       entry.Path,
+				Category:   "display_name_cleanup",
+				Message:    fmt.Sprintf("display name %q is shared by source IDs: %s", entry.Definition.DisplayName, strings.Join(ids, ", ")),
+				NextAction: "Confirm these are distinct products. Rename variants or consolidate duplicate catalog entries.",
+			})
+		}
+	}
+	return findings
+}
+
+func cleanupQuestion(finding ReviewFinding) ReviewQuestion {
+	return ReviewQuestion{
+		ID:         questionID(finding.SourceID, finding.Category),
+		SourceID:   finding.SourceID,
+		Path:       finding.Path,
+		Category:   finding.Category,
+		Question:   "Should this catalog entry remain separate?",
+		Answer:     finding.Message,
+		NextAction: finding.NextAction,
+	}
+}
+
+func projectionCoverage(familyCounts map[string]int, sources map[string]map[string]struct{}) []ProjectionCoverage {
+	coverage := make([]ProjectionCoverage, 0, len(familyCounts))
+	for template, families := range familyCounts {
+		coverage = append(coverage, ProjectionCoverage{
+			Template: template,
+			Sources:  len(sources[template]),
+			Families: families,
+		})
+	}
+	sort.SliceStable(coverage, func(i int, j int) bool {
+		if coverage[i].Families != coverage[j].Families {
+			return coverage[i].Families > coverage[j].Families
+		}
+		return coverage[i].Template < coverage[j].Template
+	})
+	return coverage
+}
+
+func sortReview(review *ReviewReport) {
+	sort.SliceStable(review.CleanupFindings, func(i int, j int) bool {
+		if review.CleanupFindings[i].SourceID != review.CleanupFindings[j].SourceID {
+			return review.CleanupFindings[i].SourceID < review.CleanupFindings[j].SourceID
+		}
+		return review.CleanupFindings[i].Category < review.CleanupFindings[j].Category
+	})
+	sort.SliceStable(review.Questions, func(i int, j int) bool {
+		if review.Questions[i].SourceID != review.Questions[j].SourceID {
+			return review.Questions[i].SourceID < review.Questions[j].SourceID
+		}
+		if review.Questions[i].Category != review.Questions[j].Category {
+			return review.Questions[i].Category < review.Questions[j].Category
+		}
+		return review.Questions[i].ID < review.Questions[j].ID
+	})
+	sort.SliceStable(review.SourceReviews, func(i int, j int) bool {
+		if review.SourceReviews[i].CleanupFindingCount != review.SourceReviews[j].CleanupFindingCount {
+			return review.SourceReviews[i].CleanupFindingCount > review.SourceReviews[j].CleanupFindingCount
+		}
+		if review.SourceReviews[i].ProjectedFamilies != review.SourceReviews[j].ProjectedFamilies {
+			return review.SourceReviews[i].ProjectedFamilies > review.SourceReviews[j].ProjectedFamilies
+		}
+		return review.SourceReviews[i].SourceID < review.SourceReviews[j].SourceID
+	})
+}
+
+func sourceIDSuffixRoot(sourceID string) (string, bool) {
+	for _, suffix := range []string{"_com", "_io", "_ai", "_app", "_cloud", "_net"} {
+		if strings.HasSuffix(sourceID, suffix) && len(sourceID) > len(suffix) {
+			return strings.TrimSuffix(sourceID, suffix), true
+		}
+	}
+	return "", false
+}
+
+func normalizedDisplayName(value string) string {
+	var builder strings.Builder
+	for _, r := range strings.ToLower(value) {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String()
+}
+
+func questionID(sourceID string, category string) string {
+	id := strings.Trim(strings.ToLower(sourceID+"_"+category), "_")
+	id = strings.NewReplacer(" ", "_", "-", "_", ".", "_", "/", "_").Replace(id)
+	return id
+}
+
+func displayName(source SourceReview) string {
+	if strings.TrimSpace(source.DisplayName) != "" {
+		return source.DisplayName
+	}
+	return source.SourceID
+}
+
+func listOrNone(values []string) string {
+	if len(values) == 0 {
+		return "no graph templates"
+	}
+	return strings.Join(values, ", ")
+}

--- a/internal/connectorcatalog/review_markdown.go
+++ b/internal/connectorcatalog/review_markdown.go
@@ -1,0 +1,109 @@
+package connectorcatalog
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderReviewMarkdown renders a compact maintenance report for GitHub job
+// summaries and artifacts. maxItems limits long source queues; zero means the
+// default limit.
+func RenderReviewMarkdown(report ReviewReport, maxItems int) string {
+	if maxItems <= 0 {
+		maxItems = 40
+	}
+	var b strings.Builder
+	b.WriteString("# Connector Catalog Review\n\n")
+	b.WriteString("## Summary\n\n")
+	b.WriteString("| Metric | Count |\n| --- | ---: |\n")
+	writeMetric(&b, "Sources", report.Summary.Total)
+	writeMetric(&b, "Sourcegen ready", report.Summary.Generateable)
+	writeMetric(&b, "Needs auth extension", report.Summary.NeedsAuthExtension)
+	writeMetric(&b, "Needs bespoke runtime", report.Summary.NeedsBespokeRuntime)
+	writeMetric(&b, "Resource families", report.Summary.ResourceFamilies)
+	writeMetric(&b, "Projected families", report.Summary.ProjectedFamilies)
+	writeMetric(&b, "Graph item types", report.Summary.ProjectionTemplates)
+	writeMetric(&b, "High-value families", report.Summary.HighValueFamilies)
+	writeMetric(&b, "Coverage dimensions", report.Summary.CoverageDimensions)
+	writeMetric(&b, "Cleanup findings", report.Summary.CleanupFindings)
+	writeMetric(&b, "Review questions", report.Summary.Questions)
+
+	b.WriteString("\n## Promotion Queues\n\n")
+	if len(report.PromotionQueues) == 0 {
+		b.WriteString("No promotion queues are populated.\n")
+	} else {
+		for _, queue := range report.PromotionQueues {
+			fmt.Fprintf(&b, "### %s (%d)\n\n", queue.Label, queue.Count)
+			b.WriteString("| Source | Status | Next action |\n| --- | --- | --- |\n")
+			for i, candidate := range queue.Entries {
+				if i >= maxItems {
+					fmt.Fprintf(&b, "| ... | ... | %d more |\n", len(queue.Entries)-maxItems)
+					break
+				}
+				fmt.Fprintf(&b, "| `%s` | `%s` | %s |\n", escapeCell(candidate.SourceID), escapeCell(candidate.Status), escapeCell(candidate.NextAction))
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("## Graph Coverage\n\n")
+	if len(report.ProjectionCoverage) == 0 {
+		b.WriteString("No projection templates are advertised.\n\n")
+	} else {
+		b.WriteString("| Graph item | Sources | Families |\n| --- | ---: | ---: |\n")
+		for i, coverage := range report.ProjectionCoverage {
+			if i >= maxItems {
+				fmt.Fprintf(&b, "| ... | ... | %d more |\n", len(report.ProjectionCoverage)-maxItems)
+				break
+			}
+			fmt.Fprintf(&b, "| `%s` | %d | %d |\n", escapeCell(coverage.Template), coverage.Sources, coverage.Families)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## Cleanup Queue\n\n")
+	if len(report.CleanupFindings) == 0 {
+		b.WriteString("No cleanup findings.\n\n")
+	} else {
+		b.WriteString("| Source | Category | Finding | Next action |\n| --- | --- | --- | --- |\n")
+		for i, finding := range report.CleanupFindings {
+			if i >= maxItems {
+				fmt.Fprintf(&b, "| ... | ... | ... | %d more |\n", len(report.CleanupFindings)-maxItems)
+				break
+			}
+			fmt.Fprintf(&b, "| `%s` | `%s` | %s | %s |\n", escapeCell(finding.SourceID), escapeCell(finding.Category), escapeCell(finding.Message), escapeCell(finding.NextAction))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## Review Q&A\n\n")
+	if len(report.Questions) == 0 {
+		b.WriteString("No review questions.\n")
+	} else {
+		for i, question := range report.Questions {
+			if i >= maxItems {
+				fmt.Fprintf(&b, "\n%d more questions in the JSON artifact.\n", len(report.Questions)-maxItems)
+				break
+			}
+			fmt.Fprintf(&b, "### `%s` %s\n\n", escapeCell(question.SourceID), escapeText(question.Category))
+			fmt.Fprintf(&b, "**Question:** %s\n\n", escapeText(question.Question))
+			fmt.Fprintf(&b, "**Answer from catalog:** %s\n\n", escapeText(question.Answer))
+			fmt.Fprintf(&b, "**Next action:** %s\n\n", escapeText(question.NextAction))
+		}
+	}
+	return b.String()
+}
+
+func writeMetric(b *strings.Builder, label string, value int) {
+	fmt.Fprintf(b, "| %s | %d |\n", label, value)
+}
+
+func escapeCell(value string) string {
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	return value
+}
+
+func escapeText(value string) string {
+	return strings.TrimSpace(strings.ReplaceAll(value, "\n", " "))
+}

--- a/internal/connectorcatalog/review_test.go
+++ b/internal/connectorcatalog/review_test.go
@@ -1,0 +1,151 @@
+package connectorcatalog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/connectordefinitions"
+)
+
+func TestReviewAnalysisBuildsPromotionCleanupAndQuestions(t *testing.T) {
+	analysis := Analysis{
+		Summary: Summary{
+			Total:              2,
+			Generateable:       1,
+			NeedsAuthExtension: 1,
+		},
+		Entries: []Entry{
+			{
+				Path:             "identity/azure.yaml",
+				Status:           StatusGenerateable,
+				ClassifierOutput: "supported",
+				Generateable:     true,
+				Definition: reviewDefinition("azure", "Azure", []connectordefinitions.ResourceFamily{
+					reviewFamily("users", "identity_user", true),
+					reviewFamily("groups", "identity_group", true),
+				}),
+			},
+			{
+				Path:             "identity/azure_com.yaml",
+				Status:           StatusNeedsAuthExtension,
+				ClassifierOutput: "supported",
+				SourcegenError:   "auth model requires an extension",
+				Definition: reviewDefinition("azure_com", "Azure", []connectordefinitions.ResourceFamily{
+					reviewFamily("users", "identity_user", true),
+					{ID: "roles", Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "app_entitlement", Support: "partial"}}},
+				}),
+			},
+		},
+	}
+
+	report := ReviewAnalysis(analysis)
+
+	if report.Summary.ProjectedFamilies != 3 {
+		t.Fatalf("projected families = %d, want 3", report.Summary.ProjectedFamilies)
+	}
+	if report.Summary.SourcesWithProjectionGap != 1 {
+		t.Fatalf("sources with projection gap = %d, want 1", report.Summary.SourcesWithProjectionGap)
+	}
+	if !hasCleanupFinding(report, "azure_com", "source_id_cleanup") {
+		t.Fatalf("cleanup findings = %#v, want azure_com source_id_cleanup", report.CleanupFindings)
+	}
+	if !hasQueue(report, "sourcegen_ready", "azure") {
+		t.Fatalf("promotion queues = %#v, want azure in sourcegen_ready", report.PromotionQueues)
+	}
+	if !hasQueue(report, "auth_extension", "azure_com") {
+		t.Fatalf("promotion queues = %#v, want azure_com in auth_extension", report.PromotionQueues)
+	}
+	if !hasQuestion(report, "azure_com", "projection_gap") {
+		t.Fatalf("questions = %#v, want azure_com projection_gap", report.Questions)
+	}
+	if !hasQuestion(report, "azure_com", "source_id_cleanup") {
+		t.Fatalf("questions = %#v, want azure_com source_id_cleanup", report.Questions)
+	}
+}
+
+func TestRenderReviewMarkdownIncludesQueuesAndQA(t *testing.T) {
+	report := ReviewReport{
+		Summary: ReviewSummary{Total: 1, ProjectedFamilies: 1, Questions: 1},
+		PromotionQueues: []PromotionQueue{{
+			ID:    "sourcegen_ready",
+			Label: "Sourcegen ready",
+			Count: 1,
+			Entries: []PromotionCandidate{{
+				SourceID:   "okta",
+				Status:     StatusGenerateable,
+				NextAction: "Generate the runtime package.",
+			}},
+		}},
+		Questions: []ReviewQuestion{{
+			SourceID:   "okta",
+			Category:   "graph_projection",
+			Question:   "Do users project?",
+			Answer:     "1 of 1 families project through identity_user.",
+			NextAction: "Open the source detail data view.",
+		}},
+	}
+
+	markdown := RenderReviewMarkdown(report, 10)
+	for _, want := range []string{"# Connector Catalog Review", "## Promotion Queues", "## Review Q&A", "Do users project?"} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, markdown)
+		}
+	}
+}
+
+func reviewDefinition(sourceID string, displayName string, families []connectordefinitions.ResourceFamily) connectordefinitions.Definition {
+	return connectordefinitions.Definition{
+		SourceID:         sourceID,
+		DisplayName:      displayName,
+		Runtime:          connectordefinitions.RuntimeJSONAPI,
+		Auth:             connectordefinitions.AuthSpec{Model: "bearer_token"},
+		Transport:        &connectordefinitions.TransportSpec{Verification: &connectordefinitions.VerificationSpec{Path: "/healthz"}},
+		ResourceFamilies: families,
+	}
+}
+
+func reviewFamily(id string, template string, highValue bool) connectordefinitions.ResourceFamily {
+	return connectordefinitions.ResourceFamily{
+		ID: id,
+		Projection: &connectordefinitions.ProjectionSpec{
+			Template: template,
+		},
+		Coverage: []connectordefinitions.CoverageDimensionSpec{{
+			Type:      "entity_family",
+			Support:   "partial",
+			HighValue: highValue,
+		}},
+	}
+}
+
+func hasCleanupFinding(report ReviewReport, sourceID string, category string) bool {
+	for _, finding := range report.CleanupFindings {
+		if finding.SourceID == sourceID && finding.Category == category {
+			return true
+		}
+	}
+	return false
+}
+
+func hasQueue(report ReviewReport, queueID string, sourceID string) bool {
+	for _, queue := range report.PromotionQueues {
+		if queue.ID != queueID {
+			continue
+		}
+		for _, candidate := range queue.Entries {
+			if candidate.SourceID == sourceID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasQuestion(report ReviewReport, sourceID string, category string) bool {
+	for _, question := range report.Questions {
+		if question.SourceID == sourceID && question.Category == category {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/changed_checks.py
+++ b/scripts/changed_checks.py
@@ -96,6 +96,9 @@ def select_commands(files: list[str], repo: Path) -> list[CommandPlan]:
     if any(path_matches(path, prefixes=("sources/", "policies/", "internal/compliance/", "internal/findings/", "tools/catalogcheck/", "internal/connectorcatalog/catalog/")) for path in files):
         add_command(commands, seen, "catalog-check", ["make", "catalog-check"], "Source, policy, finding, connector, or compliance catalog changed.")
 
+    if any(path_matches(path, prefixes=("internal/connectorcatalog/", "internal/connectordefinitions/", "internal/sourcegen/", "tools/connectorcatalogreview/"), exact=("Makefile", ".github/workflows/connector-catalog-maintenance.yml")) for path in files):
+        add_command(commands, seen, "connector-catalog-review", ["make", "connector-catalog-review"], "Connector catalog metadata, generation, or maintenance review changed.")
+
     if any(path_matches(path, prefixes=("policies/", "schemas/", "tools/findingdsl/", "internal/findingdsl/", "tools/policyrulegen/"), exact=("internal/compliance/policy_rule_extensions.yaml",)) for path in files):
         add_command(commands, seen, "finding-dsl-check", ["make", "finding-dsl-check"], "Policy DSL authoring changed.")
         add_command(commands, seen, "policy-rule-check", ["make", "policy-rule-check"], "Policy authoring or generated rule enrichment changed.")

--- a/scripts/tests/test_changed_checks.py
+++ b/scripts/tests/test_changed_checks.py
@@ -19,6 +19,11 @@ class ChangedChecksTests(unittest.TestCase):
         names = self.command_names(["internal/connectorcatalog/catalog/devops-ci-cd.yaml"])
         self.assertIn("sourcegen-check", names)
         self.assertIn("catalog-check", names)
+        self.assertIn("connector-catalog-review", names)
+
+    def test_connector_review_tooling_selects_catalog_review(self):
+        names = self.command_names(["tools/connectorcatalogreview/main.go"])
+        self.assertIn("connector-catalog-review", names)
 
     def test_policy_paths_select_rule_and_detection_checks(self):
         names = self.command_names(["policies/aws/example.yaml"])

--- a/tools/connectorcatalogreview/main.go
+++ b/tools/connectorcatalogreview/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/writer/cerebro/internal/connectorcatalog"
+)
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	markdownOut := flag.String("markdown-out", "", "write a Markdown review report to this path")
+	jsonOut := flag.String("json-out", "", "write a JSON review report to this path")
+	maxItems := flag.Int("max-items", 40, "maximum rows/questions rendered in Markdown sections")
+	flag.Parse()
+
+	catalogRoot := filepath.Join(*root, "internal", "connectorcatalog", "catalog")
+	analysis, err := connectorcatalog.AnalyzeDir(catalogRoot, connectorcatalog.Options{DryRunSourcegen: true})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "connector-catalog-review: %v\n", err)
+		os.Exit(1)
+	}
+	report := connectorcatalog.ReviewAnalysis(analysis)
+	if *jsonOut != "" {
+		if err := writeJSON(*jsonOut, report); err != nil {
+			fmt.Fprintf(os.Stderr, "connector-catalog-review: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	markdown := connectorcatalog.RenderReviewMarkdown(report, *maxItems)
+	if *markdownOut != "" {
+		if err := writeFile(*markdownOut, []byte(markdown)); err != nil {
+			fmt.Fprintf(os.Stderr, "connector-catalog-review: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("connector-catalog-review: sources=%d projected_families=%d cleanup_findings=%d questions=%d\n",
+		report.Summary.Total,
+		report.Summary.ProjectedFamilies,
+		report.Summary.CleanupFindings,
+		report.Summary.Questions,
+	)
+	if *markdownOut == "" && *jsonOut == "" {
+		fmt.Print(markdown)
+	}
+}
+
+func writeJSON(path string, report connectorcatalog.ReviewReport) error {
+	payload, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report JSON: %w", err)
+	}
+	payload = append(payload, '\n')
+	return writeFile(path, payload)
+}
+
+func writeFile(path string, payload []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add a connector catalog review engine and CLI that emits promotion queues, cleanup findings, graph coverage, and review Q&A as Markdown and JSON
- wire the review into Make targets, changed-check routing, and catalog maintenance docs
- add a scheduled and path-triggered workflow that runs catalog maintenance and uploads the review artifacts

## Validation
- make connector-catalog-maintenance
- go test ./internal/connectorcatalog ./tools/connectorcatalogreview ./tools/catalogcheck -count=1
- python3 -m unittest scripts/tests/test_changed_checks.py
- make script-test
- make test
- make check-structural-test check-arch
- make lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->