### PR TITLE
[codex] Expand AI provider catalog depth

### DIFF
--- a/internal/connectorcatalog/ai_governance_catalog_test.go
+++ b/internal/connectorcatalog/ai_governance_catalog_test.go
@@ -96,6 +96,12 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 	if got := deployments.StaticQuery["api-version"]; got != "2024-10-01" {
 		t.Fatalf("azure_openai deployments api-version = %q, want 2024-10-01", got)
 	}
+	for _, familyID := range []string{"deployments", "model_catalog", "rai_policies", "rai_blocklists", "private_endpoint_connections"} {
+		family := catalogFamily(t, azureOpenAI.Definition.ResourceFamilies, familyID)
+		if family.Pagination == nil || family.Pagination.Type != "next_url" || family.Pagination.NextURLJSONPath != "$.nextLink" || !family.Pagination.DisablePageSize {
+			t.Fatalf("azure_openai %s pagination = %#v, want nextLink next_url pagination", familyID, family.Pagination)
+		}
+	}
 	googleGemini := entries["google_gemini"]
 	if googleGemini.Definition.Auth.TokenHeader != "x-goog-api-key" {
 		t.Fatalf("google_gemini token header = %q, want x-goog-api-key", googleGemini.Definition.Auth.TokenHeader)

--- a/internal/connectorcatalog/ai_governance_catalog_test.go
+++ b/internal/connectorcatalog/ai_governance_catalog_test.go
@@ -14,13 +14,17 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 	expected := map[string][]string{
 		"anthropic":         {"api_keys", "model_catalog", "organization_invites", "organization_members", "workspaces"},
 		"aws_bedrock":       {"custom_models", "foundation_models", "guardrails", "model_customization_jobs", "provisioned_model_throughputs"},
+		"azure_openai":      {"deployments", "model_catalog", "private_endpoint_connections", "rai_blocklists", "rai_policies"},
 		"cerebras":          {"api_keys", "model_deployments", "projects", "usage_reports"},
 		"cohere":            {"connectors", "datasets", "fine_tuned_models", "model_catalog"},
 		"databricks":        {"audit_events", "assets", "model_serving_endpoints", "vulnerabilities"},
+		"deepseek":          {"account_balances", "model_catalog"},
 		"fireworks_ai":      {"audit_logs", "billing_metrics", "model_deployments", "service_accounts"},
+		"google_gemini":     {"batch_jobs", "cached_contents", "files", "model_catalog", "tuned_models"},
 		"google_vertex_ai":  {"batch_prediction_jobs", "custom_jobs", "endpoints", "indexes", "models", "reasoning_engines"},
 		"groq":              {"batch_jobs", "files", "fine_tuning_jobs", "model_catalog"},
 		"huggingface":       {"audit_logs", "organization_members", "repositories", "resource_groups"},
+		"ibm_watsonx_ai":    {"custom_models", "deployments", "foundation_model_specs", "foundation_model_tasks", "training_jobs"},
 		"microsoft_foundry": {"agents", "connections", "datasets", "evaluations", "indexes"},
 		"mistral":           {"api_keys", "audit_logs", "usage_reports", "workspaces"},
 		"openrouter":        {"api_keys", "organization_members", "provider_keys", "usage_reports"},
@@ -87,6 +91,28 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 	if got := anthropic.Definition.Transport.Headers["anthropic-version"]; got != "2023-06-01" {
 		t.Fatalf("anthropic version header = %q, want 2023-06-01", got)
 	}
+	azureOpenAI := entries["azure_openai"]
+	deployments := catalogFamily(t, azureOpenAI.Definition.ResourceFamilies, "deployments")
+	if got := deployments.StaticQuery["api-version"]; got != "2024-10-01" {
+		t.Fatalf("azure_openai deployments api-version = %q, want 2024-10-01", got)
+	}
+	googleGemini := entries["google_gemini"]
+	if googleGemini.Definition.Auth.TokenHeader != "x-goog-api-key" {
+		t.Fatalf("google_gemini token header = %q, want x-goog-api-key", googleGemini.Definition.Auth.TokenHeader)
+	}
+	geminiFiles := catalogFamily(t, googleGemini.Definition.ResourceFamilies, "files")
+	if geminiFiles.Pagination == nil || geminiFiles.Pagination.CursorParam != "pageToken" || geminiFiles.Pagination.CursorJSONPath != "$.nextPageToken" {
+		t.Fatalf("google_gemini files pagination = %#v, want pageToken cursor", geminiFiles.Pagination)
+	}
+	ibmWatsonx := entries["ibm_watsonx_ai"]
+	modelSpecs := catalogFamily(t, ibmWatsonx.Definition.ResourceFamilies, "foundation_model_specs")
+	if got := modelSpecs.StaticQuery["version"]; got != "2024-03-14" {
+		t.Fatalf("ibm_watsonx_ai foundation model specs version = %q, want 2024-03-14", got)
+	}
+	customModels := catalogFamily(t, ibmWatsonx.Definition.ResourceFamilies, "custom_models")
+	if customModels.ConfigQuery["project_id"] != "project_id" || len(customModels.ConfigQuery) != 1 {
+		t.Fatalf("ibm_watsonx_ai custom_models config query = %#v, want project_id only", customModels.ConfigQuery)
+	}
 	microsoftFoundry := entries["microsoft_foundry"]
 	if microsoftFoundry.Definition.Auth.TokenHeader != "api-key" {
 		t.Fatalf("microsoft_foundry token header = %q, want api-key", microsoftFoundry.Definition.Auth.TokenHeader)
@@ -107,9 +133,15 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 	}{
 		{sourceID: "aws_bedrock", field: "region"},
 		{sourceID: "aws_bedrock", field: "service"},
+		{sourceID: "azure_openai", field: "subscription_id"},
+		{sourceID: "azure_openai", field: "resource_group"},
+		{sourceID: "azure_openai", field: "account_name"},
+		{sourceID: "azure_openai", field: "location"},
 		{sourceID: "databricks", field: "workspace_url"},
 		{sourceID: "google_vertex_ai", field: "project_id"},
 		{sourceID: "google_vertex_ai", field: "location"},
+		{sourceID: "ibm_watsonx_ai", field: "region"},
+		{sourceID: "ibm_watsonx_ai", field: "project_id"},
 		{sourceID: "microsoft_foundry", field: "endpoint"},
 		{sourceID: "microsoft_foundry", field: "project_name"},
 		{sourceID: "snowflake", field: "account"},

--- a/internal/connectorcatalog/catalog/ai-governance.yaml
+++ b/internal/connectorcatalog/catalog/ai-governance.yaml
@@ -397,7 +397,8 @@ entries:
               evidence_types: [change_management]
               control_domains: [secure_delivery]
           pagination:
-            type: none
+            type: next_url
+            next_url_json_path: "$.nextLink"
             disable_page_size: true
         - id: model_catalog
           label: Model catalog
@@ -423,7 +424,8 @@ entries:
               evidence_types: [source_snapshot]
               control_domains: [asset_inventory]
           pagination:
-            type: none
+            type: next_url
+            next_url_json_path: "$.nextLink"
             disable_page_size: true
         - id: rai_policies
           label: RAI policies
@@ -449,7 +451,8 @@ entries:
               evidence_types: [configuration_state]
               control_domains: [security_operations]
           pagination:
-            type: none
+            type: next_url
+            next_url_json_path: "$.nextLink"
             disable_page_size: true
         - id: rai_blocklists
           label: RAI blocklists
@@ -475,7 +478,8 @@ entries:
               evidence_types: [configuration_state]
               control_domains: [security_operations]
           pagination:
-            type: none
+            type: next_url
+            next_url_json_path: "$.nextLink"
             disable_page_size: true
         - id: private_endpoint_connections
           label: Private endpoint connections
@@ -501,7 +505,8 @@ entries:
               evidence_types: [configuration_state]
               control_domains: [network_security]
           pagination:
-            type: none
+            type: next_url
+            next_url_json_path: "$.nextLink"
             disable_page_size: true
 
   - classifier_output: supported

--- a/internal/connectorcatalog/catalog/ai-governance.yaml
+++ b/internal/connectorcatalog/catalog/ai-governance.yaml
@@ -337,6 +337,176 @@ entries:
   - classifier_output: supported
     definition:
       schema_version: cerebro.integration/v1
+      id: builtin-azure-openai
+      tenant_id: builtin_catalog
+      source_id: azure_openai
+      display_name: Azure OpenAI
+      description: "Azure OpenAI connector definition for deployments, regional model catalog, responsible AI policies, blocklists, and private endpoint connections."
+      categories:
+        - ai
+        - governance
+      config_fields:
+        - key: subscription_id
+          label: Subscription ID
+          required: true
+        - key: resource_group
+          label: Resource group
+          required: true
+        - key: account_name
+          label: Azure AI account name
+          required: true
+        - key: location
+          label: Azure region
+          required: true
+          placeholder: eastus
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            label: Azure access token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://management.azure.com"
+        verification:
+          method: GET
+          path: /subscriptions/${config.subscription_id}/resourceGroups/${config.resource_group}/providers/Microsoft.CognitiveServices/accounts/${config.account_name}/deployments?api-version=2024-10-01
+          expect_status: [200]
+      resource_families:
+        - id: deployments
+          label: Deployments
+          path: /subscriptions/${config.subscription_id}/resourceGroups/${config.resource_group}/providers/Microsoft.CognitiveServices/accounts/${config.account_name}/deployments
+          method: GET
+          static_query:
+            api-version: "2024-10-01"
+          record_selector: "$.value[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: azure_openai.deployments
+            schema_ref: azure_openai/deployments/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: deployments
+              type: deployment_state
+              title: Deployments
+              families: [deployments]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: model_catalog
+          label: Model catalog
+          path: /subscriptions/${config.subscription_id}/providers/Microsoft.CognitiveServices/locations/${config.location}/models
+          method: GET
+          static_query:
+            api-version: "2024-10-01"
+          record_selector: "$.value[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: azure_openai.model_catalog
+            schema_ref: azure_openai/model_catalog/v1
+          projection:
+            template: asset
+          coverage:
+            - id: model_catalog
+              type: entity_family
+              title: Model catalog
+              families: [model_catalog]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: rai_policies
+          label: RAI policies
+          path: /subscriptions/${config.subscription_id}/resourceGroups/${config.resource_group}/providers/Microsoft.CognitiveServices/accounts/${config.account_name}/raiPolicies
+          method: GET
+          static_query:
+            api-version: "2024-10-01"
+          record_selector: "$.value[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: azure_openai.rai_policies
+            schema_ref: azure_openai/rai_policies/v1
+          projection:
+            template: policy
+          coverage:
+            - id: rai_policies
+              type: lifecycle_state
+              title: RAI policies
+              families: [rai_policies]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: rai_blocklists
+          label: RAI blocklists
+          path: /subscriptions/${config.subscription_id}/resourceGroups/${config.resource_group}/providers/Microsoft.CognitiveServices/accounts/${config.account_name}/raiBlocklists
+          method: GET
+          static_query:
+            api-version: "2024-10-01"
+          record_selector: "$.value[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: azure_openai.rai_blocklists
+            schema_ref: azure_openai/rai_blocklists/v1
+          projection:
+            template: policy
+          coverage:
+            - id: rai_blocklists
+              type: lifecycle_state
+              title: RAI blocklists
+              families: [rai_blocklists]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: private_endpoint_connections
+          label: Private endpoint connections
+          path: /subscriptions/${config.subscription_id}/resourceGroups/${config.resource_group}/providers/Microsoft.CognitiveServices/accounts/${config.account_name}/privateEndpointConnections
+          method: GET
+          static_query:
+            api-version: "2024-10-01"
+          record_selector: "$.value[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: azure_openai.private_endpoint_connections
+            schema_ref: azure_openai/private_endpoint_connections/v1
+          projection:
+            template: asset
+          coverage:
+            - id: private_endpoint_connections
+              type: network_exposure
+              title: Private endpoint connections
+              families: [private_endpoint_connections]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [network_security]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
       id: builtin-cerebras
       tenant_id: builtin_catalog
       source_id: cerebras
@@ -582,6 +752,80 @@ entries:
   - classifier_output: supported
     definition:
       schema_version: cerebro.integration/v1
+      id: builtin-deepseek
+      tenant_id: builtin_catalog
+      source_id: deepseek
+      display_name: DeepSeek
+      description: "DeepSeek connector definition for model catalog and account balance governance."
+      categories:
+        - ai
+        - governance
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            label: API key
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.deepseek.com"
+        verification:
+          method: GET
+          path: /models
+          expect_status: [200]
+      resource_families:
+        - id: model_catalog
+          label: Model catalog
+          path: /models
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: id
+          event:
+            kind: deepseek.model_catalog
+            schema_ref: deepseek/model_catalog/v1
+          projection:
+            template: asset
+          coverage:
+            - id: model_catalog
+              type: entity_family
+              title: Model catalog
+              families: [model_catalog]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: account_balances
+          label: Account balances
+          path: /user/balance
+          method: GET
+          record_selector: "$.balance_infos[*]"
+          id_field: currency
+          name_field: currency
+          event:
+            kind: deepseek.account_balances
+            schema_ref: deepseek/account_balances/v1
+          projection:
+            template: asset
+          coverage:
+            - id: account_balances
+              type: entity_family
+              title: Account balances
+              families: [account_balances]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
       id: builtin-fireworks-ai
       tenant_id: builtin_catalog
       source_id: fireworks_ai
@@ -701,6 +945,168 @@ entries:
           pagination:
             type: none
             disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-google-gemini
+      tenant_id: builtin_catalog
+      source_id: google_gemini
+      display_name: Google Gemini
+      description: "Google Gemini connector definition for model catalog, tuned models, uploaded files, cached contents, and batch jobs."
+      categories:
+        - ai
+        - governance
+      auth:
+        model: api_key
+        token_header: x-goog-api-key
+        credential_fields:
+          - key: api_key
+            label: API key
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://generativelanguage.googleapis.com"
+        verification:
+          method: GET
+          path: /v1beta/models
+          expect_status: [200]
+      resource_families:
+        - id: model_catalog
+          label: Model catalog
+          path: /v1beta/models
+          method: GET
+          record_selector: "$.models[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_gemini.model_catalog
+            schema_ref: google_gemini/model_catalog/v1
+          projection:
+            template: asset
+          coverage:
+            - id: model_catalog
+              type: entity_family
+              title: Model catalog
+              families: [model_catalog]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: tuned_models
+          label: Tuned models
+          path: /v1beta/tunedModels
+          method: GET
+          record_selector: "$.tunedModels[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_gemini.tuned_models
+            schema_ref: google_gemini/tuned_models/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: tuned_models
+              type: deployment_state
+              title: Tuned models
+              families: [tuned_models]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: files
+          label: Files
+          path: /v1beta/files
+          method: GET
+          record_selector: "$.files[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_gemini.files
+            schema_ref: google_gemini/files/v1
+          projection:
+            template: asset
+          coverage:
+            - id: files
+              type: entity_family
+              title: Files
+              families: [files]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: cached_contents
+          label: Cached contents
+          path: /v1beta/cachedContents
+          method: GET
+          record_selector: "$.cachedContents[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_gemini.cached_contents
+            schema_ref: google_gemini/cached_contents/v1
+          projection:
+            template: asset
+          coverage:
+            - id: cached_contents
+              type: entity_family
+              title: Cached contents
+              families: [cached_contents]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
+        - id: batch_jobs
+          label: Batch jobs
+          path: /v1beta/batches
+          method: GET
+          record_selector: "$.batches[*]"
+          id_field: name
+          name_field: displayName
+          event:
+            kind: google_gemini.batch_jobs
+            schema_ref: google_gemini/batch_jobs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: batch_jobs
+              type: deployment_state
+              title: Batch jobs
+              families: [batch_jobs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: pageToken
+            cursor_json_path: "$.nextPageToken"
+            page_size_param: pageSize
+            page_size: 100
 
   - classifier_output: supported
     definition:
@@ -1143,6 +1549,176 @@ entries:
             link_header: Link
             page_size_param: limit
             page_size: 100
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-ibm-watsonx-ai
+      tenant_id: builtin_catalog
+      source_id: ibm_watsonx_ai
+      display_name: IBM watsonx.ai
+      description: "IBM watsonx.ai connector definition for foundation model specs, foundation model tasks, project custom models, project deployments, and project training jobs."
+      categories:
+        - ai
+        - governance
+      config_fields:
+        - key: region
+          label: IBM Cloud region
+          required: true
+          placeholder: us-south
+        - key: project_id
+          label: Project ID
+          required: true
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            label: IBM IAM access token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://${config.region}.ml.cloud.ibm.com"
+        verification:
+          method: GET
+          path: /ml/v1/foundation_model_specs?version=2024-03-14
+          expect_status: [200]
+      resource_families:
+        - id: foundation_model_specs
+          label: Foundation model specs
+          path: /ml/v1/foundation_model_specs
+          method: GET
+          static_query:
+            version: "2024-03-14"
+          record_selector: "$.resources[*]"
+          id_field: model_id
+          name_field: label
+          event:
+            kind: ibm_watsonx_ai.foundation_model_specs
+            schema_ref: ibm_watsonx_ai/foundation_model_specs/v1
+          projection:
+            template: asset
+          coverage:
+            - id: foundation_model_specs
+              type: entity_family
+              title: Foundation model specs
+              families: [foundation_model_specs]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: foundation_model_tasks
+          label: Foundation model tasks
+          path: /ml/v1/foundation_model_tasks
+          method: GET
+          static_query:
+            version: "2024-03-14"
+          record_selector: "$.resources[*]"
+          id_field: task_id
+          name_field: label
+          event:
+            kind: ibm_watsonx_ai.foundation_model_tasks
+            schema_ref: ibm_watsonx_ai/foundation_model_tasks/v1
+          projection:
+            template: asset
+          coverage:
+            - id: foundation_model_tasks
+              type: entity_family
+              title: Foundation model tasks
+              families: [foundation_model_tasks]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: custom_models
+          label: Custom models
+          path: /ml/v4/models
+          method: GET
+          static_query:
+            version: "2024-03-14"
+          config_query:
+            project_id: project_id
+          record_selector: "$.resources[*]"
+          id_field: metadata.id
+          name_field: entity.name
+          event:
+            kind: ibm_watsonx_ai.custom_models
+            schema_ref: ibm_watsonx_ai/custom_models/v1
+          projection:
+            template: asset
+          coverage:
+            - id: custom_models
+              type: entity_family
+              title: Custom models
+              families: [custom_models]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: deployments
+          label: Deployments
+          path: /ml/v4/deployments
+          method: GET
+          static_query:
+            version: "2024-03-14"
+          config_query:
+            project_id: project_id
+          record_selector: "$.resources[*]"
+          id_field: metadata.id
+          name_field: entity.name
+          event:
+            kind: ibm_watsonx_ai.deployments
+            schema_ref: ibm_watsonx_ai/deployments/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: deployments
+              type: deployment_state
+              title: Deployments
+              families: [deployments]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: training_jobs
+          label: Training jobs
+          path: /ml/v4/trainings
+          method: GET
+          static_query:
+            version: "2024-03-14"
+          config_query:
+            project_id: project_id
+          record_selector: "$.resources[*]"
+          id_field: metadata.id
+          name_field: entity.name
+          event:
+            kind: ibm_watsonx_ai.training_jobs
+            schema_ref: ibm_watsonx_ai/training_jobs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: training_jobs
+              type: deployment_state
+              title: Training jobs
+              families: [training_jobs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
 
   - classifier_output: supported
     definition:

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/writer/cerebro/internal/connectordefinitions"
 )
 
-const wantBuiltinCatalogEntries = 788
+const wantBuiltinCatalogEntries = 792
 
 func TestAnalyzeDirAcceptsGenerateableCatalogEntry(t *testing.T) {
 	root := t.TempDir()

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -118,6 +118,7 @@ type familyData struct {
 	Singleton             bool
 	CursorParam           string
 	NextCursorKeys        []string
+	NextURLKey            string
 	LinkHeader            string
 	PageSizeParams        []string
 	DisablePageSize       bool
@@ -675,6 +676,7 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			Singleton:             resource.Singleton,
 			CursorParam:           cursorParamForResource(resource),
 			NextCursorKeys:        nextCursorKeysForResource(resource),
+			NextURLKey:            nextURLKeyForResource(resource),
 			LinkHeader:            linkHeaderForResource(resource),
 			PageSizeParams:        pageSizeParamsForResource(resource),
 			DisablePageSize:       disablePageSizeForResource(resource),
@@ -738,6 +740,17 @@ func nextCursorKeysForResource(resource connectordefinitions.ResourceFamily) []s
 		return nil
 	}
 	return []string{key}
+}
+
+func nextURLKeyForResource(resource connectordefinitions.ResourceFamily) string {
+	if resource.Pagination == nil || strings.TrimSpace(resource.Pagination.Type) != "next_url" {
+		return ""
+	}
+	key := cursorJSONPathKey(resource.Pagination.NextURLJSONPath)
+	if key == "" {
+		key = "nextLink"
+	}
+	return key
 }
 
 func cursorJSONPathKey(path string) string {
@@ -1120,6 +1133,9 @@ func renderSourceGo(request normalizedRequest) string {
 		}
 		if len(family.NextCursorKeys) != 0 {
 			fmt.Fprintf(&b, "\t\t\t\tNextCursorKeys: []string{%s},\n", quotedStrings(family.NextCursorKeys))
+		}
+		if strings.TrimSpace(family.NextURLKey) != "" {
+			fmt.Fprintf(&b, "\t\t\t\tNextURLKey:     %s,\n", strconv.Quote(family.NextURLKey))
 		}
 		if strings.TrimSpace(family.LinkHeader) != "" {
 			fmt.Fprintf(&b, "\t\t\t\tLinkHeader: %s,\n", strconv.Quote(family.LinkHeader))

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -118,7 +118,6 @@ type familyData struct {
 	Singleton             bool
 	CursorParam           string
 	NextCursorKeys        []string
-	NextURLKey            string
 	LinkHeader            string
 	PageSizeParams        []string
 	DisablePageSize       bool
@@ -676,7 +675,6 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			Singleton:             resource.Singleton,
 			CursorParam:           cursorParamForResource(resource),
 			NextCursorKeys:        nextCursorKeysForResource(resource),
-			NextURLKey:            nextURLKeyForResource(resource),
 			LinkHeader:            linkHeaderForResource(resource),
 			PageSizeParams:        pageSizeParamsForResource(resource),
 			DisablePageSize:       disablePageSizeForResource(resource),
@@ -735,22 +733,18 @@ func nextCursorKeysForResource(resource connectordefinitions.ResourceFamily) []s
 	if resource.Pagination == nil {
 		return nil
 	}
+	if strings.TrimSpace(resource.Pagination.Type) == "next_url" {
+		key := cursorJSONPathKey(resource.Pagination.NextURLJSONPath)
+		if key == "" {
+			key = "nextLink"
+		}
+		return []string{key}
+	}
 	key := cursorJSONPathKey(resource.Pagination.CursorJSONPath)
 	if key == "" {
 		return nil
 	}
 	return []string{key}
-}
-
-func nextURLKeyForResource(resource connectordefinitions.ResourceFamily) string {
-	if resource.Pagination == nil || strings.TrimSpace(resource.Pagination.Type) != "next_url" {
-		return ""
-	}
-	key := cursorJSONPathKey(resource.Pagination.NextURLJSONPath)
-	if key == "" {
-		key = "nextLink"
-	}
-	return key
 }
 
 func cursorJSONPathKey(path string) string {
@@ -1133,9 +1127,6 @@ func renderSourceGo(request normalizedRequest) string {
 		}
 		if len(family.NextCursorKeys) != 0 {
 			fmt.Fprintf(&b, "\t\t\t\tNextCursorKeys: []string{%s},\n", quotedStrings(family.NextCursorKeys))
-		}
-		if strings.TrimSpace(family.NextURLKey) != "" {
-			fmt.Fprintf(&b, "\t\t\t\tNextURLKey:     %s,\n", strconv.Quote(family.NextURLKey))
 		}
 		if strings.TrimSpace(family.LinkHeader) != "" {
 			fmt.Fprintf(&b, "\t\t\t\tLinkHeader: %s,\n", strconv.Quote(family.LinkHeader))

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -721,7 +721,7 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 		`Path:             "/models"`,
 		`CursorParam:      "after"`,
 		`NextCursorKeys:   []string{"paging.continuation"}`,
-		`NextURLKey:       "nextLink"`,
+		`NextCursorKeys:   []string{"nextLink"}`,
 		`LinkHeader:       "Link"`,
 		`DisablePageSize:  true`,
 		`Config: jsonapi.FamilyConfig{`,

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -691,6 +691,24 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 					LinkHeader:    "Link",
 					PageSizeParam: "limit",
 				},
+			}, {
+				ID:             "deployments",
+				Path:           "/deployments",
+				RecordSelector: "$.value[*]",
+				IDField:        "id",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "huggingface.deployments",
+					SchemaRef: "huggingface/deployments/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "deployment",
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "deployment_state", Support: "partial"}},
+				Pagination: &connectordefinitions.PaginationSpec{
+					Type:            "next_url",
+					NextURLJSONPath: "$.nextLink",
+					DisablePageSize: true,
+				},
 			}},
 		},
 		OutputDir: outputDir,
@@ -703,6 +721,7 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 		`Path:             "/models"`,
 		`CursorParam:      "after"`,
 		`NextCursorKeys:   []string{"paging.continuation"}`,
+		`NextURLKey:       "nextLink"`,
 		`LinkHeader:       "Link"`,
 		`DisablePageSize:  true`,
 		`Config: jsonapi.FamilyConfig{`,

--- a/internal/sourcegen/testscaffold/scaffold.go
+++ b/internal/sourcegen/testscaffold/scaffold.go
@@ -165,14 +165,20 @@ func renderTestFile(definition connectordefinitions.Definition) string {
 }
 
 func renderFixture(family connectordefinitions.ResourceFamily) string {
+	recordID := fmt.Sprintf("fixture-%s-001", family.ID)
+	recordName := fmt.Sprintf("Test %s", toPascal(family.ID))
 	record := map[string]any{
-		"id":   fmt.Sprintf("fixture-%s-001", family.ID),
-		"name": fmt.Sprintf("Test %s", toPascal(family.ID)),
+		"id":   recordID,
+		"name": recordName,
 		"type": family.ID,
 	}
 	idField := strings.TrimSpace(family.IDField)
-	if idField != "" && idField != "id" {
-		record[idField] = fmt.Sprintf("fixture-%s-001", family.ID)
+	if idField != "" {
+		setFixtureField(record, idField, recordID)
+	}
+	nameField := strings.TrimSpace(family.NameField)
+	if nameField != "" && fixturePrimaryPath(nameField) != fixturePrimaryPath(idField) {
+		setFixtureField(record, nameField, recordName)
 	}
 
 	records := []map[string]any{record}
@@ -207,6 +213,42 @@ func renderFixture(family connectordefinitions.ResourceFamily) string {
 	}
 	payload, _ := json.MarshalIndent(response, "", "  ")
 	return string(payload) + "\n"
+}
+
+func setFixtureField(record map[string]any, rawPath string, value any) {
+	if path := fixturePrimaryPath(rawPath); path != "" {
+		setFixturePath(record, strings.Split(path, "."), value)
+	}
+}
+
+func fixturePrimaryPath(rawPath string) string {
+	for _, path := range strings.Split(rawPath, "|") {
+		path = strings.TrimSpace(strings.TrimPrefix(path, "$."))
+		if path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func setFixturePath(record map[string]any, parts []string, value any) {
+	current := record
+	for index, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return
+		}
+		if index == len(parts)-1 {
+			current[part] = value
+			return
+		}
+		next, ok := current[part].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			current[part] = next
+		}
+		current = next
+	}
 }
 
 func sanitizePackageName(sourceID string) string {

--- a/internal/sourcegen/testscaffold/scaffold_test.go
+++ b/internal/sourcegen/testscaffold/scaffold_test.go
@@ -1,6 +1,7 @@
 package testscaffold
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -37,6 +38,24 @@ func TestGenerateScaffold(t *testing.T) {
 				Path:   "/v1/groups",
 				Method: "GET",
 			},
+			{
+				ID:             "models",
+				Label:          "Models",
+				Path:           "/v1/models",
+				Method:         "GET",
+				RecordSelector: "$.resources[*]",
+				IDField:        "metadata.id",
+				NameField:      "entity.name",
+			},
+			{
+				ID:             "balances",
+				Label:          "Balances",
+				Path:           "/v1/balances",
+				Method:         "GET",
+				RecordSelector: "$.balance_infos[*]",
+				IDField:        "currency",
+				NameField:      "currency",
+			},
 		},
 	}
 
@@ -72,5 +91,39 @@ func TestGenerateScaffold(t *testing.T) {
 	}
 	if !strings.Contains(result.Fixtures["users.json"], "fixture-users-001") {
 		t.Errorf("expected fixture user_id, got:\n%s", result.Fixtures["users.json"])
+	}
+	var balancesFixture struct {
+		BalanceInfos []map[string]any `json:"balance_infos"`
+	}
+	if err := json.Unmarshal([]byte(result.Fixtures["balances.json"]), &balancesFixture); err != nil {
+		t.Fatalf("unmarshal balances fixture: %v", err)
+	}
+	if len(balancesFixture.BalanceInfos) != 1 {
+		t.Fatalf("balances fixture records = %d, want 1", len(balancesFixture.BalanceInfos))
+	}
+	if got := balancesFixture.BalanceInfos[0]["currency"]; got != "fixture-balances-001" {
+		t.Fatalf("balances fixture currency = %v, want fixture ID", got)
+	}
+
+	var modelsFixture struct {
+		Resources []map[string]any `json:"resources"`
+	}
+	if err := json.Unmarshal([]byte(result.Fixtures["models.json"]), &modelsFixture); err != nil {
+		t.Fatalf("unmarshal models fixture: %v", err)
+	}
+	if len(modelsFixture.Resources) != 1 {
+		t.Fatalf("models fixture resources = %d, want 1", len(modelsFixture.Resources))
+	}
+	model := modelsFixture.Resources[0]
+	if _, ok := model["metadata.id"]; ok {
+		t.Fatalf("models fixture used flat metadata.id key: %#v", model)
+	}
+	metadata, ok := model["metadata"].(map[string]any)
+	if !ok || metadata["id"] != "fixture-models-001" {
+		t.Fatalf("models fixture metadata = %#v, want nested id", model["metadata"])
+	}
+	entity, ok := model["entity"].(map[string]any)
+	if !ok || entity["name"] != "Test Models" {
+		t.Fatalf("models fixture entity = %#v, want nested name", model["entity"])
 	}
 }

--- a/sources/internal/catalogruntime/source.go
+++ b/sources/internal/catalogruntime/source.go
@@ -155,6 +155,7 @@ func jsonapiFamily(sourceID string, resource connectordefinitions.ResourceFamily
 		NextCursorKeys:        nextCursorKeys(resource.Pagination),
 		HasMoreKey:            hasMoreKey(resource.Pagination),
 		LinkHeader:            linkHeader(resource.Pagination),
+		NextURLKey:            nextURLKey(resource.Pagination),
 		PageFirstCursor:       pageFirstCursor(resource.Pagination),
 		URNKind:               firstNonEmpty(resource.Event.URNKind, "runtime_"+name),
 		IDKeys:                idKeys(resource, class),
@@ -211,6 +212,13 @@ func linkHeader(pagination *connectordefinitions.PaginationSpec) string {
 		return ""
 	}
 	return firstNonEmpty(pagination.LinkHeader, "Link")
+}
+
+func nextURLKey(pagination *connectordefinitions.PaginationSpec) string {
+	if pagination == nil || strings.TrimSpace(pagination.Type) != "next_url" {
+		return ""
+	}
+	return firstNonEmpty(cursorJSONPathKey(pagination.NextURLJSONPath), "nextLink")
 }
 
 func pageFirstCursor(pagination *connectordefinitions.PaginationSpec) string {

--- a/sources/internal/catalogruntime/source.go
+++ b/sources/internal/catalogruntime/source.go
@@ -155,7 +155,6 @@ func jsonapiFamily(sourceID string, resource connectordefinitions.ResourceFamily
 		NextCursorKeys:        nextCursorKeys(resource.Pagination),
 		HasMoreKey:            hasMoreKey(resource.Pagination),
 		LinkHeader:            linkHeader(resource.Pagination),
-		NextURLKey:            nextURLKey(resource.Pagination),
 		PageFirstCursor:       pageFirstCursor(resource.Pagination),
 		URNKind:               firstNonEmpty(resource.Event.URNKind, "runtime_"+name),
 		IDKeys:                idKeys(resource, class),
@@ -183,6 +182,9 @@ func cursorParam(pagination *connectordefinitions.PaginationSpec) string {
 func nextCursorKeys(pagination *connectordefinitions.PaginationSpec) []string {
 	if pagination == nil {
 		return nil
+	}
+	if strings.TrimSpace(pagination.Type) == "next_url" {
+		return []string{firstNonEmpty(cursorJSONPathKey(pagination.NextURLJSONPath), "nextLink")}
 	}
 	if len(pagination.NextCursorKeys) > 0 {
 		return append([]string(nil), pagination.NextCursorKeys...)
@@ -212,13 +214,6 @@ func linkHeader(pagination *connectordefinitions.PaginationSpec) string {
 		return ""
 	}
 	return firstNonEmpty(pagination.LinkHeader, "Link")
-}
-
-func nextURLKey(pagination *connectordefinitions.PaginationSpec) string {
-	if pagination == nil || strings.TrimSpace(pagination.Type) != "next_url" {
-		return ""
-	}
-	return firstNonEmpty(cursorJSONPathKey(pagination.NextURLJSONPath), "nextLink")
 }
 
 func pageFirstCursor(pagination *connectordefinitions.PaginationSpec) string {

--- a/sources/internal/catalogruntime/source_test.go
+++ b/sources/internal/catalogruntime/source_test.go
@@ -389,6 +389,77 @@ func TestSourceDefinitionUsesLinkHeaderPagination(t *testing.T) {
 	}
 }
 
+func TestSourceDefinitionUsesNextURLPagination(t *testing.T) {
+	requests := make([]*http.Request, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Clone(r.Context()))
+		switch r.URL.Query().Get("page") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"value":    []map[string]any{{"id": "item-1"}},
+				"nextLink": "http://" + r.Host + "/records?page=2",
+			})
+		case "2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"value": []map[string]any{{"id": "item-2"}},
+			})
+		default:
+			t.Fatalf("page = %q, want empty or 2", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	source, err := NewDefinition(connectordefinitions.Definition{
+		ID:          "tenant-example",
+		TenantID:    "tenant",
+		SourceID:    "example",
+		DisplayName: "Example",
+		Auth:        connectordefinitions.AuthSpec{Model: "bearer_token"},
+		Transport:   &connectordefinitions.TransportSpec{BaseURL: server.URL},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:             "records",
+			Path:           "/records",
+			RecordSelector: "$.value[*]",
+			IDField:        "id",
+			Event:          connectordefinitions.EventMappingSpec{Kind: "example.records", SchemaRef: "example/records/v1"},
+			Projection:     &connectordefinitions.ProjectionSpec{Template: "asset"},
+			Coverage:       []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "partial"}},
+			Pagination: &connectordefinitions.PaginationSpec{
+				Type:            "next_url",
+				NextURLJSONPath: "$.nextLink",
+				DisablePageSize: true,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewDefinition() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	first, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "tenant",
+		"token":     "token",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if first.NextCursor.GetOpaque() != server.URL+"/records?page=2" {
+		t.Fatalf("first NextCursor = %q, want nextLink", first.NextCursor.GetOpaque())
+	}
+	second, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "tenant",
+		"token":     "token",
+	}), first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if len(second.Events) != 1 || second.Events[0].Id == first.Events[0].Id {
+		t.Fatalf("second events = %#v, want second page", second.Events)
+	}
+	if len(requests) != 2 || requests[1].URL.Query().Get("page") != "2" {
+		t.Fatalf("requests = %#v, want second request from nextLink", requests)
+	}
+}
+
 func TestSourceDefinitionUsesFamilyConfigQuery(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Path; got != "/models" {

--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -52,7 +52,7 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 	if pageCursor == "" {
 		pageCursor = strings.TrimSpace(family.PageFirstCursor)
 	}
-	useNextURL := strings.TrimSpace(family.NextURLKey) != "" && pageCursor != ""
+	useNextURL := isAbsoluteHTTPURL(pageCursor)
 	if pageCursor != "" && !useNextURL {
 		query.Set(cursorParam(family), pageCursor)
 	}
@@ -153,6 +153,14 @@ func cursorParam(family Family) string {
 		return param
 	}
 	return "cursor"
+}
+
+func isAbsoluteHTTPURL(value string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return false
+	}
+	return parsed.IsAbs() && parsed.Host != "" && (strings.EqualFold(parsed.Scheme, "http") || strings.EqualFold(parsed.Scheme, "https"))
 }
 
 func synthesizePageCursor(family Family, cursor string, pageSize int, itemCount int, next string) string {
@@ -392,9 +400,6 @@ func singletonRecord(raw json.RawMessage, fallbackID string) (json.RawMessage, e
 
 func responseCursor(family Family, object map[string]json.RawMessage) string {
 	if value := offsetResponseCursor(family, object); value != "" {
-		return value
-	}
-	if value := rawStringAtPath(object, family.NextURLKey); value != "" {
 		return value
 	}
 	if !responseHasMore(family, object) {

--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -226,7 +226,7 @@ func (s *Source) getJSONWithHeader(ctx context.Context, settings settings, query
 }
 
 func (s *Source) doRequest(ctx context.Context, settings settings, path string, query url.Values, target any, expectStatuses []int) (http.Header, error) {
-	endpoint, err := requestEndpoint(settings.baseURL, settings.path, path)
+	endpoint, err := requestEndpoint(s.options.SourceID, settings.baseURL, settings.path, path)
 	if err != nil {
 		return nil, fmt.Errorf("build %s request: %w", s.options.SourceID, err)
 	}
@@ -288,7 +288,7 @@ func (s *Source) doRequest(ctx context.Context, settings settings, path string, 
 	return resp.Header, nil
 }
 
-func requestEndpoint(baseURL string, defaultPath string, path string) (string, error) {
+func requestEndpoint(sourceID string, baseURL string, defaultPath string, path string) (string, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return baseURL + defaultPath, nil
@@ -300,14 +300,7 @@ func requestEndpoint(baseURL string, defaultPath string, path string) (string, e
 	if !parsed.IsAbs() {
 		return baseURL + path, nil
 	}
-	base, err := url.Parse(baseURL)
-	if err != nil {
-		return "", err
-	}
-	if !strings.EqualFold(parsed.Scheme, base.Scheme) || !strings.EqualFold(parsed.Host, base.Host) {
-		return "", fmt.Errorf("next URL host %q does not match base host %q", parsed.Host, base.Host)
-	}
-	return parsed.String(), nil
+	return sourcehttp.SameOriginAbsoluteURL(sourceID, baseURL, path)
 }
 
 func parseListResponse(family Family, raw json.RawMessage) ([]json.RawMessage, string, error) {

--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -52,11 +52,18 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 	if pageCursor == "" {
 		pageCursor = strings.TrimSpace(family.PageFirstCursor)
 	}
-	if pageCursor != "" {
+	useNextURL := strings.TrimSpace(family.NextURLKey) != "" && pageCursor != ""
+	if pageCursor != "" && !useNextURL {
 		query.Set(cursorParam(family), pageCursor)
 	}
 	var body json.RawMessage
-	headers, err := s.getJSONWithHeader(ctx, settings, query, &body)
+	var headers http.Header
+	var err error
+	if useNextURL {
+		headers, err = s.doRequest(ctx, settings, pageCursor, nil, &body, nil)
+	} else {
+		headers, err = s.getJSONWithHeader(ctx, settings, query, &body)
+	}
 	if err != nil {
 		return nil, "", err
 	}
@@ -211,9 +218,9 @@ func (s *Source) getJSONWithHeader(ctx context.Context, settings settings, query
 }
 
 func (s *Source) doRequest(ctx context.Context, settings settings, path string, query url.Values, target any, expectStatuses []int) (http.Header, error) {
-	endpoint := settings.baseURL + settings.path
-	if strings.TrimSpace(path) != "" {
-		endpoint = settings.baseURL + path
+	endpoint, err := requestEndpoint(settings.baseURL, settings.path, path)
+	if err != nil {
+		return nil, fmt.Errorf("build %s request: %w", s.options.SourceID, err)
 	}
 	if encoded := query.Encode(); encoded != "" {
 		endpoint += "?" + encoded
@@ -271,6 +278,28 @@ func (s *Source) doRequest(ctx context.Context, settings settings, path string, 
 		return resp.Header, fmt.Errorf("decode %s response: %w", s.options.SourceID, err)
 	}
 	return resp.Header, nil
+}
+
+func requestEndpoint(baseURL string, defaultPath string, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return baseURL + defaultPath, nil
+	}
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return "", err
+	}
+	if !parsed.IsAbs() {
+		return baseURL + path, nil
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	if !strings.EqualFold(parsed.Scheme, base.Scheme) || !strings.EqualFold(parsed.Host, base.Host) {
+		return "", fmt.Errorf("next URL host %q does not match base host %q", parsed.Host, base.Host)
+	}
+	return parsed.String(), nil
 }
 
 func parseListResponse(family Family, raw json.RawMessage) ([]json.RawMessage, string, error) {
@@ -363,6 +392,9 @@ func singletonRecord(raw json.RawMessage, fallbackID string) (json.RawMessage, e
 
 func responseCursor(family Family, object map[string]json.RawMessage) string {
 	if value := offsetResponseCursor(family, object); value != "" {
+		return value
+	}
+	if value := rawStringAtPath(object, family.NextURLKey); value != "" {
 		return value
 	}
 	if !responseHasMore(family, object) {

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -23,7 +23,6 @@ type Family struct {
 	NextCursorKeys        []string
 	HasMoreKey            string
 	LinkHeader            string
-	NextURLKey            string
 	PageFirstCursor       string
 	URNKind               string
 	IDKeys                []string

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -23,6 +23,7 @@ type Family struct {
 	NextCursorKeys        []string
 	HasMoreKey            string
 	LinkHeader            string
+	NextURLKey            string
 	PageFirstCursor       string
 	URNKind               string
 	IDKeys                []string

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -856,6 +856,60 @@ func TestReadUsesLinkHeaderCursor(t *testing.T) {
 	}
 }
 
+func TestReadUsesNextURLCursor(t *testing.T) {
+	requests := make([]*http.Request, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Clone(r.Context()))
+		switch r.URL.Query().Get("page") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"value":    []map[string]any{{"id": "item-1"}},
+				"nextLink": "http://" + r.Host + "/items?page=2",
+			})
+		case "2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"value": []map[string]any{{"id": "item-2"}},
+			})
+		default:
+			t.Fatalf("page = %q, want empty or 2", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	source := newCustomTestSource(t, server.URL, Family{
+		Name:            "item",
+		Path:            "/items",
+		NextURLKey:      "nextLink",
+		URNKind:         "item",
+		IDKeys:          []string{"id"},
+		ListKeys:        []string{"value"},
+		PageSizeParams:  []string{"limit"},
+		DisablePageSize: true,
+	})
+	first, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"token":     "token-1",
+		"per_page":  "1",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if want := "http://" + requests[0].Host + "/items?page=2"; first.NextCursor.GetOpaque() != want {
+		t.Fatalf("first NextCursor = %q, want %q", first.NextCursor.GetOpaque(), want)
+	}
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"token":     "token-1",
+		"per_page":  "1",
+	}), first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if len(requests) != 2 || requests[1].URL.Query().Get("page") != "2" || requests[1].URL.Query().Has("limit") {
+		t.Fatalf("requests = %#v, want second request to follow nextLink without page-size query", requests)
+	}
+}
+
 func TestReadSingletonObject(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -879,7 +879,7 @@ func TestReadUsesNextURLCursor(t *testing.T) {
 	source := newCustomTestSource(t, server.URL, Family{
 		Name:            "item",
 		Path:            "/items",
-		NextURLKey:      "nextLink",
+		NextCursorKeys:  []string{"nextLink"},
 		URNKind:         "item",
 		IDKeys:          []string{"id"},
 		ListKeys:        []string{"value"},

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -965,6 +965,49 @@ func TestReadObjectMapRecords(t *testing.T) {
 	}
 }
 
+func TestReadUsesNestedIdentityFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resources": []map[string]any{{
+				"metadata": map[string]any{"id": "model-1"},
+				"entity":   map[string]any{"name": "Risk Model"},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	source := newCustomTestSource(t, server.URL, Family{
+		Name:    "models",
+		Path:    "/models",
+		URNKind: "test_model",
+		IDKeys:  []string{"metadata.id"},
+		ListKeys: []string{
+			"resources",
+		},
+		Attributes: map[string]string{
+			"model_id":   "metadata.id",
+			"model_name": "entity.name",
+		},
+	})
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"family":    "models",
+		"token":     "token-1",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want nested record", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["external_id"]; got != "model-1" {
+		t.Fatalf("external_id = %q, want model-1", got)
+	}
+	if got := pull.Events[0].Attributes["model_name"]; got != "Risk Model" {
+		t.Fatalf("model_name = %q, want Risk Model", got)
+	}
+}
+
 func TestReadParsesUnixTimestamp(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -910,6 +910,40 @@ func TestReadUsesNextURLCursor(t *testing.T) {
 	}
 }
 
+func TestReadRejectsNextURLCursorWithUserInfo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"value":    []map[string]any{{"id": "item-1"}},
+			"nextLink": "http://user@" + r.Host + "/items?page=2",
+		})
+	}))
+	defer server.Close()
+
+	source := newCustomTestSource(t, server.URL, Family{
+		Name:            "item",
+		Path:            "/items",
+		NextCursorKeys:  []string{"nextLink"},
+		URNKind:         "item",
+		IDKeys:          []string{"id"},
+		ListKeys:        []string{"value"},
+		DisablePageSize: true,
+	})
+	first, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"token":     "token-1",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"token":     "token-1",
+	}), first.NextCursor)
+	if err == nil {
+		t.Fatal("Read(second) error = nil, want userinfo rejection")
+	}
+}
+
 func TestReadSingletonObject(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{


### PR DESCRIPTION
## Summary
- Add AI governance catalog entries for Azure OpenAI, DeepSeek, Google Gemini, and IBM watsonx.ai.
- Cover provider control-plane resources including deployments, model catalogs, policy/blocklist state, private endpoint connections, files, caches, batch jobs, account balance, foundation model specs, custom models, and training jobs.
- Update AI governance catalog tests and the builtin catalog count for 792 generateable definitions.

## Validation
- `go test ./internal/connectorcatalog -count=1`
- `make catalog-check`
- `make sourcegen-check`
- `go test ./internal/connectordefinitions ./internal/sourcegen ./internal/connectorcatalog ./internal/sourceregistry ./internal/sourceprojection ./sources/internal/catalogruntime ./sources/internal/jsonapi -count=1`
- `go test ./... -count=1`
- `make lint`
- `make connector-contract-check`
