### PR TITLE
[codex] Add source freshness short-circuiting

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -30,7 +30,7 @@ Legacy sources above the 300 LOC budget are grandfathered with exact no-growth c
 | `github` | 2024 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 814 | Extract API client setup and paginated directory readers. |
 | `grc` | 1195 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
-| `okta` | 2256 | Extract client, pagination, and identity/group/application readers into smaller units. |
+| `okta` | 2255 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 763 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2112 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1002 | Split feed/client access from vulnerability record normalization. |

--- a/internal/sourcecdk/family.go
+++ b/internal/sourcecdk/family.go
@@ -18,6 +18,7 @@ type Family[S any] struct {
 	Discover             func(context.Context, S) ([]URN, error)
 	Probe                func(context.Context, S, *cerebrov1.SourceCheckpoint) (ChangeProbe, error)
 	ProbeOptions         FamilyFreshnessReadOptions
+	ReadWithChange       func(context.Context, S, *cerebrov1.SourceCursor, *cerebrov1.SourceCheckpoint, ChangeProbe) (Pull, error)
 	Read                 func(context.Context, S, *cerebrov1.SourceCursor) (Pull, error)
 	ReadWithCheckpoint   func(context.Context, S, *cerebrov1.SourceCursor, *cerebrov1.SourceCheckpoint) (Pull, error)
 }
@@ -28,6 +29,8 @@ type ChangeProbe struct {
 	Unchanged          bool
 	Checkpoint         *cerebrov1.SourceCheckpoint
 	ShortCircuitReason PullShortCircuitReason
+	ChangedResourceIDs []string
+	ChangedURNs        []URN
 }
 
 // FamilyEngine dispatches source operations to table-driven families.
@@ -129,8 +132,12 @@ func (e *FamilyEngine[S]) ReadWithCheckpoint(ctx context.Context, cfg Config, cu
 		return Pull{ShortCircuitReason: PullShortCircuitReasonScopeExcluded}, nil
 	}
 	readCheckpoint := checkpoint
-	if family.Probe != nil {
-		probe, err := family.Probe(ctx, settings, checkpoint)
+	activeCursor := strings.TrimSpace(CursorToken(cursor)) != ""
+	if family.Probe != nil && e.sourceID != "" {
+		readCheckpoint = FamilyFreshnessCheckpointFromCursor(e.sourceID, family.Name, cursor, readCheckpoint)
+	}
+	if family.Probe != nil && !activeCursor {
+		probe, err := family.Probe(ctx, settings, readCheckpoint)
 		if err != nil {
 			if normalizeFamilyFreshnessProbeErrorMode(family.ProbeOptions.ProbeErrorMode) == FamilyFreshnessProbeErrorFailOpen {
 				probe = ChangeProbe{}
@@ -150,6 +157,13 @@ func (e *FamilyEngine[S]) ReadWithCheckpoint(ctx context.Context, cfg Config, cu
 		if probe.Checkpoint != nil {
 			readCheckpoint = probe.Checkpoint
 		}
+		if family.ReadWithChange != nil {
+			pull, err := family.ReadWithChange(ctx, settings, cursor, readCheckpoint, probe)
+			if err != nil {
+				return Pull{}, err
+			}
+			return applyResourceScopePolicy(pull, policy), nil
+		}
 	}
 	if family.ReadWithCheckpoint != nil {
 		pull, err := family.ReadWithCheckpoint(ctx, settings, cursor, readCheckpoint)
@@ -166,14 +180,31 @@ func (e *FamilyEngine[S]) ReadWithCheckpoint(ctx context.Context, cfg Config, cu
 		return Pull{}, err
 	}
 	if family.IncrementalWatermark && e.sourceID != "" {
-		readCheckpoint := IncrementalCheckpointForCursor(e.sourceID, family.Name, cursor, readCheckpoint)
+		readCheckpoint = IncrementalCheckpointForCursor(e.sourceID, family.Name, cursor, readCheckpoint)
 		next := ""
 		if pull.NextCursor != nil {
 			next = CursorToken(pull.NextCursor)
 		}
 		pull = IncrementalPullFromEvents(e.sourceID, family.Name, pull.Events, next, readCheckpoint)
+		if family.Probe != nil {
+			pull = attachFamilyFreshnessToPull(e.sourceID, family.Name, readCheckpoint, pull)
+		}
 	}
 	return applyResourceScopePolicy(pull, policy), nil
+}
+
+func attachFamilyFreshnessToPull(source string, family string, checkpoint *cerebrov1.SourceCheckpoint, pull Pull) Pull {
+	if checkpoint == nil {
+		return pull
+	}
+	pull.Checkpoint = FamilyFreshnessCheckpointFromCheckpoint(source, family, checkpoint, pull.Checkpoint)
+	if pull.NextCursor != nil {
+		nextCheckpoint := FamilyFreshnessCheckpointFromCheckpoint(source, family, checkpoint, &cerebrov1.SourceCheckpoint{CursorOpaque: pull.NextCursor.GetOpaque()})
+		if nextCheckpoint != nil {
+			pull.NextCursor.Opaque = nextCheckpoint.GetCursorOpaque()
+		}
+	}
+	return pull
 }
 
 func (e *FamilyEngine[S]) resolve(cfg Config) (Family[S], S, resourcescope.Policy, error) {

--- a/internal/sourcecdk/family_scope_test.go
+++ b/internal/sourcecdk/family_scope_test.go
@@ -131,6 +131,7 @@ func TestFamilyEngineMarksFullyFilteredEvents(t *testing.T) {
 
 func TestFamilyEngineProbeShortCircuitsBeforeRead(t *testing.T) {
 	readCalled := false
+	readWithChangeCalled := false
 	probeCheckpoint := &cerebrov1.SourceCheckpoint{
 		Watermark: timestamppb.New(time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)),
 	}
@@ -146,6 +147,10 @@ func TestFamilyEngineProbeShortCircuitsBeforeRead(t *testing.T) {
 			readCalled = true
 			return Pull{}, nil
 		},
+		ReadWithChange: func(context.Context, string, *cerebrov1.SourceCursor, *cerebrov1.SourceCheckpoint, ChangeProbe) (Pull, error) {
+			readWithChangeCalled = true
+			return Pull{}, nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewFamilyEngine() error = %v", err)
@@ -158,11 +163,155 @@ func TestFamilyEngineProbeShortCircuitsBeforeRead(t *testing.T) {
 	if readCalled {
 		t.Fatal("family Read was called after unchanged probe")
 	}
+	if readWithChangeCalled {
+		t.Fatal("family ReadWithChange was called after unchanged probe")
+	}
 	if pull.Checkpoint != probeCheckpoint {
 		t.Fatal("probe checkpoint was not returned")
 	}
 	if pull.ShortCircuitReason != PullShortCircuitReasonNotModified {
 		t.Fatalf("ShortCircuitReason = %q, want not_modified", pull.ShortCircuitReason)
+	}
+}
+
+func TestFamilyEnginePassesChangedProbeToReadWithChange(t *testing.T) {
+	probeCheckpoint := &cerebrov1.SourceCheckpoint{
+		Watermark: timestamppb.New(time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)),
+	}
+	cursor := &cerebrov1.SourceCursor{}
+	var seenCheckpoint *cerebrov1.SourceCheckpoint
+	var seenProbe ChangeProbe
+	readCalled := false
+	engine, err := NewFamilyEngine(func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name: "repository",
+		Probe: func(context.Context, string, *cerebrov1.SourceCheckpoint) (ChangeProbe, error) {
+			return ChangeProbe{
+				Checkpoint:         probeCheckpoint,
+				ChangedResourceIDs: []string{"repo-1", "repo-2"},
+				ChangedURNs:        []URN{"urn:cerebro:writer:repo:writer/repo-1"},
+			}, nil
+		},
+		Read: func(context.Context, string, *cerebrov1.SourceCursor) (Pull, error) {
+			readCalled = true
+			return Pull{}, nil
+		},
+		ReadWithChange: func(_ context.Context, _ string, gotCursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, probe ChangeProbe) (Pull, error) {
+			if gotCursor != cursor {
+				t.Fatalf("cursor = %p, want %p", gotCursor, cursor)
+			}
+			seenCheckpoint = checkpoint
+			seenProbe = probe
+			return Pull{Checkpoint: checkpoint}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngine() error = %v", err)
+	}
+
+	pull, err := engine.ReadWithCheckpoint(context.Background(), NewConfig(map[string]string{"family": "repository"}), cursor, &cerebrov1.SourceCheckpoint{})
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if readCalled {
+		t.Fatal("fallback Read was called")
+	}
+	if seenCheckpoint != probeCheckpoint {
+		t.Fatalf("checkpoint = %p, want probe checkpoint %p", seenCheckpoint, probeCheckpoint)
+	}
+	if len(seenProbe.ChangedResourceIDs) != 2 || seenProbe.ChangedResourceIDs[0] != "repo-1" || seenProbe.ChangedResourceIDs[1] != "repo-2" {
+		t.Fatalf("ChangedResourceIDs = %#v, want repo-1/repo-2", seenProbe.ChangedResourceIDs)
+	}
+	if len(seenProbe.ChangedURNs) != 1 || seenProbe.ChangedURNs[0] != "urn:cerebro:writer:repo:writer/repo-1" {
+		t.Fatalf("ChangedURNs = %#v, want repo urn", seenProbe.ChangedURNs)
+	}
+	if pull.Checkpoint != probeCheckpoint {
+		t.Fatal("pull did not preserve probe checkpoint")
+	}
+}
+
+func TestFamilyEngineSkipsProbeOnContinuationAndCarriesFreshness(t *testing.T) {
+	watermark := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	checkpoint := IncrementalWatermarkCheckpoint("okta", "user", []*primitives.Event{
+		{Id: "known", OccurredAt: timestamppb.New(watermark)},
+	}, IncrementalWatermarkState{})
+	probeTime := watermark.Add(time.Hour)
+	probeCalls := 0
+	readCalls := 0
+	engine, err := NewFamilyEngineWithSourceID("okta", func(cfg Config) (string, error) {
+		family, _ := cfg.Lookup("family")
+		return family, nil
+	}, func(settings string) string { return settings }, Family[string]{
+		Name:                 "user",
+		IncrementalWatermark: true,
+		Probe: func(context.Context, string, *cerebrov1.SourceCheckpoint) (ChangeProbe, error) {
+			probeCalls++
+			return FamilyFreshnessChangeProbe("okta", "user", checkpoint, FamilyFreshnessProbe{
+				Kind:       "latest_user",
+				ResourceID: "00u1",
+				ObservedAt: probeTime,
+				UpdatedAt:  probeTime,
+				Confidence: FamilyFreshnessConfidenceHeuristic,
+			}), nil
+		},
+		Read: func(_ context.Context, _ string, cursor *cerebrov1.SourceCursor) (Pull, error) {
+			readCalls++
+			if readCalls == 1 {
+				if CursorToken(cursor) != "" {
+					t.Fatalf("first read cursor token = %q, want empty", CursorToken(cursor))
+				}
+				return Pull{
+					Events: []*primitives.Event{
+						{Id: "new-1", OccurredAt: timestamppb.New(watermark.Add(time.Minute))},
+					},
+					NextCursor: &cerebrov1.SourceCursor{Opaque: "page-2"},
+				}, nil
+			}
+			if got := CursorToken(cursor); got != "page-2" {
+				t.Fatalf("continuation cursor token = %q, want page-2", got)
+			}
+			return Pull{
+				Events: []*primitives.Event{
+					{Id: "new-2", OccurredAt: timestamppb.New(watermark.Add(2 * time.Minute))},
+				},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFamilyEngineWithSourceID() error = %v", err)
+	}
+
+	first, err := engine.ReadWithCheckpoint(context.Background(), NewConfig(map[string]string{"family": "user"}), nil, checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	if probeCalls != 1 {
+		t.Fatalf("probe calls after first read = %d, want 1", probeCalls)
+	}
+	if first.NextCursor == nil || CursorToken(first.NextCursor) != "page-2" {
+		t.Fatalf("first.NextCursor = %#v, want page-2", first.NextCursor)
+	}
+	if _, ok := FamilyFreshnessProbeFromCheckpoint("okta", "user", &cerebrov1.SourceCheckpoint{CursorOpaque: first.NextCursor.GetOpaque()}); !ok {
+		t.Fatalf("first next cursor %q missing freshness probe", first.NextCursor.GetOpaque())
+	}
+	if _, ok := FamilyFreshnessProbeFromCheckpoint("okta", "user", first.Checkpoint); !ok {
+		t.Fatalf("first checkpoint %q missing freshness probe", first.Checkpoint.GetCursorOpaque())
+	}
+
+	second, err := engine.ReadWithCheckpoint(context.Background(), NewConfig(map[string]string{"family": "user"}), first.NextCursor, first.Checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
+	}
+	if probeCalls != 1 {
+		t.Fatalf("probe calls after continuation = %d, want still 1", probeCalls)
+	}
+	if len(second.Events) != 1 || second.Events[0].GetId() != "new-2" {
+		t.Fatalf("second events = %#v, want new-2", second.Events)
+	}
+	if _, ok := FamilyFreshnessProbeFromCheckpoint("okta", "user", second.Checkpoint); !ok {
+		t.Fatalf("second checkpoint %q missing freshness probe", second.Checkpoint.GetCursorOpaque())
 	}
 }
 

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -66,6 +66,37 @@ type Pull struct {
 	ReconciliationReason PullReconciliationReason
 }
 
+// PullFromRecordsWithCursor builds a one-page Pull from provider records and a
+// provider cursor token, using the final event as the fallback resumable cursor.
+func PullFromRecordsWithCursor[T any](records []T, next string, build func(T) (*primitives.Event, error), cursorFallback func(T) string) (Pull, error) {
+	if len(records) == 0 {
+		return Pull{}, nil
+	}
+	events := make([]*primitives.Event, 0, len(records))
+	for _, record := range records {
+		event, err := build(record)
+		if err != nil {
+			return Pull{}, err
+		}
+		events = append(events, event)
+	}
+	fallback := events[len(events)-1].GetId()
+	if cursorFallback != nil {
+		fallback = cursorFallback(records[len(records)-1])
+	}
+	pull := Pull{
+		Events: events,
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    events[len(events)-1].OccurredAt,
+			CursorOpaque: ResolveCursorOpaque(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
+		},
+	}
+	if next != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
+	}
+	return pull, nil
+}
+
 // PullShortCircuitReason describes source work that intentionally produced no
 // new append-log events.
 type PullShortCircuitReason string

--- a/sources/internal/oktafreshness/freshness.go
+++ b/sources/internal/oktafreshness/freshness.go
@@ -1,0 +1,91 @@
+package oktafreshness
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+const (
+	sourceID                 = "okta"
+	userFamily               = "user"
+	userFreshnessKind        = "okta_user_latest_record"
+	userFreshnessResourceNil = "empty"
+	userFreshnessMaxSkips    = 24
+	userFreshnessMaxAge      = 24 * time.Hour
+)
+
+type Scope struct {
+	Domain string
+	Filter string
+	Q      string
+	Search string
+}
+
+func NewScope(domain string, filter string, q string, search string) Scope {
+	return Scope{Domain: domain, Filter: filter, Q: q, Search: search}
+}
+
+type User struct {
+	ID        string
+	Status    string
+	UpdatedAt time.Time
+	URN       sourcecdk.URN
+}
+
+type LatestUserFunc func(context.Context, string, string, int) (User, bool, error)
+
+func UserReadOptions() sourcecdk.FamilyFreshnessReadOptions {
+	return sourcecdk.FamilyFreshnessReadOptions{
+		Confidence:     sourcecdk.FamilyFreshnessConfidenceHeuristic,
+		MaxSkipCount:   userFreshnessMaxSkips,
+		MaxSkipAge:     userFreshnessMaxAge,
+		ProbeErrorMode: sourcecdk.FamilyFreshnessProbeErrorFailOpen,
+	}
+}
+
+func ProbeLatestUser(ctx context.Context, checkpoint *cerebrov1.SourceCheckpoint, scope Scope, list LatestUserFunc) (sourcecdk.ChangeProbe, error) {
+	user, ok, err := list(ctx, "lastUpdated", "desc", 1)
+	if err != nil {
+		return sourcecdk.ChangeProbe{}, err
+	}
+	change := sourcecdk.FamilyFreshnessChangeProbe(sourceID, userFamily, checkpoint, latestUserProbe(scope, user, ok, time.Now().UTC()))
+	if ok {
+		if id := strings.TrimSpace(user.ID); id != "" {
+			change.ChangedResourceIDs = []string{id}
+		}
+		if strings.TrimSpace(user.URN.String()) != "" {
+			change.ChangedURNs = []sourcecdk.URN{user.URN}
+		}
+	}
+	return change, nil
+}
+
+func latestUserProbe(scope Scope, user User, ok bool, observedAt time.Time) sourcecdk.FamilyFreshnessProbe {
+	resourceID := userFreshnessResourceNil
+	updatedAt := time.Time{}
+	hashParts := scope.hashParts(userFreshnessKind, resourceID, "empty")
+	if ok {
+		if id := strings.TrimSpace(user.ID); id != "" {
+			resourceID = id
+		}
+		updatedAt = user.UpdatedAt
+		hashParts = scope.hashParts(userFreshnessKind, resourceID, updatedAt.Format(time.RFC3339Nano), user.Status)
+	}
+	return sourcecdk.FamilyFreshnessProbe{
+		Kind:       userFreshnessKind,
+		ResourceID: resourceID,
+		ObservedAt: observedAt,
+		UpdatedAt:  updatedAt,
+		Hash:       sourcecdk.FamilyFreshnessHash(hashParts...),
+		Confidence: sourcecdk.FamilyFreshnessConfidenceHeuristic,
+	}
+}
+
+func (s Scope) hashParts(parts ...string) []string {
+	scoped := []string{strings.TrimSpace(s.Domain), strings.TrimSpace(s.Filter), strings.TrimSpace(s.Q), strings.TrimSpace(s.Search)}
+	return append(scoped, parts...)
+}

--- a/sources/okta/catalog.yaml
+++ b/sources/okta/catalog.yaml
@@ -96,6 +96,16 @@ emitted_kinds:
   - okta.threat_insight
   - okta.trusted_origin
   - okta.user
+families:
+  - id: user
+    incremental: watermark
+    freshness_probe:
+      supported: true
+      canary_kind: okta_user_latest_record
+      confidence: heuristic
+      reconciliation_interval: 24h
+      max_skip_duration: 24h
+      max_consecutive_skips: 24
 runtime_families:
   - audit
   - admin_role

--- a/sources/okta/helpers.go
+++ b/sources/okta/helpers.go
@@ -21,17 +21,13 @@ import (
 	"github.com/writer/cerebro/internal/sourcehttp"
 	"github.com/writer/cerebro/sources/internal/oktaasset"
 	"github.com/writer/cerebro/sources/internal/oktaevent"
+	"github.com/writer/cerebro/sources/internal/oktafreshness"
 	"github.com/writer/cerebro/sources/internal/textutil"
 )
 
 const (
 	oktaHTTPTimeout  = 30 * time.Second
 	maxOktaBodyBytes = 4 << 20
-
-	oktaUserFreshnessKind         = "okta_user_latest_record"
-	oktaUserFreshnessResourceNone = "empty"
-	oktaUserFreshnessMaxSkipCount = 24
-	oktaUserFreshnessMaxSkipAge   = 24 * time.Hour
 )
 
 var defaultMFAFactorRetryBackoffs = []time.Duration{
@@ -293,78 +289,29 @@ func oktaFamily[T any](options oktaFamilyOptions[T]) sourcecdk.Family[settings] 
 			build := func(record T) (*primitives.Event, error) {
 				return options.Event(settings, record)
 			}
-			return oktaPullFromRecordsWithCursor(records, next, build, options.CursorFallback)
+			return sourcecdk.PullFromRecordsWithCursor(records, next, build, options.CursorFallback)
 		},
 	}
 }
 
-func oktaUserFreshnessReadOptions() sourcecdk.FamilyFreshnessReadOptions {
-	return sourcecdk.FamilyFreshnessReadOptions{
-		Confidence:     sourcecdk.FamilyFreshnessConfidenceHeuristic,
-		MaxSkipCount:   oktaUserFreshnessMaxSkipCount,
-		MaxSkipAge:     oktaUserFreshnessMaxSkipAge,
-		ProbeErrorMode: sourcecdk.FamilyFreshnessProbeErrorFailOpen,
-	}
-}
-
 func (s *Source) probeLatestUser(ctx context.Context, settings settings, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.ChangeProbe, error) {
-	probeSettings := settings
-	probeSettings.sortBy = "lastUpdated"
-	probeSettings.sortOrder = "desc"
-	records, _, err := s.listUsers(ctx, probeSettings, "", 1)
+	scope := oktafreshness.NewScope(settings.domain, settings.filter, settings.q, settings.search)
+	change, err := oktafreshness.ProbeLatestUser(ctx, checkpoint, scope, func(ctx context.Context, sortBy string, sortOrder string, limit int) (oktafreshness.User, bool, error) {
+		probeSettings := settings
+		probeSettings.sortBy = sortBy
+		probeSettings.sortOrder = sortOrder
+		records, _, err := s.listUsers(ctx, probeSettings, "", limit)
+		if err != nil || len(records) == 0 {
+			return oktafreshness.User{}, false, err
+		}
+		record := records[0]
+		urn, _ := userURN(settings.domain, record.ID)
+		return oktafreshness.User{ID: record.ID, Status: record.Status, UpdatedAt: userOccurredAt(record), URN: urn}, true, nil
+	})
 	if err != nil {
 		return sourcecdk.ChangeProbe{}, wrapLookupError(oktaLabel("okta user freshness probe", settings), err)
 	}
-	probe := oktaLatestUserProbe(settings, records, time.Now().UTC())
-	change := sourcecdk.FamilyFreshnessChangeProbe("okta", familyUser, checkpoint, probe)
-	if len(records) > 0 {
-		if id := strings.TrimSpace(records[0].ID); id != "" {
-			change.ChangedResourceIDs = []string{id}
-			if urn, err := userURN(settings.domain, id); err == nil {
-				change.ChangedURNs = []sourcecdk.URN{urn}
-			}
-		}
-	}
 	return change, nil
-}
-
-func oktaLatestUserProbe(settings settings, records []userRecord, observedAt time.Time) sourcecdk.FamilyFreshnessProbe {
-	resourceID := oktaUserFreshnessResourceNone
-	updatedAt := time.Time{}
-	hashParts := oktaFreshnessScopeParts(settings, oktaUserFreshnessKind, resourceID, "empty")
-	if len(records) > 0 {
-		record := records[0]
-		if id := strings.TrimSpace(record.ID); id != "" {
-			resourceID = id
-		}
-		updatedAt = userOccurredAt(record)
-		hashParts = oktaFreshnessScopeParts(
-			settings,
-			oktaUserFreshnessKind,
-			resourceID,
-			updatedAt.Format(time.RFC3339Nano),
-			strings.TrimSpace(record.Status),
-		)
-	}
-	return sourcecdk.FamilyFreshnessProbe{
-		Kind:       oktaUserFreshnessKind,
-		ResourceID: resourceID,
-		ObservedAt: observedAt,
-		UpdatedAt:  updatedAt,
-		Hash:       sourcecdk.FamilyFreshnessHash(hashParts...),
-		Confidence: sourcecdk.FamilyFreshnessConfidenceHeuristic,
-	}
-}
-
-func oktaFreshnessScopeParts(settings settings, parts ...string) []string {
-	scoped := []string{
-		strings.TrimSpace(settings.domain),
-		strings.TrimSpace(settings.filter),
-		strings.TrimSpace(settings.q),
-		strings.TrimSpace(settings.search),
-	}
-	scoped = append(scoped, parts...)
-	return scoped
 }
 
 func oktaAssetSettings(settings settings) oktaasset.Settings {
@@ -397,35 +344,6 @@ func oktaURNsFor[T any](settings settings, records []T, render func(settings, T)
 		urns = append(urns, urn)
 	}
 	return urns, nil
-}
-
-func oktaPullFromRecordsWithCursor[T any](records []T, next string, build func(T) (*primitives.Event, error), cursorFallback func(T) string) (sourcecdk.Pull, error) {
-	if len(records) == 0 {
-		return sourcecdk.Pull{}, nil
-	}
-	events := make([]*primitives.Event, 0, len(records))
-	for _, record := range records {
-		event, err := build(record)
-		if err != nil {
-			return sourcecdk.Pull{}, err
-		}
-		events = append(events, event)
-	}
-	fallback := events[len(events)-1].GetId()
-	if cursorFallback != nil {
-		fallback = cursorFallback(records[len(records)-1])
-	}
-	pull := sourcecdk.Pull{
-		Events: events,
-		Checkpoint: &cerebrov1.SourceCheckpoint{
-			Watermark:    events[len(events)-1].OccurredAt,
-			CursorOpaque: sourcecdk.ResolveCursorOpaque(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
-		},
-	}
-	if next != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
-	}
-	return pull, nil
 }
 
 func listJSONRecords[T any](ctx context.Context, source *Source, settings settings, requestPath string, query url.Values, label string, setRaw func(*T, json.RawMessage)) ([]T, string, error) {

--- a/sources/okta/helpers.go
+++ b/sources/okta/helpers.go
@@ -27,6 +27,11 @@ import (
 const (
 	oktaHTTPTimeout  = 30 * time.Second
 	maxOktaBodyBytes = 4 << 20
+
+	oktaUserFreshnessKind         = "okta_user_latest_record"
+	oktaUserFreshnessResourceNone = "empty"
+	oktaUserFreshnessMaxSkipCount = 24
+	oktaUserFreshnessMaxSkipAge   = 24 * time.Hour
 )
 
 var defaultMFAFactorRetryBackoffs = []time.Duration{
@@ -248,6 +253,8 @@ type oktaFamilyOptions[T any] struct {
 	Label          string
 	List           oktaListFunc[T]
 	Enrich         func(context.Context, settings, []T) ([]T, error)
+	Probe          func(context.Context, settings, *cerebrov1.SourceCheckpoint) (sourcecdk.ChangeProbe, error)
+	ProbeOptions   sourcecdk.FamilyFreshnessReadOptions
 	Event          func(settings, T) (*primitives.Event, error)
 	URN            func(settings, T) (string, error)
 	Discover       func(context.Context, settings) ([]sourcecdk.URN, error)
@@ -257,6 +264,8 @@ type oktaFamilyOptions[T any] struct {
 func oktaFamily[T any](options oktaFamilyOptions[T]) sourcecdk.Family[settings] {
 	return sourcecdk.Family[settings]{
 		Name: options.Name, IncrementalWatermark: true,
+		Probe:        options.Probe,
+		ProbeOptions: options.ProbeOptions,
 		Check: func(ctx context.Context, settings settings) error {
 			return oktaCheck(ctx, settings, options.List, options.Label)
 		},
@@ -287,6 +296,75 @@ func oktaFamily[T any](options oktaFamilyOptions[T]) sourcecdk.Family[settings] 
 			return oktaPullFromRecordsWithCursor(records, next, build, options.CursorFallback)
 		},
 	}
+}
+
+func oktaUserFreshnessReadOptions() sourcecdk.FamilyFreshnessReadOptions {
+	return sourcecdk.FamilyFreshnessReadOptions{
+		Confidence:     sourcecdk.FamilyFreshnessConfidenceHeuristic,
+		MaxSkipCount:   oktaUserFreshnessMaxSkipCount,
+		MaxSkipAge:     oktaUserFreshnessMaxSkipAge,
+		ProbeErrorMode: sourcecdk.FamilyFreshnessProbeErrorFailOpen,
+	}
+}
+
+func (s *Source) probeLatestUser(ctx context.Context, settings settings, checkpoint *cerebrov1.SourceCheckpoint) (sourcecdk.ChangeProbe, error) {
+	probeSettings := settings
+	probeSettings.sortBy = "lastUpdated"
+	probeSettings.sortOrder = "desc"
+	records, _, err := s.listUsers(ctx, probeSettings, "", 1)
+	if err != nil {
+		return sourcecdk.ChangeProbe{}, wrapLookupError(oktaLabel("okta user freshness probe", settings), err)
+	}
+	probe := oktaLatestUserProbe(settings, records, time.Now().UTC())
+	change := sourcecdk.FamilyFreshnessChangeProbe("okta", familyUser, checkpoint, probe)
+	if len(records) > 0 {
+		if id := strings.TrimSpace(records[0].ID); id != "" {
+			change.ChangedResourceIDs = []string{id}
+			if urn, err := userURN(settings.domain, id); err == nil {
+				change.ChangedURNs = []sourcecdk.URN{urn}
+			}
+		}
+	}
+	return change, nil
+}
+
+func oktaLatestUserProbe(settings settings, records []userRecord, observedAt time.Time) sourcecdk.FamilyFreshnessProbe {
+	resourceID := oktaUserFreshnessResourceNone
+	updatedAt := time.Time{}
+	hashParts := oktaFreshnessScopeParts(settings, oktaUserFreshnessKind, resourceID, "empty")
+	if len(records) > 0 {
+		record := records[0]
+		if id := strings.TrimSpace(record.ID); id != "" {
+			resourceID = id
+		}
+		updatedAt = userOccurredAt(record)
+		hashParts = oktaFreshnessScopeParts(
+			settings,
+			oktaUserFreshnessKind,
+			resourceID,
+			updatedAt.Format(time.RFC3339Nano),
+			strings.TrimSpace(record.Status),
+		)
+	}
+	return sourcecdk.FamilyFreshnessProbe{
+		Kind:       oktaUserFreshnessKind,
+		ResourceID: resourceID,
+		ObservedAt: observedAt,
+		UpdatedAt:  updatedAt,
+		Hash:       sourcecdk.FamilyFreshnessHash(hashParts...),
+		Confidence: sourcecdk.FamilyFreshnessConfidenceHeuristic,
+	}
+}
+
+func oktaFreshnessScopeParts(settings settings, parts ...string) []string {
+	scoped := []string{
+		strings.TrimSpace(settings.domain),
+		strings.TrimSpace(settings.filter),
+		strings.TrimSpace(settings.q),
+		strings.TrimSpace(settings.search),
+	}
+	scoped = append(scoped, parts...)
+	return scoped
 }
 
 func oktaAssetSettings(settings settings) oktaasset.Settings {

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -12,6 +12,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/sources/internal/oktaasset"
+	"github.com/writer/cerebro/sources/internal/oktafreshness"
 )
 
 //go:embed catalog.yaml
@@ -146,7 +147,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 			List:         s.listUsers,
 			Enrich:       s.enrichUsersWithMFAFactors,
 			Probe:        s.probeLatestUser,
-			ProbeOptions: oktaUserFreshnessReadOptions(),
+			ProbeOptions: oktafreshness.UserReadOptions(),
 			Event:        userEvent,
 			URN: func(settings settings, user userRecord) (string, error) {
 				urn, err := userURN(settings.domain, user.ID)

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -141,11 +141,13 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 		}),
 		s.assetFamily(familyTrustedOrigin, "okta trusted origins", "/api/v1/trustedOrigins", "trusted_origin", oktaasset.KindTrustedOrigin, true),
 		oktaFamily(oktaFamilyOptions[userRecord]{
-			Name:   familyUser,
-			Label:  "okta users",
-			List:   s.listUsers,
-			Enrich: s.enrichUsersWithMFAFactors,
-			Event:  userEvent,
+			Name:         familyUser,
+			Label:        "okta users",
+			List:         s.listUsers,
+			Enrich:       s.enrichUsersWithMFAFactors,
+			Probe:        s.probeLatestUser,
+			ProbeOptions: oktaUserFreshnessReadOptions(),
+			Event:        userEvent,
 			URN: func(settings settings, user userRecord) (string, error) {
 				urn, err := userURN(settings.domain, user.ID)
 				if err != nil {

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -985,6 +985,122 @@ func TestOktaMFAEnrollmentFactorKinds_IncludesTokenHardware(t *testing.T) {
 	}
 }
 
+func TestReadLiveOktaUserShortCircuitsWithFreshnessProbe(t *testing.T) {
+	userRecords := []map[string]any{
+		{
+			"id":          "00u1",
+			"status":      "ACTIVE",
+			"created":     "2026-04-20T00:00:00Z",
+			"activated":   "2026-04-20T00:01:00Z",
+			"lastUpdated": "2026-04-23T01:00:00Z",
+			"profile": map[string]any{
+				"login": "alice@writer.com",
+				"email": "alice@writer.com",
+			},
+		},
+		{
+			"id":          "00u2",
+			"status":      "ACTIVE",
+			"created":     "2026-04-20T00:00:00Z",
+			"lastUpdated": "2026-04-23T00:30:00Z",
+			"profile": map[string]any{
+				"login": "bob@writer.com",
+				"email": "bob@writer.com",
+			},
+		},
+	}
+	userListRequests := 0
+	factorRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.Header.Get("Authorization"); got != "SSWS test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			if err := json.NewEncoder(w).Encode(map[string]any{"errorSummary": "invalid token"}); err != nil {
+				t.Fatalf("encode auth error: %v", err)
+			}
+			return
+		}
+		switch r.URL.Path {
+		case "/api/v1/users":
+			userListRequests++
+			if r.URL.Query().Get("sortBy") == "lastUpdated" {
+				if got := r.URL.Query().Get("sortOrder"); got != "desc" {
+					t.Fatalf("freshness probe sortOrder = %q, want desc", got)
+				}
+				if got := r.URL.Query().Get("limit"); got != "1" {
+					t.Fatalf("freshness probe limit = %q, want 1", got)
+				}
+				if err := json.NewEncoder(w).Encode(userRecords[:1]); err != nil {
+					t.Fatalf("encode freshness user: %v", err)
+				}
+				return
+			}
+			if err := json.NewEncoder(w).Encode(userRecords); err != nil {
+				t.Fatalf("encode users: %v", err)
+			}
+		case "/api/v1/users/00u1/factors", "/api/v1/users/00u2/factors":
+			factorRequests++
+			if _, err := w.Write(mustOktaTestdata(t, "factors_not_enrolled.json")); err != nil {
+				t.Fatalf("write factors: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"domain":   "writer.okta.com",
+		"family":   "user",
+		"per_page": "2",
+		"token":    "test-token",
+	})
+
+	first, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(first) error = %v", err)
+	}
+	if len(first.Events) != 2 {
+		t.Fatalf("len(first.Events) = %d, want 2", len(first.Events))
+	}
+	if factorRequests != 2 {
+		t.Fatalf("factor requests after first read = %d, want 2", factorRequests)
+	}
+	if info, ok := sourcecdk.FamilyFreshnessInfoFromCheckpoint(first.Checkpoint); !ok || info.Source != "okta" || info.Family != familyUser {
+		t.Fatalf("first checkpoint freshness info = %#v, %t; want okta user freshness", info, ok)
+	}
+
+	second, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, first.Checkpoint)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint(second) error = %v", err)
+	}
+	if len(second.Events) != 0 {
+		t.Fatalf("len(second.Events) = %d, want 0", len(second.Events))
+	}
+	if second.ShortCircuitReason != sourcecdk.PullShortCircuitReasonNotModified {
+		t.Fatalf("second short-circuit reason = %q, want not_modified", second.ShortCircuitReason)
+	}
+	if factorRequests != 2 {
+		t.Fatalf("factor requests after short-circuit = %d, want still 2", factorRequests)
+	}
+	if userListRequests != 3 {
+		t.Fatalf("user list requests = %d, want probe/read/probe", userListRequests)
+	}
+	info, ok := sourcecdk.FamilyFreshnessInfoFromCheckpoint(second.Checkpoint)
+	if !ok {
+		t.Fatalf("second checkpoint %q missing freshness info", second.Checkpoint.GetCursorOpaque())
+	}
+	if info.Reason != sourcecdk.FamilyFreshnessReasonShortCircuit || info.SkipCount != 1 {
+		t.Fatalf("second freshness info = %#v, want short_circuit skip_count=1", info)
+	}
+}
+
 func TestReadLiveOktaUserPreviewRetriesMFAFactorRateLimit(t *testing.T) {
 	requestCount := 0
 	server := httptest.NewServer(newOktaUserFactorAPIHandler(t, "00u-rate-limited", []oktaFactorTestResponse{

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -22,7 +22,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"github":          2024,
 	"googleworkspace": 814,
 	"grc":             1195,
-	"okta":            2256,
+	"okta":            2255,
 	"panopticon":      763,
 	"sentinelone":     2112,
 	"vulnview":        1002,


### PR DESCRIPTION
## Summary
- Add source-family freshness probe plumbing for incremental reads.
- Add a freshness probe path that can return `not_modified` when the upstream freshness marker is unchanged.
- Carry freshness metadata through continuation cursors so paged reads do not re-probe mid-stream.
- Keep changed-probe reads on the same durable watermark path as normal family reads.
- Move shared record-pull and freshness helper logic out of the provider package so the source LOC ratchet moves down.

## Validation
- `go test ./internal/sourcecdk ./internal/sourceruntime ./sources/internal/oktafreshness ./sources/okta ./tools/archtests -count=1`
- `make oss-audit`
- `git diff --check`
