### PR TITLE
Preserve questionnaire evidence IDs when unique

### DIFF
--- a/internal/grcvendor/questionnaire.go
+++ b/internal/grcvendor/questionnaire.go
@@ -162,14 +162,17 @@ func questionnaireEvidenceMatches(record ports.GRCVendorQuestionnaireReviewRecor
 	if record.QuestionnaireURN != "" {
 		add(ports.GRCVendorQuestionnaireEvidence{ID: "questionnaire", Label: firstNonEmpty(record.Title, "Security questionnaire"), Source: "questionnaire", URN: record.QuestionnaireURN, Confidence: "high", Reason: "Uploaded questionnaire artifact"})
 	}
+	questionnaireTails := relatedRecordTailCounts(relationships.SecurityQuestionnaires)
 	for _, related := range relationships.SecurityQuestionnaires {
-		add(ports.GRCVendorQuestionnaireEvidence{ID: "questionnaire:" + related.URN, Label: firstNonEmpty(related.Label, "Security questionnaire"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked questionnaire"})
+		add(ports.GRCVendorQuestionnaireEvidence{ID: relationshipEvidenceID("questionnaire", related, questionnaireTails), Label: firstNonEmpty(related.Label, "Security questionnaire"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked questionnaire"})
 	}
+	assuranceTails := relatedRecordTailCounts(relationships.AssuranceDocuments)
 	for _, related := range relationships.AssuranceDocuments {
-		add(ports.GRCVendorQuestionnaireEvidence{ID: "assurance:" + related.URN, Label: firstNonEmpty(related.Label, "Assurance document"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked assurance document"})
+		add(ports.GRCVendorQuestionnaireEvidence{ID: relationshipEvidenceID("assurance", related, assuranceTails), Label: firstNonEmpty(related.Label, "Assurance document"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked assurance document"})
 	}
+	reviewTails := relatedRecordTailCounts(relationships.SecurityReviews)
 	for _, related := range relationships.SecurityReviews {
-		add(ports.GRCVendorQuestionnaireEvidence{ID: "review:" + related.URN, Label: firstNonEmpty(related.Label, "Security review"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked security review"})
+		add(ports.GRCVendorQuestionnaireEvidence{ID: relationshipEvidenceID("review", related, reviewTails), Label: firstNonEmpty(related.Label, "Security review"), Source: "graph", URN: related.URN, Confidence: "high", Reason: "Linked security review"})
 	}
 	for _, item := range evidence {
 		add(ports.GRCVendorQuestionnaireEvidence{ID: "evidence:" + item.ID, Label: firstNonEmpty(item.Title, item.ID), Source: firstNonEmpty(item.SourceID, "finding_evidence"), ControlID: item.ControlID, Confidence: confidenceFromEvidenceState(item.State), Reason: firstNonEmpty(item.State, item.Type)})
@@ -188,6 +191,22 @@ func questionnaireEvidenceMatches(record ports.GRCVendorQuestionnaireReviewRecor
 	}
 	sort.SliceStable(matches, func(i, j int) bool { return matches[i].ID < matches[j].ID })
 	return dedupeQuestionnaireEvidence(matches)
+}
+
+func relatedRecordTailCounts(records []RelatedRecord) map[string]int {
+	counts := make(map[string]int, len(records))
+	for _, record := range records {
+		counts[urnTail(record.URN)]++
+	}
+	return counts
+}
+
+func relationshipEvidenceID(prefix string, record RelatedRecord, tailCounts map[string]int) string {
+	tail := urnTail(record.URN)
+	if tailCounts[tail] <= 1 {
+		return prefix + ":" + tail
+	}
+	return prefix + ":" + tail + ":" + hashString(record.URN)[:12]
 }
 
 func questionnaireMissingQuestions(vendor Vendor, findings []QuestionnaireFindingSignal) []ports.GRCVendorQuestionnaireMissing {

--- a/internal/grcvendor/questionnaire_test.go
+++ b/internal/grcvendor/questionnaire_test.go
@@ -88,9 +88,9 @@ func TestBuildQuestionnaireReviewEnrichmentUsesVendorEvidence(t *testing.T) {
 	}
 	for _, want := range []string{
 		"questionnaire",
-		"questionnaire:urn:cerebro:writer:security_questionnaire:vrm:linked-questionnaire",
-		"assurance:urn:cerebro:writer:assurance_document:vrm:soc2",
-		"review:urn:cerebro:writer:security_review:vrm:review-1",
+		"questionnaire:linked-questionnaire",
+		"assurance:soc2",
+		"review:review-1",
 		"evidence:evidence-1",
 		"finding:finding-1",
 	} {
@@ -127,9 +127,11 @@ func TestQuestionnaireEvidenceMatchesPreserveRelationshipURNIdentity(t *testing.
 
 	matches := questionnaireEvidenceMatches(ports.GRCVendorQuestionnaireReviewRecord{}, Vendor{}, relationships, nil, nil)
 
+	firstID := "questionnaire:sig-2026:" + hashString("urn:cerebro:writer:security_questionnaire:vrm:sig-2026")[:12]
+	secondID := "questionnaire:sig-2026:" + hashString("urn:cerebro:writer:security_questionnaire:manual:sig-2026")[:12]
 	for _, want := range []string{
-		"questionnaire:urn:cerebro:writer:security_questionnaire:vrm:sig-2026",
-		"questionnaire:urn:cerebro:writer:security_questionnaire:manual:sig-2026",
+		firstID,
+		secondID,
 	} {
 		if !hasQuestionnaireEvidence(matches, want) {
 			t.Fatalf("evidence matches missing %q: %#v", want, matches)


### PR DESCRIPTION
## Summary
- Keep existing tail-based questionnaire relationship evidence IDs when the tail is unique.
- Add a stable hash suffix only when related records would otherwise collide on the same URN tail.

## Validation
- go test ./internal/sourcehttp/grcvendorquestionnaire ./internal/bootstrap ./internal/grcvendor ./internal/statestore/postgres ./api -count=1
- make check-structural check-structural-test check-arch
- make lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->