### PR TITLE
[codex] Cover SailPoint provider unavailable

### DIFF
--- a/sources/sailpoint_identitynow/source_test.go
+++ b/sources/sailpoint_identitynow/source_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -526,6 +527,63 @@ func TestSourceRolesEmitStaticPolicyAttributes(t *testing.T) {
 	}
 	if got := pull.Events[0].Attributes["role_type"]; got != "role" {
 		t.Fatalf("role_type = %q, want role", got)
+	}
+}
+
+func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+
+	var mu sync.Mutex
+	requests := []struct {
+		auth string
+		path string
+	}{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, struct {
+			auth string
+			path string
+		}{auth: r.Header.Get("Authorization"), path: r.URL.Path})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "maintenance"})
+	}))
+	defer server.Close()
+
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "tenant",
+		"base_url":  server.URL + "/v2025",
+		"token":     "test-token",
+		"family":    sailpointapi.FamilyIdentities,
+	}), nil)
+	if err == nil {
+		t.Fatal("Read() error = nil, want provider error")
+	}
+	var statusErr interface{ StatusCode() int }
+	if !errors.As(err, &statusErr) || statusErr.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("Read() error = %v, want HTTP 503", err)
+	}
+	mu.Lock()
+	gotRequests := append([]struct {
+		auth string
+		path string
+	}{}, requests...)
+	mu.Unlock()
+	if len(gotRequests) == 0 {
+		t.Fatal("provider server saw no requests")
+	}
+	for _, request := range gotRequests {
+		if request.auth != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer token", request.auth)
+		}
+		if request.path != "/v2025/identities" {
+			t.Fatalf("path = %q, want SailPoint identities endpoint", request.path)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add SailPoint provider-unavailable coverage for the identities runtime
- assert the runtime preserves bearer auth and calls the provider v2025 identities path
- assert the provider error through the shared StatusCode() contract
- confirm SailPoint fidelity is reference score 100 with no missing items after the provider-proof gate landed

## Validation
- go test ./sources/sailpoint_identitynow -count=1
- go run ./tools/sourcefidelity -json-out tmp/source-fidelity-batch9-typed-error.json -markdown-out tmp/source-fidelity-batch9-typed-error.md -max-items 100
- make sourcegen-check
- make catalog-check