### PR TITLE
[codex] Deepen MITRE graph coverage

### DIFF
--- a/internal/findings/event_rule.go
+++ b/internal/findings/event_rule.go
@@ -67,12 +67,19 @@ type RuleDefinition struct {
 	FingerprintFields        []string
 	ControlRefs              []ports.FindingControlRef
 	MITREAttack              []MITREAttackRef
+	MITREDefend              []MITREDefendRef
 	Lifecycle                Lifecycle
 }
 
 type MITREAttackRef struct {
 	Tactic    string `json:"tactic"`
 	Technique string `json:"technique"`
+}
+
+type MITREDefendRef struct {
+	Tactic    string `json:"tactic,omitempty"`
+	Technique string `json:"technique,omitempty"`
+	Artifact  string `json:"artifact,omitempty"`
 }
 
 type eventRuleConfig struct {
@@ -191,6 +198,11 @@ func (d RuleDefinition) AttributeMap() map[string]string {
 	joinAttribute(attributes, "mitre_attack", mitrePairs)
 	joinAttribute(attributes, "mitre_attack_tactics", mitreTactics)
 	joinAttribute(attributes, "mitre_attack_techniques", mitreTechniques)
+	defendTactics, defendTechniques, defendArtifacts, defendRefs := mitreDefendAttributeValues(d.MITREDefend)
+	joinAttribute(attributes, "mitre_defend", defendRefs)
+	joinAttribute(attributes, "mitre_defend_tactics", defendTactics)
+	joinAttribute(attributes, "mitre_defend_techniques", defendTechniques)
+	joinAttribute(attributes, "mitre_defend_artifacts", defendArtifacts)
 	joinAttribute(attributes, "tags", d.Tags)
 	if strings.TrimSpace(d.Runbook) != "" {
 		attributes["runbook"] = strings.TrimSpace(d.Runbook)
@@ -241,6 +253,60 @@ func mitreAttackAttributeValues(refs []MITREAttackRef) ([]string, []string, []st
 		}
 	}
 	return tactics, techniques, pairs
+}
+
+func mitreDefendAttributeValues(refs []MITREDefendRef) ([]string, []string, []string, []string) {
+	tacticSeen := map[string]struct{}{}
+	techniqueSeen := map[string]struct{}{}
+	artifactSeen := map[string]struct{}{}
+	refSeen := map[string]struct{}{}
+	var tactics []string
+	var techniques []string
+	var artifacts []string
+	var values []string
+	for _, ref := range refs {
+		tactic := strings.TrimSpace(ref.Tactic)
+		technique := strings.TrimSpace(ref.Technique)
+		artifact := strings.TrimSpace(ref.Artifact)
+		if tactic != "" {
+			if _, ok := tacticSeen[tactic]; !ok {
+				tacticSeen[tactic] = struct{}{}
+				tactics = append(tactics, tactic)
+			}
+		}
+		if technique != "" {
+			if _, ok := techniqueSeen[technique]; !ok {
+				techniqueSeen[technique] = struct{}{}
+				techniques = append(techniques, technique)
+			}
+		}
+		if artifact != "" {
+			if _, ok := artifactSeen[artifact]; !ok {
+				artifactSeen[artifact] = struct{}{}
+				artifacts = append(artifacts, artifact)
+			}
+		}
+		parts := []string{}
+		if tactic != "" {
+			parts = append(parts, tactic)
+		}
+		if technique != "" {
+			parts = append(parts, technique)
+		}
+		if artifact != "" {
+			parts = append(parts, artifact)
+		}
+		if len(parts) == 0 {
+			continue
+		}
+		value := strings.Join(parts, ":")
+		if _, ok := refSeen[value]; ok {
+			continue
+		}
+		refSeen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return tactics, techniques, artifacts, values
 }
 
 func joinAttribute(attributes map[string]string, key string, values []string) {

--- a/internal/findings/event_rule.go
+++ b/internal/findings/event_rule.go
@@ -67,13 +67,15 @@ type RuleDefinition struct {
 	FingerprintFields        []string
 	ControlRefs              []ports.FindingControlRef
 	MITREAttack              []MITREAttackRef
-	MITREDefend              []MITREDefendRef
 	Lifecycle                Lifecycle
 }
 
 type MITREAttackRef struct {
-	Tactic    string `json:"tactic"`
-	Technique string `json:"technique"`
+	Tactic          string `json:"tactic"`
+	Technique       string `json:"technique"`
+	DefendTactic    string `json:"-"`
+	DefendTechnique string `json:"-"`
+	DefendArtifact  string `json:"-"`
 }
 
 type MITREDefendRef struct {
@@ -198,7 +200,7 @@ func (d RuleDefinition) AttributeMap() map[string]string {
 	joinAttribute(attributes, "mitre_attack", mitrePairs)
 	joinAttribute(attributes, "mitre_attack_tactics", mitreTactics)
 	joinAttribute(attributes, "mitre_attack_techniques", mitreTechniques)
-	defendTactics, defendTechniques, defendArtifacts, defendRefs := mitreDefendAttributeValues(d.MITREDefend)
+	defendTactics, defendTechniques, defendArtifacts, defendRefs := mitreDefendAttributeValues(mitreDefendRefsFromAttackRefs(d.MITREAttack))
 	joinAttribute(attributes, "mitre_defend", defendRefs)
 	joinAttribute(attributes, "mitre_defend_tactics", defendTactics)
 	joinAttribute(attributes, "mitre_defend_techniques", defendTechniques)
@@ -253,6 +255,21 @@ func mitreAttackAttributeValues(refs []MITREAttackRef) ([]string, []string, []st
 		}
 	}
 	return tactics, techniques, pairs
+}
+
+func mitreDefendRefsFromAttackRefs(refs []MITREAttackRef) []MITREDefendRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	var defendRefs []MITREDefendRef
+	for _, ref := range refs {
+		defendRefs = append(defendRefs, MITREDefendRef{
+			Tactic:    ref.DefendTactic,
+			Technique: ref.DefendTechnique,
+			Artifact:  ref.DefendArtifact,
+		})
+	}
+	return cloneMITREDefendRefs(defendRefs)
 }
 
 func mitreDefendAttributeValues(refs []MITREDefendRef) ([]string, []string, []string, []string) {

--- a/internal/findings/event_rule_test.go
+++ b/internal/findings/event_rule_test.go
@@ -135,6 +135,7 @@ func TestRuleDefinitionBuildsSpecAndAttributes(t *testing.T) {
 		FingerprintFields:  []string{"repository", "action"},
 		ControlRefs:        []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC7.1"}},
 		MITREAttack:        []MITREAttackRef{{Tactic: "Defense Evasion", Technique: "T1562"}},
+		MITREDefend:        []MITREDefendRef{{Technique: "ProcessTermination", Artifact: "Process"}},
 		Lifecycle:          Lifecycle{Kind: LifecycleAuditEvidence, Anchor: AnchorNone},
 	}
 	if err := definition.Validate(); err != nil {
@@ -162,6 +163,15 @@ func TestRuleDefinitionBuildsSpecAndAttributes(t *testing.T) {
 	}
 	if got := attributes["mitre_attack"]; got != "Defense Evasion:T1562" {
 		t.Fatalf("AttributeMap()[mitre_attack] = %q, want Defense Evasion:T1562", got)
+	}
+	if got := attributes["mitre_defend_techniques"]; got != "ProcessTermination" {
+		t.Fatalf("AttributeMap()[mitre_defend_techniques] = %q, want ProcessTermination", got)
+	}
+	if got := attributes["mitre_defend_artifacts"]; got != "Process" {
+		t.Fatalf("AttributeMap()[mitre_defend_artifacts] = %q, want Process", got)
+	}
+	if got := attributes["mitre_defend"]; got != "ProcessTermination:Process" {
+		t.Fatalf("AttributeMap()[mitre_defend] = %q, want ProcessTermination:Process", got)
 	}
 }
 

--- a/internal/findings/event_rule_test.go
+++ b/internal/findings/event_rule_test.go
@@ -134,8 +134,7 @@ func TestRuleDefinitionBuildsSpecAndAttributes(t *testing.T) {
 		RequiredAttributes: []string{"action", "repository"},
 		FingerprintFields:  []string{"repository", "action"},
 		ControlRefs:        []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC7.1"}},
-		MITREAttack:        []MITREAttackRef{{Tactic: "Defense Evasion", Technique: "T1562"}},
-		MITREDefend:        []MITREDefendRef{{Technique: "ProcessTermination", Artifact: "Process"}},
+		MITREAttack:        []MITREAttackRef{{Tactic: "Defense Evasion", Technique: "T1562", DefendTechnique: "ProcessTermination", DefendArtifact: "Process"}},
 		Lifecycle:          Lifecycle{Kind: LifecycleAuditEvidence, Anchor: AnchorNone},
 	}
 	if err := definition.Validate(); err != nil {

--- a/internal/findings/policy_rule.go
+++ b/internal/findings/policy_rule.go
@@ -213,6 +213,7 @@ func (r *policyGraphCatalogRule) EvaluateRows(ctx context.Context, runtime *cere
 		finding.Attributes["policy_evidence"] = "graph"
 		finding.Attributes["policy_graph_query_present"] = "true"
 		addMITREAttackFindingAttributes(finding.Attributes, r.config.Definition.MITREAttack)
+		addMITREDefendFindingAttributes(finding.Attributes, r.config.Definition.MITREDefend)
 		for key, value := range r.config.ContractAttributes {
 			if trimmedKey := strings.TrimSpace(key); trimmedKey != "" {
 				finding.Attributes[trimmedKey] = strings.TrimSpace(value)
@@ -293,6 +294,7 @@ func (r *policyCatalogRule) buildFinding(runtime *cerebrov1.SourceRuntime, event
 		findingAttributes["rule_"+key] = value
 	}
 	addMITREAttackFindingAttributes(findingAttributes, definition.MITREAttack)
+	addMITREDefendFindingAttributes(findingAttributes, definition.MITREDefend)
 	if len(r.config.Conditions) != 0 {
 		findingAttributes["policy_condition_count"] = strconv.Itoa(len(r.config.Conditions))
 	}
@@ -337,6 +339,17 @@ func addMITREAttackFindingAttributes(attributes map[string]string, refs []MITREA
 	mergePolicyAttributeList(attributes, "mitre_attack_tactics", tactics)
 	mergePolicyAttributeList(attributes, "mitre_attack_techniques", techniques)
 	mergePolicyAttributeList(attributes, "policy_mitre", pairs)
+}
+
+func addMITREDefendFindingAttributes(attributes map[string]string, refs []MITREDefendRef) {
+	if attributes == nil {
+		return
+	}
+	tactics, techniques, artifacts, values := mitreDefendAttributeValues(refs)
+	mergePolicyAttributeList(attributes, "mitre_defend_tactics", tactics)
+	mergePolicyAttributeList(attributes, "mitre_defend_techniques", techniques)
+	mergePolicyAttributeList(attributes, "mitre_defend_artifacts", artifacts)
+	mergePolicyAttributeList(attributes, "mitre_defend", values)
 }
 
 func policyFindingTitle(name string) string {

--- a/internal/findings/policy_rule.go
+++ b/internal/findings/policy_rule.go
@@ -213,7 +213,7 @@ func (r *policyGraphCatalogRule) EvaluateRows(ctx context.Context, runtime *cere
 		finding.Attributes["policy_evidence"] = "graph"
 		finding.Attributes["policy_graph_query_present"] = "true"
 		addMITREAttackFindingAttributes(finding.Attributes, r.config.Definition.MITREAttack)
-		addMITREDefendFindingAttributes(finding.Attributes, r.config.Definition.MITREDefend)
+		addMITREDefendFindingAttributes(finding.Attributes, mitreDefendRefsFromAttackRefs(r.config.Definition.MITREAttack))
 		for key, value := range r.config.ContractAttributes {
 			if trimmedKey := strings.TrimSpace(key); trimmedKey != "" {
 				finding.Attributes[trimmedKey] = strings.TrimSpace(value)
@@ -294,7 +294,7 @@ func (r *policyCatalogRule) buildFinding(runtime *cerebrov1.SourceRuntime, event
 		findingAttributes["rule_"+key] = value
 	}
 	addMITREAttackFindingAttributes(findingAttributes, definition.MITREAttack)
-	addMITREDefendFindingAttributes(findingAttributes, definition.MITREDefend)
+	addMITREDefendFindingAttributes(findingAttributes, mitreDefendRefsFromAttackRefs(definition.MITREAttack))
 	if len(r.config.Conditions) != 0 {
 		findingAttributes["policy_condition_count"] = strconv.Itoa(len(r.config.Conditions))
 	}

--- a/internal/findings/policy_rule_test.go
+++ b/internal/findings/policy_rule_test.go
@@ -25,8 +25,7 @@ func TestPolicyCatalogRuleEmitsFindingForFailedEvidence(t *testing.T) {
 		Runbook:           "Review policy evidence.",
 		FingerprintFields: []string{"tenant_id", "policy_id", "resource_urn", "resource_id"},
 		ControlRefs:       []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6"}},
-		MITREAttack:       []MITREAttackRef{{Tactic: "Initial Access", Technique: "T1190"}},
-		MITREDefend:       []MITREDefendRef{{Technique: "InboundTrafficFiltering", Artifact: "NetworkTraffic"}},
+		MITREAttack:       []MITREAttackRef{{Tactic: "Initial Access", Technique: "T1190", DefendTechnique: "InboundTrafficFiltering", DefendArtifact: "NetworkTraffic"}},
 		Lifecycle:         Lifecycle{Kind: LifecycleAuditEvidence, Anchor: AnchorNone},
 	}
 	rule := newPolicyCatalogRule(policyRuleConfig{

--- a/internal/findings/policy_rule_test.go
+++ b/internal/findings/policy_rule_test.go
@@ -26,6 +26,7 @@ func TestPolicyCatalogRuleEmitsFindingForFailedEvidence(t *testing.T) {
 		FingerprintFields: []string{"tenant_id", "policy_id", "resource_urn", "resource_id"},
 		ControlRefs:       []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6"}},
 		MITREAttack:       []MITREAttackRef{{Tactic: "Initial Access", Technique: "T1190"}},
+		MITREDefend:       []MITREDefendRef{{Technique: "InboundTrafficFiltering", Artifact: "NetworkTraffic"}},
 		Lifecycle:         Lifecycle{Kind: LifecycleAuditEvidence, Anchor: AnchorNone},
 	}
 	rule := newPolicyCatalogRule(policyRuleConfig{
@@ -61,6 +62,8 @@ func TestPolicyCatalogRuleEmitsFindingForFailedEvidence(t *testing.T) {
 			"resource_id":             "resource-1",
 			"mitre_attack_tactics":    "Discovery",
 			"mitre_attack_techniques": "T1087",
+			"mitre_defend_techniques": "LocalAccountMonitoring",
+			"mitre_defend_artifacts":  "UserAccount",
 			"policy_mitre":            "Discovery:T1087",
 		},
 	}
@@ -137,6 +140,18 @@ func TestPolicyCatalogRuleEmitsFindingForFailedEvidence(t *testing.T) {
 	}
 	if got := finding.Attributes["rule_mitre_attack_techniques"]; got != "T1190" {
 		t.Fatalf("rule_mitre_attack_techniques = %q, want T1190", got)
+	}
+	if got := finding.Attributes["mitre_defend_techniques"]; got != "LocalAccountMonitoring,InboundTrafficFiltering" {
+		t.Fatalf("mitre_defend_techniques = %q, want LocalAccountMonitoring,InboundTrafficFiltering", got)
+	}
+	if got := finding.Attributes["mitre_defend_artifacts"]; got != "UserAccount,NetworkTraffic" {
+		t.Fatalf("mitre_defend_artifacts = %q, want UserAccount,NetworkTraffic", got)
+	}
+	if got := finding.Attributes["mitre_defend"]; got != "InboundTrafficFiltering:NetworkTraffic" {
+		t.Fatalf("mitre_defend = %q, want InboundTrafficFiltering:NetworkTraffic", got)
+	}
+	if got := finding.Attributes["rule_mitre_defend_techniques"]; got != "InboundTrafficFiltering" {
+		t.Fatalf("rule_mitre_defend_techniques = %q, want InboundTrafficFiltering", got)
 	}
 }
 

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -822,10 +822,12 @@ func AnalyzeFindingRiskContextWithConfig(finding *ports.FindingRecord, now time.
 		attributes["attack_tactics"],
 		attributes["policy_mitre"],
 		attributes["rule_mitre_attack"],
+	))
+	mitreTagContext := strings.ToLower(firstNonEmpty(
 		attributes["tags"],
 		attributes["rule_tags"],
 	))
-	if containsAny(mitreTacticContext, "credential access", "privilege escalation", "defense evasion", "lateral movement", "exfiltration", "impact", "ta0006", "ta0004", "ta0005", "ta0008", "ta0010", "ta0040") {
+	if hasHighPressureMITRETactic(mitreTacticContext, true) || hasHighPressureMITRETactic(mitreTagContext, false) {
 		applyRiskScoringFactor(settings, "mitre_high_pressure_tactic", "mitre_high_pressure_tactic", ports.RiskScoringFactorWeight{Likelihood: 5, Impact: 8}, &likelihood, &impact, &confidence, &reasons)
 	}
 	coverageContext := strings.ToLower(firstNonEmpty(attributes["mitre_coverage_state"], attributes["coverage_state"], attributes["coverage_status"], attributes["coverage"]))
@@ -1296,6 +1298,13 @@ func containsAny(value string, fragments ...string) bool {
 		}
 	}
 	return false
+}
+
+func hasHighPressureMITRETactic(value string, allowImpactName bool) bool {
+	if containsAny(value, "credential access", "privilege escalation", "defense evasion", "lateral movement", "exfiltration", "ta0006", "ta0004", "ta0005", "ta0008", "ta0010", "ta0040") {
+		return true
+	}
+	return allowImpactName && containsAny(value, "impact")
 }
 
 func findingAttributeBool(attributes map[string]string, keys ...string) bool {

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -793,6 +793,45 @@ func AnalyzeFindingRiskContextWithConfig(finding *ports.FindingRecord, now time.
 	if activeExploit {
 		applyRiskScoringFactor(settings, "active_threat", "active_threat", ports.RiskScoringFactorWeight{Likelihood: 25}, &likelihood, &impact, &confidence, &reasons)
 	}
+	mitreAttackContext := firstNonEmpty(
+		attributes["policy_mitre"],
+		attributes["mitre_attack"],
+		attributes["rule_mitre_attack"],
+		attributes["mitre_attack_technique"],
+		attributes["mitre_attack_techniques"],
+		attributes["rule_mitre_attack_technique"],
+		attributes["rule_mitre_attack_techniques"],
+		attributes["attack_technique"],
+		attributes["attack_techniques"],
+		attributes["mitre_attack_tactic"],
+		attributes["mitre_attack_tactics"],
+		attributes["rule_mitre_attack_tactic"],
+		attributes["rule_mitre_attack_tactics"],
+		attributes["attack_tactic"],
+		attributes["attack_tactics"],
+	)
+	if strings.TrimSpace(mitreAttackContext) != "" {
+		applyRiskScoringFactor(settings, "mitre_attack_context", "mitre_attack_context", ports.RiskScoringFactorWeight{Impact: 5, Confidence: 3}, &likelihood, &impact, &confidence, &reasons)
+	}
+	mitreTacticContext := strings.ToLower(firstNonEmpty(
+		attributes["mitre_attack_tactic"],
+		attributes["mitre_attack_tactics"],
+		attributes["rule_mitre_attack_tactic"],
+		attributes["rule_mitre_attack_tactics"],
+		attributes["attack_tactic"],
+		attributes["attack_tactics"],
+		attributes["policy_mitre"],
+		attributes["rule_mitre_attack"],
+		attributes["tags"],
+		attributes["rule_tags"],
+	))
+	if containsAny(mitreTacticContext, "credential access", "privilege escalation", "defense evasion", "lateral movement", "exfiltration", "impact", "ta0006", "ta0004", "ta0005", "ta0008", "ta0010", "ta0040") {
+		applyRiskScoringFactor(settings, "mitre_high_pressure_tactic", "mitre_high_pressure_tactic", ports.RiskScoringFactorWeight{Likelihood: 5, Impact: 8}, &likelihood, &impact, &confidence, &reasons)
+	}
+	coverageContext := strings.ToLower(firstNonEmpty(attributes["mitre_coverage_state"], attributes["coverage_state"], attributes["coverage_status"], attributes["coverage"]))
+	if strings.TrimSpace(mitreAttackContext) != "" && containsAny(coverageContext, "gap", "missing", "uncovered", "unsupported", "unconfigured", "failed", "stale") {
+		applyRiskScoringFactor(settings, "mitre_coverage_gap", "mitre_coverage_gap", ports.RiskScoringFactorWeight{Likelihood: 10, Confidence: 3}, &likelihood, &impact, &confidence, &reasons)
+	}
 	if findingAttributeBool(attributes, "is_kev", "kev", "known_exploited", "known_exploited_vulnerability") {
 		applyRiskScoringFactor(settings, "known_exploited", "known_exploited", ports.RiskScoringFactorWeight{Likelihood: 35}, &likelihood, &impact, &confidence, &reasons)
 	}

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -735,6 +735,24 @@ func TestAnalyzeFindingRiskContextUsesGenericSignals(t *testing.T) {
 	}
 }
 
+func TestAnalyzeFindingRiskContextUsesMITREContext(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	finding := compoundRiskFinding("finding-mitre", "policy-mitre", "MEDIUM", "", "", "urn:cerebro:writer:security_tool:agent-gateway", "control.coverage")
+	finding.Attributes["mitre_attack_tactics"] = "Defense Evasion"
+	finding.Attributes["mitre_attack_techniques"] = "T1562"
+	finding.Attributes["coverage_status"] = "gap"
+
+	context := AnalyzeFindingRiskContext(finding, now)
+	for _, reason := range []string{"mitre_attack_context", "mitre_high_pressure_tactic", "mitre_coverage_gap"} {
+		if !stringSliceContains(context.Reasons, reason) {
+			t.Fatalf("Risk reasons = %#v, want %q", context.Reasons, reason)
+		}
+	}
+	if context.ConfidenceScore <= 85 {
+		t.Fatalf("ConfidenceScore = %d, want MITRE confidence context to increase baseline", context.ConfidenceScore)
+	}
+}
+
 func TestFindingRiskFactorsDoNotChangeFindingFingerprint(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	baseline := compoundRiskFinding("finding-risk-factor-baseline", "identity-risk", "HIGH", "", "", "urn:cerebro:writer:okta_user:00u1", "")

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -753,6 +753,17 @@ func TestAnalyzeFindingRiskContextUsesMITREContext(t *testing.T) {
 	}
 }
 
+func TestAnalyzeFindingRiskContextDoesNotTreatImpactTagAsMITRETactic(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	finding := compoundRiskFinding("finding-impact-tag", "policy-impact-tag", "MEDIUM", "", "", "urn:cerebro:writer:service:billing", "control.coverage")
+	finding.Attributes["tags"] = "business_impact,service_owner"
+
+	context := AnalyzeFindingRiskContext(finding, now)
+	if stringSliceContains(context.Reasons, "mitre_high_pressure_tactic") {
+		t.Fatalf("Risk reasons = %#v, did not want MITRE high-pressure tactic from generic tag", context.Reasons)
+	}
+}
+
 func TestFindingRiskFactorsDoNotChangeFindingFingerprint(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	baseline := compoundRiskFinding("finding-risk-factor-baseline", "identity-risk", "HIGH", "", "", "urn:cerebro:writer:okta_user:00u1", "")

--- a/internal/findings/rule_metadata.go
+++ b/internal/findings/rule_metadata.go
@@ -102,6 +102,7 @@ type PublicDetection struct {
 	ControlRefs              []ports.FindingControlRef `json:"control_refs,omitempty"`
 	SourceCoverageRefs       []SourceCoverageRef       `json:"source_coverage_refs,omitempty"`
 	MITREAttack              []MITREAttackRef          `json:"mitre_attack,omitempty"`
+	MITREDefend              []MITREDefendRef          `json:"mitre_defend,omitempty"`
 }
 
 type PublicDetectionAuditDepth struct {
@@ -408,6 +409,7 @@ func publicDetectionFromRule(pack RulePack, metadata RuleDefinition, mode string
 		FingerprintFields:        uniqueTrimmedStringsPreserveOrder(metadata.FingerprintFields),
 		ControlRefs:              cloneFindingControlRefs(metadata.ControlRefs),
 		MITREAttack:              cloneMITREAttackRefs(metadata.MITREAttack),
+		MITREDefend:              cloneMITREDefendRefs(metadata.MITREDefend),
 	}
 }
 
@@ -436,6 +438,7 @@ func cloneRuleDefinition(definition RuleDefinition) RuleDefinition {
 		FingerprintFields:        cloneStringSlice(definition.FingerprintFields),
 		ControlRefs:              cloneFindingControlRefs(definition.ControlRefs),
 		MITREAttack:              cloneMITREAttackRefs(definition.MITREAttack),
+		MITREDefend:              cloneMITREDefendRefs(definition.MITREDefend),
 		Lifecycle:                definition.Lifecycle,
 	}
 }
@@ -452,6 +455,26 @@ func cloneMITREAttackRefs(refs []MITREAttackRef) []MITREAttackRef {
 			continue
 		}
 		cloned = append(cloned, MITREAttackRef{Tactic: tactic, Technique: technique})
+	}
+	if len(cloned) == 0 {
+		return nil
+	}
+	return cloned
+}
+
+func cloneMITREDefendRefs(refs []MITREDefendRef) []MITREDefendRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	cloned := make([]MITREDefendRef, 0, len(refs))
+	for _, ref := range refs {
+		tactic := strings.TrimSpace(ref.Tactic)
+		technique := strings.TrimSpace(ref.Technique)
+		artifact := strings.TrimSpace(ref.Artifact)
+		if tactic == "" && technique == "" && artifact == "" {
+			continue
+		}
+		cloned = append(cloned, MITREDefendRef{Tactic: tactic, Technique: technique, Artifact: artifact})
 	}
 	if len(cloned) == 0 {
 		return nil

--- a/internal/findings/rule_metadata.go
+++ b/internal/findings/rule_metadata.go
@@ -409,7 +409,7 @@ func publicDetectionFromRule(pack RulePack, metadata RuleDefinition, mode string
 		FingerprintFields:        uniqueTrimmedStringsPreserveOrder(metadata.FingerprintFields),
 		ControlRefs:              cloneFindingControlRefs(metadata.ControlRefs),
 		MITREAttack:              cloneMITREAttackRefs(metadata.MITREAttack),
-		MITREDefend:              cloneMITREDefendRefs(metadata.MITREDefend),
+		MITREDefend:              mitreDefendRefsFromAttackRefs(metadata.MITREAttack),
 	}
 }
 
@@ -438,7 +438,6 @@ func cloneRuleDefinition(definition RuleDefinition) RuleDefinition {
 		FingerprintFields:        cloneStringSlice(definition.FingerprintFields),
 		ControlRefs:              cloneFindingControlRefs(definition.ControlRefs),
 		MITREAttack:              cloneMITREAttackRefs(definition.MITREAttack),
-		MITREDefend:              cloneMITREDefendRefs(definition.MITREDefend),
 		Lifecycle:                definition.Lifecycle,
 	}
 }
@@ -454,7 +453,13 @@ func cloneMITREAttackRefs(refs []MITREAttackRef) []MITREAttackRef {
 		if tactic == "" && technique == "" {
 			continue
 		}
-		cloned = append(cloned, MITREAttackRef{Tactic: tactic, Technique: technique})
+		cloned = append(cloned, MITREAttackRef{
+			Tactic:          tactic,
+			Technique:       technique,
+			DefendTactic:    strings.TrimSpace(ref.DefendTactic),
+			DefendTechnique: strings.TrimSpace(ref.DefendTechnique),
+			DefendArtifact:  strings.TrimSpace(ref.DefendArtifact),
+		})
 	}
 	if len(cloned) == 0 {
 		return nil

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -1281,7 +1281,7 @@ func unsupportedQuery(reason string, traceID string, code string) UnsupportedQue
 	return UnsupportedQuery{
 		Code:             firstNonEmpty(code, unsupportedQueryCode(reason)),
 		Reason:           reason,
-		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentFailingControls, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth, IntentOktaPrivilegedWeakMFA, IntentOktaDormantAccess, IntentOktaGroupAccessRisk, IntentQuestionnaireEvidence},
+		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentFailingControls, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth, IntentOktaPrivilegedWeakMFA, IntentOktaDormantAccess, IntentOktaGroupAccessRisk, IntentQuestionnaireEvidence, IntentMITREAttackCoverage},
 		SuggestedRewrites: []string{
 			"Summarize open high-risk findings and cite the affected entities.",
 			"Show controls with open findings and cite the affected resources.",
@@ -1290,6 +1290,7 @@ func unsupportedQuery(reason string, traceID string, code string) UnsupportedQue
 			"Explain the evidence for a specific finding URN.",
 			"List privileged Okta users without strong MFA evidence.",
 			"List dormant Okta users that still have app or admin access.",
+			"Show MITRE ATT&CK coverage gaps by technique and evidence component.",
 			"Answer an Okta MFA questionnaire item from bounded graph evidence.",
 		},
 		TraceID: traceID,

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/writer/cerebro/internal/fabriccontract"
+	"github.com/writer/cerebro/internal/mitre"
 )
 
 type OntologyEntity struct {
@@ -40,6 +41,62 @@ var canonicalGraphOntology = GraphOntology{
 			Aliases:     []string{"Finding", "FINDING", "finding", "alert", "issue"},
 			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
 			Examples:    []string{"urn:cerebro:writer:finding:finding-1"},
+		},
+		{
+			Type:        mitre.AttackTacticEntityType,
+			Description: "MITRE ATT&CK tactic nodes linked from findings, controls, resources, and ATT&CK techniques.",
+			Aliases:     []string{"attack tactic", "MITRE tactic", "ATT&CK tactic", "mitre attack tactic"},
+			Properties:  []string{"urn", "label", "source_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:mitre_attack_tactic:TA0001"},
+		},
+		{
+			Type:        mitre.AttackTechniqueEntityType,
+			Description: "MITRE ATT&CK technique nodes linked from findings, controls, resources, coverage nodes, data components, and D3FEND techniques.",
+			Aliases:     []string{"attack technique", "MITRE technique", "ATT&CK technique", "mitre attack technique"},
+			Properties:  []string{"urn", "label", "source_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:mitre_attack_technique:T1190"},
+		},
+		{
+			Type:        mitre.AttackCoverageEntityType,
+			Description: "ATT&CK coverage nodes that connect a finding, control, tool, or resource to a technique and evidence data components.",
+			Aliases:     []string{"attack coverage", "MITRE coverage", "ATT&CK coverage", "coverage gap"},
+			Properties:  []string{"urn", "label", "source_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:mitre_attack_coverage:abc123"},
+		},
+		{
+			Type:        mitre.AttackDataSourceEntityType,
+			Description: "MITRE ATT&CK data source nodes such as Process, Application Log, or Network Traffic.",
+			Aliases:     []string{"attack data source", "MITRE data source", "ATT&CK data source"},
+			Properties:  []string{"urn", "label", "source_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:mitre_attack_data_source:DS0015"},
+		},
+		{
+			Type:        mitre.AttackDataComponentEntityType,
+			Description: "MITRE ATT&CK data component nodes that support detection or coverage for a technique.",
+			Aliases:     []string{"attack data component", "MITRE data component", "ATT&CK data component", "detection data component"},
+			Properties:  []string{"urn", "label", "source_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:mitre_attack_data_component:DS0015%3AApplication%20Log%20Content"},
+		},
+		{
+			Type:        mitre.DefendTacticEntityType,
+			Description: "MITRE D3FEND tactic nodes linked from findings or source facts when defensive tactic metadata is present.",
+			Aliases:     []string{"d3fend tactic", "defend tactic", "MITRE D3FEND tactic"},
+			Properties:  []string{"urn", "label", "source_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:mitre_defend_tactic:Harden"},
+		},
+		{
+			Type:        mitre.DefendTechniqueEntityType,
+			Description: "MITRE D3FEND technique nodes. These support ATT&CK techniques through defensive relationship edges.",
+			Aliases:     []string{"d3fend technique", "defend technique", "MITRE D3FEND technique"},
+			Properties:  []string{"urn", "label", "source_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:mitre_defend_technique:InboundTrafficFiltering"},
+		},
+		{
+			Type:        mitre.DefendArtifactEntityType,
+			Description: "MITRE D3FEND artifact nodes linked from D3FEND techniques or findings when defensive artifact metadata is present.",
+			Aliases:     []string{"d3fend artifact", "defend artifact", "MITRE D3FEND artifact"},
+			Properties:  []string{"urn", "label", "source_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:mitre_defend_artifact:WebServer"},
 		},
 		{
 			Type:        fabriccontract.EntityTypeGithubCodeRepository,
@@ -248,17 +305,17 @@ var canonicalGraphOntology = GraphOntology{
 		},
 		{
 			Relation:    fabriccontract.RelationSupports,
-			Description: "Evidence, policy, questionnaire, and source-fact edge to the control or object it supports.",
-			Aliases:     []string{"SUPPORTS", "control support", "mapped control"},
+			Description: "Evidence, policy, questionnaire, source-fact, ATT&CK data component, coverage, or D3FEND edge to the control or object it supports.",
+			Aliases:     []string{"SUPPORTS", "control support", "mapped control", "defends against", "detects attack technique"},
 			FromTypes:   []string{"*"},
-			ToTypes:     []string{"policy"},
+			ToTypes:     []string{"policy", mitre.AttackTechniqueEntityType},
 		},
 		{
 			Relation:    fabriccontract.RelationHasEvidence,
-			Description: "Resource or GRC artifact edge to runtime evidence or attached evidence.",
-			Aliases:     []string{"HAS_EVIDENCE", "evidence", "source evidence"},
+			Description: "Resource, GRC artifact, or ATT&CK coverage edge to runtime evidence, attached evidence, or ATT&CK data components.",
+			Aliases:     []string{"HAS_EVIDENCE", "evidence", "source evidence", "coverage evidence"},
 			FromTypes:   []string{"*"},
-			ToTypes:     []string{"runtime_evidence", "evidence"},
+			ToTypes:     []string{"runtime_evidence", "evidence", mitre.AttackDataComponentEntityType},
 		},
 		{
 			Relation:    fabriccontract.RelationAssociatedWith,
@@ -283,6 +340,7 @@ func (o GraphOntology) PromptHint() string {
 	fmt.Fprintf(&b, "- Canonical identity anchors use `entity_type` values `identity.email` and `identity.login`; there is no generic `identity` entity_type or top-level `email` property. Match identity values through `urn`, `label`, or controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Connector/source health nodes use `entity_type: 'source'`; there is no `connector` entity_type and no top-level `status` or `last_sync_minutes` property. Read source health metadata from controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Finding source grouping should prefer controlled `attributes_json.source_family` string extraction, then fall back to `finding.source_id`.\n")
+	fmt.Fprintf(&b, "- MITRE ATT&CK/D3FEND graph context uses `mitre.attack.*` and `mitre.defend.*` entity types. Findings, controls, tools, and resources link to explicit ATT&CK/D3FEND context with `has_context`; ATT&CK coverage nodes link to techniques with `supports` and to data components with `has_evidence`; D3FEND techniques link to ATT&CK techniques with `supports` when the relationship attribute is `defends_against`.\n")
 	fmt.Fprintf(&b, "- Okta access-review evidence is graph-shaped: use `okta.user` -> `okta.group` via `member_of`, user/group -> `okta.application` via `assigned_to`, user -> `okta.admin_role` via `can_admin`, and application/admin-role -> `okta.entitlement` -> `privileged.capability` before claiming app, admin, or privileged capability access.\n")
 	fmt.Fprintf(&b, "- Okta lifecycle and MFA fields such as `status`, `last_login_at`, `mfa_enrolled`, `mfa_factor_count`, `mfa_factor_types`, `mfa_phishing_resistant`, `source_event_id`, and `observed_at` live in `attributes_json`; do not treat missing factor detail as proof of weak MFA or infer contractor approval from Okta profile hints alone.\n")
 	fmt.Fprintf(&b, "- Questionnaire answers must start from bounded graph evidence: controls are `policy` nodes with `attributes_json.policy_type = 'control'`, support links use relation `supports`, evidence links use relation `has_evidence`, and policy/source freshness metadata lives in `attributes_json`.\n")

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -22,6 +22,7 @@ const (
 	IntentOktaDormantAccess         = "okta_dormant_access"
 	IntentOktaGroupAccessRisk       = "okta_group_access_risk"
 	IntentQuestionnaireEvidence     = "questionnaire_evidence_answer"
+	IntentMITREAttackCoverage       = "mitre_attack_coverage"
 
 	postProcessingCandidateRowLimit        = ports.MaxCypherQueryRows
 	questionnaireEvidenceCandidateRowLimit = postProcessingCandidateRowLimit
@@ -216,6 +217,8 @@ func deterministicFastPathPlan(request AskRequest) (AskQueryPlan, bool) {
 		plan.Filters = fastPathTopRiskFilters(question)
 	case IntentFailingControls, IntentAggregateFindingsBySource, IntentConnectorHealth, IntentIdentityBridge, IntentOktaPrivilegedWeakMFA, IntentOktaDormantAccess, IntentOktaGroupAccessRisk:
 		plan.Filters = map[string]string{}
+	case IntentMITREAttackCoverage:
+		plan.Filters = fastPathMITREAttackCoverageFilters(question)
 	case IntentQuestionnaireEvidence:
 		plan.Filters = fastPathQuestionnaireEvidenceFilters(question)
 		if planFilterValue(plan.Filters, "topic") == "" {
@@ -261,6 +264,15 @@ func fastPathTopRiskFilters(question string) map[string]string {
 
 func looksLikeQuestionnaireEvidenceQuestion(haystack string) bool {
 	return planFilterValue(fastPathQuestionnaireEvidenceFilters(haystack), "topic") != ""
+}
+
+func fastPathMITREAttackCoverageFilters(question string) map[string]string {
+	filters := map[string]string{}
+	lower := strings.ToLower(question)
+	if containsAny(lower, "gap", "gaps", "missing", "uncovered", "unsupported", "unconfigured", "failed", "stale") {
+		filters["coverage_state"] = "gap"
+	}
+	return filters
 }
 
 func fastPathQuestionnaireEvidenceFilters(question string) map[string]string {
@@ -412,6 +424,15 @@ func containsWord(haystack string, needle string) bool {
 	return pattern.MatchString(strings.ToLower(haystack))
 }
 
+func containsAny(value string, fragments ...string) bool {
+	for _, fragment := range fragments {
+		if fragment != "" && strings.Contains(value, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
 func mentionsOktaMFAPosture(haystack string) bool {
 	return strings.Contains(haystack, "mfa") || strings.Contains(haystack, "factor") || strings.Contains(haystack, "phishing resistant")
 }
@@ -524,6 +545,8 @@ func canonicalIntent(value string) string {
 		return IntentOktaGroupAccessRisk
 	case "questionnaire_evidence_answer", "questionnaire_answer", "compliance_answer", "control_coverage":
 		return IntentQuestionnaireEvidence
+	case "mitre_attack_coverage", "attack_coverage", "mitre_coverage", "attack_coverage_gaps", "mitre_coverage_gaps":
+		return IntentMITREAttackCoverage
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
 	}
@@ -550,6 +573,8 @@ func inferIntent(question string, cypher string) string {
 		return IntentOktaDormantAccess
 	case strings.Contains(haystack, "okta") && strings.Contains(haystack, "group") && (strings.Contains(haystack, "risk") || strings.Contains(haystack, "membership") || strings.Contains(haystack, "access")):
 		return IntentOktaGroupAccessRisk
+	case looksLikeMITREAttackCoverageQuestion(haystack):
+		return IntentMITREAttackCoverage
 	case strings.Contains(haystack, "explain") && strings.Contains(haystack, "finding"):
 		return IntentExplainFinding
 	case looksLikeQuestionnaireEvidenceQuestion(haystack):
@@ -557,6 +582,13 @@ func inferIntent(question string, cypher string) string {
 	default:
 		return IntentRawCypher
 	}
+}
+
+func looksLikeMITREAttackCoverageQuestion(haystack string) bool {
+	if !containsAny(haystack, "mitre", "att&ck", "attack", "d3fend", "defend") {
+		return false
+	}
+	return containsAny(haystack, "coverage", "gap", "gaps", "technique", "techniques", "tactic", "tactics", "data component", "data source", "defense", "defensive")
 }
 
 func renderDeterministicPlan(plan AskQueryPlan, defaultMaxRows int) (string, bool) {
@@ -815,9 +847,57 @@ LIMIT %d`, cypherJSONStringAttributes("assignment.attributes_json", "event_id", 
 			return "", false
 		}
 		return renderQuestionnaireEvidenceQuery(topicPredicate), true
+	case IntentMITREAttackCoverage:
+		return renderMITREAttackCoverageQuery(plan, limit), true
 	default:
 		return "", false
 	}
+}
+
+func renderMITREAttackCoverageQuery(plan AskQueryPlan, limit int) string {
+	coverageStateFilter := strings.ToLower(strings.TrimSpace(planFilterValue(plan.Filters, "coverage_state")))
+	coverageStatePredicate := ""
+	if coverageStateFilter != "" {
+		coverageStatePredicate = "\nWHERE toLower(coverage_state) = " + cypherStringLiteral(coverageStateFilter)
+	}
+	return fmt.Sprintf(`MATCH (anchor:Entity {tenant_id: $tenant_id})-[ctx:RELATION {relation: 'has_context'}]->(coverage:Entity {tenant_id: $tenant_id, entity_type: 'mitre.attack.coverage'})
+WHERE ctx.tenant_id = $tenant_id
+  AND (
+    $scope_urn = ''
+    OR anchor.urn = $scope_urn
+    OR coverage.urn = $scope_urn
+  )
+MATCH (coverage)-[coverageTechnique:RELATION {relation: 'supports'}]->(technique:Entity {tenant_id: $tenant_id, entity_type: 'mitre.attack.technique'})
+WHERE coverageTechnique.tenant_id = $tenant_id
+WITH anchor, coverage, technique,
+     coalesce(%s, '') AS coverage_state,
+     coalesce(%s, '') AS coverage_status,
+     coalesce(%s, '') AS evidence_surface%s
+OPTIONAL MATCH (coverage)-[evidenceRel:RELATION {relation: 'has_evidence'}]->(component:Entity {tenant_id: $tenant_id, entity_type: 'mitre.attack.data_component'})
+WHERE evidenceRel.tenant_id = $tenant_id
+OPTIONAL MATCH (component)-[sourceRel:RELATION {relation: 'belongs_to'}]->(dataSource:Entity {tenant_id: $tenant_id, entity_type: 'mitre.attack.data_source'})
+WHERE sourceRel.tenant_id = $tenant_id
+OPTIONAL MATCH (defend:Entity {tenant_id: $tenant_id, entity_type: 'mitre.defend.technique'})-[defends:RELATION {relation: 'supports'}]->(technique)
+WHERE defends.tenant_id = $tenant_id
+RETURN anchor.urn AS anchor_urn,
+       coalesce(anchor.label, anchor.urn) AS anchor_label,
+       anchor.entity_type AS anchor_type,
+       coverage.urn AS coverage_urn,
+       coalesce(coverage.label, coverage.urn) AS coverage_label,
+       coverage_state,
+       coverage_status,
+       evidence_surface,
+       technique.urn AS technique_urn,
+       coalesce(technique.label, technique.urn) AS technique_label,
+       component.urn AS data_component_urn,
+       coalesce(component.label, component.urn) AS data_component_label,
+       dataSource.urn AS data_source_urn,
+       coalesce(dataSource.label, dataSource.urn) AS data_source_label,
+       defend.urn AS defend_technique_urn,
+       coalesce(defend.label, defend.urn) AS defend_technique_label,
+       'MITRE coverage rows are projected graph context; treat missing data components as missing projected evidence, not proof no telemetry exists.' AS overclaim_guard
+ORDER BY coverage_state DESC, technique_label, anchor_label, data_component_label
+LIMIT %d`, cypherJSONStringAttributes("coverage.attributes_json", "coverage_state"), cypherJSONStringAttributes("coverage.attributes_json", "coverage_status"), cypherJSONStringAttributes("coverage.attributes_json", "evidence_surface"), coverageStatePredicate, limit)
 }
 
 var questionnaireEvidenceQueryFragments = []string{
@@ -1152,6 +1232,10 @@ func hasUnsupportedDeterministicModifiers(plan AskQueryPlan) bool {
 			}
 		case IntentQuestionnaireEvidence:
 			if normalized != "topic" && normalized != "answer_mode" {
+				return true
+			}
+		case IntentMITREAttackCoverage:
+			if normalized != "coverage_state" {
 				return true
 			}
 		case IntentFailingControls:

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -332,6 +332,8 @@ func questionnaireEvidenceTopic(question string) string {
 		terms.hasPhrase("mapped control")) &&
 		(terms.hasAnswerContext() || terms.has("show")):
 		return "control_coverage"
+	case terms.has("questionnaire") && answerContext && (terms.has("attack") || terms.has("attck") || terms.has("mitre")) && (terms.has("defense") || terms.has("defensive") || terms.has("defend") || terms.has("d3fend")):
+		return "attack_defense"
 	default:
 		return ""
 	}
@@ -573,19 +575,19 @@ func inferIntent(question string, cypher string) string {
 		return IntentOktaDormantAccess
 	case strings.Contains(haystack, "okta") && strings.Contains(haystack, "group") && (strings.Contains(haystack, "risk") || strings.Contains(haystack, "membership") || strings.Contains(haystack, "access")):
 		return IntentOktaGroupAccessRisk
-	case looksLikeMITREAttackCoverageQuestion(haystack):
-		return IntentMITREAttackCoverage
 	case strings.Contains(haystack, "explain") && strings.Contains(haystack, "finding"):
 		return IntentExplainFinding
 	case looksLikeQuestionnaireEvidenceQuestion(haystack):
 		return IntentQuestionnaireEvidence
+	case looksLikeMITREAttackCoverageQuestion(haystack):
+		return IntentMITREAttackCoverage
 	default:
 		return IntentRawCypher
 	}
 }
 
 func looksLikeMITREAttackCoverageQuestion(haystack string) bool {
-	if !containsAny(haystack, "mitre", "att&ck", "attack", "d3fend", "defend") {
+	if !containsAny(haystack, "mitre", "att&ck", "d3fend", "attack coverage", "attack data component", "attack data source") {
 		return false
 	}
 	return containsAny(haystack, "coverage", "gap", "gaps", "technique", "techniques", "tactic", "tactics", "data component", "data source", "defense", "defensive")
@@ -1184,6 +1186,16 @@ func questionnaireEvidenceTopicPredicate(filters map[string]string) string {
 		)
 	case "control_coverage":
 		return "WHERE " + questionnaireMatchWordPredicate("coverage") + " OR questionnaire_match_text CONTAINS 'coverage_gap' OR " + questionnaireMatchWordPredicate("gap") + " OR " + questionnaireMatchWordPredicate("missing")
+	case "attack_defense":
+		return "WHERE " + questionnaireAnyMatchPredicate(
+			questionnaireMatchWordPredicate("attack"),
+			questionnaireMatchWordPredicate("attck"),
+			questionnaireMatchWordPredicate("mitre"),
+			questionnaireMatchWordPredicate("defense"),
+			questionnaireMatchWordPredicate("defensive"),
+			questionnaireMatchWordPredicate("defend"),
+			questionnaireMatchWordPredicate("d3fend"),
+		)
 	default:
 		return ""
 	}

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -217,6 +217,18 @@ func TestInferIntentDetectsFailingControls(t *testing.T) {
 	}
 }
 
+func TestInferIntentRecognizesMITREAttackCoverage(t *testing.T) {
+	for _, question := range []string{
+		"Show MITRE ATT&CK coverage gaps by technique",
+		"Which D3FEND techniques cover attack techniques?",
+		"List attack data components for MITRE coverage",
+	} {
+		if got := inferIntent(question, ""); got != IntentMITREAttackCoverage {
+			t.Fatalf("inferIntent(%q) = %q, want %q", question, got, IntentMITREAttackCoverage)
+		}
+	}
+}
+
 func TestConvertDraftToQueryRendersOktaPrivilegedWeakMFATemplate(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "Which privileged Okta users lack strong MFA?"}, &DraftResponse{
 		Plan: &AskQueryPlan{Intent: IntentOktaPrivilegedWeakMFA, Limit: 25},
@@ -648,6 +660,37 @@ func TestConvertDraftToQueryScopesConnectorHealthTemplate(t *testing.T) {
 	}
 }
 
+func TestConvertDraftToQueryUsesMITREAttackCoverageTemplate(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Show MITRE ATT&CK coverage gaps by technique",
+		ScopeURN: "urn:cerebro:writer:security_tool:agent-gateway",
+	}, &DraftResponse{
+		Plan: &AskQueryPlan{Intent: IntentMITREAttackCoverage, Filters: map[string]string{"coverage_state": "gap"}, Limit: 25},
+	})
+
+	if result.Plan.Intent != IntentMITREAttackCoverage || !result.Deterministic {
+		t.Fatalf("conversion result = %#v, want deterministic MITRE ATT&CK coverage template", result)
+	}
+	for _, want := range []string{
+		"entity_type: 'mitre.attack.coverage'",
+		"entity_type: 'mitre.attack.technique'",
+		"entity_type: 'mitre.attack.data_component'",
+		"entity_type: 'mitre.attack.data_source'",
+		"entity_type: 'mitre.defend.technique'",
+		"relation: 'has_context'",
+		"relation: 'supports'",
+		"relation: 'has_evidence'",
+		"WHERE toLower(coverage_state) = 'gap'",
+		"$scope_urn",
+		"overclaim_guard",
+	} {
+		if !strings.Contains(result.Cypher, want) {
+			t.Fatalf("MITRE coverage cypher missing %q:\n%s", want, result.Cypher)
+		}
+	}
+}
+
 func TestConvertDraftToQueryUsesQuestionnaireEvidenceTemplate(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",
@@ -938,6 +981,7 @@ func TestDeterministicTemplatesUseProjectedGraphContract(t *testing.T) {
 		{name: "identity bridge", intent: IntentIdentityBridge, scope: "urn:cerebro:writer:github_user:alice"},
 		{name: "connector health", intent: IntentConnectorHealth, scope: "urn:cerebro:writer:source:github"},
 		{name: "questionnaire evidence", intent: IntentQuestionnaireEvidence, scope: "urn:cerebro:writer:policy:control:ac-1", filters: map[string]string{"topic": "okta_mfa"}},
+		{name: "mitre coverage", intent: IntentMITREAttackCoverage, scope: "urn:cerebro:writer:security_tool:agent-gateway", filters: map[string]string{"coverage_state": "gap"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			result := convertDraftToQuery(AskRequest{

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -229,6 +229,21 @@ func TestInferIntentRecognizesMITREAttackCoverage(t *testing.T) {
 	}
 }
 
+func TestInferIntentDoesNotStealGenericAttackQuestions(t *testing.T) {
+	for _, tc := range []struct {
+		question string
+		want     string
+	}{
+		{question: "Explain the attack technique finding", want: IntentExplainFinding},
+		{question: "Answer the attack defense questionnaire", want: IntentQuestionnaireEvidence},
+		{question: "Show findings related to attack techniques", want: IntentRawCypher},
+	} {
+		if got := inferIntent(tc.question, ""); got != tc.want {
+			t.Fatalf("inferIntent(%q) = %q, want %q", tc.question, got, tc.want)
+		}
+	}
+}
+
 func TestConvertDraftToQueryRendersOktaPrivilegedWeakMFATemplate(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "Which privileged Okta users lack strong MFA?"}, &DraftResponse{
 		Plan: &AskQueryPlan{Intent: IntentOktaPrivilegedWeakMFA, Limit: 25},

--- a/internal/mitre/knowledge.go
+++ b/internal/mitre/knowledge.go
@@ -1,0 +1,303 @@
+package mitre
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+const (
+	KnowledgePackID               = "cerebro-mitre-core-v1"
+	AttackDataSourceEntityType    = "mitre.attack.data_source"
+	AttackDataComponentEntityType = "mitre.attack.data_component"
+	AttackCoverageEntityType      = "mitre.attack.coverage"
+	AttackDataSourceURNKind       = "mitre_attack_data_source"
+	AttackDataComponentURNKind    = "mitre_attack_data_component"
+	AttackCoverageURNKind         = "mitre_attack_coverage"
+)
+
+type AttackDataSource struct {
+	ID          string
+	Name        string
+	Domain      string
+	Description string
+}
+
+type AttackDataComponent struct {
+	ID           string
+	Name         string
+	DataSourceID string
+	Description  string
+}
+
+type AttackTechniqueKnowledge struct {
+	ID               string
+	Name             string
+	TacticIDs        []string
+	DataComponents   []AttackDataComponent
+	DefendTechniques []DefendTechnique
+	DefendArtifacts  []DefendArtifact
+	References       []string
+}
+
+type CoverageState struct {
+	State           string
+	Status          string
+	EvidenceSurface string
+}
+
+type KnowledgePack struct {
+	ID string
+}
+
+func DefaultKnowledgePack() KnowledgePack {
+	return KnowledgePack{ID: KnowledgePackID}
+}
+
+func AttackTechniqueKnowledgeFor(technique AttackTechnique) (AttackTechniqueKnowledge, bool) {
+	return DefaultKnowledgePack().AttackTechniqueKnowledge(technique)
+}
+
+func (p KnowledgePack) AttackTechniqueKnowledge(technique AttackTechnique) (AttackTechniqueKnowledge, bool) {
+	id := normalizedAttackTechniqueID(technique.ID)
+	if id == "" {
+		id = normalizedAttackTechniqueID(technique.Name)
+	}
+	if id == "" {
+		return AttackTechniqueKnowledge{}, false
+	}
+	if knowledge, ok := attackTechniqueKnowledgeByID[id]; ok {
+		return cloneAttackTechniqueKnowledge(knowledge), true
+	}
+	if parent, _, ok := strings.Cut(id, "."); ok {
+		if knowledge, ok := attackTechniqueKnowledgeByID[parent]; ok {
+			knowledge = cloneAttackTechniqueKnowledge(knowledge)
+			knowledge.ID = id
+			if strings.TrimSpace(technique.Name) != "" && !strings.EqualFold(technique.Name, id) {
+				knowledge.Name = strings.TrimSpace(technique.Name)
+			} else {
+				knowledge.Name = id
+			}
+			return knowledge, true
+		}
+	}
+	return AttackTechniqueKnowledge{}, false
+}
+
+func AttackDataSourceURN(tenantID string, source AttackDataSource) string {
+	return mint(tenantID, AttackDataSourceURNKind, firstNonEmpty(source.ID, normalizeKey(source.Name)))
+}
+
+func AttackDataComponentURN(tenantID string, component AttackDataComponent) string {
+	return mint(tenantID, AttackDataComponentURNKind, firstNonEmpty(component.ID, normalizeKey(component.DataSourceID+":"+component.Name), normalizeKey(component.Name)))
+}
+
+func AttackCoverageURN(tenantID string, anchorURN string, techniqueURN string) string {
+	anchorURN = strings.TrimSpace(anchorURN)
+	techniqueURN = strings.TrimSpace(techniqueURN)
+	if anchorURN == "" || techniqueURN == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(anchorURN + "\n" + techniqueURN))
+	return mint(tenantID, AttackCoverageURNKind, hex.EncodeToString(sum[:])[:24])
+}
+
+func AttackDataSourceAttributes(source AttackDataSource) map[string]string {
+	return compact(map[string]string{
+		"mitre_domain":      "attack",
+		"data_source_id":    source.ID,
+		"data_source_name":  firstNonEmpty(source.Name, source.ID),
+		"domain":            source.Domain,
+		"description":       source.Description,
+		"source_taxonomy":   "mitre_attack",
+		"knowledge_pack_id": KnowledgePackID,
+	})
+}
+
+func AttackDataComponentAttributes(component AttackDataComponent) map[string]string {
+	return compact(map[string]string{
+		"mitre_domain":        "attack",
+		"data_component_id":   component.ID,
+		"data_component_name": firstNonEmpty(component.Name, component.ID),
+		"data_source_id":      component.DataSourceID,
+		"description":         component.Description,
+		"source_taxonomy":     "mitre_attack",
+		"knowledge_pack_id":   KnowledgePackID,
+	})
+}
+
+func AttackCoverageAttributes(technique AttackTechnique, state CoverageState, anchorURN string, sourceValue string, extra map[string]string) map[string]string {
+	attrs := map[string]string{
+		"mitre_domain":      "attack",
+		"technique_id":      strings.TrimSpace(technique.ID),
+		"technique_name":    AttackTechniqueLabel(technique),
+		"coverage_state":    NormalizeCoverageState(firstNonEmpty(state.State, state.Status)),
+		"coverage_status":   strings.TrimSpace(state.Status),
+		"evidence_surface":  strings.TrimSpace(state.EvidenceSurface),
+		"anchor_urn":        strings.TrimSpace(anchorURN),
+		"source_value":      strings.TrimSpace(sourceValue),
+		"source_taxonomy":   "mitre_attack",
+		"knowledge_pack_id": KnowledgePackID,
+	}
+	for key, value := range extra {
+		if strings.TrimSpace(key) != "" {
+			attrs[key] = strings.TrimSpace(value)
+		}
+	}
+	return compact(attrs)
+}
+
+func NormalizeCoverageState(values ...string) string {
+	for _, value := range values {
+		normalized := normalizeKey(value)
+		switch normalized {
+		case "healthy", "complete", "covered", "implemented", "enabled", "proven":
+			return "covered"
+		case "observed", "detected", "runtime-observed", "finding-observed":
+			return "observed"
+		case "configured", "mapped", "supported":
+			return "mapped"
+		case "partial", "partially-covered":
+			return "partial"
+		case "gap", "missing", "uncovered", "unsupported", "unconfigured", "failed", "stale":
+			return "gap"
+		}
+	}
+	return "mapped"
+}
+
+func AttackTacticsForTechnique(technique AttackTechnique) []AttackTactic {
+	knowledge, ok := AttackTechniqueKnowledgeFor(technique)
+	if !ok {
+		return nil
+	}
+	tactics := make([]AttackTactic, 0, len(knowledge.TacticIDs))
+	for _, id := range knowledge.TacticIDs {
+		if tactic, ok := attackTacticByID[strings.ToUpper(strings.TrimSpace(id))]; ok {
+			tactics = append(tactics, tactic)
+		}
+	}
+	return tactics
+}
+
+func cloneAttackTechniqueKnowledge(knowledge AttackTechniqueKnowledge) AttackTechniqueKnowledge {
+	knowledge.TacticIDs = append([]string(nil), knowledge.TacticIDs...)
+	knowledge.DataComponents = append([]AttackDataComponent(nil), knowledge.DataComponents...)
+	knowledge.DefendTechniques = append([]DefendTechnique(nil), knowledge.DefendTechniques...)
+	knowledge.DefendArtifacts = append([]DefendArtifact(nil), knowledge.DefendArtifacts...)
+	knowledge.References = append([]string(nil), knowledge.References...)
+	return knowledge
+}
+
+func normalizedAttackTechniqueID(value string) string {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	if attackTechniquePattern.MatchString(value) {
+		return attackTechniquePattern.FindString(value)
+	}
+	return ""
+}
+
+var attackTechniqueKnowledgeByID = map[string]AttackTechniqueKnowledge{
+	"T1059": {
+		ID:        "T1059",
+		Name:      "Command and Scripting Interpreter",
+		TacticIDs: []string{"TA0002"},
+		DataComponents: []AttackDataComponent{
+			{ID: "DS0017:Command Execution", Name: "Command Execution", DataSourceID: "DS0017", Description: "Command line and shell execution evidence."},
+			{ID: "DS0009:Process Creation", Name: "Process Creation", DataSourceID: "DS0009", Description: "Process start evidence and command-line metadata."},
+		},
+		DefendTechniques: []DefendTechnique{{ID: "ProcessTermination", Name: "Process Termination"}},
+		DefendArtifacts:  []DefendArtifact{{ID: "Process", Name: "Process"}},
+		References:       []string{"https://attack.mitre.org/techniques/T1059/"},
+	},
+	"T1078": {
+		ID:        "T1078",
+		Name:      "Valid Accounts",
+		TacticIDs: []string{"TA0001", "TA0003", "TA0004", "TA0005"},
+		DataComponents: []AttackDataComponent{
+			{ID: "DS0028:Logon Session Creation", Name: "Logon Session Creation", DataSourceID: "DS0028", Description: "Successful authentication and session creation evidence."},
+			{ID: "DS0002:User Account Authentication", Name: "User Account Authentication", DataSourceID: "DS0002", Description: "Authentication attempts and account use evidence."},
+		},
+		DefendTechniques: []DefendTechnique{{ID: "Multi-factorAuthentication", Name: "Multi-factor Authentication"}, {ID: "CredentialTransmissionScoping", Name: "Credential Transmission Scoping"}, {ID: "LocalAccountMonitoring", Name: "Local Account Monitoring"}},
+		DefendArtifacts:  []DefendArtifact{{ID: "UserAccount", Name: "User Account"}, {ID: "Credential", Name: "Credential"}},
+		References:       []string{"https://attack.mitre.org/techniques/T1078/"},
+	},
+	"T1087": {
+		ID:        "T1087",
+		Name:      "Account Discovery",
+		TacticIDs: []string{"TA0007"},
+		DataComponents: []AttackDataComponent{
+			{ID: "DS0017:Command Execution", Name: "Command Execution", DataSourceID: "DS0017", Description: "Directory and account enumeration command evidence."},
+			{ID: "DS0002:User Account Metadata", Name: "User Account Metadata", DataSourceID: "DS0002", Description: "Account inventory and attribute evidence."},
+		},
+		DefendTechniques: []DefendTechnique{{ID: "LocalAccountMonitoring", Name: "Local Account Monitoring"}},
+		DefendArtifacts:  []DefendArtifact{{ID: "UserAccount", Name: "User Account"}},
+		References:       []string{"https://attack.mitre.org/techniques/T1087/"},
+	},
+	"T1098": {
+		ID:        "T1098",
+		Name:      "Account Manipulation",
+		TacticIDs: []string{"TA0003", "TA0004"},
+		DataComponents: []AttackDataComponent{
+			{ID: "DS0002:User Account Modification", Name: "User Account Modification", DataSourceID: "DS0002", Description: "Account, group, credential, or permission change evidence."},
+			{ID: "DS0028:Logon Session Creation", Name: "Logon Session Creation", DataSourceID: "DS0028", Description: "Session evidence following account changes."},
+		},
+		DefendTechniques: []DefendTechnique{{ID: "Multi-factorAuthentication", Name: "Multi-factor Authentication"}, {ID: "LocalAccountMonitoring", Name: "Local Account Monitoring"}},
+		DefendArtifacts:  []DefendArtifact{{ID: "UserAccount", Name: "User Account"}, {ID: "Credential", Name: "Credential"}},
+		References:       []string{"https://attack.mitre.org/techniques/T1098/"},
+	},
+	"T1190": {
+		ID:        "T1190",
+		Name:      "Exploit Public-Facing Application",
+		TacticIDs: []string{"TA0001"},
+		DataComponents: []AttackDataComponent{
+			{ID: "DS0015:Application Log Content", Name: "Application Log Content", DataSourceID: "DS0015", Description: "Application request, error, and exploit-attempt evidence."},
+			{ID: "DS0029:Network Traffic Content", Name: "Network Traffic Content", DataSourceID: "DS0029", Description: "Inbound request and payload evidence for public services."},
+		},
+		DefendTechniques: []DefendTechnique{{ID: "InboundTrafficFiltering", Name: "Inbound Traffic Filtering"}, {ID: "ApplicationConfigurationHardening", Name: "Application Configuration Hardening"}, {ID: "SoftwareUpdate", Name: "Software Update"}},
+		DefendArtifacts:  []DefendArtifact{{ID: "WebServer", Name: "Web Server"}, {ID: "NetworkTraffic", Name: "Network Traffic"}, {ID: "Software", Name: "Software"}},
+		References:       []string{"https://attack.mitre.org/techniques/T1190/"},
+	},
+	"T1486": {
+		ID:        "T1486",
+		Name:      "Data Encrypted for Impact",
+		TacticIDs: []string{"TA0040"},
+		DataComponents: []AttackDataComponent{
+			{ID: "DS0022:File Modification", Name: "File Modification", DataSourceID: "DS0022", Description: "File changes consistent with encryption or destructive modification."},
+			{ID: "DS0009:Process Creation", Name: "Process Creation", DataSourceID: "DS0009", Description: "Process starts associated with encryption tooling."},
+		},
+		DefendTechniques: []DefendTechnique{{ID: "FileBackup", Name: "File Backup"}, {ID: "ProcessTermination", Name: "Process Termination"}},
+		DefendArtifacts:  []DefendArtifact{{ID: "File", Name: "File"}, {ID: "Process", Name: "Process"}},
+		References:       []string{"https://attack.mitre.org/techniques/T1486/"},
+	},
+	"T1562": {
+		ID:        "T1562",
+		Name:      "Impair Defenses",
+		TacticIDs: []string{"TA0005"},
+		DataComponents: []AttackDataComponent{
+			{ID: "DS0017:Command Execution", Name: "Command Execution", DataSourceID: "DS0017", Description: "Commands used to weaken or disable controls."},
+			{ID: "DS0009:Process Creation", Name: "Process Creation", DataSourceID: "DS0009", Description: "Process starts that alter defensive tooling."},
+		},
+		DefendTechniques: []DefendTechnique{{ID: "ProcessTermination", Name: "Process Termination"}, {ID: "ApplicationConfigurationHardening", Name: "Application Configuration Hardening"}},
+		DefendArtifacts:  []DefendArtifact{{ID: "Process", Name: "Process"}, {ID: "Configuration", Name: "Configuration"}},
+		References:       []string{"https://attack.mitre.org/techniques/T1562/"},
+	},
+}
+
+var attackDataSourcesByID = map[string]AttackDataSource{
+	"DS0002": {ID: "DS0002", Name: "User Account", Domain: "enterprise-attack", Description: "Account identity, authentication, and attribute evidence."},
+	"DS0009": {ID: "DS0009", Name: "Process", Domain: "enterprise-attack", Description: "Process execution and process metadata evidence."},
+	"DS0015": {ID: "DS0015", Name: "Application Log", Domain: "enterprise-attack", Description: "Application event, request, and error evidence."},
+	"DS0017": {ID: "DS0017", Name: "Command", Domain: "enterprise-attack", Description: "Command-line and shell execution evidence."},
+	"DS0022": {ID: "DS0022", Name: "File", Domain: "enterprise-attack", Description: "File creation, access, and modification evidence."},
+	"DS0028": {ID: "DS0028", Name: "Logon Session", Domain: "enterprise-attack", Description: "Authentication session evidence."},
+	"DS0029": {ID: "DS0029", Name: "Network Traffic", Domain: "enterprise-attack", Description: "Network flow and payload evidence."},
+}
+
+func AttackDataSourceForComponent(component AttackDataComponent) (AttackDataSource, bool) {
+	source, ok := attackDataSourcesByID[strings.ToUpper(strings.TrimSpace(component.DataSourceID))]
+	return source, ok
+}

--- a/internal/mitre/knowledge_test.go
+++ b/internal/mitre/knowledge_test.go
@@ -1,0 +1,102 @@
+package mitre
+
+import "testing"
+
+func TestAttackTechniqueKnowledgeForKnownTechnique(t *testing.T) {
+	knowledge, ok := AttackTechniqueKnowledgeFor(AttackTechnique{ID: "T1190", SourceValue: "Initial Access:T1190"})
+	if !ok {
+		t.Fatal("AttackTechniqueKnowledgeFor(T1190) ok = false, want true")
+	}
+	if knowledge.ID != "T1190" {
+		t.Fatalf("knowledge.ID = %q, want T1190", knowledge.ID)
+	}
+	if !stringSliceContains(knowledge.TacticIDs, "TA0001") {
+		t.Fatalf("TacticIDs = %#v, want TA0001", knowledge.TacticIDs)
+	}
+	if !attackDataComponentsContain(knowledge.DataComponents, "DS0015", "Application Log Content") {
+		t.Fatalf("DataComponents = %#v, want DS0015 Application Log Content", knowledge.DataComponents)
+	}
+	if !defendTechniquesContain(knowledge.DefendTechniques, "InboundTrafficFiltering") {
+		t.Fatalf("DefendTechniques = %#v, want InboundTrafficFiltering", knowledge.DefendTechniques)
+	}
+	if !defendArtifactsContain(knowledge.DefendArtifacts, "WebServer") {
+		t.Fatalf("DefendArtifacts = %#v, want WebServer", knowledge.DefendArtifacts)
+	}
+}
+
+func TestAttackTechniqueKnowledgeUsesParentForSubtechnique(t *testing.T) {
+	knowledge, ok := AttackTechniqueKnowledgeFor(AttackTechnique{ID: "T1562.001", Name: "Impair Defenses: Disable or Modify Tools"})
+	if !ok {
+		t.Fatal("AttackTechniqueKnowledgeFor(T1562.001) ok = false, want parent knowledge")
+	}
+	if knowledge.ID != "T1562.001" {
+		t.Fatalf("knowledge.ID = %q, want subtechnique ID", knowledge.ID)
+	}
+	if !stringSliceContains(knowledge.TacticIDs, "TA0005") {
+		t.Fatalf("TacticIDs = %#v, want TA0005 inherited from T1562", knowledge.TacticIDs)
+	}
+}
+
+func TestAttackTechniqueKnowledgeUnknownTechnique(t *testing.T) {
+	if _, ok := AttackTechniqueKnowledgeFor(AttackTechnique{ID: "T9999"}); ok {
+		t.Fatal("AttackTechniqueKnowledgeFor(T9999) ok = true, want false")
+	}
+}
+
+func TestAttackCoverageURNAndAttributes(t *testing.T) {
+	anchorURN := "urn:cerebro:writer:security_tool:agent-gateway"
+	techniqueURN := "urn:cerebro:writer:mitre_attack_technique:T1190"
+	urn := AttackCoverageURN("writer", anchorURN, techniqueURN)
+	if urn == "" {
+		t.Fatal("AttackCoverageURN() = empty, want stable URN")
+	}
+	if urn != AttackCoverageURN("writer", anchorURN, techniqueURN) {
+		t.Fatal("AttackCoverageURN() changed for same inputs")
+	}
+	attrs := AttackCoverageAttributes(AttackTechnique{ID: "T1190", Name: "Exploit Public-Facing Application"}, CoverageState{Status: "gap", EvidenceSurface: "endpoint"}, anchorURN, "T1190", map[string]string{"event_id": "evt-1"})
+	if attrs["coverage_state"] != "gap" {
+		t.Fatalf("coverage_state = %q, want gap", attrs["coverage_state"])
+	}
+	if attrs["evidence_surface"] != "endpoint" {
+		t.Fatalf("evidence_surface = %q, want endpoint", attrs["evidence_surface"])
+	}
+	if attrs["knowledge_pack_id"] != KnowledgePackID {
+		t.Fatalf("knowledge_pack_id = %q, want %q", attrs["knowledge_pack_id"], KnowledgePackID)
+	}
+}
+
+func attackDataComponentsContain(components []AttackDataComponent, sourceID string, name string) bool {
+	for _, component := range components {
+		if component.DataSourceID == sourceID && component.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func defendTechniquesContain(techniques []DefendTechnique, id string) bool {
+	for _, technique := range techniques {
+		if technique.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func defendArtifactsContain(artifacts []DefendArtifact, id string) bool {
+	for _, artifact := range artifacts {
+		if artifact.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sourceprojection/mitre.go
+++ b/internal/sourceprojection/mitre.go
@@ -123,6 +123,7 @@ func addMITREAttackTechniqueLinks(entities map[string]*ports.ProjectedEntity, li
 			Attributes: mitre.AttackTechniqueAttributes(technique),
 		})
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, techniqueURN, relation, mitreLinkAttributes(event, "attack_technique", technique.SourceValue, extraAttrs)))
+		addMITREAttackTechniqueKnowledgeLinks(entities, links, tenantID, event, fromURN, technique, techniqueURN, relation, extraAttrs)
 		urns = append(urns, techniqueURN)
 	}
 	return urns
@@ -203,6 +204,116 @@ func addMITREDefendArtifactLinks(entities map[string]*ports.ProjectedEntity, lin
 	}
 }
 
+func addMITREAttackTechniqueKnowledgeLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, fromURN string, technique mitre.AttackTechnique, techniqueURN string, relation string, extraAttrs map[string]string) {
+	knowledge, ok := mitre.AttackTechniqueKnowledgeFor(technique)
+	if !ok {
+		return
+	}
+	knowledgeTechnique := mitre.AttackTechnique{ID: knowledge.ID, Name: knowledge.Name, SourceValue: technique.SourceValue}
+	if strings.TrimSpace(knowledgeTechnique.ID) == "" {
+		knowledgeTechnique.ID = technique.ID
+	}
+	if strings.TrimSpace(knowledgeTechnique.Name) == "" {
+		knowledgeTechnique.Name = technique.Name
+	}
+	for _, tactic := range mitre.AttackTacticsForTechnique(knowledgeTechnique) {
+		tacticURN := mitre.AttackTacticURN(tenantID, tactic)
+		if tacticURN == "" {
+			continue
+		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        tacticURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: mitre.AttackTacticEntityType,
+			Label:      mitre.AttackTacticLabel(tactic),
+			Attributes: mitre.AttackTacticAttributes(tactic),
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), techniqueURN, tacticURN, relationBelongsTo, mitreKnowledgeLinkAttributes(event, "attack_technique_tactic", technique.SourceValue, extraAttrs)))
+	}
+	coverageURN := mitre.AttackCoverageURN(tenantID, fromURN, techniqueURN)
+	if coverageURN != "" {
+		coverageState := mitreCoverageState(relation, extraAttrs)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        coverageURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: mitre.AttackCoverageEntityType,
+			Label:      mitre.AttackTechniqueLabel(knowledgeTechnique) + " coverage",
+			Attributes: mitre.AttackCoverageAttributes(knowledgeTechnique, coverageState, fromURN, technique.SourceValue, mitreKnowledgeLinkAttributes(event, "attack_coverage", technique.SourceValue, extraAttrs)),
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, coverageURN, relationHasContext, mitreKnowledgeLinkAttributes(event, "attack_coverage_anchor", technique.SourceValue, extraAttrs)))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), coverageURN, techniqueURN, relationSupports, mitreKnowledgeLinkAttributes(event, "attack_coverage_technique", technique.SourceValue, extraAttrs)))
+	}
+	for _, component := range knowledge.DataComponents {
+		componentURN := mitre.AttackDataComponentURN(tenantID, component)
+		if componentURN == "" {
+			continue
+		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        componentURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: mitre.AttackDataComponentEntityType,
+			Label:      firstNonEmpty(component.Name, component.ID),
+			Attributes: mitre.AttackDataComponentAttributes(component),
+		})
+		if source, ok := mitre.AttackDataSourceForComponent(component); ok {
+			sourceURN := mitre.AttackDataSourceURN(tenantID, source)
+			if sourceURN != "" {
+				addEntity(entities, &ports.ProjectedEntity{
+					URN:        sourceURN,
+					TenantID:   tenantID,
+					SourceID:   event.GetSourceId(),
+					EntityType: mitre.AttackDataSourceEntityType,
+					Label:      firstNonEmpty(source.Name, source.ID),
+					Attributes: mitre.AttackDataSourceAttributes(source),
+				})
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), componentURN, sourceURN, relationBelongsTo, mitreKnowledgeLinkAttributes(event, "attack_data_component_source", technique.SourceValue, extraAttrs)))
+			}
+		}
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), componentURN, techniqueURN, relationSupports, mitreKnowledgeLinkAttributes(event, "detects_attack_technique", technique.SourceValue, extraAttrs)))
+		if coverageURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), coverageURN, componentURN, relationHasEvidence, mitreKnowledgeLinkAttributes(event, "coverage_data_component", technique.SourceValue, extraAttrs)))
+		}
+	}
+	for _, defendTechnique := range knowledge.DefendTechniques {
+		defendTechniqueURN := mitre.DefendTechniqueURN(tenantID, defendTechnique)
+		if defendTechniqueURN == "" {
+			continue
+		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        defendTechniqueURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: mitre.DefendTechniqueEntityType,
+			Label:      mitre.DefendTechniqueLabel(defendTechnique),
+			Attributes: mitre.DefendTechniqueAttributes(defendTechnique),
+		})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), defendTechniqueURN, techniqueURN, relationSupports, mitreKnowledgeLinkAttributes(event, "defends_against", technique.SourceValue, extraAttrs)))
+	}
+	for _, artifact := range knowledge.DefendArtifacts {
+		artifactURN := mitre.DefendArtifactURN(tenantID, artifact)
+		if artifactURN == "" {
+			continue
+		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        artifactURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: mitre.DefendArtifactEntityType,
+			Label:      mitre.DefendArtifactLabel(artifact),
+			Attributes: mitre.DefendArtifactAttributes(artifact),
+		})
+		for _, defendTechnique := range knowledge.DefendTechniques {
+			defendTechniqueURN := mitre.DefendTechniqueURN(tenantID, defendTechnique)
+			if defendTechniqueURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), defendTechniqueURN, artifactURN, relationHasContext, mitreKnowledgeLinkAttributes(event, "defense_artifact", technique.SourceValue, extraAttrs)))
+			}
+		}
+	}
+}
+
 func mitreAttributeValues(attrs map[string]string, keys ...string) []string {
 	values := []string{}
 	if attrs == nil {
@@ -229,4 +340,26 @@ func mitreLinkAttributes(event *cerebrov1.EventEnvelope, contextType string, sou
 		}
 	}
 	return compactAttributes(attrs)
+}
+
+func mitreKnowledgeLinkAttributes(event *cerebrov1.EventEnvelope, relationship string, sourceValue string, extra map[string]string) map[string]string {
+	attrs := mitreLinkAttributes(event, relationship, sourceValue, extra)
+	attrs["relationship"] = strings.TrimSpace(relationship)
+	attrs["knowledge_pack_id"] = mitre.KnowledgePackID
+	return compactAttributes(attrs)
+}
+
+func mitreCoverageState(relation string, attrs map[string]string) mitre.CoverageState {
+	status := ""
+	evidenceSurface := ""
+	if attrs != nil {
+		status = firstNonEmpty(attrs["coverage_state"], attrs["coverage_status"], attrs["coverage"], attrs["status"])
+		evidenceSurface = attrs["evidence_surface"]
+	}
+	state := mitre.NormalizeCoverageState(status)
+	if relation == relationHasContext && state == "mapped" {
+		state = "observed"
+		status = firstNonEmpty(status, "observed")
+	}
+	return mitre.CoverageState{State: state, Status: status, EvidenceSurface: evidenceSurface}
 }

--- a/internal/sourceprojection/security_spine_test.go
+++ b/internal/sourceprojection/security_spine_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/mitre"
 )
 
 func TestProjectBackstageComponent(t *testing.T) {
@@ -351,6 +352,46 @@ func TestProjectSecurityToolingMapControlMappingLinksMITRECoverage(t *testing.T)
 	if got := state.links[defendTechniqueURN+"|"+relationSupports+"|"+attackTechniqueURN].Attributes["relationship"]; got != "defends_against" {
 		t.Fatalf("defend attack relationship = %q, want defends_against", got)
 	}
+	coverageURN := mitre.AttackCoverageURN("writer", toolURN, attackTechniqueURN)
+	coverage := state.entities[coverageURN]
+	if coverage == nil || coverage.EntityType != mitre.AttackCoverageEntityType {
+		t.Fatalf("coverage entity = %#v, want MITRE ATT&CK coverage node", coverage)
+	}
+	if got := coverage.Attributes["coverage_state"]; got != "gap" {
+		t.Fatalf("coverage_state = %q, want gap", got)
+	}
+	if got := coverage.Attributes["evidence_surface"]; got != "endpoint" {
+		t.Fatalf("evidence_surface = %q, want endpoint", got)
+	}
+	assertProjectedLink(t, state, toolURN, relationHasContext, coverageURN)
+	assertProjectedLink(t, state, coverageURN, relationSupports, attackTechniqueURN)
+	componentURN := securitySpineEntityURNByAttribute(state, mitre.AttackDataComponentEntityType, "data_component_name", "Application Log Content")
+	if componentURN == "" {
+		t.Fatalf("MITRE ATT&CK data component Application Log Content missing: %#v", state.entities)
+	}
+	sourceURN := securitySpineEntityURNByAttribute(state, mitre.AttackDataSourceEntityType, "data_source_id", "DS0015")
+	if sourceURN == "" {
+		t.Fatalf("MITRE ATT&CK data source DS0015 missing: %#v", state.entities)
+	}
+	assertProjectedLink(t, state, coverageURN, relationHasEvidence, componentURN)
+	assertProjectedLink(t, state, componentURN, relationSupports, attackTechniqueURN)
+	assertProjectedLink(t, state, componentURN, relationBelongsTo, sourceURN)
+	assertProjectedLink(t, state, "urn:cerebro:writer:mitre_defend_technique:InboundTrafficFiltering", relationSupports, attackTechniqueURN)
+}
+
+func securitySpineEntityURNByAttribute(recorder *projectionRecorder, entityType string, key string, value string) string {
+	if recorder == nil {
+		return ""
+	}
+	for _, entity := range recorder.entities {
+		if entity == nil || entity.EntityType != entityType {
+			continue
+		}
+		if entity.Attributes[key] == value {
+			return entity.URN
+		}
+	}
+	return ""
 }
 
 func TestRegistryRoutesSecurityToolingMapDeclaredKinds(t *testing.T) {

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -1516,23 +1516,6 @@ func firstProjectionValue(values ...string) string {
 	return ""
 }
 
-func uniqueStringsPreserveOrder(values []string) []string {
-	seen := make(map[string]struct{}, len(values))
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
-	}
-	return out
-}
-
 func findingSourceEventID(finding workflowevents.FindingSnapshot) string {
 	for _, eventID := range normalizeIDs(finding.EventIDs) {
 		if strings.TrimSpace(eventID) != "" {

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -30,6 +30,9 @@ const (
 	relationEvaluates     = "evaluates"
 	relationHasFinding    = "has_finding"
 	relationHasContext    = "has_context"
+	relationBelongsTo     = "belongs_to"
+	relationSupports      = "supports"
+	relationHasEvidence   = "has_evidence"
 	relationAnnotatedWith = "annotated_with"
 	relationTrackedBy     = "tracked_by"
 	graphEntityLabelLimit = 160
@@ -72,6 +75,55 @@ var workflowMITREAttackTagKeys = []string{
 	"rule_references",
 	"rule_tags",
 	"tags",
+}
+
+var workflowMITREDefendTacticKeys = []string{
+	"d3fend_tactic",
+	"d3fend_tactics",
+	"defend_tactic",
+	"defend_tactics",
+	"mitre_defend_tactic",
+	"mitre_defend_tactics",
+	"rule_mitre_defend_tactic",
+	"rule_mitre_defend_tactics",
+}
+
+var workflowMITREDefendTechniqueKeys = []string{
+	"d3fend_technique",
+	"d3fend_technique_id",
+	"d3fend_techniques",
+	"d3fend_technique_ids",
+	"defend_technique",
+	"defend_technique_id",
+	"defend_techniques",
+	"defend_technique_ids",
+	"mitre_defend_technique",
+	"mitre_defend_technique_id",
+	"mitre_defend_techniques",
+	"mitre_defend_technique_ids",
+	"rule_mitre_defend_technique",
+	"rule_mitre_defend_technique_id",
+	"rule_mitre_defend_techniques",
+	"rule_mitre_defend_technique_ids",
+}
+
+var workflowMITREDefendArtifactKeys = []string{
+	"d3fend_artifact",
+	"d3fend_artifact_id",
+	"d3fend_artifacts",
+	"d3fend_artifact_ids",
+	"defend_artifact",
+	"defend_artifact_id",
+	"defend_artifacts",
+	"defend_artifact_ids",
+	"mitre_defend_artifact",
+	"mitre_defend_artifact_id",
+	"mitre_defend_artifacts",
+	"mitre_defend_artifact_ids",
+	"rule_mitre_defend_artifact",
+	"rule_mitre_defend_artifact_id",
+	"rule_mitre_defend_artifacts",
+	"rule_mitre_defend_artifact_ids",
 }
 
 // Service projects durable workflow events into graph entities and links.
@@ -545,8 +597,264 @@ func (s *Service) ensureFindingMITREContext(ctx context.Context, finding workflo
 	sourceID := strings.TrimSpace(finding.SourceSystem)
 	anchorURN := findingURN(tenantID, finding.FindingID)
 	currentContextURNs := []string{}
+	attackTechniqueURNs := []string{}
+	defendTechniqueURNs := []string{}
+	defendArtifactURNs := []string{}
+	appendContextURN := func(urn string) {
+		if urn = strings.TrimSpace(urn); urn != "" {
+			currentContextURNs = append(currentContextURNs, urn)
+		}
+	}
 	tactics := mitre.ExtractAttackTactics(append(findingMetadataValues(finding.Metadata, workflowMITREAttackTacticKeys...), findingMetadataValues(finding.Metadata, workflowMITREAttackTagKeys...)...)...)
 	for _, tactic := range tactics {
+		tacticURN, err := s.ensureFindingMITREAttackTactic(ctx, finding, anchorURN, tactic, "attack_tactic", result)
+		if err != nil {
+			return err
+		}
+		appendContextURN(tacticURN)
+	}
+	techniques := mitre.ExtractAttackTechniques(findingMetadataValues(finding.Metadata, workflowMITREAttackTechniqueKeys...)...)
+	techniques = append(techniques, mitre.ExtractAttackTechniqueIDs(findingMetadataValues(finding.Metadata, workflowMITREAttackTagKeys...)...)...)
+	for _, technique := range techniques {
+		techniqueURN, err := s.ensureFindingMITREAttackTechnique(ctx, finding, anchorURN, technique, "attack_technique", result)
+		if err != nil {
+			return err
+		}
+		appendContextURN(techniqueURN)
+		if techniqueURN != "" {
+			attackTechniqueURNs = append(attackTechniqueURNs, techniqueURN)
+		}
+		knowledgeURNs, err := s.ensureFindingMITREAttackTechniqueKnowledge(ctx, finding, anchorURN, technique, techniqueURN, result)
+		if err != nil {
+			return err
+		}
+		currentContextURNs = append(currentContextURNs, knowledgeURNs...)
+	}
+	for _, tactic := range mitre.ExtractDefendTactics(findingMetadataValues(finding.Metadata, workflowMITREDefendTacticKeys...)...) {
+		tacticURN, err := s.ensureFindingMITREDefendTactic(ctx, finding, anchorURN, tactic, result)
+		if err != nil {
+			return err
+		}
+		appendContextURN(tacticURN)
+	}
+	for _, technique := range mitre.ExtractDefendTechniques(findingMetadataValues(finding.Metadata, workflowMITREDefendTechniqueKeys...)...) {
+		techniqueURN, err := s.ensureFindingMITREDefendTechnique(ctx, finding, anchorURN, technique, result)
+		if err != nil {
+			return err
+		}
+		appendContextURN(techniqueURN)
+		if techniqueURN != "" {
+			defendTechniqueURNs = append(defendTechniqueURNs, techniqueURN)
+		}
+	}
+	for _, artifact := range mitre.ExtractDefendArtifacts(findingMetadataValues(finding.Metadata, workflowMITREDefendArtifactKeys...)...) {
+		artifactURN, err := s.ensureFindingMITREDefendArtifact(ctx, finding, anchorURN, artifact, result)
+		if err != nil {
+			return err
+		}
+		appendContextURN(artifactURN)
+		if artifactURN != "" {
+			defendArtifactURNs = append(defendArtifactURNs, artifactURN)
+		}
+	}
+	for _, defendTechniqueURN := range uniqueStringsPreserveOrder(defendTechniqueURNs) {
+		for _, attackTechniqueURN := range uniqueStringsPreserveOrder(attackTechniqueURNs) {
+			if err := s.upsertLink(ctx, &ports.ProjectedLink{
+				TenantID:   tenantID,
+				SourceID:   sourceID,
+				FromURN:    defendTechniqueURN,
+				ToURN:      attackTechniqueURN,
+				Relation:   relationSupports,
+				Attributes: findingMITREKnowledgeLinkAttributes(finding, "defends_against", ""),
+			}, result); err != nil {
+				return err
+			}
+		}
+		for _, artifactURN := range uniqueStringsPreserveOrder(defendArtifactURNs) {
+			if err := s.upsertLink(ctx, &ports.ProjectedLink{
+				TenantID:   tenantID,
+				SourceID:   sourceID,
+				FromURN:    defendTechniqueURN,
+				ToURN:      artifactURN,
+				Relation:   relationHasContext,
+				Attributes: findingMITREKnowledgeLinkAttributes(finding, "defense_artifact", ""),
+			}, result); err != nil {
+				return err
+			}
+		}
+	}
+	if err := s.pruneFindingMITREContextLinks(ctx, tenantID, sourceID, anchorURN, currentContextURNs, result); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) ensureFindingMITREAttackTactic(ctx context.Context, finding workflowevents.FindingSnapshot, anchorURN string, tactic mitre.AttackTactic, contextType string, result *ports.ProjectionResult) (string, error) {
+	tenantID := strings.TrimSpace(finding.TenantID)
+	sourceID := strings.TrimSpace(finding.SourceSystem)
+	tacticURN := mitre.AttackTacticURN(tenantID, tactic)
+	if tacticURN == "" {
+		return "", nil
+	}
+	if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+		URN:        tacticURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: mitre.AttackTacticEntityType,
+		Label:      mitre.AttackTacticLabel(tactic),
+		Attributes: mitre.AttackTacticAttributes(tactic),
+	}, result); err != nil {
+		return "", err
+	}
+	if err := s.upsertLink(ctx, &ports.ProjectedLink{
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		FromURN:    anchorURN,
+		ToURN:      tacticURN,
+		Relation:   relationHasContext,
+		Attributes: findingMITRELinkAttributes(finding, contextType, tactic.SourceValue),
+	}, result); err != nil {
+		return "", err
+	}
+	return tacticURN, nil
+}
+
+func (s *Service) ensureFindingMITREAttackTechnique(ctx context.Context, finding workflowevents.FindingSnapshot, anchorURN string, technique mitre.AttackTechnique, contextType string, result *ports.ProjectionResult) (string, error) {
+	tenantID := strings.TrimSpace(finding.TenantID)
+	sourceID := strings.TrimSpace(finding.SourceSystem)
+	techniqueURN := mitre.AttackTechniqueURN(tenantID, technique)
+	if techniqueURN == "" {
+		return "", nil
+	}
+	if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+		URN:        techniqueURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: mitre.AttackTechniqueEntityType,
+		Label:      mitre.AttackTechniqueLabel(technique),
+		Attributes: mitre.AttackTechniqueAttributes(technique),
+	}, result); err != nil {
+		return "", err
+	}
+	if err := s.upsertLink(ctx, &ports.ProjectedLink{
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		FromURN:    anchorURN,
+		ToURN:      techniqueURN,
+		Relation:   relationHasContext,
+		Attributes: findingMITRELinkAttributes(finding, contextType, technique.SourceValue),
+	}, result); err != nil {
+		return "", err
+	}
+	return techniqueURN, nil
+}
+
+func (s *Service) ensureFindingMITREDefendTactic(ctx context.Context, finding workflowevents.FindingSnapshot, anchorURN string, tactic mitre.DefendTactic, result *ports.ProjectionResult) (string, error) {
+	tenantID := strings.TrimSpace(finding.TenantID)
+	sourceID := strings.TrimSpace(finding.SourceSystem)
+	tacticURN := mitre.DefendTacticURN(tenantID, tactic)
+	if tacticURN == "" {
+		return "", nil
+	}
+	if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+		URN:        tacticURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: mitre.DefendTacticEntityType,
+		Label:      mitre.DefendTacticLabel(tactic),
+		Attributes: mitre.DefendTacticAttributes(tactic),
+	}, result); err != nil {
+		return "", err
+	}
+	if err := s.upsertLink(ctx, &ports.ProjectedLink{
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		FromURN:    anchorURN,
+		ToURN:      tacticURN,
+		Relation:   relationHasContext,
+		Attributes: findingMITRELinkAttributes(finding, "defend_tactic", tactic.SourceValue),
+	}, result); err != nil {
+		return "", err
+	}
+	return tacticURN, nil
+}
+
+func (s *Service) ensureFindingMITREDefendTechnique(ctx context.Context, finding workflowevents.FindingSnapshot, anchorURN string, technique mitre.DefendTechnique, result *ports.ProjectionResult) (string, error) {
+	tenantID := strings.TrimSpace(finding.TenantID)
+	sourceID := strings.TrimSpace(finding.SourceSystem)
+	techniqueURN := mitre.DefendTechniqueURN(tenantID, technique)
+	if techniqueURN == "" {
+		return "", nil
+	}
+	if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+		URN:        techniqueURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: mitre.DefendTechniqueEntityType,
+		Label:      mitre.DefendTechniqueLabel(technique),
+		Attributes: mitre.DefendTechniqueAttributes(technique),
+	}, result); err != nil {
+		return "", err
+	}
+	if err := s.upsertLink(ctx, &ports.ProjectedLink{
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		FromURN:    anchorURN,
+		ToURN:      techniqueURN,
+		Relation:   relationHasContext,
+		Attributes: findingMITRELinkAttributes(finding, "defend_technique", technique.SourceValue),
+	}, result); err != nil {
+		return "", err
+	}
+	return techniqueURN, nil
+}
+
+func (s *Service) ensureFindingMITREDefendArtifact(ctx context.Context, finding workflowevents.FindingSnapshot, anchorURN string, artifact mitre.DefendArtifact, result *ports.ProjectionResult) (string, error) {
+	tenantID := strings.TrimSpace(finding.TenantID)
+	sourceID := strings.TrimSpace(finding.SourceSystem)
+	artifactURN := mitre.DefendArtifactURN(tenantID, artifact)
+	if artifactURN == "" {
+		return "", nil
+	}
+	if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+		URN:        artifactURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: mitre.DefendArtifactEntityType,
+		Label:      mitre.DefendArtifactLabel(artifact),
+		Attributes: mitre.DefendArtifactAttributes(artifact),
+	}, result); err != nil {
+		return "", err
+	}
+	if err := s.upsertLink(ctx, &ports.ProjectedLink{
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		FromURN:    anchorURN,
+		ToURN:      artifactURN,
+		Relation:   relationHasContext,
+		Attributes: findingMITRELinkAttributes(finding, "defend_artifact", artifact.SourceValue),
+	}, result); err != nil {
+		return "", err
+	}
+	return artifactURN, nil
+}
+
+func (s *Service) ensureFindingMITREAttackTechniqueKnowledge(ctx context.Context, finding workflowevents.FindingSnapshot, anchorURN string, technique mitre.AttackTechnique, techniqueURN string, result *ports.ProjectionResult) ([]string, error) {
+	tenantID := strings.TrimSpace(finding.TenantID)
+	sourceID := strings.TrimSpace(finding.SourceSystem)
+	knowledge, ok := mitre.AttackTechniqueKnowledgeFor(technique)
+	if !ok || strings.TrimSpace(techniqueURN) == "" {
+		return nil, nil
+	}
+	knowledgeTechnique := mitre.AttackTechnique{ID: knowledge.ID, Name: knowledge.Name, SourceValue: technique.SourceValue}
+	if strings.TrimSpace(knowledgeTechnique.ID) == "" {
+		knowledgeTechnique.ID = technique.ID
+	}
+	if strings.TrimSpace(knowledgeTechnique.Name) == "" {
+		knowledgeTechnique.Name = technique.Name
+	}
+	currentContextURNs := []string{}
+	for _, tactic := range mitre.AttackTacticsForTechnique(knowledgeTechnique) {
 		tacticURN := mitre.AttackTacticURN(tenantID, tactic)
 		if tacticURN == "" {
 			continue
@@ -560,7 +868,7 @@ func (s *Service) ensureFindingMITREContext(ctx context.Context, finding workflo
 			Label:      mitre.AttackTacticLabel(tactic),
 			Attributes: mitre.AttackTacticAttributes(tactic),
 		}, result); err != nil {
-			return err
+			return nil, err
 		}
 		if err := s.upsertLink(ctx, &ports.ProjectedLink{
 			TenantID:   tenantID,
@@ -568,44 +876,177 @@ func (s *Service) ensureFindingMITREContext(ctx context.Context, finding workflo
 			FromURN:    anchorURN,
 			ToURN:      tacticURN,
 			Relation:   relationHasContext,
-			Attributes: findingMITRELinkAttributes(finding, "attack_tactic", tactic.SourceValue),
+			Attributes: findingMITREKnowledgeLinkAttributes(finding, "attack_technique_tactic", technique.SourceValue),
 		}, result); err != nil {
-			return err
+			return nil, err
 		}
-	}
-	techniques := mitre.ExtractAttackTechniques(findingMetadataValues(finding.Metadata, workflowMITREAttackTechniqueKeys...)...)
-	techniques = append(techniques, mitre.ExtractAttackTechniqueIDs(findingMetadataValues(finding.Metadata, workflowMITREAttackTagKeys...)...)...)
-	for _, technique := range techniques {
-		techniqueURN := mitre.AttackTechniqueURN(tenantID, technique)
-		if techniqueURN == "" {
-			continue
-		}
-		currentContextURNs = append(currentContextURNs, techniqueURN)
-		if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
-			URN:        techniqueURN,
+		if err := s.upsertLink(ctx, &ports.ProjectedLink{
 			TenantID:   tenantID,
 			SourceID:   sourceID,
-			EntityType: mitre.AttackTechniqueEntityType,
-			Label:      mitre.AttackTechniqueLabel(technique),
-			Attributes: mitre.AttackTechniqueAttributes(technique),
+			FromURN:    techniqueURN,
+			ToURN:      tacticURN,
+			Relation:   relationBelongsTo,
+			Attributes: findingMITREKnowledgeLinkAttributes(finding, "attack_technique_tactic", technique.SourceValue),
 		}, result); err != nil {
-			return err
+			return nil, err
+		}
+	}
+	coverageURN := mitre.AttackCoverageURN(tenantID, anchorURN, techniqueURN)
+	if coverageURN != "" {
+		currentContextURNs = append(currentContextURNs, coverageURN)
+		if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+			URN:        coverageURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: mitre.AttackCoverageEntityType,
+			Label:      mitre.AttackTechniqueLabel(knowledgeTechnique) + " coverage",
+			Attributes: mitre.AttackCoverageAttributes(knowledgeTechnique, findingMITRECoverageState(finding), anchorURN, technique.SourceValue, findingMITREKnowledgeLinkAttributes(finding, "attack_coverage", technique.SourceValue)),
+		}, result); err != nil {
+			return nil, err
 		}
 		if err := s.upsertLink(ctx, &ports.ProjectedLink{
 			TenantID:   tenantID,
 			SourceID:   sourceID,
 			FromURN:    anchorURN,
-			ToURN:      techniqueURN,
+			ToURN:      coverageURN,
 			Relation:   relationHasContext,
-			Attributes: findingMITRELinkAttributes(finding, "attack_technique", technique.SourceValue),
+			Attributes: findingMITREKnowledgeLinkAttributes(finding, "attack_coverage_anchor", technique.SourceValue),
 		}, result); err != nil {
-			return err
+			return nil, err
+		}
+		if err := s.upsertLink(ctx, &ports.ProjectedLink{
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			FromURN:    coverageURN,
+			ToURN:      techniqueURN,
+			Relation:   relationSupports,
+			Attributes: findingMITREKnowledgeLinkAttributes(finding, "attack_coverage_technique", technique.SourceValue),
+		}, result); err != nil {
+			return nil, err
 		}
 	}
-	if err := s.pruneFindingMITREContextLinks(ctx, tenantID, sourceID, anchorURN, currentContextURNs, result); err != nil {
-		return err
+	for _, component := range knowledge.DataComponents {
+		componentURN := mitre.AttackDataComponentURN(tenantID, component)
+		if componentURN == "" {
+			continue
+		}
+		if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+			URN:        componentURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: mitre.AttackDataComponentEntityType,
+			Label:      firstProjectionValue(component.Name, component.ID),
+			Attributes: mitre.AttackDataComponentAttributes(component),
+		}, result); err != nil {
+			return nil, err
+		}
+		if source, ok := mitre.AttackDataSourceForComponent(component); ok {
+			sourceURN := mitre.AttackDataSourceURN(tenantID, source)
+			if sourceURN != "" {
+				if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+					URN:        sourceURN,
+					TenantID:   tenantID,
+					SourceID:   sourceID,
+					EntityType: mitre.AttackDataSourceEntityType,
+					Label:      firstProjectionValue(source.Name, source.ID),
+					Attributes: mitre.AttackDataSourceAttributes(source),
+				}, result); err != nil {
+					return nil, err
+				}
+				if err := s.upsertLink(ctx, &ports.ProjectedLink{
+					TenantID:   tenantID,
+					SourceID:   sourceID,
+					FromURN:    componentURN,
+					ToURN:      sourceURN,
+					Relation:   relationBelongsTo,
+					Attributes: findingMITREKnowledgeLinkAttributes(finding, "attack_data_component_source", technique.SourceValue),
+				}, result); err != nil {
+					return nil, err
+				}
+			}
+		}
+		if err := s.upsertLink(ctx, &ports.ProjectedLink{
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			FromURN:    componentURN,
+			ToURN:      techniqueURN,
+			Relation:   relationSupports,
+			Attributes: findingMITREKnowledgeLinkAttributes(finding, "detects_attack_technique", technique.SourceValue),
+		}, result); err != nil {
+			return nil, err
+		}
+		if coverageURN != "" {
+			if err := s.upsertLink(ctx, &ports.ProjectedLink{
+				TenantID:   tenantID,
+				SourceID:   sourceID,
+				FromURN:    coverageURN,
+				ToURN:      componentURN,
+				Relation:   relationHasEvidence,
+				Attributes: findingMITREKnowledgeLinkAttributes(finding, "coverage_data_component", technique.SourceValue),
+			}, result); err != nil {
+				return nil, err
+			}
+		}
 	}
-	return nil
+	for _, defendTechnique := range knowledge.DefendTechniques {
+		defendTechniqueURN := mitre.DefendTechniqueURN(tenantID, defendTechnique)
+		if defendTechniqueURN == "" {
+			continue
+		}
+		if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+			URN:        defendTechniqueURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: mitre.DefendTechniqueEntityType,
+			Label:      mitre.DefendTechniqueLabel(defendTechnique),
+			Attributes: mitre.DefendTechniqueAttributes(defendTechnique),
+		}, result); err != nil {
+			return nil, err
+		}
+		if err := s.upsertLink(ctx, &ports.ProjectedLink{
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			FromURN:    defendTechniqueURN,
+			ToURN:      techniqueURN,
+			Relation:   relationSupports,
+			Attributes: findingMITREKnowledgeLinkAttributes(finding, "defends_against", technique.SourceValue),
+		}, result); err != nil {
+			return nil, err
+		}
+	}
+	for _, artifact := range knowledge.DefendArtifacts {
+		artifactURN := mitre.DefendArtifactURN(tenantID, artifact)
+		if artifactURN == "" {
+			continue
+		}
+		if err := s.upsertEntity(ctx, &ports.ProjectedEntity{
+			URN:        artifactURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: mitre.DefendArtifactEntityType,
+			Label:      mitre.DefendArtifactLabel(artifact),
+			Attributes: mitre.DefendArtifactAttributes(artifact),
+		}, result); err != nil {
+			return nil, err
+		}
+		for _, defendTechnique := range knowledge.DefendTechniques {
+			defendTechniqueURN := mitre.DefendTechniqueURN(tenantID, defendTechnique)
+			if defendTechniqueURN == "" {
+				continue
+			}
+			if err := s.upsertLink(ctx, &ports.ProjectedLink{
+				TenantID:   tenantID,
+				SourceID:   sourceID,
+				FromURN:    defendTechniqueURN,
+				ToURN:      artifactURN,
+				Relation:   relationHasContext,
+				Attributes: findingMITREKnowledgeLinkAttributes(finding, "defense_artifact", technique.SourceValue),
+			}, result); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return currentContextURNs, nil
 }
 
 type findingActiveLinkReader interface {
@@ -705,6 +1146,10 @@ LIMIT $row_limit`,
 				"entity_types": []string{
 					mitre.AttackTacticEntityType,
 					mitre.AttackTechniqueEntityType,
+					mitre.AttackCoverageEntityType,
+					mitre.DefendTacticEntityType,
+					mitre.DefendTechniqueEntityType,
+					mitre.DefendArtifactEntityType,
 				},
 				"last_seen": lastSeen,
 				"row_limit": int64(ports.MaxCypherQueryRows),
@@ -1063,6 +1508,33 @@ func findingMITRELinkAttributes(finding workflowevents.FindingSnapshot, contextT
 	return attributes
 }
 
+func findingMITREKnowledgeLinkAttributes(finding workflowevents.FindingSnapshot, relationship string, sourceValue string) map[string]string {
+	attributes := findingMITRELinkAttributes(finding, relationship, sourceValue)
+	attributes["relationship"] = strings.TrimSpace(relationship)
+	attributes["knowledge_pack_id"] = mitre.KnowledgePackID
+	trimEmptyProjectionAttributes(attributes)
+	return attributes
+}
+
+func findingMITRECoverageState(finding workflowevents.FindingSnapshot) mitre.CoverageState {
+	status := firstProjectionValue(
+		finding.Metadata["mitre_coverage_state"],
+		finding.Metadata["coverage_state"],
+		finding.Metadata["coverage_status"],
+		finding.Metadata["coverage"],
+		"observed",
+	)
+	state := mitre.NormalizeCoverageState(status)
+	if state == "mapped" {
+		state = "observed"
+	}
+	return mitre.CoverageState{
+		State:           state,
+		Status:          status,
+		EvidenceSurface: firstProjectionValue(finding.Metadata["evidence_surface"], finding.Metadata["source_family"], finding.SourceSystem),
+	}
+}
+
 func findingMetadataValues(metadata map[string]string, keys ...string) []string {
 	values := []string{}
 	for _, key := range keys {
@@ -1071,6 +1543,32 @@ func findingMetadataValues(metadata map[string]string, keys ...string) []string 
 		}
 	}
 	return values
+}
+
+func firstProjectionValue(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func uniqueStringsPreserveOrder(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func findingSourceEventID(finding workflowevents.FindingSnapshot) string {

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -597,9 +597,6 @@ func (s *Service) ensureFindingMITREContext(ctx context.Context, finding workflo
 	sourceID := strings.TrimSpace(finding.SourceSystem)
 	anchorURN := findingURN(tenantID, finding.FindingID)
 	currentContextURNs := []string{}
-	attackTechniqueURNs := []string{}
-	defendTechniqueURNs := []string{}
-	defendArtifactURNs := []string{}
 	appendContextURN := func(urn string) {
 		if urn = strings.TrimSpace(urn); urn != "" {
 			currentContextURNs = append(currentContextURNs, urn)
@@ -621,9 +618,6 @@ func (s *Service) ensureFindingMITREContext(ctx context.Context, finding workflo
 			return err
 		}
 		appendContextURN(techniqueURN)
-		if techniqueURN != "" {
-			attackTechniqueURNs = append(attackTechniqueURNs, techniqueURN)
-		}
 		knowledgeURNs, err := s.ensureFindingMITREAttackTechniqueKnowledge(ctx, finding, anchorURN, technique, techniqueURN, result)
 		if err != nil {
 			return err
@@ -643,9 +637,6 @@ func (s *Service) ensureFindingMITREContext(ctx context.Context, finding workflo
 			return err
 		}
 		appendContextURN(techniqueURN)
-		if techniqueURN != "" {
-			defendTechniqueURNs = append(defendTechniqueURNs, techniqueURN)
-		}
 	}
 	for _, artifact := range mitre.ExtractDefendArtifacts(findingMetadataValues(finding.Metadata, workflowMITREDefendArtifactKeys...)...) {
 		artifactURN, err := s.ensureFindingMITREDefendArtifact(ctx, finding, anchorURN, artifact, result)
@@ -653,35 +644,6 @@ func (s *Service) ensureFindingMITREContext(ctx context.Context, finding workflo
 			return err
 		}
 		appendContextURN(artifactURN)
-		if artifactURN != "" {
-			defendArtifactURNs = append(defendArtifactURNs, artifactURN)
-		}
-	}
-	for _, defendTechniqueURN := range uniqueStringsPreserveOrder(defendTechniqueURNs) {
-		for _, attackTechniqueURN := range uniqueStringsPreserveOrder(attackTechniqueURNs) {
-			if err := s.upsertLink(ctx, &ports.ProjectedLink{
-				TenantID:   tenantID,
-				SourceID:   sourceID,
-				FromURN:    defendTechniqueURN,
-				ToURN:      attackTechniqueURN,
-				Relation:   relationSupports,
-				Attributes: findingMITREKnowledgeLinkAttributes(finding, "defends_against", ""),
-			}, result); err != nil {
-				return err
-			}
-		}
-		for _, artifactURN := range uniqueStringsPreserveOrder(defendArtifactURNs) {
-			if err := s.upsertLink(ctx, &ports.ProjectedLink{
-				TenantID:   tenantID,
-				SourceID:   sourceID,
-				FromURN:    defendTechniqueURN,
-				ToURN:      artifactURN,
-				Relation:   relationHasContext,
-				Attributes: findingMITREKnowledgeLinkAttributes(finding, "defense_artifact", ""),
-			}, result); err != nil {
-				return err
-			}
-		}
 	}
 	if err := s.pruneFindingMITREContextLinks(ctx, tenantID, sourceID, anchorURN, currentContextURNs, result); err != nil {
 		return err

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -443,8 +443,12 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	assertWorkflowLink(t, graph, appLogComponent.URN, relationSupports, "urn:cerebro:writer:mitre_attack_technique:T1190")
 	assertWorkflowLink(t, graph, appLogComponent.URN, relationBelongsTo, appLogSource.URN)
 	assertWorkflowLink(t, graph, "urn:cerebro:writer:mitre_defend_technique:InboundTrafficFiltering", relationSupports, "urn:cerebro:writer:mitre_attack_technique:T1190")
-	assertWorkflowLink(t, graph, "urn:cerebro:writer:mitre_defend_technique:Multi-factorAuthentication", relationSupports, "urn:cerebro:writer:mitre_attack_technique:T1190")
-	assertWorkflowLink(t, graph, "urn:cerebro:writer:mitre_defend_technique:Multi-factorAuthentication", relationHasContext, "urn:cerebro:writer:mitre_defend_artifact:Credential")
+	if _, ok := graph.links["urn:cerebro:writer:mitre_defend_technique:Multi-factorAuthentication|supports|urn:cerebro:writer:mitre_attack_technique:T1190"]; ok {
+		t.Fatal("explicit D3FEND metadata should not create cross-product ATT&CK support links")
+	}
+	if _, ok := graph.links["urn:cerebro:writer:mitre_defend_technique:Multi-factorAuthentication|has_context|urn:cerebro:writer:mitre_defend_artifact:Credential"]; ok {
+		t.Fatal("explicit D3FEND metadata should not create cross-product artifact links")
+	}
 	noteEvent, err := workflowevents.NewFindingNoteAddedEvent(workflowevents.FindingNoteAdded{
 		Finding:   finding,
 		NoteID:    "note-1",

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/writer/cerebro/internal/mitre"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
@@ -121,6 +122,31 @@ func (r *projectionRecorder) ExecuteReadCypher(_ context.Context, request ports.
 		rows = append(rows, ports.CypherRow{Values: map[string]any{"resource_urn": urn}})
 	}
 	return rows, nil
+}
+
+func assertWorkflowLink(t *testing.T, recorder *projectionRecorder, fromURN string, relation string, toURN string) {
+	t.Helper()
+	if recorder == nil || recorder.links == nil {
+		t.Fatalf("projected link %s|%s|%s missing: no links recorded", fromURN, relation, toURN)
+	}
+	if _, ok := recorder.links[fromURN+"|"+relation+"|"+toURN]; !ok {
+		t.Fatalf("projected link %s|%s|%s missing", fromURN, relation, toURN)
+	}
+}
+
+func projectedEntityByAttribute(recorder *projectionRecorder, entityType string, key string, value string) *ports.ProjectedEntity {
+	if recorder == nil {
+		return nil
+	}
+	for _, entity := range recorder.entities {
+		if entity == nil || entity.EntityType != entityType {
+			continue
+		}
+		if entity.Attributes[key] == value {
+			return entity
+		}
+	}
+	return nil
 }
 
 func (r *projectionRecorder) CleanupProjectedEntities(_ context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
@@ -319,6 +345,10 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 		},
 		Metadata: map[string]string{
 			"actor_urn":         "urn:cerebro:writer:okta_actor:user:00u1",
+			"coverage_status":   "gap",
+			"d3fend_artifact":   "Credential",
+			"d3fend_technique":  "Multi-factorAuthentication",
+			"evidence_surface":  "identity",
 			"resource_type":     "okta_resource",
 			"rule_mitre_attack": "Initial Access:T1190",
 			"rule_tags":         "okta,identity,defense-evasion,attack.t1562,mitre-ta0005",
@@ -382,6 +412,39 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	if _, ok := graph.links["urn:cerebro:writer:finding:finding-1|has_context|urn:cerebro:writer:mitre_attack_tactic:TA0001"]; !ok {
 		t.Fatal("finding rule MITRE ATT&CK tactic context link missing after recorded event")
 	}
+	if _, ok := graph.links["urn:cerebro:writer:finding:finding-1|has_context|urn:cerebro:writer:mitre_defend_technique:Multi-factorAuthentication"]; !ok {
+		t.Fatal("finding MITRE D3FEND technique context link missing after recorded event")
+	}
+	if _, ok := graph.links["urn:cerebro:writer:finding:finding-1|has_context|urn:cerebro:writer:mitre_defend_artifact:Credential"]; !ok {
+		t.Fatal("finding MITRE D3FEND artifact context link missing after recorded event")
+	}
+	t1190CoverageURN := mitre.AttackCoverageURN("writer", "urn:cerebro:writer:finding:finding-1", "urn:cerebro:writer:mitre_attack_technique:T1190")
+	t1190Coverage := graph.entities[t1190CoverageURN]
+	if t1190Coverage == nil || t1190Coverage.EntityType != mitre.AttackCoverageEntityType {
+		t.Fatalf("T1190 coverage entity = %#v, want MITRE ATT&CK coverage node", t1190Coverage)
+	}
+	if got := t1190Coverage.Attributes["coverage_state"]; got != "gap" {
+		t.Fatalf("T1190 coverage_state = %q, want gap", got)
+	}
+	if got := t1190Coverage.Attributes["evidence_surface"]; got != "identity" {
+		t.Fatalf("T1190 evidence_surface = %q, want identity", got)
+	}
+	assertWorkflowLink(t, graph, "urn:cerebro:writer:finding:finding-1", relationHasContext, t1190CoverageURN)
+	assertWorkflowLink(t, graph, t1190CoverageURN, relationSupports, "urn:cerebro:writer:mitre_attack_technique:T1190")
+	appLogComponent := projectedEntityByAttribute(graph, mitre.AttackDataComponentEntityType, "data_component_name", "Application Log Content")
+	if appLogComponent == nil {
+		t.Fatalf("MITRE ATT&CK data component Application Log Content missing: %#v", graph.entities)
+	}
+	appLogSource := projectedEntityByAttribute(graph, mitre.AttackDataSourceEntityType, "data_source_id", "DS0015")
+	if appLogSource == nil {
+		t.Fatalf("MITRE ATT&CK data source DS0015 missing: %#v", graph.entities)
+	}
+	assertWorkflowLink(t, graph, t1190CoverageURN, relationHasEvidence, appLogComponent.URN)
+	assertWorkflowLink(t, graph, appLogComponent.URN, relationSupports, "urn:cerebro:writer:mitre_attack_technique:T1190")
+	assertWorkflowLink(t, graph, appLogComponent.URN, relationBelongsTo, appLogSource.URN)
+	assertWorkflowLink(t, graph, "urn:cerebro:writer:mitre_defend_technique:InboundTrafficFiltering", relationSupports, "urn:cerebro:writer:mitre_attack_technique:T1190")
+	assertWorkflowLink(t, graph, "urn:cerebro:writer:mitre_defend_technique:Multi-factorAuthentication", relationSupports, "urn:cerebro:writer:mitre_attack_technique:T1190")
+	assertWorkflowLink(t, graph, "urn:cerebro:writer:mitre_defend_technique:Multi-factorAuthentication", relationHasContext, "urn:cerebro:writer:mitre_defend_artifact:Credential")
 	noteEvent, err := workflowevents.NewFindingNoteAddedEvent(workflowevents.FindingNoteAdded{
 		Finding:   finding,
 		NoteID:    "note-1",
@@ -698,6 +761,10 @@ func TestProjectFindingRecordedPrunesStaleMITREContextLinks(t *testing.T) {
 	if _, ok := graph.links[anchorURN+"|has_context|urn:cerebro:writer:mitre_attack_tactic:TA0001"]; !ok {
 		t.Fatal("initial MITRE ATT&CK tactic link missing")
 	}
+	initialCoverageURN := mitre.AttackCoverageURN("writer", anchorURN, "urn:cerebro:writer:mitre_attack_technique:T1190")
+	if _, ok := graph.links[anchorURN+"|has_context|"+initialCoverageURN]; !ok {
+		t.Fatal("initial MITRE ATT&CK coverage link missing")
+	}
 
 	finding.Metadata = map[string]string{
 		"rule_mitre_attack": "Discovery:T1087",
@@ -713,8 +780,8 @@ func TestProjectFindingRecordedPrunesStaleMITREContextLinks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project(updated recorded) error = %v", err)
 	}
-	if result.LinksDeleted != 2 {
-		t.Fatalf("LinksDeleted = %d, want 2 stale MITRE context links", result.LinksDeleted)
+	if result.LinksDeleted != 3 {
+		t.Fatalf("LinksDeleted = %d, want 3 stale MITRE context links", result.LinksDeleted)
 	}
 	if _, ok := graph.links[anchorURN+"|has_context|urn:cerebro:writer:mitre_attack_technique:T1190"]; ok {
 		t.Fatal("stale MITRE ATT&CK technique link was not pruned")
@@ -722,11 +789,18 @@ func TestProjectFindingRecordedPrunesStaleMITREContextLinks(t *testing.T) {
 	if _, ok := graph.links[anchorURN+"|has_context|urn:cerebro:writer:mitre_attack_tactic:TA0001"]; ok {
 		t.Fatal("stale MITRE ATT&CK tactic link was not pruned")
 	}
+	if _, ok := graph.links[anchorURN+"|has_context|"+initialCoverageURN]; ok {
+		t.Fatal("stale MITRE ATT&CK coverage link was not pruned")
+	}
 	if _, ok := graph.links[anchorURN+"|has_context|urn:cerebro:writer:mitre_attack_technique:T1087"]; !ok {
 		t.Fatal("updated MITRE ATT&CK technique link missing")
 	}
 	if _, ok := graph.links[anchorURN+"|has_context|urn:cerebro:writer:mitre_attack_tactic:TA0007"]; !ok {
 		t.Fatal("updated MITRE ATT&CK tactic link missing")
+	}
+	updatedCoverageURN := mitre.AttackCoverageURN("writer", anchorURN, "urn:cerebro:writer:mitre_attack_technique:T1087")
+	if _, ok := graph.links[anchorURN+"|has_context|"+updatedCoverageURN]; !ok {
+		t.Fatal("updated MITRE ATT&CK coverage link missing")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a local MITRE ATT&CK and D3FEND knowledge pack for coverage, evidence, and defense graph expansion
- expand source and workflow projections into ATT&CK coverage, data component, data source, and D3FEND relationships
- add D3FEND rule metadata, MITRE-aware risk factors, and a deterministic graph-agent MITRE coverage query

## Validation
- go test ./internal/mitre ./internal/sourceprojection ./internal/workflowprojection ./internal/findings ./internal/graphagent -count=1
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->