### PR TITLE
Fix release dispatch OIDC subject

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -114,4 +114,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
           git push origin "refs/tags/${RELEASE_TAG}"
-          gh workflow run "Release" --ref "${RELEASE_TAG}" -f "release_tag=${RELEASE_TAG}"
+          gh workflow run "Release" --ref main -f "release_tag=${RELEASE_TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       release_tag:
@@ -18,7 +15,7 @@ permissions:
   attestations: write
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+  group: release-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 jobs:
@@ -32,15 +29,9 @@ jobs:
         id: resolve
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
-          DISPATCH_INPUTS_JSON: ${{ toJSON(github.event.inputs) }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if [ "${EVENT_NAME}" = "push" ]; then
-            tag="${REF_NAME}"
-          else
-            tag="$(echo "${DISPATCH_INPUTS_JSON}" | jq -r '.release_tag // empty')"
-          fi
+          tag="${RELEASE_TAG}"
           if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "ERROR: tag '${tag}' must match vMAJOR.MINOR.PATCH[-PRERELEASE]"
             exit 1


### PR DESCRIPTION
## Summary
- run the Release workflow from main after cutting a tag
- keep the release tag passed explicitly so release jobs still checkout/publish the tagged revision
- avoids using tag-ref GitHub OIDC subjects for Infisical secret fetches during auto release dispatch

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml-ok"' .github/workflows/cut-release.yml
- actionlint .github/workflows/cut-release.yml
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->