### PR TITLE
[codex] Deepen questionnaire graph provenance

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6692,6 +6692,18 @@ components:
           type: string
         runtime_id:
           type: string
+        source_event_ids:
+          type: array
+          items:
+            type: string
+        graph_root_urns:
+          type: array
+          items:
+            type: string
+        graph_path_ids:
+          type: array
+          items:
+            type: string
         freshness:
           $ref: '#/components/schemas/GRCEvidenceFreshness'
         review_state:
@@ -11815,6 +11827,37 @@ components:
         review_state:
           type: string
           enum: [ready, needs_review, blocked, approved, rejected]
+        source_locator:
+          $ref: '#/components/schemas/GRCQuestionnaireSourceLocator'
+    GRCQuestionnaireSourceLocator:
+      type: object
+      properties:
+        source_artifact_urn:
+          type: string
+        source_format:
+          type: string
+        source_filename:
+          type: string
+        sheet_name:
+          type: string
+        cell:
+          type: string
+        column_name:
+          type: string
+        row_number:
+          type: integer
+        line_number:
+          type: integer
+        page_number:
+          type: integer
+        text:
+          type: string
+        portal_url:
+          type: string
+        portal_field_id:
+          type: string
+        portal_field_label:
+          type: string
     GRCQuestionnaireEvidenceSlot:
       type: object
       properties:
@@ -11844,6 +11887,10 @@ components:
           type: string
         source:
           type: string
+        source_id:
+          type: string
+        runtime_id:
+          type: string
         resource_urn:
           type: string
         evidence_packet_id:
@@ -11860,6 +11907,18 @@ components:
           type: string
         expires_at:
           type: string
+        source_event_ids:
+          type: array
+          items:
+            type: string
+        graph_root_urns:
+          type: array
+          items:
+            type: string
+        graph_path_ids:
+          type: array
+          items:
+            type: string
     GRCQuestionnaireRunEvidenceGap:
       type: object
       properties:
@@ -12243,6 +12302,8 @@ components:
             type: string
         owner_id:
           type: string
+        source_locator:
+          $ref: '#/components/schemas/GRCQuestionnaireSourceLocator'
     GRCQuestionnaireProcessRunRequest:
       type: object
       properties:

--- a/api/openapi_questionnaire_runs_test.go
+++ b/api/openapi_questionnaire_runs_test.go
@@ -41,6 +41,7 @@ func TestQuestionnaireRunRoutesDocumentUnifiedQueueContract(t *testing.T) {
 		"GRCQuestionnaireRunAnswer:",
 		"GRCQuestionnaireEvidenceSlot:",
 		"GRCQuestionnaireCitation:",
+		"GRCQuestionnaireSourceLocator:",
 		"GRCQuestionnaireRunEvidenceGap:",
 		"GRCQuestionnaireQuestionUpdateRequest:",
 		"GRCQuestionnaireVendorLinkRequest:",

--- a/internal/evidencepackets/packets.go
+++ b/internal/evidencepackets/packets.go
@@ -483,6 +483,9 @@ type QuestionnaireEvidenceRef struct {
 	Freshness        EvidenceFreshness `json:"freshness"`
 	ReviewState      string            `json:"review_state,omitempty"`
 	Citations        EvidenceCitations `json:"citations"`
+	SourceEventIDs   []string          `json:"source_event_ids,omitempty"`
+	GraphRootURNs    []string          `json:"graph_root_urns,omitempty"`
+	GraphPathIDs     []string          `json:"graph_path_ids,omitempty"`
 }
 
 type QuestionnaireEvidenceGap struct {
@@ -1450,6 +1453,9 @@ func answerEvidenceRefs(packets []EvidencePacket, itemsByEvidenceID map[string]E
 				Freshness:        packet.Freshness,
 				ReviewState:      packet.Review.Status,
 				Citations:        packet.Citations,
+				SourceEventIDs:   uniqueSortedStrings(append(append([]string(nil), packet.Citations.EventIDs...), item.EventIDs...)),
+				GraphRootURNs:    uniqueSortedStrings(append(append([]string(nil), packet.Citations.GraphRoots...), item.GraphRoots...)),
+				GraphPathIDs:     uniqueSortedStrings(item.GraphPaths),
 			})
 		}
 	}

--- a/internal/evidencepackets/packets_test.go
+++ b/internal/evidencepackets/packets_test.go
@@ -304,6 +304,7 @@ func TestBuildAddsEvidenceBackedQuestionnaireAnswers(t *testing.T) {
 			ClaimIds:       []string{"claim-okta"},
 			EventIds:       []string{"event-okta"},
 			GraphRootUrns:  []string{"urn:cerebro:test:identity:admin"},
+			GraphPathUrns:  []string{"urn:cerebro:test:okta:principal:00u123", "urn:cerebro:test:okta:application:payroll"},
 			LastObservedAt: timestamppb.New(observedAt),
 		}, {
 			Id:             "ev-policy",
@@ -341,6 +342,11 @@ func TestBuildAddsEvidenceBackedQuestionnaireAnswers(t *testing.T) {
 	}
 	if len(supported.SourceEvidence) != 1 || supported.SourceEvidence[0].SourceID != "okta" {
 		t.Fatalf("source evidence = %#v, want Okta source evidence", supported.SourceEvidence)
+	}
+	if !containsString(supported.SourceEvidence[0].SourceEventIDs, "event-okta") ||
+		!containsString(supported.SourceEvidence[0].GraphRootURNs, "urn:cerebro:test:identity:admin") ||
+		!containsString(supported.SourceEvidence[0].GraphPathIDs, "urn:cerebro:test:okta:application:payroll") {
+		t.Fatalf("source evidence provenance = %#v, want graph source provenance", supported.SourceEvidence[0])
 	}
 	if len(supported.PolicyDocuments) != 1 || supported.PolicyDocuments[0].SourceID != "grc" {
 		t.Fatalf("policy documents = %#v, want policy document evidence", supported.PolicyDocuments)

--- a/internal/ports/questionnaire.go
+++ b/internal/ports/questionnaire.go
@@ -104,16 +104,33 @@ type QuestionnaireRunMetadata struct {
 }
 
 type QuestionnaireQuestion struct {
-	ID                   string   `json:"id"`
-	Question             string   `json:"question"`
-	NormalizedQuestion   string   `json:"normalized_question,omitempty"`
-	Section              string   `json:"section,omitempty"`
-	RequiredAnswerFormat string   `json:"required_answer_format,omitempty"`
-	MappedControls       []string `json:"mapped_controls,omitempty"`
-	RequiredSlots        []string `json:"required_evidence_slots,omitempty"`
-	OwnerID              string   `json:"owner_id,omitempty"`
-	AnswerState          string   `json:"answer_state"`
-	ReviewState          string   `json:"review_state"`
+	ID                   string                      `json:"id"`
+	Question             string                      `json:"question"`
+	NormalizedQuestion   string                      `json:"normalized_question,omitempty"`
+	Section              string                      `json:"section,omitempty"`
+	RequiredAnswerFormat string                      `json:"required_answer_format,omitempty"`
+	MappedControls       []string                    `json:"mapped_controls,omitempty"`
+	RequiredSlots        []string                    `json:"required_evidence_slots,omitempty"`
+	OwnerID              string                      `json:"owner_id,omitempty"`
+	AnswerState          string                      `json:"answer_state"`
+	ReviewState          string                      `json:"review_state"`
+	SourceLocator        *QuestionnaireSourceLocator `json:"source_locator,omitempty"`
+}
+
+type QuestionnaireSourceLocator struct {
+	SourceArtifactURN string `json:"source_artifact_urn,omitempty"`
+	SourceFormat      string `json:"source_format,omitempty"`
+	SourceFilename    string `json:"source_filename,omitempty"`
+	SheetName         string `json:"sheet_name,omitempty"`
+	Cell              string `json:"cell,omitempty"`
+	ColumnName        string `json:"column_name,omitempty"`
+	RowNumber         int    `json:"row_number,omitempty"`
+	LineNumber        int    `json:"line_number,omitempty"`
+	PageNumber        int    `json:"page_number,omitempty"`
+	Text              string `json:"text,omitempty"`
+	PortalURL         string `json:"portal_url,omitempty"`
+	PortalFieldID     string `json:"portal_field_id,omitempty"`
+	PortalFieldLabel  string `json:"portal_field_label,omitempty"`
 }
 
 type QuestionnaireRunAnswer struct {
@@ -147,17 +164,22 @@ type QuestionnaireEvidenceSlot struct {
 }
 
 type QuestionnaireCitation struct {
-	ID               string `json:"id"`
-	Label            string `json:"label,omitempty"`
-	Source           string `json:"source,omitempty"`
-	ResourceURN      string `json:"resource_urn,omitempty"`
-	EvidencePacketID string `json:"evidence_packet_id,omitempty"`
-	EvidenceID       string `json:"evidence_id,omitempty"`
-	EvidenceType     string `json:"evidence_type,omitempty"`
-	ControlID        string `json:"control_id,omitempty"`
-	FreshnessStatus  string `json:"freshness_status,omitempty"`
-	ObservedAt       string `json:"observed_at,omitempty"`
-	ExpiresAt        string `json:"expires_at,omitempty"`
+	ID               string   `json:"id"`
+	Label            string   `json:"label,omitempty"`
+	Source           string   `json:"source,omitempty"`
+	SourceID         string   `json:"source_id,omitempty"`
+	RuntimeID        string   `json:"runtime_id,omitempty"`
+	ResourceURN      string   `json:"resource_urn,omitempty"`
+	EvidencePacketID string   `json:"evidence_packet_id,omitempty"`
+	EvidenceID       string   `json:"evidence_id,omitempty"`
+	EvidenceType     string   `json:"evidence_type,omitempty"`
+	ControlID        string   `json:"control_id,omitempty"`
+	FreshnessStatus  string   `json:"freshness_status,omitempty"`
+	ObservedAt       string   `json:"observed_at,omitempty"`
+	ExpiresAt        string   `json:"expires_at,omitempty"`
+	SourceEventIDs   []string `json:"source_event_ids,omitempty"`
+	GraphRootURNs    []string `json:"graph_root_urns,omitempty"`
+	GraphPathIDs     []string `json:"graph_path_ids,omitempty"`
 }
 
 type QuestionnaireEvidenceGap struct {

--- a/internal/questionnaire/projection.go
+++ b/internal/questionnaire/projection.go
@@ -68,69 +68,64 @@ func graphProjectionForRecord(record ports.QuestionnaireRunRecord, at time.Time)
 	sourceID := projectionSourceID(record)
 	runtimeID := strings.TrimSpace(record.RuntimeID)
 	questionnaireURN := strings.TrimSpace(record.Attributes[QuestionnaireAttributeQuestionnaireURN])
-	entities := []*ports.ProjectedEntity{
-		{
-			URN:        questionnaireURN,
-			TenantID:   record.TenantID,
-			SourceID:   sourceID,
-			RuntimeID:  runtimeID,
-			EntityType: "security.questionnaire",
-			Label:      firstNonEmpty(record.Title, record.SourceFilename, record.RunID),
-			Attributes: questionnaireEntityAttributes(record, at),
-		},
-	}
+	entities := []*ports.ProjectedEntity{}
 	links := []*ports.ProjectedLink{}
-	addLink := func(toURN string, relation string, attrs map[string]string) {
+	addEntity := func(entity *ports.ProjectedEntity) {
+		if entity == nil || strings.TrimSpace(entity.URN) == "" {
+			return
+		}
+		entities = append(entities, entity)
+	}
+	addEdge := func(fromURN string, toURN string, relation string, attrs map[string]string) {
+		fromURN = strings.TrimSpace(fromURN)
 		toURN = strings.TrimSpace(toURN)
-		if questionnaireURN == "" || toURN == "" || relation == "" {
+		if fromURN == "" || toURN == "" || relation == "" {
 			return
 		}
 		links = append(links, &ports.ProjectedLink{
 			TenantID:   record.TenantID,
 			SourceID:   sourceID,
 			RuntimeID:  runtimeID,
-			FromURN:    questionnaireURN,
+			FromURN:    fromURN,
 			ToURN:      toURN,
 			Relation:   relation,
 			Attributes: compactProjectionAttributes(attrs),
 		})
 	}
-	if vendorURN := strings.TrimSpace(record.VendorURN); vendorURN != "" {
-		addLink(vendorURN, fabriccontract.RelationAssociatedWith, map[string]string{
-			"match_type":           "questionnaire_vendor_link",
-			"questionnaire_run_id": record.RunID,
-			"questionnaire_urn":    questionnaireURN,
-			"vendor_id":            record.VendorID,
-			"direction":            record.Direction,
-			"vendor_link_status":   record.Attributes["vendor_link_status"],
-			"vendor_link_reason":   record.Attributes["vendor_link_reason"],
-		})
+	addLink := func(toURN string, relation string, attrs map[string]string) {
+		addEdge(questionnaireURN, toURN, relation, attrs)
 	}
-	if owner := strings.TrimSpace(record.OwnerID); owner != "" {
-		ownerURN := ownerEntityURN(record.TenantID, owner)
-		if ownerURN != "" {
-			entities = append(entities, &ports.ProjectedEntity{
-				URN:        ownerURN,
-				TenantID:   record.TenantID,
-				SourceID:   sourceID,
-				RuntimeID:  runtimeID,
-				EntityType: "grc.user",
-				Label:      owner,
-				Attributes: map[string]string{
-					"owner_id":      owner,
-					"source_system": QuestionnaireProjectionSourceID,
-				},
-			})
-			addLink(ownerURN, fabriccontract.RelationOwnedBy, map[string]string{"owner_id": owner, "match_type": "questionnaire_owner"})
+	addOwnerEntity := func(owner string) string {
+		owner = strings.TrimSpace(owner)
+		if owner == "" {
+			return ""
 		}
+		ownerURN := ownerEntityURN(record.TenantID, owner)
+		if ownerURN == "" {
+			return ""
+		}
+		addEntity(&ports.ProjectedEntity{
+			URN:        ownerURN,
+			TenantID:   record.TenantID,
+			SourceID:   sourceID,
+			RuntimeID:  runtimeID,
+			EntityType: "grc.user",
+			Label:      owner,
+			Attributes: map[string]string{
+				"owner_id":      owner,
+				"source_system": QuestionnaireProjectionSourceID,
+			},
+		})
+		return ownerURN
 	}
-	for _, controlID := range questionnaireControlIDs(record) {
+	addControlEntity := func(controlID string) string {
+		controlID = strings.TrimSpace(controlID)
 		controlURN := controlEntityURN(record.TenantID, controlID)
 		if controlURN == "" {
-			continue
+			return ""
 		}
 		if !strings.HasPrefix(controlID, "urn:cerebro:") {
-			entities = append(entities, &ports.ProjectedEntity{
+			addEntity(&ports.ProjectedEntity{
 				URN:        controlURN,
 				TenantID:   record.TenantID,
 				SourceID:   sourceID,
@@ -143,14 +138,14 @@ func graphProjectionForRecord(record ports.QuestionnaireRunRecord, at time.Time)
 				},
 			})
 		}
-		addLink(controlURN, fabriccontract.RelationSupports, map[string]string{"control_id": controlID, "match_type": "questionnaire_control_mapping"})
+		return controlURN
 	}
-	for _, citation := range questionnaireCitations(record) {
+	addEvidenceEntity := func(citation ports.QuestionnaireCitation) string {
 		evidenceURN := citationResourceURN(record.TenantID, citation)
 		if evidenceURN == "" {
-			continue
+			return ""
 		}
-		entities = append(entities, &ports.ProjectedEntity{
+		addEntity(&ports.ProjectedEntity{
 			URN:        evidenceURN,
 			TenantID:   record.TenantID,
 			SourceID:   sourceID,
@@ -158,25 +153,338 @@ func graphProjectionForRecord(record ports.QuestionnaireRunRecord, at time.Time)
 			EntityType: "runtime_evidence",
 			Label:      firstNonEmpty(citation.Label, citation.EvidenceID, citation.EvidencePacketID, citation.ID),
 			Attributes: compactProjectionAttributes(map[string]string{
+				"citation_id":        citation.ID,
 				"evidence_id":        citation.EvidenceID,
 				"evidence_packet_id": citation.EvidencePacketID,
 				"evidence_type":      citation.EvidenceType,
+				"control_id":         citation.ControlID,
 				"freshness_status":   citation.FreshnessStatus,
 				"observed_at":        citation.ObservedAt,
 				"expires_at":         citation.ExpiresAt,
+				"source_id":          citation.SourceID,
+				"runtime_id":         citation.RuntimeID,
+				"source_event_ids":   joinProjectionValues(citation.SourceEventIDs),
+				"graph_root_urns":    joinProjectionValues(citation.GraphRootURNs),
+				"graph_path_ids":     joinProjectionValues(citation.GraphPathIDs),
 				"source_system":      QuestionnaireProjectionSourceID,
 			}),
 		})
-		addLink(evidenceURN, fabriccontract.RelationHasEvidence, map[string]string{
-			"citation_id":        citation.ID,
-			"evidence_id":        citation.EvidenceID,
-			"evidence_packet_id": citation.EvidencePacketID,
-			"evidence_type":      citation.EvidenceType,
-			"match_type":         "questionnaire_answer_citation",
+		return evidenceURN
+	}
+	addEntity(&ports.ProjectedEntity{
+		URN:        questionnaireURN,
+		TenantID:   record.TenantID,
+		SourceID:   sourceID,
+		RuntimeID:  runtimeID,
+		EntityType: "security.questionnaire",
+		Label:      firstNonEmpty(record.Title, record.SourceFilename, record.RunID),
+		Attributes: questionnaireEntityAttributes(record, at),
+	})
+	if vendorURN := strings.TrimSpace(record.VendorURN); vendorURN != "" {
+		addLink(vendorURN, fabriccontract.RelationAssociatedWith, map[string]string{
+			"match_type":           "questionnaire_vendor_link",
+			"questionnaire_run_id": record.RunID,
+			"questionnaire_urn":    questionnaireURN,
+			"vendor_id":            record.VendorID,
+			"direction":            record.Direction,
+			"vendor_link_status":   record.Attributes["vendor_link_status"],
+			"vendor_link_reason":   record.Attributes["vendor_link_reason"],
 		})
+	}
+	if owner := strings.TrimSpace(record.OwnerID); owner != "" {
+		ownerURN := addOwnerEntity(owner)
+		if ownerURN != "" {
+			addLink(ownerURN, fabriccontract.RelationOwnedBy, map[string]string{"owner_id": owner, "match_type": "questionnaire_owner"})
+		}
+	}
+	for _, controlID := range questionnaireControlIDs(record) {
+		controlURN := addControlEntity(controlID)
+		if controlURN == "" {
+			continue
+		}
+		addLink(controlURN, fabriccontract.RelationSupports, map[string]string{"control_id": controlID, "match_type": "questionnaire_control_mapping"})
+	}
+	for _, citation := range questionnaireCitations(record) {
+		evidenceURN := addEvidenceEntity(citation)
+		if evidenceURN == "" {
+			continue
+		}
+		addLink(evidenceURN, fabriccontract.RelationHasEvidence, citationLinkAttributes(citation, "questionnaire_answer_citation"))
 	}
 	if sourceArtifactURN := strings.TrimSpace(record.Attributes[QuestionnaireAttributeSourceArtifactURN]); isSourceArtifactURN(record.TenantID, sourceArtifactURN) {
 		addLink(sourceArtifactURN, fabriccontract.RelationAssociatedWith, map[string]string{"match_type": "questionnaire_source_artifact"})
+	}
+
+	questionURNsByID := map[string]string{}
+	questionURNsByRef := map[string]string{}
+	for _, question := range record.Questions {
+		questionRefID := questionnaireQuestionRefID(question)
+		questionURN := questionnaireQuestionURN(record.TenantID, record.RunID, questionRefID)
+		if questionURN == "" {
+			continue
+		}
+		if strings.TrimSpace(question.ID) != "" {
+			questionURNsByID[strings.TrimSpace(question.ID)] = questionURN
+		}
+		questionURNsByRef[questionRefID] = questionURN
+		addEntity(&ports.ProjectedEntity{
+			URN:        questionURN,
+			TenantID:   record.TenantID,
+			SourceID:   sourceID,
+			RuntimeID:  runtimeID,
+			EntityType: "questionnaire.question",
+			Label:      projectionLabel(firstNonEmpty(question.Question, question.ID)),
+			Attributes: questionEntityAttributes(record, question),
+		})
+		addEdge(questionnaireURN, questionURN, fabriccontract.RelationContains, map[string]string{
+			"match_type":           "questionnaire_question",
+			"questionnaire_run_id": record.RunID,
+			"question_id":          question.ID,
+		})
+		for _, controlID := range question.MappedControls {
+			controlURN := addControlEntity(controlID)
+			if controlURN == "" {
+				continue
+			}
+			addEdge(questionURN, controlURN, fabriccontract.RelationSupports, map[string]string{
+				"match_type":           "question_control_mapping",
+				"questionnaire_run_id": record.RunID,
+				"question_id":          question.ID,
+				"control_id":           controlID,
+			})
+		}
+		if ownerURN := addOwnerEntity(question.OwnerID); ownerURN != "" {
+			addEdge(questionURN, ownerURN, fabriccontract.RelationOwnedBy, map[string]string{
+				"match_type":           "question_owner",
+				"questionnaire_run_id": record.RunID,
+				"question_id":          question.ID,
+				"owner_id":             question.OwnerID,
+			})
+		}
+		if sourceArtifactURN := questionSourceArtifactURN(record, question); sourceArtifactURN != "" {
+			addEdge(questionURN, sourceArtifactURN, fabriccontract.RelationHasContext, mergeProjectionAttributes(sourceLocatorAttributes(question.SourceLocator), map[string]string{
+				"match_type":           "question_source_locator",
+				"questionnaire_run_id": record.RunID,
+				"question_id":          question.ID,
+			}))
+		}
+	}
+
+	slotURNsByKey := map[string]string{}
+	slotURNsByID := map[string]string{}
+	gapURNsByID := map[string]string{}
+	for _, answer := range record.Answers {
+		answerRefID := questionnaireAnswerRefID(answer)
+		answerURN := questionnaireAnswerURN(record.TenantID, record.RunID, answer.QuestionID, answerRefID)
+		if answerURN == "" {
+			continue
+		}
+		questionURN := questionURNForAnswer(answer, questionURNsByID, questionURNsByRef)
+		addEntity(&ports.ProjectedEntity{
+			URN:        answerURN,
+			TenantID:   record.TenantID,
+			SourceID:   sourceID,
+			RuntimeID:  runtimeID,
+			EntityType: "questionnaire.answer",
+			Label:      projectionLabel(firstNonEmpty(answer.Question, answer.ID)),
+			Attributes: answerEntityAttributes(record, answer),
+		})
+		addEdge(questionnaireURN, answerURN, fabriccontract.RelationContains, map[string]string{
+			"match_type":           "questionnaire_answer",
+			"questionnaire_run_id": record.RunID,
+			"question_id":          answer.QuestionID,
+			"answer_id":            answer.ID,
+		})
+		if questionURN != "" {
+			addEdge(answerURN, questionURN, fabriccontract.RelationAttachedTo, map[string]string{
+				"match_type":           "answer_question",
+				"questionnaire_run_id": record.RunID,
+				"question_id":          answer.QuestionID,
+				"answer_id":            answer.ID,
+			})
+		}
+		for _, controlID := range answerControlIDs(answer) {
+			controlURN := addControlEntity(controlID)
+			if controlURN == "" {
+				continue
+			}
+			addEdge(answerURN, controlURN, fabriccontract.RelationSupports, map[string]string{
+				"match_type":           "answer_control_mapping",
+				"questionnaire_run_id": record.RunID,
+				"question_id":          answer.QuestionID,
+				"answer_id":            answer.ID,
+				"control_id":           controlID,
+			})
+		}
+
+		citationURNs := map[string]string{}
+		for _, citation := range answer.Citations {
+			evidenceURN := addEvidenceEntity(citation)
+			if evidenceURN == "" {
+				continue
+			}
+			for _, citationKey := range citationLookupKeys(citation) {
+				citationURNs[citationKey] = evidenceURN
+			}
+			addEdge(answerURN, evidenceURN, fabriccontract.RelationHasEvidence, citationLinkAttributes(citation, "answer_evidence"))
+			for _, graphRootURN := range citation.GraphRootURNs {
+				graphRootURN = strings.TrimSpace(graphRootURN)
+				if !isSameTenantCerebroURN(record.TenantID, graphRootURN) {
+					continue
+				}
+				addEdge(answerURN, graphRootURN, fabriccontract.RelationHasContext, compactProjectionAttributes(map[string]string{
+					"match_type":           "answer_graph_root",
+					"questionnaire_run_id": record.RunID,
+					"question_id":          answer.QuestionID,
+					"answer_id":            answer.ID,
+					"citation_id":          citation.ID,
+					"source_event_ids":     joinProjectionValues(citation.SourceEventIDs),
+					"graph_path_ids":       joinProjectionValues(citation.GraphPathIDs),
+				}))
+			}
+		}
+
+		for _, slot := range answer.EvidenceSlots {
+			slotRefID := questionnaireSlotRefID(slot)
+			slotURN := questionnaireSlotURN(record.TenantID, record.RunID, answer.QuestionID, slotRefID)
+			if slotURN == "" {
+				continue
+			}
+			slotURNsByKey[questionnaireSlotKey(answer.QuestionID, slot.ID)] = slotURN
+			slotURNsByID[strings.TrimSpace(slot.ID)] = slotURN
+			addEntity(&ports.ProjectedEntity{
+				URN:        slotURN,
+				TenantID:   record.TenantID,
+				SourceID:   sourceID,
+				RuntimeID:  runtimeID,
+				EntityType: "questionnaire.evidence_slot",
+				Label:      projectionLabel(firstNonEmpty(slot.Label, slot.ID)),
+				Attributes: slotEntityAttributes(record, answer, slot),
+			})
+			addEdge(questionnaireURN, slotURN, fabriccontract.RelationContains, map[string]string{
+				"match_type":           "questionnaire_evidence_slot",
+				"questionnaire_run_id": record.RunID,
+				"question_id":          answer.QuestionID,
+				"answer_id":            answer.ID,
+				"slot_id":              slot.ID,
+			})
+			addEdge(slotURN, answerURN, fabriccontract.RelationAttachedTo, map[string]string{
+				"match_type":           "slot_answer",
+				"questionnaire_run_id": record.RunID,
+				"question_id":          answer.QuestionID,
+				"answer_id":            answer.ID,
+				"slot_id":              slot.ID,
+			})
+			if questionURN != "" {
+				addEdge(slotURN, questionURN, fabriccontract.RelationAttachedTo, map[string]string{
+					"match_type":           "slot_question",
+					"questionnaire_run_id": record.RunID,
+					"question_id":          answer.QuestionID,
+					"slot_id":              slot.ID,
+				})
+			}
+			for _, citationID := range slot.CitationIDs {
+				evidenceURN := citationURNs[strings.TrimSpace(citationID)]
+				if evidenceURN == "" {
+					continue
+				}
+				addEdge(slotURN, evidenceURN, fabriccontract.RelationHasEvidence, map[string]string{
+					"match_type":           "slot_evidence",
+					"questionnaire_run_id": record.RunID,
+					"question_id":          answer.QuestionID,
+					"answer_id":            answer.ID,
+					"slot_id":              slot.ID,
+					"citation_id":          citationID,
+				})
+			}
+		}
+
+		for _, gap := range append(append([]ports.QuestionnaireEvidenceGap{}, answer.MissingEvidence...), answer.Conflicts...) {
+			gapRefID := questionnaireGapRefID(gap)
+			gapURN := questionnaireGapURN(record.TenantID, record.RunID, answer.QuestionID, gapRefID)
+			if gapURN == "" {
+				continue
+			}
+			if strings.TrimSpace(gap.ID) != "" {
+				gapURNsByID[strings.TrimSpace(gap.ID)] = gapURN
+			}
+			addEntity(&ports.ProjectedEntity{
+				URN:        gapURN,
+				TenantID:   record.TenantID,
+				SourceID:   sourceID,
+				RuntimeID:  runtimeID,
+				EntityType: "questionnaire.evidence_gap",
+				Label:      projectionLabel(firstNonEmpty(gap.Code, gap.ID)),
+				Attributes: gapEntityAttributes(record, answer, gap),
+			})
+			addEdge(questionnaireURN, gapURN, fabriccontract.RelationContains, map[string]string{
+				"match_type":           "questionnaire_evidence_gap",
+				"questionnaire_run_id": record.RunID,
+				"question_id":          answer.QuestionID,
+				"answer_id":            answer.ID,
+				"gap_id":               gap.ID,
+				"slot_id":              gap.SlotID,
+			})
+			if questionURN != "" {
+				addEdge(gapURN, questionURN, fabriccontract.RelationAttachedTo, map[string]string{
+					"match_type":           "gap_question",
+					"questionnaire_run_id": record.RunID,
+					"question_id":          answer.QuestionID,
+					"gap_id":               gap.ID,
+				})
+			}
+			if slotURN := slotURNsByKey[questionnaireSlotKey(answer.QuestionID, gap.SlotID)]; slotURN != "" {
+				addEdge(gapURN, slotURN, fabriccontract.RelationAttachedTo, map[string]string{
+					"match_type":           "gap_slot",
+					"questionnaire_run_id": record.RunID,
+					"question_id":          answer.QuestionID,
+					"gap_id":               gap.ID,
+					"slot_id":              gap.SlotID,
+				})
+			}
+			if controlURN := addControlEntity(gap.ControlID); controlURN != "" {
+				addEdge(gapURN, controlURN, fabriccontract.RelationSupports, map[string]string{
+					"match_type":           "gap_control",
+					"questionnaire_run_id": record.RunID,
+					"question_id":          answer.QuestionID,
+					"gap_id":               gap.ID,
+					"control_id":           gap.ControlID,
+				})
+			}
+			if evidenceURN := gapEvidenceURN(record.TenantID, gap); evidenceURN != "" {
+				addEntity(&ports.ProjectedEntity{
+					URN:        evidenceURN,
+					TenantID:   record.TenantID,
+					SourceID:   sourceID,
+					RuntimeID:  runtimeID,
+					EntityType: "runtime_evidence",
+					Label:      firstNonEmpty(gap.PacketID, gap.Code),
+					Attributes: compactProjectionAttributes(map[string]string{
+						"evidence_packet_id": gap.PacketID,
+						"source_system":      QuestionnaireProjectionSourceID,
+					}),
+				})
+				addEdge(gapURN, evidenceURN, fabriccontract.RelationAssociatedWith, map[string]string{
+					"match_type":           "gap_evidence_packet",
+					"questionnaire_run_id": record.RunID,
+					"question_id":          answer.QuestionID,
+					"gap_id":               gap.ID,
+					"evidence_packet_id":   gap.PacketID,
+				})
+			}
+		}
+	}
+
+	for _, assignment := range record.Assignments {
+		ownerURN := addOwnerEntity(firstNonEmpty(assignment.OwnerID, assignment.Team))
+		if ownerURN == "" {
+			continue
+		}
+		targetURN := assignmentTargetURN(assignment, questionURNsByID, slotURNsByKey, slotURNsByID, gapURNsByID)
+		if targetURN == "" {
+			targetURN = questionnaireURN
+		}
+		addEdge(targetURN, ownerURN, fabriccontract.RelationAssignedTo, assignmentLinkAttributes(record, assignment))
 	}
 	return GraphProjection{
 		Record:   record,
@@ -224,8 +532,289 @@ func questionnaireEntityAttributes(record ports.QuestionnaireRunRecord, at time.
 	return compactProjectionAttributes(attrs)
 }
 
+func questionEntityAttributes(record ports.QuestionnaireRunRecord, question ports.QuestionnaireQuestion) map[string]string {
+	attrs := map[string]string{
+		"questionnaire_run_id":     record.RunID,
+		"question_id":              question.ID,
+		"question":                 projectionAttributeValue(question.Question),
+		"normalized_question":      projectionAttributeValue(question.NormalizedQuestion),
+		"section":                  question.Section,
+		"required_answer_format":   question.RequiredAnswerFormat,
+		"mapped_controls":          joinProjectionValues(question.MappedControls),
+		"required_evidence_slots":  joinProjectionValues(question.RequiredSlots),
+		"owner_id":                 question.OwnerID,
+		"answer_state":             question.AnswerState,
+		"review_state":             question.ReviewState,
+		"questionnaire_direction":  record.Direction,
+		"questionnaire_status":     record.Status,
+		"questionnaire_source_id":  record.SourceID,
+		"questionnaire_runtime_id": record.RuntimeID,
+		"source_system":            QuestionnaireProjectionSourceID,
+	}
+	return mergeProjectionAttributes(attrs, sourceLocatorAttributes(question.SourceLocator))
+}
+
+func answerEntityAttributes(record ports.QuestionnaireRunRecord, answer ports.QuestionnaireRunAnswer) map[string]string {
+	return compactProjectionAttributes(map[string]string{
+		"questionnaire_run_id":     record.RunID,
+		"answer_id":                answer.ID,
+		"question_id":              answer.QuestionID,
+		"question":                 projectionAttributeValue(answer.Question),
+		"answer_state":             answer.AnswerState,
+		"review_state":             answer.ReviewState,
+		"confidence":               answer.Confidence,
+		"confidence_score":         strconv.Itoa(answer.ConfidenceScore),
+		"controls":                 joinProjectionValues(answer.Controls),
+		"freshness_status":         answer.Freshness.Status,
+		"freshness_observed_at":    answer.Freshness.ObservedAt,
+		"freshness_expires_at":     answer.Freshness.ExpiresAt,
+		"freshness_reason":         answer.Freshness.Reason,
+		"source_answer_id":         answer.SourceAnswerID,
+		"reviewer_decision":        answer.ReviewerDecision,
+		"reviewer_reason":          projectionAttributeValue(answer.ReviewerReason),
+		"questionnaire_direction":  record.Direction,
+		"questionnaire_status":     record.Status,
+		"questionnaire_source_id":  record.SourceID,
+		"questionnaire_runtime_id": record.RuntimeID,
+		"source_system":            QuestionnaireProjectionSourceID,
+	})
+}
+
+func slotEntityAttributes(record ports.QuestionnaireRunRecord, answer ports.QuestionnaireRunAnswer, slot ports.QuestionnaireEvidenceSlot) map[string]string {
+	return compactProjectionAttributes(map[string]string{
+		"questionnaire_run_id":     record.RunID,
+		"answer_id":                answer.ID,
+		"question_id":              answer.QuestionID,
+		"slot_id":                  slot.ID,
+		"slot_label":               slot.Label,
+		"slot_state":               slot.State,
+		"required":                 strconv.FormatBool(slot.Required),
+		"citation_ids":             joinProjectionValues(slot.CitationIDs),
+		"missing_reasons":          joinProjectionValues(slot.MissingReasons),
+		"questionnaire_direction":  record.Direction,
+		"questionnaire_status":     record.Status,
+		"questionnaire_source_id":  record.SourceID,
+		"questionnaire_runtime_id": record.RuntimeID,
+		"source_system":            QuestionnaireProjectionSourceID,
+	})
+}
+
+func gapEntityAttributes(record ports.QuestionnaireRunRecord, answer ports.QuestionnaireRunAnswer, gap ports.QuestionnaireEvidenceGap) map[string]string {
+	return compactProjectionAttributes(map[string]string{
+		"questionnaire_run_id":     record.RunID,
+		"answer_id":                answer.ID,
+		"question_id":              answer.QuestionID,
+		"gap_id":                   gap.ID,
+		"gap_code":                 gap.Code,
+		"reason":                   projectionAttributeValue(gap.Reason),
+		"slot_id":                  gap.SlotID,
+		"control_id":               gap.ControlID,
+		"evidence_packet_id":       gap.PacketID,
+		"review_state":             gap.ReviewState,
+		"questionnaire_direction":  record.Direction,
+		"questionnaire_status":     record.Status,
+		"questionnaire_source_id":  record.SourceID,
+		"questionnaire_runtime_id": record.RuntimeID,
+		"source_system":            QuestionnaireProjectionSourceID,
+	})
+}
+
+func sourceLocatorAttributes(locator *ports.QuestionnaireSourceLocator) map[string]string {
+	if locator == nil {
+		return nil
+	}
+	return compactProjectionAttributes(map[string]string{
+		"source_artifact_urn": locator.SourceArtifactURN,
+		"source_format":       locator.SourceFormat,
+		"source_filename":     locator.SourceFilename,
+		"sheet_name":          locator.SheetName,
+		"cell":                locator.Cell,
+		"column_name":         locator.ColumnName,
+		"row_number":          positiveIntString(locator.RowNumber),
+		"line_number":         positiveIntString(locator.LineNumber),
+		"page_number":         positiveIntString(locator.PageNumber),
+		"source_text":         projectionAttributeValue(locator.Text),
+		"portal_url":          locator.PortalURL,
+		"portal_field_id":     locator.PortalFieldID,
+		"portal_field_label":  locator.PortalFieldLabel,
+	})
+}
+
+func questionSourceArtifactURN(record ports.QuestionnaireRunRecord, question ports.QuestionnaireQuestion) string {
+	if !sourceLocatorHasPrecision(question.SourceLocator) {
+		return ""
+	}
+	sourceArtifactURN := strings.TrimSpace(question.SourceLocator.SourceArtifactURN)
+	if sourceArtifactURN == "" {
+		sourceArtifactURN = strings.TrimSpace(record.Attributes[QuestionnaireAttributeSourceArtifactURN])
+	}
+	if !isSourceArtifactURN(record.TenantID, sourceArtifactURN) {
+		return ""
+	}
+	return sourceArtifactURN
+}
+
+func sourceLocatorHasPrecision(locator *ports.QuestionnaireSourceLocator) bool {
+	if locator == nil {
+		return false
+	}
+	if strings.TrimSpace(locator.Cell) != "" || strings.TrimSpace(locator.PortalFieldID) != "" || strings.TrimSpace(locator.PortalFieldLabel) != "" {
+		return true
+	}
+	return locator.RowNumber > 0 || locator.LineNumber > 0 || locator.PageNumber > 0
+}
+
+func citationLinkAttributes(citation ports.QuestionnaireCitation, matchType string) map[string]string {
+	return compactProjectionAttributes(map[string]string{
+		"match_type":         matchType,
+		"citation_id":        citation.ID,
+		"evidence_id":        citation.EvidenceID,
+		"evidence_packet_id": citation.EvidencePacketID,
+		"evidence_type":      citation.EvidenceType,
+		"control_id":         citation.ControlID,
+		"freshness_status":   citation.FreshnessStatus,
+		"source_id":          citation.SourceID,
+		"runtime_id":         citation.RuntimeID,
+		"source_event_ids":   joinProjectionValues(citation.SourceEventIDs),
+		"graph_root_urns":    joinProjectionValues(citation.GraphRootURNs),
+		"graph_path_ids":     joinProjectionValues(citation.GraphPathIDs),
+	})
+}
+
+func assignmentLinkAttributes(record ports.QuestionnaireRunRecord, assignment ports.QuestionnaireAssignment) map[string]string {
+	attrs := map[string]string{
+		"match_type":           "questionnaire_assignment",
+		"questionnaire_run_id": record.RunID,
+		"assignment_id":        assignment.ID,
+		"question_id":          assignment.QuestionID,
+		"gap_id":               assignment.GapID,
+		"slot_id":              assignment.SlotID,
+		"owner_id":             assignment.OwnerID,
+		"team":                 assignment.Team,
+		"status":               assignment.Status,
+		"reason":               projectionAttributeValue(assignment.Reason),
+	}
+	if assignment.DueAt != nil {
+		attrs["due_at"] = assignment.DueAt.UTC().Format(time.RFC3339)
+	}
+	if assignment.CreatedAt != nil {
+		attrs["created_at"] = assignment.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	if assignment.UpdatedAt != nil {
+		attrs["updated_at"] = assignment.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return compactProjectionAttributes(attrs)
+}
+
 func projectionSourceID(record ports.QuestionnaireRunRecord) string {
 	return firstNonEmpty(record.SourceID, QuestionnaireProjectionSourceID)
+}
+
+func questionnaireQuestionURN(tenantID string, runID string, questionID string) string {
+	return questionnaireWorkItemURN(tenantID, "questionnaire_question", runID, "question", firstNonEmpty(questionID, "question"))
+}
+
+func questionnaireAnswerURN(tenantID string, runID string, questionID string, answerID string) string {
+	return questionnaireWorkItemURN(tenantID, "questionnaire_answer", runID, "question", firstNonEmpty(questionID, "unassigned"), "answer", firstNonEmpty(answerID, "answer"))
+}
+
+func questionnaireSlotURN(tenantID string, runID string, questionID string, slotID string) string {
+	return questionnaireWorkItemURN(tenantID, "questionnaire_evidence_slot", runID, "question", firstNonEmpty(questionID, "unassigned"), "slot", firstNonEmpty(slotID, "slot"))
+}
+
+func questionnaireGapURN(tenantID string, runID string, questionID string, gapID string) string {
+	return questionnaireWorkItemURN(tenantID, "questionnaire_evidence_gap", runID, "question", firstNonEmpty(questionID, "unassigned"), "gap", firstNonEmpty(gapID, "gap"))
+}
+
+func questionnaireWorkItemURN(tenantID string, kind string, runID string, parts ...string) string {
+	segments := []string{"questionnaire_run", cerebrourn.EncodeSegment(firstNonEmpty(runID, "run"))}
+	for _, part := range parts {
+		encoded := cerebrourn.EncodeSegment(part)
+		if encoded == "" {
+			continue
+		}
+		segments = append(segments, encoded)
+	}
+	value, err := cerebrourn.Mint(tenantID, kind, segments...)
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+func questionnaireQuestionRefID(question ports.QuestionnaireQuestion) string {
+	return firstNonEmpty(question.ID, projectionStableID(question.Question, question.NormalizedQuestion, question.Section))
+}
+
+func questionnaireAnswerRefID(answer ports.QuestionnaireRunAnswer) string {
+	return firstNonEmpty(answer.ID, projectionStableID(answer.QuestionID, answer.Question, answer.SourceAnswerID))
+}
+
+func questionnaireSlotRefID(slot ports.QuestionnaireEvidenceSlot) string {
+	return firstNonEmpty(slot.ID, projectionStableID(slot.Label, slot.State, strings.Join(slot.CitationIDs, "|")))
+}
+
+func questionnaireGapRefID(gap ports.QuestionnaireEvidenceGap) string {
+	return firstNonEmpty(gap.ID, projectionStableID(gap.Code, gap.SlotID, gap.ControlID, gap.PacketID, gap.Reason))
+}
+
+func projectionStableID(values ...string) string {
+	return cerebrourn.StableExternalID(strings.Join(values, "\x00"), "id-missing")
+}
+
+func questionURNForAnswer(answer ports.QuestionnaireRunAnswer, byID map[string]string, byRef map[string]string) string {
+	if value := byID[strings.TrimSpace(answer.QuestionID)]; value != "" {
+		return value
+	}
+	if value := byRef[strings.TrimSpace(answer.QuestionID)]; value != "" {
+		return value
+	}
+	return ""
+}
+
+func answerControlIDs(answer ports.QuestionnaireRunAnswer) []string {
+	controls := append([]string(nil), answer.Controls...)
+	for _, citation := range answer.Citations {
+		controls = append(controls, citation.ControlID)
+	}
+	return uniqueSorted(controls)
+}
+
+func citationLookupKeys(citation ports.QuestionnaireCitation) []string {
+	return uniqueSorted([]string{
+		citation.ID,
+		citation.EvidenceID,
+		citation.EvidencePacketID,
+		citation.ResourceURN,
+	})
+}
+
+func questionnaireSlotKey(questionID string, slotID string) string {
+	return strings.TrimSpace(questionID) + "\x00" + strings.TrimSpace(slotID)
+}
+
+func assignmentTargetURN(assignment ports.QuestionnaireAssignment, questionURNsByID map[string]string, slotURNsByKey map[string]string, slotURNsByID map[string]string, gapURNsByID map[string]string) string {
+	if gapURN := gapURNsByID[strings.TrimSpace(assignment.GapID)]; gapURN != "" {
+		return gapURN
+	}
+	if slotURN := slotURNsByKey[questionnaireSlotKey(assignment.QuestionID, assignment.SlotID)]; slotURN != "" {
+		return slotURN
+	}
+	if slotURN := slotURNsByID[strings.TrimSpace(assignment.SlotID)]; slotURN != "" {
+		return slotURN
+	}
+	if questionURN := questionURNsByID[strings.TrimSpace(assignment.QuestionID)]; questionURN != "" {
+		return questionURN
+	}
+	return ""
+}
+
+func gapEvidenceURN(tenantID string, gap ports.QuestionnaireEvidenceGap) string {
+	packetID := strings.TrimSpace(gap.PacketID)
+	if packetID == "" {
+		return ""
+	}
+	return citationResourceURN(tenantID, ports.QuestionnaireCitation{ID: packetID, EvidencePacketID: packetID})
 }
 
 func ownerEntityURN(tenantID string, owner string) string {
@@ -279,6 +868,14 @@ func isControlURN(tenantID string, value string) bool {
 
 func isSourceArtifactURN(tenantID string, value string) bool {
 	return isSameTenantKindURN(tenantID, value, "assurance_document", "security_review", "security_questionnaire", "penetration_test", "runtime_evidence", "runtime.evidence")
+}
+
+func isSameTenantCerebroURN(tenantID string, value string) bool {
+	parsed, err := cerebrourn.Parse(value)
+	if err != nil {
+		return false
+	}
+	return parsed.TenantID == strings.TrimSpace(tenantID)
 }
 
 func isSameTenantKindURN(tenantID string, value string, kinds ...string) bool {
@@ -340,6 +937,34 @@ func questionnaireCitations(record ports.QuestionnaireRunRecord) []ports.Questio
 		}
 	}
 	return citations
+}
+
+func joinProjectionValues(values []string) string {
+	return strings.Join(uniqueSorted(values), ",")
+}
+
+func positiveIntString(value int) string {
+	if value <= 0 {
+		return ""
+	}
+	return strconv.Itoa(value)
+}
+
+func projectionLabel(value string) string {
+	value = projectionAttributeValue(value)
+	if value == "" {
+		return "Questionnaire work item"
+	}
+	return value
+}
+
+func projectionAttributeValue(value string) string {
+	value = strings.TrimSpace(value)
+	const maxProjectionAttributeBytes = 512
+	if len(value) <= maxProjectionAttributeBytes {
+		return value
+	}
+	return strings.TrimSpace(value[:maxProjectionAttributeBytes])
 }
 
 func staleProjectionLinks(previous []*ports.ProjectedLink, current []*ports.ProjectedLink) []*ports.ProjectedLink {

--- a/internal/questionnaire/projection.go
+++ b/internal/questionnaire/projection.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/writer/cerebro/internal/fabriccontract"
 	"github.com/writer/cerebro/internal/ports"
@@ -964,7 +965,11 @@ func projectionAttributeValue(value string) string {
 	if len(value) <= maxProjectionAttributeBytes {
 		return value
 	}
-	return strings.TrimSpace(value[:maxProjectionAttributeBytes])
+	truncated := value[:maxProjectionAttributeBytes]
+	for !utf8.ValidString(truncated) && len(truncated) > 0 {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return strings.TrimSpace(truncated)
 }
 
 func staleProjectionLinks(previous []*ports.ProjectedLink, current []*ports.ProjectedLink) []*ports.ProjectedLink {

--- a/internal/questionnaire/projection_test.go
+++ b/internal/questionnaire/projection_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestBuildGraphProjectionLinksQuestionnaireWork(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	dueAt := now.Add(24 * time.Hour)
 	record := ports.QuestionnaireRunRecord{
 		QuestionnaireRunIdentity: ports.QuestionnaireRunIdentity{TenantID: "writer", RunID: "run-1", Title: "Core SSO review"},
 		QuestionnaireRunSource: ports.QuestionnaireRunSource{
@@ -30,24 +31,68 @@ func TestBuildGraphProjectionLinksQuestionnaireWork(t *testing.T) {
 				ID:             "q-1",
 				Question:       "Do you enforce MFA?",
 				MappedControls: []string{"SOC2-CC6.1"},
+				RequiredSlots:  []string{"identity_mfa"},
+				OwnerID:        "security@example.com",
+				SourceLocator: &ports.QuestionnaireSourceLocator{
+					SourceFormat: "xlsx",
+					SheetName:    "sheet1",
+					RowNumber:    2,
+					Cell:         "B2",
+				},
 			}},
 			Answers: []ports.QuestionnaireRunAnswer{{
 				ID:          "a-1",
 				QuestionID:  "q-1",
 				AnswerState: ports.QuestionnaireAnswerSupported,
 				Controls:    []string{"SOC2-CC6.1"},
+				EvidenceSlots: []ports.QuestionnaireEvidenceSlot{{
+					ID:          "identity_mfa",
+					Label:       "MFA",
+					State:       "satisfied",
+					Required:    true,
+					CitationIDs: []string{"evidence-1"},
+				}},
 				Citations: []ports.QuestionnaireCitation{{
 					ID:               "evidence-1",
 					Label:            "MFA configuration",
+					SourceID:         "okta",
+					RuntimeID:        "okta-prod",
 					EvidenceID:       "evidence-1",
 					EvidencePacketID: "packet-1",
 					EvidenceType:     "identity_mfa",
+					ControlID:        "SOC2-CC6.1",
 					FreshnessStatus:  "current",
+					SourceEventIDs:   []string{"event-1"},
+					GraphRootURNs:    []string{"urn:cerebro:writer:okta_application:core-sso"},
+					GraphPathIDs:     []string{"path-1"},
+				}},
+				MissingEvidence: []ports.QuestionnaireEvidenceGap{{
+					ID:          "gap-1",
+					Code:        "stale_evidence",
+					Reason:      "Refresh MFA export before approval.",
+					SlotID:      "identity_mfa",
+					ControlID:   "SOC2-CC6.1",
+					PacketID:    "packet-1",
+					ReviewState: ports.QuestionnaireReviewNeedsReview,
 				}},
 				Freshness: ports.QuestionnaireFreshness{Status: "current"},
 			}},
+			Assignments: []ports.QuestionnaireAssignment{{
+				ID:         "assignment-1",
+				QuestionID: "q-1",
+				GapID:      "gap-1",
+				OwnerID:    "evidence@example.com",
+				Status:     "open",
+				DueAt:      &dueAt,
+			}},
 		},
-		QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{CreatedAt: now, UpdatedAt: now},
+		QuestionnaireRunMetadata: ports.QuestionnaireRunMetadata{
+			Attributes: map[string]string{
+				QuestionnaireAttributeSourceArtifactURN: "urn:cerebro:writer:assurance_document:intake-sheet",
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
 	}
 
 	projection, err := BuildGraphProjection(record, nil, now)
@@ -60,6 +105,16 @@ func TestBuildGraphProjectionLinksQuestionnaireWork(t *testing.T) {
 	}
 	if len(projection.Entities) < 4 {
 		t.Fatalf("entities = %d, want questionnaire, owner, control, and evidence entities", len(projection.Entities))
+	}
+	for _, entityType := range []string{
+		"questionnaire.question",
+		"questionnaire.answer",
+		"questionnaire.evidence_slot",
+		"questionnaire.evidence_gap",
+	} {
+		if !hasProjectedEntityType(projection.Entities, entityType) {
+			t.Fatalf("missing %s entity in %#v", entityType, projection.Entities)
+		}
 	}
 	if !hasAssociatedProjectedLink(projection.Links, questionnaireURN, "urn:cerebro:writer:vendor:core-sso") {
 		t.Fatalf("missing vendor association link in %#v", projection.Links)
@@ -75,6 +130,35 @@ func TestBuildGraphProjectionLinksQuestionnaireWork(t *testing.T) {
 	}
 	if got := projection.Entities[0].Attributes["ready_answer_count"]; got != "1" {
 		t.Fatalf("ready answer count attr = %q, want 1", got)
+	}
+
+	questionURN := questionnaireQuestionURN("writer", "run-1", "q-1")
+	answerURN := questionnaireAnswerURN("writer", "run-1", "q-1", "a-1")
+	slotURN := questionnaireSlotURN("writer", "run-1", "q-1", "identity_mfa")
+	gapURN := questionnaireGapURN("writer", "run-1", "q-1", "gap-1")
+	evidenceURN := citationResourceURN("writer", record.Answers[0].Citations[0])
+	controlURN := controlEntityURN("writer", "SOC2-CC6.1")
+	ownerURN := ownerEntityURN("writer", "evidence@example.com")
+	if !hasProjectedLink(projection.Links, questionnaireURN, fabriccontract.RelationContains, questionURN) {
+		t.Fatalf("missing run contains question link in %#v", projection.Links)
+	}
+	if !hasProjectedLink(projection.Links, answerURN, fabriccontract.RelationAttachedTo, questionURN) {
+		t.Fatalf("missing answer attached-to question link in %#v", projection.Links)
+	}
+	if !hasProjectedLink(projection.Links, slotURN, fabriccontract.RelationHasEvidence, evidenceURN) {
+		t.Fatalf("missing slot evidence link in %#v", projection.Links)
+	}
+	if !hasProjectedLink(projection.Links, questionURN, fabriccontract.RelationSupports, controlURN) {
+		t.Fatalf("missing question control link in %#v", projection.Links)
+	}
+	if !hasProjectedLink(projection.Links, questionURN, fabriccontract.RelationHasContext, "urn:cerebro:writer:assurance_document:intake-sheet") {
+		t.Fatalf("missing question source-artifact context link in %#v", projection.Links)
+	}
+	if !hasProjectedLink(projection.Links, answerURN, fabriccontract.RelationHasContext, "urn:cerebro:writer:okta_application:core-sso") {
+		t.Fatalf("missing answer graph-root context link in %#v", projection.Links)
+	}
+	if !hasProjectedLink(projection.Links, gapURN, fabriccontract.RelationAssignedTo, ownerURN) {
+		t.Fatalf("missing gap assignment link in %#v", projection.Links)
 	}
 }
 
@@ -122,6 +206,11 @@ func TestBuildGraphProjectionRemovesStaleLinks(t *testing.T) {
 	}
 	if !hasProjectedLinkToRelation(projection.RemovedLinks, fabriccontract.RelationHasEvidence) {
 		t.Fatalf("removed links missing stale evidence link: %#v", projection.RemovedLinks)
+	}
+	oldQuestionURN := questionnaireQuestionURN("writer", "run-1", "q-1")
+	oldControlURN := controlEntityURN("writer", "old-control")
+	if !hasProjectedLink(projection.RemovedLinks, oldQuestionURN, fabriccontract.RelationSupports, oldControlURN) {
+		t.Fatalf("removed links missing stale question control link: %#v", projection.RemovedLinks)
 	}
 	if hasAssociatedProjectedLink(projection.RemovedLinks, questionnaireURN, "urn:cerebro:writer:vendor:new") {
 		t.Fatalf("removed links include current vendor link: %#v", projection.RemovedLinks)
@@ -237,6 +326,24 @@ func hasAssociatedProjectedLink(links []*ports.ProjectedLink, fromURN string, to
 func hasProjectedLinkToRelation(links []*ports.ProjectedLink, relation string) bool {
 	for _, link := range links {
 		if link.Relation == relation {
+			return true
+		}
+	}
+	return false
+}
+
+func hasProjectedLink(links []*ports.ProjectedLink, fromURN string, relation string, toURN string) bool {
+	for _, link := range links {
+		if link.FromURN == fromURN && link.Relation == relation && link.ToURN == toURN {
+			return true
+		}
+	}
+	return false
+}
+
+func hasProjectedEntityType(entities []*ports.ProjectedEntity, entityType string) bool {
+	for _, entity := range entities {
+		if entity.EntityType == entityType {
 			return true
 		}
 	}

--- a/internal/questionnaire/projection_test.go
+++ b/internal/questionnaire/projection_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/writer/cerebro/internal/fabriccontract"
 	"github.com/writer/cerebro/internal/ports"
@@ -159,6 +160,22 @@ func TestBuildGraphProjectionLinksQuestionnaireWork(t *testing.T) {
 	}
 	if !hasProjectedLink(projection.Links, gapURN, fabriccontract.RelationAssignedTo, ownerURN) {
 		t.Fatalf("missing gap assignment link in %#v", projection.Links)
+	}
+}
+
+func TestProjectionAttributeValueTruncatesAtUTF8Boundary(t *testing.T) {
+	value := strings.Repeat("a", 511) + "界" + "tail"
+
+	got := projectionAttributeValue(value)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("projectionAttributeValue returned invalid UTF-8: %q", got)
+	}
+	if len(got) > 512 {
+		t.Fatalf("projectionAttributeValue length = %d, want at most 512 bytes", len(got))
+	}
+	if strings.Contains(got, "\uFFFD") {
+		t.Fatalf("projectionAttributeValue inserted replacement character: %q", got)
 	}
 }
 

--- a/internal/questionnaire/service.go
+++ b/internal/questionnaire/service.go
@@ -720,6 +720,8 @@ func citationsFromEvidenceAnswer(answer evidencepackets.QuestionnaireAnswer) []p
 			ID:               citationID,
 			Label:            firstNonEmpty(ref.EvidenceType, ref.Source, ref.SourceID, ref.RuntimeID, citationID),
 			Source:           firstNonEmpty(ref.SourceID, ref.Source, ref.RuntimeID),
+			SourceID:         ref.SourceID,
+			RuntimeID:        ref.RuntimeID,
 			ResourceURN:      firstCerebroURN(ref.ID, ref.EvidencePacketID),
 			EvidencePacketID: ref.EvidencePacketID,
 			EvidenceID:       ref.ID,
@@ -727,6 +729,9 @@ func citationsFromEvidenceAnswer(answer evidencepackets.QuestionnaireAnswer) []p
 			FreshnessStatus:  ref.Freshness.Status,
 			ObservedAt:       ref.Freshness.ObservedAt,
 			ExpiresAt:        ref.Freshness.ExpiresAt,
+			SourceEventIDs:   uniqueSorted(append(append([]string(nil), ref.SourceEventIDs...), ref.Citations.EventIDs...)),
+			GraphRootURNs:    uniqueSorted(append(append([]string(nil), ref.GraphRootURNs...), ref.Citations.GraphRoots...)),
+			GraphPathIDs:     uniqueSorted(ref.GraphPathIDs),
 		})
 	}
 	for _, packetID := range answer.EvidencePackets {
@@ -1041,6 +1046,7 @@ func cloneQuestions(values []ports.QuestionnaireQuestion) []ports.QuestionnaireQ
 	for index, value := range values {
 		value.MappedControls = cloneStringSlice(value.MappedControls)
 		value.RequiredSlots = cloneStringSlice(value.RequiredSlots)
+		value.SourceLocator = cloneSourceLocator(value.SourceLocator)
 		out[index] = value
 	}
 	return out
@@ -1054,10 +1060,32 @@ func cloneAnswers(values []ports.QuestionnaireRunAnswer) []ports.QuestionnaireRu
 	for index, value := range values {
 		value.Controls = cloneStringSlice(value.Controls)
 		value.EvidenceSlots = cloneEvidenceSlots(value.EvidenceSlots)
-		value.Citations = append([]ports.QuestionnaireCitation(nil), value.Citations...)
+		value.Citations = cloneCitations(value.Citations)
 		value.MissingEvidence = append([]ports.QuestionnaireEvidenceGap(nil), value.MissingEvidence...)
 		value.Conflicts = append([]ports.QuestionnaireEvidenceGap(nil), value.Conflicts...)
 		value.Attributes = cloneStringMap(value.Attributes)
+		out[index] = value
+	}
+	return out
+}
+
+func cloneSourceLocator(value *ports.QuestionnaireSourceLocator) *ports.QuestionnaireSourceLocator {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneCitations(values []ports.QuestionnaireCitation) []ports.QuestionnaireCitation {
+	if values == nil {
+		return nil
+	}
+	out := make([]ports.QuestionnaireCitation, len(values))
+	for index, value := range values {
+		value.SourceEventIDs = cloneStringSlice(value.SourceEventIDs)
+		value.GraphRootURNs = cloneStringSlice(value.GraphRootURNs)
+		value.GraphPathIDs = cloneStringSlice(value.GraphPathIDs)
 		out[index] = value
 	}
 	return out

--- a/internal/questionnaire/service_test.go
+++ b/internal/questionnaire/service_test.go
@@ -123,6 +123,47 @@ func TestProcessEvidenceAnswersStateMatrix(t *testing.T) {
 	}
 }
 
+func TestProcessEvidenceAnswersCarriesCitationGraphProvenance(t *testing.T) {
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	record := NewRunRecord(NewRunRequest{
+		TenantID:  "tenant-1",
+		Direction: ports.QuestionnaireDirectionCustomerSecurityReview,
+		Questions: []ports.QuestionnaireQuestion{{
+			ID:            "q-1",
+			Question:      "Do you enforce MFA for users?",
+			RequiredSlots: []string{"identity_mfa"},
+		}},
+	}, now)
+	evidenceAnswer := baseEvidenceAnswer("Do you enforce MFA for users?", "supported", "ready", "current")
+	evidenceAnswer.SourceEvidence[0].RuntimeID = "okta-prod"
+	evidenceAnswer.SourceEvidence[0].SourceEventIDs = []string{"event-source"}
+	evidenceAnswer.SourceEvidence[0].GraphRootURNs = []string{"urn:cerebro:tenant-1:okta_application:core-sso"}
+	evidenceAnswer.SourceEvidence[0].GraphPathIDs = []string{"path-1"}
+	evidenceAnswer.SourceEvidence[0].Citations = evidencepackets.EvidenceCitations{
+		EventIDs:   []string{"event-citation"},
+		GraphRoots: []string{"urn:cerebro:tenant-1:okta_group:admins"},
+	}
+
+	record = ProcessEvidenceAnswers(record, []evidencepackets.QuestionnaireAnswer{evidenceAnswer}, now)
+
+	if len(record.Answers) != 1 || len(record.Answers[0].Citations) != 1 {
+		t.Fatalf("citations = %#v, want one answer citation", record.Answers)
+	}
+	citation := record.Answers[0].Citations[0]
+	if citation.SourceID != "okta" || citation.RuntimeID != "okta-prod" {
+		t.Fatalf("citation source = %q/%q, want okta/okta-prod", citation.SourceID, citation.RuntimeID)
+	}
+	if !containsString(citation.SourceEventIDs, "event-source") || !containsString(citation.SourceEventIDs, "event-citation") {
+		t.Fatalf("source event IDs = %#v, want ref and citation events", citation.SourceEventIDs)
+	}
+	if !containsString(citation.GraphRootURNs, "urn:cerebro:tenant-1:okta_application:core-sso") || !containsString(citation.GraphRootURNs, "urn:cerebro:tenant-1:okta_group:admins") {
+		t.Fatalf("graph roots = %#v, want ref and citation graph roots", citation.GraphRootURNs)
+	}
+	if !containsString(citation.GraphPathIDs, "path-1") {
+		t.Fatalf("graph paths = %#v, want path-1", citation.GraphPathIDs)
+	}
+}
+
 func TestVendorReviewAddsVendorEvidenceSlot(t *testing.T) {
 	record := NewRunRecord(NewRunRequest{
 		TenantID:  "tenant-1",
@@ -606,4 +647,13 @@ func slotState(slots []ports.QuestionnaireEvidenceSlot, id string) string {
 		}
 	}
 	return ""
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/sourcehttp/questionnaire/handler.go
+++ b/internal/sourcehttp/questionnaire/handler.go
@@ -195,13 +195,14 @@ type createRequest struct {
 }
 
 type intakeRow struct {
-	ID                   string   `json:"id,omitempty"`
-	Question             string   `json:"question,omitempty"`
-	Section              string   `json:"section,omitempty"`
-	RequiredAnswerFormat string   `json:"required_answer_format,omitempty"`
-	MappedControls       []string `json:"mapped_controls,omitempty"`
-	RequiredSlots        []string `json:"required_evidence_slots,omitempty"`
-	OwnerID              string   `json:"owner_id,omitempty"`
+	ID                   string                            `json:"id,omitempty"`
+	Question             string                            `json:"question,omitempty"`
+	Section              string                            `json:"section,omitempty"`
+	RequiredAnswerFormat string                            `json:"required_answer_format,omitempty"`
+	MappedControls       []string                          `json:"mapped_controls,omitempty"`
+	RequiredSlots        []string                          `json:"required_evidence_slots,omitempty"`
+	OwnerID              string                            `json:"owner_id,omitempty"`
+	SourceLocator        *ports.QuestionnaireSourceLocator `json:"source_locator,omitempty"`
 }
 
 type assignmentRequest struct {
@@ -1042,7 +1043,31 @@ func questionsForCreate(request createRequest) ([]ports.QuestionnaireQuestion, e
 		}
 		questions = append(questions, parsed...)
 	}
+	questions = applyCreateSourceContext(questions, request)
 	return questionnairedomain.NormalizeQuestionsForIntake(questions), nil
+}
+
+func applyCreateSourceContext(questions []ports.QuestionnaireQuestion, request createRequest) []ports.QuestionnaireQuestion {
+	sourceFilename := strings.TrimSpace(request.SourceFilename)
+	portalURL := strings.TrimSpace(request.PortalURL)
+	for index := range questions {
+		if questions[index].SourceLocator == nil {
+			if sourceFilename == "" && portalURL == "" {
+				continue
+			}
+			questions[index].SourceLocator = &ports.QuestionnaireSourceLocator{}
+		}
+		if sourceFilename != "" && questions[index].SourceLocator.SourceFilename == "" {
+			questions[index].SourceLocator.SourceFilename = sourceFilename
+		}
+		if portalURL != "" && questions[index].SourceLocator.PortalURL == "" {
+			questions[index].SourceLocator.PortalURL = portalURL
+			if questions[index].SourceLocator.SourceFormat == "" {
+				questions[index].SourceLocator.SourceFormat = "portal"
+			}
+		}
+	}
+	return questions
 }
 
 func allowsPortalCaptureWithoutQuestions(request createRequest) bool {
@@ -1117,7 +1142,7 @@ func parseDelimitedIntake(value string, format string) ([]ports.QuestionnaireQue
 		return nil, fmt.Errorf("%w: %s intake must include a question column", ErrInvalidRequest, firstNonEmpty(format, "csv"))
 	}
 	rows := []intakeRow{}
-	for _, record := range records[1:] {
+	for rowIndex, record := range records[1:] {
 		if questionIndex >= len(record) || strings.TrimSpace(record[questionIndex]) == "" {
 			continue
 		}
@@ -1129,6 +1154,11 @@ func parseDelimitedIntake(value string, format string) ([]ports.QuestionnaireQue
 			MappedControls:       splitList(columnValue(record, header, "mapped_controls", "controls", "control_ids")),
 			RequiredSlots:        splitList(columnValue(record, header, "required_evidence_slots", "evidence_slots", "slots")),
 			OwnerID:              columnValue(record, header, "owner_id", "owner", "assignee"),
+			SourceLocator: &ports.QuestionnaireSourceLocator{
+				SourceFormat: firstNonEmpty(format, "csv"),
+				RowNumber:    rowIndex + 2,
+				ColumnName:   header[questionIndex],
+			},
 		})
 	}
 	return questionsFromIntakeRows(rows), nil
@@ -1136,14 +1166,21 @@ func parseDelimitedIntake(value string, format string) ([]ports.QuestionnaireQue
 
 func parsePlainTextIntake(value string) []ports.QuestionnaireQuestion {
 	rows := []intakeRow{}
-	for _, line := range strings.Split(value, "\n") {
+	for lineIndex, line := range strings.Split(value, "\n") {
 		line = strings.TrimSpace(line)
 		line = strings.TrimPrefix(line, "- ")
 		line = strings.TrimPrefix(line, "* ")
 		if line == "" {
 			continue
 		}
-		rows = append(rows, intakeRow{Question: line})
+		rows = append(rows, intakeRow{
+			Question: line,
+			SourceLocator: &ports.QuestionnaireSourceLocator{
+				SourceFormat: "text",
+				LineNumber:   lineIndex + 1,
+				Text:         line,
+			},
+		})
 	}
 	return questionsFromIntakeRows(rows)
 }
@@ -1155,7 +1192,7 @@ func parsePortalIntake(value string) ([]ports.QuestionnaireQuestion, error) {
 	}
 	rows := []intakeRow{}
 	section := ""
-	for _, line := range strings.Split(trimmed, "\n") {
+	for lineIndex, line := range strings.Split(trimmed, "\n") {
 		line = normalizePortalQuestionLine(line)
 		if line == "" {
 			continue
@@ -1167,7 +1204,16 @@ func parsePortalIntake(value string) ([]ports.QuestionnaireQuestion, error) {
 		if !looksLikeQuestionnairePrompt(line) {
 			continue
 		}
-		rows = append(rows, intakeRow{Question: line, Section: section})
+		rows = append(rows, intakeRow{
+			Question: line,
+			Section:  section,
+			SourceLocator: &ports.QuestionnaireSourceLocator{
+				SourceFormat:     "portal",
+				LineNumber:       lineIndex + 1,
+				Text:             line,
+				PortalFieldLabel: line,
+			},
+		})
 	}
 	return questionsFromIntakeRows(rows), nil
 }
@@ -1189,6 +1235,7 @@ func questionFromIntakeRow(row intakeRow) ports.QuestionnaireQuestion {
 		MappedControls:       row.MappedControls,
 		RequiredSlots:        row.RequiredSlots,
 		OwnerID:              row.OwnerID,
+		SourceLocator:        row.SourceLocator,
 	}
 }
 

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -99,6 +99,22 @@ func TestCreateRunParsesXLSXIntakeFile(t *testing.T) {
 	}
 }
 
+func TestParseIntakeAttachmentKeepsSpreadsheetFormat(t *testing.T) {
+	questions, err := parseIntakeAttachment(createRequest{
+		IntakeFile:   base64.StdEncoding.EncodeToString(testXLSXWorkbook(t)),
+		IntakeFormat: "xlsm",
+	})
+	if err != nil {
+		t.Fatalf("parseIntakeAttachment returned error: %v", err)
+	}
+	if len(questions) != 2 {
+		t.Fatalf("questions = %d, want 2: %#v", len(questions), questions)
+	}
+	if locator := questions[0].SourceLocator; locator == nil || locator.SourceFormat != "xlsm" || locator.SheetName != "sheet1" || locator.Cell != "B2" {
+		t.Fatalf("source locator = %#v, want xlsm sheet1 B2", locator)
+	}
+}
+
 func TestQuestionsFromSpreadsheetRowsStopsAtSheetBoundary(t *testing.T) {
 	questions, err := questionsFromSpreadsheetRows([]spreadsheetRow{
 		{
@@ -119,7 +135,7 @@ func TestQuestionsFromSpreadsheetRowsStopsAtSheetBoundary(t *testing.T) {
 			RowNumber: 1,
 			CellRefs:  []string{"A1", "B1", "C1"},
 		},
-	})
+	}, "xlsx")
 	if err != nil {
 		t.Fatalf("questionsFromSpreadsheetRows returned error: %v", err)
 	}

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -99,6 +99,41 @@ func TestCreateRunParsesXLSXIntakeFile(t *testing.T) {
 	}
 }
 
+func TestQuestionsFromSpreadsheetRowsStopsAtSheetBoundary(t *testing.T) {
+	questions, err := questionsFromSpreadsheetRows([]spreadsheetRow{
+		{
+			Values:    []string{"section", "question", "required_evidence_slots"},
+			SheetName: "sheet1",
+			RowNumber: 1,
+			CellRefs:  []string{"A1", "B1", "C1"},
+		},
+		{
+			Values:    []string{"Access", "Do you enforce MFA?", "identity_mfa"},
+			SheetName: "sheet1",
+			RowNumber: 2,
+			CellRefs:  []string{"A2", "B2", "C2"},
+		},
+		{
+			Values:    []string{"Vendor profile", "This belongs to a different worksheet.", "ignored"},
+			SheetName: "sheet2",
+			RowNumber: 1,
+			CellRefs:  []string{"A1", "B1", "C1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("questionsFromSpreadsheetRows returned error: %v", err)
+	}
+	if len(questions) != 1 {
+		t.Fatalf("questions = %d, want 1: %#v", len(questions), questions)
+	}
+	if questions[0].Question != "Do you enforce MFA?" {
+		t.Fatalf("question = %q, want first sheet question", questions[0].Question)
+	}
+	if locator := questions[0].SourceLocator; locator == nil || locator.SheetName != "sheet1" || locator.Cell != "B2" {
+		t.Fatalf("source locator = %#v, want sheet1 B2", locator)
+	}
+}
+
 func TestCreateRunAttributesIgnoreReservedGraphAttributes(t *testing.T) {
 	attrs := createRunAttributes(createRequest{
 		Attributes: map[string]string{

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -48,6 +48,10 @@ func TestCreateRunParsesCSVIntakeText(t *testing.T) {
 	if store.saved.Questions[0].Question == "" || store.saved.Questions[0].OwnerID != "security@example.com" {
 		t.Fatalf("first question not mapped from CSV: %#v", store.saved.Questions[0])
 	}
+	locator := store.saved.Questions[0].SourceLocator
+	if locator == nil || locator.SourceFormat != "csv" || locator.RowNumber != 2 || locator.ColumnName != "question" {
+		t.Fatalf("CSV source locator = %#v, want row 2 question column", locator)
+	}
 }
 
 func TestCreateRunParsesXLSXIntakeFile(t *testing.T) {
@@ -85,6 +89,10 @@ func TestCreateRunParsesXLSXIntakeFile(t *testing.T) {
 	}
 	if got := store.saved.Questions[0].RequiredSlots; len(got) != 1 || got[0] != "identity_mfa" {
 		t.Fatalf("required slots = %#v, want identity_mfa", got)
+	}
+	locator := store.saved.Questions[0].SourceLocator
+	if locator == nil || locator.SourceFormat != "xlsx" || locator.SourceFilename != "security-questionnaire.xlsx" || locator.SheetName != "sheet1" || locator.RowNumber != 2 || locator.Cell != "B2" {
+		t.Fatalf("XLSX source locator = %#v, want sheet1 row 2 cell B2", locator)
 	}
 	if store.saved.Attributes["intake_file_attached"] != "true" || store.saved.Attributes["intake_format"] != "xlsx" {
 		t.Fatalf("attributes = %#v, want xlsx attachment metadata", store.saved.Attributes)
@@ -226,6 +234,10 @@ func TestCreateRunInfersXLSXFromFilenameWhenMimeTypeIsGeneric(t *testing.T) {
 	if store.saved.Attributes["intake_format"] != "xlsx" {
 		t.Fatalf("intake format attribute = %q, want xlsx", store.saved.Attributes["intake_format"])
 	}
+	locator := store.saved.Questions[0].SourceLocator
+	if locator == nil || locator.SourceFormat != "xlsx" || locator.Cell != "B2" {
+		t.Fatalf("inferred XLSX source locator = %#v, want workbook cell context", locator)
+	}
 }
 
 func TestCreateRunParsesPDFIntakeFile(t *testing.T) {
@@ -259,6 +271,10 @@ func TestCreateRunParsesPDFIntakeFile(t *testing.T) {
 	}
 	if store.saved.Questions[0].Question != "Do you enforce MFA?" || store.saved.Questions[1].Question != "Attach SOC 2 report." {
 		t.Fatalf("questions = %#v, want extracted PDF prompts", store.saved.Questions)
+	}
+	locator := store.saved.Questions[0].SourceLocator
+	if locator == nil || locator.SourceFormat != "pdf" || locator.SourceFilename != "security-questionnaire.pdf" || locator.LineNumber == 0 {
+		t.Fatalf("PDF source locator = %#v, want file and line context", locator)
 	}
 }
 
@@ -298,6 +314,10 @@ func TestCreateRunStoresPortalMetadataAndParsesPortalText(t *testing.T) {
 		store.saved.Attributes["portal_status"] != "questions_captured" ||
 		store.saved.Attributes["portal_instructions"] != "Use SSO and route missing access to sales ops." {
 		t.Fatalf("attributes = %#v, want portal metadata", store.saved.Attributes)
+	}
+	locator := store.saved.Questions[0].SourceLocator
+	if locator == nil || locator.SourceFormat != "portal" || locator.PortalURL != "https://portal.example.test/review/123" || locator.LineNumber == 0 {
+		t.Fatalf("portal source locator = %#v, want portal URL and line context", locator)
 	}
 }
 

--- a/internal/sourcehttp/questionnaire/intake_attachment.go
+++ b/internal/sourcehttp/questionnaire/intake_attachment.go
@@ -101,7 +101,7 @@ func parseIntakeAttachment(request createRequest) ([]ports.QuestionnaireQuestion
 		if err != nil {
 			return nil, err
 		}
-		questions, err := questionsFromSpreadsheetRows(rows)
+		questions, err := questionsFromSpreadsheetRows(rows, format)
 		if err != nil {
 			return nil, err
 		}
@@ -303,7 +303,8 @@ func readXLSXWorksheet(file *zip.File, sharedStrings []string) ([]spreadsheetRow
 	return rows, nil
 }
 
-func questionsFromSpreadsheetRows(rows []spreadsheetRow) ([]ports.QuestionnaireQuestion, error) {
+func questionsFromSpreadsheetRows(rows []spreadsheetRow, sourceFormat string) ([]ports.QuestionnaireQuestion, error) {
+	sourceFormat = firstNonEmpty(canonicalIntakeFormat(sourceFormat), "xlsx")
 	for index, row := range rows {
 		header := normalizedHeaders(row.Values)
 		questionIndex := headerIndex(header, "question", "question_text", "prompt")
@@ -327,7 +328,7 @@ func questionsFromSpreadsheetRows(rows []spreadsheetRow) ([]ports.QuestionnaireQ
 				RequiredSlots:        splitList(columnValue(record.Values, header, "required_evidence_slots", "evidence_slots", "slots")),
 				OwnerID:              columnValue(record.Values, header, "owner_id", "owner", "assignee"),
 				SourceLocator: &ports.QuestionnaireSourceLocator{
-					SourceFormat: "xlsx",
+					SourceFormat: sourceFormat,
 					SheetName:    record.SheetName,
 					RowNumber:    record.RowNumber,
 					Cell:         cellRefAt(record.CellRefs, questionIndex),
@@ -337,7 +338,7 @@ func questionsFromSpreadsheetRows(rows []spreadsheetRow) ([]ports.QuestionnaireQ
 		}
 		return questionsFromIntakeRows(intakeRows), nil
 	}
-	return nil, fmt.Errorf("%w: xlsx workbook must include a question, question_text, or prompt column", ErrInvalidRequest)
+	return nil, fmt.Errorf("%w: %s workbook must include a question, question_text, or prompt column", ErrInvalidRequest, sourceFormat)
 }
 
 func worksheetNameFromPath(path string) string {

--- a/internal/sourcehttp/questionnaire/intake_attachment.go
+++ b/internal/sourcehttp/questionnaire/intake_attachment.go
@@ -28,6 +28,7 @@ type xlsxWorksheet struct {
 }
 
 type xlsxRow struct {
+	Ref   int        `xml:"r,attr"`
 	Cells []xlsxCell `xml:"c"`
 }
 
@@ -38,6 +39,13 @@ type xlsxCell struct {
 	InlineStr struct {
 		Text string `xml:"t"`
 	} `xml:"is"`
+}
+
+type spreadsheetRow struct {
+	Values    []string
+	SheetName string
+	RowNumber int
+	CellRefs  []string
 }
 
 func createRunAttributes(request createRequest, questionCount int) map[string]string {
@@ -179,7 +187,7 @@ func inferAttachmentFormat(filename string, contentType string) string {
 	}
 }
 
-func extractXLSXRows(data []byte) ([][]string, error) {
+func extractXLSXRows(data []byte) ([]spreadsheetRow, error) {
 	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return nil, fmt.Errorf("%w: read xlsx workbook: %w", ErrInvalidRequest, err)
@@ -197,7 +205,7 @@ func extractXLSXRows(data []byte) ([][]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	allRows := [][]string{}
+	allRows := []spreadsheetRow{}
 	for _, name := range worksheetNames {
 		rows, err := readXLSXWorksheet(files[name], sharedStrings)
 		if err != nil {
@@ -251,7 +259,7 @@ func readXLSXSharedStrings(file *zip.File) ([]string, error) {
 	return values, nil
 }
 
-func readXLSXWorksheet(file *zip.File, sharedStrings []string) ([][]string, error) {
+func readXLSXWorksheet(file *zip.File, sharedStrings []string) ([]spreadsheetRow, error) {
 	if file == nil {
 		return nil, nil
 	}
@@ -263,9 +271,11 @@ func readXLSXWorksheet(file *zip.File, sharedStrings []string) ([][]string, erro
 	if err := xml.Unmarshal(body, &worksheet); err != nil {
 		return nil, fmt.Errorf("%w: parse xlsx worksheet: %w", ErrInvalidRequest, err)
 	}
-	rows := make([][]string, 0, len(worksheet.Rows))
+	rows := make([]spreadsheetRow, 0, len(worksheet.Rows))
+	sheetName := worksheetNameFromPath(file.Name)
 	for _, row := range worksheet.Rows {
 		cells := []string{}
+		cellRefs := []string{}
 		nextIndex := 0
 		for _, cell := range row.Cells {
 			index := xlsxColumnIndex(cell.Ref)
@@ -274,43 +284,91 @@ func readXLSXWorksheet(file *zip.File, sharedStrings []string) ([][]string, erro
 			}
 			for len(cells) <= index {
 				cells = append(cells, "")
+				cellRefs = append(cellRefs, "")
 			}
 			cells[index] = xlsxCellValue(cell, sharedStrings)
+			cellRefs[index] = strings.TrimSpace(cell.Ref)
 			nextIndex = index + 1
 		}
-		cells = trimEmptyTail(cells)
+		cells, cellRefs = trimEmptyTailWithRefs(cells, cellRefs)
 		if len(cells) > 0 {
-			rows = append(rows, cells)
+			rows = append(rows, spreadsheetRow{
+				Values:    cells,
+				SheetName: sheetName,
+				RowNumber: firstPositive(row.Ref, xlsxRowNumber(firstNonEmpty(cellRefs...))),
+				CellRefs:  cellRefs,
+			})
 		}
 	}
 	return rows, nil
 }
 
-func questionsFromSpreadsheetRows(rows [][]string) ([]ports.QuestionnaireQuestion, error) {
+func questionsFromSpreadsheetRows(rows []spreadsheetRow) ([]ports.QuestionnaireQuestion, error) {
 	for index, row := range rows {
-		header := normalizedHeaders(row)
+		header := normalizedHeaders(row.Values)
 		questionIndex := headerIndex(header, "question", "question_text", "prompt")
 		if questionIndex < 0 {
 			continue
 		}
 		intakeRows := []intakeRow{}
 		for _, record := range rows[index+1:] {
-			if questionIndex >= len(record) || strings.TrimSpace(record[questionIndex]) == "" {
+			if questionIndex >= len(record.Values) || strings.TrimSpace(record.Values[questionIndex]) == "" {
 				continue
 			}
 			intakeRows = append(intakeRows, intakeRow{
-				ID:                   columnValue(record, header, "id", "question_id"),
-				Question:             record[questionIndex],
-				Section:              columnValue(record, header, "section", "category"),
-				RequiredAnswerFormat: columnValue(record, header, "required_answer_format", "answer_format", "format"),
-				MappedControls:       splitList(columnValue(record, header, "mapped_controls", "controls", "control_ids")),
-				RequiredSlots:        splitList(columnValue(record, header, "required_evidence_slots", "evidence_slots", "slots")),
-				OwnerID:              columnValue(record, header, "owner_id", "owner", "assignee"),
+				ID:                   columnValue(record.Values, header, "id", "question_id"),
+				Question:             record.Values[questionIndex],
+				Section:              columnValue(record.Values, header, "section", "category"),
+				RequiredAnswerFormat: columnValue(record.Values, header, "required_answer_format", "answer_format", "format"),
+				MappedControls:       splitList(columnValue(record.Values, header, "mapped_controls", "controls", "control_ids")),
+				RequiredSlots:        splitList(columnValue(record.Values, header, "required_evidence_slots", "evidence_slots", "slots")),
+				OwnerID:              columnValue(record.Values, header, "owner_id", "owner", "assignee"),
+				SourceLocator: &ports.QuestionnaireSourceLocator{
+					SourceFormat: "xlsx",
+					SheetName:    record.SheetName,
+					RowNumber:    record.RowNumber,
+					Cell:         cellRefAt(record.CellRefs, questionIndex),
+					ColumnName:   header[questionIndex],
+				},
 			})
 		}
 		return questionsFromIntakeRows(intakeRows), nil
 	}
 	return nil, fmt.Errorf("%w: xlsx workbook must include a question, question_text, or prompt column", ErrInvalidRequest)
+}
+
+func worksheetNameFromPath(path string) string {
+	name := strings.TrimSuffix(filepath.Base(strings.TrimSpace(path)), filepath.Ext(path))
+	return firstNonEmpty(name, "worksheet")
+}
+
+func xlsxRowNumber(ref string) int {
+	for index, char := range ref {
+		if char >= '0' && char <= '9' {
+			value, err := strconv.Atoi(ref[index:])
+			if err == nil {
+				return value
+			}
+			return 0
+		}
+	}
+	return 0
+}
+
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func cellRefAt(values []string, index int) string {
+	if index < 0 || index >= len(values) {
+		return ""
+	}
+	return strings.TrimSpace(values[index])
 }
 
 func xlsxCellValue(cell xlsxCell, sharedStrings []string) string {
@@ -365,11 +423,14 @@ func readZipFile(file *zip.File) ([]byte, error) {
 	return body, nil
 }
 
-func trimEmptyTail(values []string) []string {
+func trimEmptyTailWithRefs(values []string, refs []string) ([]string, []string) {
 	for len(values) > 0 && strings.TrimSpace(values[len(values)-1]) == "" {
 		values = values[:len(values)-1]
+		if len(refs) > len(values) {
+			refs = refs[:len(values)]
+		}
 	}
-	return values
+	return values, refs
 }
 
 func extractPDFText(data []byte) (string, error) {
@@ -416,12 +477,19 @@ func extractPDFText(data []byte) (string, error) {
 
 func parsePDFPromptText(value string) ([]ports.QuestionnaireQuestion, error) {
 	rows := []intakeRow{}
-	for _, line := range strings.Split(value, "\n") {
+	for lineIndex, line := range strings.Split(value, "\n") {
 		line = normalizePortalQuestionLine(line)
 		if line == "" || !looksLikeQuestionnairePrompt(line) {
 			continue
 		}
-		rows = append(rows, intakeRow{Question: line})
+		rows = append(rows, intakeRow{
+			Question: line,
+			SourceLocator: &ports.QuestionnaireSourceLocator{
+				SourceFormat: "pdf",
+				LineNumber:   lineIndex + 1,
+				Text:         line,
+			},
+		})
 	}
 	if len(rows) == 0 {
 		return nil, fmt.Errorf("%w: pdf intake did not contain extractable questionnaire prompts", ErrInvalidRequest)

--- a/internal/sourcehttp/questionnaire/intake_attachment.go
+++ b/internal/sourcehttp/questionnaire/intake_attachment.go
@@ -312,6 +312,9 @@ func questionsFromSpreadsheetRows(rows []spreadsheetRow) ([]ports.QuestionnaireQ
 		}
 		intakeRows := []intakeRow{}
 		for _, record := range rows[index+1:] {
+			if record.SheetName != row.SheetName {
+				break
+			}
 			if questionIndex >= len(record.Values) || strings.TrimSpace(record.Values[questionIndex]) == "" {
 				continue
 			}

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -2265,10 +2265,12 @@ export type GRCQuestionnaireAnswerConfidence = {
 export type GRCQuestionnaireAssignment = {
   created_at?: string;
   due_at?: string;
+  gap_id?: string;
   id?: string;
   owner_id?: string;
   question_id?: string;
   reason?: string;
+  slot_id?: string;
   status?: string;
   team?: string;
   updated_at?: string;
@@ -2276,9 +2278,11 @@ export type GRCQuestionnaireAssignment = {
 
 export type GRCQuestionnaireAssignmentRequest = {
   due_at?: string;
+  gap_id?: string;
   owner_id?: string;
   question_id?: string;
   reason?: string;
+  slot_id?: string;
   status?: string;
   team?: string;
   tenant_id?: string;
@@ -2288,12 +2292,19 @@ export type GRCQuestionnaireCitation = {
   control_id?: string;
   evidence_id?: string;
   evidence_packet_id?: string;
+  evidence_type?: string;
   expires_at?: string;
   freshness_status?: string;
+  graph_path_ids?: string[];
+  graph_root_urns?: string[];
   id?: string;
   label?: string;
   observed_at?: string;
+  resource_urn?: string;
+  runtime_id?: string;
   source?: string;
+  source_event_ids?: string[];
+  source_id?: string;
 };
 
 export type GRCQuestionnaireComment = {
@@ -2378,10 +2389,13 @@ export type GRCQuestionnaireEvidenceRef = {
   evidence_packet_id?: string;
   evidence_type?: string;
   freshness: GRCEvidenceFreshness;
+  graph_path_ids?: string[];
+  graph_root_urns?: string[];
   id: string;
   review_state?: string;
   runtime_id?: string;
   source?: string;
+  source_event_ids?: string[];
   source_id?: string;
 };
 
@@ -2420,6 +2434,7 @@ export type GRCQuestionnaireIntakeRow = {
   required_answer_format?: string;
   required_evidence_slots?: string[];
   section?: string;
+  source_locator?: GRCQuestionnaireSourceLocator;
 };
 
 export type GRCQuestionnaireProcessRunRequest = {
@@ -2437,6 +2452,7 @@ export type GRCQuestionnaireQuestion = {
   required_evidence_slots?: string[];
   review_state?: "ready" | "needs_review" | "blocked" | "approved" | "rejected";
   section?: string;
+  source_locator?: GRCQuestionnaireSourceLocator;
 };
 
 export type GRCQuestionnaireQuestionUpdateRequest = {
@@ -2542,6 +2558,7 @@ export type GRCQuestionnaireRunEvidenceGap = {
   evidence_packet_id?: string;
   id?: string;
   reason?: string;
+  review_state?: string;
   slot_id?: string;
 };
 
@@ -2568,6 +2585,22 @@ export type GRCQuestionnaireRunsResponse = {
   generated_at?: string;
   runs?: GRCQuestionnaireRun[];
   summary?: GRCQuestionnaireRunSummary;
+};
+
+export type GRCQuestionnaireSourceLocator = {
+  cell?: string;
+  column_name?: string;
+  line_number?: number;
+  page_number?: number;
+  portal_field_id?: string;
+  portal_field_label?: string;
+  portal_url?: string;
+  row_number?: number;
+  sheet_name?: string;
+  source_artifact_urn?: string;
+  source_filename?: string;
+  source_format?: string;
+  text?: string;
 };
 
 export type GRCQuestionnaireTimelineEvent = {


### PR DESCRIPTION
## Summary
- Preserve source locators for questionnaire questions from CSV, XLSX, PDF, text, and portal intake.
- Carry source IDs, runtime IDs, source events, graph roots, and graph path IDs from evidence packets into answer citations.
- Project questionnaire questions, answers, evidence slots, and evidence gaps as graph work items with control, owner, evidence, source-context, and assignment links.
- Publish the new fields through OpenAPI and regenerated TypeScript types.

## Validation
- go test ./api ./internal/questionnaire ./internal/sourcehttp/questionnaire ./internal/evidencepackets
- golangci-lint run --timeout 10m ./internal/questionnaire ./internal/sourcehttp/questionnaire ./internal/evidencepackets ./api
- make openapi-ts-check openapi-check openapi-lint
- make check-structural
- make check-structural-test
- make check-arch
- go test ./...
- make lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->