### PR TITLE
recovery: lease dead letter replay

### DIFF
--- a/cmd/cerebro/append_log.go
+++ b/cmd/cerebro/append_log.go
@@ -117,7 +117,7 @@ func runAppendLogDeadLetterReplay(ctx context.Context, cfg appconfig.Config, arg
 	}
 	if err := appendWithDeadLetterReplayLease(ctx, deps.AppendLog, store, id, token, record.Event); err != nil {
 		if releaseErr := store.ReleaseAppendLogDeadLetterReplay(ctx, id, token, "append_failed"); releaseErr != nil {
-			return fmt.Errorf("replay append log dead letter %q: %w (release claim: %v)", id, err, releaseErr)
+			return fmt.Errorf("replay append log dead letter %q: %w", id, errors.Join(err, fmt.Errorf("release claim: %w", releaseErr)))
 		}
 		return fmt.Errorf("replay append log dead letter %q: %w", id, err)
 	}

--- a/cmd/cerebro/append_log.go
+++ b/cmd/cerebro/append_log.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/bootstrap"
 	appconfig "github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
@@ -96,26 +100,73 @@ func runAppendLogDeadLetterReplay(ctx context.Context, cfg appconfig.Config, arg
 	if deps.AppendLog == nil {
 		return errors.New("append log is not configured")
 	}
-	record, err := store.GetAppendLogDeadLetter(ctx, id)
+	owner, token, err := newAppendLogDeadLetterReplayClaim()
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(record.Status) != ports.AppendLogDeadLetterStatusPending {
-		return fmt.Errorf("append log dead letter %q has status %q", id, record.Status)
+	record, err := store.ClaimAppendLogDeadLetterReplay(ctx, id, owner, token, 2*time.Minute)
+	if err != nil {
+		if errors.Is(err, ports.ErrAppendLogDeadLetterReplayClaimed) {
+			return fmt.Errorf("append log dead letter %q replay is already claimed", id)
+		}
+		return err
 	}
 	if record.Event == nil {
+		_ = store.ReleaseAppendLogDeadLetterReplay(ctx, id, token, "missing_event")
 		return fmt.Errorf("append log dead letter %q has no replay event", id)
 	}
-	if err := deps.AppendLog.Append(ctx, record.Event); err != nil {
+	if err := appendWithDeadLetterReplayLease(ctx, deps.AppendLog, store, id, token, record.Event); err != nil {
+		if releaseErr := store.ReleaseAppendLogDeadLetterReplay(ctx, id, token, "append_failed"); releaseErr != nil {
+			return fmt.Errorf("replay append log dead letter %q: %w (release claim: %v)", id, err, releaseErr)
+		}
 		return fmt.Errorf("replay append log dead letter %q: %w", id, err)
 	}
-	if err := store.MarkAppendLogDeadLetterReplayed(ctx, id); err != nil {
+	if err := store.CompleteAppendLogDeadLetterReplay(ctx, id, token); err != nil {
 		if errors.Is(err, ports.ErrAppendLogDeadLetterAlreadyReplayed) {
 			return printJSON(appendLogDeadLetterActionResponse(record, ports.AppendLogDeadLetterStatusReplayed))
 		}
 		return err
 	}
 	return printJSON(appendLogDeadLetterActionResponse(record, ports.AppendLogDeadLetterStatusReplayed))
+}
+
+func appendWithDeadLetterReplayLease(ctx context.Context, appendLog ports.AppendLog, store ports.AppendLogDeadLetterStore, id string, token string, event *cerebrov1.EventEnvelope) error {
+	appendCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	renewed := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-appendCtx.Done():
+				renewed <- nil
+				return
+			case <-ticker.C:
+				if err := store.RenewAppendLogDeadLetterReplay(appendCtx, id, token, 2*time.Minute); err != nil {
+					renewed <- err
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+	appendErr := appendLog.Append(appendCtx, event)
+	cancel()
+	renewErr := <-renewed
+	if renewErr != nil {
+		return fmt.Errorf("renew replay claim: %w", renewErr)
+	}
+	return appendErr
+}
+
+func newAppendLogDeadLetterReplayClaim() (string, string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", "", fmt.Errorf("generate append log dead letter replay claim: %w", err)
+	}
+	token := hex.EncodeToString(raw[:])
+	return "cerebro-cli:" + token[:16], token, nil
 }
 
 func runAppendLogDeadLetterDiscard(ctx context.Context, cfg appconfig.Config, args []string) error {
@@ -225,23 +276,28 @@ func parseAppendLogDeadLetterDiscardArgs(args []string) (string, string, error) 
 }
 
 type appendLogDeadLetterSummary struct {
-	ID            string `json:"id"`
-	Status        string `json:"status"`
-	Subject       string `json:"subject"`
-	Operation     string `json:"operation"`
-	EventID       string `json:"event_id"`
-	EventKind     string `json:"event_kind"`
-	TenantID      string `json:"tenant_id,omitempty"`
-	SourceID      string `json:"source_id,omitempty"`
-	RuntimeID     string `json:"runtime_id,omitempty"`
-	JobID         string `json:"job_id,omitempty"`
-	ErrorCategory string `json:"error_category,omitempty"`
-	RetryCount    int    `json:"retry_count,omitempty"`
-	MaxAttempts   int    `json:"max_attempts,omitempty"`
-	PayloadHash   string `json:"payload_hash,omitempty"`
-	PayloadBytes  int    `json:"payload_bytes,omitempty"`
-	CreatedAt     string `json:"created_at,omitempty"`
-	UpdatedAt     string `json:"updated_at,omitempty"`
+	ID                      string `json:"id"`
+	Status                  string `json:"status"`
+	Subject                 string `json:"subject"`
+	Operation               string `json:"operation"`
+	EventID                 string `json:"event_id"`
+	EventKind               string `json:"event_kind"`
+	TenantID                string `json:"tenant_id,omitempty"`
+	SourceID                string `json:"source_id,omitempty"`
+	RuntimeID               string `json:"runtime_id,omitempty"`
+	JobID                   string `json:"job_id,omitempty"`
+	ErrorCategory           string `json:"error_category,omitempty"`
+	RetryCount              int    `json:"retry_count,omitempty"`
+	MaxAttempts             int    `json:"max_attempts,omitempty"`
+	PayloadHash             string `json:"payload_hash,omitempty"`
+	PayloadBytes            int    `json:"payload_bytes,omitempty"`
+	CreatedAt               string `json:"created_at,omitempty"`
+	UpdatedAt               string `json:"updated_at,omitempty"`
+	ReplayClaimed           bool   `json:"replay_claimed,omitempty"`
+	ReplayOwner             string `json:"replay_owner,omitempty"`
+	ReplayLeaseExpiresAt    string `json:"replay_lease_expires_at,omitempty"`
+	ReplayAttemptCount      int    `json:"replay_attempt_count,omitempty"`
+	LastReplayErrorCategory string `json:"last_replay_error_category,omitempty"`
 }
 
 type appendLogDeadLetterListOutput struct {
@@ -266,27 +322,34 @@ func appendLogDeadLetterListResponse(records []ports.AppendLogDeadLetter) append
 
 func appendLogDeadLetterSummaryFor(record ports.AppendLogDeadLetter) appendLogDeadLetterSummary {
 	summary := appendLogDeadLetterSummary{
-		ID:            record.ID,
-		Status:        record.Status,
-		Subject:       record.Subject,
-		Operation:     record.Operation,
-		EventID:       record.EventID,
-		EventKind:     record.EventKind,
-		TenantID:      record.TenantID,
-		SourceID:      record.SourceID,
-		RuntimeID:     record.RuntimeID,
-		JobID:         record.JobID,
-		ErrorCategory: record.ErrorCategory,
-		RetryCount:    record.RetryCount,
-		MaxAttempts:   record.MaxAttempts,
-		PayloadHash:   record.PayloadHash,
-		PayloadBytes:  record.PayloadBytes,
+		ID:                      record.ID,
+		Status:                  record.Status,
+		Subject:                 record.Subject,
+		Operation:               record.Operation,
+		EventID:                 record.EventID,
+		EventKind:               record.EventKind,
+		TenantID:                record.TenantID,
+		SourceID:                record.SourceID,
+		RuntimeID:               record.RuntimeID,
+		JobID:                   record.JobID,
+		ErrorCategory:           record.ErrorCategory,
+		RetryCount:              record.RetryCount,
+		MaxAttempts:             record.MaxAttempts,
+		PayloadHash:             record.PayloadHash,
+		PayloadBytes:            record.PayloadBytes,
+		ReplayClaimed:           strings.TrimSpace(record.Replay.Token) != "" && record.Replay.LeaseExpiresAt.After(time.Now()),
+		ReplayOwner:             record.Replay.Owner,
+		ReplayAttemptCount:      record.Replay.AttemptCount,
+		LastReplayErrorCategory: record.Replay.LastErrorCategory,
 	}
 	if !record.CreatedAt.IsZero() {
 		summary.CreatedAt = record.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 	}
 	if !record.UpdatedAt.IsZero() {
 		summary.UpdatedAt = record.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if !record.Replay.LeaseExpiresAt.IsZero() {
+		summary.ReplayLeaseExpiresAt = record.Replay.LeaseExpiresAt.UTC().Format(time.RFC3339)
 	}
 	return summary
 }

--- a/cmd/cerebro/append_log_test.go
+++ b/cmd/cerebro/append_log_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestNewAppendLogDeadLetterReplayClaimIsOpaqueAndUnique(t *testing.T) {
+	firstOwner, firstToken, err := newAppendLogDeadLetterReplayClaim()
+	if err != nil {
+		t.Fatalf("newAppendLogDeadLetterReplayClaim() error = %v", err)
+	}
+	secondOwner, secondToken, err := newAppendLogDeadLetterReplayClaim()
+	if err != nil {
+		t.Fatalf("newAppendLogDeadLetterReplayClaim() second error = %v", err)
+	}
+	if !strings.HasPrefix(firstOwner, "cerebro-cli:") || len(firstToken) != 64 {
+		t.Fatalf("claim = (%q, %q), want opaque CLI owner and 256-bit token", firstOwner, firstToken)
+	}
+	if firstOwner == secondOwner || firstToken == secondToken {
+		t.Fatal("consecutive replay claims must be unique")
+	}
+}
+
+func TestAppendLogDeadLetterSummaryShowsClaimWithoutToken(t *testing.T) {
+	record := ports.AppendLogDeadLetter{
+		ID: "apdl_1",
+		Replay: ports.AppendLogDeadLetterReplayState{
+			Owner: "cerebro-cli:owner", Token: "secret-token",
+			LeaseExpiresAt: time.Now().Add(time.Minute), AttemptCount: 2,
+			LastErrorCategory: "append_failed",
+		},
+	}
+	summary := appendLogDeadLetterSummaryFor(record)
+	if !summary.ReplayClaimed || summary.ReplayOwner != record.Replay.Owner || summary.ReplayAttemptCount != 2 {
+		t.Fatalf("appendLogDeadLetterSummaryFor() = %#v, want active claim metadata", summary)
+	}
+	if strings.Contains(summary.ReplayOwner, record.Replay.Token) {
+		t.Fatal("operator summary exposed replay token")
+	}
+}

--- a/docs/operations/operations-runbook.md
+++ b/docs/operations/operations-runbook.md
@@ -128,6 +128,12 @@ After JetStream publish health is restored, replay one record:
 ./bin/cerebro append-log dead-letters replay <dead-letter-id>
 ```
 
+Replay first claims the pending record with a two-minute ownership lease. A
+concurrent operator receives `replay is already claimed`; wait for the lease
+expiry reported by `list` before retrying. Failed publication releases the
+claim and records the bounded `append_failed` category. A process that exits
+while holding a claim leaves the record recoverable after lease expiry.
+
 Discard a record only after confirming the event should not be replayed:
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,6 +73,11 @@ Replay one record after the append-log path is healthy, or discard it after inve
 ./bin/cerebro append-log dead-letters discard <dead-letter-id> reason=<reason>
 ```
 
+`replay` claims the record before publishing. `list` reports the claim owner,
+lease expiry, attempt count, and last bounded replay error category without
+exposing the claim token. A second operator cannot replay or discard the record
+until the active claim completes or expires.
+
 Dead-letter IDs are deterministic for the subject, event ID, and payload. A
 replayed or discarded record stays terminal if the same event exhausts again.
 

--- a/internal/appendlog/recovery/recovery_test.go
+++ b/internal/appendlog/recovery/recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -178,7 +179,19 @@ func (s *recordingStore) GetAppendLogDeadLetter(context.Context, string) (ports.
 	return ports.AppendLogDeadLetter{}, nil
 }
 
-func (s *recordingStore) MarkAppendLogDeadLetterReplayed(context.Context, string) error {
+func (s *recordingStore) ClaimAppendLogDeadLetterReplay(context.Context, string, string, string, time.Duration) (ports.AppendLogDeadLetter, error) {
+	return ports.AppendLogDeadLetter{}, nil
+}
+
+func (s *recordingStore) RenewAppendLogDeadLetterReplay(context.Context, string, string, time.Duration) error {
+	return nil
+}
+
+func (s *recordingStore) CompleteAppendLogDeadLetterReplay(context.Context, string, string) error {
+	return nil
+}
+
+func (s *recordingStore) ReleaseAppendLogDeadLetterReplay(context.Context, string, string, string) error {
 	return nil
 }
 

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -15,6 +15,8 @@ const EventAttributeJobID = "job_id"
 
 var ErrAppendLogDeadLetterNotFound = errors.New("append log dead letter not found")
 var ErrAppendLogDeadLetterAlreadyReplayed = errors.New("append log dead letter already replayed")
+var ErrAppendLogDeadLetterReplayClaimed = errors.New("append log dead letter replay already claimed")
+var ErrAppendLogDeadLetterReplayClaimInvalid = errors.New("append log dead letter replay claim is invalid or expired")
 
 const (
 	AppendLogDeadLetterStatusPending   = "pending"
@@ -89,6 +91,19 @@ type AppendLogDeadLetter struct {
 	ReplayedAt    time.Time
 	DiscardedAt   time.Time
 	DiscardReason string
+	Replay        AppendLogDeadLetterReplayState
+}
+
+// AppendLogDeadLetterReplayState records bounded recovery ownership without
+// turning the transient lease into the dead-letter status of record.
+type AppendLogDeadLetterReplayState struct {
+	Owner             string
+	Token             string
+	LeaseExpiresAt    time.Time
+	AttemptCount      int
+	LastStartedAt     time.Time
+	LastFinishedAt    time.Time
+	LastErrorCategory string
 }
 
 // AppendLogDeadLetterFilter scopes operator reads over persisted publish
@@ -108,7 +123,10 @@ type AppendLogDeadLetterStore interface {
 	RecordAppendLogDeadLetter(context.Context, AppendLogDeadLetter) error
 	ListAppendLogDeadLetters(context.Context, AppendLogDeadLetterFilter) ([]AppendLogDeadLetter, error)
 	GetAppendLogDeadLetter(context.Context, string) (AppendLogDeadLetter, error)
-	MarkAppendLogDeadLetterReplayed(context.Context, string) error
+	ClaimAppendLogDeadLetterReplay(context.Context, string, string, string, time.Duration) (AppendLogDeadLetter, error)
+	RenewAppendLogDeadLetterReplay(context.Context, string, string, time.Duration) error
+	CompleteAppendLogDeadLetterReplay(context.Context, string, string) error
+	ReleaseAppendLogDeadLetterReplay(context.Context, string, string, string) error
 	DiscardAppendLogDeadLetter(context.Context, string, string) error
 }
 

--- a/internal/statestore/postgres/append_log_dead_letters.go
+++ b/internal/statestore/postgres/append_log_dead_letters.go
@@ -39,8 +39,22 @@ var ensureAppendLogDeadLetterStatements = []string{`CREATE TABLE IF NOT EXISTS a
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   replayed_at TIMESTAMPTZ,
   discarded_at TIMESTAMPTZ,
-  discard_reason TEXT NOT NULL DEFAULT ''
+  discard_reason TEXT NOT NULL DEFAULT '',
+  replay_owner TEXT NOT NULL DEFAULT '',
+  replay_token TEXT NOT NULL DEFAULT '',
+  replay_lease_expires_at TIMESTAMPTZ,
+  replay_attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_replay_started_at TIMESTAMPTZ,
+  last_replay_finished_at TIMESTAMPTZ,
+  last_replay_error_category TEXT NOT NULL DEFAULT ''
 )`,
+	`ALTER TABLE append_log_dead_letters ADD COLUMN IF NOT EXISTS replay_owner TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE append_log_dead_letters ADD COLUMN IF NOT EXISTS replay_token TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE append_log_dead_letters ADD COLUMN IF NOT EXISTS replay_lease_expires_at TIMESTAMPTZ`,
+	`ALTER TABLE append_log_dead_letters ADD COLUMN IF NOT EXISTS replay_attempt_count INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE append_log_dead_letters ADD COLUMN IF NOT EXISTS last_replay_started_at TIMESTAMPTZ`,
+	`ALTER TABLE append_log_dead_letters ADD COLUMN IF NOT EXISTS last_replay_finished_at TIMESTAMPTZ`,
+	`ALTER TABLE append_log_dead_letters ADD COLUMN IF NOT EXISTS last_replay_error_category TEXT NOT NULL DEFAULT ''`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_status_updated_idx ON append_log_dead_letters (status, updated_at ASC, id ASC)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_subject_status_idx ON append_log_dead_letters (subject, status, updated_at ASC)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_runtime_status_idx ON append_log_dead_letters (runtime_id, status, updated_at ASC)`,
@@ -162,8 +176,128 @@ func (s *Store) GetAppendLogDeadLetter(ctx context.Context, id string) (ports.Ap
 	return record, nil
 }
 
-func (s *Store) MarkAppendLogDeadLetterReplayed(ctx context.Context, id string) error {
-	return s.updateAppendLogDeadLetterStatus(ctx, id, ports.AppendLogDeadLetterStatusReplayed, "")
+func (s *Store) ClaimAppendLogDeadLetterReplay(ctx context.Context, id string, owner string, token string, lease time.Duration) (ports.AppendLogDeadLetter, error) {
+	if s == nil || s.db == nil {
+		return ports.AppendLogDeadLetter{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogDeadLetterTables(ctx); err != nil {
+		return ports.AppendLogDeadLetter{}, err
+	}
+	id = strings.TrimSpace(id)
+	owner = strings.TrimSpace(owner)
+	token = strings.TrimSpace(token)
+	if id == "" || owner == "" || token == "" {
+		return ports.AppendLogDeadLetter{}, errors.New("append log dead letter replay id, owner, and token are required")
+	}
+	if lease < time.Second {
+		return ports.AppendLogDeadLetter{}, errors.New("append log dead letter replay lease must be at least one second")
+	}
+	record, err := scanAppendLogDeadLetter(s.db.QueryRowContext(ctx, claimAppendLogDeadLetterReplaySQL(), id, owner, token, int64(lease/time.Second)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return ports.AppendLogDeadLetter{}, s.appendLogDeadLetterClaimConflict(ctx, id)
+	}
+	if err != nil {
+		return ports.AppendLogDeadLetter{}, fmt.Errorf("claim append log dead letter %q replay: %w", id, err)
+	}
+	return record, nil
+}
+
+func claimAppendLogDeadLetterReplaySQL() string {
+	return `UPDATE append_log_dead_letters
+SET replay_owner = $2,
+    replay_token = $3,
+    replay_lease_expires_at = NOW() + ($4 * INTERVAL '1 second'),
+    replay_attempt_count = replay_attempt_count + 1,
+    last_replay_started_at = NOW(),
+    last_replay_finished_at = NULL,
+    last_replay_error_category = '',
+    updated_at = NOW()
+WHERE id = $1
+  AND status = 'pending'
+  AND (replay_token = '' OR replay_lease_expires_at IS NULL OR replay_lease_expires_at <= NOW())
+RETURNING ` + appendLogDeadLetterColumns()
+}
+
+func (s *Store) RenewAppendLogDeadLetterReplay(ctx context.Context, id string, token string, lease time.Duration) error {
+	if lease < time.Second {
+		return errors.New("append log dead letter replay lease must be at least one second")
+	}
+	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, `replay_lease_expires_at = NOW() + ($3 * INTERVAL '1 second'), updated_at = NOW()`, int64(lease/time.Second))
+}
+
+func (s *Store) CompleteAppendLogDeadLetterReplay(ctx context.Context, id string, token string) error {
+	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, `status = 'replayed', replayed_at = NOW(), replay_owner = '', replay_token = '', replay_lease_expires_at = NULL, last_replay_finished_at = NOW(), last_replay_error_category = '', updated_at = NOW()`)
+}
+
+func (s *Store) ReleaseAppendLogDeadLetterReplay(ctx context.Context, id string, token string, errorCategory string) error {
+	errorCategory = strings.TrimSpace(errorCategory)
+	if len(errorCategory) > 64 {
+		errorCategory = errorCategory[:64]
+	}
+	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, `replay_owner = '', replay_token = '', replay_lease_expires_at = NULL, last_replay_finished_at = NOW(), last_replay_error_category = $3, updated_at = NOW()`, errorCategory)
+}
+
+func (s *Store) updateAppendLogDeadLetterReplayClaim(ctx context.Context, id string, token string, assignments string, extra ...any) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogDeadLetterTables(ctx); err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	token = strings.TrimSpace(token)
+	if id == "" || token == "" {
+		return errors.New("append log dead letter replay id and token are required")
+	}
+	args := []any{id, token}
+	args = append(args, extra...)
+	query := `UPDATE append_log_dead_letters SET ` + assignments + ` WHERE id = $1 AND status = 'pending' AND replay_token = $2 AND replay_lease_expires_at > NOW()`
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("update append log dead letter %q replay claim: %w", id, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update append log dead letter %q replay claim rows affected: %w", id, err)
+	}
+	if rows == 0 {
+		return s.appendLogDeadLetterReplayClaimConflict(ctx, id)
+	}
+	return nil
+}
+
+func (s *Store) appendLogDeadLetterClaimConflict(ctx context.Context, id string) error {
+	var status string
+	var token string
+	err := s.db.QueryRowContext(ctx, `SELECT status, replay_token FROM append_log_dead_letters WHERE id = $1`, id).Scan(&status, &token)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ports.ErrAppendLogDeadLetterNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("query append log dead letter %q replay claim: %w", id, err)
+	}
+	if status == ports.AppendLogDeadLetterStatusReplayed {
+		return ports.ErrAppendLogDeadLetterAlreadyReplayed
+	}
+	if token != "" {
+		return ports.ErrAppendLogDeadLetterReplayClaimed
+	}
+	return fmt.Errorf("append log dead letter %q has status %q", id, status)
+}
+
+func (s *Store) appendLogDeadLetterReplayClaimConflict(ctx context.Context, id string) error {
+	var status string
+	err := s.db.QueryRowContext(ctx, `SELECT status FROM append_log_dead_letters WHERE id = $1`, id).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ports.ErrAppendLogDeadLetterNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("query append log dead letter %q replay claim: %w", id, err)
+	}
+	if status == ports.AppendLogDeadLetterStatusReplayed {
+		return ports.ErrAppendLogDeadLetterAlreadyReplayed
+	}
+	return ports.ErrAppendLogDeadLetterReplayClaimInvalid
 }
 
 func (s *Store) DiscardAppendLogDeadLetter(ctx context.Context, id string, reason string) error {
@@ -195,7 +329,7 @@ func (s *Store) updateAppendLogDeadLetterStatus(ctx context.Context, id string, 
 		query = `UPDATE append_log_dead_letters SET status = $2, updated_at = NOW(), replayed_at = NOW() WHERE id = $1 AND status = 'pending'`
 		args = []any{id, status}
 	case ports.AppendLogDeadLetterStatusDiscarded:
-		query = `UPDATE append_log_dead_letters SET status = $2, updated_at = NOW(), discarded_at = NOW(), discard_reason = $3 WHERE id = $1 AND status = 'pending'`
+		query = `UPDATE append_log_dead_letters SET status = $2, updated_at = NOW(), discarded_at = NOW(), discard_reason = $3 WHERE id = $1 AND status = 'pending' AND (replay_token = '' OR replay_lease_expires_at IS NULL OR replay_lease_expires_at <= NOW())`
 		args = []any{id, status, strings.TrimSpace(reason)}
 	default:
 		return fmt.Errorf("unsupported append log dead letter status %q", status)
@@ -234,11 +368,16 @@ func appendLogDeadLetterTransitionConflictError(id string, targetStatus string, 
 }
 
 func appendLogDeadLetterSelectSQL() string {
-	return `SELECT id, status, subject, operation, event_id, event_kind, tenant_id, source_id,
+	return `SELECT ` + appendLogDeadLetterColumns() + ` FROM append_log_dead_letters`
+}
+
+func appendLogDeadLetterColumns() string {
+	return `id, status, subject, operation, event_id, event_kind, tenant_id, source_id,
        runtime_id, job_id, error_category, error_message, retry_count, max_attempts,
        payload_hash, payload_bytes, event_json, created_at, updated_at, replayed_at,
-       discarded_at, discard_reason
-FROM append_log_dead_letters`
+       discarded_at, discard_reason, replay_owner, replay_token, replay_lease_expires_at,
+       replay_attempt_count, last_replay_started_at, last_replay_finished_at,
+       last_replay_error_category`
 }
 
 func appendLogDeadLetterListQuery(filter ports.AppendLogDeadLetterFilter) (string, []any) {
@@ -346,13 +485,16 @@ type appendLogDeadLetterScanner interface {
 
 func scanAppendLogDeadLetter(scanner appendLogDeadLetterScanner) (ports.AppendLogDeadLetter, error) {
 	var (
-		record        ports.AppendLogDeadLetter
-		eventJSON     []byte
-		createdAt     time.Time
-		updatedAt     time.Time
-		replayedAt    sql.NullTime
-		discardedAt   sql.NullTime
-		discardReason string
+		record               ports.AppendLogDeadLetter
+		eventJSON            []byte
+		createdAt            time.Time
+		updatedAt            time.Time
+		replayedAt           sql.NullTime
+		discardedAt          sql.NullTime
+		replayLeaseExpiresAt sql.NullTime
+		lastReplayStartedAt  sql.NullTime
+		lastReplayFinishedAt sql.NullTime
+		discardReason        string
 	)
 	if err := scanner.Scan(
 		&record.ID,
@@ -377,6 +519,13 @@ func scanAppendLogDeadLetter(scanner appendLogDeadLetterScanner) (ports.AppendLo
 		&replayedAt,
 		&discardedAt,
 		&discardReason,
+		&record.Replay.Owner,
+		&record.Replay.Token,
+		&replayLeaseExpiresAt,
+		&record.Replay.AttemptCount,
+		&lastReplayStartedAt,
+		&lastReplayFinishedAt,
+		&record.Replay.LastErrorCategory,
 	); err != nil {
 		return ports.AppendLogDeadLetter{}, err
 	}
@@ -394,6 +543,18 @@ func scanAppendLogDeadLetter(scanner appendLogDeadLetterScanner) (ports.AppendLo
 		record.DiscardedAt = discardedAt.Time
 	}
 	record.DiscardReason = strings.TrimSpace(discardReason)
+	record.Replay.Owner = strings.TrimSpace(record.Replay.Owner)
+	record.Replay.Token = strings.TrimSpace(record.Replay.Token)
+	record.Replay.LastErrorCategory = strings.TrimSpace(record.Replay.LastErrorCategory)
+	if replayLeaseExpiresAt.Valid {
+		record.Replay.LeaseExpiresAt = replayLeaseExpiresAt.Time
+	}
+	if lastReplayStartedAt.Valid {
+		record.Replay.LastStartedAt = lastReplayStartedAt.Time
+	}
+	if lastReplayFinishedAt.Valid {
+		record.Replay.LastFinishedAt = lastReplayFinishedAt.Time
+	}
 	return record, nil
 }
 

--- a/internal/statestore/postgres/append_log_dead_letters.go
+++ b/internal/statestore/postgres/append_log_dead_letters.go
@@ -222,11 +222,11 @@ func (s *Store) RenewAppendLogDeadLetterReplay(ctx context.Context, id string, t
 	if lease < time.Second {
 		return errors.New("append log dead letter replay lease must be at least one second")
 	}
-	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, `replay_lease_expires_at = NOW() + ($3 * INTERVAL '1 second'), updated_at = NOW()`, int64(lease/time.Second))
+	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, renewAppendLogDeadLetterReplaySQL, int64(lease/time.Second))
 }
 
 func (s *Store) CompleteAppendLogDeadLetterReplay(ctx context.Context, id string, token string) error {
-	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, `status = 'replayed', replayed_at = NOW(), replay_owner = '', replay_token = '', replay_lease_expires_at = NULL, last_replay_finished_at = NOW(), last_replay_error_category = '', updated_at = NOW()`)
+	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, completeAppendLogDeadLetterReplaySQL)
 }
 
 func (s *Store) ReleaseAppendLogDeadLetterReplay(ctx context.Context, id string, token string, errorCategory string) error {
@@ -234,10 +234,22 @@ func (s *Store) ReleaseAppendLogDeadLetterReplay(ctx context.Context, id string,
 	if len(errorCategory) > 64 {
 		errorCategory = errorCategory[:64]
 	}
-	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, `replay_owner = '', replay_token = '', replay_lease_expires_at = NULL, last_replay_finished_at = NOW(), last_replay_error_category = $3, updated_at = NOW()`, errorCategory)
+	return s.updateAppendLogDeadLetterReplayClaim(ctx, id, token, releaseAppendLogDeadLetterReplaySQL, errorCategory)
 }
 
-func (s *Store) updateAppendLogDeadLetterReplayClaim(ctx context.Context, id string, token string, assignments string, extra ...any) error {
+const renewAppendLogDeadLetterReplaySQL = `UPDATE append_log_dead_letters
+SET replay_lease_expires_at = NOW() + ($3 * INTERVAL '1 second'), updated_at = NOW()
+WHERE id = $1 AND status = 'pending' AND replay_token = $2 AND replay_lease_expires_at > NOW()`
+
+const completeAppendLogDeadLetterReplaySQL = `UPDATE append_log_dead_letters
+SET status = 'replayed', replayed_at = NOW(), replay_owner = '', replay_token = '', replay_lease_expires_at = NULL, last_replay_finished_at = NOW(), last_replay_error_category = '', updated_at = NOW()
+WHERE id = $1 AND status = 'pending' AND replay_token = $2 AND replay_lease_expires_at > NOW()`
+
+const releaseAppendLogDeadLetterReplaySQL = `UPDATE append_log_dead_letters
+SET replay_owner = '', replay_token = '', replay_lease_expires_at = NULL, last_replay_finished_at = NOW(), last_replay_error_category = $3, updated_at = NOW()
+WHERE id = $1 AND status = 'pending' AND replay_token = $2 AND replay_lease_expires_at > NOW()`
+
+func (s *Store) updateAppendLogDeadLetterReplayClaim(ctx context.Context, id string, token string, query string, extra ...any) error {
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")
 	}
@@ -251,7 +263,6 @@ func (s *Store) updateAppendLogDeadLetterReplayClaim(ctx context.Context, id str
 	}
 	args := []any{id, token}
 	args = append(args, extra...)
-	query := `UPDATE append_log_dead_letters SET ` + assignments + ` WHERE id = $1 AND status = 'pending' AND replay_token = $2 AND replay_lease_expires_at > NOW()`
 	result, err := s.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("update append log dead letter %q replay claim: %w", id, err)

--- a/internal/statestore/postgres/append_log_dead_letters_test.go
+++ b/internal/statestore/postgres/append_log_dead_letters_test.go
@@ -19,6 +19,13 @@ func TestAppendLogDeadLetterSchemaShape(t *testing.T) {
 		"runtime_id TEXT NOT NULL DEFAULT ''",
 		"job_id TEXT NOT NULL DEFAULT ''",
 		"event_json JSONB NOT NULL",
+		"replay_owner TEXT NOT NULL DEFAULT ''",
+		"replay_token TEXT NOT NULL DEFAULT ''",
+		"replay_lease_expires_at TIMESTAMPTZ",
+		"replay_attempt_count INTEGER NOT NULL DEFAULT 0",
+		"last_replay_started_at TIMESTAMPTZ",
+		"last_replay_finished_at TIMESTAMPTZ",
+		"last_replay_error_category TEXT NOT NULL DEFAULT ''",
 		"append_log_dead_letters_status_updated_idx",
 		"append_log_dead_letters_subject_status_idx",
 		"append_log_dead_letters_runtime_status_idx",
@@ -26,6 +33,20 @@ func TestAppendLogDeadLetterSchemaShape(t *testing.T) {
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("append log dead letter schema missing %q:\n%s", fragment, joined)
+		}
+	}
+}
+
+func TestClaimAppendLogDeadLetterReplayUsesAtomicLease(t *testing.T) {
+	query := claimAppendLogDeadLetterReplaySQL()
+	for _, fragment := range []string{
+		"replay_attempt_count = replay_attempt_count + 1",
+		"status = 'pending'",
+		"replay_token = '' OR replay_lease_expires_at IS NULL OR replay_lease_expires_at <= NOW()",
+		"RETURNING id, status",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("claimAppendLogDeadLetterReplaySQL() missing %q:\n%s", fragment, query)
 		}
 	}
 }


### PR DESCRIPTION
## What changed

- atomically claim a pending append-log dead letter before publishing it
- require an opaque claim token to renew, complete, or release replay ownership
- allow another operator to recover an expired lease while rejecting stale claim tokens
- record attempt count, claim timing, completion timing, and a bounded last error category
- renew active claims during a long publish and release failed publishes back to pending
- show claim state and lease expiry in CLI list output without exposing the token
- prevent discard while an unexpired replay claim is active

## Why

The replay command previously read a pending row, published the event, and only then marked the row as replayed. Concurrent operators could therefore publish the same event before either status update completed.

## Operator impact

One operator owns a replay at a time. A second replay reports that the record is already claimed. If the process exits, another operator can retry after the listed lease expiry. Failed publication keeps the record pending and records `append_failed` for diagnosis.

## Validation

- `go test ./internal/statestore/postgres ./internal/appendlog/recovery ./cmd/cerebro -count=1`
- `go vet ./internal/statestore/postgres ./internal/appendlog/recovery ./cmd/cerebro`
- `make docs-drift-check check-structural check-structural-test check-arch`
- `git diff --check`

Refs #1733
