### PR TITLE
[codex] Promote GitLab source fidelity

### DIFF
--- a/sources/gitlab/deploy.yaml
+++ b/sources/gitlab/deploy.yaml
@@ -6,8 +6,26 @@ runtimes:
     config:
       family: repositories
       failure_modes: api_error,auth_error,rate_limit,schema_drift
-      health_path: /v4/user
+      health_path: /api/v4/user
       expected_cadence_seconds: "86400"
       stale_after_seconds: "86400"
+      per_page: "100"
+      token: env:GITLAB_TOKEN
+  - localId: users
+    config:
+      family: users
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/v4/user
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      token: env:GITLAB_TOKEN
+  - localId: audit-events
+    config:
+      family: audit_events
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/v4/user
+      expected_cadence_seconds: "3600"
+      stale_after_seconds: "7200"
       per_page: "100"
       token: env:GITLAB_TOKEN

--- a/sources/gitlab/source_health_receipt.json
+++ b/sources/gitlab/source_health_receipt.json
@@ -2,7 +2,7 @@
   "adapter_health_path": "/api/v4/user",
   "auth_model": "bearer_token",
   "evidence_cas_reference_kind": "gitlab.evidence_cas_reference",
-  "expected_cadence_seconds": 3600,
+  "expected_cadence_seconds": 86400,
   "failure_modes": [
     "api_error",
     "auth_error",
@@ -13,5 +13,5 @@
   "receipt_kind": "source_health.receipt",
   "source_id": "gitlab",
   "source_type": "json_api",
-  "stale_after_seconds": 7200
+  "stale_after_seconds": 86400
 }

--- a/sources/gitlab/source_health_receipt.json
+++ b/sources/gitlab/source_health_receipt.json
@@ -1,5 +1,5 @@
 {
-  "adapter_health_path": "/v4/user",
+  "adapter_health_path": "/api/v4/user",
   "auth_model": "bearer_token",
   "evidence_cas_reference_kind": "gitlab.evidence_cas_reference",
   "expected_cadence_seconds": 86400,

--- a/sources/gitlab/source_health_receipt.json
+++ b/sources/gitlab/source_health_receipt.json
@@ -2,7 +2,7 @@
   "adapter_health_path": "/api/v4/user",
   "auth_model": "bearer_token",
   "evidence_cas_reference_kind": "gitlab.evidence_cas_reference",
-  "expected_cadence_seconds": 86400,
+  "expected_cadence_seconds": 3600,
   "failure_modes": [
     "api_error",
     "auth_error",
@@ -13,5 +13,5 @@
   "receipt_kind": "source_health.receipt",
   "source_id": "gitlab",
   "source_type": "json_api",
-  "stale_after_seconds": 86400
+  "stale_after_seconds": 7200
 }

--- a/sources/gitlab/source_test.go
+++ b/sources/gitlab/source_test.go
@@ -100,6 +100,38 @@ func TestSourceReadAuditEventsDoesNotInventResourceURN(t *testing.T) {
 	assertNoResourceURN(t, pull.Events[0].Attributes)
 }
 
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("Authorization"+" = %q", r.Header.Get("Authorization"))
+		}
+		if r.URL.Path != "/api/v4/projects" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "maintenance"})
+	}))
+	defer server.Close()
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url":  server.URL,
+		"family":    familyRepositories,
+		"tenant_id": "tenant",
+		"token":     "test-token",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "gitlab API returned 503") {
+		t.Fatalf("Read() error = %q, want provider status", got)
+	}
+}
+
 func TestNewFixtureReplaysGitLabFamilies(t *testing.T) {
 	source, err := NewFixture()
 	if err != nil {


### PR DESCRIPTION
## Summary
- configure GitLab deploy runtimes for repositories, users, and audit events
- align the GitLab health path with the runtime `/api/v4/user` endpoint
- add provider-unavailable coverage for GitLab 503 responses

## Validation
- go test ./sources/gitlab -count=1
- go run ./tools/sourcefidelity -json-out tmp/source-fidelity-batch4.json -markdown-out tmp/source-fidelity-batch4.md -max-items 40
- make sourcegen-check
- make catalog-check

GitLab moves to score 83 with provider-like fixtures, every-family fixture replay, deploy family coverage, provider-shaped HTTP behavior, and provider-unavailable coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->