### PR TITLE
fix: Handle failing controls ask queries

### DIFF
--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -742,6 +742,12 @@ func postProcessFailingControlRows(plan AskQueryPlan, rows []map[string]any) []m
 				case 3:
 					current.HighFindings++
 				}
+				if riskScore > current.riskScore {
+					current.riskScore = riskScore
+				}
+				if rank := severityRank(severity); rank > current.severityRank {
+					current.severityRank = rank
+				}
 			}
 			if resourceURN != "" {
 				if _, seen := current.seenResources[resourceURN]; !seen {
@@ -749,12 +755,6 @@ func postProcessFailingControlRows(plan AskQueryPlan, rows []map[string]any) []m
 					current.ResourceURNs = append(current.ResourceURNs, resourceURN)
 					current.ResourceLabels = append(current.ResourceLabels, resourceLabel)
 				}
-			}
-			if riskScore > current.riskScore {
-				current.riskScore = riskScore
-			}
-			if rank := severityRank(severity); rank > current.severityRank {
-				current.severityRank = rank
 			}
 		}
 	}

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -1149,9 +1149,10 @@ func unsupportedQuery(reason string, traceID string, code string) UnsupportedQue
 	return UnsupportedQuery{
 		Code:             firstNonEmpty(code, unsupportedQueryCode(reason)),
 		Reason:           reason,
-		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth},
+		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentFailingControls, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth},
 		SuggestedRewrites: []string{
 			"Summarize open high-risk findings and cite the affected entities.",
+			"Show controls with open findings and cite the affected resources.",
 			"Count findings by source family.",
 			"Show source health and freshness for security integrations.",
 			"Explain the evidence for a specific finding URN.",

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -502,13 +502,15 @@ func postProcessAskRows(conversion conversionResult, rows []map[string]any) []ma
 		return postProcessFindingSourceRows(conversion.Plan, rows)
 	case IntentTopRiskFindings:
 		return postProcessTopRiskFindingRows(conversion.Plan, rows)
+	case IntentFailingControls:
+		return postProcessFailingControlRows(conversion.Plan, rows)
 	default:
 		return rows
 	}
 }
 
 func usesPostProcessingCandidates(conversion conversionResult) bool {
-	return conversion.Deterministic && (conversion.Plan.Intent == IntentAggregateFindingsBySource || conversion.Plan.Intent == IntentTopRiskFindings)
+	return conversion.Deterministic && (conversion.Plan.Intent == IntentAggregateFindingsBySource || conversion.Plan.Intent == IntentTopRiskFindings || conversion.Plan.Intent == IntentFailingControls)
 }
 
 func postProcessingCandidateLimitHit(conversion conversionResult, rows []ports.CypherRow, rowLimit int) bool {
@@ -573,6 +575,27 @@ type topRiskFindingRow struct {
 	riskScore      int
 	severityRank   int
 	seenResources  map[string]struct{}
+}
+
+type failingControlRef struct {
+	FrameworkName string
+	ControlID     string
+}
+
+type failingControlRow struct {
+	FrameworkName    string
+	ControlID        string
+	FindingURNs      []string
+	FindingLabels    []string
+	ResourceURNs     []string
+	ResourceLabels   []string
+	OpenFindings     int
+	CriticalFindings int
+	HighFindings     int
+	riskScore        int
+	severityRank     int
+	seenFindings     map[string]struct{}
+	seenResources    map[string]struct{}
 }
 
 func postProcessTopRiskFindingRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {
@@ -665,6 +688,150 @@ func matchesTopRiskFilters(plan AskQueryPlan, row map[string]any, severity strin
 		return resourceTypeMatchesFilter(stringRowValue(row, "resource_type"), want)
 	}
 	return true
+}
+
+func postProcessFailingControlRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {
+	byControl := map[string]*failingControlRow{}
+	for index, row := range rows {
+		findingURN := stringRowValue(row, "finding_urn")
+		if findingURN == "" {
+			findingURN = fmt.Sprintf("row:%d", index)
+		}
+		relationAttrs := decodeInternalAttributes(row["relation_attributes_json_internal"])
+		findingAttrs := decodeInternalAttributes(row["finding_attributes_json_internal"])
+		status := firstNonEmpty(
+			firstAttributeString(relationAttrs, "status"),
+			firstAttributeString(findingAttrs, "status"),
+		)
+		if status != "" && !strings.EqualFold(status, "open") {
+			continue
+		}
+		refs := failingControlRefsFromAttributes(relationAttrs, findingAttrs)
+		if len(refs) == 0 {
+			continue
+		}
+		severity := firstNonEmpty(
+			firstAttributeString(relationAttrs, "effective_severity"),
+			firstAttributeString(findingAttrs, "effective_severity"),
+			firstAttributeString(relationAttrs, "severity"),
+			firstAttributeString(findingAttrs, "severity"),
+		)
+		riskScore := firstAttributeInt(relationAttrs, findingAttrs, "risk_score")
+		resourceURN := stringRowValue(row, "resource_urn")
+		resourceLabel := firstNonEmpty(stringRowValue(row, "resource_label"), resourceURN)
+		for _, ref := range refs {
+			key := ref.FrameworkName + "|" + ref.ControlID
+			current := byControl[key]
+			if current == nil {
+				current = &failingControlRow{
+					FrameworkName: ref.FrameworkName,
+					ControlID:     ref.ControlID,
+					seenFindings:  map[string]struct{}{},
+					seenResources: map[string]struct{}{},
+				}
+				byControl[key] = current
+			}
+			if _, seen := current.seenFindings[findingURN]; !seen {
+				current.seenFindings[findingURN] = struct{}{}
+				current.FindingURNs = append(current.FindingURNs, findingURN)
+				current.FindingLabels = append(current.FindingLabels, firstNonEmpty(stringRowValue(row, "finding_label"), findingURN))
+				current.OpenFindings++
+				switch severityRank(severity) {
+				case 4:
+					current.CriticalFindings++
+				case 3:
+					current.HighFindings++
+				}
+			}
+			if resourceURN != "" {
+				if _, seen := current.seenResources[resourceURN]; !seen {
+					current.seenResources[resourceURN] = struct{}{}
+					current.ResourceURNs = append(current.ResourceURNs, resourceURN)
+					current.ResourceLabels = append(current.ResourceLabels, resourceLabel)
+				}
+			}
+			if riskScore > current.riskScore {
+				current.riskScore = riskScore
+			}
+			if rank := severityRank(severity); rank > current.severityRank {
+				current.severityRank = rank
+			}
+		}
+	}
+	controls := make([]*failingControlRow, 0, len(byControl))
+	for _, control := range byControl {
+		controls = append(controls, control)
+	}
+	sort.Slice(controls, func(i, j int) bool {
+		left, right := controls[i], controls[j]
+		if left.OpenFindings != right.OpenFindings {
+			return left.OpenFindings > right.OpenFindings
+		}
+		if left.severityRank != right.severityRank {
+			return left.severityRank > right.severityRank
+		}
+		if left.riskScore != right.riskScore {
+			return left.riskScore > right.riskScore
+		}
+		if left.FrameworkName != right.FrameworkName {
+			return left.FrameworkName < right.FrameworkName
+		}
+		return left.ControlID < right.ControlID
+	})
+	limit := postProcessedRowLimit(plan)
+	if len(controls) < limit {
+		limit = len(controls)
+	}
+	result := make([]map[string]any, 0, limit)
+	for _, control := range controls[:limit] {
+		result = append(result, map[string]any{
+			"framework_name":    control.FrameworkName,
+			"control_id":        control.ControlID,
+			"status":            "failing",
+			"open_findings":     control.OpenFindings,
+			"critical_findings": control.CriticalFindings,
+			"high_findings":     control.HighFindings,
+			"finding_urns":      append([]string(nil), control.FindingURNs...),
+			"finding_labels":    append([]string(nil), control.FindingLabels...),
+			"resource_urns":     append([]string(nil), control.ResourceURNs...),
+			"resource_labels":   append([]string(nil), control.ResourceLabels...),
+			"risk_score":        control.riskScore,
+			"severity":          severityName(control.severityRank),
+		})
+	}
+	return result
+}
+
+func failingControlRefsFromAttributes(attrs ...map[string]any) []failingControlRef {
+	seen := map[string]struct{}{}
+	var refs []failingControlRef
+	for _, attr := range attrs {
+		raw := firstAttributeString(attr, "control_refs", "controlRefs")
+		for _, item := range strings.Split(raw, ",") {
+			item = strings.TrimSpace(item)
+			if item == "" {
+				continue
+			}
+			separator := strings.LastIndex(item, ":")
+			if separator <= 0 || separator == len(item)-1 {
+				continue
+			}
+			ref := failingControlRef{
+				FrameworkName: strings.TrimSpace(item[:separator]),
+				ControlID:     strings.TrimSpace(item[separator+1:]),
+			}
+			if ref.FrameworkName == "" || ref.ControlID == "" {
+				continue
+			}
+			key := ref.FrameworkName + "|" + ref.ControlID
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+	return refs
 }
 
 func resourceTypeMatchesFilter(resourceType string, filter string) bool {

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -214,6 +214,9 @@ func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
 	if summary.UnsupportedQuery == nil || summary.UnsupportedQuery.Code != "validator_refusal" || len(summary.UnsupportedQuery.SuggestedRewrites) == 0 {
 		t.Fatalf("unsupported query rescue = %#v, want validator refusal with structured suggestions", summary.UnsupportedQuery)
 	}
+	if !stringSliceContains(summary.UnsupportedQuery.SupportedIntents, IntentFailingControls) {
+		t.Fatalf("supported intents = %#v, want failing controls intent", summary.UnsupportedQuery.SupportedIntents)
+	}
 	done := events[6].Data.(DoneEvent)
 	if !done.CypherRefused {
 		t.Fatalf("done.CypherRefused = false, want true")
@@ -845,6 +848,15 @@ func assertEventNames(t *testing.T, events []Event, want []string) {
 			t.Fatalf("event[%d] = %q, want %q", i, events[i].Name, name)
 		}
 	}
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 type askStore struct {

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -270,7 +270,7 @@ All plan.filters values must be JSON strings, even for numbers or booleans (for 
 If the question asks for mutation, deletion, credential disclosure, or anything unsafe, return:
 {"rationale":"why refused","plan":{"intent":"raw_cypher","confidence":0},"cypher":null,"refusal":"safe refusal message"}
 
-Preferred plan intents: aggregate_findings_by_source, top_risk_findings, explain_finding, identity_bridge, connector_health, raw_cypher.
+Preferred plan intents: aggregate_findings_by_source, top_risk_findings, failing_controls, explain_finding, identity_bridge, connector_health, raw_cypher.
 Use a deterministic intent whenever the question matches one; the backend will convert that plan into canonical Cypher.`, req.Question, normalizeModel(req.Model), req.Schema, req.Guardrail, probe, history.String())
 }
 

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -348,7 +348,7 @@ func inferIntent(question string, cypher string) string {
 	switch {
 	case (strings.Contains(haystack, "high risk") || strings.Contains(haystack, "top risk") || strings.Contains(haystack, "critical")) && strings.Contains(haystack, "finding"):
 		return IntentTopRiskFindings
-	case (strings.Contains(haystack, "control") || strings.Contains(haystack, "controls")) && (containsWord(haystack, "failing") || containsWord(haystack, "failed") || containsWord(haystack, "fail") || strings.Contains(haystack, "not passing")):
+	case (strings.Contains(haystack, "control") || strings.Contains(haystack, "controls")) && (containsWord(haystack, "failing") || containsWord(haystack, "failed") || containsWord(haystack, "fail") || containsWord(haystack, "failure") || containsWord(haystack, "failures") || strings.Contains(haystack, "not passing")):
 		return IntentFailingControls
 	case strings.Contains(haystack, "source") && strings.Contains(haystack, "finding") && (strings.Contains(haystack, "count") || strings.Contains(haystack, "breakdown") || strings.Contains(haystack, "group") || strings.Contains(haystack, "top")):
 		return IntentAggregateFindingsBySource

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -13,6 +13,7 @@ const (
 	IntentRawCypher                 = "raw_cypher"
 	IntentAggregateFindingsBySource = "aggregate_findings_by_source"
 	IntentTopRiskFindings           = "top_risk_findings"
+	IntentFailingControls           = "failing_controls"
 	IntentExplainFinding            = "explain_finding"
 	IntentIdentityBridge            = "identity_bridge"
 	IntentConnectorHealth           = "connector_health"
@@ -206,6 +207,8 @@ func deterministicFastPathPlan(request AskRequest) (AskQueryPlan, bool) {
 	switch intent {
 	case IntentTopRiskFindings:
 		plan.Filters = fastPathTopRiskFilters(question)
+	case IntentFailingControls:
+		plan.Filters = map[string]string{}
 	case IntentAggregateFindingsBySource, IntentConnectorHealth, IntentIdentityBridge:
 		plan.Filters = map[string]string{}
 	case IntentExplainFinding:
@@ -260,8 +263,13 @@ func normalizePlan(plan *AskQueryPlan, request AskRequest, cypher string, defaul
 		out = *plan
 	}
 	out.Intent = canonicalIntent(out.Intent)
+	requestIntent := inferIntent(request.Question, cypher)
+	if requestIntent == IntentFailingControls && out.Intent != IntentFailingControls {
+		out.Intent = IntentFailingControls
+		out.Filters = map[string]string{}
+	}
 	if out.Intent == "" || out.Intent == IntentRawCypher {
-		out.Intent = inferIntent(request.Question, cypher)
+		out.Intent = requestIntent
 	}
 	out.ScopeURN = firstNonEmpty(out.ScopeURN, strings.TrimSpace(request.ScopeURN))
 	out.Limit = boundedLimit(out.Limit, defaultMaxRows)
@@ -270,6 +278,10 @@ func normalizePlan(plan *AskQueryPlan, request AskRequest, cypher string, defaul
 	}
 	if out.Filters == nil {
 		out.Filters = map[string]string{}
+	}
+	if out.Intent == IntentFailingControls {
+		out.Filters = map[string]string{}
+		return out
 	}
 	for key, value := range out.Filters {
 		trimmed := strings.TrimSpace(value)
@@ -317,6 +329,8 @@ func canonicalIntent(value string) string {
 		return IntentAggregateFindingsBySource
 	case "top_risk_findings", "high_risk_findings", "findings":
 		return IntentTopRiskFindings
+	case "failing_controls", "failed_controls", "control_failures":
+		return IntentFailingControls
 	case "explain_finding", "finding_explanation":
 		return IntentExplainFinding
 	case "identity_bridge", "identity_bridges":
@@ -331,6 +345,8 @@ func canonicalIntent(value string) string {
 func inferIntent(question string, cypher string) string {
 	haystack := strings.ToLower(question + "\n" + cypher)
 	switch {
+	case (strings.Contains(haystack, "control") || strings.Contains(haystack, "controls")) && (containsWord(haystack, "failing") || containsWord(haystack, "failed") || containsWord(haystack, "fail") || strings.Contains(haystack, "not passing")):
+		return IntentFailingControls
 	case (strings.Contains(haystack, "high risk") || strings.Contains(haystack, "top risk") || strings.Contains(haystack, "critical")) && strings.Contains(haystack, "finding"):
 		return IntentTopRiskFindings
 	case strings.Contains(haystack, "source") && strings.Contains(haystack, "finding") && (strings.Contains(haystack, "count") || strings.Contains(haystack, "breakdown") || strings.Contains(haystack, "group") || strings.Contains(haystack, "top")):
@@ -378,6 +394,35 @@ RETURN finding.urn AS finding_urn,
        coalesce(finding.attributes_json, '') AS finding_attributes_json_internal
 ORDER BY finding_urn, resource_urn
 LIMIT %d`, filterProjection, filterPredicate, postProcessingCandidateRowLimit), true
+	case IntentFailingControls:
+		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn
+WITH resource, r, finding,
+     coalesce(
+       %s,
+       ''
+     ) AS filter_status,
+     coalesce(
+       %s,
+       ''
+     ) AS filter_control_refs
+WHERE (filter_status = '' OR toLower(filter_status) = 'open')
+  AND filter_control_refs <> ''
+RETURN finding.urn AS finding_urn,
+       coalesce(finding.label, finding.urn) AS finding_label,
+       resource.urn AS resource_urn,
+       coalesce(resource.label, resource.urn) AS resource_label,
+       resource.entity_type AS resource_type,
+       coalesce(r.attributes_json, '') AS relation_attributes_json_internal,
+       coalesce(finding.attributes_json, '') AS finding_attributes_json_internal
+ORDER BY finding_urn, resource_urn
+LIMIT %d`, strings.Join([]string{
+			cypherJSONStringAttributes("r.attributes_json", "status"),
+			cypherJSONStringAttributes("finding.attributes_json", "status"),
+		}, ",\n       "), strings.Join([]string{
+			cypherJSONStringAttributes("r.attributes_json", "control_refs"),
+			cypherJSONStringAttributes("finding.attributes_json", "control_refs"),
+		}, ",\n       "), postProcessingCandidateRowLimit), true
 	case IntentExplainFinding:
 		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = ''
@@ -552,6 +597,8 @@ func hasUnsupportedDeterministicModifiers(plan AskQueryPlan) bool {
 			if normalized != "severity" && normalized != "status" && normalized != "resource_type" && normalized != "entity_type" {
 				return true
 			}
+		case IntentFailingControls:
+			return true
 		default:
 			return true
 		}

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -348,14 +348,14 @@ func inferIntent(question string, cypher string) string {
 	switch {
 	case (strings.Contains(haystack, "high risk") || strings.Contains(haystack, "top risk") || strings.Contains(haystack, "critical")) && strings.Contains(haystack, "finding"):
 		return IntentTopRiskFindings
+	case strings.Contains(haystack, "connector") || strings.Contains(haystack, "runtime health") || strings.Contains(haystack, "source health"):
+		return IntentConnectorHealth
 	case (strings.Contains(haystack, "control") || strings.Contains(haystack, "controls")) && (containsWord(haystack, "failing") || containsWord(haystack, "failed") || containsWord(haystack, "fail") || containsWord(haystack, "failure") || containsWord(haystack, "failures") || strings.Contains(haystack, "not passing")):
 		return IntentFailingControls
 	case strings.Contains(haystack, "source") && strings.Contains(haystack, "finding") && (strings.Contains(haystack, "count") || strings.Contains(haystack, "breakdown") || strings.Contains(haystack, "group") || strings.Contains(haystack, "top")):
 		return IntentAggregateFindingsBySource
 	case strings.Contains(haystack, "has_source") || strings.Contains(haystack, "belongs_to_source") || strings.Contains(haystack, "source_family"):
 		return IntentAggregateFindingsBySource
-	case strings.Contains(haystack, "connector") || strings.Contains(haystack, "runtime health") || strings.Contains(haystack, "source health"):
-		return IntentConnectorHealth
 	case strings.Contains(haystack, "bridge") && (strings.Contains(haystack, "identity") || strings.Contains(haystack, "okta") || strings.Contains(haystack, "github")):
 		return IntentIdentityBridge
 	case strings.Contains(haystack, "explain") && strings.Contains(haystack, "finding"):

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -346,10 +346,10 @@ func canonicalIntent(value string) string {
 func inferIntent(question string, cypher string) string {
 	haystack := strings.ToLower(question + "\n" + cypher)
 	switch {
-	case (strings.Contains(haystack, "control") || strings.Contains(haystack, "controls")) && (containsWord(haystack, "failing") || containsWord(haystack, "failed") || containsWord(haystack, "fail") || strings.Contains(haystack, "not passing")):
-		return IntentFailingControls
 	case (strings.Contains(haystack, "high risk") || strings.Contains(haystack, "top risk") || strings.Contains(haystack, "critical")) && strings.Contains(haystack, "finding"):
 		return IntentTopRiskFindings
+	case (strings.Contains(haystack, "control") || strings.Contains(haystack, "controls")) && (containsWord(haystack, "failing") || containsWord(haystack, "failed") || containsWord(haystack, "fail") || strings.Contains(haystack, "not passing")):
+		return IntentFailingControls
 	case strings.Contains(haystack, "source") && strings.Contains(haystack, "finding") && (strings.Contains(haystack, "count") || strings.Contains(haystack, "breakdown") || strings.Contains(haystack, "group") || strings.Contains(haystack, "top")):
 		return IntentAggregateFindingsBySource
 	case strings.Contains(haystack, "has_source") || strings.Contains(haystack, "belongs_to_source") || strings.Contains(haystack, "source_family"):

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -421,8 +421,8 @@ LIMIT %d`, strings.Join([]string{
 			cypherJSONStringAttributes("r.attributes_json", "status"),
 			cypherJSONStringAttributes("finding.attributes_json", "status"),
 		}, ",\n       "), strings.Join([]string{
-			cypherJSONStringAttributes("r.attributes_json", "control_refs"),
-			cypherJSONStringAttributes("finding.attributes_json", "control_refs"),
+			cypherJSONStringAttributes("r.attributes_json", "control_refs", "controlRefs"),
+			cypherJSONStringAttributes("finding.attributes_json", "control_refs", "controlRefs"),
 		}, ",\n       "), postProcessingCandidateRowLimit), true
 	case IntentExplainFinding:
 		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -19,6 +19,7 @@ const (
 	IntentConnectorHealth           = "connector_health"
 
 	postProcessingCandidateRowLimit = ports.MaxCypherQueryRows
+	confidentPlanThreshold          = 0.70
 )
 
 type AskQueryPlan struct {
@@ -264,7 +265,7 @@ func normalizePlan(plan *AskQueryPlan, request AskRequest, cypher string, defaul
 	}
 	out.Intent = canonicalIntent(out.Intent)
 	requestIntent := inferIntent(request.Question, cypher)
-	if requestIntent == IntentFailingControls && out.Intent != IntentFailingControls {
+	if requestIntent == IntentFailingControls && out.Intent != IntentFailingControls && out.Confidence < confidentPlanThreshold {
 		out.Intent = IntentFailingControls
 		out.Filters = map[string]string{}
 	}

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -144,6 +144,7 @@ func TestInferIntentDetectsFailingControls(t *testing.T) {
 	for _, question := range []string{
 		"Which controls are failing?",
 		"show failed controls",
+		"show control failures",
 		"controls not passing",
 	} {
 		if got := inferIntent(question, ""); got != IntentFailingControls {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -132,6 +132,9 @@ func TestInferIntentPrefersTopRiskOverSourceBreakdown(t *testing.T) {
 	if got := inferIntent("show top risk findings from the GitHub source", ""); got != IntentTopRiskFindings {
 		t.Fatalf("inferIntent() = %q, want %q", got, IntentTopRiskFindings)
 	}
+	if got := inferIntent("show high risk findings from failed access control", ""); got != IntentTopRiskFindings {
+		t.Fatalf("inferIntent(high risk failed access control findings) = %q, want %q", got, IntentTopRiskFindings)
+	}
 	if got := inferIntent("show top finding sources", ""); got != IntentAggregateFindingsBySource {
 		t.Fatalf("inferIntent(top finding sources) = %q, want %q", got, IntentAggregateFindingsBySource)
 	}
@@ -314,6 +317,19 @@ LIMIT 25`
 	}
 	if !strings.Contains(result.Cypher, "toLower(filter_status) = 'open'") {
 		t.Fatalf("converted cypher missing top risk status filter:\n%s", result.Cypher)
+	}
+}
+
+func TestDeterministicFastPathKeepsTopRiskFindingIntentWhenControlFailureIsContext(t *testing.T) {
+	plan, ok := deterministicFastPathPlan(AskRequest{
+		TenantID: "writer",
+		Question: "show high risk findings from failed access control",
+	})
+	if !ok {
+		t.Fatalf("deterministicFastPathPlan() did not produce a plan")
+	}
+	if plan.Intent != IntentTopRiskFindings {
+		t.Fatalf("plan.Intent = %q, want %q", plan.Intent, IntentTopRiskFindings)
 	}
 }
 

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -153,6 +153,12 @@ func TestInferIntentDetectsFailingControls(t *testing.T) {
 	}
 }
 
+func TestInferIntentPrefersConnectorHealthWhenControlFailureIsContext(t *testing.T) {
+	if got := inferIntent("show source health control failures", ""); got != IntentConnectorHealth {
+		t.Fatalf("inferIntent(source health control failures) = %q, want %q", got, IntentConnectorHealth)
+	}
+}
+
 func TestConvertDraftToQueryUsesDeterministicFindingSourceTemplate(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -137,6 +137,18 @@ func TestInferIntentPrefersTopRiskOverSourceBreakdown(t *testing.T) {
 	}
 }
 
+func TestInferIntentDetectsFailingControls(t *testing.T) {
+	for _, question := range []string{
+		"Which controls are failing?",
+		"show failed controls",
+		"controls not passing",
+	} {
+		if got := inferIntent(question, ""); got != IntentFailingControls {
+			t.Fatalf("inferIntent(%q) = %q, want %q", question, got, IntentFailingControls)
+		}
+	}
+}
+
 func TestConvertDraftToQueryUsesDeterministicFindingSourceTemplate(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",
@@ -245,6 +257,72 @@ LIMIT 25`
 		if strings.Contains(result.Cypher, forbidden) {
 			t.Fatalf("filtered cypher should leave ranking to Go; found %q:\n%s", forbidden, result.Cypher)
 		}
+	}
+}
+
+func TestConvertDraftToQueryUsesFailingControlsTemplate(t *testing.T) {
+	draftCypher := `MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+RETURN finding.urn AS finding_urn
+LIMIT 25`
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Which controls are failing?",
+	}, &DraftResponse{
+		Plan:   &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"status": "fail"}},
+		Cypher: draftCypher,
+	})
+
+	if result.Plan.Intent != IntentFailingControls || !result.Deterministic || result.Source != "deterministic_template" {
+		t.Fatalf("conversion result = %#v, want deterministic failing controls template", result)
+	}
+	for _, want := range []string{
+		`"control_refs":"`,
+		"filter_control_refs <> ''",
+		"toLower(filter_status) = 'open'",
+		"finding_attributes_json_internal",
+	} {
+		if !strings.Contains(result.Cypher, want) {
+			t.Fatalf("converted cypher missing %q:\n%s", want, result.Cypher)
+		}
+	}
+	if strings.Contains(result.Cypher, "'fail'") || strings.Contains(result.Cypher, "'failing'") {
+		t.Fatalf("converted cypher should not filter finding status as fail/failing:\n%s", result.Cypher)
+	}
+}
+
+func TestPostProcessFailingControlRowsGroupsOpenFindings(t *testing.T) {
+	rows := []map[string]any{
+		{
+			"finding_urn":                       "urn:cerebro:writer:finding:f1",
+			"finding_label":                     "Critical finding",
+			"resource_urn":                      "urn:cerebro:writer:asset:a",
+			"resource_label":                    "Asset A",
+			"relation_attributes_json_internal": `{"status":"open"}`,
+			"finding_attributes_json_internal":  `{"status":"open","effective_severity":"CRITICAL","risk_score":"91","control_refs":"SOC 2:CC6.1,ISO 27001:2022:A.8.9"}`,
+		},
+		{
+			"finding_urn":                       "urn:cerebro:writer:finding:f2",
+			"finding_label":                     "Resolved finding",
+			"resource_urn":                      "urn:cerebro:writer:asset:b",
+			"relation_attributes_json_internal": `{"status":"resolved"}`,
+			"finding_attributes_json_internal":  `{"status":"resolved","effective_severity":"HIGH","risk_score":"80","control_refs":"SOC 2:CC6.2"}`,
+		},
+	}
+
+	result := postProcessFailingControlRows(AskQueryPlan{Intent: IntentFailingControls, Limit: 25}, rows)
+	if len(result) != 2 {
+		t.Fatalf("len(result) = %d, want 2: %#v", len(result), result)
+	}
+	first := result[0]
+	if first["framework_name"] != "ISO 27001:2022" || first["control_id"] != "A.8.9" {
+		t.Fatalf("first control = %#v, want ISO 27001:2022 A.8.9", first)
+	}
+	if first["status"] != "failing" || first["open_findings"] != 1 || first["critical_findings"] != 1 || first["risk_score"] != 91 {
+		t.Fatalf("first control posture = %#v", first)
+	}
+	second := result[1]
+	if second["framework_name"] != "SOC 2" || second["control_id"] != "CC6.1" {
+		t.Fatalf("second control = %#v, want SOC 2 CC6.1", second)
 	}
 }
 
@@ -368,6 +446,7 @@ func TestDeterministicTemplatesUseProjectedGraphContract(t *testing.T) {
 	}{
 		{name: "source aggregation", intent: IntentAggregateFindingsBySource, scope: "urn:cerebro:writer:asset:alpha"},
 		{name: "top risk", intent: IntentTopRiskFindings, scope: "urn:cerebro:writer:asset:alpha"},
+		{name: "failing controls", intent: IntentFailingControls, scope: "urn:cerebro:writer:asset:alpha"},
 		{name: "explain finding", intent: IntentExplainFinding, scope: "urn:cerebro:writer:finding:alpha"},
 		{name: "identity bridge", intent: IntentIdentityBridge, scope: "urn:cerebro:writer:github_user:alice"},
 		{name: "connector health", intent: IntentConnectorHealth, scope: "urn:cerebro:writer:source:github"},

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -290,6 +290,33 @@ LIMIT 25`
 	}
 }
 
+func TestConvertDraftToQueryPreservesConfidentSpecificIntentOverFailingControlsHeuristic(t *testing.T) {
+	draftCypher := `MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+RETURN finding.urn AS finding_urn
+LIMIT 25`
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Show findings with failed access control compliance",
+	}, &DraftResponse{
+		Plan: &AskQueryPlan{
+			Intent:     IntentTopRiskFindings,
+			Confidence: 0.91,
+			Filters:    map[string]string{"status": "open"},
+		},
+		Cypher: draftCypher,
+	})
+
+	if result.Plan.Intent != IntentTopRiskFindings || !result.Deterministic || result.Source != "deterministic_template" {
+		t.Fatalf("conversion result = %#v, want confident top risk plan preserved", result)
+	}
+	if strings.Contains(result.Cypher, "filter_control_refs <> ''") {
+		t.Fatalf("converted cypher used failing controls template:\n%s", result.Cypher)
+	}
+	if !strings.Contains(result.Cypher, "toLower(filter_status) = 'open'") {
+		t.Fatalf("converted cypher missing top risk status filter:\n%s", result.Cypher)
+	}
+}
+
 func TestPostProcessFailingControlRowsGroupsOpenFindings(t *testing.T) {
 	rows := []map[string]any{
 		{

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -280,6 +280,7 @@ LIMIT 25`
 	}
 	for _, want := range []string{
 		`"control_refs":"`,
+		`"controlRefs":"`,
 		"filter_control_refs <> ''",
 		"toLower(filter_status) = 'open'",
 		"finding_attributes_json_internal",
@@ -366,6 +367,37 @@ func TestPostProcessFailingControlRowsGroupsOpenFindings(t *testing.T) {
 	second := result[1]
 	if second["framework_name"] != "SOC 2" || second["control_id"] != "CC6.1" {
 		t.Fatalf("second control = %#v, want SOC 2 CC6.1", second)
+	}
+}
+
+func TestPostProcessFailingControlRowsKeepsDuplicateFindingSeverityConsistent(t *testing.T) {
+	rows := []map[string]any{
+		{
+			"finding_urn":                       "urn:cerebro:writer:finding:f1",
+			"finding_label":                     "Finding 1",
+			"resource_urn":                      "urn:cerebro:writer:asset:a",
+			"relation_attributes_json_internal": `{"status":"open","effective_severity":"HIGH","risk_score":"70","controlRefs":"SOC 2:CC6.1"}`,
+			"finding_attributes_json_internal":  `{"status":"open","effective_severity":"HIGH","risk_score":"70"}`,
+		},
+		{
+			"finding_urn":                       "urn:cerebro:writer:finding:f1",
+			"finding_label":                     "Finding 1",
+			"resource_urn":                      "urn:cerebro:writer:asset:b",
+			"relation_attributes_json_internal": `{"status":"open","controlRefs":"SOC 2:CC6.1"}`,
+			"finding_attributes_json_internal":  `{"status":"open","effective_severity":"CRITICAL","risk_score":"95"}`,
+		},
+	}
+
+	result := postProcessFailingControlRows(AskQueryPlan{Intent: IntentFailingControls, Limit: 25}, rows)
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1: %#v", len(result), result)
+	}
+	control := result[0]
+	if control["severity"] != "HIGH" || control["critical_findings"] != 0 || control["high_findings"] != 1 {
+		t.Fatalf("duplicate finding severity summary = %#v, want HIGH with one high finding", control)
+	}
+	if control["risk_score"] != 70 {
+		t.Fatalf("duplicate finding risk_score = %#v, want first-seen score 70", control["risk_score"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a deterministic `failing_controls` Ask intent for control failure questions.
- Group open finding rows by mapped control references during deterministic post-processing.
- Add regression coverage for intent inference, deterministic query conversion, and control row grouping.

## Test Plan

- `go test ./internal/graphagent -run 'Test(InferIntentDetectsFailingControls|ConvertDraftToQueryUsesFailingControlsTemplate|PostProcessFailingControlRowsGroupsOpenFindings|DeterministicTemplatesUseProjectedGraphContract)' -count=1`
- `TMPDIR=/Users/jonathan/go-build-tmp GOTMPDIR=/Users/jonathan/go-build-tmp make verify`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->