### PR TITLE
[codex] Disambiguate OpenAPI path parameter keys

### DIFF
--- a/internal/connectordefinitions/openapigen/generator.go
+++ b/internal/connectordefinitions/openapigen/generator.go
@@ -721,25 +721,41 @@ func queryParameterNames(pathItem *openapi3.PathItem, operation *openapi3.Operat
 
 func renderPathTemplate(path string) (string, []connectordefinitions.Field) {
 	fields := []connectordefinitions.Field{}
-	seen := map[string]struct{}{}
+	rawToKey := map[string]string{}
+	used := map[string]struct{}{}
 	rendered := pathParamPattern.ReplaceAllStringFunc(path, func(match string) string {
-		raw := strings.Trim(match, "{}")
+		raw := strings.TrimSpace(strings.Trim(match, "{}"))
+		if key, ok := rawToKey[raw]; ok {
+			return "${config." + key + "}"
+		}
 		key := normalizeID(raw)
 		if key == "" {
 			key = "path_value"
 		}
-		if _, ok := seen[key]; !ok {
-			seen[key] = struct{}{}
-			fields = append(fields, connectordefinitions.Field{
-				Key:      key,
-				Label:    titleFromID(key),
-				Required: true,
-				Help:     "Path parameter inferred from the OpenAPI operation.",
-			})
-		}
+		key = uniquePathFieldKey(key, used)
+		rawToKey[raw] = key
+		used[key] = struct{}{}
+		fields = append(fields, connectordefinitions.Field{
+			Key:      key,
+			Label:    titleFromID(key),
+			Required: true,
+			Help:     "Path parameter inferred from the OpenAPI operation.",
+		})
 		return "${config." + key + "}"
 	})
 	return rendered, fields
+}
+
+func uniquePathFieldKey(base string, used map[string]struct{}) string {
+	if _, ok := used[base]; !ok {
+		return base
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s_%d", base, suffix)
+		if _, ok := used[candidate]; !ok {
+			return candidate
+		}
+	}
 }
 
 func readSpecForPathFields(fields []connectordefinitions.Field) *connectordefinitions.ResourceReadSpec {

--- a/internal/connectordefinitions/openapigen/generator_test.go
+++ b/internal/connectordefinitions/openapigen/generator_test.go
@@ -65,6 +65,23 @@ func TestGenerateBuildsSourcegenReadyDefinition(t *testing.T) {
 	}
 }
 
+func TestRenderPathTemplateDisambiguatesNormalizedPathParams(t *testing.T) {
+	rendered, fields := renderPathTemplate("/orgs/{org-id}/users/{org_id}/links/{org-id}")
+	if rendered != "/orgs/${config.org_id}/users/${config.org_id_2}/links/${config.org_id}" {
+		t.Fatalf("rendered path = %q", rendered)
+	}
+	if len(fields) != 2 {
+		t.Fatalf("path fields = %#v, want two distinct fields", fields)
+	}
+	if fields[0].Key != "org_id" || fields[1].Key != "org_id_2" {
+		t.Fatalf("path field keys = %#v, want org_id and org_id_2", fields)
+	}
+	read := readSpecForPathFields(fields)
+	if read == nil || !reflect.DeepEqual(read.PathParams, []string{"org_id", "org_id_2"}) {
+		t.Fatalf("path params = %#v, want org_id and org_id_2", read)
+	}
+}
+
 func TestGenerateInfersAPIKeyAndRootArray(t *testing.T) {
 	doc := loadFixture(t, headerCredentialFixture)
 	definition, report, err := Generate(doc, Request{MaxFamilies: 1, AllFamilies: true})


### PR DESCRIPTION
## Summary
- Disambiguate generated config keys when distinct OpenAPI path parameters normalize to the same identifier.
- Keep repeated instances of the same raw path parameter bound to one config field.
- Add regression coverage for rendered paths and `read.path_params` metadata.

## Validation
- `go test ./internal/connectordefinitions/openapigen -count=1 -v`
- `make sourcegen-test sourcegen-check check-structural check-structural-test check-arch`