### PR TITLE
[codex] speed up CI follow-up gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
             command: make script-test
           - name: mcp
             command: make mcp-contract-check mcp-sdk-compat
-          - name: lint
-            command: make lint
           - name: proto
             command: make proto-lint proto-generate-check proto-breaking
             checkout_fetch_depth: '0'
@@ -75,16 +73,47 @@ jobs:
             go.sum
             tools/linters/go.sum
 
+      - name: Run ${{ matrix.name }}
+        run: ${{ matrix.command }}
+
+  go-lint-shard:
+    name: lint-${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: api-cmd
+            command: make lint-api-cmd
+          - name: internal
+            command: make lint-internal
+          - name: sources
+            command: make lint-sources
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            tools/linters/go.sum
+
       - name: Cache golangci-lint
-        if: matrix.name == 'lint'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: ~/.cache/golangci-lint
-          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          path: |
+            ~/.cache/golangci-lint
+            ~/go/bin/golangci-lint
+          key: ${{ runner.os }}-${{ runner.arch }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml', 'Makefile') }}
           restore-keys: |
-            ${{ runner.os }}-golangci-lint-
+            ${{ runner.os }}-${{ runner.arch }}-golangci-lint-
 
-      - name: Run ${{ matrix.name }}
+      - name: Run ${{ matrix.name }} lint
         run: ${{ matrix.command }}
 
   go-test-shard:
@@ -120,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard_index: [0, 1, 2, 3]
+        shard_index: [0, 1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -137,7 +166,7 @@ jobs:
 
       - name: Run Go race shard ${{ matrix.shard_index }}
         env:
-          GO_TEST_SHARD_TOTAL: 4
+          GO_TEST_SHARD_TOTAL: 6
           GO_TEST_SHARD_INDEX: ${{ matrix.shard_index }}
         run: make test-race
 
@@ -167,9 +196,22 @@ jobs:
           fi
           echo "All Go race shards passed"
 
+  lint:
+    runs-on: ubuntu-latest
+    needs: [go-lint-shard]
+    if: always()
+    steps:
+      - name: Check Go lint shards
+        run: |
+          if [ "${{ needs.go-lint-shard.result }}" != "success" ]; then
+            echo "One or more Go lint shards failed"
+            exit 1
+          fi
+          echo "All Go lint shards passed"
+
   verify:
     runs-on: ubuntu-latest
-    needs: [verify-shard, test, race]
+    needs: [verify-shard, test, race, lint]
     if: always()
     steps:
       - name: Check verify shards
@@ -184,6 +226,10 @@ jobs:
           fi
           if [ "${{ needs.race.result }}" != "success" ]; then
             echo "One or more Go race shards failed"
+            exit 1
+          fi
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "One or more Go lint shards failed"
             exit 1
           fi
           echo "All verify shards passed"

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -122,11 +122,13 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
           exit "${status}"
       - name: Set up Node for DeepSec
+        if: steps.preflight.outputs.run_droid_review == 'true'
         continue-on-error: true
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
       - name: Install DeepSec
+        if: steps.preflight.outputs.run_droid_review == 'true'
         continue-on-error: true
         shell: bash
         run: |
@@ -135,6 +137,7 @@ jobs:
           corepack prepare pnpm@10.12.4 --activate
           pnpm -C .deepsec install --frozen-lockfile
       - name: Install Semgrep
+        if: steps.preflight.outputs.run_droid_review == 'true'
         continue-on-error: true
         shell: bash
         run: |
@@ -143,6 +146,7 @@ jobs:
           echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
       - name: Run Droid SAST context
         id: sast
+        if: steps.preflight.outputs.run_droid_review == 'true'
         shell: bash
         env:
           DROID_REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
@@ -167,7 +171,7 @@ jobs:
           exit 0
       - name: Run Droid CI context
         id: ci-context
-        if: always() && steps.preflight.outcome != 'skipped'
+        if: always() && steps.preflight.outputs.run_droid_review == 'true'
         continue-on-error: true
         shell: bash
         env:
@@ -188,7 +192,7 @@ jobs:
           fi
       - name: Run Droid feedback context
         id: feedback-context
-        if: always() && steps.preflight.outcome != 'skipped'
+        if: always() && steps.preflight.outputs.run_droid_review == 'true'
         continue-on-error: true
         shell: bash
         env:
@@ -208,7 +212,7 @@ jobs:
             } >> "${GITHUB_STEP_SUMMARY}"
           fi
       - name: Publish consolidated Droid context
-        if: always() && steps.sast.outcome != 'skipped'
+        if: always() && steps.preflight.outputs.run_droid_review == 'true' && steps.sast.outcome != 'skipped'
         continue-on-error: true
         shell: bash
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-catalog-fidelity-generate connector-catalog-fidelity-check connector-catalog-review connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo github-business-demo github-business-demo-env agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-api-cmd lint-internal lint-sources lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-catalog-fidelity-generate connector-catalog-fidelity-check connector-catalog-review connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo github-business-demo github-business-demo-env agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -10,6 +10,8 @@ GOLANGCI_LINT_CONCURRENCY ?= 4
 GOLANGCI_LINT_TIMEOUT ?= 20m
 GO_TEST_SHARD_TOTAL ?= 1
 GO_TEST_SHARD_INDEX ?= 0
+GO_TEST_SHARD_WEIGHTS ?= scripts/go_package_test_weights.json
+GO_RACE_SHARD_WEIGHTS ?= scripts/go_package_race_weights.json
 BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
@@ -23,6 +25,9 @@ DOCKER_SMOKE_BASE_IMAGES ?= $(DOCKER_RUNTIME_BASE_IMAGE) public.ecr.aws/docker/l
 DOCKER_BUILD_ATTEMPTS ?= 3
 DOCKER_BUILD_RETRY_SLEEP ?= 10
 APP_PACKAGES := ./api/... ./cmd/... ./internal/... ./sources/...
+APP_API_CMD_PACKAGES := ./api/... ./cmd/...
+APP_INTERNAL_PACKAGES := ./internal/...
+APP_SOURCE_PACKAGES := ./sources/...
 COVER_PACKAGES ?= ./internal/runtimeresponse ./internal/graphagent ./internal/deviceauth ./internal/sourceprojection ./internal/findings
 COVERAGE_OUT ?= tmp/coverage.out
 COVERAGE_MIN ?= 80.0
@@ -144,7 +149,7 @@ test: ## Run all Go tests. Set GO_TEST_SHARD_TOTAL and GO_TEST_SHARD_INDEX to ru
 	package_file="$$(mktemp)"; \
 	trap 'rm -f "$$package_file"' EXIT; \
 	go list ./... > "$$package_file"; \
-	packages="$$( $(PYTHON) scripts/go_package_shard.py --total "$(GO_TEST_SHARD_TOTAL)" --index "$(GO_TEST_SHARD_INDEX)" < "$$package_file")"; \
+	packages="$$( $(PYTHON) scripts/go_package_shard.py --total "$(GO_TEST_SHARD_TOTAL)" --index "$(GO_TEST_SHARD_INDEX)" --weights "$(GO_TEST_SHARD_WEIGHTS)" < "$$package_file")"; \
 	if [ -z "$$packages" ]; then \
 		echo "no Go packages selected for shard $(GO_TEST_SHARD_INDEX)/$(GO_TEST_SHARD_TOTAL)"; \
 	else \
@@ -156,7 +161,7 @@ test-race: ## Run all Go tests with the race detector. Set GO_TEST_SHARD_TOTAL a
 	package_file="$$(mktemp)"; \
 	trap 'rm -f "$$package_file"' EXIT; \
 	go list ./... > "$$package_file"; \
-	packages="$$( $(PYTHON) scripts/go_package_shard.py --total "$(GO_TEST_SHARD_TOTAL)" --index "$(GO_TEST_SHARD_INDEX)" < "$$package_file")"; \
+	packages="$$( $(PYTHON) scripts/go_package_shard.py --total "$(GO_TEST_SHARD_TOTAL)" --index "$(GO_TEST_SHARD_INDEX)" --weights "$(GO_RACE_SHARD_WEIGHTS)" < "$$package_file")"; \
 	if [ -z "$$packages" ]; then \
 		echo "no Go packages selected for shard $(GO_TEST_SHARD_INDEX)/$(GO_TEST_SHARD_TOTAL)"; \
 	else \
@@ -295,6 +300,15 @@ mcp-sdk-compat: build ## Check MCP SDK compatibility against local server.
 ##@ Lint and Contracts
 lint: lint-bootstrap ## Run golangci-lint over application packages.
 	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_PACKAGES)
+
+lint-api-cmd: lint-bootstrap ## Run golangci-lint over API and command packages.
+	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_API_CMD_PACKAGES)
+
+lint-internal: lint-bootstrap ## Run golangci-lint over internal packages.
+	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_INTERNAL_PACKAGES)
+
+lint-sources: lint-bootstrap ## Run golangci-lint over source packages.
+	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_SOURCE_PACKAGES)
 
 lint-bootstrap: ## Install golangci-lint if missing.
 	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi

--- a/scripts/droid_sast_context.py
+++ b/scripts/droid_sast_context.py
@@ -234,12 +234,24 @@ def run_govulncheck(packages: list[str]) -> ToolResult:
     return ToolResult("govulncheck", ", ".join(package_args), "completed", findings, notes)
 
 
-def run_semgrep(lines_by_file: dict[str, set[int]]) -> ToolResult:
+def semgrep_targets(files: list[str]) -> list[str]:
+    targets = []
+    for file_path in files:
+        normalized = normalize_repo_path(file_path)
+        if normalized and Path(normalized).is_file():
+            targets.append(normalized)
+    return sorted(set(targets))
+
+
+def run_semgrep(files: list[str], lines_by_file: dict[str, set[int]]) -> ToolResult:
     config = Path(".semgrep/cerebro.yml")
     if not config.exists():
         return ToolResult("semgrep", "repo-specific rules", "skipped", [], ["No .semgrep/cerebro.yml config found."])
+    targets = semgrep_targets(files)
+    if not targets:
+        return ToolResult("semgrep", str(config), "skipped", [], ["No changed files to scan."])
     completed = run_command(
-        ["semgrep", "--config", str(config), "--json", "--quiet"],
+        ["semgrep", "--config", str(config), "--json", "--quiet", *targets],
         timeout=240,
     )
     if completed.returncode == 127:
@@ -273,7 +285,7 @@ def run_semgrep(lines_by_file: dict[str, set[int]]) -> ToolResult:
     notes = []
     if completed.returncode not in (0, 1):
         notes.append((completed.stderr or completed.stdout).strip()[:800])
-    return ToolResult("semgrep", str(config), "completed", findings, notes)
+    return ToolResult("semgrep", ", ".join(targets), "completed", findings, notes)
 
 
 def run_deepsec_scan(files: list[str], lines_by_file: dict[str, set[int]]) -> ToolResult:
@@ -677,7 +689,7 @@ def main() -> int:
     results = [
         run_gosec(packages, lines_by_file),
         run_govulncheck(packages),
-        run_semgrep(lines_by_file),
+        run_semgrep(files, lines_by_file),
         run_deepsec_scan(files, lines_by_file),
     ]
     markdown = render_markdown(args.base, args.head, files, packages, results)

--- a/scripts/go_package_race_weights.json
+++ b/scripts/go_package_race_weights.json
@@ -1,0 +1,20 @@
+{
+  "github.com/writer/cerebro/cmd/cerebro": 130,
+  "github.com/writer/cerebro/internal/bootstrap": 98,
+  "github.com/writer/cerebro/internal/compliance": 64,
+  "github.com/writer/cerebro/internal/connectorcatalog": 67,
+  "github.com/writer/cerebro/internal/evidencepackets": 26,
+  "github.com/writer/cerebro/internal/findings": 26,
+  "github.com/writer/cerebro/internal/graphactionapi": 12,
+  "github.com/writer/cerebro/internal/grccontrol": 12,
+  "github.com/writer/cerebro/internal/grcprogram": 11,
+  "github.com/writer/cerebro/internal/reports": 15,
+  "github.com/writer/cerebro/internal/sourceprojection": 43,
+  "github.com/writer/cerebro/internal/sourceregistry": 76,
+  "github.com/writer/cerebro/internal/statestore/postgres": 15,
+  "github.com/writer/cerebro/sources/aws": 14,
+  "github.com/writer/cerebro/sources/github": 10,
+  "github.com/writer/cerebro/tools/archtests": 27,
+  "github.com/writer/cerebro/tools/detectioncatalog": 122,
+  "github.com/writer/cerebro/tools/policymappingexport": 270
+}

--- a/scripts/go_package_shard.py
+++ b/scripts/go_package_shard.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
+from pathlib import Path
 import sys
 
 
@@ -13,7 +15,34 @@ def package_shard(package: str, total: int) -> int:
     return int.from_bytes(digest[:8], "big") % total
 
 
-def select_packages(packages: list[str], total: int, index: int) -> list[str]:
+def load_weights(path: str) -> dict[str, float]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("weights file must contain a JSON object")
+    weights: dict[str, float] = {}
+    for package, value in raw.items():
+        if not isinstance(package, str):
+            raise ValueError("weight package names must be strings")
+        if not isinstance(value, (int, float)) or value <= 0:
+            raise ValueError(f"weight for {package!r} must be a positive number")
+        weights[package] = float(value)
+    return weights
+
+
+def select_weighted_packages(packages: list[str], total: int, index: int, weights: dict[str, float]) -> list[str]:
+    bins: list[tuple[float, list[str]]] = [(0.0, []) for _ in range(total)]
+    ordered = sorted(packages, key=lambda package: (-weights.get(package, 1.0), package))
+    for package in ordered:
+        bin_index = min(range(total), key=lambda candidate: (bins[candidate][0], len(bins[candidate][1]), candidate))
+        weight, selected = bins[bin_index]
+        selected.append(package)
+        bins[bin_index] = (weight + weights.get(package, 1.0), selected)
+    return sorted(bins[index][1])
+
+
+def select_packages(packages: list[str], total: int, index: int, weights: dict[str, float] | None = None) -> list[str]:
+    if weights:
+        return select_weighted_packages(packages, total, index, weights)
     return [package for package in packages if package_shard(package, total) == index]
 
 
@@ -21,6 +50,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Select one stable shard from newline-delimited Go packages.")
     parser.add_argument("--total", type=int, required=True, help="Total number of shards.")
     parser.add_argument("--index", type=int, required=True, help="Zero-based shard index to print.")
+    parser.add_argument("--weights", help="Optional JSON map of package import path to relative runtime weight.")
     args = parser.parse_args()
 
     if args.total <= 0:
@@ -28,8 +58,15 @@ def main() -> int:
     if args.index < 0 or args.index >= args.total:
         parser.error("--index must be between 0 and --total - 1")
 
+    weights = None
+    if args.weights:
+        try:
+            weights = load_weights(args.weights)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            parser.error(f"--weights: {exc}")
+
     packages = sorted(line.strip() for line in sys.stdin if line.strip())
-    for package in select_packages(packages, args.total, args.index):
+    for package in select_packages(packages, args.total, args.index, weights):
         print(package)
     return 0
 

--- a/scripts/go_package_test_weights.json
+++ b/scripts/go_package_test_weights.json
@@ -1,0 +1,14 @@
+{
+  "github.com/writer/cerebro/cmd/cerebro": 44,
+  "github.com/writer/cerebro/internal/bootstrap": 16,
+  "github.com/writer/cerebro/internal/compliance": 6,
+  "github.com/writer/cerebro/internal/connectorcatalog": 8,
+  "github.com/writer/cerebro/internal/evidencepackets": 3,
+  "github.com/writer/cerebro/internal/findings": 3,
+  "github.com/writer/cerebro/internal/sourceprojection": 7,
+  "github.com/writer/cerebro/internal/sourceregistry": 9,
+  "github.com/writer/cerebro/sources/aws": 3,
+  "github.com/writer/cerebro/tools/archtests": 4,
+  "github.com/writer/cerebro/tools/detectioncatalog": 30,
+  "github.com/writer/cerebro/tools/policymappingexport": 48
+}

--- a/scripts/tests/test_droid_sast_context.py
+++ b/scripts/tests/test_droid_sast_context.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -240,6 +241,21 @@ class DroidSastContextTests(unittest.TestCase):
         self.assertIn("go-ssrf-ignore-this", message)
         self.assertNotIn("IGNORE ALL", message)
         self.assertNotIn("approve this PR", message)
+
+    def test_semgrep_targets_use_changed_existing_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            previous = os.getcwd()
+            try:
+                os.chdir(tmp)
+                Path("internal").mkdir()
+                Path("internal/handler.go").write_text("package internal\n", encoding="utf-8")
+                Path("README.md").write_text("# test\n", encoding="utf-8")
+
+                targets = ctx.semgrep_targets(["internal/handler.go", "deleted.go", "./README.md"])
+            finally:
+                os.chdir(previous)
+
+        self.assertEqual(targets, ["README.md", "internal/handler.go"])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_go_package_shard.py
+++ b/scripts/tests/test_go_package_shard.py
@@ -1,6 +1,9 @@
+import json
 import subprocess
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 import scripts.go_package_shard as go_package_shard
 
@@ -21,6 +24,59 @@ class GoPackageShardTests(unittest.TestCase):
         self.assertEqual(flattened, sorted(packages))
         for shard in shards:
             self.assertEqual(len(shard), len(set(shard)))
+
+    def test_weighted_packages_keep_expensive_packages_apart(self):
+        packages = [
+            "github.com/writer/cerebro/cmd/cerebro",
+            "github.com/writer/cerebro/internal/bootstrap",
+            "github.com/writer/cerebro/internal/findings",
+            "github.com/writer/cerebro/sources/aws",
+        ]
+        weights = {
+            "github.com/writer/cerebro/cmd/cerebro": 100,
+            "github.com/writer/cerebro/internal/bootstrap": 90,
+        }
+
+        shards = [go_package_shard.select_packages(packages, 2, index, weights) for index in range(2)]
+
+        flattened = sorted(package for shard in shards for package in shard)
+        self.assertEqual(flattened, sorted(packages))
+        heavy_locations = {
+            package: index
+            for index, shard in enumerate(shards)
+            for package in shard
+            if package in weights
+        }
+        self.assertNotEqual(
+            heavy_locations["github.com/writer/cerebro/cmd/cerebro"],
+            heavy_locations["github.com/writer/cerebro/internal/bootstrap"],
+        )
+
+    def test_cli_accepts_weight_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            weights_path = Path(tmp) / "weights.json"
+            weights_path.write_text(json.dumps({"./heavy": 100}), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/go_package_shard.py",
+                    "--total",
+                    "2",
+                    "--index",
+                    "0",
+                    "--weights",
+                    str(weights_path),
+                ],
+                input="./heavy\n./light\n",
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("./heavy", result.stdout)
 
     def test_cli_rejects_invalid_index(self):
         result = subprocess.run(


### PR DESCRIPTION
## What changed

- Add duration-weighted Go package sharding with separate test and race weight maps.
- Increase race shards from 4 to 6 while keeping the aggregate `race` gate.
- Split golangci-lint into API/command, internal, and source package shards with an aggregate `lint` gate.
- Cache the golangci-lint analysis cache and binary together.
- Scope Droid Semgrep context to changed existing files and skip expensive Droid context setup when preflight says no review is needed.

## Why

The previous CI speedup still left uneven long poles: a few expensive Go packages dominated one test/race shard, lint remained a single serialized job, and some Droid context setup ran even when preflight had enough information to skip review.

## Validation

- `make script-test`
- `go test ./tools/droidreview/...`
- `make lint-api-cmd`
- `git diff --check`
- Parsed all `.github/workflows/*.yml` with Ruby YAML
- Verified weighted 4-way and 6-way sharding includes every `go list ./...` package exactly once
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->