### PR TITLE
[codex] Promote Kandji provider API proof

### DIFF
--- a/sources/kandji/catalog.yaml
+++ b/sources/kandji/catalog.yaml
@@ -9,6 +9,36 @@ runtime_families:
   - application
   - device
   - vulnerability
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-07-04T00:00:00Z
+  transport: rest
+  auth: bearer_token
+  auth_mechanics: authorization_bearer_token
+  base_url: https://{sub_domain}.api.kandji.io/api/v1
+  spec_url: https://www.postman.com/ksapitest/kandji-api-support-flows/collection/r796tjz/kandji-api
+  spec_kind: postman_collection
+  references:
+    - https://api-docs.iru.com/
+    - https://www.postman.com/ksapitest/kandji-api-support-flows/collection/r796tjz/kandji-api
+    - https://support.kandji.io/kb/kandji-api
+    - https://support.kandji.io/kb/prism
+  auth_evidence:
+    - https://support.kandji.io/kb/kandji-api
+  families:
+    - id: application
+      method: GET
+      path: /prism/apps
+    - id: device
+      method: GET
+      path: /devices
+    - id: device
+      method: GET
+      path: /devices/{device_id}/details
+    - id: vulnerability
+      method: GET
+      path: /vulnerability-management/detections
 event_contracts:
   - kind: kandji.application
     schema_ref: kandji/application/v1


### PR DESCRIPTION
## Summary
- add verified Kandji/Iru provider API metadata to the runtime catalog
- map application, device, device detail, and vulnerability detection reads to documented endpoints
- record bearer-token auth evidence and the Postman collection pointer used for runtime-depth proof

## Validation
- `go test ./sources/kandji ./internal/connectorcatalog ./internal/sourceprojection -count=1`
- `go run ./tools/connectorcatalogreview -json-out work/catalogreview-kandji.json -max-items=0`
- `go run ./tools/sourcefidelity -json-out work/sourcefidelity-kandji.json -max-items=0`
- `make catalog-check`

## Provider References
- https://api-docs.iru.com/
- https://www.postman.com/ksapitest/kandji-api-support-flows/collection/r796tjz/kandji-api
- https://support.kandji.io/kb/kandji-api
- https://support.kandji.io/kb/prism
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->