### PR TITLE
Add immutable evidence ledger core

### DIFF
--- a/internal/compliance/identifiers.go
+++ b/internal/compliance/identifiers.go
@@ -1,0 +1,138 @@
+package compliance
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrInvalidIdentifier = errors.New("invalid compliance identifier")
+
+// IdentifierKind names the stable public prefix for one compliance resource.
+type IdentifierKind string
+
+const (
+	IdentifierProgram        IdentifierKind = "program"
+	IdentifierScope          IdentifierKind = "scope"
+	IdentifierImplementation IdentifierKind = "implementation"
+	IdentifierPlan           IdentifierKind = "assessment-plan"
+	IdentifierTest           IdentifierKind = "assessment-test"
+	IdentifierEvidence       IdentifierKind = "evidence"
+	IdentifierClaim          IdentifierKind = "evidence-claim"
+	IdentifierRun            IdentifierKind = "assessment-run"
+	IdentifierResult         IdentifierKind = "assessment-result"
+	IdentifierReview         IdentifierKind = "assessment-review"
+	IdentifierArtifact       IdentifierKind = "artifact"
+	IdentifierMapping        IdentifierKind = "control-mapping"
+)
+
+const identifierEntropyBytes = 16
+
+// NewIdentifier returns an opaque identifier with a resource-specific prefix.
+func NewIdentifier(kind IdentifierKind) (string, error) {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return "", err
+	}
+	random := make([]byte, identifierEntropyBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate compliance identifier: %w", err)
+	}
+	return string(kind) + "-" + hex.EncodeToString(random), nil
+}
+
+// NewRevisionIdentifier returns an opaque identity for an immutable revision.
+func NewRevisionIdentifier(kind IdentifierKind) (string, error) {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return "", err
+	}
+	random := make([]byte, identifierEntropyBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate compliance revision identifier: %w", err)
+	}
+	return string(kind) + "-revision-" + hex.EncodeToString(random), nil
+}
+
+func ValidateIdentifierKind(kind IdentifierKind) error {
+	value := string(kind)
+	if value == "" || len(value) > 40 || !identifierToken(value) {
+		return fmt.Errorf("%w: kind %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+// ValidateIdentifier rejects display names, whitespace, path separators, and
+// tenant data in public identifiers. IDs remain opaque and tenant scoping is
+// enforced separately by every store lookup.
+func ValidateIdentifier(kind IdentifierKind, value string) error {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return err
+	}
+	raw := value
+	value = strings.TrimSpace(value)
+	if value != raw {
+		return fmt.Errorf("%w: identifier contains surrounding whitespace", ErrInvalidIdentifier)
+	}
+	prefix := string(kind) + "-"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+(identifierEntropyBytes*2) {
+		return fmt.Errorf("%w: expected %s prefix", ErrInvalidIdentifier, prefix)
+	}
+	if !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+// ValidateRevisionIdentifier checks an immutable revision identity separately
+// from the logical record identity.
+func ValidateRevisionIdentifier(kind IdentifierKind, value string) error {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return err
+	}
+	raw := value
+	value = strings.TrimSpace(value)
+	if value != raw {
+		return fmt.Errorf("%w: revision identifier contains surrounding whitespace", ErrInvalidIdentifier)
+	}
+	prefix := string(kind) + "-revision-"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+(identifierEntropyBytes*2) {
+		return fmt.Errorf("%w: expected %s prefix", ErrInvalidIdentifier, prefix)
+	}
+	if !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+func identifierToken(value string) bool {
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') || character == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func lowerHex(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, character := range value {
+		if (character >= 'a' && character <= 'f') || (character >= '0' && character <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func ValidateContentDigest(digest ContentDigest) error {
+	value := string(digest)
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+64 || !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: invalid content digest", ErrInvalidRevision)
+	}
+	return nil
+}

--- a/internal/compliance/identifiers_test.go
+++ b/internal/compliance/identifiers_test.go
@@ -1,0 +1,59 @@
+package compliance
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestOpaqueLogicalAndRevisionIdentifiersValidateSeparately(t *testing.T) {
+	logical, err := NewIdentifier(IdentifierProgram)
+	if err != nil {
+		t.Fatalf("NewIdentifier() error = %v", err)
+	}
+	revision, err := NewRevisionIdentifier(IdentifierProgram)
+	if err != nil {
+		t.Fatalf("NewRevisionIdentifier() error = %v", err)
+	}
+	if err := ValidateIdentifier(IdentifierProgram, logical); err != nil {
+		t.Fatalf("ValidateIdentifier() error = %v", err)
+	}
+	if err := ValidateRevisionIdentifier(IdentifierProgram, revision); err != nil {
+		t.Fatalf("ValidateRevisionIdentifier() error = %v", err)
+	}
+	if logical == revision || strings.Contains(logical, "revision") {
+		t.Fatalf("logical=%q revision=%q are not distinct", logical, revision)
+	}
+	if err := ValidateIdentifier(IdentifierProgram, revision); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateIdentifier(revision) error = %v, want ErrInvalidIdentifier", err)
+	}
+	if err := ValidateRevisionIdentifier(IdentifierProgram, logical); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateRevisionIdentifier(logical) error = %v, want ErrInvalidIdentifier", err)
+	}
+}
+
+func TestValidateIdentifierRejectsLossyAndNonOpaqueValues(t *testing.T) {
+	for _, value := range []string{
+		"program-customer/name",
+		"program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-",
+		"program-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-extra",
+		" program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	} {
+		if err := ValidateIdentifier(IdentifierProgram, value); !errors.Is(err, ErrInvalidIdentifier) {
+			t.Fatalf("ValidateIdentifier(%q) error = %v, want ErrInvalidIdentifier", value, err)
+		}
+	}
+}
+
+func TestValidateContentDigestRequiresCanonicalSHA256(t *testing.T) {
+	valid := ContentDigest("sha256:" + strings.Repeat("a", 64))
+	if err := ValidateContentDigest(valid); err != nil {
+		t.Fatalf("ValidateContentDigest() error = %v", err)
+	}
+	for _, value := range []ContentDigest{"", "sha256:abc", ContentDigest("SHA256:" + strings.Repeat("a", 64)), ContentDigest("sha256:" + strings.Repeat("A", 64))} {
+		if err := ValidateContentDigest(value); !errors.Is(err, ErrInvalidRevision) {
+			t.Fatalf("ValidateContentDigest(%q) error = %v, want ErrInvalidRevision", value, err)
+		}
+	}
+}

--- a/internal/compliance/mappings.go
+++ b/internal/compliance/mappings.go
@@ -1,0 +1,146 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var ErrInvalidMapping = errors.New("invalid compliance mapping")
+
+type MappingRelationship string
+
+const (
+	MappingEquivalent MappingRelationship = "equivalent"
+	MappingSubset     MappingRelationship = "subset"
+	MappingSuperset   MappingRelationship = "superset"
+	MappingOverlap    MappingRelationship = "overlap"
+	MappingNone       MappingRelationship = "none"
+)
+
+type MappingDecisionState string
+
+const (
+	MappingProposed MappingDecisionState = "proposed"
+	MappingApproved MappingDecisionState = "approved"
+	MappingRejected MappingDecisionState = "rejected"
+	MappingRetired  MappingDecisionState = "retired"
+)
+
+// ControlMapping records an explicit, reviewable relationship between exact
+// source and target revisions. It never grants coverage by implication.
+type ControlMapping struct {
+	ID                  string               `json:"id"`
+	RevisionID          string               `json:"revision_id"`
+	Source              RevisionRef          `json:"source"`
+	Target              RevisionRef          `json:"target"`
+	Granularity         string               `json:"granularity"`
+	Relationship        MappingRelationship  `json:"relationship"`
+	Method              string               `json:"method"`
+	Rationale           string               `json:"rationale"`
+	CoverageBasisPoints uint16               `json:"coverage_basis_points"`
+	Gaps                []string             `json:"gaps,omitempty"`
+	Provenance          []SubjectRef         `json:"provenance,omitempty"`
+	DecisionState       MappingDecisionState `json:"decision_state"`
+	AuthorID            string               `json:"author_id"`
+	ReviewerID          string               `json:"reviewer_id,omitempty"`
+}
+
+func (mapping ControlMapping) Validate() error {
+	if strings.TrimSpace(mapping.ID) == "" || strings.TrimSpace(mapping.RevisionID) == "" {
+		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidMapping)
+	}
+	if err := mapping.Source.Validate(); err != nil {
+		return fmt.Errorf("%w: source: %v", ErrInvalidMapping, err)
+	}
+	if err := mapping.Target.Validate(); err != nil {
+		return fmt.Errorf("%w: target: %v", ErrInvalidMapping, err)
+	}
+	if mapping.Source.ID == mapping.Target.ID && mapping.Source.RevisionID == mapping.Target.RevisionID {
+		return fmt.Errorf("%w: source and target must differ", ErrInvalidMapping)
+	}
+	switch mapping.Relationship {
+	case MappingEquivalent, MappingSubset, MappingSuperset, MappingOverlap, MappingNone:
+	default:
+		return fmt.Errorf("%w: relationship %q", ErrInvalidMapping, mapping.Relationship)
+	}
+	switch mapping.DecisionState {
+	case MappingProposed, MappingApproved, MappingRejected, MappingRetired:
+	default:
+		return fmt.Errorf("%w: decision_state %q", ErrInvalidMapping, mapping.DecisionState)
+	}
+	if mapping.CoverageBasisPoints > 10000 {
+		return fmt.Errorf("%w: coverage_basis_points exceeds 10000", ErrInvalidMapping)
+	}
+	if mapping.Relationship == MappingNone && mapping.CoverageBasisPoints != 0 {
+		return fmt.Errorf("%w: none relationship must have zero coverage", ErrInvalidMapping)
+	}
+	if mapping.Relationship == MappingEquivalent && mapping.CoverageBasisPoints != 10000 {
+		return fmt.Errorf("%w: equivalent relationship must have full coverage", ErrInvalidMapping)
+	}
+	if strings.TrimSpace(mapping.Granularity) == "" || strings.TrimSpace(mapping.Method) == "" || strings.TrimSpace(mapping.Rationale) == "" || strings.TrimSpace(mapping.AuthorID) == "" {
+		return fmt.Errorf("%w: granularity, method, rationale, and author_id are required", ErrInvalidMapping)
+	}
+	if mapping.DecisionState != MappingProposed && strings.TrimSpace(mapping.ReviewerID) == "" {
+		return fmt.Errorf("%w: reviewer_id is required for decided mappings", ErrInvalidMapping)
+	}
+	for index, reference := range mapping.Provenance {
+		if err := reference.Validate(); err != nil {
+			return fmt.Errorf("%w: provenance[%d]: %v", ErrInvalidMapping, index, err)
+		}
+	}
+	return nil
+}
+
+func NormalizeControlMapping(mapping ControlMapping) ControlMapping {
+	mapping.ID = strings.TrimSpace(mapping.ID)
+	mapping.RevisionID = strings.TrimSpace(mapping.RevisionID)
+	mapping.Granularity = strings.TrimSpace(mapping.Granularity)
+	mapping.Method = strings.TrimSpace(mapping.Method)
+	mapping.Rationale = strings.TrimSpace(mapping.Rationale)
+	mapping.AuthorID = strings.TrimSpace(mapping.AuthorID)
+	mapping.ReviewerID = strings.TrimSpace(mapping.ReviewerID)
+	mapping.Source = NormalizeRevisionRef(mapping.Source)
+	mapping.Target = NormalizeRevisionRef(mapping.Target)
+	mapping.Gaps = normalizedSortedStrings(mapping.Gaps)
+	mapping.Provenance = append([]SubjectRef(nil), mapping.Provenance...)
+	for index := range mapping.Provenance {
+		mapping.Provenance[index].Type = strings.TrimSpace(mapping.Provenance[index].Type)
+		mapping.Provenance[index].ID = strings.TrimSpace(mapping.Provenance[index].ID)
+	}
+	sort.Slice(mapping.Provenance, func(i, j int) bool {
+		return mapping.Provenance[i].Type+"\x00"+mapping.Provenance[i].ID < mapping.Provenance[j].Type+"\x00"+mapping.Provenance[j].ID
+	})
+	mapping.Provenance = deduplicateSubjectRefs(mapping.Provenance)
+	return mapping
+}
+
+func deduplicateSubjectRefs(values []SubjectRef) []SubjectRef {
+	result := make([]SubjectRef, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1] == value {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizedSortedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}

--- a/internal/compliance/mappings.go
+++ b/internal/compliance/mappings.go
@@ -52,10 +52,10 @@ func (mapping ControlMapping) Validate() error {
 		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidMapping)
 	}
 	if err := mapping.Source.Validate(); err != nil {
-		return fmt.Errorf("%w: source: %v", ErrInvalidMapping, err)
+		return fmt.Errorf("%w: source: %w", ErrInvalidMapping, err)
 	}
 	if err := mapping.Target.Validate(); err != nil {
-		return fmt.Errorf("%w: target: %v", ErrInvalidMapping, err)
+		return fmt.Errorf("%w: target: %w", ErrInvalidMapping, err)
 	}
 	if mapping.Source.ID == mapping.Target.ID && mapping.Source.RevisionID == mapping.Target.RevisionID {
 		return fmt.Errorf("%w: source and target must differ", ErrInvalidMapping)
@@ -87,7 +87,7 @@ func (mapping ControlMapping) Validate() error {
 	}
 	for index, reference := range mapping.Provenance {
 		if err := reference.Validate(); err != nil {
-			return fmt.Errorf("%w: provenance[%d]: %v", ErrInvalidMapping, index, err)
+			return fmt.Errorf("%w: provenance[%d]: %w", ErrInvalidMapping, index, err)
 		}
 	}
 	return nil

--- a/internal/compliance/mappings_test.go
+++ b/internal/compliance/mappings_test.go
@@ -1,0 +1,69 @@
+package compliance
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeControlMappingIsDeterministicWithoutMutatingCaller(t *testing.T) {
+	digest := ContentDigest("sha256:" + strings.Repeat("b", 64))
+	mapping := ControlMapping{
+		ID: " mapping ", RevisionID: " revision ", Granularity: " statement ",
+		Source:       RevisionRef{ID: "source", RevisionID: "source-r1", Version: 1, ContentDigest: digest, LastModified: time.Unix(1, 0)},
+		Target:       RevisionRef{ID: "target", RevisionID: "target-r1", Version: 1, ContentDigest: digest, LastModified: time.Unix(1, 0)},
+		Relationship: MappingOverlap, Method: " manual ", Rationale: " scoped overlap ", CoverageBasisPoints: 7500,
+		Gaps:          []string{" gap-b ", "gap-a", "gap-a"},
+		Provenance:    []SubjectRef{{Type: " source ", ID: "b"}, {Type: "source", ID: "a"}, {Type: "source", ID: "a"}},
+		DecisionState: MappingApproved, AuthorID: " author ", ReviewerID: " reviewer ",
+	}
+	normalized := NormalizeControlMapping(mapping)
+	if got := strings.Join(normalized.Gaps, ","); got != "gap-a,gap-b" {
+		t.Fatalf("normalized gaps = %q", got)
+	}
+	if len(normalized.Provenance) != 2 || normalized.Provenance[0].ID != "a" || normalized.Provenance[1].ID != "b" {
+		t.Fatalf("normalized provenance = %#v", normalized.Provenance)
+	}
+	if mapping.Provenance[0].Type != " source " {
+		t.Fatal("NormalizeControlMapping mutated caller provenance")
+	}
+	if normalized.Source.LastModified.Nanosecond()%int(time.Millisecond) != 0 {
+		t.Fatalf("source revision time was not normalized: %s", normalized.Source.LastModified)
+	}
+	if err := normalized.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestControlMappingRelationshipCoverageInvariants(t *testing.T) {
+	base := validControlMapping()
+	base.Relationship = MappingNone
+	base.CoverageBasisPoints = 1
+	if err := base.Validate(); err == nil {
+		t.Fatal("none relationship with coverage was accepted")
+	}
+	base = validControlMapping()
+	base.Relationship = MappingEquivalent
+	base.CoverageBasisPoints = 9999
+	if err := base.Validate(); err == nil {
+		t.Fatal("equivalent relationship without full coverage was accepted")
+	}
+	base = validControlMapping()
+	base.DecisionState = MappingApproved
+	base.ReviewerID = ""
+	if err := base.Validate(); err == nil {
+		t.Fatal("decided mapping without reviewer was accepted")
+	}
+}
+
+func validControlMapping() ControlMapping {
+	digest := ContentDigest("sha256:" + strings.Repeat("c", 64))
+	modified := time.Unix(1, 123456789).UTC()
+	return ControlMapping{
+		ID: "mapping", RevisionID: "mapping-r1", Granularity: "objective",
+		Source:       RevisionRef{ID: "source", RevisionID: "source-r1", Version: 1, ContentDigest: digest, LastModified: modified},
+		Target:       RevisionRef{ID: "target", RevisionID: "target-r1", Version: 1, ContentDigest: digest, LastModified: modified},
+		Relationship: MappingOverlap, Method: "manual", Rationale: "overlap", CoverageBasisPoints: 5000,
+		DecisionState: MappingProposed, AuthorID: "author",
+	}
+}

--- a/internal/compliance/types.go
+++ b/internal/compliance/types.go
@@ -1,0 +1,111 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var ErrInvalidRevision = errors.New("invalid compliance revision")
+
+// ContentDigest is the lowercase SHA-256 digest of normalized semantic content.
+// It deliberately remains separate from revision identity: two tenants may
+// create different revisions with the same semantic content.
+type ContentDigest string
+
+// VersionMetadata describes one immutable revision of a stable logical record.
+type VersionMetadata struct {
+	ID            string        `json:"id"`
+	RevisionID    string        `json:"revision_id"`
+	Version       uint64        `json:"version"`
+	LastModified  time.Time     `json:"last_modified"`
+	ContentDigest ContentDigest `json:"content_digest"`
+	CreatedBy     string        `json:"created_by"`
+	PredecessorID string        `json:"predecessor_id,omitempty"`
+	SuccessorID   string        `json:"successor_id,omitempty"`
+}
+
+// RevisionRef identifies one immutable revision of a stable compliance subject.
+// ContentDigest covers normalized semantic content, not database metadata.
+type RevisionRef struct {
+	ID            string        `json:"id"`
+	RevisionID    string        `json:"revision_id"`
+	Version       uint64        `json:"version"`
+	ContentDigest ContentDigest `json:"content_digest"`
+	LastModified  time.Time     `json:"last_modified"`
+}
+
+// SubjectRef identifies a tenant-scoped subject without copying its lifecycle.
+type SubjectRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+func NormalizeVersionMetadata(value VersionMetadata) VersionMetadata {
+	value.ID = strings.TrimSpace(value.ID)
+	value.RevisionID = strings.TrimSpace(value.RevisionID)
+	value.LastModified = CanonicalRevisionTime(value.LastModified)
+	value.ContentDigest = ContentDigest(strings.TrimSpace(string(value.ContentDigest)))
+	value.CreatedBy = strings.TrimSpace(value.CreatedBy)
+	value.PredecessorID = strings.TrimSpace(value.PredecessorID)
+	value.SuccessorID = strings.TrimSpace(value.SuccessorID)
+	return value
+}
+
+func NormalizeRevisionRef(value RevisionRef) RevisionRef {
+	value.ID = strings.TrimSpace(value.ID)
+	value.RevisionID = strings.TrimSpace(value.RevisionID)
+	value.ContentDigest = ContentDigest(strings.TrimSpace(string(value.ContentDigest)))
+	value.LastModified = CanonicalRevisionTime(value.LastModified)
+	return value
+}
+
+// CanonicalRevisionTime uses the precision shared by event envelopes and
+// canonical assessment hashes.
+func CanonicalRevisionTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Time{}
+	}
+	return value.UTC().Truncate(time.Millisecond)
+}
+
+func (metadata VersionMetadata) Validate() error {
+	metadata = NormalizeVersionMetadata(metadata)
+	if metadata.ID == "" || metadata.RevisionID == "" || metadata.CreatedBy == "" {
+		return fmt.Errorf("%w: id, revision_id, and created_by are required", ErrInvalidRevision)
+	}
+	if metadata.Version == 0 || metadata.LastModified.IsZero() {
+		return fmt.Errorf("%w: version and last_modified are required", ErrInvalidRevision)
+	}
+	if err := ValidateContentDigest(metadata.ContentDigest); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+	}
+	return nil
+}
+
+// Validate checks the required, transport-independent revision invariants.
+// Resource-specific identifier validation remains with the owning service.
+func (revision RevisionRef) Validate() error {
+	revision = NormalizeRevisionRef(revision)
+	if strings.TrimSpace(revision.ID) == "" || strings.TrimSpace(revision.RevisionID) == "" {
+		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidRevision)
+	}
+	if revision.Version == 0 {
+		return fmt.Errorf("%w: version must be greater than zero", ErrInvalidRevision)
+	}
+	if err := ValidateContentDigest(revision.ContentDigest); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+	}
+	if revision.LastModified.IsZero() {
+		return fmt.Errorf("%w: last_modified is required", ErrInvalidRevision)
+	}
+	return nil
+}
+
+func (reference SubjectRef) Validate() error {
+	if strings.TrimSpace(reference.Type) == "" || strings.TrimSpace(reference.ID) == "" {
+		return fmt.Errorf("%w: subject type and id are required", ErrInvalidRevision)
+	}
+	return nil
+}

--- a/internal/compliance/types.go
+++ b/internal/compliance/types.go
@@ -79,7 +79,7 @@ func (metadata VersionMetadata) Validate() error {
 		return fmt.Errorf("%w: version and last_modified are required", ErrInvalidRevision)
 	}
 	if err := ValidateContentDigest(metadata.ContentDigest); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+		return fmt.Errorf("%w: %w", ErrInvalidRevision, err)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func (revision RevisionRef) Validate() error {
 		return fmt.Errorf("%w: version must be greater than zero", ErrInvalidRevision)
 	}
 	if err := ValidateContentDigest(revision.ContentDigest); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+		return fmt.Errorf("%w: %w", ErrInvalidRevision, err)
 	}
 	if revision.LastModified.IsZero() {
 		return fmt.Errorf("%w: last_modified is required", ErrInvalidRevision)

--- a/internal/complianceassessment/conformance_test.go
+++ b/internal/complianceassessment/conformance_test.go
@@ -1,0 +1,223 @@
+package complianceassessment
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+type conformanceFixture struct {
+	Version      string          `json:"version"`
+	BaseInput    json.RawMessage `json:"base_input"`
+	BaseExpected json.RawMessage `json:"base_expected"`
+	Cases        []fixtureCase   `json:"cases"`
+}
+
+type fixtureCase struct {
+	Name           string          `json:"name"`
+	Input          json.RawMessage `json:"input"`
+	Expected       json.RawMessage `json:"expected"`
+	ExpectedDigest string          `json:"expected_digest"`
+}
+
+type fixtureExpected struct {
+	ScopeState                  ScopeState                  `json:"scope_state"`
+	AutomatedOutcome            AutomatedOutcome            `json:"automated_outcome"`
+	DesignState                 DesignState                 `json:"design_state"`
+	OperatingEffectivenessState OperatingEffectivenessState `json:"operating_effectiveness_state"`
+	EvidenceState               EvidenceState               `json:"evidence_state"`
+	DispositionState            DispositionState            `json:"disposition_state"`
+	Assurance                   Assurance                   `json:"assurance"`
+	AuditorState                AuditorState                `json:"auditor_state"`
+	ReasonCodes                 []ReasonCode                `json:"reason_codes"`
+	NextActions                 []NextAction                `json:"next_actions"`
+	LegacyStatus                string                      `json:"legacy_status"`
+}
+
+func TestObjectiveConformanceFixtures(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	if fixture.Version != "compliance-assessment-conformance/v1" {
+		t.Fatalf("fixture version = %q", fixture.Version)
+	}
+	if len(fixture.Cases) < 16 {
+		t.Fatalf("fixture cases = %d, want at least 16", len(fixture.Cases))
+	}
+	for _, testCase := range fixture.Cases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			input := mergedFixtureValue[EvaluateInput](t, fixture.BaseInput, testCase.Input)
+			expectedAxes := mergedFixtureValue[fixtureExpected](t, fixture.BaseExpected, testCase.Expected)
+			result, err := EvaluateObjective(input)
+			if err != nil {
+				t.Fatalf("EvaluateObjective() error = %v", err)
+			}
+			expected := expectedFixtureResult(input, expectedAxes)
+			gotBytes, err := CanonicalResultBytes(result)
+			if err != nil {
+				t.Fatalf("CanonicalResultBytes(result) error = %v", err)
+			}
+			wantBytes, err := CanonicalResultBytes(expected)
+			if err != nil {
+				t.Fatalf("CanonicalResultBytes(expected) error = %v", err)
+			}
+			if !bytes.Equal(gotBytes, wantBytes) {
+				t.Fatalf("canonical result mismatch\n got: %s\nwant: %s", gotBytes, wantBytes)
+			}
+			if got := LegacyStatus(result); got != expectedAxes.LegacyStatus {
+				t.Fatalf("LegacyStatus() = %q, want %q", got, expectedAxes.LegacyStatus)
+			}
+			digest, err := CanonicalResultDigest(result)
+			if err != nil {
+				t.Fatalf("CanonicalResultDigest() error = %v", err)
+			}
+			if testCase.ExpectedDigest == "" {
+				t.Errorf("expected_digest is empty; generated %s", digest)
+			} else if digest != testCase.ExpectedDigest {
+				t.Fatalf("digest = %q, want %q", digest, testCase.ExpectedDigest)
+			}
+		})
+	}
+}
+
+func TestObjectiveConformanceIsInvariantToInputOrder(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	for _, testCase := range fixture.Cases {
+		input := mergedFixtureValue[EvaluateInput](t, fixture.BaseInput, testCase.Input)
+		baseline, err := EvaluateObjective(input)
+		if err != nil {
+			t.Fatalf("%s baseline error = %v", testCase.Name, err)
+		}
+		baselineBytes, err := CanonicalResultBytes(baseline)
+		if err != nil {
+			t.Fatalf("%s baseline bytes error = %v", testCase.Name, err)
+		}
+		for iteration := 0; iteration < 32; iteration++ {
+			shuffled := cloneEvaluateInput(input)
+			rotateStrings(shuffled.FindingIDs, iteration)
+			rotateStrings(shuffled.SourceRuntimeIDs, iteration+1)
+			rotateAssessments(shuffled.RequirementAssessments, iteration+2)
+			for index := range shuffled.RequirementAssessments {
+				rotateStrings(shuffled.RequirementAssessments[index].EvidenceIDs, iteration+index)
+			}
+			result, err := EvaluateObjective(shuffled)
+			if err != nil {
+				t.Fatalf("%s iteration %d error = %v", testCase.Name, iteration, err)
+			}
+			data, err := CanonicalResultBytes(result)
+			if err != nil {
+				t.Fatalf("%s iteration %d bytes error = %v", testCase.Name, iteration, err)
+			}
+			if !bytes.Equal(data, baselineBytes) {
+				t.Fatalf("%s iteration %d changed canonical bytes", testCase.Name, iteration)
+			}
+		}
+	}
+}
+
+func loadConformanceFixture(t *testing.T) conformanceFixture {
+	t.Helper()
+	data, err := os.ReadFile("testdata/objective_conformance.json") // #nosec G304 -- fixed repository fixture path.
+	if err != nil {
+		t.Fatalf("read conformance fixture: %v", err)
+	}
+	var fixture conformanceFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("decode conformance fixture: %v", err)
+	}
+	return fixture
+}
+
+func mergedFixtureValue[T any](t *testing.T, base json.RawMessage, override json.RawMessage) T {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(base, &fields); err != nil {
+		t.Fatalf("decode fixture base: %v", err)
+	}
+	var overrides map[string]json.RawMessage
+	if len(override) != 0 {
+		if err := json.Unmarshal(override, &overrides); err != nil {
+			t.Fatalf("decode fixture override: %v", err)
+		}
+	}
+	for key, value := range overrides {
+		fields[key] = value
+	}
+	data, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal merged fixture: %v", err)
+	}
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("decode merged fixture: %v", err)
+	}
+	return result
+}
+
+func expectedFixtureResult(input EvaluateInput, expected fixtureExpected) ObjectiveResult {
+	evidenceIDs := []string{}
+	for _, assessment := range input.RequirementAssessments {
+		evidenceIDs = append(evidenceIDs, assessment.EvidenceIDs...)
+	}
+	return NormalizeResult(ObjectiveResult{
+		ID:                          input.ResultID,
+		ControlRef:                  input.Control,
+		ObjectiveID:                 input.ObjectiveID,
+		ScopeState:                  expected.ScopeState,
+		AutomatedOutcome:            expected.AutomatedOutcome,
+		DesignState:                 expected.DesignState,
+		OperatingEffectivenessState: expected.OperatingEffectivenessState,
+		EvidenceState:               expected.EvidenceState,
+		DispositionState:            expected.DispositionState,
+		Assurance:                   expected.Assurance,
+		AuditorState:                expected.AuditorState,
+		ReasonCodes:                 expected.ReasonCodes,
+		NextActions:                 expected.NextActions,
+		EvidenceIDs:                 evidenceIDs,
+		FindingIDs:                  input.FindingIDs,
+		SourceRuntimeIDs:            input.SourceRuntimeIDs,
+		EvaluatorRevision:           input.EvaluatorRevision,
+		EvaluatedAt:                 input.Now,
+	})
+}
+
+func cloneEvaluateInput(input EvaluateInput) EvaluateInput {
+	clone := input
+	clone.FindingIDs = append([]string(nil), input.FindingIDs...)
+	clone.SourceRuntimeIDs = append([]string(nil), input.SourceRuntimeIDs...)
+	clone.RequirementAssessments = append([]compliance.ControlEvidenceRequirementAssessment(nil), input.RequirementAssessments...)
+	for index := range clone.RequirementAssessments {
+		clone.RequirementAssessments[index].EvidenceIDs = append([]string(nil), input.RequirementAssessments[index].EvidenceIDs...)
+	}
+	return clone
+}
+
+func rotateStrings(values []string, count int) {
+	if len(values) < 2 {
+		return
+	}
+	count %= len(values)
+	rotated := append(append([]string(nil), values[count:]...), values[:count]...)
+	copy(values, rotated)
+}
+
+func rotateAssessments(values []compliance.ControlEvidenceRequirementAssessment, count int) {
+	if len(values) < 2 {
+		return
+	}
+	count %= len(values)
+	rotated := append(append([]compliance.ControlEvidenceRequirementAssessment(nil), values[count:]...), values[:count]...)
+	copy(values, rotated)
+}
+
+func TestFixtureNamesAreUnique(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	seen := map[string]struct{}{}
+	for _, testCase := range fixture.Cases {
+		if _, exists := seen[testCase.Name]; exists {
+			t.Fatalf("duplicate fixture name %q", testCase.Name)
+		}
+		seen[testCase.Name] = struct{}{}
+	}
+}

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -167,6 +167,15 @@ func ValidateEvaluateInput(input EvaluateInput) error {
 		return fmt.Errorf("%w: evaluation input contains an unknown required state", ErrInvalidResult)
 	}
 	for _, assessment := range input.RequirementAssessments {
+		if strings.TrimSpace(assessment.RequirementKey) == "" ||
+			strings.TrimSpace(assessment.ControlRef.ControlID) == "" ||
+			strings.TrimSpace(assessment.SourceID) == "" ||
+			strings.TrimSpace(assessment.EntityType) == "" {
+			return fmt.Errorf("%w: evidence requirement assessment identity and source binding are required", ErrInvalidResult)
+		}
+		if compliance.NormalizeControlRef(assessment.ControlRef) != input.Control {
+			return fmt.Errorf("%w: evidence requirement assessment control does not match the objective control", ErrInvalidResult)
+		}
 		switch assessment.Status {
 		case compliance.ControlEvidenceRequirementSatisfied,
 			compliance.ControlEvidenceRequirementManualReview,
@@ -175,6 +184,9 @@ func ValidateEvaluateInput(input EvaluateInput) error {
 			compliance.ControlEvidenceRequirementStale:
 		default:
 			return fmt.Errorf("%w: evaluation input contains unknown evidence requirement status %q", ErrInvalidResult, assessment.Status)
+		}
+		if assessment.Status == compliance.ControlEvidenceRequirementSatisfied && len(normalizedStrings(assessment.EvidenceIDs)) == 0 {
+			return fmt.Errorf("%w: satisfied evidence requirement assessment has no evidence", ErrInvalidResult)
 		}
 	}
 	return nil

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -1,0 +1,300 @@
+package complianceassessment
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+type EvaluateInput struct {
+	ResultID               string                                            `json:"result_id"`
+	ObjectiveID            string                                            `json:"objective_id"`
+	Control                compliance.ControlRef                             `json:"control_ref"`
+	ScopeState             ScopeState                                        `json:"scope_state"`
+	EvidenceIndex          *compliance.ControlEvidenceRequirementIndex       `json:"-"`
+	Evidence               []compliance.ControlEvidenceRequirementSignal     `json:"evidence,omitempty"`
+	RequirementAssessments []compliance.ControlEvidenceRequirementAssessment `json:"requirement_assessments,omitempty"`
+	CoverageState          CoverageState                                     `json:"coverage_state"`
+	SourceState            SourceState                                       `json:"source_state"`
+	SourceRuntimeIDs       []string                                          `json:"source_runtime_ids,omitempty"`
+	FindingIDs             []string                                          `json:"finding_ids,omitempty"`
+	InvalidEvidence        bool                                              `json:"invalid_evidence,omitempty"`
+	ConflictingEvidence    bool                                              `json:"conflicting_evidence,omitempty"`
+	DispositionState       DispositionState                                  `json:"disposition_state,omitempty"`
+	DesignState            DesignState                                       `json:"design_state,omitempty"`
+	OperatingState         OperatingEffectivenessState                       `json:"operating_effectiveness_state,omitempty"`
+	Inherited              bool                                              `json:"inherited,omitempty"`
+	Sampled                bool                                              `json:"sampled,omitempty"`
+	EvaluatorRevision      string                                            `json:"evaluator_revision"`
+	Now                    time.Time                                         `json:"now"`
+}
+
+// EvaluateObjective derives one deterministic, multi-axis result. Missing
+// coverage, evidence, or source trust always resolves to an explicit limitation;
+// an empty finding set is never sufficient to pass.
+func EvaluateObjective(input EvaluateInput) (ObjectiveResult, error) {
+	input = normalizeEvaluateInput(input)
+	if err := ValidateEvaluateInput(input); err != nil {
+		return ObjectiveResult{}, err
+	}
+	now := CanonicalTime(input.Now)
+	result := ObjectiveResult{
+		ID:                          strings.TrimSpace(input.ResultID),
+		ControlRef:                  input.Control,
+		ObjectiveID:                 strings.TrimSpace(input.ObjectiveID),
+		ScopeState:                  input.ScopeState,
+		AutomatedOutcome:            OutcomeIndeterminate,
+		DesignState:                 input.DesignState,
+		OperatingEffectivenessState: input.OperatingState,
+		EvidenceState:               EvidenceIncomplete,
+		DispositionState:            input.DispositionState,
+		Assurance:                   AssuranceNone,
+		AuditorState:                AuditorNotReviewed,
+		FindingIDs:                  input.FindingIDs,
+		SourceRuntimeIDs:            input.SourceRuntimeIDs,
+		EvaluatorRevision:           strings.TrimSpace(input.EvaluatorRevision),
+		EvaluatedAt:                 now,
+	}
+	if result.ScopeState == "" {
+		result.ScopeState = ScopeUnresolved
+	}
+	if result.DesignState == "" {
+		result.DesignState = DesignUnknown
+	}
+	if result.OperatingEffectivenessState == "" {
+		result.OperatingEffectivenessState = OperatingUnknown
+	}
+	if result.DispositionState == "" {
+		result.DispositionState = DispositionNone
+	}
+	assessments := append([]compliance.ControlEvidenceRequirementAssessment(nil), input.RequirementAssessments...)
+	if assessments == nil && input.EvidenceIndex != nil {
+		assessments = compliance.AssessControlEvidenceRequirements(compliance.ControlEvidenceRequirementAssessmentInput{
+			Index: input.EvidenceIndex, Control: input.Control, Evidence: input.Evidence, Now: now,
+		})
+	}
+	for _, assessment := range assessments {
+		result.EvidenceIDs = append(result.EvidenceIDs, assessment.EvidenceIDs...)
+	}
+
+	switch result.ScopeState {
+	case ScopeNotApplicable:
+		result.AutomatedOutcome = OutcomeNotAssessed
+		result.EvidenceState = EvidenceSufficient
+		result.DesignState = DesignNotAssessed
+		result.OperatingEffectivenessState = OperatingNotTested
+		result.ReasonCodes = append(result.ReasonCodes, ReasonNotApplicable)
+		result.NextActions = append(result.NextActions, ActionNone)
+		return validatedResult(result)
+	case ScopeUnresolved:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonScopeUnresolved)
+		result.NextActions = append(result.NextActions, ActionResolveScope)
+		return validatedResult(applyDisposition(NormalizeResult(result)))
+	}
+
+	evidenceState, reasons, actions := evaluateEvidence(assessments, input)
+	result.EvidenceState = evidenceState
+	result.ReasonCodes = append(result.ReasonCodes, reasons...)
+	result.NextActions = append(result.NextActions, actions...)
+	if len(result.FindingIDs) != 0 {
+		result.AutomatedOutcome = OutcomeNotSatisfied
+		result.ReasonCodes = append(result.ReasonCodes, ReasonActiveFinding)
+		result.NextActions = append(result.NextActions, ActionRemediate)
+		if result.DesignState == DesignUnknown {
+			result.DesignState = DesignIneffective
+		}
+		if result.OperatingEffectivenessState == OperatingUnknown {
+			result.OperatingEffectivenessState = OperatingIneffective
+		}
+	} else if evidenceState == EvidenceSufficient && input.CoverageState == CoverageComplete && input.SourceState == SourceSupported {
+		result.AutomatedOutcome = OutcomeSatisfied
+		result.ReasonCodes = append(result.ReasonCodes, ReasonSatisfied)
+		result.NextActions = append(result.NextActions, ActionNone)
+		if result.DesignState == DesignUnknown {
+			result.DesignState = DesignEffective
+		}
+		if result.OperatingEffectivenessState == OperatingUnknown {
+			result.OperatingEffectivenessState = OperatingEffective
+		}
+	} else {
+		result.AutomatedOutcome = OutcomeIndeterminate
+	}
+	if input.Inherited {
+		result.ReasonCodes = append(result.ReasonCodes, ReasonInheritedResponsibility)
+	}
+	if input.Sampled {
+		result.ReasonCodes = append(result.ReasonCodes, ReasonSampledTesting)
+	}
+	result.Assurance = deriveAssurance(result, input)
+	return validatedResult(applyDisposition(NormalizeResult(result)))
+}
+
+func normalizeEvaluateInput(input EvaluateInput) EvaluateInput {
+	input.ResultID = strings.TrimSpace(input.ResultID)
+	input.ObjectiveID = strings.TrimSpace(input.ObjectiveID)
+	input.Control = compliance.NormalizeControlRef(input.Control)
+	input.EvaluatorRevision = strings.TrimSpace(input.EvaluatorRevision)
+	input.Now = CanonicalTime(input.Now)
+	if input.ScopeState == "" {
+		input.ScopeState = ScopeUnresolved
+	}
+	if input.CoverageState == "" {
+		input.CoverageState = CoverageUnknown
+	}
+	if input.SourceState == "" {
+		input.SourceState = SourceUnknown
+	}
+	if input.DesignState == "" {
+		input.DesignState = DesignUnknown
+	}
+	if input.OperatingState == "" {
+		input.OperatingState = OperatingUnknown
+	}
+	if input.DispositionState == "" {
+		input.DispositionState = DispositionNone
+	}
+	return input
+}
+
+func ValidateEvaluateInput(input EvaluateInput) error {
+	if input.ResultID == "" || input.ObjectiveID == "" || strings.TrimSpace(input.Control.ControlID) == "" || input.EvaluatorRevision == "" || input.Now.IsZero() {
+		return fmt.Errorf("%w: result, objective, control, evaluator revision, and now are required", ErrInvalidResult)
+	}
+	if !knownScopeState(input.ScopeState) || !knownCoverageState(input.CoverageState) || !knownSourceState(input.SourceState) ||
+		!knownDesignState(input.DesignState) || !knownOperatingState(input.OperatingState) || !knownDispositionState(input.DispositionState) {
+		return fmt.Errorf("%w: evaluation input contains an unknown required state", ErrInvalidResult)
+	}
+	for _, assessment := range input.RequirementAssessments {
+		switch assessment.Status {
+		case compliance.ControlEvidenceRequirementSatisfied,
+			compliance.ControlEvidenceRequirementManualReview,
+			compliance.ControlEvidenceRequirementMissing,
+			compliance.ControlEvidenceRequirementMissingField,
+			compliance.ControlEvidenceRequirementStale:
+		default:
+			return fmt.Errorf("%w: evaluation input contains unknown evidence requirement status %q", ErrInvalidResult, assessment.Status)
+		}
+	}
+	return nil
+}
+
+func validatedResult(result ObjectiveResult) (ObjectiveResult, error) {
+	result = NormalizeResult(result)
+	if err := ValidateObjectiveResult(result); err != nil {
+		return ObjectiveResult{}, err
+	}
+	return result, nil
+}
+
+func evaluateEvidence(assessments []compliance.ControlEvidenceRequirementAssessment, input EvaluateInput) (EvidenceState, []ReasonCode, []NextAction) {
+	if input.ConflictingEvidence || input.SourceState == SourceConflicting {
+		return EvidenceConflicting, []ReasonCode{ReasonEvidenceConflicting}, []NextAction{ActionReview}
+	}
+	if input.InvalidEvidence {
+		return EvidenceUntrusted, []ReasonCode{ReasonEvidenceInvalid}, []NextAction{ActionReview}
+	}
+	switch input.SourceState {
+	case SourceUnverified:
+		return EvidenceUntrusted, []ReasonCode{ReasonSourceUntrusted}, []NextAction{ActionReview}
+	case SourceUnconfigured:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnconfigured}, []NextAction{ActionRestoreSource}
+	case SourceUnsupported:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnsupported}, []NextAction{ActionRestoreSource}
+	case SourceFailed:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceFailed}, []NextAction{ActionRestoreSource}
+	case SourcePartial:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourcePartial}, []NextAction{ActionRestoreSource}
+	case SourceStale:
+		return EvidenceStale, []ReasonCode{ReasonSourceStale}, []NextAction{ActionRefreshEvidence}
+	case SourceUnknown:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnknown}, []NextAction{ActionRestoreSource}
+	}
+	if input.CoverageState == CoverageEmpty {
+		return EvidenceIncomplete, []ReasonCode{ReasonPopulationEmpty}, []NextAction{ActionCollectEvidence}
+	}
+	if input.CoverageState != CoverageComplete {
+		return EvidenceIncomplete, []ReasonCode{ReasonCoverageIncomplete}, []NextAction{ActionCollectEvidence}
+	}
+	if len(assessments) == 0 {
+		return EvidenceMissing, []ReasonCode{ReasonEvidenceMissing}, []NextAction{ActionCollectEvidence}
+	}
+	state := EvidenceSufficient
+	var reasons []ReasonCode
+	var actions []NextAction
+	for _, assessment := range assessments {
+		switch assessment.Status {
+		case compliance.ControlEvidenceRequirementSatisfied:
+		case compliance.ControlEvidenceRequirementManualReview:
+			state = strongestEvidenceState(state, EvidenceManualReview)
+			reasons = append(reasons, ReasonManualEvidence)
+			actions = append(actions, ActionReview)
+		case compliance.ControlEvidenceRequirementStale:
+			state = strongestEvidenceState(state, EvidenceStale)
+			reasons = append(reasons, ReasonEvidenceStale)
+			actions = append(actions, ActionRefreshEvidence)
+		case compliance.ControlEvidenceRequirementMissingField:
+			state = strongestEvidenceState(state, EvidenceIncomplete)
+			reasons = append(reasons, ReasonEvidenceInvalid)
+			actions = append(actions, ActionCollectEvidence)
+		case compliance.ControlEvidenceRequirementMissing:
+			state = strongestEvidenceState(state, EvidenceMissing)
+			reasons = append(reasons, ReasonEvidenceMissing)
+			actions = append(actions, ActionCollectEvidence)
+		default:
+			state = strongestEvidenceState(state, EvidenceManualReview)
+			reasons = append(reasons, ReasonEvidenceInvalid)
+			actions = append(actions, ActionReview)
+		}
+	}
+	return state, reasons, actions
+}
+
+func strongestEvidenceState(left, right EvidenceState) EvidenceState {
+	rank := map[EvidenceState]int{
+		EvidenceSufficient: 0, EvidenceManualReview: 1, EvidenceStale: 2,
+		EvidenceMissing: 3, EvidenceIncomplete: 4, EvidenceUntrusted: 5, EvidenceConflicting: 6,
+	}
+	if rank[right] > rank[left] {
+		return right
+	}
+	return left
+}
+
+func deriveAssurance(result ObjectiveResult, input EvaluateInput) Assurance {
+	if result.AutomatedOutcome == OutcomeSatisfied && result.EvidenceState == EvidenceSufficient {
+		if input.Inherited || input.Sampled {
+			return AssuranceMedium
+		}
+		return AssuranceHigh
+	}
+	if result.AutomatedOutcome == OutcomeNotSatisfied && result.EvidenceState == EvidenceSufficient {
+		return AssuranceHigh
+	}
+	if result.EvidenceState == EvidenceManualReview || result.EvidenceState == EvidenceStale {
+		return AssuranceLow
+	}
+	return AssuranceNone
+}
+
+func applyDisposition(result ObjectiveResult) ObjectiveResult {
+	switch result.DispositionState {
+	case DispositionAcceptedException:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonAcceptedException)
+		result.NextActions = append(result.NextActions, ActionRetest)
+	case DispositionAcceptedRisk:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonAcceptedRisk)
+		result.NextActions = append(result.NextActions, ActionRetest)
+	}
+	return NormalizeResult(result)
+}
+
+func sortResults(results []ObjectiveResult) {
+	sort.Slice(results, func(i, j int) bool {
+		left, right := results[i], results[j]
+		return left.ControlRef.FrameworkID+"\x00"+left.ControlRef.ControlID+"\x00"+left.ObjectiveID+"\x00"+left.ID <
+			right.ControlRef.FrameworkID+"\x00"+right.ControlRef.ControlID+"\x00"+right.ObjectiveID+"\x00"+right.ID
+	})
+}

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -2,7 +2,6 @@ package complianceassessment
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -289,12 +288,4 @@ func applyDisposition(result ObjectiveResult) ObjectiveResult {
 		result.NextActions = append(result.NextActions, ActionRetest)
 	}
 	return NormalizeResult(result)
-}
-
-func sortResults(results []ObjectiveResult) {
-	sort.Slice(results, func(i, j int) bool {
-		left, right := results[i], results[j]
-		return left.ControlRef.FrameworkID+"\x00"+left.ControlRef.ControlID+"\x00"+left.ObjectiveID+"\x00"+left.ID <
-			right.ControlRef.FrameworkID+"\x00"+right.ControlRef.ControlID+"\x00"+right.ObjectiveID+"\x00"+right.ID
-	})
 }

--- a/internal/complianceassessment/legacy_status.go
+++ b/internal/complianceassessment/legacy_status.go
@@ -1,0 +1,38 @@
+package complianceassessment
+
+const (
+	LegacyStatusNotApplicable   = "not_applicable"
+	LegacyStatusException       = "exception"
+	LegacyStatusFailing         = "failing"
+	LegacyStatusMissingEvidence = "missing_evidence"
+	LegacyStatusStaleEvidence   = "stale_evidence"
+	LegacyStatusManualReview    = "manual_review"
+	LegacyStatusPassing         = "passing"
+)
+
+// LegacyStatus preserves the existing caller precedence while the canonical
+// result retains independent automation, evidence, and disposition axes.
+func LegacyStatus(result ObjectiveResult) string {
+	if result.ScopeState == ScopeNotApplicable {
+		return LegacyStatusNotApplicable
+	}
+	if result.DispositionState == DispositionAcceptedException || result.DispositionState == DispositionAcceptedRisk {
+		return LegacyStatusException
+	}
+	if result.AutomatedOutcome == OutcomeNotSatisfied {
+		return LegacyStatusFailing
+	}
+	switch result.EvidenceState {
+	case EvidenceMissing, EvidenceIncomplete:
+		return LegacyStatusMissingEvidence
+	case EvidenceStale:
+		return LegacyStatusStaleEvidence
+	case EvidenceManualReview, EvidenceConflicting, EvidenceUntrusted:
+		return LegacyStatusManualReview
+	case EvidenceSufficient:
+		if result.AutomatedOutcome == OutcomeSatisfied {
+			return LegacyStatusPassing
+		}
+	}
+	return LegacyStatusManualReview
+}

--- a/internal/complianceassessment/legacy_status_test.go
+++ b/internal/complianceassessment/legacy_status_test.go
@@ -1,0 +1,26 @@
+package complianceassessment
+
+import "testing"
+
+func TestLegacyStatusPreservesExistingPrecedence(t *testing.T) {
+	result := validObjectiveResult()
+	result.ScopeState = ScopeNotApplicable
+	result.DispositionState = DispositionAcceptedException
+	result.AutomatedOutcome = OutcomeNotSatisfied
+	result.EvidenceState = EvidenceMissing
+	if got := LegacyStatus(result); got != LegacyStatusNotApplicable {
+		t.Fatalf("not applicable precedence = %q", got)
+	}
+	result.ScopeState = ScopeInScope
+	if got := LegacyStatus(result); got != LegacyStatusException {
+		t.Fatalf("exception precedence = %q", got)
+	}
+	result.DispositionState = DispositionNone
+	if got := LegacyStatus(result); got != LegacyStatusFailing {
+		t.Fatalf("failing precedence = %q", got)
+	}
+	result.AutomatedOutcome = OutcomeIndeterminate
+	if got := LegacyStatus(result); got != LegacyStatusMissingEvidence {
+		t.Fatalf("missing evidence precedence = %q", got)
+	}
+}

--- a/internal/complianceassessment/testdata/objective_conformance.json
+++ b/internal/complianceassessment/testdata/objective_conformance.json
@@ -5,7 +5,7 @@
     "objective_id": "objective-1",
     "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"},
     "scope_state": "in_scope",
-    "requirement_assessments": [{"status": "satisfied", "evidence_ids": ["evidence-1"]}],
+    "requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "satisfied", "evidence_ids": ["evidence-1"]}],
     "coverage_state": "complete",
     "source_state": "supported",
     "source_runtime_ids": ["runtime-1"],
@@ -47,7 +47,7 @@
     },
     {
       "name": "stale_evidence",
-      "input": {"requirement_assessments": [{"status": "stale", "evidence_ids": ["evidence-1"]}]},
+      "input": {"requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "stale", "evidence_ids": ["evidence-1"]}]},
       "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "stale", "assurance": "low", "reason_codes": ["evidence_stale"], "next_actions": ["refresh_evidence"], "legacy_status": "stale_evidence"},
       "expected_digest": "sha256:06e1ea29fa9a5ba7e5119e2c89a1006bbe2dbd61315da9bc52579475b7cf261c"
     },
@@ -77,7 +77,7 @@
     },
     {
       "name": "manual_evidence",
-      "input": {"requirement_assessments": [{"status": "manual_review", "evidence_ids": ["evidence-1"]}]},
+      "input": {"requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "manual_review", "evidence_ids": ["evidence-1"]}]},
       "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "manual_review", "assurance": "low", "reason_codes": ["manual_evidence_review"], "next_actions": ["review"], "legacy_status": "manual_review"},
       "expected_digest": "sha256:a447dfee1c8cf7373aea662d94c746cfe49d97a97b280fee29c161d060eab786"
     },

--- a/internal/complianceassessment/testdata/objective_conformance.json
+++ b/internal/complianceassessment/testdata/objective_conformance.json
@@ -1,0 +1,121 @@
+{
+  "version": "compliance-assessment-conformance/v1",
+  "base_input": {
+    "result_id": "assessment-result-00000000000000000000000000000001",
+    "objective_id": "objective-1",
+    "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"},
+    "scope_state": "in_scope",
+    "requirement_assessments": [{"status": "satisfied", "evidence_ids": ["evidence-1"]}],
+    "coverage_state": "complete",
+    "source_state": "supported",
+    "source_runtime_ids": ["runtime-1"],
+    "evaluator_revision": "evaluator-v1",
+    "now": "2026-07-11T12:00:00.123456789Z"
+  },
+  "base_expected": {
+    "scope_state": "in_scope",
+    "automated_outcome": "satisfied",
+    "design_state": "effective",
+    "operating_effectiveness_state": "effective",
+    "evidence_state": "sufficient",
+    "disposition_state": "none",
+    "assurance": "high",
+    "auditor_state": "not_reviewed",
+    "reason_codes": ["assessment_satisfied"],
+    "next_actions": ["none"],
+    "legacy_status": "passing"
+  },
+  "cases": [
+    {"name": "pass", "input": {}, "expected": {}, "expected_digest": "sha256:aa8a2d895d281a61d20b63c855fd2fa37aba64a65446ced6f8955acacd8c2992"},
+    {
+      "name": "active_finding",
+      "input": {"finding_ids": ["finding-1"]},
+      "expected": {"automated_outcome": "not_satisfied", "design_state": "ineffective", "operating_effectiveness_state": "ineffective", "reason_codes": ["active_finding"], "next_actions": ["remediate"], "legacy_status": "failing"},
+      "expected_digest": "sha256:198812615976bf6380f497efd52c8f54841f326469d4a01614ab3ecdf4ea4168"
+    },
+    {
+      "name": "missing_evidence",
+      "input": {"requirement_assessments": []},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "missing", "assurance": "none", "reason_codes": ["evidence_missing"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:54264f10f4f4efab1705634b27510ffc958a80645f18d93598c893b77f2d9f35"
+    },
+    {
+      "name": "invalid_evidence",
+      "input": {"invalid_evidence": true},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "untrusted", "assurance": "none", "reason_codes": ["evidence_invalid"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:e2722f0ddfccb8c114cdb33a35bfd0aad9afd42004b50b0ef0bd4f9e3620150a"
+    },
+    {
+      "name": "stale_evidence",
+      "input": {"requirement_assessments": [{"status": "stale", "evidence_ids": ["evidence-1"]}]},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "stale", "assurance": "low", "reason_codes": ["evidence_stale"], "next_actions": ["refresh_evidence"], "legacy_status": "stale_evidence"},
+      "expected_digest": "sha256:06e1ea29fa9a5ba7e5119e2c89a1006bbe2dbd61315da9bc52579475b7cf261c"
+    },
+    {
+      "name": "conflicting_evidence",
+      "input": {"conflicting_evidence": true},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "conflicting", "assurance": "none", "reason_codes": ["evidence_conflicting"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:b7e40a786e56bfb861b13f5c41ff1340c1bb664bbf8862f2f31a226e0bce9742"
+    },
+    {
+      "name": "insufficient_coverage",
+      "input": {"coverage_state": "partial"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["coverage_incomplete"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:39a2db74de27785831955518f8bf0d53186a04f5b4e86a17e1f4bcc79cd5672f"
+    },
+    {
+      "name": "untrusted_source",
+      "input": {"source_state": "unverified"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "untrusted", "assurance": "none", "reason_codes": ["source_untrusted"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:4461d5e7adffda425a8109667d44c95a9f3dc52b1334900a593ec42105bbf764"
+    },
+    {
+      "name": "unknown_source_trust",
+      "input": {"source_state": "unknown"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["source_trust_unknown"], "next_actions": ["restore_source"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:433f8d418ccd407220aabaede7acf6e24051e6235f7cf4a6742b3726df40a694"
+    },
+    {
+      "name": "manual_evidence",
+      "input": {"requirement_assessments": [{"status": "manual_review", "evidence_ids": ["evidence-1"]}]},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "manual_review", "assurance": "low", "reason_codes": ["manual_evidence_review"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:a447dfee1c8cf7373aea662d94c746cfe49d97a97b280fee29c161d060eab786"
+    },
+    {
+      "name": "accepted_exception",
+      "input": {"requirement_assessments": [], "disposition_state": "accepted_exception"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "missing", "disposition_state": "accepted_exception", "assurance": "none", "reason_codes": ["accepted_exception", "evidence_missing"], "next_actions": ["collect_evidence", "retest"], "legacy_status": "exception"},
+      "expected_digest": "sha256:e6fcb3ebbe4e87e16280bb0dfd733e111bfecc7019731d1a499e9f0e0139ffec"
+    },
+    {
+      "name": "not_applicable",
+      "input": {"scope_state": "not_applicable", "requirement_assessments": [], "coverage_state": "unknown", "source_state": "unknown"},
+      "expected": {"scope_state": "not_applicable", "automated_outcome": "not_assessed", "design_state": "not_assessed", "operating_effectiveness_state": "not_tested", "evidence_state": "sufficient", "assurance": "none", "reason_codes": ["not_applicable"], "next_actions": ["none"], "legacy_status": "not_applicable"},
+      "expected_digest": "sha256:ae8ae1b84fac40ac390cbad3296b2c7e7e5de2e4f7854098b844e4b7ef33fbb7"
+    },
+    {
+      "name": "inherited_responsibility",
+      "input": {"inherited": true},
+      "expected": {"assurance": "medium", "reason_codes": ["assessment_satisfied", "inherited_responsibility"]},
+      "expected_digest": "sha256:667aafa34b03e54d6614bf72d615472b84021498c53c32db11d135cbaba20646"
+    },
+    {
+      "name": "sampled_testing",
+      "input": {"sampled": true},
+      "expected": {"assurance": "medium", "reason_codes": ["assessment_satisfied", "sampled_testing"]},
+      "expected_digest": "sha256:04f8705f2effaf18c64b323ae3820aec1156e250df6a4a75eafb4eb9b289be92"
+    },
+    {
+      "name": "no_configured_source",
+      "input": {"source_state": "unconfigured"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["source_unconfigured"], "next_actions": ["restore_source"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:9ec2b209ed153bae1d18fc647ea6699f36a91c1cdd53ffed418d242416dad3a7"
+    },
+    {
+      "name": "empty_population_with_satisfied_evidence",
+      "input": {"coverage_state": "empty"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["population_empty"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:992703e2b87bdee82adecf50d8c791bb2c6774f88c6548871292408834affc1d"
+    }
+  ]
+}

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -1,0 +1,538 @@
+package complianceassessment
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+var (
+	ErrInvalidCanonicalValue = errors.New("invalid canonical compliance value")
+	ErrInvalidManifest       = errors.New("invalid compliance input manifest")
+	ErrInvalidResult         = errors.New("invalid compliance objective result")
+)
+
+const (
+	CanonicalModelVersion = "compliance-assessment/v1"
+	ReasonRegistryVersion = "compliance-reasons/v1"
+	LegacyAdapterVersion  = "compliance-legacy-status/v1"
+)
+
+type ScopeState string
+
+const (
+	ScopeInScope       ScopeState = "in_scope"
+	ScopeNotApplicable ScopeState = "not_applicable"
+	ScopeUnresolved    ScopeState = "unresolved"
+)
+
+type AutomatedOutcome string
+
+const (
+	OutcomeSatisfied     AutomatedOutcome = "satisfied"
+	OutcomeNotSatisfied  AutomatedOutcome = "not_satisfied"
+	OutcomeIndeterminate AutomatedOutcome = "indeterminate"
+	OutcomeNotAssessed   AutomatedOutcome = "not_assessed"
+)
+
+type DesignState string
+
+const (
+	DesignEffective   DesignState = "effective"
+	DesignIneffective DesignState = "ineffective"
+	DesignUnknown     DesignState = "unknown"
+	DesignNotAssessed DesignState = "not_assessed"
+)
+
+type OperatingEffectivenessState string
+
+const (
+	OperatingEffective   OperatingEffectivenessState = "effective"
+	OperatingIneffective OperatingEffectivenessState = "ineffective"
+	OperatingUnknown     OperatingEffectivenessState = "unknown"
+	OperatingNotTested   OperatingEffectivenessState = "not_tested"
+)
+
+type EvidenceState string
+
+const (
+	EvidenceSufficient   EvidenceState = "sufficient"
+	EvidenceMissing      EvidenceState = "missing"
+	EvidenceStale        EvidenceState = "stale"
+	EvidenceConflicting  EvidenceState = "conflicting"
+	EvidenceUntrusted    EvidenceState = "untrusted"
+	EvidenceIncomplete   EvidenceState = "incomplete"
+	EvidenceManualReview EvidenceState = "manual_review"
+)
+
+type DispositionState string
+
+const (
+	DispositionNone              DispositionState = "none"
+	DispositionAcceptedException DispositionState = "accepted_exception"
+	DispositionAcceptedRisk      DispositionState = "accepted_risk"
+	DispositionReviewOverride    DispositionState = "review_override"
+)
+
+type Assurance string
+
+const (
+	AssuranceHigh   Assurance = "high"
+	AssuranceMedium Assurance = "medium"
+	AssuranceLow    Assurance = "low"
+	AssuranceNone   Assurance = "none"
+)
+
+type AuditorState string
+
+const (
+	AuditorNotReviewed      AuditorState = "not_reviewed"
+	AuditorAccepted         AuditorState = "accepted"
+	AuditorChangesRequested AuditorState = "changes_requested"
+	AuditorRejected         AuditorState = "rejected"
+)
+
+type CoverageState string
+
+const (
+	CoverageComplete CoverageState = "complete"
+	CoveragePartial  CoverageState = "partial"
+	CoverageEmpty    CoverageState = "empty"
+	CoverageUnknown  CoverageState = "unknown"
+)
+
+type SourceState string
+
+const (
+	SourceSupported    SourceState = "supported"
+	SourcePartial      SourceState = "partial"
+	SourceStale        SourceState = "stale"
+	SourceFailed       SourceState = "failed"
+	SourceUnconfigured SourceState = "unconfigured"
+	SourceUnsupported  SourceState = "unsupported"
+	SourceUnverified   SourceState = "unverified"
+	SourceConflicting  SourceState = "conflicting"
+	SourceUnknown      SourceState = "unknown"
+)
+
+type ReasonCode string
+
+const (
+	ReasonSatisfied               ReasonCode = "assessment_satisfied"
+	ReasonActiveFinding           ReasonCode = "active_finding"
+	ReasonEvidenceMissing         ReasonCode = "evidence_missing"
+	ReasonEvidenceInvalid         ReasonCode = "evidence_invalid"
+	ReasonEvidenceStale           ReasonCode = "evidence_stale"
+	ReasonEvidenceConflicting     ReasonCode = "evidence_conflicting"
+	ReasonCoverageIncomplete      ReasonCode = "coverage_incomplete"
+	ReasonSourceUntrusted         ReasonCode = "source_untrusted"
+	ReasonSourceUnknown           ReasonCode = "source_trust_unknown"
+	ReasonManualEvidence          ReasonCode = "manual_evidence_review"
+	ReasonAcceptedException       ReasonCode = "accepted_exception"
+	ReasonAcceptedRisk            ReasonCode = "accepted_risk"
+	ReasonNotApplicable           ReasonCode = "not_applicable"
+	ReasonInheritedResponsibility ReasonCode = "inherited_responsibility"
+	ReasonSampledTesting          ReasonCode = "sampled_testing"
+	ReasonSourceUnconfigured      ReasonCode = "source_unconfigured"
+	ReasonSourceUnsupported       ReasonCode = "source_unsupported"
+	ReasonSourcePartial           ReasonCode = "source_partial"
+	ReasonSourceFailed            ReasonCode = "source_failed"
+	ReasonSourceStale             ReasonCode = "source_stale"
+	ReasonScopeUnresolved         ReasonCode = "scope_unresolved"
+	ReasonPopulationEmpty         ReasonCode = "population_empty"
+)
+
+type NextAction string
+
+const (
+	ActionNone            NextAction = "none"
+	ActionReview          NextAction = "review"
+	ActionCollectEvidence NextAction = "collect_evidence"
+	ActionRefreshEvidence NextAction = "refresh_evidence"
+	ActionRestoreSource   NextAction = "restore_source"
+	ActionResolveScope    NextAction = "resolve_scope"
+	ActionRemediate       NextAction = "remediate"
+	ActionRetest          NextAction = "retest"
+)
+
+type CollectionCompleteness string
+
+const (
+	CollectionComplete          CollectionCompleteness = "complete"
+	CollectionPartial           CollectionCompleteness = "partial"
+	CollectionTruncated         CollectionCompleteness = "truncated"
+	CollectionChangedDuringScan CollectionCompleteness = "changed_during_scan"
+	CollectionUnknown           CollectionCompleteness = "unknown"
+)
+
+// ManifestRevision pins one semantic input used by an assessment run.
+type ManifestRevision struct {
+	Kind       string `json:"kind"`
+	ID         string `json:"id"`
+	RevisionID string `json:"revision_id"`
+	Version    uint64 `json:"version"`
+	Digest     string `json:"digest"`
+}
+
+type CollectionReceipt struct {
+	Kind          string                 `json:"kind"`
+	RuntimeID     string                 `json:"runtime_id,omitempty"`
+	QueryDigest   string                 `json:"query_digest"`
+	PageIndex     uint32                 `json:"page_index"`
+	Cursor        string                 `json:"cursor,omitempty"`
+	NextCursor    string                 `json:"next_cursor,omitempty"`
+	RawCount      uint64                 `json:"raw_count"`
+	Deduplicated  uint64                 `json:"deduplicated_count"`
+	Included      uint64                 `json:"included_count"`
+	Excluded      uint64                 `json:"excluded_count"`
+	ExpectedTotal *uint64                `json:"expected_total,omitempty"`
+	FirstKey      string                 `json:"first_key,omitempty"`
+	LastKey       string                 `json:"last_key,omitempty"`
+	Watermark     time.Time              `json:"watermark"`
+	Cutoff        time.Time              `json:"cutoff"`
+	Completeness  CollectionCompleteness `json:"completeness"`
+	PageDigest    string                 `json:"page_digest"`
+}
+
+// InputManifest pins every revision and collection receipt needed to reproduce
+// one automated assessment result.
+type InputManifest struct {
+	ModelVersion               string              `json:"model_version"`
+	ProgramID                  string              `json:"program_id"`
+	ScopeRevisionID            string              `json:"scope_revision_id"`
+	PlanRevisionID             string              `json:"plan_revision_id"`
+	PeriodStart                time.Time           `json:"period_start"`
+	PeriodEnd                  time.Time           `json:"period_end"`
+	CollectionCutoff           time.Time           `json:"collection_cutoff"`
+	RequestedScopeDigest       string              `json:"requested_scope_digest"`
+	ResolvedObjectiveSetDigest string              `json:"resolved_objective_set_digest"`
+	MappingSetDigest           string              `json:"mapping_set_digest"`
+	Revisions                  []ManifestRevision  `json:"revisions"`
+	Receipts                   []CollectionReceipt `json:"receipts"`
+	EvaluationRunIDs           []string            `json:"evaluation_run_ids,omitempty"`
+	ReasonRegistry             string              `json:"reason_registry"`
+	AdapterVersion             string              `json:"adapter_version"`
+}
+
+type ObjectiveResult struct {
+	ID                          string                      `json:"id"`
+	ControlRef                  compliance.ControlRef       `json:"control_ref"`
+	ObjectiveID                 string                      `json:"objective_id"`
+	ScopeState                  ScopeState                  `json:"scope_state"`
+	AutomatedOutcome            AutomatedOutcome            `json:"automated_outcome"`
+	DesignState                 DesignState                 `json:"design_state"`
+	OperatingEffectivenessState OperatingEffectivenessState `json:"operating_effectiveness_state"`
+	EvidenceState               EvidenceState               `json:"evidence_state"`
+	DispositionState            DispositionState            `json:"disposition_state"`
+	Assurance                   Assurance                   `json:"assurance"`
+	AuditorState                AuditorState                `json:"auditor_state"`
+	ReasonCodes                 []ReasonCode                `json:"reason_codes"`
+	NextActions                 []NextAction                `json:"next_actions"`
+	EvidenceIDs                 []string                    `json:"evidence_ids,omitempty"`
+	FindingIDs                  []string                    `json:"finding_ids,omitempty"`
+	SourceRuntimeIDs            []string                    `json:"source_runtime_ids,omitempty"`
+	EvaluatorRevision           string                      `json:"evaluator_revision"`
+	EvaluatedAt                 time.Time                   `json:"evaluated_at"`
+}
+
+func NormalizeManifest(value InputManifest) InputManifest {
+	if strings.TrimSpace(value.ModelVersion) == "" {
+		value.ModelVersion = CanonicalModelVersion
+	}
+	if strings.TrimSpace(value.ReasonRegistry) == "" {
+		value.ReasonRegistry = ReasonRegistryVersion
+	}
+	if strings.TrimSpace(value.AdapterVersion) == "" {
+		value.AdapterVersion = LegacyAdapterVersion
+	}
+	value.ModelVersion = strings.TrimSpace(value.ModelVersion)
+	value.ProgramID = strings.TrimSpace(value.ProgramID)
+	value.ScopeRevisionID = strings.TrimSpace(value.ScopeRevisionID)
+	value.PlanRevisionID = strings.TrimSpace(value.PlanRevisionID)
+	value.RequestedScopeDigest = strings.TrimSpace(value.RequestedScopeDigest)
+	value.ResolvedObjectiveSetDigest = strings.TrimSpace(value.ResolvedObjectiveSetDigest)
+	value.MappingSetDigest = strings.TrimSpace(value.MappingSetDigest)
+	value.ReasonRegistry = strings.TrimSpace(value.ReasonRegistry)
+	value.AdapterVersion = strings.TrimSpace(value.AdapterVersion)
+	value.PeriodStart = CanonicalTime(value.PeriodStart)
+	value.PeriodEnd = CanonicalTime(value.PeriodEnd)
+	value.CollectionCutoff = CanonicalTime(value.CollectionCutoff)
+	value.Revisions = append([]ManifestRevision(nil), value.Revisions...)
+	for index := range value.Revisions {
+		value.Revisions[index].Kind = strings.TrimSpace(value.Revisions[index].Kind)
+		value.Revisions[index].ID = strings.TrimSpace(value.Revisions[index].ID)
+		value.Revisions[index].RevisionID = strings.TrimSpace(value.Revisions[index].RevisionID)
+		value.Revisions[index].Digest = strings.TrimSpace(value.Revisions[index].Digest)
+	}
+	sort.Slice(value.Revisions, func(i, j int) bool {
+		left, right := value.Revisions[i], value.Revisions[j]
+		return left.Kind+"\x00"+left.ID+"\x00"+left.RevisionID < right.Kind+"\x00"+right.ID+"\x00"+right.RevisionID
+	})
+	value.Revisions = deduplicateManifestRevisions(value.Revisions)
+	value.Receipts = append([]CollectionReceipt(nil), value.Receipts...)
+	for index := range value.Receipts {
+		receipt := &value.Receipts[index]
+		receipt.Kind = strings.TrimSpace(receipt.Kind)
+		receipt.RuntimeID = strings.TrimSpace(receipt.RuntimeID)
+		receipt.QueryDigest = strings.TrimSpace(receipt.QueryDigest)
+		receipt.Cursor = strings.TrimSpace(receipt.Cursor)
+		receipt.NextCursor = strings.TrimSpace(receipt.NextCursor)
+		receipt.FirstKey = strings.TrimSpace(receipt.FirstKey)
+		receipt.LastKey = strings.TrimSpace(receipt.LastKey)
+		receipt.PageDigest = strings.TrimSpace(receipt.PageDigest)
+		receipt.Watermark = CanonicalTime(receipt.Watermark)
+		receipt.Cutoff = CanonicalTime(receipt.Cutoff)
+	}
+	sort.Slice(value.Receipts, func(i, j int) bool {
+		left, right := value.Receipts[i], value.Receipts[j]
+		if left.Kind+"\x00"+left.RuntimeID != right.Kind+"\x00"+right.RuntimeID {
+			return left.Kind+"\x00"+left.RuntimeID < right.Kind+"\x00"+right.RuntimeID
+		}
+		if left.PageIndex != right.PageIndex {
+			return left.PageIndex < right.PageIndex
+		}
+		return left.PageDigest < right.PageDigest
+	})
+	value.Receipts = deduplicateCollectionReceipts(value.Receipts)
+	value.EvaluationRunIDs = normalizedStrings(value.EvaluationRunIDs)
+	return value
+}
+
+func NormalizeResult(value ObjectiveResult) ObjectiveResult {
+	value.ID = strings.TrimSpace(value.ID)
+	value.ControlRef = compliance.NormalizeControlRef(value.ControlRef)
+	value.ObjectiveID = strings.TrimSpace(value.ObjectiveID)
+	value.EvaluatorRevision = strings.TrimSpace(value.EvaluatorRevision)
+	value.ReasonCodes = normalizedEnums(value.ReasonCodes)
+	value.NextActions = normalizedEnums(value.NextActions)
+	value.EvidenceIDs = normalizedStrings(value.EvidenceIDs)
+	value.FindingIDs = normalizedStrings(value.FindingIDs)
+	value.SourceRuntimeIDs = normalizedStrings(value.SourceRuntimeIDs)
+	value.EvaluatedAt = CanonicalTime(value.EvaluatedAt)
+	return value
+}
+
+func ValidateInputManifest(value InputManifest) error {
+	value = NormalizeManifest(value)
+	if value.ModelVersion != CanonicalModelVersion {
+		return fmt.Errorf("%w: unsupported model_version %q", ErrInvalidManifest, value.ModelVersion)
+	}
+	if value.ProgramID == "" || value.ScopeRevisionID == "" || value.PlanRevisionID == "" {
+		return fmt.Errorf("%w: program, scope revision, and plan revision are required", ErrInvalidManifest)
+	}
+	if value.PeriodStart.IsZero() || value.PeriodEnd.IsZero() || value.CollectionCutoff.IsZero() || value.PeriodEnd.Before(value.PeriodStart) {
+		return fmt.Errorf("%w: valid period and collection cutoff are required", ErrInvalidManifest)
+	}
+	for _, digest := range []string{value.RequestedScopeDigest, value.ResolvedObjectiveSetDigest, value.MappingSetDigest} {
+		if err := compliance.ValidateContentDigest(compliance.ContentDigest(digest)); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidManifest, err)
+		}
+	}
+	if len(value.Revisions) == 0 || len(value.Receipts) == 0 {
+		return fmt.Errorf("%w: revisions and collection receipts are required", ErrInvalidManifest)
+	}
+	for index, revision := range value.Revisions {
+		if revision.Kind == "" || revision.ID == "" || revision.RevisionID == "" || revision.Version == 0 {
+			return fmt.Errorf("%w: revisions[%d] is incomplete", ErrInvalidManifest, index)
+		}
+		if err := compliance.ValidateContentDigest(compliance.ContentDigest(revision.Digest)); err != nil {
+			return fmt.Errorf("%w: revisions[%d]: %v", ErrInvalidManifest, index, err)
+		}
+		if index > 0 {
+			previous := value.Revisions[index-1]
+			if previous.Kind == revision.Kind && previous.ID == revision.ID && previous.RevisionID == revision.RevisionID {
+				return fmt.Errorf("%w: conflicting duplicate revision %q", ErrInvalidManifest, revision.RevisionID)
+			}
+		}
+	}
+	for index, receipt := range value.Receipts {
+		if err := validateCollectionReceipt(receipt); err != nil {
+			return fmt.Errorf("%w: receipts[%d]: %v", ErrInvalidManifest, index, err)
+		}
+		if index > 0 {
+			previous := value.Receipts[index-1]
+			if previous.Kind == receipt.Kind && previous.RuntimeID == receipt.RuntimeID && previous.PageIndex == receipt.PageIndex {
+				return fmt.Errorf("%w: conflicting duplicate collection page %d", ErrInvalidManifest, receipt.PageIndex)
+			}
+		}
+	}
+	return nil
+}
+
+func ValidateObjectiveResult(value ObjectiveResult) error {
+	value = NormalizeResult(value)
+	if value.ID == "" || value.ObjectiveID == "" || strings.TrimSpace(value.ControlRef.ControlID) == "" || value.EvaluatorRevision == "" || value.EvaluatedAt.IsZero() {
+		return fmt.Errorf("%w: identity, control, evaluator revision, and evaluated_at are required", ErrInvalidResult)
+	}
+	if !knownScopeState(value.ScopeState) || !knownOutcome(value.AutomatedOutcome) || !knownDesignState(value.DesignState) ||
+		!knownOperatingState(value.OperatingEffectivenessState) || !knownEvidenceState(value.EvidenceState) ||
+		!knownDispositionState(value.DispositionState) || !knownAssurance(value.Assurance) || !knownAuditorState(value.AuditorState) {
+		return fmt.Errorf("%w: one or more required states are unknown", ErrInvalidResult)
+	}
+	if len(value.ReasonCodes) == 0 || len(value.NextActions) == 0 {
+		return fmt.Errorf("%w: reason_codes and next_actions are required", ErrInvalidResult)
+	}
+	for _, reason := range value.ReasonCodes {
+		if !knownReasonCode(reason) {
+			return fmt.Errorf("%w: unknown reason_code %q", ErrInvalidResult, reason)
+		}
+	}
+	for _, action := range value.NextActions {
+		if !knownNextAction(action) {
+			return fmt.Errorf("%w: unknown next_action %q", ErrInvalidResult, action)
+		}
+	}
+	if value.AutomatedOutcome == OutcomeSatisfied && value.EvidenceState != EvidenceSufficient {
+		return fmt.Errorf("%w: satisfied outcome requires sufficient evidence", ErrInvalidResult)
+	}
+	if value.ScopeState == ScopeNotApplicable && (value.AutomatedOutcome != OutcomeNotAssessed || value.DesignState != DesignNotAssessed || value.OperatingEffectivenessState != OperatingNotTested) {
+		return fmt.Errorf("%w: not-applicable scope requires not-assessed axes", ErrInvalidResult)
+	}
+	return nil
+}
+
+// CanonicalTime uses UTC millisecond precision, matching workflow event
+// timestamps and preventing event/database round trips from changing hashes.
+func CanonicalTime(value time.Time) time.Time {
+	return compliance.CanonicalRevisionTime(value)
+}
+
+func canonicalBytes(value any) ([]byte, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	var decoded any
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	return canonical, nil
+}
+
+func CanonicalManifestBytes(value InputManifest) ([]byte, error) {
+	value = NormalizeManifest(value)
+	if err := ValidateInputManifest(value); err != nil {
+		return nil, err
+	}
+	return canonicalBytes(value)
+}
+
+func CanonicalManifestDigest(value InputManifest) (string, error) {
+	data, err := CanonicalManifestBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(data), nil
+}
+
+func CanonicalResultBytes(value ObjectiveResult) ([]byte, error) {
+	value = NormalizeResult(value)
+	if err := ValidateObjectiveResult(value); err != nil {
+		return nil, err
+	}
+	return canonicalBytes(value)
+}
+
+func CanonicalResultDigest(value ObjectiveResult) (string, error) {
+	data, err := CanonicalResultBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(data), nil
+}
+
+func digestBytes(data []byte) string {
+	digest := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func normalizedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizedEnums[T ~string](values []T) []T {
+	stringsIn := make([]string, 0, len(values))
+	for _, value := range values {
+		stringsIn = append(stringsIn, string(value))
+	}
+	normalized := normalizedStrings(stringsIn)
+	result := make([]T, 0, len(normalized))
+	for _, value := range normalized {
+		result = append(result, T(value))
+	}
+	return result
+}
+
+func deduplicateManifestRevisions(values []ManifestRevision) []ManifestRevision {
+	result := make([]ManifestRevision, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.Kind == value.Kind && previous.ID == value.ID && previous.RevisionID == value.RevisionID && previous.Digest == value.Digest && previous.Version == value.Version {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func deduplicateCollectionReceipts(values []CollectionReceipt) []CollectionReceipt {
+	result := make([]CollectionReceipt, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.Kind == value.Kind && previous.RuntimeID == value.RuntimeID && previous.PageIndex == value.PageIndex && previous.PageDigest == value.PageDigest {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func validateCollectionReceipt(receipt CollectionReceipt) error {
+	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Watermark.IsZero() || receipt.Cutoff.IsZero() {
+		return errors.New("kind, digests, watermark, and cutoff are required")
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.QueryDigest)); err != nil {
+		return err
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.PageDigest)); err != nil {
+		return err
+	}
+	if !knownCompleteness(receipt.Completeness) {
+		return fmt.Errorf("unknown completeness %q", receipt.Completeness)
+	}
+	if receipt.Included+receipt.Excluded != receipt.Deduplicated || receipt.Deduplicated > receipt.RawCount {
+		return errors.New("collection counts are inconsistent")
+	}
+	return nil
+}

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -363,6 +363,9 @@ func ValidateInputManifest(value InputManifest) error {
 			}
 		}
 	}
+	if err := validateCollectionReceiptChains(value.Receipts); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidManifest, err)
+	}
 	return nil
 }
 
@@ -519,8 +522,8 @@ func deduplicateCollectionReceipts(values []CollectionReceipt) []CollectionRecei
 }
 
 func validateCollectionReceipt(receipt CollectionReceipt) error {
-	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Watermark.IsZero() || receipt.Cutoff.IsZero() {
-		return errors.New("kind, digests, watermark, and cutoff are required")
+	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Cutoff.IsZero() {
+		return errors.New("kind, digests, and cutoff are required")
 	}
 	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.QueryDigest)); err != nil {
 		return err
@@ -534,5 +537,60 @@ func validateCollectionReceipt(receipt CollectionReceipt) error {
 	if receipt.Included+receipt.Excluded != receipt.Deduplicated || receipt.Deduplicated > receipt.RawCount {
 		return errors.New("collection counts are inconsistent")
 	}
+	if receipt.Watermark.IsZero() && !emptyCollectionReceipt(receipt) {
+		return errors.New("watermark is required for a non-empty collection")
+	}
 	return nil
+}
+
+func validateCollectionReceiptChains(receipts []CollectionReceipt) error {
+	for start := 0; start < len(receipts); {
+		end := start + 1
+		for end < len(receipts) && receipts[end].Kind == receipts[start].Kind && receipts[end].RuntimeID == receipts[start].RuntimeID {
+			end++
+		}
+		chain := receipts[start:end]
+		if chain[0].PageIndex != 0 || chain[0].Cursor != "" {
+			return fmt.Errorf("collection %q/%q must begin at page zero without a cursor", chain[0].Kind, chain[0].RuntimeID)
+		}
+		var collected uint64
+		for index, receipt := range chain {
+			if receipt.QueryDigest != chain[0].QueryDigest || receipt.Cutoff != chain[0].Cutoff || receipt.Watermark != chain[0].Watermark {
+				return fmt.Errorf("collection %q/%q changed query, cutoff, or watermark between pages", receipt.Kind, receipt.RuntimeID)
+			}
+			if !equalExpectedTotal(receipt.ExpectedTotal, chain[0].ExpectedTotal) {
+				return fmt.Errorf("collection %q/%q changed expected total between pages", receipt.Kind, receipt.RuntimeID)
+			}
+			collected += receipt.Included + receipt.Excluded
+			if index == 0 {
+				continue
+			}
+			previous := chain[index-1]
+			if receipt.PageIndex != previous.PageIndex+1 || previous.NextCursor == "" || receipt.Cursor != previous.NextCursor {
+				return fmt.Errorf("collection %q/%q has a missing or disconnected page at index %d", receipt.Kind, receipt.RuntimeID, receipt.PageIndex)
+			}
+		}
+		terminal := chain[len(chain)-1]
+		if terminal.NextCursor != "" {
+			return fmt.Errorf("collection %q/%q has no terminal page", terminal.Kind, terminal.RuntimeID)
+		}
+		if terminal.Completeness == CollectionComplete && terminal.ExpectedTotal != nil && collected != *terminal.ExpectedTotal {
+			return fmt.Errorf("collection %q/%q completed with %d records; expected %d", terminal.Kind, terminal.RuntimeID, collected, *terminal.ExpectedTotal)
+		}
+		start = end
+	}
+	return nil
+}
+
+func emptyCollectionReceipt(receipt CollectionReceipt) bool {
+	return receipt.PageIndex == 0 && receipt.Cursor == "" && receipt.NextCursor == "" &&
+		receipt.RawCount == 0 && receipt.Deduplicated == 0 && receipt.Included == 0 && receipt.Excluded == 0 &&
+		receipt.ExpectedTotal != nil && *receipt.ExpectedTotal == 0 && receipt.FirstKey == "" && receipt.LastKey == ""
+}
+
+func equalExpectedTotal(left, right *uint64) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -332,7 +332,7 @@ func ValidateInputManifest(value InputManifest) error {
 	}
 	for _, digest := range []string{value.RequestedScopeDigest, value.ResolvedObjectiveSetDigest, value.MappingSetDigest} {
 		if err := compliance.ValidateContentDigest(compliance.ContentDigest(digest)); err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidManifest, err)
+			return fmt.Errorf("%w: %w", ErrInvalidManifest, err)
 		}
 	}
 	if len(value.Revisions) == 0 || len(value.Receipts) == 0 {
@@ -343,7 +343,7 @@ func ValidateInputManifest(value InputManifest) error {
 			return fmt.Errorf("%w: revisions[%d] is incomplete", ErrInvalidManifest, index)
 		}
 		if err := compliance.ValidateContentDigest(compliance.ContentDigest(revision.Digest)); err != nil {
-			return fmt.Errorf("%w: revisions[%d]: %v", ErrInvalidManifest, index, err)
+			return fmt.Errorf("%w: revisions[%d]: %w", ErrInvalidManifest, index, err)
 		}
 		if index > 0 {
 			previous := value.Revisions[index-1]
@@ -354,7 +354,7 @@ func ValidateInputManifest(value InputManifest) error {
 	}
 	for index, receipt := range value.Receipts {
 		if err := validateCollectionReceipt(receipt); err != nil {
-			return fmt.Errorf("%w: receipts[%d]: %v", ErrInvalidManifest, index, err)
+			return fmt.Errorf("%w: receipts[%d]: %w", ErrInvalidManifest, index, err)
 		}
 		if index > 0 {
 			previous := value.Receipts[index-1]
@@ -407,17 +407,17 @@ func CanonicalTime(value time.Time) time.Time {
 func canonicalBytes(value any) ([]byte, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	var decoded any
 	decoder := json.NewDecoder(strings.NewReader(string(data)))
 	decoder.UseNumber()
 	if err := decoder.Decode(&decoded); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	canonical, err := json.Marshal(decoded)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	return canonical, nil
 }

--- a/internal/complianceassessment/types_test.go
+++ b/internal/complianceassessment/types_test.go
@@ -1,0 +1,122 @@
+package complianceassessment
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func TestCanonicalManifestNormalizesOrderTimeAndDoesNotMutateCaller(t *testing.T) {
+	manifest := validManifest()
+	originalFirstKind := manifest.Revisions[0].Kind
+	firstBytes, err := CanonicalManifestBytes(manifest)
+	if err != nil {
+		t.Fatalf("CanonicalManifestBytes() error = %v", err)
+	}
+	shuffled := manifest
+	shuffled.Revisions = append([]ManifestRevision(nil), manifest.Revisions...)
+	shuffled.Receipts = append([]CollectionReceipt(nil), manifest.Receipts...)
+	shuffled.Revisions[0], shuffled.Revisions[1] = shuffled.Revisions[1], shuffled.Revisions[0]
+	shuffled.Receipts[0], shuffled.Receipts[1] = shuffled.Receipts[1], shuffled.Receipts[0]
+	shuffled.EvaluationRunIDs = []string{"run-b", "run-a", "run-a"}
+	secondBytes, err := CanonicalManifestBytes(shuffled)
+	if err != nil {
+		t.Fatalf("CanonicalManifestBytes(shuffled) error = %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatalf("manifest order changed canonical bytes\nfirst=%s\nsecond=%s", firstBytes, secondBytes)
+	}
+	if manifest.Revisions[0].Kind != originalFirstKind {
+		t.Fatal("NormalizeManifest mutated caller revisions")
+	}
+	if bytes.Contains(firstBytes, []byte("123456789")) || !bytes.Contains(firstBytes, []byte(".123Z")) {
+		t.Fatalf("canonical timestamp was not truncated to milliseconds: %s", firstBytes)
+	}
+}
+
+func TestUnknownEnumsSurviveDecodeAndFailCommandValidation(t *testing.T) {
+	result := validObjectiveResult()
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	data = bytes.Replace(data, []byte(`"evidence_state":"sufficient"`), []byte(`"evidence_state":"future_state"`), 1)
+	var decoded ObjectiveResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode future enum: %v", err)
+	}
+	if decoded.EvidenceState != EvidenceState("future_state") {
+		t.Fatalf("future enum was not retained: %q", decoded.EvidenceState)
+	}
+	if err := ValidateObjectiveResult(decoded); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("ValidateObjectiveResult() error = %v, want ErrInvalidResult", err)
+	}
+
+	input := validEvaluateInput()
+	input.SourceState = SourceState("future_source_state")
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective() error = %v, want ErrInvalidResult", err)
+	}
+	input = validEvaluateInput()
+	input.RequirementAssessments[0].Status = compliance.ControlEvidenceRequirementAssessmentStatus("future_requirement_state")
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective(future requirement) error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func TestCanonicalResultRejectsUnsupportedPass(t *testing.T) {
+	result := validObjectiveResult()
+	result.EvidenceState = EvidenceMissing
+	if _, err := CanonicalResultBytes(result); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("CanonicalResultBytes() error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func validManifest() InputManifest {
+	digestA := "sha256:" + strings.Repeat("a", 64)
+	digestB := "sha256:" + strings.Repeat("b", 64)
+	expected := uint64(2)
+	timestamp := time.Date(2026, 7, 11, 12, 0, 0, 123456789, time.FixedZone("offset", -7*60*60))
+	return InputManifest{
+		ProgramID: "program-00000000000000000000000000000001", ScopeRevisionID: "scope-revision-00000000000000000000000000000001",
+		PlanRevisionID: "assessment-plan-revision-00000000000000000000000000000001",
+		PeriodStart:    timestamp.Add(-time.Hour), PeriodEnd: timestamp, CollectionCutoff: timestamp,
+		RequestedScopeDigest: digestA, ResolvedObjectiveSetDigest: digestB, MappingSetDigest: digestA,
+		Revisions: []ManifestRevision{
+			{Kind: "profile", ID: "profile-1", RevisionID: "profile-r1", Version: 1, Digest: digestA},
+			{Kind: "catalog", ID: "catalog-1", RevisionID: "catalog-r1", Version: 1, Digest: digestB},
+		},
+		Receipts: []CollectionReceipt{
+			{Kind: "findings", RuntimeID: "runtime-1", QueryDigest: digestA, PageIndex: 1, Cursor: "a", RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &expected, FirstKey: "b", LastKey: "b", Watermark: timestamp, Cutoff: timestamp, Completeness: CollectionComplete, PageDigest: digestB},
+			{Kind: "findings", RuntimeID: "runtime-1", QueryDigest: digestA, PageIndex: 0, NextCursor: "a", RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &expected, FirstKey: "a", LastKey: "a", Watermark: timestamp, Cutoff: timestamp, Completeness: CollectionComplete, PageDigest: digestA},
+		},
+		EvaluationRunIDs: []string{"run-a", "run-b"},
+	}
+}
+
+func validObjectiveResult() ObjectiveResult {
+	return ObjectiveResult{
+		ID:         "assessment-result-00000000000000000000000000000001",
+		ControlRef: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ObjectiveID: "objective-1",
+		ScopeState: ScopeInScope, AutomatedOutcome: OutcomeSatisfied, DesignState: DesignEffective,
+		OperatingEffectivenessState: OperatingEffective, EvidenceState: EvidenceSufficient,
+		DispositionState: DispositionNone, Assurance: AssuranceHigh, AuditorState: AuditorNotReviewed,
+		ReasonCodes: []ReasonCode{ReasonSatisfied}, NextActions: []NextAction{ActionNone},
+		EvaluatorRevision: "evaluator-v1", EvaluatedAt: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func validEvaluateInput() EvaluateInput {
+	return EvaluateInput{
+		ResultID: "assessment-result-00000000000000000000000000000001", ObjectiveID: "objective-1",
+		Control: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ScopeState: ScopeInScope,
+		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"}}},
+		CoverageState:          CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
+		Now: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+	}
+}

--- a/internal/complianceassessment/types_test.go
+++ b/internal/complianceassessment/types_test.go
@@ -77,6 +77,37 @@ func TestCanonicalResultRejectsUnsupportedPass(t *testing.T) {
 	}
 }
 
+func TestEvaluateObjectiveRejectsSyntheticSatisfiedAssessment(t *testing.T) {
+	input := validEvaluateInput()
+	input.RequirementAssessments = []compliance.ControlEvidenceRequirementAssessment{{
+		Status: compliance.ControlEvidenceRequirementSatisfied,
+	}}
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective() error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func TestInputManifestRequiresCompleteCursorChain(t *testing.T) {
+	manifest := validManifest()
+	manifest.Receipts[1].Cursor = "disconnected"
+	if err := ValidateInputManifest(manifest); !errors.Is(err, ErrInvalidManifest) {
+		t.Fatalf("ValidateInputManifest() error = %v, want ErrInvalidManifest", err)
+	}
+}
+
+func TestInputManifestAcceptsEmptyCompletePopulationWithoutWatermark(t *testing.T) {
+	manifest := validManifest()
+	zero := uint64(0)
+	manifest.Receipts = []CollectionReceipt{{
+		Kind: "findings", RuntimeID: "runtime-1", QueryDigest: manifest.RequestedScopeDigest,
+		ExpectedTotal: &zero, Cutoff: manifest.CollectionCutoff, Completeness: CollectionComplete,
+		PageDigest: manifest.MappingSetDigest,
+	}}
+	if err := ValidateInputManifest(manifest); err != nil {
+		t.Fatalf("ValidateInputManifest() error = %v", err)
+	}
+}
+
 func validManifest() InputManifest {
 	digestA := "sha256:" + strings.Repeat("a", 64)
 	digestB := "sha256:" + strings.Repeat("b", 64)
@@ -115,8 +146,11 @@ func validEvaluateInput() EvaluateInput {
 	return EvaluateInput{
 		ResultID: "assessment-result-00000000000000000000000000000001", ObjectiveID: "objective-1",
 		Control: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ScopeState: ScopeInScope,
-		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"}}},
-		CoverageState:          CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
+		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{
+			RequirementKey: "requirement-1", ControlRef: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"},
+			SourceID: "source-1", EntityType: "resource", Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"},
+		}},
+		CoverageState: CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
 		Now: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
 	}
 }

--- a/internal/complianceassessment/validation.go
+++ b/internal/complianceassessment/validation.go
@@ -1,0 +1,128 @@
+package complianceassessment
+
+func knownScopeState(value ScopeState) bool {
+	switch value {
+	case ScopeInScope, ScopeNotApplicable, ScopeUnresolved:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownOutcome(value AutomatedOutcome) bool {
+	switch value {
+	case OutcomeSatisfied, OutcomeNotSatisfied, OutcomeIndeterminate, OutcomeNotAssessed:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownDesignState(value DesignState) bool {
+	switch value {
+	case DesignEffective, DesignIneffective, DesignUnknown, DesignNotAssessed:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownOperatingState(value OperatingEffectivenessState) bool {
+	switch value {
+	case OperatingEffective, OperatingIneffective, OperatingUnknown, OperatingNotTested:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownEvidenceState(value EvidenceState) bool {
+	switch value {
+	case EvidenceSufficient, EvidenceMissing, EvidenceStale, EvidenceConflicting,
+		EvidenceUntrusted, EvidenceIncomplete, EvidenceManualReview:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownDispositionState(value DispositionState) bool {
+	switch value {
+	case DispositionNone, DispositionAcceptedException, DispositionAcceptedRisk, DispositionReviewOverride:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownAssurance(value Assurance) bool {
+	switch value {
+	case AssuranceHigh, AssuranceMedium, AssuranceLow, AssuranceNone:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownAuditorState(value AuditorState) bool {
+	switch value {
+	case AuditorNotReviewed, AuditorAccepted, AuditorChangesRequested, AuditorRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownCoverageState(value CoverageState) bool {
+	switch value {
+	case CoverageComplete, CoveragePartial, CoverageEmpty, CoverageUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownSourceState(value SourceState) bool {
+	switch value {
+	case SourceSupported, SourcePartial, SourceStale, SourceFailed, SourceUnconfigured,
+		SourceUnsupported, SourceUnverified, SourceConflicting, SourceUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownReasonCode(value ReasonCode) bool {
+	switch value {
+	case ReasonSatisfied, ReasonActiveFinding, ReasonEvidenceMissing, ReasonEvidenceInvalid,
+		ReasonEvidenceStale, ReasonEvidenceConflicting, ReasonCoverageIncomplete,
+		ReasonSourceUntrusted, ReasonSourceUnknown, ReasonManualEvidence,
+		ReasonAcceptedException, ReasonAcceptedRisk, ReasonNotApplicable,
+		ReasonInheritedResponsibility, ReasonSampledTesting, ReasonSourceUnconfigured,
+		ReasonSourceUnsupported, ReasonSourcePartial, ReasonSourceFailed, ReasonSourceStale,
+		ReasonScopeUnresolved, ReasonPopulationEmpty:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownNextAction(value NextAction) bool {
+	switch value {
+	case ActionNone, ActionReview, ActionCollectEvidence, ActionRefreshEvidence,
+		ActionRestoreSource, ActionResolveScope, ActionRemediate, ActionRetest:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownCompleteness(value CollectionCompleteness) bool {
+	switch value {
+	case CollectionComplete, CollectionPartial, CollectionTruncated,
+		CollectionChangedDuringScan, CollectionUnknown:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/evidenceledger/service.go
+++ b/internal/evidenceledger/service.go
@@ -1,0 +1,393 @@
+package evidenceledger
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+var ErrInvalidEvidence = errors.New("invalid evidence ledger request")
+
+type Service struct {
+	store ports.EvidenceLedgerStore
+	log   ports.AppendLog
+	now   func() time.Time
+}
+
+func New(store ports.EvidenceLedgerStore, log ports.AppendLog) *Service {
+	return &Service{store: store, log: log, now: func() time.Time { return time.Now().UTC() }}
+}
+
+type RegisterVersionRequest struct {
+	Artifact ports.EvidenceArtifact
+	Version  ports.EvidenceVersion
+	ActorID  string
+}
+
+func (s *Service) RegisterVersion(ctx context.Context, request RegisterVersionRequest) (ports.EvidenceVersion, error) {
+	if s == nil || s.store == nil || s.log == nil {
+		return ports.EvidenceVersion{}, fmt.Errorf("%w: ledger capability unavailable", ErrInvalidEvidence)
+	}
+	now := s.now().UTC().Truncate(time.Millisecond)
+	artifact := request.Artifact
+	version := request.Version
+	actorID := strings.TrimSpace(request.ActorID)
+	artifact.TenantID = strings.TrimSpace(artifact.TenantID)
+	version.TenantID = artifact.TenantID
+	if artifact.ID == "" {
+		id, err := compliance.NewIdentifier(compliance.IdentifierArtifact)
+		if err != nil {
+			return ports.EvidenceVersion{}, err
+		}
+		artifact.ID = id
+	}
+	if version.ID == "" {
+		id, err := compliance.NewRevisionIdentifier(compliance.IdentifierArtifact)
+		if err != nil {
+			return ports.EvidenceVersion{}, err
+		}
+		version.ID = id
+	}
+	version.ArtifactID = artifact.ID
+	if artifact.CreatedAt.IsZero() {
+		artifact.CreatedAt = now
+	}
+	if artifact.CreatedBy == "" {
+		artifact.CreatedBy = actorID
+	}
+	version.RecordedAt = now
+	if version.ValidFrom.IsZero() {
+		version.ValidFrom = version.Provenance.CollectedAt
+	}
+	version = normalizeVersion(version)
+	artifact = normalizeArtifact(artifact)
+	if strings.TrimSpace(version.Provenance.SourceProofRevisionID) == "" {
+		version.State = ports.EvidenceStateValidationFailed
+		version.QuarantineReason = "source_proof_unverified"
+	} else if version.State == "" {
+		version.State = ports.EvidenceStateCollected
+	}
+	if version.Revision.Version == 0 {
+		version.Revision.Version = 1
+	}
+	version.Revision.ID = artifact.ID
+	version.Revision.RevisionID = version.ID
+	version.Revision.LastModified = now
+	version.Revision.ContentDigest = ""
+	recordDigest, err := semanticDigest(version)
+	if err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	version.Revision.ContentDigest = recordDigest
+	if err := validateArtifactVersion(artifact, version, actorID); err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	payload, err := json.Marshal(struct {
+		Artifact ports.EvidenceArtifact `json:"artifact"`
+		Version  ports.EvidenceVersion  `json:"version"`
+	}{artifact, version})
+	if err != nil {
+		return ports.EvidenceVersion{}, fmt.Errorf("marshal evidence version event: %w", err)
+	}
+	aggregateVersion, err := eventAggregateVersion(version.Revision.Version)
+	if err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	event, err := workflowevents.NewComplianceAggregateEvent(workflowevents.ComplianceAggregateRecorded{
+		Kind: workflowevents.EventKindComplianceEvidenceVersionRecorded, TenantID: artifact.TenantID,
+		AggregateType: "evidence_artifact", AggregateID: artifact.ID, RevisionID: version.ID,
+		AggregateVersion: aggregateVersion, Operation: "version_recorded",
+		ContentDigest: recordDigest, PayloadJSON: string(payload), ActorID: actorID, RecordedAt: now.Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	if err := s.log.Append(ctx, event); err != nil {
+		return ports.EvidenceVersion{}, fmt.Errorf("append evidence version: %w", err)
+	}
+	if err := s.store.ApplyEvidenceVersion(ctx, event.GetId(), artifact, version); err != nil {
+		return ports.EvidenceVersion{}, fmt.Errorf("project evidence version: %w", err)
+	}
+	return version, nil
+}
+
+type CreateClaimRequest struct {
+	Claim   ports.EvidenceClaim
+	ActorID string
+}
+
+func (s *Service) CreateClaim(ctx context.Context, request CreateClaimRequest) (ports.EvidenceClaim, error) {
+	if s == nil || s.store == nil || s.log == nil {
+		return ports.EvidenceClaim{}, fmt.Errorf("%w: ledger capability unavailable", ErrInvalidEvidence)
+	}
+	claim := normalizeClaim(request.Claim)
+	actorID := strings.TrimSpace(request.ActorID)
+	if claim.ID == "" {
+		id, err := compliance.NewIdentifier(compliance.IdentifierClaim)
+		if err != nil {
+			return ports.EvidenceClaim{}, err
+		}
+		claim.ID = id
+	}
+	if claim.Version == 0 {
+		claim.Version = 1
+	}
+	if claim.CreatedAt.IsZero() {
+		claim.CreatedAt = s.now().UTC().Truncate(time.Millisecond)
+	}
+	if claim.CreatedBy == "" {
+		claim.CreatedBy = actorID
+	}
+	if claim.Decision.ReviewState == "" {
+		claim.Decision.ReviewState = ports.EvidenceReviewPending
+	}
+	version, err := s.store.GetEvidenceVersion(ctx, claim.TenantID, claim.ArtifactVersionID)
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	if err := validateClaimRecord(claim, version, actorID); err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	return s.appendClaim(ctx, workflowevents.EventKindComplianceEvidenceClaimRecorded, "claim_recorded", claim, 0, actorID)
+}
+
+func (s *Service) ReviewClaim(ctx context.Context, tenantID, claimID, reviewerID, state, reason string, expectedVersion uint64) (ports.EvidenceClaim, error) {
+	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(claimID))
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	if claim.Version != expectedVersion {
+		return ports.EvidenceClaim{}, ports.ErrEvidenceLedgerConflict
+	}
+	state = strings.TrimSpace(state)
+	if state != ports.EvidenceReviewApproved && state != ports.EvidenceReviewRejected {
+		return ports.EvidenceClaim{}, fmt.Errorf("%w: review state is invalid", ErrInvalidEvidence)
+	}
+	if strings.TrimSpace(reviewerID) == "" || strings.TrimSpace(reason) == "" {
+		return ports.EvidenceClaim{}, fmt.Errorf("%w: reviewer and reason are required", ErrInvalidEvidence)
+	}
+	claim.Decision.ReviewState = state
+	claim.Decision.ReviewerID = strings.TrimSpace(reviewerID)
+	claim.Decision.ReviewReason = strings.TrimSpace(reason)
+	claim.Decision.ReviewedAt = s.now().UTC().Truncate(time.Millisecond)
+	claim.Version++
+	return s.appendClaim(ctx, workflowevents.EventKindComplianceEvidenceClaimReviewed, "claim_reviewed", claim, expectedVersion, reviewerID)
+}
+
+func (s *Service) InvalidateClaim(ctx context.Context, tenantID, claimID, actorID, reason string, expectedVersion uint64) (ports.EvidenceClaim, error) {
+	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(claimID))
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	if claim.Version != expectedVersion {
+		return ports.EvidenceClaim{}, ports.ErrEvidenceLedgerConflict
+	}
+	if strings.TrimSpace(actorID) == "" || strings.TrimSpace(reason) == "" {
+		return ports.EvidenceClaim{}, fmt.Errorf("%w: actor and invalidation reason are required", ErrInvalidEvidence)
+	}
+	claim.Decision.InvalidatedAt = s.now().UTC().Truncate(time.Millisecond)
+	claim.Decision.InvalidationReason = strings.TrimSpace(reason)
+	claim.Version++
+	return s.appendClaim(ctx, workflowevents.EventKindComplianceEvidenceClaimInvalidated, "claim_invalidated", claim, expectedVersion, actorID)
+}
+
+func (s *Service) appendClaim(ctx context.Context, kind, operation string, claim ports.EvidenceClaim, expectedVersion uint64, actorID string) (ports.EvidenceClaim, error) {
+	payload, err := json.Marshal(claim)
+	if err != nil {
+		return ports.EvidenceClaim{}, fmt.Errorf("marshal evidence claim event: %w", err)
+	}
+	digest, err := semanticDigest(claim)
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	aggregateVersion, err := eventAggregateVersion(claim.Version)
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	event, err := workflowevents.NewComplianceAggregateEvent(workflowevents.ComplianceAggregateRecorded{
+		Kind: kind, TenantID: claim.TenantID, AggregateType: "evidence_claim", AggregateID: claim.ID,
+		RevisionID: fmt.Sprintf("%s-v%d", claim.ID, claim.Version), AggregateVersion: aggregateVersion,
+		Operation: operation, ContentDigest: digest, PayloadJSON: string(payload), ActorID: strings.TrimSpace(actorID),
+		RecordedAt: s.now().UTC().Truncate(time.Millisecond).Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	if err := s.log.Append(ctx, event); err != nil {
+		return ports.EvidenceClaim{}, fmt.Errorf("append evidence claim: %w", err)
+	}
+	if err := s.store.ApplyEvidenceClaim(ctx, event.GetId(), claim, expectedVersion); err != nil {
+		return ports.EvidenceClaim{}, fmt.Errorf("project evidence claim: %w", err)
+	}
+	return claim, nil
+}
+
+func normalizeArtifact(value ports.EvidenceArtifact) ports.EvidenceArtifact {
+	value.ID = strings.TrimSpace(value.ID)
+	value.TenantID = strings.TrimSpace(value.TenantID)
+	value.Title = strings.TrimSpace(value.Title)
+	value.Description = strings.TrimSpace(value.Description)
+	value.Type = strings.TrimSpace(value.Type)
+	value.CreatedBy = strings.TrimSpace(value.CreatedBy)
+	value.CreatedAt = value.CreatedAt.UTC().Truncate(time.Millisecond)
+	return value
+}
+
+func normalizeVersion(value ports.EvidenceVersion) ports.EvidenceVersion {
+	value.ID = strings.TrimSpace(value.ID)
+	value.TenantID = strings.TrimSpace(value.TenantID)
+	value.ArtifactID = strings.TrimSpace(value.ArtifactID)
+	value.Content.MediaType = strings.TrimSpace(value.Content.MediaType)
+	value.Content.URI = strings.TrimSpace(value.Content.URI)
+	value.Content.ContentDigest = strings.TrimSpace(value.Content.ContentDigest)
+	value.Provenance.Producer = strings.TrimSpace(value.Provenance.Producer)
+	value.Provenance.ProducerVersion = strings.TrimSpace(value.Provenance.ProducerVersion)
+	value.Provenance.SourceRuntimeID = strings.TrimSpace(value.Provenance.SourceRuntimeID)
+	value.Provenance.SourceEventID = strings.TrimSpace(value.Provenance.SourceEventID)
+	value.Provenance.SourceProofRevisionID = strings.TrimSpace(value.Provenance.SourceProofRevisionID)
+	value.Governance.Sensitivity = strings.TrimSpace(value.Governance.Sensitivity)
+	value.Governance.AccessPolicy = strings.TrimSpace(value.Governance.AccessPolicy)
+	value.Governance.RedactionState = strings.TrimSpace(value.Governance.RedactionState)
+	value.Governance.ParserQuality = strings.TrimSpace(value.Governance.ParserQuality)
+	value.State = strings.TrimSpace(value.State)
+	value.QuarantineReason = strings.TrimSpace(value.QuarantineReason)
+	value.PredecessorID = strings.TrimSpace(value.PredecessorID)
+	value.Provenance.CollectedAt = value.Provenance.CollectedAt.UTC().Truncate(time.Millisecond)
+	value.Provenance.PeriodStart = value.Provenance.PeriodStart.UTC().Truncate(time.Millisecond)
+	value.Provenance.PeriodEnd = value.Provenance.PeriodEnd.UTC().Truncate(time.Millisecond)
+	value.ValidFrom = value.ValidFrom.UTC().Truncate(time.Millisecond)
+	value.ValidUntil = value.ValidUntil.UTC().Truncate(time.Millisecond)
+	value.Governance.RetentionUntil = value.Governance.RetentionUntil.UTC().Truncate(time.Millisecond)
+	value.RecordedAt = value.RecordedAt.UTC().Truncate(time.Millisecond)
+	value.Subjects = normalizeSubjects(value.Subjects)
+	value.Provenance.DerivationIDs = normalizedStrings(value.Provenance.DerivationIDs)
+	return value
+}
+
+func normalizeClaim(value ports.EvidenceClaim) ports.EvidenceClaim {
+	value.ID = strings.TrimSpace(value.ID)
+	value.TenantID = strings.TrimSpace(value.TenantID)
+	value.ArtifactVersionID = strings.TrimSpace(value.ArtifactVersionID)
+	value.Scope.ObjectiveID = strings.TrimSpace(value.Scope.ObjectiveID)
+	value.Scope.ImplementationRevisionID = strings.TrimSpace(value.Scope.ImplementationRevisionID)
+	value.Scope.RequirementID = strings.TrimSpace(value.Scope.RequirementID)
+	value.Linkage = strings.TrimSpace(value.Linkage)
+	value.Strength = strings.TrimSpace(value.Strength)
+	value.Limitation = strings.TrimSpace(value.Limitation)
+	value.MappingRationale = strings.TrimSpace(value.MappingRationale)
+	value.Decision.ReviewState = strings.TrimSpace(value.Decision.ReviewState)
+	value.Scope.Subjects = normalizeSubjects(value.Scope.Subjects)
+	value.Scope.PeriodStart = value.Scope.PeriodStart.UTC().Truncate(time.Millisecond)
+	value.Scope.PeriodEnd = value.Scope.PeriodEnd.UTC().Truncate(time.Millisecond)
+	return value
+}
+
+func normalizeSubjects(values []ports.EvidenceSubjectRef) []ports.EvidenceSubjectRef {
+	values = append([]ports.EvidenceSubjectRef(nil), values...)
+	for index := range values {
+		values[index].Type = strings.TrimSpace(values[index].Type)
+		values[index].ID = strings.TrimSpace(values[index].ID)
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i].Type+"\x00"+values[i].ID < values[j].Type+"\x00"+values[j].ID })
+	result := values[:0]
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1] == value {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func semanticDigest(value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("marshal evidence semantic content: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(digest[:]), nil
+}
+
+func eventAggregateVersion(value uint64) (int64, error) {
+	if value == 0 || value > math.MaxInt64 {
+		return 0, fmt.Errorf("%w: aggregate version is out of range", ErrInvalidEvidence)
+	}
+	return int64(value), nil
+}
+
+func validateArtifactVersion(artifact ports.EvidenceArtifact, version ports.EvidenceVersion, actorID string) error {
+	if artifact.ID == "" || artifact.TenantID == "" || artifact.Title == "" || artifact.Type == "" || actorID == "" {
+		return fmt.Errorf("%w: artifact identity, tenant, title, type, and actor are required", ErrInvalidEvidence)
+	}
+	if err := compliance.ValidateIdentifier(compliance.IdentifierArtifact, artifact.ID); err != nil {
+		return err
+	}
+	if err := compliance.ValidateRevisionIdentifier(compliance.IdentifierArtifact, version.ID); err != nil {
+		return err
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(version.Content.ContentDigest)); err != nil {
+		return err
+	}
+	if version.Content.MediaType == "" || version.Content.URI == "" || version.Provenance.Producer == "" || version.Provenance.CollectedAt.IsZero() || version.ValidFrom.IsZero() || len(version.Subjects) == 0 || version.Governance.AccessPolicy == "" {
+		return fmt.Errorf("%w: version metadata is incomplete", ErrInvalidEvidence)
+	}
+	parsed, err := url.Parse(version.Content.URI)
+	if err != nil || parsed.Scheme == "" || parsed.Scheme == "file" || parsed.Scheme == "data" {
+		return fmt.Errorf("%w: evidence URI must be an approved immutable reference", ErrInvalidEvidence)
+	}
+	for _, subject := range version.Subjects {
+		if strings.TrimSpace(subject.Type) == "" || strings.TrimSpace(subject.ID) == "" {
+			return fmt.Errorf("%w: evidence subject type and id are required", ErrInvalidEvidence)
+		}
+	}
+	if version.Revision.ID == "" || version.Revision.RevisionID == "" || version.Revision.Version == 0 || version.Revision.LastModified.IsZero() {
+		return fmt.Errorf("%w: evidence revision metadata is incomplete", ErrInvalidEvidence)
+	}
+	return compliance.ValidateContentDigest(compliance.ContentDigest(version.Revision.ContentDigest))
+}
+
+func validateClaimRecord(claim ports.EvidenceClaim, version ports.EvidenceVersion, actorID string) error {
+	if claim.TenantID == "" || claim.ArtifactVersionID == "" || claim.Scope.ObjectiveID == "" || claim.Scope.ImplementationRevisionID == "" || claim.Scope.RequirementID == "" || actorID == "" {
+		return fmt.Errorf("%w: claim identity, scope, requirement, and actor are required", ErrInvalidEvidence)
+	}
+	if version.TenantID != claim.TenantID {
+		return ports.ErrEvidenceVersionNotFound
+	}
+	if claim.Linkage != ports.EvidenceLinkDirect && claim.Linkage != ports.EvidenceLinkInherited && claim.Linkage != ports.EvidenceLinkInferred {
+		return fmt.Errorf("%w: claim linkage is invalid", ErrInvalidEvidence)
+	}
+	if claim.Strength == "" || claim.MappingRationale == "" || claim.Scope.PeriodStart.IsZero() || claim.Scope.PeriodEnd.IsZero() || claim.Scope.PeriodEnd.Before(claim.Scope.PeriodStart) || len(claim.Scope.Subjects) == 0 {
+		return fmt.Errorf("%w: claim basis is incomplete", ErrInvalidEvidence)
+	}
+	return nil
+}

--- a/internal/evidenceledger/service_test.go
+++ b/internal/evidenceledger/service_test.go
@@ -1,0 +1,287 @@
+package evidenceledger
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestArtifactVersionSupportsIndependentClaims(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{}, now)
+	version := registerTestVersion(t, service, now, true)
+	first := createTestClaim(t, service, version, "objective-1")
+	second, err := service.ReuseClaim(context.Background(), first.TenantID, first.ID, "owner-2", ports.EvidenceClaim{
+		Scope: ports.EvidenceClaimScope{ObjectiveID: "objective-2", ImplementationRevisionID: "implementation-revision-2",
+			RequirementID: "requirement-2", Subjects: first.Scope.Subjects, PeriodStart: first.Scope.PeriodStart,
+			PeriodEnd: first.Scope.PeriodEnd}, Linkage: ports.EvidenceLinkDirect, Strength: "strong",
+		MappingRationale: "Same artifact supports a separate scoped objective.",
+	})
+	if err != nil {
+		t.Fatalf("ReuseClaim() error = %v", err)
+	}
+	approved, err := service.ReviewClaim(context.Background(), first.TenantID, first.ID, "reviewer-1", ports.EvidenceReviewApproved, "Verified against the requirement.", first.Version)
+	if err != nil {
+		t.Fatalf("ReviewClaim() error = %v", err)
+	}
+	if approved.Decision.ReviewState != ports.EvidenceReviewApproved {
+		t.Fatalf("first review state = %q", approved.Decision.ReviewState)
+	}
+	storedSecond, err := store.GetEvidenceClaim(context.Background(), second.TenantID, second.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedSecond.Decision.ReviewState != ports.EvidenceReviewPending || storedSecond.Decision.ReviewerID != "" {
+		t.Fatalf("second claim inherited approval: %#v", storedSecond)
+	}
+}
+
+func TestQuarantinedVersionCannotSatisfyClaim(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{}, now)
+	version := registerTestVersion(t, service, now, false)
+	claim := createTestClaim(t, service, version, "objective-1")
+	claim, err := service.ReviewClaim(context.Background(), claim.TenantID, claim.ID, "reviewer-1", ports.EvidenceReviewApproved, "Metadata reviewed.", claim.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validation, err := service.ValidateClaim(context.Background(), ValidateClaimRequest{
+		TenantID: claim.TenantID, ClaimID: claim.ID, Subjects: claim.Scope.Subjects,
+		PeriodStart: claim.Scope.PeriodStart, PeriodEnd: claim.Scope.PeriodEnd, At: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if validation.Valid || !contains(validation.ReasonCodes, reasonVersionQuarantined) {
+		t.Fatalf("validation = %#v", validation)
+	}
+}
+
+func TestInvalidationAndScopePeriodChecks(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{}, now)
+	version := registerTestVersion(t, service, now, true)
+	claim := createTestClaim(t, service, version, "objective-1")
+	claim, err := service.ReviewClaim(context.Background(), claim.TenantID, claim.ID, "reviewer-1", ports.EvidenceReviewApproved, "Verified.", claim.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid, err := service.ValidateClaim(context.Background(), ValidateClaimRequest{TenantID: claim.TenantID, ClaimID: claim.ID, Subjects: claim.Scope.Subjects, PeriodStart: claim.Scope.PeriodStart, PeriodEnd: claim.Scope.PeriodEnd, At: now})
+	if err != nil || !valid.Valid {
+		t.Fatalf("ValidateClaim() = (%#v, %v)", valid, err)
+	}
+	invalidated, err := service.InvalidateClaim(context.Background(), claim.TenantID, claim.ID, "owner-1", "Source record was revoked.", claim.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid, err := service.ValidateClaim(context.Background(), ValidateClaimRequest{TenantID: claim.TenantID, ClaimID: invalidated.ID, Subjects: []ports.EvidenceSubjectRef{{Type: "asset", ID: "different"}}, PeriodStart: now.Add(-48 * time.Hour), PeriodEnd: now, At: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, reason := range []string{reasonClaimInvalidated, reasonPeriodGap, reasonSubjectMismatch} {
+		if !contains(invalid.ReasonCodes, reason) {
+			t.Fatalf("validation reasons %v missing %q", invalid.ReasonCodes, reason)
+		}
+	}
+}
+
+func TestEvidenceReadEnforcesPurposeSensitivityAndTenant(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{}, now)
+	version := registerTestVersion(t, service, now, true)
+	if _, err := service.ReadVersion(context.Background(), ports.EvidenceAccessRequest{TenantID: version.TenantID, ActorID: "reader", Purpose: "assessment", MaximumSensitivity: ports.EvidenceSensitivityInternal}, version.ID); !errors.Is(err, ports.ErrEvidenceAccessDenied) {
+		t.Fatalf("restricted read error = %v", err)
+	}
+	if _, err := service.ReadVersion(context.Background(), ports.EvidenceAccessRequest{TenantID: "foreign", ActorID: "reader", Purpose: "audit", MaximumSensitivity: ports.EvidenceSensitivityRestricted}, version.ID); !errors.Is(err, ports.ErrEvidenceVersionNotFound) {
+		t.Fatalf("foreign tenant read error = %v", err)
+	}
+	if _, err := service.ReadVersion(context.Background(), ports.EvidenceAccessRequest{TenantID: version.TenantID, ActorID: "reader", Purpose: "audit", MaximumSensitivity: ports.EvidenceSensitivityRestricted}, version.ID); err != nil {
+		t.Fatalf("authorized read error = %v", err)
+	}
+}
+
+func TestAppendFailurePreventsProjection(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{err: errors.New("append unavailable")}, now)
+	request := testVersionRequest(now, true)
+	if _, err := service.RegisterVersion(context.Background(), request); err == nil {
+		t.Fatal("RegisterVersion() unexpectedly succeeded")
+	}
+	if len(store.versions) != 0 {
+		t.Fatalf("projection changed after append failure: %#v", store.versions)
+	}
+}
+
+func newTestService(store *memoryStore, log *memoryLog, now time.Time) *Service {
+	service := New(store, log)
+	service.now = func() time.Time { return now }
+	return service
+}
+
+func registerTestVersion(t *testing.T, service *Service, now time.Time, trusted bool) ports.EvidenceVersion {
+	t.Helper()
+	version, err := service.RegisterVersion(context.Background(), testVersionRequest(now, trusted))
+	if err != nil {
+		t.Fatalf("RegisterVersion() error = %v", err)
+	}
+	return version
+}
+
+func testVersionRequest(now time.Time, trusted bool) RegisterVersionRequest {
+	proof := ""
+	if trusted {
+		proof = "source-proof-revision-1"
+	}
+	return RegisterVersionRequest{
+		Artifact: ports.EvidenceArtifact{TenantID: "tenant-1", Title: "Access review export", Type: "record", CreatedBy: "owner-1"},
+		Version: ports.EvidenceVersion{
+			Content: ports.EvidenceContentRef{MediaType: "application/json", URI: "cas://evidence/sha256-abc",
+				ContentDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", SizeBytes: 10},
+			Provenance: ports.EvidenceProvenance{Producer: "source-runtime", CollectedAt: now,
+				PeriodStart: now.Add(-24 * time.Hour), PeriodEnd: now, SourceProofRevisionID: proof},
+			ValidFrom: now.Add(-24 * time.Hour), ValidUntil: now.Add(24 * time.Hour),
+			Subjects:   []ports.EvidenceSubjectRef{{Type: "asset", ID: "asset-1"}},
+			Governance: ports.EvidenceGovernance{Sensitivity: ports.EvidenceSensitivityRestricted, AccessPolicy: "evidence-owner-or-engagement"},
+		},
+		ActorID: "owner-1",
+	}
+}
+
+func createTestClaim(t *testing.T, service *Service, version ports.EvidenceVersion, objectiveID string) ports.EvidenceClaim {
+	t.Helper()
+	claim, err := service.CreateClaim(context.Background(), CreateClaimRequest{Claim: ports.EvidenceClaim{
+		TenantID: version.TenantID, ArtifactVersionID: version.ID,
+		Scope: ports.EvidenceClaimScope{ObjectiveID: objectiveID, ImplementationRevisionID: "implementation-revision-1", RequirementID: "requirement-1",
+			Subjects: version.Subjects, PeriodStart: version.Provenance.PeriodStart, PeriodEnd: version.Provenance.PeriodEnd},
+		Linkage: ports.EvidenceLinkDirect, Strength: "strong", MappingRationale: "Direct source record for the objective.",
+	}, ActorID: "owner-1"})
+	if err != nil {
+		t.Fatalf("CreateClaim() error = %v", err)
+	}
+	return claim
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+type memoryLog struct {
+	mu     sync.Mutex
+	events []*cerebrov1.EventEnvelope
+	err    error
+}
+
+func (l *memoryLog) Ping(context.Context) error { return nil }
+func (l *memoryLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.err != nil {
+		return l.err
+	}
+	l.events = append(l.events, event)
+	return nil
+}
+
+type memoryStore struct {
+	mu        sync.Mutex
+	artifacts map[string]ports.EvidenceArtifact
+	versions  map[string]ports.EvidenceVersion
+	claims    map[string]ports.EvidenceClaim
+	events    map[string]struct{}
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{artifacts: map[string]ports.EvidenceArtifact{}, versions: map[string]ports.EvidenceVersion{}, claims: map[string]ports.EvidenceClaim{}, events: map[string]struct{}{}}
+}
+
+func tenantKey(tenantID, id string) string { return tenantID + "\x00" + id }
+
+func (s *memoryStore) ApplyEvidenceVersion(_ context.Context, eventID string, artifact ports.EvidenceArtifact, version ports.EvidenceVersion) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.events[eventID]; ok {
+		return nil
+	}
+	s.events[eventID] = struct{}{}
+	s.artifacts[tenantKey(artifact.TenantID, artifact.ID)] = artifact
+	s.versions[tenantKey(version.TenantID, version.ID)] = version
+	return nil
+}
+
+func (s *memoryStore) ApplyEvidenceClaim(_ context.Context, eventID string, claim ports.EvidenceClaim, expectedVersion uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.events[eventID]; ok {
+		return nil
+	}
+	key := tenantKey(claim.TenantID, claim.ID)
+	existing, ok := s.claims[key]
+	if ok && existing.Version != expectedVersion {
+		return ports.ErrEvidenceLedgerConflict
+	}
+	if !ok && expectedVersion != 0 {
+		return ports.ErrEvidenceLedgerConflict
+	}
+	s.events[eventID] = struct{}{}
+	s.claims[key] = claim
+	return nil
+}
+
+func (s *memoryStore) GetEvidenceArtifact(_ context.Context, tenantID, id string) (ports.EvidenceArtifact, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.artifacts[tenantKey(tenantID, id)]
+	if !ok {
+		return ports.EvidenceArtifact{}, ports.ErrEvidenceArtifactNotFound
+	}
+	return value, nil
+}
+func (s *memoryStore) GetEvidenceVersion(_ context.Context, tenantID, id string) (ports.EvidenceVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.versions[tenantKey(tenantID, id)]
+	if !ok {
+		return ports.EvidenceVersion{}, ports.ErrEvidenceVersionNotFound
+	}
+	return value, nil
+}
+func (s *memoryStore) GetEvidenceClaim(_ context.Context, tenantID, id string) (ports.EvidenceClaim, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.claims[tenantKey(tenantID, id)]
+	if !ok {
+		return ports.EvidenceClaim{}, ports.ErrEvidenceClaimNotFound
+	}
+	return value, nil
+}
+func (s *memoryStore) ListEvidenceClaimsByVersion(_ context.Context, tenantID, versionID string) ([]ports.EvidenceClaim, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []ports.EvidenceClaim
+	for _, claim := range s.claims {
+		if claim.TenantID == tenantID && claim.ArtifactVersionID == versionID {
+			result = append(result, claim)
+		}
+	}
+	return result, nil
+}

--- a/internal/evidenceledger/validation.go
+++ b/internal/evidenceledger/validation.go
@@ -1,0 +1,146 @@
+package evidenceledger
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	reasonApproved           = "evidence_claim_approved"
+	reasonClaimPending       = "evidence_claim_pending"
+	reasonClaimRejected      = "evidence_claim_rejected"
+	reasonClaimInvalidated   = "evidence_claim_invalidated"
+	reasonVersionQuarantined = "evidence_version_quarantined"
+	reasonVersionRevoked     = "evidence_version_revoked"
+	reasonVersionExpired     = "evidence_version_expired"
+	reasonPeriodGap          = "evidence_period_gap"
+	reasonSubjectMismatch    = "evidence_subject_mismatch"
+)
+
+type ValidateClaimRequest struct {
+	TenantID    string
+	ClaimID     string
+	Subjects    []ports.EvidenceSubjectRef
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+	At          time.Time
+}
+
+func (s *Service) ValidateClaim(ctx context.Context, request ValidateClaimRequest) (ports.EvidenceClaimValidation, error) {
+	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(request.TenantID), strings.TrimSpace(request.ClaimID))
+	if err != nil {
+		return ports.EvidenceClaimValidation{}, err
+	}
+	version, err := s.store.GetEvidenceVersion(ctx, claim.TenantID, claim.ArtifactVersionID)
+	if err != nil {
+		return ports.EvidenceClaimValidation{}, err
+	}
+	result := ports.EvidenceClaimValidation{Valid: true, ReasonCodes: []string{reasonApproved}, NextActions: []string{"none"}}
+	addInvalid := func(reason, action string) {
+		if result.Valid {
+			result.ReasonCodes = nil
+			result.NextActions = nil
+		}
+		result.Valid = false
+		result.ReasonCodes = append(result.ReasonCodes, reason)
+		result.NextActions = append(result.NextActions, action)
+	}
+	if !claim.Decision.InvalidatedAt.IsZero() {
+		addInvalid(reasonClaimInvalidated, "replace_claim")
+	}
+	switch claim.Decision.ReviewState {
+	case ports.EvidenceReviewApproved:
+	case ports.EvidenceReviewRejected:
+		addInvalid(reasonClaimRejected, "replace_claim")
+	default:
+		addInvalid(reasonClaimPending, "review")
+	}
+	if version.State == ports.EvidenceStateValidationFailed || strings.TrimSpace(version.QuarantineReason) != "" {
+		addInvalid(reasonVersionQuarantined, "repair_source")
+	}
+	if version.State == ports.EvidenceStateRevoked || version.State == ports.EvidenceStateSuperseded {
+		addInvalid(reasonVersionRevoked, "collect_evidence")
+	}
+	at := request.At.UTC()
+	if at.IsZero() {
+		at = s.now().UTC()
+	}
+	if !version.ValidUntil.IsZero() && !at.Before(version.ValidUntil) {
+		addInvalid(reasonVersionExpired, "refresh_evidence")
+	}
+	if request.PeriodStart.Before(claim.Scope.PeriodStart) || request.PeriodEnd.After(claim.Scope.PeriodEnd) || request.PeriodStart.Before(version.Provenance.PeriodStart) || request.PeriodEnd.After(version.Provenance.PeriodEnd) {
+		addInvalid(reasonPeriodGap, "collect_evidence")
+	}
+	if !subjectsCover(claim.Scope.Subjects, normalizeSubjects(request.Subjects)) || !subjectsCover(version.Subjects, normalizeSubjects(request.Subjects)) {
+		addInvalid(reasonSubjectMismatch, "collect_evidence")
+	}
+	result.ReasonCodes = normalizedStrings(result.ReasonCodes)
+	result.NextActions = normalizedStrings(result.NextActions)
+	return result, nil
+}
+
+func (s *Service) ReadVersion(ctx context.Context, access ports.EvidenceAccessRequest, versionID string) (ports.EvidenceVersion, error) {
+	version, err := s.store.GetEvidenceVersion(ctx, strings.TrimSpace(access.TenantID), strings.TrimSpace(versionID))
+	if err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	if strings.TrimSpace(access.ActorID) == "" || !allowedPurpose(access.Purpose) || sensitivityRank(access.MaximumSensitivity) < sensitivityRank(version.Governance.Sensitivity) {
+		return ports.EvidenceVersion{}, ports.ErrEvidenceAccessDenied
+	}
+	return version, nil
+}
+
+// ReuseClaim creates a separate scoped claim over the same immutable version.
+// It never copies approval or invalidation state from the source claim.
+func (s *Service) ReuseClaim(ctx context.Context, sourceTenantID, sourceClaimID, actorID string, replacement ports.EvidenceClaim) (ports.EvidenceClaim, error) {
+	source, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(sourceTenantID), strings.TrimSpace(sourceClaimID))
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	replacement.ID = ""
+	replacement.TenantID = source.TenantID
+	replacement.ArtifactVersionID = source.ArtifactVersionID
+	replacement.Decision = ports.EvidenceClaimDecision{ReviewState: ports.EvidenceReviewPending}
+	replacement.Version = 1
+	return s.CreateClaim(ctx, CreateClaimRequest{Claim: replacement, ActorID: actorID})
+}
+
+func subjectsCover(available, required []ports.EvidenceSubjectRef) bool {
+	set := make(map[ports.EvidenceSubjectRef]struct{}, len(available))
+	for _, subject := range available {
+		set[subject] = struct{}{}
+	}
+	for _, subject := range required {
+		if _, ok := set[subject]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func allowedPurpose(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "assessment", "review", "audit", "export":
+		return true
+	default:
+		return false
+	}
+}
+
+func sensitivityRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case ports.EvidenceSensitivityPublic:
+		return 1
+	case ports.EvidenceSensitivityInternal:
+		return 2
+	case ports.EvidenceSensitivityConfidential:
+		return 3
+	case ports.EvidenceSensitivityRestricted:
+		return 4
+	default:
+		return 0
+	}
+}

--- a/internal/ports/evidence_ledger.go
+++ b/internal/ports/evidence_ledger.go
@@ -1,0 +1,165 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrEvidenceArtifactNotFound = errors.New("evidence artifact not found")
+	ErrEvidenceVersionNotFound  = errors.New("evidence version not found")
+	ErrEvidenceClaimNotFound    = errors.New("evidence claim not found")
+	ErrEvidenceLedgerConflict   = errors.New("evidence ledger version conflict")
+	ErrEvidenceAccessDenied     = errors.New("evidence access denied")
+)
+
+const (
+	EvidenceStateCollected        = "collected"
+	EvidenceStateValidationFailed = "validation_failed"
+	EvidenceStateUnderReview      = "under_review"
+	EvidenceStateApproved         = "approved"
+	EvidenceStateStale            = "stale"
+	EvidenceStateSuperseded       = "superseded"
+	EvidenceStateRevoked          = "revoked"
+
+	EvidenceReviewPending  = "pending"
+	EvidenceReviewApproved = "approved"
+	EvidenceReviewRejected = "rejected"
+
+	EvidenceLinkDirect    = "direct"
+	EvidenceLinkInherited = "inherited"
+	EvidenceLinkInferred  = "inferred"
+
+	EvidenceSensitivityPublic       = "public"
+	EvidenceSensitivityInternal     = "internal"
+	EvidenceSensitivityConfidential = "confidential"
+	EvidenceSensitivityRestricted   = "restricted"
+)
+
+// EvidenceArtifact is the stable logical record. It never contains bytes.
+type EvidenceArtifact struct {
+	ID          string    `json:"id"`
+	TenantID    string    `json:"tenant_id"`
+	Title       string    `json:"title"`
+	Description string    `json:"description,omitempty"`
+	Type        string    `json:"type"`
+	CreatedAt   time.Time `json:"created_at"`
+	CreatedBy   string    `json:"created_by"`
+}
+
+type EvidenceRevisionRef struct {
+	ID            string    `json:"id"`
+	RevisionID    string    `json:"revision_id"`
+	Version       uint64    `json:"version"`
+	ContentDigest string    `json:"content_digest"`
+	LastModified  time.Time `json:"last_modified"`
+}
+
+type EvidenceSubjectRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+type EvidenceContentRef struct {
+	MediaType     string `json:"media_type"`
+	URI           string `json:"uri"`
+	ContentDigest string `json:"content_digest"`
+	SizeBytes     uint64 `json:"size_bytes"`
+}
+
+type EvidenceProvenance struct {
+	Producer              string    `json:"producer"`
+	ProducerVersion       string    `json:"producer_version,omitempty"`
+	CollectedAt           time.Time `json:"collected_at"`
+	PeriodStart           time.Time `json:"period_start,omitempty"`
+	PeriodEnd             time.Time `json:"period_end,omitempty"`
+	SourceRuntimeID       string    `json:"source_runtime_id,omitempty"`
+	SourceEventID         string    `json:"source_event_id,omitempty"`
+	SourceProofRevisionID string    `json:"source_proof_revision_id"`
+	DerivationIDs         []string  `json:"derivation_ids,omitempty"`
+}
+
+type EvidenceGovernance struct {
+	Sensitivity    string    `json:"sensitivity"`
+	AccessPolicy   string    `json:"access_policy"`
+	RetentionUntil time.Time `json:"retention_until,omitempty"`
+	LegalHold      bool      `json:"legal_hold,omitempty"`
+	RedactionState string    `json:"redaction_state,omitempty"`
+	ParserQuality  string    `json:"parser_quality,omitempty"`
+}
+
+// EvidenceVersion points to immutable bytes in the approved content-addressed
+// system or an approved external reference. Content is never stored here.
+type EvidenceVersion struct {
+	ID               string               `json:"id"`
+	TenantID         string               `json:"tenant_id"`
+	ArtifactID       string               `json:"artifact_id"`
+	Revision         EvidenceRevisionRef  `json:"revision"`
+	Content          EvidenceContentRef   `json:"content"`
+	Provenance       EvidenceProvenance   `json:"provenance"`
+	Governance       EvidenceGovernance   `json:"governance"`
+	ValidFrom        time.Time            `json:"valid_from"`
+	ValidUntil       time.Time            `json:"valid_until,omitempty"`
+	Subjects         []EvidenceSubjectRef `json:"subjects"`
+	State            string               `json:"state"`
+	QuarantineReason string               `json:"quarantine_reason,omitempty"`
+	PredecessorID    string               `json:"predecessor_id,omitempty"`
+	RecordedAt       time.Time            `json:"recorded_at"`
+}
+
+type EvidenceClaimScope struct {
+	ObjectiveID              string               `json:"objective_id"`
+	ImplementationRevisionID string               `json:"implementation_revision_id"`
+	RequirementID            string               `json:"requirement_id"`
+	Subjects                 []EvidenceSubjectRef `json:"subjects"`
+	PeriodStart              time.Time            `json:"period_start"`
+	PeriodEnd                time.Time            `json:"period_end"`
+}
+
+type EvidenceClaimDecision struct {
+	ReviewState        string    `json:"review_state"`
+	ReviewerID         string    `json:"reviewer_id,omitempty"`
+	ReviewReason       string    `json:"review_reason,omitempty"`
+	ReviewedAt         time.Time `json:"reviewed_at,omitempty"`
+	InvalidatedAt      time.Time `json:"invalidated_at,omitempty"`
+	InvalidationReason string    `json:"invalidation_reason,omitempty"`
+}
+
+type EvidenceClaim struct {
+	ID                string                `json:"id"`
+	TenantID          string                `json:"tenant_id"`
+	ArtifactVersionID string                `json:"artifact_version_id"`
+	Scope             EvidenceClaimScope    `json:"scope"`
+	Linkage           string                `json:"linkage"`
+	Strength          string                `json:"strength"`
+	Limitation        string                `json:"limitation,omitempty"`
+	MappingRationale  string                `json:"mapping_rationale"`
+	Decision          EvidenceClaimDecision `json:"decision"`
+	Version           uint64                `json:"version"`
+	CreatedAt         time.Time             `json:"created_at"`
+	CreatedBy         string                `json:"created_by"`
+}
+
+type EvidenceAccessRequest struct {
+	TenantID           string
+	Purpose            string
+	MaximumSensitivity string
+	ActorID            string
+}
+
+type EvidenceClaimValidation struct {
+	Valid       bool     `json:"valid"`
+	ReasonCodes []string `json:"reason_codes"`
+	NextActions []string `json:"next_actions"`
+}
+
+// EvidenceLedgerStore applies append-log events idempotently to current state.
+type EvidenceLedgerStore interface {
+	ApplyEvidenceVersion(context.Context, string, EvidenceArtifact, EvidenceVersion) error
+	ApplyEvidenceClaim(context.Context, string, EvidenceClaim, uint64) error
+	GetEvidenceArtifact(context.Context, string, string) (EvidenceArtifact, error)
+	GetEvidenceVersion(context.Context, string, string) (EvidenceVersion, error)
+	GetEvidenceClaim(context.Context, string, string) (EvidenceClaim, error)
+	ListEvidenceClaimsByVersion(context.Context, string, string) ([]EvidenceClaim, error)
+}

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -28,6 +28,7 @@ const (
 	EventKindComplianceActivityRecorded            = "workflow.v1.compliance.assessment_activity_recorded"
 	EventKindCompliancePopulationRecorded          = "workflow.v1.compliance.assessment_population_recorded"
 	EventKindComplianceSampleRecorded              = "workflow.v1.compliance.assessment_sample_recorded"
+	EventKindComplianceSourceCheckRecorded         = "workflow.v1.compliance.assessment_source_check_recorded"
 	EventKindComplianceReviewRecorded              = "workflow.v1.compliance.assessment_review_recorded"
 	EventKindComplianceRiskDecisionRecorded        = "workflow.v1.compliance.risk_decision_recorded"
 	EventKindComplianceExceptionUpdated            = "workflow.v1.compliance.exception_updated"
@@ -124,6 +125,7 @@ func registeredComplianceKinds() []string {
 		EventKindComplianceResultChunkRecorded, EventKindComplianceAssessmentCompleted,
 		EventKindComplianceAssessmentCancelled, EventKindComplianceActivityRecorded,
 		EventKindCompliancePopulationRecorded, EventKindComplianceSampleRecorded,
+		EventKindComplianceSourceCheckRecorded,
 		EventKindComplianceReviewRecorded, EventKindComplianceRiskDecisionRecorded,
 		EventKindComplianceExceptionUpdated, EventKindComplianceWorkItemUpdated,
 		EventKindComplianceRemediationMilestoneUpdated, EventKindComplianceAuditEngagementRecorded,

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -93,7 +93,7 @@ func NewComplianceAggregateEvent(payload ComplianceAggregateRecorded) (*cerebrov
 		ContentDigest: payload.ContentDigest, PayloadJSON: payload.PayloadJSON,
 		ActorID: payload.ActorID, RecordedAt: payload.RecordedAt,
 	}
-	primaryID := payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
+	primaryID := payload.AggregateType + "|" + payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
 	return newEvent(contract, SchemaComplianceAggregate, payload.TenantID, "compliance", primaryID, payload.RecordedAt, map[string]string{
 		EventAttributeWorkflowKind: "compliance_aggregate",
 		"aggregate_type":           payload.AggregateType,

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -65,6 +65,27 @@ func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
 	}
 }
 
+func TestComplianceAggregateIdentityIncludesAggregateType(t *testing.T) {
+	t.Parallel()
+	base := ComplianceAggregateRecorded{
+		Kind: EventKindComplianceSourceCheckRecorded, TenantID: "tenant-a",
+		AggregateType: "source_check", AggregateID: "shared-id", AggregateVersion: 1,
+		Operation: "recorded", RecordedAt: "2026-07-11T08:00:00Z",
+	}
+	first, err := NewComplianceAggregateEvent(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.AggregateType = "objective_source_assessment"
+	second, err := NewComplianceAggregateEvent(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.GetId() == second.GetId() {
+		t.Fatalf("aggregate types produced the same event id %q", first.GetId())
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -54,6 +54,17 @@ func TestComplianceExchangeRequestAndCommitRemainDistinctFacts(t *testing.T) {
 	}
 }
 
+func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
+	t.Parallel()
+	if EventKindComplianceSourceCheckRecorded == EventKindComplianceActivityRecorded ||
+		EventKindComplianceSourceCheckRecorded == EventKindComplianceInputManifestRecorded {
+		t.Fatal("source check event overloads an activity or input-manifest fact")
+	}
+	if !KindRegistered(EventKindComplianceSourceCheckRecorded) {
+		t.Fatal("source check event kind is not registered")
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{


### PR DESCRIPTION
## Summary

- separate stable evidence artifacts, immutable versions, and scoped claims
- reference approved content-addressed or external objects without storing evidence bytes
- append compliance events before applying current-state projections
- require separate review and invalidation decisions for every reused claim
- add bounded validation for subject scope, periods, source proof, quarantine, revocation, expiry, sensitivity, and purpose

## Dependency

This evidence-domain slice is stacked on the canonical compliance semantics and execution foundation.

## Exit criteria

- one immutable version can support multiple claims without sharing approval state
- missing source proof quarantines a version and prevents it from satisfying a requirement
- rejected, invalidated, expired, revoked, period-mismatched, or subject-mismatched evidence cannot validate
- append failure prevents current-state projection
- evidence reads enforce tenant, purpose, and sensitivity independently
- no raw evidence content enters events or state records

## Validation

- focused evidence ledger, port, and workflow-event tests
- evidence ledger race tests
- Go vet and package lint
- architecture and structural checks