### PR TITLE
[codex] Promote enterprise runtime API depth

### DIFF
--- a/internal/sourceprojection/datadog_test.go
+++ b/internal/sourceprojection/datadog_test.go
@@ -152,3 +152,144 @@ func TestDatadogAuditProjectsActorAndResource(t *testing.T) {
 	assertProjectedLink(t, state, auditURN, relationObservedOn, resourceURN)
 	assertProjectedLink(t, state, userURN, relationActedOn, resourceURN)
 }
+
+func TestDatadogRuntimeKindsAreExplicitDepthEvidence(t *testing.T) {
+	cases := []struct {
+		event      *cerebrov1.EventEnvelope
+		entityType string
+	}{
+		{
+			event: &cerebrov1.EventEnvelope{
+				Id:       "datadog-user-event",
+				TenantId: "writer",
+				SourceId: "datadog",
+				Kind:     "datadog.users",
+				Attributes: map[string]string{
+					"user_id": "user-1",
+					"email":   "alice@example.test",
+					"name":    "Alice Example",
+				},
+			},
+			entityType: "datadog.users",
+		},
+		{
+			event: &cerebrov1.EventEnvelope{
+				Id:       "datadog-role-event",
+				TenantId: "writer",
+				SourceId: "datadog",
+				Kind:     "datadog.roles",
+				Attributes: map[string]string{
+					"role_id": "role-1",
+					"name":    "Datadog Admin",
+				},
+			},
+			entityType: "datadog.roles",
+		},
+		{
+			event: &cerebrov1.EventEnvelope{
+				Id:       "datadog-team-event",
+				TenantId: "writer",
+				SourceId: "datadog",
+				Kind:     "datadog.teams",
+				Attributes: map[string]string{
+					"team_id": "platform",
+					"name":    "Platform",
+				},
+			},
+			entityType: "datadog.teams",
+		},
+		{
+			event: &cerebrov1.EventEnvelope{
+				Id:       "datadog-monitor-event",
+				TenantId: "writer",
+				SourceId: "datadog",
+				Kind:     "datadog.monitors",
+				Attributes: map[string]string{
+					"monitor_id": "monitor-1",
+					"name":       "Checkout latency",
+					"type":       "query alert",
+					"tags":       "service:checkout,team:platform",
+				},
+			},
+			entityType: "datadog.monitors",
+		},
+		{
+			event: &cerebrov1.EventEnvelope{
+				Id:       "datadog-slo-event",
+				TenantId: "writer",
+				SourceId: "datadog",
+				Kind:     "datadog.slos",
+				Attributes: map[string]string{
+					"slo_id": "slo-1",
+					"name":   "Checkout availability",
+					"type":   "metric",
+					"tags":   "service:checkout,team:platform",
+				},
+			},
+			entityType: "datadog.slos",
+		},
+		{
+			event: &cerebrov1.EventEnvelope{
+				Id:       "datadog-dashboard-event",
+				TenantId: "writer",
+				SourceId: "datadog",
+				Kind:     "datadog.dashboards",
+				Attributes: map[string]string{
+					"dashboard_id": "dashboard-1",
+					"title":        "Checkout operations",
+					"tags":         "service:checkout,team:platform",
+				},
+			},
+			entityType: "datadog.dashboards",
+		},
+		{
+			event: &cerebrov1.EventEnvelope{
+				Id:       "datadog-incident-event",
+				TenantId: "writer",
+				SourceId: "datadog",
+				Kind:     "datadog.incidents",
+				Attributes: map[string]string{
+					"incident_id": "incident-1",
+					"title":       "Checkout outage",
+					"state":       "active",
+					"team_id":     "platform",
+					"service":     "checkout",
+				},
+			},
+			entityType: "datadog.incidents",
+		},
+		{
+			event: &cerebrov1.EventEnvelope{
+				Id:       "datadog-audit-event",
+				TenantId: "writer",
+				SourceId: "datadog",
+				Kind:     "datadog.audit_events",
+				Attributes: map[string]string{
+					"audit_id":    "audit-1",
+					"event_type":  "role.updated",
+					"actor_id":    "user-1",
+					"resource_id": "role-1",
+				},
+			},
+			entityType: "datadog.audit_events",
+		},
+	}
+	registered := make(map[string]struct{})
+	for _, kind := range BuiltinRegistry().Kinds() {
+		registered[kind] = struct{}{}
+	}
+	for _, tc := range cases {
+		t.Run(tc.event.Kind, func(t *testing.T) {
+			if _, ok := registered[tc.event.Kind]; !ok {
+				t.Fatalf("declared Datadog kind %q is not routed in the projection registry", tc.event.Kind)
+			}
+			entities, _, err := BuiltinRegistry().Project(tc.event)
+			if err != nil {
+				t.Fatalf("Project(%s) error = %v", tc.event.Kind, err)
+			}
+			if !hasProjectedEntityType(entities, tc.entityType) {
+				t.Fatalf("kind %q did not project %q; entities=%#v", tc.event.Kind, tc.entityType, entities)
+			}
+		})
+	}
+}

--- a/sources/asana/catalog.yaml
+++ b/sources/asana/catalog.yaml
@@ -1,10 +1,35 @@
 id: asana
 name: "Asana"
-description: "Asana connector definition catalog entry for high-value security and operations resources."
+description: "Asana work-management source covering users, projects, and workspace audit log events. The runtime reads Asana REST collections from the official API, keeps workspace-scoped audit events tied to actors and resources, and emits project and user records for ownership, access, and change review."
 emitted_kinds:
   - asana.users
   - asana.projects
   - asana.audit_events
+provider_api:
+  status: verified
+  transport: rest
+  auth: bearer_token
+  base_url: https://app.asana.com/api/1.0
+  references:
+    - https://github.com/Asana/openapi/blob/master/defs/asana_oas.yaml
+    - https://developers.asana.com/reference/getusers
+    - https://developers.asana.com/reference/getprojects
+    - https://developers.asana.com/reference/getauditlogevents
+    - https://developers.asana.com/docs/authentication
+  families:
+    - id: users
+      method: GET
+      path: /users
+    - id: projects
+      method: GET
+      path: /projects
+    - id: audit_events
+      method: GET
+      path: /workspaces/{workspace_gid}/audit_log_events
+runtime_families:
+  - users
+  - projects
+  - audit_events
 kind_lifecycle:
   - kind: asana.users
     status: active
@@ -20,36 +45,41 @@ coverage_contract:
       type: entity_family
       title: "Users"
       families: [users]
-      support: partial
+      support: supported
       high_value: true
       evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      control_domains: [identity_access, asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads `GET /users` with optional workspace filtering and preserves user gid, name, and email fields for identity matching and access review.
     - id: projects
       type: entity_family
       title: "Projects"
       families: [projects]
-      support: partial
+      support: supported
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads `GET /projects` with workspace filtering and emits project gid, name, archive state, and timestamps as project inventory.
     - id: audit_events
       type: audit_event
       title: "Audit Events"
       families: [audit_events]
-      support: partial
+      support: supported
       high_value: true
       evidence_types: [logging_configuration]
       control_domains: [logging_monitoring]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads `GET /workspaces/{workspace_gid}/audit_log_events`; each event keeps actor, resource, event type, and observed timestamp for workspace change review.
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync
-      support: planned
+      families: [users, projects, audit_events]
+      support: supported
+      evidence_types: [source_sync_status]
+      control_domains: [source_operations]
+      notes:
+        - Uses Asana `limit` and `offset` pagination and stores `next_page.offset` in the Source CDK cursor for continued reads.
 event_contracts:
   - kind: asana.users
     schema_ref: asana/users/v1
@@ -58,7 +88,7 @@ event_contracts:
       - source_event_id
       - user_id
     required_payload_fields:
-      - id
+      - gid
   - kind: asana.projects
     schema_ref: asana/projects/v1
     required_attributes:
@@ -68,7 +98,7 @@ event_contracts:
       - resource_type
       - resource_id
     required_payload_fields:
-      - id
+      - gid
   - kind: asana.audit_events
     schema_ref: asana/audit_events/v1
     required_attributes:
@@ -77,4 +107,4 @@ event_contracts:
       - event_type
       - actor_id
     required_payload_fields:
-      - id
+      - gid

--- a/sources/asana/source.go
+++ b/sources/asana/source.go
@@ -23,6 +23,7 @@ const (
 	familyUsers            = "users"
 	familyProjects         = "projects"
 	familyAuditEvents      = "audit_events"
+	workspaceGIDConfig     = "workspace_gid"
 )
 
 var templateKeys = []string{"token"}
@@ -46,39 +47,46 @@ func New() (*Source, error) {
 		Families: []jsonapi.Family{
 			{
 				Name:             familyUsers,
-				Path:             "/v1/users",
+				Path:             "/users",
 				URNKind:          "runtime_users",
-				IDKeys:           []string{"id", "user_id", "email", "primary_email", "login"},
-				CursorParam:      "cursor",
+				IDKeys:           []string{"gid", "id", "user_id", "email", "primary_email", "login"},
+				CursorParam:      "offset",
+				NextCursorKeys:   []string{"next_page.offset"},
 				PageSizeParams:   []string{"limit"},
 				ListKeys:         []string{"data"},
 				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"created_at": "created_at|created|profile.created_at", "department": "department|profile.department", "display_name": "display_name|name|profile.display_name|profile.name", "domain": "domain|tenant_domain|organization_domain", "email": "email|primary_email|profile.email", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "job_title": "job_title|title|profile.title", "last_login_at": "last_login_at|last_login|last_seen_at", "login": "login|username|email|profile.login", "manager": "manager|profile.manager", "observed_at": "observed_at|updated_at|last_seen_at", "primary_email": "primary_email|email|profile.email", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "status": "status|state|lifecycle_state", "tenant_id": "tenant_id|metadata.tenant_id", "user_id": "user_id|id|uid"},
+				Attributes:       map[string]string{"created_at": "created_at|created|profile.created_at", "department": "department|profile.department", "display_name": "name|display_name|profile.display_name|profile.name", "domain": "domain|tenant_domain|organization_domain", "email": "email|primary_email|profile.email", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "job_title": "job_title|title|profile.title", "last_login_at": "last_login_at|last_login|last_seen_at", "login": "login|username|email|profile.login", "manager": "manager|profile.manager", "observed_at": "observed_at|updated_at|last_seen_at", "primary_email": "primary_email|email|profile.email", "resource_id": "resource_id|gid|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|gid|id|metadata.event_id", "status": "status|state|lifecycle_state", "tenant_id": "tenant_id|metadata.tenant_id", "user_id": "user_id|gid|id|uid"},
 				StaticAttributes: map[string]string{"record_class": "identity_user", "schema": "users", "source_system": "asana"},
+				Config:           jsonapi.FamilyConfig{ConfigQuery: map[string]string{"workspace": workspaceGIDConfig}},
 			},
 			{
 				Name:             familyProjects,
-				Path:             "/v1/projects",
+				Path:             "/projects",
 				URNKind:          "runtime_projects",
-				IDKeys:           []string{"id", "urn", "resource_urn", "name"},
-				CursorParam:      "cursor",
+				IDKeys:           []string{"gid", "id", "urn", "resource_urn", "name"},
+				CursorParam:      "offset",
+				NextCursorKeys:   []string{"next_page.offset"},
 				PageSizeParams:   []string{"limit"},
 				ListKeys:         []string{"data"},
 				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|updated_at|last_seen_at", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
+				Attributes:       map[string]string{"evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|modified_at|updated_at|last_seen_at", "resource_id": "resource_id|gid|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|gid|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
 				StaticAttributes: map[string]string{"record_class": "asset", "schema": "projects", "source_system": "asana"},
+				Config:           jsonapi.FamilyConfig{ConfigQuery: map[string]string{"workspace": workspaceGIDConfig}},
 			},
 			{
 				Name:             familyAuditEvents,
-				Path:             "/v1/audit/events",
+				Path:             "/workspaces/{workspace_gid}/audit_log_events",
+				PathParams:       []string{workspaceGIDConfig},
 				URNKind:          "runtime_audit_events",
-				IDKeys:           []string{"id", "event_id", "uuid", "request_id"},
-				CursorParam:      "cursor",
+				IDKeys:           []string{"gid", "id", "event_id", "uuid", "request_id"},
+				CursorParam:      "offset",
+				NextCursorKeys:   []string{"next_page.offset"},
 				PageSizeParams:   []string{"limit"},
 				ListKeys:         []string{"data"},
 				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"actor_email": "actor_email|actor.email|email|user.email", "actor_id": "actor_id|actor.id|actorId|user_id|user.id", "actor_name": "actor_name|actor.name|user.name", "event_type": "event_type|event_name|action|type", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|updated_at|last_seen_at", "resource_email": "resource_email|target_email|target.email", "resource_id": "resource_id|target_id|target.id|resource.id|object_id", "resource_name": "resource_name|target_name|target.name|resource.name|object_name", "resource_type": "resource_type|target_type|target.type|object_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
+				Attributes:       map[string]string{"actor_email": "actor_email|actor.email|email|user.email", "actor_id": "actor_id|actor.gid|actor.id|actorId|user_id|user.gid|user.id", "actor_name": "actor_name|actor.name|user.name", "event_type": "event_type|event_name|action|type", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|created_at|updated_at|last_seen_at", "resource_email": "resource_email|target_email|target.email", "resource_id": "resource_id|resource.gid|target_gid|target_id|target.gid|target.id|resource.id|object_id", "resource_name": "resource_name|resource.name|target_name|target.name|object_name", "resource_type": "resource_type|resource.resource_type|target_type|target.type|object_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|gid|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
 				StaticAttributes: map[string]string{"record_class": "audit_event", "schema": "audit_events", "source_system": "asana"},
+				Config:           jsonapi.FamilyConfig{ConfigAttributes: map[string]string{"workspace_gid": workspaceGIDConfig}},
 			},
 		},
 	})

--- a/sources/asana/source_test.go
+++ b/sources/asana/source_test.go
@@ -25,11 +25,11 @@ func TestSourceCheckAndRead(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		if r.URL.Path != "/v1/users" {
+		if r.URL.Path != "/users" {
 			t.Fatalf("path = %q", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]string{{"id": "record-1", "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1", "resource_type": "asset", "resource_id": "record-1", "name": "Record One", "updated_at": "2026-06-01T00:00:00Z"}}})
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"gid": "record-1", "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1", "resource_type": "asset", "resource_id": "record-1", "name": "Record One", "updated_at": "2026-06-01T00:00:00Z"}}})
 	}))
 	defer server.Close()
 	cfgValues := map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token": "test-token"}
@@ -50,6 +50,89 @@ func TestSourceCheckAndRead(t *testing.T) {
 	}
 	if strings.TrimSpace(event.Id) == "" {
 		t.Fatalf("event id is empty: %#v", event)
+	}
+}
+
+func TestRuntimeUsesAsanaAPIPathsAndOffsetPagination(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.RequestURI())
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users":
+			if got := r.URL.Query().Get("workspace"); got != "workspace-1" {
+				t.Fatalf("users workspace = %q, want workspace-1", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]string{{"gid": "user-1", "name": "User One", "email": "user@example.test"}},
+				"next_page": map[string]string{
+					"offset": "cursor-2",
+				},
+			})
+		case "/projects":
+			if got := r.URL.Query().Get("workspace"); got != "workspace-1" {
+				t.Fatalf("projects workspace = %q, want workspace-1", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"gid": "project-1", "name": "Security Evidence"}}})
+		case "/workspaces/workspace-1/audit_log_events":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{
+				"gid":        "audit-1",
+				"event_type": "project.created",
+				"actor":      map[string]string{"gid": "user-1", "email": "user@example.test", "name": "User One"},
+				"resource":   map[string]string{"gid": "project-1", "resource_type": "project", "name": "Security Evidence"},
+			}}})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	baseCfg := map[string]string{
+		"base_url":      server.URL,
+		"tenant_id":     "tenant",
+		"token":         "test-token",
+		"workspace_gid": "workspace-1",
+	}
+	for _, tt := range []struct {
+		family string
+		kind   string
+	}{
+		{family: familyUsers, kind: "asana.users"},
+		{family: familyProjects, kind: "asana.projects"},
+		{family: familyAuditEvents, kind: "asana.audit_events"},
+	} {
+		t.Run(tt.family, func(t *testing.T) {
+			cfgValues := map[string]string{}
+			for key, value := range baseCfg {
+				cfgValues[key] = value
+			}
+			cfgValues["family"] = tt.family
+			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(cfgValues), nil)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("events = %d, want 1", len(pull.Events))
+			}
+			if got := pull.Events[0].Kind; got != tt.kind {
+				t.Fatalf("event kind = %q, want %q", got, tt.kind)
+			}
+			if tt.family == familyUsers && (pull.NextCursor == nil || pull.NextCursor.GetOpaque() != "cursor-2") {
+				t.Fatalf("users NextCursor = %#v, want cursor-2", pull.NextCursor)
+			}
+		})
+	}
+	if got := strings.Join(requests, "\n"); !strings.Contains(got, "/users?") || !strings.Contains(got, "/projects?") || !strings.Contains(got, "/workspaces/workspace-1/audit_log_events?") {
+		t.Fatalf("requests = %s, want Asana collection paths", got)
 	}
 }
 

--- a/sources/asana/testdata/read_audit_events.json
+++ b/sources/asana/testdata/read_audit_events.json
@@ -8,6 +8,7 @@
     "schema_ref": "asana/audit_events/v1",
     "payload": {
       "id": "audit-1",
+      "gid": "audit-1",
       "event_type": "project.created",
       "actor": {
         "id": "user-1",

--- a/sources/box/catalog.yaml
+++ b/sources/box/catalog.yaml
@@ -1,10 +1,35 @@
 id: box
 name: "Box"
-description: "Box connector definition catalog entry for high-value security and operations resources."
+description: "Box content governance source covering managed users, root folder content items, and enterprise admin log events. The runtime reads Box Platform API collections, preserves marker and stream cursors, and emits identity, content asset, and audit event records for graph projection and review."
 emitted_kinds:
   - box.users
   - box.content_assets
   - box.audit_events
+provider_api:
+  status: verified
+  transport: rest
+  auth: oauth_authorization_code
+  base_url: https://api.box.com/2.0
+  references:
+    - https://github.com/box/box-openapi/blob/main/openapi.json
+    - https://developer.box.com/reference/get-users/
+    - https://developer.box.com/reference/get-folders-id-items/
+    - https://developer.box.com/reference/get-events/
+    - https://developer.box.com/guides/authentication/
+  families:
+    - id: users
+      method: GET
+      path: /users
+    - id: content_assets
+      method: GET
+      path: /folders/0/items
+    - id: audit_events
+      method: GET
+      path: /events
+runtime_families:
+  - users
+  - content_assets
+  - audit_events
 kind_lifecycle:
   - kind: box.users
     status: active
@@ -20,36 +45,41 @@ coverage_contract:
       type: entity_family
       title: "Users"
       families: [users]
-      support: partial
+      support: supported
       high_value: true
       evidence_types: [source_snapshot]
-      control_domains: [asset_inventory]
+      control_domains: [identity_access, asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads `GET /users` with marker pagination and preserves user ID, login email, display name, and account status fields for identity review.
     - id: content_assets
       type: entity_family
       title: "Content Assets"
       families: [content_assets]
-      support: partial
+      support: supported
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads `GET /folders/0/items` with marker pagination to seed Box content inventory from the enterprise root folder.
     - id: audit_events
       type: audit_event
       title: "Audit Events"
       families: [audit_events]
-      support: partial
+      support: supported
       high_value: true
       evidence_types: [logging_configuration]
       control_domains: [logging_monitoring]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads `GET /events` with `stream_type=admin_logs_streaming` and records event ID, actor, source item, event type, and stream position.
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync
-      support: planned
+      families: [users, content_assets, audit_events]
+      support: supported
+      evidence_types: [source_sync_status]
+      control_domains: [source_operations]
+      notes:
+        - Uses Box `next_marker` for users and content items and `next_stream_position` for enterprise events.
 event_contracts:
   - kind: box.users
     schema_ref: box/users/v1

--- a/sources/box/deploy.yaml
+++ b/sources/box/deploy.yaml
@@ -6,7 +6,7 @@ runtimes:
     config:
       family: users
       failure_modes: api_error,auth_error,rate_limit,schema_drift
-      health_path: /2.0/users/me
+      health_path: /users/me
       expected_cadence_seconds: "86400"
       stale_after_seconds: "86400"
       per_page: "100"
@@ -15,7 +15,7 @@ runtimes:
     config:
       family: content_assets
       failure_modes: api_error,auth_error,rate_limit,schema_drift
-      health_path: /2.0/users/me
+      health_path: /users/me
       expected_cadence_seconds: "86400"
       stale_after_seconds: "86400"
       per_page: "100"
@@ -24,7 +24,7 @@ runtimes:
     config:
       family: audit_events
       failure_modes: api_error,auth_error,rate_limit,schema_drift
-      health_path: /2.0/users/me
+      health_path: /users/me
       expected_cadence_seconds: "3600"
       stale_after_seconds: "7200"
       per_page: "100"

--- a/sources/box/source.go
+++ b/sources/box/source.go
@@ -17,8 +17,8 @@ var catalogFS embed.FS
 const (
 	sourceID               = "box"
 	defaultFamily          = familyUsers
-	defaultHealthPath      = "/2.0/users/me"
-	defaultBaseURLTemplate = "https://api.box.com"
+	defaultHealthPath      = "/users/me"
+	defaultBaseURLTemplate = "https://api.box.com/2.0"
 	tokenScheme            = "Bearer"
 	familyUsers            = "users"
 	familyContentAssets    = "content_assets"
@@ -43,43 +43,49 @@ func New() (*Source, error) {
 		RequireTenantID: true,
 		AuthModel:       "oauth_authorization_code",
 		TokenScheme:     tokenScheme,
-		OAuthTokenURL:   "https://api.box.com/oauth/token",
+		OAuthTokenURL:   "https://api.box.com/oauth2/token",
 		Families: []jsonapi.Family{
 			{
 				Name:             familyUsers,
-				Path:             "/v1/users",
+				Path:             "/users",
 				URNKind:          "runtime_users",
 				IDKeys:           []string{"id", "user_id", "email", "primary_email", "login"},
-				CursorParam:      "cursor",
+				CursorParam:      "marker",
+				NextCursorKeys:   []string{"next_marker"},
 				PageSizeParams:   []string{"limit"},
-				ListKeys:         []string{"data"},
+				ListKeys:         []string{"entries"},
 				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"created_at": "created_at|created|profile.created_at", "department": "department|profile.department", "display_name": "display_name|name|profile.display_name|profile.name", "domain": "domain|tenant_domain|organization_domain", "email": "email|primary_email|profile.email", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "job_title": "job_title|title|profile.title", "last_login_at": "last_login_at|last_login|last_seen_at", "login": "login|username|email|profile.login", "manager": "manager|profile.manager", "observed_at": "observed_at|updated_at|last_seen_at", "primary_email": "primary_email|email|profile.email", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "status": "status|state|lifecycle_state", "tenant_id": "tenant_id|metadata.tenant_id", "user_id": "user_id|id|uid"},
+				Attributes:       map[string]string{"created_at": "created_at|created|profile.created_at", "department": "department|profile.department", "display_name": "name|display_name|profile.display_name|profile.name", "domain": "domain|tenant_domain|organization_domain", "email": "login|email|primary_email|profile.email", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "job_title": "job_title|title|profile.title", "last_login_at": "last_login_at|last_login|last_seen_at", "login": "login|username|email|profile.login", "manager": "manager|profile.manager", "observed_at": "observed_at|modified_at|updated_at|last_seen_at", "primary_email": "login|primary_email|email|profile.email", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "status": "status|state|lifecycle_state", "tenant_id": "tenant_id|metadata.tenant_id", "user_id": "user_id|id|uid"},
 				StaticAttributes: map[string]string{"record_class": "identity_user", "schema": "users", "source_system": "box"},
+				Config:           jsonapi.FamilyConfig{StaticQuery: map[string]string{"usemarker": "true"}},
 			},
 			{
 				Name:             familyContentAssets,
-				Path:             "/v1/resources",
+				Path:             "/folders/0/items",
 				URNKind:          "runtime_content_assets",
 				IDKeys:           []string{"id", "urn", "resource_urn", "name"},
-				CursorParam:      "cursor",
+				CursorParam:      "marker",
+				NextCursorKeys:   []string{"next_marker"},
 				PageSizeParams:   []string{"limit"},
-				ListKeys:         []string{"data"},
+				ListKeys:         []string{"entries"},
 				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|updated_at|last_seen_at", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
+				Attributes:       map[string]string{"evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|modified_at|updated_at|last_seen_at", "resource_id": "resource_id|id|metadata.resource_id", "resource_name": "name|display_name|hostname|metadata.resource_name", "resource_type": "resource_type|type|metadata.resource_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
 				StaticAttributes: map[string]string{"record_class": "asset", "schema": "content_assets", "source_system": "box"},
+				Config:           jsonapi.FamilyConfig{StaticQuery: map[string]string{"usemarker": "true"}},
 			},
 			{
 				Name:             familyAuditEvents,
-				Path:             "/v1/audit/events",
+				Path:             "/events",
 				URNKind:          "runtime_audit_events",
-				IDKeys:           []string{"id", "event_id", "uuid", "request_id"},
-				CursorParam:      "cursor",
+				IDKeys:           []string{"event_id", "id", "uuid", "request_id"},
+				CursorParam:      "stream_position",
+				NextCursorKeys:   []string{"next_stream_position"},
 				PageSizeParams:   []string{"limit"},
-				ListKeys:         []string{"data"},
+				ListKeys:         []string{"entries"},
 				TimestampKeys:    []string{"observed_at", "updated_at", "last_seen_at", "created_at"},
-				Attributes:       map[string]string{"actor_email": "actor_email|actor.email|email|user.email", "actor_id": "actor_id|actor.id|actorId|user_id|user.id", "actor_name": "actor_name|actor.name|user.name", "event_type": "event_type|event_name|action|type", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|updated_at|last_seen_at", "resource_email": "resource_email|target_email|target.email", "resource_id": "resource_id|target_id|target.id|resource.id|object_id", "resource_name": "resource_name|target_name|target.name|resource.name|object_name", "resource_type": "resource_type|target_type|target.type|object_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
+				Attributes:       map[string]string{"actor_email": "actor_email|created_by.login|created_by.email|actor.email|email|user.email", "actor_id": "actor_id|created_by.id|actor.id|actorId|user_id|user.id", "actor_name": "actor_name|created_by.name|actor.name|user.name", "event_type": "event_type|event_name|action|type", "evidence_cas_commit_id": "evidence_cas.commit_id|evidence_cas_commit_id|commit_id", "evidence_cas_digest": "evidence_cas.digest|evidence_cas_digest|digest", "evidence_cas_merkle_root": "evidence_cas.merkle_root|evidence_cas_merkle_root|merkle_root", "evidence_cas_ref_type": "evidence_cas.ref_type|evidence_cas_ref_type|ref_type", "evidence_cas_uri": "evidence_cas.uri|evidence_cas_uri|uri", "observed_at": "observed_at|created_at|updated_at|last_seen_at", "resource_email": "resource_email|source.login|target_email|target.email", "resource_id": "resource_id|source.id|target_id|target.id|resource.id|object_id", "resource_name": "resource_name|source.name|target_name|target.name|resource.name|object_name", "resource_type": "resource_type|source.type|target_type|target.type|object_type", "resource_urn": "resource_urn|urn|metadata.resource_urn", "source_event_id": "event_id|id|metadata.event_id", "tenant_id": "tenant_id|metadata.tenant_id"},
 				StaticAttributes: map[string]string{"record_class": "audit_event", "schema": "audit_events", "source_system": "box"},
+				Config:           jsonapi.FamilyConfig{StaticQuery: map[string]string{"stream_type": "admin_logs_streaming"}},
 			},
 		},
 	})

--- a/sources/box/source_health_receipt.json
+++ b/sources/box/source_health_receipt.json
@@ -1,5 +1,5 @@
 {
-  "adapter_health_path": "/2.0/users/me",
+  "adapter_health_path": "/users/me",
   "auth_model": "oauth_authorization_code",
   "evidence_cas_reference_kind": "box.evidence_cas_reference",
   "expected_cadence_seconds": 86400,

--- a/sources/box/source_test.go
+++ b/sources/box/source_test.go
@@ -21,15 +21,15 @@ func TestSourceCheckAndRead(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer test-token" {
 			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
 		}
-		if r.URL.RequestURI() == "/2.0/users/me" {
+		if r.URL.RequestURI() == "/users/me" {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		if r.URL.Path != "/v1/users" {
+		if r.URL.Path != "/users" {
 			t.Fatalf("path = %q", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]string{{"id": "record-1", "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1", "resource_type": "asset", "resource_id": "record-1", "name": "Record One", "updated_at": "2026-06-01T00:00:00Z"}}})
+		_ = json.NewEncoder(w).Encode(map[string]any{"entries": []map[string]string{{"id": "record-1", "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1", "resource_type": "asset", "resource_id": "record-1", "name": "Record One", "updated_at": "2026-06-01T00:00:00Z"}}})
 	}))
 	defer server.Close()
 	cfgValues := map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token": "test-token"}
@@ -50,6 +50,93 @@ func TestSourceCheckAndRead(t *testing.T) {
 	}
 	if strings.TrimSpace(event.Id) == "" {
 		t.Fatalf("event id is empty: %#v", event)
+	}
+}
+
+func TestRuntimeUsesBoxAPIPathsAndCursors(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.RequestURI())
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users":
+			if got := r.URL.Query().Get("usemarker"); got != "true" {
+				t.Fatalf("users usemarker = %q, want true", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries":     []map[string]string{{"id": "user-1", "name": "User One", "login": "user@example.test"}},
+				"next_marker": "marker-2",
+			})
+		case "/folders/0/items":
+			if got := r.URL.Query().Get("usemarker"); got != "true" {
+				t.Fatalf("content usemarker = %q, want true", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []map[string]string{{"id": "file-1", "type": "file", "name": "Security Evidence.pdf"}}})
+		case "/events":
+			if got := r.URL.Query().Get("stream_type"); got != "admin_logs_streaming" {
+				t.Fatalf("events stream_type = %q, want admin_logs_streaming", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []map[string]any{{
+					"event_id":   "event-1",
+					"event_type": "ITEM_UPLOAD",
+					"created_by": map[string]string{"id": "user-1", "login": "user@example.test", "name": "User One"},
+					"source":     map[string]string{"id": "file-1", "type": "file", "name": "Security Evidence.pdf"},
+				}},
+				"next_stream_position": "stream-2",
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	baseCfg := map[string]string{
+		"base_url":  server.URL,
+		"tenant_id": "tenant",
+		"token":     "test-token",
+	}
+	for _, tt := range []struct {
+		family string
+		kind   string
+		cursor string
+	}{
+		{family: familyUsers, kind: "box.users", cursor: "marker-2"},
+		{family: familyContentAssets, kind: "box.content_assets"},
+		{family: familyAuditEvents, kind: "box.audit_events", cursor: "stream-2"},
+	} {
+		t.Run(tt.family, func(t *testing.T) {
+			cfgValues := map[string]string{}
+			for key, value := range baseCfg {
+				cfgValues[key] = value
+			}
+			cfgValues["family"] = tt.family
+			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(cfgValues), nil)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("events = %d, want 1", len(pull.Events))
+			}
+			if got := pull.Events[0].Kind; got != tt.kind {
+				t.Fatalf("event kind = %q, want %q", got, tt.kind)
+			}
+			if tt.cursor != "" && (pull.NextCursor == nil || pull.NextCursor.GetOpaque() != tt.cursor) {
+				t.Fatalf("NextCursor = %#v, want %s", pull.NextCursor, tt.cursor)
+			}
+		})
+	}
+	if got := strings.Join(requests, "\n"); !strings.Contains(got, "/users?") || !strings.Contains(got, "/folders/0/items?") || !strings.Contains(got, "/events?") {
+		t.Fatalf("requests = %s, want Box collection paths", got)
 	}
 }
 

--- a/sources/datadog/catalog.yaml
+++ b/sources/datadog/catalog.yaml
@@ -10,6 +10,57 @@ emitted_kinds:
   - datadog.dashboards
   - datadog.incidents
   - datadog.audit_events
+provider_api:
+  status: verified
+  transport: rest
+  auth: dd_api_and_application_keys
+  base_url: https://api.datadoghq.com
+  references:
+    - https://github.com/DataDog/datadog-api-client-python/blob/master/.generator/schemas/v1/openapi.yaml
+    - https://github.com/DataDog/datadog-api-client-python/blob/master/.generator/schemas/v2/openapi.yaml
+    - https://docs.datadoghq.com/api/latest/authentication/
+    - https://docs.datadoghq.com/api/latest/users/
+    - https://docs.datadoghq.com/api/latest/roles/
+    - https://docs.datadoghq.com/api/latest/teams/
+    - https://docs.datadoghq.com/api/latest/monitors/
+    - https://docs.datadoghq.com/api/latest/service-level-objectives/
+    - https://docs.datadoghq.com/api/latest/dashboards/
+    - https://docs.datadoghq.com/api/latest/incidents/
+    - https://docs.datadoghq.com/api/latest/audit/
+  families:
+    - id: users
+      method: GET
+      path: /api/v2/users
+    - id: roles
+      method: GET
+      path: /api/v2/roles
+    - id: teams
+      method: GET
+      path: /api/v2/team
+    - id: monitors
+      method: GET
+      path: /api/v1/monitor
+    - id: slos
+      method: GET
+      path: /api/v1/slo
+    - id: dashboards
+      method: GET
+      path: /api/v1/dashboard
+    - id: incidents
+      method: GET
+      path: /api/v2/incidents
+    - id: audit_events
+      method: GET
+      path: /api/v2/audit/events
+runtime_families:
+  - users
+  - roles
+  - teams
+  - monitors
+  - slos
+  - dashboards
+  - incidents
+  - audit_events
 families:
   - id: users
     incremental: cursor

--- a/sources/pagerduty/catalog.yaml
+++ b/sources/pagerduty/catalog.yaml
@@ -9,6 +9,41 @@ emitted_kinds:
   - pagerduty.escalation_policy
   - pagerduty.integration
   - pagerduty.vendor
+provider_api:
+  status: verified
+  transport: rest
+  auth: pagerduty_api_token
+  base_url: https://api.pagerduty.com
+  references:
+    - https://github.com/PagerDuty/api-schema/blob/main/reference/REST/openapiv3.json
+    - https://developer.pagerduty.com/api-reference
+    - https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-authentication
+  families:
+    - id: user
+      method: GET
+      path: /users
+    - id: team
+      method: GET
+      path: /teams
+    - id: service
+      method: GET
+      path: /services
+    - id: schedule
+      method: GET
+      path: /schedules
+    - id: escalation_policy
+      method: GET
+      path: /escalation_policies
+    - id: vendor
+      method: GET
+      path: /vendors
+runtime_families:
+  - user
+  - team
+  - service
+  - schedule
+  - escalation_policy
+  - vendor
 families:
   - id: user
     incremental: cursor

--- a/sources/pagerduty/catalog.yaml
+++ b/sources/pagerduty/catalog.yaml
@@ -28,6 +28,9 @@ provider_api:
     - id: service
       method: GET
       path: /services
+    - id: integration
+      method: GET
+      path: /services/{service_id}/integrations
     - id: schedule
       method: GET
       path: /schedules
@@ -41,6 +44,7 @@ runtime_families:
   - user
   - team
   - service
+  - integration
   - schedule
   - escalation_policy
   - vendor


### PR DESCRIPTION
## Summary
- add verified provider API contracts for PagerDuty and Datadog runtime families
- repair Asana and Box runtimes to use official API paths, identifiers, pagination, and source-specific descriptions
- add runtime path tests and explicit Datadog projection evidence for graph coverage review

## Validation
- go test ./sources/asana ./sources/box ./sources/datadog ./sources/pagerduty ./internal/sourceprojection ./internal/connectorcatalog ./tools/connectorcatalogreview -count=1
- go run ./tools/connectorcatalogreview -runtime-depth-required -json-out tmp/batch2-datadog-review.json -markdown-out tmp/batch2-datadog-review.md -max-items 60
- make catalog-check
- make droid-review-sast

## Notes
- This is stacked on the runtime API contract gate branch so it can stay small while the gate PR finishes review.
- DeepSec was skipped locally because the tool is not installed.