### PR TITLE
[codex] Add policy governance gaps

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8344,6 +8344,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GRCPolicyRiskRegisterItem'
+        governance_gaps:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCPolicyGovernanceGap'
         work_queue:
           type: array
           items:
@@ -8410,6 +8414,15 @@ components:
           type: integer
           minimum: 0
         documents_due_for_review:
+          type: integer
+          minimum: 0
+        governance_gaps:
+          type: integer
+          minimum: 0
+        policy_document_gaps:
+          type: integer
+          minimum: 0
+        risk_register_gaps:
           type: integer
           minimum: 0
         open_exceptions:
@@ -8591,6 +8604,37 @@ components:
           type: object
           additionalProperties:
             type: string
+    GRCPolicyGovernanceGap:
+      type: object
+      properties:
+        id:
+          type: string
+        subject:
+          type: string
+        subject_id:
+          type: string
+        title:
+          type: string
+        status:
+          type: string
+        owner:
+          type: string
+        severity:
+          type: string
+          enum:
+            - high
+            - medium
+            - low
+        reason:
+          type: string
+        action:
+          type: string
+        policy_id:
+          type: string
+        document_id:
+          type: string
+        risk_id:
+          type: string
     GRCPolicyLifecyclePolicy:
       type: object
       properties:

--- a/docs/domains/policy-lifecycle.md
+++ b/docs/domains/policy-lifecycle.md
@@ -144,8 +144,8 @@ Recommended summary fields:
 | `acceptance_overdue_policies` | Assigned policies with overdue employee acceptance. |
 | `exceptions_active` | Active policy exceptions in scope. |
 | `exceptions_expiring_soon` | Active exceptions nearing expiration. |
-| `governance_gaps` | Document and risk-register records missing ownership, review dates, links, controls, treatment, or evidence. |
-| `policy_document_gaps` | Policy document records with missing operating metadata or mappings. |
+| `governance_gaps` | Non-draft document and open risk-register records missing ownership, review dates, links, controls, treatment, or evidence. |
+| `policy_document_gaps` | Non-draft policy document records with missing operating metadata or mappings. |
 | `risk_register_gaps` | Open risk-register records missing owner, treatment, dates, links, controls, or evidence. |
 
 Recommended work items:

--- a/docs/domains/policy-lifecycle.md
+++ b/docs/domains/policy-lifecycle.md
@@ -144,6 +144,9 @@ Recommended summary fields:
 | `acceptance_overdue_policies` | Assigned policies with overdue employee acceptance. |
 | `exceptions_active` | Active policy exceptions in scope. |
 | `exceptions_expiring_soon` | Active exceptions nearing expiration. |
+| `governance_gaps` | Document and risk-register records missing ownership, review dates, links, controls, treatment, or evidence. |
+| `policy_document_gaps` | Policy document records with missing operating metadata or mappings. |
+| `risk_register_gaps` | Open risk-register records missing owner, treatment, dates, links, controls, or evidence. |
 
 Recommended work items:
 
@@ -158,6 +161,10 @@ Recommended work items:
 | Exception expires soon | Renew, close, or replace exception. |
 | Policy has no mapped controls | Map policy to controls before audit reliance. |
 | Policy has no approved document evidence | Attach approved policy document. |
+| Document has no owner or review date | Assign an owner and set the next review date. |
+| Document is not linked to a policy | Link the document to the policy it supports. |
+| Open risk has no treatment or treatment date | Add a treatment plan and due date. |
+| Open risk has no source document, control, policy, or evidence link | Link the risk to its source register, policy, controls, and supporting evidence. |
 
 ## API Shape
 
@@ -167,7 +174,7 @@ Implemented endpoints:
 
 | Endpoint | Purpose |
 | --- | --- |
-| `GET /grc/policy-lifecycle` | Tenant-scoped aggregate of policy templates, policy records, documents, risk-register records, versions, approvals, attestations, reviews, exceptions, reminders, work queue items, and explicit control/evidence mappings. |
+| `GET /grc/policy-lifecycle` | Tenant-scoped aggregate of policy templates, policy records, documents, risk-register records, governance gaps, versions, approvals, attestations, reviews, exceptions, reminders, work queue items, and explicit control/evidence mappings. |
 | `POST /grc/policy-lifecycle/actions` | Append and project a lifecycle action event for template, draft, approval, publish, attestation, review, exception, reminder, or escalation work. |
 | `GET /grc/policy-lifecycle/export` | CSV export of policy versions, approvals, attestations, reviews, exceptions, lifecycle events, and control/evidence mappings, with optional `start` and `end` date filters. |
 

--- a/docs/domains/policy-lifecycle.md
+++ b/docs/domains/policy-lifecycle.md
@@ -144,8 +144,8 @@ Recommended summary fields:
 | `acceptance_overdue_policies` | Assigned policies with overdue employee acceptance. |
 | `exceptions_active` | Active policy exceptions in scope. |
 | `exceptions_expiring_soon` | Active exceptions nearing expiration. |
-| `governance_gaps` | Non-draft document and open risk-register records missing ownership, review dates, links, controls, treatment, or evidence. |
-| `policy_document_gaps` | Non-draft policy document records with missing operating metadata or mappings. |
+| `governance_gaps` | Document records that are not drafts, including records with no status, and open risk-register records missing ownership, review dates, links, controls, treatment, or evidence. |
+| `policy_document_gaps` | Document records that are not drafts, including records with no status, that are missing operating metadata or mappings. |
 | `risk_register_gaps` | Open risk-register records missing owner, treatment, dates, links, controls, or evidence. |
 
 Recommended work items:

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -76,8 +76,8 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	document := grcPolicyLifecycleTestNode("urn:cerebro:writer:document:policyops:doc-1", "document", "Access Control PDF", map[string]string{
 		"document_id":   "doc-1",
 		"document_type": "policy_pdf",
-		"status":        "draft",
-		"review_due_at": "2026-01-01",
+		"status":        "approved",
+		"review_due_at": "2099-01-01",
 	})
 	risk := grcPolicyLifecycleTestNode("urn:cerebro:writer:claim:policyops:risk_scenario:risk-1", "claim", "Access review risk", map[string]string{
 		"claim_type":          "risk_scenario",
@@ -194,7 +194,7 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	if payload.Summary.Policies != 1 || payload.Summary.Templates != 1 {
 		t.Fatalf("summary = %+v, want one policy and one template", payload.Summary)
 	}
-	if payload.Summary.PolicyDocuments != 1 || payload.Summary.RiskRegisterItems != 1 || payload.Summary.DraftDocuments != 1 || payload.Summary.DocumentsDueForReview != 0 || payload.Summary.OpenRisks != 1 || payload.Summary.HighRisks != 1 {
+	if payload.Summary.PolicyDocuments != 1 || payload.Summary.RiskRegisterItems != 1 || payload.Summary.DraftDocuments != 0 || payload.Summary.DocumentsDueForReview != 0 || payload.Summary.OpenRisks != 1 || payload.Summary.HighRisks != 1 {
 		t.Fatalf("summary document/risk rollups = %+v, want document and risk counts", payload.Summary)
 	}
 	if payload.Summary.DraftVersions != 1 || payload.Summary.PendingApprovals != 1 || payload.Summary.OverdueReviews != 1 || payload.Summary.OverdueAttestations != 1 {
@@ -231,8 +231,8 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 		!grcPolicyLifecycleBootstrapGapExists(payload.GovernanceGaps, "risk", "risk-1", "Missing treatment date") {
 		t.Fatalf("governance gaps = %+v, want document ownership/control and risk treatment gaps", payload.GovernanceGaps)
 	}
-	if len(payload.DocumentWorkQueue) < 2 {
-		t.Fatalf("document work queue len = %d, want draft document and risk work", len(payload.DocumentWorkQueue))
+	if len(payload.DocumentWorkQueue) < 1 {
+		t.Fatalf("document work queue len = %d, want risk work", len(payload.DocumentWorkQueue))
 	}
 	if len(payload.Templates) != 1 || len(payload.Templates[0].Controls) != 1 {
 		t.Fatalf("templates = %+v, want template control mapping", payload.Templates)

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -147,6 +147,9 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 			PendingApprovals       int `json:"pending_approvals"`
 			OverdueReviews         int `json:"overdue_reviews"`
 			DocumentsDueForReview  int `json:"documents_due_for_review"`
+			GovernanceGaps         int `json:"governance_gaps"`
+			PolicyDocumentGaps     int `json:"policy_document_gaps"`
+			RiskRegisterGaps       int `json:"risk_register_gaps"`
 			OpenRisks              int `json:"open_risks"`
 			HighRisks              int `json:"high_risks"`
 			AttestationCoveragePct int `json:"attestation_coverage_pct"`
@@ -175,8 +178,9 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 			ResidualRisk     string `json:"residual_risk"`
 			SourceDocumentID string `json:"source_document_id"`
 		} `json:"risk_register"`
-		WorkQueue         []any `json:"work_queue"`
-		DocumentWorkQueue []any `json:"document_work_queue"`
+		GovernanceGaps    []grcPolicyLifecycleBootstrapGap `json:"governance_gaps"`
+		WorkQueue         []any                            `json:"work_queue"`
+		DocumentWorkQueue []any                            `json:"document_work_queue"`
 		Templates         []struct {
 			Controls []any `json:"controls"`
 		} `json:"templates"`
@@ -199,6 +203,9 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	if payload.Summary.MappedControls != 1 || payload.Summary.EvidenceItems != 1 {
 		t.Fatalf("summary mappings = %+v, want one control and one evidence item", payload.Summary)
 	}
+	if payload.Summary.GovernanceGaps != 4 || payload.Summary.PolicyDocumentGaps != 2 || payload.Summary.RiskRegisterGaps != 2 {
+		t.Fatalf("summary gaps = %+v, want document and risk gap rollups", payload.Summary)
+	}
 	if len(payload.Policies) != 1 || payload.Policies[0].ID != "access" {
 		t.Fatalf("policies = %+v, want access policy", payload.Policies)
 	}
@@ -217,6 +224,12 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 	}
 	if len(payload.RiskRegister) != 1 || payload.RiskRegister[0].ID != "risk-1" || payload.RiskRegister[0].ResidualRisk != "high" || payload.RiskRegister[0].SourceDocumentID != "doc-1" {
 		t.Fatalf("risk register = %+v, want linked high risk", payload.RiskRegister)
+	}
+	if !grcPolicyLifecycleBootstrapGapExists(payload.GovernanceGaps, "document", "doc-1", "Missing owner") ||
+		!grcPolicyLifecycleBootstrapGapExists(payload.GovernanceGaps, "document", "doc-1", "No mapped controls") ||
+		!grcPolicyLifecycleBootstrapGapExists(payload.GovernanceGaps, "risk", "risk-1", "Missing treatment") ||
+		!grcPolicyLifecycleBootstrapGapExists(payload.GovernanceGaps, "risk", "risk-1", "Missing treatment date") {
+		t.Fatalf("governance gaps = %+v, want document ownership/control and risk treatment gaps", payload.GovernanceGaps)
 	}
 	if len(payload.DocumentWorkQueue) < 2 {
 		t.Fatalf("document work queue len = %d, want draft document and risk work", len(payload.DocumentWorkQueue))
@@ -238,6 +251,23 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 			t.Fatalf("cypher query %q does not reference source and runtime filters", request.Query)
 		}
 	}
+}
+
+type grcPolicyLifecycleBootstrapGap struct {
+	Subject   string `json:"subject"`
+	SubjectID string `json:"subject_id"`
+	Reason    string `json:"reason"`
+	Action    string `json:"action"`
+	Severity  string `json:"severity"`
+}
+
+func grcPolicyLifecycleBootstrapGapExists(gaps []grcPolicyLifecycleBootstrapGap, subject string, subjectID string, reason string) bool {
+	for _, gap := range gaps {
+		if gap.Subject == subject && gap.SubjectID == subjectID && gap.Reason == reason {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGRCPolicyLifecycleActionUsesAuthenticatedActor(t *testing.T) {

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -1259,6 +1259,9 @@ func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, template
 func grcPolicyGovernanceGaps(documents []grcPolicyDocumentItem, riskRegister []grcPolicyRiskRegisterItem) []grcPolicyGovernanceGap {
 	gaps := []grcPolicyGovernanceGap{}
 	for _, document := range documents {
+		if grcPolicyDraftStatus(document.Status) {
+			continue
+		}
 		policyID := grcPolicyFirstDocumentRefID(document.Policies)
 		documentID := firstNonEmpty(document.ID, document.URN)
 		if strings.TrimSpace(document.Owner) == "" {

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -1259,6 +1259,7 @@ func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, template
 func grcPolicyGovernanceGaps(documents []grcPolicyDocumentItem, riskRegister []grcPolicyRiskRegisterItem) []grcPolicyGovernanceGap {
 	gaps := []grcPolicyGovernanceGap{}
 	for _, document := range documents {
+		// Drafts are still authored; no-status imports stay in scope for metadata gaps.
 		if grcPolicyDraftStatus(document.Status) {
 			continue
 		}

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -172,6 +172,7 @@ type Response struct {
 	Policies          []grcPolicyLifecyclePolicy    `json:"policies"`
 	Documents         []grcPolicyDocumentItem       `json:"documents"`
 	RiskRegister      []grcPolicyRiskRegisterItem   `json:"risk_register"`
+	GovernanceGaps    []grcPolicyGovernanceGap      `json:"governance_gaps"`
 	WorkQueue         []grcPolicyLifecycleWork      `json:"work_queue"`
 	DocumentWorkQueue []grcPolicyDocumentWork       `json:"document_work_queue"`
 	Reminders         []grcPolicyReminderItem       `json:"reminders"`
@@ -194,6 +195,9 @@ type grcPolicyLifecycleSummary struct {
 	PendingApprovals       int `json:"pending_approvals"`
 	OverdueReviews         int `json:"overdue_reviews"`
 	DocumentsDueForReview  int `json:"documents_due_for_review"`
+	GovernanceGaps         int `json:"governance_gaps"`
+	PolicyDocumentGaps     int `json:"policy_document_gaps"`
+	RiskRegisterGaps       int `json:"risk_register_gaps"`
 	OpenExceptions         int `json:"open_exceptions"`
 	ExpiringExceptions     int `json:"expiring_exceptions"`
 	OpenRisks              int `json:"open_risks"`
@@ -273,6 +277,21 @@ type grcPolicyRiskRegisterItem struct {
 	Controls            []grcPolicyControlRef  `json:"controls,omitempty"`
 	Evidence            []grcPolicyEvidenceRef `json:"evidence,omitempty"`
 	Attributes          map[string]string      `json:"attributes,omitempty"`
+}
+
+type grcPolicyGovernanceGap struct {
+	ID         string `json:"id"`
+	Subject    string `json:"subject"`
+	SubjectID  string `json:"subject_id,omitempty"`
+	Title      string `json:"title"`
+	Status     string `json:"status,omitempty"`
+	Owner      string `json:"owner,omitempty"`
+	Severity   string `json:"severity"`
+	Reason     string `json:"reason"`
+	Action     string `json:"action"`
+	PolicyID   string `json:"policy_id,omitempty"`
+	DocumentID string `json:"document_id,omitempty"`
+	RiskID     string `json:"risk_id,omitempty"`
 }
 
 type grcPolicyLifecyclePolicy struct {
@@ -821,12 +840,14 @@ func grcPolicyLifecycleFromGraph(entityRows []ports.CypherRow, relationRows []po
 		}
 		return left.Before(right)
 	})
+	governanceGaps := grcPolicyGovernanceGaps(documents, riskRegister)
 	return Response{
-		Summary:           grcPolicyLifecycleSummaryFrom(policies, templates, documents, riskRegister, mappings, generatedAt),
+		Summary:           grcPolicyLifecycleSummaryFrom(policies, templates, documents, riskRegister, mappings, governanceGaps, generatedAt),
 		Templates:         templates,
 		Policies:          policies,
 		Documents:         documents,
 		RiskRegister:      riskRegister,
+		GovernanceGaps:    governanceGaps,
 		WorkQueue:         grcPolicyLifecycleWorkQueue(policies, generatedAt),
 		DocumentWorkQueue: grcPolicyDocumentWorkQueue(documents, riskRegister, generatedAt),
 		Reminders:         reminders,
@@ -1117,7 +1138,7 @@ func grcPolicyFinalize(policy *grcPolicyLifecyclePolicy, now time.Time) {
 	policy.Evidence = uniqueEvidence(policy.Evidence)
 }
 
-func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, templates []grcPolicyTemplateItem, documents []grcPolicyDocumentItem, riskRegister []grcPolicyRiskRegisterItem, mappings []grcPolicyLifecycleMapping, now time.Time) grcPolicyLifecycleSummary {
+func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, templates []grcPolicyTemplateItem, documents []grcPolicyDocumentItem, riskRegister []grcPolicyRiskRegisterItem, mappings []grcPolicyLifecycleMapping, governanceGaps []grcPolicyGovernanceGap, now time.Time) grcPolicyLifecycleSummary {
 	summary := grcPolicyLifecycleSummary{Policies: len(policies), Templates: len(templates), PolicyDocuments: len(documents), RiskRegisterItems: len(riskRegister)}
 	accepted := 0
 	totalAttestations := 0
@@ -1221,9 +1242,119 @@ func grcPolicyLifecycleSummaryFrom(policies []grcPolicyLifecyclePolicy, template
 	if totalAttestations > 0 {
 		summary.AttestationCoveragePct = int(float64(accepted) / float64(totalAttestations) * 100)
 	}
+	for _, gap := range governanceGaps {
+		summary.GovernanceGaps++
+		switch gap.Subject {
+		case "document":
+			summary.PolicyDocumentGaps++
+		case "risk":
+			summary.RiskRegisterGaps++
+		}
+	}
 	summary.MappedControls = len(mappedControls)
 	summary.EvidenceItems = len(evidence)
 	return summary
+}
+
+func grcPolicyGovernanceGaps(documents []grcPolicyDocumentItem, riskRegister []grcPolicyRiskRegisterItem) []grcPolicyGovernanceGap {
+	gaps := []grcPolicyGovernanceGap{}
+	for _, document := range documents {
+		policyID := grcPolicyFirstDocumentRefID(document.Policies)
+		documentID := firstNonEmpty(document.ID, document.URN)
+		if strings.TrimSpace(document.Owner) == "" {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: document.URN + ":gap:owner", Subject: "document", SubjectID: documentID, Title: document.Title, Status: document.Status, Severity: "medium", Reason: "Missing owner", Action: "Assign owner", PolicyID: policyID, DocumentID: document.ID})
+		}
+		if strings.TrimSpace(document.NextReviewDueAt) == "" {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: document.URN + ":gap:review_date", Subject: "document", SubjectID: documentID, Title: document.Title, Status: document.Status, Owner: document.Owner, Severity: "medium", Reason: "Missing review date", Action: "Set review date", PolicyID: policyID, DocumentID: document.ID})
+		}
+		if len(document.Policies) == 0 {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: document.URN + ":gap:policy", Subject: "document", SubjectID: documentID, Title: document.Title, Status: document.Status, Owner: document.Owner, Severity: "medium", Reason: "No linked policy", Action: "Link policy", DocumentID: document.ID})
+		}
+		if grcPolicyDocumentNeedsControlMapping(document) && len(document.Controls) == 0 {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: document.URN + ":gap:controls", Subject: "document", SubjectID: documentID, Title: document.Title, Status: document.Status, Owner: document.Owner, Severity: "low", Reason: "No mapped controls", Action: "Map controls", PolicyID: policyID, DocumentID: document.ID})
+		}
+	}
+	for _, risk := range riskRegister {
+		if !grcPolicyRiskOpen(risk.Status) {
+			continue
+		}
+		policyID := grcPolicyFirstDocumentRefID(risk.Policies)
+		riskID := firstNonEmpty(risk.ID, risk.URN)
+		severity := grcPolicyRiskGapSeverity(risk)
+		if strings.TrimSpace(risk.Owner) == "" {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: risk.URN + ":gap:owner", Subject: "risk", SubjectID: riskID, Title: risk.Title, Status: risk.Status, Severity: severity, Reason: "Missing owner", Action: "Assign owner", PolicyID: policyID, DocumentID: risk.SourceDocumentID, RiskID: risk.ID})
+		}
+		if strings.TrimSpace(risk.Treatment) == "" {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: risk.URN + ":gap:treatment", Subject: "risk", SubjectID: riskID, Title: risk.Title, Status: risk.Status, Owner: risk.Owner, Severity: severity, Reason: "Missing treatment", Action: "Add treatment", PolicyID: policyID, DocumentID: risk.SourceDocumentID, RiskID: risk.ID})
+		}
+		if strings.TrimSpace(risk.TreatmentDueAt) == "" {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: risk.URN + ":gap:treatment_due", Subject: "risk", SubjectID: riskID, Title: risk.Title, Status: risk.Status, Owner: risk.Owner, Severity: severity, Reason: "Missing treatment date", Action: "Set treatment date", PolicyID: policyID, DocumentID: risk.SourceDocumentID, RiskID: risk.ID})
+		}
+		if strings.TrimSpace(risk.ReviewDueAt) == "" {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: risk.URN + ":gap:review_date", Subject: "risk", SubjectID: riskID, Title: risk.Title, Status: risk.Status, Owner: risk.Owner, Severity: "medium", Reason: "Missing review date", Action: "Set review date", PolicyID: policyID, DocumentID: risk.SourceDocumentID, RiskID: risk.ID})
+		}
+		if strings.TrimSpace(risk.SourceDocumentID) == "" {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: risk.URN + ":gap:source_document", Subject: "risk", SubjectID: riskID, Title: risk.Title, Status: risk.Status, Owner: risk.Owner, Severity: severity, Reason: "No source document", Action: "Link source document", PolicyID: policyID, RiskID: risk.ID})
+		}
+		if len(risk.Policies) == 0 {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: risk.URN + ":gap:policy", Subject: "risk", SubjectID: riskID, Title: risk.Title, Status: risk.Status, Owner: risk.Owner, Severity: severity, Reason: "No linked policy", Action: "Link policy", DocumentID: risk.SourceDocumentID, RiskID: risk.ID})
+		}
+		if len(risk.Controls) == 0 {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: risk.URN + ":gap:controls", Subject: "risk", SubjectID: riskID, Title: risk.Title, Status: risk.Status, Owner: risk.Owner, Severity: severity, Reason: "No mapped controls", Action: "Map controls", PolicyID: policyID, DocumentID: risk.SourceDocumentID, RiskID: risk.ID})
+		}
+		if len(risk.Evidence) == 0 {
+			gaps = append(gaps, grcPolicyGovernanceGap{ID: risk.URN + ":gap:evidence", Subject: "risk", SubjectID: riskID, Title: risk.Title, Status: risk.Status, Owner: risk.Owner, Severity: "medium", Reason: "No evidence", Action: "Attach evidence", PolicyID: policyID, DocumentID: risk.SourceDocumentID, RiskID: risk.ID})
+		}
+	}
+	sort.Slice(gaps, func(i, j int) bool {
+		left := grcPolicyGapSeverityRank(gaps[i].Severity)
+		right := grcPolicyGapSeverityRank(gaps[j].Severity)
+		if left != right {
+			return left < right
+		}
+		if gaps[i].Subject != gaps[j].Subject {
+			return gaps[i].Subject < gaps[j].Subject
+		}
+		if gaps[i].Title != gaps[j].Title {
+			return strings.ToLower(gaps[i].Title) < strings.ToLower(gaps[j].Title)
+		}
+		return gaps[i].Reason < gaps[j].Reason
+	})
+	return gaps
+}
+
+func grcPolicyFirstDocumentRefID(refs []grcPolicyDocumentRef) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	return refs[0].ID
+}
+
+func grcPolicyDocumentNeedsControlMapping(document grcPolicyDocumentItem) bool {
+	switch document.DocumentClass {
+	case "policy", "procedure", "standard", "control_narrative":
+		return true
+	default:
+		return false
+	}
+}
+
+func grcPolicyRiskGapSeverity(risk grcPolicyRiskRegisterItem) string {
+	if grcPolicyHighRisk(risk.ResidualRisk, risk.InherentRisk) {
+		return "high"
+	}
+	return "medium"
+}
+
+func grcPolicyGapSeverityRank(severity string) int {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "high":
+		return 0
+	case "medium":
+		return 1
+	default:
+		return 2
+	}
 }
 
 func grcPolicyLifecycleWorkQueue(policies []grcPolicyLifecyclePolicy, now time.Time) []grcPolicyLifecycleWork {

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -298,6 +298,16 @@ func TestGovernanceGapsClassifyPolicyDocumentsAndRisks(t *testing.T) {
 		DocumentClass: "policy",
 		Status:        "draft",
 	}
+	missingStatusDocument := grcPolicyDocumentItem{
+		ID:              "statusless-document",
+		URN:             "urn:document:statusless-document",
+		Title:           "Statusless document",
+		DocumentClass:   "record",
+		NextReviewDueAt: "2026-12-31",
+		Policies: []grcPolicyDocumentRef{
+			{ID: "secure-development", URN: "urn:policy:secure-development", Title: "Secure Development Policy"},
+		},
+	}
 	openRisk := grcPolicyRiskRegisterItem{
 		ID:           "privileged-access",
 		URN:          "urn:risk:privileged-access",
@@ -313,7 +323,7 @@ func TestGovernanceGapsClassifyPolicyDocumentsAndRisks(t *testing.T) {
 		ResidualRisk: "high",
 	}
 
-	gaps := grcPolicyGovernanceGaps([]grcPolicyDocumentItem{document, draftDocument}, []grcPolicyRiskRegisterItem{openRisk, closedRisk})
+	gaps := grcPolicyGovernanceGaps([]grcPolicyDocumentItem{document, draftDocument, missingStatusDocument}, []grcPolicyRiskRegisterItem{openRisk, closedRisk})
 
 	if !grcPolicyGapExists(gaps, "document", "secure-development", "Missing owner") ||
 		!grcPolicyGapExists(gaps, "document", "secure-development", "Missing review date") ||
@@ -332,12 +342,15 @@ func TestGovernanceGapsClassifyPolicyDocumentsAndRisks(t *testing.T) {
 	if grcPolicyGapExists(gaps, "document", "draft-policy", "Missing owner") {
 		t.Fatalf("gaps = %+v, want draft document excluded", gaps)
 	}
+	if !grcPolicyGapExists(gaps, "document", "statusless-document", "Missing owner") {
+		t.Fatalf("gaps = %+v, want missing-status document included for metadata completeness", gaps)
+	}
 	if len(gaps) == 0 || gaps[0].Subject != "risk" || gaps[0].Severity != "high" {
 		t.Fatalf("first gap = %+v, want high risk gap first", gaps)
 	}
 
-	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document}, []grcPolicyRiskRegisterItem{openRisk, closedRisk}, nil, gaps, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
-	if summary.GovernanceGaps != len(gaps) || summary.PolicyDocumentGaps != 4 || summary.RiskRegisterGaps != 8 {
+	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document, missingStatusDocument}, []grcPolicyRiskRegisterItem{openRisk, closedRisk}, nil, gaps, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+	if summary.GovernanceGaps != len(gaps) || summary.PolicyDocumentGaps != 5 || summary.RiskRegisterGaps != 8 {
 		t.Fatalf("summary = %+v, want governance gap rollups", summary)
 	}
 }

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -291,6 +291,13 @@ func TestGovernanceGapsClassifyPolicyDocumentsAndRisks(t *testing.T) {
 		DocumentClass: "policy",
 		Status:        "approved",
 	}
+	draftDocument := grcPolicyDocumentItem{
+		ID:            "draft-policy",
+		URN:           "urn:document:draft-policy",
+		Title:         "Draft Policy",
+		DocumentClass: "policy",
+		Status:        "draft",
+	}
 	openRisk := grcPolicyRiskRegisterItem{
 		ID:           "privileged-access",
 		URN:          "urn:risk:privileged-access",
@@ -306,7 +313,7 @@ func TestGovernanceGapsClassifyPolicyDocumentsAndRisks(t *testing.T) {
 		ResidualRisk: "high",
 	}
 
-	gaps := grcPolicyGovernanceGaps([]grcPolicyDocumentItem{document}, []grcPolicyRiskRegisterItem{openRisk, closedRisk})
+	gaps := grcPolicyGovernanceGaps([]grcPolicyDocumentItem{document, draftDocument}, []grcPolicyRiskRegisterItem{openRisk, closedRisk})
 
 	if !grcPolicyGapExists(gaps, "document", "secure-development", "Missing owner") ||
 		!grcPolicyGapExists(gaps, "document", "secure-development", "Missing review date") ||
@@ -321,6 +328,9 @@ func TestGovernanceGapsClassifyPolicyDocumentsAndRisks(t *testing.T) {
 	}
 	if grcPolicyGapExists(gaps, "risk", "closed-risk", "Missing owner") {
 		t.Fatalf("gaps = %+v, want closed risk excluded", gaps)
+	}
+	if grcPolicyGapExists(gaps, "document", "draft-policy", "Missing owner") {
+		t.Fatalf("gaps = %+v, want draft document excluded", gaps)
 	}
 	if len(gaps) == 0 || gaps[0].Subject != "risk" || gaps[0].Severity != "high" {
 		t.Fatalf("first gap = %+v, want high risk gap first", gaps)

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -169,7 +169,7 @@ func TestMissingReviewStatusDoesNotCreateOverdueWork(t *testing.T) {
 			{URN: "urn:review:missing-status", ReviewDueAt: "2026-01-15"},
 		},
 	}
-	summary := grcPolicyLifecycleSummaryFrom([]grcPolicyLifecyclePolicy{policy}, nil, nil, nil, nil, now)
+	summary := grcPolicyLifecycleSummaryFrom([]grcPolicyLifecyclePolicy{policy}, nil, nil, nil, nil, nil, now)
 	if summary.OverdueReviews != 0 {
 		t.Fatalf("summary = %+v, want missing-status review excluded from overdue count", summary)
 	}
@@ -191,7 +191,7 @@ func TestMissingDocumentStatusDoesNotCreateReviewWork(t *testing.T) {
 	if grcPolicyDocumentDueForReview(document, now) {
 		t.Fatalf("missing document status should not be due for review")
 	}
-	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document}, nil, nil, now)
+	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document}, nil, nil, nil, now)
 	if summary.DocumentsDueForReview != 0 {
 		t.Fatalf("summary = %+v, want missing-status document excluded from due count", summary)
 	}
@@ -214,7 +214,7 @@ func TestDraftDocumentDoesNotCreateReviewWork(t *testing.T) {
 	if grcPolicyDocumentDueForReview(document, now) {
 		t.Fatalf("draft document should not be due for review")
 	}
-	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document}, nil, nil, now)
+	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document}, nil, nil, nil, now)
 	if summary.DraftDocuments != 1 || summary.DocumentsDueForReview != 0 {
 		t.Fatalf("summary = %+v, want one draft document and no due review", summary)
 	}
@@ -237,7 +237,7 @@ func TestHighRiskSummaryCountsOpenRisksOnly(t *testing.T) {
 		{ID: "remediated-high", Status: "remediated", ResidualRisk: "high"},
 		{ID: "transferred-high", Status: "transferred", ResidualRisk: "high"},
 		{ID: "open-medium", Status: "open", ResidualRisk: "medium"},
-	}, nil, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+	}, nil, nil, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
 
 	if summary.OpenRisks != 2 || summary.HighRisks != 1 {
 		t.Fatalf("risk summary = %+v, want two open risks and one open high risk", summary)
@@ -281,6 +281,64 @@ func TestRiskWorkQueueIncludesLinkedPolicy(t *testing.T) {
 	if items[0].RiskID != "privileged-access" || items[0].PolicyID != "access" {
 		t.Fatalf("risk work item = %+v, want linked risk and policy IDs", items[0])
 	}
+}
+
+func TestGovernanceGapsClassifyPolicyDocumentsAndRisks(t *testing.T) {
+	document := grcPolicyDocumentItem{
+		ID:            "secure-development",
+		URN:           "urn:document:secure-development",
+		Title:         "Secure Development Policy",
+		DocumentClass: "policy",
+		Status:        "approved",
+	}
+	openRisk := grcPolicyRiskRegisterItem{
+		ID:           "privileged-access",
+		URN:          "urn:risk:privileged-access",
+		Title:        "Privileged access drift",
+		Status:       "open",
+		ResidualRisk: "high",
+	}
+	closedRisk := grcPolicyRiskRegisterItem{
+		ID:           "closed-risk",
+		URN:          "urn:risk:closed-risk",
+		Title:        "Closed risk",
+		Status:       "closed",
+		ResidualRisk: "high",
+	}
+
+	gaps := grcPolicyGovernanceGaps([]grcPolicyDocumentItem{document}, []grcPolicyRiskRegisterItem{openRisk, closedRisk})
+
+	if !grcPolicyGapExists(gaps, "document", "secure-development", "Missing owner") ||
+		!grcPolicyGapExists(gaps, "document", "secure-development", "Missing review date") ||
+		!grcPolicyGapExists(gaps, "document", "secure-development", "No linked policy") ||
+		!grcPolicyGapExists(gaps, "document", "secure-development", "No mapped controls") {
+		t.Fatalf("document gaps = %+v, want owner, review date, policy, and controls", gaps)
+	}
+	for _, reason := range []string{"Missing owner", "Missing treatment", "Missing treatment date", "Missing review date", "No source document", "No linked policy", "No mapped controls", "No evidence"} {
+		if !grcPolicyGapExists(gaps, "risk", "privileged-access", reason) {
+			t.Fatalf("risk gaps = %+v, want %q", gaps, reason)
+		}
+	}
+	if grcPolicyGapExists(gaps, "risk", "closed-risk", "Missing owner") {
+		t.Fatalf("gaps = %+v, want closed risk excluded", gaps)
+	}
+	if len(gaps) == 0 || gaps[0].Subject != "risk" || gaps[0].Severity != "high" {
+		t.Fatalf("first gap = %+v, want high risk gap first", gaps)
+	}
+
+	summary := grcPolicyLifecycleSummaryFrom(nil, nil, []grcPolicyDocumentItem{document}, []grcPolicyRiskRegisterItem{openRisk, closedRisk}, nil, gaps, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+	if summary.GovernanceGaps != len(gaps) || summary.PolicyDocumentGaps != 4 || summary.RiskRegisterGaps != 8 {
+		t.Fatalf("summary = %+v, want governance gap rollups", summary)
+	}
+}
+
+func grcPolicyGapExists(gaps []grcPolicyGovernanceGap, subject string, subjectID string, reason string) bool {
+	for _, gap := range gaps {
+		if gap.Subject == subject && gap.SubjectID == subjectID && gap.Reason == reason {
+			return true
+		}
+	}
+	return false
 }
 
 func TestExceptionRollupSkipsMissingStatus(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `governance_gaps` rows to the policy lifecycle API for non-draft document and open risk-register records.
- Add summary rollups for total governance gaps, policy document gaps, and risk register gaps.
- Classify missing owners, review dates, policy links, control mappings, treatment plans, treatment dates, source documents, and evidence on the records that need them.
- Update OpenAPI, domain docs, and policy lifecycle/bootstrap tests.

## Validation
- `go test ./internal/grcpolicylifecycle ./internal/bootstrap -count=1`
- `go test ./internal/sourceprojection ./internal/grccatalog -count=1`
- `make openapi-check openapi-lint docs-drift-check`