### PR TITLE
[codex] Limit golangci-lint concurrency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_CONCURRENCY ?= 4
 GOLANGCI_LINT_TIMEOUT ?= 20m
 BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -273,7 +274,7 @@ mcp-sdk-compat: build ## Check MCP SDK compatibility against local server.
 # ==== Lint and Contracts ====
 ##@ Lint and Contracts
 lint: lint-bootstrap ## Run golangci-lint over application packages.
-	$(GOLANGCI_LINT) run --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_PACKAGES)
+	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_PACKAGES)
 
 lint-bootstrap: ## Install golangci-lint if missing.
 	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi


### PR DESCRIPTION
## Summary

- Add a configurable golangci-lint concurrency limit.
- Keep the existing lint package set and timeout while reducing peak analyzer pressure.

## Validation

- `make lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->