### PR TITLE
[codex] add GRC list metadata

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -349,15 +349,15 @@ func (a *App) grcFindingTrends(r *http.Request, runtimes []*cerebrov1.SourceRunt
 		Framework: filter.Framework,
 	})
 }
-
 func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {
-	items, err := a.grcFindingItemsFromRequest(r, 0)
+	items, limit, err := a.grcFindingItemsFromRequest(r, 0)
 	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"findings":     items,
+		"meta":         map[string]any{"limit": limit, "returned": len(items), "truncated": limit > 0 && len(items) >= int(limit)},
 		"generated_at": time.Now().UTC(),
 	})
 }
@@ -365,14 +365,14 @@ func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {
 // grcFindingItemsFromRequest gathers risk-inbox finding items for a request,
 // shared by the JSON list handler and the CSV export. A non-zero limitOverride
 // replaces the request's scope limit (the export pulls the full dataset).
-func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) ([]grcFindingItem, error) {
+func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) ([]grcFindingItem, uint32, error) {
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	runtimes, err := a.grcListRuntimes(r, scope)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	limit := scope.Limit
 	if limitOverride > 0 {
@@ -386,9 +386,9 @@ func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) 
 	}
 	drilldown, err := grctrends.ParseDrilldownFilters(r.URL.Query())
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
+		return nil, 0, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
 	}
-	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{
+	filter := grcFindingFilter{
 		FindingID:           strings.TrimSpace(r.URL.Query().Get("finding_id")),
 		RuleID:              strings.TrimSpace(r.URL.Query().Get("rule_id")),
 		Severity:            strings.TrimSpace(r.URL.Query().Get("severity")),
@@ -405,26 +405,26 @@ func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) 
 		MaxAgeDays:          drilldown.MaxAgeDays,
 		SLAStatus:           drilldown.SLAStatus,
 		Limit:               limit,
-	})
+	}
+	findings, err := a.grcListFindingRecords(r, runtimes, filter)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	evidenceCounts, counted, err := a.grcEvidenceCountsByFindingID(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings)})
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if !counted {
 		evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: limit})
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		evidenceCounts = grcEvidenceCounts(evidence)
 	}
 	items := grcFindingItems(findings, grcRuntimeSourceIDs(runtimes), evidenceCounts)
 	grcApplyFindingDispositions(items, a.grcFindingDispositions(r, findings))
-	return items, nil
+	return items, limit, nil
 }
-
 func (a *App) handleGRCControls(w http.ResponseWriter, r *http.Request) {
 	controls, err := a.grcControlItemsFromRequest(r, 0)
 	if err != nil {
@@ -503,6 +503,7 @@ func (a *App) handleGRCEvidence(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"evidence":     grcEvidenceItems(evidence, grcFindingTitleMap(findings)),
+		"meta":         map[string]any{"limit": scope.Limit, "returned": len(evidence), "truncated": scope.Limit > 0 && len(evidence) >= int(scope.Limit)},
 		"generated_at": time.Now().UTC(),
 	})
 }

--- a/internal/bootstrap/grc_export.go
+++ b/internal/bootstrap/grc_export.go
@@ -15,7 +15,7 @@ import (
 const grcExportLimit = grcMaxLimit
 
 func (a *App) handleGRCFindingsExport(w http.ResponseWriter, r *http.Request) {
-	items, err := a.grcFindingItemsFromRequest(r, grcExportLimit)
+	items, _, err := a.grcFindingItemsFromRequest(r, grcExportLimit)
 	if err != nil {
 		writeGRCError(w, err)
 		return

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -665,6 +665,15 @@ func TestGRCFindingsUsesGroupedEvidenceCounts(t *testing.T) {
 				Status:         "open",
 				LastObservedAt: now,
 			},
+			"finding-2": {
+				ID:             "finding-2",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 2",
+				Severity:       "LOW",
+				Status:         "open",
+				LastObservedAt: now.Add(-time.Hour),
+			},
 		},
 		findingEvidence: map[string]*cerebrov1.FindingEvidence{
 			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
@@ -685,12 +694,20 @@ func TestGRCFindingsUsesGroupedEvidenceCounts(t *testing.T) {
 	}
 	var payload struct {
 		Findings []grcFindingItem `json:"findings"`
+		Meta     struct {
+			Limit     uint32 `json:"limit"`
+			Returned  int    `json:"returned"`
+			Truncated bool   `json:"truncated"`
+		} `json:"meta"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode /grc/findings: %v", err)
 	}
 	if len(payload.Findings) != 1 || payload.Findings[0].EvidenceCount != 2 {
 		t.Fatalf("findings = %+v, want grouped evidence count 2", payload.Findings)
+	}
+	if payload.Meta.Limit != 1 || payload.Meta.Returned != 1 || !payload.Meta.Truncated {
+		t.Fatalf("meta = %+v, want one truncated row", payload.Meta)
 	}
 	if store.groupedCountCalls != 1 {
 		t.Fatalf("grouped count calls = %d, want 1", store.groupedCountCalls)
@@ -703,6 +720,67 @@ func TestGRCFindingsUsesGroupedEvidenceCounts(t *testing.T) {
 	}
 	if len(store.groupedCountRequest.FindingIDs) != 1 || store.groupedCountRequest.FindingIDs[0] != "finding-1" {
 		t.Fatalf("grouped count finding ids = %#v, want finding-1", store.groupedCountRequest.FindingIDs)
+	}
+}
+
+func TestGRCEvidenceIncludesListMetadata(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "runtime-alpha"
+	tenantID := "tenant"
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:           runtimeID,
+				SourceId:     "okta",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 1",
+				Severity:       "HIGH",
+				Status:         "open",
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+			"evidence-2": {Id: "evidence-2", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now.Add(-time.Minute))},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/evidence?tenant_id=" + tenantID + "&limit=1")
+	if err != nil {
+		t.Fatalf("GET /grc/evidence error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/evidence status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload struct {
+		Evidence []grcEvidenceItem `json:"evidence"`
+		Meta     struct {
+			Limit     uint32 `json:"limit"`
+			Returned  int    `json:"returned"`
+			Truncated bool   `json:"truncated"`
+		} `json:"meta"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /grc/evidence: %v", err)
+	}
+	if len(payload.Evidence) != 1 {
+		t.Fatalf("evidence length = %d, want 1", len(payload.Evidence))
+	}
+	if payload.Meta.Limit != 1 || payload.Meta.Returned != 1 || !payload.Meta.Truncated {
+		t.Fatalf("meta = %+v, want one truncated row", payload.Meta)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add bounded list metadata to GRC findings and evidence responses
- include returned, limit, and truncated state for capped responses
- cover capped finding and evidence responses with bootstrap tests

## Validation
- go test ./internal/bootstrap -count=1
- make check-structural check-structural-test check-arch
- git diff --check