### PR TITLE
[codex] Promote Slack deploy coverage

### DIFF
--- a/sources/internal/slackapi/slackapi.go
+++ b/sources/internal/slackapi/slackapi.go
@@ -25,6 +25,7 @@ const (
 	FamilyChannelMember   = "channel_member"
 	FamilyUserGroupMember = "user_group_member"
 	FamilyAuditLog        = "audit_log"
+	auditLogCursorMode    = "rolling_window"
 
 	DefaultWebAPIBaseURL = "https://slack.com/api"
 	DefaultAuditBaseURL  = "https://api.slack.com/audit/v1"
@@ -207,13 +208,17 @@ func readAuditLogs(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.
 	}
 	query := url.Values{}
 	query.Set("limit", strconv.Itoa(options.PageSize))
-	for _, key := range []string{"oldest", "latest", "action", "actor", "entity"} {
+	cursorState := parseAuditLogCursor(cursor)
+	if err := addAuditLogTimeRange(query, cfg, cursorState); err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	for _, key := range []string{"action", "actor", "entity"} {
 		if value := sourcecdk.ConfigValue(cfg, key); value != "" {
 			query.Set(key, value)
 		}
 	}
-	if cursorToken := sourcecdk.CursorToken(cursor); cursorToken != "" {
-		query.Set("cursor", cursorToken)
+	if cursorState.token != "" {
+		query.Set("cursor", cursorState.token)
 	}
 	var response map[string]any
 	if err := getJSON(ctx, cfg, options, DefaultAuditBaseURL, "audit_log_base_url", "/logs", query, &response); err != nil {
@@ -243,7 +248,90 @@ func readAuditLogs(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.
 		events = append(events, event(tenantID, FamilyAuditLog, entryID, entry, attrs, unixTime(entry["date_create"])))
 	}
 	next := firstNonEmpty(nestedString(response, "response_metadata.next_cursor"), nestedString(response, "response_metadata.cursor"))
+	next = auditLogNextCursor(next, query, cfg)
 	return pull(events, next), nil
+}
+
+type auditLogCursorState struct {
+	token  string
+	oldest string
+	latest string
+}
+
+func parseAuditLogCursor(cursor *cerebrov1.SourceCursor) auditLogCursorState {
+	opaque := ""
+	if cursor != nil {
+		opaque = strings.TrimSpace(cursor.GetOpaque())
+	}
+	if envelope, ok := sourcecdk.DecodeCursorEnvelope(opaque); ok && envelope.Source == SourceID && envelope.Family == FamilyAuditLog && envelope.Mode == auditLogCursorMode {
+		return auditLogCursorState{
+			token:  envelope.Token,
+			oldest: strings.TrimSpace(envelope.Extra["oldest"]),
+			latest: strings.TrimSpace(envelope.Extra["latest"]),
+		}
+	}
+	return auditLogCursorState{token: sourcecdk.CursorToken(cursor)}
+}
+
+func addAuditLogTimeRange(query url.Values, cfg sourcecdk.Config, cursorState auditLogCursorState) error {
+	oldest := sourcecdk.ConfigValue(cfg, "oldest")
+	latest := sourcecdk.ConfigValue(cfg, "latest")
+	lookbackSeconds := sourcecdk.ConfigValue(cfg, "lookback_seconds")
+	if lookbackSeconds != "" {
+		if oldest != "" || latest != "" {
+			return fmt.Errorf("%s audit_log lookback_seconds cannot be combined with oldest or latest", SourceID)
+		}
+		if cursorState.oldest != "" && cursorState.latest != "" {
+			query.Set("oldest", cursorState.oldest)
+			query.Set("latest", cursorState.latest)
+			return nil
+		}
+		if cursorState.token != "" {
+			return nil
+		}
+		lookback, err := strconv.ParseInt(lookbackSeconds, 10, 64)
+		if err != nil || lookback < 1 {
+			return fmt.Errorf("%s audit_log lookback_seconds must be a positive integer", SourceID)
+		}
+		now := time.Now().UTC()
+		query.Set("oldest", strconv.FormatInt(now.Unix()-lookback, 10))
+		query.Set("latest", strconv.FormatInt(now.Unix(), 10))
+		return nil
+	}
+	if oldest != "" {
+		query.Set("oldest", oldest)
+	}
+	if latest != "" {
+		query.Set("latest", latest)
+	}
+	return nil
+}
+
+func auditLogNextCursor(next string, query url.Values, cfg sourcecdk.Config) string {
+	next = strings.TrimSpace(next)
+	if next == "" || sourcecdk.ConfigValue(cfg, "lookback_seconds") == "" {
+		return next
+	}
+	oldest := strings.TrimSpace(query.Get("oldest"))
+	latest := strings.TrimSpace(query.Get("latest"))
+	if oldest == "" || latest == "" {
+		return next
+	}
+	opaque, err := sourcecdk.EncodeCursorEnvelope(sourcecdk.CursorEnvelope{
+		Version: 1,
+		Source:  SourceID,
+		Family:  FamilyAuditLog,
+		Mode:    auditLogCursorMode,
+		Token:   next,
+		Extra: map[string]string{
+			"latest": latest,
+			"oldest": oldest,
+		},
+	})
+	if err != nil {
+		return next
+	}
+	return opaque
 }
 
 func getJSON(ctx context.Context, cfg sourcecdk.Config, options Options, defaultBaseURL string, configKey string, path string, query url.Values, target any) error {

--- a/sources/slack/catalog.yaml
+++ b/sources/slack/catalog.yaml
@@ -172,7 +172,7 @@ coverage_contract:
       evidence_types: [logging_configuration]
       control_domains: [logging_monitoring, identity_access]
       notes:
-        - Enterprise Grid audit logs use the Slack Audit Logs API host and preserve actor, entity, context, and cursor state.
+        - Enterprise Grid audit logs use a rolling lookback window on the Slack Audit Logs API host and preserve actor, entity, context, and cursor state.
     - id: pagination
       type: incremental_sync
       title: Slack pagination

--- a/sources/slack/deploy.yaml
+++ b/sources/slack/deploy.yaml
@@ -33,3 +33,38 @@ runtimes:
       expected_cadence_seconds: "86400"
       stale_after_seconds: "86400"
       token: env:SLACK_TOKEN
+  - localId: access-logs
+    config:
+      family: access_log
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "200"
+      token: env:SLACK_TOKEN
+  - localId: channel-members
+    config:
+      family: channel_member
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      channel_id: config:SLACK_CHANNEL_ID
+      per_page: "200"
+      token: env:SLACK_TOKEN
+  - localId: user-group-members
+    config:
+      family: user_group_member
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "200"
+      token: env:SLACK_TOKEN
+      usergroup_id: config:SLACK_USERGROUP_ID
+  - localId: audit-logs
+    config:
+      family: audit_log
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      lookback_seconds: "90000"
+      stale_after_seconds: "86400"
+      per_page: "200"
+      token: env:SLACK_TOKEN

--- a/sources/slack/source_test.go
+++ b/sources/slack/source_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -496,6 +497,142 @@ func TestReadSlackAuditLogsUsesAuditBaseURL(t *testing.T) {
 		if got := event.Attributes[key]; got != want {
 			t.Fatalf("attribute %q = %q, want %q", key, got, want)
 		}
+	}
+}
+
+func TestReadSlackAuditLogsUsesRollingLookback(t *testing.T) {
+	requests := 0
+	var firstOldest string
+	var firstLatest string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/logs" {
+			t.Fatalf("request path = %q, want /logs", got)
+		}
+		oldestValue := r.URL.Query().Get("oldest")
+		latestValue := r.URL.Query().Get("latest")
+		oldest, err := strconv.ParseInt(oldestValue, 10, 64)
+		if err != nil {
+			t.Fatalf("oldest query = %q, want unix seconds", oldestValue)
+		}
+		latest, err := strconv.ParseInt(latestValue, 10, 64)
+		if err != nil {
+			t.Fatalf("latest query = %q, want unix seconds", latestValue)
+		}
+		if got := latest - oldest; got != 90000 {
+			t.Fatalf("lookback window = %d, want 90000", got)
+		}
+		responseMetadata := map[string]any{}
+		entries := []map[string]any{{
+			"id":          "Ev1",
+			"date_create": 1780272000,
+			"action":      "user_login",
+		}}
+		switch requests {
+		case 0:
+			firstOldest = oldestValue
+			firstLatest = latestValue
+			responseMetadata["next_cursor"] = "cursor-2"
+		case 1:
+			entries[0]["id"] = "Ev2"
+			entries[0]["date_create"] = 1780275600
+			if got := r.URL.Query().Get("cursor"); got != "cursor-2" {
+				t.Fatalf("cursor = %q, want cursor-2", got)
+			}
+			if oldestValue != firstOldest || latestValue != firstLatest {
+				t.Fatalf("window = %s..%s, want first page window %s..%s", oldestValue, latestValue, firstOldest, firstLatest)
+			}
+		default:
+			t.Fatalf("unexpected request %d", requests+1)
+		}
+		requests++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"entries":           entries,
+			"response_metadata": responseMetadata,
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	config := sourcecdk.NewConfig(map[string]string{
+		"audit_log_base_url": server.URL,
+		"family":             familyAuditLog,
+		"lookback_seconds":   "90000",
+		"tenant_id":          "writer",
+		"token":              "slack-token",
+	})
+	first, err := source.Read(context.Background(), config, nil)
+	if err != nil {
+		t.Fatalf("first Read() error = %v", err)
+	}
+	if first.NextCursor == nil {
+		t.Fatal("first NextCursor = nil, want rolling-window cursor")
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("first Events = %d, want 1", len(first.Events))
+	}
+	if first.Checkpoint == nil {
+		t.Fatal("first Checkpoint = nil, want checkpoint with rolling-window cursor")
+	}
+	if first.Checkpoint.GetCursorOpaque() != first.NextCursor.GetOpaque() {
+		t.Fatalf("first checkpoint cursor = %q, want next cursor %q", first.Checkpoint.GetCursorOpaque(), first.NextCursor.GetOpaque())
+	}
+	envelope, ok := sourcecdk.DecodeCursorEnvelope(first.NextCursor.GetOpaque())
+	if !ok {
+		t.Fatalf("first NextCursor = %q, want cursor envelope", first.NextCursor.GetOpaque())
+	}
+	if envelope.Source != sourceID || envelope.Family != familyAuditLog || envelope.Token != "cursor-2" {
+		t.Fatalf("first NextCursor envelope = %#v, want Slack audit cursor-2", envelope)
+	}
+	second, err := source.Read(context.Background(), config, first.NextCursor)
+	if err != nil {
+		t.Fatalf("second Read() error = %v", err)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestReadSlackAuditLogsPreservesLegacyPlainCursor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/logs" {
+			t.Fatalf("request path = %q, want /logs", got)
+		}
+		if got := r.URL.Query().Get("cursor"); got != "legacy-cursor" {
+			t.Fatalf("cursor = %q, want legacy-cursor", got)
+		}
+		for _, key := range []string{"oldest", "latest"} {
+			if got := r.URL.Query().Get(key); got != "" {
+				t.Fatalf("%s = %q, want empty for legacy cursor continuation", key, got)
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"entries":           []map[string]any{},
+			"response_metadata": map[string]any{},
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	config := sourcecdk.NewConfig(map[string]string{
+		"audit_log_base_url": server.URL,
+		"family":             familyAuditLog,
+		"lookback_seconds":   "90000",
+		"tenant_id":          "writer",
+		"token":              "slack-token",
+	})
+	if _, err := source.Read(context.Background(), config, &cerebrov1.SourceCursor{Opaque: "legacy-cursor"}); err != nil {
+		t.Fatalf("Read() error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add Slack deploy runtimes for access logs, channel members, user-group members, and audit logs so every runtime family has deploy coverage.
- Use config-backed IDs for scoped membership runtimes while keeping `SLACK_TOKEN` as the only secret key.
- Run Enterprise audit logs with a 25-hour rolling lookback, preserve that window across paginated cursor reads and checkpoints, and continue legacy plain cursors without recomputing a mismatched time range.
- Confirm Slack source fidelity remains reference level with score 100 and no missing items.

## Validation
- `go test ./sources/slack -count=1`
- `make lint-shard LINT_PACKAGES="./sources/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=2`
- `go run ./tools/sourcefidelity -json-out tmp/source-fidelity-batch11-legacy-cursor.json -markdown-out tmp/source-fidelity-batch11-legacy-cursor.md -max-items 100`
- `make sourcegen-check`
- `make catalog-check`