### PR TITLE
[codex] Promote Datadog coverage fidelity

### DIFF
--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -3095,6 +3095,29 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
           "source_id": "google_workspace",
           "dimension_id": "user_lifecycle",
           "dimension_type": "lifecycle_state",
@@ -3297,28 +3320,6 @@
               "framework_name": "ISO 27001:2022",
               "control_id": "A.8.5"
             },
-            {
-              "framework_name": "SOC 2",
-              "control_id": "CC6.1"
-            }
-          ]
-        },
-        {
-          "source_id": "files_com",
-          "dimension_id": "user",
-          "dimension_type": "entity_family",
-          "support_level": "partial",
-          "high_value": true,
-          "families": [
-            "user"
-          ],
-          "evidence_types": [
-            "source_snapshot"
-          ],
-          "control_domains": [
-            "asset_inventory"
-          ],
-          "matched_control_refs": [
             {
               "framework_name": "SOC 2",
               "control_id": "CC6.1"
@@ -13901,6 +13902,29 @@
               "framework_name": "ISO 27001:2022",
               "control_id": "A.5.26"
             },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC7.4"
+            }
+          ]
+        },
+        {
+          "source_id": "datadog",
+          "dimension_id": "incidents",
+          "dimension_type": "lifecycle_state",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "incidents"
+          ],
+          "evidence_types": [
+            "incident_record"
+          ],
+          "control_domains": [
+            "availability_resilience",
+            "security_operations"
+          ],
+          "matched_control_refs": [
             {
               "framework_name": "SOC 2",
               "control_id": "CC7.4"
@@ -34651,6 +34675,28 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_roles",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "roles"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
           "source_id": "onelogin",
           "dimension_id": "directory_inventory",
           "dimension_type": "entity_family",
@@ -49228,6 +49274,29 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
           "source_id": "pagerduty",
           "dimension_id": "users",
           "dimension_type": "entity_family",
@@ -53035,6 +53104,29 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
           "source_id": "google_workspace",
           "dimension_id": "groups",
           "dimension_type": "entity_family",
@@ -53130,28 +53222,6 @@
           "dimension_id": "groups",
           "dimension_type": "entity_family",
           "support_level": "supported",
-          "high_value": true,
-          "families": [
-            "group"
-          ],
-          "evidence_types": [
-            "source_snapshot"
-          ],
-          "control_domains": [
-            "asset_inventory"
-          ],
-          "matched_control_refs": [
-            {
-              "framework_name": "SOC 2",
-              "control_id": "CC6.1"
-            }
-          ]
-        },
-        {
-          "source_id": "files_com",
-          "dimension_id": "group",
-          "dimension_type": "entity_family",
-          "support_level": "partial",
           "high_value": true,
           "families": [
             "group"
@@ -60834,6 +60904,29 @@
             {
               "framework_name": "SOC 2",
               "control_id": "CC6.2"
+            }
+          ]
+        },
+        {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
             }
           ]
         },
@@ -70742,6 +70835,29 @@
             "logging_configuration"
           ],
           "control_domains": [
+            "logging_monitoring"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC7.2"
+            }
+          ]
+        },
+        {
+          "source_id": "datadog",
+          "dimension_id": "audit_events",
+          "dimension_type": "audit_event",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "audit_events"
+          ],
+          "evidence_types": [
+            "logging_configuration"
+          ],
+          "control_domains": [
+            "identity_access",
             "logging_monitoring"
           ],
           "matched_control_refs": [
@@ -265821,6 +265937,29 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "ISO 27001:2022",
+              "control_id": "A.5.15"
+            }
+          ]
+        },
+        {
           "source_id": "files_com",
           "dimension_id": "user",
           "dimension_type": "entity_family",
@@ -266393,6 +266532,29 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "ISO 27001:2022",
+              "control_id": "A.5.15"
+            }
+          ]
+        },
+        {
           "source_id": "files_com",
           "dimension_id": "user",
           "dimension_type": "entity_family",
@@ -266822,6 +266984,33 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "ISO 27001:2022",
+              "control_id": "A.5.17"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
           "source_id": "asana",
           "dimension_id": "users",
           "dimension_type": "entity_family",
@@ -267206,6 +267395,28 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_roles",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "roles"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "ISO 27001:2022",
+              "control_id": "A.5.18"
+            }
+          ]
+        },
+        {
           "source_id": "onelogin",
           "dimension_id": "assignments",
           "dimension_type": "relationship",
@@ -267548,6 +267759,33 @@
             {
               "framework_name": "CIS Controls v8",
               "control_id": "6"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "ISO 27001:2022",
+              "control_id": "A.5.17"
             },
             {
               "framework_name": "SOC 2",
@@ -288836,6 +289074,29 @@
           ]
         },
         {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
           "source_id": "pagerduty",
           "dimension_id": "users",
           "dimension_type": "entity_family",
@@ -289420,6 +289681,29 @@
             {
               "framework_name": "SOC 2",
               "control_id": "CC6.2"
+            }
+          ]
+        },
+        {
+          "source_id": "datadog",
+          "dimension_id": "identity_users",
+          "dimension_type": "entity_family",
+          "support_level": "supported",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
             }
           ]
         },

--- a/sources/datadog/catalog.yaml
+++ b/sources/datadog/catalog.yaml
@@ -90,6 +90,13 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [identity_access, asset_inventory]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC6.1
+        - framework_name: "ISO 27001:2022"
+          control_id: A.5.15
+        - framework_name: "ISO 27001:2022"
+          control_id: A.5.17
       notes:
         - Captures Datadog user ID, handle, email, verification state, disabled state, and lifecycle timestamps.
     - id: identity_roles
@@ -100,6 +107,11 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [identity_access]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC6.1
+        - framework_name: "ISO 27001:2022"
+          control_id: A.5.18
       notes:
         - Captures Datadog role IDs, names, descriptions, and lifecycle timestamps for current-state access review.
     - id: teams
@@ -110,6 +122,11 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC6.1
+        - framework_name: "ISO 27001:2022"
+          control_id: A.5.9
       notes:
         - Teams are projected as graph anchors and linked from tagged monitors, SLOs, dashboards, and incidents.
     - id: monitors
@@ -120,6 +137,15 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [logging_monitoring, availability_resilience]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC7.2
+        - framework_name: SOC 2
+          control_id: CC7.3
+        - framework_name: "ISO 27001:2022"
+          control_id: A.8.15
+        - framework_name: "ISO 27001:2022"
+          control_id: A.8.16
       notes:
         - Monitor events include type, query, priority, state, creator, tags, and timestamps.
     - id: service_level_objectives
@@ -130,6 +156,11 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [availability_resilience, asset_inventory]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC7.2
+        - framework_name: "ISO 27001:2022"
+          control_id: A.8.16
       notes:
         - SLO events include objective type, thresholds, linked monitor IDs, creator, tags, and timestamps.
     - id: dashboards
@@ -140,6 +171,11 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [logging_monitoring, compliance_operations]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC7.2
+        - framework_name: "ISO 27001:2022"
+          control_id: A.8.15
       notes:
         - Dashboard events preserve owner, layout, read-only posture, title, description, tags, and timestamps.
     - id: incidents
@@ -150,6 +186,13 @@ coverage_contract:
       high_value: true
       evidence_types: [incident_record]
       control_domains: [security_operations, availability_resilience]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC7.4
+        - framework_name: "ISO 27001:2022"
+          control_id: A.5.24
+        - framework_name: "ISO 27001:2022"
+          control_id: A.5.25
       notes:
         - Incident events capture title, severity, state, customer-impact flag, commander, creator, team, service, and resolution timestamps.
     - id: audit_events
@@ -160,6 +203,11 @@ coverage_contract:
       high_value: true
       evidence_types: [logging_configuration]
       control_domains: [logging_monitoring, identity_access]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC7.2
+        - framework_name: "ISO 27001:2022"
+          control_id: A.8.15
       notes:
         - Audit events project actors, targets, actions, services, tags, and timestamps into the graph for access and change investigations.
     - id: pagination


### PR DESCRIPTION
## Summary
- add concrete SOC 2 and ISO control refs to Datadog runtime coverage dimensions
- keep mappings tied to the emitted Datadog evidence families: users, roles, teams, monitors, SLOs, dashboards, incidents, and audit events
- refresh the generated public detection catalog for the new Datadog coverage mappings
- confirm Datadog source fidelity is reference score 100 with no missing items

## Validation
- go test ./sources/datadog -count=1
- go run ./tools/sourcefidelity -json-out tmp/source-fidelity-batch10-rebased.json -markdown-out tmp/source-fidelity-batch10-rebased.md -max-items 100
- make detection-catalog-check
- make sourcegen-check
- make catalog-check