### PR TITLE
Harden compliance execution foundations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Build stage - use buildx cross-compilation (no QEMU needed)
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
 ARG TARGETOS

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ GO_TEST_SHARD_WEIGHTS ?= scripts/go_package_test_weights.json
 GO_TEST_SHARD_DEFAULT_WEIGHT ?= 1
 GO_RACE_SHARD_WEIGHTS ?= scripts/go_package_race_weights.json
 GO_RACE_SHARD_DEFAULT_WEIGHT ?= 5
-BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
-GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
+BUF := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
+GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
-GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/goreleaser/goreleaser/v2@v2.16.0
+GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run github.com/goreleaser/goreleaser/v2@v2.16.0
 PROTO_BREAKING_BASE ?= origin/main
 README_CHECK_BASE ?= origin/main
 DOCKER_SMOKE_IMAGE ?= cerebro-runtime-smoke:local
@@ -341,7 +341,7 @@ lint-sources: lint-bootstrap ## Run golangci-lint over source packages.
 	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_SOURCE_PACKAGES)
 
 lint-bootstrap: ## Install golangci-lint if missing.
-	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
+	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.5 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
 
 proto-lint: ## Lint protobuf definitions.
 	$(BUF) lint

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The site entry point is [docs/index.md](docs/index.md), and `mkdocs.yml` defines
 
 | Component | Technology |
 | --- | --- |
-| Language | Go 1.26+ with `go1.26.4` toolchain |
+| Language | Go 1.26+ with `go1.26.5` toolchain |
 | HTTP server | Go `net/http` `ServeMux` |
 | RPC | Connect |
 | CLI | Standard Go CLI under `cmd/cerebro` |

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -127,6 +127,10 @@ func serve() error {
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	if _, err := app.RecoverPlatformJobs(ctx); err != nil {
+		return fmt.Errorf("recover platform jobs: %w", err)
+	}
+	jobRecoveryDone := app.StartPlatformJobRecovery(ctx, log.Printf)
 	grcWarmupDone := startGRCReadModelWarmup(ctx, deps.StateStore, log.Printf)
 	riskBackfillDone := startFindingRiskBackfill(ctx, app, log.Printf)
 	reportSchedulerDone := app.StartReportScheduler(ctx, log.Printf)
@@ -151,7 +155,7 @@ func serve() error {
 		if err := <-errCh; err != nil {
 			return fmt.Errorf("serve: %w", err)
 		}
-		waitForStartupJobs(shutdownCtx, grcWarmupDone, riskBackfillDone, reportSchedulerDone)
+		waitForStartupJobs(shutdownCtx, jobRecoveryDone, grcWarmupDone, riskBackfillDone, reportSchedulerDone)
 		return nil
 	}
 }

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -4,7 +4,7 @@ This document describes the current bootstrap service on `main`. Historical ware
 
 ## Prerequisites
 
-- Go 1.26+; the repository pins `go1.26.4` in `go.mod`.
+- Go 1.26+; the repository pins `go1.26.5` in `go.mod`.
 - Docker and Docker Compose for the durable local stack.
 - Make.
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/writer/cerebro
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 replace github.com/WriterInternal/event-registry/clients/go => ./internal/eventregistry
 

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -871,6 +871,9 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, 0, 0, 0, 0, 0, 0, ctx)))
 		return nil, err
 	}
+	if request.Cursor != "" {
+		useSubjectIndex = false
+	}
 	if stream.State.LastSeq == 0 || stream.State.LastSeq < stream.State.FirstSeq {
 		recordJetStreamReplayMetrics(ctx, replayScanStats{strategy: replayStrategyEmptyStream, subjectFilterCount: len(subjectFilters)}, "completed", "", time.Since(started), 0)
 		endAttrs := streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, 0, 0, 0, 0, 0, 0, ctx)).
@@ -949,6 +952,27 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	return events, nil
 }
 
+// ReplayPage returns one bounded page and an opaque cursor for older matches.
+// The page limit remains capped; callers can traverse more than the cap by
+// passing NextCursor into the next request.
+func (l *Log) ReplayPage(ctx context.Context, request ports.ReplayRequest) (ports.ReplayPage, error) {
+	request = normalizeReplayRequest(request)
+	limit := normalizeReplayLimit(request.Limit)
+	request.Limit = limit
+	events, err := l.Replay(ctx, request)
+	if err != nil {
+		return ports.ReplayPage{}, err
+	}
+	page := ports.ReplayPage{Events: events, Complete: len(events) < int(limit)}
+	if !page.Complete && len(events) > 0 {
+		page.NextCursor = strings.TrimSpace(events[0].GetId())
+		if page.NextCursor == "" {
+			return ports.ReplayPage{}, errors.New("replay page oldest event id is required")
+		}
+	}
+	return page, nil
+}
+
 type replayScanStats struct {
 	scanned            uint64
 	missing            uint64
@@ -972,6 +996,7 @@ func (s replayScanStats) attrs(limit uint32, candidateLimit uint32, ctx context.
 func replayLegacyReverse(ctx context.Context, streamName string, state jetstream.StreamState, stream replayStream, subjectPrefixes []string, request ports.ReplayRequest, candidateLimit uint32) ([]replayCandidate, replayScanStats, error) {
 	stats := replayScanStats{strategy: replayStrategyLegacyReverseScan}
 	candidates := make([]replayCandidate, 0, candidateLimit)
+	cursorSeen := request.Cursor == ""
 	for seq := state.LastSeq; ; seq-- {
 		stats.scanned++
 		raw, err := stream.GetMsg(ctx, seq)
@@ -994,6 +1019,15 @@ func replayLegacyReverse(ctx context.Context, streamName string, state jetstream
 				return nil, stats, fmt.Errorf("decode replay message %s:%d: %w", streamName, seq, err)
 			}
 			stats.decoded++
+			if !cursorSeen {
+				if event.GetId() == request.Cursor {
+					cursorSeen = true
+				}
+				if seq == state.FirstSeq {
+					break
+				}
+				continue
+			}
 			if matchesReplayRequest(event, request) {
 				stats.matched++
 				candidates = appendNewestReplayCandidate(candidates, replayCandidate{event: event, seq: seq}, candidateLimit)
@@ -1002,6 +1036,9 @@ func replayLegacyReverse(ctx context.Context, streamName string, state jetstream
 		if seq == state.FirstSeq {
 			break
 		}
+	}
+	if !cursorSeen {
+		return nil, stats, fmt.Errorf("%w: %s", ports.ErrReplayCursorNotFound, request.Cursor)
 	}
 	return candidates, stats, nil
 }
@@ -1069,7 +1106,7 @@ func appendNewestReplayCandidate(candidates []replayCandidate, candidate replayC
 // requests fall back to the subject/legacy strategies, which collect matched
 // candidates directly.
 func runtimeIndexReplayEligible(request ports.ReplayRequest) bool {
-	if request.RuntimeID == "" {
+	if request.RuntimeID == "" || request.Cursor != "" {
 		return false
 	}
 	if request.TenantID != "" || len(request.AttributeEquals) > 0 {
@@ -1850,6 +1887,7 @@ func normalizeReplayRequest(req ports.ReplayRequest) ports.ReplayRequest {
 		TenantID:            strings.TrimSpace(req.TenantID),
 		AttributeEquals:     make(map[string]string, len(req.AttributeEquals)),
 		Limit:               req.Limit,
+		Cursor:              strings.TrimSpace(req.Cursor),
 	}
 	for key, value := range req.AttributeEquals {
 		trimmedKey := strings.TrimSpace(key)

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -1095,6 +1095,63 @@ func TestReplayFiltersEventsByRuntime(t *testing.T) {
 	}
 }
 
+func TestReplayPageTraversesBeyondPerRequestLimit(t *testing.T) {
+	const eventCount = 1205
+	messages := make(map[uint64]*natsjetstream.RawStreamMsg, eventCount)
+	for i := 1; i <= eventCount; i++ {
+		id := fmt.Sprintf("evt-%04d", i)
+		messages[uint64(i)] = rawReplayMsg(t, "events.github.audit", replayEvent(id, "github.audit", "writer-github"))
+	}
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{{
+			Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+			State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: eventCount, Msgs: eventCount},
+		}},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{"CEREBRO_EVENTS": messages},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	first, err := log.ReplayPage(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 1000})
+	if err != nil {
+		t.Fatalf("ReplayPage(first) error = %v", err)
+	}
+	if len(first.Events) != 1000 || first.Complete || first.NextCursor != "evt-0206" {
+		t.Fatalf("first page count=%d complete=%v cursor=%q", len(first.Events), first.Complete, first.NextCursor)
+	}
+	if first.Events[0].GetId() != "evt-0206" || first.Events[len(first.Events)-1].GetId() != "evt-1205" {
+		t.Fatalf("first page range = %q..%q", first.Events[0].GetId(), first.Events[len(first.Events)-1].GetId())
+	}
+
+	second, err := log.ReplayPage(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 1000, Cursor: first.NextCursor})
+	if err != nil {
+		t.Fatalf("ReplayPage(second) error = %v", err)
+	}
+	if len(second.Events) != 205 || !second.Complete || second.NextCursor != "" {
+		t.Fatalf("second page count=%d complete=%v cursor=%q", len(second.Events), second.Complete, second.NextCursor)
+	}
+	if second.Events[0].GetId() != "evt-0001" || second.Events[len(second.Events)-1].GetId() != "evt-0205" {
+		t.Fatalf("second page range = %q..%q", second.Events[0].GetId(), second.Events[len(second.Events)-1].GetId())
+	}
+}
+
+func TestReplayPageRejectsMissingCursor(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{{
+			Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+			State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 1, Msgs: 1},
+		}},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-0001", "github.audit", "writer-github"))},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	_, err := log.ReplayPage(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 100, Cursor: "evt-missing"})
+	if !errors.Is(err, ports.ErrReplayCursorNotFound) {
+		t.Fatalf("ReplayPage() error = %v, want ErrReplayCursorNotFound", err)
+	}
+}
+
 func TestReplayExactKindFiltersUseSubjectIndex(t *testing.T) {
 	replay := &fakeReplayManager{
 		streams: []*natsjetstream.StreamInfo{

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -63,6 +63,21 @@ func (a *App) newJobService() *platformjobs.Service {
 	return service
 }
 
+// RecoverPlatformJobs resumes queued work and jobs whose worker lease expired.
+// Claiming is owner-checked, so every server replica may call this at startup.
+func (a *App) RecoverPlatformJobs(ctx context.Context) (int, error) {
+	if _, ok := a.deps.StateStore.(ports.JobLeaseStore); !ok {
+		return 0, nil
+	}
+	return a.jobService().Recover(ctx, 0)
+}
+
+// StartPlatformJobRecovery continuously makes expired leases runnable. The
+// returned channel closes after cancellation and is included in shutdown waits.
+func (a *App) StartPlatformJobRecovery(ctx context.Context, logf func(string, ...any)) <-chan struct{} {
+	return a.jobService().StartRecovery(ctx, logf)
+}
+
 func (a *App) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 	var request createJobHTTPRequest
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes)).Decode(&request); err != nil {
@@ -430,6 +445,8 @@ func writeJobError(w http.ResponseWriter, err error) {
 		status = http.StatusBadRequest
 	case errors.Is(err, ports.ErrJobNotFound):
 		status = http.StatusNotFound
+	case errors.Is(err, ports.ErrJobIdempotencyConflict), errors.Is(err, ports.ErrJobUpdateConflict), errors.Is(err, ports.ErrJobLeaseConflict):
+		status = http.StatusConflict
 	case errors.Is(err, platformjobs.ErrRuntimeUnavailable):
 		status = http.StatusServiceUnavailable
 	case errors.Is(err, errTenantForbidden):

--- a/internal/bootstrap/report_schedules.go
+++ b/internal/bootstrap/report_schedules.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,17 +13,15 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
-	platformjobs "github.com/writer/cerebro/internal/jobs"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/reports"
+	"github.com/writer/cerebro/internal/reportschedule"
 )
 
 const (
-	reportSchedulePollInterval              = 30 * time.Second
-	reportScheduleMinIntervalSeconds        = int64(60)
-	reportScheduleMaxIntervalSeconds        = int64(31 * 24 * 60 * 60)
-	reportScheduleClaimBatch         uint32 = 50
-	reportScheduleSubjectType               = "report_schedule"
+	reportSchedulePollInterval       = 30 * time.Second
+	reportScheduleMinIntervalSeconds = int64(60)
+	reportScheduleMaxIntervalSeconds = int64(31 * 24 * 60 * 60)
 )
 
 type reportScheduleView struct {
@@ -281,52 +278,7 @@ func (a *App) RunDueReportSchedules(ctx context.Context) (int, error) {
 	if store == nil {
 		return 0, nil
 	}
-	due, err := store.ClaimDueReportSchedules(ctx, time.Now().UTC(), reportScheduleClaimBatch)
-	if err != nil {
-		return 0, err
-	}
-	enqueued := 0
-	var errs []error
-	for _, schedule := range due {
-		if err := a.enqueueScheduledReportRun(ctx, schedule); err != nil {
-			errs = append(errs, fmt.Errorf("report schedule %q: %w", schedule.ID, err))
-			continue
-		}
-		enqueued++
-	}
-	return enqueued, errors.Join(errs...)
-}
-
-func (a *App) enqueueScheduledReportRun(ctx context.Context, schedule *ports.ReportSchedule) error {
-	if schedule == nil {
-		return nil
-	}
-	parameters := make(map[string]any, len(schedule.Parameters)+1)
-	for key, value := range schedule.Parameters {
-		parameters[key] = value
-	}
-	if tenantID := strings.TrimSpace(schedule.TenantID); tenantID != "" {
-		if _, ok := parameters["tenant_id"]; !ok {
-			parameters["tenant_id"] = tenantID
-		}
-	}
-	job, created, err := a.jobService().Create(ctx, ports.CreateJobRequest{
-		Kind:        platformjobs.KindReportRun,
-		TenantID:    schedule.TenantID,
-		SubjectType: reportScheduleSubjectType,
-		SubjectID:   schedule.ID,
-		Payload: map[string]any{
-			"report_id":  schedule.ReportID,
-			"parameters": parameters,
-		},
-	})
-	if err != nil {
-		return err
-	}
-	if created {
-		a.jobService().StartAsync(ctx, job)
-	}
-	return nil
+	return reportschedule.RunDue(ctx, store, a.jobService(), time.Now().UTC())
 }
 
 // StartReportScheduler launches the background loop that periodically enqueues

--- a/internal/bootstrap/report_schedules_test.go
+++ b/internal/bootstrap/report_schedules_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,11 +16,16 @@ import (
 )
 
 type stubReportScheduleStore struct {
-	schedules   map[string]*ports.ReportSchedule
-	due         []*ports.ReportSchedule
-	runs        []*cerebrov1.ReportRun
-	createdJobs []ports.CreateJobRequest
-	claimLimit  uint32
+	schedules       map[string]*ports.ReportSchedule
+	due             []*ports.ReportSchedule
+	runs            []*cerebrov1.ReportRun
+	createdJobs     []ports.CreateJobRequest
+	claimLimit      uint32
+	claimOwner      string
+	claimTTL        time.Duration
+	completedClaims []string
+	releasedClaims  []string
+	createJobErr    error
 }
 
 func newStubReportScheduleStore() *stubReportScheduleStore {
@@ -60,9 +66,21 @@ func (s *stubReportScheduleStore) DeleteReportSchedule(_ context.Context, id str
 	return nil
 }
 
-func (s *stubReportScheduleStore) ClaimDueReportSchedules(_ context.Context, _ time.Time, limit uint32) ([]*ports.ReportSchedule, error) {
+func (s *stubReportScheduleStore) ClaimDueReportSchedules(_ context.Context, _ time.Time, owner string, ttl time.Duration, limit uint32) ([]*ports.ReportSchedule, error) {
 	s.claimLimit = limit
+	s.claimOwner = owner
+	s.claimTTL = ttl
 	return s.due, nil
+}
+
+func (s *stubReportScheduleStore) CompleteReportScheduleClaim(_ context.Context, id string, owner string, _ time.Time, _ time.Time) error {
+	s.completedClaims = append(s.completedClaims, id+":"+owner)
+	return nil
+}
+
+func (s *stubReportScheduleStore) ReleaseReportScheduleClaim(_ context.Context, id string, owner string) error {
+	s.releasedClaims = append(s.releasedClaims, id+":"+owner)
+	return nil
 }
 
 func (s *stubReportScheduleStore) ListReportRuns(_ context.Context, _ ports.ReportRunFilter) ([]*cerebrov1.ReportRun, error) {
@@ -71,6 +89,9 @@ func (s *stubReportScheduleStore) ListReportRuns(_ context.Context, _ ports.Repo
 
 func (s *stubReportScheduleStore) CreateJob(_ context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
 	s.createdJobs = append(s.createdJobs, request)
+	if s.createJobErr != nil {
+		return nil, false, s.createJobErr
+	}
 	return &ports.Job{ID: "job-stub", Kind: request.Kind, Status: "queued"}, false, nil
 }
 
@@ -253,7 +274,7 @@ func TestHandleDeleteReportScheduleScopesTenant(t *testing.T) {
 func TestRunDueReportSchedulesEnqueuesReportRunJobs(t *testing.T) {
 	store := newStubReportScheduleStore()
 	store.due = []*ports.ReportSchedule{
-		{ID: "a", TenantID: "local", ReportID: "finding-summary", IntervalSeconds: 3600, Enabled: true, Parameters: map[string]string{"tenant_id": "local", "runtime_ids": "rt-1"}},
+		{ID: "a", TenantID: "local", ReportID: "finding-summary", IntervalSeconds: 3600, Enabled: true, NextRunAt: time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC), Parameters: map[string]string{"tenant_id": "local", "runtime_ids": "rt-1"}},
 	}
 	app := reportScheduleTestApp(store)
 
@@ -271,6 +292,12 @@ func TestRunDueReportSchedulesEnqueuesReportRunJobs(t *testing.T) {
 	if job.Kind != "report_run" || job.TenantID != "local" {
 		t.Fatalf("unexpected job %+v", job)
 	}
+	if job.IdempotencyKey != "report-schedule:a:2026-07-11T08:00:00Z" {
+		t.Fatalf("unexpected idempotency key %q", job.IdempotencyKey)
+	}
+	if len(store.completedClaims) != 1 || len(store.releasedClaims) != 0 {
+		t.Fatalf("completed=%v released=%v, want one completion and no release", store.completedClaims, store.releasedClaims)
+	}
 	if job.Payload["report_id"] != "finding-summary" {
 		t.Fatalf("unexpected job report_id %v", job.Payload["report_id"])
 	}
@@ -280,6 +307,25 @@ func TestRunDueReportSchedulesEnqueuesReportRunJobs(t *testing.T) {
 	}
 	if parameters["tenant_id"] != "local" || parameters["runtime_ids"] != "rt-1" {
 		t.Fatalf("unexpected job parameters %+v", parameters)
+	}
+}
+
+func TestRunDueReportSchedulesReleasesClaimWhenEnqueueFails(t *testing.T) {
+	store := newStubReportScheduleStore()
+	store.createJobErr = errors.New("job store unavailable")
+	store.due = []*ports.ReportSchedule{{
+		ID: "a", TenantID: "local", ReportID: "finding-summary", IntervalSeconds: 3600,
+		Enabled: true, NextRunAt: time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC),
+		Parameters: map[string]string{"tenant_id": "local", "runtime_ids": "rt-1"},
+	}}
+	app := reportScheduleTestApp(store)
+
+	enqueued, err := app.RunDueReportSchedules(context.Background())
+	if err == nil {
+		t.Fatal("RunDueReportSchedules() error = nil, want enqueue failure")
+	}
+	if enqueued != 0 || len(store.completedClaims) != 0 || len(store.releasedClaims) != 1 {
+		t.Fatalf("enqueued=%d completed=%v released=%v", enqueued, store.completedClaims, store.releasedClaims)
 	}
 }
 

--- a/internal/eventregistry/compliance_test.go
+++ b/internal/eventregistry/compliance_test.go
@@ -1,0 +1,20 @@
+package eventregistry
+
+import "testing"
+
+func TestComplianceAggregateV1EncodesSharedSchema(t *testing.T) {
+	t.Parallel()
+	event := ComplianceAggregateV1{
+		Kind: WorkflowV1CompliancePrefix + "program_recorded", TenantID: "tenant-a",
+		AggregateType: "program", AggregateID: "program-1", RevisionID: "revision-1",
+		AggregateVersion: 1, Operation: "recorded", ContentDigest: "sha256:abc",
+		PayloadJSON: `{"id":"program-1"}`, ActorID: "actor-1", RecordedAt: "2026-07-11T08:00:00Z",
+	}
+	encoded, err := (Encoder{}).Encode(event, EncodeOptions{EventID: "event-1"})
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if encoded.Subject != event.Kind || len(encoded.EnvelopeBytes) == 0 {
+		t.Fatalf("encoded = %#v", encoded)
+	}
+}

--- a/internal/eventregistry/models_workflow_v1.go
+++ b/internal/eventregistry/models_workflow_v1.go
@@ -10,6 +10,7 @@ const (
 	WorkflowV1FindingExternalRefLinked  = "workflow.v1.finding.external_ref_linked"
 	WorkflowV1FindingStatusChanged      = "workflow.v1.finding.status_changed"
 	WorkflowV1FindingTombstoned         = "workflow.v1.finding.tombstoned"
+	WorkflowV1CompliancePrefix          = "workflow.v1.compliance."
 )
 
 const (
@@ -22,6 +23,7 @@ const (
 	workflowV1FindingExternalRefFP   = "27b8e9fa76d210c4"
 	workflowV1FindingStatusChangedFP = "8af95aec880d1c3a"
 	workflowV1FindingTombstonedFP    = "bc92d8a4e5c7d5c3"
+	workflowV1ComplianceAggregateFP  = "e5ce86187cf139f8"
 )
 
 type Event interface {
@@ -29,6 +31,41 @@ type Event interface {
 	Version() int
 	SchemaFingerprint() string
 	EncodeAvro() ([]byte, error)
+}
+
+// ComplianceAggregateV1 carries one immutable compliance-domain revision or
+// transition. Kind is constrained to workflow.v1.compliance.* and selects the
+// subject while the payload schema remains shared across aggregate families.
+type ComplianceAggregateV1 struct {
+	Kind             string `json:"kind"`
+	TenantID         string `json:"tenant_id"`
+	AggregateType    string `json:"aggregate_type"`
+	AggregateID      string `json:"aggregate_id"`
+	RevisionID       string `json:"revision_id,omitempty"`
+	AggregateVersion int64  `json:"aggregate_version"`
+	Operation        string `json:"operation"`
+	ContentDigest    string `json:"content_digest,omitempty"`
+	PayloadJSON      string `json:"payload_json,omitempty"`
+	ActorID          string `json:"actor_id,omitempty"`
+	RecordedAt       string `json:"recorded_at"`
+}
+
+func (e ComplianceAggregateV1) Subject() string         { return e.Kind }
+func (ComplianceAggregateV1) Version() int              { return 1 }
+func (ComplianceAggregateV1) SchemaFingerprint() string { return workflowV1ComplianceAggregateFP }
+func (e ComplianceAggregateV1) EncodeAvro() ([]byte, error) {
+	w := newAvroWriter()
+	w.string(e.TenantID)
+	w.string(e.AggregateType)
+	w.string(e.AggregateID)
+	w.string(e.RevisionID)
+	w.long(e.AggregateVersion)
+	w.string(e.Operation)
+	w.string(e.ContentDigest)
+	w.string(e.PayloadJSON)
+	w.string(e.ActorID)
+	w.string(e.RecordedAt)
+	return w.bytes()
 }
 
 type DecisionRecordedV1 struct {

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -5,11 +5,13 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -23,6 +25,15 @@ var (
 )
 
 const (
+	defaultLeaseTTL          = 30 * time.Second
+	defaultHeartbeatInterval = 10 * time.Second
+	defaultRecoveryBatch     = uint32(100)
+	defaultRecoveryInterval  = 15 * time.Second
+
+	JobFailurePermanent = "permanent"
+	JobFailureRetryable = "retryable"
+	JobFailureCancelled = "cancelled"
+
 	KindSourceRuntimeSync         = "source_runtime_sync"
 	KindSourceRuntimeOrchestrate  = "source_runtime_orchestrate"
 	KindGraphIngestRuntime        = "graph_ingest_runtime"
@@ -39,18 +50,44 @@ const (
 
 type Runner func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error)
 
+type retryableJobError struct {
+	err error
+}
+
+func (e retryableJobError) Error() string { return e.err.Error() }
+func (e retryableJobError) Unwrap() error { return e.err }
+
+// Retryable marks an execution failure safe for an explicit retry policy.
+func Retryable(err error) error {
+	if err == nil {
+		return nil
+	}
+	return retryableJobError{err: err}
+}
+
 type Service struct {
-	store        ports.JobStore
-	runners      map[string]Runner
-	now          func() time.Time
-	nextAsyncID  uint64
-	asyncCancels map[uint64]context.CancelFunc
-	wg           sync.WaitGroup
-	mu           sync.Mutex
+	store             ports.JobStore
+	runners           map[string]Runner
+	now               func() time.Time
+	nextAsyncID       uint64
+	asyncCancels      map[uint64]context.CancelFunc
+	jobCancels        map[string]context.CancelFunc
+	leaseTTL          time.Duration
+	heartbeatInterval time.Duration
+	wg                sync.WaitGroup
+	mu                sync.Mutex
 }
 
 func New(store ports.JobStore) *Service {
-	return &Service{store: store, runners: map[string]Runner{}, now: func() time.Time { return time.Now().UTC() }, asyncCancels: map[uint64]context.CancelFunc{}}
+	return &Service{
+		store:             store,
+		runners:           map[string]Runner{},
+		now:               func() time.Time { return time.Now().UTC() },
+		asyncCancels:      map[uint64]context.CancelFunc{},
+		jobCancels:        map[string]context.CancelFunc{},
+		leaseTTL:          defaultLeaseTTL,
+		heartbeatInterval: defaultHeartbeatInterval,
+	}
 }
 
 func (s *Service) WithRunner(kind string, runner Runner) *Service {
@@ -62,6 +99,27 @@ func (s *Service) WithRunner(kind string, runner Runner) *Service {
 		return s
 	}
 	s.runners[kind] = runner
+	return s
+}
+
+// WithLeaseTiming overrides worker lease timing. Production uses the defaults;
+// focused tests use shorter intervals to exercise renewal and cancellation.
+func (s *Service) WithLeaseTiming(ttl time.Duration, heartbeatInterval time.Duration) *Service {
+	if s == nil {
+		return nil
+	}
+	if ttl > 0 {
+		s.leaseTTL = ttl
+		if s.heartbeatInterval >= ttl {
+			s.heartbeatInterval = ttl / 3
+			if s.heartbeatInterval <= 0 {
+				s.heartbeatInterval = ttl
+			}
+		}
+	}
+	if heartbeatInterval > 0 && heartbeatInterval < s.leaseTTL {
+		s.heartbeatInterval = heartbeatInterval
+	}
 	return s
 }
 
@@ -83,6 +141,11 @@ func (s *Service) Create(ctx context.Context, request ports.CreateJobRequest) (*
 	if request.Payload == nil {
 		request.Payload = map[string]any{}
 	}
+	requestHash, err := jobRequestHash(request)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: hash request: %w", ErrInvalidRequest, err)
+	}
+	request.RequestHash = requestHash
 	job, created, err := s.store.CreateJob(ctx, request)
 	if err != nil {
 		return nil, false, err
@@ -166,7 +229,301 @@ func (s *Service) Wait(ctx context.Context) error {
 	}
 }
 
-func (s *Service) Run(ctx context.Context, jobID string) (err error) {
+// Recover resets expired leases and starts queued work. Claiming remains atomic,
+// so multiple replicas may call Recover safely during startup.
+func (s *Service) Recover(ctx context.Context, limit uint32) (int, error) {
+	if s == nil || s.store == nil {
+		return 0, ErrRuntimeUnavailable
+	}
+	leaseStore, ok := s.store.(ports.JobLeaseStore)
+	if !ok {
+		return 0, ErrRuntimeUnavailable
+	}
+	if limit == 0 {
+		limit = defaultRecoveryBatch
+	}
+	queued, err := leaseStore.RecoverJobs(ctx, ports.JobRecoveryRequest{Now: s.now(), Limit: limit})
+	if err != nil {
+		return 0, err
+	}
+	for _, job := range queued {
+		s.StartAsync(ctx, job)
+	}
+	return len(queued), nil
+}
+
+// StartRecovery periodically resumes expired and queued work until cancellation.
+func (s *Service) StartRecovery(ctx context.Context, logf func(string, ...any)) <-chan struct{} {
+	done := make(chan struct{})
+	if s == nil {
+		close(done)
+		return done
+	}
+	if _, ok := s.store.(ports.JobLeaseStore); !ok {
+		close(done)
+		return done
+	}
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(defaultRecoveryInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, err := s.Recover(ctx, 0); err != nil && ctx.Err() == nil && logf != nil {
+					logf("recover platform jobs: %v", err)
+				}
+			}
+		}
+	}()
+	return done
+}
+
+// Run claims and executes one job. Stores that implement JobLeaseStore get
+// owner-checked completion, heartbeat, cancellation, and crash recovery.
+func (s *Service) Run(ctx context.Context, jobID string) error {
+	if s == nil || s.store == nil {
+		return ErrRuntimeUnavailable
+	}
+	leaseStore, ok := s.store.(ports.JobLeaseStore)
+	if !ok {
+		return s.runWithoutLease(ctx, jobID)
+	}
+	return s.runWithLease(ctx, jobID, leaseStore)
+}
+
+func (s *Service) runWithLease(ctx context.Context, jobID string, leaseStore ports.JobLeaseStore) (err error) {
+	job, err := s.store.GetJob(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	ctx, span := telemetry.StartMain(ctx, "platform.job.run", jobTelemetryAttrs(job).With(telemetry.Attrs(
+		telemetry.Field{Key: "operation.type", Value: "platform_job"},
+		telemetry.Field{Key: "workload.kind", Value: "platform_job"},
+		telemetry.Field{Key: "job.name", Value: job.Kind},
+		telemetry.Field{Key: "job.status.initial", Value: job.Status},
+	)))
+	status := "failed"
+	spanAttrs := telemetry.Attrs()
+	startedAt := time.Time{}
+	leaseOwner := newJobLeaseOwner()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			status = ports.JobStatusFailed
+			panicErr := fmt.Errorf("%w: %v", ErrJobPanic, recovered)
+			spanAttrs = spanAttrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "job.panic", Value: true},
+				telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(panicErr)},
+				telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("platform.job.run", panicErr, jobTelemetryAttrs(job))},
+			))
+			err = s.failPanickedLeasedJob(context.WithoutCancel(ctx), jobID, leaseOwner, recovered)
+		}
+		if job != nil {
+			spanAttrs = spanAttrs.With(jobTelemetryAttrs(job))
+		}
+		if !startedAt.IsZero() {
+			spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "job.run_duration_ms", Value: s.now().Sub(startedAt).Milliseconds()})
+		}
+		telemetry.End(span, status, spanAttrs.WithField(telemetry.Field{Key: "job.status.final", Value: status}))
+	}()
+
+	runner := s.runners[job.Kind]
+	if runner == nil {
+		finished := s.now()
+		if updated, updateErr := s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{
+			Status:          ports.JobStatusFailed,
+			Message:         "job runner unavailable",
+			Error:           "job runner unavailable",
+			FailureClass:    JobFailurePermanent,
+			FinishedAt:      &finished,
+			AllowedStatuses: []string{ports.JobStatusQueued},
+		}); updateErr == nil {
+			job = updated
+			appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: "job runner unavailable"})
+		}
+		status = ports.JobStatusFailed
+		return fmt.Errorf("%w: runner missing for %s", ErrRuntimeUnavailable, job.Kind)
+	}
+
+	job, err = leaseStore.ClaimJob(ctx, ports.JobClaimRequest{JobID: job.ID, Owner: leaseOwner, Now: s.now(), TTL: s.leaseTTL})
+	if err != nil {
+		if errors.Is(err, ports.ErrJobLeaseConflict) {
+			status = "skipped"
+			spanAttrs = spanAttrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "job.run.skipped", Value: true},
+				telemetry.Field{Key: "job.run.skipped_reason", Value: "lease_conflict"},
+			))
+			return nil
+		}
+		return err
+	}
+	startedAt = job.StartedAt
+	eventType := "started"
+	eventMessage := "job started"
+	if job.Attempt > 1 {
+		eventType = "resumed"
+		eventMessage = "job resumed after recovery"
+	}
+	appendJobEventLogged(ctx, s.store, ports.JobEvent{JobID: job.ID, Type: eventType, Status: ports.JobStatusRunning, Message: eventMessage, Payload: map[string]any{"attempt": job.Attempt}})
+	telemetry.Event(ctx, "platform.job.started", jobTelemetryAttrs(job).With(telemetry.Attrs(
+		telemetry.Field{Key: "job.queue_latency_ms", Value: jobQueueLatencyMs(job)},
+		telemetry.Field{Key: "job.runner.available", Value: true},
+	)))
+
+	runnerCtx, runnerCancel := context.WithCancel(ctx)
+	s.registerJobCancel(job.ID, runnerCancel)
+	var cancelRequested atomic.Bool
+	var leaseLost atomic.Bool
+	heartbeatCtx, stopHeartbeat := context.WithCancel(context.WithoutCancel(ctx))
+	heartbeatDone := make(chan struct{})
+	go func() {
+		defer close(heartbeatDone)
+		ticker := time.NewTicker(s.heartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				renewed, renewErr := leaseStore.RenewJobLease(heartbeatCtx, ports.JobLeaseRenewRequest{JobID: job.ID, Owner: leaseOwner, Now: s.now(), TTL: s.leaseTTL})
+				if renewErr != nil {
+					leaseLost.Store(true)
+					runnerCancel()
+					return
+				}
+				if renewed.CancelRequested {
+					cancelRequested.Store(true)
+					runnerCancel()
+					return
+				}
+			}
+		}
+	}()
+	var cleanupHeartbeat sync.Once
+	cleanup := func() {
+		cleanupHeartbeat.Do(func() {
+			stopHeartbeat()
+			<-heartbeatDone
+			s.unregisterJobCancel(job.ID)
+			runnerCancel()
+		})
+	}
+	defer cleanup()
+
+	result, refs, runErr := runner(runnerCtx, job, s)
+	cleanup()
+
+	if current, getErr := s.store.GetJob(context.WithoutCancel(ctx), job.ID); getErr == nil {
+		job = current
+		if current.CancelRequested {
+			cancelRequested.Store(true)
+		}
+	}
+	if cancelRequested.Load() {
+		finished := s.now()
+		job, err = s.store.UpdateJob(context.WithoutCancel(ctx), job.ID, ports.JobUpdate{
+			Status:             ports.JobStatusCancelled,
+			Message:            "job cancelled",
+			FailureClass:       JobFailureCancelled,
+			FinishedAt:         &finished,
+			AllowedStatuses:    []string{ports.JobStatusRunning},
+			ExpectedLeaseOwner: leaseOwner,
+			ClearLease:         true,
+		})
+		if err != nil {
+			return err
+		}
+		appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "cancelled", Status: ports.JobStatusCancelled, Message: "job cancelled"})
+		status = ports.JobStatusCancelled
+		return nil
+	}
+	if leaseLost.Load() {
+		status = "abandoned"
+		return fmt.Errorf("%w: %s", ports.ErrJobLeaseConflict, job.ID)
+	}
+	if runErr != nil && errors.Is(runErr, context.Canceled) && ctx.Err() != nil {
+		status = "interrupted"
+		return runErr
+	}
+
+	finished := s.now()
+	if runErr != nil {
+		failureClass := classifyJobFailure(runErr)
+		job, err = s.store.UpdateJob(context.WithoutCancel(ctx), job.ID, ports.JobUpdate{
+			Status:             ports.JobStatusFailed,
+			Error:              runErr.Error(),
+			Message:            "job failed",
+			FailureClass:       failureClass,
+			FinishedAt:         &finished,
+			AllowedStatuses:    []string{ports.JobStatusRunning},
+			ExpectedLeaseOwner: leaseOwner,
+			ClearLease:         true,
+		})
+		if err != nil {
+			return err
+		}
+		appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: runErr.Error(), Payload: map[string]any{"failure_class": failureClass, "attempt": job.Attempt}})
+		status = ports.JobStatusFailed
+		spanAttrs = spanAttrs.With(jobResultTelemetryAttrs(result, refs)).With(telemetry.Attrs(
+			telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(runErr)},
+			telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("platform.job.run", runErr, jobTelemetryAttrs(job))},
+		))
+		telemetry.CaptureError(ctx, "platform.job.failed", runErr, jobTelemetryAttrs(job).With(spanAttrs))
+		return runErr
+	}
+
+	progress := uint32(100)
+	completedJobID := job.ID
+	completedJob, updateErr := s.store.UpdateJob(context.WithoutCancel(ctx), completedJobID, ports.JobUpdate{
+		Status:              ports.JobStatusCompleted,
+		Progress:            &progress,
+		Message:             "job completed",
+		Result:              result,
+		ResultRefs:          refs,
+		FinishedAt:          &finished,
+		AllowedStatuses:     []string{ports.JobStatusRunning},
+		ExpectedLeaseOwner:  leaseOwner,
+		RequireNotCancelled: true,
+		ClearLease:          true,
+	})
+	if updateErr != nil {
+		if errors.Is(updateErr, ports.ErrJobUpdateConflict) {
+			if current, getErr := s.store.GetJob(context.WithoutCancel(ctx), completedJobID); getErr == nil && current.CancelRequested && current.LeaseOwner == leaseOwner {
+				cancelled, cancelErr := s.store.UpdateJob(context.WithoutCancel(ctx), completedJobID, ports.JobUpdate{
+					Status:             ports.JobStatusCancelled,
+					Message:            "job cancelled",
+					FailureClass:       JobFailureCancelled,
+					FinishedAt:         &finished,
+					AllowedStatuses:    []string{ports.JobStatusRunning},
+					ExpectedLeaseOwner: leaseOwner,
+					ClearLease:         true,
+				})
+				if cancelErr == nil {
+					job = cancelled
+					appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "cancelled", Status: ports.JobStatusCancelled, Message: "job cancelled"})
+					status = ports.JobStatusCancelled
+					return nil
+				}
+			}
+			status = "skipped"
+		}
+		return updateErr
+	}
+	job = completedJob
+	appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "completed", Status: ports.JobStatusCompleted, Message: "job completed", Payload: map[string]any{"attempt": job.Attempt}})
+	status = ports.JobStatusCompleted
+	spanAttrs = spanAttrs.With(jobResultTelemetryAttrs(result, refs)).With(telemetry.Attrs(
+		telemetry.Field{Key: "job.queue_latency_ms", Value: jobQueueLatencyMs(job)},
+		telemetry.Field{Key: "job.finished_at_unix_ms", Value: finished.UnixMilli()},
+		telemetry.Field{Key: "job.progress_percent", Value: progress},
+	))
+	telemetry.Event(ctx, "platform.job.completed", jobTelemetryAttrs(job).With(spanAttrs))
+	return nil
+}
+
+func (s *Service) runWithoutLease(ctx context.Context, jobID string) (err error) {
 	if s == nil || s.store == nil {
 		return ErrRuntimeUnavailable
 	}
@@ -334,6 +691,90 @@ func (s *Service) failPanickedJob(ctx context.Context, jobID string, recovered a
 	return panicErr
 }
 
+func (s *Service) failPanickedLeasedJob(ctx context.Context, jobID string, owner string, recovered any) error {
+	panicErr := fmt.Errorf("%w: %v", ErrJobPanic, recovered)
+	jobID = strings.TrimSpace(jobID)
+	owner = strings.TrimSpace(owner)
+	if s == nil || s.store == nil || jobID == "" || owner == "" {
+		return panicErr
+	}
+	finished := s.now()
+	_, err := s.store.UpdateJob(ctx, jobID, ports.JobUpdate{
+		Status:             ports.JobStatusFailed,
+		Message:            "job failed",
+		Error:              panicErr.Error(),
+		FailureClass:       JobFailurePermanent,
+		FinishedAt:         &finished,
+		AllowedStatuses:    []string{ports.JobStatusRunning},
+		ExpectedLeaseOwner: owner,
+		ClearLease:         true,
+	})
+	if err != nil {
+		if errors.Is(err, ports.ErrJobUpdateConflict) || errors.Is(err, ports.ErrJobLeaseConflict) {
+			return panicErr
+		}
+		return fmt.Errorf("%w; mark job failed: %w", panicErr, err)
+	}
+	appendJobEventLogged(ctx, s.store, ports.JobEvent{JobID: jobID, Type: "failed", Status: ports.JobStatusFailed, Message: panicErr.Error(), Payload: map[string]any{"failure_class": JobFailurePermanent}})
+	return panicErr
+}
+
+func (s *Service) registerJobCancel(jobID string, cancel context.CancelFunc) {
+	if s == nil || cancel == nil {
+		return
+	}
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.jobCancels == nil {
+		s.jobCancels = map[string]context.CancelFunc{}
+	}
+	s.jobCancels[jobID] = cancel
+	s.mu.Unlock()
+}
+
+func (s *Service) unregisterJobCancel(jobID string) {
+	if s == nil {
+		return
+	}
+	jobID = strings.TrimSpace(jobID)
+	s.mu.Lock()
+	delete(s.jobCancels, jobID)
+	s.mu.Unlock()
+}
+
+func (s *Service) cancelRunningJob(jobID string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	cancel := s.jobCancels[strings.TrimSpace(jobID)]
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func classifyJobFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+	var retryable retryableJobError
+	if errors.As(err, &retryable) || errors.Is(err, context.DeadlineExceeded) {
+		return JobFailureRetryable
+	}
+	if errors.Is(err, context.Canceled) {
+		return JobFailureCancelled
+	}
+	return JobFailurePermanent
+}
+
+func newJobLeaseOwner() string {
+	return "worker-" + strings.TrimPrefix(NewID(), "job-")
+}
+
 func (s *Service) Get(ctx context.Context, id string) (*ports.Job, error) {
 	if s == nil || s.store == nil {
 		return nil, ErrRuntimeUnavailable
@@ -385,6 +826,9 @@ func (s *Service) Cancel(ctx context.Context, jobID string) (*ports.Job, error) 
 		return nil, err
 	}
 	appendJobEventLogged(ctx, s.store, event)
+	if event.Type == "cancellation_requested" {
+		s.cancelRunningJob(jobID)
+	}
 	telemetry.Event(ctx, "platform.job.cancel_requested", jobTelemetryAttrs(job).With(telemetry.Attrs(
 		telemetry.Field{Key: "job.cancel_requested", Value: true},
 		telemetry.Field{Key: "job.cancel.transitioned_terminal", Value: event.Type == "cancelled"},
@@ -419,6 +863,8 @@ func jobTelemetryAttrs(job *ports.Job) telemetry.Attributes {
 		telemetry.Field{Key: "job_subject_id", Value: job.SubjectID},
 		telemetry.Field{Key: "job.progress_percent", Value: job.Progress},
 		telemetry.Field{Key: "job.cancel_requested", Value: job.CancelRequested},
+		telemetry.Field{Key: "job.attempt", Value: job.Attempt},
+		telemetry.Field{Key: "job.failure_class", Value: job.FailureClass},
 		telemetry.Field{Key: "job.created_at_unix_ms", Value: unixMilliOrZero(job.CreatedAt)},
 		telemetry.Field{Key: "job.started_at_unix_ms", Value: unixMilliOrZero(job.StartedAt)},
 		telemetry.Field{Key: "job.finished_at_unix_ms", Value: unixMilliOrZero(job.FinishedAt)},
@@ -534,6 +980,28 @@ func hashText(value string) string {
 	}
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:8])
+}
+
+func jobRequestHash(request ports.CreateJobRequest) (string, error) {
+	payload := struct {
+		Kind        string         `json:"kind"`
+		TenantID    string         `json:"tenant_id"`
+		SubjectType string         `json:"subject_type"`
+		SubjectID   string         `json:"subject_id"`
+		Payload     map[string]any `json:"payload"`
+	}{
+		Kind:        strings.TrimSpace(request.Kind),
+		TenantID:    strings.TrimSpace(request.TenantID),
+		SubjectType: strings.TrimSpace(request.SubjectType),
+		SubjectID:   strings.TrimSpace(request.SubjectID),
+		Payload:     request.Payload,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func appendJobEventLogged(ctx context.Context, store ports.JobStore, event ports.JobEvent) {

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -169,10 +169,6 @@ func (s *Service) StartAsync(ctx context.Context, job *ports.Job) { //nolint:con
 	if s == nil || job == nil {
 		return
 	}
-	runner := s.runners[job.Kind]
-	if runner == nil {
-		return
-	}
 	if ctx == nil {
 		return
 	}

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -505,16 +505,18 @@ func (s *boundedRecoveryJobStore) RecoverJobs(_ context.Context, request ports.J
 	defer s.mu.Unlock()
 	limit := request.Limit
 	if limit == 0 {
-		limit = uint32(len(s.order))
+		limit = ^uint32(0)
 	}
-	jobs := make([]*ports.Job, 0, limit)
+	jobs := make([]*ports.Job, 0, len(s.order))
+	var recovered uint32
 	for _, id := range s.order {
 		job := s.jobs[id]
 		if job == nil || job.Status != ports.JobStatusQueued || job.CancelRequested {
 			continue
 		}
 		jobs = append(jobs, cloneJob(job))
-		if uint32(len(jobs)) == limit {
+		recovered++
+		if recovered == limit {
 			break
 		}
 	}

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -27,6 +27,26 @@ func TestCreateRejectsUnsupportedKind(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsIdempotencyKeyWithDifferentRequest(t *testing.T) {
+	service := New(newMemoryJobStore())
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return nil, nil, nil
+	})
+	first := ports.CreateJobRequest{Kind: KindReportRun, TenantID: "tenant-a", IdempotencyKey: "same-key", Payload: map[string]any{"report_id": "one"}}
+	job, created, err := service.Create(context.Background(), first)
+	if err != nil || !created {
+		t.Fatalf("Create(first) job=%+v created=%v error=%v", job, created, err)
+	}
+	reused, created, err := service.Create(context.Background(), first)
+	if err != nil || created || reused.ID != job.ID {
+		t.Fatalf("Create(reuse) job=%+v created=%v error=%v", reused, created, err)
+	}
+	_, _, err = service.Create(context.Background(), ports.CreateJobRequest{Kind: KindReportRun, TenantID: "tenant-a", IdempotencyKey: "same-key", Payload: map[string]any{"report_id": "two"}})
+	if !errors.Is(err, ports.ErrJobIdempotencyConflict) {
+		t.Fatalf("Create(conflict) error = %v, want ErrJobIdempotencyConflict", err)
+	}
+}
+
 func TestCancelDoesNotOverwriteTerminalJob(t *testing.T) {
 	store := newMemoryJobStore()
 	store.jobs["job-complete"] = &ports.Job{ID: "job-complete", Kind: KindReportRun, Status: ports.JobStatusCompleted}
@@ -259,11 +279,175 @@ func TestStartAsyncDetachesFromRequestAndWaitCancelsJob(t *testing.T) {
 	}
 }
 
+func TestRunCancellationTransitionsLeasedJobToCancelled(t *testing.T) {
+	store := newMemoryJobStore()
+	service := New(store).WithLeaseTiming(200*time.Millisecond, 20*time.Millisecond)
+	started := make(chan struct{})
+	service.WithRunner(KindReportRun, func(ctx context.Context, _ *ports.Job, _ *Service) (map[string]any, map[string]string, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	})
+	job, _, err := service.Create(context.Background(), ports.CreateJobRequest{Kind: KindReportRun})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	service.StartAsync(context.Background(), job)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not start")
+	}
+	if _, err := service.Cancel(context.Background(), job.ID); err != nil {
+		t.Fatalf("Cancel() error = %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		stored, getErr := store.GetJob(context.Background(), job.ID)
+		if getErr != nil {
+			t.Fatalf("GetJob() error = %v", getErr)
+		}
+		if stored.Status == ports.JobStatusCancelled {
+			if stored.LeaseOwner != "" || !stored.LeaseExpiresAt.IsZero() {
+				t.Fatalf("cancelled job retained lease: %+v", stored)
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("job did not transition to cancelled")
+}
+
+func TestRecoverRestartsExpiredLeasedJob(t *testing.T) {
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryJobStore()
+	store.jobs["job-expired"] = &ports.Job{
+		ID:             "job-expired",
+		Kind:           KindReportRun,
+		Status:         ports.JobStatusRunning,
+		Attempt:        1,
+		LeaseOwner:     "dead-worker",
+		LeaseExpiresAt: now.Add(-time.Minute),
+	}
+	service := New(store)
+	service.now = func() time.Time { return now }
+	completed := make(chan struct{})
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		close(completed)
+		return nil, nil, nil
+	})
+
+	count, err := service.Recover(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("Recover() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("Recover() count = %d, want 1", count)
+	}
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("recovered job did not execute")
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		stored, getErr := store.GetJob(context.Background(), "job-expired")
+		if getErr != nil {
+			t.Fatalf("GetJob() error = %v", getErr)
+		}
+		if stored.Status == ports.JobStatusCompleted {
+			if stored.Attempt != 2 {
+				t.Fatalf("attempt = %d, want 2", stored.Attempt)
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("recovered job did not complete")
+}
+
+func TestRunClassifiesRetryableFailure(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-retryable"] = &ports.Job{ID: "job-retryable", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store)
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return nil, nil, Retryable(errors.New("temporary dependency failure"))
+	})
+
+	if err := service.Run(context.Background(), "job-retryable"); err == nil {
+		t.Fatal("Run() error = nil, want retryable failure")
+	}
+	stored, err := store.GetJob(context.Background(), "job-retryable")
+	if err != nil {
+		t.Fatalf("GetJob() error = %v", err)
+	}
+	if stored.Status != ports.JobStatusFailed || stored.FailureClass != JobFailureRetryable {
+		t.Fatalf("job = %+v, want failed/retryable", stored)
+	}
+}
+
+func TestRunRenewsLeaseDuringLongExecution(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-heartbeat"] = &ports.Job{ID: "job-heartbeat", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store).WithLeaseTiming(100*time.Millisecond, 10*time.Millisecond)
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		time.Sleep(35 * time.Millisecond)
+		return nil, nil, nil
+	})
+
+	if err := service.Run(context.Background(), "job-heartbeat"); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	store.mu.Lock()
+	renewCount := store.renewCount
+	store.mu.Unlock()
+	if renewCount == 0 {
+		t.Fatal("job lease was not renewed")
+	}
+}
+
+func TestRunCannotCompleteAfterLeaseOwnershipChanges(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-stale-worker"] = &ports.Job{ID: "job-stale-worker", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store).WithLeaseTiming(time.Second, 500*time.Millisecond)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		close(started)
+		<-release
+		return nil, nil, nil
+	})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- service.Run(context.Background(), "job-stale-worker")
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not start")
+	}
+	store.mu.Lock()
+	store.jobs["job-stale-worker"].LeaseOwner = "replacement-worker"
+	store.mu.Unlock()
+	close(release)
+	if err := <-errCh; !errors.Is(err, ports.ErrJobUpdateConflict) {
+		t.Fatalf("Run() error = %v, want ErrJobUpdateConflict", err)
+	}
+	stored, err := store.GetJob(context.Background(), "job-stale-worker")
+	if err != nil {
+		t.Fatalf("GetJob() error = %v", err)
+	}
+	if stored.Status != ports.JobStatusRunning || stored.LeaseOwner != "replacement-worker" {
+		t.Fatalf("stale worker changed job: %+v", stored)
+	}
+}
+
 type memoryJobStore struct {
-	mu     sync.Mutex
-	nextID int
-	jobs   map[string]*ports.Job
-	events []*ports.JobEvent
+	mu         sync.Mutex
+	nextID     int
+	jobs       map[string]*ports.Job
+	events     []*ports.JobEvent
+	renewCount int
 }
 
 func newMemoryJobStore() *memoryJobStore {
@@ -277,6 +461,16 @@ func (s *memoryJobStore) Ping(context.Context) error {
 func (s *memoryJobStore) CreateJob(_ context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if request.IdempotencyKey != "" {
+		for _, existing := range s.jobs {
+			if existing.TenantID == request.TenantID && existing.IdempotencyKey == request.IdempotencyKey {
+				if existing.RequestHash != request.RequestHash {
+					return nil, false, ports.ErrJobIdempotencyConflict
+				}
+				return cloneJob(existing), false, nil
+			}
+		}
+	}
 	id := "job-test"
 	if s.nextID > 1 {
 		id = fmt.Sprintf("job-test-%d", s.nextID)
@@ -290,6 +484,7 @@ func (s *memoryJobStore) CreateJob(_ context.Context, request ports.CreateJobReq
 		SubjectType:    request.SubjectType,
 		SubjectID:      request.SubjectID,
 		IdempotencyKey: request.IdempotencyKey,
+		RequestHash:    request.RequestHash,
 		Payload:        cloneAnyMap(request.Payload),
 	}
 	s.jobs[id] = cloneJob(job)
@@ -324,6 +519,12 @@ func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.Jo
 	if len(update.AllowedStatuses) > 0 && !containsStatus(update.AllowedStatuses, job.Status) {
 		return nil, ports.ErrJobUpdateConflict
 	}
+	if update.ExpectedLeaseOwner != "" && update.ExpectedLeaseOwner != job.LeaseOwner {
+		return nil, ports.ErrJobUpdateConflict
+	}
+	if update.RequireNotCancelled && job.CancelRequested {
+		return nil, ports.ErrJobUpdateConflict
+	}
 	if update.Status != "" {
 		job.Status = update.Status
 	}
@@ -335,6 +536,9 @@ func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.Jo
 	}
 	if update.Error != "" {
 		job.Error = update.Error
+	}
+	if update.FailureClass != "" {
+		job.FailureClass = update.FailureClass
 	}
 	if update.Result != nil {
 		job.Result = cloneAnyMap(update.Result)
@@ -351,7 +555,69 @@ func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.Jo
 	if update.CancelRequested != nil {
 		job.CancelRequested = *update.CancelRequested
 	}
+	if update.ClearLease {
+		job.LeaseOwner = ""
+		job.LeaseExpiresAt = time.Time{}
+		job.HeartbeatAt = time.Time{}
+	}
 	return cloneJob(job), nil
+}
+
+func (s *memoryJobStore) ClaimJob(_ context.Context, request ports.JobClaimRequest) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[request.JobID]
+	if !ok {
+		return nil, ports.ErrJobNotFound
+	}
+	now := request.Now.UTC()
+	claimable := job.Status == ports.JobStatusQueued || (job.Status == ports.JobStatusRunning && (job.LeaseExpiresAt.IsZero() || !job.LeaseExpiresAt.After(now)))
+	if !claimable || job.CancelRequested {
+		return nil, ports.ErrJobLeaseConflict
+	}
+	job.Status = ports.JobStatusRunning
+	job.Attempt++
+	job.LeaseOwner = request.Owner
+	job.LeaseExpiresAt = now.Add(request.TTL)
+	job.HeartbeatAt = now
+	if job.StartedAt.IsZero() {
+		job.StartedAt = now
+	}
+	return cloneJob(job), nil
+}
+
+func (s *memoryJobStore) RenewJobLease(_ context.Context, request ports.JobLeaseRenewRequest) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[request.JobID]
+	if !ok {
+		return nil, ports.ErrJobNotFound
+	}
+	if job.Status != ports.JobStatusRunning || job.LeaseOwner != request.Owner || !job.LeaseExpiresAt.After(request.Now) {
+		return nil, ports.ErrJobLeaseConflict
+	}
+	job.HeartbeatAt = request.Now
+	job.LeaseExpiresAt = request.Now.Add(request.TTL)
+	s.renewCount++
+	return cloneJob(job), nil
+}
+
+func (s *memoryJobStore) RecoverJobs(_ context.Context, request ports.JobRecoveryRequest) ([]*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	jobs := make([]*ports.Job, 0)
+	for _, job := range s.jobs {
+		if job.Status == ports.JobStatusRunning && (job.LeaseExpiresAt.IsZero() || !job.LeaseExpiresAt.After(request.Now)) {
+			job.Status = ports.JobStatusQueued
+			job.LeaseOwner = ""
+			job.LeaseExpiresAt = time.Time{}
+			job.HeartbeatAt = time.Time{}
+		}
+		if job.Status == ports.JobStatusQueued && !job.CancelRequested {
+			jobs = append(jobs, cloneJob(job))
+		}
+	}
+	return jobs, nil
 }
 
 func (s *memoryJobStore) AppendJobEvent(_ context.Context, event ports.JobEvent) (*ports.JobEvent, error) {

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -366,6 +366,51 @@ func TestRecoverRestartsExpiredLeasedJob(t *testing.T) {
 	t.Fatal("recovered job did not complete")
 }
 
+func TestRecoverMarksMissingRunnerTerminalBeforeNextBatch(t *testing.T) {
+	store := &boundedRecoveryJobStore{
+		memoryJobStore: newMemoryJobStore(),
+		order:          []string{"job-orphan", "job-valid"},
+	}
+	store.jobs["job-orphan"] = &ports.Job{ID: "job-orphan", Kind: "removed_job_kind", Status: ports.JobStatusQueued}
+	store.jobs["job-valid"] = &ports.Job{ID: "job-valid", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store)
+	completed := make(chan struct{})
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		close(completed)
+		return nil, nil, nil
+	})
+
+	count, err := service.Recover(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Recover(orphan) error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("Recover(orphan) count = %d, want 1", count)
+	}
+	waitForJobStatus(t, store.memoryJobStore, "job-orphan", ports.JobStatusFailed)
+	orphan, err := store.GetJob(context.Background(), "job-orphan")
+	if err != nil {
+		t.Fatalf("GetJob(orphan) error = %v", err)
+	}
+	if orphan.FailureClass != JobFailurePermanent || orphan.Error != "job runner unavailable" {
+		t.Fatalf("orphan job = %+v, want permanent runner-unavailable failure", orphan)
+	}
+
+	count, err = service.Recover(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Recover(valid) error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("Recover(valid) count = %d, want 1", count)
+	}
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("valid job behind orphan did not execute")
+	}
+	waitForJobStatus(t, store.memoryJobStore, "job-valid", ports.JobStatusCompleted)
+}
+
 func TestRunClassifiesRetryableFailure(t *testing.T) {
 	store := newMemoryJobStore()
 	store.jobs["job-retryable"] = &ports.Job{ID: "job-retryable", Kind: KindReportRun, Status: ports.JobStatusQueued}
@@ -448,6 +493,32 @@ type memoryJobStore struct {
 	jobs       map[string]*ports.Job
 	events     []*ports.JobEvent
 	renewCount int
+}
+
+type boundedRecoveryJobStore struct {
+	*memoryJobStore
+	order []string
+}
+
+func (s *boundedRecoveryJobStore) RecoverJobs(_ context.Context, request ports.JobRecoveryRequest) ([]*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	limit := request.Limit
+	if limit == 0 {
+		limit = uint32(len(s.order))
+	}
+	jobs := make([]*ports.Job, 0, limit)
+	for _, id := range s.order {
+		job := s.jobs[id]
+		if job == nil || job.Status != ports.JobStatusQueued || job.CancelRequested {
+			continue
+		}
+		jobs = append(jobs, cloneJob(job))
+		if uint32(len(jobs)) == limit {
+			break
+		}
+	}
+	return jobs, nil
 }
 
 func newMemoryJobStore() *memoryJobStore {
@@ -672,6 +743,22 @@ func cloneStringMap(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func waitForJobStatus(t *testing.T, store *memoryJobStore, jobID string, status string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		job, err := store.GetJob(context.Background(), jobID)
+		if err != nil {
+			t.Fatalf("GetJob(%s) error = %v", jobID, err)
+		}
+		if job.Status == status {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not transition to %s", jobID, status)
 }
 
 func captureJobServiceStderr(t *testing.T, fn func()) string {

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -15,6 +15,7 @@ const EventAttributeJobID = "job_id"
 
 var ErrAppendLogDeadLetterNotFound = errors.New("append log dead letter not found")
 var ErrAppendLogDeadLetterAlreadyReplayed = errors.New("append log dead letter already replayed")
+var ErrReplayCursorNotFound = errors.New("append log replay cursor not found")
 
 const (
 	AppendLogDeadLetterStatusPending   = "pending"
@@ -122,11 +123,26 @@ type ReplayRequest struct {
 	TenantID            string
 	AttributeEquals     map[string]string
 	Limit               uint32
+	Cursor              string
 }
 
 // EventReplayer replays stored event envelopes from the append log.
 type EventReplayer interface {
 	Replay(context.Context, ReplayRequest) ([]*cerebrov1.EventEnvelope, error)
+}
+
+// ReplayPage is one bounded replay page. NextCursor is opaque to callers and
+// resumes strictly before the oldest event returned in this page.
+type ReplayPage struct {
+	Events     []*cerebrov1.EventEnvelope
+	NextCursor string
+	Complete   bool
+}
+
+// EventReplayPager traverses arbitrarily large filtered event sets without
+// increasing the per-request replay bound.
+type EventReplayPager interface {
+	ReplayPage(context.Context, ReplayRequest) (ReplayPage, error)
 }
 
 // RuntimeIndexEntry is one append-log message indexed by source runtime and stream sequence.

--- a/internal/ports/compliance_inputs.go
+++ b/internal/ports/compliance_inputs.go
@@ -1,0 +1,45 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// ErrInputSnapshotChanged indicates that a paged input no longer has the total
+// observed on its first page. Callers must discard the partial snapshot and retry.
+var ErrInputSnapshotChanged = errors.New("input snapshot changed during scan")
+
+// InputSnapshotRequest scopes one complete, cutoff-bounded keyset scan.
+// ExpectedTotal and ExpectedWatermark are supplied after the first page to
+// detect inserts, deletes, or mutable rows during later pages.
+type InputSnapshotRequest struct {
+	TenantID          string
+	RuntimeIDs        []string
+	Cutoff            time.Time
+	AfterID           string
+	Limit             uint32
+	ExpectedTotal     *uint64
+	ExpectedWatermark *time.Time
+}
+
+// InputSnapshotPage contains proof needed to assemble a complete input manifest.
+type InputSnapshotPage[T any] struct {
+	Records    []T
+	Total      uint64
+	NextCursor string
+	Complete   bool
+	Cutoff     time.Time
+	Watermark  time.Time
+}
+
+// ComplianceInputSnapshotStore exposes assessment-only scans that are not bound
+// by UI list limits. Each page is read in a repeatable-read transaction and is
+// stable by tenant, cutoff, and primary-key cursor.
+type ComplianceInputSnapshotStore interface {
+	ScanFindingSnapshot(context.Context, InputSnapshotRequest) (InputSnapshotPage[*FindingRecord], error)
+	ScanFindingEvidenceSnapshot(context.Context, InputSnapshotRequest) (InputSnapshotPage[*cerebrov1.FindingEvidence], error)
+	ScanSourceRuntimeSnapshot(context.Context, InputSnapshotRequest) (InputSnapshotPage[*cerebrov1.SourceRuntime], error)
+}

--- a/internal/ports/jobs.go
+++ b/internal/ports/jobs.go
@@ -12,6 +12,12 @@ var ErrJobNotFound = errors.New("platform job not found")
 // ErrJobUpdateConflict indicates that a conditional job state update lost a race.
 var ErrJobUpdateConflict = errors.New("platform job update conflict")
 
+// ErrJobLeaseConflict indicates that a worker no longer owns a job lease.
+var ErrJobLeaseConflict = errors.New("platform job lease conflict")
+
+// ErrJobIdempotencyConflict indicates reuse of a key for a different request.
+var ErrJobIdempotencyConflict = errors.New("platform job idempotency conflict")
+
 const (
 	JobStatusQueued    = "queued"
 	JobStatusRunning   = "running"
@@ -29,6 +35,7 @@ type Job struct {
 	SubjectType     string            `json:"subject_type,omitempty"`
 	SubjectID       string            `json:"subject_id,omitempty"`
 	IdempotencyKey  string            `json:"idempotency_key,omitempty"`
+	RequestHash     string            `json:"-"`
 	Progress        uint32            `json:"progress_percent,omitempty"`
 	Message         string            `json:"message,omitempty"`
 	Error           string            `json:"error,omitempty"`
@@ -36,6 +43,11 @@ type Job struct {
 	Result          map[string]any    `json:"result,omitempty"`
 	ResultRefs      map[string]string `json:"result_refs,omitempty"`
 	CancelRequested bool              `json:"cancel_requested,omitempty"`
+	Attempt         uint32            `json:"attempt,omitempty"`
+	LeaseOwner      string            `json:"-"`
+	LeaseExpiresAt  time.Time         `json:"lease_expires_at,omitempty"`
+	HeartbeatAt     time.Time         `json:"heartbeat_at,omitempty"`
+	FailureClass    string            `json:"failure_class,omitempty"`
 	CreatedAt       time.Time         `json:"created_at,omitempty"`
 	StartedAt       time.Time         `json:"started_at,omitempty"`
 	FinishedAt      time.Time         `json:"finished_at,omitempty"`
@@ -60,6 +72,7 @@ type CreateJobRequest struct {
 	SubjectType    string
 	SubjectID      string
 	IdempotencyKey string
+	RequestHash    string
 	Payload        map[string]any
 }
 
@@ -73,16 +86,42 @@ type JobFilter struct {
 
 // JobUpdate describes a partial job state update.
 type JobUpdate struct {
-	Status          string
-	Progress        *uint32
-	Message         string
-	Error           string
-	Result          map[string]any
-	ResultRefs      map[string]string
-	StartedAt       *time.Time
-	FinishedAt      *time.Time
-	CancelRequested *bool
-	AllowedStatuses []string
+	Status              string
+	Progress            *uint32
+	Message             string
+	Error               string
+	FailureClass        string
+	Result              map[string]any
+	ResultRefs          map[string]string
+	StartedAt           *time.Time
+	FinishedAt          *time.Time
+	CancelRequested     *bool
+	AllowedStatuses     []string
+	ExpectedLeaseOwner  string
+	RequireNotCancelled bool
+	ClearLease          bool
+}
+
+// JobClaimRequest atomically claims queued or expired work for one worker.
+type JobClaimRequest struct {
+	JobID string
+	Owner string
+	Now   time.Time
+	TTL   time.Duration
+}
+
+// JobLeaseRenewRequest extends one running job lease.
+type JobLeaseRenewRequest struct {
+	JobID string
+	Owner string
+	Now   time.Time
+	TTL   time.Duration
+}
+
+// JobRecoveryRequest resets expired work and returns queued jobs for startup.
+type JobRecoveryRequest struct {
+	Now   time.Time
+	Limit uint32
 }
 
 // JobStore persists platform jobs and their timeline events.
@@ -95,4 +134,13 @@ type JobStore interface {
 	UpdateJob(context.Context, string, JobUpdate) (*Job, error)
 	AppendJobEvent(context.Context, JobEvent) (*JobEvent, error)
 	ListJobEvents(context.Context, string, uint32) ([]*JobEvent, error)
+}
+
+// JobLeaseStore is the durable execution capability used by platform workers.
+// It is separate from JobStore so read-only test and integration stores do not
+// accidentally claim to provide recoverable execution.
+type JobLeaseStore interface {
+	ClaimJob(context.Context, JobClaimRequest) (*Job, error)
+	RenewJobLease(context.Context, JobLeaseRenewRequest) (*Job, error)
+	RecoverJobs(context.Context, JobRecoveryRequest) ([]*Job, error)
 }

--- a/internal/ports/reports.go
+++ b/internal/ports/reports.go
@@ -45,6 +45,8 @@ type ReportSchedule struct {
 	Enabled         bool
 	NextRunAt       time.Time
 	LastRunAt       time.Time
+	ClaimOwner      string
+	ClaimExpiresAt  time.Time
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
@@ -63,5 +65,7 @@ type ReportScheduleStore interface {
 	GetReportSchedule(context.Context, string) (*ReportSchedule, error)
 	ListReportSchedules(context.Context, ReportScheduleFilter) ([]*ReportSchedule, error)
 	DeleteReportSchedule(context.Context, string) error
-	ClaimDueReportSchedules(context.Context, time.Time, uint32) ([]*ReportSchedule, error)
+	ClaimDueReportSchedules(context.Context, time.Time, string, time.Duration, uint32) ([]*ReportSchedule, error)
+	CompleteReportScheduleClaim(context.Context, string, string, time.Time, time.Time) error
+	ReleaseReportScheduleClaim(context.Context, string, string) error
 }

--- a/internal/reportschedule/run.go
+++ b/internal/reportschedule/run.go
@@ -1,0 +1,92 @@
+package reportschedule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	claimBatch  = uint32(50)
+	claimTTL    = 2 * time.Minute
+	subjectType = "report_schedule"
+)
+
+// RunDue claims due occurrences, creates their idempotent jobs, and advances a
+// schedule only after job creation succeeds.
+func RunDue(ctx context.Context, store ports.ReportScheduleStore, jobs *platformjobs.Service, now time.Time) (int, error) {
+	if store == nil || jobs == nil {
+		return 0, nil
+	}
+	now = now.UTC()
+	owner := newClaimOwner()
+	due, err := store.ClaimDueReportSchedules(ctx, now, owner, claimTTL, claimBatch)
+	if err != nil {
+		return 0, err
+	}
+	enqueued := 0
+	var errs []error
+	for _, schedule := range due {
+		if err := enqueue(ctx, jobs, schedule); err != nil {
+			_ = store.ReleaseReportScheduleClaim(context.WithoutCancel(ctx), schedule.ID, owner)
+			errs = append(errs, fmt.Errorf("report schedule %q: %w", schedule.ID, err))
+			continue
+		}
+		if err := store.CompleteReportScheduleClaim(context.WithoutCancel(ctx), schedule.ID, owner, schedule.NextRunAt, now); err != nil {
+			errs = append(errs, fmt.Errorf("report schedule %q completion: %w", schedule.ID, err))
+			continue
+		}
+		enqueued++
+	}
+	return enqueued, errors.Join(errs...)
+}
+
+func enqueue(ctx context.Context, jobs *platformjobs.Service, schedule *ports.ReportSchedule) error {
+	if schedule == nil {
+		return nil
+	}
+	parameters := make(map[string]any, len(schedule.Parameters)+1)
+	for key, value := range schedule.Parameters {
+		parameters[key] = value
+	}
+	if tenantID := strings.TrimSpace(schedule.TenantID); tenantID != "" {
+		if _, ok := parameters["tenant_id"]; !ok {
+			parameters["tenant_id"] = tenantID
+		}
+	}
+	job, created, err := jobs.Create(ctx, ports.CreateJobRequest{
+		Kind:           platformjobs.KindReportRun,
+		TenantID:       schedule.TenantID,
+		SubjectType:    subjectType,
+		SubjectID:      schedule.ID,
+		IdempotencyKey: occurrenceKey(schedule),
+		Payload: map[string]any{
+			"report_id":     schedule.ReportID,
+			"parameters":    parameters,
+			"scheduled_for": schedule.NextRunAt.UTC().Format(time.RFC3339Nano),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if created {
+		jobs.StartAsync(ctx, job)
+	}
+	return nil
+}
+
+func occurrenceKey(schedule *ports.ReportSchedule) string {
+	if schedule == nil {
+		return ""
+	}
+	return "report-schedule:" + strings.TrimSpace(schedule.ID) + ":" + schedule.NextRunAt.UTC().Format(time.RFC3339Nano)
+}
+
+func newClaimOwner() string {
+	return "scheduler-" + strings.TrimPrefix(platformjobs.NewID(), "job-")
+}

--- a/internal/statestore/postgres/compliance_inputs.go
+++ b/internal/statestore/postgres/compliance_inputs.go
@@ -1,0 +1,332 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	defaultInputSnapshotPageSize = uint32(250)
+	maxInputSnapshotPageSize     = uint32(500)
+)
+
+// ScanFindingSnapshot returns one cutoff-bounded finding page with a stable ID
+// cursor and an invariant total for complete assessment collection.
+func (s *Store) ScanFindingSnapshot(ctx context.Context, request ports.InputSnapshotRequest) (ports.InputSnapshotPage[*ports.FindingRecord], error) {
+	normalized, err := normalizeInputSnapshotRequest(request)
+	if err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	if s == nil || s.db == nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, fmt.Errorf("begin finding snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	scopeClauses, scopeArgs := inputSnapshotScopeClauses(normalized, "tenant_id", "runtime_id")
+	total, watermark, err := measureInputSnapshot(ctx, tx, "findings", scopeClauses, scopeArgs)
+	if err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	if err := verifyInputSnapshotInvariant(normalized, total, watermark); err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	clauses, args := addInputSnapshotCutoff(scopeClauses, scopeArgs, normalized.Cutoff)
+	pageClauses, pageArgs := addInputSnapshotCursor(clauses, args, normalized.AfterID)
+	pageArgs = append(pageArgs, int64(normalized.Limit+1))
+	// #nosec G201 -- columns and predicates are fixed; all values are parameterized.
+	query := fmt.Sprintf(`
+SELECT %s
+FROM findings
+WHERE %s
+ORDER BY id ASC
+LIMIT $%d`, findingSelectColumns, strings.Join(pageClauses, " AND "), len(pageArgs))
+	rows, err := tx.QueryContext(ctx, query, pageArgs...)
+	if err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, fmt.Errorf("query finding snapshot: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]*ports.FindingRecord, 0, normalized.Limit+1)
+	for rows.Next() {
+		var row findingRow
+		if err := scanFindingRow(rows, &row); err != nil {
+			return ports.InputSnapshotPage[*ports.FindingRecord]{}, fmt.Errorf("scan finding snapshot: %w", err)
+		}
+		record, err := row.record()
+		if err != nil {
+			return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	page := finishInputSnapshotPage(records, normalized, total, watermark, func(record *ports.FindingRecord) string { return record.ID })
+	if err := tx.Commit(); err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, fmt.Errorf("commit finding snapshot: %w", err)
+	}
+	return page, nil
+}
+
+// ScanFindingEvidenceSnapshot returns one complete-collection evidence page.
+func (s *Store) ScanFindingEvidenceSnapshot(ctx context.Context, request ports.InputSnapshotRequest) (ports.InputSnapshotPage[*cerebrov1.FindingEvidence], error) {
+	normalized, err := normalizeInputSnapshotRequest(request)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	if s == nil || s.db == nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("begin finding evidence snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	scopeClauses, scopeArgs := findingEvidenceInputSnapshotScopeClauses(normalized)
+	total, watermark, err := measureInputSnapshot(ctx, tx, "finding_evidence", scopeClauses, scopeArgs)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	if err := verifyInputSnapshotInvariant(normalized, total, watermark); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	clauses, args := addInputSnapshotCutoff(scopeClauses, scopeArgs, normalized.Cutoff)
+	pageClauses, pageArgs := addInputSnapshotCursor(clauses, args, normalized.AfterID)
+	pageArgs = append(pageArgs, int64(normalized.Limit+1))
+	// #nosec G201 -- predicates and ordering are fixed; all values are parameterized.
+	query := fmt.Sprintf(`
+SELECT id, finding_evidence_json::text
+FROM finding_evidence
+WHERE %s
+ORDER BY id ASC
+LIMIT $%d`, strings.Join(pageClauses, " AND "), len(pageArgs))
+	rows, err := tx.QueryContext(ctx, query, pageArgs...)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("query finding evidence snapshot: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]*cerebrov1.FindingEvidence, 0, normalized.Limit+1)
+	for rows.Next() {
+		var id, payload string
+		if err := rows.Scan(&id, &payload); err != nil {
+			return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("scan finding evidence snapshot: %w", err)
+		}
+		record := &cerebrov1.FindingEvidence{}
+		if err := protojson.Unmarshal([]byte(payload), record); err != nil {
+			return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("decode finding evidence %q: %w", id, err)
+		}
+		if strings.TrimSpace(record.GetId()) != id {
+			return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("finding evidence id mismatch: row %q payload %q", id, record.GetId())
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	page := finishInputSnapshotPage(records, normalized, total, watermark, func(record *cerebrov1.FindingEvidence) string { return record.GetId() })
+	if err := tx.Commit(); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("commit finding evidence snapshot: %w", err)
+	}
+	return page, nil
+}
+
+// ScanSourceRuntimeSnapshot returns one complete-collection runtime page.
+func (s *Store) ScanSourceRuntimeSnapshot(ctx context.Context, request ports.InputSnapshotRequest) (ports.InputSnapshotPage[*cerebrov1.SourceRuntime], error) {
+	normalized, err := normalizeInputSnapshotRequest(request)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	if s == nil || s.db == nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("begin source runtime snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	scopeClauses, scopeArgs := inputSnapshotScopeClauses(normalized, "runtime_json->>'tenant_id'", "id")
+	total, watermark, err := measureInputSnapshot(ctx, tx, "source_runtimes", scopeClauses, scopeArgs)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	if err := verifyInputSnapshotInvariant(normalized, total, watermark); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	clauses, args := addInputSnapshotCutoff(scopeClauses, scopeArgs, normalized.Cutoff)
+	pageClauses, pageArgs := addInputSnapshotCursor(clauses, args, normalized.AfterID)
+	pageArgs = append(pageArgs, int64(normalized.Limit+1))
+	// #nosec G201 -- predicates and ordering are fixed; all values are parameterized.
+	query := fmt.Sprintf(`
+SELECT id, runtime_json::text
+FROM source_runtimes
+WHERE %s
+ORDER BY id ASC
+LIMIT $%d`, strings.Join(pageClauses, " AND "), len(pageArgs))
+	rows, err := tx.QueryContext(ctx, query, pageArgs...)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("query source runtime snapshot: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]*cerebrov1.SourceRuntime, 0, normalized.Limit+1)
+	for rows.Next() {
+		var id, payload string
+		if err := rows.Scan(&id, &payload); err != nil {
+			return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("scan source runtime snapshot: %w", err)
+		}
+		record := &cerebrov1.SourceRuntime{}
+		if err := protojson.Unmarshal([]byte(payload), record); err != nil {
+			return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("decode source runtime %q: %w", id, err)
+		}
+		if strings.TrimSpace(record.GetId()) != id {
+			return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("source runtime id mismatch: row %q payload %q", id, record.GetId())
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	page := finishInputSnapshotPage(records, normalized, total, watermark, func(record *cerebrov1.SourceRuntime) string { return record.GetId() })
+	if err := tx.Commit(); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("commit source runtime snapshot: %w", err)
+	}
+	return page, nil
+}
+
+func normalizeInputSnapshotRequest(request ports.InputSnapshotRequest) (ports.InputSnapshotRequest, error) {
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.RuntimeIDs = normalizedNonEmptyStrings(request.RuntimeIDs)
+	request.AfterID = strings.TrimSpace(request.AfterID)
+	request.Cutoff = request.Cutoff.UTC()
+	if request.TenantID == "" {
+		return ports.InputSnapshotRequest{}, errors.New("input snapshot tenant id is required")
+	}
+	if len(request.RuntimeIDs) == 0 {
+		return ports.InputSnapshotRequest{}, errors.New("input snapshot runtime ids are required")
+	}
+	if request.Cutoff.IsZero() {
+		return ports.InputSnapshotRequest{}, errors.New("input snapshot cutoff is required")
+	}
+	if request.Limit == 0 {
+		request.Limit = defaultInputSnapshotPageSize
+	}
+	if request.Limit > maxInputSnapshotPageSize {
+		return ports.InputSnapshotRequest{}, fmt.Errorf("input snapshot limit must be <= %d", maxInputSnapshotPageSize)
+	}
+	return request, nil
+}
+
+func inputSnapshotScopeClauses(request ports.InputSnapshotRequest, tenantColumn string, runtimeColumn string) ([]string, []any) {
+	clauses := make([]string, 0, 2)
+	args := make([]any, 0, len(request.RuntimeIDs)+1)
+	if tenantColumn != "" {
+		args = append(args, request.TenantID)
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", tenantColumn, len(args)))
+	}
+	placeholders := make([]string, 0, len(request.RuntimeIDs))
+	for _, runtimeID := range request.RuntimeIDs {
+		args = append(args, runtimeID)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+	}
+	clauses = append(clauses, fmt.Sprintf("%s IN (%s)", runtimeColumn, strings.Join(placeholders, ", ")))
+	return clauses, args
+}
+
+func findingEvidenceInputSnapshotScopeClauses(request ports.InputSnapshotRequest) ([]string, []any) {
+	args := []any{request.TenantID}
+	clauses := []string{"EXISTS (SELECT 1 FROM source_runtimes input_runtime WHERE input_runtime.id = finding_evidence.runtime_id AND input_runtime.runtime_json->>'tenant_id' = $1)"}
+	placeholders := make([]string, 0, len(request.RuntimeIDs))
+	for _, runtimeID := range request.RuntimeIDs {
+		args = append(args, runtimeID)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+	}
+	clauses = append(clauses, fmt.Sprintf("runtime_id IN (%s)", strings.Join(placeholders, ", ")))
+	return clauses, args
+}
+
+func addInputSnapshotCutoff(clauses []string, args []any, cutoff time.Time) ([]string, []any) {
+	resultClauses := append([]string(nil), clauses...)
+	resultArgs := append([]any(nil), args...)
+	resultArgs = append(resultArgs, cutoff.UTC())
+	resultClauses = append(resultClauses, fmt.Sprintf("updated_at <= $%d", len(resultArgs)))
+	return resultClauses, resultArgs
+}
+
+func addInputSnapshotCursor(clauses []string, args []any, afterID string) ([]string, []any) {
+	pageClauses := append([]string(nil), clauses...)
+	pageArgs := append([]any(nil), args...)
+	if afterID != "" {
+		pageArgs = append(pageArgs, afterID)
+		pageClauses = append(pageClauses, fmt.Sprintf("id > $%d", len(pageArgs)))
+	}
+	return pageClauses, pageArgs
+}
+
+func measureInputSnapshot(ctx context.Context, tx *sql.Tx, table string, clauses []string, args []any) (uint64, time.Time, error) {
+	// #nosec G201 -- callers supply fixed internal table names and predicates.
+	query := fmt.Sprintf("SELECT COUNT(*), MAX(updated_at) FROM %s WHERE %s", table, strings.Join(clauses, " AND "))
+	var count int64
+	var watermark sql.NullTime
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&count, &watermark); err != nil {
+		return 0, time.Time{}, fmt.Errorf("measure %s input snapshot: %w", table, err)
+	}
+	if count < 0 {
+		return 0, time.Time{}, fmt.Errorf("count %s input snapshot returned a negative value", table)
+	}
+	if !watermark.Valid {
+		return uint64(count), time.Time{}, nil
+	}
+	return uint64(count), watermark.Time.UTC(), nil
+}
+
+func verifyInputSnapshotInvariant(request ports.InputSnapshotRequest, total uint64, watermark time.Time) error {
+	if request.ExpectedTotal != nil && *request.ExpectedTotal != total {
+		return fmt.Errorf("%w: expected %d records, found %d", ports.ErrInputSnapshotChanged, *request.ExpectedTotal, total)
+	}
+	if request.ExpectedWatermark != nil && !request.ExpectedWatermark.Equal(watermark) {
+		return fmt.Errorf("%w: input watermark changed", ports.ErrInputSnapshotChanged)
+	}
+	if watermark.After(request.Cutoff) {
+		return fmt.Errorf("%w: input changed after cutoff", ports.ErrInputSnapshotChanged)
+	}
+	return nil
+}
+
+func finishInputSnapshotPage[T any](records []T, request ports.InputSnapshotRequest, total uint64, watermark time.Time, id func(T) string) ports.InputSnapshotPage[T] {
+	complete := len(records) <= int(request.Limit)
+	if !complete {
+		records = records[:request.Limit]
+	}
+	nextCursor := ""
+	if !complete && len(records) > 0 {
+		nextCursor = strings.TrimSpace(id(records[len(records)-1]))
+	}
+	return ports.InputSnapshotPage[T]{Records: records, Total: total, NextCursor: nextCursor, Complete: complete, Cutoff: request.Cutoff, Watermark: watermark}
+}
+
+var _ ports.ComplianceInputSnapshotStore = (*Store)(nil)

--- a/internal/statestore/postgres/compliance_inputs_test.go
+++ b/internal/statestore/postgres/compliance_inputs_test.go
@@ -1,0 +1,103 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestNormalizeInputSnapshotRequestRequiresStableScope(t *testing.T) {
+	cutoff := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	request, err := normalizeInputSnapshotRequest(ports.InputSnapshotRequest{
+		TenantID:   " tenant-a ",
+		RuntimeIDs: []string{"runtime-b", "runtime-a", "runtime-a", " "},
+		Cutoff:     cutoff,
+	})
+	if err != nil {
+		t.Fatalf("normalizeInputSnapshotRequest() error = %v", err)
+	}
+	if request.TenantID != "tenant-a" || request.Limit != defaultInputSnapshotPageSize || !request.Cutoff.Equal(cutoff) {
+		t.Fatalf("normalized request = %+v", request)
+	}
+	if len(request.RuntimeIDs) != 2 || request.RuntimeIDs[0] != "runtime-b" || request.RuntimeIDs[1] != "runtime-a" {
+		t.Fatalf("runtime ids = %v", request.RuntimeIDs)
+	}
+
+	cases := []ports.InputSnapshotRequest{
+		{RuntimeIDs: []string{"runtime-a"}, Cutoff: cutoff},
+		{TenantID: "tenant-a", Cutoff: cutoff},
+		{TenantID: "tenant-a", RuntimeIDs: []string{"runtime-a"}},
+		{TenantID: "tenant-a", RuntimeIDs: []string{"runtime-a"}, Cutoff: cutoff, Limit: maxInputSnapshotPageSize + 1},
+	}
+	for _, invalid := range cases {
+		if _, err := normalizeInputSnapshotRequest(invalid); err == nil {
+			t.Fatalf("normalizeInputSnapshotRequest(%+v) error = nil", invalid)
+		}
+	}
+}
+
+func TestFinishInputSnapshotPageUsesKeysetCursor(t *testing.T) {
+	cutoff := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	watermark := cutoff.Add(-time.Minute)
+	page := finishInputSnapshotPage([]string{"a", "b", "c"}, ports.InputSnapshotRequest{Limit: 2, Cutoff: cutoff}, 3, watermark, func(value string) string { return value })
+	if page.Complete || page.NextCursor != "b" || len(page.Records) != 2 || page.Total != 3 || !page.Cutoff.Equal(cutoff) || !page.Watermark.Equal(watermark) {
+		t.Fatalf("page = %+v", page)
+	}
+
+	last := finishInputSnapshotPage([]string{"c"}, ports.InputSnapshotRequest{Limit: 2, Cutoff: cutoff}, 3, watermark, func(value string) string { return value })
+	if !last.Complete || last.NextCursor != "" || len(last.Records) != 1 {
+		t.Fatalf("last page = %+v", last)
+	}
+}
+
+func TestFinishInputSnapshotPageDoesNotTruncateAtUILimit(t *testing.T) {
+	records := make([]string, 501)
+	for i := range records {
+		records[i] = fmt.Sprintf("record-%04d", i+1)
+	}
+	cutoff := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	page := finishInputSnapshotPage(records, ports.InputSnapshotRequest{Limit: 500, Cutoff: cutoff}, 501, cutoff, func(value string) string { return value })
+	if page.Complete || len(page.Records) != 500 || page.NextCursor != "record-0500" || page.Total != 501 {
+		t.Fatalf("page count=%d complete=%v cursor=%q total=%d", len(page.Records), page.Complete, page.NextCursor, page.Total)
+	}
+}
+
+func TestVerifyInputSnapshotInvariantDetectsMutation(t *testing.T) {
+	expected := uint64(501)
+	cutoff := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	watermark := cutoff.Add(-time.Minute)
+	request := ports.InputSnapshotRequest{Cutoff: cutoff, ExpectedTotal: &expected, ExpectedWatermark: &watermark}
+	if err := verifyInputSnapshotInvariant(request, 501, watermark); err != nil {
+		t.Fatalf("verifyInputSnapshotInvariant(equal) error = %v", err)
+	}
+	if err := verifyInputSnapshotInvariant(request, 500, watermark); !errors.Is(err, ports.ErrInputSnapshotChanged) {
+		t.Fatalf("verifyInputSnapshotInvariant(total changed) error = %v, want ErrInputSnapshotChanged", err)
+	}
+	if err := verifyInputSnapshotInvariant(request, 501, cutoff); !errors.Is(err, ports.ErrInputSnapshotChanged) {
+		t.Fatalf("verifyInputSnapshotInvariant(watermark changed) error = %v, want ErrInputSnapshotChanged", err)
+	}
+	request.ExpectedWatermark = nil
+	if err := verifyInputSnapshotInvariant(request, 501, cutoff.Add(time.Second)); !errors.Is(err, ports.ErrInputSnapshotChanged) {
+		t.Fatalf("verifyInputSnapshotInvariant(after cutoff) error = %v, want ErrInputSnapshotChanged", err)
+	}
+}
+
+func TestFindingEvidenceInputSnapshotClausesEnforceRuntimeTenant(t *testing.T) {
+	request := ports.InputSnapshotRequest{
+		TenantID:   "tenant-a",
+		RuntimeIDs: []string{"runtime-a", "runtime-b"},
+		Cutoff:     time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC),
+	}
+	clauses, args := findingEvidenceInputSnapshotScopeClauses(request)
+	joined := strings.Join(clauses, " AND ")
+	if !strings.Contains(joined, "input_runtime.runtime_json->>'tenant_id' = $1") {
+		t.Fatalf("clauses do not enforce tenant: %s", joined)
+	}
+	if len(args) != 3 || args[0] != "tenant-a" || args[1] != "runtime-a" || args[2] != "runtime-b" {
+		t.Fatalf("args = %#v", args)
+	}
+}

--- a/internal/statestore/postgres/jobs.go
+++ b/internal/statestore/postgres/jobs.go
@@ -23,6 +23,7 @@ var ensureJobStatements = []string{
   subject_type TEXT NOT NULL DEFAULT '',
   subject_id TEXT NOT NULL DEFAULT '',
   idempotency_key TEXT NOT NULL DEFAULT '',
+  request_hash TEXT NOT NULL DEFAULT '',
   progress_percent INTEGER NOT NULL DEFAULT 0,
   message TEXT NOT NULL DEFAULT '',
   error TEXT NOT NULL DEFAULT '',
@@ -30,14 +31,26 @@ var ensureJobStatements = []string{
   result_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   result_refs_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   cancel_requested BOOLEAN NOT NULL DEFAULT FALSE,
+  attempt INTEGER NOT NULL DEFAULT 0,
+  lease_owner TEXT NOT NULL DEFAULT '',
+  lease_expires_at TIMESTAMPTZ,
+  heartbeat_at TIMESTAMPTZ,
+  failure_class TEXT NOT NULL DEFAULT '',
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   started_at TIMESTAMPTZ,
   finished_at TIMESTAMPTZ,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS request_hash TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS lease_owner TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS heartbeat_at TIMESTAMPTZ`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS failure_class TEXT NOT NULL DEFAULT ''`,
 	`CREATE UNIQUE INDEX IF NOT EXISTS platform_jobs_idempotency_idx ON platform_jobs (tenant_id, idempotency_key) WHERE idempotency_key <> ''`,
 	`CREATE INDEX IF NOT EXISTS platform_jobs_tenant_status_idx ON platform_jobs (tenant_id, status, updated_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS platform_jobs_kind_updated_idx ON platform_jobs (kind, updated_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS platform_jobs_recovery_idx ON platform_jobs (status, lease_expires_at, created_at) WHERE status IN ('queued', 'running')`,
 	`CREATE TABLE IF NOT EXISTS platform_job_events (
   job_id TEXT NOT NULL REFERENCES platform_jobs(id) ON DELETE CASCADE,
   sequence BIGSERIAL PRIMARY KEY,
@@ -49,6 +62,11 @@ var ensureJobStatements = []string{
 )`,
 	`CREATE INDEX IF NOT EXISTS platform_job_events_job_sequence_idx ON platform_job_events (job_id, sequence ASC)`,
 }
+
+const platformJobColumns = `id, kind, status, tenant_id, subject_type, subject_id, idempotency_key, request_hash,
+       progress_percent, message, error, payload_json::text, result_json::text,
+       result_refs_json::text, cancel_requested, attempt, lease_owner, lease_expires_at,
+       heartbeat_at, failure_class, created_at, started_at, finished_at, updated_at`
 
 // CreateJob inserts a platform job or returns the existing idempotent job.
 func (s *Store) CreateJob(ctx context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
@@ -66,6 +84,7 @@ func (s *Store) CreateJob(ctx context.Context, request ports.CreateJobRequest) (
 		SubjectType:    strings.TrimSpace(request.SubjectType),
 		SubjectID:      strings.TrimSpace(request.SubjectID),
 		IdempotencyKey: strings.TrimSpace(request.IdempotencyKey),
+		RequestHash:    strings.TrimSpace(request.RequestHash),
 		Payload:        cloneMap(request.Payload),
 	}
 	payload, err := json.Marshal(job.Payload)
@@ -74,11 +93,16 @@ func (s *Store) CreateJob(ctx context.Context, request ports.CreateJobRequest) (
 	}
 	row := s.db.QueryRowContext(ctx, `
 INSERT INTO platform_jobs (
-  id, kind, status, tenant_id, subject_type, subject_id, idempotency_key, payload_json
+  id, kind, status, tenant_id, subject_type, subject_id, idempotency_key, request_hash, payload_json
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
 ON CONFLICT (tenant_id, idempotency_key) WHERE idempotency_key <> ''
-DO UPDATE SET updated_at = platform_jobs.updated_at
+DO UPDATE SET request_hash = CASE
+  WHEN platform_jobs.request_hash = '' THEN EXCLUDED.request_hash
+  ELSE platform_jobs.request_hash
+END,
+updated_at = platform_jobs.updated_at
+WHERE platform_jobs.request_hash = '' OR platform_jobs.request_hash = EXCLUDED.request_hash
 RETURNING id, (xmax = 0) AS inserted`,
 		job.ID,
 		job.Kind,
@@ -87,11 +111,15 @@ RETURNING id, (xmax = 0) AS inserted`,
 		job.SubjectType,
 		job.SubjectID,
 		job.IdempotencyKey,
+		job.RequestHash,
 		string(payload),
 	)
 	var id string
 	var inserted bool
 	if err := row.Scan(&id, &inserted); err != nil {
+		if errors.Is(err, sql.ErrNoRows) && job.IdempotencyKey != "" {
+			return nil, false, fmt.Errorf("%w: tenant %q key %q", ports.ErrJobIdempotencyConflict, job.TenantID, job.IdempotencyKey)
+		}
 		return nil, false, fmt.Errorf("insert platform job: %w", err)
 	}
 	stored, err := s.GetJob(ctx, id)
@@ -113,12 +141,11 @@ func (s *Store) GetJob(ctx context.Context, id string) (*ports.Job, error) {
 	if err := s.ensureJobTables(ctx); err != nil {
 		return nil, err
 	}
-	row := s.db.QueryRowContext(ctx, `
-SELECT id, kind, status, tenant_id, subject_type, subject_id, idempotency_key,
-       progress_percent, message, error, payload_json::text, result_json::text,
-       result_refs_json::text, cancel_requested, created_at, started_at, finished_at, updated_at
+	// #nosec G201 -- the column list is a fixed constant and the id is parameterized.
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT %s
 FROM platform_jobs
-WHERE id = $1`, id)
+WHERE id = $1`, platformJobColumns), id)
 	job, err := scanJob(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -145,13 +172,11 @@ func (s *Store) ListJobs(ctx context.Context, filter ports.JobFilter) ([]*ports.
 	args = append(args, limit)
 	// #nosec G201 -- clauses are fixed column predicates and LIMIT placeholder index is derived from args.
 	query := fmt.Sprintf(`
-SELECT id, kind, status, tenant_id, subject_type, subject_id, idempotency_key,
-       progress_percent, message, error, payload_json::text, result_json::text,
-       result_refs_json::text, cancel_requested, created_at, started_at, finished_at, updated_at
+SELECT %s
 FROM platform_jobs
 WHERE %s
 ORDER BY updated_at DESC, id ASC
-LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
+LIMIT $%d`, platformJobColumns, strings.Join(clauses, " AND "), len(args))
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list platform jobs: %w", err)
@@ -235,6 +260,9 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 	if update.Error != "" {
 		addSet("error", update.Error)
 	}
+	if update.FailureClass != "" {
+		addSet("failure_class", strings.TrimSpace(update.FailureClass))
+	}
 	if update.Result != nil {
 		result, err := json.Marshal(cloneMap(update.Result))
 		if err != nil {
@@ -258,9 +286,23 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 	if update.CancelRequested != nil {
 		addSet("cancel_requested", *update.CancelRequested)
 	}
+	if update.ClearLease {
+		setClauses = append(setClauses,
+			"lease_owner = ''",
+			"lease_expires_at = NULL",
+			"heartbeat_at = NULL",
+		)
+	}
 	setClauses = append(setClauses, "updated_at = NOW()")
 	allowedStatuses := normalizeJobStatuses(update.AllowedStatuses)
 	clauses := []string{"id = $1"}
+	if expectedOwner := strings.TrimSpace(update.ExpectedLeaseOwner); expectedOwner != "" {
+		args = append(args, expectedOwner)
+		clauses = append(clauses, fmt.Sprintf("lease_owner = $%d", len(args)))
+	}
+	if update.RequireNotCancelled {
+		clauses = append(clauses, "cancel_requested = FALSE")
+	}
 	if len(allowedStatuses) > 0 {
 		placeholders := make([]string, 0, len(allowedStatuses))
 		for _, status := range allowedStatuses {
@@ -283,6 +325,175 @@ WHERE %s`, strings.Join(setClauses, ", "), strings.Join(clauses, " AND ")), args
 		return nil, fmt.Errorf("%w: %s", ports.ErrJobNotFound, id)
 	}
 	return s.GetJob(ctx, id)
+}
+
+// ClaimJob atomically assigns queued or expired work to one worker.
+func (s *Store) ClaimJob(ctx context.Context, request ports.JobClaimRequest) (*ports.Job, error) {
+	jobID, owner, now, expiresAt, err := normalizeJobLeaseRequest(request.JobID, request.Owner, request.Now, request.TTL)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	// #nosec G201 -- the column list is fixed and all values are parameterized.
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+UPDATE platform_jobs
+SET status = $2,
+    attempt = attempt + 1,
+    lease_owner = $3,
+    lease_expires_at = $4,
+    heartbeat_at = $5,
+    started_at = COALESCE(started_at, $5),
+    message = 'job running',
+    failure_class = '',
+    updated_at = NOW()
+WHERE id = $1
+  AND cancel_requested = FALSE
+  AND (
+    status = $6
+    OR (status = $2 AND (lease_expires_at IS NULL OR lease_expires_at <= $5))
+  )
+RETURNING %s`, platformJobColumns), jobID, ports.JobStatusRunning, owner, expiresAt, now, ports.JobStatusQueued)
+	job, scanErr := scanJob(row)
+	if scanErr == nil {
+		return job, nil
+	}
+	if !errors.Is(scanErr, sql.ErrNoRows) {
+		return nil, fmt.Errorf("claim platform job %q: %w", jobID, scanErr)
+	}
+	if _, getErr := s.GetJob(ctx, jobID); getErr != nil {
+		return nil, getErr
+	}
+	return nil, fmt.Errorf("%w: %s", ports.ErrJobLeaseConflict, jobID)
+}
+
+// RenewJobLease extends a live owner lease and returns current cancellation state.
+func (s *Store) RenewJobLease(ctx context.Context, request ports.JobLeaseRenewRequest) (*ports.Job, error) {
+	jobID, owner, now, expiresAt, err := normalizeJobLeaseRequest(request.JobID, request.Owner, request.Now, request.TTL)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	// #nosec G201 -- the column list is fixed and all values are parameterized.
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+UPDATE platform_jobs
+SET lease_expires_at = $3,
+    heartbeat_at = $4,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = $5
+  AND lease_owner = $2
+  AND lease_expires_at > $4
+RETURNING %s`, platformJobColumns), jobID, owner, expiresAt, now, ports.JobStatusRunning)
+	job, scanErr := scanJob(row)
+	if scanErr == nil {
+		return job, nil
+	}
+	if errors.Is(scanErr, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %s", ports.ErrJobLeaseConflict, jobID)
+	}
+	return nil, fmt.Errorf("renew platform job lease %q: %w", jobID, scanErr)
+}
+
+// RecoverJobs resets expired running jobs and lists queued work for startup.
+func (s *Store) RecoverJobs(ctx context.Context, request ports.JobRecoveryRequest) ([]*ports.Job, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	now := request.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	limit := request.Limit
+	if limit == 0 || limit > 500 {
+		limit = 100
+	}
+	// #nosec G201 -- the column list is fixed and all values are parameterized.
+	query := fmt.Sprintf(`
+WITH cancelled AS (
+  UPDATE platform_jobs
+  SET status = $5,
+      message = 'job cancelled',
+      failure_class = 'cancelled',
+      finished_at = COALESCE(finished_at, $3),
+      lease_owner = '',
+      lease_expires_at = NULL,
+      heartbeat_at = NULL,
+      updated_at = NOW()
+  WHERE status = $2
+    AND cancel_requested = TRUE
+    AND (lease_expires_at IS NULL OR lease_expires_at <= $3)
+  RETURNING id
+), recovered AS (
+  UPDATE platform_jobs
+  SET status = $1,
+      message = 'job recovered after lease expiry',
+      lease_owner = '',
+      lease_expires_at = NULL,
+      heartbeat_at = NULL,
+      updated_at = NOW()
+  WHERE status = $2
+    AND cancel_requested = FALSE
+    AND (lease_expires_at IS NULL OR lease_expires_at <= $3)
+  RETURNING %s
+), queued AS (
+  SELECT %s
+  FROM platform_jobs
+  WHERE status = $1 AND cancel_requested = FALSE
+)
+SELECT *
+FROM (
+  SELECT * FROM recovered
+  UNION ALL
+  SELECT * FROM queued
+) runnable
+ORDER BY created_at ASC, id ASC
+LIMIT $4`, platformJobColumns, platformJobColumns)
+	rows, err := s.db.QueryContext(ctx, query, ports.JobStatusQueued, ports.JobStatusRunning, now, limit, ports.JobStatusCancelled)
+	if err != nil {
+		return nil, fmt.Errorf("recover platform jobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	jobs := make([]*ports.Job, 0)
+	for rows.Next() {
+		job, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func normalizeJobLeaseRequest(jobID string, owner string, now time.Time, ttl time.Duration) (string, string, time.Time, time.Time, error) {
+	jobID = strings.TrimSpace(jobID)
+	owner = strings.TrimSpace(owner)
+	if jobID == "" {
+		return "", "", time.Time{}, time.Time{}, errors.New("job id is required")
+	}
+	if owner == "" {
+		return "", "", time.Time{}, time.Time{}, errors.New("job lease owner is required")
+	}
+	if ttl <= 0 {
+		return "", "", time.Time{}, time.Time{}, errors.New("job lease ttl must be positive")
+	}
+	now = now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return jobID, owner, now, now.Add(ttl), nil
 }
 
 // AppendJobEvent appends one timeline event.
@@ -367,10 +578,11 @@ type scanner interface {
 func scanJob(row scanner) (*ports.Job, error) {
 	job := &ports.Job{}
 	var payload, result, refs string
-	var started, finished sql.NullTime
+	var leaseExpires, heartbeat, started, finished sql.NullTime
 	if err := row.Scan(
-		&job.ID, &job.Kind, &job.Status, &job.TenantID, &job.SubjectType, &job.SubjectID, &job.IdempotencyKey,
+		&job.ID, &job.Kind, &job.Status, &job.TenantID, &job.SubjectType, &job.SubjectID, &job.IdempotencyKey, &job.RequestHash,
 		&job.Progress, &job.Message, &job.Error, &payload, &result, &refs, &job.CancelRequested,
+		&job.Attempt, &job.LeaseOwner, &leaseExpires, &heartbeat, &job.FailureClass,
 		&job.CreatedAt, &started, &finished, &job.UpdatedAt,
 	); err != nil {
 		return nil, err
@@ -383,6 +595,12 @@ func scanJob(row scanner) (*ports.Job, error) {
 	_ = json.Unmarshal([]byte(refs), &job.ResultRefs)
 	if started.Valid {
 		job.StartedAt = started.Time
+	}
+	if leaseExpires.Valid {
+		job.LeaseExpiresAt = leaseExpires.Time
+	}
+	if heartbeat.Valid {
+		job.HeartbeatAt = heartbeat.Time
 	}
 	if finished.Valid {
 		job.FinishedAt = finished.Time

--- a/internal/statestore/postgres/report_schedules.go
+++ b/internal/statestore/postgres/report_schedules.go
@@ -22,14 +22,18 @@ var ensureReportScheduleStatements = []string{
   enabled BOOLEAN NOT NULL DEFAULT TRUE,
   next_run_at TIMESTAMPTZ NOT NULL,
   last_run_at TIMESTAMPTZ,
+  claim_owner TEXT NOT NULL DEFAULT '',
+  claim_expires_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
+	`ALTER TABLE report_schedules ADD COLUMN IF NOT EXISTS claim_owner TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE report_schedules ADD COLUMN IF NOT EXISTS claim_expires_at TIMESTAMPTZ`,
 	`CREATE INDEX IF NOT EXISTS report_schedules_tenant_idx ON report_schedules (tenant_id, created_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS report_schedules_due_idx ON report_schedules (next_run_at) WHERE enabled`,
 }
 
-const reportScheduleColumns = `id, tenant_id, report_id, parameters_json::text, interval_seconds, enabled, next_run_at, last_run_at, created_at, updated_at`
+const reportScheduleColumns = `id, tenant_id, report_id, parameters_json::text, interval_seconds, enabled, next_run_at, last_run_at, claim_owner, claim_expires_at, created_at, updated_at`
 
 func (s *Store) ensureReportScheduleTable(ctx context.Context) error {
 	return s.ensureReportTables(ctx)
@@ -70,6 +74,8 @@ ON CONFLICT (id) DO UPDATE SET
   enabled = EXCLUDED.enabled,
   next_run_at = EXCLUDED.next_run_at,
   last_run_at = EXCLUDED.last_run_at,
+  claim_owner = '',
+  claim_expires_at = NULL,
   updated_at = NOW()`,
 		id, tenantID, reportID, string(parameters), schedule.IntervalSeconds, schedule.Enabled,
 		schedule.NextRunAt.UTC(), nullableTime(schedule.LastRunAt)); err != nil {
@@ -160,7 +166,7 @@ func (s *Store) DeleteReportSchedule(ctx context.Context, scheduleID string) err
 // ClaimDueReportSchedules atomically claims enabled schedules whose next run is
 // due, advancing each one full interval ahead so a single pass enqueues each due
 // schedule exactly once even across concurrent server replicas.
-func (s *Store) ClaimDueReportSchedules(ctx context.Context, now time.Time, limit uint32) ([]*ports.ReportSchedule, error) {
+func (s *Store) ClaimDueReportSchedules(ctx context.Context, now time.Time, owner string, ttl time.Duration, limit uint32) ([]*ports.ReportSchedule, error) {
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
 	}
@@ -170,21 +176,31 @@ func (s *Store) ClaimDueReportSchedules(ctx context.Context, now time.Time, limi
 	if limit == 0 {
 		limit = reportScheduleClaimLimit
 	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return nil, errors.New("report schedule claim owner is required")
+	}
+	if ttl <= 0 {
+		return nil, errors.New("report schedule claim ttl must be positive")
+	}
+	now = now.UTC()
 	// #nosec G201 -- column list is a fixed constant and all values remain parameterized.
 	query := fmt.Sprintf(`
 UPDATE report_schedules
-SET next_run_at = $1::timestamptz + make_interval(secs => interval_seconds),
-    last_run_at = $1::timestamptz,
+SET claim_owner = $3,
+    claim_expires_at = $1::timestamptz + $4::bigint * INTERVAL '1 millisecond',
     updated_at = NOW()
 WHERE id IN (
   SELECT id FROM report_schedules
-  WHERE enabled AND next_run_at <= $1::timestamptz
+  WHERE enabled
+    AND next_run_at <= $1::timestamptz
+    AND (claim_expires_at IS NULL OR claim_expires_at <= $1::timestamptz)
   ORDER BY next_run_at
   LIMIT $2
   FOR UPDATE SKIP LOCKED
 )
 RETURNING %s`, reportScheduleColumns)
-	rows, err := s.db.QueryContext(ctx, query, now.UTC(), limit)
+	rows, err := s.db.QueryContext(ctx, query, now, limit, owner, ttl.Milliseconds())
 	if err != nil {
 		return nil, fmt.Errorf("claim due report schedules: %w", err)
 	}
@@ -198,6 +214,63 @@ RETURNING %s`, reportScheduleColumns)
 		schedules = append(schedules, schedule)
 	}
 	return schedules, rows.Err()
+}
+
+// CompleteReportScheduleClaim advances a schedule only after its occurrence job
+// has been durably created. The owner and occurrence prevent a stale worker from
+// acknowledging a newer claim.
+func (s *Store) CompleteReportScheduleClaim(ctx context.Context, scheduleID string, owner string, occurrenceAt time.Time, completedAt time.Time) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	scheduleID = strings.TrimSpace(scheduleID)
+	owner = strings.TrimSpace(owner)
+	if scheduleID == "" || owner == "" || occurrenceAt.IsZero() || completedAt.IsZero() {
+		return errors.New("report schedule id, claim owner, occurrence, and completion time are required")
+	}
+	if err := s.ensureReportScheduleTable(ctx); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE report_schedules
+SET next_run_at = $4::timestamptz + make_interval(secs => interval_seconds),
+    last_run_at = $3::timestamptz,
+    claim_owner = '',
+    claim_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND claim_owner = $2
+  AND next_run_at = $3::timestamptz`, scheduleID, owner, occurrenceAt.UTC(), completedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("complete report schedule claim %q: %w", scheduleID, err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return fmt.Errorf("report schedule claim conflict: %s", scheduleID)
+	}
+	return nil
+}
+
+// ReleaseReportScheduleClaim makes a failed enqueue eligible for the next poll.
+func (s *Store) ReleaseReportScheduleClaim(ctx context.Context, scheduleID string, owner string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	scheduleID = strings.TrimSpace(scheduleID)
+	owner = strings.TrimSpace(owner)
+	if scheduleID == "" || owner == "" {
+		return errors.New("report schedule id and claim owner are required")
+	}
+	if err := s.ensureReportScheduleTable(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `
+UPDATE report_schedules
+SET claim_owner = '', claim_expires_at = NULL, updated_at = NOW()
+WHERE id = $1 AND claim_owner = $2`, scheduleID, owner)
+	if err != nil {
+		return fmt.Errorf("release report schedule claim %q: %w", scheduleID, err)
+	}
+	return nil
 }
 
 const reportScheduleClaimLimit uint32 = 50
@@ -222,6 +295,7 @@ func scanReportSchedule(row scanner) (*ports.ReportSchedule, error) {
 		schedule       ports.ReportSchedule
 		parametersText string
 		lastRunAt      sql.NullTime
+		claimExpiresAt sql.NullTime
 	)
 	if err := row.Scan(
 		&schedule.ID,
@@ -232,6 +306,8 @@ func scanReportSchedule(row scanner) (*ports.ReportSchedule, error) {
 		&schedule.Enabled,
 		&schedule.NextRunAt,
 		&lastRunAt,
+		&schedule.ClaimOwner,
+		&claimExpiresAt,
 		&schedule.CreatedAt,
 		&schedule.UpdatedAt,
 	); err != nil {
@@ -246,6 +322,9 @@ func scanReportSchedule(row scanner) (*ports.ReportSchedule, error) {
 	schedule.Parameters = parameters
 	if lastRunAt.Valid {
 		schedule.LastRunAt = lastRunAt.Time
+	}
+	if claimExpiresAt.Valid {
+		schedule.ClaimExpiresAt = claimExpiresAt.Time
 	}
 	return &schedule, nil
 }

--- a/internal/statestore/postgres/report_schedules_test.go
+++ b/internal/statestore/postgres/report_schedules_test.go
@@ -41,6 +41,7 @@ func TestScanReportSchedule(t *testing.T) {
 			`{"tenant_id":"local","runtime_ids":"rt-1"}`,
 			int64(3600), true, next,
 			sql.NullTime{Time: last, Valid: true},
+			"", sql.NullTime{},
 			created, created,
 		}}
 		schedule, err := scanReportSchedule(scanner)
@@ -67,6 +68,7 @@ func TestScanReportSchedule(t *testing.T) {
 			"",
 			int64(7200), false, next,
 			sql.NullTime{},
+			"", sql.NullTime{},
 			created, created,
 		}}
 		schedule, err := scanReportSchedule(scanner)

--- a/internal/workflowevents/avro_decoder.go
+++ b/internal/workflowevents/avro_decoder.go
@@ -104,6 +104,8 @@ func decodeAvroPayload(kind string, data []byte, payload any) error {
 		err = decodeFindingStatusChanged(reader, target)
 	case *FindingTombstoned:
 		err = decodeFindingTombstoned(reader, target)
+	case *ComplianceAggregateRecorded:
+		err = decodeComplianceAggregateRecorded(reader, target)
 	default:
 		return fmt.Errorf("unsupported workflow payload target %T for %s", payload, kind)
 	}
@@ -114,6 +116,39 @@ func decodeAvroPayload(kind string, data []byte, payload any) error {
 		return fmt.Errorf("payload has %d trailing bytes", reader.remaining())
 	}
 	return nil
+}
+
+func decodeComplianceAggregateRecorded(reader *avroReader, payload *ComplianceAggregateRecorded) error {
+	var err error
+	if payload.TenantID, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.AggregateType, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.AggregateID, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.RevisionID, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.AggregateVersion, err = reader.long(); err != nil {
+		return err
+	}
+	if payload.Operation, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.ContentDigest, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.PayloadJSON, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.ActorID, err = reader.string(); err != nil {
+		return err
+	}
+	payload.RecordedAt, err = reader.string()
+	return err
 }
 
 func decodeDecisionRecorded(reader *avroReader, payload *DecisionRecorded) error {

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -39,6 +39,7 @@ const (
 	EventKindComplianceAuditPackageRecorded        = "workflow.v1.compliance.audit_package_recorded"
 	EventKindComplianceAuditDeliveryRecorded       = "workflow.v1.compliance.audit_delivery_recorded"
 	EventKindComplianceExchangeStaged              = "workflow.v1.compliance.exchange_staged"
+	EventKindComplianceExchangeCommitRequested     = "workflow.v1.compliance.exchange_commit_requested"
 	EventKindComplianceExchangeCommitted           = "workflow.v1.compliance.exchange_committed"
 	EventKindComplianceMonitorUpdated              = "workflow.v1.compliance.monitor_updated"
 	EventKindComplianceMonitorTriggered            = "workflow.v1.compliance.monitor_triggered"
@@ -128,7 +129,8 @@ func registeredComplianceKinds() []string {
 		EventKindComplianceRemediationMilestoneUpdated, EventKindComplianceAuditEngagementRecorded,
 		EventKindComplianceAuditRequestUpdated, EventKindComplianceAuditSubmissionRecorded,
 		EventKindComplianceAuditPackageRecorded, EventKindComplianceAuditDeliveryRecorded,
-		EventKindComplianceExchangeStaged, EventKindComplianceExchangeCommitted,
+		EventKindComplianceExchangeStaged, EventKindComplianceExchangeCommitRequested,
+		EventKindComplianceExchangeCommitted,
 		EventKindComplianceMonitorUpdated, EventKindComplianceMonitorTriggered,
 	}
 }

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -1,0 +1,134 @@
+package workflowevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	eventregistry "github.com/WriterInternal/event-registry/clients/go"
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+const (
+	EventKindComplianceProgramRecorded             = "workflow.v1.compliance.program_recorded"
+	EventKindComplianceProgramScopeRecorded        = "workflow.v1.compliance.program_scope_recorded"
+	EventKindComplianceImplementationRecorded      = "workflow.v1.compliance.control_implementation_recorded"
+	EventKindComplianceEvidenceVersionRecorded     = "workflow.v1.compliance.evidence_artifact_version_recorded"
+	EventKindComplianceEvidenceClaimRecorded       = "workflow.v1.compliance.evidence_claim_recorded"
+	EventKindComplianceEvidenceClaimReviewed       = "workflow.v1.compliance.evidence_claim_reviewed"
+	EventKindComplianceEvidenceClaimInvalidated    = "workflow.v1.compliance.evidence_claim_invalidated"
+	EventKindCompliancePlanRevisionRecorded        = "workflow.v1.compliance.assessment_plan_revision_recorded"
+	EventKindCompliancePlanPublished               = "workflow.v1.compliance.assessment_plan_published"
+	EventKindComplianceAssessmentRequested         = "workflow.v1.compliance.assessment_requested"
+	EventKindComplianceAssessmentJobBound          = "workflow.v1.compliance.assessment_job_bound"
+	EventKindComplianceInputManifestRecorded       = "workflow.v1.compliance.assessment_input_manifest_recorded"
+	EventKindComplianceResultChunkRecorded         = "workflow.v1.compliance.assessment_result_chunk_recorded"
+	EventKindComplianceAssessmentCompleted         = "workflow.v1.compliance.assessment_completed"
+	EventKindComplianceAssessmentCancelled         = "workflow.v1.compliance.assessment_cancelled"
+	EventKindComplianceActivityRecorded            = "workflow.v1.compliance.assessment_activity_recorded"
+	EventKindCompliancePopulationRecorded          = "workflow.v1.compliance.assessment_population_recorded"
+	EventKindComplianceSampleRecorded              = "workflow.v1.compliance.assessment_sample_recorded"
+	EventKindComplianceReviewRecorded              = "workflow.v1.compliance.assessment_review_recorded"
+	EventKindComplianceRiskDecisionRecorded        = "workflow.v1.compliance.risk_decision_recorded"
+	EventKindComplianceExceptionUpdated            = "workflow.v1.compliance.exception_updated"
+	EventKindComplianceWorkItemUpdated             = "workflow.v1.compliance.work_item_updated"
+	EventKindComplianceRemediationMilestoneUpdated = "workflow.v1.compliance.remediation_milestone_updated"
+	EventKindComplianceAuditEngagementRecorded     = "workflow.v1.compliance.audit_engagement_recorded"
+	EventKindComplianceAuditRequestUpdated         = "workflow.v1.compliance.audit_request_updated"
+	EventKindComplianceAuditSubmissionRecorded     = "workflow.v1.compliance.audit_submission_recorded"
+	EventKindComplianceAuditPackageRecorded        = "workflow.v1.compliance.audit_package_recorded"
+	EventKindComplianceAuditDeliveryRecorded       = "workflow.v1.compliance.audit_delivery_recorded"
+	EventKindComplianceExchangeStaged              = "workflow.v1.compliance.exchange_staged"
+	EventKindComplianceExchangeCommitted           = "workflow.v1.compliance.exchange_committed"
+	EventKindComplianceMonitorUpdated              = "workflow.v1.compliance.monitor_updated"
+	EventKindComplianceMonitorTriggered            = "workflow.v1.compliance.monitor_triggered"
+
+	SchemaComplianceAggregate = "urn:cerebro:events/workflow.compliance.aggregate/v1"
+	maxCompliancePayloadBytes = 512 * 1024
+)
+
+// ComplianceAggregateRecorded is the shared append-first envelope for bounded,
+// canonical compliance revisions and transitions. PayloadJSON contains no raw
+// evidence bytes and is validated by the owning domain before append.
+type ComplianceAggregateRecorded struct {
+	Kind             string `json:"kind"`
+	TenantID         string `json:"tenant_id"`
+	AggregateType    string `json:"aggregate_type"`
+	AggregateID      string `json:"aggregate_id"`
+	RevisionID       string `json:"revision_id,omitempty"`
+	AggregateVersion int64  `json:"aggregate_version"`
+	Operation        string `json:"operation"`
+	ContentDigest    string `json:"content_digest,omitempty"`
+	PayloadJSON      string `json:"payload_json,omitempty"`
+	ActorID          string `json:"actor_id,omitempty"`
+	RecordedAt       string `json:"recorded_at"`
+}
+
+func NewComplianceAggregateEvent(payload ComplianceAggregateRecorded) (*cerebrov1.EventEnvelope, error) {
+	payload.Kind = strings.TrimSpace(payload.Kind)
+	if !strings.HasPrefix(payload.Kind, eventregistry.WorkflowV1CompliancePrefix) || !KindRegistered(payload.Kind) {
+		return nil, fmt.Errorf("compliance event kind %q is not registered", payload.Kind)
+	}
+	if strings.TrimSpace(payload.AggregateType) == "" || strings.TrimSpace(payload.AggregateID) == "" {
+		return nil, fmt.Errorf("compliance event aggregate type and id are required")
+	}
+	if payload.AggregateVersion < 1 {
+		return nil, fmt.Errorf("compliance event aggregate version must be positive")
+	}
+	if strings.TrimSpace(payload.Operation) == "" {
+		return nil, fmt.Errorf("compliance event operation is required")
+	}
+	if len(payload.PayloadJSON) > maxCompliancePayloadBytes {
+		return nil, fmt.Errorf("compliance event payload exceeds %d bytes", maxCompliancePayloadBytes)
+	}
+	if strings.TrimSpace(payload.PayloadJSON) != "" && !json.Valid([]byte(payload.PayloadJSON)) {
+		return nil, fmt.Errorf("compliance event payload_json is invalid")
+	}
+	contract := eventregistry.ComplianceAggregateV1{
+		Kind: payload.Kind, TenantID: payload.TenantID, AggregateType: payload.AggregateType,
+		AggregateID: payload.AggregateID, RevisionID: payload.RevisionID,
+		AggregateVersion: payload.AggregateVersion, Operation: payload.Operation,
+		ContentDigest: payload.ContentDigest, PayloadJSON: payload.PayloadJSON,
+		ActorID: payload.ActorID, RecordedAt: payload.RecordedAt,
+	}
+	primaryID := payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
+	return newEvent(contract, SchemaComplianceAggregate, payload.TenantID, "compliance", primaryID, payload.RecordedAt, map[string]string{
+		EventAttributeWorkflowKind: "compliance_aggregate",
+		"aggregate_type":           payload.AggregateType,
+		"aggregate_id":             payload.AggregateID,
+		"revision_id":              payload.RevisionID,
+	})
+}
+
+func DecodeComplianceAggregate(event *cerebrov1.EventEnvelope) (*ComplianceAggregateRecorded, error) {
+	payload := &ComplianceAggregateRecorded{Kind: strings.TrimSpace(event.GetKind())}
+	if !strings.HasPrefix(payload.Kind, eventregistry.WorkflowV1CompliancePrefix) || !KindRegistered(payload.Kind) {
+		return nil, fmt.Errorf("workflow event kind = %q is not a registered compliance kind", payload.Kind)
+	}
+	if err := decodePayload(event, payload.Kind, payload); err != nil {
+		return nil, err
+	}
+	payload.Kind = strings.TrimSpace(event.GetKind())
+	return payload, nil
+}
+
+func registeredComplianceKinds() []string {
+	return []string{
+		EventKindComplianceProgramRecorded, EventKindComplianceProgramScopeRecorded,
+		EventKindComplianceImplementationRecorded, EventKindComplianceEvidenceVersionRecorded,
+		EventKindComplianceEvidenceClaimRecorded, EventKindComplianceEvidenceClaimReviewed,
+		EventKindComplianceEvidenceClaimInvalidated, EventKindCompliancePlanRevisionRecorded,
+		EventKindCompliancePlanPublished, EventKindComplianceAssessmentRequested,
+		EventKindComplianceAssessmentJobBound, EventKindComplianceInputManifestRecorded,
+		EventKindComplianceResultChunkRecorded, EventKindComplianceAssessmentCompleted,
+		EventKindComplianceAssessmentCancelled, EventKindComplianceActivityRecorded,
+		EventKindCompliancePopulationRecorded, EventKindComplianceSampleRecorded,
+		EventKindComplianceReviewRecorded, EventKindComplianceRiskDecisionRecorded,
+		EventKindComplianceExceptionUpdated, EventKindComplianceWorkItemUpdated,
+		EventKindComplianceRemediationMilestoneUpdated, EventKindComplianceAuditEngagementRecorded,
+		EventKindComplianceAuditRequestUpdated, EventKindComplianceAuditSubmissionRecorded,
+		EventKindComplianceAuditPackageRecorded, EventKindComplianceAuditDeliveryRecorded,
+		EventKindComplianceExchangeStaged, EventKindComplianceExchangeCommitted,
+		EventKindComplianceMonitorUpdated, EventKindComplianceMonitorTriggered,
+	}
+}

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -42,6 +42,18 @@ func TestComplianceAggregateKindsRegistered(t *testing.T) {
 	}
 }
 
+func TestComplianceExchangeRequestAndCommitRemainDistinctFacts(t *testing.T) {
+	t.Parallel()
+	if EventKindComplianceExchangeCommitRequested == EventKindComplianceExchangeCommitted {
+		t.Fatal("exchange commit request and completed commit share an event kind")
+	}
+	for _, kind := range []string{EventKindComplianceExchangeCommitRequested, EventKindComplianceExchangeCommitted} {
+		if !KindRegistered(kind) {
+			t.Fatalf("kind %q is not registered", kind)
+		}
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -1,0 +1,67 @@
+package workflowevents
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComplianceAggregateRoundTrip(t *testing.T) {
+	t.Parallel()
+	payload := ComplianceAggregateRecorded{
+		Kind: EventKindComplianceProgramRecorded, TenantID: "tenant-a",
+		AggregateType: "program", AggregateID: "program-1", RevisionID: "revision-1",
+		AggregateVersion: 2, Operation: "recorded",
+		ContentDigest: "sha256:abc", PayloadJSON: `{"id":"program-1"}`,
+		ActorID: "actor-1", RecordedAt: "2026-07-11T08:00:00.123Z",
+	}
+	event, err := NewComplianceAggregateEvent(payload)
+	if err != nil {
+		t.Fatalf("NewComplianceAggregateEvent() error = %v", err)
+	}
+	decoded, err := DecodeComplianceAggregate(event)
+	if err != nil {
+		t.Fatalf("DecodeComplianceAggregate() error = %v", err)
+	}
+	if decoded.Kind != payload.Kind || decoded.TenantID != payload.TenantID || decoded.AggregateID != payload.AggregateID || decoded.AggregateVersion != payload.AggregateVersion || decoded.PayloadJSON != payload.PayloadJSON {
+		t.Fatalf("round trip = %#v, want %#v", decoded, payload)
+	}
+	if event.GetAttributes()["aggregate_id"] != payload.AggregateID {
+		t.Fatalf("aggregate_id attribute = %q", event.GetAttributes()["aggregate_id"])
+	}
+}
+
+func TestComplianceAggregateKindsRegistered(t *testing.T) {
+	t.Parallel()
+	for _, kind := range registeredComplianceKinds() {
+		if !KindRegistered(kind) {
+			t.Fatalf("kind %q is not registered", kind)
+		}
+		if got := SchemaForKind(kind); got != SchemaComplianceAggregate {
+			t.Fatalf("schema for %q = %q", kind, got)
+		}
+	}
+}
+
+func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
+	t.Parallel()
+	base := ComplianceAggregateRecorded{
+		Kind: EventKindComplianceProgramRecorded, TenantID: "tenant-a",
+		AggregateType: "program", AggregateID: "program-1", AggregateVersion: 1,
+		Operation: "recorded", RecordedAt: "2026-07-11T08:00:00Z",
+	}
+	invalid := base
+	invalid.PayloadJSON = "{"
+	if _, err := NewComplianceAggregateEvent(invalid); err == nil {
+		t.Fatal("invalid JSON payload unexpectedly accepted")
+	}
+	large := base
+	large.PayloadJSON = `"` + strings.Repeat("x", maxCompliancePayloadBytes) + `"`
+	if _, err := NewComplianceAggregateEvent(large); err == nil {
+		t.Fatal("oversized payload unexpectedly accepted")
+	}
+	unknown := base
+	unknown.Kind = "workflow.v1.compliance.unknown"
+	if _, err := NewComplianceAggregateEvent(unknown); err == nil {
+		t.Fatal("unregistered kind unexpectedly accepted")
+	}
+}

--- a/internal/workflowevents/registry.go
+++ b/internal/workflowevents/registry.go
@@ -47,4 +47,7 @@ func init() {
 	registerKind(EventKindFindingNoteAdded, SchemaFindingNoteAdded)
 	registerKind(EventKindFindingTicketLinked, SchemaFindingTicketLinked)
 	registerKind(EventKindFindingStatusChanged, SchemaFindingStatusChanged)
+	for _, kind := range registeredComplianceKinds() {
+		registerKind(kind, SchemaComplianceAggregate)
+	}
 }

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -72,7 +72,7 @@ def is_reachable_finding(finding: dict[str, Any]) -> bool:
 def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
     env = os.environ.copy()
     env["GOFLAGS"] = ""
-    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.4")
+    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.5")
     command = ["go", "run", DEFAULT_TOOL, "-format", "json", *patterns]
     completed = subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
     return completed.returncode, completed.stdout, completed.stderr


### PR DESCRIPTION
## Summary

- add owner-leased platform jobs with heartbeat renewal, startup recovery, cancellation, attempt tracking, bounded failure classification, and request-bound idempotency
- claim recurring report occurrences and advance each schedule only after its durable job exists
- add tenant-scoped, cutoff-bounded assessment input pages with stable cursors and mutation detection
- add cursor-based append-log replay so callers can traverse beyond a single bounded request

## Why

Compliance runs need complete inputs and recoverable execution before policy evaluation can become a durable product surface. Previously, process loss could leave jobs running indefinitely, schedules advanced before enqueue was confirmed, assessment inputs reused UI-oriented list bounds, and replay stopped at one request page.

## Compatibility

Existing job, report schedule, and replay callers remain supported. The Postgres stores add columns through idempotent schema setup. New lease and snapshot interfaces are internal capabilities for later assessment APIs.

## Validation

- focused Go tests for jobs, report scheduling, Postgres stores, append-log replay, bootstrap, and the server entrypoint
- race tests for the changed job and replay concurrency paths
- structural and architecture checks
- contract checks
- internal, API, and command lint checks
- OSS audit

## Follow-on implementation plan

1. Define canonical control, policy, evidence, and applicability records with versioned source provenance.
2. Add assessment-run APIs that capture the new immutable input snapshot before evaluation starts.
3. Implement deterministic evaluation with explicit pass, fail, unknown, not-applicable, and error outcomes.
4. Persist requirement-level results, evidence lineage, evaluator versions, and reason codes.
5. Add exception and compensating-control workflows with owners, expiry, approval history, and reassessment triggers.
6. Build evidence freshness, collection coverage, and control-health projections from durable results.
7. Add audit packet manifests that pin every exported artifact to the assessment snapshot and source versions.
8. Add framework overlays and crosswalks without duplicating underlying controls or evidence.
9. Add notification and remediation jobs using the same leased execution contract.
10. Add migration, backfill, reconciliation, and operator runbooks before enabling continuous assessment by default.