### PR TITLE
Promote Wiz runtime depth

### DIFF
--- a/sources/wiz/SOURCE_RUNTIME.md
+++ b/sources/wiz/SOURCE_RUNTIME.md
@@ -24,5 +24,6 @@ Generated Source Runtime SDK scaffold for `wiz`.
 
 ## Tests
 
+- Fixture pairs cover discover and read payloads for `assets`, `findings`, and `vulnerabilities`.
 - `go test ./sources/wiz ./internal/sourceprojection -count=1`
 - `make catalog-check`

--- a/sources/wiz/catalog.yaml
+++ b/sources/wiz/catalog.yaml
@@ -5,6 +5,13 @@ emitted_kinds:
   - wiz.assets
   - wiz.findings
   - wiz.vulnerabilities
+families:
+  - id: assets
+    incremental: cursor
+  - id: findings
+    incremental: cursor
+  - id: vulnerabilities
+    incremental: cursor
 kind_lifecycle:
   - kind: wiz.assets
     status: active

--- a/sources/wiz/testdata/discover_assets.json
+++ b/sources/wiz/testdata/discover_assets.json
@@ -1,0 +1,13 @@
+{
+  "family": "assets",
+  "items": [
+    {
+      "cloud_provider": "aws",
+      "id": "asset-1",
+      "last_seen_at": "2026-06-01T00:00:00Z",
+      "name": "prod-payment-instance",
+      "resource_type": "compute_instance",
+      "sync_operation": "discover"
+    }
+  ]
+}

--- a/sources/wiz/testdata/discover_findings.json
+++ b/sources/wiz/testdata/discover_findings.json
@@ -1,0 +1,14 @@
+{
+  "family": "findings",
+  "items": [
+    {
+      "id": "finding-1",
+      "last_seen_at": "2026-06-01T00:00:00Z",
+      "resource_urn": "urn:cerebro:tenant:runtime_compute_instance:asset-1",
+      "severity": "high",
+      "status": "open",
+      "sync_operation": "discover",
+      "title": "Public exposure on production workload"
+    }
+  ]
+}

--- a/sources/wiz/testdata/discover_vulnerabilities.json
+++ b/sources/wiz/testdata/discover_vulnerabilities.json
@@ -1,0 +1,15 @@
+{
+  "family": "vulnerabilities",
+  "items": [
+    {
+      "cve": "CVE-2026-0001",
+      "id": "vuln-1",
+      "last_seen_at": "2026-06-01T00:00:00Z",
+      "resource_urn": "urn:cerebro:tenant:runtime_compute_instance:asset-1",
+      "severity": "critical",
+      "status": "open",
+      "sync_operation": "discover",
+      "title": "Critical package vulnerability"
+    }
+  ]
+}

--- a/sources/wiz/testdata/read_assets.json
+++ b/sources/wiz/testdata/read_assets.json
@@ -1,4 +1,5 @@
 {
+  "family": "assets",
   "items": [
     {
       "evidence_cas_digest": "sha256:test",

--- a/sources/wiz/testdata/read_findings.json
+++ b/sources/wiz/testdata/read_findings.json
@@ -1,0 +1,19 @@
+{
+  "family": "findings",
+  "items": [
+    {
+      "description": "A production workload is reachable from the internet and lacks the expected network boundary.",
+      "evidence_cas_digest": "sha256:wiz-finding",
+      "evidence_cas_uri": "cas://cases/wiz-finding-1",
+      "id": "finding-1",
+      "resource_id": "asset-1",
+      "resource_name": "prod-payment-instance",
+      "resource_type": "compute_instance",
+      "resource_urn": "urn:cerebro:tenant:runtime_compute_instance:asset-1",
+      "severity": "high",
+      "status": "open",
+      "title": "Public exposure on production workload",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ]
+}

--- a/sources/wiz/testdata/read_vulnerabilities.json
+++ b/sources/wiz/testdata/read_vulnerabilities.json
@@ -1,0 +1,19 @@
+{
+  "family": "vulnerabilities",
+  "items": [
+    {
+      "description": "A package version on the workload is affected by a critical vulnerability.",
+      "evidence_cas_digest": "sha256:wiz-vuln",
+      "evidence_cas_uri": "cas://cases/wiz-vuln-1",
+      "id": "vuln-1",
+      "resource_id": "asset-1",
+      "resource_name": "prod-payment-instance",
+      "resource_type": "compute_instance",
+      "resource_urn": "urn:cerebro:tenant:runtime_compute_instance:asset-1",
+      "severity": "critical",
+      "status": "open",
+      "title": "Critical package vulnerability",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Declare Wiz runtime families in the source catalog.
- Add discover/read fixture pairs for assets, findings, and vulnerabilities.
- Document the fixture-pair contract in the source runtime notes.

## Runtime-depth result

- Wiz runtime depth: 85 -> 100
- Reference-runtime sources: 8 -> 9 on this branch
- Runtime-depth queue: 786 -> 785 on this branch

## Tests

- go test ./sources/wiz ./internal/sourceprojection ./internal/connectorcatalog -count=1
- make catalog-check
- make connector-catalog-maintenance
