### PR TITLE
Fix GRC questionnaire review findings

### DIFF
--- a/internal/grcvendor/questionnaire.go
+++ b/internal/grcvendor/questionnaire.go
@@ -30,14 +30,6 @@ type QuestionnaireEvidenceSignal struct {
 	State     string
 }
 
-type QuestionnaireReviewSummary struct {
-	TotalReviews     int `json:"total_reviews"`
-	NeedsInput       int `json:"needs_input"`
-	ReadyForApproval int `json:"ready_for_approval"`
-	Approved         int `json:"approved"`
-	Rejected         int `json:"rejected"`
-}
-
 type NewQuestionnaireReviewRequest struct {
 	TenantID           string
 	VendorURN          string
@@ -128,27 +120,6 @@ func BuildQuestionnaireReviewEnrichment(record ports.GRCVendorQuestionnaireRevie
 	return record
 }
 
-func SummarizeQuestionnaireReviews(records []*ports.GRCVendorQuestionnaireReviewRecord) QuestionnaireReviewSummary {
-	var summary QuestionnaireReviewSummary
-	summary.TotalReviews = len(records)
-	for _, record := range records {
-		if record == nil {
-			continue
-		}
-		switch record.Status {
-		case ports.GRCVendorQuestionnaireStatusNeedsInput:
-			summary.NeedsInput++
-		case ports.GRCVendorQuestionnaireStatusReadyForApproval:
-			summary.ReadyForApproval++
-		case ports.GRCVendorQuestionnaireStatusApproved, ports.GRCVendorQuestionnaireStatusConditional:
-			summary.Approved++
-		case ports.GRCVendorQuestionnaireStatusRejected:
-			summary.Rejected++
-		}
-	}
-	return summary
-}
-
 func QuestionnaireTimeline(eventType string, actorID string, summary string, attrs map[string]string, at time.Time) ports.GRCVendorQuestionnaireTimeline {
 	at = normalizedNow(at)
 	return ports.GRCVendorQuestionnaireTimeline{
@@ -192,13 +163,13 @@ func questionnaireEvidenceMatches(record ports.GRCVendorQuestionnaireReviewRecor
 		add(ports.GRCVendorQuestionnaireEvidence{ID: "questionnaire", Label: firstNonEmpty(record.Title, "Security questionnaire"), Source: "questionnaire", URN: record.QuestionnaireURN, Confidence: "high", Reason: "Uploaded questionnaire artifact"})
 	}
 	for _, related := range relationships.SecurityQuestionnaires {
-		add(ports.GRCVendorQuestionnaireEvidence{ID: "questionnaire:" + urnTail(related.URN), Label: firstNonEmpty(related.Label, "Security questionnaire"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked questionnaire"})
+		add(ports.GRCVendorQuestionnaireEvidence{ID: "questionnaire:" + related.URN, Label: firstNonEmpty(related.Label, "Security questionnaire"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked questionnaire"})
 	}
 	for _, related := range relationships.AssuranceDocuments {
-		add(ports.GRCVendorQuestionnaireEvidence{ID: "assurance:" + urnTail(related.URN), Label: firstNonEmpty(related.Label, "Assurance document"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked assurance document"})
+		add(ports.GRCVendorQuestionnaireEvidence{ID: "assurance:" + related.URN, Label: firstNonEmpty(related.Label, "Assurance document"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked assurance document"})
 	}
 	for _, related := range relationships.SecurityReviews {
-		add(ports.GRCVendorQuestionnaireEvidence{ID: "review:" + urnTail(related.URN), Label: firstNonEmpty(related.Label, "Security review"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked security review"})
+		add(ports.GRCVendorQuestionnaireEvidence{ID: "review:" + related.URN, Label: firstNonEmpty(related.Label, "Security review"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked security review"})
 	}
 	for _, item := range evidence {
 		add(ports.GRCVendorQuestionnaireEvidence{ID: "evidence:" + item.ID, Label: firstNonEmpty(item.Title, item.ID), Source: firstNonEmpty(item.SourceID, "finding_evidence"), ControlID: item.ControlID, Confidence: confidenceFromEvidenceState(item.State), Reason: firstNonEmpty(item.State, item.Type)})

--- a/internal/grcvendor/questionnaire_test.go
+++ b/internal/grcvendor/questionnaire_test.go
@@ -86,7 +86,14 @@ func TestBuildQuestionnaireReviewEnrichmentUsesVendorEvidence(t *testing.T) {
 	if got := enriched.Attributes["llm_summary"]; got != "Conditional approval needs legal follow-up." {
 		t.Fatalf("llm_summary = %q", got)
 	}
-	for _, want := range []string{"questionnaire", "questionnaire:linked-questionnaire", "assurance:soc2", "review:review-1", "evidence:evidence-1", "finding:finding-1"} {
+	for _, want := range []string{
+		"questionnaire",
+		"questionnaire:urn:cerebro:writer:security_questionnaire:vrm:linked-questionnaire",
+		"assurance:urn:cerebro:writer:assurance_document:vrm:soc2",
+		"review:urn:cerebro:writer:security_review:vrm:review-1",
+		"evidence:evidence-1",
+		"finding:finding-1",
+	} {
 		if !hasQuestionnaireEvidence(enriched.EvidenceMatches, want) {
 			t.Fatalf("evidence matches missing %q: %#v", want, enriched.EvidenceMatches)
 		}
@@ -107,6 +114,29 @@ func TestBuildQuestionnaireReviewEnrichmentUsesVendorEvidence(t *testing.T) {
 	}
 	if len(enriched.Timeline) < 2 || enriched.Timeline[len(enriched.Timeline)-1].EventType != ports.GRCVendorQuestionnaireEventProcessed {
 		t.Fatalf("timeline = %#v", enriched.Timeline)
+	}
+}
+
+func TestQuestionnaireEvidenceMatchesPreserveRelationshipURNIdentity(t *testing.T) {
+	relationships := VendorRelationships{
+		SecurityQuestionnaires: []RelatedRecord{
+			{URN: "urn:cerebro:writer:security_questionnaire:vrm:sig-2026", Label: "Imported SIG"},
+			{URN: "urn:cerebro:writer:security_questionnaire:manual:sig-2026", Label: "Manual SIG"},
+		},
+	}
+
+	matches := questionnaireEvidenceMatches(ports.GRCVendorQuestionnaireReviewRecord{}, Vendor{}, relationships, nil, nil)
+
+	for _, want := range []string{
+		"questionnaire:urn:cerebro:writer:security_questionnaire:vrm:sig-2026",
+		"questionnaire:urn:cerebro:writer:security_questionnaire:manual:sig-2026",
+	} {
+		if !hasQuestionnaireEvidence(matches, want) {
+			t.Fatalf("evidence matches missing %q: %#v", want, matches)
+		}
+	}
+	if len(matches) != 2 {
+		t.Fatalf("matches = %#v", matches)
 	}
 }
 
@@ -142,20 +172,6 @@ func TestBuildQuestionnaireReviewEnrichmentClearsStaleLLMSummary(t *testing.T) {
 	}
 	if enriched.Status == ports.GRCVendorQuestionnaireStatusProcessing {
 		t.Fatalf("status = %q", enriched.Status)
-	}
-}
-
-func TestSummarizeQuestionnaireReviewsCountsWorkflowStates(t *testing.T) {
-	records := []*ports.GRCVendorQuestionnaireReviewRecord{
-		{GRCVendorQuestionnaireReviewWorkflow: ports.GRCVendorQuestionnaireReviewWorkflow{Status: ports.GRCVendorQuestionnaireStatusNeedsInput}},
-		{GRCVendorQuestionnaireReviewWorkflow: ports.GRCVendorQuestionnaireReviewWorkflow{Status: ports.GRCVendorQuestionnaireStatusReadyForApproval}},
-		{GRCVendorQuestionnaireReviewWorkflow: ports.GRCVendorQuestionnaireReviewWorkflow{Status: ports.GRCVendorQuestionnaireStatusApproved}},
-		{GRCVendorQuestionnaireReviewWorkflow: ports.GRCVendorQuestionnaireReviewWorkflow{Status: ports.GRCVendorQuestionnaireStatusConditional}},
-		{GRCVendorQuestionnaireReviewWorkflow: ports.GRCVendorQuestionnaireReviewWorkflow{Status: ports.GRCVendorQuestionnaireStatusRejected}},
-	}
-	summary := SummarizeQuestionnaireReviews(records)
-	if summary.TotalReviews != 5 || summary.NeedsInput != 1 || summary.ReadyForApproval != 1 || summary.Approved != 2 || summary.Rejected != 1 {
-		t.Fatalf("summary = %#v", summary)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserve full related-record URNs in questionnaire evidence IDs so same-tail URNs do not collapse during dedupe.
- Remove the unused questionnaire review summary helper and its test.

## Validation
- go test ./internal/sourcehttp/grcvendorquestionnaire ./internal/bootstrap ./internal/grcvendor ./internal/statestore/postgres ./api -count=1
- make check-structural check-structural-test check-arch
- make lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->