### PR TITLE
[codex] Fix connector catalog review feedback

### DIFF
--- a/internal/connectorcatalog/review.go
+++ b/internal/connectorcatalog/review.go
@@ -256,14 +256,20 @@ func sourceQuestions(source SourceReview, entry Entry) []ReviewQuestion {
 			NextAction: "Mark the primary evidence or inventory family as high value and include evidence types plus control domains.",
 		})
 	}
-	if source.CoverageDimensions < source.ResourceFamilies {
+	familiesWithoutCoverage := 0
+	for _, family := range entry.Definition.ResourceFamilies {
+		if len(family.Coverage) == 0 {
+			familiesWithoutCoverage++
+		}
+	}
+	if familiesWithoutCoverage > 0 {
 		questions = append(questions, ReviewQuestion{
 			ID:         questionID(source.SourceID, "coverage_depth"),
 			SourceID:   source.SourceID,
 			Path:       source.Path,
 			Category:   "coverage_depth",
 			Question:   "Does every collected family explain why it matters?",
-			Answer:     fmt.Sprintf("%d coverage dimensions are declared for %d families.", source.CoverageDimensions, source.ResourceFamilies),
+			Answer:     fmt.Sprintf("%d of %d families have no coverage dimensions.", familiesWithoutCoverage, source.ResourceFamilies),
 			NextAction: "Add coverage dimensions for each family that should appear in evidence, inventory, access, or finding workflows.",
 		})
 	}

--- a/internal/connectorcatalog/review_test.go
+++ b/internal/connectorcatalog/review_test.go
@@ -22,7 +22,7 @@ func TestReviewAnalysisBuildsPromotionCleanupAndQuestions(t *testing.T) {
 				Generateable:     true,
 				Definition: reviewDefinition("azure", "Azure", []connectordefinitions.ResourceFamily{
 					reviewFamily("users", "identity_user", true),
-					reviewFamily("groups", "identity_group", true),
+					reviewFamily("groups", "identity_group", false),
 				}),
 			},
 			{
@@ -93,6 +93,35 @@ func TestRenderReviewMarkdownIncludesQueuesAndQA(t *testing.T) {
 	}
 }
 
+func TestReviewAnalysisFlagsFamiliesWithoutCoverageIndividually(t *testing.T) {
+	familyWithTwoCoverageDimensions := reviewFamily("users", "identity_user", true)
+	familyWithTwoCoverageDimensions.Coverage = append(familyWithTwoCoverageDimensions.Coverage, connectordefinitions.CoverageDimensionSpec{
+		Type:    "access",
+		Support: "partial",
+	})
+	analysis := Analysis{
+		Summary: Summary{Total: 1, Generateable: 1},
+		Entries: []Entry{{
+			Path:         "identity/example.yaml",
+			Status:       StatusGenerateable,
+			Generateable: true,
+			Definition: reviewDefinition("example", "Example", []connectordefinitions.ResourceFamily{
+				familyWithTwoCoverageDimensions,
+				{ID: "groups", Projection: &connectordefinitions.ProjectionSpec{Template: "identity_group"}},
+			}),
+		}},
+	}
+
+	report := ReviewAnalysis(analysis)
+	question, ok := questionFor(report, "example", "coverage_depth")
+	if !ok {
+		t.Fatalf("questions = %#v, want coverage_depth question", report.Questions)
+	}
+	if !strings.Contains(question.Answer, "1 of 2 families have no coverage dimensions") {
+		t.Fatalf("coverage_depth answer = %q, want per-family gap count", question.Answer)
+	}
+}
+
 func reviewDefinition(sourceID string, displayName string, families []connectordefinitions.ResourceFamily) connectordefinitions.Definition {
 	return connectordefinitions.Definition{
 		SourceID:         sourceID,
@@ -142,10 +171,15 @@ func hasQueue(report ReviewReport, queueID string, sourceID string) bool {
 }
 
 func hasQuestion(report ReviewReport, sourceID string, category string) bool {
+	_, ok := questionFor(report, sourceID, category)
+	return ok
+}
+
+func questionFor(report ReviewReport, sourceID string, category string) (ReviewQuestion, bool) {
 	for _, question := range report.Questions {
 		if question.SourceID == sourceID && question.Category == category {
-			return true
+			return question, true
 		}
 	}
-	return false
+	return ReviewQuestion{}, false
 }

--- a/tools/connectorcatalogreview/main.go
+++ b/tools/connectorcatalogreview/main.go
@@ -58,11 +58,20 @@ func writeJSON(path string, report connectorcatalog.ReviewReport) error {
 }
 
 func writeFile(path string, payload []byte) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create output directory: %w", err)
 	}
-	if err := os.WriteFile(path, payload, 0o644); err != nil {
+	if dir != "." {
+		if err := os.Chmod(dir, 0o750); err != nil {
+			return fmt.Errorf("set output directory permissions: %w", err)
+		}
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("set %s permissions: %w", path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Count coverage-depth gaps per resource family instead of comparing aggregate coverage dimensions to family count.
- Write connector catalog review artifacts with private file permissions and normalize existing output modes.
- Add a regression test for the aggregate coverage case that previously hid missing family coverage.

## Validation
- go test ./internal/connectorcatalog ./tools/connectorcatalogreview -count=1
- make connector-catalog-maintenance
- git diff --check
- python3 -m unittest scripts/tests/test_changed_checks.py
- make lint

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->