### PR TITLE
[codex] handle Slack provider envelope errors

### DIFF
--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -289,6 +289,11 @@ func (s *Source) doRequest(ctx context.Context, settings settings, path string, 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return resp.Header, decodeResponseError(s.options.SourceID, resp.StatusCode, resp.Body)
 	}
+	if s.options.ResponseError != nil {
+		if err := s.options.ResponseError(resp.Body); err != nil {
+			return resp.Header, err
+		}
+	}
 	if target == nil {
 		return resp.Header, nil
 	}

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -87,6 +87,7 @@ type Options struct {
 	ConfigHeaders                     map[string]string
 	DiscoverURNScope                  string
 	PrivateEndpointAllowlistConfigKey string
+	ResponseError                     func([]byte) error
 	Families                          []Family
 }
 

--- a/sources/slack/source.go
+++ b/sources/slack/source.go
@@ -3,7 +3,10 @@ package slack
 import (
 	"context"
 	"embed"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -37,6 +40,7 @@ func New() (*Source, error) {
 		DefaultFamily:   defaultFamily,
 		RequireTenantID: true,
 		TokenScheme:     "Bearer",
+		ResponseError:   slackResponseError,
 		Families:        slackFamilies(),
 	})
 	if err != nil {
@@ -70,11 +74,12 @@ func slackFamilies() []jsonapi.Family {
 
 func slackTeamFamily() jsonapi.Family {
 	return slackPagedFamily(jsonapi.Family{
-		Name:    familyTeam,
-		Method:  http.MethodPost,
-		Path:    "/auth.teams.list",
-		URNKind: "slack_team",
-		IDKeys:  []string{"id", "team_id"},
+		Name:     familyTeam,
+		Method:   http.MethodPost,
+		Path:     "/auth.teams.list",
+		URNKind:  "slack_team",
+		IDKeys:   []string{"id", "team_id"},
+		ListKeys: []string{"teams"},
 		Attributes: map[string]string{
 			"team_id": "id|team_id",
 			"name":    "name",
@@ -144,6 +149,7 @@ func slackUserGroupFamily() jsonapi.Family {
 		Path:            "/usergroups.list",
 		URNKind:         "slack_user_group",
 		IDKeys:          []string{"id", "group_id"},
+		ListKeys:        []string{"usergroups"},
 		TimestampKeys:   []string{"date_update", "date_create"},
 		DisablePageSize: true,
 		Attributes: map[string]string{
@@ -166,4 +172,34 @@ func slackPagedFamily(family jsonapi.Family) jsonapi.Family {
 
 func slackStaticAttributes() map[string]string {
 	return map[string]string{"source_product": "slack"}
+}
+
+func slackResponseError(body []byte) error {
+	var payload struct {
+		OK       *bool  `json:"ok"`
+		Error    string `json:"error"`
+		Needed   string `json:"needed"`
+		Provided string `json:"provided"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return fmt.Errorf("decode slack response: %w", err)
+	}
+	if payload.OK == nil || *payload.OK {
+		return nil
+	}
+	message := strings.TrimSpace(payload.Error)
+	if message == "" {
+		message = "request_failed"
+	}
+	details := []string{}
+	if needed := strings.TrimSpace(payload.Needed); needed != "" {
+		details = append(details, "needed="+needed)
+	}
+	if provided := strings.TrimSpace(payload.Provided); provided != "" {
+		details = append(details, "provided="+provided)
+	}
+	if len(details) != 0 {
+		return fmt.Errorf("slack API returned ok=false: %s (%s)", message, strings.Join(details, ", "))
+	}
+	return fmt.Errorf("slack API returned ok=false: %s", message)
 }

--- a/sources/slack/source_test.go
+++ b/sources/slack/source_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -179,6 +180,50 @@ func TestReadSlackIdentityWorkspacePostureKinds(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestReadReturnsSlackEnvelopeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/users.list" {
+			t.Fatalf("request path = %q, want /users.list", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":       false,
+			"error":    "missing_scope",
+			"needed":   "users:read",
+			"provided": "team:read",
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	config := sourcecdk.NewConfig(map[string]string{
+		"base_url":  server.URL,
+		"family":    familyUser,
+		"tenant_id": "writer",
+		"token":     "slack-token",
+	})
+	_, err = source.Read(context.Background(), config, nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want Slack envelope error")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		"slack API returned ok=false: missing_scope",
+		"needed=users:read",
+		"provided=team:read",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("Read() error = %q, want to contain %q", message, want)
+		}
+	}
+	if strings.Contains(message, "response did not contain a record list") {
+		t.Fatalf("Read() error = %q, want provider envelope error before record-list parsing", message)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add an optional JSON API response error hook for provider success-status error envelopes.
- Surface Slack `ok:false` responses as provider errors before list parsing.
- Declare Slack team and user group list keys explicitly.

## Root Cause
Slack Web API responses can use HTTP 200 with `ok:false` and an `error` field. The shared JSON API adapter only checked HTTP status before parsing collection payloads, so provider errors without a record list were reported as generic list parsing failures.

## Validation
- `go test ./sources/slack -count=1 -v`
- `go test ./sources/internal/jsonapi -count=1 -v`
- `go test ./sources/... -count=1`
