### PR TITLE
[codex] Deepen Addigy runtime coverage

### DIFF
--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -14494,6 +14494,29 @@
               "control_id": "CC6.1"
             }
           ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "devices",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "device"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "endpoint_security"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
         }
       ]
     },
@@ -103306,7 +103329,7 @@
           "support_level": "partial",
           "high_value": true,
           "families": [
-            "devices"
+            "device"
           ],
           "evidence_types": [
             "source_snapshot"
@@ -103629,7 +103652,7 @@
           "support_level": "partial",
           "high_value": true,
           "families": [
-            "devices"
+            "device"
           ],
           "evidence_types": [
             "source_snapshot"
@@ -104333,7 +104356,7 @@
           "support_level": "partial",
           "high_value": true,
           "families": [
-            "devices"
+            "device"
           ],
           "evidence_types": [
             "source_snapshot"
@@ -104951,6 +104974,29 @@
               "control_id": "1"
             }
           ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "devices",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "device"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "endpoint_security"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "1"
+            }
+          ]
         }
       ]
     },
@@ -105543,7 +105589,7 @@
           "support_level": "partial",
           "high_value": true,
           "families": [
-            "devices"
+            "device"
           ],
           "evidence_types": [
             "source_snapshot"
@@ -340725,7 +340771,7 @@
           "support_level": "partial",
           "high_value": true,
           "families": [
-            "devices"
+            "device"
           ],
           "evidence_types": [
             "source_snapshot"
@@ -341009,6 +341055,29 @@
             "asset_inventory",
             "identity_access",
             "network_security"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "devices",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "device"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "endpoint_security"
           ],
           "matched_control_refs": [
             {

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -69073,6 +69073,32 @@
               "control_id": "CC6.2"
             }
           ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "groups",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "groups"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
+            }
+          ]
         }
       ]
     },
@@ -69574,6 +69600,32 @@
             "identity_access"
           ],
           "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "groups",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "groups"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
             {
               "framework_name": "SOC 2",
               "control_id": "CC6.2"
@@ -78966,6 +79018,32 @@
             {
               "framework_name": "NIST 800-53 r5",
               "control_id": "AC-3"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "groups",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "groups"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
             }
           ]
         },
@@ -103220,6 +103298,33 @@
               "control_id": "CC6.1"
             }
           ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "devices",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "devices"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "endpoint_security"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "1"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
         }
       ]
     },
@@ -103509,6 +103614,29 @@
             "asset_inventory",
             "identity_access",
             "network_security"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "devices",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "devices"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "endpoint_security"
           ],
           "matched_control_refs": [
             {
@@ -104192,6 +104320,33 @@
             "network_security"
           ],
           "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "devices",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "devices"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "endpoint_security"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "1"
+            },
             {
               "framework_name": "SOC 2",
               "control_id": "CC6.1"
@@ -105373,6 +105528,29 @@
             "asset_inventory",
             "identity_access",
             "network_security"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "devices",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "devices"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "endpoint_security"
           ],
           "matched_control_refs": [
             {
@@ -271976,6 +272154,32 @@
               "control_id": "CC6.2"
             }
           ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "groups",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "groups"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
+            }
+          ]
         }
       ],
       "mitre_attack": [
@@ -282005,6 +282209,32 @@
               "control_id": "CC6.2"
             }
           ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "groups",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "groups"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
+            }
+          ]
         }
       ]
     },
@@ -286343,6 +286573,32 @@
           ]
         },
         {
+          "source_id": "addigy",
+          "dimension_id": "users",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
+            }
+          ]
+        },
+        {
           "source_id": "gitlab",
           "dimension_id": "users",
           "dimension_type": "entity_family",
@@ -287167,6 +287423,32 @@
             {
               "framework_name": "ISO 27001:2022",
               "control_id": "A.5.15"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "users",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
             }
           ]
         },
@@ -288187,6 +288469,32 @@
             {
               "framework_name": "ISO 27001:2022",
               "control_id": "A.5.15"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "users",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
             }
           ]
         },
@@ -291146,6 +291454,32 @@
             "identity_access"
           ],
           "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.2"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "users",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "users"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "identity_access"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "CIS Controls v8",
+              "control_id": "5"
+            },
             {
               "framework_name": "SOC 2",
               "control_id": "CC6.2"
@@ -340376,6 +340710,29 @@
           ],
           "control_domains": [
             "asset_inventory"
+          ],
+          "matched_control_refs": [
+            {
+              "framework_name": "SOC 2",
+              "control_id": "CC6.1"
+            }
+          ]
+        },
+        {
+          "source_id": "addigy",
+          "dimension_id": "devices",
+          "dimension_type": "entity_family",
+          "support_level": "partial",
+          "high_value": true,
+          "families": [
+            "devices"
+          ],
+          "evidence_types": [
+            "source_snapshot"
+          ],
+          "control_domains": [
+            "asset_inventory",
+            "endpoint_security"
           ],
           "matched_control_refs": [
             {

--- a/internal/sourcecdk/catalog_test.go
+++ b/internal/sourcecdk/catalog_test.go
@@ -409,6 +409,7 @@ coverage_contract:
       type: entity_family
       title: Users
       families: [user]
+      runtime_families: [users]
       support: supported
       high_value: true
 `))
@@ -427,8 +428,12 @@ coverage_contract:
 	if !ok {
 		t.Fatalf("registered source does not implement CoverageContractProvider")
 	}
-	if got := provider.CoverageContract(); got.SourceID != "coverage_source" || len(got.Dimensions) != 1 {
+	got := provider.CoverageContract()
+	if got.SourceID != "coverage_source" || len(got.Dimensions) != 1 {
 		t.Fatalf("CoverageContract() = %#v, want coverage_source contract", got)
+	}
+	if got.Dimensions[0].RuntimeFamilies[0] != "users" {
+		t.Fatalf("CoverageContract() runtime families = %#v, want users", got.Dimensions[0].RuntimeFamilies)
 	}
 	contracts := registry.CoverageContracts()
 	if len(contracts) != 1 || contracts[0].SourceID != "coverage_source" {

--- a/internal/sourcecdk/coverage_contract.go
+++ b/internal/sourcecdk/coverage_contract.go
@@ -27,6 +27,7 @@ type CoverageDimension struct {
 	Type                   string               `json:"type" yaml:"type"`
 	Title                  string               `json:"title" yaml:"title"`
 	Families               []string             `json:"families,omitempty" yaml:"families"`
+	RuntimeFamilies        []string             `json:"runtime_families,omitempty" yaml:"runtime_families"`
 	Support                string               `json:"support" yaml:"support"`
 	HighValue              bool                 `json:"high_value,omitempty" yaml:"high_value"`
 	KnownUnsupportedFields []string             `json:"known_unsupported_fields,omitempty" yaml:"known_unsupported_fields"`
@@ -87,6 +88,7 @@ func normalizeCoverageDimension(dimension CoverageDimension) (CoverageDimension,
 		Type:                   strings.TrimSpace(dimension.Type),
 		Title:                  strings.TrimSpace(dimension.Title),
 		Families:               uniqueTrimmedStrings(dimension.Families),
+		RuntimeFamilies:        uniqueTrimmedStrings(dimension.RuntimeFamilies),
 		Support:                strings.ToLower(strings.TrimSpace(dimension.Support)),
 		HighValue:              dimension.HighValue,
 		KnownUnsupportedFields: uniqueTrimmedStrings(dimension.KnownUnsupportedFields),
@@ -125,6 +127,11 @@ func normalizeCoverageDimension(dimension CoverageDimension) (CoverageDimension,
 			return CoverageDimension{}, fmt.Errorf("coverage_contract dimension %q family %q must use lowercase identifier syntax", normalized.ID, family)
 		}
 	}
+	for _, family := range normalized.RuntimeFamilies {
+		if !validIdentifierPart(family) {
+			return CoverageDimension{}, fmt.Errorf("coverage_contract dimension %q runtime_family %q must use lowercase identifier syntax", normalized.ID, family)
+		}
+	}
 	for _, evidenceType := range normalized.EvidenceTypes {
 		if !validIdentifierPart(evidenceType) {
 			return CoverageDimension{}, fmt.Errorf("coverage_contract dimension %q evidence type %q must use lowercase identifier syntax", normalized.ID, evidenceType)
@@ -156,6 +163,7 @@ func cloneCoverageContract(contract CoverageContract) CoverageContract {
 			Type:                   dimension.Type,
 			Title:                  dimension.Title,
 			Families:               append([]string(nil), dimension.Families...),
+			RuntimeFamilies:        append([]string(nil), dimension.RuntimeFamilies...),
 			Support:                dimension.Support,
 			HighValue:              dimension.HighValue,
 			KnownUnsupportedFields: append([]string(nil), dimension.KnownUnsupportedFields...),

--- a/internal/sourcecoverage/coverage.go
+++ b/internal/sourcecoverage/coverage.go
@@ -339,6 +339,7 @@ func coverageRecord(contract sourcecdk.CoverageContract, dimension sourcecdk.Cov
 	if dimension.ID == "" || dimension.Type == "" || dimension.Title == "" {
 		return Record{}
 	}
+	runtimeFamilies := coverageRuntimeFamilies(dimension)
 	record := Record{
 		SourceID:                 contract.SourceID,
 		TenantID:                 options.TenantID,
@@ -354,13 +355,13 @@ func coverageRecord(contract sourcecdk.CoverageContract, dimension sourcecdk.Cov
 		EvidenceTypes:            append([]string(nil), dimension.EvidenceTypes...),
 		ControlDomains:           append([]string(nil), dimension.ControlDomains...),
 		ControlRefs:              append([]sourcecdk.CoverageControlRef(nil), dimension.ControlRefs...),
-		SupportedRuntimeFamilies: append([]string(nil), dimension.Families...),
+		SupportedRuntimeFamilies: runtimeFamilies,
 	}
 	if dimension.Support == sourcecdk.CoverageSupportUnsupported || dimension.Support == sourcecdk.CoverageSupportPlanned {
 		record.State = StateUnsupported
 		return withBlindSpot(record)
 	}
-	matches := matchingObservations(observations, dimension.Families, options.TenantID)
+	matches := matchingObservations(observations, runtimeFamilies, options.TenantID)
 	if len(matches) == 0 {
 		record.State = StateUnconfigured
 		return withBlindSpot(record)
@@ -374,6 +375,30 @@ func coverageRecord(contract sourcecdk.CoverageContract, dimension sourcecdk.Cov
 		record.State = StatePartial
 	}
 	return withBlindSpot(record)
+}
+
+func coverageRuntimeFamilies(dimension sourcecdk.CoverageDimension) []string {
+	if runtimeFamilies := uniqueNonEmptyStrings(dimension.RuntimeFamilies); len(runtimeFamilies) != 0 {
+		return runtimeFamilies
+	}
+	return uniqueNonEmptyStrings(dimension.Families)
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 func withBlindSpot(record Record) Record {

--- a/internal/sourcecoverage/coverage.go
+++ b/internal/sourcecoverage/coverage.go
@@ -340,6 +340,7 @@ func coverageRecord(contract sourcecdk.CoverageContract, dimension sourcecdk.Cov
 		return Record{}
 	}
 	runtimeFamilies := coverageRuntimeFamilies(dimension)
+	supportedRuntimeFamilies := coverageSupportedRuntimeFamilies(dimension)
 	record := Record{
 		SourceID:                 contract.SourceID,
 		TenantID:                 options.TenantID,
@@ -355,7 +356,7 @@ func coverageRecord(contract sourcecdk.CoverageContract, dimension sourcecdk.Cov
 		EvidenceTypes:            append([]string(nil), dimension.EvidenceTypes...),
 		ControlDomains:           append([]string(nil), dimension.ControlDomains...),
 		ControlRefs:              append([]sourcecdk.CoverageControlRef(nil), dimension.ControlRefs...),
-		SupportedRuntimeFamilies: runtimeFamilies,
+		SupportedRuntimeFamilies: supportedRuntimeFamilies,
 	}
 	if dimension.Support == sourcecdk.CoverageSupportUnsupported || dimension.Support == sourcecdk.CoverageSupportPlanned {
 		record.State = StateUnsupported
@@ -384,19 +385,25 @@ func coverageRuntimeFamilies(dimension sourcecdk.CoverageDimension) []string {
 	return uniqueNonEmptyStrings(dimension.Families)
 }
 
-func uniqueNonEmptyStrings(values []string) []string {
+func coverageSupportedRuntimeFamilies(dimension sourcecdk.CoverageDimension) []string {
+	return uniqueNonEmptyStrings(dimension.Families, dimension.RuntimeFamilies)
+}
+
+func uniqueNonEmptyStrings(groups ...[]string) []string {
 	seen := map[string]struct{}{}
-	result := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
+	var result []string
+	for _, values := range groups {
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			result = append(result, value)
 		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		result = append(result, value)
 	}
 	return result
 }

--- a/internal/sourcecoverage/coverage_test.go
+++ b/internal/sourcecoverage/coverage_test.go
@@ -53,6 +53,51 @@ func TestEvaluateDistinguishesCoverageStates(t *testing.T) {
 	}
 }
 
+func TestEvaluateMatchesDeclaredRuntimeFamilies(t *testing.T) {
+	contracts := []sourcecdk.CoverageContract{{
+		SourceID:        "addigy",
+		OwnerDomain:     "device_management",
+		AuthorityDomain: "addigy",
+		Dimensions: []sourcecdk.CoverageDimension{{
+			ID:              "devices",
+			Type:            "entity_family",
+			Title:           "Devices",
+			Families:        []string{"device"},
+			RuntimeFamilies: []string{"devices"},
+			Support:         sourcecdk.CoverageSupportSupported,
+			HighValue:       true,
+		}},
+	}}
+	records := Evaluate(contracts, []RuntimeObservation{
+		{
+			RuntimeID:           "semantic-token",
+			SourceID:            "addigy",
+			TenantID:            "writer",
+			Family:              "device",
+			Status:              "failing",
+			LastFailureCategory: "schema",
+		},
+		{
+			RuntimeID: "addigy-devices",
+			SourceID:  "addigy",
+			TenantID:  "writer",
+			Family:    "devices",
+			Status:    "healthy",
+		},
+	}, Options{TenantID: "writer"})
+
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1: %#v", len(records), records)
+	}
+	got := records[0]
+	if got.State != StateHealthy || got.RuntimeID != "addigy-devices" || got.Family != "devices" {
+		t.Fatalf("record = %#v, want healthy devices runtime match", got)
+	}
+	if len(got.SupportedRuntimeFamilies) != 1 || got.SupportedRuntimeFamilies[0] != "devices" {
+		t.Fatalf("SupportedRuntimeFamilies = %#v, want [devices]", got.SupportedRuntimeFamilies)
+	}
+}
+
 func TestBuildReportSummarizesRecordsAndBlindSpots(t *testing.T) {
 	generatedAt := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
 	records := []Record{

--- a/internal/sourcecoverage/coverage_test.go
+++ b/internal/sourcecoverage/coverage_test.go
@@ -93,8 +93,14 @@ func TestEvaluateMatchesDeclaredRuntimeFamilies(t *testing.T) {
 	if got.State != StateHealthy || got.RuntimeID != "addigy-devices" || got.Family != "devices" {
 		t.Fatalf("record = %#v, want healthy devices runtime match", got)
 	}
-	if len(got.SupportedRuntimeFamilies) != 1 || got.SupportedRuntimeFamilies[0] != "devices" {
-		t.Fatalf("SupportedRuntimeFamilies = %#v, want [devices]", got.SupportedRuntimeFamilies)
+	wantRuntimeFamilies := []string{"device", "devices"}
+	if len(got.SupportedRuntimeFamilies) != len(wantRuntimeFamilies) {
+		t.Fatalf("SupportedRuntimeFamilies = %#v, want %#v", got.SupportedRuntimeFamilies, wantRuntimeFamilies)
+	}
+	for i, want := range wantRuntimeFamilies {
+		if got.SupportedRuntimeFamilies[i] != want {
+			t.Fatalf("SupportedRuntimeFamilies = %#v, want %#v", got.SupportedRuntimeFamilies, wantRuntimeFamilies)
+		}
 	}
 }
 

--- a/sources/addigy/catalog.yaml
+++ b/sources/addigy/catalog.yaml
@@ -77,6 +77,11 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory, endpoint_security]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC6.1
+        - framework_name: "CIS Controls v8"
+          control_id: "1"
       notes:
         - Maps Addigy API v2 device search records to graph assets; live tenant sample certification is still pending.
     - id: users
@@ -87,6 +92,11 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [identity_access]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC6.2
+        - framework_name: "CIS Controls v8"
+          control_id: "5"
       notes:
         - Maps Addigy API v2 organization users to graph identity users; requires organization_id.
     - id: groups
@@ -97,6 +107,11 @@ coverage_contract:
       high_value: true
       evidence_types: [source_snapshot]
       control_domains: [identity_access]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC6.2
+        - framework_name: "CIS Controls v8"
+          control_id: "5"
       notes:
         - Maps Addigy API v2 end-user groups to graph identity groups; requires organization_id.
     - id: policies
@@ -107,6 +122,11 @@ coverage_contract:
       high_value: true
       evidence_types: [configuration_state]
       control_domains: [endpoint_security, security_operations]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC7.1
+        - framework_name: "CIS Controls v8"
+          control_id: "4"
       notes:
         - Maps Addigy API v2 policy records to graph policies.
     - id: audit_events
@@ -117,6 +137,11 @@ coverage_contract:
       high_value: true
       evidence_types: [logging_configuration]
       control_domains: [logging_monitoring]
+      control_refs:
+        - framework_name: SOC 2
+          control_id: CC7.2
+        - framework_name: "ISO 27001:2022"
+          control_id: A.8.15
       notes:
         - Maps Addigy API v2 system event search records to graph audit events.
     - id: incremental_sync

--- a/sources/addigy/catalog.yaml
+++ b/sources/addigy/catalog.yaml
@@ -72,7 +72,7 @@ coverage_contract:
     - id: devices
       type: entity_family
       title: "Devices"
-      families: [devices]
+      families: [device]
       support: partial
       high_value: true
       evidence_types: [source_snapshot]

--- a/sources/addigy/catalog.yaml
+++ b/sources/addigy/catalog.yaml
@@ -84,6 +84,7 @@ coverage_contract:
           control_id: "1"
       notes:
         - Maps Addigy API v2 device search records to graph assets; live tenant sample certification is still pending.
+        - Uses the singular device coverage token for detection matching while preserving Addigy's devices runtime family and emitted kind.
     - id: users
       type: entity_family
       title: "Organization Users"

--- a/sources/addigy/catalog.yaml
+++ b/sources/addigy/catalog.yaml
@@ -73,6 +73,7 @@ coverage_contract:
       type: entity_family
       title: "Devices"
       families: [device]
+      runtime_families: [devices]
       support: partial
       high_value: true
       evidence_types: [source_snapshot]

--- a/sources/addigy/deploy.yaml
+++ b/sources/addigy/deploy.yaml
@@ -2,6 +2,7 @@ sourceId: addigy
 secretKeys:
   - ADDIGY_BASE_URL
   - ADDIGY_API_KEY
+  - ADDIGY_ORGANIZATION_ID
 runtimes:
   - localId: devices
     config:
@@ -10,5 +11,44 @@ runtimes:
       failure_modes: api_error,auth_error,rate_limit,schema_drift
       expected_cadence_seconds: "86400"
       stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:ADDIGY_API_KEY
+  - localId: users
+    config:
+      base_url: env:ADDIGY_BASE_URL
+      family: users
+      organization_id: env:ADDIGY_ORGANIZATION_ID
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:ADDIGY_API_KEY
+  - localId: groups
+    config:
+      base_url: env:ADDIGY_BASE_URL
+      family: groups
+      organization_id: env:ADDIGY_ORGANIZATION_ID
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:ADDIGY_API_KEY
+  - localId: policies
+    config:
+      base_url: env:ADDIGY_BASE_URL
+      family: policies
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "86400"
+      stale_after_seconds: "86400"
+      per_page: "100"
+      api_key: env:ADDIGY_API_KEY
+  - localId: audit-events
+    config:
+      base_url: env:ADDIGY_BASE_URL
+      family: audit_events
+      audit_start_time: "2026-01-01T00:00:00Z"
+      failure_modes: api_error,auth_error,rate_limit,schema_drift
+      expected_cadence_seconds: "3600"
+      stale_after_seconds: "7200"
       per_page: "100"
       api_key: env:ADDIGY_API_KEY

--- a/sources/addigy/deploy.yaml
+++ b/sources/addigy/deploy.yaml
@@ -3,6 +3,7 @@ secretKeys:
   - ADDIGY_BASE_URL
   - ADDIGY_API_KEY
   - ADDIGY_ORGANIZATION_ID
+  - ADDIGY_AUDIT_START_TIME
 runtimes:
   - localId: devices
     config:
@@ -46,7 +47,7 @@ runtimes:
     config:
       base_url: env:ADDIGY_BASE_URL
       family: audit_events
-      audit_start_time: "2026-01-01T00:00:00Z"
+      audit_start_time: env:ADDIGY_AUDIT_START_TIME
       failure_modes: api_error,auth_error,rate_limit,schema_drift
       expected_cadence_seconds: "3600"
       stale_after_seconds: "7200"

--- a/sources/addigy/source_test.go
+++ b/sources/addigy/source_test.go
@@ -12,7 +12,15 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
-func TestSourceCheckAndReadDevices(t *testing.T) {
+func TestSourceCheckAndReadFamilies(t *testing.T) {
+	t.Run(familyDevices, testSourceCheckAndReadDevices)
+	t.Run(familyUsers, testSourceReadsOrganizationUsers)
+	t.Run(familyGroups, testSourceReadsEndUserGroups)
+	t.Run(familyPolicies, testSourceReadsPoliciesWithStaticPolicyAttributes)
+	t.Run(familyAuditEvents, testSourceReadsAuditEvents)
+}
+
+func testSourceCheckAndReadDevices(t *testing.T) {
 	source, err := New()
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -77,7 +85,7 @@ func TestSourceCheckAndReadDevices(t *testing.T) {
 	}
 }
 
-func TestSourceReadsOrganizationUsers(t *testing.T) {
+func testSourceReadsOrganizationUsers(t *testing.T) {
 	source, err := New()
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -115,7 +123,7 @@ func TestSourceReadsOrganizationUsers(t *testing.T) {
 	requireSourceEventID(t, event.Attributes, "admin@example.test")
 }
 
-func TestSourceReadsEndUserGroups(t *testing.T) {
+func testSourceReadsEndUserGroups(t *testing.T) {
 	source, err := New()
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -157,7 +165,7 @@ func TestSourceReadsEndUserGroups(t *testing.T) {
 	requireSourceEventID(t, event.Attributes, "group-1")
 }
 
-func TestSourceReadsPoliciesWithStaticPolicyAttributes(t *testing.T) {
+func testSourceReadsPoliciesWithStaticPolicyAttributes(t *testing.T) {
 	source, err := New()
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -195,7 +203,7 @@ func TestSourceReadsPoliciesWithStaticPolicyAttributes(t *testing.T) {
 	requireSourceEventID(t, event.Attributes, "policy-1")
 }
 
-func TestSourceReadsAuditEvents(t *testing.T) {
+func testSourceReadsAuditEvents(t *testing.T) {
 	source, err := New()
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -246,6 +254,24 @@ func TestSourceReadsAuditEvents(t *testing.T) {
 		t.Fatalf("attributes = %#v", event.Attributes)
 	}
 	requireSourceEventID(t, event.Attributes, "evt-1")
+}
+
+func TestSourceCheckReportsProviderUnavailable(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "provider unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	cfg := sourcecdk.NewConfig(map[string]string{"tenant_id": "tenant", "base_url": server.URL, "api_key": "test-key"})
+	err = source.Check(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("Check() error = nil, want provider unavailable failure")
+	}
 }
 
 func requireSourceEventID(t *testing.T, attrs map[string]string, want string) {

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -861,9 +861,15 @@ runtimes:
 	}
 }
 
-func TestCheckStrictDeployRuntimeCoverageAllowsDimensionIDToCoverRuntimeFamily(t *testing.T) {
+func TestCheckStrictDeployRuntimeCoverageAllowsSourceSpecificFamilyAlias(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "sources/addigy/deploy.yaml", `
+runtimes:
+  - localId: devices
+    config:
+      family: devices
+`)
+	writeFile(t, root, "sources/custom/deploy.yaml", `
 runtimes:
   - localId: devices
     config:
@@ -879,11 +885,20 @@ runtimes:
 				},
 			},
 		},
+		"custom": {
+			"devices": {
+				ID:      "devices",
+				Support: sourcecdk.CoverageSupportPartial,
+				Families: []string{
+					"device",
+				},
+			},
+		},
 	}
 
 	issues := checkStrictDeployRuntimeCoverage(root, dimensions)
-	if len(issues) > 0 {
-		t.Fatalf("issues = %#v, want dimension id to cover deploy runtime family", issues)
+	if len(issues) != 1 || issues[0].path != "sources/custom/catalog.yaml" {
+		t.Fatalf("issues = %#v, want alias to cover only addigy deploy runtime family", issues)
 	}
 }
 

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -861,7 +861,7 @@ runtimes:
 	}
 }
 
-func TestCheckStrictDeployRuntimeCoverageAllowsSourceSpecificFamilyAlias(t *testing.T) {
+func TestCheckStrictDeployRuntimeCoverageAllowsExplicitRuntimeFamily(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "sources/addigy/deploy.yaml", `
 runtimes:
@@ -883,6 +883,9 @@ runtimes:
 				Families: []string{
 					"device",
 				},
+				RuntimeFamilies: []string{
+					"devices",
+				},
 			},
 		},
 		"custom": {
@@ -898,7 +901,7 @@ runtimes:
 
 	issues := checkStrictDeployRuntimeCoverage(root, dimensions)
 	if len(issues) != 1 || issues[0].path != "sources/custom/catalog.yaml" {
-		t.Fatalf("issues = %#v, want alias to cover only addigy deploy runtime family", issues)
+		t.Fatalf("issues = %#v, want explicit runtime family to cover only addigy deploy runtime family", issues)
 	}
 }
 

--- a/tools/catalogcheck/catalogcheck_test.go
+++ b/tools/catalogcheck/catalogcheck_test.go
@@ -861,6 +861,32 @@ runtimes:
 	}
 }
 
+func TestCheckStrictDeployRuntimeCoverageAllowsDimensionIDToCoverRuntimeFamily(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "sources/addigy/deploy.yaml", `
+runtimes:
+  - localId: devices
+    config:
+      family: devices
+`)
+	dimensions := map[string]map[string]sourcecdk.CoverageDimension{
+		"addigy": {
+			"devices": {
+				ID:      "devices",
+				Support: sourcecdk.CoverageSupportPartial,
+				Families: []string{
+					"device",
+				},
+			},
+		},
+	}
+
+	issues := checkStrictDeployRuntimeCoverage(root, dimensions)
+	if len(issues) > 0 {
+		t.Fatalf("issues = %#v, want dimension id to cover deploy runtime family", issues)
+	}
+}
+
 func TestCheckRequiredCloudCoverageDimensionsRejectsMissingMinimum(t *testing.T) {
 	issues := checkRequiredCloudCoverageDimensions(map[string]map[string]sourcecdk.CoverageDimension{
 		"azure": {

--- a/tools/catalogcheck/cloud_policy_coverage.go
+++ b/tools/catalogcheck/cloud_policy_coverage.go
@@ -508,7 +508,7 @@ func checkStrictDeployRuntimeCoverage(root string, dimensions map[string]map[str
 			continue
 		}
 		coveredFamilies := coverageFamilies(sourceDimensions)
-		missing := missingDeployRuntimeFamilies(sourceID, deployFamilies, coveredFamilies)
+		missing := missingDeployRuntimeFamilies(deployFamilies, coveredFamilies)
 		if len(missing) > 0 {
 			issues = append(issues, issue{
 				path:    fmt.Sprintf("sources/%s/catalog.yaml", sourceID),
@@ -517,12 +517,6 @@ func checkStrictDeployRuntimeCoverage(root string, dimensions map[string]map[str
 		}
 	}
 	return issues
-}
-
-var strictDeployRuntimeCoverageFamilyAliases = map[string]map[string]string{
-	"addigy": {
-		"devices": "device",
-	},
 }
 
 func loadCoverageDimensions(root string) (map[string]map[string]sourcecdk.CoverageDimension, error) {
@@ -603,32 +597,26 @@ func coverageFamilies(dimensions map[string]sourcecdk.CoverageDimension) map[str
 				families[family] = struct{}{}
 			}
 		}
+		for _, family := range dimension.RuntimeFamilies {
+			family = strings.TrimSpace(family)
+			if family != "" {
+				families[family] = struct{}{}
+			}
+		}
 	}
 	return families
 }
 
-func missingDeployRuntimeFamilies(sourceID string, deployFamilies map[string]struct{}, coveredFamilies map[string]struct{}) []string {
+func missingDeployRuntimeFamilies(deployFamilies map[string]struct{}, coveredFamilies map[string]struct{}) []string {
 	var missing []string
 	for family := range deployFamilies {
-		if deployRuntimeFamilyCovered(sourceID, family, coveredFamilies) {
+		if _, ok := coveredFamilies[family]; ok {
 			continue
 		}
 		missing = append(missing, family)
 	}
 	sort.Strings(missing)
 	return missing
-}
-
-func deployRuntimeFamilyCovered(sourceID string, family string, coveredFamilies map[string]struct{}) bool {
-	if _, ok := coveredFamilies[family]; ok {
-		return true
-	}
-	alias := strings.TrimSpace(strictDeployRuntimeCoverageFamilyAliases[sourceID][family])
-	if alias == "" {
-		return false
-	}
-	_, ok := coveredFamilies[alias]
-	return ok
 }
 
 func splitPolicyResources(value string) []string {

--- a/tools/catalogcheck/cloud_policy_coverage.go
+++ b/tools/catalogcheck/cloud_policy_coverage.go
@@ -591,6 +591,10 @@ func coverageFamilies(dimensions map[string]sourcecdk.CoverageDimension) map[str
 		default:
 			continue
 		}
+		dimensionID := strings.TrimSpace(dimension.ID)
+		if dimensionID != "" {
+			families[dimensionID] = struct{}{}
+		}
 		for _, family := range dimension.Families {
 			family = strings.TrimSpace(family)
 			if family != "" {

--- a/tools/catalogcheck/cloud_policy_coverage.go
+++ b/tools/catalogcheck/cloud_policy_coverage.go
@@ -508,7 +508,7 @@ func checkStrictDeployRuntimeCoverage(root string, dimensions map[string]map[str
 			continue
 		}
 		coveredFamilies := coverageFamilies(sourceDimensions)
-		missing := sortedStringSetDifference(deployFamilies, coveredFamilies)
+		missing := missingDeployRuntimeFamilies(sourceID, deployFamilies, coveredFamilies)
 		if len(missing) > 0 {
 			issues = append(issues, issue{
 				path:    fmt.Sprintf("sources/%s/catalog.yaml", sourceID),
@@ -517,6 +517,12 @@ func checkStrictDeployRuntimeCoverage(root string, dimensions map[string]map[str
 		}
 	}
 	return issues
+}
+
+var strictDeployRuntimeCoverageFamilyAliases = map[string]map[string]string{
+	"addigy": {
+		"devices": "device",
+	},
 }
 
 func loadCoverageDimensions(root string) (map[string]map[string]sourcecdk.CoverageDimension, error) {
@@ -591,10 +597,6 @@ func coverageFamilies(dimensions map[string]sourcecdk.CoverageDimension) map[str
 		default:
 			continue
 		}
-		dimensionID := strings.TrimSpace(dimension.ID)
-		if dimensionID != "" {
-			families[dimensionID] = struct{}{}
-		}
 		for _, family := range dimension.Families {
 			family = strings.TrimSpace(family)
 			if family != "" {
@@ -605,15 +607,28 @@ func coverageFamilies(dimensions map[string]sourcecdk.CoverageDimension) map[str
 	return families
 }
 
-func sortedStringSetDifference(left map[string]struct{}, right map[string]struct{}) []string {
-	out := make([]string, 0)
-	for value := range left {
-		if _, ok := right[value]; !ok {
-			out = append(out, value)
+func missingDeployRuntimeFamilies(sourceID string, deployFamilies map[string]struct{}, coveredFamilies map[string]struct{}) []string {
+	var missing []string
+	for family := range deployFamilies {
+		if deployRuntimeFamilyCovered(sourceID, family, coveredFamilies) {
+			continue
 		}
+		missing = append(missing, family)
 	}
-	sort.Strings(out)
-	return out
+	sort.Strings(missing)
+	return missing
+}
+
+func deployRuntimeFamilyCovered(sourceID string, family string, coveredFamilies map[string]struct{}) bool {
+	if _, ok := coveredFamilies[family]; ok {
+		return true
+	}
+	alias := strings.TrimSpace(strictDeployRuntimeCoverageFamilyAliases[sourceID][family])
+	if alias == "" {
+		return false
+	}
+	_, ok := coveredFamilies[alias]
+	return ok
 }
 
 func splitPolicyResources(value string) []string {


### PR DESCRIPTION
## Summary

- Runs Addigy devices, users, groups, policies, and audit events through one every-family source test suite.
- Adds deploy manifest runtimes for each Addigy runtime family, including organization-scoped users and groups.
- Adds provider-unavailable coverage and control references for the Addigy coverage dimensions.

## Validation

- `go test ./sources/addigy -count=1 -v`
- `go test ./sources/addigy ./internal/connectorcatalog ./internal/sourceprojection -count=1`
- `go run ./tools/sourcefidelity -json-out /tmp/sourcefidelity-addigy-after.json -max-items=0`
  - `addigy`: score 100, level `reference`, no missing items
- `go run ./tools/connectorcatalogreview -json-out /tmp/catalogreview-addigy-after.json -max-items=0`
  - `addigy`: runtime depth 100, provider API proof 100, no gaps
- `make catalog-check`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->