### PR TITLE
[codex] Promote Telnyx source API proof

### DIFF
--- a/sources/telnyx/PR_BODY.md
+++ b/sources/telnyx/PR_BODY.md
@@ -1,16 +1,27 @@
 ## Summary
 
-- Adds the `telnyx` Source Runtime SDK scaffold.
-- Includes runtime adapter, health check, EvidenceCAS reference events, graph projection scaffolds, tests, and a source-health receipt.
+- Promotes the `telnyx` Source Runtime contract to provider-verified API proof.
+- Maps the existing runtime families to Telnyx API v2 list operations for call events, billing groups, credential connections, managed accounts, call-control applications, notifications, wireless reports, SIM card groups, SIM card group actions, and wireless connectivity logs.
+- Refreshes runtime notes and the source-health receipt to match the implemented runtime.
 
-## Generated runtime contract
+## Runtime contract
 
 - Source type: `json_api`
 - Auth model: `bearer_token`
+- Auth mechanics: `Authorization: Bearer <API key>`
 - Health endpoint: `/source-runtimes/health?source_id=telnyx`
-- Freshness: `24h0m0s`
+- Base URL: `https://api.telnyx.com/v2`
+- Families: `billing_group`, `call_control_application`, `call_event`, `credential_connection`, `detail_records_report`, `managed_account`, `notification_channel`, `notification_event`, `notification_event_condition`, `sim_card_group`, `sim_card_group_action`, `wireless_connectivity_log`
+- Deploy manifest: one runtime entry per family, using `TELNYX_TOKEN` as the bearer token and `TELNYX_SIM_CARD_ID` for wireless connectivity logs
 
 ## Tests
 
-- `go test ./sources/telnyx ./internal/sourceprojection -count=1`
-- `make catalog-check`
+- `go test ./sources/telnyx ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
+- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
+- `make connector-catalog-review connector-api-discovery`
+
+## Review output
+
+- Runtime depth score: `100`
+- Fidelity score: `100`
+- Provider API proof score: `100`

--- a/sources/telnyx/SOURCE_RUNTIME.md
+++ b/sources/telnyx/SOURCE_RUNTIME.md
@@ -1,11 +1,13 @@
 # Telnyx
 
-Generated Source Runtime SDK scaffold for `telnyx`.
+Source Runtime adapter for Telnyx communications, billing, managed account, notification, and wireless inventory.
 
 ## Runtime input
 
 - Source type: `json_api`
 - Auth model: `bearer_token`
+- Auth mechanics: `Authorization: Bearer <API key>`
+- Base URL: `https://api.telnyx.com/v2`
 - Freshness expectation: `24h0m0s`
 - Failure modes: `api_error,auth_error,rate_limit,schema_drift`
 
@@ -14,7 +16,7 @@ Generated Source Runtime SDK scaffold for `telnyx`.
 - Adapter package: `sources/telnyx`
 - Health endpoint: `/source-runtimes/health?source_id=telnyx`
 - Source health receipt: `sources/telnyx/source_health_receipt.json`
-- EvidenceCAS reference kind: `telnyx.evidence_cas_reference`
+- Emits call events, billing groups, credential connections, managed accounts, call-control applications, notification configuration, wireless detail-record reports, SIM card groups, SIM card group actions, and wireless connectivity logs.
 
 ## Families
 
@@ -33,5 +35,6 @@ Generated Source Runtime SDK scaffold for `telnyx`.
 
 ## Tests
 
-- `go test ./sources/telnyx ./internal/sourceprojection -count=1`
-- `make catalog-check`
+- `go test ./sources/telnyx ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
+- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
+- `make connector-catalog-review connector-api-discovery`

--- a/sources/telnyx/catalog.yaml
+++ b/sources/telnyx/catalog.yaml
@@ -27,6 +27,76 @@ runtime_families:
   - sim_card_group
   - sim_card_group_action
   - wireless_connectivity_log
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-07-04T00:00:00Z
+  transport: rest
+  auth: bearer_token
+  auth_mechanics: authorization_bearer_header
+  base_url: https://api.telnyx.com/v2
+  spec_url: https://raw.githubusercontent.com/team-telnyx/openapi/master/openapi/spec3.json
+  spec_kind: openapi
+  references:
+    - https://developers.telnyx.com/api-reference/overview
+    - https://developers.telnyx.com/development/api-fundamentals
+    - https://github.com/team-telnyx/openapi
+    - https://raw.githubusercontent.com/team-telnyx/openapi/master/openapi/spec3.json
+  auth_evidence:
+    - https://developers.telnyx.com/development/api-fundamentals
+    - https://raw.githubusercontent.com/team-telnyx/openapi/master/openapi/spec3.json
+  scope_evidence:
+    - https://developers.telnyx.com/api-reference/overview
+    - https://raw.githubusercontent.com/team-telnyx/openapi/master/openapi/spec3.json
+  families:
+    - id: call_event
+      method: GET
+      path: /call_events
+      operation: ListCallEvents
+    - id: billing_group
+      method: GET
+      path: /billing_groups
+      operation: ListBillingGroups
+    - id: credential_connection
+      method: GET
+      path: /credential_connections
+      operation: ListCredentialConnections
+    - id: managed_account
+      method: GET
+      path: /managed_accounts
+      operation: ListManagedAccounts
+    - id: call_control_application
+      method: GET
+      path: /call_control_applications
+      operation: ListCallControlApplications
+    - id: notification_channel
+      method: GET
+      path: /notification_channels
+      operation: ListNotificationChannels
+    - id: detail_records_report
+      method: GET
+      path: /wireless/detail_records_reports
+      operation: GetWdrReports
+    - id: notification_event
+      method: GET
+      path: /notification_events
+      operation: FindNotificationsEvents
+    - id: notification_event_condition
+      method: GET
+      path: /notification_event_conditions
+      operation: FindNotificationsEventsConditions
+    - id: sim_card_group
+      method: GET
+      path: /sim_card_groups
+      operation: GetAllSimCardGroups
+    - id: sim_card_group_action
+      method: GET
+      path: /sim_card_group_actions
+      operation: GetSimCardGroupActions
+    - id: wireless_connectivity_log
+      method: GET
+      path: /sim_cards/{id}/wireless_connectivity_logs
+      operation: GetWirelessConnectivityLogs
 kind_lifecycle:
   - kind: telnyx.call_event
     status: active

--- a/sources/telnyx/source_health_receipt.json
+++ b/sources/telnyx/source_health_receipt.json
@@ -1,8 +1,23 @@
 {
   "adapter_health_path": "/call_events",
   "auth_model": "bearer_token",
+  "auth_mechanics": "Authorization: Bearer",
   "evidence_cas_reference_kind": "telnyx.evidence_cas_reference",
   "expected_cadence_seconds": 86400,
+  "families": [
+    "billing_group",
+    "call_control_application",
+    "call_event",
+    "credential_connection",
+    "detail_records_report",
+    "managed_account",
+    "notification_channel",
+    "notification_event",
+    "notification_event_condition",
+    "sim_card_group",
+    "sim_card_group_action",
+    "wireless_connectivity_log"
+  ],
   "failure_modes": [
     "api_error",
     "auth_error",
@@ -10,6 +25,7 @@
     "schema_drift"
   ],
   "health_endpoint": "/source-runtimes/health?source_id=telnyx",
+  "provider_api_status": "verified",
   "receipt_kind": "source_health.receipt",
   "source_id": "telnyx",
   "source_type": "json_api",


### PR DESCRIPTION
## Summary

- Promotes the `telnyx` Source Runtime contract to provider-verified API proof.
- Maps the existing runtime families to Telnyx API v2 list operations for call events, billing groups, credential connections, managed accounts, call-control applications, notifications, wireless reports, SIM card groups, SIM card group actions, and wireless connectivity logs.
- Refreshes runtime notes and the source-health receipt to match the implemented runtime.

## Runtime contract

- Source type: `json_api`
- Auth model: `bearer_token`
- Auth mechanics: `Authorization: Bearer <API key>`
- Health endpoint: `/source-runtimes/health?source_id=telnyx`
- Base URL: `https://api.telnyx.com/v2`
- Families: `billing_group`, `call_control_application`, `call_event`, `credential_connection`, `detail_records_report`, `managed_account`, `notification_channel`, `notification_event`, `notification_event_condition`, `sim_card_group`, `sim_card_group_action`, `wireless_connectivity_log`
- Deploy manifest: one runtime entry per family, using `TELNYX_TOKEN` as the bearer token and `TELNYX_SIM_CARD_ID` for wireless connectivity logs

## Tests

- `go test ./sources/telnyx ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
- `make lint-sources catalog-check sourcegen-check check-structural check-structural-test check-arch`
- `make connector-catalog-review connector-api-discovery`

## Review output

- Runtime depth score: `100`
- Fidelity score: `100`
- Provider API proof score: `100`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->