### PR TITLE
[codex] Raise cloud source runtime fidelity

### DIFF
--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -130,6 +131,7 @@ import (
 	ssoadmintypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	vpclatticetypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+	"gopkg.in/yaml.v3"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -683,6 +685,76 @@ func TestNewFixtureReplaysAWSFamilies(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewFixtureReplaysEveryRuntimeFamily(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	sourcecdk.RunFixtureSuite(t, context.Background(), sourcecdk.FixtureSuiteOptions{
+		Source:          source,
+		FamilyConfigs:   awsRuntimeFamilyConfigsForTest(t),
+		RequireDiscover: true,
+	})
+}
+
+func TestAWSProviderUnavailableReturnsError(t *testing.T) {
+	errProviderUnavailable := errors.New("provider unavailable")
+	source := newTestSource(t, fakeAWS{fakeAWSAuditPosture: fakeAWSAuditPosture{
+		cloudTrailLookup: func(context.Context, *cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error) {
+			return nil, errProviderUnavailable
+		},
+	}})
+	cfg := sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyCloudTrail})
+
+	if err := source.Check(context.Background(), cfg); !errors.Is(err, errProviderUnavailable) {
+		t.Fatalf("Check(%s) error = %v, want provider unavailable", familyCloudTrail, err)
+	}
+	if _, err := source.Discover(context.Background(), cfg); !errors.Is(err, errProviderUnavailable) {
+		t.Fatalf("Discover(%s) error = %v, want provider unavailable", familyCloudTrail, err)
+	}
+	if _, err := source.Read(context.Background(), cfg, nil); !errors.Is(err, errProviderUnavailable) {
+		t.Fatalf("Read(%s) error = %v, want provider unavailable", familyCloudTrail, err)
+	}
+}
+
+func awsRuntimeFamilyConfigsForTest(t *testing.T) map[string]sourcecdk.Config {
+	t.Helper()
+	configs := map[string]sourcecdk.Config{}
+	for _, family := range runtimeFamiliesForTest(t) {
+		configs[family] = sourcecdk.NewConfig(map[string]string{
+			"account_id":                   "123456789012",
+			"family":                       family,
+			"group_name":                   "Security",
+			"identity_center_instance_arn": "arn:aws:sso:::instance/ssoins-1234567890abcdef",
+			"identity_store_id":            "d-1234567890",
+			"permission_set_arn":           "arn:aws:sso:::permissionSet/ssoins-1234567890abcdef/ps-1234567890abcdef",
+			"principal_name":               "admin@writer.com",
+			"principal_type":               "user",
+			"target_account_id":            "123456789012",
+			"user_name":                    "admin@writer.com",
+		})
+	}
+	return configs
+}
+
+func runtimeFamiliesForTest(t *testing.T) []string {
+	t.Helper()
+	payload, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		t.Fatalf("read catalog.yaml: %v", err)
+	}
+	var catalog struct {
+		RuntimeFamilies []string `yaml:"runtime_families"`
+	}
+	if err := yaml.Unmarshal(payload, &catalog); err != nil {
+		t.Fatalf("unmarshal catalog.yaml: %v", err)
+	}
+	if len(catalog.RuntimeFamilies) == 0 {
+		t.Fatal("catalog runtime_families is empty")
+	}
+	return catalog.RuntimeFamilies
 }
 
 func TestReadAWSNetworkACLAndFlowLogEvents(t *testing.T) {

--- a/sources/azure/source_test.go
+++ b/sources/azure/source_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/yaml.v3"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -116,6 +117,18 @@ func TestNewFixtureReplaysAzureFamilies(t *testing.T) {
 	}
 }
 
+func TestNewFixtureReplaysEveryRuntimeFamily(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	sourcecdk.RunFixtureSuite(t, context.Background(), sourcecdk.FixtureSuiteOptions{
+		Source:          source,
+		FamilyConfigs:   azureRuntimeFamilyConfigsForTest(t),
+		RequireDiscover: true,
+	})
+}
+
 func TestNewFixtureReplaysAzureGenericARMFamilies(t *testing.T) {
 	source, err := NewFixture()
 	if err != nil {
@@ -143,6 +156,43 @@ func TestNewFixtureReplaysAzureGenericARMFamilies(t *testing.T) {
 			}
 			if got := pull.Events[0].Attributes["family"]; got != definition.Name {
 				t.Fatalf("family = %q, want %q", got, definition.Name)
+			}
+		})
+	}
+}
+
+func TestAzureProviderUnavailableReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"error":"provider unavailable"}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	for _, tt := range []struct {
+		name   string
+		family string
+		config map[string]string
+	}{
+		{name: "graph", family: familyUser},
+		{name: "arm", family: familyStorageAccount, config: map[string]string{"subscription_id": "sub-1"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config := map[string]string{"base_url": server.URL, "family": tt.family, "tenant_id": "tenant-1", "token": "test-token"}
+			for key, value := range tt.config {
+				config[key] = value
+			}
+			cfg := sourcecdk.NewConfig(config)
+			if err := source.Check(context.Background(), cfg); !strings.Contains(errString(err), "azure API returned 503") {
+				t.Fatalf("Check(%s) error = %v, want provider unavailable status", tt.family, err)
+			}
+			if _, err := source.Discover(context.Background(), cfg); !strings.Contains(errString(err), "azure API returned 503") {
+				t.Fatalf("Discover(%s) error = %v, want provider unavailable status", tt.family, err)
+			}
+			if _, err := source.Read(context.Background(), cfg, nil); !strings.Contains(errString(err), "azure API returned 503") {
+				t.Fatalf("Read(%s) error = %v, want provider unavailable status", tt.family, err)
 			}
 		})
 	}
@@ -806,6 +856,47 @@ func newLiveTestSource() (*Source, error) {
 	source.allowLoopbackBaseURL = true
 	source.client = source.safeClient()
 	return source, nil
+}
+
+func azureRuntimeFamilyConfigsForTest(t *testing.T) map[string]sourcecdk.Config {
+	t.Helper()
+	configs := map[string]sourcecdk.Config{}
+	for _, family := range runtimeFamiliesForTest(t) {
+		configs[family] = sourcecdk.NewConfig(map[string]string{
+			"family":               family,
+			"group_id":             "group-1",
+			"service_principal_id": "sp-resource-1",
+			"subscription_id":      "sub-1",
+			"tenant_id":            "tenant-1",
+			"token":                "test-token",
+		})
+	}
+	return configs
+}
+
+func runtimeFamiliesForTest(t *testing.T) []string {
+	t.Helper()
+	payload, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		t.Fatalf("read catalog.yaml: %v", err)
+	}
+	var catalog struct {
+		RuntimeFamilies []string `yaml:"runtime_families"`
+	}
+	if err := yaml.Unmarshal(payload, &catalog); err != nil {
+		t.Fatalf("unmarshal catalog.yaml: %v", err)
+	}
+	if len(catalog.RuntimeFamilies) == 0 {
+		t.Fatal("catalog runtime_families is empty")
+	}
+	return catalog.RuntimeFamilies
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 func TestReadActivityLogsWithCheckpoint(t *testing.T) {

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/oauth2"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/yaml.v3"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -179,6 +180,46 @@ func TestNewFixtureReplaysGCPFamilies(t *testing.T) {
 				t.Fatalf("Read(%s).Events[0].Kind = %q, want %q", tt.family, got, tt.kind)
 			}
 		})
+	}
+}
+
+func TestNewFixtureReplaysEveryRuntimeFamily(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	sourcecdk.RunFixtureSuite(t, context.Background(), sourcecdk.FixtureSuiteOptions{
+		Source:          source,
+		FamilyConfigs:   gcpRuntimeFamilyConfigsForTest(t),
+		RequireDiscover: true,
+	})
+}
+
+func TestGCPProviderUnavailableReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"error":"provider unavailable"}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url":   server.URL,
+		"family":     familyServiceAcct,
+		"project_id": "writer-prod",
+		"token":      "test-token",
+	})
+
+	if err := source.Check(context.Background(), cfg); !strings.Contains(errString(err), "gcp API returned 503") {
+		t.Fatalf("Check(%s) error = %v, want provider unavailable status", familyServiceAcct, err)
+	}
+	if _, err := source.Discover(context.Background(), cfg); !strings.Contains(errString(err), "gcp API returned 503") {
+		t.Fatalf("Discover(%s) error = %v, want provider unavailable status", familyServiceAcct, err)
+	}
+	if _, err := source.Read(context.Background(), cfg, nil); !strings.Contains(errString(err), "gcp API returned 503") {
+		t.Fatalf("Read(%s) error = %v, want provider unavailable status", familyServiceAcct, err)
 	}
 }
 
@@ -1150,6 +1191,50 @@ func newLiveTestSource() (*Source, error) {
 	source.allowLoopbackBaseURL = true
 	source.client = source.safeClient()
 	return source, nil
+}
+
+func gcpRuntimeFamilyConfigsForTest(t *testing.T) map[string]sourcecdk.Config {
+	t.Helper()
+	configs := map[string]sourcecdk.Config{}
+	for _, family := range runtimeFamiliesForTest(t) {
+		configs[family] = sourcecdk.NewConfig(map[string]string{
+			"artifact_repository":   "projects/writer-prod/locations/us/repositories/app",
+			"customer_id":           "C01",
+			"family":                family,
+			"group_key":             "security@writer.com",
+			"key_ring":              "prod",
+			"location":              "us",
+			"project_id":            "writer-prod",
+			"service_account_email": "sa@writer-prod.iam.gserviceaccount.com",
+			"token":                 "test-token",
+		})
+	}
+	return configs
+}
+
+func runtimeFamiliesForTest(t *testing.T) []string {
+	t.Helper()
+	payload, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		t.Fatalf("read catalog.yaml: %v", err)
+	}
+	var catalog struct {
+		RuntimeFamilies []string `yaml:"runtime_families"`
+	}
+	if err := yaml.Unmarshal(payload, &catalog); err != nil {
+		t.Fatalf("unmarshal catalog.yaml: %v", err)
+	}
+	if len(catalog.RuntimeFamilies) == 0 {
+		t.Fatal("catalog runtime_families is empty")
+	}
+	return catalog.RuntimeFamilies
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 func newGCPAPIHandler(t *testing.T) http.Handler {


### PR DESCRIPTION
Stacked on #1604. Retarget this PR to main after the parent PR lands.

Summary:
- Add catalog-driven every-runtime-family fixture replay tests for AWS, Azure, and GCP.
- Add provider-unavailable error-path tests for AWS SDK/list failures, Azure Graph and ARM 503s, and GCP 503s.
- Keep deploy manifests unchanged because cloud source deploy family coverage is already complete.

Validation:
- go test ./sources/aws ./sources/azure ./sources/gcp -count=1
- go run ./tools/sourcefidelity -root . -json-out /tmp/sourcefidelity-cloud.json -max-items 40
- git diff --check

Source fidelity:
- AWS: every-family and provider-unavailable tests covered; SDK-backed HTTP advisory remains.
- Azure: reference coverage.
- GCP: reference coverage.