### PR TITLE
Add JetStream findings publish bulkhead

### DIFF
--- a/docs/operations/hosting.md
+++ b/docs/operations/hosting.md
@@ -237,6 +237,7 @@ Cerebro uses these values for proxy-aware URL reconstruction and DPoP `htu` vali
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | Subject prefix. Use a stable, environment-specific prefix if multiple logical deployments share a NATS cluster. |
 | `CEREBRO_JETSTREAM_DRAIN_TIMEOUT` | Optional graceful drain timeout for shutdown. |
 | `CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT` | Optional per-process bulkhead for concurrent publishes. Use this when many source runtimes can publish at once. |
+| `CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT` | Optional per-process bulkhead for `sec.findings.v1.*` publishes. Use this when finding-rule runs saturate JetStream publish ACKs. |
 | `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_ELAPSED` | Optional total retry budget for retryable publishes. Keep it above observed stream restore time plus margin. |
 | `CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS`, `CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF`, `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF`, `CEREBRO_JETSTREAM_PUBLISH_ATTEMPT_TIMEOUT` | Optional outer retry shape for NATS restarts, transient timeouts, and stream leader stalls. |
 | `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_ATTEMPTS`, `CEREBRO_JETSTREAM_PUBLISH_CLIENT_RETRY_WAIT` | Optional inner NATS client retry shape used inside each outer publish attempt. |

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -164,8 +164,11 @@ For JetStream append incidents, alert on `cerebro.jetstream.publish.requests`,
 `cerebro.jetstream.publish.max_attempts_exhausted` grouped by `subject` and
 `error_category`. Then pivot to `name="jetstream.append"` or
 `name="jetstream.publish.retry_exhausted"` telemetry for `tenant_id`,
-`runtime_id`, phase, retry count, and trace context. The checked-in alert
-templates in [`docs/operations/observability/headroom-alerts.promql`](observability/headroom-alerts.promql)
+`runtime_id`, phase, retry count, trace context, and
+`messaging.jetstream.publish.bulkhead.scopes`. Use
+`messaging.jetstream.publish.bulkhead.findings.wait_ms` to confirm
+`sec.findings.v1.*` publish queueing. The checked-in alert templates in
+[`docs/operations/observability/headroom-alerts.promql`](observability/headroom-alerts.promql)
 include the dedicated `sec.findings.v1.recorded` + `no_response` page.
 
 ## Error Contract

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -166,6 +166,8 @@ For JetStream append incidents, alert on `cerebro.jetstream.publish.requests`,
 `name="jetstream.publish.retry_exhausted"` telemetry for `tenant_id`,
 `runtime_id`, phase, retry count, trace context, and
 `messaging.jetstream.publish.bulkhead.scopes`. Use
+`messaging.jetstream.publish.bulkhead.effective_max_in_flight` for the tightest
+active publish cap and
 `messaging.jetstream.publish.bulkhead.findings.wait_ms` to confirm
 `sec.findings.v1.*` publish queueing. The checked-in alert templates in
 [`docs/operations/observability/headroom-alerts.promql`](observability/headroom-alerts.promql)

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -252,6 +252,7 @@ Verify:
 - `CEREBRO_APPEND_LOG_DRIVER=jetstream`,
 - `CEREBRO_JETSTREAM_URL`,
 - `CEREBRO_JETSTREAM_STREAM_NAME`,
+- `messaging.jetstream.publish.bulkhead.scopes` and `messaging.jetstream.publish.bulkhead.findings.wait_ms` on `jetstream.append` spans,
 - NATS stream storage, API errors, and account limits,
 - rollout timing and graceful drain timeout,
 - pending dead letters for the failing subject.
@@ -260,6 +261,7 @@ Common fixes:
 
 - restore NATS JetStream publish health before replay,
 - lower or pause the producer job that owns the failing phase,
+- set `CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT` when `sec.findings.v1.*` publishes saturate ACKs,
 - increase broker/account capacity when API errors or storage pressure are present,
 - replay pending dead letters one record at a time after publish health recovers,
 - discard only records that should not be replayed.

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -26,6 +26,7 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | `events` | Subject prefix for append-log events. |
 | `CEREBRO_JETSTREAM_DRAIN_TIMEOUT` | NATS default | Optional timeout for graceful NATS connection drain during shutdown. |
 | `CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT` | unlimited | Optional per-process bulkhead for concurrent JetStream publishes. |
+| `CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT` | unlimited | Optional per-process bulkhead for `sec.findings.v1.*` publishes. |
 | `CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS` | `10` | Optional maximum outer publish attempts for retryable JetStream publish errors. |
 | `CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF` | `250ms` | Optional first outer publish retry backoff. |
 | `CEREBRO_JETSTREAM_PUBLISH_RETRY_MAX_BACKOFF` | `5s` | Optional cap for outer publish retry backoff. |

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -78,26 +78,27 @@ type replayStream interface {
 }
 
 type publishTelemetry struct {
-	Attempts       int
-	MaxAttempts    int
-	RetryCount     int
-	LastBackoff    time.Duration
-	LastRetryable  bool
-	Duration       time.Duration
-	RetryBudget    time.Duration
-	AttemptTimeout time.Duration
-	MaxBackoff     time.Duration
-	ClientRetries  int
-	ClientWait     time.Duration
-	RetryExhausted bool
-	MaxExhausted   bool
-	BulkheadWait   time.Duration
-	BulkheadLimit  int
-	Bulkheads      []publishBulkheadTelemetry
-	AckStream      string
-	AckSequence    uint64
-	AckDuplicate   bool
-	AckUnavailable bool
+	Attempts               int
+	MaxAttempts            int
+	RetryCount             int
+	LastBackoff            time.Duration
+	LastRetryable          bool
+	Duration               time.Duration
+	RetryBudget            time.Duration
+	AttemptTimeout         time.Duration
+	MaxBackoff             time.Duration
+	ClientRetries          int
+	ClientWait             time.Duration
+	RetryExhausted         bool
+	MaxExhausted           bool
+	BulkheadWait           time.Duration
+	BulkheadLimit          int
+	BulkheadEffectiveLimit int
+	Bulkheads              []publishBulkheadTelemetry
+	AckStream              string
+	AckSequence            uint64
+	AckDuplicate           bool
+	AckUnavailable         bool
 }
 
 type publishBulkheadTelemetry struct {
@@ -693,8 +694,11 @@ func (r *publishTelemetry) addBulkheads(bulkheads []publishBulkheadTelemetry) {
 			continue
 		}
 		r.BulkheadWait += bulkhead.Wait
-		if r.BulkheadLimit == 0 || bulkhead.Limit < r.BulkheadLimit {
+		if bulkhead.Scope == publishBulkheadScopeGlobal || r.BulkheadLimit == 0 {
 			r.BulkheadLimit = bulkhead.Limit
+		}
+		if r.BulkheadEffectiveLimit == 0 || bulkhead.Limit < r.BulkheadEffectiveLimit {
+			r.BulkheadEffectiveLimit = bulkhead.Limit
 		}
 		found := false
 		for i := range r.Bulkheads {
@@ -735,6 +739,7 @@ func (r publishTelemetry) attrs() telemetry.Attributes {
 		attrs = attrs.With(telemetry.Attrs(
 			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.enabled", Value: true},
 			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.max_in_flight", Value: r.BulkheadLimit},
+			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.effective_max_in_flight", Value: r.BulkheadEffectiveLimit},
 			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.wait_ms", Value: r.BulkheadWait.Milliseconds()},
 			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.scopes", Value: strings.Join(scopes, ",")},
 		))

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -53,6 +53,11 @@ const (
 	replayStrategyRuntimeIndex      = "runtime_index"
 )
 
+const (
+	publishBulkheadScopeGlobal   = "global"
+	publishBulkheadScopeFindings = "findings"
+)
+
 var errRuntimeReplayIndexRequired = errors.New("runtime replay index required")
 
 var waitBeforePublishRetryFunc = waitBeforePublishRetry
@@ -88,10 +93,17 @@ type publishTelemetry struct {
 	MaxExhausted   bool
 	BulkheadWait   time.Duration
 	BulkheadLimit  int
+	Bulkheads      []publishBulkheadTelemetry
 	AckStream      string
 	AckSequence    uint64
 	AckDuplicate   bool
 	AckUnavailable bool
+}
+
+type publishBulkheadTelemetry struct {
+	Scope string
+	Limit int
+	Wait  time.Duration
 }
 
 type publishRetryConfig struct {
@@ -148,6 +160,7 @@ type Log struct {
 	streamName    string
 	subjectPrefix string
 	publishSlots  chan struct{}
+	findingSlots  chan struct{}
 	publishRetry  publishRetryConfig
 	canaryMu      sync.Mutex
 	lastCanary    time.Time
@@ -217,6 +230,9 @@ func Open(cfg config.AppendLogConfig) (*Log, error) {
 	}
 	if cfg.JetStreamPublishMaxInFlight > 0 {
 		log.publishSlots = make(chan struct{}, cfg.JetStreamPublishMaxInFlight)
+	}
+	if cfg.JetStreamPublishFindingsMaxInFlight > 0 {
+		log.findingSlots = make(chan struct{}, cfg.JetStreamPublishFindingsMaxInFlight)
 	}
 	return log, nil
 }
@@ -475,9 +491,8 @@ func (l *Log) publishMsg(ctx context.Context, msg *nats.Msg, operation string, e
 	for attempt := 1; attempt <= result.MaxAttempts; attempt++ {
 		result.Attempts = attempt
 		attemptCtx, cancel := context.WithTimeout(retryCtx, retry.AttemptTimeout)
-		wait, release, acquireErr := l.acquirePublishSlot(attemptCtx)
-		result.BulkheadWait += wait
-		result.BulkheadLimit = l.publishLimit()
+		bulkheads, release, acquireErr := l.acquirePublishSlots(attemptCtx, msg.Subject)
+		result.addBulkheads(bulkheads)
 		if acquireErr != nil {
 			cancel()
 			err = acquireErr
@@ -564,27 +579,92 @@ func (l *Log) applyExpectedStream(msg *nats.Msg) {
 	msg.Header.Set(jetstream.ExpectedStreamHeader, strings.TrimSpace(l.streamName))
 }
 
-func (l *Log) acquirePublishSlot(ctx context.Context) (time.Duration, func(), error) {
-	limit := l.publishLimit()
-	if limit <= 0 || l.publishSlots == nil {
+func (l *Log) acquirePublishSlots(ctx context.Context, subject string) ([]publishBulkheadTelemetry, func(), error) {
+	bulkheads := l.publishBulkheads(subject)
+	if len(bulkheads) == 0 {
+		return nil, func() {}, nil
+	}
+	acquired := make([]publishBulkheadTelemetry, 0, len(bulkheads))
+	releases := make([]func(), 0, len(bulkheads))
+	releaseAll := func() {
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
+	}
+	for _, bulkhead := range bulkheads {
+		wait, release, err := acquirePublishSlot(ctx, bulkhead.slots)
+		acquired = append(acquired, publishBulkheadTelemetry{
+			Scope: bulkhead.scope,
+			Limit: cap(bulkhead.slots),
+			Wait:  wait,
+		})
+		if err != nil {
+			releaseAll()
+			return acquired, func() {}, err
+		}
+		releases = append(releases, release)
+	}
+	return acquired, releaseAll, nil
+}
+
+type publishBulkhead struct {
+	scope string
+	slots chan struct{}
+}
+
+func (l *Log) publishBulkheads(subject string) []publishBulkhead {
+	if l == nil {
+		return nil
+	}
+	bulkheads := make([]publishBulkhead, 0, 2)
+	if l.publishSlots != nil {
+		bulkheads = append(bulkheads, publishBulkhead{
+			scope: publishBulkheadScopeGlobal,
+			slots: l.publishSlots,
+		})
+	}
+	if l.findingSlots != nil && isFindingPublishSubject(subject) {
+		bulkheads = append(bulkheads, publishBulkhead{
+			scope: publishBulkheadScopeFindings,
+			slots: l.findingSlots,
+		})
+	}
+	return bulkheads
+}
+
+func acquirePublishSlot(ctx context.Context, slots chan struct{}) (time.Duration, func(), error) {
+	if slots == nil {
 		return 0, func() {}, nil
 	}
 	started := time.Now()
 	select {
-	case l.publishSlots <- struct{}{}:
+	case slots <- struct{}{}:
 		return time.Since(started), func() {
-			<-l.publishSlots
+			<-slots
 		}, nil
 	case <-ctx.Done():
 		return time.Since(started), func() {}, ctx.Err()
 	}
 }
 
-func (l *Log) publishLimit() int {
-	if l == nil || l.publishSlots == nil {
-		return 0
+func isFindingPublishSubject(subject string) bool {
+	normalized := strings.TrimSpace(subject)
+	if normalized == securityevents.FindingsV1Prefix || strings.HasPrefix(normalized, securityevents.FindingsV1Prefix+".") {
+		return true
 	}
-	return cap(l.publishSlots)
+	for _, kind := range []string{
+		workflowevents.EventKindFindingRecorded,
+		workflowevents.EventKindFindingNoteAdded,
+		workflowevents.EventKindFindingTicketLinked,
+		workflowevents.EventKindFindingStatusChanged,
+		workflowevents.EventKindFindingExternalRefLinked,
+		workflowevents.EventKindFindingTombstoned,
+	} {
+		if normalized == kind || strings.HasSuffix(normalized, "."+kind) {
+			return true
+		}
+	}
+	return false
 }
 
 func publishMessageID(event *cerebrov1.EventEnvelope, payload []byte) string {
@@ -607,6 +687,30 @@ func (r *publishTelemetry) applyAck(ack *jetstream.PubAck) {
 	r.AckDuplicate = ack.Duplicate
 }
 
+func (r *publishTelemetry) addBulkheads(bulkheads []publishBulkheadTelemetry) {
+	for _, bulkhead := range bulkheads {
+		if bulkhead.Scope == "" || bulkhead.Limit <= 0 {
+			continue
+		}
+		r.BulkheadWait += bulkhead.Wait
+		if r.BulkheadLimit == 0 || bulkhead.Limit < r.BulkheadLimit {
+			r.BulkheadLimit = bulkhead.Limit
+		}
+		found := false
+		for i := range r.Bulkheads {
+			if r.Bulkheads[i].Scope == bulkhead.Scope {
+				r.Bulkheads[i].Wait += bulkhead.Wait
+				r.Bulkheads[i].Limit = bulkhead.Limit
+				found = true
+				break
+			}
+		}
+		if !found {
+			r.Bulkheads = append(r.Bulkheads, bulkhead)
+		}
+	}
+}
+
 func (r publishTelemetry) attrs() telemetry.Attributes {
 	attrs := telemetry.Attrs(
 		telemetry.Field{Key: "messaging.jetstream.publish.attempts", Value: r.Attempts},
@@ -624,11 +728,22 @@ func (r publishTelemetry) attrs() telemetry.Attributes {
 		telemetry.Field{Key: "messaging.jetstream.publish.client_retry_wait_ms", Value: r.ClientWait.Milliseconds()},
 	)
 	if r.BulkheadLimit > 0 {
+		scopes := make([]string, 0, len(r.Bulkheads))
+		for _, bulkhead := range r.Bulkheads {
+			scopes = append(scopes, bulkhead.Scope)
+		}
 		attrs = attrs.With(telemetry.Attrs(
 			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.enabled", Value: true},
 			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.max_in_flight", Value: r.BulkheadLimit},
 			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.wait_ms", Value: r.BulkheadWait.Milliseconds()},
+			telemetry.Field{Key: "messaging.jetstream.publish.bulkhead.scopes", Value: strings.Join(scopes, ",")},
 		))
+		for _, bulkhead := range r.Bulkheads {
+			attrs = attrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "messaging.jetstream.publish.bulkhead." + bulkhead.Scope + ".max_in_flight", Value: bulkhead.Limit},
+				telemetry.Field{Key: "messaging.jetstream.publish.bulkhead." + bulkhead.Scope + ".wait_ms", Value: bulkhead.Wait.Milliseconds()},
+			))
+		}
 	}
 	if r.AckUnavailable {
 		attrs = attrs.WithField(telemetry.Field{Key: "messaging.jetstream.ack.unavailable", Value: true})

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -588,6 +588,71 @@ func TestAppendEmitsPublishBulkheadTelemetry(t *testing.T) {
 	if end["messaging.jetstream.publish.bulkhead.max_in_flight"] != float64(1) {
 		t.Fatalf("bulkhead max in flight = %v, want 1", end["messaging.jetstream.publish.bulkhead.max_in_flight"])
 	}
+	if end["messaging.jetstream.publish.bulkhead.scopes"] != "global" {
+		t.Fatalf("bulkhead scopes = %v, want global", end["messaging.jetstream.publish.bulkhead.scopes"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.global.max_in_flight"] != float64(1) {
+		t.Fatalf("global bulkhead max in flight = %v, want 1", end["messaging.jetstream.publish.bulkhead.global.max_in_flight"])
+	}
+}
+
+func TestAppendEmitsFindingsPublishBulkheadTelemetry(t *testing.T) {
+	pub := &fakePublisher{}
+	log := &Log{js: pub, subjectPrefix: "events", findingSlots: make(chan struct{}, 2)}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		err := log.Append(context.Background(), &cerebrov1.EventEnvelope{
+			Id:   "evt-findings-bulkhead-telemetry",
+			Kind: securityevents.FindingRecorded,
+		})
+		if err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	})
+
+	spanEnds := jetstreamTelemetryPayloads(t, stderr, "span_end", "jetstream.append")
+	if len(spanEnds) != 1 {
+		t.Fatalf("jetstream.append span_end events = %d, want 1; stderr=%s", len(spanEnds), stderr)
+	}
+	end := spanEnds[0]
+	if end["messaging.jetstream.publish.bulkhead.enabled"] != true {
+		t.Fatalf("bulkhead enabled = %v, want true", end["messaging.jetstream.publish.bulkhead.enabled"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.max_in_flight"] != float64(2) {
+		t.Fatalf("bulkhead max in flight = %v, want 2", end["messaging.jetstream.publish.bulkhead.max_in_flight"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.scopes"] != "findings" {
+		t.Fatalf("bulkhead scopes = %v, want findings", end["messaging.jetstream.publish.bulkhead.scopes"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.findings.max_in_flight"] != float64(2) {
+		t.Fatalf("findings bulkhead max in flight = %v, want 2", end["messaging.jetstream.publish.bulkhead.findings.max_in_flight"])
+	}
+	if _, ok := end["messaging.jetstream.publish.bulkhead.global.max_in_flight"]; ok {
+		t.Fatalf("global bulkhead field present for findings-only limiter: %v", end["messaging.jetstream.publish.bulkhead.global.max_in_flight"])
+	}
+}
+
+func TestAppendNonFindingBypassesFindingsPublishBulkhead(t *testing.T) {
+	pub := &fakePublisher{}
+	findingSlots := make(chan struct{}, 1)
+	findingSlots <- struct{}{}
+	log := &Log{js: pub, subjectPrefix: "events", findingSlots: findingSlots}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := log.Append(ctx, &cerebrov1.EventEnvelope{
+		Id:   "evt-non-finding",
+		Kind: "entity.upsert",
+	})
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if pub.publishCalls != 1 {
+		t.Fatalf("publish calls = %d, want 1", pub.publishCalls)
+	}
+	if len(findingSlots) != 1 {
+		t.Fatalf("findingSlots len = %d, want 1", len(findingSlots))
+	}
 }
 
 func TestAcquirePublishSlotRespectsContextDeadline(t *testing.T) {
@@ -596,16 +661,47 @@ func TestAcquirePublishSlotRespectsContextDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
 
-	_, release, err := log.acquirePublishSlot(ctx)
+	_, release, err := log.acquirePublishSlots(ctx, "entity.upsert")
 	if err == nil {
 		release()
-		t.Fatal("acquirePublishSlot() error = nil, want deadline error")
+		t.Fatal("acquirePublishSlots() error = nil, want deadline error")
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("acquirePublishSlot() error = %v, want deadline exceeded", err)
+		t.Fatalf("acquirePublishSlots() error = %v, want deadline exceeded", err)
 	}
 	if len(log.publishSlots) != 1 {
 		t.Fatalf("publishSlots len = %d, want 1", len(log.publishSlots))
+	}
+}
+
+func TestAcquireFindingsPublishSlotReleasesGlobalOnDeadline(t *testing.T) {
+	log := &Log{
+		publishSlots: make(chan struct{}, 1),
+		findingSlots: make(chan struct{}, 1),
+	}
+	log.findingSlots <- struct{}{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	bulkheads, release, err := log.acquirePublishSlots(ctx, securityevents.FindingRecorded)
+	if err == nil {
+		release()
+		t.Fatal("acquirePublishSlots() error = nil, want deadline error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("acquirePublishSlots() error = %v, want deadline exceeded", err)
+	}
+	if len(log.publishSlots) != 0 {
+		t.Fatalf("publishSlots len = %d, want released global slot", len(log.publishSlots))
+	}
+	if len(log.findingSlots) != 1 {
+		t.Fatalf("findingSlots len = %d, want original finding slot", len(log.findingSlots))
+	}
+	if len(bulkheads) != 2 {
+		t.Fatalf("bulkheads = %#v, want global and findings", bulkheads)
+	}
+	if bulkheads[0].Scope != publishBulkheadScopeGlobal || bulkheads[1].Scope != publishBulkheadScopeFindings {
+		t.Fatalf("bulkhead scopes = %#v, want global then findings", bulkheads)
 	}
 }
 

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -632,6 +632,47 @@ func TestAppendEmitsFindingsPublishBulkheadTelemetry(t *testing.T) {
 	}
 }
 
+func TestAppendPreservesGlobalBulkheadMaxTelemetryWithFindingsBulkhead(t *testing.T) {
+	pub := &fakePublisher{}
+	log := &Log{
+		js:            pub,
+		subjectPrefix: "events",
+		publishSlots:  make(chan struct{}, 5),
+		findingSlots:  make(chan struct{}, 2),
+	}
+
+	stderr := captureJetstreamTelemetry(t, func() {
+		err := log.Append(context.Background(), &cerebrov1.EventEnvelope{
+			Id:   "evt-global-findings-bulkhead-telemetry",
+			Kind: securityevents.FindingRecorded,
+		})
+		if err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	})
+
+	spanEnds := jetstreamTelemetryPayloads(t, stderr, "span_end", "jetstream.append")
+	if len(spanEnds) != 1 {
+		t.Fatalf("jetstream.append span_end events = %d, want 1; stderr=%s", len(spanEnds), stderr)
+	}
+	end := spanEnds[0]
+	if end["messaging.jetstream.publish.bulkhead.scopes"] != "global,findings" {
+		t.Fatalf("bulkhead scopes = %v, want global,findings", end["messaging.jetstream.publish.bulkhead.scopes"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.max_in_flight"] != float64(5) {
+		t.Fatalf("bulkhead max in flight = %v, want legacy global value 5", end["messaging.jetstream.publish.bulkhead.max_in_flight"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.effective_max_in_flight"] != float64(2) {
+		t.Fatalf("effective bulkhead max in flight = %v, want tightest value 2", end["messaging.jetstream.publish.bulkhead.effective_max_in_flight"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.global.max_in_flight"] != float64(5) {
+		t.Fatalf("global bulkhead max in flight = %v, want 5", end["messaging.jetstream.publish.bulkhead.global.max_in_flight"])
+	}
+	if end["messaging.jetstream.publish.bulkhead.findings.max_in_flight"] != float64(2) {
+		t.Fatalf("findings bulkhead max in flight = %v, want 2", end["messaging.jetstream.publish.bulkhead.findings.max_in_flight"])
+	}
+}
+
 func TestAppendNonFindingBypassesFindingsPublishBulkhead(t *testing.T) {
 	pub := &fakePublisher{}
 	findingSlots := make(chan struct{}, 1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,7 @@ type AppendLogConfig struct {
 	JetStreamSubjectPrefix              string
 	JetStreamDrainTimeout               time.Duration
 	JetStreamPublishMaxInFlight         int
+	JetStreamPublishFindingsMaxInFlight int
 	JetStreamPublishRetryAttempts       int
 	JetStreamPublishRetryInitialBackoff time.Duration
 	JetStreamPublishRetryMaxBackoff     time.Duration
@@ -590,6 +591,9 @@ func Load() (Config, error) {
 	if cfg.AppendLog.JetStreamPublishMaxInFlight, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", 0); err != nil {
 		return Config{}, err
 	}
+	if cfg.AppendLog.JetStreamPublishFindingsMaxInFlight, err = parseIntEnv("CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT", 0); err != nil {
+		return Config{}, err
+	}
 	if cfg.AppendLog.JetStreamRuntimeIndexEnabled, err = parseBoolEnvDefault("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", true); err != nil {
 		return Config{}, err
 	}
@@ -718,6 +722,9 @@ func Load() (Config, error) {
 		}
 		if cfg.AppendLog.JetStreamPublishMaxInFlight < 0 {
 			return Config{}, errors.New("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT must be greater than or equal to 0")
+		}
+		if cfg.AppendLog.JetStreamPublishFindingsMaxInFlight < 0 {
+			return Config{}, errors.New("CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT must be greater than or equal to 0")
 		}
 		if err := validateJetStreamPublishRetryConfig(cfg.AppendLog); err != nil {
 			return Config{}, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,6 +23,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT", "")
 	t.Setenv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "")
@@ -187,6 +188,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "cerebro.events")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "4s")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "12")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT", "3")
 	t.Setenv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", "true")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "22")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "750ms")
@@ -307,6 +309,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.AppendLog.JetStreamPublishMaxInFlight != 12 {
 		t.Fatalf("JetStreamPublishMaxInFlight = %d, want 12", cfg.AppendLog.JetStreamPublishMaxInFlight)
+	}
+	if cfg.AppendLog.JetStreamPublishFindingsMaxInFlight != 3 {
+		t.Fatalf("JetStreamPublishFindingsMaxInFlight = %d, want 3", cfg.AppendLog.JetStreamPublishFindingsMaxInFlight)
 	}
 	if !cfg.AppendLog.JetStreamRuntimeIndexEnabled {
 		t.Fatalf("JetStreamRuntimeIndexEnabled = %v, want true", cfg.AppendLog.JetStreamRuntimeIndexEnabled)
@@ -623,6 +628,7 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
 	t.Setenv("CEREBRO_JETSTREAM_DRAIN_TIMEOUT", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT", "")
 	t.Setenv("CEREBRO_JETSTREAM_RUNTIME_INDEX_ENABLED", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_ATTEMPTS", "")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_RETRY_INITIAL_BACKOFF", "")
@@ -1342,6 +1348,16 @@ func TestLoadRejectsNegativeJetStreamPublishMaxInFlight(t *testing.T) {
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", AppendLogDriverJetStream)
 	t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
 	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_MAX_IN_FLIGHT", "-1")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsNegativeJetStreamPublishFindingsMaxInFlight(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", AppendLogDriverJetStream)
+	t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
+	t.Setenv("CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT", "-1")
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")
 	}


### PR DESCRIPTION
## Summary
- add `CEREBRO_JETSTREAM_PUBLISH_FINDINGS_MAX_IN_FLIGHT` for `sec.findings.v1.*` publish attempts
- acquire the global JetStream publish bulkhead first, then the findings bulkhead for finding subjects
- emit bulkhead scope and per-scope wait fields on JetStream append telemetry
- document the knob and the incident checks

## Tests
- `go test ./internal/appendlog/jetstream`
- `go test ./internal/config`
- `go test ./internal/appendlog/... ./internal/config`
- `go test ./internal/findings`
- `make docs-drift-check`
- `make changed-check`

Closes #1302
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->