### PR TITLE
[codex] Promote Anthropic source API proof

### DIFF
--- a/internal/connectorcatalog/provider_api_proof.go
+++ b/internal/connectorcatalog/provider_api_proof.go
@@ -151,6 +151,9 @@ func providerAPISpecPointerOK(specURL string, specKind string, transport string)
 		return strings.Contains(lowerURL, "googleapis.com/$discovery/rest") ||
 			strings.Contains(lowerURL, "googleapis.com/discovery/v1/apis/")
 	}
+	if providerAPIMarkdownReferenceOK(lowerURL, lowerKind) {
+		return true
+	}
 	hasMachineURL := strings.Contains(lowerURL, "openapi") ||
 		strings.Contains(lowerURL, "swagger") ||
 		strings.HasSuffix(providerAPIURLPath(lowerURL), ".json") ||
@@ -161,6 +164,21 @@ func providerAPISpecPointerOK(specURL string, specKind string, transport string)
 		return true
 	}
 	return strings.Contains(lowerKind, "graphql") && strings.Contains(lowerURL, "graphql")
+}
+
+func providerAPIMarkdownReferenceOK(lowerURL string, lowerKind string) bool {
+	switch lowerKind {
+	case "api_reference_markdown", "markdown_reference", "provider_reference_markdown":
+	default:
+		return false
+	}
+	path := providerAPIURLPath(lowerURL)
+	if !strings.HasSuffix(path, ".md") {
+		return false
+	}
+	return strings.Contains(lowerURL, "/docs/") ||
+		strings.Contains(lowerURL, "/developer") ||
+		strings.Contains(lowerURL, "/reference")
 }
 
 func providerAPIAuthMechanicsOK(api runtimeProviderAPIFields) bool {

--- a/internal/connectorcatalog/provider_api_proof_test.go
+++ b/internal/connectorcatalog/provider_api_proof_test.go
@@ -108,6 +108,19 @@ func TestProviderAPISpecPointerAcceptsGoogleDiscovery(t *testing.T) {
 	}
 }
 
+func TestProviderAPISpecPointerAcceptsExplicitProviderMarkdownReference(t *testing.T) {
+	specURL := "https://platform.provider.io/docs/en/api/admin.md"
+	if !providerAPISpecPointerOK(specURL, "api_reference_markdown", "rest") {
+		t.Fatalf("providerAPISpecPointerOK(%q, api_reference_markdown) = false, want true", specURL)
+	}
+	if providerAPISpecPointerOK(specURL, "", "rest") {
+		t.Fatalf("providerAPISpecPointerOK(%q, empty kind) = true, want false", specURL)
+	}
+	if providerAPISpecPointerOK("https://platform.provider.io/docs/en/api/admin", "api_reference_markdown", "rest") {
+		t.Fatal("providerAPISpecPointerOK(markdown reference without .md) = true, want false")
+	}
+}
+
 func TestProviderAPIURLIsOAuthEndpointRequiresAuthPathSegment(t *testing.T) {
 	for _, value := range []string{
 		"https://api.provider.io/oauth/token",

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1017,6 +1018,265 @@ func TestProjectAnthropicInventoryEntitiesDeterministic(t *testing.T) {
 	})
 }
 
+func TestProjectAnthropicRemainingRuntimeFamilies(t *testing.T) {
+	occurred := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		event      *cerebrov1.EventEnvelope
+		entityType string
+		attrKey    string
+		attrValue  string
+	}{
+		{
+			name: "organization",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-organization",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.organization",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"family":          "organization",
+					"organization_id": "org_123",
+					"name":            "Writer",
+				},
+			},
+			entityType: "anthropic.org",
+			attrKey:    "organization_id",
+			attrValue:  "org_123",
+		},
+		{
+			name: "external_key",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-external-key",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.external_key",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"external_key_id": "extkey_123",
+					"family":          "external_key",
+					"name":            "production key",
+					"provider":        "aws",
+					"status":          "active",
+				},
+			},
+			entityType: "anthropic.credential",
+			attrKey:    "external_key_id",
+			attrValue:  "extkey_123",
+		},
+		{
+			name: "service_account",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-service-account",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.service_account",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"family":             "service_account",
+					"name":               "Deploy worker",
+					"role":               "developer",
+					"service_account_id": "svac_123",
+					"status":             "active",
+				},
+			},
+			entityType: "anthropic.service_account",
+			attrKey:    "service_account_id",
+			attrValue:  "svac_123",
+		},
+		{
+			name: "federation_issuer",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-federation-issuer",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.federation_issuer",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"family":               "federation_issuer",
+					"federation_issuer_id": "fdis_123",
+					"issuer":               "https://issuer.example.com",
+					"name":                 "Production IdP",
+					"organization_id":      "org_123",
+					"status":               "active",
+				},
+			},
+			entityType: "anthropic.federation_issuer",
+			attrKey:    "federation_issuer_id",
+			attrValue:  "fdis_123",
+		},
+		{
+			name: "usage_report_message",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-usage-report-message",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.usage_report_message",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"family":     "usage_report_message",
+					"id":         "usage_msg_123",
+					"model":      "claude-sonnet-4-20250514",
+					"start_time": "2026-06-18T12:00:00Z",
+				},
+			},
+			entityType: "anthropic.usage_report_message",
+			attrKey:    "metric_id",
+			attrValue:  "usage_msg_123",
+		},
+		{
+			name: "usage_report_claude_code",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-usage-report-claude-code",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.usage_report_claude_code",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"family":     "usage_report_claude_code",
+					"id":         "usage_code_123",
+					"start_time": "2026-06-18T12:00:00Z",
+					"user_id":    "user_123",
+				},
+			},
+			entityType: "anthropic.usage_report_claude_code",
+			attrKey:    "metric_id",
+			attrValue:  "usage_code_123",
+		},
+		{
+			name: "analytics_cost",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-analytics-cost",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.analytics_cost",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"cost_usd":   "8.75",
+					"family":     "analytics_cost",
+					"id":         "analytics_cost_123",
+					"model":      "claude-sonnet-4-20250514",
+					"start_time": "2026-06-18T12:00:00Z",
+				},
+			},
+			entityType: "anthropic.analytics_cost",
+			attrKey:    "metric_type",
+			attrValue:  "cost",
+		},
+		{
+			name: "rate_limit",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-rate-limit",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.rate_limit",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"family":        "rate_limit",
+					"group_type":    "model",
+					"model":         "claude-sonnet-4-20250514",
+					"name":          "Messages",
+					"rate_limit_id": "rl_123",
+				},
+			},
+			entityType: "anthropic.rate_limit",
+			attrKey:    "control_type",
+			attrValue:  "rate_limit",
+		},
+		{
+			name: "spend_limit",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-spend-limit",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.spend_limit",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"amount":         "2500",
+					"family":         "spend_limit",
+					"period":         "monthly",
+					"spend_limit_id": "spend_123",
+					"user_id":        "user_123",
+				},
+			},
+			entityType: "anthropic.spend_limit",
+			attrKey:    "control_type",
+			attrValue:  "spend_limit",
+		},
+		{
+			name: "spend_limit_increase_request",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-spend-limit-increase-request",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.spend_limit_increase_request",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"amount":     "5000",
+					"family":     "spend_limit_increase_request",
+					"period":     "monthly",
+					"request_id": "req_123",
+					"status":     "pending",
+					"user_id":    "user_123",
+				},
+			},
+			entityType: "anthropic.spend_limit_increase_request",
+			attrKey:    "control_type",
+			attrValue:  "spend_limit_increase_request",
+		},
+		{
+			name: "compliance_organization",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-compliance-organization",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.compliance_organization",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"family":            "compliance_organization",
+					"name":              "Writer",
+					"organization_uuid": "org-uuid-1",
+				},
+			},
+			entityType: "anthropic.org",
+			attrKey:    "organization_uuid",
+			attrValue:  "org-uuid-1",
+		},
+		{
+			name: "compliance_organization_user",
+			event: &cerebrov1.EventEnvelope{
+				Id:         "anthropic-compliance-organization-user",
+				TenantId:   "writer",
+				SourceId:   "anthropic",
+				Kind:       "anthropic.compliance_organization_user",
+				OccurredAt: timestamppb.New(occurred),
+				Attributes: map[string]string{
+					"email":             "carol@example.com",
+					"family":            "compliance_organization_user",
+					"name":              "Carol Example",
+					"organization_uuid": "org-uuid-1",
+					"role":              "admin",
+					"user_id":           "user_789",
+				},
+			},
+			entityType: "anthropic.user",
+			attrKey:    "user_id",
+			attrValue:  "user_789",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := projectAnthropicInventoryEvent(t, tc.event)
+			if entity := findProjectedEntityByAttribute(state, tc.entityType, tc.attrKey, tc.attrValue); entity == nil {
+				t.Fatalf("projected %s entity with %s=%q missing in %#v", tc.entityType, tc.attrKey, tc.attrValue, state.entities)
+			}
+		})
+	}
+}
+
 func projectAnthropicInventoryEvent(t *testing.T, event *cerebrov1.EventEnvelope) *projectionRecorder {
 	t.Helper()
 	state := &projectionRecorder{}
@@ -1028,6 +1288,21 @@ func projectAnthropicInventoryEvent(t *testing.T, event *cerebrov1.EventEnvelope
 		t.Fatalf("Project(%q) replay error = %v", event.GetId(), err)
 	}
 	return state
+}
+
+func findProjectedEntityByAttribute(state *projectionRecorder, entityType string, attrKey string, attrValue string) *ports.ProjectedEntity {
+	if state == nil {
+		return nil
+	}
+	for _, entity := range state.entities {
+		if entity == nil || entity.EntityType != entityType {
+			continue
+		}
+		if entity.Attributes[attrKey] == attrValue {
+			return entity
+		}
+	}
+	return nil
 }
 
 func TestRegistryRoutesAnthropicDeclaredKinds(t *testing.T) {

--- a/sources/anthropic/catalog.yaml
+++ b/sources/anthropic/catalog.yaml
@@ -59,6 +59,153 @@ runtime_families:
   - workspace
   - workspace_member
   - workspace_rate_limit
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-07-04T00:00:00Z
+  transport: rest
+  auth: api_key_or_bearer_token
+  auth_mechanics: x_api_key_admin_key_or_org_admin_bearer_with_anthropic_version_header
+  base_url: https://api.anthropic.com
+  spec_url: https://platform.claude.com/docs/en/api/admin.md
+  spec_kind: api_reference_markdown
+  references:
+    - https://platform.claude.com/docs/en/manage-claude/admin-api.md
+    - https://platform.claude.com/docs/en/manage-claude/admin-api-keys.md
+    - https://platform.claude.com/docs/en/manage-claude/wif-admin-api.md
+    - https://platform.claude.com/docs/en/manage-claude/usage-cost-api.md
+    - https://platform.claude.com/docs/en/manage-claude/analytics-api.md
+    - https://platform.claude.com/docs/en/manage-claude/rate-limits-api.md
+    - https://platform.claude.com/docs/en/manage-claude/spend-limits-api.md
+    - https://platform.claude.com/docs/en/manage-claude/compliance-api.md
+    - https://platform.claude.com/docs/en/manage-claude/compliance-api-access.md
+    - https://platform.claude.com/docs/en/api/admin/organizations/me.md
+    - https://platform.claude.com/docs/en/api/admin/users/list.md
+    - https://platform.claude.com/docs/en/api/admin/invites/list.md
+    - https://platform.claude.com/docs/en/api/admin/workspaces/list.md
+    - https://platform.claude.com/docs/en/api/admin/workspaces/members/list.md
+    - https://platform.claude.com/docs/en/api/admin/api_keys/list.md
+    - https://platform.claude.com/docs/en/api/admin/external_keys/list.md
+    - https://platform.claude.com/docs/en/api/admin/service_accounts/list.md
+    - https://platform.claude.com/docs/en/api/admin/federation_issuers/list.md
+    - https://platform.claude.com/docs/en/api/admin/federation_rules/list.md
+    - https://platform.claude.com/docs/en/api/admin/usage_report/retrieve_messages.md
+    - https://platform.claude.com/docs/en/api/admin/usage_report/retrieve_claude_code.md
+    - https://platform.claude.com/docs/en/api/admin/cost_report/retrieve.md
+    - https://platform.claude.com/docs/en/api/admin/analytics/cost/list.md
+    - https://platform.claude.com/docs/en/api/admin/rate_limits/list.md
+    - https://platform.claude.com/docs/en/api/admin/workspaces/rate_limits/list.md
+    - https://platform.claude.com/docs/en/api/admin/spend_limits/list_effective.md
+    - https://platform.claude.com/docs/en/api/admin/spend_limits/increase_requests/list.md
+    - https://platform.claude.com/docs/en/api/compliance/activities/list.md
+    - https://platform.claude.com/docs/en/api/compliance/organizations/list.md
+    - https://platform.claude.com/docs/en/api/compliance/organizations/users/list.md
+    - https://platform.claude.com/docs/en/api/compliance/organizations/roles/list.md
+    - https://platform.claude.com/docs/en/api/compliance/organizations/roles/permissions/list.md
+    - https://platform.claude.com/docs/en/api/compliance/groups/list.md
+    - https://platform.claude.com/docs/en/api/compliance/groups/members/list.md
+    - https://platform.claude.com/docs/en/api/compliance/apps/projects/list.md
+    - https://platform.claude.com/docs/en/api/compliance/apps/projects/collaborators/list.md
+    - https://platform.claude.com/docs/en/api/compliance/organizations/settings/retrieve.md
+  auth_evidence:
+    - https://platform.claude.com/docs/en/manage-claude/admin-api.md
+    - https://platform.claude.com/docs/en/manage-claude/admin-api-keys.md
+    - https://platform.claude.com/docs/en/manage-claude/wif-admin-api.md
+    - https://platform.claude.com/docs/en/manage-claude/compliance-api-access.md
+  scope_evidence:
+    - https://platform.claude.com/docs/en/manage-claude/admin-api.md
+    - https://platform.claude.com/docs/en/manage-claude/wif-admin-api.md
+    - https://platform.claude.com/docs/en/manage-claude/usage-cost-api.md
+    - https://platform.claude.com/docs/en/manage-claude/analytics-api.md
+    - https://platform.claude.com/docs/en/manage-claude/rate-limits-api.md
+    - https://platform.claude.com/docs/en/manage-claude/spend-limits-api.md
+    - https://platform.claude.com/docs/en/manage-claude/compliance-api.md
+    - https://platform.claude.com/docs/en/manage-claude/compliance-api-access.md
+  families:
+    - id: analytics_cost
+      method: GET
+      path: /v1/organizations/analytics/cost_report
+    - id: api_key
+      method: GET
+      path: /v1/organizations/api_keys
+    - id: compliance_activity
+      method: GET
+      path: /v1/compliance/activities
+    - id: compliance_group
+      method: GET
+      path: /v1/compliance/groups
+    - id: compliance_group_member
+      method: GET
+      path: /v1/compliance/groups/{group_id}/members
+    - id: compliance_organization
+      method: GET
+      path: /v1/compliance/organizations
+    - id: compliance_organization_setting
+      method: GET
+      path: /v1/compliance/organizations/{organization_id}/settings
+    - id: compliance_organization_user
+      method: GET
+      path: /v1/compliance/organizations/{org_uuid}/users
+    - id: compliance_project
+      method: GET
+      path: /v1/compliance/apps/projects
+    - id: compliance_project_collaborator
+      method: GET
+      path: /v1/compliance/apps/projects/{project_id}/collaborators
+    - id: compliance_role
+      method: GET
+      path: /v1/compliance/organizations/{org_uuid}/roles
+    - id: compliance_role_permission
+      method: GET
+      path: /v1/compliance/organizations/{org_uuid}/roles/{role_id}/permissions
+    - id: cost_report
+      method: GET
+      path: /v1/organizations/cost_report
+    - id: external_key
+      method: GET
+      path: /v1/organizations/external_keys
+    - id: federation_issuer
+      method: GET
+      path: /v1/organizations/federation_issuers
+    - id: federation_rule
+      method: GET
+      path: /v1/organizations/federation_rules
+    - id: invite
+      method: GET
+      path: /v1/organizations/invites
+    - id: organization
+      method: GET
+      path: /v1/organizations/me
+    - id: rate_limit
+      method: GET
+      path: /v1/organizations/rate_limits
+    - id: service_account
+      method: GET
+      path: /v1/organizations/service_accounts
+    - id: spend_limit
+      method: GET
+      path: /v1/organizations/spend_limits/effective
+    - id: spend_limit_increase_request
+      method: GET
+      path: /v1/organizations/spend_limit_increase_requests
+    - id: usage_report_claude_code
+      method: GET
+      path: /v1/organizations/usage_report/claude_code
+    - id: usage_report_message
+      method: GET
+      path: /v1/organizations/usage_report/messages
+    - id: user
+      method: GET
+      path: /v1/organizations/users
+    - id: workspace
+      method: GET
+      path: /v1/organizations/workspaces
+    - id: workspace_member
+      method: GET
+      path: /v1/organizations/workspaces/{workspace_id}/members
+    - id: workspace_rate_limit
+      method: GET
+      path: /v1/organizations/workspaces/{workspace_id}/rate_limits
 coverage_contract:
   owner_domain: ai
   authority_domain: anthropic

--- a/sources/anthropic/source.go
+++ b/sources/anthropic/source.go
@@ -83,7 +83,7 @@ func anthropicFamilies() []jsonapi.Family {
 		anthropicReportFamily("usage_report_message", "/organizations/usage_report/messages"),
 		anthropicReportFamily("usage_report_claude_code", "/organizations/usage_report/claude_code"),
 		anthropicReportFamily("cost_report", "/organizations/cost_report"),
-		anthropicReportFamily("analytics_cost", "/organizations/analytics/cost"),
+		anthropicReportFamily("analytics_cost", "/organizations/analytics/cost_report"),
 		anthropicListFamily("rate_limit", "/organizations/rate_limits", "anthropic_rate_limit", []string{"id", "group_type", "model", "name"}, []string{"updated_at"}, rateLimitAttributes(), withQuery(map[string]string{"model": "model"}), withPageCursor()),
 		anthropicListFamily("workspace_rate_limit", "/organizations/workspaces/{workspace_id}/rate_limits", "anthropic_workspace_rate_limit", []string{"id", "group_type", "model", "name"}, []string{"updated_at"}, rateLimitAttributes(), withPathParams("workspace_id"), withPageCursor()),
 		anthropicListFamily("spend_limit", "/organizations/spend_limits/effective", "anthropic_spend_limit", []string{"spend_limit_id", "id", "scope.user_id", "actor.user_id"}, []string{"created_at", "updated_at"}, map[string]string{"spend_limit_id": "spend_limit_id|id", "scope_type": "scope.type", "user_id": "scope.user_id|actor.user_id", "actor_email": "actor.email_address|actor.email", "amount": "amount", "currency": "currency", "period": "period", "source_type": "source.type", "period_to_date_spend": "period_to_date_spend", "created_at": "created_at", "updated_at": "updated_at"}, withPageCursor(), withQuery(map[string]string{"actor_ids[]": "actor_ids", "period[]": "periods", "user_ids[]": "user_ids"})),

--- a/sources/anthropic/source_test.go
+++ b/sources/anthropic/source_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewLoadsCatalog(t *testing.T) {
@@ -18,6 +20,133 @@ func TestNewLoadsCatalog(t *testing.T) {
 	}
 	if got := source.Spec().GetId(); got != "anthropic" {
 		t.Fatalf("Spec().Id = %q, want anthropic", got)
+	}
+}
+
+func TestCatalogDeclaresVerifiedAnthropicProviderAPI(t *testing.T) {
+	payload, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	var catalog struct {
+		RuntimeFamilies []string `yaml:"runtime_families"`
+		ProviderAPI     struct {
+			Status        string   `yaml:"status"`
+			Basis         string   `yaml:"basis"`
+			Transport     string   `yaml:"transport"`
+			Auth          string   `yaml:"auth"`
+			AuthMechanics string   `yaml:"auth_mechanics"`
+			BaseURL       string   `yaml:"base_url"`
+			SpecURL       string   `yaml:"spec_url"`
+			SpecKind      string   `yaml:"spec_kind"`
+			References    []string `yaml:"references"`
+			AuthEvidence  []string `yaml:"auth_evidence"`
+			ScopeEvidence []string `yaml:"scope_evidence"`
+			Families      []struct {
+				ID     string `yaml:"id"`
+				Method string `yaml:"method"`
+				Path   string `yaml:"path"`
+			} `yaml:"families"`
+		} `yaml:"provider_api"`
+	}
+	if err := yaml.Unmarshal(payload, &catalog); err != nil {
+		t.Fatalf("unmarshal catalog: %v", err)
+	}
+	wantFamilies := []string{
+		"analytics_cost",
+		"api_key",
+		"compliance_activity",
+		"compliance_group",
+		"compliance_group_member",
+		"compliance_organization",
+		"compliance_organization_setting",
+		"compliance_organization_user",
+		"compliance_project",
+		"compliance_project_collaborator",
+		"compliance_role",
+		"compliance_role_permission",
+		"cost_report",
+		"external_key",
+		"federation_issuer",
+		"federation_rule",
+		"invite",
+		"organization",
+		"rate_limit",
+		"service_account",
+		"spend_limit",
+		"spend_limit_increase_request",
+		"usage_report_claude_code",
+		"usage_report_message",
+		"user",
+		"workspace",
+		"workspace_member",
+		"workspace_rate_limit",
+	}
+	assertStringSet(t, catalog.RuntimeFamilies, wantFamilies)
+	if catalog.ProviderAPI.Status != "verified" || catalog.ProviderAPI.Basis != "declared" || catalog.ProviderAPI.Transport != "rest" || catalog.ProviderAPI.Auth != "api_key_or_bearer_token" || catalog.ProviderAPI.BaseURL != "https://api.anthropic.com" {
+		t.Fatalf("provider_api = %#v, want verified declared REST API", catalog.ProviderAPI)
+	}
+	if catalog.ProviderAPI.AuthMechanics != "x_api_key_admin_key_or_org_admin_bearer_with_anthropic_version_header" {
+		t.Fatalf("auth_mechanics = %q", catalog.ProviderAPI.AuthMechanics)
+	}
+	if catalog.ProviderAPI.SpecURL != "https://platform.claude.com/docs/en/api/admin.md" || catalog.ProviderAPI.SpecKind != "api_reference_markdown" {
+		t.Fatalf("provider_api spec = %q/%q, want provider Markdown reference", catalog.ProviderAPI.SpecURL, catalog.ProviderAPI.SpecKind)
+	}
+	for _, ref := range []string{
+		"https://platform.claude.com/docs/en/manage-claude/admin-api.md",
+		"https://platform.claude.com/docs/en/manage-claude/wif-admin-api.md",
+		"https://platform.claude.com/docs/en/manage-claude/compliance-api.md",
+		"https://platform.claude.com/docs/en/api/admin/analytics/cost/list.md",
+		"https://platform.claude.com/docs/en/api/compliance/apps/projects/collaborators/list.md",
+	} {
+		if !hasString(catalog.ProviderAPI.References, ref) {
+			t.Fatalf("provider references = %v, want %s", catalog.ProviderAPI.References, ref)
+		}
+	}
+	if len(catalog.ProviderAPI.AuthEvidence) == 0 || len(catalog.ProviderAPI.ScopeEvidence) == 0 {
+		t.Fatalf("provider evidence incomplete: auth=%v scopes=%v", catalog.ProviderAPI.AuthEvidence, catalog.ProviderAPI.ScopeEvidence)
+	}
+	wantPaths := map[string]string{
+		"analytics_cost":                  "/v1/organizations/analytics/cost_report",
+		"api_key":                         "/v1/organizations/api_keys",
+		"compliance_activity":             "/v1/compliance/activities",
+		"compliance_group":                "/v1/compliance/groups",
+		"compliance_group_member":         "/v1/compliance/groups/{group_id}/members",
+		"compliance_organization":         "/v1/compliance/organizations",
+		"compliance_organization_setting": "/v1/compliance/organizations/{organization_id}/settings",
+		"compliance_organization_user":    "/v1/compliance/organizations/{org_uuid}/users",
+		"compliance_project":              "/v1/compliance/apps/projects",
+		"compliance_project_collaborator": "/v1/compliance/apps/projects/{project_id}/collaborators",
+		"compliance_role":                 "/v1/compliance/organizations/{org_uuid}/roles",
+		"compliance_role_permission":      "/v1/compliance/organizations/{org_uuid}/roles/{role_id}/permissions",
+		"cost_report":                     "/v1/organizations/cost_report",
+		"external_key":                    "/v1/organizations/external_keys",
+		"federation_issuer":               "/v1/organizations/federation_issuers",
+		"federation_rule":                 "/v1/organizations/federation_rules",
+		"invite":                          "/v1/organizations/invites",
+		"organization":                    "/v1/organizations/me",
+		"rate_limit":                      "/v1/organizations/rate_limits",
+		"service_account":                 "/v1/organizations/service_accounts",
+		"spend_limit":                     "/v1/organizations/spend_limits/effective",
+		"spend_limit_increase_request":    "/v1/organizations/spend_limit_increase_requests",
+		"usage_report_claude_code":        "/v1/organizations/usage_report/claude_code",
+		"usage_report_message":            "/v1/organizations/usage_report/messages",
+		"user":                            "/v1/organizations/users",
+		"workspace":                       "/v1/organizations/workspaces",
+		"workspace_member":                "/v1/organizations/workspaces/{workspace_id}/members",
+		"workspace_rate_limit":            "/v1/organizations/workspaces/{workspace_id}/rate_limits",
+	}
+	gotPaths := map[string]string{}
+	for _, family := range catalog.ProviderAPI.Families {
+		if family.Method != http.MethodGet {
+			t.Fatalf("provider family %s method = %q, want GET", family.ID, family.Method)
+		}
+		gotPaths[family.ID] = family.Path
+	}
+	for family, want := range wantPaths {
+		if got := gotPaths[family]; got != want {
+			t.Fatalf("provider path for %s = %q, want %q", family, got, want)
+		}
 	}
 }
 
@@ -39,6 +168,60 @@ func TestNewFixtureReplaysEveryRuntimeFamily(t *testing.T) {
 		FamilyConfigs:   familyConfigs,
 		RequireDiscover: true,
 	})
+}
+
+func TestReadAnalyticsCostUsesDocumentedCostReportPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/organizations/analytics/cost_report" {
+			t.Fatalf("request path = %q, want /organizations/analytics/cost_report", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != "2023-06-01" {
+			t.Fatalf("anthropic-version = %q, want 2023-06-01", got)
+		}
+		if got := r.Header.Get("x-api-key"); got != "fixture-admin-key" {
+			t.Fatalf("x-api-key = %q, want fixture-admin-key", got)
+		}
+		if got := r.URL.Query().Get("starting_at"); got != "2026-06-01T00:00:00Z" {
+			t.Fatalf("starting_at = %q, want 2026-06-01T00:00:00Z", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{
+				"id":          "analytics_cost_2026_06_01",
+				"starting_at": "2026-06-01T00:00:00Z",
+				"ending_at":   "2026-06-02T00:00:00Z",
+				"model":       "claude-sonnet-4-20250514",
+				"cost_usd":    12.48,
+			}},
+			"has_more": false,
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.inner.AllowLoopbackBaseURL = true
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder key.
+		"api_key":     "fixture-admin-key",
+		"base_url":    server.URL,
+		"family":      "analytics_cost",
+		"starting_at": "2026-06-01T00:00:00Z",
+		"tenant_id":   "writer",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	event := pull.Events[0]
+	if event.Kind != "anthropic.analytics_cost" {
+		t.Fatalf("Kind = %q, want anthropic.analytics_cost", event.Kind)
+	}
+	if got := event.Attributes["cost_usd"]; got != "12.48" {
+		t.Fatalf("cost_usd = %q, want 12.48", got)
+	}
 }
 
 func TestReadProviderUnavailableReturnsProviderError(t *testing.T) {
@@ -866,4 +1049,24 @@ func TestReadComplianceOrganizationSettingsUsesSettingsListKey(t *testing.T) {
 	if got := event.Attributes["setting_value"]; got != "true" {
 		t.Fatalf("setting_value = %q, want true", got)
 	}
+}
+
+func assertStringSet(t *testing.T, got []string, want []string) {
+	t.Helper()
+	gotCopy := append([]string(nil), got...)
+	wantCopy := append([]string(nil), want...)
+	sort.Strings(gotCopy)
+	sort.Strings(wantCopy)
+	if strings.Join(gotCopy, "\n") != strings.Join(wantCopy, "\n") {
+		t.Fatalf("set = %v, want %v", gotCopy, wantCopy)
+	}
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- maps the Anthropic runtime families to provider-owned Admin and Compliance API reference paths
- accepts explicit provider Markdown API references as a structured provider API proof source
- fixes the Anthropic analytics cost endpoint to the documented cost report path
- adds graph projection coverage for the remaining Anthropic runtime families

## Validation
- go test ./internal/connectorcatalog ./sources/anthropic ./internal/sourceprojection -run 'ProviderAPI|Anthropic|AIUsage|RegistryRoutesAnthropic' -count=1
- go test ./sources/anthropic ./internal/connectorcatalog ./internal/sourceprojection ./internal/sourcecdk -count=1
- make connector-catalog-review connector-api-discovery
- make check-structural check-structural-test check-arch
- make lint-sources
- git diff --check

## Catalog result
- Anthropic runtime depth is now 100 / reference_runtime
- Anthropic provider API proof is now verified with complete family mapping

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->