### PR TITLE
Promote JumpCloud source API proof

### DIFF
--- a/docs/reference/sources.md
+++ b/docs/reference/sources.md
@@ -399,7 +399,7 @@ Declarative connector catalog entries are cataloged when a spec exists. They are
 | `jfrog_xray` | Jfrog Xray source | jfrog_xray.audit_events, jfrog_xray.deployments, jfrog_xray.projects, jfrog_xray.repositories, jfrog_xray.users |
 | `jira` | Jira source | jira.audit_events, jira.projects, jira.users |
 | `journy_io` | Journy Io source | journy_io.account, journy_io.event, journy_io.segments_account, journy_io.segments_user, journy_io.user |
-| `jumpcloud` | Jumpcloud source | jumpcloud.audit_events, jumpcloud.groups, jumpcloud.users |
+| `jumpcloud` | Jumpcloud source | jumpcloud.applications, jumpcloud.audit_events, jumpcloud.group_members, jumpcloud.groups, jumpcloud.system_groups, jumpcloud.systems, jumpcloud.users |
 | `jumpseller` | Jumpseller source | jumpseller.checkout_custom_fields_json, jumpseller.countries_json, jumpseller.custom_fields_json, jumpseller.customer_categories_json, jumpseller.customers_json, jumpseller.fulfillments_json, jumpseller.hooks_json, jumpseller.jsapps_json, jumpseller.orders_json, jumpseller.pages_json, jumpseller.payment_methods_json, jumpseller.products_json |
 | `justworks` | Justworks source | justworks.accounts, justworks.audit_events, justworks.policies, justworks.records, justworks.users |
 | `k6_cloud` | K6 Cloud source | k6_cloud.audit_events, k6_cloud.deployments, k6_cloud.projects, k6_cloud.repositories, k6_cloud.users |

--- a/sources/jumpcloud/PR_BODY.md
+++ b/sources/jumpcloud/PR_BODY.md
@@ -17,3 +17,4 @@
 - `go test ./sources/jumpcloud ./internal/sourceprojection -count=1`
 - `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
 - `make connector-catalog-review connector-api-discovery`
+- `make docs-drift-check oss-audit`

--- a/sources/jumpcloud/PR_BODY.md
+++ b/sources/jumpcloud/PR_BODY.md
@@ -1,16 +1,19 @@
 ## Summary
 
-- Adds the `jumpcloud` Source Runtime SDK scaffold.
-- Includes runtime adapter, health check, EvidenceCAS reference events, graph projection scaffolds, tests, and a source-health receipt.
+- Promotes the `jumpcloud` Source Runtime contract to provider-verified API proof.
+- Maps the runtime families to JumpCloud API v1, API v2, and Directory Insights endpoints.
+- Refreshes the source runtime notes and health receipt to match the implemented runtime.
 
-## Generated runtime contract
+## Runtime contract
 
 - Source type: `json_api`
 - Auth model: `api_key`
+- Auth mechanics: `x-api-key` header with optional `x-org-id`
 - Health endpoint: `/source-runtimes/health?source_id=jumpcloud`
-- Freshness: `24h0m0s`
+- Families: `users`, `groups`, `systems`, `applications`, `system_groups`, `group_members`, `audit_events`
 
 ## Tests
 
 - `go test ./sources/jumpcloud ./internal/sourceprojection -count=1`
-- `make catalog-check`
+- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
+- `make connector-catalog-review connector-api-discovery`

--- a/sources/jumpcloud/SOURCE_RUNTIME.md
+++ b/sources/jumpcloud/SOURCE_RUNTIME.md
@@ -1,11 +1,14 @@
 # JumpCloud
 
-Generated Source Runtime SDK scaffold for `jumpcloud`.
+Source Runtime adapter for JumpCloud directory, device, application, group membership, and Directory Insights event data.
 
 ## Runtime input
 
 - Source type: `json_api`
 - Auth model: `api_key`
+- Auth mechanics: `x-api-key` header with optional `x-org-id`
+- Base URL: `https://console.jumpcloud.com/api`
+- Directory Insights URL: `https://api.jumpcloud.com/insights/directory/v1`
 - Freshness expectation: `24h0m0s`
 - Failure modes: `api_error,auth_error,rate_limit,schema_drift`
 
@@ -14,15 +17,20 @@ Generated Source Runtime SDK scaffold for `jumpcloud`.
 - Adapter package: `sources/jumpcloud`
 - Health endpoint: `/source-runtimes/health?source_id=jumpcloud`
 - Source health receipt: `sources/jumpcloud/source_health_receipt.json`
-- EvidenceCAS reference kind: `jumpcloud.evidence_cas_reference`
+- Emits identity users, identity groups, managed systems, SSO applications, user-group membership edges, system groups, and audit events.
 
 ## Families
 
-- `users`, emits `jumpcloud.users`, reads `/v1/users`
-- `groups`, emits `jumpcloud.groups`, reads `/v1/groups`
-- `audit_events`, emits `jumpcloud.audit_events`, reads `/v1/audit/events`
+- `users`, emits `jumpcloud.users`, reads `GET /systemusers`
+- `groups`, emits `jumpcloud.groups`, reads `GET /v2/usergroups`
+- `systems`, emits `jumpcloud.systems`, reads `GET /systems`
+- `applications`, emits `jumpcloud.applications`, reads `GET /applications`
+- `system_groups`, emits `jumpcloud.system_groups`, reads `GET /v2/systemgroups`
+- `group_members`, emits `jumpcloud.group_members`, reads `GET /v2/usergroups/{group_id}/members`
+- `audit_events`, emits `jumpcloud.audit_events`, reads `POST https://api.jumpcloud.com/insights/directory/v1/events`
 
 ## Tests
 
 - `go test ./sources/jumpcloud ./internal/sourceprojection -count=1`
-- `make catalog-check`
+- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
+- `make connector-catalog-review connector-api-discovery`

--- a/sources/jumpcloud/catalog.yaml
+++ b/sources/jumpcloud/catalog.yaml
@@ -17,6 +17,70 @@ runtime_families:
   - system_groups
   - group_members
   - audit_events
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-07-04T00:00:00Z
+  transport: rest
+  auth: api_key
+  auth_mechanics: x_api_key_header_with_optional_x_org_id_header
+  base_url: https://console.jumpcloud.com/api
+  spec_url: https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/docs/SystemusersApi.md
+  spec_kind: api_reference_markdown
+  references:
+    - https://docs.jumpcloud.com/api/1.0/index.html
+    - https://docs.jumpcloud.com/api/2.0/index.html
+    - https://docs.jumpcloud.com/api/insights/directory/1.0/index.html
+    - https://jumpcloud.com/support/directory-insights-api
+    - https://github.com/TheJumpCloud/jcapi-python
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/README.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv2/README.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/docs/SystemusersApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/docs/SystemsApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/docs/ApplicationsApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv2/docs/UserGroupsApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv2/docs/SystemGroupsApi.md
+  auth_evidence:
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/README.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv2/README.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/docs/SystemusersApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv2/docs/UserGroupsApi.md
+  scope_evidence:
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/docs/SystemusersApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/docs/SystemsApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv1/docs/ApplicationsApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv2/docs/UserGroupsApi.md
+    - https://raw.githubusercontent.com/TheJumpCloud/jcapi-python/master/jcapiv2/docs/SystemGroupsApi.md
+    - https://jumpcloud.com/support/directory-insights-api
+  families:
+    - id: applications
+      method: GET
+      path: /applications
+      operation: applications_list
+    - id: audit_events
+      method: POST
+      path: https://api.jumpcloud.com/insights/directory/v1/events
+      operation: directory_insights_events
+    - id: group_members
+      method: GET
+      path: /v2/usergroups/{group_id}/members
+      operation: graph_user_group_members_list
+    - id: groups
+      method: GET
+      path: /v2/usergroups
+      operation: groups_user_list
+    - id: system_groups
+      method: GET
+      path: /v2/systemgroups
+      operation: groups_system_list
+    - id: systems
+      method: GET
+      path: /systems
+      operation: systems_list
+    - id: users
+      method: GET
+      path: /systemusers
+      operation: systemusers_list
 kind_lifecycle:
   - kind: jumpcloud.users
     status: active

--- a/sources/jumpcloud/source_health_receipt.json
+++ b/sources/jumpcloud/source_health_receipt.json
@@ -1,5 +1,5 @@
 {
-  "adapter_health_path": "/v2/systeminsights",
+  "adapter_health_path": "/systemusers?limit=1&skip=0",
   "auth_model": "api_key",
   "evidence_cas_reference_kind": "jumpcloud.evidence_cas_reference",
   "expected_cadence_seconds": 86400,


### PR DESCRIPTION
## Summary

- Promotes the `jumpcloud` Source Runtime contract to provider-verified API proof.
- Maps the runtime families to JumpCloud API v1, API v2, and Directory Insights endpoints.
- Refreshes the source runtime notes and health receipt to match the implemented runtime.

## Runtime contract

- Source type: `json_api`
- Auth model: `api_key`
- Auth mechanics: `x-api-key` header with optional `x-org-id`
- Health endpoint: `/source-runtimes/health?source_id=jumpcloud`
- Families: `users`, `groups`, `systems`, `applications`, `system_groups`, `group_members`, `audit_events`

## Tests

- `go test ./sources/jumpcloud ./internal/sourceprojection -count=1`
- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
- `make connector-catalog-review connector-api-discovery`
- `make docs-drift-check oss-audit`
