### PR TITLE
[codex] add identity directory filters

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4926,6 +4926,16 @@ paths:
           in: query
           schema:
             type: string
+        - name: provider
+          in: query
+          schema:
+            type: string
+          description: Exact provider filter such as okta or oidc.
+        - name: source
+          in: query
+          schema:
+            type: string
+          description: Exact source filter such as mcp_oauth, mcp_oauth_client, api_key, or api_credential.
         - name: q
           in: query
           schema:
@@ -4953,6 +4963,21 @@ paths:
           in: query
           schema:
             type: string
+        - name: provider
+          in: query
+          schema:
+            type: string
+          description: Exact provider filter such as okta or oidc.
+        - name: source
+          in: query
+          schema:
+            type: string
+          description: Exact source filter such as mcp_oauth, mcp_oauth_client, api_key, api_credential, or mcp_oauth_entitlement.
+        - name: status
+          in: query
+          schema:
+            type: string
+          description: Exact user status filter such as active, inactive, suspended, or disabled.
         - name: q
           in: query
           schema:

--- a/internal/ports/identity_directory.go
+++ b/internal/ports/identity_directory.go
@@ -45,6 +45,8 @@ type IdentityUser struct {
 type IdentityOrganizationFilter struct {
 	TenantID string
 	OrgID    string
+	Provider string
+	Source   string
 	Query    string
 	Limit    uint32
 }
@@ -53,6 +55,9 @@ type IdentityUserFilter struct {
 	TenantID string
 	OrgID    string
 	UserID   string
+	Provider string
+	Source   string
+	Status   string
 	Query    string
 	Limit    uint32
 }

--- a/internal/sourcehttp/identitydirectory/handler.go
+++ b/internal/sourcehttp/identitydirectory/handler.go
@@ -97,15 +97,17 @@ func (h Handler) ListOrganizations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	orgID := strings.TrimSpace(r.URL.Query().Get("org_id"))
+	provider := strings.TrimSpace(r.URL.Query().Get("provider"))
+	source := strings.TrimSpace(r.URL.Query().Get("source"))
 	query := strings.TrimSpace(r.URL.Query().Get("q"))
 	limit := directoryLimit(r.URL.Query().Get("limit"))
 	configured := configuredOrganizations(h.cfg, tenantID)
-	persisted, err := h.persistedOrganizations(r.Context(), ports.IdentityOrganizationFilter{TenantID: tenantID, OrgID: orgID, Query: query, Limit: limit})
+	persisted, err := h.persistedOrganizations(r.Context(), ports.IdentityOrganizationFilter{TenantID: tenantID, OrgID: orgID, Provider: provider, Source: source, Query: query, Limit: limit})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "identity organizations unavailable")
 		return
 	}
-	organizations := mergeOrganizations(configured, persisted, tenantID, orgID, query, limit)
+	organizations := mergeOrganizations(configured, persisted, tenantID, orgID, provider, source, query, limit)
 	writeJSON(w, http.StatusOK, listOrganizationsResponse{
 		TenantID:      tenantID,
 		Organizations: organizationResponses(organizations),
@@ -120,15 +122,18 @@ func (h Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	orgID := strings.TrimSpace(r.URL.Query().Get("org_id"))
+	provider := strings.TrimSpace(r.URL.Query().Get("provider"))
+	source := strings.TrimSpace(r.URL.Query().Get("source"))
+	status := strings.TrimSpace(r.URL.Query().Get("status"))
 	query := strings.TrimSpace(r.URL.Query().Get("q"))
 	limit := directoryLimit(r.URL.Query().Get("limit"))
 	configured := configuredUsers(h.cfg, tenantID, orgID)
-	persisted, err := h.persistedUsers(r.Context(), ports.IdentityUserFilter{TenantID: tenantID, OrgID: orgID, Query: query, Limit: limit})
+	persisted, err := h.persistedUsers(r.Context(), ports.IdentityUserFilter{TenantID: tenantID, OrgID: orgID, Provider: provider, Source: source, Status: status, Query: query, Limit: limit})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "identity users unavailable")
 		return
 	}
-	users := mergeUsers(configured, persisted, tenantID, orgID, query, limit)
+	users := mergeUsers(configured, persisted, tenantID, orgID, provider, source, status, query, limit)
 	writeJSON(w, http.StatusOK, listUsersResponse{
 		TenantID: tenantID,
 		OrgID:    orgID,
@@ -346,15 +351,15 @@ func configuredUsers(cfg config.AuthConfig, tenantID string, orgID string) []*po
 	return users
 }
 
-func mergeOrganizations(configured []*ports.IdentityOrganization, persisted []*ports.IdentityOrganization, tenantID string, orgID string, query string, limit uint32) []*ports.IdentityOrganization {
+func mergeOrganizations(configured []*ports.IdentityOrganization, persisted []*ports.IdentityOrganization, tenantID string, orgID string, provider string, source string, query string, limit uint32) []*ports.IdentityOrganization {
 	byKey := map[string]*ports.IdentityOrganization{}
 	for _, org := range configured {
-		if organizationVisible(org, tenantID, orgID, query) {
+		if organizationVisible(org, tenantID, orgID, provider, source, query) {
 			byKey[identityOrgKey(org)] = cloneOrganization(org)
 		}
 	}
 	for _, org := range persisted {
-		if !organizationVisible(org, tenantID, orgID, query) {
+		if !organizationVisible(org, tenantID, orgID, provider, source, query) {
 			continue
 		}
 		key := identityOrgKey(org)
@@ -388,18 +393,18 @@ func mergeOrganizations(configured []*ports.IdentityOrganization, persisted []*p
 	return capOrganizations(out, limit)
 }
 
-func mergeUsers(configured []*ports.IdentityUser, persisted []*ports.IdentityUser, tenantID string, orgID string, query string, limit uint32) []*ports.IdentityUser {
+func mergeUsers(configured []*ports.IdentityUser, persisted []*ports.IdentityUser, tenantID string, orgID string, provider string, source string, status string, query string, limit uint32) []*ports.IdentityUser {
 	byKey := map[string]*ports.IdentityUser{}
 	configuredKeys := map[string]bool{}
 	for _, user := range configured {
-		if userVisible(user, tenantID, orgID, query) {
+		if userVisible(user, tenantID, orgID, provider, source, status, query) {
 			key := identityUserKey(user)
 			byKey[key] = cloneUser(user)
 			configuredKeys[key] = true
 		}
 	}
 	for _, user := range persisted {
-		if !userVisible(user, tenantID, orgID, query) {
+		if !userVisible(user, tenantID, orgID, provider, source, status, query) {
 			continue
 		}
 		key := identityUserKey(user)
@@ -476,7 +481,7 @@ func userResponses(users []*ports.IdentityUser) []userResponse {
 	return responses
 }
 
-func organizationVisible(org *ports.IdentityOrganization, tenantID string, orgID string, query string) bool {
+func organizationVisible(org *ports.IdentityOrganization, tenantID string, orgID string, provider string, source string, query string) bool {
 	if org == nil {
 		return false
 	}
@@ -486,10 +491,13 @@ func organizationVisible(org *ports.IdentityOrganization, tenantID string, orgID
 	if orgID != "" && org.OrgID != orgID {
 		return false
 	}
+	if !matchesExact(provider, org.Provider) || !matchesExact(source, org.Source) {
+		return false
+	}
 	return matchesQuery(query, org.OrgID, org.Name, org.Domain, org.Provider, org.Source)
 }
 
-func userVisible(user *ports.IdentityUser, tenantID string, orgID string, query string) bool {
+func userVisible(user *ports.IdentityUser, tenantID string, orgID string, provider string, source string, status string, query string) bool {
 	if user == nil {
 		return false
 	}
@@ -499,7 +507,18 @@ func userVisible(user *ports.IdentityUser, tenantID string, orgID string, query 
 	if orgID != "" && user.OrgID != orgID {
 		return false
 	}
+	if !matchesExact(provider, user.Provider) || !matchesExact(source, user.Source) || !matchesExact(status, firstNonEmpty(user.Status, "active")) {
+		return false
+	}
 	return matchesQuery(query, user.UserID, user.Email, user.DisplayName, user.Subject, user.Provider, user.Source)
+}
+
+func matchesExact(filter string, value string) bool {
+	filter = strings.ToLower(strings.TrimSpace(filter))
+	if filter == "" {
+		return true
+	}
+	return strings.ToLower(strings.TrimSpace(value)) == filter
 }
 
 func matchesQuery(query string, values ...string) bool {

--- a/internal/sourcehttp/identitydirectory/handler.go
+++ b/internal/sourcehttp/identitydirectory/handler.go
@@ -446,7 +446,7 @@ func organizationResponses(orgs []*ports.IdentityOrganization) []organizationRes
 			Slug:         strings.TrimSpace(org.Slug),
 			Domain:       strings.TrimSpace(org.Domain),
 			Provider:     strings.TrimSpace(org.Provider),
-			Source:       firstNonEmpty(org.Source, "identity_directory"),
+			Source:       identityDirectorySource(org.Source),
 			ExternalID:   strings.TrimSpace(org.ExternalID),
 			UserCount:    org.UserCount,
 			LastSyncedAt: timeString(org.LastSyncedAt),
@@ -469,7 +469,7 @@ func userResponses(users []*ports.IdentityUser) []userResponse {
 			DisplayName:  strings.TrimSpace(user.DisplayName),
 			Status:       firstNonEmpty(user.Status, "active"),
 			Provider:     strings.TrimSpace(user.Provider),
-			Source:       firstNonEmpty(user.Source, "identity_directory"),
+			Source:       identityDirectorySource(user.Source),
 			Roles:        normalized(user.Roles),
 			Groups:       normalized(user.Groups),
 			LastSeenAt:   timeString(user.LastSeenAt),
@@ -491,10 +491,10 @@ func organizationVisible(org *ports.IdentityOrganization, tenantID string, orgID
 	if orgID != "" && org.OrgID != orgID {
 		return false
 	}
-	if !matchesExact(provider, org.Provider) || !matchesExact(source, org.Source) {
+	if !matchesExact(provider, org.Provider) || !matchesExact(source, identityDirectorySource(org.Source)) {
 		return false
 	}
-	return matchesQuery(query, org.OrgID, org.Name, org.Domain, org.Provider, org.Source)
+	return matchesQuery(query, org.OrgID, org.Name, org.Domain, org.Provider, identityDirectorySource(org.Source))
 }
 
 func userVisible(user *ports.IdentityUser, tenantID string, orgID string, provider string, source string, status string, query string) bool {
@@ -507,10 +507,10 @@ func userVisible(user *ports.IdentityUser, tenantID string, orgID string, provid
 	if orgID != "" && user.OrgID != orgID {
 		return false
 	}
-	if !matchesExact(provider, user.Provider) || !matchesExact(source, user.Source) || !matchesExact(status, firstNonEmpty(user.Status, "active")) {
+	if !matchesExact(provider, user.Provider) || !matchesExact(source, identityDirectorySource(user.Source)) || !matchesExact(status, firstNonEmpty(user.Status, "active")) {
 		return false
 	}
-	return matchesQuery(query, user.UserID, user.Email, user.DisplayName, user.Subject, user.Provider, user.Source)
+	return matchesQuery(query, user.UserID, user.Email, user.DisplayName, user.Subject, user.Provider, identityDirectorySource(user.Source))
 }
 
 func matchesExact(filter string, value string) bool {
@@ -688,6 +688,10 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func identityDirectorySource(source string) string {
+	return firstNonEmpty(source, "identity_directory")
 }
 
 func contains(values []string, want string) bool {

--- a/internal/sourcehttp/identitydirectory/handler_test.go
+++ b/internal/sourcehttp/identitydirectory/handler_test.go
@@ -43,10 +43,10 @@ func (s *stubDirectoryStore) ListIdentityOrganizations(_ context.Context, filter
 		if filter.OrgID != "" && org.OrgID != filter.OrgID {
 			continue
 		}
-		if !matchesExact(filter.Provider, org.Provider) || !matchesExact(filter.Source, org.Source) {
+		if !matchesExact(filter.Provider, org.Provider) || !matchesExact(filter.Source, identityDirectorySource(org.Source)) {
 			continue
 		}
-		if !matchesQuery(filter.Query, org.OrgID, org.Name, org.Domain) {
+		if !matchesQuery(filter.Query, org.OrgID, org.Name, org.Domain, identityDirectorySource(org.Source)) {
 			continue
 		}
 		copied := *org
@@ -64,10 +64,10 @@ func (s *stubDirectoryStore) ListIdentityUsers(_ context.Context, filter ports.I
 		if filter.OrgID != "" && user.OrgID != filter.OrgID {
 			continue
 		}
-		if !matchesExact(filter.Provider, user.Provider) || !matchesExact(filter.Source, user.Source) || !matchesExact(filter.Status, firstNonEmpty(user.Status, "active")) {
+		if !matchesExact(filter.Provider, user.Provider) || !matchesExact(filter.Source, identityDirectorySource(user.Source)) || !matchesExact(filter.Status, firstNonEmpty(user.Status, "active")) {
 			continue
 		}
-		if !matchesQuery(filter.Query, user.UserID, user.Email, user.DisplayName) {
+		if !matchesQuery(filter.Query, user.UserID, user.Email, user.DisplayName, identityDirectorySource(user.Source)) {
 			continue
 		}
 		copied := *user
@@ -239,6 +239,32 @@ func TestListOrganizationsFiltersProviderAndSource(t *testing.T) {
 	}
 }
 
+func TestListOrganizationsFiltersDefaultIdentityDirectorySource(t *testing.T) {
+	store := &stubDirectoryStore{
+		orgs: []*ports.IdentityOrganization{{
+			TenantID: "tenant-a",
+			OrgID:    "manual",
+			Name:     "Manual",
+			Provider: "oidc",
+		}},
+	}
+	handler := testHandler(store)
+	recorder := httptest.NewRecorder()
+
+	handler.ListOrganizations(recorder, httptest.NewRequest(http.MethodGet, "/identity/orgs?provider=oidc&source=identity_directory", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response listOrganizationsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Organizations) != 1 || response.Organizations[0].OrgID != "manual" || response.Organizations[0].Source != "identity_directory" {
+		t.Fatalf("organizations = %+v, want persisted org with default identity directory source", response.Organizations)
+	}
+}
+
 func TestListUsersFiltersStatusProviderAndSource(t *testing.T) {
 	store := &stubDirectoryStore{
 		users: []*ports.IdentityUser{
@@ -277,6 +303,33 @@ func TestListUsersFiltersStatusProviderAndSource(t *testing.T) {
 	}
 	if len(response.Users) != 1 || response.Users[0].UserID != "00u123" || response.Users[0].Status != "suspended" {
 		t.Fatalf("users = %+v, want suspended Okta OAuth user", response.Users)
+	}
+}
+
+func TestListUsersFiltersDefaultIdentityDirectorySource(t *testing.T) {
+	store := &stubDirectoryStore{
+		users: []*ports.IdentityUser{{
+			TenantID:    "tenant-a",
+			OrgID:       "tenant-a",
+			UserID:      "manual-user",
+			DisplayName: "Manual User",
+			Provider:    "oidc",
+		}},
+	}
+	handler := testHandler(store)
+	recorder := httptest.NewRecorder()
+
+	handler.ListUsers(recorder, httptest.NewRequest(http.MethodGet, "/identity/users?provider=oidc&source=identity_directory&status=active", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response listUsersResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Users) != 1 || response.Users[0].UserID != "manual-user" || response.Users[0].Source != "identity_directory" {
+		t.Fatalf("users = %+v, want persisted user with default identity directory source", response.Users)
 	}
 }
 

--- a/internal/sourcehttp/identitydirectory/handler_test.go
+++ b/internal/sourcehttp/identitydirectory/handler_test.go
@@ -43,6 +43,9 @@ func (s *stubDirectoryStore) ListIdentityOrganizations(_ context.Context, filter
 		if filter.OrgID != "" && org.OrgID != filter.OrgID {
 			continue
 		}
+		if !matchesExact(filter.Provider, org.Provider) || !matchesExact(filter.Source, org.Source) {
+			continue
+		}
 		if !matchesQuery(filter.Query, org.OrgID, org.Name, org.Domain) {
 			continue
 		}
@@ -59,6 +62,9 @@ func (s *stubDirectoryStore) ListIdentityUsers(_ context.Context, filter ports.I
 			continue
 		}
 		if filter.OrgID != "" && user.OrgID != filter.OrgID {
+			continue
+		}
+		if !matchesExact(filter.Provider, user.Provider) || !matchesExact(filter.Source, user.Source) || !matchesExact(filter.Status, firstNonEmpty(user.Status, "active")) {
 			continue
 		}
 		if !matchesQuery(filter.Query, user.UserID, user.Email, user.DisplayName) {
@@ -204,6 +210,76 @@ func TestListUsersKeepsConfiguredUsersInsideLimit(t *testing.T) {
 	}
 }
 
+func TestListOrganizationsFiltersProviderAndSource(t *testing.T) {
+	store := &stubDirectoryStore{
+		orgs: []*ports.IdentityOrganization{{
+			TenantID:  "tenant-a",
+			OrgID:     "manual",
+			Name:      "Manual",
+			Provider:  "oidc",
+			Source:    "identity_directory",
+			UserCount: 2,
+			UpdatedAt: time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+	handler := testHandler(store)
+	recorder := httptest.NewRecorder()
+
+	handler.ListOrganizations(recorder, httptest.NewRequest(http.MethodGet, "/identity/orgs?provider=okta&source=mcp_oauth_client", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response listOrganizationsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Organizations) != 1 || response.Organizations[0].OrgID != "tenant-a" {
+		t.Fatalf("organizations = %+v, want configured Okta OAuth tenant", response.Organizations)
+	}
+}
+
+func TestListUsersFiltersStatusProviderAndSource(t *testing.T) {
+	store := &stubDirectoryStore{
+		users: []*ports.IdentityUser{
+			{
+				TenantID:    "tenant-a",
+				OrgID:       "tenant-a",
+				UserID:      "00u123",
+				DisplayName: "Suspended User",
+				Status:      "suspended",
+				Provider:    "okta",
+				Source:      "mcp_oauth",
+				LastSeenAt:  time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC),
+			},
+			{
+				TenantID:    "tenant-a",
+				OrgID:       "tenant-a",
+				UserID:      "active-user",
+				DisplayName: "Active User",
+				Status:      "active",
+				Provider:    "okta",
+				Source:      "mcp_oauth",
+			},
+		},
+	}
+	handler := testHandler(store)
+	recorder := httptest.NewRecorder()
+
+	handler.ListUsers(recorder, httptest.NewRequest(http.MethodGet, "/identity/users?provider=okta&source=mcp_oauth&status=suspended", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response listUsersResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Users) != 1 || response.Users[0].UserID != "00u123" || response.Users[0].Status != "suspended" {
+		t.Fatalf("users = %+v, want suspended Okta OAuth user", response.Users)
+	}
+}
+
 func TestConfiguredEntitlementUserIDPrefersSubject(t *testing.T) {
 	users := configuredUsers(config.AuthConfig{
 		MCPOAuth: config.MCPOAuthConfig{
@@ -238,7 +314,7 @@ func TestMergeUsersPreservesConfiguredGrantsOnPersistedCollision(t *testing.T) {
 		LastSeenAt:  time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
 	}}
 
-	users := mergeUsers(configured, persisted, "tenant-a", "", "", 10)
+	users := mergeUsers(configured, persisted, "tenant-a", "", "", "", "", "", 10)
 	if len(users) != 1 {
 		t.Fatalf("users = %+v, want one merged user", users)
 	}

--- a/internal/statestore/postgres/identity_directory.go
+++ b/internal/statestore/postgres/identity_directory.go
@@ -53,6 +53,7 @@ var ensureIdentityDirectoryStatements = []string{
 
 const identityOrganizationColumns = `tenant_id, org_id, name, slug, domain, provider, source, external_id, GREATEST(user_count, (SELECT COUNT(*)::INTEGER FROM identity_users WHERE identity_users.tenant_id = identity_organizations.tenant_id AND identity_users.org_id = identity_organizations.org_id)) AS user_count, last_synced_at, created_at, updated_at`
 const identityUserColumns = `tenant_id, user_id, org_id, subject, email, display_name, status, provider, source, roles_json::text, groups_json::text, last_seen_at, last_synced_at, created_at, updated_at`
+const identityDirectorySourceSQL = "COALESCE(NULLIF(source, ''), 'identity_directory')"
 
 func (s *Store) ensureIdentityDirectoryTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.identity.directory, "identity directory", ensureIdentityDirectoryStatements)
@@ -177,10 +178,10 @@ func (s *Store) ListIdentityOrganizations(ctx context.Context, filter ports.Iden
 	addIdentityStringClause(&clauses, &args, "tenant_id", filter.TenantID)
 	addIdentityStringClause(&clauses, &args, "org_id", filter.OrgID)
 	addIdentityNormalizedClause(&clauses, &args, "provider", filter.Provider)
-	addIdentityNormalizedClause(&clauses, &args, "source", filter.Source)
+	addIdentitySourceClause(&clauses, &args, filter.Source)
 	if query := strings.TrimSpace(filter.Query); query != "" {
 		args = append(args, "%"+strings.ToLower(query)+"%")
-		clauses = append(clauses, fmt.Sprintf("(LOWER(org_id) LIKE $%d OR LOWER(name) LIKE $%d OR LOWER(domain) LIKE $%d OR LOWER(provider) LIKE $%d OR LOWER(source) LIKE $%d OR LOWER(external_id) LIKE $%d)", len(args), len(args), len(args), len(args), len(args), len(args)))
+		clauses = append(clauses, fmt.Sprintf("(LOWER(org_id) LIKE $%d OR LOWER(name) LIKE $%d OR LOWER(domain) LIKE $%d OR LOWER(provider) LIKE $%d OR LOWER(%s) LIKE $%d OR LOWER(external_id) LIKE $%d)", len(args), len(args), len(args), len(args), identityDirectorySourceSQL, len(args), len(args)))
 	}
 	args = append(args, identityDirectoryLimit(filter.Limit))
 	// #nosec G201 -- clauses and selected columns are fixed identifiers; values remain query parameters.
@@ -214,11 +215,11 @@ func (s *Store) ListIdentityUsers(ctx context.Context, filter ports.IdentityUser
 	addIdentityStringClause(&clauses, &args, "org_id", filter.OrgID)
 	addIdentityStringClause(&clauses, &args, "user_id", filter.UserID)
 	addIdentityNormalizedClause(&clauses, &args, "provider", filter.Provider)
-	addIdentityNormalizedClause(&clauses, &args, "source", filter.Source)
+	addIdentitySourceClause(&clauses, &args, filter.Source)
 	addIdentityNormalizedClause(&clauses, &args, "status", filter.Status)
 	if query := strings.TrimSpace(filter.Query); query != "" {
 		args = append(args, "%"+strings.ToLower(query)+"%")
-		clauses = append(clauses, fmt.Sprintf("(LOWER(user_id) LIKE $%d OR LOWER(email) LIKE $%d OR LOWER(display_name) LIKE $%d OR LOWER(subject) LIKE $%d OR LOWER(provider) LIKE $%d OR LOWER(source) LIKE $%d)", len(args), len(args), len(args), len(args), len(args), len(args)))
+		clauses = append(clauses, fmt.Sprintf("(LOWER(user_id) LIKE $%d OR LOWER(email) LIKE $%d OR LOWER(display_name) LIKE $%d OR LOWER(subject) LIKE $%d OR LOWER(provider) LIKE $%d OR LOWER(%s) LIKE $%d)", len(args), len(args), len(args), len(args), len(args), identityDirectorySourceSQL, len(args)))
 	}
 	args = append(args, identityDirectoryLimit(filter.Limit))
 	// #nosec G201 -- clauses and selected columns are fixed identifiers; values remain query parameters.
@@ -316,6 +317,13 @@ func addIdentityNormalizedClause(clauses *[]string, args *[]any, column string, 
 		*args = append(*args, trimmed)
 		// #nosec G201 -- column is supplied by package-local callers with fixed identifiers.
 		*clauses = append(*clauses, fmt.Sprintf("LOWER(%s) = $%d", column, len(*args)))
+	}
+}
+
+func addIdentitySourceClause(clauses *[]string, args *[]any, value string) {
+	if trimmed := strings.ToLower(strings.TrimSpace(value)); trimmed != "" {
+		*args = append(*args, trimmed)
+		*clauses = append(*clauses, fmt.Sprintf("LOWER(%s) = $%d", identityDirectorySourceSQL, len(*args)))
 	}
 }
 

--- a/internal/statestore/postgres/identity_directory.go
+++ b/internal/statestore/postgres/identity_directory.go
@@ -176,6 +176,8 @@ func (s *Store) ListIdentityOrganizations(ctx context.Context, filter ports.Iden
 	args := []any{}
 	addIdentityStringClause(&clauses, &args, "tenant_id", filter.TenantID)
 	addIdentityStringClause(&clauses, &args, "org_id", filter.OrgID)
+	addIdentityNormalizedClause(&clauses, &args, "provider", filter.Provider)
+	addIdentityNormalizedClause(&clauses, &args, "source", filter.Source)
 	if query := strings.TrimSpace(filter.Query); query != "" {
 		args = append(args, "%"+strings.ToLower(query)+"%")
 		clauses = append(clauses, fmt.Sprintf("(LOWER(org_id) LIKE $%d OR LOWER(name) LIKE $%d OR LOWER(domain) LIKE $%d OR LOWER(provider) LIKE $%d OR LOWER(source) LIKE $%d OR LOWER(external_id) LIKE $%d)", len(args), len(args), len(args), len(args), len(args), len(args)))
@@ -211,6 +213,9 @@ func (s *Store) ListIdentityUsers(ctx context.Context, filter ports.IdentityUser
 	addIdentityStringClause(&clauses, &args, "tenant_id", filter.TenantID)
 	addIdentityStringClause(&clauses, &args, "org_id", filter.OrgID)
 	addIdentityStringClause(&clauses, &args, "user_id", filter.UserID)
+	addIdentityNormalizedClause(&clauses, &args, "provider", filter.Provider)
+	addIdentityNormalizedClause(&clauses, &args, "source", filter.Source)
+	addIdentityNormalizedClause(&clauses, &args, "status", filter.Status)
 	if query := strings.TrimSpace(filter.Query); query != "" {
 		args = append(args, "%"+strings.ToLower(query)+"%")
 		clauses = append(clauses, fmt.Sprintf("(LOWER(user_id) LIKE $%d OR LOWER(email) LIKE $%d OR LOWER(display_name) LIKE $%d OR LOWER(subject) LIKE $%d OR LOWER(provider) LIKE $%d OR LOWER(source) LIKE $%d)", len(args), len(args), len(args), len(args), len(args), len(args)))
@@ -303,6 +308,14 @@ func addIdentityStringClause(clauses *[]string, args *[]any, column string, valu
 		*args = append(*args, trimmed)
 		// #nosec G201 -- column is supplied by package-local callers with fixed identifiers.
 		*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
+	}
+}
+
+func addIdentityNormalizedClause(clauses *[]string, args *[]any, column string, value string) {
+	if trimmed := strings.ToLower(strings.TrimSpace(value)); trimmed != "" {
+		*args = append(*args, trimmed)
+		// #nosec G201 -- column is supplied by package-local callers with fixed identifiers.
+		*clauses = append(*clauses, fmt.Sprintf("LOWER(%s) = $%d", column, len(*args)))
 	}
 }
 

--- a/internal/statestore/postgres/identity_directory_test.go
+++ b/internal/statestore/postgres/identity_directory_test.go
@@ -21,3 +21,18 @@ func TestIdentityDirectorySchemaCreatesTenantScopedUsersAndOrganizations(t *test
 		}
 	}
 }
+
+func TestIdentitySourceClauseMatchesDisplayDefault(t *testing.T) {
+	clauses := []string{"1=1"}
+	args := []any{}
+
+	addIdentitySourceClause(&clauses, &args, " Identity_Directory ")
+
+	if len(args) != 1 || args[0] != "identity_directory" {
+		t.Fatalf("args = %#v, want normalized identity_directory", args)
+	}
+	want := "LOWER(COALESCE(NULLIF(source, ''), 'identity_directory')) = $1"
+	if len(clauses) != 2 || clauses[1] != want {
+		t.Fatalf("clauses = %#v, want %q", clauses, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Add exact provider and source filters for identity organizations.
- Add exact provider, source, and status filters for identity users.
- Document the new query parameters in the OpenAPI contract.

## Validation
- `go test ./internal/sourcehttp/identitydirectory ./internal/statestore/postgres ./internal/bootstrap -count=1`
- `make openapi-check`
- `make openapi-lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->