### PR TITLE
Add compliance impact compatibility adapters

### DIFF
--- a/internal/compliance/identifiers.go
+++ b/internal/compliance/identifiers.go
@@ -1,0 +1,138 @@
+package compliance
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrInvalidIdentifier = errors.New("invalid compliance identifier")
+
+// IdentifierKind names the stable public prefix for one compliance resource.
+type IdentifierKind string
+
+const (
+	IdentifierProgram        IdentifierKind = "program"
+	IdentifierScope          IdentifierKind = "scope"
+	IdentifierImplementation IdentifierKind = "implementation"
+	IdentifierPlan           IdentifierKind = "assessment-plan"
+	IdentifierTest           IdentifierKind = "assessment-test"
+	IdentifierEvidence       IdentifierKind = "evidence"
+	IdentifierClaim          IdentifierKind = "evidence-claim"
+	IdentifierRun            IdentifierKind = "assessment-run"
+	IdentifierResult         IdentifierKind = "assessment-result"
+	IdentifierReview         IdentifierKind = "assessment-review"
+	IdentifierArtifact       IdentifierKind = "artifact"
+	IdentifierMapping        IdentifierKind = "control-mapping"
+)
+
+const identifierEntropyBytes = 16
+
+// NewIdentifier returns an opaque identifier with a resource-specific prefix.
+func NewIdentifier(kind IdentifierKind) (string, error) {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return "", err
+	}
+	random := make([]byte, identifierEntropyBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate compliance identifier: %w", err)
+	}
+	return string(kind) + "-" + hex.EncodeToString(random), nil
+}
+
+// NewRevisionIdentifier returns an opaque identity for an immutable revision.
+func NewRevisionIdentifier(kind IdentifierKind) (string, error) {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return "", err
+	}
+	random := make([]byte, identifierEntropyBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate compliance revision identifier: %w", err)
+	}
+	return string(kind) + "-revision-" + hex.EncodeToString(random), nil
+}
+
+func ValidateIdentifierKind(kind IdentifierKind) error {
+	value := string(kind)
+	if value == "" || len(value) > 40 || !identifierToken(value) {
+		return fmt.Errorf("%w: kind %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+// ValidateIdentifier rejects display names, whitespace, path separators, and
+// tenant data in public identifiers. IDs remain opaque and tenant scoping is
+// enforced separately by every store lookup.
+func ValidateIdentifier(kind IdentifierKind, value string) error {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return err
+	}
+	raw := value
+	value = strings.TrimSpace(value)
+	if value != raw {
+		return fmt.Errorf("%w: identifier contains surrounding whitespace", ErrInvalidIdentifier)
+	}
+	prefix := string(kind) + "-"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+(identifierEntropyBytes*2) {
+		return fmt.Errorf("%w: expected %s prefix", ErrInvalidIdentifier, prefix)
+	}
+	if !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+// ValidateRevisionIdentifier checks an immutable revision identity separately
+// from the logical record identity.
+func ValidateRevisionIdentifier(kind IdentifierKind, value string) error {
+	if err := ValidateIdentifierKind(kind); err != nil {
+		return err
+	}
+	raw := value
+	value = strings.TrimSpace(value)
+	if value != raw {
+		return fmt.Errorf("%w: revision identifier contains surrounding whitespace", ErrInvalidIdentifier)
+	}
+	prefix := string(kind) + "-revision-"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+(identifierEntropyBytes*2) {
+		return fmt.Errorf("%w: expected %s prefix", ErrInvalidIdentifier, prefix)
+	}
+	if !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: %q", ErrInvalidIdentifier, value)
+	}
+	return nil
+}
+
+func identifierToken(value string) bool {
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') || character == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func lowerHex(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, character := range value {
+		if (character >= 'a' && character <= 'f') || (character >= '0' && character <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func ValidateContentDigest(digest ContentDigest) error {
+	value := string(digest)
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+64 || !lowerHex(value[len(prefix):]) {
+		return fmt.Errorf("%w: invalid content digest", ErrInvalidRevision)
+	}
+	return nil
+}

--- a/internal/compliance/identifiers_test.go
+++ b/internal/compliance/identifiers_test.go
@@ -1,0 +1,59 @@
+package compliance
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestOpaqueLogicalAndRevisionIdentifiersValidateSeparately(t *testing.T) {
+	logical, err := NewIdentifier(IdentifierProgram)
+	if err != nil {
+		t.Fatalf("NewIdentifier() error = %v", err)
+	}
+	revision, err := NewRevisionIdentifier(IdentifierProgram)
+	if err != nil {
+		t.Fatalf("NewRevisionIdentifier() error = %v", err)
+	}
+	if err := ValidateIdentifier(IdentifierProgram, logical); err != nil {
+		t.Fatalf("ValidateIdentifier() error = %v", err)
+	}
+	if err := ValidateRevisionIdentifier(IdentifierProgram, revision); err != nil {
+		t.Fatalf("ValidateRevisionIdentifier() error = %v", err)
+	}
+	if logical == revision || strings.Contains(logical, "revision") {
+		t.Fatalf("logical=%q revision=%q are not distinct", logical, revision)
+	}
+	if err := ValidateIdentifier(IdentifierProgram, revision); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateIdentifier(revision) error = %v, want ErrInvalidIdentifier", err)
+	}
+	if err := ValidateRevisionIdentifier(IdentifierProgram, logical); !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("ValidateRevisionIdentifier(logical) error = %v, want ErrInvalidIdentifier", err)
+	}
+}
+
+func TestValidateIdentifierRejectsLossyAndNonOpaqueValues(t *testing.T) {
+	for _, value := range []string{
+		"program-customer/name",
+		"program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-",
+		"program-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-extra",
+		" program-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	} {
+		if err := ValidateIdentifier(IdentifierProgram, value); !errors.Is(err, ErrInvalidIdentifier) {
+			t.Fatalf("ValidateIdentifier(%q) error = %v, want ErrInvalidIdentifier", value, err)
+		}
+	}
+}
+
+func TestValidateContentDigestRequiresCanonicalSHA256(t *testing.T) {
+	valid := ContentDigest("sha256:" + strings.Repeat("a", 64))
+	if err := ValidateContentDigest(valid); err != nil {
+		t.Fatalf("ValidateContentDigest() error = %v", err)
+	}
+	for _, value := range []ContentDigest{"", "sha256:abc", ContentDigest("SHA256:" + strings.Repeat("a", 64)), ContentDigest("sha256:" + strings.Repeat("A", 64))} {
+		if err := ValidateContentDigest(value); !errors.Is(err, ErrInvalidRevision) {
+			t.Fatalf("ValidateContentDigest(%q) error = %v, want ErrInvalidRevision", value, err)
+		}
+	}
+}

--- a/internal/compliance/mappings.go
+++ b/internal/compliance/mappings.go
@@ -1,0 +1,146 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var ErrInvalidMapping = errors.New("invalid compliance mapping")
+
+type MappingRelationship string
+
+const (
+	MappingEquivalent MappingRelationship = "equivalent"
+	MappingSubset     MappingRelationship = "subset"
+	MappingSuperset   MappingRelationship = "superset"
+	MappingOverlap    MappingRelationship = "overlap"
+	MappingNone       MappingRelationship = "none"
+)
+
+type MappingDecisionState string
+
+const (
+	MappingProposed MappingDecisionState = "proposed"
+	MappingApproved MappingDecisionState = "approved"
+	MappingRejected MappingDecisionState = "rejected"
+	MappingRetired  MappingDecisionState = "retired"
+)
+
+// ControlMapping records an explicit, reviewable relationship between exact
+// source and target revisions. It never grants coverage by implication.
+type ControlMapping struct {
+	ID                  string               `json:"id"`
+	RevisionID          string               `json:"revision_id"`
+	Source              RevisionRef          `json:"source"`
+	Target              RevisionRef          `json:"target"`
+	Granularity         string               `json:"granularity"`
+	Relationship        MappingRelationship  `json:"relationship"`
+	Method              string               `json:"method"`
+	Rationale           string               `json:"rationale"`
+	CoverageBasisPoints uint16               `json:"coverage_basis_points"`
+	Gaps                []string             `json:"gaps,omitempty"`
+	Provenance          []SubjectRef         `json:"provenance,omitempty"`
+	DecisionState       MappingDecisionState `json:"decision_state"`
+	AuthorID            string               `json:"author_id"`
+	ReviewerID          string               `json:"reviewer_id,omitempty"`
+}
+
+func (mapping ControlMapping) Validate() error {
+	if strings.TrimSpace(mapping.ID) == "" || strings.TrimSpace(mapping.RevisionID) == "" {
+		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidMapping)
+	}
+	if err := mapping.Source.Validate(); err != nil {
+		return fmt.Errorf("%w: source: %v", ErrInvalidMapping, err)
+	}
+	if err := mapping.Target.Validate(); err != nil {
+		return fmt.Errorf("%w: target: %v", ErrInvalidMapping, err)
+	}
+	if mapping.Source.ID == mapping.Target.ID && mapping.Source.RevisionID == mapping.Target.RevisionID {
+		return fmt.Errorf("%w: source and target must differ", ErrInvalidMapping)
+	}
+	switch mapping.Relationship {
+	case MappingEquivalent, MappingSubset, MappingSuperset, MappingOverlap, MappingNone:
+	default:
+		return fmt.Errorf("%w: relationship %q", ErrInvalidMapping, mapping.Relationship)
+	}
+	switch mapping.DecisionState {
+	case MappingProposed, MappingApproved, MappingRejected, MappingRetired:
+	default:
+		return fmt.Errorf("%w: decision_state %q", ErrInvalidMapping, mapping.DecisionState)
+	}
+	if mapping.CoverageBasisPoints > 10000 {
+		return fmt.Errorf("%w: coverage_basis_points exceeds 10000", ErrInvalidMapping)
+	}
+	if mapping.Relationship == MappingNone && mapping.CoverageBasisPoints != 0 {
+		return fmt.Errorf("%w: none relationship must have zero coverage", ErrInvalidMapping)
+	}
+	if mapping.Relationship == MappingEquivalent && mapping.CoverageBasisPoints != 10000 {
+		return fmt.Errorf("%w: equivalent relationship must have full coverage", ErrInvalidMapping)
+	}
+	if strings.TrimSpace(mapping.Granularity) == "" || strings.TrimSpace(mapping.Method) == "" || strings.TrimSpace(mapping.Rationale) == "" || strings.TrimSpace(mapping.AuthorID) == "" {
+		return fmt.Errorf("%w: granularity, method, rationale, and author_id are required", ErrInvalidMapping)
+	}
+	if mapping.DecisionState != MappingProposed && strings.TrimSpace(mapping.ReviewerID) == "" {
+		return fmt.Errorf("%w: reviewer_id is required for decided mappings", ErrInvalidMapping)
+	}
+	for index, reference := range mapping.Provenance {
+		if err := reference.Validate(); err != nil {
+			return fmt.Errorf("%w: provenance[%d]: %v", ErrInvalidMapping, index, err)
+		}
+	}
+	return nil
+}
+
+func NormalizeControlMapping(mapping ControlMapping) ControlMapping {
+	mapping.ID = strings.TrimSpace(mapping.ID)
+	mapping.RevisionID = strings.TrimSpace(mapping.RevisionID)
+	mapping.Granularity = strings.TrimSpace(mapping.Granularity)
+	mapping.Method = strings.TrimSpace(mapping.Method)
+	mapping.Rationale = strings.TrimSpace(mapping.Rationale)
+	mapping.AuthorID = strings.TrimSpace(mapping.AuthorID)
+	mapping.ReviewerID = strings.TrimSpace(mapping.ReviewerID)
+	mapping.Source = NormalizeRevisionRef(mapping.Source)
+	mapping.Target = NormalizeRevisionRef(mapping.Target)
+	mapping.Gaps = normalizedSortedStrings(mapping.Gaps)
+	mapping.Provenance = append([]SubjectRef(nil), mapping.Provenance...)
+	for index := range mapping.Provenance {
+		mapping.Provenance[index].Type = strings.TrimSpace(mapping.Provenance[index].Type)
+		mapping.Provenance[index].ID = strings.TrimSpace(mapping.Provenance[index].ID)
+	}
+	sort.Slice(mapping.Provenance, func(i, j int) bool {
+		return mapping.Provenance[i].Type+"\x00"+mapping.Provenance[i].ID < mapping.Provenance[j].Type+"\x00"+mapping.Provenance[j].ID
+	})
+	mapping.Provenance = deduplicateSubjectRefs(mapping.Provenance)
+	return mapping
+}
+
+func deduplicateSubjectRefs(values []SubjectRef) []SubjectRef {
+	result := make([]SubjectRef, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1] == value {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizedSortedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}

--- a/internal/compliance/mappings.go
+++ b/internal/compliance/mappings.go
@@ -52,10 +52,10 @@ func (mapping ControlMapping) Validate() error {
 		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidMapping)
 	}
 	if err := mapping.Source.Validate(); err != nil {
-		return fmt.Errorf("%w: source: %v", ErrInvalidMapping, err)
+		return fmt.Errorf("%w: source: %w", ErrInvalidMapping, err)
 	}
 	if err := mapping.Target.Validate(); err != nil {
-		return fmt.Errorf("%w: target: %v", ErrInvalidMapping, err)
+		return fmt.Errorf("%w: target: %w", ErrInvalidMapping, err)
 	}
 	if mapping.Source.ID == mapping.Target.ID && mapping.Source.RevisionID == mapping.Target.RevisionID {
 		return fmt.Errorf("%w: source and target must differ", ErrInvalidMapping)
@@ -87,7 +87,7 @@ func (mapping ControlMapping) Validate() error {
 	}
 	for index, reference := range mapping.Provenance {
 		if err := reference.Validate(); err != nil {
-			return fmt.Errorf("%w: provenance[%d]: %v", ErrInvalidMapping, index, err)
+			return fmt.Errorf("%w: provenance[%d]: %w", ErrInvalidMapping, index, err)
 		}
 	}
 	return nil

--- a/internal/compliance/mappings_test.go
+++ b/internal/compliance/mappings_test.go
@@ -1,0 +1,69 @@
+package compliance
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeControlMappingIsDeterministicWithoutMutatingCaller(t *testing.T) {
+	digest := ContentDigest("sha256:" + strings.Repeat("b", 64))
+	mapping := ControlMapping{
+		ID: " mapping ", RevisionID: " revision ", Granularity: " statement ",
+		Source:       RevisionRef{ID: "source", RevisionID: "source-r1", Version: 1, ContentDigest: digest, LastModified: time.Unix(1, 0)},
+		Target:       RevisionRef{ID: "target", RevisionID: "target-r1", Version: 1, ContentDigest: digest, LastModified: time.Unix(1, 0)},
+		Relationship: MappingOverlap, Method: " manual ", Rationale: " scoped overlap ", CoverageBasisPoints: 7500,
+		Gaps:          []string{" gap-b ", "gap-a", "gap-a"},
+		Provenance:    []SubjectRef{{Type: " source ", ID: "b"}, {Type: "source", ID: "a"}, {Type: "source", ID: "a"}},
+		DecisionState: MappingApproved, AuthorID: " author ", ReviewerID: " reviewer ",
+	}
+	normalized := NormalizeControlMapping(mapping)
+	if got := strings.Join(normalized.Gaps, ","); got != "gap-a,gap-b" {
+		t.Fatalf("normalized gaps = %q", got)
+	}
+	if len(normalized.Provenance) != 2 || normalized.Provenance[0].ID != "a" || normalized.Provenance[1].ID != "b" {
+		t.Fatalf("normalized provenance = %#v", normalized.Provenance)
+	}
+	if mapping.Provenance[0].Type != " source " {
+		t.Fatal("NormalizeControlMapping mutated caller provenance")
+	}
+	if normalized.Source.LastModified.Nanosecond()%int(time.Millisecond) != 0 {
+		t.Fatalf("source revision time was not normalized: %s", normalized.Source.LastModified)
+	}
+	if err := normalized.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestControlMappingRelationshipCoverageInvariants(t *testing.T) {
+	base := validControlMapping()
+	base.Relationship = MappingNone
+	base.CoverageBasisPoints = 1
+	if err := base.Validate(); err == nil {
+		t.Fatal("none relationship with coverage was accepted")
+	}
+	base = validControlMapping()
+	base.Relationship = MappingEquivalent
+	base.CoverageBasisPoints = 9999
+	if err := base.Validate(); err == nil {
+		t.Fatal("equivalent relationship without full coverage was accepted")
+	}
+	base = validControlMapping()
+	base.DecisionState = MappingApproved
+	base.ReviewerID = ""
+	if err := base.Validate(); err == nil {
+		t.Fatal("decided mapping without reviewer was accepted")
+	}
+}
+
+func validControlMapping() ControlMapping {
+	digest := ContentDigest("sha256:" + strings.Repeat("c", 64))
+	modified := time.Unix(1, 123456789).UTC()
+	return ControlMapping{
+		ID: "mapping", RevisionID: "mapping-r1", Granularity: "objective",
+		Source:       RevisionRef{ID: "source", RevisionID: "source-r1", Version: 1, ContentDigest: digest, LastModified: modified},
+		Target:       RevisionRef{ID: "target", RevisionID: "target-r1", Version: 1, ContentDigest: digest, LastModified: modified},
+		Relationship: MappingOverlap, Method: "manual", Rationale: "overlap", CoverageBasisPoints: 5000,
+		DecisionState: MappingProposed, AuthorID: "author",
+	}
+}

--- a/internal/compliance/types.go
+++ b/internal/compliance/types.go
@@ -1,0 +1,111 @@
+package compliance
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var ErrInvalidRevision = errors.New("invalid compliance revision")
+
+// ContentDigest is the lowercase SHA-256 digest of normalized semantic content.
+// It deliberately remains separate from revision identity: two tenants may
+// create different revisions with the same semantic content.
+type ContentDigest string
+
+// VersionMetadata describes one immutable revision of a stable logical record.
+type VersionMetadata struct {
+	ID            string        `json:"id"`
+	RevisionID    string        `json:"revision_id"`
+	Version       uint64        `json:"version"`
+	LastModified  time.Time     `json:"last_modified"`
+	ContentDigest ContentDigest `json:"content_digest"`
+	CreatedBy     string        `json:"created_by"`
+	PredecessorID string        `json:"predecessor_id,omitempty"`
+	SuccessorID   string        `json:"successor_id,omitempty"`
+}
+
+// RevisionRef identifies one immutable revision of a stable compliance subject.
+// ContentDigest covers normalized semantic content, not database metadata.
+type RevisionRef struct {
+	ID            string        `json:"id"`
+	RevisionID    string        `json:"revision_id"`
+	Version       uint64        `json:"version"`
+	ContentDigest ContentDigest `json:"content_digest"`
+	LastModified  time.Time     `json:"last_modified"`
+}
+
+// SubjectRef identifies a tenant-scoped subject without copying its lifecycle.
+type SubjectRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+func NormalizeVersionMetadata(value VersionMetadata) VersionMetadata {
+	value.ID = strings.TrimSpace(value.ID)
+	value.RevisionID = strings.TrimSpace(value.RevisionID)
+	value.LastModified = CanonicalRevisionTime(value.LastModified)
+	value.ContentDigest = ContentDigest(strings.TrimSpace(string(value.ContentDigest)))
+	value.CreatedBy = strings.TrimSpace(value.CreatedBy)
+	value.PredecessorID = strings.TrimSpace(value.PredecessorID)
+	value.SuccessorID = strings.TrimSpace(value.SuccessorID)
+	return value
+}
+
+func NormalizeRevisionRef(value RevisionRef) RevisionRef {
+	value.ID = strings.TrimSpace(value.ID)
+	value.RevisionID = strings.TrimSpace(value.RevisionID)
+	value.ContentDigest = ContentDigest(strings.TrimSpace(string(value.ContentDigest)))
+	value.LastModified = CanonicalRevisionTime(value.LastModified)
+	return value
+}
+
+// CanonicalRevisionTime uses the precision shared by event envelopes and
+// canonical assessment hashes.
+func CanonicalRevisionTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Time{}
+	}
+	return value.UTC().Truncate(time.Millisecond)
+}
+
+func (metadata VersionMetadata) Validate() error {
+	metadata = NormalizeVersionMetadata(metadata)
+	if metadata.ID == "" || metadata.RevisionID == "" || metadata.CreatedBy == "" {
+		return fmt.Errorf("%w: id, revision_id, and created_by are required", ErrInvalidRevision)
+	}
+	if metadata.Version == 0 || metadata.LastModified.IsZero() {
+		return fmt.Errorf("%w: version and last_modified are required", ErrInvalidRevision)
+	}
+	if err := ValidateContentDigest(metadata.ContentDigest); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+	}
+	return nil
+}
+
+// Validate checks the required, transport-independent revision invariants.
+// Resource-specific identifier validation remains with the owning service.
+func (revision RevisionRef) Validate() error {
+	revision = NormalizeRevisionRef(revision)
+	if strings.TrimSpace(revision.ID) == "" || strings.TrimSpace(revision.RevisionID) == "" {
+		return fmt.Errorf("%w: id and revision_id are required", ErrInvalidRevision)
+	}
+	if revision.Version == 0 {
+		return fmt.Errorf("%w: version must be greater than zero", ErrInvalidRevision)
+	}
+	if err := ValidateContentDigest(revision.ContentDigest); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+	}
+	if revision.LastModified.IsZero() {
+		return fmt.Errorf("%w: last_modified is required", ErrInvalidRevision)
+	}
+	return nil
+}
+
+func (reference SubjectRef) Validate() error {
+	if strings.TrimSpace(reference.Type) == "" || strings.TrimSpace(reference.ID) == "" {
+		return fmt.Errorf("%w: subject type and id are required", ErrInvalidRevision)
+	}
+	return nil
+}

--- a/internal/compliance/types.go
+++ b/internal/compliance/types.go
@@ -79,7 +79,7 @@ func (metadata VersionMetadata) Validate() error {
 		return fmt.Errorf("%w: version and last_modified are required", ErrInvalidRevision)
 	}
 	if err := ValidateContentDigest(metadata.ContentDigest); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+		return fmt.Errorf("%w: %w", ErrInvalidRevision, err)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func (revision RevisionRef) Validate() error {
 		return fmt.Errorf("%w: version must be greater than zero", ErrInvalidRevision)
 	}
 	if err := ValidateContentDigest(revision.ContentDigest); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidRevision, err)
+		return fmt.Errorf("%w: %w", ErrInvalidRevision, err)
 	}
 	if revision.LastModified.IsZero() {
 		return fmt.Errorf("%w: last_modified is required", ErrInvalidRevision)

--- a/internal/complianceassessment/conformance_test.go
+++ b/internal/complianceassessment/conformance_test.go
@@ -1,0 +1,223 @@
+package complianceassessment
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+type conformanceFixture struct {
+	Version      string          `json:"version"`
+	BaseInput    json.RawMessage `json:"base_input"`
+	BaseExpected json.RawMessage `json:"base_expected"`
+	Cases        []fixtureCase   `json:"cases"`
+}
+
+type fixtureCase struct {
+	Name           string          `json:"name"`
+	Input          json.RawMessage `json:"input"`
+	Expected       json.RawMessage `json:"expected"`
+	ExpectedDigest string          `json:"expected_digest"`
+}
+
+type fixtureExpected struct {
+	ScopeState                  ScopeState                  `json:"scope_state"`
+	AutomatedOutcome            AutomatedOutcome            `json:"automated_outcome"`
+	DesignState                 DesignState                 `json:"design_state"`
+	OperatingEffectivenessState OperatingEffectivenessState `json:"operating_effectiveness_state"`
+	EvidenceState               EvidenceState               `json:"evidence_state"`
+	DispositionState            DispositionState            `json:"disposition_state"`
+	Assurance                   Assurance                   `json:"assurance"`
+	AuditorState                AuditorState                `json:"auditor_state"`
+	ReasonCodes                 []ReasonCode                `json:"reason_codes"`
+	NextActions                 []NextAction                `json:"next_actions"`
+	LegacyStatus                string                      `json:"legacy_status"`
+}
+
+func TestObjectiveConformanceFixtures(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	if fixture.Version != "compliance-assessment-conformance/v1" {
+		t.Fatalf("fixture version = %q", fixture.Version)
+	}
+	if len(fixture.Cases) < 16 {
+		t.Fatalf("fixture cases = %d, want at least 16", len(fixture.Cases))
+	}
+	for _, testCase := range fixture.Cases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			input := mergedFixtureValue[EvaluateInput](t, fixture.BaseInput, testCase.Input)
+			expectedAxes := mergedFixtureValue[fixtureExpected](t, fixture.BaseExpected, testCase.Expected)
+			result, err := EvaluateObjective(input)
+			if err != nil {
+				t.Fatalf("EvaluateObjective() error = %v", err)
+			}
+			expected := expectedFixtureResult(input, expectedAxes)
+			gotBytes, err := CanonicalResultBytes(result)
+			if err != nil {
+				t.Fatalf("CanonicalResultBytes(result) error = %v", err)
+			}
+			wantBytes, err := CanonicalResultBytes(expected)
+			if err != nil {
+				t.Fatalf("CanonicalResultBytes(expected) error = %v", err)
+			}
+			if !bytes.Equal(gotBytes, wantBytes) {
+				t.Fatalf("canonical result mismatch\n got: %s\nwant: %s", gotBytes, wantBytes)
+			}
+			if got := LegacyStatus(result); got != expectedAxes.LegacyStatus {
+				t.Fatalf("LegacyStatus() = %q, want %q", got, expectedAxes.LegacyStatus)
+			}
+			digest, err := CanonicalResultDigest(result)
+			if err != nil {
+				t.Fatalf("CanonicalResultDigest() error = %v", err)
+			}
+			if testCase.ExpectedDigest == "" {
+				t.Errorf("expected_digest is empty; generated %s", digest)
+			} else if digest != testCase.ExpectedDigest {
+				t.Fatalf("digest = %q, want %q", digest, testCase.ExpectedDigest)
+			}
+		})
+	}
+}
+
+func TestObjectiveConformanceIsInvariantToInputOrder(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	for _, testCase := range fixture.Cases {
+		input := mergedFixtureValue[EvaluateInput](t, fixture.BaseInput, testCase.Input)
+		baseline, err := EvaluateObjective(input)
+		if err != nil {
+			t.Fatalf("%s baseline error = %v", testCase.Name, err)
+		}
+		baselineBytes, err := CanonicalResultBytes(baseline)
+		if err != nil {
+			t.Fatalf("%s baseline bytes error = %v", testCase.Name, err)
+		}
+		for iteration := 0; iteration < 32; iteration++ {
+			shuffled := cloneEvaluateInput(input)
+			rotateStrings(shuffled.FindingIDs, iteration)
+			rotateStrings(shuffled.SourceRuntimeIDs, iteration+1)
+			rotateAssessments(shuffled.RequirementAssessments, iteration+2)
+			for index := range shuffled.RequirementAssessments {
+				rotateStrings(shuffled.RequirementAssessments[index].EvidenceIDs, iteration+index)
+			}
+			result, err := EvaluateObjective(shuffled)
+			if err != nil {
+				t.Fatalf("%s iteration %d error = %v", testCase.Name, iteration, err)
+			}
+			data, err := CanonicalResultBytes(result)
+			if err != nil {
+				t.Fatalf("%s iteration %d bytes error = %v", testCase.Name, iteration, err)
+			}
+			if !bytes.Equal(data, baselineBytes) {
+				t.Fatalf("%s iteration %d changed canonical bytes", testCase.Name, iteration)
+			}
+		}
+	}
+}
+
+func loadConformanceFixture(t *testing.T) conformanceFixture {
+	t.Helper()
+	data, err := os.ReadFile("testdata/objective_conformance.json") // #nosec G304 -- fixed repository fixture path.
+	if err != nil {
+		t.Fatalf("read conformance fixture: %v", err)
+	}
+	var fixture conformanceFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("decode conformance fixture: %v", err)
+	}
+	return fixture
+}
+
+func mergedFixtureValue[T any](t *testing.T, base json.RawMessage, override json.RawMessage) T {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(base, &fields); err != nil {
+		t.Fatalf("decode fixture base: %v", err)
+	}
+	var overrides map[string]json.RawMessage
+	if len(override) != 0 {
+		if err := json.Unmarshal(override, &overrides); err != nil {
+			t.Fatalf("decode fixture override: %v", err)
+		}
+	}
+	for key, value := range overrides {
+		fields[key] = value
+	}
+	data, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal merged fixture: %v", err)
+	}
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("decode merged fixture: %v", err)
+	}
+	return result
+}
+
+func expectedFixtureResult(input EvaluateInput, expected fixtureExpected) ObjectiveResult {
+	evidenceIDs := []string{}
+	for _, assessment := range input.RequirementAssessments {
+		evidenceIDs = append(evidenceIDs, assessment.EvidenceIDs...)
+	}
+	return NormalizeResult(ObjectiveResult{
+		ID:                          input.ResultID,
+		ControlRef:                  input.Control,
+		ObjectiveID:                 input.ObjectiveID,
+		ScopeState:                  expected.ScopeState,
+		AutomatedOutcome:            expected.AutomatedOutcome,
+		DesignState:                 expected.DesignState,
+		OperatingEffectivenessState: expected.OperatingEffectivenessState,
+		EvidenceState:               expected.EvidenceState,
+		DispositionState:            expected.DispositionState,
+		Assurance:                   expected.Assurance,
+		AuditorState:                expected.AuditorState,
+		ReasonCodes:                 expected.ReasonCodes,
+		NextActions:                 expected.NextActions,
+		EvidenceIDs:                 evidenceIDs,
+		FindingIDs:                  input.FindingIDs,
+		SourceRuntimeIDs:            input.SourceRuntimeIDs,
+		EvaluatorRevision:           input.EvaluatorRevision,
+		EvaluatedAt:                 input.Now,
+	})
+}
+
+func cloneEvaluateInput(input EvaluateInput) EvaluateInput {
+	clone := input
+	clone.FindingIDs = append([]string(nil), input.FindingIDs...)
+	clone.SourceRuntimeIDs = append([]string(nil), input.SourceRuntimeIDs...)
+	clone.RequirementAssessments = append([]compliance.ControlEvidenceRequirementAssessment(nil), input.RequirementAssessments...)
+	for index := range clone.RequirementAssessments {
+		clone.RequirementAssessments[index].EvidenceIDs = append([]string(nil), input.RequirementAssessments[index].EvidenceIDs...)
+	}
+	return clone
+}
+
+func rotateStrings(values []string, count int) {
+	if len(values) < 2 {
+		return
+	}
+	count %= len(values)
+	rotated := append(append([]string(nil), values[count:]...), values[:count]...)
+	copy(values, rotated)
+}
+
+func rotateAssessments(values []compliance.ControlEvidenceRequirementAssessment, count int) {
+	if len(values) < 2 {
+		return
+	}
+	count %= len(values)
+	rotated := append(append([]compliance.ControlEvidenceRequirementAssessment(nil), values[count:]...), values[:count]...)
+	copy(values, rotated)
+}
+
+func TestFixtureNamesAreUnique(t *testing.T) {
+	fixture := loadConformanceFixture(t)
+	seen := map[string]struct{}{}
+	for _, testCase := range fixture.Cases {
+		if _, exists := seen[testCase.Name]; exists {
+			t.Fatalf("duplicate fixture name %q", testCase.Name)
+		}
+		seen[testCase.Name] = struct{}{}
+	}
+}

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -167,6 +167,15 @@ func ValidateEvaluateInput(input EvaluateInput) error {
 		return fmt.Errorf("%w: evaluation input contains an unknown required state", ErrInvalidResult)
 	}
 	for _, assessment := range input.RequirementAssessments {
+		if strings.TrimSpace(assessment.RequirementKey) == "" ||
+			strings.TrimSpace(assessment.ControlRef.ControlID) == "" ||
+			strings.TrimSpace(assessment.SourceID) == "" ||
+			strings.TrimSpace(assessment.EntityType) == "" {
+			return fmt.Errorf("%w: evidence requirement assessment identity and source binding are required", ErrInvalidResult)
+		}
+		if compliance.NormalizeControlRef(assessment.ControlRef) != input.Control {
+			return fmt.Errorf("%w: evidence requirement assessment control does not match the objective control", ErrInvalidResult)
+		}
 		switch assessment.Status {
 		case compliance.ControlEvidenceRequirementSatisfied,
 			compliance.ControlEvidenceRequirementManualReview,
@@ -175,6 +184,9 @@ func ValidateEvaluateInput(input EvaluateInput) error {
 			compliance.ControlEvidenceRequirementStale:
 		default:
 			return fmt.Errorf("%w: evaluation input contains unknown evidence requirement status %q", ErrInvalidResult, assessment.Status)
+		}
+		if assessment.Status == compliance.ControlEvidenceRequirementSatisfied && len(normalizedStrings(assessment.EvidenceIDs)) == 0 {
+			return fmt.Errorf("%w: satisfied evidence requirement assessment has no evidence", ErrInvalidResult)
 		}
 	}
 	return nil

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -1,0 +1,300 @@
+package complianceassessment
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+type EvaluateInput struct {
+	ResultID               string                                            `json:"result_id"`
+	ObjectiveID            string                                            `json:"objective_id"`
+	Control                compliance.ControlRef                             `json:"control_ref"`
+	ScopeState             ScopeState                                        `json:"scope_state"`
+	EvidenceIndex          *compliance.ControlEvidenceRequirementIndex       `json:"-"`
+	Evidence               []compliance.ControlEvidenceRequirementSignal     `json:"evidence,omitempty"`
+	RequirementAssessments []compliance.ControlEvidenceRequirementAssessment `json:"requirement_assessments,omitempty"`
+	CoverageState          CoverageState                                     `json:"coverage_state"`
+	SourceState            SourceState                                       `json:"source_state"`
+	SourceRuntimeIDs       []string                                          `json:"source_runtime_ids,omitempty"`
+	FindingIDs             []string                                          `json:"finding_ids,omitempty"`
+	InvalidEvidence        bool                                              `json:"invalid_evidence,omitempty"`
+	ConflictingEvidence    bool                                              `json:"conflicting_evidence,omitempty"`
+	DispositionState       DispositionState                                  `json:"disposition_state,omitempty"`
+	DesignState            DesignState                                       `json:"design_state,omitempty"`
+	OperatingState         OperatingEffectivenessState                       `json:"operating_effectiveness_state,omitempty"`
+	Inherited              bool                                              `json:"inherited,omitempty"`
+	Sampled                bool                                              `json:"sampled,omitempty"`
+	EvaluatorRevision      string                                            `json:"evaluator_revision"`
+	Now                    time.Time                                         `json:"now"`
+}
+
+// EvaluateObjective derives one deterministic, multi-axis result. Missing
+// coverage, evidence, or source trust always resolves to an explicit limitation;
+// an empty finding set is never sufficient to pass.
+func EvaluateObjective(input EvaluateInput) (ObjectiveResult, error) {
+	input = normalizeEvaluateInput(input)
+	if err := ValidateEvaluateInput(input); err != nil {
+		return ObjectiveResult{}, err
+	}
+	now := CanonicalTime(input.Now)
+	result := ObjectiveResult{
+		ID:                          strings.TrimSpace(input.ResultID),
+		ControlRef:                  input.Control,
+		ObjectiveID:                 strings.TrimSpace(input.ObjectiveID),
+		ScopeState:                  input.ScopeState,
+		AutomatedOutcome:            OutcomeIndeterminate,
+		DesignState:                 input.DesignState,
+		OperatingEffectivenessState: input.OperatingState,
+		EvidenceState:               EvidenceIncomplete,
+		DispositionState:            input.DispositionState,
+		Assurance:                   AssuranceNone,
+		AuditorState:                AuditorNotReviewed,
+		FindingIDs:                  input.FindingIDs,
+		SourceRuntimeIDs:            input.SourceRuntimeIDs,
+		EvaluatorRevision:           strings.TrimSpace(input.EvaluatorRevision),
+		EvaluatedAt:                 now,
+	}
+	if result.ScopeState == "" {
+		result.ScopeState = ScopeUnresolved
+	}
+	if result.DesignState == "" {
+		result.DesignState = DesignUnknown
+	}
+	if result.OperatingEffectivenessState == "" {
+		result.OperatingEffectivenessState = OperatingUnknown
+	}
+	if result.DispositionState == "" {
+		result.DispositionState = DispositionNone
+	}
+	assessments := append([]compliance.ControlEvidenceRequirementAssessment(nil), input.RequirementAssessments...)
+	if assessments == nil && input.EvidenceIndex != nil {
+		assessments = compliance.AssessControlEvidenceRequirements(compliance.ControlEvidenceRequirementAssessmentInput{
+			Index: input.EvidenceIndex, Control: input.Control, Evidence: input.Evidence, Now: now,
+		})
+	}
+	for _, assessment := range assessments {
+		result.EvidenceIDs = append(result.EvidenceIDs, assessment.EvidenceIDs...)
+	}
+
+	switch result.ScopeState {
+	case ScopeNotApplicable:
+		result.AutomatedOutcome = OutcomeNotAssessed
+		result.EvidenceState = EvidenceSufficient
+		result.DesignState = DesignNotAssessed
+		result.OperatingEffectivenessState = OperatingNotTested
+		result.ReasonCodes = append(result.ReasonCodes, ReasonNotApplicable)
+		result.NextActions = append(result.NextActions, ActionNone)
+		return validatedResult(result)
+	case ScopeUnresolved:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonScopeUnresolved)
+		result.NextActions = append(result.NextActions, ActionResolveScope)
+		return validatedResult(applyDisposition(NormalizeResult(result)))
+	}
+
+	evidenceState, reasons, actions := evaluateEvidence(assessments, input)
+	result.EvidenceState = evidenceState
+	result.ReasonCodes = append(result.ReasonCodes, reasons...)
+	result.NextActions = append(result.NextActions, actions...)
+	if len(result.FindingIDs) != 0 {
+		result.AutomatedOutcome = OutcomeNotSatisfied
+		result.ReasonCodes = append(result.ReasonCodes, ReasonActiveFinding)
+		result.NextActions = append(result.NextActions, ActionRemediate)
+		if result.DesignState == DesignUnknown {
+			result.DesignState = DesignIneffective
+		}
+		if result.OperatingEffectivenessState == OperatingUnknown {
+			result.OperatingEffectivenessState = OperatingIneffective
+		}
+	} else if evidenceState == EvidenceSufficient && input.CoverageState == CoverageComplete && input.SourceState == SourceSupported {
+		result.AutomatedOutcome = OutcomeSatisfied
+		result.ReasonCodes = append(result.ReasonCodes, ReasonSatisfied)
+		result.NextActions = append(result.NextActions, ActionNone)
+		if result.DesignState == DesignUnknown {
+			result.DesignState = DesignEffective
+		}
+		if result.OperatingEffectivenessState == OperatingUnknown {
+			result.OperatingEffectivenessState = OperatingEffective
+		}
+	} else {
+		result.AutomatedOutcome = OutcomeIndeterminate
+	}
+	if input.Inherited {
+		result.ReasonCodes = append(result.ReasonCodes, ReasonInheritedResponsibility)
+	}
+	if input.Sampled {
+		result.ReasonCodes = append(result.ReasonCodes, ReasonSampledTesting)
+	}
+	result.Assurance = deriveAssurance(result, input)
+	return validatedResult(applyDisposition(NormalizeResult(result)))
+}
+
+func normalizeEvaluateInput(input EvaluateInput) EvaluateInput {
+	input.ResultID = strings.TrimSpace(input.ResultID)
+	input.ObjectiveID = strings.TrimSpace(input.ObjectiveID)
+	input.Control = compliance.NormalizeControlRef(input.Control)
+	input.EvaluatorRevision = strings.TrimSpace(input.EvaluatorRevision)
+	input.Now = CanonicalTime(input.Now)
+	if input.ScopeState == "" {
+		input.ScopeState = ScopeUnresolved
+	}
+	if input.CoverageState == "" {
+		input.CoverageState = CoverageUnknown
+	}
+	if input.SourceState == "" {
+		input.SourceState = SourceUnknown
+	}
+	if input.DesignState == "" {
+		input.DesignState = DesignUnknown
+	}
+	if input.OperatingState == "" {
+		input.OperatingState = OperatingUnknown
+	}
+	if input.DispositionState == "" {
+		input.DispositionState = DispositionNone
+	}
+	return input
+}
+
+func ValidateEvaluateInput(input EvaluateInput) error {
+	if input.ResultID == "" || input.ObjectiveID == "" || strings.TrimSpace(input.Control.ControlID) == "" || input.EvaluatorRevision == "" || input.Now.IsZero() {
+		return fmt.Errorf("%w: result, objective, control, evaluator revision, and now are required", ErrInvalidResult)
+	}
+	if !knownScopeState(input.ScopeState) || !knownCoverageState(input.CoverageState) || !knownSourceState(input.SourceState) ||
+		!knownDesignState(input.DesignState) || !knownOperatingState(input.OperatingState) || !knownDispositionState(input.DispositionState) {
+		return fmt.Errorf("%w: evaluation input contains an unknown required state", ErrInvalidResult)
+	}
+	for _, assessment := range input.RequirementAssessments {
+		switch assessment.Status {
+		case compliance.ControlEvidenceRequirementSatisfied,
+			compliance.ControlEvidenceRequirementManualReview,
+			compliance.ControlEvidenceRequirementMissing,
+			compliance.ControlEvidenceRequirementMissingField,
+			compliance.ControlEvidenceRequirementStale:
+		default:
+			return fmt.Errorf("%w: evaluation input contains unknown evidence requirement status %q", ErrInvalidResult, assessment.Status)
+		}
+	}
+	return nil
+}
+
+func validatedResult(result ObjectiveResult) (ObjectiveResult, error) {
+	result = NormalizeResult(result)
+	if err := ValidateObjectiveResult(result); err != nil {
+		return ObjectiveResult{}, err
+	}
+	return result, nil
+}
+
+func evaluateEvidence(assessments []compliance.ControlEvidenceRequirementAssessment, input EvaluateInput) (EvidenceState, []ReasonCode, []NextAction) {
+	if input.ConflictingEvidence || input.SourceState == SourceConflicting {
+		return EvidenceConflicting, []ReasonCode{ReasonEvidenceConflicting}, []NextAction{ActionReview}
+	}
+	if input.InvalidEvidence {
+		return EvidenceUntrusted, []ReasonCode{ReasonEvidenceInvalid}, []NextAction{ActionReview}
+	}
+	switch input.SourceState {
+	case SourceUnverified:
+		return EvidenceUntrusted, []ReasonCode{ReasonSourceUntrusted}, []NextAction{ActionReview}
+	case SourceUnconfigured:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnconfigured}, []NextAction{ActionRestoreSource}
+	case SourceUnsupported:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnsupported}, []NextAction{ActionRestoreSource}
+	case SourceFailed:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceFailed}, []NextAction{ActionRestoreSource}
+	case SourcePartial:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourcePartial}, []NextAction{ActionRestoreSource}
+	case SourceStale:
+		return EvidenceStale, []ReasonCode{ReasonSourceStale}, []NextAction{ActionRefreshEvidence}
+	case SourceUnknown:
+		return EvidenceIncomplete, []ReasonCode{ReasonSourceUnknown}, []NextAction{ActionRestoreSource}
+	}
+	if input.CoverageState == CoverageEmpty {
+		return EvidenceIncomplete, []ReasonCode{ReasonPopulationEmpty}, []NextAction{ActionCollectEvidence}
+	}
+	if input.CoverageState != CoverageComplete {
+		return EvidenceIncomplete, []ReasonCode{ReasonCoverageIncomplete}, []NextAction{ActionCollectEvidence}
+	}
+	if len(assessments) == 0 {
+		return EvidenceMissing, []ReasonCode{ReasonEvidenceMissing}, []NextAction{ActionCollectEvidence}
+	}
+	state := EvidenceSufficient
+	var reasons []ReasonCode
+	var actions []NextAction
+	for _, assessment := range assessments {
+		switch assessment.Status {
+		case compliance.ControlEvidenceRequirementSatisfied:
+		case compliance.ControlEvidenceRequirementManualReview:
+			state = strongestEvidenceState(state, EvidenceManualReview)
+			reasons = append(reasons, ReasonManualEvidence)
+			actions = append(actions, ActionReview)
+		case compliance.ControlEvidenceRequirementStale:
+			state = strongestEvidenceState(state, EvidenceStale)
+			reasons = append(reasons, ReasonEvidenceStale)
+			actions = append(actions, ActionRefreshEvidence)
+		case compliance.ControlEvidenceRequirementMissingField:
+			state = strongestEvidenceState(state, EvidenceIncomplete)
+			reasons = append(reasons, ReasonEvidenceInvalid)
+			actions = append(actions, ActionCollectEvidence)
+		case compliance.ControlEvidenceRequirementMissing:
+			state = strongestEvidenceState(state, EvidenceMissing)
+			reasons = append(reasons, ReasonEvidenceMissing)
+			actions = append(actions, ActionCollectEvidence)
+		default:
+			state = strongestEvidenceState(state, EvidenceManualReview)
+			reasons = append(reasons, ReasonEvidenceInvalid)
+			actions = append(actions, ActionReview)
+		}
+	}
+	return state, reasons, actions
+}
+
+func strongestEvidenceState(left, right EvidenceState) EvidenceState {
+	rank := map[EvidenceState]int{
+		EvidenceSufficient: 0, EvidenceManualReview: 1, EvidenceStale: 2,
+		EvidenceMissing: 3, EvidenceIncomplete: 4, EvidenceUntrusted: 5, EvidenceConflicting: 6,
+	}
+	if rank[right] > rank[left] {
+		return right
+	}
+	return left
+}
+
+func deriveAssurance(result ObjectiveResult, input EvaluateInput) Assurance {
+	if result.AutomatedOutcome == OutcomeSatisfied && result.EvidenceState == EvidenceSufficient {
+		if input.Inherited || input.Sampled {
+			return AssuranceMedium
+		}
+		return AssuranceHigh
+	}
+	if result.AutomatedOutcome == OutcomeNotSatisfied && result.EvidenceState == EvidenceSufficient {
+		return AssuranceHigh
+	}
+	if result.EvidenceState == EvidenceManualReview || result.EvidenceState == EvidenceStale {
+		return AssuranceLow
+	}
+	return AssuranceNone
+}
+
+func applyDisposition(result ObjectiveResult) ObjectiveResult {
+	switch result.DispositionState {
+	case DispositionAcceptedException:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonAcceptedException)
+		result.NextActions = append(result.NextActions, ActionRetest)
+	case DispositionAcceptedRisk:
+		result.ReasonCodes = append(result.ReasonCodes, ReasonAcceptedRisk)
+		result.NextActions = append(result.NextActions, ActionRetest)
+	}
+	return NormalizeResult(result)
+}
+
+func sortResults(results []ObjectiveResult) {
+	sort.Slice(results, func(i, j int) bool {
+		left, right := results[i], results[j]
+		return left.ControlRef.FrameworkID+"\x00"+left.ControlRef.ControlID+"\x00"+left.ObjectiveID+"\x00"+left.ID <
+			right.ControlRef.FrameworkID+"\x00"+right.ControlRef.ControlID+"\x00"+right.ObjectiveID+"\x00"+right.ID
+	})
+}

--- a/internal/complianceassessment/evaluate.go
+++ b/internal/complianceassessment/evaluate.go
@@ -2,7 +2,6 @@ package complianceassessment
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -289,12 +288,4 @@ func applyDisposition(result ObjectiveResult) ObjectiveResult {
 		result.NextActions = append(result.NextActions, ActionRetest)
 	}
 	return NormalizeResult(result)
-}
-
-func sortResults(results []ObjectiveResult) {
-	sort.Slice(results, func(i, j int) bool {
-		left, right := results[i], results[j]
-		return left.ControlRef.FrameworkID+"\x00"+left.ControlRef.ControlID+"\x00"+left.ObjectiveID+"\x00"+left.ID <
-			right.ControlRef.FrameworkID+"\x00"+right.ControlRef.ControlID+"\x00"+right.ObjectiveID+"\x00"+right.ID
-	})
 }

--- a/internal/complianceassessment/legacy_status.go
+++ b/internal/complianceassessment/legacy_status.go
@@ -1,0 +1,38 @@
+package complianceassessment
+
+const (
+	LegacyStatusNotApplicable   = "not_applicable"
+	LegacyStatusException       = "exception"
+	LegacyStatusFailing         = "failing"
+	LegacyStatusMissingEvidence = "missing_evidence"
+	LegacyStatusStaleEvidence   = "stale_evidence"
+	LegacyStatusManualReview    = "manual_review"
+	LegacyStatusPassing         = "passing"
+)
+
+// LegacyStatus preserves the existing caller precedence while the canonical
+// result retains independent automation, evidence, and disposition axes.
+func LegacyStatus(result ObjectiveResult) string {
+	if result.ScopeState == ScopeNotApplicable {
+		return LegacyStatusNotApplicable
+	}
+	if result.DispositionState == DispositionAcceptedException || result.DispositionState == DispositionAcceptedRisk {
+		return LegacyStatusException
+	}
+	if result.AutomatedOutcome == OutcomeNotSatisfied {
+		return LegacyStatusFailing
+	}
+	switch result.EvidenceState {
+	case EvidenceMissing, EvidenceIncomplete:
+		return LegacyStatusMissingEvidence
+	case EvidenceStale:
+		return LegacyStatusStaleEvidence
+	case EvidenceManualReview, EvidenceConflicting, EvidenceUntrusted:
+		return LegacyStatusManualReview
+	case EvidenceSufficient:
+		if result.AutomatedOutcome == OutcomeSatisfied {
+			return LegacyStatusPassing
+		}
+	}
+	return LegacyStatusManualReview
+}

--- a/internal/complianceassessment/legacy_status_test.go
+++ b/internal/complianceassessment/legacy_status_test.go
@@ -1,0 +1,26 @@
+package complianceassessment
+
+import "testing"
+
+func TestLegacyStatusPreservesExistingPrecedence(t *testing.T) {
+	result := validObjectiveResult()
+	result.ScopeState = ScopeNotApplicable
+	result.DispositionState = DispositionAcceptedException
+	result.AutomatedOutcome = OutcomeNotSatisfied
+	result.EvidenceState = EvidenceMissing
+	if got := LegacyStatus(result); got != LegacyStatusNotApplicable {
+		t.Fatalf("not applicable precedence = %q", got)
+	}
+	result.ScopeState = ScopeInScope
+	if got := LegacyStatus(result); got != LegacyStatusException {
+		t.Fatalf("exception precedence = %q", got)
+	}
+	result.DispositionState = DispositionNone
+	if got := LegacyStatus(result); got != LegacyStatusFailing {
+		t.Fatalf("failing precedence = %q", got)
+	}
+	result.AutomatedOutcome = OutcomeIndeterminate
+	if got := LegacyStatus(result); got != LegacyStatusMissingEvidence {
+		t.Fatalf("missing evidence precedence = %q", got)
+	}
+}

--- a/internal/complianceassessment/testdata/objective_conformance.json
+++ b/internal/complianceassessment/testdata/objective_conformance.json
@@ -5,7 +5,7 @@
     "objective_id": "objective-1",
     "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"},
     "scope_state": "in_scope",
-    "requirement_assessments": [{"status": "satisfied", "evidence_ids": ["evidence-1"]}],
+    "requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "satisfied", "evidence_ids": ["evidence-1"]}],
     "coverage_state": "complete",
     "source_state": "supported",
     "source_runtime_ids": ["runtime-1"],
@@ -47,7 +47,7 @@
     },
     {
       "name": "stale_evidence",
-      "input": {"requirement_assessments": [{"status": "stale", "evidence_ids": ["evidence-1"]}]},
+      "input": {"requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "stale", "evidence_ids": ["evidence-1"]}]},
       "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "stale", "assurance": "low", "reason_codes": ["evidence_stale"], "next_actions": ["refresh_evidence"], "legacy_status": "stale_evidence"},
       "expected_digest": "sha256:06e1ea29fa9a5ba7e5119e2c89a1006bbe2dbd61315da9bc52579475b7cf261c"
     },
@@ -77,7 +77,7 @@
     },
     {
       "name": "manual_evidence",
-      "input": {"requirement_assessments": [{"status": "manual_review", "evidence_ids": ["evidence-1"]}]},
+      "input": {"requirement_assessments": [{"requirement_key": "requirement-1", "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"}, "source_id": "source-1", "entity_type": "resource", "status": "manual_review", "evidence_ids": ["evidence-1"]}]},
       "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "manual_review", "assurance": "low", "reason_codes": ["manual_evidence_review"], "next_actions": ["review"], "legacy_status": "manual_review"},
       "expected_digest": "sha256:a447dfee1c8cf7373aea662d94c746cfe49d97a97b280fee29c161d060eab786"
     },

--- a/internal/complianceassessment/testdata/objective_conformance.json
+++ b/internal/complianceassessment/testdata/objective_conformance.json
@@ -1,0 +1,121 @@
+{
+  "version": "compliance-assessment-conformance/v1",
+  "base_input": {
+    "result_id": "assessment-result-00000000000000000000000000000001",
+    "objective_id": "objective-1",
+    "control_ref": {"framework_name": "Example Framework", "control_id": "CC-1"},
+    "scope_state": "in_scope",
+    "requirement_assessments": [{"status": "satisfied", "evidence_ids": ["evidence-1"]}],
+    "coverage_state": "complete",
+    "source_state": "supported",
+    "source_runtime_ids": ["runtime-1"],
+    "evaluator_revision": "evaluator-v1",
+    "now": "2026-07-11T12:00:00.123456789Z"
+  },
+  "base_expected": {
+    "scope_state": "in_scope",
+    "automated_outcome": "satisfied",
+    "design_state": "effective",
+    "operating_effectiveness_state": "effective",
+    "evidence_state": "sufficient",
+    "disposition_state": "none",
+    "assurance": "high",
+    "auditor_state": "not_reviewed",
+    "reason_codes": ["assessment_satisfied"],
+    "next_actions": ["none"],
+    "legacy_status": "passing"
+  },
+  "cases": [
+    {"name": "pass", "input": {}, "expected": {}, "expected_digest": "sha256:aa8a2d895d281a61d20b63c855fd2fa37aba64a65446ced6f8955acacd8c2992"},
+    {
+      "name": "active_finding",
+      "input": {"finding_ids": ["finding-1"]},
+      "expected": {"automated_outcome": "not_satisfied", "design_state": "ineffective", "operating_effectiveness_state": "ineffective", "reason_codes": ["active_finding"], "next_actions": ["remediate"], "legacy_status": "failing"},
+      "expected_digest": "sha256:198812615976bf6380f497efd52c8f54841f326469d4a01614ab3ecdf4ea4168"
+    },
+    {
+      "name": "missing_evidence",
+      "input": {"requirement_assessments": []},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "missing", "assurance": "none", "reason_codes": ["evidence_missing"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:54264f10f4f4efab1705634b27510ffc958a80645f18d93598c893b77f2d9f35"
+    },
+    {
+      "name": "invalid_evidence",
+      "input": {"invalid_evidence": true},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "untrusted", "assurance": "none", "reason_codes": ["evidence_invalid"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:e2722f0ddfccb8c114cdb33a35bfd0aad9afd42004b50b0ef0bd4f9e3620150a"
+    },
+    {
+      "name": "stale_evidence",
+      "input": {"requirement_assessments": [{"status": "stale", "evidence_ids": ["evidence-1"]}]},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "stale", "assurance": "low", "reason_codes": ["evidence_stale"], "next_actions": ["refresh_evidence"], "legacy_status": "stale_evidence"},
+      "expected_digest": "sha256:06e1ea29fa9a5ba7e5119e2c89a1006bbe2dbd61315da9bc52579475b7cf261c"
+    },
+    {
+      "name": "conflicting_evidence",
+      "input": {"conflicting_evidence": true},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "conflicting", "assurance": "none", "reason_codes": ["evidence_conflicting"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:b7e40a786e56bfb861b13f5c41ff1340c1bb664bbf8862f2f31a226e0bce9742"
+    },
+    {
+      "name": "insufficient_coverage",
+      "input": {"coverage_state": "partial"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["coverage_incomplete"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:39a2db74de27785831955518f8bf0d53186a04f5b4e86a17e1f4bcc79cd5672f"
+    },
+    {
+      "name": "untrusted_source",
+      "input": {"source_state": "unverified"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "untrusted", "assurance": "none", "reason_codes": ["source_untrusted"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:4461d5e7adffda425a8109667d44c95a9f3dc52b1334900a593ec42105bbf764"
+    },
+    {
+      "name": "unknown_source_trust",
+      "input": {"source_state": "unknown"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["source_trust_unknown"], "next_actions": ["restore_source"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:433f8d418ccd407220aabaede7acf6e24051e6235f7cf4a6742b3726df40a694"
+    },
+    {
+      "name": "manual_evidence",
+      "input": {"requirement_assessments": [{"status": "manual_review", "evidence_ids": ["evidence-1"]}]},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "manual_review", "assurance": "low", "reason_codes": ["manual_evidence_review"], "next_actions": ["review"], "legacy_status": "manual_review"},
+      "expected_digest": "sha256:a447dfee1c8cf7373aea662d94c746cfe49d97a97b280fee29c161d060eab786"
+    },
+    {
+      "name": "accepted_exception",
+      "input": {"requirement_assessments": [], "disposition_state": "accepted_exception"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "missing", "disposition_state": "accepted_exception", "assurance": "none", "reason_codes": ["accepted_exception", "evidence_missing"], "next_actions": ["collect_evidence", "retest"], "legacy_status": "exception"},
+      "expected_digest": "sha256:e6fcb3ebbe4e87e16280bb0dfd733e111bfecc7019731d1a499e9f0e0139ffec"
+    },
+    {
+      "name": "not_applicable",
+      "input": {"scope_state": "not_applicable", "requirement_assessments": [], "coverage_state": "unknown", "source_state": "unknown"},
+      "expected": {"scope_state": "not_applicable", "automated_outcome": "not_assessed", "design_state": "not_assessed", "operating_effectiveness_state": "not_tested", "evidence_state": "sufficient", "assurance": "none", "reason_codes": ["not_applicable"], "next_actions": ["none"], "legacy_status": "not_applicable"},
+      "expected_digest": "sha256:ae8ae1b84fac40ac390cbad3296b2c7e7e5de2e4f7854098b844e4b7ef33fbb7"
+    },
+    {
+      "name": "inherited_responsibility",
+      "input": {"inherited": true},
+      "expected": {"assurance": "medium", "reason_codes": ["assessment_satisfied", "inherited_responsibility"]},
+      "expected_digest": "sha256:667aafa34b03e54d6614bf72d615472b84021498c53c32db11d135cbaba20646"
+    },
+    {
+      "name": "sampled_testing",
+      "input": {"sampled": true},
+      "expected": {"assurance": "medium", "reason_codes": ["assessment_satisfied", "sampled_testing"]},
+      "expected_digest": "sha256:04f8705f2effaf18c64b323ae3820aec1156e250df6a4a75eafb4eb9b289be92"
+    },
+    {
+      "name": "no_configured_source",
+      "input": {"source_state": "unconfigured"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["source_unconfigured"], "next_actions": ["restore_source"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:9ec2b209ed153bae1d18fc647ea6699f36a91c1cdd53ffed418d242416dad3a7"
+    },
+    {
+      "name": "empty_population_with_satisfied_evidence",
+      "input": {"coverage_state": "empty"},
+      "expected": {"automated_outcome": "indeterminate", "design_state": "unknown", "operating_effectiveness_state": "unknown", "evidence_state": "incomplete", "assurance": "none", "reason_codes": ["population_empty"], "next_actions": ["collect_evidence"], "legacy_status": "missing_evidence"},
+      "expected_digest": "sha256:992703e2b87bdee82adecf50d8c791bb2c6774f88c6548871292408834affc1d"
+    }
+  ]
+}

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -1,0 +1,538 @@
+package complianceassessment
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+var (
+	ErrInvalidCanonicalValue = errors.New("invalid canonical compliance value")
+	ErrInvalidManifest       = errors.New("invalid compliance input manifest")
+	ErrInvalidResult         = errors.New("invalid compliance objective result")
+)
+
+const (
+	CanonicalModelVersion = "compliance-assessment/v1"
+	ReasonRegistryVersion = "compliance-reasons/v1"
+	LegacyAdapterVersion  = "compliance-legacy-status/v1"
+)
+
+type ScopeState string
+
+const (
+	ScopeInScope       ScopeState = "in_scope"
+	ScopeNotApplicable ScopeState = "not_applicable"
+	ScopeUnresolved    ScopeState = "unresolved"
+)
+
+type AutomatedOutcome string
+
+const (
+	OutcomeSatisfied     AutomatedOutcome = "satisfied"
+	OutcomeNotSatisfied  AutomatedOutcome = "not_satisfied"
+	OutcomeIndeterminate AutomatedOutcome = "indeterminate"
+	OutcomeNotAssessed   AutomatedOutcome = "not_assessed"
+)
+
+type DesignState string
+
+const (
+	DesignEffective   DesignState = "effective"
+	DesignIneffective DesignState = "ineffective"
+	DesignUnknown     DesignState = "unknown"
+	DesignNotAssessed DesignState = "not_assessed"
+)
+
+type OperatingEffectivenessState string
+
+const (
+	OperatingEffective   OperatingEffectivenessState = "effective"
+	OperatingIneffective OperatingEffectivenessState = "ineffective"
+	OperatingUnknown     OperatingEffectivenessState = "unknown"
+	OperatingNotTested   OperatingEffectivenessState = "not_tested"
+)
+
+type EvidenceState string
+
+const (
+	EvidenceSufficient   EvidenceState = "sufficient"
+	EvidenceMissing      EvidenceState = "missing"
+	EvidenceStale        EvidenceState = "stale"
+	EvidenceConflicting  EvidenceState = "conflicting"
+	EvidenceUntrusted    EvidenceState = "untrusted"
+	EvidenceIncomplete   EvidenceState = "incomplete"
+	EvidenceManualReview EvidenceState = "manual_review"
+)
+
+type DispositionState string
+
+const (
+	DispositionNone              DispositionState = "none"
+	DispositionAcceptedException DispositionState = "accepted_exception"
+	DispositionAcceptedRisk      DispositionState = "accepted_risk"
+	DispositionReviewOverride    DispositionState = "review_override"
+)
+
+type Assurance string
+
+const (
+	AssuranceHigh   Assurance = "high"
+	AssuranceMedium Assurance = "medium"
+	AssuranceLow    Assurance = "low"
+	AssuranceNone   Assurance = "none"
+)
+
+type AuditorState string
+
+const (
+	AuditorNotReviewed      AuditorState = "not_reviewed"
+	AuditorAccepted         AuditorState = "accepted"
+	AuditorChangesRequested AuditorState = "changes_requested"
+	AuditorRejected         AuditorState = "rejected"
+)
+
+type CoverageState string
+
+const (
+	CoverageComplete CoverageState = "complete"
+	CoveragePartial  CoverageState = "partial"
+	CoverageEmpty    CoverageState = "empty"
+	CoverageUnknown  CoverageState = "unknown"
+)
+
+type SourceState string
+
+const (
+	SourceSupported    SourceState = "supported"
+	SourcePartial      SourceState = "partial"
+	SourceStale        SourceState = "stale"
+	SourceFailed       SourceState = "failed"
+	SourceUnconfigured SourceState = "unconfigured"
+	SourceUnsupported  SourceState = "unsupported"
+	SourceUnverified   SourceState = "unverified"
+	SourceConflicting  SourceState = "conflicting"
+	SourceUnknown      SourceState = "unknown"
+)
+
+type ReasonCode string
+
+const (
+	ReasonSatisfied               ReasonCode = "assessment_satisfied"
+	ReasonActiveFinding           ReasonCode = "active_finding"
+	ReasonEvidenceMissing         ReasonCode = "evidence_missing"
+	ReasonEvidenceInvalid         ReasonCode = "evidence_invalid"
+	ReasonEvidenceStale           ReasonCode = "evidence_stale"
+	ReasonEvidenceConflicting     ReasonCode = "evidence_conflicting"
+	ReasonCoverageIncomplete      ReasonCode = "coverage_incomplete"
+	ReasonSourceUntrusted         ReasonCode = "source_untrusted"
+	ReasonSourceUnknown           ReasonCode = "source_trust_unknown"
+	ReasonManualEvidence          ReasonCode = "manual_evidence_review"
+	ReasonAcceptedException       ReasonCode = "accepted_exception"
+	ReasonAcceptedRisk            ReasonCode = "accepted_risk"
+	ReasonNotApplicable           ReasonCode = "not_applicable"
+	ReasonInheritedResponsibility ReasonCode = "inherited_responsibility"
+	ReasonSampledTesting          ReasonCode = "sampled_testing"
+	ReasonSourceUnconfigured      ReasonCode = "source_unconfigured"
+	ReasonSourceUnsupported       ReasonCode = "source_unsupported"
+	ReasonSourcePartial           ReasonCode = "source_partial"
+	ReasonSourceFailed            ReasonCode = "source_failed"
+	ReasonSourceStale             ReasonCode = "source_stale"
+	ReasonScopeUnresolved         ReasonCode = "scope_unresolved"
+	ReasonPopulationEmpty         ReasonCode = "population_empty"
+)
+
+type NextAction string
+
+const (
+	ActionNone            NextAction = "none"
+	ActionReview          NextAction = "review"
+	ActionCollectEvidence NextAction = "collect_evidence"
+	ActionRefreshEvidence NextAction = "refresh_evidence"
+	ActionRestoreSource   NextAction = "restore_source"
+	ActionResolveScope    NextAction = "resolve_scope"
+	ActionRemediate       NextAction = "remediate"
+	ActionRetest          NextAction = "retest"
+)
+
+type CollectionCompleteness string
+
+const (
+	CollectionComplete          CollectionCompleteness = "complete"
+	CollectionPartial           CollectionCompleteness = "partial"
+	CollectionTruncated         CollectionCompleteness = "truncated"
+	CollectionChangedDuringScan CollectionCompleteness = "changed_during_scan"
+	CollectionUnknown           CollectionCompleteness = "unknown"
+)
+
+// ManifestRevision pins one semantic input used by an assessment run.
+type ManifestRevision struct {
+	Kind       string `json:"kind"`
+	ID         string `json:"id"`
+	RevisionID string `json:"revision_id"`
+	Version    uint64 `json:"version"`
+	Digest     string `json:"digest"`
+}
+
+type CollectionReceipt struct {
+	Kind          string                 `json:"kind"`
+	RuntimeID     string                 `json:"runtime_id,omitempty"`
+	QueryDigest   string                 `json:"query_digest"`
+	PageIndex     uint32                 `json:"page_index"`
+	Cursor        string                 `json:"cursor,omitempty"`
+	NextCursor    string                 `json:"next_cursor,omitempty"`
+	RawCount      uint64                 `json:"raw_count"`
+	Deduplicated  uint64                 `json:"deduplicated_count"`
+	Included      uint64                 `json:"included_count"`
+	Excluded      uint64                 `json:"excluded_count"`
+	ExpectedTotal *uint64                `json:"expected_total,omitempty"`
+	FirstKey      string                 `json:"first_key,omitempty"`
+	LastKey       string                 `json:"last_key,omitempty"`
+	Watermark     time.Time              `json:"watermark"`
+	Cutoff        time.Time              `json:"cutoff"`
+	Completeness  CollectionCompleteness `json:"completeness"`
+	PageDigest    string                 `json:"page_digest"`
+}
+
+// InputManifest pins every revision and collection receipt needed to reproduce
+// one automated assessment result.
+type InputManifest struct {
+	ModelVersion               string              `json:"model_version"`
+	ProgramID                  string              `json:"program_id"`
+	ScopeRevisionID            string              `json:"scope_revision_id"`
+	PlanRevisionID             string              `json:"plan_revision_id"`
+	PeriodStart                time.Time           `json:"period_start"`
+	PeriodEnd                  time.Time           `json:"period_end"`
+	CollectionCutoff           time.Time           `json:"collection_cutoff"`
+	RequestedScopeDigest       string              `json:"requested_scope_digest"`
+	ResolvedObjectiveSetDigest string              `json:"resolved_objective_set_digest"`
+	MappingSetDigest           string              `json:"mapping_set_digest"`
+	Revisions                  []ManifestRevision  `json:"revisions"`
+	Receipts                   []CollectionReceipt `json:"receipts"`
+	EvaluationRunIDs           []string            `json:"evaluation_run_ids,omitempty"`
+	ReasonRegistry             string              `json:"reason_registry"`
+	AdapterVersion             string              `json:"adapter_version"`
+}
+
+type ObjectiveResult struct {
+	ID                          string                      `json:"id"`
+	ControlRef                  compliance.ControlRef       `json:"control_ref"`
+	ObjectiveID                 string                      `json:"objective_id"`
+	ScopeState                  ScopeState                  `json:"scope_state"`
+	AutomatedOutcome            AutomatedOutcome            `json:"automated_outcome"`
+	DesignState                 DesignState                 `json:"design_state"`
+	OperatingEffectivenessState OperatingEffectivenessState `json:"operating_effectiveness_state"`
+	EvidenceState               EvidenceState               `json:"evidence_state"`
+	DispositionState            DispositionState            `json:"disposition_state"`
+	Assurance                   Assurance                   `json:"assurance"`
+	AuditorState                AuditorState                `json:"auditor_state"`
+	ReasonCodes                 []ReasonCode                `json:"reason_codes"`
+	NextActions                 []NextAction                `json:"next_actions"`
+	EvidenceIDs                 []string                    `json:"evidence_ids,omitempty"`
+	FindingIDs                  []string                    `json:"finding_ids,omitempty"`
+	SourceRuntimeIDs            []string                    `json:"source_runtime_ids,omitempty"`
+	EvaluatorRevision           string                      `json:"evaluator_revision"`
+	EvaluatedAt                 time.Time                   `json:"evaluated_at"`
+}
+
+func NormalizeManifest(value InputManifest) InputManifest {
+	if strings.TrimSpace(value.ModelVersion) == "" {
+		value.ModelVersion = CanonicalModelVersion
+	}
+	if strings.TrimSpace(value.ReasonRegistry) == "" {
+		value.ReasonRegistry = ReasonRegistryVersion
+	}
+	if strings.TrimSpace(value.AdapterVersion) == "" {
+		value.AdapterVersion = LegacyAdapterVersion
+	}
+	value.ModelVersion = strings.TrimSpace(value.ModelVersion)
+	value.ProgramID = strings.TrimSpace(value.ProgramID)
+	value.ScopeRevisionID = strings.TrimSpace(value.ScopeRevisionID)
+	value.PlanRevisionID = strings.TrimSpace(value.PlanRevisionID)
+	value.RequestedScopeDigest = strings.TrimSpace(value.RequestedScopeDigest)
+	value.ResolvedObjectiveSetDigest = strings.TrimSpace(value.ResolvedObjectiveSetDigest)
+	value.MappingSetDigest = strings.TrimSpace(value.MappingSetDigest)
+	value.ReasonRegistry = strings.TrimSpace(value.ReasonRegistry)
+	value.AdapterVersion = strings.TrimSpace(value.AdapterVersion)
+	value.PeriodStart = CanonicalTime(value.PeriodStart)
+	value.PeriodEnd = CanonicalTime(value.PeriodEnd)
+	value.CollectionCutoff = CanonicalTime(value.CollectionCutoff)
+	value.Revisions = append([]ManifestRevision(nil), value.Revisions...)
+	for index := range value.Revisions {
+		value.Revisions[index].Kind = strings.TrimSpace(value.Revisions[index].Kind)
+		value.Revisions[index].ID = strings.TrimSpace(value.Revisions[index].ID)
+		value.Revisions[index].RevisionID = strings.TrimSpace(value.Revisions[index].RevisionID)
+		value.Revisions[index].Digest = strings.TrimSpace(value.Revisions[index].Digest)
+	}
+	sort.Slice(value.Revisions, func(i, j int) bool {
+		left, right := value.Revisions[i], value.Revisions[j]
+		return left.Kind+"\x00"+left.ID+"\x00"+left.RevisionID < right.Kind+"\x00"+right.ID+"\x00"+right.RevisionID
+	})
+	value.Revisions = deduplicateManifestRevisions(value.Revisions)
+	value.Receipts = append([]CollectionReceipt(nil), value.Receipts...)
+	for index := range value.Receipts {
+		receipt := &value.Receipts[index]
+		receipt.Kind = strings.TrimSpace(receipt.Kind)
+		receipt.RuntimeID = strings.TrimSpace(receipt.RuntimeID)
+		receipt.QueryDigest = strings.TrimSpace(receipt.QueryDigest)
+		receipt.Cursor = strings.TrimSpace(receipt.Cursor)
+		receipt.NextCursor = strings.TrimSpace(receipt.NextCursor)
+		receipt.FirstKey = strings.TrimSpace(receipt.FirstKey)
+		receipt.LastKey = strings.TrimSpace(receipt.LastKey)
+		receipt.PageDigest = strings.TrimSpace(receipt.PageDigest)
+		receipt.Watermark = CanonicalTime(receipt.Watermark)
+		receipt.Cutoff = CanonicalTime(receipt.Cutoff)
+	}
+	sort.Slice(value.Receipts, func(i, j int) bool {
+		left, right := value.Receipts[i], value.Receipts[j]
+		if left.Kind+"\x00"+left.RuntimeID != right.Kind+"\x00"+right.RuntimeID {
+			return left.Kind+"\x00"+left.RuntimeID < right.Kind+"\x00"+right.RuntimeID
+		}
+		if left.PageIndex != right.PageIndex {
+			return left.PageIndex < right.PageIndex
+		}
+		return left.PageDigest < right.PageDigest
+	})
+	value.Receipts = deduplicateCollectionReceipts(value.Receipts)
+	value.EvaluationRunIDs = normalizedStrings(value.EvaluationRunIDs)
+	return value
+}
+
+func NormalizeResult(value ObjectiveResult) ObjectiveResult {
+	value.ID = strings.TrimSpace(value.ID)
+	value.ControlRef = compliance.NormalizeControlRef(value.ControlRef)
+	value.ObjectiveID = strings.TrimSpace(value.ObjectiveID)
+	value.EvaluatorRevision = strings.TrimSpace(value.EvaluatorRevision)
+	value.ReasonCodes = normalizedEnums(value.ReasonCodes)
+	value.NextActions = normalizedEnums(value.NextActions)
+	value.EvidenceIDs = normalizedStrings(value.EvidenceIDs)
+	value.FindingIDs = normalizedStrings(value.FindingIDs)
+	value.SourceRuntimeIDs = normalizedStrings(value.SourceRuntimeIDs)
+	value.EvaluatedAt = CanonicalTime(value.EvaluatedAt)
+	return value
+}
+
+func ValidateInputManifest(value InputManifest) error {
+	value = NormalizeManifest(value)
+	if value.ModelVersion != CanonicalModelVersion {
+		return fmt.Errorf("%w: unsupported model_version %q", ErrInvalidManifest, value.ModelVersion)
+	}
+	if value.ProgramID == "" || value.ScopeRevisionID == "" || value.PlanRevisionID == "" {
+		return fmt.Errorf("%w: program, scope revision, and plan revision are required", ErrInvalidManifest)
+	}
+	if value.PeriodStart.IsZero() || value.PeriodEnd.IsZero() || value.CollectionCutoff.IsZero() || value.PeriodEnd.Before(value.PeriodStart) {
+		return fmt.Errorf("%w: valid period and collection cutoff are required", ErrInvalidManifest)
+	}
+	for _, digest := range []string{value.RequestedScopeDigest, value.ResolvedObjectiveSetDigest, value.MappingSetDigest} {
+		if err := compliance.ValidateContentDigest(compliance.ContentDigest(digest)); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidManifest, err)
+		}
+	}
+	if len(value.Revisions) == 0 || len(value.Receipts) == 0 {
+		return fmt.Errorf("%w: revisions and collection receipts are required", ErrInvalidManifest)
+	}
+	for index, revision := range value.Revisions {
+		if revision.Kind == "" || revision.ID == "" || revision.RevisionID == "" || revision.Version == 0 {
+			return fmt.Errorf("%w: revisions[%d] is incomplete", ErrInvalidManifest, index)
+		}
+		if err := compliance.ValidateContentDigest(compliance.ContentDigest(revision.Digest)); err != nil {
+			return fmt.Errorf("%w: revisions[%d]: %v", ErrInvalidManifest, index, err)
+		}
+		if index > 0 {
+			previous := value.Revisions[index-1]
+			if previous.Kind == revision.Kind && previous.ID == revision.ID && previous.RevisionID == revision.RevisionID {
+				return fmt.Errorf("%w: conflicting duplicate revision %q", ErrInvalidManifest, revision.RevisionID)
+			}
+		}
+	}
+	for index, receipt := range value.Receipts {
+		if err := validateCollectionReceipt(receipt); err != nil {
+			return fmt.Errorf("%w: receipts[%d]: %v", ErrInvalidManifest, index, err)
+		}
+		if index > 0 {
+			previous := value.Receipts[index-1]
+			if previous.Kind == receipt.Kind && previous.RuntimeID == receipt.RuntimeID && previous.PageIndex == receipt.PageIndex {
+				return fmt.Errorf("%w: conflicting duplicate collection page %d", ErrInvalidManifest, receipt.PageIndex)
+			}
+		}
+	}
+	return nil
+}
+
+func ValidateObjectiveResult(value ObjectiveResult) error {
+	value = NormalizeResult(value)
+	if value.ID == "" || value.ObjectiveID == "" || strings.TrimSpace(value.ControlRef.ControlID) == "" || value.EvaluatorRevision == "" || value.EvaluatedAt.IsZero() {
+		return fmt.Errorf("%w: identity, control, evaluator revision, and evaluated_at are required", ErrInvalidResult)
+	}
+	if !knownScopeState(value.ScopeState) || !knownOutcome(value.AutomatedOutcome) || !knownDesignState(value.DesignState) ||
+		!knownOperatingState(value.OperatingEffectivenessState) || !knownEvidenceState(value.EvidenceState) ||
+		!knownDispositionState(value.DispositionState) || !knownAssurance(value.Assurance) || !knownAuditorState(value.AuditorState) {
+		return fmt.Errorf("%w: one or more required states are unknown", ErrInvalidResult)
+	}
+	if len(value.ReasonCodes) == 0 || len(value.NextActions) == 0 {
+		return fmt.Errorf("%w: reason_codes and next_actions are required", ErrInvalidResult)
+	}
+	for _, reason := range value.ReasonCodes {
+		if !knownReasonCode(reason) {
+			return fmt.Errorf("%w: unknown reason_code %q", ErrInvalidResult, reason)
+		}
+	}
+	for _, action := range value.NextActions {
+		if !knownNextAction(action) {
+			return fmt.Errorf("%w: unknown next_action %q", ErrInvalidResult, action)
+		}
+	}
+	if value.AutomatedOutcome == OutcomeSatisfied && value.EvidenceState != EvidenceSufficient {
+		return fmt.Errorf("%w: satisfied outcome requires sufficient evidence", ErrInvalidResult)
+	}
+	if value.ScopeState == ScopeNotApplicable && (value.AutomatedOutcome != OutcomeNotAssessed || value.DesignState != DesignNotAssessed || value.OperatingEffectivenessState != OperatingNotTested) {
+		return fmt.Errorf("%w: not-applicable scope requires not-assessed axes", ErrInvalidResult)
+	}
+	return nil
+}
+
+// CanonicalTime uses UTC millisecond precision, matching workflow event
+// timestamps and preventing event/database round trips from changing hashes.
+func CanonicalTime(value time.Time) time.Time {
+	return compliance.CanonicalRevisionTime(value)
+}
+
+func canonicalBytes(value any) ([]byte, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	var decoded any
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+	}
+	return canonical, nil
+}
+
+func CanonicalManifestBytes(value InputManifest) ([]byte, error) {
+	value = NormalizeManifest(value)
+	if err := ValidateInputManifest(value); err != nil {
+		return nil, err
+	}
+	return canonicalBytes(value)
+}
+
+func CanonicalManifestDigest(value InputManifest) (string, error) {
+	data, err := CanonicalManifestBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(data), nil
+}
+
+func CanonicalResultBytes(value ObjectiveResult) ([]byte, error) {
+	value = NormalizeResult(value)
+	if err := ValidateObjectiveResult(value); err != nil {
+		return nil, err
+	}
+	return canonicalBytes(value)
+}
+
+func CanonicalResultDigest(value ObjectiveResult) (string, error) {
+	data, err := CanonicalResultBytes(value)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(data), nil
+}
+
+func digestBytes(data []byte) string {
+	digest := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func normalizedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizedEnums[T ~string](values []T) []T {
+	stringsIn := make([]string, 0, len(values))
+	for _, value := range values {
+		stringsIn = append(stringsIn, string(value))
+	}
+	normalized := normalizedStrings(stringsIn)
+	result := make([]T, 0, len(normalized))
+	for _, value := range normalized {
+		result = append(result, T(value))
+	}
+	return result
+}
+
+func deduplicateManifestRevisions(values []ManifestRevision) []ManifestRevision {
+	result := make([]ManifestRevision, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.Kind == value.Kind && previous.ID == value.ID && previous.RevisionID == value.RevisionID && previous.Digest == value.Digest && previous.Version == value.Version {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func deduplicateCollectionReceipts(values []CollectionReceipt) []CollectionReceipt {
+	result := make([]CollectionReceipt, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 {
+			previous := result[len(result)-1]
+			if previous.Kind == value.Kind && previous.RuntimeID == value.RuntimeID && previous.PageIndex == value.PageIndex && previous.PageDigest == value.PageDigest {
+				continue
+			}
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func validateCollectionReceipt(receipt CollectionReceipt) error {
+	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Watermark.IsZero() || receipt.Cutoff.IsZero() {
+		return errors.New("kind, digests, watermark, and cutoff are required")
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.QueryDigest)); err != nil {
+		return err
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.PageDigest)); err != nil {
+		return err
+	}
+	if !knownCompleteness(receipt.Completeness) {
+		return fmt.Errorf("unknown completeness %q", receipt.Completeness)
+	}
+	if receipt.Included+receipt.Excluded != receipt.Deduplicated || receipt.Deduplicated > receipt.RawCount {
+		return errors.New("collection counts are inconsistent")
+	}
+	return nil
+}

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -363,6 +363,9 @@ func ValidateInputManifest(value InputManifest) error {
 			}
 		}
 	}
+	if err := validateCollectionReceiptChains(value.Receipts); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidManifest, err)
+	}
 	return nil
 }
 
@@ -519,8 +522,8 @@ func deduplicateCollectionReceipts(values []CollectionReceipt) []CollectionRecei
 }
 
 func validateCollectionReceipt(receipt CollectionReceipt) error {
-	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Watermark.IsZero() || receipt.Cutoff.IsZero() {
-		return errors.New("kind, digests, watermark, and cutoff are required")
+	if receipt.Kind == "" || receipt.QueryDigest == "" || receipt.PageDigest == "" || receipt.Cutoff.IsZero() {
+		return errors.New("kind, digests, and cutoff are required")
 	}
 	if err := compliance.ValidateContentDigest(compliance.ContentDigest(receipt.QueryDigest)); err != nil {
 		return err
@@ -534,5 +537,60 @@ func validateCollectionReceipt(receipt CollectionReceipt) error {
 	if receipt.Included+receipt.Excluded != receipt.Deduplicated || receipt.Deduplicated > receipt.RawCount {
 		return errors.New("collection counts are inconsistent")
 	}
+	if receipt.Watermark.IsZero() && !emptyCollectionReceipt(receipt) {
+		return errors.New("watermark is required for a non-empty collection")
+	}
 	return nil
+}
+
+func validateCollectionReceiptChains(receipts []CollectionReceipt) error {
+	for start := 0; start < len(receipts); {
+		end := start + 1
+		for end < len(receipts) && receipts[end].Kind == receipts[start].Kind && receipts[end].RuntimeID == receipts[start].RuntimeID {
+			end++
+		}
+		chain := receipts[start:end]
+		if chain[0].PageIndex != 0 || chain[0].Cursor != "" {
+			return fmt.Errorf("collection %q/%q must begin at page zero without a cursor", chain[0].Kind, chain[0].RuntimeID)
+		}
+		var collected uint64
+		for index, receipt := range chain {
+			if receipt.QueryDigest != chain[0].QueryDigest || receipt.Cutoff != chain[0].Cutoff || receipt.Watermark != chain[0].Watermark {
+				return fmt.Errorf("collection %q/%q changed query, cutoff, or watermark between pages", receipt.Kind, receipt.RuntimeID)
+			}
+			if !equalExpectedTotal(receipt.ExpectedTotal, chain[0].ExpectedTotal) {
+				return fmt.Errorf("collection %q/%q changed expected total between pages", receipt.Kind, receipt.RuntimeID)
+			}
+			collected += receipt.Included + receipt.Excluded
+			if index == 0 {
+				continue
+			}
+			previous := chain[index-1]
+			if receipt.PageIndex != previous.PageIndex+1 || previous.NextCursor == "" || receipt.Cursor != previous.NextCursor {
+				return fmt.Errorf("collection %q/%q has a missing or disconnected page at index %d", receipt.Kind, receipt.RuntimeID, receipt.PageIndex)
+			}
+		}
+		terminal := chain[len(chain)-1]
+		if terminal.NextCursor != "" {
+			return fmt.Errorf("collection %q/%q has no terminal page", terminal.Kind, terminal.RuntimeID)
+		}
+		if terminal.Completeness == CollectionComplete && terminal.ExpectedTotal != nil && collected != *terminal.ExpectedTotal {
+			return fmt.Errorf("collection %q/%q completed with %d records; expected %d", terminal.Kind, terminal.RuntimeID, collected, *terminal.ExpectedTotal)
+		}
+		start = end
+	}
+	return nil
+}
+
+func emptyCollectionReceipt(receipt CollectionReceipt) bool {
+	return receipt.PageIndex == 0 && receipt.Cursor == "" && receipt.NextCursor == "" &&
+		receipt.RawCount == 0 && receipt.Deduplicated == 0 && receipt.Included == 0 && receipt.Excluded == 0 &&
+		receipt.ExpectedTotal != nil && *receipt.ExpectedTotal == 0 && receipt.FirstKey == "" && receipt.LastKey == ""
+}
+
+func equalExpectedTotal(left, right *uint64) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }

--- a/internal/complianceassessment/types.go
+++ b/internal/complianceassessment/types.go
@@ -332,7 +332,7 @@ func ValidateInputManifest(value InputManifest) error {
 	}
 	for _, digest := range []string{value.RequestedScopeDigest, value.ResolvedObjectiveSetDigest, value.MappingSetDigest} {
 		if err := compliance.ValidateContentDigest(compliance.ContentDigest(digest)); err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidManifest, err)
+			return fmt.Errorf("%w: %w", ErrInvalidManifest, err)
 		}
 	}
 	if len(value.Revisions) == 0 || len(value.Receipts) == 0 {
@@ -343,7 +343,7 @@ func ValidateInputManifest(value InputManifest) error {
 			return fmt.Errorf("%w: revisions[%d] is incomplete", ErrInvalidManifest, index)
 		}
 		if err := compliance.ValidateContentDigest(compliance.ContentDigest(revision.Digest)); err != nil {
-			return fmt.Errorf("%w: revisions[%d]: %v", ErrInvalidManifest, index, err)
+			return fmt.Errorf("%w: revisions[%d]: %w", ErrInvalidManifest, index, err)
 		}
 		if index > 0 {
 			previous := value.Revisions[index-1]
@@ -354,7 +354,7 @@ func ValidateInputManifest(value InputManifest) error {
 	}
 	for index, receipt := range value.Receipts {
 		if err := validateCollectionReceipt(receipt); err != nil {
-			return fmt.Errorf("%w: receipts[%d]: %v", ErrInvalidManifest, index, err)
+			return fmt.Errorf("%w: receipts[%d]: %w", ErrInvalidManifest, index, err)
 		}
 		if index > 0 {
 			previous := value.Receipts[index-1]
@@ -407,17 +407,17 @@ func CanonicalTime(value time.Time) time.Time {
 func canonicalBytes(value any) ([]byte, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	var decoded any
 	decoder := json.NewDecoder(strings.NewReader(string(data)))
 	decoder.UseNumber()
 	if err := decoder.Decode(&decoded); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	canonical, err := json.Marshal(decoded)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCanonicalValue, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCanonicalValue, err)
 	}
 	return canonical, nil
 }

--- a/internal/complianceassessment/types_test.go
+++ b/internal/complianceassessment/types_test.go
@@ -1,0 +1,122 @@
+package complianceassessment
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func TestCanonicalManifestNormalizesOrderTimeAndDoesNotMutateCaller(t *testing.T) {
+	manifest := validManifest()
+	originalFirstKind := manifest.Revisions[0].Kind
+	firstBytes, err := CanonicalManifestBytes(manifest)
+	if err != nil {
+		t.Fatalf("CanonicalManifestBytes() error = %v", err)
+	}
+	shuffled := manifest
+	shuffled.Revisions = append([]ManifestRevision(nil), manifest.Revisions...)
+	shuffled.Receipts = append([]CollectionReceipt(nil), manifest.Receipts...)
+	shuffled.Revisions[0], shuffled.Revisions[1] = shuffled.Revisions[1], shuffled.Revisions[0]
+	shuffled.Receipts[0], shuffled.Receipts[1] = shuffled.Receipts[1], shuffled.Receipts[0]
+	shuffled.EvaluationRunIDs = []string{"run-b", "run-a", "run-a"}
+	secondBytes, err := CanonicalManifestBytes(shuffled)
+	if err != nil {
+		t.Fatalf("CanonicalManifestBytes(shuffled) error = %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatalf("manifest order changed canonical bytes\nfirst=%s\nsecond=%s", firstBytes, secondBytes)
+	}
+	if manifest.Revisions[0].Kind != originalFirstKind {
+		t.Fatal("NormalizeManifest mutated caller revisions")
+	}
+	if bytes.Contains(firstBytes, []byte("123456789")) || !bytes.Contains(firstBytes, []byte(".123Z")) {
+		t.Fatalf("canonical timestamp was not truncated to milliseconds: %s", firstBytes)
+	}
+}
+
+func TestUnknownEnumsSurviveDecodeAndFailCommandValidation(t *testing.T) {
+	result := validObjectiveResult()
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	data = bytes.Replace(data, []byte(`"evidence_state":"sufficient"`), []byte(`"evidence_state":"future_state"`), 1)
+	var decoded ObjectiveResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode future enum: %v", err)
+	}
+	if decoded.EvidenceState != EvidenceState("future_state") {
+		t.Fatalf("future enum was not retained: %q", decoded.EvidenceState)
+	}
+	if err := ValidateObjectiveResult(decoded); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("ValidateObjectiveResult() error = %v, want ErrInvalidResult", err)
+	}
+
+	input := validEvaluateInput()
+	input.SourceState = SourceState("future_source_state")
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective() error = %v, want ErrInvalidResult", err)
+	}
+	input = validEvaluateInput()
+	input.RequirementAssessments[0].Status = compliance.ControlEvidenceRequirementAssessmentStatus("future_requirement_state")
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective(future requirement) error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func TestCanonicalResultRejectsUnsupportedPass(t *testing.T) {
+	result := validObjectiveResult()
+	result.EvidenceState = EvidenceMissing
+	if _, err := CanonicalResultBytes(result); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("CanonicalResultBytes() error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func validManifest() InputManifest {
+	digestA := "sha256:" + strings.Repeat("a", 64)
+	digestB := "sha256:" + strings.Repeat("b", 64)
+	expected := uint64(2)
+	timestamp := time.Date(2026, 7, 11, 12, 0, 0, 123456789, time.FixedZone("offset", -7*60*60))
+	return InputManifest{
+		ProgramID: "program-00000000000000000000000000000001", ScopeRevisionID: "scope-revision-00000000000000000000000000000001",
+		PlanRevisionID: "assessment-plan-revision-00000000000000000000000000000001",
+		PeriodStart:    timestamp.Add(-time.Hour), PeriodEnd: timestamp, CollectionCutoff: timestamp,
+		RequestedScopeDigest: digestA, ResolvedObjectiveSetDigest: digestB, MappingSetDigest: digestA,
+		Revisions: []ManifestRevision{
+			{Kind: "profile", ID: "profile-1", RevisionID: "profile-r1", Version: 1, Digest: digestA},
+			{Kind: "catalog", ID: "catalog-1", RevisionID: "catalog-r1", Version: 1, Digest: digestB},
+		},
+		Receipts: []CollectionReceipt{
+			{Kind: "findings", RuntimeID: "runtime-1", QueryDigest: digestA, PageIndex: 1, Cursor: "a", RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &expected, FirstKey: "b", LastKey: "b", Watermark: timestamp, Cutoff: timestamp, Completeness: CollectionComplete, PageDigest: digestB},
+			{Kind: "findings", RuntimeID: "runtime-1", QueryDigest: digestA, PageIndex: 0, NextCursor: "a", RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &expected, FirstKey: "a", LastKey: "a", Watermark: timestamp, Cutoff: timestamp, Completeness: CollectionComplete, PageDigest: digestA},
+		},
+		EvaluationRunIDs: []string{"run-a", "run-b"},
+	}
+}
+
+func validObjectiveResult() ObjectiveResult {
+	return ObjectiveResult{
+		ID:         "assessment-result-00000000000000000000000000000001",
+		ControlRef: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ObjectiveID: "objective-1",
+		ScopeState: ScopeInScope, AutomatedOutcome: OutcomeSatisfied, DesignState: DesignEffective,
+		OperatingEffectivenessState: OperatingEffective, EvidenceState: EvidenceSufficient,
+		DispositionState: DispositionNone, Assurance: AssuranceHigh, AuditorState: AuditorNotReviewed,
+		ReasonCodes: []ReasonCode{ReasonSatisfied}, NextActions: []NextAction{ActionNone},
+		EvaluatorRevision: "evaluator-v1", EvaluatedAt: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func validEvaluateInput() EvaluateInput {
+	return EvaluateInput{
+		ResultID: "assessment-result-00000000000000000000000000000001", ObjectiveID: "objective-1",
+		Control: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ScopeState: ScopeInScope,
+		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"}}},
+		CoverageState:          CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
+		Now: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+	}
+}

--- a/internal/complianceassessment/types_test.go
+++ b/internal/complianceassessment/types_test.go
@@ -77,6 +77,37 @@ func TestCanonicalResultRejectsUnsupportedPass(t *testing.T) {
 	}
 }
 
+func TestEvaluateObjectiveRejectsSyntheticSatisfiedAssessment(t *testing.T) {
+	input := validEvaluateInput()
+	input.RequirementAssessments = []compliance.ControlEvidenceRequirementAssessment{{
+		Status: compliance.ControlEvidenceRequirementSatisfied,
+	}}
+	if _, err := EvaluateObjective(input); !errors.Is(err, ErrInvalidResult) {
+		t.Fatalf("EvaluateObjective() error = %v, want ErrInvalidResult", err)
+	}
+}
+
+func TestInputManifestRequiresCompleteCursorChain(t *testing.T) {
+	manifest := validManifest()
+	manifest.Receipts[1].Cursor = "disconnected"
+	if err := ValidateInputManifest(manifest); !errors.Is(err, ErrInvalidManifest) {
+		t.Fatalf("ValidateInputManifest() error = %v, want ErrInvalidManifest", err)
+	}
+}
+
+func TestInputManifestAcceptsEmptyCompletePopulationWithoutWatermark(t *testing.T) {
+	manifest := validManifest()
+	zero := uint64(0)
+	manifest.Receipts = []CollectionReceipt{{
+		Kind: "findings", RuntimeID: "runtime-1", QueryDigest: manifest.RequestedScopeDigest,
+		ExpectedTotal: &zero, Cutoff: manifest.CollectionCutoff, Completeness: CollectionComplete,
+		PageDigest: manifest.MappingSetDigest,
+	}}
+	if err := ValidateInputManifest(manifest); err != nil {
+		t.Fatalf("ValidateInputManifest() error = %v", err)
+	}
+}
+
 func validManifest() InputManifest {
 	digestA := "sha256:" + strings.Repeat("a", 64)
 	digestB := "sha256:" + strings.Repeat("b", 64)
@@ -115,8 +146,11 @@ func validEvaluateInput() EvaluateInput {
 	return EvaluateInput{
 		ResultID: "assessment-result-00000000000000000000000000000001", ObjectiveID: "objective-1",
 		Control: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"}, ScopeState: ScopeInScope,
-		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"}}},
-		CoverageState:          CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
+		RequirementAssessments: []compliance.ControlEvidenceRequirementAssessment{{
+			RequirementKey: "requirement-1", ControlRef: compliance.ControlRef{FrameworkName: "Example Framework", ControlID: "CC-1"},
+			SourceID: "source-1", EntityType: "resource", Status: compliance.ControlEvidenceRequirementSatisfied, EvidenceIDs: []string{"evidence-1"},
+		}},
+		CoverageState: CoverageComplete, SourceState: SourceSupported, EvaluatorRevision: "evaluator-v1",
 		Now: time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
 	}
 }

--- a/internal/complianceassessment/validation.go
+++ b/internal/complianceassessment/validation.go
@@ -1,0 +1,128 @@
+package complianceassessment
+
+func knownScopeState(value ScopeState) bool {
+	switch value {
+	case ScopeInScope, ScopeNotApplicable, ScopeUnresolved:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownOutcome(value AutomatedOutcome) bool {
+	switch value {
+	case OutcomeSatisfied, OutcomeNotSatisfied, OutcomeIndeterminate, OutcomeNotAssessed:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownDesignState(value DesignState) bool {
+	switch value {
+	case DesignEffective, DesignIneffective, DesignUnknown, DesignNotAssessed:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownOperatingState(value OperatingEffectivenessState) bool {
+	switch value {
+	case OperatingEffective, OperatingIneffective, OperatingUnknown, OperatingNotTested:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownEvidenceState(value EvidenceState) bool {
+	switch value {
+	case EvidenceSufficient, EvidenceMissing, EvidenceStale, EvidenceConflicting,
+		EvidenceUntrusted, EvidenceIncomplete, EvidenceManualReview:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownDispositionState(value DispositionState) bool {
+	switch value {
+	case DispositionNone, DispositionAcceptedException, DispositionAcceptedRisk, DispositionReviewOverride:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownAssurance(value Assurance) bool {
+	switch value {
+	case AssuranceHigh, AssuranceMedium, AssuranceLow, AssuranceNone:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownAuditorState(value AuditorState) bool {
+	switch value {
+	case AuditorNotReviewed, AuditorAccepted, AuditorChangesRequested, AuditorRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownCoverageState(value CoverageState) bool {
+	switch value {
+	case CoverageComplete, CoveragePartial, CoverageEmpty, CoverageUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownSourceState(value SourceState) bool {
+	switch value {
+	case SourceSupported, SourcePartial, SourceStale, SourceFailed, SourceUnconfigured,
+		SourceUnsupported, SourceUnverified, SourceConflicting, SourceUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownReasonCode(value ReasonCode) bool {
+	switch value {
+	case ReasonSatisfied, ReasonActiveFinding, ReasonEvidenceMissing, ReasonEvidenceInvalid,
+		ReasonEvidenceStale, ReasonEvidenceConflicting, ReasonCoverageIncomplete,
+		ReasonSourceUntrusted, ReasonSourceUnknown, ReasonManualEvidence,
+		ReasonAcceptedException, ReasonAcceptedRisk, ReasonNotApplicable,
+		ReasonInheritedResponsibility, ReasonSampledTesting, ReasonSourceUnconfigured,
+		ReasonSourceUnsupported, ReasonSourcePartial, ReasonSourceFailed, ReasonSourceStale,
+		ReasonScopeUnresolved, ReasonPopulationEmpty:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownNextAction(value NextAction) bool {
+	switch value {
+	case ActionNone, ActionReview, ActionCollectEvidence, ActionRefreshEvidence,
+		ActionRestoreSource, ActionResolveScope, ActionRemediate, ActionRetest:
+		return true
+	default:
+		return false
+	}
+}
+
+func knownCompleteness(value CollectionCompleteness) bool {
+	switch value {
+	case CollectionComplete, CollectionPartial, CollectionTruncated,
+		CollectionChangedDuringScan, CollectionUnknown:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/complianceimpact/adapters.go
+++ b/internal/complianceimpact/adapters.go
@@ -163,14 +163,14 @@ func AdaptCompatibility(request AdapterRequest) (AdapterResult, error) {
 	if err != nil {
 		return AdapterResult{}, err
 	}
-	if uint32(len(sources)) > request.Limits.MaxSources {
+	if uint64(len(sources)) > uint64(request.Limits.MaxSources) {
 		return AdapterResult{}, fmt.Errorf("%w: sources %d exceed max_sources %d", ErrAdapterLimit, len(sources), request.Limits.MaxSources)
 	}
 	mappingsBySource := make(map[string][]CompatibilityMapping, len(request.Mappings))
 	for _, mapping := range request.Mappings {
 		normalized, err := normalizeMapping(mapping)
 		if err != nil {
-			return AdapterResult{}, fmt.Errorf("%w: mapping normalization: %v", ErrInvalidAdapterRequest, err)
+			return AdapterResult{}, fmt.Errorf("%w: mapping normalization: %w", ErrInvalidAdapterRequest, err)
 		}
 		key := provenanceKey(normalized.Source)
 		mappingsBySource[key] = append(mappingsBySource[key], normalized)
@@ -228,11 +228,11 @@ func AdaptCompatibility(request AdapterRequest) (AdapterResult, error) {
 		}
 		issues = append(issues, AdapterIssue{Code: ReasonImpactIncomplete, Source: provenance(source), ImpactReason: issue.Code})
 	}
-	if uint32(len(issues)) > request.Limits.MaxIssues {
+	if uint64(len(issues)) > uint64(request.Limits.MaxIssues) {
 		return AdapterResult{}, fmt.Errorf("%w: issues %d exceed max_issues %d", ErrAdapterLimit, len(issues), request.Limits.MaxIssues)
 	}
 
-	if uint32(len(targetBuilders)) > request.Limits.MaxTargets {
+	if uint64(len(targetBuilders)) > uint64(request.Limits.MaxTargets) {
 		return AdapterResult{}, fmt.Errorf("%w: targets %d exceed max_targets %d", ErrAdapterLimit, len(targetBuilders), request.Limits.MaxTargets)
 	}
 	targets := make([]CompatibilityTarget, 0, len(targetBuilders))
@@ -242,7 +242,7 @@ func AdaptCompatibility(request AdapterRequest) (AdapterResult, error) {
 		actionCount += len(target.Actions)
 		targets = append(targets, target)
 	}
-	if uint32(actionCount) > request.Limits.MaxActions {
+	if uint64(actionCount) > uint64(request.Limits.MaxActions) {
 		return AdapterResult{}, fmt.Errorf("%w: actions %d exceed max_actions %d", ErrAdapterLimit, actionCount, request.Limits.MaxActions)
 	}
 	sort.Slice(targets, func(i, j int) bool {
@@ -303,14 +303,14 @@ func validateAdapterRequest(request AdapterRequest) error {
 			}
 		}
 	}
-	if uint32(len(request.Mappings)) > request.Limits.MaxMappings {
+	if uint64(len(request.Mappings)) > uint64(request.Limits.MaxMappings) {
 		return fmt.Errorf("%w: mappings %d exceed max_mappings %d", ErrAdapterLimit, len(request.Mappings), request.Limits.MaxMappings)
 	}
 	if !boundedValue(request.MappingSet.RevisionID, 512) {
 		return fmt.Errorf("%w: mapping_set revision_id is required and must be bounded", ErrInvalidAdapterRequest)
 	}
 	if err := compliance.ValidateContentDigest(compliance.ContentDigest(strings.TrimSpace(string(request.MappingSet.ContentDigest)))); err != nil {
-		return fmt.Errorf("%w: mapping_set content_digest: %v", ErrInvalidAdapterRequest, err)
+		return fmt.Errorf("%w: mapping_set content_digest: %w", ErrInvalidAdapterRequest, err)
 	}
 	inputActions := 0
 	for index, mapping := range request.Mappings {
@@ -318,7 +318,7 @@ func validateAdapterRequest(request AdapterRequest) error {
 			return fmt.Errorf("%w: mapping[%d] crosses tenant boundary", ErrAdapterTenantBoundary, index)
 		}
 		if _, err := revisionFromProvenance(mapping.Source); err != nil {
-			return fmt.Errorf("%w: mapping[%d] source: %v", ErrInvalidAdapterRequest, index, err)
+			return fmt.Errorf("%w: mapping[%d] source: %w", ErrInvalidAdapterRequest, index, err)
 		}
 		if !validCompatibilityTargetKind(mapping.TargetKind) {
 			return fmt.Errorf("%w: mapping[%d] target_kind %q", ErrInvalidAdapterRequest, index, mapping.TargetKind)
@@ -359,7 +359,7 @@ func collectImpactSources(tenantID string, impact Result) ([]MappedImpactSource,
 		}
 		ref, err := revisionFromProvenance(value.Revision)
 		if err != nil {
-			return fmt.Errorf("%w: affected revision: %v", ErrInvalidAdapterRequest, err)
+			return fmt.Errorf("%w: affected revision: %w", ErrInvalidAdapterRequest, err)
 		}
 		key := ref.ExactKey()
 		value.Reasons = canonicalReasons(value.Reasons)

--- a/internal/complianceimpact/adapters.go
+++ b/internal/complianceimpact/adapters.go
@@ -1,0 +1,615 @@
+package complianceimpact
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/complianceintegration"
+)
+
+var (
+	ErrInvalidAdapterRequest = errors.New("invalid compliance impact adapter request")
+	ErrAdapterTenantBoundary = errors.New("compliance impact adapter tenant boundary violation")
+	ErrAdapterLimit          = errors.New("compliance impact adapter limit exceeded")
+)
+
+const (
+	maxAdapterMappings = 100000
+	maxAdapterSources  = 100000
+	maxAdapterTargets  = 50000
+	maxAdapterActions  = 100000
+	maxAdapterIssues   = 100000
+)
+
+var adapterIdentifierPattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,127}$`)
+
+// AdapterLimits bound the compatibility adapter's in-memory work. The adapter
+// performs no external reads and never executes an action candidate.
+type AdapterLimits struct {
+	MaxMappings uint32 `json:"max_mappings"`
+	MaxSources  uint32 `json:"max_sources"`
+	MaxTargets  uint32 `json:"max_targets"`
+	MaxActions  uint32 `json:"max_actions"`
+	MaxIssues   uint32 `json:"max_issues"`
+}
+
+func DefaultAdapterLimits() AdapterLimits {
+	return AdapterLimits{MaxMappings: 10000, MaxSources: 10000, MaxTargets: 10000, MaxActions: 25000, MaxIssues: 10000}
+}
+
+// CompatibilityTargetKind identifies an existing operator-facing domain. It
+// is deliberately narrower than complianceintegration.FactKind: these are
+// compatibility destinations, not new canonical fact owners.
+type CompatibilityTargetKind string
+
+const (
+	TargetPolicy        CompatibilityTargetKind = "policy"
+	TargetFinding       CompatibilityTargetKind = "finding"
+	TargetVendor        CompatibilityTargetKind = "vendor"
+	TargetQuestionnaire CompatibilityTargetKind = "questionnaire"
+	TargetAccessReview  CompatibilityTargetKind = "access_review"
+)
+
+// AdapterReasonCode explains why a canonical impact could not be translated.
+type AdapterReasonCode string
+
+const (
+	ReasonUnmappedTarget   AdapterReasonCode = "unmapped_target"
+	ReasonAmbiguousTarget  AdapterReasonCode = "ambiguous_target"
+	ReasonImpactIncomplete AdapterReasonCode = "impact_incomplete"
+)
+
+// RevisionProvenance is the transport-safe form of one exact immutable
+// complianceintegration revision. ContentDigest is copied without alteration.
+type RevisionProvenance struct {
+	TenantID      string                         `json:"tenant_id"`
+	Domain        string                         `json:"domain"`
+	Kind          complianceintegration.FactKind `json:"kind"`
+	ID            string                         `json:"id"`
+	RevisionID    string                         `json:"revision_id"`
+	Version       uint64                         `json:"version"`
+	ContentDigest compliance.ContentDigest       `json:"content_digest"`
+	LastModified  time.Time                      `json:"last_modified"`
+}
+
+// MappingSetRevision identifies the explicit mapping input used for a replay.
+// It is provenance only; the adapter never fetches mapping data by this value.
+type MappingSetRevision struct {
+	RevisionID    string                   `json:"revision_id"`
+	ContentDigest compliance.ContentDigest `json:"content_digest"`
+}
+
+// CompatibilityMapping translates one exact impact revision to one existing
+// domain identifier. ActionIDs are candidates only and remain owned and
+// validated for execution by the destination domain.
+type CompatibilityMapping struct {
+	TenantID   string                  `json:"tenant_id"`
+	Source     RevisionProvenance      `json:"source"`
+	TargetKind CompatibilityTargetKind `json:"target_kind"`
+	TargetID   string                  `json:"target_id"`
+	ActionIDs  []string                `json:"action_ids"`
+}
+
+// AdapterRequest contains every input needed for deterministic replay.
+type AdapterRequest struct {
+	TenantID   string                 `json:"tenant_id"`
+	Impact     Result                 `json:"-"`
+	MappingSet MappingSetRevision     `json:"mapping_set"`
+	Mappings   []CompatibilityMapping `json:"mappings"`
+	Limits     AdapterLimits          `json:"limits"`
+}
+
+// MappedImpactSource retains the exact revision and canonical impact reasons
+// that caused one compatibility target to be proposed.
+type MappedImpactSource struct {
+	Revision  RevisionProvenance `json:"revision"`
+	Reasons   []ReasonCode       `json:"reasons"`
+	Relations []string           `json:"relations,omitempty"`
+	Distance  uint32             `json:"distance"`
+}
+
+// ActionCandidate is a read-only domain action identifier. This package does
+// not infer parameters, authorize execution, or mutate destination state.
+type ActionCandidate struct {
+	ActionID string       `json:"action_id"`
+	Reasons  []ReasonCode `json:"reasons"`
+}
+
+// CompatibilityTarget groups all exact impact sources for one existing domain
+// identifier and deduplicates the resulting action candidates.
+type CompatibilityTarget struct {
+	Kind    CompatibilityTargetKind `json:"kind"`
+	ID      string                  `json:"id"`
+	Sources []MappedImpactSource    `json:"sources"`
+	Actions []ActionCandidate       `json:"actions"`
+}
+
+// AdapterIssue records explicit non-matches. CandidateIDs is populated only
+// for ambiguity and is sorted so operators can repair the mapping set.
+type AdapterIssue struct {
+	Code         AdapterReasonCode       `json:"code"`
+	Source       RevisionProvenance      `json:"source"`
+	TargetKind   CompatibilityTargetKind `json:"target_kind,omitempty"`
+	CandidateIDs []string                `json:"candidate_ids,omitempty"`
+	ImpactReason ReasonCode              `json:"impact_reason,omitempty"`
+}
+
+// AdapterResult is deterministic, transport-safe, and contains no executable
+// callbacks or copied domain payloads.
+type AdapterResult struct {
+	TenantID     string                `json:"tenant_id"`
+	ImpactSource RevisionProvenance    `json:"impact_source"`
+	MappingSet   MappingSetRevision    `json:"mapping_set"`
+	Complete     bool                  `json:"complete"`
+	Targets      []CompatibilityTarget `json:"targets"`
+	Issues       []AdapterIssue        `json:"issues"`
+}
+
+// AdaptCompatibility translates canonical impact output through explicit,
+// exact-revision mappings. It performs no external I/O and returns no partial
+// output when request validation or a configured work limit fails.
+func AdaptCompatibility(request AdapterRequest) (AdapterResult, error) {
+	if err := validateAdapterRequest(request); err != nil {
+		return AdapterResult{}, err
+	}
+
+	sources, err := collectImpactSources(request.TenantID, request.Impact)
+	if err != nil {
+		return AdapterResult{}, err
+	}
+	if uint32(len(sources)) > request.Limits.MaxSources {
+		return AdapterResult{}, fmt.Errorf("%w: sources %d exceed max_sources %d", ErrAdapterLimit, len(sources), request.Limits.MaxSources)
+	}
+	mappingsBySource := make(map[string][]CompatibilityMapping, len(request.Mappings))
+	for _, mapping := range request.Mappings {
+		normalized, err := normalizeMapping(mapping)
+		if err != nil {
+			return AdapterResult{}, fmt.Errorf("%w: mapping normalization: %v", ErrInvalidAdapterRequest, err)
+		}
+		key := provenanceKey(normalized.Source)
+		mappingsBySource[key] = append(mappingsBySource[key], normalized)
+	}
+	for key := range mappingsBySource {
+		mappingsBySource[key] = deduplicateMappings(mappingsBySource[key])
+	}
+
+	targetBuilders := map[string]*compatibilityTargetBuilder{}
+	issues := make([]AdapterIssue, 0)
+	for _, source := range sources {
+		mappings := mappingsBySource[provenanceKey(source.Revision)]
+		if len(mappings) == 0 {
+			issues = append(issues, AdapterIssue{Code: ReasonUnmappedTarget, Source: source.Revision})
+			continue
+		}
+
+		mapped := false
+		byKind := mappingsByTargetKind(mappings)
+		for _, kind := range orderedTargetKinds() {
+			kindMappings := byKind[kind]
+			if len(kindMappings) == 0 {
+				continue
+			}
+			ids := distinctTargetIDs(kindMappings)
+			if len(ids) != 1 {
+				issues = append(issues, AdapterIssue{Code: ReasonAmbiguousTarget, Source: source.Revision, TargetKind: kind, CandidateIDs: ids})
+				continue
+			}
+			mapped = true
+			targetKey := string(kind) + "\x00" + ids[0]
+			builder := targetBuilders[targetKey]
+			if builder == nil {
+				builder = &compatibilityTargetBuilder{kind: kind, id: ids[0], sources: map[string]MappedImpactSource{}, actions: map[string]map[ReasonCode]struct{}{}}
+				targetBuilders[targetKey] = builder
+			}
+			builder.addSource(source)
+			for _, mapping := range kindMappings {
+				if mapping.TargetID != ids[0] {
+					continue
+				}
+				for _, actionID := range mapping.ActionIDs {
+					builder.addAction(actionID, source.Reasons)
+				}
+			}
+		}
+		if !mapped && !hasAmbiguityForSource(issues, source.Revision) {
+			issues = append(issues, AdapterIssue{Code: ReasonUnmappedTarget, Source: source.Revision})
+		}
+	}
+	for _, issue := range request.Impact.Issues {
+		source := issue.Revision
+		if source.ExactKey() == "" {
+			source = request.Impact.Signal.Revision()
+		}
+		issues = append(issues, AdapterIssue{Code: ReasonImpactIncomplete, Source: provenance(source), ImpactReason: issue.Code})
+	}
+	if uint32(len(issues)) > request.Limits.MaxIssues {
+		return AdapterResult{}, fmt.Errorf("%w: issues %d exceed max_issues %d", ErrAdapterLimit, len(issues), request.Limits.MaxIssues)
+	}
+
+	if uint32(len(targetBuilders)) > request.Limits.MaxTargets {
+		return AdapterResult{}, fmt.Errorf("%w: targets %d exceed max_targets %d", ErrAdapterLimit, len(targetBuilders), request.Limits.MaxTargets)
+	}
+	targets := make([]CompatibilityTarget, 0, len(targetBuilders))
+	actionCount := 0
+	for _, builder := range targetBuilders {
+		target := builder.build()
+		actionCount += len(target.Actions)
+		targets = append(targets, target)
+	}
+	if uint32(actionCount) > request.Limits.MaxActions {
+		return AdapterResult{}, fmt.Errorf("%w: actions %d exceed max_actions %d", ErrAdapterLimit, actionCount, request.Limits.MaxActions)
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		return string(targets[i].Kind)+"\x00"+targets[i].ID < string(targets[j].Kind)+"\x00"+targets[j].ID
+	})
+	issues = canonicalizeAdapterIssues(issues)
+	result := AdapterResult{
+		TenantID:     request.TenantID,
+		ImpactSource: provenance(request.Impact.Signal.Revision()),
+		MappingSet: MappingSetRevision{
+			RevisionID:    strings.TrimSpace(request.MappingSet.RevisionID),
+			ContentDigest: compliance.ContentDigest(strings.TrimSpace(string(request.MappingSet.ContentDigest))),
+		},
+		Complete: request.Impact.Complete && len(issues) == 0,
+		Targets:  targets,
+		Issues:   issues,
+	}
+	return result, nil
+}
+
+// CanonicalAdapterBytes provides stable replay bytes for an already adapted
+// result. AdapterResult intentionally contains no maps.
+func CanonicalAdapterBytes(result AdapterResult) ([]byte, error) {
+	return json.Marshal(result)
+}
+
+func validateAdapterRequest(request AdapterRequest) error {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" || len(tenantID) > 255 || strings.ContainsRune(tenantID, '\x00') {
+		return fmt.Errorf("%w: tenant_id is required and must be bounded", ErrInvalidAdapterRequest)
+	}
+	if request.Impact.TenantID != tenantID || request.Impact.Signal.Revision().TenantID() != tenantID {
+		return fmt.Errorf("%w: impact tenant does not match request", ErrAdapterTenantBoundary)
+	}
+	if request.Impact.Signal.Revision().ExactKey() == "" {
+		return fmt.Errorf("%w: impact source revision is required", ErrInvalidAdapterRequest)
+	}
+	if err := validateAdapterLimits(request.Limits); err != nil {
+		return err
+	}
+	rawSources := 1 + len(request.Impact.Programs) + len(request.Impact.Plans) + len(request.Impact.Objectives) + len(request.Impact.Packages) + len(request.Impact.WorkItems) + len(request.Impact.Invalidations)
+	if uint64(rawSources) > uint64(request.Limits.MaxSources) {
+		return fmt.Errorf("%w: input sources %d exceed max_sources %d", ErrAdapterLimit, rawSources, request.Limits.MaxSources)
+	}
+	if uint64(len(request.Impact.Issues)) > uint64(request.Limits.MaxIssues) {
+		return fmt.Errorf("%w: input issues %d exceed max_issues %d", ErrAdapterLimit, len(request.Impact.Issues), request.Limits.MaxIssues)
+	}
+	for index, issue := range request.Impact.Issues {
+		for _, entry := range []struct {
+			label string
+			ref   complianceintegration.RevisionRef
+		}{{label: "revision", ref: issue.Revision}, {label: "related", ref: issue.Related}} {
+			if entry.ref.ExactKey() == "" {
+				continue
+			}
+			if entry.ref.TenantID() != tenantID {
+				return fmt.Errorf("%w: impact issue[%d] %s crosses tenant boundary", ErrAdapterTenantBoundary, index, entry.label)
+			}
+		}
+	}
+	if uint32(len(request.Mappings)) > request.Limits.MaxMappings {
+		return fmt.Errorf("%w: mappings %d exceed max_mappings %d", ErrAdapterLimit, len(request.Mappings), request.Limits.MaxMappings)
+	}
+	if !boundedValue(request.MappingSet.RevisionID, 512) {
+		return fmt.Errorf("%w: mapping_set revision_id is required and must be bounded", ErrInvalidAdapterRequest)
+	}
+	if err := compliance.ValidateContentDigest(compliance.ContentDigest(strings.TrimSpace(string(request.MappingSet.ContentDigest)))); err != nil {
+		return fmt.Errorf("%w: mapping_set content_digest: %v", ErrInvalidAdapterRequest, err)
+	}
+	inputActions := 0
+	for index, mapping := range request.Mappings {
+		if strings.TrimSpace(mapping.TenantID) != tenantID || strings.TrimSpace(mapping.Source.TenantID) != tenantID {
+			return fmt.Errorf("%w: mapping[%d] crosses tenant boundary", ErrAdapterTenantBoundary, index)
+		}
+		if _, err := revisionFromProvenance(mapping.Source); err != nil {
+			return fmt.Errorf("%w: mapping[%d] source: %v", ErrInvalidAdapterRequest, index, err)
+		}
+		if !validCompatibilityTargetKind(mapping.TargetKind) {
+			return fmt.Errorf("%w: mapping[%d] target_kind %q", ErrInvalidAdapterRequest, index, mapping.TargetKind)
+		}
+		if !boundedValue(mapping.TargetID, 1024) {
+			return fmt.Errorf("%w: mapping[%d] target_id is required and must be bounded", ErrInvalidAdapterRequest, index)
+		}
+		if len(mapping.ActionIDs) == 0 {
+			return fmt.Errorf("%w: mapping[%d] requires at least one action_id", ErrInvalidAdapterRequest, index)
+		}
+		for actionIndex, actionID := range mapping.ActionIDs {
+			if !adapterIdentifierPattern.MatchString(strings.ToLower(strings.TrimSpace(actionID))) {
+				return fmt.Errorf("%w: mapping[%d] action_ids[%d] is invalid", ErrInvalidAdapterRequest, index, actionIndex)
+			}
+		}
+		inputActions += len(mapping.ActionIDs)
+	}
+	if uint32(inputActions) > request.Limits.MaxActions {
+		return fmt.Errorf("%w: input actions %d exceed max_actions %d", ErrAdapterLimit, inputActions, request.Limits.MaxActions)
+	}
+	return nil
+}
+
+func validateAdapterLimits(limits AdapterLimits) error {
+	if limits.MaxMappings == 0 || limits.MaxSources == 0 || limits.MaxTargets == 0 || limits.MaxActions == 0 || limits.MaxIssues == 0 ||
+		limits.MaxMappings > maxAdapterMappings || limits.MaxSources > maxAdapterSources || limits.MaxTargets > maxAdapterTargets ||
+		limits.MaxActions > maxAdapterActions || limits.MaxIssues > maxAdapterIssues {
+		return fmt.Errorf("%w: limits must be non-zero and within hard ceilings", ErrInvalidAdapterRequest)
+	}
+	return nil
+}
+
+func collectImpactSources(tenantID string, impact Result) ([]MappedImpactSource, error) {
+	values := map[string]MappedImpactSource{}
+	add := func(value MappedImpactSource) error {
+		if value.Revision.TenantID != tenantID {
+			return fmt.Errorf("%w: affected revision crosses tenant boundary", ErrAdapterTenantBoundary)
+		}
+		ref, err := revisionFromProvenance(value.Revision)
+		if err != nil {
+			return fmt.Errorf("%w: affected revision: %v", ErrInvalidAdapterRequest, err)
+		}
+		key := ref.ExactKey()
+		value.Reasons = canonicalReasons(value.Reasons)
+		value.Relations = canonicalStrings(value.Relations)
+		if existing, ok := values[key]; ok {
+			existing.Reasons = canonicalReasons(append(existing.Reasons, value.Reasons...))
+			existing.Relations = canonicalStrings(append(existing.Relations, value.Relations...))
+			if value.Distance < existing.Distance {
+				existing.Distance = value.Distance
+			}
+			values[key] = existing
+			return nil
+		}
+		values[key] = value
+		return nil
+	}
+	root := impact.Signal.Revision()
+	if err := add(MappedImpactSource{Revision: provenance(root), Reasons: []ReasonCode{adapterDirectReason(impact.Signal.Kind())}}); err != nil {
+		return nil, err
+	}
+	for _, facts := range [][]AffectedFact{impact.Programs, impact.Plans, impact.Objectives, impact.Packages, impact.WorkItems} {
+		for _, fact := range facts {
+			if err := add(MappedImpactSource{Revision: provenance(fact.Revision), Reasons: fact.Reasons, Relations: fact.Relations, Distance: fact.Distance}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, invalidation := range impact.Invalidations {
+		if err := add(MappedImpactSource{Revision: provenance(invalidation.Revision), Reasons: []ReasonCode{invalidation.Reason}}); err != nil {
+			return nil, err
+		}
+	}
+	result := make([]MappedImpactSource, 0, len(values))
+	for _, value := range values {
+		result = append(result, value)
+	}
+	sort.Slice(result, func(i, j int) bool { return provenanceKey(result[i].Revision) < provenanceKey(result[j].Revision) })
+	return result, nil
+}
+
+func adapterDirectReason(kind complianceintegration.ChangeKind) ReasonCode {
+	switch kind {
+	case complianceintegration.ChangeDeleted:
+		return ReasonRevisionDeleted
+	case complianceintegration.ChangeRevoked:
+		return ReasonRevisionRevoked
+	default:
+		return ReasonRevisionChanged
+	}
+}
+
+func provenance(ref complianceintegration.RevisionRef) RevisionProvenance {
+	canonical := ref.Canonical()
+	return RevisionProvenance{
+		TenantID: ref.TenantID(), Domain: ref.Domain(), Kind: ref.Kind(), ID: canonical.ID,
+		RevisionID: canonical.RevisionID, Version: canonical.Version, ContentDigest: canonical.ContentDigest,
+		LastModified: canonical.LastModified,
+	}
+}
+
+func revisionFromProvenance(value RevisionProvenance) (complianceintegration.RevisionRef, error) {
+	return complianceintegration.AdaptRevisionRef(value.TenantID, value.Domain, value.Kind, compliance.RevisionRef{
+		ID: value.ID, RevisionID: value.RevisionID, Version: value.Version,
+		ContentDigest: value.ContentDigest, LastModified: value.LastModified,
+	})
+}
+
+func provenanceKey(value RevisionProvenance) string {
+	ref, err := revisionFromProvenance(value)
+	if err != nil {
+		return ""
+	}
+	return ref.ExactKey()
+}
+
+func normalizeMapping(value CompatibilityMapping) (CompatibilityMapping, error) {
+	value.TenantID = strings.TrimSpace(value.TenantID)
+	value.TargetKind = CompatibilityTargetKind(strings.ToLower(strings.TrimSpace(string(value.TargetKind))))
+	value.TargetID = strings.TrimSpace(value.TargetID)
+	value.ActionIDs = canonicalStringsLower(value.ActionIDs)
+	ref, err := revisionFromProvenance(value.Source)
+	if err != nil {
+		return CompatibilityMapping{}, err
+	}
+	value.Source = provenance(ref)
+	return value, nil
+}
+
+func deduplicateMappings(values []CompatibilityMapping) []CompatibilityMapping {
+	sort.Slice(values, func(i, j int) bool { return mappingKey(values[i]) < mappingKey(values[j]) })
+	result := make([]CompatibilityMapping, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && mappingKey(result[len(result)-1]) == mappingKey(value) {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func mappingKey(value CompatibilityMapping) string {
+	return provenanceKey(value.Source) + "\x00" + string(value.TargetKind) + "\x00" + value.TargetID + "\x00" + strings.Join(value.ActionIDs, "\x00")
+}
+
+func mappingsByTargetKind(values []CompatibilityMapping) map[CompatibilityTargetKind][]CompatibilityMapping {
+	result := map[CompatibilityTargetKind][]CompatibilityMapping{}
+	for _, value := range values {
+		result[value.TargetKind] = append(result[value.TargetKind], value)
+	}
+	return result
+}
+
+func distinctTargetIDs(values []CompatibilityMapping) []string {
+	ids := make([]string, 0, len(values))
+	for _, value := range values {
+		ids = append(ids, value.TargetID)
+	}
+	return canonicalStrings(ids)
+}
+
+func orderedTargetKinds() []CompatibilityTargetKind {
+	return []CompatibilityTargetKind{TargetAccessReview, TargetFinding, TargetPolicy, TargetQuestionnaire, TargetVendor}
+}
+
+func validCompatibilityTargetKind(value CompatibilityTargetKind) bool {
+	value = CompatibilityTargetKind(strings.ToLower(strings.TrimSpace(string(value))))
+	for _, candidate := range orderedTargetKinds() {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func boundedValue(value string, maximum int) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && len(value) <= maximum && !strings.ContainsRune(value, '\x00')
+}
+
+func canonicalReasons(values []ReasonCode) []ReasonCode {
+	seen := map[ReasonCode]struct{}{}
+	for _, value := range values {
+		if value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	result := make([]ReasonCode, 0, len(seen))
+	for value := range seen {
+		result = append(result, value)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result
+}
+
+func canonicalStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for value := range seen {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func canonicalStringsLower(values []string) []string {
+	result := make([]string, len(values))
+	for index, value := range values {
+		result[index] = strings.ToLower(strings.TrimSpace(value))
+	}
+	return canonicalStrings(result)
+}
+
+type compatibilityTargetBuilder struct {
+	kind    CompatibilityTargetKind
+	id      string
+	sources map[string]MappedImpactSource
+	actions map[string]map[ReasonCode]struct{}
+}
+
+func (b *compatibilityTargetBuilder) addSource(source MappedImpactSource) {
+	b.sources[provenanceKey(source.Revision)] = source
+}
+
+func (b *compatibilityTargetBuilder) addAction(actionID string, reasons []ReasonCode) {
+	actionID = strings.ToLower(strings.TrimSpace(actionID))
+	values := b.actions[actionID]
+	if values == nil {
+		values = map[ReasonCode]struct{}{}
+		b.actions[actionID] = values
+	}
+	for _, reason := range reasons {
+		values[reason] = struct{}{}
+	}
+}
+
+func (b *compatibilityTargetBuilder) build() CompatibilityTarget {
+	result := CompatibilityTarget{Kind: b.kind, ID: b.id}
+	for _, source := range b.sources {
+		result.Sources = append(result.Sources, source)
+	}
+	sort.Slice(result.Sources, func(i, j int) bool {
+		return provenanceKey(result.Sources[i].Revision) < provenanceKey(result.Sources[j].Revision)
+	})
+	for actionID, reasonSet := range b.actions {
+		reasons := make([]ReasonCode, 0, len(reasonSet))
+		for reason := range reasonSet {
+			reasons = append(reasons, reason)
+		}
+		reasons = canonicalReasons(reasons)
+		result.Actions = append(result.Actions, ActionCandidate{ActionID: actionID, Reasons: reasons})
+	}
+	sort.Slice(result.Actions, func(i, j int) bool { return result.Actions[i].ActionID < result.Actions[j].ActionID })
+	return result
+}
+
+func hasAmbiguityForSource(issues []AdapterIssue, source RevisionProvenance) bool {
+	key := provenanceKey(source)
+	for _, issue := range issues {
+		if issue.Code == ReasonAmbiguousTarget && provenanceKey(issue.Source) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalizeAdapterIssues(values []AdapterIssue) []AdapterIssue {
+	for index := range values {
+		values[index].CandidateIDs = canonicalStrings(values[index].CandidateIDs)
+	}
+	sort.Slice(values, func(i, j int) bool { return adapterIssueKey(values[i]) < adapterIssueKey(values[j]) })
+	write := 0
+	for _, value := range values {
+		if write != 0 && adapterIssueKey(values[write-1]) == adapterIssueKey(value) {
+			continue
+		}
+		values[write] = value
+		write++
+	}
+	for index := write; index < len(values); index++ {
+		values[index] = AdapterIssue{}
+	}
+	return values[:write]
+}
+
+func adapterIssueKey(value AdapterIssue) string {
+	return string(value.Code) + "\x00" + provenanceKey(value.Source) + "\x00" + string(value.TargetKind) + "\x00" + strings.Join(value.CandidateIDs, "\x00") + "\x00" + string(value.ImpactReason)
+}

--- a/internal/complianceimpact/adapters_test.go
+++ b/internal/complianceimpact/adapters_test.go
@@ -1,0 +1,234 @@
+package complianceimpact
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/complianceintegration"
+)
+
+type adapterReplayFixture struct {
+	Mappings []CompatibilityMapping  `json:"mappings"`
+	Expected []adapterExpectedTarget `json:"expected_targets"`
+}
+
+type adapterExpectedTarget struct {
+	Kind      CompatibilityTargetKind `json:"kind"`
+	ID        string                  `json:"id"`
+	ActionIDs []string                `json:"action_ids"`
+}
+
+func TestCompatibilityAdapterFixtureStableReplayAndAllDestinationSlices(t *testing.T) {
+	fixture := readAdapterReplayFixture(t)
+	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
+	program := adapterRevision(t, complianceintegration.FactProgram, "program-source", 2)
+	objective := adapterRevision(t, complianceintegration.FactObjective, "objective-source", 3)
+	impact := adapterImpact(t, root)
+	impact.Programs = []AffectedFact{{Revision: program, Reasons: []ReasonCode{ReasonDependencyDeleted}, Relations: []string{"policy_scope"}, Distance: 1}}
+	impact.Objectives = []AffectedFact{{Revision: objective, Reasons: []ReasonCode{ReasonDependencyDeleted}, Relations: []string{"program_objective"}, Distance: 2}}
+
+	request := adapterRequest(impact, fixture.Mappings)
+	first, err := AdaptCompatibility(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Complete || len(first.Issues) != 0 {
+		t.Fatalf("result complete=%v issues=%#v", first.Complete, first.Issues)
+	}
+	if first.ImpactSource.ContentDigest != root.Canonical().ContentDigest || first.ImpactSource.RevisionID != root.RevisionID() {
+		t.Fatalf("impact source provenance changed: %#v", first.ImpactSource)
+	}
+	if first.MappingSet != request.MappingSet {
+		t.Fatalf("mapping set provenance = %#v, want %#v", first.MappingSet, request.MappingSet)
+	}
+
+	gotTargets := make([]adapterExpectedTarget, 0, len(first.Targets))
+	for _, target := range first.Targets {
+		actions := make([]string, 0, len(target.Actions))
+		for _, action := range target.Actions {
+			actions = append(actions, action.ActionID)
+		}
+		gotTargets = append(gotTargets, adapterExpectedTarget{Kind: target.Kind, ID: target.ID, ActionIDs: actions})
+		for _, source := range target.Sources {
+			if source.Revision.ContentDigest != compliance.ContentDigest(adapterDigest("a")) {
+				t.Fatalf("target %s source digest changed: %#v", target.ID, source.Revision)
+			}
+		}
+	}
+	if !reflect.DeepEqual(gotTargets, fixture.Expected) {
+		t.Fatalf("targets = %#v, want %#v", gotTargets, fixture.Expected)
+	}
+
+	// Replay with duplicate/reordered mapping input and reordered impact output.
+	replayedMappings := append([]CompatibilityMapping(nil), fixture.Mappings...)
+	for left, right := 0, len(replayedMappings)-1; left < right; left, right = left+1, right-1 {
+		replayedMappings[left], replayedMappings[right] = replayedMappings[right], replayedMappings[left]
+	}
+	replayedMappings = append(replayedMappings, replayedMappings[0])
+	replayedImpact := impact
+	replayedImpact.Programs[0].Reasons = []ReasonCode{ReasonDependencyDeleted, ReasonDependencyDeleted}
+	replayedImpact.Programs[0].Relations = []string{"policy_scope", "policy_scope"}
+	second, err := AdaptCompatibility(adapterRequest(replayedImpact, replayedMappings))
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := CanonicalAdapterBytes(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := CanonicalAdapterBytes(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(left) != string(right) {
+		t.Fatalf("stable replay changed:\nfirst=%s\nsecond=%s", left, right)
+	}
+}
+
+func TestCompatibilityAdapterDoesNotMapSimilarSubjectAtDifferentRevision(t *testing.T) {
+	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
+	mapping := adapterMapping(root, TargetPolicy, "policy-1", "review.complete")
+	mapping.Source.ContentDigest = compliance.ContentDigest(adapterDigest("b"))
+
+	result, err := AdaptCompatibility(adapterRequest(adapterImpact(t, root), []CompatibilityMapping{mapping}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Complete || len(result.Targets) != 0 || len(result.Issues) != 1 || result.Issues[0].Code != ReasonUnmappedTarget {
+		t.Fatalf("different revision was mapped: %#v", result)
+	}
+	if result.Issues[0].Source.RevisionID != root.RevisionID() || result.Issues[0].Source.ContentDigest != root.Canonical().ContentDigest {
+		t.Fatalf("unmapped issue lost exact source: %#v", result.Issues[0])
+	}
+}
+
+func TestCompatibilityAdapterRejectsAmbiguousTargetsWithoutGuessing(t *testing.T) {
+	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
+	mappings := []CompatibilityMapping{
+		adapterMapping(root, TargetPolicy, "policy-b", "review.complete"),
+		adapterMapping(root, TargetPolicy, "policy-a", "review.complete"),
+	}
+	result, err := AdaptCompatibility(adapterRequest(adapterImpact(t, root), mappings))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Targets) != 0 || len(result.Issues) != 1 || result.Issues[0].Code != ReasonAmbiguousTarget {
+		t.Fatalf("ambiguous target was guessed: %#v", result)
+	}
+	if !reflect.DeepEqual(result.Issues[0].CandidateIDs, []string{"policy-a", "policy-b"}) {
+		t.Fatalf("candidate ids = %v", result.Issues[0].CandidateIDs)
+	}
+}
+
+func TestCompatibilityAdapterMergesActionsForOneExplicitTarget(t *testing.T) {
+	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
+	mappings := []CompatibilityMapping{
+		adapterMapping(root, TargetPolicy, "policy-1", "review.complete"),
+		adapterMapping(root, TargetPolicy, "policy-1", "exception.renew"),
+	}
+	result, err := AdaptCompatibility(adapterRequest(adapterImpact(t, root), mappings))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Targets) != 1 || len(result.Targets[0].Actions) != 2 {
+		t.Fatalf("target actions = %#v", result.Targets)
+	}
+	if got := []string{result.Targets[0].Actions[0].ActionID, result.Targets[0].Actions[1].ActionID}; !reflect.DeepEqual(got, []string{"exception.renew", "review.complete"}) {
+		t.Fatalf("action ids = %v", got)
+	}
+}
+
+func TestCompatibilityAdapterRejectsTenantBoundaryInvalidMappingsAndLimits(t *testing.T) {
+	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
+	impact := adapterImpact(t, root)
+	mapping := adapterMapping(root, TargetPolicy, "policy-1", "review.complete")
+
+	tenantRequest := adapterRequest(impact, []CompatibilityMapping{mapping})
+	tenantRequest.Mappings[0].TenantID = "tenant-b"
+	if _, err := AdaptCompatibility(tenantRequest); !errors.Is(err, ErrAdapterTenantBoundary) {
+		t.Fatalf("tenant error = %v", err)
+	}
+
+	invalidRequest := adapterRequest(impact, []CompatibilityMapping{mapping})
+	invalidRequest.Mappings[0].ActionIDs = []string{"Review Complete"}
+	if _, err := AdaptCompatibility(invalidRequest); !errors.Is(err, ErrInvalidAdapterRequest) {
+		t.Fatalf("invalid action error = %v", err)
+	}
+
+	limitedRequest := adapterRequest(impact, []CompatibilityMapping{mapping, mapping})
+	limitedRequest.Limits.MaxMappings = 1
+	if _, err := AdaptCompatibility(limitedRequest); !errors.Is(err, ErrAdapterLimit) {
+		t.Fatalf("limit error = %v", err)
+	}
+}
+
+func TestCompatibilityAdapterCarriesIncompleteImpactReason(t *testing.T) {
+	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
+	impact := adapterImpact(t, root)
+	impact.Complete = false
+	impact.Issues = []Issue{{Code: ReasonDepthBudgetExceeded, Revision: root}}
+	result, err := AdaptCompatibility(adapterRequest(impact, []CompatibilityMapping{adapterMapping(root, TargetPolicy, "policy-1", "review.complete")}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Complete || len(result.Issues) != 1 || result.Issues[0].Code != ReasonImpactIncomplete || result.Issues[0].ImpactReason != ReasonDepthBudgetExceeded {
+		t.Fatalf("incomplete impact not preserved: %#v", result)
+	}
+}
+
+func readAdapterReplayFixture(t *testing.T) adapterReplayFixture {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join("testdata", "compatibility_adapter_replay.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture adapterReplayFixture
+	if err := json.Unmarshal(content, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
+func adapterImpact(t *testing.T, root complianceintegration.RevisionRef) Result {
+	t.Helper()
+	signal, err := complianceintegration.NewChangeSignal(complianceintegration.ChangeDeleted, root, nil, time.Unix(20, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Result{TenantID: "tenant-a", Signal: signal, Complete: true}
+}
+
+func adapterRequest(impact Result, mappings []CompatibilityMapping) AdapterRequest {
+	return AdapterRequest{
+		TenantID: "tenant-a", Impact: impact,
+		MappingSet: MappingSetRevision{RevisionID: "compatibility-map-r1", ContentDigest: compliance.ContentDigest(adapterDigest("c"))},
+		Mappings:   mappings, Limits: DefaultAdapterLimits(),
+	}
+}
+
+func adapterMapping(source complianceintegration.RevisionRef, kind CompatibilityTargetKind, id string, actions ...string) CompatibilityMapping {
+	return CompatibilityMapping{TenantID: "tenant-a", Source: provenance(source), TargetKind: kind, TargetID: id, ActionIDs: actions}
+}
+
+func adapterRevision(t *testing.T, kind complianceintegration.FactKind, id string, version uint64) complianceintegration.RevisionRef {
+	t.Helper()
+	ref, err := complianceintegration.AdaptRevisionRef("tenant-a", "test.domain", kind, compliance.RevisionRef{
+		ID: id, RevisionID: id + "-r" + string(rune('0'+version)), Version: version,
+		ContentDigest: compliance.ContentDigest(adapterDigest("a")), LastModified: time.Unix(int64(version), 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ref
+}
+
+func adapterDigest(character string) string {
+	return "sha256:" + strings.Repeat(character, 64)
+}

--- a/internal/complianceimpact/adapters_test.go
+++ b/internal/complianceimpact/adapters_test.go
@@ -3,9 +3,11 @@ package complianceimpact
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -94,7 +96,7 @@ func TestCompatibilityAdapterFixtureStableReplayAndAllDestinationSlices(t *testi
 
 func TestCompatibilityAdapterDoesNotMapSimilarSubjectAtDifferentRevision(t *testing.T) {
 	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
-	mapping := adapterMapping(root, TargetPolicy, "policy-1", "review.complete")
+	mapping := adapterMapping(root, "policy-1", "review.complete")
 	mapping.Source.ContentDigest = compliance.ContentDigest(adapterDigest("b"))
 
 	result, err := AdaptCompatibility(adapterRequest(adapterImpact(t, root), []CompatibilityMapping{mapping}))
@@ -112,8 +114,8 @@ func TestCompatibilityAdapterDoesNotMapSimilarSubjectAtDifferentRevision(t *test
 func TestCompatibilityAdapterRejectsAmbiguousTargetsWithoutGuessing(t *testing.T) {
 	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
 	mappings := []CompatibilityMapping{
-		adapterMapping(root, TargetPolicy, "policy-b", "review.complete"),
-		adapterMapping(root, TargetPolicy, "policy-a", "review.complete"),
+		adapterMapping(root, "policy-b", "review.complete"),
+		adapterMapping(root, "policy-a", "review.complete"),
 	}
 	result, err := AdaptCompatibility(adapterRequest(adapterImpact(t, root), mappings))
 	if err != nil {
@@ -130,8 +132,8 @@ func TestCompatibilityAdapterRejectsAmbiguousTargetsWithoutGuessing(t *testing.T
 func TestCompatibilityAdapterMergesActionsForOneExplicitTarget(t *testing.T) {
 	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
 	mappings := []CompatibilityMapping{
-		adapterMapping(root, TargetPolicy, "policy-1", "review.complete"),
-		adapterMapping(root, TargetPolicy, "policy-1", "exception.renew"),
+		adapterMapping(root, "policy-1", "review.complete"),
+		adapterMapping(root, "policy-1", "exception.renew"),
 	}
 	result, err := AdaptCompatibility(adapterRequest(adapterImpact(t, root), mappings))
 	if err != nil {
@@ -148,7 +150,7 @@ func TestCompatibilityAdapterMergesActionsForOneExplicitTarget(t *testing.T) {
 func TestCompatibilityAdapterRejectsTenantBoundaryInvalidMappingsAndLimits(t *testing.T) {
 	root := adapterRevision(t, complianceintegration.FactPolicy, "policy-source", 1)
 	impact := adapterImpact(t, root)
-	mapping := adapterMapping(root, TargetPolicy, "policy-1", "review.complete")
+	mapping := adapterMapping(root, "policy-1", "review.complete")
 
 	tenantRequest := adapterRequest(impact, []CompatibilityMapping{mapping})
 	tenantRequest.Mappings[0].TenantID = "tenant-b"
@@ -174,7 +176,7 @@ func TestCompatibilityAdapterCarriesIncompleteImpactReason(t *testing.T) {
 	impact := adapterImpact(t, root)
 	impact.Complete = false
 	impact.Issues = []Issue{{Code: ReasonDepthBudgetExceeded, Revision: root}}
-	result, err := AdaptCompatibility(adapterRequest(impact, []CompatibilityMapping{adapterMapping(root, TargetPolicy, "policy-1", "review.complete")}))
+	result, err := AdaptCompatibility(adapterRequest(impact, []CompatibilityMapping{adapterMapping(root, "policy-1", "review.complete")}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,15 +215,19 @@ func adapterRequest(impact Result, mappings []CompatibilityMapping) AdapterReque
 	}
 }
 
-func adapterMapping(source complianceintegration.RevisionRef, kind CompatibilityTargetKind, id string, actions ...string) CompatibilityMapping {
-	return CompatibilityMapping{TenantID: "tenant-a", Source: provenance(source), TargetKind: kind, TargetID: id, ActionIDs: actions}
+func adapterMapping(source complianceintegration.RevisionRef, id string, actions ...string) CompatibilityMapping {
+	return CompatibilityMapping{TenantID: "tenant-a", Source: provenance(source), TargetKind: TargetPolicy, TargetID: id, ActionIDs: actions}
 }
 
 func adapterRevision(t *testing.T, kind complianceintegration.FactKind, id string, version uint64) complianceintegration.RevisionRef {
 	t.Helper()
+	if version > math.MaxInt64 {
+		t.Fatalf("version %d exceeds test timestamp range", version)
+	}
+	seconds := int64(version) // #nosec G115 -- bounded by MaxInt64 above.
 	ref, err := complianceintegration.AdaptRevisionRef("tenant-a", "test.domain", kind, compliance.RevisionRef{
-		ID: id, RevisionID: id + "-r" + string(rune('0'+version)), Version: version,
-		ContentDigest: compliance.ContentDigest(adapterDigest("a")), LastModified: time.Unix(int64(version), 0),
+		ID: id, RevisionID: id + "-r" + strconv.FormatUint(version, 10), Version: version,
+		ContentDigest: compliance.ContentDigest(adapterDigest("a")), LastModified: time.Unix(seconds, 0),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/complianceimpact/analyzer.go
+++ b/internal/complianceimpact/analyzer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/writer/cerebro/internal/compliance"
@@ -22,7 +23,8 @@ func NewAnalyzer(graph ports.ComplianceImpactGraph, limits Limits) (*Analyzer, e
 	if graph == nil {
 		return nil, fmt.Errorf("%w: graph is required", ErrInvalidGraph)
 	}
-	if limits.MaxNodes == 0 || limits.MaxEdges == 0 || limits.MaxDepth == 0 || limits.PageSize == 0 {
+	if limits.MaxNodes == 0 || limits.MaxEdges == 0 || limits.MaxDepth == 0 || limits.PageSize == 0 ||
+		limits.MaxNodes > math.MaxInt32 || limits.PageSize > math.MaxInt32 {
 		return nil, ErrInvalidLimits
 	}
 	return &Analyzer{graph: graph, limits: limits}, nil
@@ -96,7 +98,8 @@ func (a *Analyzer) Analyze(ctx context.Context, signal complianceintegration.Cha
 				}
 				continue
 			}
-			if uint32(len(visited)) >= a.limits.MaxNodes {
+			// #nosec G115 -- NewAnalyzer bounds MaxNodes to MaxInt32.
+			if len(visited) >= int(a.limits.MaxNodes) {
 				result.Complete = false
 				result.Issues = append(result.Issues, Issue{Code: ReasonNodeBudgetExceeded, Revision: current.fact.Revision(), Related: ref})
 				continue
@@ -181,7 +184,8 @@ func (a *Analyzer) listDependents(ctx context.Context, tenantID string, current 
 		if err != nil {
 			return nil, 0, nil, false, err
 		}
-		if uint32(len(page.Dependents)) > limit {
+		// #nosec G115 -- NewAnalyzer bounds PageSize, and limit cannot exceed it.
+		if len(page.Dependents) > int(limit) {
 			return nil, 0, nil, false, fmt.Errorf("%w: dependent page exceeds requested limit", ErrInvalidGraph)
 		}
 		for _, rawRef := range page.Dependents {
@@ -397,7 +401,7 @@ func adaptPortRevision(ref ports.ComplianceImpactRevisionRef) (complianceintegra
 		LastModified:  ref.LastModified,
 	})
 	if err != nil {
-		return complianceintegration.RevisionRef{}, fmt.Errorf("%w: invalid stored revision: %v", ErrInvalidGraph, err)
+		return complianceintegration.RevisionRef{}, fmt.Errorf("%w: invalid stored revision: %w", ErrInvalidGraph, err)
 	}
 	return result, nil
 }
@@ -411,17 +415,17 @@ func adaptPortFact(raw ports.ComplianceImpactDomainFact) (complianceintegration.
 	for index, rawDependency := range raw.Dependencies {
 		dependencyRevision, err := adaptPortRevision(rawDependency.Revision)
 		if err != nil {
-			return complianceintegration.DomainFact{}, fmt.Errorf("%w: dependency[%d]: %v", ErrInvalidGraph, index, err)
+			return complianceintegration.DomainFact{}, fmt.Errorf("%w: dependency[%d]: %w", ErrInvalidGraph, index, err)
 		}
 		dependency, err := complianceintegration.NewDependencyRef(dependencyRevision, rawDependency.Relation)
 		if err != nil {
-			return complianceintegration.DomainFact{}, fmt.Errorf("%w: dependency[%d]: %v", ErrInvalidGraph, index, err)
+			return complianceintegration.DomainFact{}, fmt.Errorf("%w: dependency[%d]: %w", ErrInvalidGraph, index, err)
 		}
 		dependencies = append(dependencies, dependency)
 	}
 	fact, err := complianceintegration.NewDomainFact(revision, dependencies)
 	if err != nil {
-		return complianceintegration.DomainFact{}, fmt.Errorf("%w: stored fact: %v", ErrInvalidGraph, err)
+		return complianceintegration.DomainFact{}, fmt.Errorf("%w: stored fact: %w", ErrInvalidGraph, err)
 	}
 	return fact, nil
 }

--- a/internal/complianceimpact/analyzer.go
+++ b/internal/complianceimpact/analyzer.go
@@ -1,0 +1,427 @@
+package complianceimpact
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/complianceintegration"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// Analyzer traverses reverse dependency edges with hard tenant and budget
+// boundaries.
+type Analyzer struct {
+	graph  ports.ComplianceImpactGraph
+	limits Limits
+}
+
+func NewAnalyzer(graph ports.ComplianceImpactGraph, limits Limits) (*Analyzer, error) {
+	if graph == nil {
+		return nil, fmt.Errorf("%w: graph is required", ErrInvalidGraph)
+	}
+	if limits.MaxNodes == 0 || limits.MaxEdges == 0 || limits.MaxDepth == 0 || limits.PageSize == 0 {
+		return nil, ErrInvalidLimits
+	}
+	return &Analyzer{graph: graph, limits: limits}, nil
+}
+
+type traversalNode struct {
+	fact      complianceintegration.DomainFact
+	distance  uint32
+	ancestors map[string]struct{}
+}
+
+type accumulatedFact struct {
+	revision  complianceintegration.RevisionRef
+	distance  uint32
+	reasons   map[ReasonCode]struct{}
+	relations map[string]struct{}
+}
+
+// Analyze returns a deterministic impact set. Missing exact revisions and any
+// tenant boundary violation are hard errors with no partial result.
+func (a *Analyzer) Analyze(ctx context.Context, signal complianceintegration.ChangeSignal) (Result, error) {
+	rootRef := signal.Revision()
+	tenantID := rootRef.TenantID()
+	root, err := a.getFact(ctx, tenantID, rootRef)
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{TenantID: tenantID, Signal: signal, Complete: true}
+	visited := map[string]struct{}{rootRef.ExactKey(): {}}
+	queue := []traversalNode{{fact: root, ancestors: map[string]struct{}{rootRef.ExactKey(): {}}}}
+	affected := make(map[string]*accumulatedFact)
+	if isReportedKind(rootRef.Kind()) {
+		addAffected(affected, rootRef, 0, directReason(signal.Kind()), "")
+	}
+	if isInvalidatable(rootRef.Kind()) && invalidationReason(signal.Kind()) != "" {
+		result.Invalidations = append(result.Invalidations, Invalidation{Revision: rootRef, Reason: directReason(signal.Kind())})
+	}
+	var traversedEdges uint32
+	for len(queue) != 0 {
+		if traversedEdges >= a.limits.MaxEdges && len(queue) != 0 {
+			result.Complete = false
+			result.Issues = append(result.Issues, Issue{Code: ReasonEdgeBudgetExceeded})
+			break
+		}
+		current := queue[0]
+		queue = queue[1:]
+		dependents, edgeCount, issues, complete, err := a.listDependents(ctx, tenantID, current, a.limits.MaxEdges-traversedEdges)
+		if err != nil {
+			return Result{}, err
+		}
+		traversedEdges += edgeCount
+		result.Issues = append(result.Issues, issues...)
+		result.Complete = result.Complete && complete
+		for _, dependent := range dependents {
+			relations, err := explicitRelations(dependent.fact, current.fact.Revision())
+			if err != nil {
+				return Result{}, err
+			}
+			ref := dependent.fact.Revision()
+			if _, cyclic := current.ancestors[ref.ExactKey()]; cyclic {
+				for _, relation := range relations {
+					addAffected(affected, ref, dependent.distance, dependencyReason(signal.Kind()), relation)
+				}
+				result.Complete = false
+				result.Issues = append(result.Issues, Issue{Code: ReasonCycleDetected, Revision: current.fact.Revision(), Related: ref})
+				continue
+			}
+			if _, seen := visited[ref.ExactKey()]; seen {
+				for _, relation := range relations {
+					addAffected(affected, ref, dependent.distance, dependencyReason(signal.Kind()), relation)
+				}
+				continue
+			}
+			if uint32(len(visited)) >= a.limits.MaxNodes {
+				result.Complete = false
+				result.Issues = append(result.Issues, Issue{Code: ReasonNodeBudgetExceeded, Revision: current.fact.Revision(), Related: ref})
+				continue
+			}
+			for _, relation := range relations {
+				addAffected(affected, ref, dependent.distance, dependencyReason(signal.Kind()), relation)
+			}
+			visited[ref.ExactKey()] = struct{}{}
+			if isInvalidatable(ref.Kind()) && invalidationReason(signal.Kind()) != "" {
+				result.Invalidations = append(result.Invalidations, Invalidation{Revision: ref, Reason: invalidationReason(signal.Kind())})
+			}
+			ancestors := copySet(current.ancestors)
+			ancestors[ref.ExactKey()] = struct{}{}
+			queue = append(queue, traversalNode{fact: dependent.fact, distance: dependent.distance, ancestors: ancestors})
+		}
+	}
+	materializeResult(&result, affected)
+	canonicalizeResult(&result)
+	return result, nil
+}
+
+func (a *Analyzer) getFact(ctx context.Context, tenantID string, ref complianceintegration.RevisionRef) (complianceintegration.DomainFact, error) {
+	if ref.TenantID() != tenantID {
+		return complianceintegration.DomainFact{}, fmt.Errorf("%w: requested revision belongs to another tenant", ErrTenantBoundary)
+	}
+	rawFact, err := a.graph.GetComplianceImpactFact(ctx, tenantID, portRevision(ref))
+	if err != nil {
+		if errors.Is(err, ports.ErrComplianceImpactRevisionNotFound) {
+			return complianceintegration.DomainFact{}, fmt.Errorf("%w: %s/%s@%s", ErrRevisionMissing, ref.Domain(), ref.ID(), ref.RevisionID())
+		}
+		return complianceintegration.DomainFact{}, err
+	}
+	fact, err := adaptPortFact(rawFact)
+	if err != nil {
+		return complianceintegration.DomainFact{}, err
+	}
+	if fact.Revision().TenantID() != tenantID {
+		return complianceintegration.DomainFact{}, fmt.Errorf("%w: store returned another tenant", ErrTenantBoundary)
+	}
+	if !fact.Revision().Equal(ref) {
+		return complianceintegration.DomainFact{}, fmt.Errorf("%w: store returned a different exact revision", ErrInvalidGraph)
+	}
+	return fact, nil
+}
+
+type dependentNode struct {
+	fact     complianceintegration.DomainFact
+	distance uint32
+}
+
+func (a *Analyzer) listDependents(ctx context.Context, tenantID string, current traversalNode, edgeBudget uint32) ([]dependentNode, uint32, []Issue, bool, error) {
+	if current.distance >= a.limits.MaxDepth {
+		page, err := a.graph.ListComplianceImpactDependents(ctx, ports.ComplianceImpactDependentRequest{TenantID: tenantID, Dependency: portRevision(current.fact.Revision()), Limit: 1})
+		if err != nil {
+			return nil, 0, nil, false, err
+		}
+		if len(page.Dependents) > 1 {
+			return nil, 0, nil, false, fmt.Errorf("%w: dependent page exceeds requested limit", ErrInvalidGraph)
+		}
+		if len(page.Dependents) == 0 {
+			return nil, 0, nil, true, nil
+		}
+		related, err := adaptPortRevision(page.Dependents[0])
+		if err != nil {
+			return nil, 0, nil, false, err
+		}
+		if related.TenantID() != tenantID {
+			return nil, 0, nil, false, fmt.Errorf("%w: dependent reference belongs to another tenant", ErrTenantBoundary)
+		}
+		return nil, 1, []Issue{{Code: ReasonDepthBudgetExceeded, Revision: current.fact.Revision(), Related: related}}, false, nil
+	}
+	var result []dependentNode
+	var edges uint32
+	cursor := ""
+	for {
+		remaining := edgeBudget - edges
+		if remaining == 0 {
+			return result, edges, []Issue{{Code: ReasonEdgeBudgetExceeded, Revision: current.fact.Revision()}}, false, nil
+		}
+		limit := min(a.limits.PageSize, remaining)
+		page, err := a.graph.ListComplianceImpactDependents(ctx, ports.ComplianceImpactDependentRequest{TenantID: tenantID, Dependency: portRevision(current.fact.Revision()), AfterCursor: cursor, Limit: limit})
+		if err != nil {
+			return nil, 0, nil, false, err
+		}
+		if uint32(len(page.Dependents)) > limit {
+			return nil, 0, nil, false, fmt.Errorf("%w: dependent page exceeds requested limit", ErrInvalidGraph)
+		}
+		for _, rawRef := range page.Dependents {
+			ref, err := adaptPortRevision(rawRef)
+			if err != nil {
+				return nil, 0, nil, false, err
+			}
+			if ref.TenantID() != tenantID {
+				return nil, 0, nil, false, fmt.Errorf("%w: dependent reference belongs to another tenant", ErrTenantBoundary)
+			}
+			fact, err := a.getFact(ctx, tenantID, ref)
+			if err != nil {
+				return nil, 0, nil, false, err
+			}
+			result = append(result, dependentNode{fact: fact, distance: current.distance + 1})
+			edges++
+			if edges == edgeBudget && !page.Complete {
+				return result, edges, []Issue{{Code: ReasonEdgeBudgetExceeded, Revision: current.fact.Revision()}}, false, nil
+			}
+		}
+		if page.Complete {
+			break
+		}
+		if page.NextCursor == "" || page.NextCursor == cursor {
+			return nil, 0, nil, false, fmt.Errorf("%w: dependent cursor did not advance", ErrInvalidGraph)
+		}
+		cursor = page.NextCursor
+	}
+	return result, edges, nil, true, nil
+}
+
+func explicitRelations(fact complianceintegration.DomainFact, dependency complianceintegration.RevisionRef) ([]string, error) {
+	relations := make([]string, 0, 1)
+	for _, candidate := range fact.Dependencies() {
+		if candidate.Revision().Equal(dependency) {
+			relations = append(relations, candidate.Relation())
+		}
+	}
+	if len(relations) == 0 {
+		return nil, fmt.Errorf("%w: reverse edge is not backed by an explicit dependency", ErrInvalidGraph)
+	}
+	sort.Strings(relations)
+	return relations, nil
+}
+
+func addAffected(values map[string]*accumulatedFact, ref complianceintegration.RevisionRef, distance uint32, reason ReasonCode, relation string) {
+	if !isReportedKind(ref.Kind()) {
+		return
+	}
+	value, ok := values[ref.ExactKey()]
+	if !ok {
+		value = &accumulatedFact{revision: ref, distance: distance, reasons: map[ReasonCode]struct{}{}, relations: map[string]struct{}{}}
+		values[ref.ExactKey()] = value
+	}
+	if distance < value.distance {
+		value.distance = distance
+	}
+	if reason != "" {
+		value.reasons[reason] = struct{}{}
+	}
+	if relation != "" {
+		value.relations[relation] = struct{}{}
+	}
+}
+
+func directReason(kind complianceintegration.ChangeKind) ReasonCode {
+	switch kind {
+	case complianceintegration.ChangeDeleted:
+		return ReasonRevisionDeleted
+	case complianceintegration.ChangeRevoked:
+		return ReasonRevisionRevoked
+	default:
+		return ReasonRevisionChanged
+	}
+}
+
+func dependencyReason(kind complianceintegration.ChangeKind) ReasonCode {
+	switch kind {
+	case complianceintegration.ChangeDeleted:
+		return ReasonDependencyDeleted
+	case complianceintegration.ChangeRevoked:
+		return ReasonDependencyRevoked
+	default:
+		return ReasonDependencyChanged
+	}
+}
+
+func invalidationReason(kind complianceintegration.ChangeKind) ReasonCode {
+	switch kind {
+	case complianceintegration.ChangeDeleted:
+		return ReasonDependencyDeleted
+	case complianceintegration.ChangeRevoked:
+		return ReasonDependencyRevoked
+	default:
+		return ""
+	}
+}
+
+func isReportedKind(kind complianceintegration.FactKind) bool {
+	switch kind {
+	case complianceintegration.FactProgram, complianceintegration.FactAssessmentPlan,
+		complianceintegration.FactObjective, complianceintegration.FactAuditPackage,
+		complianceintegration.FactWorkItem:
+		return true
+	default:
+		return false
+	}
+}
+
+func isInvalidatable(kind complianceintegration.FactKind) bool {
+	return kind == complianceintegration.FactClaim || kind == complianceintegration.FactProjection
+}
+
+func copySet(source map[string]struct{}) map[string]struct{} {
+	result := make(map[string]struct{}, len(source)+1)
+	for key := range source {
+		result[key] = struct{}{}
+	}
+	return result
+}
+
+func materializeResult(result *Result, values map[string]*accumulatedFact) {
+	for _, value := range values {
+		affected := AffectedFact{Revision: value.revision, Distance: value.distance}
+		for reason := range value.reasons {
+			affected.Reasons = append(affected.Reasons, reason)
+		}
+		for relation := range value.relations {
+			affected.Relations = append(affected.Relations, relation)
+		}
+		sort.Slice(affected.Reasons, func(i, j int) bool { return affected.Reasons[i] < affected.Reasons[j] })
+		sort.Strings(affected.Relations)
+		switch value.revision.Kind() {
+		case complianceintegration.FactProgram:
+			result.Programs = append(result.Programs, affected)
+		case complianceintegration.FactAssessmentPlan:
+			result.Plans = append(result.Plans, affected)
+		case complianceintegration.FactObjective:
+			result.Objectives = append(result.Objectives, affected)
+		case complianceintegration.FactAuditPackage:
+			result.Packages = append(result.Packages, affected)
+		case complianceintegration.FactWorkItem:
+			result.WorkItems = append(result.WorkItems, affected)
+		}
+	}
+}
+
+func canonicalizeResult(result *Result) {
+	sortAffected := func(values []AffectedFact) {
+		sort.Slice(values, func(i, j int) bool { return values[i].Revision.ExactKey() < values[j].Revision.ExactKey() })
+	}
+	sortAffected(result.Programs)
+	sortAffected(result.Plans)
+	sortAffected(result.Objectives)
+	sortAffected(result.Packages)
+	sortAffected(result.WorkItems)
+	sort.Slice(result.Invalidations, func(i, j int) bool {
+		left := result.Invalidations[i].Revision.ExactKey() + "\x00" + string(result.Invalidations[i].Reason)
+		right := result.Invalidations[j].Revision.ExactKey() + "\x00" + string(result.Invalidations[j].Reason)
+		return left < right
+	})
+	result.Invalidations = deduplicateInvalidations(result.Invalidations)
+	sort.Slice(result.Issues, func(i, j int) bool {
+		left := string(result.Issues[i].Code) + "\x00" + result.Issues[i].Revision.ExactKey() + "\x00" + result.Issues[i].Related.ExactKey()
+		right := string(result.Issues[j].Code) + "\x00" + result.Issues[j].Revision.ExactKey() + "\x00" + result.Issues[j].Related.ExactKey()
+		return left < right
+	})
+	result.Issues = deduplicateIssues(result.Issues)
+}
+
+func deduplicateInvalidations(values []Invalidation) []Invalidation {
+	result := make([]Invalidation, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1].Revision.Equal(value.Revision) && result[len(result)-1].Reason == value.Reason {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func deduplicateIssues(values []Issue) []Issue {
+	result := make([]Issue, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1].Code == value.Code && result[len(result)-1].Revision.Equal(value.Revision) && result[len(result)-1].Related.Equal(value.Related) {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func portRevision(ref complianceintegration.RevisionRef) ports.ComplianceImpactRevisionRef {
+	canonical := ref.Canonical()
+	return ports.ComplianceImpactRevisionRef{
+		TenantID:      ref.TenantID(),
+		Domain:        ref.Domain(),
+		Kind:          string(ref.Kind()),
+		ID:            canonical.ID,
+		RevisionID:    canonical.RevisionID,
+		Version:       canonical.Version,
+		ContentDigest: string(canonical.ContentDigest),
+		LastModified:  canonical.LastModified,
+	}
+}
+
+func adaptPortRevision(ref ports.ComplianceImpactRevisionRef) (complianceintegration.RevisionRef, error) {
+	result, err := complianceintegration.AdaptRevisionRef(ref.TenantID, ref.Domain, complianceintegration.FactKind(ref.Kind), compliance.RevisionRef{
+		ID:            ref.ID,
+		RevisionID:    ref.RevisionID,
+		Version:       ref.Version,
+		ContentDigest: compliance.ContentDigest(ref.ContentDigest),
+		LastModified:  ref.LastModified,
+	})
+	if err != nil {
+		return complianceintegration.RevisionRef{}, fmt.Errorf("%w: invalid stored revision: %v", ErrInvalidGraph, err)
+	}
+	return result, nil
+}
+
+func adaptPortFact(raw ports.ComplianceImpactDomainFact) (complianceintegration.DomainFact, error) {
+	revision, err := adaptPortRevision(raw.Revision)
+	if err != nil {
+		return complianceintegration.DomainFact{}, err
+	}
+	dependencies := make([]complianceintegration.DependencyRef, 0, len(raw.Dependencies))
+	for index, rawDependency := range raw.Dependencies {
+		dependencyRevision, err := adaptPortRevision(rawDependency.Revision)
+		if err != nil {
+			return complianceintegration.DomainFact{}, fmt.Errorf("%w: dependency[%d]: %v", ErrInvalidGraph, index, err)
+		}
+		dependency, err := complianceintegration.NewDependencyRef(dependencyRevision, rawDependency.Relation)
+		if err != nil {
+			return complianceintegration.DomainFact{}, fmt.Errorf("%w: dependency[%d]: %v", ErrInvalidGraph, index, err)
+		}
+		dependencies = append(dependencies, dependency)
+	}
+	fact, err := complianceintegration.NewDomainFact(revision, dependencies)
+	if err != nil {
+		return complianceintegration.DomainFact{}, fmt.Errorf("%w: stored fact: %v", ErrInvalidGraph, err)
+	}
+	return fact, nil
+}

--- a/internal/complianceimpact/analyzer_test.go
+++ b/internal/complianceimpact/analyzer_test.go
@@ -1,0 +1,335 @@
+package complianceimpact
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/complianceintegration"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestAnalyzeReportsAllTargetClassesAndDeletionInvalidations(t *testing.T) {
+	policy := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	claim := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactClaim, "claim", 1), edge(t, policy, "policy_source"))
+	objective := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactObjective, "objective", 1), edge(t, claim.Revision(), "claim_source"))
+	plan := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactAssessmentPlan, "plan", 1), edge(t, objective.Revision(), "objective_input"))
+	program := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactProgram, "program", 1), edge(t, policy, "policy_scope"))
+	pack := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactAuditPackage, "package", 1), edge(t, plan.Revision(), "plan_result"))
+	work := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactWorkItem, "work", 1), edge(t, objective.Revision(), "objective_gap"))
+	projection := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactProjection, "projection", 1), edge(t, claim.Revision(), "claim_projection"))
+	root := impactFact(t, policy)
+	graph := newFakeGraph(root, claim, objective, plan, program, pack, work, projection)
+	result := analyzeSignal(t, graph, policy, complianceintegration.ChangeDeleted, DefaultLimits())
+
+	if !result.Complete || len(result.Issues) != 0 {
+		t.Fatalf("result complete=%v issues=%v", result.Complete, result.Issues)
+	}
+	for label, count := range map[string]int{"programs": len(result.Programs), "plans": len(result.Plans), "objectives": len(result.Objectives), "packages": len(result.Packages), "work": len(result.WorkItems)} {
+		if count != 1 {
+			t.Fatalf("%s count = %d, want 1", label, count)
+		}
+	}
+	if got := result.Packages[0].Reasons; !reflect.DeepEqual(got, []ReasonCode{ReasonDependencyDeleted}) {
+		t.Fatalf("package reasons = %v", got)
+	}
+	if result.Packages[0].Distance != 4 {
+		t.Fatalf("package distance = %d, want 4", result.Packages[0].Distance)
+	}
+	if got := invalidatedIDs(result.Invalidations); !reflect.DeepEqual(got, []string{"claim", "projection"}) {
+		t.Fatalf("invalidations = %v, want claim and projection", got)
+	}
+}
+
+func TestAnalyzeUsesRevocationAndUpdateReasonCodes(t *testing.T) {
+	policy := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	program := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactProgram, "program", 1), edge(t, policy, "policy_scope"))
+	graph := newFakeGraph(impactFact(t, policy), program)
+	revoked := analyzeSignal(t, graph, policy, complianceintegration.ChangeRevoked, DefaultLimits())
+	if !reflect.DeepEqual(revoked.Programs[0].Reasons, []ReasonCode{ReasonDependencyRevoked}) {
+		t.Fatalf("revoked reasons = %v", revoked.Programs[0].Reasons)
+	}
+
+	replacement := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 2)
+	signal, err := complianceintegration.NewChangeSignal(complianceintegration.ChangeUpdated, policy, &replacement, time.Unix(10, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	analyzer, err := NewAnalyzer(graph, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := analyzer.Analyze(context.Background(), signal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(updated.Programs[0].Reasons, []ReasonCode{ReasonDependencyChanged}) {
+		t.Fatalf("updated reasons = %v", updated.Programs[0].Reasons)
+	}
+}
+
+func TestAnalyzeMissingRevisionIsHardError(t *testing.T) {
+	root := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	missing := impactRevision(t, "tenant-a", complianceintegration.FactProgram, "program", 1)
+	graph := newFakeGraph(impactFact(t, root))
+	graph.dependents[root.ExactKey()] = []ports.ComplianceImpactRevisionRef{portRef(missing)}
+
+	result, err := analyze(t, graph, root, complianceintegration.ChangeDeleted, DefaultLimits())
+	if !errors.Is(err, ErrRevisionMissing) {
+		t.Fatalf("error = %v, want ErrRevisionMissing", err)
+	}
+	if !reflect.DeepEqual(result, Result{}) {
+		t.Fatalf("returned partial best-effort result: %#v", result)
+	}
+}
+
+func TestAnalyzeRejectsAlteredExactRevisionMetadata(t *testing.T) {
+	root := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	graph := newFakeGraph(impactFact(t, root))
+	raw := graph.facts[root.ExactKey()]
+	raw.Revision.ContentDigest = "sha256:" + strings.Repeat("b", 64)
+	graph.facts[root.ExactKey()] = raw
+
+	if _, err := analyze(t, graph, root, complianceintegration.ChangeDeleted, DefaultLimits()); !errors.Is(err, ErrInvalidGraph) {
+		t.Fatalf("error = %v, want ErrInvalidGraph", err)
+	}
+}
+
+func TestAnalyzeRejectsCrossTenantAndUnbackedEdges(t *testing.T) {
+	root := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	foreign := impactRevision(t, "tenant-b", complianceintegration.FactProgram, "program", 1)
+	graph := newFakeGraph(impactFact(t, root), impactFact(t, foreign))
+	graph.dependents[root.ExactKey()] = []ports.ComplianceImpactRevisionRef{portRef(foreign)}
+	if _, err := analyze(t, graph, root, complianceintegration.ChangeUpdated, DefaultLimits()); !errors.Is(err, ErrTenantBoundary) {
+		t.Fatalf("cross-tenant error = %v", err)
+	}
+
+	program := impactRevision(t, "tenant-a", complianceintegration.FactProgram, "program", 1)
+	graph = newFakeGraph(impactFact(t, root), impactFact(t, program))
+	graph.dependents[root.ExactKey()] = []ports.ComplianceImpactRevisionRef{portRef(program)}
+	if _, err := analyze(t, graph, root, complianceintegration.ChangeUpdated, DefaultLimits()); !errors.Is(err, ErrInvalidGraph) {
+		t.Fatalf("unbacked edge error = %v", err)
+	}
+}
+
+func TestAnalyzeDetectsCyclesWithoutConfusingConvergentPaths(t *testing.T) {
+	policy := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	projectionRef := impactRevision(t, "tenant-a", complianceintegration.FactProjection, "projection", 1)
+	policyFact := impactFact(t, policy, edge(t, projectionRef, "projection_source"))
+	projection := impactFact(t, projectionRef, edge(t, policy, "policy_source"))
+	cycle := analyzeSignal(t, newFakeGraph(policyFact, projection), policy, complianceintegration.ChangeUpdated, DefaultLimits())
+	if cycle.Complete || len(cycle.Issues) != 1 || cycle.Issues[0].Code != ReasonCycleDetected {
+		t.Fatalf("cycle result complete=%v issues=%v", cycle.Complete, cycle.Issues)
+	}
+
+	left := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactClaim, "left", 1), edge(t, policy, "left_source"))
+	right := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactClaim, "right", 1), edge(t, policy, "right_source"))
+	objective := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactObjective, "objective", 1), edge(t, left.Revision(), "left_claim"), edge(t, right.Revision(), "right_claim"))
+	convergent := analyzeSignal(t, newFakeGraph(impactFact(t, policy), left, right, objective), policy, complianceintegration.ChangeUpdated, DefaultLimits())
+	if !convergent.Complete || len(convergent.Issues) != 0 || len(convergent.Objectives) != 1 {
+		t.Fatalf("convergent graph misclassified: complete=%v issues=%v objectives=%d", convergent.Complete, convergent.Issues, len(convergent.Objectives))
+	}
+}
+
+func TestAnalyzeEnforcesNodeDepthAndGlobalEdgeBudgets(t *testing.T) {
+	root := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	objective := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactObjective, "objective", 1), edge(t, root, "policy_source"))
+	plan := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactAssessmentPlan, "plan", 1), edge(t, objective.Revision(), "objective_source"))
+	pack := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactAuditPackage, "package", 1), edge(t, plan.Revision(), "plan_source"))
+	graph := newFakeGraph(impactFact(t, root), objective, plan, pack)
+
+	nodeLimited := analyzeSignal(t, graph, root, complianceintegration.ChangeUpdated, Limits{MaxNodes: 2, MaxEdges: 10, MaxDepth: 10, PageSize: 2})
+	if nodeLimited.Complete || len(nodeLimited.Objectives) != 1 || len(nodeLimited.Plans) != 0 || !hasIssue(nodeLimited, ReasonNodeBudgetExceeded) {
+		t.Fatalf("node-limited result: %#v", nodeLimited)
+	}
+
+	depthLimited := analyzeSignal(t, graph, root, complianceintegration.ChangeUpdated, Limits{MaxNodes: 10, MaxEdges: 10, MaxDepth: 1, PageSize: 2})
+	if depthLimited.Complete || len(depthLimited.Objectives) != 1 || len(depthLimited.Plans) != 0 || !hasIssue(depthLimited, ReasonDepthBudgetExceeded) {
+		t.Fatalf("depth-limited result: %#v", depthLimited)
+	}
+
+	work := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactWorkItem, "work", 1), edge(t, objective.Revision(), "objective_work"))
+	graph = newFakeGraph(impactFact(t, root), objective, plan, work)
+	edgeLimited := analyzeSignal(t, graph, root, complianceintegration.ChangeUpdated, Limits{MaxNodes: 10, MaxEdges: 2, MaxDepth: 10, PageSize: 10})
+	if edgeLimited.Complete || !hasIssue(edgeLimited, ReasonEdgeBudgetExceeded) || len(edgeLimited.Plans)+len(edgeLimited.WorkItems) > 1 {
+		t.Fatalf("edge-limited result escaped global budget: %#v", edgeLimited)
+	}
+}
+
+func TestAnalyzePaginatesAndReturnsDeterministicOrdering(t *testing.T) {
+	root := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	programA := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactProgram, "a", 1), edge(t, root, "z_relation"), edge(t, root, "a_relation"))
+	programB := impactFact(t, impactRevision(t, "tenant-a", complianceintegration.FactProgram, "b", 1), edge(t, root, "policy_scope"))
+	graphA := newFakeGraph(impactFact(t, root), programB, programA)
+	graphB := newFakeGraph(impactFact(t, root), programA, programB)
+	limits := Limits{MaxNodes: 10, MaxEdges: 10, MaxDepth: 10, PageSize: 1}
+	left := analyzeSignal(t, graphA, root, complianceintegration.ChangeUpdated, limits)
+	right := analyzeSignal(t, graphB, root, complianceintegration.ChangeUpdated, limits)
+	if !reflect.DeepEqual(left.Programs, right.Programs) {
+		t.Fatalf("ordering changed with source order:\nleft=%#v\nright=%#v", left.Programs, right.Programs)
+	}
+	if got := left.Programs[0].Relations; !reflect.DeepEqual(got, []string{"a_relation", "z_relation"}) {
+		t.Fatalf("relations = %v", got)
+	}
+}
+
+func TestAnalyzerRejectsInvalidLimitsAndStalledCursor(t *testing.T) {
+	root := impactRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy", 1)
+	graph := newFakeGraph(impactFact(t, root))
+	if _, err := NewAnalyzer(graph, Limits{}); !errors.Is(err, ErrInvalidLimits) {
+		t.Fatalf("limits error = %v", err)
+	}
+	graph.stallCursor = true
+	graph.dependents[root.ExactKey()] = []ports.ComplianceImpactRevisionRef{portRef(root)}
+	if _, err := analyze(t, graph, root, complianceintegration.ChangeUpdated, Limits{MaxNodes: 10, MaxEdges: 10, MaxDepth: 10, PageSize: 1}); !errors.Is(err, ErrInvalidGraph) {
+		t.Fatalf("cursor error = %v", err)
+	}
+}
+
+type fakeGraph struct {
+	facts       map[string]ports.ComplianceImpactDomainFact
+	dependents  map[string][]ports.ComplianceImpactRevisionRef
+	stallCursor bool
+}
+
+func newFakeGraph(facts ...complianceintegration.DomainFact) *fakeGraph {
+	result := &fakeGraph{facts: map[string]ports.ComplianceImpactDomainFact{}, dependents: map[string][]ports.ComplianceImpactRevisionRef{}}
+	for _, fact := range facts {
+		result.facts[fact.Revision().ExactKey()] = portFact(fact)
+		for _, dependency := range fact.Dependencies() {
+			key := dependency.Revision().ExactKey()
+			result.dependents[key] = append(result.dependents[key], portRef(fact.Revision()))
+		}
+	}
+	for key := range result.dependents {
+		sort.Slice(result.dependents[key], func(i, j int) bool {
+			return result.dependents[key][i].ID < result.dependents[key][j].ID
+		})
+	}
+	return result
+}
+
+func (f *fakeGraph) GetComplianceImpactFact(_ context.Context, tenantID string, ref ports.ComplianceImpactRevisionRef) (ports.ComplianceImpactDomainFact, error) {
+	if tenantID != ref.TenantID {
+		return ports.ComplianceImpactDomainFact{}, ports.ErrComplianceImpactRevisionNotFound
+	}
+	fact, ok := f.facts[portKey(ref)]
+	if !ok {
+		return ports.ComplianceImpactDomainFact{}, ports.ErrComplianceImpactRevisionNotFound
+	}
+	return fact, nil
+}
+
+func (f *fakeGraph) ListComplianceImpactDependents(_ context.Context, request ports.ComplianceImpactDependentRequest) (ports.ComplianceImpactDependentPage, error) {
+	values := f.dependents[portKey(request.Dependency)]
+	start := 0
+	if request.AfterCursor != "" {
+		value, err := strconv.Atoi(request.AfterCursor)
+		if err != nil {
+			return ports.ComplianceImpactDependentPage{}, err
+		}
+		start = value
+	}
+	end := min(len(values), start+int(request.Limit))
+	page := ports.ComplianceImpactDependentPage{Dependents: append([]ports.ComplianceImpactRevisionRef(nil), values[start:end]...), Complete: end == len(values)}
+	if !page.Complete && !f.stallCursor {
+		page.NextCursor = strconv.Itoa(end)
+	}
+	return page, nil
+}
+
+func impactRevision(t *testing.T, tenant string, kind complianceintegration.FactKind, id string, version uint64) complianceintegration.RevisionRef {
+	t.Helper()
+	ref, err := complianceintegration.AdaptRevisionRef(tenant, "test.domain", kind, compliance.RevisionRef{
+		ID: id, RevisionID: id + "-r" + strconv.FormatUint(version, 10), Version: version,
+		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(int64(version), 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ref
+}
+
+func edge(t *testing.T, revision complianceintegration.RevisionRef, relation string) complianceintegration.DependencyRef {
+	t.Helper()
+	result, err := complianceintegration.NewDependencyRef(revision, relation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func impactFact(t *testing.T, revision complianceintegration.RevisionRef, dependencies ...complianceintegration.DependencyRef) complianceintegration.DomainFact {
+	t.Helper()
+	result, err := complianceintegration.NewDomainFact(revision, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func analyzeSignal(t *testing.T, graph ports.ComplianceImpactGraph, revision complianceintegration.RevisionRef, kind complianceintegration.ChangeKind, limits Limits) Result {
+	t.Helper()
+	result, err := analyze(t, graph, revision, kind, limits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func analyze(t *testing.T, graph ports.ComplianceImpactGraph, revision complianceintegration.RevisionRef, kind complianceintegration.ChangeKind, limits Limits) (Result, error) {
+	t.Helper()
+	signal, err := complianceintegration.NewChangeSignal(kind, revision, nil, time.Unix(10, 0))
+	if kind == complianceintegration.ChangeUpdated {
+		replacement := impactRevision(t, revision.TenantID(), revision.Kind(), revision.ID(), revision.Version()+1)
+		signal, err = complianceintegration.NewChangeSignal(kind, revision, &replacement, time.Unix(10, 0))
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	analyzer, err := NewAnalyzer(graph, limits)
+	if err != nil {
+		return Result{}, err
+	}
+	return analyzer.Analyze(context.Background(), signal)
+}
+
+func portRef(ref complianceintegration.RevisionRef) ports.ComplianceImpactRevisionRef {
+	return portRevision(ref)
+}
+
+func portFact(fact complianceintegration.DomainFact) ports.ComplianceImpactDomainFact {
+	result := ports.ComplianceImpactDomainFact{Revision: portRef(fact.Revision())}
+	for _, dependency := range fact.Dependencies() {
+		result.Dependencies = append(result.Dependencies, ports.ComplianceImpactDependencyRef{Revision: portRef(dependency.Revision()), Relation: dependency.Relation()})
+	}
+	return result
+}
+
+func portKey(ref ports.ComplianceImpactRevisionRef) string {
+	return ref.TenantID + "\x00" + ref.Domain + "\x00" + ref.Kind + "\x00" + ref.ID + "\x00" + ref.RevisionID + "\x00" + strconv.FormatUint(ref.Version, 10) + "\x00" + ref.ContentDigest + "\x00" + ref.LastModified.UTC().Format(time.RFC3339Nano)
+}
+
+func invalidatedIDs(values []Invalidation) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.Revision.ID())
+	}
+	sort.Strings(result)
+	return result
+}
+
+func hasIssue(result Result, code ReasonCode) bool {
+	for _, issue := range result.Issues {
+		if issue.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/complianceimpact/analyzer_test.go
+++ b/internal/complianceimpact/analyzer_test.go
@@ -3,6 +3,7 @@ package complianceimpact
 import (
 	"context"
 	"errors"
+	"math"
 	"reflect"
 	"sort"
 	"strconv"
@@ -246,9 +247,13 @@ func (f *fakeGraph) ListComplianceImpactDependents(_ context.Context, request po
 
 func impactRevision(t *testing.T, tenant string, kind complianceintegration.FactKind, id string, version uint64) complianceintegration.RevisionRef {
 	t.Helper()
+	if version > math.MaxInt64 {
+		t.Fatalf("version %d exceeds test timestamp range", version)
+	}
+	seconds := int64(version) // #nosec G115 -- bounded by MaxInt64 above.
 	ref, err := complianceintegration.AdaptRevisionRef(tenant, "test.domain", kind, compliance.RevisionRef{
 		ID: id, RevisionID: id + "-r" + strconv.FormatUint(version, 10), Version: version,
-		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(1, 0),
+		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(seconds, 0),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/complianceimpact/analyzer_test.go
+++ b/internal/complianceimpact/analyzer_test.go
@@ -248,7 +248,7 @@ func impactRevision(t *testing.T, tenant string, kind complianceintegration.Fact
 	t.Helper()
 	ref, err := complianceintegration.AdaptRevisionRef(tenant, "test.domain", kind, compliance.RevisionRef{
 		ID: id, RevisionID: id + "-r" + strconv.FormatUint(version, 10), Version: version,
-		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(int64(version), 0),
+		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(1, 0),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/complianceimpact/model.go
+++ b/internal/complianceimpact/model.go
@@ -1,0 +1,80 @@
+// Package complianceimpact computes bounded, explainable impact sets from exact
+// immutable domain facts.
+package complianceimpact
+
+import (
+	"errors"
+
+	"github.com/writer/cerebro/internal/complianceintegration"
+)
+
+var (
+	ErrInvalidLimits   = errors.New("invalid compliance impact limits")
+	ErrInvalidGraph    = errors.New("invalid compliance impact graph")
+	ErrRevisionMissing = errors.New("compliance impact revision missing")
+	ErrTenantBoundary  = errors.New("compliance impact tenant boundary violation")
+)
+
+// Limits bound every graph read and traversal dimension.
+type Limits struct {
+	MaxNodes uint32
+	MaxEdges uint32
+	MaxDepth uint32
+	PageSize uint32
+}
+
+func DefaultLimits() Limits {
+	return Limits{MaxNodes: 10000, MaxEdges: 50000, MaxDepth: 32, PageSize: 250}
+}
+
+type ReasonCode string
+
+const (
+	ReasonRevisionChanged     ReasonCode = "revision_changed"
+	ReasonRevisionDeleted     ReasonCode = "revision_deleted"
+	ReasonRevisionRevoked     ReasonCode = "revision_revoked"
+	ReasonDependencyChanged   ReasonCode = "dependency_revision_changed"
+	ReasonDependencyDeleted   ReasonCode = "dependency_deleted"
+	ReasonDependencyRevoked   ReasonCode = "dependency_revoked"
+	ReasonCycleDetected       ReasonCode = "cycle_detected"
+	ReasonNodeBudgetExceeded  ReasonCode = "node_budget_exceeded"
+	ReasonEdgeBudgetExceeded  ReasonCode = "edge_budget_exceeded"
+	ReasonDepthBudgetExceeded ReasonCode = "depth_budget_exceeded"
+)
+
+// AffectedFact explains one impacted exact revision.
+type AffectedFact struct {
+	Revision  complianceintegration.RevisionRef
+	Reasons   []ReasonCode
+	Relations []string
+	Distance  uint32
+}
+
+// Invalidation identifies a mutable claim or projection that must be marked
+// invalid without rewriting completed artifacts.
+type Invalidation struct {
+	Revision complianceintegration.RevisionRef
+	Reason   ReasonCode
+}
+
+// Issue records why a result is incomplete. References contain stable exact
+// revision identities and no copied domain payload.
+type Issue struct {
+	Code     ReasonCode
+	Revision complianceintegration.RevisionRef
+	Related  complianceintegration.RevisionRef
+}
+
+// Result separates operator-facing target classes and preserves completeness.
+type Result struct {
+	TenantID      string
+	Signal        complianceintegration.ChangeSignal
+	Complete      bool
+	Programs      []AffectedFact
+	Plans         []AffectedFact
+	Objectives    []AffectedFact
+	Packages      []AffectedFact
+	WorkItems     []AffectedFact
+	Invalidations []Invalidation
+	Issues        []Issue
+}

--- a/internal/complianceimpact/testdata/compatibility_adapter_replay.json
+++ b/internal/complianceimpact/testdata/compatibility_adapter_replay.json
@@ -1,0 +1,91 @@
+{
+  "mappings": [
+    {
+      "tenant_id": "tenant-a",
+      "source": {
+        "tenant_id": "tenant-a",
+        "domain": "test.domain",
+        "kind": "policy",
+        "id": "policy-source",
+        "revision_id": "policy-source-r1",
+        "version": 1,
+        "content_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_modified": "1970-01-01T00:00:01Z"
+      },
+      "target_kind": "policy",
+      "target_id": "policy-1",
+      "action_ids": ["review.complete", "review.complete"]
+    },
+    {
+      "tenant_id": "tenant-a",
+      "source": {
+        "tenant_id": "tenant-a",
+        "domain": "test.domain",
+        "kind": "policy",
+        "id": "policy-source",
+        "revision_id": "policy-source-r1",
+        "version": 1,
+        "content_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_modified": "1970-01-01T00:00:01Z"
+      },
+      "target_kind": "access_review",
+      "target_id": "access-review-1",
+      "action_ids": ["identity.okta.suspend_user"]
+    },
+    {
+      "tenant_id": "tenant-a",
+      "source": {
+        "tenant_id": "tenant-a",
+        "domain": "test.domain",
+        "kind": "program",
+        "id": "program-source",
+        "revision_id": "program-source-r2",
+        "version": 2,
+        "content_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_modified": "1970-01-01T00:00:02Z"
+      },
+      "target_kind": "vendor",
+      "target_id": "vendor-1",
+      "action_ids": ["complete_review"]
+    },
+    {
+      "tenant_id": "tenant-a",
+      "source": {
+        "tenant_id": "tenant-a",
+        "domain": "test.domain",
+        "kind": "program",
+        "id": "program-source",
+        "revision_id": "program-source-r2",
+        "version": 2,
+        "content_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_modified": "1970-01-01T00:00:02Z"
+      },
+      "target_kind": "questionnaire",
+      "target_id": "questionnaire-run-1",
+      "action_ids": ["record_decision"]
+    },
+    {
+      "tenant_id": "tenant-a",
+      "source": {
+        "tenant_id": "tenant-a",
+        "domain": "test.domain",
+        "kind": "objective",
+        "id": "objective-source",
+        "revision_id": "objective-source-r3",
+        "version": 3,
+        "content_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "last_modified": "1970-01-01T00:00:03Z"
+      },
+      "target_kind": "finding",
+      "target_id": "finding-1",
+      "action_ids": ["identity.okta.suspend_user"]
+    }
+  ],
+  "expected_targets": [
+    {"kind": "access_review", "id": "access-review-1", "action_ids": ["identity.okta.suspend_user"]},
+    {"kind": "finding", "id": "finding-1", "action_ids": ["identity.okta.suspend_user"]},
+    {"kind": "policy", "id": "policy-1", "action_ids": ["review.complete"]},
+    {"kind": "questionnaire", "id": "questionnaire-run-1", "action_ids": ["record_decision"]},
+    {"kind": "vendor", "id": "vendor-1", "action_ids": ["complete_review"]}
+  ]
+}

--- a/internal/complianceintegration/change.go
+++ b/internal/complianceintegration/change.go
@@ -1,0 +1,74 @@
+package complianceintegration
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var ErrInvalidChangeSignal = errors.New("invalid compliance change signal")
+
+// ChangeKind describes how an exact revision changed lifecycle state.
+type ChangeKind string
+
+const (
+	ChangeCreated ChangeKind = "created"
+	ChangeUpdated ChangeKind = "updated"
+	ChangeDeleted ChangeKind = "deleted"
+	ChangeRevoked ChangeKind = "revoked"
+)
+
+// ChangeSignal is a normalized immutable change notification. Revision is the
+// exact revision whose dependents must be traversed; Replacement is present only
+// for an update and identifies the new exact revision.
+type ChangeSignal struct {
+	kind        ChangeKind
+	revision    RevisionRef
+	replacement *RevisionRef
+	changedAt   time.Time
+}
+
+// NewChangeSignal rejects underspecified updates instead of allowing a
+// best-effort impact pass without exact revision identity.
+func NewChangeSignal(kind ChangeKind, revision RevisionRef, replacement *RevisionRef, changedAt time.Time) (ChangeSignal, error) {
+	kind = ChangeKind(strings.ToLower(strings.TrimSpace(string(kind))))
+	if revision.ExactKey() == "" {
+		return ChangeSignal{}, fmt.Errorf("%w: revision is required", ErrInvalidChangeSignal)
+	}
+	if changedAt.IsZero() {
+		return ChangeSignal{}, fmt.Errorf("%w: changed_at is required", ErrInvalidChangeSignal)
+	}
+	changedAt = changedAt.UTC().Truncate(time.Millisecond)
+	switch kind {
+	case ChangeUpdated:
+		if replacement == nil {
+			return ChangeSignal{}, fmt.Errorf("%w: updated signal requires replacement revision", ErrInvalidChangeSignal)
+		}
+		if !revision.SameSubject(*replacement) || replacement.Version() <= revision.Version() {
+			return ChangeSignal{}, fmt.Errorf("%w: replacement must be a newer revision of the same subject", ErrInvalidChangeSignal)
+		}
+	case ChangeCreated, ChangeDeleted, ChangeRevoked:
+		if replacement != nil {
+			return ChangeSignal{}, fmt.Errorf("%w: %s signal cannot include replacement revision", ErrInvalidChangeSignal, kind)
+		}
+	default:
+		return ChangeSignal{}, fmt.Errorf("%w: unsupported kind %q", ErrInvalidChangeSignal, kind)
+	}
+	var replacementCopy *RevisionRef
+	if replacement != nil {
+		value := *replacement
+		replacementCopy = &value
+	}
+	return ChangeSignal{kind: kind, revision: revision, replacement: replacementCopy, changedAt: changedAt}, nil
+}
+
+func (s ChangeSignal) Kind() ChangeKind      { return s.kind }
+func (s ChangeSignal) Revision() RevisionRef { return s.revision }
+func (s ChangeSignal) ChangedAt() time.Time  { return s.changedAt }
+func (s ChangeSignal) Replacement() (RevisionRef, bool) {
+	if s.replacement == nil {
+		return RevisionRef{}, false
+	}
+	return *s.replacement, true
+}

--- a/internal/complianceintegration/model.go
+++ b/internal/complianceintegration/model.go
@@ -66,7 +66,7 @@ func AdaptRevisionRef(tenantID, domain string, kind FactKind, source compliance.
 		return RevisionRef{}, fmt.Errorf("%w: invalid fact kind %q", ErrInvalidFact, kind)
 	}
 	if err := source.Validate(); err != nil {
-		return RevisionRef{}, fmt.Errorf("%w: revision: %v", ErrInvalidFact, err)
+		return RevisionRef{}, fmt.Errorf("%w: revision: %w", ErrInvalidFact, err)
 	}
 	if strings.ContainsRune(source.ID, '\x00') || strings.ContainsRune(source.RevisionID, '\x00') {
 		return RevisionRef{}, fmt.Errorf("%w: revision identifiers contain a reserved character", ErrInvalidFact)

--- a/internal/complianceintegration/model.go
+++ b/internal/complianceintegration/model.go
@@ -1,0 +1,173 @@
+// Package complianceintegration defines immutable, transport-independent facts
+// that source-domain adapters expose to compliance impact analysis.
+package complianceintegration
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+var ErrInvalidFact = errors.New("invalid compliance integration fact")
+
+var identifierPattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]{0,127}$`)
+
+// FactKind identifies the lifecycle-owning shape of an immutable domain fact.
+type FactKind string
+
+const (
+	FactCatalog             FactKind = "catalog"
+	FactMapping             FactKind = "mapping"
+	FactSourceCoverage      FactKind = "source_coverage"
+	FactInventory           FactKind = "inventory"
+	FactPolicy              FactKind = "policy"
+	FactVendor              FactKind = "vendor"
+	FactClaim               FactKind = "claim"
+	FactFinding             FactKind = "finding"
+	FactProgram             FactKind = "program"
+	FactAssessmentPlan      FactKind = "assessment_plan"
+	FactObjective           FactKind = "objective"
+	FactAuditPackage        FactKind = "audit_package"
+	FactWorkItem            FactKind = "work_item"
+	FactProjection          FactKind = "projection"
+	FactQuestionnaireAnswer FactKind = "questionnaire_answer"
+)
+
+// RevisionRef is an immutable adapter over one canonical compliance revision.
+// Tenant, domain, and kind make the otherwise transport-neutral revision safe
+// to use as an impact-graph identity.
+type RevisionRef struct {
+	valid    bool
+	tenantID string
+	domain   string
+	kind     FactKind
+	revision compliance.RevisionRef
+}
+
+// AdaptRevisionRef validates and normalizes an exact canonical revision.
+func AdaptRevisionRef(tenantID, domain string, kind FactKind, source compliance.RevisionRef) (RevisionRef, error) {
+	tenantID = strings.TrimSpace(tenantID)
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	kind = FactKind(strings.ToLower(strings.TrimSpace(string(kind))))
+	source = compliance.NormalizeRevisionRef(source)
+	if tenantID == "" || len(tenantID) > 255 || strings.ContainsRune(tenantID, '\x00') {
+		return RevisionRef{}, fmt.Errorf("%w: tenant_id is required and must be bounded", ErrInvalidFact)
+	}
+	if !identifierPattern.MatchString(domain) {
+		return RevisionRef{}, fmt.Errorf("%w: invalid domain %q", ErrInvalidFact, domain)
+	}
+	if !validFactKind(kind) {
+		return RevisionRef{}, fmt.Errorf("%w: invalid fact kind %q", ErrInvalidFact, kind)
+	}
+	if err := source.Validate(); err != nil {
+		return RevisionRef{}, fmt.Errorf("%w: revision: %v", ErrInvalidFact, err)
+	}
+	if strings.ContainsRune(source.ID, '\x00') || strings.ContainsRune(source.RevisionID, '\x00') {
+		return RevisionRef{}, fmt.Errorf("%w: revision identifiers contain a reserved character", ErrInvalidFact)
+	}
+	return RevisionRef{valid: true, tenantID: tenantID, domain: domain, kind: kind, revision: source}, nil
+}
+
+func validFactKind(kind FactKind) bool {
+	switch kind {
+	case FactCatalog, FactMapping, FactSourceCoverage, FactInventory, FactPolicy,
+		FactVendor, FactClaim, FactFinding, FactProgram, FactAssessmentPlan,
+		FactObjective, FactAuditPackage, FactWorkItem, FactProjection,
+		FactQuestionnaireAnswer:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r RevisionRef) TenantID() string                  { return r.tenantID }
+func (r RevisionRef) Domain() string                    { return r.domain }
+func (r RevisionRef) Kind() FactKind                    { return r.kind }
+func (r RevisionRef) ID() string                        { return r.revision.ID }
+func (r RevisionRef) RevisionID() string                { return r.revision.RevisionID }
+func (r RevisionRef) Version() uint64                   { return r.revision.Version }
+func (r RevisionRef) Canonical() compliance.RevisionRef { return r.revision }
+func (r RevisionRef) ExactKey() string {
+	if !r.valid {
+		return ""
+	}
+	return r.subjectKey() + "\x00" + r.revision.RevisionID + "\x00" + strconv.FormatUint(r.revision.Version, 10) + "\x00" + string(r.revision.ContentDigest) + "\x00" + r.revision.LastModified.Format(time.RFC3339Nano)
+}
+func (r RevisionRef) SameSubject(other RevisionRef) bool { return r.subjectKey() == other.subjectKey() }
+func (r RevisionRef) Equal(other RevisionRef) bool       { return r.ExactKey() == other.ExactKey() }
+func (r RevisionRef) subjectKey() string {
+	return r.tenantID + "\x00" + r.domain + "\x00" + string(r.kind) + "\x00" + r.revision.ID
+}
+
+// DependencyRef identifies the exact upstream revision and why it is used.
+type DependencyRef struct {
+	revision RevisionRef
+	relation string
+}
+
+// NewDependencyRef creates one explicit, exact dependency edge.
+func NewDependencyRef(revision RevisionRef, relation string) (DependencyRef, error) {
+	relation = strings.ToLower(strings.TrimSpace(relation))
+	if revision.ExactKey() == "" {
+		return DependencyRef{}, fmt.Errorf("%w: dependency revision is required", ErrInvalidFact)
+	}
+	if !identifierPattern.MatchString(relation) {
+		return DependencyRef{}, fmt.Errorf("%w: invalid dependency relation %q", ErrInvalidFact, relation)
+	}
+	return DependencyRef{revision: revision, relation: relation}, nil
+}
+
+func (d DependencyRef) Revision() RevisionRef { return d.revision }
+func (d DependencyRef) Relation() string      { return d.relation }
+
+// DomainFact is an immutable exact revision plus explicit upstream revisions.
+// Dependencies returns a copy so callers cannot mutate the fact after creation.
+type DomainFact struct {
+	revision     RevisionRef
+	dependencies []DependencyRef
+}
+
+// NewDomainFact validates tenant isolation and canonicalizes dependency order.
+func NewDomainFact(revision RevisionRef, dependencies []DependencyRef) (DomainFact, error) {
+	if revision.ExactKey() == "" {
+		return DomainFact{}, fmt.Errorf("%w: revision is required", ErrInvalidFact)
+	}
+	result := append([]DependencyRef(nil), dependencies...)
+	for index, dependency := range result {
+		if dependency.revision.TenantID() != revision.TenantID() {
+			return DomainFact{}, fmt.Errorf("%w: dependency[%d] crosses tenant boundary", ErrInvalidFact, index)
+		}
+		if dependency.relation == "" {
+			return DomainFact{}, fmt.Errorf("%w: dependency[%d] relation is required", ErrInvalidFact, index)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left := result[i].revision.ExactKey() + "\x00" + result[i].relation
+		right := result[j].revision.ExactKey() + "\x00" + result[j].relation
+		return left < right
+	})
+	result = deduplicateDependencies(result)
+	return DomainFact{revision: revision, dependencies: result}, nil
+}
+
+func deduplicateDependencies(values []DependencyRef) []DependencyRef {
+	result := make([]DependencyRef, 0, len(values))
+	for _, value := range values {
+		if len(result) != 0 && result[len(result)-1].revision.Equal(value.revision) && result[len(result)-1].relation == value.relation {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func (f DomainFact) Revision() RevisionRef { return f.revision }
+func (f DomainFact) Dependencies() []DependencyRef {
+	return append([]DependencyRef(nil), f.dependencies...)
+}

--- a/internal/complianceintegration/model_test.go
+++ b/internal/complianceintegration/model_test.go
@@ -1,0 +1,138 @@
+package complianceintegration
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func TestRevisionAndFactAdaptersNormalizeAndRemainImmutable(t *testing.T) {
+	modified := time.Date(2026, 7, 11, 12, 0, 0, 987654321, time.FixedZone("offset", 3600))
+	revision, err := AdaptRevisionRef(" tenant-a ", " GRC.Policy ", FactPolicy, compliance.RevisionRef{
+		ID: " policy-1 ", RevisionID: " policy-r1 ", Version: 1,
+		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: modified,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revision.TenantID() != "tenant-a" || revision.Domain() != "grc.policy" || revision.ID() != "policy-1" {
+		t.Fatalf("unexpected normalized revision: tenant=%q domain=%q id=%q", revision.TenantID(), revision.Domain(), revision.ID())
+	}
+	if got := revision.Canonical().LastModified; got.Location() != time.UTC || got.Nanosecond() != 987000000 {
+		t.Fatalf("last_modified not canonical: %v", got)
+	}
+
+	other := testRevision(t, "tenant-a", FactCatalog, "catalog-1", 1)
+	depA, err := NewDependencyRef(revision, " Policy_Source ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	depB, err := NewDependencyRef(other, "catalog_source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := []DependencyRef{depA, depB, depA}
+	fact, err := NewDomainFact(testRevision(t, "tenant-a", FactProgram, "program-1", 1), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input[0] = DependencyRef{}
+	first := fact.Dependencies()
+	if len(first) != 2 {
+		t.Fatalf("dependencies = %d, want deduplicated length 2", len(first))
+	}
+	first[0] = DependencyRef{}
+	if len(fact.Dependencies()) != 2 || fact.Dependencies()[0].Relation() == "" {
+		t.Fatal("dependencies accessor exposed mutable backing storage")
+	}
+}
+
+func TestDomainFactRejectsCrossTenantDependency(t *testing.T) {
+	owner := testRevision(t, "tenant-a", FactProgram, "program-1", 1)
+	foreign := testRevision(t, "tenant-b", FactPolicy, "policy-1", 1)
+	dependency, err := NewDependencyRef(foreign, "policy_source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewDomainFact(owner, []DependencyRef{dependency})
+	if !errors.Is(err, ErrInvalidFact) {
+		t.Fatalf("error = %v, want ErrInvalidFact", err)
+	}
+}
+
+func TestChangeSignalRequiresExactRevisionSemantics(t *testing.T) {
+	previous := testRevision(t, "tenant-a", FactPolicy, "policy-1", 1)
+	replacement := testRevision(t, "tenant-a", FactPolicy, "policy-1", 2)
+	changedAt := time.Date(2026, 7, 11, 1, 2, 3, 456789123, time.FixedZone("offset", -3600))
+	signal, err := NewChangeSignal(ChangeKind(" UPDATED "), previous, &replacement, changedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := signal.ChangedAt(); got.Location() != time.UTC || got.Nanosecond() != 456000000 {
+		t.Fatalf("changed_at not canonical: %v", got)
+	}
+	if signal.Kind() != ChangeUpdated {
+		t.Fatalf("kind = %q, want normalized updated", signal.Kind())
+	}
+	gotReplacement, ok := signal.Replacement()
+	if !ok || !gotReplacement.Equal(replacement) {
+		t.Fatal("replacement revision not preserved")
+	}
+
+	if _, err := NewChangeSignal(ChangeUpdated, previous, nil, changedAt); !errors.Is(err, ErrInvalidChangeSignal) {
+		t.Fatalf("missing replacement error = %v", err)
+	}
+	older := testRevision(t, "tenant-a", FactPolicy, "policy-1", 1)
+	if _, err := NewChangeSignal(ChangeUpdated, previous, &older, changedAt); !errors.Is(err, ErrInvalidChangeSignal) {
+		t.Fatalf("non-newer replacement error = %v", err)
+	}
+	foreignSubject := testRevision(t, "tenant-a", FactPolicy, "policy-2", 2)
+	if _, err := NewChangeSignal(ChangeUpdated, previous, &foreignSubject, changedAt); !errors.Is(err, ErrInvalidChangeSignal) {
+		t.Fatalf("different subject replacement error = %v", err)
+	}
+	if _, err := NewChangeSignal(ChangeDeleted, previous, &replacement, changedAt); !errors.Is(err, ErrInvalidChangeSignal) {
+		t.Fatalf("deleted replacement error = %v", err)
+	}
+	if _, err := NewChangeSignal(ChangeDeleted, previous, nil, time.Time{}); !errors.Is(err, ErrInvalidChangeSignal) {
+		t.Fatalf("missing time error = %v", err)
+	}
+}
+
+func TestRevisionAdapterRejectsInvalidIdentity(t *testing.T) {
+	valid := compliance.RevisionRef{ID: "id", RevisionID: "r1", Version: 1, ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(1, 0)}
+	tests := []struct {
+		name   string
+		tenant string
+		domain string
+		kind   FactKind
+		value  compliance.RevisionRef
+	}{
+		{name: "tenant", domain: "domain", kind: FactPolicy, value: valid},
+		{name: "domain", tenant: "tenant", domain: "../domain", kind: FactPolicy, value: valid},
+		{name: "kind", tenant: "tenant", domain: "domain", kind: "unknown", value: valid},
+		{name: "revision", tenant: "tenant", domain: "domain", kind: FactPolicy, value: compliance.RevisionRef{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := AdaptRevisionRef(test.tenant, test.domain, test.kind, test.value)
+			if !errors.Is(err, ErrInvalidFact) {
+				t.Fatalf("error = %v, want ErrInvalidFact", err)
+			}
+		})
+	}
+}
+
+func testRevision(t *testing.T, tenant string, kind FactKind, id string, version uint64) RevisionRef {
+	t.Helper()
+	ref, err := AdaptRevisionRef(tenant, "test.domain", kind, compliance.RevisionRef{
+		ID: id, RevisionID: id + "-r" + string(rune('0'+version)), Version: version,
+		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(int64(version), 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ref
+}

--- a/internal/complianceintegration/model_test.go
+++ b/internal/complianceintegration/model_test.go
@@ -2,6 +2,7 @@ package complianceintegration
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -128,8 +129,8 @@ func TestRevisionAdapterRejectsInvalidIdentity(t *testing.T) {
 func testRevision(t *testing.T, tenant string, kind FactKind, id string, version uint64) RevisionRef {
 	t.Helper()
 	ref, err := AdaptRevisionRef(tenant, "test.domain", kind, compliance.RevisionRef{
-		ID: id, RevisionID: id + "-r" + string(rune('0'+version)), Version: version,
-		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(int64(version), 0),
+		ID: id, RevisionID: id + "-r" + strconv.FormatUint(version, 10), Version: version,
+		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(1, 0),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/complianceintegration/model_test.go
+++ b/internal/complianceintegration/model_test.go
@@ -2,6 +2,7 @@ package complianceintegration
 
 import (
 	"errors"
+	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -128,9 +129,13 @@ func TestRevisionAdapterRejectsInvalidIdentity(t *testing.T) {
 
 func testRevision(t *testing.T, tenant string, kind FactKind, id string, version uint64) RevisionRef {
 	t.Helper()
+	if version > math.MaxInt64 {
+		t.Fatalf("version %d exceeds test timestamp range", version)
+	}
+	seconds := int64(version) // #nosec G115 -- bounded by MaxInt64 above.
 	ref, err := AdaptRevisionRef(tenant, "test.domain", kind, compliance.RevisionRef{
 		ID: id, RevisionID: id + "-r" + strconv.FormatUint(version, 10), Version: version,
-		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(1, 0),
+		ContentDigest: compliance.ContentDigest("sha256:" + strings.Repeat("a", 64)), LastModified: time.Unix(seconds, 0),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/ports/compliance_impact.go
+++ b/internal/ports/compliance_impact.go
@@ -1,0 +1,60 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrComplianceImpactRevisionNotFound means an exact immutable revision is not
+// available. Impact analysis must fail rather than silently omit its dependents.
+var ErrComplianceImpactRevisionNotFound = errors.New("compliance impact revision not found")
+
+// ComplianceImpactRevisionRef is the storage-boundary representation of one
+// exact immutable domain revision. Services validate it into their own domain
+// value before using it for traversal.
+type ComplianceImpactRevisionRef struct {
+	TenantID      string
+	Domain        string
+	Kind          string
+	ID            string
+	RevisionID    string
+	Version       uint64
+	ContentDigest string
+	LastModified  time.Time
+}
+
+// ComplianceImpactDependencyRef is one explicit upstream edge.
+type ComplianceImpactDependencyRef struct {
+	Revision ComplianceImpactRevisionRef
+	Relation string
+}
+
+// ComplianceImpactDomainFact is the storage-boundary representation of an
+// immutable domain fact.
+type ComplianceImpactDomainFact struct {
+	Revision     ComplianceImpactRevisionRef
+	Dependencies []ComplianceImpactDependencyRef
+}
+
+// ComplianceImpactDependentRequest pages exact dependents of one exact revision.
+type ComplianceImpactDependentRequest struct {
+	TenantID    string
+	Dependency  ComplianceImpactRevisionRef
+	AfterCursor string
+	Limit       uint32
+}
+
+// ComplianceImpactDependentPage is ordered by a store-defined stable cursor.
+type ComplianceImpactDependentPage struct {
+	Dependents []ComplianceImpactRevisionRef
+	NextCursor string
+	Complete   bool
+}
+
+// ComplianceImpactGraph exposes immutable domain facts and reverse dependency
+// edges. Implementations must scope every read to TenantID.
+type ComplianceImpactGraph interface {
+	GetComplianceImpactFact(context.Context, string, ComplianceImpactRevisionRef) (ComplianceImpactDomainFact, error)
+	ListComplianceImpactDependents(context.Context, ComplianceImpactDependentRequest) (ComplianceImpactDependentPage, error)
+}

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -28,6 +28,7 @@ const (
 	EventKindComplianceActivityRecorded            = "workflow.v1.compliance.assessment_activity_recorded"
 	EventKindCompliancePopulationRecorded          = "workflow.v1.compliance.assessment_population_recorded"
 	EventKindComplianceSampleRecorded              = "workflow.v1.compliance.assessment_sample_recorded"
+	EventKindComplianceSourceCheckRecorded         = "workflow.v1.compliance.assessment_source_check_recorded"
 	EventKindComplianceReviewRecorded              = "workflow.v1.compliance.assessment_review_recorded"
 	EventKindComplianceRiskDecisionRecorded        = "workflow.v1.compliance.risk_decision_recorded"
 	EventKindComplianceExceptionUpdated            = "workflow.v1.compliance.exception_updated"
@@ -124,6 +125,7 @@ func registeredComplianceKinds() []string {
 		EventKindComplianceResultChunkRecorded, EventKindComplianceAssessmentCompleted,
 		EventKindComplianceAssessmentCancelled, EventKindComplianceActivityRecorded,
 		EventKindCompliancePopulationRecorded, EventKindComplianceSampleRecorded,
+		EventKindComplianceSourceCheckRecorded,
 		EventKindComplianceReviewRecorded, EventKindComplianceRiskDecisionRecorded,
 		EventKindComplianceExceptionUpdated, EventKindComplianceWorkItemUpdated,
 		EventKindComplianceRemediationMilestoneUpdated, EventKindComplianceAuditEngagementRecorded,

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -93,7 +93,7 @@ func NewComplianceAggregateEvent(payload ComplianceAggregateRecorded) (*cerebrov
 		ContentDigest: payload.ContentDigest, PayloadJSON: payload.PayloadJSON,
 		ActorID: payload.ActorID, RecordedAt: payload.RecordedAt,
 	}
-	primaryID := payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
+	primaryID := payload.AggregateType + "|" + payload.AggregateID + "|" + fmt.Sprintf("%d", payload.AggregateVersion) + "|" + payload.Operation
 	return newEvent(contract, SchemaComplianceAggregate, payload.TenantID, "compliance", primaryID, payload.RecordedAt, map[string]string{
 		EventAttributeWorkflowKind: "compliance_aggregate",
 		"aggregate_type":           payload.AggregateType,

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -65,6 +65,27 @@ func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
 	}
 }
 
+func TestComplianceAggregateIdentityIncludesAggregateType(t *testing.T) {
+	t.Parallel()
+	base := ComplianceAggregateRecorded{
+		Kind: EventKindComplianceSourceCheckRecorded, TenantID: "tenant-a",
+		AggregateType: "source_check", AggregateID: "shared-id", AggregateVersion: 1,
+		Operation: "recorded", RecordedAt: "2026-07-11T08:00:00Z",
+	}
+	first, err := NewComplianceAggregateEvent(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.AggregateType = "objective_source_assessment"
+	second, err := NewComplianceAggregateEvent(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.GetId() == second.GetId() {
+		t.Fatalf("aggregate types produced the same event id %q", first.GetId())
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -54,6 +54,17 @@ func TestComplianceExchangeRequestAndCommitRemainDistinctFacts(t *testing.T) {
 	}
 }
 
+func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
+	t.Parallel()
+	if EventKindComplianceSourceCheckRecorded == EventKindComplianceActivityRecorded ||
+		EventKindComplianceSourceCheckRecorded == EventKindComplianceInputManifestRecorded {
+		t.Fatal("source check event overloads an activity or input-manifest fact")
+	}
+	if !KindRegistered(EventKindComplianceSourceCheckRecorded) {
+		t.Fatal("source check event kind is not registered")
+	}
+}
+
 func TestComplianceAggregateRejectsUnsafePayload(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{


### PR DESCRIPTION
## Summary

- translate canonical compliance impact results into explicit policy, finding, vendor, questionnaire, and access-review identifiers
- require exact tenant and revision mappings, preserve impact and mapping-set provenance, and return read-only action candidates
- report unmapped, ambiguous, and incomplete results with stable reason codes
- bound source, mapping, target, action, and issue work; deduplicate and sort all replay output
- add fixture coverage for every destination slice, stable replay, exact-revision matching, ambiguity, tenant isolation, and limits

## Boundaries

- no external I/O
- no destination-domain mutation
- no fuzzy identifier inference
- destination domains retain action authorization and execution ownership

## Validation

- `go test ./internal/complianceimpact ./internal/complianceintegration`
- `go test -race ./internal/complianceimpact`
- `go vet ./internal/complianceimpact`
- `make lint-internal`
- `go test ./tools/archtests/...`