### PR TITLE
[codex] Add agent task attempt contract

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7343,6 +7343,12 @@ components:
           type: string
         idempotency:
           type: string
+        attempt_tracking:
+          type: string
+        cancellation:
+          type: string
+        audit:
+          type: string
         default_behavior:
           type: string
         execution_rules:
@@ -7442,6 +7448,7 @@ components:
         - kind
         - status
         - resource
+        - attempt
         - dry_run
         - approved
       properties:
@@ -7454,6 +7461,8 @@ components:
           enum: [planned, dry_run, succeeded]
         resource:
           $ref: '#/components/schemas/AgentResourceRef'
+        attempt:
+          $ref: '#/components/schemas/AgentTaskAttemptRef'
         dry_run:
           type: boolean
         approved:
@@ -7480,6 +7489,44 @@ components:
         id:
           type: string
         path:
+          type: string
+    AgentTaskAttemptRef:
+      type: object
+      required:
+        - idempotency_key_present
+        - duplicate_detection
+        - replay_supported
+        - cancellation_supported
+      properties:
+        id:
+          type: string
+          description: Stable hashed attempt identifier when the caller supplied an idempotency key. The raw key is not embedded in this value.
+        idempotency_key_present:
+          type: boolean
+          description: True when Idempotency-Key or idempotency_key was supplied on the request.
+        duplicate_detection:
+          type: string
+          enum: [caller_provided_key, not_available]
+          description: Whether retries can be correlated by a caller-provided key. This field does not claim persisted replay unless replay_supported is true.
+        replay_supported:
+          type: boolean
+          description: False for agent task endpoints until task attempts are persisted and replayed by the execution layer.
+        cancellation_supported:
+          type: boolean
+          description: False for agent task endpoints. Use platform jobs for work that must accept cancellation requests.
+        audit:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTaskAuditRef'
+    AgentTaskAuditRef:
+      type: object
+      required:
+        - surface
+        - event
+      properties:
+        surface:
+          type: string
+        event:
           type: string
     AgentMutationRef:
       type: object

--- a/internal/sourcehttp/agenttasks/handler.go
+++ b/internal/sourcehttp/agenttasks/handler.go
@@ -2,6 +2,8 @@ package agenttasks
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +21,9 @@ const (
 	idempotencyHeader       = "Idempotency-Key"
 	maxIdempotencyKeyBytes  = 255
 	maxTaskRequestBodyBytes = 1 << 20
+
+	taskDuplicateDetectionCallerKey   = "caller_provided_key"
+	taskDuplicateDetectionUnavailable = "not_available"
 )
 
 var ErrInvalidRequest = errors.New("invalid agent task request")
@@ -86,6 +91,9 @@ type MutationContract struct {
 	DryRunField      string   `json:"dry_run_field"`
 	ApprovalField    string   `json:"approval_field"`
 	Idempotency      string   `json:"idempotency"`
+	AttemptTracking  string   `json:"attempt_tracking"`
+	Cancellation     string   `json:"cancellation"`
+	Audit            string   `json:"audit"`
 	DefaultBehavior  string   `json:"default_behavior"`
 	ExecutionRules   []string `json:"execution_rules"`
 	SupportedActions []string `json:"supported_actions"`
@@ -131,6 +139,7 @@ type TaskResponse struct {
 	Kind           string         `json:"kind"`
 	Status         string         `json:"status"`
 	Resource       ResourceRef    `json:"resource"`
+	Attempt        TaskAttemptRef `json:"attempt"`
 	DryRun         bool           `json:"dry_run"`
 	Approved       bool           `json:"approved"`
 	Reason         string         `json:"reason,omitempty"`
@@ -144,6 +153,20 @@ type ResourceRef struct {
 	Type string `json:"type"`
 	ID   string `json:"id"`
 	Path string `json:"path"`
+}
+
+type TaskAttemptRef struct {
+	ID                    string         `json:"id,omitempty"`
+	IdempotencyKeyPresent bool           `json:"idempotency_key_present"`
+	DuplicateDetection    string         `json:"duplicate_detection"`
+	ReplaySupported       bool           `json:"replay_supported"`
+	CancellationSupported bool           `json:"cancellation_supported"`
+	Audit                 []TaskAuditRef `json:"audit,omitempty"`
+}
+
+type TaskAuditRef struct {
+	Surface string `json:"surface"`
+	Event   string `json:"event"`
 }
 
 type MutationRef struct {
@@ -524,6 +547,9 @@ func mutationContract() MutationContract {
 		DryRunField:     "dry_run",
 		ApprovalField:   "approved",
 		Idempotency:     "Use Idempotency-Key or idempotency_key on approved writes that may be retried; values must match when both are sent and must not exceed 255 bytes.",
+		AttemptTracking: "Responses include attempt.id only when the caller sends Idempotency-Key or idempotency_key. Reuse that key to correlate approval retries for the same task.",
+		Cancellation:    "Agent task endpoints do not expose cancellation. Use platform jobs for work that needs a cancel request.",
+		Audit:           "Every agent task request emits the platform HTTP access audit event. Mutating results include runtime or report identifiers when execution succeeds.",
 		DefaultBehavior: "Agent task endpoints return a plan unless approved=true and dry_run is false.",
 		ExecutionRules: []string{
 			"Read and explain actions require the read scope only.",
@@ -545,11 +571,43 @@ func (h Handler) baseTaskResponse(kind string, resourceType string, resourceID s
 		Kind:           kind,
 		Status:         "planned",
 		Resource:       ResourceRef{Type: resourceType, ID: resourceID, Path: path},
+		Attempt:        taskAttemptRef(kind, resourceType, resourceID, req),
 		DryRun:         req.DryRun,
 		Approved:       req.Approved,
 		Reason:         strings.TrimSpace(req.Reason),
 		IdempotencyKey: req.Idempotency,
 	}
+}
+
+func taskAttemptRef(kind string, resourceType string, resourceID string, req TaskRequest) TaskAttemptRef {
+	key := strings.TrimSpace(req.Idempotency)
+	attempt := TaskAttemptRef{
+		IdempotencyKeyPresent: key != "",
+		DuplicateDetection:    taskDuplicateDetectionUnavailable,
+		ReplaySupported:       false,
+		CancellationSupported: false,
+		Audit: []TaskAuditRef{{
+			Surface: "platform_http_access",
+			Event:   "cerebro.api.access",
+		}},
+	}
+	if key == "" {
+		return attempt
+	}
+	attempt.ID = taskAttemptID(kind, resourceType, resourceID, key)
+	attempt.DuplicateDetection = taskDuplicateDetectionCallerKey
+	return attempt
+}
+
+func taskAttemptID(kind string, resourceType string, resourceID string, idempotencyKey string) string {
+	parts := []string{
+		strings.TrimSpace(kind),
+		strings.TrimSpace(resourceType),
+		strings.TrimSpace(resourceID),
+		strings.TrimSpace(idempotencyKey),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return "agent-task-attempt:" + strings.TrimSpace(kind) + ":" + strings.TrimSpace(resourceID) + ":" + hex.EncodeToString(sum[:])[:24]
 }
 
 func (h Handler) findingNextActions(findingID string) []NextAction {

--- a/internal/sourcehttp/agenttasks/handler_test.go
+++ b/internal/sourcehttp/agenttasks/handler_test.go
@@ -98,6 +98,52 @@ func TestRuntimeRetryDryRunEchoesIdempotencyMetadata(t *testing.T) {
 	if response.Mutation.Headers[idempotencyHeader] != "retry-runtime-1" {
 		t.Fatalf("mutation headers = %+v, want Idempotency-Key", response.Mutation.Headers)
 	}
+	if response.Attempt.ID == "" || strings.Contains(response.Attempt.ID, "retry-runtime-1") {
+		t.Fatalf("attempt id = %q, want hashed attempt id without raw key", response.Attempt.ID)
+	}
+	if !response.Attempt.IdempotencyKeyPresent || response.Attempt.DuplicateDetection != taskDuplicateDetectionCallerKey {
+		t.Fatalf("attempt = %+v, want caller-key duplicate detection", response.Attempt)
+	}
+	if response.Attempt.ReplaySupported || response.Attempt.CancellationSupported {
+		t.Fatalf("attempt = %+v, want no replay or cancellation support", response.Attempt)
+	}
+	if len(response.Attempt.Audit) != 1 || response.Attempt.Audit[0].Event != "cerebro.api.access" {
+		t.Fatalf("attempt audit = %+v, want platform access audit", response.Attempt.Audit)
+	}
+}
+
+func TestTaskAttemptIDIsStableForSameRetryKey(t *testing.T) {
+	request := TaskRequest{Idempotency: " retry-runtime-1 "}
+	first := New(Dependencies{}).baseTaskResponse("source_runtime_retry", "source_runtime", "runtime-1", "/source-runtimes/runtime-1", request)
+	replay := New(Dependencies{}).baseTaskResponse("source_runtime_retry", "source_runtime", "runtime-1", "/source-runtimes/runtime-1", request)
+	other := New(Dependencies{}).baseTaskResponse("source_runtime_retry", "source_runtime", "runtime-1", "/source-runtimes/runtime-1", TaskRequest{Idempotency: "retry-runtime-2"})
+
+	if first.Attempt.ID == "" {
+		t.Fatal("attempt id is empty, want stable id")
+	}
+	if first.Attempt.ID != replay.Attempt.ID {
+		t.Fatalf("attempt id changed across replay: %q != %q", first.Attempt.ID, replay.Attempt.ID)
+	}
+	if first.Attempt.ID == other.Attempt.ID {
+		t.Fatalf("attempt id = %q for different idempotency keys", first.Attempt.ID)
+	}
+	if strings.Contains(first.Attempt.ID, "retry-runtime-1") {
+		t.Fatalf("attempt id = %q, want no raw idempotency key", first.Attempt.ID)
+	}
+}
+
+func TestTaskAttemptWithoutIdempotencyKeyMarksDuplicateDetectionUnavailable(t *testing.T) {
+	response := New(Dependencies{}).baseTaskResponse("report_run", "report", "risk-summary", "/reports/risk-summary/runs", TaskRequest{})
+
+	if response.Attempt.ID != "" {
+		t.Fatalf("attempt id = %q, want empty without idempotency key", response.Attempt.ID)
+	}
+	if response.Attempt.IdempotencyKeyPresent {
+		t.Fatalf("attempt = %+v, want idempotency_key_present=false", response.Attempt)
+	}
+	if response.Attempt.DuplicateDetection != taskDuplicateDetectionUnavailable {
+		t.Fatalf("duplicate detection = %q, want unavailable", response.Attempt.DuplicateDetection)
+	}
 }
 
 func TestTaskParametersNormalizesTenantToAuthorizedValue(t *testing.T) {

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -102,6 +102,9 @@ export type AgentContextResponse = {
 
 export type AgentMutationContract = {
   approval_field?: string;
+  attempt_tracking?: string;
+  audit?: string;
+  cancellation?: string;
   default_behavior?: string;
   dry_run_field?: string;
   execution_rules?: string[];
@@ -623,6 +626,20 @@ export type AgentResourceRef = {
   type?: string;
 };
 
+export type AgentTaskAttemptRef = {
+  audit?: AgentTaskAuditRef[];
+  cancellation_supported: boolean;
+  duplicate_detection: "caller_provided_key" | "not_available";
+  id?: string;
+  idempotency_key_present: boolean;
+  replay_supported: boolean;
+};
+
+export type AgentTaskAuditRef = {
+  event: string;
+  surface: string;
+};
+
 export type AgentTaskRequest = {
   approved?: boolean;
   dry_run?: boolean;
@@ -634,6 +651,7 @@ export type AgentTaskRequest = {
 
 export type AgentTaskResponse = {
   approved: boolean;
+  attempt: AgentTaskAttemptRef;
   dry_run: boolean;
   id: string;
   idempotency_key?: string;


### PR DESCRIPTION
## Summary
- add agent task `attempt` metadata with hashed stable IDs when callers supply `Idempotency-Key` or `idempotency_key`
- expose duplicate detection, replay, cancellation, and audit surface in agent context and OpenAPI
- regenerate TypeScript OpenAPI types and cover keyed/unkeyed attempt behavior in tests

## Observed behavior
Agent task execution currently runs through the runtime/report handlers directly after `approved=true`; it does not persist replayable agent-task attempts. Platform jobs have durable idempotency, cancellation, and job events, but these agent task endpoints do not use that store yet.

## Contract
A caller-provided idempotency key now produces a stable hashed `attempt.id` for the same task/resource/key. Without a key, the response says duplicate detection is not available. `replay_supported` and `cancellation_supported` stay false until execution moves to a replayable layer.

## Validation
- `go test ./internal/sourcehttp/agenttasks -count=1`
- `make openapi-check openapi-lint openapi-ts-check`
- `git diff --check`
- `go test ./internal/bootstrap ./internal/sourcehttp/agenttasks ./internal/agentplatform ./internal/a2agateway -count=1`
- `make check-structural check-structural-test check-arch`
- `make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL="4" LINT_SHARD_INDEX="1"`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/1713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->