### PR TITLE
Promote Apiiro runtime depth

### DIFF
--- a/internal/sourceprojection/apiiro_test.go
+++ b/internal/sourceprojection/apiiro_test.go
@@ -37,6 +37,23 @@ func TestApiiroFindingProjection(t *testing.T) {
 	}
 }
 
+func TestApiiroVulnerabilityProjection(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apiiro", Kind: "apiiro.vulnerabilities", Attributes: map[string]string{"finding_id": "vuln-1", "title": "Dependency with exploitable CVE", "severity": "critical", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_repository:payment-service", "evidence_id": "evidence-vuln-1"}}
+	entities, links, err := apiiroVulnerabilitiesProjections(event)
+	if err != nil {
+		t.Fatalf("projection error = %v", err)
+	}
+	if len(entities) == 0 {
+		t.Fatal("expected projected vulnerability finding")
+	}
+	if len(links) == 0 {
+		t.Fatal("expected projected vulnerability links")
+	}
+	if !hasProjectedEntityType(entities, "runtime_evidence") {
+		t.Fatal("expected projected runtime evidence entity")
+	}
+}
+
 func TestApiiroPolicyProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apiiro", Kind: "apiiro.policies", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Require MFA", "policy_type": "access", "policy_status": "enabled", "evidence_id": "evidence-1"}}
 	entities, links, err := apiiroPoliciesProjections(event)

--- a/sources/apiiro/SOURCE_RUNTIME.md
+++ b/sources/apiiro/SOURCE_RUNTIME.md
@@ -26,5 +26,6 @@ Generated Source Runtime SDK scaffold for `apiiro`.
 
 ## Tests
 
+- Fixture pairs cover discover and read payloads for `assets`, `findings`, `vulnerabilities`, `policies`, and `audit_events`.
 - `go test ./sources/apiiro ./internal/sourceprojection -count=1`
 - `make catalog-check`

--- a/sources/apiiro/catalog.yaml
+++ b/sources/apiiro/catalog.yaml
@@ -7,6 +7,17 @@ emitted_kinds:
   - apiiro.vulnerabilities
   - apiiro.policies
   - apiiro.audit_events
+families:
+  - id: assets
+    incremental: cursor
+  - id: findings
+    incremental: cursor
+  - id: vulnerabilities
+    incremental: cursor
+  - id: policies
+    incremental: cursor
+  - id: audit_events
+    incremental: cursor
 kind_lifecycle:
   - kind: apiiro.assets
     status: active

--- a/sources/apiiro/testdata/discover_assets.json
+++ b/sources/apiiro/testdata/discover_assets.json
@@ -1,0 +1,12 @@
+{
+  "family": "assets",
+  "items": [
+    {
+      "id": "asset-1",
+      "last_seen_at": "2026-06-01T00:00:00Z",
+      "name": "payment-service",
+      "resource_type": "repository",
+      "sync_operation": "discover"
+    }
+  ]
+}

--- a/sources/apiiro/testdata/discover_audit_events.json
+++ b/sources/apiiro/testdata/discover_audit_events.json
@@ -1,0 +1,13 @@
+{
+  "family": "audit_events",
+  "items": [
+    {
+      "actor_id": "user-1",
+      "event_type": "finding.dismissed",
+      "id": "audit-1",
+      "occurred_at": "2026-06-01T00:00:00Z",
+      "resource_id": "finding-1",
+      "sync_operation": "discover"
+    }
+  ]
+}

--- a/sources/apiiro/testdata/discover_findings.json
+++ b/sources/apiiro/testdata/discover_findings.json
@@ -1,0 +1,14 @@
+{
+  "family": "findings",
+  "items": [
+    {
+      "id": "finding-1",
+      "last_seen_at": "2026-06-01T00:00:00Z",
+      "resource_urn": "urn:cerebro:tenant:runtime_repository:payment-service",
+      "severity": "high",
+      "status": "open",
+      "sync_operation": "discover",
+      "title": "Secret committed to repository"
+    }
+  ]
+}

--- a/sources/apiiro/testdata/discover_policies.json
+++ b/sources/apiiro/testdata/discover_policies.json
@@ -1,0 +1,12 @@
+{
+  "family": "policies",
+  "items": [
+    {
+      "id": "policy-1",
+      "last_seen_at": "2026-06-01T00:00:00Z",
+      "name": "Require branch protection",
+      "policy_status": "enabled",
+      "sync_operation": "discover"
+    }
+  ]
+}

--- a/sources/apiiro/testdata/discover_vulnerabilities.json
+++ b/sources/apiiro/testdata/discover_vulnerabilities.json
@@ -1,0 +1,14 @@
+{
+  "family": "vulnerabilities",
+  "items": [
+    {
+      "id": "vuln-1",
+      "last_seen_at": "2026-06-01T00:00:00Z",
+      "resource_urn": "urn:cerebro:tenant:runtime_repository:payment-service",
+      "severity": "critical",
+      "status": "open",
+      "sync_operation": "discover",
+      "title": "Dependency with exploitable CVE"
+    }
+  ]
+}

--- a/sources/apiiro/testdata/read_assets.json
+++ b/sources/apiiro/testdata/read_assets.json
@@ -1,4 +1,5 @@
 {
+  "family": "assets",
   "items": [
     {
       "evidence_cas_digest": "sha256:test",

--- a/sources/apiiro/testdata/read_audit_events.json
+++ b/sources/apiiro/testdata/read_audit_events.json
@@ -1,0 +1,17 @@
+{
+  "family": "audit_events",
+  "items": [
+    {
+      "actor_email": "security@example.test",
+      "actor_id": "user-1",
+      "actor_name": "Security Reviewer",
+      "event_type": "finding.dismissed",
+      "id": "audit-1",
+      "resource_id": "finding-1",
+      "resource_name": "Secret committed to repository",
+      "resource_type": "finding",
+      "resource_urn": "urn:cerebro:tenant:finding:finding-1",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ]
+}

--- a/sources/apiiro/testdata/read_findings.json
+++ b/sources/apiiro/testdata/read_findings.json
@@ -1,0 +1,19 @@
+{
+  "family": "findings",
+  "items": [
+    {
+      "description": "A repository commit contains a credential pattern that requires rotation.",
+      "evidence_cas_digest": "sha256:finding",
+      "evidence_cas_uri": "cas://cases/finding-1",
+      "id": "finding-1",
+      "resource_id": "payment-service",
+      "resource_name": "payment-service",
+      "resource_type": "repository",
+      "resource_urn": "urn:cerebro:tenant:runtime_repository:payment-service",
+      "severity": "high",
+      "status": "open",
+      "title": "Secret committed to repository",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ]
+}

--- a/sources/apiiro/testdata/read_policies.json
+++ b/sources/apiiro/testdata/read_policies.json
@@ -1,0 +1,20 @@
+{
+  "family": "policies",
+  "items": [
+    {
+      "description": "Default branch protection is required for production repositories.",
+      "evidence_cas_digest": "sha256:policy",
+      "evidence_cas_uri": "cas://cases/policy-1",
+      "id": "policy-1",
+      "policy_name": "Require branch protection",
+      "policy_severity": "high",
+      "policy_status": "enabled",
+      "policy_type": "repository_control",
+      "resource_id": "payment-service",
+      "resource_name": "payment-service",
+      "resource_type": "repository",
+      "resource_urn": "urn:cerebro:tenant:runtime_repository:payment-service",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ]
+}

--- a/sources/apiiro/testdata/read_vulnerabilities.json
+++ b/sources/apiiro/testdata/read_vulnerabilities.json
@@ -1,0 +1,19 @@
+{
+  "family": "vulnerabilities",
+  "items": [
+    {
+      "description": "A reachable dependency version is affected by an exploitable vulnerability.",
+      "evidence_cas_digest": "sha256:vulnerability",
+      "evidence_cas_uri": "cas://cases/vuln-1",
+      "id": "vuln-1",
+      "resource_id": "payment-service",
+      "resource_name": "payment-service",
+      "resource_type": "repository",
+      "resource_urn": "urn:cerebro:tenant:runtime_repository:payment-service",
+      "severity": "critical",
+      "status": "open",
+      "title": "Dependency with exploitable CVE",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Declare Apiiro runtime families in the source catalog.
- Add discover/read fixture pairs for assets, findings, vulnerabilities, policies, and audit events.
- Add missing `apiiro.vulnerabilities` projection coverage.

## Runtime-depth result

- Apiiro runtime depth: 75 -> 100
- Reference-runtime sources: 8 -> 9
- Runtime-depth queue: 786 -> 785

## Tests

- go test ./sources/apiiro ./internal/sourceprojection ./internal/connectorcatalog -count=1
- make catalog-check
- make connector-catalog-maintenance
