### PR TITLE
recovery: define dead letter data policy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ For durable evidence and graph context, run `make github-business-demo` with `GI
 | Coding agent setup handoff | [Agent onboarding](start/agent-onboarding.md) |
 | Runtime shape and dependency boundaries | [Architecture](reference/architecture.md) |
 | Runtime configuration | [Configuration variables](reference/config-env-vars.md) |
-| Hosting and operations | [Hosting](operations/hosting.md), [runtime profiles](operations/runtime-profiles.md), [deployment readiness](operations/deployment-readiness.md), [cloud deployment](operations/cloud-deployment.md), [deployment examples](operations/deployment-examples.md), [operations runbook](operations/operations-runbook.md), and [troubleshooting](operations/troubleshooting.md) |
+| Hosting and operations | [Hosting](operations/hosting.md), [runtime profiles](operations/runtime-profiles.md), [deployment readiness](operations/deployment-readiness.md), [cloud deployment](operations/cloud-deployment.md), [deployment examples](operations/deployment-examples.md), [operations runbook](operations/operations-runbook.md), [append-log dead-letter data policy](operations/append-log-dead-letter-policy.md), and [troubleshooting](operations/troubleshooting.md) |
 | API contracts | [API reference](reference/api-reference.md), [generated API contracts](reference/api-contracts.md), `../api/openapi.yaml`, and `../proto/cerebro/v1/bootstrap.proto` |
 | CLI usage | [CLI reference](reference/cli.md) |
 | Built-in source integrations | [Source catalog](reference/sources.md) |

--- a/docs/operations/append-log-dead-letter-policy.md
+++ b/docs/operations/append-log-dead-letter-policy.md
@@ -1,0 +1,48 @@
+# Append-Log Dead-Letter Data Policy
+
+## Purpose
+
+Append-log dead letters preserve one event after JetStream publication exhausts its retry budget. They exist so an operator can replay or discard that event without depending on the unavailable broker.
+
+## Data Classification
+
+| Field group | Classification | Operator list output | Telemetry |
+| --- | --- | --- | --- |
+| ID, status, event kind, subject, retry counts, payload size and hash | Operational | Allowed | Allowed with bounded dimensions |
+| Tenant, source, runtime, and job identifiers | Internal | Allowed only through authenticated operator commands | Values excluded from metric dimensions |
+| Error category and generated diagnostic | Operational | Category allowed | Category allowed |
+| Replayable event envelope | Sensitive recovery data | Never returned | Never emitted |
+| Replay claim token | Secret | Never returned | Never emitted |
+
+The stored diagnostic is generated from the bounded retry category and attempt counts. Wrapped transport errors, authorization headers, credentials, request or response bodies, and provider URLs are not persisted in the diagnostic field.
+
+The replayable envelope remains in Postgres. Production deployments must provide tenant isolation, encrypted storage, encrypted backups, and access logging for the database that owns the table.
+
+## Retention
+
+- Pending records are not deleted by a terminal-record retention job.
+- Pending records older than 7 days require an operator alert and disposition.
+- Replayed and discarded records have a default retention period of 30 days.
+- Forced deletion of a pending record requires an authenticated actor, a concrete reason, and a durable audit record for every deleted ID.
+- Cleanup runs operate in bounded batches of at most 500 rows and persist their cursor so interruption resumes after the last committed batch.
+
+## Capacity Limits
+
+- Emit backlog rows, estimated payload bytes, and oldest pending age without tenant IDs in metric dimensions.
+- Warn at 10,000 rows or 1 GiB of replayable payloads.
+- Reject creation above 100,000 rows or 10 GiB until an operator restores publication or performs an audited emergency purge.
+- A hard-limit rejection records a bounded category and never logs the rejected event envelope.
+
+These limits are defaults. A deployment may set lower limits. Raising a hard limit requires a recorded policy change and confirmed database headroom.
+
+## Audited Actions
+
+Replay, discard, forced pending purge, and retention-policy changes record the authenticated actor, action, reason, record ID or policy revision, and timestamp. Claim tokens and event envelopes are excluded from audit payloads.
+
+## Recovery Procedure
+
+1. Restore JetStream publication health.
+2. List pending records and review subject, event kind, age, attempts, and claim state.
+3. Replay one record at a time. Wait for an active ownership lease to expire before retrying an abandoned claim.
+4. Discard only when the event must not be published, and provide the reason required by the command.
+5. Use forced pending purge only when retention of the recovery payload creates a greater incident risk than event loss. Record the incident or change reference in the reason.

--- a/docs/operations/operations-runbook.md
+++ b/docs/operations/operations-runbook.md
@@ -145,6 +145,9 @@ same event exhausts again after an operator has replayed or discarded that
 record, Cerebro preserves the terminal record and does not move it back to
 `pending`.
 
+See [Append-log dead-letter data policy](append-log-dead-letter-policy.md) for
+payload classification, retention, capacity limits, and emergency purge rules.
+
 ### Neo4j or Aura
 
 Neo4j or Aura is required for graph projection, graph queries, graph health, graph ingest runs, impact queries, and graph-agent flows.

--- a/internal/appendlog/recovery/recovery.go
+++ b/internal/appendlog/recovery/recovery.go
@@ -134,7 +134,7 @@ func deadLetterFromEvent(event *cerebrov1.EventEnvelope, exhausted *ports.Append
 		RuntimeID:     strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]),
 		JobID:         strings.TrimSpace(attrs[ports.EventAttributeJobID]),
 		ErrorCategory: strings.TrimSpace(exhausted.ErrorCategory),
-		ErrorMessage:  strings.TrimSpace(exhausted.Error()),
+		ErrorMessage:  deadLetterDiagnostic(exhausted),
 		RetryCount:    exhausted.RetryCount,
 		MaxAttempts:   exhausted.MaxAttempts,
 		PayloadHash:   hash,
@@ -148,6 +148,24 @@ func deadLetterFromEvent(event *cerebrov1.EventEnvelope, exhausted *ports.Append
 		record.ErrorCategory = "unknown"
 	}
 	return record, nil
+}
+
+func deadLetterDiagnostic(exhausted *ports.AppendLogPublishExhaustedError) string {
+	if exhausted == nil {
+		return "append log publish exhausted; category=unknown"
+	}
+	category := strings.TrimSpace(exhausted.ErrorCategory)
+	if category == "" {
+		category = "unknown"
+	}
+	// Persist only bounded fields owned by the retry contract. The wrapped error may
+	// contain authorization headers, credentials, URLs, or provider response bodies.
+	return fmt.Sprintf(
+		"append log publish exhausted; category=%s; attempts=%d/%d",
+		category,
+		exhausted.RetryCount,
+		exhausted.MaxAttempts,
+	)
 }
 
 func deterministicEventPayload(event *cerebrov1.EventEnvelope) ([]byte, string, error) {

--- a/internal/appendlog/recovery/recovery_test.go
+++ b/internal/appendlog/recovery/recovery_test.go
@@ -53,7 +53,7 @@ func TestAppendRecordsExhaustedPublish(t *testing.T) {
 }
 
 func TestDeadLetterDiagnosticDoesNotPersistWrappedError(t *testing.T) {
-	secret := "Bearer test-sensitive-value"
+	secret := "Bearer test-sensitive-value" // #nosec G101 -- credential-shaped test data verifies diagnostic redaction.
 	diagnostic := deadLetterDiagnostic(&ports.AppendLogPublishExhaustedError{
 		Subject:       "sec.findings.v1.recorded",
 		ErrorCategory: "no_response",

--- a/internal/appendlog/recovery/recovery_test.go
+++ b/internal/appendlog/recovery/recovery_test.go
@@ -3,6 +3,7 @@ package recovery
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,11 +41,28 @@ func TestAppendRecordsExhaustedPublish(t *testing.T) {
 	if record.RetryCount != 3 || record.MaxAttempts != 4 || record.ErrorCategory != "no_response" {
 		t.Fatalf("record retry fields = %#v", record)
 	}
+	if record.ErrorMessage != "append log publish exhausted; category=no_response; attempts=3/4" {
+		t.Fatalf("record error message = %q, want bounded retry diagnostic", record.ErrorMessage)
+	}
 	if record.ID == "" || record.PayloadHash == "" || record.PayloadBytes == 0 || record.Event == nil {
 		t.Fatalf("record durability fields missing: %#v", record)
 	}
 	if inner.events[0] == record.Event {
 		t.Fatal("record reused event pointer; want cloned event")
+	}
+}
+
+func TestDeadLetterDiagnosticDoesNotPersistWrappedError(t *testing.T) {
+	secret := "Bearer test-sensitive-value"
+	diagnostic := deadLetterDiagnostic(&ports.AppendLogPublishExhaustedError{
+		Subject:       "sec.findings.v1.recorded",
+		ErrorCategory: "no_response",
+		RetryCount:    3,
+		MaxAttempts:   4,
+		Err:           errors.New("authorization=" + secret + " response={unbounded-body}"),
+	})
+	if strings.Contains(diagnostic, secret) || strings.Contains(diagnostic, "authorization") || strings.Contains(diagnostic, "unbounded-body") {
+		t.Fatalf("deadLetterDiagnostic() leaked wrapped error: %q", diagnostic)
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - Cloud Deployment: operations/cloud-deployment.md
       - Deployment Examples: operations/deployment-examples.md
       - Operations Runbook: operations/operations-runbook.md
+      - Append-Log Dead-Letter Data Policy: operations/append-log-dead-letter-policy.md
       - Headroom: operations/headroom.md
       - Observability: operations/observability.md
       - Troubleshooting: operations/troubleshooting.md


### PR DESCRIPTION
## What changed

- replace wrapped transport errors in dead-letter rows with a bounded diagnostic built from retry category and attempt counts
- add regression coverage proving authorization values and provider response bodies are not persisted in the diagnostic field
- define the recovery payload classification, pending and terminal retention rules, capacity limits, audit requirements, and emergency recovery procedure
- link the policy from the operations runbook and documentation index

## Why

Dead-letter rows contain the event envelope needed for recovery. The previous diagnostic also persisted the wrapped publish error, which could contain credentials, authorization headers, URLs, or unbounded provider response bodies.

## Operator impact

Operators still receive the error category and retry counts needed to diagnose publication failure. Raw transport details are excluded from the recovery row. The checked-in policy defines how the sensitive replay payload must be stored and which cleanup and audit controls the next implementation slice must enforce.

## Remaining issue slices

- enforce pending and terminal retention in bounded resumable cleanup jobs
- enforce backlog row and byte limits with bounded metrics
- persist actor/reason audit records for replay, discard, forced purge, and policy changes

## Validation

- `go test ./internal/appendlog/recovery -count=1`
- `make docs-drift-check oss-audit`
- `git diff --check`

Refs #1734
Depends on #1781
