### PR TITLE
[codex] Add questionnaire evidence answers

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3610,6 +3610,10 @@ paths:
       responses:
         '200':
           description: Audit-ready program, framework, control, request, packet, review, activity, export, and snapshot records assembled from live evidence.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GRCEvidencePacketsResponse'
   /grc/control-packets/detail:
     get:
       summary: GRC control evidence detail for one control
@@ -5195,6 +5199,1317 @@ components:
         minimum: 1
         maximum: 500
   schemas:
+    GRCEvidencePacketsResponse:
+      type: object
+      additionalProperties: true
+      properties:
+        version:
+          type: string
+        generated_at:
+          type: string
+          format: date-time
+        program:
+          $ref: '#/components/schemas/GRCAuditProgram'
+        frameworks:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFrameworkPosture'
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCControlPosture'
+        evidence_requests:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvidenceRequest'
+        evidence_packets:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvidencePacket'
+        evidence_reviews:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvidenceReview'
+        activity:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvidenceActivity'
+        assessment_scope:
+          $ref: '#/components/schemas/GRCAssessmentScope'
+        collection_sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCCollectionSource'
+        evidence_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvidenceItemRecord'
+        finding_workflow:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingWorkflow'
+        resource_subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCResourceSubject'
+        evidence_lineage:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvidenceLineage'
+        claim_records:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCClaimRecord'
+        evaluation_runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvaluationRun'
+        graph_evidence_rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCGraphEvidenceRecord'
+        graph_path_records:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCGraphPathRecord'
+        access_evidence_subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCAccessEvidenceSubject'
+        reasoning_tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvidenceReasoningTask'
+        exceptions_acceptances:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCExceptionAcceptance'
+        questionnaire_answers:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCQuestionnaireAnswer'
+        export_artifacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCEvidenceExportArtifact'
+        export:
+          $ref: '#/components/schemas/GRCEvidenceExport'
+        snapshot:
+          $ref: '#/components/schemas/GRCAuditSnapshot'
+        metadata:
+          $ref: '#/components/schemas/GRCReportMetadata'
+    GRCAuditProgram:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        profile_id:
+          type: string
+        status:
+          type: string
+        readiness_score:
+          type: integer
+        framework_count:
+          type: integer
+        control_count:
+          type: integer
+        evidence_request_count:
+          type: integer
+        evidence_packet_count:
+          type: integer
+        collection_source_count:
+          type: integer
+        evidence_item_count:
+          type: integer
+        resource_subject_count:
+          type: integer
+        lineage_count:
+          type: integer
+        claim_record_count:
+          type: integer
+        evaluation_run_count:
+          type: integer
+        graph_path_count:
+          type: integer
+        questionnaire_answer_count:
+          type: integer
+        open_review_count:
+          type: integer
+    GRCAuditSnapshot:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        hash:
+          type: string
+        generated_at:
+          type: string
+          format: date-time
+        control_count:
+          type: integer
+        evidence_request_count:
+          type: integer
+        evidence_packet_count:
+          type: integer
+        collection_source_count:
+          type: integer
+        evidence_item_count:
+          type: integer
+        resource_subject_count:
+          type: integer
+        lineage_count:
+          type: integer
+        claim_record_count:
+          type: integer
+        evaluation_run_count:
+          type: integer
+        graph_path_count:
+          type: integer
+        questionnaire_answer_count:
+          type: integer
+        open_review_count:
+          type: integer
+    GRCFrameworkPosture:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        lifecycle:
+          type: string
+        status:
+          type: string
+        control_count:
+          type: integer
+        passing_controls:
+          type: integer
+        needs_attention_controls:
+          type: integer
+        missing_evidence_count:
+          type: integer
+        stale_evidence_count:
+          type: integer
+        evidence_score:
+          type: integer
+    GRCControlPosture:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        control_id:
+          type: string
+        framework_id:
+          type: string
+        framework_name:
+          type: string
+        title:
+          type: string
+        owner_domain:
+          type: string
+        framework_version:
+          type: string
+        framework_lifecycle:
+          type: string
+        family_id:
+          type: string
+        family_name:
+          type: string
+        mapped_rules:
+          type: array
+          items:
+            type: string
+        reasons:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+        evidence_quality:
+          type: string
+        evidence_score:
+          type: integer
+        audit_summary:
+          type: string
+        open_findings:
+          type: integer
+        critical_findings:
+          type: integer
+        high_findings:
+          type: integer
+        evidence_items:
+          type: integer
+        missing_evidence_items:
+          type: integer
+        stale_evidence_items:
+          type: integer
+        test_results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCControlTestResult'
+        evidence_request_ids:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        exception_ids:
+          type: array
+          items:
+            type: string
+    GRCControlTestResult:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        rule_id:
+          type: string
+        control_id:
+          type: string
+        status:
+          type: string
+        result:
+          type: string
+        evidence_quality:
+          type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        last_observed_at:
+          type: string
+    GRCEvidenceRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        control_id:
+          type: string
+        framework_id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+        required:
+          type: boolean
+        status:
+          type: string
+        quality:
+          type: string
+        freshness_sla:
+          type: string
+        assessment_methods:
+          type: array
+          items:
+            type: string
+        accepted_from:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+        review_status:
+          type: string
+        owner_domain:
+          type: string
+        due_at:
+          type: string
+        control_test_ids:
+          type: array
+          items:
+            type: string
+    GRCEvidencePacket:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        request_id:
+          type: string
+        control_id:
+          type: string
+        framework_id:
+          type: string
+        evidence_type:
+          type: string
+        status:
+          type: string
+        quality:
+          type: string
+        reason:
+          type: string
+        source:
+          type: string
+        observed_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+        manual:
+          type: boolean
+        citations:
+          $ref: '#/components/schemas/GRCEvidenceCitations'
+        freshness:
+          $ref: '#/components/schemas/GRCEvidenceFreshness'
+        review:
+          $ref: '#/components/schemas/GRCEvidenceReview'
+        export_artifact:
+          $ref: '#/components/schemas/GRCEvidenceExportRef'
+    GRCEvidenceReview:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        subject_id:
+          type: string
+        status:
+          type: string
+        reason:
+          type: string
+        actor:
+          type: string
+        updated_at:
+          type: string
+    GRCEvidenceActivity:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        subject_id:
+          type: string
+        type:
+          type: string
+        message:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    GRCAssessmentScope:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        report_type:
+          type: string
+        profile_id:
+          type: string
+        profile_name:
+          type: string
+        generated_at:
+          type: string
+          format: date-time
+        source_ids:
+          type: array
+          items:
+            type: string
+        runtime_ids:
+          type: array
+          items:
+            type: string
+        control_count:
+          type: integer
+        finding_count:
+          type: integer
+        evidence_count:
+          type: integer
+        runtime_count:
+          type: integer
+        exclusion_count:
+          type: integer
+        collection_policy:
+          type: string
+        policy_applied_before_read:
+          type: boolean
+        filtered_before_graph_projection:
+          type: boolean
+        redaction_mode:
+          type: string
+    GRCCollectionSource:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        runtime_id:
+          type: string
+        source_id:
+          type: string
+        tenant_id:
+          type: string
+        status:
+          type: string
+        last_synced_at:
+          type: string
+        finding_count:
+          type: integer
+        evidence_item_count:
+          type: integer
+        control_count:
+          type: integer
+    GRCEvidenceItemRecord:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        runtime_id:
+          type: string
+        source_id:
+          type: string
+        finding_id:
+          type: string
+        rule_id:
+          type: string
+        run_id:
+          type: string
+        run_ids:
+          type: array
+          items:
+            type: string
+        claim_ids:
+          type: array
+          items:
+            type: string
+        event_ids:
+          type: array
+          items:
+            type: string
+        graph_root_urns:
+          type: array
+          items:
+            type: string
+        graph_path_urns:
+          type: array
+          items:
+            type: string
+        created_at:
+          type: string
+        last_observed_at:
+          type: string
+        observation_count:
+          type: integer
+        control_ids:
+          type: array
+          items:
+            type: string
+        evidence_request_ids:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+    GRCFindingWorkflow:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        severity:
+          type: string
+        status:
+          type: string
+        owner:
+          type: string
+        sla_status:
+          type: string
+        runtime_id:
+          type: string
+        source_id:
+          type: string
+        rule_id:
+          type: string
+        policy_id:
+          type: string
+        policy_name:
+          type: string
+        check_id:
+          type: string
+        check_name:
+          type: string
+        risk_score:
+          type: integer
+        risk_reasons:
+          type: array
+          items:
+            type: string
+        due_at:
+          type: string
+        status_reason:
+          type: string
+        control_ids:
+          type: array
+          items:
+            type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+        last_observed_at:
+          type: string
+        review_status:
+          type: string
+    GRCResourceSubject:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        urn:
+          type: string
+        kind:
+          type: string
+        control_ids:
+          type: array
+          items:
+            type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+        last_observed_at:
+          type: string
+    GRCEvidenceLineage:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        evidence_id:
+          type: string
+        finding_id:
+          type: string
+        runtime_id:
+          type: string
+        source_id:
+          type: string
+        rule_id:
+          type: string
+        run_ids:
+          type: array
+          items:
+            type: string
+        claim_ids:
+          type: array
+          items:
+            type: string
+        event_ids:
+          type: array
+          items:
+            type: string
+        graph_root_urns:
+          type: array
+          items:
+            type: string
+        evidence_request_ids:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+        control_ids:
+          type: array
+          items:
+            type: string
+    GRCClaimRecord:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        control_ids:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+    GRCEvaluationRun:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        runtime_id:
+          type: string
+        source_id:
+          type: string
+        rule_ids:
+          type: array
+          items:
+            type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        control_ids:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+    GRCGraphEvidenceRecord:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        evidence_id:
+          type: string
+        finding_id:
+          type: string
+        label:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+        graph_path_ids:
+          type: array
+          items:
+            type: string
+    GRCGraphPathRecord:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        evidence_id:
+          type: string
+        finding_id:
+          type: string
+        from_urn:
+          type: string
+        from_type:
+          type: string
+        relation:
+          type: string
+        to_urn:
+          type: string
+        to_type:
+          type: string
+        observed_at:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+    GRCAccessEvidenceSubject:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        evidence_use:
+          type: string
+        subject_urn:
+          type: string
+        subject_type:
+          type: string
+        subject_label:
+          type: string
+        principal_urn:
+          type: string
+        principal_type:
+          type: string
+        principal_label:
+          type: string
+        account_status:
+          type: string
+        lifecycle_state:
+          type: string
+        mfa_posture:
+          type: string
+        reviewer_urn:
+          type: string
+        owner_urn:
+          type: string
+        exception_state:
+          type: string
+        manual_review_state:
+          type: string
+        period_start:
+          type: string
+        period_end:
+          type: string
+        freshness:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCAccessSourceFreshness'
+        source_freshness:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCAccessSourceFreshness'
+        source_citations:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCAccessSourceCitation'
+        policy_citations:
+          type: array
+          items:
+            type: string
+        included_because:
+          type: array
+          items:
+            type: string
+        risk_signals:
+          type: array
+          items:
+            type: string
+        change_summary:
+          type: array
+          items:
+            type: string
+        missing_facts:
+          type: array
+          items:
+            type: string
+        unsupported_claims:
+          type: array
+          items:
+            type: string
+        overclaim_guards:
+          type: array
+          items:
+            type: string
+        confidence:
+          $ref: '#/components/schemas/GRCAccessEvidenceConfidence'
+        supported_controls:
+          type: array
+          items:
+            type: string
+        citations:
+          $ref: '#/components/schemas/GRCEvidenceCitations'
+        operating_effectiveness_item_ids:
+          type: array
+          items:
+            type: string
+        review_context_item_ids:
+          type: array
+          items:
+            type: string
+        manual_review_only_item_ids:
+          type: array
+          items:
+            type: string
+        access_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCAccessEvidenceItem'
+    GRCAccessSourceFreshness:
+      type: object
+      additionalProperties: true
+      properties:
+        source_id:
+          type: string
+        runtime_id:
+          type: string
+        observed_at:
+          type: string
+        status:
+          type: string
+    GRCAccessSourceCitation:
+      type: object
+      additionalProperties: true
+      properties:
+        source_id:
+          type: string
+        runtime_id:
+          type: string
+        event_id:
+          type: string
+        graph_path_id:
+          type: string
+        observed_at:
+          type: string
+    GRCAccessEvidenceConfidence:
+      type: object
+      additionalProperties: true
+      properties:
+        level:
+          type: string
+        reasons:
+          type: array
+          items:
+            type: string
+    GRCAccessEvidenceItem:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        evidence_use:
+          type: string
+        assignment_kind:
+          type: string
+        access_target_urn:
+          type: string
+        access_target_type:
+          type: string
+        access_target_label:
+          type: string
+        mediator_urn:
+          type: string
+        mediator_type:
+          type: string
+        mediator_label:
+          type: string
+        entitlement_urn:
+          type: string
+        entitlement_type:
+          type: string
+        entitlement_label:
+          type: string
+        capability_urn:
+          type: string
+        capability_type:
+          type: string
+        capability_label:
+          type: string
+        privileged:
+          type: boolean
+        sensitive:
+          type: boolean
+        classification:
+          type: array
+          items:
+            type: string
+        changed_during_period:
+          type: boolean
+        source_ids:
+          type: array
+          items:
+            type: string
+        runtime_ids:
+          type: array
+          items:
+            type: string
+        event_ids:
+          type: array
+          items:
+            type: string
+        graph_path_ids:
+          type: array
+          items:
+            type: string
+        graph_root_urns:
+          type: array
+          items:
+            type: string
+        source_citations:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCAccessSourceCitation'
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+    GRCEvidenceReasoningTask:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        subject_id:
+          type: string
+        question:
+          type: string
+        answer_scope:
+          type: string
+        control_ids:
+          type: array
+          items:
+            type: string
+        policy_citations:
+          type: array
+          items:
+            type: string
+        citation_graph_root_urns:
+          type: array
+          items:
+            type: string
+        citation_graph_path_ids:
+          type: array
+          items:
+            type: string
+        citation_event_ids:
+          type: array
+          items:
+            type: string
+        guards:
+          type: array
+          items:
+            type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+    GRCExceptionAcceptance:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        control_id:
+          type: string
+        framework_id:
+          type: string
+        type:
+          type: string
+        status:
+          type: string
+    GRCEvidenceExport:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        formats:
+          type: array
+          items:
+            type: string
+        redaction:
+          type: string
+        path:
+          type: string
+    GRCEvidenceExportRef:
+      type: object
+      additionalProperties: true
+      properties:
+        format:
+          type: string
+        path:
+          type: string
+    GRCEvidenceExportArtifact:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+        snapshot_id:
+          type: string
+        format:
+          type: string
+        redaction:
+          type: string
+        path:
+          type: string
+        content_hash:
+          type: string
+        included:
+          type: boolean
+    GRCReportMetadata:
+      type: object
+      additionalProperties: true
+    GRCQuestionnaireAnswer:
+      type: object
+      required:
+        - id
+        - question_id
+        - question
+        - answer
+        - answer_state
+        - review_state
+        - reasoning_contract
+        - confidence
+        - controls
+        - citations
+        - freshness
+      properties:
+        id:
+          type: string
+        question_id:
+          type: string
+        question:
+          type: string
+        answer:
+          type: string
+        answer_state:
+          type: string
+        review_state:
+          type: string
+        reasoning_contract:
+          $ref: '#/components/schemas/GRCQuestionnaireReasoningContract'
+        confidence:
+          $ref: '#/components/schemas/GRCQuestionnaireAnswerConfidence'
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCQuestionnaireControlRef'
+        framework_mappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCQuestionnaireFrameworkMapping'
+        source_evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCQuestionnaireEvidenceRef'
+        policy_documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCQuestionnaireEvidenceRef'
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+        citations:
+          $ref: '#/components/schemas/GRCEvidenceCitations'
+        freshness:
+          $ref: '#/components/schemas/GRCEvidenceFreshness'
+        missing_evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCQuestionnaireEvidenceGap'
+        guardrails:
+          type: array
+          items:
+            type: string
+    GRCQuestionnaireReasoningContract:
+      type: object
+      required:
+        - intent
+        - surface
+        - graph_question
+        - freshness
+        - confidence
+        - manual_review_state
+      properties:
+        intent:
+          type: string
+        surface:
+          type: string
+        graph_question:
+          type: string
+        relevant_controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCQuestionnaireControlRef'
+        source_citations:
+          type: array
+          items:
+            type: string
+        policy_citations:
+          type: array
+          items:
+            type: string
+        evidence_packet_ids:
+          type: array
+          items:
+            type: string
+        freshness:
+          $ref: '#/components/schemas/GRCEvidenceFreshness'
+        confidence:
+          type: string
+        unsupported_claims:
+          type: array
+          items:
+            type: string
+        manual_review_state:
+          type: string
+        missing_evidence_ids:
+          type: array
+          items:
+            type: string
+    GRCQuestionnaireAnswerConfidence:
+      type: object
+      required: [level, score]
+      properties:
+        level:
+          type: string
+        score:
+          type: integer
+        reason:
+          type: string
+    GRCQuestionnaireControlRef:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+        framework_id:
+          type: string
+        framework_name:
+          type: string
+        control_id:
+          type: string
+        title:
+          type: string
+        status:
+          type: string
+    GRCQuestionnaireFrameworkMapping:
+      type: object
+      properties:
+        framework_id:
+          type: string
+        framework_name:
+          type: string
+        framework_version:
+          type: string
+        family_id:
+          type: string
+        family_name:
+          type: string
+        control_id:
+          type: string
+        control_title:
+          type: string
+        mapped_rules:
+          type: array
+          items:
+            type: string
+    GRCQuestionnaireEvidenceRef:
+      type: object
+      required:
+        - id
+        - freshness
+        - citations
+      properties:
+        id:
+          type: string
+        evidence_packet_id:
+          type: string
+        evidence_type:
+          type: string
+        source:
+          type: string
+        source_id:
+          type: string
+        runtime_id:
+          type: string
+        freshness:
+          $ref: '#/components/schemas/GRCEvidenceFreshness'
+        review_state:
+          type: string
+        citations:
+          $ref: '#/components/schemas/GRCEvidenceCitations'
+    GRCQuestionnaireEvidenceGap:
+      type: object
+      required: [id, code]
+      properties:
+        id:
+          type: string
+        code:
+          type: string
+        field:
+          type: string
+        reason:
+          type: string
+        control_id:
+          type: string
+        evidence_request_id:
+          type: string
+        evidence_packet_id:
+          type: string
+        review_state:
+          type: string
+    GRCEvidenceCitations:
+      type: object
+      properties:
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        rule_ids:
+          type: array
+          items:
+            type: string
+        event_ids:
+          type: array
+          items:
+            type: string
+        claim_ids:
+          type: array
+          items:
+            type: string
+        graph_root_urns:
+          type: array
+          items:
+            type: string
+        run_ids:
+          type: array
+          items:
+            type: string
+    GRCEvidenceFreshness:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+        sla:
+          type: string
+        reason:
+          type: string
+        observed_at:
+          type: string
+        expires_at:
+          type: string
     IdentityListMeta:
       type: object
       required: [limit, loaded, configured, persisted]

--- a/internal/bootstrap/grc_control_packs_test.go
+++ b/internal/bootstrap/grc_control_packs_test.go
@@ -269,6 +269,17 @@ func TestGRCEvidencePacketsEndpointBuildsPackagedAuditRecords(t *testing.T) {
 	if !foundReview {
 		t.Fatalf("reviews = %#v, want packet or request review records", payload.Reviews)
 	}
+	if len(payload.Answers) == 0 {
+		t.Fatal("questionnaire answers are empty, want evidence-backed answer records")
+	}
+	if payload.Program.AnswerCount != len(payload.Answers) || payload.Snapshot.AnswerCount != len(payload.Answers) {
+		t.Fatalf("answer counts program=%d snapshot=%d answers=%d", payload.Program.AnswerCount, payload.Snapshot.AnswerCount, len(payload.Answers))
+	}
+	for _, answer := range payload.Answers {
+		if answer.Question == "" || answer.Answer == "" || answer.AnswerState == "" || answer.Confidence.Level == "" {
+			t.Fatalf("answer = %#v, want question, answer, state, and confidence", answer)
+		}
+	}
 }
 
 func TestGRCControlEvidencePacketDetailEndpointReturnsOneControl(t *testing.T) {

--- a/internal/evidencepackets/access_evidence.go
+++ b/internal/evidencepackets/access_evidence.go
@@ -185,7 +185,7 @@ func AddGraphBackedAccessEvidence(response Response, input GraphBackedAccessEvid
 	sort.Slice(response.GraphPaths, func(i, j int) bool { return response.GraphPaths[i].ID < response.GraphPaths[j].ID })
 	response.Program.GraphPathCount = len(response.GraphPaths)
 	response.Snapshot.GraphPathCount = len(response.GraphPaths)
-	response.Snapshot.Hash = snapshotHash(response.Program, response.Frameworks, response.Controls, response.Requests, response.Packets, response.Items, response.Findings, response.Resources, response.Lineage, response.Claims, response.Runs, response.GraphRows, response.GraphPaths, response.Access, response.Reasoning, response.Exceptions)
+	response.Snapshot.Hash = snapshotHash(response.Program, response.Frameworks, response.Controls, response.Requests, response.Packets, response.Items, response.Findings, response.Resources, response.Lineage, response.Claims, response.Runs, response.GraphRows, response.GraphPaths, response.Access, response.Reasoning, response.Exceptions, response.Answers)
 	response.Artifacts = exportArtifacts(response.Export, response.Snapshot)
 	return response
 }

--- a/internal/evidencepackets/openapi_contract_test.go
+++ b/internal/evidencepackets/openapi_contract_test.go
@@ -1,0 +1,63 @@
+package evidencepackets
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestEvidencePacketsResponseOpenAPIDocumentsTopLevelFields(t *testing.T) {
+	payload, err := os.ReadFile(filepath.Join("..", "..", "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var spec struct {
+		Components struct {
+			Schemas map[string]struct {
+				Properties map[string]any `yaml:"properties"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(payload, &spec); err != nil {
+		t.Fatalf("decode openapi.yaml: %v", err)
+	}
+	response, ok := spec.Components.Schemas["GRCEvidencePacketsResponse"]
+	if !ok {
+		t.Fatal("GRCEvidencePacketsResponse schema missing from openapi.yaml")
+	}
+	want := jsonFields(reflect.TypeOf(Response{}))
+	var missing []string
+	for field := range want {
+		if _, ok := response.Properties[field]; !ok {
+			missing = append(missing, field)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("GRCEvidencePacketsResponse missing properties for Response fields: %s", strings.Join(missing, ", "))
+	}
+}
+
+func jsonFields(t reflect.Type) map[string]struct{} {
+	fields := map[string]struct{}{}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Anonymous && field.Type.Kind() == reflect.Struct && field.Tag.Get("json") == "" {
+			for name := range jsonFields(field.Type) {
+				fields[name] = struct{}{}
+			}
+			continue
+		}
+		name := strings.Split(field.Tag.Get("json"), ",")[0]
+		if name == "" || name == "-" {
+			continue
+		}
+		fields[name] = struct{}{}
+	}
+	return fields
+}

--- a/internal/evidencepackets/packets.go
+++ b/internal/evidencepackets/packets.go
@@ -17,7 +17,17 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const ContractVersion = "2026-06-24"
+const ContractVersion = "2026-06-29"
+
+const (
+	questionnaireConfidenceSupported   = 90
+	questionnaireConfidenceReview      = 60
+	questionnaireConfidencePartial     = 50
+	questionnaireConfidenceGap         = 25
+	questionnaireConfidenceUnavailable = 20
+	questionnaireConfidenceMissing     = 10
+	questionnaireConfidenceNotRequired = 0
+)
 
 type Response struct {
 	Version     string               `json:"version"`
@@ -39,11 +49,11 @@ type Response struct {
 	Runs        []EvaluationRun      `json:"evaluation_runs"`
 	ResponseGraphRecords
 	ResponseReasoningRecords
-	Exceptions []ExceptionAcceptance     `json:"exceptions_acceptances"`
-	Artifacts  []EvidenceExportArtifact  `json:"export_artifacts"`
-	Export     EvidenceExport            `json:"export"`
-	Snapshot   AuditSnapshot             `json:"snapshot"`
-	Metadata   grccontrol.ReportMetadata `json:"metadata"`
+	ResponseQuestionnaireRecords
+	Artifacts []EvidenceExportArtifact  `json:"export_artifacts"`
+	Export    EvidenceExport            `json:"export"`
+	Snapshot  AuditSnapshot             `json:"snapshot"`
+	Metadata  grccontrol.ReportMetadata `json:"metadata"`
 }
 
 type ResponseGraphRecords struct {
@@ -54,6 +64,11 @@ type ResponseGraphRecords struct {
 type ResponseReasoningRecords struct {
 	Access    []AccessEvidenceSubject `json:"access_evidence_subjects,omitempty"`
 	Reasoning []EvidenceReasoningTask `json:"reasoning_tasks,omitempty"`
+}
+
+type ResponseQuestionnaireRecords struct {
+	Exceptions []ExceptionAcceptance `json:"exceptions_acceptances"`
+	Answers    []QuestionnaireAnswer `json:"questionnaire_answers"`
 }
 
 type AuditProgram struct {
@@ -73,6 +88,7 @@ type AuditProgram struct {
 	ClaimCount        int    `json:"claim_record_count"`
 	RunCount          int    `json:"evaluation_run_count"`
 	GraphPathCount    int    `json:"graph_path_count"`
+	AnswerCount       int    `json:"questionnaire_answer_count"`
 	OpenReviewCount   int    `json:"open_review_count"`
 }
 
@@ -99,6 +115,7 @@ type ControlPosture struct {
 
 type ControlPostureIdentity struct {
 	ID                 string `json:"id"`
+	ControlID          string `json:"control_id,omitempty"`
 	FrameworkID        string `json:"framework_id,omitempty"`
 	FrameworkName      string `json:"framework_name,omitempty"`
 	Title              string `json:"title,omitempty"`
@@ -395,6 +412,90 @@ type EvidenceExportArtifact struct {
 	Included    bool   `json:"included"`
 }
 
+type QuestionnaireAnswer struct {
+	ID                string                          `json:"id"`
+	QuestionID        string                          `json:"question_id"`
+	Question          string                          `json:"question"`
+	Answer            string                          `json:"answer"`
+	AnswerState       string                          `json:"answer_state"`
+	ReviewState       string                          `json:"review_state"`
+	Reasoning         QuestionnaireReasoningContract  `json:"reasoning_contract"`
+	Confidence        QuestionnaireAnswerConfidence   `json:"confidence"`
+	Controls          []QuestionnaireControlRef       `json:"controls"`
+	FrameworkMappings []QuestionnaireFrameworkMapping `json:"framework_mappings,omitempty"`
+	SourceEvidence    []QuestionnaireEvidenceRef      `json:"source_evidence,omitempty"`
+	PolicyDocuments   []QuestionnaireEvidenceRef      `json:"policy_documents,omitempty"`
+	EvidencePackets   []string                        `json:"evidence_packet_ids,omitempty"`
+	Citations         EvidenceCitations               `json:"citations"`
+	Freshness         EvidenceFreshness               `json:"freshness"`
+	MissingEvidence   []QuestionnaireEvidenceGap      `json:"missing_evidence,omitempty"`
+	Guardrails        []string                        `json:"guardrails,omitempty"`
+}
+
+type QuestionnaireReasoningContract struct {
+	Intent             string                    `json:"intent"`
+	Surface            string                    `json:"surface"`
+	GraphQuestion      string                    `json:"graph_question"`
+	RelevantControls   []QuestionnaireControlRef `json:"relevant_controls,omitempty"`
+	SourceCitations    []string                  `json:"source_citations,omitempty"`
+	PolicyCitations    []string                  `json:"policy_citations,omitempty"`
+	EvidencePacketIDs  []string                  `json:"evidence_packet_ids,omitempty"`
+	Freshness          EvidenceFreshness         `json:"freshness"`
+	Confidence         string                    `json:"confidence"`
+	UnsupportedClaims  []string                  `json:"unsupported_claims,omitempty"`
+	ManualReviewState  string                    `json:"manual_review_state"`
+	MissingEvidenceIDs []string                  `json:"missing_evidence_ids,omitempty"`
+}
+
+type QuestionnaireAnswerConfidence struct {
+	Level  string `json:"level"`
+	Score  int    `json:"score"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type QuestionnaireControlRef struct {
+	ID            string `json:"id"`
+	FrameworkID   string `json:"framework_id,omitempty"`
+	FrameworkName string `json:"framework_name,omitempty"`
+	ControlID     string `json:"control_id,omitempty"`
+	Title         string `json:"title,omitempty"`
+	Status        string `json:"status,omitempty"`
+}
+
+type QuestionnaireFrameworkMapping struct {
+	FrameworkID      string   `json:"framework_id,omitempty"`
+	FrameworkName    string   `json:"framework_name,omitempty"`
+	FrameworkVersion string   `json:"framework_version,omitempty"`
+	FamilyID         string   `json:"family_id,omitempty"`
+	FamilyName       string   `json:"family_name,omitempty"`
+	ControlID        string   `json:"control_id,omitempty"`
+	ControlTitle     string   `json:"control_title,omitempty"`
+	MappedRules      []string `json:"mapped_rules,omitempty"`
+}
+
+type QuestionnaireEvidenceRef struct {
+	ID               string            `json:"id"`
+	EvidencePacketID string            `json:"evidence_packet_id,omitempty"`
+	EvidenceType     string            `json:"evidence_type,omitempty"`
+	Source           string            `json:"source,omitempty"`
+	SourceID         string            `json:"source_id,omitempty"`
+	RuntimeID        string            `json:"runtime_id,omitempty"`
+	Freshness        EvidenceFreshness `json:"freshness"`
+	ReviewState      string            `json:"review_state,omitempty"`
+	Citations        EvidenceCitations `json:"citations"`
+}
+
+type QuestionnaireEvidenceGap struct {
+	ID          string `json:"id"`
+	Code        string `json:"code"`
+	Field       string `json:"field,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+	ControlID   string `json:"control_id,omitempty"`
+	RequestID   string `json:"evidence_request_id,omitempty"`
+	PacketID    string `json:"evidence_packet_id,omitempty"`
+	ReviewState string `json:"review_state,omitempty"`
+}
+
 type recordLinks struct {
 	ControlIDs []string
 	RequestIDs []string
@@ -415,6 +516,7 @@ type AuditSnapshot struct {
 	ClaimCount        int       `json:"claim_record_count"`
 	RunCount          int       `json:"evaluation_run_count"`
 	GraphPathCount    int       `json:"graph_path_count"`
+	AnswerCount       int       `json:"questionnaire_answer_count"`
 	ReviewOpenCount   int       `json:"open_review_count"`
 }
 
@@ -444,6 +546,7 @@ func Build(result grccontrol.PacketResult) Response {
 		control := ControlPosture{
 			ControlPostureIdentity: ControlPostureIdentity{
 				ID:                 controlID,
+				ControlID:          strings.TrimSpace(item.ControlID),
 				FrameworkID:        frameworkID,
 				FrameworkName:      strings.TrimSpace(item.FrameworkName),
 				Title:              strings.TrimSpace(item.Title),
@@ -528,12 +631,14 @@ func Build(result grccontrol.PacketResult) Response {
 	runs := evaluationRunsFromItems(items)
 	graphRows, graphPaths := graphRecordsFromEvidence(result.Evidence)
 	sources := collectionSources(result.Runtimes, result.SourceIDs, result.Controls, items)
+	answers := questionnaireAnswers(controls, requests, packets, items)
 	sort.Slice(controls, func(i, j int) bool { return controls[i].ID < controls[j].ID })
 	sort.Slice(requests, func(i, j int) bool { return requests[i].ID < requests[j].ID })
 	sort.Slice(packets, func(i, j int) bool { return packets[i].ID < packets[j].ID })
 	sort.Slice(reviews, func(i, j int) bool { return reviews[i].ID < reviews[j].ID })
 	sort.Slice(activity, func(i, j int) bool { return activity[i].ID < activity[j].ID })
 	sort.Slice(exceptions, func(i, j int) bool { return exceptions[i].ID < exceptions[j].ID })
+	sort.Slice(answers, func(i, j int) bool { return answers[i].ID < answers[j].ID })
 	openReviews := countOpenReviews(reviews)
 	program := AuditProgram{
 		ID:                stableID("audit-program", result.Profile.ID),
@@ -552,6 +657,7 @@ func Build(result grccontrol.PacketResult) Response {
 		ClaimCount:        len(claims),
 		RunCount:          len(runs),
 		GraphPathCount:    len(graphPaths),
+		AnswerCount:       len(answers),
 		OpenReviewCount:   openReviews,
 	}
 	snapshot := AuditSnapshot{
@@ -567,9 +673,10 @@ func Build(result grccontrol.PacketResult) Response {
 		ClaimCount:        len(claims),
 		RunCount:          len(runs),
 		GraphPathCount:    len(graphPaths),
+		AnswerCount:       len(answers),
 		ReviewOpenCount:   openReviews,
 	}
-	snapshot.Hash = snapshotHash(program, frameworks, controls, requests, packets, items, findings, resources, lineage, claims, runs, graphRows, graphPaths, exceptions)
+	snapshot.Hash = snapshotHash(program, frameworks, controls, requests, packets, items, findings, resources, lineage, claims, runs, graphRows, graphPaths, exceptions, answers)
 	export := EvidenceExport{
 		ID:        stableID("evidence-export", result.Profile.ID),
 		Formats:   []string{"json"},
@@ -599,11 +706,14 @@ func Build(result grccontrol.PacketResult) Response {
 			GraphRows:  graphRows,
 			GraphPaths: graphPaths,
 		},
-		Exceptions: exceptions,
-		Artifacts:  artifacts,
-		Export:     export,
-		Snapshot:   snapshot,
-		Metadata:   result.Metadata,
+		ResponseQuestionnaireRecords: ResponseQuestionnaireRecords{
+			Exceptions: exceptions,
+			Answers:    answers,
+		},
+		Artifacts: artifacts,
+		Export:    export,
+		Snapshot:  snapshot,
+		Metadata:  result.Metadata,
 	}
 }
 
@@ -1106,6 +1216,449 @@ func packetsForExpectation(control ControlPosture, request EvidenceRequest, item
 	return packets
 }
 
+func questionnaireAnswers(controls []ControlPosture, requests []EvidenceRequest, packets []EvidencePacket, items []EvidenceItemRecord) []QuestionnaireAnswer {
+	controlsByID := map[string]ControlPosture{}
+	for _, control := range controls {
+		controlsByID[control.ID] = control
+	}
+	packetsByRequest := map[string][]EvidencePacket{}
+	for _, packet := range packets {
+		packetsByRequest[packet.RequestID] = append(packetsByRequest[packet.RequestID], packet)
+	}
+	itemsByEvidenceID := map[string]EvidenceItemRecord{}
+	for _, item := range items {
+		itemsByEvidenceID[item.ID] = item
+	}
+	answers := make([]QuestionnaireAnswer, 0, len(requests))
+	for _, request := range requests {
+		control := controlsByID[request.ControlID]
+		answerPackets := packetsByRequest[request.ID]
+		citations := citationsForPackets(answerPackets)
+		freshness := answerFreshness(request, answerPackets)
+		gaps := answerGaps(control, request, answerPackets)
+		reviewState := answerReviewState(request, answerPackets, gaps)
+		answerState := answerState(request, answerPackets, gaps, reviewState)
+		confidence := answerConfidence(request, answerPackets, gaps, answerState)
+		controls := []QuestionnaireControlRef{questionnaireControlRef(control)}
+		sourceEvidence := answerEvidenceRefs(answerPackets, itemsByEvidenceID, false)
+		policyDocuments := answerEvidenceRefs(answerPackets, itemsByEvidenceID, true)
+		answerPacketIDs := packetIDs(answerPackets)
+		answer := QuestionnaireAnswer{
+			ID:                stableID("questionnaire-answer", request.ID),
+			QuestionID:        request.ID,
+			Question:          answerQuestion(request),
+			Answer:            answerText(control, request, answerState, sourceEvidence, policyDocuments, answerPacketIDs, freshness, gaps),
+			AnswerState:       answerState,
+			ReviewState:       reviewState,
+			Reasoning:         answerReasoningContract(request, controls, sourceEvidence, policyDocuments, answerPacketIDs, freshness, confidence, reviewState, gaps),
+			Confidence:        confidence,
+			Controls:          controls,
+			FrameworkMappings: []QuestionnaireFrameworkMapping{questionnaireFrameworkMapping(control)},
+			SourceEvidence:    sourceEvidence,
+			PolicyDocuments:   policyDocuments,
+			EvidencePackets:   answerPacketIDs,
+			Citations:         citations,
+			Freshness:         freshness,
+			MissingEvidence:   gaps,
+			Guardrails:        answerGuardrails(answerState, reviewState, gaps),
+		}
+		answers = append(answers, answer)
+	}
+	return answers
+}
+
+func answerQuestion(request EvidenceRequest) string {
+	return firstNonEmpty(request.Title, request.Description, request.Type, request.ID)
+}
+
+func answerReasoningContract(request EvidenceRequest, controls []QuestionnaireControlRef, sourceEvidence []QuestionnaireEvidenceRef, policyDocuments []QuestionnaireEvidenceRef, packetIDs []string, freshness EvidenceFreshness, confidence QuestionnaireAnswerConfidence, reviewState string, gaps []QuestionnaireEvidenceGap) QuestionnaireReasoningContract {
+	question := answerQuestion(request)
+	return QuestionnaireReasoningContract{
+		Intent:             "questionnaire_evidence_answer",
+		Surface:            "graph-reasoning",
+		GraphQuestion:      "Answer from bounded graph evidence for: " + question,
+		RelevantControls:   controls,
+		SourceCitations:    answerCitationIDs(sourceEvidence),
+		PolicyCitations:    answerCitationIDs(policyDocuments),
+		EvidencePacketIDs:  packetIDs,
+		Freshness:          freshness,
+		Confidence:         confidence.Level,
+		UnsupportedClaims:  answerUnsupportedClaims(question, gaps),
+		ManualReviewState:  reviewState,
+		MissingEvidenceIDs: missingEvidenceIDs(gaps),
+	}
+}
+
+func answerCitationIDs(refs []QuestionnaireEvidenceRef) []string {
+	ids := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		ids = append(ids, firstNonEmpty(ref.ID, ref.EvidencePacketID))
+	}
+	return uniqueStrings(ids)
+}
+
+func answerUnsupportedClaims(question string, gaps []QuestionnaireEvidenceGap) []string {
+	if len(gaps) == 0 {
+		return nil
+	}
+	claims := []string{}
+	for _, gap := range gaps {
+		switch gap.Code {
+		case "missing_required_evidence":
+			claims = append(claims, "Required evidence is missing for: "+question)
+		case "stale_evidence":
+			claims = append(claims, "Fresh source evidence is missing for: "+question)
+		case "manual_review_required":
+			claims = append(claims, "Reviewer approval is required for: "+question)
+		default:
+			claims = append(claims, "Evidence support is incomplete for: "+question)
+		}
+	}
+	return uniqueStrings(claims)
+}
+
+func missingEvidenceIDs(gaps []QuestionnaireEvidenceGap) []string {
+	ids := make([]string, 0, len(gaps))
+	for _, gap := range gaps {
+		ids = append(ids, gap.ID)
+	}
+	return uniqueStrings(ids)
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}
+
+func answerText(control ControlPosture, request EvidenceRequest, state string, sourceEvidence []QuestionnaireEvidenceRef, policyDocuments []QuestionnaireEvidenceRef, packetIDs []string, freshness EvidenceFreshness, gaps []QuestionnaireEvidenceGap) string {
+	subject := firstNonEmpty(control.Title, request.Title, control.ControlID, request.ID)
+	evidence := answerEvidenceSummary(sourceEvidence, policyDocuments, packetIDs)
+	freshnessStatus := strings.TrimSpace(freshness.Status)
+	if freshnessStatus == "" {
+		freshnessStatus = "unknown"
+	}
+	switch state {
+	case "supported":
+		return fmt.Sprintf("Supported for %s: %s. Freshness: %s.", subject, evidence, freshnessStatus)
+	case "manual_review":
+		return fmt.Sprintf("Reviewer approval required for %s: %s. Freshness: %s.", subject, evidence, freshnessStatus)
+	case "partial":
+		return fmt.Sprintf("Partial support for %s: %s. Open gaps: %d.", subject, evidence, len(gaps))
+	case "not_required":
+		return "No answer required for " + subject + " in this evidence packet."
+	default:
+		return fmt.Sprintf("Not answered for %s: %s.", subject, answerGapSummary(gaps))
+	}
+}
+
+func answerEvidenceSummary(sourceEvidence []QuestionnaireEvidenceRef, policyDocuments []QuestionnaireEvidenceRef, packetIDs []string) string {
+	parts := []string{fmt.Sprintf("%d evidence packet%s linked", len(packetIDs), pluralSuffix(len(packetIDs)))}
+	if sources := answerRefSources(sourceEvidence); len(sources) != 0 {
+		parts = append(parts, "source evidence from "+strings.Join(sources, ", "))
+	}
+	if sources := answerRefSources(policyDocuments); len(sources) != 0 {
+		parts = append(parts, "policy documents from "+strings.Join(sources, ", "))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func answerRefSources(refs []QuestionnaireEvidenceRef) []string {
+	values := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		values = append(values, firstNonEmpty(ref.SourceID, ref.Source, ref.RuntimeID, ref.EvidenceType, ref.ID))
+	}
+	return uniqueSortedStrings(values)
+}
+
+func answerGapSummary(gaps []QuestionnaireEvidenceGap) string {
+	if len(gaps) == 0 {
+		return "no linked evidence packets"
+	}
+	codes := make([]string, 0, len(gaps))
+	for _, gap := range gaps {
+		codes = append(codes, gap.Code)
+	}
+	return strings.Join(uniqueSortedStrings(codes), ", ")
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func questionnaireControlRef(control ControlPosture) QuestionnaireControlRef {
+	return QuestionnaireControlRef{
+		ID:            control.ID,
+		FrameworkID:   control.FrameworkID,
+		FrameworkName: control.FrameworkName,
+		ControlID:     control.IDFromControl(),
+		Title:         control.Title,
+		Status:        control.Status,
+	}
+}
+
+func (control ControlPosture) IDFromControl() string {
+	return strings.TrimSpace(control.ControlID)
+}
+
+func questionnaireFrameworkMapping(control ControlPosture) QuestionnaireFrameworkMapping {
+	return QuestionnaireFrameworkMapping{
+		FrameworkID:      control.FrameworkID,
+		FrameworkName:    control.FrameworkName,
+		FrameworkVersion: control.FrameworkVersion,
+		FamilyID:         control.FamilyID,
+		FamilyName:       control.FamilyName,
+		ControlID:        control.IDFromControl(),
+		ControlTitle:     control.Title,
+		MappedRules:      append([]string(nil), control.MappedRules...),
+	}
+}
+
+func answerEvidenceRefs(packets []EvidencePacket, itemsByEvidenceID map[string]EvidenceItemRecord, policyOnly bool) []QuestionnaireEvidenceRef {
+	refs := []QuestionnaireEvidenceRef{}
+	for _, packet := range packets {
+		if policyOnly != evidencePacketIsPolicyDocument(packet) {
+			continue
+		}
+		evidenceIDs := packet.Citations.EvidenceIDs
+		if len(evidenceIDs) == 0 {
+			evidenceIDs = []string{packet.ID}
+		}
+		for _, evidenceID := range evidenceIDs {
+			item := itemsByEvidenceID[strings.TrimSpace(evidenceID)]
+			refs = append(refs, QuestionnaireEvidenceRef{
+				ID:               firstNonEmpty(evidenceID, packet.ID),
+				EvidencePacketID: packet.ID,
+				EvidenceType:     packet.EvidenceType,
+				Source:           packet.Source,
+				SourceID:         item.SourceID,
+				RuntimeID:        item.RuntimeID,
+				Freshness:        packet.Freshness,
+				ReviewState:      packet.Review.Status,
+				Citations:        packet.Citations,
+			})
+		}
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].EvidencePacketID != refs[j].EvidencePacketID {
+			return refs[i].EvidencePacketID < refs[j].EvidencePacketID
+		}
+		return refs[i].ID < refs[j].ID
+	})
+	return refs
+}
+
+func evidencePacketIsPolicyDocument(packet EvidencePacket) bool {
+	switch normalizedEvidenceType(packet.EvidenceType) {
+	case "policy", "policy_document", "assurance_document", "procedure_document", "standard_document":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizedEvidenceType(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.NewReplacer(".", "_", "-", "_", " ", "_").Replace(value)
+	return strings.Trim(value, "_")
+}
+
+func answerState(request EvidenceRequest, packets []EvidencePacket, gaps []QuestionnaireEvidenceGap, reviewState string) string {
+	if !request.Required && len(packets) == 0 {
+		return "not_required"
+	}
+	if len(packets) == 0 || gapWithCode(gaps, "missing_required_evidence") {
+		return "not_answered"
+	}
+	if reviewState == "needs_review" || gapWithCode(gaps, "manual_review_required") {
+		return "manual_review"
+	}
+	if len(gaps) != 0 || request.Status != string(compliance.ControlEvidenceExpectationSatisfied) {
+		return "partial"
+	}
+	return "supported"
+}
+
+func answerReviewState(request EvidenceRequest, packets []EvidencePacket, gaps []QuestionnaireEvidenceGap) string {
+	if gapWithCode(gaps, "missing_required_evidence") {
+		return "blocked"
+	}
+	for _, packet := range packets {
+		if packet.Review.Status != "" && packet.Review.Status != "ready" && packet.Review.Status != "accepted" && packet.Review.Status != "not_required" {
+			return "needs_review"
+		}
+	}
+	if request.ReviewStatus != "" {
+		return request.ReviewStatus
+	}
+	return "ready"
+}
+
+func answerConfidence(request EvidenceRequest, packets []EvidencePacket, gaps []QuestionnaireEvidenceGap, state string) QuestionnaireAnswerConfidence {
+	switch state {
+	case "supported":
+		return QuestionnaireAnswerConfidence{Level: "high", Score: questionnaireConfidenceSupported, Reason: fmt.Sprintf("%d required evidence packet%s linked with no open gaps.", len(packets), pluralSuffix(len(packets)))}
+	case "manual_review":
+		return QuestionnaireAnswerConfidence{Level: "medium", Score: questionnaireConfidenceReview, Reason: fmt.Sprintf("%d evidence packet%s linked; reviewer approval is still required.", len(packets), pluralSuffix(len(packets)))}
+	case "partial":
+		return QuestionnaireAnswerConfidence{Level: "medium", Score: questionnaireConfidencePartial, Reason: fmt.Sprintf("%d evidence packet%s linked with %d open gap%s.", len(packets), pluralSuffix(len(packets)), len(gaps), pluralSuffix(len(gaps)))}
+	case "not_required":
+		return QuestionnaireAnswerConfidence{Level: "low", Score: questionnaireConfidenceNotRequired, Reason: "The packet marks this request as optional."}
+	}
+	if request.Required && len(packets) == 0 {
+		return QuestionnaireAnswerConfidence{Level: "low", Score: questionnaireConfidenceMissing, Reason: "Required evidence has not been collected."}
+	}
+	if len(gaps) != 0 {
+		return QuestionnaireAnswerConfidence{Level: "low", Score: questionnaireConfidenceGap, Reason: fmt.Sprintf("%d evidence gap%s prevent a supported answer.", len(gaps), pluralSuffix(len(gaps)))}
+	}
+	return QuestionnaireAnswerConfidence{Level: "low", Score: questionnaireConfidenceUnavailable, Reason: "No supported answer is available from the current packet."}
+}
+
+func answerFreshness(request EvidenceRequest, packets []EvidencePacket) EvidenceFreshness {
+	if len(packets) == 0 {
+		status := "missing"
+		if !request.Required {
+			status = "not_required"
+		}
+		return EvidenceFreshness{Status: status, SLA: request.FreshnessSLA, Reason: "No evidence packet is linked to this request."}
+	}
+	status := "fresh"
+	reason := ""
+	observedAt := ""
+	expiresAt := ""
+	for _, packet := range packets {
+		observedAt = maxTimeString(observedAt, packet.Freshness.ObservedAt)
+		expiresAt = minTimeString(expiresAt, packet.Freshness.ExpiresAt)
+		switch packet.Freshness.Status {
+		case "missing":
+			status = "missing"
+		case "stale":
+			if status != "missing" {
+				status = "stale"
+			}
+		}
+		if reason == "" && strings.TrimSpace(packet.Freshness.Reason) != "" {
+			reason = packet.Freshness.Reason
+		}
+	}
+	return EvidenceFreshness{Status: status, SLA: request.FreshnessSLA, Reason: reason, ObservedAt: observedAt, ExpiresAt: expiresAt}
+}
+
+func answerGaps(control ControlPosture, request EvidenceRequest, packets []EvidencePacket) []QuestionnaireEvidenceGap {
+	gaps := []QuestionnaireEvidenceGap{}
+	if request.Required && (len(packets) == 0 || request.Status == string(compliance.ControlEvidenceExpectationMissing)) {
+		gaps = append(gaps, QuestionnaireEvidenceGap{
+			ID:        stableID("questionnaire-gap", request.ID, "missing-required-evidence"),
+			Code:      "missing_required_evidence",
+			Field:     "evidence_packet_ids",
+			Reason:    firstNonEmpty(request.Description, "Required evidence has not been collected for this request."),
+			ControlID: control.ID,
+			RequestID: request.ID,
+		})
+	}
+	if request.Status == string(compliance.ControlEvidenceExpectationStale) {
+		gaps = append(gaps, QuestionnaireEvidenceGap{
+			ID:        stableID("questionnaire-gap", request.ID, "stale-evidence"),
+			Code:      "stale_evidence",
+			Field:     "freshness",
+			Reason:    firstNonEmpty(request.FreshnessSLA, "Evidence is outside the expected freshness window."),
+			ControlID: control.ID,
+			RequestID: request.ID,
+		})
+	}
+	for _, packet := range packets {
+		if packet.Freshness.Status == "stale" {
+			gaps = append(gaps, QuestionnaireEvidenceGap{
+				ID:        stableID("questionnaire-gap", request.ID, packet.ID, "stale-evidence"),
+				Code:      "stale_evidence",
+				Field:     "freshness",
+				Reason:    firstNonEmpty(packet.Freshness.Reason, "Evidence is outside the expected freshness window."),
+				ControlID: control.ID,
+				RequestID: request.ID,
+				PacketID:  packet.ID,
+			})
+		}
+		if packet.Review.Status != "" && packet.Review.Status != "ready" && packet.Review.Status != "accepted" && packet.Review.Status != "not_required" {
+			gaps = append(gaps, QuestionnaireEvidenceGap{
+				ID:          stableID("questionnaire-gap", request.ID, packet.ID, "manual-review"),
+				Code:        "manual_review_required",
+				Field:       "review_state",
+				Reason:      firstNonEmpty(packet.Review.Reason, "Evidence needs manual review before reliance."),
+				ControlID:   control.ID,
+				RequestID:   request.ID,
+				PacketID:    packet.ID,
+				ReviewState: packet.Review.Status,
+			})
+		}
+	}
+	sort.Slice(gaps, func(i, j int) bool { return gaps[i].ID < gaps[j].ID })
+	return gaps
+}
+
+func answerGuardrails(state string, reviewState string, gaps []QuestionnaireEvidenceGap) []string {
+	guardrails := []string{"Retain source citations with the answer."}
+	if state != "supported" {
+		guardrails = append(guardrails, "Do not present this as a complete answer.")
+	}
+	if reviewState == "needs_review" || reviewState == "blocked" {
+		guardrails = append(guardrails, "Route to a reviewer before sending outside the operating team.")
+	}
+	if len(gaps) != 0 {
+		guardrails = append(guardrails, "Show missing or stale evidence gaps with the answer.")
+	}
+	return uniqueSortedStrings(guardrails)
+}
+
+func packetIDs(packets []EvidencePacket) []string {
+	ids := make([]string, 0, len(packets))
+	for _, packet := range packets {
+		ids = append(ids, packet.ID)
+	}
+	return uniqueSortedStrings(ids)
+}
+
+func citationsForPackets(packets []EvidencePacket) EvidenceCitations {
+	citations := EvidenceCitations{}
+	for _, packet := range packets {
+		citations.EvidenceIDs = append(citations.EvidenceIDs, packet.Citations.EvidenceIDs...)
+		citations.RuleIDs = append(citations.RuleIDs, packet.Citations.RuleIDs...)
+		citations.EventIDs = append(citations.EventIDs, packet.Citations.EventIDs...)
+		citations.ClaimIDs = append(citations.ClaimIDs, packet.Citations.ClaimIDs...)
+		citations.GraphRoots = append(citations.GraphRoots, packet.Citations.GraphRoots...)
+		citations.RunIDs = append(citations.RunIDs, packet.Citations.RunIDs...)
+	}
+	citations.EvidenceIDs = uniqueSortedStrings(citations.EvidenceIDs)
+	citations.RuleIDs = uniqueSortedStrings(citations.RuleIDs)
+	citations.EventIDs = uniqueSortedStrings(citations.EventIDs)
+	citations.ClaimIDs = uniqueSortedStrings(citations.ClaimIDs)
+	citations.GraphRoots = uniqueSortedStrings(citations.GraphRoots)
+	citations.RunIDs = uniqueSortedStrings(citations.RunIDs)
+	return citations
+}
+
+func gapWithCode(gaps []QuestionnaireEvidenceGap, code string) bool {
+	for _, gap := range gaps {
+		if gap.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
 func testResults(controlID string, item grccontrol.ControlItem, evidenceIDs map[string][]string) []ControlTestResult {
 	results := make([]ControlTestResult, 0, len(item.MappedRules))
 	failingRules := failingRulesByID(item.Findings)
@@ -1377,16 +1930,58 @@ func resourceKind(urn string) string {
 }
 
 func maxTimeString(a string, b string) string {
+	a, aTime, aOK := normalizedTimeString(a)
+	b, bTime, bOK := normalizedTimeString(b)
 	if a == "" {
 		return b
 	}
 	if b == "" {
 		return a
 	}
+	if aOK && bOK {
+		if bTime.After(aTime) {
+			return b
+		}
+		return a
+	}
 	if b > a {
 		return b
 	}
 	return a
+}
+
+func minTimeString(a string, b string) string {
+	a, aTime, aOK := normalizedTimeString(a)
+	b, bTime, bOK := normalizedTimeString(b)
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if aOK && bOK {
+		if bTime.Before(aTime) {
+			return b
+		}
+		return a
+	}
+	if b < a {
+		return b
+	}
+	return a
+}
+
+func normalizedTimeString(value string) (string, time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return value, time.Time{}, false
+	}
+	parsed = parsed.UTC()
+	return parsed.Format(time.RFC3339), parsed, true
 }
 
 func protoTime(value *timestamppb.Timestamp) string {
@@ -1404,15 +1999,7 @@ func formatTimePtr(value *time.Time) string {
 }
 
 func uniqueSortedStrings(values []string) []string {
-	seen := map[string]bool{}
-	out := []string{}
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value != "" && !seen[value] {
-			seen[value] = true
-			out = append(out, value)
-		}
-	}
+	out := uniqueStrings(values)
 	sort.Strings(out)
 	return out
 }
@@ -1496,7 +2083,7 @@ func formatTime(value time.Time) string {
 	if value.IsZero() {
 		return ""
 	}
-	return value.Format(time.RFC3339)
+	return value.UTC().Format(time.RFC3339)
 }
 
 func nonEmptyStrings(values ...string) []string {

--- a/internal/evidencepackets/packets_test.go
+++ b/internal/evidencepackets/packets_test.go
@@ -1,6 +1,7 @@
 package evidencepackets
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +12,12 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestContractVersionIncludesQuestionnaireAnswerFields(t *testing.T) {
+	if ContractVersion < "2026-06-29" {
+		t.Fatalf("contract version = %q, want questionnaire answer fields advertised in 2026-06-29 or later", ContractVersion)
+	}
+}
 
 func TestBuildUsesStableFrameworkIDAndRuleScopedTestResults(t *testing.T) {
 	observedAt := time.Unix(90, 0).UTC()
@@ -207,6 +214,188 @@ func TestBuildKeepsNotApplicableFrameworkReadyAndTrimsEvidenceKeys(t *testing.T)
 	}
 	if len(response.GraphPaths) != 1 || response.GraphPaths[0].EvidenceID != "ev-space" || response.GraphPaths[0].FindingID != "finding-space" {
 		t.Fatalf("graph paths = %#v, want trimmed evidence and finding IDs", response.GraphPaths)
+	}
+}
+
+func TestBuildAddsEvidenceBackedQuestionnaireAnswers(t *testing.T) {
+	observedAt := time.Unix(300, 0).UTC()
+	nearExpiry := observedAt.Add(24 * time.Hour)
+	farExpiry := observedAt.Add(72 * time.Hour)
+	response := Build(grccontrol.PacketResult{
+		Profile: grccontrol.Profile{ID: "security-core", Name: "Security Core"},
+		Packet: compliance.ControlEvidencePacket{
+			GeneratedAt: observedAt,
+			Controls: []compliance.ControlEvidencePacketControl{{
+				Control: compliance.ControlPostureControl{FrameworkName: "SOC 2", FrameworkID: "soc2", ControlID: "CC6.1", Title: "Logical access", FamilyID: "CC6", FamilyName: "Access Controls"},
+				Status:  compliance.ControlPosturePassing,
+				Evidence: compliance.ControlEvidencePacketEvidence{
+					Expectations: []compliance.ControlEvidenceExpectationPosture{{
+						ID:           "mfa-policy",
+						Title:        "MFA enforcement",
+						Description:  "Show that MFA is enforced for privileged access.",
+						Required:     true,
+						Status:       compliance.ControlEvidenceExpectationSatisfied,
+						Quality:      compliance.ControlEvidenceQualityStrong,
+						EvidenceIDs:  []string{"ev-okta", "ev-policy"},
+						FreshnessSLA: "P30D",
+						AcceptedFrom: []string{"okta", "policy_document"},
+					}},
+					Items: []compliance.ControlEvidencePacketEvidenceItem{{
+						ID:           "ev-okta",
+						RuleID:       "okta.mfa.enforced",
+						EvidenceType: "source_snapshot",
+						Quality:      compliance.ControlEvidenceQualityStrong,
+						Source:       "policy_engine",
+						ObservedAt:   observedAt,
+						ExpiresAt:    farExpiry,
+					}, {
+						ID:           "ev-policy",
+						EvidenceType: "policy_document",
+						Quality:      compliance.ControlEvidenceQualityStrong,
+						Source:       "policy_document",
+						ObservedAt:   observedAt,
+						ExpiresAt:    nearExpiry,
+					}},
+				},
+				Readiness: compliance.ControlEvidencePacketReadiness{Score: 100, Rating: compliance.ControlEvidenceQualityStrong},
+				MappedRules: []string{
+					"okta.mfa.enforced",
+				},
+			}, {
+				Control: compliance.ControlPostureControl{FrameworkName: "SOC 2", FrameworkID: "soc2", ControlID: "CC7.2", Title: "Monitoring"},
+				Status:  compliance.ControlPostureMissingEvidence,
+				Evidence: compliance.ControlEvidencePacketEvidence{
+					Expectations: []compliance.ControlEvidenceExpectationPosture{{
+						ID:          "monitoring-review",
+						Title:       "Monitoring review",
+						Description: "Show that monitoring evidence was reviewed.",
+						Required:    true,
+						Status:      compliance.ControlEvidenceExpectationMissing,
+						Quality:     compliance.ControlEvidenceQualityMissing,
+					}},
+				},
+				Readiness: compliance.ControlEvidencePacketReadiness{Score: 25, Rating: compliance.ControlEvidenceQualityMissing, MissingEvidence: 1},
+			}},
+		},
+		Controls: []grccontrol.ControlItem{{
+			FrameworkName: "SOC 2",
+			FrameworkID:   "soc2",
+			FamilyID:      "CC6",
+			FamilyName:    "Access Controls",
+			ControlID:     "CC6.1",
+			Title:         "Logical access",
+			Status:        "passing",
+			EvidenceScore: 100,
+			MappedRules:   []string{"okta.mfa.enforced"},
+		}, {
+			FrameworkName:   "SOC 2",
+			FrameworkID:     "soc2",
+			ControlID:       "CC7.2",
+			Title:           "Monitoring",
+			Status:          "missing_evidence",
+			EvidenceScore:   25,
+			MissingEvidence: 1,
+		}},
+		Evidence: []*cerebrov1.FindingEvidence{{
+			Id:             "ev-okta",
+			RuntimeId:      "runtime-okta",
+			RuleId:         "okta.mfa.enforced",
+			RunId:          "run-okta",
+			ClaimIds:       []string{"claim-okta"},
+			EventIds:       []string{"event-okta"},
+			GraphRootUrns:  []string{"urn:cerebro:test:identity:admin"},
+			LastObservedAt: timestamppb.New(observedAt),
+		}, {
+			Id:             "ev-policy",
+			RuntimeId:      "runtime-grc",
+			ClaimIds:       []string{"claim-policy"},
+			LastObservedAt: timestamppb.New(observedAt),
+		}},
+		SourceIDs: map[string]string{"runtime-okta": "okta", "runtime-grc": "grc"},
+	})
+
+	if len(response.Answers) != 2 {
+		t.Fatalf("questionnaire answers = %d, want one per evidence request", len(response.Answers))
+	}
+	answers := map[string]QuestionnaireAnswer{}
+	for _, answer := range response.Answers {
+		answers[answer.Question] = answer
+	}
+	supported := answers["MFA enforcement"]
+	if supported.AnswerState != "supported" || supported.Confidence.Level != "high" || supported.Freshness.Status != "fresh" {
+		t.Fatalf("supported answer = %#v, want high-confidence fresh answer", supported)
+	}
+	for _, want := range []string{"2 evidence packets linked", "source evidence from okta", "policy documents from grc"} {
+		if !strings.Contains(supported.Answer, want) {
+			t.Fatalf("supported answer text = %q, want evidence detail %q", supported.Answer, want)
+		}
+	}
+	if supported.Freshness.ExpiresAt != nearExpiry.Format(time.RFC3339) {
+		t.Fatalf("freshness expires_at = %q, want nearest expiry %q", supported.Freshness.ExpiresAt, nearExpiry.Format(time.RFC3339))
+	}
+	if supported.Reasoning.Intent != "questionnaire_evidence_answer" || supported.Reasoning.Surface != "graph-reasoning" {
+		t.Fatalf("reasoning contract = %#v, want graph-backed questionnaire intent", supported.Reasoning)
+	}
+	if supported.Reasoning.Confidence != "high" || supported.Reasoning.ManualReviewState != "ready" || len(supported.Reasoning.UnsupportedClaims) != 0 {
+		t.Fatalf("supported reasoning = %#v, want high confidence ready state without unsupported claims", supported.Reasoning)
+	}
+	if len(supported.SourceEvidence) != 1 || supported.SourceEvidence[0].SourceID != "okta" {
+		t.Fatalf("source evidence = %#v, want Okta source evidence", supported.SourceEvidence)
+	}
+	if len(supported.PolicyDocuments) != 1 || supported.PolicyDocuments[0].SourceID != "grc" {
+		t.Fatalf("policy documents = %#v, want policy document evidence", supported.PolicyDocuments)
+	}
+	if len(supported.FrameworkMappings) != 1 || supported.FrameworkMappings[0].ControlID != "CC6.1" || supported.FrameworkMappings[0].MappedRules[0] != "okta.mfa.enforced" {
+		t.Fatalf("framework mappings = %#v, want control and mapped rule", supported.FrameworkMappings)
+	}
+	if len(supported.Citations.EventIDs) != 1 || supported.Citations.EventIDs[0] != "event-okta" || len(supported.Citations.ClaimIDs) != 2 {
+		t.Fatalf("citations = %#v, want source provenance citations", supported.Citations)
+	}
+	if len(supported.Reasoning.SourceCitations) != 1 || supported.Reasoning.SourceCitations[0] != "ev-okta" {
+		t.Fatalf("source citations = %#v, want Okta evidence citation", supported.Reasoning.SourceCitations)
+	}
+	if len(supported.Reasoning.PolicyCitations) != 1 || supported.Reasoning.PolicyCitations[0] != "ev-policy" {
+		t.Fatalf("policy citations = %#v, want policy evidence citation", supported.Reasoning.PolicyCitations)
+	}
+	missing := answers["Monitoring review"]
+	if missing.AnswerState != "not_answered" || missing.ReviewState != "blocked" || len(missing.MissingEvidence) != 1 {
+		t.Fatalf("missing answer = %#v, want blocked missing-evidence state", missing)
+	}
+	if !strings.Contains(missing.Answer, "missing_required_evidence") {
+		t.Fatalf("missing answer text = %q, want gap code", missing.Answer)
+	}
+	if missing.Reasoning.ManualReviewState != "blocked" || len(missing.Reasoning.UnsupportedClaims) == 0 || len(missing.Reasoning.MissingEvidenceIDs) != 1 {
+		t.Fatalf("missing reasoning = %#v, want unsupported claim and missing evidence id", missing.Reasoning)
+	}
+	if missing.MissingEvidence[0].Code != "missing_required_evidence" || len(missing.Guardrails) == 0 {
+		t.Fatalf("missing evidence gap = %#v guardrails=%#v, want explicit gap and guardrails", missing.MissingEvidence, missing.Guardrails)
+	}
+}
+
+func TestTimeStringAggregationComparesRFC3339Instants(t *testing.T) {
+	earlierWithOffset := "2026-01-01T23:00:00+09:00"
+	laterUTC := "2026-01-01T15:00:00Z"
+
+	if got, want := minTimeString(laterUTC, earlierWithOffset), "2026-01-01T14:00:00Z"; got != want {
+		t.Fatalf("minTimeString() = %q, want chronological earliest %q", got, want)
+	}
+	if got, want := maxTimeString(earlierWithOffset, laterUTC), laterUTC; got != want {
+		t.Fatalf("maxTimeString() = %q, want chronological latest %q", got, want)
+	}
+}
+
+func TestEvidencePacketPolicyDocumentClassificationUsesEvidenceType(t *testing.T) {
+	for _, evidenceType := range []string{"policy_document", "policy.document", "assurance-document", "procedure document"} {
+		if !evidencePacketIsPolicyDocument(EvidencePacket{EvidenceType: evidenceType}) {
+			t.Fatalf("evidence type %q not classified as policy document", evidenceType)
+		}
+	}
+	packet := EvidencePacket{
+		EvidenceType: "source_snapshot",
+		Reason:       "Required policy document evidence is missing.",
+	}
+	if evidencePacketIsPolicyDocument(packet) {
+		t.Fatalf("source evidence classified as policy document from reason text")
 	}
 }
 

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -248,9 +248,10 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 
 func (s *Service) validateConversion(ctx context.Context, conversion conversionResult, cypher string, params map[string]any) (ValidatorResult, int, error) {
 	validator := s.validator
-	if usesPostProcessingCandidates(conversion) && validator != nil && validator.options.MaxRows < postProcessingCandidateRowLimit {
+	candidateLimit := postProcessingCandidateLimit(conversion)
+	if usesPostProcessingCandidates(conversion) && validator != nil && validator.options.MaxRows < candidateLimit {
 		options := validator.options
-		options.MaxRows = postProcessingCandidateRowLimit
+		options.MaxRows = candidateLimit
 		validator = NewValidator(validator.store, options)
 	}
 	return validator.validate(ctx, cypher, params)
@@ -385,11 +386,33 @@ func cypherRowsToMaps(rows []ports.CypherRow) []map[string]any {
 
 func sanitizeInternalRowFields(rows []map[string]any) {
 	for _, row := range rows {
+		if questionnaireEvidenceRow(row) {
+			mergeInternalAttributesWithPrefix(row, "control_attributes_json_internal", "control_", []string{"control_id", "control_external_id", "policy_id", "policy_type", "status", "source_system"})
+			mergeInternalAttributesWithPrefix(row, "support_attributes_json_internal", "support_", []string{"evidence_type", "document_type", "policy_document_type", "policy_type", "questionnaire_type", "status", "source_system"})
+			mergeInternalAttributesWithPrefix(row, "evidence_attributes_json_internal", "evidence_", []string{"evidence_id", "evidence_type", "document_type", "policy_document_type", "status", "source_system"})
+			mergeInternalAttributesWithPrefix(row, "direct_evidence_attributes_json_internal", "direct_evidence_", []string{"evidence_id", "evidence_type", "document_type", "policy_document_type", "status", "source_system"})
+			mergeInternalAttributesWithPrefix(row, "finding_attributes_json_internal", "finding_", []string{"summary", "status", "severity", "effective_severity", "risk_score"})
+			mergeInternalAttributesWithPrefix(row, "exception_attributes_json_internal", "exception_", []string{"status", "exception_id", "expires_at", "owner_id", "source_system"})
+			mergeInternalAttributesWithPrefix(row, "source_attributes_json_internal", "source_", []string{"status", "health", "last_sync_at", "last_sync_minutes", "last_success_at", "last_error"})
+			mergeInternalAttributes(row, "relation_attributes_json_internal", []string{"severity", "effective_severity", "risk_score"})
+			removeRawAttributeJSONFields(row)
+			continue
+		}
 		mergeInternalAttributes(row, "finding_attributes_json_internal", []string{"summary", "status", "severity", "effective_severity", "risk_score"})
+		mergeInternalAttributesWithPrefix(row, "exception_attributes_json_internal", "exception_", []string{"status", "exception_id", "expires_at", "owner_id", "source_system"})
 		mergeInternalAttributes(row, "relation_attributes_json_internal", []string{"severity", "effective_severity", "risk_score"})
 		mergeInternalAttributes(row, "source_attributes_json_internal", []string{"status", "health", "last_sync_at", "last_sync_minutes", "last_success_at", "last_error"})
 		removeRawAttributeJSONFields(row)
 	}
+}
+
+func questionnaireEvidenceRow(row map[string]any) bool {
+	for _, key := range []string{"control_attributes_json_internal", "support_attributes_json_internal", "evidence_attributes_json_internal"} {
+		if _, ok := row[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func removeRawAttributeJSONFields(row map[string]any) {
@@ -504,17 +527,40 @@ func postProcessAskRows(conversion conversionResult, rows []map[string]any) []ma
 		return postProcessTopRiskFindingRows(conversion.Plan, rows)
 	case IntentFailingControls:
 		return postProcessFailingControlRows(conversion.Plan, rows)
+	case IntentQuestionnaireEvidence:
+		return postProcessQuestionnaireEvidenceRows(conversion.Plan, rows)
 	default:
 		return rows
 	}
 }
 
 func usesPostProcessingCandidates(conversion conversionResult) bool {
-	return conversion.Deterministic && (conversion.Plan.Intent == IntentAggregateFindingsBySource || conversion.Plan.Intent == IntentTopRiskFindings || conversion.Plan.Intent == IntentFailingControls)
+	if !conversion.Deterministic {
+		return false
+	}
+	switch conversion.Plan.Intent {
+	case IntentAggregateFindingsBySource, IntentTopRiskFindings, IntentFailingControls, IntentQuestionnaireEvidence:
+		return true
+	default:
+		return false
+	}
 }
 
 func postProcessingCandidateLimitHit(conversion conversionResult, rows []ports.CypherRow, rowLimit int) bool {
-	return usesPostProcessingCandidates(conversion) && rowLimit >= postProcessingCandidateRowLimit && len(rows) >= rowLimit
+	candidateLimit := postProcessingCandidateLimit(conversion)
+	return usesPostProcessingCandidates(conversion) && rowLimit >= candidateLimit && len(rows) >= rowLimit
+}
+
+func postProcessingCandidateLimit(conversion conversionResult) int {
+	if !usesPostProcessingCandidates(conversion) {
+		return defaultMaxRows
+	}
+	switch conversion.Plan.Intent {
+	case IntentQuestionnaireEvidence:
+		return questionnaireEvidenceCandidateRowLimit
+	default:
+		return postProcessingCandidateRowLimit
+	}
 }
 
 func postProcessFindingSourceRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {
@@ -802,6 +848,41 @@ func postProcessFailingControlRows(plan AskQueryPlan, rows []map[string]any) []m
 	return result
 }
 
+func postProcessQuestionnaireEvidenceRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {
+	limit := postProcessedRowLimit(plan)
+	result := make([]map[string]any, 0, limit)
+	seen := map[string]struct{}{}
+	for index, row := range rows {
+		key := questionnaireEvidenceCandidateKey(row, index)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, row)
+		if len(result) >= limit {
+			break
+		}
+	}
+	return result
+}
+
+func questionnaireEvidenceCandidateKey(row map[string]any, index int) string {
+	parts := []string{
+		stringRowValue(row, "control_urn"),
+		stringRowValue(row, "support_urn"),
+		stringRowValue(row, "evidence_urn"),
+		stringRowValue(row, "finding_urn"),
+		stringRowValue(row, "exception_urn"),
+		stringRowValue(row, "source_urn"),
+	}
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			return strings.Join(parts, "\x00")
+		}
+	}
+	return fmt.Sprintf("row:%d", index)
+}
+
 func failingControlRefsFromAttributes(attrs ...map[string]any) []failingControlRef {
 	seen := map[string]struct{}{}
 	var refs []failingControlRef
@@ -942,6 +1023,10 @@ func severityName(rank int) string {
 }
 
 func mergeInternalAttributes(row map[string]any, key string, fields []string) {
+	mergeInternalAttributesWithPrefix(row, key, "", fields)
+}
+
+func mergeInternalAttributesWithPrefix(row map[string]any, key string, prefix string, fields []string) {
 	raw, ok := row[key].(string)
 	delete(row, key)
 	if !ok || strings.TrimSpace(raw) == "" {
@@ -952,7 +1037,14 @@ func mergeInternalAttributes(row map[string]any, key string, fields []string) {
 		return
 	}
 	for _, field := range fields {
-		if !rowValueEmpty(row[field]) {
+		outputField := prefixedAttributeField(prefix, field)
+		if !rowValueEmpty(row[outputField]) && strings.TrimSpace(prefix) != "" {
+			collisionField := strings.TrimSpace(prefix) + strings.TrimSpace(field)
+			if collisionField != outputField {
+				outputField = collisionField
+			}
+		}
+		if !rowValueEmpty(row[outputField]) {
 			continue
 		}
 		value, ok := attrs[field]
@@ -960,9 +1052,22 @@ func mergeInternalAttributes(row map[string]any, key string, fields []string) {
 			continue
 		}
 		if text, ok := internalAttributeText(value); ok {
-			row[field] = text
+			row[outputField] = text
 		}
 	}
+}
+
+func prefixedAttributeField(prefix string, field string) string {
+	prefix = strings.TrimSpace(prefix)
+	field = strings.TrimSpace(field)
+	if prefix == "" || field == "" {
+		return field
+	}
+	base := strings.TrimSuffix(prefix, "_")
+	if base != "" && strings.HasPrefix(field, base+"_") {
+		return field
+	}
+	return prefix + field
 }
 
 func internalAttributeText(value any) (string, bool) {
@@ -1149,13 +1254,14 @@ func unsupportedQuery(reason string, traceID string, code string) UnsupportedQue
 	return UnsupportedQuery{
 		Code:             firstNonEmpty(code, unsupportedQueryCode(reason)),
 		Reason:           reason,
-		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentFailingControls, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth},
+		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentFailingControls, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth, IntentQuestionnaireEvidence},
 		SuggestedRewrites: []string{
 			"Summarize open high-risk findings and cite the affected entities.",
 			"Show controls with open findings and cite the affected resources.",
 			"Count findings by source family.",
 			"Show source health and freshness for security integrations.",
 			"Explain the evidence for a specific finding URN.",
+			"Answer an Okta MFA questionnaire item from bounded graph evidence.",
 		},
 		TraceID: traceID,
 	}

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -131,6 +131,135 @@ func TestServiceUsesDeterministicFastPathForCommonTopRiskAsk(t *testing.T) {
 	}
 }
 
+func TestServiceUsesGraphEvidenceBeforeQuestionnaireSummary(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"control_urn":                              "urn:cerebro:writer:policy:control:iam-1",
+				"control_label":                            "Access control",
+				"control_ref":                              "IAM-1",
+				"control_attributes_json_internal":         `{"policy_type":"control","control_id":"IAM-1","status":"monitored"}`,
+				"support_urn":                              "urn:cerebro:writer:okta_policy_rule:mfa-global",
+				"support_label":                            "Okta MFA rule",
+				"support_type":                             "okta.policy_rule",
+				"support_source_id":                        "okta",
+				"support_relation":                         "supports",
+				"support_attributes_json_internal":         `{"status":"active","source_system":"okta"}`,
+				"evidence_urn":                             "urn:cerebro:writer:runtime_evidence:okta-mfa-snapshot",
+				"evidence_label":                           "Okta MFA snapshot",
+				"evidence_type":                            "runtime_evidence",
+				"evidence_source_id":                       "okta",
+				"evidence_relation":                        "has_evidence",
+				"evidence_attributes_json_internal":        `{"evidence_type":"okta_policy","status":"ready"}`,
+				"direct_evidence_urn":                      "urn:cerebro:writer:runtime_evidence:okta-direct-control",
+				"direct_evidence_label":                    "Okta direct control evidence",
+				"direct_evidence_type":                     "runtime_evidence",
+				"direct_evidence_source_id":                "okta",
+				"direct_evidence_relation":                 "has_evidence",
+				"direct_evidence_attributes_json_internal": `{"evidence_type":"okta_control","status":"reviewed","source_system":"okta"}`,
+				"source_urn":                               "urn:cerebro:writer:source:okta",
+				"source_label":                             "Okta",
+				"source_attributes_json_internal":          `{"status":"healthy","last_sync_at":"2026-06-29T12:00:00Z"}`,
+			},
+		}},
+	}
+	llm := &StubLLMClient{
+		DraftErr: errors.New("draft should be skipped"),
+		Summary:  "Okta MFA is supported by `urn:cerebro:writer:runtime_evidence:okta-mfa-snapshot`; review any uncovered lifecycle claims manually.",
+	}
+	service := NewServiceWithOptions(store, llm, ValidatorOptions{}, ServiceOptions{EnableDeterministicFastPath: true})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "Does Okta enforce MFA for access?",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
+	if len(llm.DraftRequests) != 0 {
+		t.Fatalf("DraftCypher called %#v, want deterministic graph retrieval before LLM summary", llm.DraftRequests)
+	}
+	if len(llm.SummaryRequests) != 1 {
+		t.Fatalf("Summary requests = %#v, want one grounded LLM summary", llm.SummaryRequests)
+	}
+	planEvent := events[2].Data.(QueryPlanEvent)
+	if planEvent.Plan.Intent != IntentQuestionnaireEvidence || planEvent.Source != "deterministic_fast_path" {
+		t.Fatalf("query plan event = %#v, want questionnaire evidence fast path", planEvent)
+	}
+	if !strings.Contains(store.requests[0].Query, `questionnaire_match_text =~ '(?s).*\\bokta\\b.*'`) || !strings.Contains(store.requests[0].Query, "relation: 'has_evidence'") {
+		t.Fatalf("store request did not retrieve bounded questionnaire graph evidence:\n%s", store.requests[0].Query)
+	}
+	if store.requests[0].RowLimit != questionnaireEvidenceCandidateRowLimit {
+		t.Fatalf("store row limit = %d, want questionnaire candidate row limit %d", store.requests[0].RowLimit, questionnaireEvidenceCandidateRowLimit)
+	}
+	rowsEvent := events[6].Data.(RowsEvent)
+	for field, want := range map[string]any{
+		"control_status":                "monitored",
+		"support_status":                "active",
+		"evidence_type":                 "runtime_evidence",
+		"evidence_evidence_type":        "okta_policy",
+		"evidence_status":               "ready",
+		"direct_evidence_status":        "reviewed",
+		"direct_evidence_evidence_type": "okta_control",
+		"direct_evidence_source_system": "okta",
+		"source_status":                 "healthy",
+		"source_last_sync_at":           "2026-06-29T12:00:00Z",
+	} {
+		if got := rowsEvent.Rows[0][field]; got != want {
+			t.Fatalf("%s = %#v, want %#v in sanitized questionnaire row %#v", field, got, want, rowsEvent.Rows[0])
+		}
+	}
+	if got := rowsEvent.Rows[0]["status"]; got != nil {
+		t.Fatalf("status = %#v, want no unprefixed status collision in questionnaire row %#v", got, rowsEvent.Rows[0])
+	}
+	if _, leaked := rowsEvent.Rows[0]["source_attributes_json_internal"]; leaked {
+		t.Fatalf("rows leaked raw source attributes: %#v", rowsEvent.Rows[0])
+	}
+	if _, leaked := rowsEvent.Rows[0]["direct_evidence_attributes_json_internal"]; leaked {
+		t.Fatalf("rows leaked raw direct evidence attributes: %#v", rowsEvent.Rows[0])
+	}
+	summaryEvent := events[8].Data.(SummaryEvent)
+	if len(summaryEvent.Citations) != 1 || summaryEvent.Citations[0].URN != "urn:cerebro:writer:runtime_evidence:okta-mfa-snapshot" {
+		t.Fatalf("citations = %#v, want cited evidence urn", summaryEvent.Citations)
+	}
+}
+
+func TestPostProcessQuestionnaireEvidenceRowsDeduplicatesAndLimitsCandidates(t *testing.T) {
+	rows := []map[string]any{
+		{
+			"control_urn":  "urn:cerebro:writer:policy:control:ac-1",
+			"support_urn":  "urn:cerebro:writer:runtime_evidence:support-1",
+			"evidence_urn": "urn:cerebro:writer:runtime_evidence:evidence-1",
+		},
+		{
+			"control_urn":  "urn:cerebro:writer:policy:control:ac-1",
+			"support_urn":  "urn:cerebro:writer:runtime_evidence:support-1",
+			"evidence_urn": "urn:cerebro:writer:runtime_evidence:evidence-1",
+		},
+		{
+			"control_urn":  "urn:cerebro:writer:policy:control:ac-2",
+			"support_urn":  "urn:cerebro:writer:runtime_evidence:support-2",
+			"evidence_urn": "urn:cerebro:writer:runtime_evidence:evidence-2",
+		},
+	}
+
+	result := postProcessQuestionnaireEvidenceRows(AskQueryPlan{Intent: IntentQuestionnaireEvidence, Limit: 2}, rows)
+	if len(result) != 2 {
+		t.Fatalf("rows = %#v, want two distinct questionnaire candidates", result)
+	}
+	if got := result[0]["control_urn"]; got != "urn:cerebro:writer:policy:control:ac-1" {
+		t.Fatalf("first control_urn = %#v, want first distinct candidate", got)
+	}
+	if got := result[1]["control_urn"]; got != "urn:cerebro:writer:policy:control:ac-2" {
+		t.Fatalf("second control_urn = %#v, want second distinct candidate", got)
+	}
+}
+
 func TestValidateRequestRejectsUnsupportedModel(t *testing.T) {
 	err := ValidateRequest(AskRequest{
 		TenantID: "writer",
@@ -213,6 +342,12 @@ func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
 	summary := events[5].Data.(SummaryEvent)
 	if summary.UnsupportedQuery == nil || summary.UnsupportedQuery.Code != "validator_refusal" || len(summary.UnsupportedQuery.SuggestedRewrites) == 0 {
 		t.Fatalf("unsupported query rescue = %#v, want validator refusal with structured suggestions", summary.UnsupportedQuery)
+	}
+	if !stringSliceContains(summary.UnsupportedQuery.SupportedIntents, IntentQuestionnaireEvidence) {
+		t.Fatalf("supported intents = %#v, want questionnaire evidence intent", summary.UnsupportedQuery.SupportedIntents)
+	}
+	if !stringSliceContains(summary.UnsupportedQuery.SuggestedRewrites, "Answer an Okta MFA questionnaire item from bounded graph evidence.") {
+		t.Fatalf("suggested rewrites = %#v, want questionnaire evidence rewrite", summary.UnsupportedQuery.SuggestedRewrites)
 	}
 	if !stringSliceContains(summary.UnsupportedQuery.SupportedIntents, IntentFailingControls) {
 		t.Fatalf("supported intents = %#v, want failing controls intent", summary.UnsupportedQuery.SupportedIntents)
@@ -766,6 +901,57 @@ func TestServiceSanitizesInternalSourceAttributes(t *testing.T) {
 	}
 	if len(store.requests) != 1 || !strings.Contains(store.requests[0].Query, "source_attributes_json_internal") {
 		t.Fatalf("store request = %#v, want internal source attributes", store.requests)
+	}
+}
+
+func TestServiceKeepsExceptionOnlyRowsOnNonQuestionnaireAttributePath(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"exception_urn":                      "urn:cerebro:writer:exception:exc-1",
+				"exception_label":                    "Accepted exception",
+				"exception_attributes_json_internal": `{"status":"accepted","exception_id":"exc-1","owner_id":"security"}`,
+			},
+		}},
+	}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Checking accepted exceptions.",
+			Cypher: `MATCH (exception:Entity {tenant_id: $tenant_id})
+RETURN exception.urn AS exception_urn,
+       coalesce(exception.label, exception.urn) AS exception_label,
+       coalesce(exception.attributes_json, '') AS exception_attributes_json_internal
+LIMIT 25`,
+		},
+		Summary: "Accepted exception is present.",
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "Show accepted exceptions",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
+	rowsEvent := events[6].Data.(RowsEvent)
+	row := rowsEvent.Rows[0]
+	if _, exists := row["exception_attributes_json_internal"]; exists {
+		t.Fatalf("internal exception attributes leaked in row: %#v", row)
+	}
+	if _, exists := row["status"]; exists {
+		t.Fatalf("exception-only non-questionnaire row used ambiguous status field: %#v", row)
+	}
+	if got := row["exception_status"]; got != "accepted" {
+		t.Fatalf("exception_status = %q, want accepted", got)
+	}
+	if got := row["exception_id"]; got != "exc-1" {
+		t.Fatalf("exception_id = %q, want exc-1", got)
 	}
 }
 

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -69,6 +69,34 @@ var canonicalGraphOntology = GraphOntology{
 			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
 			Examples:    []string{"urn:cerebro:writer:source:github"},
 		},
+		{
+			Type:        "policy",
+			Description: "GRC policy, control, and policy-document anchors. Control nodes use attributes_json.policy_type = 'control'.",
+			Aliases:     []string{"control", "grc control", "policy", "policy document"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:policy:control:ac-1"},
+		},
+		{
+			Type:        "runtime_evidence",
+			Description: "Runtime evidence object linked from a source fact, policy, control, or assurance artifact through has_evidence.",
+			Aliases:     []string{"runtime evidence", "evidence packet", "source evidence"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:runtime_evidence:evidence-1"},
+		},
+		{
+			Type:        "security.questionnaire",
+			Description: "GRC security questionnaire artifacts linked to controls, accounts, documents, and evidence through projected relations.",
+			Aliases:     []string{"questionnaire", "security questionnaire"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:security_questionnaire:questionnaire-1"},
+		},
+		{
+			Type:        "assurance.document",
+			Description: "Assurance and policy document evidence used for questionnaire answers and control support.",
+			Aliases:     []string{"assurance document", "policy doc", "document"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:assurance_document:soc2-report"},
+		},
 	},
 	Relations: []OntologyRelation{
 		{
@@ -106,6 +134,27 @@ var canonicalGraphOntology = GraphOntology{
 			FromTypes:   []string{"*"},
 			ToTypes:     []string{"identity.email", "identity.login"},
 		},
+		{
+			Relation:    fabriccontract.RelationSupports,
+			Description: "Evidence, policy, questionnaire, and source-fact edge to the control or object it supports.",
+			Aliases:     []string{"SUPPORTS", "control support", "mapped control"},
+			FromTypes:   []string{"*"},
+			ToTypes:     []string{"policy"},
+		},
+		{
+			Relation:    fabriccontract.RelationHasEvidence,
+			Description: "Resource or GRC artifact edge to runtime evidence or attached evidence.",
+			Aliases:     []string{"HAS_EVIDENCE", "evidence", "source evidence"},
+			FromTypes:   []string{"*"},
+			ToTypes:     []string{"runtime_evidence", "evidence"},
+		},
+		{
+			Relation:    fabriccontract.RelationAssociatedWith,
+			Description: "Association edge between GRC artifacts, findings, accounts, and related source objects.",
+			Aliases:     []string{"ASSOCIATED_WITH", "associated", "related"},
+			FromTypes:   []string{"*"},
+			ToTypes:     []string{"*"},
+		},
 	},
 }
 
@@ -122,6 +171,7 @@ func (o GraphOntology) PromptHint() string {
 	fmt.Fprintf(&b, "- Canonical identity anchors use `entity_type` values `identity.email` and `identity.login`; there is no generic `identity` entity_type or top-level `email` property. Match identity values through `urn`, `label`, or controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Connector/source health nodes use `entity_type: 'source'`; there is no `connector` entity_type and no top-level `status` or `last_sync_minutes` property. Read source health metadata from controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Finding source grouping should prefer controlled `attributes_json.source_family` string extraction, then fall back to `finding.source_id`.\n")
+	fmt.Fprintf(&b, "- Questionnaire answers must start from bounded graph evidence: controls are `policy` nodes with `attributes_json.policy_type = 'control'`, support links use relation `supports`, evidence links use relation `has_evidence`, and policy/source freshness metadata lives in `attributes_json`.\n")
 	for _, entity := range o.Entities {
 		fmt.Fprintf(&b, "- Entity `%s`: %s Aliases: %s. Useful properties: %s.\n", entity.Type, entity.Description, strings.Join(entity.Aliases, ", "), strings.Join(entity.Properties, ", "))
 		if len(entity.Examples) > 0 {

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -17,9 +18,11 @@ const (
 	IntentExplainFinding            = "explain_finding"
 	IntentIdentityBridge            = "identity_bridge"
 	IntentConnectorHealth           = "connector_health"
+	IntentQuestionnaireEvidence     = "questionnaire_evidence_answer"
 
-	postProcessingCandidateRowLimit = ports.MaxCypherQueryRows
-	confidentPlanThreshold          = 0.70
+	postProcessingCandidateRowLimit        = ports.MaxCypherQueryRows
+	questionnaireEvidenceCandidateRowLimit = postProcessingCandidateRowLimit
+	confidentPlanThreshold                 = 0.70
 )
 
 type AskQueryPlan struct {
@@ -212,6 +215,11 @@ func deterministicFastPathPlan(request AskRequest) (AskQueryPlan, bool) {
 		plan.Filters = map[string]string{}
 	case IntentAggregateFindingsBySource, IntentConnectorHealth, IntentIdentityBridge:
 		plan.Filters = map[string]string{}
+	case IntentQuestionnaireEvidence:
+		plan.Filters = fastPathQuestionnaireEvidenceFilters(question)
+		if planFilterValue(plan.Filters, "topic") == "" {
+			return AskQueryPlan{}, false
+		}
 	case IntentExplainFinding:
 		if plan.ScopeURN == "" {
 			return AskQueryPlan{}, false
@@ -248,6 +256,110 @@ func fastPathTopRiskFilters(question string) map[string]string {
 		filters["resource_type"] = "repository"
 	}
 	return filters
+}
+
+func looksLikeQuestionnaireEvidenceQuestion(haystack string) bool {
+	return planFilterValue(fastPathQuestionnaireEvidenceFilters(haystack), "topic") != ""
+}
+
+func fastPathQuestionnaireEvidenceFilters(question string) map[string]string {
+	filters := map[string]string{"answer_mode": "bounded_graph_evidence"}
+	if topic := questionnaireEvidenceTopic(question); topic != "" {
+		filters["topic"] = topic
+	}
+	return filters
+}
+
+func questionnaireEvidenceTopic(question string) string {
+	terms := newQuestionnaireEvidenceTerms(question)
+	if terms.hasFindingRetrievalContext() {
+		return ""
+	}
+	oktaContext := terms.hasAnswerContext() || terms.has("evidence") || terms.startsWith("does", "can", "do")
+	evidencePacketCoverageContext := terms.hasPhrase("evidence packet") &&
+		(terms.has("coverage") || terms.has("gap") || terms.has("gaps") || terms.has("control") || terms.has("controls"))
+	switch {
+	case terms.has("okta") && (terms.has("mfa") || terms.hasPhrase("multi factor") || terms.has("multifactor")) && oktaContext:
+		return "okta_mfa"
+	case terms.has("okta") && terms.has("lifecycle") && oktaContext:
+		return "okta_lifecycle"
+	case terms.has("okta") && terms.has("access") && oktaContext:
+		return "okta_access"
+	case (terms.hasPhrase("policy doc") || terms.hasPhrase("policy document")) && terms.hasAnswerContext():
+		return "policy_documents"
+	case (terms.hasPhrase("control coverage") ||
+		terms.hasPhrase("coverage gap") ||
+		terms.hasPhrase("evidence gap") ||
+		evidencePacketCoverageContext ||
+		terms.hasPhrase("mapped control")) &&
+		(terms.hasAnswerContext() || terms.has("show")):
+		return "control_coverage"
+	default:
+		return ""
+	}
+}
+
+type questionnaireEvidenceTerms struct {
+	normalized string
+	tokens     map[string]struct{}
+	firstToken string
+}
+
+var questionnaireEvidenceTokenPattern = regexp.MustCompile(`[a-z0-9]+`)
+
+func newQuestionnaireEvidenceTerms(question string) questionnaireEvidenceTerms {
+	normalized := strings.ToLower(strings.NewReplacer("-", " ", "_", " ", "/", " ").Replace(question))
+	tokenValues := questionnaireEvidenceTokenPattern.FindAllString(normalized, -1)
+	tokens := make(map[string]struct{}, len(tokenValues))
+	for _, token := range tokenValues {
+		tokens[token] = struct{}{}
+	}
+	firstToken := ""
+	if len(tokenValues) > 0 {
+		firstToken = tokenValues[0]
+	}
+	return questionnaireEvidenceTerms{
+		normalized: " " + strings.Join(tokenValues, " ") + " ",
+		tokens:     tokens,
+		firstToken: firstToken,
+	}
+}
+
+func (terms questionnaireEvidenceTerms) has(token string) bool {
+	_, ok := terms.tokens[strings.ToLower(strings.TrimSpace(token))]
+	return ok
+}
+
+func (terms questionnaireEvidenceTerms) hasPhrase(phrase string) bool {
+	phraseTerms := questionnaireEvidenceTokenPattern.FindAllString(strings.ToLower(phrase), -1)
+	if len(phraseTerms) == 0 {
+		return false
+	}
+	return strings.Contains(terms.normalized, " "+strings.Join(phraseTerms, " ")+" ")
+}
+
+func (terms questionnaireEvidenceTerms) startsWith(tokens ...string) bool {
+	for _, token := range tokens {
+		if terms.firstToken == strings.ToLower(strings.TrimSpace(token)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (terms questionnaireEvidenceTerms) hasAnswerContext() bool {
+	return terms.has("answer") ||
+		terms.has("answers") ||
+		terms.has("audit") ||
+		terms.has("auditor") ||
+		terms.has("compliance") ||
+		terms.has("question") ||
+		terms.has("questionnaire")
+}
+
+func (terms questionnaireEvidenceTerms) hasFindingRetrievalContext() bool {
+	return (terms.has("finding") || terms.has("findings")) &&
+		(terms.has("show") || terms.has("list") || terms.has("source") || terms.has("evidence"))
 }
 
 func containsWord(haystack string, needle string) bool {
@@ -338,6 +450,8 @@ func canonicalIntent(value string) string {
 		return IntentIdentityBridge
 	case "connector_health", "source_health", "runtime_health":
 		return IntentConnectorHealth
+	case "questionnaire_evidence_answer", "questionnaire_answer", "compliance_answer", "control_coverage":
+		return IntentQuestionnaireEvidence
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
 	}
@@ -360,6 +474,8 @@ func inferIntent(question string, cypher string) string {
 		return IntentIdentityBridge
 	case strings.Contains(haystack, "explain") && strings.Contains(haystack, "finding"):
 		return IntentExplainFinding
+	case looksLikeQuestionnaireEvidenceQuestion(haystack):
+		return IntentQuestionnaireEvidence
 	default:
 		return IntentRawCypher
 	}
@@ -506,9 +622,137 @@ RETURN source.urn AS source_urn,
        coalesce(source.attributes_json, '') AS source_attributes_json_internal
 ORDER BY source_label, source_urn
 LIMIT %d`, limit), true
+	case IntentQuestionnaireEvidence:
+		topicPredicate := questionnaireEvidenceTopicPredicate(plan.Filters)
+		if topicPredicate == "" {
+			return "", false
+		}
+		return renderQuestionnaireEvidenceQuery(topicPredicate), true
 	default:
 		return "", false
 	}
+}
+
+var questionnaireEvidenceQueryFragments = []string{
+	`MATCH (control:Entity {tenant_id: $tenant_id, entity_type: 'policy'})
+WITH control,
+     coalesce(__CONTROL_POLICY_TYPE__, '') AS control_policy_type,
+     coalesce(__CONTROL_REF__, '') AS control_ref
+WHERE control_policy_type = 'control'
+  AND CASE
+        WHEN $scope_urn = '' THEN true
+        WHEN control.urn = $scope_urn THEN true
+        ELSE false
+      END`,
+	`OPTIONAL MATCH (support:Entity {tenant_id: $tenant_id})-[supportRel:RELATION {relation: 'supports'}]->(control)
+WHERE CASE
+        WHEN $scope_urn = '' THEN true
+        WHEN support.urn = $scope_urn THEN true
+        WHEN control.urn = $scope_urn THEN true
+        ELSE false
+      END
+OPTIONAL MATCH (support)-[supportEvidenceRel:RELATION {relation: 'has_evidence'}]->(supportEvidence:Entity {tenant_id: $tenant_id})
+WITH DISTINCT control, control_ref, support, supportRel, supportEvidence, supportEvidenceRel`,
+	`OPTIONAL MATCH (control)-[controlEvidenceRel:RELATION {relation: 'has_evidence'}]->(controlEvidence:Entity {tenant_id: $tenant_id})
+WITH DISTINCT control, control_ref, support, supportRel,
+     supportEvidence,
+     supportEvidenceRel,
+     controlEvidence,
+     controlEvidenceRel,
+     coalesce(supportEvidence, controlEvidence) AS evidence,
+     coalesce(supportEvidenceRel, controlEvidenceRel) AS evidenceRel
+WHERE evidence IS NOT NULL OR support IS NOT NULL`,
+	`OPTIONAL MATCH (support)-[findingRel:RELATION]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE findingRel.relation IN ['associated_with', 'supports', 'has_finding'] OR finding IS NULL
+WITH DISTINCT control, control_ref, support, supportRel, supportEvidence, supportEvidenceRel, controlEvidence, controlEvidenceRel, evidence, evidenceRel, finding, findingRel
+OPTIONAL MATCH (exception:Entity {tenant_id: $tenant_id})-[exceptionRel:RELATION]->(control)
+WHERE exception IS NULL OR exception.entity_type CONTAINS 'exception' OR exception.urn CONTAINS 'exception'
+WITH DISTINCT control, control_ref, support, supportRel, supportEvidence, supportEvidenceRel, controlEvidence, controlEvidenceRel, evidence, evidenceRel, finding, findingRel, exception, exceptionRel`,
+	`WITH control, control_ref, support, supportRel, supportEvidence, supportEvidenceRel, controlEvidence, controlEvidenceRel, evidence, evidenceRel, finding, findingRel, exception, exceptionRel,
+     coalesce(__CONTROL_MATCH_ATTRIBUTES__, '') AS control_match_attributes,
+     coalesce(__SUPPORT_MATCH_ATTRIBUTES__, '') AS support_match_attributes,
+     coalesce(__EVIDENCE_MATCH_ATTRIBUTES__, '') AS evidence_match_attributes,
+     coalesce(__DIRECT_EVIDENCE_MATCH_ATTRIBUTES__, '') AS direct_evidence_match_attributes
+WITH control, control_ref, support, supportRel, supportEvidence, supportEvidenceRel, controlEvidence, controlEvidenceRel, evidence, evidenceRel, finding, findingRel, exception, exceptionRel,
+     toLower(coalesce(control.label, '') + ' ' +
+             coalesce(control.source_id, '') + ' ' +
+             coalesce(control_ref, '') + ' ' +
+             control_match_attributes + ' ' +
+             coalesce(support.label, '') + ' ' +
+             coalesce(support.source_id, '') + ' ' +
+             support_match_attributes + ' ' +
+             coalesce(evidence.label, '') + ' ' +
+             coalesce(evidence.source_id, '') + ' ' +
+             evidence_match_attributes + ' ' +
+             coalesce(controlEvidence.label, '') + ' ' +
+             coalesce(controlEvidence.source_id, '') + ' ' +
+             direct_evidence_match_attributes) AS questionnaire_match_text,
+     coalesce(evidence.source_id, support.source_id, control.source_id, '') AS evidence_source_id
+__TOPIC_PREDICATE__
+OPTIONAL MATCH (source:Entity {tenant_id: $tenant_id, entity_type: 'source'})
+WHERE evidence_source_id <> '' AND source.source_id = evidence_source_id`,
+	`RETURN DISTINCT control.urn AS control_urn,
+       coalesce(control.label, control_ref, control.urn) AS control_label,
+       control_ref,
+       coalesce(control.attributes_json, '') AS control_attributes_json_internal,
+       support.urn AS support_urn,
+       coalesce(support.label, support.urn) AS support_label,
+       support.entity_type AS support_type,
+       support.source_id AS support_source_id,
+       supportRel.relation AS support_relation,
+       coalesce(support.attributes_json, '') AS support_attributes_json_internal,
+       evidence.urn AS evidence_urn,
+       coalesce(evidence.label, evidence.urn) AS evidence_label,
+       evidence.entity_type AS evidence_type,
+       evidence_source_id,
+       evidenceRel.relation AS evidence_relation,
+       coalesce(evidence.attributes_json, '') AS evidence_attributes_json_internal,
+       controlEvidence.urn AS direct_evidence_urn,
+       coalesce(controlEvidence.label, controlEvidence.urn) AS direct_evidence_label,
+       controlEvidence.entity_type AS direct_evidence_type,
+       controlEvidence.source_id AS direct_evidence_source_id,
+       controlEvidenceRel.relation AS direct_evidence_relation,
+       coalesce(controlEvidence.attributes_json, '') AS direct_evidence_attributes_json_internal,
+       finding.urn AS finding_urn,
+       coalesce(finding.label, finding.urn) AS finding_label,
+       findingRel.relation AS finding_relation,
+       coalesce(finding.attributes_json, '') AS finding_attributes_json_internal,
+       exception.urn AS exception_urn,
+       coalesce(exception.label, exception.urn) AS exception_label,
+       exception.entity_type AS exception_type,
+       exceptionRel.relation AS exception_relation,
+       coalesce(exception.attributes_json, '') AS exception_attributes_json_internal,
+       source.urn AS source_urn,
+       coalesce(source.label, source.urn) AS source_label,
+       coalesce(source.attributes_json, '') AS source_attributes_json_internal
+ORDER BY control_label, support_label, evidence_label
+LIMIT __CANDIDATE_LIMIT__`,
+}
+
+func renderQuestionnaireEvidenceQuery(topicPredicate string) string {
+	return replaceQuestionnaireEvidencePlaceholders(strings.Join(questionnaireEvidenceQueryFragments, "\n"), map[string]string{
+		"__CONTROL_POLICY_TYPE__":              cypherJSONStringAttributes("control.attributes_json", "policy_type"),
+		"__CONTROL_REF__":                      cypherJSONStringAttributes("control.attributes_json", "control_external_id", "control_id", "policy_id"),
+		"__CONTROL_MATCH_ATTRIBUTES__":         cypherJSONStringAttributes("control.attributes_json", "control_external_id", "control_id", "policy_id"),
+		"__SUPPORT_MATCH_ATTRIBUTES__":         cypherJSONStringAttributes("support.attributes_json", "evidence_type", "document_type", "policy_document_type", "policy_type", "questionnaire_type", "source_system"),
+		"__EVIDENCE_MATCH_ATTRIBUTES__":        cypherJSONStringAttributes("evidence.attributes_json", "evidence_type", "document_type", "policy_document_type", "policy_type", "questionnaire_type", "source_system"),
+		"__DIRECT_EVIDENCE_MATCH_ATTRIBUTES__": cypherJSONStringAttributes("controlEvidence.attributes_json", "evidence_type", "document_type", "policy_document_type", "policy_type", "questionnaire_type", "source_system"),
+		"__TOPIC_PREDICATE__":                  topicPredicate,
+		"__CANDIDATE_LIMIT__":                  fmt.Sprint(questionnaireEvidenceCandidateRowLimit),
+	})
+}
+
+func replaceQuestionnaireEvidencePlaceholders(template string, values map[string]string) string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	replacements := make([]string, 0, len(keys)*2)
+	for _, key := range keys {
+		replacements = append(replacements, key, values[key])
+	}
+	return strings.NewReplacer(replacements...).Replace(template)
 }
 
 func cypherJSONStringAttributes(expression string, keys ...string) string {
@@ -571,6 +815,46 @@ func resourceTypePredicate(value string) string {
 	}
 }
 
+func questionnaireEvidenceTopicPredicate(filters map[string]string) string {
+	switch strings.ToLower(planFilterValue(filters, "topic")) {
+	case "okta_mfa":
+		return `WHERE CASE
+        WHEN NOT ` + questionnaireMatchWordPredicate("okta") + ` THEN false
+        WHEN ` + questionnaireMatchWordPredicate("mfa") + ` THEN true
+        WHEN questionnaire_match_text CONTAINS 'multi factor' THEN true
+        WHEN questionnaire_match_text CONTAINS 'multi-factor' THEN true
+        WHEN ` + questionnaireMatchWordPredicate("multifactor") + ` THEN true
+        ELSE false
+      END`
+	case "okta_lifecycle":
+		return `WHERE CASE
+        WHEN NOT ` + questionnaireMatchWordPredicate("okta") + ` THEN false
+        WHEN ` + questionnaireMatchWordPredicate("lifecycle") + ` THEN true
+        WHEN ` + questionnaireMatchWordPredicate("deprovision") + ` THEN true
+        WHEN ` + questionnaireMatchWordPredicate("provision") + ` THEN true
+        ELSE false
+      END`
+	case "okta_access":
+		return `WHERE CASE
+        WHEN NOT ` + questionnaireMatchWordPredicate("okta") + ` THEN false
+        WHEN ` + questionnaireMatchWordPredicate("access") + ` THEN true
+        WHEN ` + questionnaireMatchWordPredicate("sso") + ` THEN true
+        WHEN ` + questionnaireMatchWordPredicate("group") + ` THEN true
+        ELSE false
+      END`
+	case "policy_documents":
+		return "WHERE questionnaire_match_text CONTAINS 'policy document' OR questionnaire_match_text CONTAINS 'policy_document' OR " + questionnaireMatchWordPredicate("document")
+	case "control_coverage":
+		return "WHERE " + questionnaireMatchWordPredicate("coverage") + " OR questionnaire_match_text CONTAINS 'coverage_gap' OR " + questionnaireMatchWordPredicate("gap") + " OR " + questionnaireMatchWordPredicate("missing")
+	default:
+		return ""
+	}
+}
+
+func questionnaireMatchWordPredicate(word string) string {
+	return "questionnaire_match_text =~ '(?s).*\\\\b" + regexp.QuoteMeta(strings.ToLower(word)) + "\\\\b.*'"
+}
+
 func planFilterValue(filters map[string]string, key string) string {
 	for filterKey, value := range filters {
 		if strings.EqualFold(filterKey, key) {
@@ -596,6 +880,10 @@ func hasUnsupportedDeterministicModifiers(plan AskQueryPlan) bool {
 		switch plan.Intent {
 		case IntentTopRiskFindings:
 			if normalized != "severity" && normalized != "status" && normalized != "resource_type" && normalized != "entity_type" {
+				return true
+			}
+		case IntentQuestionnaireEvidence:
+			if normalized != "topic" && normalized != "answer_mode" {
 				return true
 			}
 		case IntentFailingControls:

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -2,6 +2,7 @@ package graphagent
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -489,6 +490,237 @@ func TestConvertDraftToQueryScopesConnectorHealthTemplate(t *testing.T) {
 	}
 }
 
+func TestConvertDraftToQueryUsesQuestionnaireEvidenceTemplate(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Answer this Okta MFA questionnaire item from evidence",
+	}, &DraftResponse{
+		Plan: &AskQueryPlan{Intent: IntentQuestionnaireEvidence, Filters: map[string]string{"topic": "okta_mfa"}, Limit: 25},
+	})
+
+	if result.Plan.Intent != IntentQuestionnaireEvidence || !result.Deterministic {
+		t.Fatalf("conversion result = %#v, want deterministic questionnaire evidence template", result)
+	}
+	for _, want := range []string{
+		"control_policy_type = 'control'",
+		"relation: 'supports'",
+		"relation: 'has_evidence'",
+		`questionnaire_match_text =~ '(?s).*\\bokta\\b.*'`,
+		`questionnaire_match_text =~ '(?s).*\\bmfa\\b.*'`,
+		"OPTIONAL MATCH (support)-[supportEvidenceRel:RELATION {relation: 'has_evidence'}]->(supportEvidence:Entity {tenant_id: $tenant_id})",
+		"OPTIONAL MATCH (control)-[controlEvidenceRel:RELATION {relation: 'has_evidence'}]->(controlEvidence:Entity {tenant_id: $tenant_id})",
+		"WITH DISTINCT control, control_ref, support, supportRel, supportEvidence, supportEvidenceRel",
+		"coalesce(supportEvidence, controlEvidence) AS evidence",
+		"coalesce(supportEvidenceRel, controlEvidenceRel) AS evidenceRel",
+		"controlEvidence.urn AS direct_evidence_urn",
+		"direct_evidence_attributes_json_internal",
+		"RETURN DISTINCT control.urn AS control_urn",
+		"evidence_source_id,",
+		"source_attributes_json_internal",
+		"exception_attributes_json_internal",
+		"finding_attributes_json_internal",
+		"LIMIT " + strconv.Itoa(questionnaireEvidenceCandidateRowLimit),
+	} {
+		if !strings.Contains(result.Cypher, want) {
+			t.Fatalf("questionnaire cypher missing %q:\n%s", want, result.Cypher)
+		}
+	}
+	for _, forbidden := range []string{
+		"control.status",
+		"support.status",
+		"evidence.status",
+		"source.last_sync_at",
+		"coalesce(support.entity_type, '') +",
+		"coalesce(evidence.entity_type, '') +",
+		"coalesce(controlEvidence.entity_type, '') +",
+		"coalesce(control.attributes_json, '') +",
+		"coalesce(support.attributes_json, '') +",
+		"coalesce(evidence.attributes_json, '')) AS questionnaire_match_text",
+		"OPTIONAL MATCH (support:Entity {tenant_id: $tenant_id})-[supportEvidenceRel",
+		"OPTIONAL MATCH (control:Entity {tenant_id: $tenant_id})-[controlEvidenceRel",
+		"OPTIONAL MATCH (support:Entity {tenant_id: $tenant_id})-[findingRel",
+		"OPTIONAL MATCH (exception:Entity {tenant_id: $tenant_id})-[exceptionRel:RELATION]->(control:Entity",
+	} {
+		if strings.Contains(result.Cypher, forbidden) {
+			t.Fatalf("questionnaire template references non-projected top-level field %q:\n%s", forbidden, result.Cypher)
+		}
+	}
+}
+
+func TestInferIntentRoutesQuestionnairePromptsToGraphEvidence(t *testing.T) {
+	for _, question := range []string{
+		"Does Okta enforce MFA for access?",
+		"Answer the Okta access control question",
+		"Explain Okta lifecycle evidence for user deprovisioning",
+		"Answer this policy document questionnaire item",
+		"Show control coverage evidence gaps",
+		"Show the control evidence packet coverage",
+	} {
+		if got := inferIntent(question, ""); got != IntentQuestionnaireEvidence {
+			t.Fatalf("inferIntent(%q) = %q, want %q", question, got, IntentQuestionnaireEvidence)
+		}
+	}
+	if got := inferIntent("Which identities bridge Okta and GitHub access?", ""); got != IntentIdentityBridge {
+		t.Fatalf("inferIntent(identity bridge access) = %q, want %q", got, IntentIdentityBridge)
+	}
+	if got := inferIntent("Explain the Okta access finding", ""); got != IntentExplainFinding {
+		t.Fatalf("inferIntent(okta finding explanation) = %q, want %q", got, IntentExplainFinding)
+	}
+}
+
+func TestInferIntentLeavesGenericControlEvidencePromptsForLLMPlanning(t *testing.T) {
+	for _, question := range []string{
+		"Show source evidence for access control findings",
+		"What evidence supports this control gap?",
+		"Do we have control evidence for access management?",
+		"List controls with evidence attached",
+		"What is in the evidence packet for this finding?",
+		"Show the evidence packet export status",
+		"List all policy documents",
+		"Show policy doc count",
+		"Answer this security questionnaire item",
+		"Is data encrypted at rest in S3?",
+		"Show source evidence for Okta access findings",
+		"Audit answer for access posture",
+	} {
+		if got := inferIntent(question, ""); got != IntentRawCypher {
+			t.Fatalf("inferIntent(%q) = %q, want %q", question, got, IntentRawCypher)
+		}
+	}
+}
+
+func TestQuestionnaireFastPathRequiresResolvedTopic(t *testing.T) {
+	for _, question := range []string{
+		"Answer this security questionnaire item",
+		"Can we answer this questionnaire item?",
+	} {
+		if result, _, ok := deterministicFastPathConversion(AskRequest{TenantID: "writer", Question: question}, true); ok {
+			t.Fatalf("deterministicFastPathConversion(%q) = %#v, want LLM planning fallback", question, result)
+		}
+	}
+}
+
+func TestQuestionnaireTemplateRequiresTopicFilter(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Answer this security questionnaire item",
+	}, &DraftResponse{Plan: &AskQueryPlan{Intent: IntentQuestionnaireEvidence, Limit: 25}})
+	if result.Cypher != "" || result.Source != "conversion_refusal" {
+		t.Fatalf("conversion result = %#v, want refusal without questionnaire topic", result)
+	}
+}
+
+func TestQuestionnairePromptsUseDeterministicGraphRetrieval(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		question    string
+		wantTopic   string
+		wantSnippet string
+	}{
+		{name: "okta mfa", question: "Does Okta enforce MFA for access?", wantTopic: "okta_mfa", wantSnippet: `questionnaire_match_text =~ '(?s).*\\bmfa\\b.*'`},
+		{name: "okta access", question: "Answer the Okta access control question", wantTopic: "okta_access", wantSnippet: `questionnaire_match_text =~ '(?s).*\\baccess\\b.*'`},
+		{name: "okta lifecycle", question: "Explain Okta lifecycle evidence for deprovisioning", wantTopic: "okta_lifecycle", wantSnippet: `questionnaire_match_text =~ '(?s).*\\blifecycle\\b.*'`},
+		{name: "policy docs", question: "Answer this policy document questionnaire item", wantTopic: "policy_documents", wantSnippet: "questionnaire_match_text CONTAINS 'policy_document'"},
+		{name: "hyphenated policy docs", question: "Answer this policy-document questionnaire item", wantTopic: "policy_documents", wantSnippet: "questionnaire_match_text CONTAINS 'policy_document'"},
+		{name: "coverage gap", question: "Show control coverage evidence gaps", wantTopic: "control_coverage", wantSnippet: `questionnaire_match_text =~ '(?s).*\\bcoverage\\b.*'`},
+		{name: "hyphenated coverage gap", question: "Show control-coverage evidence-gaps", wantTopic: "control_coverage", wantSnippet: `questionnaire_match_text =~ '(?s).*\\bcoverage\\b.*'`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _, ok := deterministicFastPathConversion(AskRequest{TenantID: "writer", Question: tt.question}, true)
+			if !ok || !result.Deterministic || result.Source != "deterministic_fast_path" {
+				t.Fatalf("deterministicFastPathConversion() = %#v, %v; want questionnaire graph fast path", result, ok)
+			}
+			if result.Plan.Intent != IntentQuestionnaireEvidence || result.Plan.Filters["topic"] != tt.wantTopic {
+				t.Fatalf("plan = %#v, want questionnaire topic %q", result.Plan, tt.wantTopic)
+			}
+			for _, want := range []string{
+				"relation: 'supports'",
+				"relation: 'has_evidence'",
+				"controlEvidence.urn AS direct_evidence_urn",
+				"source_attributes_json_internal",
+				tt.wantSnippet,
+			} {
+				if !strings.Contains(result.Cypher, want) {
+					t.Fatalf("questionnaire cypher missing %q:\n%s", want, result.Cypher)
+				}
+			}
+			for _, forbidden := range []string{
+				"WHERE supportEvidence IS NULL",
+				"coalesce(control.attributes_json, '') +",
+				"coalesce(support.attributes_json, '') +",
+				"coalesce(evidence.attributes_json, '') +",
+			} {
+				if strings.Contains(result.Cypher, forbidden) {
+					t.Fatalf("questionnaire cypher contains forbidden raw/suppressing fragment %q:\n%s", forbidden, result.Cypher)
+				}
+			}
+		})
+	}
+}
+
+func TestQuestionnaireTopicPredicatesAvoidRawJSONKeyCollisions(t *testing.T) {
+	tests := []struct {
+		name       string
+		question   string
+		forbidden  []string
+		want       []string
+		wantFilter string
+	}{
+		{
+			name:       "policy documents",
+			question:   "Answer this policy document questionnaire item",
+			wantFilter: "policy_documents",
+			forbidden: []string{
+				"questionnaire_match_text CONTAINS 'policy' OR",
+				"coalesce(control.attributes_json, '') +",
+				"coalesce(support.attributes_json, '') +",
+				"coalesce(evidence.attributes_json, '')) AS questionnaire_match_text",
+			},
+			want: []string{
+				"questionnaire_match_text CONTAINS 'policy document'",
+				"questionnaire_match_text CONTAINS 'policy_document'",
+				`questionnaire_match_text =~ '(?s).*\\bdocument\\b.*'`,
+			},
+		},
+		{
+			name:       "control coverage",
+			question:   "Show control coverage evidence gaps",
+			wantFilter: "control_coverage",
+			forbidden: []string{
+				"questionnaire_match_text CONTAINS 'control'",
+				"questionnaire_match_text CONTAINS 'evidence'",
+				"coalesce(control.attributes_json, '') +",
+				"coalesce(support.attributes_json, '') +",
+				"coalesce(evidence.attributes_json, '')) AS questionnaire_match_text",
+			},
+			want: []string{
+				`questionnaire_match_text =~ '(?s).*\\bcoverage\\b.*'`,
+				"questionnaire_match_text CONTAINS 'coverage_gap'",
+				`questionnaire_match_text =~ '(?s).*\\bgap\\b.*'`,
+				`questionnaire_match_text =~ '(?s).*\\bmissing\\b.*'`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _, ok := deterministicFastPathConversion(AskRequest{TenantID: "writer", Question: tt.question}, true)
+			if !ok || result.Plan.Filters["topic"] != tt.wantFilter {
+				t.Fatalf("deterministicFastPathConversion() = %#v, %v; want topic %q", result, ok, tt.wantFilter)
+			}
+			for _, forbidden := range tt.forbidden {
+				if strings.Contains(result.Cypher, forbidden) {
+					t.Fatalf("questionnaire cypher contains collision-prone predicate %q:\n%s", forbidden, result.Cypher)
+				}
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(result.Cypher, want) {
+					t.Fatalf("questionnaire cypher missing %q:\n%s", want, result.Cypher)
+				}
+			}
+		})
+	}
+}
+
 func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",
@@ -522,9 +754,10 @@ func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 
 func TestDeterministicTemplatesUseProjectedGraphContract(t *testing.T) {
 	for _, tt := range []struct {
-		name   string
-		intent string
-		scope  string
+		name    string
+		intent  string
+		scope   string
+		filters map[string]string
 	}{
 		{name: "source aggregation", intent: IntentAggregateFindingsBySource, scope: "urn:cerebro:writer:asset:alpha"},
 		{name: "top risk", intent: IntentTopRiskFindings, scope: "urn:cerebro:writer:asset:alpha"},
@@ -532,13 +765,14 @@ func TestDeterministicTemplatesUseProjectedGraphContract(t *testing.T) {
 		{name: "explain finding", intent: IntentExplainFinding, scope: "urn:cerebro:writer:finding:alpha"},
 		{name: "identity bridge", intent: IntentIdentityBridge, scope: "urn:cerebro:writer:github_user:alice"},
 		{name: "connector health", intent: IntentConnectorHealth, scope: "urn:cerebro:writer:source:github"},
+		{name: "questionnaire evidence", intent: IntentQuestionnaireEvidence, scope: "urn:cerebro:writer:policy:control:ac-1", filters: map[string]string{"topic": "okta_mfa"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			result := convertDraftToQuery(AskRequest{
 				TenantID: "writer",
 				Question: tt.name,
 				ScopeURN: tt.scope,
-			}, &DraftResponse{Plan: &AskQueryPlan{Intent: tt.intent, Limit: 25}})
+			}, &DraftResponse{Plan: &AskQueryPlan{Intent: tt.intent, Limit: 25, Filters: tt.filters}})
 			if !result.Deterministic {
 				t.Fatalf("conversion result = %#v, want deterministic template", result)
 			}
@@ -607,6 +841,7 @@ func TestUnsupportedPlanOnlyMutationsAreRefused(t *testing.T) {
 		{name: "unsupported top risk owner filter", plan: AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"owner": "security"}}},
 		{name: "unsupported source runtime filter", plan: AskQueryPlan{Intent: IntentConnectorHealth, Filters: map[string]string{"entity_type": "runtime"}}},
 		{name: "unsupported identity bridge group", plan: AskQueryPlan{Intent: IntentIdentityBridge, GroupBy: "email"}},
+		{name: "unsupported questionnaire owner filter", plan: AskQueryPlan{Intent: IntentQuestionnaireEvidence, Filters: map[string]string{"owner": "security"}}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: tt.name}, &DraftResponse{Plan: &tt.plan})

--- a/internal/sourceprojection/grc_policy_lifecycle_test.go
+++ b/internal/sourceprojection/grc_policy_lifecycle_test.go
@@ -372,7 +372,7 @@ func TestProjectGRCPolicyEvidenceSnippetLinksDocumentPolicyControlAndQuestion(t 
 	if entity := state.entities[snippetURN]; entity == nil || entity.EntityType != "policy.evidence_snippet" || entity.Attributes["snippet_text"] == "" {
 		t.Fatalf("snippet entity = %#v, want policy evidence snippet with text", entity)
 	} else if entity.Attributes["policy_citations"] == "" || entity.Attributes["manual_review_state"] != "ready_to_project" || entity.Attributes["unsupported_claims"] == "" || entity.Attributes["source_provenance"] == "" {
-		t.Fatalf("snippet attrs = %#v, want QAuto citation fields", entity.Attributes)
+		t.Fatalf("snippet attrs = %#v, want questionnaire citation fields", entity.Attributes)
 	}
 	assertProjectedLink(t, state, documentURN, relationHasEvidence, snippetURN)
 	assertProjectedLink(t, state, policyURN, relationHasEvidence, snippetURN)

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -828,6 +828,101 @@ export type CreatePlatformJobRequest = {
   tenant_id?: string;
 };
 
+export type CredentialStoreBinding = {
+  auth_method?: string;
+  connection_status?: string;
+  credential_id?: string;
+  credential_status?: string;
+  credential_store_id: string;
+  field_count?: number;
+  fields?: string[];
+  id: string;
+  last_used_at?: string;
+  last_validated_at?: string;
+  next_action?: string;
+  reference_prefixes?: string[];
+  resolver?: "cerebro_vault" | "environment" | "environment_projection" | "native" | "native_reference" | "unknown";
+  runtime_id?: string;
+  source_id?: string;
+  source_name?: string;
+  tenant_id?: string;
+  updated_at?: string;
+};
+
+export type CredentialStoreDetailResponse = {
+  audit?: ConnectorCredentialAuditEvent[];
+  credential_store_status: "ready" | "unavailable";
+  generated_at: string;
+  runtime_store_status: "ready" | "unavailable";
+  store: CredentialStoreOperational;
+  tenant_id?: string;
+};
+
+export type CredentialStoreHealth = {
+  detail?: string;
+  next_action?: string;
+  severity?: "success" | "warning" | "error";
+  status: "ready" | "in_use" | "warning" | "needs_attention" | "needs_configuration" | "unavailable";
+};
+
+export type CredentialStoreIssue = {
+  credential_id?: string;
+  credential_store_id?: string;
+  detail: string;
+  field?: string;
+  id: string;
+  next_action?: string;
+  runtime_id?: string;
+  severity: "error" | "warning";
+  source_id?: string;
+  status: "blocked" | "warning";
+};
+
+export type CredentialStoreListResponse = {
+  credential_store_status: "ready" | "unavailable";
+  generated_at: string;
+  issues?: CredentialStoreIssue[];
+  runtime_store_status: "ready" | "unavailable";
+  stores: CredentialStoreOperational[];
+  tenant_id?: string;
+};
+
+export type CredentialStoreMetadata = {
+  available: boolean;
+  default?: boolean;
+  description?: string;
+  detail?: string;
+  id: string;
+  label: string;
+  mode: "encrypted_submission" | "environment_managed" | "reference";
+  native_resolution_available?: boolean;
+  provider: string;
+  reference_field_template?: string;
+  reference_namespace_template?: string;
+  reference_placeholder?: string;
+  reference_prefixes?: string[];
+  required_config?: { description?: string; env?: string; label?: string; required?: boolean }[];
+  setup_steps?: { command?: string; description?: string; id?: string; label?: string }[];
+  status?: string;
+};
+
+export type CredentialStoreOperational = {
+  bindings?: CredentialStoreBinding[];
+  health: CredentialStoreHealth;
+  issues?: CredentialStoreIssue[];
+  store: CredentialStoreMetadata;
+  usage: CredentialStoreUsage;
+};
+
+export type CredentialStoreUsage = {
+  bindings: number;
+  connections: number;
+  credentials: number;
+  field_references: number;
+  issues: number;
+  last_updated_at?: string;
+};
+
 export type DeviceEnrollRequest = {
   agent_version?: string;
   attestation?: string;
@@ -1097,12 +1192,232 @@ export type FindingRiskFactor = {
   weight?: number;
 };
 
+export type GRCAccessEvidenceConfidence = {
+  level?: string;
+  reasons?: string[];
+  [key: string]: unknown;
+};
+
+export type GRCAccessEvidenceItem = {
+  access_target_label?: string;
+  access_target_type?: string;
+  access_target_urn?: string;
+  assignment_kind?: string;
+  attributes?: Record<string, string>;
+  capability_label?: string;
+  capability_type?: string;
+  capability_urn?: string;
+  changed_during_period?: boolean;
+  classification?: string[];
+  entitlement_label?: string;
+  entitlement_type?: string;
+  entitlement_urn?: string;
+  event_ids?: string[];
+  evidence_use?: string;
+  graph_path_ids?: string[];
+  graph_root_urns?: string[];
+  id?: string;
+  mediator_label?: string;
+  mediator_type?: string;
+  mediator_urn?: string;
+  privileged?: boolean;
+  runtime_ids?: string[];
+  sensitive?: boolean;
+  source_citations?: GRCAccessSourceCitation[];
+  source_ids?: string[];
+  [key: string]: unknown;
+};
+
+export type GRCAccessEvidenceSubject = {
+  access_items?: GRCAccessEvidenceItem[];
+  account_status?: string;
+  change_summary?: string[];
+  citations?: GRCEvidenceCitations;
+  confidence?: GRCAccessEvidenceConfidence;
+  evidence_use?: string;
+  exception_state?: string;
+  freshness?: GRCAccessSourceFreshness[];
+  id?: string;
+  included_because?: string[];
+  lifecycle_state?: string;
+  manual_review_only_item_ids?: string[];
+  manual_review_state?: string;
+  mfa_posture?: string;
+  missing_facts?: string[];
+  operating_effectiveness_item_ids?: string[];
+  overclaim_guards?: string[];
+  owner_urn?: string;
+  period_end?: string;
+  period_start?: string;
+  policy_citations?: string[];
+  principal_label?: string;
+  principal_type?: string;
+  principal_urn?: string;
+  review_context_item_ids?: string[];
+  reviewer_urn?: string;
+  risk_signals?: string[];
+  source_citations?: GRCAccessSourceCitation[];
+  source_freshness?: GRCAccessSourceFreshness[];
+  subject_label?: string;
+  subject_type?: string;
+  subject_urn?: string;
+  supported_controls?: string[];
+  tenant_id?: string;
+  unsupported_claims?: string[];
+  [key: string]: unknown;
+};
+
+export type GRCAccessSourceCitation = {
+  event_id?: string;
+  graph_path_id?: string;
+  observed_at?: string;
+  runtime_id?: string;
+  source_id?: string;
+  [key: string]: unknown;
+};
+
+export type GRCAccessSourceFreshness = {
+  observed_at?: string;
+  runtime_id?: string;
+  source_id?: string;
+  status?: string;
+  [key: string]: unknown;
+};
+
 export type GRCAskRequest = {
   history?: { content?: string; role?: "user" | "assistant" }[];
   model?: string;
   question: string;
   scope_urn?: string;
   tenant_id: string;
+};
+
+export type GRCAssessmentScope = {
+  collection_policy?: string;
+  control_count?: number;
+  evidence_count?: number;
+  exclusion_count?: number;
+  filtered_before_graph_projection?: boolean;
+  finding_count?: number;
+  generated_at?: string;
+  id?: string;
+  policy_applied_before_read?: boolean;
+  profile_id?: string;
+  profile_name?: string;
+  redaction_mode?: string;
+  report_type?: string;
+  runtime_count?: number;
+  runtime_ids?: string[];
+  source_ids?: string[];
+  [key: string]: unknown;
+};
+
+export type GRCAuditProgram = {
+  claim_record_count?: number;
+  collection_source_count?: number;
+  control_count?: number;
+  evaluation_run_count?: number;
+  evidence_item_count?: number;
+  evidence_packet_count?: number;
+  evidence_request_count?: number;
+  framework_count?: number;
+  graph_path_count?: number;
+  id?: string;
+  lineage_count?: number;
+  name?: string;
+  open_review_count?: number;
+  profile_id?: string;
+  questionnaire_answer_count?: number;
+  readiness_score?: number;
+  resource_subject_count?: number;
+  status?: string;
+  [key: string]: unknown;
+};
+
+export type GRCAuditSnapshot = {
+  claim_record_count?: number;
+  collection_source_count?: number;
+  control_count?: number;
+  evaluation_run_count?: number;
+  evidence_item_count?: number;
+  evidence_packet_count?: number;
+  evidence_request_count?: number;
+  generated_at?: string;
+  graph_path_count?: number;
+  hash?: string;
+  id?: string;
+  lineage_count?: number;
+  open_review_count?: number;
+  questionnaire_answer_count?: number;
+  resource_subject_count?: number;
+  [key: string]: unknown;
+};
+
+export type GRCClaimRecord = {
+  control_ids?: string[];
+  evidence_ids?: string[];
+  evidence_packet_ids?: string[];
+  finding_ids?: string[];
+  id?: string;
+  [key: string]: unknown;
+};
+
+export type GRCCollectionSource = {
+  control_count?: number;
+  evidence_item_count?: number;
+  finding_count?: number;
+  id?: string;
+  last_synced_at?: string;
+  runtime_id?: string;
+  source_id?: string;
+  status?: string;
+  tenant_id?: string;
+  [key: string]: unknown;
+};
+
+export type GRCControlPosture = {
+  audit_summary?: string;
+  control_id?: string;
+  critical_findings?: number;
+  evidence_items?: number;
+  evidence_packet_ids?: string[];
+  evidence_quality?: string;
+  evidence_request_ids?: string[];
+  evidence_score?: number;
+  exception_ids?: string[];
+  family_id?: string;
+  family_name?: string;
+  finding_ids?: string[];
+  framework_id?: string;
+  framework_lifecycle?: string;
+  framework_name?: string;
+  framework_version?: string;
+  high_findings?: number;
+  id?: string;
+  mapped_rules?: string[];
+  missing_evidence_items?: number;
+  open_findings?: number;
+  owner_domain?: string;
+  reasons?: string[];
+  stale_evidence_items?: number;
+  status?: string;
+  tags?: string[];
+  test_results?: GRCControlTestResult[];
+  title?: string;
+  [key: string]: unknown;
+};
+
+export type GRCControlTestResult = {
+  control_id?: string;
+  evidence_ids?: string[];
+  evidence_quality?: string;
+  finding_ids?: string[];
+  id?: string;
+  last_observed_at?: string;
+  result?: string;
+  rule_id?: string;
+  status?: string;
+  [key: string]: unknown;
 };
 
 export type GRCDashboardResponse = {
@@ -1116,6 +1431,278 @@ export type GRCDashboardResponse = {
   product_areas?: GRCProductArea[];
   source_summaries?: Record<string, unknown>[];
   summary?: Record<string, unknown>;
+};
+
+export type GRCEvaluationRun = {
+  control_ids?: string[];
+  evidence_ids?: string[];
+  evidence_packet_ids?: string[];
+  finding_ids?: string[];
+  id?: string;
+  rule_ids?: string[];
+  runtime_id?: string;
+  source_id?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceActivity = {
+  created_at?: string;
+  id?: string;
+  message?: string;
+  subject_id?: string;
+  type?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceCitations = {
+  claim_ids?: string[];
+  event_ids?: string[];
+  evidence_ids?: string[];
+  graph_root_urns?: string[];
+  rule_ids?: string[];
+  run_ids?: string[];
+};
+
+export type GRCEvidenceExport = {
+  formats?: string[];
+  id?: string;
+  path?: string;
+  redaction?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceExportArtifact = {
+  content_hash?: string;
+  format?: string;
+  id?: string;
+  included?: boolean;
+  path?: string;
+  redaction?: string;
+  snapshot_id?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceExportRef = {
+  format?: string;
+  path?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceFreshness = {
+  expires_at?: string;
+  observed_at?: string;
+  reason?: string;
+  sla?: string;
+  status: string;
+};
+
+export type GRCEvidenceItemRecord = {
+  claim_ids?: string[];
+  control_ids?: string[];
+  created_at?: string;
+  event_ids?: string[];
+  evidence_packet_ids?: string[];
+  evidence_request_ids?: string[];
+  finding_id?: string;
+  graph_path_urns?: string[];
+  graph_root_urns?: string[];
+  id?: string;
+  last_observed_at?: string;
+  observation_count?: number;
+  rule_id?: string;
+  run_id?: string;
+  run_ids?: string[];
+  runtime_id?: string;
+  source_id?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceLineage = {
+  claim_ids?: string[];
+  control_ids?: string[];
+  event_ids?: string[];
+  evidence_id?: string;
+  evidence_packet_ids?: string[];
+  evidence_request_ids?: string[];
+  finding_id?: string;
+  graph_root_urns?: string[];
+  id?: string;
+  rule_id?: string;
+  run_ids?: string[];
+  runtime_id?: string;
+  source_id?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidencePacket = {
+  citations?: GRCEvidenceCitations;
+  control_id?: string;
+  evidence_type?: string;
+  expires_at?: string;
+  export_artifact?: GRCEvidenceExportRef;
+  framework_id?: string;
+  freshness?: GRCEvidenceFreshness;
+  id?: string;
+  manual?: boolean;
+  observed_at?: string;
+  quality?: string;
+  reason?: string;
+  request_id?: string;
+  review?: GRCEvidenceReview;
+  source?: string;
+  status?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidencePacketsResponse = {
+  access_evidence_subjects?: GRCAccessEvidenceSubject[];
+  activity?: GRCEvidenceActivity[];
+  assessment_scope?: GRCAssessmentScope;
+  claim_records?: GRCClaimRecord[];
+  collection_sources?: GRCCollectionSource[];
+  controls?: GRCControlPosture[];
+  evaluation_runs?: GRCEvaluationRun[];
+  evidence_items?: GRCEvidenceItemRecord[];
+  evidence_lineage?: GRCEvidenceLineage[];
+  evidence_packets?: GRCEvidencePacket[];
+  evidence_requests?: GRCEvidenceRequest[];
+  evidence_reviews?: GRCEvidenceReview[];
+  exceptions_acceptances?: GRCExceptionAcceptance[];
+  export?: GRCEvidenceExport;
+  export_artifacts?: GRCEvidenceExportArtifact[];
+  finding_workflow?: GRCFindingWorkflow[];
+  frameworks?: GRCFrameworkPosture[];
+  generated_at?: string;
+  graph_evidence_rows?: GRCGraphEvidenceRecord[];
+  graph_path_records?: GRCGraphPathRecord[];
+  metadata?: GRCReportMetadata;
+  program?: GRCAuditProgram;
+  questionnaire_answers?: GRCQuestionnaireAnswer[];
+  reasoning_tasks?: GRCEvidenceReasoningTask[];
+  resource_subjects?: GRCResourceSubject[];
+  snapshot?: GRCAuditSnapshot;
+  version?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceReasoningTask = {
+  answer_scope?: string;
+  attributes?: Record<string, string>;
+  citation_event_ids?: string[];
+  citation_graph_path_ids?: string[];
+  citation_graph_root_urns?: string[];
+  control_ids?: string[];
+  guards?: string[];
+  id?: string;
+  policy_citations?: string[];
+  question?: string;
+  subject_id?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceRequest = {
+  accepted_from?: string[];
+  assessment_methods?: string[];
+  control_id?: string;
+  control_test_ids?: string[];
+  description?: string;
+  due_at?: string;
+  evidence_packet_ids?: string[];
+  framework_id?: string;
+  freshness_sla?: string;
+  id?: string;
+  owner_domain?: string;
+  quality?: string;
+  required?: boolean;
+  review_status?: string;
+  status?: string;
+  title?: string;
+  type?: string;
+  [key: string]: unknown;
+};
+
+export type GRCEvidenceReview = {
+  actor?: string;
+  id?: string;
+  reason?: string;
+  status?: string;
+  subject_id?: string;
+  updated_at?: string;
+  [key: string]: unknown;
+};
+
+export type GRCExceptionAcceptance = {
+  control_id?: string;
+  framework_id?: string;
+  id?: string;
+  status?: string;
+  type?: string;
+  [key: string]: unknown;
+};
+
+export type GRCFindingWorkflow = {
+  check_id?: string;
+  check_name?: string;
+  control_ids?: string[];
+  due_at?: string;
+  evidence_ids?: string[];
+  evidence_packet_ids?: string[];
+  id?: string;
+  last_observed_at?: string;
+  owner?: string;
+  policy_id?: string;
+  policy_name?: string;
+  review_status?: string;
+  risk_reasons?: string[];
+  risk_score?: number;
+  rule_id?: string;
+  runtime_id?: string;
+  severity?: string;
+  sla_status?: string;
+  source_id?: string;
+  status?: string;
+  status_reason?: string;
+  title?: string;
+  [key: string]: unknown;
+};
+
+export type GRCFrameworkPosture = {
+  control_count?: number;
+  evidence_score?: number;
+  id?: string;
+  lifecycle?: string;
+  missing_evidence_count?: number;
+  name?: string;
+  needs_attention_controls?: number;
+  passing_controls?: number;
+  stale_evidence_count?: number;
+  status?: string;
+  version?: string;
+  [key: string]: unknown;
+};
+
+export type GRCGraphEvidenceRecord = {
+  attributes?: Record<string, string>;
+  evidence_id?: string;
+  finding_id?: string;
+  graph_path_ids?: string[];
+  id?: string;
+  label?: string;
+  [key: string]: unknown;
+};
+
+export type GRCGraphPathRecord = {
+  attributes?: Record<string, string>;
+  evidence_id?: string;
+  finding_id?: string;
+  from_type?: string;
+  from_urn?: string;
+  id?: string;
+  observed_at?: string;
+  relation?: string;
+  to_type?: string;
+  to_urn?: string;
+  [key: string]: unknown;
 };
 
 export type GRCPolicyAcceptanceSummary = {
@@ -1649,6 +2236,104 @@ export type GRCProgramReadinessResponse = {
   work_items?: Record<string, unknown>[];
 };
 
+export type GRCQuestionnaireAnswer = {
+  answer: string;
+  answer_state: string;
+  citations: GRCEvidenceCitations;
+  confidence: GRCQuestionnaireAnswerConfidence;
+  controls: GRCQuestionnaireControlRef[];
+  evidence_packet_ids?: string[];
+  framework_mappings?: GRCQuestionnaireFrameworkMapping[];
+  freshness: GRCEvidenceFreshness;
+  guardrails?: string[];
+  id: string;
+  missing_evidence?: GRCQuestionnaireEvidenceGap[];
+  policy_documents?: GRCQuestionnaireEvidenceRef[];
+  question: string;
+  question_id: string;
+  reasoning_contract: GRCQuestionnaireReasoningContract;
+  review_state: string;
+  source_evidence?: GRCQuestionnaireEvidenceRef[];
+};
+
+export type GRCQuestionnaireAnswerConfidence = {
+  level: string;
+  reason?: string;
+  score: number;
+};
+
+export type GRCQuestionnaireControlRef = {
+  control_id?: string;
+  framework_id?: string;
+  framework_name?: string;
+  id: string;
+  status?: string;
+  title?: string;
+};
+
+export type GRCQuestionnaireEvidenceGap = {
+  code: string;
+  control_id?: string;
+  evidence_packet_id?: string;
+  evidence_request_id?: string;
+  field?: string;
+  id: string;
+  reason?: string;
+  review_state?: string;
+};
+
+export type GRCQuestionnaireEvidenceRef = {
+  citations: GRCEvidenceCitations;
+  evidence_packet_id?: string;
+  evidence_type?: string;
+  freshness: GRCEvidenceFreshness;
+  id: string;
+  review_state?: string;
+  runtime_id?: string;
+  source?: string;
+  source_id?: string;
+};
+
+export type GRCQuestionnaireFrameworkMapping = {
+  control_id?: string;
+  control_title?: string;
+  family_id?: string;
+  family_name?: string;
+  framework_id?: string;
+  framework_name?: string;
+  framework_version?: string;
+  mapped_rules?: string[];
+};
+
+export type GRCQuestionnaireReasoningContract = {
+  confidence: string;
+  evidence_packet_ids?: string[];
+  freshness: GRCEvidenceFreshness;
+  graph_question: string;
+  intent: string;
+  manual_review_state: string;
+  missing_evidence_ids?: string[];
+  policy_citations?: string[];
+  relevant_controls?: GRCQuestionnaireControlRef[];
+  source_citations?: string[];
+  surface: string;
+  unsupported_claims?: string[];
+};
+
+export type GRCReportMetadata = Record<string, unknown>;
+
+export type GRCResourceSubject = {
+  control_ids?: string[];
+  evidence_ids?: string[];
+  evidence_packet_ids?: string[];
+  finding_ids?: string[];
+  id?: string;
+  kind?: string;
+  last_observed_at?: string;
+  urn?: string;
+  [key: string]: unknown;
+};
+
 export type GRCUploadEntityMatchHint = {
   candidate_state?: "dedupe_candidate";
   match_key?: string;
@@ -1855,6 +2540,59 @@ export type IdempotencyContract = {
   routes: { method?: string; path?: string; replay?: string; requirement?: string; scope?: string }[];
   semantics: string[];
   version: string;
+};
+
+export type IdentityListMeta = {
+  configured: number;
+  limit: number;
+  loaded: number;
+  persisted: number;
+};
+
+export type IdentityOrganization = {
+  created_at?: string;
+  domain?: string;
+  external_id?: string;
+  last_synced_at?: string;
+  name: string;
+  org_id: string;
+  provider?: string;
+  slug?: string;
+  source: string;
+  tenant_id: string;
+  updated_at?: string;
+  user_count: number;
+};
+
+export type IdentityOrganizationListResponse = {
+  meta: IdentityListMeta;
+  organizations: IdentityOrganization[];
+  tenant_id?: string;
+};
+
+export type IdentityUser = {
+  created_at?: string;
+  display_name: string;
+  email?: string;
+  groups?: string[];
+  last_seen_at?: string;
+  last_synced_at?: string;
+  org_id?: string;
+  provider?: string;
+  roles?: string[];
+  source: string;
+  status: string;
+  subject?: string;
+  tenant_id: string;
+  updated_at?: string;
+  user_id: string;
+};
+
+export type IdentityUserListResponse = {
+  meta: IdentityListMeta;
+  org_id?: string;
+  tenant_id?: string;
+  users: IdentityUser[];
 };
 
 export type IssueBootstrapTokenRequest = {


### PR DESCRIPTION
## Summary
- Add questionnaire answer records to GRC evidence packet responses with controls, evidence packets, citations, freshness, review state, and missing-evidence gaps.
- Add deterministic graph retrieval for known questionnaire evidence topics with explicit topic resolution, word-boundary predicates, and sanitized graph rows before summary generation.
- Keep the OpenAPI and generated TypeScript contracts aligned with the new response records.

## Validation
- `go test ./internal/graphagent ./internal/evidencepackets ./internal/sourceprojection ./internal/bootstrap -count=1`
- `make openapi-ts-check`
- `make check-structural`
- `make contracts-check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->