### PR TITLE
[codex] Measure skipped source sync work

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -479,7 +479,9 @@ func orchestratorDownstreamSkipReason(syncResult *cerebrov1.SyncSourceRuntimeRes
 		return ""
 	}
 	switch strings.TrimSpace(syncResult.GetShortCircuitReason()) {
-	case string(sourcecdk.PullShortCircuitReasonNotModified), string(sourcecdk.PullShortCircuitReasonCheckpointAdvanced):
+	case string(sourcecdk.PullShortCircuitReasonNotModified),
+		string(sourcecdk.PullShortCircuitReasonCheckpointAdvanced),
+		string(sourcecdk.PullShortCircuitReasonWatermarkReached):
 		return "source_unchanged"
 	default:
 		return ""

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -688,6 +688,9 @@ func runOrchestratorIteration(
 					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_skip_reason", downstreamSkipReason)
 					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_skip_reason", downstreamSkipReason)
 					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", downstreamSkipReason)
+					recordOrchestratorPhaseSkip(runtimeCtx, runtime, "orchestrator.graph_ingest", downstreamSkipReason)
+					recordOrchestratorPhaseSkip(runtimeCtx, runtime, "orchestrator.finding_rules", downstreamSkipReason)
+					recordOrchestratorPhaseSkip(runtimeCtx, runtime, "orchestrator.graph_rules", downstreamSkipReason)
 					runtimeResult.Health = withOrchestratorFreshGraphHealth(runtimeResult.Health)
 				}
 			}
@@ -887,6 +890,17 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 		WithField(telemetryField("phase.tenant_id", runtime.GetTenantId())))
 	telemetry.End(span, status, endAttrs)
 	return result, err
+}
+
+func recordOrchestratorPhaseSkip(ctx context.Context, runtime *cerebrov1.SourceRuntime, name string, reason string) {
+	if runtime == nil {
+		return
+	}
+	observability.RecordOrchestratorPhaseSkip(ctx, observability.OrchestratorPhaseSkipMetrics{
+		PhaseKey:   orchestratorPhaseTelemetryKey(name),
+		SourceID:   runtime.GetSourceId(),
+		SkipReason: reason,
+	})
 }
 
 func errorKindForMetric(err error) string {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -773,6 +773,7 @@ func runOrchestratorIteration(
 			} else {
 				runtimeResult.GraphRules = "skipped"
 				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", "graph_ingest_not_caught_up")
+				recordOrchestratorPhaseSkip(runtimeCtx, runtime, "orchestrator.graph_rules", "graph_ingest_not_caught_up")
 			}
 		}
 		cancelRuntime()

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -86,6 +86,53 @@ func TestParseOrchestratorOptionsAcceptsRuntimeIDs(t *testing.T) {
 	}
 }
 
+func TestOrchestratorDownstreamSkipReasonTreatsWatermarkBoundaryAsUnchanged(t *testing.T) {
+	resp := &cerebrov1.SyncSourceRuntimeResponse{
+		ShortCircuitReason: string(sourcecdk.PullShortCircuitReasonWatermarkReached),
+		Runtime:            &cerebrov1.SourceRuntime{},
+	}
+	if got := orchestratorDownstreamSkipReason(resp); got != "source_unchanged" {
+		t.Fatalf("orchestratorDownstreamSkipReason() = %q, want source_unchanged", got)
+	}
+}
+
+func TestOrchestratorDownstreamSkipReasonKeepsCoverageGuards(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *cerebrov1.SyncSourceRuntimeResponse
+	}{
+		{
+			name: "events appended",
+			resp: &cerebrov1.SyncSourceRuntimeResponse{
+				EventsAppended:     1,
+				ShortCircuitReason: string(sourcecdk.PullShortCircuitReasonWatermarkReached),
+				Runtime:            &cerebrov1.SourceRuntime{},
+			},
+		},
+		{
+			name: "continuation cursor",
+			resp: &cerebrov1.SyncSourceRuntimeResponse{
+				ShortCircuitReason: string(sourcecdk.PullShortCircuitReasonWatermarkReached),
+				Runtime:            &cerebrov1.SourceRuntime{NextCursor: &cerebrov1.SourceCursor{Opaque: "next-page"}},
+			},
+		},
+		{
+			name: "unrelated short circuit",
+			resp: &cerebrov1.SyncSourceRuntimeResponse{
+				ShortCircuitReason: string(sourcecdk.PullShortCircuitReasonScopeExcluded),
+				Runtime:            &cerebrov1.SourceRuntime{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := orchestratorDownstreamSkipReason(test.resp); got != "" {
+				t.Fatalf("orchestratorDownstreamSkipReason() = %q, want empty", got)
+			}
+		})
+	}
+}
+
 func TestOrchestratorShutdownSignalsIncludeSIGTERM(t *testing.T) {
 	signals := orchestratorShutdownSignals()
 	if len(signals) != 2 || signals[0] != os.Interrupt || signals[1] != syscall.SIGTERM {

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -134,9 +134,11 @@ safe to aggregate in CloudWatch, Prometheus, or a vendor backend.
 | `cerebro.source_runtime.sync.duration` | `s` | `source_id`, `status`, `error_kind`, `contract_configured` | Source sync duration distribution |
 | `cerebro.source_runtime.records` | `{record}` | `source_id`, `status`, `error_kind`, `contract_configured`, `record.kind` | Pages, scanned records, accepted/rejected events, appended events, and projected entities/links |
 | `cerebro.source_runtime.watermark.lag` | `s` | `source_id`, `status`, `error_kind`, `contract_configured` | Observed source freshness lag when a checkpoint watermark exists |
+| `cerebro.source_runtime.sync.short_circuits` | `{sync}` | `source_id`, `status`, `error_kind`, `contract_configured`, `short_circuit_reason`, `reconciliation_reason` | Source syncs that intentionally skipped full work after an unchanged or advanced checkpoint |
 | `cerebro.source_projection.runs` | `{projection}` | `source_id`, `event_kind`, `status` | Projection success/failure rate |
 | `cerebro.source_projection.duration` | `s` | `source_id`, `event_kind`, `status` | Projection latency distribution |
 | `cerebro.source_projection.records` | `{record}` | `source_id`, `event_kind`, `status`, `record.kind` | Graph/current-state records projected or deleted |
+| `cerebro.orchestrator.phase.skips` | `{phase}` | `phase_key`, `source_id`, `skip_reason` | Orchestrator phases skipped before execution because prior work proved they were unnecessary |
 | `cerebro.graph_action.recorded` | `{action}` | `provider`, `action`, `status`, `external_status`, `dry_run` | Provider-backed graph actions successfully recorded into the workflow/event path |
 | `cerebro.jetstream.publish.requests` | `{request}` | `subject`, `operation`, `status`, `error_category`, `max_attempts_exhausted` | Append-log publish success and failure counts by bounded subject and error category |
 | `cerebro.jetstream.publish.retries` | `{retry}` | `subject`, `operation`, `status`, `error_category`, `max_attempts_exhausted` | Publish retry attempts by bounded subject and error category |

--- a/internal/observability/domain_metrics.go
+++ b/internal/observability/domain_metrics.go
@@ -44,6 +44,14 @@ func otelSourceRuntimeWatermarkLag() otelmetric.Float64Histogram {
 	return instrument
 }
 
+func otelSourceRuntimeShortCircuits() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.source_runtime.sync.short_circuits",
+		otelmetric.WithDescription("Source runtime syncs that intentionally skipped full work after an unchanged or advanced checkpoint."),
+	)
+	return instrument
+}
+
 func otelSourceProjectionRuns() otelmetric.Int64Counter {
 	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
 		"cerebro.source_projection.runs",
@@ -136,6 +144,14 @@ func otelOrchestratorPhaseDuration() otelmetric.Float64Histogram {
 	return instrument
 }
 
+func otelOrchestratorPhaseSkips() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.orchestrator.phase.skips",
+		otelmetric.WithDescription("Orchestrator phases skipped before execution by bounded phase, source, and skip reason."),
+	)
+	return instrument
+}
+
 func otelJetStreamPublishRequests() otelmetric.Int64Counter {
 	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
 		"cerebro.jetstream.publish.requests",
@@ -198,20 +214,22 @@ func otelJetStreamReplayRecords() otelmetric.Int64Counter {
 // metrics. Runtime IDs, tenant IDs, resource URNs, evidence IDs, request IDs,
 // and trace IDs belong in spans/wide events, not metric labels.
 type SourceRuntimeSyncMetrics struct {
-	SourceID            string
-	Status              string
-	ErrorKind           string
-	ContractConfigured  bool
-	Duration            time.Duration
-	PagesRead           uint32
-	RecordsScanned      uint32
-	RecordsAccepted     uint32
-	RecordsRejected     uint32
-	EventsAppended      uint32
-	EntitiesProjected   uint32
-	LinksProjected      uint32
-	WatermarkLagSeconds int64
-	HasWatermarkLag     bool
+	SourceID             string
+	Status               string
+	ErrorKind            string
+	ContractConfigured   bool
+	Duration             time.Duration
+	PagesRead            uint32
+	RecordsScanned       uint32
+	RecordsAccepted      uint32
+	RecordsRejected      uint32
+	EventsAppended       uint32
+	EntitiesProjected    uint32
+	LinksProjected       uint32
+	WatermarkLagSeconds  int64
+	HasWatermarkLag      bool
+	ShortCircuitReason   string
+	ReconciliationReason string
 }
 
 // SourceProjectionMetrics is intentionally scoped to bounded event dimensions.
@@ -273,6 +291,14 @@ type OrchestratorPhaseMetrics struct {
 	TimeoutExceeded bool
 }
 
+// OrchestratorPhaseSkipMetrics records work intentionally not run. Runtime IDs
+// and tenant IDs belong in spans/wide events, not metric labels.
+type OrchestratorPhaseSkipMetrics struct {
+	PhaseKey   string
+	SourceID   string
+	SkipReason string
+}
+
 // JetStreamPublishMetrics is intentionally scoped to bounded operational
 // dimensions. Message IDs, tenant IDs, runtime IDs, and resource identifiers
 // belong in spans/wide events rather than metric labels.
@@ -314,6 +340,13 @@ func RecordSourceRuntimeSync(ctx context.Context, metrics SourceRuntimeSyncMetri
 	otelSourceRuntimeRuns().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
 	if metrics.Duration >= 0 {
 		otelSourceRuntimeDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+	if strings.TrimSpace(metrics.ShortCircuitReason) != "" {
+		shortCircuitAttrs := append(cloneMetricAttributes(attrs),
+			attribute.String("short_circuit_reason", boundedMetricValue(metrics.ShortCircuitReason, "unknown")),
+			attribute.String("reconciliation_reason", boundedMetricValue(metrics.ReconciliationReason, "none")),
+		)
+		otelSourceRuntimeShortCircuits().Add(ctx, 1, otelmetric.WithAttributes(shortCircuitAttrs...))
 	}
 	recordSourceRuntimeRecordCount(ctx, attrs, "page", int64(metrics.PagesRead))
 	recordSourceRuntimeRecordCount(ctx, attrs, "scanned", int64(metrics.RecordsScanned))
@@ -395,6 +428,15 @@ func RecordOrchestratorPhase(ctx context.Context, metrics OrchestratorPhaseMetri
 	if metrics.Duration >= 0 {
 		otelOrchestratorPhaseDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
 	}
+}
+
+func RecordOrchestratorPhaseSkip(ctx context.Context, metrics OrchestratorPhaseSkipMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("phase_key", boundedMetricValue(metrics.PhaseKey, "unknown")),
+		attribute.String("source_id", boundedMetricValue(metrics.SourceID, "unknown")),
+		attribute.String("skip_reason", boundedMetricValue(metrics.SkipReason, "unknown")),
+	}
+	otelOrchestratorPhaseSkips().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
 }
 
 func RecordJetStreamPublish(ctx context.Context, metrics JetStreamPublishMetrics) {

--- a/internal/observability/domain_metrics_test.go
+++ b/internal/observability/domain_metrics_test.go
@@ -15,19 +15,21 @@ import (
 func TestRecordSourceRuntimeSyncMetricsAreLowCardinality(t *testing.T) {
 	reader, shutdown := installManualMetricReader(t)
 	RecordSourceRuntimeSync(context.Background(), SourceRuntimeSyncMetrics{
-		SourceID:            "GitHub",
-		Status:              "completed",
-		ContractConfigured:  true,
-		Duration:            150 * time.Millisecond,
-		PagesRead:           2,
-		RecordsScanned:      10,
-		RecordsAccepted:     9,
-		RecordsRejected:     1,
-		EventsAppended:      9,
-		EntitiesProjected:   7,
-		LinksProjected:      4,
-		WatermarkLagSeconds: 42,
-		HasWatermarkLag:     true,
+		SourceID:             "GitHub",
+		Status:               "completed",
+		ContractConfigured:   true,
+		Duration:             150 * time.Millisecond,
+		PagesRead:            2,
+		RecordsScanned:       10,
+		RecordsAccepted:      9,
+		RecordsRejected:      1,
+		EventsAppended:       9,
+		EntitiesProjected:    7,
+		LinksProjected:       4,
+		WatermarkLagSeconds:  42,
+		HasWatermarkLag:      true,
+		ShortCircuitReason:   "not_modified",
+		ReconciliationReason: "max_consecutive_skips",
 	})
 	t.Cleanup(shutdown)
 
@@ -37,14 +39,18 @@ func TestRecordSourceRuntimeSyncMetricsAreLowCardinality(t *testing.T) {
 		"cerebro.source_runtime.sync.duration",
 		"cerebro.source_runtime.records",
 		"cerebro.source_runtime.watermark.lag",
+		"cerebro.source_runtime.sync.short_circuits",
 	} {
 		if _, ok := metrics[name]; !ok {
 			t.Fatalf("metric %q missing from %#v", name, metricNames(metrics))
 		}
 	}
 	assertNoForbiddenMetricAttributes(t, metrics["cerebro.source_runtime.records"])
+	assertNoForbiddenMetricAttributes(t, metrics["cerebro.source_runtime.sync.short_circuits"])
 	assertMetricHasAttribute(t, metrics["cerebro.source_runtime.records"], "record.kind", "accepted")
 	assertMetricHasAttribute(t, metrics["cerebro.source_runtime.records"], "source_id", "github")
+	assertMetricHasAttribute(t, metrics["cerebro.source_runtime.sync.short_circuits"], "short_circuit_reason", "not_modified")
+	assertMetricHasAttribute(t, metrics["cerebro.source_runtime.sync.short_circuits"], "reconciliation_reason", "max_consecutive_skips")
 }
 
 func TestRecordSourceProjectionMetricsAreLowCardinality(t *testing.T) {
@@ -97,6 +103,26 @@ func TestRecordGraphActionMetricsAreLowCardinality(t *testing.T) {
 	assertMetricHasAttribute(t, metric, "status", "succeeded")
 	assertMetricHasAttribute(t, metric, "external_status", "suspended")
 	assertMetricHasBoolAttribute(t, metric, "dry_run", false)
+}
+
+func TestRecordOrchestratorPhaseSkipMetricsAreLowCardinality(t *testing.T) {
+	reader, shutdown := installManualMetricReader(t)
+	RecordOrchestratorPhaseSkip(context.Background(), OrchestratorPhaseSkipMetrics{
+		PhaseKey:   "Graph Ingest",
+		SourceID:   "GitHub",
+		SkipReason: "source_unchanged",
+	})
+	t.Cleanup(shutdown)
+
+	metrics := collectMetrics(t, reader)
+	metric, ok := metrics["cerebro.orchestrator.phase.skips"]
+	if !ok {
+		t.Fatalf("metric %q missing from %#v", "cerebro.orchestrator.phase.skips", metricNames(metrics))
+	}
+	assertNoForbiddenMetricAttributes(t, metric)
+	assertMetricHasAttribute(t, metric, "phase_key", "graph_ingest")
+	assertMetricHasAttribute(t, metric, "source_id", "github")
+	assertMetricHasAttribute(t, metric, "skip_reason", "source_unchanged")
 }
 
 func TestRecordJetStreamPublishMetricsAreLowCardinality(t *testing.T) {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -277,6 +277,8 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		linksProjected         uint32
 		lastQuarantineCategory string
 		checkpointAdvanced     bool
+		shortCircuitReason     string
+		reconciliationReason   string
 	)
 	defer func() {
 		if err != nil {
@@ -314,20 +316,22 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			_, watermarkLagSeconds, hasWatermarkLag = runtimeWatermarkLag(runtime, time.Now().UTC())
 		}
 		observability.RecordSourceRuntimeSync(ctx, observability.SourceRuntimeSyncMetrics{
-			SourceID:            sourceID,
-			Status:              status,
-			ErrorKind:           sourceRuntimeTelemetryErrorKind(err),
-			ContractConfigured:  contractConfigured,
-			Duration:            time.Since(started),
-			PagesRead:           pagesRead,
-			RecordsScanned:      recordsScanned,
-			RecordsAccepted:     eventsAppended,
-			RecordsRejected:     recordsRejected,
-			EventsAppended:      eventsAppended,
-			EntitiesProjected:   entitiesProjected,
-			LinksProjected:      linksProjected,
-			WatermarkLagSeconds: watermarkLagSeconds,
-			HasWatermarkLag:     hasWatermarkLag,
+			SourceID:             sourceID,
+			Status:               status,
+			ErrorKind:            sourceRuntimeTelemetryErrorKind(err),
+			ContractConfigured:   contractConfigured,
+			Duration:             time.Since(started),
+			PagesRead:            pagesRead,
+			RecordsScanned:       recordsScanned,
+			RecordsAccepted:      eventsAppended,
+			RecordsRejected:      recordsRejected,
+			EventsAppended:       eventsAppended,
+			EntitiesProjected:    entitiesProjected,
+			LinksProjected:       linksProjected,
+			WatermarkLagSeconds:  watermarkLagSeconds,
+			HasWatermarkLag:      hasWatermarkLag,
+			ShortCircuitReason:   shortCircuitReason,
+			ReconciliationReason: reconciliationReason,
 		})
 		telemetry.End(span, status, spanAttributes)
 	}()
@@ -371,8 +375,6 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	contractConfigured = len(eventContracts) > 0
 	sourceConfig := sourcecdk.NewConfig(runtimeConfig)
 	originalCheckpoint := cloneCheckpoint(runtime.GetCheckpoint())
-	shortCircuitReason := ""
-	reconciliationReason := ""
 	for i := uint32(0); i < pageLimit; i++ {
 		pull, err := readSourcePull(ctx, source, sourceConfig, cursor, originalCheckpoint)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Add a low-cardinality source-runtime counter for short-circuited syncs, including bounded short-circuit and reconciliation reasons.
- Add a low-cardinality orchestrator phase-skip counter and record graph/finding phases skipped when source sync proves downstream work is unnecessary.
- Treat zero-event watermark-boundary syncs without continuation as unchanged so downstream graph and finding work can skip.
- Document the new metrics in the observability guide.

## Validation
- `go test ./internal/observability -count=1`
- `go test ./cmd/cerebro -run 'TestRunOrchestratorIterationSkipsDownstreamWhenSourceUnchanged|TestRunOrchestratorIterationRunsGraphWhenSourceUnchangedButGraphCheckpointMissing' -count=1`\n- `go test ./internal/sourceruntime -run 'TestSync.*ShortCircuit|TestSync.*Reconciliation|TestSyncSourceRuntimeTelemetryIncludesFamilyFreshness|TestSourceRuntimeSyncRollupTelemetry' -count=1`\n- `go test ./cmd/cerebro -count=1`\n- `go test ./internal/sourceruntime -count=1`\n- `go test ./cmd/cerebro -run 'TestOrchestratorDownstreamSkipReason|TestRunOrchestratorIterationSkipsDownstreamWhenSourceUnchanged|TestRunOrchestratorIterationRunsGraphWhenSourceUnchangedButGraphCheckpointMissing' -count=1`