### PR TITLE
Add audit engagement domain core

### DIFF
--- a/internal/grcaudit/engagements.go
+++ b/internal/grcaudit/engagements.go
@@ -1,0 +1,456 @@
+package grcaudit
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EngagementStatus is the operating state of an audit engagement revision.
+type EngagementStatus string
+
+const (
+	EngagementStatusPlanning      EngagementStatus = "planning"
+	EngagementStatusFieldwork     EngagementStatus = "fieldwork"
+	EngagementStatusClarification EngagementStatus = "clarification"
+	EngagementStatusComplete      EngagementStatus = "complete"
+	EngagementStatusClosed        EngagementStatus = "closed"
+)
+
+// ParticipantRole identifies an engagement participant's bounded authority.
+type ParticipantRole string
+
+const (
+	ParticipantRoleAuditLead     ParticipantRole = "audit_lead"
+	ParticipantRoleAuditor       ParticipantRole = "auditor"
+	ParticipantRoleClientOwner   ParticipantRole = "client_owner"
+	ParticipantRoleEvidenceOwner ParticipantRole = "evidence_owner"
+	ParticipantRoleObserver      ParticipantRole = "observer"
+)
+
+// ParticipantStatus is the current assignment state for an engagement participant.
+type ParticipantStatus string
+
+const (
+	ParticipantStatusActive  ParticipantStatus = "active"
+	ParticipantStatusRemoved ParticipantStatus = "removed"
+)
+
+// EngagementPermission is one domain-level object permission.
+type EngagementPermission string
+
+const (
+	EngagementPermissionRead     EngagementPermission = "read"
+	EngagementPermissionManage   EngagementPermission = "manage"
+	EngagementPermissionReview   EngagementPermission = "review"
+	EngagementPermissionDisclose EngagementPermission = "disclose"
+	EngagementPermissionDeliver  EngagementPermission = "deliver"
+)
+
+// Principal is the server-derived identity passed into audit object authorization.
+// TenantWide must only be set after transport authorization has established the
+// corresponding tenant-wide permission.
+type Principal struct {
+	TenantID   string
+	ID         string
+	TenantWide bool
+}
+
+// Participant is the current assignment of one principal to one engagement.
+type Participant struct {
+	ID           string            `json:"id"`
+	TenantID     string            `json:"tenant_id"`
+	EngagementID string            `json:"engagement_id"`
+	PrincipalID  string            `json:"principal_id"`
+	Role         ParticipantRole   `json:"role"`
+	Status       ParticipantStatus `json:"status"`
+	Version      uint64            `json:"version"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+}
+
+// ParticipantInput assigns one principal during engagement creation or update.
+type ParticipantInput struct {
+	PrincipalID string
+	Role        ParticipantRole
+}
+
+// Engagement is the current pointer for a stable audit engagement identity.
+// Semantic scope and period data live only in immutable EngagementRevision values.
+type Engagement struct {
+	ID                string           `json:"id"`
+	TenantID          string           `json:"tenant_id"`
+	Version           uint64           `json:"version"`
+	CurrentRevision   uint64           `json:"current_revision"`
+	CurrentRevisionID string           `json:"current_revision_id"`
+	Status            EngagementStatus `json:"status"`
+	Participants      []Participant    `json:"participants,omitempty"`
+}
+
+// EngagementRevision is one immutable engagement scope and period decision.
+type EngagementRevision struct {
+	ID                   string           `json:"id"`
+	TenantID             string           `json:"tenant_id"`
+	EngagementID         string           `json:"engagement_id"`
+	Revision             uint64           `json:"revision"`
+	PredecessorID        string           `json:"predecessor_id,omitempty"`
+	ProgramID            string           `json:"program_id"`
+	ProgramScopeRevision string           `json:"program_scope_revision_id"`
+	FrameworkRevisionIDs []string         `json:"framework_revision_ids,omitempty"`
+	PlanRevisionID       string           `json:"plan_revision_id,omitempty"`
+	PeriodStart          time.Time        `json:"period_start"`
+	PeriodEnd            time.Time        `json:"period_end"`
+	Deadline             time.Time        `json:"deadline"`
+	DisclosurePolicyID   string           `json:"disclosure_policy_id"`
+	Status               EngagementStatus `json:"status"`
+	ChangeSummary        string           `json:"change_summary,omitempty"`
+	CreatedBy            string           `json:"created_by"`
+	CreatedAt            time.Time        `json:"created_at"`
+	RevisionHash         string           `json:"revision_hash"`
+}
+
+// EngagementRevisionInput contains the semantic fields for a new revision.
+type EngagementRevisionInput struct {
+	ProgramID            string
+	ProgramScopeRevision string
+	FrameworkRevisionIDs []string
+	PlanRevisionID       string
+	PeriodStart          time.Time
+	PeriodEnd            time.Time
+	Deadline             time.Time
+	DisclosurePolicyID   string
+	Status               EngagementStatus
+	ChangeSummary        string
+}
+
+// CreateEngagementRequest creates a stable engagement and its first revision.
+type CreateEngagementRequest struct {
+	ID           string
+	TenantID     string
+	Revision     EngagementRevisionInput
+	Participants []ParticipantInput
+	CreatedBy    string
+	CreatedAt    time.Time
+}
+
+// NewEngagement creates one engagement and immutable revision one.
+func NewEngagement(request CreateEngagementRequest) (Engagement, EngagementRevision, error) {
+	id, err := required(request.ID, "engagement id")
+	if err != nil {
+		return Engagement{}, EngagementRevision{}, err
+	}
+	tenantID, err := required(request.TenantID, "tenant id")
+	if err != nil {
+		return Engagement{}, EngagementRevision{}, err
+	}
+	actor, err := required(request.CreatedBy, "created by")
+	if err != nil {
+		return Engagement{}, EngagementRevision{}, err
+	}
+	createdAt := request.CreatedAt.UTC()
+	if createdAt.IsZero() {
+		return Engagement{}, EngagementRevision{}, fmt.Errorf("%w: created at is required", ErrInvalidRequest)
+	}
+	if request.Revision.Status == "" {
+		request.Revision.Status = EngagementStatusPlanning
+	}
+	if request.Revision.Status != EngagementStatusPlanning {
+		return Engagement{}, EngagementRevision{}, fmt.Errorf("%w: initial engagement status must be planning", ErrInvalidRequest)
+	}
+	revision, err := buildEngagementRevision(tenantID, id, 1, "", request.Revision, actor, createdAt)
+	if err != nil {
+		return Engagement{}, EngagementRevision{}, err
+	}
+	participants, err := buildParticipants(tenantID, id, request.Participants, createdAt)
+	if err != nil {
+		return Engagement{}, EngagementRevision{}, err
+	}
+	return Engagement{ID: id, TenantID: tenantID, Version: 1, CurrentRevision: 1, CurrentRevisionID: revision.ID, Status: revision.Status, Participants: participants}, revision, nil
+}
+
+// ReviseEngagement creates a new immutable revision without changing the supplied aggregate.
+func ReviseEngagement(current Engagement, expectedVersion uint64, input EngagementRevisionInput, actor string, createdAt time.Time) (Engagement, EngagementRevision, error) {
+	if current.Version != expectedVersion {
+		return Engagement{}, EngagementRevision{}, fmt.Errorf("%w: expected %d, current %d", ErrVersionConflict, expectedVersion, current.Version)
+	}
+	if input.Status == "" {
+		input.Status = current.Status
+	}
+	if !engagementTransitionAllowed(current.Status, input.Status) {
+		return Engagement{}, EngagementRevision{}, fmt.Errorf("%w: engagement transition %q to %q is invalid", ErrInvalidRequest, current.Status, input.Status)
+	}
+	actor, err := required(actor, "created by")
+	if err != nil {
+		return Engagement{}, EngagementRevision{}, err
+	}
+	createdAt = createdAt.UTC()
+	if createdAt.IsZero() {
+		return Engagement{}, EngagementRevision{}, fmt.Errorf("%w: created at is required", ErrInvalidRequest)
+	}
+	revision, err := buildEngagementRevision(current.TenantID, current.ID, current.CurrentRevision+1, current.CurrentRevisionID, input, actor, createdAt)
+	if err != nil {
+		return Engagement{}, EngagementRevision{}, err
+	}
+	next := cloneEngagement(current)
+	next.Version++
+	next.CurrentRevision++
+	next.CurrentRevisionID = revision.ID
+	next.Status = revision.Status
+	return next, revision, nil
+}
+
+// GrantParticipant creates or replaces one current participant assignment without
+// changing any immutable engagement revision.
+func GrantParticipant(current Engagement, expectedVersion uint64, input ParticipantInput, updatedAt time.Time) (Engagement, Participant, error) {
+	if current.Version != expectedVersion {
+		return Engagement{}, Participant{}, fmt.Errorf("%w: expected %d, current %d", ErrVersionConflict, expectedVersion, current.Version)
+	}
+	participant, err := buildParticipant(current.TenantID, current.ID, input, updatedAt.UTC())
+	if err != nil {
+		return Engagement{}, Participant{}, err
+	}
+	next := cloneEngagement(current)
+	participant.Version = 1
+	replaced := false
+	for idx := range next.Participants {
+		if next.Participants[idx].PrincipalID != participant.PrincipalID {
+			continue
+		}
+		participant.Version = next.Participants[idx].Version + 1
+		next.Participants[idx] = participant
+		replaced = true
+		break
+	}
+	if !replaced {
+		next.Participants = append(next.Participants, participant)
+	}
+	sortParticipants(next.Participants)
+	next.Version++
+	return next, participant, nil
+}
+
+// RemoveParticipant records a removed assignment without changing any immutable
+// engagement revision. The removed assignment remains available for audit history.
+func RemoveParticipant(current Engagement, expectedVersion uint64, principalID string, updatedAt time.Time) (Engagement, Participant, error) {
+	if current.Version != expectedVersion {
+		return Engagement{}, Participant{}, fmt.Errorf("%w: expected %d, current %d", ErrVersionConflict, expectedVersion, current.Version)
+	}
+	principalID, err := required(principalID, "participant principal id")
+	if err != nil {
+		return Engagement{}, Participant{}, err
+	}
+	updatedAt = updatedAt.UTC()
+	if updatedAt.IsZero() {
+		return Engagement{}, Participant{}, fmt.Errorf("%w: participant updated at is required", ErrInvalidRequest)
+	}
+	next := cloneEngagement(current)
+	for index := range next.Participants {
+		participant := next.Participants[index]
+		if participant.PrincipalID != principalID || participant.Status != ParticipantStatusActive {
+			continue
+		}
+		participant.Status = ParticipantStatusRemoved
+		participant.Version++
+		participant.UpdatedAt = updatedAt
+		next.Participants[index] = participant
+		next.Version++
+		return next, participant, nil
+	}
+	return Engagement{}, Participant{}, ErrEngagementNotFound
+}
+
+// AuthorizeEngagementAccess applies tenant and participant scope without revealing
+// whether an inaccessible engagement exists.
+func AuthorizeEngagementAccess(principal Principal, engagement Engagement, permission EngagementPermission) error {
+	if strings.TrimSpace(principal.TenantID) == "" || strings.TrimSpace(principal.ID) == "" || strings.TrimSpace(engagement.ID) == "" {
+		return ErrEngagementNotFound
+	}
+	if !validEngagementPermission(permission) {
+		return ErrEngagementNotFound
+	}
+	if strings.TrimSpace(principal.TenantID) != strings.TrimSpace(engagement.TenantID) {
+		return ErrEngagementNotFound
+	}
+	if principal.TenantWide {
+		return nil
+	}
+	for _, participant := range engagement.Participants {
+		if participant.Status != ParticipantStatusActive || participant.PrincipalID != strings.TrimSpace(principal.ID) {
+			continue
+		}
+		if roleAllows(participant.Role, permission) {
+			return nil
+		}
+	}
+	return ErrEngagementNotFound
+}
+
+func buildEngagementRevision(tenantID, engagementID string, revisionNumber uint64, predecessorID string, input EngagementRevisionInput, actor string, createdAt time.Time) (EngagementRevision, error) {
+	programID, err := required(input.ProgramID, "program id")
+	if err != nil {
+		return EngagementRevision{}, err
+	}
+	scopeRevision, err := required(input.ProgramScopeRevision, "program scope revision id")
+	if err != nil {
+		return EngagementRevision{}, err
+	}
+	disclosurePolicyID, err := required(input.DisclosurePolicyID, "disclosure policy id")
+	if err != nil {
+		return EngagementRevision{}, err
+	}
+	periodStart := input.PeriodStart.UTC()
+	periodEnd := input.PeriodEnd.UTC()
+	if periodStart.IsZero() || periodEnd.IsZero() || periodEnd.Before(periodStart) {
+		return EngagementRevision{}, fmt.Errorf("%w: audit period is invalid", ErrInvalidRequest)
+	}
+	deadline := input.Deadline.UTC()
+	if deadline.IsZero() {
+		return EngagementRevision{}, fmt.Errorf("%w: deadline is required", ErrInvalidRequest)
+	}
+	status := input.Status
+	if status == "" {
+		status = EngagementStatusPlanning
+	}
+	if !validEngagementStatus(status) {
+		return EngagementRevision{}, fmt.Errorf("%w: engagement status %q is invalid", ErrInvalidRequest, status)
+	}
+	revision := EngagementRevision{
+		TenantID:             strings.TrimSpace(tenantID),
+		EngagementID:         strings.TrimSpace(engagementID),
+		Revision:             revisionNumber,
+		PredecessorID:        strings.TrimSpace(predecessorID),
+		ProgramID:            programID,
+		ProgramScopeRevision: scopeRevision,
+		FrameworkRevisionIDs: normalizedStrings(input.FrameworkRevisionIDs),
+		PlanRevisionID:       strings.TrimSpace(input.PlanRevisionID),
+		PeriodStart:          periodStart,
+		PeriodEnd:            periodEnd,
+		Deadline:             deadline,
+		DisclosurePolicyID:   disclosurePolicyID,
+		Status:               status,
+		ChangeSummary:        strings.TrimSpace(input.ChangeSummary),
+		CreatedBy:            actor,
+		CreatedAt:            createdAt,
+	}
+	hash, err := canonicalDigest(revision)
+	if err != nil {
+		return EngagementRevision{}, fmt.Errorf("hash engagement revision: %w", err)
+	}
+	revision.RevisionHash = hash
+	revision.ID = digestID("audit-engagement-revision-", hash)
+	return revision, nil
+}
+
+func buildParticipants(tenantID, engagementID string, inputs []ParticipantInput, updatedAt time.Time) ([]Participant, error) {
+	participants := make([]Participant, 0, len(inputs))
+	seen := map[string]struct{}{}
+	for _, input := range inputs {
+		participant, err := buildParticipant(tenantID, engagementID, input, updatedAt)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[participant.PrincipalID]; ok {
+			return nil, fmt.Errorf("%w: participant %q is duplicated", ErrInvalidRequest, participant.PrincipalID)
+		}
+		seen[participant.PrincipalID] = struct{}{}
+		participant.Version = 1
+		participants = append(participants, participant)
+	}
+	sortParticipants(participants)
+	return participants, nil
+}
+
+func buildParticipant(tenantID, engagementID string, input ParticipantInput, updatedAt time.Time) (Participant, error) {
+	principalID, err := required(input.PrincipalID, "participant principal id")
+	if err != nil {
+		return Participant{}, err
+	}
+	if !validParticipantRole(input.Role) {
+		return Participant{}, fmt.Errorf("%w: participant role %q is invalid", ErrInvalidRequest, input.Role)
+	}
+	if updatedAt.IsZero() {
+		return Participant{}, fmt.Errorf("%w: participant updated at is required", ErrInvalidRequest)
+	}
+	digest := DigestBytes([]byte(strings.Join([]string{tenantID, engagementID, principalID}, "\x00")))
+	return Participant{
+		ID:           digestID("audit-participant-", digest),
+		TenantID:     strings.TrimSpace(tenantID),
+		EngagementID: strings.TrimSpace(engagementID),
+		PrincipalID:  principalID,
+		Role:         input.Role,
+		Status:       ParticipantStatusActive,
+		UpdatedAt:    updatedAt,
+	}, nil
+}
+
+func cloneEngagement(value Engagement) Engagement {
+	value.Participants = append([]Participant(nil), value.Participants...)
+	return value
+}
+
+func sortParticipants(participants []Participant) {
+	for i := 1; i < len(participants); i++ {
+		for j := i; j > 0 && participants[j].PrincipalID < participants[j-1].PrincipalID; j-- {
+			participants[j], participants[j-1] = participants[j-1], participants[j]
+		}
+	}
+}
+
+func validEngagementStatus(status EngagementStatus) bool {
+	switch status {
+	case EngagementStatusPlanning, EngagementStatusFieldwork, EngagementStatusClarification, EngagementStatusComplete, EngagementStatusClosed:
+		return true
+	default:
+		return false
+	}
+}
+
+func engagementTransitionAllowed(from, to EngagementStatus) bool {
+	if from == to {
+		return validEngagementStatus(to)
+	}
+	switch from {
+	case EngagementStatusPlanning:
+		return to == EngagementStatusFieldwork || to == EngagementStatusClosed
+	case EngagementStatusFieldwork:
+		return to == EngagementStatusClarification || to == EngagementStatusComplete || to == EngagementStatusClosed
+	case EngagementStatusClarification:
+		return to == EngagementStatusFieldwork || to == EngagementStatusComplete || to == EngagementStatusClosed
+	case EngagementStatusComplete:
+		return to == EngagementStatusClarification || to == EngagementStatusClosed
+	default:
+		return false
+	}
+}
+
+func validEngagementPermission(permission EngagementPermission) bool {
+	switch permission {
+	case EngagementPermissionRead, EngagementPermissionManage, EngagementPermissionReview, EngagementPermissionDisclose, EngagementPermissionDeliver:
+		return true
+	default:
+		return false
+	}
+}
+
+func validParticipantRole(role ParticipantRole) bool {
+	switch role {
+	case ParticipantRoleAuditLead, ParticipantRoleAuditor, ParticipantRoleClientOwner, ParticipantRoleEvidenceOwner, ParticipantRoleObserver:
+		return true
+	default:
+		return false
+	}
+}
+
+func roleAllows(role ParticipantRole, permission EngagementPermission) bool {
+	switch role {
+	case ParticipantRoleAuditLead, ParticipantRoleClientOwner:
+		return true
+	case ParticipantRoleAuditor:
+		return permission == EngagementPermissionRead || permission == EngagementPermissionReview || permission == EngagementPermissionDisclose
+	case ParticipantRoleEvidenceOwner:
+		return permission == EngagementPermissionRead || permission == EngagementPermissionDisclose
+	case ParticipantRoleObserver:
+		return permission == EngagementPermissionRead
+	default:
+		return false
+	}
+}

--- a/internal/grcaudit/engagements.go
+++ b/internal/grcaudit/engagements.go
@@ -274,7 +274,9 @@ func AuthorizeEngagementAccess(principal Principal, engagement Engagement, permi
 		return nil
 	}
 	for _, participant := range engagement.Participants {
-		if participant.Status != ParticipantStatusActive || participant.PrincipalID != strings.TrimSpace(principal.ID) {
+		if strings.TrimSpace(participant.TenantID) != strings.TrimSpace(engagement.TenantID) ||
+			strings.TrimSpace(participant.EngagementID) != strings.TrimSpace(engagement.ID) ||
+			participant.Status != ParticipantStatusActive || participant.PrincipalID != strings.TrimSpace(principal.ID) {
 			continue
 		}
 		if roleAllows(participant.Role, permission) {

--- a/internal/grcaudit/engagements_test.go
+++ b/internal/grcaudit/engagements_test.go
@@ -28,6 +28,19 @@ func TestAuthorizeEngagementAccessDeniesSameTenantForeignEngagement(t *testing.T
 	}
 }
 
+func TestAuthorizeEngagementAccessRejectsMisboundParticipant(t *testing.T) {
+	engagement, _, err := NewEngagement(testCreateEngagementRequest())
+	if err != nil {
+		t.Fatalf("NewEngagement() error = %v", err)
+	}
+	misbound := engagement
+	misbound.Participants = append([]Participant(nil), engagement.Participants...)
+	misbound.Participants[0].EngagementID = "engagement-b"
+	if err := AuthorizeEngagementAccess(Principal{TenantID: "tenant-a", ID: "auditor-a"}, misbound, EngagementPermissionRead); !errors.Is(err, ErrEngagementNotFound) {
+		t.Fatalf("misbound participant access error = %v, want ErrEngagementNotFound", err)
+	}
+}
+
 func TestEngagementRevisionsAreImmutableAcrossParticipantAndScopeChanges(t *testing.T) {
 	request := testCreateEngagementRequest()
 	engagement, first, err := NewEngagement(request)

--- a/internal/grcaudit/engagements_test.go
+++ b/internal/grcaudit/engagements_test.go
@@ -1,0 +1,126 @@
+package grcaudit
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestAuthorizeEngagementAccessDeniesSameTenantForeignEngagement(t *testing.T) {
+	engagement, _, err := NewEngagement(testCreateEngagementRequest())
+	if err != nil {
+		t.Fatalf("NewEngagement() error = %v", err)
+	}
+	if err := AuthorizeEngagementAccess(Principal{TenantID: "tenant-a", ID: "auditor-a"}, engagement, EngagementPermissionRead); err != nil {
+		t.Fatalf("assigned auditor read error = %v", err)
+	}
+	if err := AuthorizeEngagementAccess(Principal{TenantID: "tenant-a", ID: "auditor-b"}, engagement, EngagementPermissionRead); !errors.Is(err, ErrEngagementNotFound) {
+		t.Fatalf("same-tenant foreign engagement error = %v, want ErrEngagementNotFound", err)
+	}
+	if err := AuthorizeEngagementAccess(Principal{TenantID: "tenant-b", ID: "auditor-a"}, engagement, EngagementPermissionRead); !errors.Is(err, ErrEngagementNotFound) {
+		t.Fatalf("foreign tenant engagement error = %v, want ErrEngagementNotFound", err)
+	}
+	if err := AuthorizeEngagementAccess(Principal{TenantID: "tenant-a", ID: "manager", TenantWide: true}, engagement, EngagementPermissionManage); err != nil {
+		t.Fatalf("tenant-wide manager error = %v", err)
+	}
+	if err := AuthorizeEngagementAccess(Principal{TenantID: "tenant-a", ID: "auditor-a"}, engagement, EngagementPermissionDeliver); !errors.Is(err, ErrEngagementNotFound) {
+		t.Fatalf("auditor delivery error = %v, want non-disclosing not found", err)
+	}
+}
+
+func TestEngagementRevisionsAreImmutableAcrossParticipantAndScopeChanges(t *testing.T) {
+	request := testCreateEngagementRequest()
+	engagement, first, err := NewEngagement(request)
+	if err != nil {
+		t.Fatalf("NewEngagement() error = %v", err)
+	}
+	withOwner, participant, err := GrantParticipant(engagement, 1, ParticipantInput{PrincipalID: "owner-a", Role: ParticipantRoleClientOwner}, request.CreatedAt.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("GrantParticipant() error = %v", err)
+	}
+	if engagement.Version != 1 || engagement.CurrentRevision != 1 || len(engagement.Participants) != 1 {
+		t.Fatalf("original engagement mutated: %+v", engagement)
+	}
+	if withOwner.Version != 2 || withOwner.CurrentRevision != 1 || participant.Version != 1 {
+		t.Fatalf("participant update = engagement %+v participant %+v", withOwner, participant)
+	}
+	frameworks := []string{"framework-r2", "framework-r1"}
+	nextInput := request.Revision
+	nextInput.FrameworkRevisionIDs = frameworks
+	nextInput.Status = EngagementStatusFieldwork
+	nextInput.ChangeSummary = "Start fieldwork."
+	revised, second, err := ReviseEngagement(withOwner, 2, nextInput, "lead-a", request.CreatedAt.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("ReviseEngagement() error = %v", err)
+	}
+	frameworks[0] = "mutated-after-call"
+	if first.Revision != 1 || first.PredecessorID != "" || first.RevisionHash == "" {
+		t.Fatalf("first revision changed or incomplete: %+v", first)
+	}
+	if revised.Version != 3 || revised.CurrentRevision != 2 || revised.CurrentRevisionID != second.ID {
+		t.Fatalf("revised engagement = %+v", revised)
+	}
+	if engagement.Status != EngagementStatusPlanning || revised.Status != EngagementStatusFieldwork {
+		t.Fatalf("engagement status pointers = original %q revised %q", engagement.Status, revised.Status)
+	}
+	if second.PredecessorID != first.ID || second.Revision != 2 {
+		t.Fatalf("second revision lineage = %+v", second)
+	}
+	if len(second.FrameworkRevisionIDs) != 2 || second.FrameworkRevisionIDs[0] != "framework-r1" || second.FrameworkRevisionIDs[1] != "framework-r2" {
+		t.Fatalf("second revision frameworks = %#v", second.FrameworkRevisionIDs)
+	}
+	if len(revised.Participants) != 2 || len(withOwner.Participants) != 2 {
+		t.Fatalf("participant assignments were not preserved: revised=%+v previous=%+v", revised.Participants, withOwner.Participants)
+	}
+	if _, _, err := ReviseEngagement(revised, 2, nextInput, "lead-a", request.CreatedAt.Add(3*time.Hour)); !errors.Is(err, ErrVersionConflict) {
+		t.Fatalf("stale engagement revision error = %v, want ErrVersionConflict", err)
+	}
+}
+
+func TestEngagementLifecycleAndParticipantRemoval(t *testing.T) {
+	request := testCreateEngagementRequest()
+	engagement, _, err := NewEngagement(request)
+	if err != nil {
+		t.Fatalf("NewEngagement() error = %v", err)
+	}
+	invalid := request.Revision
+	invalid.Status = EngagementStatusComplete
+	if _, _, err := ReviseEngagement(engagement, engagement.Version, invalid, "lead-a", request.CreatedAt.Add(time.Hour)); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("planning to complete error = %v, want ErrInvalidRequest", err)
+	}
+	removedEngagement, removed, err := RemoveParticipant(engagement, engagement.Version, "auditor-a", request.CreatedAt.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("RemoveParticipant() error = %v", err)
+	}
+	if removed.Status != ParticipantStatusRemoved || removed.Version != 2 || removedEngagement.Version != 2 || engagement.Participants[0].Status != ParticipantStatusActive {
+		t.Fatalf("participant removal = engagement %+v participant %+v original %+v", removedEngagement, removed, engagement)
+	}
+	if err := AuthorizeEngagementAccess(Principal{TenantID: "tenant-a", ID: "auditor-a"}, removedEngagement, EngagementPermissionRead); !errors.Is(err, ErrEngagementNotFound) {
+		t.Fatalf("removed participant access error = %v, want ErrEngagementNotFound", err)
+	}
+	if err := AuthorizeEngagementAccess(Principal{TenantID: "tenant-a", ID: "manager", TenantWide: true}, engagement, EngagementPermission("unknown")); !errors.Is(err, ErrEngagementNotFound) {
+		t.Fatalf("unknown tenant-wide permission error = %v, want ErrEngagementNotFound", err)
+	}
+}
+
+func testCreateEngagementRequest() CreateEngagementRequest {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return CreateEngagementRequest{
+		ID:       "engagement-a",
+		TenantID: "tenant-a",
+		Revision: EngagementRevisionInput{
+			ProgramID:            "program-a",
+			ProgramScopeRevision: "scope-r1",
+			FrameworkRevisionIDs: []string{"framework-r1"},
+			PlanRevisionID:       "plan-r1",
+			PeriodStart:          start,
+			PeriodEnd:            start.AddDate(0, 3, 0),
+			Deadline:             start.AddDate(0, 4, 0),
+			DisclosurePolicyID:   "disclosure-r1",
+			Status:               EngagementStatusPlanning,
+		},
+		Participants: []ParticipantInput{{PrincipalID: "auditor-a", Role: ParticipantRoleAuditor}},
+		CreatedBy:    "lead-a",
+		CreatedAt:    start,
+	}
+}

--- a/internal/grcaudit/manifest.go
+++ b/internal/grcaudit/manifest.go
@@ -145,6 +145,11 @@ func BuildPackageManifest(request PackageManifestRequest) (PackageManifest, erro
 
 // VerifyPackageManifest validates canonical fields and detects altered semantic content.
 func VerifyPackageManifest(manifest PackageManifest) error {
+	_, err := verifiedPackageManifest(manifest)
+	return err
+}
+
+func verifiedPackageManifest(manifest PackageManifest) (PackageManifest, error) {
 	rebuilt, err := BuildPackageManifest(PackageManifestRequest{
 		PackageID:         manifest.PackageID,
 		TenantID:          manifest.TenantID,
@@ -157,20 +162,21 @@ func VerifyPackageManifest(manifest PackageManifest) error {
 		Entries:           manifest.Entries,
 	})
 	if err != nil {
-		return err
+		return PackageManifest{}, err
 	}
 	if manifest.SchemaVersion != rebuilt.SchemaVersion || manifest.SemanticDigest != rebuilt.SemanticDigest {
-		return ErrManifestDigestMismatch
+		return PackageManifest{}, ErrManifestDigestMismatch
 	}
-	return nil
+	return rebuilt, nil
 }
 
 // CanonicalPackageManifestBytes returns the stable bytes covered by a signature.
 func CanonicalPackageManifestBytes(manifest PackageManifest) ([]byte, error) {
-	if err := VerifyPackageManifest(manifest); err != nil {
+	canonical, err := verifiedPackageManifest(manifest)
+	if err != nil {
 		return nil, err
 	}
-	payload, err := json.Marshal(manifest)
+	payload, err := json.Marshal(canonical)
 	if err != nil {
 		return nil, fmt.Errorf("encode package manifest: %w", err)
 	}

--- a/internal/grcaudit/manifest.go
+++ b/internal/grcaudit/manifest.go
@@ -1,0 +1,430 @@
+package grcaudit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const packageManifestSchemaVersion = "grc-audit-package/v1"
+
+var (
+	// ErrManifestDigestMismatch indicates that a manifest's semantic content was altered.
+	ErrManifestDigestMismatch = errors.New("audit package manifest digest mismatch")
+	// ErrArtifactCapabilityUnavailable indicates that no approved artifact writer is configured.
+	ErrArtifactCapabilityUnavailable = errors.New("audit package artifact capability unavailable")
+	// ErrSigningCapabilityUnavailable indicates that no approved manifest signer is configured.
+	ErrSigningCapabilityUnavailable = errors.New("audit package signing capability unavailable")
+)
+
+// RedactionAction records how one logical package entry was disclosed.
+type RedactionAction string
+
+const (
+	RedactionActionIncluded RedactionAction = "included"
+	RedactionActionRedacted RedactionAction = "redacted"
+	RedactionActionOmitted  RedactionAction = "omitted"
+)
+
+// RedactionDecision is the bounded disclosure decision for one package entry.
+type RedactionDecision struct {
+	Mode             string          `json:"mode"`
+	Action           RedactionAction `json:"action"`
+	ReasonCode       string          `json:"reason_code,omitempty"`
+	PolicyRevisionID string          `json:"policy_revision_id"`
+}
+
+// PackageManifestEntry is one logical artifact covered by the package digest.
+type PackageManifestEntry struct {
+	Path           string            `json:"path"`
+	LogicalType    string            `json:"logical_type"`
+	SchemaVersion  string            `json:"schema_version"`
+	StableID       string            `json:"stable_id"`
+	RevisionID     string            `json:"revision_id"`
+	MediaType      string            `json:"media_type"`
+	ContentDigest  string            `json:"content_digest,omitempty"`
+	SourceDigest   string            `json:"source_digest,omitempty"`
+	SizeBytes      uint64            `json:"size_bytes,omitempty"`
+	Redaction      RedactionDecision `json:"redaction"`
+	ProvenanceRefs []string          `json:"provenance_refs,omitempty"`
+}
+
+// PackageManifest is the deterministic semantic envelope for one immutable package revision.
+type PackageManifest struct {
+	SchemaVersion     string                 `json:"schema_version"`
+	PackageID         string                 `json:"package_id"`
+	TenantID          string                 `json:"tenant_id"`
+	EngagementID      string                 `json:"engagement_id"`
+	Revision          uint64                 `json:"revision"`
+	AssessmentRunID   string                 `json:"assessment_run_id"`
+	ReviewRevisionID  string                 `json:"review_revision_id"`
+	RedactionMode     string                 `json:"redaction_mode"`
+	PredecessorDigest string                 `json:"predecessor_digest,omitempty"`
+	Entries           []PackageManifestEntry `json:"entries"`
+	SemanticDigest    string                 `json:"semantic_digest"`
+}
+
+// PackageManifestRequest contains exact immutable inputs for a package revision.
+type PackageManifestRequest struct {
+	PackageID         string
+	TenantID          string
+	EngagementID      string
+	Revision          uint64
+	AssessmentRunID   string
+	ReviewRevisionID  string
+	RedactionMode     string
+	PredecessorDigest string
+	Entries           []PackageManifestEntry
+}
+
+// BuildPackageManifest validates, sorts, and hashes one immutable package manifest.
+func BuildPackageManifest(request PackageManifestRequest) (PackageManifest, error) {
+	packageID, err := required(request.PackageID, "package id")
+	if err != nil {
+		return PackageManifest{}, err
+	}
+	tenantID, err := required(request.TenantID, "tenant id")
+	if err != nil {
+		return PackageManifest{}, err
+	}
+	engagementID, err := required(request.EngagementID, "engagement id")
+	if err != nil {
+		return PackageManifest{}, err
+	}
+	assessmentRunID, err := required(request.AssessmentRunID, "assessment run id")
+	if err != nil {
+		return PackageManifest{}, err
+	}
+	reviewRevisionID, err := required(request.ReviewRevisionID, "review revision id")
+	if err != nil {
+		return PackageManifest{}, err
+	}
+	redactionMode, err := required(request.RedactionMode, "redaction mode")
+	if err != nil {
+		return PackageManifest{}, err
+	}
+	if request.Revision == 0 {
+		return PackageManifest{}, fmt.Errorf("%w: package revision must be positive", ErrInvalidRequest)
+	}
+	predecessorDigest := strings.TrimSpace(request.PredecessorDigest)
+	if request.Revision > 1 && !validDigest(predecessorDigest) {
+		return PackageManifest{}, fmt.Errorf("%w: predecessor digest is required after revision one", ErrInvalidRequest)
+	}
+	if request.Revision == 1 && predecessorDigest != "" {
+		return PackageManifest{}, fmt.Errorf("%w: revision one cannot have a predecessor digest", ErrInvalidRequest)
+	}
+	entries, err := normalizeManifestEntries(request.Entries, redactionMode)
+	if err != nil {
+		return PackageManifest{}, err
+	}
+	manifest := PackageManifest{
+		SchemaVersion:     packageManifestSchemaVersion,
+		PackageID:         packageID,
+		TenantID:          tenantID,
+		EngagementID:      engagementID,
+		Revision:          request.Revision,
+		AssessmentRunID:   assessmentRunID,
+		ReviewRevisionID:  reviewRevisionID,
+		RedactionMode:     redactionMode,
+		PredecessorDigest: predecessorDigest,
+		Entries:           entries,
+	}
+	digest, err := manifestDigest(manifest)
+	if err != nil {
+		return PackageManifest{}, err
+	}
+	manifest.SemanticDigest = digest
+	return manifest, nil
+}
+
+// VerifyPackageManifest validates canonical fields and detects altered semantic content.
+func VerifyPackageManifest(manifest PackageManifest) error {
+	rebuilt, err := BuildPackageManifest(PackageManifestRequest{
+		PackageID:         manifest.PackageID,
+		TenantID:          manifest.TenantID,
+		EngagementID:      manifest.EngagementID,
+		Revision:          manifest.Revision,
+		AssessmentRunID:   manifest.AssessmentRunID,
+		ReviewRevisionID:  manifest.ReviewRevisionID,
+		RedactionMode:     manifest.RedactionMode,
+		PredecessorDigest: manifest.PredecessorDigest,
+		Entries:           manifest.Entries,
+	})
+	if err != nil {
+		return err
+	}
+	if manifest.SchemaVersion != rebuilt.SchemaVersion || manifest.SemanticDigest != rebuilt.SemanticDigest {
+		return ErrManifestDigestMismatch
+	}
+	return nil
+}
+
+// CanonicalPackageManifestBytes returns the stable bytes covered by a signature.
+func CanonicalPackageManifestBytes(manifest PackageManifest) ([]byte, error) {
+	if err := VerifyPackageManifest(manifest); err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("encode package manifest: %w", err)
+	}
+	return payload, nil
+}
+
+// PackageManifestSigner signs canonical manifest bytes using an approved capability.
+type PackageManifestSigner interface {
+	SignPackageManifest(context.Context, []byte) (PackageSignature, error)
+}
+
+// PackageArtifactWriter writes the signed manifest to an approved artifact system.
+type PackageArtifactWriter interface {
+	WritePackageManifest(context.Context, PackageArtifact) (PackageArtifactReceipt, error)
+}
+
+// PackageSignature describes the signer and detached signature returned by a signer.
+type PackageSignature struct {
+	Algorithm string    `json:"algorithm"`
+	KeyRef    string    `json:"key_ref"`
+	Value     string    `json:"value"`
+	SignedAt  time.Time `json:"signed_at"`
+}
+
+// PackageArtifact is the signed manifest passed to an artifact writer.
+type PackageArtifact struct {
+	PackageID     string
+	Revision      uint64
+	Content       []byte
+	ContentDigest string
+	Signature     PackageSignature
+}
+
+// PackageArtifactReceipt is the non-content receipt returned by an artifact writer.
+type PackageArtifactReceipt struct {
+	URI       string `json:"uri"`
+	Digest    string `json:"digest"`
+	SizeBytes uint64 `json:"size_bytes"`
+}
+
+// PackageFinalizationReceipt records the manifest, signature, and artifact receipt.
+type PackageFinalizationReceipt struct {
+	PackageID      string                 `json:"package_id"`
+	Revision       uint64                 `json:"revision"`
+	ManifestDigest string                 `json:"manifest_digest"`
+	Signature      PackageSignature       `json:"signature"`
+	Artifact       PackageArtifactReceipt `json:"artifact"`
+}
+
+// PackageFinalizer requires explicit artifact and signing capabilities. It never
+// substitutes one capability when another is absent.
+type PackageFinalizer struct {
+	Artifacts PackageArtifactWriter
+	Signer    PackageManifestSigner
+}
+
+// Finalize signs and writes an already-built immutable manifest.
+func (f PackageFinalizer) Finalize(ctx context.Context, manifest PackageManifest) (PackageFinalizationReceipt, error) {
+	if err := f.requireCapabilities(); err != nil {
+		return PackageFinalizationReceipt{}, err
+	}
+	payload, err := CanonicalPackageManifestBytes(manifest)
+	if err != nil {
+		return PackageFinalizationReceipt{}, err
+	}
+	signature, err := f.Signer.SignPackageManifest(ctx, payload)
+	if err != nil {
+		return PackageFinalizationReceipt{}, fmt.Errorf("sign package manifest: %w", err)
+	}
+	if strings.TrimSpace(signature.Algorithm) == "" || strings.TrimSpace(signature.KeyRef) == "" || strings.TrimSpace(signature.Value) == "" || signature.SignedAt.IsZero() {
+		return PackageFinalizationReceipt{}, fmt.Errorf("%w: signer returned an incomplete signature", ErrInvalidRequest)
+	}
+	contentDigest := DigestBytes(payload)
+	receipt, err := f.Artifacts.WritePackageManifest(ctx, PackageArtifact{
+		PackageID:     manifest.PackageID,
+		Revision:      manifest.Revision,
+		Content:       cloneBytes(payload),
+		ContentDigest: contentDigest,
+		Signature:     signature,
+	})
+	if err != nil {
+		return PackageFinalizationReceipt{}, fmt.Errorf("write package manifest: %w", err)
+	}
+	if strings.TrimSpace(receipt.URI) == "" || receipt.Digest != contentDigest || receipt.SizeBytes != uint64(len(payload)) {
+		return PackageFinalizationReceipt{}, fmt.Errorf("%w: artifact writer returned an invalid receipt", ErrInvalidRequest)
+	}
+	return PackageFinalizationReceipt{
+		PackageID:      manifest.PackageID,
+		Revision:       manifest.Revision,
+		ManifestDigest: manifest.SemanticDigest,
+		Signature:      signature,
+		Artifact:       receipt,
+	}, nil
+}
+
+func (f PackageFinalizer) requireCapabilities() error {
+	var missing []error
+	if f.Artifacts == nil {
+		missing = append(missing, ErrArtifactCapabilityUnavailable)
+	}
+	if f.Signer == nil {
+		missing = append(missing, ErrSigningCapabilityUnavailable)
+	}
+	return errors.Join(missing...)
+}
+
+func normalizeManifestEntries(entries []PackageManifestEntry, redactionMode string) ([]PackageManifestEntry, error) {
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("%w: package entries are required", ErrInvalidRequest)
+	}
+	result := make([]PackageManifestEntry, 0, len(entries))
+	seenPaths := map[string]struct{}{}
+	for index, entry := range entries {
+		normalized, err := normalizeManifestEntry(entry, redactionMode)
+		if err != nil {
+			return nil, fmt.Errorf("entry %d: %w", index, err)
+		}
+		if _, ok := seenPaths[normalized.Path]; ok {
+			return nil, fmt.Errorf("%w: package entry path %q is duplicated", ErrInvalidRequest, normalized.Path)
+		}
+		seenPaths[normalized.Path] = struct{}{}
+		result = append(result, normalized)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Path < result[j].Path })
+	return result, nil
+}
+
+func normalizeManifestEntry(entry PackageManifestEntry, redactionMode string) (PackageManifestEntry, error) {
+	rawPath, err := required(entry.Path, "path")
+	if err != nil {
+		return PackageManifestEntry{}, err
+	}
+	cleanPath := path.Clean(strings.ReplaceAll(rawPath, "\\", "/"))
+	if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") || strings.HasPrefix(cleanPath, "/") || cleanPath != rawPath {
+		return PackageManifestEntry{}, fmt.Errorf("%w: package entry path %q is not canonical and relative", ErrInvalidRequest, rawPath)
+	}
+	logicalType, err := required(entry.LogicalType, "logical type")
+	if err != nil {
+		return PackageManifestEntry{}, err
+	}
+	schemaVersion, err := required(entry.SchemaVersion, "schema version")
+	if err != nil {
+		return PackageManifestEntry{}, err
+	}
+	stableID, err := required(entry.StableID, "stable id")
+	if err != nil {
+		return PackageManifestEntry{}, err
+	}
+	revisionID, err := required(entry.RevisionID, "revision id")
+	if err != nil {
+		return PackageManifestEntry{}, err
+	}
+	mediaType, err := required(entry.MediaType, "media type")
+	if err != nil {
+		return PackageManifestEntry{}, err
+	}
+	policyRevisionID, err := required(entry.Redaction.PolicyRevisionID, "redaction policy revision id")
+	if err != nil {
+		return PackageManifestEntry{}, err
+	}
+	mode := strings.TrimSpace(entry.Redaction.Mode)
+	if mode == "" {
+		mode = redactionMode
+	}
+	if mode != redactionMode {
+		return PackageManifestEntry{}, fmt.Errorf("%w: entry redaction mode %q does not match manifest mode %q", ErrInvalidRequest, mode, redactionMode)
+	}
+	if !validRedactionAction(entry.Redaction.Action) {
+		return PackageManifestEntry{}, fmt.Errorf("%w: redaction action %q is invalid", ErrInvalidRequest, entry.Redaction.Action)
+	}
+	contentDigest := strings.TrimSpace(entry.ContentDigest)
+	if entry.Redaction.Action != RedactionActionOmitted && !validDigest(contentDigest) {
+		return PackageManifestEntry{}, fmt.Errorf("%w: included or redacted entries require a SHA-256 content digest", ErrInvalidRequest)
+	}
+	if entry.Redaction.Action == RedactionActionOmitted && (contentDigest != "" || entry.SizeBytes != 0) {
+		return PackageManifestEntry{}, fmt.Errorf("%w: omitted entries cannot include disclosed content metadata", ErrInvalidRequest)
+	}
+	reasonCode := strings.TrimSpace(entry.Redaction.ReasonCode)
+	if entry.Redaction.Action != RedactionActionIncluded && reasonCode == "" {
+		return PackageManifestEntry{}, fmt.Errorf("%w: redacted or omitted entries require a reason code", ErrInvalidRequest)
+	}
+	sourceDigest := strings.TrimSpace(entry.SourceDigest)
+	if sourceDigest != "" && !validDigest(sourceDigest) {
+		return PackageManifestEntry{}, fmt.Errorf("%w: source digest is invalid", ErrInvalidRequest)
+	}
+	return PackageManifestEntry{
+		Path:          cleanPath,
+		LogicalType:   logicalType,
+		SchemaVersion: schemaVersion,
+		StableID:      stableID,
+		RevisionID:    revisionID,
+		MediaType:     mediaType,
+		ContentDigest: contentDigest,
+		SourceDigest:  sourceDigest,
+		SizeBytes:     entry.SizeBytes,
+		Redaction: RedactionDecision{
+			Mode:             mode,
+			Action:           entry.Redaction.Action,
+			ReasonCode:       reasonCode,
+			PolicyRevisionID: policyRevisionID,
+		},
+		ProvenanceRefs: normalizedStrings(entry.ProvenanceRefs),
+	}, nil
+}
+
+func manifestDigest(manifest PackageManifest) (string, error) {
+	manifest.SemanticDigest = ""
+	digest, err := canonicalDigest(manifest)
+	if err != nil {
+		return "", fmt.Errorf("hash package manifest: %w", err)
+	}
+	return digest, nil
+}
+
+func validRedactionAction(action RedactionAction) bool {
+	switch action {
+	case RedactionActionIncluded, RedactionActionRedacted, RedactionActionOmitted:
+		return true
+	default:
+		return false
+	}
+}
+
+func validDigest(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+64 {
+		return false
+	}
+	for _, char := range strings.TrimPrefix(value, "sha256:") {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneBytes(values []byte) []byte {
+	if values == nil {
+		return nil
+	}
+	return append([]byte(nil), values...)
+}
+
+// AuthorizePackageAccess verifies package and engagement object scope.
+func AuthorizePackageAccess(principal Principal, engagement Engagement, manifest PackageManifest, permission EngagementPermission) error {
+	if strings.TrimSpace(manifest.PackageID) == "" || manifest.TenantID != engagement.TenantID || manifest.EngagementID != engagement.ID {
+		return ErrPackageNotFound
+	}
+	if err := AuthorizeEngagementAccess(principal, engagement, permission); err != nil {
+		return ErrPackageNotFound
+	}
+	return nil
+}
+
+// PackageRevisionRef returns a stable human-readable package revision reference.
+func PackageRevisionRef(manifest PackageManifest) string {
+	return strings.TrimSpace(manifest.PackageID) + "@" + strconv.FormatUint(manifest.Revision, 10)
+}

--- a/internal/grcaudit/manifest_test.go
+++ b/internal/grcaudit/manifest_test.go
@@ -35,6 +35,30 @@ func TestBuildPackageManifestIsDeterministicAcrossEntryOrder(t *testing.T) {
 	}
 }
 
+func TestCanonicalPackageManifestBytesNormalizeEquivalentEntryOrder(t *testing.T) {
+	manifest, err := BuildPackageManifest(testManifestRequest(testManifestEntries()))
+	if err != nil {
+		t.Fatalf("BuildPackageManifest() error = %v", err)
+	}
+	want, err := CanonicalPackageManifestBytes(manifest)
+	if err != nil {
+		t.Fatalf("CanonicalPackageManifestBytes(canonical) error = %v", err)
+	}
+	equivalent := manifest
+	equivalent.Entries = append([]PackageManifestEntry(nil), manifest.Entries...)
+	equivalent.Entries[0], equivalent.Entries[1] = equivalent.Entries[1], equivalent.Entries[0]
+	if err := VerifyPackageManifest(equivalent); err != nil {
+		t.Fatalf("VerifyPackageManifest(equivalent) error = %v", err)
+	}
+	got, err := CanonicalPackageManifestBytes(equivalent)
+	if err != nil {
+		t.Fatalf("CanonicalPackageManifestBytes(equivalent) error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("canonical bytes depend on equivalent entry order:\n%s\n%s", got, want)
+	}
+}
+
 func TestPackageManifestDetectsAlteredEntry(t *testing.T) {
 	manifest, err := BuildPackageManifest(testManifestRequest(testManifestEntries()))
 	if err != nil {

--- a/internal/grcaudit/manifest_test.go
+++ b/internal/grcaudit/manifest_test.go
@@ -1,0 +1,203 @@
+package grcaudit
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBuildPackageManifestIsDeterministicAcrossEntryOrder(t *testing.T) {
+	entries := testManifestEntries()
+	first, err := BuildPackageManifest(testManifestRequest(entries))
+	if err != nil {
+		t.Fatalf("BuildPackageManifest(first) error = %v", err)
+	}
+	entries[0], entries[1] = entries[1], entries[0]
+	second, err := BuildPackageManifest(testManifestRequest(entries))
+	if err != nil {
+		t.Fatalf("BuildPackageManifest(second) error = %v", err)
+	}
+	if first.SemanticDigest != second.SemanticDigest || !reflect.DeepEqual(first.Entries, second.Entries) {
+		t.Fatalf("deterministic manifests differ:\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	firstBytes, err := CanonicalPackageManifestBytes(first)
+	if err != nil {
+		t.Fatalf("CanonicalPackageManifestBytes(first) error = %v", err)
+	}
+	secondBytes, err := CanonicalPackageManifestBytes(second)
+	if err != nil {
+		t.Fatalf("CanonicalPackageManifestBytes(second) error = %v", err)
+	}
+	if !reflect.DeepEqual(firstBytes, secondBytes) {
+		t.Fatalf("canonical manifest bytes differ:\n%s\n%s", firstBytes, secondBytes)
+	}
+}
+
+func TestPackageManifestDetectsAlteredEntry(t *testing.T) {
+	manifest, err := BuildPackageManifest(testManifestRequest(testManifestEntries()))
+	if err != nil {
+		t.Fatalf("BuildPackageManifest() error = %v", err)
+	}
+	altered := manifest
+	altered.Entries = append([]PackageManifestEntry(nil), manifest.Entries...)
+	altered.Entries[0].ContentDigest = DigestBytes([]byte("altered content"))
+	if err := VerifyPackageManifest(altered); !errors.Is(err, ErrManifestDigestMismatch) {
+		t.Fatalf("VerifyPackageManifest(altered) error = %v, want ErrManifestDigestMismatch", err)
+	}
+	rebuilt, err := BuildPackageManifest(PackageManifestRequest{
+		PackageID:        altered.PackageID,
+		TenantID:         altered.TenantID,
+		EngagementID:     altered.EngagementID,
+		Revision:         altered.Revision,
+		AssessmentRunID:  altered.AssessmentRunID,
+		ReviewRevisionID: altered.ReviewRevisionID,
+		RedactionMode:    altered.RedactionMode,
+		Entries:          altered.Entries,
+	})
+	if err != nil {
+		t.Fatalf("BuildPackageManifest(altered) error = %v", err)
+	}
+	if rebuilt.SemanticDigest == manifest.SemanticDigest {
+		t.Fatal("altered entry did not change semantic digest")
+	}
+}
+
+func TestPackageFinalizerReturnsTypedCapabilityErrors(t *testing.T) {
+	manifest, err := BuildPackageManifest(testManifestRequest(testManifestEntries()))
+	if err != nil {
+		t.Fatalf("BuildPackageManifest() error = %v", err)
+	}
+	_, err = (PackageFinalizer{}).Finalize(context.Background(), manifest)
+	if !errors.Is(err, ErrArtifactCapabilityUnavailable) || !errors.Is(err, ErrSigningCapabilityUnavailable) {
+		t.Fatalf("Finalize() error = %v, want both capability errors", err)
+	}
+	writer := &recordingArtifactWriter{}
+	finalizer := PackageFinalizer{Artifacts: writer, Signer: staticManifestSigner{}}
+	receipt, err := finalizer.Finalize(context.Background(), manifest)
+	if err != nil {
+		t.Fatalf("Finalize(configured) error = %v", err)
+	}
+	if receipt.ManifestDigest != manifest.SemanticDigest || writer.artifact.ContentDigest != DigestBytes(writer.artifact.Content) {
+		t.Fatalf("finalization receipt/artifact = %+v / %+v", receipt, writer.artifact)
+	}
+}
+
+func TestPackageFinalizerRejectsInvalidArtifactReceipt(t *testing.T) {
+	manifest, err := BuildPackageManifest(testManifestRequest(testManifestEntries()))
+	if err != nil {
+		t.Fatalf("BuildPackageManifest() error = %v", err)
+	}
+	finalizer := PackageFinalizer{Artifacts: invalidReceiptWriter{}, Signer: staticManifestSigner{}}
+	if _, err := finalizer.Finalize(context.Background(), manifest); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Finalize() error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestPackageManifestRequiresBoundedOmissionMetadata(t *testing.T) {
+	entries := testManifestEntries()
+	entries[0].Redaction.Action = RedactionActionOmitted
+	entries[0].Redaction.ReasonCode = ""
+	if _, err := BuildPackageManifest(testManifestRequest(entries)); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("BuildPackageManifest(omitted content) error = %v, want ErrInvalidRequest", err)
+	}
+	entries[0].ContentDigest = ""
+	entries[0].SizeBytes = 0
+	entries[0].Redaction.ReasonCode = "not_disclosed"
+	if _, err := BuildPackageManifest(testManifestRequest(entries)); err != nil {
+		t.Fatalf("BuildPackageManifest(valid omission) error = %v", err)
+	}
+}
+
+func TestAuthorizePackageAccessUsesEngagementScope(t *testing.T) {
+	engagement, _, err := NewEngagement(testCreateEngagementRequest())
+	if err != nil {
+		t.Fatalf("NewEngagement() error = %v", err)
+	}
+	manifest, err := BuildPackageManifest(testManifestRequest(testManifestEntries()))
+	if err != nil {
+		t.Fatalf("BuildPackageManifest() error = %v", err)
+	}
+	if err := AuthorizePackageAccess(Principal{TenantID: "tenant-a", ID: "auditor-a"}, engagement, manifest, EngagementPermissionRead); err != nil {
+		t.Fatalf("assigned auditor package read error = %v", err)
+	}
+	if err := AuthorizePackageAccess(Principal{TenantID: "tenant-a", ID: "auditor-b"}, engagement, manifest, EngagementPermissionRead); !errors.Is(err, ErrPackageNotFound) {
+		t.Fatalf("same-tenant foreign package error = %v, want ErrPackageNotFound", err)
+	}
+}
+
+type staticManifestSigner struct{}
+
+func (staticManifestSigner) SignPackageManifest(_ context.Context, _ []byte) (PackageSignature, error) {
+	return PackageSignature{
+		Algorithm: "test-signature-v1",
+		KeyRef:    "test-key",
+		Value:     "signature-value",
+		SignedAt:  time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+type recordingArtifactWriter struct {
+	artifact PackageArtifact
+}
+
+type invalidReceiptWriter struct{}
+
+func (invalidReceiptWriter) WritePackageManifest(_ context.Context, _ PackageArtifact) (PackageArtifactReceipt, error) {
+	return PackageArtifactReceipt{URI: "artifact://package-a/1", Digest: DigestBytes([]byte("wrong")), SizeBytes: 1}, nil
+}
+
+func (w *recordingArtifactWriter) WritePackageManifest(_ context.Context, artifact PackageArtifact) (PackageArtifactReceipt, error) {
+	w.artifact = artifact
+	return PackageArtifactReceipt{URI: "artifact://package-a/1", Digest: artifact.ContentDigest, SizeBytes: uint64(len(artifact.Content))}, nil
+}
+
+func testManifestRequest(entries []PackageManifestEntry) PackageManifestRequest {
+	return PackageManifestRequest{
+		PackageID:        "package-a",
+		TenantID:         "tenant-a",
+		EngagementID:     "engagement-a",
+		Revision:         1,
+		AssessmentRunID:  "assessment-run-a",
+		ReviewRevisionID: "review-r1",
+		RedactionMode:    "share_safe",
+		Entries:          entries,
+	}
+}
+
+func testManifestEntries() []PackageManifestEntry {
+	return []PackageManifestEntry{
+		{
+			Path:          "evidence/evidence-a.json",
+			LogicalType:   "evidence_claim",
+			SchemaVersion: "evidence-claim/v1",
+			StableID:      "evidence-a",
+			RevisionID:    "evidence-a-r1",
+			MediaType:     "application/json",
+			ContentDigest: DigestBytes([]byte("evidence-a")),
+			SourceDigest:  DigestBytes([]byte("source-evidence-a")),
+			SizeBytes:     10,
+			Redaction: RedactionDecision{
+				Action:           RedactionActionRedacted,
+				ReasonCode:       "sensitive_fields_removed",
+				PolicyRevisionID: "disclosure-r1",
+			},
+			ProvenanceRefs: []string{"event-b", "event-a"},
+		},
+		{
+			Path:          "results/objective-a.json",
+			LogicalType:   "assessment_objective_result",
+			SchemaVersion: "objective-result/v1",
+			StableID:      "objective-a",
+			RevisionID:    "result-r1",
+			MediaType:     "application/json",
+			ContentDigest: DigestBytes([]byte("result-a")),
+			SizeBytes:     8,
+			Redaction: RedactionDecision{
+				Action:           RedactionActionIncluded,
+				PolicyRevisionID: "disclosure-r1",
+			},
+		},
+	}
+}

--- a/internal/grcaudit/requests.go
+++ b/internal/grcaudit/requests.go
@@ -1,0 +1,317 @@
+package grcaudit
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EvidenceRequestStatus is the current state of an audit evidence request.
+type EvidenceRequestStatus string
+
+const (
+	EvidenceRequestStatusOpen             EvidenceRequestStatus = "open"
+	EvidenceRequestStatusInProgress       EvidenceRequestStatus = "in_progress"
+	EvidenceRequestStatusSubmitted        EvidenceRequestStatus = "submitted"
+	EvidenceRequestStatusChangesRequested EvidenceRequestStatus = "changes_requested"
+	EvidenceRequestStatusAccepted         EvidenceRequestStatus = "accepted"
+	EvidenceRequestStatusRejected         EvidenceRequestStatus = "rejected"
+	EvidenceRequestStatusWithdrawn        EvidenceRequestStatus = "withdrawn"
+	EvidenceRequestStatusClosed           EvidenceRequestStatus = "closed"
+)
+
+// EvidenceRequest is the mutable pointer for a stable request identity.
+type EvidenceRequest struct {
+	ID                string                `json:"id"`
+	TenantID          string                `json:"tenant_id"`
+	EngagementID      string                `json:"engagement_id"`
+	Version           uint64                `json:"version"`
+	CurrentRevision   uint64                `json:"current_revision"`
+	CurrentRevisionID string                `json:"current_revision_id"`
+	Status            EvidenceRequestStatus `json:"status"`
+}
+
+// EvidenceRequestRevision is one immutable statement of requested evidence.
+type EvidenceRequestRevision struct {
+	ID                   string                `json:"id"`
+	TenantID             string                `json:"tenant_id"`
+	EngagementID         string                `json:"engagement_id"`
+	RequestID            string                `json:"request_id"`
+	Revision             uint64                `json:"revision"`
+	PredecessorID        string                `json:"predecessor_id,omitempty"`
+	ObjectiveID          string                `json:"objective_id"`
+	SubjectIDs           []string              `json:"subject_ids,omitempty"`
+	PeriodStart          time.Time             `json:"period_start"`
+	PeriodEnd            time.Time             `json:"period_end"`
+	SampleRevisionID     string                `json:"sample_revision_id,omitempty"`
+	RequesterPrincipalID string                `json:"requester_principal_id"`
+	OwnerPrincipalID     string                `json:"owner_principal_id"`
+	DueAt                time.Time             `json:"due_at"`
+	ExpectedFormats      []string              `json:"expected_formats,omitempty"`
+	Instructions         string                `json:"instructions,omitempty"`
+	Status               EvidenceRequestStatus `json:"status"`
+	ChangeSummary        string                `json:"change_summary,omitempty"`
+	CreatedBy            string                `json:"created_by"`
+	CreatedAt            time.Time             `json:"created_at"`
+	RevisionHash         string                `json:"revision_hash"`
+}
+
+// EvidenceRequestRevisionInput contains the semantic fields of a request revision.
+type EvidenceRequestRevisionInput struct {
+	ObjectiveID          string
+	SubjectIDs           []string
+	PeriodStart          time.Time
+	PeriodEnd            time.Time
+	SampleRevisionID     string
+	RequesterPrincipalID string
+	OwnerPrincipalID     string
+	DueAt                time.Time
+	ExpectedFormats      []string
+	Instructions         string
+	Status               EvidenceRequestStatus
+	ChangeSummary        string
+}
+
+// CreateEvidenceRequestRequest creates a request and immutable revision one.
+type CreateEvidenceRequestRequest struct {
+	ID           string
+	TenantID     string
+	EngagementID string
+	Revision     EvidenceRequestRevisionInput
+	CreatedBy    string
+	CreatedAt    time.Time
+}
+
+// EvidenceSubmission is an immutable response to one exact request version.
+type EvidenceSubmission struct {
+	ID                 string    `json:"id"`
+	TenantID           string    `json:"tenant_id"`
+	EngagementID       string    `json:"engagement_id"`
+	RequestID          string    `json:"request_id"`
+	RequestVersion     uint64    `json:"request_version"`
+	ClaimIDs           []string  `json:"claim_ids,omitempty"`
+	ArtifactVersionIDs []string  `json:"artifact_version_ids,omitempty"`
+	PackageRevisionID  string    `json:"package_revision_id,omitempty"`
+	Message            string    `json:"message,omitempty"`
+	SubmittedBy        string    `json:"submitted_by"`
+	SubmittedAt        time.Time `json:"submitted_at"`
+	SubmissionHash     string    `json:"submission_hash"`
+}
+
+// EvidenceSubmissionInput supplies the immutable references in a submission.
+type EvidenceSubmissionInput struct {
+	ClaimIDs           []string
+	ArtifactVersionIDs []string
+	PackageRevisionID  string
+	Message            string
+}
+
+// NewEvidenceRequest creates one request and immutable revision one.
+func NewEvidenceRequest(request CreateEvidenceRequestRequest) (EvidenceRequest, EvidenceRequestRevision, error) {
+	id, err := required(request.ID, "evidence request id")
+	if err != nil {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, err
+	}
+	tenantID, err := required(request.TenantID, "tenant id")
+	if err != nil {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, err
+	}
+	engagementID, err := required(request.EngagementID, "engagement id")
+	if err != nil {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, err
+	}
+	actor, err := required(request.CreatedBy, "created by")
+	if err != nil {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, err
+	}
+	createdAt := request.CreatedAt.UTC()
+	if createdAt.IsZero() {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, fmt.Errorf("%w: created at is required", ErrInvalidRequest)
+	}
+	if request.Revision.Status == "" {
+		request.Revision.Status = EvidenceRequestStatusOpen
+	}
+	if request.Revision.Status != EvidenceRequestStatusOpen {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, fmt.Errorf("%w: initial request status must be open", ErrInvalidRequest)
+	}
+	revision, err := buildEvidenceRequestRevision(tenantID, engagementID, id, 1, "", request.Revision, actor, createdAt)
+	if err != nil {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, err
+	}
+	return EvidenceRequest{ID: id, TenantID: tenantID, EngagementID: engagementID, Version: 1, CurrentRevision: 1, CurrentRevisionID: revision.ID, Status: revision.Status}, revision, nil
+}
+
+// ReviseEvidenceRequest creates a new immutable request revision.
+func ReviseEvidenceRequest(current EvidenceRequest, expectedVersion uint64, input EvidenceRequestRevisionInput, actor string, createdAt time.Time) (EvidenceRequest, EvidenceRequestRevision, error) {
+	if current.Version != expectedVersion {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, fmt.Errorf("%w: expected %d, current %d", ErrVersionConflict, expectedVersion, current.Version)
+	}
+	if input.Status == "" {
+		input.Status = current.Status
+	}
+	if !requestTransitionAllowed(current.Status, input.Status) {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, fmt.Errorf("%w: request transition %q to %q is invalid", ErrInvalidRequest, current.Status, input.Status)
+	}
+	actor, err := required(actor, "created by")
+	if err != nil {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, err
+	}
+	createdAt = createdAt.UTC()
+	if createdAt.IsZero() {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, fmt.Errorf("%w: created at is required", ErrInvalidRequest)
+	}
+	revision, err := buildEvidenceRequestRevision(current.TenantID, current.EngagementID, current.ID, current.CurrentRevision+1, current.CurrentRevisionID, input, actor, createdAt)
+	if err != nil {
+		return EvidenceRequest{}, EvidenceRequestRevision{}, err
+	}
+	next := current
+	next.Version++
+	next.CurrentRevision++
+	next.CurrentRevisionID = revision.ID
+	next.Status = revision.Status
+	return next, revision, nil
+}
+
+// RecordEvidenceSubmission creates an immutable submission and moves the request
+// to submitted without changing the supplied request value.
+func RecordEvidenceSubmission(current EvidenceRequest, expectedVersion uint64, input EvidenceSubmissionInput, actor string, submittedAt time.Time) (EvidenceRequest, EvidenceSubmission, error) {
+	if current.Version != expectedVersion {
+		return EvidenceRequest{}, EvidenceSubmission{}, fmt.Errorf("%w: expected %d, current %d", ErrVersionConflict, expectedVersion, current.Version)
+	}
+	switch current.Status {
+	case EvidenceRequestStatusOpen, EvidenceRequestStatusInProgress, EvidenceRequestStatusChangesRequested:
+	default:
+		return EvidenceRequest{}, EvidenceSubmission{}, fmt.Errorf("%w: request in state %q cannot accept a submission", ErrInvalidRequest, current.Status)
+	}
+	actor, err := required(actor, "submitted by")
+	if err != nil {
+		return EvidenceRequest{}, EvidenceSubmission{}, err
+	}
+	submittedAt = submittedAt.UTC()
+	if submittedAt.IsZero() {
+		return EvidenceRequest{}, EvidenceSubmission{}, fmt.Errorf("%w: submitted at is required", ErrInvalidRequest)
+	}
+	input.ClaimIDs = normalizedStrings(input.ClaimIDs)
+	input.ArtifactVersionIDs = normalizedStrings(input.ArtifactVersionIDs)
+	input.PackageRevisionID = strings.TrimSpace(input.PackageRevisionID)
+	if len(input.ClaimIDs) == 0 && len(input.ArtifactVersionIDs) == 0 && input.PackageRevisionID == "" {
+		return EvidenceRequest{}, EvidenceSubmission{}, fmt.Errorf("%w: submission requires a claim, artifact version, or package revision", ErrInvalidRequest)
+	}
+	submission := EvidenceSubmission{
+		TenantID:           strings.TrimSpace(current.TenantID),
+		EngagementID:       strings.TrimSpace(current.EngagementID),
+		RequestID:          strings.TrimSpace(current.ID),
+		RequestVersion:     current.Version,
+		ClaimIDs:           input.ClaimIDs,
+		ArtifactVersionIDs: input.ArtifactVersionIDs,
+		PackageRevisionID:  input.PackageRevisionID,
+		Message:            strings.TrimSpace(input.Message),
+		SubmittedBy:        actor,
+		SubmittedAt:        submittedAt,
+	}
+	hash, err := canonicalDigest(submission)
+	if err != nil {
+		return EvidenceRequest{}, EvidenceSubmission{}, fmt.Errorf("hash evidence submission: %w", err)
+	}
+	submission.SubmissionHash = hash
+	submission.ID = digestID("audit-submission-", hash)
+	next := current
+	next.Version++
+	next.Status = EvidenceRequestStatusSubmitted
+	return next, submission, nil
+}
+
+// AuthorizeEvidenceRequestAccess verifies request and engagement object scope.
+func AuthorizeEvidenceRequestAccess(principal Principal, engagement Engagement, request EvidenceRequest, permission EngagementPermission) error {
+	if strings.TrimSpace(request.ID) == "" || request.TenantID != engagement.TenantID || request.EngagementID != engagement.ID {
+		return ErrEvidenceRequestNotFound
+	}
+	if err := AuthorizeEngagementAccess(principal, engagement, permission); err != nil {
+		return ErrEvidenceRequestNotFound
+	}
+	return nil
+}
+
+func buildEvidenceRequestRevision(tenantID, engagementID, requestID string, revisionNumber uint64, predecessorID string, input EvidenceRequestRevisionInput, actor string, createdAt time.Time) (EvidenceRequestRevision, error) {
+	objectiveID, err := required(input.ObjectiveID, "objective id")
+	if err != nil {
+		return EvidenceRequestRevision{}, err
+	}
+	requesterID, err := required(input.RequesterPrincipalID, "requester principal id")
+	if err != nil {
+		return EvidenceRequestRevision{}, err
+	}
+	ownerID, err := required(input.OwnerPrincipalID, "owner principal id")
+	if err != nil {
+		return EvidenceRequestRevision{}, err
+	}
+	periodStart := input.PeriodStart.UTC()
+	periodEnd := input.PeriodEnd.UTC()
+	if periodStart.IsZero() || periodEnd.IsZero() || periodEnd.Before(periodStart) {
+		return EvidenceRequestRevision{}, fmt.Errorf("%w: evidence request period is invalid", ErrInvalidRequest)
+	}
+	dueAt := input.DueAt.UTC()
+	if dueAt.IsZero() {
+		return EvidenceRequestRevision{}, fmt.Errorf("%w: due at is required", ErrInvalidRequest)
+	}
+	if !validEvidenceRequestStatus(input.Status) {
+		return EvidenceRequestRevision{}, fmt.Errorf("%w: evidence request status %q is invalid", ErrInvalidRequest, input.Status)
+	}
+	revision := EvidenceRequestRevision{
+		TenantID:             strings.TrimSpace(tenantID),
+		EngagementID:         strings.TrimSpace(engagementID),
+		RequestID:            strings.TrimSpace(requestID),
+		Revision:             revisionNumber,
+		PredecessorID:        strings.TrimSpace(predecessorID),
+		ObjectiveID:          objectiveID,
+		SubjectIDs:           normalizedStrings(input.SubjectIDs),
+		PeriodStart:          periodStart,
+		PeriodEnd:            periodEnd,
+		SampleRevisionID:     strings.TrimSpace(input.SampleRevisionID),
+		RequesterPrincipalID: requesterID,
+		OwnerPrincipalID:     ownerID,
+		DueAt:                dueAt,
+		ExpectedFormats:      normalizedStrings(input.ExpectedFormats),
+		Instructions:         strings.TrimSpace(input.Instructions),
+		Status:               input.Status,
+		ChangeSummary:        strings.TrimSpace(input.ChangeSummary),
+		CreatedBy:            actor,
+		CreatedAt:            createdAt,
+	}
+	hash, err := canonicalDigest(revision)
+	if err != nil {
+		return EvidenceRequestRevision{}, fmt.Errorf("hash evidence request revision: %w", err)
+	}
+	revision.RevisionHash = hash
+	revision.ID = digestID("audit-request-revision-", hash)
+	return revision, nil
+}
+
+func validEvidenceRequestStatus(status EvidenceRequestStatus) bool {
+	switch status {
+	case EvidenceRequestStatusOpen, EvidenceRequestStatusInProgress, EvidenceRequestStatusSubmitted, EvidenceRequestStatusChangesRequested, EvidenceRequestStatusAccepted, EvidenceRequestStatusRejected, EvidenceRequestStatusWithdrawn, EvidenceRequestStatusClosed:
+		return true
+	default:
+		return false
+	}
+}
+
+func requestTransitionAllowed(from, to EvidenceRequestStatus) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case EvidenceRequestStatusOpen:
+		return to == EvidenceRequestStatusInProgress || to == EvidenceRequestStatusWithdrawn || to == EvidenceRequestStatusClosed
+	case EvidenceRequestStatusInProgress:
+		return to == EvidenceRequestStatusSubmitted || to == EvidenceRequestStatusChangesRequested || to == EvidenceRequestStatusWithdrawn || to == EvidenceRequestStatusClosed
+	case EvidenceRequestStatusSubmitted:
+		return to == EvidenceRequestStatusAccepted || to == EvidenceRequestStatusRejected || to == EvidenceRequestStatusChangesRequested
+	case EvidenceRequestStatusChangesRequested:
+		return to == EvidenceRequestStatusInProgress || to == EvidenceRequestStatusSubmitted || to == EvidenceRequestStatusWithdrawn
+	case EvidenceRequestStatusAccepted, EvidenceRequestStatusRejected, EvidenceRequestStatusWithdrawn:
+		return to == EvidenceRequestStatusClosed
+	default:
+		return false
+	}
+}

--- a/internal/grcaudit/requests_test.go
+++ b/internal/grcaudit/requests_test.go
@@ -1,0 +1,79 @@
+package grcaudit
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEvidenceRequestSubmissionPreservesRevisionLineage(t *testing.T) {
+	createdAt := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	input := testEvidenceRequestRevisionInput(createdAt)
+	request, first, err := NewEvidenceRequest(CreateEvidenceRequestRequest{
+		ID:           "request-a",
+		TenantID:     "tenant-a",
+		EngagementID: "engagement-a",
+		Revision:     input,
+		CreatedBy:    "auditor-a",
+		CreatedAt:    createdAt,
+	})
+	if err != nil {
+		t.Fatalf("NewEvidenceRequest() error = %v", err)
+	}
+	updated, submission, err := RecordEvidenceSubmission(request, 1, EvidenceSubmissionInput{
+		ClaimIDs:           []string{"claim-b", "claim-a", "claim-a"},
+		ArtifactVersionIDs: []string{"artifact-r1"},
+		Message:            "Evidence for review.",
+	}, "owner-a", createdAt.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("RecordEvidenceSubmission() error = %v", err)
+	}
+	if request.Version != 1 || request.Status != EvidenceRequestStatusOpen {
+		t.Fatalf("original request mutated: %+v", request)
+	}
+	if updated.Version != 2 || updated.CurrentRevision != 1 || updated.CurrentRevisionID != first.ID || updated.Status != EvidenceRequestStatusSubmitted {
+		t.Fatalf("submitted request = %+v", updated)
+	}
+	if len(submission.ClaimIDs) != 2 || submission.ClaimIDs[0] != "claim-a" || submission.ClaimIDs[1] != "claim-b" || submission.SubmissionHash == "" {
+		t.Fatalf("submission = %+v", submission)
+	}
+	input.Status = EvidenceRequestStatusAccepted
+	input.ChangeSummary = "Accept submitted evidence."
+	accepted, second, err := ReviseEvidenceRequest(updated, 2, input, "auditor-a", createdAt.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("ReviseEvidenceRequest(accepted) error = %v", err)
+	}
+	if accepted.Version != 3 || accepted.CurrentRevision != 2 || second.Revision != 2 || second.PredecessorID != first.ID {
+		t.Fatalf("accepted request/revision = %+v / %+v", accepted, second)
+	}
+	if _, _, err := RecordEvidenceSubmission(accepted, 3, EvidenceSubmissionInput{ClaimIDs: []string{"claim-c"}}, "owner-a", createdAt.Add(3*time.Hour)); err == nil {
+		t.Fatal("RecordEvidenceSubmission(accepted) error = nil, want invalid state")
+	}
+}
+
+func TestAuthorizeEvidenceRequestAccessDeniesMismatchedEngagement(t *testing.T) {
+	engagement, _, err := NewEngagement(testCreateEngagementRequest())
+	if err != nil {
+		t.Fatalf("NewEngagement() error = %v", err)
+	}
+	request := EvidenceRequest{ID: "request-a", TenantID: "tenant-a", EngagementID: "engagement-b"}
+	err = AuthorizeEvidenceRequestAccess(Principal{TenantID: "tenant-a", ID: "auditor-a"}, engagement, request, EngagementPermissionRead)
+	if !errors.Is(err, ErrEvidenceRequestNotFound) {
+		t.Fatalf("AuthorizeEvidenceRequestAccess() error = %v, want ErrEvidenceRequestNotFound", err)
+	}
+}
+
+func testEvidenceRequestRevisionInput(start time.Time) EvidenceRequestRevisionInput {
+	return EvidenceRequestRevisionInput{
+		ObjectiveID:          "objective-a",
+		SubjectIDs:           []string{"subject-b", "subject-a"},
+		PeriodStart:          start,
+		PeriodEnd:            start.AddDate(0, 1, 0),
+		RequesterPrincipalID: "auditor-a",
+		OwnerPrincipalID:     "owner-a",
+		DueAt:                start.AddDate(0, 0, 14),
+		ExpectedFormats:      []string{"application/json"},
+		Instructions:         "Provide selected evidence claims.",
+		Status:               EvidenceRequestStatusOpen,
+	}
+}

--- a/internal/grcaudit/sampling.go
+++ b/internal/grcaudit/sampling.go
@@ -1,0 +1,182 @@
+package grcaudit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// SampleAlgorithmHashRankedV1 is a deterministic, without-replacement sampling algorithm.
+const SampleAlgorithmHashRankedV1 = "hash_ranked_v1"
+
+// PopulationSnapshot is an immutable population used for audit sample refinement.
+type PopulationSnapshot struct {
+	ID         string   `json:"id"`
+	SubjectIDs []string `json:"subject_ids"`
+	Digest     string   `json:"digest"`
+}
+
+// SampleRevision is one immutable auditor-selected sample revision.
+type SampleRevision struct {
+	ID                 string    `json:"id"`
+	TenantID           string    `json:"tenant_id"`
+	EngagementID       string    `json:"engagement_id"`
+	EvidenceRequestID  string    `json:"evidence_request_id"`
+	Revision           uint64    `json:"revision"`
+	PredecessorID      string    `json:"predecessor_id,omitempty"`
+	PopulationID       string    `json:"population_id"`
+	PopulationDigest   string    `json:"population_digest"`
+	Algorithm          string    `json:"algorithm"`
+	Seed               string    `json:"seed"`
+	RequestedSize      uint32    `json:"requested_size"`
+	SelectedSubjectIDs []string  `json:"selected_subject_ids"`
+	SelectionDigest    string    `json:"selection_digest"`
+	CreatedBy          string    `json:"created_by"`
+	CreatedAt          time.Time `json:"created_at"`
+	RevisionHash       string    `json:"revision_hash"`
+}
+
+// SampleRefinementRequest creates a new immutable sample without modifying its population.
+type SampleRefinementRequest struct {
+	TenantID          string
+	EngagementID      string
+	EvidenceRequestID string
+	Population        PopulationSnapshot
+	Seed              string
+	Size              uint32
+	Predecessor       *SampleRevision
+	CreatedBy         string
+	CreatedAt         time.Time
+}
+
+// NormalizePopulation canonicalizes one population and verifies a supplied digest.
+func NormalizePopulation(population PopulationSnapshot) (PopulationSnapshot, error) {
+	id, err := required(population.ID, "population id")
+	if err != nil {
+		return PopulationSnapshot{}, err
+	}
+	subjects := normalizedStrings(population.SubjectIDs)
+	if len(subjects) == 0 {
+		return PopulationSnapshot{}, fmt.Errorf("%w: population subjects are required", ErrInvalidRequest)
+	}
+	digest, err := canonicalDigest(struct {
+		ID         string   `json:"id"`
+		SubjectIDs []string `json:"subject_ids"`
+	}{ID: id, SubjectIDs: subjects})
+	if err != nil {
+		return PopulationSnapshot{}, fmt.Errorf("hash population: %w", err)
+	}
+	if supplied := strings.TrimSpace(population.Digest); supplied != "" && supplied != digest {
+		return PopulationSnapshot{}, fmt.Errorf("%w: population digest does not match subjects", ErrInvalidRequest)
+	}
+	return PopulationSnapshot{ID: id, SubjectIDs: subjects, Digest: digest}, nil
+}
+
+// RefineSample selects a reproducible sample by ranking each normalized subject
+// with SHA-256 over algorithm, seed, and subject identity.
+func RefineSample(request SampleRefinementRequest) (SampleRevision, error) {
+	tenantID, err := required(request.TenantID, "tenant id")
+	if err != nil {
+		return SampleRevision{}, err
+	}
+	engagementID, err := required(request.EngagementID, "engagement id")
+	if err != nil {
+		return SampleRevision{}, err
+	}
+	evidenceRequestID, err := required(request.EvidenceRequestID, "evidence request id")
+	if err != nil {
+		return SampleRevision{}, err
+	}
+	seed, err := required(request.Seed, "sample seed")
+	if err != nil {
+		return SampleRevision{}, err
+	}
+	actor, err := required(request.CreatedBy, "created by")
+	if err != nil {
+		return SampleRevision{}, err
+	}
+	createdAt := request.CreatedAt.UTC()
+	if createdAt.IsZero() {
+		return SampleRevision{}, fmt.Errorf("%w: created at is required", ErrInvalidRequest)
+	}
+	population, err := NormalizePopulation(request.Population)
+	if err != nil {
+		return SampleRevision{}, err
+	}
+	if request.Size == 0 || uint64(request.Size) > uint64(len(population.SubjectIDs)) {
+		return SampleRevision{}, fmt.Errorf("%w: sample size must be between 1 and population size", ErrInvalidRequest)
+	}
+	revisionNumber := uint64(1)
+	predecessorID := ""
+	if request.Predecessor != nil {
+		previous := request.Predecessor
+		if strings.TrimSpace(previous.ID) == "" || previous.Revision == 0 {
+			return SampleRevision{}, fmt.Errorf("%w: sample predecessor identity is invalid", ErrInvalidRequest)
+		}
+		if previous.TenantID != tenantID || previous.EngagementID != engagementID || previous.EvidenceRequestID != evidenceRequestID || previous.PopulationID != population.ID || previous.PopulationDigest != population.Digest {
+			return SampleRevision{}, fmt.Errorf("%w: sample predecessor scope does not match", ErrInvalidRequest)
+		}
+		revisionNumber = previous.Revision + 1
+		predecessorID = previous.ID
+	}
+	selected := hashRankedSubjects(population.SubjectIDs, seed, int(request.Size))
+	selectionDigest, err := canonicalDigest(struct {
+		PopulationDigest string   `json:"population_digest"`
+		Algorithm        string   `json:"algorithm"`
+		Seed             string   `json:"seed"`
+		Subjects         []string `json:"subjects"`
+	}{PopulationDigest: population.Digest, Algorithm: SampleAlgorithmHashRankedV1, Seed: seed, Subjects: selected})
+	if err != nil {
+		return SampleRevision{}, fmt.Errorf("hash sample selection: %w", err)
+	}
+	revision := SampleRevision{
+		TenantID:           tenantID,
+		EngagementID:       engagementID,
+		EvidenceRequestID:  evidenceRequestID,
+		Revision:           revisionNumber,
+		PredecessorID:      predecessorID,
+		PopulationID:       population.ID,
+		PopulationDigest:   population.Digest,
+		Algorithm:          SampleAlgorithmHashRankedV1,
+		Seed:               seed,
+		RequestedSize:      request.Size,
+		SelectedSubjectIDs: selected,
+		SelectionDigest:    selectionDigest,
+		CreatedBy:          actor,
+		CreatedAt:          createdAt,
+	}
+	revisionHash, err := canonicalDigest(revision)
+	if err != nil {
+		return SampleRevision{}, fmt.Errorf("hash sample revision: %w", err)
+	}
+	revision.RevisionHash = revisionHash
+	revision.ID = digestID("audit-sample-revision-", revisionHash)
+	return revision, nil
+}
+
+type rankedSubject struct {
+	id   string
+	rank string
+}
+
+func hashRankedSubjects(subjectIDs []string, seed string, size int) []string {
+	ranked := make([]rankedSubject, 0, len(subjectIDs))
+	for _, subjectID := range subjectIDs {
+		sum := sha256.Sum256([]byte(strings.Join([]string{SampleAlgorithmHashRankedV1, seed, subjectID}, "\x00")))
+		ranked = append(ranked, rankedSubject{id: subjectID, rank: hex.EncodeToString(sum[:])})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].rank != ranked[j].rank {
+			return ranked[i].rank < ranked[j].rank
+		}
+		return ranked[i].id < ranked[j].id
+	})
+	selected := make([]string, 0, size)
+	for _, item := range ranked[:size] {
+		selected = append(selected, item.id)
+	}
+	return selected
+}

--- a/internal/grcaudit/sampling_test.go
+++ b/internal/grcaudit/sampling_test.go
@@ -1,0 +1,85 @@
+package grcaudit
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRefineSampleIsDeterministicAcrossPopulationOrder(t *testing.T) {
+	createdAt := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	base := SampleRefinementRequest{
+		TenantID:          "tenant-a",
+		EngagementID:      "engagement-a",
+		EvidenceRequestID: "request-a",
+		Population:        PopulationSnapshot{ID: "population-a", SubjectIDs: []string{"subject-c", "subject-a", "subject-b", "subject-d", "subject-a"}},
+		Seed:              "auditor-seed-a",
+		Size:              3,
+		CreatedBy:         "auditor-a",
+		CreatedAt:         createdAt,
+	}
+	first, err := RefineSample(base)
+	if err != nil {
+		t.Fatalf("RefineSample(first) error = %v", err)
+	}
+	base.Population.SubjectIDs = []string{"subject-d", "subject-b", "subject-c", "subject-a"}
+	second, err := RefineSample(base)
+	if err != nil {
+		t.Fatalf("RefineSample(second) error = %v", err)
+	}
+	if first.ID != second.ID || first.RevisionHash != second.RevisionHash || first.SelectionDigest != second.SelectionDigest || !reflect.DeepEqual(first.SelectedSubjectIDs, second.SelectedSubjectIDs) {
+		t.Fatalf("deterministic samples differ:\nfirst=%+v\nsecond=%+v", first, second)
+	}
+	if len(first.SelectedSubjectIDs) != 3 {
+		t.Fatalf("selected subjects = %#v, want three", first.SelectedSubjectIDs)
+	}
+	if len(first.PopulationDigest) == 0 || first.Algorithm != SampleAlgorithmHashRankedV1 {
+		t.Fatalf("sample contract = %+v", first)
+	}
+}
+
+func TestRefineSampleRejectsInvalidPredecessorIdentity(t *testing.T) {
+	request := SampleRefinementRequest{
+		TenantID:          "tenant-a",
+		EngagementID:      "engagement-a",
+		EvidenceRequestID: "request-a",
+		Population:        PopulationSnapshot{ID: "population-a", SubjectIDs: []string{"subject-a"}},
+		Seed:              "seed-a",
+		Size:              1,
+		Predecessor:       &SampleRevision{TenantID: "tenant-a", EngagementID: "engagement-a", EvidenceRequestID: "request-a", PopulationID: "population-a"},
+		CreatedBy:         "auditor-a",
+		CreatedAt:         time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if _, err := RefineSample(request); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("RefineSample() error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestRefineSampleCreatesPredecessorLinkedRevision(t *testing.T) {
+	createdAt := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	request := SampleRefinementRequest{
+		TenantID:          "tenant-a",
+		EngagementID:      "engagement-a",
+		EvidenceRequestID: "request-a",
+		Population:        PopulationSnapshot{ID: "population-a", SubjectIDs: []string{"subject-a", "subject-b", "subject-c"}},
+		Seed:              "seed-a",
+		Size:              2,
+		CreatedBy:         "auditor-a",
+		CreatedAt:         createdAt,
+	}
+	first, err := RefineSample(request)
+	if err != nil {
+		t.Fatalf("RefineSample(first) error = %v", err)
+	}
+	request.Predecessor = &first
+	request.Seed = "seed-b"
+	request.CreatedAt = createdAt.Add(time.Hour)
+	second, err := RefineSample(request)
+	if err != nil {
+		t.Fatalf("RefineSample(second) error = %v", err)
+	}
+	if second.Revision != 2 || second.PredecessorID != first.ID || second.SelectionDigest == first.SelectionDigest {
+		t.Fatalf("sample revision lineage = first %+v second %+v", first, second)
+	}
+}

--- a/internal/grcaudit/types.go
+++ b/internal/grcaudit/types.go
@@ -1,0 +1,74 @@
+// Package grcaudit defines the transport- and storage-independent contracts for
+// audit engagements, requests, samples, and immutable package manifests.
+package grcaudit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var (
+	// ErrInvalidRequest indicates that an audit-domain command is malformed.
+	ErrInvalidRequest = errors.New("invalid audit request")
+	// ErrVersionConflict indicates that an optimistic concurrency precondition failed.
+	ErrVersionConflict = errors.New("audit aggregate version conflict")
+	// ErrEngagementNotFound is deliberately non-disclosing for missing or inaccessible engagements.
+	ErrEngagementNotFound = errors.New("audit engagement not found")
+	// ErrEvidenceRequestNotFound is deliberately non-disclosing for missing or inaccessible requests.
+	ErrEvidenceRequestNotFound = errors.New("audit evidence request not found")
+	// ErrPackageNotFound is deliberately non-disclosing for missing or inaccessible packages.
+	ErrPackageNotFound = errors.New("audit package not found")
+)
+
+func canonicalDigest(value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return DigestBytes(payload), nil
+}
+
+// DigestBytes returns a lowercase SHA-256 digest with an explicit algorithm prefix.
+func DigestBytes(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func digestID(prefix, digest string) string {
+	digest = strings.TrimPrefix(strings.TrimSpace(digest), "sha256:")
+	if len(digest) > 20 {
+		digest = digest[:20]
+	}
+	return strings.TrimSpace(prefix) + digest
+}
+
+func normalizedStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func required(value, field string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%w: %s is required", ErrInvalidRequest, field)
+	}
+	return value, nil
+}


### PR DESCRIPTION
## Summary

- add immutable audit engagement revisions with participant-scoped access decisions
- add versioned evidence requests, submissions, and explicit acceptance state
- add deterministic auditor sample refinement with predecessor lineage
- add deterministic package manifests covering redaction, provenance, predecessor, and every entry digest
- add explicit artifact and signing capability boundaries plus delivery receipt validation

## Dependency

This audit-domain core is stacked on the compliance correctness foundation. Persistence, workflow projection, and typed transports arrive in their owning slices.

## Exit criteria

- an auditor can read only engagements where they are an active participant
- removing a participant immediately removes object-scope access without disclosing foreign objects
- request, sample, and package revisions are immutable and retain predecessor lineage
- rebuilding the same package manifest produces identical semantic content and digest
- missing artifact or signing capability fails closed without claiming delivery

## Validation

- focused audit tests
- audit race tests
- audit package lint
- architecture and diff checks