### PR TITLE
Add connector certification gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Plain Compose initializes the local Postgres volume with the compose-file passwo
 | MCP | Agent-readable source, policy, graph, and evidence context | `POST /api/v1/mcp`, `docs/domains/mcp-droid-setup.md` |
 | SDK helpers | Client helper packages for generated API surfaces | `sdk/python/README.md`, `sdk/typescript/README.md`, `sdk/go/cerebroapi` |
 
-Top-level commands are `serve`, `version`, `source`, `source-runtime`, `append-log`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
+Top-level commands are `serve`, `version`, `source`, `source-runtime`, `connector-catalog`, `append-log`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
 
 ## Choose A Path
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -552,6 +552,17 @@ paths:
           in: query
           schema:
             type: string
+        - name: min_certification_tier
+          in: query
+          description: Minimum certification tier used to compute each connector's availability state. Entries below the tier remain in the response.
+          schema:
+            type: string
+            enum: [cataloged, spec_verified, contract_tested, production_observed, outcome_validated]
+        - name: include_preview
+          in: query
+          description: Mark below-minimum connectors as available for evaluation. This does not promote their certification tier.
+          schema:
+            type: boolean
       responses:
         '200':
           description: Source events and cursor.
@@ -647,9 +658,9 @@ paths:
             type: string
       responses:
         '200':
-          description: Connector catalog with executable built-in sources plus catalog-only connector definitions. Default and full responses include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping. Summary responses keep catalog browsing fields and omit setup payloads; use /connectors/{sourceID} for one connector's full setup and operations detail. Paginated responses include page.total, page.returned, page.limit, page.has_more, and page.next_cursor when another page is available.
+          description: Connector catalog with executable built-in sources plus catalog-only connector definitions. Every entry includes its closed certification tier, proof ownership and expiry, live runtime observation when present, and an availability state. Availability gates annotate rather than hide catalog-only or configured connectors. Default and full responses include runtime counts, credential capability state, catalog status (catalog_ready, generateable, needs_auth_extension, needs_bespoke_runtime), classifier output, auth model, verification endpoint, resource families, backend-advertised connection methods when executable, credential-store choices, deployment/readiness guidance, product groups, region guidance, and source resource scope options including support notes for resource scoping. Summary responses keep catalog browsing fields and omit setup payloads; use /connectors/{sourceID} for one connector's full setup and operations detail. Paginated responses include page.total, page.returned, page.limit, page.has_more, and page.next_cursor when another page is available.
         '400':
-          description: Connector catalog view, limit, or cursor was invalid.
+          description: Connector catalog view, limit, cursor, certification tier, or preview value was invalid.
   /connectors/{sourceID}:
     get:
       summary: Get connector operations summary

--- a/cmd/cerebro/connector_catalog.go
+++ b/cmd/cerebro/connector_catalog.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectorcatalog"
+	"github.com/writer/cerebro/internal/sourcecertification"
+	"github.com/writer/cerebro/internal/sourceregistry"
+)
+
+type connectorCatalogCLIEntry struct {
+	SourceID      string                           `json:"source_id"`
+	DisplayName   string                           `json:"display_name"`
+	CatalogStatus string                           `json:"catalog_status,omitempty"`
+	Certification sourcecertification.Result       `json:"certification"`
+	Availability  sourcecertification.Availability `json:"availability"`
+}
+
+type connectorCatalogCLIResponse struct {
+	Connectors  []connectorCatalogCLIEntry `json:"connectors"`
+	GeneratedAt string                     `json:"generated_at"`
+}
+
+func runConnectorCatalog(args []string, output io.Writer) error {
+	if len(args) == 0 || args[0] != "list" {
+		return usageError("usage: cerebro connector-catalog list [--min-certification-tier tier] [--include-preview]")
+	}
+	flags := flag.NewFlagSet("connector-catalog list", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	minimum := flags.String("min-certification-tier", "cataloged", "minimum certification tier")
+	includePreview := flags.Bool("include-preview", false, "mark below-minimum connectors for evaluation")
+	if err := flags.Parse(args[1:]); err != nil {
+		return usageError(err.Error())
+	}
+	tier, err := sourcecertification.ParseTier(*minimum)
+	if err != nil {
+		return usageError(err.Error())
+	}
+	response, err := loadConnectorCatalogCLIResponse(time.Now().UTC(), sourcecertification.AvailabilityPolicy{MinimumTier: tier, IncludePreview: *includePreview})
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(response)
+}
+
+func loadConnectorCatalogCLIResponse(now time.Time, policy sourcecertification.AvailabilityPolicy) (connectorCatalogCLIResponse, error) {
+	registry, err := sourceregistry.Builtin()
+	if err != nil {
+		return connectorCatalogCLIResponse{}, fmt.Errorf("load source registry: %w", err)
+	}
+	analysis, err := connectorcatalog.BuiltinRuntime()
+	if err != nil {
+		return connectorCatalogCLIResponse{}, fmt.Errorf("load connector catalog: %w", err)
+	}
+	return buildConnectorCatalogCLIResponse(now, policy, registry.List(), analysis), nil
+}
+
+func buildConnectorCatalogCLIResponse(now time.Time, policy sourcecertification.AvailabilityPolicy, specs []*cerebrov1.SourceSpec, analysis connectorcatalog.Analysis) connectorCatalogCLIResponse {
+	statusBySource := map[string]string{}
+	nameBySource := map[string]string{}
+	for _, entry := range analysis.Entries {
+		statusBySource[entry.Definition.SourceID] = entry.Status
+		nameBySource[entry.Definition.SourceID] = entry.Definition.DisplayName
+	}
+	seen := map[string]bool{}
+	entries := make([]connectorCatalogCLIEntry, 0, len(specs)+len(analysis.Entries))
+	appendEntry := func(sourceID, displayName string) {
+		if seen[sourceID] {
+			return
+		}
+		seen[sourceID] = true
+		certification := sourcecertification.CatalogResult(sourceID, now, sourcecertification.RuntimeObservation{})
+		entries = append(entries, connectorCatalogCLIEntry{
+			SourceID: sourceID, DisplayName: displayName, CatalogStatus: statusBySource[sourceID], Certification: certification,
+			Availability: sourcecertification.ApplyAvailability(certification, false, policy),
+		})
+	}
+	for _, spec := range specs {
+		appendEntry(spec.GetId(), spec.GetName())
+	}
+	for sourceID, displayName := range nameBySource {
+		appendEntry(sourceID, displayName)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].SourceID < entries[j].SourceID })
+	return connectorCatalogCLIResponse{Connectors: entries, GeneratedAt: now.Format(time.RFC3339)}
+}

--- a/cmd/cerebro/connector_catalog_test.go
+++ b/cmd/cerebro/connector_catalog_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectorcatalog"
+	"github.com/writer/cerebro/internal/connectordefinitions"
+	"github.com/writer/cerebro/internal/sourcecertification"
+)
+
+func TestBuildConnectorCatalogCLIResponsePreservesCatalogOnlyDiscovery(t *testing.T) {
+	response := buildConnectorCatalogCLIResponse(
+		time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC),
+		sourcecertification.AvailabilityPolicy{MinimumTier: sourcecertification.TierContractTested},
+		[]*cerebrov1.SourceSpec{{Id: "compiled", Name: "Compiled"}},
+		connectorcatalog.Analysis{Entries: []connectorcatalog.Entry{{Definition: connectordefinitions.Definition{SourceID: "catalog-only", DisplayName: "Catalog only"}, Status: connectorcatalog.StatusGenerateable}}},
+	)
+	seenBelowMinimum := false
+	for _, entry := range response.Connectors {
+		if !entry.Availability.Discoverable {
+			t.Fatalf("connector %q was hidden by availability gate", entry.SourceID)
+		}
+		if entry.Availability.State == sourcecertification.AvailabilityBelowMinimum {
+			seenBelowMinimum = true
+		}
+	}
+	if len(response.Connectors) != 2 {
+		t.Fatalf("connector count = %d, want compiled and catalog-only entries", len(response.Connectors))
+	}
+	if !seenBelowMinimum {
+		t.Fatal("expected at least one discoverable below-minimum connector")
+	}
+}

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -76,6 +76,8 @@ func run(args []string) error {
 		return runSource(args[1:])
 	case "source-runtime":
 		return runSourceRuntime(args[1:])
+	case "connector-catalog":
+		return runConnectorCatalog(args[1:], os.Stdout)
 	case "append-log":
 		return runAppendLog(args[1:])
 	case "vulndb":
@@ -88,7 +90,7 @@ func run(args []string) error {
 		fmt.Printf("%s %s\n", buildinfo.ServiceName, buildinfo.Version)
 		return nil
 	}
-	return usageError(fmt.Sprintf("usage: %s [serve|version|deploy|graph|orchestrator|finding-rule|source|source-runtime|append-log|vulndb|closeout]", os.Args[0]))
+	return usageError(fmt.Sprintf("usage: %s [serve|version|deploy|graph|orchestrator|finding-rule|source|source-runtime|connector-catalog|append-log|vulndb|closeout]", os.Args[0]))
 }
 
 func serve() error {

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -86,6 +86,11 @@ Stateless source MCP tools stay limited to request/response mapping over
 reserved runtime key rejection, while bootstrap invokes that guard at the MCP
 transport boundary.
 
+Connector certification keeps tier evaluation, proof expiry and invalidation,
+source-runtime observations, and availability decisions in
+`internal/sourcecertification`. Bootstrap passes runtime records and returns the
+resulting state through HTTP and MCP connector discovery.
+
 The current budget includes a narrow transport-boundary exception for graph
 reasoning: HTTP and MCP handlers clear the server write deadline before entering
 the long-running reasoning pipeline. That deadline is owned by `net/http` and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,7 @@ make build
 ./bin/cerebro version
 ```
 
-Top-level commands are `serve`, `version`, `source`, `source-runtime`, `append-log`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
+Top-level commands are `serve`, `version`, `source`, `source-runtime`, `connector-catalog`, `append-log`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
 
 Agent onboarding is a Makefile workflow around the CLI and HTTP API:
 
@@ -56,6 +56,18 @@ Source runtime persistence requires Postgres. Sync also requires NATS JetStream.
 ```
 
 See [Source runtime guide](../domains/source-runtime-guide.md) for store setup, secrets, sync behavior, and recovery.
+
+## Connector Certification
+
+List compiled and catalog-only connectors with their certification proof and availability state:
+
+```bash
+./bin/cerebro connector-catalog list
+./bin/cerebro connector-catalog list --min-certification-tier contract_tested
+./bin/cerebro connector-catalog list --min-certification-tier production_observed --include-preview
+```
+
+The minimum tier changes each connector's availability state. It does not hide catalog entries or promote static proof into a live production or outcome state.
 
 ## Append Log Recovery
 

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -39,6 +39,7 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_POSTGRES_DSN` | unset | Postgres connection string. Setting this infers `postgres`. |
 | `CEREBRO_CONNECTOR_CREDENTIAL_KEY` | unset | High-entropy key used to seal Cerebro-managed connector credentials before storing them in Postgres. Supports `_FILE` via `CEREBRO_CONNECTOR_CREDENTIAL_KEY_FILE`. |
 | `CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY` | unset | RSA private key used to decrypt browser-submitted connector credential envelopes. All replicas must share the same key. Supports `_FILE` via `CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE`. |
+| `CEREBRO_SOURCE_MIN_CERTIFICATION_TIER` | `cataloged` | Minimum connector certification tier for availability decisions. Supported values: `cataloged`, `spec_verified`, `contract_tested`, `production_observed`, and `outcome_validated`. Catalog-only and configured connectors remain discoverable with an explicit below-minimum state. |
 | `CEREBRO_POSTGRES_MAX_OPEN_CONNS` | Go default | Optional `database/sql` maximum open connections. |
 | `CEREBRO_POSTGRES_MAX_IDLE_CONNS` | Go default | Optional `database/sql` maximum idle connections. |
 | `CEREBRO_POSTGRES_CONN_MAX_LIFETIME` | Go default | Optional maximum lifetime for pooled Postgres connections. |

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -569,7 +569,7 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 	}
 	view, err := connectorpresentation.ParseLibraryView(r.URL.Query().Get("view"))
 	if err != nil {
-		writeConnectorError(w, fmt.Errorf("%w: %v", connectorcredentials.ErrInvalidRequest, err))
+		writeConnectorError(w, fmt.Errorf("%w: %w", connectorcredentials.ErrInvalidRequest, err))
 		return
 	}
 	pagination, err := connectorLibraryPaginationFromRequest(r)
@@ -579,7 +579,7 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 	}
 	policy, err := sourcecertification.ParseAvailabilityPolicy(a.cfg.ConnectorAccess.MinCertificationTier, r.URL.Query().Get("min_certification_tier"), r.URL.Query().Get("include_preview"))
 	if err != nil {
-		writeConnectorError(w, fmt.Errorf("%w: %v", connectorcredentials.ErrInvalidRequest, err))
+		writeConnectorError(w, fmt.Errorf("%w: %w", connectorcredentials.ErrInvalidRequest, err))
 		return
 	}
 	response := a.connectorLibraryWithPolicy(r, tenantID, policy)

--- a/internal/bootstrap/connectors.go
+++ b/internal/bootstrap/connectors.go
@@ -24,12 +24,14 @@ import (
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/connectordiagnostics"
 	"github.com/writer/cerebro/internal/connectorpreflight"
+	"github.com/writer/cerebro/internal/connectorpresentation"
 	"github.com/writer/cerebro/internal/connectorpreview"
 	"github.com/writer/cerebro/internal/connectorsecretstores"
 	"github.com/writer/cerebro/internal/connectorvalidation"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcecertification"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceregistry"
@@ -94,24 +96,26 @@ type connectorCatalogIdentity struct {
 	Description string `json:"description"`
 }
 type connectorCatalogDefinitionState struct {
-	EmittedKinds          []string                      `json:"emitted_kinds"`
-	CatalogStatus         string                        `json:"catalog_status,omitempty"`
-	ClassifierOutput      string                        `json:"classifier_output,omitempty"`
-	AuthModel             string                        `json:"auth_model,omitempty"`
-	RuntimeExecutable     bool                          `json:"runtime_executable,omitempty"`
-	MissingFeatures       []string                      `json:"missing_features,omitempty"`
-	CatalogCategories     []string                      `json:"catalog_categories,omitempty"`
-	VerificationEndpoint  string                        `json:"verification_endpoint,omitempty"`
-	ResourceFamilies      []connectorResourceFamilyView `json:"resource_families,omitempty"`
-	CatalogSchemaVersion  string                        `json:"catalog_schema_version,omitempty"`
-	CatalogCurrentVersion int                           `json:"catalog_current_version,omitempty"`
-	CatalogSourcePath     string                        `json:"catalog_source_path,omitempty"`
-	DefinitionOrigin      string                        `json:"definition_origin,omitempty"`
-	ReadinessStage        string                        `json:"readiness_stage,omitempty"`
-	ValidationGrade       string                        `json:"validation_grade,omitempty"`
-	Cataloged             bool                          `json:"cataloged"`
-	Callable              bool                          `json:"callable"`
-	IntegrationDepth      connectorIntegrationDepthView `json:"integration_depth,omitempty"`
+	EmittedKinds          []string                         `json:"emitted_kinds"`
+	CatalogStatus         string                           `json:"catalog_status,omitempty"`
+	ClassifierOutput      string                           `json:"classifier_output,omitempty"`
+	AuthModel             string                           `json:"auth_model,omitempty"`
+	RuntimeExecutable     bool                             `json:"runtime_executable,omitempty"`
+	MissingFeatures       []string                         `json:"missing_features,omitempty"`
+	CatalogCategories     []string                         `json:"catalog_categories,omitempty"`
+	VerificationEndpoint  string                           `json:"verification_endpoint,omitempty"`
+	ResourceFamilies      []connectorResourceFamilyView    `json:"resource_families,omitempty"`
+	CatalogSchemaVersion  string                           `json:"catalog_schema_version,omitempty"`
+	CatalogCurrentVersion int                              `json:"catalog_current_version,omitempty"`
+	CatalogSourcePath     string                           `json:"catalog_source_path,omitempty"`
+	DefinitionOrigin      string                           `json:"definition_origin,omitempty"`
+	ReadinessStage        string                           `json:"readiness_stage,omitempty"`
+	ValidationGrade       string                           `json:"validation_grade,omitempty"`
+	Cataloged             bool                             `json:"cataloged"`
+	Callable              bool                             `json:"callable"`
+	IntegrationDepth      connectorIntegrationDepthView    `json:"integration_depth,omitempty"`
+	Certification         sourcecertification.Result       `json:"certification"`
+	Availability          sourcecertification.Availability `json:"availability"`
 	connectorcatalog.ProviderAPIView
 }
 type connectorCatalogRuntimeState struct {
@@ -563,9 +567,9 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 		writeConnectorError(w, err)
 		return
 	}
-	view, err := connectorLibraryView(r)
+	view, err := connectorpresentation.ParseLibraryView(r.URL.Query().Get("view"))
 	if err != nil {
-		writeConnectorError(w, err)
+		writeConnectorError(w, fmt.Errorf("%w: %v", connectorcredentials.ErrInvalidRequest, err))
 		return
 	}
 	pagination, err := connectorLibraryPaginationFromRequest(r)
@@ -573,29 +577,18 @@ func (a *App) handleListConnectors(w http.ResponseWriter, r *http.Request) {
 		writeConnectorError(w, err)
 		return
 	}
-	response := a.connectorLibrary(r, tenantID)
+	policy, err := sourcecertification.ParseAvailabilityPolicy(a.cfg.ConnectorAccess.MinCertificationTier, r.URL.Query().Get("min_certification_tier"), r.URL.Query().Get("include_preview"))
+	if err != nil {
+		writeConnectorError(w, fmt.Errorf("%w: %v", connectorcredentials.ErrInvalidRequest, err))
+		return
+	}
+	response := a.connectorLibraryWithPolicy(r, tenantID, policy)
 	response.Connectors, response.Page = pageConnectorLibraryEntries(response.Connectors, pagination)
 	if view == connectorLibraryViewSummary {
 		writeJSON(w, http.StatusOK, summarizeConnectorLibrary(response))
 		return
 	}
 	writeJSON(w, http.StatusOK, response)
-}
-
-func connectorLibraryView(r *http.Request) (string, error) {
-	if r == nil || r.URL == nil {
-		return connectorLibraryViewFull, nil
-	}
-	view := strings.TrimSpace(r.URL.Query().Get("view"))
-	if view == "" {
-		return connectorLibraryViewFull, nil
-	}
-	switch view {
-	case connectorLibraryViewFull, connectorLibraryViewSummary:
-		return view, nil
-	default:
-		return "", fmt.Errorf("%w: connector library view must be full or summary", connectorcredentials.ErrInvalidRequest)
-	}
 }
 
 func summarizeConnectorLibrary(response connectorLibraryResponse) connectorLibrarySummaryResponse {
@@ -715,8 +708,15 @@ func summarizeConnectorCatalogEntry(entry connectorCatalogEntry) connectorCatalo
 }
 
 func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibraryResponse {
+	policy, _ := sourcecertification.ParseAvailabilityPolicy(a.cfg.ConnectorAccess.MinCertificationTier, "", "")
+	return a.connectorLibraryWithPolicy(r, tenantID, policy)
+}
+
+func (a *App) connectorLibraryWithPolicy(r *http.Request, tenantID string, policy sourcecertification.AvailabilityPolicy) connectorLibraryResponse {
 	runtimes, runtimeStoreStatus := a.connectorRuntimeCatalog(r, tenantID)
-	counts := connectorRuntimeCounts(runtimes)
+	counts := sourcecertification.RuntimeCounts(runtimes)
+	now := time.Now().UTC()
+	observations := sourcecertification.RuntimeObservations(runtimes, now)
 	sources := a.sourceService().List().GetSources()
 	transport := connectorTransportView{
 		Available: a.connectorTransitKey != nil,
@@ -758,19 +758,20 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 		if !a.applyConnectorAccess(&entry, tenantID) {
 			continue
 		}
-		if count := counts[source.GetId()]; count.total > 0 {
-			entry.ConfiguredRuntimes = count.total
-			entry.HealthyRuntimes = count.healthy
-			entry.NeedsAttentionRuntimes = count.total - count.healthy
+		if count := counts[source.GetId()]; count.Total > 0 {
+			entry.ConfiguredRuntimes = count.Total
+			entry.HealthyRuntimes = count.Healthy
+			entry.NeedsAttentionRuntimes = count.Total - count.Healthy
 			switch {
-			case count.healthy == count.total:
+			case count.Healthy == count.Total:
 				entry.Status = "connected"
-			case count.healthy > 0:
+			case count.Healthy > 0:
 				entry.Status = "degraded"
 			default:
 				entry.Status = "needs_attention"
 			}
 		}
+		applyConnectorCertification(&entry, observations[source.GetId()], now, policy)
 		entries = append(entries, entry)
 		seen[source.GetId()] = struct{}{}
 	}
@@ -816,19 +817,20 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 		if !a.applyConnectorAccess(&entry, tenantID) {
 			continue
 		}
-		if count := counts[sourceID]; count.total > 0 {
-			entry.ConfiguredRuntimes = count.total
-			entry.HealthyRuntimes = count.healthy
-			entry.NeedsAttentionRuntimes = count.total - count.healthy
+		if count := counts[sourceID]; count.Total > 0 {
+			entry.ConfiguredRuntimes = count.Total
+			entry.HealthyRuntimes = count.Healthy
+			entry.NeedsAttentionRuntimes = count.Total - count.Healthy
 			switch {
-			case count.healthy == count.total:
+			case count.Healthy == count.Total:
 				entry.Status = "connected"
-			case count.healthy > 0:
+			case count.Healthy > 0:
 				entry.Status = "degraded"
 			default:
 				entry.Status = "needs_attention"
 			}
 		}
+		applyConnectorCertification(&entry, observations[sourceID], now, policy)
 		entries = append(entries, entry)
 		seen[sourceID] = struct{}{}
 	}
@@ -859,6 +861,12 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 		if !a.applyConnectorAccess(&entry, tenantID) {
 			continue
 		}
+		if count := counts[sourceID]; count.Total > 0 {
+			entry.ConfiguredRuntimes = count.Total
+			entry.HealthyRuntimes = count.Healthy
+			entry.NeedsAttentionRuntimes = count.Total - count.Healthy
+		}
+		applyConnectorCertification(&entry, observations[sourceID], now, policy)
 		entries = append(entries, entry)
 	}
 	sort.SliceStable(entries, func(i, j int) bool {
@@ -882,6 +890,14 @@ func (a *App) connectorLibrary(r *http.Request, tenantID string) connectorLibrar
 		CredentialVault:     vaultStatus,
 		CredentialStores:    stores,
 	}
+}
+
+func applyConnectorCertification(entry *connectorCatalogEntry, observation sourcecertification.RuntimeObservation, now time.Time, policy sourcecertification.AvailabilityPolicy) {
+	if entry == nil {
+		return
+	}
+	entry.Certification = sourcecertification.CatalogResult(entry.SourceID, now, observation)
+	entry.Availability = sourcecertification.ApplyAvailability(entry.Certification, observation.Configured, policy)
 }
 
 func (a *App) handleGetConnector(w http.ResponseWriter, r *http.Request) {
@@ -1830,11 +1846,6 @@ func (a *App) connectorRuntimeCatalog(r *http.Request, tenantID string) ([]*cere
 	return runtimes, "ready"
 }
 
-type connectorRuntimeCount struct {
-	total   int
-	healthy int
-}
-
 type connectorSchema struct {
 	ConfigKeys          map[string]struct{}
 	CredentialKeys      map[string]struct{}
@@ -2019,23 +2030,6 @@ func addConnectorSchemaConfigKey(keys map[string]struct{}, key string) {
 	keys[key] = struct{}{}
 }
 
-func connectorRuntimeCounts(runtimes []*cerebrov1.SourceRuntime) map[string]connectorRuntimeCount {
-	counts := make(map[string]connectorRuntimeCount)
-	for _, runtime := range runtimes {
-		sourceID := strings.TrimSpace(runtime.GetSourceId())
-		if sourceID == "" {
-			continue
-		}
-		count := counts[sourceID]
-		count.total++
-		if connectorRuntimeHealthy(runtime) {
-			count.healthy++
-		}
-		counts[sourceID] = count
-	}
-	return counts
-}
-
 func connectorEntryBySourceID(entries []connectorCatalogEntry, sourceID string) (connectorCatalogEntry, bool) {
 	normalized := strings.TrimSpace(sourceID)
 	for _, entry := range entries {
@@ -2097,12 +2091,12 @@ func (a *App) applyConnectorAccess(entry *connectorCatalogEntry, tenantID string
 		return false
 	}
 	sourceID := strings.TrimSpace(entry.SourceID)
-	if sourceID == "" || connectorSourceListed(a.cfg.ConnectorAccess.HiddenSources, sourceID) {
+	if sourceID == "" || connectorpresentation.SourceListed(a.cfg.ConnectorAccess.HiddenSources, sourceID) {
 		return false
 	}
 	hasSetup := len(entry.ConnectionMethods) > 0
 	switch {
-	case connectorSourceListed(a.cfg.ConnectorAccess.RestrictedSources, sourceID):
+	case connectorpresentation.SourceListed(a.cfg.ConnectorAccess.RestrictedSources, sourceID):
 		entry.AccessStatus = connectorAccessRestricted
 		entry.AccessReason = firstNonEmpty(a.cfg.ConnectorAccess.RestrictionReason, "Connector setup is restricted by this deployment.")
 		entry.SetupAllowed = false
@@ -2153,23 +2147,13 @@ func connectorLibraryCountsFor(entries []connectorCatalogEntry) connectorLibrary
 }
 
 func (a *App) requireConnectorSetupAccess(sourceID string) error {
-	if connectorSourceListed(a.cfg.ConnectorAccess.HiddenSources, sourceID) {
+	if connectorpresentation.SourceListed(a.cfg.ConnectorAccess.HiddenSources, sourceID) {
 		return fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, strings.TrimSpace(sourceID))
 	}
-	if connectorSourceListed(a.cfg.ConnectorAccess.RestrictedSources, sourceID) {
+	if connectorpresentation.SourceListed(a.cfg.ConnectorAccess.RestrictedSources, sourceID) {
 		return fmt.Errorf("%w: %s", errConnectorAccessRestricted, strings.TrimSpace(sourceID))
 	}
 	return nil
-}
-
-func connectorSourceListed(values []string, sourceID string) bool {
-	normalized := strings.TrimSpace(sourceID)
-	for _, value := range values {
-		if strings.EqualFold(strings.TrimSpace(value), normalized) {
-			return true
-		}
-	}
-	return false
 }
 
 func connectorCatalogOnlyReason(status string) string {
@@ -2854,7 +2838,7 @@ func connectorActivityFromHealth(records []sourceRuntimeHealthRecord) []connecto
 	for _, record := range records {
 		syncStatus := connectorSyncActivityStatus(record)
 		activity = append(activity, connectorActivityView{
-			ID:              connectorActivityID(record.RuntimeID, "sync", connectorRecordLastActivity(record)),
+			ID:              connectorpresentation.ActivityID(record.RuntimeID, "sync", connectorRecordLastActivity(record)),
 			RuntimeID:       record.RuntimeID,
 			SourceID:        record.SourceID,
 			TenantID:        record.TenantID,
@@ -2871,7 +2855,7 @@ func connectorActivityFromHealth(records []sourceRuntimeHealthRecord) []connecto
 		if record.LatestGraphRun != nil {
 			graphStatus := connectorGraphActivityStatus(record.LatestGraphRun.Status)
 			activity = append(activity, connectorActivityView{
-				ID:                connectorActivityID(record.RuntimeID, "graph", connectorGraphActivityTime(record.LatestGraphRun)),
+				ID:                connectorpresentation.ActivityID(record.RuntimeID, "graph", connectorGraphActivityTime(record.LatestGraphRun)),
 				RuntimeID:         record.RuntimeID,
 				SourceID:          record.SourceID,
 				TenantID:          record.TenantID,
@@ -3074,22 +3058,6 @@ func connectorGraphFailureClass(status string) string {
 		return "graph_ingest_failed"
 	}
 	return ""
-}
-
-func connectorActivityID(runtimeID string, kind string, occurredAt string) string {
-	parts := []string{strings.TrimSpace(runtimeID), strings.TrimSpace(kind), strings.TrimSpace(occurredAt)}
-	return strings.Trim(strings.Join(parts, ":"), ":")
-}
-
-func connectorRuntimeHealthy(runtime *cerebrov1.SourceRuntime) bool {
-	if runtime == nil {
-		return false
-	}
-	status := strings.TrimSpace(runtime.GetConfig()["__cerebro_runtime_status"])
-	if status != "" {
-		return status == "completed" || status == "healthy"
-	}
-	return runtime.GetLastSyncedAt() != nil
 }
 
 func (a *App) checkConnectorRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime, plaintextFields map[string]string) error {

--- a/internal/bootstrap/connectors_test.go
+++ b/internal/bootstrap/connectors_test.go
@@ -2315,11 +2315,12 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 			TransitPrivateKey: testConnectorTransitPrivateKeyPEM(t),
 		},
 		ConnectorAccess: config.ConnectorAccessConfig{
-			HiddenSources:       []string{"auth0", "duo"},
-			RestrictedSources:   []string{"bootstrap_token", "duo", "jumpcloud"},
-			RestrictionReason:   "limited preview",
-			RequestAccessURL:    "https://access.example.com/request?source={source_id}&tenant={tenant_id}",
-			RequestAccessAction: "Request in Access Hub",
+			HiddenSources:        []string{"auth0", "duo"},
+			RestrictedSources:    []string{"bootstrap_token", "duo", "jumpcloud"},
+			MinCertificationTier: "contract_tested",
+			RestrictionReason:    "limited preview",
+			RequestAccessURL:     "https://access.example.com/request?source={source_id}&tenant={tenant_id}",
+			RequestAccessAction:  "Request in Access Hub",
 		},
 	}, Dependencies{StateStore: &connectorTestStore{stubRuntimeStore: &stubRuntimeStore{}}}, registry)
 	server := httptest.NewServer(app.Handler())
@@ -2348,7 +2349,14 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 			RequestAccessURL    string `json:"request_access_url"`
 			RequestAccessAction string `json:"request_access_action"`
 			ReadinessStage      string `json:"readiness_stage"`
-			ConnectionMethods   []struct {
+			Certification       struct {
+				EffectiveTier string `json:"effective_tier"`
+			} `json:"certification"`
+			Availability struct {
+				State        string `json:"state"`
+				Discoverable bool   `json:"discoverable"`
+			} `json:"availability"`
+			ConnectionMethods []struct {
 				ID string `json:"id"`
 			} `json:"connection_methods"`
 		} `json:"connectors"`
@@ -2366,7 +2374,14 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 		RequestAccessURL    string `json:"request_access_url"`
 		RequestAccessAction string `json:"request_access_action"`
 		ReadinessStage      string `json:"readiness_stage"`
-		ConnectionMethods   []struct {
+		Certification       struct {
+			EffectiveTier string `json:"effective_tier"`
+		} `json:"certification"`
+		Availability struct {
+			State        string `json:"state"`
+			Discoverable bool   `json:"discoverable"`
+		} `json:"availability"`
+		ConnectionMethods []struct {
 			ID string `json:"id"`
 		} `json:"connection_methods"`
 	}{}
@@ -2380,6 +2395,9 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 		t.Fatal("duo was returned despite hidden source precedence over restricted source config")
 	}
 	bootstrapToken := bySourceID["bootstrap_token"]
+	if bootstrapToken.Certification.EffectiveTier != "cataloged" || bootstrapToken.Availability.State != "below_minimum" || !bootstrapToken.Availability.Discoverable {
+		t.Fatalf("bootstrap_token certification availability = %#v", bootstrapToken)
+	}
 	if bootstrapToken.AccessStatus != connectorAccessRestricted || bootstrapToken.AccessReason != "limited preview" || bootstrapToken.SetupAllowed || !bootstrapToken.Requestable || len(bootstrapToken.ConnectionMethods) != 0 {
 		t.Fatalf("bootstrap_token access = %#v, want restricted without setup methods", bootstrapToken)
 	}
@@ -2389,6 +2407,16 @@ func TestConnectorAccessConfigHidesAndRestrictsSources(t *testing.T) {
 	jumpcloud := bySourceID["jumpcloud"]
 	if jumpcloud.AccessStatus != connectorAccessRestricted || jumpcloud.AccessReason != "limited preview" || jumpcloud.SetupAllowed || !jumpcloud.Requestable {
 		t.Fatalf("jumpcloud access = %#v, want restricted catalog metadata", jumpcloud)
+	}
+	invalidTierResp, err := server.Client().Get(server.URL + "/connectors?min_certification_tier=trusted")
+	if err != nil {
+		t.Fatalf("GET /connectors invalid tier error = %v", err)
+	}
+	if closeErr := invalidTierResp.Body.Close(); closeErr != nil {
+		t.Fatalf("close invalid tier response: %v", closeErr)
+	}
+	if invalidTierResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid certification tier status = %d, want 400", invalidTierResp.StatusCode)
 	}
 
 	preflightResp, err := server.Client().Post(server.URL+"/connectors/bootstrap_token/preflight", "application/json", strings.NewReader(`{}`))

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -648,7 +648,7 @@ func (app *App) mcpListConnectors(r *http.Request, args map[string]any) (any, er
 	}
 	policy, err := sourcecertification.ParseAvailabilityPolicy(app.cfg.ConnectorAccess.MinCertificationTier, mcpStringArg(args, "min_certification_tier"), preview)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", errInvalidHTTPRequest, err)
+		return nil, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
 	}
 	return app.connectorLibraryWithPolicy(r, tenantID, policy), nil
 }

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -28,6 +28,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/riskplan"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcecertification"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
@@ -558,6 +559,8 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 		})
 	case "cerebro.sources.list":
 		return app.mcpListSources()
+	case "cerebro.connectors.list":
+		return app.mcpListConnectors(r, args)
 	case "cerebro.sources.check":
 		return app.mcpCheckSource(r, args)
 	case "cerebro.sources.discover":
@@ -632,6 +635,22 @@ func (app *App) mcpListSources() (any, error) {
 		return nil, err
 	}
 	return mcpAddResponseMetadata(value, mcpLiveSourceMetadata(len(response.GetSources()))), nil
+}
+
+func (app *App) mcpListConnectors(r *http.Request, args map[string]any) (any, error) {
+	tenantID, err := effectiveTenantFilter(r.Context(), mcpTenantArg(r, args))
+	if err != nil {
+		return nil, err
+	}
+	preview := ""
+	if _, ok := args["include_preview"]; ok {
+		preview = strconv.FormatBool(mcpBoolArg(args, "include_preview"))
+	}
+	policy, err := sourcecertification.ParseAvailabilityPolicy(app.cfg.ConnectorAccess.MinCertificationTier, mcpStringArg(args, "min_certification_tier"), preview)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errInvalidHTTPRequest, err)
+	}
+	return app.connectorLibraryWithPolicy(r, tenantID, policy), nil
 }
 
 func (app *App) mcpCheckSource(r *http.Request, args map[string]any) (any, error) {
@@ -2170,6 +2189,18 @@ func mcpTools() []mcpTool {
 			Annotations:  mcpReadOnlyAnnotations("List Sources"),
 		},
 		{
+			Name:        "cerebro.connectors.list",
+			Title:       "List Connector Certification",
+			Description: "List compiled and catalog-only connectors with certification proof, current runtime observation, and availability state.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"tenant_id":              map[string]any{"type": "string"},
+				"min_certification_tier": map[string]any{"type": "string", "enum": []string{"cataloged", "spec_verified", "contract_tested", "production_observed", "outcome_validated"}},
+				"include_preview":        map[string]any{"type": "boolean", "description": "Mark below-minimum connectors as available for evaluation without hiding catalog entries."},
+			}, nil),
+			OutputSchema: mcpOutputSchema(map[string]any{"connectors": map[string]any{"type": "array"}}),
+			Annotations:  mcpReadOnlyAnnotations("List Connector Certification"),
+		},
+		{
 			Name:        "cerebro.sources.check",
 			Title:       "Check Source",
 			Description: "Validate live source configuration without requiring durable stores or writing state.",
@@ -3248,7 +3279,7 @@ func mcpToolsetForName(name string) string {
 		return "findings"
 	case strings.HasPrefix(name, "assets."):
 		return "assets"
-	case strings.HasPrefix(name, "sources.") || strings.HasPrefix(name, "source_runtimes.") || strings.HasPrefix(name, "runtimes.") || strings.HasPrefix(name, "connector_definitions."):
+	case strings.HasPrefix(name, "sources.") || strings.HasPrefix(name, "connectors.") || strings.HasPrefix(name, "source_runtimes.") || strings.HasPrefix(name, "runtimes.") || strings.HasPrefix(name, "connector_definitions."):
 		return "operations"
 	case strings.HasPrefix(name, "agent."):
 		return "agent"

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -240,6 +240,7 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		"cerebro.health",
 		"cerebro.version",
 		"cerebro.sources.list",
+		"cerebro.connectors.list",
 		"cerebro.sources.check",
 		"cerebro.sources.discover",
 		"cerebro.sources.read",
@@ -310,6 +311,32 @@ func TestMCPSourceToolsUseStatelessSourceService(t *testing.T) {
 	}
 	if metadata := listed["metadata"].(map[string]any); metadata["source_preview"] != true {
 		t.Fatalf("sources.list metadata = %#v, want source_preview=true", metadata)
+	}
+	connectorsResp, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0", "id": 11, "method": "tools/call",
+		"params": map[string]any{"name": "cerebro.connectors.list", "arguments": map[string]any{"min_certification_tier": "contract_tested", "include_preview": true}},
+	})
+	if connectorsResp["error"] != nil {
+		t.Fatalf("connectors.list error = %#v", connectorsResp["error"])
+	}
+	connectorContent := connectorsResp["result"].(map[string]any)["structuredContent"].(map[string]any)
+	foundGitHub := false
+	for _, item := range connectorContent["connectors"].([]any) {
+		connector := item.(map[string]any)
+		availability := connector["availability"].(map[string]any)
+		if availability["discoverable"] != true {
+			t.Fatalf("connectors.list availability = %#v", availability)
+		}
+		if connector["source_id"] == "github" {
+			foundGitHub = true
+			certification := connector["certification"].(map[string]any)
+			if certification["effective_tier"] == "" || availability["state"] == "" {
+				t.Fatalf("github connector state = %#v", connector)
+			}
+		}
+	}
+	if !foundGitHub {
+		t.Fatal("connectors.list missing github")
 	}
 
 	config := map[string]any{"tenant_id": "writer", "owner": "writer", "repo": "cerebro"}
@@ -509,6 +536,7 @@ var mcpToolDomainSurfaceContracts = map[string]mcpToolDomainSurfaceContract{
 	"cerebro.health":                          {Markers: []string{"GET /health"}},
 	"cerebro.version":                         {Markers: []string{"GetVersion"}},
 	"cerebro.sources.list":                    {Markers: []string{"GET /sources"}},
+	"cerebro.connectors.list":                 {Markers: []string{"GET /connectors"}},
 	"cerebro.sources.check":                   {Markers: []string{"GET /sources/{sourceID}/check"}},
 	"cerebro.sources.discover":                {Markers: []string{"GET /sources/{sourceID}/discover"}},
 	"cerebro.sources.read":                    {Markers: []string{"GET /sources/{sourceID}/read"}},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,11 +152,12 @@ type ConnectorSecretStoreConfig struct {
 
 // ConnectorAccessConfig controls connector catalog visibility and setup gates.
 type ConnectorAccessConfig struct {
-	HiddenSources       []string
-	RestrictedSources   []string
-	RestrictionReason   string
-	RequestAccessURL    string
-	RequestAccessAction string
+	HiddenSources        []string
+	RestrictedSources    []string
+	MinCertificationTier string
+	RestrictionReason    string
+	RequestAccessURL     string
+	RequestAccessAction  string
 }
 
 // GraphActionsConfig configures graph action executors.
@@ -474,11 +475,12 @@ func Load() (Config, error) {
 			},
 		},
 		ConnectorAccess: ConnectorAccessConfig{
-			HiddenSources:       parseCSV(os.Getenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES")),
-			RestrictedSources:   parseCSV(os.Getenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES")),
-			RestrictionReason:   strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_RESTRICTION_REASON")),
-			RequestAccessURL:    strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL")),
-			RequestAccessAction: strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION")),
+			HiddenSources:        parseCSV(os.Getenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES")),
+			RestrictedSources:    parseCSV(os.Getenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES")),
+			MinCertificationTier: strings.ToLower(strings.TrimSpace(os.Getenv("CEREBRO_SOURCE_MIN_CERTIFICATION_TIER"))),
+			RestrictionReason:    strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_RESTRICTION_REASON")),
+			RequestAccessURL:     strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL")),
+			RequestAccessAction:  strings.TrimSpace(os.Getenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION")),
 		},
 		GraphActions: GraphActionsConfig{
 			AccessApprovals: AccessApprovalsActionConfig{
@@ -510,6 +512,14 @@ func Load() (Config, error) {
 				TrustedProxyCIDRs: parseCSV(os.Getenv("CEREBRO_TRUSTED_PROXY_CIDRS")),
 			},
 		},
+	}
+	if cfg.ConnectorAccess.MinCertificationTier == "" {
+		cfg.ConnectorAccess.MinCertificationTier = "cataloged"
+	}
+	switch cfg.ConnectorAccess.MinCertificationTier {
+	case "cataloged", "spec_verified", "contract_tested", "production_observed", "outcome_validated":
+	default:
+		return Config{}, fmt.Errorf("unsupported CEREBRO_SOURCE_MIN_CERTIFICATION_TIER %q", cfg.ConnectorAccess.MinCertificationTier)
 	}
 	authEnabled, err := parseBoolEnvDefault("CEREBRO_API_AUTH_ENABLED", !cfg.DevMode)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "")
+	t.Setenv("CEREBRO_SOURCE_MIN_CERTIFICATION_TIER", "")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "")
 	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL", "")
 	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION", "")
@@ -260,6 +261,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_CREDENTIAL_TRANSIT_PRIVATE_KEY_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "internal_source")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "aws,auth0")
+	t.Setenv("CEREBRO_SOURCE_MIN_CERTIFICATION_TIER", "contract_tested")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "limited preview")
 	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL", "https://access.example.com/request?source={source_id}&tenant={tenant_id}")
 	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION", "Request in Access Hub")
@@ -417,6 +419,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if got := cfg.ConnectorAccess.RestrictedSources; len(got) != 2 || got[0] != "auth0" || got[1] != "aws" {
 		t.Fatalf("ConnectorAccess.RestrictedSources = %#v, want auth0/aws", got)
+	}
+	if cfg.ConnectorAccess.MinCertificationTier != "contract_tested" {
+		t.Fatalf("ConnectorAccess.MinCertificationTier = %q, want contract_tested", cfg.ConnectorAccess.MinCertificationTier)
 	}
 	if cfg.ConnectorAccess.RestrictionReason != "limited preview" {
 		t.Fatalf("ConnectorAccess.RestrictionReason = %q, want limited preview", cfg.ConnectorAccess.RestrictionReason)
@@ -685,6 +690,7 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CONNECTOR_SECRET_STORES_FILE", "")
 	t.Setenv("CEREBRO_CONNECTOR_HIDDEN_SOURCES", "")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTED_SOURCES", "")
+	t.Setenv("CEREBRO_SOURCE_MIN_CERTIFICATION_TIER", "")
 	t.Setenv("CEREBRO_CONNECTOR_RESTRICTION_REASON", "")
 	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_URL", "")
 	t.Setenv("CEREBRO_CONNECTOR_REQUEST_ACCESS_ACTION", "")

--- a/internal/connectorpresentation/helpers.go
+++ b/internal/connectorpresentation/helpers.go
@@ -1,0 +1,31 @@
+package connectorpresentation
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ParseLibraryView(value string) (string, error) {
+	view := strings.TrimSpace(value)
+	if view == "" {
+		return "full", nil
+	}
+	if view != "full" && view != "summary" {
+		return "", fmt.Errorf("connector library view must be full or summary")
+	}
+	return view, nil
+}
+
+func SourceListed(values []string, sourceID string) bool {
+	normalized := strings.TrimSpace(sourceID)
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), normalized) {
+			return true
+		}
+	}
+	return false
+}
+
+func ActivityID(runtimeID, kind, occurredAt string) string {
+	return strings.Trim(strings.Join([]string{strings.TrimSpace(runtimeID), strings.TrimSpace(kind), strings.TrimSpace(occurredAt)}, ":"), ":")
+}

--- a/internal/connectorpresentation/helpers_test.go
+++ b/internal/connectorpresentation/helpers_test.go
@@ -1,0 +1,18 @@
+package connectorpresentation
+
+import "testing"
+
+func TestConnectorPresentationHelpers(t *testing.T) {
+	if view, err := ParseLibraryView(""); err != nil || view != "full" {
+		t.Fatalf("ParseLibraryView(empty) = %q, %v", view, err)
+	}
+	if _, err := ParseLibraryView("compact"); err == nil {
+		t.Fatal("ParseLibraryView(compact) error = nil")
+	}
+	if !SourceListed([]string{" AWS "}, "aws") {
+		t.Fatal("SourceListed() = false")
+	}
+	if got := ActivityID("runtime", "sync", "now"); got != "runtime:sync:now" {
+		t.Fatalf("ActivityID() = %q", got)
+	}
+}

--- a/internal/sourcecdk/catalog.go
+++ b/internal/sourcecdk/catalog.go
@@ -17,6 +17,7 @@ var (
 	catalogCoverageContracts  sync.Map
 	catalogLifecycleContracts sync.Map
 	catalogProviderAPIs       sync.Map
+	catalogCertifications     sync.Map
 )
 
 type catalogFile struct {
@@ -29,6 +30,7 @@ type catalogFile struct {
 	Families            []CatalogFamily            `yaml:"families"`
 	ProviderAPI         CatalogProviderAPI         `yaml:"provider_api"`
 	ProviderAPIDisproof CatalogProviderAPIDisproof `yaml:"provider_api_disproof"`
+	Certification       CatalogCertification       `yaml:"certification"`
 	EventContracts      []EventContract            `yaml:"event_contracts"`
 	Coverage            CoverageContract           `yaml:"coverage_contract"`
 }
@@ -41,6 +43,7 @@ type SourceCatalog struct {
 	EventContracts    []EventContract
 	CoverageContract  *CoverageContract
 	LifecycleContract *LifecycleContract
+	Certification     *CatalogCertification
 }
 
 // CatalogFamily declares optional per-family source catalog capabilities.
@@ -141,6 +144,10 @@ func LoadSourceCatalog(data []byte) (*SourceCatalog, error) {
 	runtimeFamilies := normalizeCatalogRuntimeFamilies(catalog.RuntimeFamilies, families)
 	providerAPI := normalizeCatalogProviderAPI(catalog.ProviderAPI)
 	providerAPIDisproof := normalizeCatalogProviderAPIDisproof(catalog.ProviderAPIDisproof)
+	certification, err := normalizeCatalogCertification(catalog.Certification)
+	if err != nil {
+		return nil, err
+	}
 	if providerAPI == nil && providerAPIDisproof != nil {
 		providerAPI = &CatalogProviderAPI{}
 	}
@@ -159,6 +166,7 @@ func LoadSourceCatalog(data []byte) (*SourceCatalog, error) {
 	registerCatalogCoverageContract(catalog.ID, coverageContract)
 	registerCatalogLifecycleContract(catalog.ID, lifecycleContract)
 	registerCatalogProviderAPI(catalog.ID, providerAPI, runtimeFamilies)
+	registerCatalogCertification(catalog.ID, certification)
 	var coverage *CoverageContract
 	if len(coverageContract.Dimensions) > 0 {
 		cloned := cloneCoverageContract(coverageContract)
@@ -179,7 +187,7 @@ func LoadSourceCatalog(data []byte) (*SourceCatalog, error) {
 		Name:         catalog.Name,
 		Description:  catalog.Description,
 		EmittedKinds: emittedKinds,
-	}, RuntimeFamilies: runtimeFamilies, Families: families, ProviderAPI: api, EventContracts: eventContracts, CoverageContract: coverage, LifecycleContract: lifecycle}, nil
+	}, RuntimeFamilies: runtimeFamilies, Families: families, ProviderAPI: api, EventContracts: eventContracts, CoverageContract: coverage, LifecycleContract: lifecycle, Certification: cloneCatalogCertificationPtr(certification)}, nil
 }
 
 func registerCatalogEventContracts(sourceID string, contracts []EventContract) {

--- a/internal/sourcecdk/certification.go
+++ b/internal/sourcecdk/certification.go
@@ -1,0 +1,174 @@
+package sourcecdk
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	CertificationEvidenceProviderSpec          = "provider_spec"
+	CertificationEvidenceProviderDocumentation = "provider_documentation"
+	CertificationEvidenceSandboxContract       = "sandbox_contract"
+	CertificationEvidenceRecordedReplay        = "recorded_replay"
+)
+
+// CatalogCertification records review ownership and static proof only. Live
+// runtime and outcome states are intentionally absent from this catalog type.
+type CatalogCertification struct {
+	Owner              string                         `yaml:"owner" json:"owner"`
+	ReviewedAt         string                         `yaml:"reviewed_at" json:"reviewed_at"`
+	ExpiresAt          string                         `yaml:"expires_at" json:"expires_at"`
+	Evidence           []CatalogCertificationEvidence `yaml:"evidence" json:"evidence"`
+	ProductionObserved any                            `yaml:"production_observed" json:"-"`
+	OutcomeValidated   any                            `yaml:"outcome_validated" json:"-"`
+}
+
+// CatalogCertificationEvidence points at one immutable static proof artifact.
+type CatalogCertificationEvidence struct {
+	Kind      string   `yaml:"kind" json:"kind"`
+	Reference string   `yaml:"reference" json:"reference,omitempty"`
+	Receipt   string   `yaml:"receipt" json:"receipt,omitempty"`
+	Digest    string   `yaml:"digest" json:"digest"`
+	Families  []string `yaml:"families" json:"families,omitempty"`
+}
+
+func normalizeCatalogCertification(certification CatalogCertification) (*CatalogCertification, error) {
+	if certification.ProductionObserved != nil || certification.OutcomeValidated != nil {
+		return nil, fmt.Errorf("certification catalog cannot declare production_observed or outcome_validated; live owners supply those states")
+	}
+	certification.Owner = strings.TrimSpace(certification.Owner)
+	certification.ReviewedAt = strings.TrimSpace(certification.ReviewedAt)
+	certification.ExpiresAt = strings.TrimSpace(certification.ExpiresAt)
+	if certification.Owner == "" && certification.ReviewedAt == "" && certification.ExpiresAt == "" && len(certification.Evidence) == 0 {
+		return nil, nil
+	}
+	if certification.Owner == "" {
+		return nil, fmt.Errorf("certification owner is required")
+	}
+	reviewedAt, err := parseCertificationTime("reviewed_at", certification.ReviewedAt)
+	if err != nil {
+		return nil, err
+	}
+	expiresAt, err := parseCertificationTime("expires_at", certification.ExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	if !expiresAt.After(reviewedAt) {
+		return nil, fmt.Errorf("certification expires_at must be after reviewed_at")
+	}
+	if len(certification.Evidence) == 0 {
+		return nil, fmt.Errorf("certification evidence is required")
+	}
+	normalized := make([]CatalogCertificationEvidence, 0, len(certification.Evidence))
+	seen := map[string]struct{}{}
+	for index, evidence := range certification.Evidence {
+		evidence.Kind = strings.TrimSpace(evidence.Kind)
+		evidence.Reference = strings.TrimSpace(evidence.Reference)
+		evidence.Receipt = strings.TrimSpace(evidence.Receipt)
+		evidence.Digest = strings.ToLower(strings.TrimSpace(evidence.Digest))
+		evidence.Families = normalizeCatalogStringList(evidence.Families)
+		switch evidence.Kind {
+		case CertificationEvidenceProviderSpec, CertificationEvidenceProviderDocumentation:
+			if evidence.Reference == "" || evidence.Receipt != "" {
+				return nil, fmt.Errorf("certification evidence[%d] %s requires reference and forbids receipt", index, evidence.Kind)
+			}
+		case CertificationEvidenceSandboxContract, CertificationEvidenceRecordedReplay:
+			if evidence.Receipt == "" || evidence.Reference != "" {
+				return nil, fmt.Errorf("certification evidence[%d] %s requires receipt and forbids reference", index, evidence.Kind)
+			}
+		default:
+			return nil, fmt.Errorf("certification evidence[%d] kind %q is not supported", index, evidence.Kind)
+		}
+		if !validCertificationDigest(evidence.Digest) {
+			return nil, fmt.Errorf("certification evidence[%d] digest must be sha256 followed by 64 lowercase hexadecimal characters", index)
+		}
+		key := evidence.Kind + "\x00" + evidence.Reference + "\x00" + evidence.Receipt + "\x00" + evidence.Digest
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("duplicate certification evidence[%d]", index)
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, evidence)
+	}
+	sort.SliceStable(normalized, func(i, j int) bool {
+		if normalized[i].Kind != normalized[j].Kind {
+			return normalized[i].Kind < normalized[j].Kind
+		}
+		if normalized[i].Reference != normalized[j].Reference {
+			return normalized[i].Reference < normalized[j].Reference
+		}
+		return normalized[i].Receipt < normalized[j].Receipt
+	})
+	certification.ReviewedAt = reviewedAt.UTC().Format(time.RFC3339)
+	certification.ExpiresAt = expiresAt.UTC().Format(time.RFC3339)
+	certification.Evidence = normalized
+	return &certification, nil
+}
+
+func parseCertificationTime(field, value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, fmt.Errorf("certification %s is required", field)
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("certification %s must be RFC3339: %w", field, err)
+	}
+	return parsed.UTC(), nil
+}
+
+func validCertificationDigest(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+64 {
+		return false
+	}
+	for _, char := range strings.TrimPrefix(value, "sha256:") {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func registerCatalogCertification(sourceID string, certification *CatalogCertification) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return
+	}
+	if certification == nil {
+		catalogCertifications.Delete(sourceID)
+		return
+	}
+	catalogCertifications.Store(sourceID, cloneCatalogCertification(*certification))
+}
+
+// CatalogCertificationForSource returns normalized static proof metadata for a
+// loaded source catalog.
+func CatalogCertificationForSource(sourceID string) (CatalogCertification, bool) {
+	value, ok := catalogCertifications.Load(strings.TrimSpace(sourceID))
+	if !ok {
+		return CatalogCertification{}, false
+	}
+	certification, ok := value.(CatalogCertification)
+	if !ok {
+		return CatalogCertification{}, false
+	}
+	return cloneCatalogCertification(certification), true
+}
+
+func cloneCatalogCertification(certification CatalogCertification) CatalogCertification {
+	cloned := certification
+	cloned.Evidence = make([]CatalogCertificationEvidence, len(certification.Evidence))
+	for index, evidence := range certification.Evidence {
+		cloned.Evidence[index] = evidence
+		cloned.Evidence[index].Families = append([]string(nil), evidence.Families...)
+	}
+	return cloned
+}
+
+func cloneCatalogCertificationPtr(certification *CatalogCertification) *CatalogCertification {
+	if certification == nil {
+		return nil
+	}
+	cloned := cloneCatalogCertification(*certification)
+	return &cloned
+}

--- a/internal/sourcecdk/certification_test.go
+++ b/internal/sourcecdk/certification_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLoadSourceCatalogCertification(t *testing.T) {
-	catalog, err := LoadSourceCatalog([]byte(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec")))
+	catalog, err := LoadSourceCatalog([]byte(certificationCatalogYAML()))
 	if err != nil {
 		t.Fatalf("LoadSourceCatalog() error = %v", err)
 	}
@@ -26,10 +26,10 @@ func TestLoadSourceCatalogCertification(t *testing.T) {
 
 func TestLoadSourceCatalogCertificationRejectsInvalidProof(t *testing.T) {
 	tests := map[string]string{
-		"unknown evidence":      strings.Replace(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec"), "provider_spec", "trusted", 1),
-		"invalid digest":        strings.Replace(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec"), strings.Repeat("0", 64), "bad", 1),
-		"expired before review": strings.Replace(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec"), "2026-10-14", "2026-06-14", 1),
-		"live state":            strings.Replace(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec"), "  evidence:", "  production_observed: true\n  evidence:", 1),
+		"unknown evidence":      strings.Replace(certificationCatalogYAML(), "provider_spec", "trusted", 1),
+		"invalid digest":        strings.Replace(certificationCatalogYAML(), strings.Repeat("0", 64), "bad", 1),
+		"expired before review": strings.Replace(certificationCatalogYAML(), "2026-10-14", "2026-06-14", 1),
+		"live state":            strings.Replace(certificationCatalogYAML(), "  evidence:", "  production_observed: true\n  evidence:", 1),
 	}
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -40,8 +40,8 @@ func TestLoadSourceCatalogCertificationRejectsInvalidProof(t *testing.T) {
 	}
 }
 
-func certificationCatalogYAML(kind, locator string) string {
+func certificationCatalogYAML() string {
 	return "id: certification-test\nname: Certification Test\ndescription: test\nemitted_kinds: [test.asset]\n" +
 		"certification:\n  owner: source-runtime\n  reviewed_at: 2026-07-14T00:00:00Z\n  expires_at: 2026-10-14T00:00:00Z\n" +
-		"  evidence:\n    - kind: " + kind + "\n      " + locator + "\n      digest: sha256:" + strings.Repeat("0", 64) + "\n      families: [assets]\n"
+		"  evidence:\n    - kind: provider_spec\n      reference: https://provider.example/spec\n      digest: sha256:" + strings.Repeat("0", 64) + "\n      families: [assets]\n"
 }

--- a/internal/sourcecdk/certification_test.go
+++ b/internal/sourcecdk/certification_test.go
@@ -1,0 +1,47 @@
+package sourcecdk
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadSourceCatalogCertification(t *testing.T) {
+	catalog, err := LoadSourceCatalog([]byte(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec")))
+	if err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
+	}
+	if catalog.Certification == nil || catalog.Certification.Owner != "source-runtime" {
+		t.Fatalf("Certification = %+v", catalog.Certification)
+	}
+	stored, ok := CatalogCertificationForSource("certification-test")
+	if !ok || len(stored.Evidence) != 1 {
+		t.Fatalf("CatalogCertificationForSource() = %+v, %t", stored, ok)
+	}
+	stored.Evidence[0].Families = append(stored.Evidence[0].Families, "mutated")
+	again, _ := CatalogCertificationForSource("certification-test")
+	if len(again.Evidence[0].Families) != 1 {
+		t.Fatal("stored certification was mutated through returned clone")
+	}
+}
+
+func TestLoadSourceCatalogCertificationRejectsInvalidProof(t *testing.T) {
+	tests := map[string]string{
+		"unknown evidence":      strings.Replace(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec"), "provider_spec", "trusted", 1),
+		"invalid digest":        strings.Replace(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec"), strings.Repeat("0", 64), "bad", 1),
+		"expired before review": strings.Replace(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec"), "2026-10-14", "2026-06-14", 1),
+		"live state":            strings.Replace(certificationCatalogYAML("provider_spec", "reference: https://provider.example/spec"), "  evidence:", "  production_observed: true\n  evidence:", 1),
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := LoadSourceCatalog([]byte(data)); err == nil {
+				t.Fatal("LoadSourceCatalog() error = nil")
+			}
+		})
+	}
+}
+
+func certificationCatalogYAML(kind, locator string) string {
+	return "id: certification-test\nname: Certification Test\ndescription: test\nemitted_kinds: [test.asset]\n" +
+		"certification:\n  owner: source-runtime\n  reviewed_at: 2026-07-14T00:00:00Z\n  expires_at: 2026-10-14T00:00:00Z\n" +
+		"  evidence:\n    - kind: " + kind + "\n      " + locator + "\n      digest: sha256:" + strings.Repeat("0", 64) + "\n      families: [assets]\n"
+}

--- a/internal/sourcecertification/service.go
+++ b/internal/sourcecertification/service.go
@@ -1,0 +1,350 @@
+package sourcecertification
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectorcatalog"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+type Tier string
+
+const (
+	TierCataloged          Tier = "cataloged"
+	TierSpecVerified       Tier = "spec_verified"
+	TierContractTested     Tier = "contract_tested"
+	TierProductionObserved Tier = "production_observed"
+	TierOutcomeValidated   Tier = "outcome_validated"
+
+	AvailabilityAvailable              = "available"
+	AvailabilityPreview                = "preview"
+	AvailabilityBelowMinimum           = "below_minimum"
+	AvailabilityConfiguredBelowMinimum = "configured_below_minimum"
+	AvailabilityInvalidated            = "invalidated"
+)
+
+const DefaultRuntimeFreshness = 24 * time.Hour
+
+var ErrInvalidTier = errors.New("invalid certification tier")
+
+type RuntimeObservation struct {
+	Configured     bool      `json:"configured"`
+	Healthy        bool      `json:"healthy"`
+	LastObservedAt time.Time `json:"last_observed_at,omitempty"`
+	Fresh          bool      `json:"fresh"`
+}
+
+type RuntimeCount struct {
+	Total   int
+	Healthy int
+}
+
+type OutcomeObservation struct {
+	Accepted       bool      `json:"accepted"`
+	Receipt        string    `json:"receipt,omitempty"`
+	LastObservedAt time.Time `json:"last_observed_at,omitempty"`
+}
+
+type Input struct {
+	SourceID      string
+	Certification *sourcecdk.CatalogCertification
+	ProviderAPI   connectorcatalog.RuntimeProviderAPIDepth
+	Runtime       RuntimeObservation
+	Outcome       OutcomeObservation
+	Now           time.Time
+}
+
+type Result struct {
+	SourceID       string                                   `json:"source_id"`
+	EffectiveTier  Tier                                     `json:"effective_tier"`
+	StaticTier     Tier                                     `json:"static_tier"`
+	DynamicTier    Tier                                     `json:"dynamic_tier"`
+	Invalidated    bool                                     `json:"invalidated"`
+	Expired        bool                                     `json:"expired"`
+	Owner          string                                   `json:"owner,omitempty"`
+	ReviewedAt     string                                   `json:"reviewed_at,omitempty"`
+	ExpiresAt      string                                   `json:"expires_at,omitempty"`
+	Gaps           []string                                 `json:"gaps,omitempty"`
+	Evidence       []sourcecdk.CatalogCertificationEvidence `json:"evidence,omitempty"`
+	LastObservedAt string                                   `json:"last_observed_at,omitempty"`
+}
+
+type AvailabilityPolicy struct {
+	MinimumTier    Tier
+	IncludePreview bool
+}
+
+type Availability struct {
+	State          string `json:"state"`
+	MinimumTier    Tier   `json:"minimum_tier"`
+	MeetsMinimum   bool   `json:"meets_minimum"`
+	Discoverable   bool   `json:"discoverable"`
+	PreviewAllowed bool   `json:"preview_allowed,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+}
+
+func ParseAvailabilityPolicy(configured, requested, preview string) (AvailabilityPolicy, error) {
+	value := strings.TrimSpace(requested)
+	if value == "" {
+		value = strings.TrimSpace(configured)
+	}
+	tier, err := ParseTier(value)
+	if err != nil {
+		return AvailabilityPolicy{}, err
+	}
+	includePreview := false
+	if strings.TrimSpace(preview) != "" {
+		includePreview, err = strconv.ParseBool(preview)
+		if err != nil {
+			return AvailabilityPolicy{}, fmt.Errorf("include_preview must be true or false")
+		}
+	}
+	return AvailabilityPolicy{MinimumTier: tier, IncludePreview: includePreview}, nil
+}
+
+func RuntimeHealthy(runtime *cerebrov1.SourceRuntime) bool {
+	if runtime == nil {
+		return false
+	}
+	status := strings.TrimSpace(runtime.GetConfig()["__cerebro_runtime_status"])
+	if status != "" {
+		return status == "completed" || status == "healthy"
+	}
+	return runtime.GetLastSyncedAt() != nil
+}
+
+func RuntimeCounts(runtimes []*cerebrov1.SourceRuntime) map[string]RuntimeCount {
+	counts := map[string]RuntimeCount{}
+	for _, runtime := range runtimes {
+		sourceID := strings.TrimSpace(runtime.GetSourceId())
+		if sourceID == "" {
+			continue
+		}
+		count := counts[sourceID]
+		count.Total++
+		if RuntimeHealthy(runtime) {
+			count.Healthy++
+		}
+		counts[sourceID] = count
+	}
+	return counts
+}
+
+func RuntimeObservations(runtimes []*cerebrov1.SourceRuntime, now time.Time) map[string]RuntimeObservation {
+	result := map[string]RuntimeObservation{}
+	for _, runtime := range runtimes {
+		if runtime == nil || strings.TrimSpace(runtime.GetSourceId()) == "" {
+			continue
+		}
+		sourceID := strings.TrimSpace(runtime.GetSourceId())
+		observation := result[sourceID]
+		observation.Configured = true
+		observation.Healthy = observation.Healthy || RuntimeHealthy(runtime)
+		if syncedAt := runtime.GetLastSyncedAt(); syncedAt != nil && syncedAt.AsTime().After(observation.LastObservedAt) {
+			observation.LastObservedAt = syncedAt.AsTime().UTC()
+		}
+		result[sourceID] = observation
+	}
+	for sourceID, observation := range result {
+		observation.Fresh = !observation.LastObservedAt.IsZero() && now.Sub(observation.LastObservedAt) <= DefaultRuntimeFreshness
+		result[sourceID] = observation
+	}
+	return result
+}
+
+func ParseTier(value string) (Tier, error) {
+	tier := Tier(strings.ToLower(strings.TrimSpace(value)))
+	if tier == "" {
+		return TierCataloged, nil
+	}
+	if tierRank(tier) < 0 {
+		return "", fmt.Errorf("%w %q; expected cataloged, spec_verified, contract_tested, production_observed, or outcome_validated", ErrInvalidTier, value)
+	}
+	return tier, nil
+}
+
+func AtLeast(actual, minimum Tier) bool {
+	return tierRank(actual) >= tierRank(minimum) && tierRank(minimum) >= 0
+}
+
+func Evaluate(input Input) Result {
+	now := input.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	result := Result{
+		SourceID:      strings.TrimSpace(input.SourceID),
+		EffectiveTier: TierCataloged,
+		StaticTier:    TierCataloged,
+		DynamicTier:   TierCataloged,
+	}
+	if input.ProviderAPI.HasDisproof {
+		result.Invalidated = true
+		result.Gaps = normalizedGaps("provider_api_invalidated")
+		return result
+	}
+	certification := input.Certification
+	if certification == nil {
+		result.Gaps = normalizedGaps("certification_proof_missing")
+		return result
+	}
+	result.Owner = strings.TrimSpace(certification.Owner)
+	reviewedAt, _ := time.Parse(time.RFC3339, certification.ReviewedAt)
+	expiresAt, _ := time.Parse(time.RFC3339, certification.ExpiresAt)
+	result.ReviewedAt = reviewedAt.UTC().Format(time.RFC3339)
+	result.ExpiresAt = expiresAt.UTC().Format(time.RFC3339)
+	result.Evidence = cloneEvidence(certification.Evidence)
+	if expiresAt.IsZero() || !expiresAt.After(now) {
+		result.Expired = true
+		result.Gaps = normalizedGaps("certification_proof_expired")
+		return result
+	}
+	hasProviderProof := input.ProviderAPI.HasProof && hasEvidence(result.Evidence,
+		sourcecdk.CertificationEvidenceProviderSpec,
+		sourcecdk.CertificationEvidenceProviderDocumentation,
+	)
+	if hasProviderProof {
+		result.StaticTier = TierSpecVerified
+	}
+	if hasProviderProof && hasEvidence(result.Evidence, sourcecdk.CertificationEvidenceSandboxContract) {
+		result.StaticTier = TierContractTested
+	}
+	result.DynamicTier = result.StaticTier
+	result.EffectiveTier = result.StaticTier
+	if AtLeast(result.StaticTier, TierContractTested) {
+		switch {
+		case !input.Runtime.Configured:
+			result.Gaps = append(result.Gaps, "production_observation_missing")
+		case !input.Runtime.Healthy:
+			result.Gaps = append(result.Gaps, "runtime_unhealthy")
+		case !input.Runtime.Fresh:
+			result.Gaps = append(result.Gaps, "runtime_observation_stale")
+		default:
+			result.DynamicTier = TierProductionObserved
+			result.EffectiveTier = TierProductionObserved
+			result.LastObservedAt = input.Runtime.LastObservedAt.UTC().Format(time.RFC3339)
+		}
+	}
+	if AtLeast(result.DynamicTier, TierProductionObserved) {
+		if input.Outcome.Accepted && strings.TrimSpace(input.Outcome.Receipt) != "" && !input.Outcome.LastObservedAt.IsZero() {
+			result.DynamicTier = TierOutcomeValidated
+			result.EffectiveTier = TierOutcomeValidated
+			if input.Outcome.LastObservedAt.After(input.Runtime.LastObservedAt) {
+				result.LastObservedAt = input.Outcome.LastObservedAt.UTC().Format(time.RFC3339)
+			}
+		} else {
+			result.Gaps = append(result.Gaps, "accepted_outcome_missing")
+		}
+	}
+	if result.StaticTier == TierCataloged && !hasProviderProof {
+		result.Gaps = append(result.Gaps, "provider_proof_missing")
+	}
+	result.Gaps = normalizedGaps(result.Gaps...)
+	return result
+}
+
+// CatalogResult computes certification from loaded source-catalog proof and an
+// optional live runtime observation. Outcome state remains absent until a
+// durable outcome owner supplies it.
+func CatalogResult(sourceID string, now time.Time, runtime RuntimeObservation) Result {
+	certification, hasCertification := sourcecdk.CatalogCertificationForSource(sourceID)
+	api, runtimeFamilies, hasAPI := sourcecdk.CatalogProviderAPIForSource(sourceID)
+	input := Input{SourceID: sourceID, Runtime: runtime, Now: now}
+	if hasCertification {
+		input.Certification = &certification
+	}
+	if hasAPI {
+		input.ProviderAPI = connectorcatalog.ProviderAPIDepthForSourceCatalog(api, runtimeFamilies)
+	}
+	return Evaluate(input)
+}
+
+func ApplyAvailability(result Result, configured bool, policy AvailabilityPolicy) Availability {
+	minimum := policy.MinimumTier
+	if tierRank(minimum) < 0 {
+		minimum = TierCataloged
+	}
+	availability := Availability{MinimumTier: minimum, Discoverable: true}
+	switch {
+	case result.Invalidated:
+		availability.State = AvailabilityInvalidated
+		availability.Reason = "Static provider proof is invalidated. Review the disproof before enabling this connector."
+	case AtLeast(result.EffectiveTier, minimum):
+		availability.State = AvailabilityAvailable
+		availability.MeetsMinimum = true
+	case configured:
+		availability.State = AvailabilityConfiguredBelowMinimum
+		availability.Reason = "The configured runtime remains visible but its connector certification is below the required tier."
+	case policy.IncludePreview:
+		availability.State = AvailabilityPreview
+		availability.PreviewAllowed = true
+		availability.Reason = "The connector is below the required tier and is included for evaluation."
+	default:
+		availability.State = AvailabilityBelowMinimum
+		availability.Reason = "The connector remains discoverable but is below the required certification tier."
+	}
+	return availability
+}
+
+func tierRank(tier Tier) int {
+	switch tier {
+	case TierCataloged:
+		return 0
+	case TierSpecVerified:
+		return 1
+	case TierContractTested:
+		return 2
+	case TierProductionObserved:
+		return 3
+	case TierOutcomeValidated:
+		return 4
+	default:
+		return -1
+	}
+}
+
+func hasEvidence(evidence []sourcecdk.CatalogCertificationEvidence, kinds ...string) bool {
+	allowed := map[string]bool{}
+	for _, kind := range kinds {
+		allowed[kind] = true
+	}
+	for _, item := range evidence {
+		if allowed[item.Kind] {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneEvidence(evidence []sourcecdk.CatalogCertificationEvidence) []sourcecdk.CatalogCertificationEvidence {
+	cloned := make([]sourcecdk.CatalogCertificationEvidence, len(evidence))
+	for index, item := range evidence {
+		cloned[index] = item
+		cloned[index].Families = append([]string(nil), item.Families...)
+	}
+	return cloned
+}
+
+func normalizedGaps(values ...string) []string {
+	seen := map[string]struct{}{}
+	gaps := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		gaps = append(gaps, value)
+	}
+	sort.Strings(gaps)
+	return gaps
+}

--- a/internal/sourcecertification/service.go
+++ b/internal/sourcecertification/service.go
@@ -145,8 +145,9 @@ func RuntimeObservations(runtimes []*cerebrov1.SourceRuntime, now time.Time) map
 		sourceID := strings.TrimSpace(runtime.GetSourceId())
 		observation := result[sourceID]
 		observation.Configured = true
-		observation.Healthy = observation.Healthy || RuntimeHealthy(runtime)
-		if syncedAt := runtime.GetLastSyncedAt(); syncedAt != nil && syncedAt.AsTime().After(observation.LastObservedAt) {
+		healthy := RuntimeHealthy(runtime)
+		observation.Healthy = observation.Healthy || healthy
+		if syncedAt := runtime.GetLastSyncedAt(); healthy && syncedAt != nil && syncedAt.AsTime().After(observation.LastObservedAt) {
 			observation.LastObservedAt = syncedAt.AsTime().UTC()
 		}
 		result[sourceID] = observation

--- a/internal/sourcecertification/service_test.go
+++ b/internal/sourcecertification/service_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/connectorcatalog"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestEvaluateConcreteCertificationStates(t *testing.T) {
@@ -73,6 +75,39 @@ func TestEvaluateRequiresDurableOutcomeReceipt(t *testing.T) {
 	input.Outcome = OutcomeObservation{Accepted: true, LastObservedAt: now}
 	if result := Evaluate(input); result.EffectiveTier != TierProductionObserved {
 		t.Fatalf("EffectiveTier = %q, want production_observed without durable outcome receipt", result.EffectiveTier)
+	}
+}
+
+func TestRuntimeObservationsRequireFreshHealthyRuntime(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	observations := RuntimeObservations([]*cerebrov1.SourceRuntime{
+		{
+			SourceId:     "github",
+			Config:       map[string]string{"__cerebro_runtime_status": "healthy"},
+			LastSyncedAt: timestamppb.New(now.Add(-DefaultRuntimeFreshness - time.Hour)),
+		},
+		{
+			SourceId:     "github",
+			Config:       map[string]string{"__cerebro_runtime_status": "failed"},
+			LastSyncedAt: timestamppb.New(now.Add(-time.Minute)),
+		},
+	}, now)
+
+	observation := observations["github"]
+	if !observation.Healthy {
+		t.Fatal("Healthy = false, want true when a healthy runtime exists")
+	}
+	if observation.Fresh {
+		t.Fatal("Fresh = true, want false when the only fresh runtime is unhealthy")
+	}
+	wantObservedAt := now.Add(-DefaultRuntimeFreshness - time.Hour)
+	if !observation.LastObservedAt.Equal(wantObservedAt) {
+		t.Fatalf("LastObservedAt = %s, want latest healthy observation %s", observation.LastObservedAt, wantObservedAt)
+	}
+	input := certifiedInput("github", now, true)
+	input.Runtime = observation
+	if result := Evaluate(input); result.EffectiveTier != TierContractTested {
+		t.Fatalf("EffectiveTier = %q, want contract_tested without a fresh healthy runtime", result.EffectiveTier)
 	}
 }
 

--- a/internal/sourcecertification/service_test.go
+++ b/internal/sourcecertification/service_test.go
@@ -1,0 +1,118 @@
+package sourcecertification
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/connectorcatalog"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+func TestEvaluateConcreteCertificationStates(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		input       Input
+		want        Tier
+		invalidated bool
+		expired     bool
+	}{
+		{name: "catalog only", input: Input{SourceID: "aws", Now: now}, want: TierCataloged},
+		{name: "spec verified", input: certifiedInput("github", now, false), want: TierSpecVerified},
+		{name: "contract tested", input: certifiedInput("okta", now, true), want: TierContractTested},
+		{name: "production observed", input: func() Input {
+			input := certifiedInput("jira", now, true)
+			input.Runtime = RuntimeObservation{Configured: true, Healthy: true, Fresh: true, LastObservedAt: now.Add(-time.Hour)}
+			return input
+		}(), want: TierProductionObserved},
+		{name: "outcome validated", input: func() Input {
+			input := certifiedInput("trivy", now, true)
+			input.Runtime = RuntimeObservation{Configured: true, Healthy: true, Fresh: true, LastObservedAt: now.Add(-time.Hour)}
+			input.Outcome = OutcomeObservation{Accepted: true, Receipt: "outcomes/accepted/1", LastObservedAt: now}
+			return input
+		}(), want: TierOutcomeValidated},
+		{name: "expired", input: func() Input {
+			input := certifiedInput("github", now, false)
+			input.Certification.ExpiresAt = now.Add(-time.Hour).Format(time.RFC3339)
+			return input
+		}(), want: TierCataloged, expired: true},
+		{name: "invalidated", input: func() Input {
+			input := certifiedInput("github", now, false)
+			input.ProviderAPI.HasDisproof = true
+			return input
+		}(), want: TierCataloged, invalidated: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := Evaluate(test.input)
+			if got.EffectiveTier != test.want || got.Invalidated != test.invalidated || got.Expired != test.expired {
+				t.Fatalf("Evaluate() = %+v, want tier=%s invalidated=%t expired=%t", got, test.want, test.invalidated, test.expired)
+			}
+		})
+	}
+}
+
+func TestEvaluateDoesNotTreatRuntimeVolumeAsOutcomeProof(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	input := certifiedInput("github", now, true)
+	input.Runtime = RuntimeObservation{Configured: true, Healthy: true, Fresh: true, LastObservedAt: now}
+	result := Evaluate(input)
+	if result.EffectiveTier != TierProductionObserved {
+		t.Fatalf("EffectiveTier = %q, want production_observed", result.EffectiveTier)
+	}
+	if result.EffectiveTier == TierOutcomeValidated {
+		t.Fatal("runtime observation counted as accepted outcome")
+	}
+}
+
+func TestEvaluateRequiresDurableOutcomeReceipt(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	input := certifiedInput("github", now, true)
+	input.Runtime = RuntimeObservation{Configured: true, Healthy: true, Fresh: true, LastObservedAt: now.Add(-time.Hour)}
+	input.Outcome = OutcomeObservation{Accepted: true, LastObservedAt: now}
+	if result := Evaluate(input); result.EffectiveTier != TierProductionObserved {
+		t.Fatalf("EffectiveTier = %q, want production_observed without durable outcome receipt", result.EffectiveTier)
+	}
+}
+
+func TestAvailabilityGatePreservesDiscoveryAndConfiguredRuntime(t *testing.T) {
+	result := Result{EffectiveTier: TierCataloged}
+	policy := AvailabilityPolicy{MinimumTier: TierContractTested}
+	below := ApplyAvailability(result, false, policy)
+	if below.State != AvailabilityBelowMinimum || !below.Discoverable || below.MeetsMinimum {
+		t.Fatalf("below-minimum availability = %+v", below)
+	}
+	configured := ApplyAvailability(result, true, policy)
+	if configured.State != AvailabilityConfiguredBelowMinimum || !configured.Discoverable {
+		t.Fatalf("configured availability = %+v", configured)
+	}
+	preview := ApplyAvailability(result, false, AvailabilityPolicy{MinimumTier: TierContractTested, IncludePreview: true})
+	if preview.State != AvailabilityPreview || !preview.PreviewAllowed || !preview.Discoverable {
+		t.Fatalf("preview availability = %+v", preview)
+	}
+}
+
+func TestParseTierIsClosed(t *testing.T) {
+	for _, value := range []string{"cataloged", "spec_verified", "contract_tested", "production_observed", "outcome_validated"} {
+		if _, err := ParseTier(value); err != nil {
+			t.Fatalf("ParseTier(%q) error = %v", value, err)
+		}
+	}
+	if _, err := ParseTier("trusted"); err == nil {
+		t.Fatal("ParseTier(trusted) error = nil, want closed-tier validation error")
+	}
+}
+
+func certifiedInput(sourceID string, now time.Time, sandbox bool) Input {
+	evidence := []sourcecdk.CatalogCertificationEvidence{{Kind: sourcecdk.CertificationEvidenceProviderSpec, Reference: "https://provider.example/spec", Digest: "sha256:" + strings.Repeat("0", 64)}}
+	if sandbox {
+		evidence = append(evidence, sourcecdk.CatalogCertificationEvidence{Kind: sourcecdk.CertificationEvidenceSandboxContract, Receipt: "contract/receipt", Digest: "sha256:" + strings.Repeat("0", 64)})
+	}
+	return Input{
+		SourceID:      sourceID,
+		Certification: &sourcecdk.CatalogCertification{Owner: "source-runtime", ReviewedAt: now.Add(-time.Hour).Format(time.RFC3339), ExpiresAt: now.Add(90 * 24 * time.Hour).Format(time.RFC3339), Evidence: evidence},
+		ProviderAPI:   connectorcatalog.RuntimeProviderAPIDepth{RuntimeProviderAPIProofDepth: connectorcatalog.RuntimeProviderAPIProofDepth{HasProof: true}},
+		Now:           now,
+	}
+}

--- a/sources/aws/catalog.yaml
+++ b/sources/aws/catalog.yaml
@@ -1,6 +1,14 @@
 id: aws
 name: AWS
 description: AWS IAM inventory and CloudTrail source.
+certification:
+  owner: source-runtime
+  reviewed_at: 2026-07-14T00:00:00Z
+  expires_at: 2026-10-14T00:00:00Z
+  evidence:
+    - kind: recorded_replay
+      receipt: sources/aws/testdata
+      digest: sha256:0f5af244ce0e4df261973549e35756667dff6c7216034ae65946dc23ec6bd0bb
 emitted_kinds:
   - aws.access_key
   - aws.access_analyzer

--- a/sources/github/catalog.yaml
+++ b/sources/github/catalog.yaml
@@ -1,6 +1,17 @@
 id: github
 name: GitHub
 description: GitHub audit, pull request, and Dependabot alert source.
+certification:
+  owner: source-runtime
+  reviewed_at: 2026-07-14T00:00:00Z
+  expires_at: 2026-10-14T00:00:00Z
+  evidence:
+    - kind: provider_spec
+      reference: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
+      digest: sha256:9b0a095713ff578ebe58b7d7fc284470b6ac7fd005cb384bed2e2c0f7640dc0a
+    - kind: sandbox_contract
+      receipt: sources/github/testdata
+      digest: sha256:68926f0e37058aae12ec59a91bd8c8d567783c06e47f2f91f1f09b169452dfa4
 emitted_kinds:
   - github.audit
   - github.code.repository

--- a/sources/jira/catalog.yaml
+++ b/sources/jira/catalog.yaml
@@ -1,6 +1,17 @@
 id: jira
 name: "Jira"
 description: "Collects Jira Cloud users, groups, group membership, projects, project role assignments, permission schemes, and audit records from the Jira REST API."
+certification:
+  owner: source-runtime
+  reviewed_at: 2026-07-14T00:00:00Z
+  expires_at: 2026-10-14T00:00:00Z
+  evidence:
+    - kind: provider_spec
+      reference: https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json
+      digest: sha256:611d46cf5dc985e38c78bbb81327da04090f0a6d59884757397fd85d9eb8b7b3
+    - kind: sandbox_contract
+      receipt: sources/jira/testdata
+      digest: sha256:b1ebdb300aa715c25c79704a16c130eec1ded5d0999d2f3de94f50d77d42dcfb
 emitted_kinds:
   - jira.users
   - jira.groups

--- a/sources/okta/catalog.yaml
+++ b/sources/okta/catalog.yaml
@@ -1,6 +1,17 @@
 id: okta
 name: Okta
 description: Okta audit log, identity inventory, group, application, assignment, federation, network zone, trusted origin, control-plane asset, and admin role source.
+certification:
+  owner: source-runtime
+  reviewed_at: 2026-07-14T00:00:00Z
+  expires_at: 2026-10-14T00:00:00Z
+  evidence:
+    - kind: provider_spec
+      reference: https://raw.githubusercontent.com/okta/okta-management-openapi-spec/master/dist/current/management-minimal.yaml
+      digest: sha256:97f151486fbfa9418e3d8abab77e9d9c3cfa1d2eb53cdecd60ee580ea5b5b439
+    - kind: sandbox_contract
+      receipt: sources/okta/testdata
+      digest: sha256:b9e2f6817b7ffef26c3d07bf53afb00fed2ff050d5050a2e6ac72178c8265a7b
 provider_api:
   status: verified
   basis: declared

--- a/sources/trivy/catalog.yaml
+++ b/sources/trivy/catalog.yaml
@@ -1,6 +1,14 @@
 id: trivy
 name: Trivy
 description: Offline Trivy JSON report source for container image packages, vulnerabilities, and fixes.
+certification:
+  owner: source-runtime
+  reviewed_at: 2026-07-14T00:00:00Z
+  expires_at: 2026-10-14T00:00:00Z
+  evidence:
+    - kind: recorded_replay
+      receipt: sources/trivy/testdata
+      digest: sha256:9dc135487763ddd97a38a7c6611a668f58765812ed486efea77724bdddadcc83
 emitted_kinds:
   - trivy.image_scan
   - trivy.image_package


### PR DESCRIPTION
## Summary

- add the closed connector certification tiers `cataloged`, `spec_verified`, `contract_tested`, `production_observed`, and `outcome_validated`
- validate static proof ownership, review time, expiry, evidence type, receipt or reference, and SHA-256 digest in source catalogs
- keep production observations tied to current Source Runtime health and require a durable accepted-outcome receipt for outcome validation
- return certification and availability through connector HTTP and MCP discovery, and add `cerebro connector-catalog list` for operators
- preserve compiled, configured, and catalog-only discovery when a minimum tier is configured; below-minimum and invalidated connectors receive explicit states
- seed GitHub, Okta, Jira, AWS, and Trivy with current static proof receipts without declaring production or outcome state

## Operator behavior

Set `CEREBRO_SOURCE_MIN_CERTIFICATION_TIER` to the required tier. `/connectors` accepts `min_certification_tier` and `include_preview` for read-time evaluation. Entries remain in the response with `available`, `preview`, `below_minimum`, `configured_below_minimum`, or `invalidated` availability.

## Validation

- focused Go tests for source catalog proof, certification states, HTTP, MCP, CLI, and configuration
- `make catalog-check sourcegen-check connector-catalog-fidelity-check`
- `make check-structural check-structural-test check-arch` (bootstrap remains below the existing line budget; no budget change)
- `make openapi-check openapi-lint` through the contract suite
- `make docs-drift-check readme-check oss-audit`
- MCP contract and SDK compatibility checks
- CLI smoke test for the contract-tested minimum tier and catalog visibility

`proto-generate-check` reached the Buf registry rate limit on the SDK generation step after two attempts. Proto lint and breaking checks passed, and this change does not modify proto files.

Refs #1725