### PR TITLE
[codex] Cover provider unavailable reference sources

### DIFF
--- a/sources/asana/source_test.go
+++ b/sources/asana/source_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -210,6 +211,62 @@ func TestProjectsUseModifiedAtForOccurredAt(t *testing.T) {
 	want := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
 	if got := event.OccurredAt.AsTime(); !got.Equal(want) {
 		t.Fatalf("OccurredAt = %s, want %s", got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	var mu sync.Mutex
+	requests := []struct {
+		auth string
+		path string
+	}{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, struct {
+			auth string
+			path string
+		}{auth: r.Header.Get("Authorization"), path: r.URL.Path})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "maintenance"})
+	}))
+	defer server.Close()
+
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "tenant",
+		"base_url":      server.URL,
+		"family":        familyUsers,
+		"token":         "test-token",
+		"workspace_gid": "workspace-1",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "asana API returned 503") {
+		t.Fatalf("Read() error = %q, want provider status", got)
+	}
+	mu.Lock()
+	gotRequests := append([]struct {
+		auth string
+		path string
+	}{}, requests...)
+	mu.Unlock()
+	if len(gotRequests) == 0 {
+		t.Fatal("provider server saw no requests")
+	}
+	for _, request := range gotRequests {
+		if request.auth != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer token", request.auth)
+		}
+		if request.path != "/users" {
+			t.Fatalf("path = %q, want Asana users endpoint", request.path)
+		}
 	}
 }
 

--- a/sources/cohere/source_test.go
+++ b/sources/cohere/source_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -234,6 +235,62 @@ func TestSourceRejectsMissingProviderListKey(t *testing.T) {
 	_, err = source.Read(context.Background(), cfg, nil)
 	if sourcecdk.SourceErrorKind(err) != sourcecdk.ErrorKindProvider {
 		t.Fatalf("Read() error kind = %q, want provider; err=%v", sourcecdk.SourceErrorKind(err), err)
+	}
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	var mu sync.Mutex
+	requests := []struct {
+		auth string
+		path string
+	}{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, struct {
+			auth string
+			path string
+		}{auth: r.Header.Get("Authorization"), path: r.URL.Path})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "maintenance"})
+	}))
+	defer server.Close()
+
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "tenant",
+		"base_url":  server.URL,
+		"family":    familyDatasets,
+		"token":     "test-token",
+		"per_page":  "1",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "cohere API returned 503") {
+		t.Fatalf("Read() error = %q, want provider status", got)
+	}
+	mu.Lock()
+	gotRequests := append([]struct {
+		auth string
+		path string
+	}{}, requests...)
+	mu.Unlock()
+	if len(gotRequests) == 0 {
+		t.Fatal("provider server saw no requests")
+	}
+	for _, request := range gotRequests {
+		if request.auth != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer token", request.auth)
+		}
+		if request.path != "/v1/datasets" {
+			t.Fatalf("path = %q, want Cohere datasets endpoint", request.path)
+		}
 	}
 }
 

--- a/sources/openrouter/source_test.go
+++ b/sources/openrouter/source_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -268,6 +269,58 @@ func TestSourceReadReturnsOpenRouterErrorBody(t *testing.T) {
 	var statusErr interface{ StatusCode() int }
 	if !errors.As(err, &statusErr) || statusErr.StatusCode() != http.StatusUnauthorized {
 		t.Fatalf("Read() error = %v, want HTTP 401", err)
+	}
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source := newTestSource(t)
+	var mu sync.Mutex
+	requests := []struct {
+		auth string
+		path string
+	}{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, struct {
+			auth string
+			path string
+		}{auth: r.Header.Get("Authorization"), path: r.URL.Path})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": 503, "message": "maintenance"}})
+	}))
+	defer server.Close()
+
+	_, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "tenant",
+		"base_url":  server.URL,
+		"family":    familyApiKeys,
+		"token":     "test-token",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	var statusErr interface{ StatusCode() int }
+	if !errors.As(err, &statusErr) || statusErr.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("Read() error = %v, want HTTP 503", err)
+	}
+	mu.Lock()
+	gotRequests := append([]struct {
+		auth string
+		path string
+	}{}, requests...)
+	mu.Unlock()
+	if len(gotRequests) == 0 {
+		t.Fatal("provider server saw no requests")
+	}
+	for _, request := range gotRequests {
+		if request.auth != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer token", request.auth)
+		}
+		if request.path != "/v1/keys" {
+			t.Fatalf("path = %q, want OpenRouter keys endpoint", request.path)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add provider-unavailable read coverage for Asana users, Cohere datasets, and OpenRouter API keys.
- Keep request assertions on the test goroutine after the provider server returns.
- Ratchet Asana, Cohere, and OpenRouter to 100/100 sourcefidelity reference status.

## Validation
- go test ./sources/asana ./sources/cohere ./sources/openrouter -count=1
- go run ./tools/sourcefidelity -json-out tmp/source-fidelity-batch8.json -markdown-out tmp/source-fidelity-batch8.md -max-items 100
- make sourcegen-check
- make catalog-check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->