### PR TITLE
Add questionnaire file and portal intake

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -12167,10 +12167,22 @@ components:
             $ref: '#/components/schemas/GRCQuestionnaireIntakeRow'
         intake_text:
           type: string
-          description: JSON, CSV, TSV, or one-question-per-line intake content.
+          description: JSON, CSV, TSV, portal capture text, PDF-extracted text, or one-question-per-line intake content.
         intake_format:
           type: string
-          enum: [json, csv, tsv, text]
+          enum: [json, csv, tsv, text, portal, pdf, xlsx, xlsm]
+        intake_file_base64:
+          type: string
+          description: Base64-encoded questionnaire attachment for PDF, XLSX, XLSM, CSV, TSV, JSON, text, or portal capture intake.
+        intake_content_type:
+          type: string
+          description: MIME type for the intake attachment.
+        portal_url:
+          type: string
+          description: Portal URL for questionnaires captured from a customer or vendor portal. Portal intake with a URL can be created before questions are captured.
+        portal_instructions:
+          type: string
+          description: Login, workspace, owner, or handling notes for portal intake.
         attributes:
           type: object
           additionalProperties:
@@ -12203,7 +12215,6 @@ components:
           type: string
     GRCQuestionnaireAssignmentRequest:
       type: object
-      required: [question_id]
       properties:
         tenant_id:
           type: string
@@ -12260,7 +12271,7 @@ components:
           type: string
     GRCQuestionnaireCommentRequest:
       type: object
-      required: [question_id, body]
+      required: [body]
       properties:
         tenant_id:
           type: string

--- a/internal/sourcehttp/questionnaire/handler.go
+++ b/internal/sourcehttp/questionnaire/handler.go
@@ -19,6 +19,7 @@ import (
 )
 
 const maxQuestionnaireBodyBytes = 512 << 10
+const maxQuestionnaireCreateBodyBytes = 16 << 20
 const defaultLimit uint32 = 100
 
 var (
@@ -175,6 +176,10 @@ type createRequest struct {
 	IntakeRows     []intakeRow                   `json:"intake_rows,omitempty"`
 	IntakeText     string                        `json:"intake_text,omitempty"`
 	IntakeFormat   string                        `json:"intake_format,omitempty"`
+	IntakeFile     string                        `json:"intake_file_base64,omitempty"`
+	IntakeMimeType string                        `json:"intake_content_type,omitempty"`
+	PortalURL      string                        `json:"portal_url,omitempty"`
+	PortalNotes    string                        `json:"portal_instructions,omitempty"`
 	Attributes     map[string]string             `json:"attributes,omitempty"`
 }
 
@@ -272,7 +277,7 @@ func (h *Handler) ListRuns(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) CreateRun(w http.ResponseWriter, r *http.Request) {
 	var request createRequest
-	if err := decodeJSON(w, r, &request); err != nil {
+	if err := decodeJSONWithLimit(w, r, &request, maxQuestionnaireCreateBodyBytes); err != nil {
 		h.writeError(w, err)
 		return
 	}
@@ -298,7 +303,7 @@ func (h *Handler) CreateRun(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, err)
 		return
 	}
-	if len(questions) == 0 {
+	if len(questions) == 0 && !allowsPortalCaptureWithoutQuestions(request) {
 		h.writeError(w, fmt.Errorf("%w: at least one question is required", ErrInvalidRequest))
 		return
 	}
@@ -312,6 +317,7 @@ func (h *Handler) CreateRun(w http.ResponseWriter, r *http.Request) {
 	if uploadID == "" {
 		uploadID = fmt.Sprintf("intake-%d", now.UnixNano())
 	}
+	attributes := createRunAttributes(request, len(questions))
 	record := questionnairedomain.NewRunRecord(questionnairedomain.NewRunRequest{
 		TenantID:       scope.TenantID,
 		Direction:      request.Direction,
@@ -329,7 +335,7 @@ func (h *Handler) CreateRun(w http.ResponseWriter, r *http.Request) {
 		AssignedTeam:   request.AssignedTeam,
 		DueAt:          dueAt,
 		Questions:      questions,
-		Attributes:     request.Attributes,
+		Attributes:     attributes,
 	}, now)
 	event := questionnairedomain.Event(record, ports.QuestionnaireEventCreated, h.actorID(r.Context()), "Questionnaire run created", map[string]string{"direction": record.Direction, "question_count": strconv.Itoa(len(record.Questions)), "source_format": record.SourceFormat}, now)
 	created, err := h.store.UpsertQuestionnaireRun(r.Context(), record, event)
@@ -411,7 +417,7 @@ func (h *Handler) AssignRun(w http.ResponseWriter, r *http.Request) {
 		Status:     firstNonEmpty(request.Status, "open"),
 		Reason:     strings.TrimSpace(request.Reason),
 	}
-	if err := validateQuestionReference(record, assignment.QuestionID, true); err != nil {
+	if err := validateQuestionReference(record, assignment.QuestionID, false); err != nil {
 		h.writeError(w, err)
 		return
 	}
@@ -549,7 +555,7 @@ func (h *Handler) CommentRun(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, fmt.Errorf("%w: comment body is required", ErrInvalidRequest))
 		return
 	}
-	if err := validateQuestionReference(record, comment.QuestionID, true); err != nil {
+	if err := validateQuestionReference(record, comment.QuestionID, false); err != nil {
 		h.writeError(w, err)
 		return
 	}
@@ -761,7 +767,11 @@ func questionnaireStatusIsOpenWork(status string) bool {
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {
-	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxQuestionnaireBodyBytes))
+	return decodeJSONWithLimit(w, r, target, maxQuestionnaireBodyBytes)
+}
+
+func decodeJSONWithLimit(w http.ResponseWriter, r *http.Request, target any, limit int64) error {
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, limit))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
 		return fmt.Errorf("%w: decode questionnaire request: %w", ErrInvalidRequest, err)
@@ -873,6 +883,13 @@ func questionsForCreate(request createRequest) ([]ports.QuestionnaireQuestion, e
 	for _, row := range request.IntakeRows {
 		questions = append(questions, questionFromIntakeRow(row))
 	}
+	if strings.TrimSpace(request.IntakeFile) != "" {
+		parsed, err := parseIntakeAttachment(request)
+		if err != nil {
+			return nil, err
+		}
+		questions = append(questions, parsed...)
+	}
 	if strings.TrimSpace(request.IntakeText) != "" {
 		parsed, err := parseIntakeText(request.IntakeText, firstNonEmpty(request.IntakeFormat, request.SourceFormat))
 		if err != nil {
@@ -881,6 +898,11 @@ func questionsForCreate(request createRequest) ([]ports.QuestionnaireQuestion, e
 		questions = append(questions, parsed...)
 	}
 	return questionnairedomain.NormalizeQuestionsForIntake(questions), nil
+}
+
+func allowsPortalCaptureWithoutQuestions(request createRequest) bool {
+	format := canonicalIntakeFormat(firstNonEmpty(request.IntakeFormat, request.SourceFormat))
+	return format == "portal" && strings.TrimSpace(request.PortalURL) != ""
 }
 
 func parseIntakeText(value string, format string) ([]ports.QuestionnaireQuestion, error) {
@@ -894,10 +916,16 @@ func parseIntakeText(value string, format string) ([]ports.QuestionnaireQuestion
 		return parseJSONIntake(trimmed)
 	case "csv", "tsv":
 		return parseDelimitedIntake(trimmed, format)
+	case "portal":
+		return parsePortalIntake(trimmed)
+	case "pdf":
+		return parsePDFPromptText(trimmed)
+	case "xlsx", "xlsm":
+		return nil, fmt.Errorf("%w: xlsx intake requires intake_file_base64", ErrInvalidRequest)
 	case "", "text", "txt", "plain":
 		return parsePlainTextIntake(trimmed), nil
 	default:
-		return nil, fmt.Errorf("%w: intake_format must be csv, tsv, json, or text", ErrInvalidRequest)
+		return nil, fmt.Errorf("%w: intake_format must be csv, tsv, json, text, portal, pdf, or xlsx", ErrInvalidRequest)
 	}
 }
 
@@ -973,6 +1001,30 @@ func parsePlainTextIntake(value string) []ports.QuestionnaireQuestion {
 		rows = append(rows, intakeRow{Question: line})
 	}
 	return questionsFromIntakeRows(rows)
+}
+
+func parsePortalIntake(value string) ([]ports.QuestionnaireQuestion, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, nil
+	}
+	rows := []intakeRow{}
+	section := ""
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = normalizePortalQuestionLine(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasSuffix(line, ":") && !strings.Contains(line, "?") && len(line) <= 80 {
+			section = strings.TrimSuffix(line, ":")
+			continue
+		}
+		if !looksLikeQuestionnairePrompt(line) {
+			continue
+		}
+		rows = append(rows, intakeRow{Question: line, Section: section})
+	}
+	return questionsFromIntakeRows(rows), nil
 }
 
 func questionsFromIntakeRows(rows []intakeRow) []ports.QuestionnaireQuestion {

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -1,7 +1,10 @@
 package questionnaire
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -42,6 +45,188 @@ func TestCreateRunParsesCSVIntakeText(t *testing.T) {
 	}
 	if store.saved.Questions[0].Question == "" || store.saved.Questions[0].OwnerID != "security@example.com" {
 		t.Fatalf("first question not mapped from CSV: %#v", store.saved.Questions[0])
+	}
+}
+
+func TestCreateRunParsesXLSXIntakeFile(t *testing.T) {
+	store := &processRunStore{}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "grc@example.com" },
+	})
+	body := mustJSON(t, map[string]any{
+		"tenant_id":           "tenant-1",
+		"direction":           "customer_security_review",
+		"title":               "Acme security review",
+		"customer_name":       "Acme",
+		"source_filename":     "security-questionnaire.xlsx",
+		"source_format":       "xlsx",
+		"intake_format":       "xlsx",
+		"intake_content_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"intake_file_base64":  base64.StdEncoding.EncodeToString(testXLSXWorkbook(t)),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	handler.CreateRun(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if len(store.saved.Questions) != 2 {
+		t.Fatalf("questions = %d, want 2: %#v", len(store.saved.Questions), store.saved.Questions)
+	}
+	if store.saved.Questions[0].Question != "Do you enforce MFA?" || store.saved.Questions[0].Section != "Access" {
+		t.Fatalf("first question = %#v, want mapped XLSX question", store.saved.Questions[0])
+	}
+	if got := store.saved.Questions[0].RequiredSlots; len(got) != 1 || got[0] != "identity_mfa" {
+		t.Fatalf("required slots = %#v, want identity_mfa", got)
+	}
+	if store.saved.Attributes["intake_file_attached"] != "true" || store.saved.Attributes["intake_format"] != "xlsx" {
+		t.Fatalf("attributes = %#v, want xlsx attachment metadata", store.saved.Attributes)
+	}
+}
+
+func TestCreateRunInfersXLSXFromFilenameWhenMimeTypeIsGeneric(t *testing.T) {
+	store := &processRunStore{}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "grc@example.com" },
+	})
+	body := mustJSON(t, map[string]any{
+		"tenant_id":           "tenant-1",
+		"direction":           "customer_security_review",
+		"title":               "Acme security review",
+		"source_filename":     "security-questionnaire.xlsx",
+		"intake_content_type": "application/octet-stream",
+		"intake_file_base64":  base64.StdEncoding.EncodeToString(testXLSXWorkbook(t)),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	handler.CreateRun(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if len(store.saved.Questions) != 2 {
+		t.Fatalf("questions = %d, want 2: %#v", len(store.saved.Questions), store.saved.Questions)
+	}
+	if store.saved.Attributes["intake_format"] != "xlsx" {
+		t.Fatalf("intake format attribute = %q, want xlsx", store.saved.Attributes["intake_format"])
+	}
+}
+
+func TestCreateRunParsesPDFIntakeFile(t *testing.T) {
+	store := &processRunStore{}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "grc@example.com" },
+	})
+	body := mustJSON(t, map[string]any{
+		"tenant_id":           "tenant-1",
+		"direction":           "customer_security_review",
+		"title":               "Acme security review",
+		"source_filename":     "security-questionnaire.pdf",
+		"source_format":       "pdf",
+		"intake_format":       "pdf",
+		"intake_content_type": "application/pdf",
+		"intake_file_base64":  base64.StdEncoding.EncodeToString(testPDFWithPrompts()),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	handler.CreateRun(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if len(store.saved.Questions) != 2 {
+		t.Fatalf("questions = %d, want 2: %#v", len(store.saved.Questions), store.saved.Questions)
+	}
+	if store.saved.Questions[0].Question != "Do you enforce MFA?" || store.saved.Questions[1].Question != "Attach SOC 2 report." {
+		t.Fatalf("questions = %#v, want extracted PDF prompts", store.saved.Questions)
+	}
+}
+
+func TestCreateRunStoresPortalMetadataAndParsesPortalText(t *testing.T) {
+	store := &processRunStore{}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "grc@example.com" },
+	})
+	body := mustJSON(t, map[string]any{
+		"tenant_id":           "tenant-1",
+		"direction":           "customer_security_review",
+		"title":               "Portal review",
+		"source_format":       "portal",
+		"intake_format":       "portal",
+		"portal_url":          "https://portal.example.test/review/123",
+		"portal_instructions": "Use SSO and route missing access to sales ops.",
+		"intake_text":         "Access:\nQuestion 1: Do you enforce MFA?\nSave\nAudit:\nQuestion: Attach SOC 2 report.",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	handler.CreateRun(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if len(store.saved.Questions) != 2 {
+		t.Fatalf("questions = %d, want 2: %#v", len(store.saved.Questions), store.saved.Questions)
+	}
+	if store.saved.Questions[0].Section != "Access" || store.saved.Questions[1].Section != "Audit" {
+		t.Fatalf("sections = %#v, want portal sections", store.saved.Questions)
+	}
+	if store.saved.Attributes["portal_url"] != "https://portal.example.test/review/123" ||
+		store.saved.Attributes["portal_status"] != "questions_captured" ||
+		store.saved.Attributes["portal_instructions"] != "Use SSO and route missing access to sales ops." {
+		t.Fatalf("attributes = %#v, want portal metadata", store.saved.Attributes)
+	}
+}
+
+func TestCreateRunAllowsPortalCaptureWithoutQuestions(t *testing.T) {
+	store := &processRunStore{}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "grc@example.com" },
+	})
+	body := mustJSON(t, map[string]any{
+		"tenant_id":           "tenant-1",
+		"direction":           "customer_security_review",
+		"title":               "Portal review",
+		"source_format":       "portal",
+		"intake_format":       "portal",
+		"portal_url":          "https://portal.example.test/review/123",
+		"portal_instructions": "Capture questions after account access is granted.",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	handler.CreateRun(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if len(store.saved.Questions) != 0 {
+		t.Fatalf("questions = %#v, want none before portal capture", store.saved.Questions)
+	}
+	if store.saved.Status != ports.QuestionnaireStatusIntake {
+		t.Fatalf("status = %q, want intake", store.saved.Status)
+	}
+	if store.saved.Attributes["portal_status"] != "needs_capture" || store.saved.Attributes["portal_url"] == "" {
+		t.Fatalf("attributes = %#v, want portal capture metadata", store.saved.Attributes)
 	}
 }
 
@@ -88,6 +273,40 @@ func TestCommentRunRecordsComment(t *testing.T) {
 	}
 }
 
+func TestCommentRunAllowsRunLevelComment(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	store := &processRunStore{
+		record: ports.QuestionnaireRunRecord{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "tenant-1", RunID: "run-1", Title: "Portal review"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{Direction: ports.QuestionnaireDirectionCustomerSecurityReview},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusIntake},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
+				Attributes: map[string]string{"portal_status": "needs_capture"},
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			},
+		},
+	}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "security@example.com" },
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/comments", strings.NewReader(`{"body":"Portal access requested from account owner."}`))
+	req.SetPathValue("runID", "run-1")
+	recorder := httptest.NewRecorder()
+
+	handler.CommentRun(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if len(store.saved.Comments) != 1 || store.saved.Comments[0].QuestionID != "" {
+		t.Fatalf("comments = %#v, want run-level comment", store.saved.Comments)
+	}
+}
+
 func TestCommentRunRejectsForgedActorAndUnknownQuestion(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
 	store := &processRunStore{
@@ -125,6 +344,37 @@ func TestCommentRunRejectsForgedActorAndUnknownQuestion(t *testing.T) {
 	}
 }
 
+func TestCommentRunRejectsOversizedBody(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	store := &processRunStore{
+		record: ports.QuestionnaireRunRecord{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "tenant-1", RunID: "run-1", Title: "Customer review"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{Direction: ports.QuestionnaireDirectionCustomerSecurityReview},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusNeedsInput},
+			QuestionnaireRunContent: ports.QuestionnaireRunContent{
+				Questions: []ports.QuestionnaireQuestion{{ID: "q-1", Question: "Attach SOC 2 report."}},
+			},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{CreatedAt: now, UpdatedAt: now},
+		},
+	}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: "tenant-1", Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "security@example.com" },
+	})
+	body := `{"question_id":"q-1","body":"` + strings.Repeat("a", 600<<10) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/comments", strings.NewReader(body))
+	req.SetPathValue("runID", "run-1")
+	recorder := httptest.NewRecorder()
+
+	handler.CommentRun(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestAssignRunRejectsEmptyOwnerAndNestedBody(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
 	store := &processRunStore{
@@ -159,6 +409,40 @@ func TestAssignRunRejectsEmptyOwnerAndNestedBody(t *testing.T) {
 	handler.AssignRun(recorder, req)
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("nested assignment status = %d, want 400: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestAssignRunAllowsRunLevelAssignment(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	store := &processRunStore{
+		record: ports.QuestionnaireRunRecord{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "tenant-1", RunID: "run-1", Title: "Portal review"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{Direction: ports.QuestionnaireDirectionCustomerSecurityReview},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusIntake},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
+				Attributes: map[string]string{"portal_status": "needs_capture"},
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			},
+		},
+	}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "security@example.com" },
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/assignments", strings.NewReader(`{"owner_id":"sales-ops@example.com","reason":"Capture portal questions."}`))
+	req.SetPathValue("runID", "run-1")
+	recorder := httptest.NewRecorder()
+
+	handler.AssignRun(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if len(store.saved.Assignments) != 1 || store.saved.Assignments[0].QuestionID != "" || store.saved.Assignments[0].OwnerID != "sales-ops@example.com" {
+		t.Fatalf("assignments = %#v, want run-level assignment", store.saved.Assignments)
 	}
 }
 
@@ -430,6 +714,73 @@ func TestRunViewJSONStaysFlat(t *testing.T) {
 			t.Fatalf("missing flat JSON key %q in %s", key, payload)
 		}
 	}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(payload)
+}
+
+func testXLSXWorkbook(t *testing.T) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	writeZipFile(t, writer, "xl/worksheets/sheet1.xml", `<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1" t="inlineStr"><is><t>section</t></is></c>
+      <c r="B1" t="inlineStr"><is><t>question</t></is></c>
+      <c r="C1" t="inlineStr"><is><t>required_evidence_slots</t></is></c>
+      <c r="D1" t="inlineStr"><is><t>mapped_controls</t></is></c>
+      <c r="E1" t="inlineStr"><is><t>owner_id</t></is></c>
+    </row>
+    <row r="2">
+      <c r="A2" t="inlineStr"><is><t>Access</t></is></c>
+      <c r="B2" t="inlineStr"><is><t>Do you enforce MFA?</t></is></c>
+      <c r="C2" t="inlineStr"><is><t>identity_mfa</t></is></c>
+      <c r="D2" t="inlineStr"><is><t>SOC2-CC6.1</t></is></c>
+      <c r="E2" t="inlineStr"><is><t>security@example.com</t></is></c>
+    </row>
+    <row r="3">
+      <c r="A3" t="inlineStr"><is><t>Audit</t></is></c>
+      <c r="B3" t="inlineStr"><is><t>Attach SOC 2 report.</t></is></c>
+      <c r="C3" t="inlineStr"><is><t>audit_report</t></is></c>
+      <c r="D3" t="inlineStr"><is><t>SOC2-CC7.2</t></is></c>
+      <c r="E3" t="inlineStr"><is><t>security@example.com</t></is></c>
+    </row>
+  </sheetData>
+</worksheet>`)
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func writeZipFile(t *testing.T, writer *zip.Writer, name string, body string) {
+	t.Helper()
+	file, err := writer.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte(body)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testPDFWithPrompts() []byte {
+	return []byte(`%PDF-1.4
+1 0 obj
+<< /Length 66 >>
+stream
+BT (Do you enforce MFA?) Tj (Attach SOC 2 report.) Tj ET
+endstream
+endobj
+%%EOF`)
 }
 
 type processRunStore struct {

--- a/internal/sourcehttp/questionnaire/intake_attachment.go
+++ b/internal/sourcehttp/questionnaire/intake_attachment.go
@@ -1,0 +1,662 @@
+package questionnaire
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/zlib"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf16"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const maxIntakeAttachmentBytes = 12 << 20
+const maxIntakeArchiveEntryBytes = maxIntakeAttachmentBytes
+
+type xlsxWorksheet struct {
+	Rows []xlsxRow `xml:"sheetData>row"`
+}
+
+type xlsxRow struct {
+	Cells []xlsxCell `xml:"c"`
+}
+
+type xlsxCell struct {
+	Ref       string `xml:"r,attr"`
+	Type      string `xml:"t,attr"`
+	Value     string `xml:"v"`
+	InlineStr struct {
+		Text string `xml:"t"`
+	} `xml:"is"`
+}
+
+func createRunAttributes(request createRequest, questionCount int) map[string]string {
+	attributes := map[string]string{}
+	for key, value := range request.Attributes {
+		if key = strings.TrimSpace(key); key != "" {
+			attributes[key] = strings.TrimSpace(value)
+		}
+	}
+	format := canonicalIntakeFormat(firstNonEmpty(request.IntakeFormat, request.SourceFormat, inferAttachmentFormat(request.SourceFilename, request.IntakeMimeType)))
+	if format != "" {
+		attributes["intake_format"] = format
+	}
+	if strings.TrimSpace(request.IntakeFile) != "" {
+		attributes["intake_file_attached"] = "true"
+		if contentType := strings.TrimSpace(request.IntakeMimeType); contentType != "" {
+			attributes["intake_content_type"] = contentType
+		}
+	}
+	if portalURL := strings.TrimSpace(request.PortalURL); portalURL != "" {
+		attributes["portal_url"] = portalURL
+		if _, ok := attributes["portal_status"]; !ok {
+			attributes["portal_status"] = "questions_captured"
+			if questionCount == 0 {
+				attributes["portal_status"] = "needs_capture"
+			}
+		}
+	}
+	if notes := strings.TrimSpace(request.PortalNotes); notes != "" {
+		attributes["portal_instructions"] = notes
+	}
+	return attributes
+}
+
+func parseIntakeAttachment(request createRequest) ([]ports.QuestionnaireQuestion, error) {
+	data, err := decodeIntakeAttachment(request.IntakeFile)
+	if err != nil {
+		return nil, err
+	}
+	format := canonicalIntakeFormat(firstNonEmpty(request.IntakeFormat, request.SourceFormat, inferAttachmentFormat(request.SourceFilename, request.IntakeMimeType)))
+	switch format {
+	case "pdf":
+		text, err := extractPDFText(data)
+		if err != nil {
+			return nil, err
+		}
+		return parsePDFPromptText(text)
+	case "xlsx", "xlsm":
+		rows, err := extractXLSXRows(data)
+		if err != nil {
+			return nil, err
+		}
+		questions, err := questionsFromSpreadsheetRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		return questions, nil
+	case "json", "csv", "tsv", "text", "portal":
+		return parseIntakeText(string(data), format)
+	default:
+		return nil, fmt.Errorf("%w: intake attachment must be pdf, xlsx, csv, tsv, json, portal, or text", ErrInvalidRequest)
+	}
+}
+
+func decodeIntakeAttachment(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	if comma := strings.Index(value, ","); comma >= 0 && strings.HasPrefix(strings.ToLower(value[:comma+1]), "data:") {
+		value = value[comma+1:]
+	}
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		data, err = base64.RawStdEncoding.DecodeString(value)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: intake_file_base64 is not valid base64", ErrInvalidRequest)
+	}
+	if len(data) > maxIntakeAttachmentBytes {
+		return nil, fmt.Errorf("%w: intake attachment must be 12 MB or smaller", ErrInvalidRequest)
+	}
+	return data, nil
+}
+
+func canonicalIntakeFormat(format string) string {
+	format = strings.ToLower(strings.TrimSpace(format))
+	format = strings.TrimPrefix(format, ".")
+	switch format {
+	case "application/pdf":
+		return "pdf"
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return "xlsx"
+	case "application/vnd.ms-excel.sheet.macroenabled.12":
+		return "xlsm"
+	case "text/csv":
+		return "csv"
+	case "text/tab-separated-values":
+		return "tsv"
+	case "application/json":
+		return "json"
+	case "text/plain", "plain", "txt":
+		return "text"
+	default:
+		return format
+	}
+}
+
+func inferAttachmentFormat(filename string, contentType string) string {
+	if contentType = strings.TrimSpace(contentType); contentType != "" {
+		format := canonicalIntakeFormat(contentType)
+		if format != "" && format != contentType {
+			return format
+		}
+		if !strings.Contains(contentType, "/") && format != "" {
+			return format
+		}
+	}
+	switch strings.ToLower(filepath.Ext(strings.TrimSpace(filename))) {
+	case ".pdf":
+		return "pdf"
+	case ".xlsx":
+		return "xlsx"
+	case ".xlsm":
+		return "xlsm"
+	case ".csv":
+		return "csv"
+	case ".tsv":
+		return "tsv"
+	case ".json":
+		return "json"
+	case ".txt":
+		return "text"
+	default:
+		return ""
+	}
+}
+
+func extractXLSXRows(data []byte) ([][]string, error) {
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("%w: read xlsx workbook: %w", ErrInvalidRequest, err)
+	}
+	files := map[string]*zip.File{}
+	worksheetNames := []string{}
+	for _, file := range reader.File {
+		files[file.Name] = file
+		if strings.HasPrefix(file.Name, "xl/worksheets/sheet") && strings.HasSuffix(file.Name, ".xml") {
+			worksheetNames = append(worksheetNames, file.Name)
+		}
+	}
+	sort.Strings(worksheetNames)
+	sharedStrings, err := readXLSXSharedStrings(files["xl/sharedStrings.xml"])
+	if err != nil {
+		return nil, err
+	}
+	allRows := [][]string{}
+	for _, name := range worksheetNames {
+		rows, err := readXLSXWorksheet(files[name], sharedStrings)
+		if err != nil {
+			return nil, err
+		}
+		allRows = append(allRows, rows...)
+	}
+	if len(allRows) == 0 {
+		return nil, fmt.Errorf("%w: xlsx workbook did not contain worksheet rows", ErrInvalidRequest)
+	}
+	return allRows, nil
+}
+
+func readXLSXSharedStrings(file *zip.File) ([]string, error) {
+	if file == nil {
+		return nil, nil
+	}
+	body, err := readZipFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read xlsx shared strings: %w", ErrInvalidRequest, err)
+	}
+	decoder := xml.NewDecoder(bytes.NewReader(body))
+	values := []string{}
+	inString := false
+	var builder strings.Builder
+	for {
+		token, err := decoder.Token()
+		if errorsIsEOF(err) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("%w: parse xlsx shared strings: %w", ErrInvalidRequest, err)
+		}
+		switch token := token.(type) {
+		case xml.StartElement:
+			if token.Name.Local == "si" {
+				inString = true
+				builder.Reset()
+			}
+		case xml.EndElement:
+			if token.Name.Local == "si" && inString {
+				values = append(values, builder.String())
+				inString = false
+			}
+		case xml.CharData:
+			if inString {
+				builder.WriteString(string(token))
+			}
+		}
+	}
+	return values, nil
+}
+
+func readXLSXWorksheet(file *zip.File, sharedStrings []string) ([][]string, error) {
+	if file == nil {
+		return nil, nil
+	}
+	body, err := readZipFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read xlsx worksheet: %w", ErrInvalidRequest, err)
+	}
+	var worksheet xlsxWorksheet
+	if err := xml.Unmarshal(body, &worksheet); err != nil {
+		return nil, fmt.Errorf("%w: parse xlsx worksheet: %w", ErrInvalidRequest, err)
+	}
+	rows := make([][]string, 0, len(worksheet.Rows))
+	for _, row := range worksheet.Rows {
+		cells := []string{}
+		nextIndex := 0
+		for _, cell := range row.Cells {
+			index := xlsxColumnIndex(cell.Ref)
+			if index < 0 {
+				index = nextIndex
+			}
+			for len(cells) <= index {
+				cells = append(cells, "")
+			}
+			cells[index] = xlsxCellValue(cell, sharedStrings)
+			nextIndex = index + 1
+		}
+		cells = trimEmptyTail(cells)
+		if len(cells) > 0 {
+			rows = append(rows, cells)
+		}
+	}
+	return rows, nil
+}
+
+func questionsFromSpreadsheetRows(rows [][]string) ([]ports.QuestionnaireQuestion, error) {
+	for index, row := range rows {
+		header := normalizedHeaders(row)
+		questionIndex := headerIndex(header, "question", "question_text", "prompt")
+		if questionIndex < 0 {
+			continue
+		}
+		intakeRows := []intakeRow{}
+		for _, record := range rows[index+1:] {
+			if questionIndex >= len(record) || strings.TrimSpace(record[questionIndex]) == "" {
+				continue
+			}
+			intakeRows = append(intakeRows, intakeRow{
+				ID:                   columnValue(record, header, "id", "question_id"),
+				Question:             record[questionIndex],
+				Section:              columnValue(record, header, "section", "category"),
+				RequiredAnswerFormat: columnValue(record, header, "required_answer_format", "answer_format", "format"),
+				MappedControls:       splitList(columnValue(record, header, "mapped_controls", "controls", "control_ids")),
+				RequiredSlots:        splitList(columnValue(record, header, "required_evidence_slots", "evidence_slots", "slots")),
+				OwnerID:              columnValue(record, header, "owner_id", "owner", "assignee"),
+			})
+		}
+		return questionsFromIntakeRows(intakeRows), nil
+	}
+	return nil, fmt.Errorf("%w: xlsx workbook must include a question, question_text, or prompt column", ErrInvalidRequest)
+}
+
+func xlsxCellValue(cell xlsxCell, sharedStrings []string) string {
+	switch cell.Type {
+	case "s":
+		index, err := strconv.Atoi(strings.TrimSpace(cell.Value))
+		if err == nil && index >= 0 && index < len(sharedStrings) {
+			return strings.TrimSpace(sharedStrings[index])
+		}
+	case "inlineStr":
+		return strings.TrimSpace(cell.InlineStr.Text)
+	}
+	return strings.TrimSpace(cell.Value)
+}
+
+func xlsxColumnIndex(ref string) int {
+	if ref == "" {
+		return -1
+	}
+	index := 0
+	found := false
+	for _, char := range ref {
+		if char < 'A' || char > 'Z' {
+			if char >= 'a' && char <= 'z' {
+				char -= 'a' - 'A'
+			} else {
+				break
+			}
+		}
+		found = true
+		index = index*26 + int(char-'A'+1)
+	}
+	if !found {
+		return -1
+	}
+	return index - 1
+}
+
+func readZipFile(file *zip.File) ([]byte, error) {
+	reader, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = reader.Close() }()
+	body, err := io.ReadAll(io.LimitReader(reader, maxIntakeArchiveEntryBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxIntakeArchiveEntryBytes {
+		return nil, fmt.Errorf("xlsx entry exceeds %d bytes", maxIntakeArchiveEntryBytes)
+	}
+	return body, nil
+}
+
+func trimEmptyTail(values []string) []string {
+	for len(values) > 0 && strings.TrimSpace(values[len(values)-1]) == "" {
+		values = values[:len(values)-1]
+	}
+	return values
+}
+
+func extractPDFText(data []byte) (string, error) {
+	if !bytes.Contains(data[:min(len(data), 1024)], []byte("%PDF")) {
+		return "", fmt.Errorf("%w: pdf intake is not a PDF document", ErrInvalidRequest)
+	}
+	var text strings.Builder
+	offset := 0
+	for {
+		streamIndex := bytes.Index(data[offset:], []byte("stream"))
+		if streamIndex < 0 {
+			break
+		}
+		streamIndex += offset
+		bodyStart := streamIndex + len("stream")
+		if bodyStart < len(data) && data[bodyStart] == '\r' {
+			bodyStart++
+		}
+		if bodyStart < len(data) && data[bodyStart] == '\n' {
+			bodyStart++
+		}
+		endRelative := bytes.Index(data[bodyStart:], []byte("endstream"))
+		if endRelative < 0 {
+			break
+		}
+		bodyEnd := bodyStart + endRelative
+		raw := bytes.Trim(data[bodyStart:bodyEnd], "\r\n")
+		dict := pdfStreamDictionary(data[:streamIndex])
+		decoded := decodePDFStream(raw, dict)
+		for _, value := range pdfTextStrings(decoded) {
+			if strings.TrimSpace(value) != "" {
+				text.WriteString(value)
+				text.WriteByte('\n')
+			}
+		}
+		offset = bodyEnd + len("endstream")
+	}
+	result := strings.TrimSpace(text.String())
+	if result == "" {
+		return "", fmt.Errorf("%w: pdf intake did not contain extractable text", ErrInvalidRequest)
+	}
+	return result, nil
+}
+
+func parsePDFPromptText(value string) ([]ports.QuestionnaireQuestion, error) {
+	rows := []intakeRow{}
+	for _, line := range strings.Split(value, "\n") {
+		line = normalizePortalQuestionLine(line)
+		if line == "" || !looksLikeQuestionnairePrompt(line) {
+			continue
+		}
+		rows = append(rows, intakeRow{Question: line})
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("%w: pdf intake did not contain extractable questionnaire prompts", ErrInvalidRequest)
+	}
+	return questionsFromIntakeRows(rows), nil
+}
+
+func pdfStreamDictionary(prefix []byte) []byte {
+	end := bytes.LastIndex(prefix, []byte(">>"))
+	start := bytes.LastIndex(prefix, []byte("<<"))
+	if start >= 0 && end >= start {
+		return prefix[start : end+len(">>")]
+	}
+	return nil
+}
+
+func decodePDFStream(raw []byte, dict []byte) []byte {
+	if !bytes.Contains(dict, []byte("/FlateDecode")) {
+		return raw
+	}
+	reader, err := zlib.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return raw
+	}
+	defer func() { _ = reader.Close() }()
+	decoded, err := io.ReadAll(io.LimitReader(reader, maxIntakeAttachmentBytes+1))
+	if err != nil {
+		return raw
+	}
+	if len(decoded) > maxIntakeAttachmentBytes {
+		return raw
+	}
+	return decoded
+}
+
+func pdfTextStrings(data []byte) []string {
+	values := []string{}
+	for index := 0; index < len(data); index++ {
+		switch data[index] {
+		case '(':
+			value, next := readPDFLiteralString(data, index+1)
+			if next > index {
+				values = append(values, value)
+				index = next
+			}
+		case '<':
+			if index+1 < len(data) && data[index+1] == '<' {
+				continue
+			}
+			value, next := readPDFHexString(data, index+1)
+			if next > index {
+				values = append(values, value)
+				index = next
+			}
+		}
+	}
+	return values
+}
+
+func readPDFLiteralString(data []byte, index int) (string, int) {
+	var out []byte
+	depth := 1
+	for index < len(data) {
+		char := data[index]
+		index++
+		if char == '\\' && index < len(data) {
+			decoded, next := decodePDFEscape(data, index)
+			if decoded >= 0 && decoded <= 255 {
+				out = append(out, byte(decoded))
+			}
+			index = next
+			continue
+		}
+		switch char {
+		case '(':
+			depth++
+			out = append(out, char)
+		case ')':
+			depth--
+			if depth == 0 {
+				return decodePDFTextBytes(out), index - 1
+			}
+			out = append(out, char)
+		default:
+			out = append(out, char)
+		}
+	}
+	return "", -1
+}
+
+func decodePDFEscape(data []byte, index int) (int, int) {
+	char := data[index]
+	switch char {
+	case 'n':
+		return '\n', index + 1
+	case 'r':
+		return '\r', index + 1
+	case 't':
+		return '\t', index + 1
+	case 'b':
+		return '\b', index + 1
+	case 'f':
+		return '\f', index + 1
+	case '(', ')', '\\':
+		return int(char), index + 1
+	case '\r', '\n':
+		for index < len(data) && (data[index] == '\r' || data[index] == '\n') {
+			index++
+		}
+		return -1, index
+	default:
+		if char >= '0' && char <= '7' {
+			end := index
+			for end < len(data) && end-index < 3 && data[end] >= '0' && data[end] <= '7' {
+				end++
+			}
+			value, err := strconv.ParseInt(string(data[index:end]), 8, 16)
+			if err == nil {
+				return int(value), end
+			}
+		}
+		return int(char), index + 1
+	}
+}
+
+func readPDFHexString(data []byte, index int) (string, int) {
+	var hexText strings.Builder
+	for index < len(data) {
+		char := data[index]
+		index++
+		if char == '>' {
+			text := hexText.String()
+			if len(text)%2 == 1 {
+				text += "0"
+			}
+			decoded, err := hex.DecodeString(text)
+			if err != nil {
+				return "", -1
+			}
+			return decodePDFTextBytes(decoded), index - 1
+		}
+		if unicode.IsSpace(rune(char)) {
+			continue
+		}
+		hexText.WriteByte(char)
+	}
+	return "", -1
+}
+
+func decodePDFTextBytes(data []byte) string {
+	if len(data) >= 2 && data[0] == 0xfe && data[1] == 0xff {
+		words := make([]uint16, 0, (len(data)-2)/2)
+		for index := 2; index+1 < len(data); index += 2 {
+			words = append(words, uint16(data[index])<<8|uint16(data[index+1]))
+		}
+		return string(utf16.Decode(words))
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func normalizePortalQuestionLine(line string) string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "- ")
+	line = strings.TrimPrefix(line, "* ")
+	line = strings.TrimSpace(trimNumberedPrefix(line))
+	lower := strings.ToLower(line)
+	for _, prefix := range []string{"question:", "field:", "prompt:"} {
+		if strings.HasPrefix(lower, prefix) {
+			line = strings.TrimSpace(line[len(prefix):])
+			lower = strings.ToLower(line)
+		}
+	}
+	if strings.HasPrefix(lower, "question ") {
+		if colon := strings.Index(line, ":"); colon > 0 && colon < 24 {
+			line = strings.TrimSpace(line[colon+1:])
+			lower = strings.ToLower(line)
+		}
+	}
+	switch strings.Trim(lower, " .:") {
+	case "", "next", "previous", "submit", "save", "cancel", "continue", "back", "log in", "login", "sign in", "upload", "upload file":
+		return ""
+	}
+	return line
+}
+
+func looksLikeQuestionnairePrompt(line string) bool {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return false
+	}
+	if strings.Contains(line, "?") {
+		return true
+	}
+	lower := strings.ToLower(line)
+	for _, prefix := range []string{
+		"attach ",
+		"confirm ",
+		"describe ",
+		"enter ",
+		"explain ",
+		"identify ",
+		"list ",
+		"provide ",
+		"select ",
+		"share ",
+		"state ",
+		"upload ",
+	} {
+		if strings.HasPrefix(lower, prefix) || strings.HasPrefix(lower, "please "+prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func trimNumberedPrefix(line string) string {
+	index := 0
+	for index < len(line) {
+		char := rune(line[index])
+		if unicode.IsDigit(char) || char == '.' || char == ')' {
+			index++
+			continue
+		}
+		break
+	}
+	if index > 0 && index < len(line) && unicode.IsSpace(rune(line[index])) {
+		return strings.TrimSpace(line[index:])
+	}
+	return line
+}
+
+func errorsIsEOF(err error) bool {
+	return errors.Is(err, io.EOF)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -2277,7 +2277,7 @@ export type GRCQuestionnaireAssignment = {
 export type GRCQuestionnaireAssignmentRequest = {
   due_at?: string;
   owner_id?: string;
-  question_id: string;
+  question_id?: string;
   reason?: string;
   status?: string;
   team?: string;
@@ -2306,7 +2306,7 @@ export type GRCQuestionnaireComment = {
 
 export type GRCQuestionnaireCommentRequest = {
   body: string;
-  question_id: string;
+  question_id?: string;
   tenant_id?: string;
 };
 
@@ -2325,10 +2325,14 @@ export type GRCQuestionnaireCreateRunRequest = {
   customer_name?: string;
   direction: "customer_security_review" | "vendor_review";
   due_at?: string;
-  intake_format?: "json" | "csv" | "tsv" | "text";
+  intake_content_type?: string;
+  intake_file_base64?: string;
+  intake_format?: "json" | "csv" | "tsv" | "text" | "portal" | "pdf" | "xlsx" | "xlsm";
   intake_rows?: GRCQuestionnaireIntakeRow[];
   intake_text?: string;
   owner_id?: string;
+  portal_instructions?: string;
+  portal_url?: string;
   questions?: GRCQuestionnaireQuestion[];
   requester?: string;
   runtime_id?: string;


### PR DESCRIPTION
## Summary
- add base64 questionnaire attachment intake for PDF, XLSX, XLSM, CSV, TSV, JSON, text, and portal capture payloads
- extract PDF prompt text, read XLSX question rows with explicit question columns, and store portal URL/notes/status on runs
- extend the questionnaire create contract and generated TypeScript SDK types

## Validation
- go test ./internal/sourcehttp/questionnaire -count=1
- go test ./internal/questionnaire ./internal/sourcehttp/questionnaire ./internal/bootstrap ./internal/statestore/postgres ./api -count=1
- make check-structural check-structural-test check-arch openapi-check openapi-ts-check
- make lint
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->