### PR TITLE
[codex] Add Okta every-family fixture replay

### DIFF
--- a/sources/okta/fixture.go
+++ b/sources/okta/fixture.go
@@ -18,7 +18,7 @@ func NewFixture() (sourcecdk.Source, error) {
 		return nil, err
 	}
 	families := []sourcecdk.FixtureFamily{}
-	for _, family := range []string{"api_token", "authorization_server", "brand", "device_assurance", "event_hook", "inline_hook", "log_stream", familyAdminRole, familyAppAssign, familyApplication, familyAudit, familyGroup, familyGroupMember, familyIDP, familyNetworkZone, familyPolicyRule, familyTrustedOrigin, familyUser} {
+	for _, family := range []string{"api_token", "authorization_server", "brand", "device_assurance", "event_hook", "inline_hook", "log_stream", familyAdminRole, familyAppAssign, familyApplication, familyAudit, familyAuthenticator, familyGroup, familyGroupMember, familyIDP, familyNetworkZone, familyPolicyRule, familyThreatInsight, familyTrustedOrigin, familyUser} {
 		urns, err := sourcecdk.LoadFixtureURNs(fixtureFS, "testdata/discover_"+family+".json")
 		if err != nil {
 			return nil, err

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -130,21 +130,24 @@ func TestNewFixtureReplaysFixturePages(t *testing.T) {
 	}
 }
 
-func TestNewFixtureReplaysOktaIdentityFamilies(t *testing.T) {
+func TestNewFixtureReplaysEveryRuntimeFamily(t *testing.T) {
 	source, err := NewFixture()
 	if err != nil {
 		t.Fatalf("NewFixture() error = %v", err)
 	}
 	for _, tt := range []struct {
-		family string
-		config map[string]string
-		kind   string
+		family       string
+		config       map[string]string
+		kind         string
+		wantDiscover int
+		wantRead     int
 	}{
 		{family: "admin_role", config: map[string]string{"user_id": "00u1", "user_email": "admin@writer.com"}, kind: "okta.admin_role"},
 		{family: "api_token", kind: "okta.api_token"},
 		{family: "app_assignment", config: map[string]string{"app_id": "app-prod"}, kind: "okta.app_assignment"},
 		{family: "application", kind: "okta.application"},
 		{family: "authorization_server", kind: "okta.authorization_server"},
+		{family: "authenticator", kind: "okta.authenticator"},
 		{family: "brand", kind: "okta.brand"},
 		{family: "device_assurance", kind: "okta.device_assurance"},
 		{family: "event_hook", kind: "okta.event_hook"},
@@ -155,9 +158,19 @@ func TestNewFixtureReplaysOktaIdentityFamilies(t *testing.T) {
 		{family: "log_stream", kind: "okta.log_stream"},
 		{family: "network_zone", kind: "okta.network_zone"},
 		{family: "policy_rule", kind: "okta.policy_rule"},
+		{family: "threat_insight", kind: "okta.threat_insight"},
 		{family: "trusted_origin", kind: "okta.trusted_origin"},
+		{family: "user", kind: "okta.user", wantDiscover: 2},
 	} {
 		t.Run(tt.family, func(t *testing.T) {
+			wantDiscover := tt.wantDiscover
+			if wantDiscover == 0 {
+				wantDiscover = 1
+			}
+			wantRead := tt.wantRead
+			if wantRead == 0 {
+				wantRead = 1
+			}
 			config := map[string]string{
 				"domain": "writer.okta.com",
 				"family": tt.family,
@@ -170,15 +183,15 @@ func TestNewFixtureReplaysOktaIdentityFamilies(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Discover(%s) error = %v", tt.family, err)
 			}
-			if len(urns) != 1 {
-				t.Fatalf("len(Discover(%s)) = %d, want 1", tt.family, len(urns))
+			if len(urns) != wantDiscover {
+				t.Fatalf("len(Discover(%s)) = %d, want %d", tt.family, len(urns), wantDiscover)
 			}
 			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(config), nil)
 			if err != nil {
 				t.Fatalf("Read(%s) error = %v", tt.family, err)
 			}
-			if len(pull.Events) != 1 {
-				t.Fatalf("len(Read(%s).Events) = %d, want 1", tt.family, len(pull.Events))
+			if len(pull.Events) != wantRead {
+				t.Fatalf("len(Read(%s).Events) = %d, want %d", tt.family, len(pull.Events), wantRead)
 			}
 			if got := pull.Events[0].Kind; got != tt.kind {
 				t.Fatalf("Read(%s).Events[0].Kind = %q, want %q", tt.family, got, tt.kind)

--- a/sources/okta/testdata/discover_authenticator.json
+++ b/sources/okta/testdata/discover_authenticator.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:writer.okta.com:authenticator:aut-password"
+]

--- a/sources/okta/testdata/discover_threat_insight.json
+++ b/sources/okta/testdata/discover_threat_insight.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:writer.okta.com:threat_insight:config"
+]

--- a/sources/okta/testdata/read_authenticator.json
+++ b/sources/okta/testdata/read_authenticator.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "okta-authenticator-aut-password-1776925200000",
+    "tenant_id": "writer.okta.com",
+    "source_id": "okta",
+    "kind": "okta.authenticator",
+    "occurred_at": "2026-04-23T01:00:00Z",
+    "schema_ref": "okta/authenticator/v1",
+    "payload": {
+      "id": "aut-password",
+      "domain": "writer.okta.com",
+      "name": "Password",
+      "key": "okta_password",
+      "status": "ACTIVE",
+      "type": "password",
+      "raw": {
+        "id": "aut-password",
+        "key": "okta_password",
+        "name": "Password",
+        "status": "ACTIVE",
+        "type": "password",
+        "created": "2026-04-20T00:00:00.000Z",
+        "lastUpdated": "2026-04-23T01:00:00.000Z"
+      }
+    },
+    "attributes": {
+      "authenticator_id": "aut-password",
+      "domain": "writer.okta.com",
+      "family": "authenticator",
+      "key": "okta_password",
+      "name": "Password",
+      "resource_id": "aut-password",
+      "resource_type": "Authenticator",
+      "status": "ACTIVE",
+      "type": "password"
+    }
+  }
+]

--- a/sources/okta/testdata/read_threat_insight.json
+++ b/sources/okta/testdata/read_threat_insight.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "okta-threat-insight-writer.okta.com-1776925200000",
+    "tenant_id": "writer.okta.com",
+    "source_id": "okta",
+    "kind": "okta.threat_insight",
+    "occurred_at": "2026-04-23T01:00:00Z",
+    "schema_ref": "okta/threat_insight/v1",
+    "payload": {
+      "domain": "writer.okta.com",
+      "action": "block",
+      "exclude_zones": [
+        "nzo-trusted"
+      ]
+    },
+    "attributes": {
+      "action": "block",
+      "domain": "writer.okta.com",
+      "exclude_zone_count": "1",
+      "family": "threat_insight",
+      "resource_id": "threat_insight_config",
+      "resource_type": "ThreatInsightConfiguration"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add Okta fixture coverage for authenticator and threat insight runtime families
- expand the fixture replay test to cover every Okta family served by the fixture source
- promote Okta source fidelity to reference, 90/90

## Validation
- go test ./sources/okta -count=1
- go run ./tools/sourcefidelity -json-out /tmp/okta-fidelity.json
- make catalog-check sourcegen-check
- git diff --check

## API sources checked
- Okta Management API Authenticators
- Okta Management API ThreatInsight configuration
