### PR TITLE
[codex] Add JetStream append alert templates

### DIFF
--- a/docs/operations/headroom.md
+++ b/docs/operations/headroom.md
@@ -269,6 +269,22 @@ ORDER BY P99(duration_ms) DESC
 ```
 
 ```sql
+-- Which append-log subjects are failing publish or exhausting retries?
+SELECT COUNT(*), MAX(messaging.jetstream.publish.retry_count)
+WHERE name = "jetstream.append" AND event.outcome = "failure"
+GROUP BY messaging.jetstream.subject, messaging.jetstream.error.category, messaging.jetstream.publish.max_attempts_exhausted
+```
+
+```sql
+-- Which job phase produced failed finding-record publishes?
+SELECT COUNT(*), P95(duration_ms)
+WHERE name = "jetstream.append"
+  AND event.outcome = "failure"
+  AND messaging.jetstream.subject = "sec.findings.v1.recorded"
+GROUP BY tenant_id, source_id, runtime_id, phase.last_name, messaging.jetstream.error.category
+```
+
+```sql
 -- Which runtime/source is falling behind?
 SELECT COUNT(*), P95(duration_ms)
 WHERE main = true AND source_runtime.sync.outcome != "success"
@@ -304,8 +320,9 @@ Use this when Cerebro "feels choked": slow requests, readiness flaps, source/run
 4. If graph-ingest-specific, pause broad rebuilds and keep read-only graph health checks running.
 5. If Postgres pool waits are high, reduce app/background concurrency before increasing replicas.
 6. If JetStream lag is growing, identify producers and consumers; scale consumers only if storage and downstream stores have room.
-7. If Redis/Valkey is down, estimate cache miss amplification into Postgres, LLM, or graph queries.
-8. If provider or LLM latency is the cause, reduce concurrency and use configured fallback/provider routing when available.
+7. If JetStream append publish failures are nonzero, group `cerebro.jetstream.publish.requests` by `subject`, `error_category`, and `max_attempts_exhausted`; inspect `jetstream.append` spans for the affected phase/runtime; check pending dead letters for the same subject before retrying broad work.
+8. If Redis/Valkey is down, estimate cache miss amplification into Postgres, LLM, or graph queries.
+9. If provider or LLM latency is the cause, reduce concurrency and use configured fallback/provider routing when available.
 
 ### Mitigation Choices
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -138,6 +138,13 @@ safe to aggregate in CloudWatch, Prometheus, or a vendor backend.
 | `cerebro.source_projection.duration` | `s` | `source_id`, `event_kind`, `status` | Projection latency distribution |
 | `cerebro.source_projection.records` | `{record}` | `source_id`, `event_kind`, `status`, `record.kind` | Graph/current-state records projected or deleted |
 | `cerebro.graph_action.recorded` | `{action}` | `provider`, `action`, `status`, `external_status`, `dry_run` | Provider-backed graph actions successfully recorded into the workflow/event path |
+| `cerebro.jetstream.publish.requests` | `{request}` | `subject`, `operation`, `status`, `error_category`, `max_attempts_exhausted` | Append-log publish success and failure counts by bounded subject and error category |
+| `cerebro.jetstream.publish.retries` | `{retry}` | `subject`, `operation`, `status`, `error_category`, `max_attempts_exhausted` | Publish retry attempts by bounded subject and error category |
+| `cerebro.jetstream.publish.duration` | `s` | `subject`, `operation`, `status`, `error_category`, `max_attempts_exhausted` | Publish ACK latency by bounded subject and outcome |
+| `cerebro.jetstream.publish.max_attempts_exhausted` | `{request}` | `subject`, `operation`, `status`, `error_category`, `max_attempts_exhausted` | Publish requests that used every configured attempt |
+| `cerebro.jetstream.replay.requests` | `{request}` | `strategy`, `status`, `error_category`, `subject_filter_present` | Append-log replay request count by scan strategy and outcome |
+| `cerebro.jetstream.replay.duration` | `s` | `strategy`, `status`, `error_category`, `subject_filter_present` | Append-log replay latency by scan strategy and outcome |
+| `cerebro.jetstream.replay.records` | `{record}` | `strategy`, `status`, `error_category`, `subject_filter_present`, `record.kind` | Replay records scanned, decoded, matched, missing, or returned |
 
 Metric attributes deliberately exclude `tenant_id`, `runtime_id`, `resource_urn`,
 `evidence_id`, `request_id`, and `trace_id`. Those identifiers remain available
@@ -151,6 +158,15 @@ telemetry on `name="source_runtime.sync"`, `name="source_projection.project"`,
 or workflow `graph_action.recorded` events. Those diagnostic events carry
 `tenant_id`, `runtime_id`, finding IDs, and namespaced source/action fields for
 per-tenant triage without turning tenant IDs into metric dimensions.
+
+For JetStream append incidents, alert on `cerebro.jetstream.publish.requests`,
+`cerebro.jetstream.publish.retries`, and
+`cerebro.jetstream.publish.max_attempts_exhausted` grouped by `subject` and
+`error_category`. Then pivot to `name="jetstream.append"` or
+`name="jetstream.publish.retry_exhausted"` telemetry for `tenant_id`,
+`runtime_id`, phase, retry count, and trace context. The checked-in alert
+templates in [`docs/operations/observability/headroom-alerts.promql`](observability/headroom-alerts.promql)
+include the dedicated `sec.findings.v1.recorded` + `no_response` page.
 
 ## Error Contract
 

--- a/docs/operations/observability/headroom-alerts.promql
+++ b/docs/operations/observability/headroom-alerts.promql
@@ -118,6 +118,49 @@ nats_jetstream_stream_bytes{stream=~".*cerebro.*"}
   / clamp_min(nats_jetstream_stream_bytes_limit{stream=~".*cerebro.*"}, 1)
 > 0.8
 
+# JetStream append publish failures by bounded subject and error category.
+# These use OTEL metric names after Prometheus mapping. Rename the metric names
+# if the collector uses a different mapping.
+sum by (subject, error_category, max_attempts_exhausted) (
+  rate(cerebro_jetstream_publish_requests_total{operation="append",status="failed"}[5m])
+) > 0
+
+# JetStream append publish attempts that exhausted the configured retry budget.
+sum by (subject, error_category) (
+  increase(cerebro_jetstream_publish_max_attempts_exhausted_total{operation="append"}[5m])
+) > 0
+
+# Dedicated page for finding-record publish exhaustion with no JetStream response.
+sum (
+  increase(cerebro_jetstream_publish_max_attempts_exhausted_total{
+    operation="append",
+    subject="sec.findings.v1.recorded",
+    error_category="no_response"
+  }[5m])
+) > 0
+
+# JetStream append retry pressure by subject and error category.
+(
+  sum by (subject, error_category) (
+    rate(cerebro_jetstream_publish_retries_total{operation="append"}[5m])
+  )
+  /
+  clamp_min(
+    sum by (subject, error_category) (
+      rate(cerebro_jetstream_publish_requests_total{operation="append"}[5m])
+    ),
+    1
+  )
+) > 1
+
+# JetStream append publish p95 latency by subject.
+histogram_quantile(
+  0.95,
+  sum by (le, subject) (
+    rate(cerebro_jetstream_publish_duration_seconds_bucket{operation="append"}[5m])
+  )
+) > 2
+
 # Neo4j/Aura query latency from a managed-service exporter.
 # Replace names to match the Aura/Neo4j integration.
 histogram_quantile(

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -229,6 +229,41 @@ Common fixes:
 - pause overlapping jobs,
 - inspect invalid events and fix source config or source implementation.
 
+## JetStream append publishes fail
+
+Symptoms:
+
+- `cerebro.jetstream.publish.requests` has `status="failed"`,
+- `cerebro.jetstream.publish.max_attempts_exhausted` is nonzero,
+- `jetstream.append` spans show `messaging.jetstream.error.category`,
+- source sync, graph ingest, or finding evaluation completes with missing append-log events.
+
+Checks:
+
+```bash
+curl -sS http://127.0.0.1:8080/health
+./bin/cerebro append-log dead-letters list status=pending limit=20
+./bin/cerebro append-log dead-letters list subject=sec.findings.v1.recorded status=pending limit=20
+```
+
+Verify:
+
+- `subject`, `error_category`, and `max_attempts_exhausted` on the alert,
+- `CEREBRO_APPEND_LOG_DRIVER=jetstream`,
+- `CEREBRO_JETSTREAM_URL`,
+- `CEREBRO_JETSTREAM_STREAM_NAME`,
+- NATS stream storage, API errors, and account limits,
+- rollout timing and graceful drain timeout,
+- pending dead letters for the failing subject.
+
+Common fixes:
+
+- restore NATS JetStream publish health before replay,
+- lower or pause the producer job that owns the failing phase,
+- increase broker/account capacity when API errors or storage pressure are present,
+- replay pending dead letters one record at a time after publish health recovers,
+- discard only records that should not be replayed.
+
 ## Graph routes fail
 
 Symptoms:


### PR DESCRIPTION
## Summary
- Add PromQL templates for JetStream append publish failures, retry exhaustion, retry pressure, and p95 publish latency.
- Document JetStream publish and replay OTEL metrics with their bounded dimensions.
- Add runbook queries and troubleshooting steps for subject/category alerts and pending dead-letter recovery.

## Why
The app already emits bounded JetStream publish metrics. Operators need alert templates and response steps that identify the failing subject, error category, retry exhaustion state, and affected job phase/runtime.

## Validation
- `git diff --check`
- `make docs-drift-check`

Closes #1305