### PR TITLE
[codex] Harden GRC upload identifiers and projection recovery

### DIFF
--- a/internal/grcupload/upload.go
+++ b/internal/grcupload/upload.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -284,7 +283,7 @@ func recordURN(request UploadRequest, kind string, recordID string) string {
 	if recordID == "" {
 		return ""
 	}
-	recordID = url.QueryEscape(recordID)
+	recordID = cerebrourn.EncodeSegment(recordID)
 	var urn string
 	var err error
 	switch kind {

--- a/internal/grcupload/upload.go
+++ b/internal/grcupload/upload.go
@@ -70,18 +70,20 @@ type EventRef struct {
 }
 
 type Response struct {
-	UploadID       string     `json:"upload_id"`
-	Target         string     `json:"target"`
-	FileName       string     `json:"file_name"`
-	ContentType    string     `json:"content_type,omitempty"`
-	ReductoFileID  string     `json:"reducto_file_id,omitempty"`
-	ReductoParseID string     `json:"reducto_parse_id,omitempty"`
-	ParseStatus    string     `json:"parse_status,omitempty"`
-	TextPreview    string     `json:"text_preview,omitempty"`
-	ChunkCount     int        `json:"chunk_count,omitempty"`
-	PageCount      int        `json:"page_count,omitempty"`
-	Events         []EventRef `json:"events"`
-	GeneratedAt    time.Time  `json:"generated_at"`
+	UploadID           string     `json:"upload_id"`
+	Target             string     `json:"target"`
+	FileName           string     `json:"file_name"`
+	ContentType        string     `json:"content_type,omitempty"`
+	ReductoFileID      string     `json:"reducto_file_id,omitempty"`
+	ReductoParseID     string     `json:"reducto_parse_id,omitempty"`
+	ParseStatus        string     `json:"parse_status,omitempty"`
+	TextPreview        string     `json:"text_preview,omitempty"`
+	ChunkCount         int        `json:"chunk_count,omitempty"`
+	PageCount          int        `json:"page_count,omitempty"`
+	ProjectionStatus   string     `json:"projection_status,omitempty"`
+	ProjectionFailures int        `json:"projection_failures,omitempty"`
+	Events             []EventRef `json:"events"`
+	GeneratedAt        time.Time  `json:"generated_at"`
 }
 
 func BuildEvents(request UploadRequest, parsed ParsedDocument, now time.Time) ([]*cerebrov1.EventEnvelope, Response, error) {

--- a/internal/grcupload/upload.go
+++ b/internal/grcupload/upload.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -62,11 +63,12 @@ type UploadRequest struct {
 }
 
 type EventRef struct {
-	EventID   string `json:"event_id"`
-	EventKind string `json:"event_kind"`
-	SchemaRef string `json:"schema_ref"`
-	RecordID  string `json:"record_id,omitempty"`
-	RecordURN string `json:"record_urn,omitempty"`
+	EventID         string `json:"event_id"`
+	EventKind       string `json:"event_kind"`
+	SchemaRef       string `json:"schema_ref"`
+	RecordID        string `json:"record_id,omitempty"`
+	RecordURN       string `json:"record_urn,omitempty"`
+	LegacyRecordURN string `json:"legacy_record_urn,omitempty"`
 }
 
 type Response struct {
@@ -129,11 +131,12 @@ func BuildEvents(request UploadRequest, parsed ParsedDocument, now time.Time) ([
 		}
 		events = append(events, event)
 		refs = append(refs, EventRef{
-			EventID:   event.GetId(),
-			EventKind: event.GetKind(),
-			SchemaRef: event.GetSchemaRef(),
-			RecordID:  spec.RecordID,
-			RecordURN: spec.RecordURN,
+			EventID:         event.GetId(),
+			EventKind:       event.GetKind(),
+			SchemaRef:       event.GetSchemaRef(),
+			RecordID:        spec.RecordID,
+			RecordURN:       spec.RecordURN,
+			LegacyRecordURN: spec.LegacyRecordURN,
 		})
 	}
 	return events, Response{
@@ -153,11 +156,12 @@ func BuildEvents(request UploadRequest, parsed ParsedDocument, now time.Time) ([
 }
 
 type eventSpec struct {
-	Kind      string
-	SchemaRef string
-	RecordID  string
-	RecordURN string
-	Attrs     map[string]string
+	Kind            string
+	SchemaRef       string
+	RecordID        string
+	RecordURN       string
+	LegacyRecordURN string
+	Attrs           map[string]string
 }
 
 func policyEventSpecs(request UploadRequest, parsed ParsedDocument, uploadID string, now time.Time) []eventSpec {
@@ -191,8 +195,8 @@ func policyEventSpecs(request UploadRequest, parsed ParsedDocument, uploadID str
 		"upload_status":        "parsed",
 	})
 	return []eventSpec{
-		{Kind: "grc.policy", SchemaRef: SchemaRefPolicy, RecordID: policyID, RecordURN: recordURN(request, "grc.policy", policyID), Attrs: policyAttrs},
-		{Kind: "grc.document", SchemaRef: SchemaRefDocument, RecordID: documentID, RecordURN: recordURN(request, "grc.document", documentID), Attrs: documentAttrs},
+		recordEventSpec(request, "grc.policy", SchemaRefPolicy, policyID, policyAttrs),
+		recordEventSpec(request, "grc.document", SchemaRefDocument, documentID, documentAttrs),
 	}
 }
 
@@ -227,8 +231,20 @@ func vendorEventSpecs(request UploadRequest, parsed ParsedDocument, uploadID str
 		"upload_status":         "parsed",
 	})
 	return []eventSpec{
-		{Kind: "grc.vendor", SchemaRef: SchemaRefVendor, RecordID: vendorID, RecordURN: recordURN(request, "grc.vendor", vendorID), Attrs: vendorAttrs},
-		{Kind: "grc.assurance_document", SchemaRef: SchemaRefAssuranceDocument, RecordID: documentID, RecordURN: recordURN(request, "grc.assurance_document", documentID), Attrs: documentAttrs},
+		recordEventSpec(request, "grc.vendor", SchemaRefVendor, vendorID, vendorAttrs),
+		recordEventSpec(request, "grc.assurance_document", SchemaRefAssuranceDocument, documentID, documentAttrs),
+	}
+}
+
+func recordEventSpec(request UploadRequest, kind string, schemaRef string, recordID string, attrs map[string]string) eventSpec {
+	recordURN, legacyRecordURN := recordURNs(request, kind, recordID)
+	return eventSpec{
+		Kind:            kind,
+		SchemaRef:       schemaRef,
+		RecordID:        recordID,
+		RecordURN:       recordURN,
+		LegacyRecordURN: legacyRecordURN,
+		Attrs:           attrs,
 	}
 }
 
@@ -246,6 +262,9 @@ func buildEvent(request UploadRequest, spec eventSpec, uploadID string, index in
 	}
 	if spec.RecordURN != "" {
 		attrs["record_urn"] = spec.RecordURN
+	}
+	if spec.LegacyRecordURN != "" {
+		attrs["legacy_record_urn"] = spec.LegacyRecordURN
 	}
 	recordID := strings.TrimSpace(spec.RecordID)
 	if recordID == "" {
@@ -281,11 +300,28 @@ func buildEvent(request UploadRequest, spec eventSpec, uploadID string, index in
 }
 
 func recordURN(request UploadRequest, kind string, recordID string) string {
+	canonical, _ := recordURNs(request, kind, recordID)
+	return canonical
+}
+
+func recordURNs(request UploadRequest, kind string, recordID string) (string, string) {
+	recordID = strings.TrimSpace(recordID)
+	if recordID == "" {
+		return "", ""
+	}
+	canonical := mintRecordURN(request, kind, cerebrourn.EncodeSegment(recordID))
+	legacy := mintRecordURN(request, kind, url.QueryEscape(recordID))
+	if legacy == canonical {
+		legacy = ""
+	}
+	return canonical, legacy
+}
+
+func mintRecordURN(request UploadRequest, kind string, recordID string) string {
 	recordID = strings.TrimSpace(recordID)
 	if recordID == "" {
 		return ""
 	}
-	recordID = cerebrourn.EncodeSegment(recordID)
 	var urn string
 	var err error
 	switch kind {

--- a/internal/grcupload/upload_test.go
+++ b/internal/grcupload/upload_test.go
@@ -84,6 +84,9 @@ func TestBuildEventsBuildsPolicyAndDocumentEvents(t *testing.T) {
 	if got := document.GetAttributes()["document_type"]; got != "policy" {
 		t.Fatalf("document_type = %q, want policy", got)
 	}
+	if _, ok := document.GetAttributes()["legacy_record_urn"]; ok {
+		t.Fatal("document included legacy_record_urn for unchanged encoding")
+	}
 	if got := document.GetAttributes()["owner_id"]; got != "owner-1" {
 		t.Fatalf("owner_id = %q, want owner-1", got)
 	}
@@ -154,6 +157,40 @@ func TestBuildEventsBuildsVendorAndAssuranceDocumentEvents(t *testing.T) {
 	}
 	if got := document.GetAttributes()["document_type"]; got != "soc2" {
 		t.Fatalf("document_type = %q, want soc2", got)
+	}
+}
+
+func TestBuildEventsReportsLegacyRecordURNWhenEncodingChanged(t *testing.T) {
+	now := time.Date(2026, 6, 28, 10, 30, 0, 0, time.UTC)
+	events, response, err := BuildEvents(UploadRequest{
+		Target:   TargetPolicy,
+		TenantID: "tenant-1",
+		FileName: "Access Policy.pdf",
+		Fields: map[string]string{
+			"policy_id":   "Access Policy+Admin",
+			"document_id": "Access Policy:v2",
+		},
+	}, ParsedDocument{}, now)
+	if err != nil {
+		t.Fatalf("BuildEvents() error = %v", err)
+	}
+	if got, want := response.Events[0].RecordURN, "urn:cerebro:tenant-1:policy:cerebro_upload:Access%20Policy+Admin"; got != want {
+		t.Fatalf("policy record_urn = %q, want %q", got, want)
+	}
+	if got, want := response.Events[0].LegacyRecordURN, "urn:cerebro:tenant-1:policy:cerebro_upload:Access+Policy%2BAdmin"; got != want {
+		t.Fatalf("policy legacy_record_urn = %q, want %q", got, want)
+	}
+	if got, want := events[0].GetAttributes()["legacy_record_urn"], response.Events[0].LegacyRecordURN; got != want {
+		t.Fatalf("policy legacy_record_urn attr = %q, want %q", got, want)
+	}
+	if got, want := response.Events[1].RecordURN, "urn:cerebro:tenant-1:document:cerebro_upload:Access%20Policy%3Av2"; got != want {
+		t.Fatalf("document record_urn = %q, want %q", got, want)
+	}
+	if got, want := response.Events[1].LegacyRecordURN, "urn:cerebro:tenant-1:document:cerebro_upload:Access+Policy%3Av2"; got != want {
+		t.Fatalf("document legacy_record_urn = %q, want %q", got, want)
+	}
+	if got, want := events[1].GetAttributes()["legacy_record_urn"], response.Events[1].LegacyRecordURN; got != want {
+		t.Fatalf("document legacy_record_urn attr = %q, want %q", got, want)
 	}
 }
 

--- a/internal/sourcehttp/grcupload/handler.go
+++ b/internal/sourcehttp/grcupload/handler.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/grcupload"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const maxUploadBytes int64 = 32 << 20
@@ -93,11 +95,13 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, err)
 		return
 	}
+	sourceID := firstNonEmpty(fields["source_id"], scope.SourceID)
+	runtimeID := firstNonEmpty(fields["runtime_id"], scope.RuntimeID)
 	events, response, err := grcupload.BuildEvents(grcupload.UploadRequest{
 		Target:      h.options.Target,
 		TenantID:    tenantID,
-		SourceID:    firstNonEmpty(fields["source_id"], scope.SourceID),
-		RuntimeID:   firstNonEmpty(fields["runtime_id"], scope.RuntimeID),
+		SourceID:    sourceID,
+		RuntimeID:   runtimeID,
 		ActorUserID: h.actorUserID(r.Context()),
 		FileName:    header.Filename,
 		ContentType: contentType,
@@ -108,22 +112,123 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, err)
 		return
 	}
-	for _, event := range events {
-		if err := h.options.AppendLog.Append(r.Context(), event); err != nil {
-			h.writeError(w, fmt.Errorf("%w: append upload event: %w", grcupload.ErrRuntimeUnavailable, err))
-			return
-		}
+	appended, err := h.appendEvents(r.Context(), events)
+	if err != nil {
+		wrapped := fmt.Errorf("%w: append upload event: %w", grcupload.ErrRuntimeUnavailable, err)
+		emitUploadTelemetry(r.Context(), uploadTelemetry{
+			target:         h.options.Target,
+			tenantID:       tenantID,
+			sourceID:       sourceID,
+			runtimeID:      runtimeID,
+			status:         "append_failed",
+			eventsBuilt:    len(events),
+			eventsAppended: appended,
+			err:            wrapped,
+		})
+		h.writeError(w, wrapped)
+		return
 	}
-	for _, event := range events {
-		if _, err := h.options.Projector.Project(r.Context(), event); err != nil {
-			h.writeError(w, fmt.Errorf("%w: project upload event: %w", grcupload.ErrRuntimeUnavailable, err))
-			return
-		}
+	projection := h.projectEvents(r.Context(), events)
+	status := "accepted"
+	if projection.err != nil {
+		status = "accepted_with_projection_errors"
 	}
-	if h.options.BumpCache != nil {
+	emitUploadTelemetry(r.Context(), uploadTelemetry{
+		target:             h.options.Target,
+		tenantID:           tenantID,
+		sourceID:           sourceID,
+		runtimeID:          runtimeID,
+		status:             status,
+		eventsBuilt:        len(events),
+		eventsAppended:     appended,
+		eventsProjected:    projection.eventsProjected,
+		entitiesProjected:  projection.entitiesProjected,
+		linksProjected:     projection.linksProjected,
+		projectionFailures: projection.failures,
+		err:                projection.err,
+	})
+	if h.options.BumpCache != nil && projection.eventsProjected > 0 {
 		h.options.BumpCache(r.Context(), tenantID)
 	}
 	h.writeJSON(w, http.StatusAccepted, response)
+}
+
+func (h Handler) appendEvents(ctx context.Context, events []*cerebrov1.EventEnvelope) (int, error) {
+	appended := 0
+	for _, event := range events {
+		if err := h.options.AppendLog.Append(ctx, event); err != nil {
+			return appended, err
+		}
+		appended++
+	}
+	return appended, nil
+}
+
+type projectionSummary struct {
+	eventsProjected   int
+	entitiesProjected uint32
+	linksProjected    uint32
+	failures          int
+	err               error
+}
+
+func (h Handler) projectEvents(ctx context.Context, events []*cerebrov1.EventEnvelope) projectionSummary {
+	var summary projectionSummary
+	for _, event := range events {
+		result, err := h.options.Projector.Project(ctx, event)
+		if err != nil {
+			summary.failures++
+			if summary.err == nil {
+				summary.err = err
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				break
+			}
+			continue
+		}
+		summary.eventsProjected++
+		summary.entitiesProjected += result.EntitiesProjected
+		summary.linksProjected += result.LinksProjected
+	}
+	return summary
+}
+
+type uploadTelemetry struct {
+	target             grcupload.Target
+	tenantID           string
+	sourceID           string
+	runtimeID          string
+	status             string
+	eventsBuilt        int
+	eventsAppended     int
+	eventsProjected    int
+	entitiesProjected  uint32
+	linksProjected     uint32
+	projectionFailures int
+	err                error
+}
+
+func emitUploadTelemetry(ctx context.Context, summary uploadTelemetry) {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "target", Value: string(summary.target)},
+		telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(summary.tenantID)},
+		telemetry.Field{Key: "source_id", Value: strings.TrimSpace(summary.sourceID)},
+		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(summary.runtimeID)},
+		telemetry.Field{Key: "status", Value: strings.TrimSpace(summary.status)},
+		telemetry.Field{Key: "events_built", Value: summary.eventsBuilt},
+		telemetry.Field{Key: "events_appended", Value: summary.eventsAppended},
+		telemetry.Field{Key: "events_projected", Value: summary.eventsProjected},
+		telemetry.Field{Key: "entities_projected", Value: summary.entitiesProjected},
+		telemetry.Field{Key: "links_projected", Value: summary.linksProjected},
+		telemetry.Field{Key: "projection_failures", Value: summary.projectionFailures},
+	)
+	if summary.err != nil {
+		attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(summary.err)})
+	}
+	telemetry.Event(ctx, "cerebro.grc.upload", attrs)
+	if summary.err != nil {
+		telemetry.CaptureError(ctx, "cerebro.grc.upload.error", summary.err, attrs.WithField(telemetry.Field{Key: "operation", Value: strings.TrimSpace(summary.status)}))
+	}
 }
 
 func (h Handler) scope(r *http.Request) (Scope, error) {

--- a/internal/sourcehttp/grcupload/handler.go
+++ b/internal/sourcehttp/grcupload/handler.go
@@ -130,8 +130,11 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	projection := h.projectEvents(r.Context(), events)
 	status := "accepted"
+	response.ProjectionStatus = "projected"
 	if projection.err != nil {
 		status = "accepted_with_projection_errors"
+		response.ProjectionStatus = status
+		response.ProjectionFailures = projection.failures
 	}
 	emitUploadTelemetry(r.Context(), uploadTelemetry{
 		target:             h.options.Target,

--- a/internal/sourcehttp/grcupload/handler_test.go
+++ b/internal/sourcehttp/grcupload/handler_test.go
@@ -118,6 +118,9 @@ func TestHandlerAcceptsUploadWithEncodedRecordIDs(t *testing.T) {
 	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
+	if got, want := payload.ProjectionStatus, "projected"; got != want {
+		t.Fatalf("projection_status = %q, want %q", got, want)
+	}
 	if len(payload.Events) != 2 {
 		t.Fatalf("response events = %d, want 2", len(payload.Events))
 	}
@@ -170,6 +173,16 @@ func TestHandlerAcceptsUploadWhenProjectionFailsAfterAppend(t *testing.T) {
 
 	if response.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d", response.Code, http.StatusAccepted)
+	}
+	var payload grcupload.Response
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, want := payload.ProjectionStatus, "accepted_with_projection_errors"; got != want {
+		t.Fatalf("projection_status = %q, want %q", got, want)
+	}
+	if got, want := payload.ProjectionFailures, 1; got != want {
+		t.Fatalf("projection_failures = %d, want %d", got, want)
 	}
 	if len(appendLog.events) != 2 {
 		t.Fatalf("appended events = %d, want 2", len(appendLog.events))

--- a/internal/sourcehttp/grcupload/handler_test.go
+++ b/internal/sourcehttp/grcupload/handler_test.go
@@ -133,6 +133,9 @@ func TestHandlerAcceptsUploadWithEncodedRecordIDs(t *testing.T) {
 	if got, want := payload.Events[1].RecordURN, "urn:cerebro:tenant-1:document:cerebro_upload:Access%20Policy%3Av2"; got != want {
 		t.Fatalf("document record_urn = %q, want %q", got, want)
 	}
+	if got, want := payload.Events[1].LegacyRecordURN, "urn:cerebro:tenant-1:document:cerebro_upload:Access+Policy%3Av2"; got != want {
+		t.Fatalf("document legacy_record_urn = %q, want %q", got, want)
+	}
 	if len(appendLog.events) != 2 || len(projector.events) != 2 {
 		t.Fatalf("append/project counts = %d/%d, want 2/2", len(appendLog.events), len(projector.events))
 	}
@@ -141,6 +144,9 @@ func TestHandlerAcceptsUploadWithEncodedRecordIDs(t *testing.T) {
 	}
 	if got, want := appendLog.events[0].GetAttributes()["record_urn"], payload.Events[0].RecordURN; got != want {
 		t.Fatalf("record_urn attribute = %q, want %q", got, want)
+	}
+	if got, want := appendLog.events[1].GetAttributes()["legacy_record_urn"], payload.Events[1].LegacyRecordURN; got != want {
+		t.Fatalf("legacy_record_urn attribute = %q, want %q", got, want)
 	}
 	if cacheBumps != 1 {
 		t.Fatalf("cache bumps = %d, want 1", cacheBumps)

--- a/internal/sourcehttp/grcupload/handler_test.go
+++ b/internal/sourcehttp/grcupload/handler_test.go
@@ -3,6 +3,7 @@ package grcuploadhttp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"mime/multipart"
@@ -80,6 +81,104 @@ func TestHandlerAppendsAllEventsBeforeProjecting(t *testing.T) {
 	}
 	if len(projector.events) != 0 {
 		t.Fatalf("projected events = %d, want 0 before all appends succeed", len(projector.events))
+	}
+}
+
+func TestHandlerAcceptsUploadWithEncodedRecordIDs(t *testing.T) {
+	appendLog := &recordingAppendLog{}
+	projector := &recordingProjector{}
+	cacheBumps := 0
+	handler := NewHandler(Options{
+		Target: grcupload.TargetPolicy,
+		ParserFactory: func() (grcupload.Parser, error) {
+			return stubParser{parsed: grcupload.ParsedDocument{ProviderFileID: "file-1", ParseID: "parse-1", Status: "completed"}}, nil
+		},
+		AppendLog: appendLog,
+		Projector: projector,
+		ResolveScope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: r.URL.Query().Get("tenant_id"), SourceID: "grc", RuntimeID: "runtime-1"}, nil
+		},
+		AuthorizeTenant: func(context.Context, string) error { return nil },
+		BumpCache: func(context.Context, string) {
+			cacheBumps++
+		},
+		Now: fixedUploadTime,
+	})
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, uploadRequest(t, "?tenant_id=tenant-1", map[string]string{
+		"policy_id":   "ISO:27001/2022",
+		"document_id": "Access Policy:v2",
+	}))
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusAccepted)
+	}
+	var payload grcupload.Response
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Events) != 2 {
+		t.Fatalf("response events = %d, want 2", len(payload.Events))
+	}
+	if got, want := payload.Events[0].RecordID, "ISO:27001/2022"; got != want {
+		t.Fatalf("policy record_id = %q, want %q", got, want)
+	}
+	if got, want := payload.Events[0].RecordURN, "urn:cerebro:tenant-1:policy:cerebro_upload:ISO%3A27001%2F2022"; got != want {
+		t.Fatalf("policy record_urn = %q, want %q", got, want)
+	}
+	if got, want := payload.Events[1].RecordURN, "urn:cerebro:tenant-1:document:cerebro_upload:Access%20Policy%3Av2"; got != want {
+		t.Fatalf("document record_urn = %q, want %q", got, want)
+	}
+	if len(appendLog.events) != 2 || len(projector.events) != 2 {
+		t.Fatalf("append/project counts = %d/%d, want 2/2", len(appendLog.events), len(projector.events))
+	}
+	if got, want := appendLog.events[0].GetAttributes()["policy_id"], "ISO:27001/2022"; got != want {
+		t.Fatalf("policy_id attribute = %q, want %q", got, want)
+	}
+	if got, want := appendLog.events[0].GetAttributes()["record_urn"], payload.Events[0].RecordURN; got != want {
+		t.Fatalf("record_urn attribute = %q, want %q", got, want)
+	}
+	if cacheBumps != 1 {
+		t.Fatalf("cache bumps = %d, want 1", cacheBumps)
+	}
+}
+
+func TestHandlerAcceptsUploadWhenProjectionFailsAfterAppend(t *testing.T) {
+	appendLog := &recordingAppendLog{}
+	projector := &recordingProjector{failAt: 1}
+	cacheBumps := 0
+	handler := NewHandler(Options{
+		Target: grcupload.TargetPolicy,
+		ParserFactory: func() (grcupload.Parser, error) {
+			return stubParser{parsed: grcupload.ParsedDocument{ProviderFileID: "file-1", ParseID: "parse-1", Status: "completed"}}, nil
+		},
+		AppendLog: appendLog,
+		Projector: projector,
+		ResolveScope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: r.URL.Query().Get("tenant_id"), SourceID: "grc", RuntimeID: "runtime-1"}, nil
+		},
+		AuthorizeTenant: func(context.Context, string) error { return nil },
+		BumpCache: func(context.Context, string) {
+			cacheBumps++
+		},
+		Now: fixedUploadTime,
+	})
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, uploadRequest(t, "?tenant_id=tenant-1", map[string]string{"policy_id": "access"}))
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusAccepted)
+	}
+	if len(appendLog.events) != 2 {
+		t.Fatalf("appended events = %d, want 2", len(appendLog.events))
+	}
+	if len(projector.events) != 2 {
+		t.Fatalf("projected events = %d, want both events attempted", len(projector.events))
+	}
+	if cacheBumps != 1 {
+		t.Fatalf("cache bumps = %d, want 1 for the successful projection", cacheBumps)
 	}
 }
 

--- a/internal/urn/urn.go
+++ b/internal/urn/urn.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -87,6 +88,12 @@ func TenantID(raw string) string {
 func SameTenant(raw string, tenantID string) bool {
 	tenant := strings.TrimSpace(tenantID)
 	return tenant != "" && TenantID(raw) == tenant
+}
+
+// EncodeSegment escapes provider-controlled identifiers for Cerebro's colon-delimited URN parts.
+func EncodeSegment(value string) string {
+	escaped := url.PathEscape(strings.TrimSpace(value))
+	return strings.ReplaceAll(escaped, ":", "%3A")
 }
 
 func StableExternalID(value string, emptyFallback string) string {

--- a/internal/urn/urn_test.go
+++ b/internal/urn/urn_test.go
@@ -47,6 +47,40 @@ func TestMintAllowsKindOnlyProjectionURNs(t *testing.T) {
 	}
 }
 
+func TestEncodeSegment(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", value: "", want: ""},
+		{name: "whitespace", value: "   ", want: ""},
+		{name: "colon and slash", value: " ISO:27001/2022 ", want: "ISO%3A27001%2F2022"},
+		{name: "space", value: "Access Policy:v2", want: "Access%20Policy%3Av2"},
+		{name: "literal plus", value: "role/Admin+Owner", want: "role%2FAdmin+Owner"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EncodeSegment(tc.value); got != tc.want {
+				t.Fatalf("EncodeSegment(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMintWithEncodedSegmentKeepsProviderIDInOnePart(t *testing.T) {
+	raw, err := Mint("writer", "policy", "provider", EncodeSegment("ISO:27001/2022"))
+	if err != nil {
+		t.Fatalf("Mint() error = %v", err)
+	}
+	parsed, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(parsed.Parts) != 2 || parsed.Parts[0] != "provider" || parsed.Parts[1] != "ISO%3A27001%2F2022" {
+		t.Fatalf("Parse().Parts = %#v", parsed.Parts)
+	}
+}
+
 func TestParseRejectsInvalidValue(t *testing.T) {
 	for _, raw := range []string{
 		"",


### PR DESCRIPTION
## Summary
- centralize encoding for provider-supplied identifier segments
- accept uploads once event append succeeds while reporting projection failures through telemetry
- cover multipart upload flows for encoded record IDs and projection recovery

## Validation
- go test -count=1 ./internal/urn ./internal/grcupload ./internal/sourcehttp/grcupload ./internal/sourcehttp/reducto
- make check-structural
- make check-structural-test
- make check-arch
- make lint