### PR TITLE
[codex] Carry path params through sourcegen families

### DIFF
--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -136,6 +136,7 @@ type familyConfigData struct {
 	StaticQuery  map[string]string
 	ConfigQuery  map[string]string
 	IdentityKeys []string
+	PathParams   []string
 }
 
 type oauthClientCredentialsData struct {
@@ -711,6 +712,8 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 				return nil, err
 			}
 		}
+		config := familyConfig(resource)
+		config.PathParams = pathParamsForResource(resource)
 		families = append(families, familyData{
 			Name:                  name,
 			Schema:                schemaNameFromRef(schemaRef, name),
@@ -732,7 +735,7 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			LinkHeader:            linkHeaderForResource(resource),
 			PageSizeParams:        pageSizeParamsForResource(resource),
 			DisablePageSize:       disablePageSizeForResource(resource),
-			Config:                familyConfig(resource),
+			Config:                config,
 			RequiredAttributes:    requiredAttributes,
 			RequiredPayloadFields: requiredPayloadFields,
 			Projection:            resource.Projection,
@@ -757,6 +760,13 @@ func idKeysForResource(resource connectordefinitions.ResourceFamily) []string {
 		}
 	}
 	return uniqueStrings(keys)
+}
+
+func pathParamsForResource(resource connectordefinitions.ResourceFamily) []string {
+	if resource.Read == nil {
+		return nil
+	}
+	return uniqueStrings(resource.Read.PathParams)
 }
 
 func familyConfig(resource connectordefinitions.ResourceFamily) familyConfigData {
@@ -1104,6 +1114,9 @@ func renderDeploy(request normalizedRequest) string {
 	for _, key := range request.ConfigKeys {
 		secretKeys = append(secretKeys, envNameForConfigKey(request, key))
 	}
+	for _, key := range pathParamKeys(request.Families) {
+		secretKeys = append(secretKeys, envNameForConfigKey(request, key))
+	}
 	for _, key := range authConfigKeys {
 		secretKeys = append(secretKeys, deployAuthEnvName(request, key, tokenEnv))
 	}
@@ -1119,6 +1132,13 @@ func renderDeploy(request normalizedRequest) string {
 		}
 		writtenConfigKeys := map[string]struct{}{}
 		for _, key := range request.ConfigKeys {
+			writtenConfigKeys[key] = struct{}{}
+			fmt.Fprintf(&b, "      %s: env:%s\n", key, envNameForConfigKey(request, key))
+		}
+		for _, key := range family.Config.PathParams {
+			if _, ok := writtenConfigKeys[key]; ok {
+				continue
+			}
 			writtenConfigKeys[key] = struct{}{}
 			fmt.Fprintf(&b, "      %s: env:%s\n", key, envNameForConfigKey(request, key))
 		}
@@ -1144,6 +1164,14 @@ func deployAuthEnvName(request normalizedRequest, key string, tokenEnv string) s
 		return tokenEnv
 	}
 	return envNameForConfigKey(request, key)
+}
+
+func pathParamKeys(families []familyData) []string {
+	keys := []string{}
+	for _, family := range families {
+		keys = append(keys, family.Config.PathParams...)
+	}
+	return uniqueStrings(keys)
 }
 
 func coverageDimensionType(class string) string {
@@ -1308,6 +1336,9 @@ func renderSourceGo(request normalizedRequest) string {
 		fmt.Fprintf(&b, "\t\t\t{\n")
 		fmt.Fprintf(&b, "\t\t\t\tName: %s,\n", family.ConstName)
 		fmt.Fprintf(&b, "\t\t\t\tPath: %s,\n", strconv.Quote(family.Path))
+		if len(family.Config.PathParams) != 0 {
+			fmt.Fprintf(&b, "\t\t\t\tPathParams: []string{%s},\n", quotedStrings(family.Config.PathParams))
+		}
 		fmt.Fprintf(&b, "\t\t\t\tURNKind: %s,\n", strconv.Quote(family.URNKind))
 		fmt.Fprintf(&b, "\t\t\t\tIDKeys: []string{%s},\n", quotedStrings(idKeysForFamily(family)))
 		if strings.TrimSpace(family.CursorParam) != "" {
@@ -1587,7 +1618,7 @@ func renderSourceTestGo(request normalizedRequest) string {
 	for _, family := range request.Families {
 		fmt.Fprintf(&b, "\t\t{\n")
 		fmt.Fprintf(&b, "\t\t\tname: %s,\n", family.ConstName)
-		fmt.Fprintf(&b, "\t\t\tpath: %s,\n", strconv.Quote(renderTestPath(family.Path)))
+		fmt.Fprintf(&b, "\t\t\tpath: %s,\n", strconv.Quote(renderTestPath(family.Path, family.Config.PathParams...)))
 		fmt.Fprintf(&b, "\t\t\tkind: %s,\n", strconv.Quote(family.EventKind))
 		fmt.Fprintf(&b, "\t\t\texpectedAttributes: map[string]string{%s},\n", renderedAttributeMap(sourceTestExpectedAttributes(request, family)))
 		if usesDuoHMACAuth(request) {
@@ -1657,6 +1688,9 @@ func renderSourceTestGo(request normalizedRequest) string {
 	}
 	for _, family := range request.Families {
 		for _, key := range extractTemplateKeys(family.Path) {
+			emitCfgValue(key, strconv.Quote(testConfigValue(key)))
+		}
+		for _, key := range family.Config.PathParams {
 			emitCfgValue(key, strconv.Quote(testConfigValue(key)))
 		}
 	}
@@ -1868,16 +1902,22 @@ func isDuoHMACAuthModel(authModel string) bool {
 	}
 }
 
-// renderTestPath substitutes ${config.key}/${credential.key}/${connection.key}
-// placeholders with their testConfigValue so generated test assertions match the
-// concrete request paths the runtime produces for sources with path parameters.
-func renderTestPath(template string) string {
+// renderTestPath substitutes config-template and path-parameter placeholders
+// with their testConfigValue so generated test assertions match runtime paths.
+func renderTestPath(template string, pathParams ...string) string {
 	rendered := template
 	for _, key := range extractTemplateKeys(template) {
 		value := testConfigValue(key)
 		for _, prefix := range []string{"config", "credential", "connection"} {
 			rendered = strings.ReplaceAll(rendered, "${"+prefix+"."+key+"}", value)
 		}
+	}
+	for _, param := range pathParams {
+		param = strings.TrimSpace(param)
+		if param == "" {
+			continue
+		}
+		rendered = strings.ReplaceAll(rendered, "{"+param+"}", testConfigValue(param))
 	}
 	return rendered
 }

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -1162,6 +1162,80 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 	}
 }
 
+func TestGenerateDefinitionCarriesPathParams(t *testing.T) {
+	outputDir := t.TempDir()
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			SchemaVersion: connectordefinitions.SchemaVersionIntegrationV1,
+			ID:            "tenant-a-example_idp",
+			TenantID:      "tenant-a",
+			SourceID:      "example_idp",
+			DisplayName:   "Example IDP",
+			Auth: connectordefinitions.AuthSpec{
+				Model: "bearer_token",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "token",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://api.example.test",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/v1/me",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "workspace_members",
+				Path:           "/v1/workspaces/{workspace_id}/members",
+				RecordSelector: "$.data[*]",
+				Read:           &connectordefinitions.ResourceReadSpec{PathParams: []string{"workspace_id"}},
+				IDField:        "id",
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "example_idp.workspace_members",
+					SchemaRef: "example_idp/workspace_members/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{Template: "identity_user"},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{
+					Type:    "entity_family",
+					Support: "supported",
+				}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	source := readGeneratedFile(t, outputDir, "sources/example_idp/source.go")
+	for _, want := range []string{
+		`Path:             "/v1/workspaces/{workspace_id}/members"`,
+		`PathParams:       []string{"workspace_id"}`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("source.go missing %q:\n%s", want, source)
+		}
+	}
+	sourceTest := readGeneratedFile(t, outputDir, "sources/example_idp/source_test.go")
+	for _, want := range []string{
+		`path:               "/v1/workspaces/test-workspace_id/members"`,
+		`"workspace_id": "test-workspace_id"`,
+	} {
+		if !strings.Contains(sourceTest, want) {
+			t.Fatalf("source_test.go missing %q:\n%s", want, sourceTest)
+		}
+	}
+	deploy := readGeneratedFile(t, outputDir, "sources/example_idp/deploy.yaml")
+	for _, want := range []string{
+		`- EXAMPLE_IDP_WORKSPACE_ID`,
+		`workspace_id: env:EXAMPLE_IDP_WORKSPACE_ID`,
+	} {
+		if !strings.Contains(deploy, want) {
+			t.Fatalf("deploy.yaml missing %q:\n%s", want, deploy)
+		}
+	}
+}
+
 func TestGenerateDefinitionSupportsCustomTokenHeader(t *testing.T) {
 	outputDir := t.TempDir()
 	_, err := GenerateDefinition(DefinitionRequest{


### PR DESCRIPTION
## Summary
- Carry `ResourceReadSpec.PathParams` into generated `jsonapi.Family` definitions.
- Add path parameter values to generated source tests so scoped paths resolve during generated runtime tests.
- Add path parameter config to generated deploy manifests.
- Add a regression test for generated source, source-test, and deploy output with a scoped resource path.

## Impact
Generated source packages can now preserve configured path parameters for scoped provider endpoints instead of dropping that metadata during sourcegen.

## Validation
- `go test ./internal/sourcegen -run 'TestGenerateDefinitionCarriesPathParams|TestGenerateDefinitionSupportsFamilyQueryBindings' -count=1 -v`
- `go test ./internal/sourcegen/... -count=1`
- `go test ./internal/sourcecdk ./internal/connectordefinitions ./sources/internal/jsonapi -count=1`
- `make sourcegen-test`
- `make sourcegen-check`
