### PR TITLE
Add compliance program revision core

### DIFF
--- a/internal/compliance/identifiers.go
+++ b/internal/compliance/identifiers.go
@@ -1,0 +1,138 @@
+package compliance
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrInvalidIdentifier = errors.New("invalid compliance identifier")
+
+// IdentifierKind names the stable public prefix for one compliance resource.
+type IdentifierKind string
+
+const (
+	IdentifierProgram        IdentifierKind = "program"
+	IdentifierScope          IdentifierKind = "scope"
+	IdentifierImplementation IdentifierKind = "implementation"
+	IdentifierPlan           IdentifierKind = "assessment-plan"
+	IdentifierTest           IdentifierKind = "assessment-test"
+	IdentifierEvidence       IdentifierKind = "evidence"
+	IdentifierClaim          IdentifierKind = "evidence-claim"
+	IdentifierRun            IdentifierKind = "assessment-run"
+	IdentifierResult         IdentifierKind = "assessment-result"
+	IdentifierReview         IdentifierKind = "assessment-review"
+	IdentifierArtifact       IdentifierKind = "artifact"
+	IdentifierMapping        IdentifierKind = "control-mapping"
+)
+
+const identifierEntropyBytes = 16
+
+// NewIdentifier returns an opaque identifier with a resource-specific prefix.
+func NewIdentifier(kind IdentifierKind) (string, error) {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return "", err
+	}
+	random := make([]byte, identifierEntropyBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate compliance identifier: %w", err)
+	}
+	return string(kind) + "-" + hex.EncodeToString(random), nil
+}
+
+// NewRevisionIdentifier returns an opaque identity for an immutable revision.
+func NewRevisionIdentifier(kind IdentifierKind) (string, error) {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return "", err
+	}
+	random := make([]byte, identifierEntropyBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate compliance revision identifier: %w", err)
+	}
+	return string(kind) + "-revision-" + hex.EncodeToString(random), nil
+}
+
+func ValidateIdentifierKind(kind IdentifierKind) error {
+	value := string(kind)
+	if value == "" || len(value) > 40 || !identifierToken(value) {
+		return fmt.Errorf("%w: kind %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+// ValidateIdentifier rejects display names, whitespace, path separators, and
+// tenant data in public identifiers. IDs remain opaque and tenant scoping is
+// enforced separately by every store lookup.
+func ValidateIdentifier(kind IdentifierKind, value string) error {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return err
+	}
+	raw := value
+	value = strings.TrimSpace(value)
+	if value != raw {
+		return fmt.Errorf("%w: identifier contains surrounding whitespace", ErrInvalidIdentifier)
+	}
+	prefix := string(kind) + "-"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+(identifierEntropyBytes*2) {
+		return fmt.Errorf("%w: expected %s prefix", ErrInvalidIdentifier, prefix)
+	}
+	if !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+// ValidateRevisionIdentifier checks an immutable revision identity separately
+// from the logical record identity.
+func ValidateRevisionIdentifier(kind IdentifierKind, value string) error {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return err
+	}
+	raw := value
+	value = strings.TrimSpace(value)
+	if value != raw {
+		return fmt.Errorf("%w: revision identifier contains surrounding whitespace", ErrInvalidIdentifier)
+	}
+	prefix := string(kind) + "-revision-"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+(identifierEntropyBytes*2) {
+		return fmt.Errorf("%w: expected %s prefix", ErrInvalidIdentifier, prefix)
+	}
+	if !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+func identifierToken(value string) bool {
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') || character == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func lowerHex(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, character := range value {
+		if (character >= 'a' && character <= 'f') || (character >= '0' && character <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func ValidateContentDigest(digest ContentDigest) error {
+	value := string(digest)
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+64 || !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: invalid content digest", ErrInvalidRevision)
+	}
+	return nil
+}

--- a/internal/compliance/identifiers_test.go
+++ b/internal/compliance/identifiers_test.go
@@ -1,0 +1,59 @@
+package compliance
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestOpaqueLogicalAndRevisionIdentifiersValidateSeparately(t *testing.T) {
+	logical, err := NewIdentifier(IdentifierProgram)
+	if err != nil {
+		t.Fatalf("NewIdentifier() error = %v", err)
+	}
+	revision, err := NewRevisionIdentifier(IdentifierProgram)
+	if err != nil {
+		t.Fatalf("NewRevisionIdentifier() error = %v", err)
+	}
+	if err := ValidateIdentifier(IdentifierProgram, logical); err != nil {
+		t.Fatalf("ValidateIdentifier() error = %v", err)
+	}
+	if err := ValidateRevisionIdentifier(IdentifierProgram, revision); err != nil {
+		t.Fatalf("ValidateRevisionIdentifier() error = %v", err)
+	}
+	if logical == revision || strings.Contains(logical, "revision") {
+		t.Fatalf("logical=%q revision=%q are not distinct", logical, revision)
+	}
+	if err := ValidateIdentifier(IdentifierProgram, revision); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateIdentifier(revision) error = %v, want ErrInvalidIdentifier", err)
+	}
+	if err := ValidateRevisionIdentifier(IdentifierProgram, logical); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateRevisionIdentifier(logical) error = %v, want ErrInvalidIdentifier", err)
+	}
+}
+
+func TestValidateIdentifierRejectsLossyAndNonOpaqueValues(t *testing.T) {
+	for _, value := range []string{
+		"program-customer/name",
+		"program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-",
+		"program-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-extra",
+		" program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	} {
+		if err := ValidateIdentifier(IdentifierProgram, value); !errors.Is(err, ErrInvalidIdentifier) {
+			t.Fatalf("ValidateIdentifier(%q) error = %v, want ErrInvalidIdentifier", value, err)
+		}
+	}
+}
+
+func TestValidateContentDigestRequiresCanonicalSHA256(t *testing.T) {
+	valid := ContentDigest("sha256:" + strings.Repeat("a", 64))
+	if err := ValidateContentDigest(valid); err != nil {
+		t.Fatalf("ValidateContentDigest() error = %v", err)
+	}
+	for _, value := range []ContentDigest{"", "sha256:abc", ContentDigest("SHA256:" + strings.Repeat("a", 64)), ContentDigest("sha256:" + strings.Repeat("A", 64))} {
+		if err := ValidateContentDigest(value); !errors.Is(err, ErrInvalidRevision) {
+			t.Fatalf("ValidateContentDigest(%q) error = %v, want ErrInvalidRevision", value, err)
+		}
+	}
+}

--- a/internal/compliance/mappings.go
+++ b/internal/compliance/mappings.go
@@ -1,0 +1,146 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var ErrInvalidMapping = errors.New("invalid compliance mapping")
+
+type MappingRelationship string
+
+const (
+	MappingEquivalent MappingRelationship = "equivalent"
+	MappingSubset     MappingRelationship = "subset"
+	MappingSuperset   MappingRelationship = "superset"
+	MappingOverlap    MappingRelationship = "overlap"
+	MappingNone       MappingRelationship = "none"
+)
+
+type MappingDecisionState string
+
+const (
+	MappingProposed MappingDecisionState = "proposed"
+	MappingApproved MappingDecisionState = "approved"
+	MappingRejected MappingDecisionState = "rejected"
+	MappingRetired  MappingDecisionState = "retired"
+)
+
+// ControlMapping records an explicit, reviewable relationship between exact
+// source and target revisions. It never grants coverage by implication.
+type ControlMapping struct {
+	ID                  string               `json:"id"`
+	RevisionID          string               `json:"revision_id"`
+	Source              RevisionRef          `json:"source"`
+	Target              RevisionRef          `json:"target"`
+	Granularity         string               `json:"granularity"`
+	Relationship        MappingRelationship  `json:"relationship"`
+	Method              string               `json:"method"`
+	Rationale           string               `json:"rationale"`
+	CoverageBasisPoints uint16               `json:"coverage_basis_points"`
+	Gaps                []string             `json:"gaps,omitempty"`
+	Provenance          []SubjectRef         `json:"provenance,omitempty"`
+	DecisionState       MappingDecisionState `json:"decision_state"`
+	AuthorID            string               `json:"author_id"`
+	ReviewerID          string               `json:"reviewer_id,omitempty"`
+}
+
+func (mapping ControlMapping) Validate() error {
+	if strings.TrimSpace(mapping.ID) == "" || strings.TrimSpace(mapping.RevisionID) == "" {
+		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidMapping)
+	}
+	if err := mapping.Source.Validate(); err != nil {
+		return fmt.Errorf("%w: source: %v", ErrInvalidMapping, err)
+	}
+	if err := mapping.Target.Validate(); err != nil {
+		return fmt.Errorf("%w: target: %v", ErrInvalidMapping, err)
+	}
+	if mapping.Source.ID == mapping.Target.ID && mapping.Source.RevisionID == mapping.Target.RevisionID {
+		return fmt.Errorf("%w: source and target must differ", ErrInvalidMapping)
+	}
+	switch mapping.Relationship {
+	case MappingEquivalent, MappingSubset, MappingSuperset, MappingOverlap, MappingNone:
+	default:
+		return fmt.Errorf("%w: relationship %q", ErrInvalidMapping, mapping.Relationship)
+	}
+	switch mapping.DecisionState {
+	case MappingProposed, MappingApproved, MappingRejected, MappingRetired:
+	default:
+		return fmt.Errorf("%w: decision_state %q", ErrInvalidMapping, mapping.DecisionState)
+	}
+	if mapping.CoverageBasisPoints > 10000 {
+		return fmt.Errorf("%w: coverage_basis_points exceeds 10000", ErrInvalidMapping)
+	}
+	if mapping.Relationship == MappingNone && mapping.CoverageBasisPoints != 0 {
+		return fmt.Errorf("%w: none relationship must have zero coverage", ErrInvalidMapping)
+	}
+	if mapping.Relationship == MappingEquivalent && mapping.CoverageBasisPoints != 10000 {
+		return fmt.Errorf("%w: equivalent relationship must have full coverage", ErrInvalidMapping)
+	}
+	if strings.TrimSpace(mapping.Granularity) == "" || strings.TrimSpace(mapping.Method) == "" || strings.TrimSpace(mapping.Rationale) == "" || strings.TrimSpace(mapping.AuthorID) == "" {
+		return fmt.Errorf("%w: granularity, method, rationale, and author_id are required", ErrInvalidMapping)
+	}
+	if mapping.DecisionState != MappingProposed && strings.TrimSpace(mapping.ReviewerID) == "" {
+		return fmt.Errorf("%w: reviewer_id is required for decided mappings", ErrInvalidMapping)
+	}
+	for index, reference := range mapping.Provenance {
+		if err := reference.Validate(); err != nil {
+			return fmt.Errorf("%w: provenance[%d]: %v", ErrInvalidMapping, index, err)
+		}
+	}
+	return nil
+}
+
+func NormalizeControlMapping(mapping ControlMapping) ControlMapping {
+	mapping.ID = strings.TrimSpace(mapping.ID)
+	mapping.RevisionID = strings.TrimSpace(mapping.RevisionID)
+	mapping.Granularity = strings.TrimSpace(mapping.Granularity)
+	mapping.Method = strings.TrimSpace(mapping.Method)
+	mapping.Rationale = strings.TrimSpace(mapping.Rationale)
+	mapping.AuthorID = strings.TrimSpace(mapping.AuthorID)
+	mapping.ReviewerID = strings.TrimSpace(mapping.ReviewerID)
+	mapping.Source = NormalizeRevisionRef(mapping.Source)
+	mapping.Target = NormalizeRevisionRef(mapping.Target)
+	mapping.Gaps = normalizedSortedStrings(mapping.Gaps)
+	mapping.Provenance = append([]SubjectRef(nil), mapping.Provenance...)
+	for index := range mapping.Provenance {
+		mapping.Provenance[index].Type = strings.TrimSpace(mapping.Provenance[index].Type)
+		mapping.Provenance[index].ID = strings.TrimSpace(mapping.Provenance[index].ID)
+	}
+	sort.Slice(mapping.Provenance, func(i, j int) bool {
+		return mapping.Provenance[i].Type+"\x00"+mapping.Provenance[i].ID < mapping.Provenance[j].Type+"\x00"+mapping.Provenance[j].ID
+	})
+	mapping.Provenance = deduplicateSubjectRefs(mapping.Provenance)
+	return mapping
+}
+
+func deduplicateSubjectRefs(values []SubjectRef) []SubjectRef {
+	result := make([]SubjectRef, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1] == value {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizedSortedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}

--- a/internal/compliance/mappings.go
+++ b/internal/compliance/mappings.go
@@ -52,10 +52,10 @@ func (mapping ControlMapping) Validate() error {
 		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidMapping)
 	}
 	if err := mapping.Source.Validate(); err != nil {
-		return fmt.Errorf("%w: source: %v", ErrInvalidMapping, err)
+		return fmt.Errorf("%w: source: %w", ErrInvalidMapping, err)
 	}
 	if err := mapping.Target.Validate(); err != nil {
-		return fmt.Errorf("%w: target: %v", ErrInvalidMapping, err)
+		return fmt.Errorf("%w: target: %w", ErrInvalidMapping, err)
 	}
 	if mapping.Source.ID == mapping.Target.ID && mapping.Source.RevisionID == mapping.Target.RevisionID {
 		return fmt.Errorf("%w: source and target must differ", ErrInvalidMapping)
@@ -87,7 +87,7 @@ func (mapping ControlMapping) Validate() error {
 	}
 	for index, reference := range mapping.Provenance {
 		if err := reference.Validate(); err != nil {
-			return fmt.Errorf("%w: provenance[%d]: %v", ErrInvalidMapping, index, err)
+			return fmt.Errorf("%w: provenance[%d]: %w", ErrInvalidMapping, index, err)
 		}
 	}
 	return nil

--- a/internal/compliance/mappings_test.go
+++ b/internal/compliance/mappings_test.go
@@ -1,0 +1,69 @@
+package compliance
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeControlMappingIsDeterministicWithoutMutatingCaller(t *testing.T) {
+	digest := ContentDigest("sha256:" + strings.Repeat("b", 64))
+	mapping := ControlMapping{
+		ID: " mapping ", RevisionID: " revision ", Granularity: " statement ",
+		Source:       RevisionRef{ID: "source", RevisionID: "source-r1", Version: 1, ContentDigest: digest, LastModified: time.Unix(1, 0)},
+		Target:       RevisionRef{ID: "target", RevisionID: "target-r1", Version: 1, ContentDigest: digest, LastModified: time.Unix(1, 0)},
+		Relationship: MappingOverlap, Method: " manual ", Rationale: " scoped overlap ", CoverageBasisPoints: 7500,
+		Gaps:          []string{" gap-b ", "gap-a", "gap-a"},
+		Provenance:    []SubjectRef{{Type: " source ", ID: "b"}, {Type: "source", ID: "a"}, {Type: "source", ID: "a"}},
+		DecisionState: MappingApproved, AuthorID: " author ", ReviewerID: " reviewer ",
+	}
+	normalized := NormalizeControlMapping(mapping)
+	if got := strings.Join(normalized.Gaps, ","); got != "gap-a,gap-b" {
+		t.Fatalf("normalized gaps = %q", got)
+	}
+	if len(normalized.Provenance) != 2 || normalized.Provenance[0].ID != "a" || normalized.Provenance[1].ID != "b" {
+		t.Fatalf("normalized provenance = %#v", normalized.Provenance)
+	}
+	if mapping.Provenance[0].Type != " source " {
+		t.Fatal("NormalizeControlMapping mutated caller provenance")
+	}
+	if normalized.Source.LastModified.Nanosecond()%int(time.Millisecond) != 0 {
+		t.Fatalf("source revision time was not normalized: %s", normalized.Source.LastModified)
+	}
+	if err := normalized.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestControlMappingRelationshipCoverageInvariants(t *testing.T) {
+	base := validControlMapping()
+	base.Relationship = MappingNone
+	base.CoverageBasisPoints = 1
+	if err := base.Validate(); err == nil {
+		t.Fatal("none relationship with coverage was accepted")
+	}
+	base = validControlMapping()
+	base.Relationship = MappingEquivalent
+	base.CoverageBasisPoints = 9999
+	if err := base.Validate(); err == nil {
+		t.Fatal("equivalent relationship without full coverage was accepted")
+	}
+	base = validControlMapping()
+	base.DecisionState = MappingApproved
+	base.ReviewerID = ""
+	if err := base.Validate(); err == nil {
+		t.Fatal("decided mapping without reviewer was accepted")
+	}
+}
+
+func validControlMapping() ControlMapping {
+	digest := ContentDigest("sha256:" + strings.Repeat("c", 64))
+	modified := time.Unix(1, 123456789).UTC()
+	return ControlMapping{
+		ID: "mapping", RevisionID: "mapping-r1", Granularity: "objective",
+		Source:       RevisionRef{ID: "source", RevisionID: "source-r1", Version: 1, ContentDigest: digest, LastModified: modified},
+		Target:       RevisionRef{ID: "target", RevisionID: "target-r1", Version: 1, ContentDigest: digest, LastModified: modified},
+		Relationship: MappingOverlap, Method: "manual", Rationale: "overlap", CoverageBasisPoints: 5000,
+		DecisionState: MappingProposed, AuthorID: "author",
+	}
+}

--- a/internal/compliance/types.go
+++ b/internal/compliance/types.go
@@ -1,0 +1,111 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var ErrInvalidRevision = errors.New("invalid compliance revision")
+
+// ContentDigest is the lowercase SHA-256 digest of normalized semantic content.
+// It deliberately remains separate from revision identity: two tenants may
+// create different revisions with the same semantic content.
+type ContentDigest string
+
+// VersionMetadata describes one immutable revision of a stable logical record.
+type VersionMetadata struct {
+	ID            string        `json:"id"`
+	RevisionID    string        `json:"revision_id"`
+	Version       uint64        `json:"version"`
+	LastModified  time.Time     `json:"last_modified"`
+	ContentDigest ContentDigest `json:"content_digest"`
+	CreatedBy     string        `json:"created_by"`
+	PredecessorID string        `json:"predecessor_id,omitempty"`
+	SuccessorID   string        `json:"successor_id,omitempty"`
+}
+
+// RevisionRef identifies one immutable revision of a stable compliance subject.
+// ContentDigest covers normalized semantic content, not database metadata.
+type RevisionRef struct {
+	ID            string        `json:"id"`
+	RevisionID    string        `json:"revision_id"`
+	Version       uint64        `json:"version"`
+	ContentDigest ContentDigest `json:"content_digest"`
+	LastModified  time.Time     `json:"last_modified"`
+}
+
+// SubjectRef identifies a tenant-scoped subject without copying its lifecycle.
+type SubjectRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+func NormalizeVersionMetadata(value VersionMetadata) VersionMetadata {
+	value.ID = strings.TrimSpace(value.ID)
+	value.RevisionID = strings.TrimSpace(value.RevisionID)
+	value.LastModified = CanonicalRevisionTime(value.LastModified)
+	value.ContentDigest = ContentDigest(strings.TrimSpace(string(value.ContentDigest)))
+	value.CreatedBy = strings.TrimSpace(value.CreatedBy)
+	value.PredecessorID = strings.TrimSpace(value.PredecessorID)
+	value.SuccessorID = strings.TrimSpace(value.SuccessorID)
+	return value
+}
+
+func NormalizeRevisionRef(value RevisionRef) RevisionRef {
+	value.ID = strings.TrimSpace(value.ID)
+	value.RevisionID = strings.TrimSpace(value.RevisionID)
+	value.ContentDigest = ContentDigest(strings.TrimSpace(string(value.ContentDigest)))
+	value.LastModified = CanonicalRevisionTime(value.LastModified)
+	return value
+}
+
+// CanonicalRevisionTime uses the precision shared by event envelopes and
+// canonical assessment hashes.
+func CanonicalRevisionTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Time{}
+	}
+	return value.UTC().Truncate(time.Millisecond)
+}
+
+func (metadata VersionMetadata) Validate() error {
+	metadata = NormalizeVersionMetadata(metadata)
+	if metadata.ID == "" || metadata.RevisionID == "" || metadata.CreatedBy == "" {
+		return fmt.Errorf("%w: id, revision_id, and created_by are required", ErrInvalidRevision)
+	}
+	if metadata.Version == 0 || metadata.LastModified.IsZero() {
+		return fmt.Errorf("%w: version and last_modified are required", ErrInvalidRevision)
+	}
+	if err := ValidateContentDigest(metadata.ContentDigest); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+	}
+	return nil
+}
+
+// Validate checks the required, transport-independent revision invariants.
+// Resource-specific identifier validation remains with the owning service.
+func (revision RevisionRef) Validate() error {
+	revision = NormalizeRevisionRef(revision)
+	if strings.TrimSpace(revision.ID) == "" || strings.TrimSpace(revision.RevisionID) == "" {
+		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidRevision)
+	}
+	if revision.Version == 0 {
+		return fmt.Errorf("%w: version must be greater than zero", ErrInvalidRevision)
+	}
+	if err := ValidateContentDigest(revision.ContentDigest); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+	}
+	if revision.LastModified.IsZero() {
+		return fmt.Errorf("%w: last_modified is required", ErrInvalidRevision)
+	}
+	return nil
+}
+
+func (reference SubjectRef) Validate() error {
+	if strings.TrimSpace(reference.Type) == "" || strings.TrimSpace(reference.ID) == "" {
+		return fmt.Errorf("%w: subject type and id are required", ErrInvalidRevision)
+	}
+	return nil
+}

--- a/internal/compliance/types.go
+++ b/internal/compliance/types.go
@@ -79,7 +79,7 @@ func (metadata VersionMetadata) Validate() error {
 		return fmt.Errorf("%w: version and last_modified are required", ErrInvalidRevision)
 	}
 	if err := ValidateContentDigest(metadata.ContentDigest); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+		return fmt.Errorf("%w: %w", ErrInvalidRevision, err)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func (revision RevisionRef) Validate() error {
 		return fmt.Errorf("%w: version must be greater than zero", ErrInvalidRevision)
 	}
 	if err := ValidateContentDigest(revision.ContentDigest); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+		return fmt.Errorf("%w: %w", ErrInvalidRevision, err)
 	}
 	if revision.LastModified.IsZero() {
 		return fmt.Errorf("%w: last_modified is required", ErrInvalidRevision)

--- a/internal/complianceassessment/conformance_test.go
+++ b/internal/complianceassessment/conformance_test.go
@@ -1,0 +1,223 @@
+package complianceassessment
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+type conformanceFixture struct {
+	Version      string          `json:"version"`
+	BaseInput    json.RawMessage `json:"base_input"`
+	BaseExpected json.RawMessage `json:"base_expected"`
+	Cases        []fixtureCase   `json:"cases"`
+}
+
+type fixtureCase struct {
+	Name           string          `json:"name"`
+	Input          json.RawMessage `json:"input"`
+	Expected       json.RawMessage `json:"expected"`
+	ExpectedDigest string          `json:"expected_digest"`
+}
+
+type fixtureExpected struct {
+	ScopeState                  ScopeState                  `json:"scope_state"`
+	AutomatedOutcome            AutomatedOutcome            `json:"automated_outcome"`
+	DesignState                 DesignState                 `json:"design_state"`
+	OperatingEffectivenessState OperatingEffectivenessState `json:"operating_effectiveness_state"`
+	EvidenceState               EvidenceState               `json:"evidence_state"`
+	DispositionState            DispositionState            `json:"disposition_state"`
+	Assurance                   Assurance                   `json:"assurance"`
+	AuditorState                AuditorState                `json:"auditor_state"`
+	ReasonCodes                 []ReasonCode                `json:"reason_codes"`
+	NextActions                 []NextAction                `json:"next_actions"`
+	LegacyStatus                string                      `json:"legacy_status"`
+}
+
+func TestObjectiveConformanceFixtures(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	if fixture.Version != "compliance-assessment-conformance/v1" {
+		t.Fatalf("fixture version = %q", fixture.Version)
+	}
+	if len(fixture.Cases) < 16 {
+		t.Fatalf("fixture cases = %d, want at least 16", len(fixture.Cases))
+	}
+	for _, testCase := range fixture.Cases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			input := mergedFixtureValue[EvaluateInput](t, fixture.BaseInput, testCase.Input)
+			expectedAxes := mergedFixtureValue[fixtureExpected](t, fixture.BaseExpected, testCase.Expected)
+			result, err := EvaluateObjective(input)
+			if err != nil {
+				t.Fatalf("EvaluateObjective() error = %v", err)
+			}
+			expected := expectedFixtureResult(input, expectedAxes)
+			gotBytes, err := CanonicalResultBytes(result)
+			if err != nil {
+				t.Fatalf("CanonicalResultBytes(result) error = %v", err)
+			}
+			wantBytes, err := CanonicalResultBytes(expected)
+			if err != nil {
+				t.Fatalf("CanonicalResultBytes(expected) error = %v", err)
+			}
+			if !bytes.Equal(gotBytes, wantBytes) {
+				t.Fatalf("canonical result mismatch\n got: %s\nwant: %s", gotBytes, wantBytes)
+			}
+			if got := LegacyStatus(result); got != expectedAxes.LegacyStatus {
+				t.Fatalf("LegacyStatus() = %q, want %q", got, expectedAxes.LegacyStatus)
+			}
+			digest, err := CanonicalResultDigest(result)
+			if err != nil {
+				t.Fatalf("CanonicalResultDigest() error = %v", err)
+			}
+			if testCase.ExpectedDigest == "" {
+				t.Errorf("expected_digest is empty; generated %s", digest)
+			} else if digest != testCase.ExpectedDigest {
+				t.Fatalf("digest = %q, want %q", digest, testCase.ExpectedDigest)
+			}
+		})
+	}
+}
+
+func TestObjectiveConformanceIsInvariantToInputOrder(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	for _, testCase := range fixture.Cases {
+		input := mergedFixtureValue[EvaluateInput](t, fixture.BaseInput, testCase.Input)
+		baseline, err := EvaluateObjective(input)
+		if err != nil {
+			t.Fatalf("%s baseline error = %v", testCase.Name, err)
+		}
+		baselineBytes, err := CanonicalResultBytes(baseline)
+		if err != nil {
+			t.Fatalf("%s baseline bytes error = %v", testCase.Name, err)
+		}
+		for iteration := 0; iteration < 32; iteration++ {
+			shuffled := cloneEvaluateInput(input)
+			rotateStrings(shuffled.FindingIDs, iteration)
+			rotateStrings(shuffled.SourceRuntimeIDs, iteration+1)
+			rotateAssessments(shuffled.RequirementAssessments, iteration+2)
+			for index := range shuffled.RequirementAssessments {
+				rotateStrings(shuffled.RequirementAssessments[index].EvidenceIDs, iteration+index)
+			}
+			result, err := EvaluateObjective(shuffled)
+			if err != nil {
+				t.Fatalf("%s iteration %d error = %v", testCase.Name, iteration, err)
+			}
+			data, err := CanonicalResultBytes(result)
+			if err != nil {
+				t.Fatalf("%s iteration %d bytes error = %v", testCase.Name, iteration, err)
+			}
+			if !bytes.Equal(data, baselineBytes) {
+				t.Fatalf("%s iteration %d changed canonical bytes", testCase.Name, iteration)
+			}
+		}
+	}
+}
+
+func loadConformanceFixture(t *testing.T) conformanceFixture {
+	t.Helper()
+	data, err := os.ReadFile("testdata/objective_conformance.json") // #nosec G304 -- fixed repository fixture path.
+	if err != nil {
+		t.Fatalf("read conformance fixture: %v", err)
+	}
+	var fixture conformanceFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("decode conformance fixture: %v", err)
+	}
+	return fixture
+}
+
+func mergedFixtureValue[T any](t *testing.T, base json.RawMessage, override json.RawMessage) T {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(base, &fields); err != nil {
+		t.Fatalf("decode fixture base: %v", err)
+	}
+	var overrides map[string]json.RawMessage
+	if len(override) != 0 {
+		if err := json.Unmarshal(override, &overrides); err != nil {
+			t.Fatalf("decode fixture override: %v", err)
+		}
+	}
+	for key, value := range overrides {
+		fields[key] = value
+	}
+	data, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal merged fixture: %v", err)
+	}
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("decode merged fixture: %v", err)
+	}
+	return result
+}
+
+func expectedFixtureResult(input EvaluateInput, expected fixtureExpected) ObjectiveResult {
+	evidenceIDs := []string{}
+	for _, assessment := range input.RequirementAssessments {
+		evidenceIDs = append(evidenceIDs, assessment.EvidenceIDs...)
+	}
+	return NormalizeResult(ObjectiveResult{
+		ID:                          input.ResultID,
+		ControlRef:                  input.Control,
+		ObjectiveID:                 input.ObjectiveID,
+		ScopeState:                  expected.ScopeState,
+		AutomatedOutcome:            expected.AutomatedOutcome,
+		DesignState:                 expected.DesignState,
+		OperatingEffectivenessState: expected.OperatingEffectivenessState,
+		EvidenceState:               expected.EvidenceState,
+		DispositionState:            expected.DispositionState,
+		Assurance:                   expected.Assurance,
+		AuditorState:                expected.AuditorState,
+		ReasonCodes:                 expected.ReasonCodes,
+		NextActions:                 expected.NextActions,
+		EvidenceIDs:                 evidenceIDs,
+		FindingIDs:                  input.FindingIDs,
+		SourceRuntimeIDs:            input.SourceRuntimeIDs,
+		EvaluatorRevision:           input.EvaluatorRevision,
+		EvaluatedAt:                 input.Now,
+	})
+}
+
+func cloneEvaluateInput(input EvaluateInput) EvaluateInput {
+	clone := input
+	clone.FindingIDs = append([]string(nil), input.FindingIDs...)
+	clone.SourceRuntimeIDs = append([]string(nil), input.SourceRuntimeIDs...)
+	clone.RequirementAssessments = append([]compliance.ControlEvidenceRequirementAssessment(nil), input.RequirementAssessments...)
+	for index := range clone.RequirementAssessments {
+		clone.RequirementAssessments[index].EvidenceIDs = append([]string(nil), input.RequirementAssessments[index].EvidenceIDs...)
+	}
+	return clone
+}
+
+func rotateStrings(values []string, count int) {
+	if len(values) < 2 {
+		return
+	}
+	count %= len(values)
+	rotated := append(append([]string(nil), values[count:]...), values[:count]...)
+	copy(values, rotated)
+}
+
+func rotateAssessments(values []compliance.ControlEvidenceRequirementAssessment, count int) {
+	if len(values) < 2 {
+		return
+	}
+	count %= len(values)
+	rotated := append(append([]compliance.ControlEvidenceRequirementAssessment(nil), values[count:]...), values[:count]...)
+	copy(values, rotated)
+}
+
+func TestFixtureNamesAreUnique(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	seen := map[string]struct{}{}
+	for _, testCase := range fixture.Cases {
+		if _, exists := seen[testCase.Name]; exists {
+			t.Fatalf("duplicate fixture name %q", testCase.Name)
+		}
+		seen[testCase.Name] = struct{}{}
+	}
+}

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -167,6 +167,15 @@ func ValidateEvaluateInput(input EvaluateInput) error {
 		return fmt.Errorf("%w: evaluation input contains an unknown required state", ErrInvalidResult)
 	}
 	for _, assessment := range input.RequirementAssessments {
+		if strings.TrimSpace(assessment.RequirementKey) == "" ||
+			strings.TrimSpace(assessment.ControlRef.ControlID) == "" ||
+			strings.TrimSpace(assessment.SourceID) == "" ||
+			strings.TrimSpace(assessment.EntityType) == "" {
+			return fmt.Errorf("%w: evidence requirement assessment identity and source binding are required", ErrInvalidResult)
+		}
+		if compliance.NormalizeControlRef(assessment.ControlRef) != input.Control {
+			return fmt.Errorf("%w: evidence requirement assessment control does not match the objective control", ErrInvalidResult)
+		}
 		switch assessment.Status {
 		case compliance.ControlEvidenceRequirementSatisfied,
 			compliance.ControlEvidenceRequirementManualReview,
@@ -175,6 +184,9 @@ func ValidateEvaluateInput(input EvaluateInput) error {
 			compliance.ControlEvidenceRequirementStale:
 		default:
 			return fmt.Errorf("%w: evaluation input contains unknown evidence requirement status %q", ErrInvalidResult, assessment.Status)
+		}
+		if assessment.Status == compliance.ControlEvidenceRequirementSatisfied && len(normalizedStrings(assessment.EvidenceIDs)) == 0 {
+			return fmt.Errorf("%w: satisfied evidence requirement assessment has no evidence", ErrInvalidResult)
 		}
 	}
 	return nil

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -1,0 +1,300 @@
+package complianceassessment
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+type EvaluateInput struct {
+	ResultID               string                                            `json:"result_id"`
+	ObjectiveID            string                                            `json:"objective_id"`
+	Control                compliance.ControlRef                             `json:"control_ref"`
+	ScopeState             ScopeState                                        `json:"scope_state"`
+	EvidenceIndex          *compliance.ControlEvidenceRequirementIndex       `json:"-"`
+	Evidence               []compliance.ControlEvidenceRequirementSignal     `json:"evidence,omitempty"`
+	RequirementAssessments []compliance.ControlEvidenceRequirementAssessment `json:"requirement_assessments,omitempty"`
+	CoverageState          CoverageState                                     `json:"coverage_state"`
+	SourceState            SourceState                                       `json:"source_state"`
+	SourceRuntimeIDs       []string                                          `json:"source_runtime_ids,omitempty"`
+	FindingIDs             []string                                          `json:"finding_ids,omitempty"`
+	InvalidEvidence        bool                                              `json:"invalid_evidence,omitempty"`
+	ConflictingEvidence    bool                                              `json:"conflicting_evidence,omitempty"`
+	DispositionState       DispositionState                                  `json:"disposition_state,omitempty"`
+	DesignState            DesignState                                       `json:"design_state,omitempty"`
+	OperatingState         OperatingEffectivenessState                       `json:"operating_effectiveness_state,omitempty"`
+	Inherited              bool                                              `json:"inherited,omitempty"`
+	Sampled                bool                                              `json:"sampled,omitempty"`
+	EvaluatorRevision      string                                            `json:"evaluator_revision"`
+	Now                    time.Time                                         `json:"now"`
+}
+
+// EvaluateObjective derives one deterministic, multi-axis result. Missing
+// coverage, evidence, or source trust always resolves to an explicit limitation;
+// an empty finding set is never sufficient to pass.
+func EvaluateObjective(input EvaluateInput) (ObjectiveResult, error) {
+	input = normalizeEvaluateInput(input)
+	if err := ValidateEvaluateInput(input); err != nil {
+		return ObjectiveResult{}, err
+	}
+	now := CanonicalTime(input.Now)
+	result := ObjectiveResult{
+		ID:                          strings.TrimSpace(input.ResultID),
+		ControlRef:                  input.Control,
+		ObjectiveID:                 strings.TrimSpace(input.ObjectiveID),
+		ScopeState:                  input.ScopeState,
+		AutomatedOutcome:            OutcomeIndeterminate,
+		DesignState:                 input.DesignState,
+		OperatingEffectivenessState: input.OperatingState,
+		EvidenceState:               EvidenceIncomplete,
+		DispositionState:            input.DispositionState,
+		Assurance:                   AssuranceNone,
+		AuditorState:                AuditorNotReviewed,
+		FindingIDs:                  input.FindingIDs,
+		SourceRuntimeIDs:            input.SourceRuntimeIDs,
+		EvaluatorRevision:           strings.TrimSpace(input.EvaluatorRevision),
+		EvaluatedAt:                 now,
+	}
+	if result.ScopeState == "" {
+		result.ScopeState = ScopeUnresolved
+	}
+	if result.DesignState == "" {
+		result.DesignState = DesignUnknown
+	}
+	if result.OperatingEffectivenessState == "" {
+		result.OperatingEffectivenessState = OperatingUnknown
+	}
+	if result.DispositionState == "" {
+		result.DispositionState = DispositionNone
+	}
+	assessments := append([]compliance.ControlEvidenceRequirementAssessment(nil), input.RequirementAssessments...)
+	if assessments == nil && input.EvidenceIndex != nil {
+		assessments = compliance.AssessControlEvidenceRequirements(compliance.ControlEvidenceRequirementAssessmentInput{
+			Index: input.EvidenceIndex, Control: input.Control, Evidence: input.Evidence, Now: now,
+		})
+	}
+	for _, assessment := range assessments {
+		result.EvidenceIDs = append(result.EvidenceIDs, assessment.EvidenceIDs...)
+	}
+
+	switch result.ScopeState {
+	case ScopeNotApplicable:
+		result.AutomatedOutcome = OutcomeNotAssessed
+		result.EvidenceState = EvidenceSufficient
+		result.DesignState = DesignNotAssessed
+		result.OperatingEffectivenessState = OperatingNotTested
+		result.ReasonCodes = append(result.ReasonCodes, ReasonNotApplicable)
+		result.NextActions = append(result.NextActions, ActionNone)
+		return validatedResult(result)
+	case ScopeUnresolved:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonScopeUnresolved)
+		result.NextActions = append(result.NextActions, ActionResolveScope)
+		return validatedResult(applyDisposition(NormalizeResult(result)))
+	}
+
+	evidenceState, reasons, actions := evaluateEvidence(assessments, input)
+	result.EvidenceState = evidenceState
+	result.ReasonCodes = append(result.ReasonCodes, reasons...)
+	result.NextActions = append(result.NextActions, actions...)
+	if len(result.FindingIDs) != 0 {
+		result.AutomatedOutcome = OutcomeNotSatisfied
+		result.ReasonCodes = append(result.ReasonCodes, ReasonActiveFinding)
+		result.NextActions = append(result.NextActions, ActionRemediate)
+		if result.DesignState == DesignUnknown {
+			result.DesignState = DesignIneffective
+		}
+		if result.OperatingEffectivenessState == OperatingUnknown {
+			result.OperatingEffectivenessState = OperatingIneffective
+		}
+	} else if evidenceState == EvidenceSufficient && input.CoverageState == CoverageComplete && input.SourceState == SourceSupported {
+		result.AutomatedOutcome = OutcomeSatisfied
+		result.ReasonCodes = append(result.ReasonCodes, ReasonSatisfied)
+		result.NextActions = append(result.NextActions, ActionNone)
+		if result.DesignState == DesignUnknown {
+			result.DesignState = DesignEffective
+		}
+		if result.OperatingEffectivenessState == OperatingUnknown {
+			result.OperatingEffectivenessState = OperatingEffective
+		}
+	} else {
+		result.AutomatedOutcome = OutcomeIndeterminate
+	}
+	if input.Inherited {
+		result.ReasonCodes = append(result.ReasonCodes, ReasonInheritedResponsibility)
+	}
+	if input.Sampled {
+		result.ReasonCodes = append(result.ReasonCodes, ReasonSampledTesting)
+	}
+	result.Assurance = deriveAssurance(result, input)
+	return validatedResult(applyDisposition(NormalizeResult(result)))
+}
+
+func normalizeEvaluateInput(input EvaluateInput) EvaluateInput {
+	input.ResultID = strings.TrimSpace(input.ResultID)
+	input.ObjectiveID = strings.TrimSpace(input.ObjectiveID)
+	input.Control = compliance.NormalizeControlRef(input.Control)
+	input.EvaluatorRevision = strings.TrimSpace(input.EvaluatorRevision)
+	input.Now = CanonicalTime(input.Now)
+	if input.ScopeState == "" {
+		input.ScopeState = ScopeUnresolved
+	}
+	if input.CoverageState == "" {
+		input.CoverageState = CoverageUnknown
+	}
+	if input.SourceState == "" {
+		input.SourceState = SourceUnknown
+	}
+	if input.DesignState == "" {
+		input.DesignState = DesignUnknown
+	}
+	if input.OperatingState == "" {
+		input.OperatingState = OperatingUnknown
+	}
+	if input.DispositionState == "" {
+		input.DispositionState = DispositionNone
+	}
+	return input
+}
+
+func ValidateEvaluateInput(input EvaluateInput) error {
+	if input.ResultID == "" || input.ObjectiveID == "" || strings.TrimSpace(input.Control.ControlID) == "" || input.EvaluatorRevision == "" || input.Now.IsZero() {
+		return fmt.Errorf("%w: result, objective, control, evaluator revision, and now are required", ErrInvalidResult)
+	}
+	if !knownScopeState(input.ScopeState) || !knownCoverageState(input.CoverageState) || !knownSourceState(input.SourceState) ||
+		!knownDesignState(input.DesignState) || !knownOperatingState(input.OperatingState) || !knownDispositionState(input.DispositionState) {
+		return fmt.Errorf("%w: evaluation input contains an unknown required state", ErrInvalidResult)
+	}
+	for _, assessment := range input.RequirementAssessments {
+		switch assessment.Status {
+		case compliance.ControlEvidenceRequirementSatisfied,
+			compliance.ControlEvidenceRequirementManualReview,
+			compliance.ControlEvidenceRequirementMissing,
+			compliance.ControlEvidenceRequirementMissingField,
+			compliance.ControlEvidenceRequirementStale:
+		default:
+			return fmt.Errorf("%w: evaluation input contains unknown evidence requirement status %q", ErrInvalidResult, assessment.Status)
+		}
+	}
+	return nil
+}
+
+func validatedResult(result ObjectiveResult) (ObjectiveResult, error) {
+	result = NormalizeResult(result)
+	if err := ValidateObjectiveResult(result); err != nil {
+		return ObjectiveResult{}, err
+	}
+	return result, nil
+}
+
+func evaluateEvidence(assessments []compliance.ControlEvidenceRequirementAssessment, input EvaluateInput) (EvidenceState, []ReasonCode, []NextAction) {
+	if input.ConflictingEvidence || input.SourceState == SourceConflicting {
+		return EvidenceConflicting, []ReasonCode{ReasonEvidenceConflicting}, []NextAction{ActionReview}
+	}
+	if input.InvalidEvidence {
+		return EvidenceUntrusted, []ReasonCode{ReasonEvidenceInvalid}, []NextAction{ActionReview}
+	}
+	switch input.SourceState {
+	case SourceUnverified:
+		return EvidenceUntrusted, []ReasonCode{ReasonSourceUntrusted}, []NextAction{ActionReview}
+	case SourceUnconfigured:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnconfigured}, []NextAction{ActionRestoreSource}
+	case SourceUnsupported:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnsupported}, []NextAction{ActionRestoreSource}
+	case SourceFailed:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceFailed}, []NextAction{ActionRestoreSource}
+	case SourcePartial:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourcePartial}, []NextAction{ActionRestoreSource}
+	case SourceStale:
+		return EvidenceStale, []ReasonCode{ReasonSourceStale}, []NextAction{ActionRefreshEvidence}
+	case SourceUnknown:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnknown}, []NextAction{ActionRestoreSource}
+	}
+	if input.CoverageState == CoverageEmpty {
+		return EvidenceIncomplete, []ReasonCode{ReasonPopulationEmpty}, []NextAction{ActionCollectEvidence}
+	}
+	if input.CoverageState != CoverageComplete {
+		return EvidenceIncomplete, []ReasonCode{ReasonCoverageIncomplete}, []NextAction{ActionCollectEvidence}
+	}
+	if len(assessments) == 0 {
+		return EvidenceMissing, []ReasonCode{ReasonEvidenceMissing}, []NextAction{ActionCollectEvidence}
+	}
+	state := EvidenceSufficient
+	var reasons []ReasonCode
+	var actions []NextAction
+	for _, assessment := range assessments {
+		switch assessment.Status {
+		case compliance.ControlEvidenceRequirementSatisfied:
+		case compliance.ControlEvidenceRequirementManualReview:
+			state = strongestEvidenceState(state, EvidenceManualReview)
+			reasons = append(reasons, ReasonManualEvidence)
+			actions = append(actions, ActionReview)
+		case compliance.ControlEvidenceRequirementStale:
+			state = strongestEvidenceState(state, EvidenceStale)
+			reasons = append(reasons, ReasonEvidenceStale)
+			actions = append(actions, ActionRefreshEvidence)
+		case compliance.ControlEvidenceRequirementMissingField:
+			state = strongestEvidenceState(state, EvidenceIncomplete)
+			reasons = append(reasons, ReasonEvidenceInvalid)
+			actions = append(actions, ActionCollectEvidence)
+		case compliance.ControlEvidenceRequirementMissing:
+			state = strongestEvidenceState(state, EvidenceMissing)
+			reasons = append(reasons, ReasonEvidenceMissing)
+			actions = append(actions, ActionCollectEvidence)
+		default:
+			state = strongestEvidenceState(state, EvidenceManualReview)
+			reasons = append(reasons, ReasonEvidenceInvalid)
+			actions = append(actions, ActionReview)
+		}
+	}
+	return state, reasons, actions
+}
+
+func strongestEvidenceState(left, right EvidenceState) EvidenceState {
+	rank := map[EvidenceState]int{
+		EvidenceSufficient: 0, EvidenceManualReview: 1, EvidenceStale: 2,
+		EvidenceMissing: 3, EvidenceIncomplete: 4, EvidenceUntrusted: 5, EvidenceConflicting: 6,
+	}
+	if rank[right] > rank[left] {
+		return right
+	}
+	return left
+}
+
+func deriveAssurance(result ObjectiveResult, input EvaluateInput) Assurance {
+	if result.AutomatedOutcome == OutcomeSatisfied && result.EvidenceState == EvidenceSufficient {
+		if input.Inherited || input.Sampled {
+			return AssuranceMedium
+		}
+		return AssuranceHigh
+	}
+	if result.AutomatedOutcome == OutcomeNotSatisfied && result.EvidenceState == EvidenceSufficient {
+		return AssuranceHigh
+	}
+	if result.EvidenceState == EvidenceManualReview || result.EvidenceState == EvidenceStale {
+		return AssuranceLow
+	}
+	return AssuranceNone
+}
+
+func applyDisposition(result ObjectiveResult) ObjectiveResult {
+	switch result.DispositionState {
+	case DispositionAcceptedException:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonAcceptedException)
+		result.NextActions = append(result.NextActions, ActionRetest)
+	case DispositionAcceptedRisk:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonAcceptedRisk)
+		result.NextActions = append(result.NextActions, ActionRetest)
+	}
+	return NormalizeResult(result)
+}
+
+func sortResults(results []ObjectiveResult) {
+	sort.Slice(results, func(i, j int) bool {
+		left, right := results[i], results[j]
+		return left.ControlRef.FrameworkID+"\x00"+left.ControlRef.ControlID+"\x00"+left.ObjectiveID+"\x00"+left.ID <
+			right.ControlRef.FrameworkID+"\x00"+right.ControlRef.ControlID+"\x00"+right.ObjectiveID+"\x00"+right.ID
+	})
+}

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -2,7 +2,6 @@ package complianceassessment
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -289,12 +288,4 @@ func applyDisposition(result ObjectiveResult) ObjectiveResult {
 		result.NextActions = append(result.NextActions, ActionRetest)
 	}
 	return NormalizeResult(result)
-}
-
-func sortResults(results []ObjectiveResult) {
-	sort.Slice(results, func(i, j int) bool {
-		left, right := results[i], results[j]
-		return left.ControlRef.FrameworkID+"\x00"+left.ControlRef.ControlID+"\x00"+left.ObjectiveID+"\x00"+left.ID <
-			right.ControlRef.FrameworkID+"\x00"+right.ControlRef.ControlID+"\x00"+right.ObjectiveID+"\x00"+right.ID
-	})
 }

--- a/internal/complianceassessment/legacy_status.go
+++ b/internal/complianceassessment/legacy_status.go
@@ -1,0 +1,38 @@
+package complianceassessment
+
+const (
+	LegacyStatusNotApplicable   = "not_applicable"
+	LegacyStatusException       = "exception"
+	LegacyStatusFailing         = "failing"
+	LegacyStatusMissingEvidence = "missing_evidence"
+	LegacyStatusStaleEvidence   = "stale_evidence"
+	LegacyStatusManualReview    = "manual_review"
+	LegacyStatusPassing         = "passing"
+)
+
+// LegacyStatus preserves the existing caller precedence while the canonical
+// result retains independent automation, evidence, and disposition axes.
+func LegacyStatus(result ObjectiveResult) string {
+	if result.ScopeState == ScopeNotApplicable {
+		return LegacyStatusNotApplicable
+	}
+	if result.DispositionState == DispositionAcceptedException || result.DispositionState == DispositionAcceptedRisk {
+		return LegacyStatusException
+	}
+	if result.AutomatedOutcome == OutcomeNotSatisfied {
+		return LegacyStatusFailing
+	}
+	switch result.EvidenceState {
+	case EvidenceMissing, EvidenceIncomplete:
+		return LegacyStatusMissingEvidence
+	case EvidenceStale:
+		return LegacyStatusStaleEvidence
+	case EvidenceManualReview, EvidenceConflicting, EvidenceUntrusted:
+		return LegacyStatusManualReview
+	case EvidenceSufficient:
+		if result.AutomatedOutcome == OutcomeSatisfied {
+			return LegacyStatusPassing
+		}
+	}
+	return LegacyStatusManualReview
+}

--- a/internal/complianceassessment/legacy_status_test.go
+++ b/internal/complianceassessment/legacy_status_test.go
@@ -1,0 +1,26 @@
+package complianceassessment
+
+import "testing"
+
+func TestLegacyStatusPreservesExistingPrecedence(t *testing.T) {
+	result := validObjectiveResult()
+	result.ScopeState = ScopeNotApplicable
+	result.DispositionState = DispositionAcceptedException
+	result.AutomatedOutcome = OutcomeNotSatisfied
+	result.EvidenceState = EvidenceMissing
+	if got := LegacyStatus(result); got != LegacyStatusNotApplicable {
+		t.Fatalf("not applicable precedence = %q", got)
+	}
+	result.ScopeState = ScopeInScope
+	if got := LegacyStatus(result); got != LegacyStatusException {
+		t.Fatalf("exception precedence = %q", got)
+	}
+	result.DispositionState = DispositionNone
+	if got := LegacyStatus(result); got != LegacyStatusFailing {
+		t.Fatalf("failing precedence = %q", got)
+	}
+	result.AutomatedOutcome = OutcomeIndeterminate
+	if got := LegacyStatus(result); got != LegacyStatusMissingEvidence {
+		t.Fatalf("missing evidence precedence = %q", got)
+	}
+}

--- a/internal/complianceassessment/testdata/objective_conformance.json
+++ b/internal/complianceassessment/testdata/objective_conformance.json
@@ -5,7 +5,7 @@
     "objective_id": "objective-1",
     "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"},
     "scope_state": "in_scope",
-    "requirement_assessments": [{"status": "satisfied", "evidence_ids": ["evidence-1"]}],
+    "requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "satisfied", "evidence_ids": ["evidence-1"]}],
     "coverage_state": "complete",
     "source_state": "supported",
     "source_runtime_ids": ["runtime-1"],
@@ -47,7 +47,7 @@
     },
     {
       "name": "stale_evidence",
-      "input": {"requirement_assessments": [{"status": "stale", "evidence_ids": ["evidence-1"]}]},
+      "input": {"requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "stale", "evidence_ids": ["evidence-1"]}]},
       "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "stale", "assurance": "low", "reason_codes": ["evidence_stale"], "next_actions": ["refresh_evidence"], "legacy_status": "stale_evidence"},
       "expected_digest": "sha256:06e1ea29fa9a5ba7e5119e2c89a1006bbe2dbd61315da9bc52579475b7cf261c"
     },
@@ -77,7 +77,7 @@
     },
     {
       "name": "manual_evidence",
-      "input": {"requirement_assessments": [{"status": "manual_review", "evidence_ids": ["evidence-1"]}]},
+      "input": {"requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "manual_review", "evidence_ids": ["evidence-1"]}]},
       "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "manual_review", "assurance": "low", "reason_codes": ["manual_evidence_review"], "next_actions": ["review"], "legacy_status": "manual_review"},
       "expected_digest": "sha256:a447dfee1c8cf7373aea662d94c746cfe49d97a97b280fee29c161d060eab786"
     },

--- a/internal/complianceassessment/testdata/objective_conformance.json
+++ b/internal/complianceassessment/testdata/objective_conformance.json
@@ -1,0 +1,121 @@
+{
+  "version": "compliance-assessment-conformance/v1",
+  "base_input": {
+    "result_id": "assessment-result-00000000000000000000000000000001",
+    "objective_id": "objective-1",
+    "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"},
+    "scope_state": "in_scope",
+    "requirement_assessments": [{"status": "satisfied", "evidence_ids": ["evidence-1"]}],
+    "coverage_state": "complete",
+    "source_state": "supported",
+    "source_runtime_ids": ["runtime-1"],
+    "evaluator_revision": "evaluator-v1",
+    "now": "2026-07-11T12:00:00.123456789Z"
+  },
+  "base_expected": {
+    "scope_state": "in_scope",
+    "automated_outcome": "satisfied",
+    "design_state": "effective",
+    "operating_effectiveness_state": "effective",
+    "evidence_state": "sufficient",
+    "disposition_state": "none",
+    "assurance": "high",
+    "auditor_state": "not_reviewed",
+    "reason_codes": ["assessment_satisfied"],
+    "next_actions": ["none"],
+    "legacy_status": "passing"
+  },
+  "cases": [
+    {"name": "pass", "input": {}, "expected": {}, "expected_digest": "sha256:aa8a2d895d281a61d20b63c855fd2fa37aba64a65446ced6f8955acacd8c2992"},
+    {
+      "name": "active_finding",
+      "input": {"finding_ids": ["finding-1"]},
+      "expected": {"automated_outcome": "not_satisfied", "design_state": "ineffective", "operating_effectiveness_state": "ineffective", "reason_codes": ["active_finding"], "next_actions": ["remediate"], "legacy_status": "failing"},
+      "expected_digest": "sha256:198812615976bf6380f497efd52c8f54841f326469d4a01614ab3ecdf4ea4168"
+    },
+    {
+      "name": "missing_evidence",
+      "input": {"requirement_assessments": []},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "missing", "assurance": "none", "reason_codes": ["evidence_missing"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:54264f10f4f4efab1705634b27510ffc958a80645f18d93598c893b77f2d9f35"
+    },
+    {
+      "name": "invalid_evidence",
+      "input": {"invalid_evidence": true},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "untrusted", "assurance": "none", "reason_codes": ["evidence_invalid"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:e2722f0ddfccb8c114cdb33a35bfd0aad9afd42004b50b0ef0bd4f9e3620150a"
+    },
+    {
+      "name": "stale_evidence",
+      "input": {"requirement_assessments": [{"status": "stale", "evidence_ids": ["evidence-1"]}]},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "stale", "assurance": "low", "reason_codes": ["evidence_stale"], "next_actions": ["refresh_evidence"], "legacy_status": "stale_evidence"},
+      "expected_digest": "sha256:06e1ea29fa9a5ba7e5119e2c89a1006bbe2dbd61315da9bc52579475b7cf261c"
+    },
+    {
+      "name": "conflicting_evidence",
+      "input": {"conflicting_evidence": true},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "conflicting", "assurance": "none", "reason_codes": ["evidence_conflicting"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:b7e40a786e56bfb861b13f5c41ff1340c1bb664bbf8862f2f31a226e0bce9742"
+    },
+    {
+      "name": "insufficient_coverage",
+      "input": {"coverage_state": "partial"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["coverage_incomplete"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:39a2db74de27785831955518f8bf0d53186a04f5b4e86a17e1f4bcc79cd5672f"
+    },
+    {
+      "name": "untrusted_source",
+      "input": {"source_state": "unverified"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "untrusted", "assurance": "none", "reason_codes": ["source_untrusted"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:4461d5e7adffda425a8109667d44c95a9f3dc52b1334900a593ec42105bbf764"
+    },
+    {
+      "name": "unknown_source_trust",
+      "input": {"source_state": "unknown"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["source_trust_unknown"], "next_actions": ["restore_source"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:433f8d418ccd407220aabaede7acf6e24051e6235f7cf4a6742b3726df40a694"
+    },
+    {
+      "name": "manual_evidence",
+      "input": {"requirement_assessments": [{"status": "manual_review", "evidence_ids": ["evidence-1"]}]},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "manual_review", "assurance": "low", "reason_codes": ["manual_evidence_review"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:a447dfee1c8cf7373aea662d94c746cfe49d97a97b280fee29c161d060eab786"
+    },
+    {
+      "name": "accepted_exception",
+      "input": {"requirement_assessments": [], "disposition_state": "accepted_exception"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "missing", "disposition_state": "accepted_exception", "assurance": "none", "reason_codes": ["accepted_exception", "evidence_missing"], "next_actions": ["collect_evidence", "retest"], "legacy_status": "exception"},
+      "expected_digest": "sha256:e6fcb3ebbe4e87e16280bb0dfd733e111bfecc7019731d1a499e9f0e0139ffec"
+    },
+    {
+      "name": "not_applicable",
+      "input": {"scope_state": "not_applicable", "requirement_assessments": [], "coverage_state": "unknown", "source_state": "unknown"},
+      "expected": {"scope_state": "not_applicable", "automated_outcome": "not_assessed", "design_state": "not_assessed", "operating_effectiveness_state": "not_tested", "evidence_state": "sufficient", "assurance": "none", "reason_codes": ["not_applicable"], "next_actions": ["none"], "legacy_status": "not_applicable"},
+      "expected_digest": "sha256:ae8ae1b84fac40ac390cbad3296b2c7e7e5de2e4f7854098b844e4b7ef33fbb7"
+    },
+    {
+      "name": "inherited_responsibility",
+      "input": {"inherited": true},
+      "expected": {"assurance": "medium", "reason_codes": ["assessment_satisfied", "inherited_responsibility"]},
+      "expected_digest": "sha256:667aafa34b03e54d6614bf72d615472b84021498c53c32db11d135cbaba20646"
+    },
+    {
+      "name": "sampled_testing",
+      "input": {"sampled": true},
+      "expected": {"assurance": "medium", "reason_codes": ["assessment_satisfied", "sampled_testing"]},
+      "expected_digest": "sha256:04f8705f2effaf18c64b323ae3820aec1156e250df6a4a75eafb4eb9b289be92"
+    },
+    {
+      "name": "no_configured_source",
+      "input": {"source_state": "unconfigured"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["source_unconfigured"], "next_actions": ["restore_source"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:9ec2b209ed153bae1d18fc647ea6699f36a91c1cdd53ffed418d242416dad3a7"
+    },
+    {
+      "name": "empty_population_with_satisfied_evidence",
+      "input": {"coverage_state": "empty"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["population_empty"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:992703e2b87bdee82adecf50d8c791bb2c6774f88c6548871292408834affc1d"
+    }
+  ]
+}

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -1,0 +1,538 @@
+package complianceassessment
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+var (
+	ErrInvalidCanonicalValue = errors.New("invalid canonical compliance value")
+	ErrInvalidManifest       = errors.New("invalid compliance input manifest")
+	ErrInvalidResult         = errors.New("invalid compliance objective result")
+)
+
+const (
+	CanonicalModelVersion = "compliance-assessment/v1"
+	ReasonRegistryVersion = "compliance-reasons/v1"
+	LegacyAdapterVersion  = "compliance-legacy-status/v1"
+)
+
+type ScopeState string
+
+const (
+	ScopeInScope       ScopeState = "in_scope"
+	ScopeNotApplicable ScopeState = "not_applicable"
+	ScopeUnresolved    ScopeState = "unresolved"
+)
+
+type AutomatedOutcome string
+
+const (
+	OutcomeSatisfied     AutomatedOutcome = "satisfied"
+	OutcomeNotSatisfied  AutomatedOutcome = "not_satisfied"
+	OutcomeIndeterminate AutomatedOutcome = "indeterminate"
+	OutcomeNotAssessed   AutomatedOutcome = "not_assessed"
+)
+
+type DesignState string
+
+const (
+	DesignEffective   DesignState = "effective"
+	DesignIneffective DesignState = "ineffective"
+	DesignUnknown     DesignState = "unknown"
+	DesignNotAssessed DesignState = "not_assessed"
+)
+
+type OperatingEffectivenessState string
+
+const (
+	OperatingEffective   OperatingEffectivenessState = "effective"
+	OperatingIneffective OperatingEffectivenessState = "ineffective"
+	OperatingUnknown     OperatingEffectivenessState = "unknown"
+	OperatingNotTested   OperatingEffectivenessState = "not_tested"
+)
+
+type EvidenceState string
+
+const (
+	EvidenceSufficient   EvidenceState = "sufficient"
+	EvidenceMissing      EvidenceState = "missing"
+	EvidenceStale        EvidenceState = "stale"
+	EvidenceConflicting  EvidenceState = "conflicting"
+	EvidenceUntrusted    EvidenceState = "untrusted"
+	EvidenceIncomplete   EvidenceState = "incomplete"
+	EvidenceManualReview EvidenceState = "manual_review"
+)
+
+type DispositionState string
+
+const (
+	DispositionNone              DispositionState = "none"
+	DispositionAcceptedException DispositionState = "accepted_exception"
+	DispositionAcceptedRisk      DispositionState = "accepted_risk"
+	DispositionReviewOverride    DispositionState = "review_override"
+)
+
+type Assurance string
+
+const (
+	AssuranceHigh   Assurance = "high"
+	AssuranceMedium Assurance = "medium"
+	AssuranceLow    Assurance = "low"
+	AssuranceNone   Assurance = "none"
+)
+
+type AuditorState string
+
+const (
+	AuditorNotReviewed      AuditorState = "not_reviewed"
+	AuditorAccepted         AuditorState = "accepted"
+	AuditorChangesRequested AuditorState = "changes_requested"
+	AuditorRejected         AuditorState = "rejected"
+)
+
+type CoverageState string
+
+const (
+	CoverageComplete CoverageState = "complete"
+	CoveragePartial  CoverageState = "partial"
+	CoverageEmpty    CoverageState = "empty"
+	CoverageUnknown  CoverageState = "unknown"
+)
+
+type SourceState string
+
+const (
+	SourceSupported    SourceState = "supported"
+	SourcePartial      SourceState = "partial"
+	SourceStale        SourceState = "stale"
+	SourceFailed       SourceState = "failed"
+	SourceUnconfigured SourceState = "unconfigured"
+	SourceUnsupported  SourceState = "unsupported"
+	SourceUnverified   SourceState = "unverified"
+	SourceConflicting  SourceState = "conflicting"
+	SourceUnknown      SourceState = "unknown"
+)
+
+type ReasonCode string
+
+const (
+	ReasonSatisfied               ReasonCode = "assessment_satisfied"
+	ReasonActiveFinding           ReasonCode = "active_finding"
+	ReasonEvidenceMissing         ReasonCode = "evidence_missing"
+	ReasonEvidenceInvalid         ReasonCode = "evidence_invalid"
+	ReasonEvidenceStale           ReasonCode = "evidence_stale"
+	ReasonEvidenceConflicting     ReasonCode = "evidence_conflicting"
+	ReasonCoverageIncomplete      ReasonCode = "coverage_incomplete"
+	ReasonSourceUntrusted         ReasonCode = "source_untrusted"
+	ReasonSourceUnknown           ReasonCode = "source_trust_unknown"
+	ReasonManualEvidence          ReasonCode = "manual_evidence_review"
+	ReasonAcceptedException       ReasonCode = "accepted_exception"
+	ReasonAcceptedRisk            ReasonCode = "accepted_risk"
+	ReasonNotApplicable           ReasonCode = "not_applicable"
+	ReasonInheritedResponsibility ReasonCode = "inherited_responsibility"
+	ReasonSampledTesting          ReasonCode = "sampled_testing"
+	ReasonSourceUnconfigured      ReasonCode = "source_unconfigured"
+	ReasonSourceUnsupported       ReasonCode = "source_unsupported"
+	ReasonSourcePartial           ReasonCode = "source_partial"
+	ReasonSourceFailed            ReasonCode = "source_failed"
+	ReasonSourceStale             ReasonCode = "source_stale"
+	ReasonScopeUnresolved         ReasonCode = "scope_unresolved"
+	ReasonPopulationEmpty         ReasonCode = "population_empty"
+)
+
+type NextAction string
+
+const (
+	ActionNone            NextAction = "none"
+	ActionReview          NextAction = "review"
+	ActionCollectEvidence NextAction = "collect_evidence"
+	ActionRefreshEvidence NextAction = "refresh_evidence"
+	ActionRestoreSource   NextAction = "restore_source"
+	ActionResolveScope    NextAction = "resolve_scope"
+	ActionRemediate       NextAction = "remediate"
+	ActionRetest          NextAction = "retest"
+)
+
+type CollectionCompleteness string
+
+const (
+	CollectionComplete          CollectionCompleteness = "complete"
+	CollectionPartial           CollectionCompleteness = "partial"
+	CollectionTruncated         CollectionCompleteness = "truncated"
+	CollectionChangedDuringScan CollectionCompleteness = "changed_during_scan"
+	CollectionUnknown           CollectionCompleteness = "unknown"
+)
+
+// ManifestRevision pins one semantic input used by an assessment run.
+type ManifestRevision struct {
+	Kind       string `json:"kind"`
+	ID         string `json:"id"`
+	RevisionID string `json:"revision_id"`
+	Version    uint64 `json:"version"`
+	Digest     string `json:"digest"`
+}
+
+type CollectionReceipt struct {
+	Kind          string                 `json:"kind"`
+	RuntimeID     string                 `json:"runtime_id,omitempty"`
+	QueryDigest   string                 `json:"query_digest"`
+	PageIndex     uint32                 `json:"page_index"`
+	Cursor        string                 `json:"cursor,omitempty"`
+	NextCursor    string                 `json:"next_cursor,omitempty"`
+	RawCount      uint64                 `json:"raw_count"`
+	Deduplicated  uint64                 `json:"deduplicated_count"`
+	Included      uint64                 `json:"included_count"`
+	Excluded      uint64                 `json:"excluded_count"`
+	ExpectedTotal *uint64                `json:"expected_total,omitempty"`
+	FirstKey      string                 `json:"first_key,omitempty"`
+	LastKey       string                 `json:"last_key,omitempty"`
+	Watermark     time.Time              `json:"watermark"`
+	Cutoff        time.Time              `json:"cutoff"`
+	Completeness  CollectionCompleteness `json:"completeness"`
+	PageDigest    string                 `json:"page_digest"`
+}
+
+// InputManifest pins every revision and collection receipt needed to reproduce
+// one automated assessment result.
+type InputManifest struct {
+	ModelVersion               string              `json:"model_version"`
+	ProgramID                  string              `json:"program_id"`
+	ScopeRevisionID            string              `json:"scope_revision_id"`
+	PlanRevisionID             string              `json:"plan_revision_id"`
+	PeriodStart                time.Time           `json:"period_start"`
+	PeriodEnd                  time.Time           `json:"period_end"`
+	CollectionCutoff           time.Time           `json:"collection_cutoff"`
+	RequestedScopeDigest       string              `json:"requested_scope_digest"`
+	ResolvedObjectiveSetDigest string              `json:"resolved_objective_set_digest"`
+	MappingSetDigest           string              `json:"mapping_set_digest"`
+	Revisions                  []ManifestRevision  `json:"revisions"`
+	Receipts                   []CollectionReceipt `json:"receipts"`
+	EvaluationRunIDs           []string            `json:"evaluation_run_ids,omitempty"`
+	ReasonRegistry             string              `json:"reason_registry"`
+	AdapterVersion             string              `json:"adapter_version"`
+}
+
+type ObjectiveResult struct {
+	ID                          string                      `json:"id"`
+	ControlRef                  compliance.ControlRef       `json:"control_ref"`
+	ObjectiveID                 string                      `json:"objective_id"`
+	ScopeState                  ScopeState                  `json:"scope_state"`
+	AutomatedOutcome            AutomatedOutcome            `json:"automated_outcome"`
+	DesignState                 DesignState                 `json:"design_state"`
+	OperatingEffectivenessState OperatingEffectivenessState `json:"operating_effectiveness_state"`
+	EvidenceState               EvidenceState               `json:"evidence_state"`
+	DispositionState            DispositionState            `json:"disposition_state"`
+	Assurance                   Assurance                   `json:"assurance"`
+	AuditorState                AuditorState                `json:"auditor_state"`
+	ReasonCodes                 []ReasonCode                `json:"reason_codes"`
+	NextActions                 []NextAction                `json:"next_actions"`
+	EvidenceIDs                 []string                    `json:"evidence_ids,omitempty"`
+	FindingIDs                  []string                    `json:"finding_ids,omitempty"`
+	SourceRuntimeIDs            []string                    `json:"source_runtime_ids,omitempty"`
+	EvaluatorRevision           string                      `json:"evaluator_revision"`
+	EvaluatedAt                 time.Time                   `json:"evaluated_at"`
+}
+
+func NormalizeManifest(value InputManifest) InputManifest {
+	if strings.TrimSpace(value.ModelVersion) == "" {
+		value.ModelVersion = CanonicalModelVersion
+	}
+	if strings.TrimSpace(value.ReasonRegistry) == "" {
+		value.ReasonRegistry = ReasonRegistryVersion
+	}
+	if strings.TrimSpace(value.AdapterVersion) == "" {
+		value.AdapterVersion = LegacyAdapterVersion
+	}
+	value.ModelVersion = strings.TrimSpace(value.ModelVersion)
+	value.ProgramID = strings.TrimSpace(value.ProgramID)
+	value.ScopeRevisionID = strings.TrimSpace(value.ScopeRevisionID)
+	value.PlanRevisionID = strings.TrimSpace(value.PlanRevisionID)
+	value.RequestedScopeDigest = strings.TrimSpace(value.RequestedScopeDigest)
+	value.ResolvedObjectiveSetDigest = strings.TrimSpace(value.ResolvedObjectiveSetDigest)
+	value.MappingSetDigest = strings.TrimSpace(value.MappingSetDigest)
+	value.ReasonRegistry = strings.TrimSpace(value.ReasonRegistry)
+	value.AdapterVersion = strings.TrimSpace(value.AdapterVersion)
+	value.PeriodStart = CanonicalTime(value.PeriodStart)
+	value.PeriodEnd = CanonicalTime(value.PeriodEnd)
+	value.CollectionCutoff = CanonicalTime(value.CollectionCutoff)
+	value.Revisions = append([]ManifestRevision(nil), value.Revisions...)
+	for index := range value.Revisions {
+		value.Revisions[index].Kind = strings.TrimSpace(value.Revisions[index].Kind)
+		value.Revisions[index].ID = strings.TrimSpace(value.Revisions[index].ID)
+		value.Revisions[index].RevisionID = strings.TrimSpace(value.Revisions[index].RevisionID)
+		value.Revisions[index].Digest = strings.TrimSpace(value.Revisions[index].Digest)
+	}
+	sort.Slice(value.Revisions, func(i, j int) bool {
+		left, right := value.Revisions[i], value.Revisions[j]
+		return left.Kind+"\x00"+left.ID+"\x00"+left.RevisionID < right.Kind+"\x00"+right.ID+"\x00"+right.RevisionID
+	})
+	value.Revisions = deduplicateManifestRevisions(value.Revisions)
+	value.Receipts = append([]CollectionReceipt(nil), value.Receipts...)
+	for index := range value.Receipts {
+		receipt := &value.Receipts[index]
+		receipt.Kind = strings.TrimSpace(receipt.Kind)
+		receipt.RuntimeID = strings.TrimSpace(receipt.RuntimeID)
+		receipt.QueryDigest = strings.TrimSpace(receipt.QueryDigest)
+		receipt.Cursor = strings.TrimSpace(receipt.Cursor)
+		receipt.NextCursor = strings.TrimSpace(receipt.NextCursor)
+		receipt.FirstKey = strings.TrimSpace(receipt.FirstKey)
+		receipt.LastKey = strings.TrimSpace(receipt.LastKey)
+		receipt.PageDigest = strings.TrimSpace(receipt.PageDigest)
+		receipt.Watermark = CanonicalTime(receipt.Watermark)
+		receipt.Cutoff = CanonicalTime(receipt.Cutoff)
+	}
+	sort.Slice(value.Receipts, func(i, j int) bool {
+		left, right := value.Receipts[i], value.Receipts[j]
+		if left.Kind+"\x00"+left.RuntimeID != right.Kind+"\x00"+right.RuntimeID {
+			return left.Kind+"\x00"+left.RuntimeID < right.Kind+"\x00"+right.RuntimeID
+		}
+		if left.PageIndex != right.PageIndex {
+			return left.PageIndex < right.PageIndex
+		}
+		return left.PageDigest < right.PageDigest
+	})
+	value.Receipts = deduplicateCollectionReceipts(value.Receipts)
+	value.EvaluationRunIDs = normalizedStrings(value.EvaluationRunIDs)
+	return value
+}
+
+func NormalizeResult(value ObjectiveResult) ObjectiveResult {
+	value.ID = strings.TrimSpace(value.ID)
+	value.ControlRef = compliance.NormalizeControlRef(value.ControlRef)
+	value.ObjectiveID = strings.TrimSpace(value.ObjectiveID)
+	value.EvaluatorRevision = strings.TrimSpace(value.EvaluatorRevision)
+	value.ReasonCodes = normalizedEnums(value.ReasonCodes)
+	value.NextActions = normalizedEnums(value.NextActions)
+	value.EvidenceIDs = normalizedStrings(value.EvidenceIDs)
+	value.FindingIDs = normalizedStrings(value.FindingIDs)
+	value.SourceRuntimeIDs = normalizedStrings(value.SourceRuntimeIDs)
+	value.EvaluatedAt = CanonicalTime(value.EvaluatedAt)
+	return value
+}
+
+func ValidateInputManifest(value InputManifest) error {
+	value = NormalizeManifest(value)
+	if value.ModelVersion != CanonicalModelVersion {
+		return fmt.Errorf("%w: unsupported model_version %q", ErrInvalidManifest, value.ModelVersion)
+	}
+	if value.ProgramID == "" || value.ScopeRevisionID == "" || value.PlanRevisionID == "" {
+		return fmt.Errorf("%w: program, scope revision, and plan revision are required", ErrInvalidManifest)
+	}
+	if value.PeriodStart.IsZero() || value.PeriodEnd.IsZero() || value.CollectionCutoff.IsZero() || value.PeriodEnd.Before(value.PeriodStart) {
+		return fmt.Errorf("%w: valid period and collection cutoff are required", ErrInvalidManifest)
+	}
+	for _, digest := range []string{value.RequestedScopeDigest, value.ResolvedObjectiveSetDigest, value.MappingSetDigest} {
+		if err := compliance.ValidateContentDigest(compliance.ContentDigest(digest)); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidManifest, err)
+		}
+	}
+	if len(value.Revisions) == 0 || len(value.Receipts) == 0 {
+		return fmt.Errorf("%w: revisions and collection receipts are required", ErrInvalidManifest)
+	}
+	for index, revision := range value.Revisions {
+		if revision.Kind == "" || revision.ID == "" || revision.RevisionID == "" || revision.Version == 0 {
+			return fmt.Errorf("%w: revisions[%d] is incomplete", ErrInvalidManifest, index)
+		}
+		if err := compliance.ValidateContentDigest(compliance.ContentDigest(revision.Digest)); err != nil {
+			return fmt.Errorf("%w: revisions[%d]: %v", ErrInvalidManifest, index, err)
+		}
+		if index > 0 {
+			previous := value.Revisions[index-1]
+			if previous.Kind == revision.Kind && previous.ID == revision.ID && previous.RevisionID == revision.RevisionID {
+				return fmt.Errorf("%w: conflicting duplicate revision %q", ErrInvalidManifest, revision.RevisionID)
+			}
+		}
+	}
+	for index, receipt := range value.Receipts {
+		if err := validateCollectionReceipt(receipt); err != nil {
+			return fmt.Errorf("%w: receipts[%d]: %v", ErrInvalidManifest, index, err)
+		}
+		if index > 0 {
+			previous := value.Receipts[index-1]
+			if previous.Kind == receipt.Kind && previous.RuntimeID == receipt.RuntimeID && previous.PageIndex == receipt.PageIndex {
+				return fmt.Errorf("%w: conflicting duplicate collection page %d", ErrInvalidManifest, receipt.PageIndex)
+			}
+		}
+	}
+	return nil
+}
+
+func ValidateObjectiveResult(value ObjectiveResult) error {
+	value = NormalizeResult(value)
+	if value.ID == "" || value.ObjectiveID == "" || strings.TrimSpace(value.ControlRef.ControlID) == "" || value.EvaluatorRevision == "" || value.EvaluatedAt.IsZero() {
+		return fmt.Errorf("%w: identity, control, evaluator revision, and evaluated_at are required", ErrInvalidResult)
+	}
+	if !knownScopeState(value.ScopeState) || !knownOutcome(value.AutomatedOutcome) || !knownDesignState(value.DesignState) ||
+		!knownOperatingState(value.OperatingEffectivenessState) || !knownEvidenceState(value.EvidenceState) ||
+		!knownDispositionState(value.DispositionState) || !knownAssurance(value.Assurance) || !knownAuditorState(value.AuditorState) {
+		return fmt.Errorf("%w: one or more required states are unknown", ErrInvalidResult)
+	}
+	if len(value.ReasonCodes) == 0 || len(value.NextActions) == 0 {
+		return fmt.Errorf("%w: reason_codes and next_actions are required", ErrInvalidResult)
+	}
+	for _, reason := range value.ReasonCodes {
+		if !knownReasonCode(reason) {
+			return fmt.Errorf("%w: unknown reason_code %q", ErrInvalidResult, reason)
+		}
+	}
+	for _, action := range value.NextActions {
+		if !knownNextAction(action) {
+			return fmt.Errorf("%w: unknown next_action %q", ErrInvalidResult, action)
+		}
+	}
+	if value.AutomatedOutcome == OutcomeSatisfied && value.EvidenceState != EvidenceSufficient {
+		return fmt.Errorf("%w: satisfied outcome requires sufficient evidence", ErrInvalidResult)
+	}
+	if value.ScopeState == ScopeNotApplicable && (value.AutomatedOutcome != OutcomeNotAssessed || value.DesignState != DesignNotAssessed || value.OperatingEffectivenessState != OperatingNotTested) {
+		return fmt.Errorf("%w: not-applicable scope requires not-assessed axes", ErrInvalidResult)
+	}
+	return nil
+}
+
+// CanonicalTime uses UTC millisecond precision, matching workflow event
+// timestamps and preventing event/database round trips from changing hashes.
+func CanonicalTime(value time.Time) time.Time {
+	return compliance.CanonicalRevisionTime(value)
+}
+
+func canonicalBytes(value any) ([]byte, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	var decoded any
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	return canonical, nil
+}
+
+func CanonicalManifestBytes(value InputManifest) ([]byte, error) {
+	value = NormalizeManifest(value)
+	if err := ValidateInputManifest(value); err != nil {
+		return nil, err
+	}
+	return canonicalBytes(value)
+}
+
+func CanonicalManifestDigest(value InputManifest) (string, error) {
+	data, err := CanonicalManifestBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(data), nil
+}
+
+func CanonicalResultBytes(value ObjectiveResult) ([]byte, error) {
+	value = NormalizeResult(value)
+	if err := ValidateObjectiveResult(value); err != nil {
+		return nil, err
+	}
+	return canonicalBytes(value)
+}
+
+func CanonicalResultDigest(value ObjectiveResult) (string, error) {
+	data, err := CanonicalResultBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(data), nil
+}
+
+func digestBytes(data []byte) string {
+	digest := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func normalizedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizedEnums[T ~string](values []T) []T {
+	stringsIn := make([]string, 0, len(values))
+	for _, value := range values {
+		stringsIn = append(stringsIn, string(value))
+	}
+	normalized := normalizedStrings(stringsIn)
+	result := make([]T, 0, len(normalized))
+	for _, value := range normalized {
+		result = append(result, T(value))
+	}
+	return result
+}
+
+func deduplicateManifestRevisions(values []ManifestRevision) []ManifestRevision {
+	result := make([]ManifestRevision, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.Kind == value.Kind && previous.ID == value.ID && previous.RevisionID == value.RevisionID && previous.Digest == value.Digest && previous.Version == value.Version {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func deduplicateCollectionReceipts(values []CollectionReceipt) []CollectionReceipt {
+	result := make([]CollectionReceipt, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.Kind == value.Kind && previous.RuntimeID == value.RuntimeID && previous.PageIndex == value.PageIndex && previous.PageDigest == value.PageDigest {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func validateCollectionReceipt(receipt CollectionReceipt) error {
+	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Watermark.IsZero() || receipt.Cutoff.IsZero() {
+		return errors.New("kind, digests, watermark, and cutoff are required")
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.QueryDigest)); err != nil {
+		return err
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.PageDigest)); err != nil {
+		return err
+	}
+	if !knownCompleteness(receipt.Completeness) {
+		return fmt.Errorf("unknown completeness %q", receipt.Completeness)
+	}
+	if receipt.Included+receipt.Excluded != receipt.Deduplicated || receipt.Deduplicated > receipt.RawCount {
+		return errors.New("collection counts are inconsistent")
+	}
+	return nil
+}

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -363,6 +363,9 @@ func ValidateInputManifest(value InputManifest) error {
 			}
 		}
 	}
+	if err := validateCollectionReceiptChains(value.Receipts); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidManifest, err)
+	}
 	return nil
 }
 
@@ -519,8 +522,8 @@ func deduplicateCollectionReceipts(values []CollectionReceipt) []CollectionRecei
 }
 
 func validateCollectionReceipt(receipt CollectionReceipt) error {
-	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Watermark.IsZero() || receipt.Cutoff.IsZero() {
-		return errors.New("kind, digests, watermark, and cutoff are required")
+	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Cutoff.IsZero() {
+		return errors.New("kind, digests, and cutoff are required")
 	}
 	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.QueryDigest)); err != nil {
 		return err
@@ -534,5 +537,60 @@ func validateCollectionReceipt(receipt CollectionReceipt) error {
 	if receipt.Included+receipt.Excluded != receipt.Deduplicated || receipt.Deduplicated > receipt.RawCount {
 		return errors.New("collection counts are inconsistent")
 	}
+	if receipt.Watermark.IsZero() && !emptyCollectionReceipt(receipt) {
+		return errors.New("watermark is required for a non-empty collection")
+	}
 	return nil
+}
+
+func validateCollectionReceiptChains(receipts []CollectionReceipt) error {
+	for start := 0; start < len(receipts); {
+		end := start + 1
+		for end < len(receipts) && receipts[end].Kind == receipts[start].Kind && receipts[end].RuntimeID == receipts[start].RuntimeID {
+			end++
+		}
+		chain := receipts[start:end]
+		if chain[0].PageIndex != 0 || chain[0].Cursor != "" {
+			return fmt.Errorf("collection %q/%q must begin at page zero without a cursor", chain[0].Kind, chain[0].RuntimeID)
+		}
+		var collected uint64
+		for index, receipt := range chain {
+			if receipt.QueryDigest != chain[0].QueryDigest || receipt.Cutoff != chain[0].Cutoff || receipt.Watermark != chain[0].Watermark {
+				return fmt.Errorf("collection %q/%q changed query, cutoff, or watermark between pages", receipt.Kind, receipt.RuntimeID)
+			}
+			if !equalExpectedTotal(receipt.ExpectedTotal, chain[0].ExpectedTotal) {
+				return fmt.Errorf("collection %q/%q changed expected total between pages", receipt.Kind, receipt.RuntimeID)
+			}
+			collected += receipt.Included + receipt.Excluded
+			if index == 0 {
+				continue
+			}
+			previous := chain[index-1]
+			if receipt.PageIndex != previous.PageIndex+1 || previous.NextCursor == "" || receipt.Cursor != previous.NextCursor {
+				return fmt.Errorf("collection %q/%q has a missing or disconnected page at index %d", receipt.Kind, receipt.RuntimeID, receipt.PageIndex)
+			}
+		}
+		terminal := chain[len(chain)-1]
+		if terminal.NextCursor != "" {
+			return fmt.Errorf("collection %q/%q has no terminal page", terminal.Kind, terminal.RuntimeID)
+		}
+		if terminal.Completeness == CollectionComplete && terminal.ExpectedTotal != nil && collected != *terminal.ExpectedTotal {
+			return fmt.Errorf("collection %q/%q completed with %d records; expected %d", terminal.Kind, terminal.RuntimeID, collected, *terminal.ExpectedTotal)
+		}
+		start = end
+	}
+	return nil
+}
+
+func emptyCollectionReceipt(receipt CollectionReceipt) bool {
+	return receipt.PageIndex == 0 && receipt.Cursor == "" && receipt.NextCursor == "" &&
+		receipt.RawCount == 0 && receipt.Deduplicated == 0 && receipt.Included == 0 && receipt.Excluded == 0 &&
+		receipt.ExpectedTotal != nil && *receipt.ExpectedTotal == 0 && receipt.FirstKey == "" && receipt.LastKey == ""
+}
+
+func equalExpectedTotal(left, right *uint64) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -332,7 +332,7 @@ func ValidateInputManifest(value InputManifest) error {
 	}
 	for _, digest := range []string{value.RequestedScopeDigest, value.ResolvedObjectiveSetDigest, value.MappingSetDigest} {
 		if err := compliance.ValidateContentDigest(compliance.ContentDigest(digest)); err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidManifest, err)
+			return fmt.Errorf("%w: %w", ErrInvalidManifest, err)
 		}
 	}
 	if len(value.Revisions) == 0 || len(value.Receipts) == 0 {
@@ -343,7 +343,7 @@ func ValidateInputManifest(value InputManifest) error {
 			return fmt.Errorf("%w: revisions[%d] is incomplete", ErrInvalidManifest, index)
 		}
 		if err := compliance.ValidateContentDigest(compliance.ContentDigest(revision.Digest)); err != nil {
-			return fmt.Errorf("%w: revisions[%d]: %v", ErrInvalidManifest, index, err)
+			return fmt.Errorf("%w: revisions[%d]: %w", ErrInvalidManifest, index, err)
 		}
 		if index > 0 {
 			previous := value.Revisions[index-1]
@@ -354,7 +354,7 @@ func ValidateInputManifest(value InputManifest) error {
 	}
 	for index, receipt := range value.Receipts {
 		if err := validateCollectionReceipt(receipt); err != nil {
-			return fmt.Errorf("%w: receipts[%d]: %v", ErrInvalidManifest, index, err)
+			return fmt.Errorf("%w: receipts[%d]: %w", ErrInvalidManifest, index, err)
 		}
 		if index > 0 {
 			previous := value.Receipts[index-1]
@@ -407,17 +407,17 @@ func CanonicalTime(value time.Time) time.Time {
 func canonicalBytes(value any) ([]byte, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	var decoded any
 	decoder := json.NewDecoder(strings.NewReader(string(data)))
 	decoder.UseNumber()
 	if err := decoder.Decode(&decoded); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	canonical, err := json.Marshal(decoded)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	return canonical, nil
 }

--- a/internal/complianceassessment/types_test.go
+++ b/internal/complianceassessment/types_test.go
@@ -1,0 +1,122 @@
+package complianceassessment
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func TestCanonicalManifestNormalizesOrderTimeAndDoesNotMutateCaller(t *testing.T) {
+	manifest := validManifest()
+	originalFirstKind := manifest.Revisions[0].Kind
+	firstBytes, err := CanonicalManifestBytes(manifest)
+	if err != nil {
+		t.Fatalf("CanonicalManifestBytes() error = %v", err)
+	}
+	shuffled := manifest
+	shuffled.Revisions = append([]ManifestRevision(nil), manifest.Revisions...)
+	shuffled.Receipts = append([]CollectionReceipt(nil), manifest.Receipts...)
+	shuffled.Revisions[0], shuffled.Revisions[1] = shuffled.Revisions[1], shuffled.Revisions[0]
+	shuffled.Receipts[0], shuffled.Receipts[1] = shuffled.Receipts[1], shuffled.Receipts[0]
+	shuffled.EvaluationRunIDs = []string{"run-b", "run-a", "run-a"}
+	secondBytes, err := CanonicalManifestBytes(shuffled)
+	if err != nil {
+		t.Fatalf("CanonicalManifestBytes(shuffled) error = %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatalf("manifest order changed canonical bytes\nfirst=%s\nsecond=%s", firstBytes, secondBytes)
+	}
+	if manifest.Revisions[0].Kind != originalFirstKind {
+		t.Fatal("NormalizeManifest mutated caller revisions")
+	}
+	if bytes.Contains(firstBytes, []byte("123456789")) || !bytes.Contains(firstBytes, []byte(".123Z")) {
+		t.Fatalf("canonical timestamp was not truncated to milliseconds: %s", firstBytes)
+	}
+}
+
+func TestUnknownEnumsSurviveDecodeAndFailCommandValidation(t *testing.T) {
+	result := validObjectiveResult()
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	data = bytes.Replace(data, []byte(`"evidence_state":"sufficient"`), []byte(`"evidence_state":"future_state"`), 1)
+	var decoded ObjectiveResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode future enum: %v", err)
+	}
+	if decoded.EvidenceState != EvidenceState("future_state") {
+		t.Fatalf("future enum was not retained: %q", decoded.EvidenceState)
+	}
+	if err := ValidateObjectiveResult(decoded); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("ValidateObjectiveResult() error = %v, want ErrInvalidResult", err)
+	}
+
+	input := validEvaluateInput()
+	input.SourceState = SourceState("future_source_state")
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective() error = %v, want ErrInvalidResult", err)
+	}
+	input = validEvaluateInput()
+	input.RequirementAssessments[0].Status = compliance.ControlEvidenceRequirementAssessmentStatus("future_requirement_state")
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective(future requirement) error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func TestCanonicalResultRejectsUnsupportedPass(t *testing.T) {
+	result := validObjectiveResult()
+	result.EvidenceState = EvidenceMissing
+	if _, err := CanonicalResultBytes(result); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("CanonicalResultBytes() error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func validManifest() InputManifest {
+	digestA := "sha256:" + strings.Repeat("a", 64)
+	digestB := "sha256:" + strings.Repeat("b", 64)
+	expected := uint64(2)
+	timestamp := time.Date(2026, 7, 11, 12, 0, 0, 123456789, time.FixedZone("offset", -7*60*60))
+	return InputManifest{
+		ProgramID: "program-00000000000000000000000000000001", ScopeRevisionID: "scope-revision-00000000000000000000000000000001",
+		PlanRevisionID: "assessment-plan-revision-00000000000000000000000000000001",
+		PeriodStart:    timestamp.Add(-time.Hour), PeriodEnd: timestamp, CollectionCutoff: timestamp,
+		RequestedScopeDigest: digestA, ResolvedObjectiveSetDigest: digestB, MappingSetDigest: digestA,
+		Revisions: []ManifestRevision{
+			{Kind: "profile", ID: "profile-1", RevisionID: "profile-r1", Version: 1, Digest: digestA},
+			{Kind: "catalog", ID: "catalog-1", RevisionID: "catalog-r1", Version: 1, Digest: digestB},
+		},
+		Receipts: []CollectionReceipt{
+			{Kind: "findings", RuntimeID: "runtime-1", QueryDigest: digestA, PageIndex: 1, Cursor: "a", RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &expected, FirstKey: "b", LastKey: "b", Watermark: timestamp, Cutoff: timestamp, Completeness: CollectionComplete, PageDigest: digestB},
+			{Kind: "findings", RuntimeID: "runtime-1", QueryDigest: digestA, PageIndex: 0, NextCursor: "a", RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &expected, FirstKey: "a", LastKey: "a", Watermark: timestamp, Cutoff: timestamp, Completeness: CollectionComplete, PageDigest: digestA},
+		},
+		EvaluationRunIDs: []string{"run-a", "run-b"},
+	}
+}
+
+func validObjectiveResult() ObjectiveResult {
+	return ObjectiveResult{
+		ID:         "assessment-result-00000000000000000000000000000001",
+		ControlRef: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ObjectiveID: "objective-1",
+		ScopeState: ScopeInScope, AutomatedOutcome: OutcomeSatisfied, DesignState: DesignEffective,
+		OperatingEffectivenessState: OperatingEffective, EvidenceState: EvidenceSufficient,
+		DispositionState: DispositionNone, Assurance: AssuranceHigh, AuditorState: AuditorNotReviewed,
+		ReasonCodes: []ReasonCode{ReasonSatisfied}, NextActions: []NextAction{ActionNone},
+		EvaluatorRevision: "evaluator-v1", EvaluatedAt: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func validEvaluateInput() EvaluateInput {
+	return EvaluateInput{
+		ResultID: "assessment-result-00000000000000000000000000000001", ObjectiveID: "objective-1",
+		Control: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ScopeState: ScopeInScope,
+		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"}}},
+		CoverageState:          CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
+		Now: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+	}
+}

--- a/internal/complianceassessment/types_test.go
+++ b/internal/complianceassessment/types_test.go
@@ -77,6 +77,37 @@ func TestCanonicalResultRejectsUnsupportedPass(t *testing.T) {
 	}
 }
 
+func TestEvaluateObjectiveRejectsSyntheticSatisfiedAssessment(t *testing.T) {
+	input := validEvaluateInput()
+	input.RequirementAssessments = []compliance.ControlEvidenceRequirementAssessment{{
+		Status: compliance.ControlEvidenceRequirementSatisfied,
+	}}
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective() error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func TestInputManifestRequiresCompleteCursorChain(t *testing.T) {
+	manifest := validManifest()
+	manifest.Receipts[1].Cursor = "disconnected"
+	if err := ValidateInputManifest(manifest); !errors.Is(err, ErrInvalidManifest) {
+		t.Fatalf("ValidateInputManifest() error = %v, want ErrInvalidManifest", err)
+	}
+}
+
+func TestInputManifestAcceptsEmptyCompletePopulationWithoutWatermark(t *testing.T) {
+	manifest := validManifest()
+	zero := uint64(0)
+	manifest.Receipts = []CollectionReceipt{{
+		Kind: "findings", RuntimeID: "runtime-1", QueryDigest: manifest.RequestedScopeDigest,
+		ExpectedTotal: &zero, Cutoff: manifest.CollectionCutoff, Completeness: CollectionComplete,
+		PageDigest: manifest.MappingSetDigest,
+	}}
+	if err := ValidateInputManifest(manifest); err != nil {
+		t.Fatalf("ValidateInputManifest() error = %v", err)
+	}
+}
+
 func validManifest() InputManifest {
 	digestA := "sha256:" + strings.Repeat("a", 64)
 	digestB := "sha256:" + strings.Repeat("b", 64)
@@ -115,8 +146,11 @@ func validEvaluateInput() EvaluateInput {
 	return EvaluateInput{
 		ResultID: "assessment-result-00000000000000000000000000000001", ObjectiveID: "objective-1",
 		Control: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ScopeState: ScopeInScope,
-		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"}}},
-		CoverageState:          CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
+		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{
+			RequirementKey: "requirement-1", ControlRef: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"},
+			SourceID: "source-1", EntityType: "resource", Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"},
+		}},
+		CoverageState: CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
 		Now: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
 	}
 }

--- a/internal/complianceassessment/validation.go
+++ b/internal/complianceassessment/validation.go
@@ -1,0 +1,128 @@
+package complianceassessment
+
+func knownScopeState(value ScopeState) bool {
+	switch value {
+	case ScopeInScope, ScopeNotApplicable, ScopeUnresolved:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownOutcome(value AutomatedOutcome) bool {
+	switch value {
+	case OutcomeSatisfied, OutcomeNotSatisfied, OutcomeIndeterminate, OutcomeNotAssessed:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownDesignState(value DesignState) bool {
+	switch value {
+	case DesignEffective, DesignIneffective, DesignUnknown, DesignNotAssessed:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownOperatingState(value OperatingEffectivenessState) bool {
+	switch value {
+	case OperatingEffective, OperatingIneffective, OperatingUnknown, OperatingNotTested:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownEvidenceState(value EvidenceState) bool {
+	switch value {
+	case EvidenceSufficient, EvidenceMissing, EvidenceStale, EvidenceConflicting,
+		EvidenceUntrusted, EvidenceIncomplete, EvidenceManualReview:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownDispositionState(value DispositionState) bool {
+	switch value {
+	case DispositionNone, DispositionAcceptedException, DispositionAcceptedRisk, DispositionReviewOverride:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownAssurance(value Assurance) bool {
+	switch value {
+	case AssuranceHigh, AssuranceMedium, AssuranceLow, AssuranceNone:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownAuditorState(value AuditorState) bool {
+	switch value {
+	case AuditorNotReviewed, AuditorAccepted, AuditorChangesRequested, AuditorRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownCoverageState(value CoverageState) bool {
+	switch value {
+	case CoverageComplete, CoveragePartial, CoverageEmpty, CoverageUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownSourceState(value SourceState) bool {
+	switch value {
+	case SourceSupported, SourcePartial, SourceStale, SourceFailed, SourceUnconfigured,
+		SourceUnsupported, SourceUnverified, SourceConflicting, SourceUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownReasonCode(value ReasonCode) bool {
+	switch value {
+	case ReasonSatisfied, ReasonActiveFinding, ReasonEvidenceMissing, ReasonEvidenceInvalid,
+		ReasonEvidenceStale, ReasonEvidenceConflicting, ReasonCoverageIncomplete,
+		ReasonSourceUntrusted, ReasonSourceUnknown, ReasonManualEvidence,
+		ReasonAcceptedException, ReasonAcceptedRisk, ReasonNotApplicable,
+		ReasonInheritedResponsibility, ReasonSampledTesting, ReasonSourceUnconfigured,
+		ReasonSourceUnsupported, ReasonSourcePartial, ReasonSourceFailed, ReasonSourceStale,
+		ReasonScopeUnresolved, ReasonPopulationEmpty:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownNextAction(value NextAction) bool {
+	switch value {
+	case ActionNone, ActionReview, ActionCollectEvidence, ActionRefreshEvidence,
+		ActionRestoreSource, ActionResolveScope, ActionRemediate, ActionRetest:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownCompleteness(value CollectionCompleteness) bool {
+	switch value {
+	case CollectionComplete, CollectionPartial, CollectionTruncated,
+		CollectionChangedDuringScan, CollectionUnknown:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/grcprogram/canonical.go
+++ b/internal/grcprogram/canonical.go
@@ -1,0 +1,105 @@
+package grcprogram
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func semanticDigest(value any) (compliance.ContentDigest, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("marshal canonical program revision: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	return compliance.ContentDigest("sha256:" + hex.EncodeToString(digest[:])), nil
+}
+
+func normalizeRevisionRefs(values []compliance.RevisionRef) []compliance.RevisionRef {
+	result := append([]compliance.RevisionRef(nil), values...)
+	for index := range result {
+		result[index] = compliance.NormalizeRevisionRef(result[index])
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left, right := result[i], result[j]
+		return left.ID+"\x00"+left.RevisionID < right.ID+"\x00"+right.RevisionID
+	})
+	return deduplicateRevisionRefs(result)
+}
+
+func deduplicateRevisionRefs(values []compliance.RevisionRef) []compliance.RevisionRef {
+	result := make([]compliance.RevisionRef, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.ID == value.ID && previous.RevisionID == value.RevisionID {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizeSubjectRefs(values []compliance.SubjectRef) []compliance.SubjectRef {
+	result := append([]compliance.SubjectRef(nil), values...)
+	for index := range result {
+		result[index].Type = strings.TrimSpace(result[index].Type)
+		result[index].ID = strings.TrimSpace(result[index].ID)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return subjectKey(result[i]) < subjectKey(result[j])
+	})
+	return deduplicateSubjectRefs(result)
+}
+
+func deduplicateSubjectRefs(values []compliance.SubjectRef) []compliance.SubjectRef {
+	result := make([]compliance.SubjectRef, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1] == value {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func subjectKey(value compliance.SubjectRef) string {
+	return value.Type + "\x00" + value.ID
+}
+
+func normalizeParameters(values []ScopeParameter) []ScopeParameter {
+	result := append([]ScopeParameter(nil), values...)
+	for index := range result {
+		result[index].Name = strings.TrimSpace(result[index].Name)
+		result[index].Value = strings.TrimSpace(result[index].Value)
+		result[index].Rationale = strings.TrimSpace(result[index].Rationale)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name+"\x00"+result[i].Value < result[j].Name+"\x00"+result[j].Value
+	})
+	return result
+}
+
+func normalizedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/grcprogram/implementations.go
+++ b/internal/grcprogram/implementations.go
@@ -1,0 +1,406 @@
+package grcprogram
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type RecordImplementationRevisionRequest struct {
+	TenantID                      string
+	ProgramID                     string
+	ExpectedProgramVersion        uint64
+	ImplementationID              string
+	ExpectedImplementationVersion uint64
+	ChangeSummary                 string
+	CreatedBy                     string
+	Specification                 ControlImplementationSpecification
+}
+
+type RecordImplementationRevisionResult struct {
+	Program        *ComplianceProgramRecord
+	Implementation *ControlImplementationRecord
+	Revision       *ControlImplementationRevisionRecord
+}
+
+func (service *Service) GetImplementation(ctx context.Context, tenantID string, programID string, implementationID string) (*ControlImplementationRecord, error) {
+	if service == nil || service.store == nil {
+		return nil, ErrProgramUnavailable
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	programID = strings.TrimSpace(programID)
+	implementationID = strings.TrimSpace(implementationID)
+	if tenantID == "" || programID == "" || implementationID == "" {
+		return nil, ports.ErrControlImplementationNotFound
+	}
+	if _, err := service.GetProgram(ctx, tenantID, programID); err != nil {
+		if errors.Is(err, ports.ErrComplianceProgramNotFound) {
+			return nil, ports.ErrControlImplementationNotFound
+		}
+		return nil, err
+	}
+	record, err := service.store.GetControlImplementation(ctx, tenantID, programID, implementationID)
+	if err != nil {
+		if errors.Is(err, ports.ErrComplianceProgramNotFound) || errors.Is(err, ports.ErrControlImplementationNotFound) {
+			return nil, ports.ErrControlImplementationNotFound
+		}
+		return nil, err
+	}
+	if record == nil || record.TenantID != tenantID || record.ProgramID != programID || record.ID != implementationID {
+		return nil, ports.ErrControlImplementationNotFound
+	}
+	return record, nil
+}
+
+func (service *Service) GetImplementationRevision(ctx context.Context, tenantID string, programID string, implementationID string, revisionID string) (*ControlImplementationRevisionRecord, error) {
+	revisionID = strings.TrimSpace(revisionID)
+	implementation, err := service.GetImplementation(ctx, tenantID, programID, implementationID)
+	if err != nil {
+		return nil, err
+	}
+	if revisionID == "" {
+		return nil, ports.ErrControlImplementationNotFound
+	}
+	revision, err := service.store.GetControlImplementationRevision(ctx, implementation.TenantID, implementation.ProgramID, implementation.ID, revisionID)
+	if err != nil {
+		if errors.Is(err, ports.ErrComplianceProgramNotFound) || errors.Is(err, ports.ErrControlImplementationNotFound) || errors.Is(err, ports.ErrProgramRevisionConflict) {
+			return nil, ports.ErrControlImplementationNotFound
+		}
+		return nil, err
+	}
+	if revision == nil || revision.TenantID != implementation.TenantID || revision.ProgramID != implementation.ProgramID ||
+		revision.ImplementationID != implementation.ID || revision.Version.RevisionID != revisionID {
+		return nil, ports.ErrControlImplementationNotFound
+	}
+	return revision, nil
+}
+
+func (service *Service) RecordImplementationRevision(ctx context.Context, request RecordImplementationRevisionRequest) (*RecordImplementationRevisionResult, error) {
+	if service == nil || service.store == nil {
+		return nil, ErrProgramUnavailable
+	}
+	request = normalizeImplementationRequest(request)
+	if err := validateImplementationRequest(request); err != nil {
+		return nil, err
+	}
+	program, err := service.GetProgram(ctx, request.TenantID, request.ProgramID)
+	if err != nil {
+		return nil, err
+	}
+	if program.AggregateVersion != request.ExpectedProgramVersion {
+		return nil, ports.ErrComplianceProgramVersionConflict
+	}
+	if _, err := service.store.GetProgramScopeRevision(ctx, request.TenantID, request.ProgramID, request.Specification.ScopeRevisionID); err != nil {
+		if errors.Is(err, ports.ErrComplianceProgramNotFound) || errors.Is(err, ports.ErrProgramRevisionConflict) {
+			return nil, ports.ErrProgramRevisionConflict
+		}
+		return nil, err
+	}
+
+	implementation, previous, err := service.loadImplementationRevision(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	implementationID := request.ImplementationID
+	if implementationID == "" {
+		implementationID, err = service.newID(compliance.IdentifierImplementation)
+		if err != nil {
+			return nil, fmt.Errorf("create implementation identifier: %w", err)
+		}
+	}
+	if err := compliance.ValidateIdentifier(compliance.IdentifierImplementation, implementationID); err != nil {
+		return nil, fmt.Errorf("%w: implementation id: %w", ErrInvalidProgramRequest, err)
+	}
+	revisionID, err := service.newRevision(compliance.IdentifierImplementation)
+	if err != nil {
+		return nil, fmt.Errorf("create implementation revision identifier: %w", err)
+	}
+	if err := compliance.ValidateRevisionIdentifier(compliance.IdentifierImplementation, revisionID); err != nil {
+		return nil, fmt.Errorf("%w: implementation revision id: %w", ErrInvalidProgramRequest, err)
+	}
+
+	version := uint64(1)
+	predecessorID := ""
+	if previous != nil {
+		if previous.Version.ID != implementationID {
+			return nil, ports.ErrProgramRevisionConflict
+		}
+		if err := previous.Version.Validate(); err != nil {
+			return nil, ports.ErrProgramRevisionConflict
+		}
+		version = previous.Version.Version + 1
+		predecessorID = previous.Version.RevisionID
+	}
+	digest, err := semanticDigest(request.Specification)
+	if err != nil {
+		return nil, err
+	}
+	if previous != nil && previous.Version.ContentDigest == digest {
+		return nil, ports.ErrProgramRevisionConflict
+	}
+	now := compliance.CanonicalRevisionTime(service.now())
+	createdAt := now
+	if implementation != nil {
+		createdAt = implementation.CreatedAt
+	}
+	revision := ControlImplementationRevisionRecord{
+		TenantID: request.TenantID, ProgramID: request.ProgramID, ImplementationID: implementationID,
+		Version: compliance.VersionMetadata{
+			ID: implementationID, RevisionID: revisionID, Version: version, LastModified: now,
+			ContentDigest: digest, CreatedBy: request.CreatedBy, PredecessorID: predecessorID,
+		},
+		ChangeSummary: request.ChangeSummary, Specification: request.Specification,
+	}
+	aggregate := ControlImplementationRecord{
+		TenantID: request.TenantID, ProgramID: request.ProgramID, ID: implementationID,
+		CurrentRevisionID: revisionID, AggregateVersion: request.ExpectedImplementationVersion + 1,
+		CreatedAt: createdAt, UpdatedAt: now,
+	}
+	updatedProgram, updatedImplementation, err := service.store.AppendControlImplementationRevision(ctx, AppendControlImplementationRevisionRequest{
+		TenantID: request.TenantID, ProgramID: request.ProgramID,
+		ExpectedProgramVersion:        request.ExpectedProgramVersion,
+		ExpectedImplementationVersion: request.ExpectedImplementationVersion,
+		Implementation:                aggregate, Revision: revision,
+	})
+	if err != nil {
+		return nil, programStoreError(err)
+	}
+	return &RecordImplementationRevisionResult{
+		Program: updatedProgram, Implementation: updatedImplementation, Revision: &revision,
+	}, nil
+}
+
+func (service *Service) loadImplementationRevision(ctx context.Context, request RecordImplementationRevisionRequest) (*ControlImplementationRecord, *ControlImplementationRevisionRecord, error) {
+	if request.ImplementationID == "" {
+		if request.ExpectedImplementationVersion != 0 {
+			return nil, nil, ports.ErrComplianceProgramVersionConflict
+		}
+		return nil, nil, nil
+	}
+	if err := compliance.ValidateIdentifier(compliance.IdentifierImplementation, request.ImplementationID); err != nil {
+		return nil, nil, fmt.Errorf("%w: implementation id: %w", ErrInvalidProgramRequest, err)
+	}
+	implementation, err := service.store.GetControlImplementation(ctx, request.TenantID, request.ProgramID, request.ImplementationID)
+	if err != nil {
+		if errors.Is(err, ports.ErrControlImplementationNotFound) && request.ExpectedImplementationVersion == 0 {
+			return nil, nil, nil
+		}
+		return nil, nil, programStoreError(err)
+	}
+	if implementation == nil || implementation.TenantID != request.TenantID || implementation.ProgramID != request.ProgramID {
+		return nil, nil, ports.ErrControlImplementationNotFound
+	}
+	if implementation.AggregateVersion != request.ExpectedImplementationVersion {
+		return nil, nil, ports.ErrComplianceProgramVersionConflict
+	}
+	previous, err := service.store.GetControlImplementationRevision(ctx, request.TenantID, request.ProgramID, request.ImplementationID, implementation.CurrentRevisionID)
+	if err != nil {
+		return nil, nil, programStoreError(err)
+	}
+	return implementation, previous, nil
+}
+
+func normalizeImplementationRequest(request RecordImplementationRevisionRequest) RecordImplementationRevisionRequest {
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.ProgramID = strings.TrimSpace(request.ProgramID)
+	request.ImplementationID = strings.TrimSpace(request.ImplementationID)
+	request.ChangeSummary = strings.TrimSpace(request.ChangeSummary)
+	request.CreatedBy = strings.TrimSpace(request.CreatedBy)
+	request.Specification = normalizeImplementationSpecification(request.Specification)
+	return request
+}
+
+func validateImplementationRequest(request RecordImplementationRevisionRequest) error {
+	if request.TenantID == "" || request.ProgramID == "" || request.ExpectedProgramVersion == 0 || request.ChangeSummary == "" || request.CreatedBy == "" {
+		return fmt.Errorf("%w: tenant, program, expected version, change summary, and actor are required", ErrInvalidProgramRequest)
+	}
+	return validateImplementationSpecification(request.Specification)
+}
+
+func normalizeImplementationSpecification(value ControlImplementationSpecification) ControlImplementationSpecification {
+	value.ScopeRevisionID = strings.TrimSpace(value.ScopeRevisionID)
+	value.ControlRef = compliance.NormalizeControlRef(value.ControlRef)
+	value.StatementID = strings.TrimSpace(value.StatementID)
+	value.ObjectiveIDs = normalizedStrings(value.ObjectiveIDs)
+	value.Status = strings.TrimSpace(value.Status)
+	value.Narrative = strings.TrimSpace(value.Narrative)
+	value.Procedure = strings.TrimSpace(value.Procedure)
+	value.OwnerTeam = strings.TrimSpace(value.OwnerTeam)
+	value.ReviewPolicy.Cadence = strings.TrimSpace(value.ReviewPolicy.Cadence)
+	value.ReviewPolicy.EffectiveFrom = compliance.CanonicalRevisionTime(value.ReviewPolicy.EffectiveFrom)
+	value.ReviewPolicy.EffectiveUntil = compliance.CanonicalRevisionTime(value.ReviewPolicy.EffectiveUntil)
+	value.ResponsibleRoles = normalizedStrings(value.ResponsibleRoles)
+	value.AccountableRoles = normalizedStrings(value.AccountableRoles)
+	value.Responsibility = strings.TrimSpace(value.Responsibility)
+	if value.UpstreamImplementation != nil {
+		reference := normalizeSubjectRefs([]compliance.SubjectRef{*value.UpstreamImplementation})[0]
+		value.UpstreamImplementation = &reference
+	}
+	value.SubjectRefs = normalizeSubjectRefs(value.SubjectRefs)
+	value.ParameterValues = normalizeParameters(value.ParameterValues)
+	value.MappingRefs = normalizeMappingRefs(value.MappingRefs)
+	value.ExpectedTestRefs = normalizeSubjectRefs(value.ExpectedTestRefs)
+	value.EvidenceRequirementRefs = normalizeSubjectRefs(value.EvidenceRequirementRefs)
+	value.SourceDimensionRefs = normalizeSubjectRefs(value.SourceDimensionRefs)
+	value.RiskRefs = normalizeSubjectRefs(value.RiskRefs)
+	value.ExceptionRefs = normalizeSubjectRefs(value.ExceptionRefs)
+	value.MaterialChangeCriteria = normalizedStrings(value.MaterialChangeCriteria)
+	value.InvalidationRules = normalizedStrings(value.InvalidationRules)
+	return value
+}
+
+func validateImplementationSpecification(value ControlImplementationSpecification) error {
+	if value.ScopeRevisionID == "" || value.ControlRef.ControlID == "" || (value.ControlRef.FrameworkID == "" && value.ControlRef.FrameworkName == "") {
+		return fmt.Errorf("%w: scope revision and exact control reference are required", ErrInvalidProgramRequest)
+	}
+	if value.Narrative == "" || value.OwnerTeam == "" || len(value.ResponsibleRoles) == 0 || len(value.AccountableRoles) == 0 {
+		return fmt.Errorf("%w: narrative, owner, responsible roles, and accountable roles are required", ErrInvalidProgramRequest)
+	}
+	if value.ReviewPolicy.Cadence == "" || value.ReviewPolicy.EffectiveFrom.IsZero() {
+		return fmt.Errorf("%w: review cadence and effective_from are required", ErrInvalidProgramRequest)
+	}
+	if !value.ReviewPolicy.EffectiveUntil.IsZero() && !value.ReviewPolicy.EffectiveUntil.After(value.ReviewPolicy.EffectiveFrom) {
+		return fmt.Errorf("%w: effective_until must be after effective_from", ErrInvalidProgramRequest)
+	}
+	if !knownImplementationStatus(value.Status) || !knownResponsibility(value.Responsibility) {
+		return fmt.Errorf("%w: implementation status or responsibility mode is invalid", ErrInvalidProgramRequest)
+	}
+	if (value.Responsibility == ResponsibilityInherited || value.Responsibility == ResponsibilityShared) && value.UpstreamImplementation == nil {
+		return fmt.Errorf("%w: inherited and shared responsibilities require an upstream implementation", ErrInvalidProgramRequest)
+	}
+	if value.UpstreamImplementation != nil {
+		if err := value.UpstreamImplementation.Validate(); err != nil {
+			return fmt.Errorf("%w: invalid upstream implementation: %w", ErrInvalidProgramRequest, err)
+		}
+	}
+	for _, parameter := range value.ParameterValues {
+		if parameter.Name == "" || parameter.Value == "" || parameter.Rationale == "" {
+			return fmt.Errorf("%w: implementation parameters require name, value, and rationale", ErrInvalidProgramRequest)
+		}
+	}
+	for _, reference := range appendImplementationSubjectRefs(value) {
+		if err := reference.Validate(); err != nil {
+			return fmt.Errorf("%w: invalid implementation subject: %w", ErrInvalidProgramRequest, err)
+		}
+	}
+	for _, mapping := range value.MappingRefs {
+		if err := validateMappingRef(mapping); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeMappingRefs(values []ControlMappingRef) []ControlMappingRef {
+	result := append([]ControlMappingRef(nil), values...)
+	for index := range result {
+		mapping := &result[index]
+		mapping.ID = strings.TrimSpace(mapping.ID)
+		mapping.RevisionID = strings.TrimSpace(mapping.RevisionID)
+		mapping.Granularity = strings.TrimSpace(mapping.Granularity)
+		mapping.Method = strings.TrimSpace(mapping.Method)
+		mapping.Rationale = strings.TrimSpace(mapping.Rationale)
+		mapping.Gaps = normalizedStrings(mapping.Gaps)
+		mapping.Provenance = normalizeSubjectRefs(mapping.Provenance)
+		mapping.AuthorID = strings.TrimSpace(mapping.AuthorID)
+		mapping.ReviewerID = strings.TrimSpace(mapping.ReviewerID)
+		mapping.Source = compliance.NormalizeRevisionRef(mapping.Source)
+		mapping.Target = compliance.NormalizeRevisionRef(mapping.Target)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID+"\x00"+result[i].RevisionID < result[j].ID+"\x00"+result[j].RevisionID
+	})
+	return result
+}
+
+func validateMappingRef(value ControlMappingRef) error {
+	if err := compliance.ValidateIdentifier(compliance.IdentifierMapping, value.ID); err != nil {
+		return fmt.Errorf("%w: mapping id: %w", ErrInvalidProgramRequest, err)
+	}
+	if err := compliance.ValidateRevisionIdentifier(compliance.IdentifierMapping, value.RevisionID); err != nil {
+		return fmt.Errorf("%w: mapping revision id: %w", ErrInvalidProgramRequest, err)
+	}
+	if value.Granularity == "" {
+		return fmt.Errorf("%w: mapping granularity is required", ErrInvalidProgramRequest)
+	}
+	if value.Method == "" || value.Rationale == "" || value.AuthorID == "" {
+		return fmt.Errorf("%w: mapping method, rationale, and author are required", ErrInvalidProgramRequest)
+	}
+	if err := value.Source.Validate(); err != nil {
+		return fmt.Errorf("%w: mapping source: %w", ErrInvalidProgramRequest, err)
+	}
+	if err := value.Target.Validate(); err != nil {
+		return fmt.Errorf("%w: mapping target: %w", ErrInvalidProgramRequest, err)
+	}
+	if value.Source.ID == value.Target.ID && value.Source.RevisionID == value.Target.RevisionID {
+		return fmt.Errorf("%w: mapping source and target must differ", ErrInvalidProgramRequest)
+	}
+	for _, reference := range value.Provenance {
+		if err := reference.Validate(); err != nil {
+			return fmt.Errorf("%w: mapping provenance: %w", ErrInvalidProgramRequest, err)
+		}
+	}
+	switch value.DecisionState {
+	case compliance.MappingProposed:
+	case compliance.MappingApproved, compliance.MappingRejected, compliance.MappingRetired:
+		if value.ReviewerID == "" {
+			return fmt.Errorf("%w: decided mappings require a reviewer", ErrInvalidProgramRequest)
+		}
+	default:
+		return fmt.Errorf("%w: mapping decision state is invalid", ErrInvalidProgramRequest)
+	}
+	if value.CoverageBasisPoints > 10000 {
+		return fmt.Errorf("%w: mapping coverage exceeds 10000 basis points", ErrInvalidProgramRequest)
+	}
+	switch value.Relationship {
+	case compliance.MappingEquivalent:
+		if value.CoverageBasisPoints != 10000 {
+			return fmt.Errorf("%w: equivalent mappings require full coverage", ErrInvalidProgramRequest)
+		}
+		return nil
+	case compliance.MappingNone:
+		if value.CoverageBasisPoints != 0 {
+			return fmt.Errorf("%w: no-relationship mappings require zero coverage", ErrInvalidProgramRequest)
+		}
+		return nil
+	case compliance.MappingSubset, compliance.MappingSuperset, compliance.MappingOverlap:
+		return nil
+	default:
+		return fmt.Errorf("%w: mapping relationship is invalid", ErrInvalidProgramRequest)
+	}
+}
+
+func appendImplementationSubjectRefs(value ControlImplementationSpecification) []compliance.SubjectRef {
+	result := append([]compliance.SubjectRef(nil), value.SubjectRefs...)
+	result = append(result, value.ExpectedTestRefs...)
+	result = append(result, value.EvidenceRequirementRefs...)
+	result = append(result, value.SourceDimensionRefs...)
+	result = append(result, value.RiskRefs...)
+	result = append(result, value.ExceptionRefs...)
+	return result
+}
+
+func knownImplementationStatus(value string) bool {
+	switch value {
+	case ImplementationPlanned, ImplementationPartial, ImplementationImplemented,
+		ImplementationAlternative, ImplementationNotApplicable, ImplementationRetired:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownResponsibility(value string) bool {
+	switch value {
+	case ResponsibilityDirect, ResponsibilityProvided, ResponsibilityCustomerResponsibility,
+		ResponsibilityShared, ResponsibilityInherited:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/grcprogram/model.go
+++ b/internal/grcprogram/model.go
@@ -1,0 +1,231 @@
+package grcprogram
+
+import (
+	"context"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+const (
+	ComplianceProgramDraft     = "draft"
+	ComplianceProgramActive    = "active"
+	ComplianceProgramSuspended = "suspended"
+	ComplianceProgramRetired   = "retired"
+
+	ScopeRevisionProposed = "proposed"
+	ScopeRevisionActive   = "active"
+
+	ScopeSelectorInclude = "include"
+	ScopeSelectorExclude = "exclude"
+
+	SubjectResolutionResolved   = "resolved"
+	SubjectResolutionUnresolved = "unresolved"
+
+	SubjectUnresolvedUnsupported          = "unsupported_selector"
+	SubjectUnresolvedSourceUnavailable    = "source_unavailable"
+	SubjectUnresolvedInvalidSelector      = "invalid_selector"
+	SubjectUnresolvedWatermarkUnavailable = "watermark_unavailable"
+
+	ImplementationPlanned       = "planned"
+	ImplementationPartial       = "partial"
+	ImplementationImplemented   = "implemented"
+	ImplementationAlternative   = "alternative"
+	ImplementationNotApplicable = "not_applicable"
+	ImplementationRetired       = "retired"
+
+	ResponsibilityDirect                 = "direct"
+	ResponsibilityProvided               = "provided"
+	ResponsibilityCustomerResponsibility = "customer_responsibility"
+	ResponsibilityShared                 = "shared"
+	ResponsibilityInherited              = "inherited"
+)
+
+type ComplianceProgramRecord struct {
+	TenantID               string    `json:"tenant_id"`
+	ID                     string    `json:"id"`
+	Name                   string    `json:"name"`
+	OwnerTeam              string    `json:"owner_team"`
+	RiskOwner              string    `json:"risk_owner,omitempty"`
+	Status                 string    `json:"status"`
+	ScopeID                string    `json:"scope_id,omitempty"`
+	CurrentScopeRevisionID string    `json:"current_scope_revision_id,omitempty"`
+	AggregateVersion       uint64    `json:"aggregate_version"`
+	CreatedAt              time.Time `json:"created_at"`
+	UpdatedAt              time.Time `json:"updated_at"`
+}
+
+type ScopeSelectorCriterion struct {
+	Field    string `json:"field"`
+	Operator string `json:"operator"`
+	Value    string `json:"value"`
+}
+
+type ProgramScopeSelector struct {
+	ID                   string                   `json:"id"`
+	Kind                 string                   `json:"kind"`
+	Mode                 string                   `json:"mode"`
+	Criteria             []ScopeSelectorCriterion `json:"criteria"`
+	Source               string                   `json:"source"`
+	Reason               string                   `json:"reason"`
+	ApproverID           string                   `json:"approver_id"`
+	EffectiveFrom        time.Time                `json:"effective_from"`
+	EffectiveUntil       time.Time                `json:"effective_until,omitempty"`
+	ReviewAt             time.Time                `json:"review_at,omitempty"`
+	SupersedesSelectorID string                   `json:"supersedes_selector_id,omitempty"`
+}
+
+type ScopeParameter struct {
+	Name      string `json:"name"`
+	Value     string `json:"value"`
+	Rationale string `json:"rationale"`
+}
+
+type SelectorResolution struct {
+	SelectorID string                  `json:"selector_id"`
+	State      string                  `json:"state"`
+	ReasonCode string                  `json:"reason_code,omitempty"`
+	Subjects   []compliance.SubjectRef `json:"subjects"`
+}
+
+type SubjectResolutionRequest struct {
+	TenantID  string                 `json:"tenant_id"`
+	Selectors []ProgramScopeSelector `json:"selectors"`
+	Cutoff    time.Time              `json:"cutoff"`
+}
+
+type SubjectResolutionBatch struct {
+	Watermark   string               `json:"watermark"`
+	Cutoff      time.Time            `json:"cutoff"`
+	Resolutions []SelectorResolution `json:"resolutions"`
+}
+
+type ProgramSubjectManifest struct {
+	Subjects              []compliance.SubjectRef  `json:"subjects"`
+	SelectorResolutions   []SelectorResolution     `json:"selector_resolutions"`
+	ZeroMatchSelectorIDs  []string                 `json:"zero_match_selector_ids"`
+	UnresolvedSelectorIDs []string                 `json:"unresolved_selector_ids"`
+	Watermark             string                   `json:"watermark"`
+	Cutoff                time.Time                `json:"cutoff"`
+	ContentDigest         compliance.ContentDigest `json:"content_digest"`
+}
+
+type ProgramScopeSpecification struct {
+	FrameworkRevisions []compliance.RevisionRef `json:"framework_revisions"`
+	ProfileRevisions   []compliance.RevisionRef `json:"profile_revisions"`
+	Selectors          []ProgramScopeSelector   `json:"selectors"`
+	Parameters         []ScopeParameter         `json:"parameters"`
+	SubjectManifest    ProgramSubjectManifest   `json:"subject_manifest"`
+	EvidenceWindow     string                   `json:"evidence_window,omitempty"`
+	MonitoringCadence  string                   `json:"monitoring_cadence,omitempty"`
+	SourceProofPolicy  string                   `json:"source_proof_policy,omitempty"`
+	MaterialityLevel   string                   `json:"materiality_level,omitempty"`
+}
+
+type ProgramScopeRevisionRecord struct {
+	TenantID      string                     `json:"tenant_id"`
+	ProgramID     string                     `json:"program_id"`
+	State         string                     `json:"state"`
+	Version       compliance.VersionMetadata `json:"version"`
+	ChangeSummary string                     `json:"change_summary"`
+	Specification ProgramScopeSpecification  `json:"specification"`
+}
+
+type ControlMappingRef struct {
+	ID                  string                          `json:"id"`
+	RevisionID          string                          `json:"revision_id"`
+	Relationship        compliance.MappingRelationship  `json:"relationship"`
+	Granularity         string                          `json:"granularity"`
+	Source              compliance.RevisionRef          `json:"source"`
+	Target              compliance.RevisionRef          `json:"target"`
+	Method              string                          `json:"method"`
+	Rationale           string                          `json:"rationale"`
+	CoverageBasisPoints uint16                          `json:"coverage_basis_points"`
+	Gaps                []string                        `json:"gaps,omitempty"`
+	Provenance          []compliance.SubjectRef         `json:"provenance,omitempty"`
+	DecisionState       compliance.MappingDecisionState `json:"decision_state"`
+	AuthorID            string                          `json:"author_id"`
+	ReviewerID          string                          `json:"reviewer_id,omitempty"`
+}
+
+type ImplementationReviewPolicy struct {
+	Cadence        string    `json:"cadence"`
+	EffectiveFrom  time.Time `json:"effective_from"`
+	EffectiveUntil time.Time `json:"effective_until,omitempty"`
+}
+
+type ControlImplementationRecord struct {
+	TenantID          string    `json:"tenant_id"`
+	ProgramID         string    `json:"program_id"`
+	ID                string    `json:"id"`
+	CurrentRevisionID string    `json:"current_revision_id"`
+	AggregateVersion  uint64    `json:"aggregate_version"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
+type ControlImplementationSpecification struct {
+	ScopeRevisionID         string                     `json:"scope_revision_id"`
+	ControlRef              compliance.ControlRef      `json:"control_ref"`
+	StatementID             string                     `json:"statement_id,omitempty"`
+	ObjectiveIDs            []string                   `json:"objective_ids"`
+	Status                  string                     `json:"status"`
+	Narrative               string                     `json:"narrative"`
+	Procedure               string                     `json:"procedure,omitempty"`
+	OwnerTeam               string                     `json:"owner_team"`
+	ReviewPolicy            ImplementationReviewPolicy `json:"review_policy"`
+	ResponsibleRoles        []string                   `json:"responsible_roles"`
+	AccountableRoles        []string                   `json:"accountable_roles"`
+	Responsibility          string                     `json:"responsibility"`
+	UpstreamImplementation  *compliance.SubjectRef     `json:"upstream_implementation,omitempty"`
+	SubjectRefs             []compliance.SubjectRef    `json:"subject_refs"`
+	ParameterValues         []ScopeParameter           `json:"parameter_values"`
+	MappingRefs             []ControlMappingRef        `json:"mapping_refs"`
+	ExpectedTestRefs        []compliance.SubjectRef    `json:"expected_test_refs"`
+	EvidenceRequirementRefs []compliance.SubjectRef    `json:"evidence_requirement_refs"`
+	SourceDimensionRefs     []compliance.SubjectRef    `json:"source_dimension_refs"`
+	RiskRefs                []compliance.SubjectRef    `json:"risk_refs"`
+	ExceptionRefs           []compliance.SubjectRef    `json:"exception_refs"`
+	MaterialChangeCriteria  []string                   `json:"material_change_criteria"`
+	InvalidationRules       []string                   `json:"invalidation_rules"`
+}
+
+type ControlImplementationRevisionRecord struct {
+	TenantID         string                             `json:"tenant_id"`
+	ProgramID        string                             `json:"program_id"`
+	ImplementationID string                             `json:"implementation_id"`
+	Version          compliance.VersionMetadata         `json:"version"`
+	ChangeSummary    string                             `json:"change_summary"`
+	Specification    ControlImplementationSpecification `json:"specification"`
+}
+
+type AppendProgramScopeRevisionRequest struct {
+	TenantID               string
+	ProgramID              string
+	ExpectedProgramVersion uint64
+	Revision               ProgramScopeRevisionRecord
+}
+
+type AppendControlImplementationRevisionRequest struct {
+	TenantID                      string
+	ProgramID                     string
+	ExpectedProgramVersion        uint64
+	ExpectedImplementationVersion uint64
+	Implementation                ControlImplementationRecord
+	Revision                      ControlImplementationRevisionRecord
+}
+
+type ComplianceProgramStore interface {
+	Ping(context.Context) error
+	CreateComplianceProgram(context.Context, ComplianceProgramRecord) (*ComplianceProgramRecord, error)
+	GetComplianceProgram(context.Context, string, string) (*ComplianceProgramRecord, error)
+	GetProgramScopeRevision(context.Context, string, string, string) (*ProgramScopeRevisionRecord, error)
+	AppendProgramScopeRevision(context.Context, AppendProgramScopeRevisionRequest) (*ComplianceProgramRecord, error)
+	GetControlImplementation(context.Context, string, string, string) (*ControlImplementationRecord, error)
+	GetControlImplementationRevision(context.Context, string, string, string, string) (*ControlImplementationRevisionRecord, error)
+	AppendControlImplementationRevision(context.Context, AppendControlImplementationRevisionRequest) (*ComplianceProgramRecord, *ControlImplementationRecord, error)
+}
+
+type ProgramSubjectResolver interface {
+	ResolveProgramSubjects(context.Context, SubjectResolutionRequest) (SubjectResolutionBatch, error)
+}

--- a/internal/grcprogram/program_core_test.go
+++ b/internal/grcprogram/program_core_test.go
@@ -1,0 +1,476 @@
+package grcprogram
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestBuildSubjectManifestDeterministicAndSeparatesResolutionOutcomes(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, time.July, 11, 16, 30, 0, 123456789, time.FixedZone("test", -7*60*60))
+	selectors := []ProgramScopeSelector{
+		testSelector("people-unresolved", "people", ScopeSelectorInclude),
+		testSelector("asset-exclude", "asset", ScopeSelectorExclude),
+		testSelector("vendor-zero", "vendor", ScopeSelectorInclude),
+		testSelector("asset-include", "asset", ScopeSelectorInclude),
+	}
+	resolutions := []SelectorResolution{
+		{SelectorID: "vendor-zero", State: SubjectResolutionResolved},
+		{SelectorID: "people-unresolved", State: SubjectResolutionUnresolved, ReasonCode: SubjectUnresolvedSourceUnavailable},
+		{SelectorID: "asset-exclude", State: SubjectResolutionResolved, Subjects: []compliance.SubjectRef{{Type: "asset", ID: "two"}}},
+		{SelectorID: "asset-include", State: SubjectResolutionResolved, Subjects: []compliance.SubjectRef{
+			{Type: "asset", ID: "two"}, {Type: "asset", ID: "one"}, {Type: "asset", ID: "one"},
+		}},
+	}
+	first, err := BuildSubjectManifest(selectors, SubjectResolutionBatch{Watermark: " inventory:42 ", Cutoff: cutoff, Resolutions: resolutions})
+	if err != nil {
+		t.Fatalf("BuildSubjectManifest() error = %v", err)
+	}
+	reverse(selectors)
+	reverse(resolutions)
+	second, err := BuildSubjectManifest(selectors, SubjectResolutionBatch{Watermark: "inventory:42", Cutoff: cutoff, Resolutions: resolutions})
+	if err != nil {
+		t.Fatalf("BuildSubjectManifest() shuffled error = %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("manifest is not deterministic:\nfirst = %#v\nsecond = %#v", first, second)
+	}
+	if got, want := first.Subjects, []compliance.SubjectRef{{Type: "asset", ID: "one"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Subjects = %#v, want %#v", got, want)
+	}
+	if got, want := first.ZeroMatchSelectorIDs, []string{"vendor-zero"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ZeroMatchSelectorIDs = %#v, want %#v", got, want)
+	}
+	if got, want := first.UnresolvedSelectorIDs, []string{"people-unresolved"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("UnresolvedSelectorIDs = %#v, want %#v", got, want)
+	}
+	if err := compliance.ValidateContentDigest(first.ContentDigest); err != nil {
+		t.Fatalf("manifest content digest is invalid: %v", err)
+	}
+}
+
+func TestServiceTenantLookupIsOpaque(t *testing.T) {
+	t.Parallel()
+	store := newMemoryProgramStore()
+	service := testService(store, staticResolver{})
+	created, err := service.CreateProgram(context.Background(), CreateProgramRequest{
+		TenantID: "tenant-one", Name: "Payments", OwnerTeam: "security",
+	})
+	if err != nil {
+		t.Fatalf("CreateProgram() error = %v", err)
+	}
+	_, err = service.GetProgram(context.Background(), "tenant-two", created.ID)
+	if !errors.Is(err, ports.ErrComplianceProgramNotFound) {
+		t.Fatalf("GetProgram() error = %v, want non-disclosing sentinel", err)
+	}
+}
+
+func TestScopeRevisionChainAndExpectedVersion(t *testing.T) {
+	t.Parallel()
+	store := newMemoryProgramStore()
+	cutoff := testTime()
+	resolver := staticResolver{batch: SubjectResolutionBatch{
+		Watermark: "inventory:9", Cutoff: cutoff,
+		Resolutions: []SelectorResolution{{SelectorID: "asset-include", State: SubjectResolutionResolved, Subjects: []compliance.SubjectRef{{Type: "asset", ID: "one"}}}},
+	}}
+	service := testService(store, resolver)
+	program, err := service.CreateProgram(context.Background(), CreateProgramRequest{TenantID: "tenant-one", Name: "Payments", OwnerTeam: "security"})
+	if err != nil {
+		t.Fatalf("CreateProgram() error = %v", err)
+	}
+	request := RecordScopeRevisionRequest{
+		TenantID: "tenant-one", ProgramID: program.ID, ExpectedProgramVersion: 1,
+		State: ScopeRevisionActive, ChangeSummary: "Establish payment scope", CreatedBy: "owner@example.com", Cutoff: cutoff,
+		Specification: testScopeSpecification(),
+	}
+	first, err := service.RecordScopeRevision(context.Background(), request)
+	if err != nil {
+		t.Fatalf("RecordScopeRevision() error = %v", err)
+	}
+	if first.Revision.Version.Version != 1 || first.Revision.Version.PredecessorID != "" || first.Program.AggregateVersion != 2 {
+		t.Fatalf("first revision metadata = %#v, program version = %d", first.Revision.Version, first.Program.AggregateVersion)
+	}
+	request.Specification.Parameters = append(request.Specification.Parameters, ScopeParameter{Name: "tier", Value: "critical", Rationale: "Material payment systems"})
+	if _, err := service.RecordScopeRevision(context.Background(), request); !errors.Is(err, ports.ErrComplianceProgramVersionConflict) {
+		t.Fatalf("stale RecordScopeRevision() error = %v, want version conflict", err)
+	}
+	request.ExpectedProgramVersion = 2
+	request.ChangeSummary = "Set materiality tier"
+	second, err := service.RecordScopeRevision(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second RecordScopeRevision() error = %v", err)
+	}
+	if second.Revision.Version.Version != 2 || second.Revision.Version.PredecessorID != first.Revision.Version.RevisionID || second.Program.AggregateVersion != 3 {
+		t.Fatalf("second revision metadata = %#v, program version = %d", second.Revision.Version, second.Program.AggregateVersion)
+	}
+	if second.Revision.Version.ContentDigest == first.Revision.Version.ContentDigest {
+		t.Fatal("semantic content change did not change revision digest")
+	}
+	request.ExpectedProgramVersion = 3
+	request.ChangeSummary = "Duplicate content"
+	if _, err := service.RecordScopeRevision(context.Background(), request); !errors.Is(err, ports.ErrProgramRevisionConflict) {
+		t.Fatalf("duplicate RecordScopeRevision() error = %v, want revision conflict", err)
+	}
+	second.Revision.Specification.Parameters[0].Value = "mutated"
+	stored, err := store.GetProgramScopeRevision(context.Background(), "tenant-one", program.ID, second.Revision.Version.RevisionID)
+	if err != nil {
+		t.Fatalf("GetProgramScopeRevision() error = %v", err)
+	}
+	if stored.Specification.Parameters[0].Value == "mutated" {
+		t.Fatal("stored immutable revision was mutated through returned value")
+	}
+}
+
+func TestImplementationRevisionPreservesMappingRelationships(t *testing.T) {
+	t.Parallel()
+	store := newMemoryProgramStore()
+	cutoff := testTime()
+	service := testService(store, staticResolver{batch: SubjectResolutionBatch{
+		Watermark: "inventory:10", Cutoff: cutoff,
+		Resolutions: []SelectorResolution{{SelectorID: "asset-include", State: SubjectResolutionResolved, Subjects: []compliance.SubjectRef{{Type: "asset", ID: "one"}}}},
+	}})
+	program, err := service.CreateProgram(context.Background(), CreateProgramRequest{TenantID: "tenant-one", Name: "Payments", OwnerTeam: "security"})
+	if err != nil {
+		t.Fatalf("CreateProgram() error = %v", err)
+	}
+	scope, err := service.RecordScopeRevision(context.Background(), RecordScopeRevisionRequest{
+		TenantID: "tenant-one", ProgramID: program.ID, ExpectedProgramVersion: 1,
+		State: ScopeRevisionActive, ChangeSummary: "Establish scope", CreatedBy: "owner@example.com", Cutoff: cutoff,
+		Specification: testScopeSpecification(),
+	})
+	if err != nil {
+		t.Fatalf("RecordScopeRevision() error = %v", err)
+	}
+	relationships := []compliance.MappingRelationship{
+		compliance.MappingNone, compliance.MappingOverlap, compliance.MappingSuperset, compliance.MappingEquivalent, compliance.MappingSubset,
+	}
+	mappings := make([]ControlMappingRef, 0, len(relationships))
+	for index, relationship := range relationships {
+		mappings = append(mappings, testMappingRef(index+1, relationship))
+	}
+	upstream := compliance.SubjectRef{Type: "control_implementation", ID: "implementation-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	request := RecordImplementationRevisionRequest{
+		TenantID: "tenant-one", ProgramID: program.ID, ExpectedProgramVersion: scope.Program.AggregateVersion,
+		ChangeSummary: "Record inherited control", CreatedBy: "owner@example.com",
+		Specification: ControlImplementationSpecification{
+			ScopeRevisionID: scope.Revision.Version.RevisionID,
+			ControlRef:      compliance.ControlRef{FrameworkID: "framework-one", ControlID: "AC-1"},
+			Status:          ImplementationImplemented, Narrative: "Identity policy is enforced by the platform.", OwnerTeam: "identity",
+			ReviewPolicy:     ImplementationReviewPolicy{Cadence: "P30D", EffectiveFrom: cutoff},
+			ResponsibleRoles: []string{"operator"}, AccountableRoles: []string{"service-owner"},
+			Responsibility: ResponsibilityInherited, UpstreamImplementation: &upstream, MappingRefs: mappings,
+			SubjectRefs: []compliance.SubjectRef{{Type: "system", ID: "identity-platform"}},
+		},
+	}
+	first, err := service.RecordImplementationRevision(context.Background(), request)
+	if err != nil {
+		t.Fatalf("RecordImplementationRevision() error = %v", err)
+	}
+	gotRelationships := make([]compliance.MappingRelationship, 0, len(first.Revision.Specification.MappingRefs))
+	for _, mapping := range first.Revision.Specification.MappingRefs {
+		gotRelationships = append(gotRelationships, mapping.Relationship)
+	}
+	wantRelationships := relationships
+	if !reflect.DeepEqual(gotRelationships, wantRelationships) {
+		t.Fatalf("mapping relationships = %v, want %v", gotRelationships, wantRelationships)
+	}
+	if _, err := service.GetImplementation(context.Background(), "tenant-two", program.ID, first.Implementation.ID); !errors.Is(err, ports.ErrControlImplementationNotFound) {
+		t.Fatalf("foreign tenant implementation lookup error = %v, want opaque not found", err)
+	}
+	if _, err := service.GetImplementationRevision(context.Background(), "tenant-two", program.ID, first.Implementation.ID, first.Revision.Version.RevisionID); !errors.Is(err, ports.ErrControlImplementationNotFound) {
+		t.Fatalf("foreign tenant revision lookup error = %v, want opaque not found", err)
+	}
+	request.ImplementationID = first.Implementation.ID
+	request.ExpectedProgramVersion = first.Program.AggregateVersion
+	request.ExpectedImplementationVersion = 0
+	request.Specification.Narrative = "Identity policy is enforced and reviewed monthly."
+	if _, err := service.RecordImplementationRevision(context.Background(), request); !errors.Is(err, ports.ErrComplianceProgramVersionConflict) {
+		t.Fatalf("stale implementation update error = %v, want version conflict", err)
+	}
+	request.ExpectedImplementationVersion = 1
+	second, err := service.RecordImplementationRevision(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second RecordImplementationRevision() error = %v", err)
+	}
+	if second.Revision.Version.Version != 2 || second.Revision.Version.PredecessorID != first.Revision.Version.RevisionID {
+		t.Fatalf("second implementation revision metadata = %#v", second.Revision.Version)
+	}
+	request.ExpectedProgramVersion = second.Program.AggregateVersion
+	request.ExpectedImplementationVersion = second.Implementation.AggregateVersion
+	request.Specification.Responsibility = ResponsibilityInherited
+	request.Specification.UpstreamImplementation = nil
+	if _, err := service.RecordImplementationRevision(context.Background(), request); !errors.Is(err, ErrInvalidProgramRequest) {
+		t.Fatalf("inherited implementation without upstream error = %v, want invalid request", err)
+	}
+}
+
+func TestResponsibilityModesRemainDistinctInRevisionContent(t *testing.T) {
+	t.Parallel()
+	modes := []string{
+		ResponsibilityDirect, ResponsibilityProvided, ResponsibilityCustomerResponsibility,
+		ResponsibilityShared, ResponsibilityInherited,
+	}
+	digests := map[compliance.ContentDigest]string{}
+	for _, mode := range modes {
+		specification := ControlImplementationSpecification{
+			ScopeRevisionID: "scope-revision-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			ControlRef:      compliance.ControlRef{FrameworkID: "framework-one", ControlID: "AC-1"},
+			Status:          ImplementationPlanned, Narrative: "Document the implementation boundary.", OwnerTeam: "security",
+			ReviewPolicy:     ImplementationReviewPolicy{Cadence: "P90D", EffectiveFrom: testTime()},
+			ResponsibleRoles: []string{"operator"}, AccountableRoles: []string{"owner"}, Responsibility: mode,
+		}
+		if mode == ResponsibilityShared || mode == ResponsibilityInherited {
+			specification.UpstreamImplementation = &compliance.SubjectRef{Type: "control_implementation", ID: "implementation-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+		}
+		specification = normalizeImplementationSpecification(specification)
+		if err := validateImplementationSpecification(specification); err != nil {
+			t.Fatalf("validateImplementationSpecification(%q) error = %v", mode, err)
+		}
+		digest, err := semanticDigest(specification)
+		if err != nil {
+			t.Fatalf("semanticDigest(%q) error = %v", mode, err)
+		}
+		if previous, exists := digests[digest]; exists {
+			t.Fatalf("responsibility modes %q and %q share a digest", previous, mode)
+		}
+		digests[digest] = mode
+	}
+}
+
+type staticResolver struct {
+	batch SubjectResolutionBatch
+	err   error
+}
+
+func (resolver staticResolver) ResolveProgramSubjects(context.Context, SubjectResolutionRequest) (SubjectResolutionBatch, error) {
+	return cloneValue(resolver.batch), resolver.err
+}
+
+type memoryProgramStore struct {
+	mu              sync.Mutex
+	programs        map[string]ComplianceProgramRecord
+	scopeRevisions  map[string]ProgramScopeRevisionRecord
+	implementations map[string]ControlImplementationRecord
+	implRevisions   map[string]ControlImplementationRevisionRecord
+}
+
+func newMemoryProgramStore() *memoryProgramStore {
+	return &memoryProgramStore{
+		programs: map[string]ComplianceProgramRecord{}, scopeRevisions: map[string]ProgramScopeRevisionRecord{},
+		implementations: map[string]ControlImplementationRecord{}, implRevisions: map[string]ControlImplementationRevisionRecord{},
+	}
+}
+
+func (store *memoryProgramStore) Ping(context.Context) error { return nil }
+
+func (store *memoryProgramStore) CreateComplianceProgram(_ context.Context, record ComplianceProgramRecord) (*ComplianceProgramRecord, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	key := storeKey(record.TenantID, record.ID)
+	if _, exists := store.programs[key]; exists {
+		return nil, ports.ErrComplianceProgramVersionConflict
+	}
+	store.programs[key] = cloneValue(record)
+	result := cloneValue(record)
+	return &result, nil
+}
+
+func (store *memoryProgramStore) GetComplianceProgram(_ context.Context, tenantID string, programID string) (*ComplianceProgramRecord, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	record, exists := store.programs[storeKey(tenantID, programID)]
+	if !exists {
+		return nil, ports.ErrComplianceProgramNotFound
+	}
+	result := cloneValue(record)
+	return &result, nil
+}
+
+func (store *memoryProgramStore) GetProgramScopeRevision(_ context.Context, tenantID string, programID string, revisionID string) (*ProgramScopeRevisionRecord, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	record, exists := store.scopeRevisions[storeKey(tenantID, programID, revisionID)]
+	if !exists {
+		return nil, ports.ErrProgramRevisionConflict
+	}
+	result := cloneValue(record)
+	return &result, nil
+}
+
+func (store *memoryProgramStore) AppendProgramScopeRevision(_ context.Context, request AppendProgramScopeRevisionRequest) (*ComplianceProgramRecord, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	programKey := storeKey(request.TenantID, request.ProgramID)
+	program, exists := store.programs[programKey]
+	if !exists {
+		return nil, ports.ErrComplianceProgramNotFound
+	}
+	if program.AggregateVersion != request.ExpectedProgramVersion {
+		return nil, ports.ErrComplianceProgramVersionConflict
+	}
+	revisionKey := storeKey(request.TenantID, request.ProgramID, request.Revision.Version.RevisionID)
+	if _, exists := store.scopeRevisions[revisionKey]; exists {
+		return nil, ports.ErrProgramRevisionConflict
+	}
+	store.scopeRevisions[revisionKey] = cloneValue(request.Revision)
+	program.ScopeID = request.Revision.Version.ID
+	program.CurrentScopeRevisionID = request.Revision.Version.RevisionID
+	program.AggregateVersion++
+	program.UpdatedAt = request.Revision.Version.LastModified
+	store.programs[programKey] = program
+	result := cloneValue(program)
+	return &result, nil
+}
+
+func (store *memoryProgramStore) GetControlImplementation(_ context.Context, tenantID string, programID string, implementationID string) (*ControlImplementationRecord, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	record, exists := store.implementations[storeKey(tenantID, programID, implementationID)]
+	if !exists {
+		return nil, ports.ErrControlImplementationNotFound
+	}
+	result := cloneValue(record)
+	return &result, nil
+}
+
+func (store *memoryProgramStore) GetControlImplementationRevision(_ context.Context, tenantID string, programID string, implementationID string, revisionID string) (*ControlImplementationRevisionRecord, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	record, exists := store.implRevisions[storeKey(tenantID, programID, implementationID, revisionID)]
+	if !exists {
+		return nil, ports.ErrProgramRevisionConflict
+	}
+	result := cloneValue(record)
+	return &result, nil
+}
+
+func (store *memoryProgramStore) AppendControlImplementationRevision(_ context.Context, request AppendControlImplementationRevisionRequest) (*ComplianceProgramRecord, *ControlImplementationRecord, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	programKey := storeKey(request.TenantID, request.ProgramID)
+	program, exists := store.programs[programKey]
+	if !exists {
+		return nil, nil, ports.ErrComplianceProgramNotFound
+	}
+	if program.AggregateVersion != request.ExpectedProgramVersion {
+		return nil, nil, ports.ErrComplianceProgramVersionConflict
+	}
+	implementationKey := storeKey(request.TenantID, request.ProgramID, request.Implementation.ID)
+	current, exists := store.implementations[implementationKey]
+	if exists && current.AggregateVersion != request.ExpectedImplementationVersion {
+		return nil, nil, ports.ErrComplianceProgramVersionConflict
+	}
+	if !exists && request.ExpectedImplementationVersion != 0 {
+		return nil, nil, ports.ErrComplianceProgramVersionConflict
+	}
+	revisionKey := storeKey(request.TenantID, request.ProgramID, request.Implementation.ID, request.Revision.Version.RevisionID)
+	if _, exists := store.implRevisions[revisionKey]; exists {
+		return nil, nil, ports.ErrProgramRevisionConflict
+	}
+	implementation := cloneValue(request.Implementation)
+	implementation.AggregateVersion = request.ExpectedImplementationVersion + 1
+	store.implementations[implementationKey] = implementation
+	store.implRevisions[revisionKey] = cloneValue(request.Revision)
+	program.AggregateVersion++
+	program.UpdatedAt = request.Revision.Version.LastModified
+	store.programs[programKey] = program
+	programResult := cloneValue(program)
+	implementationResult := cloneValue(implementation)
+	return &programResult, &implementationResult, nil
+}
+
+func testService(store ComplianceProgramStore, resolver ProgramSubjectResolver) *Service {
+	service := NewService(store, resolver)
+	service.now = func() time.Time { return testTime() }
+	service.newID = func(kind compliance.IdentifierKind) (string, error) {
+		return string(kind) + "-" + strings.Repeat("a", 32), nil
+	}
+	var revisionCounter byte
+	service.newRevision = func(kind compliance.IdentifierKind) (string, error) {
+		revisionCounter++
+		return fmt.Sprintf("%s-revision-%032x", kind, revisionCounter), nil
+	}
+	return service
+}
+
+func testSelector(id string, kind string, mode string) ProgramScopeSelector {
+	return ProgramScopeSelector{
+		ID: id, Kind: kind, Mode: mode, Source: "inventory", Reason: "Program boundary", ApproverID: "owner@example.com",
+		EffectiveFrom: testTime(), Criteria: []ScopeSelectorCriterion{{Field: "id", Operator: "prefix", Value: "prod-"}},
+	}
+}
+
+func testScopeSpecification() ProgramScopeSpecification {
+	return ProgramScopeSpecification{
+		FrameworkRevisions: []compliance.RevisionRef{testRevisionRef("framework-one", "framework-revision-one")},
+		ProfileRevisions:   []compliance.RevisionRef{testRevisionRef("profile-one", "profile-revision-one")},
+		Selectors:          []ProgramScopeSelector{testSelector("asset-include", "asset", ScopeSelectorInclude)},
+		Parameters:         []ScopeParameter{{Name: "region", Value: "us", Rationale: "Contract boundary"}},
+	}
+}
+
+func testMappingRef(index int, relationship compliance.MappingRelationship) ControlMappingRef {
+	hex := fmt.Sprintf("%032x", index)
+	return ControlMappingRef{
+		ID: "control-mapping-" + hex, RevisionID: "control-mapping-revision-" + hex,
+		Relationship: relationship, Granularity: "control",
+		Source: testRevisionRef(fmt.Sprintf("source-%d", index), fmt.Sprintf("source-revision-%d", index)),
+		Target: testRevisionRef(fmt.Sprintf("target-%d", index), fmt.Sprintf("target-revision-%d", index)),
+		Method: "manual_review", Rationale: "Reviewed control intent and evidence expectations.",
+		CoverageBasisPoints: testMappingCoverage(relationship), Gaps: []string{"Residual operating test"},
+		Provenance:    []compliance.SubjectRef{{Type: "mapping_review", ID: fmt.Sprintf("review-%d", index)}},
+		DecisionState: compliance.MappingApproved, AuthorID: "mapper@example.com", ReviewerID: "reviewer@example.com",
+	}
+}
+
+func testMappingCoverage(relationship compliance.MappingRelationship) uint16 {
+	switch relationship {
+	case compliance.MappingEquivalent:
+		return 10000
+	case compliance.MappingNone:
+		return 0
+	default:
+		return 5000
+	}
+}
+
+func testRevisionRef(id string, revisionID string) compliance.RevisionRef {
+	return compliance.RevisionRef{
+		ID: id, RevisionID: revisionID, Version: 1,
+		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("1", 64)), LastModified: testTime(),
+	}
+}
+
+func testTime() time.Time {
+	return time.Date(2026, time.July, 11, 20, 0, 0, 0, time.UTC)
+}
+
+func storeKey(parts ...string) string { return strings.Join(parts, "\x00") }
+
+func cloneValue[T any](value T) T {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	var result T
+	if err := json.Unmarshal(payload, &result); err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func reverse[T any](values []T) {
+	for left, right := 0, len(values)-1; left < right; left, right = left+1, right-1 {
+		values[left], values[right] = values[right], values[left]
+	}
+}

--- a/internal/grcprogram/programs.go
+++ b/internal/grcprogram/programs.go
@@ -1,0 +1,150 @@
+package grcprogram
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var (
+	ErrInvalidProgramRequest = errors.New("invalid compliance program request")
+	ErrProgramUnavailable    = errors.New("compliance program runtime unavailable")
+)
+
+type identifierFactory func(compliance.IdentifierKind) (string, error)
+
+// Service owns program, scope, and control-implementation revision semantics.
+// Persistence implementations enforce the same expected-version conditions
+// atomically when appending a revision.
+type Service struct {
+	store       ComplianceProgramStore
+	resolver    ProgramSubjectResolver
+	now         func() time.Time
+	newID       identifierFactory
+	newRevision identifierFactory
+}
+
+type CreateProgramRequest struct {
+	TenantID  string
+	ID        string
+	Name      string
+	OwnerTeam string
+	RiskOwner string
+	Status    string
+}
+
+func NewService(store ComplianceProgramStore, resolver ProgramSubjectResolver) *Service {
+	return &Service{
+		store:       store,
+		resolver:    resolver,
+		now:         func() time.Time { return time.Now().UTC() },
+		newID:       compliance.NewIdentifier,
+		newRevision: compliance.NewRevisionIdentifier,
+	}
+}
+
+func (service *Service) CreateProgram(ctx context.Context, request CreateProgramRequest) (*ComplianceProgramRecord, error) {
+	if service == nil || service.store == nil {
+		return nil, ErrProgramUnavailable
+	}
+	request = normalizeCreateProgramRequest(request)
+	if err := validateCreateProgramRequest(request); err != nil {
+		return nil, err
+	}
+	id := request.ID
+	if id == "" {
+		var err error
+		id, err = service.newID(compliance.IdentifierProgram)
+		if err != nil {
+			return nil, fmt.Errorf("create program identifier: %w", err)
+		}
+	}
+	if err := compliance.ValidateIdentifier(compliance.IdentifierProgram, id); err != nil {
+		return nil, fmt.Errorf("%w: program id: %w", ErrInvalidProgramRequest, err)
+	}
+	now := compliance.CanonicalRevisionTime(service.now())
+	record, err := service.store.CreateComplianceProgram(ctx, ComplianceProgramRecord{
+		TenantID: request.TenantID, ID: id, Name: request.Name, OwnerTeam: request.OwnerTeam,
+		RiskOwner: request.RiskOwner, Status: request.Status, AggregateVersion: 1,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		return nil, programStoreError(err)
+	}
+	return record, nil
+}
+
+// GetProgram uses the tenant-scoped store lookup directly. A foreign tenant and
+// an unknown identifier therefore return the same non-disclosing sentinel.
+func (service *Service) GetProgram(ctx context.Context, tenantID string, programID string) (*ComplianceProgramRecord, error) {
+	if service == nil || service.store == nil {
+		return nil, ErrProgramUnavailable
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	programID = strings.TrimSpace(programID)
+	if tenantID == "" || programID == "" {
+		return nil, ports.ErrComplianceProgramNotFound
+	}
+	record, err := service.store.GetComplianceProgram(ctx, tenantID, programID)
+	if err != nil {
+		return nil, programStoreError(err)
+	}
+	if record == nil || record.TenantID != tenantID {
+		return nil, ports.ErrComplianceProgramNotFound
+	}
+	return record, nil
+}
+
+func normalizeCreateProgramRequest(request CreateProgramRequest) CreateProgramRequest {
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.ID = strings.TrimSpace(request.ID)
+	request.Name = strings.TrimSpace(request.Name)
+	request.OwnerTeam = strings.TrimSpace(request.OwnerTeam)
+	request.RiskOwner = strings.TrimSpace(request.RiskOwner)
+	request.Status = strings.TrimSpace(request.Status)
+	if request.Status == "" {
+		request.Status = ComplianceProgramDraft
+	}
+	return request
+}
+
+func validateCreateProgramRequest(request CreateProgramRequest) error {
+	if request.TenantID == "" || request.Name == "" || request.OwnerTeam == "" {
+		return fmt.Errorf("%w: tenant_id, name, and owner_team are required", ErrInvalidProgramRequest)
+	}
+	if !knownProgramStatus(request.Status) {
+		return fmt.Errorf("%w: unknown program status %q", ErrInvalidProgramRequest, request.Status)
+	}
+	return nil
+}
+
+func knownProgramStatus(value string) bool {
+	switch value {
+	case ComplianceProgramDraft, ComplianceProgramActive, ComplianceProgramSuspended, ComplianceProgramRetired:
+		return true
+	default:
+		return false
+	}
+}
+
+func programStoreError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ports.ErrComplianceProgramNotFound):
+		return ports.ErrComplianceProgramNotFound
+	case errors.Is(err, ports.ErrControlImplementationNotFound):
+		return ports.ErrControlImplementationNotFound
+	case errors.Is(err, ports.ErrComplianceProgramVersionConflict):
+		return ports.ErrComplianceProgramVersionConflict
+	case errors.Is(err, ports.ErrProgramRevisionConflict):
+		return ports.ErrProgramRevisionConflict
+	default:
+		return err
+	}
+}

--- a/internal/grcprogram/scope.go
+++ b/internal/grcprogram/scope.go
@@ -1,0 +1,386 @@
+package grcprogram
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type RecordScopeRevisionRequest struct {
+	TenantID               string
+	ProgramID              string
+	ExpectedProgramVersion uint64
+	State                  string
+	ChangeSummary          string
+	CreatedBy              string
+	Cutoff                 time.Time
+	Specification          ProgramScopeSpecification
+}
+
+type RecordScopeRevisionResult struct {
+	Program  *ComplianceProgramRecord
+	Revision *ProgramScopeRevisionRecord
+}
+
+func (service *Service) RecordScopeRevision(ctx context.Context, request RecordScopeRevisionRequest) (*RecordScopeRevisionResult, error) {
+	if service == nil || service.store == nil || service.resolver == nil {
+		return nil, ErrProgramUnavailable
+	}
+	request = normalizeScopeRevisionRequest(request)
+	if err := validateScopeRevisionRequest(request); err != nil {
+		return nil, err
+	}
+	program, err := service.GetProgram(ctx, request.TenantID, request.ProgramID)
+	if err != nil {
+		return nil, err
+	}
+	if request.ExpectedProgramVersion != program.AggregateVersion {
+		return nil, ports.ErrComplianceProgramVersionConflict
+	}
+
+	var previous *ProgramScopeRevisionRecord
+	if program.CurrentScopeRevisionID != "" {
+		previous, err = service.store.GetProgramScopeRevision(ctx, request.TenantID, request.ProgramID, program.CurrentScopeRevisionID)
+		if err != nil {
+			return nil, programStoreError(err)
+		}
+	}
+	batch, err := service.resolver.ResolveProgramSubjects(ctx, SubjectResolutionRequest{
+		TenantID: request.TenantID, Selectors: request.Specification.Selectors, Cutoff: request.Cutoff,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolve program subjects: %w", err)
+	}
+	if !compliance.CanonicalRevisionTime(batch.Cutoff).Equal(request.Cutoff) {
+		return nil, fmt.Errorf("%w: subject resolution cutoff differs from the requested cutoff", ErrInvalidProgramRequest)
+	}
+	manifest, err := BuildSubjectManifest(request.Specification.Selectors, batch)
+	if err != nil {
+		return nil, err
+	}
+	request.Specification.SubjectManifest = manifest
+	request.Specification = normalizeScopeSpecification(request.Specification)
+	if err := validateScopeSpecification(request.Specification); err != nil {
+		return nil, err
+	}
+
+	scopeID := program.ScopeID
+	if scopeID == "" {
+		scopeID, err = service.newID(compliance.IdentifierScope)
+		if err != nil {
+			return nil, fmt.Errorf("create scope identifier: %w", err)
+		}
+	}
+	if err := compliance.ValidateIdentifier(compliance.IdentifierScope, scopeID); err != nil {
+		return nil, fmt.Errorf("%w: scope id: %w", ErrInvalidProgramRequest, err)
+	}
+	revisionID, err := service.newRevision(compliance.IdentifierScope)
+	if err != nil {
+		return nil, fmt.Errorf("create scope revision identifier: %w", err)
+	}
+	if err := compliance.ValidateRevisionIdentifier(compliance.IdentifierScope, revisionID); err != nil {
+		return nil, fmt.Errorf("%w: scope revision id: %w", ErrInvalidProgramRequest, err)
+	}
+	version := uint64(1)
+	predecessorID := ""
+	if previous != nil {
+		if previous.Version.ID != scopeID {
+			return nil, ports.ErrProgramRevisionConflict
+		}
+		if err := previous.Version.Validate(); err != nil {
+			return nil, ports.ErrProgramRevisionConflict
+		}
+		version = previous.Version.Version + 1
+		predecessorID = previous.Version.RevisionID
+	}
+	digest, err := semanticDigest(request.Specification)
+	if err != nil {
+		return nil, err
+	}
+	if previous != nil && previous.Version.ContentDigest == digest {
+		return nil, ports.ErrProgramRevisionConflict
+	}
+	now := compliance.CanonicalRevisionTime(service.now())
+	revision := ProgramScopeRevisionRecord{
+		TenantID: request.TenantID, ProgramID: request.ProgramID, State: request.State,
+		Version: compliance.VersionMetadata{
+			ID: scopeID, RevisionID: revisionID, Version: version, LastModified: now,
+			ContentDigest: digest, CreatedBy: request.CreatedBy, PredecessorID: predecessorID,
+		},
+		ChangeSummary: request.ChangeSummary, Specification: request.Specification,
+	}
+	updated, err := service.store.AppendProgramScopeRevision(ctx, AppendProgramScopeRevisionRequest{
+		TenantID: request.TenantID, ProgramID: request.ProgramID,
+		ExpectedProgramVersion: request.ExpectedProgramVersion, Revision: revision,
+	})
+	if err != nil {
+		return nil, programStoreError(err)
+	}
+	return &RecordScopeRevisionResult{Program: updated, Revision: &revision}, nil
+}
+
+// BuildSubjectManifest converts per-selector resolution facts into one stable
+// included-subject set while retaining zero-match and unresolved selectors as
+// separate, reviewable outcomes.
+func BuildSubjectManifest(selectors []ProgramScopeSelector, batch SubjectResolutionBatch) (ProgramSubjectManifest, error) {
+	selectors = normalizeSelectors(selectors)
+	if err := validateSelectors(selectors); err != nil {
+		return ProgramSubjectManifest{}, err
+	}
+	batch.Cutoff = compliance.CanonicalRevisionTime(batch.Cutoff)
+	batch.Watermark = strings.TrimSpace(batch.Watermark)
+	if batch.Cutoff.IsZero() || batch.Watermark == "" {
+		return ProgramSubjectManifest{}, fmt.Errorf("%w: subject resolution cutoff and watermark are required", ErrInvalidProgramRequest)
+	}
+
+	selectorByID := make(map[string]ProgramScopeSelector, len(selectors))
+	for _, selector := range selectors {
+		selectorByID[selector.ID] = selector
+	}
+	resolutionByID := make(map[string]SelectorResolution, len(batch.Resolutions))
+	for _, resolution := range batch.Resolutions {
+		resolution = normalizeSelectorResolution(resolution)
+		if _, exists := selectorByID[resolution.SelectorID]; !exists {
+			return ProgramSubjectManifest{}, fmt.Errorf("%w: resolution references an unknown selector", ErrInvalidProgramRequest)
+		}
+		if _, exists := resolutionByID[resolution.SelectorID]; exists {
+			return ProgramSubjectManifest{}, fmt.Errorf("%w: duplicate selector resolution", ErrInvalidProgramRequest)
+		}
+		if err := validateSelectorResolution(resolution); err != nil {
+			return ProgramSubjectManifest{}, err
+		}
+		resolutionByID[resolution.SelectorID] = resolution
+	}
+
+	included := map[string]compliance.SubjectRef{}
+	excluded := map[string]struct{}{}
+	manifest := ProgramSubjectManifest{Watermark: batch.Watermark, Cutoff: batch.Cutoff}
+	for _, selector := range selectors {
+		resolution, exists := resolutionByID[selector.ID]
+		if !exists {
+			return ProgramSubjectManifest{}, fmt.Errorf("%w: selector resolution is missing", ErrInvalidProgramRequest)
+		}
+		manifest.SelectorResolutions = append(manifest.SelectorResolutions, resolution)
+		if resolution.State == SubjectResolutionUnresolved {
+			manifest.UnresolvedSelectorIDs = append(manifest.UnresolvedSelectorIDs, selector.ID)
+			continue
+		}
+		if len(resolution.Subjects) == 0 {
+			manifest.ZeroMatchSelectorIDs = append(manifest.ZeroMatchSelectorIDs, selector.ID)
+		}
+		for _, subject := range resolution.Subjects {
+			key := subjectKey(subject)
+			if selector.Mode == ScopeSelectorExclude {
+				excluded[key] = struct{}{}
+				continue
+			}
+			included[key] = subject
+		}
+	}
+	for key, subject := range included {
+		if _, removed := excluded[key]; removed {
+			continue
+		}
+		manifest.Subjects = append(manifest.Subjects, subject)
+	}
+	manifest.Subjects = normalizeSubjectRefs(manifest.Subjects)
+	manifest.ZeroMatchSelectorIDs = normalizedStrings(manifest.ZeroMatchSelectorIDs)
+	manifest.UnresolvedSelectorIDs = normalizedStrings(manifest.UnresolvedSelectorIDs)
+	sort.Slice(manifest.SelectorResolutions, func(i, j int) bool {
+		return manifest.SelectorResolutions[i].SelectorID < manifest.SelectorResolutions[j].SelectorID
+	})
+	digestInput := manifest
+	digestInput.ContentDigest = ""
+	digest, err := semanticDigest(digestInput)
+	if err != nil {
+		return ProgramSubjectManifest{}, err
+	}
+	manifest.ContentDigest = digest
+	return manifest, nil
+}
+
+func normalizeScopeRevisionRequest(request RecordScopeRevisionRequest) RecordScopeRevisionRequest {
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.ProgramID = strings.TrimSpace(request.ProgramID)
+	request.State = strings.TrimSpace(request.State)
+	request.ChangeSummary = strings.TrimSpace(request.ChangeSummary)
+	request.CreatedBy = strings.TrimSpace(request.CreatedBy)
+	request.Cutoff = compliance.CanonicalRevisionTime(request.Cutoff)
+	if request.State == "" {
+		request.State = ScopeRevisionProposed
+	}
+	request.Specification = normalizeScopeSpecification(request.Specification)
+	return request
+}
+
+func validateScopeRevisionRequest(request RecordScopeRevisionRequest) error {
+	if request.TenantID == "" || request.ProgramID == "" || request.ExpectedProgramVersion == 0 || request.ChangeSummary == "" || request.CreatedBy == "" || request.Cutoff.IsZero() {
+		return fmt.Errorf("%w: tenant, program, expected version, change summary, actor, and cutoff are required", ErrInvalidProgramRequest)
+	}
+	if request.State != ScopeRevisionProposed && request.State != ScopeRevisionActive {
+		return fmt.Errorf("%w: unknown scope revision state %q", ErrInvalidProgramRequest, request.State)
+	}
+	return validateScopeSpecification(request.Specification)
+}
+
+func normalizeScopeSpecification(value ProgramScopeSpecification) ProgramScopeSpecification {
+	value.FrameworkRevisions = normalizeRevisionRefs(value.FrameworkRevisions)
+	value.ProfileRevisions = normalizeRevisionRefs(value.ProfileRevisions)
+	value.Selectors = normalizeSelectors(value.Selectors)
+	value.Parameters = normalizeParameters(value.Parameters)
+	value.EvidenceWindow = strings.TrimSpace(value.EvidenceWindow)
+	value.MonitoringCadence = strings.TrimSpace(value.MonitoringCadence)
+	value.SourceProofPolicy = strings.TrimSpace(value.SourceProofPolicy)
+	value.MaterialityLevel = strings.TrimSpace(value.MaterialityLevel)
+	return value
+}
+
+func validateScopeSpecification(value ProgramScopeSpecification) error {
+	if len(value.FrameworkRevisions) == 0 || len(value.ProfileRevisions) == 0 {
+		return fmt.Errorf("%w: framework and profile revisions are required", ErrInvalidProgramRequest)
+	}
+	for _, revision := range append(append([]compliance.RevisionRef(nil), value.FrameworkRevisions...), value.ProfileRevisions...) {
+		if err := revision.Validate(); err != nil {
+			return fmt.Errorf("%w: invalid framework or profile revision: %w", ErrInvalidProgramRequest, err)
+		}
+	}
+	if err := validateSelectors(value.Selectors); err != nil {
+		return err
+	}
+	for _, parameter := range value.Parameters {
+		if parameter.Name == "" || parameter.Value == "" || parameter.Rationale == "" {
+			return fmt.Errorf("%w: scope parameters require name, value, and rationale", ErrInvalidProgramRequest)
+		}
+	}
+	return nil
+}
+
+func normalizeSelectors(values []ProgramScopeSelector) []ProgramScopeSelector {
+	result := append([]ProgramScopeSelector(nil), values...)
+	for index := range result {
+		selector := &result[index]
+		selector.ID = strings.TrimSpace(selector.ID)
+		selector.Kind = strings.TrimSpace(selector.Kind)
+		selector.Mode = strings.TrimSpace(selector.Mode)
+		selector.Source = strings.TrimSpace(selector.Source)
+		selector.Reason = strings.TrimSpace(selector.Reason)
+		selector.ApproverID = strings.TrimSpace(selector.ApproverID)
+		selector.SupersedesSelectorID = strings.TrimSpace(selector.SupersedesSelectorID)
+		selector.EffectiveFrom = compliance.CanonicalRevisionTime(selector.EffectiveFrom)
+		selector.EffectiveUntil = compliance.CanonicalRevisionTime(selector.EffectiveUntil)
+		selector.ReviewAt = compliance.CanonicalRevisionTime(selector.ReviewAt)
+		selector.Criteria = append([]ScopeSelectorCriterion(nil), selector.Criteria...)
+		for criterionIndex := range selector.Criteria {
+			criterion := &selector.Criteria[criterionIndex]
+			criterion.Field = strings.TrimSpace(criterion.Field)
+			criterion.Operator = strings.TrimSpace(criterion.Operator)
+			criterion.Value = strings.TrimSpace(criterion.Value)
+		}
+		sort.Slice(selector.Criteria, func(i, j int) bool {
+			left, right := selector.Criteria[i], selector.Criteria[j]
+			return left.Field+"\x00"+left.Operator+"\x00"+left.Value < right.Field+"\x00"+right.Operator+"\x00"+right.Value
+		})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+func validateSelectors(values []ProgramScopeSelector) error {
+	if len(values) == 0 {
+		return fmt.Errorf("%w: at least one scope selector is required", ErrInvalidProgramRequest)
+	}
+	seen := map[string]struct{}{}
+	hasInclude := false
+	for _, selector := range values {
+		if selector.ID == "" || selector.Kind == "" || selector.Source == "" || selector.Reason == "" || selector.ApproverID == "" || selector.EffectiveFrom.IsZero() {
+			return fmt.Errorf("%w: selectors require id, kind, source, reason, approver, and effective_from", ErrInvalidProgramRequest)
+		}
+		if _, exists := seen[selector.ID]; exists {
+			return fmt.Errorf("%w: duplicate selector id", ErrInvalidProgramRequest)
+		}
+		seen[selector.ID] = struct{}{}
+		if selector.Mode != ScopeSelectorInclude && selector.Mode != ScopeSelectorExclude {
+			return fmt.Errorf("%w: selector mode is invalid", ErrInvalidProgramRequest)
+		}
+		if selector.Mode == ScopeSelectorInclude {
+			hasInclude = true
+		}
+		if !knownSelectorKind(selector.Kind) || len(selector.Criteria) == 0 {
+			return fmt.Errorf("%w: selector kind or criteria are invalid", ErrInvalidProgramRequest)
+		}
+		for _, criterion := range selector.Criteria {
+			if criterion.Field == "" || criterion.Value == "" || !knownSelectorOperator(criterion.Operator) {
+				return fmt.Errorf("%w: selector criterion is invalid", ErrInvalidProgramRequest)
+			}
+		}
+	}
+	if !hasInclude {
+		return fmt.Errorf("%w: at least one include selector is required", ErrInvalidProgramRequest)
+	}
+	return nil
+}
+
+func normalizeSelectorResolution(value SelectorResolution) SelectorResolution {
+	value.SelectorID = strings.TrimSpace(value.SelectorID)
+	value.State = strings.TrimSpace(value.State)
+	value.ReasonCode = strings.TrimSpace(value.ReasonCode)
+	value.Subjects = normalizeSubjectRefs(value.Subjects)
+	return value
+}
+
+func validateSelectorResolution(value SelectorResolution) error {
+	if value.SelectorID == "" {
+		return fmt.Errorf("%w: selector resolution id is required", ErrInvalidProgramRequest)
+	}
+	switch value.State {
+	case SubjectResolutionResolved:
+		if value.ReasonCode != "" {
+			return fmt.Errorf("%w: resolved selector cannot have an unresolved reason", ErrInvalidProgramRequest)
+		}
+	case SubjectResolutionUnresolved:
+		if !knownUnresolvedReason(value.ReasonCode) || len(value.Subjects) != 0 {
+			return fmt.Errorf("%w: unresolved selector requires a bounded reason and no subjects", ErrInvalidProgramRequest)
+		}
+	default:
+		return fmt.Errorf("%w: selector resolution state is invalid", ErrInvalidProgramRequest)
+	}
+	for _, subject := range value.Subjects {
+		if err := subject.Validate(); err != nil {
+			return fmt.Errorf("%w: invalid resolved subject: %w", ErrInvalidProgramRequest, err)
+		}
+	}
+	return nil
+}
+
+func knownSelectorKind(value string) bool {
+	switch value {
+	case "system", "product", "business_unit", "region", "account", "environment", "data", "data_class", "people", "asset", "application", "vendor":
+		return true
+	default:
+		return false
+	}
+}
+
+func knownSelectorOperator(value string) bool {
+	switch value {
+	case "equals", "in", "prefix":
+		return true
+	default:
+		return false
+	}
+}
+
+func knownUnresolvedReason(value string) bool {
+	switch value {
+	case SubjectUnresolvedUnsupported, SubjectUnresolvedSourceUnavailable,
+		SubjectUnresolvedInvalidSelector, SubjectUnresolvedWatermarkUnavailable:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/ports/compliance_programs.go
+++ b/internal/ports/compliance_programs.go
@@ -1,0 +1,10 @@
+package ports
+
+import "errors"
+
+var (
+	ErrComplianceProgramNotFound        = errors.New("compliance program not found")
+	ErrComplianceProgramVersionConflict = errors.New("compliance program version conflict")
+	ErrProgramRevisionConflict          = errors.New("compliance program revision conflict")
+	ErrControlImplementationNotFound    = errors.New("control implementation not found")
+)

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -28,6 +28,7 @@ const (
 	EventKindComplianceActivityRecorded            = "workflow.v1.compliance.assessment_activity_recorded"
 	EventKindCompliancePopulationRecorded          = "workflow.v1.compliance.assessment_population_recorded"
 	EventKindComplianceSampleRecorded              = "workflow.v1.compliance.assessment_sample_recorded"
+	EventKindComplianceSourceCheckRecorded         = "workflow.v1.compliance.assessment_source_check_recorded"
 	EventKindComplianceReviewRecorded              = "workflow.v1.compliance.assessment_review_recorded"
 	EventKindComplianceRiskDecisionRecorded        = "workflow.v1.compliance.risk_decision_recorded"
 	EventKindComplianceExceptionUpdated            = "workflow.v1.compliance.exception_updated"
@@ -124,6 +125,7 @@ func registeredComplianceKinds() []string {
 		EventKindComplianceResultChunkRecorded, EventKindComplianceAssessmentCompleted,
 		EventKindComplianceAssessmentCancelled, EventKindComplianceActivityRecorded,
 		EventKindCompliancePopulationRecorded, EventKindComplianceSampleRecorded,
+		EventKindComplianceSourceCheckRecorded,
 		EventKindComplianceReviewRecorded, EventKindComplianceRiskDecisionRecorded,
 		EventKindComplianceExceptionUpdated, EventKindComplianceWorkItemUpdated,
 		EventKindComplianceRemediationMilestoneUpdated, EventKindComplianceAuditEngagementRecorded,

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -93,7 +93,7 @@ func NewComplianceAggregateEvent(payload ComplianceAggregateRecorded) (*cerebrov
 		ContentDigest: payload.ContentDigest, PayloadJSON: payload.PayloadJSON,
 		ActorID: payload.ActorID, RecordedAt: payload.RecordedAt,
 	}
-	primaryID := payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
+	primaryID := payload.AggregateType + "|" + payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
 	return newEvent(contract, SchemaComplianceAggregate, payload.TenantID, "compliance", primaryID, payload.RecordedAt, map[string]string{
 		EventAttributeWorkflowKind: "compliance_aggregate",
 		"aggregate_type":           payload.AggregateType,

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -65,6 +65,27 @@ func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
 	}
 }
 
+func TestComplianceAggregateIdentityIncludesAggregateType(t *testing.T) {
+	t.Parallel()
+	base := ComplianceAggregateRecorded{
+		Kind: EventKindComplianceSourceCheckRecorded, TenantID: "tenant-a",
+		AggregateType: "source_check", AggregateID: "shared-id", AggregateVersion: 1,
+		Operation: "recorded", RecordedAt: "2026-07-11T08:00:00Z",
+	}
+	first, err := NewComplianceAggregateEvent(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.AggregateType = "objective_source_assessment"
+	second, err := NewComplianceAggregateEvent(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.GetId() == second.GetId() {
+		t.Fatalf("aggregate types produced the same event id %q", first.GetId())
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -54,6 +54,17 @@ func TestComplianceExchangeRequestAndCommitRemainDistinctFacts(t *testing.T) {
 	}
 }
 
+func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
+	t.Parallel()
+	if EventKindComplianceSourceCheckRecorded == EventKindComplianceActivityRecorded ||
+		EventKindComplianceSourceCheckRecorded == EventKindComplianceInputManifestRecorded {
+		t.Fatal("source check event overloads an activity or input-manifest fact")
+	}
+	if !KindRegistered(EventKindComplianceSourceCheckRecorded) {
+		t.Fatal("source check event kind is not registered")
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{


### PR DESCRIPTION
## Summary

- add tenant-scoped compliance program shells with immutable scope and implementation revisions
- add deterministic subject manifests that distinguish zero matches from unresolved selectors
- add optimistic concurrency, predecessor lineage, content hashes, and change summaries
- preserve direct, shared, inherited, provider, and customer responsibility modes
- persist full structured mapping snapshots rather than treating every relationship as equivalence
- normalize foreign-tenant implementation and revision reads to opaque not-found results

## Dependency

This program-domain core is stacked on canonical compliance semantics.

## Exit criteria

- the same scope revision and source watermark always produce the same subject manifest
- zero matches and unresolved selectors remain distinct states
- semantic changes require a new immutable revision and expected-version match
- responsibility modes and mapping relationships round-trip without flattening
- foreign tenants cannot infer whether a program, implementation, or revision exists

## Validation

- focused program tests and race tests
- Go vet and diff-scoped lint
- architecture and structural checks