### PR TITLE
Add durable compliance monitors

### DIFF
--- a/docs/operations/compliance-imports.md
+++ b/docs/operations/compliance-imports.md
@@ -1,0 +1,47 @@
+# Compliance Import Operations
+
+## Default state
+
+Imports are validation-only until an authorized actor accepts the staged change
+plan with the expected staging version. Parsing or validating a package must not
+write canonical programs, evidence claims, assessments, work, or audit records.
+
+## Validation order
+
+1. Enforce request, file, and archive limits.
+2. Normalize relative paths and reject traversal, symlinks, duplicates, and case
+   collisions.
+3. Parse the manifest and identify its declared version.
+4. Validate schema and references.
+5. Validate tenant and disclosure policy.
+6. Verify every file digest and the package digest.
+7. Verify the detached signature with the configured tenant trust resolver.
+8. Compare the round-trip canonical records.
+9. Persist validation issues and the proposed change plan.
+
+The validator never follows a remote key URL. Add trusted keys through the
+configured resolver before retrying a signature failure.
+
+## Failed validation
+
+- Keep the validation result and bounded issue codes.
+- Do not persist package attachments into a new blob store.
+- Do not copy evidence contents into logs, metrics, events, or validation errors.
+- A digest mismatch requires a new package; it is not repairable through metadata.
+- A tenant mismatch is terminal for the staged import.
+- An unsupported mandatory record type requires a supported exchange adapter.
+
+## Staged commit
+
+Before commit, verify:
+
+- the staging version still matches the operator request
+- every referenced canonical revision still exists
+- the signer remains trusted for this tenant and purpose
+- the change plan contains no unresolved error
+- the actor has the mutation scopes required by every planned operation
+
+Commit appends canonical domain events. If projection fails after append, replay
+the events; do not rebuild the change plan against newer inputs under the same
+staging ID.
+

--- a/docs/operations/compliance-parity-rollout.md
+++ b/docs/operations/compliance-parity-rollout.md
@@ -1,0 +1,61 @@
+# Compliance Parity Rollout
+
+## Cohort gates
+
+Advance one caller and tenant cohort at a time.
+
+1. **Fixtures:** canonical hashes, result axes, reason codes, and legacy mappings
+   match frozen conformance cases.
+2. **Replay:** an empty Postgres projection rebuilds the same revisions, counts,
+   chunks, and hashes.
+3. **Shadow:** canonical collection and evaluation run without serving results.
+   Every required input is complete and every difference has a reason.
+4. **Read:** the cohort reads canonical projections while writes remain on the
+   current path.
+5. **Write:** the cohort creates canonical plans and runs. Compatibility reads
+   continue to work.
+6. **Audit:** package rebuild, engagement access, redaction, and receipt checks
+   pass.
+7. **Default:** canonical reads become the cohort default after two complete
+   assessment cycles.
+8. **Retirement:** remove a legacy calculation only when its caller count is zero.
+
+## Required switches
+
+Maintain separate switches for:
+
+- canonical reads
+- assessment creation
+- monitor scheduling
+- package delivery
+
+Do not use one global switch. A package-delivery incident must not disable safe
+assessment reads.
+
+## Difference handling
+
+Classify each shadow difference as:
+
+- expected compatibility mapping
+- input completeness difference
+- source-trust difference
+- evidence-scope or period difference
+- evaluator defect
+- legacy defect
+- unresolved
+
+An unresolved difference blocks the cohort. Do not normalize it away or treat the
+legacy result as authoritative by default.
+
+## Rollback
+
+1. Disable the narrowest affected switch.
+2. Keep canonical events, completed runs, review revisions, and package manifests.
+3. Route reads to the previous adapter for the affected cohort.
+4. Rebuild and compare the canonical projection from its last verified receipt.
+5. Record the rollback owner, threshold crossed, affected caller, and recovery
+   decision in the internal incident channel.
+6. Resume only after replay and parity checks pass for the affected cohort.
+
+Rollback never deletes canonical history or mutates a completed run.
+

--- a/docs/operations/compliance-schedules.md
+++ b/docs/operations/compliance-schedules.md
@@ -1,0 +1,53 @@
+# Compliance Schedule Operations
+
+## Monitor states
+
+Each monitor points to one tenant, program, and immutable assessment-plan
+revision. Operators should use these fields when deciding what action to take:
+
+| Field | Operator meaning |
+| --- | --- |
+| `enabled` | New occurrences may be claimed. Disabling does not cancel a running job. |
+| `next_run_at` | Logical occurrence time. It advances only after the job exists. |
+| `claim_owner`, `claim_expires_at` | Scheduler claim. An expired claim is safe to reclaim. |
+| plan run lease | Prevents overlapping runs for one tenant and plan revision. |
+| `last_success_at` | Last terminal assessment recorded as successful. |
+| `consecutive_failures` | Number of terminal failures since the last success. |
+
+## Missed occurrence
+
+1. Confirm the monitor is enabled and `next_run_at` is due.
+2. Check whether the monitor claim is active. Do not clear an unexpired claim.
+3. Check for a job with the monitor occurrence idempotency key.
+4. If the job exists, let the scheduler acknowledge the occurrence on its next
+   pass. Do not create another job manually.
+5. If no job exists and the claim expired, release the claim or wait for the next
+   scheduler pass.
+6. Confirm `next_run_at` advanced only after the job record appeared.
+
+## Stuck plan lease
+
+1. Find the assessment job referenced by the occurrence.
+2. If the job is running and its worker lease is current, keep the plan lease.
+3. If the job lease expired, allow platform job recovery to resume it.
+4. If the job is terminal but the plan lease remains, release the plan lease with
+   the recorded owner.
+5. If the plan lease expired while a job still runs, stop and investigate the job
+   heartbeat before allowing another occurrence.
+
+## Repeated failures
+
+- Inspect the assessment run failure code. Do not use evidence text or attachment
+  content in alerts.
+- `collection_incomplete` requires a complete source scan before retry.
+- `source_unavailable` requires source runtime recovery; unaffected objectives may
+  still finish in a later run.
+- `result_invalid` requires evaluator or conformance-fixture repair before retry.
+- Disable the monitor when retries would repeat an unresolved contract failure.
+
+## Safe cancellation
+
+Cancel the platform job. The runner records a readable cancelled run and releases
+the plan lease after its terminal event is durable. Do not delete the run, its
+input receipts, or completed result chunks.
+

--- a/docs/operations/compliance-schedules.md
+++ b/docs/operations/compliance-schedules.md
@@ -25,6 +25,22 @@ revision. Operators should use these fields when deciding what action to take:
    scheduler pass.
 6. Confirm `next_run_at` advanced only after the job record appeared.
 
+## Change-triggered occurrence
+
+Change monitors keep a tenant-scoped receipt for each monitor and source event.
+Repeated delivery of one event does not increase the window count. New events
+extend the monitor's debounce window and increment its version.
+
+1. Confirm the monitor is enabled, uses the `change` trigger, and has a positive
+   debounce window.
+2. Check the change receipt by tenant, monitor, and event ID.
+3. Check `ready_at`. A window is not missed while its debounce period is open.
+4. If a claim exists, compare its version with the current window version. A
+   newer version means another signal arrived while the older claim ran.
+5. Confirm the assessment job exists before acknowledging the claimed version.
+6. Leave a newer window in place. The plan run lease prevents it from starting
+   until the current assessment reaches a terminal state.
+
 ## Stuck plan lease
 
 1. Find the assessment job referenced by the occurrence.
@@ -50,4 +66,3 @@ revision. Operators should use these fields when deciding what action to take:
 Cancel the platform job. The runner records a readable cancelled run and releases
 the plan lease after its terminal event is durable. Do not delete the run, its
 input receipts, or completed result chunks.
-

--- a/internal/compliancemonitor/run.go
+++ b/internal/compliancemonitor/run.go
@@ -78,11 +78,82 @@ func RunDue(ctx context.Context, store ports.ComplianceMonitorStore, jobs *platf
 	return enqueued, errors.Join(errs...)
 }
 
+// RunDueChanges claims coalesced change windows, obtains the same per-plan
+// overlap lease used by time monitors, creates one assessment job, and only
+// then acknowledges the exact claimed window version.
+func RunDueChanges(ctx context.Context, store ports.ComplianceChangeMonitorStore, jobs *platformjobs.Service, now time.Time) (int, error) {
+	if store == nil || jobs == nil {
+		return 0, nil
+	}
+	now = now.UTC()
+	owner := newOwner()
+	windows, err := store.ClaimDueComplianceChangeWindows(ctx, now, owner, claimTTL, claimBatch)
+	if err != nil {
+		return 0, err
+	}
+	enqueued := 0
+	var errs []error
+	for _, window := range windows {
+		if window == nil {
+			continue
+		}
+		occurrence := changeOccurrenceKey(window)
+		if err := store.AcquireCompliancePlanLease(ctx, window.TenantID, window.PlanRevisionID, owner, occurrence, now, planLeaseTTL); err != nil {
+			_ = store.ReleaseComplianceChangeWindow(context.WithoutCancel(ctx), window.TenantID, window.MonitorID, owner)
+			if !errors.Is(err, ports.ErrComplianceMonitorOverlap) {
+				errs = append(errs, fmt.Errorf("compliance change monitor %q plan lease: %w", window.MonitorID, err))
+			}
+			continue
+		}
+		job, created, createErr := jobs.Create(ctx, ports.CreateJobRequest{
+			Kind:           platformjobs.KindComplianceAssessment,
+			TenantID:       window.TenantID,
+			SubjectType:    subjectType,
+			SubjectID:      window.MonitorID,
+			IdempotencyKey: occurrence,
+			Payload: map[string]any{
+				"program_id":              window.ProgramID,
+				"plan_revision_id":        window.PlanRevisionID,
+				"monitor_id":              window.MonitorID,
+				"change_window_version":   window.Version,
+				"change_window_opened_at": window.OpenedAt.UTC().Format(time.RFC3339Nano),
+				"change_signal_count":     window.SignalCount,
+				"change_scope_digest":     window.ScopeDigest,
+				"plan_lease_owner":        owner,
+				"plan_lease_occurrence":   occurrence,
+			},
+		})
+		if createErr != nil {
+			_ = store.ReleaseCompliancePlanLease(context.WithoutCancel(ctx), window.TenantID, window.PlanRevisionID, owner)
+			_ = store.ReleaseComplianceChangeWindow(context.WithoutCancel(ctx), window.TenantID, window.MonitorID, owner)
+			errs = append(errs, fmt.Errorf("compliance change monitor %q enqueue: %w", window.MonitorID, createErr))
+			continue
+		}
+		if err := store.CompleteComplianceChangeWindow(context.WithoutCancel(ctx), window.TenantID, window.MonitorID, owner, window.Version); err != nil {
+			_ = store.ReleaseComplianceChangeWindow(context.WithoutCancel(ctx), window.TenantID, window.MonitorID, owner)
+			errs = append(errs, fmt.Errorf("compliance change monitor %q completion: %w", window.MonitorID, err))
+			continue
+		}
+		if created {
+			jobs.StartAsync(ctx, job)
+		}
+		enqueued++
+	}
+	return enqueued, errors.Join(errs...)
+}
+
 func occurrenceKey(monitor *ports.ComplianceMonitor) string {
 	if monitor == nil {
 		return ""
 	}
 	return "compliance-monitor:" + strings.TrimSpace(monitor.ID) + ":" + monitor.NextRunAt.UTC().Format(time.RFC3339Nano)
+}
+
+func changeOccurrenceKey(window *ports.ComplianceChangeWindow) string {
+	if window == nil {
+		return ""
+	}
+	return fmt.Sprintf("compliance-change:%s:%d:%s", strings.TrimSpace(window.MonitorID), window.Version, window.OpenedAt.UTC().Format(time.RFC3339Nano))
 }
 
 func newOwner() string {

--- a/internal/compliancemonitor/run.go
+++ b/internal/compliancemonitor/run.go
@@ -1,0 +1,124 @@
+package compliancemonitor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	claimBatch   = uint32(50)
+	claimTTL     = 2 * time.Minute
+	planLeaseTTL = 6 * time.Hour
+	subjectType  = "compliance_monitor"
+)
+
+// RunDue claims due monitor occurrences, obtains one durable lease per tenant
+// and plan revision, creates the assessment job, and advances the monitor only
+// after the job exists.
+func RunDue(ctx context.Context, store ports.ComplianceMonitorStore, jobs *platformjobs.Service, now time.Time) (int, error) {
+	if store == nil || jobs == nil {
+		return 0, nil
+	}
+	now = now.UTC()
+	owner := newOwner()
+	due, err := store.ClaimDueComplianceMonitors(ctx, now, owner, claimTTL, claimBatch)
+	if err != nil {
+		return 0, err
+	}
+	enqueued := 0
+	var errs []error
+	for _, monitor := range due {
+		if monitor == nil {
+			continue
+		}
+		occurrence := occurrenceKey(monitor)
+		if err := store.AcquireCompliancePlanLease(ctx, monitor.TenantID, monitor.PlanRevisionID, owner, occurrence, now, planLeaseTTL); err != nil {
+			_ = store.ReleaseComplianceMonitorClaim(context.WithoutCancel(ctx), monitor.TenantID, monitor.ID, owner)
+			if !errors.Is(err, ports.ErrComplianceMonitorOverlap) {
+				errs = append(errs, fmt.Errorf("compliance monitor %q plan lease: %w", monitor.ID, err))
+			}
+			continue
+		}
+		job, created, createErr := jobs.Create(ctx, ports.CreateJobRequest{
+			Kind:           platformjobs.KindComplianceAssessment,
+			TenantID:       monitor.TenantID,
+			SubjectType:    subjectType,
+			SubjectID:      monitor.ID,
+			IdempotencyKey: occurrence,
+			Payload: map[string]any{
+				"program_id":            monitor.ProgramID,
+				"plan_revision_id":      monitor.PlanRevisionID,
+				"monitor_id":            monitor.ID,
+				"scheduled_for":         monitor.NextRunAt.UTC().Format(time.RFC3339Nano),
+				"plan_lease_owner":      owner,
+				"plan_lease_occurrence": occurrence,
+			},
+		})
+		if createErr != nil {
+			_ = store.ReleaseCompliancePlanLease(context.WithoutCancel(ctx), monitor.TenantID, monitor.PlanRevisionID, owner)
+			_ = store.ReleaseComplianceMonitorClaim(context.WithoutCancel(ctx), monitor.TenantID, monitor.ID, owner)
+			errs = append(errs, fmt.Errorf("compliance monitor %q enqueue: %w", monitor.ID, createErr))
+			continue
+		}
+		if err := store.CompleteComplianceMonitorClaim(context.WithoutCancel(ctx), monitor.TenantID, monitor.ID, owner, monitor.NextRunAt, now); err != nil {
+			errs = append(errs, fmt.Errorf("compliance monitor %q completion: %w", monitor.ID, err))
+			continue
+		}
+		if created {
+			jobs.StartAsync(ctx, job)
+		}
+		enqueued++
+	}
+	return enqueued, errors.Join(errs...)
+}
+
+func occurrenceKey(monitor *ports.ComplianceMonitor) string {
+	if monitor == nil {
+		return ""
+	}
+	return "compliance-monitor:" + strings.TrimSpace(monitor.ID) + ":" + monitor.NextRunAt.UTC().Format(time.RFC3339Nano)
+}
+
+func newOwner() string {
+	return "compliance-scheduler-" + strings.TrimPrefix(platformjobs.NewID(), "job-")
+}
+
+// ReleasePlanLease releases the overlap guard after the assessment runner has
+// reached a terminal state. The runner should call it from a deferred cleanup.
+func ReleasePlanLease(ctx context.Context, store ports.ComplianceMonitorStore, job *ports.Job) error {
+	if store == nil || job == nil {
+		return nil
+	}
+	planRevisionID, _ := job.Payload["plan_revision_id"].(string)
+	owner, _ := job.Payload["plan_lease_owner"].(string)
+	if strings.TrimSpace(job.TenantID) == "" || strings.TrimSpace(planRevisionID) == "" || strings.TrimSpace(owner) == "" {
+		return nil
+	}
+	return store.ReleaseCompliancePlanLease(ctx, job.TenantID, planRevisionID, owner)
+}
+
+// CompleteRun records the bounded monitor outcome and releases the plan overlap
+// lease. The assessment runner calls this once after its own terminal event is
+// durable.
+func CompleteRun(ctx context.Context, store ports.ComplianceMonitorStore, job *ports.Job, succeeded bool, at time.Time) error {
+	if store == nil || job == nil {
+		return nil
+	}
+	monitorID, _ := job.Payload["monitor_id"].(string)
+	var errs []error
+	if strings.TrimSpace(monitorID) != "" {
+		if err := store.RecordComplianceMonitorOutcome(ctx, job.TenantID, monitorID, succeeded, at.UTC()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := ReleasePlanLease(ctx, store, job); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}

--- a/internal/compliancemonitor/run_test.go
+++ b/internal/compliancemonitor/run_test.go
@@ -1,0 +1,227 @@
+package compliancemonitor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestRunDueCreatesJobBeforeAdvancingAndPreventsOverlap(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	monitors := &memoryMonitorStore{due: []*ports.ComplianceMonitor{{
+		ID: "monitor-1", TenantID: "tenant-1", ProgramID: "program-1",
+		PlanRevisionID: "plan-revision-1", TriggerKind: ports.ComplianceTriggerTime,
+		IntervalSeconds: 3600, Enabled: true, NextRunAt: now,
+	}}}
+	jobStore := newMemoryJobStore(now)
+	jobs := platformjobs.New(jobStore).WithRunner(platformjobs.KindComplianceAssessment, func(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+		return nil, nil, CompleteRun(ctx, monitors, job, true, now.Add(time.Minute))
+	})
+
+	count, err := RunDue(context.Background(), monitors, jobs, now)
+	if err != nil {
+		t.Fatalf("RunDue() error = %v", err)
+	}
+	if count != 1 || !monitors.completed || !monitors.jobExistedAtComplete(jobStore) {
+		t.Fatalf("count=%d completed=%v jobExistedAtComplete=%v", count, monitors.completed, monitors.jobExistedAtComplete(jobStore))
+	}
+	if err := jobs.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if monitors.planLeaseOwner != "" {
+		t.Fatalf("plan lease owner after completion = %q", monitors.planLeaseOwner)
+	}
+	if !monitors.outcomeRecorded {
+		t.Fatal("monitor outcome was not recorded")
+	}
+}
+
+func TestRunDueReleasesClaimsWhenJobCreationFails(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	monitors := &memoryMonitorStore{due: []*ports.ComplianceMonitor{{
+		ID: "monitor-1", TenantID: "tenant-1", ProgramID: "program-1",
+		PlanRevisionID: "plan-revision-1", TriggerKind: ports.ComplianceTriggerTime,
+		IntervalSeconds: 3600, Enabled: true, NextRunAt: now,
+	}}}
+	jobStore := newMemoryJobStore(now)
+	jobStore.createErr = errors.New("store unavailable")
+	jobs := platformjobs.New(jobStore).WithRunner(platformjobs.KindComplianceAssessment, func(context.Context, *ports.Job, *platformjobs.Service) (map[string]any, map[string]string, error) {
+		return nil, nil, nil
+	})
+
+	count, err := RunDue(context.Background(), monitors, jobs, now)
+	if err == nil || count != 0 {
+		t.Fatalf("RunDue() = (%d, %v), want error", count, err)
+	}
+	if !monitors.claimReleased || monitors.planLeaseOwner != "" {
+		t.Fatalf("claimReleased=%v planLeaseOwner=%q", monitors.claimReleased, monitors.planLeaseOwner)
+	}
+}
+
+func TestRunDueSkipsOverlappingPlan(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	monitors := &memoryMonitorStore{due: []*ports.ComplianceMonitor{{
+		ID: "monitor-2", TenantID: "tenant-1", ProgramID: "program-1",
+		PlanRevisionID: "plan-revision-1", TriggerKind: ports.ComplianceTriggerTime,
+		IntervalSeconds: 3600, Enabled: true, NextRunAt: now,
+	}}, planLeaseOwner: "active-run"}
+	jobs := platformjobs.New(newMemoryJobStore(now)).WithRunner(platformjobs.KindComplianceAssessment, func(context.Context, *ports.Job, *platformjobs.Service) (map[string]any, map[string]string, error) {
+		return nil, nil, nil
+	})
+
+	count, err := RunDue(context.Background(), monitors, jobs, now)
+	if err != nil || count != 0 || !monitors.claimReleased {
+		t.Fatalf("RunDue() = (%d, %v), claimReleased=%v", count, err, monitors.claimReleased)
+	}
+}
+
+type memoryMonitorStore struct {
+	mu               sync.Mutex
+	due              []*ports.ComplianceMonitor
+	planLeaseOwner   string
+	completed        bool
+	claimReleased    bool
+	completeJobCount int
+	outcomeRecorded  bool
+}
+
+func (s *memoryMonitorStore) PutComplianceMonitor(context.Context, *ports.ComplianceMonitor, uint64) (*ports.ComplianceMonitor, error) {
+	return nil, nil
+}
+func (s *memoryMonitorStore) GetComplianceMonitor(context.Context, string, string) (*ports.ComplianceMonitor, error) {
+	return nil, ports.ErrComplianceMonitorNotFound
+}
+func (s *memoryMonitorStore) ListComplianceMonitors(context.Context, ports.ComplianceMonitorFilter) ([]*ports.ComplianceMonitor, error) {
+	return nil, nil
+}
+func (s *memoryMonitorStore) ClaimDueComplianceMonitors(context.Context, time.Time, string, time.Duration, uint32) ([]*ports.ComplianceMonitor, error) {
+	return s.due, nil
+}
+func (s *memoryMonitorStore) CompleteComplianceMonitorClaim(_ context.Context, _, _, _ string, _, _ time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.completed = true
+	return nil
+}
+func (s *memoryMonitorStore) ReleaseComplianceMonitorClaim(context.Context, string, string, string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.claimReleased = true
+	return nil
+}
+func (s *memoryMonitorStore) AcquireCompliancePlanLease(_ context.Context, _, _, owner, _ string, _ time.Time, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.planLeaseOwner != "" && s.planLeaseOwner != owner {
+		return ports.ErrComplianceMonitorOverlap
+	}
+	s.planLeaseOwner = owner
+	return nil
+}
+func (s *memoryMonitorStore) ReleaseCompliancePlanLease(_ context.Context, _, _, owner string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.planLeaseOwner == owner {
+		s.planLeaseOwner = ""
+	}
+	return nil
+}
+func (s *memoryMonitorStore) RecordComplianceMonitorOutcome(context.Context, string, string, bool, time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.outcomeRecorded = true
+	return nil
+}
+func (s *memoryMonitorStore) jobExistedAtComplete(store *memoryJobStore) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return s.completed && len(store.jobs) == 1
+}
+
+type memoryJobStore struct {
+	mu        sync.Mutex
+	now       time.Time
+	jobs      map[string]*ports.Job
+	byKey     map[string]*ports.Job
+	createErr error
+}
+
+func newMemoryJobStore(now time.Time) *memoryJobStore {
+	return &memoryJobStore{now: now, jobs: map[string]*ports.Job{}, byKey: map[string]*ports.Job{}}
+}
+func (s *memoryJobStore) Ping(context.Context) error { return nil }
+func (s *memoryJobStore) CreateJob(_ context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.createErr != nil {
+		return nil, false, s.createErr
+	}
+	if existing := s.byKey[request.IdempotencyKey]; existing != nil {
+		return cloneJob(existing), false, nil
+	}
+	job := &ports.Job{ID: "job-1", Kind: request.Kind, Status: ports.JobStatusQueued, TenantID: request.TenantID, SubjectType: request.SubjectType, SubjectID: request.SubjectID, IdempotencyKey: request.IdempotencyKey, RequestHash: request.RequestHash, Payload: request.Payload, CreatedAt: s.now, UpdatedAt: s.now}
+	s.jobs[job.ID] = job
+	s.byKey[request.IdempotencyKey] = job
+	return cloneJob(job), true, nil
+}
+func (s *memoryJobStore) GetJob(_ context.Context, id string) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job := s.jobs[id]
+	if job == nil {
+		return nil, ports.ErrJobNotFound
+	}
+	return cloneJob(job), nil
+}
+func (s *memoryJobStore) ListJobs(context.Context, ports.JobFilter) ([]*ports.Job, error) {
+	return nil, nil
+}
+func (s *memoryJobStore) CountJobs(context.Context, ports.JobFilter) (uint64, error) { return 0, nil }
+func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.JobUpdate) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job := s.jobs[id]
+	if job == nil {
+		return nil, ports.ErrJobNotFound
+	}
+	if update.Status != "" {
+		job.Status = update.Status
+	}
+	job.Result = update.Result
+	job.ResultRefs = update.ResultRefs
+	if update.StartedAt != nil {
+		job.StartedAt = *update.StartedAt
+	}
+	if update.FinishedAt != nil {
+		job.FinishedAt = *update.FinishedAt
+	}
+	return cloneJob(job), nil
+}
+func (s *memoryJobStore) AppendJobEvent(_ context.Context, event ports.JobEvent) (*ports.JobEvent, error) {
+	return &event, nil
+}
+func (s *memoryJobStore) ListJobEvents(context.Context, string, uint32) ([]*ports.JobEvent, error) {
+	return nil, nil
+}
+
+func cloneJob(job *ports.Job) *ports.Job {
+	if job == nil {
+		return nil
+	}
+	clone := *job
+	clone.Payload = map[string]any{}
+	for key, value := range job.Payload {
+		clone.Payload[key] = value
+	}
+	return &clone
+}

--- a/internal/compliancemonitor/run_test.go
+++ b/internal/compliancemonitor/run_test.go
@@ -83,14 +83,42 @@ func TestRunDueSkipsOverlappingPlan(t *testing.T) {
 	}
 }
 
+func TestRunDueChangesCreatesJobBeforeAcknowledgingExactWindow(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)
+	monitors := &memoryMonitorStore{changeWindows: []*ports.ComplianceChangeWindow{{
+		TenantID: "tenant-1", MonitorID: "monitor-change-1", ProgramID: "program-1",
+		PlanRevisionID: "plan-revision-1", Version: 4, OpenedAt: now.Add(-time.Minute),
+		LastSignalAt: now.Add(-30 * time.Second), ReadyAt: now, SignalCount: 3,
+		ScopeDigest: "sha256:scope",
+	}}}
+	jobStore := newMemoryJobStore(now)
+	jobs := platformjobs.New(jobStore).WithRunner(platformjobs.KindComplianceAssessment, func(ctx context.Context, job *ports.Job, _ *platformjobs.Service) (map[string]any, map[string]string, error) {
+		return nil, nil, CompleteRun(ctx, monitors, job, true, now.Add(time.Minute))
+	})
+
+	count, err := RunDueChanges(context.Background(), monitors, jobs, now)
+	if err != nil {
+		t.Fatalf("RunDueChanges() error = %v", err)
+	}
+	if count != 1 || !monitors.changeCompleted || monitors.completedChangeVersion != 4 || !monitors.changeJobExistedAtComplete(jobStore) {
+		t.Fatalf("count=%d completed=%v version=%d jobExistedAtComplete=%v", count, monitors.changeCompleted, monitors.completedChangeVersion, monitors.changeJobExistedAtComplete(jobStore))
+	}
+	if err := jobs.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+}
+
 type memoryMonitorStore struct {
-	mu               sync.Mutex
-	due              []*ports.ComplianceMonitor
-	planLeaseOwner   string
-	completed        bool
-	claimReleased    bool
-	completeJobCount int
-	outcomeRecorded  bool
+	mu                     sync.Mutex
+	due                    []*ports.ComplianceMonitor
+	planLeaseOwner         string
+	completed              bool
+	claimReleased          bool
+	outcomeRecorded        bool
+	changeWindows          []*ports.ComplianceChangeWindow
+	changeCompleted        bool
+	completedChangeVersion uint64
 }
 
 func (s *memoryMonitorStore) PutComplianceMonitor(context.Context, *ports.ComplianceMonitor, uint64) (*ports.ComplianceMonitor, error) {
@@ -140,12 +168,35 @@ func (s *memoryMonitorStore) RecordComplianceMonitorOutcome(context.Context, str
 	s.outcomeRecorded = true
 	return nil
 }
+func (s *memoryMonitorStore) RecordComplianceChangeSignal(context.Context, ports.ComplianceChangeSignal) (bool, error) {
+	return true, nil
+}
+func (s *memoryMonitorStore) ClaimDueComplianceChangeWindows(context.Context, time.Time, string, time.Duration, uint32) ([]*ports.ComplianceChangeWindow, error) {
+	return s.changeWindows, nil
+}
+func (s *memoryMonitorStore) CompleteComplianceChangeWindow(_ context.Context, _, _, _ string, version uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.changeCompleted = true
+	s.completedChangeVersion = version
+	return nil
+}
+func (s *memoryMonitorStore) ReleaseComplianceChangeWindow(context.Context, string, string, string) error {
+	return nil
+}
 func (s *memoryMonitorStore) jobExistedAtComplete(store *memoryJobStore) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	return s.completed && len(store.jobs) == 1
+}
+func (s *memoryMonitorStore) changeJobExistedAtComplete(store *memoryJobStore) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return s.changeCompleted && len(store.jobs) == 1
 }
 
 type memoryJobStore struct {

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -46,6 +46,7 @@ const (
 	KindAppendLogRuntimeIndex     = "append_log_runtime_index"
 	KindProactiveFindingTriage    = "proactive_finding_triage"
 	KindGRCUpload                 = "grc_upload"
+	KindComplianceAssessment      = "compliance_assessment"
 )
 
 type Runner func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error)

--- a/internal/ports/compliance_monitor.go
+++ b/internal/ports/compliance_monitor.go
@@ -29,6 +29,7 @@ type ComplianceMonitor struct {
 	ExpectedCoverage    string
 	MaximumEvidenceAge  time.Duration
 	GracePeriod         time.Duration
+	DebounceWindow      time.Duration
 	EscalationOwner     string
 	Enabled             bool
 	Version             uint64
@@ -47,6 +48,35 @@ type ComplianceMonitorFilter struct {
 	Limit    uint32
 }
 
+// ComplianceChangeSignal is a bounded notification that an assessment input
+// changed. ScopeDigest identifies the affected canonical scope without copying
+// resource or evidence contents into scheduler state.
+type ComplianceChangeSignal struct {
+	EventID     string
+	TenantID    string
+	MonitorID   string
+	SignalKind  string
+	ScopeDigest string
+	ObservedAt  time.Time
+}
+
+// ComplianceChangeWindow is the coalesced, claimable unit for one change
+// monitor. Version changes whenever another signal joins the window.
+type ComplianceChangeWindow struct {
+	TenantID       string
+	MonitorID      string
+	ProgramID      string
+	PlanRevisionID string
+	Version        uint64
+	OpenedAt       time.Time
+	LastSignalAt   time.Time
+	ReadyAt        time.Time
+	SignalCount    uint64
+	ScopeDigest    string
+	ClaimOwner     string
+	ClaimExpiresAt time.Time
+}
+
 // ComplianceMonitorStore owns monitor definitions, due claims, and per-plan
 // overlap leases. Advancing a monitor is an acknowledgement after durable job
 // creation, never part of claiming the occurrence.
@@ -60,4 +90,16 @@ type ComplianceMonitorStore interface {
 	AcquireCompliancePlanLease(context.Context, string, string, string, string, time.Time, time.Duration) error
 	ReleaseCompliancePlanLease(context.Context, string, string, string) error
 	RecordComplianceMonitorOutcome(context.Context, string, string, bool, time.Time) error
+}
+
+// ComplianceChangeMonitorStore owns idempotent signal ingestion and durable
+// debounce windows. Completing a claim is an acknowledgement after job
+// creation; a signal that arrives while claimed creates a newer version that
+// cannot be deleted by the older acknowledgement.
+type ComplianceChangeMonitorStore interface {
+	ComplianceMonitorStore
+	RecordComplianceChangeSignal(context.Context, ComplianceChangeSignal) (bool, error)
+	ClaimDueComplianceChangeWindows(context.Context, time.Time, string, time.Duration, uint32) ([]*ComplianceChangeWindow, error)
+	CompleteComplianceChangeWindow(context.Context, string, string, string, uint64) error
+	ReleaseComplianceChangeWindow(context.Context, string, string, string) error
 }

--- a/internal/ports/compliance_monitor.go
+++ b/internal/ports/compliance_monitor.go
@@ -1,0 +1,63 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrComplianceMonitorNotFound = errors.New("compliance monitor not found")
+	ErrComplianceMonitorConflict = errors.New("compliance monitor conflict")
+	ErrComplianceMonitorOverlap  = errors.New("compliance assessment already running for plan revision")
+)
+
+const (
+	ComplianceTriggerTime   = "time"
+	ComplianceTriggerChange = "change"
+)
+
+// ComplianceMonitor defines when one exact assessment plan revision should run.
+// Current execution state is kept separate from the immutable plan revision.
+type ComplianceMonitor struct {
+	ID                  string
+	TenantID            string
+	ProgramID           string
+	PlanRevisionID      string
+	TriggerKind         string
+	IntervalSeconds     int64
+	ExpectedCoverage    string
+	MaximumEvidenceAge  time.Duration
+	GracePeriod         time.Duration
+	EscalationOwner     string
+	Enabled             bool
+	Version             uint64
+	NextRunAt           time.Time
+	LastSuccessAt       time.Time
+	ConsecutiveFailures uint32
+	ClaimOwner          string
+	ClaimExpiresAt      time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type ComplianceMonitorFilter struct {
+	TenantID string
+	AfterID  string
+	Limit    uint32
+}
+
+// ComplianceMonitorStore owns monitor definitions, due claims, and per-plan
+// overlap leases. Advancing a monitor is an acknowledgement after durable job
+// creation, never part of claiming the occurrence.
+type ComplianceMonitorStore interface {
+	PutComplianceMonitor(context.Context, *ComplianceMonitor, uint64) (*ComplianceMonitor, error)
+	GetComplianceMonitor(context.Context, string, string) (*ComplianceMonitor, error)
+	ListComplianceMonitors(context.Context, ComplianceMonitorFilter) ([]*ComplianceMonitor, error)
+	ClaimDueComplianceMonitors(context.Context, time.Time, string, time.Duration, uint32) ([]*ComplianceMonitor, error)
+	CompleteComplianceMonitorClaim(context.Context, string, string, string, time.Time, time.Time) error
+	ReleaseComplianceMonitorClaim(context.Context, string, string, string) error
+	AcquireCompliancePlanLease(context.Context, string, string, string, string, time.Time, time.Duration) error
+	ReleaseCompliancePlanLease(context.Context, string, string, string) error
+	RecordComplianceMonitorOutcome(context.Context, string, string, bool, time.Time) error
+}

--- a/internal/statestore/postgres/compliance_monitor.go
+++ b/internal/statestore/postgres/compliance_monitor.go
@@ -1,0 +1,343 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureComplianceMonitorStatements = []string{
+	`CREATE TABLE IF NOT EXISTS compliance_monitors (
+  tenant_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  program_id TEXT NOT NULL,
+  plan_revision_id TEXT NOT NULL,
+  trigger_kind TEXT NOT NULL,
+  interval_seconds BIGINT NOT NULL,
+  expected_coverage TEXT NOT NULL DEFAULT '',
+  maximum_evidence_age_seconds BIGINT NOT NULL DEFAULT 0,
+  grace_period_seconds BIGINT NOT NULL DEFAULT 0,
+  escalation_owner TEXT NOT NULL DEFAULT '',
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  aggregate_version BIGINT NOT NULL DEFAULT 1,
+  next_run_at TIMESTAMPTZ NOT NULL,
+  last_success_at TIMESTAMPTZ,
+  consecutive_failures INTEGER NOT NULL DEFAULT 0,
+  claim_owner TEXT NOT NULL DEFAULT '',
+  claim_expires_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, id)
+)`,
+	`CREATE INDEX IF NOT EXISTS compliance_monitors_due_idx ON compliance_monitors (next_run_at) WHERE enabled`,
+	`CREATE INDEX IF NOT EXISTS compliance_monitors_plan_idx ON compliance_monitors (tenant_id, plan_revision_id)`,
+	`CREATE TABLE IF NOT EXISTS compliance_plan_run_leases (
+  tenant_id TEXT NOT NULL,
+  plan_revision_id TEXT NOT NULL,
+  lease_owner TEXT NOT NULL,
+  occurrence_key TEXT NOT NULL,
+  lease_expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, plan_revision_id)
+)`,
+	`CREATE INDEX IF NOT EXISTS compliance_plan_run_leases_expiry_idx ON compliance_plan_run_leases (lease_expires_at)`,
+}
+
+const complianceMonitorColumns = `tenant_id, id, program_id, plan_revision_id, trigger_kind, interval_seconds, expected_coverage, maximum_evidence_age_seconds, grace_period_seconds, escalation_owner, enabled, aggregate_version, next_run_at, last_success_at, consecutive_failures, claim_owner, claim_expires_at, created_at, updated_at`
+
+func (s *Store) ensureComplianceMonitorTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.grc.complianceMonitor, "compliance_monitors", ensureComplianceMonitorStatements)
+}
+
+func (s *Store) PutComplianceMonitor(ctx context.Context, monitor *ports.ComplianceMonitor, expectedVersion uint64) (*ports.ComplianceMonitor, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := validateComplianceMonitor(monitor); err != nil {
+		return nil, err
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return nil, err
+	}
+	version := monitor.Version
+	if version == 0 {
+		version = 1
+	}
+	// #nosec G201 -- the column list is fixed and values remain parameterized.
+	query := fmt.Sprintf(`
+INSERT INTO compliance_monitors (
+  tenant_id, id, program_id, plan_revision_id, trigger_kind, interval_seconds,
+  expected_coverage, maximum_evidence_age_seconds, grace_period_seconds,
+  escalation_owner, enabled, aggregate_version, next_run_at
+)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+ON CONFLICT (tenant_id, id) DO UPDATE SET
+  program_id = EXCLUDED.program_id,
+  plan_revision_id = EXCLUDED.plan_revision_id,
+  trigger_kind = EXCLUDED.trigger_kind,
+  interval_seconds = EXCLUDED.interval_seconds,
+  expected_coverage = EXCLUDED.expected_coverage,
+  maximum_evidence_age_seconds = EXCLUDED.maximum_evidence_age_seconds,
+  grace_period_seconds = EXCLUDED.grace_period_seconds,
+  escalation_owner = EXCLUDED.escalation_owner,
+  enabled = EXCLUDED.enabled,
+  aggregate_version = compliance_monitors.aggregate_version + 1,
+  next_run_at = EXCLUDED.next_run_at,
+  claim_owner = '',
+  claim_expires_at = NULL,
+  updated_at = NOW()
+WHERE compliance_monitors.aggregate_version = $14
+RETURNING %s`, complianceMonitorColumns)
+	row := s.db.QueryRowContext(ctx, query,
+		strings.TrimSpace(monitor.TenantID), strings.TrimSpace(monitor.ID), strings.TrimSpace(monitor.ProgramID),
+		strings.TrimSpace(monitor.PlanRevisionID), strings.TrimSpace(monitor.TriggerKind), monitor.IntervalSeconds,
+		strings.TrimSpace(monitor.ExpectedCoverage), int64(monitor.MaximumEvidenceAge/time.Second),
+		int64(monitor.GracePeriod/time.Second), strings.TrimSpace(monitor.EscalationOwner), monitor.Enabled,
+		version, monitor.NextRunAt.UTC(), expectedVersion)
+	stored, err := scanComplianceMonitor(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrComplianceMonitorConflict, monitor.ID)
+		}
+		return nil, fmt.Errorf("put compliance monitor %q: %w", monitor.ID, err)
+	}
+	return stored, nil
+}
+
+func (s *Store) GetComplianceMonitor(ctx context.Context, tenantID, monitorID string) (*ports.ComplianceMonitor, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return nil, err
+	}
+	// #nosec G201 -- the column list is fixed and values remain parameterized.
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`SELECT %s FROM compliance_monitors WHERE tenant_id = $1 AND id = $2`, complianceMonitorColumns), strings.TrimSpace(tenantID), strings.TrimSpace(monitorID))
+	monitor, err := scanComplianceMonitor(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ports.ErrComplianceMonitorNotFound
+		}
+		return nil, fmt.Errorf("get compliance monitor: %w", err)
+	}
+	return monitor, nil
+}
+
+func (s *Store) ListComplianceMonitors(ctx context.Context, filter ports.ComplianceMonitorFilter) ([]*ports.ComplianceMonitor, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return nil, err
+	}
+	limit := filter.Limit
+	if limit == 0 || limit > 500 {
+		limit = 500
+	}
+	// #nosec G201 -- the column list is fixed and values remain parameterized.
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`SELECT %s FROM compliance_monitors WHERE tenant_id = $1 AND id > $2 ORDER BY id LIMIT $3`, complianceMonitorColumns), strings.TrimSpace(filter.TenantID), strings.TrimSpace(filter.AfterID), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list compliance monitors: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	monitors := []*ports.ComplianceMonitor{}
+	for rows.Next() {
+		monitor, scanErr := scanComplianceMonitor(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		monitors = append(monitors, monitor)
+	}
+	return monitors, rows.Err()
+}
+
+func (s *Store) ClaimDueComplianceMonitors(ctx context.Context, now time.Time, owner string, ttl time.Duration, limit uint32) ([]*ports.ComplianceMonitor, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return nil, err
+	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" || ttl <= 0 {
+		return nil, errors.New("compliance monitor owner and positive ttl are required")
+	}
+	if limit == 0 || limit > 100 {
+		limit = 50
+	}
+	// #nosec G201 -- the column list is fixed and values remain parameterized.
+	query := fmt.Sprintf(`
+UPDATE compliance_monitors
+SET claim_owner = $3,
+    claim_expires_at = $1::timestamptz + $4::bigint * INTERVAL '1 millisecond',
+    updated_at = NOW()
+WHERE (tenant_id, id) IN (
+  SELECT tenant_id, id FROM compliance_monitors
+  WHERE enabled AND trigger_kind = 'time' AND next_run_at <= $1
+    AND (claim_expires_at IS NULL OR claim_expires_at <= $1)
+  ORDER BY next_run_at, tenant_id, id
+  LIMIT $2 FOR UPDATE SKIP LOCKED
+)
+RETURNING %s`, complianceMonitorColumns)
+	rows, err := s.db.QueryContext(ctx, query, now.UTC(), limit, owner, ttl.Milliseconds())
+	if err != nil {
+		return nil, fmt.Errorf("claim due compliance monitors: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	monitors := []*ports.ComplianceMonitor{}
+	for rows.Next() {
+		monitor, scanErr := scanComplianceMonitor(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		monitors = append(monitors, monitor)
+	}
+	return monitors, rows.Err()
+}
+
+func (s *Store) CompleteComplianceMonitorClaim(ctx context.Context, tenantID, monitorID, owner string, occurrenceAt, completedAt time.Time) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE compliance_monitors
+SET next_run_at = $5::timestamptz + make_interval(secs => interval_seconds),
+    claim_owner = '', claim_expires_at = NULL, updated_at = NOW()
+WHERE tenant_id = $1 AND id = $2 AND claim_owner = $3 AND next_run_at = $4`,
+		strings.TrimSpace(tenantID), strings.TrimSpace(monitorID), strings.TrimSpace(owner), occurrenceAt.UTC(), completedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("complete compliance monitor claim: %w", err)
+	}
+	if count, _ := result.RowsAffected(); count == 0 {
+		return ports.ErrComplianceMonitorConflict
+	}
+	return nil
+}
+
+func (s *Store) ReleaseComplianceMonitorClaim(ctx context.Context, tenantID, monitorID, owner string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `UPDATE compliance_monitors SET claim_owner = '', claim_expires_at = NULL, updated_at = NOW() WHERE tenant_id = $1 AND id = $2 AND claim_owner = $3`, strings.TrimSpace(tenantID), strings.TrimSpace(monitorID), strings.TrimSpace(owner))
+	return err
+}
+
+func (s *Store) AcquireCompliancePlanLease(ctx context.Context, tenantID, planRevisionID, owner, occurrence string, now time.Time, ttl time.Duration) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(planRevisionID) == "" || strings.TrimSpace(owner) == "" || strings.TrimSpace(occurrence) == "" || ttl <= 0 {
+		return errors.New("tenant, plan revision, lease owner, occurrence, and positive ttl are required")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+INSERT INTO compliance_plan_run_leases (tenant_id, plan_revision_id, lease_owner, occurrence_key, lease_expires_at)
+VALUES ($1,$2,$3,$4,$5::timestamptz + $6::bigint * INTERVAL '1 millisecond')
+ON CONFLICT (tenant_id, plan_revision_id) DO UPDATE SET
+  lease_owner = EXCLUDED.lease_owner,
+  occurrence_key = EXCLUDED.occurrence_key,
+  lease_expires_at = EXCLUDED.lease_expires_at,
+  updated_at = NOW()
+WHERE compliance_plan_run_leases.lease_expires_at <= $5 OR compliance_plan_run_leases.occurrence_key = EXCLUDED.occurrence_key`,
+		strings.TrimSpace(tenantID), strings.TrimSpace(planRevisionID), strings.TrimSpace(owner), strings.TrimSpace(occurrence), now.UTC(), ttl.Milliseconds())
+	if err != nil {
+		return fmt.Errorf("acquire compliance plan lease: %w", err)
+	}
+	if count, _ := result.RowsAffected(); count == 0 {
+		return ports.ErrComplianceMonitorOverlap
+	}
+	return nil
+}
+
+func (s *Store) ReleaseCompliancePlanLease(ctx context.Context, tenantID, planRevisionID, owner string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM compliance_plan_run_leases WHERE tenant_id = $1 AND plan_revision_id = $2 AND lease_owner = $3`, strings.TrimSpace(tenantID), strings.TrimSpace(planRevisionID), strings.TrimSpace(owner))
+	return err
+}
+
+func (s *Store) RecordComplianceMonitorOutcome(ctx context.Context, tenantID, monitorID string, succeeded bool, at time.Time) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE compliance_monitors
+SET last_success_at = CASE WHEN $3 THEN $4::timestamptz ELSE last_success_at END,
+    consecutive_failures = CASE WHEN $3 THEN 0 ELSE consecutive_failures + 1 END,
+    updated_at = NOW()
+WHERE tenant_id = $1 AND id = $2`, strings.TrimSpace(tenantID), strings.TrimSpace(monitorID), succeeded, at.UTC())
+	if err != nil {
+		return fmt.Errorf("record compliance monitor outcome: %w", err)
+	}
+	if count, _ := result.RowsAffected(); count == 0 {
+		return ports.ErrComplianceMonitorNotFound
+	}
+	return nil
+}
+
+func validateComplianceMonitor(monitor *ports.ComplianceMonitor) error {
+	if monitor == nil {
+		return errors.New("compliance monitor is required")
+	}
+	if strings.TrimSpace(monitor.ID) == "" || strings.TrimSpace(monitor.TenantID) == "" || strings.TrimSpace(monitor.ProgramID) == "" || strings.TrimSpace(monitor.PlanRevisionID) == "" {
+		return errors.New("compliance monitor id, tenant, program, and plan revision are required")
+	}
+	if monitor.TriggerKind != ports.ComplianceTriggerTime && monitor.TriggerKind != ports.ComplianceTriggerChange {
+		return errors.New("compliance monitor trigger kind is invalid")
+	}
+	if monitor.TriggerKind == ports.ComplianceTriggerTime && monitor.IntervalSeconds <= 0 {
+		return errors.New("time-triggered compliance monitor interval must be positive")
+	}
+	if monitor.NextRunAt.IsZero() {
+		return errors.New("compliance monitor next run time is required")
+	}
+	return nil
+}
+
+func scanComplianceMonitor(row scanner) (*ports.ComplianceMonitor, error) {
+	var monitor ports.ComplianceMonitor
+	var maximumAgeSeconds, graceSeconds int64
+	var lastSuccessAt, claimExpiresAt sql.NullTime
+	if err := row.Scan(
+		&monitor.TenantID, &monitor.ID, &monitor.ProgramID, &monitor.PlanRevisionID,
+		&monitor.TriggerKind, &monitor.IntervalSeconds, &monitor.ExpectedCoverage,
+		&maximumAgeSeconds, &graceSeconds, &monitor.EscalationOwner, &monitor.Enabled,
+		&monitor.Version, &monitor.NextRunAt, &lastSuccessAt, &monitor.ConsecutiveFailures,
+		&monitor.ClaimOwner, &claimExpiresAt, &monitor.CreatedAt, &monitor.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	monitor.MaximumEvidenceAge = time.Duration(maximumAgeSeconds) * time.Second
+	monitor.GracePeriod = time.Duration(graceSeconds) * time.Second
+	if lastSuccessAt.Valid {
+		monitor.LastSuccessAt = lastSuccessAt.Time.UTC()
+	}
+	if claimExpiresAt.Valid {
+		monitor.ClaimExpiresAt = claimExpiresAt.Time.UTC()
+	}
+	monitor.NextRunAt = monitor.NextRunAt.UTC()
+	monitor.CreatedAt = monitor.CreatedAt.UTC()
+	monitor.UpdatedAt = monitor.UpdatedAt.UTC()
+	return &monitor, nil
+}

--- a/internal/statestore/postgres/compliance_monitor.go
+++ b/internal/statestore/postgres/compliance_monitor.go
@@ -22,6 +22,7 @@ var ensureComplianceMonitorStatements = []string{
   expected_coverage TEXT NOT NULL DEFAULT '',
   maximum_evidence_age_seconds BIGINT NOT NULL DEFAULT 0,
   grace_period_seconds BIGINT NOT NULL DEFAULT 0,
+  debounce_seconds BIGINT NOT NULL DEFAULT 0,
   escalation_owner TEXT NOT NULL DEFAULT '',
   enabled BOOLEAN NOT NULL DEFAULT TRUE,
   aggregate_version BIGINT NOT NULL DEFAULT 1,
@@ -34,6 +35,8 @@ var ensureComplianceMonitorStatements = []string{
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (tenant_id, id)
 )`,
+	`ALTER TABLE compliance_monitors ADD COLUMN IF NOT EXISTS debounce_seconds BIGINT NOT NULL DEFAULT 0`,
+	`ALTER TABLE compliance_monitors ALTER COLUMN next_run_at DROP NOT NULL`,
 	`CREATE INDEX IF NOT EXISTS compliance_monitors_due_idx ON compliance_monitors (next_run_at) WHERE enabled`,
 	`CREATE INDEX IF NOT EXISTS compliance_monitors_plan_idx ON compliance_monitors (tenant_id, plan_revision_id)`,
 	`CREATE TABLE IF NOT EXISTS compliance_plan_run_leases (
@@ -47,9 +50,35 @@ var ensureComplianceMonitorStatements = []string{
   PRIMARY KEY (tenant_id, plan_revision_id)
 )`,
 	`CREATE INDEX IF NOT EXISTS compliance_plan_run_leases_expiry_idx ON compliance_plan_run_leases (lease_expires_at)`,
+	`CREATE TABLE IF NOT EXISTS compliance_monitor_change_signals (
+  tenant_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  monitor_id TEXT NOT NULL,
+  signal_kind TEXT NOT NULL,
+  scope_digest TEXT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, monitor_id, event_id)
+)`,
+	`CREATE TABLE IF NOT EXISTS compliance_monitor_change_windows (
+  tenant_id TEXT NOT NULL,
+  monitor_id TEXT NOT NULL,
+  window_version BIGINT NOT NULL DEFAULT 1,
+  opened_at TIMESTAMPTZ NOT NULL,
+  last_signal_at TIMESTAMPTZ NOT NULL,
+  ready_at TIMESTAMPTZ NOT NULL,
+  signal_count BIGINT NOT NULL DEFAULT 1,
+  scope_digest TEXT NOT NULL,
+  claim_owner TEXT NOT NULL DEFAULT '',
+  claim_expires_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, monitor_id),
+  FOREIGN KEY (tenant_id, monitor_id) REFERENCES compliance_monitors(tenant_id, id) ON DELETE CASCADE
+)`,
+	`CREATE INDEX IF NOT EXISTS compliance_monitor_change_windows_due_idx ON compliance_monitor_change_windows (ready_at)`,
 }
 
-const complianceMonitorColumns = `tenant_id, id, program_id, plan_revision_id, trigger_kind, interval_seconds, expected_coverage, maximum_evidence_age_seconds, grace_period_seconds, escalation_owner, enabled, aggregate_version, next_run_at, last_success_at, consecutive_failures, claim_owner, claim_expires_at, created_at, updated_at`
+const complianceMonitorColumns = `tenant_id, id, program_id, plan_revision_id, trigger_kind, interval_seconds, expected_coverage, maximum_evidence_age_seconds, grace_period_seconds, debounce_seconds, escalation_owner, enabled, aggregate_version, next_run_at, last_success_at, consecutive_failures, claim_owner, claim_expires_at, created_at, updated_at`
 
 func (s *Store) ensureComplianceMonitorTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.grc.complianceMonitor, "compliance_monitors", ensureComplianceMonitorStatements)
@@ -73,10 +102,10 @@ func (s *Store) PutComplianceMonitor(ctx context.Context, monitor *ports.Complia
 	query := fmt.Sprintf(`
 INSERT INTO compliance_monitors (
   tenant_id, id, program_id, plan_revision_id, trigger_kind, interval_seconds,
-  expected_coverage, maximum_evidence_age_seconds, grace_period_seconds,
+  expected_coverage, maximum_evidence_age_seconds, grace_period_seconds, debounce_seconds,
   escalation_owner, enabled, aggregate_version, next_run_at
 )
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
 ON CONFLICT (tenant_id, id) DO UPDATE SET
   program_id = EXCLUDED.program_id,
   plan_revision_id = EXCLUDED.plan_revision_id,
@@ -85,6 +114,7 @@ ON CONFLICT (tenant_id, id) DO UPDATE SET
   expected_coverage = EXCLUDED.expected_coverage,
   maximum_evidence_age_seconds = EXCLUDED.maximum_evidence_age_seconds,
   grace_period_seconds = EXCLUDED.grace_period_seconds,
+  debounce_seconds = EXCLUDED.debounce_seconds,
   escalation_owner = EXCLUDED.escalation_owner,
   enabled = EXCLUDED.enabled,
   aggregate_version = compliance_monitors.aggregate_version + 1,
@@ -92,14 +122,18 @@ ON CONFLICT (tenant_id, id) DO UPDATE SET
   claim_owner = '',
   claim_expires_at = NULL,
   updated_at = NOW()
-WHERE compliance_monitors.aggregate_version = $14
+WHERE compliance_monitors.aggregate_version = $15
 RETURNING %s`, complianceMonitorColumns)
+	var nextRunAt any
+	if monitor.TriggerKind == ports.ComplianceTriggerTime {
+		nextRunAt = monitor.NextRunAt.UTC()
+	}
 	row := s.db.QueryRowContext(ctx, query,
 		strings.TrimSpace(monitor.TenantID), strings.TrimSpace(monitor.ID), strings.TrimSpace(monitor.ProgramID),
 		strings.TrimSpace(monitor.PlanRevisionID), strings.TrimSpace(monitor.TriggerKind), monitor.IntervalSeconds,
 		strings.TrimSpace(monitor.ExpectedCoverage), int64(monitor.MaximumEvidenceAge/time.Second),
-		int64(monitor.GracePeriod/time.Second), strings.TrimSpace(monitor.EscalationOwner), monitor.Enabled,
-		version, monitor.NextRunAt.UTC(), expectedVersion)
+		int64(monitor.GracePeriod/time.Second), int64(monitor.DebounceWindow/time.Second), strings.TrimSpace(monitor.EscalationOwner), monitor.Enabled,
+		version, nextRunAt, expectedVersion)
 	stored, err := scanComplianceMonitor(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -210,8 +244,8 @@ func (s *Store) CompleteComplianceMonitorClaim(ctx context.Context, tenantID, mo
 	}
 	result, err := s.db.ExecContext(ctx, `
 UPDATE compliance_monitors
-SET next_run_at = $5::timestamptz + make_interval(secs => interval_seconds),
-    claim_owner = '', claim_expires_at = NULL, updated_at = NOW()
+SET next_run_at = $4::timestamptz + make_interval(secs => interval_seconds),
+    claim_owner = '', claim_expires_at = NULL, updated_at = $5
 WHERE tenant_id = $1 AND id = $2 AND claim_owner = $3 AND next_run_at = $4`,
 		strings.TrimSpace(tenantID), strings.TrimSpace(monitorID), strings.TrimSpace(owner), occurrenceAt.UTC(), completedAt.UTC())
 	if err != nil {
@@ -296,6 +330,165 @@ WHERE tenant_id = $1 AND id = $2`, strings.TrimSpace(tenantID), strings.TrimSpac
 	return nil
 }
 
+func (s *Store) RecordComplianceChangeSignal(ctx context.Context, signal ports.ComplianceChangeSignal) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, errors.New("postgres is not configured")
+	}
+	signal.EventID = strings.TrimSpace(signal.EventID)
+	signal.TenantID = strings.TrimSpace(signal.TenantID)
+	signal.MonitorID = strings.TrimSpace(signal.MonitorID)
+	signal.SignalKind = strings.TrimSpace(signal.SignalKind)
+	signal.ScopeDigest = strings.TrimSpace(signal.ScopeDigest)
+	if signal.EventID == "" || signal.TenantID == "" || signal.MonitorID == "" || signal.SignalKind == "" || signal.ScopeDigest == "" || signal.ObservedAt.IsZero() {
+		return false, errors.New("change signal event, tenant, monitor, kind, scope digest, and observed time are required")
+	}
+	if len(signal.SignalKind) > 128 || len(signal.ScopeDigest) > 256 {
+		return false, errors.New("change signal kind or scope digest exceeds its limit")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return false, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin compliance change signal: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var debounceSeconds int64
+	if err := tx.QueryRowContext(ctx, `SELECT debounce_seconds FROM compliance_monitors WHERE tenant_id = $1 AND id = $2 AND enabled AND trigger_kind = 'change'`, signal.TenantID, signal.MonitorID).Scan(&debounceSeconds); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, ports.ErrComplianceMonitorNotFound
+		}
+		return false, fmt.Errorf("read compliance change monitor: %w", err)
+	}
+	if debounceSeconds <= 0 {
+		return false, errors.New("change-triggered compliance monitor debounce window must be positive")
+	}
+	result, err := tx.ExecContext(ctx, `
+INSERT INTO compliance_monitor_change_signals (tenant_id, event_id, monitor_id, signal_kind, scope_digest, observed_at)
+VALUES ($1,$2,$3,$4,$5,$6)
+ON CONFLICT (tenant_id, monitor_id, event_id) DO NOTHING`, signal.TenantID, signal.EventID, signal.MonitorID, signal.SignalKind, signal.ScopeDigest, signal.ObservedAt.UTC())
+	if err != nil {
+		return false, fmt.Errorf("record compliance change signal: %w", err)
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("count compliance change signal insert: %w", err)
+	}
+	if inserted == 0 {
+		return false, nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO compliance_monitor_change_windows (
+  tenant_id, monitor_id, window_version, opened_at, last_signal_at, ready_at,
+  signal_count, scope_digest
+)
+VALUES ($1,$2,1,$3,$3,$3::timestamptz + $5::bigint * INTERVAL '1 second',1,$4)
+ON CONFLICT (tenant_id, monitor_id) DO UPDATE SET
+  window_version = compliance_monitor_change_windows.window_version + 1,
+  last_signal_at = GREATEST(compliance_monitor_change_windows.last_signal_at, EXCLUDED.last_signal_at),
+  ready_at = GREATEST(compliance_monitor_change_windows.ready_at, EXCLUDED.ready_at),
+  signal_count = compliance_monitor_change_windows.signal_count + 1,
+  scope_digest = CASE
+    WHEN compliance_monitor_change_windows.scope_digest = EXCLUDED.scope_digest
+      THEN compliance_monitor_change_windows.scope_digest
+    ELSE 'multiple'
+  END,
+  updated_at = NOW()`, signal.TenantID, signal.MonitorID, signal.ObservedAt.UTC(), signal.ScopeDigest, debounceSeconds); err != nil {
+		return false, fmt.Errorf("coalesce compliance change signal: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit compliance change signal: %w", err)
+	}
+	return true, nil
+}
+
+func (s *Store) ClaimDueComplianceChangeWindows(ctx context.Context, now time.Time, owner string, ttl time.Duration, limit uint32) ([]*ports.ComplianceChangeWindow, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" || ttl <= 0 {
+		return nil, errors.New("compliance change claim owner and positive ttl are required")
+	}
+	if limit == 0 || limit > 100 {
+		limit = 50
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+WITH due AS (
+  SELECT w.tenant_id, w.monitor_id
+  FROM compliance_monitor_change_windows w
+  JOIN compliance_monitors m ON m.tenant_id = w.tenant_id AND m.id = w.monitor_id
+  WHERE m.enabled AND m.trigger_kind = 'change' AND w.ready_at <= $1
+    AND (w.claim_expires_at IS NULL OR w.claim_expires_at <= $1)
+  ORDER BY w.ready_at, w.tenant_id, w.monitor_id
+  LIMIT $2 FOR UPDATE OF w SKIP LOCKED
+), claimed AS (
+  UPDATE compliance_monitor_change_windows w
+  SET claim_owner = $3,
+      claim_expires_at = $1::timestamptz + $4::bigint * INTERVAL '1 millisecond',
+      updated_at = NOW()
+  FROM due
+  WHERE w.tenant_id = due.tenant_id AND w.monitor_id = due.monitor_id
+  RETURNING w.*
+)
+SELECT c.tenant_id, c.monitor_id, m.program_id, m.plan_revision_id,
+       c.window_version, c.opened_at, c.last_signal_at, c.ready_at,
+       c.signal_count, c.scope_digest, c.claim_owner, c.claim_expires_at
+FROM claimed c
+JOIN compliance_monitors m ON m.tenant_id = c.tenant_id AND m.id = c.monitor_id
+ORDER BY c.ready_at, c.tenant_id, c.monitor_id`, now.UTC(), limit, owner, ttl.Milliseconds())
+	if err != nil {
+		return nil, fmt.Errorf("claim compliance change windows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	windows := []*ports.ComplianceChangeWindow{}
+	for rows.Next() {
+		var window ports.ComplianceChangeWindow
+		if err := rows.Scan(&window.TenantID, &window.MonitorID, &window.ProgramID, &window.PlanRevisionID,
+			&window.Version, &window.OpenedAt, &window.LastSignalAt, &window.ReadyAt,
+			&window.SignalCount, &window.ScopeDigest, &window.ClaimOwner, &window.ClaimExpiresAt); err != nil {
+			return nil, fmt.Errorf("scan compliance change window: %w", err)
+		}
+		window.OpenedAt = window.OpenedAt.UTC()
+		window.LastSignalAt = window.LastSignalAt.UTC()
+		window.ReadyAt = window.ReadyAt.UTC()
+		window.ClaimExpiresAt = window.ClaimExpiresAt.UTC()
+		windows = append(windows, &window)
+	}
+	return windows, rows.Err()
+}
+
+func (s *Store) CompleteComplianceChangeWindow(ctx context.Context, tenantID, monitorID, owner string, version uint64) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM compliance_monitor_change_windows WHERE tenant_id = $1 AND monitor_id = $2 AND claim_owner = $3 AND window_version = $4`, strings.TrimSpace(tenantID), strings.TrimSpace(monitorID), strings.TrimSpace(owner), version)
+	if err != nil {
+		return fmt.Errorf("complete compliance change window: %w", err)
+	}
+	if count, _ := result.RowsAffected(); count == 0 {
+		return ports.ErrComplianceMonitorConflict
+	}
+	return nil
+}
+
+func (s *Store) ReleaseComplianceChangeWindow(ctx context.Context, tenantID, monitorID, owner string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureComplianceMonitorTables(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `UPDATE compliance_monitor_change_windows SET claim_owner = '', claim_expires_at = NULL, updated_at = NOW() WHERE tenant_id = $1 AND monitor_id = $2 AND claim_owner = $3`, strings.TrimSpace(tenantID), strings.TrimSpace(monitorID), strings.TrimSpace(owner))
+	return err
+}
+
 func validateComplianceMonitor(monitor *ports.ComplianceMonitor) error {
 	if monitor == nil {
 		return errors.New("compliance monitor is required")
@@ -309,7 +502,10 @@ func validateComplianceMonitor(monitor *ports.ComplianceMonitor) error {
 	if monitor.TriggerKind == ports.ComplianceTriggerTime && monitor.IntervalSeconds <= 0 {
 		return errors.New("time-triggered compliance monitor interval must be positive")
 	}
-	if monitor.NextRunAt.IsZero() {
+	if monitor.TriggerKind == ports.ComplianceTriggerChange && monitor.DebounceWindow <= 0 {
+		return errors.New("change-triggered compliance monitor debounce window must be positive")
+	}
+	if monitor.TriggerKind == ports.ComplianceTriggerTime && monitor.NextRunAt.IsZero() {
 		return errors.New("compliance monitor next run time is required")
 	}
 	return nil
@@ -317,26 +513,29 @@ func validateComplianceMonitor(monitor *ports.ComplianceMonitor) error {
 
 func scanComplianceMonitor(row scanner) (*ports.ComplianceMonitor, error) {
 	var monitor ports.ComplianceMonitor
-	var maximumAgeSeconds, graceSeconds int64
-	var lastSuccessAt, claimExpiresAt sql.NullTime
+	var maximumAgeSeconds, graceSeconds, debounceSeconds int64
+	var nextRunAt, lastSuccessAt, claimExpiresAt sql.NullTime
 	if err := row.Scan(
 		&monitor.TenantID, &monitor.ID, &monitor.ProgramID, &monitor.PlanRevisionID,
 		&monitor.TriggerKind, &monitor.IntervalSeconds, &monitor.ExpectedCoverage,
-		&maximumAgeSeconds, &graceSeconds, &monitor.EscalationOwner, &monitor.Enabled,
-		&monitor.Version, &monitor.NextRunAt, &lastSuccessAt, &monitor.ConsecutiveFailures,
+		&maximumAgeSeconds, &graceSeconds, &debounceSeconds, &monitor.EscalationOwner, &monitor.Enabled,
+		&monitor.Version, &nextRunAt, &lastSuccessAt, &monitor.ConsecutiveFailures,
 		&monitor.ClaimOwner, &claimExpiresAt, &monitor.CreatedAt, &monitor.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}
 	monitor.MaximumEvidenceAge = time.Duration(maximumAgeSeconds) * time.Second
 	monitor.GracePeriod = time.Duration(graceSeconds) * time.Second
+	monitor.DebounceWindow = time.Duration(debounceSeconds) * time.Second
 	if lastSuccessAt.Valid {
 		monitor.LastSuccessAt = lastSuccessAt.Time.UTC()
+	}
+	if nextRunAt.Valid {
+		monitor.NextRunAt = nextRunAt.Time.UTC()
 	}
 	if claimExpiresAt.Valid {
 		monitor.ClaimExpiresAt = claimExpiresAt.Time.UTC()
 	}
-	monitor.NextRunAt = monitor.NextRunAt.UTC()
 	monitor.CreatedAt = monitor.CreatedAt.UTC()
 	monitor.UpdatedAt = monitor.UpdatedAt.UTC()
 	return &monitor, nil

--- a/internal/statestore/postgres/compliance_monitor_test.go
+++ b/internal/statestore/postgres/compliance_monitor_test.go
@@ -13,6 +13,11 @@ func TestComplianceMonitorSchemaIsTenantScopedAndLeaseBacked(t *testing.T) {
 		"PRIMARY KEY (tenant_id, plan_revision_id)",
 		"claim_expires_at",
 		"occurrence_key",
+		"compliance_monitor_change_signals",
+		"PRIMARY KEY (tenant_id, monitor_id, event_id)",
+		"compliance_monitor_change_windows",
+		"window_version",
+		"FOREIGN KEY (tenant_id, monitor_id)",
 	} {
 		if !strings.Contains(joined, required) {
 			t.Fatalf("schema/query contract missing %q", required)

--- a/internal/statestore/postgres/compliance_monitor_test.go
+++ b/internal/statestore/postgres/compliance_monitor_test.go
@@ -1,0 +1,21 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComplianceMonitorSchemaIsTenantScopedAndLeaseBacked(t *testing.T) {
+	t.Parallel()
+	joined := strings.Join(ensureComplianceMonitorStatements, "\n")
+	for _, required := range []string{
+		"PRIMARY KEY (tenant_id, id)",
+		"PRIMARY KEY (tenant_id, plan_revision_id)",
+		"claim_expires_at",
+		"occurrence_key",
+	} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("schema/query contract missing %q", required)
+		}
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -46,6 +46,7 @@ type grcTablesReady struct {
 	customDashboards     bool
 	vendorDiscovery      bool
 	questionnaireRun     bool
+	complianceMonitor    bool
 }
 
 type appendLogTablesReady struct {


### PR DESCRIPTION
## Summary

- add tenant-scoped compliance monitor definitions for exact program and assessment-plan revisions
- add claim-and-ack scheduling so a monitor advances only after its assessment job exists
- add idempotent change-signal receipts, durable debounce windows, and exact-version acknowledgements
- add durable per-plan overlap leases and bounded monitor outcome tracking
- add schedule, import, parity-rollout, and rollback runbooks
- reuse the platform job lease and idempotency contracts from the execution foundation

## Dependency

This is an independently reviewable later-phase slice stacked on the compliance execution foundation. Assessment execution stays with the platform job runner.

## Exit criteria

- a scheduled occurrence cannot advance before durable job creation
- timed occurrences retain their logical cadence instead of drifting with scheduler completion time
- duplicate change delivery does not increase a debounce window and one event may affect multiple monitors
- a signal arriving during a claim creates a newer window version that the older acknowledgement cannot delete
- concurrent schedulers cannot start overlapping runs for one tenant and plan revision
- enqueue failure releases both occurrence and plan claims
- successful and failed terminal outcomes update bounded monitor state
- list and lookup operations remain tenant-scoped and keyset-bounded

## Validation

- focused monitor, job, and Postgres tests
- monitor race tests
- architecture and structural checks
- Go vet and lint on changed packages
- documentation drift and public-content audit
