### PR TITLE
Add agent-friendly API context and tasks

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -121,6 +121,141 @@ paths:
                 $ref: '#/components/schemas/A2AJSONRPCResponse'
         '400':
           description: Malformed JSON-RPC request body.
+  /api/v1/agent/context:
+    get:
+      operationId: getAgentContext
+      summary: Get agent workflow context
+      tags:
+        - Platform
+      responses:
+        '200':
+          description: Agent-facing auth discovery, caller context, mutation contract, telemetry labels, and workflow next actions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentContextResponse'
+        '401':
+          description: Missing or invalid credential. Response body includes auth discovery and required scope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthErrorResponse'
+  /api/v1/agent/tasks/findings/{findingID}/explain:
+    post:
+      operationId: explainFindingForAgent
+      summary: Plan a finding explanation task
+      tags:
+        - Platform
+        - Findings
+      parameters:
+        - $ref: '#/components/parameters/findingID'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentTaskRequest'
+      responses:
+        '200':
+          description: Authorized finding explanation plan with evidence and graph reasoning next actions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTaskResponse'
+  /api/v1/agent/tasks/findings/{findingID}/triage:
+    post:
+      operationId: triageFindingForAgent
+      summary: Plan a finding triage task
+      tags:
+        - Platform
+        - Findings
+      parameters:
+        - $ref: '#/components/parameters/findingID'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentTaskRequest'
+      responses:
+        '200':
+          description: Authorized finding triage plan with lifecycle next actions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTaskResponse'
+  /api/v1/agent/tasks/findings/{findingID}/audit-packet:
+    post:
+      operationId: buildFindingAuditPacketForAgent
+      summary: Plan a finding audit packet task
+      tags:
+        - Platform
+        - Findings
+      parameters:
+        - $ref: '#/components/parameters/findingID'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentTaskRequest'
+      responses:
+        '200':
+          description: Authorized audit packet plan with evidence packet and control packet next actions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTaskResponse'
+  /api/v1/agent/tasks/source-runtimes/{runtimeID}/retry:
+    post:
+      operationId: retrySourceRuntimeForAgent
+      summary: Plan or execute a source runtime retry task
+      description: Returns a dry-run plan by default. Mutating retry execution requires approved=true, dry_run=false, and the source runtime write scope.
+      tags:
+        - Platform
+        - Sources
+      parameters:
+        - $ref: '#/components/parameters/runtimeID'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentTaskRequest'
+      responses:
+        '200':
+          description: Runtime retry plan or execution result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTaskResponse'
+        '403':
+          description: Approved execution is missing the source runtime write scope.
+  /api/v1/agent/tasks/reports/{reportID}/run:
+    post:
+      operationId: runReportForAgent
+      summary: Plan or execute a report run task
+      description: Returns a dry-run plan by default. Mutating report execution requires approved=true, dry_run=false, and the report run scope.
+      tags:
+        - Platform
+        - Reports
+      parameters:
+        - $ref: '#/components/parameters/reportID'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentTaskRequest'
+      responses:
+        '200':
+          description: Report run plan or execution result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTaskResponse'
+        '403':
+          description: Approved execution is missing the report run scope.
   /api/v1/agent-platform/contract:
     get:
       operationId: getAgentPlatformContract
@@ -7109,6 +7244,260 @@ components:
         data:
           type: object
           additionalProperties: true
+    AgentContextResponse:
+      type: object
+      required:
+        - version
+        - links
+        - auth
+        - caller
+        - mutation_contract
+        - telemetry
+        - workflows
+      properties:
+        version:
+          type: string
+        links:
+          type: object
+          additionalProperties:
+            type: string
+        auth:
+          $ref: '#/components/schemas/AgentAuthDiscovery'
+        caller:
+          $ref: '#/components/schemas/AgentCallerContext'
+        mutation_contract:
+          $ref: '#/components/schemas/AgentMutationContract'
+        telemetry:
+          $ref: '#/components/schemas/AgentTelemetryContext'
+        workflows:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentWorkflow'
+    AgentAuthDiscovery:
+      type: object
+      properties:
+        schemes:
+          type: array
+          items:
+            type: string
+        protected_resource_metadata:
+          type: string
+        authorization_server:
+          type: string
+        token_endpoint:
+          type: string
+        required_default_scope:
+          type: string
+        supported_scopes:
+          type: array
+          items:
+            type: string
+    AgentCallerContext:
+      type: object
+      properties:
+        authenticated:
+          type: boolean
+        tenant_id:
+          type: string
+        actor_id:
+          type: string
+        auth_mode:
+          type: string
+        actor_type:
+          type: string
+          enum: [human, agent, service, automation, unknown]
+        scopes:
+          type: array
+          items:
+            type: string
+        user_agent:
+          type: string
+    AgentMutationContract:
+      type: object
+      properties:
+        dry_run_field:
+          type: string
+        approval_field:
+          type: string
+        idempotency:
+          type: string
+        default_behavior:
+          type: string
+        execution_rules:
+          type: array
+          items:
+            type: string
+        supported_actions:
+          type: array
+          items:
+            type: string
+    AgentTelemetryContext:
+      type: object
+      properties:
+        actor_type_attribute:
+          type: string
+        user_agent_attribute:
+          type: string
+        request_headers:
+          type: array
+          items:
+            type: string
+    AgentWorkflow:
+      type: object
+      required:
+        - id
+        - resource
+        - state_check
+        - next_actions
+      properties:
+        id:
+          type: string
+        resource:
+          type: string
+        state_check:
+          $ref: '#/components/schemas/AgentNextAction'
+        next_actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentNextAction'
+        slack_bot_intent:
+          type: string
+    AgentNextAction:
+      type: object
+      required:
+        - id
+        - label
+        - method
+        - path
+        - required_scope
+        - stage
+        - when
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        method:
+          type: string
+          enum: [GET, POST, PUT, PATCH, DELETE]
+        path:
+          type: string
+        required_scope:
+          type: string
+        stage:
+          type: string
+          enum: [observe, explain, recommend, dry_run, execute, close_loop]
+        dry_run_supported:
+          type: boolean
+        approval_required:
+          type: boolean
+        when:
+          type: string
+    AgentTaskRequest:
+      type: object
+      properties:
+        tenant_id:
+          type: string
+        dry_run:
+          type: boolean
+          description: When true, return the plan and do not mutate state.
+        approved:
+          type: boolean
+          description: Required as true for approved execution on task routes that can mutate state.
+        reason:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        idempotency_key:
+          type: string
+    AgentTaskResponse:
+      type: object
+      required:
+        - id
+        - kind
+        - status
+        - resource
+        - dry_run
+        - approved
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+        status:
+          type: string
+          enum: [planned, dry_run, succeeded]
+        resource:
+          $ref: '#/components/schemas/AgentResourceRef'
+        dry_run:
+          type: boolean
+        approved:
+          type: boolean
+        reason:
+          type: string
+        mutation:
+          $ref: '#/components/schemas/AgentMutationRef'
+        next_actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentNextAction'
+        result:
+          type: object
+          additionalProperties: true
+    AgentResourceRef:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+        path:
+          type: string
+    AgentMutationRef:
+      type: object
+      properties:
+        method:
+          type: string
+        path:
+          type: string
+        required_scope:
+          type: string
+        approval_required:
+          type: boolean
+        dry_run_supported:
+          type: boolean
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+    AuthErrorResponse:
+      type: object
+      required:
+        - error
+        - status
+        - next_action
+        - auth
+      properties:
+        error:
+          type: string
+        status:
+          type: integer
+        method:
+          type: string
+        path:
+          type: string
+        retryable:
+          type: boolean
+        next_action:
+          type: string
+        required_scope:
+          type: string
+        required_role:
+          type: string
+        auth:
+          $ref: '#/components/schemas/AgentAuthDiscovery'
     A2AProtocolContract:
       type: object
       required:

--- a/internal/bootstrap/agent_context.go
+++ b/internal/bootstrap/agent_context.go
@@ -2,172 +2,54 @@ package bootstrap
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"strconv"
 	"strings"
-	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
-	"github.com/writer/cerebro/internal/agentplatform"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/reports"
+	"github.com/writer/cerebro/internal/sourcehttp/agenttasks"
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
-const agentContextPath = "/api/v1/agent/context"
+const agentContextPath = agenttasks.ContextPath
 
-type agentContextResponse struct {
-	Version          string                `json:"version"`
-	Links            map[string]string     `json:"links"`
-	Auth             agentAuthDiscovery    `json:"auth"`
-	Caller           agentCallerContext    `json:"caller"`
-	MutationContract agentMutationContract `json:"mutation_contract"`
-	Telemetry        agentTelemetryContext `json:"telemetry"`
-	Workflows        []agentWorkflow       `json:"workflows"`
-}
-
-type agentAuthDiscovery struct {
-	Schemes                   []string `json:"schemes"`
-	ProtectedResourceMetadata string   `json:"protected_resource_metadata"`
-	AuthorizationServer       string   `json:"authorization_server"`
-	TokenEndpoint             string   `json:"token_endpoint"`
-	RequiredDefaultScope      string   `json:"required_default_scope"`
-	SupportedScopes           []string `json:"supported_scopes"`
-}
-
-type agentCallerContext struct {
-	Authenticated bool     `json:"authenticated"`
-	TenantID      string   `json:"tenant_id,omitempty"`
-	ActorID       string   `json:"actor_id,omitempty"`
-	AuthMode      string   `json:"auth_mode,omitempty"`
-	ActorType     string   `json:"actor_type"`
-	Scopes        []string `json:"scopes,omitempty"`
-	UserAgent     string   `json:"user_agent"`
-}
-
-type agentMutationContract struct {
-	DryRunField      string   `json:"dry_run_field"`
-	ApprovalField    string   `json:"approval_field"`
-	Idempotency      string   `json:"idempotency"`
-	DefaultBehavior  string   `json:"default_behavior"`
-	ExecutionRules   []string `json:"execution_rules"`
-	SupportedActions []string `json:"supported_actions"`
-}
-
-type agentTelemetryContext struct {
-	ActorTypeAttribute string   `json:"actor_type_attribute"`
-	UserAgentAttribute string   `json:"user_agent_attribute"`
-	RequestHeaders     []string `json:"request_headers"`
-}
-
-type agentWorkflow struct {
-	ID             string            `json:"id"`
-	Resource       string            `json:"resource"`
-	StateCheck     agentNextAction   `json:"state_check"`
-	NextActions    []agentNextAction `json:"next_actions"`
-	SlackBotIntent string            `json:"slack_bot_intent,omitempty"`
-}
-
-type agentNextAction struct {
-	ID               string `json:"id"`
-	Label            string `json:"label"`
-	Method           string `json:"method"`
-	Path             string `json:"path"`
-	RequiredScope    string `json:"required_scope"`
-	Stage            string `json:"stage"`
-	DryRunSupported  bool   `json:"dry_run_supported,omitempty"`
-	ApprovalRequired bool   `json:"approval_required,omitempty"`
-	When             string `json:"when"`
-}
-
-type agentTaskRequest struct {
-	TenantID    string            `json:"tenant_id,omitempty"`
-	DryRun      bool              `json:"dry_run,omitempty"`
-	Approved    bool              `json:"approved,omitempty"`
-	Reason      string            `json:"reason,omitempty"`
-	Parameters  map[string]string `json:"parameters,omitempty"`
-	Idempotency string            `json:"idempotency_key,omitempty"`
-}
-
-type agentTaskResponse struct {
-	ID          string            `json:"id"`
-	Kind        string            `json:"kind"`
-	Status      string            `json:"status"`
-	Resource    agentResourceRef  `json:"resource"`
-	DryRun      bool              `json:"dry_run"`
-	Approved    bool              `json:"approved"`
-	Reason      string            `json:"reason,omitempty"`
-	Mutation    *agentMutationRef `json:"mutation,omitempty"`
-	NextActions []agentNextAction `json:"next_actions,omitempty"`
-	Result      map[string]any    `json:"result,omitempty"`
-}
-
-type agentResourceRef struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
-	Path string `json:"path"`
-}
-
-type agentMutationRef struct {
-	Method           string            `json:"method"`
-	Path             string            `json:"path"`
-	RequiredScope    string            `json:"required_scope"`
-	ApprovalRequired bool              `json:"approval_required"`
-	DryRunSupported  bool              `json:"dry_run_supported"`
-	Parameters       map[string]string `json:"parameters,omitempty"`
-}
-
-func (a *App) handleAgentContext(w http.ResponseWriter, r *http.Request) {
-	origin := strings.TrimRight(externalOrigin(r, a.cfg.Auth.RequestOrigin), "/")
-	if origin == "" {
-		origin = "https://cerebro"
-	}
-	writeJSON(w, http.StatusOK, agentContextResponse{
-		Version: agentplatform.ContractVersion,
-		Links: map[string]string{
-			"openapi":             origin + "/openapi.yaml",
-			"agent_card":          origin + agentplatform.A2AAgentCardPath,
-			"agent_platform":      origin + "/api/v1/agent-platform/contract",
-			"capabilities":        origin + "/api/v1/agent-platform/capabilities",
-			"event_subscriptions": origin + agentplatform.EventSubscriptionContractPath,
-			"idempotency":         origin + agentplatform.IdempotencyContractPath,
+func (a *App) agentTaskHandler() agenttasks.Handler {
+	return agenttasks.New(agenttasks.Dependencies{
+		Origin:                       func(r *http.Request) string { return externalOrigin(r, a.cfg.Auth.RequestOrigin) },
+		Caller:                       agentCallerContextForRequest,
+		SupportedScopes:              supportedOAuthScopes,
+		OAuthProtectedResourcePath:   oauthProtectedResourceMetadataPath,
+		OAuthAuthorizationServerPath: oauthAuthorizationServerMetadataPath,
+		OAuthTokenPath:               oauthTokenPath,
+		Scopes: agenttasks.ScopeSet{
+			SecurityRead:          scopeCosmoSecurityRead,
+			GraphActionsWrite:     scopeGraphActionsWrite,
+			FindingLifecycleWrite: scopeFindingLifecycleWrite,
+			SourceRuntimesWrite:   scopeSourceRuntimesWrite,
+			ReportsRun:            scopeReportsRun,
 		},
-		Auth:             agentAuthDiscoveryForOrigin(origin),
-		Caller:           agentCallerContextForRequest(r),
-		MutationContract: agentMutationContractForContext(),
-		Telemetry: agentTelemetryContext{
-			ActorTypeAttribute: "client.actor_type",
-			UserAgentAttribute: "user_agent.family",
-			RequestHeaders:     []string{"User-Agent", "X-Request-Id", "X-Cerebro-Tenant", "Idempotency-Key"},
+		AuthorizeFinding: func(ctx context.Context, findingID string) error {
+			return normalizeIDLookupError(authorizeFindingIDTenant(ctx, findingStore(a.deps.StateStore), findingID), ports.ErrFindingNotFound)
 		},
-		Workflows: agentWorkflows(),
+		AuthorizeSourceRuntime: func(ctx context.Context, runtimeID string) error {
+			return normalizeIDLookupError(authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(a.deps.StateStore), runtimeID), ports.ErrSourceRuntimeNotFound)
+		},
+		AuthorizeTenant:         authorizeTenantID,
+		AuthorizeExecutionScope: authorizeAgentTaskExecutionScope,
+		SyncRuntime:             a.syncAgentTaskRuntime,
+		RunReport:               a.runAgentTaskReport,
+		ErrorStatus:             agentTaskErrorStatus,
 	})
 }
 
-func agentAuthDiscoveryForOrigin(origin string) agentAuthDiscovery {
-	origin = strings.TrimRight(strings.TrimSpace(origin), "/")
-	if origin == "" {
-		origin = "https://cerebro"
-	}
-	return agentAuthDiscovery{
-		Schemes:                   []string{"Authorization: Bearer <token>", "X-Cerebro-API-Key: <key>"},
-		ProtectedResourceMetadata: origin + oauthProtectedResourceMetadataPath,
-		AuthorizationServer:       origin + oauthAuthorizationServerMetadataPath,
-		TokenEndpoint:             origin + oauthTokenPath,
-		RequiredDefaultScope:      scopeCosmoSecurityRead,
-		SupportedScopes:           supportedOAuthScopes(),
-	}
-}
-
-func agentCallerContextForRequest(r *http.Request) agentCallerContext {
-	ctx := agentCallerContext{
-		ActorType: agentActorTypeFromUserAgent(requestHeaderValue(r, "User-Agent")),
-		UserAgent: userAgentFamilyValue(requestHeaderValue(r, "User-Agent")),
+func agentCallerContextForRequest(r *http.Request) agenttasks.CallerContext {
+	userAgent := requestHeaderValue(r, "User-Agent")
+	ctx := agenttasks.CallerContext{
+		ActorType: agenttasks.ActorTypeFromUserAgent(userAgent),
+		UserAgent: agenttasks.UserAgentFamily(userAgent),
 	}
 	if r == nil {
 		return ctx
@@ -182,7 +64,7 @@ func agentCallerContextForRequest(r *http.Request) agentCallerContext {
 	ctx.AuthMode = strings.TrimSpace(auth.principal.AuthMode)
 	ctx.Scopes = expandedPrincipalScopes(auth.principal)
 	if ctx.ActorType == "unknown" || ctx.ActorType == "automation" {
-		ctx.ActorType = agentActorTypeFromPrincipal(auth.principal, requestHeaderValue(r, "User-Agent"))
+		ctx.ActorType = agentActorTypeFromPrincipal(auth.principal, userAgent)
 	}
 	return ctx
 }
@@ -194,82 +76,7 @@ func agentActorTypeFromPrincipal(principal authPrincipal, userAgent string) stri
 	case "api_credential", "capability_token":
 		return "service"
 	}
-	return agentActorTypeFromUserAgent(userAgent)
-}
-
-func agentActorTypeFromUserAgent(value string) string {
-	normalized := strings.ToLower(strings.TrimSpace(value))
-	switch {
-	case normalized == "":
-		return "unknown"
-	case strings.Contains(normalized, "codex"),
-		strings.Contains(normalized, "openai"),
-		strings.Contains(normalized, "mcp"),
-		strings.Contains(normalized, "langchain"),
-		strings.Contains(normalized, "autogen"),
-		strings.Contains(normalized, "crewai"),
-		strings.Contains(normalized, "claude"),
-		strings.Contains(normalized, "anthropic"):
-		return "agent"
-	case strings.Contains(normalized, "bot"),
-		strings.Contains(normalized, "crawler"),
-		strings.Contains(normalized, "spider"):
-		return "agent"
-	case strings.Contains(normalized, "mozilla") &&
-		(strings.Contains(normalized, "chrome") || strings.Contains(normalized, "safari") || strings.Contains(normalized, "firefox") || strings.Contains(normalized, "edg/")):
-		return "human"
-	case strings.Contains(normalized, "curl"),
-		strings.Contains(normalized, "httpie"),
-		strings.Contains(normalized, "wget"),
-		strings.Contains(normalized, "python-requests"),
-		strings.Contains(normalized, "go-http-client"),
-		strings.Contains(normalized, "node-fetch"),
-		strings.Contains(normalized, "axios"),
-		strings.Contains(normalized, "postman"):
-		return "automation"
-	default:
-		return "unknown"
-	}
-}
-
-func userAgentFamilyValue(value string) string {
-	normalized := strings.ToLower(strings.TrimSpace(value))
-	switch {
-	case normalized == "":
-		return "none"
-	case strings.Contains(normalized, "codex"):
-		return "codex"
-	case strings.Contains(normalized, "openai"):
-		return "openai"
-	case strings.Contains(normalized, "mcp"):
-		return "mcp"
-	case strings.Contains(normalized, "slack"):
-		return "slack"
-	case strings.Contains(normalized, "bot"), strings.Contains(normalized, "crawler"), strings.Contains(normalized, "spider"):
-		return "bot"
-	case strings.Contains(normalized, "edge"), strings.Contains(normalized, "edg/"):
-		return "edge"
-	case strings.Contains(normalized, "chrome"):
-		return "chrome"
-	case strings.Contains(normalized, "safari"):
-		return "safari"
-	case strings.Contains(normalized, "firefox"):
-		return "firefox"
-	case strings.Contains(normalized, "curl"):
-		return "curl"
-	case strings.Contains(normalized, "python-requests"):
-		return "python-requests"
-	case strings.Contains(normalized, "go-http-client"):
-		return "go-http-client"
-	case strings.Contains(normalized, "node-fetch"):
-		return "node-fetch"
-	case strings.Contains(normalized, "axios"):
-		return "axios"
-	case strings.Contains(normalized, "postman"):
-		return "postman"
-	default:
-		return "other"
-	}
+	return agenttasks.ActorTypeFromUserAgent(userAgent)
 }
 
 func requestHeaderValue(r *http.Request, key string) string {
@@ -277,309 +84,6 @@ func requestHeaderValue(r *http.Request, key string) string {
 		return ""
 	}
 	return r.Header.Get(key)
-}
-
-func agentMutationContractForContext() agentMutationContract {
-	return agentMutationContract{
-		DryRunField:     "dry_run",
-		ApprovalField:   "approved",
-		Idempotency:     "Use Idempotency-Key or idempotency_key on approved writes that may be retried.",
-		DefaultBehavior: "Agent task endpoints return a plan unless approved=true and dry_run is false.",
-		ExecutionRules: []string{
-			"Read and explain actions require the read scope only.",
-			"Mutating runtime and report tasks require their dedicated write scope.",
-			"Provider-backed graph actions support dry_run=true and require approved=true before execution.",
-			"Finding lifecycle updates stay on typed finding endpoints and require the finding lifecycle write scope.",
-		},
-		SupportedActions: []string{
-			"identity.okta.suspend_user",
-			"identity.okta.unsuspend_user",
-			"endpoint.cerebro.revoke_device",
-		},
-	}
-}
-
-func agentWorkflows() []agentWorkflow {
-	return []agentWorkflow{
-		{
-			ID:         "finding_triage",
-			Resource:   "finding",
-			StateCheck: agentNextAction{ID: "read_finding", Label: "Read finding", Method: http.MethodGet, Path: "/findings/{findingID}", RequiredScope: scopeCosmoSecurityRead, Stage: "observe", When: "Start here before changing finding state."},
-			NextActions: []agentNextAction{
-				{ID: "explain_finding", Label: "Explain finding", Method: http.MethodPost, Path: "/api/v1/agent/tasks/findings/{findingID}/explain", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use when a bot needs a short packet for a channel or review thread."},
-				{ID: "triage_finding", Label: "Prepare triage", Method: http.MethodPost, Path: "/api/v1/agent/tasks/findings/{findingID}/triage", RequiredScope: scopeCosmoSecurityRead, Stage: "recommend", When: "Use when the next owner, due date, note, or ticket is not decided yet."},
-				{ID: "plan_graph_action", Label: "Dry-run graph action", Method: http.MethodPost, Path: "/platform/graph/actions", RequiredScope: scopeGraphActionsWrite, Stage: "dry_run", DryRunSupported: true, ApprovalRequired: true, When: "Use for provider-backed actions tied to an eligible finding."},
-			},
-			SlackBotIntent: "Post finding summary, owner, evidence, and proposed next step.",
-		},
-		{
-			ID:         "control_packet",
-			Resource:   "control",
-			StateCheck: agentNextAction{ID: "read_controls", Label: "Read controls", Method: http.MethodGet, Path: "/grc/controls", RequiredScope: scopeCosmoSecurityRead, Stage: "observe", When: "Use before collecting evidence for control status."},
-			NextActions: []agentNextAction{
-				{ID: "build_control_packet", Label: "Build control packet", Method: http.MethodGet, Path: "/grc/control-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use when the team needs evidence and gaps for a control."},
-				{ID: "custom_control_packet", Label: "Build scoped packet", Method: http.MethodPost, Path: "/grc/control-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use when the bot has a specific framework, control, or evidence scope."},
-			},
-			SlackBotIntent: "Post control status, missing evidence, stale evidence, and owners.",
-		},
-		{
-			ID:         "report_run",
-			Resource:   "report",
-			StateCheck: agentNextAction{ID: "list_reports", Label: "List reports", Method: http.MethodGet, Path: "/reports", RequiredScope: scopeCosmoSecurityRead, Stage: "observe", When: "Use before selecting a report id."},
-			NextActions: []agentNextAction{
-				{ID: "plan_report_run", Label: "Plan report run", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/{reportID}/run", RequiredScope: scopeCosmoSecurityRead, Stage: "dry_run", DryRunSupported: true, When: "Use when a bot needs to show parameters before running a report."},
-				{ID: "run_report", Label: "Run report", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/{reportID}/run", RequiredScope: scopeReportsRun, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Use after a human approves the report parameters."},
-			},
-			SlackBotIntent: "Post report parameters, run status, and link to the report run.",
-		},
-		{
-			ID:         "runtime_retry",
-			Resource:   "source_runtime",
-			StateCheck: agentNextAction{ID: "read_runtime", Label: "Read runtime", Method: http.MethodGet, Path: "/source-runtimes/{runtimeID}", RequiredScope: scopeCosmoSecurityRead, Stage: "observe", When: "Use before retrying a runtime."},
-			NextActions: []agentNextAction{
-				{ID: "plan_runtime_retry", Label: "Plan runtime retry", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", RequiredScope: scopeCosmoSecurityRead, Stage: "dry_run", DryRunSupported: true, When: "Use when a runtime is stale or failed and the bot needs the exact retry call."},
-				{ID: "retry_runtime", Label: "Retry runtime", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", RequiredScope: scopeSourceRuntimesWrite, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Use after a human approves the retry."},
-			},
-			SlackBotIntent: "Post runtime status, last sync, failure reason, and retry plan.",
-		},
-	}
-}
-
-func (a *App) handleAgentFindingExplainTask(w http.ResponseWriter, r *http.Request) {
-	findingID := r.PathValue("findingID")
-	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), findingID); err != nil {
-		writeAgentTaskError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
-		return
-	}
-	req, err := readAgentTaskRequest(w, r)
-	if err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	response := baseAgentTaskResponse("finding_explain", "finding", findingID, "/findings/"+findingID, req)
-	response.Status = "planned"
-	response.NextActions = findingAgentNextActions(findingID)
-	response.Result = map[string]any{
-		"read_path":        "/findings/" + findingID,
-		"evidence_request": "/api/v1/agent-platform/evidence-packets",
-		"graph_reason":     "/api/v1/agent-platform/graph/reason",
-	}
-	writeJSON(w, http.StatusOK, response)
-}
-
-func (a *App) handleAgentFindingTriageTask(w http.ResponseWriter, r *http.Request) {
-	findingID := r.PathValue("findingID")
-	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), findingID); err != nil {
-		writeAgentTaskError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
-		return
-	}
-	req, err := readAgentTaskRequest(w, r)
-	if err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	response := baseAgentTaskResponse("finding_triage", "finding", findingID, "/findings/"+findingID, req)
-	response.Status = "planned"
-	response.NextActions = findingAgentNextActions(findingID)
-	response.Result = map[string]any{
-		"lifecycle_paths": []string{
-			"/findings/" + findingID + "/assign",
-			"/findings/" + findingID + "/due",
-			"/findings/" + findingID + "/notes",
-			"/findings/" + findingID + "/tickets",
-			"/findings/" + findingID + "/resolve",
-			"/findings/" + findingID + "/suppress",
-		},
-	}
-	writeJSON(w, http.StatusOK, response)
-}
-
-func (a *App) handleAgentFindingAuditPacketTask(w http.ResponseWriter, r *http.Request) {
-	findingID := r.PathValue("findingID")
-	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), findingID); err != nil {
-		writeAgentTaskError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
-		return
-	}
-	req, err := readAgentTaskRequest(w, r)
-	if err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	response := baseAgentTaskResponse("finding_audit_packet", "finding", findingID, "/findings/"+findingID, req)
-	response.Status = "planned"
-	response.NextActions = []agentNextAction{
-		{ID: "build_evidence_packet", Label: "Build evidence packet", Method: http.MethodPost, Path: "/api/v1/agent-platform/evidence-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use scope_urn for the finding and include evidence URNs when known."},
-		{ID: "read_control_packets", Label: "Read control packets", Method: http.MethodGet, Path: "/grc/control-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use when the finding maps to framework controls."},
-	}
-	response.Result = map[string]any{
-		"scope_urn": "urn:cerebro:{tenant}:finding:" + findingID,
-	}
-	writeJSON(w, http.StatusOK, response)
-}
-
-func (a *App) handleAgentSourceRuntimeRetryTask(w http.ResponseWriter, r *http.Request) {
-	runtimeID := r.PathValue("runtimeID")
-	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), runtimeID); err != nil {
-		writeAgentTaskError(w, normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
-		return
-	}
-	req, err := readAgentTaskRequest(w, r)
-	if err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	response := baseAgentTaskResponse("source_runtime_retry", "source_runtime", runtimeID, "/source-runtimes/"+runtimeID, req)
-	response.Mutation = &agentMutationRef{
-		Method:           http.MethodPost,
-		Path:             "/source-runtimes/" + runtimeID + "/sync",
-		RequiredScope:    scopeSourceRuntimesWrite,
-		ApprovalRequired: true,
-		DryRunSupported:  true,
-		Parameters:       req.Parameters,
-	}
-	if req.DryRun || !req.Approved {
-		response.Status = "dry_run"
-		response.DryRun = true
-		response.NextActions = []agentNextAction{
-			{ID: "approve_runtime_retry", Label: "Approve runtime retry", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/" + runtimeID + "/retry", RequiredScope: scopeSourceRuntimesWrite, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Call with approved=true after review."},
-		}
-		writeJSON(w, http.StatusOK, response)
-		return
-	}
-	if err := authorizeAgentTaskExecutionScope(r.Context(), scopeSourceRuntimesWrite); err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	pageLimit, err := pageLimitFromTask(req)
-	if err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	syncResp, err := a.runtimeService().SyncWithLease(r.Context(), &cerebrov1.SyncSourceRuntimeRequest{Id: runtimeID, PageLimit: pageLimit}, sourceruntime.SyncWithLeaseOptions{
-		LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore),
-	})
-	if err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	response.Status = "succeeded"
-	response.Result = map[string]any{
-		"runtime_id":         syncResp.GetRuntime().GetId(),
-		"pages_read":         syncResp.GetPagesRead(),
-		"events_appended":    syncResp.GetEventsAppended(),
-		"entities_projected": syncResp.GetEntitiesProjected(),
-		"links_projected":    syncResp.GetLinksProjected(),
-	}
-	writeJSON(w, http.StatusOK, response)
-}
-
-func (a *App) handleAgentReportRunTask(w http.ResponseWriter, r *http.Request) {
-	reportID := r.PathValue("reportID")
-	req, err := readAgentTaskRequest(w, r)
-	if err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	if tenantID := strings.TrimSpace(firstNonEmpty(req.TenantID, req.Parameters["tenant_id"])); tenantID != "" {
-		if err := authorizeTenantID(r.Context(), tenantID); err != nil {
-			writeAgentTaskError(w, err)
-			return
-		}
-	}
-	response := baseAgentTaskResponse("report_run", "report", reportID, "/reports/"+reportID+"/runs", req)
-	response.Mutation = &agentMutationRef{
-		Method:           http.MethodPost,
-		Path:             "/reports/" + reportID + "/runs",
-		RequiredScope:    scopeReportsRun,
-		ApprovalRequired: true,
-		DryRunSupported:  true,
-		Parameters:       req.Parameters,
-	}
-	if req.DryRun || !req.Approved {
-		response.Status = "dry_run"
-		response.DryRun = true
-		response.NextActions = []agentNextAction{
-			{ID: "approve_report_run", Label: "Approve report run", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/" + reportID + "/run", RequiredScope: scopeReportsRun, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Call with approved=true after checking report parameters."},
-		}
-		writeJSON(w, http.StatusOK, response)
-		return
-	}
-	if err := authorizeAgentTaskExecutionScope(r.Context(), scopeReportsRun); err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	runResp, err := a.reportService().Run(r.Context(), &cerebrov1.RunReportRequest{ReportId: reportID, Parameters: req.Parameters})
-	if err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	if err := authorizeTenantID(r.Context(), runResp.GetRun().GetParameters()["tenant_id"]); err != nil {
-		writeAgentTaskError(w, err)
-		return
-	}
-	response.Status = "succeeded"
-	response.Result = map[string]any{
-		"report_id":    runResp.GetRun().GetReportId(),
-		"run_id":       runResp.GetRun().GetId(),
-		"status":       runResp.GetRun().GetStatus(),
-		"generated_at": agentTaskTimestampString(runResp.GetRun().GetGeneratedAt()),
-	}
-	writeJSON(w, http.StatusOK, response)
-}
-
-func baseAgentTaskResponse(kind string, resourceType string, resourceID string, path string, req agentTaskRequest) agentTaskResponse {
-	return agentTaskResponse{
-		ID:       "agent-task:" + kind + ":" + resourceID,
-		Kind:     kind,
-		Status:   "planned",
-		Resource: agentResourceRef{Type: resourceType, ID: resourceID, Path: path},
-		DryRun:   req.DryRun,
-		Approved: req.Approved,
-		Reason:   strings.TrimSpace(req.Reason),
-	}
-}
-
-func findingAgentNextActions(findingID string) []agentNextAction {
-	return []agentNextAction{
-		{ID: "build_evidence_packet", Label: "Build evidence packet", Method: http.MethodPost, Path: "/api/v1/agent-platform/evidence-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use before posting a finding summary or making a recommendation."},
-		{ID: "add_note", Label: "Add finding note", Method: http.MethodPost, Path: "/findings/" + findingID + "/notes", RequiredScope: scopeFindingLifecycleWrite, Stage: "close_loop", ApprovalRequired: true, When: "Use after the team approves the note text."},
-		{ID: "link_ticket", Label: "Link ticket", Method: http.MethodPost, Path: "/findings/" + findingID + "/tickets", RequiredScope: scopeFindingLifecycleWrite, Stage: "close_loop", ApprovalRequired: true, When: "Use when a remediation ticket already exists."},
-		{ID: "dry_run_graph_action", Label: "Dry-run graph action", Method: http.MethodPost, Path: "/platform/graph/actions", RequiredScope: scopeGraphActionsWrite, Stage: "dry_run", DryRunSupported: true, ApprovalRequired: true, When: "Use for supported provider actions attached to the finding."},
-	}
-}
-
-func readAgentTaskRequest(w http.ResponseWriter, r *http.Request) (agentTaskRequest, error) {
-	request := agentTaskRequest{Parameters: map[string]string{}}
-	if r == nil || r.Body == nil {
-		return request, nil
-	}
-	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&request); err != nil {
-		if errors.Is(err, io.EOF) {
-			return request, nil
-		}
-		return agentTaskRequest{}, fmt.Errorf("%w: decode agent task request: %w", errInvalidHTTPRequest, err)
-	}
-	if request.Parameters == nil {
-		request.Parameters = map[string]string{}
-	}
-	return request, nil
-}
-
-func pageLimitFromTask(req agentTaskRequest) (uint32, error) {
-	raw := strings.TrimSpace(req.Parameters["page_limit"])
-	if raw == "" {
-		return 0, nil
-	}
-	value, err := strconv.ParseUint(raw, 10, 32)
-	if err != nil {
-		return 0, fmt.Errorf("%w: page_limit must be a positive integer", errInvalidHTTPRequest)
-	}
-	if value == 0 {
-		return 0, fmt.Errorf("%w: page_limit must be a positive integer", errInvalidHTTPRequest)
-	}
-	return uint32(value), nil
 }
 
 func authorizeAgentTaskExecutionScope(ctx context.Context, required string) error {
@@ -590,28 +94,53 @@ func authorizeAgentTaskExecutionScope(ctx context.Context, required string) erro
 	return authorizePrincipalScope(auth.principal, required)
 }
 
-func writeAgentTaskError(w http.ResponseWriter, err error) {
-	status := http.StatusInternalServerError
-	switch {
-	case errors.Is(err, errInvalidHTTPRequest), errors.Is(err, reports.ErrInvalidRequest), errors.Is(err, sourceruntime.ErrInvalidRequest):
-		status = http.StatusBadRequest
-	case errors.Is(err, errTenantForbidden), errors.Is(err, errScopeForbidden):
-		status = http.StatusForbidden
-	case errors.Is(err, ports.ErrFindingNotFound), errors.Is(err, ports.ErrSourceRuntimeNotFound):
-		status = http.StatusNotFound
-	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable), errors.Is(err, reports.ErrRuntimeUnavailable), errors.Is(err, findings.ErrRuntimeUnavailable):
-		status = http.StatusServiceUnavailable
+func (a *App) syncAgentTaskRuntime(ctx context.Context, runtimeID string, pageLimit uint32) (agenttasks.RuntimeSyncResult, error) {
+	syncResp, err := a.runtimeService().SyncWithLease(ctx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtimeID, PageLimit: pageLimit}, sourceruntime.SyncWithLeaseOptions{
+		LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore),
+	})
+	if err != nil {
+		return agenttasks.RuntimeSyncResult{}, err
 	}
-	writeJSON(w, status, map[string]any{"error": err.Error()})
+	return agenttasks.RuntimeSyncResult{
+		RuntimeID:         syncResp.GetRuntime().GetId(),
+		PagesRead:         syncResp.GetPagesRead(),
+		EventsAppended:    syncResp.GetEventsAppended(),
+		EntitiesProjected: syncResp.GetEntitiesProjected(),
+		LinksProjected:    syncResp.GetLinksProjected(),
+	}, nil
 }
 
-func agentTaskTimestampString(ts interface{ AsTime() time.Time }) string {
-	if ts == nil {
-		return ""
+func (a *App) runAgentTaskReport(ctx context.Context, reportID string, parameters map[string]string) (agenttasks.ReportRunResult, error) {
+	runResp, err := a.reportService().Run(ctx, &cerebrov1.RunReportRequest{ReportId: reportID, Parameters: parameters})
+	if err != nil {
+		return agenttasks.ReportRunResult{}, err
 	}
-	value := ts.AsTime()
-	if value.IsZero() {
-		return ""
+	run := runResp.GetRun()
+	if err := authorizeTenantID(ctx, run.GetParameters()["tenant_id"]); err != nil {
+		return agenttasks.ReportRunResult{}, err
 	}
-	return value.UTC().Format(time.RFC3339)
+	result := agenttasks.ReportRunResult{
+		ReportID: run.GetReportId(),
+		RunID:    run.GetId(),
+		Status:   run.GetStatus(),
+	}
+	if generatedAt := run.GetGeneratedAt(); generatedAt != nil {
+		result.GeneratedAt = generatedAt.AsTime()
+	}
+	return result, nil
+}
+
+func agentTaskErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, agenttasks.ErrInvalidRequest), errors.Is(err, reports.ErrInvalidRequest), errors.Is(err, sourceruntime.ErrInvalidRequest):
+		return http.StatusBadRequest
+	case errors.Is(err, errTenantForbidden), errors.Is(err, errScopeForbidden):
+		return http.StatusForbidden
+	case errors.Is(err, ports.ErrFindingNotFound), errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable), errors.Is(err, reports.ErrRuntimeUnavailable), errors.Is(err, findings.ErrRuntimeUnavailable):
+		return http.StatusServiceUnavailable
+	default:
+		return 0
+	}
 }

--- a/internal/bootstrap/agent_context.go
+++ b/internal/bootstrap/agent_context.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -42,6 +43,7 @@ func (a *App) agentTaskHandler() agenttasks.Handler {
 		SyncRuntime:             a.syncAgentTaskRuntime,
 		RunReport:               a.runAgentTaskReport,
 		ErrorStatus:             agentTaskErrorStatus,
+		ErrorMessage:            agentTaskErrorMessage,
 	})
 }
 
@@ -111,12 +113,19 @@ func (a *App) syncAgentTaskRuntime(ctx context.Context, runtimeID string, pageLi
 }
 
 func (a *App) runAgentTaskReport(ctx context.Context, reportID string, parameters map[string]string) (agenttasks.ReportRunResult, error) {
+	tenantID := strings.TrimSpace(parameters["tenant_id"])
+	if tenantID == "" {
+		return agenttasks.ReportRunResult{}, fmt.Errorf("%w: tenant_id is required", reports.ErrInvalidRequest)
+	}
+	if err := authorizeTenantScopeRequired(ctx, tenantID); err != nil {
+		return agenttasks.ReportRunResult{}, err
+	}
 	runResp, err := a.reportService().Run(ctx, &cerebrov1.RunReportRequest{ReportId: reportID, Parameters: parameters})
 	if err != nil {
 		return agenttasks.ReportRunResult{}, err
 	}
 	run := runResp.GetRun()
-	if err := authorizeTenantID(ctx, run.GetParameters()["tenant_id"]); err != nil {
+	if err := authorizeTenantScopeRequired(ctx, run.GetParameters()["tenant_id"]); err != nil {
 		return agenttasks.ReportRunResult{}, err
 	}
 	result := agenttasks.ReportRunResult{
@@ -142,5 +151,22 @@ func agentTaskErrorStatus(err error) int {
 		return http.StatusServiceUnavailable
 	default:
 		return 0
+	}
+}
+
+func agentTaskErrorMessage(status int, err error) string {
+	switch {
+	case status == http.StatusBadRequest:
+		return err.Error()
+	case errors.Is(err, errTenantForbidden):
+		return "tenant forbidden"
+	case errors.Is(err, errScopeForbidden):
+		return "scope forbidden"
+	case status == http.StatusNotFound:
+		return "resource not found"
+	case status == http.StatusServiceUnavailable:
+		return "agent task service unavailable"
+	default:
+		return "agent task failed"
 	}
 }

--- a/internal/bootstrap/agent_context.go
+++ b/internal/bootstrap/agent_context.go
@@ -1,0 +1,617 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/agentplatform"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/reports"
+	"github.com/writer/cerebro/internal/sourceruntime"
+)
+
+const agentContextPath = "/api/v1/agent/context"
+
+type agentContextResponse struct {
+	Version          string                `json:"version"`
+	Links            map[string]string     `json:"links"`
+	Auth             agentAuthDiscovery    `json:"auth"`
+	Caller           agentCallerContext    `json:"caller"`
+	MutationContract agentMutationContract `json:"mutation_contract"`
+	Telemetry        agentTelemetryContext `json:"telemetry"`
+	Workflows        []agentWorkflow       `json:"workflows"`
+}
+
+type agentAuthDiscovery struct {
+	Schemes                   []string `json:"schemes"`
+	ProtectedResourceMetadata string   `json:"protected_resource_metadata"`
+	AuthorizationServer       string   `json:"authorization_server"`
+	TokenEndpoint             string   `json:"token_endpoint"`
+	RequiredDefaultScope      string   `json:"required_default_scope"`
+	SupportedScopes           []string `json:"supported_scopes"`
+}
+
+type agentCallerContext struct {
+	Authenticated bool     `json:"authenticated"`
+	TenantID      string   `json:"tenant_id,omitempty"`
+	ActorID       string   `json:"actor_id,omitempty"`
+	AuthMode      string   `json:"auth_mode,omitempty"`
+	ActorType     string   `json:"actor_type"`
+	Scopes        []string `json:"scopes,omitempty"`
+	UserAgent     string   `json:"user_agent"`
+}
+
+type agentMutationContract struct {
+	DryRunField      string   `json:"dry_run_field"`
+	ApprovalField    string   `json:"approval_field"`
+	Idempotency      string   `json:"idempotency"`
+	DefaultBehavior  string   `json:"default_behavior"`
+	ExecutionRules   []string `json:"execution_rules"`
+	SupportedActions []string `json:"supported_actions"`
+}
+
+type agentTelemetryContext struct {
+	ActorTypeAttribute string   `json:"actor_type_attribute"`
+	UserAgentAttribute string   `json:"user_agent_attribute"`
+	RequestHeaders     []string `json:"request_headers"`
+}
+
+type agentWorkflow struct {
+	ID             string            `json:"id"`
+	Resource       string            `json:"resource"`
+	StateCheck     agentNextAction   `json:"state_check"`
+	NextActions    []agentNextAction `json:"next_actions"`
+	SlackBotIntent string            `json:"slack_bot_intent,omitempty"`
+}
+
+type agentNextAction struct {
+	ID               string `json:"id"`
+	Label            string `json:"label"`
+	Method           string `json:"method"`
+	Path             string `json:"path"`
+	RequiredScope    string `json:"required_scope"`
+	Stage            string `json:"stage"`
+	DryRunSupported  bool   `json:"dry_run_supported,omitempty"`
+	ApprovalRequired bool   `json:"approval_required,omitempty"`
+	When             string `json:"when"`
+}
+
+type agentTaskRequest struct {
+	TenantID    string            `json:"tenant_id,omitempty"`
+	DryRun      bool              `json:"dry_run,omitempty"`
+	Approved    bool              `json:"approved,omitempty"`
+	Reason      string            `json:"reason,omitempty"`
+	Parameters  map[string]string `json:"parameters,omitempty"`
+	Idempotency string            `json:"idempotency_key,omitempty"`
+}
+
+type agentTaskResponse struct {
+	ID          string            `json:"id"`
+	Kind        string            `json:"kind"`
+	Status      string            `json:"status"`
+	Resource    agentResourceRef  `json:"resource"`
+	DryRun      bool              `json:"dry_run"`
+	Approved    bool              `json:"approved"`
+	Reason      string            `json:"reason,omitempty"`
+	Mutation    *agentMutationRef `json:"mutation,omitempty"`
+	NextActions []agentNextAction `json:"next_actions,omitempty"`
+	Result      map[string]any    `json:"result,omitempty"`
+}
+
+type agentResourceRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Path string `json:"path"`
+}
+
+type agentMutationRef struct {
+	Method           string            `json:"method"`
+	Path             string            `json:"path"`
+	RequiredScope    string            `json:"required_scope"`
+	ApprovalRequired bool              `json:"approval_required"`
+	DryRunSupported  bool              `json:"dry_run_supported"`
+	Parameters       map[string]string `json:"parameters,omitempty"`
+}
+
+func (a *App) handleAgentContext(w http.ResponseWriter, r *http.Request) {
+	origin := strings.TrimRight(externalOrigin(r, a.cfg.Auth.RequestOrigin), "/")
+	if origin == "" {
+		origin = "https://cerebro"
+	}
+	writeJSON(w, http.StatusOK, agentContextResponse{
+		Version: agentplatform.ContractVersion,
+		Links: map[string]string{
+			"openapi":             origin + "/openapi.yaml",
+			"agent_card":          origin + agentplatform.A2AAgentCardPath,
+			"agent_platform":      origin + "/api/v1/agent-platform/contract",
+			"capabilities":        origin + "/api/v1/agent-platform/capabilities",
+			"event_subscriptions": origin + agentplatform.EventSubscriptionContractPath,
+			"idempotency":         origin + agentplatform.IdempotencyContractPath,
+		},
+		Auth:             agentAuthDiscoveryForOrigin(origin),
+		Caller:           agentCallerContextForRequest(r),
+		MutationContract: agentMutationContractForContext(),
+		Telemetry: agentTelemetryContext{
+			ActorTypeAttribute: "client.actor_type",
+			UserAgentAttribute: "user_agent.family",
+			RequestHeaders:     []string{"User-Agent", "X-Request-Id", "X-Cerebro-Tenant", "Idempotency-Key"},
+		},
+		Workflows: agentWorkflows(),
+	})
+}
+
+func agentAuthDiscoveryForOrigin(origin string) agentAuthDiscovery {
+	origin = strings.TrimRight(strings.TrimSpace(origin), "/")
+	if origin == "" {
+		origin = "https://cerebro"
+	}
+	return agentAuthDiscovery{
+		Schemes:                   []string{"Authorization: Bearer <token>", "X-Cerebro-API-Key: <key>"},
+		ProtectedResourceMetadata: origin + oauthProtectedResourceMetadataPath,
+		AuthorizationServer:       origin + oauthAuthorizationServerMetadataPath,
+		TokenEndpoint:             origin + oauthTokenPath,
+		RequiredDefaultScope:      scopeCosmoSecurityRead,
+		SupportedScopes:           supportedOAuthScopes(),
+	}
+}
+
+func agentCallerContextForRequest(r *http.Request) agentCallerContext {
+	ctx := agentCallerContext{
+		ActorType: agentActorTypeFromUserAgent(requestHeaderValue(r, "User-Agent")),
+		UserAgent: userAgentFamilyValue(requestHeaderValue(r, "User-Agent")),
+	}
+	if r == nil {
+		return ctx
+	}
+	auth, ok := r.Context().Value(authContextKey{}).(authContext)
+	if !ok {
+		return ctx
+	}
+	ctx.Authenticated = true
+	ctx.TenantID = strings.TrimSpace(auth.principal.TenantID)
+	ctx.ActorID = agentPlatformPrincipalActorID(auth.principal, "")
+	ctx.AuthMode = strings.TrimSpace(auth.principal.AuthMode)
+	ctx.Scopes = expandedPrincipalScopes(auth.principal)
+	if ctx.ActorType == "unknown" || ctx.ActorType == "automation" {
+		ctx.ActorType = agentActorTypeFromPrincipal(auth.principal, requestHeaderValue(r, "User-Agent"))
+	}
+	return ctx
+}
+
+func agentActorTypeFromPrincipal(principal authPrincipal, userAgent string) string {
+	switch strings.TrimSpace(principal.AuthMode) {
+	case "device_jwt":
+		return "agent"
+	case "api_credential", "capability_token":
+		return "service"
+	}
+	return agentActorTypeFromUserAgent(userAgent)
+}
+
+func agentActorTypeFromUserAgent(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case normalized == "":
+		return "unknown"
+	case strings.Contains(normalized, "codex"),
+		strings.Contains(normalized, "openai"),
+		strings.Contains(normalized, "mcp"),
+		strings.Contains(normalized, "langchain"),
+		strings.Contains(normalized, "autogen"),
+		strings.Contains(normalized, "crewai"),
+		strings.Contains(normalized, "claude"),
+		strings.Contains(normalized, "anthropic"):
+		return "agent"
+	case strings.Contains(normalized, "bot"),
+		strings.Contains(normalized, "crawler"),
+		strings.Contains(normalized, "spider"):
+		return "agent"
+	case strings.Contains(normalized, "mozilla") &&
+		(strings.Contains(normalized, "chrome") || strings.Contains(normalized, "safari") || strings.Contains(normalized, "firefox") || strings.Contains(normalized, "edg/")):
+		return "human"
+	case strings.Contains(normalized, "curl"),
+		strings.Contains(normalized, "httpie"),
+		strings.Contains(normalized, "wget"),
+		strings.Contains(normalized, "python-requests"),
+		strings.Contains(normalized, "go-http-client"),
+		strings.Contains(normalized, "node-fetch"),
+		strings.Contains(normalized, "axios"),
+		strings.Contains(normalized, "postman"):
+		return "automation"
+	default:
+		return "unknown"
+	}
+}
+
+func userAgentFamilyValue(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case normalized == "":
+		return "none"
+	case strings.Contains(normalized, "codex"):
+		return "codex"
+	case strings.Contains(normalized, "openai"):
+		return "openai"
+	case strings.Contains(normalized, "mcp"):
+		return "mcp"
+	case strings.Contains(normalized, "slack"):
+		return "slack"
+	case strings.Contains(normalized, "bot"), strings.Contains(normalized, "crawler"), strings.Contains(normalized, "spider"):
+		return "bot"
+	case strings.Contains(normalized, "edge"), strings.Contains(normalized, "edg/"):
+		return "edge"
+	case strings.Contains(normalized, "chrome"):
+		return "chrome"
+	case strings.Contains(normalized, "safari"):
+		return "safari"
+	case strings.Contains(normalized, "firefox"):
+		return "firefox"
+	case strings.Contains(normalized, "curl"):
+		return "curl"
+	case strings.Contains(normalized, "python-requests"):
+		return "python-requests"
+	case strings.Contains(normalized, "go-http-client"):
+		return "go-http-client"
+	case strings.Contains(normalized, "node-fetch"):
+		return "node-fetch"
+	case strings.Contains(normalized, "axios"):
+		return "axios"
+	case strings.Contains(normalized, "postman"):
+		return "postman"
+	default:
+		return "other"
+	}
+}
+
+func requestHeaderValue(r *http.Request, key string) string {
+	if r == nil {
+		return ""
+	}
+	return r.Header.Get(key)
+}
+
+func agentMutationContractForContext() agentMutationContract {
+	return agentMutationContract{
+		DryRunField:     "dry_run",
+		ApprovalField:   "approved",
+		Idempotency:     "Use Idempotency-Key or idempotency_key on approved writes that may be retried.",
+		DefaultBehavior: "Agent task endpoints return a plan unless approved=true and dry_run is false.",
+		ExecutionRules: []string{
+			"Read and explain actions require the read scope only.",
+			"Mutating runtime and report tasks require their dedicated write scope.",
+			"Provider-backed graph actions support dry_run=true and require approved=true before execution.",
+			"Finding lifecycle updates stay on typed finding endpoints and require the finding lifecycle write scope.",
+		},
+		SupportedActions: []string{
+			"identity.okta.suspend_user",
+			"identity.okta.unsuspend_user",
+			"endpoint.cerebro.revoke_device",
+		},
+	}
+}
+
+func agentWorkflows() []agentWorkflow {
+	return []agentWorkflow{
+		{
+			ID:         "finding_triage",
+			Resource:   "finding",
+			StateCheck: agentNextAction{ID: "read_finding", Label: "Read finding", Method: http.MethodGet, Path: "/findings/{findingID}", RequiredScope: scopeCosmoSecurityRead, Stage: "observe", When: "Start here before changing finding state."},
+			NextActions: []agentNextAction{
+				{ID: "explain_finding", Label: "Explain finding", Method: http.MethodPost, Path: "/api/v1/agent/tasks/findings/{findingID}/explain", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use when a bot needs a short packet for a channel or review thread."},
+				{ID: "triage_finding", Label: "Prepare triage", Method: http.MethodPost, Path: "/api/v1/agent/tasks/findings/{findingID}/triage", RequiredScope: scopeCosmoSecurityRead, Stage: "recommend", When: "Use when the next owner, due date, note, or ticket is not decided yet."},
+				{ID: "plan_graph_action", Label: "Dry-run graph action", Method: http.MethodPost, Path: "/platform/graph/actions", RequiredScope: scopeGraphActionsWrite, Stage: "dry_run", DryRunSupported: true, ApprovalRequired: true, When: "Use for provider-backed actions tied to an eligible finding."},
+			},
+			SlackBotIntent: "Post finding summary, owner, evidence, and proposed next step.",
+		},
+		{
+			ID:         "control_packet",
+			Resource:   "control",
+			StateCheck: agentNextAction{ID: "read_controls", Label: "Read controls", Method: http.MethodGet, Path: "/grc/controls", RequiredScope: scopeCosmoSecurityRead, Stage: "observe", When: "Use before collecting evidence for control status."},
+			NextActions: []agentNextAction{
+				{ID: "build_control_packet", Label: "Build control packet", Method: http.MethodGet, Path: "/grc/control-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use when the team needs evidence and gaps for a control."},
+				{ID: "custom_control_packet", Label: "Build scoped packet", Method: http.MethodPost, Path: "/grc/control-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use when the bot has a specific framework, control, or evidence scope."},
+			},
+			SlackBotIntent: "Post control status, missing evidence, stale evidence, and owners.",
+		},
+		{
+			ID:         "report_run",
+			Resource:   "report",
+			StateCheck: agentNextAction{ID: "list_reports", Label: "List reports", Method: http.MethodGet, Path: "/reports", RequiredScope: scopeCosmoSecurityRead, Stage: "observe", When: "Use before selecting a report id."},
+			NextActions: []agentNextAction{
+				{ID: "plan_report_run", Label: "Plan report run", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/{reportID}/run", RequiredScope: scopeCosmoSecurityRead, Stage: "dry_run", DryRunSupported: true, When: "Use when a bot needs to show parameters before running a report."},
+				{ID: "run_report", Label: "Run report", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/{reportID}/run", RequiredScope: scopeReportsRun, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Use after a human approves the report parameters."},
+			},
+			SlackBotIntent: "Post report parameters, run status, and link to the report run.",
+		},
+		{
+			ID:         "runtime_retry",
+			Resource:   "source_runtime",
+			StateCheck: agentNextAction{ID: "read_runtime", Label: "Read runtime", Method: http.MethodGet, Path: "/source-runtimes/{runtimeID}", RequiredScope: scopeCosmoSecurityRead, Stage: "observe", When: "Use before retrying a runtime."},
+			NextActions: []agentNextAction{
+				{ID: "plan_runtime_retry", Label: "Plan runtime retry", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", RequiredScope: scopeCosmoSecurityRead, Stage: "dry_run", DryRunSupported: true, When: "Use when a runtime is stale or failed and the bot needs the exact retry call."},
+				{ID: "retry_runtime", Label: "Retry runtime", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", RequiredScope: scopeSourceRuntimesWrite, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Use after a human approves the retry."},
+			},
+			SlackBotIntent: "Post runtime status, last sync, failure reason, and retry plan.",
+		},
+	}
+}
+
+func (a *App) handleAgentFindingExplainTask(w http.ResponseWriter, r *http.Request) {
+	findingID := r.PathValue("findingID")
+	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), findingID); err != nil {
+		writeAgentTaskError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
+		return
+	}
+	req, err := readAgentTaskRequest(w, r)
+	if err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	response := baseAgentTaskResponse("finding_explain", "finding", findingID, "/findings/"+findingID, req)
+	response.Status = "planned"
+	response.NextActions = findingAgentNextActions(findingID)
+	response.Result = map[string]any{
+		"read_path":        "/findings/" + findingID,
+		"evidence_request": "/api/v1/agent-platform/evidence-packets",
+		"graph_reason":     "/api/v1/agent-platform/graph/reason",
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleAgentFindingTriageTask(w http.ResponseWriter, r *http.Request) {
+	findingID := r.PathValue("findingID")
+	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), findingID); err != nil {
+		writeAgentTaskError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
+		return
+	}
+	req, err := readAgentTaskRequest(w, r)
+	if err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	response := baseAgentTaskResponse("finding_triage", "finding", findingID, "/findings/"+findingID, req)
+	response.Status = "planned"
+	response.NextActions = findingAgentNextActions(findingID)
+	response.Result = map[string]any{
+		"lifecycle_paths": []string{
+			"/findings/" + findingID + "/assign",
+			"/findings/" + findingID + "/due",
+			"/findings/" + findingID + "/notes",
+			"/findings/" + findingID + "/tickets",
+			"/findings/" + findingID + "/resolve",
+			"/findings/" + findingID + "/suppress",
+		},
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleAgentFindingAuditPacketTask(w http.ResponseWriter, r *http.Request) {
+	findingID := r.PathValue("findingID")
+	if err := authorizeFindingIDTenant(r.Context(), findingStore(a.deps.StateStore), findingID); err != nil {
+		writeAgentTaskError(w, normalizeIDLookupError(err, ports.ErrFindingNotFound))
+		return
+	}
+	req, err := readAgentTaskRequest(w, r)
+	if err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	response := baseAgentTaskResponse("finding_audit_packet", "finding", findingID, "/findings/"+findingID, req)
+	response.Status = "planned"
+	response.NextActions = []agentNextAction{
+		{ID: "build_evidence_packet", Label: "Build evidence packet", Method: http.MethodPost, Path: "/api/v1/agent-platform/evidence-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use scope_urn for the finding and include evidence URNs when known."},
+		{ID: "read_control_packets", Label: "Read control packets", Method: http.MethodGet, Path: "/grc/control-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use when the finding maps to framework controls."},
+	}
+	response.Result = map[string]any{
+		"scope_urn": "urn:cerebro:{tenant}:finding:" + findingID,
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleAgentSourceRuntimeRetryTask(w http.ResponseWriter, r *http.Request) {
+	runtimeID := r.PathValue("runtimeID")
+	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), runtimeID); err != nil {
+		writeAgentTaskError(w, normalizeIDLookupError(err, ports.ErrSourceRuntimeNotFound))
+		return
+	}
+	req, err := readAgentTaskRequest(w, r)
+	if err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	response := baseAgentTaskResponse("source_runtime_retry", "source_runtime", runtimeID, "/source-runtimes/"+runtimeID, req)
+	response.Mutation = &agentMutationRef{
+		Method:           http.MethodPost,
+		Path:             "/source-runtimes/" + runtimeID + "/sync",
+		RequiredScope:    scopeSourceRuntimesWrite,
+		ApprovalRequired: true,
+		DryRunSupported:  true,
+		Parameters:       req.Parameters,
+	}
+	if req.DryRun || !req.Approved {
+		response.Status = "dry_run"
+		response.DryRun = true
+		response.NextActions = []agentNextAction{
+			{ID: "approve_runtime_retry", Label: "Approve runtime retry", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/" + runtimeID + "/retry", RequiredScope: scopeSourceRuntimesWrite, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Call with approved=true after review."},
+		}
+		writeJSON(w, http.StatusOK, response)
+		return
+	}
+	if err := authorizeAgentTaskExecutionScope(r.Context(), scopeSourceRuntimesWrite); err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	pageLimit, err := pageLimitFromTask(req)
+	if err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	syncResp, err := a.runtimeService().SyncWithLease(r.Context(), &cerebrov1.SyncSourceRuntimeRequest{Id: runtimeID, PageLimit: pageLimit}, sourceruntime.SyncWithLeaseOptions{
+		LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore),
+	})
+	if err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	response.Status = "succeeded"
+	response.Result = map[string]any{
+		"runtime_id":         syncResp.GetRuntime().GetId(),
+		"pages_read":         syncResp.GetPagesRead(),
+		"events_appended":    syncResp.GetEventsAppended(),
+		"entities_projected": syncResp.GetEntitiesProjected(),
+		"links_projected":    syncResp.GetLinksProjected(),
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleAgentReportRunTask(w http.ResponseWriter, r *http.Request) {
+	reportID := r.PathValue("reportID")
+	req, err := readAgentTaskRequest(w, r)
+	if err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	if tenantID := strings.TrimSpace(firstNonEmpty(req.TenantID, req.Parameters["tenant_id"])); tenantID != "" {
+		if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+			writeAgentTaskError(w, err)
+			return
+		}
+	}
+	response := baseAgentTaskResponse("report_run", "report", reportID, "/reports/"+reportID+"/runs", req)
+	response.Mutation = &agentMutationRef{
+		Method:           http.MethodPost,
+		Path:             "/reports/" + reportID + "/runs",
+		RequiredScope:    scopeReportsRun,
+		ApprovalRequired: true,
+		DryRunSupported:  true,
+		Parameters:       req.Parameters,
+	}
+	if req.DryRun || !req.Approved {
+		response.Status = "dry_run"
+		response.DryRun = true
+		response.NextActions = []agentNextAction{
+			{ID: "approve_report_run", Label: "Approve report run", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/" + reportID + "/run", RequiredScope: scopeReportsRun, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Call with approved=true after checking report parameters."},
+		}
+		writeJSON(w, http.StatusOK, response)
+		return
+	}
+	if err := authorizeAgentTaskExecutionScope(r.Context(), scopeReportsRun); err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	runResp, err := a.reportService().Run(r.Context(), &cerebrov1.RunReportRequest{ReportId: reportID, Parameters: req.Parameters})
+	if err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	if err := authorizeTenantID(r.Context(), runResp.GetRun().GetParameters()["tenant_id"]); err != nil {
+		writeAgentTaskError(w, err)
+		return
+	}
+	response.Status = "succeeded"
+	response.Result = map[string]any{
+		"report_id":    runResp.GetRun().GetReportId(),
+		"run_id":       runResp.GetRun().GetId(),
+		"status":       runResp.GetRun().GetStatus(),
+		"generated_at": agentTaskTimestampString(runResp.GetRun().GetGeneratedAt()),
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func baseAgentTaskResponse(kind string, resourceType string, resourceID string, path string, req agentTaskRequest) agentTaskResponse {
+	return agentTaskResponse{
+		ID:       "agent-task:" + kind + ":" + resourceID,
+		Kind:     kind,
+		Status:   "planned",
+		Resource: agentResourceRef{Type: resourceType, ID: resourceID, Path: path},
+		DryRun:   req.DryRun,
+		Approved: req.Approved,
+		Reason:   strings.TrimSpace(req.Reason),
+	}
+}
+
+func findingAgentNextActions(findingID string) []agentNextAction {
+	return []agentNextAction{
+		{ID: "build_evidence_packet", Label: "Build evidence packet", Method: http.MethodPost, Path: "/api/v1/agent-platform/evidence-packets", RequiredScope: scopeCosmoSecurityRead, Stage: "explain", When: "Use before posting a finding summary or making a recommendation."},
+		{ID: "add_note", Label: "Add finding note", Method: http.MethodPost, Path: "/findings/" + findingID + "/notes", RequiredScope: scopeFindingLifecycleWrite, Stage: "close_loop", ApprovalRequired: true, When: "Use after the team approves the note text."},
+		{ID: "link_ticket", Label: "Link ticket", Method: http.MethodPost, Path: "/findings/" + findingID + "/tickets", RequiredScope: scopeFindingLifecycleWrite, Stage: "close_loop", ApprovalRequired: true, When: "Use when a remediation ticket already exists."},
+		{ID: "dry_run_graph_action", Label: "Dry-run graph action", Method: http.MethodPost, Path: "/platform/graph/actions", RequiredScope: scopeGraphActionsWrite, Stage: "dry_run", DryRunSupported: true, ApprovalRequired: true, When: "Use for supported provider actions attached to the finding."},
+	}
+}
+
+func readAgentTaskRequest(w http.ResponseWriter, r *http.Request) (agentTaskRequest, error) {
+	request := agentTaskRequest{Parameters: map[string]string{}}
+	if r == nil || r.Body == nil {
+		return request, nil
+	}
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		if errors.Is(err, io.EOF) {
+			return request, nil
+		}
+		return agentTaskRequest{}, fmt.Errorf("%w: decode agent task request: %w", errInvalidHTTPRequest, err)
+	}
+	if request.Parameters == nil {
+		request.Parameters = map[string]string{}
+	}
+	return request, nil
+}
+
+func pageLimitFromTask(req agentTaskRequest) (uint32, error) {
+	raw := strings.TrimSpace(req.Parameters["page_limit"])
+	if raw == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: page_limit must be a positive integer", errInvalidHTTPRequest)
+	}
+	if value == 0 {
+		return 0, fmt.Errorf("%w: page_limit must be a positive integer", errInvalidHTTPRequest)
+	}
+	return uint32(value), nil
+}
+
+func authorizeAgentTaskExecutionScope(ctx context.Context, required string) error {
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok || !principalScopeRestricted(auth.principal) {
+		return nil
+	}
+	return authorizePrincipalScope(auth.principal, required)
+}
+
+func writeAgentTaskError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, errInvalidHTTPRequest), errors.Is(err, reports.ErrInvalidRequest), errors.Is(err, sourceruntime.ErrInvalidRequest):
+		status = http.StatusBadRequest
+	case errors.Is(err, errTenantForbidden), errors.Is(err, errScopeForbidden):
+		status = http.StatusForbidden
+	case errors.Is(err, ports.ErrFindingNotFound), errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable), errors.Is(err, reports.ErrRuntimeUnavailable), errors.Is(err, findings.ErrRuntimeUnavailable):
+		status = http.StatusServiceUnavailable
+	}
+	writeJSON(w, status, map[string]any{"error": err.Error()})
+}
+
+func agentTaskTimestampString(ts interface{ AsTime() time.Time }) string {
+	if ts == nil {
+		return ""
+	}
+	value := ts.AsTime()
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -90,7 +90,7 @@ func TestAgentFindingTaskReturnsNextActions(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent/tasks/findings/finding-1/explain", bytes.NewReader([]byte(`{"reason":"post to channel"}`)))
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent/tasks/findings/finding-1/explain", bytes.NewReader([]byte(`{"reason":"post to channel","client_context":{"schema_version":"next"}}`)))
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
@@ -110,6 +110,9 @@ func TestAgentFindingTaskReturnsNextActions(t *testing.T) {
 	}
 	if task.Kind != "finding_explain" || task.Status != "planned" || task.Resource.ID != "finding-1" {
 		t.Fatalf("task = %+v, want planned finding explain task", task)
+	}
+	if task.Reason != "post to channel" {
+		t.Fatalf("reason = %q, want request reason while ignoring future fields", task.Reason)
 	}
 	if len(task.NextActions) == 0 || task.Result["evidence_request"] == "" {
 		t.Fatalf("task missing next actions or evidence request: %+v", task)

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -165,6 +167,72 @@ func TestAgentSourceRuntimeRetryTaskPlansWithReadScopeAndExecutesWithWriteScope(
 	}
 }
 
+func TestAgentReportRunRequiresTenantBeforeExecution(t *testing.T) {
+	cfg := agentPlatformAuthConfig()
+	cfg.Auth.APICredentials[0].Scopes = []string{scopeCosmoSecurityRead, scopeReportsRun}
+	store := &stubRuntimeStore{}
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent/tasks/reports/finding-summary/run", bytes.NewReader([]byte(`{"approved":true}`)))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST report run task: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if len(store.reportRuns) != 0 {
+		t.Fatalf("report runs persisted = %d, want none before tenant authorization", len(store.reportRuns))
+	}
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(string(payload), "tenant_id is required") {
+		t.Fatalf("body = %q, want tenant_id guidance", string(payload))
+	}
+}
+
+func TestAgentTaskInternalErrorsAreSanitized(t *testing.T) {
+	store := &stubRuntimeStore{err: errors.New("database password leaked")}
+	app := New(agentPlatformAuthConfig(), Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent/tasks/findings/finding-1/explain", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST finding task: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", resp.StatusCode)
+	}
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if strings.Contains(string(payload), "database password leaked") {
+		t.Fatalf("body leaked raw internal error: %q", string(payload))
+	}
+	if !strings.Contains(string(payload), "agent task failed") {
+		t.Fatalf("body = %q, want sanitized agent task failure", string(payload))
+	}
+}
+
 func TestAgentAuthErrorIncludesDiscoveryAndRequiredScope(t *testing.T) {
 	app := New(agentPlatformAuthConfig(), Dependencies{}, nil)
 	server := httptest.NewServer(app.Handler())
@@ -191,6 +259,40 @@ func TestAgentAuthErrorIncludesDiscoveryAndRequiredScope(t *testing.T) {
 	auth, ok := body["auth"].(map[string]any)
 	if !ok || auth["token_endpoint"] == "" {
 		t.Fatalf("auth discovery = %#v, want token endpoint", body["auth"])
+	}
+}
+
+func TestTenantForbiddenAuthChallengeDoesNotAdvertiseScope(t *testing.T) {
+	app := New(agentPlatformAuthConfig(), Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+agentContextPath+"?tenant_id=other", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET tenant-forbidden agent context: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	challenge := resp.Header.Get("WWW-Authenticate")
+	if strings.Contains(challenge, "insufficient_scope") || strings.Contains(challenge, `scope="`) {
+		t.Fatalf("WWW-Authenticate = %q, want tenant denial without scope challenge", challenge)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode auth error: %v", err)
+	}
+	if body["required_scope"] != nil {
+		t.Fatalf("auth error = %+v, want no required scope for tenant denial", body)
+	}
+	if body["next_action"] != "Use a credential allowed for the requested tenant." {
+		t.Fatalf("next_action = %#v, want tenant credential guidance", body["next_action"])
 	}
 }
 

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -43,6 +44,149 @@ func TestHandleAgentPlatformContract(t *testing.T) {
 	}
 	if contract.A2A.JSONRPCPath == "" || contract.EventSubscriptions.Resource == "" || contract.Idempotency.Header == "" {
 		t.Fatalf("contract response missing public protocol contracts: %+v", contract)
+	}
+}
+
+func TestHandleAgentContext(t *testing.T) {
+	app := New(agentPlatformAuthConfig(), Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+agentContextPath, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("User-Agent", "Codex/1.0")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET agent context: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var context agentContextResponse
+	if err := json.NewDecoder(resp.Body).Decode(&context); err != nil {
+		t.Fatalf("decode context: %v", err)
+	}
+	if context.Caller.TenantID != "writer" || context.Caller.ActorID != "tester" || context.Caller.ActorType != "agent" {
+		t.Fatalf("caller = %+v, want authenticated agent caller", context.Caller)
+	}
+	if context.Auth.TokenEndpoint == "" || context.MutationContract.DryRunField != "dry_run" {
+		t.Fatalf("context missing auth or mutation contract: %+v", context)
+	}
+	if len(context.Workflows) < 4 {
+		t.Fatalf("workflows = %d, want agent workflow map", len(context.Workflows))
+	}
+}
+
+func TestAgentFindingTaskReturnsNextActions(t *testing.T) {
+	store := &stubRuntimeStore{findings: map[string]*ports.FindingRecord{
+		"finding-1": {ID: "finding-1", TenantID: "writer", RuntimeID: "runtime-1", Title: "Owner missing"},
+	}}
+	app := New(agentPlatformAuthConfig(), Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent/tasks/findings/finding-1/explain", bytes.NewReader([]byte(`{"reason":"post to channel"}`)))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST finding explain task: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var task agentTaskResponse
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		t.Fatalf("decode task: %v", err)
+	}
+	if task.Kind != "finding_explain" || task.Status != "planned" || task.Resource.ID != "finding-1" {
+		t.Fatalf("task = %+v, want planned finding explain task", task)
+	}
+	if len(task.NextActions) == 0 || task.Result["evidence_request"] == "" {
+		t.Fatalf("task missing next actions or evidence request: %+v", task)
+	}
+}
+
+func TestAgentSourceRuntimeRetryTaskPlansWithReadScopeAndExecutesWithWriteScope(t *testing.T) {
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-1": {Id: "runtime-1", SourceId: "okta", TenantId: "writer"},
+	}}
+	app := New(agentPlatformAuthConfig(), Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	planReq, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent/tasks/source-runtimes/runtime-1/retry", bytes.NewReader([]byte(`{"dry_run":true}`)))
+	if err != nil {
+		t.Fatalf("NewRequest plan: %v", err)
+	}
+	planReq.Header.Set("Authorization", "Bearer test-key")
+	planReq.Header.Set("Content-Type", "application/json")
+	planResp, err := server.Client().Do(planReq)
+	if err != nil {
+		t.Fatalf("POST retry plan: %v", err)
+	}
+	defer func() { _ = planResp.Body.Close() }()
+	if planResp.StatusCode != http.StatusOK {
+		t.Fatalf("plan status = %d, want 200", planResp.StatusCode)
+	}
+	var plan agentTaskResponse
+	if err := json.NewDecoder(planResp.Body).Decode(&plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+	if plan.Status != "dry_run" || plan.Mutation == nil || plan.Mutation.RequiredScope != scopeSourceRuntimesWrite {
+		t.Fatalf("plan = %+v, want dry-run mutation with source runtime write scope", plan)
+	}
+
+	executeReq, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/agent/tasks/source-runtimes/runtime-1/retry", bytes.NewReader([]byte(`{"approved":true}`)))
+	if err != nil {
+		t.Fatalf("NewRequest execute: %v", err)
+	}
+	executeReq.Header.Set("Authorization", "Bearer test-key")
+	executeReq.Header.Set("Content-Type", "application/json")
+	executeResp, err := server.Client().Do(executeReq)
+	if err != nil {
+		t.Fatalf("POST retry execute: %v", err)
+	}
+	defer func() { _ = executeResp.Body.Close() }()
+	if executeResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("execute status = %d, want 403", executeResp.StatusCode)
+	}
+}
+
+func TestAgentAuthErrorIncludesDiscoveryAndRequiredScope(t *testing.T) {
+	app := New(agentPlatformAuthConfig(), Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + agentContextPath)
+	if err != nil {
+		t.Fatalf("GET agent context without auth: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	if !strings.Contains(resp.Header.Get("WWW-Authenticate"), oauthProtectedResourceMetadataPath) {
+		t.Fatalf("WWW-Authenticate = %q, want resource metadata", resp.Header.Get("WWW-Authenticate"))
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode auth error: %v", err)
+	}
+	if body["required_scope"] != scopeCosmoSecurityRead || body["next_action"] == "" {
+		t.Fatalf("auth error = %+v, want required scope and next action", body)
+	}
+	auth, ok := body["auth"].(map[string]any)
+	if !ok || auth["token_endpoint"] == "" {
+		t.Fatalf("auth discovery = %#v, want token endpoint", body["auth"])
 	}
 }
 

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp/agenttasks"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -66,7 +67,7 @@ func TestHandleAgentContext(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	var context agentContextResponse
+	var context agenttasks.ContextResponse
 	if err := json.NewDecoder(resp.Body).Decode(&context); err != nil {
 		t.Fatalf("decode context: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestAgentFindingTaskReturnsNextActions(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	var task agentTaskResponse
+	var task agenttasks.TaskResponse
 	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
 		t.Fatalf("decode task: %v", err)
 	}
@@ -137,7 +138,7 @@ func TestAgentSourceRuntimeRetryTaskPlansWithReadScopeAndExecutesWithWriteScope(
 	if planResp.StatusCode != http.StatusOK {
 		t.Fatalf("plan status = %d, want 200", planResp.StatusCode)
 	}
-	var plan agentTaskResponse
+	var plan agenttasks.TaskResponse
 	if err := json.NewDecoder(planResp.Body).Decode(&plan); err != nil {
 		t.Fatalf("decode plan: %v", err)
 	}

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -30,8 +30,13 @@ import (
 	"github.com/writer/cerebro/internal/telemetry"
 )
 
-var errTenantForbidden = errors.New("tenant forbidden")
-var errScopeForbidden = errors.New("scope forbidden")
+const (
+	authMessageTenantForbidden = "tenant forbidden"
+	authMessageScopeForbidden  = "scope forbidden"
+)
+
+var errTenantForbidden = errors.New(authMessageTenantForbidden)
+var errScopeForbidden = errors.New(authMessageScopeForbidden)
 
 type authContextKey struct{}
 type accessAuditContextKey struct{}
@@ -878,18 +883,18 @@ func writeAuthErrorForRequest(w http.ResponseWriter, r *http.Request, cfg config
 	}
 	if cfg.MCPOAuth.Enabled && r != nil && r.URL != nil && r.URL.Path == mcpEndpointPath && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
 		challenge := `Bearer resource_metadata="` + mcpOAuthResourceMetadataURL(r, cfg) + `", scope="` + scopeCosmoSecurityRead + `"`
-		if status == http.StatusForbidden {
+		if isInsufficientScopeDenial(status, message, policy) {
 			challenge += `, error="insufficient_scope", error_description="MCP access requires the ` + scopeCosmoSecurityRead + ` scope"`
 		}
 		w.Header().Set("WWW-Authenticate", challenge)
 	}
 	if (status == http.StatusUnauthorized || status == http.StatusForbidden) && w.Header().Get("WWW-Authenticate") == "" {
-		w.Header().Set("WWW-Authenticate", authChallengeForRequest(r, cfg, policy, status))
+		w.Header().Set("WWW-Authenticate", authChallengeForRequest(r, cfg, policy, status, message))
 	}
 	writeAuthErrorDetails(w, r, cfg, status, message, policy)
 }
 
-func authChallengeForRequest(r *http.Request, cfg config.AuthConfig, policy httpAuthRoutePolicy, status int) string {
+func authChallengeForRequest(r *http.Request, cfg config.AuthConfig, policy httpAuthRoutePolicy, status int, message string) string {
 	origin := "https://cerebro"
 	if r != nil {
 		origin = strings.TrimRight(externalOrigin(r, cfg.RequestOrigin), "/")
@@ -898,13 +903,24 @@ func authChallengeForRequest(r *http.Request, cfg config.AuthConfig, policy http
 		}
 	}
 	parts := []string{`Bearer resource_metadata="` + origin + oauthProtectedResourceMetadataPath + `"`}
-	if policy.Scope != "" {
+	if shouldAdvertiseChallengeScope(status, message, policy) {
 		parts = append(parts, `scope="`+policy.Scope+`"`)
 	}
-	if status == http.StatusForbidden {
+	if isInsufficientScopeDenial(status, message, policy) {
 		parts = append(parts, `error="insufficient_scope"`)
 	}
 	return strings.Join(parts, ", ")
+}
+
+func shouldAdvertiseChallengeScope(status int, message string, policy httpAuthRoutePolicy) bool {
+	if policy.Scope == "" {
+		return false
+	}
+	return status == http.StatusUnauthorized || isInsufficientScopeDenial(status, message, policy)
+}
+
+func isInsufficientScopeDenial(status int, message string, policy httpAuthRoutePolicy) bool {
+	return status == http.StatusForbidden && !policy.AdminOnly && policy.Scope != "" && message == authMessageScopeForbidden
 }
 
 func writeAuthErrorDetails(w http.ResponseWriter, r *http.Request, cfg config.AuthConfig, status int, message string, policy httpAuthRoutePolicy) {
@@ -927,7 +943,7 @@ func writeAuthErrorDetails(w http.ResponseWriter, r *http.Request, cfg config.Au
 		"method":      method,
 		"path":        path,
 		"retryable":   status == http.StatusUnauthorized,
-		"next_action": authErrorNextAction(status, policy),
+		"next_action": authErrorNextAction(status, message, policy),
 		"auth": map[string]any{
 			"schemes":                     []string{"Authorization: Bearer <token>", "X-Cerebro-API-Key: <key>"},
 			"protected_resource_metadata": origin + oauthProtectedResourceMetadataPath,
@@ -936,7 +952,7 @@ func writeAuthErrorDetails(w http.ResponseWriter, r *http.Request, cfg config.Au
 			"supported_scopes":            supportedOAuthScopes(),
 		},
 	}
-	if policy.Scope != "" {
+	if shouldAdvertiseChallengeScope(status, message, policy) {
 		body["required_scope"] = policy.Scope
 	}
 	if policy.AdminOnly {
@@ -947,14 +963,17 @@ func writeAuthErrorDetails(w http.ResponseWriter, r *http.Request, cfg config.Au
 	_ = json.NewEncoder(w).Encode(body)
 }
 
-func authErrorNextAction(status int, policy httpAuthRoutePolicy) string {
+func authErrorNextAction(status int, message string, policy httpAuthRoutePolicy) string {
 	if status == http.StatusUnauthorized {
 		return "Send a bearer token or X-Cerebro-API-Key, then retry the request."
+	}
+	if message == authMessageTenantForbidden {
+		return "Use a credential allowed for the requested tenant."
 	}
 	if policy.AdminOnly {
 		return "Use an admin credential for this route."
 	}
-	if policy.Scope != "" {
+	if isInsufficientScopeDenial(status, message, policy) {
 		return "Request a token that includes " + policy.Scope + "."
 	}
 	return "Use a credential allowed for this route."

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -881,6 +881,10 @@ func writeAuthError(w http.ResponseWriter, status int, message string) {
 }
 
 func writeAuthErrorForRequest(w http.ResponseWriter, r *http.Request, cfg config.AuthConfig, status int, message string) {
+	policy := httpAuthRoutePolicy{}
+	if r != nil {
+		policy = httpRoutePolicyForRequest(r)
+	}
 	if cfg.MCPOAuth.Enabled && r != nil && r.URL != nil && r.URL.Path == mcpEndpointPath && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
 		challenge := `Bearer resource_metadata="` + mcpOAuthResourceMetadataURL(r, cfg) + `", scope="` + scopeCosmoSecurityRead + `"`
 		if status == http.StatusForbidden {
@@ -888,7 +892,81 @@ func writeAuthErrorForRequest(w http.ResponseWriter, r *http.Request, cfg config
 		}
 		w.Header().Set("WWW-Authenticate", challenge)
 	}
-	writeAuthError(w, status, message)
+	if (status == http.StatusUnauthorized || status == http.StatusForbidden) && w.Header().Get("WWW-Authenticate") == "" {
+		w.Header().Set("WWW-Authenticate", authChallengeForRequest(r, cfg, policy, status))
+	}
+	writeAuthErrorDetails(w, r, cfg, status, message, policy)
+}
+
+func authChallengeForRequest(r *http.Request, cfg config.AuthConfig, policy httpAuthRoutePolicy, status int) string {
+	origin := "https://cerebro"
+	if r != nil {
+		origin = strings.TrimRight(externalOrigin(r, cfg.RequestOrigin), "/")
+		if origin == "" {
+			origin = "https://cerebro"
+		}
+	}
+	parts := []string{`Bearer resource_metadata="` + origin + oauthProtectedResourceMetadataPath + `"`}
+	if policy.Scope != "" {
+		parts = append(parts, `scope="`+policy.Scope+`"`)
+	}
+	if status == http.StatusForbidden {
+		parts = append(parts, `error="insufficient_scope"`)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func writeAuthErrorDetails(w http.ResponseWriter, r *http.Request, cfg config.AuthConfig, status int, message string, policy httpAuthRoutePolicy) {
+	origin := "https://cerebro"
+	method := ""
+	path := ""
+	if r != nil {
+		method = r.Method
+		if r.URL != nil {
+			path = r.URL.Path
+		}
+		origin = strings.TrimRight(externalOrigin(r, cfg.RequestOrigin), "/")
+		if origin == "" {
+			origin = "https://cerebro"
+		}
+	}
+	body := map[string]any{
+		"error":       message,
+		"status":      status,
+		"method":      method,
+		"path":        path,
+		"retryable":   status == http.StatusUnauthorized,
+		"next_action": authErrorNextAction(status, policy),
+		"auth": map[string]any{
+			"schemes":                     []string{"Authorization: Bearer <token>", "X-Cerebro-API-Key: <key>"},
+			"protected_resource_metadata": origin + oauthProtectedResourceMetadataPath,
+			"authorization_server":        origin + oauthAuthorizationServerMetadataPath,
+			"token_endpoint":              origin + oauthTokenPath,
+			"supported_scopes":            supportedOAuthScopes(),
+		},
+	}
+	if policy.Scope != "" {
+		body["required_scope"] = policy.Scope
+	}
+	if policy.AdminOnly {
+		body["required_role"] = "admin"
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func authErrorNextAction(status int, policy httpAuthRoutePolicy) string {
+	if status == http.StatusUnauthorized {
+		return "Send a bearer token or X-Cerebro-API-Key, then retry the request."
+	}
+	if policy.AdminOnly {
+		return "Use an admin credential for this route."
+	}
+	if policy.Scope != "" {
+		return "Request a token that includes " + policy.Scope + "."
+	}
+	return "Use a credential allowed for this route."
 }
 
 type accessAuditResponseWriter struct {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -871,15 +871,6 @@ func appendTenantID(rawTenantID string, seen map[string]struct{}, tenants *[]str
 	*tenants = append(*tenants, tenantID)
 }
 
-func writeAuthError(w http.ResponseWriter, status int, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	if (status == http.StatusUnauthorized || status == http.StatusForbidden) && w.Header().Get("WWW-Authenticate") == "" {
-		w.Header().Set("WWW-Authenticate", "Bearer")
-	}
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
-}
-
 func writeAuthErrorForRequest(w http.ResponseWriter, r *http.Request, cfg config.AuthConfig, status int, message string) {
 	policy := httpAuthRoutePolicy{}
 	if r != nil {

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -27,6 +27,7 @@ type httpAuthRoutePolicy struct {
 
 var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: agentplatform.A2AJSONRPCPath, Static: true, AdminOnly: true},
+	{Method: http.MethodGet, Exact: agentContextPath, Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/contract", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/capabilities", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/security-control-plane", Scope: scopeCosmoSecurityRead, Static: true},
@@ -37,6 +38,11 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/evidence-packets", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/claims/verify", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/graph/reason", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Prefix: "/api/v1/agent/tasks/findings/", Suffix: "/explain", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Prefix: "/api/v1/agent/tasks/findings/", Suffix: "/triage", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Prefix: "/api/v1/agent/tasks/findings/", Suffix: "/audit-packet", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Prefix: "/api/v1/agent/tasks/source-runtimes/", Suffix: "/retry", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Prefix: "/api/v1/agent/tasks/reports/", Suffix: "/run", Scope: scopeCosmoSecurityRead, Static: true},
 	{Exact: "/api/v1/mcp", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/metrics", Static: true, AdminOnly: true},
 	{Method: http.MethodPost, Prefix: "/reports/", Suffix: "/runs", Scope: scopeReportsRun, Static: true},

--- a/internal/bootstrap/auth_route_policy_test.go
+++ b/internal/bootstrap/auth_route_policy_test.go
@@ -86,6 +86,25 @@ func TestGraphActionHTTPRoutesRequireDedicatedScope(t *testing.T) {
 	}
 }
 
+func TestAgentTaskHTTPRoutesPlanWithReadScope(t *testing.T) {
+	for _, tt := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: agentContextPath},
+		{method: http.MethodPost, path: "/api/v1/agent/tasks/findings/finding-1/explain"},
+		{method: http.MethodPost, path: "/api/v1/agent/tasks/findings/finding-1/triage"},
+		{method: http.MethodPost, path: "/api/v1/agent/tasks/findings/finding-1/audit-packet"},
+		{method: http.MethodPost, path: "/api/v1/agent/tasks/source-runtimes/runtime-1/retry"},
+		{method: http.MethodPost, path: "/api/v1/agent/tasks/reports/report-1/run"},
+	} {
+		policy := httpRoutePolicyFor(tt.method, tt.path)
+		if policy.Scope != scopeCosmoSecurityRead || policy.AdminOnly {
+			t.Fatalf("%s %s policy = %#v, want read scope for planning", tt.method, tt.path, policy)
+		}
+	}
+}
+
 func TestAskQueryHTTPRoutesRequireWriteScope(t *testing.T) {
 	readPolicy := httpRoutePolicyFor(http.MethodGet, "/ask-queries")
 	if readPolicy.Scope != scopeCosmoSecurityRead || readPolicy.AdminOnly {

--- a/internal/bootstrap/oauth_handlers.go
+++ b/internal/bootstrap/oauth_handlers.go
@@ -32,7 +32,10 @@ func (app *App) handleOAuthProtectedResourceMetadata(w http.ResponseWriter, r *h
 	cfg := app.cfg.Auth.MCPOAuth
 	resource := strings.TrimSpace(cfg.Resource)
 	if resource == "" {
-		resource = externalOrigin(r, app.cfg.Auth.RequestOrigin) + mcpEndpointPath
+		resource = strings.TrimRight(externalOrigin(r, app.cfg.Auth.RequestOrigin), "/")
+		if r != nil && r.URL != nil && r.URL.Path == oauthProtectedResourceMetadataMCPPath {
+			resource += mcpEndpointPath
+		}
 	}
 	issuer := strings.TrimSpace(cfg.Issuer)
 	if issuer == "" {
@@ -73,7 +76,24 @@ func (app *App) handleOAuthAuthorizationServerMetadata(w http.ResponseWriter, r 
 func supportedOAuthScopes() []string {
 	return []string{
 		scopeCosmoSecurityRead,
+		scopeAskQueriesWrite,
+		scopeConnectorDefinitionsWrite,
+		scopeConnectorCredentialsRead,
+		scopeConnectorCredentialsWrite,
+		scopeConnectorsWrite,
+		scopeDashboardsWrite,
+		scopeFindingCandidatePromote,
+		scopeFindingLifecycleWrite,
+		scopeGRCInventoryWrite,
+		scopeGRCPolicyLifecycleWrite,
 		scopeGraphActionsWrite,
+		scopeJobsWrite,
+		scopeReportsRun,
+		scopeRiskScoringWrite,
+		scopeRuntimeResponseWrite,
+		scopeSourceRuntimesWrite,
+		scopeUserPreferencesWrite,
+		scopeWorkflowReplay,
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -71,6 +71,7 @@ func (app *App) registerPublicRoutes(mux *http.ServeMux) {
 }
 func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /api/v1/a2a", routeSurfacePlatformHTTP, app.handleA2AJSONRPC)
+	registerHTTPRoute(mux, "GET /api/v1/agent/context", routeSurfacePlatformHTTP, app.handleAgentContext)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/contract", routeSurfacePlatformHTTP, app.handleAgentPlatformContract)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/capabilities", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilities)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/security-control-plane", routeSurfacePlatformHTTP, app.handleAgentPlatformSecurityControlPlane)
@@ -81,6 +82,11 @@ func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/evidence-packets", routeSurfacePlatformHTTP, app.handleAgentPlatformEvidencePacket)
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/claims/verify", routeSurfacePlatformHTTP, app.handleAgentPlatformClaimVerification)
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/graph/reason", routeSurfacePlatformHTTP, app.handleAgentPlatformGraphReason)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/explain", routeSurfacePlatformHTTP, app.handleAgentFindingExplainTask)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/triage", routeSurfacePlatformHTTP, app.handleAgentFindingTriageTask)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/audit-packet", routeSurfacePlatformHTTP, app.handleAgentFindingAuditPacketTask)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", routeSurfacePlatformHTTP, app.handleAgentSourceRuntimeRetryTask)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/reports/{reportID}/run", routeSurfacePlatformHTTP, app.handleAgentReportRunTask)
 }
 func (app *App) registerOAuthRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /.well-known/oauth-protected-resource", routeSurfacePublicHTTP, app.handleOAuthProtectedResourceMetadata)

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -70,8 +70,9 @@ func (app *App) registerPublicRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /.well-known/agent.json", routeSurfacePublicHTTP, app.handleA2AAgentCard)
 }
 func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
+	agentTasks := app.agentTaskHandler()
 	registerHTTPRoute(mux, "POST /api/v1/a2a", routeSurfacePlatformHTTP, app.handleA2AJSONRPC)
-	registerHTTPRoute(mux, "GET /api/v1/agent/context", routeSurfacePlatformHTTP, app.handleAgentContext)
+	registerHTTPRoute(mux, "GET /api/v1/agent/context", routeSurfacePlatformHTTP, agentTasks.Context)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/contract", routeSurfacePlatformHTTP, app.handleAgentPlatformContract)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/capabilities", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilities)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/security-control-plane", routeSurfacePlatformHTTP, app.handleAgentPlatformSecurityControlPlane)
@@ -82,11 +83,11 @@ func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/evidence-packets", routeSurfacePlatformHTTP, app.handleAgentPlatformEvidencePacket)
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/claims/verify", routeSurfacePlatformHTTP, app.handleAgentPlatformClaimVerification)
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/graph/reason", routeSurfacePlatformHTTP, app.handleAgentPlatformGraphReason)
-	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/explain", routeSurfacePlatformHTTP, app.handleAgentFindingExplainTask)
-	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/triage", routeSurfacePlatformHTTP, app.handleAgentFindingTriageTask)
-	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/audit-packet", routeSurfacePlatformHTTP, app.handleAgentFindingAuditPacketTask)
-	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", routeSurfacePlatformHTTP, app.handleAgentSourceRuntimeRetryTask)
-	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/reports/{reportID}/run", routeSurfacePlatformHTTP, app.handleAgentReportRunTask)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/explain", routeSurfacePlatformHTTP, agentTasks.FindingExplain)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/triage", routeSurfacePlatformHTTP, agentTasks.FindingTriage)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/findings/{findingID}/audit-packet", routeSurfacePlatformHTTP, agentTasks.FindingAuditPacket)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", routeSurfacePlatformHTTP, agentTasks.SourceRuntimeRetry)
+	registerHTTPRoute(mux, "POST /api/v1/agent/tasks/reports/{reportID}/run", routeSurfacePlatformHTTP, agentTasks.ReportRun)
 }
 func (app *App) registerOAuthRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /.well-known/oauth-protected-resource", routeSurfacePublicHTTP, app.handleOAuthProtectedResourceMetadata)

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -258,6 +258,7 @@ func httpRequestWideAttributes(r *http.Request, method string, route string) tel
 		telemetry.Field{Key: "http.request.header.content_type", Value: requestHeader(r, "Content-Type")},
 		telemetry.Field{Key: "http.request.header.user_agent.present", Value: requestHeader(r, "User-Agent") != ""},
 		telemetry.Field{Key: "user_agent.family", Value: userAgentFamily(requestHeader(r, "User-Agent"))},
+		telemetry.Field{Key: "client.actor_type", Value: userAgentActorType(requestHeader(r, "User-Agent"))},
 		telemetry.Field{Key: "client.address_hash", Value: remoteAddressHash(r)},
 	))
 }
@@ -444,6 +445,14 @@ func userAgentFamily(value string) string {
 	switch {
 	case normalized == "":
 		return "none"
+	case strings.Contains(normalized, "codex"):
+		return "codex"
+	case strings.Contains(normalized, "openai"):
+		return "openai"
+	case strings.Contains(normalized, "mcp"):
+		return "mcp"
+	case strings.Contains(normalized, "slack"):
+		return "slack"
 	case strings.Contains(normalized, "bot"), strings.Contains(normalized, "crawler"), strings.Contains(normalized, "spider"):
 		return "bot"
 	case strings.Contains(normalized, "edge"), strings.Contains(normalized, "edg/"):
@@ -456,8 +465,52 @@ func userAgentFamily(value string) string {
 		return "firefox"
 	case strings.Contains(normalized, "curl"):
 		return "curl"
+	case strings.Contains(normalized, "python-requests"):
+		return "python-requests"
+	case strings.Contains(normalized, "go-http-client"):
+		return "go-http-client"
+	case strings.Contains(normalized, "node-fetch"):
+		return "node-fetch"
+	case strings.Contains(normalized, "axios"):
+		return "axios"
+	case strings.Contains(normalized, "postman"):
+		return "postman"
 	default:
 		return "other"
+	}
+}
+
+func userAgentActorType(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case normalized == "":
+		return "unknown"
+	case strings.Contains(normalized, "codex"),
+		strings.Contains(normalized, "openai"),
+		strings.Contains(normalized, "mcp"),
+		strings.Contains(normalized, "langchain"),
+		strings.Contains(normalized, "autogen"),
+		strings.Contains(normalized, "crewai"),
+		strings.Contains(normalized, "claude"),
+		strings.Contains(normalized, "anthropic"),
+		strings.Contains(normalized, "bot"),
+		strings.Contains(normalized, "crawler"),
+		strings.Contains(normalized, "spider"):
+		return "agent"
+	case strings.Contains(normalized, "mozilla") &&
+		(strings.Contains(normalized, "chrome") || strings.Contains(normalized, "safari") || strings.Contains(normalized, "firefox") || strings.Contains(normalized, "edg/")):
+		return "human"
+	case strings.Contains(normalized, "curl"),
+		strings.Contains(normalized, "httpie"),
+		strings.Contains(normalized, "wget"),
+		strings.Contains(normalized, "python-requests"),
+		strings.Contains(normalized, "go-http-client"),
+		strings.Contains(normalized, "node-fetch"),
+		strings.Contains(normalized, "axios"),
+		strings.Contains(normalized, "postman"):
+		return "automation"
+	default:
+		return "unknown"
 	}
 }
 
@@ -565,6 +618,7 @@ var exactRouteLabels = map[string]struct{}{
 	"/platform/telemetry/ingest":                                          {},
 	"/source-runtimes":                                                    {},
 	"/api/v1/a2a":                                                         {},
+	"/api/v1/agent/context":                                               {},
 	"/api/v1/agent-platform/contract":                                     {},
 	"/api/v1/agent-platform/capabilities":                                 {},
 	"/api/v1/agent-platform/security-control-plane":                       {},
@@ -643,6 +697,16 @@ func dynamicRouteLabel(parts []string) (string, bool) {
 		return "/sources/{sourceID}/read", true
 	case match(parts, "source-runtimes", "health"):
 		return "/source-runtimes/health", true
+	case match(parts, "api", "v1", "agent", "tasks", "findings", "*", "explain"):
+		return "/api/v1/agent/tasks/findings/{findingID}/explain", true
+	case match(parts, "api", "v1", "agent", "tasks", "findings", "*", "triage"):
+		return "/api/v1/agent/tasks/findings/{findingID}/triage", true
+	case match(parts, "api", "v1", "agent", "tasks", "findings", "*", "audit-packet"):
+		return "/api/v1/agent/tasks/findings/{findingID}/audit-packet", true
+	case match(parts, "api", "v1", "agent", "tasks", "source-runtimes", "*", "retry"):
+		return "/api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", true
+	case match(parts, "api", "v1", "agent", "tasks", "reports", "*", "run"):
+		return "/api/v1/agent/tasks/reports/{reportID}/run", true
 	case match(parts, "platform", "graph", "impact", "vulnerability", "*"):
 		return "/platform/graph/impact/vulnerability/{id}", true
 	case match(parts, "platform", "graph", "ingest-runs", "*"):

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -145,6 +145,7 @@ func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
 		"http.request.header.user_agent.present":      true,
 		"http.request.auth_header.present":            true,
 		"user_agent.family":                           "curl",
+		"client.actor_type":                           "automation",
 		"cache.redis.hit.count":                       float64(1),
 		"http.response.status_code":                   float64(http.StatusOK),
 		"http.response.status_class":                  "2xx",
@@ -164,6 +165,30 @@ func TestMiddlewareEmitsHTTPWideEventFields(t *testing.T) {
 	}
 	if strings.Contains(stderr, "curl/8.0") {
 		t.Fatalf("raw user-agent leaked into telemetry: %s", stderr)
+	}
+}
+
+func TestUserAgentActorTypeClassifiesHumanAndAgentClients(t *testing.T) {
+	tests := []struct {
+		name       string
+		userAgent  string
+		wantFamily string
+		wantActor  string
+	}{
+		{name: "browser", userAgent: "Mozilla/5.0 Chrome/126.0", wantFamily: "chrome", wantActor: "human"},
+		{name: "agent", userAgent: "Codex/1.0", wantFamily: "codex", wantActor: "agent"},
+		{name: "automation", userAgent: "python-requests/2.32", wantFamily: "python-requests", wantActor: "automation"},
+		{name: "empty", userAgent: "", wantFamily: "none", wantActor: "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := userAgentFamily(tt.userAgent); got != tt.wantFamily {
+				t.Fatalf("family = %q, want %q", got, tt.wantFamily)
+			}
+			if got := userAgentActorType(tt.userAgent); got != tt.wantActor {
+				t.Fatalf("actor = %q, want %q", got, tt.wantActor)
+			}
+		})
 	}
 }
 

--- a/internal/sourcehttp/agenttasks/handler.go
+++ b/internal/sourcehttp/agenttasks/handler.go
@@ -575,7 +575,7 @@ func taskParameters(req TaskRequest, tenantID string) map[string]string {
 	for key, value := range req.Parameters {
 		parameters[key] = value
 	}
-	if strings.TrimSpace(parameters["tenant_id"]) == "" && strings.TrimSpace(tenantID) != "" {
+	if strings.TrimSpace(tenantID) != "" {
 		parameters["tenant_id"] = strings.TrimSpace(tenantID)
 	}
 	return parameters

--- a/internal/sourcehttp/agenttasks/handler.go
+++ b/internal/sourcehttp/agenttasks/handler.go
@@ -549,7 +549,6 @@ func readTaskRequest(w http.ResponseWriter, r *http.Request) (TaskRequest, error
 		return request, nil
 	}
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<20))
-	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&request); err != nil {
 		if errors.Is(err, io.EOF) {
 			return request, nil

--- a/internal/sourcehttp/agenttasks/handler.go
+++ b/internal/sourcehttp/agenttasks/handler.go
@@ -14,7 +14,10 @@ import (
 	"github.com/writer/cerebro/internal/agentplatform"
 )
 
-const ContextPath = "/api/v1/agent/context"
+const (
+	ContextPath             = "/api/v1/agent/context"
+	maxTaskRequestBodyBytes = 1 << 20
+)
 
 var ErrInvalidRequest = errors.New("invalid agent task request")
 
@@ -325,7 +328,9 @@ func (h Handler) ReportRun(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, err)
 		return
 	}
-	if tenantID := strings.TrimSpace(firstNonEmpty(req.TenantID, req.Parameters["tenant_id"])); tenantID != "" {
+	tenantID := strings.TrimSpace(firstNonEmpty(req.TenantID, req.Parameters["tenant_id"]))
+	parameters := taskParameters(req, tenantID)
+	if tenantID != "" {
 		if err := h.authorizeTenant(r.Context(), tenantID); err != nil {
 			h.writeError(w, err)
 			return
@@ -338,7 +343,7 @@ func (h Handler) ReportRun(w http.ResponseWriter, r *http.Request) {
 		RequiredScope:    h.deps.Scopes.ReportsRun,
 		ApprovalRequired: true,
 		DryRunSupported:  true,
-		Parameters:       req.Parameters,
+		Parameters:       parameters,
 	}
 	if req.DryRun || !req.Approved {
 		response.Status = "dry_run"
@@ -353,7 +358,11 @@ func (h Handler) ReportRun(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, err)
 		return
 	}
-	result, err := h.runReport(r.Context(), reportID, req.Parameters)
+	if tenantID == "" {
+		h.writeError(w, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest))
+		return
+	}
+	result, err := h.runReport(r.Context(), reportID, parameters)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -548,7 +557,7 @@ func readTaskRequest(w http.ResponseWriter, r *http.Request) (TaskRequest, error
 	if r == nil || r.Body == nil {
 		return request, nil
 	}
-	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<20))
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxTaskRequestBodyBytes))
 	if err := decoder.Decode(&request); err != nil {
 		if errors.Is(err, io.EOF) {
 			return request, nil
@@ -559,6 +568,17 @@ func readTaskRequest(w http.ResponseWriter, r *http.Request) (TaskRequest, error
 		request.Parameters = map[string]string{}
 	}
 	return request, nil
+}
+
+func taskParameters(req TaskRequest, tenantID string) map[string]string {
+	parameters := make(map[string]string, len(req.Parameters)+1)
+	for key, value := range req.Parameters {
+		parameters[key] = value
+	}
+	if strings.TrimSpace(parameters["tenant_id"]) == "" && strings.TrimSpace(tenantID) != "" {
+		parameters["tenant_id"] = strings.TrimSpace(tenantID)
+	}
+	return parameters
 }
 
 func pageLimitFromTask(req TaskRequest) (uint32, error) {

--- a/internal/sourcehttp/agenttasks/handler.go
+++ b/internal/sourcehttp/agenttasks/handler.go
@@ -1,0 +1,689 @@
+package agenttasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+)
+
+const ContextPath = "/api/v1/agent/context"
+
+var ErrInvalidRequest = errors.New("invalid agent task request")
+
+type ScopeSet struct {
+	SecurityRead          string
+	GraphActionsWrite     string
+	FindingLifecycleWrite string
+	SourceRuntimesWrite   string
+	ReportsRun            string
+}
+
+type Dependencies struct {
+	Origin                       func(*http.Request) string
+	Caller                       func(*http.Request) CallerContext
+	SupportedScopes              func() []string
+	OAuthProtectedResourcePath   string
+	OAuthAuthorizationServerPath string
+	OAuthTokenPath               string
+	Scopes                       ScopeSet
+	AuthorizeFinding             func(context.Context, string) error
+	AuthorizeSourceRuntime       func(context.Context, string) error
+	AuthorizeTenant              func(context.Context, string) error
+	AuthorizeExecutionScope      func(context.Context, string) error
+	SyncRuntime                  func(context.Context, string, uint32) (RuntimeSyncResult, error)
+	RunReport                    func(context.Context, string, map[string]string) (ReportRunResult, error)
+	ErrorStatus                  func(error) int
+	ErrorMessage                 func(int, error) string
+}
+
+type Handler struct {
+	deps Dependencies
+}
+
+type ContextResponse struct {
+	Version          string            `json:"version"`
+	Links            map[string]string `json:"links"`
+	Auth             AuthDiscovery     `json:"auth"`
+	Caller           CallerContext     `json:"caller"`
+	MutationContract MutationContract  `json:"mutation_contract"`
+	Telemetry        TelemetryContext  `json:"telemetry"`
+	Workflows        []Workflow        `json:"workflows"`
+}
+
+type AuthDiscovery struct {
+	Schemes                   []string `json:"schemes"`
+	ProtectedResourceMetadata string   `json:"protected_resource_metadata"`
+	AuthorizationServer       string   `json:"authorization_server"`
+	TokenEndpoint             string   `json:"token_endpoint"`
+	RequiredDefaultScope      string   `json:"required_default_scope"`
+	SupportedScopes           []string `json:"supported_scopes"`
+}
+
+type CallerContext struct {
+	Authenticated bool     `json:"authenticated"`
+	TenantID      string   `json:"tenant_id,omitempty"`
+	ActorID       string   `json:"actor_id,omitempty"`
+	AuthMode      string   `json:"auth_mode,omitempty"`
+	ActorType     string   `json:"actor_type"`
+	Scopes        []string `json:"scopes,omitempty"`
+	UserAgent     string   `json:"user_agent"`
+}
+
+type MutationContract struct {
+	DryRunField      string   `json:"dry_run_field"`
+	ApprovalField    string   `json:"approval_field"`
+	Idempotency      string   `json:"idempotency"`
+	DefaultBehavior  string   `json:"default_behavior"`
+	ExecutionRules   []string `json:"execution_rules"`
+	SupportedActions []string `json:"supported_actions"`
+}
+
+type TelemetryContext struct {
+	ActorTypeAttribute string   `json:"actor_type_attribute"`
+	UserAgentAttribute string   `json:"user_agent_attribute"`
+	RequestHeaders     []string `json:"request_headers"`
+}
+
+type Workflow struct {
+	ID             string       `json:"id"`
+	Resource       string       `json:"resource"`
+	StateCheck     NextAction   `json:"state_check"`
+	NextActions    []NextAction `json:"next_actions"`
+	SlackBotIntent string       `json:"slack_bot_intent,omitempty"`
+}
+
+type NextAction struct {
+	ID               string `json:"id"`
+	Label            string `json:"label"`
+	Method           string `json:"method"`
+	Path             string `json:"path"`
+	RequiredScope    string `json:"required_scope"`
+	Stage            string `json:"stage"`
+	DryRunSupported  bool   `json:"dry_run_supported,omitempty"`
+	ApprovalRequired bool   `json:"approval_required,omitempty"`
+	When             string `json:"when"`
+}
+
+type TaskRequest struct {
+	TenantID    string            `json:"tenant_id,omitempty"`
+	DryRun      bool              `json:"dry_run,omitempty"`
+	Approved    bool              `json:"approved,omitempty"`
+	Reason      string            `json:"reason,omitempty"`
+	Parameters  map[string]string `json:"parameters,omitempty"`
+	Idempotency string            `json:"idempotency_key,omitempty"`
+}
+
+type TaskResponse struct {
+	ID          string         `json:"id"`
+	Kind        string         `json:"kind"`
+	Status      string         `json:"status"`
+	Resource    ResourceRef    `json:"resource"`
+	DryRun      bool           `json:"dry_run"`
+	Approved    bool           `json:"approved"`
+	Reason      string         `json:"reason,omitempty"`
+	Mutation    *MutationRef   `json:"mutation,omitempty"`
+	NextActions []NextAction   `json:"next_actions,omitempty"`
+	Result      map[string]any `json:"result,omitempty"`
+}
+
+type ResourceRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Path string `json:"path"`
+}
+
+type MutationRef struct {
+	Method           string            `json:"method"`
+	Path             string            `json:"path"`
+	RequiredScope    string            `json:"required_scope"`
+	ApprovalRequired bool              `json:"approval_required"`
+	DryRunSupported  bool              `json:"dry_run_supported"`
+	Parameters       map[string]string `json:"parameters,omitempty"`
+}
+
+type RuntimeSyncResult struct {
+	RuntimeID         string
+	PagesRead         uint32
+	EventsAppended    uint32
+	EntitiesProjected uint32
+	LinksProjected    uint32
+}
+
+type ReportRunResult struct {
+	ReportID    string
+	RunID       string
+	Status      string
+	GeneratedAt time.Time
+}
+
+func New(deps Dependencies) Handler {
+	return Handler{deps: deps}
+}
+
+func (h Handler) Context(w http.ResponseWriter, r *http.Request) {
+	origin := h.origin(r)
+	writeJSON(w, http.StatusOK, ContextResponse{
+		Version: agentplatform.ContractVersion,
+		Links: map[string]string{
+			"openapi":             origin + "/openapi.yaml",
+			"agent_card":          origin + agentplatform.A2AAgentCardPath,
+			"agent_platform":      origin + "/api/v1/agent-platform/contract",
+			"capabilities":        origin + "/api/v1/agent-platform/capabilities",
+			"event_subscriptions": origin + agentplatform.EventSubscriptionContractPath,
+			"idempotency":         origin + agentplatform.IdempotencyContractPath,
+		},
+		Auth:             h.authDiscovery(origin),
+		Caller:           h.caller(r),
+		MutationContract: mutationContract(),
+		Telemetry: TelemetryContext{
+			ActorTypeAttribute: "client.actor_type",
+			UserAgentAttribute: "user_agent.family",
+			RequestHeaders:     []string{"User-Agent", "X-Request-Id", "X-Cerebro-Tenant", "Idempotency-Key"},
+		},
+		Workflows: h.workflows(),
+	})
+}
+
+func (h Handler) FindingExplain(w http.ResponseWriter, r *http.Request) {
+	findingID := r.PathValue("findingID")
+	if err := h.authorizeFinding(r.Context(), findingID); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	req, err := readTaskRequest(w, r)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response := h.baseTaskResponse("finding_explain", "finding", findingID, "/findings/"+findingID, req)
+	response.Status = "planned"
+	response.NextActions = h.findingNextActions(findingID)
+	response.Result = map[string]any{
+		"read_path":        "/findings/" + findingID,
+		"evidence_request": "/api/v1/agent-platform/evidence-packets",
+		"graph_reason":     "/api/v1/agent-platform/graph/reason",
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (h Handler) FindingTriage(w http.ResponseWriter, r *http.Request) {
+	findingID := r.PathValue("findingID")
+	if err := h.authorizeFinding(r.Context(), findingID); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	req, err := readTaskRequest(w, r)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response := h.baseTaskResponse("finding_triage", "finding", findingID, "/findings/"+findingID, req)
+	response.Status = "planned"
+	response.NextActions = h.findingNextActions(findingID)
+	response.Result = map[string]any{
+		"lifecycle_paths": []string{
+			"/findings/" + findingID + "/assign",
+			"/findings/" + findingID + "/due",
+			"/findings/" + findingID + "/notes",
+			"/findings/" + findingID + "/tickets",
+			"/findings/" + findingID + "/resolve",
+			"/findings/" + findingID + "/suppress",
+		},
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (h Handler) FindingAuditPacket(w http.ResponseWriter, r *http.Request) {
+	findingID := r.PathValue("findingID")
+	if err := h.authorizeFinding(r.Context(), findingID); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	req, err := readTaskRequest(w, r)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response := h.baseTaskResponse("finding_audit_packet", "finding", findingID, "/findings/"+findingID, req)
+	response.Status = "planned"
+	response.NextActions = []NextAction{
+		{ID: "build_evidence_packet", Label: "Build evidence packet", Method: http.MethodPost, Path: "/api/v1/agent-platform/evidence-packets", RequiredScope: h.deps.Scopes.SecurityRead, Stage: "explain", When: "Use scope_urn for the finding and include evidence URNs when known."},
+		{ID: "read_control_packets", Label: "Read control packets", Method: http.MethodGet, Path: "/grc/control-packets", RequiredScope: h.deps.Scopes.SecurityRead, Stage: "explain", When: "Use when the finding maps to framework controls."},
+	}
+	response.Result = map[string]any{
+		"scope_urn": "urn:cerebro:{tenant}:finding:" + findingID,
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (h Handler) SourceRuntimeRetry(w http.ResponseWriter, r *http.Request) {
+	runtimeID := r.PathValue("runtimeID")
+	if err := h.authorizeSourceRuntime(r.Context(), runtimeID); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	req, err := readTaskRequest(w, r)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response := h.baseTaskResponse("source_runtime_retry", "source_runtime", runtimeID, "/source-runtimes/"+runtimeID, req)
+	response.Mutation = &MutationRef{
+		Method:           http.MethodPost,
+		Path:             "/source-runtimes/" + runtimeID + "/sync",
+		RequiredScope:    h.deps.Scopes.SourceRuntimesWrite,
+		ApprovalRequired: true,
+		DryRunSupported:  true,
+		Parameters:       req.Parameters,
+	}
+	if req.DryRun || !req.Approved {
+		response.Status = "dry_run"
+		response.DryRun = true
+		response.NextActions = []NextAction{
+			{ID: "approve_runtime_retry", Label: "Approve runtime retry", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/" + runtimeID + "/retry", RequiredScope: h.deps.Scopes.SourceRuntimesWrite, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Call with approved=true after review."},
+		}
+		writeJSON(w, http.StatusOK, response)
+		return
+	}
+	if err := h.authorizeExecutionScope(r.Context(), h.deps.Scopes.SourceRuntimesWrite); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	pageLimit, err := pageLimitFromTask(req)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	result, err := h.syncRuntime(r.Context(), runtimeID, pageLimit)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response.Status = "succeeded"
+	response.Result = map[string]any{
+		"runtime_id":         result.RuntimeID,
+		"pages_read":         result.PagesRead,
+		"events_appended":    result.EventsAppended,
+		"entities_projected": result.EntitiesProjected,
+		"links_projected":    result.LinksProjected,
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (h Handler) ReportRun(w http.ResponseWriter, r *http.Request) {
+	reportID := r.PathValue("reportID")
+	req, err := readTaskRequest(w, r)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	if tenantID := strings.TrimSpace(firstNonEmpty(req.TenantID, req.Parameters["tenant_id"])); tenantID != "" {
+		if err := h.authorizeTenant(r.Context(), tenantID); err != nil {
+			h.writeError(w, err)
+			return
+		}
+	}
+	response := h.baseTaskResponse("report_run", "report", reportID, "/reports/"+reportID+"/runs", req)
+	response.Mutation = &MutationRef{
+		Method:           http.MethodPost,
+		Path:             "/reports/" + reportID + "/runs",
+		RequiredScope:    h.deps.Scopes.ReportsRun,
+		ApprovalRequired: true,
+		DryRunSupported:  true,
+		Parameters:       req.Parameters,
+	}
+	if req.DryRun || !req.Approved {
+		response.Status = "dry_run"
+		response.DryRun = true
+		response.NextActions = []NextAction{
+			{ID: "approve_report_run", Label: "Approve report run", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/" + reportID + "/run", RequiredScope: h.deps.Scopes.ReportsRun, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Call with approved=true after checking report parameters."},
+		}
+		writeJSON(w, http.StatusOK, response)
+		return
+	}
+	if err := h.authorizeExecutionScope(r.Context(), h.deps.Scopes.ReportsRun); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	result, err := h.runReport(r.Context(), reportID, req.Parameters)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	response.Status = "succeeded"
+	response.Result = map[string]any{
+		"report_id":    result.ReportID,
+		"run_id":       result.RunID,
+		"status":       result.Status,
+		"generated_at": timestampString(result.GeneratedAt),
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (h Handler) authDiscovery(origin string) AuthDiscovery {
+	return AuthDiscovery{
+		Schemes:                   []string{"Authorization: Bearer <token>", "X-Cerebro-API-Key: <key>"},
+		ProtectedResourceMetadata: origin + h.deps.OAuthProtectedResourcePath,
+		AuthorizationServer:       origin + h.deps.OAuthAuthorizationServerPath,
+		TokenEndpoint:             origin + h.deps.OAuthTokenPath,
+		RequiredDefaultScope:      h.deps.Scopes.SecurityRead,
+		SupportedScopes:           h.supportedScopes(),
+	}
+}
+
+func (h Handler) workflows() []Workflow {
+	scopes := h.deps.Scopes
+	return []Workflow{
+		{
+			ID:         "finding_triage",
+			Resource:   "finding",
+			StateCheck: NextAction{ID: "read_finding", Label: "Read finding", Method: http.MethodGet, Path: "/findings/{findingID}", RequiredScope: scopes.SecurityRead, Stage: "observe", When: "Start here before changing finding state."},
+			NextActions: []NextAction{
+				{ID: "explain_finding", Label: "Explain finding", Method: http.MethodPost, Path: "/api/v1/agent/tasks/findings/{findingID}/explain", RequiredScope: scopes.SecurityRead, Stage: "explain", When: "Use when a bot needs a short packet for a channel or review thread."},
+				{ID: "triage_finding", Label: "Prepare triage", Method: http.MethodPost, Path: "/api/v1/agent/tasks/findings/{findingID}/triage", RequiredScope: scopes.SecurityRead, Stage: "recommend", When: "Use when the next owner, due date, note, or ticket is not decided yet."},
+				{ID: "plan_graph_action", Label: "Dry-run graph action", Method: http.MethodPost, Path: "/platform/graph/actions", RequiredScope: scopes.GraphActionsWrite, Stage: "dry_run", DryRunSupported: true, ApprovalRequired: true, When: "Use for provider-backed actions tied to an eligible finding."},
+			},
+			SlackBotIntent: "Post finding summary, owner, evidence, and proposed next step.",
+		},
+		{
+			ID:         "control_packet",
+			Resource:   "control",
+			StateCheck: NextAction{ID: "read_controls", Label: "Read controls", Method: http.MethodGet, Path: "/grc/controls", RequiredScope: scopes.SecurityRead, Stage: "observe", When: "Use before collecting evidence for control status."},
+			NextActions: []NextAction{
+				{ID: "build_control_packet", Label: "Build control packet", Method: http.MethodGet, Path: "/grc/control-packets", RequiredScope: scopes.SecurityRead, Stage: "explain", When: "Use when the team needs evidence and gaps for a control."},
+				{ID: "custom_control_packet", Label: "Build scoped packet", Method: http.MethodPost, Path: "/grc/control-packets", RequiredScope: scopes.SecurityRead, Stage: "explain", When: "Use when the bot has a specific framework, control, or evidence scope."},
+			},
+			SlackBotIntent: "Post control status, missing evidence, stale evidence, and owners.",
+		},
+		{
+			ID:         "report_run",
+			Resource:   "report",
+			StateCheck: NextAction{ID: "list_reports", Label: "List reports", Method: http.MethodGet, Path: "/reports", RequiredScope: scopes.SecurityRead, Stage: "observe", When: "Use before selecting a report id."},
+			NextActions: []NextAction{
+				{ID: "plan_report_run", Label: "Plan report run", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/{reportID}/run", RequiredScope: scopes.SecurityRead, Stage: "dry_run", DryRunSupported: true, When: "Use when a bot needs to show parameters before running a report."},
+				{ID: "run_report", Label: "Run report", Method: http.MethodPost, Path: "/api/v1/agent/tasks/reports/{reportID}/run", RequiredScope: scopes.ReportsRun, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Use after a human approves the report parameters."},
+			},
+			SlackBotIntent: "Post report parameters, run status, and link to the report run.",
+		},
+		{
+			ID:         "runtime_retry",
+			Resource:   "source_runtime",
+			StateCheck: NextAction{ID: "read_runtime", Label: "Read runtime", Method: http.MethodGet, Path: "/source-runtimes/{runtimeID}", RequiredScope: scopes.SecurityRead, Stage: "observe", When: "Use before retrying a runtime."},
+			NextActions: []NextAction{
+				{ID: "plan_runtime_retry", Label: "Plan runtime retry", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", RequiredScope: scopes.SecurityRead, Stage: "dry_run", DryRunSupported: true, When: "Use when a runtime is stale or failed and the bot needs the exact retry call."},
+				{ID: "retry_runtime", Label: "Retry runtime", Method: http.MethodPost, Path: "/api/v1/agent/tasks/source-runtimes/{runtimeID}/retry", RequiredScope: scopes.SourceRuntimesWrite, Stage: "execute", DryRunSupported: true, ApprovalRequired: true, When: "Use after a human approves the retry."},
+			},
+			SlackBotIntent: "Post runtime status, last sync, failure reason, and retry plan.",
+		},
+	}
+}
+
+func ActorTypeFromUserAgent(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case normalized == "":
+		return "unknown"
+	case strings.Contains(normalized, "codex"),
+		strings.Contains(normalized, "openai"),
+		strings.Contains(normalized, "mcp"),
+		strings.Contains(normalized, "langchain"),
+		strings.Contains(normalized, "autogen"),
+		strings.Contains(normalized, "crewai"),
+		strings.Contains(normalized, "claude"),
+		strings.Contains(normalized, "anthropic"):
+		return "agent"
+	case strings.Contains(normalized, "bot"),
+		strings.Contains(normalized, "crawler"),
+		strings.Contains(normalized, "spider"):
+		return "agent"
+	case strings.Contains(normalized, "mozilla") &&
+		(strings.Contains(normalized, "chrome") || strings.Contains(normalized, "safari") || strings.Contains(normalized, "firefox") || strings.Contains(normalized, "edg/")):
+		return "human"
+	case strings.Contains(normalized, "curl"),
+		strings.Contains(normalized, "httpie"),
+		strings.Contains(normalized, "wget"),
+		strings.Contains(normalized, "python-requests"),
+		strings.Contains(normalized, "go-http-client"),
+		strings.Contains(normalized, "node-fetch"),
+		strings.Contains(normalized, "axios"),
+		strings.Contains(normalized, "postman"):
+		return "automation"
+	default:
+		return "unknown"
+	}
+}
+
+func UserAgentFamily(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case normalized == "":
+		return "none"
+	case strings.Contains(normalized, "codex"):
+		return "codex"
+	case strings.Contains(normalized, "openai"):
+		return "openai"
+	case strings.Contains(normalized, "mcp"):
+		return "mcp"
+	case strings.Contains(normalized, "slack"):
+		return "slack"
+	case strings.Contains(normalized, "bot"), strings.Contains(normalized, "crawler"), strings.Contains(normalized, "spider"):
+		return "bot"
+	case strings.Contains(normalized, "edge"), strings.Contains(normalized, "edg/"):
+		return "edge"
+	case strings.Contains(normalized, "chrome"):
+		return "chrome"
+	case strings.Contains(normalized, "safari"):
+		return "safari"
+	case strings.Contains(normalized, "firefox"):
+		return "firefox"
+	case strings.Contains(normalized, "curl"):
+		return "curl"
+	case strings.Contains(normalized, "python-requests"):
+		return "python-requests"
+	case strings.Contains(normalized, "go-http-client"):
+		return "go-http-client"
+	case strings.Contains(normalized, "node-fetch"):
+		return "node-fetch"
+	case strings.Contains(normalized, "axios"):
+		return "axios"
+	case strings.Contains(normalized, "postman"):
+		return "postman"
+	default:
+		return "other"
+	}
+}
+
+func mutationContract() MutationContract {
+	return MutationContract{
+		DryRunField:     "dry_run",
+		ApprovalField:   "approved",
+		Idempotency:     "Use Idempotency-Key or idempotency_key on approved writes that may be retried.",
+		DefaultBehavior: "Agent task endpoints return a plan unless approved=true and dry_run is false.",
+		ExecutionRules: []string{
+			"Read and explain actions require the read scope only.",
+			"Mutating runtime and report tasks require their dedicated write scope.",
+			"Provider-backed graph actions support dry_run=true and require approved=true before execution.",
+			"Finding lifecycle updates stay on typed finding endpoints and require the finding lifecycle write scope.",
+		},
+		SupportedActions: []string{
+			"identity.okta.suspend_user",
+			"identity.okta.unsuspend_user",
+			"endpoint.cerebro.revoke_device",
+		},
+	}
+}
+
+func (h Handler) baseTaskResponse(kind string, resourceType string, resourceID string, path string, req TaskRequest) TaskResponse {
+	return TaskResponse{
+		ID:       "agent-task:" + kind + ":" + resourceID,
+		Kind:     kind,
+		Status:   "planned",
+		Resource: ResourceRef{Type: resourceType, ID: resourceID, Path: path},
+		DryRun:   req.DryRun,
+		Approved: req.Approved,
+		Reason:   strings.TrimSpace(req.Reason),
+	}
+}
+
+func (h Handler) findingNextActions(findingID string) []NextAction {
+	scopes := h.deps.Scopes
+	return []NextAction{
+		{ID: "build_evidence_packet", Label: "Build evidence packet", Method: http.MethodPost, Path: "/api/v1/agent-platform/evidence-packets", RequiredScope: scopes.SecurityRead, Stage: "explain", When: "Use before posting a finding summary or making a recommendation."},
+		{ID: "add_note", Label: "Add finding note", Method: http.MethodPost, Path: "/findings/" + findingID + "/notes", RequiredScope: scopes.FindingLifecycleWrite, Stage: "close_loop", ApprovalRequired: true, When: "Use after the team approves the note text."},
+		{ID: "link_ticket", Label: "Link ticket", Method: http.MethodPost, Path: "/findings/" + findingID + "/tickets", RequiredScope: scopes.FindingLifecycleWrite, Stage: "close_loop", ApprovalRequired: true, When: "Use when a remediation ticket already exists."},
+		{ID: "dry_run_graph_action", Label: "Dry-run graph action", Method: http.MethodPost, Path: "/platform/graph/actions", RequiredScope: scopes.GraphActionsWrite, Stage: "dry_run", DryRunSupported: true, ApprovalRequired: true, When: "Use for supported provider actions attached to the finding."},
+	}
+}
+
+func readTaskRequest(w http.ResponseWriter, r *http.Request) (TaskRequest, error) {
+	request := TaskRequest{Parameters: map[string]string{}}
+	if r == nil || r.Body == nil {
+		return request, nil
+	}
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<20))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		if errors.Is(err, io.EOF) {
+			return request, nil
+		}
+		return TaskRequest{}, fmt.Errorf("%w: decode agent task request: %w", ErrInvalidRequest, err)
+	}
+	if request.Parameters == nil {
+		request.Parameters = map[string]string{}
+	}
+	return request, nil
+}
+
+func pageLimitFromTask(req TaskRequest) (uint32, error) {
+	raw := strings.TrimSpace(req.Parameters["page_limit"])
+	if raw == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: page_limit must be a positive integer", ErrInvalidRequest)
+	}
+	if value == 0 {
+		return 0, fmt.Errorf("%w: page_limit must be a positive integer", ErrInvalidRequest)
+	}
+	return uint32(value), nil
+}
+
+func (h Handler) origin(r *http.Request) string {
+	origin := ""
+	if h.deps.Origin != nil {
+		origin = h.deps.Origin(r)
+	}
+	origin = strings.TrimRight(strings.TrimSpace(origin), "/")
+	if origin == "" {
+		return "https://cerebro"
+	}
+	return origin
+}
+
+func (h Handler) caller(r *http.Request) CallerContext {
+	if h.deps.Caller == nil {
+		return CallerContext{ActorType: "unknown", UserAgent: "none"}
+	}
+	return h.deps.Caller(r)
+}
+
+func (h Handler) supportedScopes() []string {
+	if h.deps.SupportedScopes == nil {
+		return nil
+	}
+	return h.deps.SupportedScopes()
+}
+
+func (h Handler) authorizeFinding(ctx context.Context, findingID string) error {
+	if h.deps.AuthorizeFinding == nil {
+		return nil
+	}
+	return h.deps.AuthorizeFinding(ctx, findingID)
+}
+
+func (h Handler) authorizeSourceRuntime(ctx context.Context, runtimeID string) error {
+	if h.deps.AuthorizeSourceRuntime == nil {
+		return nil
+	}
+	return h.deps.AuthorizeSourceRuntime(ctx, runtimeID)
+}
+
+func (h Handler) authorizeTenant(ctx context.Context, tenantID string) error {
+	if h.deps.AuthorizeTenant == nil {
+		return nil
+	}
+	return h.deps.AuthorizeTenant(ctx, tenantID)
+}
+
+func (h Handler) authorizeExecutionScope(ctx context.Context, scope string) error {
+	if h.deps.AuthorizeExecutionScope == nil {
+		return nil
+	}
+	return h.deps.AuthorizeExecutionScope(ctx, scope)
+}
+
+func (h Handler) syncRuntime(ctx context.Context, runtimeID string, pageLimit uint32) (RuntimeSyncResult, error) {
+	if h.deps.SyncRuntime == nil {
+		return RuntimeSyncResult{}, errors.New("agent runtime sync is not configured")
+	}
+	return h.deps.SyncRuntime(ctx, runtimeID, pageLimit)
+}
+
+func (h Handler) runReport(ctx context.Context, reportID string, parameters map[string]string) (ReportRunResult, error) {
+	if h.deps.RunReport == nil {
+		return ReportRunResult{}, errors.New("agent report run is not configured")
+	}
+	return h.deps.RunReport(ctx, reportID, parameters)
+}
+
+func (h Handler) writeError(w http.ResponseWriter, err error) {
+	status := h.status(err)
+	message := err.Error()
+	if h.deps.ErrorMessage != nil {
+		message = h.deps.ErrorMessage(status, err)
+	}
+	writeJSON(w, status, map[string]any{"error": message})
+}
+
+func (h Handler) status(err error) int {
+	if h.deps.ErrorStatus != nil {
+		if status := h.deps.ErrorStatus(err); status != 0 {
+			return status
+		}
+	}
+	if errors.Is(err, ErrInvalidRequest) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}
+
+func timestampString(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/internal/sourcehttp/agenttasks/handler_test.go
+++ b/internal/sourcehttp/agenttasks/handler_test.go
@@ -22,3 +22,25 @@ func TestReadTaskRequestUsesInboundBodyLimit(t *testing.T) {
 		t.Fatalf("readTaskRequest() error = %v, want MaxBytesError", err)
 	}
 }
+
+func TestTaskParametersNormalizesTenantToAuthorizedValue(t *testing.T) {
+	request := TaskRequest{
+		TenantID: " authorized-tenant ",
+		Parameters: map[string]string{
+			"tenant_id": "other-tenant",
+			"format":    "packet",
+		},
+	}
+
+	parameters := taskParameters(request, strings.TrimSpace(request.TenantID))
+
+	if parameters["tenant_id"] != "authorized-tenant" {
+		t.Fatalf("tenant_id = %q, want authorized tenant", parameters["tenant_id"])
+	}
+	if parameters["format"] != "packet" {
+		t.Fatalf("format = %q, want existing parameter preserved", parameters["format"])
+	}
+	if request.Parameters["tenant_id"] != "other-tenant" {
+		t.Fatalf("request parameters were mutated: %+v", request.Parameters)
+	}
+}

--- a/internal/sourcehttp/agenttasks/handler_test.go
+++ b/internal/sourcehttp/agenttasks/handler_test.go
@@ -1,0 +1,24 @@
+package agenttasks
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReadTaskRequestUsesInboundBodyLimit(t *testing.T) {
+	body := `{"reason":"` + strings.Repeat("a", 2<<20) + `"}`
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent/tasks/findings/finding-1/explain", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	_, err := readTaskRequest(recorder, request)
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("readTaskRequest() error = %v, want ErrInvalidRequest", err)
+	}
+	var maxBytesErr *http.MaxBytesError
+	if !errors.As(err, &maxBytesErr) {
+		t.Fatalf("readTaskRequest() error = %v, want MaxBytesError", err)
+	}
+}

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -92,8 +92,11 @@ import (
 // assembly and runtime state stay behind the existing registry, catalog, and
 // store boundaries. Duo connector setup adds resource-family metadata and
 // config-query keys through schema/response mapping at the existing connector
-// catalog boundary.
-const bootstrapProductionGoLineBudget = 27088
+// catalog boundary. Agent-friendly HTTP context and task routes add route/auth
+// wiring, caller-context mapping, and existing runtime/report service adapters;
+// task planning and response shapes live in internal/sourcehttp/agenttasks, and
+// auth discovery stays at the HTTP boundary.
+const bootstrapProductionGoLineBudget = 27328
 
 type bootstrapFileLineCount struct {
 	path  string

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -95,8 +95,10 @@ import (
 // catalog boundary. Agent-friendly HTTP context and task routes add route/auth
 // wiring, caller-context mapping, and existing runtime/report service adapters;
 // task planning and response shapes live in internal/sourcehttp/agenttasks, and
-// auth discovery stays at the HTTP boundary.
-const bootstrapProductionGoLineBudget = 27328
+// auth discovery stays at the HTTP boundary. Agent task review hardening keeps
+// tenant-before-mutation checks and auth-challenge classification in bootstrap
+// because those depend on bootstrap auth sentinels and HTTP route policy.
+const bootstrapProductionGoLineBudget = 27373
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- add an authenticated agent context endpoint with auth discovery, workflow next actions, dry-run and approval guidance, and low-cardinality telemetry hints
- add agent task planning endpoints for finding explain/triage/audit packet, source runtime retry, and report runs
- return structured auth errors with required scope and token discovery details, and classify request user agents as human, agent, automation, or unknown in telemetry

## Tests
- go test ./internal/bootstrap ./internal/agentplatform ./internal/observability ./api -count=1
- make contracts-check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->