### PR TITLE
[codex] Raise Google Workspace source runtime fidelity

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -28,7 +28,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `cosmo` | 1006 | Move shared API pagination and response normalization into reusable source helpers. |
 | `gcp` | 2130 | Extract project traversal, service clients, and resource-family pagination helpers. |
 | `github` | 2024 | Split audit/event readers from repository/user normalization and shared pagination. |
-| `googleworkspace` | 815 | Extract API client setup and paginated directory readers. |
+| `googleworkspace` | 814 | Extract API client setup and paginated directory readers. |
 | `grc` | 1195 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2256 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 763 | Separate request plumbing from emitted record construction. |

--- a/sources/googleworkspace/fixture.go
+++ b/sources/googleworkspace/fixture.go
@@ -24,6 +24,10 @@ func NewFixture() (sourcecdk.Source, error) {
 		if err != nil {
 			return nil, err
 		}
+		urns, err := sourcecdk.LoadFixtureURNs(fixtureFS, "testdata/discover_"+family+".json")
+		if err != nil {
+			return nil, err
+		}
 		settings := settings{
 			family:      family,
 			domain:      "writer.com",
@@ -33,7 +37,6 @@ func NewFixture() (sourcecdk.Source, error) {
 			application: "admin",
 			perPage:     1,
 		}
-		urns := []sourcecdk.URN{}
 		events := []*cerebrov1.EventEnvelope{}
 		for _, record := range records {
 			event, err := sourceEvent(settings, record)
@@ -41,10 +44,6 @@ func NewFixture() (sourcecdk.Source, error) {
 				return nil, err
 			}
 			events = append(events, event)
-			urn, err := discoverURN(settings, record)
-			if err == nil && urn != "" {
-				urns = append(urns, urn)
-			}
 		}
 		families = append(families, sourcecdk.FixtureFamily{Name: family, URNs: urns, Events: events})
 	}

--- a/sources/googleworkspace/source_test.go
+++ b/sources/googleworkspace/source_test.go
@@ -131,6 +131,13 @@ func TestNewFixtureReplaysGoogleWorkspaceFamilies(t *testing.T) {
 			if got := pull.Events[0].Kind; got != tt.kind {
 				t.Fatalf("Read(%s).Events[0].Kind = %q, want %q", tt.family, got, tt.kind)
 			}
+			urns, err := source.Discover(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("Discover(%s) error = %v", tt.family, err)
+			}
+			if len(urns) == 0 {
+				t.Fatalf("Discover(%s) returned no URNs", tt.family)
+			}
 		})
 	}
 }
@@ -290,6 +297,33 @@ func TestGoogleWorkspaceRoleAssignmentCachesUserLookupsPerPage(t *testing.T) {
 	}
 	if userLookups != 1 {
 		t.Fatalf("user lookups = %d, want 1", userLookups)
+	}
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/directory/v1/users" {
+			t.Fatalf("path = %q, want /admin/directory/v1/users", r.URL.Path)
+		}
+		http.Error(w, `{"error":"service unavailable"}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"domain":   "writer.com",
+		"family":   familyUser,
+		"token":    "test-token",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "google_workspace API returned 503") {
+		t.Fatalf("Read() error = %q, want provider status", got)
 	}
 }
 

--- a/sources/googleworkspace/testdata/discover_audit.json
+++ b/sources/googleworkspace/testdata/discover_audit.json
@@ -1,30 +1,4 @@
 [
-  {
-    "id": {
-      "time": "2026-04-23T00:00:00.000Z",
-      "uniqueQualifier": "audit-1",
-      "applicationName": "admin",
-      "customerId": "C01"
-    },
-    "actor": {
-      "email": "admin@writer.com",
-      "profileId": "1001"
-    },
-    "events": [
-      {
-        "name": "CHANGE_TWO_STEP_VERIFICATION_ENFORCEMENT",
-        "type": "SECURITY_SETTINGS",
-        "parameters": [
-          {
-            "name": "RESOURCE_TYPE",
-            "value": "security_setting"
-          },
-          {
-            "name": "SETTING_NAME",
-            "value": "2SV enforcement"
-          }
-        ]
-      }
-    ]
-  }
+  "urn:cerebro:writer.com:google_workspace_audit:CHANGE_TWO_STEP_VERIFICATION_ENFORCEMENT",
+  "urn:cerebro:writer.com:google_workspace_audit:AUTHORIZE_API_CLIENT_ACCESS"
 ]

--- a/sources/googleworkspace/testdata/discover_group.json
+++ b/sources/googleworkspace/testdata/discover_group.json
@@ -1,10 +1,3 @@
 [
-  {
-    "id": "group-1",
-    "email": "security@writer.com",
-    "name": "Security",
-    "description": "Security team",
-    "adminCreated": true,
-    "directMembersCount": "2"
-  }
+  "urn:cerebro:writer.com:google_workspace_group:group-1"
 ]

--- a/sources/googleworkspace/testdata/discover_group_member.json
+++ b/sources/googleworkspace/testdata/discover_group_member.json
@@ -1,9 +1,4 @@
 [
-  {
-    "id": "member-1",
-    "email": "admin@writer.com",
-    "type": "USER",
-    "role": "OWNER",
-    "status": "ACTIVE"
-  }
+  "urn:cerebro:writer.com:google_workspace_group_member:member-1",
+  "urn:cerebro:writer.com:google_workspace_group_member:member-2"
 ]

--- a/sources/googleworkspace/testdata/discover_role_assignment.json
+++ b/sources/googleworkspace/testdata/discover_role_assignment.json
@@ -1,9 +1,3 @@
 [
-  {
-    "roleAssignmentId": "ra-1",
-    "roleId": "super-admin",
-    "assignedTo": "1001",
-    "assigneeType": "USER",
-    "scopeType": "CUSTOMER"
-  }
+  "urn:cerebro:writer.com:google_workspace_role_assignment:ra-1"
 ]

--- a/sources/googleworkspace/testdata/discover_user.json
+++ b/sources/googleworkspace/testdata/discover_user.json
@@ -1,18 +1,4 @@
 [
-  {
-    "id": "1001",
-    "primaryEmail": "admin@writer.com",
-    "name": {
-      "fullName": "Admin Writer"
-    },
-    "isAdmin": true,
-    "isDelegatedAdmin": true,
-    "isEnrolledIn2Sv": false,
-    "isEnforcedIn2Sv": false,
-    "suspended": false,
-    "archived": false,
-    "creationTime": "2025-01-01T00:00:00.000Z",
-    "lastLoginTime": "2025-01-15T00:00:00.000Z",
-    "orgUnitPath": "/"
-  }
+  "urn:cerebro:writer.com:google_workspace_user:1001",
+  "urn:cerebro:writer.com:google_workspace_user:1002"
 ]

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -20,7 +20,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"cosmo":           1006,
 	"gcp":             2130,
 	"github":          2024,
-	"googleworkspace": 815,
+	"googleworkspace": 814,
 	"grc":             1195,
 	"okta":            2256,
 	"panopticon":      763,


### PR DESCRIPTION
Summary:
- Add explicit discover fixtures for Google Workspace runtime families.
- Make fixture replay load discover URNs from fixture files.
- Add provider-unavailable coverage for Google Workspace reads.
- Update the source package budget for the extracted fixture helper.

Validation:
- go test ./sources/googleworkspace -count=1
- go run ./tools/sourcefidelity -root . -json-out /tmp/google-workspace-fidelity-pr1614.json -max-items 40
- git diff --check origin/main...HEAD
- make check-structural
- make droid-review-sast
