### PR TITLE
[codex] Promote near-ready source fidelity

### DIFF
--- a/sources/jumpcloud/source_test.go
+++ b/sources/jumpcloud/source_test.go
@@ -367,6 +367,29 @@ func TestSourceReadsDirectoryInsightsAuditEvents(t *testing.T) {
 	}
 }
 
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source := newTestSource(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requireJumpCloudHeaders(t, r)
+		if r.URL.Path != "/systemusers" {
+			t.Fatalf("path = %q, want /systemusers", r.URL.Path)
+		}
+		http.Error(w, `{"message":"temporarily unavailable"}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	_, err := source.Read(context.Background(), jumpCloudConfig(server.URL, map[string]string{
+		"family":   familyUsers,
+		"per_page": "2",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "jumpcloud API returned 503") || !strings.Contains(got, "temporarily unavailable") {
+		t.Fatalf("Read() error = %q, want provider status and message", got)
+	}
+}
+
 func newTestSource(t *testing.T) *Source {
 	t.Helper()
 	source, err := New()

--- a/sources/new_relic/source_test.go
+++ b/sources/new_relic/source_test.go
@@ -224,6 +224,34 @@ func TestSanitizeEventIDPreservesProviderIdentifiers(t *testing.T) {
 	}
 }
 
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			t.Fatalf("path = %q, want /graphql", r.URL.Path)
+		}
+		http.Error(w, `{"error":{"message":"temporarily unavailable"}}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder key.
+		"api_key":   "test-api-key",
+		"base_url":  server.URL,
+		"family":    familyAssets,
+		"tenant_id": "tenant",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "new_relic GraphQL status 503") || !strings.Contains(got, "temporarily unavailable") {
+		t.Fatalf("Read() error = %q, want provider status and message", got)
+	}
+}
+
 func TestNewFindingEventKeepsRequiredAttributesForPartialIssue(t *testing.T) {
 	event := newrelicapi.NewFindingEvent(newrelicapi.Settings{TenantID: "tenant"}, newrelicapi.Record{
 		"issueId": "ISSUE-1",

--- a/sources/snyk/source_test.go
+++ b/sources/snyk/source_test.go
@@ -76,6 +76,37 @@ func TestSourceCheckAndRead(t *testing.T) {
 	}
 }
 
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Token test-token" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		if r.URL.Path != "/orgs" {
+			t.Fatalf("path = %q, want /orgs", r.URL.Path)
+		}
+		http.Error(w, `{"message":"temporarily unavailable"}`, http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url":  server.URL,
+		"family":    familyOrgs,
+		"tenant_id": "tenant",
+		"token":     "test-token",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "snyk API returned 503") || !strings.Contains(got, "temporarily unavailable") {
+		t.Fatalf("Read() error = %q, want provider status and message", got)
+	}
+}
+
 func TestRuntimeUsesSnykRESTPathsAndVersionedPagination(t *testing.T) {
 	for _, tt := range []struct {
 		family    string


### PR DESCRIPTION
## Summary

- Add provider-unavailable regression coverage for JumpCloud, New Relic, and Snyk runtime sources.
- Exercise each source through its real Read path against a 503 provider response.
- Move the sourcefidelity high-fidelity count from 31 to 34.

## Fidelity result

- jumpcloud: 78 -> 83
- new_relic: 78 -> 83
- snyk: 78 -> 83

## Validation

- go test ./sources/new_relic -count=1
- go test ./sources/jumpcloud -count=1
- go test ./sources/snyk -count=1
- go run ./tools/sourcefidelity -json-out tmp/source-fidelity-after.json -markdown-out tmp/source-fidelity-after.md -max-items 25
- make sourcegen-check
- make catalog-check
