### PR TITLE
[codex] Promote Okta source fidelity

### DIFF
--- a/sources/okta/deploy.yaml
+++ b/sources/okta/deploy.yaml
@@ -10,16 +10,19 @@ runtimes:
       per_page: "200"
       since: "2026-05-01T00:00:00Z"
       token: env:OKTA_API_TOKEN
-  - localId: user
+  - localId: admin-role
     config:
       domain: env:OKTA_DOMAIN
-      family: user
+      family: admin_role
       per_page: "200"
       token: env:OKTA_API_TOKEN
-  - localId: group
+      user_id: config:OKTA_ADMIN_ROLE_USER_ID
+      user_email: config:OKTA_ADMIN_ROLE_USER_EMAIL
+  - localId: app-assignment
     config:
+      app_id: config:OKTA_APP_ID
       domain: env:OKTA_DOMAIN
-      family: group
+      family: app_assignment
       per_page: "200"
       token: env:OKTA_API_TOKEN
   - localId: application
@@ -28,10 +31,77 @@ runtimes:
       family: application
       per_page: "200"
       token: env:OKTA_API_TOKEN
+  - localId: api-token
+    config:
+      domain: env:OKTA_DOMAIN
+      family: api_token
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: authorization-server
+    config:
+      domain: env:OKTA_DOMAIN
+      family: authorization_server
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
   - localId: authenticator
     config:
       domain: env:OKTA_DOMAIN
       family: authenticator
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: brand
+    config:
+      domain: env:OKTA_DOMAIN
+      family: brand
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: device-assurance
+    config:
+      domain: env:OKTA_DOMAIN
+      family: device_assurance
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: event-hook
+    config:
+      domain: env:OKTA_DOMAIN
+      family: event_hook
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: group
+    config:
+      domain: env:OKTA_DOMAIN
+      family: group
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: group-membership
+    config:
+      domain: env:OKTA_DOMAIN
+      family: group_membership
+      group_id: config:OKTA_GROUP_ID
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: identity-provider
+    config:
+      domain: env:OKTA_DOMAIN
+      family: identity_provider
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: inline-hook
+    config:
+      domain: env:OKTA_DOMAIN
+      family: inline_hook
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: log-stream
+    config:
+      domain: env:OKTA_DOMAIN
+      family: log_stream
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: network-zone
+    config:
+      domain: env:OKTA_DOMAIN
+      family: network_zone
       per_page: "200"
       token: env:OKTA_API_TOKEN
   - localId: policy-rule
@@ -44,5 +114,17 @@ runtimes:
     config:
       domain: env:OKTA_DOMAIN
       family: threat_insight
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: trusted-origin
+    config:
+      domain: env:OKTA_DOMAIN
+      family: trusted_origin
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: user
+    config:
+      domain: env:OKTA_DOMAIN
+      family: user
       per_page: "200"
       token: env:OKTA_API_TOKEN

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -258,13 +259,18 @@ func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	source.allowLoopbackBaseURL = true
+	var mu sync.Mutex
+	requests := []struct {
+		auth string
+		path string
+	}{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "SSWS test-token" {
-			t.Fatalf("Authorization = %q, want SSWS token", got)
-		}
-		if r.URL.Path != "/api/v1/users" {
-			t.Fatalf("path = %q, want Okta users endpoint", r.URL.Path)
-		}
+		mu.Lock()
+		requests = append(requests, struct {
+			auth string
+			path string
+		}{auth: r.Header.Get("Authorization"), path: r.URL.Path})
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_ = json.NewEncoder(w).Encode(map[string]string{"errorSummary": "maintenance"})
@@ -283,6 +289,23 @@ func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
 	}
 	if got := err.Error(); !strings.Contains(got, "okta API returned 503") {
 		t.Fatalf("Read() error = %q, want provider status", got)
+	}
+	mu.Lock()
+	gotRequests := append([]struct {
+		auth string
+		path string
+	}{}, requests...)
+	mu.Unlock()
+	if len(gotRequests) == 0 {
+		t.Fatal("provider server saw no requests")
+	}
+	for _, request := range gotRequests {
+		if request.auth != "SSWS test-token" {
+			t.Fatalf("Authorization = %q, want SSWS token", request.auth)
+		}
+		if request.path != "/api/v1/users" {
+			t.Fatalf("path = %q, want Okta users endpoint", request.path)
+		}
 	}
 }
 

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -187,6 +187,105 @@ func TestNewFixtureReplaysOktaIdentityFamilies(t *testing.T) {
 	}
 }
 
+func TestNewFixtureReplaysEveryRuntimeFamily(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+
+	tests := []struct {
+		family string
+		config map[string]string
+		kind   string
+	}{
+		{family: "api_token", kind: "okta.api_token"},
+		{family: "authorization_server", kind: "okta.authorization_server"},
+		{family: "brand", kind: "okta.brand"},
+		{family: "device_assurance", kind: "okta.device_assurance"},
+		{family: "event_hook", kind: "okta.event_hook"},
+		{family: "inline_hook", kind: "okta.inline_hook"},
+		{family: "log_stream", kind: "okta.log_stream"},
+		{family: familyAdminRole, config: map[string]string{"user_id": "00u1", "user_email": "admin@writer.com"}, kind: "okta.admin_role"},
+		{family: familyAppAssign, config: map[string]string{"app_id": "app-prod"}, kind: "okta.app_assignment"},
+		{family: familyApplication, kind: "okta.application"},
+		{family: familyAudit, kind: "okta.audit"},
+		{family: familyAuthenticator, kind: "okta.authenticator"},
+		{family: familyGroup, kind: "okta.group"},
+		{family: familyGroupMember, config: map[string]string{"group_id": "grp-security"}, kind: "okta.group_membership"},
+		{family: familyIDP, kind: "okta.identity_provider"},
+		{family: familyNetworkZone, kind: "okta.network_zone"},
+		{family: familyPolicyRule, kind: "okta.policy_rule"},
+		{family: familyThreatInsight, kind: "okta.threat_insight"},
+		{family: familyTrustedOrigin, kind: "okta.trusted_origin"},
+		{family: familyUser, kind: "okta.user"},
+	}
+	familyConfigs := map[string]sourcecdk.Config{}
+	for _, tt := range tests {
+		values := map[string]string{
+			"domain": "writer.okta.com",
+			"family": tt.family,
+			"token":  "test-token",
+		}
+		for key, value := range tt.config {
+			values[key] = value
+		}
+		familyConfigs[tt.family] = sourcecdk.NewConfig(values)
+	}
+	sourcecdk.RunFixtureSuite(t, context.Background(), sourcecdk.FixtureSuiteOptions{
+		Source:          source,
+		FamilyConfigs:   familyConfigs,
+		RequireDiscover: true,
+	})
+	for _, tt := range tests {
+		t.Run(tt.family, func(t *testing.T) {
+			pull, err := source.Read(context.Background(), familyConfigs[tt.family], nil)
+			if err != nil {
+				t.Fatalf("Read(%s) error = %v", tt.family, err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("len(Read(%s).Events) = %d, want 1", tt.family, len(pull.Events))
+			}
+			if got := pull.Events[0].Kind; got != tt.kind {
+				t.Fatalf("Read(%s).Events[0].Kind = %q, want %q", tt.family, got, tt.kind)
+			}
+		})
+	}
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "SSWS test-token" {
+			t.Fatalf("Authorization = %q, want SSWS token", got)
+		}
+		if r.URL.Path != "/api/v1/users" {
+			t.Fatalf("path = %q, want Okta users endpoint", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"errorSummary": "maintenance"})
+	}))
+	defer server.Close()
+
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"domain":   "writer.okta.com",
+		"family":   familyUser,
+		"per_page": "200",
+		"token":    "test-token",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "okta API returned 503") {
+		t.Fatalf("Read() error = %q, want provider status", got)
+	}
+}
+
 func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
 	server := httptest.NewServer(newOktaAPIHandler(t))
 	defer server.Close()


### PR DESCRIPTION
## Summary
- Add Okta deploy runtimes for every catalog runtime family.
- Add every-family fixture replay coverage across all 20 Okta families.
- Add provider-unavailable coverage for 503 responses from the users endpoint.

## Validation
- go test ./sources/okta -count=1
- go run ./tools/sourcefidelity -json-out tmp/source-fidelity-batch7.json -markdown-out tmp/source-fidelity-batch7.md -max-items 80
- make sourcegen-check
- make catalog-check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->