### PR TITLE
fix: Increase golangci-lint timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_TIMEOUT ?= 20m
 BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
@@ -272,7 +273,7 @@ mcp-sdk-compat: build ## Check MCP SDK compatibility against local server.
 # ==== Lint and Contracts ====
 ##@ Lint and Contracts
 lint: lint-bootstrap ## Run golangci-lint over application packages.
-	$(GOLANGCI_LINT) run --timeout 10m $(APP_PACKAGES)
+	$(GOLANGCI_LINT) run --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_PACKAGES)
 
 lint-bootstrap: ## Install golangci-lint if missing.
 	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi


### PR DESCRIPTION
## Summary

Increase the golangci-lint timeout and make it configurable so the lint shard can complete instead of timing out with no findings.

## Test Plan

- `make -C /Users/jonathan/cerebro lint`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->