### PR TITLE
Gate generated sources on provider fidelity

### DIFF
--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -136,7 +136,12 @@ type familyData struct {
 	Config                familyConfigData
 	RequiredAttributes    []string
 	RequiredPayloadFields []string
-	Projection            *connectordefinitions.ProjectionSpec
+	Contract              familyContractData
+}
+
+type familyContractData struct {
+	Projection *connectordefinitions.ProjectionSpec
+	Coverage   []connectordefinitions.CoverageDimensionSpec
 }
 
 type familyConfigData struct {
@@ -749,7 +754,10 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			Config:                config,
 			RequiredAttributes:    requiredAttributes,
 			RequiredPayloadFields: requiredPayloadFields,
-			Projection:            resource.Projection,
+			Contract: familyContractData{
+				Projection: resource.Projection,
+				Coverage:   append([]connectordefinitions.CoverageDimensionSpec(nil), resource.Coverage...),
+			},
 		})
 	}
 	return families, nil
@@ -1017,6 +1025,12 @@ func renderCatalog(request normalizedRequest) string {
 	fmt.Fprintf(&b, "  authority_domain: %s\n", request.SourceID)
 	fmt.Fprintf(&b, "  dimensions:\n")
 	for _, family := range request.Families {
+		if len(family.Contract.Coverage) > 0 {
+			for index, dimension := range family.Contract.Coverage {
+				renderCoverageDimension(&b, family, dimension, index)
+			}
+			continue
+		}
 		dimensionType := coverageDimensionType(family.Class)
 		fmt.Fprintf(&b, "    - id: %s\n", family.Name)
 		fmt.Fprintf(&b, "      type: %s\n", dimensionType)
@@ -1049,6 +1063,55 @@ func renderCatalog(request normalizedRequest) string {
 		}
 	}
 	return b.String()
+}
+
+func renderCoverageDimension(b *strings.Builder, family familyData, dimension connectordefinitions.CoverageDimensionSpec, index int) {
+	id := strings.TrimSpace(dimension.ID)
+	if id == family.Name+"_"+strings.TrimSpace(dimension.Type) {
+		id = family.Name
+	}
+	if id == "" {
+		id = family.Name
+		if index > 0 {
+			id += "_" + strings.TrimSpace(dimension.Type)
+		}
+	}
+	families := uniqueStrings(dimension.Families)
+	if len(families) == 0 {
+		families = []string{family.Name}
+	}
+	fmt.Fprintf(b, "    - id: %s\n", id)
+	fmt.Fprintf(b, "      type: %s\n", strings.TrimSpace(dimension.Type))
+	fmt.Fprintf(b, "      title: %s\n", yamlString(firstNonEmptyString(dimension.Title, titleFromID(id))))
+	fmt.Fprintf(b, "      families: [%s]\n", strings.Join(families, ", "))
+	fmt.Fprintf(b, "      support: %s\n", strings.TrimSpace(dimension.Support))
+	fmt.Fprintf(b, "      high_value: %t\n", dimension.HighValue)
+	if len(dimension.EvidenceTypes) > 0 {
+		fmt.Fprintf(b, "      evidence_types: [%s]\n", strings.Join(dimension.EvidenceTypes, ", "))
+	}
+	if len(dimension.ControlDomains) > 0 {
+		fmt.Fprintf(b, "      control_domains: [%s]\n", strings.Join(dimension.ControlDomains, ", "))
+	}
+	if len(dimension.ControlRefs) > 0 {
+		fmt.Fprintf(b, "      control_refs:\n")
+		for _, ref := range dimension.ControlRefs {
+			if strings.TrimSpace(ref.FrameworkID) != "" {
+				fmt.Fprintf(b, "        - framework_id: %s\n", yamlString(ref.FrameworkID))
+			} else {
+				fmt.Fprintf(b, "        - framework_name: %s\n", yamlString(ref.FrameworkName))
+			}
+			fmt.Fprintf(b, "          control_id: %s\n", yamlString(ref.ControlID))
+		}
+	}
+	if len(dimension.KnownUnsupportedFields) > 0 {
+		fmt.Fprintf(b, "      known_unsupported_fields: [%s]\n", quotedStrings(dimension.KnownUnsupportedFields))
+	}
+	if len(dimension.Notes) > 0 {
+		fmt.Fprintf(b, "      notes:\n")
+		for _, note := range dimension.Notes {
+			fmt.Fprintf(b, "        - %s\n", yamlString(note))
+		}
+	}
 }
 
 func renderProviderAPI(b *strings.Builder, api *connectordefinitions.ProviderAPISpec) {
@@ -1587,8 +1650,8 @@ func attributePathsForFamily(family familyData) map[string]string {
 		base["alert_resolved_at"] = "resolved_at|closed_at|acknowledged_at"
 		base["alert_description"] = "description|summary|message|body"
 	}
-	if family.Projection != nil {
-		for key, value := range family.Projection.Fields {
+	if family.Contract.Projection != nil {
+		for key, value := range family.Contract.Projection.Fields {
 			if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
 				base[strings.TrimSpace(key)] = strings.TrimSpace(value)
 			}
@@ -1747,6 +1810,14 @@ func renderSourceTestGo(request normalizedRequest) string {
 	if request.OAuth != nil {
 		fmt.Fprintf(&b, "\tif tokenRequests < 1 || tokenRequests > len(familyCases) {\n\t\tt.Fatalf(\"token requests = %%d, want between 1 and %%d\", tokenRequests, len(familyCases))\n\t}\n")
 	}
+	fmt.Fprintf(&b, "\tt.Run(\"ProviderUnavailable\", func(t *testing.T) {\n")
+	fmt.Fprintf(&b, "\t\tunavailableServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {\n\t\t\thttp.Error(w, \"provider unavailable\", http.StatusServiceUnavailable)\n\t\t}))\n\t\tdefer unavailableServer.Close()\n")
+	fmt.Fprintf(&b, "\t\tunavailableSource, err := New()\n\t\tif err != nil {\n\t\t\tt.Fatalf(\"New() error = %%v\", err)\n\t\t}\n\t\tunavailableSource.allowLoopbackForTest()\n")
+	fmt.Fprintf(&b, "\t\tunavailableValues := map[string]string{}\n\t\tfor key, value := range cfgValues {\n\t\t\tunavailableValues[key] = value\n\t\t}\n\t\tunavailableValues[\"base_url\"] = unavailableServer.URL\n")
+	if request.OAuth != nil {
+		fmt.Fprintf(&b, "\t\tunavailableValues[\"token_url\"] = unavailableServer.URL + \"/oauth/token\"\n")
+	}
+	fmt.Fprintf(&b, "\t\tif err := unavailableSource.Check(context.Background(), sourcecdk.NewConfig(unavailableValues)); err == nil {\n\t\t\tt.Fatal(\"Check() error = nil, want provider unavailable error\")\n\t\t}\n\t})\n")
 	fmt.Fprintf(&b, "}\n")
 	fmt.Fprintf(&b, "\nfunc TestNewFixtureReplaysGeneratedFamilies(t *testing.T) {\n")
 	fmt.Fprintf(&b, "\tsource, err := NewFixture()\n\tif err != nil {\n\t\tt.Fatalf(\"NewFixture() error = %%v\", err)\n\t}\n")
@@ -1792,8 +1863,8 @@ func sourceTestRecord(request normalizedRequest, family familyData) map[string]a
 			}
 		}
 	}
-	if family.Projection != nil {
-		for attr := range family.Projection.Fields {
+	if family.Contract.Projection != nil {
+		for attr := range family.Contract.Projection.Fields {
 			if path := strings.TrimSpace(paths[attr]); path != "" {
 				value := fixtureAttributeValueForMapping(request, attr, path, family)
 				if strings.TrimSpace(value) != "" {
@@ -2013,8 +2084,6 @@ func fixturePayload(request normalizedRequest, family familyData) map[string]any
 	displayName := fixtureDisplayName(request, family)
 	evidenceURI := fixtureEvidenceURI(request, family)
 	payload := map[string]any{
-		"api_method":          fixtureAPIMethod(family),
-		"api_path":            family.Path,
 		"family":              family.Name,
 		"id":                  recordID,
 		"name":                displayName,
@@ -2027,6 +2096,10 @@ func fixturePayload(request normalizedRequest, family familyData) map[string]any
 		"updated_at":          "2026-06-01T00:00:00Z",
 		"evidence_cas_uri":    evidenceURI,
 		"evidence_cas_digest": "sha256:test",
+	}
+	if !providerAPIVerified(request) {
+		payload["api_method"] = fixtureAPIMethod(family)
+		payload["api_path"] = family.Path
 	}
 	if family.RecordSelector != "" {
 		payload["record_selector"] = family.RecordSelector
@@ -2082,8 +2155,6 @@ func fixtureAttributes(request normalizedRequest, family familyData) map[string]
 	displayName := fixtureDisplayName(request, family)
 	evidenceURI := fixtureEvidenceURI(request, family)
 	attributes := map[string]string{
-		"api_method":            fixtureAPIMethod(family),
-		"api_path":              family.Path,
 		"external_id":           recordID,
 		"family":                family.Name,
 		"provider":              request.SourceID,
@@ -2101,6 +2172,10 @@ func fixtureAttributes(request normalizedRequest, family familyData) map[string]
 		"evidence_cas_uri":      evidenceURI,
 		"evidence_cas_digest":   "sha256:test",
 		"evidence_cas_ref_type": "source_fixture",
+	}
+	if !providerAPIVerified(request) {
+		attributes["api_method"] = fixtureAPIMethod(family)
+		attributes["api_path"] = family.Path
 	}
 	if family.RecordSelector != "" {
 		attributes["record_selector"] = family.RecordSelector
@@ -2320,6 +2395,9 @@ func fixtureLiteralResourceType(rawPath string) string {
 }
 
 func fixtureRecordID(request normalizedRequest, family familyData) string {
+	if providerAPIVerified(request) {
+		return request.SourceID + "-" + family.Name + "-001"
+	}
 	return "source-" + request.SourceID + "-" + family.Name + "-1"
 }
 
@@ -2332,7 +2410,14 @@ func fixtureRelatedRecordID(request normalizedRequest, familyName string) string
 }
 
 func fixtureDisplayName(request normalizedRequest, family familyData) string {
+	if providerAPIVerified(request) {
+		return titleFromID(request.SourceID) + " " + titleFromID(family.Name)
+	}
 	return titleFromID(request.SourceID) + " " + titleFromID(family.Name) + " Fixture"
+}
+
+func providerAPIVerified(request normalizedRequest) bool {
+	return request.ProviderAPI != nil && strings.EqualFold(strings.TrimSpace(request.ProviderAPI.Status), "verified")
 }
 
 func fixtureEvidenceURI(request normalizedRequest, family familyData) string {
@@ -2477,7 +2562,7 @@ func renderProjectionGo(request normalizedRequest) string {
 			}
 			renderedProjectionResources[family.ProjectorName] = struct{}{}
 			fmt.Fprintf(&b, "var %sProjectionResource = connectordefinitions.ResourceFamily{\n\tID: %s,\n\tProjection: &connectordefinitions.ProjectionSpec{\n", family.ProjectorName, strconv.Quote(family.Name))
-			renderProjectionSpecLiteral(&b, family.Projection, "\t\t")
+			renderProjectionSpecLiteral(&b, family.Contract.Projection, "\t\t")
 			fmt.Fprintf(&b, "\t},\n}\n\n")
 		}
 	}
@@ -2587,7 +2672,7 @@ func projectionNeedsConnectordefinitions(families []familyData) bool {
 }
 
 func projectionFamilyNeedsAugmentation(family familyData) bool {
-	return family.Projection != nil && (family.Projection.Entity != nil || len(family.Projection.Relationships) != 0)
+	return family.Contract.Projection != nil && (family.Contract.Projection.Entity != nil || len(family.Contract.Projection.Relationships) != 0)
 }
 
 func renderProjectionDispatchReturn(b *strings.Builder, sourceID string, family familyData, baseFunc string) {

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -301,13 +301,12 @@ func TestGenerateDefinitionWritesIdentitySource(t *testing.T) {
 	}
 	readFixture := readGeneratedFile(t, outputDir, "sources/example_idp/testdata/read_users.json")
 	for _, want := range []string{
-		`"api_path": "/v1/users"`,
 		`"kind": "example_idp.user"`,
 		`"record_selector": "$.data[*]"`,
 		`"schema_ref": "example_idp/user/v1"`,
 		`"source_id": "example_idp"`,
 		`"user_id":`,
-		`source-example_idp-users-1`,
+		`example_idp-users-001`,
 	} {
 		if !strings.Contains(readFixture, want) {
 			t.Fatalf("read fixture missing %q:\n%s", want, readFixture)
@@ -315,6 +314,9 @@ func TestGenerateDefinitionWritesIdentitySource(t *testing.T) {
 	}
 	if strings.Contains(readFixture, "Record One") {
 		t.Fatalf("read fixture still uses generic synthetic name:\n%s", readFixture)
+	}
+	if strings.Contains(readFixture, `"api_path"`) || strings.Contains(readFixture, " Fixture") {
+		t.Fatalf("verified provider fixture still contains generator markers:\n%s", readFixture)
 	}
 	var events []struct {
 		Payload    map[string]any    `json:"payload"`

--- a/tools/sourcefidelity/main_test.go
+++ b/tools/sourcefidelity/main_test.go
@@ -5,7 +5,134 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/writer/cerebro/internal/connectordefinitions"
+	"github.com/writer/cerebro/internal/sourcegen"
 )
+
+func TestGeneratedProviderPilotsAreHighFidelity(t *testing.T) {
+	root := t.TempDir()
+	pilots := []struct {
+		name       string
+		auth       string
+		method     string
+		pagination *connectordefinitions.PaginationSpec
+	}{
+		{
+			name: "bearer_cursor_pilot",
+			auth: sourcegen.AuthModelBearerToken,
+			pagination: &connectordefinitions.PaginationSpec{
+				Type: "cursor", CursorParam: "after", CursorJSONPath: "$.paging.next",
+			},
+		},
+		{
+			name: "oauth_page_pilot",
+			auth: sourcegen.AuthModelOAuthClientCredentials,
+			pagination: &connectordefinitions.PaginationSpec{
+				Type: "page", PageParam: "page", PageSizeParam: "per_page", StartPage: 1,
+			},
+		},
+		{
+			name:   "post_list_pilot",
+			auth:   sourcegen.AuthModelBearerToken,
+			method: "POST",
+		},
+	}
+	for _, pilot := range pilots {
+		t.Run(pilot.name, func(t *testing.T) {
+			if _, err := sourcegen.GenerateDefinition(sourcegen.DefinitionRequest{
+				Definition: providerPilotDefinition(pilot.name, pilot.auth, pilot.method, pilot.pagination),
+				OutputDir:  root,
+			}); err != nil {
+				t.Fatalf("GenerateDefinition() error = %v", err)
+			}
+		})
+	}
+
+	result, err := buildReport(root)
+	if err != nil {
+		t.Fatalf("buildReport() error = %v", err)
+	}
+	for _, pilot := range pilots {
+		source := sourceByID(t, result, pilot.name)
+		if source.Score != 100 || source.Level != "reference" {
+			t.Fatalf("%s fidelity = %d (%s), missing %#v", pilot.name, source.Score, source.Level, source.Missing)
+		}
+		if !source.IsGeneratedScaffold {
+			t.Fatalf("%s was not recognized as sourcegen output", pilot.name)
+		}
+	}
+}
+
+func providerPilotDefinition(sourceID string, authModel string, method string, pagination *connectordefinitions.PaginationSpec) connectordefinitions.Definition {
+	credentialFields := []connectordefinitions.Field{{Key: "token", Secret: true, ReferenceOnly: true}}
+	auth := connectordefinitions.AuthSpec{Model: authModel, CredentialFields: credentialFields}
+	if authModel == sourcegen.AuthModelOAuthClientCredentials {
+		auth.TokenURL = "https://api." + sourceID + ".example/oauth/token"
+		auth.CredentialFields = []connectordefinitions.Field{
+			{Key: "client_id", ReferenceOnly: true},
+			{Key: "client_secret", Secret: true, ReferenceOnly: true},
+		}
+	}
+	providerFamilies := make([]connectordefinitions.ProviderAPIFamilySpec, 0, 2)
+	resourceFamilies := make([]connectordefinitions.ResourceFamily, 0, 2)
+	for _, family := range []string{"accounts", "users"} {
+		path := "/v1/" + family
+		providerFamilies = append(providerFamilies, connectordefinitions.ProviderAPIFamilySpec{ID: family, Method: firstNonEmpty(method, "GET"), Path: path})
+		resourceFamilies = append(resourceFamilies, connectordefinitions.ResourceFamily{
+			ID:             family,
+			Path:           path,
+			Method:         method,
+			RecordSelector: "$.data[*]",
+			IDField:        "id",
+			NameField:      "name",
+			Pagination:     pagination,
+			Event: connectordefinitions.EventMappingSpec{
+				Kind:      sourceID + "." + family,
+				SchemaRef: sourceID + "/" + family + "/v1",
+			},
+			Projection: &connectordefinitions.ProjectionSpec{Template: "asset"},
+			Coverage: []connectordefinitions.CoverageDimensionSpec{{
+				ID:             family,
+				Type:           "entity_family",
+				Title:          strings.ToUpper(family[:1]) + family[1:],
+				Families:       []string{family},
+				Support:        "supported",
+				HighValue:      true,
+				EvidenceTypes:  []string{"asset_inventory"},
+				ControlDomains: []string{"asset_inventory"},
+				ControlRefs: []connectordefinitions.CoverageControlRefSpec{{
+					FrameworkName: "SOC 2", ControlID: "CC7.2",
+				}},
+			}},
+		})
+	}
+	return connectordefinitions.Definition{
+		ID:          "builtin-" + sourceID,
+		TenantID:    "builtin",
+		SourceID:    sourceID,
+		DisplayName: strings.ReplaceAll(sourceID, "_", " "),
+		Auth:        auth,
+		Transport: &connectordefinitions.TransportSpec{
+			BaseURL:      "https://api." + sourceID + ".example",
+			Verification: &connectordefinitions.VerificationSpec{Path: "/health"},
+		},
+		ProviderAPI: &connectordefinitions.ProviderAPISpec{
+			Status:        "verified",
+			Basis:         "provider_documentation",
+			VerifiedAt:    "2026-07-14T00:00:00Z",
+			Transport:     "rest",
+			Auth:          authModel,
+			AuthMechanics: authModel,
+			BaseURL:       "https://api." + sourceID + ".example",
+			References:    []string{"https://docs." + sourceID + ".example/api"},
+			AuthEvidence:  []string{"https://docs." + sourceID + ".example/auth"},
+			ScopeEvidence: []string{"https://docs." + sourceID + ".example/scopes"},
+			Families:      providerFamilies,
+		},
+		ResourceFamilies: resourceFamilies,
+	}
+}
 
 func TestBuildReportScoresProviderLikeSourceAboveGeneratedScaffold(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

- carry definition-owned coverage dimensions and control references into generated source catalogs
- emit provider-shaped fixture values for definitions with verified provider API evidence while retaining clear generator markers for unverified scaffolds
- add a generated provider-unavailable check to source HTTP tests
- gate bearer/cursor, OAuth/page, and POST-list pilots at a 100 source-fidelity score without editing generated outputs

## Validation

- `make sourcegen-test sourcegen-check`
- `go test ./tools/sourcefidelity -count=1`
- `go test ./tools/sourcefidelity -run TestGeneratedProviderPilotsAreHighFidelity -count=1`
- `go vet ./internal/sourcegen ./tools/sourcefidelity`
- `make check-structural check-structural-test check-arch`
- `make oss-audit`
