### PR TITLE
Page connector catalog responses

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -483,11 +483,23 @@ paths:
             enum:
               - full
               - summary
+        - name: limit
+          in: query
+          description: Maximum connector entries to return in one response. Pass limit=200 for bounded catalog pages. Values above 200 are clamped to 200.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - name: cursor
+          in: query
+          description: Opaque page cursor from page.next_cursor. Connector catalog cursors currently encode the next stable offset.
+          schema:
+            type: string
       responses:
         '200':
-          description: Connector catalog with executable built-in sources plus catalog-only connector definitions. Default and full responses include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping. Summary responses keep catalog browsing fields and omit setup payloads; use /connectors/{sourceID} for one connector's full setup and operations detail.
+          description: Connector catalog with executable built-in sources plus catalog-only connector definitions. Default and full responses include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping. Summary responses keep catalog browsing fields and omit setup payloads; use /connectors/{sourceID} for one connector's full setup and operations detail. Paginated responses include page.total, page.returned, page.limit, page.has_more, and page.next_cursor when another page is available.
         '400':
-          description: Connector catalog view was invalid.
+          description: Connector catalog view, limit, or cursor was invalid.
   /connectors/{sourceID}:
     get:
       summary: Get connector operations summary

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -234,11 +234,11 @@ includes only MCP request/response mapping for source check, discover, and read
 operations, plus response-boundary event limits so one live source page cannot
 produce an unbounded MCP payload.
 
-Connector catalog summary view stays in bootstrap as HTTP boundary mapping. The
-budget includes only the `view` query parsing and compact response shaping over
-the existing connector library response; catalog assembly, runtime state, and
-credential-store behavior stay behind the registry, catalog, and store
-boundaries.
+Connector catalog summary view and pagination stay in bootstrap as HTTP
+boundary mapping. The budget includes only `view`, `limit`, and `cursor` query
+parsing plus compact and paginated response shaping over the existing connector
+library response; catalog assembly, runtime state, and credential-store behavior
+stay behind the registry, catalog, and store boundaries.
 
 ## Postgres migrations
 

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -41,6 +41,8 @@ const (
 	connectorStoreEnvironmentManaged  = "environment_managed"
 	connectorActivityDefaultLimit     = 500
 	connectorActivityMaxLimit         = 500
+	connectorLibraryPageDefaultLimit  = 200
+	connectorLibraryPageMaxLimit      = 200
 
 	connectorAuthMethodEncryptedSubmission = "encrypted_submission"
 	connectorAuthMethodAWSSSOProfile       = "aws_sso_profile"
@@ -148,6 +150,7 @@ type connectorLibraryResponse struct {
 	Counts              connectorLibraryCounts  `json:"counts"`
 	GeneratedAt         string                  `json:"generated_at"`
 	View                string                  `json:"view"`
+	Page                *connectorLibraryPage   `json:"page,omitempty"`
 	TenantID            string                  `json:"tenant_id,omitempty"`
 	RuntimeStore        string                  `json:"runtime_store"`
 	CatalogVersion      string                  `json:"catalog_version,omitempty"`
@@ -161,10 +164,18 @@ type connectorLibrarySummaryResponse struct {
 	Counts              connectorLibraryCounts         `json:"counts"`
 	GeneratedAt         string                         `json:"generated_at"`
 	View                string                         `json:"view"`
+	Page                *connectorLibraryPage          `json:"page,omitempty"`
 	TenantID            string                         `json:"tenant_id,omitempty"`
 	RuntimeStore        string                         `json:"runtime_store"`
 	CatalogVersion      string                         `json:"catalog_version,omitempty"`
 	CatalogSourceCommit string                         `json:"catalog_source_commit,omitempty"`
+}
+type connectorLibraryPage struct {
+	Total      int    `json:"total"`
+	Returned   int    `json:"returned"`
+	Limit      int    `json:"limit"`
+	HasMore    bool   `json:"has_more"`
+	NextCursor string `json:"next_cursor,omitempty"`
 }
 type connectorCatalogSummaryEntry struct {
 	SourceID               string   `json:"source_id"`
@@ -551,7 +562,13 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 		writeConnectorError(w, err)
 		return
 	}
+	pagination, err := connectorLibraryPaginationFromRequest(r)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
 	response := a.connectorLibrary(r, tenantID)
+	response.Connectors, response.Page = pageConnectorLibraryEntries(response.Connectors, pagination)
 	if view == connectorLibraryViewSummary {
 		writeJSON(w, http.StatusOK, summarizeConnectorLibrary(response))
 		return
@@ -581,6 +598,7 @@ func summarizeConnectorLibrary(response connectorLibraryResponse) connectorLibra
 		Counts:              response.Counts,
 		GeneratedAt:         response.GeneratedAt,
 		View:                connectorLibraryViewSummary,
+		Page:                response.Page,
 		TenantID:            response.TenantID,
 		RuntimeStore:        response.RuntimeStore,
 		CatalogVersion:      response.CatalogVersion,
@@ -590,6 +608,75 @@ func summarizeConnectorLibrary(response connectorLibraryResponse) connectorLibra
 		summary.Connectors = append(summary.Connectors, summarizeConnectorCatalogEntry(entry))
 	}
 	return summary
+}
+
+type connectorLibraryPagination struct {
+	paged bool
+	start int
+	limit int
+}
+
+func connectorLibraryPaginationFromRequest(r *http.Request) (connectorLibraryPagination, error) {
+	pagination := connectorLibraryPagination{}
+	if r == nil || r.URL == nil {
+		return pagination, nil
+	}
+	query := r.URL.Query()
+	limitValue := strings.TrimSpace(query.Get("limit"))
+	cursorValue := strings.TrimSpace(query.Get("cursor"))
+	if limitValue != "" || cursorValue != "" {
+		pagination.paged = true
+		if pagination.limit == 0 {
+			pagination.limit = connectorLibraryPageDefaultLimit
+		}
+	}
+	if limitValue != "" {
+		parsed, err := strconv.Atoi(limitValue)
+		if err != nil || parsed < 1 {
+			return connectorLibraryPagination{}, fmt.Errorf("%w: connector catalog limit must be at least 1", connectorcredentials.ErrInvalidRequest)
+		}
+		if parsed > connectorLibraryPageMaxLimit {
+			parsed = connectorLibraryPageMaxLimit
+		}
+		pagination.limit = parsed
+	}
+	if cursorValue != "" {
+		parsed, err := strconv.Atoi(cursorValue)
+		if err != nil || parsed < 0 {
+			return connectorLibraryPagination{}, fmt.Errorf("%w: connector catalog cursor must be a non-negative offset", connectorcredentials.ErrInvalidRequest)
+		}
+		pagination.start = parsed
+	}
+	return pagination, nil
+}
+
+func pageConnectorLibraryEntries(entries []connectorCatalogEntry, pagination connectorLibraryPagination) ([]connectorCatalogEntry, *connectorLibraryPage) {
+	if !pagination.paged {
+		return entries, nil
+	}
+	total := len(entries)
+	start := pagination.start
+	if start > total {
+		start = total
+	}
+	limit := pagination.limit
+	if limit <= 0 || limit > connectorLibraryPageMaxLimit {
+		limit = connectorLibraryPageMaxLimit
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+	page := &connectorLibraryPage{
+		Total:    total,
+		Returned: end - start,
+		Limit:    limit,
+	}
+	if end < total {
+		page.HasMore = true
+		page.NextCursor = strconv.Itoa(end)
+	}
+	return entries[start:end], page
 }
 
 func summarizeConnectorCatalogEntry(entry connectorCatalogEntry) connectorCatalogSummaryEntry {
@@ -766,8 +853,13 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 		}
 		entries = append(entries, entry)
 	}
-	sort.Slice(entries, func(i, j int) bool {
-		return strings.ToLower(entries[i].Name) < strings.ToLower(entries[j].Name)
+	sort.SliceStable(entries, func(i, j int) bool {
+		leftName := strings.ToLower(entries[i].Name)
+		rightName := strings.ToLower(entries[j].Name)
+		if leftName != rightName {
+			return leftName < rightName
+		}
+		return entries[i].SourceID < entries[j].SourceID
 	})
 	return connectorLibraryResponse{
 		Connectors:          entries,

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -1597,6 +1597,7 @@ func TestConnectorCatalogDefaultViewReturnsFullPayload(t *testing.T) {
 	var payload struct {
 		CredentialTransport json.RawMessage              `json:"credential_transport"`
 		View                string                       `json:"view"`
+		Page                *connectorLibraryPage        `json:"page"`
 		Connectors          []map[string]json.RawMessage `json:"connectors"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
@@ -1604,6 +1605,9 @@ func TestConnectorCatalogDefaultViewReturnsFullPayload(t *testing.T) {
 	}
 	if payload.View != connectorLibraryViewFull {
 		t.Fatalf("view = %q, want full", payload.View)
+	}
+	if payload.Page != nil {
+		t.Fatalf("page = %#v, want omitted for unpaged default full response", payload.Page)
 	}
 	if len(payload.CredentialTransport) == 0 {
 		t.Fatal("credential_transport missing from default connector catalog response")
@@ -1661,6 +1665,7 @@ func TestConnectorCatalogSummaryViewOmitsSetupPayloads(t *testing.T) {
 	var payload struct {
 		View             string                       `json:"view"`
 		Counts           connectorLibraryCounts       `json:"counts"`
+		Page             *connectorLibraryPage        `json:"page"`
 		Connectors       []map[string]json.RawMessage `json:"connectors"`
 		CredentialStores []json.RawMessage            `json:"credential_stores"`
 	}
@@ -1672,6 +1677,12 @@ func TestConnectorCatalogSummaryViewOmitsSetupPayloads(t *testing.T) {
 	}
 	if payload.Counts.Total == 0 || len(payload.Connectors) == 0 {
 		t.Fatalf("summary response missing connectors/counts: counts=%#v connectors=%d", payload.Counts, len(payload.Connectors))
+	}
+	if payload.Page != nil {
+		t.Fatalf("page = %#v, want omitted for unpaged summary response", payload.Page)
+	}
+	if len(payload.Connectors) != payload.Counts.Total {
+		t.Fatalf("summary connectors = %d, want counts total %d", len(payload.Connectors), payload.Counts.Total)
 	}
 	if len(payload.CredentialStores) != 0 {
 		t.Fatalf("credential_stores = %#v, want omitted from summary view", payload.CredentialStores)
@@ -1724,6 +1735,105 @@ func TestConnectorCatalogSummaryViewOmitsSetupPayloads(t *testing.T) {
 	}
 	if awsSummary.IntegrationLevel == "" || awsSummary.IntegrationScore == 0 || awsSummary.EmittedKindCount == 0 {
 		t.Fatalf("aws integration summary = %#v, want compact depth counts", awsSummary)
+	}
+}
+
+func TestConnectorCatalogPagination(t *testing.T) {
+	source := &bootstrapTokenSource{id: "aws", emittedKinds: []string{"aws.account", "aws.iam_role"}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	registry.WithBuiltinDefinitionCatalog()
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	type pagedConnectorCatalog struct {
+		View       string                  `json:"view"`
+		Counts     connectorLibraryCounts  `json:"counts"`
+		Page       *connectorLibraryPage   `json:"page"`
+		Connectors []connectorCatalogEntry `json:"connectors"`
+	}
+	decodePage := func(path string) pagedConnectorCatalog {
+		t.Helper()
+		resp, err := server.Client().Get(server.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s error = %v", path, err)
+		}
+		defer closeResponseBody(t, resp)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want 200", path, resp.StatusCode)
+		}
+		var payload pagedConnectorCatalog
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode %s response: %v", path, err)
+		}
+		if payload.Page == nil {
+			t.Fatalf("GET %s missing page metadata", path)
+		}
+		return payload
+	}
+
+	first := decodePage("/connectors?view=summary&limit=200")
+	if first.View != connectorLibraryViewSummary {
+		t.Fatalf("first view = %q, want summary", first.View)
+	}
+	if got := len(first.Connectors); got != connectorLibraryPageMaxLimit {
+		t.Fatalf("first page connectors = %d, want %d", got, connectorLibraryPageMaxLimit)
+	}
+	if first.Page.Total != first.Counts.Total || first.Page.Returned != connectorLibraryPageMaxLimit || !first.Page.HasMore || first.Page.NextCursor != "200" {
+		t.Fatalf("first page metadata = %#v counts=%#v", first.Page, first.Counts)
+	}
+
+	second := decodePage("/connectors?view=summary&limit=200&cursor=" + first.Page.NextCursor)
+	if got := len(second.Connectors); got != connectorLibraryPageMaxLimit {
+		t.Fatalf("second page connectors = %d, want %d", got, connectorLibraryPageMaxLimit)
+	}
+	if second.Page.Total != first.Page.Total || second.Page.Returned != connectorLibraryPageMaxLimit || !second.Page.HasMore || second.Page.NextCursor != "400" {
+		t.Fatalf("second page metadata = %#v first=%#v", second.Page, first.Page)
+	}
+	if len(first.Connectors) == 0 || len(second.Connectors) == 0 {
+		t.Fatalf("pagination returned empty page: first=%d second=%d", len(first.Connectors), len(second.Connectors))
+	}
+	if first.Connectors[0].SourceID == second.Connectors[0].SourceID {
+		t.Fatalf("pagination did not advance: first=%q second=%q", first.Connectors[0].SourceID, second.Connectors[0].SourceID)
+	}
+
+	full := decodePage("/connectors?limit=500")
+	if full.View != connectorLibraryViewFull {
+		t.Fatalf("full view = %q, want full", full.View)
+	}
+	if full.Page.Limit != connectorLibraryPageMaxLimit || len(full.Connectors) != connectorLibraryPageMaxLimit {
+		t.Fatalf("full page = %#v connectors=%d, want max-page clamp", full.Page, len(full.Connectors))
+	}
+}
+
+func TestConnectorCatalogRejectsInvalidPagination(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	for _, query := range []string{"limit=0", "limit=abc", "cursor=-1", "cursor=abc"} {
+		resp, err := server.Client().Get(server.URL + "/connectors?" + query)
+		if err != nil {
+			t.Fatalf("GET /connectors?%s error = %v", query, err)
+		}
+		defer closeResponseBody(t, resp)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("GET /connectors?%s status = %d, want 400", query, resp.StatusCode)
+		}
 	}
 }
 

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -86,11 +86,12 @@ import (
 // adapters; HTTP request handling lives in
 // internal/sourcehttp/grcvendorquestionnaire, questionnaire state shaping lives
 // in internal/grcvendor, and storage stays behind the
-// GRCVendorQuestionnaireReviewStore port. Connector catalog summary view adds
-// only query-parameter parsing plus compact response mapping over the existing
-// connector library response; catalog assembly and runtime state stay behind the
-// existing registry, catalog, and store boundaries.
-const bootstrapProductionGoLineBudget = 26980
+// GRCVendorQuestionnaireReviewStore port. Connector catalog summary view and
+// pagination add only query-parameter parsing plus compact and paginated
+// response mapping over the existing connector library response; catalog
+// assembly and runtime state stay behind the existing registry, catalog, and
+// store boundaries.
+const bootstrapProductionGoLineBudget = 27067
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- add `limit` and `cursor` to `/connectors` so clients can fetch connector catalog entries in bounded pages
- clamp requested page sizes above 200 to 200
- preserve existing unpaged `/connectors` and `/connectors?view=summary` behavior unless a client passes `limit` or `cursor`
- return `page.total`, `page.returned`, `page.limit`, `page.has_more`, and `page.next_cursor` on paginated responses
- make catalog ordering deterministic with a source-id tie-break so offset cursors stay stable

## Tests
- go test ./internal/bootstrap -run 'TestConnectorCatalog|TestConnectorDetail|TestConnectorActivity|TestConnectorDefinitionCreateSurfacesDefinitionInConnectorLibrary' -count=1
- go test ./tools/archtests -run TestBootstrapProductionSurfaceDoesNotGrow -count=1
- GO_TEST_SHARD_TOTAL=12 GO_TEST_SHARD_INDEX=10 make test
- make openapi-check openapi-lint
- make contracts-check
- git diff --check