### PR TITLE
[codex] add identity directory API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -15,6 +15,7 @@ tags:
   - name: GRC
   - name: Graph
   - name: Health
+  - name: Identity
   - name: Knowledge
   - name: MCP
   - name: OAuth
@@ -4914,6 +4915,60 @@ paths:
             application/json:
               schema:
                 type: object
+  /identity/orgs:
+    get:
+      summary: List identity organizations
+      tags:
+        - Identity
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - name: org_id
+          in: query
+          schema:
+            type: string
+        - name: q
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limitQuery'
+      responses:
+        '200':
+          description: Tenant-scoped organizations from configured auth grants and stored identity directory records.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityOrganizationListResponse'
+        '403':
+          description: Tenant access forbidden.
+        '500':
+          description: Identity organizations are unavailable.
+  /identity/users:
+    get:
+      summary: List identity users
+      tags:
+        - Identity
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - name: org_id
+          in: query
+          schema:
+            type: string
+        - name: q
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limitQuery'
+      responses:
+        '200':
+          description: Tenant-scoped users from configured auth grants and stored identity directory records.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityUserListResponse'
+        '403':
+          description: Tenant access forbidden.
+        '500':
+          description: Identity users are unavailable.
   /user/preferences:
     get:
       summary: Get current user preferences
@@ -5115,6 +5170,122 @@ components:
         minimum: 1
         maximum: 500
   schemas:
+    IdentityListMeta:
+      type: object
+      required: [limit, loaded, configured, persisted]
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+        loaded:
+          type: integer
+          minimum: 0
+        configured:
+          type: integer
+          minimum: 0
+        persisted:
+          type: integer
+          minimum: 0
+    IdentityOrganization:
+      type: object
+      required: [org_id, tenant_id, name, source, user_count]
+      properties:
+        org_id:
+          type: string
+        tenant_id:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+        domain:
+          type: string
+        provider:
+          type: string
+        source:
+          type: string
+        external_id:
+          type: string
+        user_count:
+          type: integer
+          minimum: 0
+        last_synced_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    IdentityOrganizationListResponse:
+      type: object
+      required: [organizations, meta]
+      properties:
+        tenant_id:
+          type: string
+        organizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityOrganization'
+        meta:
+          $ref: '#/components/schemas/IdentityListMeta'
+    IdentityUser:
+      type: object
+      required: [user_id, tenant_id, display_name, status, source]
+      properties:
+        user_id:
+          type: string
+        tenant_id:
+          type: string
+        org_id:
+          type: string
+        subject:
+          type: string
+        email:
+          type: string
+        display_name:
+          type: string
+        status:
+          type: string
+        provider:
+          type: string
+        source:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        groups:
+          type: array
+          items:
+            type: string
+        last_seen_at:
+          type: string
+          format: date-time
+        last_synced_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    IdentityUserListResponse:
+      type: object
+      required: [users, meta]
+      properties:
+        tenant_id:
+          type: string
+        org_id:
+          type: string
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityUser'
+        meta:
+          $ref: '#/components/schemas/IdentityListMeta'
     A2AAgentCard:
       type: object
       required:

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -141,6 +141,8 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/ask-queries", Scope: scopeAskQueriesWrite, Static: true},
 	{Method: http.MethodPatch, Prefix: "/ask-queries/", Scope: scopeAskQueriesWrite},
 	{Method: http.MethodDelete, Prefix: "/ask-queries/", Scope: scopeAskQueriesWrite},
+	{Method: http.MethodGet, Exact: "/identity/orgs", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/identity/users", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/user/preferences", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPut, Exact: "/user/preferences", Scope: scopeUserPreferencesWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/platform/jobs", Scope: scopeJobsWrite, Static: true},

--- a/internal/bootstrap/oauth_oidc.go
+++ b/internal/bootstrap/oauth_oidc.go
@@ -228,6 +228,7 @@ func (c *mcpOAuthOIDCClient) verifyIDToken(ctx context.Context, token string, no
 	return mcpoauth.Identity{
 		Subject: subject,
 		Email:   email,
+		Name:    oauthStringClaim(claims, "name"),
 		Groups:  oauthStringListClaim(claims, c.cfg.GroupsClaim),
 	}, nil
 }

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 	credentialstoreshttp "github.com/writer/cerebro/internal/sourcehttp/credentialstores"
 	"github.com/writer/cerebro/internal/sourcehttp/customdashboards"
+	"github.com/writer/cerebro/internal/sourcehttp/identitydirectory"
 	"github.com/writer/cerebro/internal/sourcehttp/userpreferences"
 	"github.com/writer/cerebro/internal/sourceplanapi"
 	"github.com/writer/cerebro/internal/sourceruntime"
@@ -39,6 +40,9 @@ func (app *App) registerRoutes(mux *http.ServeMux, cfg config.Config, deps Depen
 	preferencesHandler := userpreferences.NewHandler(app.deps.StateStore, effectiveTenantFilter, userPreferenceActorID)
 	registerHTTPRoute(mux, "GET /user/preferences", routeSurfacePlatformHTTP, preferencesHandler.Get)
 	registerHTTPRoute(mux, "PUT /user/preferences", routeSurfacePlatformHTTP, preferencesHandler.Put)
+	identityHandler := identitydirectory.NewHandler(app.deps.StateStore, cfg.Auth, effectiveTenantFilter, authorizeTenantID)
+	registerHTTPRoute(mux, "GET /identity/orgs", routeSurfacePlatformHTTP, identityHandler.ListOrganizations)
+	registerHTTPRoute(mux, "GET /identity/users", routeSurfacePlatformHTTP, identityHandler.ListUsers)
 	app.registerGRCRoutes(mux)
 	app.registerFindingRoutes(mux)
 	app.registerSourceRoutes(mux)

--- a/internal/mcpoauth/oidc.go
+++ b/internal/mcpoauth/oidc.go
@@ -10,5 +10,6 @@ type OIDCProvider interface {
 type Identity struct {
 	Subject string
 	Email   string
+	Name    string
 	Groups  []string
 }

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -760,15 +760,34 @@ func identityTenantIDs(entitlement grantEntitlement) []string {
 }
 
 func oauthProviderFromIssuer(issuer string) string {
-	issuer = strings.ToLower(strings.TrimSpace(issuer))
 	switch {
-	case strings.Contains(issuer, "okta"):
+	case oktaIssuer(issuer):
 		return "okta"
-	case issuer != "":
+	case strings.TrimSpace(issuer) != "":
 		return "oidc"
 	default:
 		return ""
 	}
+}
+
+func oktaIssuer(issuer string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(issuer))
+	host := ""
+	if err == nil {
+		host = parsed.Hostname()
+	}
+	if host == "" {
+		host = strings.TrimSpace(issuer)
+	}
+	host = strings.ToLower(host)
+	return host == "okta.com" ||
+		host == "okta-emea.com" ||
+		host == "oktapreview.com" ||
+		host == "okta-gov.com" ||
+		strings.HasSuffix(host, ".okta.com") ||
+		strings.HasSuffix(host, ".okta-emea.com") ||
+		strings.HasSuffix(host, ".oktapreview.com") ||
+		strings.HasSuffix(host, ".okta-gov.com")
 }
 
 func tenantSlug(tenantID string) string {

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 // AccessGrant is the claim set Cerebro places into an MCP capability token.
@@ -91,6 +92,11 @@ const (
 
 type oauthClientLimitStore interface {
 	SaveOAuthClientWithLimit(ctx context.Context, client OAuthClient, maxClients int) error
+}
+
+type identityDirectoryStore interface {
+	UpsertIdentityOrganization(context.Context, *ports.IdentityOrganization) error
+	UpsertIdentityUser(context.Context, *ports.IdentityUser) error
 }
 
 type OAuthError struct {
@@ -324,6 +330,9 @@ func (s *Service) Callback(ctx context.Context, query url.Values) (string, error
 		return "", fmt.Errorf("mcpoauth: generate code: %w", err)
 	}
 	now := s.now().UTC()
+	if err := s.recordIdentity(ctx, identity, entitlement, now); err != nil {
+		return "", err
+	}
 	if err := s.store.SaveAuthorizationCode(ctx, AuthorizationCode{
 		CodeHash:       HashToken(codeToken),
 		ClientID:       login.ClientID,
@@ -688,6 +697,97 @@ func (s *Service) entitlementForIdentity(identity Identity, clientID string, req
 		}, nil
 	}
 	return grantEntitlement{}, oauthError("access_denied", "authenticated user has no Cerebro tenant entitlement", statusForbidden)
+}
+
+func (s *Service) recordIdentity(ctx context.Context, identity Identity, entitlement grantEntitlement, now time.Time) error {
+	store, ok := s.store.(identityDirectoryStore)
+	if !ok || store == nil {
+		return nil
+	}
+	tenantIDs := identityTenantIDs(entitlement)
+	if len(tenantIDs) == 0 {
+		return nil
+	}
+	provider := oauthProviderFromIssuer(s.cfg.Upstream.Issuer)
+	externalID := strings.TrimSpace(s.cfg.Upstream.Issuer)
+	for _, tenantID := range tenantIDs {
+		org := &ports.IdentityOrganization{
+			OrgID:        tenantID,
+			TenantID:     tenantID,
+			Name:         tenantID,
+			Slug:         tenantSlug(tenantID),
+			Provider:     provider,
+			Source:       "mcp_oauth",
+			ExternalID:   externalID,
+			UserCount:    1,
+			LastSyncedAt: now,
+		}
+		if err := store.UpsertIdentityOrganization(ctx, org); err != nil {
+			return fmt.Errorf("mcpoauth: record identity organization: %w", err)
+		}
+		userID := firstNonEmpty(identity.Subject, identity.Email)
+		displayName := firstNonEmpty(identity.Name, identity.Email, identity.Subject)
+		if userID == "" || displayName == "" {
+			continue
+		}
+		user := &ports.IdentityUser{
+			UserID:       userID,
+			TenantID:     tenantID,
+			OrgID:        tenantID,
+			Subject:      strings.TrimSpace(identity.Subject),
+			Email:        strings.ToLower(strings.TrimSpace(identity.Email)),
+			DisplayName:  displayName,
+			Status:       "active",
+			Provider:     provider,
+			Source:       "mcp_oauth",
+			Roles:        cloneStrings(entitlement.Roles),
+			Groups:       cloneStrings(identity.Groups),
+			LastSeenAt:   now,
+			LastSyncedAt: now,
+		}
+		if err := store.UpsertIdentityUser(ctx, user); err != nil {
+			return fmt.Errorf("mcpoauth: record identity user: %w", err)
+		}
+	}
+	return nil
+}
+
+func identityTenantIDs(entitlement grantEntitlement) []string {
+	var values []string
+	if tenantID := strings.TrimSpace(entitlement.TenantID); tenantID != "" {
+		values = append(values, tenantID)
+	}
+	values = append(values, entitlement.AllowedTenants...)
+	return normalizeStrings(values)
+}
+
+func oauthProviderFromIssuer(issuer string) string {
+	issuer = strings.ToLower(strings.TrimSpace(issuer))
+	switch {
+	case strings.Contains(issuer, "okta"):
+		return "okta"
+	case issuer != "":
+		return "oidc"
+	default:
+		return ""
+	}
+}
+
+func tenantSlug(tenantID string) string {
+	slug := strings.ToLower(strings.TrimSpace(tenantID))
+	slug = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-' || r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, slug)
+	return strings.Trim(slug, "-")
 }
 
 func entitlementMatches(entitlement config.MCPOAuthEntitlement, identity Identity, clientID string) bool {

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -330,9 +330,7 @@ func (s *Service) Callback(ctx context.Context, query url.Values) (string, error
 		return "", fmt.Errorf("mcpoauth: generate code: %w", err)
 	}
 	now := s.now().UTC()
-	if err := s.recordIdentity(ctx, identity, entitlement, now); err != nil {
-		return "", err
-	}
+	_ = s.recordIdentity(ctx, identity, entitlement, now)
 	if err := s.store.SaveAuthorizationCode(ctx, AuthorizationCode{
 		CodeHash:       HashToken(codeToken),
 		ClientID:       login.ClientID,

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -6,10 +6,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestTokenRefreshReplayRevokesFamily(t *testing.T) {
@@ -263,6 +265,68 @@ func TestEntitlementForIdentityDropsRolesWhenExplicitScopeRequested(t *testing.T
 	}
 }
 
+func TestCallbackRecordsOAuthIdentityDirectory(t *testing.T) {
+	stateToken := "state-token"
+	store := &directoryOAuthStore{
+		login: LoginState{
+			StateHash:     HashToken(stateToken),
+			ClientID:      "droid",
+			RedirectURI:   "http://127.0.0.1/callback",
+			ClientState:   "client-state",
+			Resource:      "https://cerebro.example/api/v1/mcp",
+			Scopes:        []string{ScopeSecurityRead},
+			CodeChallenge: "challenge",
+			Nonce:         "nonce",
+			ExpiresAt:     time.Now().Add(time.Minute),
+		},
+	}
+	service, err := NewService(config.MCPOAuthConfig{
+		Resource: "https://cerebro.example/api/v1/mcp",
+		CodeTTL:  time.Minute,
+		Upstream: config.MCPOAuthUpstreamConfig{
+			Issuer:         "https://example.okta.com",
+			SecurityGroups: []string{"security-team"},
+		},
+		Entitlements: []config.MCPOAuthEntitlement{{
+			Groups:         []string{"security-team"},
+			AllowedTenants: []string{"tenant-a"},
+			Roles:          []string{"cerebro.viewer"},
+			Scopes:         []string{ScopeSecurityRead},
+		}},
+	}, store, func(context.Context, AccessGrant, time.Duration, time.Time) (string, error) {
+		return "access-token", nil
+	}, WithOIDCProvider(staticOIDCProvider{identity: Identity{
+		Subject: "00u123",
+		Email:   "person@example.com",
+		Name:    "Person Example",
+		Groups:  []string{"security-team"},
+	}}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	redirect, err := service.Callback(context.Background(), url.Values{"state": {stateToken}, "code": {"upstream-code"}})
+	if err != nil {
+		t.Fatalf("Callback error = %v", err)
+	}
+	if !strings.HasPrefix(redirect, "http://127.0.0.1/callback?") {
+		t.Fatalf("redirect = %q", redirect)
+	}
+	if len(store.orgs) != 1 || store.orgs[0].TenantID != "tenant-a" || store.orgs[0].Provider != "okta" {
+		t.Fatalf("recorded orgs = %+v", store.orgs)
+	}
+	if len(store.users) != 1 {
+		t.Fatalf("recorded users = %+v", store.users)
+	}
+	user := store.users[0]
+	if user.UserID != "00u123" || user.DisplayName != "Person Example" || user.Provider != "okta" || user.Source != "mcp_oauth" {
+		t.Fatalf("recorded user = %+v", user)
+	}
+	if len(user.Roles) != 1 || user.Roles[0] != "cerebro.viewer" || len(user.Groups) != 1 || user.Groups[0] != "security-team" {
+		t.Fatalf("recorded grants = roles %#v groups %#v", user.Roles, user.Groups)
+	}
+}
+
 func base16Lower(raw []byte) string {
 	const alphabet = "0123456789abcdef"
 	out := make([]byte, len(raw)*2)
@@ -300,6 +364,40 @@ func (s *limitedClientStore) SaveOAuthClientWithLimit(_ context.Context, _ OAuth
 	return s.err
 }
 
+type directoryOAuthStore struct {
+	Store
+	login LoginState
+	code  AuthorizationCode
+	orgs  []*ports.IdentityOrganization
+	users []*ports.IdentityUser
+}
+
+func (s *directoryOAuthStore) ConsumeLoginState(_ context.Context, stateHash [32]byte, _ time.Time) (LoginState, error) {
+	if stateHash != s.login.StateHash {
+		return LoginState{}, ErrNotFound
+	}
+	return s.login, nil
+}
+
+func (s *directoryOAuthStore) SaveAuthorizationCode(_ context.Context, code AuthorizationCode) error {
+	s.code = code
+	return nil
+}
+
+func (s *directoryOAuthStore) UpsertIdentityOrganization(_ context.Context, org *ports.IdentityOrganization) error {
+	copied := *org
+	s.orgs = append(s.orgs, &copied)
+	return nil
+}
+
+func (s *directoryOAuthStore) UpsertIdentityUser(_ context.Context, user *ports.IdentityUser) error {
+	copied := *user
+	copied.Roles = cloneStrings(user.Roles)
+	copied.Groups = cloneStrings(user.Groups)
+	s.users = append(s.users, &copied)
+	return nil
+}
+
 type stubOIDCProvider struct{}
 
 func (stubOIDCProvider) AuthorizationEndpoint(context.Context) (string, error) {
@@ -308,4 +406,16 @@ func (stubOIDCProvider) AuthorizationEndpoint(context.Context) (string, error) {
 
 func (stubOIDCProvider) ExchangeCode(context.Context, string, string) (Identity, error) {
 	return Identity{}, nil
+}
+
+type staticOIDCProvider struct {
+	identity Identity
+}
+
+func (staticOIDCProvider) AuthorizationEndpoint(context.Context) (string, error) {
+	return "https://sso.example/authorize", nil
+}
+
+func (p staticOIDCProvider) ExchangeCode(context.Context, string, string) (Identity, error) {
+	return p.identity, nil
 }

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -327,6 +327,58 @@ func TestCallbackRecordsOAuthIdentityDirectory(t *testing.T) {
 	}
 }
 
+func TestCallbackContinuesWhenIdentityDirectoryRecordFails(t *testing.T) {
+	stateToken := "state-token"
+	store := &directoryOAuthStore{
+		login: LoginState{
+			StateHash:     HashToken(stateToken),
+			ClientID:      "droid",
+			RedirectURI:   "http://127.0.0.1/callback",
+			ClientState:   "client-state",
+			Resource:      "https://cerebro.example/api/v1/mcp",
+			Scopes:        []string{ScopeSecurityRead},
+			CodeChallenge: "challenge",
+			Nonce:         "nonce",
+			ExpiresAt:     time.Now().Add(time.Minute),
+		},
+		recordErr: errors.New("directory unavailable"),
+	}
+	service, err := NewService(config.MCPOAuthConfig{
+		Resource: "https://cerebro.example/api/v1/mcp",
+		CodeTTL:  time.Minute,
+		Upstream: config.MCPOAuthUpstreamConfig{
+			SecurityGroups: []string{"security-team"},
+		},
+		Entitlements: []config.MCPOAuthEntitlement{{
+			Groups:         []string{"security-team"},
+			AllowedTenants: []string{"tenant-a"},
+			Roles:          []string{"cerebro.viewer"},
+			Scopes:         []string{ScopeSecurityRead},
+		}},
+	}, store, func(context.Context, AccessGrant, time.Duration, time.Time) (string, error) {
+		return "access-token", nil
+	}, WithOIDCProvider(staticOIDCProvider{identity: Identity{
+		Subject: "00u123",
+		Email:   "person@example.com",
+		Name:    "Person Example",
+		Groups:  []string{"security-team"},
+	}}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	redirect, err := service.Callback(context.Background(), url.Values{"state": {stateToken}, "code": {"upstream-code"}})
+	if err != nil {
+		t.Fatalf("Callback error = %v", err)
+	}
+	if !strings.HasPrefix(redirect, "http://127.0.0.1/callback?") {
+		t.Fatalf("redirect = %q", redirect)
+	}
+	if store.code.CodeHash == ([32]byte{}) {
+		t.Fatalf("authorization code was not saved")
+	}
+}
+
 func base16Lower(raw []byte) string {
 	const alphabet = "0123456789abcdef"
 	out := make([]byte, len(raw)*2)
@@ -366,10 +418,11 @@ func (s *limitedClientStore) SaveOAuthClientWithLimit(_ context.Context, _ OAuth
 
 type directoryOAuthStore struct {
 	Store
-	login LoginState
-	code  AuthorizationCode
-	orgs  []*ports.IdentityOrganization
-	users []*ports.IdentityUser
+	login     LoginState
+	code      AuthorizationCode
+	orgs      []*ports.IdentityOrganization
+	users     []*ports.IdentityUser
+	recordErr error
 }
 
 func (s *directoryOAuthStore) ConsumeLoginState(_ context.Context, stateHash [32]byte, _ time.Time) (LoginState, error) {
@@ -385,12 +438,18 @@ func (s *directoryOAuthStore) SaveAuthorizationCode(_ context.Context, code Auth
 }
 
 func (s *directoryOAuthStore) UpsertIdentityOrganization(_ context.Context, org *ports.IdentityOrganization) error {
+	if s.recordErr != nil {
+		return s.recordErr
+	}
 	copied := *org
 	s.orgs = append(s.orgs, &copied)
 	return nil
 }
 
 func (s *directoryOAuthStore) UpsertIdentityUser(_ context.Context, user *ports.IdentityUser) error {
+	if s.recordErr != nil {
+		return s.recordErr
+	}
 	copied := *user
 	copied.Roles = cloneStrings(user.Roles)
 	copied.Groups = cloneStrings(user.Groups)

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -379,6 +379,15 @@ func TestCallbackContinuesWhenIdentityDirectoryRecordFails(t *testing.T) {
 	}
 }
 
+func TestOAuthProviderFromIssuerUsesHost(t *testing.T) {
+	if got := oauthProviderFromIssuer("https://tenant.okta.com/oauth2/default"); got != "okta" {
+		t.Fatalf("oauthProviderFromIssuer(okta issuer) = %q, want okta", got)
+	}
+	if got := oauthProviderFromIssuer("https://booktaku.example.com/oauth2/default"); got != "oidc" {
+		t.Fatalf("oauthProviderFromIssuer(non-okta issuer) = %q, want oidc", got)
+	}
+}
+
 func base16Lower(raw []byte) string {
 	const alphabet = "0123456789abcdef"
 	out := make([]byte, len(raw)*2)

--- a/internal/ports/identity_directory.go
+++ b/internal/ports/identity_directory.go
@@ -1,0 +1,68 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+// IdentityOrganization is a product organization Cerebro can authorize and show
+// in the console. TenantID remains the enforcement boundary; OrgID is the
+// operator-facing organization key inside that tenant.
+type IdentityOrganization struct {
+	OrgID        string
+	TenantID     string
+	Name         string
+	Slug         string
+	Domain       string
+	Provider     string
+	Source       string
+	ExternalID   string
+	UserCount    int
+	LastSyncedAt time.Time
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// IdentityUser is a product user associated with a Cerebro organization.
+type IdentityUser struct {
+	UserID       string
+	TenantID     string
+	OrgID        string
+	Subject      string
+	Email        string
+	DisplayName  string
+	Status       string
+	Provider     string
+	Source       string
+	Roles        []string
+	Groups       []string
+	LastSeenAt   time.Time
+	LastSyncedAt time.Time
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type IdentityOrganizationFilter struct {
+	TenantID string
+	OrgID    string
+	Query    string
+	Limit    uint32
+}
+
+type IdentityUserFilter struct {
+	TenantID string
+	OrgID    string
+	UserID   string
+	Query    string
+	Limit    uint32
+}
+
+// IdentityDirectoryStore persists users and organizations learned from auth
+// flows or operator-configured identity sources.
+type IdentityDirectoryStore interface {
+	StateStore
+	UpsertIdentityOrganization(context.Context, *IdentityOrganization) error
+	UpsertIdentityUser(context.Context, *IdentityUser) error
+	ListIdentityOrganizations(context.Context, IdentityOrganizationFilter) ([]*IdentityOrganization, error)
+	ListIdentityUsers(context.Context, IdentityUserFilter) ([]*IdentityUser, error)
+}

--- a/internal/sourcehttp/identitydirectory/handler.go
+++ b/internal/sourcehttp/identitydirectory/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"sort"
 	"strconv"
@@ -600,15 +601,34 @@ func tenantSlug(tenantID string) string {
 }
 
 func oauthProvider(issuer string) string {
-	issuer = strings.ToLower(strings.TrimSpace(issuer))
 	switch {
-	case strings.Contains(issuer, "okta"):
+	case oktaIssuer(issuer):
 		return "okta"
-	case issuer != "":
+	case strings.TrimSpace(issuer) != "":
 		return "oidc"
 	default:
 		return ""
 	}
+}
+
+func oktaIssuer(issuer string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(issuer))
+	host := ""
+	if err == nil {
+		host = parsed.Hostname()
+	}
+	if host == "" {
+		host = strings.TrimSpace(issuer)
+	}
+	host = strings.ToLower(host)
+	return host == "okta.com" ||
+		host == "okta-emea.com" ||
+		host == "oktapreview.com" ||
+		host == "okta-gov.com" ||
+		strings.HasSuffix(host, ".okta.com") ||
+		strings.HasSuffix(host, ".okta-emea.com") ||
+		strings.HasSuffix(host, ".oktapreview.com") ||
+		strings.HasSuffix(host, ".okta-gov.com")
 }
 
 func identityOrgKey(org *ports.IdentityOrganization) string {

--- a/internal/sourcehttp/identitydirectory/handler.go
+++ b/internal/sourcehttp/identitydirectory/handler.go
@@ -1,0 +1,660 @@
+package identitydirectory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const defaultDirectoryLimit uint32 = 100
+const maxDirectoryLimit uint32 = 500
+
+type TenantResolver func(context.Context, string) (string, error)
+type TenantAuthorizer func(context.Context, string) error
+
+type Handler struct {
+	store            ports.IdentityDirectoryStore
+	cfg              config.AuthConfig
+	tenantResolver   TenantResolver
+	tenantAuthorizer TenantAuthorizer
+}
+
+type organizationResponse struct {
+	OrgID        string `json:"org_id"`
+	TenantID     string `json:"tenant_id"`
+	Name         string `json:"name"`
+	Slug         string `json:"slug,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	Source       string `json:"source"`
+	ExternalID   string `json:"external_id,omitempty"`
+	UserCount    int    `json:"user_count"`
+	LastSyncedAt string `json:"last_synced_at,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+type userResponse struct {
+	UserID       string   `json:"user_id"`
+	TenantID     string   `json:"tenant_id"`
+	OrgID        string   `json:"org_id,omitempty"`
+	Subject      string   `json:"subject,omitempty"`
+	Email        string   `json:"email,omitempty"`
+	DisplayName  string   `json:"display_name"`
+	Status       string   `json:"status"`
+	Provider     string   `json:"provider,omitempty"`
+	Source       string   `json:"source"`
+	Roles        []string `json:"roles,omitempty"`
+	Groups       []string `json:"groups,omitempty"`
+	LastSeenAt   string   `json:"last_seen_at,omitempty"`
+	LastSyncedAt string   `json:"last_synced_at,omitempty"`
+	CreatedAt    string   `json:"created_at,omitempty"`
+	UpdatedAt    string   `json:"updated_at,omitempty"`
+}
+
+type listOrganizationsResponse struct {
+	TenantID      string                 `json:"tenant_id,omitempty"`
+	Organizations []organizationResponse `json:"organizations"`
+	Meta          listMeta               `json:"meta"`
+}
+
+type listUsersResponse struct {
+	TenantID string         `json:"tenant_id,omitempty"`
+	OrgID    string         `json:"org_id,omitempty"`
+	Users    []userResponse `json:"users"`
+	Meta     listMeta       `json:"meta"`
+}
+
+type listMeta struct {
+	Limit      uint32 `json:"limit"`
+	Loaded     int    `json:"loaded"`
+	Configured int    `json:"configured"`
+	Persisted  int    `json:"persisted"`
+}
+
+func NewHandler(store ports.StateStore, cfg config.AuthConfig, tenantResolver TenantResolver, tenantAuthorizer TenantAuthorizer) Handler {
+	directoryStore, _ := store.(ports.IdentityDirectoryStore)
+	if isNil(directoryStore) {
+		directoryStore = nil
+	}
+	return Handler{store: directoryStore, cfg: cfg, tenantResolver: tenantResolver, tenantAuthorizer: tenantAuthorizer}
+}
+
+func (h Handler) ListOrganizations(w http.ResponseWriter, r *http.Request) {
+	tenantID, err := h.tenantForRequest(r, r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		writeError(w, statusForTenantError(err), err.Error())
+		return
+	}
+	orgID := strings.TrimSpace(r.URL.Query().Get("org_id"))
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	limit := directoryLimit(r.URL.Query().Get("limit"))
+	configured := configuredOrganizations(h.cfg, tenantID)
+	persisted, err := h.persistedOrganizations(r.Context(), ports.IdentityOrganizationFilter{TenantID: tenantID, OrgID: orgID, Query: query, Limit: limit})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "identity organizations unavailable")
+		return
+	}
+	organizations := mergeOrganizations(configured, persisted, tenantID, orgID, query, limit)
+	writeJSON(w, http.StatusOK, listOrganizationsResponse{
+		TenantID:      tenantID,
+		Organizations: organizationResponses(organizations),
+		Meta:          listMeta{Limit: limit, Loaded: len(organizations), Configured: len(configured), Persisted: len(persisted)},
+	})
+}
+
+func (h Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
+	tenantID, err := h.tenantForRequest(r, r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		writeError(w, statusForTenantError(err), err.Error())
+		return
+	}
+	orgID := strings.TrimSpace(r.URL.Query().Get("org_id"))
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	limit := directoryLimit(r.URL.Query().Get("limit"))
+	configured := configuredUsers(h.cfg, tenantID, orgID)
+	persisted, err := h.persistedUsers(r.Context(), ports.IdentityUserFilter{TenantID: tenantID, OrgID: orgID, Query: query, Limit: limit})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "identity users unavailable")
+		return
+	}
+	users := mergeUsers(configured, persisted, tenantID, orgID, query, limit)
+	writeJSON(w, http.StatusOK, listUsersResponse{
+		TenantID: tenantID,
+		OrgID:    orgID,
+		Users:    userResponses(users),
+		Meta:     listMeta{Limit: limit, Loaded: len(users), Configured: len(configured), Persisted: len(persisted)},
+	})
+}
+
+func (h Handler) tenantForRequest(r *http.Request, requestedTenantID string) (string, error) {
+	if h.tenantResolver != nil {
+		return h.tenantResolver(r.Context(), requestedTenantID)
+	}
+	tenantID := strings.TrimSpace(requestedTenantID)
+	if h.tenantAuthorizer != nil {
+		if err := h.tenantAuthorizer(r.Context(), tenantID); err != nil {
+			return "", err
+		}
+	}
+	return tenantID, nil
+}
+
+func (h Handler) persistedOrganizations(ctx context.Context, filter ports.IdentityOrganizationFilter) ([]*ports.IdentityOrganization, error) {
+	if h.store == nil {
+		return nil, nil
+	}
+	return h.store.ListIdentityOrganizations(ctx, filter)
+}
+
+func (h Handler) persistedUsers(ctx context.Context, filter ports.IdentityUserFilter) ([]*ports.IdentityUser, error) {
+	if h.store == nil {
+		return nil, nil
+	}
+	return h.store.ListIdentityUsers(ctx, filter)
+}
+
+func configuredOrganizations(cfg config.AuthConfig, tenantID string) []*ports.IdentityOrganization {
+	organizations := map[string]*ports.IdentityOrganization{}
+	add := func(tenantID string, source string, provider string, externalID string) {
+		tenantID = strings.TrimSpace(tenantID)
+		if tenantID == "" {
+			return
+		}
+		key := tenantID + "\x00" + tenantID
+		if existing := organizations[key]; existing != nil {
+			if provider != "" {
+				existing.Source = source
+				existing.Provider = provider
+			} else if existing.Source == "auth_config" && source != "" {
+				existing.Source = source
+			}
+			if existing.ExternalID == "" {
+				existing.ExternalID = externalID
+			}
+			return
+		}
+		organizations[key] = &ports.IdentityOrganization{
+			OrgID:      tenantID,
+			TenantID:   tenantID,
+			Name:       tenantName(tenantID),
+			Slug:       tenantSlug(tenantID),
+			Provider:   provider,
+			Source:     firstNonEmpty(source, "auth_config"),
+			ExternalID: externalID,
+		}
+	}
+	for _, tenant := range cfg.AllowedTenants {
+		add(tenant, "auth_config", "", "")
+	}
+	for _, key := range cfg.APIKeys {
+		add(key.TenantID, "api_key", "", "")
+	}
+	for _, credential := range cfg.APICredentials {
+		add(credential.TenantID, "api_credential", "", "")
+		for _, tenant := range credential.AllowedTenants {
+			add(tenant, "api_credential", "", "")
+		}
+	}
+	oauthProvider := oauthProvider(cfg.MCPOAuth.Upstream.Issuer)
+	oauthExternalID := strings.TrimSpace(cfg.MCPOAuth.Upstream.Issuer)
+	add(cfg.MCPOAuth.TenantID, "mcp_oauth", oauthProvider, oauthExternalID)
+	for _, tenant := range cfg.MCPOAuth.AllowedTenants {
+		add(tenant, "mcp_oauth", oauthProvider, oauthExternalID)
+	}
+	for _, client := range cfg.MCPOAuth.Clients {
+		add(client.TenantID, "mcp_oauth_client", oauthProvider, oauthExternalID)
+		for _, tenant := range client.AllowedTenants {
+			add(tenant, "mcp_oauth_client", oauthProvider, oauthExternalID)
+		}
+	}
+	for _, entitlement := range cfg.MCPOAuth.Entitlements {
+		add(entitlement.TenantID, "mcp_oauth", oauthProvider, oauthExternalID)
+		for _, tenant := range entitlement.AllowedTenants {
+			add(tenant, "mcp_oauth", oauthProvider, oauthExternalID)
+		}
+	}
+	var out []*ports.IdentityOrganization
+	for _, org := range organizations {
+		if tenantID != "" && org.TenantID != tenantID {
+			continue
+		}
+		out = append(out, org)
+	}
+	return out
+}
+
+func configuredUsers(cfg config.AuthConfig, tenantID string, orgID string) []*ports.IdentityUser {
+	var users []*ports.IdentityUser
+	add := func(user ports.IdentityUser) {
+		user.TenantID = strings.TrimSpace(user.TenantID)
+		user.OrgID = firstNonEmpty(user.OrgID, user.TenantID)
+		user.UserID = firstNonEmpty(user.UserID, user.Subject, user.Email, user.DisplayName)
+		user.DisplayName = firstNonEmpty(user.DisplayName, user.Email, user.Subject, user.UserID)
+		user.Status = firstNonEmpty(user.Status, "active")
+		if user.TenantID == "" || user.UserID == "" || user.DisplayName == "" {
+			return
+		}
+		if tenantID != "" && user.TenantID != tenantID {
+			return
+		}
+		if orgID != "" && user.OrgID != orgID {
+			return
+		}
+		users = append(users, &user)
+	}
+	for index, key := range cfg.APIKeys {
+		userID := firstNonEmpty(key.Principal, fmt.Sprintf("api-key:%d", index+1))
+		add(ports.IdentityUser{
+			TenantID:    key.TenantID,
+			UserID:      userID,
+			DisplayName: userID,
+			Source:      "api_key",
+		})
+	}
+	for _, credential := range cfg.APICredentials {
+		userID := firstNonEmpty(credential.Principal, credential.Name, credential.ClientID, credential.ID)
+		add(ports.IdentityUser{
+			TenantID:    credential.TenantID,
+			UserID:      userID,
+			DisplayName: userID,
+			Source:      "api_credential",
+			Roles:       credential.Roles,
+			Groups:      nil,
+		})
+		for _, allowedTenant := range credential.AllowedTenants {
+			add(ports.IdentityUser{
+				TenantID:    allowedTenant,
+				UserID:      userID,
+				DisplayName: userID,
+				Source:      "api_credential",
+				Roles:       credential.Roles,
+			})
+		}
+	}
+	oauthProvider := oauthProvider(cfg.MCPOAuth.Upstream.Issuer)
+	for _, client := range cfg.MCPOAuth.Clients {
+		if !contains(client.GrantTypes, "client_credentials") {
+			continue
+		}
+		userID := "service:" + strings.TrimSpace(client.ClientID)
+		add(ports.IdentityUser{
+			TenantID:    client.TenantID,
+			UserID:      userID,
+			DisplayName: firstNonEmpty(client.Name, client.ClientID),
+			Status:      "active",
+			Provider:    oauthProvider,
+			Source:      "mcp_oauth_client",
+			Roles:       client.Roles,
+			Groups:      client.Groups,
+		})
+		for _, allowedTenant := range client.AllowedTenants {
+			add(ports.IdentityUser{
+				TenantID:    allowedTenant,
+				UserID:      userID,
+				DisplayName: firstNonEmpty(client.Name, client.ClientID),
+				Status:      "active",
+				Provider:    oauthProvider,
+				Source:      "mcp_oauth_client",
+				Roles:       client.Roles,
+				Groups:      client.Groups,
+			})
+		}
+	}
+	for _, entitlement := range cfg.MCPOAuth.Entitlements {
+		userID := firstNonEmpty(entitlement.Email, entitlement.Subject)
+		if userID == "" {
+			continue
+		}
+		add(ports.IdentityUser{
+			TenantID:    entitlement.TenantID,
+			UserID:      userID,
+			Subject:     entitlement.Subject,
+			Email:       strings.ToLower(strings.TrimSpace(entitlement.Email)),
+			DisplayName: userID,
+			Status:      "active",
+			Provider:    oauthProvider,
+			Source:      "mcp_oauth_entitlement",
+			Roles:       entitlement.Roles,
+			Groups:      entitlement.Groups,
+		})
+		for _, allowedTenant := range entitlement.AllowedTenants {
+			add(ports.IdentityUser{
+				TenantID:    allowedTenant,
+				UserID:      userID,
+				Subject:     entitlement.Subject,
+				Email:       strings.ToLower(strings.TrimSpace(entitlement.Email)),
+				DisplayName: userID,
+				Status:      "active",
+				Provider:    oauthProvider,
+				Source:      "mcp_oauth_entitlement",
+				Roles:       entitlement.Roles,
+				Groups:      entitlement.Groups,
+			})
+		}
+	}
+	return users
+}
+
+func mergeOrganizations(configured []*ports.IdentityOrganization, persisted []*ports.IdentityOrganization, tenantID string, orgID string, query string, limit uint32) []*ports.IdentityOrganization {
+	byKey := map[string]*ports.IdentityOrganization{}
+	for _, org := range configured {
+		if organizationVisible(org, tenantID, orgID, query) {
+			byKey[identityOrgKey(org)] = cloneOrganization(org)
+		}
+	}
+	for _, org := range persisted {
+		if !organizationVisible(org, tenantID, orgID, query) {
+			continue
+		}
+		key := identityOrgKey(org)
+		if existing := byKey[key]; existing != nil {
+			if existing.UserCount == 0 {
+				existing.UserCount = org.UserCount
+			}
+			if existing.LastSyncedAt.IsZero() {
+				existing.LastSyncedAt = org.LastSyncedAt
+			}
+			if existing.CreatedAt.IsZero() {
+				existing.CreatedAt = org.CreatedAt
+			}
+			if org.UpdatedAt.After(existing.UpdatedAt) {
+				existing.UpdatedAt = org.UpdatedAt
+			}
+			continue
+		}
+		byKey[key] = cloneOrganization(org)
+	}
+	out := make([]*ports.IdentityOrganization, 0, len(byKey))
+	for _, org := range byKey {
+		out = append(out, org)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].OrgID < out[j].OrgID
+	})
+	return capOrganizations(out, limit)
+}
+
+func mergeUsers(configured []*ports.IdentityUser, persisted []*ports.IdentityUser, tenantID string, orgID string, query string, limit uint32) []*ports.IdentityUser {
+	byKey := map[string]*ports.IdentityUser{}
+	for _, user := range configured {
+		if userVisible(user, tenantID, orgID, query) {
+			byKey[identityUserKey(user)] = cloneUser(user)
+		}
+	}
+	for _, user := range persisted {
+		if !userVisible(user, tenantID, orgID, query) {
+			continue
+		}
+		byKey[identityUserKey(user)] = cloneUser(user)
+	}
+	out := make([]*ports.IdentityUser, 0, len(byKey))
+	for _, user := range byKey {
+		out = append(out, user)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].LastSeenAt.Equal(out[j].LastSeenAt) {
+			return out[i].LastSeenAt.After(out[j].LastSeenAt)
+		}
+		if out[i].DisplayName != out[j].DisplayName {
+			return out[i].DisplayName < out[j].DisplayName
+		}
+		return out[i].UserID < out[j].UserID
+	})
+	return capUsers(out, limit)
+}
+
+func organizationResponses(orgs []*ports.IdentityOrganization) []organizationResponse {
+	responses := make([]organizationResponse, 0, len(orgs))
+	for _, org := range orgs {
+		responses = append(responses, organizationResponse{
+			OrgID:        strings.TrimSpace(org.OrgID),
+			TenantID:     strings.TrimSpace(org.TenantID),
+			Name:         strings.TrimSpace(org.Name),
+			Slug:         strings.TrimSpace(org.Slug),
+			Domain:       strings.TrimSpace(org.Domain),
+			Provider:     strings.TrimSpace(org.Provider),
+			Source:       firstNonEmpty(org.Source, "identity_directory"),
+			ExternalID:   strings.TrimSpace(org.ExternalID),
+			UserCount:    org.UserCount,
+			LastSyncedAt: timeString(org.LastSyncedAt),
+			CreatedAt:    timeString(org.CreatedAt),
+			UpdatedAt:    timeString(org.UpdatedAt),
+		})
+	}
+	return responses
+}
+
+func userResponses(users []*ports.IdentityUser) []userResponse {
+	responses := make([]userResponse, 0, len(users))
+	for _, user := range users {
+		responses = append(responses, userResponse{
+			UserID:       strings.TrimSpace(user.UserID),
+			TenantID:     strings.TrimSpace(user.TenantID),
+			OrgID:        strings.TrimSpace(user.OrgID),
+			Subject:      strings.TrimSpace(user.Subject),
+			Email:        strings.TrimSpace(user.Email),
+			DisplayName:  strings.TrimSpace(user.DisplayName),
+			Status:       firstNonEmpty(user.Status, "active"),
+			Provider:     strings.TrimSpace(user.Provider),
+			Source:       firstNonEmpty(user.Source, "identity_directory"),
+			Roles:        normalized(user.Roles),
+			Groups:       normalized(user.Groups),
+			LastSeenAt:   timeString(user.LastSeenAt),
+			LastSyncedAt: timeString(user.LastSyncedAt),
+			CreatedAt:    timeString(user.CreatedAt),
+			UpdatedAt:    timeString(user.UpdatedAt),
+		})
+	}
+	return responses
+}
+
+func organizationVisible(org *ports.IdentityOrganization, tenantID string, orgID string, query string) bool {
+	if org == nil {
+		return false
+	}
+	if tenantID != "" && org.TenantID != tenantID {
+		return false
+	}
+	if orgID != "" && org.OrgID != orgID {
+		return false
+	}
+	return matchesQuery(query, org.OrgID, org.Name, org.Domain, org.Provider, org.Source)
+}
+
+func userVisible(user *ports.IdentityUser, tenantID string, orgID string, query string) bool {
+	if user == nil {
+		return false
+	}
+	if tenantID != "" && user.TenantID != tenantID {
+		return false
+	}
+	if orgID != "" && user.OrgID != orgID {
+		return false
+	}
+	return matchesQuery(query, user.UserID, user.Email, user.DisplayName, user.Subject, user.Provider, user.Source)
+}
+
+func matchesQuery(query string, values ...string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return true
+	}
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(strings.TrimSpace(value)), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneOrganization(org *ports.IdentityOrganization) *ports.IdentityOrganization {
+	if org == nil {
+		return nil
+	}
+	copied := *org
+	return &copied
+}
+
+func cloneUser(user *ports.IdentityUser) *ports.IdentityUser {
+	if user == nil {
+		return nil
+	}
+	copied := *user
+	copied.Roles = normalized(user.Roles)
+	copied.Groups = normalized(user.Groups)
+	return &copied
+}
+
+func capOrganizations(orgs []*ports.IdentityOrganization, limit uint32) []*ports.IdentityOrganization {
+	if uint32(len(orgs)) <= limit {
+		return orgs
+	}
+	return orgs[:limit]
+}
+
+func capUsers(users []*ports.IdentityUser, limit uint32) []*ports.IdentityUser {
+	if uint32(len(users)) <= limit {
+		return users
+	}
+	return users[:limit]
+}
+
+func directoryLimit(raw string) uint32 {
+	parsed, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 32)
+	if err != nil || parsed == 0 {
+		return defaultDirectoryLimit
+	}
+	if parsed > uint64(maxDirectoryLimit) {
+		return maxDirectoryLimit
+	}
+	return uint32(parsed)
+}
+
+func statusForTenantError(error) int {
+	return http.StatusForbidden
+}
+
+func writeJSON(w http.ResponseWriter, statusCode int, value any) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(payload)
+}
+
+func writeError(w http.ResponseWriter, statusCode int, message string) {
+	http.Error(w, message, statusCode)
+}
+
+func tenantName(tenantID string) string {
+	return strings.TrimSpace(tenantID)
+}
+
+func tenantSlug(tenantID string) string {
+	slug := strings.ToLower(strings.TrimSpace(tenantID))
+	slug = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-' || r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, slug)
+	return strings.Trim(slug, "-")
+}
+
+func oauthProvider(issuer string) string {
+	issuer = strings.ToLower(strings.TrimSpace(issuer))
+	switch {
+	case strings.Contains(issuer, "okta"):
+		return "okta"
+	case issuer != "":
+		return "oidc"
+	default:
+		return ""
+	}
+}
+
+func identityOrgKey(org *ports.IdentityOrganization) string {
+	return strings.TrimSpace(org.TenantID) + "\x00" + strings.TrimSpace(org.OrgID)
+}
+
+func identityUserKey(user *ports.IdentityUser) string {
+	return strings.TrimSpace(user.TenantID) + "\x00" + strings.TrimSpace(user.UserID)
+}
+
+func normalized(values []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func contains(values []string, want string) bool {
+	want = strings.TrimSpace(want)
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func timeString(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	kind := reflect.TypeOf(value).Kind()
+	switch kind {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflect.ValueOf(value).IsNil()
+	default:
+		return false
+	}
+}

--- a/internal/sourcehttp/identitydirectory/handler.go
+++ b/internal/sourcehttp/identitydirectory/handler.go
@@ -519,17 +519,25 @@ func cloneUser(user *ports.IdentityUser) *ports.IdentityUser {
 }
 
 func capOrganizations(orgs []*ports.IdentityOrganization, limit uint32) []*ports.IdentityOrganization {
-	if uint32(len(orgs)) <= limit {
-		return orgs
+	remaining := limit
+	for index := range orgs {
+		if remaining == 0 {
+			return orgs[:index]
+		}
+		remaining--
 	}
-	return orgs[:limit]
+	return orgs
 }
 
 func capUsers(users []*ports.IdentityUser, limit uint32) []*ports.IdentityUser {
-	if uint32(len(users)) <= limit {
-		return users
+	remaining := limit
+	for index := range users {
+		if remaining == 0 {
+			return users[:index]
+		}
+		remaining--
 	}
-	return users[:limit]
+	return users
 }
 
 func directoryLimit(raw string) uint32 {

--- a/internal/sourcehttp/identitydirectory/handler.go
+++ b/internal/sourcehttp/identitydirectory/handler.go
@@ -402,7 +402,13 @@ func mergeUsers(configured []*ports.IdentityUser, persisted []*ports.IdentityUse
 		if !userVisible(user, tenantID, orgID, query) {
 			continue
 		}
-		byKey[identityUserKey(user)] = cloneUser(user)
+		key := identityUserKey(user)
+		merged := cloneUser(user)
+		if configuredUser := byKey[key]; configuredUser != nil {
+			merged.Roles = normalized(append(configuredUser.Roles, merged.Roles...))
+			merged.Groups = normalized(append(configuredUser.Groups, merged.Groups...))
+		}
+		byKey[key] = merged
 	}
 	out := make([]*ports.IdentityUser, 0, len(byKey))
 	for _, user := range byKey {

--- a/internal/sourcehttp/identitydirectory/handler.go
+++ b/internal/sourcehttp/identitydirectory/handler.go
@@ -311,7 +311,7 @@ func configuredUsers(cfg config.AuthConfig, tenantID string, orgID string) []*po
 		}
 	}
 	for _, entitlement := range cfg.MCPOAuth.Entitlements {
-		userID := firstNonEmpty(entitlement.Email, entitlement.Subject)
+		userID := firstNonEmpty(entitlement.Subject, entitlement.Email)
 		if userID == "" {
 			continue
 		}
@@ -389,9 +389,12 @@ func mergeOrganizations(configured []*ports.IdentityOrganization, persisted []*p
 
 func mergeUsers(configured []*ports.IdentityUser, persisted []*ports.IdentityUser, tenantID string, orgID string, query string, limit uint32) []*ports.IdentityUser {
 	byKey := map[string]*ports.IdentityUser{}
+	configuredKeys := map[string]bool{}
 	for _, user := range configured {
 		if userVisible(user, tenantID, orgID, query) {
-			byKey[identityUserKey(user)] = cloneUser(user)
+			key := identityUserKey(user)
+			byKey[key] = cloneUser(user)
+			configuredKeys[key] = true
 		}
 	}
 	for _, user := range persisted {
@@ -405,6 +408,11 @@ func mergeUsers(configured []*ports.IdentityUser, persisted []*ports.IdentityUse
 		out = append(out, user)
 	}
 	sort.Slice(out, func(i, j int) bool {
+		leftConfigured := configuredKeys[identityUserKey(out[i])]
+		rightConfigured := configuredKeys[identityUserKey(out[j])]
+		if leftConfigured != rightConfigured {
+			return leftConfigured
+		}
 		if !out[i].LastSeenAt.Equal(out[j].LastSeenAt) {
 			return out[i].LastSeenAt.After(out[j].LastSeenAt)
 		}

--- a/internal/sourcehttp/identitydirectory/handler_test.go
+++ b/internal/sourcehttp/identitydirectory/handler_test.go
@@ -162,3 +162,61 @@ func TestListUsersMergesPersistedOAuthUsersAndConfiguredServiceUsers(t *testing.
 		t.Fatalf("all users response missing non-secret API key placeholder: %s", allRecorder.Body.String())
 	}
 }
+
+func TestListUsersKeepsConfiguredUsersInsideLimit(t *testing.T) {
+	store := &stubDirectoryStore{
+		users: []*ports.IdentityUser{
+			{
+				TenantID:    "tenant-a",
+				OrgID:       "tenant-a",
+				UserID:      "persisted-1",
+				DisplayName: "Persisted 1",
+				LastSeenAt:  time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC),
+			},
+			{
+				TenantID:    "tenant-a",
+				OrgID:       "tenant-a",
+				UserID:      "persisted-2",
+				DisplayName: "Persisted 2",
+				LastSeenAt:  time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	handler := testHandler(store)
+	recorder := httptest.NewRecorder()
+
+	handler.ListUsers(recorder, httptest.NewRequest(http.MethodGet, "/identity/users?limit=2", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response listUsersResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Users) != 2 {
+		t.Fatalf("users = %+v, want two configured users", response.Users)
+	}
+	for _, want := range []string{"api-key:1", "service:automation"} {
+		if !strings.Contains(recorder.Body.String(), want) {
+			t.Fatalf("limited users response missing configured user %q: %s", want, recorder.Body.String())
+		}
+	}
+}
+
+func TestConfiguredEntitlementUserIDPrefersSubject(t *testing.T) {
+	users := configuredUsers(config.AuthConfig{
+		MCPOAuth: config.MCPOAuthConfig{
+			Upstream: config.MCPOAuthUpstreamConfig{Issuer: "https://example.okta.com"},
+			Entitlements: []config.MCPOAuthEntitlement{{
+				TenantID: "tenant-a",
+				Subject:  "00u123",
+				Email:    "person@example.com",
+			}},
+		},
+	}, "tenant-a", "")
+
+	if len(users) != 1 || users[0].UserID != "00u123" {
+		t.Fatalf("configured users = %+v, want subject-derived user id", users)
+	}
+}

--- a/internal/sourcehttp/identitydirectory/handler_test.go
+++ b/internal/sourcehttp/identitydirectory/handler_test.go
@@ -221,6 +221,38 @@ func TestConfiguredEntitlementUserIDPrefersSubject(t *testing.T) {
 	}
 }
 
+func TestMergeUsersPreservesConfiguredGrantsOnPersistedCollision(t *testing.T) {
+	configured := []*ports.IdentityUser{{
+		TenantID:    "tenant-a",
+		UserID:      "00u123",
+		DisplayName: "Configured User",
+		Roles:       []string{"cerebro.viewer"},
+		Groups:      []string{"security-team"},
+	}}
+	persisted := []*ports.IdentityUser{{
+		TenantID:    "tenant-a",
+		UserID:      "00u123",
+		Subject:     "00u123",
+		Email:       "person@example.com",
+		DisplayName: "Persisted User",
+		LastSeenAt:  time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	}}
+
+	users := mergeUsers(configured, persisted, "tenant-a", "", "", 10)
+	if len(users) != 1 {
+		t.Fatalf("users = %+v, want one merged user", users)
+	}
+	if users[0].Email != "person@example.com" || users[0].DisplayName != "Persisted User" {
+		t.Fatalf("merged user did not keep persisted profile fields: %+v", users[0])
+	}
+	if len(users[0].Roles) != 1 || users[0].Roles[0] != "cerebro.viewer" {
+		t.Fatalf("merged roles = %#v, want configured role", users[0].Roles)
+	}
+	if len(users[0].Groups) != 1 || users[0].Groups[0] != "security-team" {
+		t.Fatalf("merged groups = %#v, want configured group", users[0].Groups)
+	}
+}
+
 func TestOAuthProviderUsesIssuerHost(t *testing.T) {
 	if got := oauthProvider("https://tenant.okta.com/oauth2/default"); got != "okta" {
 		t.Fatalf("oauthProvider(okta issuer) = %q, want okta", got)

--- a/internal/sourcehttp/identitydirectory/handler_test.go
+++ b/internal/sourcehttp/identitydirectory/handler_test.go
@@ -1,0 +1,164 @@
+package identitydirectory
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type stubDirectoryStore struct {
+	orgs  []*ports.IdentityOrganization
+	users []*ports.IdentityUser
+}
+
+func (s *stubDirectoryStore) Ping(context.Context) error { return nil }
+
+func (s *stubDirectoryStore) UpsertIdentityOrganization(_ context.Context, org *ports.IdentityOrganization) error {
+	copied := *org
+	s.orgs = append(s.orgs, &copied)
+	return nil
+}
+
+func (s *stubDirectoryStore) UpsertIdentityUser(_ context.Context, user *ports.IdentityUser) error {
+	copied := *user
+	copied.Roles = append([]string(nil), user.Roles...)
+	copied.Groups = append([]string(nil), user.Groups...)
+	s.users = append(s.users, &copied)
+	return nil
+}
+
+func (s *stubDirectoryStore) ListIdentityOrganizations(_ context.Context, filter ports.IdentityOrganizationFilter) ([]*ports.IdentityOrganization, error) {
+	var out []*ports.IdentityOrganization
+	for _, org := range s.orgs {
+		if filter.TenantID != "" && org.TenantID != filter.TenantID {
+			continue
+		}
+		if filter.OrgID != "" && org.OrgID != filter.OrgID {
+			continue
+		}
+		if !matchesQuery(filter.Query, org.OrgID, org.Name, org.Domain) {
+			continue
+		}
+		copied := *org
+		out = append(out, &copied)
+	}
+	return out, nil
+}
+
+func (s *stubDirectoryStore) ListIdentityUsers(_ context.Context, filter ports.IdentityUserFilter) ([]*ports.IdentityUser, error) {
+	var out []*ports.IdentityUser
+	for _, user := range s.users {
+		if filter.TenantID != "" && user.TenantID != filter.TenantID {
+			continue
+		}
+		if filter.OrgID != "" && user.OrgID != filter.OrgID {
+			continue
+		}
+		if !matchesQuery(filter.Query, user.UserID, user.Email, user.DisplayName) {
+			continue
+		}
+		copied := *user
+		copied.Roles = append([]string(nil), user.Roles...)
+		copied.Groups = append([]string(nil), user.Groups...)
+		out = append(out, &copied)
+	}
+	return out, nil
+}
+
+func testHandler(store ports.StateStore) Handler {
+	return NewHandler(store, config.AuthConfig{
+		APIKeys: []config.APIKey{{
+			Key:      "opaque-api-key-value",
+			TenantID: "tenant-a",
+		}},
+		MCPOAuth: config.MCPOAuthConfig{
+			TenantID: "tenant-a",
+			Upstream: config.MCPOAuthUpstreamConfig{
+				Issuer: "https://example.okta.com",
+			},
+			Clients: []config.MCPOAuthClient{{
+				ClientID:   "automation",
+				Name:       "Automation",
+				GrantTypes: []string{"client_credentials"},
+				TenantID:   "tenant-a",
+				Roles:      []string{"cerebro.viewer"},
+			}},
+		},
+	}, func(context.Context, string) (string, error) {
+		return "tenant-a", nil
+	}, nil)
+}
+
+func TestListOrganizationsIncludesOAuthTenant(t *testing.T) {
+	handler := testHandler(&stubDirectoryStore{})
+	recorder := httptest.NewRecorder()
+
+	handler.ListOrganizations(recorder, httptest.NewRequest(http.MethodGet, "/identity/orgs", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response listOrganizationsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Organizations) != 1 {
+		t.Fatalf("organizations = %+v, want one oauth tenant", response.Organizations)
+	}
+	org := response.Organizations[0]
+	if org.OrgID != "tenant-a" || org.TenantID != "tenant-a" || org.Provider != "okta" || !strings.HasPrefix(org.Source, "mcp_oauth") {
+		t.Fatalf("oauth organization = %+v", org)
+	}
+}
+
+func TestListUsersMergesPersistedOAuthUsersAndConfiguredServiceUsers(t *testing.T) {
+	store := &stubDirectoryStore{
+		users: []*ports.IdentityUser{{
+			TenantID:    "tenant-a",
+			OrgID:       "tenant-a",
+			UserID:      "00u123",
+			Subject:     "00u123",
+			Email:       "person@example.com",
+			DisplayName: "Person Example",
+			Status:      "active",
+			Provider:    "okta",
+			Source:      "mcp_oauth",
+			Groups:      []string{"security-team"},
+			LastSeenAt:  time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+	handler := testHandler(store)
+	recorder := httptest.NewRecorder()
+
+	handler.ListUsers(recorder, httptest.NewRequest(http.MethodGet, "/identity/users?q=person", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response listUsersResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Users) != 1 || response.Users[0].Email != "person@example.com" {
+		t.Fatalf("filtered users = %+v, want persisted OAuth user", response.Users)
+	}
+
+	allRecorder := httptest.NewRecorder()
+	handler.ListUsers(allRecorder, httptest.NewRequest(http.MethodGet, "/identity/users", nil))
+	if !strings.Contains(allRecorder.Body.String(), "service:automation") {
+		t.Fatalf("all users response missing configured service principal: %s", allRecorder.Body.String())
+	}
+	if strings.Contains(allRecorder.Body.String(), "opaque-api-key-value") {
+		t.Fatalf("all users response leaked API key material: %s", allRecorder.Body.String())
+	}
+	if !strings.Contains(allRecorder.Body.String(), "api-key:1") {
+		t.Fatalf("all users response missing non-secret API key placeholder: %s", allRecorder.Body.String())
+	}
+}

--- a/internal/sourcehttp/identitydirectory/handler_test.go
+++ b/internal/sourcehttp/identitydirectory/handler_test.go
@@ -220,3 +220,12 @@ func TestConfiguredEntitlementUserIDPrefersSubject(t *testing.T) {
 		t.Fatalf("configured users = %+v, want subject-derived user id", users)
 	}
 }
+
+func TestOAuthProviderUsesIssuerHost(t *testing.T) {
+	if got := oauthProvider("https://tenant.okta.com/oauth2/default"); got != "okta" {
+		t.Fatalf("oauthProvider(okta issuer) = %q, want okta", got)
+	}
+	if got := oauthProvider("https://booktaku.example.com/oauth2/default"); got != "oidc" {
+		t.Fatalf("oauthProvider(non-okta issuer) = %q, want oidc", got)
+	}
+}

--- a/internal/statestore/postgres/identity_directory.go
+++ b/internal/statestore/postgres/identity_directory.go
@@ -178,7 +178,7 @@ func (s *Store) ListIdentityOrganizations(ctx context.Context, filter ports.Iden
 	addIdentityStringClause(&clauses, &args, "org_id", filter.OrgID)
 	if query := strings.TrimSpace(filter.Query); query != "" {
 		args = append(args, "%"+strings.ToLower(query)+"%")
-		clauses = append(clauses, fmt.Sprintf("(LOWER(org_id) LIKE $%d OR LOWER(name) LIKE $%d OR LOWER(domain) LIKE $%d)", len(args), len(args), len(args)))
+		clauses = append(clauses, fmt.Sprintf("(LOWER(org_id) LIKE $%d OR LOWER(name) LIKE $%d OR LOWER(domain) LIKE $%d OR LOWER(provider) LIKE $%d OR LOWER(source) LIKE $%d OR LOWER(external_id) LIKE $%d)", len(args), len(args), len(args), len(args), len(args), len(args)))
 	}
 	args = append(args, identityDirectoryLimit(filter.Limit))
 	// #nosec G201 -- clauses and selected columns are fixed identifiers; values remain query parameters.
@@ -213,7 +213,7 @@ func (s *Store) ListIdentityUsers(ctx context.Context, filter ports.IdentityUser
 	addIdentityStringClause(&clauses, &args, "user_id", filter.UserID)
 	if query := strings.TrimSpace(filter.Query); query != "" {
 		args = append(args, "%"+strings.ToLower(query)+"%")
-		clauses = append(clauses, fmt.Sprintf("(LOWER(user_id) LIKE $%d OR LOWER(email) LIKE $%d OR LOWER(display_name) LIKE $%d)", len(args), len(args), len(args)))
+		clauses = append(clauses, fmt.Sprintf("(LOWER(user_id) LIKE $%d OR LOWER(email) LIKE $%d OR LOWER(display_name) LIKE $%d OR LOWER(subject) LIKE $%d OR LOWER(provider) LIKE $%d OR LOWER(source) LIKE $%d)", len(args), len(args), len(args), len(args), len(args), len(args)))
 	}
 	args = append(args, identityDirectoryLimit(filter.Limit))
 	// #nosec G201 -- clauses and selected columns are fixed identifiers; values remain query parameters.

--- a/internal/statestore/postgres/identity_directory.go
+++ b/internal/statestore/postgres/identity_directory.go
@@ -1,0 +1,331 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var _ ports.IdentityDirectoryStore = (*Store)(nil)
+
+var ensureIdentityDirectoryStatements = []string{
+	`CREATE TABLE IF NOT EXISTS identity_organizations (
+  tenant_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL DEFAULT '',
+  domain TEXT NOT NULL DEFAULT '',
+  provider TEXT NOT NULL DEFAULT '',
+  source TEXT NOT NULL DEFAULT '',
+  external_id TEXT NOT NULL DEFAULT '',
+  user_count INTEGER NOT NULL DEFAULT 0,
+  last_synced_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, org_id)
+)`,
+	`CREATE INDEX IF NOT EXISTS identity_organizations_updated_idx ON identity_organizations (tenant_id, updated_at DESC)`,
+	`CREATE TABLE IF NOT EXISTS identity_users (
+  tenant_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  org_id TEXT NOT NULL DEFAULT '',
+  subject TEXT NOT NULL DEFAULT '',
+  email TEXT NOT NULL DEFAULT '',
+  display_name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  provider TEXT NOT NULL DEFAULT '',
+  source TEXT NOT NULL DEFAULT '',
+  roles_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  groups_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  last_seen_at TIMESTAMPTZ,
+  last_synced_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, user_id)
+)`,
+	`CREATE INDEX IF NOT EXISTS identity_users_org_updated_idx ON identity_users (tenant_id, org_id, updated_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS identity_users_email_idx ON identity_users (tenant_id, email) WHERE email <> ''`,
+}
+
+const identityOrganizationColumns = `tenant_id, org_id, name, slug, domain, provider, source, external_id, GREATEST(user_count, (SELECT COUNT(*)::INTEGER FROM identity_users WHERE identity_users.tenant_id = identity_organizations.tenant_id AND identity_users.org_id = identity_organizations.org_id)) AS user_count, last_synced_at, created_at, updated_at`
+const identityUserColumns = `tenant_id, user_id, org_id, subject, email, display_name, status, provider, source, roles_json::text, groups_json::text, last_seen_at, last_synced_at, created_at, updated_at`
+
+func (s *Store) ensureIdentityDirectoryTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.identity.directory, "identity directory", ensureIdentityDirectoryStatements)
+}
+
+func (s *Store) UpsertIdentityOrganization(ctx context.Context, org *ports.IdentityOrganization) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if org == nil {
+		return errors.New("identity organization is required")
+	}
+	tenantID := strings.TrimSpace(org.TenantID)
+	orgID := strings.TrimSpace(org.OrgID)
+	name := strings.TrimSpace(org.Name)
+	if tenantID == "" || orgID == "" || name == "" {
+		return errors.New("identity organization tenant_id, org_id, and name are required")
+	}
+	if err := s.ensureIdentityDirectoryTables(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO identity_organizations (
+  tenant_id, org_id, name, slug, domain, provider, source, external_id, user_count, last_synced_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+ON CONFLICT (tenant_id, org_id) DO UPDATE SET
+  name = EXCLUDED.name,
+  slug = EXCLUDED.slug,
+  domain = EXCLUDED.domain,
+  provider = EXCLUDED.provider,
+  source = EXCLUDED.source,
+  external_id = EXCLUDED.external_id,
+  user_count = GREATEST(identity_organizations.user_count, EXCLUDED.user_count),
+  last_synced_at = COALESCE(EXCLUDED.last_synced_at, identity_organizations.last_synced_at),
+  updated_at = NOW()`,
+		tenantID,
+		orgID,
+		name,
+		strings.TrimSpace(org.Slug),
+		strings.TrimSpace(org.Domain),
+		strings.TrimSpace(org.Provider),
+		strings.TrimSpace(org.Source),
+		strings.TrimSpace(org.ExternalID),
+		org.UserCount,
+		nullableUTC(org.LastSyncedAt),
+	); err != nil {
+		return fmt.Errorf("upsert identity organization %q/%q: %w", tenantID, orgID, err)
+	}
+	return nil
+}
+
+func (s *Store) UpsertIdentityUser(ctx context.Context, user *ports.IdentityUser) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if user == nil {
+		return errors.New("identity user is required")
+	}
+	tenantID := strings.TrimSpace(user.TenantID)
+	userID := strings.TrimSpace(user.UserID)
+	displayName := strings.TrimSpace(user.DisplayName)
+	if tenantID == "" || userID == "" || displayName == "" {
+		return errors.New("identity user tenant_id, user_id, and display_name are required")
+	}
+	roles, err := stringSliceJSON(normalizedNonEmptyStrings(user.Roles))
+	if err != nil {
+		return fmt.Errorf("marshal identity user roles: %w", err)
+	}
+	groups, err := stringSliceJSON(normalizedNonEmptyStrings(user.Groups))
+	if err != nil {
+		return fmt.Errorf("marshal identity user groups: %w", err)
+	}
+	if err := s.ensureIdentityDirectoryTables(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO identity_users (
+  tenant_id, user_id, org_id, subject, email, display_name, status, provider, source,
+  roles_json, groups_json, last_seen_at, last_synced_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11::jsonb,$12,$13)
+ON CONFLICT (tenant_id, user_id) DO UPDATE SET
+  org_id = EXCLUDED.org_id,
+  subject = EXCLUDED.subject,
+  email = EXCLUDED.email,
+  display_name = EXCLUDED.display_name,
+  status = EXCLUDED.status,
+  provider = EXCLUDED.provider,
+  source = EXCLUDED.source,
+  roles_json = EXCLUDED.roles_json,
+  groups_json = EXCLUDED.groups_json,
+  last_seen_at = COALESCE(EXCLUDED.last_seen_at, identity_users.last_seen_at),
+  last_synced_at = COALESCE(EXCLUDED.last_synced_at, identity_users.last_synced_at),
+  updated_at = NOW()`,
+		tenantID,
+		userID,
+		strings.TrimSpace(user.OrgID),
+		strings.TrimSpace(user.Subject),
+		strings.ToLower(strings.TrimSpace(user.Email)),
+		displayName,
+		identityUserStatus(user.Status),
+		strings.TrimSpace(user.Provider),
+		strings.TrimSpace(user.Source),
+		roles,
+		groups,
+		nullableUTC(user.LastSeenAt),
+		nullableUTC(user.LastSyncedAt),
+	); err != nil {
+		return fmt.Errorf("upsert identity user %q/%q: %w", tenantID, userID, err)
+	}
+	return nil
+}
+
+func (s *Store) ListIdentityOrganizations(ctx context.Context, filter ports.IdentityOrganizationFilter) ([]*ports.IdentityOrganization, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureIdentityDirectoryTables(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	addIdentityStringClause(&clauses, &args, "tenant_id", filter.TenantID)
+	addIdentityStringClause(&clauses, &args, "org_id", filter.OrgID)
+	if query := strings.TrimSpace(filter.Query); query != "" {
+		args = append(args, "%"+strings.ToLower(query)+"%")
+		clauses = append(clauses, fmt.Sprintf("(LOWER(org_id) LIKE $%d OR LOWER(name) LIKE $%d OR LOWER(domain) LIKE $%d)", len(args), len(args), len(args)))
+	}
+	args = append(args, identityDirectoryLimit(filter.Limit))
+	// #nosec G201 -- clauses and selected columns are fixed identifiers; values remain query parameters.
+	query := fmt.Sprintf("SELECT %s FROM identity_organizations WHERE %s ORDER BY updated_at DESC, name ASC, org_id ASC LIMIT $%d", identityOrganizationColumns, strings.Join(clauses, " AND "), len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list identity organizations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var organizations []*ports.IdentityOrganization
+	for rows.Next() {
+		item, err := scanIdentityOrganization(rows)
+		if err != nil {
+			return nil, err
+		}
+		organizations = append(organizations, item)
+	}
+	return organizations, rows.Err()
+}
+
+func (s *Store) ListIdentityUsers(ctx context.Context, filter ports.IdentityUserFilter) ([]*ports.IdentityUser, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureIdentityDirectoryTables(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	addIdentityStringClause(&clauses, &args, "tenant_id", filter.TenantID)
+	addIdentityStringClause(&clauses, &args, "org_id", filter.OrgID)
+	addIdentityStringClause(&clauses, &args, "user_id", filter.UserID)
+	if query := strings.TrimSpace(filter.Query); query != "" {
+		args = append(args, "%"+strings.ToLower(query)+"%")
+		clauses = append(clauses, fmt.Sprintf("(LOWER(user_id) LIKE $%d OR LOWER(email) LIKE $%d OR LOWER(display_name) LIKE $%d)", len(args), len(args), len(args)))
+	}
+	args = append(args, identityDirectoryLimit(filter.Limit))
+	// #nosec G201 -- clauses and selected columns are fixed identifiers; values remain query parameters.
+	query := fmt.Sprintf("SELECT %s FROM identity_users WHERE %s ORDER BY updated_at DESC, display_name ASC, user_id ASC LIMIT $%d", identityUserColumns, strings.Join(clauses, " AND "), len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list identity users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var users []*ports.IdentityUser
+	for rows.Next() {
+		item, err := scanIdentityUser(rows)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, item)
+	}
+	return users, rows.Err()
+}
+
+func scanIdentityOrganization(row scanner) (*ports.IdentityOrganization, error) {
+	org := &ports.IdentityOrganization{}
+	var lastSynced sql.NullTime
+	if err := row.Scan(
+		&org.TenantID,
+		&org.OrgID,
+		&org.Name,
+		&org.Slug,
+		&org.Domain,
+		&org.Provider,
+		&org.Source,
+		&org.ExternalID,
+		&org.UserCount,
+		&lastSynced,
+		&org.CreatedAt,
+		&org.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if lastSynced.Valid {
+		org.LastSyncedAt = lastSynced.Time.UTC()
+	}
+	return org, nil
+}
+
+func scanIdentityUser(row scanner) (*ports.IdentityUser, error) {
+	user := &ports.IdentityUser{}
+	var rolesJSON, groupsJSON string
+	var lastSeen, lastSynced sql.NullTime
+	if err := row.Scan(
+		&user.TenantID,
+		&user.UserID,
+		&user.OrgID,
+		&user.Subject,
+		&user.Email,
+		&user.DisplayName,
+		&user.Status,
+		&user.Provider,
+		&user.Source,
+		&rolesJSON,
+		&groupsJSON,
+		&lastSeen,
+		&lastSynced,
+		&user.CreatedAt,
+		&user.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	var err error
+	if user.Roles, err = stringSliceFromJSON(rolesJSON); err != nil {
+		return nil, err
+	}
+	if user.Groups, err = stringSliceFromJSON(groupsJSON); err != nil {
+		return nil, err
+	}
+	if lastSeen.Valid {
+		user.LastSeenAt = lastSeen.Time.UTC()
+	}
+	if lastSynced.Valid {
+		user.LastSyncedAt = lastSynced.Time.UTC()
+	}
+	return user, nil
+}
+
+func addIdentityStringClause(clauses *[]string, args *[]any, column string, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		*args = append(*args, trimmed)
+		// #nosec G201 -- column is supplied by package-local callers with fixed identifiers.
+		*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
+	}
+}
+
+func identityDirectoryLimit(limit uint32) uint32 {
+	const (
+		defaultLimit uint32 = 100
+		maxLimit     uint32 = 500
+	)
+	switch {
+	case limit == 0:
+		return defaultLimit
+	case limit > maxLimit:
+		return maxLimit
+	default:
+		return limit
+	}
+}
+
+func identityUserStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "inactive", "suspended", "disabled":
+		return strings.ToLower(strings.TrimSpace(status))
+	default:
+		return "active"
+	}
+}

--- a/internal/statestore/postgres/identity_directory_test.go
+++ b/internal/statestore/postgres/identity_directory_test.go
@@ -1,0 +1,23 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIdentityDirectorySchemaCreatesTenantScopedUsersAndOrganizations(t *testing.T) {
+	joined := strings.Join(ensureIdentityDirectoryStatements, "\n")
+
+	for _, want := range []string{
+		"CREATE TABLE IF NOT EXISTS identity_organizations",
+		"PRIMARY KEY (tenant_id, org_id)",
+		"CREATE TABLE IF NOT EXISTS identity_users",
+		"PRIMARY KEY (tenant_id, user_id)",
+		"roles_json JSONB",
+		"groups_json JSONB",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("identity directory schema missing %q", want)
+		}
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -35,6 +35,10 @@ type askTablesReady struct {
 	savedQuery bool
 }
 
+type identityTablesReady struct {
+	directory bool
+}
+
 type grcTablesReady struct {
 	inventoryScope       bool
 	inventoryAssetReport bool
@@ -64,6 +68,7 @@ type Store struct {
 	jobTablesReady             bool
 	runtimeBlocklistReady      bool
 	grc                        grcTablesReady
+	identity                   identityTablesReady
 	connectorCredentialReady   bool
 	connectorDefinitionReady   bool
 	appendLogRuntimeIndexReady bool

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -79,8 +79,10 @@ import (
 // internal/sourcehttp/credentialstores; the read model lives in
 // internal/credentialstores. Finding-rule partial evaluation handling adds
 // only cache invalidation and job result mapping while rule execution and run
-// state stay in internal/findings.
-const bootstrapProductionGoLineBudget = 26707
+// state stay in internal/findings. Identity directory routes add only route
+// wiring while HTTP behavior lives in internal/sourcehttp/identitydirectory
+// and storage stays behind the IdentityDirectoryStore port.
+const bootstrapProductionGoLineBudget = 26714
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- add read-only identity directory organization and user endpoints
- persist OAuth/OIDC identities into the Postgres-backed directory
- document the identity directory API contract

## Tests
- go test ./internal/sourcehttp/identitydirectory ./internal/statestore/postgres ./internal/mcpoauth ./internal/bootstrap -count=1
- make openapi-check openapi-lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->