### PR TITLE
[codex] Promote Qdrant Cloud source API proof

### DIFF
--- a/sources/qdrant_cloud/PR_BODY.md
+++ b/sources/qdrant_cloud/PR_BODY.md
@@ -1,16 +1,26 @@
 ## Summary
 
-- Adds the `qdrant_cloud` Source Runtime SDK scaffold.
-- Includes runtime adapter, health check, EvidenceCAS reference events, graph projection scaffolds, tests, and a source-health receipt.
+- Promotes the `qdrant_cloud` Source Runtime contract to provider-verified API proof.
+- Maps the existing runtime families to Qdrant Cloud Account, Cluster, Database API Key, Backup, and IAM services.
+- Refreshes runtime notes, catalog coverage notes, deploy manifest coverage, and the source-health receipt to match the implemented runtime.
 
-## Generated runtime contract
+## Runtime contract
 
 - Source type: `json_api`
 - Auth model: `api_key`
+- Auth mechanics: `Authorization: apikey <management key>`
 - Health endpoint: `/source-runtimes/health?source_id=qdrant_cloud`
-- Freshness: `24h0m0s`
+- Families: `accounts`, `account_members`, `clusters`, `database_api_keys`, `backups`, `backup_restores`, `backup_schedules`, `roles`
+- Deploy manifest: one runtime entry per family, using `QDRANT_CLOUD_MANAGEMENT_KEY` as `api_key`
 
 ## Tests
 
-- `go test ./sources/qdrant_cloud ./internal/sourceprojection -count=1`
-- `make catalog-check`
+- `go test ./sources/qdrant_cloud ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
+- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
+- `make connector-catalog-review connector-api-discovery`
+
+## Review output
+
+- Runtime depth score: `100`
+- Fidelity score: `100`
+- Provider API proof score: `100`

--- a/sources/qdrant_cloud/SOURCE_RUNTIME.md
+++ b/sources/qdrant_cloud/SOURCE_RUNTIME.md
@@ -1,11 +1,13 @@
 # Qdrant Cloud
 
-Generated Source Runtime SDK scaffold for `qdrant_cloud`.
+Source Runtime adapter for Qdrant Cloud account, cluster, backup, database API key, and IAM role inventory.
 
 ## Runtime input
 
 - Source type: `json_api`
 - Auth model: `api_key`
+- Auth mechanics: `Authorization: apikey <management key>`
+- Base URL: `https://api.cloud.qdrant.io`
 - Freshness expectation: `24h0m0s`
 - Failure modes: `api_error,auth_error,rate_limit,schema_drift`
 
@@ -14,7 +16,7 @@ Generated Source Runtime SDK scaffold for `qdrant_cloud`.
 - Adapter package: `sources/qdrant_cloud`
 - Health endpoint: `/source-runtimes/health?source_id=qdrant_cloud`
 - Source health receipt: `sources/qdrant_cloud/source_health_receipt.json`
-- EvidenceCAS reference kind: `qdrant_cloud.evidence_cas_reference`
+- Emits account, identity, cluster, database API key, backup, backup schedule, and role configuration evidence.
 
 ## Families
 
@@ -29,5 +31,6 @@ Generated Source Runtime SDK scaffold for `qdrant_cloud`.
 
 ## Tests
 
-- `go test ./sources/qdrant_cloud ./internal/sourceprojection -count=1`
-- `make catalog-check`
+- `go test ./sources/qdrant_cloud ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
+- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
+- `make connector-catalog-review connector-api-discovery`

--- a/sources/qdrant_cloud/catalog.yaml
+++ b/sources/qdrant_cloud/catalog.yaml
@@ -19,6 +19,66 @@ runtime_families:
   - clusters
   - database_api_keys
   - roles
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-07-04T00:00:00Z
+  transport: rest
+  auth: api_key
+  auth_mechanics: authorization_apikey_header
+  base_url: https://api.cloud.qdrant.io
+  spec_url: https://raw.githubusercontent.com/qdrant/qdrant-cloud-public-api/main/gen/openapiv2/qdrant/cloud/account/v1/account.swagger.json
+  spec_kind: openapi
+  references:
+    - https://qdrant.tech/documentation/cloud-api/
+    - https://github.com/qdrant/qdrant-cloud-public-api
+    - https://raw.githubusercontent.com/qdrant/qdrant-cloud-public-api/main/gen/openapiv2/qdrant/cloud/account/v1/account.swagger.json
+    - https://raw.githubusercontent.com/qdrant/qdrant-cloud-public-api/main/gen/openapiv2/qdrant/cloud/cluster/v1/cluster.swagger.json
+    - https://raw.githubusercontent.com/qdrant/qdrant-cloud-public-api/main/gen/openapiv2/qdrant/cloud/cluster/auth/v2/database_api_key.swagger.json
+    - https://raw.githubusercontent.com/qdrant/qdrant-cloud-public-api/main/gen/openapiv2/qdrant/cloud/cluster/backup/v1/backup.swagger.json
+    - https://raw.githubusercontent.com/qdrant/qdrant-cloud-public-api/main/gen/openapiv2/qdrant/cloud/iam/v1/iam.swagger.json
+  auth_evidence:
+    - https://qdrant.tech/documentation/cloud-api/
+    - https://github.com/qdrant/qdrant-cloud-public-api
+  scope_evidence:
+    - https://github.com/qdrant/qdrant-cloud-public-api/tree/main/proto/qdrant/cloud/account/v1
+    - https://github.com/qdrant/qdrant-cloud-public-api/tree/main/proto/qdrant/cloud/cluster/v1
+    - https://github.com/qdrant/qdrant-cloud-public-api/tree/main/proto/qdrant/cloud/cluster/auth/v2
+    - https://github.com/qdrant/qdrant-cloud-public-api/tree/main/proto/qdrant/cloud/cluster/backup/v1
+    - https://github.com/qdrant/qdrant-cloud-public-api/tree/main/proto/qdrant/cloud/iam/v1
+  families:
+    - id: accounts
+      method: GET
+      path: /api/account/v1/accounts
+      operation: AccountService/ListAccounts
+    - id: account_members
+      method: GET
+      path: /api/account/v1/accounts/{account_id}/members
+      operation: AccountService/ListAccountMembers
+    - id: clusters
+      method: GET
+      path: /api/cluster/v1/accounts/{account_id}/clusters
+      operation: ClusterService/ListClusters
+    - id: database_api_keys
+      method: GET
+      path: /api/cluster/auth/v2/accounts/{account_id}/database-api-keys
+      operation: DatabaseApiKeyService/ListDatabaseApiKeys
+    - id: backups
+      method: GET
+      path: /api/cluster/backup/v1/accounts/{account_id}/backups
+      operation: BackupService/ListBackups
+    - id: backup_restores
+      method: GET
+      path: /api/cluster/backup/v1/accounts/{account_id}/backup_restores
+      operation: BackupService/ListBackupRestores
+    - id: backup_schedules
+      method: GET
+      path: /api/cluster/backup/v1/accounts/{account_id}/backup_schedules
+      operation: BackupService/ListBackupSchedules
+    - id: roles
+      method: GET
+      path: /api/iam/v1/accounts/{account_id}/roles
+      operation: IAMService/ListRoles
 kind_lifecycle:
   - kind: qdrant_cloud.accounts
     status: active
@@ -49,7 +109,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads accounts from Qdrant Cloud AccountService/ListAccounts.
     - id: account_members
       type: entity_family
       title: "Account Members"
@@ -59,7 +119,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads account members from AccountService/ListAccountMembers.
     - id: clusters
       type: deployment_state
       title: "Clusters"
@@ -69,7 +129,7 @@ coverage_contract:
       evidence_types: [change_management]
       control_domains: [secure_delivery]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads clusters from ClusterService/ListClusters.
     - id: database_api_keys
       type: entity_family
       title: "Database Api Keys"
@@ -79,7 +139,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads database API keys from DatabaseApiKeyService/ListDatabaseApiKeys.
     - id: backups
       type: entity_family
       title: "Backups"
@@ -89,7 +149,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads backups from BackupService/ListBackups.
     - id: backup_restores
       type: deployment_state
       title: "Backup Restores"
@@ -99,7 +159,7 @@ coverage_contract:
       evidence_types: [change_management]
       control_domains: [secure_delivery]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads backup restore jobs from BackupService/ListBackupRestores.
     - id: backup_schedules
       type: lifecycle_state
       title: "Backup Schedules"
@@ -109,7 +169,7 @@ coverage_contract:
       evidence_types: [configuration_state]
       control_domains: [security_operations]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads backup schedules from BackupService/ListBackupSchedules.
     - id: roles
       type: entity_family
       title: "Roles"
@@ -119,7 +179,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Reads account roles from IAMService/ListRoles.
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync

--- a/sources/qdrant_cloud/deploy.yaml
+++ b/sources/qdrant_cloud/deploy.yaml
@@ -2,16 +2,88 @@ sourceId: qdrant_cloud
 secretKeys:
   - QDRANT_CLOUD_ACCOUNT_ID
   - QDRANT_CLOUD_CLUSTER_ID
-  - QDRANT_CLOUD_API_TOKEN
+  - QDRANT_CLOUD_MANAGEMENT_KEY
 runtimes:
   - localId: accounts
     config:
-      account_id: env:QDRANT_CLOUD_ACCOUNT_ID
-      cluster_id: env:QDRANT_CLOUD_CLUSTER_ID
       family: accounts
       failure_modes: api_error,auth_error,rate_limit,schema_drift
       health_path: /api/account/v1/accounts
       expected_cadence_seconds: "86400"
       stale_after_seconds: "86400"
       per_page: "100"
-      api_token: env:QDRANT_CLOUD_API_TOKEN
+      api_key: env:QDRANT_CLOUD_MANAGEMENT_KEY
+  - localId: account-members
+    config:
+      account_id: env:QDRANT_CLOUD_ACCOUNT_ID
+      family: account_members
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/account/v1/accounts
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:QDRANT_CLOUD_MANAGEMENT_KEY
+  - localId: clusters
+    config:
+      account_id: env:QDRANT_CLOUD_ACCOUNT_ID
+      family: clusters
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/account/v1/accounts
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:QDRANT_CLOUD_MANAGEMENT_KEY
+  - localId: database-api-keys
+    config:
+      account_id: env:QDRANT_CLOUD_ACCOUNT_ID
+      cluster_id: env:QDRANT_CLOUD_CLUSTER_ID
+      family: database_api_keys
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/account/v1/accounts
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:QDRANT_CLOUD_MANAGEMENT_KEY
+  - localId: backups
+    config:
+      account_id: env:QDRANT_CLOUD_ACCOUNT_ID
+      cluster_id: env:QDRANT_CLOUD_CLUSTER_ID
+      family: backups
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/account/v1/accounts
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:QDRANT_CLOUD_MANAGEMENT_KEY
+  - localId: backup-restores
+    config:
+      account_id: env:QDRANT_CLOUD_ACCOUNT_ID
+      cluster_id: env:QDRANT_CLOUD_CLUSTER_ID
+      family: backup_restores
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/account/v1/accounts
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:QDRANT_CLOUD_MANAGEMENT_KEY
+  - localId: backup-schedules
+    config:
+      account_id: env:QDRANT_CLOUD_ACCOUNT_ID
+      cluster_id: env:QDRANT_CLOUD_CLUSTER_ID
+      family: backup_schedules
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/account/v1/accounts
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:QDRANT_CLOUD_MANAGEMENT_KEY
+  - localId: roles
+    config:
+      account_id: env:QDRANT_CLOUD_ACCOUNT_ID
+      family: roles
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      health_path: /api/account/v1/accounts
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:QDRANT_CLOUD_MANAGEMENT_KEY

--- a/sources/qdrant_cloud/source_health_receipt.json
+++ b/sources/qdrant_cloud/source_health_receipt.json
@@ -1,8 +1,19 @@
 {
   "adapter_health_path": "/api/account/v1/accounts",
   "auth_model": "api_key",
+  "auth_mechanics": "Authorization: apikey",
   "evidence_cas_reference_kind": "qdrant_cloud.evidence_cas_reference",
   "expected_cadence_seconds": 86400,
+  "families": [
+    "accounts",
+    "account_members",
+    "clusters",
+    "database_api_keys",
+    "backups",
+    "backup_restores",
+    "backup_schedules",
+    "roles"
+  ],
   "failure_modes": [
     "api_error",
     "auth_error",
@@ -10,6 +21,7 @@
     "schema_drift"
   ],
   "health_endpoint": "/source-runtimes/health?source_id=qdrant_cloud",
+  "provider_api_status": "verified",
   "receipt_kind": "source_health.receipt",
   "source_id": "qdrant_cloud",
   "source_type": "json_api",


### PR DESCRIPTION
## Summary

- Promotes the `qdrant_cloud` Source Runtime contract to provider-verified API proof.
- Maps the existing runtime families to Qdrant Cloud Account, Cluster, Database API Key, Backup, and IAM services.
- Refreshes runtime notes, catalog coverage notes, deploy manifest coverage, and the source-health receipt to match the implemented runtime.

## Runtime contract

- Source type: `json_api`
- Auth model: `api_key`
- Auth mechanics: `Authorization: apikey <management key>`
- Health endpoint: `/source-runtimes/health?source_id=qdrant_cloud`
- Families: `accounts`, `account_members`, `clusters`, `database_api_keys`, `backups`, `backup_restores`, `backup_schedules`, `roles`
- Deploy manifest: one runtime entry per family, using `QDRANT_CLOUD_MANAGEMENT_KEY` as `api_key`

## Tests

- `go test ./sources/qdrant_cloud ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
- `make connector-catalog-review connector-api-discovery`

## Review output

- Runtime depth score: `100`
- Fidelity score: `100`
- Provider API proof score: `100`
