### PR TITLE
[codex] Add connector catalog runtime-depth review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ connector-catalog-fidelity-check: ## Verify deterministic connector catalog fide
 	go run ./tools/connectorcatalogfidelity -check -json-out "$(CONNECTOR_CATALOG_FIDELITY_JSON)"
 
 connector-catalog-review: ## Generate connector catalog cleanup, promotion, and Q&A review artifacts.
-	go run ./tools/connectorcatalogreview -markdown-out "$(CONNECTOR_CATALOG_REVIEW_MD)" -json-out "$(CONNECTOR_CATALOG_REVIEW_JSON)" -max-items "$(CONNECTOR_CATALOG_REVIEW_MAX_ITEMS)"
+	go run ./tools/connectorcatalogreview -runtime-depth-required -markdown-out "$(CONNECTOR_CATALOG_REVIEW_MD)" -json-out "$(CONNECTOR_CATALOG_REVIEW_JSON)" -max-items "$(CONNECTOR_CATALOG_REVIEW_MAX_ITEMS)"
 
 connector-catalog-maintenance: catalog-check sourcegen-check connector-catalog-fidelity-check connector-catalog-review ## Validate connector catalog state and publish maintenance review artifacts.
 

--- a/internal/connectorcatalog/fidelity_update.go
+++ b/internal/connectorcatalog/fidelity_update.go
@@ -47,7 +47,7 @@ func HardenDefinitionFidelity(definition connectordefinitions.Definition) (conne
 			continue
 		}
 		if strings.TrimSpace(family.Event.Kind) == "" && sourceID != "" {
-			family.Event.Kind = sourceID + "." + familyID
+			family.Event.Kind = defaultEventKind(sourceID, familyID)
 			addChange(familyID, "resource_families.event.kind", fmt.Sprintf("set event kind to %s", family.Event.Kind))
 		}
 		if strings.TrimSpace(family.Event.SchemaRef) == "" && sourceID != "" {
@@ -313,6 +313,24 @@ func defaultURNKind(sourceID string, familyID string) string {
 	}
 	if value[0] < 'a' || value[0] > 'z' {
 		value = "runtime_" + value
+	}
+	return value
+}
+
+func defaultEventKind(sourceID string, familyID string) string {
+	return defaultEventKindPart(sourceID, "runtime") + "." + defaultEventKindPart(familyID, "resource")
+}
+
+func defaultEventKindPart(value string, fallback string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "-", "_")
+	value = urnKindSegment.ReplaceAllString(value, "_")
+	value = strings.Trim(value, "_")
+	if value == "" {
+		value = fallback
+	}
+	if value[0] < 'a' || value[0] > 'z' {
+		value = fallback + "_" + value
 	}
 	return value
 }

--- a/internal/connectorcatalog/fidelity_update_test.go
+++ b/internal/connectorcatalog/fidelity_update_test.go
@@ -88,6 +88,37 @@ func TestHardenDefinitionFidelityPreservesExistingProjectionFields(t *testing.T)
 	}
 }
 
+func TestHardenDefinitionFidelityNormalizesGeneratedEventKind(t *testing.T) {
+	definition := connectordefinitions.Definition{
+		SourceID:    "example-saas",
+		DisplayName: "Example SaaS",
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:        "audit-logs",
+			IDField:   "id",
+			NameField: "name",
+		}},
+	}
+
+	hardened, _ := HardenDefinitionFidelity(definition)
+	family := hardened.ResourceFamilies[0]
+
+	if family.Event.Kind != "example_saas.audit_logs" {
+		t.Fatalf("event kind = %q, want example_saas.audit_logs", family.Event.Kind)
+	}
+	if family.Event.URNKind != "example_saas_audit_logs" {
+		t.Fatalf("urn kind = %q, want example_saas_audit_logs", family.Event.URNKind)
+	}
+	normalized, err := connectordefinitions.Normalize(hardened)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	for _, check := range normalized.Validation.Checks {
+		if check.ID == "event_kind_audit-logs" && check.Status == connectordefinitions.ValidationBlocked {
+			t.Fatalf("event kind validation is blocking after normalization: %#v", check)
+		}
+	}
+}
+
 func TestHardenDefinitionFidelityMakesShallowSourceReferenceDepth(t *testing.T) {
 	definition := reviewDefinition("example_saas", "Example SaaS", []connectordefinitions.ResourceFamily{
 		{

--- a/internal/connectorcatalog/review.go
+++ b/internal/connectorcatalog/review.go
@@ -14,35 +14,47 @@ import (
 // and review questions that can be published by CI without mutating catalog
 // files.
 type ReviewReport struct {
-	Summary            ReviewSummary        `json:"summary"`
-	PromotionQueues    []PromotionQueue     `json:"promotion_queues,omitempty"`
-	FidelityQueue      []FidelityCandidate  `json:"fidelity_queue,omitempty"`
-	CleanupFindings    []ReviewFinding      `json:"cleanup_findings,omitempty"`
-	Questions          []ReviewQuestion     `json:"questions,omitempty"`
-	SourceReviews      []SourceReview       `json:"source_reviews,omitempty"`
-	ProjectionCoverage []ProjectionCoverage `json:"projection_coverage,omitempty"`
+	Summary            ReviewSummary           `json:"summary"`
+	PromotionQueues    []PromotionQueue        `json:"promotion_queues,omitempty"`
+	FidelityQueue      []FidelityCandidate     `json:"fidelity_queue,omitempty"`
+	RuntimeDepthQueue  []RuntimeDepthCandidate `json:"runtime_depth_queue,omitempty"`
+	CleanupFindings    []ReviewFinding         `json:"cleanup_findings,omitempty"`
+	Questions          []ReviewQuestion        `json:"questions,omitempty"`
+	SourceReviews      []SourceReview          `json:"source_reviews,omitempty"`
+	ProjectionCoverage []ProjectionCoverage    `json:"projection_coverage,omitempty"`
 }
 
 type ReviewSummary struct {
-	Total                    int            `json:"total"`
-	Generateable             int            `json:"generateable"`
-	CatalogReady             int            `json:"catalog_ready"`
-	NeedsAuthExtension       int            `json:"needs_auth_extension"`
-	NeedsBespokeRuntime      int            `json:"needs_bespoke_runtime"`
-	FidelityBaselineScore    int            `json:"fidelity_baseline_score"`
-	HighFidelitySources      int            `json:"high_fidelity_sources"`
-	NeedsFidelityReview      int            `json:"needs_fidelity_review"`
-	ResourceFamilies         int            `json:"resource_families"`
-	ProjectedFamilies        int            `json:"projected_families"`
-	HighValueFamilies        int            `json:"high_value_families"`
-	CoverageDimensions       int            `json:"coverage_dimensions"`
-	ProjectionTemplates      int            `json:"projection_templates"`
-	SourcesWithProjection    int            `json:"sources_with_projection"`
-	SourcesWithProjectionGap int            `json:"sources_with_projection_gap"`
-	CleanupFindings          int            `json:"cleanup_findings"`
-	Questions                int            `json:"questions"`
-	ByStatus                 map[string]int `json:"by_status,omitempty"`
-	ByProjectionTemplate     map[string]int `json:"by_projection_template,omitempty"`
+	Total                    int                  `json:"total"`
+	Generateable             int                  `json:"generateable"`
+	CatalogReady             int                  `json:"catalog_ready"`
+	NeedsAuthExtension       int                  `json:"needs_auth_extension"`
+	NeedsBespokeRuntime      int                  `json:"needs_bespoke_runtime"`
+	FidelityBaselineScore    int                  `json:"fidelity_baseline_score"`
+	HighFidelitySources      int                  `json:"high_fidelity_sources"`
+	NeedsFidelityReview      int                  `json:"needs_fidelity_review"`
+	RuntimeDepth             *RuntimeDepthSummary `json:"runtime_depth,omitempty"`
+	ResourceFamilies         int                  `json:"resource_families"`
+	ProjectedFamilies        int                  `json:"projected_families"`
+	HighValueFamilies        int                  `json:"high_value_families"`
+	CoverageDimensions       int                  `json:"coverage_dimensions"`
+	ProjectionTemplates      int                  `json:"projection_templates"`
+	SourcesWithProjection    int                  `json:"sources_with_projection"`
+	SourcesWithProjectionGap int                  `json:"sources_with_projection_gap"`
+	CleanupFindings          int                  `json:"cleanup_findings"`
+	Questions                int                  `json:"questions"`
+	ByStatus                 map[string]int       `json:"by_status,omitempty"`
+	ByProjectionTemplate     map[string]int       `json:"by_projection_template,omitempty"`
+}
+
+type RuntimeDepthSummary struct {
+	BaselineScore              int `json:"baseline_score"`
+	RuntimeBackedSources       int `json:"runtime_backed_sources"`
+	ReferenceRuntimeSources    int `json:"reference_runtime_sources"`
+	NeedsRuntimeDepth          int `json:"needs_runtime_depth"`
+	SourcesWithRuntimeFixtures int `json:"sources_with_runtime_fixtures"`
+	SourcesWithDeployManifest  int `json:"sources_with_deploy_manifest"`
+	SourcesWithProjectorTests  int `json:"sources_with_projector_tests"`
 }
 
 type PromotionQueue struct {
@@ -65,6 +77,16 @@ type FidelityCandidate struct {
 	SourceID    string   `json:"source_id"`
 	DisplayName string   `json:"display_name,omitempty"`
 	Path        string   `json:"path,omitempty"`
+	Score       int      `json:"score"`
+	Missing     []string `json:"missing,omitempty"`
+	NextAction  string   `json:"next_action"`
+}
+
+type RuntimeDepthCandidate struct {
+	SourceID    string   `json:"source_id"`
+	DisplayName string   `json:"display_name,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	PackagePath string   `json:"package_path,omitempty"`
 	Score       int      `json:"score"`
 	Missing     []string `json:"missing,omitempty"`
 	NextAction  string   `json:"next_action"`
@@ -100,6 +122,7 @@ type SourceReview struct {
 	HighValueFamilies  int    `json:"high_value_families"`
 	CoverageDimensions int    `json:"coverage_dimensions"`
 	SourceFidelityFields
+	RuntimeDepthFields
 	SourceFamilyReadinessFields
 	ProjectionTemplates   []string `json:"projection_templates,omitempty"`
 	PromotionQueue        string   `json:"promotion_queue,omitempty"`
@@ -119,6 +142,21 @@ type SourceFidelityFields struct {
 	FidelityGaps  []string `json:"fidelity_gaps,omitempty"`
 }
 
+type RuntimeDepthFields struct {
+	RuntimeDepthScore        int      `json:"runtime_depth_score,omitempty"`
+	RuntimeDepthLevel        string   `json:"runtime_depth_level,omitempty"`
+	RuntimeDepthGaps         []string `json:"runtime_depth_gaps,omitempty"`
+	RuntimePackagePath       string   `json:"runtime_package_path,omitempty"`
+	HasRuntimePackage        bool     `json:"has_runtime_package,omitempty"`
+	HasRuntimeCatalog        bool     `json:"has_runtime_catalog,omitempty"`
+	HasRuntimeImplementation bool     `json:"has_runtime_implementation,omitempty"`
+	HasRuntimeTests          bool     `json:"has_runtime_tests,omitempty"`
+	HasRuntimeFixtures       bool     `json:"has_runtime_fixtures,omitempty"`
+	HasDeployManifest        bool     `json:"has_deploy_manifest,omitempty"`
+	HasProjectorTests        bool     `json:"has_projector_tests,omitempty"`
+	RuntimeFamilies          []string `json:"runtime_families,omitempty"`
+}
+
 type SourceFamilyReadinessFields struct {
 	FamiliesWithEvents    int `json:"families_with_events"`
 	FamiliesWithFieldMaps int `json:"families_with_field_maps"`
@@ -134,16 +172,32 @@ type ProjectionCoverage struct {
 }
 
 const fidelityReviewThreshold = 90
+const runtimeDepthReviewThreshold = 90
 
 // ReviewAnalysis builds a deterministic maintenance report from a catalog
 // analysis. It does not re-read files or run source generation.
 func ReviewAnalysis(analysis Analysis) ReviewReport {
+	return reviewAnalysis(analysis, nil, false)
+}
+
+// ReviewAnalysisWithRuntimeDepth builds a deterministic maintenance report and
+// folds in source package evidence gathered from the repository checkout.
+func ReviewAnalysisWithRuntimeDepth(analysis Analysis, runtimeInventory RuntimeDepthInventory) ReviewReport {
+	return reviewAnalysis(analysis, runtimeInventory, true)
+}
+
+func reviewAnalysis(analysis Analysis, runtimeInventory RuntimeDepthInventory, includeRuntimeDepth bool) ReviewReport {
 	review := ReviewReport{
 		Summary: ReviewSummary{
 			ByStatus:              map[string]int{},
 			ByProjectionTemplate:  map[string]int{},
 			FidelityBaselineScore: fidelityReviewThreshold,
 		},
+	}
+	if includeRuntimeDepth {
+		review.Summary.RuntimeDepth = &RuntimeDepthSummary{
+			BaselineScore: runtimeDepthReviewThreshold,
+		}
 	}
 	sourceIDs := map[string]Entry{}
 	displayNames := map[string][]Entry{}
@@ -161,7 +215,7 @@ func ReviewAnalysis(analysis Analysis) ReviewReport {
 			displayNames[key] = append(displayNames[key], entry)
 		}
 
-		sourceReview := buildSourceReview(entry)
+		sourceReview := buildSourceReview(entry, runtimeInventory[entry.Definition.SourceID], includeRuntimeDepth)
 		review.SourceReviews = append(review.SourceReviews, sourceReview)
 		review.Summary.Total++
 		review.Summary.ResourceFamilies += sourceReview.ResourceFamilies
@@ -182,6 +236,34 @@ func ReviewAnalysis(analysis Analysis) ReviewReport {
 				NextAction:  fidelityNextAction(),
 			})
 		}
+		if includeRuntimeDepth {
+			if sourceReview.HasRuntimePackage {
+				review.Summary.RuntimeDepth.RuntimeBackedSources++
+			}
+			if sourceReview.RuntimeDepthScore >= runtimeDepthReviewThreshold {
+				review.Summary.RuntimeDepth.ReferenceRuntimeSources++
+			} else {
+				review.Summary.RuntimeDepth.NeedsRuntimeDepth++
+				review.RuntimeDepthQueue = append(review.RuntimeDepthQueue, RuntimeDepthCandidate{
+					SourceID:    sourceReview.SourceID,
+					DisplayName: sourceReview.DisplayName,
+					Path:        sourceReview.Path,
+					PackagePath: sourceReview.RuntimePackagePath,
+					Score:       sourceReview.RuntimeDepthScore,
+					Missing:     append([]string(nil), sourceReview.RuntimeDepthGaps...),
+					NextAction:  runtimeDepthNextAction(),
+				})
+			}
+			if sourceReview.HasRuntimeFixtures {
+				review.Summary.RuntimeDepth.SourcesWithRuntimeFixtures++
+			}
+			if sourceReview.HasDeployManifest {
+				review.Summary.RuntimeDepth.SourcesWithDeployManifest++
+			}
+			if sourceReview.HasProjectorTests {
+				review.Summary.RuntimeDepth.SourcesWithProjectorTests++
+			}
+		}
 		if sourceReview.ProjectedFamilies > 0 {
 			review.Summary.SourcesWithProjection++
 		}
@@ -200,7 +282,7 @@ func ReviewAnalysis(analysis Analysis) ReviewReport {
 		if queueID != "" {
 			queueEntries[queueID] = append(queueEntries[queueID], candidate)
 		}
-		for _, question := range sourceQuestions(sourceReview, entry) {
+		for _, question := range sourceQuestions(sourceReview, entry, includeRuntimeDepth) {
 			review.Questions = append(review.Questions, question)
 			questionsBySource[question.SourceID]++
 		}
@@ -233,7 +315,7 @@ func ReviewAnalysis(analysis Analysis) ReviewReport {
 	return review
 }
 
-func buildSourceReview(entry Entry) SourceReview {
+func buildSourceReview(entry Entry, runtimeDepth RuntimeDepth, includeRuntimeDepth bool) SourceReview {
 	review := SourceReview{
 		SourceID:          entry.Definition.SourceID,
 		DisplayName:       entry.Definition.DisplayName,
@@ -275,13 +357,39 @@ func buildSourceReview(entry Entry) SourceReview {
 	review.FamiliesWithScopes = countFamilies(entry, func(family connectordefinitions.ResourceFamily) bool {
 		return familyHasScopeOption(entry.Definition.ScopeOptions, family.ID)
 	})
+	if includeRuntimeDepth {
+		review.RuntimeDepthScore = runtimeDepth.Score
+		review.RuntimeDepthGaps = append([]string(nil), runtimeDepth.Missing...)
+		review.RuntimePackagePath = runtimeDepth.PackagePath
+		review.HasRuntimePackage = runtimeDepth.HasSourcePackage
+		review.HasRuntimeCatalog = runtimeDepth.HasSourceCatalog
+		review.HasRuntimeImplementation = runtimeDepth.HasSourceImplementation
+		review.HasRuntimeTests = runtimeDepth.HasSourceTests
+		review.HasRuntimeFixtures = runtimeDepth.HasFixturePair
+		review.HasDeployManifest = runtimeDepth.HasDeployManifest
+		review.HasProjectorTests = runtimeDepth.HasProjectorTests
+		review.RuntimeFamilies = append([]string(nil), runtimeDepth.RuntimeFamilies...)
+		switch {
+		case review.RuntimeDepthScore >= runtimeDepthReviewThreshold:
+			review.RuntimeDepthLevel = "reference_runtime"
+		case review.HasRuntimePackage:
+			review.RuntimeDepthLevel = "runtime_package"
+		default:
+			review.RuntimeDepthLevel = "catalog_only"
+			if len(review.RuntimeDepthGaps) == 0 {
+				review.RuntimeDepthGaps = []string{"runtime:source_package"}
+			}
+		}
+	}
 	sort.Strings(review.ProjectionTemplates)
 	sort.Strings(review.ProjectionGapFamilies)
+	sort.Strings(review.RuntimeFamilies)
+	sort.Strings(review.RuntimeDepthGaps)
 	review.PromotionQueue, review.NextAction = promotionQueueAndAction(entry)
 	return review
 }
 
-func sourceQuestions(source SourceReview, entry Entry) []ReviewQuestion {
+func sourceQuestions(source SourceReview, entry Entry, includeRuntimeDepth bool) []ReviewQuestion {
 	var questions []ReviewQuestion
 	if source.ResourceFamilies > 0 {
 		questions = append(questions, ReviewQuestion{
@@ -364,6 +472,17 @@ func sourceQuestions(source SourceReview, entry Entry) []ReviewQuestion {
 			Question:   "Does this source meet the reference catalog depth baseline?",
 			Answer:     fmt.Sprintf("Score %d of 100. Missing: %s.", source.FidelityScore, listOrNone(limitStrings(source.FidelityGaps, 8))),
 			NextAction: fidelityNextAction(),
+		})
+	}
+	if includeRuntimeDepth && source.RuntimeDepthScore < runtimeDepthReviewThreshold {
+		questions = append(questions, ReviewQuestion{
+			ID:         questionID(source.SourceID, "runtime_depth"),
+			SourceID:   source.SourceID,
+			Path:       source.Path,
+			Category:   "runtime_depth",
+			Question:   "Does this source have a source package at the reference runtime bar?",
+			Answer:     fmt.Sprintf("Score %d of 100. Level: %s. Missing: %s.", source.RuntimeDepthScore, source.RuntimeDepthLevel, listOrNone(limitStrings(source.RuntimeDepthGaps, 8))),
+			NextAction: runtimeDepthNextAction(),
 		})
 	}
 	return questions
@@ -524,6 +643,10 @@ func wordCount(value string) int {
 
 func fidelityNextAction() string {
 	return "Raise the source to the reference connector baseline: add source verification, scope options, event schema fields, graph projection mappings, coverage evidence, control domains, and collection behavior for each family."
+}
+
+func runtimeDepthNextAction() string {
+	return "Promote this source from catalog-only to source-runtime depth: add a Source CDK package, source catalog, read/discover fixtures, source tests, deploy runtime, and projector tests for the graph items it emits."
 }
 
 func familyHasHighValueCoverage(family connectordefinitions.ResourceFamily) bool {
@@ -749,6 +872,12 @@ func sortReview(review *ReviewReport) {
 			return review.FidelityQueue[i].Score < review.FidelityQueue[j].Score
 		}
 		return review.FidelityQueue[i].SourceID < review.FidelityQueue[j].SourceID
+	})
+	sort.SliceStable(review.RuntimeDepthQueue, func(i int, j int) bool {
+		if review.RuntimeDepthQueue[i].Score != review.RuntimeDepthQueue[j].Score {
+			return review.RuntimeDepthQueue[i].Score < review.RuntimeDepthQueue[j].Score
+		}
+		return review.RuntimeDepthQueue[i].SourceID < review.RuntimeDepthQueue[j].SourceID
 	})
 	sort.SliceStable(review.CleanupFindings, func(i int, j int) bool {
 		if review.CleanupFindings[i].SourceID != review.CleanupFindings[j].SourceID {

--- a/internal/connectorcatalog/review_markdown.go
+++ b/internal/connectorcatalog/review_markdown.go
@@ -22,6 +22,14 @@ func RenderReviewMarkdown(report ReviewReport, maxItems int) string {
 	writeMetric(&b, "Needs bespoke runtime", report.Summary.NeedsBespokeRuntime)
 	writeMetric(&b, "Reference-depth sources", report.Summary.HighFidelitySources)
 	writeMetric(&b, "Needs fidelity review", report.Summary.NeedsFidelityReview)
+	if report.Summary.RuntimeDepth != nil {
+		writeMetric(&b, "Runtime-backed sources", report.Summary.RuntimeDepth.RuntimeBackedSources)
+		writeMetric(&b, "Reference-runtime sources", report.Summary.RuntimeDepth.ReferenceRuntimeSources)
+		writeMetric(&b, "Needs runtime depth", report.Summary.RuntimeDepth.NeedsRuntimeDepth)
+		writeMetric(&b, "Sources with runtime fixtures", report.Summary.RuntimeDepth.SourcesWithRuntimeFixtures)
+		writeMetric(&b, "Sources with deploy manifest", report.Summary.RuntimeDepth.SourcesWithDeployManifest)
+		writeMetric(&b, "Sources with projector tests", report.Summary.RuntimeDepth.SourcesWithProjectorTests)
+	}
 	writeMetric(&b, "Resource families", report.Summary.ResourceFamilies)
 	writeMetric(&b, "Projected families", report.Summary.ProjectedFamilies)
 	writeMetric(&b, "Graph item types", report.Summary.ProjectionTemplates)
@@ -62,6 +70,28 @@ func RenderReviewMarkdown(report ReviewReport, maxItems int) string {
 			fmt.Fprintf(&b, "| `%s` | %d | %s | %s |\n", escapeCell(candidate.SourceID), candidate.Score, escapeCell(strings.Join(limitStrings(candidate.Missing, 6), ", ")), escapeCell(candidate.NextAction))
 		}
 		b.WriteString("\n")
+	}
+
+	if report.Summary.RuntimeDepth != nil || len(report.RuntimeDepthQueue) > 0 {
+		b.WriteString("## Runtime Depth Queue\n\n")
+		if len(report.RuntimeDepthQueue) == 0 {
+			b.WriteString("No sources need runtime-depth review.\n\n")
+		} else {
+			baseline := runtimeDepthReviewThreshold
+			if report.Summary.RuntimeDepth != nil {
+				baseline = report.Summary.RuntimeDepth.BaselineScore
+			}
+			fmt.Fprintf(&b, "Reference runtime baseline: %d/100.\n\n", baseline)
+			b.WriteString("| Source | Score | Package | Missing | Next action |\n| --- | ---: | --- | --- | --- |\n")
+			for i, candidate := range report.RuntimeDepthQueue {
+				if i >= maxItems {
+					fmt.Fprintf(&b, "| ... | ... | ... | ... | %d more |\n", len(report.RuntimeDepthQueue)-maxItems)
+					break
+				}
+				fmt.Fprintf(&b, "| `%s` | %d | %s | %s | %s |\n", escapeCell(candidate.SourceID), candidate.Score, inlineCodeOrDash(candidate.PackagePath), escapeCell(strings.Join(limitStrings(candidate.Missing, 6), ", ")), escapeCell(candidate.NextAction))
+			}
+			b.WriteString("\n")
+		}
 	}
 
 	b.WriteString("## Graph Coverage\n\n")
@@ -120,6 +150,14 @@ func escapeCell(value string) string {
 	value = strings.ReplaceAll(value, "\n", " ")
 	value = strings.ReplaceAll(value, "|", "\\|")
 	return value
+}
+
+func inlineCodeOrDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return "`" + escapeCell(value) + "`"
 }
 
 func escapeText(value string) string {

--- a/internal/connectorcatalog/review_test.go
+++ b/internal/connectorcatalog/review_test.go
@@ -66,6 +66,30 @@ func TestReviewAnalysisBuildsPromotionCleanupAndQuestions(t *testing.T) {
 	}
 }
 
+func TestReviewAnalysisOmitsRuntimeDepthWithoutInventory(t *testing.T) {
+	analysis := Analysis{
+		Summary: Summary{Total: 1, Generateable: 1},
+		Entries: []Entry{{
+			Path:         "identity/catalog_only.yaml",
+			Status:       StatusGenerateable,
+			Generateable: true,
+			Definition:   reviewDefinition("catalog_only", "Catalog Only", []connectordefinitions.ResourceFamily{reviewDetailedFamily("users", "identity_user")}),
+		}},
+	}
+
+	report := ReviewAnalysis(analysis)
+
+	if report.Summary.RuntimeDepth != nil {
+		t.Fatalf("runtime depth summary = %#v, want nil without runtime inventory", report.Summary.RuntimeDepth)
+	}
+	if len(report.RuntimeDepthQueue) != 0 {
+		t.Fatalf("runtime depth queue = %#v, want empty without runtime inventory", report.RuntimeDepthQueue)
+	}
+	if hasQuestion(report, "catalog_only", "runtime_depth") {
+		t.Fatalf("questions = %#v, did not expect runtime_depth question without runtime inventory", report.Questions)
+	}
+}
+
 func TestReviewAnalysisFlagsScrapedSourceIdentity(t *testing.T) {
 	analysis := Analysis{
 		Summary: Summary{Total: 2, Generateable: 2},
@@ -254,6 +278,68 @@ func TestReviewAnalysisBuildsFidelityQueue(t *testing.T) {
 	}
 }
 
+func TestReviewAnalysisBuildsRuntimeDepthQueue(t *testing.T) {
+	analysis := Analysis{
+		Summary: Summary{Total: 2, Generateable: 2},
+		Entries: []Entry{
+			{
+				Path:         "devops/github.yaml",
+				Status:       StatusGenerateable,
+				Generateable: true,
+				Definition:   reviewDefinition("github", "GitHub", []connectordefinitions.ResourceFamily{reviewDetailedFamily("audit", "audit_event")}),
+			},
+			{
+				Path:         "identity/catalog_only.yaml",
+				Status:       StatusGenerateable,
+				Generateable: true,
+				Definition:   reviewDefinition("catalog_only", "Catalog Only", []connectordefinitions.ResourceFamily{reviewDetailedFamily("users", "identity_user")}),
+			},
+		},
+	}
+	inventory := RuntimeDepthInventory{
+		"github": {
+			SourceID:                "github",
+			PackagePath:             "sources/github",
+			Score:                   100,
+			HasSourcePackage:        true,
+			HasSourceCatalog:        true,
+			HasSourceImplementation: true,
+			HasSourceTests:          true,
+			HasFixturePair:          true,
+			HasDeployManifest:       true,
+			HasProjectorTests:       true,
+			HasEventContracts:       true,
+			HasCoverageContract:     true,
+			RuntimeFamilies:         []string{"audit"},
+		},
+	}
+
+	report := ReviewAnalysisWithRuntimeDepth(analysis, inventory)
+
+	if report.Summary.RuntimeDepth == nil {
+		t.Fatal("runtime depth summary = nil, want runtime depth summary")
+	}
+	if report.Summary.RuntimeDepth.ReferenceRuntimeSources != 1 {
+		t.Fatalf("reference runtime sources = %d, want 1", report.Summary.RuntimeDepth.ReferenceRuntimeSources)
+	}
+	if report.Summary.RuntimeDepth.NeedsRuntimeDepth != 1 {
+		t.Fatalf("needs runtime depth = %d, want 1", report.Summary.RuntimeDepth.NeedsRuntimeDepth)
+	}
+	if _, ok := runtimeDepthFor(report, "github"); ok {
+		t.Fatalf("runtime depth queue = %#v, did not expect github source", report.RuntimeDepthQueue)
+	}
+	candidate, ok := runtimeDepthFor(report, "catalog_only")
+	if !ok {
+		t.Fatalf("runtime depth queue = %#v, want catalog_only source", report.RuntimeDepthQueue)
+	}
+	if !containsString(candidate.Missing, "runtime:source_package") {
+		t.Fatalf("catalog_only missing = %v, want runtime:source_package", candidate.Missing)
+	}
+	if !hasQuestion(report, "catalog_only", "runtime_depth") {
+		t.Fatalf("questions = %#v, want runtime_depth question", report.Questions)
+	}
+}
+
 func reviewDefinition(sourceID string, displayName string, families []connectordefinitions.ResourceFamily) connectordefinitions.Definition {
 	return connectordefinitions.Definition{
 		SourceID:         sourceID,
@@ -340,6 +426,15 @@ func fidelityFor(report ReviewReport, sourceID string) (FidelityCandidate, bool)
 	return FidelityCandidate{}, false
 }
 
+func runtimeDepthFor(report ReviewReport, sourceID string) (RuntimeDepthCandidate, bool) {
+	for _, candidate := range report.RuntimeDepthQueue {
+		if candidate.SourceID == sourceID {
+			return candidate, true
+		}
+	}
+	return RuntimeDepthCandidate{}, false
+}
+
 func hasQueue(report ReviewReport, queueID string, sourceID string) bool {
 	for _, queue := range report.PromotionQueues {
 		if queue.ID != queueID {
@@ -366,4 +461,13 @@ func questionFor(report ReviewReport, sourceID string, category string) (ReviewQ
 		}
 	}
 	return ReviewQuestion{}, false
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/connectorcatalog/runtime_depth.go
+++ b/internal/connectorcatalog/runtime_depth.go
@@ -1,0 +1,396 @@
+package connectorcatalog
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RuntimeDepthInventory maps source IDs to repository evidence for a concrete
+// Source CDK package. Catalog-only connector definitions will not have an entry.
+type RuntimeDepthInventory map[string]RuntimeDepth
+
+// RuntimeDepth captures the repository-level implementation signals expected
+// from reference sources such as GitHub: source package, catalog, fixtures,
+// deploy manifest, and projector coverage.
+type RuntimeDepth struct {
+	SourceID                string   `json:"source_id"`
+	PackagePath             string   `json:"package_path,omitempty"`
+	Score                   int      `json:"score"`
+	Missing                 []string `json:"missing,omitempty"`
+	HasSourcePackage        bool     `json:"has_source_package,omitempty"`
+	HasSourceCatalog        bool     `json:"has_source_catalog,omitempty"`
+	HasSourceImplementation bool     `json:"has_source_implementation,omitempty"`
+	HasSourceTests          bool     `json:"has_source_tests,omitempty"`
+	HasReadFixtures         bool     `json:"has_read_fixtures,omitempty"`
+	HasDiscoverFixtures     bool     `json:"has_discover_fixtures,omitempty"`
+	HasFixturePair          bool     `json:"has_fixture_pair,omitempty"`
+	HasDeployManifest       bool     `json:"has_deploy_manifest,omitempty"`
+	HasProjectorTests       bool     `json:"has_projector_tests,omitempty"`
+	HasEventContracts       bool     `json:"has_event_contracts,omitempty"`
+	HasCoverageContract     bool     `json:"has_coverage_contract,omitempty"`
+	RuntimeFamilies         []string `json:"runtime_families,omitempty"`
+	ReadFixtureFamilies     []string `json:"read_fixture_families,omitempty"`
+	DiscoverFixtureFamilies []string `json:"discover_fixture_families,omitempty"`
+}
+
+type runtimeCatalogFields struct {
+	ID              string   `yaml:"id"`
+	RuntimeFamilies []string `yaml:"runtime_families"`
+	EventContracts  []struct {
+		Kind string `yaml:"kind"`
+	} `yaml:"event_contracts"`
+	CoverageContract *struct{} `yaml:"coverage_contract"`
+}
+
+// DiscoverRuntimeDepth scans repository source packages and sourceprojection
+// tests for reference-runtime evidence. Missing sources/ is treated as an empty
+// inventory so callers can use the review tool on partial checkouts.
+func DiscoverRuntimeDepth(root string) (RuntimeDepthInventory, error) {
+	root = filepath.Clean(strings.TrimSpace(root))
+	if root == "" || root == "." {
+		root = "."
+	}
+	repoRoot, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, fmt.Errorf("open repository root: %w", err)
+	}
+	defer func() {
+		_ = repoRoot.Close()
+	}()
+	inventory := RuntimeDepthInventory{}
+	projectorTests, err := discoverProjectorTestSources(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := fs.ReadDir(repoRoot.FS(), "sources")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return inventory, nil
+		}
+		return nil, fmt.Errorf("read sources directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sourceDir := filepath.Join(root, "sources", entry.Name())
+		depth, err := inspectRuntimeDepth(root, repoRoot, sourceDir, projectorTests)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(depth.SourceID) == "" {
+			continue
+		}
+		inventory[depth.SourceID] = depth
+	}
+	return inventory, nil
+}
+
+func inspectRuntimeDepth(root string, repoRoot *os.Root, sourceDir string, projectorTests map[string]struct{}) (RuntimeDepth, error) {
+	sourceID := filepath.Base(sourceDir)
+	depth := RuntimeDepth{
+		SourceID:         sourceID,
+		PackagePath:      slashRel(root, sourceDir),
+		HasSourcePackage: true,
+	}
+	if hasRegularFile(filepath.Join(sourceDir, "catalog.yaml")) {
+		depth.HasSourceCatalog = true
+		catalog, err := readRuntimeCatalogFields(repoRoot, filepath.ToSlash(filepath.Join(depth.PackagePath, "catalog.yaml")))
+		if err != nil {
+			return RuntimeDepth{}, err
+		}
+		if strings.TrimSpace(catalog.ID) != "" {
+			depth.SourceID = strings.TrimSpace(catalog.ID)
+		}
+		depth.RuntimeFamilies = normalizedList(catalog.RuntimeFamilies)
+		depth.HasEventContracts = len(catalog.EventContracts) > 0
+		depth.HasCoverageContract = catalog.CoverageContract != nil
+	}
+	depth.HasSourceImplementation = hasRegularFile(filepath.Join(sourceDir, "source.go"))
+	depth.HasSourceTests = hasSourceTests(sourceDir)
+	depth.HasDeployManifest = hasRegularFile(filepath.Join(sourceDir, "deploy.yaml"))
+	depth.ReadFixtureFamilies, depth.DiscoverFixtureFamilies = fixtureFamilies(sourceDir)
+	depth.HasReadFixtures = len(depth.ReadFixtureFamilies) > 0
+	depth.HasDiscoverFixtures = len(depth.DiscoverFixtureFamilies) > 0
+	depth.HasFixturePair = hasFixturePair(depth.ReadFixtureFamilies, depth.DiscoverFixtureFamilies)
+	_, depth.HasProjectorTests = projectorTests[depth.SourceID]
+	depth.Score, depth.Missing = runtimeDepthScore(depth)
+	sort.Strings(depth.RuntimeFamilies)
+	sort.Strings(depth.ReadFixtureFamilies)
+	sort.Strings(depth.DiscoverFixtureFamilies)
+	sort.Strings(depth.Missing)
+	return depth, nil
+}
+
+func readRuntimeCatalogFields(repoRoot *os.Root, path string) (runtimeCatalogFields, error) {
+	payload, err := repoRoot.ReadFile(path)
+	if err != nil {
+		return runtimeCatalogFields{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var catalog runtimeCatalogFields
+	if err := yaml.Unmarshal(payload, &catalog); err != nil {
+		return runtimeCatalogFields{}, fmt.Errorf("unmarshal %s: %w", path, err)
+	}
+	return catalog, nil
+}
+
+func runtimeDepthScore(depth RuntimeDepth) (int, []string) {
+	score := 0
+	var missing []string
+	if depth.HasSourcePackage {
+		score += 10
+	} else {
+		missing = append(missing, "runtime:source_package")
+	}
+	if depth.HasSourceCatalog {
+		score += 10
+	} else {
+		missing = append(missing, "runtime:catalog")
+	}
+	if depth.HasEventContracts && depth.HasCoverageContract {
+		score += 15
+	} else {
+		missing = append(missing, "runtime:catalog_contracts")
+	}
+	if depth.HasSourceImplementation {
+		score += 15
+	} else {
+		missing = append(missing, "runtime:source_go")
+	}
+	if depth.HasSourceTests {
+		score += 15
+	} else {
+		missing = append(missing, "runtime:source_tests")
+	}
+	if depth.HasFixturePair {
+		score += 15
+	} else {
+		missing = append(missing, "runtime:fixture_pair")
+	}
+	if depth.HasDeployManifest {
+		score += 10
+	} else {
+		missing = append(missing, "runtime:deploy_manifest")
+	}
+	if depth.HasProjectorTests {
+		score += 10
+	} else {
+		missing = append(missing, "runtime:projector_tests")
+	}
+	return score, missing
+}
+
+func hasRegularFile(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func hasSourceTests(sourceDir string) bool {
+	matches, err := filepath.Glob(filepath.Join(sourceDir, "*_test.go"))
+	return err == nil && len(matches) > 0
+}
+
+func fixtureFamilies(sourceDir string) ([]string, []string) {
+	testdata := filepath.Join(sourceDir, "testdata")
+	entries, err := os.ReadDir(testdata)
+	if err != nil {
+		return nil, nil
+	}
+	read := map[string]struct{}{}
+	discover := map[string]struct{}{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".json")
+		switch {
+		case name == "read":
+			read["default"] = struct{}{}
+		case strings.HasPrefix(name, "read_"):
+			read[strings.TrimPrefix(name, "read_")] = struct{}{}
+		case name == "discover":
+			discover["default"] = struct{}{}
+		case strings.HasPrefix(name, "discover_"):
+			discover[strings.TrimPrefix(name, "discover_")] = struct{}{}
+		}
+	}
+	return sortedKeys(read), sortedKeys(discover)
+}
+
+func hasFixturePair(read []string, discover []string) bool {
+	if len(read) == 0 || len(discover) == 0 {
+		return false
+	}
+	discovered := map[string]struct{}{}
+	for _, family := range discover {
+		discovered[family] = struct{}{}
+	}
+	for _, family := range read {
+		if _, ok := discovered[family]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func discoverProjectorTestSources(repoRoot *os.Root) (map[string]struct{}, error) {
+	sources := map[string]struct{}{}
+	const dir = "internal/sourceprojection"
+	err := fs.WalkDir(repoRoot.FS(), dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+		payload, err := repoRoot.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		for _, sourceID := range sourceIDsFromProjectorTest(string(payload)) {
+			sources[sourceID] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return sources, nil
+		}
+		return nil, err
+	}
+	return sources, nil
+}
+
+func sourceIDsFromProjectorTest(content string) []string {
+	file, err := parser.ParseFile(token.NewFileSet(), "sourceprojection_test.go", content, 0)
+	if err != nil {
+		return nil
+	}
+	eventSources := map[string]struct{}{}
+	kindSources := map[string]struct{}{}
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.ImportSpec:
+			return false
+		case *ast.KeyValueExpr:
+			key, ok := n.Key.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			value, ok := stringLiteralValue(n.Value)
+			if !ok {
+				return true
+			}
+			switch key.Name {
+			case "SourceId":
+				if sourceIDLooksStable(value) {
+					eventSources[value] = struct{}{}
+				}
+			case "Kind":
+				if sourceID, ok := sourceIDFromEventKindLiteral(value); ok {
+					kindSources[sourceID] = struct{}{}
+				}
+			}
+		case *ast.BasicLit:
+			value, ok := stringLiteralValue(n)
+			if !ok {
+				return true
+			}
+			if sourceID, ok := sourceIDFromEventKindLiteral(value); ok {
+				kindSources[sourceID] = struct{}{}
+			}
+		}
+		return true
+	})
+	covered := map[string]struct{}{}
+	for sourceID := range kindSources {
+		if _, ok := eventSources[sourceID]; ok {
+			covered[sourceID] = struct{}{}
+		}
+	}
+	return sortedKeys(covered)
+}
+
+func stringLiteralValue(expression ast.Expr) (string, bool) {
+	literal, ok := expression.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(value), true
+}
+
+func sourceIDFromEventKindLiteral(value string) (string, bool) {
+	if strings.Contains(value, "/") || strings.Contains(value, "@") || strings.Contains(value, "://") {
+		return "", false
+	}
+	parts := strings.Split(value, ".")
+	if len(parts) < 2 {
+		return "", false
+	}
+	for _, part := range parts {
+		if !sourceIDLooksStable(part) {
+			return "", false
+		}
+	}
+	return parts[0], true
+}
+
+func sourceIDLooksStable(value string) bool {
+	if len(value) < 2 {
+		return false
+	}
+	if value[0] < 'a' || value[0] > 'z' {
+		return false
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func normalizedList(values []string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		seen[value] = struct{}{}
+	}
+	return sortedKeys(seen)
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func slashRel(root string, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/connectorcatalog/runtime_depth_test.go
+++ b/internal/connectorcatalog/runtime_depth_test.go
@@ -1,0 +1,111 @@
+package connectorcatalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverRuntimeDepthScoresReferenceSourcePackage(t *testing.T) {
+	root := t.TempDir()
+	writeRuntimeDepthFile(t, root, "sources/github/catalog.yaml", `
+id: github
+name: GitHub
+emitted_kinds: [github.audit]
+runtime_families: [audit]
+coverage_contract:
+  dimensions:
+    - id: audit
+      type: audit_event
+event_contracts:
+  - kind: github.audit
+    schema_ref: github/audit/v1
+`)
+	writeRuntimeDepthFile(t, root, "sources/github/source.go", "package github\n")
+	writeRuntimeDepthFile(t, root, "sources/github/source_test.go", "package github\n")
+	writeRuntimeDepthFile(t, root, "sources/github/deploy.yaml", "sourceId: github\n")
+	writeRuntimeDepthFile(t, root, "sources/github/testdata/discover_audit.json", "[]")
+	writeRuntimeDepthFile(t, root, "sources/github/testdata/read_audit.json", "[]")
+	writeRuntimeDepthFile(t, root, "internal/sourceprojection/github_test.go", `package sourceprojection
+
+func TestProjectGitHubAudit(t *testing.T) {
+	_ = struct{ SourceId, Kind string }{SourceId: "github", Kind: "github.audit"}
+}
+`)
+
+	inventory, err := DiscoverRuntimeDepth(root)
+	if err != nil {
+		t.Fatalf("DiscoverRuntimeDepth() error = %v", err)
+	}
+	depth := inventory["github"]
+	if depth.Score != 100 {
+		t.Fatalf("runtime depth score = %d missing=%v, want 100", depth.Score, depth.Missing)
+	}
+	if !depth.HasSourcePackage || !depth.HasSourceCatalog || !depth.HasSourceImplementation || !depth.HasSourceTests || !depth.HasFixturePair || !depth.HasDeployManifest || !depth.HasProjectorTests {
+		t.Fatalf("runtime depth flags = %#v, want all reference-runtime flags", depth)
+	}
+	if got := depth.PackagePath; got != "sources/github" {
+		t.Fatalf("package path = %q, want sources/github", got)
+	}
+}
+
+func TestDiscoverRuntimeDepthQueuesPartialSourcePackage(t *testing.T) {
+	root := t.TempDir()
+	writeRuntimeDepthFile(t, root, "sources/example/catalog.yaml", `
+id: example
+name: Example
+coverage_contract:
+  dimensions: []
+`)
+	writeRuntimeDepthFile(t, root, "sources/example/source.go", "package example\n")
+
+	inventory, err := DiscoverRuntimeDepth(root)
+	if err != nil {
+		t.Fatalf("DiscoverRuntimeDepth() error = %v", err)
+	}
+	depth := inventory["example"]
+	if depth.Score >= runtimeDepthReviewThreshold {
+		t.Fatalf("runtime depth score = %d missing=%v, want below threshold", depth.Score, depth.Missing)
+	}
+	for _, want := range []string{"runtime:catalog_contracts", "runtime:deploy_manifest", "runtime:fixture_pair", "runtime:projector_tests", "runtime:source_tests"} {
+		if !containsString(depth.Missing, want) {
+			t.Fatalf("missing = %v, want %s", depth.Missing, want)
+		}
+	}
+}
+
+func TestSourceIDsFromProjectorTestRequiresSourceEvent(t *testing.T) {
+	got := sourceIDsFromProjectorTest(`package sourceprojection
+
+import (
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestProjectGRCAsset(t *testing.T) {
+	_ = &cerebrov1.EventEnvelope{SourceId: "grc", Kind: "grc.asset"}
+	_ = "github.org"
+	_ = "user@example.test"
+	_ = "10.0.1.2"
+	_ = ports.ProjectedEntity{EntityType: "github.code.repository"}
+}
+`)
+
+	if !containsString(got, "grc") {
+		t.Fatalf("source IDs = %v, want grc", got)
+	}
+	if containsString(got, "github") {
+		t.Fatalf("source IDs = %v, did not expect foreign graph entity source", got)
+	}
+}
+
+func writeRuntimeDepthFile(t *testing.T, root string, rel string, body string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/tools/connectorcatalogreview/main.go
+++ b/tools/connectorcatalogreview/main.go
@@ -15,6 +15,8 @@ func main() {
 	markdownOut := flag.String("markdown-out", "", "write a Markdown review report to this path")
 	jsonOut := flag.String("json-out", "", "write a JSON review report to this path")
 	maxItems := flag.Int("max-items", 40, "maximum rows/questions rendered in Markdown sections")
+	includeRuntimeDepth := flag.Bool("runtime-depth", true, "scan source packages and projector tests for runtime-depth evidence")
+	requireRuntimeDepth := flag.Bool("runtime-depth-required", false, "fail when runtime-depth evidence cannot be scanned")
 	flag.Parse()
 
 	catalogRoot := filepath.Join(*root, "internal", "connectorcatalog", "catalog")
@@ -23,7 +25,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "connector-catalog-review: %v\n", err)
 		os.Exit(1)
 	}
-	report := connectorcatalog.ReviewAnalysis(analysis)
+	reportResult, err := buildReviewReport(analysis, *root, *includeRuntimeDepth, *requireRuntimeDepth)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "connector-catalog-review: %v\n", err)
+		os.Exit(1)
+	}
+	if reportResult.RuntimeDepthWarning != nil {
+		fmt.Fprintf(os.Stderr, "connector-catalog-review: runtime depth unavailable; using catalog-only report: %v\n", reportResult.RuntimeDepthWarning)
+	}
+	report := reportResult.Report
 	if *jsonOut != "" {
 		if err := writeJSON(*jsonOut, report); err != nil {
 			fmt.Fprintf(os.Stderr, "connector-catalog-review: %v\n", err)
@@ -37,15 +47,40 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Printf("connector-catalog-review: sources=%d projected_families=%d cleanup_findings=%d questions=%d\n",
+	referenceRuntimeSources := 0
+	if report.Summary.RuntimeDepth != nil {
+		referenceRuntimeSources = report.Summary.RuntimeDepth.ReferenceRuntimeSources
+	}
+	fmt.Printf("connector-catalog-review: sources=%d projected_families=%d reference_runtime_sources=%d cleanup_findings=%d questions=%d\n",
 		report.Summary.Total,
 		report.Summary.ProjectedFamilies,
+		referenceRuntimeSources,
 		report.Summary.CleanupFindings,
 		report.Summary.Questions,
 	)
 	if *markdownOut == "" && *jsonOut == "" {
 		fmt.Print(markdown)
 	}
+}
+
+type reviewReportResult struct {
+	Report              connectorcatalog.ReviewReport
+	RuntimeDepthWarning error
+}
+
+func buildReviewReport(analysis connectorcatalog.Analysis, root string, includeRuntimeDepth bool, requireRuntimeDepth bool) (reviewReportResult, error) {
+	if !includeRuntimeDepth {
+		return reviewReportResult{Report: connectorcatalog.ReviewAnalysis(analysis)}, nil
+	}
+	runtimeInventory, err := connectorcatalog.DiscoverRuntimeDepth(root)
+	if err != nil {
+		report := connectorcatalog.ReviewAnalysis(analysis)
+		if requireRuntimeDepth {
+			return reviewReportResult{}, fmt.Errorf("discover runtime depth: %w", err)
+		}
+		return reviewReportResult{Report: report, RuntimeDepthWarning: err}, nil
+	}
+	return reviewReportResult{Report: connectorcatalog.ReviewAnalysisWithRuntimeDepth(analysis, runtimeInventory)}, nil
 }
 
 func writeJSON(path string, report connectorcatalog.ReviewReport) error {

--- a/tools/connectorcatalogreview/main_test.go
+++ b/tools/connectorcatalogreview/main_test.go
@@ -3,8 +3,51 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/writer/cerebro/internal/connectorcatalog"
 )
+
+func TestBuildReviewReportFallsBackWhenRuntimeDepthUnavailable(t *testing.T) {
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+
+	result, err := buildReviewReport(connectorcatalog.Analysis{}, missingRoot, true, false)
+	if err != nil {
+		t.Fatalf("buildReviewReport() error = %v", err)
+	}
+	if result.RuntimeDepthWarning == nil {
+		t.Fatal("runtime depth warning = nil, want warning")
+	}
+	if result.Report.Summary.RuntimeDepth != nil {
+		t.Fatalf("runtime depth summary = %#v, want nil fallback report", result.Report.Summary.RuntimeDepth)
+	}
+}
+
+func TestBuildReviewReportRequiresRuntimeDepthWhenConfigured(t *testing.T) {
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+
+	_, err := buildReviewReport(connectorcatalog.Analysis{}, missingRoot, true, true)
+	if err == nil {
+		t.Fatal("buildReviewReport() error = nil, want runtime depth error")
+	}
+	if !strings.Contains(err.Error(), "discover runtime depth") {
+		t.Fatalf("buildReviewReport() error = %v, want discover runtime depth context", err)
+	}
+}
+
+func TestBuildReviewReportIncludesRuntimeDepthWhenAvailable(t *testing.T) {
+	result, err := buildReviewReport(connectorcatalog.Analysis{}, t.TempDir(), true, false)
+	if err != nil {
+		t.Fatalf("buildReviewReport() error = %v", err)
+	}
+	if result.RuntimeDepthWarning != nil {
+		t.Fatalf("runtime depth warning = %v, want nil", result.RuntimeDepthWarning)
+	}
+	if result.Report.Summary.RuntimeDepth == nil {
+		t.Fatal("runtime depth summary = nil, want runtime depth summary")
+	}
+}
 
 func TestWriteFileDoesNotChmodExistingParentDirectory(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
## Summary
- Add a runtime-depth inventory pass for connector catalog review artifacts.
- Surface Source CDK package, catalog, test, fixture, deploy, and projector gaps per source.
- Add a runtime-depth review queue and Q&A category so catalog-only entries are visible in CI output.
- Normalize generated event kinds with the same hyphen handling as generated URN kinds.

## Impact
The catalog review now separates definition fidelity from source-runtime depth. The current report shows 794 definition-ready sources, 20 runtime-backed sources, 2 reference-runtime sources, and 792 sources that still need Source CDK package depth.

## Validation
- `go test ./internal/connectorcatalog ./tools/connectorcatalogreview ./tools/connectorcatalogfidelity -count=1`
- `make connector-catalog-maintenance`
- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen ./internal/sourceprojection ./internal/sourcecdk ./internal/sourceruntime ./tools/connectorcatalogreview ./tools/connectorcatalogfidelity -count=1`
- `make check-structural`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->