### PR TITLE
[codex] Fix Snyk asset relationship discovery IDs

### DIFF
--- a/sources/internal/snykapi/snykapi.go
+++ b/sources/internal/snykapi/snykapi.go
@@ -580,10 +580,11 @@ func snykAssetProjectsFamily() jsonapi.Family {
 		IDKeys:     []string{"id"},
 		ListKeys:   []string{"data"},
 		Attributes: map[string]string{
+			"external_id":     "id",
 			"org_id":          orgIDConfig,
 			"asset_id":        assetIDConfig,
 			"project_id":      "id",
-			"source_event_id": "id",
+			"source_event_id": "_record_id",
 			"resource_id":     "id",
 			"resource_name":   "attributes.name|name",
 			"resource_type":   "type",
@@ -592,6 +593,7 @@ func snykAssetProjectsFamily() jsonapi.Family {
 	})
 	family.Config.IdentityKeys = []string{assetIDConfig}
 	family.Config.ResourceURNKind = "snyk_projects"
+	family.Config.IDTemplate = "${asset_id}-${id}"
 	return family
 }
 
@@ -604,10 +606,11 @@ func snykAssetTargetsFamily() jsonapi.Family {
 		IDKeys:     []string{"id"},
 		ListKeys:   []string{"data"},
 		Attributes: map[string]string{
+			"external_id":     "id",
 			"org_id":          orgIDConfig,
 			"asset_id":        assetIDConfig,
 			"target_id":       "id",
-			"source_event_id": "id",
+			"source_event_id": "_record_id",
 			"resource_id":     "id",
 			"resource_name":   "attributes.display_name|attributes.name|name",
 			"resource_type":   "type",
@@ -616,6 +619,7 @@ func snykAssetTargetsFamily() jsonapi.Family {
 	})
 	family.Config.IdentityKeys = []string{assetIDConfig}
 	family.Config.ResourceURNKind = "snyk_targets"
+	family.Config.IDTemplate = "${asset_id}-${id}"
 	return family
 }
 

--- a/sources/snyk/source_test.go
+++ b/sources/snyk/source_test.go
@@ -319,9 +319,11 @@ func TestRuntimeUsesSnykRESTPathsAndVersionedPagination(t *testing.T) {
 			path:   "/orgs/org-1/inventory/assets/asset-1/relationships/projects",
 			record: map[string]any{"id": "project-1", "type": "project", "attributes": map[string]any{"name": "Checkout API", "project_type": "sast", "target_id": "target-1", "risk_score": 890}},
 			wantAttrs: map[string]string{
-				"org_id":     "org-1",
-				"asset_id":   "asset-1",
-				"project_id": "project-1",
+				"external_id":     "project-1",
+				"source_event_id": "asset-1-project-1",
+				"org_id":          "org-1",
+				"asset_id":        "asset-1",
+				"project_id":      "project-1",
 			},
 			config: map[string]string{"asset_ids": "asset-1"},
 		},
@@ -331,9 +333,11 @@ func TestRuntimeUsesSnykRESTPathsAndVersionedPagination(t *testing.T) {
 			path:   "/orgs/org-1/inventory/assets/asset-1/relationships/targets",
 			record: map[string]any{"id": "target-1", "type": "target", "attributes": map[string]any{"display_name": "writer/cerebro", "target_origin": "github", "imported_at": "2026-06-01T00:00:00Z"}},
 			wantAttrs: map[string]string{
-				"org_id":    "org-1",
-				"asset_id":  "asset-1",
-				"target_id": "target-1",
+				"external_id":     "target-1",
+				"source_event_id": "asset-1-target-1",
+				"org_id":          "org-1",
+				"asset_id":        "asset-1",
+				"target_id":       "target-1",
 			},
 			config: map[string]string{"asset_ids": "asset-1"},
 		},
@@ -563,6 +567,85 @@ func TestRuntimeReadsAssetScopedFamiliesAcrossConfiguredAssetIDs(t *testing.T) {
 	}
 	if strings.Join(requests, "\n") != strings.Join(wantRequests, "\n") {
 		t.Fatalf("requests = %#v, want %#v", requests, wantRequests)
+	}
+}
+
+func TestRuntimeDiscoversAssetScopedRelationshipURNsPerAsset(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		family       string
+		relationship string
+		recordID     string
+		recordType   string
+	}{
+		{
+			name:         "projects",
+			family:       familyAssetProjects,
+			relationship: "projects",
+			recordID:     "project-shared",
+			recordType:   "project",
+		},
+		{
+			name:         "targets",
+			family:       familyAssetTargets,
+			relationship: "targets",
+			recordID:     "target-shared",
+			recordType:   "target",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source, err := New()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			source.allowLoopbackForTest()
+			requests := []string{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r.URL.EscapedPath())
+				if got := r.Header.Get("Authorization"); got != "Token test-token" {
+					t.Fatalf("Authorization = %q, want Token test-token", got)
+				}
+				assertSnykQuery(t, r.URL.Query(), "", nil)
+				switch r.URL.EscapedPath() {
+				case "/orgs/org-1/inventory/assets/asset-a/relationships/" + tc.relationship,
+					"/orgs/org-1/inventory/assets/asset-b/relationships/" + tc.relationship:
+				default:
+					t.Fatalf("path = %q, want configured asset relationship scope", r.URL.EscapedPath())
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{
+					"id":         tc.recordID,
+					"type":       tc.recordType,
+					"attributes": map[string]any{"display_name": tc.recordID, "name": tc.recordID},
+				}}})
+			}))
+			defer server.Close()
+
+			urns, err := source.Discover(context.Background(), sourcecdk.NewConfig(map[string]string{
+				"asset_ids": "asset-a, asset-b",
+				"base_url":  server.URL,
+				"family":    tc.family,
+				"org_id":    "org-1",
+				"tenant_id": "tenant",
+				"token":     "test-token",
+			}))
+			if err != nil {
+				t.Fatalf("Discover() error = %v", err)
+			}
+			if len(urns) != 2 {
+				t.Fatalf("URNs = %#v, want one relationship URN per asset", urns)
+			}
+			if urns[0] == urns[1] {
+				t.Fatalf("relationship URNs collapsed across assets: %#v", urns)
+			}
+			wantRequests := []string{
+				"/orgs/org-1/inventory/assets/asset-a/relationships/" + tc.relationship,
+				"/orgs/org-1/inventory/assets/asset-b/relationships/" + tc.relationship,
+			}
+			if strings.Join(requests, "\n") != strings.Join(wantRequests, "\n") {
+				t.Fatalf("requests = %#v, want %#v", requests, wantRequests)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Include the Snyk asset id in project and target relationship record IDs.
- Add discovery coverage for shared project and target IDs across multiple assets.

## Why
Droid found that asset relationship discovery could collapse the same related project or target when it appeared under more than one asset. The relationship record ID now includes the asset scope, so each discovered relationship keeps its own URN.

## Validation
- `go test ./sources/snyk -count=1`
- `make sourcegen-check`
- `make catalog-check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->