### PR TITLE
Shard CI test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-shard:
     name: ${{ matrix.name }}
@@ -17,10 +21,6 @@ jobs:
         include:
           - name: build
             command: make build
-          - name: test
-            command: make test
-          - name: race
-            command: make test-race
           - name: coverage
             command: make cover
           - name: sdk
@@ -35,6 +35,7 @@ jobs:
             command: make lint
           - name: proto
             command: make proto-lint proto-generate-check proto-breaking
+            checkout_fetch_depth: '0'
           - name: openapi
             command: make openapi-check openapi-lint
           - name: catalog
@@ -45,6 +46,7 @@ jobs:
             command: make docs-drift-check
           - name: readme
             command: make readme-check
+            checkout_fetch_depth: '0'
           - name: oss-audit
             command: make oss-audit
           - name: govulncheck
@@ -58,26 +60,130 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ matrix.checkout_fetch_depth || '1' }}
+
+      - name: Fetch main for base comparisons
+        if: matrix.checkout_fetch_depth == '0'
+        run: git fetch origin main:refs/remotes/origin/main
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            tools/linters/go.sum
+
+      - name: Cache golangci-lint
+        if: matrix.name == 'lint'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-
 
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}
 
+  go-test-shard:
+    name: test-${{ matrix.shard_index }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            tools/linters/go.sum
+
+      - name: Run Go test shard ${{ matrix.shard_index }}
+        env:
+          GO_TEST_SHARD_TOTAL: 4
+          GO_TEST_SHARD_INDEX: ${{ matrix.shard_index }}
+        run: make test
+
+  go-race-shard:
+    name: race-${{ matrix.shard_index }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            tools/linters/go.sum
+
+      - name: Run Go race shard ${{ matrix.shard_index }}
+        env:
+          GO_TEST_SHARD_TOTAL: 4
+          GO_TEST_SHARD_INDEX: ${{ matrix.shard_index }}
+        run: make test-race
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [go-test-shard]
+    if: always()
+    steps:
+      - name: Check Go test shards
+        run: |
+          if [ "${{ needs.go-test-shard.result }}" != "success" ]; then
+            echo "One or more Go test shards failed"
+            exit 1
+          fi
+          echo "All Go test shards passed"
+
+  race:
+    runs-on: ubuntu-latest
+    needs: [go-race-shard]
+    if: always()
+    steps:
+      - name: Check Go race shards
+        run: |
+          if [ "${{ needs.go-race-shard.result }}" != "success" ]; then
+            echo "One or more Go race shards failed"
+            exit 1
+          fi
+          echo "All Go race shards passed"
+
   verify:
     runs-on: ubuntu-latest
-    needs: [verify-shard]
+    needs: [verify-shard, test, race]
     if: always()
     steps:
       - name: Check verify shards
         run: |
           if [ "${{ needs.verify-shard.result }}" != "success" ]; then
             echo "One or more verify shards failed"
+            exit 1
+          fi
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more Go test shards failed"
+            exit 1
+          fi
+          if [ "${{ needs.race.result }}" != "success" ]; then
+            echo "One or more Go race shards failed"
             exit 1
           fi
           echo "All verify shards passed"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
     - cron: '17 4 * * 2'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ GOLANGCI_LINT := $(GO_BIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.4
 GOLANGCI_LINT_CONCURRENCY ?= 4
 GOLANGCI_LINT_TIMEOUT ?= 20m
+GO_TEST_SHARD_TOTAL ?= 1
+GO_TEST_SHARD_INDEX ?= 0
 BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
@@ -137,11 +139,29 @@ serve: build ## Build and run the local HTTP server.
 serve-dev: build ## Build and run the local HTTP server with acknowledged dev-mode auth/rate-limit opt-out.
 	CEREBRO_DEV_MODE=1 CEREBRO_DEV_MODE_ACK=1 ./bin/cerebro serve
 
-test: ## Run all Go tests.
-	go test ./...
+test: ## Run all Go tests. Set GO_TEST_SHARD_TOTAL and GO_TEST_SHARD_INDEX to run one stable shard.
+	@set -e; \
+	package_file="$$(mktemp)"; \
+	trap 'rm -f "$$package_file"' EXIT; \
+	go list ./... > "$$package_file"; \
+	packages="$$( $(PYTHON) scripts/go_package_shard.py --total "$(GO_TEST_SHARD_TOTAL)" --index "$(GO_TEST_SHARD_INDEX)" < "$$package_file")"; \
+	if [ -z "$$packages" ]; then \
+		echo "no Go packages selected for shard $(GO_TEST_SHARD_INDEX)/$(GO_TEST_SHARD_TOTAL)"; \
+	else \
+		go test $$packages; \
+	fi
 
-test-race: ## Run all Go tests with the race detector.
-	go test -race -timeout 20m ./...
+test-race: ## Run all Go tests with the race detector. Set GO_TEST_SHARD_TOTAL and GO_TEST_SHARD_INDEX to run one stable shard.
+	@set -e; \
+	package_file="$$(mktemp)"; \
+	trap 'rm -f "$$package_file"' EXIT; \
+	go list ./... > "$$package_file"; \
+	packages="$$( $(PYTHON) scripts/go_package_shard.py --total "$(GO_TEST_SHARD_TOTAL)" --index "$(GO_TEST_SHARD_INDEX)" < "$$package_file")"; \
+	if [ -z "$$packages" ]; then \
+		echo "no Go packages selected for shard $(GO_TEST_SHARD_INDEX)/$(GO_TEST_SHARD_TOTAL)"; \
+	else \
+		go test -race -timeout 20m $$packages; \
+	fi
 
 cover: ## Run Go coverage for high-stakes packages.
 	mkdir -p "$(dir $(COVERAGE_OUT))"

--- a/scripts/go_package_shard.py
+++ b/scripts/go_package_shard.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Select a deterministic shard from a list of Go packages."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+
+
+def package_shard(package: str, total: int) -> int:
+    digest = hashlib.sha256(package.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % total
+
+
+def select_packages(packages: list[str], total: int, index: int) -> list[str]:
+    return [package for package in packages if package_shard(package, total) == index]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Select one stable shard from newline-delimited Go packages.")
+    parser.add_argument("--total", type=int, required=True, help="Total number of shards.")
+    parser.add_argument("--index", type=int, required=True, help="Zero-based shard index to print.")
+    args = parser.parse_args()
+
+    if args.total <= 0:
+        parser.error("--total must be positive")
+    if args.index < 0 or args.index >= args.total:
+        parser.error("--index must be between 0 and --total - 1")
+
+    packages = sorted(line.strip() for line in sys.stdin if line.strip())
+    for package in select_packages(packages, args.total, args.index):
+        print(package)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/land_pr.py
+++ b/scripts/land_pr.py
@@ -107,6 +107,89 @@ def fetch_comments(pr_number: int, repo: str) -> list[dict[str, object]]:
     return comments
 
 
+def repo_parts(repo: str) -> tuple[str, str]:
+    owner, separator, name = repo.partition("/")
+    if not owner or not separator or not name:
+        raise RuntimeError(f"repo must be OWNER/NAME, got {repo!r}")
+    return owner, name
+
+
+def fetch_active_review_threads(pr_number: int, repo: str) -> list[dict[str, object]]:
+    owner, name = repo_parts(repo)
+    query = """
+    query($owner:String!, $name:String!, $number:Int!, $after:String) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$number) {
+          reviewThreads(first:100, after:$after) {
+            nodes {
+              isResolved
+              isOutdated
+              path
+              line
+              comments(last:1) {
+                nodes {
+                  url
+                  body
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    }
+    """
+    active_threads = []
+    cursor: str | None = None
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={pr_number}",
+            "-f",
+            f"query={query}",
+        ]
+        if cursor:
+            args.extend(["-f", f"after={cursor}"])
+        else:
+            args.extend(["-F", "after=null"])
+        raw = run_gh(args, repo)
+        parsed = json.loads(raw)
+        review_threads = (
+            parsed.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+        )
+        for thread in review_threads.get("nodes", []):
+            if thread.get("isResolved") or thread.get("isOutdated"):
+                continue
+            comments = thread.get("comments", {}).get("nodes", [])
+            latest = comments[-1] if comments else {}
+            active_threads.append(
+                {
+                    "path": thread.get("path") or "",
+                    "line": thread.get("line"),
+                    "url": latest.get("url") or "",
+                    "body": latest.get("body") or "",
+                }
+            )
+        page_info = review_threads.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            return active_threads
+        cursor = str(page_info.get("endCursor") or "")
+        if not cursor:
+            raise RuntimeError("review thread pagination did not return an end cursor")
+
+
 def check_named_status(checks: list[dict[str, object]], name: str) -> tuple[bool, str]:
     matches = [check for check in checks if check.get("name") == name]
     if not matches:
@@ -193,6 +276,18 @@ def check_droid_finished(comments: list[dict[str, object]]) -> tuple[bool, str]:
     if not is_finished_droid_review(body):
         return False, f"Droid latest comment is not a finished review: {comment.get('url') or ''}"
     return True, ""
+
+
+def check_no_active_review_threads(threads: list[dict[str, object]]) -> tuple[bool, str]:
+    if not threads:
+        return True, ""
+    first = threads[0]
+    location = str(first.get("path") or "review thread")
+    if first.get("line"):
+        location = f"{location}:{first['line']}"
+    url = str(first.get("url") or "")
+    suffix = f" ({url})" if url else ""
+    return False, f"{len(threads)} active review thread(s), first at {location}{suffix}"
 
 
 def wait_for_gate(label: str, timeout_seconds: int, interval_seconds: int, predicate) -> None:
@@ -297,6 +392,12 @@ def main() -> int:
         args.timeout_seconds,
         args.interval_seconds,
         lambda: check_droid_finished(fetch_comments(args.pr_number, args.repo)),
+    )
+    wait_for_gate(
+        "review threads",
+        args.timeout_seconds,
+        args.interval_seconds,
+        lambda: check_no_active_review_threads(fetch_active_review_threads(args.pr_number, args.repo)),
     )
 
     merge_args = ["pr", "merge", str(args.pr_number), "--squash", "--match-head-commit", str(pr.get("headRefOid") or "")]

--- a/scripts/tests/test_go_package_shard.py
+++ b/scripts/tests/test_go_package_shard.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+import unittest
+
+import scripts.go_package_shard as go_package_shard
+
+
+class GoPackageShardTests(unittest.TestCase):
+    def test_select_packages_is_stable_and_complete(self):
+        packages = [
+            "./api",
+            "./cmd/cerebro",
+            "./internal/bootstrap",
+            "./internal/grcvendor",
+            "./sources/okta",
+        ]
+
+        shards = [go_package_shard.select_packages(packages, 3, index) for index in range(3)]
+
+        flattened = sorted(package for shard in shards for package in shard)
+        self.assertEqual(flattened, sorted(packages))
+        for shard in shards:
+            self.assertEqual(len(shard), len(set(shard)))
+
+    def test_cli_rejects_invalid_index(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/go_package_shard.py", "--total", "2", "--index", "2"],
+            input="./api\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--index", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_land_pr.py
+++ b/scripts/tests/test_land_pr.py
@@ -162,6 +162,105 @@ class LandPRTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("not a finished review", reason)
 
+    def test_check_no_active_review_threads_accepts_empty_threads(self):
+        ok, reason = land_pr.check_no_active_review_threads([])
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+    def test_check_no_active_review_threads_rejects_open_threads(self):
+        ok, reason = land_pr.check_no_active_review_threads(
+            [{"path": "internal/example.go", "line": 42, "url": "https://thread"}]
+        )
+        self.assertFalse(ok)
+        self.assertIn("active review thread", reason)
+        self.assertIn("internal/example.go:42", reason)
+
+    def test_fetch_active_review_threads_filters_resolved_and_outdated(self):
+        raw = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": True,
+                                    "isOutdated": False,
+                                    "path": "resolved.go",
+                                    "line": 1,
+                                    "comments": {"nodes": [{"url": "https://resolved", "body": "done"}]},
+                                },
+                                {
+                                    "isResolved": False,
+                                    "isOutdated": True,
+                                    "path": "outdated.go",
+                                    "line": 2,
+                                    "comments": {"nodes": [{"url": "https://outdated", "body": "old"}]},
+                                },
+                                {
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "path": "active.go",
+                                    "line": 3,
+                                    "comments": {"nodes": [{"url": "https://active", "body": "fix me"}]},
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+
+        with mock.patch("scripts.land_pr.run_gh", return_value=land_pr.json.dumps(raw)):
+            threads = land_pr.fetch_active_review_threads(12, "writer/cerebro")
+
+        self.assertEqual(len(threads), 1)
+        self.assertEqual(threads[0]["path"], "active.go")
+        self.assertEqual(threads[0]["url"], "https://active")
+
+    def test_fetch_active_review_threads_paginates(self):
+        first_page = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                        }
+                    }
+                }
+            }
+        }
+        second_page = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "path": "late.go",
+                                    "line": 9,
+                                    "comments": {"nodes": [{"url": "https://late", "body": "late thread"}]},
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    }
+                }
+            }
+        }
+
+        with mock.patch(
+            "scripts.land_pr.run_gh",
+            side_effect=[land_pr.json.dumps(first_page), land_pr.json.dumps(second_page)],
+        ) as run_gh:
+            threads = land_pr.fetch_active_review_threads(12, "writer/cerebro")
+
+        self.assertEqual(len(threads), 1)
+        self.assertEqual(threads[0]["path"], "late.go")
+        self.assertIn("after=cursor-1", run_gh.call_args_list[1].args[0])
+
     def test_delete_branch_if_safe_skips_already_deleted_branch(self):
         pr = {
             "headRefName": "codex/test-branch",


### PR DESCRIPTION
## Summary
- Shard `make test` and `make test-race` across four CI jobs while preserving the full `go list ./...` package set.
- Keep aggregate `test` and `race` checks for branch protection, and make `verify` wait on both aggregate gates.
- Add golangci-lint cache restore/save and include the tools/linters module in Go cache keys.
- Cancel superseded CI and CodeQL runs for the same PR/ref.
- Make the landing helper wait for active review threads before merge to avoid stale finding follow-up churn.

## Validation
- `python3 -m unittest scripts.tests.test_go_package_shard scripts.tests.test_land_pr scripts.tests.test_makefile_targets`
- Ruby YAML parse for `.github/workflows/ci.yml` and `.github/workflows/codeql.yml`
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml`
- `GO_TEST_SHARD_TOTAL=4 GO_TEST_SHARD_INDEX=0 make test`
- `make script-test`
- `make check-structural check-structural-test check-arch`
- `make lint`
- `go list ./...` shard coverage check: 986 packages, 986 combined, 0 missing, 0 duplicates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->