### PR TITLE
[codex] guard OAuth identity authority boundaries

### DIFF
--- a/docs/engineering/security-regression-harness.md
+++ b/docs/engineering/security-regression-harness.md
@@ -10,6 +10,7 @@ This harness keeps recent Droid findings from becoming one-off fixes. Add new sc
 | Oversized VulnDB advisory feeds | `go test ./internal/vulndb`; feed importers return `ErrVulnDBFeedTooLarge` before decoding over-limit OSV, CISA KEV, EPSS, or NVD payloads. |
 | Spoofable `X-Forwarded-For`, DPoP `htu`, and audit client IP drift | `go test ./internal/bootstrap ./internal/config`; request origin is resolved through `internal/bootstrap/request_origin.go` and configured by `CEREBRO_PUBLIC_ORIGIN`, `CEREBRO_TRUSTED_PROXY_CIDRS`, and `CEREBRO_TRUSTED_PROXY_COUNT`. |
 | Candidate promote/reject lost updates and partial lifecycle attempts | `go test ./internal/findings`; lifecycle decisions use stable IDs and recover completed concurrent CAS transitions. |
+| OAuth identity email used as authority before verification | `go test ./internal/mcpoauth ./internal/bootstrap -run 'TestEntitlementForIdentityRequiresVerifiedEmailClaim|TestAuthorizationCodeSubjectRequiresVerifiedEmail|TestMCPOAuthOIDCClientVerifiesIDToken'` plus `make check-structural`; `mcpoauth.Identity` carries only typed `VerifiedEmail` values and `noidentityemail` rejects direct identity email field reads. |
 
 Before dismissing a future scanner report as a false positive, add one of:
 
@@ -20,5 +21,6 @@ Before dismissing a future scanner report as a false positive, add one of:
 Run the focused harness locally with:
 
 ```bash
-go test ./internal/graphagent ./internal/sourcehttp ./internal/bootstrap ./internal/config ./internal/findings ./internal/vulndb ./tools/archtests
+go test ./internal/graphagent ./internal/sourcehttp ./internal/bootstrap ./internal/config ./internal/findings ./internal/vulndb ./internal/mcpoauth ./tools/archtests
+make check-structural
 ```

--- a/docs/engineering/security-regression-harness.md
+++ b/docs/engineering/security-regression-harness.md
@@ -10,7 +10,7 @@ This harness keeps recent Droid findings from becoming one-off fixes. Add new sc
 | Oversized VulnDB advisory feeds | `go test ./internal/vulndb`; feed importers return `ErrVulnDBFeedTooLarge` before decoding over-limit OSV, CISA KEV, EPSS, or NVD payloads. |
 | Spoofable `X-Forwarded-For`, DPoP `htu`, and audit client IP drift | `go test ./internal/bootstrap ./internal/config`; request origin is resolved through `internal/bootstrap/request_origin.go` and configured by `CEREBRO_PUBLIC_ORIGIN`, `CEREBRO_TRUSTED_PROXY_CIDRS`, and `CEREBRO_TRUSTED_PROXY_COUNT`. |
 | Candidate promote/reject lost updates and partial lifecycle attempts | `go test ./internal/findings`; lifecycle decisions use stable IDs and recover completed concurrent CAS transitions. |
-| OAuth identity email used as authority before verification | `go test ./internal/mcpoauth ./internal/bootstrap -run 'TestEntitlementForIdentityRequiresVerifiedEmailClaim|TestAuthorizationCodeSubjectRequiresVerifiedEmail|TestMCPOAuthOIDCClientVerifiesIDToken'` plus `make check-structural`; `mcpoauth.Identity` carries only typed `VerifiedEmail` values and `noidentityemail` rejects direct identity email field reads. |
+| OAuth identity email used as authority before verification | `go test ./internal/mcpoauth ./internal/bootstrap -run 'TestEntitlementForIdentityRequiresVerifiedEmailClaim|TestAuthorizationCodeSubjectRequiresVerifiedEmail|TestMCPOAuthOIDCEmailRequiresVerifiedClaim'` plus `make check-structural`; `mcpoauth.Identity` carries only typed `VerifiedEmail` values and `noidentityemail` rejects direct identity email field reads. |
 
 Before dismissing a future scanner report as a false positive, add one of:
 

--- a/internal/bootstrap/mcp_oauth_test.go
+++ b/internal/bootstrap/mcp_oauth_test.go
@@ -459,7 +459,7 @@ func TestMCPOAuthOIDCEmailRequiresVerifiedClaim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verify unverified token: %v", err)
 	}
-	if identity.Email != "" || identity.EmailVerified {
+	if email, ok := identity.VerifiedEmail(); email != "" || ok {
 		t.Fatalf("identity = %#v, want no email from unverified claim", identity)
 	}
 
@@ -476,7 +476,7 @@ func TestMCPOAuthOIDCEmailRequiresVerifiedClaim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verify verified token: %v", err)
 	}
-	if identity.Email != "user@example.com" || !identity.EmailVerified {
+	if email, ok := identity.VerifiedEmail(); email != "user@example.com" || !ok {
 		t.Fatalf("identity = %#v, want verified email", identity)
 	}
 }

--- a/internal/bootstrap/oauth_oidc.go
+++ b/internal/bootstrap/oauth_oidc.go
@@ -224,18 +224,13 @@ func (c *mcpOAuthOIDCClient) verifyIDToken(ctx context.Context, token string, no
 	if subject == "" {
 		return mcpoauth.Identity{}, mcpoauthOAuthError("invalid_grant", "upstream id_token missing subject", http.StatusBadGateway)
 	}
-	email := ""
-	emailVerified := oauthBoolClaim(claims, "email_verified")
-	if emailVerified {
-		email = oauthStringClaim(claims, "email")
-	}
-	return mcpoauth.Identity{
-		Subject:       subject,
-		Email:         email,
-		EmailVerified: emailVerified && email != "",
-		Name:          oauthStringClaim(claims, "name"),
-		Groups:        oauthStringListClaim(claims, c.cfg.GroupsClaim),
-	}, nil
+	email, _ := mcpoauth.NewVerifiedEmail(oauthStringClaim(claims, "email"), oauthBoolClaim(claims, "email_verified"))
+	return mcpoauth.NewIdentity(
+		subject,
+		email,
+		oauthStringClaim(claims, "name"),
+		oauthStringListClaim(claims, c.cfg.GroupsClaim),
+	), nil
 }
 
 type oauthOIDCDiscovery struct {

--- a/internal/mcpoauth/oidc.go
+++ b/internal/mcpoauth/oidc.go
@@ -1,16 +1,67 @@
 package mcpoauth
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 type OIDCProvider interface {
 	AuthorizationEndpoint(context.Context) (string, error)
 	ExchangeCode(context.Context, string, string) (Identity, error)
 }
 
+type VerifiedEmail struct {
+	value string
+}
+
+func NewVerifiedEmail(email string, verified bool) (VerifiedEmail, bool) {
+	email = strings.TrimSpace(email)
+	if !verified || email == "" {
+		return VerifiedEmail{}, false
+	}
+	return VerifiedEmail{value: email}, true
+}
+
+func (email VerifiedEmail) String() string {
+	return email.value
+}
+
 type Identity struct {
-	Subject       string
-	Email         string
-	EmailVerified bool
-	Name          string
-	Groups        []string
+	subject string
+	email   VerifiedEmail
+	name    string
+	groups  []string
+}
+
+func NewIdentity(subject string, email VerifiedEmail, name string, groups []string) Identity {
+	return Identity{
+		subject: strings.TrimSpace(subject),
+		email:   email,
+		name:    strings.TrimSpace(name),
+		groups:  normalizeStrings(groups),
+	}
+}
+
+func (identity Identity) PrincipalSubject() string {
+	return identity.subject
+}
+
+func (identity Identity) VerifiedEmail() (string, bool) {
+	email := identity.email.String()
+	if email == "" {
+		return "", false
+	}
+	return email, true
+}
+
+func (identity Identity) ContactEmail() string {
+	return identity.email.String()
+}
+
+func (identity Identity) DisplayName() string {
+	return identity.name
+}
+
+func (identity Identity) Groups() []string {
+	return cloneStrings(identity.groups)
 }

--- a/internal/mcpoauth/service.go
+++ b/internal/mcpoauth/service.go
@@ -318,7 +318,8 @@ func (s *Service) Callback(ctx context.Context, query url.Values) (string, error
 	if err != nil {
 		return "", err
 	}
-	if !containsAny(identity.Groups, s.cfg.Upstream.SecurityGroups) {
+	identityGroups := identity.Groups()
+	if !containsAny(identityGroups, s.cfg.Upstream.SecurityGroups) {
 		return "", oauthError("access_denied", "authenticated user is not in an authorized security group", statusForbidden)
 	}
 	entitlement, err := s.entitlementForIdentity(identity, login.ClientID, login.Scopes, login.ScopesExplicit)
@@ -331,22 +332,7 @@ func (s *Service) Callback(ctx context.Context, query url.Values) (string, error
 	}
 	now := s.now().UTC()
 	_ = s.recordIdentity(ctx, identity, entitlement, now)
-	if err := s.store.SaveAuthorizationCode(ctx, AuthorizationCode{
-		CodeHash:       HashToken(codeToken),
-		ClientID:       login.ClientID,
-		RedirectURI:    login.RedirectURI,
-		Resource:       login.Resource,
-		Subject:        authorizationCodeSubject(identity),
-		Email:          identity.Email,
-		TenantID:       entitlement.TenantID,
-		AllowedTenants: cloneStrings(entitlement.AllowedTenants),
-		Scopes:         cloneStrings(entitlement.Scopes),
-		Roles:          cloneStrings(entitlement.Roles),
-		Groups:         []string{"security"},
-		CodeChallenge:  login.CodeChallenge,
-		CreatedAt:      now,
-		ExpiresAt:      now.Add(s.cfg.CodeTTL),
-	}); err != nil {
+	if err := s.store.SaveAuthorizationCode(ctx, authorizationCodeFromLogin(login, identity, entitlement, codeToken, now, s.cfg.CodeTTL)); err != nil {
 		return "", fmt.Errorf("mcpoauth: save authorization code: %w", err)
 	}
 	redirect, err := url.Parse(login.RedirectURI)
@@ -723,8 +709,10 @@ func (s *Service) recordIdentity(ctx context.Context, identity Identity, entitle
 		if err := store.UpsertIdentityOrganization(ctx, org); err != nil {
 			return fmt.Errorf("mcpoauth: record identity organization: %w", err)
 		}
-		userID := firstNonEmpty(identity.Subject, identity.Email)
-		displayName := firstNonEmpty(identity.Name, identity.Email, identity.Subject)
+		subject := identity.PrincipalSubject()
+		email := identity.ContactEmail()
+		displayName := firstNonEmpty(identity.DisplayName(), email, subject)
+		userID := firstNonEmpty(subject, email)
 		if userID == "" || displayName == "" {
 			continue
 		}
@@ -732,14 +720,14 @@ func (s *Service) recordIdentity(ctx context.Context, identity Identity, entitle
 			UserID:       userID,
 			TenantID:     tenantID,
 			OrgID:        tenantID,
-			Subject:      strings.TrimSpace(identity.Subject),
-			Email:        strings.ToLower(strings.TrimSpace(identity.Email)),
+			Subject:      subject,
+			Email:        strings.ToLower(email),
 			DisplayName:  displayName,
 			Status:       "active",
 			Provider:     provider,
 			Source:       "mcp_oauth",
 			Roles:        cloneStrings(entitlement.Roles),
-			Groups:       cloneStrings(identity.Groups),
+			Groups:       identity.Groups(),
 			LastSeenAt:   now,
 			LastSyncedAt: now,
 		}
@@ -811,15 +799,16 @@ func entitlementMatches(entitlement config.MCPOAuthEntitlement, identity Identit
 	if entitlement.ClientID != "" && entitlement.ClientID != strings.TrimSpace(clientID) {
 		return false
 	}
-	if entitlement.Subject != "" && entitlement.Subject != strings.TrimSpace(identity.Subject) {
+	if entitlement.Subject != "" && entitlement.Subject != identity.PrincipalSubject() {
 		return false
 	}
 	if entitlement.Email != "" {
-		if !identity.EmailVerified || !strings.EqualFold(entitlement.Email, strings.TrimSpace(identity.Email)) {
+		email, ok := identity.VerifiedEmail()
+		if !ok || !strings.EqualFold(entitlement.Email, email) {
 			return false
 		}
 	}
-	if len(entitlement.Groups) > 0 && !containsAny(identity.Groups, entitlement.Groups) {
+	if len(entitlement.Groups) > 0 && !containsAny(identity.Groups(), entitlement.Groups) {
 		return false
 	}
 	return entitlement.ClientID != "" || entitlement.Subject != "" || entitlement.Email != "" || len(entitlement.Groups) > 0
@@ -827,10 +816,29 @@ func entitlementMatches(entitlement config.MCPOAuthEntitlement, identity Identit
 
 func authorizationCodeSubject(identity Identity) string {
 	// Keep legacy email-shaped grant subjects only when upstream verified the email.
-	if identity.EmailVerified {
-		return firstNonEmpty(identity.Email, identity.Subject)
+	if email, ok := identity.VerifiedEmail(); ok {
+		return firstNonEmpty(email, identity.PrincipalSubject())
 	}
-	return strings.TrimSpace(identity.Subject)
+	return identity.PrincipalSubject()
+}
+
+func authorizationCodeFromLogin(login LoginState, identity Identity, entitlement grantEntitlement, codeToken string, now time.Time, ttl time.Duration) AuthorizationCode {
+	return AuthorizationCode{
+		CodeHash:       HashToken(codeToken),
+		ClientID:       login.ClientID,
+		RedirectURI:    login.RedirectURI,
+		Resource:       login.Resource,
+		Subject:        authorizationCodeSubject(identity),
+		Email:          identity.ContactEmail(),
+		TenantID:       entitlement.TenantID,
+		AllowedTenants: cloneStrings(entitlement.AllowedTenants),
+		Scopes:         cloneStrings(entitlement.Scopes),
+		Roles:          cloneStrings(entitlement.Roles),
+		Groups:         []string{"security"},
+		CodeChallenge:  login.CodeChallenge,
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(ttl),
+	}
 }
 
 func clientGrantAllowed(client config.MCPOAuthClient, grant string) bool {

--- a/internal/mcpoauth/service_test.go
+++ b/internal/mcpoauth/service_test.go
@@ -14,6 +14,19 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+func identityForTest(subject string, groups []string) Identity {
+	return NewIdentity(subject, VerifiedEmail{}, "", groups)
+}
+
+func verifiedIdentityForTest(t *testing.T, subject string, email string, name string, groups []string) Identity {
+	t.Helper()
+	verifiedEmail, ok := NewVerifiedEmail(email, true)
+	if !ok {
+		t.Fatalf("NewVerifiedEmail(%q, true) rejected test email", email)
+	}
+	return NewIdentity(subject, verifiedEmail, name, groups)
+}
+
 func TestTokenRefreshReplayRevokesFamily(t *testing.T) {
 	store := &replayRefreshStore{
 		consumeRecord: RefreshToken{FamilyID: "family-1"},
@@ -208,11 +221,7 @@ func TestEntitlementForIdentityScopesTenantGrant(t *testing.T) {
 			Scopes:         []string{ScopeSecurityRead},
 		}},
 	}}
-	entitlement, err := service.entitlementForIdentity(Identity{
-		Subject: "user-1",
-		Email:   "user@example.com",
-		Groups:  []string{"secops"},
-	}, "droid", []string{ScopeSecurityRead}, false)
+	entitlement, err := service.entitlementForIdentity(identityForTest("user-1", []string{"secops"}), "droid", []string{ScopeSecurityRead}, false)
 	if err != nil {
 		t.Fatalf("entitlementForIdentity error = %v", err)
 	}
@@ -220,10 +229,7 @@ func TestEntitlementForIdentityScopesTenantGrant(t *testing.T) {
 		t.Fatalf("AllowedTenants = %#v, want [writer]", got)
 	}
 
-	_, err = service.entitlementForIdentity(Identity{
-		Subject: "user-2",
-		Groups:  []string{"engineering"},
-	}, "droid", []string{ScopeSecurityRead}, false)
+	_, err = service.entitlementForIdentity(identityForTest("user-2", []string{"engineering"}), "droid", []string{ScopeSecurityRead}, false)
 	var oauthErr *OAuthError
 	if !errors.As(err, &oauthErr) || oauthErr.Code != "access_denied" {
 		t.Fatalf("missing entitlement error = %v, want access_denied", err)
@@ -238,22 +244,17 @@ func TestEntitlementForIdentityRequiresVerifiedEmailClaim(t *testing.T) {
 			Scopes:         []string{ScopeSecurityRead},
 		}},
 	}}
-	_, err := service.entitlementForIdentity(Identity{
-		Subject: "user-1",
-		Email:   "user@example.com",
-		Groups:  []string{"secops"},
-	}, "droid", []string{ScopeSecurityRead}, false)
+	unverifiedEmail, ok := NewVerifiedEmail("user@example.com", false)
+	if ok {
+		t.Fatal("NewVerifiedEmail accepted an unverified email")
+	}
+	_, err := service.entitlementForIdentity(NewIdentity("user-1", unverifiedEmail, "", []string{"secops"}), "droid", []string{ScopeSecurityRead}, false)
 	var oauthErr *OAuthError
 	if !errors.As(err, &oauthErr) || oauthErr.Code != "access_denied" {
 		t.Fatalf("unverified email entitlement error = %v, want access_denied", err)
 	}
 
-	entitlement, err := service.entitlementForIdentity(Identity{
-		Subject:       "user-1",
-		Email:         "user@example.com",
-		EmailVerified: true,
-		Groups:        []string{"secops"},
-	}, "droid", []string{ScopeSecurityRead}, false)
+	entitlement, err := service.entitlementForIdentity(verifiedIdentityForTest(t, "user-1", "user@example.com", "", []string{"secops"}), "droid", []string{ScopeSecurityRead}, false)
 	if err != nil {
 		t.Fatalf("verified email entitlement error = %v", err)
 	}
@@ -270,11 +271,7 @@ func TestEntitlementForIdentitySubjectGrantDoesNotRequireVerifiedEmail(t *testin
 			Scopes:         []string{ScopeSecurityRead},
 		}},
 	}}
-	entitlement, err := service.entitlementForIdentity(Identity{
-		Subject: "user-1",
-		Email:   "user@example.com",
-		Groups:  []string{"secops"},
-	}, "droid", []string{ScopeSecurityRead}, false)
+	entitlement, err := service.entitlementForIdentity(identityForTest("user-1", []string{"secops"}), "droid", []string{ScopeSecurityRead}, false)
 	if err != nil {
 		t.Fatalf("subject entitlement error = %v", err)
 	}
@@ -290,28 +287,19 @@ func TestAuthorizationCodeSubjectRequiresVerifiedEmail(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "verified email keeps legacy email subject",
-			identity: Identity{
-				Subject:       "user-1",
-				Email:         "user@example.com",
-				EmailVerified: true,
-			},
-			want: "user@example.com",
+			name:     "verified email keeps legacy email subject",
+			identity: verifiedIdentityForTest(t, "user-1", "user@example.com", "", nil),
+			want:     "user@example.com",
 		},
 		{
-			name: "unverified email uses oidc subject",
-			identity: Identity{
-				Subject: "user-1",
-				Email:   "user@example.com",
-			},
-			want: "user-1",
+			name:     "unverified email uses oidc subject",
+			identity: NewIdentity("user-1", VerifiedEmail{}, "", nil),
+			want:     "user-1",
 		},
 		{
-			name: "missing email uses oidc subject",
-			identity: Identity{
-				Subject: "user-1",
-			},
-			want: "user-1",
+			name:     "missing email uses oidc subject",
+			identity: identityForTest("user-1", nil),
+			want:     "user-1",
 		},
 	}
 
@@ -321,6 +309,32 @@ func TestAuthorizationCodeSubjectRequiresVerifiedEmail(t *testing.T) {
 				t.Fatalf("authorizationCodeSubject() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestAuthorizationCodeFromLoginUsesVerifiedEmailBoundary(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	login := LoginState{
+		ClientID:      "droid",
+		RedirectURI:   "http://127.0.0.1/callback",
+		Resource:      "https://cerebro.example/api/v1/mcp",
+		CodeChallenge: "challenge",
+	}
+	entitlement := grantEntitlement{
+		TenantID:       "writer",
+		AllowedTenants: []string{"writer"},
+		Scopes:         []string{ScopeSecurityRead},
+		Roles:          []string{"cerebro.viewer"},
+	}
+
+	verifiedCode := authorizationCodeFromLogin(login, verifiedIdentityForTest(t, "user-1", "user@example.com", "", nil), entitlement, "code-token", now, time.Minute)
+	if verifiedCode.Subject != "user@example.com" || verifiedCode.Email != "user@example.com" {
+		t.Fatalf("verified authorization code subject/email = %q/%q, want verified email", verifiedCode.Subject, verifiedCode.Email)
+	}
+
+	unverifiedCode := authorizationCodeFromLogin(login, identityForTest("user-1", nil), entitlement, "code-token", now, time.Minute)
+	if unverifiedCode.Subject != "user-1" || unverifiedCode.Email != "" {
+		t.Fatalf("unverified authorization code subject/email = %q/%q, want subject only", unverifiedCode.Subject, unverifiedCode.Email)
 	}
 }
 
@@ -334,11 +348,7 @@ func TestEntitlementForIdentityDropsRolesWhenExplicitScopeRequested(t *testing.T
 		}},
 	}}
 
-	narrowed, err := service.entitlementForIdentity(Identity{
-		Subject: "user-1",
-		Email:   "user@example.com",
-		Groups:  []string{"secops"},
-	}, "droid", []string{ScopeSecurityRead}, true)
+	narrowed, err := service.entitlementForIdentity(identityForTest("user-1", []string{"secops"}), "droid", []string{ScopeSecurityRead}, true)
 	if err != nil {
 		t.Fatalf("entitlementForIdentity explicit scope error = %v", err)
 	}
@@ -346,11 +356,7 @@ func TestEntitlementForIdentityDropsRolesWhenExplicitScopeRequested(t *testing.T
 		t.Fatalf("explicit-scope entitlement roles = %#v, want none so scope request narrows grant", narrowed.Roles)
 	}
 
-	defaulted, err := service.entitlementForIdentity(Identity{
-		Subject: "user-1",
-		Email:   "user@example.com",
-		Groups:  []string{"secops"},
-	}, "droid", []string{ScopeSecurityRead}, false)
+	defaulted, err := service.entitlementForIdentity(identityForTest("user-1", []string{"secops"}), "droid", []string{ScopeSecurityRead}, false)
 	if err != nil {
 		t.Fatalf("entitlementForIdentity default scope error = %v", err)
 	}
@@ -389,12 +395,7 @@ func TestCallbackRecordsOAuthIdentityDirectory(t *testing.T) {
 		}},
 	}, store, func(context.Context, AccessGrant, time.Duration, time.Time) (string, error) {
 		return "access-token", nil
-	}, WithOIDCProvider(staticOIDCProvider{identity: Identity{
-		Subject: "00u123",
-		Email:   "person@example.com",
-		Name:    "Person Example",
-		Groups:  []string{"security-team"},
-	}}))
+	}, WithOIDCProvider(staticOIDCProvider{identity: verifiedIdentityForTest(t, "00u123", "person@example.com", "Person Example", []string{"security-team"})}))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}
@@ -451,12 +452,7 @@ func TestCallbackContinuesWhenIdentityDirectoryRecordFails(t *testing.T) {
 		}},
 	}, store, func(context.Context, AccessGrant, time.Duration, time.Time) (string, error) {
 		return "access-token", nil
-	}, WithOIDCProvider(staticOIDCProvider{identity: Identity{
-		Subject: "00u123",
-		Email:   "person@example.com",
-		Name:    "Person Example",
-		Groups:  []string{"security-team"},
-	}}))
+	}, WithOIDCProvider(staticOIDCProvider{identity: verifiedIdentityForTest(t, "00u123", "person@example.com", "Person Example", []string{"security-team"})}))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}

--- a/tools/linters/cerebrolint/main.go
+++ b/tools/linters/cerebrolint/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/tools/linters/nobackpointer"
 	"github.com/writer/cerebro/tools/linters/noenvoutsidecmd"
 	"github.com/writer/cerebro/tools/linters/noerrstringmatch"
+	"github.com/writer/cerebro/tools/linters/noidentityemail"
 	"github.com/writer/cerebro/tools/linters/noinmemorydb"
 	"github.com/writer/cerebro/tools/linters/nopanicprod"
 	"github.com/writer/cerebro/tools/linters/nosleep"
@@ -32,6 +33,7 @@ func main() {
 		novarfunc.Analyzer,
 		nosleep.Analyzer,
 		noerrstringmatch.Analyzer,
+		noidentityemail.Analyzer,
 		nountypedboundary.Analyzer,
 		nobackpointer.Analyzer,
 		sealedinterface.Analyzer,

--- a/tools/linters/noidentityemail/noidentityemail.go
+++ b/tools/linters/noidentityemail/noidentityemail.go
@@ -1,0 +1,124 @@
+package noidentityemail
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const doc = `forbid direct email-field reads from mcpoauth.Identity
+
+OAuth identity email is a trust boundary. Callers must use the typed
+VerifiedEmail, ContactEmail, or PrincipalSubject methods so unverified email
+claims cannot become token subjects or entitlement authority.`
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "noidentityemail",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	ins.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if fn.Body == nil || isTestFile(pass, fn.Pos()) {
+			return
+		}
+		allowDirectEmailField := isIdentityAccessor(pass, fn)
+		allowVerifiedEmailLiteral := isVerifiedEmailConstructor(pass, fn)
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			if lit, ok := node.(*ast.CompositeLit); ok {
+				if !allowVerifiedEmailLiteral && isMCPOAuthVerifiedEmail(pass.TypesInfo.TypeOf(lit)) {
+					pass.Report(analysis.Diagnostic{
+						Pos:     lit.Pos(),
+						End:     lit.End(),
+						Message: "direct mcpoauth.VerifiedEmail construction bypasses email verification; use NewVerifiedEmail",
+					})
+				}
+				return true
+			}
+			sel, ok := node.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if !isIdentityEmailField(sel.Sel.Name) {
+				return true
+			}
+			if allowDirectEmailField {
+				return true
+			}
+			if !isMCPOAuthIdentity(pass.TypesInfo.TypeOf(sel.X)) {
+				return true
+			}
+			pass.Report(analysis.Diagnostic{
+				Pos:     sel.Pos(),
+				End:     sel.End(),
+				Message: "direct mcpoauth.Identity email field read bypasses verified-email authority boundary; use VerifiedEmail(), ContactEmail(), or PrincipalSubject()",
+			})
+			return true
+		})
+	})
+	return nil, nil
+}
+
+func isIdentityEmailField(name string) bool {
+	switch name {
+	case "email", "Email", "EmailVerified":
+		return true
+	default:
+		return false
+	}
+}
+
+func isIdentityAccessor(pass *analysis.Pass, fn *ast.FuncDecl) bool {
+	if pass == nil || pass.Pkg == nil || fn == nil || fn.Recv == nil {
+		return false
+	}
+	if pass.Pkg.Path() != "github.com/writer/cerebro/internal/mcpoauth" {
+		return false
+	}
+	switch fn.Name.Name {
+	case "VerifiedEmail", "ContactEmail":
+		return true
+	default:
+		return false
+	}
+}
+
+func isVerifiedEmailConstructor(pass *analysis.Pass, fn *ast.FuncDecl) bool {
+	if pass == nil || pass.Pkg == nil || fn == nil {
+		return false
+	}
+	return pass.Pkg.Path() == "github.com/writer/cerebro/internal/mcpoauth" && fn.Name.Name == "NewVerifiedEmail"
+}
+
+func isMCPOAuthIdentity(t types.Type) bool {
+	return isMCPOAuthNamedType(t, "Identity")
+}
+
+func isMCPOAuthVerifiedEmail(t types.Type) bool {
+	return isMCPOAuthNamedType(t, "VerifiedEmail")
+}
+
+func isMCPOAuthNamedType(t types.Type, name string) bool {
+	t = types.Unalias(t)
+	if pointer, ok := t.(*types.Pointer); ok {
+		t = types.Unalias(pointer.Elem())
+	}
+	named, ok := t.(*types.Named)
+	if !ok || named.Obj() == nil || named.Obj().Pkg() == nil {
+		return false
+	}
+	return named.Obj().Name() == name && strings.HasSuffix(named.Obj().Pkg().Path(), "/internal/mcpoauth")
+}
+
+func isTestFile(pass *analysis.Pass, pos token.Pos) bool {
+	return strings.HasSuffix(pass.Fset.Position(pos).Filename, "_test.go")
+}

--- a/tools/linters/noidentityemail/noidentityemail_test.go
+++ b/tools/linters/noidentityemail/noidentityemail_test.go
@@ -1,0 +1,13 @@
+package noidentityemail_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/writer/cerebro/tools/linters/noidentityemail"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), noidentityemail.Analyzer, "github.com/writer/cerebro/internal/mcpoauth")
+}

--- a/tools/linters/noidentityemail/testdata/src/github.com/writer/cerebro/internal/mcpoauth/identity.go
+++ b/tools/linters/noidentityemail/testdata/src/github.com/writer/cerebro/internal/mcpoauth/identity.go
@@ -1,0 +1,58 @@
+package mcpoauth
+
+type Identity struct {
+	email         string
+	Email         string
+	EmailVerified bool
+	subject       string
+}
+
+type VerifiedEmail struct {
+	value string
+}
+
+func NewVerifiedEmail(email string, verified bool) (VerifiedEmail, bool) {
+	if !verified || email == "" {
+		return VerifiedEmail{}, false
+	}
+	return VerifiedEmail{value: email}, true
+}
+
+func (identity Identity) VerifiedEmail() (string, bool) {
+	if identity.email == "" {
+		return "", false
+	}
+	return identity.email, true
+}
+
+func (identity Identity) ContactEmail() string {
+	return identity.email
+}
+
+func (identity Identity) PrincipalSubject() string {
+	return identity.subject
+}
+
+func subject(identity Identity) string {
+	return identity.PrincipalSubject()
+}
+
+func contact(identity Identity) string {
+	return identity.ContactEmail()
+}
+
+func directUnexportedEmail(identity Identity) string {
+	return identity.email // want "direct mcpoauth.Identity email field read bypasses verified-email authority boundary"
+}
+
+func directExportedEmail(identity Identity) string {
+	return identity.Email // want "direct mcpoauth.Identity email field read bypasses verified-email authority boundary"
+}
+
+func directEmailVerified(identity Identity) bool {
+	return identity.EmailVerified // want "direct mcpoauth.Identity email field read bypasses verified-email authority boundary"
+}
+
+func directVerifiedEmailLiteral(email string) VerifiedEmail {
+	return VerifiedEmail{value: email} // want "direct mcpoauth.VerifiedEmail construction bypasses email verification"
+}


### PR DESCRIPTION
## Summary

- make OAuth identity email a typed verified value instead of a raw authority string
- centralize authorization-code grant construction behind the verified identity boundary
- add a structural linter and regression harness entry so direct identity email bypasses fail CI

## Validation

- `go test ./internal/mcpoauth -count=1`
- `go test ./internal/bootstrap -run 'TestMCPOAuthOIDCClientVerifiesIDToken|TestMCPOAuthTokenEndpointRejectsPKCEMismatch' -count=1`
- `go test ./internal/bootstrap ./internal/mcpoauth -count=1`
- `cd tools/linters && GOFLAGS= go test ./...`
- `make check-structural`
- `make check-structural-test check-arch`
- `make lint-internal`
- `git diff --check`