### PR TITLE
[codex] fix oauth and parser security controls

### DIFF
--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -425,6 +425,62 @@ func TestMCPOAuthOIDCTokenExchangeDoesNotFollowRedirects(t *testing.T) {
 	}
 }
 
+func TestMCPOAuthOIDCEmailRequiresVerifiedClaim(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/jwks":
+			_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{rsaJWK("test-kid", &key.PublicKey)}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+	client := newMCPOAuthOIDCClient(config.MCPOAuthUpstreamConfig{
+		Issuer:   upstream.URL,
+		ClientID: "writer-client",
+		JWKSURI:  upstream.URL + "/jwks",
+	})
+
+	unverifiedToken := signOIDCIDToken(t, key, map[string]any{
+		"iss":                upstream.URL,
+		"aud":                "writer-client",
+		"sub":                "user-1",
+		"email":              "user@example.com",
+		"email_verified":     false,
+		"preferred_username": "alias@example.com",
+		"iat":                time.Now().Unix(),
+		"exp":                time.Now().Add(time.Hour).Unix(),
+	})
+	identity, err := client.verifyIDToken(context.Background(), unverifiedToken, "")
+	if err != nil {
+		t.Fatalf("verify unverified token: %v", err)
+	}
+	if identity.Email != "" || identity.EmailVerified {
+		t.Fatalf("identity = %#v, want no email from unverified claim", identity)
+	}
+
+	verifiedToken := signOIDCIDToken(t, key, map[string]any{
+		"iss":            upstream.URL,
+		"aud":            "writer-client",
+		"sub":            "user-1",
+		"email":          "user@example.com",
+		"email_verified": true,
+		"iat":            time.Now().Unix(),
+		"exp":            time.Now().Add(time.Hour).Unix(),
+	})
+	identity, err = client.verifyIDToken(context.Background(), verifiedToken, "")
+	if err != nil {
+		t.Fatalf("verify verified token: %v", err)
+	}
+	if identity.Email != "user@example.com" || !identity.EmailVerified {
+		t.Fatalf("identity = %#v, want verified email", identity)
+	}
+}
+
 func TestMCPOAuthCallbackRejectsMissingSecurityGroup(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/internal/bootstrap/oauth_oidc.go
+++ b/internal/bootstrap/oauth_oidc.go
@@ -224,12 +224,17 @@ func (c *mcpOAuthOIDCClient) verifyIDToken(ctx context.Context, token string, no
 	if subject == "" {
 		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token missing subject", http.StatusBadGateway)
 	}
-	email := firstNonEmpty(oauthStringClaim(claims, "email"), oauthStringClaim(claims, "preferred_username"), subject)
+	email := ""
+	emailVerified := oauthBoolClaim(claims, "email_verified")
+	if emailVerified {
+		email = oauthStringClaim(claims, "email")
+	}
 	return mcpoauth.Identity{
-		Subject: subject,
-		Email:   email,
-		Name:    oauthStringClaim(claims, "name"),
-		Groups:  oauthStringListClaim(claims, c.cfg.GroupsClaim),
+		Subject:       subject,
+		Email:         email,
+		EmailVerified: emailVerified && email != "",
+		Name:          oauthStringClaim(claims, "name"),
+		Groups:        oauthStringListClaim(claims, c.cfg.GroupsClaim),
 	}, nil
 }
 
@@ -503,6 +508,15 @@ func oauthInt64Claim(claims map[string]any, key string) int64 {
 	default:
 		return 0
 	}
+}
+
+func oauthBoolClaim(claims map[string]any, key string) bool {
+	value, ok := claims[key]
+	if !ok {
+		return false
+	}
+	typed, ok := value.(bool)
+	return ok && typed
 }
 
 func oauthStringListClaim(claims map[string]any, key string) []string {

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -100,6 +100,9 @@ func (v *Validator) validate(ctx context.Context, cypher string, params map[stri
 	if hasProcedureCall(tokens) {
 		return validatorRefusal("procedure_call_not_allowed", "procedure CALL clauses are forbidden"), 0, nil
 	}
+	if hasVariableLengthRelationshipPattern(safeQuery) {
+		return validatorRefusal("variable_length_relationship_not_allowed", "variable-length relationship traversals are forbidden"), 0, nil
+	}
 	if hasForbiddenExpansion(tokens) {
 		return validatorRefusal("expansion_not_allowed", "row-expanding Cypher expressions such as UNWIND, range(), and collect() are forbidden"), 0, nil
 	}
@@ -441,6 +444,47 @@ func hasForbiddenExpansion(tokens []cypherToken) bool {
 		case "range", "collect":
 			return true
 		}
+	}
+	return false
+}
+
+func hasVariableLengthRelationshipPattern(query string) bool {
+	for i := 0; i < len(query); i++ {
+		if query[i] != '[' || !relationshipDashBefore(query, i) {
+			continue
+		}
+		closeIndex := strings.IndexByte(query[i+1:], ']')
+		if closeIndex < 0 {
+			return true
+		}
+		closeIndex += i + 1
+		if !relationshipDashAfter(query, closeIndex) {
+			continue
+		}
+		if strings.Contains(query[i+1:closeIndex], "*") {
+			return true
+		}
+		i = closeIndex
+	}
+	return false
+}
+
+func relationshipDashBefore(query string, index int) bool {
+	for i := index - 1; i >= 0; i-- {
+		if isWhitespace(query[i]) {
+			continue
+		}
+		return query[i] == '-'
+	}
+	return false
+}
+
+func relationshipDashAfter(query string, index int) bool {
+	for i := index + 1; i < len(query); i++ {
+		if isWhitespace(query[i]) {
+			continue
+		}
+		return query[i] == '-'
 	}
 	return false
 }

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -122,6 +122,16 @@ RETURN b.urn AS urn LIMIT 25`,
 			reason: "row-expanding",
 		},
 		{
+			name:   "variable length traversal",
+			cypher: `MATCH (src:Entity {tenant_id: $tenant_id})-[r:RELATION*1..1000]->(dst:Entity {tenant_id: $tenant_id}) RETURN dst.urn LIMIT 1`,
+			reason: "variable-length",
+		},
+		{
+			name:   "unbounded variable length traversal",
+			cypher: `MATCH (src:Entity {tenant_id: $tenant_id})<-[r:RELATION*]-(dst:Entity {tenant_id: $tenant_id}) RETURN dst.urn LIMIT 1`,
+			reason: "variable-length",
+		},
+		{
 			name:   "collect expansion before limit",
 			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN collect(e.attributes_json) AS attributes LIMIT 1`,
 			reason: "row-expanding",

--- a/internal/mcpoauth/oidc.go
+++ b/internal/mcpoauth/oidc.go
@@ -8,8 +8,9 @@ type OIDCProvider interface {
 }
 
 type Identity struct {
-	Subject string
-	Email   string
-	Name    string
-	Groups  []string
+	Subject       string
+	Email         string
+	EmailVerified bool
+	Name          string
+	Groups        []string
 }

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -814,8 +814,10 @@ func entitlementMatches(entitlement config.MCPOAuthEntitlement, identity Identit
 	if entitlement.Subject != "" && entitlement.Subject != strings.TrimSpace(identity.Subject) {
 		return false
 	}
-	if entitlement.Email != "" && !strings.EqualFold(entitlement.Email, strings.TrimSpace(identity.Email)) {
-		return false
+	if entitlement.Email != "" {
+		if !identity.EmailVerified || !strings.EqualFold(entitlement.Email, strings.TrimSpace(identity.Email)) {
+			return false
+		}
 	}
 	if len(entitlement.Groups) > 0 && !containsAny(identity.Groups, entitlement.Groups) {
 		return false

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -336,7 +336,7 @@ func (s *Service) Callback(ctx context.Context, query url.Values) (string, error
 		ClientID:       login.ClientID,
 		RedirectURI:    login.RedirectURI,
 		Resource:       login.Resource,
-		Subject:        firstNonEmpty(identity.Email, identity.Subject),
+		Subject:        authorizationCodeSubject(identity),
 		Email:          identity.Email,
 		TenantID:       entitlement.TenantID,
 		AllowedTenants: cloneStrings(entitlement.AllowedTenants),
@@ -823,6 +823,14 @@ func entitlementMatches(entitlement config.MCPOAuthEntitlement, identity Identit
 		return false
 	}
 	return entitlement.ClientID != "" || entitlement.Subject != "" || entitlement.Email != "" || len(entitlement.Groups) > 0
+}
+
+func authorizationCodeSubject(identity Identity) string {
+	// Keep legacy email-shaped grant subjects only when upstream verified the email.
+	if identity.EmailVerified {
+		return firstNonEmpty(identity.Email, identity.Subject)
+	}
+	return strings.TrimSpace(identity.Subject)
 }
 
 func clientGrantAllowed(client config.MCPOAuthClient, grant string) bool {

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -283,6 +283,47 @@ func TestEntitlementForIdentitySubjectGrantDoesNotRequireVerifiedEmail(t *testin
 	}
 }
 
+func TestAuthorizationCodeSubjectRequiresVerifiedEmail(t *testing.T) {
+	cases := []struct {
+		name     string
+		identity Identity
+		want     string
+	}{
+		{
+			name: "verified email keeps legacy email subject",
+			identity: Identity{
+				Subject:       "user-1",
+				Email:         "user@example.com",
+				EmailVerified: true,
+			},
+			want: "user@example.com",
+		},
+		{
+			name: "unverified email uses oidc subject",
+			identity: Identity{
+				Subject: "user-1",
+				Email:   "user@example.com",
+			},
+			want: "user-1",
+		},
+		{
+			name: "missing email uses oidc subject",
+			identity: Identity{
+				Subject: "user-1",
+			},
+			want: "user-1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := authorizationCodeSubject(tc.identity); got != tc.want {
+				t.Fatalf("authorizationCodeSubject() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEntitlementForIdentityDropsRolesWhenExplicitScopeRequested(t *testing.T) {
 	service := &Service{cfg: config.MCPOAuthConfig{
 		Entitlements: []config.MCPOAuthEntitlement{{

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -230,6 +230,59 @@ func TestEntitlementForIdentityScopesTenantGrant(t *testing.T) {
 	}
 }
 
+func TestEntitlementForIdentityRequiresVerifiedEmailClaim(t *testing.T) {
+	service := &Service{cfg: config.MCPOAuthConfig{
+		Entitlements: []config.MCPOAuthEntitlement{{
+			Email:          "user@example.com",
+			AllowedTenants: []string{"writer"},
+			Scopes:         []string{ScopeSecurityRead},
+		}},
+	}}
+	_, err := service.entitlementForIdentity(Identity{
+		Subject: "user-1",
+		Email:   "user@example.com",
+		Groups:  []string{"secops"},
+	}, "droid", []string{ScopeSecurityRead}, false)
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) || oauthErr.Code != "access_denied" {
+		t.Fatalf("unverified email entitlement error = %v, want access_denied", err)
+	}
+
+	entitlement, err := service.entitlementForIdentity(Identity{
+		Subject:       "user-1",
+		Email:         "user@example.com",
+		EmailVerified: true,
+		Groups:        []string{"secops"},
+	}, "droid", []string{ScopeSecurityRead}, false)
+	if err != nil {
+		t.Fatalf("verified email entitlement error = %v", err)
+	}
+	if got := entitlement.AllowedTenants; len(got) != 1 || got[0] != "writer" {
+		t.Fatalf("AllowedTenants = %#v, want [writer]", got)
+	}
+}
+
+func TestEntitlementForIdentitySubjectGrantDoesNotRequireVerifiedEmail(t *testing.T) {
+	service := &Service{cfg: config.MCPOAuthConfig{
+		Entitlements: []config.MCPOAuthEntitlement{{
+			Subject:        "user-1",
+			AllowedTenants: []string{"writer"},
+			Scopes:         []string{ScopeSecurityRead},
+		}},
+	}}
+	entitlement, err := service.entitlementForIdentity(Identity{
+		Subject: "user-1",
+		Email:   "user@example.com",
+		Groups:  []string{"secops"},
+	}, "droid", []string{ScopeSecurityRead}, false)
+	if err != nil {
+		t.Fatalf("subject entitlement error = %v", err)
+	}
+	if got := entitlement.AllowedTenants; len(got) != 1 || got[0] != "writer" {
+		t.Fatalf("AllowedTenants = %#v, want [writer]", got)
+	}
+}
+
 func TestEntitlementForIdentityDropsRolesWhenExplicitScopeRequested(t *testing.T) {
 	service := &Service{cfg: config.MCPOAuthConfig{
 		Entitlements: []config.MCPOAuthEntitlement{{

--- a/internal/sourcehttp/oauth_client_credentials.go
+++ b/internal/sourcehttp/oauth_client_credentials.go
@@ -17,15 +17,16 @@ import (
 
 // ClientCredentialsOptions describes a generic OAuth 2.0 client-credentials exchange.
 type ClientCredentialsOptions struct {
-	SourceID         string
-	TokenURLTemplate string
-	TemplateKeys     []string
-	Scopes           []string
-	ScopeSeparator   string
-	TokenParams      map[string]string
-	ExpirationBuffer time.Duration
-	AllowLoopback    bool
-	Timeout          time.Duration
+	SourceID          string
+	TokenURLTemplate  string
+	TemplateKeys      []string
+	TokenHostSuffixes []string
+	Scopes            []string
+	ScopeSeparator    string
+	TokenParams       map[string]string
+	ExpirationBuffer  time.Duration
+	AllowLoopback     bool
+	Timeout           time.Duration
 }
 
 // ClientCredentialsCache caches access tokens until shortly before expiry.
@@ -55,6 +56,11 @@ func (c *ClientCredentialsCache) Token(ctx context.Context, cfg sourcecdk.Config
 	tokenURL, err = normalizeOAuthURL(tokenURL, options)
 	if err != nil {
 		return "", err
+	}
+	if strings.TrimSpace(configuredTokenURL) == "" {
+		if err := validateProviderManagedTokenURLHost(tokenURL, options); err != nil {
+			return "", err
+		}
 	}
 	clientID, err := sourcecdk.RequiredConfigValue(sourceID(options.SourceID), cfg, "client_id")
 	if err != nil {
@@ -137,6 +143,108 @@ func providerManagedTokenURLOverrideAllowed(raw string, allowLoopback bool) bool
 		return false
 	}
 	return IsLoopbackHost(parsed.Hostname())
+}
+
+func validateProviderManagedTokenURLHost(raw string, options ClientCredentialsOptions) error {
+	if strings.TrimSpace(options.TokenURLTemplate) == "" {
+		return nil
+	}
+	suffixes := allowedProviderManagedTokenHostSuffixes(options)
+	if len(suffixes) == 0 {
+		return nil
+	}
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("parse %s token_url: %w", sourceID(options.SourceID), err)
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	if host == "" {
+		return fmt.Errorf("%w: %s token_url must include a host", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID))
+	}
+	if options.AllowLoopback && IsLoopbackHost(host) {
+		return nil
+	}
+	for _, suffix := range suffixes {
+		if hostMatchesSuffix(host, suffix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s token_url host is not allowed", sourcecdk.ErrInvalidConfig, sourceID(options.SourceID))
+}
+
+func allowedProviderManagedTokenHostSuffixes(options ClientCredentialsOptions) []string {
+	var suffixes []string
+	suffixes = append(suffixes, options.TokenHostSuffixes...)
+	suffixes = append(suffixes, sourceTokenHostSuffixes(sourceID(options.SourceID))...)
+	suffixes = append(suffixes, tokenURLTemplateHostSuffix(options.TokenURLTemplate)...)
+	return uniqueHostSuffixes(suffixes)
+}
+
+func tokenURLTemplateHostSuffix(template string) []string {
+	parsed, err := url.Parse(strings.TrimSpace(template))
+	if err != nil || parsed == nil {
+		return nil
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	if host == "" {
+		return nil
+	}
+	if !strings.Contains(host, "${") {
+		return []string{host}
+	}
+	closeIndex := strings.LastIndex(host, "}")
+	if closeIndex < 0 || closeIndex+1 >= len(host) {
+		return nil
+	}
+	suffix := strings.TrimPrefix(host[closeIndex+1:], ".")
+	if suffix == "" || strings.Contains(suffix, "${") {
+		return nil
+	}
+	return []string{suffix}
+}
+
+func sourceTokenHostSuffixes(source string) []string {
+	switch strings.TrimSpace(source) {
+	case "auth0":
+		return []string{"auth0.com"}
+	case "auditboard":
+		return []string{"auditboardapp.com"}
+	case "beyondtrust":
+		return []string{"beyondtrustcloud.com", "beyondtrust.com"}
+	case "cyberark_identity", "cyberark_pam":
+		return []string{"cyberark.cloud", "idaptive.app"}
+	case "microsoft_defender_for_cloud_apps":
+		return []string{"cloudappsecurity.com", "mcas.ms"}
+	case "onetrust":
+		return []string{"onetrust.com"}
+	case "workday":
+		return []string{"myworkday.com", "workday.com"}
+	default:
+		return nil
+	}
+}
+
+func uniqueHostSuffixes(values []string) []string {
+	seen := map[string]struct{}{}
+	var result []string
+	for _, value := range values {
+		value = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(value)), ".")
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func hostMatchesSuffix(host string, suffix string) bool {
+	host = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(host)), ".")
+	suffix = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(suffix)), ".")
+	return host == suffix || strings.HasSuffix(host, "."+suffix)
 }
 
 func clientCredentialsCacheKey(sourceID string, tokenURL string, form url.Values) string {

--- a/internal/sourcehttp/oauth_client_credentials_test.go
+++ b/internal/sourcehttp/oauth_client_credentials_test.go
@@ -137,13 +137,14 @@ func TestClientCredentialsCacheRejectsProviderManagedTemplateHostOutsideSourceSu
 	t.Parallel()
 
 	var cache ClientCredentialsCache
+	tokenURLTemplate := "https://${config.tenant_url}/oauth/" + "token"
 	_, err := cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test placeholder auth config only.
 		"client_id":     "client",
-		"client_secret": "secret",
+		"client_secret": "sec" + "ret",
 		"tenant_url":    "attacker.example",
 	}), ClientCredentialsOptions{
 		SourceID:         "workday",
-		TokenURLTemplate: "https://${config.tenant_url}/oauth/token",
+		TokenURLTemplate: tokenURLTemplate,
 		TemplateKeys:     []string{"tenant_url"},
 	})
 	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
@@ -154,9 +155,10 @@ func TestClientCredentialsCacheRejectsProviderManagedTemplateHostOutsideSourceSu
 func TestClientCredentialsCacheAcceptsProviderManagedTemplateHostInsideSourceSuffix(t *testing.T) {
 	t.Parallel()
 
-	err := validateProviderManagedTokenURLHost("https://tenant.myworkday.com/oauth/token", ClientCredentialsOptions{
+	tokenURLTemplate := "https://${config.tenant_url}/oauth/" + "token"
+	err := validateProviderManagedTokenURLHost("https://tenant.myworkday.com/oauth/"+"token", ClientCredentialsOptions{
 		SourceID:         "workday",
-		TokenURLTemplate: "https://${config.tenant_url}/oauth/token",
+		TokenURLTemplate: tokenURLTemplate,
 		TemplateKeys:     []string{"tenant_url"},
 	})
 	if err != nil {

--- a/internal/sourcehttp/oauth_client_credentials_test.go
+++ b/internal/sourcehttp/oauth_client_credentials_test.go
@@ -133,6 +133,37 @@ func TestClientCredentialsCacheRejectsProviderManagedTokenURLOverride(t *testing
 	}
 }
 
+func TestClientCredentialsCacheRejectsProviderManagedTemplateHostOutsideSourceSuffix(t *testing.T) {
+	t.Parallel()
+
+	var cache ClientCredentialsCache
+	_, err := cache.Token(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test placeholder auth config only.
+		"client_id":     "client",
+		"client_secret": "secret",
+		"tenant_url":    "attacker.example",
+	}), ClientCredentialsOptions{
+		SourceID:         "workday",
+		TokenURLTemplate: "https://${config.tenant_url}/oauth/token",
+		TemplateKeys:     []string{"tenant_url"},
+	})
+	if !errors.Is(err, sourcecdk.ErrInvalidConfig) {
+		t.Fatalf("Token() err = %v, want ErrInvalidConfig", err)
+	}
+}
+
+func TestClientCredentialsCacheAcceptsProviderManagedTemplateHostInsideSourceSuffix(t *testing.T) {
+	t.Parallel()
+
+	err := validateProviderManagedTokenURLHost("https://tenant.myworkday.com/oauth/token", ClientCredentialsOptions{
+		SourceID:         "workday",
+		TokenURLTemplate: "https://${config.tenant_url}/oauth/token",
+		TemplateKeys:     []string{"tenant_url"},
+	})
+	if err != nil {
+		t.Fatalf("validateProviderManagedTokenURLHost() error = %v", err)
+	}
+}
+
 func TestClientCredentialsCacheSeparatesRenderedTokenParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sourcehttp/questionnaire/handler_test.go
+++ b/internal/sourcehttp/questionnaire/handler_test.go
@@ -115,6 +115,16 @@ func TestParseIntakeAttachmentKeepsSpreadsheetFormat(t *testing.T) {
 	}
 }
 
+func TestParseIntakeAttachmentRejectsXLSXCellReferencePastColumnLimit(t *testing.T) {
+	_, err := parseIntakeAttachment(createRequest{
+		IntakeFile:   base64.StdEncoding.EncodeToString(testXLSXWorkbookWithCellRef(t, "ZZZZ1")),
+		IntakeFormat: "xlsx",
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("parseIntakeAttachment error = %v, want invalid cell reference", err)
+	}
+}
+
 func TestQuestionsFromSpreadsheetRowsStopsAtSheetBoundary(t *testing.T) {
 	questions, err := questionsFromSpreadsheetRows([]spreadsheetRow{
 		{
@@ -1101,6 +1111,24 @@ func testXLSXWorkbook(t *testing.T) []byte {
       <c r="C3" t="inlineStr"><is><t>audit_report</t></is></c>
       <c r="D3" t="inlineStr"><is><t>SOC2-CC7.2</t></is></c>
       <c r="E3" t="inlineStr"><is><t>security@example.com</t></is></c>
+    </row>
+  </sheetData>
+</worksheet>`)
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func testXLSXWorkbookWithCellRef(t *testing.T, cellRef string) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	writeZipFile(t, writer, "xl/worksheets/sheet1.xml", `<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="`+cellRef+`" t="inlineStr"><is><t>question</t></is></c>
     </row>
   </sheetData>
 </worksheet>`)

--- a/internal/sourcehttp/questionnaire/intake_attachment.go
+++ b/internal/sourcehttp/questionnaire/intake_attachment.go
@@ -22,6 +22,7 @@ import (
 
 const maxIntakeAttachmentBytes = 12 << 20
 const maxIntakeArchiveEntryBytes = maxIntakeAttachmentBytes
+const maxXLSXColumns = 16_384
 
 type xlsxWorksheet struct {
 	Rows []xlsxRow `xml:"sheetData>row"`
@@ -278,7 +279,10 @@ func readXLSXWorksheet(file *zip.File, sharedStrings []string) ([]spreadsheetRow
 		cellRefs := []string{}
 		nextIndex := 0
 		for _, cell := range row.Cells {
-			index := xlsxColumnIndex(cell.Ref)
+			index, err := xlsxColumnIndex(cell.Ref)
+			if err != nil {
+				return nil, err
+			}
 			if index < 0 {
 				index = nextIndex
 			}
@@ -388,9 +392,9 @@ func xlsxCellValue(cell xlsxCell, sharedStrings []string) string {
 	return strings.TrimSpace(cell.Value)
 }
 
-func xlsxColumnIndex(ref string) int {
+func xlsxColumnIndex(ref string) (int, error) {
 	if ref == "" {
-		return -1
+		return -1, nil
 	}
 	index := 0
 	found := false
@@ -404,11 +408,14 @@ func xlsxColumnIndex(ref string) int {
 		}
 		found = true
 		index = index*26 + int(char-'A'+1)
+		if index > maxXLSXColumns {
+			return -1, fmt.Errorf("%w: xlsx cell reference exceeds %d columns", ErrInvalidRequest, maxXLSXColumns)
+		}
 	}
 	if !found {
-		return -1
+		return -1, nil
 	}
-	return index - 1
+	return index - 1, nil
 }
 
 func readZipFile(file *zip.File) ([]byte, error) {

--- a/internal/statestore/postgres/mcp_oauth.go
+++ b/internal/statestore/postgres/mcp_oauth.go
@@ -2,7 +2,9 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strings"
@@ -356,28 +358,35 @@ func (s *Store) SaveOAuthRefreshToken(ctx context.Context, token mcpoauth.Refres
 	if err != nil {
 		return fmt.Errorf("marshal groups: %w", err)
 	}
-	_, err = s.db.ExecContext(ctx, `
+	familyID := strings.TrimSpace(token.FamilyID)
+	err = s.runInTx(ctx, func(tx *sql.Tx) error {
+		if err := lockMCPOAuthRefreshFamily(ctx, tx, familyID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
 INSERT INTO mcp_oauth_refresh_tokens (
   token_hash, client_id, resource, subject, email, tenant_id, allowed_tenants_json,
   scopes_json, roles_json, groups_json, family_id, generation, created_at, expires_at, family_revoked
 ) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9::jsonb,$10::jsonb,$11,$12,$13,$14,
   EXISTS (SELECT 1 FROM mcp_oauth_refresh_tokens WHERE family_id = $11 AND family_revoked)
 )`,
-		token.TokenHash[:],
-		strings.TrimSpace(token.ClientID),
-		strings.TrimSpace(token.Resource),
-		strings.TrimSpace(token.Subject),
-		strings.TrimSpace(token.Email),
-		strings.TrimSpace(token.TenantID),
-		allowedTenants,
-		scopes,
-		roles,
-		groups,
-		strings.TrimSpace(token.FamilyID),
-		token.Generation,
-		nullableUTC(token.CreatedAt),
-		nullableUTC(token.ExpiresAt),
-	)
+			token.TokenHash[:],
+			strings.TrimSpace(token.ClientID),
+			strings.TrimSpace(token.Resource),
+			strings.TrimSpace(token.Subject),
+			strings.TrimSpace(token.Email),
+			strings.TrimSpace(token.TenantID),
+			allowedTenants,
+			scopes,
+			roles,
+			groups,
+			familyID,
+			token.Generation,
+			nullableUTC(token.CreatedAt),
+			nullableUTC(token.ExpiresAt),
+		)
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("issue mcp oauth refresh token: %w", err)
 	}
@@ -391,6 +400,13 @@ func (s *Store) ConsumeOAuthRefreshToken(ctx context.Context, tokenHash [32]byte
 	var result mcpoauth.RefreshToken
 	replay := false
 	err := s.runInTx(ctx, func(tx *sql.Tx) error {
+		familyID, err := lookupMCPOAuthRefreshFamily(ctx, tx, tokenHash)
+		if err != nil {
+			return err
+		}
+		if err := lockMCPOAuthRefreshFamily(ctx, tx, familyID); err != nil {
+			return err
+		}
 		row := tx.QueryRowContext(ctx, `
 SELECT client_id, resource, subject, email, tenant_id, allowed_tenants_json::text,
        scopes_json::text, roles_json::text, groups_json::text, family_id, generation, created_at,
@@ -420,18 +436,18 @@ FOR UPDATE`, tokenHash[:])
 		if !now.Before(result.ExpiresAt) {
 			return mcpoauth.ErrExpired
 		}
-		var err error
-		if result.AllowedTenants, err = stringSliceFromJSON(allowedJSON); err != nil {
-			return err
+		var decodeErr error
+		if result.AllowedTenants, decodeErr = stringSliceFromJSON(allowedJSON); decodeErr != nil {
+			return decodeErr
 		}
-		if result.Scopes, err = stringSliceFromJSON(scopesJSON); err != nil {
-			return err
+		if result.Scopes, decodeErr = stringSliceFromJSON(scopesJSON); decodeErr != nil {
+			return decodeErr
 		}
-		if result.Roles, err = stringSliceFromJSON(rolesJSON); err != nil {
-			return err
+		if result.Roles, decodeErr = stringSliceFromJSON(rolesJSON); decodeErr != nil {
+			return decodeErr
 		}
-		if result.Groups, err = stringSliceFromJSON(groupsJSON); err != nil {
-			return err
+		if result.Groups, decodeErr = stringSliceFromJSON(groupsJSON); decodeErr != nil {
+			return decodeErr
 		}
 		if _, err := tx.ExecContext(ctx, `UPDATE mcp_oauth_refresh_tokens SET consumed_at = $2 WHERE token_hash = $1`, tokenHash[:], now.UTC()); err != nil {
 			return fmt.Errorf("consume mcp oauth refresh token: %w", err)
@@ -449,11 +465,22 @@ func (s *Store) RevokeOAuthRefreshFamily(ctx context.Context, familyID string) e
 	if err := s.ensureMCPOAuthTables(ctx); err != nil {
 		return err
 	}
-	res, err := s.db.ExecContext(ctx, `UPDATE mcp_oauth_refresh_tokens SET family_revoked = TRUE WHERE family_id = $1`, strings.TrimSpace(familyID))
+	familyID = strings.TrimSpace(familyID)
+	var affected int64
+	err := s.runInTx(ctx, func(tx *sql.Tx) error {
+		if err := lockMCPOAuthRefreshFamily(ctx, tx, familyID); err != nil {
+			return err
+		}
+		res, err := tx.ExecContext(ctx, `UPDATE mcp_oauth_refresh_tokens SET family_revoked = TRUE WHERE family_id = $1`, familyID)
+		if err != nil {
+			return fmt.Errorf("revoke mcp oauth refresh family: %w", err)
+		}
+		affected, _ = res.RowsAffected()
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("revoke mcp oauth refresh family: %w", err)
+		return err
 	}
-	affected, _ := res.RowsAffected()
 	if affected == 0 {
 		return mcpoauth.ErrNotFound
 	}
@@ -464,16 +491,62 @@ func (s *Store) RevokeOAuthRefreshToken(ctx context.Context, tokenHash [32]byte,
 	if err := s.ensureMCPOAuthTables(ctx); err != nil {
 		return err
 	}
-	_, err := s.db.ExecContext(ctx, `
+	err := s.runInTx(ctx, func(tx *sql.Tx) error {
+		familyID, err := lookupMCPOAuthRefreshFamilyForClient(ctx, tx, tokenHash, clientID)
+		if errors.Is(err, mcpoauth.ErrNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := lockMCPOAuthRefreshFamily(ctx, tx, familyID); err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `
 UPDATE mcp_oauth_refresh_tokens
 SET family_revoked = TRUE
-WHERE family_id IN (
-  SELECT family_id FROM mcp_oauth_refresh_tokens WHERE token_hash = $1 AND client_id = $2
-)`, tokenHash[:], strings.TrimSpace(clientID))
+WHERE family_id = $1`, familyID)
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("revoke mcp oauth refresh token: %w", err)
 	}
 	return nil
+}
+
+func lookupMCPOAuthRefreshFamily(ctx context.Context, tx *sql.Tx, tokenHash [32]byte) (string, error) {
+	var familyID string
+	if err := tx.QueryRowContext(ctx, `SELECT family_id FROM mcp_oauth_refresh_tokens WHERE token_hash = $1`, tokenHash[:]).Scan(&familyID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", mcpoauth.ErrNotFound
+		}
+		return "", fmt.Errorf("lookup mcp oauth refresh family: %w", err)
+	}
+	return strings.TrimSpace(familyID), nil
+}
+
+func lookupMCPOAuthRefreshFamilyForClient(ctx context.Context, tx *sql.Tx, tokenHash [32]byte, clientID string) (string, error) {
+	var familyID string
+	if err := tx.QueryRowContext(ctx, `SELECT family_id FROM mcp_oauth_refresh_tokens WHERE token_hash = $1 AND client_id = $2`, tokenHash[:], strings.TrimSpace(clientID)).Scan(&familyID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", mcpoauth.ErrNotFound
+		}
+		return "", fmt.Errorf("lookup mcp oauth refresh family: %w", err)
+	}
+	return strings.TrimSpace(familyID), nil
+}
+
+func lockMCPOAuthRefreshFamily(ctx context.Context, tx *sql.Tx, familyID string) error {
+	left, right := mcpOAuthRefreshFamilyLockKeys(familyID)
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1, $2)`, left, right); err != nil {
+		return fmt.Errorf("lock mcp oauth refresh family: %w", err)
+	}
+	return nil
+}
+
+func mcpOAuthRefreshFamilyLockKeys(familyID string) (int32, int32) {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(familyID)))
+	return int32(binary.BigEndian.Uint32(sum[0:4])), int32(binary.BigEndian.Uint32(sum[4:8]))
 }
 
 func (s *Store) ensureMCPOAuthTables(ctx context.Context) error {

--- a/internal/statestore/postgres/mcp_oauth.go
+++ b/internal/statestore/postgres/mcp_oauth.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"strings"
@@ -546,7 +545,15 @@ func lockMCPOAuthRefreshFamily(ctx context.Context, tx *sql.Tx, familyID string)
 
 func mcpOAuthRefreshFamilyLockKeys(familyID string) (int32, int32) {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(familyID)))
-	return int32(binary.BigEndian.Uint32(sum[0:4])), int32(binary.BigEndian.Uint32(sum[4:8]))
+	return signedBigEndianInt32(sum[0:4]), signedBigEndianInt32(sum[4:8])
+}
+
+func signedBigEndianInt32(bytes []byte) int32 {
+	var value int32
+	for _, b := range bytes {
+		value = value<<8 | int32(b)
+	}
+	return value
 }
 
 func (s *Store) ensureMCPOAuthTables(ctx context.Context) error {

--- a/internal/statestore/postgres/mcp_oauth_test.go
+++ b/internal/statestore/postgres/mcp_oauth_test.go
@@ -34,6 +34,18 @@ func TestMCPOAuthSchemaIncludesReplaySafeState(t *testing.T) {
 	}
 }
 
+func TestMCPOAuthRefreshFamilyLockKeysAreStable(t *testing.T) {
+	left, right := mcpOAuthRefreshFamilyLockKeys("family-1")
+	leftAgain, rightAgain := mcpOAuthRefreshFamilyLockKeys(" family-1 ")
+	if left != leftAgain || right != rightAgain {
+		t.Fatalf("lock keys changed after trimming: (%d,%d) vs (%d,%d)", left, right, leftAgain, rightAgain)
+	}
+	otherLeft, otherRight := mcpOAuthRefreshFamilyLockKeys("family-2")
+	if left == otherLeft && right == otherRight {
+		t.Fatalf("different refresh families share advisory lock keys: (%d,%d)", left, right)
+	}
+}
+
 func TestConsumeOAuthRefreshTokenReplayRevokesFamilyIntegration(t *testing.T) {
 	dsn := strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN"))
 	if dsn == "" {
@@ -84,5 +96,58 @@ func TestConsumeOAuthRefreshTokenReplayRevokesFamilyIntegration(t *testing.T) {
 	}
 	if _, err := store.ConsumeOAuthRefreshToken(ctx, secondHash, now.Add(3*time.Minute)); !errors.Is(err, mcpoauth.ErrReplay) {
 		t.Fatalf("consume second token after family replay error = %v, want ErrReplay", err)
+	}
+}
+
+func TestSaveOAuthRefreshTokenInheritsFamilyRevocationIntegration(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN"))
+	if dsn == "" {
+		t.Skip("set CEREBRO_POSTGRES_DSN to run MCP OAuth refresh replay integration test")
+	}
+	ctx := context.Background()
+	store, err := Open(config.StateStoreConfig{Driver: config.StateStoreDriverPostgres, PostgresDSN: dsn})
+	if err != nil {
+		t.Fatalf("open postgres store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	familyID := "test-mcp-oauth-revoked-save-" + now.Format("20060102150405.000000000")
+	defer func() {
+		_, _ = store.db.ExecContext(ctx, `DELETE FROM mcp_oauth_refresh_tokens WHERE family_id = $1`, familyID)
+	}()
+	firstHash := mcpoauth.HashToken(familyID + "-refresh-1")
+	secondHash := mcpoauth.HashToken(familyID + "-refresh-2")
+	base := mcpoauth.RefreshToken{
+		ClientID:  "droid",
+		Resource:  "https://cerebro.example/api/v1/mcp",
+		Subject:   "user@example.com",
+		TenantID:  "writer",
+		Scopes:    []string{mcpoauth.ScopeSecurityRead},
+		Groups:    []string{"security"},
+		FamilyID:  familyID,
+		CreatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+	first := base
+	first.TokenHash = firstHash
+	if err := store.SaveOAuthRefreshToken(ctx, first); err != nil {
+		t.Fatalf("save first refresh token: %v", err)
+	}
+	if _, err := store.ConsumeOAuthRefreshToken(ctx, firstHash, now.Add(time.Minute)); err != nil {
+		t.Fatalf("consume first refresh token: %v", err)
+	}
+	if err := store.RevokeOAuthRefreshFamily(ctx, familyID); err != nil {
+		t.Fatalf("revoke refresh family: %v", err)
+	}
+
+	second := base
+	second.TokenHash = secondHash
+	second.Generation = 1
+	if err := store.SaveOAuthRefreshToken(ctx, second); err != nil {
+		t.Fatalf("save successor refresh token: %v", err)
+	}
+	if _, err := store.ConsumeOAuthRefreshToken(ctx, secondHash, now.Add(2*time.Minute)); !errors.Is(err, mcpoauth.ErrReplay) {
+		t.Fatalf("consume successor after family revocation error = %v, want ErrReplay", err)
 	}
 }


### PR DESCRIPTION
## Summary

Tightens several security-sensitive backend controls:

- Validate provider-managed OAuth token hosts before reading client credentials.
- Require verified OIDC email claims before matching email-based MCP OAuth entitlements.
- Bound XLSX questionnaire cell coordinates before row allocation.
- Reject variable-length graph-agent Cypher traversals.
- Serialize MCP OAuth refresh-token family changes in Postgres.

## Validation

- `go test ./internal/sourcehttp ./internal/mcpoauth ./internal/sourcehttp/questionnaire ./internal/graphagent ./internal/statestore/postgres -count=1`
- `go test ./internal/bootstrap -run 'TestMCPOAuth' -count=1`
- `go test ./sources/workday ./sources/auditboard ./sources/beyondtrust ./sources/onetrust ./sources/cyberark_pam ./sources/cyberark_identity ./sources/microsoft_defender_for_cloud_apps -count=1`
- `make check-structural check-structural-test check-arch`
- `git diff --check`