### PR TITLE
Persist evidence ledger projections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Build stage - use buildx cross-compilation (no QEMU needed)
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
 ARG TARGETOS

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ GO_TEST_SHARD_WEIGHTS ?= scripts/go_package_test_weights.json
 GO_TEST_SHARD_DEFAULT_WEIGHT ?= 1
 GO_RACE_SHARD_WEIGHTS ?= scripts/go_package_race_weights.json
 GO_RACE_SHARD_DEFAULT_WEIGHT ?= 5
-BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
-GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
+BUF := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
+GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
-GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/goreleaser/goreleaser/v2@v2.16.0
+GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run github.com/goreleaser/goreleaser/v2@v2.16.0
 PROTO_BREAKING_BASE ?= origin/main
 README_CHECK_BASE ?= origin/main
 DOCKER_SMOKE_IMAGE ?= cerebro-runtime-smoke:local
@@ -341,7 +341,7 @@ lint-sources: lint-bootstrap ## Run golangci-lint over source packages.
 	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_SOURCE_PACKAGES)
 
 lint-bootstrap: ## Install golangci-lint if missing.
-	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
+	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.5 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
 
 proto-lint: ## Lint protobuf definitions.
 	$(BUF) lint

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The site entry point is [docs/index.md](docs/index.md), and `mkdocs.yml` defines
 
 | Component | Technology |
 | --- | --- |
-| Language | Go 1.26+ with `go1.26.4` toolchain |
+| Language | Go 1.26+ with `go1.26.5` toolchain |
 | HTTP server | Go `net/http` `ServeMux` |
 | RPC | Connect |
 | CLI | Standard Go CLI under `cmd/cerebro` |

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -127,6 +127,10 @@ func serve() error {
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	if _, err := app.RecoverPlatformJobs(ctx); err != nil {
+		return fmt.Errorf("recover platform jobs: %w", err)
+	}
+	jobRecoveryDone := app.StartPlatformJobRecovery(ctx, log.Printf)
 	grcWarmupDone := startGRCReadModelWarmup(ctx, deps.StateStore, log.Printf)
 	riskBackfillDone := startFindingRiskBackfill(ctx, app, log.Printf)
 	reportSchedulerDone := app.StartReportScheduler(ctx, log.Printf)
@@ -151,7 +155,7 @@ func serve() error {
 		if err := <-errCh; err != nil {
 			return fmt.Errorf("serve: %w", err)
 		}
-		waitForStartupJobs(shutdownCtx, grcWarmupDone, riskBackfillDone, reportSchedulerDone)
+		waitForStartupJobs(shutdownCtx, jobRecoveryDone, grcWarmupDone, riskBackfillDone, reportSchedulerDone)
 		return nil
 	}
 }

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -4,7 +4,7 @@ This document describes the current bootstrap service on `main`. Historical ware
 
 ## Prerequisites
 
-- Go 1.26+; the repository pins `go1.26.4` in `go.mod`.
+- Go 1.26+; the repository pins `go1.26.5` in `go.mod`.
 - Docker and Docker Compose for the durable local stack.
 - Make.
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/writer/cerebro
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 replace github.com/WriterInternal/event-registry/clients/go => ./internal/eventregistry
 

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -871,6 +871,9 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		jetstreamTelemetryError(ctx, span, "replay", err, streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, 0, 0, 0, 0, 0, 0, ctx)))
 		return nil, err
 	}
+	if request.Cursor != "" {
+		useSubjectIndex = false
+	}
 	if stream.State.LastSeq == 0 || stream.State.LastSeq < stream.State.FirstSeq {
 		recordJetStreamReplayMetrics(ctx, replayScanStats{strategy: replayStrategyEmptyStream, subjectFilterCount: len(subjectFilters)}, "completed", "", time.Since(started), 0)
 		endAttrs := streamAttrs.With(jetstreamReplayScanAttrs(limit, candidateLimit, 0, 0, 0, 0, 0, 0, ctx)).
@@ -949,6 +952,27 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	return events, nil
 }
 
+// ReplayPage returns one bounded page and an opaque cursor for older matches.
+// The page limit remains capped; callers can traverse more than the cap by
+// passing NextCursor into the next request.
+func (l *Log) ReplayPage(ctx context.Context, request ports.ReplayRequest) (ports.ReplayPage, error) {
+	request = normalizeReplayRequest(request)
+	limit := normalizeReplayLimit(request.Limit)
+	request.Limit = limit
+	events, err := l.Replay(ctx, request)
+	if err != nil {
+		return ports.ReplayPage{}, err
+	}
+	page := ports.ReplayPage{Events: events, Complete: len(events) < int(limit)}
+	if !page.Complete && len(events) > 0 {
+		page.NextCursor = strings.TrimSpace(events[0].GetId())
+		if page.NextCursor == "" {
+			return ports.ReplayPage{}, errors.New("replay page oldest event id is required")
+		}
+	}
+	return page, nil
+}
+
 type replayScanStats struct {
 	scanned            uint64
 	missing            uint64
@@ -972,6 +996,7 @@ func (s replayScanStats) attrs(limit uint32, candidateLimit uint32, ctx context.
 func replayLegacyReverse(ctx context.Context, streamName string, state jetstream.StreamState, stream replayStream, subjectPrefixes []string, request ports.ReplayRequest, candidateLimit uint32) ([]replayCandidate, replayScanStats, error) {
 	stats := replayScanStats{strategy: replayStrategyLegacyReverseScan}
 	candidates := make([]replayCandidate, 0, candidateLimit)
+	cursorSeen := request.Cursor == ""
 	for seq := state.LastSeq; ; seq-- {
 		stats.scanned++
 		raw, err := stream.GetMsg(ctx, seq)
@@ -994,6 +1019,15 @@ func replayLegacyReverse(ctx context.Context, streamName string, state jetstream
 				return nil, stats, fmt.Errorf("decode replay message %s:%d: %w", streamName, seq, err)
 			}
 			stats.decoded++
+			if !cursorSeen {
+				if event.GetId() == request.Cursor {
+					cursorSeen = true
+				}
+				if seq == state.FirstSeq {
+					break
+				}
+				continue
+			}
 			if matchesReplayRequest(event, request) {
 				stats.matched++
 				candidates = appendNewestReplayCandidate(candidates, replayCandidate{event: event, seq: seq}, candidateLimit)
@@ -1002,6 +1036,9 @@ func replayLegacyReverse(ctx context.Context, streamName string, state jetstream
 		if seq == state.FirstSeq {
 			break
 		}
+	}
+	if !cursorSeen {
+		return nil, stats, fmt.Errorf("%w: %s", ports.ErrReplayCursorNotFound, request.Cursor)
 	}
 	return candidates, stats, nil
 }
@@ -1069,7 +1106,7 @@ func appendNewestReplayCandidate(candidates []replayCandidate, candidate replayC
 // requests fall back to the subject/legacy strategies, which collect matched
 // candidates directly.
 func runtimeIndexReplayEligible(request ports.ReplayRequest) bool {
-	if request.RuntimeID == "" {
+	if request.RuntimeID == "" || request.Cursor != "" {
 		return false
 	}
 	if request.TenantID != "" || len(request.AttributeEquals) > 0 {
@@ -1850,6 +1887,7 @@ func normalizeReplayRequest(req ports.ReplayRequest) ports.ReplayRequest {
 		TenantID:            strings.TrimSpace(req.TenantID),
 		AttributeEquals:     make(map[string]string, len(req.AttributeEquals)),
 		Limit:               req.Limit,
+		Cursor:              strings.TrimSpace(req.Cursor),
 	}
 	for key, value := range req.AttributeEquals {
 		trimmedKey := strings.TrimSpace(key)

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -1095,6 +1095,63 @@ func TestReplayFiltersEventsByRuntime(t *testing.T) {
 	}
 }
 
+func TestReplayPageTraversesBeyondPerRequestLimit(t *testing.T) {
+	const eventCount = 1205
+	messages := make(map[uint64]*natsjetstream.RawStreamMsg, eventCount)
+	for i := 1; i <= eventCount; i++ {
+		id := fmt.Sprintf("evt-%04d", i)
+		messages[uint64(i)] = rawReplayMsg(t, "events.github.audit", replayEvent(id, "github.audit", "writer-github"))
+	}
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{{
+			Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+			State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: eventCount, Msgs: eventCount},
+		}},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{"CEREBRO_EVENTS": messages},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	first, err := log.ReplayPage(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 1000})
+	if err != nil {
+		t.Fatalf("ReplayPage(first) error = %v", err)
+	}
+	if len(first.Events) != 1000 || first.Complete || first.NextCursor != "evt-0206" {
+		t.Fatalf("first page count=%d complete=%v cursor=%q", len(first.Events), first.Complete, first.NextCursor)
+	}
+	if first.Events[0].GetId() != "evt-0206" || first.Events[len(first.Events)-1].GetId() != "evt-1205" {
+		t.Fatalf("first page range = %q..%q", first.Events[0].GetId(), first.Events[len(first.Events)-1].GetId())
+	}
+
+	second, err := log.ReplayPage(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 1000, Cursor: first.NextCursor})
+	if err != nil {
+		t.Fatalf("ReplayPage(second) error = %v", err)
+	}
+	if len(second.Events) != 205 || !second.Complete || second.NextCursor != "" {
+		t.Fatalf("second page count=%d complete=%v cursor=%q", len(second.Events), second.Complete, second.NextCursor)
+	}
+	if second.Events[0].GetId() != "evt-0001" || second.Events[len(second.Events)-1].GetId() != "evt-0205" {
+		t.Fatalf("second page range = %q..%q", second.Events[0].GetId(), second.Events[len(second.Events)-1].GetId())
+	}
+}
+
+func TestReplayPageRejectsMissingCursor(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{{
+			Config: natsjetstream.StreamConfig{Name: "CEREBRO_EVENTS", Subjects: []string{"events.>"}},
+			State:  natsjetstream.StreamState{FirstSeq: 1, LastSeq: 1, Msgs: 1},
+		}},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-0001", "github.audit", "writer-github"))},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	_, err := log.ReplayPage(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 100, Cursor: "evt-missing"})
+	if !errors.Is(err, ports.ErrReplayCursorNotFound) {
+		t.Fatalf("ReplayPage() error = %v, want ErrReplayCursorNotFound", err)
+	}
+}
+
 func TestReplayExactKindFiltersUseSubjectIndex(t *testing.T) {
 	replay := &fakeReplayManager{
 		streams: []*natsjetstream.StreamInfo{

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -63,6 +63,21 @@ func (a *App) newJobService() *platformjobs.Service {
 	return service
 }
 
+// RecoverPlatformJobs resumes queued work and jobs whose worker lease expired.
+// Claiming is owner-checked, so every server replica may call this at startup.
+func (a *App) RecoverPlatformJobs(ctx context.Context) (int, error) {
+	if _, ok := a.deps.StateStore.(ports.JobLeaseStore); !ok {
+		return 0, nil
+	}
+	return a.jobService().Recover(ctx, 0)
+}
+
+// StartPlatformJobRecovery continuously makes expired leases runnable. The
+// returned channel closes after cancellation and is included in shutdown waits.
+func (a *App) StartPlatformJobRecovery(ctx context.Context, logf func(string, ...any)) <-chan struct{} {
+	return a.jobService().StartRecovery(ctx, logf)
+}
+
 func (a *App) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 	var request createJobHTTPRequest
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes)).Decode(&request); err != nil {
@@ -430,6 +445,8 @@ func writeJobError(w http.ResponseWriter, err error) {
 		status = http.StatusBadRequest
 	case errors.Is(err, ports.ErrJobNotFound):
 		status = http.StatusNotFound
+	case errors.Is(err, ports.ErrJobIdempotencyConflict), errors.Is(err, ports.ErrJobUpdateConflict), errors.Is(err, ports.ErrJobLeaseConflict):
+		status = http.StatusConflict
 	case errors.Is(err, platformjobs.ErrRuntimeUnavailable):
 		status = http.StatusServiceUnavailable
 	case errors.Is(err, errTenantForbidden):

--- a/internal/bootstrap/report_schedules.go
+++ b/internal/bootstrap/report_schedules.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,17 +13,15 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
-	platformjobs "github.com/writer/cerebro/internal/jobs"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/reports"
+	"github.com/writer/cerebro/internal/reportschedule"
 )
 
 const (
-	reportSchedulePollInterval              = 30 * time.Second
-	reportScheduleMinIntervalSeconds        = int64(60)
-	reportScheduleMaxIntervalSeconds        = int64(31 * 24 * 60 * 60)
-	reportScheduleClaimBatch         uint32 = 50
-	reportScheduleSubjectType               = "report_schedule"
+	reportSchedulePollInterval       = 30 * time.Second
+	reportScheduleMinIntervalSeconds = int64(60)
+	reportScheduleMaxIntervalSeconds = int64(31 * 24 * 60 * 60)
 )
 
 type reportScheduleView struct {
@@ -281,52 +278,7 @@ func (a *App) RunDueReportSchedules(ctx context.Context) (int, error) {
 	if store == nil {
 		return 0, nil
 	}
-	due, err := store.ClaimDueReportSchedules(ctx, time.Now().UTC(), reportScheduleClaimBatch)
-	if err != nil {
-		return 0, err
-	}
-	enqueued := 0
-	var errs []error
-	for _, schedule := range due {
-		if err := a.enqueueScheduledReportRun(ctx, schedule); err != nil {
-			errs = append(errs, fmt.Errorf("report schedule %q: %w", schedule.ID, err))
-			continue
-		}
-		enqueued++
-	}
-	return enqueued, errors.Join(errs...)
-}
-
-func (a *App) enqueueScheduledReportRun(ctx context.Context, schedule *ports.ReportSchedule) error {
-	if schedule == nil {
-		return nil
-	}
-	parameters := make(map[string]any, len(schedule.Parameters)+1)
-	for key, value := range schedule.Parameters {
-		parameters[key] = value
-	}
-	if tenantID := strings.TrimSpace(schedule.TenantID); tenantID != "" {
-		if _, ok := parameters["tenant_id"]; !ok {
-			parameters["tenant_id"] = tenantID
-		}
-	}
-	job, created, err := a.jobService().Create(ctx, ports.CreateJobRequest{
-		Kind:        platformjobs.KindReportRun,
-		TenantID:    schedule.TenantID,
-		SubjectType: reportScheduleSubjectType,
-		SubjectID:   schedule.ID,
-		Payload: map[string]any{
-			"report_id":  schedule.ReportID,
-			"parameters": parameters,
-		},
-	})
-	if err != nil {
-		return err
-	}
-	if created {
-		a.jobService().StartAsync(ctx, job)
-	}
-	return nil
+	return reportschedule.RunDue(ctx, store, a.jobService(), time.Now().UTC())
 }
 
 // StartReportScheduler launches the background loop that periodically enqueues

--- a/internal/bootstrap/report_schedules_test.go
+++ b/internal/bootstrap/report_schedules_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,11 +16,16 @@ import (
 )
 
 type stubReportScheduleStore struct {
-	schedules   map[string]*ports.ReportSchedule
-	due         []*ports.ReportSchedule
-	runs        []*cerebrov1.ReportRun
-	createdJobs []ports.CreateJobRequest
-	claimLimit  uint32
+	schedules       map[string]*ports.ReportSchedule
+	due             []*ports.ReportSchedule
+	runs            []*cerebrov1.ReportRun
+	createdJobs     []ports.CreateJobRequest
+	claimLimit      uint32
+	claimOwner      string
+	claimTTL        time.Duration
+	completedClaims []string
+	releasedClaims  []string
+	createJobErr    error
 }
 
 func newStubReportScheduleStore() *stubReportScheduleStore {
@@ -60,9 +66,21 @@ func (s *stubReportScheduleStore) DeleteReportSchedule(_ context.Context, id str
 	return nil
 }
 
-func (s *stubReportScheduleStore) ClaimDueReportSchedules(_ context.Context, _ time.Time, limit uint32) ([]*ports.ReportSchedule, error) {
+func (s *stubReportScheduleStore) ClaimDueReportSchedules(_ context.Context, _ time.Time, owner string, ttl time.Duration, limit uint32) ([]*ports.ReportSchedule, error) {
 	s.claimLimit = limit
+	s.claimOwner = owner
+	s.claimTTL = ttl
 	return s.due, nil
+}
+
+func (s *stubReportScheduleStore) CompleteReportScheduleClaim(_ context.Context, id string, owner string, _ time.Time, _ time.Time) error {
+	s.completedClaims = append(s.completedClaims, id+":"+owner)
+	return nil
+}
+
+func (s *stubReportScheduleStore) ReleaseReportScheduleClaim(_ context.Context, id string, owner string) error {
+	s.releasedClaims = append(s.releasedClaims, id+":"+owner)
+	return nil
 }
 
 func (s *stubReportScheduleStore) ListReportRuns(_ context.Context, _ ports.ReportRunFilter) ([]*cerebrov1.ReportRun, error) {
@@ -71,6 +89,9 @@ func (s *stubReportScheduleStore) ListReportRuns(_ context.Context, _ ports.Repo
 
 func (s *stubReportScheduleStore) CreateJob(_ context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
 	s.createdJobs = append(s.createdJobs, request)
+	if s.createJobErr != nil {
+		return nil, false, s.createJobErr
+	}
 	return &ports.Job{ID: "job-stub", Kind: request.Kind, Status: "queued"}, false, nil
 }
 
@@ -253,7 +274,7 @@ func TestHandleDeleteReportScheduleScopesTenant(t *testing.T) {
 func TestRunDueReportSchedulesEnqueuesReportRunJobs(t *testing.T) {
 	store := newStubReportScheduleStore()
 	store.due = []*ports.ReportSchedule{
-		{ID: "a", TenantID: "local", ReportID: "finding-summary", IntervalSeconds: 3600, Enabled: true, Parameters: map[string]string{"tenant_id": "local", "runtime_ids": "rt-1"}},
+		{ID: "a", TenantID: "local", ReportID: "finding-summary", IntervalSeconds: 3600, Enabled: true, NextRunAt: time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC), Parameters: map[string]string{"tenant_id": "local", "runtime_ids": "rt-1"}},
 	}
 	app := reportScheduleTestApp(store)
 
@@ -271,6 +292,12 @@ func TestRunDueReportSchedulesEnqueuesReportRunJobs(t *testing.T) {
 	if job.Kind != "report_run" || job.TenantID != "local" {
 		t.Fatalf("unexpected job %+v", job)
 	}
+	if job.IdempotencyKey != "report-schedule:a:2026-07-11T08:00:00Z" {
+		t.Fatalf("unexpected idempotency key %q", job.IdempotencyKey)
+	}
+	if len(store.completedClaims) != 1 || len(store.releasedClaims) != 0 {
+		t.Fatalf("completed=%v released=%v, want one completion and no release", store.completedClaims, store.releasedClaims)
+	}
 	if job.Payload["report_id"] != "finding-summary" {
 		t.Fatalf("unexpected job report_id %v", job.Payload["report_id"])
 	}
@@ -280,6 +307,25 @@ func TestRunDueReportSchedulesEnqueuesReportRunJobs(t *testing.T) {
 	}
 	if parameters["tenant_id"] != "local" || parameters["runtime_ids"] != "rt-1" {
 		t.Fatalf("unexpected job parameters %+v", parameters)
+	}
+}
+
+func TestRunDueReportSchedulesReleasesClaimWhenEnqueueFails(t *testing.T) {
+	store := newStubReportScheduleStore()
+	store.createJobErr = errors.New("job store unavailable")
+	store.due = []*ports.ReportSchedule{{
+		ID: "a", TenantID: "local", ReportID: "finding-summary", IntervalSeconds: 3600,
+		Enabled: true, NextRunAt: time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC),
+		Parameters: map[string]string{"tenant_id": "local", "runtime_ids": "rt-1"},
+	}}
+	app := reportScheduleTestApp(store)
+
+	enqueued, err := app.RunDueReportSchedules(context.Background())
+	if err == nil {
+		t.Fatal("RunDueReportSchedules() error = nil, want enqueue failure")
+	}
+	if enqueued != 0 || len(store.completedClaims) != 0 || len(store.releasedClaims) != 1 {
+		t.Fatalf("enqueued=%d completed=%v released=%v", enqueued, store.completedClaims, store.releasedClaims)
 	}
 }
 

--- a/internal/compliance/identifiers.go
+++ b/internal/compliance/identifiers.go
@@ -1,0 +1,138 @@
+package compliance
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrInvalidIdentifier = errors.New("invalid compliance identifier")
+
+// IdentifierKind names the stable public prefix for one compliance resource.
+type IdentifierKind string
+
+const (
+	IdentifierProgram        IdentifierKind = "program"
+	IdentifierScope          IdentifierKind = "scope"
+	IdentifierImplementation IdentifierKind = "implementation"
+	IdentifierPlan           IdentifierKind = "assessment-plan"
+	IdentifierTest           IdentifierKind = "assessment-test"
+	IdentifierEvidence       IdentifierKind = "evidence"
+	IdentifierClaim          IdentifierKind = "evidence-claim"
+	IdentifierRun            IdentifierKind = "assessment-run"
+	IdentifierResult         IdentifierKind = "assessment-result"
+	IdentifierReview         IdentifierKind = "assessment-review"
+	IdentifierArtifact       IdentifierKind = "artifact"
+	IdentifierMapping        IdentifierKind = "control-mapping"
+)
+
+const identifierEntropyBytes = 16
+
+// NewIdentifier returns an opaque identifier with a resource-specific prefix.
+func NewIdentifier(kind IdentifierKind) (string, error) {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return "", err
+	}
+	random := make([]byte, identifierEntropyBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate compliance identifier: %w", err)
+	}
+	return string(kind) + "-" + hex.EncodeToString(random), nil
+}
+
+// NewRevisionIdentifier returns an opaque identity for an immutable revision.
+func NewRevisionIdentifier(kind IdentifierKind) (string, error) {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return "", err
+	}
+	random := make([]byte, identifierEntropyBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate compliance revision identifier: %w", err)
+	}
+	return string(kind) + "-revision-" + hex.EncodeToString(random), nil
+}
+
+func ValidateIdentifierKind(kind IdentifierKind) error {
+	value := string(kind)
+	if value == "" || len(value) > 40 || !identifierToken(value) {
+		return fmt.Errorf("%w: kind %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+// ValidateIdentifier rejects display names, whitespace, path separators, and
+// tenant data in public identifiers. IDs remain opaque and tenant scoping is
+// enforced separately by every store lookup.
+func ValidateIdentifier(kind IdentifierKind, value string) error {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return err
+	}
+	raw := value
+	value = strings.TrimSpace(value)
+	if value != raw {
+		return fmt.Errorf("%w: identifier contains surrounding whitespace", ErrInvalidIdentifier)
+	}
+	prefix := string(kind) + "-"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+(identifierEntropyBytes*2) {
+		return fmt.Errorf("%w: expected %s prefix", ErrInvalidIdentifier, prefix)
+	}
+	if !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+// ValidateRevisionIdentifier checks an immutable revision identity separately
+// from the logical record identity.
+func ValidateRevisionIdentifier(kind IdentifierKind, value string) error {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return err
+	}
+	raw := value
+	value = strings.TrimSpace(value)
+	if value != raw {
+		return fmt.Errorf("%w: revision identifier contains surrounding whitespace", ErrInvalidIdentifier)
+	}
+	prefix := string(kind) + "-revision-"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+(identifierEntropyBytes*2) {
+		return fmt.Errorf("%w: expected %s prefix", ErrInvalidIdentifier, prefix)
+	}
+	if !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+func identifierToken(value string) bool {
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') || character == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func lowerHex(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, character := range value {
+		if (character >= 'a' && character <= 'f') || (character >= '0' && character <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func ValidateContentDigest(digest ContentDigest) error {
+	value := string(digest)
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+64 || !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: invalid content digest", ErrInvalidRevision)
+	}
+	return nil
+}

--- a/internal/compliance/identifiers_test.go
+++ b/internal/compliance/identifiers_test.go
@@ -1,0 +1,59 @@
+package compliance
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestOpaqueLogicalAndRevisionIdentifiersValidateSeparately(t *testing.T) {
+	logical, err := NewIdentifier(IdentifierProgram)
+	if err != nil {
+		t.Fatalf("NewIdentifier() error = %v", err)
+	}
+	revision, err := NewRevisionIdentifier(IdentifierProgram)
+	if err != nil {
+		t.Fatalf("NewRevisionIdentifier() error = %v", err)
+	}
+	if err := ValidateIdentifier(IdentifierProgram, logical); err != nil {
+		t.Fatalf("ValidateIdentifier() error = %v", err)
+	}
+	if err := ValidateRevisionIdentifier(IdentifierProgram, revision); err != nil {
+		t.Fatalf("ValidateRevisionIdentifier() error = %v", err)
+	}
+	if logical == revision || strings.Contains(logical, "revision") {
+		t.Fatalf("logical=%q revision=%q are not distinct", logical, revision)
+	}
+	if err := ValidateIdentifier(IdentifierProgram, revision); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateIdentifier(revision) error = %v, want ErrInvalidIdentifier", err)
+	}
+	if err := ValidateRevisionIdentifier(IdentifierProgram, logical); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateRevisionIdentifier(logical) error = %v, want ErrInvalidIdentifier", err)
+	}
+}
+
+func TestValidateIdentifierRejectsLossyAndNonOpaqueValues(t *testing.T) {
+	for _, value := range []string{
+		"program-customer/name",
+		"program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-",
+		"program-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-extra",
+		" program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	} {
+		if err := ValidateIdentifier(IdentifierProgram, value); !errors.Is(err, ErrInvalidIdentifier) {
+			t.Fatalf("ValidateIdentifier(%q) error = %v, want ErrInvalidIdentifier", value, err)
+		}
+	}
+}
+
+func TestValidateContentDigestRequiresCanonicalSHA256(t *testing.T) {
+	valid := ContentDigest("sha256:" + strings.Repeat("a", 64))
+	if err := ValidateContentDigest(valid); err != nil {
+		t.Fatalf("ValidateContentDigest() error = %v", err)
+	}
+	for _, value := range []ContentDigest{"", "sha256:abc", ContentDigest("SHA256:" + strings.Repeat("a", 64)), ContentDigest("sha256:" + strings.Repeat("A", 64))} {
+		if err := ValidateContentDigest(value); !errors.Is(err, ErrInvalidRevision) {
+			t.Fatalf("ValidateContentDigest(%q) error = %v, want ErrInvalidRevision", value, err)
+		}
+	}
+}

--- a/internal/compliance/mappings.go
+++ b/internal/compliance/mappings.go
@@ -1,0 +1,146 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var ErrInvalidMapping = errors.New("invalid compliance mapping")
+
+type MappingRelationship string
+
+const (
+	MappingEquivalent MappingRelationship = "equivalent"
+	MappingSubset     MappingRelationship = "subset"
+	MappingSuperset   MappingRelationship = "superset"
+	MappingOverlap    MappingRelationship = "overlap"
+	MappingNone       MappingRelationship = "none"
+)
+
+type MappingDecisionState string
+
+const (
+	MappingProposed MappingDecisionState = "proposed"
+	MappingApproved MappingDecisionState = "approved"
+	MappingRejected MappingDecisionState = "rejected"
+	MappingRetired  MappingDecisionState = "retired"
+)
+
+// ControlMapping records an explicit, reviewable relationship between exact
+// source and target revisions. It never grants coverage by implication.
+type ControlMapping struct {
+	ID                  string               `json:"id"`
+	RevisionID          string               `json:"revision_id"`
+	Source              RevisionRef          `json:"source"`
+	Target              RevisionRef          `json:"target"`
+	Granularity         string               `json:"granularity"`
+	Relationship        MappingRelationship  `json:"relationship"`
+	Method              string               `json:"method"`
+	Rationale           string               `json:"rationale"`
+	CoverageBasisPoints uint16               `json:"coverage_basis_points"`
+	Gaps                []string             `json:"gaps,omitempty"`
+	Provenance          []SubjectRef         `json:"provenance,omitempty"`
+	DecisionState       MappingDecisionState `json:"decision_state"`
+	AuthorID            string               `json:"author_id"`
+	ReviewerID          string               `json:"reviewer_id,omitempty"`
+}
+
+func (mapping ControlMapping) Validate() error {
+	if strings.TrimSpace(mapping.ID) == "" || strings.TrimSpace(mapping.RevisionID) == "" {
+		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidMapping)
+	}
+	if err := mapping.Source.Validate(); err != nil {
+		return fmt.Errorf("%w: source: %v", ErrInvalidMapping, err)
+	}
+	if err := mapping.Target.Validate(); err != nil {
+		return fmt.Errorf("%w: target: %v", ErrInvalidMapping, err)
+	}
+	if mapping.Source.ID == mapping.Target.ID && mapping.Source.RevisionID == mapping.Target.RevisionID {
+		return fmt.Errorf("%w: source and target must differ", ErrInvalidMapping)
+	}
+	switch mapping.Relationship {
+	case MappingEquivalent, MappingSubset, MappingSuperset, MappingOverlap, MappingNone:
+	default:
+		return fmt.Errorf("%w: relationship %q", ErrInvalidMapping, mapping.Relationship)
+	}
+	switch mapping.DecisionState {
+	case MappingProposed, MappingApproved, MappingRejected, MappingRetired:
+	default:
+		return fmt.Errorf("%w: decision_state %q", ErrInvalidMapping, mapping.DecisionState)
+	}
+	if mapping.CoverageBasisPoints > 10000 {
+		return fmt.Errorf("%w: coverage_basis_points exceeds 10000", ErrInvalidMapping)
+	}
+	if mapping.Relationship == MappingNone && mapping.CoverageBasisPoints != 0 {
+		return fmt.Errorf("%w: none relationship must have zero coverage", ErrInvalidMapping)
+	}
+	if mapping.Relationship == MappingEquivalent && mapping.CoverageBasisPoints != 10000 {
+		return fmt.Errorf("%w: equivalent relationship must have full coverage", ErrInvalidMapping)
+	}
+	if strings.TrimSpace(mapping.Granularity) == "" || strings.TrimSpace(mapping.Method) == "" || strings.TrimSpace(mapping.Rationale) == "" || strings.TrimSpace(mapping.AuthorID) == "" {
+		return fmt.Errorf("%w: granularity, method, rationale, and author_id are required", ErrInvalidMapping)
+	}
+	if mapping.DecisionState != MappingProposed && strings.TrimSpace(mapping.ReviewerID) == "" {
+		return fmt.Errorf("%w: reviewer_id is required for decided mappings", ErrInvalidMapping)
+	}
+	for index, reference := range mapping.Provenance {
+		if err := reference.Validate(); err != nil {
+			return fmt.Errorf("%w: provenance[%d]: %v", ErrInvalidMapping, index, err)
+		}
+	}
+	return nil
+}
+
+func NormalizeControlMapping(mapping ControlMapping) ControlMapping {
+	mapping.ID = strings.TrimSpace(mapping.ID)
+	mapping.RevisionID = strings.TrimSpace(mapping.RevisionID)
+	mapping.Granularity = strings.TrimSpace(mapping.Granularity)
+	mapping.Method = strings.TrimSpace(mapping.Method)
+	mapping.Rationale = strings.TrimSpace(mapping.Rationale)
+	mapping.AuthorID = strings.TrimSpace(mapping.AuthorID)
+	mapping.ReviewerID = strings.TrimSpace(mapping.ReviewerID)
+	mapping.Source = NormalizeRevisionRef(mapping.Source)
+	mapping.Target = NormalizeRevisionRef(mapping.Target)
+	mapping.Gaps = normalizedSortedStrings(mapping.Gaps)
+	mapping.Provenance = append([]SubjectRef(nil), mapping.Provenance...)
+	for index := range mapping.Provenance {
+		mapping.Provenance[index].Type = strings.TrimSpace(mapping.Provenance[index].Type)
+		mapping.Provenance[index].ID = strings.TrimSpace(mapping.Provenance[index].ID)
+	}
+	sort.Slice(mapping.Provenance, func(i, j int) bool {
+		return mapping.Provenance[i].Type+"\x00"+mapping.Provenance[i].ID < mapping.Provenance[j].Type+"\x00"+mapping.Provenance[j].ID
+	})
+	mapping.Provenance = deduplicateSubjectRefs(mapping.Provenance)
+	return mapping
+}
+
+func deduplicateSubjectRefs(values []SubjectRef) []SubjectRef {
+	result := make([]SubjectRef, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1] == value {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizedSortedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}

--- a/internal/compliance/mappings.go
+++ b/internal/compliance/mappings.go
@@ -52,10 +52,10 @@ func (mapping ControlMapping) Validate() error {
 		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidMapping)
 	}
 	if err := mapping.Source.Validate(); err != nil {
-		return fmt.Errorf("%w: source: %v", ErrInvalidMapping, err)
+		return fmt.Errorf("%w: source: %w", ErrInvalidMapping, err)
 	}
 	if err := mapping.Target.Validate(); err != nil {
-		return fmt.Errorf("%w: target: %v", ErrInvalidMapping, err)
+		return fmt.Errorf("%w: target: %w", ErrInvalidMapping, err)
 	}
 	if mapping.Source.ID == mapping.Target.ID && mapping.Source.RevisionID == mapping.Target.RevisionID {
 		return fmt.Errorf("%w: source and target must differ", ErrInvalidMapping)
@@ -87,7 +87,7 @@ func (mapping ControlMapping) Validate() error {
 	}
 	for index, reference := range mapping.Provenance {
 		if err := reference.Validate(); err != nil {
-			return fmt.Errorf("%w: provenance[%d]: %v", ErrInvalidMapping, index, err)
+			return fmt.Errorf("%w: provenance[%d]: %w", ErrInvalidMapping, index, err)
 		}
 	}
 	return nil

--- a/internal/compliance/mappings_test.go
+++ b/internal/compliance/mappings_test.go
@@ -1,0 +1,69 @@
+package compliance
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeControlMappingIsDeterministicWithoutMutatingCaller(t *testing.T) {
+	digest := ContentDigest("sha256:" + strings.Repeat("b", 64))
+	mapping := ControlMapping{
+		ID: " mapping ", RevisionID: " revision ", Granularity: " statement ",
+		Source:       RevisionRef{ID: "source", RevisionID: "source-r1", Version: 1, ContentDigest: digest, LastModified: time.Unix(1, 0)},
+		Target:       RevisionRef{ID: "target", RevisionID: "target-r1", Version: 1, ContentDigest: digest, LastModified: time.Unix(1, 0)},
+		Relationship: MappingOverlap, Method: " manual ", Rationale: " scoped overlap ", CoverageBasisPoints: 7500,
+		Gaps:          []string{" gap-b ", "gap-a", "gap-a"},
+		Provenance:    []SubjectRef{{Type: " source ", ID: "b"}, {Type: "source", ID: "a"}, {Type: "source", ID: "a"}},
+		DecisionState: MappingApproved, AuthorID: " author ", ReviewerID: " reviewer ",
+	}
+	normalized := NormalizeControlMapping(mapping)
+	if got := strings.Join(normalized.Gaps, ","); got != "gap-a,gap-b" {
+		t.Fatalf("normalized gaps = %q", got)
+	}
+	if len(normalized.Provenance) != 2 || normalized.Provenance[0].ID != "a" || normalized.Provenance[1].ID != "b" {
+		t.Fatalf("normalized provenance = %#v", normalized.Provenance)
+	}
+	if mapping.Provenance[0].Type != " source " {
+		t.Fatal("NormalizeControlMapping mutated caller provenance")
+	}
+	if normalized.Source.LastModified.Nanosecond()%int(time.Millisecond) != 0 {
+		t.Fatalf("source revision time was not normalized: %s", normalized.Source.LastModified)
+	}
+	if err := normalized.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestControlMappingRelationshipCoverageInvariants(t *testing.T) {
+	base := validControlMapping()
+	base.Relationship = MappingNone
+	base.CoverageBasisPoints = 1
+	if err := base.Validate(); err == nil {
+		t.Fatal("none relationship with coverage was accepted")
+	}
+	base = validControlMapping()
+	base.Relationship = MappingEquivalent
+	base.CoverageBasisPoints = 9999
+	if err := base.Validate(); err == nil {
+		t.Fatal("equivalent relationship without full coverage was accepted")
+	}
+	base = validControlMapping()
+	base.DecisionState = MappingApproved
+	base.ReviewerID = ""
+	if err := base.Validate(); err == nil {
+		t.Fatal("decided mapping without reviewer was accepted")
+	}
+}
+
+func validControlMapping() ControlMapping {
+	digest := ContentDigest("sha256:" + strings.Repeat("c", 64))
+	modified := time.Unix(1, 123456789).UTC()
+	return ControlMapping{
+		ID: "mapping", RevisionID: "mapping-r1", Granularity: "objective",
+		Source:       RevisionRef{ID: "source", RevisionID: "source-r1", Version: 1, ContentDigest: digest, LastModified: modified},
+		Target:       RevisionRef{ID: "target", RevisionID: "target-r1", Version: 1, ContentDigest: digest, LastModified: modified},
+		Relationship: MappingOverlap, Method: "manual", Rationale: "overlap", CoverageBasisPoints: 5000,
+		DecisionState: MappingProposed, AuthorID: "author",
+	}
+}

--- a/internal/compliance/types.go
+++ b/internal/compliance/types.go
@@ -1,0 +1,111 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var ErrInvalidRevision = errors.New("invalid compliance revision")
+
+// ContentDigest is the lowercase SHA-256 digest of normalized semantic content.
+// It deliberately remains separate from revision identity: two tenants may
+// create different revisions with the same semantic content.
+type ContentDigest string
+
+// VersionMetadata describes one immutable revision of a stable logical record.
+type VersionMetadata struct {
+	ID            string        `json:"id"`
+	RevisionID    string        `json:"revision_id"`
+	Version       uint64        `json:"version"`
+	LastModified  time.Time     `json:"last_modified"`
+	ContentDigest ContentDigest `json:"content_digest"`
+	CreatedBy     string        `json:"created_by"`
+	PredecessorID string        `json:"predecessor_id,omitempty"`
+	SuccessorID   string        `json:"successor_id,omitempty"`
+}
+
+// RevisionRef identifies one immutable revision of a stable compliance subject.
+// ContentDigest covers normalized semantic content, not database metadata.
+type RevisionRef struct {
+	ID            string        `json:"id"`
+	RevisionID    string        `json:"revision_id"`
+	Version       uint64        `json:"version"`
+	ContentDigest ContentDigest `json:"content_digest"`
+	LastModified  time.Time     `json:"last_modified"`
+}
+
+// SubjectRef identifies a tenant-scoped subject without copying its lifecycle.
+type SubjectRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+func NormalizeVersionMetadata(value VersionMetadata) VersionMetadata {
+	value.ID = strings.TrimSpace(value.ID)
+	value.RevisionID = strings.TrimSpace(value.RevisionID)
+	value.LastModified = CanonicalRevisionTime(value.LastModified)
+	value.ContentDigest = ContentDigest(strings.TrimSpace(string(value.ContentDigest)))
+	value.CreatedBy = strings.TrimSpace(value.CreatedBy)
+	value.PredecessorID = strings.TrimSpace(value.PredecessorID)
+	value.SuccessorID = strings.TrimSpace(value.SuccessorID)
+	return value
+}
+
+func NormalizeRevisionRef(value RevisionRef) RevisionRef {
+	value.ID = strings.TrimSpace(value.ID)
+	value.RevisionID = strings.TrimSpace(value.RevisionID)
+	value.ContentDigest = ContentDigest(strings.TrimSpace(string(value.ContentDigest)))
+	value.LastModified = CanonicalRevisionTime(value.LastModified)
+	return value
+}
+
+// CanonicalRevisionTime uses the precision shared by event envelopes and
+// canonical assessment hashes.
+func CanonicalRevisionTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Time{}
+	}
+	return value.UTC().Truncate(time.Millisecond)
+}
+
+func (metadata VersionMetadata) Validate() error {
+	metadata = NormalizeVersionMetadata(metadata)
+	if metadata.ID == "" || metadata.RevisionID == "" || metadata.CreatedBy == "" {
+		return fmt.Errorf("%w: id, revision_id, and created_by are required", ErrInvalidRevision)
+	}
+	if metadata.Version == 0 || metadata.LastModified.IsZero() {
+		return fmt.Errorf("%w: version and last_modified are required", ErrInvalidRevision)
+	}
+	if err := ValidateContentDigest(metadata.ContentDigest); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+	}
+	return nil
+}
+
+// Validate checks the required, transport-independent revision invariants.
+// Resource-specific identifier validation remains with the owning service.
+func (revision RevisionRef) Validate() error {
+	revision = NormalizeRevisionRef(revision)
+	if strings.TrimSpace(revision.ID) == "" || strings.TrimSpace(revision.RevisionID) == "" {
+		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidRevision)
+	}
+	if revision.Version == 0 {
+		return fmt.Errorf("%w: version must be greater than zero", ErrInvalidRevision)
+	}
+	if err := ValidateContentDigest(revision.ContentDigest); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+	}
+	if revision.LastModified.IsZero() {
+		return fmt.Errorf("%w: last_modified is required", ErrInvalidRevision)
+	}
+	return nil
+}
+
+func (reference SubjectRef) Validate() error {
+	if strings.TrimSpace(reference.Type) == "" || strings.TrimSpace(reference.ID) == "" {
+		return fmt.Errorf("%w: subject type and id are required", ErrInvalidRevision)
+	}
+	return nil
+}

--- a/internal/compliance/types.go
+++ b/internal/compliance/types.go
@@ -79,7 +79,7 @@ func (metadata VersionMetadata) Validate() error {
 		return fmt.Errorf("%w: version and last_modified are required", ErrInvalidRevision)
 	}
 	if err := ValidateContentDigest(metadata.ContentDigest); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+		return fmt.Errorf("%w: %w", ErrInvalidRevision, err)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func (revision RevisionRef) Validate() error {
 		return fmt.Errorf("%w: version must be greater than zero", ErrInvalidRevision)
 	}
 	if err := ValidateContentDigest(revision.ContentDigest); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+		return fmt.Errorf("%w: %w", ErrInvalidRevision, err)
 	}
 	if revision.LastModified.IsZero() {
 		return fmt.Errorf("%w: last_modified is required", ErrInvalidRevision)

--- a/internal/complianceassessment/conformance_test.go
+++ b/internal/complianceassessment/conformance_test.go
@@ -1,0 +1,223 @@
+package complianceassessment
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+type conformanceFixture struct {
+	Version      string          `json:"version"`
+	BaseInput    json.RawMessage `json:"base_input"`
+	BaseExpected json.RawMessage `json:"base_expected"`
+	Cases        []fixtureCase   `json:"cases"`
+}
+
+type fixtureCase struct {
+	Name           string          `json:"name"`
+	Input          json.RawMessage `json:"input"`
+	Expected       json.RawMessage `json:"expected"`
+	ExpectedDigest string          `json:"expected_digest"`
+}
+
+type fixtureExpected struct {
+	ScopeState                  ScopeState                  `json:"scope_state"`
+	AutomatedOutcome            AutomatedOutcome            `json:"automated_outcome"`
+	DesignState                 DesignState                 `json:"design_state"`
+	OperatingEffectivenessState OperatingEffectivenessState `json:"operating_effectiveness_state"`
+	EvidenceState               EvidenceState               `json:"evidence_state"`
+	DispositionState            DispositionState            `json:"disposition_state"`
+	Assurance                   Assurance                   `json:"assurance"`
+	AuditorState                AuditorState                `json:"auditor_state"`
+	ReasonCodes                 []ReasonCode                `json:"reason_codes"`
+	NextActions                 []NextAction                `json:"next_actions"`
+	LegacyStatus                string                      `json:"legacy_status"`
+}
+
+func TestObjectiveConformanceFixtures(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	if fixture.Version != "compliance-assessment-conformance/v1" {
+		t.Fatalf("fixture version = %q", fixture.Version)
+	}
+	if len(fixture.Cases) < 16 {
+		t.Fatalf("fixture cases = %d, want at least 16", len(fixture.Cases))
+	}
+	for _, testCase := range fixture.Cases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			input := mergedFixtureValue[EvaluateInput](t, fixture.BaseInput, testCase.Input)
+			expectedAxes := mergedFixtureValue[fixtureExpected](t, fixture.BaseExpected, testCase.Expected)
+			result, err := EvaluateObjective(input)
+			if err != nil {
+				t.Fatalf("EvaluateObjective() error = %v", err)
+			}
+			expected := expectedFixtureResult(input, expectedAxes)
+			gotBytes, err := CanonicalResultBytes(result)
+			if err != nil {
+				t.Fatalf("CanonicalResultBytes(result) error = %v", err)
+			}
+			wantBytes, err := CanonicalResultBytes(expected)
+			if err != nil {
+				t.Fatalf("CanonicalResultBytes(expected) error = %v", err)
+			}
+			if !bytes.Equal(gotBytes, wantBytes) {
+				t.Fatalf("canonical result mismatch\n got: %s\nwant: %s", gotBytes, wantBytes)
+			}
+			if got := LegacyStatus(result); got != expectedAxes.LegacyStatus {
+				t.Fatalf("LegacyStatus() = %q, want %q", got, expectedAxes.LegacyStatus)
+			}
+			digest, err := CanonicalResultDigest(result)
+			if err != nil {
+				t.Fatalf("CanonicalResultDigest() error = %v", err)
+			}
+			if testCase.ExpectedDigest == "" {
+				t.Errorf("expected_digest is empty; generated %s", digest)
+			} else if digest != testCase.ExpectedDigest {
+				t.Fatalf("digest = %q, want %q", digest, testCase.ExpectedDigest)
+			}
+		})
+	}
+}
+
+func TestObjectiveConformanceIsInvariantToInputOrder(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	for _, testCase := range fixture.Cases {
+		input := mergedFixtureValue[EvaluateInput](t, fixture.BaseInput, testCase.Input)
+		baseline, err := EvaluateObjective(input)
+		if err != nil {
+			t.Fatalf("%s baseline error = %v", testCase.Name, err)
+		}
+		baselineBytes, err := CanonicalResultBytes(baseline)
+		if err != nil {
+			t.Fatalf("%s baseline bytes error = %v", testCase.Name, err)
+		}
+		for iteration := 0; iteration < 32; iteration++ {
+			shuffled := cloneEvaluateInput(input)
+			rotateStrings(shuffled.FindingIDs, iteration)
+			rotateStrings(shuffled.SourceRuntimeIDs, iteration+1)
+			rotateAssessments(shuffled.RequirementAssessments, iteration+2)
+			for index := range shuffled.RequirementAssessments {
+				rotateStrings(shuffled.RequirementAssessments[index].EvidenceIDs, iteration+index)
+			}
+			result, err := EvaluateObjective(shuffled)
+			if err != nil {
+				t.Fatalf("%s iteration %d error = %v", testCase.Name, iteration, err)
+			}
+			data, err := CanonicalResultBytes(result)
+			if err != nil {
+				t.Fatalf("%s iteration %d bytes error = %v", testCase.Name, iteration, err)
+			}
+			if !bytes.Equal(data, baselineBytes) {
+				t.Fatalf("%s iteration %d changed canonical bytes", testCase.Name, iteration)
+			}
+		}
+	}
+}
+
+func loadConformanceFixture(t *testing.T) conformanceFixture {
+	t.Helper()
+	data, err := os.ReadFile("testdata/objective_conformance.json") // #nosec G304 -- fixed repository fixture path.
+	if err != nil {
+		t.Fatalf("read conformance fixture: %v", err)
+	}
+	var fixture conformanceFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("decode conformance fixture: %v", err)
+	}
+	return fixture
+}
+
+func mergedFixtureValue[T any](t *testing.T, base json.RawMessage, override json.RawMessage) T {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(base, &fields); err != nil {
+		t.Fatalf("decode fixture base: %v", err)
+	}
+	var overrides map[string]json.RawMessage
+	if len(override) != 0 {
+		if err := json.Unmarshal(override, &overrides); err != nil {
+			t.Fatalf("decode fixture override: %v", err)
+		}
+	}
+	for key, value := range overrides {
+		fields[key] = value
+	}
+	data, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal merged fixture: %v", err)
+	}
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("decode merged fixture: %v", err)
+	}
+	return result
+}
+
+func expectedFixtureResult(input EvaluateInput, expected fixtureExpected) ObjectiveResult {
+	evidenceIDs := []string{}
+	for _, assessment := range input.RequirementAssessments {
+		evidenceIDs = append(evidenceIDs, assessment.EvidenceIDs...)
+	}
+	return NormalizeResult(ObjectiveResult{
+		ID:                          input.ResultID,
+		ControlRef:                  input.Control,
+		ObjectiveID:                 input.ObjectiveID,
+		ScopeState:                  expected.ScopeState,
+		AutomatedOutcome:            expected.AutomatedOutcome,
+		DesignState:                 expected.DesignState,
+		OperatingEffectivenessState: expected.OperatingEffectivenessState,
+		EvidenceState:               expected.EvidenceState,
+		DispositionState:            expected.DispositionState,
+		Assurance:                   expected.Assurance,
+		AuditorState:                expected.AuditorState,
+		ReasonCodes:                 expected.ReasonCodes,
+		NextActions:                 expected.NextActions,
+		EvidenceIDs:                 evidenceIDs,
+		FindingIDs:                  input.FindingIDs,
+		SourceRuntimeIDs:            input.SourceRuntimeIDs,
+		EvaluatorRevision:           input.EvaluatorRevision,
+		EvaluatedAt:                 input.Now,
+	})
+}
+
+func cloneEvaluateInput(input EvaluateInput) EvaluateInput {
+	clone := input
+	clone.FindingIDs = append([]string(nil), input.FindingIDs...)
+	clone.SourceRuntimeIDs = append([]string(nil), input.SourceRuntimeIDs...)
+	clone.RequirementAssessments = append([]compliance.ControlEvidenceRequirementAssessment(nil), input.RequirementAssessments...)
+	for index := range clone.RequirementAssessments {
+		clone.RequirementAssessments[index].EvidenceIDs = append([]string(nil), input.RequirementAssessments[index].EvidenceIDs...)
+	}
+	return clone
+}
+
+func rotateStrings(values []string, count int) {
+	if len(values) < 2 {
+		return
+	}
+	count %= len(values)
+	rotated := append(append([]string(nil), values[count:]...), values[:count]...)
+	copy(values, rotated)
+}
+
+func rotateAssessments(values []compliance.ControlEvidenceRequirementAssessment, count int) {
+	if len(values) < 2 {
+		return
+	}
+	count %= len(values)
+	rotated := append(append([]compliance.ControlEvidenceRequirementAssessment(nil), values[count:]...), values[:count]...)
+	copy(values, rotated)
+}
+
+func TestFixtureNamesAreUnique(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	seen := map[string]struct{}{}
+	for _, testCase := range fixture.Cases {
+		if _, exists := seen[testCase.Name]; exists {
+			t.Fatalf("duplicate fixture name %q", testCase.Name)
+		}
+		seen[testCase.Name] = struct{}{}
+	}
+}

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -167,6 +167,15 @@ func ValidateEvaluateInput(input EvaluateInput) error {
 		return fmt.Errorf("%w: evaluation input contains an unknown required state", ErrInvalidResult)
 	}
 	for _, assessment := range input.RequirementAssessments {
+		if strings.TrimSpace(assessment.RequirementKey) == "" ||
+			strings.TrimSpace(assessment.ControlRef.ControlID) == "" ||
+			strings.TrimSpace(assessment.SourceID) == "" ||
+			strings.TrimSpace(assessment.EntityType) == "" {
+			return fmt.Errorf("%w: evidence requirement assessment identity and source binding are required", ErrInvalidResult)
+		}
+		if compliance.NormalizeControlRef(assessment.ControlRef) != input.Control {
+			return fmt.Errorf("%w: evidence requirement assessment control does not match the objective control", ErrInvalidResult)
+		}
 		switch assessment.Status {
 		case compliance.ControlEvidenceRequirementSatisfied,
 			compliance.ControlEvidenceRequirementManualReview,
@@ -175,6 +184,9 @@ func ValidateEvaluateInput(input EvaluateInput) error {
 			compliance.ControlEvidenceRequirementStale:
 		default:
 			return fmt.Errorf("%w: evaluation input contains unknown evidence requirement status %q", ErrInvalidResult, assessment.Status)
+		}
+		if assessment.Status == compliance.ControlEvidenceRequirementSatisfied && len(normalizedStrings(assessment.EvidenceIDs)) == 0 {
+			return fmt.Errorf("%w: satisfied evidence requirement assessment has no evidence", ErrInvalidResult)
 		}
 	}
 	return nil

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -1,0 +1,300 @@
+package complianceassessment
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+type EvaluateInput struct {
+	ResultID               string                                            `json:"result_id"`
+	ObjectiveID            string                                            `json:"objective_id"`
+	Control                compliance.ControlRef                             `json:"control_ref"`
+	ScopeState             ScopeState                                        `json:"scope_state"`
+	EvidenceIndex          *compliance.ControlEvidenceRequirementIndex       `json:"-"`
+	Evidence               []compliance.ControlEvidenceRequirementSignal     `json:"evidence,omitempty"`
+	RequirementAssessments []compliance.ControlEvidenceRequirementAssessment `json:"requirement_assessments,omitempty"`
+	CoverageState          CoverageState                                     `json:"coverage_state"`
+	SourceState            SourceState                                       `json:"source_state"`
+	SourceRuntimeIDs       []string                                          `json:"source_runtime_ids,omitempty"`
+	FindingIDs             []string                                          `json:"finding_ids,omitempty"`
+	InvalidEvidence        bool                                              `json:"invalid_evidence,omitempty"`
+	ConflictingEvidence    bool                                              `json:"conflicting_evidence,omitempty"`
+	DispositionState       DispositionState                                  `json:"disposition_state,omitempty"`
+	DesignState            DesignState                                       `json:"design_state,omitempty"`
+	OperatingState         OperatingEffectivenessState                       `json:"operating_effectiveness_state,omitempty"`
+	Inherited              bool                                              `json:"inherited,omitempty"`
+	Sampled                bool                                              `json:"sampled,omitempty"`
+	EvaluatorRevision      string                                            `json:"evaluator_revision"`
+	Now                    time.Time                                         `json:"now"`
+}
+
+// EvaluateObjective derives one deterministic, multi-axis result. Missing
+// coverage, evidence, or source trust always resolves to an explicit limitation;
+// an empty finding set is never sufficient to pass.
+func EvaluateObjective(input EvaluateInput) (ObjectiveResult, error) {
+	input = normalizeEvaluateInput(input)
+	if err := ValidateEvaluateInput(input); err != nil {
+		return ObjectiveResult{}, err
+	}
+	now := CanonicalTime(input.Now)
+	result := ObjectiveResult{
+		ID:                          strings.TrimSpace(input.ResultID),
+		ControlRef:                  input.Control,
+		ObjectiveID:                 strings.TrimSpace(input.ObjectiveID),
+		ScopeState:                  input.ScopeState,
+		AutomatedOutcome:            OutcomeIndeterminate,
+		DesignState:                 input.DesignState,
+		OperatingEffectivenessState: input.OperatingState,
+		EvidenceState:               EvidenceIncomplete,
+		DispositionState:            input.DispositionState,
+		Assurance:                   AssuranceNone,
+		AuditorState:                AuditorNotReviewed,
+		FindingIDs:                  input.FindingIDs,
+		SourceRuntimeIDs:            input.SourceRuntimeIDs,
+		EvaluatorRevision:           strings.TrimSpace(input.EvaluatorRevision),
+		EvaluatedAt:                 now,
+	}
+	if result.ScopeState == "" {
+		result.ScopeState = ScopeUnresolved
+	}
+	if result.DesignState == "" {
+		result.DesignState = DesignUnknown
+	}
+	if result.OperatingEffectivenessState == "" {
+		result.OperatingEffectivenessState = OperatingUnknown
+	}
+	if result.DispositionState == "" {
+		result.DispositionState = DispositionNone
+	}
+	assessments := append([]compliance.ControlEvidenceRequirementAssessment(nil), input.RequirementAssessments...)
+	if assessments == nil && input.EvidenceIndex != nil {
+		assessments = compliance.AssessControlEvidenceRequirements(compliance.ControlEvidenceRequirementAssessmentInput{
+			Index: input.EvidenceIndex, Control: input.Control, Evidence: input.Evidence, Now: now,
+		})
+	}
+	for _, assessment := range assessments {
+		result.EvidenceIDs = append(result.EvidenceIDs, assessment.EvidenceIDs...)
+	}
+
+	switch result.ScopeState {
+	case ScopeNotApplicable:
+		result.AutomatedOutcome = OutcomeNotAssessed
+		result.EvidenceState = EvidenceSufficient
+		result.DesignState = DesignNotAssessed
+		result.OperatingEffectivenessState = OperatingNotTested
+		result.ReasonCodes = append(result.ReasonCodes, ReasonNotApplicable)
+		result.NextActions = append(result.NextActions, ActionNone)
+		return validatedResult(result)
+	case ScopeUnresolved:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonScopeUnresolved)
+		result.NextActions = append(result.NextActions, ActionResolveScope)
+		return validatedResult(applyDisposition(NormalizeResult(result)))
+	}
+
+	evidenceState, reasons, actions := evaluateEvidence(assessments, input)
+	result.EvidenceState = evidenceState
+	result.ReasonCodes = append(result.ReasonCodes, reasons...)
+	result.NextActions = append(result.NextActions, actions...)
+	if len(result.FindingIDs) != 0 {
+		result.AutomatedOutcome = OutcomeNotSatisfied
+		result.ReasonCodes = append(result.ReasonCodes, ReasonActiveFinding)
+		result.NextActions = append(result.NextActions, ActionRemediate)
+		if result.DesignState == DesignUnknown {
+			result.DesignState = DesignIneffective
+		}
+		if result.OperatingEffectivenessState == OperatingUnknown {
+			result.OperatingEffectivenessState = OperatingIneffective
+		}
+	} else if evidenceState == EvidenceSufficient && input.CoverageState == CoverageComplete && input.SourceState == SourceSupported {
+		result.AutomatedOutcome = OutcomeSatisfied
+		result.ReasonCodes = append(result.ReasonCodes, ReasonSatisfied)
+		result.NextActions = append(result.NextActions, ActionNone)
+		if result.DesignState == DesignUnknown {
+			result.DesignState = DesignEffective
+		}
+		if result.OperatingEffectivenessState == OperatingUnknown {
+			result.OperatingEffectivenessState = OperatingEffective
+		}
+	} else {
+		result.AutomatedOutcome = OutcomeIndeterminate
+	}
+	if input.Inherited {
+		result.ReasonCodes = append(result.ReasonCodes, ReasonInheritedResponsibility)
+	}
+	if input.Sampled {
+		result.ReasonCodes = append(result.ReasonCodes, ReasonSampledTesting)
+	}
+	result.Assurance = deriveAssurance(result, input)
+	return validatedResult(applyDisposition(NormalizeResult(result)))
+}
+
+func normalizeEvaluateInput(input EvaluateInput) EvaluateInput {
+	input.ResultID = strings.TrimSpace(input.ResultID)
+	input.ObjectiveID = strings.TrimSpace(input.ObjectiveID)
+	input.Control = compliance.NormalizeControlRef(input.Control)
+	input.EvaluatorRevision = strings.TrimSpace(input.EvaluatorRevision)
+	input.Now = CanonicalTime(input.Now)
+	if input.ScopeState == "" {
+		input.ScopeState = ScopeUnresolved
+	}
+	if input.CoverageState == "" {
+		input.CoverageState = CoverageUnknown
+	}
+	if input.SourceState == "" {
+		input.SourceState = SourceUnknown
+	}
+	if input.DesignState == "" {
+		input.DesignState = DesignUnknown
+	}
+	if input.OperatingState == "" {
+		input.OperatingState = OperatingUnknown
+	}
+	if input.DispositionState == "" {
+		input.DispositionState = DispositionNone
+	}
+	return input
+}
+
+func ValidateEvaluateInput(input EvaluateInput) error {
+	if input.ResultID == "" || input.ObjectiveID == "" || strings.TrimSpace(input.Control.ControlID) == "" || input.EvaluatorRevision == "" || input.Now.IsZero() {
+		return fmt.Errorf("%w: result, objective, control, evaluator revision, and now are required", ErrInvalidResult)
+	}
+	if !knownScopeState(input.ScopeState) || !knownCoverageState(input.CoverageState) || !knownSourceState(input.SourceState) ||
+		!knownDesignState(input.DesignState) || !knownOperatingState(input.OperatingState) || !knownDispositionState(input.DispositionState) {
+		return fmt.Errorf("%w: evaluation input contains an unknown required state", ErrInvalidResult)
+	}
+	for _, assessment := range input.RequirementAssessments {
+		switch assessment.Status {
+		case compliance.ControlEvidenceRequirementSatisfied,
+			compliance.ControlEvidenceRequirementManualReview,
+			compliance.ControlEvidenceRequirementMissing,
+			compliance.ControlEvidenceRequirementMissingField,
+			compliance.ControlEvidenceRequirementStale:
+		default:
+			return fmt.Errorf("%w: evaluation input contains unknown evidence requirement status %q", ErrInvalidResult, assessment.Status)
+		}
+	}
+	return nil
+}
+
+func validatedResult(result ObjectiveResult) (ObjectiveResult, error) {
+	result = NormalizeResult(result)
+	if err := ValidateObjectiveResult(result); err != nil {
+		return ObjectiveResult{}, err
+	}
+	return result, nil
+}
+
+func evaluateEvidence(assessments []compliance.ControlEvidenceRequirementAssessment, input EvaluateInput) (EvidenceState, []ReasonCode, []NextAction) {
+	if input.ConflictingEvidence || input.SourceState == SourceConflicting {
+		return EvidenceConflicting, []ReasonCode{ReasonEvidenceConflicting}, []NextAction{ActionReview}
+	}
+	if input.InvalidEvidence {
+		return EvidenceUntrusted, []ReasonCode{ReasonEvidenceInvalid}, []NextAction{ActionReview}
+	}
+	switch input.SourceState {
+	case SourceUnverified:
+		return EvidenceUntrusted, []ReasonCode{ReasonSourceUntrusted}, []NextAction{ActionReview}
+	case SourceUnconfigured:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnconfigured}, []NextAction{ActionRestoreSource}
+	case SourceUnsupported:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnsupported}, []NextAction{ActionRestoreSource}
+	case SourceFailed:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceFailed}, []NextAction{ActionRestoreSource}
+	case SourcePartial:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourcePartial}, []NextAction{ActionRestoreSource}
+	case SourceStale:
+		return EvidenceStale, []ReasonCode{ReasonSourceStale}, []NextAction{ActionRefreshEvidence}
+	case SourceUnknown:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnknown}, []NextAction{ActionRestoreSource}
+	}
+	if input.CoverageState == CoverageEmpty {
+		return EvidenceIncomplete, []ReasonCode{ReasonPopulationEmpty}, []NextAction{ActionCollectEvidence}
+	}
+	if input.CoverageState != CoverageComplete {
+		return EvidenceIncomplete, []ReasonCode{ReasonCoverageIncomplete}, []NextAction{ActionCollectEvidence}
+	}
+	if len(assessments) == 0 {
+		return EvidenceMissing, []ReasonCode{ReasonEvidenceMissing}, []NextAction{ActionCollectEvidence}
+	}
+	state := EvidenceSufficient
+	var reasons []ReasonCode
+	var actions []NextAction
+	for _, assessment := range assessments {
+		switch assessment.Status {
+		case compliance.ControlEvidenceRequirementSatisfied:
+		case compliance.ControlEvidenceRequirementManualReview:
+			state = strongestEvidenceState(state, EvidenceManualReview)
+			reasons = append(reasons, ReasonManualEvidence)
+			actions = append(actions, ActionReview)
+		case compliance.ControlEvidenceRequirementStale:
+			state = strongestEvidenceState(state, EvidenceStale)
+			reasons = append(reasons, ReasonEvidenceStale)
+			actions = append(actions, ActionRefreshEvidence)
+		case compliance.ControlEvidenceRequirementMissingField:
+			state = strongestEvidenceState(state, EvidenceIncomplete)
+			reasons = append(reasons, ReasonEvidenceInvalid)
+			actions = append(actions, ActionCollectEvidence)
+		case compliance.ControlEvidenceRequirementMissing:
+			state = strongestEvidenceState(state, EvidenceMissing)
+			reasons = append(reasons, ReasonEvidenceMissing)
+			actions = append(actions, ActionCollectEvidence)
+		default:
+			state = strongestEvidenceState(state, EvidenceManualReview)
+			reasons = append(reasons, ReasonEvidenceInvalid)
+			actions = append(actions, ActionReview)
+		}
+	}
+	return state, reasons, actions
+}
+
+func strongestEvidenceState(left, right EvidenceState) EvidenceState {
+	rank := map[EvidenceState]int{
+		EvidenceSufficient: 0, EvidenceManualReview: 1, EvidenceStale: 2,
+		EvidenceMissing: 3, EvidenceIncomplete: 4, EvidenceUntrusted: 5, EvidenceConflicting: 6,
+	}
+	if rank[right] > rank[left] {
+		return right
+	}
+	return left
+}
+
+func deriveAssurance(result ObjectiveResult, input EvaluateInput) Assurance {
+	if result.AutomatedOutcome == OutcomeSatisfied && result.EvidenceState == EvidenceSufficient {
+		if input.Inherited || input.Sampled {
+			return AssuranceMedium
+		}
+		return AssuranceHigh
+	}
+	if result.AutomatedOutcome == OutcomeNotSatisfied && result.EvidenceState == EvidenceSufficient {
+		return AssuranceHigh
+	}
+	if result.EvidenceState == EvidenceManualReview || result.EvidenceState == EvidenceStale {
+		return AssuranceLow
+	}
+	return AssuranceNone
+}
+
+func applyDisposition(result ObjectiveResult) ObjectiveResult {
+	switch result.DispositionState {
+	case DispositionAcceptedException:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonAcceptedException)
+		result.NextActions = append(result.NextActions, ActionRetest)
+	case DispositionAcceptedRisk:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonAcceptedRisk)
+		result.NextActions = append(result.NextActions, ActionRetest)
+	}
+	return NormalizeResult(result)
+}
+
+func sortResults(results []ObjectiveResult) {
+	sort.Slice(results, func(i, j int) bool {
+		left, right := results[i], results[j]
+		return left.ControlRef.FrameworkID+"\x00"+left.ControlRef.ControlID+"\x00"+left.ObjectiveID+"\x00"+left.ID <
+			right.ControlRef.FrameworkID+"\x00"+right.ControlRef.ControlID+"\x00"+right.ObjectiveID+"\x00"+right.ID
+	})
+}

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -2,7 +2,6 @@ package complianceassessment
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -289,12 +288,4 @@ func applyDisposition(result ObjectiveResult) ObjectiveResult {
 		result.NextActions = append(result.NextActions, ActionRetest)
 	}
 	return NormalizeResult(result)
-}
-
-func sortResults(results []ObjectiveResult) {
-	sort.Slice(results, func(i, j int) bool {
-		left, right := results[i], results[j]
-		return left.ControlRef.FrameworkID+"\x00"+left.ControlRef.ControlID+"\x00"+left.ObjectiveID+"\x00"+left.ID <
-			right.ControlRef.FrameworkID+"\x00"+right.ControlRef.ControlID+"\x00"+right.ObjectiveID+"\x00"+right.ID
-	})
 }

--- a/internal/complianceassessment/legacy_status.go
+++ b/internal/complianceassessment/legacy_status.go
@@ -1,0 +1,38 @@
+package complianceassessment
+
+const (
+	LegacyStatusNotApplicable   = "not_applicable"
+	LegacyStatusException       = "exception"
+	LegacyStatusFailing         = "failing"
+	LegacyStatusMissingEvidence = "missing_evidence"
+	LegacyStatusStaleEvidence   = "stale_evidence"
+	LegacyStatusManualReview    = "manual_review"
+	LegacyStatusPassing         = "passing"
+)
+
+// LegacyStatus preserves the existing caller precedence while the canonical
+// result retains independent automation, evidence, and disposition axes.
+func LegacyStatus(result ObjectiveResult) string {
+	if result.ScopeState == ScopeNotApplicable {
+		return LegacyStatusNotApplicable
+	}
+	if result.DispositionState == DispositionAcceptedException || result.DispositionState == DispositionAcceptedRisk {
+		return LegacyStatusException
+	}
+	if result.AutomatedOutcome == OutcomeNotSatisfied {
+		return LegacyStatusFailing
+	}
+	switch result.EvidenceState {
+	case EvidenceMissing, EvidenceIncomplete:
+		return LegacyStatusMissingEvidence
+	case EvidenceStale:
+		return LegacyStatusStaleEvidence
+	case EvidenceManualReview, EvidenceConflicting, EvidenceUntrusted:
+		return LegacyStatusManualReview
+	case EvidenceSufficient:
+		if result.AutomatedOutcome == OutcomeSatisfied {
+			return LegacyStatusPassing
+		}
+	}
+	return LegacyStatusManualReview
+}

--- a/internal/complianceassessment/legacy_status_test.go
+++ b/internal/complianceassessment/legacy_status_test.go
@@ -1,0 +1,26 @@
+package complianceassessment
+
+import "testing"
+
+func TestLegacyStatusPreservesExistingPrecedence(t *testing.T) {
+	result := validObjectiveResult()
+	result.ScopeState = ScopeNotApplicable
+	result.DispositionState = DispositionAcceptedException
+	result.AutomatedOutcome = OutcomeNotSatisfied
+	result.EvidenceState = EvidenceMissing
+	if got := LegacyStatus(result); got != LegacyStatusNotApplicable {
+		t.Fatalf("not applicable precedence = %q", got)
+	}
+	result.ScopeState = ScopeInScope
+	if got := LegacyStatus(result); got != LegacyStatusException {
+		t.Fatalf("exception precedence = %q", got)
+	}
+	result.DispositionState = DispositionNone
+	if got := LegacyStatus(result); got != LegacyStatusFailing {
+		t.Fatalf("failing precedence = %q", got)
+	}
+	result.AutomatedOutcome = OutcomeIndeterminate
+	if got := LegacyStatus(result); got != LegacyStatusMissingEvidence {
+		t.Fatalf("missing evidence precedence = %q", got)
+	}
+}

--- a/internal/complianceassessment/testdata/objective_conformance.json
+++ b/internal/complianceassessment/testdata/objective_conformance.json
@@ -5,7 +5,7 @@
     "objective_id": "objective-1",
     "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"},
     "scope_state": "in_scope",
-    "requirement_assessments": [{"status": "satisfied", "evidence_ids": ["evidence-1"]}],
+    "requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "satisfied", "evidence_ids": ["evidence-1"]}],
     "coverage_state": "complete",
     "source_state": "supported",
     "source_runtime_ids": ["runtime-1"],
@@ -47,7 +47,7 @@
     },
     {
       "name": "stale_evidence",
-      "input": {"requirement_assessments": [{"status": "stale", "evidence_ids": ["evidence-1"]}]},
+      "input": {"requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "stale", "evidence_ids": ["evidence-1"]}]},
       "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "stale", "assurance": "low", "reason_codes": ["evidence_stale"], "next_actions": ["refresh_evidence"], "legacy_status": "stale_evidence"},
       "expected_digest": "sha256:06e1ea29fa9a5ba7e5119e2c89a1006bbe2dbd61315da9bc52579475b7cf261c"
     },
@@ -77,7 +77,7 @@
     },
     {
       "name": "manual_evidence",
-      "input": {"requirement_assessments": [{"status": "manual_review", "evidence_ids": ["evidence-1"]}]},
+      "input": {"requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "manual_review", "evidence_ids": ["evidence-1"]}]},
       "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "manual_review", "assurance": "low", "reason_codes": ["manual_evidence_review"], "next_actions": ["review"], "legacy_status": "manual_review"},
       "expected_digest": "sha256:a447dfee1c8cf7373aea662d94c746cfe49d97a97b280fee29c161d060eab786"
     },

--- a/internal/complianceassessment/testdata/objective_conformance.json
+++ b/internal/complianceassessment/testdata/objective_conformance.json
@@ -1,0 +1,121 @@
+{
+  "version": "compliance-assessment-conformance/v1",
+  "base_input": {
+    "result_id": "assessment-result-00000000000000000000000000000001",
+    "objective_id": "objective-1",
+    "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"},
+    "scope_state": "in_scope",
+    "requirement_assessments": [{"status": "satisfied", "evidence_ids": ["evidence-1"]}],
+    "coverage_state": "complete",
+    "source_state": "supported",
+    "source_runtime_ids": ["runtime-1"],
+    "evaluator_revision": "evaluator-v1",
+    "now": "2026-07-11T12:00:00.123456789Z"
+  },
+  "base_expected": {
+    "scope_state": "in_scope",
+    "automated_outcome": "satisfied",
+    "design_state": "effective",
+    "operating_effectiveness_state": "effective",
+    "evidence_state": "sufficient",
+    "disposition_state": "none",
+    "assurance": "high",
+    "auditor_state": "not_reviewed",
+    "reason_codes": ["assessment_satisfied"],
+    "next_actions": ["none"],
+    "legacy_status": "passing"
+  },
+  "cases": [
+    {"name": "pass", "input": {}, "expected": {}, "expected_digest": "sha256:aa8a2d895d281a61d20b63c855fd2fa37aba64a65446ced6f8955acacd8c2992"},
+    {
+      "name": "active_finding",
+      "input": {"finding_ids": ["finding-1"]},
+      "expected": {"automated_outcome": "not_satisfied", "design_state": "ineffective", "operating_effectiveness_state": "ineffective", "reason_codes": ["active_finding"], "next_actions": ["remediate"], "legacy_status": "failing"},
+      "expected_digest": "sha256:198812615976bf6380f497efd52c8f54841f326469d4a01614ab3ecdf4ea4168"
+    },
+    {
+      "name": "missing_evidence",
+      "input": {"requirement_assessments": []},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "missing", "assurance": "none", "reason_codes": ["evidence_missing"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:54264f10f4f4efab1705634b27510ffc958a80645f18d93598c893b77f2d9f35"
+    },
+    {
+      "name": "invalid_evidence",
+      "input": {"invalid_evidence": true},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "untrusted", "assurance": "none", "reason_codes": ["evidence_invalid"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:e2722f0ddfccb8c114cdb33a35bfd0aad9afd42004b50b0ef0bd4f9e3620150a"
+    },
+    {
+      "name": "stale_evidence",
+      "input": {"requirement_assessments": [{"status": "stale", "evidence_ids": ["evidence-1"]}]},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "stale", "assurance": "low", "reason_codes": ["evidence_stale"], "next_actions": ["refresh_evidence"], "legacy_status": "stale_evidence"},
+      "expected_digest": "sha256:06e1ea29fa9a5ba7e5119e2c89a1006bbe2dbd61315da9bc52579475b7cf261c"
+    },
+    {
+      "name": "conflicting_evidence",
+      "input": {"conflicting_evidence": true},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "conflicting", "assurance": "none", "reason_codes": ["evidence_conflicting"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:b7e40a786e56bfb861b13f5c41ff1340c1bb664bbf8862f2f31a226e0bce9742"
+    },
+    {
+      "name": "insufficient_coverage",
+      "input": {"coverage_state": "partial"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["coverage_incomplete"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:39a2db74de27785831955518f8bf0d53186a04f5b4e86a17e1f4bcc79cd5672f"
+    },
+    {
+      "name": "untrusted_source",
+      "input": {"source_state": "unverified"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "untrusted", "assurance": "none", "reason_codes": ["source_untrusted"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:4461d5e7adffda425a8109667d44c95a9f3dc52b1334900a593ec42105bbf764"
+    },
+    {
+      "name": "unknown_source_trust",
+      "input": {"source_state": "unknown"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["source_trust_unknown"], "next_actions": ["restore_source"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:433f8d418ccd407220aabaede7acf6e24051e6235f7cf4a6742b3726df40a694"
+    },
+    {
+      "name": "manual_evidence",
+      "input": {"requirement_assessments": [{"status": "manual_review", "evidence_ids": ["evidence-1"]}]},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "manual_review", "assurance": "low", "reason_codes": ["manual_evidence_review"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:a447dfee1c8cf7373aea662d94c746cfe49d97a97b280fee29c161d060eab786"
+    },
+    {
+      "name": "accepted_exception",
+      "input": {"requirement_assessments": [], "disposition_state": "accepted_exception"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "missing", "disposition_state": "accepted_exception", "assurance": "none", "reason_codes": ["accepted_exception", "evidence_missing"], "next_actions": ["collect_evidence", "retest"], "legacy_status": "exception"},
+      "expected_digest": "sha256:e6fcb3ebbe4e87e16280bb0dfd733e111bfecc7019731d1a499e9f0e0139ffec"
+    },
+    {
+      "name": "not_applicable",
+      "input": {"scope_state": "not_applicable", "requirement_assessments": [], "coverage_state": "unknown", "source_state": "unknown"},
+      "expected": {"scope_state": "not_applicable", "automated_outcome": "not_assessed", "design_state": "not_assessed", "operating_effectiveness_state": "not_tested", "evidence_state": "sufficient", "assurance": "none", "reason_codes": ["not_applicable"], "next_actions": ["none"], "legacy_status": "not_applicable"},
+      "expected_digest": "sha256:ae8ae1b84fac40ac390cbad3296b2c7e7e5de2e4f7854098b844e4b7ef33fbb7"
+    },
+    {
+      "name": "inherited_responsibility",
+      "input": {"inherited": true},
+      "expected": {"assurance": "medium", "reason_codes": ["assessment_satisfied", "inherited_responsibility"]},
+      "expected_digest": "sha256:667aafa34b03e54d6614bf72d615472b84021498c53c32db11d135cbaba20646"
+    },
+    {
+      "name": "sampled_testing",
+      "input": {"sampled": true},
+      "expected": {"assurance": "medium", "reason_codes": ["assessment_satisfied", "sampled_testing"]},
+      "expected_digest": "sha256:04f8705f2effaf18c64b323ae3820aec1156e250df6a4a75eafb4eb9b289be92"
+    },
+    {
+      "name": "no_configured_source",
+      "input": {"source_state": "unconfigured"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["source_unconfigured"], "next_actions": ["restore_source"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:9ec2b209ed153bae1d18fc647ea6699f36a91c1cdd53ffed418d242416dad3a7"
+    },
+    {
+      "name": "empty_population_with_satisfied_evidence",
+      "input": {"coverage_state": "empty"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["population_empty"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:992703e2b87bdee82adecf50d8c791bb2c6774f88c6548871292408834affc1d"
+    }
+  ]
+}

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -1,0 +1,538 @@
+package complianceassessment
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+var (
+	ErrInvalidCanonicalValue = errors.New("invalid canonical compliance value")
+	ErrInvalidManifest       = errors.New("invalid compliance input manifest")
+	ErrInvalidResult         = errors.New("invalid compliance objective result")
+)
+
+const (
+	CanonicalModelVersion = "compliance-assessment/v1"
+	ReasonRegistryVersion = "compliance-reasons/v1"
+	LegacyAdapterVersion  = "compliance-legacy-status/v1"
+)
+
+type ScopeState string
+
+const (
+	ScopeInScope       ScopeState = "in_scope"
+	ScopeNotApplicable ScopeState = "not_applicable"
+	ScopeUnresolved    ScopeState = "unresolved"
+)
+
+type AutomatedOutcome string
+
+const (
+	OutcomeSatisfied     AutomatedOutcome = "satisfied"
+	OutcomeNotSatisfied  AutomatedOutcome = "not_satisfied"
+	OutcomeIndeterminate AutomatedOutcome = "indeterminate"
+	OutcomeNotAssessed   AutomatedOutcome = "not_assessed"
+)
+
+type DesignState string
+
+const (
+	DesignEffective   DesignState = "effective"
+	DesignIneffective DesignState = "ineffective"
+	DesignUnknown     DesignState = "unknown"
+	DesignNotAssessed DesignState = "not_assessed"
+)
+
+type OperatingEffectivenessState string
+
+const (
+	OperatingEffective   OperatingEffectivenessState = "effective"
+	OperatingIneffective OperatingEffectivenessState = "ineffective"
+	OperatingUnknown     OperatingEffectivenessState = "unknown"
+	OperatingNotTested   OperatingEffectivenessState = "not_tested"
+)
+
+type EvidenceState string
+
+const (
+	EvidenceSufficient   EvidenceState = "sufficient"
+	EvidenceMissing      EvidenceState = "missing"
+	EvidenceStale        EvidenceState = "stale"
+	EvidenceConflicting  EvidenceState = "conflicting"
+	EvidenceUntrusted    EvidenceState = "untrusted"
+	EvidenceIncomplete   EvidenceState = "incomplete"
+	EvidenceManualReview EvidenceState = "manual_review"
+)
+
+type DispositionState string
+
+const (
+	DispositionNone              DispositionState = "none"
+	DispositionAcceptedException DispositionState = "accepted_exception"
+	DispositionAcceptedRisk      DispositionState = "accepted_risk"
+	DispositionReviewOverride    DispositionState = "review_override"
+)
+
+type Assurance string
+
+const (
+	AssuranceHigh   Assurance = "high"
+	AssuranceMedium Assurance = "medium"
+	AssuranceLow    Assurance = "low"
+	AssuranceNone   Assurance = "none"
+)
+
+type AuditorState string
+
+const (
+	AuditorNotReviewed      AuditorState = "not_reviewed"
+	AuditorAccepted         AuditorState = "accepted"
+	AuditorChangesRequested AuditorState = "changes_requested"
+	AuditorRejected         AuditorState = "rejected"
+)
+
+type CoverageState string
+
+const (
+	CoverageComplete CoverageState = "complete"
+	CoveragePartial  CoverageState = "partial"
+	CoverageEmpty    CoverageState = "empty"
+	CoverageUnknown  CoverageState = "unknown"
+)
+
+type SourceState string
+
+const (
+	SourceSupported    SourceState = "supported"
+	SourcePartial      SourceState = "partial"
+	SourceStale        SourceState = "stale"
+	SourceFailed       SourceState = "failed"
+	SourceUnconfigured SourceState = "unconfigured"
+	SourceUnsupported  SourceState = "unsupported"
+	SourceUnverified   SourceState = "unverified"
+	SourceConflicting  SourceState = "conflicting"
+	SourceUnknown      SourceState = "unknown"
+)
+
+type ReasonCode string
+
+const (
+	ReasonSatisfied               ReasonCode = "assessment_satisfied"
+	ReasonActiveFinding           ReasonCode = "active_finding"
+	ReasonEvidenceMissing         ReasonCode = "evidence_missing"
+	ReasonEvidenceInvalid         ReasonCode = "evidence_invalid"
+	ReasonEvidenceStale           ReasonCode = "evidence_stale"
+	ReasonEvidenceConflicting     ReasonCode = "evidence_conflicting"
+	ReasonCoverageIncomplete      ReasonCode = "coverage_incomplete"
+	ReasonSourceUntrusted         ReasonCode = "source_untrusted"
+	ReasonSourceUnknown           ReasonCode = "source_trust_unknown"
+	ReasonManualEvidence          ReasonCode = "manual_evidence_review"
+	ReasonAcceptedException       ReasonCode = "accepted_exception"
+	ReasonAcceptedRisk            ReasonCode = "accepted_risk"
+	ReasonNotApplicable           ReasonCode = "not_applicable"
+	ReasonInheritedResponsibility ReasonCode = "inherited_responsibility"
+	ReasonSampledTesting          ReasonCode = "sampled_testing"
+	ReasonSourceUnconfigured      ReasonCode = "source_unconfigured"
+	ReasonSourceUnsupported       ReasonCode = "source_unsupported"
+	ReasonSourcePartial           ReasonCode = "source_partial"
+	ReasonSourceFailed            ReasonCode = "source_failed"
+	ReasonSourceStale             ReasonCode = "source_stale"
+	ReasonScopeUnresolved         ReasonCode = "scope_unresolved"
+	ReasonPopulationEmpty         ReasonCode = "population_empty"
+)
+
+type NextAction string
+
+const (
+	ActionNone            NextAction = "none"
+	ActionReview          NextAction = "review"
+	ActionCollectEvidence NextAction = "collect_evidence"
+	ActionRefreshEvidence NextAction = "refresh_evidence"
+	ActionRestoreSource   NextAction = "restore_source"
+	ActionResolveScope    NextAction = "resolve_scope"
+	ActionRemediate       NextAction = "remediate"
+	ActionRetest          NextAction = "retest"
+)
+
+type CollectionCompleteness string
+
+const (
+	CollectionComplete          CollectionCompleteness = "complete"
+	CollectionPartial           CollectionCompleteness = "partial"
+	CollectionTruncated         CollectionCompleteness = "truncated"
+	CollectionChangedDuringScan CollectionCompleteness = "changed_during_scan"
+	CollectionUnknown           CollectionCompleteness = "unknown"
+)
+
+// ManifestRevision pins one semantic input used by an assessment run.
+type ManifestRevision struct {
+	Kind       string `json:"kind"`
+	ID         string `json:"id"`
+	RevisionID string `json:"revision_id"`
+	Version    uint64 `json:"version"`
+	Digest     string `json:"digest"`
+}
+
+type CollectionReceipt struct {
+	Kind          string                 `json:"kind"`
+	RuntimeID     string                 `json:"runtime_id,omitempty"`
+	QueryDigest   string                 `json:"query_digest"`
+	PageIndex     uint32                 `json:"page_index"`
+	Cursor        string                 `json:"cursor,omitempty"`
+	NextCursor    string                 `json:"next_cursor,omitempty"`
+	RawCount      uint64                 `json:"raw_count"`
+	Deduplicated  uint64                 `json:"deduplicated_count"`
+	Included      uint64                 `json:"included_count"`
+	Excluded      uint64                 `json:"excluded_count"`
+	ExpectedTotal *uint64                `json:"expected_total,omitempty"`
+	FirstKey      string                 `json:"first_key,omitempty"`
+	LastKey       string                 `json:"last_key,omitempty"`
+	Watermark     time.Time              `json:"watermark"`
+	Cutoff        time.Time              `json:"cutoff"`
+	Completeness  CollectionCompleteness `json:"completeness"`
+	PageDigest    string                 `json:"page_digest"`
+}
+
+// InputManifest pins every revision and collection receipt needed to reproduce
+// one automated assessment result.
+type InputManifest struct {
+	ModelVersion               string              `json:"model_version"`
+	ProgramID                  string              `json:"program_id"`
+	ScopeRevisionID            string              `json:"scope_revision_id"`
+	PlanRevisionID             string              `json:"plan_revision_id"`
+	PeriodStart                time.Time           `json:"period_start"`
+	PeriodEnd                  time.Time           `json:"period_end"`
+	CollectionCutoff           time.Time           `json:"collection_cutoff"`
+	RequestedScopeDigest       string              `json:"requested_scope_digest"`
+	ResolvedObjectiveSetDigest string              `json:"resolved_objective_set_digest"`
+	MappingSetDigest           string              `json:"mapping_set_digest"`
+	Revisions                  []ManifestRevision  `json:"revisions"`
+	Receipts                   []CollectionReceipt `json:"receipts"`
+	EvaluationRunIDs           []string            `json:"evaluation_run_ids,omitempty"`
+	ReasonRegistry             string              `json:"reason_registry"`
+	AdapterVersion             string              `json:"adapter_version"`
+}
+
+type ObjectiveResult struct {
+	ID                          string                      `json:"id"`
+	ControlRef                  compliance.ControlRef       `json:"control_ref"`
+	ObjectiveID                 string                      `json:"objective_id"`
+	ScopeState                  ScopeState                  `json:"scope_state"`
+	AutomatedOutcome            AutomatedOutcome            `json:"automated_outcome"`
+	DesignState                 DesignState                 `json:"design_state"`
+	OperatingEffectivenessState OperatingEffectivenessState `json:"operating_effectiveness_state"`
+	EvidenceState               EvidenceState               `json:"evidence_state"`
+	DispositionState            DispositionState            `json:"disposition_state"`
+	Assurance                   Assurance                   `json:"assurance"`
+	AuditorState                AuditorState                `json:"auditor_state"`
+	ReasonCodes                 []ReasonCode                `json:"reason_codes"`
+	NextActions                 []NextAction                `json:"next_actions"`
+	EvidenceIDs                 []string                    `json:"evidence_ids,omitempty"`
+	FindingIDs                  []string                    `json:"finding_ids,omitempty"`
+	SourceRuntimeIDs            []string                    `json:"source_runtime_ids,omitempty"`
+	EvaluatorRevision           string                      `json:"evaluator_revision"`
+	EvaluatedAt                 time.Time                   `json:"evaluated_at"`
+}
+
+func NormalizeManifest(value InputManifest) InputManifest {
+	if strings.TrimSpace(value.ModelVersion) == "" {
+		value.ModelVersion = CanonicalModelVersion
+	}
+	if strings.TrimSpace(value.ReasonRegistry) == "" {
+		value.ReasonRegistry = ReasonRegistryVersion
+	}
+	if strings.TrimSpace(value.AdapterVersion) == "" {
+		value.AdapterVersion = LegacyAdapterVersion
+	}
+	value.ModelVersion = strings.TrimSpace(value.ModelVersion)
+	value.ProgramID = strings.TrimSpace(value.ProgramID)
+	value.ScopeRevisionID = strings.TrimSpace(value.ScopeRevisionID)
+	value.PlanRevisionID = strings.TrimSpace(value.PlanRevisionID)
+	value.RequestedScopeDigest = strings.TrimSpace(value.RequestedScopeDigest)
+	value.ResolvedObjectiveSetDigest = strings.TrimSpace(value.ResolvedObjectiveSetDigest)
+	value.MappingSetDigest = strings.TrimSpace(value.MappingSetDigest)
+	value.ReasonRegistry = strings.TrimSpace(value.ReasonRegistry)
+	value.AdapterVersion = strings.TrimSpace(value.AdapterVersion)
+	value.PeriodStart = CanonicalTime(value.PeriodStart)
+	value.PeriodEnd = CanonicalTime(value.PeriodEnd)
+	value.CollectionCutoff = CanonicalTime(value.CollectionCutoff)
+	value.Revisions = append([]ManifestRevision(nil), value.Revisions...)
+	for index := range value.Revisions {
+		value.Revisions[index].Kind = strings.TrimSpace(value.Revisions[index].Kind)
+		value.Revisions[index].ID = strings.TrimSpace(value.Revisions[index].ID)
+		value.Revisions[index].RevisionID = strings.TrimSpace(value.Revisions[index].RevisionID)
+		value.Revisions[index].Digest = strings.TrimSpace(value.Revisions[index].Digest)
+	}
+	sort.Slice(value.Revisions, func(i, j int) bool {
+		left, right := value.Revisions[i], value.Revisions[j]
+		return left.Kind+"\x00"+left.ID+"\x00"+left.RevisionID < right.Kind+"\x00"+right.ID+"\x00"+right.RevisionID
+	})
+	value.Revisions = deduplicateManifestRevisions(value.Revisions)
+	value.Receipts = append([]CollectionReceipt(nil), value.Receipts...)
+	for index := range value.Receipts {
+		receipt := &value.Receipts[index]
+		receipt.Kind = strings.TrimSpace(receipt.Kind)
+		receipt.RuntimeID = strings.TrimSpace(receipt.RuntimeID)
+		receipt.QueryDigest = strings.TrimSpace(receipt.QueryDigest)
+		receipt.Cursor = strings.TrimSpace(receipt.Cursor)
+		receipt.NextCursor = strings.TrimSpace(receipt.NextCursor)
+		receipt.FirstKey = strings.TrimSpace(receipt.FirstKey)
+		receipt.LastKey = strings.TrimSpace(receipt.LastKey)
+		receipt.PageDigest = strings.TrimSpace(receipt.PageDigest)
+		receipt.Watermark = CanonicalTime(receipt.Watermark)
+		receipt.Cutoff = CanonicalTime(receipt.Cutoff)
+	}
+	sort.Slice(value.Receipts, func(i, j int) bool {
+		left, right := value.Receipts[i], value.Receipts[j]
+		if left.Kind+"\x00"+left.RuntimeID != right.Kind+"\x00"+right.RuntimeID {
+			return left.Kind+"\x00"+left.RuntimeID < right.Kind+"\x00"+right.RuntimeID
+		}
+		if left.PageIndex != right.PageIndex {
+			return left.PageIndex < right.PageIndex
+		}
+		return left.PageDigest < right.PageDigest
+	})
+	value.Receipts = deduplicateCollectionReceipts(value.Receipts)
+	value.EvaluationRunIDs = normalizedStrings(value.EvaluationRunIDs)
+	return value
+}
+
+func NormalizeResult(value ObjectiveResult) ObjectiveResult {
+	value.ID = strings.TrimSpace(value.ID)
+	value.ControlRef = compliance.NormalizeControlRef(value.ControlRef)
+	value.ObjectiveID = strings.TrimSpace(value.ObjectiveID)
+	value.EvaluatorRevision = strings.TrimSpace(value.EvaluatorRevision)
+	value.ReasonCodes = normalizedEnums(value.ReasonCodes)
+	value.NextActions = normalizedEnums(value.NextActions)
+	value.EvidenceIDs = normalizedStrings(value.EvidenceIDs)
+	value.FindingIDs = normalizedStrings(value.FindingIDs)
+	value.SourceRuntimeIDs = normalizedStrings(value.SourceRuntimeIDs)
+	value.EvaluatedAt = CanonicalTime(value.EvaluatedAt)
+	return value
+}
+
+func ValidateInputManifest(value InputManifest) error {
+	value = NormalizeManifest(value)
+	if value.ModelVersion != CanonicalModelVersion {
+		return fmt.Errorf("%w: unsupported model_version %q", ErrInvalidManifest, value.ModelVersion)
+	}
+	if value.ProgramID == "" || value.ScopeRevisionID == "" || value.PlanRevisionID == "" {
+		return fmt.Errorf("%w: program, scope revision, and plan revision are required", ErrInvalidManifest)
+	}
+	if value.PeriodStart.IsZero() || value.PeriodEnd.IsZero() || value.CollectionCutoff.IsZero() || value.PeriodEnd.Before(value.PeriodStart) {
+		return fmt.Errorf("%w: valid period and collection cutoff are required", ErrInvalidManifest)
+	}
+	for _, digest := range []string{value.RequestedScopeDigest, value.ResolvedObjectiveSetDigest, value.MappingSetDigest} {
+		if err := compliance.ValidateContentDigest(compliance.ContentDigest(digest)); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidManifest, err)
+		}
+	}
+	if len(value.Revisions) == 0 || len(value.Receipts) == 0 {
+		return fmt.Errorf("%w: revisions and collection receipts are required", ErrInvalidManifest)
+	}
+	for index, revision := range value.Revisions {
+		if revision.Kind == "" || revision.ID == "" || revision.RevisionID == "" || revision.Version == 0 {
+			return fmt.Errorf("%w: revisions[%d] is incomplete", ErrInvalidManifest, index)
+		}
+		if err := compliance.ValidateContentDigest(compliance.ContentDigest(revision.Digest)); err != nil {
+			return fmt.Errorf("%w: revisions[%d]: %v", ErrInvalidManifest, index, err)
+		}
+		if index > 0 {
+			previous := value.Revisions[index-1]
+			if previous.Kind == revision.Kind && previous.ID == revision.ID && previous.RevisionID == revision.RevisionID {
+				return fmt.Errorf("%w: conflicting duplicate revision %q", ErrInvalidManifest, revision.RevisionID)
+			}
+		}
+	}
+	for index, receipt := range value.Receipts {
+		if err := validateCollectionReceipt(receipt); err != nil {
+			return fmt.Errorf("%w: receipts[%d]: %v", ErrInvalidManifest, index, err)
+		}
+		if index > 0 {
+			previous := value.Receipts[index-1]
+			if previous.Kind == receipt.Kind && previous.RuntimeID == receipt.RuntimeID && previous.PageIndex == receipt.PageIndex {
+				return fmt.Errorf("%w: conflicting duplicate collection page %d", ErrInvalidManifest, receipt.PageIndex)
+			}
+		}
+	}
+	return nil
+}
+
+func ValidateObjectiveResult(value ObjectiveResult) error {
+	value = NormalizeResult(value)
+	if value.ID == "" || value.ObjectiveID == "" || strings.TrimSpace(value.ControlRef.ControlID) == "" || value.EvaluatorRevision == "" || value.EvaluatedAt.IsZero() {
+		return fmt.Errorf("%w: identity, control, evaluator revision, and evaluated_at are required", ErrInvalidResult)
+	}
+	if !knownScopeState(value.ScopeState) || !knownOutcome(value.AutomatedOutcome) || !knownDesignState(value.DesignState) ||
+		!knownOperatingState(value.OperatingEffectivenessState) || !knownEvidenceState(value.EvidenceState) ||
+		!knownDispositionState(value.DispositionState) || !knownAssurance(value.Assurance) || !knownAuditorState(value.AuditorState) {
+		return fmt.Errorf("%w: one or more required states are unknown", ErrInvalidResult)
+	}
+	if len(value.ReasonCodes) == 0 || len(value.NextActions) == 0 {
+		return fmt.Errorf("%w: reason_codes and next_actions are required", ErrInvalidResult)
+	}
+	for _, reason := range value.ReasonCodes {
+		if !knownReasonCode(reason) {
+			return fmt.Errorf("%w: unknown reason_code %q", ErrInvalidResult, reason)
+		}
+	}
+	for _, action := range value.NextActions {
+		if !knownNextAction(action) {
+			return fmt.Errorf("%w: unknown next_action %q", ErrInvalidResult, action)
+		}
+	}
+	if value.AutomatedOutcome == OutcomeSatisfied && value.EvidenceState != EvidenceSufficient {
+		return fmt.Errorf("%w: satisfied outcome requires sufficient evidence", ErrInvalidResult)
+	}
+	if value.ScopeState == ScopeNotApplicable && (value.AutomatedOutcome != OutcomeNotAssessed || value.DesignState != DesignNotAssessed || value.OperatingEffectivenessState != OperatingNotTested) {
+		return fmt.Errorf("%w: not-applicable scope requires not-assessed axes", ErrInvalidResult)
+	}
+	return nil
+}
+
+// CanonicalTime uses UTC millisecond precision, matching workflow event
+// timestamps and preventing event/database round trips from changing hashes.
+func CanonicalTime(value time.Time) time.Time {
+	return compliance.CanonicalRevisionTime(value)
+}
+
+func canonicalBytes(value any) ([]byte, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	var decoded any
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	return canonical, nil
+}
+
+func CanonicalManifestBytes(value InputManifest) ([]byte, error) {
+	value = NormalizeManifest(value)
+	if err := ValidateInputManifest(value); err != nil {
+		return nil, err
+	}
+	return canonicalBytes(value)
+}
+
+func CanonicalManifestDigest(value InputManifest) (string, error) {
+	data, err := CanonicalManifestBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(data), nil
+}
+
+func CanonicalResultBytes(value ObjectiveResult) ([]byte, error) {
+	value = NormalizeResult(value)
+	if err := ValidateObjectiveResult(value); err != nil {
+		return nil, err
+	}
+	return canonicalBytes(value)
+}
+
+func CanonicalResultDigest(value ObjectiveResult) (string, error) {
+	data, err := CanonicalResultBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(data), nil
+}
+
+func digestBytes(data []byte) string {
+	digest := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func normalizedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizedEnums[T ~string](values []T) []T {
+	stringsIn := make([]string, 0, len(values))
+	for _, value := range values {
+		stringsIn = append(stringsIn, string(value))
+	}
+	normalized := normalizedStrings(stringsIn)
+	result := make([]T, 0, len(normalized))
+	for _, value := range normalized {
+		result = append(result, T(value))
+	}
+	return result
+}
+
+func deduplicateManifestRevisions(values []ManifestRevision) []ManifestRevision {
+	result := make([]ManifestRevision, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.Kind == value.Kind && previous.ID == value.ID && previous.RevisionID == value.RevisionID && previous.Digest == value.Digest && previous.Version == value.Version {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func deduplicateCollectionReceipts(values []CollectionReceipt) []CollectionReceipt {
+	result := make([]CollectionReceipt, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.Kind == value.Kind && previous.RuntimeID == value.RuntimeID && previous.PageIndex == value.PageIndex && previous.PageDigest == value.PageDigest {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func validateCollectionReceipt(receipt CollectionReceipt) error {
+	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Watermark.IsZero() || receipt.Cutoff.IsZero() {
+		return errors.New("kind, digests, watermark, and cutoff are required")
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.QueryDigest)); err != nil {
+		return err
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.PageDigest)); err != nil {
+		return err
+	}
+	if !knownCompleteness(receipt.Completeness) {
+		return fmt.Errorf("unknown completeness %q", receipt.Completeness)
+	}
+	if receipt.Included+receipt.Excluded != receipt.Deduplicated || receipt.Deduplicated > receipt.RawCount {
+		return errors.New("collection counts are inconsistent")
+	}
+	return nil
+}

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -363,6 +363,9 @@ func ValidateInputManifest(value InputManifest) error {
 			}
 		}
 	}
+	if err := validateCollectionReceiptChains(value.Receipts); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidManifest, err)
+	}
 	return nil
 }
 
@@ -519,8 +522,8 @@ func deduplicateCollectionReceipts(values []CollectionReceipt) []CollectionRecei
 }
 
 func validateCollectionReceipt(receipt CollectionReceipt) error {
-	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Watermark.IsZero() || receipt.Cutoff.IsZero() {
-		return errors.New("kind, digests, watermark, and cutoff are required")
+	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Cutoff.IsZero() {
+		return errors.New("kind, digests, and cutoff are required")
 	}
 	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.QueryDigest)); err != nil {
 		return err
@@ -534,5 +537,60 @@ func validateCollectionReceipt(receipt CollectionReceipt) error {
 	if receipt.Included+receipt.Excluded != receipt.Deduplicated || receipt.Deduplicated > receipt.RawCount {
 		return errors.New("collection counts are inconsistent")
 	}
+	if receipt.Watermark.IsZero() && !emptyCollectionReceipt(receipt) {
+		return errors.New("watermark is required for a non-empty collection")
+	}
 	return nil
+}
+
+func validateCollectionReceiptChains(receipts []CollectionReceipt) error {
+	for start := 0; start < len(receipts); {
+		end := start + 1
+		for end < len(receipts) && receipts[end].Kind == receipts[start].Kind && receipts[end].RuntimeID == receipts[start].RuntimeID {
+			end++
+		}
+		chain := receipts[start:end]
+		if chain[0].PageIndex != 0 || chain[0].Cursor != "" {
+			return fmt.Errorf("collection %q/%q must begin at page zero without a cursor", chain[0].Kind, chain[0].RuntimeID)
+		}
+		var collected uint64
+		for index, receipt := range chain {
+			if receipt.QueryDigest != chain[0].QueryDigest || receipt.Cutoff != chain[0].Cutoff || receipt.Watermark != chain[0].Watermark {
+				return fmt.Errorf("collection %q/%q changed query, cutoff, or watermark between pages", receipt.Kind, receipt.RuntimeID)
+			}
+			if !equalExpectedTotal(receipt.ExpectedTotal, chain[0].ExpectedTotal) {
+				return fmt.Errorf("collection %q/%q changed expected total between pages", receipt.Kind, receipt.RuntimeID)
+			}
+			collected += receipt.Included + receipt.Excluded
+			if index == 0 {
+				continue
+			}
+			previous := chain[index-1]
+			if receipt.PageIndex != previous.PageIndex+1 || previous.NextCursor == "" || receipt.Cursor != previous.NextCursor {
+				return fmt.Errorf("collection %q/%q has a missing or disconnected page at index %d", receipt.Kind, receipt.RuntimeID, receipt.PageIndex)
+			}
+		}
+		terminal := chain[len(chain)-1]
+		if terminal.NextCursor != "" {
+			return fmt.Errorf("collection %q/%q has no terminal page", terminal.Kind, terminal.RuntimeID)
+		}
+		if terminal.Completeness == CollectionComplete && terminal.ExpectedTotal != nil && collected != *terminal.ExpectedTotal {
+			return fmt.Errorf("collection %q/%q completed with %d records; expected %d", terminal.Kind, terminal.RuntimeID, collected, *terminal.ExpectedTotal)
+		}
+		start = end
+	}
+	return nil
+}
+
+func emptyCollectionReceipt(receipt CollectionReceipt) bool {
+	return receipt.PageIndex == 0 && receipt.Cursor == "" && receipt.NextCursor == "" &&
+		receipt.RawCount == 0 && receipt.Deduplicated == 0 && receipt.Included == 0 && receipt.Excluded == 0 &&
+		receipt.ExpectedTotal != nil && *receipt.ExpectedTotal == 0 && receipt.FirstKey == "" && receipt.LastKey == ""
+}
+
+func equalExpectedTotal(left, right *uint64) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -332,7 +332,7 @@ func ValidateInputManifest(value InputManifest) error {
 	}
 	for _, digest := range []string{value.RequestedScopeDigest, value.ResolvedObjectiveSetDigest, value.MappingSetDigest} {
 		if err := compliance.ValidateContentDigest(compliance.ContentDigest(digest)); err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidManifest, err)
+			return fmt.Errorf("%w: %w", ErrInvalidManifest, err)
 		}
 	}
 	if len(value.Revisions) == 0 || len(value.Receipts) == 0 {
@@ -343,7 +343,7 @@ func ValidateInputManifest(value InputManifest) error {
 			return fmt.Errorf("%w: revisions[%d] is incomplete", ErrInvalidManifest, index)
 		}
 		if err := compliance.ValidateContentDigest(compliance.ContentDigest(revision.Digest)); err != nil {
-			return fmt.Errorf("%w: revisions[%d]: %v", ErrInvalidManifest, index, err)
+			return fmt.Errorf("%w: revisions[%d]: %w", ErrInvalidManifest, index, err)
 		}
 		if index > 0 {
 			previous := value.Revisions[index-1]
@@ -354,7 +354,7 @@ func ValidateInputManifest(value InputManifest) error {
 	}
 	for index, receipt := range value.Receipts {
 		if err := validateCollectionReceipt(receipt); err != nil {
-			return fmt.Errorf("%w: receipts[%d]: %v", ErrInvalidManifest, index, err)
+			return fmt.Errorf("%w: receipts[%d]: %w", ErrInvalidManifest, index, err)
 		}
 		if index > 0 {
 			previous := value.Receipts[index-1]
@@ -407,17 +407,17 @@ func CanonicalTime(value time.Time) time.Time {
 func canonicalBytes(value any) ([]byte, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	var decoded any
 	decoder := json.NewDecoder(strings.NewReader(string(data)))
 	decoder.UseNumber()
 	if err := decoder.Decode(&decoded); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	canonical, err := json.Marshal(decoded)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	return canonical, nil
 }

--- a/internal/complianceassessment/types_test.go
+++ b/internal/complianceassessment/types_test.go
@@ -1,0 +1,122 @@
+package complianceassessment
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func TestCanonicalManifestNormalizesOrderTimeAndDoesNotMutateCaller(t *testing.T) {
+	manifest := validManifest()
+	originalFirstKind := manifest.Revisions[0].Kind
+	firstBytes, err := CanonicalManifestBytes(manifest)
+	if err != nil {
+		t.Fatalf("CanonicalManifestBytes() error = %v", err)
+	}
+	shuffled := manifest
+	shuffled.Revisions = append([]ManifestRevision(nil), manifest.Revisions...)
+	shuffled.Receipts = append([]CollectionReceipt(nil), manifest.Receipts...)
+	shuffled.Revisions[0], shuffled.Revisions[1] = shuffled.Revisions[1], shuffled.Revisions[0]
+	shuffled.Receipts[0], shuffled.Receipts[1] = shuffled.Receipts[1], shuffled.Receipts[0]
+	shuffled.EvaluationRunIDs = []string{"run-b", "run-a", "run-a"}
+	secondBytes, err := CanonicalManifestBytes(shuffled)
+	if err != nil {
+		t.Fatalf("CanonicalManifestBytes(shuffled) error = %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatalf("manifest order changed canonical bytes\nfirst=%s\nsecond=%s", firstBytes, secondBytes)
+	}
+	if manifest.Revisions[0].Kind != originalFirstKind {
+		t.Fatal("NormalizeManifest mutated caller revisions")
+	}
+	if bytes.Contains(firstBytes, []byte("123456789")) || !bytes.Contains(firstBytes, []byte(".123Z")) {
+		t.Fatalf("canonical timestamp was not truncated to milliseconds: %s", firstBytes)
+	}
+}
+
+func TestUnknownEnumsSurviveDecodeAndFailCommandValidation(t *testing.T) {
+	result := validObjectiveResult()
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	data = bytes.Replace(data, []byte(`"evidence_state":"sufficient"`), []byte(`"evidence_state":"future_state"`), 1)
+	var decoded ObjectiveResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode future enum: %v", err)
+	}
+	if decoded.EvidenceState != EvidenceState("future_state") {
+		t.Fatalf("future enum was not retained: %q", decoded.EvidenceState)
+	}
+	if err := ValidateObjectiveResult(decoded); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("ValidateObjectiveResult() error = %v, want ErrInvalidResult", err)
+	}
+
+	input := validEvaluateInput()
+	input.SourceState = SourceState("future_source_state")
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective() error = %v, want ErrInvalidResult", err)
+	}
+	input = validEvaluateInput()
+	input.RequirementAssessments[0].Status = compliance.ControlEvidenceRequirementAssessmentStatus("future_requirement_state")
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective(future requirement) error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func TestCanonicalResultRejectsUnsupportedPass(t *testing.T) {
+	result := validObjectiveResult()
+	result.EvidenceState = EvidenceMissing
+	if _, err := CanonicalResultBytes(result); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("CanonicalResultBytes() error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func validManifest() InputManifest {
+	digestA := "sha256:" + strings.Repeat("a", 64)
+	digestB := "sha256:" + strings.Repeat("b", 64)
+	expected := uint64(2)
+	timestamp := time.Date(2026, 7, 11, 12, 0, 0, 123456789, time.FixedZone("offset", -7*60*60))
+	return InputManifest{
+		ProgramID: "program-00000000000000000000000000000001", ScopeRevisionID: "scope-revision-00000000000000000000000000000001",
+		PlanRevisionID: "assessment-plan-revision-00000000000000000000000000000001",
+		PeriodStart:    timestamp.Add(-time.Hour), PeriodEnd: timestamp, CollectionCutoff: timestamp,
+		RequestedScopeDigest: digestA, ResolvedObjectiveSetDigest: digestB, MappingSetDigest: digestA,
+		Revisions: []ManifestRevision{
+			{Kind: "profile", ID: "profile-1", RevisionID: "profile-r1", Version: 1, Digest: digestA},
+			{Kind: "catalog", ID: "catalog-1", RevisionID: "catalog-r1", Version: 1, Digest: digestB},
+		},
+		Receipts: []CollectionReceipt{
+			{Kind: "findings", RuntimeID: "runtime-1", QueryDigest: digestA, PageIndex: 1, Cursor: "a", RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &expected, FirstKey: "b", LastKey: "b", Watermark: timestamp, Cutoff: timestamp, Completeness: CollectionComplete, PageDigest: digestB},
+			{Kind: "findings", RuntimeID: "runtime-1", QueryDigest: digestA, PageIndex: 0, NextCursor: "a", RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &expected, FirstKey: "a", LastKey: "a", Watermark: timestamp, Cutoff: timestamp, Completeness: CollectionComplete, PageDigest: digestA},
+		},
+		EvaluationRunIDs: []string{"run-a", "run-b"},
+	}
+}
+
+func validObjectiveResult() ObjectiveResult {
+	return ObjectiveResult{
+		ID:         "assessment-result-00000000000000000000000000000001",
+		ControlRef: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ObjectiveID: "objective-1",
+		ScopeState: ScopeInScope, AutomatedOutcome: OutcomeSatisfied, DesignState: DesignEffective,
+		OperatingEffectivenessState: OperatingEffective, EvidenceState: EvidenceSufficient,
+		DispositionState: DispositionNone, Assurance: AssuranceHigh, AuditorState: AuditorNotReviewed,
+		ReasonCodes: []ReasonCode{ReasonSatisfied}, NextActions: []NextAction{ActionNone},
+		EvaluatorRevision: "evaluator-v1", EvaluatedAt: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func validEvaluateInput() EvaluateInput {
+	return EvaluateInput{
+		ResultID: "assessment-result-00000000000000000000000000000001", ObjectiveID: "objective-1",
+		Control: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ScopeState: ScopeInScope,
+		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"}}},
+		CoverageState:          CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
+		Now: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+	}
+}

--- a/internal/complianceassessment/types_test.go
+++ b/internal/complianceassessment/types_test.go
@@ -77,6 +77,37 @@ func TestCanonicalResultRejectsUnsupportedPass(t *testing.T) {
 	}
 }
 
+func TestEvaluateObjectiveRejectsSyntheticSatisfiedAssessment(t *testing.T) {
+	input := validEvaluateInput()
+	input.RequirementAssessments = []compliance.ControlEvidenceRequirementAssessment{{
+		Status: compliance.ControlEvidenceRequirementSatisfied,
+	}}
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective() error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func TestInputManifestRequiresCompleteCursorChain(t *testing.T) {
+	manifest := validManifest()
+	manifest.Receipts[1].Cursor = "disconnected"
+	if err := ValidateInputManifest(manifest); !errors.Is(err, ErrInvalidManifest) {
+		t.Fatalf("ValidateInputManifest() error = %v, want ErrInvalidManifest", err)
+	}
+}
+
+func TestInputManifestAcceptsEmptyCompletePopulationWithoutWatermark(t *testing.T) {
+	manifest := validManifest()
+	zero := uint64(0)
+	manifest.Receipts = []CollectionReceipt{{
+		Kind: "findings", RuntimeID: "runtime-1", QueryDigest: manifest.RequestedScopeDigest,
+		ExpectedTotal: &zero, Cutoff: manifest.CollectionCutoff, Completeness: CollectionComplete,
+		PageDigest: manifest.MappingSetDigest,
+	}}
+	if err := ValidateInputManifest(manifest); err != nil {
+		t.Fatalf("ValidateInputManifest() error = %v", err)
+	}
+}
+
 func validManifest() InputManifest {
 	digestA := "sha256:" + strings.Repeat("a", 64)
 	digestB := "sha256:" + strings.Repeat("b", 64)
@@ -115,8 +146,11 @@ func validEvaluateInput() EvaluateInput {
 	return EvaluateInput{
 		ResultID: "assessment-result-00000000000000000000000000000001", ObjectiveID: "objective-1",
 		Control: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ScopeState: ScopeInScope,
-		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"}}},
-		CoverageState:          CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
+		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{
+			RequirementKey: "requirement-1", ControlRef: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"},
+			SourceID: "source-1", EntityType: "resource", Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"},
+		}},
+		CoverageState: CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
 		Now: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
 	}
 }

--- a/internal/complianceassessment/validation.go
+++ b/internal/complianceassessment/validation.go
@@ -1,0 +1,128 @@
+package complianceassessment
+
+func knownScopeState(value ScopeState) bool {
+	switch value {
+	case ScopeInScope, ScopeNotApplicable, ScopeUnresolved:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownOutcome(value AutomatedOutcome) bool {
+	switch value {
+	case OutcomeSatisfied, OutcomeNotSatisfied, OutcomeIndeterminate, OutcomeNotAssessed:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownDesignState(value DesignState) bool {
+	switch value {
+	case DesignEffective, DesignIneffective, DesignUnknown, DesignNotAssessed:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownOperatingState(value OperatingEffectivenessState) bool {
+	switch value {
+	case OperatingEffective, OperatingIneffective, OperatingUnknown, OperatingNotTested:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownEvidenceState(value EvidenceState) bool {
+	switch value {
+	case EvidenceSufficient, EvidenceMissing, EvidenceStale, EvidenceConflicting,
+		EvidenceUntrusted, EvidenceIncomplete, EvidenceManualReview:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownDispositionState(value DispositionState) bool {
+	switch value {
+	case DispositionNone, DispositionAcceptedException, DispositionAcceptedRisk, DispositionReviewOverride:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownAssurance(value Assurance) bool {
+	switch value {
+	case AssuranceHigh, AssuranceMedium, AssuranceLow, AssuranceNone:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownAuditorState(value AuditorState) bool {
+	switch value {
+	case AuditorNotReviewed, AuditorAccepted, AuditorChangesRequested, AuditorRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownCoverageState(value CoverageState) bool {
+	switch value {
+	case CoverageComplete, CoveragePartial, CoverageEmpty, CoverageUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownSourceState(value SourceState) bool {
+	switch value {
+	case SourceSupported, SourcePartial, SourceStale, SourceFailed, SourceUnconfigured,
+		SourceUnsupported, SourceUnverified, SourceConflicting, SourceUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownReasonCode(value ReasonCode) bool {
+	switch value {
+	case ReasonSatisfied, ReasonActiveFinding, ReasonEvidenceMissing, ReasonEvidenceInvalid,
+		ReasonEvidenceStale, ReasonEvidenceConflicting, ReasonCoverageIncomplete,
+		ReasonSourceUntrusted, ReasonSourceUnknown, ReasonManualEvidence,
+		ReasonAcceptedException, ReasonAcceptedRisk, ReasonNotApplicable,
+		ReasonInheritedResponsibility, ReasonSampledTesting, ReasonSourceUnconfigured,
+		ReasonSourceUnsupported, ReasonSourcePartial, ReasonSourceFailed, ReasonSourceStale,
+		ReasonScopeUnresolved, ReasonPopulationEmpty:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownNextAction(value NextAction) bool {
+	switch value {
+	case ActionNone, ActionReview, ActionCollectEvidence, ActionRefreshEvidence,
+		ActionRestoreSource, ActionResolveScope, ActionRemediate, ActionRetest:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownCompleteness(value CollectionCompleteness) bool {
+	switch value {
+	case CollectionComplete, CollectionPartial, CollectionTruncated,
+		CollectionChangedDuringScan, CollectionUnknown:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/eventregistry/compliance_test.go
+++ b/internal/eventregistry/compliance_test.go
@@ -1,0 +1,20 @@
+package eventregistry
+
+import "testing"
+
+func TestComplianceAggregateV1EncodesSharedSchema(t *testing.T) {
+	t.Parallel()
+	event := ComplianceAggregateV1{
+		Kind: WorkflowV1CompliancePrefix + "program_recorded", TenantID: "tenant-a",
+		AggregateType: "program", AggregateID: "program-1", RevisionID: "revision-1",
+		AggregateVersion: 1, Operation: "recorded", ContentDigest: "sha256:abc",
+		PayloadJSON: `{"id":"program-1"}`, ActorID: "actor-1", RecordedAt: "2026-07-11T08:00:00Z",
+	}
+	encoded, err := (Encoder{}).Encode(event, EncodeOptions{EventID: "event-1"})
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if encoded.Subject != event.Kind || len(encoded.EnvelopeBytes) == 0 {
+		t.Fatalf("encoded = %#v", encoded)
+	}
+}

--- a/internal/eventregistry/models_workflow_v1.go
+++ b/internal/eventregistry/models_workflow_v1.go
@@ -10,6 +10,7 @@ const (
 	WorkflowV1FindingExternalRefLinked  = "workflow.v1.finding.external_ref_linked"
 	WorkflowV1FindingStatusChanged      = "workflow.v1.finding.status_changed"
 	WorkflowV1FindingTombstoned         = "workflow.v1.finding.tombstoned"
+	WorkflowV1CompliancePrefix          = "workflow.v1.compliance."
 )
 
 const (
@@ -22,6 +23,7 @@ const (
 	workflowV1FindingExternalRefFP   = "27b8e9fa76d210c4"
 	workflowV1FindingStatusChangedFP = "8af95aec880d1c3a"
 	workflowV1FindingTombstonedFP    = "bc92d8a4e5c7d5c3"
+	workflowV1ComplianceAggregateFP  = "e5ce86187cf139f8"
 )
 
 type Event interface {
@@ -29,6 +31,41 @@ type Event interface {
 	Version() int
 	SchemaFingerprint() string
 	EncodeAvro() ([]byte, error)
+}
+
+// ComplianceAggregateV1 carries one immutable compliance-domain revision or
+// transition. Kind is constrained to workflow.v1.compliance.* and selects the
+// subject while the payload schema remains shared across aggregate families.
+type ComplianceAggregateV1 struct {
+	Kind             string `json:"kind"`
+	TenantID         string `json:"tenant_id"`
+	AggregateType    string `json:"aggregate_type"`
+	AggregateID      string `json:"aggregate_id"`
+	RevisionID       string `json:"revision_id,omitempty"`
+	AggregateVersion int64  `json:"aggregate_version"`
+	Operation        string `json:"operation"`
+	ContentDigest    string `json:"content_digest,omitempty"`
+	PayloadJSON      string `json:"payload_json,omitempty"`
+	ActorID          string `json:"actor_id,omitempty"`
+	RecordedAt       string `json:"recorded_at"`
+}
+
+func (e ComplianceAggregateV1) Subject() string         { return e.Kind }
+func (ComplianceAggregateV1) Version() int              { return 1 }
+func (ComplianceAggregateV1) SchemaFingerprint() string { return workflowV1ComplianceAggregateFP }
+func (e ComplianceAggregateV1) EncodeAvro() ([]byte, error) {
+	w := newAvroWriter()
+	w.string(e.TenantID)
+	w.string(e.AggregateType)
+	w.string(e.AggregateID)
+	w.string(e.RevisionID)
+	w.long(e.AggregateVersion)
+	w.string(e.Operation)
+	w.string(e.ContentDigest)
+	w.string(e.PayloadJSON)
+	w.string(e.ActorID)
+	w.string(e.RecordedAt)
+	return w.bytes()
 }
 
 type DecisionRecordedV1 struct {

--- a/internal/evidenceledger/service.go
+++ b/internal/evidenceledger/service.go
@@ -1,0 +1,393 @@
+package evidenceledger
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+var ErrInvalidEvidence = errors.New("invalid evidence ledger request")
+
+type Service struct {
+	store ports.EvidenceLedgerStore
+	log   ports.AppendLog
+	now   func() time.Time
+}
+
+func New(store ports.EvidenceLedgerStore, log ports.AppendLog) *Service {
+	return &Service{store: store, log: log, now: func() time.Time { return time.Now().UTC() }}
+}
+
+type RegisterVersionRequest struct {
+	Artifact ports.EvidenceArtifact
+	Version  ports.EvidenceVersion
+	ActorID  string
+}
+
+func (s *Service) RegisterVersion(ctx context.Context, request RegisterVersionRequest) (ports.EvidenceVersion, error) {
+	if s == nil || s.store == nil || s.log == nil {
+		return ports.EvidenceVersion{}, fmt.Errorf("%w: ledger capability unavailable", ErrInvalidEvidence)
+	}
+	now := s.now().UTC().Truncate(time.Millisecond)
+	artifact := request.Artifact
+	version := request.Version
+	actorID := strings.TrimSpace(request.ActorID)
+	artifact.TenantID = strings.TrimSpace(artifact.TenantID)
+	version.TenantID = artifact.TenantID
+	if artifact.ID == "" {
+		id, err := compliance.NewIdentifier(compliance.IdentifierArtifact)
+		if err != nil {
+			return ports.EvidenceVersion{}, err
+		}
+		artifact.ID = id
+	}
+	if version.ID == "" {
+		id, err := compliance.NewRevisionIdentifier(compliance.IdentifierArtifact)
+		if err != nil {
+			return ports.EvidenceVersion{}, err
+		}
+		version.ID = id
+	}
+	version.ArtifactID = artifact.ID
+	if artifact.CreatedAt.IsZero() {
+		artifact.CreatedAt = now
+	}
+	if artifact.CreatedBy == "" {
+		artifact.CreatedBy = actorID
+	}
+	version.RecordedAt = now
+	if version.ValidFrom.IsZero() {
+		version.ValidFrom = version.Provenance.CollectedAt
+	}
+	version = normalizeVersion(version)
+	artifact = normalizeArtifact(artifact)
+	if strings.TrimSpace(version.Provenance.SourceProofRevisionID) == "" {
+		version.State = ports.EvidenceStateValidationFailed
+		version.QuarantineReason = "source_proof_unverified"
+	} else if version.State == "" {
+		version.State = ports.EvidenceStateCollected
+	}
+	if version.Revision.Version == 0 {
+		version.Revision.Version = 1
+	}
+	version.Revision.ID = artifact.ID
+	version.Revision.RevisionID = version.ID
+	version.Revision.LastModified = now
+	version.Revision.ContentDigest = ""
+	recordDigest, err := semanticDigest(version)
+	if err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	version.Revision.ContentDigest = recordDigest
+	if err := validateArtifactVersion(artifact, version, actorID); err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	payload, err := json.Marshal(struct {
+		Artifact ports.EvidenceArtifact `json:"artifact"`
+		Version  ports.EvidenceVersion  `json:"version"`
+	}{artifact, version})
+	if err != nil {
+		return ports.EvidenceVersion{}, fmt.Errorf("marshal evidence version event: %w", err)
+	}
+	aggregateVersion, err := eventAggregateVersion(version.Revision.Version)
+	if err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	event, err := workflowevents.NewComplianceAggregateEvent(workflowevents.ComplianceAggregateRecorded{
+		Kind: workflowevents.EventKindComplianceEvidenceVersionRecorded, TenantID: artifact.TenantID,
+		AggregateType: "evidence_artifact", AggregateID: artifact.ID, RevisionID: version.ID,
+		AggregateVersion: aggregateVersion, Operation: "version_recorded",
+		ContentDigest: recordDigest, PayloadJSON: string(payload), ActorID: actorID, RecordedAt: now.Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	if err := s.log.Append(ctx, event); err != nil {
+		return ports.EvidenceVersion{}, fmt.Errorf("append evidence version: %w", err)
+	}
+	if err := s.store.ApplyEvidenceVersion(ctx, event.GetId(), artifact, version); err != nil {
+		return ports.EvidenceVersion{}, fmt.Errorf("project evidence version: %w", err)
+	}
+	return version, nil
+}
+
+type CreateClaimRequest struct {
+	Claim   ports.EvidenceClaim
+	ActorID string
+}
+
+func (s *Service) CreateClaim(ctx context.Context, request CreateClaimRequest) (ports.EvidenceClaim, error) {
+	if s == nil || s.store == nil || s.log == nil {
+		return ports.EvidenceClaim{}, fmt.Errorf("%w: ledger capability unavailable", ErrInvalidEvidence)
+	}
+	claim := normalizeClaim(request.Claim)
+	actorID := strings.TrimSpace(request.ActorID)
+	if claim.ID == "" {
+		id, err := compliance.NewIdentifier(compliance.IdentifierClaim)
+		if err != nil {
+			return ports.EvidenceClaim{}, err
+		}
+		claim.ID = id
+	}
+	if claim.Version == 0 {
+		claim.Version = 1
+	}
+	if claim.CreatedAt.IsZero() {
+		claim.CreatedAt = s.now().UTC().Truncate(time.Millisecond)
+	}
+	if claim.CreatedBy == "" {
+		claim.CreatedBy = actorID
+	}
+	if claim.Decision.ReviewState == "" {
+		claim.Decision.ReviewState = ports.EvidenceReviewPending
+	}
+	version, err := s.store.GetEvidenceVersion(ctx, claim.TenantID, claim.ArtifactVersionID)
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	if err := validateClaimRecord(claim, version, actorID); err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	return s.appendClaim(ctx, workflowevents.EventKindComplianceEvidenceClaimRecorded, "claim_recorded", claim, 0, actorID)
+}
+
+func (s *Service) ReviewClaim(ctx context.Context, tenantID, claimID, reviewerID, state, reason string, expectedVersion uint64) (ports.EvidenceClaim, error) {
+	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(claimID))
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	if claim.Version != expectedVersion {
+		return ports.EvidenceClaim{}, ports.ErrEvidenceLedgerConflict
+	}
+	state = strings.TrimSpace(state)
+	if state != ports.EvidenceReviewApproved && state != ports.EvidenceReviewRejected {
+		return ports.EvidenceClaim{}, fmt.Errorf("%w: review state is invalid", ErrInvalidEvidence)
+	}
+	if strings.TrimSpace(reviewerID) == "" || strings.TrimSpace(reason) == "" {
+		return ports.EvidenceClaim{}, fmt.Errorf("%w: reviewer and reason are required", ErrInvalidEvidence)
+	}
+	claim.Decision.ReviewState = state
+	claim.Decision.ReviewerID = strings.TrimSpace(reviewerID)
+	claim.Decision.ReviewReason = strings.TrimSpace(reason)
+	claim.Decision.ReviewedAt = s.now().UTC().Truncate(time.Millisecond)
+	claim.Version++
+	return s.appendClaim(ctx, workflowevents.EventKindComplianceEvidenceClaimReviewed, "claim_reviewed", claim, expectedVersion, reviewerID)
+}
+
+func (s *Service) InvalidateClaim(ctx context.Context, tenantID, claimID, actorID, reason string, expectedVersion uint64) (ports.EvidenceClaim, error) {
+	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(claimID))
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	if claim.Version != expectedVersion {
+		return ports.EvidenceClaim{}, ports.ErrEvidenceLedgerConflict
+	}
+	if strings.TrimSpace(actorID) == "" || strings.TrimSpace(reason) == "" {
+		return ports.EvidenceClaim{}, fmt.Errorf("%w: actor and invalidation reason are required", ErrInvalidEvidence)
+	}
+	claim.Decision.InvalidatedAt = s.now().UTC().Truncate(time.Millisecond)
+	claim.Decision.InvalidationReason = strings.TrimSpace(reason)
+	claim.Version++
+	return s.appendClaim(ctx, workflowevents.EventKindComplianceEvidenceClaimInvalidated, "claim_invalidated", claim, expectedVersion, actorID)
+}
+
+func (s *Service) appendClaim(ctx context.Context, kind, operation string, claim ports.EvidenceClaim, expectedVersion uint64, actorID string) (ports.EvidenceClaim, error) {
+	payload, err := json.Marshal(claim)
+	if err != nil {
+		return ports.EvidenceClaim{}, fmt.Errorf("marshal evidence claim event: %w", err)
+	}
+	digest, err := semanticDigest(claim)
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	aggregateVersion, err := eventAggregateVersion(claim.Version)
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	event, err := workflowevents.NewComplianceAggregateEvent(workflowevents.ComplianceAggregateRecorded{
+		Kind: kind, TenantID: claim.TenantID, AggregateType: "evidence_claim", AggregateID: claim.ID,
+		RevisionID: fmt.Sprintf("%s-v%d", claim.ID, claim.Version), AggregateVersion: aggregateVersion,
+		Operation: operation, ContentDigest: digest, PayloadJSON: string(payload), ActorID: strings.TrimSpace(actorID),
+		RecordedAt: s.now().UTC().Truncate(time.Millisecond).Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	if err := s.log.Append(ctx, event); err != nil {
+		return ports.EvidenceClaim{}, fmt.Errorf("append evidence claim: %w", err)
+	}
+	if err := s.store.ApplyEvidenceClaim(ctx, event.GetId(), claim, expectedVersion); err != nil {
+		return ports.EvidenceClaim{}, fmt.Errorf("project evidence claim: %w", err)
+	}
+	return claim, nil
+}
+
+func normalizeArtifact(value ports.EvidenceArtifact) ports.EvidenceArtifact {
+	value.ID = strings.TrimSpace(value.ID)
+	value.TenantID = strings.TrimSpace(value.TenantID)
+	value.Title = strings.TrimSpace(value.Title)
+	value.Description = strings.TrimSpace(value.Description)
+	value.Type = strings.TrimSpace(value.Type)
+	value.CreatedBy = strings.TrimSpace(value.CreatedBy)
+	value.CreatedAt = value.CreatedAt.UTC().Truncate(time.Millisecond)
+	return value
+}
+
+func normalizeVersion(value ports.EvidenceVersion) ports.EvidenceVersion {
+	value.ID = strings.TrimSpace(value.ID)
+	value.TenantID = strings.TrimSpace(value.TenantID)
+	value.ArtifactID = strings.TrimSpace(value.ArtifactID)
+	value.Content.MediaType = strings.TrimSpace(value.Content.MediaType)
+	value.Content.URI = strings.TrimSpace(value.Content.URI)
+	value.Content.ContentDigest = strings.TrimSpace(value.Content.ContentDigest)
+	value.Provenance.Producer = strings.TrimSpace(value.Provenance.Producer)
+	value.Provenance.ProducerVersion = strings.TrimSpace(value.Provenance.ProducerVersion)
+	value.Provenance.SourceRuntimeID = strings.TrimSpace(value.Provenance.SourceRuntimeID)
+	value.Provenance.SourceEventID = strings.TrimSpace(value.Provenance.SourceEventID)
+	value.Provenance.SourceProofRevisionID = strings.TrimSpace(value.Provenance.SourceProofRevisionID)
+	value.Governance.Sensitivity = strings.TrimSpace(value.Governance.Sensitivity)
+	value.Governance.AccessPolicy = strings.TrimSpace(value.Governance.AccessPolicy)
+	value.Governance.RedactionState = strings.TrimSpace(value.Governance.RedactionState)
+	value.Governance.ParserQuality = strings.TrimSpace(value.Governance.ParserQuality)
+	value.State = strings.TrimSpace(value.State)
+	value.QuarantineReason = strings.TrimSpace(value.QuarantineReason)
+	value.PredecessorID = strings.TrimSpace(value.PredecessorID)
+	value.Provenance.CollectedAt = value.Provenance.CollectedAt.UTC().Truncate(time.Millisecond)
+	value.Provenance.PeriodStart = value.Provenance.PeriodStart.UTC().Truncate(time.Millisecond)
+	value.Provenance.PeriodEnd = value.Provenance.PeriodEnd.UTC().Truncate(time.Millisecond)
+	value.ValidFrom = value.ValidFrom.UTC().Truncate(time.Millisecond)
+	value.ValidUntil = value.ValidUntil.UTC().Truncate(time.Millisecond)
+	value.Governance.RetentionUntil = value.Governance.RetentionUntil.UTC().Truncate(time.Millisecond)
+	value.RecordedAt = value.RecordedAt.UTC().Truncate(time.Millisecond)
+	value.Subjects = normalizeSubjects(value.Subjects)
+	value.Provenance.DerivationIDs = normalizedStrings(value.Provenance.DerivationIDs)
+	return value
+}
+
+func normalizeClaim(value ports.EvidenceClaim) ports.EvidenceClaim {
+	value.ID = strings.TrimSpace(value.ID)
+	value.TenantID = strings.TrimSpace(value.TenantID)
+	value.ArtifactVersionID = strings.TrimSpace(value.ArtifactVersionID)
+	value.Scope.ObjectiveID = strings.TrimSpace(value.Scope.ObjectiveID)
+	value.Scope.ImplementationRevisionID = strings.TrimSpace(value.Scope.ImplementationRevisionID)
+	value.Scope.RequirementID = strings.TrimSpace(value.Scope.RequirementID)
+	value.Linkage = strings.TrimSpace(value.Linkage)
+	value.Strength = strings.TrimSpace(value.Strength)
+	value.Limitation = strings.TrimSpace(value.Limitation)
+	value.MappingRationale = strings.TrimSpace(value.MappingRationale)
+	value.Decision.ReviewState = strings.TrimSpace(value.Decision.ReviewState)
+	value.Scope.Subjects = normalizeSubjects(value.Scope.Subjects)
+	value.Scope.PeriodStart = value.Scope.PeriodStart.UTC().Truncate(time.Millisecond)
+	value.Scope.PeriodEnd = value.Scope.PeriodEnd.UTC().Truncate(time.Millisecond)
+	return value
+}
+
+func normalizeSubjects(values []ports.EvidenceSubjectRef) []ports.EvidenceSubjectRef {
+	values = append([]ports.EvidenceSubjectRef(nil), values...)
+	for index := range values {
+		values[index].Type = strings.TrimSpace(values[index].Type)
+		values[index].ID = strings.TrimSpace(values[index].ID)
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i].Type+"\x00"+values[i].ID < values[j].Type+"\x00"+values[j].ID })
+	result := values[:0]
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1] == value {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func semanticDigest(value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("marshal evidence semantic content: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(digest[:]), nil
+}
+
+func eventAggregateVersion(value uint64) (int64, error) {
+	if value == 0 || value > math.MaxInt64 {
+		return 0, fmt.Errorf("%w: aggregate version is out of range", ErrInvalidEvidence)
+	}
+	return int64(value), nil
+}
+
+func validateArtifactVersion(artifact ports.EvidenceArtifact, version ports.EvidenceVersion, actorID string) error {
+	if artifact.ID == "" || artifact.TenantID == "" || artifact.Title == "" || artifact.Type == "" || actorID == "" {
+		return fmt.Errorf("%w: artifact identity, tenant, title, type, and actor are required", ErrInvalidEvidence)
+	}
+	if err := compliance.ValidateIdentifier(compliance.IdentifierArtifact, artifact.ID); err != nil {
+		return err
+	}
+	if err := compliance.ValidateRevisionIdentifier(compliance.IdentifierArtifact, version.ID); err != nil {
+		return err
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(version.Content.ContentDigest)); err != nil {
+		return err
+	}
+	if version.Content.MediaType == "" || version.Content.URI == "" || version.Provenance.Producer == "" || version.Provenance.CollectedAt.IsZero() || version.ValidFrom.IsZero() || len(version.Subjects) == 0 || version.Governance.AccessPolicy == "" {
+		return fmt.Errorf("%w: version metadata is incomplete", ErrInvalidEvidence)
+	}
+	parsed, err := url.Parse(version.Content.URI)
+	if err != nil || parsed.Scheme == "" || parsed.Scheme == "file" || parsed.Scheme == "data" {
+		return fmt.Errorf("%w: evidence URI must be an approved immutable reference", ErrInvalidEvidence)
+	}
+	for _, subject := range version.Subjects {
+		if strings.TrimSpace(subject.Type) == "" || strings.TrimSpace(subject.ID) == "" {
+			return fmt.Errorf("%w: evidence subject type and id are required", ErrInvalidEvidence)
+		}
+	}
+	if version.Revision.ID == "" || version.Revision.RevisionID == "" || version.Revision.Version == 0 || version.Revision.LastModified.IsZero() {
+		return fmt.Errorf("%w: evidence revision metadata is incomplete", ErrInvalidEvidence)
+	}
+	return compliance.ValidateContentDigest(compliance.ContentDigest(version.Revision.ContentDigest))
+}
+
+func validateClaimRecord(claim ports.EvidenceClaim, version ports.EvidenceVersion, actorID string) error {
+	if claim.TenantID == "" || claim.ArtifactVersionID == "" || claim.Scope.ObjectiveID == "" || claim.Scope.ImplementationRevisionID == "" || claim.Scope.RequirementID == "" || actorID == "" {
+		return fmt.Errorf("%w: claim identity, scope, requirement, and actor are required", ErrInvalidEvidence)
+	}
+	if version.TenantID != claim.TenantID {
+		return ports.ErrEvidenceVersionNotFound
+	}
+	if claim.Linkage != ports.EvidenceLinkDirect && claim.Linkage != ports.EvidenceLinkInherited && claim.Linkage != ports.EvidenceLinkInferred {
+		return fmt.Errorf("%w: claim linkage is invalid", ErrInvalidEvidence)
+	}
+	if claim.Strength == "" || claim.MappingRationale == "" || claim.Scope.PeriodStart.IsZero() || claim.Scope.PeriodEnd.IsZero() || claim.Scope.PeriodEnd.Before(claim.Scope.PeriodStart) || len(claim.Scope.Subjects) == 0 {
+		return fmt.Errorf("%w: claim basis is incomplete", ErrInvalidEvidence)
+	}
+	return nil
+}

--- a/internal/evidenceledger/service_test.go
+++ b/internal/evidenceledger/service_test.go
@@ -1,0 +1,287 @@
+package evidenceledger
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestArtifactVersionSupportsIndependentClaims(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{}, now)
+	version := registerTestVersion(t, service, now, true)
+	first := createTestClaim(t, service, version, "objective-1")
+	second, err := service.ReuseClaim(context.Background(), first.TenantID, first.ID, "owner-2", ports.EvidenceClaim{
+		Scope: ports.EvidenceClaimScope{ObjectiveID: "objective-2", ImplementationRevisionID: "implementation-revision-2",
+			RequirementID: "requirement-2", Subjects: first.Scope.Subjects, PeriodStart: first.Scope.PeriodStart,
+			PeriodEnd: first.Scope.PeriodEnd}, Linkage: ports.EvidenceLinkDirect, Strength: "strong",
+		MappingRationale: "Same artifact supports a separate scoped objective.",
+	})
+	if err != nil {
+		t.Fatalf("ReuseClaim() error = %v", err)
+	}
+	approved, err := service.ReviewClaim(context.Background(), first.TenantID, first.ID, "reviewer-1", ports.EvidenceReviewApproved, "Verified against the requirement.", first.Version)
+	if err != nil {
+		t.Fatalf("ReviewClaim() error = %v", err)
+	}
+	if approved.Decision.ReviewState != ports.EvidenceReviewApproved {
+		t.Fatalf("first review state = %q", approved.Decision.ReviewState)
+	}
+	storedSecond, err := store.GetEvidenceClaim(context.Background(), second.TenantID, second.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedSecond.Decision.ReviewState != ports.EvidenceReviewPending || storedSecond.Decision.ReviewerID != "" {
+		t.Fatalf("second claim inherited approval: %#v", storedSecond)
+	}
+}
+
+func TestQuarantinedVersionCannotSatisfyClaim(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{}, now)
+	version := registerTestVersion(t, service, now, false)
+	claim := createTestClaim(t, service, version, "objective-1")
+	claim, err := service.ReviewClaim(context.Background(), claim.TenantID, claim.ID, "reviewer-1", ports.EvidenceReviewApproved, "Metadata reviewed.", claim.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validation, err := service.ValidateClaim(context.Background(), ValidateClaimRequest{
+		TenantID: claim.TenantID, ClaimID: claim.ID, Subjects: claim.Scope.Subjects,
+		PeriodStart: claim.Scope.PeriodStart, PeriodEnd: claim.Scope.PeriodEnd, At: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if validation.Valid || !contains(validation.ReasonCodes, reasonVersionQuarantined) {
+		t.Fatalf("validation = %#v", validation)
+	}
+}
+
+func TestInvalidationAndScopePeriodChecks(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{}, now)
+	version := registerTestVersion(t, service, now, true)
+	claim := createTestClaim(t, service, version, "objective-1")
+	claim, err := service.ReviewClaim(context.Background(), claim.TenantID, claim.ID, "reviewer-1", ports.EvidenceReviewApproved, "Verified.", claim.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid, err := service.ValidateClaim(context.Background(), ValidateClaimRequest{TenantID: claim.TenantID, ClaimID: claim.ID, Subjects: claim.Scope.Subjects, PeriodStart: claim.Scope.PeriodStart, PeriodEnd: claim.Scope.PeriodEnd, At: now})
+	if err != nil || !valid.Valid {
+		t.Fatalf("ValidateClaim() = (%#v, %v)", valid, err)
+	}
+	invalidated, err := service.InvalidateClaim(context.Background(), claim.TenantID, claim.ID, "owner-1", "Source record was revoked.", claim.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid, err := service.ValidateClaim(context.Background(), ValidateClaimRequest{TenantID: claim.TenantID, ClaimID: invalidated.ID, Subjects: []ports.EvidenceSubjectRef{{Type: "asset", ID: "different"}}, PeriodStart: now.Add(-48 * time.Hour), PeriodEnd: now, At: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, reason := range []string{reasonClaimInvalidated, reasonPeriodGap, reasonSubjectMismatch} {
+		if !contains(invalid.ReasonCodes, reason) {
+			t.Fatalf("validation reasons %v missing %q", invalid.ReasonCodes, reason)
+		}
+	}
+}
+
+func TestEvidenceReadEnforcesPurposeSensitivityAndTenant(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{}, now)
+	version := registerTestVersion(t, service, now, true)
+	if _, err := service.ReadVersion(context.Background(), ports.EvidenceAccessRequest{TenantID: version.TenantID, ActorID: "reader", Purpose: "assessment", MaximumSensitivity: ports.EvidenceSensitivityInternal}, version.ID); !errors.Is(err, ports.ErrEvidenceAccessDenied) {
+		t.Fatalf("restricted read error = %v", err)
+	}
+	if _, err := service.ReadVersion(context.Background(), ports.EvidenceAccessRequest{TenantID: "foreign", ActorID: "reader", Purpose: "audit", MaximumSensitivity: ports.EvidenceSensitivityRestricted}, version.ID); !errors.Is(err, ports.ErrEvidenceVersionNotFound) {
+		t.Fatalf("foreign tenant read error = %v", err)
+	}
+	if _, err := service.ReadVersion(context.Background(), ports.EvidenceAccessRequest{TenantID: version.TenantID, ActorID: "reader", Purpose: "audit", MaximumSensitivity: ports.EvidenceSensitivityRestricted}, version.ID); err != nil {
+		t.Fatalf("authorized read error = %v", err)
+	}
+}
+
+func TestAppendFailurePreventsProjection(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	service := newTestService(store, &memoryLog{err: errors.New("append unavailable")}, now)
+	request := testVersionRequest(now, true)
+	if _, err := service.RegisterVersion(context.Background(), request); err == nil {
+		t.Fatal("RegisterVersion() unexpectedly succeeded")
+	}
+	if len(store.versions) != 0 {
+		t.Fatalf("projection changed after append failure: %#v", store.versions)
+	}
+}
+
+func newTestService(store *memoryStore, log *memoryLog, now time.Time) *Service {
+	service := New(store, log)
+	service.now = func() time.Time { return now }
+	return service
+}
+
+func registerTestVersion(t *testing.T, service *Service, now time.Time, trusted bool) ports.EvidenceVersion {
+	t.Helper()
+	version, err := service.RegisterVersion(context.Background(), testVersionRequest(now, trusted))
+	if err != nil {
+		t.Fatalf("RegisterVersion() error = %v", err)
+	}
+	return version
+}
+
+func testVersionRequest(now time.Time, trusted bool) RegisterVersionRequest {
+	proof := ""
+	if trusted {
+		proof = "source-proof-revision-1"
+	}
+	return RegisterVersionRequest{
+		Artifact: ports.EvidenceArtifact{TenantID: "tenant-1", Title: "Access review export", Type: "record", CreatedBy: "owner-1"},
+		Version: ports.EvidenceVersion{
+			Content: ports.EvidenceContentRef{MediaType: "application/json", URI: "cas://evidence/sha256-abc",
+				ContentDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", SizeBytes: 10},
+			Provenance: ports.EvidenceProvenance{Producer: "source-runtime", CollectedAt: now,
+				PeriodStart: now.Add(-24 * time.Hour), PeriodEnd: now, SourceProofRevisionID: proof},
+			ValidFrom: now.Add(-24 * time.Hour), ValidUntil: now.Add(24 * time.Hour),
+			Subjects:   []ports.EvidenceSubjectRef{{Type: "asset", ID: "asset-1"}},
+			Governance: ports.EvidenceGovernance{Sensitivity: ports.EvidenceSensitivityRestricted, AccessPolicy: "evidence-owner-or-engagement"},
+		},
+		ActorID: "owner-1",
+	}
+}
+
+func createTestClaim(t *testing.T, service *Service, version ports.EvidenceVersion, objectiveID string) ports.EvidenceClaim {
+	t.Helper()
+	claim, err := service.CreateClaim(context.Background(), CreateClaimRequest{Claim: ports.EvidenceClaim{
+		TenantID: version.TenantID, ArtifactVersionID: version.ID,
+		Scope: ports.EvidenceClaimScope{ObjectiveID: objectiveID, ImplementationRevisionID: "implementation-revision-1", RequirementID: "requirement-1",
+			Subjects: version.Subjects, PeriodStart: version.Provenance.PeriodStart, PeriodEnd: version.Provenance.PeriodEnd},
+		Linkage: ports.EvidenceLinkDirect, Strength: "strong", MappingRationale: "Direct source record for the objective.",
+	}, ActorID: "owner-1"})
+	if err != nil {
+		t.Fatalf("CreateClaim() error = %v", err)
+	}
+	return claim
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+type memoryLog struct {
+	mu     sync.Mutex
+	events []*cerebrov1.EventEnvelope
+	err    error
+}
+
+func (l *memoryLog) Ping(context.Context) error { return nil }
+func (l *memoryLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.err != nil {
+		return l.err
+	}
+	l.events = append(l.events, event)
+	return nil
+}
+
+type memoryStore struct {
+	mu        sync.Mutex
+	artifacts map[string]ports.EvidenceArtifact
+	versions  map[string]ports.EvidenceVersion
+	claims    map[string]ports.EvidenceClaim
+	events    map[string]struct{}
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{artifacts: map[string]ports.EvidenceArtifact{}, versions: map[string]ports.EvidenceVersion{}, claims: map[string]ports.EvidenceClaim{}, events: map[string]struct{}{}}
+}
+
+func tenantKey(tenantID, id string) string { return tenantID + "\x00" + id }
+
+func (s *memoryStore) ApplyEvidenceVersion(_ context.Context, eventID string, artifact ports.EvidenceArtifact, version ports.EvidenceVersion) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.events[eventID]; ok {
+		return nil
+	}
+	s.events[eventID] = struct{}{}
+	s.artifacts[tenantKey(artifact.TenantID, artifact.ID)] = artifact
+	s.versions[tenantKey(version.TenantID, version.ID)] = version
+	return nil
+}
+
+func (s *memoryStore) ApplyEvidenceClaim(_ context.Context, eventID string, claim ports.EvidenceClaim, expectedVersion uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.events[eventID]; ok {
+		return nil
+	}
+	key := tenantKey(claim.TenantID, claim.ID)
+	existing, ok := s.claims[key]
+	if ok && existing.Version != expectedVersion {
+		return ports.ErrEvidenceLedgerConflict
+	}
+	if !ok && expectedVersion != 0 {
+		return ports.ErrEvidenceLedgerConflict
+	}
+	s.events[eventID] = struct{}{}
+	s.claims[key] = claim
+	return nil
+}
+
+func (s *memoryStore) GetEvidenceArtifact(_ context.Context, tenantID, id string) (ports.EvidenceArtifact, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.artifacts[tenantKey(tenantID, id)]
+	if !ok {
+		return ports.EvidenceArtifact{}, ports.ErrEvidenceArtifactNotFound
+	}
+	return value, nil
+}
+func (s *memoryStore) GetEvidenceVersion(_ context.Context, tenantID, id string) (ports.EvidenceVersion, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.versions[tenantKey(tenantID, id)]
+	if !ok {
+		return ports.EvidenceVersion{}, ports.ErrEvidenceVersionNotFound
+	}
+	return value, nil
+}
+func (s *memoryStore) GetEvidenceClaim(_ context.Context, tenantID, id string) (ports.EvidenceClaim, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.claims[tenantKey(tenantID, id)]
+	if !ok {
+		return ports.EvidenceClaim{}, ports.ErrEvidenceClaimNotFound
+	}
+	return value, nil
+}
+func (s *memoryStore) ListEvidenceClaimsByVersion(_ context.Context, tenantID, versionID string) ([]ports.EvidenceClaim, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []ports.EvidenceClaim
+	for _, claim := range s.claims {
+		if claim.TenantID == tenantID && claim.ArtifactVersionID == versionID {
+			result = append(result, claim)
+		}
+	}
+	return result, nil
+}

--- a/internal/evidenceledger/validation.go
+++ b/internal/evidenceledger/validation.go
@@ -1,0 +1,146 @@
+package evidenceledger
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	reasonApproved           = "evidence_claim_approved"
+	reasonClaimPending       = "evidence_claim_pending"
+	reasonClaimRejected      = "evidence_claim_rejected"
+	reasonClaimInvalidated   = "evidence_claim_invalidated"
+	reasonVersionQuarantined = "evidence_version_quarantined"
+	reasonVersionRevoked     = "evidence_version_revoked"
+	reasonVersionExpired     = "evidence_version_expired"
+	reasonPeriodGap          = "evidence_period_gap"
+	reasonSubjectMismatch    = "evidence_subject_mismatch"
+)
+
+type ValidateClaimRequest struct {
+	TenantID    string
+	ClaimID     string
+	Subjects    []ports.EvidenceSubjectRef
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+	At          time.Time
+}
+
+func (s *Service) ValidateClaim(ctx context.Context, request ValidateClaimRequest) (ports.EvidenceClaimValidation, error) {
+	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(request.TenantID), strings.TrimSpace(request.ClaimID))
+	if err != nil {
+		return ports.EvidenceClaimValidation{}, err
+	}
+	version, err := s.store.GetEvidenceVersion(ctx, claim.TenantID, claim.ArtifactVersionID)
+	if err != nil {
+		return ports.EvidenceClaimValidation{}, err
+	}
+	result := ports.EvidenceClaimValidation{Valid: true, ReasonCodes: []string{reasonApproved}, NextActions: []string{"none"}}
+	addInvalid := func(reason, action string) {
+		if result.Valid {
+			result.ReasonCodes = nil
+			result.NextActions = nil
+		}
+		result.Valid = false
+		result.ReasonCodes = append(result.ReasonCodes, reason)
+		result.NextActions = append(result.NextActions, action)
+	}
+	if !claim.Decision.InvalidatedAt.IsZero() {
+		addInvalid(reasonClaimInvalidated, "replace_claim")
+	}
+	switch claim.Decision.ReviewState {
+	case ports.EvidenceReviewApproved:
+	case ports.EvidenceReviewRejected:
+		addInvalid(reasonClaimRejected, "replace_claim")
+	default:
+		addInvalid(reasonClaimPending, "review")
+	}
+	if version.State == ports.EvidenceStateValidationFailed || strings.TrimSpace(version.QuarantineReason) != "" {
+		addInvalid(reasonVersionQuarantined, "repair_source")
+	}
+	if version.State == ports.EvidenceStateRevoked || version.State == ports.EvidenceStateSuperseded {
+		addInvalid(reasonVersionRevoked, "collect_evidence")
+	}
+	at := request.At.UTC()
+	if at.IsZero() {
+		at = s.now().UTC()
+	}
+	if !version.ValidUntil.IsZero() && !at.Before(version.ValidUntil) {
+		addInvalid(reasonVersionExpired, "refresh_evidence")
+	}
+	if request.PeriodStart.Before(claim.Scope.PeriodStart) || request.PeriodEnd.After(claim.Scope.PeriodEnd) || request.PeriodStart.Before(version.Provenance.PeriodStart) || request.PeriodEnd.After(version.Provenance.PeriodEnd) {
+		addInvalid(reasonPeriodGap, "collect_evidence")
+	}
+	if !subjectsCover(claim.Scope.Subjects, normalizeSubjects(request.Subjects)) || !subjectsCover(version.Subjects, normalizeSubjects(request.Subjects)) {
+		addInvalid(reasonSubjectMismatch, "collect_evidence")
+	}
+	result.ReasonCodes = normalizedStrings(result.ReasonCodes)
+	result.NextActions = normalizedStrings(result.NextActions)
+	return result, nil
+}
+
+func (s *Service) ReadVersion(ctx context.Context, access ports.EvidenceAccessRequest, versionID string) (ports.EvidenceVersion, error) {
+	version, err := s.store.GetEvidenceVersion(ctx, strings.TrimSpace(access.TenantID), strings.TrimSpace(versionID))
+	if err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	if strings.TrimSpace(access.ActorID) == "" || !allowedPurpose(access.Purpose) || sensitivityRank(access.MaximumSensitivity) < sensitivityRank(version.Governance.Sensitivity) {
+		return ports.EvidenceVersion{}, ports.ErrEvidenceAccessDenied
+	}
+	return version, nil
+}
+
+// ReuseClaim creates a separate scoped claim over the same immutable version.
+// It never copies approval or invalidation state from the source claim.
+func (s *Service) ReuseClaim(ctx context.Context, sourceTenantID, sourceClaimID, actorID string, replacement ports.EvidenceClaim) (ports.EvidenceClaim, error) {
+	source, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(sourceTenantID), strings.TrimSpace(sourceClaimID))
+	if err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	replacement.ID = ""
+	replacement.TenantID = source.TenantID
+	replacement.ArtifactVersionID = source.ArtifactVersionID
+	replacement.Decision = ports.EvidenceClaimDecision{ReviewState: ports.EvidenceReviewPending}
+	replacement.Version = 1
+	return s.CreateClaim(ctx, CreateClaimRequest{Claim: replacement, ActorID: actorID})
+}
+
+func subjectsCover(available, required []ports.EvidenceSubjectRef) bool {
+	set := make(map[ports.EvidenceSubjectRef]struct{}, len(available))
+	for _, subject := range available {
+		set[subject] = struct{}{}
+	}
+	for _, subject := range required {
+		if _, ok := set[subject]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func allowedPurpose(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "assessment", "review", "audit", "export":
+		return true
+	default:
+		return false
+	}
+}
+
+func sensitivityRank(value string) int {
+	switch strings.TrimSpace(value) {
+	case ports.EvidenceSensitivityPublic:
+		return 1
+	case ports.EvidenceSensitivityInternal:
+		return 2
+	case ports.EvidenceSensitivityConfidential:
+		return 3
+	case ports.EvidenceSensitivityRestricted:
+		return 4
+	default:
+		return 0
+	}
+}

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -5,11 +5,13 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -23,6 +25,15 @@ var (
 )
 
 const (
+	defaultLeaseTTL          = 30 * time.Second
+	defaultHeartbeatInterval = 10 * time.Second
+	defaultRecoveryBatch     = uint32(100)
+	defaultRecoveryInterval  = 15 * time.Second
+
+	JobFailurePermanent = "permanent"
+	JobFailureRetryable = "retryable"
+	JobFailureCancelled = "cancelled"
+
 	KindSourceRuntimeSync         = "source_runtime_sync"
 	KindSourceRuntimeOrchestrate  = "source_runtime_orchestrate"
 	KindGraphIngestRuntime        = "graph_ingest_runtime"
@@ -39,18 +50,44 @@ const (
 
 type Runner func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error)
 
+type retryableJobError struct {
+	err error
+}
+
+func (e retryableJobError) Error() string { return e.err.Error() }
+func (e retryableJobError) Unwrap() error { return e.err }
+
+// Retryable marks an execution failure safe for an explicit retry policy.
+func Retryable(err error) error {
+	if err == nil {
+		return nil
+	}
+	return retryableJobError{err: err}
+}
+
 type Service struct {
-	store        ports.JobStore
-	runners      map[string]Runner
-	now          func() time.Time
-	nextAsyncID  uint64
-	asyncCancels map[uint64]context.CancelFunc
-	wg           sync.WaitGroup
-	mu           sync.Mutex
+	store             ports.JobStore
+	runners           map[string]Runner
+	now               func() time.Time
+	nextAsyncID       uint64
+	asyncCancels      map[uint64]context.CancelFunc
+	jobCancels        map[string]context.CancelFunc
+	leaseTTL          time.Duration
+	heartbeatInterval time.Duration
+	wg                sync.WaitGroup
+	mu                sync.Mutex
 }
 
 func New(store ports.JobStore) *Service {
-	return &Service{store: store, runners: map[string]Runner{}, now: func() time.Time { return time.Now().UTC() }, asyncCancels: map[uint64]context.CancelFunc{}}
+	return &Service{
+		store:             store,
+		runners:           map[string]Runner{},
+		now:               func() time.Time { return time.Now().UTC() },
+		asyncCancels:      map[uint64]context.CancelFunc{},
+		jobCancels:        map[string]context.CancelFunc{},
+		leaseTTL:          defaultLeaseTTL,
+		heartbeatInterval: defaultHeartbeatInterval,
+	}
 }
 
 func (s *Service) WithRunner(kind string, runner Runner) *Service {
@@ -62,6 +99,27 @@ func (s *Service) WithRunner(kind string, runner Runner) *Service {
 		return s
 	}
 	s.runners[kind] = runner
+	return s
+}
+
+// WithLeaseTiming overrides worker lease timing. Production uses the defaults;
+// focused tests use shorter intervals to exercise renewal and cancellation.
+func (s *Service) WithLeaseTiming(ttl time.Duration, heartbeatInterval time.Duration) *Service {
+	if s == nil {
+		return nil
+	}
+	if ttl > 0 {
+		s.leaseTTL = ttl
+		if s.heartbeatInterval >= ttl {
+			s.heartbeatInterval = ttl / 3
+			if s.heartbeatInterval <= 0 {
+				s.heartbeatInterval = ttl
+			}
+		}
+	}
+	if heartbeatInterval > 0 && heartbeatInterval < s.leaseTTL {
+		s.heartbeatInterval = heartbeatInterval
+	}
 	return s
 }
 
@@ -83,6 +141,11 @@ func (s *Service) Create(ctx context.Context, request ports.CreateJobRequest) (*
 	if request.Payload == nil {
 		request.Payload = map[string]any{}
 	}
+	requestHash, err := jobRequestHash(request)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: hash request: %w", ErrInvalidRequest, err)
+	}
+	request.RequestHash = requestHash
 	job, created, err := s.store.CreateJob(ctx, request)
 	if err != nil {
 		return nil, false, err
@@ -166,7 +229,301 @@ func (s *Service) Wait(ctx context.Context) error {
 	}
 }
 
-func (s *Service) Run(ctx context.Context, jobID string) (err error) {
+// Recover resets expired leases and starts queued work. Claiming remains atomic,
+// so multiple replicas may call Recover safely during startup.
+func (s *Service) Recover(ctx context.Context, limit uint32) (int, error) {
+	if s == nil || s.store == nil {
+		return 0, ErrRuntimeUnavailable
+	}
+	leaseStore, ok := s.store.(ports.JobLeaseStore)
+	if !ok {
+		return 0, ErrRuntimeUnavailable
+	}
+	if limit == 0 {
+		limit = defaultRecoveryBatch
+	}
+	queued, err := leaseStore.RecoverJobs(ctx, ports.JobRecoveryRequest{Now: s.now(), Limit: limit})
+	if err != nil {
+		return 0, err
+	}
+	for _, job := range queued {
+		s.StartAsync(ctx, job)
+	}
+	return len(queued), nil
+}
+
+// StartRecovery periodically resumes expired and queued work until cancellation.
+func (s *Service) StartRecovery(ctx context.Context, logf func(string, ...any)) <-chan struct{} {
+	done := make(chan struct{})
+	if s == nil {
+		close(done)
+		return done
+	}
+	if _, ok := s.store.(ports.JobLeaseStore); !ok {
+		close(done)
+		return done
+	}
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(defaultRecoveryInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, err := s.Recover(ctx, 0); err != nil && ctx.Err() == nil && logf != nil {
+					logf("recover platform jobs: %v", err)
+				}
+			}
+		}
+	}()
+	return done
+}
+
+// Run claims and executes one job. Stores that implement JobLeaseStore get
+// owner-checked completion, heartbeat, cancellation, and crash recovery.
+func (s *Service) Run(ctx context.Context, jobID string) error {
+	if s == nil || s.store == nil {
+		return ErrRuntimeUnavailable
+	}
+	leaseStore, ok := s.store.(ports.JobLeaseStore)
+	if !ok {
+		return s.runWithoutLease(ctx, jobID)
+	}
+	return s.runWithLease(ctx, jobID, leaseStore)
+}
+
+func (s *Service) runWithLease(ctx context.Context, jobID string, leaseStore ports.JobLeaseStore) (err error) {
+	job, err := s.store.GetJob(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	ctx, span := telemetry.StartMain(ctx, "platform.job.run", jobTelemetryAttrs(job).With(telemetry.Attrs(
+		telemetry.Field{Key: "operation.type", Value: "platform_job"},
+		telemetry.Field{Key: "workload.kind", Value: "platform_job"},
+		telemetry.Field{Key: "job.name", Value: job.Kind},
+		telemetry.Field{Key: "job.status.initial", Value: job.Status},
+	)))
+	status := "failed"
+	spanAttrs := telemetry.Attrs()
+	startedAt := time.Time{}
+	leaseOwner := newJobLeaseOwner()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			status = ports.JobStatusFailed
+			panicErr := fmt.Errorf("%w: %v", ErrJobPanic, recovered)
+			spanAttrs = spanAttrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "job.panic", Value: true},
+				telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(panicErr)},
+				telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("platform.job.run", panicErr, jobTelemetryAttrs(job))},
+			))
+			err = s.failPanickedLeasedJob(context.WithoutCancel(ctx), jobID, leaseOwner, recovered)
+		}
+		if job != nil {
+			spanAttrs = spanAttrs.With(jobTelemetryAttrs(job))
+		}
+		if !startedAt.IsZero() {
+			spanAttrs = spanAttrs.WithField(telemetry.Field{Key: "job.run_duration_ms", Value: s.now().Sub(startedAt).Milliseconds()})
+		}
+		telemetry.End(span, status, spanAttrs.WithField(telemetry.Field{Key: "job.status.final", Value: status}))
+	}()
+
+	runner := s.runners[job.Kind]
+	if runner == nil {
+		finished := s.now()
+		if updated, updateErr := s.store.UpdateJob(ctx, job.ID, ports.JobUpdate{
+			Status:          ports.JobStatusFailed,
+			Message:         "job runner unavailable",
+			Error:           "job runner unavailable",
+			FailureClass:    JobFailurePermanent,
+			FinishedAt:      &finished,
+			AllowedStatuses: []string{ports.JobStatusQueued},
+		}); updateErr == nil {
+			job = updated
+			appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: "job runner unavailable"})
+		}
+		status = ports.JobStatusFailed
+		return fmt.Errorf("%w: runner missing for %s", ErrRuntimeUnavailable, job.Kind)
+	}
+
+	job, err = leaseStore.ClaimJob(ctx, ports.JobClaimRequest{JobID: job.ID, Owner: leaseOwner, Now: s.now(), TTL: s.leaseTTL})
+	if err != nil {
+		if errors.Is(err, ports.ErrJobLeaseConflict) {
+			status = "skipped"
+			spanAttrs = spanAttrs.With(telemetry.Attrs(
+				telemetry.Field{Key: "job.run.skipped", Value: true},
+				telemetry.Field{Key: "job.run.skipped_reason", Value: "lease_conflict"},
+			))
+			return nil
+		}
+		return err
+	}
+	startedAt = job.StartedAt
+	eventType := "started"
+	eventMessage := "job started"
+	if job.Attempt > 1 {
+		eventType = "resumed"
+		eventMessage = "job resumed after recovery"
+	}
+	appendJobEventLogged(ctx, s.store, ports.JobEvent{JobID: job.ID, Type: eventType, Status: ports.JobStatusRunning, Message: eventMessage, Payload: map[string]any{"attempt": job.Attempt}})
+	telemetry.Event(ctx, "platform.job.started", jobTelemetryAttrs(job).With(telemetry.Attrs(
+		telemetry.Field{Key: "job.queue_latency_ms", Value: jobQueueLatencyMs(job)},
+		telemetry.Field{Key: "job.runner.available", Value: true},
+	)))
+
+	runnerCtx, runnerCancel := context.WithCancel(ctx)
+	s.registerJobCancel(job.ID, runnerCancel)
+	var cancelRequested atomic.Bool
+	var leaseLost atomic.Bool
+	heartbeatCtx, stopHeartbeat := context.WithCancel(context.WithoutCancel(ctx))
+	heartbeatDone := make(chan struct{})
+	go func() {
+		defer close(heartbeatDone)
+		ticker := time.NewTicker(s.heartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				renewed, renewErr := leaseStore.RenewJobLease(heartbeatCtx, ports.JobLeaseRenewRequest{JobID: job.ID, Owner: leaseOwner, Now: s.now(), TTL: s.leaseTTL})
+				if renewErr != nil {
+					leaseLost.Store(true)
+					runnerCancel()
+					return
+				}
+				if renewed.CancelRequested {
+					cancelRequested.Store(true)
+					runnerCancel()
+					return
+				}
+			}
+		}
+	}()
+	var cleanupHeartbeat sync.Once
+	cleanup := func() {
+		cleanupHeartbeat.Do(func() {
+			stopHeartbeat()
+			<-heartbeatDone
+			s.unregisterJobCancel(job.ID)
+			runnerCancel()
+		})
+	}
+	defer cleanup()
+
+	result, refs, runErr := runner(runnerCtx, job, s)
+	cleanup()
+
+	if current, getErr := s.store.GetJob(context.WithoutCancel(ctx), job.ID); getErr == nil {
+		job = current
+		if current.CancelRequested {
+			cancelRequested.Store(true)
+		}
+	}
+	if cancelRequested.Load() {
+		finished := s.now()
+		job, err = s.store.UpdateJob(context.WithoutCancel(ctx), job.ID, ports.JobUpdate{
+			Status:             ports.JobStatusCancelled,
+			Message:            "job cancelled",
+			FailureClass:       JobFailureCancelled,
+			FinishedAt:         &finished,
+			AllowedStatuses:    []string{ports.JobStatusRunning},
+			ExpectedLeaseOwner: leaseOwner,
+			ClearLease:         true,
+		})
+		if err != nil {
+			return err
+		}
+		appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "cancelled", Status: ports.JobStatusCancelled, Message: "job cancelled"})
+		status = ports.JobStatusCancelled
+		return nil
+	}
+	if leaseLost.Load() {
+		status = "abandoned"
+		return fmt.Errorf("%w: %s", ports.ErrJobLeaseConflict, job.ID)
+	}
+	if runErr != nil && errors.Is(runErr, context.Canceled) && ctx.Err() != nil {
+		status = "interrupted"
+		return runErr
+	}
+
+	finished := s.now()
+	if runErr != nil {
+		failureClass := classifyJobFailure(runErr)
+		job, err = s.store.UpdateJob(context.WithoutCancel(ctx), job.ID, ports.JobUpdate{
+			Status:             ports.JobStatusFailed,
+			Error:              runErr.Error(),
+			Message:            "job failed",
+			FailureClass:       failureClass,
+			FinishedAt:         &finished,
+			AllowedStatuses:    []string{ports.JobStatusRunning},
+			ExpectedLeaseOwner: leaseOwner,
+			ClearLease:         true,
+		})
+		if err != nil {
+			return err
+		}
+		appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "failed", Status: ports.JobStatusFailed, Message: runErr.Error(), Payload: map[string]any{"failure_class": failureClass, "attempt": job.Attempt}})
+		status = ports.JobStatusFailed
+		spanAttrs = spanAttrs.With(jobResultTelemetryAttrs(result, refs)).With(telemetry.Attrs(
+			telemetry.Field{Key: "error_kind", Value: telemetry.ErrorKind(runErr)},
+			telemetry.Field{Key: "error_fingerprint", Value: telemetry.ErrorFingerprint("platform.job.run", runErr, jobTelemetryAttrs(job))},
+		))
+		telemetry.CaptureError(ctx, "platform.job.failed", runErr, jobTelemetryAttrs(job).With(spanAttrs))
+		return runErr
+	}
+
+	progress := uint32(100)
+	completedJobID := job.ID
+	completedJob, updateErr := s.store.UpdateJob(context.WithoutCancel(ctx), completedJobID, ports.JobUpdate{
+		Status:              ports.JobStatusCompleted,
+		Progress:            &progress,
+		Message:             "job completed",
+		Result:              result,
+		ResultRefs:          refs,
+		FinishedAt:          &finished,
+		AllowedStatuses:     []string{ports.JobStatusRunning},
+		ExpectedLeaseOwner:  leaseOwner,
+		RequireNotCancelled: true,
+		ClearLease:          true,
+	})
+	if updateErr != nil {
+		if errors.Is(updateErr, ports.ErrJobUpdateConflict) {
+			if current, getErr := s.store.GetJob(context.WithoutCancel(ctx), completedJobID); getErr == nil && current.CancelRequested && current.LeaseOwner == leaseOwner {
+				cancelled, cancelErr := s.store.UpdateJob(context.WithoutCancel(ctx), completedJobID, ports.JobUpdate{
+					Status:             ports.JobStatusCancelled,
+					Message:            "job cancelled",
+					FailureClass:       JobFailureCancelled,
+					FinishedAt:         &finished,
+					AllowedStatuses:    []string{ports.JobStatusRunning},
+					ExpectedLeaseOwner: leaseOwner,
+					ClearLease:         true,
+				})
+				if cancelErr == nil {
+					job = cancelled
+					appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "cancelled", Status: ports.JobStatusCancelled, Message: "job cancelled"})
+					status = ports.JobStatusCancelled
+					return nil
+				}
+			}
+			status = "skipped"
+		}
+		return updateErr
+	}
+	job = completedJob
+	appendJobEventLogged(context.WithoutCancel(ctx), s.store, ports.JobEvent{JobID: job.ID, Type: "completed", Status: ports.JobStatusCompleted, Message: "job completed", Payload: map[string]any{"attempt": job.Attempt}})
+	status = ports.JobStatusCompleted
+	spanAttrs = spanAttrs.With(jobResultTelemetryAttrs(result, refs)).With(telemetry.Attrs(
+		telemetry.Field{Key: "job.queue_latency_ms", Value: jobQueueLatencyMs(job)},
+		telemetry.Field{Key: "job.finished_at_unix_ms", Value: finished.UnixMilli()},
+		telemetry.Field{Key: "job.progress_percent", Value: progress},
+	))
+	telemetry.Event(ctx, "platform.job.completed", jobTelemetryAttrs(job).With(spanAttrs))
+	return nil
+}
+
+func (s *Service) runWithoutLease(ctx context.Context, jobID string) (err error) {
 	if s == nil || s.store == nil {
 		return ErrRuntimeUnavailable
 	}
@@ -334,6 +691,90 @@ func (s *Service) failPanickedJob(ctx context.Context, jobID string, recovered a
 	return panicErr
 }
 
+func (s *Service) failPanickedLeasedJob(ctx context.Context, jobID string, owner string, recovered any) error {
+	panicErr := fmt.Errorf("%w: %v", ErrJobPanic, recovered)
+	jobID = strings.TrimSpace(jobID)
+	owner = strings.TrimSpace(owner)
+	if s == nil || s.store == nil || jobID == "" || owner == "" {
+		return panicErr
+	}
+	finished := s.now()
+	_, err := s.store.UpdateJob(ctx, jobID, ports.JobUpdate{
+		Status:             ports.JobStatusFailed,
+		Message:            "job failed",
+		Error:              panicErr.Error(),
+		FailureClass:       JobFailurePermanent,
+		FinishedAt:         &finished,
+		AllowedStatuses:    []string{ports.JobStatusRunning},
+		ExpectedLeaseOwner: owner,
+		ClearLease:         true,
+	})
+	if err != nil {
+		if errors.Is(err, ports.ErrJobUpdateConflict) || errors.Is(err, ports.ErrJobLeaseConflict) {
+			return panicErr
+		}
+		return fmt.Errorf("%w; mark job failed: %w", panicErr, err)
+	}
+	appendJobEventLogged(ctx, s.store, ports.JobEvent{JobID: jobID, Type: "failed", Status: ports.JobStatusFailed, Message: panicErr.Error(), Payload: map[string]any{"failure_class": JobFailurePermanent}})
+	return panicErr
+}
+
+func (s *Service) registerJobCancel(jobID string, cancel context.CancelFunc) {
+	if s == nil || cancel == nil {
+		return
+	}
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.jobCancels == nil {
+		s.jobCancels = map[string]context.CancelFunc{}
+	}
+	s.jobCancels[jobID] = cancel
+	s.mu.Unlock()
+}
+
+func (s *Service) unregisterJobCancel(jobID string) {
+	if s == nil {
+		return
+	}
+	jobID = strings.TrimSpace(jobID)
+	s.mu.Lock()
+	delete(s.jobCancels, jobID)
+	s.mu.Unlock()
+}
+
+func (s *Service) cancelRunningJob(jobID string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	cancel := s.jobCancels[strings.TrimSpace(jobID)]
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func classifyJobFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+	var retryable retryableJobError
+	if errors.As(err, &retryable) || errors.Is(err, context.DeadlineExceeded) {
+		return JobFailureRetryable
+	}
+	if errors.Is(err, context.Canceled) {
+		return JobFailureCancelled
+	}
+	return JobFailurePermanent
+}
+
+func newJobLeaseOwner() string {
+	return "worker-" + strings.TrimPrefix(NewID(), "job-")
+}
+
 func (s *Service) Get(ctx context.Context, id string) (*ports.Job, error) {
 	if s == nil || s.store == nil {
 		return nil, ErrRuntimeUnavailable
@@ -385,6 +826,9 @@ func (s *Service) Cancel(ctx context.Context, jobID string) (*ports.Job, error) 
 		return nil, err
 	}
 	appendJobEventLogged(ctx, s.store, event)
+	if event.Type == "cancellation_requested" {
+		s.cancelRunningJob(jobID)
+	}
 	telemetry.Event(ctx, "platform.job.cancel_requested", jobTelemetryAttrs(job).With(telemetry.Attrs(
 		telemetry.Field{Key: "job.cancel_requested", Value: true},
 		telemetry.Field{Key: "job.cancel.transitioned_terminal", Value: event.Type == "cancelled"},
@@ -419,6 +863,8 @@ func jobTelemetryAttrs(job *ports.Job) telemetry.Attributes {
 		telemetry.Field{Key: "job_subject_id", Value: job.SubjectID},
 		telemetry.Field{Key: "job.progress_percent", Value: job.Progress},
 		telemetry.Field{Key: "job.cancel_requested", Value: job.CancelRequested},
+		telemetry.Field{Key: "job.attempt", Value: job.Attempt},
+		telemetry.Field{Key: "job.failure_class", Value: job.FailureClass},
 		telemetry.Field{Key: "job.created_at_unix_ms", Value: unixMilliOrZero(job.CreatedAt)},
 		telemetry.Field{Key: "job.started_at_unix_ms", Value: unixMilliOrZero(job.StartedAt)},
 		telemetry.Field{Key: "job.finished_at_unix_ms", Value: unixMilliOrZero(job.FinishedAt)},
@@ -534,6 +980,28 @@ func hashText(value string) string {
 	}
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:8])
+}
+
+func jobRequestHash(request ports.CreateJobRequest) (string, error) {
+	payload := struct {
+		Kind        string         `json:"kind"`
+		TenantID    string         `json:"tenant_id"`
+		SubjectType string         `json:"subject_type"`
+		SubjectID   string         `json:"subject_id"`
+		Payload     map[string]any `json:"payload"`
+	}{
+		Kind:        strings.TrimSpace(request.Kind),
+		TenantID:    strings.TrimSpace(request.TenantID),
+		SubjectType: strings.TrimSpace(request.SubjectType),
+		SubjectID:   strings.TrimSpace(request.SubjectID),
+		Payload:     request.Payload,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func appendJobEventLogged(ctx context.Context, store ports.JobStore, event ports.JobEvent) {

--- a/internal/jobs/service.go
+++ b/internal/jobs/service.go
@@ -169,10 +169,6 @@ func (s *Service) StartAsync(ctx context.Context, job *ports.Job) { //nolint:con
 	if s == nil || job == nil {
 		return
 	}
-	runner := s.runners[job.Kind]
-	if runner == nil {
-		return
-	}
 	if ctx == nil {
 		return
 	}

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -505,16 +505,18 @@ func (s *boundedRecoveryJobStore) RecoverJobs(_ context.Context, request ports.J
 	defer s.mu.Unlock()
 	limit := request.Limit
 	if limit == 0 {
-		limit = uint32(len(s.order))
+		limit = ^uint32(0)
 	}
-	jobs := make([]*ports.Job, 0, limit)
+	jobs := make([]*ports.Job, 0, len(s.order))
+	var recovered uint32
 	for _, id := range s.order {
 		job := s.jobs[id]
 		if job == nil || job.Status != ports.JobStatusQueued || job.CancelRequested {
 			continue
 		}
 		jobs = append(jobs, cloneJob(job))
-		if uint32(len(jobs)) == limit {
+		recovered++
+		if recovered == limit {
 			break
 		}
 	}

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -27,6 +27,26 @@ func TestCreateRejectsUnsupportedKind(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsIdempotencyKeyWithDifferentRequest(t *testing.T) {
+	service := New(newMemoryJobStore())
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return nil, nil, nil
+	})
+	first := ports.CreateJobRequest{Kind: KindReportRun, TenantID: "tenant-a", IdempotencyKey: "same-key", Payload: map[string]any{"report_id": "one"}}
+	job, created, err := service.Create(context.Background(), first)
+	if err != nil || !created {
+		t.Fatalf("Create(first) job=%+v created=%v error=%v", job, created, err)
+	}
+	reused, created, err := service.Create(context.Background(), first)
+	if err != nil || created || reused.ID != job.ID {
+		t.Fatalf("Create(reuse) job=%+v created=%v error=%v", reused, created, err)
+	}
+	_, _, err = service.Create(context.Background(), ports.CreateJobRequest{Kind: KindReportRun, TenantID: "tenant-a", IdempotencyKey: "same-key", Payload: map[string]any{"report_id": "two"}})
+	if !errors.Is(err, ports.ErrJobIdempotencyConflict) {
+		t.Fatalf("Create(conflict) error = %v, want ErrJobIdempotencyConflict", err)
+	}
+}
+
 func TestCancelDoesNotOverwriteTerminalJob(t *testing.T) {
 	store := newMemoryJobStore()
 	store.jobs["job-complete"] = &ports.Job{ID: "job-complete", Kind: KindReportRun, Status: ports.JobStatusCompleted}
@@ -259,11 +279,175 @@ func TestStartAsyncDetachesFromRequestAndWaitCancelsJob(t *testing.T) {
 	}
 }
 
+func TestRunCancellationTransitionsLeasedJobToCancelled(t *testing.T) {
+	store := newMemoryJobStore()
+	service := New(store).WithLeaseTiming(200*time.Millisecond, 20*time.Millisecond)
+	started := make(chan struct{})
+	service.WithRunner(KindReportRun, func(ctx context.Context, _ *ports.Job, _ *Service) (map[string]any, map[string]string, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	})
+	job, _, err := service.Create(context.Background(), ports.CreateJobRequest{Kind: KindReportRun})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	service.StartAsync(context.Background(), job)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not start")
+	}
+	if _, err := service.Cancel(context.Background(), job.ID); err != nil {
+		t.Fatalf("Cancel() error = %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		stored, getErr := store.GetJob(context.Background(), job.ID)
+		if getErr != nil {
+			t.Fatalf("GetJob() error = %v", getErr)
+		}
+		if stored.Status == ports.JobStatusCancelled {
+			if stored.LeaseOwner != "" || !stored.LeaseExpiresAt.IsZero() {
+				t.Fatalf("cancelled job retained lease: %+v", stored)
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("job did not transition to cancelled")
+}
+
+func TestRecoverRestartsExpiredLeasedJob(t *testing.T) {
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newMemoryJobStore()
+	store.jobs["job-expired"] = &ports.Job{
+		ID:             "job-expired",
+		Kind:           KindReportRun,
+		Status:         ports.JobStatusRunning,
+		Attempt:        1,
+		LeaseOwner:     "dead-worker",
+		LeaseExpiresAt: now.Add(-time.Minute),
+	}
+	service := New(store)
+	service.now = func() time.Time { return now }
+	completed := make(chan struct{})
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		close(completed)
+		return nil, nil, nil
+	})
+
+	count, err := service.Recover(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("Recover() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("Recover() count = %d, want 1", count)
+	}
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("recovered job did not execute")
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		stored, getErr := store.GetJob(context.Background(), "job-expired")
+		if getErr != nil {
+			t.Fatalf("GetJob() error = %v", getErr)
+		}
+		if stored.Status == ports.JobStatusCompleted {
+			if stored.Attempt != 2 {
+				t.Fatalf("attempt = %d, want 2", stored.Attempt)
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("recovered job did not complete")
+}
+
+func TestRunClassifiesRetryableFailure(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-retryable"] = &ports.Job{ID: "job-retryable", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store)
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		return nil, nil, Retryable(errors.New("temporary dependency failure"))
+	})
+
+	if err := service.Run(context.Background(), "job-retryable"); err == nil {
+		t.Fatal("Run() error = nil, want retryable failure")
+	}
+	stored, err := store.GetJob(context.Background(), "job-retryable")
+	if err != nil {
+		t.Fatalf("GetJob() error = %v", err)
+	}
+	if stored.Status != ports.JobStatusFailed || stored.FailureClass != JobFailureRetryable {
+		t.Fatalf("job = %+v, want failed/retryable", stored)
+	}
+}
+
+func TestRunRenewsLeaseDuringLongExecution(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-heartbeat"] = &ports.Job{ID: "job-heartbeat", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store).WithLeaseTiming(100*time.Millisecond, 10*time.Millisecond)
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		time.Sleep(35 * time.Millisecond)
+		return nil, nil, nil
+	})
+
+	if err := service.Run(context.Background(), "job-heartbeat"); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	store.mu.Lock()
+	renewCount := store.renewCount
+	store.mu.Unlock()
+	if renewCount == 0 {
+		t.Fatal("job lease was not renewed")
+	}
+}
+
+func TestRunCannotCompleteAfterLeaseOwnershipChanges(t *testing.T) {
+	store := newMemoryJobStore()
+	store.jobs["job-stale-worker"] = &ports.Job{ID: "job-stale-worker", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store).WithLeaseTiming(time.Second, 500*time.Millisecond)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		close(started)
+		<-release
+		return nil, nil, nil
+	})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- service.Run(context.Background(), "job-stale-worker")
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not start")
+	}
+	store.mu.Lock()
+	store.jobs["job-stale-worker"].LeaseOwner = "replacement-worker"
+	store.mu.Unlock()
+	close(release)
+	if err := <-errCh; !errors.Is(err, ports.ErrJobUpdateConflict) {
+		t.Fatalf("Run() error = %v, want ErrJobUpdateConflict", err)
+	}
+	stored, err := store.GetJob(context.Background(), "job-stale-worker")
+	if err != nil {
+		t.Fatalf("GetJob() error = %v", err)
+	}
+	if stored.Status != ports.JobStatusRunning || stored.LeaseOwner != "replacement-worker" {
+		t.Fatalf("stale worker changed job: %+v", stored)
+	}
+}
+
 type memoryJobStore struct {
-	mu     sync.Mutex
-	nextID int
-	jobs   map[string]*ports.Job
-	events []*ports.JobEvent
+	mu         sync.Mutex
+	nextID     int
+	jobs       map[string]*ports.Job
+	events     []*ports.JobEvent
+	renewCount int
 }
 
 func newMemoryJobStore() *memoryJobStore {
@@ -277,6 +461,16 @@ func (s *memoryJobStore) Ping(context.Context) error {
 func (s *memoryJobStore) CreateJob(_ context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if request.IdempotencyKey != "" {
+		for _, existing := range s.jobs {
+			if existing.TenantID == request.TenantID && existing.IdempotencyKey == request.IdempotencyKey {
+				if existing.RequestHash != request.RequestHash {
+					return nil, false, ports.ErrJobIdempotencyConflict
+				}
+				return cloneJob(existing), false, nil
+			}
+		}
+	}
 	id := "job-test"
 	if s.nextID > 1 {
 		id = fmt.Sprintf("job-test-%d", s.nextID)
@@ -290,6 +484,7 @@ func (s *memoryJobStore) CreateJob(_ context.Context, request ports.CreateJobReq
 		SubjectType:    request.SubjectType,
 		SubjectID:      request.SubjectID,
 		IdempotencyKey: request.IdempotencyKey,
+		RequestHash:    request.RequestHash,
 		Payload:        cloneAnyMap(request.Payload),
 	}
 	s.jobs[id] = cloneJob(job)
@@ -324,6 +519,12 @@ func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.Jo
 	if len(update.AllowedStatuses) > 0 && !containsStatus(update.AllowedStatuses, job.Status) {
 		return nil, ports.ErrJobUpdateConflict
 	}
+	if update.ExpectedLeaseOwner != "" && update.ExpectedLeaseOwner != job.LeaseOwner {
+		return nil, ports.ErrJobUpdateConflict
+	}
+	if update.RequireNotCancelled && job.CancelRequested {
+		return nil, ports.ErrJobUpdateConflict
+	}
 	if update.Status != "" {
 		job.Status = update.Status
 	}
@@ -335,6 +536,9 @@ func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.Jo
 	}
 	if update.Error != "" {
 		job.Error = update.Error
+	}
+	if update.FailureClass != "" {
+		job.FailureClass = update.FailureClass
 	}
 	if update.Result != nil {
 		job.Result = cloneAnyMap(update.Result)
@@ -351,7 +555,69 @@ func (s *memoryJobStore) UpdateJob(_ context.Context, id string, update ports.Jo
 	if update.CancelRequested != nil {
 		job.CancelRequested = *update.CancelRequested
 	}
+	if update.ClearLease {
+		job.LeaseOwner = ""
+		job.LeaseExpiresAt = time.Time{}
+		job.HeartbeatAt = time.Time{}
+	}
 	return cloneJob(job), nil
+}
+
+func (s *memoryJobStore) ClaimJob(_ context.Context, request ports.JobClaimRequest) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[request.JobID]
+	if !ok {
+		return nil, ports.ErrJobNotFound
+	}
+	now := request.Now.UTC()
+	claimable := job.Status == ports.JobStatusQueued || (job.Status == ports.JobStatusRunning && (job.LeaseExpiresAt.IsZero() || !job.LeaseExpiresAt.After(now)))
+	if !claimable || job.CancelRequested {
+		return nil, ports.ErrJobLeaseConflict
+	}
+	job.Status = ports.JobStatusRunning
+	job.Attempt++
+	job.LeaseOwner = request.Owner
+	job.LeaseExpiresAt = now.Add(request.TTL)
+	job.HeartbeatAt = now
+	if job.StartedAt.IsZero() {
+		job.StartedAt = now
+	}
+	return cloneJob(job), nil
+}
+
+func (s *memoryJobStore) RenewJobLease(_ context.Context, request ports.JobLeaseRenewRequest) (*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[request.JobID]
+	if !ok {
+		return nil, ports.ErrJobNotFound
+	}
+	if job.Status != ports.JobStatusRunning || job.LeaseOwner != request.Owner || !job.LeaseExpiresAt.After(request.Now) {
+		return nil, ports.ErrJobLeaseConflict
+	}
+	job.HeartbeatAt = request.Now
+	job.LeaseExpiresAt = request.Now.Add(request.TTL)
+	s.renewCount++
+	return cloneJob(job), nil
+}
+
+func (s *memoryJobStore) RecoverJobs(_ context.Context, request ports.JobRecoveryRequest) ([]*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	jobs := make([]*ports.Job, 0)
+	for _, job := range s.jobs {
+		if job.Status == ports.JobStatusRunning && (job.LeaseExpiresAt.IsZero() || !job.LeaseExpiresAt.After(request.Now)) {
+			job.Status = ports.JobStatusQueued
+			job.LeaseOwner = ""
+			job.LeaseExpiresAt = time.Time{}
+			job.HeartbeatAt = time.Time{}
+		}
+		if job.Status == ports.JobStatusQueued && !job.CancelRequested {
+			jobs = append(jobs, cloneJob(job))
+		}
+	}
+	return jobs, nil
 }
 
 func (s *memoryJobStore) AppendJobEvent(_ context.Context, event ports.JobEvent) (*ports.JobEvent, error) {

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -366,6 +366,51 @@ func TestRecoverRestartsExpiredLeasedJob(t *testing.T) {
 	t.Fatal("recovered job did not complete")
 }
 
+func TestRecoverMarksMissingRunnerTerminalBeforeNextBatch(t *testing.T) {
+	store := &boundedRecoveryJobStore{
+		memoryJobStore: newMemoryJobStore(),
+		order:          []string{"job-orphan", "job-valid"},
+	}
+	store.jobs["job-orphan"] = &ports.Job{ID: "job-orphan", Kind: "removed_job_kind", Status: ports.JobStatusQueued}
+	store.jobs["job-valid"] = &ports.Job{ID: "job-valid", Kind: KindReportRun, Status: ports.JobStatusQueued}
+	service := New(store)
+	completed := make(chan struct{})
+	service.WithRunner(KindReportRun, func(context.Context, *ports.Job, *Service) (map[string]any, map[string]string, error) {
+		close(completed)
+		return nil, nil, nil
+	})
+
+	count, err := service.Recover(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Recover(orphan) error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("Recover(orphan) count = %d, want 1", count)
+	}
+	waitForJobStatus(t, store.memoryJobStore, "job-orphan", ports.JobStatusFailed)
+	orphan, err := store.GetJob(context.Background(), "job-orphan")
+	if err != nil {
+		t.Fatalf("GetJob(orphan) error = %v", err)
+	}
+	if orphan.FailureClass != JobFailurePermanent || orphan.Error != "job runner unavailable" {
+		t.Fatalf("orphan job = %+v, want permanent runner-unavailable failure", orphan)
+	}
+
+	count, err = service.Recover(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Recover(valid) error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("Recover(valid) count = %d, want 1", count)
+	}
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("valid job behind orphan did not execute")
+	}
+	waitForJobStatus(t, store.memoryJobStore, "job-valid", ports.JobStatusCompleted)
+}
+
 func TestRunClassifiesRetryableFailure(t *testing.T) {
 	store := newMemoryJobStore()
 	store.jobs["job-retryable"] = &ports.Job{ID: "job-retryable", Kind: KindReportRun, Status: ports.JobStatusQueued}
@@ -448,6 +493,32 @@ type memoryJobStore struct {
 	jobs       map[string]*ports.Job
 	events     []*ports.JobEvent
 	renewCount int
+}
+
+type boundedRecoveryJobStore struct {
+	*memoryJobStore
+	order []string
+}
+
+func (s *boundedRecoveryJobStore) RecoverJobs(_ context.Context, request ports.JobRecoveryRequest) ([]*ports.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	limit := request.Limit
+	if limit == 0 {
+		limit = uint32(len(s.order))
+	}
+	jobs := make([]*ports.Job, 0, limit)
+	for _, id := range s.order {
+		job := s.jobs[id]
+		if job == nil || job.Status != ports.JobStatusQueued || job.CancelRequested {
+			continue
+		}
+		jobs = append(jobs, cloneJob(job))
+		if uint32(len(jobs)) == limit {
+			break
+		}
+	}
+	return jobs, nil
 }
 
 func newMemoryJobStore() *memoryJobStore {
@@ -672,6 +743,22 @@ func cloneStringMap(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func waitForJobStatus(t *testing.T, store *memoryJobStore, jobID string, status string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		job, err := store.GetJob(context.Background(), jobID)
+		if err != nil {
+			t.Fatalf("GetJob(%s) error = %v", jobID, err)
+		}
+		if job.Status == status {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not transition to %s", jobID, status)
 }
 
 func captureJobServiceStderr(t *testing.T, fn func()) string {

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -15,6 +15,7 @@ const EventAttributeJobID = "job_id"
 
 var ErrAppendLogDeadLetterNotFound = errors.New("append log dead letter not found")
 var ErrAppendLogDeadLetterAlreadyReplayed = errors.New("append log dead letter already replayed")
+var ErrReplayCursorNotFound = errors.New("append log replay cursor not found")
 
 const (
 	AppendLogDeadLetterStatusPending   = "pending"
@@ -122,11 +123,26 @@ type ReplayRequest struct {
 	TenantID            string
 	AttributeEquals     map[string]string
 	Limit               uint32
+	Cursor              string
 }
 
 // EventReplayer replays stored event envelopes from the append log.
 type EventReplayer interface {
 	Replay(context.Context, ReplayRequest) ([]*cerebrov1.EventEnvelope, error)
+}
+
+// ReplayPage is one bounded replay page. NextCursor is opaque to callers and
+// resumes strictly before the oldest event returned in this page.
+type ReplayPage struct {
+	Events     []*cerebrov1.EventEnvelope
+	NextCursor string
+	Complete   bool
+}
+
+// EventReplayPager traverses arbitrarily large filtered event sets without
+// increasing the per-request replay bound.
+type EventReplayPager interface {
+	ReplayPage(context.Context, ReplayRequest) (ReplayPage, error)
 }
 
 // RuntimeIndexEntry is one append-log message indexed by source runtime and stream sequence.

--- a/internal/ports/compliance_inputs.go
+++ b/internal/ports/compliance_inputs.go
@@ -1,0 +1,45 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// ErrInputSnapshotChanged indicates that a paged input no longer has the total
+// observed on its first page. Callers must discard the partial snapshot and retry.
+var ErrInputSnapshotChanged = errors.New("input snapshot changed during scan")
+
+// InputSnapshotRequest scopes one complete, cutoff-bounded keyset scan.
+// ExpectedTotal and ExpectedWatermark are supplied after the first page to
+// detect inserts, deletes, or mutable rows during later pages.
+type InputSnapshotRequest struct {
+	TenantID          string
+	RuntimeIDs        []string
+	Cutoff            time.Time
+	AfterID           string
+	Limit             uint32
+	ExpectedTotal     *uint64
+	ExpectedWatermark *time.Time
+}
+
+// InputSnapshotPage contains proof needed to assemble a complete input manifest.
+type InputSnapshotPage[T any] struct {
+	Records    []T
+	Total      uint64
+	NextCursor string
+	Complete   bool
+	Cutoff     time.Time
+	Watermark  time.Time
+}
+
+// ComplianceInputSnapshotStore exposes assessment-only scans that are not bound
+// by UI list limits. Each page is read in a repeatable-read transaction and is
+// stable by tenant, cutoff, and primary-key cursor.
+type ComplianceInputSnapshotStore interface {
+	ScanFindingSnapshot(context.Context, InputSnapshotRequest) (InputSnapshotPage[*FindingRecord], error)
+	ScanFindingEvidenceSnapshot(context.Context, InputSnapshotRequest) (InputSnapshotPage[*cerebrov1.FindingEvidence], error)
+	ScanSourceRuntimeSnapshot(context.Context, InputSnapshotRequest) (InputSnapshotPage[*cerebrov1.SourceRuntime], error)
+}

--- a/internal/ports/evidence_ledger.go
+++ b/internal/ports/evidence_ledger.go
@@ -1,0 +1,165 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrEvidenceArtifactNotFound = errors.New("evidence artifact not found")
+	ErrEvidenceVersionNotFound  = errors.New("evidence version not found")
+	ErrEvidenceClaimNotFound    = errors.New("evidence claim not found")
+	ErrEvidenceLedgerConflict   = errors.New("evidence ledger version conflict")
+	ErrEvidenceAccessDenied     = errors.New("evidence access denied")
+)
+
+const (
+	EvidenceStateCollected        = "collected"
+	EvidenceStateValidationFailed = "validation_failed"
+	EvidenceStateUnderReview      = "under_review"
+	EvidenceStateApproved         = "approved"
+	EvidenceStateStale            = "stale"
+	EvidenceStateSuperseded       = "superseded"
+	EvidenceStateRevoked          = "revoked"
+
+	EvidenceReviewPending  = "pending"
+	EvidenceReviewApproved = "approved"
+	EvidenceReviewRejected = "rejected"
+
+	EvidenceLinkDirect    = "direct"
+	EvidenceLinkInherited = "inherited"
+	EvidenceLinkInferred  = "inferred"
+
+	EvidenceSensitivityPublic       = "public"
+	EvidenceSensitivityInternal     = "internal"
+	EvidenceSensitivityConfidential = "confidential"
+	EvidenceSensitivityRestricted   = "restricted"
+)
+
+// EvidenceArtifact is the stable logical record. It never contains bytes.
+type EvidenceArtifact struct {
+	ID          string    `json:"id"`
+	TenantID    string    `json:"tenant_id"`
+	Title       string    `json:"title"`
+	Description string    `json:"description,omitempty"`
+	Type        string    `json:"type"`
+	CreatedAt   time.Time `json:"created_at"`
+	CreatedBy   string    `json:"created_by"`
+}
+
+type EvidenceRevisionRef struct {
+	ID            string    `json:"id"`
+	RevisionID    string    `json:"revision_id"`
+	Version       uint64    `json:"version"`
+	ContentDigest string    `json:"content_digest"`
+	LastModified  time.Time `json:"last_modified"`
+}
+
+type EvidenceSubjectRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+type EvidenceContentRef struct {
+	MediaType     string `json:"media_type"`
+	URI           string `json:"uri"`
+	ContentDigest string `json:"content_digest"`
+	SizeBytes     uint64 `json:"size_bytes"`
+}
+
+type EvidenceProvenance struct {
+	Producer              string    `json:"producer"`
+	ProducerVersion       string    `json:"producer_version,omitempty"`
+	CollectedAt           time.Time `json:"collected_at"`
+	PeriodStart           time.Time `json:"period_start,omitempty"`
+	PeriodEnd             time.Time `json:"period_end,omitempty"`
+	SourceRuntimeID       string    `json:"source_runtime_id,omitempty"`
+	SourceEventID         string    `json:"source_event_id,omitempty"`
+	SourceProofRevisionID string    `json:"source_proof_revision_id"`
+	DerivationIDs         []string  `json:"derivation_ids,omitempty"`
+}
+
+type EvidenceGovernance struct {
+	Sensitivity    string    `json:"sensitivity"`
+	AccessPolicy   string    `json:"access_policy"`
+	RetentionUntil time.Time `json:"retention_until,omitempty"`
+	LegalHold      bool      `json:"legal_hold,omitempty"`
+	RedactionState string    `json:"redaction_state,omitempty"`
+	ParserQuality  string    `json:"parser_quality,omitempty"`
+}
+
+// EvidenceVersion points to immutable bytes in the approved content-addressed
+// system or an approved external reference. Content is never stored here.
+type EvidenceVersion struct {
+	ID               string               `json:"id"`
+	TenantID         string               `json:"tenant_id"`
+	ArtifactID       string               `json:"artifact_id"`
+	Revision         EvidenceRevisionRef  `json:"revision"`
+	Content          EvidenceContentRef   `json:"content"`
+	Provenance       EvidenceProvenance   `json:"provenance"`
+	Governance       EvidenceGovernance   `json:"governance"`
+	ValidFrom        time.Time            `json:"valid_from"`
+	ValidUntil       time.Time            `json:"valid_until,omitempty"`
+	Subjects         []EvidenceSubjectRef `json:"subjects"`
+	State            string               `json:"state"`
+	QuarantineReason string               `json:"quarantine_reason,omitempty"`
+	PredecessorID    string               `json:"predecessor_id,omitempty"`
+	RecordedAt       time.Time            `json:"recorded_at"`
+}
+
+type EvidenceClaimScope struct {
+	ObjectiveID              string               `json:"objective_id"`
+	ImplementationRevisionID string               `json:"implementation_revision_id"`
+	RequirementID            string               `json:"requirement_id"`
+	Subjects                 []EvidenceSubjectRef `json:"subjects"`
+	PeriodStart              time.Time            `json:"period_start"`
+	PeriodEnd                time.Time            `json:"period_end"`
+}
+
+type EvidenceClaimDecision struct {
+	ReviewState        string    `json:"review_state"`
+	ReviewerID         string    `json:"reviewer_id,omitempty"`
+	ReviewReason       string    `json:"review_reason,omitempty"`
+	ReviewedAt         time.Time `json:"reviewed_at,omitempty"`
+	InvalidatedAt      time.Time `json:"invalidated_at,omitempty"`
+	InvalidationReason string    `json:"invalidation_reason,omitempty"`
+}
+
+type EvidenceClaim struct {
+	ID                string                `json:"id"`
+	TenantID          string                `json:"tenant_id"`
+	ArtifactVersionID string                `json:"artifact_version_id"`
+	Scope             EvidenceClaimScope    `json:"scope"`
+	Linkage           string                `json:"linkage"`
+	Strength          string                `json:"strength"`
+	Limitation        string                `json:"limitation,omitempty"`
+	MappingRationale  string                `json:"mapping_rationale"`
+	Decision          EvidenceClaimDecision `json:"decision"`
+	Version           uint64                `json:"version"`
+	CreatedAt         time.Time             `json:"created_at"`
+	CreatedBy         string                `json:"created_by"`
+}
+
+type EvidenceAccessRequest struct {
+	TenantID           string
+	Purpose            string
+	MaximumSensitivity string
+	ActorID            string
+}
+
+type EvidenceClaimValidation struct {
+	Valid       bool     `json:"valid"`
+	ReasonCodes []string `json:"reason_codes"`
+	NextActions []string `json:"next_actions"`
+}
+
+// EvidenceLedgerStore applies append-log events idempotently to current state.
+type EvidenceLedgerStore interface {
+	ApplyEvidenceVersion(context.Context, string, EvidenceArtifact, EvidenceVersion) error
+	ApplyEvidenceClaim(context.Context, string, EvidenceClaim, uint64) error
+	GetEvidenceArtifact(context.Context, string, string) (EvidenceArtifact, error)
+	GetEvidenceVersion(context.Context, string, string) (EvidenceVersion, error)
+	GetEvidenceClaim(context.Context, string, string) (EvidenceClaim, error)
+	ListEvidenceClaimsByVersion(context.Context, string, string) ([]EvidenceClaim, error)
+}

--- a/internal/ports/jobs.go
+++ b/internal/ports/jobs.go
@@ -12,6 +12,12 @@ var ErrJobNotFound = errors.New("platform job not found")
 // ErrJobUpdateConflict indicates that a conditional job state update lost a race.
 var ErrJobUpdateConflict = errors.New("platform job update conflict")
 
+// ErrJobLeaseConflict indicates that a worker no longer owns a job lease.
+var ErrJobLeaseConflict = errors.New("platform job lease conflict")
+
+// ErrJobIdempotencyConflict indicates reuse of a key for a different request.
+var ErrJobIdempotencyConflict = errors.New("platform job idempotency conflict")
+
 const (
 	JobStatusQueued    = "queued"
 	JobStatusRunning   = "running"
@@ -29,6 +35,7 @@ type Job struct {
 	SubjectType     string            `json:"subject_type,omitempty"`
 	SubjectID       string            `json:"subject_id,omitempty"`
 	IdempotencyKey  string            `json:"idempotency_key,omitempty"`
+	RequestHash     string            `json:"-"`
 	Progress        uint32            `json:"progress_percent,omitempty"`
 	Message         string            `json:"message,omitempty"`
 	Error           string            `json:"error,omitempty"`
@@ -36,6 +43,11 @@ type Job struct {
 	Result          map[string]any    `json:"result,omitempty"`
 	ResultRefs      map[string]string `json:"result_refs,omitempty"`
 	CancelRequested bool              `json:"cancel_requested,omitempty"`
+	Attempt         uint32            `json:"attempt,omitempty"`
+	LeaseOwner      string            `json:"-"`
+	LeaseExpiresAt  time.Time         `json:"lease_expires_at,omitempty"`
+	HeartbeatAt     time.Time         `json:"heartbeat_at,omitempty"`
+	FailureClass    string            `json:"failure_class,omitempty"`
 	CreatedAt       time.Time         `json:"created_at,omitempty"`
 	StartedAt       time.Time         `json:"started_at,omitempty"`
 	FinishedAt      time.Time         `json:"finished_at,omitempty"`
@@ -60,6 +72,7 @@ type CreateJobRequest struct {
 	SubjectType    string
 	SubjectID      string
 	IdempotencyKey string
+	RequestHash    string
 	Payload        map[string]any
 }
 
@@ -73,16 +86,42 @@ type JobFilter struct {
 
 // JobUpdate describes a partial job state update.
 type JobUpdate struct {
-	Status          string
-	Progress        *uint32
-	Message         string
-	Error           string
-	Result          map[string]any
-	ResultRefs      map[string]string
-	StartedAt       *time.Time
-	FinishedAt      *time.Time
-	CancelRequested *bool
-	AllowedStatuses []string
+	Status              string
+	Progress            *uint32
+	Message             string
+	Error               string
+	FailureClass        string
+	Result              map[string]any
+	ResultRefs          map[string]string
+	StartedAt           *time.Time
+	FinishedAt          *time.Time
+	CancelRequested     *bool
+	AllowedStatuses     []string
+	ExpectedLeaseOwner  string
+	RequireNotCancelled bool
+	ClearLease          bool
+}
+
+// JobClaimRequest atomically claims queued or expired work for one worker.
+type JobClaimRequest struct {
+	JobID string
+	Owner string
+	Now   time.Time
+	TTL   time.Duration
+}
+
+// JobLeaseRenewRequest extends one running job lease.
+type JobLeaseRenewRequest struct {
+	JobID string
+	Owner string
+	Now   time.Time
+	TTL   time.Duration
+}
+
+// JobRecoveryRequest resets expired work and returns queued jobs for startup.
+type JobRecoveryRequest struct {
+	Now   time.Time
+	Limit uint32
 }
 
 // JobStore persists platform jobs and their timeline events.
@@ -95,4 +134,13 @@ type JobStore interface {
 	UpdateJob(context.Context, string, JobUpdate) (*Job, error)
 	AppendJobEvent(context.Context, JobEvent) (*JobEvent, error)
 	ListJobEvents(context.Context, string, uint32) ([]*JobEvent, error)
+}
+
+// JobLeaseStore is the durable execution capability used by platform workers.
+// It is separate from JobStore so read-only test and integration stores do not
+// accidentally claim to provide recoverable execution.
+type JobLeaseStore interface {
+	ClaimJob(context.Context, JobClaimRequest) (*Job, error)
+	RenewJobLease(context.Context, JobLeaseRenewRequest) (*Job, error)
+	RecoverJobs(context.Context, JobRecoveryRequest) ([]*Job, error)
 }

--- a/internal/ports/reports.go
+++ b/internal/ports/reports.go
@@ -45,6 +45,8 @@ type ReportSchedule struct {
 	Enabled         bool
 	NextRunAt       time.Time
 	LastRunAt       time.Time
+	ClaimOwner      string
+	ClaimExpiresAt  time.Time
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
@@ -63,5 +65,7 @@ type ReportScheduleStore interface {
 	GetReportSchedule(context.Context, string) (*ReportSchedule, error)
 	ListReportSchedules(context.Context, ReportScheduleFilter) ([]*ReportSchedule, error)
 	DeleteReportSchedule(context.Context, string) error
-	ClaimDueReportSchedules(context.Context, time.Time, uint32) ([]*ReportSchedule, error)
+	ClaimDueReportSchedules(context.Context, time.Time, string, time.Duration, uint32) ([]*ReportSchedule, error)
+	CompleteReportScheduleClaim(context.Context, string, string, time.Time, time.Time) error
+	ReleaseReportScheduleClaim(context.Context, string, string) error
 }

--- a/internal/reportschedule/run.go
+++ b/internal/reportschedule/run.go
@@ -1,0 +1,92 @@
+package reportschedule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	claimBatch  = uint32(50)
+	claimTTL    = 2 * time.Minute
+	subjectType = "report_schedule"
+)
+
+// RunDue claims due occurrences, creates their idempotent jobs, and advances a
+// schedule only after job creation succeeds.
+func RunDue(ctx context.Context, store ports.ReportScheduleStore, jobs *platformjobs.Service, now time.Time) (int, error) {
+	if store == nil || jobs == nil {
+		return 0, nil
+	}
+	now = now.UTC()
+	owner := newClaimOwner()
+	due, err := store.ClaimDueReportSchedules(ctx, now, owner, claimTTL, claimBatch)
+	if err != nil {
+		return 0, err
+	}
+	enqueued := 0
+	var errs []error
+	for _, schedule := range due {
+		if err := enqueue(ctx, jobs, schedule); err != nil {
+			_ = store.ReleaseReportScheduleClaim(context.WithoutCancel(ctx), schedule.ID, owner)
+			errs = append(errs, fmt.Errorf("report schedule %q: %w", schedule.ID, err))
+			continue
+		}
+		if err := store.CompleteReportScheduleClaim(context.WithoutCancel(ctx), schedule.ID, owner, schedule.NextRunAt, now); err != nil {
+			errs = append(errs, fmt.Errorf("report schedule %q completion: %w", schedule.ID, err))
+			continue
+		}
+		enqueued++
+	}
+	return enqueued, errors.Join(errs...)
+}
+
+func enqueue(ctx context.Context, jobs *platformjobs.Service, schedule *ports.ReportSchedule) error {
+	if schedule == nil {
+		return nil
+	}
+	parameters := make(map[string]any, len(schedule.Parameters)+1)
+	for key, value := range schedule.Parameters {
+		parameters[key] = value
+	}
+	if tenantID := strings.TrimSpace(schedule.TenantID); tenantID != "" {
+		if _, ok := parameters["tenant_id"]; !ok {
+			parameters["tenant_id"] = tenantID
+		}
+	}
+	job, created, err := jobs.Create(ctx, ports.CreateJobRequest{
+		Kind:           platformjobs.KindReportRun,
+		TenantID:       schedule.TenantID,
+		SubjectType:    subjectType,
+		SubjectID:      schedule.ID,
+		IdempotencyKey: occurrenceKey(schedule),
+		Payload: map[string]any{
+			"report_id":     schedule.ReportID,
+			"parameters":    parameters,
+			"scheduled_for": schedule.NextRunAt.UTC().Format(time.RFC3339Nano),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if created {
+		jobs.StartAsync(ctx, job)
+	}
+	return nil
+}
+
+func occurrenceKey(schedule *ports.ReportSchedule) string {
+	if schedule == nil {
+		return ""
+	}
+	return "report-schedule:" + strings.TrimSpace(schedule.ID) + ":" + schedule.NextRunAt.UTC().Format(time.RFC3339Nano)
+}
+
+func newClaimOwner() string {
+	return "scheduler-" + strings.TrimPrefix(platformjobs.NewID(), "job-")
+}

--- a/internal/statestore/postgres/compliance_inputs.go
+++ b/internal/statestore/postgres/compliance_inputs.go
@@ -1,0 +1,332 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	defaultInputSnapshotPageSize = uint32(250)
+	maxInputSnapshotPageSize     = uint32(500)
+)
+
+// ScanFindingSnapshot returns one cutoff-bounded finding page with a stable ID
+// cursor and an invariant total for complete assessment collection.
+func (s *Store) ScanFindingSnapshot(ctx context.Context, request ports.InputSnapshotRequest) (ports.InputSnapshotPage[*ports.FindingRecord], error) {
+	normalized, err := normalizeInputSnapshotRequest(request)
+	if err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	if s == nil || s.db == nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, fmt.Errorf("begin finding snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	scopeClauses, scopeArgs := inputSnapshotScopeClauses(normalized, "tenant_id", "runtime_id")
+	total, watermark, err := measureInputSnapshot(ctx, tx, "findings", scopeClauses, scopeArgs)
+	if err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	if err := verifyInputSnapshotInvariant(normalized, total, watermark); err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	clauses, args := addInputSnapshotCutoff(scopeClauses, scopeArgs, normalized.Cutoff)
+	pageClauses, pageArgs := addInputSnapshotCursor(clauses, args, normalized.AfterID)
+	pageArgs = append(pageArgs, int64(normalized.Limit+1))
+	// #nosec G201 -- columns and predicates are fixed; all values are parameterized.
+	query := fmt.Sprintf(`
+SELECT %s
+FROM findings
+WHERE %s
+ORDER BY id ASC
+LIMIT $%d`, findingSelectColumns, strings.Join(pageClauses, " AND "), len(pageArgs))
+	rows, err := tx.QueryContext(ctx, query, pageArgs...)
+	if err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, fmt.Errorf("query finding snapshot: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]*ports.FindingRecord, 0, normalized.Limit+1)
+	for rows.Next() {
+		var row findingRow
+		if err := scanFindingRow(rows, &row); err != nil {
+			return ports.InputSnapshotPage[*ports.FindingRecord]{}, fmt.Errorf("scan finding snapshot: %w", err)
+		}
+		record, err := row.record()
+		if err != nil {
+			return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, err
+	}
+	page := finishInputSnapshotPage(records, normalized, total, watermark, func(record *ports.FindingRecord) string { return record.ID })
+	if err := tx.Commit(); err != nil {
+		return ports.InputSnapshotPage[*ports.FindingRecord]{}, fmt.Errorf("commit finding snapshot: %w", err)
+	}
+	return page, nil
+}
+
+// ScanFindingEvidenceSnapshot returns one complete-collection evidence page.
+func (s *Store) ScanFindingEvidenceSnapshot(ctx context.Context, request ports.InputSnapshotRequest) (ports.InputSnapshotPage[*cerebrov1.FindingEvidence], error) {
+	normalized, err := normalizeInputSnapshotRequest(request)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	if s == nil || s.db == nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("begin finding evidence snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	scopeClauses, scopeArgs := findingEvidenceInputSnapshotScopeClauses(normalized)
+	total, watermark, err := measureInputSnapshot(ctx, tx, "finding_evidence", scopeClauses, scopeArgs)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	if err := verifyInputSnapshotInvariant(normalized, total, watermark); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	clauses, args := addInputSnapshotCutoff(scopeClauses, scopeArgs, normalized.Cutoff)
+	pageClauses, pageArgs := addInputSnapshotCursor(clauses, args, normalized.AfterID)
+	pageArgs = append(pageArgs, int64(normalized.Limit+1))
+	// #nosec G201 -- predicates and ordering are fixed; all values are parameterized.
+	query := fmt.Sprintf(`
+SELECT id, finding_evidence_json::text
+FROM finding_evidence
+WHERE %s
+ORDER BY id ASC
+LIMIT $%d`, strings.Join(pageClauses, " AND "), len(pageArgs))
+	rows, err := tx.QueryContext(ctx, query, pageArgs...)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("query finding evidence snapshot: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]*cerebrov1.FindingEvidence, 0, normalized.Limit+1)
+	for rows.Next() {
+		var id, payload string
+		if err := rows.Scan(&id, &payload); err != nil {
+			return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("scan finding evidence snapshot: %w", err)
+		}
+		record := &cerebrov1.FindingEvidence{}
+		if err := protojson.Unmarshal([]byte(payload), record); err != nil {
+			return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("decode finding evidence %q: %w", id, err)
+		}
+		if strings.TrimSpace(record.GetId()) != id {
+			return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("finding evidence id mismatch: row %q payload %q", id, record.GetId())
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, err
+	}
+	page := finishInputSnapshotPage(records, normalized, total, watermark, func(record *cerebrov1.FindingEvidence) string { return record.GetId() })
+	if err := tx.Commit(); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.FindingEvidence]{}, fmt.Errorf("commit finding evidence snapshot: %w", err)
+	}
+	return page, nil
+}
+
+// ScanSourceRuntimeSnapshot returns one complete-collection runtime page.
+func (s *Store) ScanSourceRuntimeSnapshot(ctx context.Context, request ports.InputSnapshotRequest) (ports.InputSnapshotPage[*cerebrov1.SourceRuntime], error) {
+	normalized, err := normalizeInputSnapshotRequest(request)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	if s == nil || s.db == nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("begin source runtime snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	scopeClauses, scopeArgs := inputSnapshotScopeClauses(normalized, "runtime_json->>'tenant_id'", "id")
+	total, watermark, err := measureInputSnapshot(ctx, tx, "source_runtimes", scopeClauses, scopeArgs)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	if err := verifyInputSnapshotInvariant(normalized, total, watermark); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	clauses, args := addInputSnapshotCutoff(scopeClauses, scopeArgs, normalized.Cutoff)
+	pageClauses, pageArgs := addInputSnapshotCursor(clauses, args, normalized.AfterID)
+	pageArgs = append(pageArgs, int64(normalized.Limit+1))
+	// #nosec G201 -- predicates and ordering are fixed; all values are parameterized.
+	query := fmt.Sprintf(`
+SELECT id, runtime_json::text
+FROM source_runtimes
+WHERE %s
+ORDER BY id ASC
+LIMIT $%d`, strings.Join(pageClauses, " AND "), len(pageArgs))
+	rows, err := tx.QueryContext(ctx, query, pageArgs...)
+	if err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("query source runtime snapshot: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]*cerebrov1.SourceRuntime, 0, normalized.Limit+1)
+	for rows.Next() {
+		var id, payload string
+		if err := rows.Scan(&id, &payload); err != nil {
+			return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("scan source runtime snapshot: %w", err)
+		}
+		record := &cerebrov1.SourceRuntime{}
+		if err := protojson.Unmarshal([]byte(payload), record); err != nil {
+			return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("decode source runtime %q: %w", id, err)
+		}
+		if strings.TrimSpace(record.GetId()) != id {
+			return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("source runtime id mismatch: row %q payload %q", id, record.GetId())
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
+	}
+	page := finishInputSnapshotPage(records, normalized, total, watermark, func(record *cerebrov1.SourceRuntime) string { return record.GetId() })
+	if err := tx.Commit(); err != nil {
+		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, fmt.Errorf("commit source runtime snapshot: %w", err)
+	}
+	return page, nil
+}
+
+func normalizeInputSnapshotRequest(request ports.InputSnapshotRequest) (ports.InputSnapshotRequest, error) {
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.RuntimeIDs = normalizedNonEmptyStrings(request.RuntimeIDs)
+	request.AfterID = strings.TrimSpace(request.AfterID)
+	request.Cutoff = request.Cutoff.UTC()
+	if request.TenantID == "" {
+		return ports.InputSnapshotRequest{}, errors.New("input snapshot tenant id is required")
+	}
+	if len(request.RuntimeIDs) == 0 {
+		return ports.InputSnapshotRequest{}, errors.New("input snapshot runtime ids are required")
+	}
+	if request.Cutoff.IsZero() {
+		return ports.InputSnapshotRequest{}, errors.New("input snapshot cutoff is required")
+	}
+	if request.Limit == 0 {
+		request.Limit = defaultInputSnapshotPageSize
+	}
+	if request.Limit > maxInputSnapshotPageSize {
+		return ports.InputSnapshotRequest{}, fmt.Errorf("input snapshot limit must be <= %d", maxInputSnapshotPageSize)
+	}
+	return request, nil
+}
+
+func inputSnapshotScopeClauses(request ports.InputSnapshotRequest, tenantColumn string, runtimeColumn string) ([]string, []any) {
+	clauses := make([]string, 0, 2)
+	args := make([]any, 0, len(request.RuntimeIDs)+1)
+	if tenantColumn != "" {
+		args = append(args, request.TenantID)
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", tenantColumn, len(args)))
+	}
+	placeholders := make([]string, 0, len(request.RuntimeIDs))
+	for _, runtimeID := range request.RuntimeIDs {
+		args = append(args, runtimeID)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+	}
+	clauses = append(clauses, fmt.Sprintf("%s IN (%s)", runtimeColumn, strings.Join(placeholders, ", ")))
+	return clauses, args
+}
+
+func findingEvidenceInputSnapshotScopeClauses(request ports.InputSnapshotRequest) ([]string, []any) {
+	args := []any{request.TenantID}
+	clauses := []string{"EXISTS (SELECT 1 FROM source_runtimes input_runtime WHERE input_runtime.id = finding_evidence.runtime_id AND input_runtime.runtime_json->>'tenant_id' = $1)"}
+	placeholders := make([]string, 0, len(request.RuntimeIDs))
+	for _, runtimeID := range request.RuntimeIDs {
+		args = append(args, runtimeID)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+	}
+	clauses = append(clauses, fmt.Sprintf("runtime_id IN (%s)", strings.Join(placeholders, ", ")))
+	return clauses, args
+}
+
+func addInputSnapshotCutoff(clauses []string, args []any, cutoff time.Time) ([]string, []any) {
+	resultClauses := append([]string(nil), clauses...)
+	resultArgs := append([]any(nil), args...)
+	resultArgs = append(resultArgs, cutoff.UTC())
+	resultClauses = append(resultClauses, fmt.Sprintf("updated_at <= $%d", len(resultArgs)))
+	return resultClauses, resultArgs
+}
+
+func addInputSnapshotCursor(clauses []string, args []any, afterID string) ([]string, []any) {
+	pageClauses := append([]string(nil), clauses...)
+	pageArgs := append([]any(nil), args...)
+	if afterID != "" {
+		pageArgs = append(pageArgs, afterID)
+		pageClauses = append(pageClauses, fmt.Sprintf("id > $%d", len(pageArgs)))
+	}
+	return pageClauses, pageArgs
+}
+
+func measureInputSnapshot(ctx context.Context, tx *sql.Tx, table string, clauses []string, args []any) (uint64, time.Time, error) {
+	// #nosec G201 -- callers supply fixed internal table names and predicates.
+	query := fmt.Sprintf("SELECT COUNT(*), MAX(updated_at) FROM %s WHERE %s", table, strings.Join(clauses, " AND "))
+	var count int64
+	var watermark sql.NullTime
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&count, &watermark); err != nil {
+		return 0, time.Time{}, fmt.Errorf("measure %s input snapshot: %w", table, err)
+	}
+	if count < 0 {
+		return 0, time.Time{}, fmt.Errorf("count %s input snapshot returned a negative value", table)
+	}
+	if !watermark.Valid {
+		return uint64(count), time.Time{}, nil
+	}
+	return uint64(count), watermark.Time.UTC(), nil
+}
+
+func verifyInputSnapshotInvariant(request ports.InputSnapshotRequest, total uint64, watermark time.Time) error {
+	if request.ExpectedTotal != nil && *request.ExpectedTotal != total {
+		return fmt.Errorf("%w: expected %d records, found %d", ports.ErrInputSnapshotChanged, *request.ExpectedTotal, total)
+	}
+	if request.ExpectedWatermark != nil && !request.ExpectedWatermark.Equal(watermark) {
+		return fmt.Errorf("%w: input watermark changed", ports.ErrInputSnapshotChanged)
+	}
+	if watermark.After(request.Cutoff) {
+		return fmt.Errorf("%w: input changed after cutoff", ports.ErrInputSnapshotChanged)
+	}
+	return nil
+}
+
+func finishInputSnapshotPage[T any](records []T, request ports.InputSnapshotRequest, total uint64, watermark time.Time, id func(T) string) ports.InputSnapshotPage[T] {
+	complete := len(records) <= int(request.Limit)
+	if !complete {
+		records = records[:request.Limit]
+	}
+	nextCursor := ""
+	if !complete && len(records) > 0 {
+		nextCursor = strings.TrimSpace(id(records[len(records)-1]))
+	}
+	return ports.InputSnapshotPage[T]{Records: records, Total: total, NextCursor: nextCursor, Complete: complete, Cutoff: request.Cutoff, Watermark: watermark}
+}
+
+var _ ports.ComplianceInputSnapshotStore = (*Store)(nil)

--- a/internal/statestore/postgres/compliance_inputs_test.go
+++ b/internal/statestore/postgres/compliance_inputs_test.go
@@ -1,0 +1,103 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestNormalizeInputSnapshotRequestRequiresStableScope(t *testing.T) {
+	cutoff := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	request, err := normalizeInputSnapshotRequest(ports.InputSnapshotRequest{
+		TenantID:   " tenant-a ",
+		RuntimeIDs: []string{"runtime-b", "runtime-a", "runtime-a", " "},
+		Cutoff:     cutoff,
+	})
+	if err != nil {
+		t.Fatalf("normalizeInputSnapshotRequest() error = %v", err)
+	}
+	if request.TenantID != "tenant-a" || request.Limit != defaultInputSnapshotPageSize || !request.Cutoff.Equal(cutoff) {
+		t.Fatalf("normalized request = %+v", request)
+	}
+	if len(request.RuntimeIDs) != 2 || request.RuntimeIDs[0] != "runtime-b" || request.RuntimeIDs[1] != "runtime-a" {
+		t.Fatalf("runtime ids = %v", request.RuntimeIDs)
+	}
+
+	cases := []ports.InputSnapshotRequest{
+		{RuntimeIDs: []string{"runtime-a"}, Cutoff: cutoff},
+		{TenantID: "tenant-a", Cutoff: cutoff},
+		{TenantID: "tenant-a", RuntimeIDs: []string{"runtime-a"}},
+		{TenantID: "tenant-a", RuntimeIDs: []string{"runtime-a"}, Cutoff: cutoff, Limit: maxInputSnapshotPageSize + 1},
+	}
+	for _, invalid := range cases {
+		if _, err := normalizeInputSnapshotRequest(invalid); err == nil {
+			t.Fatalf("normalizeInputSnapshotRequest(%+v) error = nil", invalid)
+		}
+	}
+}
+
+func TestFinishInputSnapshotPageUsesKeysetCursor(t *testing.T) {
+	cutoff := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	watermark := cutoff.Add(-time.Minute)
+	page := finishInputSnapshotPage([]string{"a", "b", "c"}, ports.InputSnapshotRequest{Limit: 2, Cutoff: cutoff}, 3, watermark, func(value string) string { return value })
+	if page.Complete || page.NextCursor != "b" || len(page.Records) != 2 || page.Total != 3 || !page.Cutoff.Equal(cutoff) || !page.Watermark.Equal(watermark) {
+		t.Fatalf("page = %+v", page)
+	}
+
+	last := finishInputSnapshotPage([]string{"c"}, ports.InputSnapshotRequest{Limit: 2, Cutoff: cutoff}, 3, watermark, func(value string) string { return value })
+	if !last.Complete || last.NextCursor != "" || len(last.Records) != 1 {
+		t.Fatalf("last page = %+v", last)
+	}
+}
+
+func TestFinishInputSnapshotPageDoesNotTruncateAtUILimit(t *testing.T) {
+	records := make([]string, 501)
+	for i := range records {
+		records[i] = fmt.Sprintf("record-%04d", i+1)
+	}
+	cutoff := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	page := finishInputSnapshotPage(records, ports.InputSnapshotRequest{Limit: 500, Cutoff: cutoff}, 501, cutoff, func(value string) string { return value })
+	if page.Complete || len(page.Records) != 500 || page.NextCursor != "record-0500" || page.Total != 501 {
+		t.Fatalf("page count=%d complete=%v cursor=%q total=%d", len(page.Records), page.Complete, page.NextCursor, page.Total)
+	}
+}
+
+func TestVerifyInputSnapshotInvariantDetectsMutation(t *testing.T) {
+	expected := uint64(501)
+	cutoff := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	watermark := cutoff.Add(-time.Minute)
+	request := ports.InputSnapshotRequest{Cutoff: cutoff, ExpectedTotal: &expected, ExpectedWatermark: &watermark}
+	if err := verifyInputSnapshotInvariant(request, 501, watermark); err != nil {
+		t.Fatalf("verifyInputSnapshotInvariant(equal) error = %v", err)
+	}
+	if err := verifyInputSnapshotInvariant(request, 500, watermark); !errors.Is(err, ports.ErrInputSnapshotChanged) {
+		t.Fatalf("verifyInputSnapshotInvariant(total changed) error = %v, want ErrInputSnapshotChanged", err)
+	}
+	if err := verifyInputSnapshotInvariant(request, 501, cutoff); !errors.Is(err, ports.ErrInputSnapshotChanged) {
+		t.Fatalf("verifyInputSnapshotInvariant(watermark changed) error = %v, want ErrInputSnapshotChanged", err)
+	}
+	request.ExpectedWatermark = nil
+	if err := verifyInputSnapshotInvariant(request, 501, cutoff.Add(time.Second)); !errors.Is(err, ports.ErrInputSnapshotChanged) {
+		t.Fatalf("verifyInputSnapshotInvariant(after cutoff) error = %v, want ErrInputSnapshotChanged", err)
+	}
+}
+
+func TestFindingEvidenceInputSnapshotClausesEnforceRuntimeTenant(t *testing.T) {
+	request := ports.InputSnapshotRequest{
+		TenantID:   "tenant-a",
+		RuntimeIDs: []string{"runtime-a", "runtime-b"},
+		Cutoff:     time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC),
+	}
+	clauses, args := findingEvidenceInputSnapshotScopeClauses(request)
+	joined := strings.Join(clauses, " AND ")
+	if !strings.Contains(joined, "input_runtime.runtime_json->>'tenant_id' = $1") {
+		t.Fatalf("clauses do not enforce tenant: %s", joined)
+	}
+	if len(args) != 3 || args[0] != "tenant-a" || args[1] != "runtime-a" || args[2] != "runtime-b" {
+		t.Fatalf("args = %#v", args)
+	}
+}

--- a/internal/statestore/postgres/evidence_ledger.go
+++ b/internal/statestore/postgres/evidence_ledger.go
@@ -1,0 +1,291 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureEvidenceLedgerStatements = []string{
+	`CREATE TABLE IF NOT EXISTS grc_evidence_artifacts (
+  tenant_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  record_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (tenant_id, id)
+)`,
+	`CREATE TABLE IF NOT EXISTS grc_evidence_versions (
+  tenant_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  artifact_id TEXT NOT NULL,
+  revision_id TEXT NOT NULL,
+  revision_version BIGINT NOT NULL,
+  record_digest TEXT NOT NULL,
+  content_digest TEXT NOT NULL,
+  state TEXT NOT NULL,
+  valid_until TIMESTAMPTZ,
+  record_json JSONB NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (tenant_id, id),
+  UNIQUE (tenant_id, artifact_id, revision_version),
+  UNIQUE (tenant_id, revision_id),
+  FOREIGN KEY (tenant_id, artifact_id) REFERENCES grc_evidence_artifacts (tenant_id, id)
+)`,
+	`CREATE INDEX IF NOT EXISTS grc_evidence_versions_artifact_idx ON grc_evidence_versions (tenant_id, artifact_id, revision_version DESC)`,
+	`CREATE INDEX IF NOT EXISTS grc_evidence_versions_expiry_idx ON grc_evidence_versions (tenant_id, valid_until) WHERE valid_until IS NOT NULL`,
+	`CREATE TABLE IF NOT EXISTS grc_evidence_claims (
+  tenant_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  artifact_version_id TEXT NOT NULL,
+  aggregate_version BIGINT NOT NULL,
+  review_state TEXT NOT NULL,
+  invalidated_at TIMESTAMPTZ,
+  record_digest TEXT NOT NULL,
+  record_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, id),
+  FOREIGN KEY (tenant_id, artifact_version_id) REFERENCES grc_evidence_versions (tenant_id, id)
+)`,
+	`CREATE INDEX IF NOT EXISTS grc_evidence_claims_version_idx ON grc_evidence_claims (tenant_id, artifact_version_id, id)`,
+	`CREATE TABLE IF NOT EXISTS grc_evidence_event_receipts (
+  event_id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  aggregate_type TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  aggregate_version BIGINT NOT NULL,
+  payload_digest TEXT NOT NULL,
+  applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS grc_evidence_event_receipts_aggregate_idx ON grc_evidence_event_receipts (tenant_id, aggregate_type, aggregate_id, aggregate_version)`,
+}
+
+func (s *Store) ensureEvidenceLedgerTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.grc.evidenceLedger, "grc_evidence_ledger", ensureEvidenceLedgerStatements)
+}
+
+func (s *Store) ApplyEvidenceVersion(ctx context.Context, eventID string, artifact ports.EvidenceArtifact, version ports.EvidenceVersion) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	eventID = strings.TrimSpace(eventID)
+	if eventID == "" || artifact.TenantID == "" || artifact.ID == "" || version.ID == "" || version.ArtifactID != artifact.ID || version.TenantID != artifact.TenantID {
+		return errors.New("evidence version event and tenant-scoped identity are required")
+	}
+	if err := s.ensureEvidenceLedgerTables(ctx); err != nil {
+		return err
+	}
+	artifactJSON, err := json.Marshal(artifact)
+	if err != nil {
+		return fmt.Errorf("marshal evidence artifact: %w", err)
+	}
+	versionJSON, err := json.Marshal(version)
+	if err != nil {
+		return fmt.Errorf("marshal evidence version: %w", err)
+	}
+	payloadDigest := jsonDigest(versionJSON)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("begin evidence version projection: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	applied, err := evidenceEventApplied(ctx, tx, eventID, payloadDigest)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return tx.Commit()
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO grc_evidence_artifacts (tenant_id, id, record_json, created_at)
+VALUES ($1,$2,$3::jsonb,$4)
+ON CONFLICT (tenant_id, id) DO NOTHING`, artifact.TenantID, artifact.ID, string(artifactJSON), artifact.CreatedAt.UTC()); err != nil {
+		return fmt.Errorf("project evidence artifact: %w", err)
+	}
+	result, err := tx.ExecContext(ctx, `
+INSERT INTO grc_evidence_versions (
+  tenant_id,id,artifact_id,revision_id,revision_version,record_digest,content_digest,state,valid_until,record_json,recorded_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11)
+ON CONFLICT (tenant_id, id) DO NOTHING`, version.TenantID, version.ID, version.ArtifactID,
+		version.Revision.RevisionID, version.Revision.Version, version.Revision.ContentDigest,
+		version.Content.ContentDigest, version.State, nullableTime(version.ValidUntil), string(versionJSON), version.RecordedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("project evidence version: %w", err)
+	}
+	if count, _ := result.RowsAffected(); count == 0 {
+		var existingDigest string
+		if err := tx.QueryRowContext(ctx, `SELECT record_digest FROM grc_evidence_versions WHERE tenant_id = $1 AND id = $2`, version.TenantID, version.ID).Scan(&existingDigest); err != nil {
+			return fmt.Errorf("read existing evidence version: %w", err)
+		}
+		if existingDigest != version.Revision.ContentDigest {
+			return ports.ErrEvidenceLedgerConflict
+		}
+	}
+	if err := insertEvidenceReceipt(ctx, tx, eventID, version.TenantID, "evidence_version", version.ID, version.Revision.Version, payloadDigest); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit evidence version projection: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ApplyEvidenceClaim(ctx context.Context, eventID string, claim ports.EvidenceClaim, expectedVersion uint64) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureEvidenceLedgerTables(ctx); err != nil {
+		return err
+	}
+	recordJSON, err := json.Marshal(claim)
+	if err != nil {
+		return fmt.Errorf("marshal evidence claim: %w", err)
+	}
+	digest := jsonDigest(recordJSON)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("begin evidence claim projection: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	applied, err := evidenceEventApplied(ctx, tx, eventID, digest)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return tx.Commit()
+	}
+	var result sql.Result
+	if expectedVersion == 0 {
+		result, err = tx.ExecContext(ctx, `
+INSERT INTO grc_evidence_claims (tenant_id,id,artifact_version_id,aggregate_version,review_state,invalidated_at,record_digest,record_json,created_at)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9)
+ON CONFLICT (tenant_id, id) DO NOTHING`, claim.TenantID, claim.ID, claim.ArtifactVersionID, claim.Version,
+			claim.Decision.ReviewState, nullableTime(claim.Decision.InvalidatedAt), digest, string(recordJSON), claim.CreatedAt.UTC())
+	} else {
+		result, err = tx.ExecContext(ctx, `
+UPDATE grc_evidence_claims
+SET aggregate_version = $4, review_state = $5, invalidated_at = $6, record_digest = $7, record_json = $8::jsonb, updated_at = NOW()
+WHERE tenant_id = $1 AND id = $2 AND aggregate_version = $3`, claim.TenantID, claim.ID, expectedVersion, claim.Version,
+			claim.Decision.ReviewState, nullableTime(claim.Decision.InvalidatedAt), digest, string(recordJSON))
+	}
+	if err != nil {
+		return fmt.Errorf("project evidence claim: %w", err)
+	}
+	if count, _ := result.RowsAffected(); count == 0 {
+		return ports.ErrEvidenceLedgerConflict
+	}
+	if err := insertEvidenceReceipt(ctx, tx, eventID, claim.TenantID, "evidence_claim", claim.ID, claim.Version, digest); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit evidence claim projection: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetEvidenceArtifact(ctx context.Context, tenantID, artifactID string) (ports.EvidenceArtifact, error) {
+	var value ports.EvidenceArtifact
+	if err := s.getEvidenceJSON(ctx, `SELECT record_json FROM grc_evidence_artifacts WHERE tenant_id = $1 AND id = $2`, tenantID, artifactID, &value, ports.ErrEvidenceArtifactNotFound); err != nil {
+		return ports.EvidenceArtifact{}, err
+	}
+	return value, nil
+}
+
+func (s *Store) GetEvidenceVersion(ctx context.Context, tenantID, versionID string) (ports.EvidenceVersion, error) {
+	var value ports.EvidenceVersion
+	if err := s.getEvidenceJSON(ctx, `SELECT record_json FROM grc_evidence_versions WHERE tenant_id = $1 AND id = $2`, tenantID, versionID, &value, ports.ErrEvidenceVersionNotFound); err != nil {
+		return ports.EvidenceVersion{}, err
+	}
+	return value, nil
+}
+
+func (s *Store) GetEvidenceClaim(ctx context.Context, tenantID, claimID string) (ports.EvidenceClaim, error) {
+	var value ports.EvidenceClaim
+	if err := s.getEvidenceJSON(ctx, `SELECT record_json FROM grc_evidence_claims WHERE tenant_id = $1 AND id = $2`, tenantID, claimID, &value, ports.ErrEvidenceClaimNotFound); err != nil {
+		return ports.EvidenceClaim{}, err
+	}
+	return value, nil
+}
+
+func (s *Store) ListEvidenceClaimsByVersion(ctx context.Context, tenantID, versionID string) ([]ports.EvidenceClaim, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureEvidenceLedgerTables(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT record_json FROM grc_evidence_claims WHERE tenant_id = $1 AND artifact_version_id = $2 ORDER BY id`, strings.TrimSpace(tenantID), strings.TrimSpace(versionID))
+	if err != nil {
+		return nil, fmt.Errorf("list evidence claims: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var result []ports.EvidenceClaim
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, err
+		}
+		var claim ports.EvidenceClaim
+		if err := json.Unmarshal(data, &claim); err != nil {
+			return nil, fmt.Errorf("decode evidence claim: %w", err)
+		}
+		result = append(result, claim)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) getEvidenceJSON(ctx context.Context, query, tenantID, id string, target any, notFound error) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureEvidenceLedgerTables(ctx); err != nil {
+		return err
+	}
+	var data []byte
+	if err := s.db.QueryRowContext(ctx, query, strings.TrimSpace(tenantID), strings.TrimSpace(id)).Scan(&data); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return notFound
+		}
+		return err
+	}
+	if err := json.Unmarshal(data, target); err != nil {
+		return fmt.Errorf("decode evidence record: %w", err)
+	}
+	return nil
+}
+
+func evidenceEventApplied(ctx context.Context, tx *sql.Tx, eventID, digest string) (bool, error) {
+	var existing string
+	err := tx.QueryRowContext(ctx, `SELECT payload_digest FROM grc_evidence_event_receipts WHERE event_id = $1`, eventID).Scan(&existing)
+	switch {
+	case err == nil && existing == digest:
+		return true, nil
+	case err == nil:
+		return false, ports.ErrEvidenceLedgerConflict
+	case errors.Is(err, sql.ErrNoRows):
+		return false, nil
+	default:
+		return false, fmt.Errorf("read evidence event receipt: %w", err)
+	}
+}
+
+func insertEvidenceReceipt(ctx context.Context, tx *sql.Tx, eventID, tenantID, aggregateType, aggregateID string, version uint64, digest string) error {
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO grc_evidence_event_receipts (event_id,tenant_id,aggregate_type,aggregate_id,aggregate_version,payload_digest)
+VALUES ($1,$2,$3,$4,$5,$6)`, eventID, tenantID, aggregateType, aggregateID, version, digest); err != nil {
+		return fmt.Errorf("record evidence event receipt: %w", err)
+	}
+	return nil
+}
+
+func jsonDigest(data []byte) string {
+	digest := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}

--- a/internal/statestore/postgres/evidence_ledger_test.go
+++ b/internal/statestore/postgres/evidence_ledger_test.go
@@ -1,0 +1,35 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEvidenceLedgerSchemaKeepsTenantAndImmutableRevisionBoundaries(t *testing.T) {
+	t.Parallel()
+	joined := strings.Join(ensureEvidenceLedgerStatements, "\n")
+	for _, required := range []string{
+		"PRIMARY KEY (tenant_id, id)",
+		"UNIQUE (tenant_id, artifact_id, revision_version)",
+		"FOREIGN KEY (tenant_id, artifact_id)",
+		"FOREIGN KEY (tenant_id, artifact_version_id)",
+		"payload_digest TEXT NOT NULL",
+		"content_digest TEXT NOT NULL",
+	} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("evidence ledger schema missing %q", required)
+		}
+	}
+	if strings.Contains(joined, "content_bytes") || strings.Contains(joined, "BYTEA") {
+		t.Fatal("evidence ledger schema must not store raw evidence bytes")
+	}
+}
+
+func TestEvidenceJSONDigestIsDeterministic(t *testing.T) {
+	t.Parallel()
+	left := jsonDigest([]byte(`{"id":"evidence-1"}`))
+	right := jsonDigest([]byte(`{"id":"evidence-1"}`))
+	if left != right || !strings.HasPrefix(left, "sha256:") {
+		t.Fatalf("digests = %q and %q", left, right)
+	}
+}

--- a/internal/statestore/postgres/jobs.go
+++ b/internal/statestore/postgres/jobs.go
@@ -23,6 +23,7 @@ var ensureJobStatements = []string{
   subject_type TEXT NOT NULL DEFAULT '',
   subject_id TEXT NOT NULL DEFAULT '',
   idempotency_key TEXT NOT NULL DEFAULT '',
+  request_hash TEXT NOT NULL DEFAULT '',
   progress_percent INTEGER NOT NULL DEFAULT 0,
   message TEXT NOT NULL DEFAULT '',
   error TEXT NOT NULL DEFAULT '',
@@ -30,14 +31,26 @@ var ensureJobStatements = []string{
   result_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   result_refs_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   cancel_requested BOOLEAN NOT NULL DEFAULT FALSE,
+  attempt INTEGER NOT NULL DEFAULT 0,
+  lease_owner TEXT NOT NULL DEFAULT '',
+  lease_expires_at TIMESTAMPTZ,
+  heartbeat_at TIMESTAMPTZ,
+  failure_class TEXT NOT NULL DEFAULT '',
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   started_at TIMESTAMPTZ,
   finished_at TIMESTAMPTZ,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS request_hash TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS lease_owner TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS heartbeat_at TIMESTAMPTZ`,
+	`ALTER TABLE platform_jobs ADD COLUMN IF NOT EXISTS failure_class TEXT NOT NULL DEFAULT ''`,
 	`CREATE UNIQUE INDEX IF NOT EXISTS platform_jobs_idempotency_idx ON platform_jobs (tenant_id, idempotency_key) WHERE idempotency_key <> ''`,
 	`CREATE INDEX IF NOT EXISTS platform_jobs_tenant_status_idx ON platform_jobs (tenant_id, status, updated_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS platform_jobs_kind_updated_idx ON platform_jobs (kind, updated_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS platform_jobs_recovery_idx ON platform_jobs (status, lease_expires_at, created_at) WHERE status IN ('queued', 'running')`,
 	`CREATE TABLE IF NOT EXISTS platform_job_events (
   job_id TEXT NOT NULL REFERENCES platform_jobs(id) ON DELETE CASCADE,
   sequence BIGSERIAL PRIMARY KEY,
@@ -49,6 +62,11 @@ var ensureJobStatements = []string{
 )`,
 	`CREATE INDEX IF NOT EXISTS platform_job_events_job_sequence_idx ON platform_job_events (job_id, sequence ASC)`,
 }
+
+const platformJobColumns = `id, kind, status, tenant_id, subject_type, subject_id, idempotency_key, request_hash,
+       progress_percent, message, error, payload_json::text, result_json::text,
+       result_refs_json::text, cancel_requested, attempt, lease_owner, lease_expires_at,
+       heartbeat_at, failure_class, created_at, started_at, finished_at, updated_at`
 
 // CreateJob inserts a platform job or returns the existing idempotent job.
 func (s *Store) CreateJob(ctx context.Context, request ports.CreateJobRequest) (*ports.Job, bool, error) {
@@ -66,6 +84,7 @@ func (s *Store) CreateJob(ctx context.Context, request ports.CreateJobRequest) (
 		SubjectType:    strings.TrimSpace(request.SubjectType),
 		SubjectID:      strings.TrimSpace(request.SubjectID),
 		IdempotencyKey: strings.TrimSpace(request.IdempotencyKey),
+		RequestHash:    strings.TrimSpace(request.RequestHash),
 		Payload:        cloneMap(request.Payload),
 	}
 	payload, err := json.Marshal(job.Payload)
@@ -74,11 +93,16 @@ func (s *Store) CreateJob(ctx context.Context, request ports.CreateJobRequest) (
 	}
 	row := s.db.QueryRowContext(ctx, `
 INSERT INTO platform_jobs (
-  id, kind, status, tenant_id, subject_type, subject_id, idempotency_key, payload_json
+  id, kind, status, tenant_id, subject_type, subject_id, idempotency_key, request_hash, payload_json
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
 ON CONFLICT (tenant_id, idempotency_key) WHERE idempotency_key <> ''
-DO UPDATE SET updated_at = platform_jobs.updated_at
+DO UPDATE SET request_hash = CASE
+  WHEN platform_jobs.request_hash = '' THEN EXCLUDED.request_hash
+  ELSE platform_jobs.request_hash
+END,
+updated_at = platform_jobs.updated_at
+WHERE platform_jobs.request_hash = '' OR platform_jobs.request_hash = EXCLUDED.request_hash
 RETURNING id, (xmax = 0) AS inserted`,
 		job.ID,
 		job.Kind,
@@ -87,11 +111,15 @@ RETURNING id, (xmax = 0) AS inserted`,
 		job.SubjectType,
 		job.SubjectID,
 		job.IdempotencyKey,
+		job.RequestHash,
 		string(payload),
 	)
 	var id string
 	var inserted bool
 	if err := row.Scan(&id, &inserted); err != nil {
+		if errors.Is(err, sql.ErrNoRows) && job.IdempotencyKey != "" {
+			return nil, false, fmt.Errorf("%w: tenant %q key %q", ports.ErrJobIdempotencyConflict, job.TenantID, job.IdempotencyKey)
+		}
 		return nil, false, fmt.Errorf("insert platform job: %w", err)
 	}
 	stored, err := s.GetJob(ctx, id)
@@ -113,12 +141,11 @@ func (s *Store) GetJob(ctx context.Context, id string) (*ports.Job, error) {
 	if err := s.ensureJobTables(ctx); err != nil {
 		return nil, err
 	}
-	row := s.db.QueryRowContext(ctx, `
-SELECT id, kind, status, tenant_id, subject_type, subject_id, idempotency_key,
-       progress_percent, message, error, payload_json::text, result_json::text,
-       result_refs_json::text, cancel_requested, created_at, started_at, finished_at, updated_at
+	// #nosec G201 -- the column list is a fixed constant and the id is parameterized.
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT %s
 FROM platform_jobs
-WHERE id = $1`, id)
+WHERE id = $1`, platformJobColumns), id)
 	job, err := scanJob(row)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -145,13 +172,11 @@ func (s *Store) ListJobs(ctx context.Context, filter ports.JobFilter) ([]*ports.
 	args = append(args, limit)
 	// #nosec G201 -- clauses are fixed column predicates and LIMIT placeholder index is derived from args.
 	query := fmt.Sprintf(`
-SELECT id, kind, status, tenant_id, subject_type, subject_id, idempotency_key,
-       progress_percent, message, error, payload_json::text, result_json::text,
-       result_refs_json::text, cancel_requested, created_at, started_at, finished_at, updated_at
+SELECT %s
 FROM platform_jobs
 WHERE %s
 ORDER BY updated_at DESC, id ASC
-LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
+LIMIT $%d`, platformJobColumns, strings.Join(clauses, " AND "), len(args))
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list platform jobs: %w", err)
@@ -235,6 +260,9 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 	if update.Error != "" {
 		addSet("error", update.Error)
 	}
+	if update.FailureClass != "" {
+		addSet("failure_class", strings.TrimSpace(update.FailureClass))
+	}
 	if update.Result != nil {
 		result, err := json.Marshal(cloneMap(update.Result))
 		if err != nil {
@@ -258,9 +286,23 @@ func (s *Store) UpdateJob(ctx context.Context, id string, update ports.JobUpdate
 	if update.CancelRequested != nil {
 		addSet("cancel_requested", *update.CancelRequested)
 	}
+	if update.ClearLease {
+		setClauses = append(setClauses,
+			"lease_owner = ''",
+			"lease_expires_at = NULL",
+			"heartbeat_at = NULL",
+		)
+	}
 	setClauses = append(setClauses, "updated_at = NOW()")
 	allowedStatuses := normalizeJobStatuses(update.AllowedStatuses)
 	clauses := []string{"id = $1"}
+	if expectedOwner := strings.TrimSpace(update.ExpectedLeaseOwner); expectedOwner != "" {
+		args = append(args, expectedOwner)
+		clauses = append(clauses, fmt.Sprintf("lease_owner = $%d", len(args)))
+	}
+	if update.RequireNotCancelled {
+		clauses = append(clauses, "cancel_requested = FALSE")
+	}
 	if len(allowedStatuses) > 0 {
 		placeholders := make([]string, 0, len(allowedStatuses))
 		for _, status := range allowedStatuses {
@@ -283,6 +325,175 @@ WHERE %s`, strings.Join(setClauses, ", "), strings.Join(clauses, " AND ")), args
 		return nil, fmt.Errorf("%w: %s", ports.ErrJobNotFound, id)
 	}
 	return s.GetJob(ctx, id)
+}
+
+// ClaimJob atomically assigns queued or expired work to one worker.
+func (s *Store) ClaimJob(ctx context.Context, request ports.JobClaimRequest) (*ports.Job, error) {
+	jobID, owner, now, expiresAt, err := normalizeJobLeaseRequest(request.JobID, request.Owner, request.Now, request.TTL)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	// #nosec G201 -- the column list is fixed and all values are parameterized.
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+UPDATE platform_jobs
+SET status = $2,
+    attempt = attempt + 1,
+    lease_owner = $3,
+    lease_expires_at = $4,
+    heartbeat_at = $5,
+    started_at = COALESCE(started_at, $5),
+    message = 'job running',
+    failure_class = '',
+    updated_at = NOW()
+WHERE id = $1
+  AND cancel_requested = FALSE
+  AND (
+    status = $6
+    OR (status = $2 AND (lease_expires_at IS NULL OR lease_expires_at <= $5))
+  )
+RETURNING %s`, platformJobColumns), jobID, ports.JobStatusRunning, owner, expiresAt, now, ports.JobStatusQueued)
+	job, scanErr := scanJob(row)
+	if scanErr == nil {
+		return job, nil
+	}
+	if !errors.Is(scanErr, sql.ErrNoRows) {
+		return nil, fmt.Errorf("claim platform job %q: %w", jobID, scanErr)
+	}
+	if _, getErr := s.GetJob(ctx, jobID); getErr != nil {
+		return nil, getErr
+	}
+	return nil, fmt.Errorf("%w: %s", ports.ErrJobLeaseConflict, jobID)
+}
+
+// RenewJobLease extends a live owner lease and returns current cancellation state.
+func (s *Store) RenewJobLease(ctx context.Context, request ports.JobLeaseRenewRequest) (*ports.Job, error) {
+	jobID, owner, now, expiresAt, err := normalizeJobLeaseRequest(request.JobID, request.Owner, request.Now, request.TTL)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	// #nosec G201 -- the column list is fixed and all values are parameterized.
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+UPDATE platform_jobs
+SET lease_expires_at = $3,
+    heartbeat_at = $4,
+    updated_at = NOW()
+WHERE id = $1
+  AND status = $5
+  AND lease_owner = $2
+  AND lease_expires_at > $4
+RETURNING %s`, platformJobColumns), jobID, owner, expiresAt, now, ports.JobStatusRunning)
+	job, scanErr := scanJob(row)
+	if scanErr == nil {
+		return job, nil
+	}
+	if errors.Is(scanErr, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %s", ports.ErrJobLeaseConflict, jobID)
+	}
+	return nil, fmt.Errorf("renew platform job lease %q: %w", jobID, scanErr)
+}
+
+// RecoverJobs resets expired running jobs and lists queued work for startup.
+func (s *Store) RecoverJobs(ctx context.Context, request ports.JobRecoveryRequest) ([]*ports.Job, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureJobTables(ctx); err != nil {
+		return nil, err
+	}
+	now := request.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	limit := request.Limit
+	if limit == 0 || limit > 500 {
+		limit = 100
+	}
+	// #nosec G201 -- the column list is fixed and all values are parameterized.
+	query := fmt.Sprintf(`
+WITH cancelled AS (
+  UPDATE platform_jobs
+  SET status = $5,
+      message = 'job cancelled',
+      failure_class = 'cancelled',
+      finished_at = COALESCE(finished_at, $3),
+      lease_owner = '',
+      lease_expires_at = NULL,
+      heartbeat_at = NULL,
+      updated_at = NOW()
+  WHERE status = $2
+    AND cancel_requested = TRUE
+    AND (lease_expires_at IS NULL OR lease_expires_at <= $3)
+  RETURNING id
+), recovered AS (
+  UPDATE platform_jobs
+  SET status = $1,
+      message = 'job recovered after lease expiry',
+      lease_owner = '',
+      lease_expires_at = NULL,
+      heartbeat_at = NULL,
+      updated_at = NOW()
+  WHERE status = $2
+    AND cancel_requested = FALSE
+    AND (lease_expires_at IS NULL OR lease_expires_at <= $3)
+  RETURNING %s
+), queued AS (
+  SELECT %s
+  FROM platform_jobs
+  WHERE status = $1 AND cancel_requested = FALSE
+)
+SELECT *
+FROM (
+  SELECT * FROM recovered
+  UNION ALL
+  SELECT * FROM queued
+) runnable
+ORDER BY created_at ASC, id ASC
+LIMIT $4`, platformJobColumns, platformJobColumns)
+	rows, err := s.db.QueryContext(ctx, query, ports.JobStatusQueued, ports.JobStatusRunning, now, limit, ports.JobStatusCancelled)
+	if err != nil {
+		return nil, fmt.Errorf("recover platform jobs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	jobs := make([]*ports.Job, 0)
+	for rows.Next() {
+		job, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func normalizeJobLeaseRequest(jobID string, owner string, now time.Time, ttl time.Duration) (string, string, time.Time, time.Time, error) {
+	jobID = strings.TrimSpace(jobID)
+	owner = strings.TrimSpace(owner)
+	if jobID == "" {
+		return "", "", time.Time{}, time.Time{}, errors.New("job id is required")
+	}
+	if owner == "" {
+		return "", "", time.Time{}, time.Time{}, errors.New("job lease owner is required")
+	}
+	if ttl <= 0 {
+		return "", "", time.Time{}, time.Time{}, errors.New("job lease ttl must be positive")
+	}
+	now = now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return jobID, owner, now, now.Add(ttl), nil
 }
 
 // AppendJobEvent appends one timeline event.
@@ -367,10 +578,11 @@ type scanner interface {
 func scanJob(row scanner) (*ports.Job, error) {
 	job := &ports.Job{}
 	var payload, result, refs string
-	var started, finished sql.NullTime
+	var leaseExpires, heartbeat, started, finished sql.NullTime
 	if err := row.Scan(
-		&job.ID, &job.Kind, &job.Status, &job.TenantID, &job.SubjectType, &job.SubjectID, &job.IdempotencyKey,
+		&job.ID, &job.Kind, &job.Status, &job.TenantID, &job.SubjectType, &job.SubjectID, &job.IdempotencyKey, &job.RequestHash,
 		&job.Progress, &job.Message, &job.Error, &payload, &result, &refs, &job.CancelRequested,
+		&job.Attempt, &job.LeaseOwner, &leaseExpires, &heartbeat, &job.FailureClass,
 		&job.CreatedAt, &started, &finished, &job.UpdatedAt,
 	); err != nil {
 		return nil, err
@@ -383,6 +595,12 @@ func scanJob(row scanner) (*ports.Job, error) {
 	_ = json.Unmarshal([]byte(refs), &job.ResultRefs)
 	if started.Valid {
 		job.StartedAt = started.Time
+	}
+	if leaseExpires.Valid {
+		job.LeaseExpiresAt = leaseExpires.Time
+	}
+	if heartbeat.Valid {
+		job.HeartbeatAt = heartbeat.Time
 	}
 	if finished.Valid {
 		job.FinishedAt = finished.Time

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -46,6 +46,7 @@ type grcTablesReady struct {
 	customDashboards     bool
 	vendorDiscovery      bool
 	questionnaireRun     bool
+	evidenceLedger       bool
 }
 
 type appendLogTablesReady struct {

--- a/internal/statestore/postgres/report_schedules.go
+++ b/internal/statestore/postgres/report_schedules.go
@@ -22,14 +22,18 @@ var ensureReportScheduleStatements = []string{
   enabled BOOLEAN NOT NULL DEFAULT TRUE,
   next_run_at TIMESTAMPTZ NOT NULL,
   last_run_at TIMESTAMPTZ,
+  claim_owner TEXT NOT NULL DEFAULT '',
+  claim_expires_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
+	`ALTER TABLE report_schedules ADD COLUMN IF NOT EXISTS claim_owner TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE report_schedules ADD COLUMN IF NOT EXISTS claim_expires_at TIMESTAMPTZ`,
 	`CREATE INDEX IF NOT EXISTS report_schedules_tenant_idx ON report_schedules (tenant_id, created_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS report_schedules_due_idx ON report_schedules (next_run_at) WHERE enabled`,
 }
 
-const reportScheduleColumns = `id, tenant_id, report_id, parameters_json::text, interval_seconds, enabled, next_run_at, last_run_at, created_at, updated_at`
+const reportScheduleColumns = `id, tenant_id, report_id, parameters_json::text, interval_seconds, enabled, next_run_at, last_run_at, claim_owner, claim_expires_at, created_at, updated_at`
 
 func (s *Store) ensureReportScheduleTable(ctx context.Context) error {
 	return s.ensureReportTables(ctx)
@@ -70,6 +74,8 @@ ON CONFLICT (id) DO UPDATE SET
   enabled = EXCLUDED.enabled,
   next_run_at = EXCLUDED.next_run_at,
   last_run_at = EXCLUDED.last_run_at,
+  claim_owner = '',
+  claim_expires_at = NULL,
   updated_at = NOW()`,
 		id, tenantID, reportID, string(parameters), schedule.IntervalSeconds, schedule.Enabled,
 		schedule.NextRunAt.UTC(), nullableTime(schedule.LastRunAt)); err != nil {
@@ -160,7 +166,7 @@ func (s *Store) DeleteReportSchedule(ctx context.Context, scheduleID string) err
 // ClaimDueReportSchedules atomically claims enabled schedules whose next run is
 // due, advancing each one full interval ahead so a single pass enqueues each due
 // schedule exactly once even across concurrent server replicas.
-func (s *Store) ClaimDueReportSchedules(ctx context.Context, now time.Time, limit uint32) ([]*ports.ReportSchedule, error) {
+func (s *Store) ClaimDueReportSchedules(ctx context.Context, now time.Time, owner string, ttl time.Duration, limit uint32) ([]*ports.ReportSchedule, error) {
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
 	}
@@ -170,21 +176,31 @@ func (s *Store) ClaimDueReportSchedules(ctx context.Context, now time.Time, limi
 	if limit == 0 {
 		limit = reportScheduleClaimLimit
 	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return nil, errors.New("report schedule claim owner is required")
+	}
+	if ttl <= 0 {
+		return nil, errors.New("report schedule claim ttl must be positive")
+	}
+	now = now.UTC()
 	// #nosec G201 -- column list is a fixed constant and all values remain parameterized.
 	query := fmt.Sprintf(`
 UPDATE report_schedules
-SET next_run_at = $1::timestamptz + make_interval(secs => interval_seconds),
-    last_run_at = $1::timestamptz,
+SET claim_owner = $3,
+    claim_expires_at = $1::timestamptz + $4::bigint * INTERVAL '1 millisecond',
     updated_at = NOW()
 WHERE id IN (
   SELECT id FROM report_schedules
-  WHERE enabled AND next_run_at <= $1::timestamptz
+  WHERE enabled
+    AND next_run_at <= $1::timestamptz
+    AND (claim_expires_at IS NULL OR claim_expires_at <= $1::timestamptz)
   ORDER BY next_run_at
   LIMIT $2
   FOR UPDATE SKIP LOCKED
 )
 RETURNING %s`, reportScheduleColumns)
-	rows, err := s.db.QueryContext(ctx, query, now.UTC(), limit)
+	rows, err := s.db.QueryContext(ctx, query, now, limit, owner, ttl.Milliseconds())
 	if err != nil {
 		return nil, fmt.Errorf("claim due report schedules: %w", err)
 	}
@@ -198,6 +214,63 @@ RETURNING %s`, reportScheduleColumns)
 		schedules = append(schedules, schedule)
 	}
 	return schedules, rows.Err()
+}
+
+// CompleteReportScheduleClaim advances a schedule only after its occurrence job
+// has been durably created. The owner and occurrence prevent a stale worker from
+// acknowledging a newer claim.
+func (s *Store) CompleteReportScheduleClaim(ctx context.Context, scheduleID string, owner string, occurrenceAt time.Time, completedAt time.Time) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	scheduleID = strings.TrimSpace(scheduleID)
+	owner = strings.TrimSpace(owner)
+	if scheduleID == "" || owner == "" || occurrenceAt.IsZero() || completedAt.IsZero() {
+		return errors.New("report schedule id, claim owner, occurrence, and completion time are required")
+	}
+	if err := s.ensureReportScheduleTable(ctx); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE report_schedules
+SET next_run_at = $4::timestamptz + make_interval(secs => interval_seconds),
+    last_run_at = $3::timestamptz,
+    claim_owner = '',
+    claim_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND claim_owner = $2
+  AND next_run_at = $3::timestamptz`, scheduleID, owner, occurrenceAt.UTC(), completedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("complete report schedule claim %q: %w", scheduleID, err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		return fmt.Errorf("report schedule claim conflict: %s", scheduleID)
+	}
+	return nil
+}
+
+// ReleaseReportScheduleClaim makes a failed enqueue eligible for the next poll.
+func (s *Store) ReleaseReportScheduleClaim(ctx context.Context, scheduleID string, owner string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	scheduleID = strings.TrimSpace(scheduleID)
+	owner = strings.TrimSpace(owner)
+	if scheduleID == "" || owner == "" {
+		return errors.New("report schedule id and claim owner are required")
+	}
+	if err := s.ensureReportScheduleTable(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `
+UPDATE report_schedules
+SET claim_owner = '', claim_expires_at = NULL, updated_at = NOW()
+WHERE id = $1 AND claim_owner = $2`, scheduleID, owner)
+	if err != nil {
+		return fmt.Errorf("release report schedule claim %q: %w", scheduleID, err)
+	}
+	return nil
 }
 
 const reportScheduleClaimLimit uint32 = 50
@@ -222,6 +295,7 @@ func scanReportSchedule(row scanner) (*ports.ReportSchedule, error) {
 		schedule       ports.ReportSchedule
 		parametersText string
 		lastRunAt      sql.NullTime
+		claimExpiresAt sql.NullTime
 	)
 	if err := row.Scan(
 		&schedule.ID,
@@ -232,6 +306,8 @@ func scanReportSchedule(row scanner) (*ports.ReportSchedule, error) {
 		&schedule.Enabled,
 		&schedule.NextRunAt,
 		&lastRunAt,
+		&schedule.ClaimOwner,
+		&claimExpiresAt,
 		&schedule.CreatedAt,
 		&schedule.UpdatedAt,
 	); err != nil {
@@ -246,6 +322,9 @@ func scanReportSchedule(row scanner) (*ports.ReportSchedule, error) {
 	schedule.Parameters = parameters
 	if lastRunAt.Valid {
 		schedule.LastRunAt = lastRunAt.Time
+	}
+	if claimExpiresAt.Valid {
+		schedule.ClaimExpiresAt = claimExpiresAt.Time
 	}
 	return &schedule, nil
 }

--- a/internal/statestore/postgres/report_schedules_test.go
+++ b/internal/statestore/postgres/report_schedules_test.go
@@ -41,6 +41,7 @@ func TestScanReportSchedule(t *testing.T) {
 			`{"tenant_id":"local","runtime_ids":"rt-1"}`,
 			int64(3600), true, next,
 			sql.NullTime{Time: last, Valid: true},
+			"", sql.NullTime{},
 			created, created,
 		}}
 		schedule, err := scanReportSchedule(scanner)
@@ -67,6 +68,7 @@ func TestScanReportSchedule(t *testing.T) {
 			"",
 			int64(7200), false, next,
 			sql.NullTime{},
+			"", sql.NullTime{},
 			created, created,
 		}}
 		schedule, err := scanReportSchedule(scanner)

--- a/internal/workflowevents/avro_decoder.go
+++ b/internal/workflowevents/avro_decoder.go
@@ -104,6 +104,8 @@ func decodeAvroPayload(kind string, data []byte, payload any) error {
 		err = decodeFindingStatusChanged(reader, target)
 	case *FindingTombstoned:
 		err = decodeFindingTombstoned(reader, target)
+	case *ComplianceAggregateRecorded:
+		err = decodeComplianceAggregateRecorded(reader, target)
 	default:
 		return fmt.Errorf("unsupported workflow payload target %T for %s", payload, kind)
 	}
@@ -114,6 +116,39 @@ func decodeAvroPayload(kind string, data []byte, payload any) error {
 		return fmt.Errorf("payload has %d trailing bytes", reader.remaining())
 	}
 	return nil
+}
+
+func decodeComplianceAggregateRecorded(reader *avroReader, payload *ComplianceAggregateRecorded) error {
+	var err error
+	if payload.TenantID, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.AggregateType, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.AggregateID, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.RevisionID, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.AggregateVersion, err = reader.long(); err != nil {
+		return err
+	}
+	if payload.Operation, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.ContentDigest, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.PayloadJSON, err = reader.string(); err != nil {
+		return err
+	}
+	if payload.ActorID, err = reader.string(); err != nil {
+		return err
+	}
+	payload.RecordedAt, err = reader.string()
+	return err
 }
 
 func decodeDecisionRecorded(reader *avroReader, payload *DecisionRecorded) error {

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -28,6 +28,7 @@ const (
 	EventKindComplianceActivityRecorded            = "workflow.v1.compliance.assessment_activity_recorded"
 	EventKindCompliancePopulationRecorded          = "workflow.v1.compliance.assessment_population_recorded"
 	EventKindComplianceSampleRecorded              = "workflow.v1.compliance.assessment_sample_recorded"
+	EventKindComplianceSourceCheckRecorded         = "workflow.v1.compliance.assessment_source_check_recorded"
 	EventKindComplianceReviewRecorded              = "workflow.v1.compliance.assessment_review_recorded"
 	EventKindComplianceRiskDecisionRecorded        = "workflow.v1.compliance.risk_decision_recorded"
 	EventKindComplianceExceptionUpdated            = "workflow.v1.compliance.exception_updated"
@@ -124,6 +125,7 @@ func registeredComplianceKinds() []string {
 		EventKindComplianceResultChunkRecorded, EventKindComplianceAssessmentCompleted,
 		EventKindComplianceAssessmentCancelled, EventKindComplianceActivityRecorded,
 		EventKindCompliancePopulationRecorded, EventKindComplianceSampleRecorded,
+		EventKindComplianceSourceCheckRecorded,
 		EventKindComplianceReviewRecorded, EventKindComplianceRiskDecisionRecorded,
 		EventKindComplianceExceptionUpdated, EventKindComplianceWorkItemUpdated,
 		EventKindComplianceRemediationMilestoneUpdated, EventKindComplianceAuditEngagementRecorded,

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -93,7 +93,7 @@ func NewComplianceAggregateEvent(payload ComplianceAggregateRecorded) (*cerebrov
 		ContentDigest: payload.ContentDigest, PayloadJSON: payload.PayloadJSON,
 		ActorID: payload.ActorID, RecordedAt: payload.RecordedAt,
 	}
-	primaryID := payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
+	primaryID := payload.AggregateType + "|" + payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
 	return newEvent(contract, SchemaComplianceAggregate, payload.TenantID, "compliance", primaryID, payload.RecordedAt, map[string]string{
 		EventAttributeWorkflowKind: "compliance_aggregate",
 		"aggregate_type":           payload.AggregateType,

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -39,6 +39,7 @@ const (
 	EventKindComplianceAuditPackageRecorded        = "workflow.v1.compliance.audit_package_recorded"
 	EventKindComplianceAuditDeliveryRecorded       = "workflow.v1.compliance.audit_delivery_recorded"
 	EventKindComplianceExchangeStaged              = "workflow.v1.compliance.exchange_staged"
+	EventKindComplianceExchangeCommitRequested     = "workflow.v1.compliance.exchange_commit_requested"
 	EventKindComplianceExchangeCommitted           = "workflow.v1.compliance.exchange_committed"
 	EventKindComplianceMonitorUpdated              = "workflow.v1.compliance.monitor_updated"
 	EventKindComplianceMonitorTriggered            = "workflow.v1.compliance.monitor_triggered"
@@ -128,7 +129,8 @@ func registeredComplianceKinds() []string {
 		EventKindComplianceRemediationMilestoneUpdated, EventKindComplianceAuditEngagementRecorded,
 		EventKindComplianceAuditRequestUpdated, EventKindComplianceAuditSubmissionRecorded,
 		EventKindComplianceAuditPackageRecorded, EventKindComplianceAuditDeliveryRecorded,
-		EventKindComplianceExchangeStaged, EventKindComplianceExchangeCommitted,
+		EventKindComplianceExchangeStaged, EventKindComplianceExchangeCommitRequested,
+		EventKindComplianceExchangeCommitted,
 		EventKindComplianceMonitorUpdated, EventKindComplianceMonitorTriggered,
 	}
 }

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -1,0 +1,134 @@
+package workflowevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	eventregistry "github.com/WriterInternal/event-registry/clients/go"
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+const (
+	EventKindComplianceProgramRecorded             = "workflow.v1.compliance.program_recorded"
+	EventKindComplianceProgramScopeRecorded        = "workflow.v1.compliance.program_scope_recorded"
+	EventKindComplianceImplementationRecorded      = "workflow.v1.compliance.control_implementation_recorded"
+	EventKindComplianceEvidenceVersionRecorded     = "workflow.v1.compliance.evidence_artifact_version_recorded"
+	EventKindComplianceEvidenceClaimRecorded       = "workflow.v1.compliance.evidence_claim_recorded"
+	EventKindComplianceEvidenceClaimReviewed       = "workflow.v1.compliance.evidence_claim_reviewed"
+	EventKindComplianceEvidenceClaimInvalidated    = "workflow.v1.compliance.evidence_claim_invalidated"
+	EventKindCompliancePlanRevisionRecorded        = "workflow.v1.compliance.assessment_plan_revision_recorded"
+	EventKindCompliancePlanPublished               = "workflow.v1.compliance.assessment_plan_published"
+	EventKindComplianceAssessmentRequested         = "workflow.v1.compliance.assessment_requested"
+	EventKindComplianceAssessmentJobBound          = "workflow.v1.compliance.assessment_job_bound"
+	EventKindComplianceInputManifestRecorded       = "workflow.v1.compliance.assessment_input_manifest_recorded"
+	EventKindComplianceResultChunkRecorded         = "workflow.v1.compliance.assessment_result_chunk_recorded"
+	EventKindComplianceAssessmentCompleted         = "workflow.v1.compliance.assessment_completed"
+	EventKindComplianceAssessmentCancelled         = "workflow.v1.compliance.assessment_cancelled"
+	EventKindComplianceActivityRecorded            = "workflow.v1.compliance.assessment_activity_recorded"
+	EventKindCompliancePopulationRecorded          = "workflow.v1.compliance.assessment_population_recorded"
+	EventKindComplianceSampleRecorded              = "workflow.v1.compliance.assessment_sample_recorded"
+	EventKindComplianceReviewRecorded              = "workflow.v1.compliance.assessment_review_recorded"
+	EventKindComplianceRiskDecisionRecorded        = "workflow.v1.compliance.risk_decision_recorded"
+	EventKindComplianceExceptionUpdated            = "workflow.v1.compliance.exception_updated"
+	EventKindComplianceWorkItemUpdated             = "workflow.v1.compliance.work_item_updated"
+	EventKindComplianceRemediationMilestoneUpdated = "workflow.v1.compliance.remediation_milestone_updated"
+	EventKindComplianceAuditEngagementRecorded     = "workflow.v1.compliance.audit_engagement_recorded"
+	EventKindComplianceAuditRequestUpdated         = "workflow.v1.compliance.audit_request_updated"
+	EventKindComplianceAuditSubmissionRecorded     = "workflow.v1.compliance.audit_submission_recorded"
+	EventKindComplianceAuditPackageRecorded        = "workflow.v1.compliance.audit_package_recorded"
+	EventKindComplianceAuditDeliveryRecorded       = "workflow.v1.compliance.audit_delivery_recorded"
+	EventKindComplianceExchangeStaged              = "workflow.v1.compliance.exchange_staged"
+	EventKindComplianceExchangeCommitted           = "workflow.v1.compliance.exchange_committed"
+	EventKindComplianceMonitorUpdated              = "workflow.v1.compliance.monitor_updated"
+	EventKindComplianceMonitorTriggered            = "workflow.v1.compliance.monitor_triggered"
+
+	SchemaComplianceAggregate = "urn:cerebro:events/workflow.compliance.aggregate/v1"
+	maxCompliancePayloadBytes = 512 * 1024
+)
+
+// ComplianceAggregateRecorded is the shared append-first envelope for bounded,
+// canonical compliance revisions and transitions. PayloadJSON contains no raw
+// evidence bytes and is validated by the owning domain before append.
+type ComplianceAggregateRecorded struct {
+	Kind             string `json:"kind"`
+	TenantID         string `json:"tenant_id"`
+	AggregateType    string `json:"aggregate_type"`
+	AggregateID      string `json:"aggregate_id"`
+	RevisionID       string `json:"revision_id,omitempty"`
+	AggregateVersion int64  `json:"aggregate_version"`
+	Operation        string `json:"operation"`
+	ContentDigest    string `json:"content_digest,omitempty"`
+	PayloadJSON      string `json:"payload_json,omitempty"`
+	ActorID          string `json:"actor_id,omitempty"`
+	RecordedAt       string `json:"recorded_at"`
+}
+
+func NewComplianceAggregateEvent(payload ComplianceAggregateRecorded) (*cerebrov1.EventEnvelope, error) {
+	payload.Kind = strings.TrimSpace(payload.Kind)
+	if !strings.HasPrefix(payload.Kind, eventregistry.WorkflowV1CompliancePrefix) || !KindRegistered(payload.Kind) {
+		return nil, fmt.Errorf("compliance event kind %q is not registered", payload.Kind)
+	}
+	if strings.TrimSpace(payload.AggregateType) == "" || strings.TrimSpace(payload.AggregateID) == "" {
+		return nil, fmt.Errorf("compliance event aggregate type and id are required")
+	}
+	if payload.AggregateVersion < 1 {
+		return nil, fmt.Errorf("compliance event aggregate version must be positive")
+	}
+	if strings.TrimSpace(payload.Operation) == "" {
+		return nil, fmt.Errorf("compliance event operation is required")
+	}
+	if len(payload.PayloadJSON) > maxCompliancePayloadBytes {
+		return nil, fmt.Errorf("compliance event payload exceeds %d bytes", maxCompliancePayloadBytes)
+	}
+	if strings.TrimSpace(payload.PayloadJSON) != "" && !json.Valid([]byte(payload.PayloadJSON)) {
+		return nil, fmt.Errorf("compliance event payload_json is invalid")
+	}
+	contract := eventregistry.ComplianceAggregateV1{
+		Kind: payload.Kind, TenantID: payload.TenantID, AggregateType: payload.AggregateType,
+		AggregateID: payload.AggregateID, RevisionID: payload.RevisionID,
+		AggregateVersion: payload.AggregateVersion, Operation: payload.Operation,
+		ContentDigest: payload.ContentDigest, PayloadJSON: payload.PayloadJSON,
+		ActorID: payload.ActorID, RecordedAt: payload.RecordedAt,
+	}
+	primaryID := payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
+	return newEvent(contract, SchemaComplianceAggregate, payload.TenantID, "compliance", primaryID, payload.RecordedAt, map[string]string{
+		EventAttributeWorkflowKind: "compliance_aggregate",
+		"aggregate_type":           payload.AggregateType,
+		"aggregate_id":             payload.AggregateID,
+		"revision_id":              payload.RevisionID,
+	})
+}
+
+func DecodeComplianceAggregate(event *cerebrov1.EventEnvelope) (*ComplianceAggregateRecorded, error) {
+	payload := &ComplianceAggregateRecorded{Kind: strings.TrimSpace(event.GetKind())}
+	if !strings.HasPrefix(payload.Kind, eventregistry.WorkflowV1CompliancePrefix) || !KindRegistered(payload.Kind) {
+		return nil, fmt.Errorf("workflow event kind = %q is not a registered compliance kind", payload.Kind)
+	}
+	if err := decodePayload(event, payload.Kind, payload); err != nil {
+		return nil, err
+	}
+	payload.Kind = strings.TrimSpace(event.GetKind())
+	return payload, nil
+}
+
+func registeredComplianceKinds() []string {
+	return []string{
+		EventKindComplianceProgramRecorded, EventKindComplianceProgramScopeRecorded,
+		EventKindComplianceImplementationRecorded, EventKindComplianceEvidenceVersionRecorded,
+		EventKindComplianceEvidenceClaimRecorded, EventKindComplianceEvidenceClaimReviewed,
+		EventKindComplianceEvidenceClaimInvalidated, EventKindCompliancePlanRevisionRecorded,
+		EventKindCompliancePlanPublished, EventKindComplianceAssessmentRequested,
+		EventKindComplianceAssessmentJobBound, EventKindComplianceInputManifestRecorded,
+		EventKindComplianceResultChunkRecorded, EventKindComplianceAssessmentCompleted,
+		EventKindComplianceAssessmentCancelled, EventKindComplianceActivityRecorded,
+		EventKindCompliancePopulationRecorded, EventKindComplianceSampleRecorded,
+		EventKindComplianceReviewRecorded, EventKindComplianceRiskDecisionRecorded,
+		EventKindComplianceExceptionUpdated, EventKindComplianceWorkItemUpdated,
+		EventKindComplianceRemediationMilestoneUpdated, EventKindComplianceAuditEngagementRecorded,
+		EventKindComplianceAuditRequestUpdated, EventKindComplianceAuditSubmissionRecorded,
+		EventKindComplianceAuditPackageRecorded, EventKindComplianceAuditDeliveryRecorded,
+		EventKindComplianceExchangeStaged, EventKindComplianceExchangeCommitted,
+		EventKindComplianceMonitorUpdated, EventKindComplianceMonitorTriggered,
+	}
+}

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -42,6 +42,18 @@ func TestComplianceAggregateKindsRegistered(t *testing.T) {
 	}
 }
 
+func TestComplianceExchangeRequestAndCommitRemainDistinctFacts(t *testing.T) {
+	t.Parallel()
+	if EventKindComplianceExchangeCommitRequested == EventKindComplianceExchangeCommitted {
+		t.Fatal("exchange commit request and completed commit share an event kind")
+	}
+	for _, kind := range []string{EventKindComplianceExchangeCommitRequested, EventKindComplianceExchangeCommitted} {
+		if !KindRegistered(kind) {
+			t.Fatalf("kind %q is not registered", kind)
+		}
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -65,6 +65,27 @@ func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
 	}
 }
 
+func TestComplianceAggregateIdentityIncludesAggregateType(t *testing.T) {
+	t.Parallel()
+	base := ComplianceAggregateRecorded{
+		Kind: EventKindComplianceSourceCheckRecorded, TenantID: "tenant-a",
+		AggregateType: "source_check", AggregateID: "shared-id", AggregateVersion: 1,
+		Operation: "recorded", RecordedAt: "2026-07-11T08:00:00Z",
+	}
+	first, err := NewComplianceAggregateEvent(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.AggregateType = "objective_source_assessment"
+	second, err := NewComplianceAggregateEvent(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.GetId() == second.GetId() {
+		t.Fatalf("aggregate types produced the same event id %q", first.GetId())
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -1,0 +1,67 @@
+package workflowevents
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComplianceAggregateRoundTrip(t *testing.T) {
+	t.Parallel()
+	payload := ComplianceAggregateRecorded{
+		Kind: EventKindComplianceProgramRecorded, TenantID: "tenant-a",
+		AggregateType: "program", AggregateID: "program-1", RevisionID: "revision-1",
+		AggregateVersion: 2, Operation: "recorded",
+		ContentDigest: "sha256:abc", PayloadJSON: `{"id":"program-1"}`,
+		ActorID: "actor-1", RecordedAt: "2026-07-11T08:00:00.123Z",
+	}
+	event, err := NewComplianceAggregateEvent(payload)
+	if err != nil {
+		t.Fatalf("NewComplianceAggregateEvent() error = %v", err)
+	}
+	decoded, err := DecodeComplianceAggregate(event)
+	if err != nil {
+		t.Fatalf("DecodeComplianceAggregate() error = %v", err)
+	}
+	if decoded.Kind != payload.Kind || decoded.TenantID != payload.TenantID || decoded.AggregateID != payload.AggregateID || decoded.AggregateVersion != payload.AggregateVersion || decoded.PayloadJSON != payload.PayloadJSON {
+		t.Fatalf("round trip = %#v, want %#v", decoded, payload)
+	}
+	if event.GetAttributes()["aggregate_id"] != payload.AggregateID {
+		t.Fatalf("aggregate_id attribute = %q", event.GetAttributes()["aggregate_id"])
+	}
+}
+
+func TestComplianceAggregateKindsRegistered(t *testing.T) {
+	t.Parallel()
+	for _, kind := range registeredComplianceKinds() {
+		if !KindRegistered(kind) {
+			t.Fatalf("kind %q is not registered", kind)
+		}
+		if got := SchemaForKind(kind); got != SchemaComplianceAggregate {
+			t.Fatalf("schema for %q = %q", kind, got)
+		}
+	}
+}
+
+func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
+	t.Parallel()
+	base := ComplianceAggregateRecorded{
+		Kind: EventKindComplianceProgramRecorded, TenantID: "tenant-a",
+		AggregateType: "program", AggregateID: "program-1", AggregateVersion: 1,
+		Operation: "recorded", RecordedAt: "2026-07-11T08:00:00Z",
+	}
+	invalid := base
+	invalid.PayloadJSON = "{"
+	if _, err := NewComplianceAggregateEvent(invalid); err == nil {
+		t.Fatal("invalid JSON payload unexpectedly accepted")
+	}
+	large := base
+	large.PayloadJSON = `"` + strings.Repeat("x", maxCompliancePayloadBytes) + `"`
+	if _, err := NewComplianceAggregateEvent(large); err == nil {
+		t.Fatal("oversized payload unexpectedly accepted")
+	}
+	unknown := base
+	unknown.Kind = "workflow.v1.compliance.unknown"
+	if _, err := NewComplianceAggregateEvent(unknown); err == nil {
+		t.Fatal("unregistered kind unexpectedly accepted")
+	}
+}

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -54,6 +54,17 @@ func TestComplianceExchangeRequestAndCommitRemainDistinctFacts(t *testing.T) {
 	}
 }
 
+func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
+	t.Parallel()
+	if EventKindComplianceSourceCheckRecorded == EventKindComplianceActivityRecorded ||
+		EventKindComplianceSourceCheckRecorded == EventKindComplianceInputManifestRecorded {
+		t.Fatal("source check event overloads an activity or input-manifest fact")
+	}
+	if !KindRegistered(EventKindComplianceSourceCheckRecorded) {
+		t.Fatal("source check event kind is not registered")
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{

--- a/internal/workflowevents/registry.go
+++ b/internal/workflowevents/registry.go
@@ -47,4 +47,7 @@ func init() {
 	registerKind(EventKindFindingNoteAdded, SchemaFindingNoteAdded)
 	registerKind(EventKindFindingTicketLinked, SchemaFindingTicketLinked)
 	registerKind(EventKindFindingStatusChanged, SchemaFindingStatusChanged)
+	for _, kind := range registeredComplianceKinds() {
+		registerKind(kind, SchemaComplianceAggregate)
+	}
 }

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -72,7 +72,7 @@ def is_reachable_finding(finding: dict[str, Any]) -> bool:
 def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
     env = os.environ.copy()
     env["GOFLAGS"] = ""
-    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.4")
+    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.5")
     command = ["go", "run", DEFAULT_TOOL, "-format", "json", *patterns]
     completed = subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
     return completed.returncode, completed.stdout, completed.stderr


### PR DESCRIPTION
## Summary

- add tenant-keyed Postgres projections for evidence artifacts, immutable versions, scoped claims, and event application receipts
- preserve immutable revision uniqueness and tenant-qualified foreign keys
- apply append-log events idempotently with payload-digest conflict detection
- enforce expected-version claim updates and opaque tenant-scoped reads
- store metadata and content references without raw evidence bytes

## Dependency

This persistence slice is stacked on the immutable evidence ledger core.

## Exit criteria

- replaying the same event and digest is idempotent
- reusing an event ID or immutable version ID with different content conflicts
- claim updates require the expected aggregate version
- every primary, unique, and foreign-key boundary includes the tenant
- schema contains no raw evidence byte column

## Validation

- focused Postgres and evidence ledger tests
- Go vet and diff-scoped lint
- architecture and structural checks