### PR TITLE
[codex] Promote Cohere provider API proof

### DIFF
--- a/sources/cohere/catalog.yaml
+++ b/sources/cohere/catalog.yaml
@@ -11,6 +11,37 @@ runtime_families:
   - datasets
   - fine_tuned_models
   - model_catalog
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-07-04T00:00:00Z
+  transport: rest
+  auth: bearer_token
+  auth_mechanics: authorization_bearer_token
+  base_url: https://api.cohere.com
+  spec_url: https://docs.cohere.com/reference
+  spec_kind: openapi_embedded_html
+  references:
+    - https://docs.cohere.com/reference
+    - https://docs.cohere.com/reference/list-models
+    - https://docs.cohere.com/reference/list-connectors
+    - https://docs.cohere.com/reference/list-datasets
+    - https://docs.cohere.com/reference/listfinetunedmodels
+  auth_evidence:
+    - https://docs.cohere.com/reference/list-models
+  families:
+    - id: connectors
+      method: GET
+      path: /v1/connectors
+    - id: datasets
+      method: GET
+      path: /v1/datasets
+    - id: fine_tuned_models
+      method: GET
+      path: /v1/finetuning/finetuned-models
+    - id: model_catalog
+      method: GET
+      path: /v1/models
 kind_lifecycle:
   - kind: cohere.model_catalog
     status: active


### PR DESCRIPTION
## Summary
- add verified Cohere provider API metadata to the runtime catalog
- map model catalog, connectors, datasets, and fine-tuned models to documented Cohere GET endpoints
- record bearer-token auth evidence so runtime-depth review treats Cohere as a reference runtime

## Validation
- `go test ./sources/cohere ./internal/connectorcatalog ./internal/sourceprojection -count=1`
- `go run ./tools/connectorcatalogreview -json-out work/catalogreview-cohere.json -max-items=0`
- `go run ./tools/sourcefidelity -json-out work/sourcefidelity-cohere.json -max-items=0`
- `make catalog-check`

## Provider References
- https://docs.cohere.com/reference
- https://docs.cohere.com/reference/list-models
- https://docs.cohere.com/reference/list-connectors
- https://docs.cohere.com/reference/list-datasets
- https://docs.cohere.com/reference/listfinetunedmodels
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->