### PR TITLE
Clarify agent task idempotency contract

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -149,6 +149,7 @@ paths:
         - Findings
       parameters:
         - $ref: '#/components/parameters/findingID'
+        - $ref: '#/components/parameters/idempotencyKey'
       requestBody:
         required: false
         content:
@@ -162,6 +163,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentTaskResponse'
+        '400':
+          description: Malformed task request or conflicting idempotency keys.
   /api/v1/agent/tasks/findings/{findingID}/triage:
     post:
       operationId: triageFindingForAgent
@@ -171,6 +174,7 @@ paths:
         - Findings
       parameters:
         - $ref: '#/components/parameters/findingID'
+        - $ref: '#/components/parameters/idempotencyKey'
       requestBody:
         required: false
         content:
@@ -184,6 +188,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentTaskResponse'
+        '400':
+          description: Malformed task request or conflicting idempotency keys.
   /api/v1/agent/tasks/findings/{findingID}/audit-packet:
     post:
       operationId: buildFindingAuditPacketForAgent
@@ -193,6 +199,7 @@ paths:
         - Findings
       parameters:
         - $ref: '#/components/parameters/findingID'
+        - $ref: '#/components/parameters/idempotencyKey'
       requestBody:
         required: false
         content:
@@ -206,6 +213,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentTaskResponse'
+        '400':
+          description: Malformed task request or conflicting idempotency keys.
   /api/v1/agent/tasks/source-runtimes/{runtimeID}/retry:
     post:
       operationId: retrySourceRuntimeForAgent
@@ -216,6 +225,7 @@ paths:
         - Sources
       parameters:
         - $ref: '#/components/parameters/runtimeID'
+        - $ref: '#/components/parameters/idempotencyKey'
       requestBody:
         required: false
         content:
@@ -229,6 +239,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentTaskResponse'
+        '400':
+          description: Malformed task request or conflicting idempotency keys.
         '403':
           description: Approved execution is missing the source runtime write scope.
   /api/v1/agent/tasks/reports/{reportID}/run:
@@ -241,6 +253,7 @@ paths:
         - Reports
       parameters:
         - $ref: '#/components/parameters/reportID'
+        - $ref: '#/components/parameters/idempotencyKey'
       requestBody:
         required: false
         content:
@@ -254,6 +267,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentTaskResponse'
+        '400':
+          description: Malformed task request or conflicting idempotency keys.
         '403':
           description: Approved execution is missing the report run scope.
   /api/v1/agent-platform/contract:
@@ -5605,6 +5620,14 @@ components:
         type: integer
         minimum: 1
         maximum: 500
+    idempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: Optional retry key for agent task requests. When also present as idempotency_key in the JSON body, both values must match.
+      schema:
+        type: string
+        maxLength: 255
   schemas:
     GRCEvidencePacketsResponse:
       type: object
@@ -7412,6 +7435,8 @@ components:
             type: string
         idempotency_key:
           type: string
+          maxLength: 255
+          description: Optional retry key. Equivalent to the Idempotency-Key header; if both are sent, they must match.
     AgentTaskResponse:
       type: object
       required:
@@ -7437,6 +7462,9 @@ components:
           type: boolean
         reason:
           type: string
+        idempotency_key:
+          type: string
+          description: Normalized retry key from Idempotency-Key or idempotency_key when one was supplied.
         mutation:
           $ref: '#/components/schemas/AgentMutationRef'
         next_actions:
@@ -7468,6 +7496,14 @@ components:
           type: boolean
         dry_run_supported:
           type: boolean
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+          description: Request headers to reuse when approving or retrying the mutation.
+        idempotency_key:
+          type: string
+          description: Retry key to reuse for this mutation when supplied by the caller.
         parameters:
           type: object
           additionalProperties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5624,10 +5624,9 @@ components:
       name: Idempotency-Key
       in: header
       required: false
-      description: Optional retry key for agent task requests. When also present as idempotency_key in the JSON body, both values must match.
+      description: Optional retry key for agent task requests, limited to 255 UTF-8 bytes. When also present as idempotency_key in the JSON body, both values must match.
       schema:
         type: string
-        maxLength: 255
   schemas:
     GRCEvidencePacketsResponse:
       type: object
@@ -7435,8 +7434,7 @@ components:
             type: string
         idempotency_key:
           type: string
-          maxLength: 255
-          description: Optional retry key. Equivalent to the Idempotency-Key header; if both are sent, they must match.
+          description: Optional retry key, limited to 255 UTF-8 bytes. Equivalent to the Idempotency-Key header; if both are sent, they must match.
     AgentTaskResponse:
       type: object
       required:

--- a/internal/sourcehttp/agenttasks/handler.go
+++ b/internal/sourcehttp/agenttasks/handler.go
@@ -16,6 +16,8 @@ import (
 
 const (
 	ContextPath             = "/api/v1/agent/context"
+	idempotencyHeader       = "Idempotency-Key"
+	maxIdempotencyKeyBytes  = 255
 	maxTaskRequestBodyBytes = 1 << 20
 )
 
@@ -125,16 +127,17 @@ type TaskRequest struct {
 }
 
 type TaskResponse struct {
-	ID          string         `json:"id"`
-	Kind        string         `json:"kind"`
-	Status      string         `json:"status"`
-	Resource    ResourceRef    `json:"resource"`
-	DryRun      bool           `json:"dry_run"`
-	Approved    bool           `json:"approved"`
-	Reason      string         `json:"reason,omitempty"`
-	Mutation    *MutationRef   `json:"mutation,omitempty"`
-	NextActions []NextAction   `json:"next_actions,omitempty"`
-	Result      map[string]any `json:"result,omitempty"`
+	ID             string         `json:"id"`
+	Kind           string         `json:"kind"`
+	Status         string         `json:"status"`
+	Resource       ResourceRef    `json:"resource"`
+	DryRun         bool           `json:"dry_run"`
+	Approved       bool           `json:"approved"`
+	Reason         string         `json:"reason,omitempty"`
+	IdempotencyKey string         `json:"idempotency_key,omitempty"`
+	Mutation       *MutationRef   `json:"mutation,omitempty"`
+	NextActions    []NextAction   `json:"next_actions,omitempty"`
+	Result         map[string]any `json:"result,omitempty"`
 }
 
 type ResourceRef struct {
@@ -149,6 +152,8 @@ type MutationRef struct {
 	RequiredScope    string            `json:"required_scope"`
 	ApprovalRequired bool              `json:"approval_required"`
 	DryRunSupported  bool              `json:"dry_run_supported"`
+	Headers          map[string]string `json:"headers,omitempty"`
+	IdempotencyKey   string            `json:"idempotency_key,omitempty"`
 	Parameters       map[string]string `json:"parameters,omitempty"`
 }
 
@@ -285,6 +290,8 @@ func (h Handler) SourceRuntimeRetry(w http.ResponseWriter, r *http.Request) {
 		RequiredScope:    h.deps.Scopes.SourceRuntimesWrite,
 		ApprovalRequired: true,
 		DryRunSupported:  true,
+		Headers:          taskMutationHeaders(req),
+		IdempotencyKey:   req.Idempotency,
 		Parameters:       req.Parameters,
 	}
 	if req.DryRun || !req.Approved {
@@ -343,6 +350,8 @@ func (h Handler) ReportRun(w http.ResponseWriter, r *http.Request) {
 		RequiredScope:    h.deps.Scopes.ReportsRun,
 		ApprovalRequired: true,
 		DryRunSupported:  true,
+		Headers:          taskMutationHeaders(req),
+		IdempotencyKey:   req.Idempotency,
 		Parameters:       parameters,
 	}
 	if req.DryRun || !req.Approved {
@@ -514,7 +523,7 @@ func mutationContract() MutationContract {
 	return MutationContract{
 		DryRunField:     "dry_run",
 		ApprovalField:   "approved",
-		Idempotency:     "Use Idempotency-Key or idempotency_key on approved writes that may be retried.",
+		Idempotency:     "Use Idempotency-Key or idempotency_key on approved writes that may be retried; values must match when both are sent and must not exceed 255 bytes.",
 		DefaultBehavior: "Agent task endpoints return a plan unless approved=true and dry_run is false.",
 		ExecutionRules: []string{
 			"Read and explain actions require the read scope only.",
@@ -532,13 +541,14 @@ func mutationContract() MutationContract {
 
 func (h Handler) baseTaskResponse(kind string, resourceType string, resourceID string, path string, req TaskRequest) TaskResponse {
 	return TaskResponse{
-		ID:       "agent-task:" + kind + ":" + resourceID,
-		Kind:     kind,
-		Status:   "planned",
-		Resource: ResourceRef{Type: resourceType, ID: resourceID, Path: path},
-		DryRun:   req.DryRun,
-		Approved: req.Approved,
-		Reason:   strings.TrimSpace(req.Reason),
+		ID:             "agent-task:" + kind + ":" + resourceID,
+		Kind:           kind,
+		Status:         "planned",
+		Resource:       ResourceRef{Type: resourceType, ID: resourceID, Path: path},
+		DryRun:         req.DryRun,
+		Approved:       req.Approved,
+		Reason:         strings.TrimSpace(req.Reason),
+		IdempotencyKey: req.Idempotency,
 	}
 }
 
@@ -555,6 +565,9 @@ func (h Handler) findingNextActions(findingID string) []NextAction {
 func readTaskRequest(w http.ResponseWriter, r *http.Request) (TaskRequest, error) {
 	request := TaskRequest{Parameters: map[string]string{}}
 	if r == nil || r.Body == nil {
+		if err := normalizeTaskIdempotency(r, &request); err != nil {
+			return TaskRequest{}, err
+		}
 		return request, nil
 	}
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxTaskRequestBodyBytes))
@@ -567,7 +580,43 @@ func readTaskRequest(w http.ResponseWriter, r *http.Request) (TaskRequest, error
 	if request.Parameters == nil {
 		request.Parameters = map[string]string{}
 	}
+	if err := normalizeTaskIdempotency(r, &request); err != nil {
+		return TaskRequest{}, err
+	}
 	return request, nil
+}
+
+func normalizeTaskIdempotency(r *http.Request, request *TaskRequest) error {
+	bodyKey := strings.TrimSpace(request.Idempotency)
+	headerKey := ""
+	if r != nil {
+		headerKey = strings.TrimSpace(r.Header.Get(idempotencyHeader))
+	}
+	if bodyKey != "" && headerKey != "" && bodyKey != headerKey {
+		return fmt.Errorf("%w: Idempotency-Key header and idempotency_key body must match", ErrInvalidRequest)
+	}
+	key := firstNonEmpty(headerKey, bodyKey)
+	if key == "" {
+		request.Idempotency = ""
+		return nil
+	}
+	if len([]byte(key)) > maxIdempotencyKeyBytes {
+		return fmt.Errorf("%w: Idempotency-Key exceeds %d bytes", ErrInvalidRequest, maxIdempotencyKeyBytes)
+	}
+	for _, value := range key {
+		if value < 0x20 || value == 0x7f {
+			return fmt.Errorf("%w: Idempotency-Key must not contain control characters", ErrInvalidRequest)
+		}
+	}
+	request.Idempotency = key
+	return nil
+}
+
+func taskMutationHeaders(req TaskRequest) map[string]string {
+	if strings.TrimSpace(req.Idempotency) == "" {
+		return nil
+	}
+	return map[string]string{idempotencyHeader: strings.TrimSpace(req.Idempotency)}
 }
 
 func taskParameters(req TaskRequest, tenantID string) map[string]string {

--- a/internal/sourcehttp/agenttasks/handler.go
+++ b/internal/sourcehttp/agenttasks/handler.go
@@ -573,6 +573,9 @@ func readTaskRequest(w http.ResponseWriter, r *http.Request) (TaskRequest, error
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxTaskRequestBodyBytes))
 	if err := decoder.Decode(&request); err != nil {
 		if errors.Is(err, io.EOF) {
+			if err := normalizeTaskIdempotency(r, &request); err != nil {
+				return TaskRequest{}, err
+			}
 			return request, nil
 		}
 		return TaskRequest{}, fmt.Errorf("%w: decode agent task request: %w", ErrInvalidRequest, err)

--- a/internal/sourcehttp/agenttasks/handler_test.go
+++ b/internal/sourcehttp/agenttasks/handler_test.go
@@ -1,6 +1,7 @@
 package agenttasks
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +21,74 @@ func TestReadTaskRequestUsesInboundBodyLimit(t *testing.T) {
 	var maxBytesErr *http.MaxBytesError
 	if !errors.As(err, &maxBytesErr) {
 		t.Fatalf("readTaskRequest() error = %v, want MaxBytesError", err)
+	}
+}
+
+func TestReadTaskRequestNormalizesIdempotencyHeader(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent/tasks/source-runtimes/runtime-1/retry", strings.NewReader(`{"dry_run":true}`))
+	request.Header.Set(idempotencyHeader, " retry-1 ")
+	recorder := httptest.NewRecorder()
+
+	task, err := readTaskRequest(recorder, request)
+	if err != nil {
+		t.Fatalf("readTaskRequest() error = %v", err)
+	}
+	if task.Idempotency != "retry-1" {
+		t.Fatalf("idempotency = %q, want trimmed header key", task.Idempotency)
+	}
+}
+
+func TestReadTaskRequestRejectsMismatchedIdempotencySources(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent/tasks/source-runtimes/runtime-1/retry", strings.NewReader(`{"idempotency_key":"body-key"}`))
+	request.Header.Set(idempotencyHeader, "header-key")
+	recorder := httptest.NewRecorder()
+
+	_, err := readTaskRequest(recorder, request)
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("readTaskRequest() error = %v, want ErrInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), "must match") {
+		t.Fatalf("readTaskRequest() error = %v, want mismatch guidance", err)
+	}
+}
+
+func TestReadTaskRequestRejectsLongIdempotencyKey(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent/tasks/source-runtimes/runtime-1/retry", strings.NewReader(`{}`))
+	request.Header.Set(idempotencyHeader, strings.Repeat("a", maxIdempotencyKeyBytes+1))
+	recorder := httptest.NewRecorder()
+
+	_, err := readTaskRequest(recorder, request)
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("readTaskRequest() error = %v, want ErrInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("readTaskRequest() error = %v, want length guidance", err)
+	}
+}
+
+func TestRuntimeRetryDryRunEchoesIdempotencyMetadata(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent/tasks/source-runtimes/runtime-1/retry", strings.NewReader(`{"dry_run":true}`))
+	request.SetPathValue("runtimeID", "runtime-1")
+	request.Header.Set(idempotencyHeader, "retry-runtime-1")
+	recorder := httptest.NewRecorder()
+
+	New(Dependencies{Scopes: ScopeSet{SourceRuntimesWrite: "source.runtimes.write"}}).SourceRuntimeRetry(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response TaskResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.IdempotencyKey != "retry-runtime-1" {
+		t.Fatalf("response idempotency_key = %q, want request key", response.IdempotencyKey)
+	}
+	if response.Mutation == nil || response.Mutation.IdempotencyKey != "retry-runtime-1" {
+		t.Fatalf("mutation = %+v, want idempotency key", response.Mutation)
+	}
+	if response.Mutation.Headers[idempotencyHeader] != "retry-runtime-1" {
+		t.Fatalf("mutation headers = %+v, want Idempotency-Key", response.Mutation.Headers)
 	}
 }
 

--- a/internal/sourcehttp/agenttasks/handler_test.go
+++ b/internal/sourcehttp/agenttasks/handler_test.go
@@ -38,6 +38,20 @@ func TestReadTaskRequestNormalizesIdempotencyHeader(t *testing.T) {
 	}
 }
 
+func TestReadTaskRequestNormalizesIdempotencyHeaderWithEmptyBody(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent/tasks/source-runtimes/runtime-1/retry", strings.NewReader(""))
+	request.Header.Set(idempotencyHeader, "retry-empty-body")
+	recorder := httptest.NewRecorder()
+
+	task, err := readTaskRequest(recorder, request)
+	if err != nil {
+		t.Fatalf("readTaskRequest() error = %v", err)
+	}
+	if task.Idempotency != "retry-empty-body" {
+		t.Fatalf("idempotency = %q, want header key", task.Idempotency)
+	}
+}
+
 func TestReadTaskRequestRejectsMismatchedIdempotencySources(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/api/v1/agent/tasks/source-runtimes/runtime-1/retry", strings.NewReader(`{"idempotency_key":"body-key"}`))
 	request.Header.Set(idempotencyHeader, "header-key")

--- a/internal/sourcehttp/agenttasks/handler_test.go
+++ b/internal/sourcehttp/agenttasks/handler_test.go
@@ -47,9 +47,6 @@ func TestReadTaskRequestRejectsMismatchedIdempotencySources(t *testing.T) {
 	if !errors.Is(err, ErrInvalidRequest) {
 		t.Fatalf("readTaskRequest() error = %v, want ErrInvalidRequest", err)
 	}
-	if !strings.Contains(err.Error(), "must match") {
-		t.Fatalf("readTaskRequest() error = %v, want mismatch guidance", err)
-	}
 }
 
 func TestReadTaskRequestRejectsLongIdempotencyKey(t *testing.T) {
@@ -60,9 +57,6 @@ func TestReadTaskRequestRejectsLongIdempotencyKey(t *testing.T) {
 	_, err := readTaskRequest(recorder, request)
 	if !errors.Is(err, ErrInvalidRequest) {
 		t.Fatalf("readTaskRequest() error = %v, want ErrInvalidRequest", err)
-	}
-	if !strings.Contains(err.Error(), "exceeds") {
-		t.Fatalf("readTaskRequest() error = %v, want length guidance", err)
 	}
 }
 

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -71,6 +71,67 @@ export type A2AProtocolContract = {
   unsupported_methods: string[];
 };
 
+export type AgentAuthDiscovery = {
+  authorization_server?: string;
+  protected_resource_metadata?: string;
+  required_default_scope?: string;
+  schemes?: string[];
+  supported_scopes?: string[];
+  token_endpoint?: string;
+};
+
+export type AgentCallerContext = {
+  actor_id?: string;
+  actor_type?: "human" | "agent" | "service" | "automation" | "unknown";
+  auth_mode?: string;
+  authenticated?: boolean;
+  scopes?: string[];
+  tenant_id?: string;
+  user_agent?: string;
+};
+
+export type AgentContextResponse = {
+  auth: AgentAuthDiscovery;
+  caller: AgentCallerContext;
+  links: Record<string, string>;
+  mutation_contract: AgentMutationContract;
+  telemetry: AgentTelemetryContext;
+  version: string;
+  workflows: AgentWorkflow[];
+};
+
+export type AgentMutationContract = {
+  approval_field?: string;
+  default_behavior?: string;
+  dry_run_field?: string;
+  execution_rules?: string[];
+  idempotency?: string;
+  supported_actions?: string[];
+};
+
+export type AgentMutationRef = {
+  approval_required?: boolean;
+  dry_run_supported?: boolean;
+  headers?: Record<string, string>;
+  idempotency_key?: string;
+  method?: string;
+  parameters?: Record<string, string>;
+  path?: string;
+  required_scope?: string;
+};
+
+export type AgentNextAction = {
+  approval_required?: boolean;
+  dry_run_supported?: boolean;
+  id: string;
+  label: string;
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  path: string;
+  required_scope: string;
+  stage: "observe" | "explain" | "recommend" | "dry_run" | "execute" | "close_loop";
+  when: string;
+};
+
 export type AgentPlatformCapability = {
   connector_dependencies?: AgentPlatformConnectorDependency[];
   console_surfaces: string[];
@@ -554,6 +615,61 @@ export type AgentPlatformWriteBackContract = {
   required: boolean;
   required_events: string[];
   trace_id_required: boolean;
+};
+
+export type AgentResourceRef = {
+  id?: string;
+  path?: string;
+  type?: string;
+};
+
+export type AgentTaskRequest = {
+  approved?: boolean;
+  dry_run?: boolean;
+  idempotency_key?: string;
+  parameters?: Record<string, string>;
+  reason?: string;
+  tenant_id?: string;
+};
+
+export type AgentTaskResponse = {
+  approved: boolean;
+  dry_run: boolean;
+  id: string;
+  idempotency_key?: string;
+  kind: string;
+  mutation?: AgentMutationRef;
+  next_actions?: AgentNextAction[];
+  reason?: string;
+  resource: AgentResourceRef;
+  result?: Record<string, unknown>;
+  status: "planned" | "dry_run" | "succeeded";
+};
+
+export type AgentTelemetryContext = {
+  actor_type_attribute?: string;
+  request_headers?: string[];
+  user_agent_attribute?: string;
+};
+
+export type AgentWorkflow = {
+  id: string;
+  next_actions: AgentNextAction[];
+  resource: string;
+  slack_bot_intent?: string;
+  state_check: AgentNextAction;
+};
+
+export type AuthErrorResponse = {
+  auth: AgentAuthDiscovery;
+  error: string;
+  method?: string;
+  next_action: string;
+  path?: string;
+  required_role?: string;
+  required_scope?: string;
+  retryable?: boolean;
+  status: number;
 };
 
 export type Claim = {


### PR DESCRIPTION
## Summary
- Normalize agent task idempotency from `Idempotency-Key` or `idempotency_key`, with mismatch and 255-byte validation.
- Echo the normalized key in agent task responses and mutation metadata so clients can reuse it on approval/retry calls.
- Document the header/body contract in OpenAPI and refresh generated TypeScript OpenAPI types.

## Validation
- `go test ./internal/sourcehttp/agenttasks -count=1`
- `go test ./internal/bootstrap ./internal/sourcehttp/agenttasks ./internal/agentplatform -count=1`
- `make openapi-check openapi-lint openapi-ts-check`
- `make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL="4" LINT_SHARD_INDEX="1"`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->