### PR TITLE
Add compact connector catalog summary view

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -474,9 +474,17 @@ paths:
           in: query
           schema:
             type: string
+        - name: view
+          in: query
+          description: Omit this parameter or use summary for catalog browsing. The summary view keeps connector identity, status, access, readiness, and scalar integration-depth counts, and omits setup payloads such as connection methods, scope options, resource-family detail, descriptions, emitted-kind lists, and credential-store setup guidance. Use full only when setup metadata for the complete catalog is required.
+          schema:
+            type: string
+            enum:
+              - full
+              - summary
       responses:
         '200':
-          description: Connector catalog with executable built-in sources plus catalog-only connector definitions. Entries include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping.
+          description: Compact connector catalog with executable built-in sources plus catalog-only connector definitions. Default and summary responses keep catalog browsing fields and omit setup payloads; use /connectors/{sourceID} for one connector's full setup and operations detail. Full responses include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping.
   /connectors/{sourceID}:
     get:
       summary: Get connector operations summary

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -476,15 +476,18 @@ paths:
             type: string
         - name: view
           in: query
-          description: Omit this parameter or use summary for catalog browsing. The summary view keeps connector identity, status, access, readiness, and scalar integration-depth counts, and omits setup payloads such as connection methods, scope options, resource-family detail, descriptions, emitted-kind lists, and credential-store setup guidance. Use full only when setup metadata for the complete catalog is required.
+          description: The default is full. Use summary for catalog browsing when setup payloads are not needed; it keeps connector identity, status, access, readiness, and scalar integration-depth counts, and omits setup payloads such as connection methods, scope options, resource-family detail, descriptions, emitted-kind lists, and credential-store setup guidance. Use full when setup metadata for the complete catalog is required.
           schema:
             type: string
+            default: full
             enum:
               - full
               - summary
       responses:
         '200':
-          description: Compact connector catalog with executable built-in sources plus catalog-only connector definitions. Default and summary responses keep catalog browsing fields and omit setup payloads; use /connectors/{sourceID} for one connector's full setup and operations detail. Full responses include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping.
+          description: Connector catalog with executable built-in sources plus catalog-only connector definitions. Default and full responses include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping. Summary responses keep catalog browsing fields and omit setup payloads; use /connectors/{sourceID} for one connector's full setup and operations detail.
+        '400':
+          description: Connector catalog view or tenant filter was invalid.
   /connectors/{sourceID}:
     get:
       summary: Get connector operations summary

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -487,7 +487,7 @@ paths:
         '200':
           description: Connector catalog with executable built-in sources plus catalog-only connector definitions. Default and full responses include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping. Summary responses keep catalog browsing fields and omit setup payloads; use /connectors/{sourceID} for one connector's full setup and operations detail.
         '400':
-          description: Connector catalog view or tenant filter was invalid.
+          description: Connector catalog view was invalid.
   /connectors/{sourceID}:
     get:
       summary: Get connector operations summary

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -234,6 +234,12 @@ includes only MCP request/response mapping for source check, discover, and read
 operations, plus response-boundary event limits so one live source page cannot
 produce an unbounded MCP payload.
 
+Connector catalog summary view stays in bootstrap as HTTP boundary mapping. The
+budget includes only the `view` query parsing and compact response shaping over
+the existing connector library response; catalog assembly, runtime state, and
+credential-store behavior stay behind the registry, catalog, and store
+boundaries.
+
 ## Postgres migrations
 
 State-store schema preparation runs at service startup and before store operations. Most migrations use additive `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, or `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` patterns.

--- a/internal/bootstrap/connector_definitions_test.go
+++ b/internal/bootstrap/connector_definitions_test.go
@@ -400,7 +400,7 @@ func TestTenantConnectorDefinitionAppearsAsRunnableConnector(t *testing.T) {
 		t.Fatalf("POST /connector-definitions status = %d, want 200", createResp.StatusCode)
 	}
 
-	listResp, err := server.Client().Get(server.URL + "/connectors?tenant_id=tenant-a")
+	listResp, err := server.Client().Get(server.URL + "/connectors?tenant_id=tenant-a&view=full")
 	if err != nil {
 		t.Fatalf("GET /connectors error = %v", err)
 	}

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -147,6 +147,7 @@ type connectorLibraryResponse struct {
 	Connectors          []connectorCatalogEntry `json:"connectors"`
 	Counts              connectorLibraryCounts  `json:"counts"`
 	GeneratedAt         string                  `json:"generated_at"`
+	View                string                  `json:"view"`
 	TenantID            string                  `json:"tenant_id,omitempty"`
 	RuntimeStore        string                  `json:"runtime_store"`
 	CatalogVersion      string                  `json:"catalog_version,omitempty"`
@@ -772,6 +773,7 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 		Connectors:          entries,
 		Counts:              connectorLibraryCountsFor(entries),
 		GeneratedAt:         time.Now().UTC().Format(time.RFC3339),
+		View:                connectorLibraryViewFull,
 		TenantID:            tenantID,
 		RuntimeStore:        runtimeStoreStatus,
 		CatalogVersion:      connectordefinitions.SchemaVersionIntegrationV1,

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -180,10 +180,10 @@ type connectorCatalogSummaryEntry struct {
 	DefinitionOrigin       string   `json:"definition_origin,omitempty"`
 	ReadinessStage         string   `json:"readiness_stage,omitempty"`
 	ValidationGrade        string   `json:"validation_grade,omitempty"`
-	Cataloged              bool     `json:"cataloged,omitempty"`
-	Callable               bool     `json:"callable,omitempty"`
+	Cataloged              bool     `json:"cataloged"`
+	Callable               bool     `json:"callable"`
 	AccessStatus           string   `json:"access_status,omitempty"`
-	SetupAllowed           bool     `json:"setup_allowed,omitempty"`
+	SetupAllowed           bool     `json:"setup_allowed"`
 	Requestable            bool     `json:"requestable,omitempty"`
 	IntegrationLevel       string   `json:"integration_level,omitempty"`
 	IntegrationScore       int      `json:"integration_score,omitempty"`
@@ -560,11 +560,11 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 
 func connectorLibraryView(r *http.Request) (string, error) {
 	if r == nil || r.URL == nil {
-		return connectorLibraryViewSummary, nil
+		return connectorLibraryViewFull, nil
 	}
 	view := strings.TrimSpace(r.URL.Query().Get("view"))
 	if view == "" {
-		return connectorLibraryViewSummary, nil
+		return connectorLibraryViewFull, nil
 	}
 	switch view {
 	case connectorLibraryViewFull, connectorLibraryViewSummary:

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -71,6 +71,9 @@ const (
 	connectorReadinessStageRuntimeNeeded       = "runtime_required"
 	connectorReadinessStageRuntimeBacked       = "runtime_backed"
 	connectorReadinessStageRuntimeUnknown      = "runtime_unknown"
+
+	connectorLibraryViewFull    = "full"
+	connectorLibraryViewSummary = "summary"
 )
 
 var errConnectorAccessRestricted = errors.New("connector access restricted")
@@ -151,6 +154,42 @@ type connectorLibraryResponse struct {
 	CredentialTransport connectorTransportView  `json:"credential_transport"`
 	CredentialVault     connectorVaultView      `json:"credential_vault"`
 	CredentialStores    []connectorStoreView    `json:"credential_stores,omitempty"`
+}
+type connectorLibrarySummaryResponse struct {
+	Connectors          []connectorCatalogSummaryEntry `json:"connectors"`
+	Counts              connectorLibraryCounts         `json:"counts"`
+	GeneratedAt         string                         `json:"generated_at"`
+	View                string                         `json:"view"`
+	TenantID            string                         `json:"tenant_id,omitempty"`
+	RuntimeStore        string                         `json:"runtime_store"`
+	CatalogVersion      string                         `json:"catalog_version,omitempty"`
+	CatalogSourceCommit string                         `json:"catalog_source_commit,omitempty"`
+}
+type connectorCatalogSummaryEntry struct {
+	SourceID               string   `json:"source_id"`
+	DisplayName            string   `json:"display_name,omitempty"`
+	Status                 string   `json:"status,omitempty"`
+	ConfiguredRuntimes     int      `json:"configured_runtimes,omitempty"`
+	HealthyRuntimes        int      `json:"healthy_runtimes,omitempty"`
+	NeedsAttentionRuntimes int      `json:"needs_attention_runtimes,omitempty"`
+	CatalogStatus          string   `json:"catalog_status,omitempty"`
+	ClassifierOutput       string   `json:"classifier_output,omitempty"`
+	AuthModel              string   `json:"auth_model,omitempty"`
+	RuntimeExecutable      bool     `json:"runtime_executable,omitempty"`
+	CatalogCategories      []string `json:"catalog_categories,omitempty"`
+	DefinitionOrigin       string   `json:"definition_origin,omitempty"`
+	ReadinessStage         string   `json:"readiness_stage,omitempty"`
+	ValidationGrade        string   `json:"validation_grade,omitempty"`
+	Cataloged              bool     `json:"cataloged,omitempty"`
+	Callable               bool     `json:"callable,omitempty"`
+	AccessStatus           string   `json:"access_status,omitempty"`
+	SetupAllowed           bool     `json:"setup_allowed,omitempty"`
+	Requestable            bool     `json:"requestable,omitempty"`
+	IntegrationLevel       string   `json:"integration_level,omitempty"`
+	IntegrationScore       int      `json:"integration_score,omitempty"`
+	ResourceFamilyCount    int      `json:"resource_family_count,omitempty"`
+	EmittedKindCount       int      `json:"emitted_kind_count,omitempty"`
+	ScopeOptionCount       int      `json:"scope_option_count,omitempty"`
 }
 type connectorLibraryCounts struct {
 	Total        int `json:"total"`
@@ -506,8 +545,79 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 		writeConnectorError(w, err)
 		return
 	}
+	view, err := connectorLibraryView(r)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	response := a.connectorLibrary(r, tenantID)
+	if view == connectorLibraryViewSummary {
+		writeJSON(w, http.StatusOK, summarizeConnectorLibrary(response))
+		return
+	}
 	writeJSON(w, http.StatusOK, response)
+}
+
+func connectorLibraryView(r *http.Request) (string, error) {
+	if r == nil || r.URL == nil {
+		return connectorLibraryViewSummary, nil
+	}
+	view := strings.TrimSpace(r.URL.Query().Get("view"))
+	if view == "" {
+		return connectorLibraryViewSummary, nil
+	}
+	switch view {
+	case connectorLibraryViewFull, connectorLibraryViewSummary:
+		return view, nil
+	default:
+		return "", fmt.Errorf("%w: connector library view must be full or summary", connectorcredentials.ErrInvalidRequest)
+	}
+}
+
+func summarizeConnectorLibrary(response connectorLibraryResponse) connectorLibrarySummaryResponse {
+	summary := connectorLibrarySummaryResponse{
+		Connectors:          make([]connectorCatalogSummaryEntry, 0, len(response.Connectors)),
+		Counts:              response.Counts,
+		GeneratedAt:         response.GeneratedAt,
+		View:                connectorLibraryViewSummary,
+		TenantID:            response.TenantID,
+		RuntimeStore:        response.RuntimeStore,
+		CatalogVersion:      response.CatalogVersion,
+		CatalogSourceCommit: response.CatalogSourceCommit,
+	}
+	for _, entry := range response.Connectors {
+		summary.Connectors = append(summary.Connectors, summarizeConnectorCatalogEntry(entry))
+	}
+	return summary
+}
+
+func summarizeConnectorCatalogEntry(entry connectorCatalogEntry) connectorCatalogSummaryEntry {
+	return connectorCatalogSummaryEntry{
+		SourceID:               entry.SourceID,
+		DisplayName:            entry.DisplayName,
+		Status:                 entry.Status,
+		ConfiguredRuntimes:     entry.ConfiguredRuntimes,
+		HealthyRuntimes:        entry.HealthyRuntimes,
+		NeedsAttentionRuntimes: entry.NeedsAttentionRuntimes,
+		CatalogStatus:          entry.CatalogStatus,
+		ClassifierOutput:       entry.ClassifierOutput,
+		AuthModel:              entry.AuthModel,
+		RuntimeExecutable:      entry.RuntimeExecutable,
+		CatalogCategories:      append([]string{}, entry.CatalogCategories...),
+		DefinitionOrigin:       entry.DefinitionOrigin,
+		ReadinessStage:         entry.ReadinessStage,
+		ValidationGrade:        entry.ValidationGrade,
+		Cataloged:              entry.Cataloged,
+		Callable:               entry.Callable,
+		AccessStatus:           entry.AccessStatus,
+		SetupAllowed:           entry.SetupAllowed,
+		Requestable:            entry.Requestable,
+		IntegrationLevel:       entry.IntegrationDepth.Level,
+		IntegrationScore:       entry.IntegrationDepth.Score,
+		ResourceFamilyCount:    entry.IntegrationDepth.ResourceFamilies,
+		EmittedKindCount:       entry.IntegrationDepth.EmittedKinds,
+		ScopeOptionCount:       entry.IntegrationDepth.ScopeOptions,
+	}
 }
 
 func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibraryResponse {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1596,10 +1596,14 @@ func TestConnectorCatalogDefaultViewReturnsFullPayload(t *testing.T) {
 	}
 	var payload struct {
 		CredentialTransport json.RawMessage              `json:"credential_transport"`
+		View                string                       `json:"view"`
 		Connectors          []map[string]json.RawMessage `json:"connectors"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode response: %v", err)
+	}
+	if payload.View != connectorLibraryViewFull {
+		t.Fatalf("view = %q, want full", payload.View)
 	}
 	if len(payload.CredentialTransport) == 0 {
 		t.Fatal("credential_transport missing from default connector catalog response")

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1572,7 +1572,7 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 	}
 }
 
-func TestConnectorCatalogDefaultViewOmitsSetupPayloads(t *testing.T) {
+func TestConnectorCatalogDefaultViewReturnsFullPayload(t *testing.T) {
 	source := &bootstrapTokenSource{id: "aws", emittedKinds: []string{"aws.account", "aws.iam_role"}}
 	registry, err := sourcecdk.NewRegistry(source)
 	if err != nil {
@@ -1593,6 +1593,59 @@ func TestConnectorCatalogDefaultViewOmitsSetupPayloads(t *testing.T) {
 	defer closeResponseBody(t, resp)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GET /connectors status = %d, want 200", resp.StatusCode)
+	}
+	var payload struct {
+		CredentialTransport json.RawMessage              `json:"credential_transport"`
+		Connectors          []map[string]json.RawMessage `json:"connectors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.CredentialTransport) == 0 {
+		t.Fatal("credential_transport missing from default connector catalog response")
+	}
+	var aws map[string]json.RawMessage
+	for _, connector := range payload.Connectors {
+		var sourceID string
+		if err := json.Unmarshal(connector["source_id"], &sourceID); err != nil {
+			t.Fatalf("decode connector source_id: %v", err)
+		}
+		if sourceID == "aws" {
+			aws = connector
+			break
+		}
+	}
+	if aws == nil {
+		t.Fatal("aws connector missing from default connector catalog response")
+	}
+	for _, field := range []string{"connection_methods", "scope_options", "emitted_kinds", "description", "integration_depth"} {
+		if _, ok := aws[field]; !ok {
+			t.Fatalf("default connector catalog response missing %s for aws", field)
+		}
+	}
+}
+
+func TestConnectorCatalogSummaryViewOmitsSetupPayloads(t *testing.T) {
+	source := &bootstrapTokenSource{id: "aws", emittedKinds: []string{"aws.account", "aws.iam_role"}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	registry.WithBuiltinDefinitionCatalog()
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors?view=summary")
+	if err != nil {
+		t.Fatalf("GET /connectors?view=summary error = %v", err)
+	}
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors?view=summary status = %d, want 200", resp.StatusCode)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -1628,6 +1681,11 @@ func TestConnectorCatalogDefaultViewOmitsSetupPayloads(t *testing.T) {
 		for _, field := range []string{"connection_methods", "scope_options", "resource_families", "credential_stores", "emitted_kinds", "description", "integration_depth"} {
 			if _, ok := connector[field]; ok {
 				t.Fatalf("summary connector %q included %s: %s", sourceID, field, body)
+			}
+		}
+		for _, field := range []string{"cataloged", "callable", "setup_allowed"} {
+			if _, ok := connector[field]; !ok {
+				t.Fatalf("summary connector %q omitted %s: %s", sourceID, field, body)
 			}
 		}
 		if sourceID == "aws" {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1356,7 +1356,7 @@ func TestConnectorCatalogAdvertisesConnectionMethods(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/connectors")
+	resp, err := server.Client().Get(server.URL + "/connectors?view=full")
 	if err != nil {
 		t.Fatalf("GET /connectors error = %v", err)
 	}
@@ -1454,7 +1454,7 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/connectors")
+	resp, err := server.Client().Get(server.URL + "/connectors?view=full")
 	if err != nil {
 		t.Fatalf("GET /connectors error = %v", err)
 	}
@@ -1569,6 +1569,122 @@ func TestConnectorCatalogIncludesBuiltinDefinitionCatalogWhenEnabled(t *testing.
 		if family.ProjectionTemplate == "" || !family.HighValue {
 			t.Fatalf("jenkins family = %#v, want projection and high-value coverage", family)
 		}
+	}
+}
+
+func TestConnectorCatalogDefaultViewOmitsSetupPayloads(t *testing.T) {
+	source := &bootstrapTokenSource{id: "aws", emittedKinds: []string{"aws.account", "aws.iam_role"}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	registry.WithBuiltinDefinitionCatalog()
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors")
+	if err != nil {
+		t.Fatalf("GET /connectors error = %v", err)
+	}
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /connectors status = %d, want 200", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if got, max := len(body), 512*1024; got > max {
+		t.Fatalf("summary response size = %d bytes, want <= %d bytes", got, max)
+	}
+	var payload struct {
+		View             string                       `json:"view"`
+		Counts           connectorLibraryCounts       `json:"counts"`
+		Connectors       []map[string]json.RawMessage `json:"connectors"`
+		CredentialStores []json.RawMessage            `json:"credential_stores"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.View != connectorLibraryViewSummary {
+		t.Fatalf("view = %q, want summary", payload.View)
+	}
+	if payload.Counts.Total == 0 || len(payload.Connectors) == 0 {
+		t.Fatalf("summary response missing connectors/counts: counts=%#v connectors=%d", payload.Counts, len(payload.Connectors))
+	}
+	if len(payload.CredentialStores) != 0 {
+		t.Fatalf("credential_stores = %#v, want omitted from summary view", payload.CredentialStores)
+	}
+	var aws map[string]json.RawMessage
+	for _, connector := range payload.Connectors {
+		var sourceID string
+		if err := json.Unmarshal(connector["source_id"], &sourceID); err != nil {
+			t.Fatalf("decode connector source_id: %v", err)
+		}
+		for _, field := range []string{"connection_methods", "scope_options", "resource_families", "credential_stores", "emitted_kinds", "description", "integration_depth"} {
+			if _, ok := connector[field]; ok {
+				t.Fatalf("summary connector %q included %s: %s", sourceID, field, body)
+			}
+		}
+		if sourceID == "aws" {
+			aws = connector
+		}
+	}
+	if aws == nil {
+		t.Fatalf("aws connector missing from summary response: %s", body)
+	}
+	var awsSummary struct {
+		SourceID            string `json:"source_id"`
+		DisplayName         string `json:"display_name"`
+		AccessStatus        string `json:"access_status"`
+		ReadinessStage      string `json:"readiness_stage"`
+		IntegrationLevel    string `json:"integration_level"`
+		IntegrationScore    int    `json:"integration_score"`
+		EmittedKindCount    int    `json:"emitted_kind_count"`
+		ResourceFamilyCount int    `json:"resource_family_count"`
+	}
+	encodedAWS, err := json.Marshal(aws)
+	if err != nil {
+		t.Fatalf("marshal aws connector: %v", err)
+	}
+	if err := json.Unmarshal(encodedAWS, &awsSummary); err != nil {
+		t.Fatalf("decode aws connector: %v", err)
+	}
+	if awsSummary.SourceID != "aws" || awsSummary.DisplayName != "Amazon Web Services" {
+		t.Fatalf("aws identity = %#v, want source/display name", awsSummary)
+	}
+	if awsSummary.AccessStatus == "" || awsSummary.ReadinessStage == "" {
+		t.Fatalf("aws access/readiness missing: %#v", awsSummary)
+	}
+	if awsSummary.IntegrationLevel == "" || awsSummary.IntegrationScore == 0 || awsSummary.EmittedKindCount == 0 {
+		t.Fatalf("aws integration summary = %#v, want compact depth counts", awsSummary)
+	}
+}
+
+func TestConnectorCatalogRejectsUnknownView(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/connectors?view=verbose")
+	if err != nil {
+		t.Fatalf("GET /connectors?view=verbose error = %v", err)
+	}
+	defer closeResponseBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("GET /connectors?view=verbose status = %d, want 400", resp.StatusCode)
 	}
 }
 
@@ -1880,7 +1996,7 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/connectors")
+	resp, err := server.Client().Get(server.URL + "/connectors?view=full")
 	if err != nil {
 		t.Fatalf("GET /connectors error = %v", err)
 	}
@@ -1988,7 +2104,7 @@ func TestConnectorCatalogAdvertisesAWSSecretStoreEnvProjectionUntilNativeConfigu
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/connectors")
+	resp, err := server.Client().Get(server.URL + "/connectors?view=full")
 	if err != nil {
 		t.Fatalf("GET /connectors error = %v", err)
 	}
@@ -2054,7 +2170,7 @@ func TestConnectorCatalogAdvertisesConfiguredAWSSecretStore(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/connectors")
+	resp, err := server.Client().Get(server.URL + "/connectors?view=full")
 	if err != nil {
 		t.Fatalf("GET /connectors error = %v", err)
 	}
@@ -2110,7 +2226,7 @@ func TestConnectorCatalogAdvertisesAWSOnboardingGuidance(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/connectors")
+	resp, err := server.Client().Get(server.URL + "/connectors?view=full")
 	if err != nil {
 		t.Fatalf("GET /connectors error = %v", err)
 	}
@@ -2256,7 +2372,7 @@ func TestConnectorScopeOptionsIncludeCoverageNotes(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/connectors")
+	resp, err := server.Client().Get(server.URL + "/connectors?view=full")
 	if err != nil {
 		t.Fatalf("GET /connectors error = %v", err)
 	}

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -86,8 +86,11 @@ import (
 // adapters; HTTP request handling lives in
 // internal/sourcehttp/grcvendorquestionnaire, questionnaire state shaping lives
 // in internal/grcvendor, and storage stays behind the
-// GRCVendorQuestionnaireReviewStore port.
-const bootstrapProductionGoLineBudget = 26878
+// GRCVendorQuestionnaireReviewStore port. Connector catalog summary view adds
+// only query-parameter parsing plus compact response mapping over the existing
+// connector library response; catalog assembly and runtime state stay behind the
+// existing registry, catalog, and store boundaries.
+const bootstrapProductionGoLineBudget = 26978
 
 type bootstrapFileLineCount struct {
 	path  string

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -90,7 +90,7 @@ import (
 // only query-parameter parsing plus compact response mapping over the existing
 // connector library response; catalog assembly and runtime state stay behind the
 // existing registry, catalog, and store boundaries.
-const bootstrapProductionGoLineBudget = 26978
+const bootstrapProductionGoLineBudget = 26980
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- add `view=summary` for compact `/connectors` catalog responses while preserving the default full catalog response
- include `view` in both full and summary response shapes
- document invalid `view` handling and keep the bootstrap boundary ratchet current

## Tests
- go test ./internal/bootstrap -run 'TestConnectorCatalog|TestConnectorDetail|TestConnectorActivity|TestConnectorDefinitionCreateSurfacesDefinitionInConnectorLibrary' -count=1
- GO_TEST_SHARD_TOTAL=12 GO_TEST_SHARD_INDEX=10 make test
- make contracts-check
- make openapi-check openapi-lint
- git diff --check