### PR TITLE
Add compliance exchange validation core

### DIFF
--- a/internal/complianceexchange/exchange_test.go
+++ b/internal/complianceexchange/exchange_test.go
@@ -1,0 +1,406 @@
+package complianceexchange
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+var exchangeTestTime = time.Date(2026, time.July, 11, 12, 30, 0, 123456000, time.UTC)
+
+func TestBuildDeterministicManifestAndCompleteCoverage(t *testing.T) {
+	signer, trust := newEd25519Fixture(t, "package-key-1")
+	request := BuildRequest{
+		PackageID: "package-1", TenantID: "tenant-1", CreatedAt: exchangeTestTime,
+		DisclosurePolicy: "auditor", RedactionMode: "external",
+		Files: []File{
+			{Path: "data/evidence/access.json", MediaType: "application/json", LogicalType: "evidence", Data: []byte(`{"state":"current"}`)},
+			{Path: "data/oscal/results.json", MediaType: "application/oscal+json", LogicalType: "assessment-results", Data: []byte(`{"assessment-results":{}}`)},
+		},
+	}
+	first, err := Build(context.Background(), request, signer)
+	if err != nil {
+		t.Fatalf("Build(first): %v", err)
+	}
+	request.Files[0], request.Files[1] = request.Files[1], request.Files[0]
+	second, err := Build(context.Background(), request, signer)
+	if err != nil {
+		t.Fatalf("Build(second): %v", err)
+	}
+	if !bytes.Equal(first.ManifestBytes, second.ManifestBytes) {
+		t.Fatalf("manifest bytes differ by input order:\n%s\n%s", first.ManifestBytes, second.ManifestBytes)
+	}
+	if first.ManifestDigest != second.ManifestDigest || first.Signature != second.Signature {
+		t.Fatalf("deterministic digest/signature mismatch: %q/%q vs %q/%q", first.ManifestDigest, first.Signature, second.ManifestDigest, second.Signature)
+	}
+	if got := []string{first.Manifest.Files[0].Path, first.Manifest.Files[1].Path}; got[0] != "data/evidence/access.json" || got[1] != "data/oscal/results.json" {
+		t.Fatalf("manifest paths = %v, want canonical order", got)
+	}
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: first.ManifestBytes,
+		Signature: first.Signature, Files: first.Files, Trust: trust,
+	})
+	if result.Status != ValidationValid || len(result.Issues) != 0 || result.ChangePlan == nil {
+		t.Fatalf("validation = %+v, want valid change plan", result)
+	}
+	if result.ChangePlan.ManifestDigest != first.ManifestDigest || len(result.ChangePlan.Operations) != 2 {
+		t.Fatalf("change plan = %+v", result.ChangePlan)
+	}
+}
+
+func TestBuildCopiesFileBytesBeforeDigesting(t *testing.T) {
+	signer, _ := newEd25519Fixture(t, "package-key-1")
+	data := []byte("original")
+	built, err := Build(context.Background(), BuildRequest{
+		PackageID: "package-1", TenantID: "tenant-1", CreatedAt: exchangeTestTime,
+		Files: []File{{Path: "data/item.txt", MediaType: "text/plain", LogicalType: "evidence", Data: data}},
+	}, signer)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	data[0] = 'X'
+	if string(built.Files[0].Data) != "original" {
+		t.Fatalf("built file = %q, want immutable copy", built.Files[0].Data)
+	}
+}
+
+func TestValidateRejectsAlteredAttachment(t *testing.T) {
+	fixture := buildFixture(t)
+	files := cloneFiles(fixture.built.Files)
+	files[0].Data = []byte("altered")
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: fixture.built.ManifestBytes,
+		Signature: fixture.built.Signature, Files: files, Trust: fixture.trust,
+	})
+	assertIssue(t, result, "file_digest_mismatch")
+	if result.ChangePlan != nil {
+		t.Fatal("invalid package received a change plan")
+	}
+}
+
+func TestValidateRejectsTraversalAndUnexpectedPayload(t *testing.T) {
+	fixture := buildFixture(t)
+	files := append(cloneFiles(fixture.built.Files), File{
+		Path: "../private.txt", MediaType: "text/plain", LogicalType: "evidence", Data: []byte("secret"),
+	})
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: fixture.built.ManifestBytes,
+		Signature: fixture.built.Signature, Files: files, Trust: fixture.trust,
+	})
+	assertIssue(t, result, "unsafe_path")
+}
+
+func TestValidateRejectsDuplicateAndCaseCollidingPayloadPaths(t *testing.T) {
+	fixture := buildFixture(t)
+	duplicate := fixture.built.Files[0]
+	duplicate.Path = strings.ToUpper(duplicate.Path)
+	files := append(cloneFiles(fixture.built.Files), duplicate)
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: fixture.built.ManifestBytes,
+		Signature: fixture.built.Signature, Files: files, Trust: fixture.trust,
+	})
+	assertIssue(t, result, "duplicate_path")
+}
+
+func TestValidateRejectsDuplicateManifestPath(t *testing.T) {
+	fixture := buildFixture(t)
+	manifest := fixture.built.Manifest
+	duplicate := manifest.Files[0]
+	duplicate.Path = strings.ToUpper(duplicate.Path)
+	manifest.Files = append(manifest.Files, duplicate)
+	manifest.FileCount++
+	manifest.TotalBytes += duplicate.SizeBytes
+	manifestBytes, err := marshalManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature, err := SignDetached(context.Background(), manifestBytes, fixture.signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: manifestBytes,
+		Signature: signature, Files: fixture.built.Files, Trust: fixture.trust,
+	})
+	assertIssue(t, result, "duplicate_manifest_path")
+}
+
+func TestValidateRejectsMissingAndUnexpectedFile(t *testing.T) {
+	fixture := buildFixture(t)
+	files := []File{{Path: "data/other.json", MediaType: "application/json", LogicalType: "evidence", Data: []byte(`{}`)}}
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: fixture.built.ManifestBytes,
+		Signature: fixture.built.Signature, Files: files, Trust: fixture.trust,
+	})
+	assertIssue(t, result, "payload_file_missing")
+	assertIssue(t, result, "unexpected_payload_file")
+}
+
+func TestValidateRejectsTenantMismatchBeforeChangePlan(t *testing.T) {
+	fixture := buildFixture(t)
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-2", ManifestBytes: fixture.built.ManifestBytes,
+		Signature: fixture.built.Signature, Files: fixture.built.Files, Trust: fixture.trust,
+	})
+	assertIssue(t, result, "tenant_mismatch")
+}
+
+func TestValidateRejectsAlteredManifestSignature(t *testing.T) {
+	fixture := buildFixture(t)
+	manifest := fixture.built.Manifest
+	manifest.RedactionMode = "changed-after-signing"
+	altered, err := marshalManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: altered,
+		Signature: fixture.built.Signature, Files: fixture.built.Files, Trust: fixture.trust,
+	})
+	assertIssue(t, result, "signature_invalid")
+}
+
+func TestValidateDoesNotResolveRemoteKeysFromSignature(t *testing.T) {
+	fixture := buildFixture(t)
+	called := 0
+	trust := TrustResolverFunc(func(_ context.Context, keyID string, algorithm string) (crypto.PublicKey, error) {
+		called++
+		if keyID != "package-key-1" || algorithm != AlgorithmEdDSA {
+			t.Fatalf("resolver args = %q/%q", keyID, algorithm)
+		}
+		return nil, errors.New("not configured")
+	})
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: fixture.built.ManifestBytes,
+		Signature: fixture.built.Signature, Files: fixture.built.Files, Trust: trust,
+	})
+	assertIssue(t, result, "signature_invalid")
+	if called != 1 {
+		t.Fatalf("resolver calls = %d, want 1", called)
+	}
+}
+
+func TestValidateRejectsRemoteKeyHeaderWithoutCallingResolver(t *testing.T) {
+	fixture := buildFixture(t)
+	parts := strings.Split(fixture.built.Signature, ".")
+	parts[0] = base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"EdDSA","kid":"package-key-1","typ":"compliance-manifest+jws","jku":"https://keys.invalid"}`))
+	called := false
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: fixture.built.ManifestBytes,
+		Signature: strings.Join(parts, "."), Files: fixture.built.Files,
+		Trust: TrustResolverFunc(func(context.Context, string, string) (crypto.PublicKey, error) {
+			called = true
+			return nil, errors.New("must not be called")
+		}),
+	})
+	assertIssue(t, result, "signature_invalid")
+	if called {
+		t.Fatal("trust resolver called for a signature header containing an unsupported remote-key field")
+	}
+}
+
+func TestValidateES256RoundTrip(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := CryptoSigner{AlgorithmName: AlgorithmES256, KeyIDValue: "p256-key-1", PrivateKey: key}
+	built, err := Build(context.Background(), fixtureBuildRequest(), signer)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: built.ManifestBytes,
+		Signature: built.Signature, Files: built.Files,
+		Trust: TrustResolverFunc(func(_ context.Context, keyID string, algorithm string) (crypto.PublicKey, error) {
+			if keyID != "p256-key-1" || algorithm != AlgorithmES256 {
+				return nil, errors.New("unexpected key")
+			}
+			return &key.PublicKey, nil
+		}),
+	})
+	if result.Status != ValidationValid {
+		t.Fatalf("validation = %+v", result)
+	}
+}
+
+func TestBuildRejectsUnsafePathsDuplicatesAndLimits(t *testing.T) {
+	signer, _ := newEd25519Fixture(t, "package-key-1")
+	tests := []struct {
+		name   string
+		files  []File
+		limits Limits
+	}{
+		{name: "traversal", files: []File{{Path: "data/../secret", MediaType: "text/plain", LogicalType: "evidence", Data: []byte("x")}}},
+		{name: "backslash", files: []File{{Path: `data\secret`, MediaType: "text/plain", LogicalType: "evidence", Data: []byte("x")}}},
+		{name: "volume", files: []File{{Path: "C:/secret", MediaType: "text/plain", LogicalType: "evidence", Data: []byte("x")}}},
+		{name: "control character", files: []File{{Path: "data/a\tb", MediaType: "text/plain", LogicalType: "evidence", Data: []byte("x")}}},
+		{name: "reserved", files: []File{{Path: "manifest.json", MediaType: "application/json", LogicalType: "manifest", Data: []byte("x")}}},
+		{name: "duplicates", files: []File{
+			{Path: "data/A", MediaType: "text/plain", LogicalType: "evidence", Data: []byte("x")},
+			{Path: "data/a", MediaType: "text/plain", LogicalType: "evidence", Data: []byte("x")},
+		}},
+		{name: "file limit", files: []File{{Path: "data/a", MediaType: "text/plain", LogicalType: "evidence", Data: []byte("xx")}}, limits: Limits{MaxFiles: 1, MaxFileBytes: 1, MaxTotalBytes: 1, MaxPathBytes: 20}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Build(context.Background(), BuildRequest{
+				PackageID: "package-1", TenantID: "tenant-1", CreatedAt: exchangeTestTime,
+				Files: tt.files, Limits: tt.limits,
+			}, signer)
+			if !errors.Is(err, ErrInvalidPackage) {
+				t.Fatalf("Build error = %v, want ErrInvalidPackage", err)
+			}
+		})
+	}
+}
+
+func TestValidateBoundsManifestAndSignatureBeforeParsing(t *testing.T) {
+	limits := Limits{
+		MaxFiles: 1, MaxFileBytes: 16, MaxTotalBytes: 16, MaxPathBytes: 32,
+		MaxManifestBytes: 2, MaxSignatureBytes: 2,
+	}
+	manifestResult := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: []byte(`{}` + " "), Limits: limits,
+	})
+	assertIssue(t, manifestResult, "manifest_size_limit")
+
+	limits.MaxManifestBytes = 4
+	signatureResult := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-1", ManifestBytes: []byte(`{}`), Signature: "abc", Limits: limits,
+	})
+	assertIssue(t, signatureResult, "signature_size_limit")
+}
+
+func TestSignDetachedRejectsUnapprovedAlgorithm(t *testing.T) {
+	signer := staticSigner{algorithm: "none", keyID: "key-1", signature: []byte("invalid")}
+	if _, err := SignDetached(context.Background(), []byte(`{}`), signer); !errors.Is(err, ErrUnsupportedAlg) {
+		t.Fatalf("SignDetached error = %v, want unsupported algorithm", err)
+	}
+}
+
+func TestBuildRejectsInvalidPredecessorAndSignatureShape(t *testing.T) {
+	signer, _ := newEd25519Fixture(t, "package-key-1")
+	request := fixtureBuildRequest()
+	request.PredecessorDigest = "sha256:not-a-digest"
+	if _, err := Build(context.Background(), request, signer); !errors.Is(err, ErrInvalidPackage) {
+		t.Fatalf("Build predecessor error = %v, want ErrInvalidPackage", err)
+	}
+
+	request.PredecessorDigest = ""
+	badSigner := staticSigner{algorithm: AlgorithmEdDSA, keyID: "key-1", signature: []byte("short")}
+	if _, err := Build(context.Background(), request, badSigner); err == nil {
+		t.Fatal("Build accepted a malformed signature")
+	}
+}
+
+func TestDecodeManifestRejectsUnknownAndTrailingFields(t *testing.T) {
+	for _, content := range []string{
+		`{"schema_version":"compliance-exchange-manifest/v1","unknown":true}`,
+		`{} {}`,
+	} {
+		if _, err := decodeManifest([]byte(content)); err == nil {
+			t.Fatalf("decodeManifest(%q) error = nil", content)
+		}
+	}
+}
+
+func TestValidationIssuesHaveDeterministicOrder(t *testing.T) {
+	fixture := buildFixture(t)
+	result := Validate(context.Background(), ValidationRequest{
+		ExpectedTenantID: "tenant-2", ManifestBytes: fixture.built.ManifestBytes,
+		Files: []File{{Path: "../x", Data: []byte("x")}},
+	})
+	for index := 1; index < len(result.Issues); index++ {
+		left := validationLayerOrder[result.Issues[index-1].Layer]
+		right := validationLayerOrder[result.Issues[index].Layer]
+		if left > right {
+			t.Fatalf("issues out of order: %+v", result.Issues)
+		}
+	}
+}
+
+type staticSigner struct {
+	algorithm string
+	keyID     string
+	signature []byte
+}
+
+func (s staticSigner) Algorithm() string { return s.algorithm }
+func (s staticSigner) KeyID() string     { return s.keyID }
+func (s staticSigner) Sign(context.Context, []byte) ([]byte, error) {
+	return s.signature, nil
+}
+
+type packageFixture struct {
+	built  Package
+	signer CryptoSigner
+	trust  TrustResolver
+}
+
+func buildFixture(t *testing.T) packageFixture {
+	t.Helper()
+	signer, trust := newEd25519Fixture(t, "package-key-1")
+	built, err := Build(context.Background(), fixtureBuildRequest(), signer)
+	if err != nil {
+		t.Fatalf("Build fixture: %v", err)
+	}
+	return packageFixture{built: built, signer: signer, trust: trust}
+}
+
+func fixtureBuildRequest() BuildRequest {
+	return BuildRequest{
+		PackageID: "package-1", TenantID: "tenant-1", CreatedAt: exchangeTestTime,
+		PredecessorDigest: strings.Repeat("a", 64),
+		Files: []File{{
+			Path: "data/evidence.json", MediaType: "application/json",
+			LogicalType: "evidence", Data: []byte(`{"state":"current"}`),
+		}},
+	}
+}
+
+func newEd25519Fixture(t *testing.T, keyID string) (CryptoSigner, TrustResolver) {
+	t.Helper()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := CryptoSigner{AlgorithmName: AlgorithmEdDSA, KeyIDValue: keyID, PrivateKey: private}
+	trust := TrustResolverFunc(func(_ context.Context, requestedKeyID string, algorithm string) (crypto.PublicKey, error) {
+		if requestedKeyID != keyID || algorithm != AlgorithmEdDSA {
+			return nil, errors.New("key not trusted")
+		}
+		return public, nil
+	})
+	return signer, trust
+}
+
+func cloneFiles(files []File) []File {
+	cloned := make([]File, len(files))
+	for index, file := range files {
+		file.Data = bytes.Clone(file.Data)
+		cloned[index] = file
+	}
+	return cloned
+}
+
+func assertIssue(t *testing.T, result ValidationResult, code string) {
+	t.Helper()
+	for _, issue := range result.Issues {
+		if issue.Code == code {
+			return
+		}
+	}
+	content, _ := json.Marshal(result.Issues)
+	t.Fatalf("issues = %s, want code %q", content, code)
+}

--- a/internal/complianceexchange/exchange_test.go
+++ b/internal/complianceexchange/exchange_test.go
@@ -19,7 +19,7 @@ import (
 var exchangeTestTime = time.Date(2026, time.July, 11, 12, 30, 0, 123456000, time.UTC)
 
 func TestBuildDeterministicManifestAndCompleteCoverage(t *testing.T) {
-	signer, trust := newEd25519Fixture(t, "package-key-1")
+	signer, trust := newEd25519Fixture(t)
 	request := BuildRequest{
 		PackageID: "package-1", TenantID: "tenant-1", CreatedAt: exchangeTestTime,
 		DisclosurePolicy: "auditor", RedactionMode: "external",
@@ -59,7 +59,7 @@ func TestBuildDeterministicManifestAndCompleteCoverage(t *testing.T) {
 }
 
 func TestBuildCopiesFileBytesBeforeDigesting(t *testing.T) {
-	signer, _ := newEd25519Fixture(t, "package-key-1")
+	signer, _ := newEd25519Fixture(t)
 	data := []byte("original")
 	built, err := Build(context.Background(), BuildRequest{
 		PackageID: "package-1", TenantID: "tenant-1", CreatedAt: exchangeTestTime,
@@ -235,7 +235,7 @@ func TestValidateES256RoundTrip(t *testing.T) {
 }
 
 func TestBuildRejectsUnsafePathsDuplicatesAndLimits(t *testing.T) {
-	signer, _ := newEd25519Fixture(t, "package-key-1")
+	signer, _ := newEd25519Fixture(t)
 	tests := []struct {
 		name   string
 		files  []File
@@ -290,7 +290,7 @@ func TestSignDetachedRejectsUnapprovedAlgorithm(t *testing.T) {
 }
 
 func TestBuildRejectsInvalidPredecessorAndSignatureShape(t *testing.T) {
-	signer, _ := newEd25519Fixture(t, "package-key-1")
+	signer, _ := newEd25519Fixture(t)
 	request := fixtureBuildRequest()
 	request.PredecessorDigest = "sha256:not-a-digest"
 	if _, err := Build(context.Background(), request, signer); !errors.Is(err, ErrInvalidPackage) {
@@ -350,7 +350,7 @@ type packageFixture struct {
 
 func buildFixture(t *testing.T) packageFixture {
 	t.Helper()
-	signer, trust := newEd25519Fixture(t, "package-key-1")
+	signer, trust := newEd25519Fixture(t)
 	built, err := Build(context.Background(), fixtureBuildRequest(), signer)
 	if err != nil {
 		t.Fatalf("Build fixture: %v", err)
@@ -369,8 +369,9 @@ func fixtureBuildRequest() BuildRequest {
 	}
 }
 
-func newEd25519Fixture(t *testing.T, keyID string) (CryptoSigner, TrustResolver) {
+func newEd25519Fixture(t *testing.T) (CryptoSigner, TrustResolver) {
 	t.Helper()
+	const keyID = "package-key-1"
 	public, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/complianceexchange/manifest.go
+++ b/internal/complianceexchange/manifest.go
@@ -1,0 +1,204 @@
+package complianceexchange
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Build creates a deterministic manifest, covers every supplied file, and
+// signs the exact manifest bytes. The same request produces the same manifest
+// bytes regardless of input file order.
+func Build(ctx context.Context, request BuildRequest, signer Signer) (Package, error) {
+	limits, err := normalizeLimits(request.Limits)
+	if err != nil {
+		return Package{}, err
+	}
+	if strings.TrimSpace(request.PackageID) == "" {
+		return Package{}, fmt.Errorf("%w: package_id is required", ErrInvalidPackage)
+	}
+	if strings.TrimSpace(request.TenantID) == "" {
+		return Package{}, fmt.Errorf("%w: tenant_id is required", ErrInvalidPackage)
+	}
+	if request.CreatedAt.IsZero() {
+		return Package{}, fmt.Errorf("%w: created_at is required", ErrInvalidPackage)
+	}
+	if predecessor := strings.TrimSpace(request.PredecessorDigest); predecessor != "" && !validDigest(predecessor) {
+		return Package{}, fmt.Errorf("%w: predecessor_digest must be a lowercase SHA-256 value", ErrInvalidPackage)
+	}
+	if signer == nil {
+		return Package{}, fmt.Errorf("%w: signer is required", ErrInvalidPackage)
+	}
+
+	files, manifestFiles, total, err := prepareFiles(request.Files, limits)
+	if err != nil {
+		return Package{}, err
+	}
+	manifest := Manifest{
+		SchemaVersion:     ManifestSchemaVersion,
+		PackageID:         strings.TrimSpace(request.PackageID),
+		TenantID:          strings.TrimSpace(request.TenantID),
+		CreatedAt:         request.CreatedAt.UTC(),
+		PredecessorDigest: strings.TrimSpace(request.PredecessorDigest),
+		DisclosurePolicy:  strings.TrimSpace(request.DisclosurePolicy),
+		RedactionMode:     strings.TrimSpace(request.RedactionMode),
+		FileCount:         len(manifestFiles),
+		TotalBytes:        total,
+		Files:             manifestFiles,
+	}
+	manifestBytes, err := marshalManifest(manifest)
+	if err != nil {
+		return Package{}, err
+	}
+	if len(manifestBytes) > limits.MaxManifestBytes {
+		return Package{}, fmt.Errorf("%w: manifest exceeds size limit", ErrInvalidPackage)
+	}
+	signature, err := SignDetached(ctx, manifestBytes, signer)
+	if err != nil {
+		return Package{}, err
+	}
+	if len(signature) > limits.MaxSignatureBytes {
+		return Package{}, fmt.Errorf("%w: detached signature exceeds size limit", ErrInvalidPackage)
+	}
+	return Package{
+		Manifest:       manifest,
+		ManifestBytes:  manifestBytes,
+		ManifestDigest: sha256Hex(manifestBytes),
+		Signature:      signature,
+		Files:          files,
+	}, nil
+}
+
+func prepareFiles(input []File, limits Limits) ([]File, []ManifestFile, int64, error) {
+	if len(input) == 0 {
+		return nil, nil, 0, fmt.Errorf("%w: at least one payload file is required", ErrInvalidPackage)
+	}
+	if len(input) > limits.MaxFiles {
+		return nil, nil, 0, fmt.Errorf("%w: file count exceeds limit", ErrInvalidPackage)
+	}
+	files := make([]File, 0, len(input))
+	manifestFiles := make([]ManifestFile, 0, len(input))
+	seen := make(map[string]string, len(input))
+	var total int64
+	for _, source := range input {
+		if err := validatePackagePath(source.Path, limits.MaxPathBytes); err != nil {
+			return nil, nil, 0, fmt.Errorf("%w: %q: %v", ErrInvalidPackage, source.Path, err)
+		}
+		key := collisionKey(source.Path)
+		if prior, ok := seen[key]; ok {
+			return nil, nil, 0, fmt.Errorf("%w: duplicate or case-colliding paths %q and %q", ErrInvalidPackage, prior, source.Path)
+		}
+		seen[key] = source.Path
+		if strings.TrimSpace(source.MediaType) == "" {
+			return nil, nil, 0, fmt.Errorf("%w: media_type is required for %q", ErrInvalidPackage, source.Path)
+		}
+		if strings.TrimSpace(source.LogicalType) == "" {
+			return nil, nil, 0, fmt.Errorf("%w: logical_type is required for %q", ErrInvalidPackage, source.Path)
+		}
+		size := int64(len(source.Data))
+		if size > limits.MaxFileBytes {
+			return nil, nil, 0, fmt.Errorf("%w: file %q exceeds size limit", ErrInvalidPackage, source.Path)
+		}
+		if total > limits.MaxTotalBytes-size {
+			return nil, nil, 0, fmt.Errorf("%w: total payload exceeds size limit", ErrInvalidPackage)
+		}
+		total += size
+		copied := File{
+			Path:        source.Path,
+			MediaType:   strings.TrimSpace(source.MediaType),
+			LogicalType: strings.TrimSpace(source.LogicalType),
+			Data:        bytes.Clone(source.Data),
+		}
+		files = append(files, copied)
+		manifestFiles = append(manifestFiles, ManifestFile{
+			Path:        copied.Path,
+			MediaType:   copied.MediaType,
+			LogicalType: copied.LogicalType,
+			SizeBytes:   size,
+			SHA256:      sha256Hex(copied.Data),
+		})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	sort.Slice(manifestFiles, func(i, j int) bool { return manifestFiles[i].Path < manifestFiles[j].Path })
+	return files, manifestFiles, total, nil
+}
+
+func marshalManifest(manifest Manifest) ([]byte, error) {
+	content, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("marshal compliance package manifest: %w", err)
+	}
+	return content, nil
+}
+
+func decodeManifest(content []byte) (Manifest, error) {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	var manifest Manifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return Manifest{}, fmt.Errorf("decode manifest: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return Manifest{}, errorsTrailingJSON()
+	}
+	return manifest, nil
+}
+
+func errorsTrailingJSON() error {
+	return fmt.Errorf("manifest contains trailing JSON values")
+}
+
+func sha256Hex(content []byte) string {
+	digest := sha256.Sum256(content)
+	return hex.EncodeToString(digest[:])
+}
+
+func normalizeLimits(limits Limits) (Limits, error) {
+	if limits.MaxFiles < 0 || limits.MaxFileBytes < 0 || limits.MaxTotalBytes < 0 || limits.MaxPathBytes < 0 || limits.MaxManifestBytes < 0 || limits.MaxSignatureBytes < 0 {
+		return Limits{}, fmt.Errorf("%w: limits cannot be negative", ErrInvalidPackage)
+	}
+	defaults := DefaultLimits()
+	if limits.MaxFiles == 0 {
+		limits.MaxFiles = defaults.MaxFiles
+	}
+	if limits.MaxFileBytes == 0 {
+		limits.MaxFileBytes = defaults.MaxFileBytes
+	}
+	if limits.MaxTotalBytes == 0 {
+		limits.MaxTotalBytes = defaults.MaxTotalBytes
+	}
+	if limits.MaxPathBytes == 0 {
+		limits.MaxPathBytes = defaults.MaxPathBytes
+	}
+	if limits.MaxManifestBytes == 0 {
+		limits.MaxManifestBytes = defaults.MaxManifestBytes
+	}
+	if limits.MaxSignatureBytes == 0 {
+		limits.MaxSignatureBytes = defaults.MaxSignatureBytes
+	}
+	if limits.MaxFileBytes > limits.MaxTotalBytes {
+		return Limits{}, fmt.Errorf("%w: max file bytes cannot exceed max total bytes", ErrInvalidPackage)
+	}
+	return limits, nil
+}
+
+func validDigest(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil && value == strings.ToLower(value)
+}
+
+func validCreatedAt(value time.Time) bool {
+	return !value.IsZero() && value.Location() != nil
+}

--- a/internal/complianceexchange/manifest.go
+++ b/internal/complianceexchange/manifest.go
@@ -90,7 +90,7 @@ func prepareFiles(input []File, limits Limits) ([]File, []ManifestFile, int64, e
 	var total int64
 	for _, source := range input {
 		if err := validatePackagePath(source.Path, limits.MaxPathBytes); err != nil {
-			return nil, nil, 0, fmt.Errorf("%w: %q: %v", ErrInvalidPackage, source.Path, err)
+			return nil, nil, 0, fmt.Errorf("%w: %q: %w", ErrInvalidPackage, source.Path, err)
 		}
 		key := collisionKey(source.Path)
 		if prior, ok := seen[key]; ok {

--- a/internal/complianceexchange/model.go
+++ b/internal/complianceexchange/model.go
@@ -1,0 +1,189 @@
+// Package complianceexchange builds and validates portable compliance package
+// manifests. It is deliberately storage- and transport-agnostic: callers
+// provide already-bounded file bytes, signing capability, and trusted public
+// keys, while this package proves path safety, complete file coverage,
+// integrity, and signature validity before any persistence is attempted.
+package complianceexchange
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"time"
+)
+
+const (
+	ManifestSchemaVersion = "compliance-exchange-manifest/v1"
+	SignatureType         = "compliance-manifest+jws"
+
+	AlgorithmEdDSA = "EdDSA"
+	AlgorithmES256 = "ES256"
+
+	SeverityError   = "error"
+	SeverityWarning = "warning"
+
+	ValidationValid   = "valid"
+	ValidationInvalid = "invalid"
+)
+
+var (
+	ErrInvalidPackage   = errors.New("invalid compliance exchange package")
+	ErrUnsupportedAlg   = errors.New("unsupported compliance package signature algorithm")
+	ErrSignatureInvalid = errors.New("compliance package signature is invalid")
+)
+
+// Limits bounds the uncompressed files presented to the exchange core. The
+// transport layer must independently bound compressed request bytes and archive
+// expansion before constructing Files.
+type Limits struct {
+	MaxFiles          int
+	MaxFileBytes      int64
+	MaxTotalBytes     int64
+	MaxPathBytes      int
+	MaxManifestBytes  int
+	MaxSignatureBytes int
+}
+
+// DefaultLimits returns conservative in-memory validation bounds.
+func DefaultLimits() Limits {
+	return Limits{
+		MaxFiles:          10_000,
+		MaxFileBytes:      64 << 20,
+		MaxTotalBytes:     512 << 20,
+		MaxPathBytes:      512,
+		MaxManifestBytes:  8 << 20,
+		MaxSignatureBytes: 16 << 10,
+	}
+}
+
+// File is one uncompressed package payload file. Data is copied by Build so a
+// caller cannot mutate a built package after its digest has been recorded.
+type File struct {
+	Path        string
+	MediaType   string
+	LogicalType string
+	Data        []byte
+}
+
+// ManifestFile is the immutable, signed description of one payload file.
+type ManifestFile struct {
+	Path        string `json:"path"`
+	MediaType   string `json:"media_type"`
+	LogicalType string `json:"logical_type"`
+	SizeBytes   int64  `json:"size_bytes"`
+	SHA256      string `json:"sha256"`
+}
+
+// Manifest covers every payload file and the package-level provenance needed
+// to stage it. ManifestDigest is intentionally not embedded because a manifest
+// cannot contain its own digest.
+type Manifest struct {
+	SchemaVersion     string         `json:"schema_version"`
+	PackageID         string         `json:"package_id"`
+	TenantID          string         `json:"tenant_id"`
+	CreatedAt         time.Time      `json:"created_at"`
+	PredecessorDigest string         `json:"predecessor_digest,omitempty"`
+	DisclosurePolicy  string         `json:"disclosure_policy,omitempty"`
+	RedactionMode     string         `json:"redaction_mode,omitempty"`
+	FileCount         int            `json:"file_count"`
+	TotalBytes        int64          `json:"total_bytes"`
+	Files             []ManifestFile `json:"files"`
+}
+
+// BuildRequest contains the exact revision-level inputs for one package.
+type BuildRequest struct {
+	PackageID         string
+	TenantID          string
+	CreatedAt         time.Time
+	PredecessorDigest string
+	DisclosurePolicy  string
+	RedactionMode     string
+	Files             []File
+	Limits            Limits
+}
+
+// Package is an in-memory portable package core. Archive and object-storage
+// adapters can serialize it without changing the signed manifest bytes.
+type Package struct {
+	Manifest       Manifest
+	ManifestBytes  []byte
+	ManifestDigest string
+	Signature      string
+	Files          []File
+}
+
+// Signer provides signing without exposing private key material. Implementors
+// may wrap a local crypto.Signer or a remote signer outside this package.
+type Signer interface {
+	Algorithm() string
+	KeyID() string
+	Sign(context.Context, []byte) ([]byte, error)
+}
+
+// TrustResolver resolves only locally configured trusted keys. A resolver must
+// not treat key IDs as URLs or fetch key material from the package.
+type TrustResolver interface {
+	ResolveTrustedKey(context.Context, string, string) (crypto.PublicKey, error)
+}
+
+// TrustResolverFunc adapts a function into a TrustResolver.
+type TrustResolverFunc func(context.Context, string, string) (crypto.PublicKey, error)
+
+func (f TrustResolverFunc) ResolveTrustedKey(ctx context.Context, keyID string, algorithm string) (crypto.PublicKey, error) {
+	return f(ctx, keyID, algorithm)
+}
+
+// ValidationRequest is a pure staging request. ExpectedTenantID is required so
+// a valid package for another tenant cannot be accepted by mistake.
+type ValidationRequest struct {
+	ExpectedTenantID string
+	ManifestBytes    []byte
+	Signature        string
+	Files            []File
+	Limits           Limits
+	Trust            TrustResolver
+}
+
+// ValidationIssue is stable, machine-readable, and safe to show to the tenant
+// that supplied the package. It intentionally excludes raw content and crypto
+// implementation errors.
+type ValidationIssue struct {
+	Layer       string `json:"layer"`
+	Code        string `json:"code"`
+	Severity    string `json:"severity"`
+	Path        string `json:"path,omitempty"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// ChangeOperation describes what a later persistence adapter would stage. The
+// core cannot classify creates versus updates without canonical state, so its
+// only action is stage.
+type ChangeOperation struct {
+	Action      string `json:"action"`
+	Path        string `json:"path"`
+	LogicalType string `json:"logical_type"`
+	SHA256      string `json:"sha256"`
+	SizeBytes   int64  `json:"size_bytes"`
+}
+
+// ChangePlan is emitted only after all validation layers pass.
+type ChangePlan struct {
+	PackageID      string            `json:"package_id"`
+	TenantID       string            `json:"tenant_id"`
+	ManifestDigest string            `json:"manifest_digest"`
+	FileCount      int               `json:"file_count"`
+	TotalBytes     int64             `json:"total_bytes"`
+	Operations     []ChangeOperation `json:"operations"`
+}
+
+// ValidationResult is the complete output of staged validation.
+type ValidationResult struct {
+	Status         string            `json:"status"`
+	Manifest       *Manifest         `json:"manifest,omitempty"`
+	ManifestDigest string            `json:"manifest_digest,omitempty"`
+	SignerKeyID    string            `json:"signer_key_id,omitempty"`
+	Algorithm      string            `json:"algorithm,omitempty"`
+	Issues         []ValidationIssue `json:"issues"`
+	ChangePlan     *ChangePlan       `json:"change_plan,omitempty"`
+}

--- a/internal/complianceexchange/paths.go
+++ b/internal/complianceexchange/paths.go
@@ -1,0 +1,81 @@
+package complianceexchange
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var reservedPackagePaths = map[string]struct{}{
+	"manifest.json": {},
+	"manifest.jws":  {},
+}
+
+func validatePackagePath(value string, maxBytes int) error {
+	if value == "" {
+		return errorsPath("path is required")
+	}
+	if !utf8.ValidString(value) {
+		return errorsPath("path must be valid UTF-8")
+	}
+	if len(value) > maxBytes {
+		return errorsPath(fmt.Sprintf("path exceeds %d bytes", maxBytes))
+	}
+	if strings.ContainsAny(value, "\\\x00\r\n") {
+		return errorsPath("path contains a forbidden character")
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return errorsPath("path contains a control character")
+		}
+	}
+	if strings.HasPrefix(value, "/") || strings.HasSuffix(value, "/") {
+		return errorsPath("path must be a relative file path")
+	}
+	cleaned := path.Clean(value)
+	if cleaned != value || cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return errorsPath("path is not normalized or escapes the package root")
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return errorsPath("path contains an unsafe segment")
+		}
+	}
+	if strings.Contains(strings.SplitN(value, "/", 2)[0], ":") {
+		return errorsPath("path starts with a volume-like segment")
+	}
+	if _, reserved := reservedPackagePaths[strings.ToLower(value)]; reserved {
+		return errorsPath("path is reserved for package metadata")
+	}
+	return nil
+}
+
+type pathError string
+
+func (e pathError) Error() string { return string(e) }
+
+func errorsPath(message string) error { return pathError(message) }
+
+func collisionKey(value string) string {
+	return strings.ToLower(value)
+}
+
+func safeIssuePath(value string) string {
+	const maxRunes = 160
+	value = strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) || character == utf8.RuneError {
+			return '\uFFFD'
+		}
+		return character
+	}, value)
+	characters := []rune(value)
+	if len(characters) > maxRunes {
+		return string(characters[:maxRunes]) + "..."
+	}
+	if value == "" {
+		return "files"
+	}
+	return value
+}

--- a/internal/complianceexchange/signature.go
+++ b/internal/complianceexchange/signature.go
@@ -1,0 +1,174 @@
+package complianceexchange
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
+)
+
+type protectedHeader struct {
+	Algorithm string `json:"alg"`
+	KeyID     string `json:"kid"`
+	Type      string `json:"typ"`
+}
+
+// CryptoSigner adapts a standard-library crypto.Signer to detached package
+// signatures. ES256 signatures are converted from ASN.1 to the fixed-width JWS
+// representation; Ed25519 signs the JWS signing input directly.
+type CryptoSigner struct {
+	AlgorithmName string
+	KeyIDValue    string
+	PrivateKey    crypto.Signer
+}
+
+func (s CryptoSigner) Algorithm() string { return strings.TrimSpace(s.AlgorithmName) }
+func (s CryptoSigner) KeyID() string     { return strings.TrimSpace(s.KeyIDValue) }
+
+func (s CryptoSigner) Sign(_ context.Context, signingInput []byte) ([]byte, error) {
+	if s.PrivateKey == nil {
+		return nil, errors.New("private signer is required")
+	}
+	switch s.Algorithm() {
+	case AlgorithmEdDSA:
+		if _, ok := s.PrivateKey.Public().(ed25519.PublicKey); !ok {
+			return nil, errors.New("EdDSA signer does not expose an Ed25519 public key")
+		}
+		return s.PrivateKey.Sign(rand.Reader, signingInput, crypto.Hash(0))
+	case AlgorithmES256:
+		publicKey, ok := s.PrivateKey.Public().(*ecdsa.PublicKey)
+		if !ok || publicKey.Curve != elliptic.P256() {
+			return nil, errors.New("ES256 signer does not expose a P-256 public key")
+		}
+		digest := sha256.Sum256(signingInput)
+		der, err := s.PrivateKey.Sign(rand.Reader, digest[:], crypto.SHA256)
+		if err != nil {
+			return nil, err
+		}
+		return ecdsaDERToJWS(der)
+	default:
+		return nil, ErrUnsupportedAlg
+	}
+}
+
+// SignDetached creates compact JWS detached-content serialization. The empty
+// middle segment means the manifest bytes travel separately.
+func SignDetached(ctx context.Context, manifest []byte, signer Signer) (string, error) {
+	if signer == nil {
+		return "", errors.New("signer is required")
+	}
+	algorithm := strings.TrimSpace(signer.Algorithm())
+	if !allowedAlgorithm(algorithm) {
+		return "", ErrUnsupportedAlg
+	}
+	keyID := strings.TrimSpace(signer.KeyID())
+	if keyID == "" {
+		return "", errors.New("signer key ID is required")
+	}
+	header, err := json.Marshal(protectedHeader{Algorithm: algorithm, KeyID: keyID, Type: SignatureType})
+	if err != nil {
+		return "", fmt.Errorf("marshal signature header: %w", err)
+	}
+	headerSegment := base64.RawURLEncoding.EncodeToString(header)
+	payloadSegment := base64.RawURLEncoding.EncodeToString(manifest)
+	signingInput := []byte(headerSegment + "." + payloadSegment)
+	signature, err := signer.Sign(ctx, signingInput)
+	if err != nil {
+		return "", fmt.Errorf("sign manifest: %w", err)
+	}
+	if len(signature) != ed25519.SignatureSize {
+		return "", errors.New("signer returned a signature with an invalid size")
+	}
+	return headerSegment + ".." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func verifyDetached(ctx context.Context, manifest []byte, compact string, trust TrustResolver) (protectedHeader, error) {
+	if trust == nil {
+		return protectedHeader{}, errors.New("trust resolver is required")
+	}
+	parts := strings.Split(compact, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] != "" || parts[2] == "" {
+		return protectedHeader{}, ErrSignatureInvalid
+	}
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return protectedHeader{}, ErrSignatureInvalid
+	}
+	var header protectedHeader
+	decoder := json.NewDecoder(strings.NewReader(string(headerBytes)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&header); err != nil {
+		return protectedHeader{}, ErrSignatureInvalid
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return protectedHeader{}, ErrSignatureInvalid
+	}
+	if !allowedAlgorithm(header.Algorithm) || strings.TrimSpace(header.KeyID) == "" || header.Type != SignatureType {
+		return protectedHeader{}, ErrSignatureInvalid
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return protectedHeader{}, ErrSignatureInvalid
+	}
+	publicKey, err := trust.ResolveTrustedKey(ctx, header.KeyID, header.Algorithm)
+	if err != nil || publicKey == nil {
+		return protectedHeader{}, ErrSignatureInvalid
+	}
+	payloadSegment := base64.RawURLEncoding.EncodeToString(manifest)
+	signingInput := []byte(parts[0] + "." + payloadSegment)
+	switch header.Algorithm {
+	case AlgorithmEdDSA:
+		key, ok := publicKey.(ed25519.PublicKey)
+		if !ok || !ed25519.Verify(key, signingInput, signature) {
+			return protectedHeader{}, ErrSignatureInvalid
+		}
+	case AlgorithmES256:
+		key, ok := publicKey.(*ecdsa.PublicKey)
+		if !ok || key.Curve != elliptic.P256() || len(signature) != 64 {
+			return protectedHeader{}, ErrSignatureInvalid
+		}
+		r := new(big.Int).SetBytes(signature[:32])
+		s := new(big.Int).SetBytes(signature[32:])
+		digest := sha256.Sum256(signingInput)
+		if !ecdsa.Verify(key, digest[:], r, s) {
+			return protectedHeader{}, ErrSignatureInvalid
+		}
+	default:
+		return protectedHeader{}, ErrSignatureInvalid
+	}
+	return header, nil
+}
+
+func allowedAlgorithm(value string) bool {
+	return value == AlgorithmEdDSA || value == AlgorithmES256
+}
+
+func ecdsaDERToJWS(der []byte) ([]byte, error) {
+	var parsed struct {
+		R *big.Int
+		S *big.Int
+	}
+	rest, err := asn1.Unmarshal(der, &parsed)
+	if err != nil || len(rest) != 0 || parsed.R == nil || parsed.S == nil || parsed.R.Sign() <= 0 || parsed.S.Sign() <= 0 {
+		return nil, errors.New("ES256 signer returned a malformed signature")
+	}
+	if parsed.R.BitLen() > 256 || parsed.S.BitLen() > 256 {
+		return nil, errors.New("ES256 signer returned an oversized signature")
+	}
+	signature := make([]byte, 64)
+	parsed.R.FillBytes(signature[:32])
+	parsed.S.FillBytes(signature[32:])
+	return signature, nil
+}

--- a/internal/complianceexchange/validation.go
+++ b/internal/complianceexchange/validation.go
@@ -1,0 +1,242 @@
+package complianceexchange
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	layerParse     = "parse"
+	layerSchema    = "schema"
+	layerPaths     = "archive_safety"
+	layerLimits    = "limits"
+	layerRefs      = "referential_integrity"
+	layerDigest    = "digest"
+	layerTenant    = "authorization"
+	layerSignature = "signature"
+)
+
+var validationLayerOrder = map[string]int{
+	layerParse: 1, layerSchema: 2, layerPaths: 3, layerLimits: 4,
+	layerRefs: 5, layerDigest: 6, layerTenant: 7, layerSignature: 8,
+}
+
+// Validate performs pure staged validation. It never persists bytes or
+// canonical records, and emits a change plan only when every layer passes.
+func Validate(ctx context.Context, request ValidationRequest) ValidationResult {
+	result := ValidationResult{Status: ValidationInvalid, Issues: []ValidationIssue{}}
+	limits, err := normalizeLimits(request.Limits)
+	if err != nil {
+		result.Issues = append(result.Issues, issue(layerLimits, "invalid_limits", "", "Validation limits are invalid.", "Use positive limits with the per-file limit no larger than the total limit."))
+		return result
+	}
+	if len(request.ManifestBytes) == 0 {
+		result.Issues = append(result.Issues, issue(layerParse, "manifest_required", "manifest.json", "The package manifest is missing.", "Include one manifest.json file."))
+		return result
+	}
+	if len(request.ManifestBytes) > limits.MaxManifestBytes {
+		result.Issues = append(result.Issues, issue(layerLimits, "manifest_size_limit", "manifest.json", "The package manifest exceeds the size limit.", "Reduce the manifest or split the package."))
+		return result
+	}
+	if len(request.Signature) > limits.MaxSignatureBytes {
+		result.Issues = append(result.Issues, issue(layerLimits, "signature_size_limit", "manifest.jws", "The detached signature exceeds the size limit.", "Use the bounded detached signature format."))
+		return result
+	}
+	manifest, err := decodeManifest(request.ManifestBytes)
+	if err != nil {
+		result.Issues = append(result.Issues, issue(layerParse, "manifest_invalid_json", "manifest.json", "The package manifest is not valid JSON.", "Provide one JSON object matching the supported manifest schema."))
+		return result
+	}
+	result.Manifest = &manifest
+	result.ManifestDigest = sha256Hex(request.ManifestBytes)
+	validateManifestShape(&result, manifest)
+	validateTenant(&result, request.ExpectedTenantID, manifest.TenantID)
+	actual := validateActualFiles(&result, request.Files, limits)
+	validateManifestFiles(&result, manifest, actual, limits)
+
+	if strings.TrimSpace(request.Signature) == "" {
+		result.Issues = append(result.Issues, issue(layerSignature, "signature_required", "manifest.jws", "The detached manifest signature is missing.", "Sign the exact manifest bytes with an allowed trusted key."))
+	} else if header, err := verifyDetached(ctx, request.ManifestBytes, request.Signature, request.Trust); err != nil {
+		result.Issues = append(result.Issues, issue(layerSignature, "signature_invalid", "manifest.jws", "The manifest signature could not be verified.", "Use an allowed algorithm and a key trusted for this tenant."))
+	} else {
+		result.SignerKeyID = header.KeyID
+		result.Algorithm = header.Algorithm
+	}
+
+	sortIssues(result.Issues)
+	if len(result.Issues) > 0 {
+		return result
+	}
+	result.Status = ValidationValid
+	result.ChangePlan = changePlan(manifest, result.ManifestDigest)
+	return result
+}
+
+func validateManifestShape(result *ValidationResult, manifest Manifest) {
+	if manifest.SchemaVersion != ManifestSchemaVersion {
+		result.Issues = append(result.Issues, issue(layerSchema, "unsupported_manifest_version", "schema_version", "The manifest schema version is not supported.", "Export the package using a supported manifest version."))
+	}
+	if strings.TrimSpace(manifest.PackageID) == "" {
+		result.Issues = append(result.Issues, issue(layerSchema, "package_id_required", "package_id", "The package ID is missing.", "Set a stable package ID."))
+	}
+	if strings.TrimSpace(manifest.TenantID) == "" {
+		result.Issues = append(result.Issues, issue(layerSchema, "tenant_id_required", "tenant_id", "The tenant ID is missing.", "Set the package tenant ID."))
+	}
+	if !validCreatedAt(manifest.CreatedAt) {
+		result.Issues = append(result.Issues, issue(layerSchema, "created_at_required", "created_at", "The package creation time is missing.", "Set an RFC 3339 package creation time."))
+	}
+	if manifest.FileCount != len(manifest.Files) {
+		result.Issues = append(result.Issues, issue(layerSchema, "file_count_mismatch", "file_count", "The declared file count does not match the manifest file list.", "Regenerate the manifest from the complete payload."))
+	}
+	if manifest.FileCount == 0 {
+		result.Issues = append(result.Issues, issue(layerSchema, "payload_required", "files", "The package contains no payload files.", "Include at least one typed payload file."))
+	}
+	if manifest.PredecessorDigest != "" && !validDigest(manifest.PredecessorDigest) {
+		result.Issues = append(result.Issues, issue(layerSchema, "predecessor_digest_invalid", "predecessor_digest", "The predecessor digest is not a lowercase SHA-256 value.", "Use the verified SHA-256 digest of the predecessor manifest."))
+	}
+}
+
+func validateTenant(result *ValidationResult, expected string, actual string) {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		result.Issues = append(result.Issues, issue(layerTenant, "expected_tenant_required", "tenant_id", "The validation tenant is missing.", "Resolve the authenticated tenant before validation."))
+		return
+	}
+	if expected != strings.TrimSpace(actual) {
+		result.Issues = append(result.Issues, issue(layerTenant, "tenant_mismatch", "tenant_id", "The package is not scoped to the importing tenant.", "Import a package issued for the authenticated tenant."))
+	}
+}
+
+type actualFile struct {
+	file File
+	key  string
+}
+
+func validateActualFiles(result *ValidationResult, files []File, limits Limits) map[string]actualFile {
+	actual := make(map[string]actualFile, len(files))
+	if len(files) > limits.MaxFiles {
+		result.Issues = append(result.Issues, issue(layerLimits, "file_count_limit", "files", "The package exceeds the file-count limit.", "Split the package into smaller bounded packages."))
+	}
+	var total int64
+	for _, file := range files {
+		if err := validatePackagePath(file.Path, limits.MaxPathBytes); err != nil {
+			result.Issues = append(result.Issues, issue(layerPaths, "unsafe_path", safeIssuePath(file.Path), "A payload path is unsafe or not normalized.", "Use a unique normalized relative path without dot segments or backslashes."))
+			continue
+		}
+		key := collisionKey(file.Path)
+		if prior, ok := actual[key]; ok {
+			result.Issues = append(result.Issues, issue(layerPaths, "duplicate_path", file.Path, fmt.Sprintf("The payload path collides with %q.", prior.file.Path), "Use unique paths that also differ when case-folded."))
+			continue
+		}
+		actual[key] = actualFile{file: file, key: key}
+		size := int64(len(file.Data))
+		if size > limits.MaxFileBytes {
+			result.Issues = append(result.Issues, issue(layerLimits, "file_size_limit", file.Path, "A payload file exceeds the per-file size limit.", "Split or omit the oversized payload."))
+		}
+		if total <= limits.MaxTotalBytes {
+			if size > limits.MaxTotalBytes-total {
+				total = limits.MaxTotalBytes + 1
+			} else {
+				total += size
+			}
+		}
+	}
+	if total > limits.MaxTotalBytes {
+		result.Issues = append(result.Issues, issue(layerLimits, "total_size_limit", "files", "The package exceeds the total uncompressed size limit.", "Split the package into smaller bounded packages."))
+	}
+	return actual
+}
+
+func validateManifestFiles(result *ValidationResult, manifest Manifest, actual map[string]actualFile, limits Limits) {
+	seen := make(map[string]string, len(manifest.Files))
+	var declaredTotal int64
+	priorPath := ""
+	for index, declared := range manifest.Files {
+		fieldPath := fmt.Sprintf("files[%d]", index)
+		if err := validatePackagePath(declared.Path, limits.MaxPathBytes); err != nil {
+			result.Issues = append(result.Issues, issue(layerPaths, "unsafe_manifest_path", fieldPath+".path", "A manifest path is unsafe or not normalized.", "Regenerate the manifest with normalized relative paths."))
+			continue
+		}
+		if priorPath != "" && declared.Path <= priorPath {
+			result.Issues = append(result.Issues, issue(layerSchema, "files_not_canonical", fieldPath+".path", "Manifest files are not in canonical path order.", "Sort manifest files by path and regenerate the signature."))
+		}
+		priorPath = declared.Path
+		key := collisionKey(declared.Path)
+		if prior, ok := seen[key]; ok {
+			result.Issues = append(result.Issues, issue(layerPaths, "duplicate_manifest_path", fieldPath+".path", fmt.Sprintf("The manifest path collides with %q.", prior), "Use unique paths that also differ when case-folded."))
+			continue
+		}
+		seen[key] = declared.Path
+		if strings.TrimSpace(declared.MediaType) == "" || strings.TrimSpace(declared.LogicalType) == "" {
+			result.Issues = append(result.Issues, issue(layerSchema, "file_type_required", fieldPath, "Every manifest file needs media and logical types.", "Set both media_type and logical_type."))
+		}
+		if declared.SizeBytes < 0 || declared.SizeBytes > limits.MaxFileBytes {
+			result.Issues = append(result.Issues, issue(layerLimits, "declared_file_size_invalid", fieldPath+".size_bytes", "A declared file size is invalid or exceeds the limit.", "Regenerate the manifest from a bounded payload."))
+		} else if declaredTotal <= limits.MaxTotalBytes {
+			if declared.SizeBytes > limits.MaxTotalBytes-declaredTotal {
+				declaredTotal = limits.MaxTotalBytes + 1
+			} else {
+				declaredTotal += declared.SizeBytes
+			}
+		}
+		if !validDigest(declared.SHA256) {
+			result.Issues = append(result.Issues, issue(layerSchema, "digest_invalid", fieldPath+".sha256", "A file digest is not a lowercase SHA-256 value.", "Regenerate the manifest from the exact payload bytes."))
+		}
+		found, ok := actual[key]
+		if !ok {
+			result.Issues = append(result.Issues, issue(layerRefs, "payload_file_missing", declared.Path, "A file declared by the manifest is missing.", "Include every declared payload file."))
+			continue
+		}
+		if found.file.Path != declared.Path {
+			continue
+		}
+		if int64(len(found.file.Data)) != declared.SizeBytes || sha256Hex(found.file.Data) != declared.SHA256 {
+			result.Issues = append(result.Issues, issue(layerDigest, "file_digest_mismatch", declared.Path, "A payload file does not match its signed size or digest.", "Restore the exact signed file or regenerate and re-sign the package."))
+		}
+		if strings.TrimSpace(found.file.MediaType) != declared.MediaType || strings.TrimSpace(found.file.LogicalType) != declared.LogicalType {
+			result.Issues = append(result.Issues, issue(layerSchema, "file_metadata_mismatch", declared.Path, "Payload file metadata does not match the signed manifest.", "Use the media and logical types recorded in the signed manifest."))
+		}
+	}
+	if declaredTotal != manifest.TotalBytes {
+		result.Issues = append(result.Issues, issue(layerSchema, "total_bytes_mismatch", "total_bytes", "The declared total does not match the manifest file sizes.", "Regenerate the manifest from the complete payload."))
+	}
+	for key, found := range actual {
+		if _, ok := seen[key]; !ok {
+			result.Issues = append(result.Issues, issue(layerRefs, "unexpected_payload_file", found.file.Path, "A payload file is not covered by the signed manifest.", "Remove the file or include it in a newly signed manifest."))
+		}
+	}
+}
+
+func changePlan(manifest Manifest, digest string) *ChangePlan {
+	operations := make([]ChangeOperation, 0, len(manifest.Files))
+	for _, file := range manifest.Files {
+		operations = append(operations, ChangeOperation{
+			Action: "stage", Path: file.Path, LogicalType: file.LogicalType,
+			SHA256: file.SHA256, SizeBytes: file.SizeBytes,
+		})
+	}
+	return &ChangePlan{
+		PackageID: manifest.PackageID, TenantID: manifest.TenantID,
+		ManifestDigest: digest, FileCount: manifest.FileCount,
+		TotalBytes: manifest.TotalBytes, Operations: operations,
+	}
+}
+
+func issue(layer string, code string, path string, message string, remediation string) ValidationIssue {
+	return ValidationIssue{Layer: layer, Code: code, Severity: SeverityError, Path: path, Message: message, Remediation: remediation}
+}
+
+func sortIssues(issues []ValidationIssue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		left, right := validationLayerOrder[issues[i].Layer], validationLayerOrder[issues[j].Layer]
+		if left != right {
+			return left < right
+		}
+		if issues[i].Path != issues[j].Path {
+			return issues[i].Path < issues[j].Path
+		}
+		return issues[i].Code < issues[j].Code
+	})
+}


### PR DESCRIPTION
## Summary

- add deterministic package manifests with complete SHA-256 file coverage
- add bounded staged validation for paths, limits, duplicates, case collisions, tenant scope, and digest integrity
- add injected signing and trust resolution for detached EdDSA and ES256 signatures with strict protected headers
- add stable machine-readable validation issues and valid-only change plans

## Dependency

This portable-exchange core is stacked on the compliance correctness foundation. Canonical record adapters, persistence, and transport commands arrive in their owning slices.

## Exit criteria

- rebuilding the same package produces identical manifest bytes and digest
- traversal, unsafe paths, duplicates, case collisions, altered files, and unsupported algorithms fail before a change plan is accepted
- validation never fetches remote signing keys
- signature trust and import authorization remain separate decisions
- invalid packages cannot produce a committable change plan

## Validation

- focused exchange tests
- exchange race tests
- architecture and structural checks
- internal lint