### PR TITLE
Restore release deploy dispatch secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,8 +344,8 @@ jobs:
       - name: Dispatch release deployment request
         shell: bash
         env:
-          GH_TOKEN: ${{ env.CEREBRO_INFRA_PROMOTION_TOKEN }}
-          INFRA_REPOSITORY: ${{ env.CEREBRO_INFRA_REPOSITORY }}
+          GITHUB_CEREBRO_INFRA_PROMOTION_TOKEN: ${{ secrets.CEREBRO_INFRA_PROMOTION_TOKEN }}
+          GITHUB_CEREBRO_INFRA_REPOSITORY: ${{ secrets.CEREBRO_INFRA_REPOSITORY }}
           RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
           IMAGE_DIGEST: ${{ needs.ghcr-publish.outputs.digest }}
           SOURCE_REPOSITORY: ${{ github.repository }}
@@ -353,6 +353,9 @@ jobs:
           APPLY_MODE: ${{ matrix.apply_mode }}
         run: |
           set -euo pipefail
+          GH_TOKEN="${CEREBRO_INFRA_PROMOTION_TOKEN:-${GITHUB_CEREBRO_INFRA_PROMOTION_TOKEN:-}}"
+          INFRA_REPOSITORY="${CEREBRO_INFRA_REPOSITORY:-${GITHUB_CEREBRO_INFRA_REPOSITORY:-}}"
+          export GH_TOKEN
           if [ -z "${GH_TOKEN}" ]; then
             echo "::warning::CEREBRO_INFRA_PROMOTION_TOKEN is not configured; skipping ${TARGET_ENVIRONMENT} deploy dispatch for ${RELEASE_TAG}"
             exit 0


### PR DESCRIPTION
## Summary
- prefer Infisical-provided deploy dispatch settings when present
- fall back to the existing GitHub Actions secrets for the infra promotion token and repository
- keeps release dispatch from silently skipping while the Infisical migration catches up

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml-ok"' .github/workflows/release.yml
- actionlint .github/workflows/release.yml
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->