### PR TITLE
[codex] Promote Jira provider API proof

### DIFF
--- a/sources/jira/catalog.yaml
+++ b/sources/jira/catalog.yaml
@@ -17,6 +17,65 @@ runtime_families:
   - project_roles
   - projects
   - users
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-07-04T00:00:00Z
+  transport: rest
+  auth: basic
+  auth_mechanics: basic_authorization_header_email_api_token
+  base_url: https://${config.site_url}
+  spec_url: https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
+  spec_kind: openapi
+  references:
+    - https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/
+    - https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-groups/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-roles/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-permission-schemes/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-audit-records/
+  auth_evidence:
+    - https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/
+  scope_evidence:
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-groups/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-roles/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-permission-schemes/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-audit-records/
+  families:
+    - id: audit_events
+      method: GET
+      path: /rest/api/3/auditing/record
+      operation: getAuditRecords
+    - id: group_members
+      method: GET
+      path: /rest/api/3/group/member
+      operation: getUsersFromGroup
+    - id: groups
+      method: GET
+      path: /rest/api/3/group/bulk
+      operation: bulkGetGroups
+    - id: permission_schemes
+      method: GET
+      path: /rest/api/3/permissionscheme
+      operation: getAllPermissionSchemes
+    - id: project_roles
+      method: GET
+      path: /rest/api/3/project/{projectIdOrKey}/roledetails
+      operation: getProjectRoleDetails
+    - id: projects
+      method: GET
+      path: /rest/api/3/project/search
+      operation: searchProjects
+    - id: users
+      method: GET
+      path: /rest/api/3/users/search
+      operation: getAllUsers
 kind_lifecycle:
   - kind: jira.users
     status: active

--- a/sources/jira/source_test.go
+++ b/sources/jira/source_test.go
@@ -6,13 +6,95 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/sources/internal/jiraapi"
+	"gopkg.in/yaml.v3"
 )
+
+func TestCatalogDeclaresVerifiedJiraProviderAPI(t *testing.T) {
+	payload, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	var catalog struct {
+		RuntimeFamilies []string `yaml:"runtime_families"`
+		ProviderAPI     struct {
+			Status     string   `yaml:"status"`
+			Transport  string   `yaml:"transport"`
+			Auth       string   `yaml:"auth"`
+			BaseURL    string   `yaml:"base_url"`
+			SpecURL    string   `yaml:"spec_url"`
+			References []string `yaml:"references"`
+			Families   []struct {
+				ID        string `yaml:"id"`
+				Method    string `yaml:"method"`
+				Path      string `yaml:"path"`
+				Operation string `yaml:"operation"`
+			} `yaml:"families"`
+		} `yaml:"provider_api"`
+	}
+	if err := yaml.Unmarshal(payload, &catalog); err != nil {
+		t.Fatalf("unmarshal catalog: %v", err)
+	}
+	assertStringSet(t, catalog.RuntimeFamilies, []string{
+		jiraapi.FamilyAuditEvents,
+		jiraapi.FamilyGroupMembers,
+		jiraapi.FamilyGroups,
+		jiraapi.FamilyPermissionSchemes,
+		jiraapi.FamilyProjectRoles,
+		jiraapi.FamilyProjects,
+		jiraapi.FamilyUsers,
+	})
+	if catalog.ProviderAPI.Status != "verified" || catalog.ProviderAPI.Transport != "rest" || catalog.ProviderAPI.Auth != "basic" || catalog.ProviderAPI.BaseURL != defaultBaseURLTemplate {
+		t.Fatalf("provider_api = %#v, want verified REST basic-auth API", catalog.ProviderAPI)
+	}
+	if catalog.ProviderAPI.SpecURL != "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json" {
+		t.Fatalf("provider_api spec_url = %q", catalog.ProviderAPI.SpecURL)
+	}
+	for _, ref := range []string{
+		"https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json",
+		"https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/",
+		"https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/",
+		"https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-groups/",
+		"https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/",
+		"https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-roles/",
+		"https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-permission-schemes/",
+		"https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-audit-records/",
+	} {
+		if !hasString(catalog.ProviderAPI.References, ref) {
+			t.Fatalf("provider references = %v, want %s", catalog.ProviderAPI.References, ref)
+		}
+	}
+	wantPaths := map[string]string{
+		jiraapi.FamilyAuditEvents:       "/rest/api/3/auditing/record",
+		jiraapi.FamilyGroupMembers:      "/rest/api/3/group/member",
+		jiraapi.FamilyGroups:            "/rest/api/3/group/bulk",
+		jiraapi.FamilyPermissionSchemes: "/rest/api/3/permissionscheme",
+		jiraapi.FamilyProjectRoles:      "/rest/api/3/project/{projectIdOrKey}/roledetails",
+		jiraapi.FamilyProjects:          "/rest/api/3/project/search",
+		jiraapi.FamilyUsers:             "/rest/api/3/users/search",
+	}
+	gotPaths := map[string]string{}
+	for _, family := range catalog.ProviderAPI.Families {
+		if family.Method != http.MethodGet {
+			t.Fatalf("provider family %s method = %q, want GET", family.ID, family.Method)
+		}
+		if strings.TrimSpace(family.Operation) == "" {
+			t.Fatalf("provider family %s operation is empty", family.ID)
+		}
+		gotPaths[family.ID] = family.Path
+	}
+	for family, want := range wantPaths {
+		if got := gotPaths[family]; got != want {
+			t.Fatalf("provider path for %s = %q, want %q", family, got, want)
+		}
+	}
+}
 
 func TestSourceCheckAndReadUsersUsesJiraREST(t *testing.T) {
 	source, err := New()
@@ -91,6 +173,26 @@ func TestSourceCheckAndReadUsersUsesJiraREST(t *testing.T) {
 	if len(requests) < 3 {
 		t.Fatalf("request count = %d, want health, check, and read", len(requests))
 	}
+}
+
+func assertStringSet(t *testing.T, got []string, want []string) {
+	t.Helper()
+	got = append([]string(nil), got...)
+	want = append([]string(nil), want...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("strings = %v, want %v", got, want)
+	}
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSourceCheckProjectRolesUsesConfiguredFanoutProjectKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a verified Jira Cloud REST provider API proof to the Jira source catalog.
- Map every Jira runtime family to the documented v3 method, path, and OpenAPI operation.
- Add a catalog contract test that protects the verified proof, references, base URL, and family path mapping.

## Impact
- Promotes Jira from the provider API discovery queue into reference-runtime coverage.
- Keeps the existing Jira runtime, fixtures, and graph projections unchanged.

## Validation
- `go test ./sources/jira ./internal/connectorcatalog ./internal/sourcecdk -count=1`
- `make connector-catalog-review connector-api-discovery`
- `make check-structural check-structural-test check-arch`
- `make lint-sources`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->