### PR TITLE
Upgrade Go toolchain to 1.26.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.4
+golang 1.26.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Build stage - use buildx cross-compilation (no QEMU needed)
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
 ARG TARGETOS

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ GO_TEST_SHARD_WEIGHTS ?= scripts/go_package_test_weights.json
 GO_TEST_SHARD_DEFAULT_WEIGHT ?= 1
 GO_RACE_SHARD_WEIGHTS ?= scripts/go_package_race_weights.json
 GO_RACE_SHARD_DEFAULT_WEIGHT ?= 5
-BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
-GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
+BUF := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
+GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
-GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/goreleaser/goreleaser/v2@v2.16.0
+GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run github.com/goreleaser/goreleaser/v2@v2.16.0
 PROTO_BREAKING_BASE ?= origin/main
 README_CHECK_BASE ?= origin/main
 DOCKER_SMOKE_IMAGE ?= cerebro-runtime-smoke:local
@@ -341,7 +341,7 @@ lint-sources: lint-bootstrap ## Run golangci-lint over source packages.
 	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_SOURCE_PACKAGES)
 
 lint-bootstrap: ## Install golangci-lint if missing.
-	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
+	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.5 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
 
 proto-lint: ## Lint protobuf definitions.
 	$(BUF) lint

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The site entry point is [docs/index.md](docs/index.md), and `mkdocs.yml` defines
 
 | Component | Technology |
 | --- | --- |
-| Language | Go 1.26+ with `go1.26.4` toolchain |
+| Language | Go 1.26+ with `go1.26.5` toolchain |
 | HTTP server | Go `net/http` `ServeMux` |
 | RPC | Connect |
 | CLI | Standard Go CLI under `cmd/cerebro` |

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -4,7 +4,7 @@ This document describes the current bootstrap service on `main`. Historical ware
 
 ## Prerequisites
 
-- Go 1.26+; the repository pins `go1.26.4` in `go.mod`.
+- Go 1.26+; the repository pins `go1.26.5` in `go.mod`.
 - Docker and Docker Compose for the durable local stack.
 - Make.
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/writer/cerebro
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 replace github.com/WriterInternal/event-registry/clients/go => ./internal/eventregistry
 

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -72,7 +72,7 @@ def is_reachable_finding(finding: dict[str, Any]) -> bool:
 def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
     env = os.environ.copy()
     env["GOFLAGS"] = ""
-    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.4")
+    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.5")
     command = ["go", "run", DEFAULT_TOOL, "-format", "json", *patterns]
     completed = subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
     return completed.returncode, completed.stdout, completed.stderr


### PR DESCRIPTION
## Merge path

Targets main. Includes #1732.

Merge this PR first. It clears the Go vulnerability gate for the remaining queue.

The intermediate PRs in this chain are superseded by this PR.

## Context

`make govulncheck` now reports two reachable Go standard-library
vulnerabilities against the repository's pinned `go1.26.4` toolchain:

- `GO-2026-5856`: Encrypted Client Hello privacy leak in `crypto/tls`, fixed in
  Go 1.26.5.
- `GO-2026-4970`: `os.Root` escape through a symlink plus trailing slash, fixed
  in Go 1.26.5.

This first appeared in documentation-only PR checks after the Go vulnerability
database updated. PR #1729 has no `go.mod` or `go.sum` diff, and the same gate
passes on its base SHA only with the older vulnerability-database snapshot.
A failed-only rerun reproduced the findings, and a local scan produced reachable
traces through TLS call paths and repository file tooling.

Do not add these IDs to `.govulncheck-ignore`; fixed toolchain versions are
available.

## Implementation

Update every executable toolchain pin from 1.26.4 to 1.26.5 in one pull request:

- `go.mod` (`toolchain` directive)
- `Dockerfile` (`GO_VERSION` build argument)
- `Makefile` (`GOTOOLCHAIN` pins for Buf, govulncheck, GoReleaser, and
  golangci-lint installation)
- `scripts/govulncheck_gate.py` (default toolchain)
- `README.md`
- `docs/engineering/development.md`

Do not change module versions or add suppressions unless the toolchain update
independently proves they are required.

## Validation performed

```bash
go version
make govulncheck
make build
make test
make docs-drift-check
make readme-check
make docker-smoke
git diff --check
```

Also run:

```bash
rg -n '1\.26\.4' go.mod Dockerfile Makefile scripts README.md docs
```

The final search should return no active toolchain pin. Historical release notes
may remain if any exist.

The full repository suite and Docker smoke check also passed on the identical
commit before this focused branch was split from PR #1729.

## Acceptance criteria

- Every build, local tool, and CI path resolves Go 1.26.5.
- `make govulncheck` reports no unsuppressed reachable vulnerabilities.
- `.govulncheck-ignore` is unchanged for these findings.
- `go.mod` and `go.sum` contain no unrelated dependency churn.
- The runtime Docker image builds with Go 1.26.5.
- Build, unit, documentation, README, and Docker smoke checks pass.
- PRs blocked only by `GO-2026-5856` and `GO-2026-4970` are rerun after this
  change reaches `main`.

## Evidence

Reachable examples include TLS handshake paths from JetStream, HTTP, Redis, and
safe HTTP transport code, plus `os.Root` file operations in policy/finding tools.
The scanner reports the fixed standard-library version as Go 1.26.5 for both
findings.

Closes #1730.