### PR TITLE
[codex] improve JetStream finding reliability

### DIFF
--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -1445,6 +1445,74 @@ func TestReplayLegacyFullScanKeepsNewestOccurredCandidates(t *testing.T) {
 	}
 }
 
+func TestReplayScansLegacyRangeWithBoundedCandidateMemory(t *testing.T) {
+	msgs := make(map[uint64]*natsjetstream.RawStreamMsg)
+	for seq := uint64(1); seq <= 100; seq++ {
+		msgs[seq] = rawReplayMsg(t, "events.github.audit", replayEvent("evt-"+strconv.FormatUint(seq, 10), "github.audit", "writer-github"))
+	}
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 100},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{"CEREBRO_EVENTS": msgs},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 2})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if got, want := replayedEventIDs(events), []string{"evt-99", "evt-100"}; !slices.Equal(got, want) {
+		t.Fatalf("replayed ids = %#v, want newest append-order ids %#v", got, want)
+	}
+	if replay.getMsgCalls != 100 {
+		t.Fatalf("getMsgCalls = %d, want full legacy scan with bounded candidate memory", replay.getMsgCalls)
+	}
+}
+
+func TestReplayReturnsNewestOccurredEventsBeyondCandidateWindow(t *testing.T) {
+	base := time.Date(2026, 5, 13, 18, 0, 0, 0, time.UTC)
+	msgs := make(map[uint64]*natsjetstream.RawStreamMsg)
+	for seq := uint64(1); seq <= 100; seq++ {
+		occurredAt := base.Add(time.Duration(101-seq) * time.Minute)
+		id := "evt-" + strconv.FormatUint(seq, 10)
+		msgs[seq] = rawReplayMsg(t, "events.github.audit", replayEventAt(id, "github.audit", "writer-github", occurredAt))
+	}
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 100},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{"CEREBRO_EVENTS": msgs},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 2})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got, want := replayedEventIDs(events), []string{"evt-1", "evt-2"}; !slices.Equal(got, want) {
+		t.Fatalf("replayed ids = %#v, want newest occurred ids %#v", got, want)
+	}
+	if replay.getMsgCalls != 100 {
+		t.Fatalf("getMsgCalls = %d, want full legacy scan so newest occurred events beyond the old candidate window are visible", replay.getMsgCalls)
+	}
+}
+
 func TestSubjectMatchesRequiresTokenForFullWildcard(t *testing.T) {
 	if subjectMatches("events.>", "events") {
 		t.Fatal("subjectMatches(events.>, events) = true, want false")
@@ -1941,6 +2009,7 @@ func TestReplayRuntimeIndexedSkipsUnnarrowedFilters(t *testing.T) {
 }
 
 func TestScanRuntimeIndexCollectsRuntimeEntries(t *testing.T) {
+	indexedAt := time.Date(2026, 5, 13, 18, 0, 0, 0, time.UTC)
 	replay := &fakeReplayManager{
 		streams: []*natsjetstream.StreamInfo{
 			{
@@ -1950,7 +2019,7 @@ func TestScanRuntimeIndexCollectsRuntimeEntries(t *testing.T) {
 		},
 		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
 			"CEREBRO_EVENTS": {
-				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				1: rawReplayMsg(t, "events.github.audit", replayEventAt("evt-1", "github.audit", "writer-github", indexedAt)),
 				2: rawReplayMsg(t, "events.github.audit", replayEvent("evt-2", "github.audit", "other-runtime")),
 				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "writer-github")),
 				4: rawReplayMsg(t, "events.ignored", replayEvent("evt-4", "ignored", "")),
@@ -1972,6 +2041,9 @@ func TestScanRuntimeIndexCollectsRuntimeEntries(t *testing.T) {
 	first := scan.Entries[0]
 	if first.RuntimeID != "writer-github" || first.Seq != 1 || first.Kind != "github.audit" {
 		t.Fatalf("first entry = %#v, want writer-github seq 1 github.audit", first)
+	}
+	if !first.OccurredAt.Equal(indexedAt) {
+		t.Fatalf("first entry occurred_at = %v, want %v", first.OccurredAt, indexedAt)
 	}
 }
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1049,10 +1049,12 @@ func (s *bootstrapService) EvaluateSourceRuntimeFindingRules(ctx context.Context
 		RuleIDs:    req.Msg.GetRuleIds(),
 		EventLimit: req.Msg.GetEventLimit(),
 	})
+	if response != nil {
+		bumpGRCCacheForRuntime(ctx, s.deps, req.Msg.GetId(), grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
+	}
 	if err != nil {
 		return nil, findingConnectError(err)
 	}
-	bumpGRCCacheForRuntime(ctx, s.deps, req.Msg.GetId(), grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	return connect.NewResponse(findingRulesResponse(response)), nil
 }
 

--- a/internal/bootstrap/finding_handlers.go
+++ b/internal/bootstrap/finding_handlers.go
@@ -350,11 +350,13 @@ func (a *App) handleEvaluateSourceRuntimeFindingRules(w http.ResponseWriter, r *
 		RuleIDs:    request.GetRuleIds(),
 		EventLimit: request.GetEventLimit(),
 	})
+	if response != nil {
+		bumpGRCCacheForRuntime(r.Context(), a.deps, request.GetId(), grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
+	}
 	if err != nil {
 		writeFindingError(w, err)
 		return
 	}
-	bumpGRCCacheForRuntime(r.Context(), a.deps, request.GetId(), grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	writeProtoJSON(w, http.StatusOK, findingRulesResponse(response))
 }
 

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -224,14 +224,11 @@ func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job
 	if err != nil {
 		return nil, nil, err
 	}
-	ruleResult, err := a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+	ruleResult, ruleErr := a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
 		RuntimeID:  runtimeID,
 		RuleIDs:    stringSlicePayload(job.Payload, "rule_ids"),
 		EventLimit: uint32Payload(job.Payload, "event_limit"),
 	})
-	if err != nil {
-		return nil, nil, err
-	}
 	graphPayload, err := json.Marshal(graphResult)
 	if err != nil {
 		return nil, nil, err
@@ -253,7 +250,13 @@ func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job
 	if graphResult.Run.ID != "" {
 		refs["graph_ingest_run_id"] = graphResult.Run.ID
 	}
-	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeRuntime, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeGraph, grcCacheScopeInventory)
+	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeRuntime, grcCacheScopeGraph, grcCacheScopeInventory)
+	if ruleResult != nil {
+		bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
+	}
+	if ruleErr != nil {
+		return result, refs, ruleErr
+	}
 	return result, refs, nil
 }
 
@@ -289,21 +292,23 @@ func (a *App) runFindingRulesEvaluateJob(ctx context.Context, job *ports.Job, _ 
 	if runtimeID == "" {
 		return nil, nil, fmt.Errorf("%w: runtime_id is required", platformjobs.ErrInvalidRequest)
 	}
-	result, err := a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+	result, evaluationErr := a.findingService().EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
 		RuntimeID:  runtimeID,
 		RuleIDs:    stringSlicePayload(job.Payload, "rule_ids"),
 		EventLimit: uint32Payload(job.Payload, "event_limit"),
 	})
-	if err != nil {
-		return nil, nil, err
+	if result != nil {
+		bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	}
-	bumpGRCCacheForRuntime(ctx, a.deps, runtimeID, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeInventory)
 	payload, err := json.Marshal(result)
 	if err != nil {
 		return nil, nil, err
 	}
 	out := map[string]any{}
 	_ = json.Unmarshal(payload, &out)
+	if evaluationErr != nil {
+		return out, nil, evaluationErr
+	}
 	return out, nil, nil
 }
 

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -167,6 +167,7 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 		}
 	}
 	result.EventsEvaluated = boundedUint32(len(events))
+	var evaluationErr error
 	for _, event := range events {
 		for _, state := range states {
 			if state.failed || !state.rule.SupportsRuntime(runtime) {
@@ -174,7 +175,9 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 			}
 			emitted, err := state.rule.Evaluate(ctx, runtime, event)
 			if err != nil {
-				if failErr := s.markCandidateEvaluationFailed(ctx, state, fmt.Errorf("evaluate finding candidate rule %q for event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
+				ruleErr := fmt.Errorf("evaluate finding candidate rule %q for event %q: %w", state.result.Rule.GetId(), event.GetId(), err)
+				evaluationErr = errors.Join(evaluationErr, ruleErr)
+				if failErr := s.markCandidateEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 					return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
 				}
 				continue
@@ -195,7 +198,9 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 				candidateFinding := normalizeCandidateFinding(record, runtime, startedAt)
 				config, err := s.riskScoringConfigForFinding(ctx, candidateFinding)
 				if err != nil {
-					if failErr := s.markCandidateEvaluationFailed(ctx, state, fmt.Errorf("load risk scoring config for candidate finding %q: %w", candidateFinding.ID, err)); failErr != nil {
+					ruleErr := fmt.Errorf("load risk scoring config for candidate finding %q: %w", candidateFinding.ID, err)
+					evaluationErr = errors.Join(evaluationErr, ruleErr)
+					if failErr := s.markCandidateEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 						return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
 					}
 					break
@@ -203,7 +208,9 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 				candidateFinding = recomputeFindingRiskWithConfig(candidateFinding, startedAt, config)
 				evidence, err := s.buildFindingEvidence(ctx, candidateFinding, candidateEvidenceRun(state.run))
 				if err != nil {
-					if failErr := s.markCandidateEvaluationFailed(ctx, state, fmt.Errorf("build candidate evidence for finding %q: %w", candidateFinding.ID, err)); failErr != nil {
+					ruleErr := fmt.Errorf("build candidate evidence for finding %q: %w", candidateFinding.ID, err)
+					evaluationErr = errors.Join(evaluationErr, ruleErr)
+					if failErr := s.markCandidateEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 						return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
 					}
 					break
@@ -211,7 +218,9 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 				candidate := newFindingCandidateRecord(candidateFinding, evidence, state.run.ID)
 				stored, err := s.candidateStore.UpsertFindingCandidate(ctx, candidate)
 				if err != nil {
-					if failErr := s.markCandidateEvaluationFailed(ctx, state, fmt.Errorf("persist finding candidate %q: %w", candidate.ID, err)); failErr != nil {
+					ruleErr := fmt.Errorf("persist finding candidate %q: %w", candidate.ID, err)
+					evaluationErr = errors.Join(evaluationErr, ruleErr)
+					if failErr := s.markCandidateEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 						return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
 					}
 					break
@@ -236,12 +245,17 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 			EvaluatedEventIDs: state.evaluatedEventIDs,
 			RunStartedAt:      state.run.StartedAt,
 		}); err != nil {
-			return nil, s.markCandidateEvaluationsFailed(ctx, unfinishedCandidateEvaluations(states, state), fmt.Errorf("expire stale finding candidates for run %q: %w", state.run.ID, err))
+			finalErr := fmt.Errorf("expire stale finding candidates for run %q: %w", state.run.ID, err)
+			return nil, s.markCandidateEvaluationsFailed(ctx, unfinishedCandidateEvaluations(states, state), errors.Join(evaluationErr, finalErr))
 		}
 		if err := s.candidateStore.PutFindingCandidateRun(ctx, state.run); err != nil {
-			return nil, s.markCandidateEvaluationsFailed(ctx, unfinishedCandidateEvaluations(states, state), fmt.Errorf("persist finding candidate run %q: %w", state.run.ID, err))
+			finalErr := fmt.Errorf("persist finding candidate run %q: %w", state.run.ID, err)
+			return nil, s.markCandidateEvaluationsFailed(ctx, unfinishedCandidateEvaluations(states, state), errors.Join(evaluationErr, finalErr))
 		}
 		emitFindingCandidateRunTelemetry(ctx, state.run)
+	}
+	if evaluationErr != nil {
+		return result, evaluationErr
 	}
 	return result, nil
 }

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -178,7 +178,7 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 				ruleErr := fmt.Errorf("evaluate finding candidate rule %q for event %q: %w", state.result.Rule.GetId(), event.GetId(), err)
 				evaluationErr = errors.Join(evaluationErr, ruleErr)
 				if failErr := s.markCandidateEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-					return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
+					return nil, s.markCandidateEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 				}
 				continue
 			}
@@ -201,7 +201,7 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 					ruleErr := fmt.Errorf("load risk scoring config for candidate finding %q: %w", candidateFinding.ID, err)
 					evaluationErr = errors.Join(evaluationErr, ruleErr)
 					if failErr := s.markCandidateEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-						return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
+						return nil, s.markCandidateEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 					}
 					break
 				}
@@ -211,7 +211,7 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 					ruleErr := fmt.Errorf("build candidate evidence for finding %q: %w", candidateFinding.ID, err)
 					evaluationErr = errors.Join(evaluationErr, ruleErr)
 					if failErr := s.markCandidateEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-						return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
+						return nil, s.markCandidateEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 					}
 					break
 				}
@@ -221,7 +221,7 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 					ruleErr := fmt.Errorf("persist finding candidate %q: %w", candidate.ID, err)
 					evaluationErr = errors.Join(evaluationErr, ruleErr)
 					if failErr := s.markCandidateEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-						return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
+						return nil, s.markCandidateEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 					}
 					break
 				}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -548,7 +548,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 				ruleErr := fmt.Errorf("evaluate finding rule %q for event %q: %w", state.result.Rule.GetId(), event.GetId(), err)
 				evaluationErr = errors.Join(evaluationErr, ruleErr)
 				if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-					return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
+					return nil, s.markRuleEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 				}
 				continue
 			}
@@ -567,7 +567,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					ruleErr := fmt.Errorf("reconcile finding identity for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)
 					evaluationErr = errors.Join(evaluationErr, ruleErr)
 					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
+						return nil, s.markRuleEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 					}
 					break
 				}
@@ -576,7 +576,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					ruleErr := fmt.Errorf("persist finding for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)
 					evaluationErr = errors.Join(evaluationErr, ruleErr)
 					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
+						return nil, s.markRuleEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 					}
 					break
 				}
@@ -587,7 +587,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					ruleErr := fmt.Errorf("build evidence for finding %q: %w", stored.ID, err)
 					evaluationErr = errors.Join(evaluationErr, ruleErr)
 					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
+						return nil, s.markRuleEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 					}
 					break
 				}
@@ -596,7 +596,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 						ruleErr := fmt.Errorf("persist evidence for finding %q: %w", stored.ID, err)
 						evaluationErr = errors.Join(evaluationErr, ruleErr)
 						if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-							return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
+							return nil, s.markRuleEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 						}
 						break
 					}
@@ -607,7 +607,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					ruleErr := fmt.Errorf("project finding %q graph anchor: %w", stored.ID, err)
 					evaluationErr = errors.Join(evaluationErr, ruleErr)
 					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
+						return nil, s.markRuleEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 					}
 					break
 				}
@@ -615,7 +615,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					ruleErr := fmt.Errorf("project finding %q external refs: %w", stored.ID, err)
 					evaluationErr = errors.Join(evaluationErr, ruleErr)
 					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
+						return nil, s.markRuleEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 					}
 					break
 				}
@@ -624,7 +624,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 						ruleErr := fmt.Errorf("project finding %q action recommendations: %w", stored.ID, err)
 						evaluationErr = errors.Join(evaluationErr, ruleErr)
 						if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
-							return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
+							return nil, s.markRuleEvaluationsFailed(ctx, states, errors.Join(evaluationErr, failErr))
 						}
 						break
 					}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -534,6 +534,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 	}
 	result.EventsEvaluated = boundedUint32(len(events))
 	evaluatedEventIDs := map[string]struct{}{}
+	var evaluationErr error
 	for _, event := range events {
 		if eventID := strings.TrimSpace(event.GetId()); eventID != "" {
 			evaluatedEventIDs[eventID] = struct{}{}
@@ -544,7 +545,9 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 			}
 			emitted, err := state.rule.Evaluate(ctx, runtime, event)
 			if err != nil {
-				if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("evaluate finding rule %q for event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
+				ruleErr := fmt.Errorf("evaluate finding rule %q for event %q: %w", state.result.Rule.GetId(), event.GetId(), err)
+				evaluationErr = errors.Join(evaluationErr, ruleErr)
+				if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 					return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
 				}
 				continue
@@ -561,14 +564,18 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 				}
 				record, err = s.reconcileLegacyFindingIdentity(ctx, record)
 				if err != nil {
-					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("reconcile finding identity for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
+					ruleErr := fmt.Errorf("reconcile finding identity for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)
+					evaluationErr = errors.Join(evaluationErr, ruleErr)
+					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
 					}
 					break
 				}
 				stored, isNewFinding, err := s.upsertFindingWithRiskAndNewness(ctx, record, runtime, startedAt)
 				if err != nil {
-					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("persist finding for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
+					ruleErr := fmt.Errorf("persist finding for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)
+					evaluationErr = errors.Join(evaluationErr, ruleErr)
+					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
 					}
 					break
@@ -577,14 +584,18 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 				state.emittedFindingIDs[strings.TrimSpace(stored.ID)] = struct{}{}
 				evidence, err := s.buildFindingEvidence(ctx, stored, state.result.Run)
 				if err != nil {
-					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("build evidence for finding %q: %w", stored.ID, err)); failErr != nil {
+					ruleErr := fmt.Errorf("build evidence for finding %q: %w", stored.ID, err)
+					evaluationErr = errors.Join(evaluationErr, ruleErr)
+					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
 					}
 					break
 				}
 				if _, seen := state.evidenceIDs[evidence.GetId()]; !seen {
 					if err := s.evidenceStore.PutFindingEvidence(ctx, evidence); err != nil {
-						if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("persist evidence for finding %q: %w", stored.ID, err)); failErr != nil {
+						ruleErr := fmt.Errorf("persist evidence for finding %q: %w", stored.ID, err)
+						evaluationErr = errors.Join(evaluationErr, ruleErr)
+						if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 							return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
 						}
 						break
@@ -593,20 +604,26 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					state.result.Evidence = append(state.result.Evidence, evidence)
 				}
 				if err := s.projectFindingAnchor(ctx, stored); err != nil {
-					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("project finding %q graph anchor: %w", stored.ID, err)); failErr != nil {
+					ruleErr := fmt.Errorf("project finding %q graph anchor: %w", stored.ID, err)
+					evaluationErr = errors.Join(evaluationErr, ruleErr)
+					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
 					}
 					break
 				}
 				if err := s.projectFindingExternalRefs(ctx, stored); err != nil {
-					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("project finding %q external refs: %w", stored.ID, err)); failErr != nil {
+					ruleErr := fmt.Errorf("project finding %q external refs: %w", stored.ID, err)
+					evaluationErr = errors.Join(evaluationErr, ruleErr)
+					if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
 					}
 					break
 				}
 				if isNewFinding {
 					if err := s.projectFindingNewActionRecommendations(ctx, stored); err != nil {
-						if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("project finding %q action recommendations: %w", stored.ID, err)); failErr != nil {
+						ruleErr := fmt.Errorf("project finding %q action recommendations: %w", stored.ID, err)
+						evaluationErr = errors.Join(evaluationErr, ruleErr)
+						if failErr := s.markRuleEvaluationFailed(ctx, state, ruleErr); failErr != nil {
 							return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
 						}
 						break
@@ -621,16 +638,19 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 		}
 		resolvedCounterFindings, err := s.resolveRuleOpenFindings(ctx, runtime, state.rule, events, evaluatedEventIDs, state.emittedFindingIDs)
 		if err != nil {
-			evaluationErr := fmt.Errorf("resolve stale findings for rule %q: %w", state.result.Rule.GetId(), err)
-			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), evaluationErr)
+			finalErr := fmt.Errorf("resolve stale findings for rule %q: %w", state.result.Rule.GetId(), err)
+			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), errors.Join(evaluationErr, finalErr))
 		}
 		if err := s.applyCounterEventResolutionResults(ctx, state.result.Run, state.result.Findings, &state.result.Evidence, state.evidenceIDs, resolvedCounterFindings); err != nil {
-			evaluationErr := fmt.Errorf("persist counter-event close evidence for rule %q: %w", state.result.Rule.GetId(), err)
-			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), evaluationErr)
+			finalErr := fmt.Errorf("persist counter-event close evidence for rule %q: %w", state.result.Rule.GetId(), err)
+			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), errors.Join(evaluationErr, finalErr))
 		}
 		if err := s.finishCompletedRun(ctx, state.result.Run, state.eventsEvaluated, state.eventsMatched, findingIDs(state.result.Findings)); err != nil {
-			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), err)
+			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), errors.Join(evaluationErr, err))
 		}
+	}
+	if evaluationErr != nil {
+		return result, evaluationErr
 	}
 	return result, nil
 }

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -4019,6 +4019,53 @@ func TestEvaluateSourceRuntimeRulesReturnsErrorWhenAnyRuleFails(t *testing.T) {
 	}
 }
 
+func TestEvaluateSourceRuntimeRulesPreservesEarlierErrorWhenLaterFailureUpdateFails(t *testing.T) {
+	ruleAErr := errors.New("rule-a exploded")
+	ruleBErr := errors.New("rule-b exploded")
+	runUpdateErr := errors.New("rule-b failure update failed")
+	registry, err := NewRegistry(
+		&failingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			err:                ruleAErr,
+		},
+		&failingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b", Name: "Rule B"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			err:                ruleBErr,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{
+		failRunPutByCall: map[int]error{
+			4: runUpdateErr,
+		},
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		&stubReplayer{events: []*cerebrov1.EventEnvelope{newAuditEvent("okta-audit-1", "policy.rule.deactivate", "SUCCESS")}},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	_, err = service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-okta-audit"})
+	if err == nil {
+		t.Fatal("EvaluateSourceRuntimeRules() error = nil, want joined rule and run update errors")
+	}
+	for _, want := range []error{ruleAErr, ruleBErr, runUpdateErr} {
+		if !errors.Is(err, want) {
+			t.Fatalf("EvaluateSourceRuntimeRules() error = %v, want %v", err, want)
+		}
+	}
+}
+
 func TestEvaluateSourceRuntimeRulesMarksStartedRunsFailedWhenLaterRunStartFails(t *testing.T) {
 	registry, err := NewRegistry(
 		&emittingRule{

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3022,6 +3022,65 @@ func TestEvaluateSourceRuntimeCandidateRulesDoesNotWriteProductionFindings(t *te
 	}
 }
 
+func TestEvaluateSourceRuntimeCandidateRulesReturnsErrorWhenAnyRuleFails(t *testing.T) {
+	ruleBErr := errors.New("candidate rule-b exploded")
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			triggerEventID:     "okta-audit-1",
+		},
+		&failingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b", Name: "Rule B"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			err:                ruleBErr,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		&stubReplayer{events: []*cerebrov1.EventEnvelope{newAuditEvent("okta-audit-1", "policy.rule.deactivate", "SUCCESS")}},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	).WithFindingCandidateStore(store)
+
+	result, err := service.EvaluateSourceRuntimeCandidateRules(context.Background(), EvaluateCandidateRulesRequest{RuntimeID: "writer-okta-audit"})
+	if err == nil {
+		t.Fatal("EvaluateSourceRuntimeCandidateRules() error = nil, want rule failure")
+	}
+	if !errors.Is(err, ruleBErr) {
+		t.Fatalf("EvaluateSourceRuntimeCandidateRules() error = %v, want %v", err, ruleBErr)
+	}
+	if result == nil || len(result.Evaluations) != 2 {
+		t.Fatalf("EvaluateSourceRuntimeCandidateRules() result = %#v, want both rule evaluations returned with error", result)
+	}
+	ruleARun, ok := candidateRunForRule(store.candidateState.runs, "rule-a")
+	if !ok {
+		t.Fatal("rule-a candidate run missing")
+	}
+	if got := ruleARun.Status; got != "completed" {
+		t.Fatalf("rule-a candidate run status = %q, want completed", got)
+	}
+	ruleBRun, ok := candidateRunForRule(store.candidateState.runs, "rule-b")
+	if !ok {
+		t.Fatal("rule-b candidate run missing")
+	}
+	if got := ruleBRun.Status; got != "failed" {
+		t.Fatalf("rule-b candidate run status = %q, want failed", got)
+	}
+	if got := ruleBRun.Error; !strings.Contains(got, "candidate rule-b exploded") {
+		t.Fatalf("rule-b candidate run error = %q, want candidate rule-b exploded", got)
+	}
+}
+
 func TestEvaluateSourceRuntimeCandidateRulesExpiresStaleCandidates(t *testing.T) {
 	registry, err := NewRegistry(&emittingRule{
 		spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
@@ -3898,6 +3957,65 @@ func TestEvaluateSourceRuntimeRulesProbesStaleUnsupportedRulesOnce(t *testing.T)
 	request := store.listFindingsRequests[0]
 	if request.RuleID != "" || request.RuntimeID != "writer-aws-public-endpoint" || request.Status != findingStatusOpen {
 		t.Fatalf("stale probe request = %#v, want one runtime-wide open-finding query", request)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesReturnsErrorWhenAnyRuleFails(t *testing.T) {
+	ruleBErr := errors.New("rule-b exploded")
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			triggerEventID:     "okta-audit-1",
+		},
+		&failingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b", Name: "Rule B"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			err:                ruleBErr,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		&stubReplayer{events: []*cerebrov1.EventEnvelope{newAuditEvent("okta-audit-1", "policy.rule.deactivate", "SUCCESS")}},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	result, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-okta-audit"})
+	if err == nil {
+		t.Fatal("EvaluateSourceRuntimeRules() error = nil, want rule failure")
+	}
+	if !errors.Is(err, ruleBErr) {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v, want %v", err, ruleBErr)
+	}
+	if result == nil || len(result.Evaluations) != 2 {
+		t.Fatalf("EvaluateSourceRuntimeRules() result = %#v, want both rule evaluations returned with error", result)
+	}
+	ruleARun, ok := runForRule(store.runs, "rule-a")
+	if !ok {
+		t.Fatal("rule-a run missing")
+	}
+	if got := ruleARun.GetStatus(); got != "completed" {
+		t.Fatalf("rule-a run status = %q, want completed", got)
+	}
+	ruleBRun, ok := runForRule(store.runs, "rule-b")
+	if !ok {
+		t.Fatal("rule-b run missing")
+	}
+	if got := ruleBRun.GetStatus(); got != "failed" {
+		t.Fatalf("rule-b run status = %q, want failed", got)
+	}
+	if got := ruleBRun.GetError(); !strings.Contains(got, "rule-b exploded") {
+		t.Fatalf("rule-b run error = %q, want rule-b exploded", got)
 	}
 }
 
@@ -6383,6 +6501,15 @@ func claimMatches(request ports.ListClaimsRequest, claim *ports.ClaimRecord) boo
 func runForRule(runs map[string]*cerebrov1.FindingEvaluationRun, ruleID string) (*cerebrov1.FindingEvaluationRun, bool) {
 	for _, run := range runs {
 		if strings.TrimSpace(run.GetRuleId()) == strings.TrimSpace(ruleID) {
+			return run, true
+		}
+	}
+	return nil, false
+}
+
+func candidateRunForRule(runs map[string]*ports.FindingCandidateRun, ruleID string) (*ports.FindingCandidateRun, bool) {
+	for _, run := range runs {
+		if strings.TrimSpace(run.RuleID) == strings.TrimSpace(ruleID) {
 			return run, true
 		}
 	}

--- a/internal/statestore/postgres/append_log_runtime_index.go
+++ b/internal/statestore/postgres/append_log_runtime_index.go
@@ -25,6 +25,7 @@ var ensureAppendLogRuntimeIndexStatements = []string{
   occurred_at TIMESTAMPTZ,
   PRIMARY KEY (runtime_id, seq)
 )`,
+	`CREATE INDEX IF NOT EXISTS append_log_runtime_index_runtime_kind_seq_idx ON append_log_runtime_index (runtime_id, kind, seq DESC)`,
 	`CREATE INDEX IF NOT EXISTS append_log_runtime_index_runtime_observed_idx ON append_log_runtime_index (runtime_id, occurred_at DESC NULLS LAST, seq DESC)`,
 	`CREATE INDEX IF NOT EXISTS append_log_runtime_index_runtime_kind_observed_idx ON append_log_runtime_index (runtime_id, kind, occurred_at DESC NULLS LAST, seq DESC)`,
 	`CREATE TABLE IF NOT EXISTS append_log_index_state (
@@ -104,8 +105,8 @@ func (s *Store) RuntimeIndexWatermark(ctx context.Context) (uint64, error) {
 	return uint64(lastSeq), nil
 }
 
-// LookupRuntimeReplay returns the newest-observed indexed stream sequences for one
-// runtime, optionally narrowed to exact event kinds, along with the watermark.
+// LookupRuntimeReplay returns the newest observed indexed stream sequences for
+// one runtime, optionally narrowed to exact event kinds, along with the watermark.
 func (s *Store) LookupRuntimeReplay(ctx context.Context, query ports.RuntimeIndexQuery) (ports.RuntimeIndexResult, error) {
 	runtimeID := strings.TrimSpace(query.RuntimeID)
 	if runtimeID == "" {
@@ -148,8 +149,9 @@ func (s *Store) LookupRuntimeReplay(ctx context.Context, query ports.RuntimeInde
 	return result, nil
 }
 
-// runtimeReplayIndexQuery builds the newest-observed-first sequence lookup, bounding by
-// the watermark and (optionally) exact event kinds. Values stay parameterized.
+// runtimeReplayIndexQuery builds the newest-observed-first sequence lookup,
+// bounding by the watermark and (optionally) exact event kinds. Values stay
+// parameterized.
 func runtimeReplayIndexQuery(runtimeID string, kinds []string, watermark uint64, limit uint32) (string, []any) {
 	args := []any{runtimeID, boundedInt64(watermark)}
 	var builder strings.Builder

--- a/internal/statestore/postgres/append_log_runtime_index.go
+++ b/internal/statestore/postgres/append_log_runtime_index.go
@@ -25,7 +25,7 @@ var ensureAppendLogRuntimeIndexStatements = []string{
   occurred_at TIMESTAMPTZ,
   PRIMARY KEY (runtime_id, seq)
 )`,
-	`CREATE INDEX IF NOT EXISTS append_log_runtime_index_runtime_kind_seq_idx ON append_log_runtime_index (runtime_id, kind, seq DESC)`,
+	`DROP INDEX IF EXISTS append_log_runtime_index_runtime_kind_seq_idx`,
 	`CREATE INDEX IF NOT EXISTS append_log_runtime_index_runtime_observed_idx ON append_log_runtime_index (runtime_id, occurred_at DESC NULLS LAST, seq DESC)`,
 	`CREATE INDEX IF NOT EXISTS append_log_runtime_index_runtime_kind_observed_idx ON append_log_runtime_index (runtime_id, kind, occurred_at DESC NULLS LAST, seq DESC)`,
 	`CREATE TABLE IF NOT EXISTS append_log_index_state (

--- a/internal/statestore/postgres/append_log_runtime_index_test.go
+++ b/internal/statestore/postgres/append_log_runtime_index_test.go
@@ -34,6 +34,8 @@ func TestAppendLogRuntimeIndexSchemaShape(t *testing.T) {
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS append_log_runtime_index",
 		"PRIMARY KEY (runtime_id, seq)",
+		"append_log_runtime_index_runtime_kind_seq_idx",
+		"(runtime_id, kind, seq DESC)",
 		"append_log_runtime_index_runtime_observed_idx",
 		"(runtime_id, occurred_at DESC NULLS LAST, seq DESC)",
 		"append_log_runtime_index_runtime_kind_observed_idx",

--- a/internal/statestore/postgres/append_log_runtime_index_test.go
+++ b/internal/statestore/postgres/append_log_runtime_index_test.go
@@ -34,8 +34,7 @@ func TestAppendLogRuntimeIndexSchemaShape(t *testing.T) {
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS append_log_runtime_index",
 		"PRIMARY KEY (runtime_id, seq)",
-		"append_log_runtime_index_runtime_kind_seq_idx",
-		"(runtime_id, kind, seq DESC)",
+		"DROP INDEX IF EXISTS append_log_runtime_index_runtime_kind_seq_idx",
 		"append_log_runtime_index_runtime_observed_idx",
 		"(runtime_id, occurred_at DESC NULLS LAST, seq DESC)",
 		"append_log_runtime_index_runtime_kind_observed_idx",
@@ -46,6 +45,9 @@ func TestAppendLogRuntimeIndexSchemaShape(t *testing.T) {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("append log runtime index schema missing %q:\n%s", fragment, joined)
 		}
+	}
+	if strings.Contains(joined, "CREATE INDEX IF NOT EXISTS append_log_runtime_index_runtime_kind_seq_idx") {
+		t.Fatalf("append log runtime index schema still creates redundant kind/seq index:\n%s", joined)
 	}
 }
 

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -77,8 +77,10 @@ import (
 // so reserved runtime keys cannot cross the MCP transport layer. Credential
 // store operations add only route wiring plus auth policy for a handler in
 // internal/sourcehttp/credentialstores; the read model lives in
-// internal/credentialstores.
-const bootstrapProductionGoLineBudget = 26698
+// internal/credentialstores. Finding-rule partial evaluation handling adds
+// only cache invalidation and job result mapping while rule execution and run
+// state stay in internal/findings.
+const bootstrapProductionGoLineBudget = 26707
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## What changed

- Preserve newest-observed replay correctness in the JetStream legacy replay fallback by scanning the full legacy range while keeping bounded candidate memory.
- Order runtime replay index lookups by `occurred_at DESC NULLS LAST, seq DESC` and add matching Postgres indexes.
- Return an error from multi-rule production and candidate finding evaluations when any rule fails, while still finalizing healthy rules and failed run state.
- Add regression coverage for replay ordering, runtime-index timestamp propagation, runtime-index query shape, and partial rule failures.

## Why

Finding evaluation uses replay output as the source of truth for current rule decisions. A bounded legacy scan by append sequence could miss the newest observed events when history was appended in newest-first order. Multi-rule evaluators could also persist failed per-rule runs while returning an overall success, which made failed evaluations harder to detect from orchestration.

## Validation

- `go test ./internal/appendlog/jetstream ./internal/appendlogindex ./internal/statestore/postgres ./internal/findings -count=1`
- `go test ./cmd/cerebro -run 'Test.*Orchestrator|Test.*Finding|Test.*Preflight' -count=1`
- `go test ./... -count=1`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->