### PR TITLE
[codex] Add runtime depth checks to sourcegen plans

### DIFF
--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -562,6 +562,212 @@ func TestPlanDefinitionBuildsPromotionChecklist(t *testing.T) {
 	t.Fatalf("plan missing ready source_cdk.scaffold step: %#v", plan.Checklist)
 }
 
+func TestPlanDefinitionAddsRuntimeDepthChecklist(t *testing.T) {
+	definition := connectordefinitions.Definition{
+		SchemaVersion: connectordefinitions.SchemaVersionIntegrationV1,
+		ID:            "tenant-a-example_idp",
+		TenantID:      "tenant-a",
+		SourceID:      "example_idp",
+		DisplayName:   "Example IDP",
+		Auth: connectordefinitions.AuthSpec{
+			Model: "bearer_token",
+			CredentialFields: []connectordefinitions.Field{{
+				Key:           "token",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		Transport: &connectordefinitions.TransportSpec{
+			BaseURL:      "https://api.example.test",
+			Verification: &connectordefinitions.VerificationSpec{Path: "/v1/me"},
+		},
+		ProviderAPI: &connectordefinitions.ProviderAPISpec{
+			Status:        "verified",
+			Basis:         "detected",
+			VerifiedAt:    "2026-07-04T00:00:00Z",
+			Transport:     "rest",
+			Auth:          "bearer_token",
+			AuthMechanics: "Authorization: Bearer token",
+			BaseURL:       "https://api.example.test",
+			SpecURL:       "https://docs.example.test/openapi.yaml",
+			SpecKind:      "openapi",
+			References:    []string{"https://docs.example.test/openapi.yaml"},
+			Families: []connectordefinitions.ProviderAPIFamilySpec{{
+				ID:     "users",
+				Method: "GET",
+				Path:   "/v1/users",
+			}},
+		},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:             "users",
+			Path:           "/v1/users",
+			RecordSelector: "$.data[*]",
+			IDField:        "id",
+			Event: connectordefinitions.EventMappingSpec{
+				Kind:      "example_idp.user",
+				SchemaRef: "example_idp/user/v1",
+			},
+			Projection: &connectordefinitions.ProjectionSpec{Template: "identity_user"},
+			Coverage: []connectordefinitions.CoverageDimensionSpec{{
+				Type:    "entity_family",
+				Support: "supported",
+			}},
+		}},
+	}
+	plan, err := PlanDefinition(DefinitionRequest{
+		Definition: definition,
+		OutputDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PlanDefinition() error = %v", err)
+	}
+	if plan.Status != PlanStatusReady {
+		t.Fatalf("plan status = %q, want ready: %#v", plan.Status, plan.Warnings)
+	}
+	proof := requirePlanStep(t, plan, "runtime_depth.provider_api_proof")
+	if proof.Status != PlanStatusReady || !strings.Contains(proof.Detail, "maps 1 of 1 resource families") {
+		t.Fatalf("provider proof step = %#v", proof)
+	}
+	fixtures := requirePlanStep(t, plan, "source_cdk.fixture_suite")
+	if !strings.Contains(fixtures.Detail, "read and discover fixture pairs for 1 resource families: users") {
+		t.Fatalf("fixture detail = %q", fixtures.Detail)
+	}
+	projectors := requirePlanStep(t, plan, "source_cdk.projector_tests")
+	if !strings.Contains(projectors.Detail, "example_idp.user") {
+		t.Fatalf("projector detail = %q", projectors.Detail)
+	}
+
+	definition.ProviderAPI.Families = nil
+	warningPlan, err := PlanDefinition(DefinitionRequest{
+		Definition: definition,
+		OutputDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PlanDefinition() warning path error = %v", err)
+	}
+	if warningPlan.Status != PlanStatusWarning {
+		t.Fatalf("warning plan status = %q, want warning", warningPlan.Status)
+	}
+	proof = requirePlanStep(t, warningPlan, "runtime_depth.provider_api_proof")
+	if proof.Status != PlanStatusWarning || !strings.Contains(proof.Detail, "family:users") {
+		t.Fatalf("warning provider proof step = %#v", proof)
+	}
+
+	definition.ProviderAPI.Families = []connectordefinitions.ProviderAPIFamilySpec{{
+		ID:   "users",
+		Path: "/v1/users",
+	}}
+	pathOnlyPlan, err := PlanDefinition(DefinitionRequest{
+		Definition: definition,
+		OutputDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PlanDefinition() partial family path error = %v", err)
+	}
+	proof = requirePlanStep(t, pathOnlyPlan, "runtime_depth.provider_api_proof")
+	if proof.Status != PlanStatusReady {
+		t.Fatalf("path-only provider proof step = %#v", proof)
+	}
+
+	definition.ProviderAPI.Families = []connectordefinitions.ProviderAPIFamilySpec{{
+		ID:     "users",
+		Method: "GET",
+	}}
+	warningPlan, err = PlanDefinition(DefinitionRequest{
+		Definition: definition,
+		OutputDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PlanDefinition() partial family method error = %v", err)
+	}
+	proof = requirePlanStep(t, warningPlan, "runtime_depth.provider_api_proof")
+	if proof.Status != PlanStatusWarning || !strings.Contains(proof.Detail, "family:users.path") {
+		t.Fatalf("partial provider proof step = %#v", proof)
+	}
+}
+
+func TestPlanDefinitionAcceptsGraphQLProviderProof(t *testing.T) {
+	definition := connectordefinitions.Definition{
+		SchemaVersion: connectordefinitions.SchemaVersionIntegrationV1,
+		ID:            "tenant-a-example_graph",
+		TenantID:      "tenant-a",
+		SourceID:      "example_graph",
+		DisplayName:   "Example Graph",
+		Auth: connectordefinitions.AuthSpec{
+			Model: "bearer_token",
+			CredentialFields: []connectordefinitions.Field{{
+				Key:           "token",
+				Secret:        true,
+				ReferenceOnly: true,
+			}},
+		},
+		Transport: &connectordefinitions.TransportSpec{
+			BaseURL:      "https://api.example.test/graphql",
+			Verification: &connectordefinitions.VerificationSpec{Path: "/graphql"},
+		},
+		ProviderAPI: &connectordefinitions.ProviderAPISpec{
+			Status:        "verified",
+			Basis:         "detected",
+			VerifiedAt:    "2026-07-04T00:00:00Z",
+			Transport:     "graphql",
+			Auth:          "bearer_token",
+			AuthMechanics: "Authorization: Bearer token",
+			BaseURL:       "https://api.example.test/graphql",
+			SpecKind:      "graphql_introspection",
+			References:    []string{"https://docs.example.test/graphql"},
+			Families: []connectordefinitions.ProviderAPIFamilySpec{{
+				ID:        "users",
+				Operation: "query Users { users { id email } }",
+			}},
+		},
+		ResourceFamilies: []connectordefinitions.ResourceFamily{{
+			ID:             "users",
+			Path:           "/graphql",
+			RecordSelector: "$.data.users[*]",
+			IDField:        "id",
+			Event: connectordefinitions.EventMappingSpec{
+				Kind:      "example_graph.user",
+				SchemaRef: "example_graph/user/v1",
+			},
+			Projection: &connectordefinitions.ProjectionSpec{Template: "identity_user"},
+			Coverage: []connectordefinitions.CoverageDimensionSpec{{
+				Type:    "entity_family",
+				Support: "supported",
+			}},
+		}},
+	}
+	plan, err := PlanDefinition(DefinitionRequest{
+		Definition: definition,
+		OutputDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PlanDefinition() error = %v", err)
+	}
+	if plan.Status != PlanStatusReady {
+		t.Fatalf("plan status = %q, want ready: %#v", plan.Status, plan.Warnings)
+	}
+	proof := requirePlanStep(t, plan, "runtime_depth.provider_api_proof")
+	if proof.Status != PlanStatusReady || strings.Contains(proof.Detail, "machine_readable_spec") {
+		t.Fatalf("provider proof step = %#v", proof)
+	}
+
+	definition.ProviderAPI.Families[0].Operation = ""
+	warningPlan, err := PlanDefinition(DefinitionRequest{
+		Definition: definition,
+		OutputDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("PlanDefinition() warning path error = %v", err)
+	}
+	if warningPlan.Status != PlanStatusWarning {
+		t.Fatalf("warning plan status = %q, want warning", warningPlan.Status)
+	}
+	proof = requirePlanStep(t, warningPlan, "runtime_depth.provider_api_proof")
+	if proof.Status != PlanStatusWarning || !strings.Contains(proof.Detail, "family:users.operation") || strings.Contains(proof.Detail, "machine_readable_spec") {
+		t.Fatalf("warning provider proof step = %#v", proof)
+	}
+}
+
 func TestPlanDefinitionReportsGrammarBlockers(t *testing.T) {
 	plan, err := PlanDefinition(DefinitionRequest{
 		Definition: connectordefinitions.Definition{
@@ -592,6 +798,17 @@ func TestPlanDefinitionReportsGrammarBlockers(t *testing.T) {
 	if len(plan.Blockers) == 0 {
 		t.Fatalf("plan blockers empty: %#v", plan)
 	}
+}
+
+func requirePlanStep(t *testing.T, plan *PromotionPlan, id string) PromotionPlanStep {
+	t.Helper()
+	for _, step := range plan.Checklist {
+		if step.ID == id {
+			return step
+		}
+	}
+	t.Fatalf("plan missing step %q: %#v", id, plan.Checklist)
+	return PromotionPlanStep{}
 }
 
 func TestGenerateDefinitionCarriesProjectionRelationships(t *testing.T) {

--- a/internal/sourcegen/plan.go
+++ b/internal/sourcegen/plan.go
@@ -2,6 +2,7 @@ package sourcegen
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -151,12 +152,22 @@ func PlanDefinition(request DefinitionRequest) (*PromotionPlan, error) {
 		})
 	}
 
+	if step := providerAPIProofStep(definition); step != nil {
+		addStep(*step)
+	}
 	addStep(PromotionPlanStep{
 		ID:       "source_cdk.fixture_suite",
 		Title:    "Fixture suite",
 		Category: "source_cdk",
 		Status:   PlanStatusReady,
-		Detail:   "Generated source tests exercise auth headers, health checks, provider reads, and projection registration.",
+		Detail:   fixtureSuiteDetail(definition),
+	})
+	addStep(PromotionPlanStep{
+		ID:       "source_cdk.projector_tests",
+		Title:    "Projector tests",
+		Category: "source_cdk",
+		Status:   PlanStatusReady,
+		Detail:   projectorTestsDetail(definition),
 	})
 	addStep(PromotionPlanStep{
 		ID:       "source_cdk.health_receipt",
@@ -241,4 +252,186 @@ func firstString(values []string) string {
 		}
 	}
 	return ""
+}
+
+func providerAPIProofStep(definition connectordefinitions.Definition) *PromotionPlanStep {
+	if definition.ProviderAPI == nil {
+		return nil
+	}
+	missing := providerAPIProofGaps(definition)
+	step := PromotionPlanStep{
+		ID:       "runtime_depth.provider_api_proof",
+		Title:    "Provider API proof",
+		Category: "runtime_depth",
+		Status:   PlanStatusReady,
+		Detail:   fmt.Sprintf("Provider API proof maps %d of %d resource families.", len(providerAPIMappedFamilies(definition.ProviderAPI)), len(resourceFamilyIDs(definition.ResourceFamilies))),
+	}
+	if len(missing) == 0 {
+		return &step
+	}
+	step.Status = PlanStatusWarning
+	step.Detail = "Provider API proof is incomplete: " + strings.Join(missing, ", ") + "."
+	step.Action = "Add missing provider API proof fields before reference runtime promotion."
+	return &step
+}
+
+func providerAPIProofGaps(definition connectordefinitions.Definition) []string {
+	api := definition.ProviderAPI
+	if api == nil {
+		return nil
+	}
+	missing := []string{}
+	if strings.TrimSpace(api.Status) != "verified" {
+		missing = append(missing, "status")
+	}
+	if strings.TrimSpace(api.Basis) == "" {
+		missing = append(missing, "basis")
+	}
+	if strings.TrimSpace(api.VerifiedAt) == "" {
+		missing = append(missing, "verified_at")
+	}
+	if strings.TrimSpace(api.Transport) == "" {
+		missing = append(missing, "transport")
+	}
+	if strings.TrimSpace(api.Auth) == "" {
+		missing = append(missing, "auth")
+	}
+	if strings.TrimSpace(api.AuthMechanics) == "" {
+		missing = append(missing, "auth_mechanics")
+	}
+	if strings.TrimSpace(api.BaseURL) == "" && strings.TrimSpace(api.Endpoint) == "" {
+		missing = append(missing, "locator")
+	}
+	if len(normalizedPlanStrings(api.References)) == 0 {
+		missing = append(missing, "references")
+	}
+	if strings.TrimSpace(api.SpecURL) == "" && strings.TrimSpace(api.Transport) != "graphql" {
+		missing = append(missing, "machine_readable_spec")
+	}
+	missing = append(missing, providerAPIFamilyProofGaps(resourceFamilyIDs(definition.ResourceFamilies), api)...)
+	return normalizedPlanStrings(missing)
+}
+
+func providerAPIMappedFamilies(api *connectordefinitions.ProviderAPISpec) []string {
+	if api == nil {
+		return nil
+	}
+	transport := strings.TrimSpace(api.Transport)
+	seen := map[string]struct{}{}
+	for _, family := range api.Families {
+		id := strings.TrimSpace(family.ID)
+		if id == "" {
+			continue
+		}
+		switch transport {
+		case "graphql":
+			if strings.TrimSpace(family.Operation) == "" {
+				continue
+			}
+		default:
+			if strings.TrimSpace(family.Path) == "" {
+				continue
+			}
+		}
+		seen[id] = struct{}{}
+	}
+	return sortedPlanKeys(seen)
+}
+
+func providerAPIFamilyProofGaps(resourceIDs []string, api *connectordefinitions.ProviderAPISpec) []string {
+	if api == nil {
+		return nil
+	}
+	transport := strings.TrimSpace(api.Transport)
+	gaps := []string{}
+	for _, resourceID := range resourceIDs {
+		hasFamily := false
+		hasPath := false
+		hasOperation := false
+		for _, family := range api.Families {
+			if strings.TrimSpace(family.ID) != resourceID {
+				continue
+			}
+			hasFamily = true
+			if strings.TrimSpace(family.Path) != "" {
+				hasPath = true
+			}
+			if strings.TrimSpace(family.Operation) != "" {
+				hasOperation = true
+			}
+		}
+		if !hasFamily {
+			gaps = append(gaps, "family:"+resourceID)
+			continue
+		}
+		if transport == "graphql" {
+			if !hasOperation {
+				gaps = append(gaps, "family:"+resourceID+".operation")
+			}
+			continue
+		}
+		if !hasPath {
+			gaps = append(gaps, "family:"+resourceID+".path")
+		}
+	}
+	return gaps
+}
+
+func resourceFamilyIDs(families []connectordefinitions.ResourceFamily) []string {
+	seen := map[string]struct{}{}
+	for _, family := range families {
+		if id := strings.TrimSpace(family.ID); id != "" {
+			seen[id] = struct{}{}
+		}
+	}
+	return sortedPlanKeys(seen)
+}
+
+func fixtureSuiteDetail(definition connectordefinitions.Definition) string {
+	families := resourceFamilyIDs(definition.ResourceFamilies)
+	if len(families) == 0 {
+		return "Generated fixture suite has no resource families."
+	}
+	return fmt.Sprintf("Generated fixture suite includes read and discover fixture pairs for %d resource families: %s.", len(families), strings.Join(families, ", "))
+}
+
+func projectorTestsDetail(definition connectordefinitions.Definition) string {
+	kinds := eventKinds(definition.ResourceFamilies, definition.SourceID)
+	if len(kinds) == 0 {
+		return "Generated projector tests have no event kinds."
+	}
+	return fmt.Sprintf("Generated projector tests cover %d event kinds: %s.", len(kinds), strings.Join(kinds, ", "))
+}
+
+func eventKinds(families []connectordefinitions.ResourceFamily, sourceID string) []string {
+	seen := map[string]struct{}{}
+	for _, family := range families {
+		kind := strings.TrimSpace(family.Event.Kind)
+		if kind == "" && strings.TrimSpace(sourceID) != "" && strings.TrimSpace(family.ID) != "" {
+			kind = strings.TrimSpace(sourceID) + "." + strings.TrimSpace(family.ID)
+		}
+		if kind != "" {
+			seen[kind] = struct{}{}
+		}
+	}
+	return sortedPlanKeys(seen)
+}
+
+func normalizedPlanStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	return sortedPlanKeys(seen)
+}
+
+func sortedPlanKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
## Summary
- Add runtime-depth checklist entries to Source Runtime SDK promotion plans.
- Report generated read/discover fixture coverage and generated projector test coverage by resource family and event kind.
- Warn when supplied provider API proof is incomplete or misses a resource family mapping.

## Impact
Promotion plans now show the runtime-depth work needed before a generated source is treated as a reference runtime. Basic connector plans without provider API metadata keep their existing ready behavior.

## Validation
- `go test ./internal/sourcegen -run 'TestPlanDefinitionBuildsPromotionChecklist|TestPlanDefinitionAddsRuntimeDepthChecklist|TestPlanDefinitionReportsGrammarBlockers' -count=1 -v`
- `go test ./internal/sourcegen/... -count=1`
- `go test ./internal/sourcecdk ./internal/connectordefinitions -count=1`
- `make sourcegen-test`
- `make sourcegen-check`
- `go test ./internal/bootstrap -run 'TestConnectorDefinitionPlanEndpoint|TestConnectorDefinitionStoredPromotionPlan' -count=1`
