### PR TITLE
Add questionnaire vendor linking

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3183,6 +3183,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GRCQuestionnaireRunResponse'
+  /grc/questionnaire-runs/{runID}/vendor-link:
+    post:
+      summary: Link questionnaire vendor
+      tags:
+        - GRC
+      parameters:
+        - name: runID
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/tenantIDQuery'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GRCQuestionnaireVendorLinkRequest'
+      responses:
+        '200':
+          description: Vendor link updated on the questionnaire run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GRCQuestionnaireRunResponse'
   /grc/questionnaire-runs/{runID}/decisions:
     post:
       summary: Record questionnaire decision
@@ -12213,6 +12238,19 @@ components:
       properties:
         tenant_id:
           type: string
+    GRCQuestionnaireVendorLinkRequest:
+      type: object
+      properties:
+        tenant_id:
+          type: string
+        vendor_urn:
+          type: string
+        vendor_id:
+          type: string
+        reason:
+          type: string
+        unlink:
+          type: boolean
     GRCQuestionnaireAssignmentRequest:
       type: object
       properties:

--- a/api/openapi_questionnaire_runs_test.go
+++ b/api/openapi_questionnaire_runs_test.go
@@ -18,6 +18,7 @@ func TestQuestionnaireRunRoutesDocumentUnifiedQueueContract(t *testing.T) {
 		"/grc/questionnaire-runs/{runID}/process",
 		"/grc/questionnaire-runs/{runID}/assignments",
 		"/grc/questionnaire-runs/{runID}/questions",
+		"/grc/questionnaire-runs/{runID}/vendor-link",
 		"/grc/questionnaire-runs/{runID}/decisions",
 		"/grc/questionnaire-runs/{runID}/comments",
 	} {
@@ -42,6 +43,7 @@ func TestQuestionnaireRunRoutesDocumentUnifiedQueueContract(t *testing.T) {
 		"GRCQuestionnaireCitation:",
 		"GRCQuestionnaireRunEvidenceGap:",
 		"GRCQuestionnaireQuestionUpdateRequest:",
+		"GRCQuestionnaireVendorLinkRequest:",
 		"GRCQuestionnaireDecisionRequest:",
 	} {
 		if !strings.Contains(doc, want) {

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -107,6 +107,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Prefix: "/grc/questionnaire-runs/", Suffix: "/process", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodPost, Prefix: "/grc/questionnaire-runs/", Suffix: "/assignments", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodPost, Prefix: "/grc/questionnaire-runs/", Suffix: "/questions", Scope: scopeGRCInventoryWrite},
+	{Method: http.MethodPost, Prefix: "/grc/questionnaire-runs/", Suffix: "/vendor-link", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodPost, Prefix: "/grc/questionnaire-runs/", Suffix: "/decisions", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodPost, Prefix: "/grc/questionnaire-runs/", Suffix: "/comments", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodPost, Exact: "/grc/policy-lifecycle/actions", Scope: scopeGRCPolicyLifecycleWrite, Static: true},

--- a/internal/bootstrap/auth_route_policy_test.go
+++ b/internal/bootstrap/auth_route_policy_test.go
@@ -202,6 +202,7 @@ func TestQuestionnaireRunHTTPRoutesRequireWriteScope(t *testing.T) {
 		{method: http.MethodPost, path: "/grc/questionnaire-runs/run-1/process"},
 		{method: http.MethodPost, path: "/grc/questionnaire-runs/run-1/assignments"},
 		{method: http.MethodPost, path: "/grc/questionnaire-runs/run-1/questions"},
+		{method: http.MethodPost, path: "/grc/questionnaire-runs/run-1/vendor-link"},
 		{method: http.MethodPost, path: "/grc/questionnaire-runs/run-1/decisions"},
 		{method: http.MethodPost, path: "/grc/questionnaire-runs/run-1/comments"},
 	} {

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -155,6 +155,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /grc/questionnaire-runs/{runID}/process", routeSurfacePlatformHTTP, questionnaireRuns.ProcessRun)
 	registerHTTPRoute(mux, "POST /grc/questionnaire-runs/{runID}/assignments", routeSurfacePlatformHTTP, questionnaireRuns.AssignRun)
 	registerHTTPRoute(mux, "POST /grc/questionnaire-runs/{runID}/questions", routeSurfacePlatformHTTP, questionnaireRuns.UpdateQuestion)
+	registerHTTPRoute(mux, "POST /grc/questionnaire-runs/{runID}/vendor-link", routeSurfacePlatformHTTP, questionnaireRuns.LinkVendor)
 	registerHTTPRoute(mux, "POST /grc/questionnaire-runs/{runID}/decisions", routeSurfacePlatformHTTP, questionnaireRuns.DecideRun)
 	registerHTTPRoute(mux, "POST /grc/questionnaire-runs/{runID}/comments", routeSurfacePlatformHTTP, questionnaireRuns.CommentRun)
 	registerHTTPRoute(mux, "GET /grc/inventory/categories", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.categories", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeInventory), app.handleGRCInventoryCategories))

--- a/internal/ports/questionnaire.go
+++ b/internal/ports/questionnaire.go
@@ -35,12 +35,13 @@ const (
 	QuestionnaireDecisionRejected               = "rejected"
 	QuestionnaireDecisionNeedsInput             = "needs_input"
 
-	QuestionnaireEventCreated   = "created"
-	QuestionnaireEventProcessed = "processed"
-	QuestionnaireEventAssigned  = "assigned"
-	QuestionnaireEventUpdated   = "updated"
-	QuestionnaireEventDecided   = "decision_recorded"
-	QuestionnaireEventCommented = "commented"
+	QuestionnaireEventCreated      = "created"
+	QuestionnaireEventProcessed    = "processed"
+	QuestionnaireEventAssigned     = "assigned"
+	QuestionnaireEventUpdated      = "updated"
+	QuestionnaireEventDecided      = "decision_recorded"
+	QuestionnaireEventCommented    = "commented"
+	QuestionnaireEventVendorLinked = "vendor_linked"
 )
 
 var ErrQuestionnaireRunNotFound = errors.New("questionnaire run not found")

--- a/internal/questionnaire/service.go
+++ b/internal/questionnaire/service.go
@@ -46,6 +46,14 @@ type UpdateQuestionRequest struct {
 	ClearControls  bool
 }
 
+type LinkVendorRequest struct {
+	VendorURN string
+	VendorID  string
+	Reason    string
+	ActorID   string
+	Unlink    bool
+}
+
 func NewRunRecord(request NewRunRequest, now time.Time) ports.QuestionnaireRunRecord {
 	now = normalizeNow(now)
 	direction := strings.TrimSpace(request.Direction)
@@ -95,6 +103,51 @@ func NewRunRecord(request NewRunRequest, now time.Time) ports.QuestionnaireRunRe
 		},
 	}
 	record.Timeline = append(record.Timeline, Timeline(ports.QuestionnaireEventCreated, firstNonEmpty(record.OwnerID, record.AssignedTeam), "Questionnaire run created", nil, now))
+	return SummarizeRun(record)
+}
+
+func LinkVendor(record ports.QuestionnaireRunRecord, request LinkVendorRequest, now time.Time) ports.QuestionnaireRunRecord {
+	now = normalizeNow(now)
+	record.UpdatedAt = now
+	record.Attributes = copyStringMap(record.Attributes)
+	if record.Attributes == nil {
+		record.Attributes = map[string]string{}
+	}
+	attrs := map[string]string{
+		"reason": strings.TrimSpace(request.Reason),
+	}
+	if request.Unlink {
+		attrs["previous_vendor_urn"] = record.VendorURN
+		attrs["previous_vendor_id"] = record.VendorID
+		record.VendorURN = ""
+		record.VendorID = ""
+		delete(record.Attributes, "linked_vendor_urn")
+		delete(record.Attributes, "linked_vendor_id")
+		record.Attributes["vendor_link_status"] = "unlinked"
+		if reason := strings.TrimSpace(request.Reason); reason != "" {
+			record.Attributes["vendor_link_reason"] = reason
+		}
+		record.Timeline = append(record.Timeline, Timeline(ports.QuestionnaireEventVendorLinked, request.ActorID, "Vendor link removed", attrs, now))
+		return SummarizeRun(record)
+	}
+	vendorURN := strings.TrimSpace(request.VendorURN)
+	vendorID := strings.TrimSpace(request.VendorID)
+	record.Direction = ports.QuestionnaireDirectionVendorReview
+	record.VendorURN = vendorURN
+	record.VendorID = vendorID
+	record.Attributes["linked_vendor_urn"] = vendorURN
+	if vendorID != "" {
+		record.Attributes["linked_vendor_id"] = vendorID
+	} else {
+		delete(record.Attributes, "linked_vendor_id")
+	}
+	record.Attributes["vendor_link_status"] = "linked"
+	if reason := strings.TrimSpace(request.Reason); reason != "" {
+		record.Attributes["vendor_link_reason"] = reason
+	}
+	attrs["vendor_urn"] = vendorURN
+	attrs["vendor_id"] = vendorID
+	record.Timeline = append(record.Timeline, Timeline(ports.QuestionnaireEventVendorLinked, request.ActorID, "Vendor linked", attrs, now))
 	return SummarizeRun(record)
 }
 

--- a/internal/questionnaire/service.go
+++ b/internal/questionnaire/service.go
@@ -54,6 +54,11 @@ type LinkVendorRequest struct {
 	Unlink    bool
 }
 
+const (
+	questionnaireVendorLinkPreviousDirectionAttribute = "vendor_link_previous_direction"
+	questionnaireVendorLinkReasonAttribute            = "vendor_link_reason"
+)
+
 func NewRunRecord(request NewRunRequest, now time.Time) ports.QuestionnaireRunRecord {
 	now = normalizeNow(now)
 	direction := strings.TrimSpace(request.Direction)
@@ -113,28 +118,34 @@ func LinkVendor(record ports.QuestionnaireRunRecord, request LinkVendorRequest, 
 	if record.Attributes == nil {
 		record.Attributes = map[string]string{}
 	}
-	attrs := map[string]string{
-		"reason": strings.TrimSpace(request.Reason),
+	reason := strings.TrimSpace(request.Reason)
+	attrs := map[string]string{}
+	if reason != "" {
+		attrs["reason"] = reason
 	}
 	if request.Unlink {
+		restoredDirection := directionForVendorUnlink(record.Attributes)
 		attrs["previous_vendor_urn"] = record.VendorURN
 		attrs["previous_vendor_id"] = record.VendorID
+		attrs["restored_direction"] = restoredDirection
+		record.Direction = restoredDirection
 		record.VendorURN = ""
 		record.VendorID = ""
 		delete(record.Attributes, "linked_vendor_urn")
 		delete(record.Attributes, "linked_vendor_id")
+		delete(record.Attributes, questionnaireVendorLinkPreviousDirectionAttribute)
 		record.Attributes["vendor_link_status"] = "unlinked"
-		if reason := strings.TrimSpace(request.Reason); reason != "" {
-			record.Attributes["vendor_link_reason"] = reason
-		}
+		setVendorLinkReason(record.Attributes, reason)
 		record.Timeline = append(record.Timeline, Timeline(ports.QuestionnaireEventVendorLinked, request.ActorID, "Vendor link removed", attrs, now))
 		return SummarizeRun(record)
 	}
 	vendorURN := strings.TrimSpace(request.VendorURN)
 	vendorID := strings.TrimSpace(request.VendorID)
+	previousDirection := previousDirectionForVendorLink(record)
 	record.Direction = ports.QuestionnaireDirectionVendorReview
 	record.VendorURN = vendorURN
 	record.VendorID = vendorID
+	record.Attributes[questionnaireVendorLinkPreviousDirectionAttribute] = previousDirection
 	record.Attributes["linked_vendor_urn"] = vendorURN
 	if vendorID != "" {
 		record.Attributes["linked_vendor_id"] = vendorID
@@ -142,13 +153,37 @@ func LinkVendor(record ports.QuestionnaireRunRecord, request LinkVendorRequest, 
 		delete(record.Attributes, "linked_vendor_id")
 	}
 	record.Attributes["vendor_link_status"] = "linked"
-	if reason := strings.TrimSpace(request.Reason); reason != "" {
-		record.Attributes["vendor_link_reason"] = reason
-	}
+	setVendorLinkReason(record.Attributes, reason)
 	attrs["vendor_urn"] = vendorURN
 	attrs["vendor_id"] = vendorID
+	attrs["previous_direction"] = previousDirection
 	record.Timeline = append(record.Timeline, Timeline(ports.QuestionnaireEventVendorLinked, request.ActorID, "Vendor linked", attrs, now))
 	return SummarizeRun(record)
+}
+
+func previousDirectionForVendorLink(record ports.QuestionnaireRunRecord) string {
+	if stored := strings.TrimSpace(record.Attributes[questionnaireVendorLinkPreviousDirectionAttribute]); ports.IsQuestionnaireDirection(stored) {
+		return stored
+	}
+	if direction := strings.TrimSpace(record.Direction); ports.IsQuestionnaireDirection(direction) {
+		return direction
+	}
+	return ports.QuestionnaireDirectionCustomerSecurityReview
+}
+
+func directionForVendorUnlink(attributes map[string]string) string {
+	if direction := strings.TrimSpace(attributes[questionnaireVendorLinkPreviousDirectionAttribute]); ports.IsQuestionnaireDirection(direction) {
+		return direction
+	}
+	return ports.QuestionnaireDirectionCustomerSecurityReview
+}
+
+func setVendorLinkReason(attributes map[string]string, reason string) {
+	if reason == "" {
+		delete(attributes, questionnaireVendorLinkReasonAttribute)
+		return
+	}
+	attributes[questionnaireVendorLinkReasonAttribute] = reason
 }
 
 func ProcessEvidenceAnswers(record ports.QuestionnaireRunRecord, evidenceAnswers []evidencepackets.QuestionnaireAnswer, now time.Time) ports.QuestionnaireRunRecord {

--- a/internal/questionnaire/service_test.go
+++ b/internal/questionnaire/service_test.go
@@ -140,6 +140,64 @@ func TestVendorReviewAddsVendorEvidenceSlot(t *testing.T) {
 	}
 }
 
+func TestLinkVendorRestoresCustomerReviewDirectionBeforeProcessing(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	record := NewRunRecord(NewRunRequest{
+		TenantID:  "tenant-1",
+		Direction: ports.QuestionnaireDirectionCustomerSecurityReview,
+		Title:     "Acme security review",
+		Questions: []ports.QuestionnaireQuestion{{
+			ID:            "q-1",
+			Question:      "Do you enforce MFA for users?",
+			RequiredSlots: []string{"identity_mfa"},
+		}},
+	}, now)
+
+	record = LinkVendor(record, LinkVendorRequest{
+		VendorURN: "urn:cerebro:tenant-1:vendor:okta",
+		VendorID:  "okta",
+		Reason:    "Matched intake requester.",
+		ActorID:   "risk@example.com",
+	}, now.Add(time.Minute))
+	if record.Direction != ports.QuestionnaireDirectionVendorReview {
+		t.Fatalf("direction after link = %q, want vendor_review", record.Direction)
+	}
+	if got := record.Attributes[questionnaireVendorLinkPreviousDirectionAttribute]; got != ports.QuestionnaireDirectionCustomerSecurityReview {
+		t.Fatalf("previous direction = %q, want customer_security_review", got)
+	}
+	if got := record.Attributes[questionnaireVendorLinkReasonAttribute]; got != "Matched intake requester." {
+		t.Fatalf("link reason = %q, want stored reason", got)
+	}
+
+	record = LinkVendor(record, LinkVendorRequest{Unlink: true, ActorID: "risk@example.com"}, now.Add(2*time.Minute))
+	if record.Direction != ports.QuestionnaireDirectionCustomerSecurityReview {
+		t.Fatalf("direction after unlink = %q, want customer_security_review", record.Direction)
+	}
+	if record.VendorURN != "" || record.VendorID != "" {
+		t.Fatalf("vendor context = %q/%q, want cleared", record.VendorURN, record.VendorID)
+	}
+	if got := record.Attributes[questionnaireVendorLinkPreviousDirectionAttribute]; got != "" {
+		t.Fatalf("previous direction attribute = %q, want cleared", got)
+	}
+	if got := record.Attributes[questionnaireVendorLinkReasonAttribute]; got != "" {
+		t.Fatalf("link reason = %q, want cleared", got)
+	}
+
+	record = ProcessEvidenceAnswers(record, []evidencepackets.QuestionnaireAnswer{
+		baseEvidenceAnswer("Do you enforce MFA for users?", "supported", "ready", "current"),
+	}, now.Add(3*time.Minute))
+	if len(record.Answers) != 1 {
+		t.Fatalf("answer count = %d, want 1", len(record.Answers))
+	}
+	answer := record.Answers[0]
+	if slotPresent(answer.EvidenceSlots, "vendor_profile") {
+		t.Fatalf("vendor_profile slot present after unlink: %#v", answer.EvidenceSlots)
+	}
+	if answer.AnswerState != ports.QuestionnaireAnswerSupported {
+		t.Fatalf("answer state = %q, want supported; slots=%#v gaps=%#v", answer.AnswerState, answer.EvidenceSlots, answer.MissingEvidence)
+	}
+}
+
 func TestProcessEvidenceAnswersRequiresCitationForRequiredSlot(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
 	for _, tt := range []struct {

--- a/internal/sourcehttp/questionnaire/handler.go
+++ b/internal/sourcehttp/questionnaire/handler.go
@@ -232,6 +232,14 @@ type questionUpdateRequest struct {
 	ClearOwner     bool                         `json:"clear_owner,omitempty"`
 }
 
+type vendorLinkRequest struct {
+	TenantID  string `json:"tenant_id,omitempty"`
+	VendorURN string `json:"vendor_urn,omitempty"`
+	VendorID  string `json:"vendor_id,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+	Unlink    bool   `json:"unlink,omitempty"`
+}
+
 type processRequest struct {
 	TenantID string `json:"tenant_id,omitempty"`
 }
@@ -481,6 +489,49 @@ func (h *Handler) UpdateQuestion(w http.ResponseWriter, r *http.Request) {
 		ClearOwner:     request.ClearOwner,
 	}, now)
 	event := questionnairedomain.Event(updated, ports.QuestionnaireEventUpdated, h.actorID(r.Context()), "Questionnaire question updated", map[string]string{"question_id": strings.TrimSpace(request.QuestionID)}, now)
+	saved, err := h.store.UpsertQuestionnaireRun(r.Context(), updated, event)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	h.bumpReviewCache(r.Context(), saved.TenantID)
+	writeJSON(w, http.StatusOK, runResponse{Run: runViewFromRecord(saved, false), GeneratedAt: now})
+}
+
+func (h *Handler) LinkVendor(w http.ResponseWriter, r *http.Request) {
+	var request vendorLinkRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	record, _, err := h.runFromRequest(r.Context(), requestWithTenant(r, request.TenantID), request.TenantID)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	if !request.Unlink && strings.TrimSpace(request.VendorURN) == "" {
+		h.writeError(w, fmt.Errorf("%w: vendor_urn is required", ErrInvalidRequest))
+		return
+	}
+	now := time.Now().UTC()
+	actorID := h.actorID(r.Context())
+	updated := questionnairedomain.LinkVendor(*record, questionnairedomain.LinkVendorRequest{
+		VendorURN: request.VendorURN,
+		VendorID:  request.VendorID,
+		Reason:    request.Reason,
+		ActorID:   actorID,
+		Unlink:    request.Unlink,
+	}, now)
+	summary := "Questionnaire linked to vendor"
+	if request.Unlink {
+		summary = "Questionnaire vendor link removed"
+	}
+	event := questionnairedomain.Event(updated, ports.QuestionnaireEventVendorLinked, actorID, summary, map[string]string{
+		"vendor_urn": strings.TrimSpace(request.VendorURN),
+		"vendor_id":  strings.TrimSpace(request.VendorID),
+		"reason":     strings.TrimSpace(request.Reason),
+		"unlink":     strconv.FormatBool(request.Unlink),
+	}, now)
 	saved, err := h.store.UpsertQuestionnaireRun(r.Context(), updated, event)
 	if err != nil {
 		h.writeError(w, err)

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -485,6 +485,115 @@ func TestUpdateQuestionMapsRequiredEvidenceSlots(t *testing.T) {
 	}
 }
 
+func TestLinkVendorAttachesVendorContext(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	store := &processRunStore{
+		record: ports.QuestionnaireRunRecord{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "tenant-1", RunID: "run-1", Title: "Vendor diligence"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{Direction: ports.QuestionnaireDirectionCustomerSecurityReview},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusNeedsInput},
+			QuestionnaireRunContent: ports.QuestionnaireRunContent{
+				Questions: []ports.QuestionnaireQuestion{{ID: "q-1", Question: "Attach vendor SOC 2 report."}},
+			},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{Attributes: map[string]string{"source": "portal"}, CreatedAt: now, UpdatedAt: now},
+		},
+	}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "risk@example.com" },
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/vendor-link", strings.NewReader(`{"vendor_urn":"urn:cerebro:tenant-1:vendor:okta","vendor_id":"okta","reason":"Matched intake requester."}`))
+	req.SetPathValue("runID", "run-1")
+	recorder := httptest.NewRecorder()
+
+	handler.LinkVendor(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if store.saved.Direction != ports.QuestionnaireDirectionVendorReview || store.saved.VendorURN != "urn:cerebro:tenant-1:vendor:okta" || store.saved.VendorID != "okta" {
+		t.Fatalf("saved source = %#v, want linked vendor review", store.saved.QuestionnaireRunSource)
+	}
+	if store.saved.Attributes["linked_vendor_urn"] != "urn:cerebro:tenant-1:vendor:okta" || store.saved.Attributes["vendor_link_status"] != "linked" {
+		t.Fatalf("attributes = %#v, want linked vendor metadata", store.saved.Attributes)
+	}
+	if len(store.saved.Timeline) == 0 || store.saved.Timeline[len(store.saved.Timeline)-1].EventType != ports.QuestionnaireEventVendorLinked {
+		t.Fatalf("timeline = %#v, want vendor link event", store.saved.Timeline)
+	}
+	if store.savedEvent.EventType != ports.QuestionnaireEventVendorLinked || store.savedEvent.Payload["vendor_urn"] == "" {
+		t.Fatalf("event = %#v, want persisted vendor link event", store.savedEvent)
+	}
+}
+
+func TestLinkVendorRemovesVendorContext(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	store := &processRunStore{
+		record: ports.QuestionnaireRunRecord{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "tenant-1", RunID: "run-1", Title: "Vendor diligence"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{Direction: ports.QuestionnaireDirectionVendorReview, VendorURN: "urn:cerebro:tenant-1:vendor:okta", VendorID: "okta"},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusNeedsInput},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
+				Attributes: map[string]string{
+					"linked_vendor_urn":  "urn:cerebro:tenant-1:vendor:okta",
+					"linked_vendor_id":   "okta",
+					"vendor_link_status": "linked",
+				},
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+	}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "risk@example.com" },
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/vendor-link", strings.NewReader(`{"unlink":true,"reason":"Wrong vendor."}`))
+	req.SetPathValue("runID", "run-1")
+	recorder := httptest.NewRecorder()
+
+	handler.LinkVendor(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if store.saved.VendorURN != "" || store.saved.VendorID != "" {
+		t.Fatalf("vendor context = %q/%q, want cleared", store.saved.VendorURN, store.saved.VendorID)
+	}
+	if store.saved.Attributes["linked_vendor_urn"] != "" || store.saved.Attributes["vendor_link_status"] != "unlinked" {
+		t.Fatalf("attributes = %#v, want unlinked vendor metadata", store.saved.Attributes)
+	}
+}
+
+func TestLinkVendorRejectsMissingVendorURN(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	store := &processRunStore{
+		record: ports.QuestionnaireRunRecord{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "tenant-1", RunID: "run-1", Title: "Vendor diligence"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{Direction: ports.QuestionnaireDirectionCustomerSecurityReview},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusNeedsInput},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{CreatedAt: now, UpdatedAt: now},
+		},
+	}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/vendor-link", strings.NewReader(`{"reason":"No selected vendor."}`))
+	req.SetPathValue("runID", "run-1")
+	recorder := httptest.NewRecorder()
+
+	handler.LinkVendor(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestCreateRunRejectsDelimitedIntakeWithoutQuestionHeader(t *testing.T) {
 	store := &processRunStore{}
 	handler := NewHandler(store, Options{
@@ -789,10 +898,12 @@ type processRunStore struct {
 	listRecords []*ports.QuestionnaireRunRecord
 	summary     ports.QuestionnaireRunSummary
 	saved       ports.QuestionnaireRunRecord
+	savedEvent  ports.QuestionnaireRunEventRecord
 }
 
-func (s *processRunStore) UpsertQuestionnaireRun(_ context.Context, record ports.QuestionnaireRunRecord, _ ports.QuestionnaireRunEventRecord) (*ports.QuestionnaireRunRecord, error) {
+func (s *processRunStore) UpsertQuestionnaireRun(_ context.Context, record ports.QuestionnaireRunRecord, event ports.QuestionnaireRunEventRecord) (*ports.QuestionnaireRunRecord, error) {
 	s.saved = record
+	s.savedEvent = event
 	return &s.saved, nil
 }
 

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -536,9 +536,11 @@ func TestLinkVendorRemovesVendorContext(t *testing.T) {
 			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusNeedsInput},
 			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
 				Attributes: map[string]string{
-					"linked_vendor_urn":  "urn:cerebro:tenant-1:vendor:okta",
-					"linked_vendor_id":   "okta",
-					"vendor_link_status": "linked",
+					"linked_vendor_urn":              "urn:cerebro:tenant-1:vendor:okta",
+					"linked_vendor_id":               "okta",
+					"vendor_link_previous_direction": ports.QuestionnaireDirectionCustomerSecurityReview,
+					"vendor_link_reason":             "Matched intake requester.",
+					"vendor_link_status":             "linked",
 				},
 				CreatedAt: now,
 				UpdatedAt: now,
@@ -551,7 +553,7 @@ func TestLinkVendorRemovesVendorContext(t *testing.T) {
 		},
 		Actor: func(context.Context) string { return "risk@example.com" },
 	})
-	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/vendor-link", strings.NewReader(`{"unlink":true,"reason":"Wrong vendor."}`))
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/vendor-link", strings.NewReader(`{"unlink":true}`))
 	req.SetPathValue("runID", "run-1")
 	recorder := httptest.NewRecorder()
 
@@ -563,7 +565,13 @@ func TestLinkVendorRemovesVendorContext(t *testing.T) {
 	if store.saved.VendorURN != "" || store.saved.VendorID != "" {
 		t.Fatalf("vendor context = %q/%q, want cleared", store.saved.VendorURN, store.saved.VendorID)
 	}
-	if store.saved.Attributes["linked_vendor_urn"] != "" || store.saved.Attributes["vendor_link_status"] != "unlinked" {
+	if store.saved.Direction != ports.QuestionnaireDirectionCustomerSecurityReview {
+		t.Fatalf("direction = %q, want customer_security_review", store.saved.Direction)
+	}
+	if store.saved.Attributes["linked_vendor_urn"] != "" ||
+		store.saved.Attributes["vendor_link_previous_direction"] != "" ||
+		store.saved.Attributes["vendor_link_reason"] != "" ||
+		store.saved.Attributes["vendor_link_status"] != "unlinked" {
 		t.Fatalf("attributes = %#v, want unlinked vendor metadata", store.saved.Attributes)
 	}
 }

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -2579,6 +2579,14 @@ export type GRCQuestionnaireTimelineEvent = {
   summary?: string;
 };
 
+export type GRCQuestionnaireVendorLinkRequest = {
+  reason?: string;
+  tenant_id?: string;
+  unlink?: boolean;
+  vendor_id?: string;
+  vendor_urn?: string;
+};
+
 export type GRCReportMetadata = Record<string, unknown>;
 
 export type GRCResourceSubject = {


### PR DESCRIPTION
## Summary
- add a questionnaire vendor-link action for attaching or removing vendor context after intake
- record vendor link changes in the questionnaire timeline and event stream
- document the endpoint in OpenAPI and regenerate TypeScript contract types

## Validation
- go test ./internal/sourcehttp/questionnaire ./internal/bootstrap ./api
- make openapi-ts-check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->