### PR TITLE
[codex] use structured extraction for GRC uploads

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2217,7 +2217,7 @@ paths:
                   type: string
       responses:
         '202':
-          description: Accepted policy and document upload events after Reducto parsing.
+          description: Accepted policy and document upload events after Reducto structured extraction.
           content:
             application/json:
               schema:
@@ -3020,7 +3020,7 @@ paths:
                   type: string
       responses:
         '202':
-          description: Accepted vendor and assurance-document upload events after Reducto parsing.
+          description: Accepted vendor and assurance-document upload events after Reducto structured extraction.
           content:
             application/json:
               schema:
@@ -9350,6 +9350,15 @@ components:
           type: string
         record_urn:
           type: string
+    GRCUploadStructuredField:
+      type: object
+      properties:
+        key:
+          type: string
+        label:
+          type: string
+        value:
+          type: string
     GRCUploadResponse:
       type: object
       properties:
@@ -9374,6 +9383,16 @@ components:
           type: integer
         page_count:
           type: integer
+        structure_status:
+          type: string
+        structure_schema:
+          type: string
+        structured_summary:
+          type: string
+        structured_fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCUploadStructuredField'
         events:
           type: array
           items:

--- a/internal/grcupload/upload.go
+++ b/internal/grcupload/upload.go
@@ -19,8 +19,11 @@ import (
 )
 
 const (
-	defaultSourceID = "grc"
-	uploadProvider  = "cerebro_upload"
+	defaultSourceID              = "grc"
+	uploadProvider               = "cerebro_upload"
+	maxStructuredFields          = 12
+	maxStructuredFieldValueChars = 300
+	maxStructuredSummaryChars    = 600
 
 	SchemaRefPolicy            = "grc/policy/v1"
 	SchemaRefDocument          = "grc/document/v1"
@@ -42,12 +45,22 @@ const (
 )
 
 type ParsedDocument struct {
-	ProviderFileID string
-	ParseID        string
-	Status         string
-	TextPreview    string
-	ChunkCount     int
-	PageCount      int
+	ProviderFileID    string
+	ParseID           string
+	Status            string
+	TextPreview       string
+	ChunkCount        int
+	PageCount         int
+	StructureStatus   string
+	StructureSchema   string
+	StructuredSummary string
+	StructuredFields  []StructuredField
+}
+
+type StructuredField struct {
+	Key   string `json:"key"`
+	Label string `json:"label,omitempty"`
+	Value string `json:"value"`
 }
 
 type UploadRequest struct {
@@ -72,20 +85,24 @@ type EventRef struct {
 }
 
 type Response struct {
-	UploadID           string     `json:"upload_id"`
-	Target             string     `json:"target"`
-	FileName           string     `json:"file_name"`
-	ContentType        string     `json:"content_type,omitempty"`
-	ReductoFileID      string     `json:"reducto_file_id,omitempty"`
-	ReductoParseID     string     `json:"reducto_parse_id,omitempty"`
-	ParseStatus        string     `json:"parse_status,omitempty"`
-	TextPreview        string     `json:"text_preview,omitempty"`
-	ChunkCount         int        `json:"chunk_count,omitempty"`
-	PageCount          int        `json:"page_count,omitempty"`
-	ProjectionStatus   string     `json:"projection_status,omitempty"`
-	ProjectionFailures int        `json:"projection_failures,omitempty"`
-	Events             []EventRef `json:"events"`
-	GeneratedAt        time.Time  `json:"generated_at"`
+	UploadID           string            `json:"upload_id"`
+	Target             string            `json:"target"`
+	FileName           string            `json:"file_name"`
+	ContentType        string            `json:"content_type,omitempty"`
+	ReductoFileID      string            `json:"reducto_file_id,omitempty"`
+	ReductoParseID     string            `json:"reducto_parse_id,omitempty"`
+	ParseStatus        string            `json:"parse_status,omitempty"`
+	TextPreview        string            `json:"text_preview,omitempty"`
+	ChunkCount         int               `json:"chunk_count,omitempty"`
+	PageCount          int               `json:"page_count,omitempty"`
+	StructureStatus    string            `json:"structure_status,omitempty"`
+	StructureSchema    string            `json:"structure_schema,omitempty"`
+	StructuredSummary  string            `json:"structured_summary,omitempty"`
+	StructuredFields   []StructuredField `json:"structured_fields,omitempty"`
+	ProjectionStatus   string            `json:"projection_status,omitempty"`
+	ProjectionFailures int               `json:"projection_failures,omitempty"`
+	Events             []EventRef        `json:"events"`
+	GeneratedAt        time.Time         `json:"generated_at"`
 }
 
 func BuildEvents(request UploadRequest, parsed ParsedDocument, now time.Time) ([]*cerebrov1.EventEnvelope, Response, error) {
@@ -108,6 +125,10 @@ func BuildEvents(request UploadRequest, parsed ParsedDocument, now time.Time) ([
 	parsed.ParseID = strings.TrimSpace(parsed.ParseID)
 	parsed.Status = strings.TrimSpace(parsed.Status)
 	parsed.TextPreview = compactWhitespace(parsed.TextPreview)
+	parsed.StructureStatus = strings.TrimSpace(parsed.StructureStatus)
+	parsed.StructureSchema = strings.TrimSpace(parsed.StructureSchema)
+	parsed.StructuredSummary = truncateRunes(compactWhitespace(parsed.StructuredSummary), maxStructuredSummaryChars)
+	parsed.StructuredFields = sanitizeStructuredFields(parsed.StructuredFields)
 
 	var specs []eventSpec
 	switch request.Target {
@@ -140,18 +161,22 @@ func BuildEvents(request UploadRequest, parsed ParsedDocument, now time.Time) ([
 		})
 	}
 	return events, Response{
-		UploadID:       uploadID,
-		Target:         string(request.Target),
-		FileName:       request.FileName,
-		ContentType:    request.ContentType,
-		ReductoFileID:  parsed.ProviderFileID,
-		ReductoParseID: parsed.ParseID,
-		ParseStatus:    parsed.Status,
-		TextPreview:    parsed.TextPreview,
-		ChunkCount:     parsed.ChunkCount,
-		PageCount:      parsed.PageCount,
-		Events:         refs,
-		GeneratedAt:    now,
+		UploadID:          uploadID,
+		Target:            string(request.Target),
+		FileName:          request.FileName,
+		ContentType:       request.ContentType,
+		ReductoFileID:     parsed.ProviderFileID,
+		ReductoParseID:    parsed.ParseID,
+		ParseStatus:       parsed.Status,
+		TextPreview:       parsed.TextPreview,
+		ChunkCount:        parsed.ChunkCount,
+		PageCount:         parsed.PageCount,
+		StructureStatus:   parsed.StructureStatus,
+		StructureSchema:   parsed.StructureSchema,
+		StructuredSummary: parsed.StructuredSummary,
+		StructuredFields:  parsed.StructuredFields,
+		Events:            refs,
+		GeneratedAt:       now,
 	}, nil
 }
 
@@ -362,22 +387,26 @@ func normalizeRequest(request UploadRequest) UploadRequest {
 
 func commonAttrs(request UploadRequest, parsed ParsedDocument, uploadID string, now time.Time) map[string]string {
 	attrs := map[string]string{
-		"provider":              uploadProvider,
-		"source_system":         uploadProvider,
-		"upload_id":             uploadID,
-		"file_name":             request.FileName,
-		"content_type":          request.ContentType,
-		"uploaded_at":           now.Format(time.RFC3339),
-		"parse_provider":        "reducto",
-		"reducto_file_id":       parsed.ProviderFileID,
-		"reducto_parse_id":      parsed.ParseID,
-		"reducto_parse_status":  parsed.Status,
-		"parsed_text_preview":   parsed.TextPreview,
-		"parsed_chunk_count":    intString(parsed.ChunkCount),
-		"parsed_page_count":     intString(parsed.PageCount),
-		"uploaded_by_user_id":   request.ActorUserID,
-		"created_by_user_id":    request.ActorUserID,
-		"source_upload_surface": "cerebro-web",
+		"provider":               uploadProvider,
+		"source_system":          uploadProvider,
+		"upload_id":              uploadID,
+		"file_name":              request.FileName,
+		"content_type":           request.ContentType,
+		"uploaded_at":            now.Format(time.RFC3339),
+		"parse_provider":         "reducto",
+		"reducto_file_id":        parsed.ProviderFileID,
+		"reducto_parse_id":       parsed.ParseID,
+		"reducto_parse_status":   parsed.Status,
+		"parsed_text_preview":    parsed.TextPreview,
+		"parsed_chunk_count":     intString(parsed.ChunkCount),
+		"parsed_page_count":      intString(parsed.PageCount),
+		"structure_status":       parsed.StructureStatus,
+		"structure_schema":       parsed.StructureSchema,
+		"structured_summary":     parsed.StructuredSummary,
+		"structured_field_count": intString(len(parsed.StructuredFields)),
+		"uploaded_by_user_id":    request.ActorUserID,
+		"created_by_user_id":     request.ActorUserID,
+		"source_upload_surface":  "cerebro-web",
 	}
 	if request.FileSize > 0 {
 		attrs["file_size_bytes"] = fmt.Sprintf("%d", request.FileSize)
@@ -509,6 +538,17 @@ func compactWhitespace(value string) string {
 	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
 }
 
+func truncateRunes(value string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return string(runes[:maxRunes])
+}
+
 func firstNonEmpty(values ...string) string {
 	for _, value := range values {
 		value = strings.TrimSpace(value)
@@ -524,4 +564,36 @@ func intString(value int) string {
 		return ""
 	}
 	return fmt.Sprintf("%d", value)
+}
+
+func sanitizeStructuredFields(fields []StructuredField) []StructuredField {
+	if len(fields) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	sanitized := make([]StructuredField, 0, min(len(fields), maxStructuredFields))
+	for _, field := range fields {
+		key := strings.TrimSpace(field.Key)
+		value := truncateRunes(compactWhitespace(field.Value), maxStructuredFieldValueChars)
+		if key == "" || value == "" {
+			continue
+		}
+		normalizedKey := strings.ToLower(key)
+		if _, ok := seen[normalizedKey]; ok {
+			continue
+		}
+		seen[normalizedKey] = struct{}{}
+		sanitized = append(sanitized, StructuredField{
+			Key:   key,
+			Label: compactWhitespace(field.Label),
+			Value: value,
+		})
+		if len(sanitized) >= maxStructuredFields {
+			break
+		}
+	}
+	if len(sanitized) == 0 {
+		return nil
+	}
+	return sanitized
 }

--- a/internal/grcupload/upload_test.go
+++ b/internal/grcupload/upload_test.go
@@ -27,12 +27,19 @@ func TestBuildEventsBuildsPolicyAndDocumentEvents(t *testing.T) {
 			"ignored":            "drop-me",
 		},
 	}, ParsedDocument{
-		ProviderFileID: "file-1",
-		ParseID:        "parse-1",
-		Status:         "completed",
-		TextPreview:    "  Access   policy body.  ",
-		ChunkCount:     4,
-		PageCount:      2,
+		ProviderFileID:    "file-1",
+		ParseID:           "parse-1",
+		Status:            "completed",
+		TextPreview:       "  Access   policy body.  ",
+		ChunkCount:        4,
+		PageCount:         2,
+		StructureStatus:   "structured",
+		StructureSchema:   "grc_upload_v1",
+		StructuredSummary: "Access policy summary",
+		StructuredFields: []StructuredField{
+			{Key: "summary", Label: "Summary", Value: "Access policy summary"},
+			{Key: "owner", Value: "Owner 1"},
+		},
 	}, now)
 	if err != nil {
 		t.Fatalf("BuildEvents() error = %v", err)
@@ -42,6 +49,9 @@ func TestBuildEventsBuildsPolicyAndDocumentEvents(t *testing.T) {
 	}
 	if response.TextPreview != "Access policy body." || response.ChunkCount != 4 || response.PageCount != 2 {
 		t.Fatalf("parsed response fields = %#v", response)
+	}
+	if response.StructureStatus != "structured" || response.StructureSchema != "grc_upload_v1" || response.StructuredSummary != "Access policy summary" || len(response.StructuredFields) != 2 {
+		t.Fatalf("structured response fields = %#v", response)
 	}
 	if len(events) != 2 || len(response.Events) != 2 {
 		t.Fatalf("events length = %d, response refs = %d, want 2", len(events), len(response.Events))
@@ -65,6 +75,12 @@ func TestBuildEventsBuildsPolicyAndDocumentEvents(t *testing.T) {
 	}
 	if got := policy.GetAttributes()["parsed_text_preview"]; got != "Access policy body." {
 		t.Fatalf("parsed_text_preview = %q", got)
+	}
+	if got := policy.GetAttributes()["structured_summary"]; got != "Access policy summary" {
+		t.Fatalf("structured_summary = %q", got)
+	}
+	if got := policy.GetAttributes()["structured_field_count"]; got != "2" {
+		t.Fatalf("structured_field_count = %q", got)
 	}
 	if _, ok := policy.GetAttributes()["ignored"]; ok {
 		t.Fatal("policy event included unapproved upload field")

--- a/internal/sourcehttp/reducto/client.go
+++ b/internal/sourcehttp/reducto/client.go
@@ -184,6 +184,7 @@ func (c *Client) extract(ctx context.Context, fileID string) (grcupload.ParsedDo
 		parsed = mergeParsedDocument(parsed, parsedDocumentFromPayload(resultPayload))
 	}
 	parsed.ProviderFileID = firstNonEmpty(parsed.ProviderFileID, fileID)
+	parsed.StructureStatus = structureStatus(parsed.StructureStatus, parsed.StructuredFields)
 	parsed.StructureSchema = firstNonEmpty(parsed.StructureSchema, grcUploadStructureSchema)
 	return parsed, nil
 }
@@ -288,7 +289,7 @@ func parsedDocumentFromPayload(payload any) grcupload.ParsedDocument {
 		TextPreview:       preview,
 		ChunkCount:        len(chunks),
 		PageCount:         pageCount,
-		StructureStatus:   firstNonEmpty(lookupTopString(payload, "structure_status", "extract_status"), lookupTopString(payload, "status"), "structured"),
+		StructureStatus:   lookupTopString(payload, "structure_status", "extract_status"),
 		StructureSchema:   grcUploadStructureSchema,
 		StructuredSummary: structuredSummary,
 		StructuredFields:  structuredFields,
@@ -516,12 +517,26 @@ func structuredFieldsFromValue(value any, prefix string) []grcupload.StructuredF
 			return []grcupload.StructuredField{{Key: prefix, Label: labelForFieldKey(prefix), Value: strings.Join(values, "; ")}}
 		}
 		fields := []grcupload.StructuredField{}
-		for _, rawValue := range typed {
-			fields = append(fields, structuredFieldsFromValue(rawValue, prefix)...)
+		for index, rawValue := range typed {
+			itemPrefix := prefix
+			if _, ok := rawValue.(map[string]any); ok && prefix != "" {
+				itemPrefix = fmt.Sprintf("%s.%d", prefix, index+1)
+			}
+			fields = append(fields, structuredFieldsFromValue(rawValue, itemPrefix)...)
 		}
 		return fields
 	}
 	return nil
+}
+
+func structureStatus(status string, fields []grcupload.StructuredField) string {
+	if status = strings.TrimSpace(status); status != "" {
+		return status
+	}
+	if len(fields) > 0 {
+		return "structured"
+	}
+	return "unstructured"
 }
 
 func scalarStrings(value any) []string {

--- a/internal/sourcehttp/reducto/client.go
+++ b/internal/sourcehttp/reducto/client.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +26,7 @@ const (
 	maxReductoBodyBytes       int64 = 8 << 20
 	maxReductoResultURLBytes  int64 = 16 << 20
 	maxParsedTextPreviewChars       = 1200
+	grcUploadStructureSchema        = "grc_upload_v1"
 )
 
 type Config struct {
@@ -95,7 +97,7 @@ func (c *Client) Parse(ctx context.Context, fileName string, contentType string,
 	if err != nil {
 		return grcupload.ParsedDocument{}, err
 	}
-	parsed, err := c.parse(ctx, fileID)
+	parsed, err := c.extract(ctx, fileID)
 	if err != nil {
 		return grcupload.ParsedDocument{}, err
 	}
@@ -149,29 +151,29 @@ func (c *Client) upload(ctx context.Context, fileName string, contentType string
 	return fileID, nil
 }
 
-func (c *Client) parse(ctx context.Context, fileID string) (grcupload.ParsedDocument, error) {
-	body, err := json.Marshal(map[string]any{"input": fileID})
+func (c *Client) extract(ctx context.Context, fileID string) (grcupload.ParsedDocument, error) {
+	body, err := json.Marshal(grcUploadExtractRequest(fileID))
 	if err != nil {
-		return grcupload.ParsedDocument{}, fmt.Errorf("%w: encode Reducto parse request: %w", grcupload.ErrInvalidRequest, err)
+		return grcupload.ParsedDocument{}, fmt.Errorf("%w: encode Reducto extract request: %w", grcupload.ErrInvalidRequest, err)
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.resolvePath("/parse"), bytes.NewReader(body))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.resolvePath("/extract"), bytes.NewReader(body))
 	if err != nil {
-		return grcupload.ParsedDocument{}, fmt.Errorf("%w: build Reducto parse request: %w", grcupload.ErrInvalidRequest, err)
+		return grcupload.ParsedDocument{}, fmt.Errorf("%w: build Reducto extract request: %w", grcupload.ErrInvalidRequest, err)
 	}
 	request.Header.Set("Authorization", "Bearer "+c.apiKey)
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return grcupload.ParsedDocument{}, fmt.Errorf("%w: parse request: %w", grcupload.ErrRemote, err)
+		return grcupload.ParsedDocument{}, fmt.Errorf("%w: extract request: %w", grcupload.ErrRemote, err)
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return grcupload.ParsedDocument{}, reductoStatusError("parse", response)
+		return grcupload.ParsedDocument{}, reductoStatusError("extract", response)
 	}
 	payload, err := readJSON(response.Body, maxReductoBodyBytes)
 	if err != nil {
-		return grcupload.ParsedDocument{}, fmt.Errorf("%w: decode Reducto parse response: %w", grcupload.ErrRemote, err)
+		return grcupload.ParsedDocument{}, fmt.Errorf("%w: decode Reducto extract response: %w", grcupload.ErrRemote, err)
 	}
 	parsed := parsedDocumentFromPayload(payload)
 	if resultURL := lookupTopString(payload, "result_url", "download_url", "url"); parsed.ChunkCount == 0 && resultURL != "" {
@@ -182,7 +184,56 @@ func (c *Client) parse(ctx context.Context, fileID string) (grcupload.ParsedDocu
 		parsed = mergeParsedDocument(parsed, parsedDocumentFromPayload(resultPayload))
 	}
 	parsed.ProviderFileID = firstNonEmpty(parsed.ProviderFileID, fileID)
+	parsed.StructureSchema = firstNonEmpty(parsed.StructureSchema, grcUploadStructureSchema)
 	return parsed, nil
+}
+
+func grcUploadExtractRequest(fileID string) map[string]any {
+	return map[string]any{
+		"input": fileID,
+		"parsing": map[string]any{
+			"enhance": map[string]any{
+				"agentic":              []string{},
+				"intelligent_ordering": true,
+				"summarize_figures":    true,
+			},
+		},
+		"instructions": map[string]any{
+			"schema":        grcUploadExtractionSchema(),
+			"system_prompt": "Extract GRC document fields for policy and vendor evidence review. Return only facts present in the document.",
+		},
+		"settings": map[string]any{
+			"include_images":       false,
+			"optimize_for_latency": false,
+			"array_extract":        false,
+			"deep_extract":         false,
+			"citations": map[string]any{
+				"enabled":              false,
+				"numerical_confidence": true,
+				"parent_block":         "full",
+			},
+		},
+	}
+}
+
+func grcUploadExtractionSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"document_title":  map[string]any{"type": "string"},
+			"document_type":   map[string]any{"type": "string"},
+			"summary":         map[string]any{"type": "string"},
+			"policy_name":     map[string]any{"type": "string"},
+			"vendor_name":     map[string]any{"type": "string"},
+			"owner":           map[string]any{"type": "string"},
+			"effective_date":  map[string]any{"type": "string"},
+			"review_due_date": map[string]any{"type": "string"},
+			"controls":        map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+			"requirements":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+			"risks":           map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		},
+	}
 }
 
 func (c *Client) fetchResultURL(ctx context.Context, rawURL string) (any, error) {
@@ -228,13 +279,19 @@ func parsedDocumentFromPayload(payload any) grcupload.ParsedDocument {
 		pageCount = lookupFirstInt(result, "page_count", "pages")
 	}
 	preview := truncateRunes(compactWhitespace(strings.Join(texts, " ")), maxParsedTextPreviewChars)
+	structuredFields := structuredFieldsFromPayload(payload)
+	structuredSummary := structuredSummaryFromFields(structuredFields)
 	return grcupload.ParsedDocument{
-		ProviderFileID: lookupTopString(payload, "file_id", "document_url", "input", "reducto_file_id"),
-		ParseID:        lookupTopString(payload, "parse_id", "job_id", "id"),
-		Status:         firstNonEmpty(lookupTopString(payload, "status"), "parsed"),
-		TextPreview:    preview,
-		ChunkCount:     len(chunks),
-		PageCount:      pageCount,
+		ProviderFileID:    lookupTopString(payload, "file_id", "document_url", "input", "reducto_file_id"),
+		ParseID:           lookupTopString(payload, "parse_id", "job_id", "id"),
+		Status:            firstNonEmpty(lookupTopString(payload, "status"), "parsed"),
+		TextPreview:       preview,
+		ChunkCount:        len(chunks),
+		PageCount:         pageCount,
+		StructureStatus:   firstNonEmpty(lookupTopString(payload, "structure_status", "extract_status"), lookupTopString(payload, "status"), "structured"),
+		StructureSchema:   grcUploadStructureSchema,
+		StructuredSummary: structuredSummary,
+		StructuredFields:  structuredFields,
 	}
 }
 
@@ -256,6 +313,18 @@ func mergeParsedDocument(left grcupload.ParsedDocument, right grcupload.ParsedDo
 	}
 	if left.PageCount == 0 {
 		left.PageCount = right.PageCount
+	}
+	if left.StructureStatus == "" {
+		left.StructureStatus = right.StructureStatus
+	}
+	if left.StructureSchema == "" {
+		left.StructureSchema = right.StructureSchema
+	}
+	if left.StructuredSummary == "" {
+		left.StructuredSummary = right.StructuredSummary
+	}
+	if len(left.StructuredFields) == 0 {
+		left.StructuredFields = right.StructuredFields
 	}
 	return left
 }
@@ -391,6 +460,120 @@ func lookupTopValue(value any, key string) any {
 		}
 	}
 	return nil
+}
+
+func structuredFieldsFromPayload(payload any) []grcupload.StructuredField {
+	candidates := []any{
+		lookupTopValue(payload, "extraction"),
+		lookupTopValue(payload, "structured"),
+		lookupTopValue(payload, "structured_data"),
+		lookupTopValue(payload, "data"),
+		lookupTopValue(lookupTopValue(payload, "result"), "extraction"),
+		lookupTopValue(lookupTopValue(payload, "result"), "structured"),
+		lookupTopValue(lookupTopValue(payload, "result"), "data"),
+		lookupTopValue(payload, "result"),
+	}
+	for _, candidate := range candidates {
+		fields := structuredFieldsFromValue(candidate, "")
+		if len(fields) > 0 {
+			return fields
+		}
+	}
+	return nil
+}
+
+func structuredFieldsFromValue(value any, prefix string) []grcupload.StructuredField {
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			if !skipStructuredFieldKey(key) {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		fields := []grcupload.StructuredField{}
+		for _, key := range keys {
+			rawValue := typed[key]
+			fieldKey := key
+			if prefix != "" {
+				fieldKey = prefix + "." + key
+			}
+			if scalar := scalarString(rawValue); scalar != "" {
+				fields = append(fields, grcupload.StructuredField{Key: fieldKey, Label: labelForFieldKey(fieldKey), Value: scalar})
+				continue
+			}
+			if values := scalarStrings(rawValue); len(values) > 0 {
+				fields = append(fields, grcupload.StructuredField{Key: fieldKey, Label: labelForFieldKey(fieldKey), Value: strings.Join(values, "; ")})
+				continue
+			}
+			fields = append(fields, structuredFieldsFromValue(rawValue, fieldKey)...)
+		}
+		return fields
+	case []any:
+		values := scalarStrings(typed)
+		if len(values) > 0 && prefix != "" {
+			return []grcupload.StructuredField{{Key: prefix, Label: labelForFieldKey(prefix), Value: strings.Join(values, "; ")}}
+		}
+		fields := []grcupload.StructuredField{}
+		for _, rawValue := range typed {
+			fields = append(fields, structuredFieldsFromValue(rawValue, prefix)...)
+		}
+		return fields
+	}
+	return nil
+}
+
+func scalarStrings(value any) []string {
+	switch typed := value.(type) {
+	case []any:
+		values := []string{}
+		for _, rawValue := range typed {
+			if scalar := scalarString(rawValue); scalar != "" {
+				values = append(values, scalar)
+			}
+		}
+		return values
+	case []string:
+		values := []string{}
+		for _, rawValue := range typed {
+			if scalar := strings.TrimSpace(rawValue); scalar != "" {
+				values = append(values, scalar)
+			}
+		}
+		return values
+	}
+	return nil
+}
+
+func structuredSummaryFromFields(fields []grcupload.StructuredField) string {
+	for _, key := range []string{"summary", "document_summary"} {
+		for _, field := range fields {
+			if strings.EqualFold(field.Key, key) {
+				return field.Value
+			}
+		}
+	}
+	return ""
+}
+
+func skipStructuredFieldKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "", "chunks", "blocks", "pages", "page_count", "content", "text", "markdown", "result_url", "download_url", "url", "status", "parse_id", "job_id", "id", "input", "file_id":
+		return true
+	default:
+		return false
+	}
+}
+
+func labelForFieldKey(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	key = strings.ReplaceAll(key, "_", " ")
+	key = strings.ReplaceAll(key, ".", " ")
+	return strings.Join(strings.Fields(key), " ")
 }
 
 func scalarString(value any) string {

--- a/internal/sourcehttp/reducto/client_test.go
+++ b/internal/sourcehttp/reducto/client_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestReductoClientParseUploadsAndParsesDocument(t *testing.T) {
 	var sawUpload bool
-	var sawParse bool
+	var sawExtract bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer reducto-token" {
 			t.Fatalf("Authorization = %q, want bearer token", got)
@@ -43,22 +43,32 @@ func TestReductoClientParseUploadsAndParsesDocument(t *testing.T) {
 				t.Fatalf("uploaded body = %q, want policy body", string(body))
 			}
 			writeJSON(t, w, map[string]string{"file_id": "file-1"})
-		case "/parse":
-			sawParse = true
+		case "/extract":
+			sawExtract = true
 			if r.Method != http.MethodPost {
-				t.Fatalf("parse method = %s, want POST", r.Method)
+				t.Fatalf("extract method = %s, want POST", r.Method)
 			}
-			var request map[string]string
+			var request map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-				t.Fatalf("decode parse request: %v", err)
+				t.Fatalf("decode extract request: %v", err)
 			}
 			if request["input"] != "file-1" {
-				t.Fatalf("parse input = %q, want file-1", request["input"])
+				t.Fatalf("extract input = %q, want file-1", request["input"])
+			}
+			instructions, ok := request["instructions"].(map[string]any)
+			if !ok {
+				t.Fatalf("extract instructions = %#v, want object", request["instructions"])
+			}
+			schema, ok := instructions["schema"].(map[string]any)
+			if !ok || schema["type"] != "object" {
+				t.Fatalf("extract schema = %#v, want object schema", instructions["schema"])
 			}
 			writeJSON(t, w, map[string]any{
 				"parse_id": "parse-1",
 				"status":   "completed",
 				"result": map[string]any{
+					"summary":       "Access policy summary",
+					"document_type": "policy",
 					"chunks": []map[string]string{
 						{"content": "Access control policy"},
 						{"content": "Review access quarterly"},
@@ -84,8 +94,8 @@ func TestReductoClientParseUploadsAndParsesDocument(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse() error = %v", err)
 	}
-	if !sawUpload || !sawParse {
-		t.Fatalf("sawUpload=%v sawParse=%v, want both true", sawUpload, sawParse)
+	if !sawUpload || !sawExtract {
+		t.Fatalf("sawUpload=%v sawExtract=%v, want both true", sawUpload, sawExtract)
 	}
 	if parsed.ProviderFileID != "file-1" || parsed.ParseID != "parse-1" || parsed.Status != "completed" {
 		t.Fatalf("parsed IDs/status = %#v", parsed)
@@ -96,6 +106,15 @@ func TestReductoClientParseUploadsAndParsesDocument(t *testing.T) {
 	if parsed.TextPreview != "Access control policy Review access quarterly" {
 		t.Fatalf("TextPreview = %q", parsed.TextPreview)
 	}
+	if parsed.StructureStatus != "completed" || parsed.StructureSchema != "grc_upload_v1" {
+		t.Fatalf("structured status/schema = %#v", parsed)
+	}
+	if len(parsed.StructuredFields) != 2 {
+		t.Fatalf("structured fields = %#v, want summary and document_type", parsed.StructuredFields)
+	}
+	if parsed.StructuredSummary != "Access policy summary" {
+		t.Fatalf("StructuredSummary = %q", parsed.StructuredSummary)
+	}
 }
 
 func TestReductoClientFetchesSameOriginResultURL(t *testing.T) {
@@ -105,7 +124,7 @@ func TestReductoClientFetchesSameOriginResultURL(t *testing.T) {
 		switch r.URL.Path {
 		case "/upload":
 			writeJSON(t, w, map[string]string{"file_id": "file-1"})
-		case "/parse":
+		case "/extract":
 			writeJSON(t, w, map[string]any{
 				"parse_id":   "parse-1",
 				"status":     "completed",
@@ -158,7 +177,7 @@ func TestReductoClientReturnsResultURLFetchError(t *testing.T) {
 		switch r.URL.Path {
 		case "/upload":
 			writeJSON(t, w, map[string]string{"file_id": "file-1"})
-		case "/parse":
+		case "/extract":
 			writeJSON(t, w, map[string]any{
 				"parse_id":   "parse-1",
 				"status":     "completed",
@@ -210,13 +229,13 @@ func TestReductoClientPreservesNumericIdentifiers(t *testing.T) {
 		switch r.URL.Path {
 		case "/upload":
 			writeJSON(t, w, map[string]any{"file_id": 12345})
-		case "/parse":
-			var request map[string]string
+		case "/extract":
+			var request map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-				t.Fatalf("decode parse request: %v", err)
+				t.Fatalf("decode extract request: %v", err)
 			}
 			if request["input"] != "12345" {
-				t.Fatalf("parse input = %q, want 12345", request["input"])
+				t.Fatalf("extract input = %q, want 12345", request["input"])
 			}
 			writeJSON(t, w, map[string]any{
 				"parse_id": 67890,

--- a/internal/sourcehttp/reducto/client_test.go
+++ b/internal/sourcehttp/reducto/client_test.go
@@ -106,7 +106,7 @@ func TestReductoClientParseUploadsAndParsesDocument(t *testing.T) {
 	if parsed.TextPreview != "Access control policy Review access quarterly" {
 		t.Fatalf("TextPreview = %q", parsed.TextPreview)
 	}
-	if parsed.StructureStatus != "completed" || parsed.StructureSchema != "grc_upload_v1" {
+	if parsed.StructureStatus != "structured" || parsed.StructureSchema != "grc_upload_v1" {
 		t.Fatalf("structured status/schema = %#v", parsed)
 	}
 	if len(parsed.StructuredFields) != 2 {
@@ -114,6 +114,73 @@ func TestReductoClientParseUploadsAndParsesDocument(t *testing.T) {
 	}
 	if parsed.StructuredSummary != "Access policy summary" {
 		t.Fatalf("StructuredSummary = %q", parsed.StructuredSummary)
+	}
+}
+
+func TestReductoClientMarksUnstructuredWhenNoFieldsExtracted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/upload":
+			writeJSON(t, w, map[string]string{"file_id": "file-1"})
+		case "/extract":
+			writeJSON(t, w, map[string]any{
+				"parse_id": "parse-1",
+				"status":   "completed",
+				"result": map[string]any{
+					"chunks": []map[string]string{
+						{"content": "Policy content only"},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		APIKey:  "reducto-token",
+		BaseURL: server.URL,
+		Timeout: time.Second,
+	}, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	parsed, err := client.Parse(context.Background(), "Access Policy.pdf", "application/pdf", strings.NewReader("policy body"))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if parsed.StructureStatus != "unstructured" {
+		t.Fatalf("StructureStatus = %q, want unstructured", parsed.StructureStatus)
+	}
+	if len(parsed.StructuredFields) != 0 {
+		t.Fatalf("StructuredFields = %#v, want none", parsed.StructuredFields)
+	}
+}
+
+func TestStructuredFieldsFromPayloadIndexesArrayObjects(t *testing.T) {
+	fields := structuredFieldsFromPayload(map[string]any{
+		"result": map[string]any{
+			"controls": []any{
+				map[string]any{"name": "Access review", "owner": "Security"},
+				map[string]any{"name": "Vendor review", "owner": "GRC"},
+			},
+		},
+	})
+	got := map[string]string{}
+	for _, field := range fields {
+		got[field.Key] = field.Value
+	}
+	want := map[string]string{
+		"controls.1.name":  "Access review",
+		"controls.1.owner": "Security",
+		"controls.2.name":  "Vendor review",
+		"controls.2.owner": "GRC",
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("field %s = %q, want %q; fields=%#v", key, got[key], value, fields)
+		}
 	}
 }
 

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -1667,9 +1667,19 @@ export type GRCUploadResponse = {
   parse_status?: string;
   reducto_file_id?: string;
   reducto_parse_id?: string;
+  structure_schema?: string;
+  structure_status?: string;
+  structured_fields?: GRCUploadStructuredField[];
+  structured_summary?: string;
   target?: "policy" | "vendor";
   text_preview?: string;
   upload_id?: string;
+};
+
+export type GRCUploadStructuredField = {
+  key?: string;
+  label?: string;
+  value?: string;
 };
 
 export type GetEntityNeighborhoodResponse = {


### PR DESCRIPTION
## Summary
- Route GRC document uploads through structured Reducto extraction with a bounded schema for policy and vendor evidence.
- Return structured status, summary, and key fields in upload responses while preserving parse and projection metadata.
- Update OpenAPI and generated TypeScript API types for the expanded upload response.

## Why
Uploads need a durable response that shows whether parsing, structuring, and projection completed and exposes extracted document facts for downstream review.

## Validation
- `go test ./internal/grcupload ./internal/sourcehttp/reducto ./internal/sourcehttp/grcupload -count=1`
- `make openapi-ts-check`
- `make openapi-lint`
- `make contracts-check`
- `go test ./... -count=1`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->