### PR TITLE
[codex] Add executable evidence requirement index

### DIFF
--- a/docs/domains/policy-compliance-mapping.md
+++ b/docs/domains/policy-compliance-mapping.md
@@ -209,6 +209,8 @@ Each requirement declares:
 
 `finding_evidence_requirement_map.csv` joins public findings to the expanded requirements through direct control refs. Use `requirement_match_status` to see whether the finding source or source coverage already matches the requirement source, or whether the requirement is defined but not source-matched yet.
 
+`BuildControlEvidenceRequirementIndex` turns the resolved requirements into a runtime lookup surface by control, source/entity, and profile. Use `AssessControlEvidenceRequirements` when an API, graph projection, or report needs to evaluate supplied evidence against required source, entity type, fields, freshness, manual-review, claim-strength, sufficiency, coverage-claim, and overclaim-guard metadata. Generated CSVs remain review artifacts; the index is the typed contract for executable policy and control evidence checks.
+
 ## Commands
 
 ```bash

--- a/internal/compliance/evidence_requirement_index.go
+++ b/internal/compliance/evidence_requirement_index.go
@@ -1,0 +1,398 @@
+package compliance
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+type ControlEvidenceRequirementIndex struct {
+	version        string
+	requirements   []ResolvedControlEvidenceRequirement
+	byControl      map[string][]int
+	bySourceEntity map[string][]int
+	byProfile      map[string][]int
+}
+
+type ControlEvidenceRequirementAssessmentStatus string
+
+const (
+	ControlEvidenceRequirementSatisfied    ControlEvidenceRequirementAssessmentStatus = "satisfied"
+	ControlEvidenceRequirementManualReview ControlEvidenceRequirementAssessmentStatus = "manual_review"
+	ControlEvidenceRequirementMissing      ControlEvidenceRequirementAssessmentStatus = "missing"
+	ControlEvidenceRequirementMissingField ControlEvidenceRequirementAssessmentStatus = "missing_fields"
+	ControlEvidenceRequirementStale        ControlEvidenceRequirementAssessmentStatus = "stale"
+)
+
+type ControlEvidenceRequirementAssessmentInput struct {
+	Index    *ControlEvidenceRequirementIndex
+	Control  ControlRef
+	Evidence []ControlEvidenceRequirementSignal
+	Now      time.Time
+}
+
+type ControlEvidenceRequirementSignal struct {
+	ID           string            `json:"id,omitempty"`
+	SourceID     string            `json:"source_id,omitempty"`
+	EntityType   string            `json:"entity_type,omitempty"`
+	EvidenceType string            `json:"evidence_type,omitempty"`
+	Status       string            `json:"status,omitempty"`
+	Fields       []string          `json:"fields,omitempty"`
+	FieldValues  map[string]string `json:"field_values,omitempty"`
+	ControlRefs  []ControlRef      `json:"control_refs,omitempty"`
+	ObservedAt   time.Time         `json:"observed_at,omitempty"`
+	ExpiresAt    time.Time         `json:"expires_at,omitempty"`
+	Manual       bool              `json:"manual,omitempty"`
+}
+
+type ControlEvidenceRequirementAssessment struct {
+	RequirementKey       string                                     `json:"requirement_key"`
+	ControlRef           ControlRef                                 `json:"control_ref"`
+	ProfileID            string                                     `json:"profile_id"`
+	ProfileName          string                                     `json:"profile_name,omitempty"`
+	SourceID             string                                     `json:"source_id"`
+	EntityType           string                                     `json:"entity_type"`
+	RequiredFields       []string                                   `json:"required_fields,omitempty"`
+	FreshnessWindow      string                                     `json:"freshness_window,omitempty"`
+	AssessmentMethods    []string                                   `json:"assessment_methods,omitempty"`
+	ClaimStrength        string                                     `json:"claim_strength,omitempty"`
+	SufficiencyRule      string                                     `json:"sufficiency_rule,omitempty"`
+	CoverageClaim        string                                     `json:"coverage_claim,omitempty"`
+	OverclaimGuard       string                                     `json:"overclaim_guard,omitempty"`
+	Status               ControlEvidenceRequirementAssessmentStatus `json:"status"`
+	Reason               string                                     `json:"reason,omitempty"`
+	NextAction           string                                     `json:"next_action,omitempty"`
+	EvidenceIDs          []string                                   `json:"evidence_ids,omitempty"`
+	StaleEvidenceIDs     []string                                   `json:"stale_evidence_ids,omitempty"`
+	MissingFields        []string                                   `json:"missing_fields,omitempty"`
+	ManualReviewRequired bool                                       `json:"manual_review_required,omitempty"`
+}
+
+func BuildControlEvidenceRequirementIndex(resolution ControlEvidenceRequirementResolution) *ControlEvidenceRequirementIndex {
+	index := &ControlEvidenceRequirementIndex{
+		version:        strings.TrimSpace(resolution.Version),
+		requirements:   make([]ResolvedControlEvidenceRequirement, 0, len(resolution.Requirements)),
+		byControl:      map[string][]int{},
+		bySourceEntity: map[string][]int{},
+		byProfile:      map[string][]int{},
+	}
+	for _, requirement := range resolution.Requirements {
+		requirement = cloneResolvedControlEvidenceRequirement(requirement)
+		idx := len(index.requirements)
+		index.requirements = append(index.requirements, requirement)
+		index.byControl[controlEvidenceRequirementControlKey(requirement)] = append(index.byControl[controlEvidenceRequirementControlKey(requirement)], idx)
+		index.bySourceEntity[controlEvidenceRequirementSourceKey(requirement.SourceRequirement.SourceID, requirement.SourceRequirement.EntityType)] = append(index.bySourceEntity[controlEvidenceRequirementSourceKey(requirement.SourceRequirement.SourceID, requirement.SourceRequirement.EntityType)], idx)
+		if profileID := strings.TrimSpace(requirement.ProfileID); profileID != "" {
+			index.byProfile[profileID] = append(index.byProfile[profileID], idx)
+		}
+	}
+	for key := range index.byControl {
+		sortRequirementIndexes(index.requirements, index.byControl[key])
+	}
+	for key := range index.bySourceEntity {
+		sortRequirementIndexes(index.requirements, index.bySourceEntity[key])
+	}
+	for key := range index.byProfile {
+		sortRequirementIndexes(index.requirements, index.byProfile[key])
+	}
+	return index
+}
+
+func (index *ControlEvidenceRequirementIndex) Version() string {
+	if index == nil {
+		return ""
+	}
+	return index.version
+}
+
+func (index *ControlEvidenceRequirementIndex) Requirements() []ResolvedControlEvidenceRequirement {
+	if index == nil {
+		return nil
+	}
+	return cloneResolvedControlEvidenceRequirements(index.requirements)
+}
+
+func (index *ControlEvidenceRequirementIndex) RequirementsForControl(ref ControlRef) []ResolvedControlEvidenceRequirement {
+	if index == nil {
+		return nil
+	}
+	return index.requirementsForIndexes(index.byControl[ControlKey(ref)])
+}
+
+func (index *ControlEvidenceRequirementIndex) RequirementsForSource(sourceID string, entityType string) []ResolvedControlEvidenceRequirement {
+	if index == nil {
+		return nil
+	}
+	return index.requirementsForIndexes(index.bySourceEntity[controlEvidenceRequirementSourceKey(sourceID, entityType)])
+}
+
+func (index *ControlEvidenceRequirementIndex) RequirementsForProfile(profileID string) []ResolvedControlEvidenceRequirement {
+	if index == nil {
+		return nil
+	}
+	return index.requirementsForIndexes(index.byProfile[strings.TrimSpace(profileID)])
+}
+
+func (index *ControlEvidenceRequirementIndex) RequirementKeysForControl(ref ControlRef) []string {
+	requirements := index.RequirementsForControl(ref)
+	keys := make([]string, 0, len(requirements))
+	for _, requirement := range requirements {
+		keys = appendUniqueString(keys, ControlEvidenceRequirementKey(requirement))
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func AssessControlEvidenceRequirements(input ControlEvidenceRequirementAssessmentInput) []ControlEvidenceRequirementAssessment {
+	if input.Index == nil {
+		return nil
+	}
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	requirements := input.Index.RequirementsForControl(input.Control)
+	assessments := make([]ControlEvidenceRequirementAssessment, 0, len(requirements))
+	for _, requirement := range requirements {
+		assessments = append(assessments, assessControlEvidenceRequirement(requirement, input.Evidence, now))
+	}
+	sort.Slice(assessments, func(i, j int) bool {
+		return assessments[i].RequirementKey < assessments[j].RequirementKey
+	})
+	return assessments
+}
+
+func ControlEvidenceRequirementKey(requirement ResolvedControlEvidenceRequirement) string {
+	parts := []string{
+		controlEvidenceRequirementControlLabel(requirement),
+		strings.TrimSpace(requirement.ProfileID),
+		strings.TrimSpace(requirement.SourceRequirement.SourceID),
+		strings.TrimSpace(requirement.SourceRequirement.EntityType),
+	}
+	return strings.Join(parts, "/")
+}
+
+func (index *ControlEvidenceRequirementIndex) requirementsForIndexes(indexes []int) []ResolvedControlEvidenceRequirement {
+	if len(indexes) == 0 {
+		return nil
+	}
+	requirements := make([]ResolvedControlEvidenceRequirement, 0, len(indexes))
+	for _, idx := range indexes {
+		if idx < 0 || idx >= len(index.requirements) {
+			continue
+		}
+		requirements = append(requirements, cloneResolvedControlEvidenceRequirement(index.requirements[idx]))
+	}
+	return requirements
+}
+
+func assessControlEvidenceRequirement(requirement ResolvedControlEvidenceRequirement, evidence []ControlEvidenceRequirementSignal, now time.Time) ControlEvidenceRequirementAssessment {
+	sourceRequirement := requirement.SourceRequirement
+	assessment := ControlEvidenceRequirementAssessment{
+		RequirementKey:    ControlEvidenceRequirementKey(requirement),
+		ControlRef:        ControlRef{FrameworkID: requirement.FrameworkID, FrameworkName: requirement.FrameworkName, ControlID: requirement.ControlID},
+		ProfileID:         strings.TrimSpace(requirement.ProfileID),
+		ProfileName:       strings.TrimSpace(requirement.ProfileName),
+		SourceID:          strings.TrimSpace(sourceRequirement.SourceID),
+		EntityType:        strings.TrimSpace(sourceRequirement.EntityType),
+		RequiredFields:    sortedUniqueStrings(sourceRequirement.RequiredFields),
+		FreshnessWindow:   strings.TrimSpace(sourceRequirement.FreshnessWindow),
+		AssessmentMethods: sortedUniqueStrings(sourceRequirement.AssessmentMethods),
+		ClaimStrength:     strings.TrimSpace(sourceRequirement.ClaimStrength),
+		SufficiencyRule:   strings.TrimSpace(sourceRequirement.SufficiencyRule),
+		CoverageClaim:     strings.TrimSpace(sourceRequirement.CoverageClaim),
+		OverclaimGuard:    strings.TrimSpace(sourceRequirement.OverclaimGuard),
+		Status:            ControlEvidenceRequirementMissing,
+		Reason:            "Required evidence has not been supplied.",
+		NextAction:        "Connect the required evidence source or record an approved manual evidence owner.",
+	}
+	matches := controlEvidenceRequirementMatches(requirement, evidence)
+	if len(matches) == 0 {
+		return assessment
+	}
+	assessment.EvidenceIDs = sortedUniqueStrings(controlEvidenceRequirementSignalIDs(matches, assessment.RequirementKey))
+	missingFields := []string{}
+	staleEvidenceIDs := []string{}
+	hasFreshCompleteEvidence := false
+	hasCompleteEvidence := false
+	for _, signal := range matches {
+		signalMissingFields := controlEvidenceRequirementMissingFields(sourceRequirement.RequiredFields, signal)
+		if len(signalMissingFields) != 0 {
+			missingFields = appendUniqueStrings(missingFields, signalMissingFields...)
+			continue
+		}
+		hasCompleteEvidence = true
+		if controlEvidenceRequirementSignalStale(sourceRequirement.FreshnessWindow, signal, now) {
+			staleEvidenceIDs = appendUniqueString(staleEvidenceIDs, controlEvidenceRequirementSignalID(signal, assessment.RequirementKey))
+			continue
+		}
+		hasFreshCompleteEvidence = true
+	}
+	assessment.StaleEvidenceIDs = sortedUniqueStrings(staleEvidenceIDs)
+	assessment.MissingFields = sortedUniqueStrings(missingFields)
+	assessment.ManualReviewRequired = controlEvidenceRequirementManualReviewRequired(sourceRequirement, matches)
+	switch {
+	case hasFreshCompleteEvidence && assessment.ManualReviewRequired:
+		assessment.Status = ControlEvidenceRequirementManualReview
+		assessment.Reason = "Evidence is present and current, but the assessment method requires human review."
+		assessment.NextAction = "Review the evidence packet and record the reviewer decision."
+	case hasFreshCompleteEvidence:
+		assessment.Status = ControlEvidenceRequirementSatisfied
+		assessment.Reason = "Required evidence is present and current."
+		assessment.NextAction = "Package the evidence and keep the source within the freshness window."
+	case hasCompleteEvidence:
+		assessment.Status = ControlEvidenceRequirementStale
+		assessment.Reason = "Evidence is present but outside the required freshness window."
+		assessment.NextAction = "Refresh the evidence source and rerun assessment."
+	default:
+		assessment.Status = ControlEvidenceRequirementMissingField
+		assessment.Reason = "Evidence is present but missing required fields."
+		assessment.NextAction = "Add the missing fields to the source projection or evidence packet."
+	}
+	return assessment
+}
+
+func controlEvidenceRequirementMatches(requirement ResolvedControlEvidenceRequirement, evidence []ControlEvidenceRequirementSignal) []ControlEvidenceRequirementSignal {
+	matches := []ControlEvidenceRequirementSignal{}
+	wantControlKey := controlEvidenceRequirementControlKey(requirement)
+	wantSourceID := strings.TrimSpace(requirement.SourceRequirement.SourceID)
+	wantEntityType := strings.TrimSpace(requirement.SourceRequirement.EntityType)
+	for _, signal := range evidence {
+		if !evidenceUsable(signal.Status) {
+			continue
+		}
+		if wantSourceID != "" && !strings.EqualFold(strings.TrimSpace(signal.SourceID), wantSourceID) {
+			continue
+		}
+		if wantEntityType != "" && !strings.EqualFold(strings.TrimSpace(signal.EntityType), wantEntityType) {
+			continue
+		}
+		if len(signal.ControlRefs) != 0 && !controlEvidenceRequirementSignalReferencesControl(signal.ControlRefs, wantControlKey) {
+			continue
+		}
+		matches = append(matches, signal)
+	}
+	return matches
+}
+
+func controlEvidenceRequirementSignalReferencesControl(refs []ControlRef, wantControlKey string) bool {
+	for _, ref := range refs {
+		if ControlKey(ref) == wantControlKey {
+			return true
+		}
+	}
+	return false
+}
+
+func controlEvidenceRequirementMissingFields(required []string, signal ControlEvidenceRequirementSignal) []string {
+	if len(required) == 0 {
+		return nil
+	}
+	present := map[string]struct{}{}
+	for _, field := range signal.Fields {
+		if field = strings.ToLower(strings.TrimSpace(field)); field != "" {
+			present[field] = struct{}{}
+		}
+	}
+	for field, value := range signal.FieldValues {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		if field = strings.ToLower(strings.TrimSpace(field)); field != "" {
+			present[field] = struct{}{}
+		}
+	}
+	missing := []string{}
+	for _, field := range required {
+		trimmed := strings.TrimSpace(field)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := present[strings.ToLower(trimmed)]; !ok {
+			missing = appendUniqueString(missing, trimmed)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func controlEvidenceRequirementSignalStale(freshnessWindow string, signal ControlEvidenceRequirementSignal, now time.Time) bool {
+	if !signal.ExpiresAt.IsZero() && !signal.ExpiresAt.After(now) {
+		return true
+	}
+	window, ok := parseFreshnessWindow(freshnessWindow)
+	return ok && !signal.ObservedAt.IsZero() && signal.ObservedAt.Add(window).Before(now)
+}
+
+func controlEvidenceRequirementManualReviewRequired(requirement ControlEvidenceSourceRequirement, signals []ControlEvidenceRequirementSignal) bool {
+	if hasAssessmentMethod(requirement.AssessmentMethods, "interview") {
+		return true
+	}
+	for _, signal := range signals {
+		if signal.Manual {
+			return true
+		}
+	}
+	return false
+}
+
+func controlEvidenceRequirementSignalIDs(signals []ControlEvidenceRequirementSignal, fallback string) []string {
+	ids := []string{}
+	for _, signal := range signals {
+		ids = appendUniqueString(ids, controlEvidenceRequirementSignalID(signal, fallback))
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func controlEvidenceRequirementSignalID(signal ControlEvidenceRequirementSignal, fallback string) string {
+	if id := strings.TrimSpace(signal.ID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func controlEvidenceRequirementControlKey(requirement ResolvedControlEvidenceRequirement) string {
+	return ControlKey(ControlRef{FrameworkID: requirement.FrameworkID, FrameworkName: requirement.FrameworkName, ControlID: requirement.ControlID})
+}
+
+func controlEvidenceRequirementControlLabel(requirement ResolvedControlEvidenceRequirement) string {
+	framework := firstNonEmpty(requirement.FrameworkName, requirement.FrameworkID)
+	controlID := strings.TrimSpace(requirement.ControlID)
+	switch {
+	case framework != "" && controlID != "":
+		return framework + ":" + controlID
+	case framework != "":
+		return framework
+	default:
+		return controlID
+	}
+}
+
+func controlEvidenceRequirementSourceKey(sourceID string, entityType string) string {
+	return strings.ToLower(strings.TrimSpace(sourceID)) + "/" + strings.ToLower(strings.TrimSpace(entityType))
+}
+
+func sortRequirementIndexes(requirements []ResolvedControlEvidenceRequirement, indexes []int) {
+	sort.Slice(indexes, func(i, j int) bool {
+		return ControlEvidenceRequirementKey(requirements[indexes[i]]) < ControlEvidenceRequirementKey(requirements[indexes[j]])
+	})
+}
+
+func cloneResolvedControlEvidenceRequirements(requirements []ResolvedControlEvidenceRequirement) []ResolvedControlEvidenceRequirement {
+	if len(requirements) == 0 {
+		return nil
+	}
+	cloned := make([]ResolvedControlEvidenceRequirement, 0, len(requirements))
+	for _, requirement := range requirements {
+		cloned = append(cloned, cloneResolvedControlEvidenceRequirement(requirement))
+	}
+	return cloned
+}
+
+func cloneResolvedControlEvidenceRequirement(requirement ResolvedControlEvidenceRequirement) ResolvedControlEvidenceRequirement {
+	requirement.SourceRequirement.RequiredFields = sortedUniqueStrings(requirement.SourceRequirement.RequiredFields)
+	requirement.SourceRequirement.AssessmentMethods = sortedUniqueStrings(requirement.SourceRequirement.AssessmentMethods)
+	requirement.ManualEvidenceAllowed = cloneBool(requirement.ManualEvidenceAllowed)
+	return requirement
+}

--- a/internal/compliance/evidence_requirement_index.go
+++ b/internal/compliance/evidence_requirement_index.go
@@ -267,7 +267,7 @@ func controlEvidenceRequirementMatches(requirement ResolvedControlEvidenceRequir
 		if wantEntityType != "" && !strings.EqualFold(strings.TrimSpace(signal.EntityType), wantEntityType) {
 			continue
 		}
-		if len(signal.ControlRefs) != 0 && !controlEvidenceRequirementSignalReferencesControl(signal.ControlRefs, wantControlKey) {
+		if !controlEvidenceRequirementSignalReferencesControl(signal.ControlRefs, wantControlKey) {
 			continue
 		}
 		matches = append(matches, signal)
@@ -317,11 +317,17 @@ func controlEvidenceRequirementMissingFields(required []string, signal ControlEv
 }
 
 func controlEvidenceRequirementSignalStale(freshnessWindow string, signal ControlEvidenceRequirementSignal, now time.Time) bool {
-	if !signal.ExpiresAt.IsZero() && !signal.ExpiresAt.After(now) {
-		return true
+	if !signal.ExpiresAt.IsZero() {
+		return !signal.ExpiresAt.After(now)
 	}
 	window, ok := parseFreshnessWindow(freshnessWindow)
-	return ok && !signal.ObservedAt.IsZero() && signal.ObservedAt.Add(window).Before(now)
+	if !ok {
+		return false
+	}
+	if signal.ObservedAt.IsZero() {
+		return true
+	}
+	return signal.ObservedAt.Add(window).Before(now)
 }
 
 func controlEvidenceRequirementManualReviewRequired(requirement ControlEvidenceSourceRequirement, signals []ControlEvidenceRequirementSignal) bool {

--- a/internal/compliance/evidence_requirement_index_test.go
+++ b/internal/compliance/evidence_requirement_index_test.go
@@ -65,11 +65,12 @@ func TestAssessControlEvidenceRequirementsReportsOperatingStates(t *testing.T) {
 				ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
 			},
 			{
-				ID:         "github-evidence",
-				SourceID:   "github",
-				EntityType: "repository_access",
-				Fields:     []string{"repository_id"},
-				ObservedAt: now.Add(-time.Hour),
+				ID:          "github-evidence",
+				SourceID:    "github",
+				EntityType:  "repository_access",
+				Fields:      []string{"repository_id"},
+				ObservedAt:  now.Add(-time.Hour),
+				ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
 			},
 			{
 				ID:          "risk-evidence",
@@ -77,6 +78,7 @@ func TestAssessControlEvidenceRequirementsReportsOperatingStates(t *testing.T) {
 				EntityType:  "risk_record",
 				FieldValues: map[string]string{"risk_id": "risk-1"},
 				ObservedAt:  now.Add(-48 * time.Hour),
+				ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
 			},
 		},
 	})
@@ -114,11 +116,12 @@ func TestAssessControlEvidenceRequirementsMarksManualReview(t *testing.T) {
 		Control: ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"},
 		Now:     now,
 		Evidence: []ControlEvidenceRequirementSignal{{
-			ID:         "owner-review",
-			SourceID:   "control_owner_review",
-			EntityType: "control_evidence_packet",
-			Fields:     []string{"reviewer"},
-			ObservedAt: now.Add(-time.Hour),
+			ID:          "owner-review",
+			SourceID:    "control_owner_review",
+			EntityType:  "control_evidence_packet",
+			Fields:      []string{"reviewer"},
+			ObservedAt:  now.Add(-time.Hour),
+			ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
 		}},
 	})
 	if len(assessments) != 1 {
@@ -126,6 +129,66 @@ func TestAssessControlEvidenceRequirementsMarksManualReview(t *testing.T) {
 	}
 	if assessments[0].Status != ControlEvidenceRequirementManualReview || !assessments[0].ManualReviewRequired {
 		t.Fatalf("assessment = %#v, want manual review", assessments[0])
+	}
+}
+
+func TestAssessControlEvidenceRequirementsTreatsTimestamplessFreshnessEvidenceAsStale(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	requirement := testResolvedEvidenceRequirement("CC6.1", "identity-access", "okta", "identity_user", []string{"user_id"})
+	index := BuildControlEvidenceRequirementIndex(ControlEvidenceRequirementResolution{
+		Version:      "2026-07-04",
+		Requirements: []ResolvedControlEvidenceRequirement{requirement},
+	})
+	assessments := AssessControlEvidenceRequirements(ControlEvidenceRequirementAssessmentInput{
+		Index:   index,
+		Control: ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"},
+		Now:     now,
+		Evidence: []ControlEvidenceRequirementSignal{{
+			ID:          "timestampless",
+			SourceID:    "okta",
+			EntityType:  "identity_user",
+			Fields:      []string{"user_id"},
+			ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+		}},
+	})
+	if len(assessments) != 1 {
+		t.Fatalf("assessments = %d, want 1", len(assessments))
+	}
+	if assessments[0].Status != ControlEvidenceRequirementStale {
+		t.Fatalf("status = %q, want stale", assessments[0].Status)
+	}
+	if got := assessments[0].StaleEvidenceIDs; len(got) != 1 || got[0] != "timestampless" {
+		t.Fatalf("stale evidence = %#v, want timestampless", got)
+	}
+}
+
+func TestAssessControlEvidenceRequirementsRequiresScopedControlRefs(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	requirement := testResolvedEvidenceRequirement("CC6.1", "identity-access", "okta", "identity_user", []string{"user_id"})
+	index := BuildControlEvidenceRequirementIndex(ControlEvidenceRequirementResolution{
+		Version:      "2026-07-04",
+		Requirements: []ResolvedControlEvidenceRequirement{requirement},
+	})
+	assessments := AssessControlEvidenceRequirements(ControlEvidenceRequirementAssessmentInput{
+		Index:   index,
+		Control: ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"},
+		Now:     now,
+		Evidence: []ControlEvidenceRequirementSignal{{
+			ID:         "unscoped",
+			SourceID:   "okta",
+			EntityType: "identity_user",
+			Fields:     []string{"user_id"},
+			ObservedAt: now.Add(-time.Hour),
+		}},
+	})
+	if len(assessments) != 1 {
+		t.Fatalf("assessments = %d, want 1", len(assessments))
+	}
+	if assessments[0].Status != ControlEvidenceRequirementMissing {
+		t.Fatalf("status = %q, want missing", assessments[0].Status)
+	}
+	if got := assessments[0].EvidenceIDs; len(got) != 0 {
+		t.Fatalf("evidence ids = %#v, want none", got)
 	}
 }
 

--- a/internal/compliance/evidence_requirement_index_test.go
+++ b/internal/compliance/evidence_requirement_index_test.go
@@ -9,9 +9,9 @@ func TestControlEvidenceRequirementIndexLooksUpRequirements(t *testing.T) {
 	index := BuildControlEvidenceRequirementIndex(ControlEvidenceRequirementResolution{
 		Version: "2026-07-04",
 		Requirements: []ResolvedControlEvidenceRequirement{
-			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "identity-access", "okta", "identity_user", []string{"user_id"}),
-			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "governance-risk", "risk_register", "risk_record", []string{"risk_id"}),
-			testResolvedEvidenceRequirement("SOC 2", "CC7.1", "logging", "aws", "cloudtrail_trail", []string{"trail_arn"}),
+			testResolvedEvidenceRequirement("CC6.1", "identity-access", "okta", "identity_user", []string{"user_id"}),
+			testResolvedEvidenceRequirement("CC6.1", "governance-risk", "risk_register", "risk_record", []string{"risk_id"}),
+			testResolvedEvidenceRequirement("CC7.1", "logging", "aws", "cloudtrail_trail", []string{"trail_arn"}),
 		},
 	})
 	if index.Version() != "2026-07-04" {
@@ -45,10 +45,10 @@ func TestAssessControlEvidenceRequirementsReportsOperatingStates(t *testing.T) {
 	index := BuildControlEvidenceRequirementIndex(ControlEvidenceRequirementResolution{
 		Version: "2026-07-04",
 		Requirements: []ResolvedControlEvidenceRequirement{
-			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "identity-access", "okta", "identity_user", []string{"user_id", "status"}),
-			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "repository-access", "github", "repository_access", []string{"repository_id", "permission"}),
-			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "governance-risk", "risk_register", "risk_record", []string{"risk_id"}),
-			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "policy-document", "grc_policy_lifecycle", "policy_document", []string{"document_id"}),
+			testResolvedEvidenceRequirement("CC6.1", "identity-access", "okta", "identity_user", []string{"user_id", "status"}),
+			testResolvedEvidenceRequirement("CC6.1", "repository-access", "github", "repository_access", []string{"repository_id", "permission"}),
+			testResolvedEvidenceRequirement("CC6.1", "governance-risk", "risk_register", "risk_record", []string{"risk_id"}),
+			testResolvedEvidenceRequirement("CC6.1", "policy-document", "grc_policy_lifecycle", "policy_document", []string{"document_id"}),
 		},
 	})
 	assessments := AssessControlEvidenceRequirements(ControlEvidenceRequirementAssessmentInput{
@@ -103,7 +103,7 @@ func TestAssessControlEvidenceRequirementsReportsOperatingStates(t *testing.T) {
 
 func TestAssessControlEvidenceRequirementsMarksManualReview(t *testing.T) {
 	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
-	requirement := testResolvedEvidenceRequirement("SOC 2", "CC6.1", "owner-review", "control_owner_review", "control_evidence_packet", []string{"reviewer"})
+	requirement := testResolvedEvidenceRequirement("CC6.1", "owner-review", "control_owner_review", "control_evidence_packet", []string{"reviewer"})
 	requirement.SourceRequirement.AssessmentMethods = []string{"examine", "interview"}
 	index := BuildControlEvidenceRequirementIndex(ControlEvidenceRequirementResolution{
 		Version:      "2026-07-04",
@@ -129,9 +129,9 @@ func TestAssessControlEvidenceRequirementsMarksManualReview(t *testing.T) {
 	}
 }
 
-func testResolvedEvidenceRequirement(framework string, controlID string, profileID string, sourceID string, entityType string, requiredFields []string) ResolvedControlEvidenceRequirement {
+func testResolvedEvidenceRequirement(controlID string, profileID string, sourceID string, entityType string, requiredFields []string) ResolvedControlEvidenceRequirement {
 	return ResolvedControlEvidenceRequirement{
-		FrameworkName:      framework,
+		FrameworkName:      "SOC 2",
 		FrameworkVersion:   "2026",
 		FrameworkLifecycle: "current",
 		FamilyID:           "CC",

--- a/internal/compliance/evidence_requirement_index_test.go
+++ b/internal/compliance/evidence_requirement_index_test.go
@@ -1,0 +1,164 @@
+package compliance
+
+import (
+	"testing"
+	"time"
+)
+
+func TestControlEvidenceRequirementIndexLooksUpRequirements(t *testing.T) {
+	index := BuildControlEvidenceRequirementIndex(ControlEvidenceRequirementResolution{
+		Version: "2026-07-04",
+		Requirements: []ResolvedControlEvidenceRequirement{
+			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "identity-access", "okta", "identity_user", []string{"user_id"}),
+			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "governance-risk", "risk_register", "risk_record", []string{"risk_id"}),
+			testResolvedEvidenceRequirement("SOC 2", "CC7.1", "logging", "aws", "cloudtrail_trail", []string{"trail_arn"}),
+		},
+	})
+	if index.Version() != "2026-07-04" {
+		t.Fatalf("Version() = %q, want 2026-07-04", index.Version())
+	}
+	controlRequirements := index.RequirementsForControl(ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"})
+	if len(controlRequirements) != 2 {
+		t.Fatalf("RequirementsForControl() = %d, want 2", len(controlRequirements))
+	}
+	sourceRequirements := index.RequirementsForSource("OKTA", "IDENTITY_USER")
+	if len(sourceRequirements) != 1 || sourceRequirements[0].ProfileID != "identity-access" {
+		t.Fatalf("RequirementsForSource() = %#v, want identity-access requirement", sourceRequirements)
+	}
+	profileRequirements := index.RequirementsForProfile("logging")
+	if len(profileRequirements) != 1 || profileRequirements[0].ControlID != "CC7.1" {
+		t.Fatalf("RequirementsForProfile() = %#v, want CC7.1 logging requirement", profileRequirements)
+	}
+	keys := index.RequirementKeysForControl(ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"})
+	if len(keys) != 2 || keys[0] != "SOC 2:CC6.1/governance-risk/risk_register/risk_record" || keys[1] != "SOC 2:CC6.1/identity-access/okta/identity_user" {
+		t.Fatalf("RequirementKeysForControl() = %#v", keys)
+	}
+	controlRequirements[0].SourceRequirement.RequiredFields[0] = "mutated"
+	again := index.RequirementsForControl(ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"})
+	if again[0].SourceRequirement.RequiredFields[0] == "mutated" {
+		t.Fatal("RequirementsForControl() returned mutable internal state")
+	}
+}
+
+func TestAssessControlEvidenceRequirementsReportsOperatingStates(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	index := BuildControlEvidenceRequirementIndex(ControlEvidenceRequirementResolution{
+		Version: "2026-07-04",
+		Requirements: []ResolvedControlEvidenceRequirement{
+			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "identity-access", "okta", "identity_user", []string{"user_id", "status"}),
+			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "repository-access", "github", "repository_access", []string{"repository_id", "permission"}),
+			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "governance-risk", "risk_register", "risk_record", []string{"risk_id"}),
+			testResolvedEvidenceRequirement("SOC 2", "CC6.1", "policy-document", "grc_policy_lifecycle", "policy_document", []string{"document_id"}),
+		},
+	})
+	assessments := AssessControlEvidenceRequirements(ControlEvidenceRequirementAssessmentInput{
+		Index:   index,
+		Control: ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"},
+		Now:     now,
+		Evidence: []ControlEvidenceRequirementSignal{
+			{
+				ID:          "okta-evidence",
+				SourceID:    "okta",
+				EntityType:  "identity_user",
+				Fields:      []string{"user_id", "status"},
+				ObservedAt:  now.Add(-time.Hour),
+				ControlRefs: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+			},
+			{
+				ID:         "github-evidence",
+				SourceID:   "github",
+				EntityType: "repository_access",
+				Fields:     []string{"repository_id"},
+				ObservedAt: now.Add(-time.Hour),
+			},
+			{
+				ID:          "risk-evidence",
+				SourceID:    "risk_register",
+				EntityType:  "risk_record",
+				FieldValues: map[string]string{"risk_id": "risk-1"},
+				ObservedAt:  now.Add(-48 * time.Hour),
+			},
+		},
+	})
+	byProfile := evidenceRequirementAssessmentsByProfile(assessments)
+	if got := byProfile["identity-access"].Status; got != ControlEvidenceRequirementSatisfied {
+		t.Fatalf("identity status = %q, want satisfied", got)
+	}
+	if got := byProfile["repository-access"].Status; got != ControlEvidenceRequirementMissingField {
+		t.Fatalf("repository status = %q, want missing_fields", got)
+	}
+	if got := byProfile["repository-access"].MissingFields; len(got) != 1 || got[0] != "permission" {
+		t.Fatalf("repository missing fields = %#v, want permission", got)
+	}
+	if got := byProfile["governance-risk"].Status; got != ControlEvidenceRequirementStale {
+		t.Fatalf("governance status = %q, want stale", got)
+	}
+	if got := byProfile["governance-risk"].StaleEvidenceIDs; len(got) != 1 || got[0] != "risk-evidence" {
+		t.Fatalf("governance stale evidence = %#v, want risk-evidence", got)
+	}
+	if got := byProfile["policy-document"].Status; got != ControlEvidenceRequirementMissing {
+		t.Fatalf("policy document status = %q, want missing", got)
+	}
+}
+
+func TestAssessControlEvidenceRequirementsMarksManualReview(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	requirement := testResolvedEvidenceRequirement("SOC 2", "CC6.1", "owner-review", "control_owner_review", "control_evidence_packet", []string{"reviewer"})
+	requirement.SourceRequirement.AssessmentMethods = []string{"examine", "interview"}
+	index := BuildControlEvidenceRequirementIndex(ControlEvidenceRequirementResolution{
+		Version:      "2026-07-04",
+		Requirements: []ResolvedControlEvidenceRequirement{requirement},
+	})
+	assessments := AssessControlEvidenceRequirements(ControlEvidenceRequirementAssessmentInput{
+		Index:   index,
+		Control: ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"},
+		Now:     now,
+		Evidence: []ControlEvidenceRequirementSignal{{
+			ID:         "owner-review",
+			SourceID:   "control_owner_review",
+			EntityType: "control_evidence_packet",
+			Fields:     []string{"reviewer"},
+			ObservedAt: now.Add(-time.Hour),
+		}},
+	})
+	if len(assessments) != 1 {
+		t.Fatalf("assessments = %d, want 1", len(assessments))
+	}
+	if assessments[0].Status != ControlEvidenceRequirementManualReview || !assessments[0].ManualReviewRequired {
+		t.Fatalf("assessment = %#v, want manual review", assessments[0])
+	}
+}
+
+func testResolvedEvidenceRequirement(framework string, controlID string, profileID string, sourceID string, entityType string, requiredFields []string) ResolvedControlEvidenceRequirement {
+	return ResolvedControlEvidenceRequirement{
+		FrameworkName:      framework,
+		FrameworkVersion:   "2026",
+		FrameworkLifecycle: "current",
+		FamilyID:           "CC",
+		FamilyName:         "Common Criteria",
+		ControlID:          controlID,
+		ControlTitle:       "Control " + controlID,
+		ProfileID:          profileID,
+		ProfileName:        profileID,
+		SourceRequirement: ControlEvidenceSourceRequirement{
+			SourceID:             sourceID,
+			EntityType:           entityType,
+			RequiredFields:       requiredFields,
+			FreshnessWindow:      "24h",
+			AssessmentMethods:    []string{"examine"},
+			AuditorGradeEvidence: "Evidence identifies the source object and current control state.",
+			ClaimStrength:        "source_backed",
+			SufficiencyRule:      "source_period_state_exception",
+			CoverageClaim:        "supports_control",
+			OverclaimGuard:       "Do not claim broader framework coverage from this requirement alone.",
+		},
+	}
+}
+
+func evidenceRequirementAssessmentsByProfile(assessments []ControlEvidenceRequirementAssessment) map[string]ControlEvidenceRequirementAssessment {
+	byProfile := map[string]ControlEvidenceRequirementAssessment{}
+	for _, assessment := range assessments {
+		byProfile[assessment.ProfileID] = assessment
+	}
+	return byProfile
+}


### PR DESCRIPTION
## Summary
- add a typed control evidence requirement index for resolved control requirements
- add assessment statuses for satisfied, manual review, missing, missing fields, and stale evidence
- document the index as the runtime contract for executable policy and control evidence checks

## Impact
This gives policy, graph, API, and report code a shared way to answer which evidence a control requires and whether supplied evidence is complete, current, and review-ready. The checked-in CSVs remain review artifacts; YAML remains the source of truth.

## Validation
- go test ./internal/compliance
- go test ./internal/compliance ./tools/catalogcheck

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->