### PR TITLE
[codex] deepen AI provider catalog

### DIFF
--- a/internal/connectorcatalog/ai_governance_catalog_test.go
+++ b/internal/connectorcatalog/ai_governance_catalog_test.go
@@ -16,9 +16,11 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 		"aws_bedrock":       {"custom_models", "foundation_models", "guardrails", "model_customization_jobs", "provisioned_model_throughputs"},
 		"azure_openai":      {"deployments", "model_catalog", "private_endpoint_connections", "rai_blocklists", "rai_policies"},
 		"cerebras":          {"api_keys", "model_deployments", "projects", "usage_reports"},
+		"cloudflare_ai":     {"ai_gateways", "gateway_evaluations", "gateway_logs", "gateway_provider_configs", "model_catalog", "vectorize_indexes"},
 		"cohere":            {"connectors", "datasets", "fine_tuned_models", "model_catalog"},
 		"databricks":        {"audit_events", "assets", "model_serving_endpoints", "vulnerabilities"},
 		"deepseek":          {"account_balances", "model_catalog"},
+		"elevenlabs":        {"auth_connections", "model_catalog", "service_account_api_keys", "service_accounts", "voices", "webhooks"},
 		"fireworks_ai":      {"audit_logs", "billing_metrics", "model_deployments", "service_accounts"},
 		"google_gemini":     {"batch_jobs", "cached_contents", "files", "model_catalog", "tuned_models"},
 		"google_vertex_ai":  {"batch_prediction_jobs", "custom_jobs", "endpoints", "indexes", "models", "reasoning_engines"},
@@ -29,6 +31,8 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 		"mistral":           {"api_keys", "audit_logs", "usage_reports", "workspaces"},
 		"openrouter":        {"api_keys", "organization_members", "provider_keys", "usage_reports"},
 		"perplexity":        {"api_groups", "api_keys", "team_members", "usage_reports"},
+		"pinecone":          {"backups", "collections", "indexes", "restore_jobs"},
+		"qdrant_cloud":      {"account_members", "accounts", "backup_restores", "backup_schedules", "backups", "clusters", "database_api_keys", "roles"},
 		"replicate":         {"collections", "deployments", "models", "predictions"},
 		"snowflake":         {"assets", "audit_events", "cortex_search_services", "vulnerabilities"},
 		"stability_ai":      {"account", "account_balance", "engines"},
@@ -102,6 +106,40 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 			t.Fatalf("azure_openai %s pagination = %#v, want nextLink next_url pagination", familyID, family.Pagination)
 		}
 	}
+	cloudflareAI := entries["cloudflare_ai"]
+	cloudflareModels := catalogFamily(t, cloudflareAI.Definition.ResourceFamilies, "model_catalog")
+	if got := cloudflareModels.StaticQuery["format"]; got != "openrouter" {
+		t.Fatalf("cloudflare_ai model_catalog format query = %q, want openrouter", got)
+	}
+	if cloudflareModels.RecordSelector != "$.data[*]" {
+		t.Fatalf("cloudflare_ai model_catalog selector = %q, want OpenRouter-format data selector", cloudflareModels.RecordSelector)
+	}
+	for _, familyID := range []string{"model_catalog", "ai_gateways", "gateway_provider_configs", "gateway_evaluations", "gateway_logs"} {
+		family := catalogFamily(t, cloudflareAI.Definition.ResourceFamilies, familyID)
+		if family.Pagination == nil || family.Pagination.Type != "page" || family.Pagination.PageParam != "page" || family.Pagination.PageSizeParam != "per_page" || family.Pagination.StartPage != 1 {
+			t.Fatalf("cloudflare_ai %s pagination = %#v, want page/per_page pagination", familyID, family.Pagination)
+		}
+	}
+	gatewayProviderConfigs := catalogFamily(t, cloudflareAI.Definition.ResourceFamilies, "gateway_provider_configs")
+	if gatewayProviderConfigs.Path != "/accounts/${config.account_id}/ai-gateway/gateways/${config.gateway_id}/provider_configs" {
+		t.Fatalf("cloudflare_ai gateway_provider_configs path = %q, want gateway-scoped provider configs path", gatewayProviderConfigs.Path)
+	}
+	elevenLabs := entries["elevenlabs"]
+	if elevenLabs.Definition.Auth.TokenHeader != "xi-api-key" {
+		t.Fatalf("elevenlabs token header = %q, want xi-api-key", elevenLabs.Definition.Auth.TokenHeader)
+	}
+	elevenLabsVoices := catalogFamily(t, elevenLabs.Definition.ResourceFamilies, "voices")
+	if elevenLabsVoices.Pagination == nil || elevenLabsVoices.Pagination.CursorParam != "next_page_token" || elevenLabsVoices.Pagination.CursorJSONPath != "$.next_page_token" || elevenLabsVoices.Pagination.HasMoreKey != "has_more" {
+		t.Fatalf("elevenlabs voices pagination = %#v, want next_page_token cursor with has_more", elevenLabsVoices.Pagination)
+	}
+	serviceAccounts := catalogFamily(t, elevenLabs.Definition.ResourceFamilies, "service_accounts")
+	if serviceAccounts.RecordSelector != "$.service-accounts[*]" {
+		t.Fatalf("elevenlabs service_accounts selector = %q, want service-accounts list selector", serviceAccounts.RecordSelector)
+	}
+	serviceAccountAPIKeys := catalogFamily(t, elevenLabs.Definition.ResourceFamilies, "service_account_api_keys")
+	if serviceAccountAPIKeys.Path != "/v1/service-accounts/${config.service_account_user_id}/api-keys" || serviceAccountAPIKeys.RecordSelector != "$.api-keys[*]" {
+		t.Fatalf("elevenlabs service_account_api_keys path=%q selector=%q, want scoped API key list", serviceAccountAPIKeys.Path, serviceAccountAPIKeys.RecordSelector)
+	}
 	googleGemini := entries["google_gemini"]
 	if googleGemini.Definition.Auth.TokenHeader != "x-goog-api-key" {
 		t.Fatalf("google_gemini token header = %q, want x-goog-api-key", googleGemini.Definition.Auth.TokenHeader)
@@ -127,6 +165,31 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 	if got := agents.StaticQuery["api-version"]; got != "v1" {
 		t.Fatalf("microsoft_foundry agents api-version = %q, want v1", got)
 	}
+	pinecone := entries["pinecone"]
+	if pinecone.Definition.Auth.TokenHeader != "Api-Key" {
+		t.Fatalf("pinecone token header = %q, want Api-Key", pinecone.Definition.Auth.TokenHeader)
+	}
+	if got := pinecone.Definition.Transport.Headers["X-Pinecone-Api-Version"]; got != "2025-10" {
+		t.Fatalf("pinecone API version header = %q, want 2025-10", got)
+	}
+	for _, familyID := range []string{"backups", "restore_jobs"} {
+		family := catalogFamily(t, pinecone.Definition.ResourceFamilies, familyID)
+		if family.Pagination == nil || family.Pagination.CursorParam != "paginationToken" || family.Pagination.CursorJSONPath != "$.pagination.next" || family.Pagination.PageSizeParam != "limit" {
+			t.Fatalf("pinecone %s pagination = %#v, want paginationToken cursor", familyID, family.Pagination)
+		}
+	}
+	qdrant := entries["qdrant_cloud"]
+	if qdrant.Definition.Auth.TokenHeader != "Authorization" || qdrant.Definition.Auth.TokenScheme != "apikey" {
+		t.Fatalf("qdrant_cloud auth header=%q scheme=%q, want Authorization apikey", qdrant.Definition.Auth.TokenHeader, qdrant.Definition.Auth.TokenScheme)
+	}
+	qdrantClusters := catalogFamily(t, qdrant.Definition.ResourceFamilies, "clusters")
+	if qdrantClusters.Pagination == nil || qdrantClusters.Pagination.CursorParam != "page_token" || qdrantClusters.Pagination.CursorJSONPath != "$.next_page_token" || qdrantClusters.Pagination.PageSizeParam != "page_size" {
+		t.Fatalf("qdrant_cloud clusters pagination = %#v, want page_token cursor", qdrantClusters.Pagination)
+	}
+	qdrantKeys := catalogFamily(t, qdrant.Definition.ResourceFamilies, "database_api_keys")
+	if qdrantKeys.ConfigQuery["cluster_id"] != "cluster_id" {
+		t.Fatalf("qdrant_cloud database_api_keys config query = %#v, want cluster_id filter", qdrantKeys.ConfigQuery)
+	}
 	stability := entries["stability_ai"]
 	for _, familyID := range []string{"account", "account_balance"} {
 		if family := catalogFamily(t, stability.Definition.ResourceFamilies, familyID); !family.Singleton {
@@ -136,28 +199,38 @@ func TestAIGovernanceProvidersAreGenerateable(t *testing.T) {
 	for _, test := range []struct {
 		sourceID string
 		field    string
+		required bool
 	}{
-		{sourceID: "aws_bedrock", field: "region"},
-		{sourceID: "aws_bedrock", field: "service"},
-		{sourceID: "azure_openai", field: "subscription_id"},
-		{sourceID: "azure_openai", field: "resource_group"},
-		{sourceID: "azure_openai", field: "account_name"},
-		{sourceID: "azure_openai", field: "location"},
-		{sourceID: "databricks", field: "workspace_url"},
-		{sourceID: "google_vertex_ai", field: "project_id"},
-		{sourceID: "google_vertex_ai", field: "location"},
-		{sourceID: "ibm_watsonx_ai", field: "region"},
-		{sourceID: "ibm_watsonx_ai", field: "project_id"},
-		{sourceID: "microsoft_foundry", field: "endpoint"},
-		{sourceID: "microsoft_foundry", field: "project_name"},
-		{sourceID: "snowflake", field: "account"},
+		{sourceID: "aws_bedrock", field: "region", required: true},
+		{sourceID: "aws_bedrock", field: "service", required: true},
+		{sourceID: "azure_openai", field: "subscription_id", required: true},
+		{sourceID: "azure_openai", field: "resource_group", required: true},
+		{sourceID: "azure_openai", field: "account_name", required: true},
+		{sourceID: "azure_openai", field: "location", required: true},
+		{sourceID: "cloudflare_ai", field: "account_id", required: true},
+		{sourceID: "cloudflare_ai", field: "gateway_id", required: true},
+		{sourceID: "databricks", field: "workspace_url", required: true},
+		{sourceID: "elevenlabs", field: "service_account_user_id", required: true},
+		{sourceID: "google_vertex_ai", field: "project_id", required: true},
+		{sourceID: "google_vertex_ai", field: "location", required: true},
+		{sourceID: "ibm_watsonx_ai", field: "region", required: true},
+		{sourceID: "ibm_watsonx_ai", field: "project_id", required: true},
+		{sourceID: "microsoft_foundry", field: "endpoint", required: true},
+		{sourceID: "microsoft_foundry", field: "project_name", required: true},
+		{sourceID: "qdrant_cloud", field: "account_id", required: true},
+		{sourceID: "qdrant_cloud", field: "cluster_id"},
+		{sourceID: "snowflake", field: "account", required: true},
 	} {
-		fields := map[string]struct{}{}
+		fields := map[string]bool{}
 		for _, field := range entries[test.sourceID].Definition.ConfigFields {
-			fields[field.Key] = struct{}{}
+			fields[field.Key] = field.Required
 		}
-		if _, ok := fields[test.field]; !ok {
+		required, ok := fields[test.field]
+		if !ok {
 			t.Fatalf("source %q missing config field %q", test.sourceID, test.field)
+		}
+		if required != test.required {
+			t.Fatalf("source %q config field %q required = %v, want %v", test.sourceID, test.field, required, test.required)
 		}
 	}
 }

--- a/internal/connectorcatalog/catalog/ai-governance.yaml
+++ b/internal/connectorcatalog/catalog/ai-governance.yaml
@@ -632,6 +632,201 @@ entries:
   - classifier_output: supported
     definition:
       schema_version: cerebro.integration/v1
+      id: builtin-cloudflare-ai
+      tenant_id: builtin_catalog
+      source_id: cloudflare_ai
+      display_name: Cloudflare AI
+      description: "Collects Workers AI models, AI Gateway configuration, gateway provider configs, gateway evaluations, gateway logs, and Vectorize indexes from Cloudflare."
+      categories:
+        - ai
+        - governance
+      config_fields:
+        - key: account_id
+          label: Account ID
+          required: true
+        - key: gateway_id
+          label: AI Gateway ID
+          required: true
+          help: "Required for gateway-scoped provider config, evaluation, and log families."
+      auth:
+        model: bearer_token
+        credential_fields:
+          - key: token
+            label: API token
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.cloudflare.com/client/v4"
+        verification:
+          method: GET
+          path: /accounts/${config.account_id}/ai/models/search
+          expect_status: [200]
+      resource_families:
+        - id: model_catalog
+          label: Model catalog
+          path: /accounts/${config.account_id}/ai/models/search
+          method: GET
+          static_query:
+            format: openrouter
+          record_selector: "$.data[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: cloudflare_ai.model_catalog
+            schema_ref: cloudflare_ai/model_catalog/v1
+          projection:
+            template: asset
+          coverage:
+            - id: model_catalog
+              type: entity_family
+              title: Model catalog
+              families: [model_catalog]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+        - id: ai_gateways
+          label: AI gateways
+          path: /accounts/${config.account_id}/ai-gateway/gateways
+          method: GET
+          record_selector: "$.result[*]"
+          id_field: id
+          name_field: id
+          event:
+            kind: cloudflare_ai.ai_gateways
+            schema_ref: cloudflare_ai/ai_gateways/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: ai_gateways
+              type: deployment_state
+              title: AI gateways
+              families: [ai_gateways]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [secure_delivery]
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+        - id: gateway_provider_configs
+          label: Gateway provider configs
+          path: /accounts/${config.account_id}/ai-gateway/gateways/${config.gateway_id}/provider_configs
+          method: GET
+          record_selector: "$.result[*]"
+          id_field: id
+          name_field: alias
+          event:
+            kind: cloudflare_ai.gateway_provider_configs
+            schema_ref: cloudflare_ai/gateway_provider_configs/v1
+          projection:
+            template: secret
+          coverage:
+            - id: gateway_provider_configs
+              type: app_entitlement
+              title: Gateway provider configs
+              families: [gateway_provider_configs]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+        - id: gateway_evaluations
+          label: Gateway evaluations
+          path: /accounts/${config.account_id}/ai-gateway/gateways/${config.gateway_id}/evaluations
+          method: GET
+          record_selector: "$.result[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: cloudflare_ai.gateway_evaluations
+            schema_ref: cloudflare_ai/gateway_evaluations/v1
+          projection:
+            template: policy
+          coverage:
+            - id: gateway_evaluations
+              type: lifecycle_state
+              title: Gateway evaluations
+              families: [gateway_evaluations]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+        - id: gateway_logs
+          label: Gateway logs
+          path: /accounts/${config.account_id}/ai-gateway/gateways/${config.gateway_id}/logs
+          method: GET
+          record_selector: "$.result[*]"
+          id_field: id
+          updated_at_field: created_at
+          event:
+            kind: cloudflare_ai.gateway_logs
+            schema_ref: cloudflare_ai/gateway_logs/v1
+          projection:
+            template: audit_event
+          coverage:
+            - id: gateway_logs
+              type: audit_event
+              title: Gateway logs
+              families: [gateway_logs]
+              support: partial
+              high_value: true
+              evidence_types: [logging_configuration]
+              control_domains: [logging_monitoring]
+          pagination:
+            type: page
+            page_param: page
+            page_size_param: per_page
+            start_page: 1
+            page_size: 100
+        - id: vectorize_indexes
+          label: Vectorize indexes
+          path: /accounts/${config.account_id}/vectorize/v2/indexes
+          method: GET
+          record_selector: "$.result[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: cloudflare_ai.vectorize_indexes
+            schema_ref: cloudflare_ai/vectorize_indexes/v1
+          projection:
+            template: asset
+          coverage:
+            - id: vectorize_indexes
+              type: entity_family
+              title: Vectorize indexes
+              families: [vectorize_indexes]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
       id: builtin-cohere
       tenant_id: builtin_catalog
       source_id: cohere
@@ -824,6 +1019,186 @@ entries:
               high_value: true
               evidence_types: [source_snapshot]
               control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-elevenlabs
+      tenant_id: builtin_catalog
+      source_id: elevenlabs
+      display_name: ElevenLabs
+      description: "Collects models, voices, service accounts, service-account API keys, webhooks, and workspace auth connections from ElevenLabs."
+      categories:
+        - ai
+        - governance
+      config_fields:
+        - key: service_account_user_id
+          label: Service account user ID
+          required: true
+          help: "Required for the service-account API keys family."
+      auth:
+        model: api_key
+        token_header: xi-api-key
+        credential_fields:
+          - key: api_key
+            label: API key
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.elevenlabs.io"
+        verification:
+          method: GET
+          path: /v1/models
+          expect_status: [200]
+      resource_families:
+        - id: model_catalog
+          label: Model catalog
+          path: /v1/models
+          method: GET
+          record_selector: "$[*]"
+          id_field: model_id
+          name_field: name
+          event:
+            kind: elevenlabs.model_catalog
+            schema_ref: elevenlabs/model_catalog/v1
+          projection:
+            template: asset
+          coverage:
+            - id: model_catalog
+              type: entity_family
+              title: Model catalog
+              families: [model_catalog]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: voices
+          label: Voices
+          path: /v2/voices
+          method: GET
+          record_selector: "$.voices[*]"
+          id_field: voice_id
+          name_field: name
+          event:
+            kind: elevenlabs.voices
+            schema_ref: elevenlabs/voices/v1
+          projection:
+            template: asset
+          coverage:
+            - id: voices
+              type: entity_family
+              title: Voices
+              families: [voices]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: cursor
+            cursor_param: next_page_token
+            cursor_json_path: "$.next_page_token"
+            page_size_param: page_size
+            page_size: 100
+            has_more_key: has_more
+        - id: service_accounts
+          label: Service accounts
+          path: /v1/service-accounts
+          method: GET
+          record_selector: "$.service-accounts[*]"
+          id_field: service_account_user_id
+          name_field: name
+          event:
+            kind: elevenlabs.service_accounts
+            schema_ref: elevenlabs/service_accounts/v1
+          projection:
+            template: identity_user
+          coverage:
+            - id: service_accounts
+              type: app_entitlement
+              title: Service accounts
+              families: [service_accounts]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: service_account_api_keys
+          label: Service-account API keys
+          path: /v1/service-accounts/${config.service_account_user_id}/api-keys
+          method: GET
+          record_selector: "$.api-keys[*]"
+          id_field: key_id
+          name_field: name
+          event:
+            kind: elevenlabs.service_account_api_keys
+            schema_ref: elevenlabs/service_account_api_keys/v1
+          projection:
+            template: secret
+          coverage:
+            - id: service_account_api_keys
+              type: app_entitlement
+              title: Service-account API keys
+              families: [service_account_api_keys]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: webhooks
+          label: Webhooks
+          path: /v1/workspace/webhooks
+          method: GET
+          record_selector: "$.webhooks[*]"
+          id_field: webhook_id
+          name_field: name
+          event:
+            kind: elevenlabs.webhooks
+            schema_ref: elevenlabs/webhooks/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: webhooks
+              type: deployment_state
+              title: Webhooks
+              families: [webhooks]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [secure_delivery]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: auth_connections
+          label: Auth connections
+          path: /v1/workspace/auth-connections
+          method: GET
+          record_selector: "$.auth_connections[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: elevenlabs.auth_connections
+            schema_ref: elevenlabs/auth_connections/v1
+          projection:
+            template: secret
+          coverage:
+            - id: auth_connections
+              type: app_entitlement
+              title: Auth connections
+              families: [auth_connections]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
           pagination:
             type: none
             disable_page_size: true
@@ -2245,6 +2620,385 @@ entries:
               high_value: true
               evidence_types: [source_snapshot]
               control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-pinecone
+      tenant_id: builtin_catalog
+      source_id: pinecone
+      display_name: Pinecone
+      description: "Collects indexes, collections, backups, and restore jobs from Pinecone project control-plane APIs."
+      categories:
+        - ai
+        - governance
+      auth:
+        model: api_key
+        token_header: Api-Key
+        credential_fields:
+          - key: api_key
+            label: API key
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.pinecone.io"
+        headers:
+          X-Pinecone-Api-Version: "2025-10"
+        verification:
+          method: GET
+          path: /indexes
+          expect_status: [200]
+      resource_families:
+        - id: indexes
+          label: Indexes
+          path: /indexes
+          method: GET
+          record_selector: "$.indexes[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: pinecone.indexes
+            schema_ref: pinecone/indexes/v1
+          projection:
+            template: asset
+          coverage:
+            - id: indexes
+              type: entity_family
+              title: Indexes
+              families: [indexes]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: collections
+          label: Collections
+          path: /collections
+          method: GET
+          record_selector: "$.collections[*]"
+          id_field: name
+          name_field: name
+          event:
+            kind: pinecone.collections
+            schema_ref: pinecone/collections/v1
+          projection:
+            template: asset
+          coverage:
+            - id: collections
+              type: entity_family
+              title: Collections
+              families: [collections]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: backups
+          label: Backups
+          path: /backups
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: backup_id
+          name_field: name
+          event:
+            kind: pinecone.backups
+            schema_ref: pinecone/backups/v1
+          projection:
+            template: asset
+          coverage:
+            - id: backups
+              type: lifecycle_state
+              title: Backups
+              families: [backups]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
+          pagination:
+            type: cursor
+            cursor_param: paginationToken
+            cursor_json_path: "$.pagination.next"
+            page_size_param: limit
+            page_size: 100
+        - id: restore_jobs
+          label: Restore jobs
+          path: /restore-jobs
+          method: GET
+          record_selector: "$.data[*]"
+          id_field: restore_job_id
+          name_field: target_index_name
+          event:
+            kind: pinecone.restore_jobs
+            schema_ref: pinecone/restore_jobs/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: restore_jobs
+              type: deployment_state
+              title: Restore jobs
+              families: [restore_jobs]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: paginationToken
+            cursor_json_path: "$.pagination.next"
+            page_size_param: limit
+            page_size: 100
+
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      id: builtin-qdrant-cloud
+      tenant_id: builtin_catalog
+      source_id: qdrant_cloud
+      display_name: Qdrant Cloud
+      description: "Collects accounts, account members, clusters, database API keys, backups, backup restores, backup schedules, and IAM roles from Qdrant Cloud."
+      categories:
+        - ai
+        - governance
+      config_fields:
+        - key: account_id
+          label: Account ID
+          required: true
+          help: "Required for account-scoped Qdrant Cloud families."
+        - key: cluster_id
+          label: Cluster ID
+          help: "Optional filter for cluster-scoped backup and database API key families."
+      auth:
+        model: api_key
+        token_header: Authorization
+        token_scheme: apikey
+        credential_fields:
+          - key: api_key
+            label: Management key
+            secret: true
+            reference_only: true
+      transport:
+        base_url: "https://api.cloud.qdrant.io"
+        verification:
+          method: GET
+          path: /api/account/v1/accounts
+          expect_status: [200]
+      resource_families:
+        - id: accounts
+          label: Accounts
+          path: /api/account/v1/accounts
+          method: GET
+          record_selector: "$.items[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: qdrant_cloud.accounts
+            schema_ref: qdrant_cloud/accounts/v1
+          projection:
+            template: asset
+          coverage:
+            - id: accounts
+              type: entity_family
+              title: Accounts
+              families: [accounts]
+              support: partial
+              high_value: true
+              evidence_types: [source_snapshot]
+              control_domains: [asset_inventory]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: account_members
+          label: Account members
+          path: /api/account/v1/accounts/${config.account_id}/members
+          method: GET
+          record_selector: "$.items[*]"
+          id_field: account_member.id
+          name_field: account_member.email
+          event:
+            kind: qdrant_cloud.account_members
+            schema_ref: qdrant_cloud/account_members/v1
+          projection:
+            template: identity_user
+          coverage:
+            - id: account_members
+              type: app_entitlement
+              title: Account members
+              families: [account_members]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: clusters
+          label: Clusters
+          path: /api/cluster/v1/accounts/${config.account_id}/clusters
+          method: GET
+          record_selector: "$.items[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: qdrant_cloud.clusters
+            schema_ref: qdrant_cloud/clusters/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: clusters
+              type: deployment_state
+              title: Clusters
+              families: [clusters]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: page_token
+            cursor_json_path: "$.next_page_token"
+            page_size_param: page_size
+            page_size: 250
+        - id: database_api_keys
+          label: Database API keys
+          path: /api/cluster/auth/v2/accounts/${config.account_id}/database-api-keys
+          method: GET
+          config_query:
+            cluster_id: cluster_id
+          record_selector: "$.items[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: qdrant_cloud.database_api_keys
+            schema_ref: qdrant_cloud/database_api_keys/v1
+          projection:
+            template: secret
+          coverage:
+            - id: database_api_keys
+              type: app_entitlement
+              title: Database API keys
+              families: [database_api_keys]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
+          pagination:
+            type: none
+            disable_page_size: true
+        - id: backups
+          label: Backups
+          path: /api/cluster/backup/v1/accounts/${config.account_id}/backups
+          method: GET
+          config_query:
+            cluster_id: cluster_id
+          record_selector: "$.items[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: qdrant_cloud.backups
+            schema_ref: qdrant_cloud/backups/v1
+          projection:
+            template: asset
+          coverage:
+            - id: backups
+              type: lifecycle_state
+              title: Backups
+              families: [backups]
+              support: partial
+              high_value: true
+              evidence_types: [configuration_state]
+              control_domains: [security_operations]
+          pagination:
+            type: cursor
+            cursor_param: page_token
+            cursor_json_path: "$.next_page_token"
+            page_size_param: page_size
+            page_size: 250
+        - id: backup_restores
+          label: Backup restores
+          path: /api/cluster/backup/v1/accounts/${config.account_id}/backup_restores
+          method: GET
+          config_query:
+            cluster_id: cluster_id
+          record_selector: "$.items[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: qdrant_cloud.backup_restores
+            schema_ref: qdrant_cloud/backup_restores/v1
+          projection:
+            template: deployment
+          coverage:
+            - id: backup_restores
+              type: deployment_state
+              title: Backup restores
+              families: [backup_restores]
+              support: partial
+              high_value: true
+              evidence_types: [change_management]
+              control_domains: [secure_delivery]
+          pagination:
+            type: cursor
+            cursor_param: page_token
+            cursor_json_path: "$.next_page_token"
+            page_size_param: page_size
+            page_size: 250
+        - id: backup_schedules
+          label: Backup schedules
+          path: /api/cluster/backup/v1/accounts/${config.account_id}/backup_schedules
+          method: GET
+          config_query:
+            cluster_id: cluster_id
+          record_selector: "$.items[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: qdrant_cloud.backup_schedules
+            schema_ref: qdrant_cloud/backup_schedules/v1
+          projection:
+            template: policy
+          coverage:
+            - id: backup_schedules
+              type: lifecycle_state
+              title: Backup schedules
+              families: [backup_schedules]
+              support: partial
+              high_value: true
+              evidence_types: [policy_configuration]
+              control_domains: [policy_management]
+          pagination:
+            type: cursor
+            cursor_param: page_token
+            cursor_json_path: "$.next_page_token"
+            page_size_param: page_size
+            page_size: 250
+        - id: roles
+          label: Roles
+          path: /api/iam/v1/accounts/${config.account_id}/roles
+          method: GET
+          record_selector: "$.items[*]"
+          id_field: id
+          name_field: name
+          event:
+            kind: qdrant_cloud.roles
+            schema_ref: qdrant_cloud/roles/v1
+          projection:
+            template: identity_group
+          coverage:
+            - id: roles
+              type: app_entitlement
+              title: Roles
+              families: [roles]
+              support: partial
+              high_value: true
+              evidence_types: [identity_configuration]
+              control_domains: [identity_access]
           pagination:
             type: none
             disable_page_size: true

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/writer/cerebro/internal/connectordefinitions"
 )
 
-const wantBuiltinCatalogEntries = 792
+const wantBuiltinCatalogEntries = 796
 
 func TestAnalyzeDirAcceptsGenerateableCatalogEntry(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
## Summary
- add generated AI governance catalog coverage for four additional AI provider and control-plane surfaces
- model provider-specific auth headers, scoped config fields, and pagination for the new families
- extend catalog regression coverage for provider family sets, scoped paths, and cursor/page handling

## Validation
- go test ./internal/connectorcatalog -count=1
- make catalog-check
- make sourcegen-check
- go test ./internal/connectordefinitions ./internal/sourcegen ./internal/connectorcatalog ./internal/sourceregistry ./internal/sourceprojection ./sources/internal/catalogruntime ./sources/internal/jsonapi -count=1
- make lint
- make verify
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->