### PR TITLE
[codex] Link questionnaire work to vendor graph

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -11844,9 +11844,13 @@ components:
           type: string
         source:
           type: string
+        resource_urn:
+          type: string
         evidence_packet_id:
           type: string
         evidence_id:
+          type: string
+        evidence_type:
           type: string
         control_id:
           type: string
@@ -11870,6 +11874,8 @@ components:
         control_id:
           type: string
         evidence_packet_id:
+          type: string
+        review_state:
           type: string
     GRCQuestionnaireFreshness:
       type: object
@@ -11941,6 +11947,10 @@ components:
         id:
           type: string
         question_id:
+          type: string
+        gap_id:
+          type: string
+        slot_id:
           type: string
         team:
           type: string
@@ -12257,6 +12267,10 @@ components:
         tenant_id:
           type: string
         question_id:
+          type: string
+        gap_id:
+          type: string
+        slot_id:
           type: string
         owner_id:
           type: string

--- a/internal/bootstrap/grc_questionnaire.go
+++ b/internal/bootstrap/grc_questionnaire.go
@@ -21,7 +21,9 @@ func (app *App) grcQuestionnaireRunHandler() *questionnairehttp.Handler {
 		BumpCache: func(ctx context.Context, tenantID string) {
 			app.bumpGRCCacheVersions(ctx, tenantID, grcCacheScopeEvidence, grcCacheScopeFindings, grcCacheScopeGraph)
 		},
-		WriteErr: writeGRCQuestionnaireError,
+		WriteErr:        writeGRCQuestionnaireError,
+		ProjectionState: sourceProjectionStateStore(app.deps.StateStore),
+		ProjectionGraph: sourceProjectionGraphStore(app.deps.GraphStore),
 	})
 }
 

--- a/internal/bootstrap/grc_vendor.go
+++ b/internal/bootstrap/grc_vendor.go
@@ -154,6 +154,11 @@ func (a *App) grcVendorDetailResponse(r *http.Request) (grcVendorDetailResponse,
 		return grcVendorDetailResponse{}, err
 	}
 	urn = detail.Vendor.URN
+	questionnaireRollups, err := grcvendor.QuestionnaireVendorRollups(r.Context(), grcQuestionnaireRunStore(a.deps.StateStore), scope.TenantID, []string{urn}, time.Now().UTC())
+	if err != nil {
+		return grcVendorDetailResponse{}, err
+	}
+	detail.Vendor = grcvendor.ApplyQuestionnaireVendorRollup(detail.Vendor, questionnaireRollups[urn])
 	runtimes, err := a.grcListRuntimes(r, scope)
 	if err != nil {
 		return grcVendorDetailResponse{}, err
@@ -321,7 +326,18 @@ func (a *App) handleUpdateGRCVendorDiscoveryDecision(w http.ResponseWriter, r *h
 
 func (a *App) enrichGRCVendors(r *http.Request, scope grcScope, vendors []grcvendor.Vendor) ([]grcvendor.Vendor, error) {
 	if len(vendors) == 0 || findingStore(a.deps.StateStore) == nil {
+		rollups, err := grcvendor.QuestionnaireVendorRollups(r.Context(), grcQuestionnaireRunStore(a.deps.StateStore), scope.TenantID, grcVendorURNs(vendors), time.Now().UTC())
+		if err != nil {
+			return nil, err
+		}
+		for index := range vendors {
+			vendors[index] = grcvendor.ApplyQuestionnaireVendorRollup(vendors[index], rollups[vendors[index].URN])
+		}
 		return vendors, nil
+	}
+	questionnaireRollups, err := grcvendor.QuestionnaireVendorRollups(r.Context(), grcQuestionnaireRunStore(a.deps.StateStore), scope.TenantID, grcVendorURNs(vendors), time.Now().UTC())
+	if err != nil {
+		return nil, err
 	}
 	runtimes, err := a.grcListRuntimes(r, scope)
 	if err != nil {
@@ -358,9 +374,18 @@ func (a *App) enrichGRCVendors(r *http.Request, scope grcScope, vendors []grcven
 		vendors[index].CriticalFindings = item.CriticalFindings
 		vendors[index].HighFindings = item.HighFindings
 		vendors[index].EvidenceItems = item.EvidenceItems
+		vendors[index] = grcvendor.ApplyQuestionnaireVendorRollup(vendors[index], questionnaireRollups[vendors[index].URN])
 		vendors[index] = grcvendor.RefreshVendorQueuePosture(vendors[index])
 	}
 	return vendors, nil
+}
+
+func grcQuestionnaireRunStore(store ports.StateStore) ports.QuestionnaireRunStore {
+	runStore, ok := store.(ports.QuestionnaireRunStore)
+	if !ok || isNilInterface(runStore) {
+		return nil
+	}
+	return runStore
 }
 
 func vendorFindingMetrics(findings []grcFindingItem) map[string]grcVendorFindingMetrics {

--- a/internal/grcvendor/questionnaire_rollup.go
+++ b/internal/grcvendor/questionnaire_rollup.go
@@ -90,12 +90,3 @@ func ApplyQuestionnaireVendorRollup(vendor Vendor, rollup QuestionnaireVendorRol
 	vendor.Attributes["questionnaire_open_assignments"] = fmt.Sprint(rollup.OpenAssignments)
 	return RefreshVendorQueuePosture(vendor)
 }
-
-func questionnaireTerminal(status string) bool {
-	switch strings.TrimSpace(status) {
-	case ports.QuestionnaireStatusApproved, ports.QuestionnaireStatusRejected:
-		return true
-	default:
-		return false
-	}
-}

--- a/internal/grcvendor/questionnaire_rollup.go
+++ b/internal/grcvendor/questionnaire_rollup.go
@@ -1,0 +1,109 @@
+package grcvendor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+	questionnairedomain "github.com/writer/cerebro/internal/questionnaire"
+)
+
+type QuestionnaireVendorRollup struct {
+	QuestionnaireCount int
+	ReadyAnswers       int
+	BlockedAnswers     int
+	ReviewAnswers      int
+	MissingEvidence    int
+	StaleEvidence      int
+	DueQuestionnaires  int
+	OpenAssignments    int
+}
+
+func QuestionnaireVendorRollups(ctx context.Context, store ports.QuestionnaireRunStore, tenantID string, vendorURNs []string, now time.Time) (map[string]QuestionnaireVendorRollup, error) {
+	result := map[string]QuestionnaireVendorRollup{}
+	vendorSet := map[string]struct{}{}
+	for _, urn := range vendorURNs {
+		urn = strings.TrimSpace(urn)
+		if urn == "" {
+			continue
+		}
+		vendorSet[urn] = struct{}{}
+		result[urn] = QuestionnaireVendorRollup{}
+	}
+	if len(vendorSet) == 0 || store == nil {
+		return result, nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	records, err := store.ListQuestionnaireRuns(ctx, ports.QuestionnaireRunFilter{
+		TenantID: strings.TrimSpace(tenantID),
+		Limit:    500,
+	})
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		vendorURN := strings.TrimSpace(record.VendorURN)
+		if _, ok := vendorSet[vendorURN]; !ok {
+			continue
+		}
+		key := vendorURN + "\x00" + firstNonEmpty(record.Attributes[questionnairedomain.QuestionnaireAttributeQuestionnaireURN], record.RunID)
+		rollup := result[vendorURN]
+		if _, ok := seen[key]; !ok {
+			rollup.QuestionnaireCount++
+			seen[key] = struct{}{}
+		}
+		if !questionnaireTerminal(record.Status) && record.DueAt != nil && !record.DueAt.After(now) {
+			rollup.DueQuestionnaires++
+		}
+		rollup.ReadyAnswers += record.ReadyAnswerCount
+		rollup.BlockedAnswers += record.BlockedAnswerCount
+		rollup.ReviewAnswers += record.ReviewAnswerCount
+		rollup.MissingEvidence += record.MissingEvidence
+		rollup.StaleEvidence += record.StaleEvidence
+		for _, assignment := range record.Assignments {
+			if strings.TrimSpace(assignment.Status) == "" || assignment.Status == "open" {
+				rollup.OpenAssignments++
+			}
+		}
+		result[vendorURN] = rollup
+	}
+	return result, nil
+}
+
+func ApplyQuestionnaireVendorRollup(vendor Vendor, rollup QuestionnaireVendorRollup) Vendor {
+	if rollup.QuestionnaireCount == 0 && rollup.ReadyAnswers == 0 && rollup.BlockedAnswers == 0 && rollup.ReviewAnswers == 0 && rollup.MissingEvidence == 0 && rollup.StaleEvidence == 0 && rollup.DueQuestionnaires == 0 && rollup.OpenAssignments == 0 {
+		return vendor
+	}
+	if rollup.QuestionnaireCount > vendor.QuestionnaireCount {
+		vendor.QuestionnaireCount = rollup.QuestionnaireCount
+	}
+	if vendor.Attributes == nil {
+		vendor.Attributes = map[string]string{}
+	}
+	vendor.Attributes["questionnaire_run_count"] = fmt.Sprint(rollup.QuestionnaireCount)
+	vendor.Attributes["questionnaire_ready_answers"] = fmt.Sprint(rollup.ReadyAnswers)
+	vendor.Attributes["questionnaire_blocked_answers"] = fmt.Sprint(rollup.BlockedAnswers)
+	vendor.Attributes["questionnaire_review_answers"] = fmt.Sprint(rollup.ReviewAnswers)
+	vendor.Attributes["questionnaire_missing_evidence"] = fmt.Sprint(rollup.MissingEvidence)
+	vendor.Attributes["questionnaire_stale_evidence"] = fmt.Sprint(rollup.StaleEvidence)
+	vendor.Attributes["questionnaire_due"] = fmt.Sprint(rollup.DueQuestionnaires)
+	vendor.Attributes["questionnaire_open_assignments"] = fmt.Sprint(rollup.OpenAssignments)
+	return RefreshVendorQueuePosture(vendor)
+}
+
+func questionnaireTerminal(status string) bool {
+	switch strings.TrimSpace(status) {
+	case ports.QuestionnaireStatusApproved, ports.QuestionnaireStatusRejected:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/grcvendor/questionnaire_rollup.go
+++ b/internal/grcvendor/questionnaire_rollup.go
@@ -3,6 +3,7 @@ package grcvendor
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -38,42 +39,54 @@ func QuestionnaireVendorRollups(ctx context.Context, store ports.QuestionnaireRu
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	records, err := store.ListQuestionnaireRuns(ctx, ports.QuestionnaireRunFilter{
-		TenantID: strings.TrimSpace(tenantID),
-		Limit:    500,
-	})
-	if err != nil {
-		return nil, err
-	}
 	seen := map[string]struct{}{}
-	for _, record := range records {
-		if record == nil {
-			continue
+	vendorList := make([]string, 0, len(vendorSet))
+	for vendorURN := range vendorSet {
+		vendorList = append(vendorList, vendorURN)
+	}
+	sort.Strings(vendorList)
+	for _, requestedVendorURN := range vendorList {
+		records, err := store.ListQuestionnaireRuns(ctx, ports.QuestionnaireRunFilter{
+			TenantID:  strings.TrimSpace(tenantID),
+			VendorURN: requestedVendorURN,
+			Limit:     500,
+		})
+		if err != nil {
+			return nil, err
 		}
-		vendorURN := strings.TrimSpace(record.VendorURN)
-		if _, ok := vendorSet[vendorURN]; !ok {
-			continue
-		}
-		key := vendorURN + "\x00" + firstNonEmpty(record.Attributes[questionnairedomain.QuestionnaireAttributeQuestionnaireURN], record.RunID)
-		rollup := result[vendorURN]
-		if _, ok := seen[key]; !ok {
-			rollup.QuestionnaireCount++
-			seen[key] = struct{}{}
-		}
-		if !questionnaireTerminal(record.Status) && record.DueAt != nil && !record.DueAt.After(now) {
-			rollup.DueQuestionnaires++
-		}
-		rollup.ReadyAnswers += record.ReadyAnswerCount
-		rollup.BlockedAnswers += record.BlockedAnswerCount
-		rollup.ReviewAnswers += record.ReviewAnswerCount
-		rollup.MissingEvidence += record.MissingEvidence
-		rollup.StaleEvidence += record.StaleEvidence
-		for _, assignment := range record.Assignments {
-			if strings.TrimSpace(assignment.Status) == "" || assignment.Status == "open" {
-				rollup.OpenAssignments++
+		for _, record := range records {
+			if record == nil {
+				continue
 			}
+			vendorURN := strings.TrimSpace(record.VendorURN)
+			if vendorURN != requestedVendorURN {
+				continue
+			}
+			key := vendorURN + "\x00" + firstNonEmpty(record.Attributes[questionnairedomain.QuestionnaireAttributeQuestionnaireURN], record.RunID)
+			rollup := result[vendorURN]
+			if _, ok := seen[key]; !ok {
+				rollup.QuestionnaireCount++
+				seen[key] = struct{}{}
+			}
+			if questionnaireTerminal(record.Status) {
+				result[vendorURN] = rollup
+				continue
+			}
+			if record.DueAt != nil && !record.DueAt.After(now) {
+				rollup.DueQuestionnaires++
+			}
+			rollup.ReadyAnswers += record.ReadyAnswerCount
+			rollup.BlockedAnswers += record.BlockedAnswerCount
+			rollup.ReviewAnswers += record.ReviewAnswerCount
+			rollup.MissingEvidence += record.MissingEvidence
+			rollup.StaleEvidence += record.StaleEvidence
+			for _, assignment := range record.Assignments {
+				if strings.TrimSpace(assignment.Status) == "" || assignment.Status == "open" {
+					rollup.OpenAssignments++
+				}
+			}
+			result[vendorURN] = rollup
 		}
-		result[vendorURN] = rollup
 	}
 	return result, nil
 }

--- a/internal/grcvendor/questionnaire_rollup.go
+++ b/internal/grcvendor/questionnaire_rollup.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/ports"
-	questionnairedomain "github.com/writer/cerebro/internal/questionnaire"
 )
 
 type QuestionnaireVendorRollup struct {
@@ -39,53 +38,33 @@ func QuestionnaireVendorRollups(ctx context.Context, store ports.QuestionnaireRu
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	seen := map[string]struct{}{}
 	vendorList := make([]string, 0, len(vendorSet))
 	for vendorURN := range vendorSet {
 		vendorList = append(vendorList, vendorURN)
 	}
 	sort.Strings(vendorList)
-	for _, requestedVendorURN := range vendorList {
-		records, err := store.ListQuestionnaireRuns(ctx, ports.QuestionnaireRunFilter{
-			TenantID:  strings.TrimSpace(tenantID),
-			VendorURN: requestedVendorURN,
-			Limit:     500,
-		})
-		if err != nil {
-			return nil, err
+	records, err := store.ListQuestionnaireVendorRollups(ctx, ports.QuestionnaireVendorRollupFilter{
+		TenantID:   strings.TrimSpace(tenantID),
+		VendorURNs: vendorList,
+		Now:        now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, record := range records {
+		vendorURN := strings.TrimSpace(record.VendorURN)
+		if _, ok := vendorSet[vendorURN]; !ok {
+			continue
 		}
-		for _, record := range records {
-			if record == nil {
-				continue
-			}
-			vendorURN := strings.TrimSpace(record.VendorURN)
-			if vendorURN != requestedVendorURN {
-				continue
-			}
-			key := vendorURN + "\x00" + firstNonEmpty(record.Attributes[questionnairedomain.QuestionnaireAttributeQuestionnaireURN], record.RunID)
-			rollup := result[vendorURN]
-			if _, ok := seen[key]; !ok {
-				rollup.QuestionnaireCount++
-				seen[key] = struct{}{}
-			}
-			if questionnaireTerminal(record.Status) {
-				result[vendorURN] = rollup
-				continue
-			}
-			if record.DueAt != nil && !record.DueAt.After(now) {
-				rollup.DueQuestionnaires++
-			}
-			rollup.ReadyAnswers += record.ReadyAnswerCount
-			rollup.BlockedAnswers += record.BlockedAnswerCount
-			rollup.ReviewAnswers += record.ReviewAnswerCount
-			rollup.MissingEvidence += record.MissingEvidence
-			rollup.StaleEvidence += record.StaleEvidence
-			for _, assignment := range record.Assignments {
-				if strings.TrimSpace(assignment.Status) == "" || assignment.Status == "open" {
-					rollup.OpenAssignments++
-				}
-			}
-			result[vendorURN] = rollup
+		result[vendorURN] = QuestionnaireVendorRollup{
+			QuestionnaireCount: record.QuestionnaireCount,
+			ReadyAnswers:       record.ReadyAnswers,
+			BlockedAnswers:     record.BlockedAnswers,
+			ReviewAnswers:      record.ReviewAnswers,
+			MissingEvidence:    record.MissingEvidence,
+			StaleEvidence:      record.StaleEvidence,
+			DueQuestionnaires:  record.DueQuestionnaires,
+			OpenAssignments:    record.OpenAssignments,
 		}
 	}
 	return result, nil

--- a/internal/grcvendor/service.go
+++ b/internal/grcvendor/service.go
@@ -956,6 +956,7 @@ func RefreshVendorQueuePosture(vendor Vendor, at ...time.Time) Vendor {
 		now = at[0].UTC()
 	}
 	vendor.VendorRiskScoring = vendorRiskScoring(vendor)
+	vendor.VendorAssessmentPosture = vendorAssessmentPosture(vendor, now)
 	vendor.VendorMonitoringPosture = vendorMonitoringPosture(vendor)
 	vendor.VendorOperationalPosture = vendorOperationalPosture(vendor, now)
 	vendor.VendorQueuePosture = vendorQueuePosture(vendor)
@@ -1815,6 +1816,12 @@ func vendorQueuePosture(vendor Vendor) VendorQueuePosture {
 	}
 	if vendor.MonitoringState == "critical" || vendor.MonitoringState == "alert" {
 		addQueueItem(85, "monitoring alert", vendorAction("review_monitoring", "Review monitoring", "Monitoring alert", "monitoring", "clear", 85), vendorCloseAction("monitoring_clear", "Monitoring clear", "Resolve or accept active monitoring signals", "vendor-monitoring"))
+	}
+	if intAttribute(vendor.Attributes, "questionnaire_blocked_answers") > 0 || intAttribute(vendor.Attributes, "questionnaire_missing_evidence") > 0 {
+		addQueueItem(78, "questionnaire blocked", vendorAction("clear_questionnaire_blockers", "Clear questionnaire blockers", "Questionnaire answers need evidence or owner input", "questionnaire", "ready", 78), vendorCloseAction("questionnaire_ready", "Questionnaire ready", "Clear blocked answers and missing evidence", "vendor-questionnaire"))
+	}
+	if intAttribute(vendor.Attributes, "questionnaire_due") > 0 {
+		addQueueItem(52, "questionnaire due", vendorAction("finish_questionnaire", "Finish questionnaire", "Linked questionnaire is due", "questionnaire", FreshnessStateCurrent, 52), VendorCloseAction{})
 	}
 	switch vendor.PacketState {
 	case "blocked":

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -131,6 +131,112 @@ func TestListVendorsDerivesPostureAndAppliesFilters(t *testing.T) {
 	}
 }
 
+func TestRefreshVendorQueuePostureAddsQuestionnaireBlockers(t *testing.T) {
+	vendor := Vendor{
+		VendorIdentity: VendorIdentity{
+			URN:  "urn:cerebro:writer:vendor:core-sso",
+			Name: "Core SSO",
+		},
+		VendorLifecycle:         VendorLifecycle{LifecycleState: LifecycleStateActive},
+		VendorOwnership:         VendorOwnership{OwnerState: OwnerStateAssigned},
+		VendorReviewPosture:     VendorReviewPosture{ReviewState: ReviewStateCurrent},
+		VendorAssessmentPosture: VendorAssessmentPosture{AssessmentState: ReviewStateCurrent},
+		VendorFreshnessPosture:  VendorFreshnessPosture{EvidenceFreshnessState: FreshnessStateCurrent},
+		Attributes: map[string]string{
+			"questionnaire_blocked_answers":  "2",
+			"questionnaire_missing_evidence": "1",
+		},
+	}
+
+	refreshed := RefreshVendorQueuePosture(vendor, time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC))
+
+	if !hasVendorAction(refreshed.NextActions, "clear_questionnaire_blockers") {
+		t.Fatalf("next actions = %#v, want questionnaire blocker action", refreshed.NextActions)
+	}
+	if !hasVendorQueueReason(refreshed.QueueReasons, "questionnaire blocked") {
+		t.Fatalf("queue reasons = %#v, want questionnaire blocked", refreshed.QueueReasons)
+	}
+}
+
+func TestQuestionnaireVendorRollupsCountsOperationalWork(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	due := now.Add(-time.Hour)
+	vendorURN := "urn:cerebro:writer:vendor:core-sso"
+	store := &stubQuestionnaireRunStore{records: []*ports.QuestionnaireRunRecord{
+		{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-1"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{VendorURN: vendorURN},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{
+				Status:             ports.QuestionnaireStatusNeedsInput,
+				ReadyAnswerCount:   2,
+				BlockedAnswerCount: 1,
+				ReviewAnswerCount:  3,
+				MissingEvidence:    4,
+				StaleEvidence:      5,
+			},
+			QuestionnaireRunContent: ports.QuestionnaireRunContent{Assignments: []ports.QuestionnaireAssignment{
+				{ID: "assignment-open", Status: "open"},
+				{ID: "assignment-empty"},
+				{ID: "assignment-closed", Status: "closed"},
+			}},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
+				Attributes: map[string]string{"questionnaire_urn": "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-1"},
+				DueAt:      &due,
+			},
+		},
+		{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-1-copy"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{VendorURN: vendorURN},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusApproved},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
+				Attributes: map[string]string{"questionnaire_urn": "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-1"},
+				DueAt:      &due,
+			},
+		},
+		{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-2"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{VendorURN: vendorURN},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{
+				Status:           ports.QuestionnaireStatusApproved,
+				ReadyAnswerCount: 1,
+			},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
+				Attributes: map[string]string{"questionnaire_urn": "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-2"},
+				DueAt:      &due,
+			},
+		},
+		{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "other-vendor"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{VendorURN: "urn:cerebro:writer:vendor:other"},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusNeedsInput, BlockedAnswerCount: 9},
+		},
+	}}
+
+	rollups, err := QuestionnaireVendorRollups(context.Background(), store, "writer", []string{vendorURN, "urn:cerebro:writer:vendor:missing"}, now)
+	if err != nil {
+		t.Fatalf("QuestionnaireVendorRollups() error = %v", err)
+	}
+	rollup := rollups[vendorURN]
+	if rollup.QuestionnaireCount != 2 || rollup.DueQuestionnaires != 1 || rollup.ReadyAnswers != 3 || rollup.BlockedAnswers != 1 || rollup.ReviewAnswers != 3 || rollup.MissingEvidence != 4 || rollup.StaleEvidence != 5 || rollup.OpenAssignments != 2 {
+		t.Fatalf("rollup = %#v", rollup)
+	}
+
+	vendor := ApplyQuestionnaireVendorRollup(Vendor{
+		VendorIdentity:          VendorIdentity{URN: vendorURN, Name: "Core SSO"},
+		VendorLifecycle:         VendorLifecycle{LifecycleState: LifecycleStateActive},
+		VendorOwnership:         VendorOwnership{OwnerState: OwnerStateAssigned},
+		VendorReviewPosture:     VendorReviewPosture{ReviewState: ReviewStateCurrent},
+		VendorAssessmentPosture: VendorAssessmentPosture{AssessmentState: ReviewStateCurrent},
+		VendorFreshnessPosture:  VendorFreshnessPosture{EvidenceFreshnessState: FreshnessStateCurrent},
+	}, rollup)
+	if vendor.QuestionnaireCount != 2 || vendor.Attributes["questionnaire_blocked_answers"] != "1" || vendor.Attributes["questionnaire_due"] != "1" {
+		t.Fatalf("vendor questionnaire attrs = %#v", vendor)
+	}
+	if !hasVendorAction(vendor.NextActions, "clear_questionnaire_blockers") {
+		t.Fatalf("next actions = %#v, want questionnaire blocker action", vendor.NextActions)
+	}
+}
+
 func TestListVendorsCanDeferLimitUntilAfterEnrichment(t *testing.T) {
 	store := &stubGraphStore{
 		rows: [][]ports.CypherRow{{
@@ -218,6 +324,24 @@ func TestNormalizeVendorLifecycleStateTreatsOffboardedAsTerminal(t *testing.T) {
 	if got := normalizeVendorLifecycleState("offboarded"); got != LifecycleStateRetired {
 		t.Fatalf("normalizeVendorLifecycleState(offboarded) = %q, want %q", got, LifecycleStateRetired)
 	}
+}
+
+func hasVendorAction(actions []VendorAction, id string) bool {
+	for _, action := range actions {
+		if action.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVendorQueueReason(reasons []string, want string) bool {
+	for _, reason := range reasons {
+		if reason == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGetVendorReturnsRelationshipsAndGraph(t *testing.T) {
@@ -363,6 +487,32 @@ func TestListDiscoveriesAppliesSourceStatusAndOverlay(t *testing.T) {
 	if summary.Linked != 1 || summary.Discovered != 0 {
 		t.Fatalf("summary = %#v", summary)
 	}
+}
+
+type stubQuestionnaireRunStore struct {
+	ports.StateStore
+	records []*ports.QuestionnaireRunRecord
+	err     error
+}
+
+func (s *stubQuestionnaireRunStore) UpsertQuestionnaireRun(context.Context, ports.QuestionnaireRunRecord, ports.QuestionnaireRunEventRecord) (*ports.QuestionnaireRunRecord, error) {
+	return nil, s.err
+}
+
+func (s *stubQuestionnaireRunStore) GetQuestionnaireRun(context.Context, ports.QuestionnaireRunFilter) (*ports.QuestionnaireRunRecord, error) {
+	return nil, s.err
+}
+
+func (s *stubQuestionnaireRunStore) ListQuestionnaireRuns(context.Context, ports.QuestionnaireRunFilter) ([]*ports.QuestionnaireRunRecord, error) {
+	return s.records, s.err
+}
+
+func (s *stubQuestionnaireRunStore) SummarizeQuestionnaireRuns(context.Context, ports.QuestionnaireRunFilter) (ports.QuestionnaireRunSummary, error) {
+	return ports.QuestionnaireRunSummary{}, s.err
+}
+
+func (s *stubQuestionnaireRunStore) ListQuestionnaireRunEvents(context.Context, ports.QuestionnaireRunEventFilter) ([]*ports.QuestionnaireRunEventRecord, error) {
+	return nil, s.err
 }
 
 func vendorRow(urn string, label string, attrs string, contracts int64, reviews int64, questionnaires int64, documents int64) ports.CypherRow {

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -221,8 +221,8 @@ func TestQuestionnaireVendorRollupsCountsOperationalWork(t *testing.T) {
 	if rollup.QuestionnaireCount != 2 || rollup.DueQuestionnaires != 1 || rollup.ReadyAnswers != 2 || rollup.BlockedAnswers != 1 || rollup.ReviewAnswers != 3 || rollup.MissingEvidence != 4 || rollup.StaleEvidence != 5 || rollup.OpenAssignments != 2 {
 		t.Fatalf("rollup = %#v", rollup)
 	}
-	if len(store.filters) != 2 || !hasQuestionnaireVendorFilter(store.filters, vendorURN) || !hasQuestionnaireVendorFilter(store.filters, "urn:cerebro:writer:vendor:missing") {
-		t.Fatalf("filters = %#v, want one query per vendor", store.filters)
+	if len(store.rollupFilters) != 1 || !hasQuestionnaireVendorRollupFilter(store.rollupFilters[0], vendorURN) || !hasQuestionnaireVendorRollupFilter(store.rollupFilters[0], "urn:cerebro:writer:vendor:missing") {
+		t.Fatalf("rollup filters = %#v, want one batch query for requested vendors", store.rollupFilters)
 	}
 
 	vendor := ApplyQuestionnaireVendorRollup(Vendor{
@@ -495,9 +495,10 @@ func TestListDiscoveriesAppliesSourceStatusAndOverlay(t *testing.T) {
 
 type stubQuestionnaireRunStore struct {
 	ports.StateStore
-	records []*ports.QuestionnaireRunRecord
-	filters []ports.QuestionnaireRunFilter
-	err     error
+	records       []*ports.QuestionnaireRunRecord
+	filters       []ports.QuestionnaireRunFilter
+	rollupFilters []ports.QuestionnaireVendorRollupFilter
+	err           error
 }
 
 func (s *stubQuestionnaireRunStore) UpsertQuestionnaireRun(context.Context, ports.QuestionnaireRunRecord, ports.QuestionnaireRunEventRecord) (*ports.QuestionnaireRunRecord, error) {
@@ -526,13 +527,63 @@ func (s *stubQuestionnaireRunStore) SummarizeQuestionnaireRuns(context.Context, 
 	return ports.QuestionnaireRunSummary{}, s.err
 }
 
+func (s *stubQuestionnaireRunStore) ListQuestionnaireVendorRollups(_ context.Context, filter ports.QuestionnaireVendorRollupFilter) ([]ports.QuestionnaireVendorRollupRecord, error) {
+	s.rollupFilters = append(s.rollupFilters, filter)
+	vendorSet := map[string]struct{}{}
+	for _, vendorURN := range filter.VendorURNs {
+		vendorURN = strings.TrimSpace(vendorURN)
+		if vendorURN != "" {
+			vendorSet[vendorURN] = struct{}{}
+		}
+	}
+	seen := map[string]struct{}{}
+	rollups := map[string]ports.QuestionnaireVendorRollupRecord{}
+	for _, record := range s.records {
+		if record == nil {
+			continue
+		}
+		vendorURN := strings.TrimSpace(record.VendorURN)
+		if _, ok := vendorSet[vendorURN]; !ok {
+			continue
+		}
+		rollup := rollups[vendorURN]
+		rollup.VendorURN = vendorURN
+		key := vendorURN + "\x00" + firstNonEmpty(record.Attributes["questionnaire_urn"], record.RunID)
+		if _, ok := seen[key]; !ok {
+			rollup.QuestionnaireCount++
+			seen[key] = struct{}{}
+		}
+		if !questionnaireTerminal(record.Status) {
+			if record.DueAt != nil && !record.DueAt.After(filter.Now) {
+				rollup.DueQuestionnaires++
+			}
+			rollup.ReadyAnswers += record.ReadyAnswerCount
+			rollup.BlockedAnswers += record.BlockedAnswerCount
+			rollup.ReviewAnswers += record.ReviewAnswerCount
+			rollup.MissingEvidence += record.MissingEvidence
+			rollup.StaleEvidence += record.StaleEvidence
+			for _, assignment := range record.Assignments {
+				if strings.TrimSpace(assignment.Status) == "" || assignment.Status == "open" {
+					rollup.OpenAssignments++
+				}
+			}
+		}
+		rollups[vendorURN] = rollup
+	}
+	records := make([]ports.QuestionnaireVendorRollupRecord, 0, len(rollups))
+	for _, record := range rollups {
+		records = append(records, record)
+	}
+	return records, s.err
+}
+
 func (s *stubQuestionnaireRunStore) ListQuestionnaireRunEvents(context.Context, ports.QuestionnaireRunEventFilter) ([]*ports.QuestionnaireRunEventRecord, error) {
 	return nil, s.err
 }
 
-func hasQuestionnaireVendorFilter(filters []ports.QuestionnaireRunFilter, vendorURN string) bool {
-	for _, filter := range filters {
-		if filter.VendorURN == vendorURN {
+func hasQuestionnaireVendorRollupFilter(filter ports.QuestionnaireVendorRollupFilter, vendorURN string) bool {
+	for _, filteredVendorURN := range filter.VendorURNs {
+		if filteredVendorURN == vendorURN {
 			return true
 		}
 	}

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -183,6 +183,27 @@ func TestQuestionnaireVendorRollupsCountsOperationalWork(t *testing.T) {
 			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
 				Attributes: map[string]string{"questionnaire_urn": "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-1"},
 				DueAt:      &due,
+				UpdatedAt:  now,
+			},
+		},
+		{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-1-old-active"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{VendorURN: vendorURN},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{
+				Status:             ports.QuestionnaireStatusNeedsInput,
+				ReadyAnswerCount:   20,
+				BlockedAnswerCount: 20,
+				ReviewAnswerCount:  20,
+				MissingEvidence:    20,
+				StaleEvidence:      20,
+			},
+			QuestionnaireRunContent: ports.QuestionnaireRunContent{Assignments: []ports.QuestionnaireAssignment{
+				{ID: "assignment-duplicate-open", Status: "open"},
+			}},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
+				Attributes: map[string]string{"questionnaire_urn": "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-1"},
+				DueAt:      &due,
+				UpdatedAt:  now.Add(-time.Hour),
 			},
 		},
 		{
@@ -192,6 +213,7 @@ func TestQuestionnaireVendorRollupsCountsOperationalWork(t *testing.T) {
 			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
 				Attributes: map[string]string{"questionnaire_urn": "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-1"},
 				DueAt:      &due,
+				UpdatedAt:  now.Add(-2 * time.Hour),
 			},
 		},
 		{
@@ -204,6 +226,7 @@ func TestQuestionnaireVendorRollupsCountsOperationalWork(t *testing.T) {
 			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
 				Attributes: map[string]string{"questionnaire_urn": "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-2"},
 				DueAt:      &due,
+				UpdatedAt:  now,
 			},
 		},
 		{
@@ -537,7 +560,7 @@ func (s *stubQuestionnaireRunStore) ListQuestionnaireVendorRollups(_ context.Con
 		}
 	}
 	seen := map[string]struct{}{}
-	rollups := map[string]ports.QuestionnaireVendorRollupRecord{}
+	current := map[string]*ports.QuestionnaireRunRecord{}
 	for _, record := range s.records {
 		if record == nil {
 			continue
@@ -546,9 +569,16 @@ func (s *stubQuestionnaireRunStore) ListQuestionnaireVendorRollups(_ context.Con
 		if _, ok := vendorSet[vendorURN]; !ok {
 			continue
 		}
+		key := vendorURN + "\x00" + firstNonEmpty(record.Attributes["questionnaire_urn"], record.RunID)
+		if existing := current[key]; existing == nil || record.UpdatedAt.After(existing.UpdatedAt) || (record.UpdatedAt.Equal(existing.UpdatedAt) && record.RunID > existing.RunID) {
+			current[key] = record
+		}
+	}
+	rollups := map[string]ports.QuestionnaireVendorRollupRecord{}
+	for key, record := range current {
+		vendorURN := strings.TrimSpace(record.VendorURN)
 		rollup := rollups[vendorURN]
 		rollup.VendorURN = vendorURN
-		key := vendorURN + "\x00" + firstNonEmpty(record.Attributes["questionnaire_urn"], record.RunID)
 		if _, ok := seen[key]; !ok {
 			rollup.QuestionnaireCount++
 			seen[key] = struct{}{}

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -3,6 +3,7 @@ package grcvendor
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -217,8 +218,11 @@ func TestQuestionnaireVendorRollupsCountsOperationalWork(t *testing.T) {
 		t.Fatalf("QuestionnaireVendorRollups() error = %v", err)
 	}
 	rollup := rollups[vendorURN]
-	if rollup.QuestionnaireCount != 2 || rollup.DueQuestionnaires != 1 || rollup.ReadyAnswers != 3 || rollup.BlockedAnswers != 1 || rollup.ReviewAnswers != 3 || rollup.MissingEvidence != 4 || rollup.StaleEvidence != 5 || rollup.OpenAssignments != 2 {
+	if rollup.QuestionnaireCount != 2 || rollup.DueQuestionnaires != 1 || rollup.ReadyAnswers != 2 || rollup.BlockedAnswers != 1 || rollup.ReviewAnswers != 3 || rollup.MissingEvidence != 4 || rollup.StaleEvidence != 5 || rollup.OpenAssignments != 2 {
 		t.Fatalf("rollup = %#v", rollup)
+	}
+	if len(store.filters) != 2 || !hasQuestionnaireVendorFilter(store.filters, vendorURN) || !hasQuestionnaireVendorFilter(store.filters, "urn:cerebro:writer:vendor:missing") {
+		t.Fatalf("filters = %#v, want one query per vendor", store.filters)
 	}
 
 	vendor := ApplyQuestionnaireVendorRollup(Vendor{
@@ -492,6 +496,7 @@ func TestListDiscoveriesAppliesSourceStatusAndOverlay(t *testing.T) {
 type stubQuestionnaireRunStore struct {
 	ports.StateStore
 	records []*ports.QuestionnaireRunRecord
+	filters []ports.QuestionnaireRunFilter
 	err     error
 }
 
@@ -503,8 +508,18 @@ func (s *stubQuestionnaireRunStore) GetQuestionnaireRun(context.Context, ports.Q
 	return nil, s.err
 }
 
-func (s *stubQuestionnaireRunStore) ListQuestionnaireRuns(context.Context, ports.QuestionnaireRunFilter) ([]*ports.QuestionnaireRunRecord, error) {
-	return s.records, s.err
+func (s *stubQuestionnaireRunStore) ListQuestionnaireRuns(_ context.Context, filter ports.QuestionnaireRunFilter) ([]*ports.QuestionnaireRunRecord, error) {
+	s.filters = append(s.filters, filter)
+	if strings.TrimSpace(filter.VendorURN) == "" {
+		return s.records, s.err
+	}
+	filtered := []*ports.QuestionnaireRunRecord{}
+	for _, record := range s.records {
+		if record != nil && record.VendorURN == filter.VendorURN {
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered, s.err
 }
 
 func (s *stubQuestionnaireRunStore) SummarizeQuestionnaireRuns(context.Context, ports.QuestionnaireRunFilter) (ports.QuestionnaireRunSummary, error) {
@@ -513,6 +528,15 @@ func (s *stubQuestionnaireRunStore) SummarizeQuestionnaireRuns(context.Context, 
 
 func (s *stubQuestionnaireRunStore) ListQuestionnaireRunEvents(context.Context, ports.QuestionnaireRunEventFilter) ([]*ports.QuestionnaireRunEventRecord, error) {
 	return nil, s.err
+}
+
+func hasQuestionnaireVendorFilter(filters []ports.QuestionnaireRunFilter, vendorURN string) bool {
+	for _, filter := range filters {
+		if filter.VendorURN == vendorURN {
+			return true
+		}
+	}
+	return false
 }
 
 func vendorRow(urn string, label string, attrs string, contracts int64, reviews int64, questionnaires int64, documents int64) ports.CypherRow {

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -553,7 +553,7 @@ func (s *stubQuestionnaireRunStore) ListQuestionnaireVendorRollups(_ context.Con
 			rollup.QuestionnaireCount++
 			seen[key] = struct{}{}
 		}
-		if !questionnaireTerminal(record.Status) {
+		if !testQuestionnaireTerminal(record.Status) {
 			if record.DueAt != nil && !record.DueAt.After(filter.Now) {
 				rollup.DueQuestionnaires++
 			}
@@ -588,6 +588,15 @@ func hasQuestionnaireVendorRollupFilter(filter ports.QuestionnaireVendorRollupFi
 		}
 	}
 	return false
+}
+
+func testQuestionnaireTerminal(status string) bool {
+	switch strings.TrimSpace(status) {
+	case ports.QuestionnaireStatusApproved, ports.QuestionnaireStatusRejected:
+		return true
+	default:
+		return false
+	}
 }
 
 func vendorRow(urn string, label string, attrs string, contracts int64, reviews int64, questionnaires int64, documents int64) ports.CypherRow {

--- a/internal/ports/questionnaire.go
+++ b/internal/ports/questionnaire.go
@@ -242,6 +242,24 @@ type QuestionnaireRunFilter struct {
 	Limit     uint32
 }
 
+type QuestionnaireVendorRollupFilter struct {
+	TenantID   string
+	VendorURNs []string
+	Now        time.Time
+}
+
+type QuestionnaireVendorRollupRecord struct {
+	VendorURN          string
+	QuestionnaireCount int
+	ReadyAnswers       int
+	BlockedAnswers     int
+	ReviewAnswers      int
+	MissingEvidence    int
+	StaleEvidence      int
+	DueQuestionnaires  int
+	OpenAssignments    int
+}
+
 type QuestionnaireRunEventFilter struct {
 	TenantID string
 	RunID    string
@@ -266,6 +284,7 @@ type QuestionnaireRunStore interface {
 	GetQuestionnaireRun(context.Context, QuestionnaireRunFilter) (*QuestionnaireRunRecord, error)
 	ListQuestionnaireRuns(context.Context, QuestionnaireRunFilter) ([]*QuestionnaireRunRecord, error)
 	SummarizeQuestionnaireRuns(context.Context, QuestionnaireRunFilter) (QuestionnaireRunSummary, error)
+	ListQuestionnaireVendorRollups(context.Context, QuestionnaireVendorRollupFilter) ([]QuestionnaireVendorRollupRecord, error)
 	ListQuestionnaireRunEvents(context.Context, QuestionnaireRunEventFilter) ([]*QuestionnaireRunEventRecord, error)
 }
 

--- a/internal/ports/questionnaire.go
+++ b/internal/ports/questionnaire.go
@@ -150,8 +150,10 @@ type QuestionnaireCitation struct {
 	ID               string `json:"id"`
 	Label            string `json:"label,omitempty"`
 	Source           string `json:"source,omitempty"`
+	ResourceURN      string `json:"resource_urn,omitempty"`
 	EvidencePacketID string `json:"evidence_packet_id,omitempty"`
 	EvidenceID       string `json:"evidence_id,omitempty"`
+	EvidenceType     string `json:"evidence_type,omitempty"`
 	ControlID        string `json:"control_id,omitempty"`
 	FreshnessStatus  string `json:"freshness_status,omitempty"`
 	ObservedAt       string `json:"observed_at,omitempty"`
@@ -159,12 +161,13 @@ type QuestionnaireCitation struct {
 }
 
 type QuestionnaireEvidenceGap struct {
-	ID        string `json:"id"`
-	Code      string `json:"code"`
-	Reason    string `json:"reason,omitempty"`
-	SlotID    string `json:"slot_id,omitempty"`
-	ControlID string `json:"control_id,omitempty"`
-	PacketID  string `json:"evidence_packet_id,omitempty"`
+	ID          string `json:"id"`
+	Code        string `json:"code"`
+	Reason      string `json:"reason,omitempty"`
+	SlotID      string `json:"slot_id,omitempty"`
+	ControlID   string `json:"control_id,omitempty"`
+	PacketID    string `json:"evidence_packet_id,omitempty"`
+	ReviewState string `json:"review_state,omitempty"`
 }
 
 type QuestionnaireFreshness struct {
@@ -177,6 +180,8 @@ type QuestionnaireFreshness struct {
 type QuestionnaireAssignment struct {
 	ID         string     `json:"id"`
 	QuestionID string     `json:"question_id,omitempty"`
+	GapID      string     `json:"gap_id,omitempty"`
+	SlotID     string     `json:"slot_id,omitempty"`
 	Team       string     `json:"team,omitempty"`
 	OwnerID    string     `json:"owner_id,omitempty"`
 	Status     string     `json:"status"`

--- a/internal/questionnaire/projection.go
+++ b/internal/questionnaire/projection.go
@@ -175,7 +175,7 @@ func graphProjectionForRecord(record ports.QuestionnaireRunRecord, at time.Time)
 			"match_type":         "questionnaire_answer_citation",
 		})
 	}
-	if sourceArtifactURN := strings.TrimSpace(record.Attributes[QuestionnaireAttributeSourceArtifactURN]); strings.HasPrefix(sourceArtifactURN, "urn:cerebro:") {
+	if sourceArtifactURN := strings.TrimSpace(record.Attributes[QuestionnaireAttributeSourceArtifactURN]); isSourceArtifactURN(record.TenantID, sourceArtifactURN) {
 		addLink(sourceArtifactURN, fabriccontract.RelationAssociatedWith, map[string]string{"match_type": "questionnaire_source_artifact"})
 	}
 	return GraphProjection{
@@ -239,6 +239,9 @@ func ownerEntityURN(tenantID string, owner string) string {
 func controlEntityURN(tenantID string, controlID string) string {
 	controlID = strings.TrimSpace(controlID)
 	if strings.HasPrefix(controlID, "urn:cerebro:") {
+		if !isControlURN(tenantID, controlID) {
+			return ""
+		}
 		return controlID
 	}
 	value, err := cerebrourn.Mint(tenantID, "control", "questionnaire", cerebrourn.EncodeSegment(controlID))
@@ -267,6 +270,18 @@ func citationResourceURN(tenantID string, citation ports.QuestionnaireCitation) 
 }
 
 func isRuntimeEvidenceURN(tenantID string, value string) bool {
+	return isSameTenantKindURN(tenantID, value, "runtime_evidence", "runtime.evidence")
+}
+
+func isControlURN(tenantID string, value string) bool {
+	return isSameTenantKindURN(tenantID, value, "control")
+}
+
+func isSourceArtifactURN(tenantID string, value string) bool {
+	return isSameTenantKindURN(tenantID, value, "assurance_document", "security_review", "security_questionnaire", "penetration_test", "runtime_evidence", "runtime.evidence")
+}
+
+func isSameTenantKindURN(tenantID string, value string, kinds ...string) bool {
 	parsed, err := cerebrourn.Parse(value)
 	if err != nil {
 		return false
@@ -274,12 +289,12 @@ func isRuntimeEvidenceURN(tenantID string, value string) bool {
 	if parsed.TenantID != strings.TrimSpace(tenantID) {
 		return false
 	}
-	switch parsed.Kind {
-	case "runtime_evidence", "runtime.evidence":
-		return true
-	default:
-		return false
+	for _, kind := range kinds {
+		if parsed.Kind == kind {
+			return true
+		}
 	}
+	return false
 }
 
 func firstNonCerebroURN(values ...string) string {

--- a/internal/questionnaire/projection.go
+++ b/internal/questionnaire/projection.go
@@ -254,11 +254,11 @@ func controlEntityURN(tenantID string, controlID string) string {
 func citationResourceURN(tenantID string, citation ports.QuestionnaireCitation) string {
 	for _, value := range []string{citation.ResourceURN, citation.EvidenceID, citation.EvidencePacketID, citation.ID} {
 		value = strings.TrimSpace(value)
-		if strings.HasPrefix(value, "urn:cerebro:") {
+		if isRuntimeEvidenceURN(tenantID, value) {
 			return value
 		}
 	}
-	evidenceID := firstNonEmpty(citation.EvidenceID, citation.EvidencePacketID, citation.ID)
+	evidenceID := firstNonCerebroURN(citation.EvidenceID, citation.EvidencePacketID, citation.ID)
 	if evidenceID == "" {
 		return ""
 	}
@@ -267,6 +267,32 @@ func citationResourceURN(tenantID string, citation ports.QuestionnaireCitation) 
 		return ""
 	}
 	return value
+}
+
+func isRuntimeEvidenceURN(tenantID string, value string) bool {
+	parsed, err := cerebrourn.Parse(value)
+	if err != nil {
+		return false
+	}
+	if parsed.TenantID != strings.TrimSpace(tenantID) {
+		return false
+	}
+	switch parsed.Kind {
+	case "runtime_evidence", "runtime.evidence":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstNonCerebroURN(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" && !strings.HasPrefix(value, "urn:cerebro:") {
+			return value
+		}
+	}
+	return ""
 }
 
 func questionnaireControlIDs(record ports.QuestionnaireRunRecord) []string {

--- a/internal/questionnaire/projection.go
+++ b/internal/questionnaire/projection.go
@@ -1,0 +1,403 @@
+package questionnaire
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/fabriccontract"
+	"github.com/writer/cerebro/internal/ports"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
+)
+
+const (
+	QuestionnaireAttributeQuestionnaireURN  = "questionnaire_urn"
+	QuestionnaireAttributeSourceArtifactURN = "source_artifact_urn"
+	QuestionnaireProjectionSourceID         = "cerebro-questionnaires"
+)
+
+type GraphProjection struct {
+	Record       ports.QuestionnaireRunRecord
+	Entities     []*ports.ProjectedEntity
+	Links        []*ports.ProjectedLink
+	RemovedLinks []*ports.ProjectedLink
+}
+
+func BuildGraphProjection(record ports.QuestionnaireRunRecord, previous *ports.QuestionnaireRunRecord, at time.Time) (GraphProjection, error) {
+	record, err := EnsureGraphIdentity(record)
+	if err != nil {
+		return GraphProjection{}, err
+	}
+	current := graphProjectionForRecord(record, at)
+	current.Record = record
+	if previous == nil {
+		return current, nil
+	}
+	previousRecord, err := EnsureGraphIdentity(*previous)
+	if err != nil {
+		return GraphProjection{}, err
+	}
+	previousProjection := graphProjectionForRecord(previousRecord, at)
+	current.RemovedLinks = staleProjectionLinks(previousProjection.Links, current.Links)
+	return current, nil
+}
+
+func EnsureGraphIdentity(record ports.QuestionnaireRunRecord) (ports.QuestionnaireRunRecord, error) {
+	record.Attributes = copyStringMap(record.Attributes)
+	if record.Attributes == nil {
+		record.Attributes = map[string]string{}
+	}
+	if strings.TrimSpace(record.Attributes[QuestionnaireAttributeQuestionnaireURN]) != "" {
+		return record, nil
+	}
+	questionnaireURN, err := cerebroQuestionnaireURN(record.TenantID, record.RunID)
+	if err != nil {
+		return ports.QuestionnaireRunRecord{}, err
+	}
+	record.Attributes[QuestionnaireAttributeQuestionnaireURN] = questionnaireURN
+	return record, nil
+}
+
+func cerebroQuestionnaireURN(tenantID string, runID string) (string, error) {
+	value, err := cerebrourn.Mint(tenantID, "security_questionnaire", "questionnaire_run", runID)
+	if err != nil {
+		return "", fmt.Errorf("mint questionnaire urn: %w", err)
+	}
+	return value, nil
+}
+
+func graphProjectionForRecord(record ports.QuestionnaireRunRecord, at time.Time) GraphProjection {
+	sourceID := projectionSourceID(record)
+	runtimeID := strings.TrimSpace(record.RuntimeID)
+	questionnaireURN := strings.TrimSpace(record.Attributes[QuestionnaireAttributeQuestionnaireURN])
+	entities := []*ports.ProjectedEntity{
+		{
+			URN:        questionnaireURN,
+			TenantID:   record.TenantID,
+			SourceID:   sourceID,
+			RuntimeID:  runtimeID,
+			EntityType: "security.questionnaire",
+			Label:      firstNonEmpty(record.Title, record.SourceFilename, record.RunID),
+			Attributes: questionnaireEntityAttributes(record, at),
+		},
+	}
+	links := []*ports.ProjectedLink{}
+	addLink := func(toURN string, relation string, attrs map[string]string) {
+		toURN = strings.TrimSpace(toURN)
+		if questionnaireURN == "" || toURN == "" || relation == "" {
+			return
+		}
+		links = append(links, &ports.ProjectedLink{
+			TenantID:   record.TenantID,
+			SourceID:   sourceID,
+			RuntimeID:  runtimeID,
+			FromURN:    questionnaireURN,
+			ToURN:      toURN,
+			Relation:   relation,
+			Attributes: compactProjectionAttributes(attrs),
+		})
+	}
+	if vendorURN := strings.TrimSpace(record.VendorURN); vendorURN != "" {
+		addLink(vendorURN, fabriccontract.RelationAssociatedWith, map[string]string{
+			"match_type":           "questionnaire_vendor_link",
+			"questionnaire_run_id": record.RunID,
+			"questionnaire_urn":    questionnaireURN,
+			"vendor_id":            record.VendorID,
+			"direction":            record.Direction,
+			"vendor_link_status":   record.Attributes["vendor_link_status"],
+			"vendor_link_reason":   record.Attributes["vendor_link_reason"],
+		})
+	}
+	if owner := strings.TrimSpace(record.OwnerID); owner != "" {
+		ownerURN := ownerEntityURN(record.TenantID, owner)
+		if ownerURN != "" {
+			entities = append(entities, &ports.ProjectedEntity{
+				URN:        ownerURN,
+				TenantID:   record.TenantID,
+				SourceID:   sourceID,
+				RuntimeID:  runtimeID,
+				EntityType: "grc.user",
+				Label:      owner,
+				Attributes: map[string]string{
+					"owner_id":      owner,
+					"source_system": QuestionnaireProjectionSourceID,
+				},
+			})
+			addLink(ownerURN, fabriccontract.RelationOwnedBy, map[string]string{"owner_id": owner, "match_type": "questionnaire_owner"})
+		}
+	}
+	for _, controlID := range questionnaireControlIDs(record) {
+		controlURN := controlEntityURN(record.TenantID, controlID)
+		if controlURN == "" {
+			continue
+		}
+		if !strings.HasPrefix(controlID, "urn:cerebro:") {
+			entities = append(entities, &ports.ProjectedEntity{
+				URN:        controlURN,
+				TenantID:   record.TenantID,
+				SourceID:   sourceID,
+				RuntimeID:  runtimeID,
+				EntityType: "control",
+				Label:      controlID,
+				Attributes: map[string]string{
+					"control_id":    controlID,
+					"source_system": QuestionnaireProjectionSourceID,
+				},
+			})
+		}
+		addLink(controlURN, fabriccontract.RelationSupports, map[string]string{"control_id": controlID, "match_type": "questionnaire_control_mapping"})
+	}
+	for _, citation := range questionnaireCitations(record) {
+		evidenceURN := citationResourceURN(record.TenantID, citation)
+		if evidenceURN == "" {
+			continue
+		}
+		entities = append(entities, &ports.ProjectedEntity{
+			URN:        evidenceURN,
+			TenantID:   record.TenantID,
+			SourceID:   sourceID,
+			RuntimeID:  runtimeID,
+			EntityType: "runtime_evidence",
+			Label:      firstNonEmpty(citation.Label, citation.EvidenceID, citation.EvidencePacketID, citation.ID),
+			Attributes: compactProjectionAttributes(map[string]string{
+				"evidence_id":        citation.EvidenceID,
+				"evidence_packet_id": citation.EvidencePacketID,
+				"evidence_type":      citation.EvidenceType,
+				"freshness_status":   citation.FreshnessStatus,
+				"observed_at":        citation.ObservedAt,
+				"expires_at":         citation.ExpiresAt,
+				"source_system":      QuestionnaireProjectionSourceID,
+			}),
+		})
+		addLink(evidenceURN, fabriccontract.RelationHasEvidence, map[string]string{
+			"citation_id":        citation.ID,
+			"evidence_id":        citation.EvidenceID,
+			"evidence_packet_id": citation.EvidencePacketID,
+			"evidence_type":      citation.EvidenceType,
+			"match_type":         "questionnaire_answer_citation",
+		})
+	}
+	if sourceArtifactURN := strings.TrimSpace(record.Attributes[QuestionnaireAttributeSourceArtifactURN]); strings.HasPrefix(sourceArtifactURN, "urn:cerebro:") {
+		addLink(sourceArtifactURN, fabriccontract.RelationAssociatedWith, map[string]string{"match_type": "questionnaire_source_artifact"})
+	}
+	return GraphProjection{
+		Record:   record,
+		Entities: dedupeProjectedEntities(entities),
+		Links:    dedupeProjectedLinks(links),
+	}
+}
+
+func questionnaireEntityAttributes(record ports.QuestionnaireRunRecord, at time.Time) map[string]string {
+	attrs := map[string]string{
+		"questionnaire_run_id":        record.RunID,
+		"questionnaire_direction":     record.Direction,
+		"status":                      record.Status,
+		"decision":                    record.Decision,
+		"requester":                   record.Requester,
+		"customer_name":               record.CustomerName,
+		"vendor_urn":                  record.VendorURN,
+		"vendor_id":                   record.VendorID,
+		"source_id":                   record.SourceID,
+		"runtime_id":                  record.RuntimeID,
+		"upload_id":                   record.UploadID,
+		"source_filename":             record.SourceFilename,
+		"source_format":               record.SourceFormat,
+		"owner_id":                    record.OwnerID,
+		"assigned_team":               record.AssignedTeam,
+		"question_count":              strconv.Itoa(len(record.Questions)),
+		"answer_count":                strconv.Itoa(len(record.Answers)),
+		"ready_answer_count":          strconv.Itoa(record.ReadyAnswerCount),
+		"blocked_answer_count":        strconv.Itoa(record.BlockedAnswerCount),
+		"review_answer_count":         strconv.Itoa(record.ReviewAnswerCount),
+		"missing_evidence_count":      strconv.Itoa(record.MissingEvidence),
+		"stale_evidence_count":        strconv.Itoa(record.StaleEvidence),
+		"unassigned_count":            strconv.Itoa(record.UnassignedCount),
+		"questionnaire_projection_at": at.UTC().Format(time.RFC3339),
+		"source_system":               QuestionnaireProjectionSourceID,
+	}
+	if record.DueAt != nil {
+		attrs["due_at"] = record.DueAt.UTC().Format(time.RFC3339)
+	}
+	for key, value := range record.Attributes {
+		if strings.HasPrefix(key, "portal_") || strings.HasPrefix(key, "intake_") || key == QuestionnaireAttributeQuestionnaireURN || key == QuestionnaireAttributeSourceArtifactURN {
+			attrs[key] = value
+		}
+	}
+	return compactProjectionAttributes(attrs)
+}
+
+func projectionSourceID(record ports.QuestionnaireRunRecord) string {
+	return firstNonEmpty(record.SourceID, QuestionnaireProjectionSourceID)
+}
+
+func ownerEntityURN(tenantID string, owner string) string {
+	value, err := cerebrourn.Mint(tenantID, "grc_user", cerebrourn.EncodeSegment(owner))
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+func controlEntityURN(tenantID string, controlID string) string {
+	controlID = strings.TrimSpace(controlID)
+	if strings.HasPrefix(controlID, "urn:cerebro:") {
+		return controlID
+	}
+	value, err := cerebrourn.Mint(tenantID, "control", "questionnaire", cerebrourn.EncodeSegment(controlID))
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+func citationResourceURN(tenantID string, citation ports.QuestionnaireCitation) string {
+	for _, value := range []string{citation.ResourceURN, citation.EvidenceID, citation.EvidencePacketID, citation.ID} {
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "urn:cerebro:") {
+			return value
+		}
+	}
+	evidenceID := firstNonEmpty(citation.EvidenceID, citation.EvidencePacketID, citation.ID)
+	if evidenceID == "" {
+		return ""
+	}
+	value, err := cerebrourn.Mint(tenantID, "runtime_evidence", cerebrourn.EncodeSegment(evidenceID))
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+func questionnaireControlIDs(record ports.QuestionnaireRunRecord) []string {
+	controls := []string{}
+	for _, question := range record.Questions {
+		controls = append(controls, question.MappedControls...)
+	}
+	for _, answer := range record.Answers {
+		controls = append(controls, answer.Controls...)
+		for _, citation := range answer.Citations {
+			if citation.ControlID != "" {
+				controls = append(controls, citation.ControlID)
+			}
+		}
+	}
+	return uniqueSorted(controls)
+}
+
+func questionnaireCitations(record ports.QuestionnaireRunRecord) []ports.QuestionnaireCitation {
+	seen := map[string]struct{}{}
+	citations := []ports.QuestionnaireCitation{}
+	for _, answer := range record.Answers {
+		for _, citation := range answer.Citations {
+			key := firstNonEmpty(citation.ResourceURN, citation.EvidenceID, citation.EvidencePacketID, citation.ID)
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			citations = append(citations, citation)
+		}
+	}
+	return citations
+}
+
+func staleProjectionLinks(previous []*ports.ProjectedLink, current []*ports.ProjectedLink) []*ports.ProjectedLink {
+	currentKeys := map[string]struct{}{}
+	for _, link := range current {
+		currentKeys[projectionLinkKey(link)] = struct{}{}
+	}
+	removed := []*ports.ProjectedLink{}
+	for _, link := range previous {
+		if _, ok := currentKeys[projectionLinkKey(link)]; ok {
+			continue
+		}
+		removed = append(removed, link)
+	}
+	return dedupeProjectedLinks(removed)
+}
+
+func dedupeProjectedEntities(entities []*ports.ProjectedEntity) []*ports.ProjectedEntity {
+	seen := map[string]*ports.ProjectedEntity{}
+	order := []string{}
+	for _, entity := range entities {
+		if entity == nil || strings.TrimSpace(entity.URN) == "" {
+			continue
+		}
+		key := strings.TrimSpace(entity.URN)
+		if existing, ok := seen[key]; ok {
+			existing.Attributes = mergeProjectionAttributes(existing.Attributes, entity.Attributes)
+			if strings.TrimSpace(existing.Label) == "" {
+				existing.Label = entity.Label
+			}
+			continue
+		}
+		seen[key] = entity
+		order = append(order, key)
+	}
+	result := make([]*ports.ProjectedEntity, 0, len(order))
+	for _, key := range order {
+		result = append(result, seen[key])
+	}
+	return result
+}
+
+func dedupeProjectedLinks(links []*ports.ProjectedLink) []*ports.ProjectedLink {
+	seen := map[string]*ports.ProjectedLink{}
+	order := []string{}
+	for _, link := range links {
+		key := projectionLinkKey(link)
+		if key == "" {
+			continue
+		}
+		if existing, ok := seen[key]; ok {
+			existing.Attributes = mergeProjectionAttributes(existing.Attributes, link.Attributes)
+			continue
+		}
+		seen[key] = link
+		order = append(order, key)
+	}
+	result := make([]*ports.ProjectedLink, 0, len(order))
+	for _, key := range order {
+		result = append(result, seen[key])
+	}
+	return result
+}
+
+func projectionLinkKey(link *ports.ProjectedLink) string {
+	if link == nil || strings.TrimSpace(link.FromURN) == "" || strings.TrimSpace(link.Relation) == "" || strings.TrimSpace(link.ToURN) == "" {
+		return ""
+	}
+	return strings.TrimSpace(link.FromURN) + "\x00" + strings.TrimSpace(link.Relation) + "\x00" + strings.TrimSpace(link.ToURN)
+}
+
+func mergeProjectionAttributes(left map[string]string, right map[string]string) map[string]string {
+	result := copyStringMap(left)
+	if result == nil {
+		result = map[string]string{}
+	}
+	for key, value := range right {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func compactProjectionAttributes(values map[string]string) map[string]string {
+	result := map[string]string{}
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		result[key] = value
+	}
+	return result
+}

--- a/internal/questionnaire/projection.go
+++ b/internal/questionnaire/projection.go
@@ -48,9 +48,6 @@ func EnsureGraphIdentity(record ports.QuestionnaireRunRecord) (ports.Questionnai
 	if record.Attributes == nil {
 		record.Attributes = map[string]string{}
 	}
-	if strings.TrimSpace(record.Attributes[QuestionnaireAttributeQuestionnaireURN]) != "" {
-		return record, nil
-	}
 	questionnaireURN, err := cerebroQuestionnaireURN(record.TenantID, record.RunID)
 	if err != nil {
 		return ports.QuestionnaireRunRecord{}, err

--- a/internal/questionnaire/projection_test.go
+++ b/internal/questionnaire/projection_test.go
@@ -61,7 +61,7 @@ func TestBuildGraphProjectionLinksQuestionnaireWork(t *testing.T) {
 	if len(projection.Entities) < 4 {
 		t.Fatalf("entities = %d, want questionnaire, owner, control, and evidence entities", len(projection.Entities))
 	}
-	if !hasProjectedLink(projection.Links, questionnaireURN, fabriccontract.RelationAssociatedWith, "urn:cerebro:writer:vendor:core-sso") {
+	if !hasAssociatedProjectedLink(projection.Links, questionnaireURN, "urn:cerebro:writer:vendor:core-sso") {
 		t.Fatalf("missing vendor association link in %#v", projection.Links)
 	}
 	if !hasProjectedLinkToRelation(projection.Links, fabriccontract.RelationOwnedBy) {
@@ -114,7 +114,7 @@ func TestBuildGraphProjectionRemovesStaleLinks(t *testing.T) {
 		t.Fatalf("BuildGraphProjection() error = %v", err)
 	}
 	questionnaireURN := projection.Record.Attributes[QuestionnaireAttributeQuestionnaireURN]
-	if !hasProjectedLink(projection.RemovedLinks, questionnaireURN, fabriccontract.RelationAssociatedWith, "urn:cerebro:writer:vendor:old") {
+	if !hasAssociatedProjectedLink(projection.RemovedLinks, questionnaireURN, "urn:cerebro:writer:vendor:old") {
 		t.Fatalf("removed links missing old vendor link: %#v", projection.RemovedLinks)
 	}
 	if !hasProjectedLinkToRelation(projection.RemovedLinks, fabriccontract.RelationSupports) {
@@ -123,7 +123,7 @@ func TestBuildGraphProjectionRemovesStaleLinks(t *testing.T) {
 	if !hasProjectedLinkToRelation(projection.RemovedLinks, fabriccontract.RelationHasEvidence) {
 		t.Fatalf("removed links missing stale evidence link: %#v", projection.RemovedLinks)
 	}
-	if hasProjectedLink(projection.RemovedLinks, questionnaireURN, fabriccontract.RelationAssociatedWith, "urn:cerebro:writer:vendor:new") {
+	if hasAssociatedProjectedLink(projection.RemovedLinks, questionnaireURN, "urn:cerebro:writer:vendor:new") {
 		t.Fatalf("removed links include current vendor link: %#v", projection.RemovedLinks)
 	}
 }
@@ -145,6 +145,58 @@ func TestEnsureGraphIdentityOverwritesUserProvidedQuestionnaireURN(t *testing.T)
 	}
 	if got := record.Attributes[QuestionnaireAttributeQuestionnaireURN]; got != "urn:cerebro:writer:vendor:core-sso" {
 		t.Fatalf("original attributes mutated to %q", got)
+	}
+}
+
+func TestBuildGraphProjectionOnlyLinksValidSourceArtifactURNs(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	record := ports.QuestionnaireRunRecord{
+		QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-1"},
+		QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{Attributes: map[string]string{
+			QuestionnaireAttributeSourceArtifactURN: "urn:cerebro:writer:assurance_document:soc2",
+		}},
+	}
+
+	projection, err := BuildGraphProjection(record, nil, now)
+	if err != nil {
+		t.Fatalf("BuildGraphProjection() error = %v", err)
+	}
+	questionnaireURN := projection.Record.Attributes[QuestionnaireAttributeQuestionnaireURN]
+	if !hasAssociatedProjectedLink(projection.Links, questionnaireURN, "urn:cerebro:writer:assurance_document:soc2") {
+		t.Fatalf("missing source artifact link in %#v", projection.Links)
+	}
+
+	record.Attributes[QuestionnaireAttributeSourceArtifactURN] = "urn:cerebro:writer:vendor:core-sso"
+	projection, err = BuildGraphProjection(record, nil, now)
+	if err != nil {
+		t.Fatalf("BuildGraphProjection() error = %v", err)
+	}
+	if hasAssociatedProjectedLink(projection.Links, projection.Record.Attributes[QuestionnaireAttributeQuestionnaireURN], "urn:cerebro:writer:vendor:core-sso") {
+		t.Fatalf("source artifact link accepted wrong-kind urn: %#v", projection.Links)
+	}
+
+	record.Attributes[QuestionnaireAttributeSourceArtifactURN] = "urn:cerebro:other:assurance_document:soc2"
+	projection, err = BuildGraphProjection(record, nil, now)
+	if err != nil {
+		t.Fatalf("BuildGraphProjection() error = %v", err)
+	}
+	if hasAssociatedProjectedLink(projection.Links, projection.Record.Attributes[QuestionnaireAttributeQuestionnaireURN], "urn:cerebro:other:assurance_document:soc2") {
+		t.Fatalf("source artifact link accepted cross-tenant urn: %#v", projection.Links)
+	}
+}
+
+func TestControlEntityURNOnlyPassesThroughSameTenantControlURNs(t *testing.T) {
+	if got := controlEntityURN("writer", "SOC2-CC6.1"); got != "urn:cerebro:writer:control:questionnaire:SOC2-CC6.1" {
+		t.Fatalf("controlEntityURN() = %q, want minted control urn", got)
+	}
+	if got := controlEntityURN("writer", "urn:cerebro:writer:control:soc2-cc6.1"); got != "urn:cerebro:writer:control:soc2-cc6.1" {
+		t.Fatalf("controlEntityURN() = %q, want same-tenant control urn passthrough", got)
+	}
+	if got := controlEntityURN("writer", "urn:cerebro:writer:grc_user:security"); got != "" {
+		t.Fatalf("controlEntityURN() = %q, want wrong-kind urn skipped", got)
+	}
+	if got := controlEntityURN("writer", "urn:cerebro:other:control:soc2-cc6.1"); got != "" {
+		t.Fatalf("controlEntityURN() = %q, want cross-tenant urn skipped", got)
 	}
 }
 
@@ -173,9 +225,9 @@ func TestCitationResourceURNOnlyPassesThroughRuntimeEvidenceURNs(t *testing.T) {
 	}
 }
 
-func hasProjectedLink(links []*ports.ProjectedLink, fromURN string, relation string, toURN string) bool {
+func hasAssociatedProjectedLink(links []*ports.ProjectedLink, fromURN string, toURN string) bool {
 	for _, link := range links {
-		if link.FromURN == fromURN && link.Relation == relation && link.ToURN == toURN {
+		if link.FromURN == fromURN && link.Relation == fabriccontract.RelationAssociatedWith && link.ToURN == toURN {
 			return true
 		}
 	}

--- a/internal/questionnaire/projection_test.go
+++ b/internal/questionnaire/projection_test.go
@@ -128,6 +128,31 @@ func TestBuildGraphProjectionRemovesStaleLinks(t *testing.T) {
 	}
 }
 
+func TestCitationResourceURNOnlyPassesThroughRuntimeEvidenceURNs(t *testing.T) {
+	got := citationResourceURN("writer", ports.QuestionnaireCitation{
+		ResourceURN: "urn:cerebro:writer:vendor:core-sso",
+		EvidenceID:  "evidence-1",
+	})
+	if got != "urn:cerebro:writer:runtime_evidence:evidence-1" {
+		t.Fatalf("citationResourceURN() = %q, want minted runtime evidence urn", got)
+	}
+
+	got = citationResourceURN("writer", ports.QuestionnaireCitation{
+		ResourceURN: "urn:cerebro:writer:runtime_evidence:evidence-2",
+		EvidenceID:  "evidence-1",
+	})
+	if got != "urn:cerebro:writer:runtime_evidence:evidence-2" {
+		t.Fatalf("citationResourceURN() = %q, want existing runtime evidence urn", got)
+	}
+
+	got = citationResourceURN("writer", ports.QuestionnaireCitation{
+		EvidenceID: "urn:cerebro:writer:vendor:core-sso",
+	})
+	if got != "" {
+		t.Fatalf("citationResourceURN() = %q, want non-evidence urn ignored", got)
+	}
+}
+
 func hasProjectedLink(links []*ports.ProjectedLink, fromURN string, relation string, toURN string) bool {
 	for _, link := range links {
 		if link.FromURN == fromURN && link.Relation == relation && link.ToURN == toURN {

--- a/internal/questionnaire/projection_test.go
+++ b/internal/questionnaire/projection_test.go
@@ -128,6 +128,26 @@ func TestBuildGraphProjectionRemovesStaleLinks(t *testing.T) {
 	}
 }
 
+func TestEnsureGraphIdentityOverwritesUserProvidedQuestionnaireURN(t *testing.T) {
+	record := ports.QuestionnaireRunRecord{
+		QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-1"},
+		QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{Attributes: map[string]string{
+			QuestionnaireAttributeQuestionnaireURN: "urn:cerebro:writer:vendor:core-sso",
+		}},
+	}
+
+	normalized, err := EnsureGraphIdentity(record)
+	if err != nil {
+		t.Fatalf("EnsureGraphIdentity() error = %v", err)
+	}
+	if got := normalized.Attributes[QuestionnaireAttributeQuestionnaireURN]; got != "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-1" {
+		t.Fatalf("questionnaire urn = %q, want minted questionnaire urn", got)
+	}
+	if got := record.Attributes[QuestionnaireAttributeQuestionnaireURN]; got != "urn:cerebro:writer:vendor:core-sso" {
+		t.Fatalf("original attributes mutated to %q", got)
+	}
+}
+
 func TestCitationResourceURNOnlyPassesThroughRuntimeEvidenceURNs(t *testing.T) {
 	got := citationResourceURN("writer", ports.QuestionnaireCitation{
 		ResourceURN: "urn:cerebro:writer:vendor:core-sso",

--- a/internal/questionnaire/projection_test.go
+++ b/internal/questionnaire/projection_test.go
@@ -1,0 +1,147 @@
+package questionnaire
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/fabriccontract"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestBuildGraphProjectionLinksQuestionnaireWork(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	record := ports.QuestionnaireRunRecord{
+		QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-1", Title: "Core SSO review"},
+		QuestionnaireRunSource: ports.QuestionnaireRunSource{
+			Direction: ports.QuestionnaireDirectionVendorReview,
+			VendorURN: "urn:cerebro:writer:vendor:core-sso",
+			VendorID:  "core-sso",
+			SourceID:  "grc",
+			RuntimeID: "runtime-1",
+		},
+		QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{
+			Status:           ports.QuestionnaireStatusReadyForApproval,
+			OwnerID:          "security@example.com",
+			ReadyAnswerCount: 1,
+		},
+		QuestionnaireRunContent: ports.QuestionnaireRunContent{
+			Questions: []ports.QuestionnaireQuestion{{
+				ID:             "q-1",
+				Question:       "Do you enforce MFA?",
+				MappedControls: []string{"SOC2-CC6.1"},
+			}},
+			Answers: []ports.QuestionnaireRunAnswer{{
+				ID:          "a-1",
+				QuestionID:  "q-1",
+				AnswerState: ports.QuestionnaireAnswerSupported,
+				Controls:    []string{"SOC2-CC6.1"},
+				Citations: []ports.QuestionnaireCitation{{
+					ID:               "evidence-1",
+					Label:            "MFA configuration",
+					EvidenceID:       "evidence-1",
+					EvidencePacketID: "packet-1",
+					EvidenceType:     "identity_mfa",
+					FreshnessStatus:  "current",
+				}},
+				Freshness: ports.QuestionnaireFreshness{Status: "current"},
+			}},
+		},
+		QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{CreatedAt: now, UpdatedAt: now},
+	}
+
+	projection, err := BuildGraphProjection(record, nil, now)
+	if err != nil {
+		t.Fatalf("BuildGraphProjection() error = %v", err)
+	}
+	questionnaireURN := projection.Record.Attributes[QuestionnaireAttributeQuestionnaireURN]
+	if !strings.HasPrefix(questionnaireURN, "urn:cerebro:writer:security_questionnaire:questionnaire_run:run-1") {
+		t.Fatalf("questionnaire urn = %q, want stable security questionnaire urn", questionnaireURN)
+	}
+	if len(projection.Entities) < 4 {
+		t.Fatalf("entities = %d, want questionnaire, owner, control, and evidence entities", len(projection.Entities))
+	}
+	if !hasProjectedLink(projection.Links, questionnaireURN, fabriccontract.RelationAssociatedWith, "urn:cerebro:writer:vendor:core-sso") {
+		t.Fatalf("missing vendor association link in %#v", projection.Links)
+	}
+	if !hasProjectedLinkToRelation(projection.Links, fabriccontract.RelationOwnedBy) {
+		t.Fatalf("missing owner link in %#v", projection.Links)
+	}
+	if !hasProjectedLinkToRelation(projection.Links, fabriccontract.RelationSupports) {
+		t.Fatalf("missing control support link in %#v", projection.Links)
+	}
+	if !hasProjectedLinkToRelation(projection.Links, fabriccontract.RelationHasEvidence) {
+		t.Fatalf("missing evidence link in %#v", projection.Links)
+	}
+	if got := projection.Entities[0].Attributes["ready_answer_count"]; got != "1" {
+		t.Fatalf("ready answer count attr = %q, want 1", got)
+	}
+}
+
+func TestBuildGraphProjectionRemovesStaleLinks(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	previous := ports.QuestionnaireRunRecord{
+		QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-1", Title: "Vendor review"},
+		QuestionnaireRunSource: ports.QuestionnaireRunSource{
+			Direction: ports.QuestionnaireDirectionVendorReview,
+			VendorURN: "urn:cerebro:writer:vendor:old",
+			SourceID:  "grc",
+		},
+		QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusNeedsInput},
+		QuestionnaireRunContent: ports.QuestionnaireRunContent{
+			Questions: []ports.QuestionnaireQuestion{{ID: "q-1", Question: "Do you encrypt data?", MappedControls: []string{"old-control"}}},
+			Answers: []ports.QuestionnaireRunAnswer{{
+				ID:          "a-1",
+				QuestionID:  "q-1",
+				AnswerState: ports.QuestionnaireAnswerSupported,
+				Controls:    []string{"old-control"},
+				Citations:   []ports.QuestionnaireCitation{{ID: "old-evidence", EvidenceID: "old-evidence"}},
+				Freshness:   ports.QuestionnaireFreshness{Status: "current"},
+			}},
+		},
+		QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{CreatedAt: now, UpdatedAt: now},
+	}
+	current := previous
+	current.Questions = append([]ports.QuestionnaireQuestion(nil), previous.Questions...)
+	current.Answers = append([]ports.QuestionnaireRunAnswer(nil), previous.Answers...)
+	current.VendorURN = "urn:cerebro:writer:vendor:new"
+	current.Questions[0].MappedControls = []string{"new-control"}
+	current.Answers[0].Controls = []string{"new-control"}
+	current.Answers[0].Citations = []ports.QuestionnaireCitation{{ID: "new-evidence", EvidenceID: "new-evidence"}}
+
+	projection, err := BuildGraphProjection(current, &previous, now)
+	if err != nil {
+		t.Fatalf("BuildGraphProjection() error = %v", err)
+	}
+	questionnaireURN := projection.Record.Attributes[QuestionnaireAttributeQuestionnaireURN]
+	if !hasProjectedLink(projection.RemovedLinks, questionnaireURN, fabriccontract.RelationAssociatedWith, "urn:cerebro:writer:vendor:old") {
+		t.Fatalf("removed links missing old vendor link: %#v", projection.RemovedLinks)
+	}
+	if !hasProjectedLinkToRelation(projection.RemovedLinks, fabriccontract.RelationSupports) {
+		t.Fatalf("removed links missing stale control link: %#v", projection.RemovedLinks)
+	}
+	if !hasProjectedLinkToRelation(projection.RemovedLinks, fabriccontract.RelationHasEvidence) {
+		t.Fatalf("removed links missing stale evidence link: %#v", projection.RemovedLinks)
+	}
+	if hasProjectedLink(projection.RemovedLinks, questionnaireURN, fabriccontract.RelationAssociatedWith, "urn:cerebro:writer:vendor:new") {
+		t.Fatalf("removed links include current vendor link: %#v", projection.RemovedLinks)
+	}
+}
+
+func hasProjectedLink(links []*ports.ProjectedLink, fromURN string, relation string, toURN string) bool {
+	for _, link := range links {
+		if link.FromURN == fromURN && link.Relation == relation && link.ToURN == toURN {
+			return true
+		}
+	}
+	return false
+}
+
+func hasProjectedLinkToRelation(links []*ports.ProjectedLink, relation string) bool {
+	for _, link := range links {
+		if link.Relation == relation {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/questionnaire/service.go
+++ b/internal/questionnaire/service.go
@@ -112,6 +112,7 @@ func NewRunRecord(request NewRunRequest, now time.Time) ports.QuestionnaireRunRe
 }
 
 func LinkVendor(record ports.QuestionnaireRunRecord, request LinkVendorRequest, now time.Time) ports.QuestionnaireRunRecord {
+	record = cloneRunRecord(record)
 	now = normalizeNow(now)
 	record.UpdatedAt = now
 	record.Attributes = copyStringMap(record.Attributes)
@@ -187,6 +188,7 @@ func setVendorLinkReason(attributes map[string]string, reason string) {
 }
 
 func ProcessEvidenceAnswers(record ports.QuestionnaireRunRecord, evidenceAnswers []evidencepackets.QuestionnaireAnswer, now time.Time) ports.QuestionnaireRunRecord {
+	record = cloneRunRecord(record)
 	now = normalizeNow(now)
 	previousStatus := record.Status
 	previousDecision := record.Decision
@@ -273,6 +275,7 @@ func NormalizeQuestionsForIntake(questions []ports.QuestionnaireQuestion) []port
 }
 
 func AddAssignment(record ports.QuestionnaireRunRecord, assignment ports.QuestionnaireAssignment, actorID string, now time.Time) ports.QuestionnaireRunRecord {
+	record = cloneRunRecord(record)
 	now = normalizeNow(now)
 	assignment.ID = firstNonEmpty(assignment.ID, stableID("questionnaire-assignment", record.RunID, assignment.QuestionID, assignment.OwnerID, assignment.Team, fmt.Sprint(len(record.Assignments)+1)))
 	assignment.Status = firstNonEmpty(assignment.Status, "open")
@@ -299,6 +302,7 @@ func AddAssignment(record ports.QuestionnaireRunRecord, assignment ports.Questio
 }
 
 func AddComment(record ports.QuestionnaireRunRecord, comment ports.QuestionnaireComment, actorID string, now time.Time) ports.QuestionnaireRunRecord {
+	record = cloneRunRecord(record)
 	now = normalizeNow(now)
 	comment.ActorID = strings.TrimSpace(actorID)
 	comment.ID = firstNonEmpty(comment.ID, stableID("questionnaire-comment", record.RunID, comment.QuestionID, comment.ActorID, comment.Body, now.Format(time.RFC3339Nano)))
@@ -312,6 +316,7 @@ func AddComment(record ports.QuestionnaireRunRecord, comment ports.Questionnaire
 }
 
 func UpdateQuestion(record ports.QuestionnaireRunRecord, request UpdateQuestionRequest, now time.Time) ports.QuestionnaireRunRecord {
+	record = cloneRunRecord(record)
 	now = normalizeNow(now)
 	questionID := strings.TrimSpace(request.QuestionID)
 	for index := range record.Questions {
@@ -347,6 +352,7 @@ func UpdateQuestion(record ports.QuestionnaireRunRecord, request UpdateQuestionR
 }
 
 func RecordDecision(record ports.QuestionnaireRunRecord, decision ports.QuestionnaireDecision, now time.Time) ports.QuestionnaireRunRecord {
+	record = cloneRunRecord(record)
 	now = normalizeNow(now)
 	decision.ID = firstNonEmpty(decision.ID, stableID("questionnaire-decision", record.RunID, decision.QuestionID, decision.Decision, decision.ActorID, now.Format(time.RFC3339Nano)))
 	if decision.CreatedAt == nil {
@@ -1013,6 +1019,135 @@ func normalizeNow(value time.Time) time.Time {
 		return time.Now().UTC()
 	}
 	return value.UTC()
+}
+
+func cloneRunRecord(record ports.QuestionnaireRunRecord) ports.QuestionnaireRunRecord {
+	record.Attributes = cloneStringMap(record.Attributes)
+	record.DueAt = cloneTimePtr(record.DueAt)
+	record.Questions = cloneQuestions(record.Questions)
+	record.Answers = cloneAnswers(record.Answers)
+	record.Assignments = cloneAssignments(record.Assignments)
+	record.Decisions = cloneDecisions(record.Decisions)
+	record.Comments = cloneComments(record.Comments)
+	record.Timeline = cloneTimeline(record.Timeline)
+	return record
+}
+
+func cloneQuestions(values []ports.QuestionnaireQuestion) []ports.QuestionnaireQuestion {
+	if values == nil {
+		return nil
+	}
+	out := make([]ports.QuestionnaireQuestion, len(values))
+	for index, value := range values {
+		value.MappedControls = cloneStringSlice(value.MappedControls)
+		value.RequiredSlots = cloneStringSlice(value.RequiredSlots)
+		out[index] = value
+	}
+	return out
+}
+
+func cloneAnswers(values []ports.QuestionnaireRunAnswer) []ports.QuestionnaireRunAnswer {
+	if values == nil {
+		return nil
+	}
+	out := make([]ports.QuestionnaireRunAnswer, len(values))
+	for index, value := range values {
+		value.Controls = cloneStringSlice(value.Controls)
+		value.EvidenceSlots = cloneEvidenceSlots(value.EvidenceSlots)
+		value.Citations = append([]ports.QuestionnaireCitation(nil), value.Citations...)
+		value.MissingEvidence = append([]ports.QuestionnaireEvidenceGap(nil), value.MissingEvidence...)
+		value.Conflicts = append([]ports.QuestionnaireEvidenceGap(nil), value.Conflicts...)
+		value.Attributes = cloneStringMap(value.Attributes)
+		out[index] = value
+	}
+	return out
+}
+
+func cloneEvidenceSlots(values []ports.QuestionnaireEvidenceSlot) []ports.QuestionnaireEvidenceSlot {
+	if values == nil {
+		return nil
+	}
+	out := make([]ports.QuestionnaireEvidenceSlot, len(values))
+	for index, value := range values {
+		value.CitationIDs = cloneStringSlice(value.CitationIDs)
+		value.MissingReasons = cloneStringSlice(value.MissingReasons)
+		out[index] = value
+	}
+	return out
+}
+
+func cloneAssignments(values []ports.QuestionnaireAssignment) []ports.QuestionnaireAssignment {
+	if values == nil {
+		return nil
+	}
+	out := make([]ports.QuestionnaireAssignment, len(values))
+	for index, value := range values {
+		value.DueAt = cloneTimePtr(value.DueAt)
+		value.CreatedAt = cloneTimePtr(value.CreatedAt)
+		value.UpdatedAt = cloneTimePtr(value.UpdatedAt)
+		out[index] = value
+	}
+	return out
+}
+
+func cloneDecisions(values []ports.QuestionnaireDecision) []ports.QuestionnaireDecision {
+	if values == nil {
+		return nil
+	}
+	out := make([]ports.QuestionnaireDecision, len(values))
+	for index, value := range values {
+		value.CreatedAt = cloneTimePtr(value.CreatedAt)
+		out[index] = value
+	}
+	return out
+}
+
+func cloneComments(values []ports.QuestionnaireComment) []ports.QuestionnaireComment {
+	if values == nil {
+		return nil
+	}
+	out := make([]ports.QuestionnaireComment, len(values))
+	for index, value := range values {
+		value.CreatedAt = cloneTimePtr(value.CreatedAt)
+		out[index] = value
+	}
+	return out
+}
+
+func cloneTimeline(values []ports.QuestionnaireTimeline) []ports.QuestionnaireTimeline {
+	if values == nil {
+		return nil
+	}
+	out := make([]ports.QuestionnaireTimeline, len(values))
+	for index, value := range values {
+		value.Attributes = cloneStringMap(value.Attributes)
+		value.CreatedAt = cloneTimePtr(value.CreatedAt)
+		out[index] = value
+	}
+	return out
+}
+
+func cloneStringSlice(values []string) []string {
+	return append([]string(nil), values...)
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func copyStringMap(values map[string]string) map[string]string {

--- a/internal/questionnaire/service.go
+++ b/internal/questionnaire/service.go
@@ -289,7 +289,12 @@ func AddAssignment(record ports.QuestionnaireRunRecord, assignment ports.Questio
 		}
 	}
 	record.UpdatedAt = now
-	record.Timeline = append(record.Timeline, Timeline(ports.QuestionnaireEventAssigned, actorID, "Questionnaire answer assigned", map[string]string{"question_id": assignment.QuestionID, "owner_id": assignment.OwnerID}, now))
+	record.Timeline = append(record.Timeline, Timeline(ports.QuestionnaireEventAssigned, actorID, "Questionnaire answer assigned", map[string]string{
+		"question_id": assignment.QuestionID,
+		"gap_id":      assignment.GapID,
+		"slot_id":     assignment.SlotID,
+		"owner_id":    assignment.OwnerID,
+	}, now))
 	return SummarizeRun(record)
 }
 
@@ -661,12 +666,13 @@ func gapsFromEvidenceAnswer(questionID string, requiredSlots []string, evidenceA
 	for _, gap := range evidenceAnswer.MissingEvidence {
 		slotID := slotForGap(gap.Code, requiredSlots)
 		gaps = append(gaps, ports.QuestionnaireEvidenceGap{
-			ID:        firstNonEmpty(gap.ID, stableID("questionnaire-gap", questionID, gap.Code, gap.PacketID)),
-			Code:      gap.Code,
-			Reason:    gap.Reason,
-			SlotID:    slotID,
-			ControlID: gap.ControlID,
-			PacketID:  gap.PacketID,
+			ID:          firstNonEmpty(gap.ID, stableID("questionnaire-gap", questionID, gap.Code, gap.PacketID)),
+			Code:        gap.Code,
+			Reason:      gap.Reason,
+			SlotID:      slotID,
+			ControlID:   gap.ControlID,
+			PacketID:    gap.PacketID,
+			ReviewState: gap.ReviewState,
 		})
 	}
 	for _, slot := range slots {
@@ -708,8 +714,10 @@ func citationsFromEvidenceAnswer(answer evidencepackets.QuestionnaireAnswer) []p
 			ID:               citationID,
 			Label:            firstNonEmpty(ref.EvidenceType, ref.Source, ref.SourceID, ref.RuntimeID, citationID),
 			Source:           firstNonEmpty(ref.SourceID, ref.Source, ref.RuntimeID),
+			ResourceURN:      firstCerebroURN(ref.ID, ref.EvidencePacketID),
 			EvidencePacketID: ref.EvidencePacketID,
 			EvidenceID:       ref.ID,
+			EvidenceType:     ref.EvidenceType,
 			FreshnessStatus:  ref.Freshness.Status,
 			ObservedAt:       ref.Freshness.ObservedAt,
 			ExpiresAt:        ref.Freshness.ExpiresAt,
@@ -723,6 +731,16 @@ func citationsFromEvidenceAnswer(answer evidencepackets.QuestionnaireAnswer) []p
 	}
 	sort.Slice(citations, func(i, j int) bool { return citations[i].ID < citations[j].ID })
 	return citations
+}
+
+func firstCerebroURN(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "urn:cerebro:") {
+			return value
+		}
+	}
+	return ""
 }
 
 func freshnessFromEvidenceAnswer(answer evidencepackets.QuestionnaireAnswer) ports.QuestionnaireFreshness {

--- a/internal/sourcehttp/questionnaire/handler.go
+++ b/internal/sourcehttp/questionnaire/handler.go
@@ -44,33 +44,42 @@ type CacheBumper func(context.Context, string)
 type ErrorWriter func(http.ResponseWriter, error)
 
 type Options struct {
-	Scope     ScopeResolver
-	Evidence  EvidenceResolver
-	Authorize TenantAuthorizer
-	Actor     ActorResolver
-	BumpCache CacheBumper
-	WriteErr  ErrorWriter
+	Scope           ScopeResolver
+	Evidence        EvidenceResolver
+	Authorize       TenantAuthorizer
+	Actor           ActorResolver
+	BumpCache       CacheBumper
+	WriteErr        ErrorWriter
+	ProjectionState ports.ProjectionStateStore
+	ProjectionGraph ports.ProjectionGraphStore
 }
 
 type Handler struct {
-	store     ports.QuestionnaireRunStore
-	scope     ScopeResolver
-	evidence  EvidenceResolver
-	authorize TenantAuthorizer
-	actor     ActorResolver
-	bumpCache CacheBumper
-	writeErr  ErrorWriter
+	store       ports.QuestionnaireRunStore
+	projections []questionnaireProjectionWriter
+	scope       ScopeResolver
+	evidence    EvidenceResolver
+	authorize   TenantAuthorizer
+	actor       ActorResolver
+	bumpCache   CacheBumper
+	writeErr    ErrorWriter
+}
+
+type questionnaireProjectionWriter interface {
+	UpsertProjectedEntity(context.Context, *ports.ProjectedEntity) error
+	UpsertProjectedLink(context.Context, *ports.ProjectedLink) error
 }
 
 func NewHandler(store ports.StateStore, options Options) *Handler {
 	return &Handler{
-		store:     questionnaireRunStore(store),
-		scope:     options.Scope,
-		evidence:  options.Evidence,
-		authorize: options.Authorize,
-		actor:     options.Actor,
-		bumpCache: options.BumpCache,
-		writeErr:  options.WriteErr,
+		store:       questionnaireRunStore(store),
+		projections: questionnaireProjectionWriters(store, options),
+		scope:       options.Scope,
+		evidence:    options.Evidence,
+		authorize:   options.Authorize,
+		actor:       options.Actor,
+		bumpCache:   options.BumpCache,
+		writeErr:    options.WriteErr,
 	}
 }
 
@@ -197,6 +206,8 @@ type assignmentRequest struct {
 	TenantID   string                         `json:"tenant_id,omitempty"`
 	Assignment *ports.QuestionnaireAssignment `json:"assignment,omitempty"`
 	QuestionID string                         `json:"question_id,omitempty"`
+	GapID      string                         `json:"gap_id,omitempty"`
+	SlotID     string                         `json:"slot_id,omitempty"`
 	OwnerID    string                         `json:"owner_id,omitempty"`
 	Team       string                         `json:"team,omitempty"`
 	Status     string                         `json:"status,omitempty"`
@@ -346,7 +357,7 @@ func (h *Handler) CreateRun(w http.ResponseWriter, r *http.Request) {
 		Attributes:     attributes,
 	}, now)
 	event := questionnairedomain.Event(record, ports.QuestionnaireEventCreated, h.actorID(r.Context()), "Questionnaire run created", map[string]string{"direction": record.Direction, "question_count": strconv.Itoa(len(record.Questions)), "source_format": record.SourceFormat}, now)
-	created, err := h.store.UpsertQuestionnaireRun(r.Context(), record, event)
+	created, err := h.saveQuestionnaireRun(r.Context(), record, event, nil, now)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -389,7 +400,7 @@ func (h *Handler) ProcessRun(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	updated := questionnairedomain.ProcessEvidenceAnswers(*record, answers, now)
 	event := questionnairedomain.Event(updated, ports.QuestionnaireEventProcessed, h.actorID(r.Context()), "Questionnaire answers refreshed from evidence", map[string]string{"answer_count": strconv.Itoa(len(updated.Answers)), "status": updated.Status}, now)
-	saved, err := h.store.UpsertQuestionnaireRun(r.Context(), updated, event)
+	saved, err := h.saveQuestionnaireRun(r.Context(), updated, event, record, now)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -420,6 +431,8 @@ func (h *Handler) AssignRun(w http.ResponseWriter, r *http.Request) {
 	}
 	assignment := ports.QuestionnaireAssignment{
 		QuestionID: strings.TrimSpace(request.QuestionID),
+		GapID:      strings.TrimSpace(request.GapID),
+		SlotID:     strings.TrimSpace(request.SlotID),
 		OwnerID:    strings.TrimSpace(request.OwnerID),
 		Team:       strings.TrimSpace(request.Team),
 		Status:     firstNonEmpty(request.Status, "open"),
@@ -443,8 +456,13 @@ func (h *Handler) AssignRun(w http.ResponseWriter, r *http.Request) {
 	}
 	now := time.Now().UTC()
 	updated := questionnairedomain.AddAssignment(*record, assignment, h.actorID(r.Context()), now)
-	event := questionnairedomain.Event(updated, ports.QuestionnaireEventAssigned, h.actorID(r.Context()), "Questionnaire answer assigned", map[string]string{"question_id": assignment.QuestionID, "owner_id": assignment.OwnerID}, now)
-	saved, err := h.store.UpsertQuestionnaireRun(r.Context(), updated, event)
+	event := questionnairedomain.Event(updated, ports.QuestionnaireEventAssigned, h.actorID(r.Context()), "Questionnaire answer assigned", map[string]string{
+		"question_id": assignment.QuestionID,
+		"gap_id":      assignment.GapID,
+		"slot_id":     assignment.SlotID,
+		"owner_id":    assignment.OwnerID,
+	}, now)
+	saved, err := h.saveQuestionnaireRun(r.Context(), updated, event, record, now)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -489,7 +507,7 @@ func (h *Handler) UpdateQuestion(w http.ResponseWriter, r *http.Request) {
 		ClearOwner:     request.ClearOwner,
 	}, now)
 	event := questionnairedomain.Event(updated, ports.QuestionnaireEventUpdated, h.actorID(r.Context()), "Questionnaire question updated", map[string]string{"question_id": strings.TrimSpace(request.QuestionID)}, now)
-	saved, err := h.store.UpsertQuestionnaireRun(r.Context(), updated, event)
+	saved, err := h.saveQuestionnaireRun(r.Context(), updated, event, record, now)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -532,7 +550,7 @@ func (h *Handler) LinkVendor(w http.ResponseWriter, r *http.Request) {
 		"reason":     strings.TrimSpace(request.Reason),
 		"unlink":     strconv.FormatBool(request.Unlink),
 	}, now)
-	saved, err := h.store.UpsertQuestionnaireRun(r.Context(), updated, event)
+	saved, err := h.saveQuestionnaireRun(r.Context(), updated, event, record, now)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -573,7 +591,7 @@ func (h *Handler) DecideRun(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	updated := questionnairedomain.RecordDecision(*record, decision, now)
 	event := questionnairedomain.Event(updated, ports.QuestionnaireEventDecided, decision.ActorID, "Questionnaire decision recorded", map[string]string{"question_id": decision.QuestionID, "decision": decision.Decision}, now)
-	saved, err := h.store.UpsertQuestionnaireRun(r.Context(), updated, event)
+	saved, err := h.saveQuestionnaireRun(r.Context(), updated, event, record, now)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -613,7 +631,7 @@ func (h *Handler) CommentRun(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	updated := questionnairedomain.AddComment(*record, comment, h.actorID(r.Context()), now)
 	event := questionnairedomain.Event(updated, ports.QuestionnaireEventCommented, comment.ActorID, "Questionnaire comment added", map[string]string{"question_id": comment.QuestionID}, now)
-	saved, err := h.store.UpsertQuestionnaireRun(r.Context(), updated, event)
+	saved, err := h.saveQuestionnaireRun(r.Context(), updated, event, record, now)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -912,6 +930,66 @@ func questionnaireRunStore(store ports.StateStore) ports.QuestionnaireRunStore {
 		return nil
 	}
 	return runStore
+}
+
+func questionnaireProjectionWriters(store ports.StateStore, options Options) []questionnaireProjectionWriter {
+	writers := []questionnaireProjectionWriter{}
+	if options.ProjectionState != nil && !isNilInterface(options.ProjectionState) {
+		writers = append(writers, options.ProjectionState)
+	} else if projectionStore, ok := store.(ports.ProjectionStateStore); ok && !isNilInterface(projectionStore) {
+		writers = append(writers, projectionStore)
+	}
+	if options.ProjectionGraph != nil && !isNilInterface(options.ProjectionGraph) {
+		writers = append(writers, options.ProjectionGraph)
+	}
+	return writers
+}
+
+func (h *Handler) saveQuestionnaireRun(ctx context.Context, record ports.QuestionnaireRunRecord, event ports.QuestionnaireRunEventRecord, previous *ports.QuestionnaireRunRecord, at time.Time) (*ports.QuestionnaireRunRecord, error) {
+	projection, err := questionnairedomain.BuildGraphProjection(record, previous, at)
+	if err != nil {
+		return nil, err
+	}
+	if event.Payload == nil {
+		event.Payload = map[string]string{}
+	}
+	if questionnaireURN := strings.TrimSpace(projection.Record.Attributes[questionnairedomain.QuestionnaireAttributeQuestionnaireURN]); questionnaireURN != "" {
+		event.Payload[questionnairedomain.QuestionnaireAttributeQuestionnaireURN] = questionnaireURN
+	}
+	saved, err := h.store.UpsertQuestionnaireRun(ctx, projection.Record, event)
+	if err != nil {
+		return nil, err
+	}
+	if err := h.projectQuestionnaireRun(ctx, projection); err != nil {
+		return nil, err
+	}
+	return saved, nil
+}
+
+func (h *Handler) projectQuestionnaireRun(ctx context.Context, projection questionnairedomain.GraphProjection) error {
+	if len(h.projections) == 0 {
+		return nil
+	}
+	for _, writer := range h.projections {
+		for _, entity := range projection.Entities {
+			if err := writer.UpsertProjectedEntity(ctx, entity); err != nil {
+				return err
+			}
+		}
+		if deleter, ok := writer.(ports.ProjectionLinkDeleter); ok {
+			for _, link := range projection.RemovedLinks {
+				if err := deleter.DeleteProjectedLink(ctx, link); err != nil {
+					return err
+				}
+			}
+		}
+		for _, link := range projection.Links {
+			if err := writer.UpsertProjectedLink(ctx, link); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func parseOptionalTime(value string) (*time.Time, error) {

--- a/internal/sourcehttp/questionnaire/handler.go
+++ b/internal/sourcehttp/questionnaire/handler.go
@@ -16,11 +16,13 @@ import (
 	"github.com/writer/cerebro/internal/evidencepackets"
 	"github.com/writer/cerebro/internal/ports"
 	questionnairedomain "github.com/writer/cerebro/internal/questionnaire"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const maxQuestionnaireBodyBytes = 512 << 10
 const maxQuestionnaireCreateBodyBytes = 16 << 20
 const defaultLimit uint32 = 100
+const questionnaireProjectionTimeout = 10 * time.Second
 
 var (
 	ErrRuntimeUnavailable = errors.New("questionnaire runtime is unavailable")
@@ -960,10 +962,24 @@ func (h *Handler) saveQuestionnaireRun(ctx context.Context, record ports.Questio
 	if err != nil {
 		return nil, err
 	}
-	if err := h.projectQuestionnaireRun(ctx, projection); err != nil {
-		return nil, err
-	}
+	h.projectQuestionnaireRunAsync(ctx, projection)
 	return saved, nil
+}
+
+func (h *Handler) projectQuestionnaireRunAsync(parent context.Context, projection questionnairedomain.GraphProjection) {
+	if len(h.projections) == 0 {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), questionnaireProjectionTimeout)
+		defer cancel()
+		if err := h.projectQuestionnaireRun(ctx, projection); err != nil {
+			telemetry.CaptureError(ctx, "questionnaire.projection.failed", err, telemetry.Attrs(
+				telemetry.Field{Key: "tenant_id", Value: projection.Record.TenantID},
+				telemetry.Field{Key: "questionnaire.run_id", Value: projection.Record.RunID},
+			))
+		}
+	}()
 }
 
 func (h *Handler) projectQuestionnaireRun(ctx context.Context, projection questionnairedomain.GraphProjection) error {

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -89,6 +89,21 @@ func TestCreateRunParsesXLSXIntakeFile(t *testing.T) {
 	}
 }
 
+func TestCreateRunAttributesIgnoreUserProvidedQuestionnaireURN(t *testing.T) {
+	attrs := createRunAttributes(createRequest{
+		Attributes: map[string]string{
+			"questionnaire_urn": "urn:cerebro:tenant-1:vendor:core-sso",
+			"business_unit":     "enterprise",
+		},
+	}, 1)
+	if _, ok := attrs["questionnaire_urn"]; ok {
+		t.Fatalf("attributes = %#v, want questionnaire_urn filtered", attrs)
+	}
+	if attrs["business_unit"] != "enterprise" {
+		t.Fatalf("attributes = %#v, want non-reserved attributes retained", attrs)
+	}
+}
+
 func TestCreateRunInfersXLSXFromFilenameWhenMimeTypeIsGeneric(t *testing.T) {
 	store := &processRunStore{}
 	handler := NewHandler(store, Options{

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/evidencepackets"
+	"github.com/writer/cerebro/internal/fabriccontract"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -89,18 +91,108 @@ func TestCreateRunParsesXLSXIntakeFile(t *testing.T) {
 	}
 }
 
-func TestCreateRunAttributesIgnoreUserProvidedQuestionnaireURN(t *testing.T) {
+func TestCreateRunAttributesIgnoreReservedGraphAttributes(t *testing.T) {
 	attrs := createRunAttributes(createRequest{
 		Attributes: map[string]string{
-			"questionnaire_urn": "urn:cerebro:tenant-1:vendor:core-sso",
-			"business_unit":     "enterprise",
+			"questionnaire_urn":   "urn:cerebro:tenant-1:vendor:core-sso",
+			"source_artifact_urn": "urn:cerebro:tenant-1:vendor:core-sso",
+			"business_unit":       "enterprise",
 		},
 	}, 1)
 	if _, ok := attrs["questionnaire_urn"]; ok {
 		t.Fatalf("attributes = %#v, want questionnaire_urn filtered", attrs)
 	}
+	if _, ok := attrs["source_artifact_urn"]; ok {
+		t.Fatalf("attributes = %#v, want source_artifact_urn filtered", attrs)
+	}
 	if attrs["business_unit"] != "enterprise" {
 		t.Fatalf("attributes = %#v, want non-reserved attributes retained", attrs)
+	}
+}
+
+func TestCreateRunSucceedsWhenProjectionFailsAfterSave(t *testing.T) {
+	store := &processRunStore{}
+	var bumpedTenant string
+	projectionAttempted := make(chan struct{}, 1)
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor:           func(context.Context) string { return "grc@example.com" },
+		BumpCache:       func(_ context.Context, tenantID string) { bumpedTenant = tenantID },
+		ProjectionState: failingQuestionnaireProjectionStore{attempted: projectionAttempted},
+	})
+	body := `{
+		"tenant_id": "tenant-1",
+		"direction": "customer_security_review",
+		"title": "Acme security review",
+		"source_format": "csv",
+		"intake_text": "question\nDo you enforce MFA?"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	handler.CreateRun(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if store.saved.RunID == "" {
+		t.Fatalf("saved run is empty: %#v", store.saved)
+	}
+	if bumpedTenant != "tenant-1" {
+		t.Fatalf("bumped tenant = %q, want tenant-1", bumpedTenant)
+	}
+	select {
+	case <-projectionAttempted:
+	case <-time.After(time.Second):
+		t.Fatal("projection writer was not called")
+	}
+}
+
+func TestCreateRunDoesNotWaitForProjection(t *testing.T) {
+	store := &processRunStore{}
+	releaseProjection := make(chan struct{})
+	defer close(releaseProjection)
+	projectionStarted := make(chan struct{}, 1)
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor: func(context.Context) string { return "grc@example.com" },
+		ProjectionState: blockingQuestionnaireProjectionStore{
+			started: projectionStarted,
+			release: releaseProjection,
+		},
+	})
+	body := `{
+		"tenant_id": "tenant-1",
+		"direction": "customer_security_review",
+		"title": "Acme security review",
+		"source_format": "csv",
+		"intake_text": "question\nDo you enforce MFA?"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+
+	go func() {
+		handler.CreateRun(recorder, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("CreateRun waited for projection writer")
+	}
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	select {
+	case <-projectionStarted:
+	case <-time.After(time.Second):
+		t.Fatal("projection writer was not called")
 	}
 }
 
@@ -497,6 +589,60 @@ func TestUpdateQuestionMapsRequiredEvidenceSlots(t *testing.T) {
 	}
 	if store.saved.Questions[0].OwnerID != "security@example.com" {
 		t.Fatalf("owner = %q, want security@example.com", store.saved.Questions[0].OwnerID)
+	}
+}
+
+func TestUpdateQuestionRemovesStaleControlProjectionLinks(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	deletedLinks := make(chan *ports.ProjectedLink, 4)
+	store := &processRunStore{
+		record: ports.QuestionnaireRunRecord{
+			QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "tenant-1", RunID: "run-1", Title: "Customer review"},
+			QuestionnaireRunSource:   ports.QuestionnaireRunSource{Direction: ports.QuestionnaireDirectionCustomerSecurityReview},
+			QuestionnaireRunWorkflow: ports.QuestionnaireRunWorkflow{Status: ports.QuestionnaireStatusNeedsInput},
+			QuestionnaireRunContent: ports.QuestionnaireRunContent{
+				Questions: []ports.QuestionnaireQuestion{{
+					ID:             "q-1",
+					Question:       "Attach SOC 2 report.",
+					MappedControls: []string{"SOC2-CC6.1"},
+					AnswerState:    ports.QuestionnaireAnswerNeedsReview,
+					ReviewState:    ports.QuestionnaireReviewNeedsReview,
+				}},
+			},
+			QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{CreatedAt: now, UpdatedAt: now},
+		},
+	}
+	handler := NewHandler(store, Options{
+		Scope: func(r *http.Request) (Scope, error) {
+			return Scope{TenantID: firstNonEmpty(r.URL.Query().Get("tenant_id"), "tenant-1"), Limit: 25}, nil
+		},
+		Actor:           func(context.Context) string { return "security@example.com" },
+		ProjectionState: recordingQuestionnaireProjectionStore{deleted: deletedLinks},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grc/questionnaire-runs/run-1/questions", strings.NewReader(`{"question_id":"q-1","mapped_controls":["SOC2-CC7.2"],"reason":"Remapped from review."}`))
+	req.SetPathValue("runID", "run-1")
+	recorder := httptest.NewRecorder()
+
+	handler.UpdateQuestion(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := store.record.Questions[0].MappedControls; len(got) != 1 || got[0] != "SOC2-CC6.1" {
+		t.Fatalf("stored baseline controls = %#v, want original control", got)
+	}
+	if got := store.saved.Questions[0].MappedControls; len(got) != 1 || got[0] != "SOC2-CC7.2" {
+		t.Fatalf("saved controls = %#v, want remapped control", got)
+	}
+	for {
+		select {
+		case link := <-deletedLinks:
+			if link.Relation == fabriccontract.RelationSupports && link.Attributes["control_id"] == "SOC2-CC6.1" {
+				return
+			}
+		case <-time.After(time.Second):
+			t.Fatal("stale control projection link was not removed")
+		}
 	}
 }
 
@@ -952,4 +1098,78 @@ func (s *processRunStore) ListQuestionnaireVendorRollups(context.Context, ports.
 
 func (s *processRunStore) ListQuestionnaireRunEvents(context.Context, ports.QuestionnaireRunEventFilter) ([]*ports.QuestionnaireRunEventRecord, error) {
 	return nil, nil
+}
+
+type failingQuestionnaireProjectionStore struct {
+	ports.StateStore
+	attempted chan struct{}
+}
+
+func (s failingQuestionnaireProjectionStore) UpsertProjectedEntity(context.Context, *ports.ProjectedEntity) error {
+	s.signal()
+	return errors.New("projection unavailable")
+}
+
+func (s failingQuestionnaireProjectionStore) UpsertProjectedLink(context.Context, *ports.ProjectedLink) error {
+	s.signal()
+	return errors.New("projection unavailable")
+}
+
+func (s failingQuestionnaireProjectionStore) signal() {
+	if s.attempted == nil {
+		return
+	}
+	select {
+	case s.attempted <- struct{}{}:
+	default:
+	}
+}
+
+type blockingQuestionnaireProjectionStore struct {
+	ports.StateStore
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s blockingQuestionnaireProjectionStore) UpsertProjectedEntity(ctx context.Context, _ *ports.ProjectedEntity) error {
+	if s.started != nil {
+		select {
+		case s.started <- struct{}{}:
+		default:
+		}
+	}
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s blockingQuestionnaireProjectionStore) UpsertProjectedLink(context.Context, *ports.ProjectedLink) error {
+	return nil
+}
+
+type recordingQuestionnaireProjectionStore struct {
+	ports.StateStore
+	deleted chan *ports.ProjectedLink
+}
+
+func (s recordingQuestionnaireProjectionStore) UpsertProjectedEntity(context.Context, *ports.ProjectedEntity) error {
+	return nil
+}
+
+func (s recordingQuestionnaireProjectionStore) UpsertProjectedLink(context.Context, *ports.ProjectedLink) error {
+	return nil
+}
+
+func (s recordingQuestionnaireProjectionStore) DeleteProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if s.deleted == nil {
+		return nil
+	}
+	select {
+	case s.deleted <- link:
+	default:
+	}
+	return nil
 }

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -931,6 +931,10 @@ func (s *processRunStore) SummarizeQuestionnaireRuns(context.Context, ports.Ques
 	return s.summary, nil
 }
 
+func (s *processRunStore) ListQuestionnaireVendorRollups(context.Context, ports.QuestionnaireVendorRollupFilter) ([]ports.QuestionnaireVendorRollupRecord, error) {
+	return nil, nil
+}
+
 func (s *processRunStore) ListQuestionnaireRunEvents(context.Context, ports.QuestionnaireRunEventFilter) ([]*ports.QuestionnaireRunEventRecord, error) {
 	return nil, nil
 }

--- a/internal/sourcehttp/questionnaire/intake_attachment.go
+++ b/internal/sourcehttp/questionnaire/intake_attachment.go
@@ -44,7 +44,7 @@ func createRunAttributes(request createRequest, questionCount int) map[string]st
 	attributes := map[string]string{}
 	for key, value := range request.Attributes {
 		if key = strings.TrimSpace(key); key != "" {
-			if key == "questionnaire_urn" {
+			if key == "questionnaire_urn" || key == "source_artifact_urn" {
 				continue
 			}
 			attributes[key] = strings.TrimSpace(value)

--- a/internal/sourcehttp/questionnaire/intake_attachment.go
+++ b/internal/sourcehttp/questionnaire/intake_attachment.go
@@ -44,6 +44,9 @@ func createRunAttributes(request createRequest, questionCount int) map[string]st
 	attributes := map[string]string{}
 	for key, value := range request.Attributes {
 		if key = strings.TrimSpace(key); key != "" {
+			if key == "questionnaire_urn" {
+				continue
+			}
 			attributes[key] = strings.TrimSpace(value)
 		}
 	}

--- a/internal/statestore/postgres/grc_vendor_test.go
+++ b/internal/statestore/postgres/grc_vendor_test.go
@@ -79,7 +79,7 @@ func TestQuestionnaireVendorRollupQueryBatchesVendors(t *testing.T) {
 		"vendor_urn IN ($2, $3)",
 		"due_at <= $4",
 		"status NOT IN ('approved', 'rejected')",
-		"jsonb_array_elements(assignments_json)",
+		"jsonb_array_elements(CASE WHEN jsonb_typeof(assignments_json) = 'array' THEN assignments_json ELSE '[]'::jsonb END)",
 		"GROUP BY vendor_urn",
 		"ORDER BY vendor_urn ASC",
 	} {
@@ -89,5 +89,44 @@ func TestQuestionnaireVendorRollupQueryBatchesVendors(t *testing.T) {
 	}
 	if len(args) != 4 || args[0] != "writer" || args[3] != now {
 		t.Fatalf("args = %#v, want tenant, two vendors, and cutoff", args)
+	}
+}
+
+func TestQuestionnaireRunOwnerFilterGuardsAssignmentJSONType(t *testing.T) {
+	clauses, args := questionnaireRunWhere(ports.QuestionnaireRunFilter{OwnerID: "security"})
+	query := strings.Join(clauses, "\n")
+	for _, fragment := range []string{
+		"jsonb_array_elements(CASE WHEN jsonb_typeof(assignments_json) = 'array' THEN assignments_json ELSE '[]'::jsonb END)",
+		"lower(assignment->>'owner_id') LIKE $1",
+		"lower(assignment->>'team') LIKE $1",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("questionnaire owner filter missing %q:\n%s", fragment, query)
+		}
+	}
+	if len(args) != 1 || args[0] != "%security%" {
+		t.Fatalf("args = %#v, want owner search arg", args)
+	}
+}
+
+func TestMarshalQuestionnaireRunJSONUsesArraysForNilSlices(t *testing.T) {
+	fields, err := marshalQuestionnaireRunJSON(ports.QuestionnaireRunRecord{})
+	if err != nil {
+		t.Fatalf("marshalQuestionnaireRunJSON() error = %v", err)
+	}
+	for label, value := range map[string]string{
+		"questions":   fields.questions,
+		"answers":     fields.answers,
+		"assignments": fields.assignments,
+		"decisions":   fields.decisions,
+		"comments":    fields.comments,
+		"timeline":    fields.timeline,
+	} {
+		if value != "[]" {
+			t.Fatalf("%s JSON = %q, want []", label, value)
+		}
+	}
+	if fields.attributes != "{}" {
+		t.Fatalf("attributes JSON = %q, want {}", fields.attributes)
 	}
 }

--- a/internal/statestore/postgres/grc_vendor_test.go
+++ b/internal/statestore/postgres/grc_vendor_test.go
@@ -76,10 +76,17 @@ func TestQuestionnaireVendorRollupQueryBatchesVendors(t *testing.T) {
 		Now:        now,
 	})
 	for _, fragment := range []string{
+		"WITH filtered AS",
+		"ROW_NUMBER() OVER",
+		"PARTITION BY vendor_urn, COALESCE(NULLIF(attributes_json->>'questionnaire_urn', ''), run_id)",
+		"current_questionnaires AS",
+		"WHERE questionnaire_rank = 1",
 		"vendor_urn IN ($2, $3)",
 		"due_at <= $4",
+		"CROSS JOIN LATERAL jsonb_array_elements(CASE WHEN jsonb_typeof(assignments_json) = 'array' THEN assignments_json ELSE '[]'::jsonb END)",
 		"status NOT IN ('approved', 'rejected')",
-		"jsonb_array_elements(CASE WHEN jsonb_typeof(assignments_json) = 'array' THEN assignments_json ELSE '[]'::jsonb END)",
+		"LEFT JOIN open_assignments USING (tenant_id, run_id)",
+		"COALESCE(open_assignments.open_assignment_count, 0)",
 		"GROUP BY vendor_urn",
 		"ORDER BY vendor_urn ASC",
 	} {

--- a/internal/statestore/postgres/grc_vendor_test.go
+++ b/internal/statestore/postgres/grc_vendor_test.go
@@ -3,6 +3,9 @@ package postgres
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestGRCVendorDiscoveryDecisionSchemaSerializesEvents(t *testing.T) {
@@ -62,5 +65,29 @@ func TestQuestionnaireRunAdvisoryLockSerializesUpserts(t *testing.T) {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("questionnaire run advisory lock query missing %q:\n%s", fragment, query)
 		}
+	}
+}
+
+func TestQuestionnaireVendorRollupQueryBatchesVendors(t *testing.T) {
+	now := time.Date(2026, 1, 20, 12, 0, 0, 0, time.UTC)
+	query, args := questionnaireVendorRollupQuery(ports.QuestionnaireVendorRollupFilter{
+		TenantID:   "writer",
+		VendorURNs: []string{"urn:cerebro:writer:vendor:one", "urn:cerebro:writer:vendor:two"},
+		Now:        now,
+	})
+	for _, fragment := range []string{
+		"vendor_urn IN ($2, $3)",
+		"due_at <= $4",
+		"status NOT IN ('approved', 'rejected')",
+		"jsonb_array_elements(assignments_json)",
+		"GROUP BY vendor_urn",
+		"ORDER BY vendor_urn ASC",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("questionnaire vendor rollup query missing %q:\n%s", fragment, query)
+		}
+	}
+	if len(args) != 4 || args[0] != "writer" || args[3] != now {
+		t.Fatalf("args = %#v, want tenant, two vendors, and cutoff", args)
 	}
 }

--- a/internal/statestore/postgres/questionnaire.go
+++ b/internal/statestore/postgres/questionnaire.go
@@ -328,36 +328,61 @@ func questionnaireVendorRollupQuery(filter ports.QuestionnaireVendorRollupFilter
 	activeRun := "status NOT IN ('approved', 'rejected')"
 	// #nosec G201 -- clauses are fixed column predicates and values remain parameterized.
 	query := fmt.Sprintf(`
+WITH filtered AS (
+	SELECT *
+	FROM grc_questionnaire_runs
+	WHERE %s
+),
+ranked AS (
+	SELECT
+	  filtered.*,
+	  %s AS questionnaire_id,
+	  ROW_NUMBER() OVER (
+	    PARTITION BY vendor_urn, %s
+	    ORDER BY updated_at DESC, run_id DESC
+	  ) AS questionnaire_rank
+	FROM filtered
+),
+current_questionnaires AS (
+	SELECT *
+	FROM ranked
+	WHERE questionnaire_rank = 1
+),
+open_assignments AS (
+	SELECT current_questionnaires.tenant_id, current_questionnaires.run_id, COUNT(*) AS open_assignment_count
+	FROM current_questionnaires
+	CROSS JOIN LATERAL jsonb_array_elements(%s) AS assignment
+	WHERE %s
+	  AND (COALESCE(assignment->>'status', '') = '' OR assignment->>'status' = 'open')
+	GROUP BY current_questionnaires.tenant_id, current_questionnaires.run_id
+)
 SELECT
   vendor_urn,
-  COUNT(DISTINCT %s),
-  COUNT(DISTINCT CASE WHEN due_at IS NOT NULL AND due_at <= $%d AND %s THEN %s END),
+  COUNT(DISTINCT questionnaire_id),
+  COUNT(DISTINCT CASE WHEN due_at IS NOT NULL AND due_at <= $%d AND %s THEN questionnaire_id END),
   COALESCE(SUM(CASE WHEN %s THEN ready_answer_count ELSE 0 END), 0),
   COALESCE(SUM(CASE WHEN %s THEN blocked_answer_count ELSE 0 END), 0),
   COALESCE(SUM(CASE WHEN %s THEN review_answer_count ELSE 0 END), 0),
   COALESCE(SUM(CASE WHEN %s THEN missing_evidence_count ELSE 0 END), 0),
   COALESCE(SUM(CASE WHEN %s THEN stale_evidence_count ELSE 0 END), 0),
-	  COALESCE(SUM(CASE WHEN %s THEN (
-	    SELECT COUNT(*)
-	    FROM jsonb_array_elements(%s) AS assignment
-	    WHERE COALESCE(assignment->>'status', '') = '' OR assignment->>'status' = 'open'
-	  ) ELSE 0 END), 0)
-FROM grc_questionnaire_runs
-WHERE %s
+  COALESCE(SUM(CASE WHEN %s THEN COALESCE(open_assignments.open_assignment_count, 0) ELSE 0 END), 0)
+FROM current_questionnaires
+LEFT JOIN open_assignments USING (tenant_id, run_id)
 GROUP BY vendor_urn
 ORDER BY vendor_urn ASC`,
+		strings.Join(clauses, " AND "),
 		questionnaireID,
+		questionnaireID,
+		questionnaireAssignmentsArraySQL(),
+		activeRun,
 		nowPlaceholder,
 		activeRun,
-		questionnaireID,
 		activeRun,
 		activeRun,
 		activeRun,
 		activeRun,
 		activeRun,
-		activeRun,
-		questionnaireAssignmentsArraySQL(),
-		strings.Join(clauses, " AND "))
+		activeRun)
 	return query, args
 }
 

--- a/internal/statestore/postgres/questionnaire.go
+++ b/internal/statestore/postgres/questionnaire.go
@@ -276,6 +276,90 @@ WHERE %s`, strings.Join(clauses, " AND "))
 	return summary, nil
 }
 
+func (s *Store) ListQuestionnaireVendorRollups(ctx context.Context, filter ports.QuestionnaireVendorRollupFilter) ([]ports.QuestionnaireVendorRollupRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureQuestionnaireRunTables(ctx); err != nil {
+		return nil, err
+	}
+	filter.VendorURNs = normalizedNonEmptyStrings(filter.VendorURNs)
+	if len(filter.VendorURNs) == 0 {
+		return nil, nil
+	}
+	if filter.Now.IsZero() {
+		filter.Now = time.Now().UTC()
+	}
+	query, args := questionnaireVendorRollupQuery(filter)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list questionnaire vendor rollups: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := []ports.QuestionnaireVendorRollupRecord{}
+	for rows.Next() {
+		var record ports.QuestionnaireVendorRollupRecord
+		if err := rows.Scan(
+			&record.VendorURN,
+			&record.QuestionnaireCount,
+			&record.DueQuestionnaires,
+			&record.ReadyAnswers,
+			&record.BlockedAnswers,
+			&record.ReviewAnswers,
+			&record.MissingEvidence,
+			&record.StaleEvidence,
+			&record.OpenAssignments,
+		); err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func questionnaireVendorRollupQuery(filter ports.QuestionnaireVendorRollupFilter) (string, []any) {
+	clauses := []string{"vendor_urn <> ''"}
+	args := []any{}
+	addTextFilter(&clauses, &args, "tenant_id", filter.TenantID)
+	addStringInFilter(&clauses, &args, "vendor_urn", filter.VendorURNs)
+	args = append(args, filter.Now)
+	nowPlaceholder := len(args)
+	questionnaireID := "COALESCE(NULLIF(attributes_json->>'questionnaire_urn', ''), run_id)"
+	activeRun := "status NOT IN ('approved', 'rejected')"
+	// #nosec G201 -- clauses are fixed column predicates and values remain parameterized.
+	query := fmt.Sprintf(`
+SELECT
+  vendor_urn,
+  COUNT(DISTINCT %s),
+  COUNT(DISTINCT CASE WHEN due_at IS NOT NULL AND due_at <= $%d AND %s THEN %s END),
+  COALESCE(SUM(CASE WHEN %s THEN ready_answer_count ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN %s THEN blocked_answer_count ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN %s THEN review_answer_count ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN %s THEN missing_evidence_count ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN %s THEN stale_evidence_count ELSE 0 END), 0),
+  COALESCE(SUM(CASE WHEN %s THEN (
+    SELECT COUNT(*)
+    FROM jsonb_array_elements(assignments_json) AS assignment
+    WHERE COALESCE(assignment->>'status', '') = '' OR assignment->>'status' = 'open'
+  ) ELSE 0 END), 0)
+FROM grc_questionnaire_runs
+WHERE %s
+GROUP BY vendor_urn
+ORDER BY vendor_urn ASC`,
+		questionnaireID,
+		nowPlaceholder,
+		activeRun,
+		questionnaireID,
+		activeRun,
+		activeRun,
+		activeRun,
+		activeRun,
+		activeRun,
+		activeRun,
+		strings.Join(clauses, " AND "))
+	return query, args
+}
+
 func questionnaireRunWhere(filter ports.QuestionnaireRunFilter) ([]string, []any) {
 	clauses := []string{"1=1"}
 	args := []any{}

--- a/internal/statestore/postgres/questionnaire.go
+++ b/internal/statestore/postgres/questionnaire.go
@@ -337,11 +337,11 @@ SELECT
   COALESCE(SUM(CASE WHEN %s THEN review_answer_count ELSE 0 END), 0),
   COALESCE(SUM(CASE WHEN %s THEN missing_evidence_count ELSE 0 END), 0),
   COALESCE(SUM(CASE WHEN %s THEN stale_evidence_count ELSE 0 END), 0),
-  COALESCE(SUM(CASE WHEN %s THEN (
-    SELECT COUNT(*)
-    FROM jsonb_array_elements(assignments_json) AS assignment
-    WHERE COALESCE(assignment->>'status', '') = '' OR assignment->>'status' = 'open'
-  ) ELSE 0 END), 0)
+	  COALESCE(SUM(CASE WHEN %s THEN (
+	    SELECT COUNT(*)
+	    FROM jsonb_array_elements(%s) AS assignment
+	    WHERE COALESCE(assignment->>'status', '') = '' OR assignment->>'status' = 'open'
+	  ) ELSE 0 END), 0)
 FROM grc_questionnaire_runs
 WHERE %s
 GROUP BY vendor_urn
@@ -356,8 +356,13 @@ ORDER BY vendor_urn ASC`,
 		activeRun,
 		activeRun,
 		activeRun,
+		questionnaireAssignmentsArraySQL(),
 		strings.Join(clauses, " AND "))
 	return query, args
+}
+
+func questionnaireAssignmentsArraySQL() string {
+	return "CASE WHEN jsonb_typeof(assignments_json) = 'array' THEN assignments_json ELSE '[]'::jsonb END"
 }
 
 func questionnaireRunWhere(filter ports.QuestionnaireRunFilter) ([]string, []any) {
@@ -373,13 +378,13 @@ func questionnaireRunWhere(filter ports.QuestionnaireRunFilter) ([]string, []any
 	if ownerID := strings.TrimSpace(filter.OwnerID); ownerID != "" {
 		args = append(args, "%"+strings.ToLower(ownerID)+"%")
 		clauses = append(clauses, fmt.Sprintf(`(
-			lower(owner_id) LIKE $%d
-			OR lower(assigned_team) LIKE $%d
-			OR EXISTS (
-				SELECT 1 FROM jsonb_array_elements(assignments_json) AS assignment
-				WHERE lower(assignment->>'owner_id') LIKE $%d OR lower(assignment->>'team') LIKE $%d
-			)
-		)`, len(args), len(args), len(args), len(args)))
+				lower(owner_id) LIKE $%d
+				OR lower(assigned_team) LIKE $%d
+				OR EXISTS (
+					SELECT 1 FROM jsonb_array_elements(%s) AS assignment
+					WHERE lower(assignment->>'owner_id') LIKE $%d OR lower(assignment->>'team') LIKE $%d
+				)
+			)`, len(args), len(args), questionnaireAssignmentsArraySQL(), len(args), len(args)))
 	}
 	if query := strings.TrimSpace(filter.Query); query != "" {
 		args = append(args, "%"+strings.ToLower(query)+"%")
@@ -459,28 +464,35 @@ func marshalQuestionnaireRunJSON(record ports.QuestionnaireRunRecord) (questionn
 	}
 	var fields questionnaireRunJSONFields
 	var err error
-	if fields.questions, err = marshal("questions", record.Questions); err != nil {
+	if fields.questions, err = marshal("questions", emptySlice(record.Questions)); err != nil {
 		return fields, err
 	}
-	if fields.answers, err = marshal("answers", record.Answers); err != nil {
+	if fields.answers, err = marshal("answers", emptySlice(record.Answers)); err != nil {
 		return fields, err
 	}
-	if fields.assignments, err = marshal("assignments", record.Assignments); err != nil {
+	if fields.assignments, err = marshal("assignments", emptySlice(record.Assignments)); err != nil {
 		return fields, err
 	}
-	if fields.decisions, err = marshal("decisions", record.Decisions); err != nil {
+	if fields.decisions, err = marshal("decisions", emptySlice(record.Decisions)); err != nil {
 		return fields, err
 	}
-	if fields.comments, err = marshal("comments", record.Comments); err != nil {
+	if fields.comments, err = marshal("comments", emptySlice(record.Comments)); err != nil {
 		return fields, err
 	}
-	if fields.timeline, err = marshal("timeline", record.Timeline); err != nil {
+	if fields.timeline, err = marshal("timeline", emptySlice(record.Timeline)); err != nil {
 		return fields, err
 	}
 	if fields.attributes, err = marshal("attributes", emptyStringMap(record.Attributes)); err != nil {
 		return fields, err
 	}
 	return fields, nil
+}
+
+func emptySlice[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
 }
 
 func scanQuestionnaireRun(row scanner) (*ports.QuestionnaireRunRecord, error) {


### PR DESCRIPTION
## Summary
- Mint a stable questionnaire URN for each questionnaire record and project questionnaire work as `security.questionnaire` graph artifacts.
- Link questionnaire artifacts to vendors, owners, controls, evidence resources, and source artifacts, including stale-link cleanup on updates.
- Roll operational questionnaire counts back into vendor posture and queue actions without putting domain counting logic in bootstrap.
- Carry citation resource URNs, evidence types, gap review state, and assignment gap/slot IDs through the public contract.

## Validation
- `go test ./internal/grcvendor ./internal/bootstrap ./internal/sourcehttp/questionnaire ./internal/questionnaire ./tools/archtests`
- `go test ./...`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->