### PR TITLE
recovery: add audited terminal dead-letter cleanup

### DIFF
--- a/cmd/cerebro/append_log.go
+++ b/cmd/cerebro/append_log.go
@@ -20,19 +20,19 @@ import (
 
 func runAppendLog(args []string) error {
 	if len(args) == 0 {
-		return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard] ...", os.Args[0]))
+		return appendLogDeadLetterUsageError()
 	}
 	switch args[0] {
 	case "dead-letters":
 		return runAppendLogDeadLetters(args[1:])
 	default:
-		return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard] ...", os.Args[0]))
+		return appendLogDeadLetterUsageError()
 	}
 }
 
 func runAppendLogDeadLetters(args []string) error {
 	if len(args) == 0 {
-		return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard] ...", os.Args[0]))
+		return appendLogDeadLetterUsageError()
 	}
 	cfg, err := appconfig.Load()
 	if err != nil {
@@ -53,9 +53,17 @@ func runAppendLogDeadLetters(args []string) error {
 		return runAppendLogDeadLetterReplay(ctx, cfg, args[1:])
 	case "discard":
 		return runAppendLogDeadLetterDiscard(ctx, cfg, args[1:])
+	case "stats":
+		return runAppendLogDeadLetterStats(ctx, cfg, args[1:])
+	case "cleanup":
+		return runAppendLogDeadLetterCleanup(ctx, cfg, args[1:])
 	default:
-		return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard] ...", os.Args[0]))
+		return appendLogDeadLetterUsageError()
 	}
+}
+
+func appendLogDeadLetterUsageError() error {
+	return usageError(fmt.Sprintf("usage: %s append-log dead-letters [list|replay|discard|stats|cleanup] ...", os.Args[0]))
 }
 
 func runAppendLogDeadLetterList(ctx context.Context, cfg appconfig.Config, args []string) error {
@@ -196,6 +204,47 @@ func runAppendLogDeadLetterDiscard(ctx context.Context, cfg appconfig.Config, ar
 	return printJSON(appendLogDeadLetterActionResponse(record, ports.AppendLogDeadLetterStatusDiscarded))
 }
 
+func runAppendLogDeadLetterStats(ctx context.Context, cfg appconfig.Config, args []string) error {
+	if len(args) != 0 {
+		return usageError(fmt.Sprintf("usage: %s append-log dead-letters stats", os.Args[0]))
+	}
+	store, closeDeps, err := openAppendLogDeadLetterStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := closeDeps(); err != nil {
+			log.Printf("close dependencies: %v", err)
+		}
+	}()
+	backlog, err := store.GetAppendLogDeadLetterBacklog(ctx)
+	if err != nil {
+		return err
+	}
+	return printJSON(appendLogDeadLetterBacklogResponse(backlog))
+}
+
+func runAppendLogDeadLetterCleanup(ctx context.Context, cfg appconfig.Config, args []string) error {
+	request, err := parseAppendLogDeadLetterCleanupArgs(args)
+	if err != nil {
+		return err
+	}
+	store, closeDeps, err := openAppendLogDeadLetterStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := closeDeps(); err != nil {
+			log.Printf("close dependencies: %v", err)
+		}
+	}()
+	result, err := store.CleanupAppendLogDeadLetters(ctx, request)
+	if err != nil {
+		return err
+	}
+	return printJSON(appendLogDeadLetterCleanupResponse(result))
+}
+
 func openAppendLogDeadLetterStore(ctx context.Context, cfg appconfig.Config) (ports.AppendLogDeadLetterStore, func() error, error) {
 	deps, closeDeps, err := bootstrap.OpenSourceRuntimeBootstrapDependencies(ctx, cfg)
 	if err != nil {
@@ -275,6 +324,44 @@ func parseAppendLogDeadLetterDiscardArgs(args []string) (string, string, error) 
 	return id, reason, nil
 }
 
+func parseAppendLogDeadLetterCleanupArgs(args []string) (ports.AppendLogDeadLetterCleanupRequest, error) {
+	request := ports.AppendLogDeadLetterCleanupRequest{}
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return ports.AppendLogDeadLetterCleanupRequest{}, fmt.Errorf("invalid append log dead-letter cleanup argument %q; want key=value", arg)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "terminal_before":
+			cutoff, err := time.Parse(time.RFC3339, value)
+			if err != nil {
+				return ports.AppendLogDeadLetterCleanupRequest{}, fmt.Errorf("parse terminal_before as RFC3339: %w", err)
+			}
+			request.TerminalBefore = cutoff
+		case "after_id":
+			request.AfterID = value
+		case "actor":
+			request.Actor = value
+		case "reason":
+			request.Reason = value
+		case "limit":
+			parsed, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return ports.AppendLogDeadLetterCleanupRequest{}, fmt.Errorf("parse limit: %w", err)
+			}
+			request.Limit = uint32(parsed)
+		default:
+			return ports.AppendLogDeadLetterCleanupRequest{}, fmt.Errorf("unsupported append log dead-letter cleanup argument %q", key)
+		}
+	}
+	if request.TerminalBefore.IsZero() || strings.TrimSpace(request.Actor) == "" || strings.TrimSpace(request.Reason) == "" {
+		return ports.AppendLogDeadLetterCleanupRequest{}, usageError(fmt.Sprintf("usage: %s append-log dead-letters cleanup terminal_before=<RFC3339> actor=<actor> reason=<reason> [after_id=<dead-letter-id>] [limit=<count>]", os.Args[0]))
+	}
+	return request, nil
+}
+
 type appendLogDeadLetterSummary struct {
 	ID                      string `json:"id"`
 	Status                  string `json:"status"`
@@ -310,6 +397,20 @@ type appendLogDeadLetterActionOutput struct {
 	Status  string `json:"status"`
 	EventID string `json:"event_id"`
 	Subject string `json:"subject"`
+}
+
+type appendLogDeadLetterBacklogOutput struct {
+	PendingRecords      int64  `json:"pending_records"`
+	TerminalRecords     int64  `json:"terminal_records"`
+	PendingPayloadBytes int64  `json:"pending_payload_bytes"`
+	OldestPendingAt     string `json:"oldest_pending_at,omitempty"`
+}
+
+type appendLogDeadLetterCleanupOutput struct {
+	DeletedIDs   []string `json:"deleted_ids"`
+	DeletedCount int      `json:"deleted_count"`
+	NextAfterID  string   `json:"next_after_id,omitempty"`
+	HasMore      bool     `json:"has_more"`
 }
 
 func appendLogDeadLetterListResponse(records []ports.AppendLogDeadLetter) appendLogDeadLetterListOutput {
@@ -360,5 +461,26 @@ func appendLogDeadLetterActionResponse(record ports.AppendLogDeadLetter, status 
 		Status:  status,
 		EventID: record.EventID,
 		Subject: record.Subject,
+	}
+}
+
+func appendLogDeadLetterBacklogResponse(backlog ports.AppendLogDeadLetterBacklog) appendLogDeadLetterBacklogOutput {
+	response := appendLogDeadLetterBacklogOutput{
+		PendingRecords:      backlog.PendingRecords,
+		TerminalRecords:     backlog.TerminalRecords,
+		PendingPayloadBytes: backlog.PendingPayloadBytes,
+	}
+	if !backlog.OldestPendingAt.IsZero() {
+		response.OldestPendingAt = backlog.OldestPendingAt.UTC().Format(time.RFC3339)
+	}
+	return response
+}
+
+func appendLogDeadLetterCleanupResponse(result ports.AppendLogDeadLetterCleanupResult) appendLogDeadLetterCleanupOutput {
+	return appendLogDeadLetterCleanupOutput{
+		DeletedIDs:   result.DeletedIDs,
+		DeletedCount: len(result.DeletedIDs),
+		NextAfterID:  result.NextAfterID,
+		HasMore:      result.HasMore,
 	}
 }

--- a/cmd/cerebro/append_log_test.go
+++ b/cmd/cerebro/append_log_test.go
@@ -42,3 +42,44 @@ func TestAppendLogDeadLetterSummaryShowsClaimWithoutToken(t *testing.T) {
 		t.Fatal("operator summary exposed replay token")
 	}
 }
+
+func TestParseAppendLogDeadLetterCleanupArgs(t *testing.T) {
+	request, err := parseAppendLogDeadLetterCleanupArgs([]string{
+		"terminal_before=2026-07-01T00:00:00Z",
+		"actor=oncall@example.com",
+		"reason=retention-policy-30d",
+		"after_id=apdl_10",
+		"limit=75",
+	})
+	if err != nil {
+		t.Fatalf("parseAppendLogDeadLetterCleanupArgs() error = %v", err)
+	}
+	if got := request.TerminalBefore.UTC().Format(time.RFC3339); got != "2026-07-01T00:00:00Z" {
+		t.Fatalf("TerminalBefore = %q", got)
+	}
+	if request.Actor != "oncall@example.com" || request.Reason != "retention-policy-30d" || request.AfterID != "apdl_10" || request.Limit != 75 {
+		t.Fatalf("request = %#v", request)
+	}
+}
+
+func TestParseAppendLogDeadLetterCleanupArgsRequiresAuditContext(t *testing.T) {
+	_, err := parseAppendLogDeadLetterCleanupArgs([]string{"terminal_before=2026-07-01T00:00:00Z"})
+	if err == nil {
+		t.Fatal("parseAppendLogDeadLetterCleanupArgs() error = nil, want actor and reason requirement")
+	}
+}
+
+func TestAppendLogDeadLetterBacklogResponseDoesNotContainPayload(t *testing.T) {
+	response := appendLogDeadLetterBacklogResponse(ports.AppendLogDeadLetterBacklog{
+		PendingRecords:      3,
+		TerminalRecords:     8,
+		PendingPayloadBytes: 512,
+		OldestPendingAt:     time.Date(2026, time.July, 1, 2, 3, 4, 0, time.FixedZone("offset", -7*60*60)),
+	})
+	if response.PendingRecords != 3 || response.TerminalRecords != 8 || response.PendingPayloadBytes != 512 {
+		t.Fatalf("response = %#v", response)
+	}
+	if response.OldestPendingAt != "2026-07-01T09:03:04Z" {
+		t.Fatalf("OldestPendingAt = %q", response.OldestPendingAt)
+	}
+}

--- a/docs/operations/append-log-dead-letter-policy.md
+++ b/docs/operations/append-log-dead-letter-policy.md
@@ -24,7 +24,7 @@ The replayable envelope remains in Postgres. Production deployments must provide
 - Pending records older than 7 days require an operator alert and disposition.
 - Replayed and discarded records have a default retention period of 30 days.
 - Forced deletion of a pending record requires an authenticated actor, a concrete reason, and a durable audit record for every deleted ID.
-- Cleanup runs operate in bounded batches of at most 500 rows and persist their cursor so interruption resumes after the last committed batch.
+- Terminal cleanup runs operate in bounded batches of at most 500 rows and return the last committed ID so an interrupted run can resume from that cursor.
 
 ## Capacity Limits
 
@@ -41,8 +41,10 @@ Replay, discard, forced pending purge, and retention-policy changes record the a
 
 ## Recovery Procedure
 
-1. Restore JetStream publication health.
-2. List pending records and review subject, event kind, age, attempts, and claim state.
-3. Replay one record at a time. Wait for an active ownership lease to expire before retrying an abandoned claim.
-4. Discard only when the event must not be published, and provide the reason required by the command.
-5. Use forced pending purge only when retention of the recovery payload creates a greater incident risk than event loss. Record the incident or change reference in the reason.
+1. Run `append-log dead-letters stats` and compare pending records, pending bytes, and oldest pending time with the capacity limits.
+2. Restore JetStream publication health.
+3. List pending records and review subject, event kind, age, attempts, and claim state.
+4. Replay one record at a time. Wait for an active ownership lease to expire before retrying an abandoned claim.
+5. Discard only when the event must not be published, and provide the reason required by the command.
+6. Delete expired terminal records with `cleanup`. Pass an actor and change or incident reference as the reason. If `has_more` is true, pass `next_after_id` as `after_id` in the next batch.
+7. Use forced pending purge only when retention of the recovery payload creates a greater incident risk than event loss. Record the incident or change reference in the reason.

--- a/docs/operations/operations-runbook.md
+++ b/docs/operations/operations-runbook.md
@@ -118,6 +118,7 @@ Relevant variable:
 If publish retries exhaust, check the recovery table before advancing runtime work:
 
 ```bash
+./bin/cerebro append-log dead-letters stats
 ./bin/cerebro append-log dead-letters list status=pending limit=20
 ./bin/cerebro append-log dead-letters list subject=sec.findings.v1.recorded status=pending limit=20
 ```
@@ -144,6 +145,17 @@ Dead-letter IDs are deterministic for the subject, event ID, and payload. If the
 same event exhausts again after an operator has replayed or discarded that
 record, Cerebro preserves the terminal record and does not move it back to
 `pending`.
+
+Delete replayed or discarded records after the retention window:
+
+```bash
+./bin/cerebro append-log dead-letters cleanup terminal_before=2026-06-01T00:00:00Z actor=oncall@example.com reason=CHG-1234 limit=100
+./bin/cerebro append-log dead-letters cleanup terminal_before=2026-06-01T00:00:00Z actor=oncall@example.com reason=CHG-1234 after_id=<next-after-id> limit=100
+```
+
+Each committed deletion has an audit row with the actor and reason. Cleanup
+never selects pending records. Continue only when `has_more` is true, using the
+returned `next_after_id` as `after_id`.
 
 See [Append-log dead-letter data policy](append-log-dead-letter-policy.md) for
 payload classification, retention, capacity limits, and emergency purge rules.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -62,6 +62,7 @@ See [Source runtime guide](../domains/source-runtime-guide.md) for store setup, 
 Exhausted JetStream publishes are recorded in Postgres when the state store is configured. List pending records without requiring JetStream to be healthy:
 
 ```bash
+./bin/cerebro append-log dead-letters stats
 ./bin/cerebro append-log dead-letters list
 ./bin/cerebro append-log dead-letters list subject=sec.findings.v1.recorded status=pending limit=20
 ```
@@ -80,6 +81,15 @@ until the active claim completes or expires.
 
 Dead-letter IDs are deterministic for the subject, event ID, and payload. A
 replayed or discarded record stays terminal if the same event exhausts again.
+
+Delete terminal records before a retention cutoff in audited, resumable batches:
+
+```bash
+./bin/cerebro append-log dead-letters cleanup terminal_before=2026-06-01T00:00:00Z actor=oncall@example.com reason=CHG-1234 limit=100
+```
+
+`cleanup` only deletes replayed or discarded records. When `has_more` is true,
+run the command again with the returned `next_after_id` as `after_id`.
 
 ## Finding Rules
 

--- a/internal/appendlog/recovery/recovery_test.go
+++ b/internal/appendlog/recovery/recovery_test.go
@@ -216,3 +216,11 @@ func (s *recordingStore) ReleaseAppendLogDeadLetterReplay(context.Context, strin
 func (s *recordingStore) DiscardAppendLogDeadLetter(context.Context, string, string) error {
 	return nil
 }
+
+func (s *recordingStore) GetAppendLogDeadLetterBacklog(context.Context) (ports.AppendLogDeadLetterBacklog, error) {
+	return ports.AppendLogDeadLetterBacklog{}, nil
+}
+
+func (s *recordingStore) CleanupAppendLogDeadLetters(context.Context, ports.AppendLogDeadLetterCleanupRequest) (ports.AppendLogDeadLetterCleanupResult, error) {
+	return ports.AppendLogDeadLetterCleanupResult{}, nil
+}

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -116,6 +116,31 @@ type AppendLogDeadLetterFilter struct {
 	Limit     uint32
 }
 
+// AppendLogDeadLetterBacklog summarizes recovery capacity without returning
+// replayable event envelopes.
+type AppendLogDeadLetterBacklog struct {
+	PendingRecords      int64
+	TerminalRecords     int64
+	PendingPayloadBytes int64
+	OldestPendingAt     time.Time
+}
+
+// AppendLogDeadLetterCleanupRequest scopes one resumable terminal-record purge.
+type AppendLogDeadLetterCleanupRequest struct {
+	TerminalBefore time.Time
+	AfterID        string
+	Actor          string
+	Reason         string
+	Limit          uint32
+}
+
+// AppendLogDeadLetterCleanupResult reports one committed cleanup batch.
+type AppendLogDeadLetterCleanupResult struct {
+	DeletedIDs  []string
+	NextAfterID string
+	HasMore     bool
+}
+
 // AppendLogDeadLetterStore persists and manages exhausted publish recovery
 // records outside JetStream so broker degradation does not recursively depend
 // on the same append path.
@@ -128,6 +153,8 @@ type AppendLogDeadLetterStore interface {
 	CompleteAppendLogDeadLetterReplay(context.Context, string, string) error
 	ReleaseAppendLogDeadLetterReplay(context.Context, string, string, string) error
 	DiscardAppendLogDeadLetter(context.Context, string, string) error
+	GetAppendLogDeadLetterBacklog(context.Context) (AppendLogDeadLetterBacklog, error)
+	CleanupAppendLogDeadLetters(context.Context, AppendLogDeadLetterCleanupRequest) (AppendLogDeadLetterCleanupResult, error)
 }
 
 // ReplayRequest scopes a bounded event replay from the append log.

--- a/internal/statestore/postgres/append_log_dead_letters.go
+++ b/internal/statestore/postgres/append_log_dead_letters.go
@@ -16,6 +16,7 @@ import (
 
 const appendLogDeadLetterDefaultLimit = uint32(50)
 const appendLogDeadLetterMaxLimit = uint32(500)
+const appendLogDeadLetterCleanupDefaultLimit = uint32(100)
 
 var ensureAppendLogDeadLetterStatements = []string{`CREATE TABLE IF NOT EXISTS append_log_dead_letters (
   id TEXT PRIMARY KEY,
@@ -59,6 +60,15 @@ var ensureAppendLogDeadLetterStatements = []string{`CREATE TABLE IF NOT EXISTS a
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_subject_status_idx ON append_log_dead_letters (subject, status, updated_at ASC)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_runtime_status_idx ON append_log_dead_letters (runtime_id, status, updated_at ASC)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letters_source_status_idx ON append_log_dead_letters (source_id, status, updated_at ASC)`,
+	`CREATE TABLE IF NOT EXISTS append_log_dead_letter_audit (
+  id BIGSERIAL PRIMARY KEY,
+  dead_letter_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS append_log_dead_letter_audit_record_created_idx ON append_log_dead_letter_audit (dead_letter_id, created_at DESC)`,
 }
 
 const recordAppendLogDeadLetterSQL = `
@@ -317,6 +327,125 @@ func (s *Store) DiscardAppendLogDeadLetter(ctx context.Context, id string, reaso
 		return errors.New("discard reason is required")
 	}
 	return s.updateAppendLogDeadLetterStatus(ctx, id, ports.AppendLogDeadLetterStatusDiscarded, reason)
+}
+
+func (s *Store) GetAppendLogDeadLetterBacklog(ctx context.Context) (ports.AppendLogDeadLetterBacklog, error) {
+	if s == nil || s.db == nil {
+		return ports.AppendLogDeadLetterBacklog{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogDeadLetterTables(ctx); err != nil {
+		return ports.AppendLogDeadLetterBacklog{}, err
+	}
+	var backlog ports.AppendLogDeadLetterBacklog
+	var oldest sql.NullTime
+	err := s.db.QueryRowContext(ctx, `SELECT
+  COUNT(*) FILTER (WHERE status = 'pending'),
+  COUNT(*) FILTER (WHERE status IN ('replayed', 'discarded')),
+  COALESCE(SUM(payload_bytes) FILTER (WHERE status = 'pending'), 0),
+  MIN(created_at) FILTER (WHERE status = 'pending')
+FROM append_log_dead_letters`).Scan(
+		&backlog.PendingRecords,
+		&backlog.TerminalRecords,
+		&backlog.PendingPayloadBytes,
+		&oldest,
+	)
+	if err != nil {
+		return ports.AppendLogDeadLetterBacklog{}, fmt.Errorf("get append log dead letter backlog: %w", err)
+	}
+	if oldest.Valid {
+		backlog.OldestPendingAt = oldest.Time
+	}
+	return backlog, nil
+}
+
+func (s *Store) CleanupAppendLogDeadLetters(ctx context.Context, request ports.AppendLogDeadLetterCleanupRequest) (ports.AppendLogDeadLetterCleanupResult, error) {
+	if s == nil || s.db == nil {
+		return ports.AppendLogDeadLetterCleanupResult{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureAppendLogDeadLetterTables(ctx); err != nil {
+		return ports.AppendLogDeadLetterCleanupResult{}, err
+	}
+	request.Actor = strings.TrimSpace(request.Actor)
+	request.Reason = strings.TrimSpace(request.Reason)
+	request.AfterID = strings.TrimSpace(request.AfterID)
+	if request.TerminalBefore.IsZero() {
+		return ports.AppendLogDeadLetterCleanupResult{}, errors.New("terminal retention cutoff is required")
+	}
+	if request.Actor == "" || request.Reason == "" {
+		return ports.AppendLogDeadLetterCleanupResult{}, errors.New("cleanup actor and reason are required")
+	}
+	if request.Limit == 0 {
+		request.Limit = appendLogDeadLetterCleanupDefaultLimit
+	}
+	if request.Limit > appendLogDeadLetterMaxLimit {
+		request.Limit = appendLogDeadLetterMaxLimit
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("begin append log dead letter cleanup: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, appendLogDeadLetterCleanupSelectSQL(), request.TerminalBefore.UTC(), request.AfterID, int64(request.Limit)+1)
+	if err != nil {
+		return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("select append log dead letter cleanup batch: %w", err)
+	}
+	ids := make([]string, 0, request.Limit+1)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("scan append log dead letter cleanup batch: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("iterate append log dead letter cleanup batch: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("close append log dead letter cleanup batch: %w", err)
+	}
+	hasMore := len(ids) > int(request.Limit)
+	if len(ids) > int(request.Limit) {
+		ids = ids[:request.Limit]
+	}
+	result := ports.AppendLogDeadLetterCleanupResult{DeletedIDs: make([]string, 0, len(ids))}
+	for _, id := range ids {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO append_log_dead_letter_audit (dead_letter_id, action, actor, reason) VALUES ($1, 'retention_purge', $2, $3)`, id, request.Actor, request.Reason); err != nil {
+			return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("audit append log dead letter %q cleanup: %w", id, err)
+		}
+		deleteResult, err := tx.ExecContext(ctx, `DELETE FROM append_log_dead_letters WHERE id = $1 AND status IN ('replayed', 'discarded') AND updated_at < $2`, id, request.TerminalBefore.UTC())
+		if err != nil {
+			return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("delete append log dead letter %q: %w", id, err)
+		}
+		deleted, err := deleteResult.RowsAffected()
+		if err != nil {
+			return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("delete append log dead letter %q rows affected: %w", id, err)
+		}
+		if deleted != 1 {
+			return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("append log dead letter %q changed during cleanup", id)
+		}
+		result.DeletedIDs = append(result.DeletedIDs, id)
+	}
+	if len(result.DeletedIDs) > 0 {
+		result.NextAfterID = result.DeletedIDs[len(result.DeletedIDs)-1]
+	}
+	result.HasMore = hasMore
+	if err := tx.Commit(); err != nil {
+		return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("commit append log dead letter cleanup: %w", err)
+	}
+	return result, nil
+}
+
+func appendLogDeadLetterCleanupSelectSQL() string {
+	return `SELECT id
+FROM append_log_dead_letters
+WHERE status IN ('replayed', 'discarded')
+  AND updated_at < $1
+  AND id > $2
+ORDER BY id ASC
+LIMIT $3
+FOR UPDATE SKIP LOCKED`
 }
 
 func (s *Store) updateAppendLogDeadLetterStatus(ctx context.Context, id string, status string, reason string) error {

--- a/internal/statestore/postgres/append_log_dead_letters.go
+++ b/internal/statestore/postgres/append_log_dead_letters.go
@@ -16,7 +16,8 @@ import (
 
 const appendLogDeadLetterDefaultLimit = uint32(50)
 const appendLogDeadLetterMaxLimit = uint32(500)
-const appendLogDeadLetterCleanupDefaultLimit = uint32(100)
+const appendLogDeadLetterCleanupDefaultLimit = 100
+const appendLogDeadLetterCleanupMaxLimit = 500
 
 var ensureAppendLogDeadLetterStatements = []string{`CREATE TABLE IF NOT EXISTS append_log_dead_letters (
   id TEXT PRIMARY KEY,
@@ -374,22 +375,25 @@ func (s *Store) CleanupAppendLogDeadLetters(ctx context.Context, request ports.A
 	if request.Actor == "" || request.Reason == "" {
 		return ports.AppendLogDeadLetterCleanupResult{}, errors.New("cleanup actor and reason are required")
 	}
-	if request.Limit == 0 {
-		request.Limit = appendLogDeadLetterCleanupDefaultLimit
-	}
-	if request.Limit > appendLogDeadLetterMaxLimit {
-		request.Limit = appendLogDeadLetterMaxLimit
+	limit := appendLogDeadLetterCleanupDefaultLimit
+	if request.Limit > 0 {
+		if request.Limit > uint32(appendLogDeadLetterCleanupMaxLimit) {
+			limit = appendLogDeadLetterCleanupMaxLimit
+		} else {
+			limit = int(request.Limit)
+		}
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("begin append log dead letter cleanup: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	rows, err := tx.QueryContext(ctx, appendLogDeadLetterCleanupSelectSQL(), request.TerminalBefore.UTC(), request.AfterID, int64(request.Limit)+1)
+	rows, err := tx.QueryContext(ctx, appendLogDeadLetterCleanupSelectSQL(), request.TerminalBefore.UTC(), request.AfterID, int64(limit)+1)
 	if err != nil {
 		return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("select append log dead letter cleanup batch: %w", err)
 	}
-	ids := make([]string, 0, request.Limit+1)
+	defer func() { _ = rows.Close() }()
+	ids := make([]string, 0, limit+1)
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
@@ -405,9 +409,9 @@ func (s *Store) CleanupAppendLogDeadLetters(ctx context.Context, request ports.A
 	if err := rows.Close(); err != nil {
 		return ports.AppendLogDeadLetterCleanupResult{}, fmt.Errorf("close append log dead letter cleanup batch: %w", err)
 	}
-	hasMore := len(ids) > int(request.Limit)
-	if len(ids) > int(request.Limit) {
-		ids = ids[:request.Limit]
+	hasMore := len(ids) > limit
+	if len(ids) > limit {
+		ids = ids[:limit]
 	}
 	result := ports.AppendLogDeadLetterCleanupResult{DeletedIDs: make([]string, 0, len(ids))}
 	for _, id := range ids {

--- a/internal/statestore/postgres/append_log_dead_letters_test.go
+++ b/internal/statestore/postgres/append_log_dead_letters_test.go
@@ -30,10 +30,34 @@ func TestAppendLogDeadLetterSchemaShape(t *testing.T) {
 		"append_log_dead_letters_subject_status_idx",
 		"append_log_dead_letters_runtime_status_idx",
 		"append_log_dead_letters_source_status_idx",
+		"CREATE TABLE IF NOT EXISTS append_log_dead_letter_audit",
+		"dead_letter_id TEXT NOT NULL",
+		"actor TEXT NOT NULL",
+		"reason TEXT NOT NULL",
+		"append_log_dead_letter_audit_record_created_idx",
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("append log dead letter schema missing %q:\n%s", fragment, joined)
 		}
+	}
+}
+
+func TestAppendLogDeadLetterCleanupSelectsOnlyTerminalRowsInBoundedLockingBatch(t *testing.T) {
+	query := appendLogDeadLetterCleanupSelectSQL()
+	for _, fragment := range []string{
+		"status IN ('replayed', 'discarded')",
+		"updated_at < $1",
+		"id > $2",
+		"ORDER BY id ASC",
+		"LIMIT $3",
+		"FOR UPDATE SKIP LOCKED",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("appendLogDeadLetterCleanupSelectSQL() missing %q:\n%s", fragment, query)
+		}
+	}
+	if strings.Contains(query, "'pending'") {
+		t.Fatalf("appendLogDeadLetterCleanupSelectSQL() may not select pending rows:\n%s", query)
 	}
 }
 


### PR DESCRIPTION
## Summary
- report pending records, pending payload bytes, terminal records, and the oldest pending timestamp without returning event envelopes
- delete only replayed or discarded records before an explicit cutoff in bounded, cursor-based batches
- record the operator actor and reason for every deletion in the same transaction
- document the stats and cleanup commands and their continuation contract

## Stack
- depends on #1783
- advances #1734

## Validation
- go test ./cmd/cerebro ./internal/statestore/postgres ./internal/appendlog/recovery ./internal/ports
- go vet ./cmd/cerebro ./internal/statestore/postgres ./internal/appendlog/recovery ./internal/ports
- make docs-drift-check check-structural check-structural-test check-arch
- git diff --check

## Remaining #1734 work
- forced pending purge with an authenticated actor
- configurable warning and hard capacity limits
- exported backlog metrics and alerts