### PR TITLE
[codex] Carry read flags through sourcegen

### DIFF
--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -726,7 +726,7 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			SchemaRef:             schemaRef,
 			IDKeys:                idKeysForResource(resource),
 			ListKeys:              listKeysForResource(resource),
-			Singleton:             resource.Singleton,
+			Singleton:             singletonForResource(resource),
 			CursorParam:           cursorParamForResource(resource),
 			NextCursorKeys:        nextCursorKeysForResource(resource),
 			LinkHeader:            linkHeaderForResource(resource),
@@ -849,7 +849,17 @@ func pageSizeParamsForResource(resource connectordefinitions.ResourceFamily) []s
 }
 
 func disablePageSizeForResource(resource connectordefinitions.ResourceFamily) bool {
+	if resource.Read != nil && resource.Read.DisablePageSize {
+		return true
+	}
 	return resource.Pagination != nil && resource.Pagination.DisablePageSize
+}
+
+func singletonForResource(resource connectordefinitions.ResourceFamily) bool {
+	if resource.Singleton {
+		return true
+	}
+	return resource.Read != nil && resource.Read.Singleton
 }
 
 func uniqueStrings(values []string) []string {

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -1162,6 +1162,63 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 	}
 }
 
+func TestGenerateDefinitionCarriesReadFlags(t *testing.T) {
+	outputDir := t.TempDir()
+	_, err := GenerateDefinition(DefinitionRequest{
+		Definition: connectordefinitions.Definition{
+			ID:          "tenant-example_status",
+			TenantID:    "tenant",
+			SourceID:    "example_status",
+			DisplayName: "Example Status",
+			Auth: connectordefinitions.AuthSpec{
+				Model: "bearer_token",
+				CredentialFields: []connectordefinitions.Field{{
+					Key:           "token",
+					Secret:        true,
+					ReferenceOnly: true,
+				}},
+			},
+			Transport: &connectordefinitions.TransportSpec{
+				BaseURL: "https://api.example.test",
+				Verification: &connectordefinitions.VerificationSpec{
+					Path: "/v1/me",
+				},
+			},
+			ResourceFamilies: []connectordefinitions.ResourceFamily{{
+				ID:             "tenant_status",
+				Path:           "/v1/status",
+				RecordSelector: "$",
+				IDField:        "id",
+				Read: &connectordefinitions.ResourceReadSpec{
+					Singleton:       true,
+					DisablePageSize: true,
+				},
+				Event: connectordefinitions.EventMappingSpec{
+					Kind:      "example_status.tenant_status",
+					SchemaRef: "example_status/tenant_status/v1",
+				},
+				Projection: &connectordefinitions.ProjectionSpec{
+					Template: "asset",
+				},
+				Coverage: []connectordefinitions.CoverageDimensionSpec{{Type: "entity_family", Support: "partial"}},
+			}},
+		},
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("GenerateDefinition() error = %v", err)
+	}
+	source := readGeneratedFile(t, outputDir, "sources/example_status/source.go")
+	for _, want := range []string{
+		`DisablePageSize:  true`,
+		`Singleton:        true`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("source.go missing %q:\n%s", want, source)
+		}
+	}
+}
+
 func TestGenerateDefinitionSupportsCustomTokenHeader(t *testing.T) {
 	outputDir := t.TempDir()
 	_, err := GenerateDefinition(DefinitionRequest{


### PR DESCRIPTION
## Summary
- Carry read-level singleton and page-size suppression flags into generated JSON API families.
- Preserve existing top-level singleton and pagination disable-page-size behavior.
- Add generator coverage for read-scoped flags.

## Validation
- go test ./internal/sourcegen -run 'TestGenerateDefinitionCarriesReadFlags|TestGenerateDefinitionSupportsFamilyQueryBindings' -count=1 -v
- make check-structural check-structural-test check-arch
- go test ./internal/sourcegen/... -count=1
- go test ./internal/sourcecdk ./internal/connectordefinitions ./sources/internal/jsonapi -count=1
- make sourcegen-test
- make sourcegen-check