### PR TITLE
Add deterministic assessment sampling

### DIFF
--- a/internal/complianceassessment/activities.go
+++ b/internal/complianceassessment/activities.go
@@ -1,0 +1,43 @@
+package complianceassessment
+
+import "time"
+
+type ActivityMethod string
+
+const (
+	ActivityExamine   ActivityMethod = "examine"
+	ActivityInterview ActivityMethod = "interview"
+	ActivityTest      ActivityMethod = "test"
+)
+
+type ActivityExecutionState string
+
+const (
+	ActivityQueued    ActivityExecutionState = "queued"
+	ActivityRunning   ActivityExecutionState = "running"
+	ActivityCompleted ActivityExecutionState = "completed"
+	ActivityFailed    ActivityExecutionState = "failed"
+	ActivityError     ActivityExecutionState = "error"
+	ActivitySkipped   ActivityExecutionState = "skipped"
+	ActivityCancelled ActivityExecutionState = "cancelled"
+)
+
+// AssessmentActivity records what was performed. ExecutionState is operational
+// state and must not be interpreted as a control outcome.
+type AssessmentActivity struct {
+	ID               string                 `json:"id"`
+	RunID            string                 `json:"run_id"`
+	ObjectiveID      string                 `json:"objective_id"`
+	PlanTaskID       string                 `json:"plan_task_id"`
+	Method           ActivityMethod         `json:"method"`
+	Procedure        string                 `json:"procedure"`
+	ExpectedResult   string                 `json:"expected_result"`
+	OperatorRef      string                 `json:"operator_ref,omitempty"`
+	ToolRef          string                 `json:"tool_ref,omitempty"`
+	ExecutionState   ActivityExecutionState `json:"execution_state"`
+	FailureCode      string                 `json:"failure_code,omitempty"`
+	SubjectCount     uint64                 `json:"subject_count"`
+	OutputReferences []string               `json:"output_references,omitempty"`
+	StartedAt        time.Time              `json:"started_at,omitempty"`
+	FinishedAt       time.Time              `json:"finished_at,omitempty"`
+}

--- a/internal/complianceassessment/populations.go
+++ b/internal/complianceassessment/populations.go
@@ -1,0 +1,136 @@
+package complianceassessment
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	ErrInvalidPopulation = errors.New("invalid assessment population")
+	ErrInvalidSample     = errors.New("invalid assessment sample")
+)
+
+const DeterministicSampleAlgorithm = "compliance-sample/v1"
+
+type PopulationSubject struct {
+	ID   string `json:"id"`
+	Type string `json:"type,omitempty"`
+}
+
+type PopulationSnapshot struct {
+	ID               string    `json:"id"`
+	RunID            string    `json:"run_id"`
+	ObjectiveID      string    `json:"objective_id"`
+	QueryDigest      string    `json:"query_digest"`
+	SourceWatermark  time.Time `json:"source_watermark"`
+	ExpectedCount    uint64    `json:"expected_count"`
+	ObservedCount    uint64    `json:"observed_count"`
+	Complete         bool      `json:"complete"`
+	ExclusionReasons []string  `json:"exclusion_reasons,omitempty"`
+	ContentDigest    string    `json:"content_digest"`
+}
+
+type SampleSelection struct {
+	ID               string              `json:"id"`
+	PopulationID     string              `json:"population_id"`
+	Algorithm        string              `json:"algorithm"`
+	Seed             string              `json:"seed"`
+	RequestedSize    uint32              `json:"requested_size"`
+	PopulationDigest string              `json:"population_digest"`
+	Subjects         []PopulationSubject `json:"subjects"`
+	SelectionDigest  string              `json:"selection_digest"`
+}
+
+// NormalizePopulation deduplicates stable subject identities and sorts them by
+// type and ID. Display names and collection order never affect population or
+// sample identity.
+func NormalizePopulation(subjects []PopulationSubject) ([]PopulationSubject, error) {
+	seen := map[string]struct{}{}
+	normalized := make([]PopulationSubject, 0, len(subjects))
+	for _, subject := range subjects {
+		subject.ID = strings.TrimSpace(subject.ID)
+		subject.Type = strings.TrimSpace(subject.Type)
+		if subject.ID == "" {
+			return nil, ErrInvalidPopulation
+		}
+		key := subject.Type + "\x00" + subject.ID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, subject)
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		return normalized[i].Type+"\x00"+normalized[i].ID < normalized[j].Type+"\x00"+normalized[j].ID
+	})
+	return normalized, nil
+}
+
+func PopulationDigest(subjects []PopulationSubject) (string, error) {
+	normalized, err := NormalizePopulation(subjects)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.New()
+	_, _ = hash.Write([]byte("compliance-population/v1"))
+	for _, subject := range normalized {
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(subject.Type))
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(subject.ID))
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// SelectDeterministicSample uses a versioned hash rank rather than math/rand,
+// making selections stable across process retries and Go releases.
+func SelectDeterministicSample(populationID, seed string, requested uint32, subjects []PopulationSubject) (SampleSelection, error) {
+	populationID = strings.TrimSpace(populationID)
+	seed = strings.TrimSpace(seed)
+	if populationID == "" || seed == "" || requested == 0 {
+		return SampleSelection{}, ErrInvalidSample
+	}
+	normalized, err := NormalizePopulation(subjects)
+	if err != nil {
+		return SampleSelection{}, err
+	}
+	if uint64(requested) > uint64(len(normalized)) {
+		return SampleSelection{}, ErrInvalidSample
+	}
+	populationDigest, err := PopulationDigest(normalized)
+	if err != nil {
+		return SampleSelection{}, err
+	}
+	type rankedSubject struct {
+		subject PopulationSubject
+		rank    [sha256.Size]byte
+	}
+	ranked := make([]rankedSubject, 0, len(normalized))
+	for _, subject := range normalized {
+		ranked = append(ranked, rankedSubject{subject: subject, rank: sha256.Sum256([]byte(
+			DeterministicSampleAlgorithm + "\x00" + seed + "\x00" + subject.Type + "\x00" + subject.ID,
+		))})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		left := hex.EncodeToString(ranked[i].rank[:]) + "\x00" + ranked[i].subject.Type + "\x00" + ranked[i].subject.ID
+		right := hex.EncodeToString(ranked[j].rank[:]) + "\x00" + ranked[j].subject.Type + "\x00" + ranked[j].subject.ID
+		return left < right
+	})
+	selected := make([]PopulationSubject, 0, requested)
+	for _, item := range ranked[:requested] {
+		selected = append(selected, item.subject)
+	}
+	selectionDigest, err := PopulationDigest(selected)
+	if err != nil {
+		return SampleSelection{}, err
+	}
+	return SampleSelection{
+		PopulationID: populationID, Algorithm: DeterministicSampleAlgorithm, Seed: seed,
+		RequestedSize: requested, PopulationDigest: populationDigest,
+		Subjects: selected, SelectionDigest: selectionDigest,
+	}, nil
+}

--- a/internal/complianceassessment/populations_test.go
+++ b/internal/complianceassessment/populations_test.go
@@ -1,0 +1,71 @@
+package complianceassessment
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+func TestDeterministicSampleSurvivesShuffleDuplicatesAndLargePopulation(t *testing.T) {
+	t.Parallel()
+	subjects := make([]PopulationSubject, 0, 1205)
+	for index := 0; index < 1205; index++ {
+		subjects = append(subjects, PopulationSubject{Type: "asset", ID: fmt.Sprintf("asset-%04d", index)})
+	}
+	want, err := SelectDeterministicSample("population-1", "seed-1", 75, subjects)
+	if err != nil {
+		t.Fatalf("SelectDeterministicSample() error = %v", err)
+	}
+	shuffled := append([]PopulationSubject(nil), subjects...)
+	rand.New(rand.NewSource(42)).Shuffle(len(shuffled), func(i, j int) { //nolint:gosec // deterministic test shuffle only.
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	shuffled = append(shuffled, subjects[0], subjects[100])
+	got, err := SelectDeterministicSample("population-1", "seed-1", 75, shuffled)
+	if err != nil {
+		t.Fatalf("SelectDeterministicSample(shuffled) error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sample changed after shuffle or duplicates\ngot=%#v\nwant=%#v", got, want)
+	}
+}
+
+func TestDeterministicSampleChangesWithSeed(t *testing.T) {
+	t.Parallel()
+	subjects := []PopulationSubject{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"}}
+	left, err := SelectDeterministicSample("population-1", "seed-1", 2, subjects)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := SelectDeterministicSample("population-1", "seed-2", 2, subjects)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(left.Subjects, right.Subjects) {
+		t.Fatalf("different seeds returned identical subjects: %#v", left.Subjects)
+	}
+}
+
+func TestDeterministicSampleRejectsInvalidSizeAndIdentity(t *testing.T) {
+	t.Parallel()
+	if _, err := SelectDeterministicSample("population-1", "seed", 2, []PopulationSubject{{ID: "only"}}); err == nil {
+		t.Fatal("oversized sample unexpectedly accepted")
+	}
+	if _, err := PopulationDigest([]PopulationSubject{{ID: " "}}); err == nil {
+		t.Fatal("empty subject id unexpectedly accepted")
+	}
+}
+
+func TestActivityExecutionFailureIsNotAControlOutcome(t *testing.T) {
+	t.Parallel()
+	activity := AssessmentActivity{ExecutionState: ActivityFailed, FailureCode: "source_unavailable"}
+	if activity.ExecutionState == ActivityCompleted {
+		t.Fatal("failed activity reported as completed")
+	}
+	// AssessmentActivity intentionally has no result or control-status field.
+	type resultCarrier interface{ ControlOutcome() string }
+	if _, ok := any(activity).(resultCarrier); ok {
+		t.Fatal("activity execution unexpectedly exposes a control outcome")
+	}
+}


### PR DESCRIPTION
## Summary

- add explicit examine, interview, and test activity execution records without conflating execution state with control outcome
- add normalized population identities and stable content digests
- add versioned hash-ranked sampling that remains reproducible across retries, input order, duplicates, and Go releases
- reject empty identities, empty seeds, zero-size samples, and requests larger than the population

## Dependency

This execution slice is stacked on the compliance correctness foundation. Durable population persistence and assessment-run orchestration arrive in their owning slices.

## Exit criteria

- the same population and seed always select the same subjects
- input order and duplicate subjects do not change population or selection digests
- large populations remain deterministic without bounded UI collectors
- activity failure remains operational state and never becomes a control failure

## Validation

- focused assessment tests
- assessment race tests
- Go vet
- architecture and structural checks