### PR TITLE
[codex] Raise Datadog source runtime fidelity

### DIFF
--- a/sources/datadog/fixture.go
+++ b/sources/datadog/fixture.go
@@ -41,10 +41,8 @@ func NewFixture() (sourcecdk.Source, error) {
 }
 
 func checkFixtureConfig(_ context.Context, cfg sourcecdk.Config) error {
-	if strings.TrimSpace(sourcecdk.ConfigValue(cfg, "tenant_id")) == "" {
-		return fmt.Errorf("tenant_id is required")
-	}
-	return nil
+	_, err := resolveFixtureFamily(cfg)
+	return err
 }
 
 func resolveFixtureFamily(cfg sourcecdk.Config) (string, error) {

--- a/sources/datadog/source.go
+++ b/sources/datadog/source.go
@@ -93,6 +93,13 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 	return s.inner.Read(ctx, cfg, cursor)
 }
 
+func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.Pull, error) {
+	if err := validateConfig(cfg); err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	return s.inner.ReadWithCheckpoint(ctx, cfg, cursor, checkpoint)
+}
+
 func (s *Source) allowLoopbackForTest() { s.inner.AllowLoopbackBaseURL = true }
 
 func validateConfig(cfg sourcecdk.Config) error {

--- a/sources/datadog/source.go
+++ b/sources/datadog/source.go
@@ -3,7 +3,6 @@ package datadog
 import (
 	"context"
 	"embed"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -103,12 +102,11 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 func (s *Source) allowLoopbackForTest() { s.inner.AllowLoopbackBaseURL = true }
 
 func validateConfig(cfg sourcecdk.Config) error {
-	for _, key := range []string{"api_key", "application_key"} {
-		if strings.TrimSpace(sourcecdk.ConfigValue(cfg, key)) == "" {
-			return fmt.Errorf("%w: %s %s is required", sourcecdk.ErrInvalidConfig, sourceID, key)
-		}
+	if _, err := sourcecdk.RequiredConfigValue(sourceID, cfg, "api_key"); err != nil {
+		return err
 	}
-	return nil
+	_, err := sourcecdk.RequiredConfigValue(sourceID, cfg, "application_key")
+	return err
 }
 
 func datadogFamilies() []jsonapi.Family {

--- a/sources/datadog/source_test.go
+++ b/sources/datadog/source_test.go
@@ -88,6 +88,90 @@ func TestSourceCheckReadAndCursor(t *testing.T) {
 	}
 }
 
+func TestSourceReadWithCheckpointUsesCursor(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("DD-API-KEY"); got != "api-key" {
+			t.Fatalf("DD-API-KEY = %q", got)
+		}
+		if got := r.Header.Get("DD-APPLICATION-KEY"); got != "app-key" {
+			t.Fatalf("DD-APPLICATION-KEY = %q", got)
+		}
+		if r.URL.Path != "/api/v2/users" {
+			t.Fatalf("request path = %q, want /api/v2/users", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("page[size]"); got != "2" {
+			t.Fatalf("page[size] = %q, want 2", got)
+		}
+		if got := r.URL.Query().Get("page[cursor]"); got != "cursor-2" {
+			t.Fatalf("page[cursor] = %q, want cursor-2", got)
+		}
+		requests = append(requests, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{
+				"id":   "user-2",
+				"type": "users",
+				"attributes": map[string]any{
+					"email":       "bob@example.test",
+					"name":        "Bob Example",
+					"created_at":  "2026-06-01T00:00:00Z",
+					"modified_at": "2026-06-02T00:00:00Z",
+				},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	pull, err := source.ReadWithCheckpoint(
+		context.Background(),
+		datadogTestConfig(server.URL, familyUsers),
+		&cerebrov1.SourceCursor{Opaque: "cursor-2"},
+		&cerebrov1.SourceCheckpoint{CursorOpaque: "older"},
+	)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["user_id"]; got != "user-2" {
+		t.Fatalf("user_id attribute = %q, want user-2", got)
+	}
+	if len(requests) != 1 || !strings.Contains(requests[0], "page%5Bcursor%5D=cursor-2") {
+		t.Fatalf("requests = %#v, want encoded page cursor", requests)
+	}
+	assertDatadogEventContracts(t, source, pull.Events[0])
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/users" {
+			t.Fatalf("request path = %q, want /api/v2/users", r.URL.Path)
+		}
+		http.Error(w, `{"errors":["service unavailable"]}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	_, err = source.Read(context.Background(), datadogTestConfig(server.URL, familyUsers), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if !strings.Contains(err.Error(), "datadog API returned 503") {
+		t.Fatalf("Read() error = %v, want datadog API returned 503", err)
+	}
+}
+
 func TestSourceMapsRuntimeFamilies(t *testing.T) {
 	source, err := New()
 	if err != nil {

--- a/sources/datadog/source_test.go
+++ b/sources/datadog/source_test.go
@@ -3,6 +3,7 @@ package datadog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -167,8 +168,9 @@ func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Read() error = nil, want provider error")
 	}
-	if !strings.Contains(err.Error(), "datadog API returned 503") {
-		t.Fatalf("Read() error = %v, want datadog API returned 503", err)
+	var statusErr interface{ StatusCode() int }
+	if !errors.As(err, &statusErr) || statusErr.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("Read() error = %v, want provider status %d", err, http.StatusServiceUnavailable)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Expose the Datadog runtime checkpoint read path.
- Add provider-unavailable coverage for Datadog API failures.
- Cover cursor passthrough on checkpoint reads.

Validation:
- go test ./sources/datadog -count=1
- go run ./tools/sourcefidelity -root . -json-out /tmp/datadog-fidelity-pr1609.json -max-items 40
- git diff --check origin/main...HEAD
- make check-structural
- make droid-review-sast
