### PR TITLE
[codex] Promote Duo source fidelity

### DIFF
--- a/sources/duo/fixture.go
+++ b/sources/duo/fixture.go
@@ -1,0 +1,80 @@
+package duo
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+//go:embed testdata/*.json
+var fixtureFS embed.FS
+
+var duoFixtureFamilies = []string{
+	"user",
+	"group",
+	"administrator",
+	"endpoint",
+	"phone",
+	"token",
+	"web_authn_credential",
+	"role",
+	"application",
+	"audit_event",
+	"authentication_log",
+}
+
+func NewFixture() (sourcecdk.Source, error) {
+	catalogBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read catalog: %w", err)
+	}
+	catalog, err := sourcecdk.LoadSourceCatalog(catalogBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog: %w", err)
+	}
+	families := make([]sourcecdk.FixtureFamily, 0, len(duoFixtureFamilies))
+	for _, family := range duoFixtureFamilies {
+		urns, err := sourcecdk.LoadFixtureURNs(fixtureFS, "testdata/discover_"+family+".json")
+		if err != nil {
+			return nil, err
+		}
+		events, err := sourcecdk.LoadFixtureEventsWithContracts(fixtureFS, "testdata/read_"+family+".json", catalog.EventContracts)
+		if err != nil {
+			return nil, err
+		}
+		families = append(families, sourcecdk.FixtureFamily{Name: family, URNs: urns, Events: events})
+	}
+	return sourcecdk.NewFixtureSource(sourcecdk.FixtureSourceOptions{
+		Spec:          catalog.Spec,
+		Contracts:     catalog.EventContracts,
+		DefaultFamily: defaultFamily,
+		Check:         checkFixtureConfig,
+		ResolveFamily: resolveFixtureFamily,
+		Families:      families,
+	})
+}
+
+func checkFixtureConfig(_ context.Context, cfg sourcecdk.Config) error {
+	if fixtureTenantID(cfg) == "" {
+		return fmt.Errorf("tenant_id is required")
+	}
+	return nil
+}
+
+func resolveFixtureFamily(cfg sourcecdk.Config) (string, error) {
+	if fixtureTenantID(cfg) == "" {
+		return "", fmt.Errorf("tenant_id is required")
+	}
+	family := strings.TrimSpace(sourcecdk.ConfigValue(cfg, "family"))
+	if family == "" {
+		return defaultFamily, nil
+	}
+	return family, nil
+}
+
+func fixtureTenantID(cfg sourcecdk.Config) string {
+	return strings.TrimSpace(sourcecdk.ConfigValue(cfg, "tenant_id"))
+}

--- a/sources/duo/fixture.go
+++ b/sources/duo/fixture.go
@@ -1,3 +1,4 @@
+// Hand-maintained fixture source for Duo's HMAC-backed runtime.
 package duo
 
 import (

--- a/sources/duo/source_test.go
+++ b/sources/duo/source_test.go
@@ -77,6 +77,18 @@ func TestReadDuoIdentityAndMFAPostureKinds(t *testing.T) {
 			want: map[string]string{"admin_id": "admin-1", "user_id": "admin-1", "email": "secadmin@writer.com", "role": "Owner", "status": "Active"},
 		},
 		{
+			name:   "endpoint",
+			family: "endpoint",
+			kind:   "duo.endpoint",
+			path:   "/admin/v1/endpoints",
+			response: map[string]any{"stat": "OK", "response": []map[string]any{{
+				"endpoint_id": "endpoint-1", "hostname": "macbook-1", "os": "macOS",
+				"os_version": "15.5", "browser": "Safari", "disk_encryption_status": "encrypted",
+				"last_seen": 1700000000,
+			}}},
+			want: map[string]string{"endpoint_id": "endpoint-1", "hostname": "macbook-1", "os": "macOS", "os_version": "15.5", "disk_encryption_status": "encrypted"},
+		},
+		{
 			name:   "phone",
 			family: "phone",
 			kind:   "duo.phone",
@@ -384,6 +396,58 @@ func TestReadDuoAuthenticationLogRoundTripsNextOffset(t *testing.T) {
 	}
 	if requests != 2 {
 		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestNewFixtureReplaysEveryRuntimeFamily(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+
+	familyConfigs := map[string]sourcecdk.Config{}
+	for _, family := range duoFixtureFamilies {
+		familyConfigs[family] = sourcecdk.NewConfig(map[string]string{
+			"family":    family,
+			"tenant_id": "tenant",
+		})
+	}
+	sourcecdk.RunFixtureSuite(t, context.Background(), sourcecdk.FixtureSuiteOptions{
+		Source:          source,
+		FamilyConfigs:   familyConfigs,
+		RequireDiscover: true,
+	})
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/admin/v1/users" {
+			t.Fatalf("request path = %q, want /admin/v1/users", got)
+		}
+		assertDuoHMACAuth(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "temporarily unavailable", "stat": "FAIL"})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url":      server.URL,
+		"client_id":     testDuoIntegrationKey,
+		"client_secret": testDuoSecretKey,
+		"family":        "user",
+		"tenant_id":     "writer",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "duo API returned 503") {
+		t.Fatalf("Read() error = %q, want provider status", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a Duo fixture source backed by the existing provider-shaped discover/read payloads
- replay every Duo runtime family through the source fixture suite
- cover Duo endpoint reads and 503 provider-unavailable behavior

## Validation
- go test ./sources/duo -count=1
- go run ./tools/sourcefidelity -json-out tmp/source-fidelity-batch2.json -markdown-out tmp/source-fidelity-batch2.md -max-items 25
- make sourcegen-check
- make catalog-check

Duo moves to score 83 with every-family fixture coverage, provider-like read fixtures, deploy family coverage, HTTP provider behavior, checkpoint evidence, and provider-unavailable coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->