### PR TITLE
Make audit packet receipts immutable and replayable

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4128,9 +4128,51 @@ paths:
       responses:
         '200':
           description: Markdown or JSON export for the generated control evidence packet.
+  /grc/findings/{findingID}/audit-preview:
+    get:
+      operationId: previewGRCAuditPacket
+      summary: Preview the current audit evidence for one finding
+      tags:
+        - GRC
+      parameters:
+        - name: findingID
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Live finding, evidence, controls, graph context, and recommended next action. This response is not an immutable audit packet.
+  /grc/audit-packets:
+    post:
+      operationId: createGRCAuditPacket
+      summary: Create an immutable audit packet from current finding evidence
+      tags:
+        - GRC
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - finding_id
+              properties:
+                finding_id:
+                  type: string
+                  description: Finding to snapshot after tenant authorization.
+                supersedes:
+                  type: array
+                  items:
+                    type: string
+                  description: Earlier immutable packet IDs replaced by this packet.
+      responses:
+        '201':
+          description: Immutable audit packet with an independent packet ID and deterministic digest.
   /grc/audit-packets/{packetID}:
     get:
-      summary: GRC audit packet for one finding
+      operationId: getGRCAuditPacket
+      summary: Read one immutable GRC audit packet
       tags:
         - GRC
       parameters:
@@ -4141,7 +4183,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Finding, evidence, controls, graph context, and recommended next action.
+          description: Exact stored packet receipt. The read does not resolve current finding, evidence, runtime, or graph state.
   /platform/knowledge/decisions:
     post:
       summary: Record platform decision
@@ -5266,7 +5308,7 @@ paths:
   /grc/audit-packets/{packetID}/export:
     get:
       operationId: exportGRCAuditPacket
-      summary: Export a GRC audit packet
+      summary: Export one immutable GRC audit packet
       tags:
         - GRC
       parameters:
@@ -5285,7 +5327,7 @@ paths:
           description: Optional export format. Defaults to markdown.
       responses:
         '200':
-          description: Exported audit packet content.
+          description: Exported content derived from the exact stored packet receipt.
           content:
             text/markdown:
               schema:

--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -19,7 +19,7 @@ Generated-by-hand snapshot for the current bootstrap service. Source of truth: `
 | Source runtimes | `/source-runtimes/{runtimeID}`, `/source-runtimes/{runtimeID}/sync`, `/source-runtimes/{runtimeID}/graph-ingest-runs` |
 | Claims/findings | `/source-runtimes/{runtimeID}/claims`, `/source-runtimes/{runtimeID}/findings`, finding lifecycle routes |
 | Reports | `/reports`, `/reports/{reportID}/runs`, `/report-runs/{runID}` |
-| GRC/compliance | `/grc/dashboard`, `/grc/program-readiness`, `/grc/findings`, `/grc/controls`, `/grc/evidence`, `/grc/control-archetypes`, `/grc/control-profiles`, `/grc/control-coverage`, `/grc/control-packs*`, `/grc/audit-packets/{packetID}` |
+| GRC/compliance | `/grc/dashboard`, `/grc/program-readiness`, `/grc/findings`, `/grc/controls`, `/grc/evidence`, `/grc/control-archetypes`, `/grc/control-profiles`, `/grc/control-coverage`, `/grc/control-packs*`, `/grc/findings/{findingID}/audit-preview`, `/grc/audit-packets*` |
 | Platform knowledge | `/platform/knowledge/decisions`, `/platform/knowledge/actions`, `/platform/knowledge/outcomes` |
 | Platform workflow | `/platform/workflow/replay` |
 | Platform graph | `/platform/graph/neighborhood`, `/platform/graph/effective-access-paths`, `/platform/graph/ingest-health`, `/platform/graph/ingest-runs*` |

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -737,6 +737,7 @@ type stubRuntimeStore struct {
 	findingCandidates               map[string]*ports.FindingCandidateRecord
 	findingCandidateListRequest     ports.ListFindingCandidatesRequest
 	reportRuns                      map[string]*cerebrov1.ReportRun
+	grcAuditPackets                 map[string]*ports.GRCAuditPacketReceipt
 	runtimeIndexWatermark           uint64
 	runtimeIndexWatermarks          []uint64
 }
@@ -779,6 +780,35 @@ func (s *leaseAwareRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, _ 
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
+
+func (s *stubRuntimeStore) PutGRCAuditPacket(_ context.Context, receipt *ports.GRCAuditPacketReceipt) error {
+	if s.err != nil {
+		return s.err
+	}
+	if s.grcAuditPackets == nil {
+		s.grcAuditPackets = make(map[string]*ports.GRCAuditPacketReceipt)
+	}
+	if _, exists := s.grcAuditPackets[receipt.ID]; exists {
+		return errors.New("audit packet already exists")
+	}
+	copy := *receipt
+	copy.Payload = append([]byte(nil), receipt.Payload...)
+	s.grcAuditPackets[receipt.ID] = &copy
+	return nil
+}
+
+func (s *stubRuntimeStore) GetGRCAuditPacket(_ context.Context, packetID string) (*ports.GRCAuditPacketReceipt, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	receipt, ok := s.grcAuditPackets[packetID]
+	if !ok {
+		return nil, ports.ErrGRCAuditPacketNotFound
+	}
+	copy := *receipt
+	copy.Payload = append([]byte(nil), receipt.Payload...)
+	return &copy, nil
+}
 
 func (s *stubRuntimeStore) RuntimeIndexWatermark(context.Context) (uint64, error) {
 	if s.err != nil {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/grcauditpacket"
 	"github.com/writer/cerebro/internal/knowledge"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/primitives"
@@ -781,20 +782,36 @@ func (s *leaseAwareRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, _ 
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
 
-func (s *stubRuntimeStore) PutGRCAuditPacket(_ context.Context, receipt *ports.GRCAuditPacketReceipt) error {
+func (s *stubRuntimeStore) ApplyAuditProjectionEvent(_ context.Context, event *cerebrov1.EventEnvelope) (bool, error) {
 	if s.err != nil {
-		return s.err
+		return false, s.err
+	}
+	recorded, err := workflowevents.DecodeComplianceAggregate(event)
+	if err != nil {
+		return false, err
+	}
+	var packet grcauditpacket.Packet
+	if err := json.Unmarshal([]byte(recorded.PayloadJSON), &packet); err != nil {
+		return false, err
+	}
+	if err := grcauditpacket.Verify(packet); err != nil {
+		return false, err
 	}
 	if s.grcAuditPackets == nil {
 		s.grcAuditPackets = make(map[string]*ports.GRCAuditPacketReceipt)
 	}
-	if _, exists := s.grcAuditPackets[receipt.ID]; exists {
-		return errors.New("audit packet already exists")
+	if _, exists := s.grcAuditPackets[packet.ID]; exists {
+		return false, nil
 	}
-	copy := *receipt
-	copy.Payload = append([]byte(nil), receipt.Payload...)
-	s.grcAuditPackets[receipt.ID] = &copy
-	return nil
+	payload, err := json.Marshal(packet)
+	if err != nil {
+		return false, err
+	}
+	s.grcAuditPackets[packet.ID] = &ports.GRCAuditPacketReceipt{
+		ID: packet.ID, TenantID: packet.TenantID, FindingID: packet.FindingReference.ID,
+		Digest: packet.Digest, Payload: payload, CreatedAt: packet.GeneratedAt,
+	}
+	return true, nil
 }
 
 func (s *stubRuntimeStore) GetGRCAuditPacket(_ context.Context, packetID string) (*ports.GRCAuditPacketReceipt, error) {

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -107,6 +107,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodDelete, Exact: "/grc/risk-scoring-config", Scope: scopeRiskScoringWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/control-packets", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/control-packets/export", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodPost, Exact: "/grc/audit-packets", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Prefix: "/grc/control-packs", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/grc/evidence-packets", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/questionnaire-runs", Scope: scopeGRCInventoryWrite, Static: true},

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -609,6 +609,22 @@ func (a *App) buildGRCAuditPreview(r *http.Request, findingID string) (grcAuditP
 	if err != nil {
 		return grcAuditPacketResponse{}, err
 	}
+	evidenceTotal, err := a.grcEvidenceCount(r, runtimes, grcEvidenceFilter{FindingID: finding.ID})
+	if err != nil {
+		return grcAuditPacketResponse{}, err
+	}
+	packetGaps := []grcAuditPacketGap{}
+	switch {
+	case evidenceTotal == nil:
+		packetGaps = append(packetGaps, grcAuditPacketGap{
+			Code: "evidence_total_unavailable", Message: "The evidence store could not report the total matching record count; snapshot completeness is unverified.",
+		})
+	case *evidenceTotal > len(evidence):
+		packetGaps = append(packetGaps, grcAuditPacketGap{
+			Code:    "evidence_snapshot_truncated",
+			Message: fmt.Sprintf("The snapshot includes %d of %d matching evidence records because the request limit is %d.", len(evidence), *evidenceTotal, limit),
+		})
+	}
 	var graph *ports.EntityNeighborhood
 	if len(finding.ResourceURNs) > 0 {
 		if graphStore := graphQueryStore(a.deps.GraphStore); graphStore != nil {
@@ -633,7 +649,7 @@ func (a *App) buildGRCAuditPreview(r *http.Request, findingID string) (grcAuditP
 		Controls:          controls,
 		RecommendedAction: grcRecommendedAction(items[0]),
 		GeneratedAt:       generatedAt,
-		Gaps:              []grcAuditPacketGap{},
+		Gaps:              packetGaps,
 		Supersedes:        []string{},
 		FindingRecord:     finding,
 		EvidenceRecords:   evidence,

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grcauditpacket"
 	"github.com/writer/cerebro/internal/grccontrol"
 	"github.com/writer/cerebro/internal/grcfindings"
 	"github.com/writer/cerebro/internal/grcpolicylifecycle"
@@ -34,6 +35,7 @@ const (
 	grcDefaultLimit          = uint32(100)
 	grcMaxLimit              = uint32(500)
 	grcDashboardPreviewLimit = uint32(25)
+	grcAuditPacketSchema     = grcauditpacket.SchemaVersion
 )
 
 type grcScope struct {
@@ -86,16 +88,9 @@ type grcEntityImpactResponse struct {
 	GeneratedAt time.Time                 `json:"generated_at"`
 }
 
-type grcAuditPacketResponse struct {
-	ID                string                    `json:"id"`
-	Finding           grcFindingItem            `json:"finding"`
-	Evidence          []grcEvidenceItem         `json:"evidence"`
-	Graph             *ports.EntityNeighborhood `json:"graph,omitempty"`
-	Controls          []grcControlRef           `json:"controls,omitempty"`
-	RecommendedAction string                    `json:"recommended_action"`
-	Metadata          grccontrol.ReportMetadata `json:"metadata"`
-	GeneratedAt       time.Time                 `json:"generated_at"`
-}
+type grcAuditPacketResponse = grcauditpacket.Packet
+type grcAuditFindingReference = grcauditpacket.FindingReference
+type grcAuditPacketGap = grcauditpacket.Gap
 
 func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	ctx, span := telemetry.Start(r.Context(), "grc.dashboard", grcDashboardTelemetryAttrs())
@@ -584,30 +579,8 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (a *App) handleGRCAuditPacket(w http.ResponseWriter, r *http.Request) {
-	packet, err := a.buildGRCAuditPacket(r)
-	if err != nil {
-		writeGRCError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, packet)
-}
-
-func (a *App) handleGRCAuditPacketExport(w http.ResponseWriter, r *http.Request) {
-	packet, err := a.buildGRCAuditPacket(r)
-	if err != nil {
-		writeGRCError(w, err)
-		return
-	}
-	if strings.EqualFold(r.URL.Query().Get("format"), "json") {
-		writeJSON(w, http.StatusOK, packet)
-		return
-	}
-	writeGRCMarkdownExport(w, "finding-audit-packet.md", grccontrol.RenderFindingAuditPacketMarkdown(grcFindingAuditMarkdownInput(packet)))
-}
-
-func (a *App) buildGRCAuditPacket(r *http.Request) (grcAuditPacketResponse, error) {
-	findingID := strings.TrimSpace(r.PathValue("packetID"))
+func (a *App) buildGRCAuditPreview(r *http.Request, findingID string) (grcAuditPacketResponse, error) {
+	findingID = strings.TrimSpace(findingID)
 	if findingID == "" {
 		return grcAuditPacketResponse{}, fmt.Errorf("%w: finding id is required", errInvalidHTTPRequest)
 	}
@@ -653,13 +626,18 @@ func (a *App) buildGRCAuditPacket(r *http.Request) (grcAuditPacketResponse, erro
 	generatedAt := time.Now().UTC()
 	controls := grcControlRefs(finding.ControlRefs)
 	packet := grcAuditPacketResponse{
-		ID:                finding.ID,
+		ResourceState:     "live_preview",
 		Finding:           items[0],
 		Evidence:          grcEvidenceItems(evidence, map[string]string{finding.ID: finding.Title}),
 		Graph:             graph,
 		Controls:          controls,
 		RecommendedAction: grcRecommendedAction(items[0]),
 		GeneratedAt:       generatedAt,
+		Gaps:              []grcAuditPacketGap{},
+		Supersedes:        []string{},
+		FindingRecord:     finding,
+		EvidenceRecords:   evidence,
+		RuntimeRecords:    runtimes,
 	}
 	packet.Metadata = grccontrol.BuildReportMetadata(grccontrol.ReportMetadataInput{
 		ReportType:    "finding",
@@ -676,38 +654,6 @@ func (a *App) buildGRCAuditPacket(r *http.Request) (grcAuditPacketResponse, erro
 		Runtimes: reportScopeRuntimes,
 	})
 	return packet, nil
-}
-
-func grcFindingAuditMarkdownInput(packet grcAuditPacketResponse) grccontrol.FindingAuditMarkdownInput {
-	controls := make([]grccontrol.ControlRef, 0, len(packet.Controls))
-	for _, control := range packet.Controls {
-		controls = append(controls, grccontrol.ControlRef{FrameworkName: control.FrameworkName, ControlID: control.ControlID})
-	}
-	evidence := make([]grccontrol.FindingAuditMarkdownEvidence, 0, len(packet.Evidence))
-	for _, item := range packet.Evidence {
-		evidence = append(evidence, grccontrol.FindingAuditMarkdownEvidence{
-			ID:        item.ID,
-			RuleID:    item.RuleID,
-			CreatedAt: item.CreatedAt,
-		})
-	}
-	return grccontrol.FindingAuditMarkdownInput{
-		Finding: grccontrol.FindingAuditMarkdownFinding{
-			ID:        packet.Finding.ID,
-			Title:     packet.Finding.Title,
-			Severity:  packet.Finding.Severity,
-			Status:    packet.Finding.Status,
-			Summary:   packet.Finding.Summary,
-			RiskScore: packet.Finding.RiskScore,
-			Owner:     packet.Finding.Owner,
-			SLAStatus: packet.Finding.SLAStatus,
-		},
-		Controls:          controls,
-		Evidence:          evidence,
-		RecommendedAction: packet.RecommendedAction,
-		Metadata:          packet.Metadata,
-		GeneratedAt:       packet.GeneratedAt,
-	}
 }
 
 type grcFindingFilter = ports.ListFindingsRequest
@@ -781,6 +727,7 @@ func grcTelemetryErrorKind(err error) string {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound),
 		errors.Is(err, ports.ErrFindingNotFound),
 		errors.Is(err, ports.ErrFindingEvidenceNotFound),
+		errors.Is(err, ports.ErrGRCAuditPacketNotFound),
 		errors.Is(err, ports.ErrGraphEntityNotFound),
 		errors.Is(err, ports.ErrGRCInventoryAssetReportNotFound):
 		return "not_found"
@@ -1453,6 +1400,7 @@ func grcHTTPStatusCode(err error) int {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound),
 		errors.Is(err, ports.ErrFindingNotFound),
 		errors.Is(err, ports.ErrFindingEvidenceNotFound),
+		errors.Is(err, ports.ErrGRCAuditPacketNotFound),
 		errors.Is(err, ports.ErrGraphEntityNotFound),
 		errors.Is(err, ports.ErrGRCInventoryAssetReportNotFound),
 		errors.Is(err, ports.ErrGRCVendorDiscoveryDecisionNotFound),

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -17,11 +17,13 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grcaudit"
 	"github.com/writer/cerebro/internal/grcauditpacket"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	grcuploadhttp "github.com/writer/cerebro/internal/sourcehttp/grcupload"
 	questionnairehttp "github.com/writer/cerebro/internal/sourcehttp/questionnaire"
+	"github.com/writer/cerebro/internal/workflowevents"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1003,18 +1005,21 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	rootURN := "urn:cerebro:writer:okta_user:00u1"
 	store := &stubRuntimeStore{
 		runtimes: map[string]*cerebrov1.SourceRuntime{
-			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer", LastSyncedAt: timestamppb.New(now), Checkpoint: &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)}},
 		},
 		findings: map[string]*ports.FindingRecord{
 			"finding-high": {
-				ID:             "finding-high",
-				TenantID:       "writer",
-				RuntimeID:      "writer-okta-audit",
-				Title:          "Identity API token created",
-				Severity:       "HIGH",
-				Status:         "open",
-				ResourceURNs:   []string{rootURN},
-				LastObservedAt: now,
+				ID:              "finding-high",
+				Fingerprint:     "fingerprint-high",
+				TenantID:        "writer",
+				RuntimeID:       "writer-okta-audit",
+				Title:           "Identity API token created",
+				Severity:        "HIGH",
+				Status:          "open",
+				ResourceURNs:    []string{rootURN},
+				LastObservedAt:  now,
+				ControlRefs:     []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+				FindingWorkflow: ports.FindingWorkflow{StatusUpdatedAt: now},
 			},
 		},
 		findingEvidence: map[string]*cerebrov1.FindingEvidence{
@@ -1027,6 +1032,7 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 				EventIds:      []string{"event-1"},
 				GraphRootUrns: []string{rootURN},
 				GraphPathUrns: []string{"urn:cerebro:writer:graph-path:path-1"},
+				GraphRows:     []*cerebrov1.GraphEvidenceRow{{Attributes: map[string]string{"fact_id": "fact-1"}}},
 				Observations: []*cerebrov1.FindingEvidenceObservation{{
 					RunId: "observation-run-1", ObservedAt: timestamppb.New(now),
 				}},
@@ -1053,7 +1059,8 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 			}},
 		},
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore}, nil)
+	appendLog := &recordingAppendLog{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore, AppendLog: appendLog}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -1113,8 +1120,21 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	if created.Graph != nil || len(created.GraphReferences.RootURNs) != 1 {
 		t.Fatalf("created graph state = graph %#v refs %#v, want references only", created.Graph, created.GraphReferences)
 	}
+	if !containsTrimmed(created.GraphReferences.FactRefs, "fact-1") || len(created.ControlReferences) != 1 {
+		t.Fatalf("created exact references = graph %#v controls %#v", created.GraphReferences, created.ControlReferences)
+	}
 	if len(created.EvidenceReferences) != 1 || !containsTrimmed(created.EvidenceReferences[0].EvaluationRunIDs, "evaluation-run-1") || !containsTrimmed(created.EvidenceReferences[0].ObservationRunIDs, "observation-run-1") {
 		t.Fatalf("created evidence references = %#v, want exact evaluation and observation runs", created.EvidenceReferences)
+	}
+	if len(appendLog.events) != 1 {
+		t.Fatalf("appended audit packet events = %d, want 1", len(appendLog.events))
+	}
+	recorded, err := workflowevents.DecodeComplianceAggregate(appendLog.events[0])
+	if err != nil {
+		t.Fatalf("decode appended audit packet event: %v", err)
+	}
+	if recorded.AggregateType != grcaudit.AuditAggregatePacketReceipt || recorded.AggregateID != created.ID || recorded.ContentDigest != created.Digest {
+		t.Fatalf("appended audit packet event = %#v", recorded)
 	}
 
 	// Current finding and graph mutations after creation must not affect the packet.
@@ -1166,7 +1186,7 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 		t.Fatalf("read packet export: %v", err)
 	}
 	markdown := string(body)
-	for _, want := range []string{"# Finding Audit Packet", "Recommended Action", "Readiness"} {
+	for _, want := range []string{"# Finding Audit Packet", "Recommended Action", "Readiness", created.ID, created.Digest, "Review state: unreviewed", "Export state: ready"} {
 		if !strings.Contains(markdown, want) {
 			t.Fatalf("finding export missing %q:\n%s", want, markdown)
 		}
@@ -1218,7 +1238,7 @@ func TestGRCAuditPacketRecordsGraphGapWhenProjectionUnavailable(t *testing.T) {
 		runtimes: map[string]*cerebrov1.SourceRuntime{"runtime-1": {Id: "runtime-1", TenantId: "writer", SourceId: "okta"}},
 		findings: map[string]*ports.FindingRecord{"finding-1": {ID: "finding-1", TenantID: "writer", RuntimeID: "runtime-1", Status: "open", LastObservedAt: now}},
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, AppendLog: &recordingAppendLog{}}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 	response, err := server.Client().Post(server.URL+"/grc/audit-packets", "application/json", bytes.NewBufferString(`{"finding_id":"finding-1"}`))
@@ -1235,6 +1255,36 @@ func TestGRCAuditPacketRecordsGraphGapWhenProjectionUnavailable(t *testing.T) {
 	}
 	if !hasGRCAuditPacketGap(packet.Gaps, "graph_context_unavailable") || !hasGRCAuditPacketGap(packet.Gaps, "evidence_unavailable") {
 		t.Fatalf("gaps = %#v, want graph and evidence gaps", packet.Gaps)
+	}
+	if !hasGRCAuditPacketGap(packet.Gaps, "finding_fingerprint_unavailable") || !hasGRCAuditPacketGap(packet.Gaps, "source_checkpoint_unavailable") {
+		t.Fatalf("gaps = %#v, want missing finding and runtime references", packet.Gaps)
+	}
+	if len(packet.SourceRuntimes) != 1 || packet.SourceRuntimes[0].CompletenessState != "unknown" {
+		t.Fatalf("runtime references = %#v, want unknown completeness without a checkpoint", packet.SourceRuntimes)
+	}
+}
+
+func TestGRCAuditPacketDoesNotProjectWhenAppendFails(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{"runtime-1": {Id: "runtime-1", TenantId: "writer", SourceId: "okta"}},
+		findings: map[string]*ports.FindingRecord{"finding-1": {ID: "finding-1", TenantID: "writer", RuntimeID: "runtime-1", Status: "open", LastObservedAt: now}},
+	}
+	appendLog := &recordingAppendLog{err: errors.New("append unavailable")}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, AppendLog: appendLog}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	response, err := server.Client().Post(server.URL+"/grc/audit-packets", "application/json", bytes.NewBufferString(`{"finding_id":"finding-1"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("POST /grc/audit-packets status = %d, want %d", response.StatusCode, http.StatusServiceUnavailable)
+	}
+	if len(store.grcAuditPackets) != 0 {
+		t.Fatalf("projected audit packets = %d, want 0 after append failure", len(store.grcAuditPackets))
 	}
 }
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -16,6 +17,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grcauditpacket"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	grcuploadhttp "github.com/writer/cerebro/internal/sourcehttp/grcupload"
@@ -1020,9 +1022,15 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 				Id:            "evidence-1",
 				RuntimeId:     "writer-okta-audit",
 				FindingId:     "finding-high",
+				RunId:         "evaluation-run-1",
+				RunIds:        []string{"evaluation-run-1"},
 				EventIds:      []string{"event-1"},
 				GraphRootUrns: []string{rootURN},
-				CreatedAt:     timestamppb.New(now),
+				GraphPathUrns: []string{"urn:cerebro:writer:graph-path:path-1"},
+				Observations: []*cerebrov1.FindingEvidenceObservation{{
+					RunId: "observation-run-1", ObservedAt: timestamppb.New(now),
+				}},
+				CreatedAt: timestamppb.New(now),
 			},
 		},
 	}
@@ -1068,7 +1076,53 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 		t.Fatalf("impact findings = %#v, want finding-high", impact.Findings)
 	}
 
-	packetResp, err := server.Client().Get(server.URL + "/grc/audit-packets/finding-high")
+	previewResp, err := server.Client().Get(server.URL + "/grc/findings/finding-high/audit-preview")
+	if err != nil {
+		t.Fatalf("GET audit preview error = %v", err)
+	}
+	defer func() { _ = previewResp.Body.Close() }()
+	if previewResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET audit preview status = %d, want %d", previewResp.StatusCode, http.StatusOK)
+	}
+	var preview grcAuditPacketResponse
+	if err := json.NewDecoder(previewResp.Body).Decode(&preview); err != nil {
+		t.Fatalf("decode preview: %v", err)
+	}
+	if preview.ResourceState != "live_preview" || preview.Graph == nil || preview.Graph.Root == nil {
+		t.Fatalf("preview = %#v, want live graph context", preview)
+	}
+
+	createResp, err := server.Client().Post(server.URL+"/grc/audit-packets", "application/json", bytes.NewBufferString(`{"finding_id":"finding-high"}`))
+	if err != nil {
+		t.Fatalf("POST /grc/audit-packets error = %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST /grc/audit-packets status = %d, want %d", createResp.StatusCode, http.StatusCreated)
+	}
+	var created grcAuditPacketResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created packet: %v", err)
+	}
+	if created.ID == "finding-high" || !strings.HasPrefix(created.ID, "audit-packet-") {
+		t.Fatalf("packet id = %q, want independent audit-packet id", created.ID)
+	}
+	if created.ResourceState != "immutable" || created.SchemaVersion != grcAuditPacketSchema || !strings.HasPrefix(created.Digest, "sha256:") {
+		t.Fatalf("created packet identity = %#v", created)
+	}
+	if created.Graph != nil || len(created.GraphReferences.RootURNs) != 1 {
+		t.Fatalf("created graph state = graph %#v refs %#v, want references only", created.Graph, created.GraphReferences)
+	}
+	if len(created.EvidenceReferences) != 1 || !containsTrimmed(created.EvidenceReferences[0].EvaluationRunIDs, "evaluation-run-1") || !containsTrimmed(created.EvidenceReferences[0].ObservationRunIDs, "observation-run-1") {
+		t.Fatalf("created evidence references = %#v, want exact evaluation and observation runs", created.EvidenceReferences)
+	}
+
+	// Current finding and graph mutations after creation must not affect the packet.
+	store.findings["finding-high"].Status = "resolved"
+	store.findingEvidence = map[string]*cerebrov1.FindingEvidence{}
+	graphStore.neighborhood = nil
+
+	packetResp, err := server.Client().Get(server.URL + "/grc/audit-packets/" + created.ID)
 	if err != nil {
 		t.Fatalf("GET /grc/audit-packets error = %v", err)
 	}
@@ -1086,8 +1140,8 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	if len(packet.Evidence) != 1 {
 		t.Fatalf("packet evidence len = %d, want 1", len(packet.Evidence))
 	}
-	if packet.Graph == nil || packet.Graph.Root == nil {
-		t.Fatalf("packet graph missing")
+	if packet.Finding.Status == "resolved" || packet.Digest != created.Digest {
+		t.Fatalf("packet changed after current-state mutation: %#v", packet)
 	}
 	if packet.RecommendedAction == "" {
 		t.Fatalf("packet recommended action is empty")
@@ -1099,7 +1153,7 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 		t.Fatalf("redaction metadata = %#v, want share-safe default", packet.Metadata.Redaction)
 	}
 
-	exportResp, err := server.Client().Get(server.URL + "/grc/audit-packets/finding-high/export")
+	exportResp, err := server.Client().Get(server.URL + "/grc/audit-packets/" + created.ID + "/export")
 	if err != nil {
 		t.Fatalf("GET /grc/audit-packets export error = %v", err)
 	}
@@ -1117,6 +1171,80 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 			t.Fatalf("finding export missing %q:\n%s", want, markdown)
 		}
 	}
+	jsonExportResp, err := server.Client().Get(server.URL + "/grc/audit-packets/" + created.ID + "/export?format=json")
+	if err != nil {
+		t.Fatalf("GET JSON packet export error = %v", err)
+	}
+	defer func() { _ = jsonExportResp.Body.Close() }()
+	var exported grcAuditPacketResponse
+	if err := json.NewDecoder(jsonExportResp.Body).Decode(&exported); err != nil {
+		t.Fatalf("decode JSON packet export: %v", err)
+	}
+	if exported.Digest != packet.Digest || exported.ID != packet.ID {
+		t.Fatalf("JSON export = %q/%q, read = %q/%q", exported.ID, exported.Digest, packet.ID, packet.Digest)
+	}
+}
+
+func TestGRCAuditPacketDigestIsDeterministic(t *testing.T) {
+	packet := grcAuditPacketResponse{
+		ID: "audit-packet-1", SchemaVersion: grcAuditPacketSchema, ResourceState: "immutable", TenantID: "writer",
+		FindingReference: grcAuditFindingReference{ID: "finding-1", Status: "open", StatusRevision: time.Date(2026, 7, 14, 8, 0, 0, 0, time.UTC)},
+		Gaps:             []grcAuditPacketGap{}, Supersedes: []string{}, GeneratedAt: time.Date(2026, 7, 14, 8, 1, 0, 0, time.UTC),
+	}
+	first, err := grcauditpacket.Digest(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := grcauditpacket.Digest(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("digest mismatch: %q != %q", first, second)
+	}
+	packet.FindingReference.Status = "resolved"
+	changed, err := grcauditpacket.Digest(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed == first {
+		t.Fatalf("digest did not change after finding revision changed")
+	}
+}
+
+func TestGRCAuditPacketRecordsGraphGapWhenProjectionUnavailable(t *testing.T) {
+	now := time.Date(2026, 7, 14, 8, 0, 0, 0, time.UTC)
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{"runtime-1": {Id: "runtime-1", TenantId: "writer", SourceId: "okta"}},
+		findings: map[string]*ports.FindingRecord{"finding-1": {ID: "finding-1", TenantID: "writer", RuntimeID: "runtime-1", Status: "open", LastObservedAt: now}},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+	response, err := server.Client().Post(server.URL+"/grc/audit-packets", "application/json", bytes.NewBufferString(`{"finding_id":"finding-1"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusCreated)
+	}
+	packet := grcAuditPacketResponse{}
+	if err := json.NewDecoder(response.Body).Decode(&packet); err != nil {
+		t.Fatal(err)
+	}
+	if !hasGRCAuditPacketGap(packet.Gaps, "graph_context_unavailable") || !hasGRCAuditPacketGap(packet.Gaps, "evidence_unavailable") {
+		t.Fatalf("gaps = %#v, want graph and evidence gaps", packet.Gaps)
+	}
+}
+
+func hasGRCAuditPacketGap(gaps []grcAuditPacketGap, code string) bool {
+	for _, gap := range gaps {
+		if gap.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGRCEntityImpactResolvesLegacyGitHubRepoURN(t *testing.T) {
@@ -1218,19 +1346,38 @@ func TestGRCAuditPacketNormalizesForeignFindingLookup(t *testing.T) {
 		},
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
-	request := httptest.NewRequest(http.MethodGet, "/grc/audit-packets/foreign-finding", nil)
-	request.SetPathValue("packetID", "foreign-finding")
+	request := httptest.NewRequest(http.MethodGet, "/grc/findings/foreign-finding/audit-preview", nil)
+	request.SetPathValue("findingID", "foreign-finding")
 	request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{
 		cfg:       config.AuthConfig{},
 		principal: authPrincipal{TenantID: "writer"},
 	}))
 
-	_, err := app.buildGRCAuditPacket(request)
+	_, err := app.buildGRCAuditPreview(request, "foreign-finding")
 	if !errors.Is(err, ports.ErrFindingNotFound) {
-		t.Fatalf("buildGRCAuditPacket() error = %v, want finding not found", err)
+		t.Fatalf("buildGRCAuditPreview() error = %v, want finding not found", err)
 	}
 	if got := grcHTTPStatusCode(err); got != http.StatusNotFound {
-		t.Fatalf("grcHTTPStatusCode(buildGRCAuditPacket error) = %d, want %d", got, http.StatusNotFound)
+		t.Fatalf("grcHTTPStatusCode(buildGRCAuditPreview error) = %d, want %d", got, http.StatusNotFound)
+	}
+}
+
+func TestGRCAuditPacketNormalizesForeignReceiptLookup(t *testing.T) {
+	store := &stubRuntimeStore{grcAuditPackets: map[string]*ports.GRCAuditPacketReceipt{
+		"packet-other": {ID: "packet-other", TenantID: "other", FindingID: "finding-other", Digest: "sha256:unused", Payload: []byte(`{}`), CreatedAt: time.Now()},
+	}}
+	request := httptest.NewRequest(http.MethodGet, "/grc/audit-packets/packet-other", nil)
+	request.SetPathValue("packetID", "packet-other")
+	request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{cfg: config.AuthConfig{}, principal: authPrincipal{TenantID: "writer"}}))
+
+	_, err := grcauditpacket.Load(request.Context(), store, "packet-other", func(tenantID string) bool {
+		return tenantAllowedByContext(request.Context(), tenantID)
+	})
+	if !errors.Is(err, ports.ErrGRCAuditPacketNotFound) {
+		t.Fatalf("getGRCAuditPacket() error = %v, want packet not found", err)
+	}
+	if got := grcHTTPStatusCode(err); got != http.StatusNotFound {
+		t.Fatalf("grcHTTPStatusCode(getGRCAuditPacket error) = %d, want %d", got, http.StatusNotFound)
 	}
 }
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -1264,6 +1264,43 @@ func TestGRCAuditPacketRecordsGraphGapWhenProjectionUnavailable(t *testing.T) {
 	}
 }
 
+func TestGRCAuditPacketRecordsTruncatedEvidenceSnapshot(t *testing.T) {
+	now := time.Date(2026, time.July, 14, 8, 0, 0, 0, time.UTC)
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{"runtime-1": {Id: "runtime-1", TenantId: "writer", SourceId: "okta"}},
+		findings: map[string]*ports.FindingRecord{"finding-1": {
+			ID: "finding-1", TenantID: "writer", RuntimeID: "runtime-1", Status: "open", LastObservedAt: now,
+			FindingWorkflow: ports.FindingWorkflow{StatusUpdatedAt: now},
+		}},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: "runtime-1", FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+			"evidence-2": {Id: "evidence-2", RuntimeId: "runtime-1", FindingId: "finding-1", CreatedAt: timestamppb.New(now.Add(-time.Minute))},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, AppendLog: &recordingAppendLog{}}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	response, err := server.Client().Post(server.URL+"/grc/audit-packets?limit=1", "application/json", bytes.NewBufferString(`{"finding_id":"finding-1"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusCreated)
+	}
+	packet := grcAuditPacketResponse{}
+	if err := json.NewDecoder(response.Body).Decode(&packet); err != nil {
+		t.Fatal(err)
+	}
+	if len(packet.Evidence) != 1 || len(packet.EvidenceReferences) != 1 {
+		t.Fatalf("captured evidence = %d/%d, want one limited record", len(packet.Evidence), len(packet.EvidenceReferences))
+	}
+	if !hasGRCAuditPacketGap(packet.Gaps, "evidence_snapshot_truncated") {
+		t.Fatalf("gaps = %#v, want evidence_snapshot_truncated", packet.Gaps)
+	}
+}
+
 func TestGRCAuditPacketDoesNotProjectWhenAppendFails(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	store := &stubRuntimeStore{

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 	credentialstoreshttp "github.com/writer/cerebro/internal/sourcehttp/credentialstores"
 	"github.com/writer/cerebro/internal/sourcehttp/customdashboards"
+	grcauditpackethttp "github.com/writer/cerebro/internal/sourcehttp/grcauditpacket"
 	"github.com/writer/cerebro/internal/sourcehttp/identitydirectory"
 	"github.com/writer/cerebro/internal/sourcehttp/userpreferences"
 	"github.com/writer/cerebro/internal/sourceplanapi"
@@ -117,6 +119,7 @@ func (app *App) registerAskQueryRoutes(mux *http.ServeMux) {
 }
 func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	dashboards := customdashboards.NewHandler(app.deps.StateStore, effectiveTenantFilter, authorizeTenantID, customDashboardActorID)
+	auditPackets := grcauditpackethttp.NewHTTPHandler(app.deps.StateStore, app.buildGRCAuditPreview, tenantAllowedByContext, func(err error) error { return errors.Join(errInvalidHTTPRequest, err) }, writeGRCError)
 	registerHTTPRoute(mux, "GET /grc/dashboards", routeSurfacePlatformHTTP, dashboards.List)
 	registerHTTPRoute(mux, "POST /grc/dashboards", routeSurfacePlatformHTTP, dashboards.Create)
 	registerHTTPRoute(mux, "GET /grc/dashboards/{dashboardID}", routeSurfacePlatformHTTP, dashboards.Get)
@@ -185,8 +188,10 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/inventory/asset-reports/{reportID}", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.asset_report", time.Minute, grcCacheScopeInventory), app.handleGetGRCInventoryAssetReport))
 	registerHTTPRoute(mux, "PATCH /grc/inventory/asset-reports/{reportID}/triage", routeSurfacePlatformHTTP, app.handleUpdateGRCInventoryAssetReportTriage)
 	registerHTTPRoute(mux, "GET /grc/entities/{entityID}/impact", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("entity.impact", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCEntityImpact))
-	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("audit.packet", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCAuditPacket))
-	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}/export", routeSurfacePlatformHTTP, app.handleGRCAuditPacketExport)
+	registerHTTPRoute(mux, "GET /grc/findings/{findingID}/audit-preview", routeSurfacePlatformHTTP, auditPackets.Preview)
+	registerHTTPRoute(mux, "POST /grc/audit-packets", routeSurfacePlatformHTTP, auditPackets.Create)
+	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}", routeSurfacePlatformHTTP, auditPackets.Get)
+	registerHTTPRoute(mux, "GET /grc/audit-packets/{packetID}/export", routeSurfacePlatformHTTP, auditPackets.Export)
 }
 func (app *App) registerFindingRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /finding-rules", routeSurfacePlatformHTTP, app.handleListFindingRules)

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -119,7 +119,7 @@ func (app *App) registerAskQueryRoutes(mux *http.ServeMux) {
 }
 func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	dashboards := customdashboards.NewHandler(app.deps.StateStore, effectiveTenantFilter, authorizeTenantID, customDashboardActorID)
-	auditPackets := grcauditpackethttp.NewHTTPHandler(app.deps.StateStore, app.buildGRCAuditPreview, tenantAllowedByContext, func(err error) error { return errors.Join(errInvalidHTTPRequest, err) }, writeGRCError)
+	auditPackets := grcauditpackethttp.NewHTTPHandler(app.deps.StateStore, app.deps.AppendLog, app.buildGRCAuditPreview, tenantAllowedByContext, func(err error) error { return errors.Join(errInvalidHTTPRequest, err) }, writeGRCError)
 	registerHTTPRoute(mux, "GET /grc/dashboards", routeSurfacePlatformHTTP, dashboards.List)
 	registerHTTPRoute(mux, "POST /grc/dashboards", routeSurfacePlatformHTTP, dashboards.Create)
 	registerHTTPRoute(mux, "GET /grc/dashboards/{dashboardID}", routeSurfacePlatformHTTP, dashboards.Get)

--- a/internal/grcaudit/persistence.go
+++ b/internal/grcaudit/persistence.go
@@ -12,13 +12,14 @@ var (
 )
 
 const (
-	AuditAggregateEngagement = "audit_engagement"
-	AuditAggregateRequest    = "audit_evidence_request"
-	AuditAggregateSubmission = "audit_evidence_submission"
-	AuditAggregateSample     = "audit_sample"
-	AuditAggregatePackage    = "audit_package"
-	AuditAggregateCapability = "audit_capability"
-	AuditAggregateGrant      = "audit_access_grant"
+	AuditAggregateEngagement    = "audit_engagement"
+	AuditAggregateRequest       = "audit_evidence_request"
+	AuditAggregateSubmission    = "audit_evidence_submission"
+	AuditAggregateSample        = "audit_sample"
+	AuditAggregatePackage       = "audit_package"
+	AuditAggregatePacketReceipt = "audit_packet_receipt"
+	AuditAggregateCapability    = "audit_capability"
+	AuditAggregateGrant         = "audit_access_grant"
 )
 
 type EngagementRecordedPayload struct {

--- a/internal/grcauditpacket/packet.go
+++ b/internal/grcauditpacket/packet.go
@@ -14,9 +14,11 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/grcaudit"
 	"github.com/writer/cerebro/internal/grccontrol"
 	"github.com/writer/cerebro/internal/grcfindings"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
 )
 
 const SchemaVersion = "grc.audit-packet.v1"
@@ -29,6 +31,7 @@ type Packet struct {
 	TenantID           string                       `json:"tenant_id,omitempty"`
 	FindingReference   FindingReference             `json:"finding_reference,omitempty"`
 	EvidenceReferences []EvidenceReference          `json:"evidence_references,omitempty"`
+	ControlReferences  []ControlReference           `json:"control_references,omitempty"`
 	GraphReferences    GraphReferences              `json:"graph_references,omitempty"`
 	SourceRuntimes     []SourceRuntimeReference     `json:"source_runtimes,omitempty"`
 	Gaps               []Gap                        `json:"gaps"`
@@ -64,9 +67,18 @@ type EvidenceReference struct {
 	GraphPathURNs     []string `json:"graph_path_urns,omitempty"`
 }
 
+type ControlReference struct {
+	FrameworkID      string `json:"framework_id"`
+	ControlID        string `json:"control_id"`
+	FrameworkVersion string `json:"framework_version,omitempty"`
+	ProfileID        string `json:"profile_id,omitempty"`
+	ProfileVersion   string `json:"profile_version,omitempty"`
+}
+
 type GraphReferences struct {
 	RootURNs             []string  `json:"root_urns"`
 	PathURNs             []string  `json:"path_urns"`
+	FactRefs             []string  `json:"fact_refs"`
 	ObservationWatermark time.Time `json:"observation_watermark,omitempty"`
 }
 
@@ -104,6 +116,7 @@ func Freeze(ctx context.Context, store ports.GRCAuditPacketStore, preview Packet
 	packet.TenantID = preview.FindingRecord.TenantID
 	packet.FindingReference = findingReference(preview.FindingRecord)
 	packet.EvidenceReferences, packet.GraphReferences = evidenceReferences(preview.EvidenceRecords, preview.FindingRecord.LastObservedAt)
+	packet.ControlReferences = controlReferences(packet.Controls, packet.Metadata)
 	packet.SourceRuntimes = sourceRuntimeReferences(preview.RuntimeRecords)
 	packet.Graph = nil
 	packet.Gaps = gaps(preview, packet)
@@ -113,15 +126,39 @@ func Freeze(ctx context.Context, store ports.GRCAuditPacketStore, preview Packet
 	if err != nil {
 		return Packet{}, err
 	}
+	return packet, nil
+}
+
+// RecordedEvent returns the append-first compliance event used to rebuild the
+// immutable receipt projection in Postgres.
+func RecordedEvent(packet Packet) (*cerebrov1.EventEnvelope, error) {
+	if err := Verify(packet); err != nil {
+		return nil, err
+	}
 	payload, err := json.Marshal(packet)
 	if err != nil {
-		return Packet{}, fmt.Errorf("marshal GRC audit packet: %w", err)
+		return nil, fmt.Errorf("marshal GRC audit packet event: %w", err)
 	}
-	err = store.PutGRCAuditPacket(ctx, &ports.GRCAuditPacketReceipt{
-		ID: packet.ID, TenantID: packet.TenantID, FindingID: packet.FindingReference.ID,
-		Digest: packet.Digest, Payload: payload, CreatedAt: packet.GeneratedAt,
+	return workflowevents.NewComplianceAggregateEvent(workflowevents.ComplianceAggregateRecorded{
+		Kind: workflowevents.EventKindComplianceAuditPackageRecorded, TenantID: packet.TenantID,
+		AggregateType: grcaudit.AuditAggregatePacketReceipt, AggregateID: packet.ID,
+		AggregateVersion: 1, Operation: "recorded", ContentDigest: packet.Digest,
+		PayloadJSON: string(payload), RecordedAt: packet.GeneratedAt.UTC().Format(time.RFC3339Nano),
 	})
-	return packet, err
+}
+
+func Verify(packet Packet) error {
+	if packet.ID == "" || packet.TenantID == "" || packet.FindingReference.ID == "" || packet.SchemaVersion != SchemaVersion || packet.ResourceState != "immutable" || packet.GeneratedAt.IsZero() {
+		return fmt.Errorf("invalid GRC audit packet receipt")
+	}
+	digest, err := Digest(packet)
+	if err != nil {
+		return err
+	}
+	if packet.Digest == "" || packet.Digest != digest {
+		return fmt.Errorf("GRC audit packet digest verification failed")
+	}
+	return nil
 }
 
 func Load(ctx context.Context, store ports.GRCAuditPacketStore, packetID string, tenantAllowed func(string) bool) (Packet, error) {
@@ -139,9 +176,8 @@ func Load(ctx context.Context, store ports.GRCAuditPacketStore, packetID string,
 	if packet.ID != receipt.ID || packet.TenantID != receipt.TenantID || packet.Digest != receipt.Digest {
 		return Packet{}, fmt.Errorf("GRC audit packet %q envelope does not match stored payload", packetID)
 	}
-	digest, err := Digest(packet)
-	if err != nil || digest != packet.Digest {
-		return Packet{}, fmt.Errorf("GRC audit packet %q digest verification failed", packetID)
+	if err := Verify(packet); err != nil {
+		return Packet{}, fmt.Errorf("GRC audit packet %q: %w", packetID, err)
 	}
 	return packet, nil
 }
@@ -174,7 +210,7 @@ func findingReference(finding *ports.FindingRecord) FindingReference {
 
 func evidenceReferences(evidence []*cerebrov1.FindingEvidence, findingWatermark time.Time) ([]EvidenceReference, GraphReferences) {
 	refs := make([]EvidenceReference, 0, len(evidence))
-	graph := GraphReferences{RootURNs: []string{}, PathURNs: []string{}, ObservationWatermark: findingWatermark.UTC()}
+	graph := GraphReferences{RootURNs: []string{}, PathURNs: []string{}, FactRefs: []string{}, ObservationWatermark: findingWatermark.UTC()}
 	for _, item := range evidence {
 		if item == nil {
 			continue
@@ -190,6 +226,18 @@ func evidenceReferences(evidence []*cerebrov1.FindingEvidence, findingWatermark 
 			graph.ObservationWatermark = at.AsTime().UTC()
 		}
 		roots, paths := NormalizeStrings(item.GetGraphRootUrns()), NormalizeStrings(item.GetGraphPathUrns())
+		for _, row := range item.GetGraphRows() {
+			if ref := graphFactRef(row); ref != "" {
+				graph.FactRefs = append(graph.FactRefs, ref)
+			}
+		}
+		for _, observation := range item.GetObservations() {
+			for _, row := range observation.GetGraphRows() {
+				if ref := graphFactRef(row); ref != "" {
+					graph.FactRefs = append(graph.FactRefs, ref)
+				}
+			}
+		}
 		refs = append(refs, EvidenceReference{
 			ID: item.GetId(), EvaluationRunIDs: NormalizeStrings(append([]string{item.GetRunId()}, item.GetRunIds()...)), ObservationRunIDs: NormalizeStrings(observationRuns),
 			ClaimIDs: NormalizeStrings(item.GetClaimIds()), EventIDs: NormalizeStrings(item.GetEventIds()), GraphRootURNs: roots, GraphPathURNs: paths,
@@ -197,8 +245,40 @@ func evidenceReferences(evidence []*cerebrov1.FindingEvidence, findingWatermark 
 		graph.RootURNs, graph.PathURNs = append(graph.RootURNs, roots...), append(graph.PathURNs, paths...)
 	}
 	sort.Slice(refs, func(i, j int) bool { return refs[i].ID < refs[j].ID })
-	graph.RootURNs, graph.PathURNs = NormalizeStrings(graph.RootURNs), NormalizeStrings(graph.PathURNs)
+	graph.RootURNs, graph.PathURNs, graph.FactRefs = NormalizeStrings(graph.RootURNs), NormalizeStrings(graph.PathURNs), NormalizeStrings(graph.FactRefs)
 	return refs, graph
+}
+
+func graphFactRef(row *cerebrov1.GraphEvidenceRow) string {
+	if row == nil {
+		return ""
+	}
+	if factID := strings.TrimSpace(row.GetAttributes()["fact_id"]); factID != "" {
+		return factID
+	}
+	payload, err := json.Marshal(row)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(payload)
+	return "graph-row:sha256:" + hex.EncodeToString(sum[:])
+}
+
+func controlReferences(controls []grcfindings.ControlRef, metadata grccontrol.ReportMetadata) []ControlReference {
+	refs := make([]ControlReference, 0, len(controls))
+	for _, control := range controls {
+		refs = append(refs, ControlReference{
+			FrameworkID: control.FrameworkName, ControlID: control.ControlID,
+			ProfileID: metadata.Provenance.ProfileID, ProfileVersion: metadata.Provenance.PacketVersion,
+		})
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].FrameworkID == refs[j].FrameworkID {
+			return refs[i].ControlID < refs[j].ControlID
+		}
+		return refs[i].FrameworkID < refs[j].FrameworkID
+	})
+	return refs
 }
 
 func sourceRuntimeReferences(runtimes []*cerebrov1.SourceRuntime) []SourceRuntimeReference {
@@ -207,12 +287,13 @@ func sourceRuntimeReferences(runtimes []*cerebrov1.SourceRuntime) []SourceRuntim
 		if runtime == nil {
 			continue
 		}
-		ref := SourceRuntimeReference{ID: runtime.GetId(), SourceID: runtime.GetSourceId(), FreshnessState: "never_synced", CompletenessState: "complete"}
+		ref := SourceRuntimeReference{ID: runtime.GetId(), SourceID: runtime.GetSourceId(), FreshnessState: "never_synced", CompletenessState: "unknown"}
 		if at := runtime.GetLastSyncedAt(); at != nil {
 			ref.LastSyncedAt, ref.FreshnessState = at.AsTime().UTC(), "observed"
 		}
 		if checkpoint := runtime.GetCheckpoint(); checkpoint != nil && checkpoint.GetWatermark() != nil {
 			ref.CheckpointWatermark = checkpoint.GetWatermark().AsTime().UTC()
+			ref.CompletenessState = "complete"
 		}
 		if cursor := runtime.GetNextCursor(); cursor != nil && strings.TrimSpace(cursor.GetOpaque()) != "" {
 			ref.CompletenessState = "partial"
@@ -225,14 +306,44 @@ func sourceRuntimeReferences(runtimes []*cerebrov1.SourceRuntime) []SourceRuntim
 
 func gaps(preview Packet, packet Packet) []Gap {
 	result := []Gap{}
+	if strings.TrimSpace(packet.FindingReference.Fingerprint) == "" {
+		result = append(result, Gap{Code: "finding_fingerprint_unavailable", Message: "The finding had no durable fingerprint when this packet was created."})
+	}
+	if packet.FindingReference.StatusRevision.IsZero() {
+		result = append(result, Gap{Code: "finding_status_revision_unavailable", Message: "The finding had no status revision timestamp when this packet was created."})
+	}
 	if preview.Graph == nil {
 		result = append(result, Gap{Code: "graph_context_unavailable", Message: "No graph neighborhood was available when this packet was created; the receipt contains only cited graph roots and paths."})
 	}
-	if len(packet.Controls) != 0 && packet.Metadata.Provenance.PacketVersion == "" {
-		result = append(result, Gap{Code: "control_version_unavailable", Message: "The finding carried control identifiers without a versioned control profile."})
+	for _, control := range packet.ControlReferences {
+		if control.FrameworkVersion == "" {
+			result = append(result, Gap{Code: "framework_version_unavailable", Message: "Framework " + control.FrameworkID + " had no version reference when this packet was created."})
+		}
+		if control.ProfileVersion == "" {
+			result = append(result, Gap{Code: "profile_version_unavailable", Message: "Control " + control.ControlID + " had no profile version when this packet was created."})
+		}
 	}
 	if len(packet.EvidenceReferences) == 0 {
 		result = append(result, Gap{Code: "evidence_unavailable", Message: "No evidence records were available when this packet was created."})
+	}
+	for _, evidence := range packet.EvidenceReferences {
+		if len(evidence.EvaluationRunIDs) == 0 {
+			result = append(result, Gap{Code: "evaluation_run_unavailable", Message: "Evidence " + evidence.ID + " had no evaluation run reference."})
+		}
+		if len(evidence.ObservationRunIDs) == 0 {
+			result = append(result, Gap{Code: "observation_run_unavailable", Message: "Evidence " + evidence.ID + " had no observation run reference."})
+		}
+	}
+	if packet.GraphReferences.ObservationWatermark.IsZero() {
+		result = append(result, Gap{Code: "graph_observation_watermark_unavailable", Message: "No graph observation watermark was available when this packet was created."})
+	}
+	if len(packet.GraphReferences.FactRefs) == 0 && (len(packet.GraphReferences.RootURNs) != 0 || len(packet.GraphReferences.PathURNs) != 0) {
+		result = append(result, Gap{Code: "graph_fact_refs_unavailable", Message: "Graph roots or paths were captured without graph fact references."})
+	}
+	for _, runtime := range packet.SourceRuntimes {
+		if runtime.CheckpointWatermark.IsZero() {
+			result = append(result, Gap{Code: "source_checkpoint_unavailable", Message: "Source runtime " + runtime.ID + " had no checkpoint watermark when this packet was created."})
+		}
 	}
 	return result
 }

--- a/internal/grcauditpacket/packet.go
+++ b/internal/grcauditpacket/packet.go
@@ -201,11 +201,7 @@ func newID() (string, error) {
 }
 
 func findingReference(finding *ports.FindingRecord) FindingReference {
-	revision := finding.StatusUpdatedAt
-	if revision.IsZero() {
-		revision = finding.LastObservedAt
-	}
-	return FindingReference{ID: finding.ID, Fingerprint: finding.Fingerprint, Status: finding.Status, StatusRevision: revision.UTC()}
+	return FindingReference{ID: finding.ID, Fingerprint: finding.Fingerprint, Status: finding.Status, StatusRevision: finding.StatusUpdatedAt.UTC()}
 }
 
 func evidenceReferences(evidence []*cerebrov1.FindingEvidence, findingWatermark time.Time) ([]EvidenceReference, GraphReferences) {
@@ -305,7 +301,7 @@ func sourceRuntimeReferences(runtimes []*cerebrov1.SourceRuntime) []SourceRuntim
 }
 
 func gaps(preview Packet, packet Packet) []Gap {
-	result := []Gap{}
+	result := append([]Gap(nil), preview.Gaps...)
 	if strings.TrimSpace(packet.FindingReference.Fingerprint) == "" {
 		result = append(result, Gap{Code: "finding_fingerprint_unavailable", Message: "The finding had no durable fingerprint when this packet was created."})
 	}

--- a/internal/grcauditpacket/packet.go
+++ b/internal/grcauditpacket/packet.go
@@ -1,0 +1,251 @@
+// Package grcauditpacket owns immutable audit packet identity, references,
+// canonical digesting, and state-store persistence.
+package grcauditpacket
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/grcfindings"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const SchemaVersion = "grc.audit-packet.v1"
+
+type Packet struct {
+	ID                 string                       `json:"id"`
+	SchemaVersion      string                       `json:"schema_version,omitempty"`
+	ResourceState      string                       `json:"resource_state"`
+	Digest             string                       `json:"digest,omitempty"`
+	TenantID           string                       `json:"tenant_id,omitempty"`
+	FindingReference   FindingReference             `json:"finding_reference,omitempty"`
+	EvidenceReferences []EvidenceReference          `json:"evidence_references,omitempty"`
+	GraphReferences    GraphReferences              `json:"graph_references,omitempty"`
+	SourceRuntimes     []SourceRuntimeReference     `json:"source_runtimes,omitempty"`
+	Gaps               []Gap                        `json:"gaps"`
+	ReviewState        string                       `json:"review_state,omitempty"`
+	ExportState        string                       `json:"export_state,omitempty"`
+	Supersedes         []string                     `json:"supersedes"`
+	Finding            grcfindings.FindingItem      `json:"finding"`
+	Evidence           []grcfindings.EvidenceItem   `json:"evidence"`
+	Graph              *ports.EntityNeighborhood    `json:"graph,omitempty"`
+	Controls           []grcfindings.ControlRef     `json:"controls,omitempty"`
+	RecommendedAction  string                       `json:"recommended_action"`
+	Metadata           grccontrol.ReportMetadata    `json:"metadata"`
+	GeneratedAt        time.Time                    `json:"generated_at"`
+	FindingRecord      *ports.FindingRecord         `json:"-"`
+	EvidenceRecords    []*cerebrov1.FindingEvidence `json:"-"`
+	RuntimeRecords     []*cerebrov1.SourceRuntime   `json:"-"`
+}
+
+type FindingReference struct {
+	ID             string    `json:"id"`
+	Fingerprint    string    `json:"fingerprint,omitempty"`
+	Status         string    `json:"status"`
+	StatusRevision time.Time `json:"status_revision"`
+}
+
+type EvidenceReference struct {
+	ID                string   `json:"id"`
+	EvaluationRunIDs  []string `json:"evaluation_run_ids"`
+	ObservationRunIDs []string `json:"observation_run_ids"`
+	ClaimIDs          []string `json:"claim_ids,omitempty"`
+	EventIDs          []string `json:"event_ids,omitempty"`
+	GraphRootURNs     []string `json:"graph_root_urns,omitempty"`
+	GraphPathURNs     []string `json:"graph_path_urns,omitempty"`
+}
+
+type GraphReferences struct {
+	RootURNs             []string  `json:"root_urns"`
+	PathURNs             []string  `json:"path_urns"`
+	ObservationWatermark time.Time `json:"observation_watermark,omitempty"`
+}
+
+type SourceRuntimeReference struct {
+	ID                  string    `json:"id"`
+	SourceID            string    `json:"source_id"`
+	FreshnessState      string    `json:"freshness_state"`
+	CompletenessState   string    `json:"completeness_state"`
+	LastSyncedAt        time.Time `json:"last_synced_at,omitempty"`
+	CheckpointWatermark time.Time `json:"checkpoint_watermark,omitempty"`
+}
+
+type Gap struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func Freeze(ctx context.Context, store ports.GRCAuditPacketStore, preview Packet, supersedes []string, tenantAllowed func(string) bool) (Packet, error) {
+	if store == nil || preview.FindingRecord == nil {
+		return Packet{}, fmt.Errorf("GRC audit packet store and finding snapshot are required")
+	}
+	supersedes = NormalizeStrings(supersedes)
+	for _, packetID := range supersedes {
+		receipt, err := store.GetGRCAuditPacket(ctx, packetID)
+		if err != nil || receipt.TenantID != preview.FindingRecord.TenantID || (tenantAllowed != nil && !tenantAllowed(receipt.TenantID)) {
+			return Packet{}, ports.ErrGRCAuditPacketNotFound
+		}
+	}
+	packetID, err := newID()
+	if err != nil {
+		return Packet{}, err
+	}
+	packet := preview
+	packet.ID, packet.SchemaVersion, packet.ResourceState = packetID, SchemaVersion, "immutable"
+	packet.TenantID = preview.FindingRecord.TenantID
+	packet.FindingReference = findingReference(preview.FindingRecord)
+	packet.EvidenceReferences, packet.GraphReferences = evidenceReferences(preview.EvidenceRecords, preview.FindingRecord.LastObservedAt)
+	packet.SourceRuntimes = sourceRuntimeReferences(preview.RuntimeRecords)
+	packet.Graph = nil
+	packet.Gaps = gaps(preview, packet)
+	packet.ReviewState, packet.ExportState, packet.Supersedes = "unreviewed", "ready", supersedes
+	packet.FindingRecord, packet.EvidenceRecords, packet.RuntimeRecords = nil, nil, nil
+	packet.Digest, err = Digest(packet)
+	if err != nil {
+		return Packet{}, err
+	}
+	payload, err := json.Marshal(packet)
+	if err != nil {
+		return Packet{}, fmt.Errorf("marshal GRC audit packet: %w", err)
+	}
+	err = store.PutGRCAuditPacket(ctx, &ports.GRCAuditPacketReceipt{
+		ID: packet.ID, TenantID: packet.TenantID, FindingID: packet.FindingReference.ID,
+		Digest: packet.Digest, Payload: payload, CreatedAt: packet.GeneratedAt,
+	})
+	return packet, err
+}
+
+func Load(ctx context.Context, store ports.GRCAuditPacketStore, packetID string, tenantAllowed func(string) bool) (Packet, error) {
+	receipt, err := store.GetGRCAuditPacket(ctx, strings.TrimSpace(packetID))
+	if err != nil {
+		return Packet{}, err
+	}
+	if tenantAllowed != nil && !tenantAllowed(receipt.TenantID) {
+		return Packet{}, ports.ErrGRCAuditPacketNotFound
+	}
+	packet := Packet{}
+	if err := json.Unmarshal(receipt.Payload, &packet); err != nil {
+		return Packet{}, fmt.Errorf("decode GRC audit packet %q: %w", packetID, err)
+	}
+	if packet.ID != receipt.ID || packet.TenantID != receipt.TenantID || packet.Digest != receipt.Digest {
+		return Packet{}, fmt.Errorf("GRC audit packet %q envelope does not match stored payload", packetID)
+	}
+	digest, err := Digest(packet)
+	if err != nil || digest != packet.Digest {
+		return Packet{}, fmt.Errorf("GRC audit packet %q digest verification failed", packetID)
+	}
+	return packet, nil
+}
+
+func Digest(packet Packet) (string, error) {
+	packet.Digest = ""
+	payload, err := json.Marshal(packet)
+	if err != nil {
+		return "", fmt.Errorf("marshal GRC audit packet digest payload: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func newID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate GRC audit packet id: %w", err)
+	}
+	return "audit-packet-" + hex.EncodeToString(value[:]), nil
+}
+
+func findingReference(finding *ports.FindingRecord) FindingReference {
+	revision := finding.StatusUpdatedAt
+	if revision.IsZero() {
+		revision = finding.LastObservedAt
+	}
+	return FindingReference{ID: finding.ID, Fingerprint: finding.Fingerprint, Status: finding.Status, StatusRevision: revision.UTC()}
+}
+
+func evidenceReferences(evidence []*cerebrov1.FindingEvidence, findingWatermark time.Time) ([]EvidenceReference, GraphReferences) {
+	refs := make([]EvidenceReference, 0, len(evidence))
+	graph := GraphReferences{RootURNs: []string{}, PathURNs: []string{}, ObservationWatermark: findingWatermark.UTC()}
+	for _, item := range evidence {
+		if item == nil {
+			continue
+		}
+		observationRuns := []string{}
+		for _, observation := range item.GetObservations() {
+			observationRuns = append(observationRuns, observation.GetRunId())
+			if at := observation.GetObservedAt(); at != nil && at.AsTime().After(graph.ObservationWatermark) {
+				graph.ObservationWatermark = at.AsTime().UTC()
+			}
+		}
+		if at := item.GetLastObservedAt(); at != nil && at.AsTime().After(graph.ObservationWatermark) {
+			graph.ObservationWatermark = at.AsTime().UTC()
+		}
+		roots, paths := NormalizeStrings(item.GetGraphRootUrns()), NormalizeStrings(item.GetGraphPathUrns())
+		refs = append(refs, EvidenceReference{
+			ID: item.GetId(), EvaluationRunIDs: NormalizeStrings(append([]string{item.GetRunId()}, item.GetRunIds()...)), ObservationRunIDs: NormalizeStrings(observationRuns),
+			ClaimIDs: NormalizeStrings(item.GetClaimIds()), EventIDs: NormalizeStrings(item.GetEventIds()), GraphRootURNs: roots, GraphPathURNs: paths,
+		})
+		graph.RootURNs, graph.PathURNs = append(graph.RootURNs, roots...), append(graph.PathURNs, paths...)
+	}
+	sort.Slice(refs, func(i, j int) bool { return refs[i].ID < refs[j].ID })
+	graph.RootURNs, graph.PathURNs = NormalizeStrings(graph.RootURNs), NormalizeStrings(graph.PathURNs)
+	return refs, graph
+}
+
+func sourceRuntimeReferences(runtimes []*cerebrov1.SourceRuntime) []SourceRuntimeReference {
+	refs := make([]SourceRuntimeReference, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		ref := SourceRuntimeReference{ID: runtime.GetId(), SourceID: runtime.GetSourceId(), FreshnessState: "never_synced", CompletenessState: "complete"}
+		if at := runtime.GetLastSyncedAt(); at != nil {
+			ref.LastSyncedAt, ref.FreshnessState = at.AsTime().UTC(), "observed"
+		}
+		if checkpoint := runtime.GetCheckpoint(); checkpoint != nil && checkpoint.GetWatermark() != nil {
+			ref.CheckpointWatermark = checkpoint.GetWatermark().AsTime().UTC()
+		}
+		if cursor := runtime.GetNextCursor(); cursor != nil && strings.TrimSpace(cursor.GetOpaque()) != "" {
+			ref.CompletenessState = "partial"
+		}
+		refs = append(refs, ref)
+	}
+	sort.Slice(refs, func(i, j int) bool { return refs[i].ID < refs[j].ID })
+	return refs
+}
+
+func gaps(preview Packet, packet Packet) []Gap {
+	result := []Gap{}
+	if preview.Graph == nil {
+		result = append(result, Gap{Code: "graph_context_unavailable", Message: "No graph neighborhood was available when this packet was created; the receipt contains only cited graph roots and paths."})
+	}
+	if len(packet.Controls) != 0 && packet.Metadata.Provenance.PacketVersion == "" {
+		result = append(result, Gap{Code: "control_version_unavailable", Message: "The finding carried control identifiers without a versioned control profile."})
+	}
+	if len(packet.EvidenceReferences) == 0 {
+		result = append(result, Gap{Code: "evidence_unavailable", Message: "No evidence records were available when this packet was created."})
+	}
+	return result
+}
+
+func NormalizeStrings(values []string) []string {
+	seen, result := map[string]struct{}{}, []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if _, ok := seen[value]; value == "" || ok {
+			continue
+		}
+		seen[value], result = struct{}{}, append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/grcauditpacket/packet_test.go
+++ b/internal/grcauditpacket/packet_test.go
@@ -1,0 +1,51 @@
+package grcauditpacket
+
+import (
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/grcfindings"
+)
+
+func TestPacketReferencesAndGapsPreserveUnavailableHistory(t *testing.T) {
+	t.Parallel()
+	evidence := []*cerebrov1.FindingEvidence{{
+		Id: "evidence-one", GraphRootUrns: []string{"root-one"}, GraphPathUrns: []string{"path-one"},
+		GraphRows: []*cerebrov1.GraphEvidenceRow{{Attributes: map[string]string{"fact_id": "fact-one"}}},
+	}}
+	evidenceRefs, graphRefs := evidenceReferences(evidence, time.Time{})
+	if len(evidenceRefs) != 1 || len(graphRefs.FactRefs) != 1 || graphRefs.FactRefs[0] != "fact-one" {
+		t.Fatalf("evidence refs = %#v graph refs = %#v", evidenceRefs, graphRefs)
+	}
+	packet := Packet{
+		FindingReference:   FindingReference{ID: "finding-one", Status: "open"},
+		EvidenceReferences: evidenceRefs, GraphReferences: graphRefs,
+		ControlReferences: controlReferences([]grcfindings.ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}}, grccontrol.ReportMetadata{}),
+		SourceRuntimes:    sourceRuntimeReferences([]*cerebrov1.SourceRuntime{{Id: "runtime-one", SourceId: "okta"}}),
+	}
+	packet.Gaps = gaps(Packet{}, packet)
+	for _, code := range []string{
+		"finding_fingerprint_unavailable", "finding_status_revision_unavailable",
+		"framework_version_unavailable", "profile_version_unavailable",
+		"evaluation_run_unavailable", "observation_run_unavailable",
+		"graph_observation_watermark_unavailable", "source_checkpoint_unavailable",
+	} {
+		if !hasGap(packet.Gaps, code) {
+			t.Fatalf("gaps = %#v, want %q", packet.Gaps, code)
+		}
+	}
+	if got := packet.SourceRuntimes[0].CompletenessState; got != "unknown" {
+		t.Fatalf("completeness = %q, want unknown without checkpoint", got)
+	}
+}
+
+func hasGap(gaps []Gap, code string) bool {
+	for _, gap := range gaps {
+		if gap.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/grcauditpacket/packet_test.go
+++ b/internal/grcauditpacket/packet_test.go
@@ -7,6 +7,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/grccontrol"
 	"github.com/writer/cerebro/internal/grcfindings"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestPacketReferencesAndGapsPreserveUnavailableHistory(t *testing.T) {
@@ -38,6 +39,20 @@ func TestPacketReferencesAndGapsPreserveUnavailableHistory(t *testing.T) {
 	}
 	if got := packet.SourceRuntimes[0].CompletenessState; got != "unknown" {
 		t.Fatalf("completeness = %q, want unknown without checkpoint", got)
+	}
+}
+
+func TestFindingReferenceDoesNotSubstituteObservationTimeForStatusRevision(t *testing.T) {
+	t.Parallel()
+	reference := findingReference(&ports.FindingRecord{
+		ID: "finding-one", Status: "open", LastObservedAt: time.Date(2026, time.July, 14, 8, 0, 0, 0, time.UTC),
+	})
+	if !reference.StatusRevision.IsZero() {
+		t.Fatalf("status revision = %v, want unavailable when status_updated_at is absent", reference.StatusRevision)
+	}
+	packet := Packet{FindingReference: reference}
+	if got := gaps(Packet{}, packet); !hasGap(got, "finding_status_revision_unavailable") {
+		t.Fatalf("gaps = %#v, want finding_status_revision_unavailable", got)
 	}
 }
 

--- a/internal/ports/grc_audit_packets.go
+++ b/internal/ports/grc_audit_packets.go
@@ -24,6 +24,5 @@ type GRCAuditPacketReceipt struct {
 // GRCAuditPacketStore owns immutable audit packet receipts in current state.
 type GRCAuditPacketStore interface {
 	StateStore
-	PutGRCAuditPacket(context.Context, *GRCAuditPacketReceipt) error
 	GetGRCAuditPacket(context.Context, string) (*GRCAuditPacketReceipt, error)
 }

--- a/internal/ports/grc_audit_packets.go
+++ b/internal/ports/grc_audit_packets.go
@@ -1,0 +1,29 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrGRCAuditPacketNotFound indicates that an immutable audit packet does not exist.
+var ErrGRCAuditPacketNotFound = errors.New("GRC audit packet not found")
+
+// GRCAuditPacketReceipt is the state-store envelope for one immutable packet.
+// Payload contains the complete, versioned packet response. Readers must
+// authorize TenantID before decoding or returning Payload.
+type GRCAuditPacketReceipt struct {
+	ID        string
+	TenantID  string
+	FindingID string
+	Digest    string
+	Payload   []byte
+	CreatedAt time.Time
+}
+
+// GRCAuditPacketStore owns immutable audit packet receipts in current state.
+type GRCAuditPacketStore interface {
+	StateStore
+	PutGRCAuditPacket(context.Context, *GRCAuditPacketReceipt) error
+	GetGRCAuditPacket(context.Context, string) (*GRCAuditPacketReceipt, error)
+}

--- a/internal/sourcehttp/grcauditpacket/handler.go
+++ b/internal/sourcehttp/grcauditpacket/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/grcauditpacket"
 	"github.com/writer/cerebro/internal/grccontrol"
@@ -19,14 +20,20 @@ type PreviewBuilder func(*http.Request, string) (grcauditpacket.Packet, error)
 
 type HTTPHandler struct {
 	stateStore    ports.StateStore
+	appendLog     ports.AppendLog
 	preview       PreviewBuilder
 	tenantAllowed func(context.Context, string) bool
 	invalid       func(error) error
 	writeError    func(http.ResponseWriter, error)
 }
 
-func NewHTTPHandler(stateStore ports.StateStore, preview PreviewBuilder, tenantAllowed func(context.Context, string) bool, invalid func(error) error, writeError func(http.ResponseWriter, error)) *HTTPHandler {
-	return &HTTPHandler{stateStore: stateStore, preview: preview, tenantAllowed: tenantAllowed, invalid: invalid, writeError: writeError}
+type auditPacketProjectionStore interface {
+	ports.GRCAuditPacketStore
+	ApplyAuditProjectionEvent(context.Context, *cerebrov1.EventEnvelope) (bool, error)
+}
+
+func NewHTTPHandler(stateStore ports.StateStore, appendLog ports.AppendLog, preview PreviewBuilder, tenantAllowed func(context.Context, string) bool, invalid func(error) error, writeError func(http.ResponseWriter, error)) *HTTPHandler {
+	return &HTTPHandler{stateStore: stateStore, appendLog: appendLog, preview: preview, tenantAllowed: tenantAllowed, invalid: invalid, writeError: writeError}
 }
 
 func (h *HTTPHandler) Preview(w http.ResponseWriter, r *http.Request) {
@@ -45,14 +52,28 @@ func (h *HTTPHandler) Create(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, h.invalid(fmt.Errorf("decode audit packet request: %w", err)))
 		return
 	}
-	store, ok := h.stateStore.(ports.GRCAuditPacketStore)
-	if !ok {
+	store, ok := h.stateStore.(auditPacketProjectionStore)
+	if !ok || h.appendLog == nil {
 		h.writeError(w, findings.ErrRuntimeUnavailable)
 		return
 	}
 	preview, err := h.preview(r, request.FindingID)
 	if err == nil {
 		preview, err = grcauditpacket.Freeze(r.Context(), store, preview, request.Supersedes, func(tenantID string) bool { return h.tenantAllowed(r.Context(), tenantID) })
+	}
+	var event *cerebrov1.EventEnvelope
+	if err == nil {
+		event, err = grcauditpacket.RecordedEvent(preview)
+	}
+	if err == nil {
+		if appendErr := h.appendLog.Append(r.Context(), event); appendErr != nil {
+			err = fmt.Errorf("%w: append audit packet receipt", findings.ErrRuntimeUnavailable)
+		}
+	}
+	if err == nil {
+		if _, projectionErr := store.ApplyAuditProjectionEvent(r.Context(), event); projectionErr != nil {
+			err = fmt.Errorf("%w: project audit packet receipt", findings.ErrRuntimeUnavailable)
+		}
 	}
 	if err != nil {
 		h.writeError(w, err)
@@ -80,7 +101,12 @@ func (h *HTTPHandler) Export(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 	w.Header().Set("Content-Disposition", `attachment; filename="finding-audit-packet.md"`)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	_, _ = w.Write([]byte(grccontrol.RenderFindingAuditPacketMarkdown(markdownInput(packet))))
+	markdown := grccontrol.RenderFindingAuditPacketMarkdown(markdownInput(packet))
+	markdown += fmt.Sprintf("\n## Receipt\n\n- Packet ID: `%s`\n- Canonical digest: `%s`\n- Review state: %s\n- Export state: %s\n", packet.ID, packet.Digest, packet.ReviewState, packet.ExportState)
+	for _, gap := range packet.Gaps {
+		markdown += fmt.Sprintf("- Gap `%s`: %s\n", gap.Code, gap.Message)
+	}
+	_, _ = w.Write([]byte(markdown))
 }
 
 func (h *HTTPHandler) load(r *http.Request) (grcauditpacket.Packet, error) {

--- a/internal/sourcehttp/grcauditpacket/handler.go
+++ b/internal/sourcehttp/grcauditpacket/handler.go
@@ -1,0 +1,129 @@
+package grcauditpackethttp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/grcauditpacket"
+	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const maxCreateBodyBytes = 1 << 20
+
+type PreviewBuilder func(*http.Request, string) (grcauditpacket.Packet, error)
+
+type HTTPHandler struct {
+	stateStore    ports.StateStore
+	preview       PreviewBuilder
+	tenantAllowed func(context.Context, string) bool
+	invalid       func(error) error
+	writeError    func(http.ResponseWriter, error)
+}
+
+func NewHTTPHandler(stateStore ports.StateStore, preview PreviewBuilder, tenantAllowed func(context.Context, string) bool, invalid func(error) error, writeError func(http.ResponseWriter, error)) *HTTPHandler {
+	return &HTTPHandler{stateStore: stateStore, preview: preview, tenantAllowed: tenantAllowed, invalid: invalid, writeError: writeError}
+}
+
+func (h *HTTPHandler) Preview(w http.ResponseWriter, r *http.Request) {
+	packet, err := h.preview(r, strings.TrimSpace(r.PathValue("findingID")))
+	h.write(w, http.StatusOK, packet, err)
+}
+
+func (h *HTTPHandler) Create(w http.ResponseWriter, r *http.Request) {
+	request := struct {
+		FindingID  string   `json:"finding_id"`
+		Supersedes []string `json:"supersedes,omitempty"`
+	}{}
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxCreateBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		h.writeError(w, h.invalid(fmt.Errorf("decode audit packet request: %w", err)))
+		return
+	}
+	store, ok := h.stateStore.(ports.GRCAuditPacketStore)
+	if !ok {
+		h.writeError(w, findings.ErrRuntimeUnavailable)
+		return
+	}
+	preview, err := h.preview(r, request.FindingID)
+	if err == nil {
+		preview, err = grcauditpacket.Freeze(r.Context(), store, preview, request.Supersedes, func(tenantID string) bool { return h.tenantAllowed(r.Context(), tenantID) })
+	}
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	w.Header().Set("Location", "/grc/audit-packets/"+preview.ID)
+	h.write(w, http.StatusCreated, preview, nil)
+}
+
+func (h *HTTPHandler) Get(w http.ResponseWriter, r *http.Request) {
+	packet, err := h.load(r)
+	h.write(w, http.StatusOK, packet, err)
+}
+
+func (h *HTTPHandler) Export(w http.ResponseWriter, r *http.Request) {
+	packet, err := h.load(r)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	if strings.EqualFold(r.URL.Query().Get("format"), "json") {
+		h.write(w, http.StatusOK, packet, nil)
+		return
+	}
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="finding-audit-packet.md"`)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, _ = w.Write([]byte(grccontrol.RenderFindingAuditPacketMarkdown(markdownInput(packet))))
+}
+
+func (h *HTTPHandler) load(r *http.Request) (grcauditpacket.Packet, error) {
+	packetID := strings.TrimSpace(r.PathValue("packetID"))
+	if packetID == "" {
+		return grcauditpacket.Packet{}, h.invalid(fmt.Errorf("packet id is required"))
+	}
+	store, ok := h.stateStore.(ports.GRCAuditPacketStore)
+	if !ok {
+		return grcauditpacket.Packet{}, findings.ErrRuntimeUnavailable
+	}
+	return grcauditpacket.Load(r.Context(), store, packetID, func(tenantID string) bool { return h.tenantAllowed(r.Context(), tenantID) })
+}
+
+func (h *HTTPHandler) write(w http.ResponseWriter, status int, packet grcauditpacket.Packet, err error) {
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	payload, err := json.Marshal(packet)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(payload)
+}
+
+func markdownInput(packet grcauditpacket.Packet) grccontrol.FindingAuditMarkdownInput {
+	controls := make([]grccontrol.ControlRef, 0, len(packet.Controls))
+	for _, control := range packet.Controls {
+		controls = append(controls, grccontrol.ControlRef{FrameworkName: control.FrameworkName, ControlID: control.ControlID})
+	}
+	evidence := make([]grccontrol.FindingAuditMarkdownEvidence, 0, len(packet.Evidence))
+	for _, item := range packet.Evidence {
+		evidence = append(evidence, grccontrol.FindingAuditMarkdownEvidence{ID: item.ID, RuleID: item.RuleID, CreatedAt: item.CreatedAt})
+	}
+	return grccontrol.FindingAuditMarkdownInput{
+		Finding: grccontrol.FindingAuditMarkdownFinding{
+			ID: packet.Finding.ID, Title: packet.Finding.Title, Severity: packet.Finding.Severity, Status: packet.Finding.Status,
+			Summary: packet.Finding.Summary, RiskScore: packet.Finding.RiskScore, Owner: packet.Finding.Owner, SLAStatus: packet.Finding.SLAStatus,
+		},
+		Controls: controls, Evidence: evidence, RecommendedAction: packet.RecommendedAction, Metadata: packet.Metadata, GeneratedAt: packet.GeneratedAt,
+	}
+}

--- a/internal/sourcehttp/grcauditpacket/handler.go
+++ b/internal/sourcehttp/grcauditpacket/handler.go
@@ -42,6 +42,7 @@ func (h *HTTPHandler) Preview(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPHandler) Create(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	request := struct {
 		FindingID  string   `json:"finding_id"`
 		Supersedes []string `json:"supersedes,omitempty"`
@@ -59,19 +60,19 @@ func (h *HTTPHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	preview, err := h.preview(r, request.FindingID)
 	if err == nil {
-		preview, err = grcauditpacket.Freeze(r.Context(), store, preview, request.Supersedes, func(tenantID string) bool { return h.tenantAllowed(r.Context(), tenantID) })
+		preview, err = grcauditpacket.Freeze(ctx, store, preview, request.Supersedes, func(tenantID string) bool { return h.tenantAllowed(ctx, tenantID) })
 	}
 	var event *cerebrov1.EventEnvelope
 	if err == nil {
 		event, err = grcauditpacket.RecordedEvent(preview)
 	}
 	if err == nil {
-		if appendErr := h.appendLog.Append(r.Context(), event); appendErr != nil {
+		if appendErr := h.appendLog.Append(ctx, event); appendErr != nil {
 			err = fmt.Errorf("%w: append audit packet receipt", findings.ErrRuntimeUnavailable)
 		}
 	}
 	if err == nil {
-		if _, projectionErr := store.ApplyAuditProjectionEvent(r.Context(), event); projectionErr != nil {
+		if _, projectionErr := store.ApplyAuditProjectionEvent(ctx, event); projectionErr != nil {
 			err = fmt.Errorf("%w: project audit packet receipt", findings.ErrRuntimeUnavailable)
 		}
 	}
@@ -84,12 +85,12 @@ func (h *HTTPHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPHandler) Get(w http.ResponseWriter, r *http.Request) {
-	packet, err := h.load(r)
+	packet, err := h.load(r.Context(), r)
 	h.write(w, http.StatusOK, packet, err)
 }
 
 func (h *HTTPHandler) Export(w http.ResponseWriter, r *http.Request) {
-	packet, err := h.load(r)
+	packet, err := h.load(r.Context(), r)
 	if err != nil {
 		h.writeError(w, err)
 		return
@@ -106,10 +107,10 @@ func (h *HTTPHandler) Export(w http.ResponseWriter, r *http.Request) {
 	for _, gap := range packet.Gaps {
 		markdown += fmt.Sprintf("- Gap `%s`: %s\n", gap.Code, gap.Message)
 	}
-	_, _ = w.Write([]byte(markdown))
+	_, _ = w.Write([]byte(markdown)) // #nosec G705 -- the response is a nosniff text/markdown attachment, not browser-rendered HTML.
 }
 
-func (h *HTTPHandler) load(r *http.Request) (grcauditpacket.Packet, error) {
+func (h *HTTPHandler) load(ctx context.Context, r *http.Request) (grcauditpacket.Packet, error) {
 	packetID := strings.TrimSpace(r.PathValue("packetID"))
 	if packetID == "" {
 		return grcauditpacket.Packet{}, h.invalid(fmt.Errorf("packet id is required"))
@@ -118,7 +119,7 @@ func (h *HTTPHandler) load(r *http.Request) (grcauditpacket.Packet, error) {
 	if !ok {
 		return grcauditpacket.Packet{}, findings.ErrRuntimeUnavailable
 	}
-	return grcauditpacket.Load(r.Context(), store, packetID, func(tenantID string) bool { return h.tenantAllowed(r.Context(), tenantID) })
+	return grcauditpacket.Load(ctx, store, packetID, func(tenantID string) bool { return h.tenantAllowed(ctx, tenantID) })
 }
 
 func (h *HTTPHandler) write(w http.ResponseWriter, status int, packet grcauditpacket.Packet, err error) {

--- a/internal/statestore/postgres/audit_state.go
+++ b/internal/statestore/postgres/audit_state.go
@@ -13,6 +13,8 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/grcaudit"
+	"github.com/writer/cerebro/internal/grcauditpacket"
+	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -171,6 +173,8 @@ func applyAuditProjectionPayload(ctx context.Context, tx *sql.Tx, event auditPro
 		return applyAuditSample(ctx, tx, event)
 	case grcaudit.AuditAggregatePackage:
 		return applyAuditPackage(ctx, tx, event)
+	case grcaudit.AuditAggregatePacketReceipt:
+		return applyAuditPacketReceipt(ctx, tx, event)
 	case grcaudit.AuditAggregateCapability:
 		return applyAuditCapability(ctx, tx, event)
 	case grcaudit.AuditAggregateGrant:
@@ -178,6 +182,30 @@ func applyAuditProjectionPayload(ctx context.Context, tx *sql.Tx, event auditPro
 	default:
 		return grcaudit.ErrInvalidRequest
 	}
+}
+
+func applyAuditPacketReceipt(ctx context.Context, tx *sql.Tx, event auditProjectionEvent) error {
+	if event.aggregateVersion != 1 || event.operation != "recorded" {
+		return grcaudit.ErrVersionConflict
+	}
+	var packet grcauditpacket.Packet
+	if err := decodeAuditPayload(event, &packet); err != nil {
+		return err
+	}
+	if packet.ID != event.aggregateID || packet.TenantID != event.tenantID || packet.Digest != event.contentDigest {
+		return grcaudit.ErrInvalidRequest
+	}
+	if err := grcauditpacket.Verify(packet); err != nil {
+		return grcaudit.ErrInvalidRequest
+	}
+	payload, err := json.Marshal(packet)
+	if err != nil {
+		return fmt.Errorf("encode audit packet receipt: %w", err)
+	}
+	return insertGRCAuditPacket(ctx, tx, &ports.GRCAuditPacketReceipt{
+		ID: packet.ID, TenantID: packet.TenantID, FindingID: packet.FindingReference.ID,
+		Digest: packet.Digest, Payload: payload, CreatedAt: packet.GeneratedAt,
+	})
 }
 
 func applyAuditEngagement(ctx context.Context, tx *sql.Tx, event auditProjectionEvent) error {
@@ -712,6 +740,8 @@ func auditEventKindMatchesAggregate(kind string, aggregateType string) bool {
 	case grcaudit.AuditAggregateSample:
 		return kind == workflowevents.EventKindComplianceSampleRecorded
 	case grcaudit.AuditAggregatePackage:
+		return kind == workflowevents.EventKindComplianceAuditPackageRecorded
+	case grcaudit.AuditAggregatePacketReceipt:
 		return kind == workflowevents.EventKindComplianceAuditPackageRecorded
 	default:
 		return false

--- a/internal/statestore/postgres/audit_state_schema.go
+++ b/internal/statestore/postgres/audit_state_schema.go
@@ -3,6 +3,11 @@ package postgres
 import "context"
 
 var ensureAuditStateStatements = []string{
+	`CREATE TABLE IF NOT EXISTS grc_audit_packets (
+  id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, finding_id TEXT NOT NULL,
+  digest TEXT NOT NULL, packet_json JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL
+)`,
+	`CREATE INDEX IF NOT EXISTS grc_audit_packets_tenant_created_idx ON grc_audit_packets (tenant_id, created_at DESC)`,
 	`CREATE TABLE IF NOT EXISTS grc_audit_engagements (
   tenant_id TEXT NOT NULL, engagement_id TEXT NOT NULL, aggregate_version BIGINT NOT NULL,
   current_revision BIGINT NOT NULL, current_revision_id TEXT NOT NULL, status TEXT NOT NULL,

--- a/internal/statestore/postgres/audit_state_test.go
+++ b/internal/statestore/postgres/audit_state_test.go
@@ -15,6 +15,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/grcaudit"
+	"github.com/writer/cerebro/internal/grcauditpacket"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -28,12 +29,38 @@ func TestAuditStateSchemaCoversTenantScopedAuditObjects(t *testing.T) {
 		"grc_audit_evidence_request_revisions", "grc_audit_evidence_submissions",
 		"grc_audit_sample_revisions", "grc_audit_package_manifests",
 		"grc_audit_package_manifest_entries", "grc_audit_capability_state",
+		"grc_audit_packets", "grc_audit_packets_tenant_created_idx",
 		"grc_audit_access_grants", "grc_audit_event_application_receipts",
 		"PRIMARY KEY (tenant_id, event_id)",
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("audit state schema missing %q", fragment)
 		}
+	}
+}
+
+func TestAuditPacketReceiptUsesReplayableAuditProjectionEvent(t *testing.T) {
+	t.Parallel()
+	packet := grcauditpacket.Packet{
+		ID: "audit-packet-one", SchemaVersion: grcauditpacket.SchemaVersion, ResourceState: "immutable",
+		TenantID: "tenant-one", FindingReference: grcauditpacket.FindingReference{ID: "finding-one", Status: "open", StatusRevision: testAuditTime()},
+		Gaps: []grcauditpacket.Gap{}, Supersedes: []string{}, GeneratedAt: testAuditTime(),
+	}
+	digest, err := grcauditpacket.Digest(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet.Digest = digest
+	event, err := grcauditpacket.RecordedEvent(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeAuditProjectionEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.aggregateType != grcaudit.AuditAggregatePacketReceipt || decoded.aggregateID != packet.ID || decoded.contentDigest != packet.Digest {
+		t.Fatalf("decoded packet event = %#v", decoded)
 	}
 }
 
@@ -410,6 +437,7 @@ func cleanupAuditTenant(t *testing.T, ctx context.Context, store *Store, tenantI
 	t.Helper()
 	for _, statement := range []string{
 		`DELETE FROM grc_audit_event_application_receipts WHERE tenant_id = $1`,
+		`DELETE FROM grc_audit_packets WHERE tenant_id = $1`,
 		`DELETE FROM grc_audit_access_grants WHERE tenant_id = $1`,
 		`DELETE FROM grc_audit_capability_state WHERE tenant_id = $1`,
 		`DELETE FROM grc_audit_package_manifest_entries WHERE tenant_id = $1`,

--- a/internal/statestore/postgres/grc_audit_packets.go
+++ b/internal/statestore/postgres/grc_audit_packets.go
@@ -1,0 +1,78 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureGRCAuditPacketStatements = []string{`
+CREATE TABLE IF NOT EXISTS grc_audit_packets (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  finding_id TEXT NOT NULL,
+  digest TEXT NOT NULL,
+  packet_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL
+)`, `
+CREATE INDEX IF NOT EXISTS grc_audit_packets_tenant_created_idx
+ON grc_audit_packets (tenant_id, created_at DESC)`}
+
+// PutGRCAuditPacket inserts one immutable packet receipt. The insert has no
+// conflict-update path: an existing packet ID can never be rewritten.
+func (s *Store) PutGRCAuditPacket(ctx context.Context, receipt *ports.GRCAuditPacketReceipt) error {
+	if receipt == nil {
+		return errors.New("GRC audit packet receipt is required")
+	}
+	if strings.TrimSpace(receipt.ID) == "" || strings.TrimSpace(receipt.TenantID) == "" || strings.TrimSpace(receipt.FindingID) == "" || strings.TrimSpace(receipt.Digest) == "" || len(receipt.Payload) == 0 || receipt.CreatedAt.IsZero() {
+		return errors.New("GRC audit packet receipt is incomplete")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCAuditPacketTable(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO grc_audit_packets (id, tenant_id, finding_id, digest, packet_json, created_at)
+VALUES ($1, $2, $3, $4, $5::jsonb, $6)`, receipt.ID, receipt.TenantID, receipt.FindingID, receipt.Digest, string(receipt.Payload), receipt.CreatedAt.UTC()); err != nil {
+		return fmt.Errorf("insert GRC audit packet %q: %w", receipt.ID, err)
+	}
+	return nil
+}
+
+// GetGRCAuditPacket loads one immutable packet receipt without resolving any
+// current finding, evidence, runtime, or graph records.
+func (s *Store) GetGRCAuditPacket(ctx context.Context, packetID string) (*ports.GRCAuditPacketReceipt, error) {
+	id := strings.TrimSpace(packetID)
+	if id == "" {
+		return nil, errors.New("GRC audit packet id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureGRCAuditPacketTable(ctx); err != nil {
+		return nil, err
+	}
+	receipt := &ports.GRCAuditPacketReceipt{}
+	var payload string
+	if err := s.db.QueryRowContext(ctx, `
+SELECT id, tenant_id, finding_id, digest, packet_json::text, created_at
+FROM grc_audit_packets
+WHERE id = $1`, id).Scan(&receipt.ID, &receipt.TenantID, &receipt.FindingID, &receipt.Digest, &payload, &receipt.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrGRCAuditPacketNotFound, id)
+		}
+		return nil, fmt.Errorf("query GRC audit packet %q: %w", id, err)
+	}
+	receipt.Payload = []byte(payload)
+	return receipt, nil
+}
+
+func (s *Store) ensureGRCAuditPacketTable(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.grc.auditPackets, "grc_audit_packets", ensureGRCAuditPacketStatements)
+}

--- a/internal/statestore/postgres/grc_audit_packets.go
+++ b/internal/statestore/postgres/grc_audit_packets.go
@@ -22,22 +22,23 @@ CREATE TABLE IF NOT EXISTS grc_audit_packets (
 CREATE INDEX IF NOT EXISTS grc_audit_packets_tenant_created_idx
 ON grc_audit_packets (tenant_id, created_at DESC)`}
 
-// PutGRCAuditPacket inserts one immutable packet receipt. The insert has no
-// conflict-update path: an existing packet ID can never be rewritten.
-func (s *Store) PutGRCAuditPacket(ctx context.Context, receipt *ports.GRCAuditPacketReceipt) error {
+type grcAuditPacketExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+// insertGRCAuditPacket is called only by the audit event projector. It has no
+// conflict-update path: a replay can rebuild a receipt but never rewrite it.
+func insertGRCAuditPacket(ctx context.Context, execer grcAuditPacketExecer, receipt *ports.GRCAuditPacketReceipt) error {
 	if receipt == nil {
 		return errors.New("GRC audit packet receipt is required")
 	}
 	if strings.TrimSpace(receipt.ID) == "" || strings.TrimSpace(receipt.TenantID) == "" || strings.TrimSpace(receipt.FindingID) == "" || strings.TrimSpace(receipt.Digest) == "" || len(receipt.Payload) == 0 || receipt.CreatedAt.IsZero() {
 		return errors.New("GRC audit packet receipt is incomplete")
 	}
-	if s == nil || s.db == nil {
-		return errors.New("postgres is not configured")
+	if execer == nil {
+		return errors.New("GRC audit packet projection store is required")
 	}
-	if err := s.ensureGRCAuditPacketTable(ctx); err != nil {
-		return err
-	}
-	if _, err := s.db.ExecContext(ctx, `
+	if _, err := execer.ExecContext(ctx, `
 INSERT INTO grc_audit_packets (id, tenant_id, finding_id, digest, packet_json, created_at)
 VALUES ($1, $2, $3, $4, $5::jsonb, $6)`, receipt.ID, receipt.TenantID, receipt.FindingID, receipt.Digest, string(receipt.Payload), receipt.CreatedAt.UTC()); err != nil {
 		return fmt.Errorf("insert GRC audit packet %q: %w", receipt.ID, err)

--- a/internal/statestore/postgres/grc_audit_packets_test.go
+++ b/internal/statestore/postgres/grc_audit_packets_test.go
@@ -1,0 +1,25 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGRCAuditPacketSchemaIsTenantScopedAndImmutable(t *testing.T) {
+	schema := strings.Join(ensureGRCAuditPacketStatements, "\n")
+	for _, required := range []string{
+		"id TEXT PRIMARY KEY",
+		"tenant_id TEXT NOT NULL",
+		"finding_id TEXT NOT NULL",
+		"digest TEXT NOT NULL",
+		"packet_json JSONB NOT NULL",
+		"grc_audit_packets_tenant_created_idx",
+	} {
+		if !strings.Contains(schema, required) {
+			t.Fatalf("schema missing %q:\n%s", required, schema)
+		}
+	}
+	if strings.Contains(strings.ToUpper(schema), " UPDATE ") {
+		t.Fatalf("audit packet schema must not install an update path:\n%s", schema)
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -47,6 +47,7 @@ type grcTablesReady struct {
 	vendorDiscovery      bool
 	questionnaireRun     bool
 	auditState           bool
+	auditPackets         bool
 }
 
 type appendLogTablesReady struct {


### PR DESCRIPTION
## What changed

- add immutable audit packet receipts with independent packet IDs and canonical digests
- append receipt events before applying the Postgres projection so replay rebuilds the stored packet
- keep preview routes on current state while packet reads and exports return the frozen receipt
- capture finding, evidence, control, runtime, and graph fact references with explicit gaps when historical inputs are unavailable
- authorize packet access before decoding the stored payload

## Stack

Supersedes #1785. This branch is stacked on `agent/compliance-phase8-audit-store` at `7ded508f`.

## Validation

- `go test ./internal/grcauditpacket ./internal/sourcehttp/grcauditpacket ./internal/statestore/postgres ./internal/bootstrap -count=1`
- focused race tests for packet and projection paths
- `go vet ./internal/grcauditpacket ./internal/sourcehttp/grcauditpacket ./internal/statestore/postgres ./internal/bootstrap`
- `make check-structural check-structural-test check-arch openapi-check openapi-ts-check`
- `make contracts-check` completed all reported checks except `proto-generate-check`, which was blocked on two attempts by the Buf registry rate limit (`resource_exhausted: too many requests`)

Closes #1768