### PR TITLE
[codex] Add JetStream publish recovery outbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,10 @@ make readme-check   # README and docs drift checks
 make docs-drift-check
 make oss-audit      # public repository hygiene scan
 cerebro deploy preflight  # emit a redacted deployment readiness receipt
+cerebro append-log dead-letters list  # list pending exhausted publish records
 ```
 
-Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
+Top-level commands are `serve`, `version`, `source`, `source-runtime`, `append-log`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
 
 For policy or compliance-control work, run `make finding-dsl-check`, `make policy-rule-check`, `make detection-catalog-check`, and `make control-index-check` as applicable. Control extension packs are documented in [Compliance controls](docs/domains/compliance-controls.md) and use `--init-extension`, `--extension`, `--profile`, `--output`, and `--write` workflows.
 

--- a/cmd/cerebro/append_log.go
+++ b/cmd/cerebro/append_log.go
@@ -110,6 +110,9 @@ func runAppendLogDeadLetterReplay(ctx context.Context, cfg appconfig.Config, arg
 		return fmt.Errorf("replay append log dead letter %q: %w", id, err)
 	}
 	if err := store.MarkAppendLogDeadLetterReplayed(ctx, id); err != nil {
+		if errors.Is(err, ports.ErrAppendLogDeadLetterAlreadyReplayed) {
+			return printJSON(appendLogDeadLetterActionResponse(record, ports.AppendLogDeadLetterStatusReplayed))
+		}
 		return err
 	}
 	return printJSON(appendLogDeadLetterActionResponse(record, ports.AppendLogDeadLetterStatusReplayed))

--- a/cmd/cerebro/append_log.go
+++ b/cmd/cerebro/append_log.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/writer/cerebro/internal/bootstrap"
+	appconfig "github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func runAppendLog(args []string) error {
+	if len(args) == 0 {
+		return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard] ...", os.Args[0]))
+	}
+	switch args[0] {
+	case "dead-letters":
+		return runAppendLogDeadLetters(args[1:])
+	default:
+		return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard] ...", os.Args[0]))
+	}
+}
+
+func runAppendLogDeadLetters(args []string) error {
+	if len(args) == 0 {
+		return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard] ...", os.Args[0]))
+	}
+	cfg, err := appconfig.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	ctx, stop := sourceRuntimeCommandContext()
+	defer stop()
+	closeTelemetry, err := configureOpenTelemetry(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("configure telemetry: %w", err)
+	}
+	defer shutdownTelemetry(context.Background(), closeTelemetry, cfg.ShutdownTimeout)
+
+	switch args[0] {
+	case "list":
+		return runAppendLogDeadLetterList(ctx, cfg, args[1:])
+	case "replay":
+		return runAppendLogDeadLetterReplay(ctx, cfg, args[1:])
+	case "discard":
+		return runAppendLogDeadLetterDiscard(ctx, cfg, args[1:])
+	default:
+		return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard] ...", os.Args[0]))
+	}
+}
+
+func runAppendLogDeadLetterList(ctx context.Context, cfg appconfig.Config, args []string) error {
+	filter, err := parseAppendLogDeadLetterListArgs(args)
+	if err != nil {
+		return err
+	}
+	store, closeDeps, err := openAppendLogDeadLetterStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := closeDeps(); err != nil {
+			log.Printf("close dependencies: %v", err)
+		}
+	}()
+	records, err := store.ListAppendLogDeadLetters(ctx, filter)
+	if err != nil {
+		return err
+	}
+	return printJSON(appendLogDeadLetterListResponse(records))
+}
+
+func runAppendLogDeadLetterReplay(ctx context.Context, cfg appconfig.Config, args []string) error {
+	id, err := parseAppendLogDeadLetterIDArg("replay", args)
+	if err != nil {
+		return err
+	}
+	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("open dependencies: %w", err)
+	}
+	defer func() {
+		if err := closeDeps(); err != nil {
+			log.Printf("close dependencies: %v", err)
+		}
+	}()
+	store := appendLogDeadLetterStore(deps.StateStore)
+	if store == nil {
+		return errors.New("append log dead letter store is not configured")
+	}
+	if deps.AppendLog == nil {
+		return errors.New("append log is not configured")
+	}
+	record, err := store.GetAppendLogDeadLetter(ctx, id)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(record.Status) != ports.AppendLogDeadLetterStatusPending {
+		return fmt.Errorf("append log dead letter %q has status %q", id, record.Status)
+	}
+	if record.Event == nil {
+		return fmt.Errorf("append log dead letter %q has no replay event", id)
+	}
+	if err := deps.AppendLog.Append(ctx, record.Event); err != nil {
+		return fmt.Errorf("replay append log dead letter %q: %w", id, err)
+	}
+	if err := store.MarkAppendLogDeadLetterReplayed(ctx, id); err != nil {
+		return err
+	}
+	return printJSON(appendLogDeadLetterActionResponse(record, ports.AppendLogDeadLetterStatusReplayed))
+}
+
+func runAppendLogDeadLetterDiscard(ctx context.Context, cfg appconfig.Config, args []string) error {
+	id, reason, err := parseAppendLogDeadLetterDiscardArgs(args)
+	if err != nil {
+		return err
+	}
+	store, closeDeps, err := openAppendLogDeadLetterStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := closeDeps(); err != nil {
+			log.Printf("close dependencies: %v", err)
+		}
+	}()
+	record, err := store.GetAppendLogDeadLetter(ctx, id)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(record.Status) != ports.AppendLogDeadLetterStatusPending {
+		return fmt.Errorf("append log dead letter %q has status %q", id, record.Status)
+	}
+	if err := store.DiscardAppendLogDeadLetter(ctx, id, reason); err != nil {
+		return err
+	}
+	return printJSON(appendLogDeadLetterActionResponse(record, ports.AppendLogDeadLetterStatusDiscarded))
+}
+
+func openAppendLogDeadLetterStore(ctx context.Context, cfg appconfig.Config) (ports.AppendLogDeadLetterStore, func() error, error) {
+	deps, closeDeps, err := bootstrap.OpenSourceRuntimeBootstrapDependencies(ctx, cfg)
+	if err != nil {
+		return nil, func() error { return nil }, fmt.Errorf("open state store: %w", err)
+	}
+	store := appendLogDeadLetterStore(deps.StateStore)
+	if store == nil {
+		_ = closeDeps()
+		return nil, func() error { return nil }, errors.New("append log dead letter store is not configured")
+	}
+	return store, closeDeps, nil
+}
+
+func appendLogDeadLetterStore(store ports.StateStore) ports.AppendLogDeadLetterStore {
+	deadLetters, ok := store.(ports.AppendLogDeadLetterStore)
+	if !ok {
+		return nil
+	}
+	return deadLetters
+}
+
+func parseAppendLogDeadLetterListArgs(args []string) (ports.AppendLogDeadLetterFilter, error) {
+	filter := ports.AppendLogDeadLetterFilter{Status: ports.AppendLogDeadLetterStatusPending}
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return ports.AppendLogDeadLetterFilter{}, fmt.Errorf("invalid append log dead-letter list argument %q; want key=value", arg)
+		}
+		switch strings.TrimSpace(key) {
+		case "status":
+			filter.Status = strings.TrimSpace(value)
+		case "subject":
+			filter.Subject = strings.TrimSpace(value)
+		case "runtime_id":
+			filter.RuntimeID = strings.TrimSpace(value)
+		case "source_id":
+			filter.SourceID = strings.TrimSpace(value)
+		case "limit":
+			parsed, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return ports.AppendLogDeadLetterFilter{}, fmt.Errorf("parse limit: %w", err)
+			}
+			filter.Limit = uint32(parsed)
+		default:
+			return ports.AppendLogDeadLetterFilter{}, fmt.Errorf("unsupported append log dead-letter list argument %q", key)
+		}
+	}
+	return filter, nil
+}
+
+func parseAppendLogDeadLetterIDArg(command string, args []string) (string, error) {
+	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+		return "", usageError(fmt.Sprintf("usage: %s append-log dead-letters %s <dead-letter-id>", os.Args[0], command))
+	}
+	return strings.TrimSpace(args[0]), nil
+}
+
+func parseAppendLogDeadLetterDiscardArgs(args []string) (string, string, error) {
+	if len(args) < 2 || strings.TrimSpace(args[0]) == "" {
+		return "", "", usageError(fmt.Sprintf("usage: %s append-log dead-letters discard <dead-letter-id> reason=<reason>", os.Args[0]))
+	}
+	id := strings.TrimSpace(args[0])
+	reason := ""
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return "", "", fmt.Errorf("invalid append log dead-letter discard argument %q; want key=value", arg)
+		}
+		if strings.TrimSpace(key) != "reason" {
+			return "", "", fmt.Errorf("unsupported append log dead-letter discard argument %q", key)
+		}
+		reason = strings.TrimSpace(value)
+	}
+	if reason == "" {
+		return "", "", errors.New("discard reason is required")
+	}
+	return id, reason, nil
+}
+
+type appendLogDeadLetterSummary struct {
+	ID            string `json:"id"`
+	Status        string `json:"status"`
+	Subject       string `json:"subject"`
+	Operation     string `json:"operation"`
+	EventID       string `json:"event_id"`
+	EventKind     string `json:"event_kind"`
+	TenantID      string `json:"tenant_id,omitempty"`
+	SourceID      string `json:"source_id,omitempty"`
+	RuntimeID     string `json:"runtime_id,omitempty"`
+	JobID         string `json:"job_id,omitempty"`
+	ErrorCategory string `json:"error_category,omitempty"`
+	RetryCount    int    `json:"retry_count,omitempty"`
+	MaxAttempts   int    `json:"max_attempts,omitempty"`
+	PayloadHash   string `json:"payload_hash,omitempty"`
+	PayloadBytes  int    `json:"payload_bytes,omitempty"`
+	CreatedAt     string `json:"created_at,omitempty"`
+	UpdatedAt     string `json:"updated_at,omitempty"`
+}
+
+type appendLogDeadLetterListOutput struct {
+	Records []appendLogDeadLetterSummary `json:"records"`
+	Count   int                          `json:"count"`
+}
+
+type appendLogDeadLetterActionOutput struct {
+	ID      string `json:"id"`
+	Status  string `json:"status"`
+	EventID string `json:"event_id"`
+	Subject string `json:"subject"`
+}
+
+func appendLogDeadLetterListResponse(records []ports.AppendLogDeadLetter) appendLogDeadLetterListOutput {
+	out := appendLogDeadLetterListOutput{Records: make([]appendLogDeadLetterSummary, 0, len(records)), Count: len(records)}
+	for _, record := range records {
+		out.Records = append(out.Records, appendLogDeadLetterSummaryFor(record))
+	}
+	return out
+}
+
+func appendLogDeadLetterSummaryFor(record ports.AppendLogDeadLetter) appendLogDeadLetterSummary {
+	summary := appendLogDeadLetterSummary{
+		ID:            record.ID,
+		Status:        record.Status,
+		Subject:       record.Subject,
+		Operation:     record.Operation,
+		EventID:       record.EventID,
+		EventKind:     record.EventKind,
+		TenantID:      record.TenantID,
+		SourceID:      record.SourceID,
+		RuntimeID:     record.RuntimeID,
+		JobID:         record.JobID,
+		ErrorCategory: record.ErrorCategory,
+		RetryCount:    record.RetryCount,
+		MaxAttempts:   record.MaxAttempts,
+		PayloadHash:   record.PayloadHash,
+		PayloadBytes:  record.PayloadBytes,
+	}
+	if !record.CreatedAt.IsZero() {
+		summary.CreatedAt = record.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if !record.UpdatedAt.IsZero() {
+		summary.UpdatedAt = record.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+	}
+	return summary
+}
+
+func appendLogDeadLetterActionResponse(record ports.AppendLogDeadLetter, status string) appendLogDeadLetterActionOutput {
+	return appendLogDeadLetterActionOutput{
+		ID:      record.ID,
+		Status:  status,
+		EventID: record.EventID,
+		Subject: record.Subject,
+	}
+}

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -76,6 +76,8 @@ func run(args []string) error {
 		return runSource(args[1:])
 	case "source-runtime":
 		return runSourceRuntime(args[1:])
+	case "append-log":
+		return runAppendLog(args[1:])
 	case "vulndb":
 		return runVulnDB(args[1:])
 	case "closeout":
@@ -86,7 +88,7 @@ func run(args []string) error {
 		fmt.Printf("%s %s\n", buildinfo.ServiceName, buildinfo.Version)
 		return nil
 	}
-	return usageError(fmt.Sprintf("usage: %s [serve|version|deploy|graph|orchestrator|finding-rule|source|source-runtime|vulndb|closeout]", os.Args[0]))
+	return usageError(fmt.Sprintf("usage: %s [serve|version|deploy|graph|orchestrator|finding-rule|source|source-runtime|append-log|vulndb|closeout]", os.Args[0]))
 }
 
 func serve() error {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -953,6 +953,31 @@ func TestParseSourceRuntimeListArgs(t *testing.T) {
 	}
 }
 
+func TestParseAppendLogDeadLetterListArgs(t *testing.T) {
+	filter, err := parseAppendLogDeadLetterListArgs([]string{
+		"status=all",
+		"subject=sec.findings.v1.recorded",
+		"runtime_id=runtime-1",
+		"source_id=github",
+		"limit=7",
+	})
+	if err != nil {
+		t.Fatalf("parseAppendLogDeadLetterListArgs() error = %v", err)
+	}
+	if filter.Status != "all" || filter.Subject != "sec.findings.v1.recorded" || filter.RuntimeID != "runtime-1" || filter.SourceID != "github" || filter.Limit != 7 {
+		t.Fatalf("parseAppendLogDeadLetterListArgs() = %#v", filter)
+	}
+}
+
+func TestParseAppendLogDeadLetterDiscardArgsRequiresReason(t *testing.T) {
+	if _, _, err := parseAppendLogDeadLetterDiscardArgs([]string{"apdl_1", "reason=operator replay skipped"}); err != nil {
+		t.Fatalf("parseAppendLogDeadLetterDiscardArgs() error = %v", err)
+	}
+	if _, _, err := parseAppendLogDeadLetterDiscardArgs([]string{"apdl_1", "reason= "}); err == nil {
+		t.Fatal("parseAppendLogDeadLetterDiscardArgs() error = nil, want missing reason error")
+	}
+}
+
 func TestParseSourceRuntimeListArgsRejectsZeroLimit(t *testing.T) {
 	if _, err := parseSourceRuntimeListArgs([]string{"limit=0"}); err == nil {
 		t.Fatal("parseSourceRuntimeListArgs(limit=0) error = nil, want error")

--- a/docs/operations/operations-runbook.md
+++ b/docs/operations/operations-runbook.md
@@ -115,6 +115,25 @@ Relevant variable:
 
 - `CEREBRO_JETSTREAM_DRAIN_TIMEOUT`
 
+If publish retries exhaust, check the recovery table before advancing runtime work:
+
+```bash
+./bin/cerebro append-log dead-letters list status=pending limit=20
+./bin/cerebro append-log dead-letters list subject=sec.findings.v1.recorded status=pending limit=20
+```
+
+After JetStream publish health is restored, replay one record:
+
+```bash
+./bin/cerebro append-log dead-letters replay <dead-letter-id>
+```
+
+Discard a record only after confirming the event should not be replayed:
+
+```bash
+./bin/cerebro append-log dead-letters discard <dead-letter-id> reason=<reason>
+```
+
 ### Neo4j or Aura
 
 Neo4j or Aura is required for graph projection, graph queries, graph health, graph ingest runs, impact queries, and graph-agent flows.

--- a/docs/operations/operations-runbook.md
+++ b/docs/operations/operations-runbook.md
@@ -134,6 +134,11 @@ Discard a record only after confirming the event should not be replayed:
 ./bin/cerebro append-log dead-letters discard <dead-letter-id> reason=<reason>
 ```
 
+Dead-letter IDs are deterministic for the subject, event ID, and payload. If the
+same event exhausts again after an operator has replayed or discarded that
+record, Cerebro preserves the terminal record and does not move it back to
+`pending`.
+
 ### Neo4j or Aura
 
 Neo4j or Aura is required for graph projection, graph queries, graph health, graph ingest runs, impact queries, and graph-agent flows.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,7 @@ make build
 ./bin/cerebro version
 ```
 
-Top-level commands are `serve`, `version`, `source`, `source-runtime`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
+Top-level commands are `serve`, `version`, `source`, `source-runtime`, `append-log`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
 
 Agent onboarding is a Makefile workflow around the CLI and HTTP API:
 
@@ -56,6 +56,22 @@ Source runtime persistence requires Postgres. Sync also requires NATS JetStream.
 ```
 
 See [Source runtime guide](../domains/source-runtime-guide.md) for store setup, secrets, sync behavior, and recovery.
+
+## Append Log Recovery
+
+Exhausted JetStream publishes are recorded in Postgres when the state store is configured. List pending records without requiring JetStream to be healthy:
+
+```bash
+./bin/cerebro append-log dead-letters list
+./bin/cerebro append-log dead-letters list subject=sec.findings.v1.recorded status=pending limit=20
+```
+
+Replay one record after the append-log path is healthy, or discard it after investigation:
+
+```bash
+./bin/cerebro append-log dead-letters replay <dead-letter-id>
+./bin/cerebro append-log dead-letters discard <dead-letter-id> reason=<reason>
+```
 
 ## Finding Rules
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,6 +73,9 @@ Replay one record after the append-log path is healthy, or discard it after inve
 ./bin/cerebro append-log dead-letters discard <dead-letter-id> reason=<reason>
 ```
 
+Dead-letter IDs are deterministic for the subject, event ID, and payload. A
+replayed or discarded record stays terminal if the same event exhausts again.
+
 ## Finding Rules
 
 ```bash

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -420,10 +420,20 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	publishResult, err := l.publishMsg(ctx, msg, "append", publishAttrs)
 	endAttrs := publishAttrs().With(publishResult.attrs())
 	if err != nil {
-		err = fmt.Errorf("publish event: %w", err)
-		recordJetStreamPublish(ctx, "append", subject, "failed", err, publishResult)
-		jetstreamTelemetryError(ctx, span, "append", err, endAttrs)
-		return err
+		publishErr := fmt.Errorf("publish event: %w", err)
+		recordJetStreamPublish(ctx, "append", subject, "failed", publishErr, publishResult)
+		jetstreamTelemetryError(ctx, span, "append", publishErr, endAttrs)
+		if publishResult.MaxExhausted {
+			return &ports.AppendLogPublishExhaustedError{
+				Operation:     "append",
+				Subject:       subject,
+				ErrorCategory: jetstreamErrorCategory(err),
+				RetryCount:    publishResult.RetryCount,
+				MaxAttempts:   publishResult.MaxAttempts,
+				Err:           publishErr,
+			}
+		}
+		return publishErr
 	}
 	recordJetStreamPublish(ctx, "append", subject, "completed", nil, publishResult)
 	if publishResult.RetryCount > 0 {

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -510,6 +510,34 @@ func TestAppendEmitsPublishRetryExhaustedTelemetry(t *testing.T) {
 	}
 }
 
+func TestAppendReturnsTypedPublishExhaustedError(t *testing.T) {
+	skipPublishRetryWaits(t)
+	errs := make([]error, publishRetryAttempts)
+	for i := range errs {
+		errs[i] = errors.New("nats: no response from stream")
+	}
+	pub := &fakePublisher{publishErrs: errs}
+	log := &Log{js: pub, subjectPrefix: "events"}
+
+	err := log.Append(context.Background(), &cerebrov1.EventEnvelope{
+		Id:   "evt-exhausted",
+		Kind: securityevents.FindingRecorded,
+	})
+	var exhausted *ports.AppendLogPublishExhaustedError
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("Append() error = %T %v, want AppendLogPublishExhaustedError", err, err)
+	}
+	if exhausted.Subject != securityevents.FindingRecorded {
+		t.Fatalf("exhausted subject = %q, want canonical finding subject", exhausted.Subject)
+	}
+	if exhausted.Operation != "append" || exhausted.ErrorCategory != "no_response" {
+		t.Fatalf("exhausted details = %#v", exhausted)
+	}
+	if exhausted.RetryCount != publishRetryAttempts-1 || exhausted.MaxAttempts != publishRetryAttempts {
+		t.Fatalf("exhausted retry budget = %d/%d, want %d/%d", exhausted.RetryCount, exhausted.MaxAttempts, publishRetryAttempts-1, publishRetryAttempts)
+	}
+}
+
 func TestAppendRetriesTransientPublishErrorWithDerivedMessageID(t *testing.T) {
 	skipPublishRetryWaits(t)
 	pub := &fakePublisher{

--- a/internal/appendlog/recovery/recovery.go
+++ b/internal/appendlog/recovery/recovery.go
@@ -1,0 +1,182 @@
+package recovery
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
+)
+
+// Wrap persists max-attempt-exhausted append failures to store before returning
+// the original append error to the caller.
+func Wrap(inner ports.AppendLog, store ports.AppendLogDeadLetterStore) ports.AppendLog {
+	if inner == nil || store == nil {
+		return inner
+	}
+	return &Log{inner: inner, store: store}
+}
+
+// Log records exhausted publish attempts while preserving the append-log
+// interface used by runtime and workflow services.
+type Log struct {
+	inner ports.AppendLog
+	store ports.AppendLogDeadLetterStore
+}
+
+func (l *Log) Ping(ctx context.Context) error {
+	if l == nil || l.inner == nil {
+		return errors.New("append log is not configured")
+	}
+	return l.inner.Ping(ctx)
+}
+
+func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error {
+	if l == nil || l.inner == nil {
+		return errors.New("append log is not configured")
+	}
+	err := l.inner.Append(ctx, event)
+	if err == nil {
+		return nil
+	}
+	if recordErr := l.recordExhaustedPublish(ctx, event, err); recordErr != nil {
+		return errors.Join(err, recordErr)
+	}
+	return err
+}
+
+func (l *Log) AppendBatch(ctx context.Context, events []*cerebrov1.EventEnvelope) error {
+	for index, event := range events {
+		if err := l.Append(ctx, event); err != nil {
+			return fmt.Errorf("append batch event %d: %w", index, err)
+		}
+	}
+	return nil
+}
+
+func (l *Log) Replay(ctx context.Context, request ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
+	replayer, ok := l.inner.(ports.EventReplayer)
+	if !ok || replayer == nil {
+		return nil, errors.New("append log replayer is not configured")
+	}
+	return replayer.Replay(ctx, request)
+}
+
+func (l *Log) ScanRuntimeIndex(ctx context.Context, fromSeq uint64, batch uint32) (ports.RuntimeIndexScan, error) {
+	source, ok := l.inner.(ports.RuntimeIndexSource)
+	if !ok || source == nil {
+		return ports.RuntimeIndexScan{}, errors.New("append log runtime index source is not configured")
+	}
+	return source.ScanRuntimeIndex(ctx, fromSeq, batch)
+}
+
+func (l *Log) recordExhaustedPublish(ctx context.Context, event *cerebrov1.EventEnvelope, err error) error {
+	if l == nil || l.store == nil {
+		return nil
+	}
+	var exhausted *ports.AppendLogPublishExhaustedError
+	if !errors.As(err, &exhausted) || exhausted == nil {
+		return nil
+	}
+	record, recordErr := deadLetterFromEvent(event, exhausted)
+	if recordErr != nil {
+		return fmt.Errorf("build append log dead letter: %w", recordErr)
+	}
+	if err := l.store.RecordAppendLogDeadLetter(ctx, record); err != nil {
+		return fmt.Errorf("record append log dead letter %q: %w", record.ID, err)
+	}
+	telemetry.Event(ctx, "append_log.dead_letter.recorded", telemetry.Attrs(
+		telemetry.Field{Key: "append_log.dead_letter.id", Value: record.ID},
+		telemetry.Field{Key: "messaging.jetstream.subject", Value: record.Subject},
+		telemetry.Field{Key: "event.kind", Value: record.EventKind},
+		telemetry.Field{Key: "event.id_hash", Value: shortRecordHash(record.EventID)},
+		telemetry.Field{Key: "runtime_id", Value: record.RuntimeID},
+		telemetry.Field{Key: "source_id", Value: record.SourceID},
+		telemetry.Field{Key: "tenant_id", Value: record.TenantID},
+		telemetry.Field{Key: "job_id", Value: record.JobID},
+		telemetry.Field{Key: "error_category", Value: record.ErrorCategory},
+		telemetry.Field{Key: "retry_count", Value: record.RetryCount},
+		telemetry.Field{Key: "max_attempts", Value: record.MaxAttempts},
+	))
+	telemetry.IncrementMain(ctx, "append_log.dead_letter.recorded.count", 1)
+	return nil
+}
+
+func deadLetterFromEvent(event *cerebrov1.EventEnvelope, exhausted *ports.AppendLogPublishExhaustedError) (ports.AppendLogDeadLetter, error) {
+	if event == nil {
+		return ports.AppendLogDeadLetter{}, errors.New("event is required")
+	}
+	payload, hash, err := deterministicEventPayload(event)
+	if err != nil {
+		return ports.AppendLogDeadLetter{}, err
+	}
+	eventID := strings.TrimSpace(event.GetId())
+	if eventID == "" {
+		eventID = "sha256:" + hash
+	}
+	attrs := event.GetAttributes()
+	record := ports.AppendLogDeadLetter{
+		ID:            deadLetterID(strings.TrimSpace(exhausted.Subject), eventID, hash),
+		Status:        ports.AppendLogDeadLetterStatusPending,
+		Subject:       strings.TrimSpace(exhausted.Subject),
+		Operation:     strings.TrimSpace(exhausted.Operation),
+		EventID:       eventID,
+		EventKind:     strings.TrimSpace(event.GetKind()),
+		TenantID:      strings.TrimSpace(event.GetTenantId()),
+		SourceID:      strings.TrimSpace(event.GetSourceId()),
+		RuntimeID:     strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]),
+		JobID:         strings.TrimSpace(attrs[ports.EventAttributeJobID]),
+		ErrorCategory: strings.TrimSpace(exhausted.ErrorCategory),
+		ErrorMessage:  strings.TrimSpace(exhausted.Error()),
+		RetryCount:    exhausted.RetryCount,
+		MaxAttempts:   exhausted.MaxAttempts,
+		PayloadHash:   hash,
+		PayloadBytes:  len(payload),
+		Event:         proto.Clone(event).(*cerebrov1.EventEnvelope),
+	}
+	if record.Operation == "" {
+		record.Operation = "append"
+	}
+	if record.ErrorCategory == "" {
+		record.ErrorCategory = "unknown"
+	}
+	return record, nil
+}
+
+func deterministicEventPayload(event *cerebrov1.EventEnvelope) ([]byte, string, error) {
+	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(event)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal append log event: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return payload, hex.EncodeToString(sum[:]), nil
+}
+
+func deadLetterID(subject string, eventID string, payloadHash string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		strings.TrimSpace(subject),
+		strings.TrimSpace(eventID),
+		strings.TrimSpace(payloadHash),
+	}, "\x00")))
+	return "apdl_" + hex.EncodeToString(sum[:16])
+}
+
+func shortRecordHash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	return hex.EncodeToString(sum[:8])
+}
+
+var _ ports.AppendLog = (*Log)(nil)
+var _ ports.AppendLogBatcher = (*Log)(nil)
+var _ ports.EventReplayer = (*Log)(nil)
+var _ ports.RuntimeIndexSource = (*Log)(nil)

--- a/internal/appendlog/recovery/recovery_test.go
+++ b/internal/appendlog/recovery/recovery_test.go
@@ -1,0 +1,187 @@
+package recovery
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestAppendRecordsExhaustedPublish(t *testing.T) {
+	inner := &recordingLog{err: &ports.AppendLogPublishExhaustedError{
+		Operation:     "append",
+		Subject:       "sec.findings.v1.recorded",
+		ErrorCategory: "no_response",
+		RetryCount:    3,
+		MaxAttempts:   4,
+		Err:           errors.New("publish event: no response"),
+	}}
+	store := &recordingStore{}
+	log := Wrap(inner, store)
+	event := recoveryTestEvent("finding-1")
+
+	err := log.Append(context.Background(), event)
+	if err == nil {
+		t.Fatal("Append() error = nil, want original publish error")
+	}
+	if len(store.records) != 1 {
+		t.Fatalf("dead letter records = %d, want 1", len(store.records))
+	}
+	record := store.records[0]
+	if record.Subject != "sec.findings.v1.recorded" || record.EventID != "finding-1" || record.EventKind != "sec.findings.v1.recorded" {
+		t.Fatalf("record event fields = %#v", record)
+	}
+	if record.RuntimeID != "runtime-1" || record.SourceID != "github" || record.TenantID != "writer" || record.JobID != "job-1" {
+		t.Fatalf("record context fields = %#v", record)
+	}
+	if record.RetryCount != 3 || record.MaxAttempts != 4 || record.ErrorCategory != "no_response" {
+		t.Fatalf("record retry fields = %#v", record)
+	}
+	if record.ID == "" || record.PayloadHash == "" || record.PayloadBytes == 0 || record.Event == nil {
+		t.Fatalf("record durability fields missing: %#v", record)
+	}
+	if inner.events[0] == record.Event {
+		t.Fatal("record reused event pointer; want cloned event")
+	}
+}
+
+func TestAppendDoesNotRecordNonExhaustedError(t *testing.T) {
+	inner := &recordingLog{err: errors.New("validation failed")}
+	store := &recordingStore{}
+	log := Wrap(inner, store)
+
+	err := log.Append(context.Background(), recoveryTestEvent("finding-1"))
+	if err == nil {
+		t.Fatal("Append() error = nil, want original error")
+	}
+	if len(store.records) != 0 {
+		t.Fatalf("dead letter records = %d, want 0", len(store.records))
+	}
+}
+
+func TestAppendReturnsStoreFailureWithOriginalError(t *testing.T) {
+	inner := &recordingLog{err: &ports.AppendLogPublishExhaustedError{
+		Subject:       "sec.findings.v1.recorded",
+		ErrorCategory: "no_response",
+		Err:           errors.New("publish event: no response"),
+	}}
+	storeErr := errors.New("postgres unavailable")
+	log := Wrap(inner, &recordingStore{recordErr: storeErr})
+
+	err := log.Append(context.Background(), recoveryTestEvent("finding-1"))
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("Append() error = %v, want joined store error", err)
+	}
+	if !strings.Contains(err.Error(), "publish event: no response") {
+		t.Fatalf("Append() error = %v, want original publish error text", err)
+	}
+}
+
+func TestAppendBatchRecordsFailedEvent(t *testing.T) {
+	inner := &recordingLog{
+		failOnID: "finding-2",
+		err: &ports.AppendLogPublishExhaustedError{
+			Subject:       "sec.findings.v1.recorded",
+			ErrorCategory: "no_response",
+			Err:           errors.New("publish event: no response"),
+		},
+	}
+	store := &recordingStore{}
+	log := Wrap(inner, store).(ports.AppendLogBatcher)
+
+	err := log.AppendBatch(context.Background(), []*cerebrov1.EventEnvelope{
+		recoveryTestEvent("finding-1"),
+		recoveryTestEvent("finding-2"),
+	})
+	if err == nil {
+		t.Fatal("AppendBatch() error = nil, want failed event error")
+	}
+	if len(store.records) != 1 || store.records[0].EventID != "finding-2" {
+		t.Fatalf("recorded events = %#v, want only failed event finding-2", store.records)
+	}
+}
+
+func TestReplayDelegatesToInnerReplayer(t *testing.T) {
+	event := recoveryTestEvent("finding-1")
+	inner := &recordingLog{replayEvents: []*cerebrov1.EventEnvelope{event}}
+	log := Wrap(inner, &recordingStore{}).(ports.EventReplayer)
+
+	got, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "runtime-1"})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(got) != 1 || got[0].GetId() != "finding-1" {
+		t.Fatalf("Replay() events = %#v", got)
+	}
+	if inner.replayRequests != 1 {
+		t.Fatalf("inner replay requests = %d, want 1", inner.replayRequests)
+	}
+}
+
+func recoveryTestEvent(id string) *cerebrov1.EventEnvelope {
+	return &cerebrov1.EventEnvelope{
+		Id:       id,
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "sec.findings.v1.recorded",
+		Attributes: map[string]string{
+			ports.EventAttributeSourceRuntimeID: "runtime-1",
+			ports.EventAttributeJobID:           "job-1",
+		},
+	}
+}
+
+type recordingLog struct {
+	err            error
+	failOnID       string
+	events         []*cerebrov1.EventEnvelope
+	replayEvents   []*cerebrov1.EventEnvelope
+	replayRequests int
+}
+
+func (l *recordingLog) Ping(context.Context) error { return nil }
+
+func (l *recordingLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	l.events = append(l.events, event)
+	if l.failOnID == "" || event.GetId() == l.failOnID {
+		return l.err
+	}
+	return nil
+}
+
+func (l *recordingLog) Replay(context.Context, ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
+	l.replayRequests++
+	return l.replayEvents, nil
+}
+
+type recordingStore struct {
+	records   []ports.AppendLogDeadLetter
+	recordErr error
+}
+
+func (s *recordingStore) RecordAppendLogDeadLetter(_ context.Context, record ports.AppendLogDeadLetter) error {
+	if s.recordErr != nil {
+		return s.recordErr
+	}
+	s.records = append(s.records, record)
+	return nil
+}
+
+func (s *recordingStore) ListAppendLogDeadLetters(context.Context, ports.AppendLogDeadLetterFilter) ([]ports.AppendLogDeadLetter, error) {
+	return nil, nil
+}
+
+func (s *recordingStore) GetAppendLogDeadLetter(context.Context, string) (ports.AppendLogDeadLetter, error) {
+	return ports.AppendLogDeadLetter{}, nil
+}
+
+func (s *recordingStore) MarkAppendLogDeadLetterReplayed(context.Context, string) error {
+	return nil
+}
+
+func (s *recordingStore) DiscardAppendLogDeadLetter(context.Context, string, string) error {
+	return nil
+}

--- a/internal/appendlog/recovery/recovery_test.go
+++ b/internal/appendlog/recovery/recovery_test.go
@@ -3,7 +3,6 @@ package recovery
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -63,10 +62,11 @@ func TestAppendDoesNotRecordNonExhaustedError(t *testing.T) {
 }
 
 func TestAppendReturnsStoreFailureWithOriginalError(t *testing.T) {
+	publishErr := errors.New("publish event: no response")
 	inner := &recordingLog{err: &ports.AppendLogPublishExhaustedError{
 		Subject:       "sec.findings.v1.recorded",
 		ErrorCategory: "no_response",
-		Err:           errors.New("publish event: no response"),
+		Err:           publishErr,
 	}}
 	storeErr := errors.New("postgres unavailable")
 	log := Wrap(inner, &recordingStore{recordErr: storeErr})
@@ -75,8 +75,8 @@ func TestAppendReturnsStoreFailureWithOriginalError(t *testing.T) {
 	if !errors.Is(err, storeErr) {
 		t.Fatalf("Append() error = %v, want joined store error", err)
 	}
-	if !strings.Contains(err.Error(), "publish event: no response") {
-		t.Fatalf("Append() error = %v, want original publish error text", err)
+	if !errors.Is(err, publishErr) {
+		t.Fatalf("Append() error = %v, want original publish error", err)
 	}
 }
 

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	appendlogjetstream "github.com/writer/cerebro/internal/appendlog/jetstream"
+	appendlogrecovery "github.com/writer/cerebro/internal/appendlog/recovery"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphagent"
 	graphstoreneo4j "github.com/writer/cerebro/internal/graphstore/neo4j"
@@ -40,7 +41,6 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 		_ = closeAll()
 		return Dependencies{}, func() error { return nil }, err
 	}
-
 	if cfg.AppendLog.Driver == config.AppendLogDriverJetStream {
 		appendLog, err := appendlogjetstream.Open(cfg.AppendLog)
 		if err != nil {
@@ -67,6 +67,9 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 				appendLog.SetRuntimeReplayIndex(index)
 			}
 		}
+	}
+	if store, ok := deps.StateStore.(ports.AppendLogDeadLetterStore); ok && !isNilInterface(store) {
+		deps.AppendLog = appendlogrecovery.Wrap(deps.AppendLog, store)
 	}
 	switch cfg.GraphStore.Driver {
 	case "":
@@ -140,8 +143,7 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	return deps, closeAll, nil
 }
 
-// OpenSourceRuntimeBootstrapDependencies opens only the state-store dependency
-// required to validate and persist source runtime definitions.
+// OpenSourceRuntimeBootstrapDependencies opens only the state-store dependency required to validate and persist source runtime definitions.
 func OpenSourceRuntimeBootstrapDependencies(ctx context.Context, cfg config.Config) (Dependencies, func() error, error) {
 	var (
 		deps    Dependencies
@@ -162,7 +164,6 @@ func OpenSourceRuntimeBootstrapDependencies(ctx context.Context, cfg config.Conf
 		_ = closeAll()
 		return Dependencies{}, func() error { return nil }, err
 	}
-
 	if cfg.StateStore.Driver == config.StateStoreDriverPostgres {
 		stateStore, err := statestorepostgres.Open(cfg.StateStore)
 		if err != nil {
@@ -178,7 +179,6 @@ func OpenSourceRuntimeBootstrapDependencies(ctx context.Context, cfg config.Conf
 	}
 	return deps, closeAll, nil
 }
-
 func graphAgentLLMConfigured(cfg config.GraphAgentLLMConfig) bool {
 	return cfg.Provider != "" || cfg.Model != "" ||
 		cfg.SonnetModel != "" || cfg.OpusModel != "" || cfg.HaikuModel != "" ||

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -2,12 +2,24 @@ package ports
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
 const EventAttributeSourceRuntimeID = "source_runtime_id"
+const EventAttributeJobID = "job_id"
+
+var ErrAppendLogDeadLetterNotFound = errors.New("append log dead letter not found")
+
+const (
+	AppendLogDeadLetterStatusPending   = "pending"
+	AppendLogDeadLetterStatusReplayed  = "replayed"
+	AppendLogDeadLetterStatusDiscarded = "discarded"
+)
 
 // AppendLog is the future append-only event log boundary.
 type AppendLog interface {
@@ -19,6 +31,84 @@ type AppendLog interface {
 // publish a validated page or upload batch through one boundary.
 type AppendLogBatcher interface {
 	AppendBatch(context.Context, []*cerebrov1.EventEnvelope) error
+}
+
+// AppendLogPublishExhaustedError marks a publish that exhausted the configured
+// retry budget. It lets recovery wrappers distinguish durable publish failures
+// from validation, authorization, and caller-cancellation errors.
+type AppendLogPublishExhaustedError struct {
+	Operation     string
+	Subject       string
+	ErrorCategory string
+	RetryCount    int
+	MaxAttempts   int
+	Err           error
+}
+
+func (e *AppendLogPublishExhaustedError) Error() string {
+	subject := strings.TrimSpace(e.Subject)
+	if subject == "" {
+		subject = "unknown"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("append log publish exhausted for subject %s", subject)
+	}
+	return fmt.Sprintf("append log publish exhausted for subject %s: %v", subject, e.Err)
+}
+
+func (e *AppendLogPublishExhaustedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// AppendLogDeadLetter records one append-log event that could not be published
+// after all configured attempts.
+type AppendLogDeadLetter struct {
+	ID            string
+	Status        string
+	Subject       string
+	Operation     string
+	EventID       string
+	EventKind     string
+	TenantID      string
+	SourceID      string
+	RuntimeID     string
+	JobID         string
+	ErrorCategory string
+	ErrorMessage  string
+	RetryCount    int
+	MaxAttempts   int
+	PayloadHash   string
+	PayloadBytes  int
+	Event         *cerebrov1.EventEnvelope
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	ReplayedAt    time.Time
+	DiscardedAt   time.Time
+	DiscardReason string
+}
+
+// AppendLogDeadLetterFilter scopes operator reads over persisted publish
+// recovery records.
+type AppendLogDeadLetterFilter struct {
+	Status    string
+	Subject   string
+	RuntimeID string
+	SourceID  string
+	Limit     uint32
+}
+
+// AppendLogDeadLetterStore persists and manages exhausted publish recovery
+// records outside JetStream so broker degradation does not recursively depend
+// on the same append path.
+type AppendLogDeadLetterStore interface {
+	RecordAppendLogDeadLetter(context.Context, AppendLogDeadLetter) error
+	ListAppendLogDeadLetters(context.Context, AppendLogDeadLetterFilter) ([]AppendLogDeadLetter, error)
+	GetAppendLogDeadLetter(context.Context, string) (AppendLogDeadLetter, error)
+	MarkAppendLogDeadLetterReplayed(context.Context, string) error
+	DiscardAppendLogDeadLetter(context.Context, string, string) error
 }
 
 // ReplayRequest scopes a bounded event replay from the append log.

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -14,6 +14,7 @@ const EventAttributeSourceRuntimeID = "source_runtime_id"
 const EventAttributeJobID = "job_id"
 
 var ErrAppendLogDeadLetterNotFound = errors.New("append log dead letter not found")
+var ErrAppendLogDeadLetterAlreadyReplayed = errors.New("append log dead letter already replayed")
 
 const (
 	AppendLogDeadLetterStatusPending   = "pending"

--- a/internal/statestore/postgres/append_log_dead_letters.go
+++ b/internal/statestore/postgres/append_log_dead_letters.go
@@ -47,6 +47,36 @@ var ensureAppendLogDeadLetterStatements = []string{`CREATE TABLE IF NOT EXISTS a
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_source_status_idx ON append_log_dead_letters (source_id, status, updated_at ASC)`,
 }
 
+const recordAppendLogDeadLetterSQL = `
+	INSERT INTO append_log_dead_letters (
+	  id, status, subject, operation, event_id, event_kind, tenant_id, source_id,
+	  runtime_id, job_id, error_category, error_message, retry_count, max_attempts,
+	  payload_hash, payload_bytes, event_json
+	)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb)
+	ON CONFLICT (id)
+	DO UPDATE SET status = EXCLUDED.status,
+	              subject = EXCLUDED.subject,
+	              operation = EXCLUDED.operation,
+	              event_id = EXCLUDED.event_id,
+	              event_kind = EXCLUDED.event_kind,
+	              tenant_id = EXCLUDED.tenant_id,
+	              source_id = EXCLUDED.source_id,
+	              runtime_id = EXCLUDED.runtime_id,
+	              job_id = EXCLUDED.job_id,
+	              error_category = EXCLUDED.error_category,
+	              error_message = EXCLUDED.error_message,
+	              retry_count = EXCLUDED.retry_count,
+	              max_attempts = EXCLUDED.max_attempts,
+	              payload_hash = EXCLUDED.payload_hash,
+	              payload_bytes = EXCLUDED.payload_bytes,
+	              event_json = EXCLUDED.event_json,
+	              updated_at = NOW(),
+	              replayed_at = NULL,
+	              discarded_at = NULL,
+	              discard_reason = ''
+	WHERE append_log_dead_letters.status = 'pending'`
+
 func (s *Store) RecordAppendLogDeadLetter(ctx context.Context, record ports.AppendLogDeadLetter) error {
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")
@@ -62,34 +92,7 @@ func (s *Store) RecordAppendLogDeadLetter(ctx context.Context, record ports.Appe
 	if err != nil {
 		return fmt.Errorf("marshal append log dead letter event %q: %w", record.EventID, err)
 	}
-	_, err = s.db.ExecContext(ctx, `
-INSERT INTO append_log_dead_letters (
-  id, status, subject, operation, event_id, event_kind, tenant_id, source_id,
-  runtime_id, job_id, error_category, error_message, retry_count, max_attempts,
-  payload_hash, payload_bytes, event_json
-)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb)
-ON CONFLICT (id)
-DO UPDATE SET status = EXCLUDED.status,
-              subject = EXCLUDED.subject,
-              operation = EXCLUDED.operation,
-              event_id = EXCLUDED.event_id,
-              event_kind = EXCLUDED.event_kind,
-              tenant_id = EXCLUDED.tenant_id,
-              source_id = EXCLUDED.source_id,
-              runtime_id = EXCLUDED.runtime_id,
-              job_id = EXCLUDED.job_id,
-              error_category = EXCLUDED.error_category,
-              error_message = EXCLUDED.error_message,
-              retry_count = EXCLUDED.retry_count,
-              max_attempts = EXCLUDED.max_attempts,
-              payload_hash = EXCLUDED.payload_hash,
-              payload_bytes = EXCLUDED.payload_bytes,
-              event_json = EXCLUDED.event_json,
-              updated_at = NOW(),
-              replayed_at = NULL,
-              discarded_at = NULL,
-              discard_reason = ''`,
+	_, err = s.db.ExecContext(ctx, recordAppendLogDeadLetterSQL,
 		record.ID,
 		record.Status,
 		record.Subject,
@@ -206,9 +209,28 @@ func (s *Store) updateAppendLogDeadLetterStatus(ctx context.Context, id string, 
 		return fmt.Errorf("update append log dead letter %q rows affected: %w", id, err)
 	}
 	if rows == 0 {
-		return ports.ErrAppendLogDeadLetterNotFound
+		return s.appendLogDeadLetterStatusConflict(ctx, id, status)
 	}
 	return nil
+}
+
+func (s *Store) appendLogDeadLetterStatusConflict(ctx context.Context, id string, targetStatus string) error {
+	var currentStatus string
+	err := s.db.QueryRowContext(ctx, `SELECT status FROM append_log_dead_letters WHERE id = $1`, id).Scan(&currentStatus)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ports.ErrAppendLogDeadLetterNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("query append log dead letter %q status: %w", id, err)
+	}
+	return appendLogDeadLetterTransitionConflictError(id, targetStatus, currentStatus)
+}
+
+func appendLogDeadLetterTransitionConflictError(id string, targetStatus string, currentStatus string) error {
+	if strings.TrimSpace(targetStatus) == ports.AppendLogDeadLetterStatusReplayed && strings.TrimSpace(currentStatus) == ports.AppendLogDeadLetterStatusReplayed {
+		return ports.ErrAppendLogDeadLetterAlreadyReplayed
+	}
+	return fmt.Errorf("append log dead letter %q has status %q", id, currentStatus)
 }
 
 func appendLogDeadLetterSelectSQL() string {

--- a/internal/statestore/postgres/append_log_dead_letters.go
+++ b/internal/statestore/postgres/append_log_dead_letters.go
@@ -1,0 +1,385 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const appendLogDeadLetterDefaultLimit = uint32(50)
+const appendLogDeadLetterMaxLimit = uint32(500)
+
+var ensureAppendLogDeadLetterStatements = []string{`CREATE TABLE IF NOT EXISTS append_log_dead_letters (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  operation TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  event_kind TEXT NOT NULL,
+  tenant_id TEXT NOT NULL DEFAULT '',
+  source_id TEXT NOT NULL DEFAULT '',
+  runtime_id TEXT NOT NULL DEFAULT '',
+  job_id TEXT NOT NULL DEFAULT '',
+  error_category TEXT NOT NULL DEFAULT '',
+  error_message TEXT NOT NULL DEFAULT '',
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 0,
+  payload_hash TEXT NOT NULL,
+  payload_bytes INTEGER NOT NULL DEFAULT 0,
+  event_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  replayed_at TIMESTAMPTZ,
+  discarded_at TIMESTAMPTZ,
+  discard_reason TEXT NOT NULL DEFAULT ''
+)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_status_updated_idx ON append_log_dead_letters (status, updated_at ASC, id ASC)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_subject_status_idx ON append_log_dead_letters (subject, status, updated_at ASC)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_runtime_status_idx ON append_log_dead_letters (runtime_id, status, updated_at ASC)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_source_status_idx ON append_log_dead_letters (source_id, status, updated_at ASC)`,
+}
+
+func (s *Store) RecordAppendLogDeadLetter(ctx context.Context, record ports.AppendLogDeadLetter) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogDeadLetterTables(ctx); err != nil {
+		return err
+	}
+	record = normalizeAppendLogDeadLetter(record)
+	if err := validateAppendLogDeadLetter(record); err != nil {
+		return err
+	}
+	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(record.Event)
+	if err != nil {
+		return fmt.Errorf("marshal append log dead letter event %q: %w", record.EventID, err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO append_log_dead_letters (
+  id, status, subject, operation, event_id, event_kind, tenant_id, source_id,
+  runtime_id, job_id, error_category, error_message, retry_count, max_attempts,
+  payload_hash, payload_bytes, event_json
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb)
+ON CONFLICT (id)
+DO UPDATE SET status = EXCLUDED.status,
+              subject = EXCLUDED.subject,
+              operation = EXCLUDED.operation,
+              event_id = EXCLUDED.event_id,
+              event_kind = EXCLUDED.event_kind,
+              tenant_id = EXCLUDED.tenant_id,
+              source_id = EXCLUDED.source_id,
+              runtime_id = EXCLUDED.runtime_id,
+              job_id = EXCLUDED.job_id,
+              error_category = EXCLUDED.error_category,
+              error_message = EXCLUDED.error_message,
+              retry_count = EXCLUDED.retry_count,
+              max_attempts = EXCLUDED.max_attempts,
+              payload_hash = EXCLUDED.payload_hash,
+              payload_bytes = EXCLUDED.payload_bytes,
+              event_json = EXCLUDED.event_json,
+              updated_at = NOW(),
+              replayed_at = NULL,
+              discarded_at = NULL,
+              discard_reason = ''`,
+		record.ID,
+		record.Status,
+		record.Subject,
+		record.Operation,
+		record.EventID,
+		record.EventKind,
+		record.TenantID,
+		record.SourceID,
+		record.RuntimeID,
+		record.JobID,
+		record.ErrorCategory,
+		record.ErrorMessage,
+		record.RetryCount,
+		record.MaxAttempts,
+		record.PayloadHash,
+		record.PayloadBytes,
+		string(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("record append log dead letter %q: %w", record.ID, err)
+	}
+	return nil
+}
+
+func (s *Store) ListAppendLogDeadLetters(ctx context.Context, filter ports.AppendLogDeadLetterFilter) ([]ports.AppendLogDeadLetter, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogDeadLetterTables(ctx); err != nil {
+		return nil, err
+	}
+	query, args := appendLogDeadLetterListQuery(filter)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list append log dead letters: %w", err)
+	}
+	defer rows.Close()
+	var records []ports.AppendLogDeadLetter
+	for rows.Next() {
+		record, err := scanAppendLogDeadLetter(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list append log dead letters rows: %w", err)
+	}
+	return records, nil
+}
+
+func (s *Store) GetAppendLogDeadLetter(ctx context.Context, id string) (ports.AppendLogDeadLetter, error) {
+	if s == nil || s.db == nil {
+		return ports.AppendLogDeadLetter{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogDeadLetterTables(ctx); err != nil {
+		return ports.AppendLogDeadLetter{}, err
+	}
+	row := s.db.QueryRowContext(ctx, appendLogDeadLetterSelectSQL()+` WHERE id = $1`, strings.TrimSpace(id))
+	record, err := scanAppendLogDeadLetter(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ports.AppendLogDeadLetter{}, ports.ErrAppendLogDeadLetterNotFound
+		}
+		return ports.AppendLogDeadLetter{}, err
+	}
+	return record, nil
+}
+
+func (s *Store) MarkAppendLogDeadLetterReplayed(ctx context.Context, id string) error {
+	return s.updateAppendLogDeadLetterStatus(ctx, id, ports.AppendLogDeadLetterStatusReplayed, "")
+}
+
+func (s *Store) DiscardAppendLogDeadLetter(ctx context.Context, id string, reason string) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return errors.New("discard reason is required")
+	}
+	return s.updateAppendLogDeadLetterStatus(ctx, id, ports.AppendLogDeadLetterStatusDiscarded, reason)
+}
+
+func (s *Store) updateAppendLogDeadLetterStatus(ctx context.Context, id string, status string, reason string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogDeadLetterTables(ctx); err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("append log dead letter id is required")
+	}
+	status = strings.TrimSpace(status)
+	var (
+		query string
+		args  []any
+	)
+	switch status {
+	case ports.AppendLogDeadLetterStatusReplayed:
+		query = `UPDATE append_log_dead_letters SET status = $2, updated_at = NOW(), replayed_at = NOW() WHERE id = $1 AND status = 'pending'`
+		args = []any{id, status}
+	case ports.AppendLogDeadLetterStatusDiscarded:
+		query = `UPDATE append_log_dead_letters SET status = $2, updated_at = NOW(), discarded_at = NOW(), discard_reason = $3 WHERE id = $1 AND status = 'pending'`
+		args = []any{id, status, strings.TrimSpace(reason)}
+	default:
+		return fmt.Errorf("unsupported append log dead letter status %q", status)
+	}
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("update append log dead letter %q: %w", id, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update append log dead letter %q rows affected: %w", id, err)
+	}
+	if rows == 0 {
+		return ports.ErrAppendLogDeadLetterNotFound
+	}
+	return nil
+}
+
+func appendLogDeadLetterSelectSQL() string {
+	return `SELECT id, status, subject, operation, event_id, event_kind, tenant_id, source_id,
+       runtime_id, job_id, error_category, error_message, retry_count, max_attempts,
+       payload_hash, payload_bytes, event_json, created_at, updated_at, replayed_at,
+       discarded_at, discard_reason
+FROM append_log_dead_letters`
+}
+
+func appendLogDeadLetterListQuery(filter ports.AppendLogDeadLetterFilter) (string, []any) {
+	normalized := normalizeAppendLogDeadLetterFilter(filter)
+	var (
+		where []string
+		args  []any
+	)
+	if normalized.Status != "" && normalized.Status != "all" {
+		args = append(args, normalized.Status)
+		where = append(where, fmt.Sprintf("status = $%d", len(args)))
+	}
+	if normalized.Subject != "" {
+		args = append(args, normalized.Subject)
+		where = append(where, fmt.Sprintf("subject = $%d", len(args)))
+	}
+	if normalized.RuntimeID != "" {
+		args = append(args, normalized.RuntimeID)
+		where = append(where, fmt.Sprintf("runtime_id = $%d", len(args)))
+	}
+	if normalized.SourceID != "" {
+		args = append(args, normalized.SourceID)
+		where = append(where, fmt.Sprintf("source_id = $%d", len(args)))
+	}
+	if len(where) == 0 {
+		where = append(where, "TRUE")
+	}
+	args = append(args, int64(normalized.Limit))
+	return appendLogDeadLetterSelectSQL() + " WHERE " + strings.Join(where, " AND ") + fmt.Sprintf(" ORDER BY updated_at ASC, id ASC LIMIT $%d", len(args)), args
+}
+
+func normalizeAppendLogDeadLetterFilter(filter ports.AppendLogDeadLetterFilter) ports.AppendLogDeadLetterFilter {
+	filter.Status = strings.TrimSpace(filter.Status)
+	if filter.Status == "" {
+		filter.Status = ports.AppendLogDeadLetterStatusPending
+	}
+	filter.Subject = strings.TrimSpace(filter.Subject)
+	filter.RuntimeID = strings.TrimSpace(filter.RuntimeID)
+	filter.SourceID = strings.TrimSpace(filter.SourceID)
+	if filter.Limit == 0 {
+		filter.Limit = appendLogDeadLetterDefaultLimit
+	}
+	if filter.Limit > appendLogDeadLetterMaxLimit {
+		filter.Limit = appendLogDeadLetterMaxLimit
+	}
+	return filter
+}
+
+func normalizeAppendLogDeadLetter(record ports.AppendLogDeadLetter) ports.AppendLogDeadLetter {
+	record.ID = strings.TrimSpace(record.ID)
+	record.Status = strings.TrimSpace(record.Status)
+	if record.Status == "" {
+		record.Status = ports.AppendLogDeadLetterStatusPending
+	}
+	record.Subject = strings.TrimSpace(record.Subject)
+	record.Operation = strings.TrimSpace(record.Operation)
+	if record.Operation == "" {
+		record.Operation = "append"
+	}
+	record.EventID = strings.TrimSpace(record.EventID)
+	record.EventKind = strings.TrimSpace(record.EventKind)
+	record.TenantID = strings.TrimSpace(record.TenantID)
+	record.SourceID = strings.TrimSpace(record.SourceID)
+	record.RuntimeID = strings.TrimSpace(record.RuntimeID)
+	record.JobID = strings.TrimSpace(record.JobID)
+	record.ErrorCategory = strings.TrimSpace(record.ErrorCategory)
+	record.ErrorMessage = strings.TrimSpace(record.ErrorMessage)
+	record.PayloadHash = strings.TrimSpace(record.PayloadHash)
+	if record.PayloadBytes < 0 {
+		record.PayloadBytes = 0
+	}
+	return record
+}
+
+func validateAppendLogDeadLetter(record ports.AppendLogDeadLetter) error {
+	if record.ID == "" {
+		return errors.New("append log dead letter id is required")
+	}
+	switch record.Status {
+	case ports.AppendLogDeadLetterStatusPending, ports.AppendLogDeadLetterStatusReplayed, ports.AppendLogDeadLetterStatusDiscarded:
+	default:
+		return fmt.Errorf("unsupported append log dead letter status %q", record.Status)
+	}
+	if record.Subject == "" {
+		return errors.New("append log dead letter subject is required")
+	}
+	if record.EventID == "" {
+		return errors.New("append log dead letter event id is required")
+	}
+	if record.EventKind == "" {
+		return errors.New("append log dead letter event kind is required")
+	}
+	if record.PayloadHash == "" {
+		return errors.New("append log dead letter payload hash is required")
+	}
+	if record.Event == nil {
+		return errors.New("append log dead letter event is required")
+	}
+	return nil
+}
+
+type appendLogDeadLetterScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAppendLogDeadLetter(scanner appendLogDeadLetterScanner) (ports.AppendLogDeadLetter, error) {
+	var (
+		record        ports.AppendLogDeadLetter
+		eventJSON     []byte
+		createdAt     time.Time
+		updatedAt     time.Time
+		replayedAt    sql.NullTime
+		discardedAt   sql.NullTime
+		discardReason string
+	)
+	if err := scanner.Scan(
+		&record.ID,
+		&record.Status,
+		&record.Subject,
+		&record.Operation,
+		&record.EventID,
+		&record.EventKind,
+		&record.TenantID,
+		&record.SourceID,
+		&record.RuntimeID,
+		&record.JobID,
+		&record.ErrorCategory,
+		&record.ErrorMessage,
+		&record.RetryCount,
+		&record.MaxAttempts,
+		&record.PayloadHash,
+		&record.PayloadBytes,
+		&eventJSON,
+		&createdAt,
+		&updatedAt,
+		&replayedAt,
+		&discardedAt,
+		&discardReason,
+	); err != nil {
+		return ports.AppendLogDeadLetter{}, err
+	}
+	var event cerebrov1.EventEnvelope
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(eventJSON, &event); err != nil {
+		return ports.AppendLogDeadLetter{}, fmt.Errorf("unmarshal append log dead letter event %q: %w", record.ID, err)
+	}
+	record.Event = &event
+	record.CreatedAt = createdAt
+	record.UpdatedAt = updatedAt
+	if replayedAt.Valid {
+		record.ReplayedAt = replayedAt.Time
+	}
+	if discardedAt.Valid {
+		record.DiscardedAt = discardedAt.Time
+	}
+	record.DiscardReason = strings.TrimSpace(discardReason)
+	return record, nil
+}
+
+func (s *Store) ensureAppendLogDeadLetterTables(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	return s.ensureStatements(ctx, &s.appendLogDeadLettersReady, "append_log_dead_letters", ensureAppendLogDeadLetterStatements)
+}
+
+var _ ports.AppendLogDeadLetterStore = (*Store)(nil)

--- a/internal/statestore/postgres/append_log_dead_letters.go
+++ b/internal/statestore/postgres/append_log_dead_letters.go
@@ -126,7 +126,7 @@ func (s *Store) ListAppendLogDeadLetters(ctx context.Context, filter ports.Appen
 	if err != nil {
 		return nil, fmt.Errorf("list append log dead letters: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var records []ports.AppendLogDeadLetter
 	for rows.Next() {
 		record, err := scanAppendLogDeadLetter(rows)

--- a/internal/statestore/postgres/append_log_dead_letters.go
+++ b/internal/statestore/postgres/append_log_dead_letters.go
@@ -379,7 +379,7 @@ func (s *Store) ensureAppendLogDeadLetterTables(ctx context.Context) error {
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")
 	}
-	return s.ensureStatements(ctx, &s.appendLogDeadLettersReady, "append_log_dead_letters", ensureAppendLogDeadLetterStatements)
+	return s.ensureStatements(ctx, &s.appendLog.deadLetters, "append_log_dead_letters", ensureAppendLogDeadLetterStatements)
 }
 
 var _ ports.AppendLogDeadLetterStore = (*Store)(nil)

--- a/internal/statestore/postgres/append_log_dead_letters_test.go
+++ b/internal/statestore/postgres/append_log_dead_letters_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -41,6 +42,31 @@ func TestAppendLogDeadLetterListQueryDefaultsToPending(t *testing.T) {
 	}
 	if len(args) != 2 || args[0] != ports.AppendLogDeadLetterStatusPending || args[1] != int64(appendLogDeadLetterDefaultLimit) {
 		t.Fatalf("query args = %#v, want pending and default limit", args)
+	}
+}
+
+func TestRecordAppendLogDeadLetterUpsertOnlyUpdatesPendingRows(t *testing.T) {
+	for _, fragment := range []string{
+		"ON CONFLICT (id)",
+		"discarded_at = NULL",
+		"discard_reason = ''",
+		"WHERE append_log_dead_letters.status = 'pending'",
+	} {
+		if !strings.Contains(recordAppendLogDeadLetterSQL, fragment) {
+			t.Fatalf("recordAppendLogDeadLetterSQL missing %q:\n%s", fragment, recordAppendLogDeadLetterSQL)
+		}
+	}
+}
+
+func TestAppendLogDeadLetterTransitionConflictAlreadyReplayed(t *testing.T) {
+	err := appendLogDeadLetterTransitionConflictError("apdl_1", ports.AppendLogDeadLetterStatusReplayed, ports.AppendLogDeadLetterStatusReplayed)
+	if !errors.Is(err, ports.ErrAppendLogDeadLetterAlreadyReplayed) {
+		t.Fatalf("transition conflict error = %v, want already replayed sentinel", err)
+	}
+
+	err = appendLogDeadLetterTransitionConflictError("apdl_1", ports.AppendLogDeadLetterStatusReplayed, ports.AppendLogDeadLetterStatusDiscarded)
+	if err == nil || errors.Is(err, ports.ErrAppendLogDeadLetterAlreadyReplayed) {
+		t.Fatalf("transition conflict error = %v, want status conflict", err)
 	}
 }
 

--- a/internal/statestore/postgres/append_log_dead_letters_test.go
+++ b/internal/statestore/postgres/append_log_dead_letters_test.go
@@ -1,0 +1,89 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestAppendLogDeadLetterSchemaShape(t *testing.T) {
+	joined := strings.Join(ensureAppendLogDeadLetterStatements, "\n")
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS append_log_dead_letters",
+		"id TEXT PRIMARY KEY",
+		"status TEXT NOT NULL",
+		"subject TEXT NOT NULL",
+		"runtime_id TEXT NOT NULL DEFAULT ''",
+		"job_id TEXT NOT NULL DEFAULT ''",
+		"event_json JSONB NOT NULL",
+		"append_log_dead_letters_status_updated_idx",
+		"append_log_dead_letters_subject_status_idx",
+		"append_log_dead_letters_runtime_status_idx",
+		"append_log_dead_letters_source_status_idx",
+	} {
+		if !strings.Contains(joined, fragment) {
+			t.Fatalf("append log dead letter schema missing %q:\n%s", fragment, joined)
+		}
+	}
+}
+
+func TestAppendLogDeadLetterListQueryDefaultsToPending(t *testing.T) {
+	query, args := appendLogDeadLetterListQuery(ports.AppendLogDeadLetterFilter{})
+	for _, fragment := range []string{
+		"WHERE status = $1",
+		"ORDER BY updated_at ASC, id ASC LIMIT $2",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("appendLogDeadLetterListQuery() = %q, missing %q", query, fragment)
+		}
+	}
+	if len(args) != 2 || args[0] != ports.AppendLogDeadLetterStatusPending || args[1] != int64(appendLogDeadLetterDefaultLimit) {
+		t.Fatalf("query args = %#v, want pending and default limit", args)
+	}
+}
+
+func TestAppendLogDeadLetterListQueryBoundsFilters(t *testing.T) {
+	query, args := appendLogDeadLetterListQuery(ports.AppendLogDeadLetterFilter{
+		Status:    "all",
+		Subject:   " sec.findings.v1.recorded ",
+		RuntimeID: " runtime-1 ",
+		SourceID:  " github ",
+		Limit:     1000,
+	})
+	if strings.Contains(query, "status =") {
+		t.Fatalf("query with status=all should not include status predicate: %q", query)
+	}
+	for _, fragment := range []string{
+		"subject = $1",
+		"runtime_id = $2",
+		"source_id = $3",
+		"LIMIT $4",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("appendLogDeadLetterListQuery() = %q, missing %q", query, fragment)
+		}
+	}
+	if len(args) != 4 || args[0] != "sec.findings.v1.recorded" || args[1] != "runtime-1" || args[2] != "github" || args[3] != int64(appendLogDeadLetterMaxLimit) {
+		t.Fatalf("query args = %#v, want trimmed filters and capped limit", args)
+	}
+}
+
+func TestValidateAppendLogDeadLetterRequiresReplayableEvent(t *testing.T) {
+	record := normalizeAppendLogDeadLetter(ports.AppendLogDeadLetter{
+		ID:          " apdl_1 ",
+		Subject:     " sec.findings.v1.recorded ",
+		EventID:     " event-1 ",
+		EventKind:   " sec.findings.v1.recorded ",
+		PayloadHash: " hash ",
+		Event:       &cerebrov1.EventEnvelope{Id: "event-1"},
+	})
+	if err := validateAppendLogDeadLetter(record); err != nil {
+		t.Fatalf("validateAppendLogDeadLetter() error = %v", err)
+	}
+	record.Event = nil
+	if err := validateAppendLogDeadLetter(record); err == nil {
+		t.Fatal("validateAppendLogDeadLetter() error = nil, want missing event error")
+	}
+}

--- a/internal/statestore/postgres/append_log_runtime_index.go
+++ b/internal/statestore/postgres/append_log_runtime_index.go
@@ -181,5 +181,5 @@ func boundedInt64(value uint64) int64 {
 }
 
 func (s *Store) ensureAppendLogRuntimeIndexTable(ctx context.Context) error {
-	return s.ensureStatements(ctx, &s.appendLogRuntimeIndexReady, "append log runtime index", ensureAppendLogRuntimeIndexStatements)
+	return s.ensureStatements(ctx, &s.appendLog.runtimeIndex, "append log runtime index", ensureAppendLogRuntimeIndexStatements)
 }

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -73,6 +73,7 @@ type Store struct {
 	connectorCredentialReady   bool
 	connectorDefinitionReady   bool
 	appendLogRuntimeIndexReady bool
+	appendLogDeadLettersReady  bool
 	userPreferencesReady       bool
 }
 

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -48,33 +48,37 @@ type grcTablesReady struct {
 	vendorQuestionnaire  bool
 }
 
+type appendLogTablesReady struct {
+	runtimeIndex bool
+	deadLetters  bool
+}
+
 // Store is the Postgres-backed current-state store implementation.
 type Store struct {
-	db                         *sql.DB
-	schemaMu                   sync.Mutex
-	claimTablesReady           bool
-	projectionTablesReady      bool
-	findingTablesReady         bool
-	reportTablesReady          bool
-	sourceRuntimeTableReady    bool
-	findingEvidenceReady       bool
-	findingEvaluationRunReady  bool
-	findingIntel               findingIntelReady
-	vulnDBTablesReady          bool
-	deviceAuthTablesReady      bool
-	mcpOAuthTablesReady        bool
-	startupLeaseTableReady     bool
-	schemaMigrationsReady      bool
-	ask                        askTablesReady
-	jobTablesReady             bool
-	runtimeBlocklistReady      bool
-	grc                        grcTablesReady
-	identity                   identityTablesReady
-	connectorCredentialReady   bool
-	connectorDefinitionReady   bool
-	appendLogRuntimeIndexReady bool
-	appendLogDeadLettersReady  bool
-	userPreferencesReady       bool
+	db                        *sql.DB
+	schemaMu                  sync.Mutex
+	claimTablesReady          bool
+	projectionTablesReady     bool
+	findingTablesReady        bool
+	reportTablesReady         bool
+	sourceRuntimeTableReady   bool
+	findingEvidenceReady      bool
+	findingEvaluationRunReady bool
+	findingIntel              findingIntelReady
+	vulnDBTablesReady         bool
+	deviceAuthTablesReady     bool
+	mcpOAuthTablesReady       bool
+	startupLeaseTableReady    bool
+	schemaMigrationsReady     bool
+	ask                       askTablesReady
+	jobTablesReady            bool
+	runtimeBlocklistReady     bool
+	grc                       grcTablesReady
+	identity                  identityTablesReady
+	connectorCredentialReady  bool
+	connectorDefinitionReady  bool
+	appendLog                 appendLogTablesReady
+	userPreferencesReady      bool
 }
 
 // Open opens a Postgres-backed current-state store.


### PR DESCRIPTION
## What changed

- Added a typed max-attempt-exhausted append-log publish error from the JetStream append path.
- Added an append-log recovery wrapper that records exhausted publishes to a Postgres-backed dead-letter table.
- Added operator CLI commands to list, replay, and discard append-log dead-letter records.
- Added docs for the recovery workflow in the CLI reference, operations runbook, and README command list.

## Why

JetStream publish retries can still exhaust under publish pressure. When that happens, operators need a durable record with enough context to inspect, replay, or discard the event instead of relying on logs alone.

## Impact

- Durable deployments with Postgres now record exhausted publish events outside JetStream.
- List and discard only require the Postgres state store, so operators can inspect records while JetStream is unhealthy.
- Replay requires the append-log path and marks the record replayed after a successful append.

## Validation

- `go test ./internal/appendlog/jetstream ./internal/appendlog/recovery ./internal/statestore/postgres ./internal/bootstrap ./cmd/cerebro ./tools/archtests -count=1`
- `make readme-check`
- `make docs-drift-check`
