### PR TITLE
[codex] Mark OpenAPI path parameters in generated definitions

### DIFF
--- a/internal/connectordefinitions/openapigen/generator.go
+++ b/internal/connectordefinitions/openapigen/generator.go
@@ -262,6 +262,7 @@ func collectCandidates(doc *openapi3.T, sourceID string, getOnly bool) []candida
 				ListKey:        listKey,
 				IDField:        idField,
 				NameField:      nameField,
+				Read:           readSpecForPathFields(pathConfigFields),
 				Event: connectordefinitions.EventMappingSpec{
 					Kind:                  eventKind,
 					SchemaRef:             sourceID + "/" + familyID + "/v1",
@@ -739,6 +740,22 @@ func renderPathTemplate(path string) (string, []connectordefinitions.Field) {
 		return "${config." + key + "}"
 	})
 	return rendered, fields
+}
+
+func readSpecForPathFields(fields []connectordefinitions.Field) *connectordefinitions.ResourceReadSpec {
+	if len(fields) == 0 {
+		return nil
+	}
+	params := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if key := strings.TrimSpace(field.Key); key != "" {
+			params = append(params, key)
+		}
+	}
+	if len(params) == 0 {
+		return nil
+	}
+	return &connectordefinitions.ResourceReadSpec{PathParams: params}
 }
 
 func projectionTemplate(familyID, path string, operation *openapi3.Operation, properties map[string]*openapi3.SchemaRef) string {

--- a/internal/connectordefinitions/openapigen/generator_test.go
+++ b/internal/connectordefinitions/openapigen/generator_test.go
@@ -32,6 +32,9 @@ func TestGenerateBuildsSourcegenReadyDefinition(t *testing.T) {
 	if audit.Path != "/orgs/${config.org}/audit-log" {
 		t.Fatalf("audit path = %q", audit.Path)
 	}
+	if audit.Read == nil || !reflect.DeepEqual(audit.Read.PathParams, []string{"org"}) {
+		t.Fatalf("audit path params = %#v, want org", audit.Read)
+	}
 	if audit.Projection == nil || audit.Projection.Template != "audit_event" {
 		t.Fatalf("audit projection = %#v, want audit_event", audit.Projection)
 	}


### PR DESCRIPTION
## Summary
- Mark OpenAPI templated path fields as resource read path parameters.
- Preserve the existing rendered path and required config field behavior.
- Add coverage for the generated audit log path parameter metadata.

## Validation
- go test ./internal/connectordefinitions/openapigen -run 'TestGenerateBuildsSourcegenReadyDefinition' -count=1 -v
- make sourcegen-test
- make sourcegen-check
- make check-structural check-structural-test check-arch