### PR TITLE
[codex] add credential store operations API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -416,6 +416,7 @@ paths:
             type: string
         - name: limit
           in: query
+          description: Caps each backing collection independently. Source runtimes and credential records are each limited to this value before the operations view is built.
           schema:
             type: integer
             minimum: 0
@@ -446,6 +447,7 @@ paths:
             type: string
         - name: limit
           in: query
+          description: Caps each backing collection independently. Source runtimes and credential records are each limited to this value before the store detail is built.
           schema:
             type: integer
             minimum: 0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -404,6 +404,63 @@ paths:
       responses:
         '200':
           description: Source events and cursor.
+  /credential-stores:
+    get:
+      summary: List connector credential stores
+      tags:
+        - Connectors
+      parameters:
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000
+      responses:
+        '200':
+          description: Credential-store readiness, runtime bindings, credential metadata, and non-secret setup issues. Secret values and full secret reference addresses are never returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CredentialStoreListResponse'
+        '403':
+          description: Caller is not allowed to inspect credential stores for the requested tenant.
+  /credential-stores/{storeID}:
+    get:
+      summary: Get connector credential store operations
+      tags:
+        - Connectors
+      parameters:
+        - name: storeID
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000
+      responses:
+        '200':
+          description: One credential store with runtime bindings, setup issues, and recent non-secret credential audit events.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CredentialStoreDetailResponse'
+        '403':
+          description: Caller is not allowed to inspect credential stores for the requested tenant.
+        '404':
+          description: Credential store was not found.
   /connectors:
     get:
       summary: List connector library entries
@@ -6673,6 +6730,292 @@ components:
         nonce:
           type: string
         ciphertext:
+          type: string
+    CredentialStoreListResponse:
+      type: object
+      required:
+        - generated_at
+        - runtime_store_status
+        - credential_store_status
+        - stores
+      properties:
+        generated_at:
+          type: string
+          format: date-time
+        tenant_id:
+          type: string
+        runtime_store_status:
+          type: string
+          enum:
+            - ready
+            - unavailable
+        credential_store_status:
+          type: string
+          enum:
+            - ready
+            - unavailable
+        stores:
+          type: array
+          items:
+            $ref: '#/components/schemas/CredentialStoreOperational'
+        issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/CredentialStoreIssue'
+    CredentialStoreDetailResponse:
+      type: object
+      required:
+        - generated_at
+        - runtime_store_status
+        - credential_store_status
+        - store
+      properties:
+        generated_at:
+          type: string
+          format: date-time
+        tenant_id:
+          type: string
+        runtime_store_status:
+          type: string
+          enum:
+            - ready
+            - unavailable
+        credential_store_status:
+          type: string
+          enum:
+            - ready
+            - unavailable
+        store:
+          $ref: '#/components/schemas/CredentialStoreOperational'
+        audit:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectorCredentialAuditEvent'
+    CredentialStoreOperational:
+      type: object
+      required:
+        - store
+        - health
+        - usage
+      properties:
+        store:
+          $ref: '#/components/schemas/CredentialStoreMetadata'
+        health:
+          $ref: '#/components/schemas/CredentialStoreHealth'
+        usage:
+          $ref: '#/components/schemas/CredentialStoreUsage'
+        bindings:
+          type: array
+          items:
+            $ref: '#/components/schemas/CredentialStoreBinding'
+        issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/CredentialStoreIssue'
+    CredentialStoreMetadata:
+      type: object
+      required:
+        - id
+        - label
+        - provider
+        - available
+        - mode
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        provider:
+          type: string
+        available:
+          type: boolean
+        default:
+          type: boolean
+        mode:
+          type: string
+          enum:
+            - encrypted_submission
+            - environment_managed
+            - reference
+        status:
+          type: string
+        detail:
+          type: string
+        description:
+          type: string
+        reference_prefixes:
+          type: array
+          items:
+            type: string
+        reference_namespace_template:
+          type: string
+        reference_field_template:
+          type: string
+        reference_placeholder:
+          type: string
+        native_resolution_available:
+          type: boolean
+        setup_steps:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              label:
+                type: string
+              description:
+                type: string
+              command:
+                type: string
+        required_config:
+          type: array
+          items:
+            type: object
+            properties:
+              env:
+                type: string
+              label:
+                type: string
+              required:
+                type: boolean
+              description:
+                type: string
+    CredentialStoreHealth:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - ready
+            - in_use
+            - warning
+            - needs_attention
+            - needs_configuration
+            - unavailable
+        severity:
+          type: string
+          enum:
+            - success
+            - warning
+            - error
+        detail:
+          type: string
+        next_action:
+          type: string
+    CredentialStoreUsage:
+      type: object
+      required:
+        - connections
+        - credentials
+        - bindings
+        - field_references
+        - issues
+      properties:
+        connections:
+          type: integer
+        credentials:
+          type: integer
+        bindings:
+          type: integer
+        field_references:
+          type: integer
+        issues:
+          type: integer
+        last_updated_at:
+          type: string
+          format: date-time
+    CredentialStoreBinding:
+      type: object
+      required:
+        - id
+        - credential_store_id
+      properties:
+        id:
+          type: string
+        credential_store_id:
+          type: string
+        source_id:
+          type: string
+        source_name:
+          type: string
+        runtime_id:
+          type: string
+        tenant_id:
+          type: string
+        auth_method:
+          type: string
+        resolver:
+          type: string
+          enum:
+            - cerebro_vault
+            - environment
+            - environment_projection
+            - native
+            - native_reference
+            - unknown
+        credential_id:
+          type: string
+        credential_status:
+          type: string
+        connection_status:
+          type: string
+        next_action:
+          type: string
+        fields:
+          type: array
+          items:
+            type: string
+        field_count:
+          type: integer
+        reference_prefixes:
+          type: array
+          items:
+            type: string
+        updated_at:
+          type: string
+          format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+        last_validated_at:
+          type: string
+          format: date-time
+    CredentialStoreIssue:
+      type: object
+      required:
+        - id
+        - status
+        - severity
+        - detail
+      properties:
+        id:
+          type: string
+        credential_store_id:
+          type: string
+        source_id:
+          type: string
+        runtime_id:
+          type: string
+        credential_id:
+          type: string
+        field:
+          type: string
+        status:
+          type: string
+          enum:
+            - blocked
+            - warning
+        severity:
+          type: string
+          enum:
+            - error
+            - warning
+        detail:
+          type: string
+        next_action:
           type: string
     ConnectorCredential:
       type: object

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1485,8 +1485,10 @@ func fallbackAccessAuditRoute(method string, path string) string {
 				return prefix + "/sources/{sourceID}/{subresource}"
 			}
 		}
-	case path == "/connectors":
-		return prefix + "/connectors"
+	case path == "/connectors", path == "/credential-stores":
+		return prefix + path
+	case strings.HasPrefix(path, "/credential-stores/"):
+		return prefix + "/credential-stores/{storeID}"
 	case path == "/connectors/credential-key":
 		return prefix + "/connectors/credential-key"
 	case path == "/connector-definitions":

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -47,6 +47,8 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/platform/workflow/replay", Scope: scopeWorkflowReplay, Static: true},
 	{Method: http.MethodGet, Exact: "/sources", Scope: scopeCosmoSecurityRead},
 	{Method: http.MethodGet, Prefix: "/sources/", Scope: scopeSourcesPreview, Static: true},
+	{Method: http.MethodGet, Exact: "/credential-stores", Scope: scopeConnectorCredentialsRead, Static: true},
+	{Method: http.MethodGet, Prefix: "/credential-stores/", Scope: scopeConnectorCredentialsRead, Static: true},
 	{Method: http.MethodGet, Exact: "/connectors", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/connectors/coverage", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/connectors/credential-key", Scope: scopeCosmoSecurityRead, Static: true},

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -195,6 +196,246 @@ func connectorCredentialRecordMatches(record *ports.ConnectorCredentialRecord, f
 		return false
 	}
 	return true
+}
+
+func TestCredentialStoresListReturnsOperationalBindings(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	now := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)
+	store := &connectorTestStore{
+		stubRuntimeStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"runtime-vault": {
+				Id:       "runtime-vault",
+				SourceId: "bootstrap_token",
+				TenantId: "tenant-a",
+				Config: map[string]string{
+					"token": connectorcredentials.Reference("cred-valid", "token"),
+				},
+			},
+			"runtime-env": {
+				Id:       "runtime-env",
+				SourceId: "bootstrap_token",
+				TenantId: "tenant-a",
+				Config: map[string]string{
+					"token": "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN",
+				},
+			},
+			"runtime-aws": {
+				Id:       "runtime-aws",
+				SourceId: "bootstrap_token",
+				TenantId: "tenant-a",
+				Config: map[string]string{
+					"token": "aws-sm:us-east-1:cerebro/tenant-a/bootstrap_token/runtime-aws/credentials#token",
+				},
+			},
+			"runtime-plain": {
+				Id:       "runtime-plain",
+				SourceId: "bootstrap_token",
+				TenantId: "tenant-a",
+				Config: map[string]string{
+					"token": "plain-secret-value",
+				},
+			},
+		}},
+		credentials: map[string]*ports.ConnectorCredentialRecord{
+			"cred-valid": {
+				ID:                "cred-valid",
+				TenantID:          "tenant-a",
+				SourceID:          "bootstrap_token",
+				RuntimeID:         "runtime-vault",
+				CredentialStoreID: defaultConnectorCredentialStoreID,
+				AuthMethod:        connectorAuthMethodEncryptedSubmission,
+				Status:            connectorcredentials.StatusValid,
+				Fields:            []string{"token"},
+				CreatedAt:         now,
+				UpdatedAt:         now,
+				LastValidatedAt:   now,
+			},
+		},
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/credential-stores?tenant_id=tenant-a")
+	if err != nil {
+		t.Fatalf("GET /credential-stores error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	body := string(bodyBytes)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /credential-stores status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if strings.Contains(body, "plain-secret-value") || strings.Contains(body, "CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN") || strings.Contains(body, "cerebro/tenant-a/bootstrap_token/runtime-aws") {
+		t.Fatalf("credential store response leaked runtime reference value: %s", body)
+	}
+	type credentialStoreTestItem struct {
+		Store struct {
+			ID string `json:"id"`
+		} `json:"store"`
+		Health struct {
+			Status string `json:"status"`
+		} `json:"health"`
+		Usage struct {
+			Connections     int `json:"connections"`
+			Credentials     int `json:"credentials"`
+			FieldReferences int `json:"field_references"`
+		} `json:"usage"`
+		Bindings []struct {
+			RuntimeID         string   `json:"runtime_id"`
+			CredentialID      string   `json:"credential_id"`
+			ReferencePrefixes []string `json:"reference_prefixes"`
+		} `json:"bindings"`
+		Issues []struct {
+			Detail string `json:"detail"`
+		} `json:"issues"`
+	}
+	var payload struct {
+		Stores []credentialStoreTestItem `json:"stores"`
+		Issues []struct {
+			StoreID string `json:"credential_store_id"`
+			Field   string `json:"field"`
+			Detail  string `json:"detail"`
+		} `json:"issues"`
+	}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	stores := map[string]credentialStoreTestItem{}
+	for _, item := range payload.Stores {
+		stores[item.Store.ID] = item
+	}
+	vault := stores[defaultConnectorCredentialStoreID]
+	if vault.Usage.Credentials != 1 || vault.Usage.Connections != 1 || len(vault.Bindings) != 1 || vault.Bindings[0].CredentialID != "cred-valid" {
+		t.Fatalf("vault usage/bindings = %#v, want one credential-backed connection", vault)
+	}
+	env := stores[connectorStoreEnvironmentManaged]
+	if env.Usage.Connections != 1 || env.Usage.FieldReferences != 1 || len(env.Bindings) != 1 {
+		t.Fatalf("environment usage/bindings = %#v, want one env reference", env)
+	}
+	aws := stores[connectorStoreAWSSecretsManager]
+	if aws.Usage.Connections != 1 || aws.Health.Status != "needs_attention" || len(aws.Issues) == 0 {
+		t.Fatalf("aws store = %#v, want unavailable in-use issue", aws)
+	}
+	foundPlaintextIssue := false
+	for _, issue := range payload.Issues {
+		if issue.Field == "token" && strings.Contains(issue.Detail, "without a credential reference") {
+			foundPlaintextIssue = true
+			break
+		}
+	}
+	if !foundPlaintextIssue {
+		t.Fatalf("issues = %#v, want plaintext sensitive config issue", payload.Issues)
+	}
+}
+
+func TestCredentialStoreDetailReturnsAudit(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	now := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)
+	store := &connectorTestStore{
+		stubRuntimeStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"runtime-vault": {
+				Id:       "runtime-vault",
+				SourceId: "bootstrap_token",
+				TenantId: "tenant-a",
+				Config: map[string]string{
+					"token": connectorcredentials.Reference("cred-valid", "token"),
+				},
+			},
+		}},
+		credentials: map[string]*ports.ConnectorCredentialRecord{
+			"cred-valid": {
+				ID:                "cred-valid",
+				TenantID:          "tenant-a",
+				SourceID:          "bootstrap_token",
+				RuntimeID:         "runtime-vault",
+				CredentialStoreID: defaultConnectorCredentialStoreID,
+				AuthMethod:        connectorAuthMethodEncryptedSubmission,
+				Status:            connectorcredentials.StatusValid,
+				Fields:            []string{"token"},
+				CreatedAt:         now,
+				UpdatedAt:         now,
+				LastValidatedAt:   now,
+			},
+		},
+		audit: []*ports.ConnectorCredentialAuditRecord{
+			{
+				ID:           "audit-validated",
+				CredentialID: "cred-valid",
+				TenantID:     "tenant-a",
+				SourceID:     "bootstrap_token",
+				RuntimeID:    "runtime-vault",
+				EventType:    connectorcredentials.AuditEventValidated,
+				Status:       connectorcredentials.StatusValid,
+				CreatedAt:    now,
+			},
+		},
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		ConnectorCredentials: config.ConnectorCredentialConfig{
+			Key:               "test-connector-vault-key",
+			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
+		},
+	}, Dependencies{StateStore: store}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/credential-stores/" + defaultConnectorCredentialStoreID + "?tenant_id=tenant-a")
+	if err != nil {
+		t.Fatalf("GET /credential-stores/{storeID} error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /credential-stores/{storeID} status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		Store struct {
+			Usage struct {
+				Credentials int `json:"credentials"`
+			} `json:"usage"`
+		} `json:"store"`
+		Audit []struct {
+			ID        string `json:"id"`
+			EventType string `json:"event_type"`
+		} `json:"audit"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Store.Usage.Credentials != 1 {
+		t.Fatalf("credentials = %d, want 1", payload.Store.Usage.Credentials)
+	}
+	if len(payload.Audit) != 1 || payload.Audit[0].ID != "audit-validated" || payload.Audit[0].EventType != connectorcredentials.AuditEventValidated {
+		t.Fatalf("audit = %#v, want validated event", payload.Audit)
+	}
 }
 
 func TestConnectorConnectionStoresCredentialReference(t *testing.T) {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -219,6 +219,7 @@ func TestCredentialStoresListReturnsOperationalBindings(t *testing.T) {
 				Id:       "runtime-env",
 				SourceId: "bootstrap_token",
 				TenantId: "tenant-a",
+				// #nosec G101 -- credential store tests use reference-shaped fixture values, not real secrets.
 				Config: map[string]string{
 					"token": "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN",
 				},
@@ -227,6 +228,7 @@ func TestCredentialStoresListReturnsOperationalBindings(t *testing.T) {
 				Id:       "runtime-aws",
 				SourceId: "bootstrap_token",
 				TenantId: "tenant-a",
+				// #nosec G101 -- credential store tests use reference-shaped fixture values, not real secrets.
 				Config: map[string]string{
 					"token": "aws-sm:us-east-1:cerebro/tenant-a/bootstrap_token/runtime-aws/credentials#token",
 				},

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -393,6 +393,16 @@ func TestCredentialStoreDetailReturnsAudit(t *testing.T) {
 				Status:       connectorcredentials.StatusValid,
 				CreatedAt:    now,
 			},
+			{
+				ID:           "audit-used",
+				CredentialID: "cred-valid",
+				TenantID:     "tenant-a",
+				SourceID:     "bootstrap_token",
+				RuntimeID:    "runtime-vault",
+				EventType:    connectorcredentials.AuditEventUsed,
+				Status:       connectorcredentials.StatusValid,
+				CreatedAt:    now.Add(500 * time.Millisecond),
+			},
 		},
 	}
 	app := New(config.Config{
@@ -427,6 +437,7 @@ func TestCredentialStoreDetailReturnsAudit(t *testing.T) {
 		Audit []struct {
 			ID        string `json:"id"`
 			EventType string `json:"event_type"`
+			CreatedAt string `json:"created_at"`
 		} `json:"audit"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
@@ -435,8 +446,14 @@ func TestCredentialStoreDetailReturnsAudit(t *testing.T) {
 	if payload.Store.Usage.Credentials != 1 {
 		t.Fatalf("credentials = %d, want 1", payload.Store.Usage.Credentials)
 	}
-	if len(payload.Audit) != 1 || payload.Audit[0].ID != "audit-validated" || payload.Audit[0].EventType != connectorcredentials.AuditEventValidated {
-		t.Fatalf("audit = %#v, want validated event", payload.Audit)
+	if len(payload.Audit) != 2 {
+		t.Fatalf("audit length = %d, want 2: %#v", len(payload.Audit), payload.Audit)
+	}
+	if payload.Audit[0].ID != "audit-used" || payload.Audit[0].EventType != connectorcredentials.AuditEventUsed {
+		t.Fatalf("audit[0] = %#v, want latest used event", payload.Audit[0])
+	}
+	if payload.Audit[1].ID != "audit-validated" || payload.Audit[1].EventType != connectorcredentials.AuditEventValidated {
+		t.Fatalf("audit[1] = %#v, want earlier validated event", payload.Audit[1])
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/connectordefinitionrecords"
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	credentialstoreshttp "github.com/writer/cerebro/internal/sourcehttp/credentialstores"
 	"github.com/writer/cerebro/internal/sourcehttp/customdashboards"
 	"github.com/writer/cerebro/internal/sourcehttp/userpreferences"
 	"github.com/writer/cerebro/internal/sourceplanapi"
@@ -198,6 +199,9 @@ func (app *App) registerSourceRoutes(mux *http.ServeMux) {
 }
 
 func (app *App) registerConnectorRoutes(mux *http.ServeMux) {
+	credentialStores := credentialstoreshttp.New(credentialstoreshttp.Dependencies{Config: app.cfg, StateStore: app.deps.StateStore, TransitKey: app.connectorTransitKey, SourceService: app.sourceService(), EffectiveTenant: effectiveTenantFilter, RequiresTenantFilter: requiresTenantFilter, TenantAllowed: tenantAllowedByContext, WriteError: writeConnectorError})
+	registerHTTPRoute(mux, "GET /credential-stores", routeSurfacePlatformHTTP, credentialStores.List)
+	registerHTTPRoute(mux, "GET /credential-stores/{storeID}", routeSurfacePlatformHTTP, credentialStores.Get)
 	registerHTTPRoute(mux, "GET /connectors", routeSurfacePlatformHTTP, app.handleListConnectors)
 	registerHTTPRoute(mux, "GET /connectors/coverage", routeSurfacePlatformHTTP, app.handleGetConnectorCoverage)
 	registerHTTPRoute(mux, "GET /connectors/credential-key", routeSurfacePlatformHTTP, app.handleConnectorCredentialKey)

--- a/internal/credentialstores/catalog.go
+++ b/internal/credentialstores/catalog.go
@@ -1,0 +1,229 @@
+package credentialstores
+
+import (
+	"strings"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/connectorsecretstores"
+)
+
+type CatalogInput struct {
+	CredentialKeyConfigured  bool
+	CredentialStoreAvailable bool
+	CredentialStoreDetail    string
+	TransitAvailable         bool
+	SecretStoreConfiguration config.ConnectorSecretStoreConfig
+}
+
+func Catalog(input CatalogInput) []StoreMetadata {
+	vaultAvailable := input.CredentialStoreAvailable && input.CredentialKeyConfigured && input.TransitAvailable
+	vaultStatus := "unavailable"
+	vaultDetail := strings.TrimSpace(input.CredentialStoreDetail)
+	if vaultAvailable {
+		vaultStatus = "ready"
+		vaultDetail = "ready"
+	}
+	if vaultDetail == "" {
+		switch {
+		case !input.CredentialStoreAvailable:
+			vaultDetail = "state store unavailable"
+		case !input.CredentialKeyConfigured:
+			vaultDetail = "credential key unavailable"
+		case !input.TransitAvailable:
+			vaultDetail = "credential transit key unavailable"
+		}
+	}
+	return []StoreMetadata{
+		{
+			ID:          DefaultStoreID,
+			Label:       "Cerebro Vault",
+			Provider:    "Cerebro",
+			Available:   vaultAvailable,
+			Default:     true,
+			Mode:        "encrypted_submission",
+			Status:      vaultStatus,
+			Detail:      vaultDetail,
+			Description: "Cerebro stores one sealed credential envelope in its state store. The browser submits secrets only after encrypting them to the backend transit key.",
+			SetupSteps: []SetupStep{
+				{
+					ID:          "configure_state_store",
+					Label:       "Use a credential-capable state store",
+					Description: "The configured state store must implement connector credential persistence.",
+				},
+				{
+					ID:          "publish_transit_key",
+					Label:       "Publish the credential transit key",
+					Description: "/connectors/credential-key must return the public key used by the browser before encrypted submission.",
+				},
+			},
+			RequiredConfig: []ConfigField{
+				{
+					Env:         "CEREBRO_CONNECTOR_CREDENTIAL_KEY",
+					Label:       "Credential envelope key",
+					Required:    true,
+					Description: "Symmetric key material used to seal connector credentials at rest.",
+				},
+				{
+					Env:         "CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY",
+					Label:       "Browser transit private key",
+					Required:    true,
+					Description: "Private key matching /connectors/credential-key for encrypted browser submissions.",
+				},
+			},
+		},
+		{
+			ID:                         EnvironmentManagedID,
+			Label:                      "Environment managed",
+			Provider:                   "Deployment",
+			Available:                  true,
+			Mode:                       "environment_managed",
+			Status:                     "ready",
+			Detail:                     "ready",
+			Description:                "Cerebro stores env: references and resolves them inside the backend process. The browser never receives the secret value.",
+			ReferencePrefixes:          []string{"env:"},
+			ReferenceNamespaceTemplate: "CEREBRO_SOURCE_<SOURCE>_*",
+			ReferenceFieldTemplate:     "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>",
+			ReferencePlaceholder:       "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>",
+			SetupSteps: []SetupStep{
+				{
+					ID:          "project_env",
+					Label:       "Project secrets into the Cerebro runtime",
+					Description: "Set source-scoped CEREBRO_SOURCE_<SOURCE>_<FIELD> variables or allow explicit shared env names with CEREBRO_SOURCE_CONFIG_ENV_ALLOWLIST.",
+				},
+			},
+		},
+		externalStore(input.SecretStoreConfiguration, InfisicalID, "Infisical", "Infisical"),
+		externalStore(input.SecretStoreConfiguration, GoogleSecretManagerID, "Google Secret Manager", "Google Cloud Platform"),
+		externalStore(input.SecretStoreConfiguration, AWSSecretsManagerID, "AWS Secrets Manager", "Amazon Web Services"),
+		externalStore(input.SecretStoreConfiguration, AzureKeyVaultID, "Azure Key Vault", "Microsoft Azure"),
+		externalStore(input.SecretStoreConfiguration, HashiCorpVaultID, "HashiCorp Vault", "HashiCorp"),
+	}
+}
+
+func externalStore(secretStoreConfig config.ConnectorSecretStoreConfig, id string, label string, provider string) StoreMetadata {
+	enabled := connectorsecretstores.StoreEnabled(secretStoreConfig, id)
+	native := connectorsecretstores.NativeResolutionAvailable(secretStoreConfig, id)
+	status := "needs_configuration"
+	detail := "enable with CEREBRO_CONNECTOR_SECRET_STORES"
+	if enabled {
+		status = "ready"
+		detail = "ready via env projection"
+	}
+	if native {
+		detail = "native resolver ready"
+	}
+	referencePrefixes := connectorsecretstores.ReferencePrefixes(id)
+	if id == AWSSecretsManagerID && !native {
+		referencePrefixes = []string{"env:"}
+	}
+	return StoreMetadata{
+		ID:                         id,
+		Label:                      label,
+		Provider:                   provider,
+		Available:                  enabled,
+		Mode:                       "reference",
+		Status:                     status,
+		Detail:                     detail,
+		Description:                externalStoreDescription(id, label),
+		ReferencePrefixes:          referencePrefixes,
+		ReferenceNamespaceTemplate: referenceNamespaceTemplate(id, native),
+		ReferenceFieldTemplate:     referenceFieldTemplate(id, native),
+		ReferencePlaceholder:       referencePlaceholder(id, native),
+		NativeResolutionAvailable:  native,
+		SetupSteps:                 externalStoreSetupSteps(id, native),
+		RequiredConfig:             externalStoreRequiredConfig(id),
+	}
+}
+
+func externalStoreDescription(id string, label string) string {
+	if id == AWSSecretsManagerID {
+		return "Cerebro can resolve aws-sm: references natively when AWS resolver config is present, or consume env: references projected by deployment automation."
+	}
+	return label + " references are saved as non-secret pointers. Configure deployment-side projection to env: references until a native backend resolver is enabled for this store."
+}
+
+func referencePlaceholder(id string, native bool) string {
+	if id == AWSSecretsManagerID && native {
+		return "aws-sm:us-east-1:cerebro/<tenant>/<source>/<runtime>/credentials#<field>"
+	}
+	return "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>"
+}
+
+func referenceNamespaceTemplate(id string, native bool) string {
+	if id == AWSSecretsManagerID && native {
+		return "cerebro/<tenant>/<source>/<runtime>/credentials"
+	}
+	return "CEREBRO_SOURCE_<SOURCE>_*"
+}
+
+func referenceFieldTemplate(id string, native bool) string {
+	if id == AWSSecretsManagerID && native {
+		return "aws-sm:<region>:cerebro/<tenant>/<source>/<runtime>/credentials#<field>"
+	}
+	return "env:CEREBRO_SOURCE_<SOURCE>_<FIELD>"
+}
+
+func externalStoreSetupSteps(id string, native bool) []SetupStep {
+	steps := []SetupStep{
+		{
+			ID:          "enable_store",
+			Label:       "Enable the store for connector references",
+			Description: "Add the store id to CEREBRO_CONNECTOR_SECRET_STORES before saving references that target it.",
+			Command:     "CEREBRO_CONNECTOR_SECRET_STORES=" + id,
+		},
+		{
+			ID:          "keep_browser_secretless",
+			Label:       "Submit references, not secret values",
+			Description: "The UI should send credential_references only. Secret material is resolved by the backend or projected into the runtime environment.",
+		},
+	}
+	if id == AWSSecretsManagerID {
+		description := "Set CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION to enable native aws-sm: resolution with the AWS SDK."
+		if native {
+			description = "Native aws-sm: resolution is enabled for this deployment."
+		}
+		steps = append(steps, SetupStep{
+			ID:          "configure_native_resolver",
+			Label:       "Configure native AWS resolution",
+			Description: description,
+			Command:     "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION=us-east-1",
+		})
+	}
+	return steps
+}
+
+func externalStoreRequiredConfig(id string) []ConfigField {
+	fields := []ConfigField{
+		{
+			Env:         "CEREBRO_CONNECTOR_SECRET_STORES",
+			Label:       "Enabled connector secret stores",
+			Required:    true,
+			Description: "Comma-separated store ids that this deployment accepts for connector credential references.",
+		},
+	}
+	if id != AWSSecretsManagerID {
+		return fields
+	}
+	return append(fields,
+		ConfigField{
+			Env:         "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_REGION",
+			Label:       "AWS resolver region",
+			Description: "Default region used when aws-sm: references do not include a region.",
+		},
+		ConfigField{
+			Env:         "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_PROFILE",
+			Label:       "AWS shared config profile",
+			Description: "Optional shared AWS config profile used by the backend resolver.",
+		},
+		ConfigField{
+			Env:         "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_ROLE_ARN",
+			Label:       "AWS resolver role",
+			Description: "Optional role the backend assumes before reading secrets.",
+		},
+		ConfigField{
+			Env:         "CEREBRO_CONNECTOR_AWS_SECRETS_MANAGER_EXTERNAL_ID",
+			Label:       "AWS external ID",
+			Description: "Optional external ID used with the resolver role.",
+		},
+	)
+}

--- a/internal/credentialstores/operations.go
+++ b/internal/credentialstores/operations.go
@@ -169,6 +169,7 @@ func BuildOperations(input BuildInput) ListResponse {
 	credentialByID := make(map[string]*ports.ConnectorCredentialRecord, len(input.Credentials))
 	credentialIDsByStore := map[string]map[string]struct{}{}
 	runtimeIDsByStore := map[string]map[string]struct{}{}
+	lastUpdatedByStore := map[string]time.Time{}
 	bindingsByID := map[string]*bindingAccumulator{}
 	issueIDs := map[string]struct{}{}
 	issues := []Issue{}
@@ -298,11 +299,7 @@ func BuildOperations(input BuildInput) ListResponse {
 			runtimeIDsByStore[storeID][binding.view.RuntimeID] = struct{}{}
 		}
 		if !binding.updatedAt.IsZero() {
-			if op.Usage.LastUpdatedAt == "" {
-				op.Usage.LastUpdatedAt = connectorcredentials.TimestampOrZero(binding.updatedAt)
-			} else if parsed, err := time.Parse(time.RFC3339, op.Usage.LastUpdatedAt); err == nil && binding.updatedAt.After(parsed) {
-				op.Usage.LastUpdatedAt = connectorcredentials.TimestampOrZero(binding.updatedAt)
-			}
+			lastUpdatedByStore[storeID] = newerTime(lastUpdatedByStore[storeID], binding.updatedAt)
 		}
 	}
 
@@ -310,6 +307,7 @@ func BuildOperations(input BuildInput) ListResponse {
 		op.Usage.Credentials = len(credentialIDsByStore[storeID])
 		op.Usage.Connections = len(runtimeIDsByStore[storeID])
 		op.Usage.Bindings = len(op.Bindings)
+		op.Usage.LastUpdatedAt = connectorcredentials.TimestampOrZero(lastUpdatedByStore[storeID])
 		sort.Slice(op.Bindings, func(i, j int) bool {
 			return bindingSortKey(op.Bindings[i]) < bindingSortKey(op.Bindings[j])
 		})

--- a/internal/credentialstores/operations.go
+++ b/internal/credentialstores/operations.go
@@ -1,0 +1,697 @@
+package credentialstores
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/connectorsecretstores"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceconfig"
+)
+
+const (
+	DefaultStoreID         = "cerebro_vault"
+	EnvironmentManagedID   = "environment_managed"
+	InfisicalID            = "infisical"
+	GoogleSecretManagerID  = "google_secret_manager"
+	AWSSecretsManagerID    = "aws_secrets_manager"
+	AzureKeyVaultID        = "azure_key_vault"
+	HashiCorpVaultID       = "hashicorp_vault"
+	RuntimeStatusConfigKey = "__cerebro_runtime_status"
+
+	authMethodEncryptedSubmission = "encrypted_submission"
+	authMethodEnvironmentManaged  = "environment_managed"
+	authMethodExternalReference   = "external_reference"
+)
+
+type BuildInput struct {
+	GeneratedAt           time.Time
+	TenantID              string
+	RuntimeStoreStatus    string
+	CredentialStoreStatus string
+	Stores                []StoreMetadata
+	Runtimes              []*cerebrov1.SourceRuntime
+	Credentials           []*ports.ConnectorCredentialRecord
+	SourceNames           map[string]string
+	RequiresTenantFilter  bool
+	TenantAllowed         func(string) bool
+}
+
+type ListResponse struct {
+	GeneratedAt           string        `json:"generated_at"`
+	TenantID              string        `json:"tenant_id,omitempty"`
+	RuntimeStoreStatus    string        `json:"runtime_store_status"`
+	CredentialStoreStatus string        `json:"credential_store_status"`
+	Stores                []Operational `json:"stores"`
+	Issues                []Issue       `json:"issues,omitempty"`
+}
+
+type Operational struct {
+	Store    StoreMetadata `json:"store"`
+	Health   Health        `json:"health"`
+	Usage    Usage         `json:"usage"`
+	Bindings []Binding     `json:"bindings,omitempty"`
+	Issues   []Issue       `json:"issues,omitempty"`
+}
+
+type StoreMetadata struct {
+	ID                         string        `json:"id"`
+	Label                      string        `json:"label"`
+	Provider                   string        `json:"provider"`
+	Available                  bool          `json:"available"`
+	Default                    bool          `json:"default,omitempty"`
+	Mode                       string        `json:"mode"`
+	Status                     string        `json:"status,omitempty"`
+	Detail                     string        `json:"detail,omitempty"`
+	Description                string        `json:"description,omitempty"`
+	ReferencePrefixes          []string      `json:"reference_prefixes,omitempty"`
+	ReferenceNamespaceTemplate string        `json:"reference_namespace_template,omitempty"`
+	ReferenceFieldTemplate     string        `json:"reference_field_template,omitempty"`
+	ReferencePlaceholder       string        `json:"reference_placeholder,omitempty"`
+	NativeResolutionAvailable  bool          `json:"native_resolution_available,omitempty"`
+	SetupSteps                 []SetupStep   `json:"setup_steps,omitempty"`
+	RequiredConfig             []ConfigField `json:"required_config,omitempty"`
+}
+
+type SetupStep struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	Command     string `json:"command,omitempty"`
+}
+
+type ConfigField struct {
+	Env         string `json:"env"`
+	Label       string `json:"label"`
+	Required    bool   `json:"required,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type Health struct {
+	Status     string `json:"status"`
+	Severity   string `json:"severity,omitempty"`
+	Detail     string `json:"detail,omitempty"`
+	NextAction string `json:"next_action,omitempty"`
+}
+
+type Usage struct {
+	Connections     int    `json:"connections"`
+	Credentials     int    `json:"credentials"`
+	Bindings        int    `json:"bindings"`
+	FieldReferences int    `json:"field_references"`
+	Issues          int    `json:"issues"`
+	LastUpdatedAt   string `json:"last_updated_at,omitempty"`
+}
+
+type Binding struct {
+	ID                string   `json:"id"`
+	StoreID           string   `json:"credential_store_id"`
+	SourceID          string   `json:"source_id,omitempty"`
+	SourceName        string   `json:"source_name,omitempty"`
+	RuntimeID         string   `json:"runtime_id,omitempty"`
+	TenantID          string   `json:"tenant_id,omitempty"`
+	AuthMethod        string   `json:"auth_method,omitempty"`
+	Resolver          string   `json:"resolver,omitempty"`
+	CredentialID      string   `json:"credential_id,omitempty"`
+	CredentialStatus  string   `json:"credential_status,omitempty"`
+	ConnectionStatus  string   `json:"connection_status,omitempty"`
+	NextAction        string   `json:"next_action,omitempty"`
+	Fields            []string `json:"fields,omitempty"`
+	FieldCount        int      `json:"field_count,omitempty"`
+	ReferencePrefixes []string `json:"reference_prefixes,omitempty"`
+	UpdatedAt         string   `json:"updated_at,omitempty"`
+	LastUsedAt        string   `json:"last_used_at,omitempty"`
+	LastValidatedAt   string   `json:"last_validated_at,omitempty"`
+}
+
+type Issue struct {
+	ID           string `json:"id"`
+	StoreID      string `json:"credential_store_id,omitempty"`
+	SourceID     string `json:"source_id,omitempty"`
+	RuntimeID    string `json:"runtime_id,omitempty"`
+	CredentialID string `json:"credential_id,omitempty"`
+	Field        string `json:"field,omitempty"`
+	Status       string `json:"status"`
+	Severity     string `json:"severity"`
+	Detail       string `json:"detail"`
+	NextAction   string `json:"next_action,omitempty"`
+}
+
+type bindingAccumulator struct {
+	view            Binding
+	fields          map[string]struct{}
+	referenceFields map[string]struct{}
+	prefixes        map[string]struct{}
+	updatedAt       time.Time
+}
+
+func BuildOperations(input BuildInput) ListResponse {
+	generatedAt := input.GeneratedAt
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	opsByStore := make(map[string]*Operational, len(input.Stores))
+	for _, store := range input.Stores {
+		store := store
+		opsByStore[store.ID] = &Operational{
+			Store:  store,
+			Health: baseHealth(store),
+		}
+	}
+
+	sourceNames := input.SourceNames
+	if sourceNames == nil {
+		sourceNames = map[string]string{}
+	}
+	credentialByID := make(map[string]*ports.ConnectorCredentialRecord, len(input.Credentials))
+	credentialIDsByStore := map[string]map[string]struct{}{}
+	runtimeIDsByStore := map[string]map[string]struct{}{}
+	bindingsByID := map[string]*bindingAccumulator{}
+	issueIDs := map[string]struct{}{}
+	issues := []Issue{}
+
+	addIssue := func(issue Issue) {
+		issue.ID = strings.TrimSpace(issue.ID)
+		if issue.ID == "" {
+			issue.ID = StableID("credential_store_issue", issue.StoreID, issue.SourceID, issue.RuntimeID, issue.CredentialID, issue.Field, issue.Detail)
+		}
+		if _, ok := issueIDs[issue.ID]; ok {
+			return
+		}
+		issueIDs[issue.ID] = struct{}{}
+		if issue.Status == "" {
+			issue.Status = "warning"
+		}
+		if issue.Severity == "" {
+			if issue.Status == "blocked" {
+				issue.Severity = "error"
+			} else {
+				issue.Severity = "warning"
+			}
+		}
+		issues = append(issues, issue)
+		if op, ok := opsByStore[issue.StoreID]; ok {
+			op.Issues = append(op.Issues, issue)
+			op.Usage.Issues++
+		}
+	}
+
+	for _, record := range input.Credentials {
+		if record == nil {
+			continue
+		}
+		if !tenantVisible(input, record.TenantID) {
+			continue
+		}
+		credentialByID[record.ID] = record
+		storeID := firstNonEmpty(record.CredentialStoreID, DefaultStoreID)
+		if _, ok := opsByStore[storeID]; !ok {
+			addIssue(Issue{
+				ID:           StableID("unknown_store", record.ID),
+				StoreID:      storeID,
+				SourceID:     record.SourceID,
+				RuntimeID:    record.RuntimeID,
+				CredentialID: record.ID,
+				Status:       "blocked",
+				Severity:     "error",
+				Detail:       "Credential record uses an unsupported credential store.",
+				NextAction:   "rotate_credential",
+			})
+			continue
+		}
+		if credentialIDsByStore[storeID] == nil {
+			credentialIDsByStore[storeID] = map[string]struct{}{}
+		}
+		credentialIDsByStore[storeID][record.ID] = struct{}{}
+		binding := upsertBinding(bindingsByID, storeID, record.SourceID, sourceNames[record.SourceID], record.RuntimeID, record.TenantID, record.ID)
+		binding.view.AuthMethod = firstNonEmpty(record.AuthMethod, authMethodEncryptedSubmission)
+		binding.view.Resolver = ResolverForStore(storeID, "")
+		binding.view.CredentialStatus = firstNonEmpty(record.Status, connectorcredentials.StatusValid)
+		binding.view.UpdatedAt = connectorcredentials.TimestampOrZero(record.UpdatedAt)
+		binding.view.LastUsedAt = connectorcredentials.TimestampOrZero(record.LastUsedAt)
+		binding.view.LastValidatedAt = connectorcredentials.TimestampOrZero(record.LastValidatedAt)
+		binding.updatedAt = newerTime(binding.updatedAt, record.UpdatedAt)
+		for _, field := range record.Fields {
+			addSetValue(binding.fields, field)
+		}
+		switch firstNonEmpty(record.Status, connectorcredentials.StatusValid) {
+		case connectorcredentials.StatusRevoked:
+			addIssue(Issue{
+				ID:           StableID("revoked_credential", record.ID),
+				StoreID:      storeID,
+				SourceID:     record.SourceID,
+				RuntimeID:    record.RuntimeID,
+				CredentialID: record.ID,
+				Status:       "blocked",
+				Severity:     "error",
+				Detail:       "Credential record is revoked.",
+				NextAction:   "rotate_credential",
+			})
+		case connectorcredentials.StatusValid:
+			if record.LastValidatedAt.IsZero() {
+				addIssue(Issue{
+					ID:           StableID("credential_not_validated", record.ID),
+					StoreID:      storeID,
+					SourceID:     record.SourceID,
+					RuntimeID:    record.RuntimeID,
+					CredentialID: record.ID,
+					Status:       "warning",
+					Severity:     "warning",
+					Detail:       "Credential has no recorded validation check.",
+					NextAction:   "run_connector_preflight",
+				})
+			}
+		}
+	}
+
+	for _, runtime := range input.Runtimes {
+		if runtime == nil {
+			continue
+		}
+		if !tenantVisible(input, runtime.GetTenantId()) {
+			continue
+		}
+		addRuntimeBindings(runtime, sourceNames, credentialByID, bindingsByID, addIssue)
+	}
+
+	for _, binding := range bindingsByID {
+		storeID := binding.view.StoreID
+		op, ok := opsByStore[storeID]
+		if !ok {
+			continue
+		}
+		binding.view.Fields = sortedSetKeys(binding.fields)
+		binding.view.FieldCount = len(binding.view.Fields)
+		binding.view.ReferencePrefixes = sortedSetKeys(binding.prefixes)
+		if binding.view.UpdatedAt == "" && !binding.updatedAt.IsZero() {
+			binding.view.UpdatedAt = connectorcredentials.TimestampOrZero(binding.updatedAt)
+		}
+		op.Bindings = append(op.Bindings, binding.view)
+		op.Usage.FieldReferences += len(binding.referenceFields)
+		if binding.view.RuntimeID != "" {
+			if runtimeIDsByStore[storeID] == nil {
+				runtimeIDsByStore[storeID] = map[string]struct{}{}
+			}
+			runtimeIDsByStore[storeID][binding.view.RuntimeID] = struct{}{}
+		}
+		if !binding.updatedAt.IsZero() {
+			if op.Usage.LastUpdatedAt == "" {
+				op.Usage.LastUpdatedAt = connectorcredentials.TimestampOrZero(binding.updatedAt)
+			} else if parsed, err := time.Parse(time.RFC3339, op.Usage.LastUpdatedAt); err == nil && binding.updatedAt.After(parsed) {
+				op.Usage.LastUpdatedAt = connectorcredentials.TimestampOrZero(binding.updatedAt)
+			}
+		}
+	}
+
+	for storeID, op := range opsByStore {
+		op.Usage.Credentials = len(credentialIDsByStore[storeID])
+		op.Usage.Connections = len(runtimeIDsByStore[storeID])
+		op.Usage.Bindings = len(op.Bindings)
+		sort.Slice(op.Bindings, func(i, j int) bool {
+			return bindingSortKey(op.Bindings[i]) < bindingSortKey(op.Bindings[j])
+		})
+		if (op.Usage.Connections > 0 || op.Usage.Credentials > 0) && !op.Store.Available {
+			addIssue(Issue{
+				ID:         StableID("store_unavailable", storeID),
+				StoreID:    storeID,
+				Status:     "blocked",
+				Severity:   "error",
+				Detail:     "Credential store has saved bindings but is not available in this deployment.",
+				NextAction: "configure_store",
+			})
+		}
+	}
+
+	views := make([]Operational, 0, len(input.Stores))
+	for _, store := range input.Stores {
+		op := opsByStore[store.ID]
+		op.Health = health(*op)
+		views = append(views, *op)
+	}
+	return ListResponse{
+		GeneratedAt:           generatedAt.Format(time.RFC3339),
+		TenantID:              strings.TrimSpace(input.TenantID),
+		RuntimeStoreStatus:    firstNonEmpty(input.RuntimeStoreStatus, "unavailable"),
+		CredentialStoreStatus: firstNonEmpty(input.CredentialStoreStatus, "unavailable"),
+		Stores:                views,
+		Issues:                issues,
+	}
+}
+
+func addRuntimeBindings(runtime *cerebrov1.SourceRuntime, sourceNames map[string]string, credentials map[string]*ports.ConnectorCredentialRecord, bindings map[string]*bindingAccumulator, addIssue func(Issue)) {
+	sourceID := strings.TrimSpace(runtime.GetSourceId())
+	runtimeID := strings.TrimSpace(runtime.GetId())
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	sourceName := sourceNames[sourceID]
+	for key, value := range runtime.GetConfig() {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || sourceconfig.InternalKey(key) {
+			continue
+		}
+		if credentialID, field, ok := sourceconfig.CredentialReference(value); ok {
+			record := credentials[credentialID]
+			storeID := DefaultStoreID
+			authMethod := authMethodEncryptedSubmission
+			status := "missing"
+			if record != nil {
+				storeID = firstNonEmpty(record.CredentialStoreID, DefaultStoreID)
+				authMethod = firstNonEmpty(record.AuthMethod, authMethodEncryptedSubmission)
+				status = firstNonEmpty(record.Status, connectorcredentials.StatusValid)
+			} else {
+				addIssue(Issue{
+					ID:           StableID("missing_credential_record", runtimeID, credentialID, field),
+					StoreID:      storeID,
+					SourceID:     sourceID,
+					RuntimeID:    runtimeID,
+					CredentialID: credentialID,
+					Field:        firstNonEmpty(field, key),
+					Status:       "blocked",
+					Severity:     "error",
+					Detail:       "Runtime references a credential record that is not present.",
+					NextAction:   "rotate_credential",
+				})
+			}
+			binding := upsertBinding(bindings, storeID, sourceID, sourceName, runtimeID, tenantID, credentialID)
+			binding.view.AuthMethod = firstNonEmpty(binding.view.AuthMethod, authMethod)
+			binding.view.Resolver = ResolverForStore(storeID, "credential:")
+			binding.view.CredentialStatus = firstNonEmpty(binding.view.CredentialStatus, status)
+			binding.view.ConnectionStatus = firstNonEmpty(binding.view.ConnectionStatus, runtimeStatus(runtime))
+			binding.view.NextAction = firstNonEmpty(binding.view.NextAction, runtimeNextAction(runtime))
+			addSetValue(binding.fields, firstNonEmpty(field, key))
+			addSetValue(binding.referenceFields, firstNonEmpty(field, key))
+			addSetValue(binding.prefixes, "credential:")
+			continue
+		}
+		if _, ok := sourceconfig.SecretReferenceName(value); ok {
+			binding := upsertBinding(bindings, EnvironmentManagedID, sourceID, sourceName, runtimeID, tenantID, "")
+			binding.view.AuthMethod = firstNonEmpty(binding.view.AuthMethod, authMethodEnvironmentManaged)
+			binding.view.Resolver = ResolverForStore(EnvironmentManagedID, "env:")
+			binding.view.ConnectionStatus = firstNonEmpty(binding.view.ConnectionStatus, runtimeStatus(runtime))
+			binding.view.NextAction = firstNonEmpty(binding.view.NextAction, runtimeNextAction(runtime))
+			addSetValue(binding.fields, key)
+			addSetValue(binding.referenceFields, key)
+			addSetValue(binding.prefixes, "env:")
+			continue
+		}
+		ref, ok, err := connectorsecretstores.ParseReference(value)
+		if err != nil {
+			addIssue(Issue{
+				ID:         StableID("invalid_native_reference", runtimeID, key),
+				StoreID:    StoreIDForNativeReference(value),
+				SourceID:   sourceID,
+				RuntimeID:  runtimeID,
+				Field:      key,
+				Status:     "blocked",
+				Severity:   "error",
+				Detail:     "Runtime credential reference has an invalid secret-store address.",
+				NextAction: "fix_credential_reference",
+			})
+			continue
+		}
+		if ok {
+			storeID := ref.StoreID
+			binding := upsertBinding(bindings, storeID, sourceID, sourceName, runtimeID, tenantID, "")
+			binding.view.AuthMethod = firstNonEmpty(binding.view.AuthMethod, authMethodExternalReference)
+			binding.view.Resolver = ResolverForStore(storeID, ref.Prefix)
+			binding.view.ConnectionStatus = firstNonEmpty(binding.view.ConnectionStatus, runtimeStatus(runtime))
+			binding.view.NextAction = firstNonEmpty(binding.view.NextAction, runtimeNextAction(runtime))
+			addSetValue(binding.fields, key)
+			addSetValue(binding.referenceFields, key)
+			addSetValue(binding.prefixes, ref.Prefix)
+			if err := validateReferenceForRuntime(storeID, sourceID, tenantID, runtimeID, map[string]string{key: value}); err != nil {
+				addIssue(Issue{
+					ID:         StableID("reference_boundary", runtimeID, key),
+					StoreID:    storeID,
+					SourceID:   sourceID,
+					RuntimeID:  runtimeID,
+					Field:      key,
+					Status:     "blocked",
+					Severity:   "error",
+					Detail:     "Runtime credential reference is not allowed for this store or runtime scope.",
+					NextAction: "fix_credential_reference",
+				})
+			}
+			continue
+		}
+		if sourceconfig.SensitiveKey(key) {
+			addIssue(Issue{
+				ID:         StableID("plaintext_sensitive_config", runtimeID, key),
+				SourceID:   sourceID,
+				RuntimeID:  runtimeID,
+				Field:      key,
+				Status:     "blocked",
+				Severity:   "error",
+				Detail:     "Sensitive runtime field is stored without a credential reference.",
+				NextAction: "replace_with_credential_reference",
+			})
+		}
+	}
+}
+
+func validateReferenceForRuntime(storeID string, sourceID string, tenantID string, runtimeID string, references map[string]string) error {
+	for _, value := range references {
+		if err := connectorsecretstores.ValidateReferenceForStore(storeID, value); err != nil {
+			return err
+		}
+		if err := connectorsecretstores.AuthorizeRuntimeReferences(sourceID, tenantID, runtimeID, references); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertBinding(bindings map[string]*bindingAccumulator, storeID string, sourceID string, sourceName string, runtimeID string, tenantID string, credentialID string) *bindingAccumulator {
+	key := StableID("binding", storeID, sourceID, runtimeID, tenantID, credentialID)
+	if credentialID == "" {
+		key = StableID("binding", storeID, sourceID, runtimeID, tenantID, "references")
+	}
+	binding, ok := bindings[key]
+	if ok {
+		return binding
+	}
+	if sourceName == "" && sourceID != "" {
+		sourceName = sourceID
+	}
+	binding = &bindingAccumulator{
+		view: Binding{
+			ID:         key,
+			StoreID:    storeID,
+			SourceID:   sourceID,
+			SourceName: sourceName,
+			RuntimeID:  runtimeID,
+			TenantID:   tenantID,
+		},
+		fields:          map[string]struct{}{},
+		referenceFields: map[string]struct{}{},
+		prefixes:        map[string]struct{}{},
+	}
+	if credentialID != "" {
+		binding.view.CredentialID = credentialID
+	}
+	bindings[key] = binding
+	return binding
+}
+
+func baseHealth(store StoreMetadata) Health {
+	status := firstNonEmpty(store.Status, "needs_configuration")
+	severity := "warning"
+	nextAction := "configure_store"
+	if store.Available {
+		status = "ready"
+		severity = "success"
+		nextAction = "connect_source"
+	}
+	return Health{
+		Status:     status,
+		Severity:   severity,
+		Detail:     store.Detail,
+		NextAction: nextAction,
+	}
+}
+
+func health(op Operational) Health {
+	hasError := false
+	hasWarning := false
+	for _, issue := range op.Issues {
+		switch issue.Severity {
+		case "error":
+			hasError = true
+		case "warning":
+			hasWarning = true
+		}
+	}
+	inUse := op.Usage.Connections > 0 || op.Usage.Credentials > 0
+	switch {
+	case hasError:
+		return Health{
+			Status:     "needs_attention",
+			Severity:   "error",
+			Detail:     "Credential bindings need operator action.",
+			NextAction: "fix_credential_store_issues",
+		}
+	case hasWarning:
+		return Health{
+			Status:     "warning",
+			Severity:   "warning",
+			Detail:     "Credential bindings have warnings to review.",
+			NextAction: "review_credential_store_warnings",
+		}
+	case inUse && op.Store.Available:
+		return Health{
+			Status:     "in_use",
+			Severity:   "success",
+			Detail:     "Credential store has active runtime bindings.",
+			NextAction: "monitor_rotation",
+		}
+	case op.Store.Available:
+		return Health{
+			Status:     "ready",
+			Severity:   "success",
+			Detail:     "Credential store is ready for new connector bindings.",
+			NextAction: "connect_source",
+		}
+	default:
+		return baseHealth(op.Store)
+	}
+}
+
+func runtimeStatus(runtime *cerebrov1.SourceRuntime) string {
+	status := strings.TrimSpace(runtime.GetConfig()[RuntimeStatusConfigKey])
+	if status == "" {
+		return "configured"
+	}
+	return status
+}
+
+func runtimeNextAction(runtime *cerebrov1.SourceRuntime) string {
+	switch runtimeStatus(runtime) {
+	case "healthy", "ready":
+		return "monitor_runtime"
+	case "failed", "degraded", "needs_attention":
+		return "fix_runtime"
+	default:
+		return "run_source_check"
+	}
+}
+
+func ResolverForStore(storeID string, prefix string) string {
+	switch strings.TrimSpace(storeID) {
+	case DefaultStoreID:
+		return "cerebro_vault"
+	case EnvironmentManagedID:
+		return "environment"
+	case AWSSecretsManagerID:
+		if prefix == connectorsecretstores.PrefixAWSSecretsManager {
+			return "native"
+		}
+		return "environment_projection"
+	case InfisicalID, GoogleSecretManagerID, AzureKeyVaultID, HashiCorpVaultID:
+		if strings.TrimSpace(prefix) != "" && prefix != "env:" {
+			return "native_reference"
+		}
+		return "environment_projection"
+	default:
+		return "unknown"
+	}
+}
+
+func StoreIDForNativeReference(value string) string {
+	value = strings.TrimSpace(value)
+	switch {
+	case strings.HasPrefix(value, connectorsecretstores.PrefixAWSSecretsManager):
+		return AWSSecretsManagerID
+	case strings.HasPrefix(value, connectorsecretstores.PrefixGoogleSecretMgr):
+		return GoogleSecretManagerID
+	case strings.HasPrefix(value, connectorsecretstores.PrefixAzureKeyVault):
+		return AzureKeyVaultID
+	case strings.HasPrefix(value, connectorsecretstores.PrefixHashiCorpVault):
+		return HashiCorpVaultID
+	case strings.HasPrefix(value, connectorsecretstores.PrefixInfisical):
+		return InfisicalID
+	default:
+		return ""
+	}
+}
+
+func bindingSortKey(binding Binding) string {
+	return strings.ToLower(strings.Join([]string{
+		binding.SourceName,
+		binding.SourceID,
+		binding.RuntimeID,
+		binding.CredentialID,
+	}, "\x00"))
+}
+
+func StableID(parts ...string) string {
+	builder := strings.Builder{}
+	for _, part := range parts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part == "" {
+			continue
+		}
+		if builder.Len() > 0 {
+			builder.WriteByte('_')
+		}
+		for _, char := range part {
+			switch {
+			case char >= 'a' && char <= 'z':
+				builder.WriteRune(char)
+			case char >= '0' && char <= '9':
+				builder.WriteRune(char)
+			default:
+				builder.WriteByte('_')
+			}
+		}
+	}
+	return strings.Trim(builder.String(), "_")
+}
+
+func tenantVisible(input BuildInput, tenantID string) bool {
+	if !input.RequiresTenantFilter {
+		return true
+	}
+	if input.TenantAllowed == nil {
+		return false
+	}
+	return input.TenantAllowed(tenantID)
+}
+
+func addSetValue(set map[string]struct{}, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	set[value] = struct{}{}
+}
+
+func newerTime(left time.Time, right time.Time) time.Time {
+	if right.IsZero() {
+		return left
+	}
+	if left.IsZero() || right.After(left) {
+		return right
+	}
+	return left
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func sortedSetKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/credentialstores/operations_test.go
+++ b/internal/credentialstores/operations_test.go
@@ -1,0 +1,52 @@
+package credentialstores
+
+import (
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/connectorcredentials"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestBuildOperationsUsesNewestCredentialUpdateWithFractionalTimestamp(t *testing.T) {
+	olderFractional := time.Date(2026, 6, 28, 10, 0, 0, 500_000_000, time.UTC)
+	newerWholeSecond := time.Date(2026, 6, 28, 10, 0, 1, 0, time.UTC)
+
+	response := BuildOperations(BuildInput{
+		GeneratedAt: time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC),
+		Stores: []StoreMetadata{
+			{
+				ID:        DefaultStoreID,
+				Label:     "Cerebro Vault",
+				Available: true,
+			},
+		},
+		Credentials: []*ports.ConnectorCredentialRecord{
+			{
+				ID:                "cred-older",
+				TenantID:          "tenant-a",
+				SourceID:          "bootstrap_token",
+				RuntimeID:         "runtime-older",
+				CredentialStoreID: DefaultStoreID,
+				UpdatedAt:         olderFractional,
+				Fields:            []string{"token"},
+			},
+			{
+				ID:                "cred-newer",
+				TenantID:          "tenant-a",
+				SourceID:          "bootstrap_token",
+				RuntimeID:         "runtime-newer",
+				CredentialStoreID: DefaultStoreID,
+				UpdatedAt:         newerWholeSecond,
+				Fields:            []string{"token"},
+			},
+		},
+	})
+
+	if len(response.Stores) != 1 {
+		t.Fatalf("stores = %d, want 1", len(response.Stores))
+	}
+	if got, want := response.Stores[0].Usage.LastUpdatedAt, connectorcredentials.TimestampOrZero(newerWholeSecond); got != want {
+		t.Fatalf("last_updated_at = %q, want %q", got, want)
+	}
+}

--- a/internal/sourcehttp/credentialstores/handler.go
+++ b/internal/sourcehttp/credentialstores/handler.go
@@ -230,12 +230,25 @@ func (h *Handler) auditEvents(ctx context.Context, bindings []domain.Binding, li
 		}
 	}
 	sort.Slice(events, func(i, j int) bool {
-		return events[i].CreatedAt > events[j].CreatedAt
+		left := auditEventCreatedAt(events[i])
+		right := auditEventCreatedAt(events[j])
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return events[i].ID < events[j].ID
 	})
 	if len(events) > limit {
 		return events[:limit]
 	}
 	return events
+}
+
+func auditEventCreatedAt(event auditEvent) time.Time {
+	createdAt, err := time.Parse(time.RFC3339Nano, event.CreatedAt)
+	if err != nil {
+		return time.Time{}
+	}
+	return createdAt
 }
 
 func auditEvents(records []*ports.ConnectorCredentialAuditRecord) []auditEvent {

--- a/internal/sourcehttp/credentialstores/handler.go
+++ b/internal/sourcehttp/credentialstores/handler.go
@@ -167,7 +167,7 @@ func (h *Handler) runtimes(ctx context.Context, tenantID string, limit int) ([]*
 	}
 	runtimes, err := lister.ListSourceRuntimes(ctx, ports.SourceRuntimeFilter{
 		TenantID: strings.TrimSpace(tenantID),
-		Limit:    uint32(limit),
+		Limit:    uint32(limit), // #nosec G115 -- queryLimit clamps list requests to maxLimit.
 	})
 	if err != nil {
 		return nil, "unavailable", err

--- a/internal/sourcehttp/credentialstores/handler.go
+++ b/internal/sourcehttp/credentialstores/handler.go
@@ -1,0 +1,350 @@
+package credentialstores
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/connectorcredentials"
+	domain "github.com/writer/cerebro/internal/credentialstores"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceops"
+)
+
+const (
+	defaultLimit = 500
+	maxLimit     = 1000
+)
+
+type Dependencies struct {
+	Config               config.Config
+	StateStore           ports.StateStore
+	TransitKey           *connectorcredentials.TransitKey
+	SourceService        *sourceops.Service
+	EffectiveTenant      func(context.Context, string) (string, error)
+	RequiresTenantFilter func(context.Context) bool
+	TenantAllowed        func(context.Context, string) bool
+	WriteError           func(http.ResponseWriter, error)
+}
+
+type Handler struct {
+	deps Dependencies
+}
+
+type detailResponse struct {
+	GeneratedAt           string             `json:"generated_at"`
+	TenantID              string             `json:"tenant_id,omitempty"`
+	RuntimeStoreStatus    string             `json:"runtime_store_status"`
+	CredentialStoreStatus string             `json:"credential_store_status"`
+	Store                 domain.Operational `json:"store"`
+	Audit                 []auditEvent       `json:"audit,omitempty"`
+}
+
+type auditEvent struct {
+	ID           string `json:"id"`
+	CredentialID string `json:"credential_id"`
+	TenantID     string `json:"tenant_id"`
+	SourceID     string `json:"source_id"`
+	RuntimeID    string `json:"runtime_id"`
+	EventType    string `json:"event_type"`
+	Actor        string `json:"actor,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Detail       string `json:"detail,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+}
+
+func New(deps Dependencies) *Handler {
+	return &Handler{deps: deps}
+}
+
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	tenantID, err := h.effectiveTenant(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	limit, err := queryLimit(r)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response, err := h.operations(r.Context(), tenantID, limit)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	storeID := strings.TrimSpace(r.PathValue("storeID"))
+	if storeID == "" {
+		h.writeError(w, connectorcredentials.ErrInvalidRequest)
+		return
+	}
+	tenantID, err := h.effectiveTenant(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	limit, err := queryLimit(r)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response, err := h.operations(r.Context(), tenantID, limit)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	for _, store := range response.Stores {
+		if store.Store.ID != storeID {
+			continue
+		}
+		writeJSON(w, http.StatusOK, detailResponse{
+			GeneratedAt:           response.GeneratedAt,
+			TenantID:              response.TenantID,
+			RuntimeStoreStatus:    response.RuntimeStoreStatus,
+			CredentialStoreStatus: response.CredentialStoreStatus,
+			Store:                 store,
+			Audit:                 h.auditEvents(r.Context(), store.Bindings, 50),
+		})
+		return
+	}
+	http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+}
+
+func (h *Handler) operations(ctx context.Context, tenantID string, limit int) (domain.ListResponse, error) {
+	runtimes, runtimeStoreStatus, err := h.runtimes(ctx, tenantID, limit)
+	if err != nil {
+		return domain.ListResponse{}, err
+	}
+	records, credentialStoreStatus, err := h.credentialRecords(ctx, tenantID, limit)
+	if err != nil {
+		return domain.ListResponse{}, err
+	}
+	return domain.BuildOperations(domain.BuildInput{
+		GeneratedAt:           time.Now().UTC(),
+		TenantID:              tenantID,
+		RuntimeStoreStatus:    runtimeStoreStatus,
+		CredentialStoreStatus: credentialStoreStatus,
+		Stores:                h.catalog(),
+		Runtimes:              runtimes,
+		Credentials:           records,
+		SourceNames:           h.sourceNames(),
+		RequiresTenantFilter:  h.requiresTenantFilter(ctx),
+		TenantAllowed: func(candidate string) bool {
+			return h.tenantAllowed(ctx, candidate)
+		},
+	}), nil
+}
+
+func (h *Handler) catalog() []domain.StoreMetadata {
+	return domain.Catalog(domain.CatalogInput{
+		CredentialKeyConfigured:  strings.TrimSpace(h.deps.Config.ConnectorCredentials.Key) != "",
+		CredentialStoreAvailable: connectorCredentialStore(h.deps.StateStore) != nil,
+		TransitAvailable:         h.deps.TransitKey != nil,
+		SecretStoreConfiguration: h.deps.Config.ConnectorSecretStores,
+	})
+}
+
+func (h *Handler) runtimes(ctx context.Context, tenantID string, limit int) ([]*cerebrov1.SourceRuntime, string, error) {
+	store := sourceRuntimeStore(h.deps.StateStore)
+	if store == nil {
+		return nil, "unavailable", nil
+	}
+	lister, ok := store.(ports.SourceRuntimeListStore)
+	if !ok {
+		return nil, "unavailable", nil
+	}
+	runtimes, err := lister.ListSourceRuntimes(ctx, ports.SourceRuntimeFilter{
+		TenantID: strings.TrimSpace(tenantID),
+		Limit:    uint32(limit),
+	})
+	if err != nil {
+		return nil, "unavailable", err
+	}
+	return runtimes, "ready", nil
+}
+
+func (h *Handler) credentialRecords(ctx context.Context, tenantID string, limit int) ([]*ports.ConnectorCredentialRecord, string, error) {
+	store := connectorCredentialStore(h.deps.StateStore)
+	if store == nil {
+		return nil, "unavailable", nil
+	}
+	records, err := store.ListConnectorCredentials(ctx, ports.ConnectorCredentialFilter{
+		TenantID: strings.TrimSpace(tenantID),
+		Limit:    limit,
+	})
+	if err != nil {
+		return nil, "unavailable", err
+	}
+	return records, "ready", nil
+}
+
+func (h *Handler) sourceNames() map[string]string {
+	names := map[string]string{}
+	if h.deps.SourceService == nil {
+		return names
+	}
+	for _, source := range h.deps.SourceService.List().GetSources() {
+		if source == nil {
+			continue
+		}
+		names[source.GetId()] = firstNonEmpty(source.GetName(), source.GetId())
+	}
+	return names
+}
+
+func (h *Handler) auditEvents(ctx context.Context, bindings []domain.Binding, limit int) []auditEvent {
+	store := connectorCredentialStore(h.deps.StateStore)
+	if store == nil || limit <= 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	events := []auditEvent{}
+	for _, binding := range bindings {
+		credentialID := strings.TrimSpace(binding.CredentialID)
+		if credentialID == "" {
+			continue
+		}
+		if _, ok := seen[credentialID]; ok {
+			continue
+		}
+		seen[credentialID] = struct{}{}
+		records, err := store.ListConnectorCredentialAuditEvents(ctx, credentialID, limit-len(events))
+		if err != nil {
+			return events
+		}
+		events = append(events, auditEvents(records)...)
+		if len(events) >= limit {
+			break
+		}
+	}
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].CreatedAt > events[j].CreatedAt
+	})
+	if len(events) > limit {
+		return events[:limit]
+	}
+	return events
+}
+
+func auditEvents(records []*ports.ConnectorCredentialAuditRecord) []auditEvent {
+	events := make([]auditEvent, 0, len(records))
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		events = append(events, auditEvent{
+			ID:           record.ID,
+			CredentialID: record.CredentialID,
+			TenantID:     record.TenantID,
+			SourceID:     record.SourceID,
+			RuntimeID:    record.RuntimeID,
+			EventType:    record.EventType,
+			Actor:        record.Actor,
+			Status:       record.Status,
+			Detail:       record.Detail,
+			CreatedAt:    connectorcredentials.TimestampOrZero(record.CreatedAt),
+		})
+	}
+	return events
+}
+
+func (h *Handler) effectiveTenant(ctx context.Context, requested string) (string, error) {
+	if h.deps.EffectiveTenant == nil {
+		return strings.TrimSpace(requested), nil
+	}
+	return h.deps.EffectiveTenant(ctx, requested)
+}
+
+func (h *Handler) requiresTenantFilter(ctx context.Context) bool {
+	return h.deps.RequiresTenantFilter != nil && h.deps.RequiresTenantFilter(ctx)
+}
+
+func (h *Handler) tenantAllowed(ctx context.Context, tenantID string) bool {
+	return h.deps.TenantAllowed == nil || h.deps.TenantAllowed(ctx, tenantID)
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, err error) {
+	if h.deps.WriteError != nil {
+		h.deps.WriteError(w, err)
+		return
+	}
+	status := http.StatusInternalServerError
+	if errors.Is(err, connectorcredentials.ErrInvalidRequest) {
+		status = http.StatusBadRequest
+	}
+	http.Error(w, http.StatusText(status), status)
+}
+
+func queryLimit(r *http.Request) (int, error) {
+	value := strings.TrimSpace(r.URL.Query().Get("limit"))
+	if value == "" {
+		return defaultLimit, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return 0, connectorcredentials.ErrInvalidRequest
+	}
+	if parsed == 0 {
+		return defaultLimit, nil
+	}
+	if parsed > maxLimit {
+		return maxLimit, nil
+	}
+	return parsed, nil
+}
+
+func writeJSON(w http.ResponseWriter, statusCode int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
+	runtimeStore, ok := store.(ports.SourceRuntimeStore)
+	if !ok || isNilInterface(runtimeStore) {
+		return nil
+	}
+	return runtimeStore
+}
+
+func connectorCredentialStore(store ports.StateStore) ports.ConnectorCredentialStore {
+	credentialStore, ok := store.(ports.ConnectorCredentialStore)
+	if !ok || isNilInterface(credentialStore) {
+		return nil
+	}
+	return credentialStore
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -74,8 +74,11 @@ import (
 // the read tool also trims event and preview-event arrays at the response
 // boundary so MCP clients cannot receive an unbounded source page. The same MCP
 // source boundary calls sourceops preview-config validation before tenant checks
-// so reserved runtime keys cannot cross the MCP transport layer.
-const bootstrapProductionGoLineBudget = 26690
+// so reserved runtime keys cannot cross the MCP transport layer. Credential
+// store operations add only route wiring plus auth policy for a handler in
+// internal/sourcehttp/credentialstores; the read model lives in
+// internal/credentialstores.
+const bootstrapProductionGoLineBudget = 26698
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- Add first-class `/credential-stores` and `/credential-stores/{storeID}` endpoints for credential-store operations.
- Build the read model outside bootstrap in `internal/credentialstores`, with HTTP wiring in `internal/sourcehttp/credentialstores`.
- Return non-secret store health, runtime bindings, credential metadata, setup issues, and audit events.
- Update OpenAPI and add endpoint tests that verify bindings, issue states, audit events, and no secret/reference-value leakage.

## Impact
The frontend can render credential-store operations from backend state instead of static connector metadata. This does not add a new store or change persisted runtime shape.

## Validation
- `make test`
- `make openapi-check`
- `make openapi-lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->