### PR TITLE
[codex] Invalidate Zuora generated source API proof

### DIFF
--- a/sources/zuora/PR_BODY.md
+++ b/sources/zuora/PR_BODY.md
@@ -1,16 +1,27 @@
 ## Summary
 
-- Adds the `zuora` Source Runtime SDK scaffold.
-- Includes runtime adapter, health check, EvidenceCAS reference events, graph projection scaffolds, tests, and a source-health receipt.
+- Invalidates the generated `zuora` Source Runtime provider API proof.
+- Records the provider Swagger mismatch for generated `account`, `revenue_event`, and `revenue_schedule` runtime paths.
+- Leaves the runtime in place, but blocks promotion until those families are rewritten against documented provider paths or removed.
 
-## Generated runtime contract
+## Provider API result
 
-- Source type: `json_api`
-- Auth model: `bearer_token`
-- Health endpoint: `/source-runtimes/health?source_id=zuora`
-- Freshness: `24h0m0s`
+- Status: `invalidated`
+- Reason: `generated_runtime_paths_not_in_provider_spec`
+- Affected families: `account`, `revenue_event`, `revenue_schedule`
+- Missing paths:
+  - `/v1/payment-methods/credit-cards/accounts/{account-key}`
+  - `/v1/revenue-events/revenue-schedules/{rs-number}`
+  - `/v1/revenue-items/revenue-events/{event-number}`
+
+## Next rewrite
+
+- Rewrite `account` against documented account or payment-method endpoints.
+- Rewrite or remove `revenue_event` and `revenue_schedule` unless provider-backed paths are found.
+- Promote the remaining provider-backed families after the invalid families are removed from the runtime contract.
 
 ## Tests
 
-- `go test ./sources/zuora ./internal/sourceprojection -count=1`
+- `go test ./sources/zuora ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
 - `make catalog-check`
+- `make connector-catalog-review connector-api-discovery`

--- a/sources/zuora/SOURCE_RUNTIME.md
+++ b/sources/zuora/SOURCE_RUNTIME.md
@@ -1,11 +1,12 @@
 # Zuora
 
-Generated Source Runtime SDK scaffold for `zuora`.
+Source Runtime adapter for Zuora billing, notification, product, and revenue configuration.
 
 ## Runtime input
 
 - Source type: `json_api`
 - Auth model: `bearer_token`
+- Base URL: `https://rest.zuora.com`
 - Freshness expectation: `24h0m0s`
 - Failure modes: `api_error,auth_error,rate_limit,schema_drift`
 
@@ -15,6 +16,13 @@ Generated Source Runtime SDK scaffold for `zuora`.
 - Health endpoint: `/source-runtimes/health?source_id=zuora`
 - Source health receipt: `sources/zuora/source_health_receipt.json`
 - EvidenceCAS reference kind: `zuora.evidence_cas_reference`
+
+## Provider API status
+
+- Status: invalidated for promotion.
+- Reason: generated runtime paths not present in the provider Swagger.
+- Affected families: `account`, `revenue_event`, `revenue_schedule`.
+- The remaining nine runtime family paths are present in the provider Swagger and should be promoted after the generated families are rewritten or removed.
 
 ## Families
 
@@ -33,5 +41,6 @@ Generated Source Runtime SDK scaffold for `zuora`.
 
 ## Tests
 
-- `go test ./sources/zuora ./internal/sourceprojection -count=1`
+- `go test ./sources/zuora ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
 - `make catalog-check`
+- `make connector-catalog-review connector-api-discovery`

--- a/sources/zuora/catalog.yaml
+++ b/sources/zuora/catalog.yaml
@@ -52,6 +52,26 @@ kind_lifecycle:
     status: active
   - kind: zuora.account
     status: active
+provider_api_disproof:
+  status: invalidated
+  reason: generated_runtime_paths_not_in_provider_spec
+  checked_at: 2026-07-04T00:00:00Z
+  references:
+    - https://developer.zuora.com/v1-api-reference/api
+    - https://developer.zuora.com/yaml/swagger.yaml
+    - https://docs.zuora.com/en/zuora-platform/integration/apis/rest-api
+  affected_families:
+    - account
+    - revenue_event
+    - revenue_schedule
+  missing_paths:
+    - /v1/payment-methods/credit-cards/accounts/{account-key}
+    - /v1/revenue-events/revenue-schedules/{rs-number}
+    - /v1/revenue-items/revenue-events/{event-number}
+  notes:
+    - The provider Swagger verifies nine current runtime family paths, but not these three generated keyed paths.
+    - The account family should be rewritten against documented account or payment-method endpoints before promotion.
+    - The revenue event and revenue schedule families need provider-backed paths or removal before promotion.
 coverage_contract:
   owner_domain: source_runtime
   authority_domain: zuora


### PR DESCRIPTION
## Summary

- Invalidates the generated `zuora` Source Runtime provider API proof.
- Records the provider Swagger mismatch for generated `account`, `revenue_event`, and `revenue_schedule` runtime paths.
- Leaves the runtime in place, but blocks promotion until those families are rewritten against documented provider paths or removed.

## Provider API result

- Status: `invalidated`
- Reason: `generated_runtime_paths_not_in_provider_spec`
- Affected families: `account`, `revenue_event`, `revenue_schedule`
- Missing paths:
  - `/v1/payment-methods/credit-cards/accounts/{account-key}`
  - `/v1/revenue-events/revenue-schedules/{rs-number}`
  - `/v1/revenue-items/revenue-events/{event-number}`

## Next rewrite

- Rewrite `account` against documented account or payment-method endpoints.
- Rewrite or remove `revenue_event` and `revenue_schedule` unless provider-backed paths are found.
- Promote the remaining provider-backed families after the invalid families are removed from the runtime contract.

## Tests

- `go test ./sources/zuora ./internal/sourceprojection ./sources/internal/catalogruntime ./internal/connectordefinitions ./internal/connectorcatalog -count=1`
- `make catalog-check`
- `make connector-catalog-review connector-api-discovery`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->