### PR TITLE
[codex] Raise OpenRouter source runtime fidelity

### DIFF
--- a/sources/openrouter/source_test.go
+++ b/sources/openrouter/source_test.go
@@ -213,6 +213,32 @@ func TestSourceReadReturnsOpenRouterErrorBody(t *testing.T) {
 	}
 }
 
+func TestSourceReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source := newTestSource(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requireOpenRouterAuth(t, r)
+		if r.URL.Path != "/v1/byok" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+		writeJSON(t, w, map[string]any{"error": "provider temporarily unavailable"})
+	}))
+	defer server.Close()
+
+	cfg := sourcecdk.NewConfig(map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": familyProviderKeys, "token": "test-token"})
+	_, err := source.Read(context.Background(), cfg, nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider unavailable error")
+	}
+	var statusErr interface{ StatusCode() int }
+	if !errors.As(err, &statusErr) || statusErr.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("Read() error = %v, want HTTP 503", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "openrouter API returned 503") || !strings.Contains(got, "provider temporarily unavailable") {
+		t.Fatalf("Read() error = %q, want provider unavailable detail", got)
+	}
+}
+
 func TestFixtureContractsLoad(t *testing.T) {
 	fixture, err := NewFixture()
 	if err != nil {


### PR DESCRIPTION
Stacked on #1604.

## Summary
- Adds OpenRouter provider-unavailable coverage for the `provider_keys` family.
- Asserts the BYOK path returns the upstream 503 status and error detail.
- Raises the OpenRouter sourcefidelity entry to reference status with no remaining gaps.

## Validation
- `go test ./sources/openrouter -count=1`
- `go run ./tools/sourcefidelity -json-out /tmp/openrouter-fidelity.json`
- `git diff --check`