### PR TITLE
[codex] deepen box source runtime fixtures

### DIFF
--- a/sources/box/deploy.yaml
+++ b/sources/box/deploy.yaml
@@ -11,3 +11,21 @@ runtimes:
       stale_after_seconds: "86400"
       per_page: "100"
       token: env:BOX_TOKEN
+  - localId: content-assets
+    config:
+      family: content_assets
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /2.0/users/me
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      token: env:BOX_TOKEN
+  - localId: audit-events
+    config:
+      family: audit_events
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /2.0/users/me
+      expected_cadence_seconds: "3600"
+      stale_after_seconds: "7200"
+      per_page: "100"
+      token: env:BOX_TOKEN

--- a/sources/box/fixture.go
+++ b/sources/box/fixture.go
@@ -1,0 +1,62 @@
+package box
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+//go:embed testdata/*.json
+var fixtureFS embed.FS
+
+// NewFixture constructs the deterministic Box source used by tests.
+func NewFixture() (sourcecdk.Source, error) {
+	spec, err := loadSpec()
+	if err != nil {
+		return nil, err
+	}
+	families := []sourcecdk.FixtureFamily{}
+	for _, family := range []string{familyUsers, familyContentAssets, familyAuditEvents} {
+		urns, err := sourcecdk.LoadFixtureURNs(fixtureFS, "testdata/discover_"+family+".json")
+		if err != nil {
+			return nil, err
+		}
+		events, err := sourcecdk.LoadFixtureEvents(fixtureFS, "testdata/read_"+family+".json")
+		if err != nil {
+			return nil, err
+		}
+		families = append(families, sourcecdk.FixtureFamily{Name: family, URNs: urns, Events: events})
+	}
+	return sourcecdk.NewFixtureSource(sourcecdk.FixtureSourceOptions{
+		Spec:          spec,
+		DefaultFamily: defaultFamily,
+		Check:         checkFixtureConfig,
+		ResolveFamily: resolveFixtureFamily,
+		Families:      families,
+	})
+}
+
+func checkFixtureConfig(_ context.Context, cfg sourcecdk.Config) error {
+	if fixtureTenantID(cfg) == "" {
+		return fmt.Errorf("tenant_id is required")
+	}
+	return nil
+}
+
+func resolveFixtureFamily(cfg sourcecdk.Config) (string, error) {
+	if fixtureTenantID(cfg) == "" {
+		return "", fmt.Errorf("tenant_id is required")
+	}
+	family := strings.TrimSpace(sourcecdk.ConfigValue(cfg, "family"))
+	if family == "" {
+		return defaultFamily, nil
+	}
+	return family, nil
+}
+
+func fixtureTenantID(cfg sourcecdk.Config) string {
+	return strings.TrimSpace(sourcecdk.ConfigValue(cfg, "tenant_id"))
+}

--- a/sources/box/source_test.go
+++ b/sources/box/source_test.go
@@ -52,3 +52,47 @@ func TestSourceCheckAndRead(t *testing.T) {
 		t.Fatalf("event id is empty: %#v", event)
 	}
 }
+
+func TestNewFixtureReplaysBoxFamilies(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	familyConfigs := map[string]sourcecdk.Config{}
+	for _, family := range []string{familyUsers, familyContentAssets, familyAuditEvents} {
+		familyConfigs[family] = sourcecdk.NewConfig(map[string]string{
+			"family":    family,
+			"tenant_id": "tenant",
+		})
+	}
+	sourcecdk.RunFixtureSuite(t, context.Background(), sourcecdk.FixtureSuiteOptions{
+		Source:          source,
+		FamilyConfigs:   familyConfigs,
+		RequireDiscover: true,
+	})
+	for _, tt := range []struct {
+		family          string
+		kind            string
+		wantResourceURN string
+	}{
+		{family: familyUsers, kind: "box.users", wantResourceURN: "urn:cerebro:tenant:runtime_users:user-1"},
+		{family: familyContentAssets, kind: "box.content_assets", wantResourceURN: "urn:cerebro:tenant:runtime_content_assets:file-1"},
+		{family: familyAuditEvents, kind: "box.audit_events", wantResourceURN: "urn:cerebro:tenant:runtime_content_assets:file-1"},
+	} {
+		t.Run(tt.family, func(t *testing.T) {
+			pull, err := source.Read(context.Background(), familyConfigs[tt.family], nil)
+			if err != nil {
+				t.Fatalf("Read(%s) error = %v", tt.family, err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("events = %d, want 1", len(pull.Events))
+			}
+			if got := pull.Events[0].Kind; got != tt.kind {
+				t.Fatalf("event kind = %q, want %q", got, tt.kind)
+			}
+			if got := pull.Events[0].Attributes["resource_urn"]; got != tt.wantResourceURN {
+				t.Fatalf("resource_urn = %q, want %q", got, tt.wantResourceURN)
+			}
+		})
+	}
+}

--- a/sources/box/testdata/discover_audit_events.json
+++ b/sources/box/testdata/discover_audit_events.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:runtime_audit_events:audit-1"
+]

--- a/sources/box/testdata/discover_content_assets.json
+++ b/sources/box/testdata/discover_content_assets.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:runtime_content_assets:file-1"
+]

--- a/sources/box/testdata/discover_users.json
+++ b/sources/box/testdata/discover_users.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:runtime_users:user-1"
+]

--- a/sources/box/testdata/read_audit_events.json
+++ b/sources/box/testdata/read_audit_events.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "box-audit-audit-1",
+    "tenant_id": "tenant",
+    "source_id": "box",
+    "kind": "box.audit_events",
+    "occurred_at": "2026-06-01T00:00:00Z",
+    "schema_ref": "box/audit_events/v1",
+    "payload": {
+      "id": "audit-1",
+      "event_type": "file.downloaded",
+      "actor": {
+        "id": "user-1",
+        "email": "user@example.test",
+        "name": "User One"
+      },
+      "resource": {
+        "id": "file-1",
+        "type": "file",
+        "name": "Security Evidence.pdf"
+      }
+    },
+    "attributes": {
+      "actor_email": "user@example.test",
+      "actor_id": "user-1",
+      "actor_name": "User One",
+      "event_type": "file.downloaded",
+      "resource_id": "file-1",
+      "resource_name": "Security Evidence.pdf",
+      "resource_type": "file",
+      "resource_urn": "urn:cerebro:tenant:runtime_content_assets:file-1",
+      "source_event_id": "audit-1",
+      "tenant_id": "tenant"
+    }
+  }
+]

--- a/sources/box/testdata/read_content_assets.json
+++ b/sources/box/testdata/read_content_assets.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "box-content-asset-file-1",
+    "tenant_id": "tenant",
+    "source_id": "box",
+    "kind": "box.content_assets",
+    "occurred_at": "2026-06-01T00:00:00Z",
+    "schema_ref": "box/content_assets/v1",
+    "payload": {
+      "id": "file-1",
+      "type": "file",
+      "name": "Security Evidence.pdf",
+      "etag": "1",
+      "owned_by": {
+        "id": "user-1",
+        "login": "user@example.test",
+        "name": "User One"
+      },
+      "created_at": "2026-05-15T00:00:00Z",
+      "modified_at": "2026-06-01T00:00:00Z"
+    },
+    "attributes": {
+      "evidence_cas_digest": "sha256:test",
+      "evidence_cas_uri": "cas://cases/box-content-asset-file-1",
+      "resource_id": "file-1",
+      "resource_name": "Security Evidence.pdf",
+      "resource_type": "file",
+      "resource_urn": "urn:cerebro:tenant:runtime_content_assets:file-1",
+      "source_event_id": "file-1",
+      "tenant_id": "tenant"
+    }
+  }
+]

--- a/sources/box/testdata/read_users.json
+++ b/sources/box/testdata/read_users.json
@@ -1,14 +1,31 @@
-{
-  "items": [
-    {
-      "evidence_cas_digest": "sha256:test",
-      "evidence_cas_uri": "cas://cases/record-1",
-      "id": "record-1",
-      "name": "Record One",
-      "resource_id": "record-1",
-      "resource_type": "asset",
-      "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1",
-      "updated_at": "2026-06-01T00:00:00Z"
+[
+  {
+    "id": "box-user-user-1",
+    "tenant_id": "tenant",
+    "source_id": "box",
+    "kind": "box.users",
+    "occurred_at": "2026-06-01T00:00:00Z",
+    "schema_ref": "box/users/v1",
+    "payload": {
+      "id": "user-1",
+      "name": "User One",
+      "login": "user@example.test",
+      "email": "user@example.test",
+      "status": "active",
+      "created_at": "2026-05-01T00:00:00Z"
+    },
+    "attributes": {
+      "display_name": "User One",
+      "email": "user@example.test",
+      "login": "user@example.test",
+      "resource_id": "user-1",
+      "resource_name": "User One",
+      "resource_type": "identity_user",
+      "resource_urn": "urn:cerebro:tenant:runtime_users:user-1",
+      "source_event_id": "user-1",
+      "status": "active",
+      "tenant_id": "tenant",
+      "user_id": "user-1"
     }
-  ]
-}
+  }
+]


### PR DESCRIPTION
## Summary
- add deterministic Source CDK fixtures for Box users, content assets, and audit events
- replay all Box runtime families through `RunFixtureSuite` with discover coverage
- schedule Box content assets and audit events in the deploy manifest alongside users

## Validation
- `go test ./sources/box ./internal/sourceprojection ./internal/connectorcatalog -count=1`
- `make connector-catalog-maintenance`
- `make check-structural check-structural-test check-arch`
- `make droid-review-preflight`
- `go test -p 4 ./...`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->