### PR TITLE
[codex] Promote Microsoft Entra source fidelity

### DIFF
--- a/sources/microsoft_entra_id/deploy.yaml
+++ b/sources/microsoft_entra_id/deploy.yaml
@@ -2,6 +2,7 @@ sourceId: microsoft_entra_id
 secretKeys:
   - MICROSOFT_ENTRA_ID_CLIENT_ID
   - MICROSOFT_ENTRA_ID_CLIENT_SECRET
+  - MICROSOFT_ENTRA_ID_TENANT_ID
 runtimes:
   - localId: users
     config:
@@ -13,6 +14,7 @@ runtimes:
       per_page: "100"
       client_id: env:MICROSOFT_ENTRA_ID_CLIENT_ID
       client_secret: env:MICROSOFT_ENTRA_ID_CLIENT_SECRET
+      tenant_id: env:MICROSOFT_ENTRA_ID_TENANT_ID
   - localId: groups
     config:
       family: groups
@@ -23,6 +25,7 @@ runtimes:
       per_page: "100"
       client_id: env:MICROSOFT_ENTRA_ID_CLIENT_ID
       client_secret: env:MICROSOFT_ENTRA_ID_CLIENT_SECRET
+      tenant_id: env:MICROSOFT_ENTRA_ID_TENANT_ID
   - localId: audit-events
     config:
       family: audit_events
@@ -33,3 +36,4 @@ runtimes:
       per_page: "100"
       client_id: env:MICROSOFT_ENTRA_ID_CLIENT_ID
       client_secret: env:MICROSOFT_ENTRA_ID_CLIENT_SECRET
+      tenant_id: env:MICROSOFT_ENTRA_ID_TENANT_ID

--- a/sources/microsoft_entra_id/deploy.yaml
+++ b/sources/microsoft_entra_id/deploy.yaml
@@ -13,3 +13,23 @@ runtimes:
       per_page: "100"
       client_id: env:MICROSOFT_ENTRA_ID_CLIENT_ID
       client_secret: env:MICROSOFT_ENTRA_ID_CLIENT_SECRET
+  - localId: groups
+    config:
+      family: groups
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /v1.0/organization
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      client_id: env:MICROSOFT_ENTRA_ID_CLIENT_ID
+      client_secret: env:MICROSOFT_ENTRA_ID_CLIENT_SECRET
+  - localId: audit-events
+    config:
+      family: audit_events
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /v1.0/organization
+      expected_cadence_seconds: "3600"
+      stale_after_seconds: "7200"
+      per_page: "100"
+      client_id: env:MICROSOFT_ENTRA_ID_CLIENT_ID
+      client_secret: env:MICROSOFT_ENTRA_ID_CLIENT_SECRET

--- a/sources/microsoft_entra_id/source_test.go
+++ b/sources/microsoft_entra_id/source_test.go
@@ -58,7 +58,14 @@ func TestSourceCheckAndRead(t *testing.T) {
 			t.Fatalf("$top query is empty")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"value": []map[string]any{{"id": "user-1", "displayName": "Record One", "mail": "record@example.test", "userPrincipalName": "record@example.test", "accountEnabled": true, "createdDateTime": "2026-06-01T00:00:00Z"}}})
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []map[string]any{{
+			"id":                "user-1",
+			"displayName":       "Ada Lovelace",
+			"mail":              "ada@example.test",
+			"userPrincipalName": "ada@example.test",
+			"accountEnabled":    true,
+			"createdDateTime":   "2026-06-01T00:00:00Z",
+		}}})
 	}))
 	defer server.Close()
 	cfgValues := map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token_url": server.URL + "/oauth/token", "client_id": "client-id", "client_secret": "client-secret"}
@@ -85,6 +92,12 @@ func TestSourceCheckAndRead(t *testing.T) {
 	}
 	if got := event.Attributes["account_enabled"]; got != "true" {
 		t.Fatalf("account_enabled = %q", got)
+	}
+	if got := event.Attributes["display_name"]; got != "Ada Lovelace" {
+		t.Fatalf("display_name = %q", got)
+	}
+	if got := event.Attributes["email"]; got != "ada@example.test" {
+		t.Fatalf("email = %q", got)
 	}
 	if got := event.Attributes["status"]; got != "" {
 		t.Fatalf("status = %q, want empty when only accountEnabled is present", got)
@@ -142,6 +155,45 @@ func TestSourceReadAuditEventsDoesNotInventResourceURN(t *testing.T) {
 		t.Fatalf("resource_type = %q, want Group", got)
 	}
 	assertNoResourceURN(t, pull.Events[0].Attributes)
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 600})
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("Authorization"+" = %q", r.Header.Get("Authorization"))
+		}
+		if r.URL.Path != "/v1.0/users" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "maintenance"})
+	}))
+	defer server.Close()
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url":      server.URL,
+		"family":        familyUsers,
+		"tenant_id":     "tenant",
+		"token_url":     server.URL + "/oauth/token",
+		"client_id":     "client-id",
+		"client_secret": "client-secret",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "microsoft_entra_id API returned 503") {
+		t.Fatalf("Read() error = %q, want provider status", got)
+	}
 }
 
 func TestNewFixtureReplaysMicrosoftEntraIDFamilies(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Microsoft Entra ID deploy runtimes for users, groups, and audit events
- replace the generic user HTTP response with Microsoft Graph-shaped user data
- add provider-unavailable coverage after OAuth token exchange

## Validation
- go test ./sources/microsoft_entra_id -count=1
- go run ./tools/sourcefidelity -json-out tmp/source-fidelity-batch5.json -markdown-out tmp/source-fidelity-batch5.md -max-items 40
- make sourcegen-check
- make catalog-check

Microsoft Entra ID moves to score 83 with provider-like fixtures, every-family fixture replay, deploy family coverage, provider-shaped HTTP behavior, and provider-unavailable coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->