### PR TITLE
[codex] Deepen Slack source runtime

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -51,6 +51,7 @@ import (
 	githubsource "github.com/writer/cerebro/sources/github"
 	oktasource "github.com/writer/cerebro/sources/okta"
 	sdksource "github.com/writer/cerebro/sources/sdk"
+	slacksource "github.com/writer/cerebro/sources/slack"
 )
 
 func sourceGet(t *testing.T, server *httptest.Server, path string, config map[string]string) (*http.Response, error) {
@@ -1745,8 +1746,8 @@ func TestBootstrapEndpoints(t *testing.T) {
 		t.Fatalf("decode /sources response: %v", err)
 	}
 	entries, ok := sourcesPayload["sources"].([]any)
-	if !ok || len(entries) != 4 {
-		t.Fatalf("/sources entries = %#v, want 4 entries", sourcesPayload["sources"])
+	if !ok || len(entries) != 5 {
+		t.Fatalf("/sources entries = %#v, want 5 entries", sourcesPayload["sources"])
 	}
 	checkResp, err := sourceGet(t, server, "/sources/github/check", map[string]string{"token": "test"})
 	if err != nil {
@@ -1914,8 +1915,8 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSources() error = %v", err)
 	}
-	if len(listResp.Msg.Sources) != 4 {
-		t.Fatalf("len(ListSources.Sources) = %d, want 4", len(listResp.Msg.Sources))
+	if len(listResp.Msg.Sources) != 5 {
+		t.Fatalf("len(ListSources.Sources) = %d, want 5", len(listResp.Msg.Sources))
 	}
 	checkSourceResp, err := client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{
 		SourceId: "github",
@@ -7710,7 +7711,11 @@ func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sourcecdk.NewRegistry(source, auth0, okta, sdk)
+	slack, err := slacksource.NewFixture()
+	if err != nil {
+		return nil, err
+	}
+	return sourcecdk.NewRegistry(source, auth0, okta, sdk, slack)
 }
 
 func assertBootstrapProjectedLink(t *testing.T, graph *stubGraphStore, fromURN string, relation string, toURN string) {

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -16,6 +16,7 @@ import (
 	githubsource "github.com/writer/cerebro/sources/github"
 	googleworkspacesource "github.com/writer/cerebro/sources/googleworkspace"
 	oktasource "github.com/writer/cerebro/sources/okta"
+	slacksource "github.com/writer/cerebro/sources/slack"
 )
 
 func TestList(t *testing.T) {
@@ -25,8 +26,8 @@ func TestList(t *testing.T) {
 	}
 	service := New(registry)
 	response := service.List()
-	if len(response.Sources) != 4 {
-		t.Fatalf("len(List().Sources) = %d, want 4", len(response.Sources))
+	if len(response.Sources) != 5 {
+		t.Fatalf("len(List().Sources) = %d, want 5", len(response.Sources))
 	}
 }
 
@@ -485,7 +486,11 @@ func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sourcecdk.NewRegistry(source, auth0, googleWorkspace, okta)
+	slack, err := slacksource.NewFixture()
+	if err != nil {
+		return nil, err
+	}
+	return sourcecdk.NewRegistry(source, auth0, googleWorkspace, okta, slack)
 }
 
 func captureSourceOpsStderr(t *testing.T, fn func()) string {

--- a/internal/sourceprojection/slack_test.go
+++ b/internal/sourceprojection/slack_test.go
@@ -177,3 +177,64 @@ func TestRegistryRoutesSlackDeclaredKinds(t *testing.T) {
 		})
 	}
 }
+
+func TestSlackRuntimeKindLiteralsProjectThroughRegistry(t *testing.T) {
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:       "slack-team-literal",
+			TenantId: "writer",
+			SourceId: "slack",
+			Kind:     "slack.team",
+			Attributes: map[string]string{
+				"team_id": "T1",
+				"name":    "Writer",
+			},
+		},
+		{
+			Id:       "slack-user-literal",
+			TenantId: "writer",
+			SourceId: "slack",
+			Kind:     "slack.user",
+			Attributes: map[string]string{
+				"user_id":  "U1",
+				"team_id":  "T1",
+				"email":    "alice@writer.com",
+				"is_admin": "true",
+				"has_2fa":  "false",
+			},
+		},
+		{
+			Id:       "slack-channel-literal",
+			TenantId: "writer",
+			SourceId: "slack",
+			Kind:     "slack.channel",
+			Attributes: map[string]string{
+				"channel_id": "C1",
+				"team_id":    "T1",
+				"creator":    "U1",
+			},
+		},
+		{
+			Id:       "slack-user-group-literal",
+			TenantId: "writer",
+			SourceId: "slack",
+			Kind:     "slack.user_group",
+			Attributes: map[string]string{
+				"group_id": "S1",
+				"team_id":  "T1",
+				"handle":   "eng",
+			},
+		},
+	}
+	for _, event := range events {
+		t.Run(event.GetKind(), func(t *testing.T) {
+			entities, _, err := BuiltinRegistry().Project(event)
+			if err != nil {
+				t.Fatalf("Project(%s) error = %v", event.GetKind(), err)
+			}
+			if len(entities) == 0 {
+				t.Fatalf("Project(%s) emitted no entities", event.GetKind())
+			}
+		})
+	}
+}

--- a/sources/slack/catalog.yaml
+++ b/sources/slack/catalog.yaml
@@ -1,11 +1,16 @@
 id: slack
 name: Slack
-description: Slack team, user, channel, and user group source.
+description: Slack collaboration governance source covering workspaces, users, public and private channels, and user groups. The runtime emits team context, user privilege and MFA enrollment posture, channel ownership context, and user group membership anchors for graph projection and review.
 emitted_kinds:
   - slack.team
   - slack.user
   - slack.channel
   - slack.user_group
+families:
+  - id: team
+  - id: user
+  - id: channel
+  - id: user_group
 coverage_contract:
   owner_domain: collaboration
   authority_domain: slack
@@ -18,6 +23,8 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
+      notes:
+        - Reads public and private channel records so access review and asset inventory do not depend on public-channel visibility alone.
     - id: teams
       type: entity_family
       title: Teams
@@ -26,6 +33,8 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
+      notes:
+        - Team records anchor Slack users, channels, and user groups to the workspace context projected on the graph.
     - id: user_groups
       type: relationship
       title: User groups
@@ -34,6 +43,8 @@ coverage_contract:
       high_value: true
       evidence_types: [relationship_evidence]
       control_domains: [asset_inventory]
+      notes:
+        - User group records provide durable group anchors for ownership, notification, and access review workflows.
     - id: users
       type: entity_family
       title: Users
@@ -42,6 +53,18 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
+      notes:
+        - User snapshots include privilege flags, deletion state, email identifiers, and MFA enrollment state for identity posture projection.
+    - id: pagination
+      type: incremental_sync
+      title: Slack cursor pagination
+      families: [team, user, channel]
+      support: supported
+      high_value: true
+      evidence_types: [source_sync_status]
+      control_domains: [source_operations]
+      notes:
+        - Slack cursor responses are preserved through Source CDK cursors so scheduled reads can continue from the provider cursor.
 event_contracts:
   - kind: slack.team
     schema_ref: slack/team/v1

--- a/sources/slack/deploy.yaml
+++ b/sources/slack/deploy.yaml
@@ -1,0 +1,35 @@
+sourceId: slack
+secretKeys:
+  - SLACK_TOKEN
+runtimes:
+  - localId: teams
+    config:
+      family: team
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "200"
+      token: env:SLACK_TOKEN
+  - localId: users
+    config:
+      family: user
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "200"
+      token: env:SLACK_TOKEN
+  - localId: channels
+    config:
+      family: channel
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "200"
+      token: env:SLACK_TOKEN
+  - localId: user-groups
+    config:
+      family: user_group
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      token: env:SLACK_TOKEN

--- a/sources/slack/fixture.go
+++ b/sources/slack/fixture.go
@@ -1,0 +1,62 @@
+package slack
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+//go:embed testdata/*.json
+var fixtureFS embed.FS
+
+// NewFixture constructs the deterministic Slack source used by tests.
+func NewFixture() (sourcecdk.Source, error) {
+	spec, err := loadSpec()
+	if err != nil {
+		return nil, err
+	}
+	families := []sourcecdk.FixtureFamily{}
+	for _, family := range []string{familyTeam, familyUser, familyChannel, familyUserGroup} {
+		urns, err := sourcecdk.LoadFixtureURNs(fixtureFS, "testdata/discover_"+family+".json")
+		if err != nil {
+			return nil, err
+		}
+		events, err := sourcecdk.LoadFixtureEvents(fixtureFS, "testdata/read_"+family+".json")
+		if err != nil {
+			return nil, err
+		}
+		families = append(families, sourcecdk.FixtureFamily{Name: family, URNs: urns, Events: events})
+	}
+	return sourcecdk.NewFixtureSource(sourcecdk.FixtureSourceOptions{
+		Spec:          spec,
+		DefaultFamily: defaultFamily,
+		Check:         checkFixtureConfig,
+		ResolveFamily: resolveFixtureFamily,
+		Families:      families,
+	})
+}
+
+func checkFixtureConfig(_ context.Context, cfg sourcecdk.Config) error {
+	if fixtureTenantID(cfg) == "" {
+		return fmt.Errorf("tenant_id is required")
+	}
+	return nil
+}
+
+func resolveFixtureFamily(cfg sourcecdk.Config) (string, error) {
+	if fixtureTenantID(cfg) == "" {
+		return "", fmt.Errorf("tenant_id is required")
+	}
+	family := strings.TrimSpace(sourcecdk.ConfigValue(cfg, "family"))
+	if family == "" {
+		return defaultFamily, nil
+	}
+	return family, nil
+}
+
+func fixtureTenantID(cfg sourcecdk.Config) string {
+	return strings.TrimSpace(sourcecdk.ConfigValue(cfg, "tenant_id"))
+}

--- a/sources/slack/source.go
+++ b/sources/slack/source.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"embed"
+	"net/http"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -12,7 +13,16 @@ import (
 //go:embed catalog.yaml
 var catalogFS embed.FS
 
-const sourceID = "slack"
+const (
+	sourceID        = "slack"
+	defaultFamily   = familyUser
+	familyTeam      = "team"
+	familyUser      = "user"
+	familyChannel   = "channel"
+	familyUserGroup = "user_group"
+
+	slackNextCursor = "response_metadata.next_cursor"
+)
 
 type Source struct{ inner *jsonapi.Source }
 
@@ -24,15 +34,10 @@ func New() (*Source, error) {
 	inner, err := jsonapi.New(spec, jsonapi.Options{
 		SourceID:        sourceID,
 		DefaultBaseURL:  "https://slack.com/api",
-		DefaultFamily:   "user",
+		DefaultFamily:   defaultFamily,
 		RequireTenantID: true,
 		TokenScheme:     "Bearer",
-		Families: []jsonapi.Family{
-			{Name: "team", Path: "/auth.teams.list", URNKind: "slack_team", IDKeys: []string{"id", "team_id"}, Attributes: map[string]string{"team_id": "id|team_id", "name": "name", "domain": "domain"}, StaticAttributes: map[string]string{"source_product": "slack"}},
-			{Name: "user", Path: "/users.list", URNKind: "slack_user", IDKeys: []string{"id", "user_id"}, TimestampKeys: []string{"updated"}, ListKeys: []string{"members"}, Attributes: map[string]string{"user_id": "id|user_id", "team_id": "team_id", "email": "profile.email|email", "real_name": "real_name|profile.real_name", "name": "name", "deleted": "deleted", "is_admin": "is_admin", "is_owner": "is_owner", "is_primary_owner": "is_primary_owner", "is_bot": "is_bot", "is_restricted": "is_restricted", "is_ultra_restricted": "is_ultra_restricted", "has_2fa": "has_2fa", "has_mfa": "has_2fa", "two_factor_type": "two_factor_type"}, StaticAttributes: map[string]string{"source_product": "slack"}},
-			{Name: "channel", Path: "/conversations.list", URNKind: "slack_channel", IDKeys: []string{"id", "channel_id"}, TimestampKeys: []string{"updated", "created"}, Attributes: map[string]string{"channel_id": "id|channel_id", "team_id": "context_team_id", "shared_team_ids": "shared_team_ids|internal_team_ids", "name": "name", "is_private": "is_private", "is_archived": "is_archived", "creator": "creator", "num_members": "num_members"}, StaticAttributes: map[string]string{"source_product": "slack"}},
-			{Name: "user_group", Path: "/usergroups.list", URNKind: "slack_user_group", IDKeys: []string{"id", "group_id"}, TimestampKeys: []string{"date_update", "date_create"}, Attributes: map[string]string{"group_id": "id|group_id", "team_id": "team_id", "handle": "handle", "name": "name", "description": "description", "is_disabled": "is_disabled"}, StaticAttributes: map[string]string{"source_product": "slack"}},
-		},
+		Families:        slackFamilies(),
 	})
 	if err != nil {
 		return nil, err
@@ -52,4 +57,113 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 }
 func loadSpec() (*cerebrov1.SourceSpec, error) {
 	return sourcecdk.LoadSpecFromFS(catalogFS, "catalog.yaml")
+}
+
+func slackFamilies() []jsonapi.Family {
+	return []jsonapi.Family{
+		slackTeamFamily(),
+		slackUserFamily(),
+		slackChannelFamily(),
+		slackUserGroupFamily(),
+	}
+}
+
+func slackTeamFamily() jsonapi.Family {
+	return slackPagedFamily(jsonapi.Family{
+		Name:    familyTeam,
+		Method:  http.MethodPost,
+		Path:    "/auth.teams.list",
+		URNKind: "slack_team",
+		IDKeys:  []string{"id", "team_id"},
+		Attributes: map[string]string{
+			"team_id": "id|team_id",
+			"name":    "name",
+			"domain":  "domain",
+		},
+		StaticAttributes: slackStaticAttributes(),
+	})
+}
+
+func slackUserFamily() jsonapi.Family {
+	return slackPagedFamily(jsonapi.Family{
+		Name:          familyUser,
+		Path:          "/users.list",
+		URNKind:       "slack_user",
+		IDKeys:        []string{"id", "user_id"},
+		TimestampKeys: []string{"updated"},
+		ListKeys:      []string{"members"},
+		Attributes: map[string]string{
+			"user_id":             "id|user_id",
+			"team_id":             "team_id",
+			"email":               "profile.email|email",
+			"real_name":           "real_name|profile.real_name",
+			"name":                "name",
+			"deleted":             "deleted",
+			"is_admin":            "is_admin",
+			"is_owner":            "is_owner",
+			"is_primary_owner":    "is_primary_owner",
+			"is_bot":              "is_bot",
+			"is_restricted":       "is_restricted",
+			"is_ultra_restricted": "is_ultra_restricted",
+			"has_2fa":             "has_2fa",
+			"has_mfa":             "has_2fa",
+			"two_factor_type":     "two_factor_type",
+		},
+		StaticAttributes: slackStaticAttributes(),
+	})
+}
+
+func slackChannelFamily() jsonapi.Family {
+	return slackPagedFamily(jsonapi.Family{
+		Name:          familyChannel,
+		Path:          "/conversations.list",
+		URNKind:       "slack_channel",
+		IDKeys:        []string{"id", "channel_id"},
+		TimestampKeys: []string{"updated", "created"},
+		Attributes: map[string]string{
+			"channel_id":      "id|channel_id",
+			"team_id":         "context_team_id",
+			"shared_team_ids": "shared_team_ids|internal_team_ids",
+			"name":            "name",
+			"is_private":      "is_private",
+			"is_archived":     "is_archived",
+			"creator":         "creator",
+			"num_members":     "num_members",
+		},
+		StaticAttributes: slackStaticAttributes(),
+		Config: jsonapi.FamilyConfig{StaticQuery: map[string]string{
+			"exclude_archived": "false",
+			"types":            "public_channel,private_channel",
+		}},
+	})
+}
+
+func slackUserGroupFamily() jsonapi.Family {
+	return jsonapi.Family{
+		Name:            familyUserGroup,
+		Path:            "/usergroups.list",
+		URNKind:         "slack_user_group",
+		IDKeys:          []string{"id", "group_id"},
+		TimestampKeys:   []string{"date_update", "date_create"},
+		DisablePageSize: true,
+		Attributes: map[string]string{
+			"group_id":    "id|group_id",
+			"team_id":     "team_id",
+			"handle":      "handle",
+			"name":        "name",
+			"description": "description",
+			"is_disabled": "is_disabled",
+		},
+		StaticAttributes: slackStaticAttributes(),
+	}
+}
+
+func slackPagedFamily(family jsonapi.Family) jsonapi.Family {
+	family.NextCursorKeys = []string{slackNextCursor}
+	family.PageSizeParams = []string{"limit"}
+	return family
+}
+
+func slackStaticAttributes() map[string]string {
+	return map[string]string{"source_product": "slack"}
 }

--- a/sources/slack/source_health_receipt.json
+++ b/sources/slack/source_health_receipt.json
@@ -1,0 +1,17 @@
+{
+  "adapter_health_path": "/auth.teams.list",
+  "auth_model": "bearer_token",
+  "evidence_cas_reference_kind": "slack.evidence_cas_reference",
+  "expected_cadence_seconds": 86400,
+  "failure_modes": [
+    "api_error",
+    "auth_error",
+    "rate_limit",
+    "schema_drift"
+  ],
+  "health_endpoint": "/source-runtimes/health?source_id=slack",
+  "receipt_kind": "source_health.receipt",
+  "source_id": "slack",
+  "source_type": "json_api",
+  "stale_after_seconds": 86400
+}

--- a/sources/slack/source_test.go
+++ b/sources/slack/source_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
@@ -26,14 +27,19 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 		family   string
 		kind     string
 		path     string
+		method   string
+		query    map[string]string
+		noQuery  []string
 		response map[string]any
 		want     map[string]string
 	}{
 		{
 			name:   "team",
-			family: "team",
+			family: familyTeam,
 			kind:   "slack.team",
 			path:   "/auth.teams.list",
+			method: http.MethodPost,
+			query:  map[string]string{"limit": "100"},
 			response: map[string]any{"ok": true, "teams": []map[string]any{{
 				"id": "T1", "name": "Writer", "domain": "writer",
 			}}},
@@ -41,9 +47,11 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 		},
 		{
 			name:   "user_privileged_no_mfa",
-			family: "user",
+			family: familyUser,
 			kind:   "slack.user",
 			path:   "/users.list",
+			method: http.MethodGet,
+			query:  map[string]string{"limit": "100"},
 			response: map[string]any{"ok": true, "members": []map[string]any{{
 				"id": "U1", "team_id": "T1", "name": "alice", "real_name": "Alice Admin",
 				"profile":  map[string]any{"email": "alice@writer.com"},
@@ -57,9 +65,11 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 		},
 		{
 			name:   "user_privileged_with_mfa",
-			family: "user",
+			family: familyUser,
 			kind:   "slack.user",
 			path:   "/users.list",
+			method: http.MethodGet,
+			query:  map[string]string{"limit": "100"},
 			response: map[string]any{"ok": true, "members": []map[string]any{{
 				"id": "U2", "team_id": "T1", "name": "bob",
 				"profile":  map[string]any{"email": "bob@writer.com"},
@@ -71,9 +81,15 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 		},
 		{
 			name:   "channel",
-			family: "channel",
+			family: familyChannel,
 			kind:   "slack.channel",
 			path:   "/conversations.list",
+			method: http.MethodGet,
+			query: map[string]string{
+				"exclude_archived": "false",
+				"limit":            "100",
+				"types":            "public_channel,private_channel",
+			},
 			response: map[string]any{"ok": true, "channels": []map[string]any{{
 				"id": "C1", "name": "general", "context_team_id": "T1",
 				"is_private": false, "is_archived": false, "creator": "U1", "num_members": 12,
@@ -82,9 +98,15 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 		},
 		{
 			name:   "shared_channel",
-			family: "channel",
+			family: familyChannel,
 			kind:   "slack.channel",
 			path:   "/conversations.list",
+			method: http.MethodGet,
+			query: map[string]string{
+				"exclude_archived": "false",
+				"limit":            "100",
+				"types":            "public_channel,private_channel",
+			},
 			response: map[string]any{"ok": true, "channels": []map[string]any{{
 				"id": "C9", "name": "connect", "shared_team_ids": []string{"T1", "T2"},
 				"is_private": false, "creator": "U1",
@@ -93,9 +115,15 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 		},
 		{
 			name:   "user_group",
-			family: "user_group",
+			family: familyUserGroup,
 			kind:   "slack.user_group",
 			path:   "/usergroups.list",
+			method: http.MethodGet,
+			noQuery: []string{
+				"cursor",
+				"limit",
+				"per_page",
+			},
 			response: map[string]any{"ok": true, "usergroups": []map[string]any{{
 				"id": "S1", "team_id": "T1", "handle": "eng", "name": "Engineering",
 				"description": "Eng team", "is_disabled": false,
@@ -107,6 +135,22 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if got := r.URL.EscapedPath(); got != tt.path {
 					t.Fatalf("request path = %q, want %s", got, tt.path)
+				}
+				if got := r.Method; got != tt.method {
+					t.Fatalf("request method = %q, want %q", got, tt.method)
+				}
+				for key, want := range tt.query {
+					if got := r.URL.Query().Get(key); got != want {
+						t.Fatalf("query %q = %q, want %q", key, got, want)
+					}
+				}
+				if got := r.URL.Query().Get("per_page"); got != "" {
+					t.Fatalf("query per_page = %q, want empty", got)
+				}
+				for _, key := range tt.noQuery {
+					if got := r.URL.Query().Get(key); got != "" {
+						t.Fatalf("query %q = %q, want empty", key, got)
+					}
 				}
 				_ = json.NewEncoder(w).Encode(tt.response)
 			}))
@@ -132,6 +176,127 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 			for key, value := range tt.want {
 				if got := event.Attributes[key]; got != value {
 					t.Fatalf("attribute %q = %q, want %q", key, got, value)
+				}
+			}
+		})
+	}
+}
+
+func TestReadUsesSlackCursorAndLimit(t *testing.T) {
+	expectedRequests := []struct {
+		cursor string
+	}{
+		{},
+		{cursor: "cursor-2"},
+	}
+	requestIndex := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestIndex >= len(expectedRequests) {
+			t.Fatalf("unexpected request %d: %s", requestIndex+1, r.URL.RequestURI())
+		}
+		if got := r.URL.EscapedPath(); got != "/users.list" {
+			t.Fatalf("request path = %q, want /users.list", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("limit = %q, want 2", got)
+		}
+		if got := r.URL.Query().Get("per_page"); got != "" {
+			t.Fatalf("per_page = %q, want empty", got)
+		}
+		expected := expectedRequests[requestIndex]
+		if expected.cursor != r.URL.Query().Get("cursor") {
+			t.Fatalf("cursor = %q, want %q", r.URL.Query().Get("cursor"), expected.cursor)
+		}
+		response := map[string]any{
+			"ok": true,
+			"members": []map[string]any{{
+				"id":      "U1",
+				"team_id": "T1",
+				"name":    "alice",
+			}},
+			"response_metadata": map[string]any{},
+		}
+		if expected.cursor == "" {
+			response["response_metadata"] = map[string]any{"next_cursor": "cursor-2"}
+		}
+		requestIndex++
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	config := sourcecdk.NewConfig(map[string]string{
+		"base_url":  server.URL,
+		"family":    familyUser,
+		"per_page":  "2",
+		"tenant_id": "writer",
+		"token":     "slack-token",
+	})
+	first, err := source.Read(context.Background(), config, nil)
+	if err != nil {
+		t.Fatalf("first Read() error = %v", err)
+	}
+	if first.NextCursor == nil || first.NextCursor.GetOpaque() != "cursor-2" {
+		t.Fatalf("first NextCursor = %#v, want cursor-2", first.NextCursor)
+	}
+	second, err := source.Read(context.Background(), config, &cerebrov1.SourceCursor{Opaque: "cursor-2"})
+	if err != nil {
+		t.Fatalf("second Read() error = %v", err)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if requestIndex != len(expectedRequests) {
+		t.Fatalf("requests = %d, want %d", requestIndex, len(expectedRequests))
+	}
+}
+
+func TestNewFixtureReplaysSlackFamilies(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	familyConfigs := map[string]sourcecdk.Config{}
+	for _, family := range []string{familyTeam, familyUser, familyChannel, familyUserGroup} {
+		familyConfigs[family] = sourcecdk.NewConfig(map[string]string{
+			"family":    family,
+			"tenant_id": "tenant",
+		})
+	}
+	sourcecdk.RunFixtureSuite(t, context.Background(), sourcecdk.FixtureSuiteOptions{
+		Source:          source,
+		FamilyConfigs:   familyConfigs,
+		RequireDiscover: true,
+	})
+	for _, tt := range []struct {
+		family string
+		kind   string
+		want   map[string]string
+	}{
+		{family: familyTeam, kind: "slack.team", want: map[string]string{"team_id": "T1", "domain": "writer"}},
+		{family: familyUser, kind: "slack.user", want: map[string]string{"user_id": "U1", "team_id": "T1", "email": "alice@example.test", "has_2fa": "false"}},
+		{family: familyChannel, kind: "slack.channel", want: map[string]string{"channel_id": "C1", "team_id": "T1", "creator": "U1"}},
+		{family: familyUserGroup, kind: "slack.user_group", want: map[string]string{"group_id": "S1", "team_id": "T1", "handle": "eng"}},
+	} {
+		t.Run(tt.family, func(t *testing.T) {
+			pull, err := source.Read(context.Background(), familyConfigs[tt.family], nil)
+			if err != nil {
+				t.Fatalf("Read(%s) error = %v", tt.family, err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("events = %d, want 1", len(pull.Events))
+			}
+			event := pull.Events[0]
+			if got := event.Kind; got != tt.kind {
+				t.Fatalf("event kind = %q, want %q", got, tt.kind)
+			}
+			for key, want := range tt.want {
+				if got := event.Attributes[key]; got != want {
+					t.Fatalf("attribute %q = %q, want %q", key, got, want)
 				}
 			}
 		})

--- a/sources/slack/testdata/discover_channel.json
+++ b/sources/slack/testdata/discover_channel.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:slack_channel:C1"
+]

--- a/sources/slack/testdata/discover_team.json
+++ b/sources/slack/testdata/discover_team.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:slack_team:T1"
+]

--- a/sources/slack/testdata/discover_user.json
+++ b/sources/slack/testdata/discover_user.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:slack_user:U1"
+]

--- a/sources/slack/testdata/discover_user_group.json
+++ b/sources/slack/testdata/discover_user_group.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:slack_user_group:S1"
+]

--- a/sources/slack/testdata/read_channel.json
+++ b/sources/slack/testdata/read_channel.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "slack-channel-C1",
+    "tenant_id": "tenant",
+    "source_id": "slack",
+    "kind": "slack.channel",
+    "occurred_at": "2026-06-01T00:00:00Z",
+    "schema_ref": "slack/channel/v1",
+    "payload": {
+      "id": "C1",
+      "name": "general",
+      "context_team_id": "T1",
+      "is_private": false,
+      "is_archived": false,
+      "creator": "U1",
+      "num_members": 12,
+      "created": 1780272000
+    },
+    "attributes": {
+      "channel_id": "C1",
+      "creator": "U1",
+      "external_id": "C1",
+      "family": "channel",
+      "is_archived": "false",
+      "is_private": "false",
+      "name": "general",
+      "num_members": "12",
+      "provider": "slack",
+      "source_product": "slack",
+      "source_provider": "slack",
+      "team_id": "T1"
+    }
+  }
+]

--- a/sources/slack/testdata/read_team.json
+++ b/sources/slack/testdata/read_team.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "slack-team-T1",
+    "tenant_id": "tenant",
+    "source_id": "slack",
+    "kind": "slack.team",
+    "occurred_at": "2026-06-01T00:00:00Z",
+    "schema_ref": "slack/team/v1",
+    "payload": {
+      "id": "T1",
+      "name": "Writer",
+      "domain": "writer"
+    },
+    "attributes": {
+      "domain": "writer",
+      "external_id": "T1",
+      "family": "team",
+      "name": "Writer",
+      "provider": "slack",
+      "source_product": "slack",
+      "source_provider": "slack",
+      "team_id": "T1"
+    }
+  }
+]

--- a/sources/slack/testdata/read_user.json
+++ b/sources/slack/testdata/read_user.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "slack-user-U1",
+    "tenant_id": "tenant",
+    "source_id": "slack",
+    "kind": "slack.user",
+    "occurred_at": "2026-06-01T00:00:00Z",
+    "schema_ref": "slack/user/v1",
+    "payload": {
+      "id": "U1",
+      "team_id": "T1",
+      "name": "alice",
+      "real_name": "Alice Admin",
+      "profile": {
+        "email": "alice@example.test",
+        "real_name": "Alice Admin"
+      },
+      "is_admin": true,
+      "is_owner": false,
+      "is_primary_owner": false,
+      "is_bot": false,
+      "has_2fa": false,
+      "deleted": false,
+      "updated": 1780272000
+    },
+    "attributes": {
+      "deleted": "false",
+      "email": "alice@example.test",
+      "external_id": "U1",
+      "family": "user",
+      "has_2fa": "false",
+      "has_mfa": "false",
+      "is_admin": "true",
+      "is_bot": "false",
+      "is_owner": "false",
+      "is_primary_owner": "false",
+      "name": "alice",
+      "provider": "slack",
+      "real_name": "Alice Admin",
+      "source_product": "slack",
+      "source_provider": "slack",
+      "team_id": "T1",
+      "user_id": "U1"
+    }
+  }
+]

--- a/sources/slack/testdata/read_user_group.json
+++ b/sources/slack/testdata/read_user_group.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "slack-user-group-S1",
+    "tenant_id": "tenant",
+    "source_id": "slack",
+    "kind": "slack.user_group",
+    "occurred_at": "2026-06-01T00:00:00Z",
+    "schema_ref": "slack/user_group/v1",
+    "payload": {
+      "id": "S1",
+      "team_id": "T1",
+      "handle": "eng",
+      "name": "Engineering",
+      "description": "Engineering team",
+      "is_disabled": false,
+      "date_create": 1780272000,
+      "date_update": 1780272000
+    },
+    "attributes": {
+      "description": "Engineering team",
+      "external_id": "S1",
+      "family": "user_group",
+      "group_id": "S1",
+      "handle": "eng",
+      "is_disabled": "false",
+      "name": "Engineering",
+      "provider": "slack",
+      "source_product": "slack",
+      "source_provider": "slack",
+      "team_id": "T1"
+    }
+  }
+]


### PR DESCRIPTION
Summary
- Split the Slack source family config into readable runtime helpers with Slack cursor and limit handling.
- Add Slack deploy runtimes plus deterministic Source CDK fixtures for teams, users, channels, and user groups.
- Register Slack fixtures in source ops and bootstrap tests, and add projector literal coverage for all emitted Slack kinds.

Validation
- go test ./sources/slack ./internal/sourceprojection ./internal/sourceops ./internal/bootstrap ./internal/connectorcatalog -count=1
- make connector-catalog-maintenance
- make check-structural check-structural-test check-arch
- make droid-review-preflight
- make droid-review-sast
- go test ./...