### PR TITLE
[codex] Carry resource read metadata through sourcegen

### DIFF
--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -133,10 +133,13 @@ type familyData struct {
 }
 
 type familyConfigData struct {
-	StaticQuery  map[string]string
-	ConfigQuery  map[string]string
-	IdentityKeys []string
-	PathParams   []string
+	StaticQuery           map[string]string
+	ConfigQuery           map[string]string
+	IdentityKeys          []string
+	DetailPath            string
+	AllowBareDetailRecord bool
+	PathParams            []string
+	MapRecords            map[string]string
 }
 
 type oauthClientCredentialsData struct {
@@ -731,7 +734,7 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			SchemaRef:             schemaRef,
 			IDKeys:                idKeysForResource(resource),
 			ListKeys:              listKeysForResource(resource),
-			Singleton:             resource.Singleton,
+			Singleton:             singletonForResource(resource),
 			CursorParam:           cursorParamForResource(resource),
 			NextCursorKeys:        nextCursorKeysForResource(resource),
 			LinkHeader:            linkHeaderForResource(resource),
@@ -775,6 +778,12 @@ func familyConfig(resource connectordefinitions.ResourceFamily) familyConfigData
 	config := familyConfigData{
 		StaticQuery: cloneStringMap(resource.StaticQuery),
 		ConfigQuery: cloneStringMap(resource.ConfigQuery),
+	}
+	if resource.Read != nil {
+		config.DetailPath = strings.TrimSpace(resource.Read.DetailPath)
+		config.AllowBareDetailRecord = resource.Read.AllowBareDetailRecord
+		config.PathParams = uniqueStrings(resource.Read.PathParams)
+		config.MapRecords = cloneStringMap(resource.Read.MapRecords)
 	}
 	if resource.Config == nil {
 		return config
@@ -861,7 +870,17 @@ func pageSizeParamsForResource(resource connectordefinitions.ResourceFamily) []s
 }
 
 func disablePageSizeForResource(resource connectordefinitions.ResourceFamily) bool {
+	if resource.Read != nil && resource.Read.DisablePageSize {
+		return true
+	}
 	return resource.Pagination != nil && resource.Pagination.DisablePageSize
+}
+
+func singletonForResource(resource connectordefinitions.ResourceFamily) bool {
+	if resource.Singleton {
+		return true
+	}
+	return resource.Read != nil && resource.Read.Singleton
 }
 
 func uniqueStrings(values []string) []string {
@@ -1372,6 +1391,12 @@ func renderSourceGo(request normalizedRequest) string {
 		if len(family.Config.PathParams) != 0 {
 			fmt.Fprintf(&b, "\t\t\t\tPathParams: []string{%s},\n", quotedStrings(family.Config.PathParams))
 		}
+		if strings.TrimSpace(family.Config.DetailPath) != "" {
+			fmt.Fprintf(&b, "\t\t\t\tDetailPath: %s,\n", strconv.Quote(family.Config.DetailPath))
+		}
+		if family.Config.AllowBareDetailRecord {
+			fmt.Fprintf(&b, "\t\t\t\tAllowBareDetailRecord: true,\n")
+		}
 		fmt.Fprintf(&b, "\t\t\t\tURNKind: %s,\n", strconv.Quote(family.URNKind))
 		fmt.Fprintf(&b, "\t\t\t\tIDKeys: []string{%s},\n", quotedStrings(idKeysForFamily(family)))
 		if strings.TrimSpace(family.CursorParam) != "" {
@@ -1398,6 +1423,9 @@ func renderSourceGo(request normalizedRequest) string {
 		fmt.Fprintf(&b, "\t\t\t\tTimestampKeys: []string{%s},\n", quotedStrings([]string{"observed_at", "updated_at", "last_seen_at", "created_at"}))
 		fmt.Fprintf(&b, "\t\t\t\tAttributes: map[string]string{%s},\n", renderedAttributeMap(attributePathsForFamily(family)))
 		fmt.Fprintf(&b, "\t\t\t\tStaticAttributes: map[string]string{%s},\n", renderedAttributeMap(staticAttributesForFamily(request, family)))
+		if len(family.Config.MapRecords) != 0 {
+			fmt.Fprintf(&b, "\t\t\t\tMapRecords: map[string]string{%s},\n", renderedAttributeMap(family.Config.MapRecords))
+		}
 		if strings.TrimSpace(family.Method) != "" || strings.TrimSpace(family.AuthModel) != "" || len(family.Config.StaticQuery) != 0 || len(family.Config.ConfigQuery) != 0 || len(family.Config.IdentityKeys) != 0 {
 			fmt.Fprintf(&b, "\t\t\t\tConfig: jsonapi.FamilyConfig{\n")
 			if strings.TrimSpace(family.Method) != "" {

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -1252,6 +1252,91 @@ func TestGenerateDefinitionCarriesPathParams(t *testing.T) {
 	}
 }
 
+func TestGenerateDefinitionCarriesDetailReadMetadata(t *testing.T) {
+	outputDir := t.TempDir()
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			ID:          "tenant-example_assets",
+			TenantID:    "tenant",
+			SourceID:    "example_assets",
+			DisplayName: "Example Assets",
+			Auth: connectordefinitions.AuthSpec{
+				Model: "bearer_token",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "token",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://api.example.test",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/v1/me",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "devices",
+				Path:           "/v1/workspaces/{workspace_id}/devices",
+				RecordSelector: "$.data[*]",
+				IDField:        "id",
+				Read: &connectordefinitions.ResourceReadSpec{
+					DetailPath:            "/v1/devices/{id}/detail",
+					AllowBareDetailRecord: true,
+					PathParams:            []string{"workspace_id"},
+					MapRecords:            map[string]string{"groups": "members"},
+					Singleton:             true,
+					DisablePageSize:       true,
+				},
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "example_assets.device",
+					SchemaRef: "example_assets/device/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "asset",
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "partial"}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	source := readGeneratedFile(t, outputDir, "sources/example_assets/source.go")
+	for _, want := range []string{
+		`Path:                  "/v1/workspaces/{workspace_id}/devices"`,
+		`PathParams:            []string{"workspace_id"}`,
+		`DetailPath:            "/v1/devices/{id}/detail"`,
+		`AllowBareDetailRecord: true`,
+		`DisablePageSize:       true`,
+		`Singleton:             true`,
+		`MapRecords:`,
+		`"groups": "members"`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("source.go missing %q:\n%s", want, source)
+		}
+	}
+	sourceTest := readGeneratedFile(t, outputDir, "sources/example_assets/source_test.go")
+	for _, want := range []string{
+		`path:               "/v1/workspaces/test-workspace_id/devices"`,
+		`"workspace_id": "test-workspace_id"`,
+	} {
+		if !strings.Contains(sourceTest, want) {
+			t.Fatalf("source_test.go missing %q:\n%s", want, sourceTest)
+		}
+	}
+	deploy := readGeneratedFile(t, outputDir, "sources/example_assets/deploy.yaml")
+	for _, want := range []string{
+		"- EXAMPLE_ASSETS_WORKSPACE_ID",
+		"workspace_id: env:EXAMPLE_ASSETS_WORKSPACE_ID",
+	} {
+		if !strings.Contains(deploy, want) {
+			t.Fatalf("deploy.yaml missing %q:\n%s", want, deploy)
+		}
+	}
+}
+
 func TestGenerateDefinitionSupportsCustomTokenHeader(t *testing.T) {
 	outputDir := t.TempDir()
 	_, err := GenerateDefinition(DefinitionRequest{


### PR DESCRIPTION
## Summary
- Carry declarative resource read metadata into generated JSON API families.
- Emit path params, detail paths, bare detail record handling, record remapping, singleton reads, and page-size suppression from sourcegen.
- Add generator coverage for source, generated test, and deploy manifest read metadata.

## Validation
- go test ./internal/sourcegen -run 'TestGenerateDefinitionCarriesDetailReadMetadata|TestGenerateDefinitionSupportsFamilyQueryBindings' -count=1 -v
- go test ./internal/sourcecdk ./internal/connectordefinitions ./sources/internal/jsonapi -count=1
- go test ./internal/sourcegen/... -count=1
- make sourcegen-test
- make sourcegen-check
- make check-structural check-structural-test check-arch