### PR TITLE
[codex] Fan out PagerDuty integrations runtime

### DIFF
--- a/sources/internal/jsonapi/fanout.go
+++ b/sources/internal/jsonapi/fanout.go
@@ -1,0 +1,172 @@
+package jsonapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+type fanoutCursor struct {
+	Index  int    `json:"index"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+// ReadPathParamValues reads one configured family across a bounded list of path
+// parameter values. The returned cursor preserves both the current value index
+// and that value's provider cursor.
+func (s *Source) ReadPathParamValues(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, param string, values []string) (sourcecdk.Pull, error) {
+	values = compactUniqueStrings(values)
+	if len(values) == 0 {
+		return sourcecdk.Pull{}, fmt.Errorf("%w: %s %s values are required", sourcecdk.ErrInvalidConfig, s.options.SourceID, param)
+	}
+	state := parseFanoutCursor(fanoutCursorToken(cursor))
+	for state.Index < len(values) {
+		pull, err := s.Read(ctx, configWithValue(cfg, param, values[state.Index]), sourceCursor(state.Cursor))
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		if next := sourcecdk.CursorToken(pull.NextCursor); next != "" {
+			pull.NextCursor = encodeFanoutCursor(s.options.SourceID, fanoutCursor{Index: state.Index, Cursor: next})
+			return pull, nil
+		}
+		if len(pull.Events) > 0 {
+			if state.Index+1 < len(values) {
+				pull.NextCursor = encodeFanoutCursor(s.options.SourceID, fanoutCursor{Index: state.Index + 1})
+			}
+			return pull, nil
+		}
+		state.Index++
+		state.Cursor = ""
+	}
+	return sourcecdk.Pull{}, nil
+}
+
+// CheckPathParamValues validates a path-parameter scoped family with the first
+// configured value. Check calls should stay cheap while still proving the
+// scoped endpoint can be reached with the provided credentials.
+func (s *Source) CheckPathParamValues(ctx context.Context, cfg sourcecdk.Config, param string, values []string) error {
+	values = compactUniqueStrings(values)
+	if len(values) == 0 {
+		return fmt.Errorf("%w: %s %s values are required", sourcecdk.ErrInvalidConfig, s.options.SourceID, param)
+	}
+	return s.Check(ctx, configWithValue(cfg, param, values[0]))
+}
+
+// DiscoverPathParamValues discovers URNs for a path-parameter scoped family
+// across every configured value.
+func (s *Source) DiscoverPathParamValues(ctx context.Context, cfg sourcecdk.Config, param string, values []string) ([]sourcecdk.URN, error) {
+	values = compactUniqueStrings(values)
+	if len(values) == 0 {
+		return nil, fmt.Errorf("%w: %s %s values are required", sourcecdk.ErrInvalidConfig, s.options.SourceID, param)
+	}
+	seen := map[sourcecdk.URN]struct{}{}
+	urns := []sourcecdk.URN{}
+	for _, value := range values {
+		discovered, err := s.Discover(ctx, configWithValue(cfg, param, value))
+		if err != nil {
+			return nil, err
+		}
+		for _, urn := range discovered {
+			if _, ok := seen[urn]; ok {
+				continue
+			}
+			seen[urn] = struct{}{}
+			urns = append(urns, urn)
+		}
+	}
+	return urns, nil
+}
+
+func parseFanoutCursor(raw string) fanoutCursor {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fanoutCursor{}
+	}
+	if state, ok := decodeFanoutCursor(raw); ok {
+		return state
+	}
+	return fanoutCursor{Cursor: raw}
+}
+
+func fanoutCursorToken(cursor *cerebrov1.SourceCursor) string {
+	if cursor == nil {
+		return ""
+	}
+	opaque := strings.TrimSpace(cursor.GetOpaque())
+	if _, ok := decodeFanoutCursor(opaque); ok {
+		return opaque
+	}
+	return sourcecdk.CursorToken(cursor)
+}
+
+func decodeFanoutCursor(raw string) (fanoutCursor, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.HasPrefix(raw, "{") {
+		return fanoutCursor{}, false
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+		return fanoutCursor{}, false
+	}
+	if _, ok := fields["index"]; !ok {
+		if _, ok := fields["cursor"]; !ok {
+			return fanoutCursor{}, false
+		}
+	}
+	var state fanoutCursor
+	if err := json.Unmarshal([]byte(raw), &state); err == nil && state.Index >= 0 {
+		return state, true
+	}
+	return fanoutCursor{}, false
+}
+
+func encodeFanoutCursor(sourceID string, state fanoutCursor) *cerebrov1.SourceCursor {
+	token, err := json.Marshal(state)
+	if err != nil {
+		return nil
+	}
+	opaque, err := sourcecdk.EncodeCursorEnvelope(sourcecdk.CursorEnvelope{
+		Version: 1,
+		Source:  sourceID,
+		Mode:    "fanout_path_param",
+		Token:   string(token),
+	})
+	if err != nil {
+		return nil
+	}
+	return &cerebrov1.SourceCursor{Opaque: opaque}
+}
+
+func sourceCursor(raw string) *cerebrov1.SourceCursor {
+	if raw = strings.TrimSpace(raw); raw != "" {
+		return &cerebrov1.SourceCursor{Opaque: raw}
+	}
+	return nil
+}
+
+func configWithValue(cfg sourcecdk.Config, key string, value string) sourcecdk.Config {
+	values := cfg.Values()
+	values[key] = value
+	return sourcecdk.NewConfig(values)
+}
+
+func compactUniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -139,6 +139,90 @@ func TestReadPagesJSONAPIRecords(t *testing.T) {
 	}
 }
 
+func TestReadPathParamValuesPreservesValueAndProviderCursor(t *testing.T) {
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.EscapedPath()+"?cursor="+r.URL.Query().Get("cursor"))
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.EscapedPath() == "/accounts/acct-a/devices" && r.URL.Query().Get("cursor") == "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":        []map[string]any{{"id": "device-a-1"}},
+				"next_cursor": "page-2",
+			})
+		case r.URL.EscapedPath() == "/accounts/acct-a/devices" && r.URL.Query().Get("cursor") == "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{"id": "device-a-2"}},
+			})
+		case r.URL.EscapedPath() == "/accounts/acct-b/devices" && r.URL.Query().Get("cursor") == "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{"id": "device-b-1"}},
+			})
+		default:
+			t.Fatalf("request = %s?%s, want configured fan-out page", r.URL.EscapedPath(), r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	source := newCustomTestSource(t, server.URL, Family{
+		Name:           "device",
+		Path:           "/accounts/{account_id}/devices",
+		PathParams:     []string{"account_id"},
+		CursorParam:    "cursor",
+		NextCursorKeys: []string{"next_cursor"},
+		URNKind:        "test_device",
+		IDKeys:         []string{"id"},
+		Attributes:     map[string]string{"account_id": "account_id"},
+	})
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"family":    "device",
+		"token":     "token-1",
+	})
+	first, err := source.ReadPathParamValues(context.Background(), cfg, nil, "account_id", []string{"acct-a", "acct-b"})
+	if err != nil {
+		t.Fatalf("ReadPathParamValues(first) error = %v", err)
+	}
+	if len(first.Events) != 1 || first.Events[0].Attributes["external_id"] != "device-a-1" {
+		t.Fatalf("first Events = %#v, want device-a-1", first.Events)
+	}
+	firstState := parseFanoutCursor(sourcecdk.CursorToken(first.NextCursor))
+	if firstState.Index != 0 || firstState.Cursor != "page-2" {
+		t.Fatalf("first fan-out cursor = %#v, want acct-a page-2", firstState)
+	}
+
+	second, err := source.ReadPathParamValues(context.Background(), cfg, first.NextCursor, "account_id", []string{"acct-a", "acct-b"})
+	if err != nil {
+		t.Fatalf("ReadPathParamValues(second) error = %v", err)
+	}
+	if len(second.Events) != 1 || second.Events[0].Attributes["external_id"] != "device-a-2" {
+		t.Fatalf("second Events = %#v, want device-a-2", second.Events)
+	}
+	secondState := parseFanoutCursor(sourcecdk.CursorToken(second.NextCursor))
+	if secondState.Index != 1 || secondState.Cursor != "" {
+		t.Fatalf("second fan-out cursor = %#v, want acct-b start", secondState)
+	}
+
+	third, err := source.ReadPathParamValues(context.Background(), cfg, second.NextCursor, "account_id", []string{"acct-a", "acct-b"})
+	if err != nil {
+		t.Fatalf("ReadPathParamValues(third) error = %v", err)
+	}
+	if len(third.Events) != 1 || third.Events[0].Attributes["external_id"] != "device-b-1" {
+		t.Fatalf("third Events = %#v, want device-b-1", third.Events)
+	}
+	if third.NextCursor != nil {
+		t.Fatalf("third NextCursor = %#v, want nil", third.NextCursor)
+	}
+	wantRequests := []string{
+		"/accounts/acct-a/devices?cursor=",
+		"/accounts/acct-a/devices?cursor=page-2",
+		"/accounts/acct-b/devices?cursor=",
+	}
+	if strings.Join(requests, "\n") != strings.Join(wantRequests, "\n") {
+		t.Fatalf("requests = %#v, want %#v", requests, wantRequests)
+	}
+}
+
 func TestReadSynthesizesPageCursorForFullPages(t *testing.T) {
 	requests := make([]*http.Request, 0, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sources/pagerduty/catalog.yaml
+++ b/sources/pagerduty/catalog.yaml
@@ -47,7 +47,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Integrations are collected per service and retain the service ID plus vendor reference for service-to-tool dependency projection.
+        - Integrations fan out across service_ids, fall back to service_id for single-service deployments, and retain each service ID plus vendor reference for service-to-tool dependency projection.
     - id: schedules
       type: entity_family
       title: Schedules

--- a/sources/pagerduty/deploy.yaml
+++ b/sources/pagerduty/deploy.yaml
@@ -1,7 +1,9 @@
 sourceId: pagerduty
 secretKeys:
   - PAGERDUTY_TOKEN
-  # Env-backed service scope required by the integrations runtime.
+  # Comma-separated service IDs used to fan out the integrations runtime.
+  - PAGERDUTY_SERVICE_IDS
+  # Single-service fallback for existing integrations runtime deployments.
   - PAGERDUTY_SERVICE_ID
 runtimes:
   - localId: users
@@ -47,6 +49,7 @@ runtimes:
   - localId: integrations
     config:
       family: integration
+      service_ids: env:PAGERDUTY_SERVICE_IDS
       service_id: env:PAGERDUTY_SERVICE_ID
       failure_modes: api_error,auth_error,rate_limit,schema_drift
       expected_cadence_seconds: "3600"

--- a/sources/pagerduty/source.go
+++ b/sources/pagerduty/source.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"context"
 	"embed"
+	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -13,20 +14,21 @@ import (
 var catalogFS embed.FS
 
 const (
-	sourceID                 = "pagerduty"
-	defaultFamily            = familyUser
-	familyUser               = "user"
-	familyTeam               = "team"
-	familyService            = "service"
-	familySchedule           = "schedule"
-	familyEscalationPolicy   = "escalation_policy"
-	familyIntegration        = "integration"
-	familyVendor             = "vendor"
-	pagerDutySourceProduct   = "pagerduty"
-	pagerDutyCursorParam     = "offset"
-	pagerDutyHasMoreKey      = "more"
-	pagerDutyPageSizeParam   = "limit"
-	pagerDutyServiceIDConfig = "service_id"
+	sourceID                  = "pagerduty"
+	defaultFamily             = familyUser
+	familyUser                = "user"
+	familyTeam                = "team"
+	familyService             = "service"
+	familySchedule            = "schedule"
+	familyEscalationPolicy    = "escalation_policy"
+	familyIntegration         = "integration"
+	familyVendor              = "vendor"
+	pagerDutySourceProduct    = "pagerduty"
+	pagerDutyCursorParam      = "offset"
+	pagerDutyHasMoreKey       = "more"
+	pagerDutyPageSizeParam    = "limit"
+	pagerDutyServiceIDConfig  = "service_id"
+	pagerDutyServiceIDsConfig = "service_ids"
 )
 
 type Source struct{ inner *jsonapi.Source }
@@ -52,12 +54,27 @@ func New() (*Source, error) {
 
 func (s *Source) Spec() *cerebrov1.SourceSpec { return s.inner.Spec() }
 func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	if sourcecdk.ConfigValue(cfg, "family") == familyIntegration {
+		if serviceIDs := pagerDutyIntegrationServiceIDs(cfg); len(serviceIDs) > 0 {
+			return s.inner.CheckPathParamValues(ctx, cfg, pagerDutyServiceIDConfig, serviceIDs)
+		}
+	}
 	return s.inner.Check(ctx, cfg)
 }
 func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	if sourcecdk.ConfigValue(cfg, "family") == familyIntegration {
+		if serviceIDs := pagerDutyIntegrationServiceIDs(cfg); len(serviceIDs) > 0 {
+			return s.inner.DiscoverPathParamValues(ctx, cfg, pagerDutyServiceIDConfig, serviceIDs)
+		}
+	}
 	return s.inner.Discover(ctx, cfg)
 }
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	if sourcecdk.ConfigValue(cfg, "family") == familyIntegration {
+		if serviceIDs := pagerDutyIntegrationServiceIDs(cfg); len(serviceIDs) > 0 {
+			return s.inner.ReadPathParamValues(ctx, cfg, cursor, pagerDutyServiceIDConfig, serviceIDs)
+		}
+	}
 	return s.inner.Read(ctx, cfg, cursor)
 }
 func loadSpec() (*cerebrov1.SourceSpec, error) {
@@ -211,4 +228,22 @@ func pagerDutyPagedFamily(family jsonapi.Family) jsonapi.Family {
 
 func pagerDutyStaticAttributes() map[string]string {
 	return map[string]string{"source_product": pagerDutySourceProduct}
+}
+
+func pagerDutyIntegrationServiceIDs(cfg sourcecdk.Config) []string {
+	if values := splitConfigList(sourcecdk.ConfigValue(cfg, pagerDutyServiceIDsConfig)); len(values) > 0 {
+		return values
+	}
+	return splitConfigList(sourcecdk.ConfigValue(cfg, pagerDutyServiceIDConfig))
+}
+
+func splitConfigList(value string) []string {
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			values = append(values, part)
+		}
+	}
+	return values
 }

--- a/sources/pagerduty/source_test.go
+++ b/sources/pagerduty/source_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -235,6 +236,174 @@ func TestReadUsesPagerDutyOffsetPagination(t *testing.T) {
 	}
 	if len(requests) != 2 || requests[1].URL.Query().Get(pagerDutyCursorParam) != "2" {
 		t.Fatalf("requests = %#v, want second request with offset=2", requests)
+	}
+}
+
+func TestReadIntegrationsFansOutAcrossServiceIDs(t *testing.T) {
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.EscapedPath())
+		serviceID := "PS1"
+		if r.URL.EscapedPath() == "/services/PS2/integrations" {
+			serviceID = "PS2"
+		} else if r.URL.EscapedPath() != "/services/PS1/integrations" {
+			t.Fatalf("request path = %q, want service integration path", r.URL.EscapedPath())
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"integrations": []map[string]any{{
+			"id": "PI-" + serviceID, "name": "Integration " + serviceID,
+			"service": map[string]any{"id": serviceID, "summary": "Service " + serviceID},
+			"vendor":  map[string]any{"id": "PV1", "summary": "Vendor"},
+		}}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url":    server.URL,
+		"family":      familyIntegration,
+		"tenant_id":   "writer",
+		"token":       "pagerduty-token",
+		"service_ids": "PS1,PS2",
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if len(first.Events) != 1 || first.Events[0].Attributes["service_id"] != "PS1" {
+		t.Fatalf("first integration events = %#v, want PS1", first.Events)
+	}
+	if first.NextCursor == nil {
+		t.Fatal("first NextCursor = nil, want cursor for next service")
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if len(second.Events) != 1 || second.Events[0].Attributes["service_id"] != "PS2" {
+		t.Fatalf("second integration attributes = %#v, requests = %#v, want PS2", second.Events[0].Attributes, requests)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %#v, want two service integration requests", requests)
+	}
+}
+
+func TestIntegrationServiceIDsSupportCheckAndDiscover(t *testing.T) {
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.EscapedPath())
+		serviceID := "PS1"
+		if r.URL.EscapedPath() == "/services/PS2/integrations" {
+			serviceID = "PS2"
+		} else if r.URL.EscapedPath() != "/services/PS1/integrations" {
+			t.Fatalf("request path = %q, want service integration path", r.URL.EscapedPath())
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"integrations": []map[string]any{{
+			"id": "PI-" + serviceID, "name": "Integration " + serviceID,
+			"service": map[string]any{"id": serviceID, "summary": "Service " + serviceID},
+			"vendor":  map[string]any{"id": "PV1", "summary": "Vendor"},
+		}}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url":    server.URL,
+		"family":      familyIntegration,
+		"tenant_id":   "writer",
+		"token":       "pagerduty-token",
+		"service_ids": "PS1,PS2",
+	})
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	urns, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	got := make([]string, 0, len(urns))
+	for _, urn := range urns {
+		got = append(got, urn.String())
+	}
+	want := []string{
+		"urn:cerebro:writer:pagerduty_integration:PI-PS1",
+		"urn:cerebro:writer:pagerduty_integration:PI-PS2",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("Discover() = %#v, want %#v", got, want)
+	}
+	wantRequests := []string{
+		"/services/PS1/integrations",
+		"/services/PS1/integrations",
+		"/services/PS2/integrations",
+	}
+	if strings.Join(requests, "\n") != strings.Join(wantRequests, "\n") {
+		t.Fatalf("requests = %#v, want %#v", requests, wantRequests)
+	}
+}
+
+func TestIntegrationLegacyServiceIDStillWorks(t *testing.T) {
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.EscapedPath())
+		if r.URL.EscapedPath() != "/services/PS1/integrations" {
+			t.Fatalf("request path = %q, want legacy service integration path", r.URL.EscapedPath())
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"integrations": []map[string]any{{
+			"id":      "PI-PS1",
+			"name":    "Integration PS1",
+			"service": map[string]any{"id": "PS1", "summary": "Service PS1"},
+			"vendor":  map[string]any{"id": "PV1", "summary": "Vendor"},
+		}}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url":   server.URL,
+		"family":     familyIntegration,
+		"tenant_id":  "writer",
+		"token":      "pagerduty-token",
+		"service_id": "PS1",
+	})
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	urns, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(urns) != 1 || urns[0].String() != "urn:cerebro:writer:pagerduty_integration:PI-PS1" {
+		t.Fatalf("Discover() = %#v, want PI-PS1", urns)
+	}
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.Events[0].Attributes["service_id"] != "PS1" {
+		t.Fatalf("Read() events = %#v, want PS1", pull.Events)
+	}
+	wantRequests := []string{
+		"/services/PS1/integrations",
+		"/services/PS1/integrations",
+		"/services/PS1/integrations",
+	}
+	if strings.Join(requests, "\n") != strings.Join(wantRequests, "\n") {
+		t.Fatalf("requests = %#v, want %#v", requests, wantRequests)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a shared jsonapi path-parameter fan-out reader with Source CDK cursor-envelope state.
- Update PagerDuty integrations to read a configured service_ids list instead of one service_id.
- Add regressions for provider cursor preservation and PagerDuty service-to-service integration fan-out.

## Validation
- go test ./sources/internal/jsonapi ./sources/pagerduty ./tools/sourcedeploy -count=1
- go test ./sources/pagerduty ./sources/internal/jsonapi ./internal/sourceprojection ./internal/sourceregistry ./internal/sourceops ./internal/bootstrap ./tools/sourcedeploy ./tools/archtests ./internal/connectorcatalog -count=1
- make oss-audit
- make connector-catalog-maintenance
- make droid-review-preflight
- make droid-review-sast
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->