### PR TITLE
feat: add evidence-backed trust claim receipts

### DIFF
--- a/internal/trustclaims/adapters.go
+++ b/internal/trustclaims/adapters.go
@@ -1,0 +1,125 @@
+package trustclaims
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/evidencepackets"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+// CitationFromQuestionnaire preserves the source-event and resource lineage of
+// a questionnaire answer when it becomes an external factual claim.
+func CitationFromQuestionnaire(citation ports.QuestionnaireCitation, trusted bool) Citation {
+	observedAt, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(citation.ObservedAt))
+	expiresAt := parseOptionalTime(citation.ExpiresAt)
+	resourceRefs := make([]ResourceRef, 0, len(citation.GraphRootURNs)+1)
+	if resourceURN := strings.TrimSpace(citation.ResourceURN); resourceURN != "" {
+		resourceRefs = append(resourceRefs, ResourceRef{URN: resourceURN})
+	}
+	for _, urn := range citation.GraphRootURNs {
+		resourceRefs = append(resourceRefs, ResourceRef{URN: urn})
+	}
+	state := normalizeFreshnessState(citation.FreshnessStatus)
+	return Citation{
+		ID:               citation.ID,
+		EvidenceID:       firstNonEmpty(citation.EvidenceID, citation.ID),
+		EvidencePacketID: citation.EvidencePacketID,
+		EvidenceType:     citation.EvidenceType,
+		SourceID:         firstNonEmpty(citation.SourceID, citation.Source),
+		RuntimeID:        citation.RuntimeID,
+		SourceEventIDs:   citation.SourceEventIDs,
+		ResourceRefs:     resourceRefs,
+		State:            state,
+		Trusted:          trusted,
+		ObservedAt:       observedAt,
+		ExpiresAt:        expiresAt,
+	}
+}
+
+// CitationFromEvidencePacket converts the existing evidence-packet reasoning
+// contract without inferring trust or silently upgrading freshness.
+func CitationFromEvidencePacket(reference evidencepackets.QuestionnaireEvidenceRef, trusted bool) Citation {
+	observedAt, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(reference.Freshness.ObservedAt))
+	expiresAt := parseOptionalTime(reference.Freshness.ExpiresAt)
+	resources := make([]ResourceRef, 0, len(reference.GraphRootURNs))
+	for _, urn := range reference.GraphRootURNs {
+		resources = append(resources, ResourceRef{URN: urn})
+	}
+	return Citation{
+		ID:               reference.ID,
+		EvidenceID:       reference.ID,
+		EvidencePacketID: reference.EvidencePacketID,
+		EvidenceType:     reference.EvidenceType,
+		SourceID:         firstNonEmpty(reference.SourceID, reference.Source),
+		RuntimeID:        reference.RuntimeID,
+		SourceEventIDs:   reference.SourceEventIDs,
+		ResourceRefs:     resources,
+		State:            normalizeFreshnessState(reference.Freshness.Status),
+		Trusted:          trusted,
+		ObservedAt:       observedAt,
+		ExpiresAt:        expiresAt,
+	}
+}
+
+// WorkflowDecision maps a trust-claim transition onto the existing durable
+// knowledge-decision event contract. The caller remains responsible for
+// appending the event before projecting current state.
+func (transition ClaimTransition) WorkflowDecision() workflowevents.DecisionRecorded {
+	evidenceIDs := make([]string, 0, len(transition.Receipt.Citations))
+	for _, citation := range transition.Receipt.Citations {
+		evidenceIDs = append(evidenceIDs, citation.EvidenceID)
+	}
+	return workflowevents.DecisionRecorded{
+		TenantID:      transition.TenantID,
+		DecisionID:    transition.Receipt.ReceiptID + ":v" + fmt.Sprintf("%d", transition.Receipt.Version),
+		DecisionType:  transition.TransitionType,
+		Status:        transition.Receipt.Status,
+		Rationale:     transition.Receipt.TransitionReason,
+		TargetIDs:     uniqueSortedStrings([]string{transition.ClaimID, transition.Receipt.ReceiptID}),
+		EvidenceIDs:   uniqueSortedStrings(evidenceIDs),
+		SourceSystem:  "cerebro-trust-claims",
+		SourceEventID: transition.FromDigest,
+		ObservedAt:    transition.Receipt.IssuedAt.UTC().Format(time.RFC3339Nano),
+		ValidFrom:     transition.Receipt.IssuedAt.UTC().Format(time.RFC3339Nano),
+		Confidence:    1,
+		Metadata: map[string]any{
+			"receipt_digest":  transition.Receipt.Digest,
+			"previous_digest": transition.FromDigest,
+			"receipt_version": transition.Receipt.Version,
+			"transition_type": transition.TransitionType,
+		},
+	}
+}
+
+func normalizeFreshnessState(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "current", "fresh", "supported":
+		return CitationCurrent
+	case "conflict", "conflicted":
+		return CitationConflicted
+	case "revoked", "retracted":
+		return CitationRevoked
+	default:
+		return CitationStale
+	}
+}
+
+func parseOptionalTime(value string) *time.Time {
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/trustclaims/model.go
+++ b/internal/trustclaims/model.go
@@ -1,0 +1,209 @@
+package trustclaims
+
+import "time"
+
+const (
+	ReceiptSchemaVersion    = "trust-claim-receipt.v1"
+	PackageSchemaVersion    = "trust-claim-package.v1"
+	ObligationSchemaVersion = "trust-obligation.v1"
+
+	ClaimOriginAuthored  = "authored"
+	ClaimOriginGenerated = "generated"
+	ClaimOriginExtracted = "extracted"
+
+	ClaimStatusDraft        = "draft"
+	ClaimStatusShareable    = "shareable"
+	ClaimStatusAuditorReady = "auditor_ready"
+	ClaimStatusWithdrawn    = "withdrawn"
+	ClaimStatusReopened     = "reopened"
+	ClaimStatusSuperseded   = "superseded"
+
+	DisclosureInternal = "internal"
+	DisclosureCustomer = "customer"
+	DisclosureAuditor  = "auditor"
+
+	CitationCurrent    = "current"
+	CitationStale      = "stale"
+	CitationRevoked    = "revoked"
+	CitationConflicted = "conflicted"
+
+	ApprovalApproved = "approved"
+
+	TransitionClaimWithdrawn  = "trust_claim_withdrawn"
+	TransitionClaimReopened   = "trust_claim_reopened"
+	TransitionClaimSuperseded = "trust_claim_superseded"
+
+	ObligationSuggested  = "suggested"
+	ObligationActive     = "active"
+	ObligationSuperseded = "superseded"
+)
+
+// ClaimReceipt is an immutable version of a factual external claim. A changed
+// claim or dependency produces another receipt linked through PreviousDigest.
+type ClaimReceipt struct {
+	SchemaVersion     string             `json:"schema_version"`
+	TenantID          string             `json:"tenant_id"`
+	ReceiptID         string             `json:"receipt_id"`
+	ClaimID           string             `json:"claim_id"`
+	Version           int                `json:"version"`
+	Statement         string             `json:"statement"`
+	Origin            string             `json:"origin"`
+	Status            string             `json:"status"`
+	DisclosureClass   string             `json:"disclosure_class"`
+	Citations         []Citation         `json:"citations,omitempty"`
+	Controls          []VersionedRef     `json:"controls,omitempty"`
+	Policies          []VersionedRef     `json:"policies,omitempty"`
+	ResourceRefs      []ResourceRef      `json:"resource_refs,omitempty"`
+	Generation        *GenerationReceipt `json:"generation,omitempty"`
+	UnsupportedClaims []string           `json:"unsupported_claims,omitempty"`
+	Approval          *ReviewerApproval  `json:"approval,omitempty"`
+	FreshUntil        *time.Time         `json:"fresh_until,omitempty"`
+	ExpiresAt         *time.Time         `json:"expires_at,omitempty"`
+	IssuedAt          time.Time          `json:"issued_at"`
+	PreviousDigest    string             `json:"previous_digest,omitempty"`
+	TransitionReason  string             `json:"transition_reason,omitempty"`
+	Digest            string             `json:"digest"`
+}
+
+type Citation struct {
+	ID               string        `json:"id"`
+	EvidenceID       string        `json:"evidence_id"`
+	EvidencePacketID string        `json:"evidence_packet_id,omitempty"`
+	EvidenceType     string        `json:"evidence_type,omitempty"`
+	SourceID         string        `json:"source_id"`
+	RuntimeID        string        `json:"runtime_id,omitempty"`
+	SourceEventIDs   []string      `json:"source_event_ids"`
+	ResourceRefs     []ResourceRef `json:"resource_refs,omitempty"`
+	State            string        `json:"state"`
+	Trusted          bool          `json:"trusted"`
+	ObservedAt       time.Time     `json:"observed_at"`
+	ExpiresAt        *time.Time    `json:"expires_at,omitempty"`
+}
+
+type ResourceRef struct {
+	URN      string `json:"urn"`
+	Revision string `json:"revision,omitempty"`
+	Type     string `json:"type,omitempty"`
+}
+
+type VersionedRef struct {
+	ID      string `json:"id"`
+	Version string `json:"version"`
+}
+
+type GenerationReceipt struct {
+	ModelID       string `json:"model_id"`
+	ModelVersion  string `json:"model_version"`
+	PromptVersion string `json:"prompt_version"`
+	PromptDigest  string `json:"prompt_digest,omitempty"`
+}
+
+type ReviewerApproval struct {
+	ReviewerID string    `json:"reviewer_id"`
+	Decision   string    `json:"decision"`
+	Reason     string    `json:"reason,omitempty"`
+	ApprovedAt time.Time `json:"approved_at"`
+}
+
+type ReceiptInput struct {
+	TenantID          string
+	ReceiptID         string
+	ClaimID           string
+	Version           int
+	Statement         string
+	Origin            string
+	RequestedStatus   string
+	DisclosureClass   string
+	Citations         []Citation
+	Controls          []VersionedRef
+	Policies          []VersionedRef
+	ResourceRefs      []ResourceRef
+	Generation        *GenerationReceipt
+	UnsupportedClaims []string
+	Approval          *ReviewerApproval
+	FreshUntil        *time.Time
+	ExpiresAt         *time.Time
+	IssuedAt          time.Time
+	PreviousDigest    string
+}
+
+type EvidenceChange struct {
+	TenantID   string
+	CitationID string
+	State      string
+	Reason     string
+	ObservedAt time.Time
+}
+
+type ClaimTransition struct {
+	EventKind      string       `json:"event_kind"`
+	TransitionType string       `json:"transition_type"`
+	TenantID       string       `json:"tenant_id"`
+	ClaimID        string       `json:"claim_id"`
+	FromDigest     string       `json:"from_digest"`
+	Receipt        ClaimReceipt `json:"receipt"`
+}
+
+// Obligation binds a confirmed commitment to the exact controls, evidence
+// requirements, population, owner, and deadline used to operate it.
+type Obligation struct {
+	SchemaVersion        string             `json:"schema_version"`
+	TenantID             string             `json:"tenant_id"`
+	ObligationID         string             `json:"obligation_id"`
+	Version              int                `json:"version"`
+	Status               string             `json:"status"`
+	ContractRef          VersionedRef       `json:"contract_ref"`
+	CommitmentRef        string             `json:"commitment_ref"`
+	Controls             []VersionedRef     `json:"controls"`
+	EvidenceRequirements []VersionedRef     `json:"evidence_requirements"`
+	ResourcePopulation   []ResourceRef      `json:"resource_population"`
+	OwnerID              string             `json:"owner_id"`
+	Deadline             *time.Time         `json:"deadline,omitempty"`
+	SuggestedBy          *ExtractionReceipt `json:"suggested_by,omitempty"`
+	ConfirmedBy          *ReviewerApproval  `json:"confirmed_by,omitempty"`
+	PreviousDigest       string             `json:"previous_digest,omitempty"`
+	SupersededBy         string             `json:"superseded_by,omitempty"`
+	IssuedAt             time.Time          `json:"issued_at"`
+	Digest               string             `json:"digest"`
+}
+
+type ExtractionReceipt struct {
+	SourceRef     string `json:"source_ref"`
+	ExtractorID   string `json:"extractor_id"`
+	ModelVersion  string `json:"model_version,omitempty"`
+	PromptVersion string `json:"prompt_version,omitempty"`
+}
+
+type ObligationInput struct {
+	TenantID             string
+	ObligationID         string
+	Version              int
+	ContractRef          VersionedRef
+	CommitmentRef        string
+	Controls             []VersionedRef
+	EvidenceRequirements []VersionedRef
+	ResourcePopulation   []ResourceRef
+	OwnerID              string
+	Deadline             *time.Time
+	SuggestedBy          *ExtractionReceipt
+	IssuedAt             time.Time
+	PreviousDigest       string
+}
+
+type PackageRequest struct {
+	TenantID      string
+	Audience      string
+	ReceiptIDs    []string
+	ObligationIDs []string
+	PackagedAt    time.Time
+}
+
+type ClaimPackage struct {
+	SchemaVersion string         `json:"schema_version"`
+	TenantID      string         `json:"tenant_id"`
+	Audience      string         `json:"audience"`
+	Receipts      []ClaimReceipt `json:"receipts"`
+	Obligations   []Obligation   `json:"obligations,omitempty"`
+	PackagedAt    time.Time      `json:"packaged_at"`
+	Digest        string         `json:"digest"`
+}

--- a/internal/trustclaims/service.go
+++ b/internal/trustclaims/service.go
@@ -1,0 +1,690 @@
+package trustclaims
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+var (
+	ErrInvalidReceipt            = errors.New("invalid trust claim receipt")
+	ErrNotShareable              = errors.New("trust claim is not shareable")
+	ErrTenantMismatch            = errors.New("tenant mismatch")
+	ErrReceiptNotFound           = errors.New("trust claim receipt not found")
+	ErrObligationNotFound        = errors.New("trust obligation not found")
+	ErrHumanConfirmationRequired = errors.New("human confirmation is required")
+)
+
+func IssueReceipt(input ReceiptInput) (ClaimReceipt, error) {
+	normalizeReceiptInput(&input)
+	if err := validateReceiptInput(input); err != nil {
+		return ClaimReceipt{}, err
+	}
+	receipt := ClaimReceipt{
+		SchemaVersion:     ReceiptSchemaVersion,
+		TenantID:          input.TenantID,
+		ReceiptID:         input.ReceiptID,
+		ClaimID:           input.ClaimID,
+		Version:           input.Version,
+		Statement:         input.Statement,
+		Origin:            input.Origin,
+		Status:            input.RequestedStatus,
+		DisclosureClass:   input.DisclosureClass,
+		Citations:         input.Citations,
+		Controls:          input.Controls,
+		Policies:          input.Policies,
+		ResourceRefs:      input.ResourceRefs,
+		Generation:        input.Generation,
+		UnsupportedClaims: input.UnsupportedClaims,
+		Approval:          input.Approval,
+		FreshUntil:        utcTimePtr(input.FreshUntil),
+		ExpiresAt:         utcTimePtr(input.ExpiresAt),
+		IssuedAt:          input.IssuedAt.UTC(),
+		PreviousDigest:    input.PreviousDigest,
+	}
+	if receipt.Status == "" {
+		receipt.Status = ClaimStatusDraft
+	}
+	if isExternalStatus(receipt.Status) {
+		if err := validateExternalEligibility(receipt, receipt.IssuedAt); err != nil {
+			return ClaimReceipt{}, err
+		}
+	}
+	digest, err := digestValue(receiptWithoutDigest(receipt))
+	if err != nil {
+		return ClaimReceipt{}, err
+	}
+	receipt.Digest = digest
+	return receipt, nil
+}
+
+func validateReceiptInput(input ReceiptInput) error {
+	if input.TenantID == "" || input.ReceiptID == "" || input.ClaimID == "" || input.Statement == "" || input.IssuedAt.IsZero() {
+		return fmt.Errorf("%w: tenant_id, receipt_id, claim_id, statement, and issued_at are required", ErrInvalidReceipt)
+	}
+	if !utf8.ValidString(input.Statement) || strings.ContainsRune(input.Statement, '\x00') {
+		return fmt.Errorf("%w: statement must be valid text without NUL bytes", ErrInvalidReceipt)
+	}
+	if input.Version < 1 {
+		return fmt.Errorf("%w: version must be positive", ErrInvalidReceipt)
+	}
+	if len(input.Citations) == 0 {
+		if isExternalStatus(input.RequestedStatus) {
+			return fmt.Errorf("%w: current citations are required", ErrNotShareable)
+		}
+		return fmt.Errorf("%w: evidence citations are required", ErrInvalidReceipt)
+	}
+	if len(input.Controls) == 0 || len(input.Policies) == 0 || len(input.ResourceRefs) == 0 {
+		return fmt.Errorf("%w: versioned controls, versioned policies, and resource refs are required", ErrInvalidReceipt)
+	}
+	if input.FreshUntil == nil || input.ExpiresAt == nil || !input.FreshUntil.After(input.IssuedAt) || !input.ExpiresAt.After(input.IssuedAt) {
+		return fmt.Errorf("%w: future freshness and expiry bounds are required", ErrInvalidReceipt)
+	}
+	switch input.Origin {
+	case ClaimOriginAuthored, ClaimOriginGenerated, ClaimOriginExtracted:
+	default:
+		return fmt.Errorf("%w: unsupported claim origin %q", ErrInvalidReceipt, input.Origin)
+	}
+	if input.Origin == ClaimOriginGenerated {
+		if input.Generation == nil || input.Generation.ModelID == "" || input.Generation.ModelVersion == "" || input.Generation.PromptVersion == "" {
+			return fmt.Errorf("%w: generated claims require model and prompt versions", ErrInvalidReceipt)
+		}
+	}
+	switch input.RequestedStatus {
+	case "", ClaimStatusDraft, ClaimStatusShareable, ClaimStatusAuditorReady:
+	default:
+		return fmt.Errorf("%w: status %q cannot be issued directly", ErrInvalidReceipt, input.RequestedStatus)
+	}
+	switch input.DisclosureClass {
+	case DisclosureInternal, DisclosureCustomer, DisclosureAuditor:
+	default:
+		return fmt.Errorf("%w: unsupported disclosure class %q", ErrInvalidReceipt, input.DisclosureClass)
+	}
+	if isExternalStatus(input.RequestedStatus) && input.DisclosureClass == DisclosureInternal {
+		return fmt.Errorf("%w: external status requires customer or auditor disclosure", ErrInvalidReceipt)
+	}
+	for _, ref := range append(append([]VersionedRef(nil), input.Controls...), input.Policies...) {
+		if ref.ID == "" || ref.Version == "" {
+			return fmt.Errorf("%w: control and policy refs require exact versions", ErrInvalidReceipt)
+		}
+	}
+	for _, ref := range input.ResourceRefs {
+		if ref.URN == "" || ref.Revision == "" {
+			return fmt.Errorf("%w: resource refs require urn and revision", ErrInvalidReceipt)
+		}
+	}
+	for _, citation := range input.Citations {
+		if citation.ID == "" || citation.EvidenceID == "" || citation.SourceID == "" || citation.ObservedAt.IsZero() || len(citation.SourceEventIDs) == 0 {
+			return fmt.Errorf("%w: citations require id, evidence_id, source_id, observed_at, and source event ids", ErrInvalidReceipt)
+		}
+		if citation.ObservedAt.After(input.IssuedAt) {
+			return fmt.Errorf("%w: citation %s was observed after receipt issuance", ErrInvalidReceipt, citation.ID)
+		}
+		switch citation.State {
+		case CitationCurrent, CitationStale, CitationRevoked, CitationConflicted:
+		default:
+			return fmt.Errorf("%w: unsupported citation state %q", ErrInvalidReceipt, citation.State)
+		}
+	}
+	return nil
+}
+
+func validateExternalEligibility(receipt ClaimReceipt, at time.Time) error {
+	if len(receipt.Citations) == 0 {
+		return fmt.Errorf("%w: current citations are required", ErrNotShareable)
+	}
+	if receipt.Approval == nil || receipt.Approval.Decision != ApprovalApproved || receipt.Approval.ReviewerID == "" || receipt.Approval.ApprovedAt.IsZero() {
+		return fmt.Errorf("%w: reviewer approval is required", ErrNotShareable)
+	}
+	if len(receipt.UnsupportedClaims) != 0 {
+		return fmt.Errorf("%w: unsupported claims remain", ErrNotShareable)
+	}
+	if receipt.ExpiresAt != nil && !receipt.ExpiresAt.After(at) {
+		return fmt.Errorf("%w: receipt has expired", ErrNotShareable)
+	}
+	if receipt.FreshUntil != nil && !receipt.FreshUntil.After(at) {
+		return fmt.Errorf("%w: receipt freshness window has elapsed", ErrNotShareable)
+	}
+	for _, citation := range receipt.Citations {
+		if citation.State != CitationCurrent || !citation.Trusted {
+			return fmt.Errorf("%w: citation %s is not current and trusted", ErrNotShareable, citation.ID)
+		}
+		if citation.ExpiresAt != nil && !citation.ExpiresAt.After(at) {
+			return fmt.Errorf("%w: citation %s has expired", ErrNotShareable, citation.ID)
+		}
+	}
+	if receipt.Status == ClaimStatusAuditorReady && receipt.DisclosureClass != DisclosureAuditor {
+		return fmt.Errorf("%w: auditor-ready claims require auditor disclosure", ErrNotShareable)
+	}
+	return nil
+}
+
+// ApplyEvidenceChange creates a new immutable receipt version and a workflow
+// transition. It never updates citations in place or transfers prior approval.
+func ApplyEvidenceChange(receipt ClaimReceipt, change EvidenceChange) (ClaimTransition, error) {
+	if err := verifyReceipt(receipt); err != nil {
+		return ClaimTransition{}, err
+	}
+	if receipt.Status == ClaimStatusSuperseded {
+		return ClaimTransition{}, fmt.Errorf("%w: superseded claims cannot be reopened", ErrInvalidReceipt)
+	}
+	change.TenantID = strings.TrimSpace(change.TenantID)
+	change.CitationID = strings.TrimSpace(change.CitationID)
+	change.State = strings.TrimSpace(change.State)
+	change.Reason = strings.TrimSpace(change.Reason)
+	if change.TenantID != receipt.TenantID {
+		return ClaimTransition{}, ErrTenantMismatch
+	}
+	if change.ObservedAt.IsZero() || change.CitationID == "" {
+		return ClaimTransition{}, fmt.Errorf("%w: citation_id and observed_at are required", ErrInvalidReceipt)
+	}
+	switch change.State {
+	case CitationStale, CitationRevoked, CitationConflicted:
+	default:
+		return ClaimTransition{}, fmt.Errorf("%w: evidence changes must be stale, revoked, or conflicted", ErrInvalidReceipt)
+	}
+	citations := append([]Citation(nil), receipt.Citations...)
+	found := false
+	for index := range citations {
+		if citations[index].ID == change.CitationID {
+			citations[index].State = change.State
+			found = true
+		}
+	}
+	if !found {
+		return ClaimTransition{}, fmt.Errorf("%w: citation %s does not belong to receipt", ErrInvalidReceipt, change.CitationID)
+	}
+	status := ClaimStatusReopened
+	transitionType := TransitionClaimReopened
+	if receipt.Status == ClaimStatusShareable || receipt.Status == ClaimStatusAuditorReady {
+		status = ClaimStatusWithdrawn
+		transitionType = TransitionClaimWithdrawn
+	}
+	next := receipt
+	next.Version++
+	next.Status = status
+	next.Citations = citations
+	next.Approval = nil
+	next.IssuedAt = change.ObservedAt.UTC()
+	next.PreviousDigest = receipt.Digest
+	next.TransitionReason = change.Reason
+	next.Digest = ""
+	normalizeReceipt(&next)
+	digest, err := digestValue(receiptWithoutDigest(next))
+	if err != nil {
+		return ClaimTransition{}, err
+	}
+	next.Digest = digest
+	return ClaimTransition{
+		EventKind:      workflowevents.EventKindKnowledgeDecisionRecorded,
+		TransitionType: transitionType,
+		TenantID:       receipt.TenantID,
+		ClaimID:        receipt.ClaimID,
+		FromDigest:     receipt.Digest,
+		Receipt:        next,
+	}, nil
+}
+
+// ReconcileExpiry turns elapsed receipt or citation freshness into an explicit
+// transition. A nil transition means the immutable receipt remains current.
+func ReconcileExpiry(receipt ClaimReceipt, at time.Time) (*ClaimTransition, error) {
+	if err := verifyReceipt(receipt); err != nil {
+		return nil, err
+	}
+	if at.IsZero() {
+		return nil, fmt.Errorf("%w: reconciliation time is required", ErrInvalidReceipt)
+	}
+	for _, citation := range receipt.Citations {
+		if citation.ExpiresAt != nil && !citation.ExpiresAt.After(at) {
+			transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
+				TenantID: receipt.TenantID, CitationID: citation.ID, State: CitationStale,
+				Reason: "Cited evidence expired.", ObservedAt: at,
+			})
+			return &transition, err
+		}
+	}
+	if (receipt.ExpiresAt != nil && !receipt.ExpiresAt.After(at)) || (receipt.FreshUntil != nil && !receipt.FreshUntil.After(at)) {
+		if len(receipt.Citations) == 0 {
+			return nil, fmt.Errorf("%w: expiring receipt has no citation to invalidate", ErrInvalidReceipt)
+		}
+		transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
+			TenantID: receipt.TenantID, CitationID: receipt.Citations[0].ID, State: CitationStale,
+			Reason: "Claim freshness window elapsed.", ObservedAt: at,
+		})
+		return &transition, err
+	}
+	return nil, nil
+}
+
+func SupersedeReceipt(receipt ClaimReceipt, successorReceiptID string, at time.Time) (ClaimTransition, error) {
+	if err := verifyReceipt(receipt); err != nil {
+		return ClaimTransition{}, err
+	}
+	if strings.TrimSpace(successorReceiptID) == "" || at.IsZero() {
+		return ClaimTransition{}, fmt.Errorf("%w: successor receipt and transition time are required", ErrInvalidReceipt)
+	}
+	next := receipt
+	next.Version++
+	next.Status = ClaimStatusSuperseded
+	next.Approval = nil
+	next.IssuedAt = at.UTC()
+	next.PreviousDigest = receipt.Digest
+	next.TransitionReason = "Superseded by receipt " + strings.TrimSpace(successorReceiptID) + "."
+	next.Digest = ""
+	normalizeReceipt(&next)
+	digest, err := digestValue(receiptWithoutDigest(next))
+	if err != nil {
+		return ClaimTransition{}, err
+	}
+	next.Digest = digest
+	return ClaimTransition{EventKind: workflowevents.EventKindKnowledgeDecisionRecorded, TransitionType: TransitionClaimSuperseded, TenantID: receipt.TenantID, ClaimID: receipt.ClaimID, FromDigest: receipt.Digest, Receipt: next}, nil
+}
+
+func SuggestObligation(input ObligationInput) (Obligation, error) {
+	if input.SuggestedBy == nil {
+		return Obligation{}, fmt.Errorf("%w: extracted suggestion receipt is required", ErrInvalidReceipt)
+	}
+	return buildObligation(input, ObligationSuggested, nil)
+}
+
+func ConfirmObligation(suggestion Obligation, approval ReviewerApproval, at time.Time) (Obligation, error) {
+	if err := verifyObligation(suggestion); err != nil {
+		return Obligation{}, err
+	}
+	if suggestion.Status != ObligationSuggested {
+		return Obligation{}, fmt.Errorf("%w: only suggestions can be confirmed", ErrHumanConfirmationRequired)
+	}
+	normalizeApproval(&approval)
+	if approval.Decision != ApprovalApproved || approval.ReviewerID == "" || approval.ApprovedAt.IsZero() {
+		return Obligation{}, ErrHumanConfirmationRequired
+	}
+	if at.IsZero() {
+		return Obligation{}, fmt.Errorf("%w: confirmation time is required", ErrInvalidReceipt)
+	}
+	next := suggestion
+	next.Version++
+	next.Status = ObligationActive
+	next.ConfirmedBy = &approval
+	next.IssuedAt = at.UTC()
+	next.PreviousDigest = suggestion.Digest
+	next.Digest = ""
+	normalizeObligation(&next)
+	digest, err := digestValue(obligationWithoutDigest(next))
+	if err != nil {
+		return Obligation{}, err
+	}
+	next.Digest = digest
+	return next, nil
+}
+
+func SupersedeObligation(obligation Obligation, successorID string, at time.Time) (Obligation, error) {
+	if err := verifyObligation(obligation); err != nil {
+		return Obligation{}, err
+	}
+	if obligation.Status != ObligationActive || strings.TrimSpace(successorID) == "" || at.IsZero() {
+		return Obligation{}, fmt.Errorf("%w: active obligation, successor id, and transition time are required", ErrInvalidReceipt)
+	}
+	next := obligation
+	next.Version++
+	next.Status = ObligationSuperseded
+	next.SupersededBy = strings.TrimSpace(successorID)
+	next.IssuedAt = at.UTC()
+	next.PreviousDigest = obligation.Digest
+	next.Digest = ""
+	normalizeObligation(&next)
+	digest, err := digestValue(obligationWithoutDigest(next))
+	if err != nil {
+		return Obligation{}, err
+	}
+	next.Digest = digest
+	return next, nil
+}
+
+func buildObligation(input ObligationInput, status string, approval *ReviewerApproval) (Obligation, error) {
+	normalizeObligationInput(&input)
+	if input.TenantID == "" || input.ObligationID == "" || input.Version < 1 || input.ContractRef.ID == "" || input.ContractRef.Version == "" || input.CommitmentRef == "" || input.OwnerID == "" || input.IssuedAt.IsZero() {
+		return Obligation{}, fmt.Errorf("%w: obligation identity, contract version, commitment, owner, version, and issued_at are required", ErrInvalidReceipt)
+	}
+	if input.SuggestedBy == nil || input.SuggestedBy.SourceRef == "" || input.SuggestedBy.ExtractorID == "" {
+		return Obligation{}, fmt.Errorf("%w: extracted obligations require source and extractor receipts", ErrInvalidReceipt)
+	}
+	if len(input.Controls) == 0 || len(input.EvidenceRequirements) == 0 || len(input.ResourcePopulation) == 0 {
+		return Obligation{}, fmt.Errorf("%w: controls, evidence requirements, and resource population are required", ErrInvalidReceipt)
+	}
+	obligation := Obligation{
+		SchemaVersion:        ObligationSchemaVersion,
+		TenantID:             input.TenantID,
+		ObligationID:         input.ObligationID,
+		Version:              input.Version,
+		Status:               status,
+		ContractRef:          input.ContractRef,
+		CommitmentRef:        input.CommitmentRef,
+		Controls:             input.Controls,
+		EvidenceRequirements: input.EvidenceRequirements,
+		ResourcePopulation:   input.ResourcePopulation,
+		OwnerID:              input.OwnerID,
+		Deadline:             utcTimePtr(input.Deadline),
+		SuggestedBy:          input.SuggestedBy,
+		ConfirmedBy:          approval,
+		PreviousDigest:       input.PreviousDigest,
+		IssuedAt:             input.IssuedAt.UTC(),
+	}
+	digest, err := digestValue(obligationWithoutDigest(obligation))
+	if err != nil {
+		return Obligation{}, err
+	}
+	obligation.Digest = digest
+	return obligation, nil
+}
+
+// ReadService reads caller-supplied current-state records. Persistence remains
+// owned by the existing state store and workflow event projection.
+type ReadService struct {
+	Receipts    []ClaimReceipt
+	Obligations []Obligation
+}
+
+func (service ReadService) GetReceipt(tenantID, receiptID string) (ClaimReceipt, error) {
+	tenantID = strings.TrimSpace(tenantID)
+	receiptID = strings.TrimSpace(receiptID)
+	for _, receipt := range service.Receipts {
+		if receipt.ReceiptID != receiptID {
+			continue
+		}
+		if receipt.TenantID != tenantID {
+			return ClaimReceipt{}, ErrTenantMismatch
+		}
+		if err := verifyReceipt(receipt); err != nil {
+			return ClaimReceipt{}, err
+		}
+		return receipt, nil
+	}
+	return ClaimReceipt{}, ErrReceiptNotFound
+}
+
+func (service ReadService) BuildPackage(request PackageRequest) (ClaimPackage, error) {
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.Audience = strings.TrimSpace(request.Audience)
+	request.ReceiptIDs = uniqueSortedStrings(request.ReceiptIDs)
+	request.ObligationIDs = uniqueSortedStrings(request.ObligationIDs)
+	if request.TenantID == "" || request.PackagedAt.IsZero() || (request.Audience != DisclosureCustomer && request.Audience != DisclosureAuditor) {
+		return ClaimPackage{}, fmt.Errorf("%w: tenant, customer or auditor audience, and packaged_at are required", ErrInvalidReceipt)
+	}
+	pack := ClaimPackage{SchemaVersion: PackageSchemaVersion, TenantID: request.TenantID, Audience: request.Audience, PackagedAt: request.PackagedAt.UTC()}
+	for _, id := range request.ReceiptIDs {
+		receipt, err := service.GetReceipt(request.TenantID, id)
+		if err != nil {
+			return ClaimPackage{}, err
+		}
+		if request.Audience == DisclosureAuditor && receipt.Status != ClaimStatusAuditorReady {
+			return ClaimPackage{}, fmt.Errorf("%w: receipt %s is not auditor ready", ErrNotShareable, id)
+		}
+		if request.Audience == DisclosureCustomer && receipt.Status != ClaimStatusShareable && receipt.Status != ClaimStatusAuditorReady {
+			return ClaimPackage{}, fmt.Errorf("%w: receipt %s is not customer shareable", ErrNotShareable, id)
+		}
+		if err := validateExternalEligibility(receipt, request.PackagedAt); err != nil {
+			return ClaimPackage{}, err
+		}
+		pack.Receipts = append(pack.Receipts, receipt)
+	}
+	for _, id := range request.ObligationIDs {
+		obligation, err := service.getObligation(request.TenantID, id)
+		if err != nil {
+			return ClaimPackage{}, err
+		}
+		if obligation.Status != ObligationActive {
+			return ClaimPackage{}, fmt.Errorf("%w: obligation %s is not active", ErrNotShareable, id)
+		}
+		pack.Obligations = append(pack.Obligations, obligation)
+	}
+	digest, err := digestValue(packageWithoutDigest(pack))
+	if err != nil {
+		return ClaimPackage{}, err
+	}
+	pack.Digest = digest
+	return pack, nil
+}
+
+func (service ReadService) getObligation(tenantID, obligationID string) (Obligation, error) {
+	for _, obligation := range service.Obligations {
+		if obligation.ObligationID != obligationID {
+			continue
+		}
+		if obligation.TenantID != tenantID {
+			return Obligation{}, ErrTenantMismatch
+		}
+		if err := verifyObligation(obligation); err != nil {
+			return Obligation{}, err
+		}
+		return obligation, nil
+	}
+	return Obligation{}, ErrObligationNotFound
+}
+
+func verifyReceipt(receipt ClaimReceipt) error {
+	if receipt.SchemaVersion != ReceiptSchemaVersion || receipt.Digest == "" {
+		return fmt.Errorf("%w: schema version and digest are required", ErrInvalidReceipt)
+	}
+	digest, err := digestValue(receiptWithoutDigest(receipt))
+	if err != nil {
+		return err
+	}
+	if digest != receipt.Digest {
+		return fmt.Errorf("%w: receipt digest does not match content", ErrInvalidReceipt)
+	}
+	return nil
+}
+
+func verifyObligation(obligation Obligation) error {
+	digest, err := digestValue(obligationWithoutDigest(obligation))
+	if err != nil {
+		return err
+	}
+	if obligation.SchemaVersion != ObligationSchemaVersion || obligation.Digest == "" || digest != obligation.Digest {
+		return fmt.Errorf("%w: obligation digest does not match content", ErrInvalidReceipt)
+	}
+	return nil
+}
+
+func normalizeReceiptInput(input *ReceiptInput) {
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.ReceiptID = strings.TrimSpace(input.ReceiptID)
+	input.ClaimID = strings.TrimSpace(input.ClaimID)
+	input.Statement = strings.TrimSpace(input.Statement)
+	input.Origin = strings.TrimSpace(input.Origin)
+	input.RequestedStatus = strings.TrimSpace(input.RequestedStatus)
+	input.DisclosureClass = strings.TrimSpace(input.DisclosureClass)
+	input.PreviousDigest = strings.TrimSpace(input.PreviousDigest)
+	if input.Version == 0 {
+		input.Version = 1
+	}
+	input.IssuedAt = input.IssuedAt.UTC()
+	input.UnsupportedClaims = uniqueSortedStrings(input.UnsupportedClaims)
+	normalizeCitations(input.Citations)
+	input.Controls = normalizeVersionedRefs(input.Controls)
+	input.Policies = normalizeVersionedRefs(input.Policies)
+	input.ResourceRefs = normalizeResourceRefs(input.ResourceRefs)
+	if input.Generation != nil {
+		normalizeGeneration(input.Generation)
+	}
+	if input.Approval != nil {
+		normalizeApproval(input.Approval)
+	}
+}
+
+func normalizeReceipt(receipt *ClaimReceipt) {
+	normalizeCitations(receipt.Citations)
+	receipt.Controls = normalizeVersionedRefs(receipt.Controls)
+	receipt.Policies = normalizeVersionedRefs(receipt.Policies)
+	receipt.ResourceRefs = normalizeResourceRefs(receipt.ResourceRefs)
+	receipt.UnsupportedClaims = uniqueSortedStrings(receipt.UnsupportedClaims)
+	receipt.IssuedAt = receipt.IssuedAt.UTC()
+}
+
+func normalizeCitations(citations []Citation) {
+	for index := range citations {
+		citation := &citations[index]
+		citation.ID = strings.TrimSpace(citation.ID)
+		citation.EvidenceID = strings.TrimSpace(citation.EvidenceID)
+		citation.EvidencePacketID = strings.TrimSpace(citation.EvidencePacketID)
+		citation.EvidenceType = strings.TrimSpace(citation.EvidenceType)
+		citation.SourceID = strings.TrimSpace(citation.SourceID)
+		citation.RuntimeID = strings.TrimSpace(citation.RuntimeID)
+		citation.State = strings.TrimSpace(citation.State)
+		citation.SourceEventIDs = uniqueSortedStrings(citation.SourceEventIDs)
+		citation.ResourceRefs = normalizeResourceRefs(citation.ResourceRefs)
+		citation.ObservedAt = citation.ObservedAt.UTC()
+		citation.ExpiresAt = utcTimePtr(citation.ExpiresAt)
+	}
+	sort.Slice(citations, func(i, j int) bool { return citations[i].ID < citations[j].ID })
+}
+
+func normalizeVersionedRefs(refs []VersionedRef) []VersionedRef {
+	result := append([]VersionedRef(nil), refs...)
+	for index := range result {
+		result[index].ID = strings.TrimSpace(result[index].ID)
+		result[index].Version = strings.TrimSpace(result[index].Version)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ID == result[j].ID {
+			return result[i].Version < result[j].Version
+		}
+		return result[i].ID < result[j].ID
+	})
+	return dedupeVersionedRefs(result)
+}
+
+func normalizeResourceRefs(refs []ResourceRef) []ResourceRef {
+	result := append([]ResourceRef(nil), refs...)
+	for index := range result {
+		result[index].URN = strings.TrimSpace(result[index].URN)
+		result[index].Revision = strings.TrimSpace(result[index].Revision)
+		result[index].Type = strings.TrimSpace(result[index].Type)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return resourceKey(result[i]) < resourceKey(result[j])
+	})
+	return dedupeResourceRefs(result)
+}
+
+func normalizeObligationInput(input *ObligationInput) {
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.ObligationID = strings.TrimSpace(input.ObligationID)
+	input.ContractRef = normalizeVersionedRefs([]VersionedRef{input.ContractRef})[0]
+	input.CommitmentRef = strings.TrimSpace(input.CommitmentRef)
+	input.Controls = normalizeVersionedRefs(input.Controls)
+	input.EvidenceRequirements = normalizeVersionedRefs(input.EvidenceRequirements)
+	input.ResourcePopulation = normalizeResourceRefs(input.ResourcePopulation)
+	input.OwnerID = strings.TrimSpace(input.OwnerID)
+	input.IssuedAt = input.IssuedAt.UTC()
+	input.PreviousDigest = strings.TrimSpace(input.PreviousDigest)
+	if input.Version == 0 {
+		input.Version = 1
+	}
+	if input.SuggestedBy != nil {
+		input.SuggestedBy.SourceRef = strings.TrimSpace(input.SuggestedBy.SourceRef)
+		input.SuggestedBy.ExtractorID = strings.TrimSpace(input.SuggestedBy.ExtractorID)
+		input.SuggestedBy.ModelVersion = strings.TrimSpace(input.SuggestedBy.ModelVersion)
+		input.SuggestedBy.PromptVersion = strings.TrimSpace(input.SuggestedBy.PromptVersion)
+	}
+}
+
+func normalizeObligation(obligation *Obligation) {
+	obligation.Controls = normalizeVersionedRefs(obligation.Controls)
+	obligation.EvidenceRequirements = normalizeVersionedRefs(obligation.EvidenceRequirements)
+	obligation.ResourcePopulation = normalizeResourceRefs(obligation.ResourcePopulation)
+	obligation.IssuedAt = obligation.IssuedAt.UTC()
+}
+
+func normalizeGeneration(generation *GenerationReceipt) {
+	generation.ModelID = strings.TrimSpace(generation.ModelID)
+	generation.ModelVersion = strings.TrimSpace(generation.ModelVersion)
+	generation.PromptVersion = strings.TrimSpace(generation.PromptVersion)
+	generation.PromptDigest = strings.TrimSpace(generation.PromptDigest)
+}
+
+func normalizeApproval(approval *ReviewerApproval) {
+	approval.ReviewerID = strings.TrimSpace(approval.ReviewerID)
+	approval.Decision = strings.TrimSpace(approval.Decision)
+	approval.Reason = strings.TrimSpace(approval.Reason)
+	approval.ApprovedAt = approval.ApprovedAt.UTC()
+}
+
+func uniqueSortedStrings(values []string) []string {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func dedupeVersionedRefs(refs []VersionedRef) []VersionedRef {
+	result := refs[:0]
+	last := ""
+	for _, ref := range refs {
+		key := ref.ID + "\x00" + ref.Version
+		if ref.ID == "" || ref.Version == "" || key == last {
+			continue
+		}
+		result = append(result, ref)
+		last = key
+	}
+	return result
+}
+
+func dedupeResourceRefs(refs []ResourceRef) []ResourceRef {
+	result := refs[:0]
+	last := ""
+	for _, ref := range refs {
+		key := resourceKey(ref)
+		if ref.URN == "" || key == last {
+			continue
+		}
+		result = append(result, ref)
+		last = key
+	}
+	return result
+}
+
+func resourceKey(ref ResourceRef) string { return ref.URN + "\x00" + ref.Revision + "\x00" + ref.Type }
+func utcTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalized := value.UTC()
+	return &normalized
+}
+func isExternalStatus(status string) bool {
+	return status == ClaimStatusShareable || status == ClaimStatusAuditorReady
+}
+
+func digestValue(value any) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("canonical receipt encoding: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func receiptWithoutDigest(receipt ClaimReceipt) ClaimReceipt { receipt.Digest = ""; return receipt }
+func obligationWithoutDigest(obligation Obligation) Obligation {
+	obligation.Digest = ""
+	return obligation
+}
+func packageWithoutDigest(pack ClaimPackage) ClaimPackage { pack.Digest = ""; return pack }

--- a/internal/trustclaims/service.go
+++ b/internal/trustclaims/service.go
@@ -578,7 +578,8 @@ func normalizeResourceRefs(refs []ResourceRef) []ResourceRef {
 func normalizeObligationInput(input *ObligationInput) {
 	input.TenantID = strings.TrimSpace(input.TenantID)
 	input.ObligationID = strings.TrimSpace(input.ObligationID)
-	input.ContractRef = normalizeVersionedRefs([]VersionedRef{input.ContractRef})[0]
+	input.ContractRef.ID = strings.TrimSpace(input.ContractRef.ID)
+	input.ContractRef.Version = strings.TrimSpace(input.ContractRef.Version)
 	input.CommitmentRef = strings.TrimSpace(input.CommitmentRef)
 	input.Controls = normalizeVersionedRefs(input.Controls)
 	input.EvidenceRequirements = normalizeVersionedRefs(input.EvidenceRequirements)

--- a/internal/trustclaims/service_test.go
+++ b/internal/trustclaims/service_test.go
@@ -229,6 +229,14 @@ func TestExtractedObligationRequiresHumanConfirmationAndPreservesSupersession(t 
 	}
 }
 
+func TestInvalidObligationContractReturnsError(t *testing.T) {
+	input := validObligationInput(fixedTime())
+	input.ContractRef = VersionedRef{}
+	if _, err := SuggestObligation(input); !errors.Is(err, ErrInvalidReceipt) {
+		t.Fatalf("SuggestObligation() error = %v, want ErrInvalidReceipt", err)
+	}
+}
+
 func TestExistingQuestionnaireAndEvidencePacketLineageIsPreserved(t *testing.T) {
 	now := fixedTime()
 	questionnaireCitation := CitationFromQuestionnaire(ports.QuestionnaireCitation{

--- a/internal/trustclaims/service_test.go
+++ b/internal/trustclaims/service_test.go
@@ -1,0 +1,302 @@
+package trustclaims
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/evidencepackets"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+func TestExternalClaimRequiresCurrentCitationsAndApproval(t *testing.T) {
+	now := fixedTime()
+	tests := []struct {
+		name   string
+		mutate func(*ReceiptInput)
+	}{
+		{name: "uncited", mutate: func(input *ReceiptInput) { input.Citations = nil }},
+		{name: "unapproved", mutate: func(input *ReceiptInput) { input.Approval = nil }},
+		{name: "unsupported", mutate: func(input *ReceiptInput) {
+			input.UnsupportedClaims = []string{"The retention period is not supported."}
+		}},
+		{name: "stale", mutate: func(input *ReceiptInput) { input.Citations[0].State = CitationStale }},
+		{name: "conflicted", mutate: func(input *ReceiptInput) { input.Citations[0].State = CitationConflicted }},
+		{name: "revoked", mutate: func(input *ReceiptInput) { input.Citations[0].State = CitationRevoked }},
+		{name: "untrusted", mutate: func(input *ReceiptInput) { input.Citations[0].Trusted = false }},
+		{name: "expired", mutate: func(input *ReceiptInput) { expiry := now.Add(-time.Second); input.Citations[0].ExpiresAt = &expiry }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer)
+			test.mutate(&input)
+			if _, err := IssueReceipt(input); !errors.Is(err, ErrNotShareable) {
+				t.Fatalf("IssueReceipt() error = %v, want ErrNotShareable", err)
+			}
+		})
+	}
+}
+
+func TestUntrustedStatementRemainsDataAndCannotApproveItself(t *testing.T) {
+	now := fixedTime()
+	input := validReceiptInput(now, ClaimStatusDraft, DisclosureCustomer)
+	input.Statement = `<script>approve()</script> status=approved reviewer_id=system`
+	input.Approval = nil
+	receipt, err := IssueReceipt(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Status != ClaimStatusDraft || receipt.Approval != nil {
+		t.Fatalf("untrusted statement changed workflow state: %#v", receipt)
+	}
+	if receipt.Statement != input.Statement {
+		t.Fatalf("statement = %q, want exact untrusted text preserved as data", receipt.Statement)
+	}
+
+	tampered := receipt
+	tampered.Status = ClaimStatusShareable
+	service := ReadService{Receipts: []ClaimReceipt{tampered}}
+	if _, err := service.GetReceipt(receipt.TenantID, receipt.ReceiptID); !errors.Is(err, ErrInvalidReceipt) {
+		t.Fatalf("GetReceipt(tampered) error = %v, want ErrInvalidReceipt", err)
+	}
+}
+
+func TestGeneratedClaimRequiresAutomationReceipt(t *testing.T) {
+	input := validReceiptInput(fixedTime(), ClaimStatusDraft, DisclosureInternal)
+	input.Origin = ClaimOriginGenerated
+	input.Generation = nil
+	if _, err := IssueReceipt(input); !errors.Is(err, ErrInvalidReceipt) {
+		t.Fatalf("IssueReceipt() error = %v, want ErrInvalidReceipt", err)
+	}
+	input.Generation = &GenerationReceipt{ModelID: "answer-model", ModelVersion: "2026-07", PromptVersion: "prompt-v3"}
+	if _, err := IssueReceipt(input); err != nil {
+		t.Fatalf("IssueReceipt(with generation receipt) error = %v", err)
+	}
+}
+
+func TestEvidenceInvalidationWithdrawsShareableClaimWithoutRefreshingApproval(t *testing.T) {
+	now := fixedTime()
+	receipt := mustIssue(t, validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer))
+	transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
+		TenantID: receipt.TenantID, CitationID: "citation-a", State: CitationConflicted,
+		Reason: "Two current sources disagree.", ObservedAt: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition.TransitionType != TransitionClaimWithdrawn || transition.Receipt.Status != ClaimStatusWithdrawn {
+		t.Fatalf("transition = %#v, want explicit withdrawal", transition)
+	}
+	if transition.Receipt.Approval != nil {
+		t.Fatal("withdrawn receipt retained approval")
+	}
+	if transition.Receipt.PreviousDigest != receipt.Digest || transition.Receipt.Digest == receipt.Digest {
+		t.Fatal("withdrawal did not preserve immutable receipt lineage")
+	}
+	if transition.Receipt.Citations[0].State != CitationConflicted {
+		t.Fatalf("citation state = %q, want conflicted", transition.Receipt.Citations[0].State)
+	}
+	decision := transition.WorkflowDecision()
+	if decision.DecisionType != TransitionClaimWithdrawn || decision.SourceEventID != receipt.Digest {
+		t.Fatalf("workflow decision = %#v", decision)
+	}
+	if _, err := workflowevents.NewDecisionRecordedEvent(decision); err != nil {
+		t.Fatalf("NewDecisionRecordedEvent() error = %v", err)
+	}
+}
+
+func TestEvidenceInvalidationReopensDraftClaim(t *testing.T) {
+	now := fixedTime()
+	receipt := mustIssue(t, validReceiptInput(now, ClaimStatusDraft, DisclosureInternal))
+	transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
+		TenantID: receipt.TenantID, CitationID: "citation-a", State: CitationRevoked,
+		Reason: "Source retracted the record.", ObservedAt: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition.TransitionType != TransitionClaimReopened || transition.Receipt.Status != ClaimStatusReopened {
+		t.Fatalf("transition = %#v, want reopened", transition)
+	}
+}
+
+func TestExpiryEmitsWithdrawal(t *testing.T) {
+	now := fixedTime()
+	input := validReceiptInput(now, ClaimStatusAuditorReady, DisclosureAuditor)
+	expires := now.Add(time.Hour)
+	input.Citations[0].ExpiresAt = &expires
+	receipt := mustIssue(t, input)
+
+	transition, err := ReconcileExpiry(receipt, expires.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition == nil || transition.TransitionType != TransitionClaimWithdrawn || transition.Receipt.Status != ClaimStatusWithdrawn {
+		t.Fatalf("transition = %#v, want withdrawal", transition)
+	}
+}
+
+func TestSupersededClaimCannotBePackaged(t *testing.T) {
+	now := fixedTime()
+	receipt := mustIssue(t, validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer))
+	transition, err := SupersedeReceipt(receipt, "receipt-b", now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := ReadService{Receipts: []ClaimReceipt{transition.Receipt}}
+	_, err = service.BuildPackage(PackageRequest{
+		TenantID: receipt.TenantID, Audience: DisclosureCustomer, ReceiptIDs: []string{receipt.ReceiptID}, PackagedAt: now.Add(2 * time.Hour),
+	})
+	if !errors.Is(err, ErrNotShareable) {
+		t.Fatalf("BuildPackage() error = %v, want ErrNotShareable", err)
+	}
+}
+
+func TestReceiptAndPackageDigestsAreDeterministic(t *testing.T) {
+	now := fixedTime()
+	first := validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer)
+	first.Citations = append(first.Citations, validCitation("citation-b", now))
+	first.Controls = []VersionedRef{{ID: "control-b", Version: "2"}, {ID: "control-a", Version: "1"}}
+	first.ResourceRefs = []ResourceRef{{URN: "urn:resource:b", Revision: "2"}, {URN: "urn:resource:a", Revision: "1"}}
+	second := first
+	second.Citations = []Citation{first.Citations[1], first.Citations[0]}
+	second.Controls = []VersionedRef{first.Controls[1], first.Controls[0]}
+	second.ResourceRefs = []ResourceRef{first.ResourceRefs[1], first.ResourceRefs[0]}
+
+	receiptA := mustIssue(t, first)
+	receiptB := mustIssue(t, second)
+	if receiptA.Digest != receiptB.Digest {
+		t.Fatalf("deterministic digests differ: %s != %s", receiptA.Digest, receiptB.Digest)
+	}
+	serviceA := ReadService{Receipts: []ClaimReceipt{receiptA}}
+	serviceB := ReadService{Receipts: []ClaimReceipt{receiptB}}
+	request := PackageRequest{TenantID: receiptA.TenantID, Audience: DisclosureCustomer, ReceiptIDs: []string{receiptA.ReceiptID}, PackagedAt: now.Add(time.Minute)}
+	packA, err := serviceA.BuildPackage(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packB, err := serviceB.BuildPackage(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packA.Digest != packB.Digest {
+		t.Fatalf("package digests differ: %s != %s", packA.Digest, packB.Digest)
+	}
+}
+
+func TestReadServiceEnforcesTenantIsolation(t *testing.T) {
+	receipt := mustIssue(t, validReceiptInput(fixedTime(), ClaimStatusShareable, DisclosureCustomer))
+	service := ReadService{Receipts: []ClaimReceipt{receipt}}
+	if _, err := service.GetReceipt("tenant-b", receipt.ReceiptID); !errors.Is(err, ErrTenantMismatch) {
+		t.Fatalf("GetReceipt() error = %v, want ErrTenantMismatch", err)
+	}
+	if _, err := service.BuildPackage(PackageRequest{TenantID: "tenant-b", Audience: DisclosureCustomer, ReceiptIDs: []string{receipt.ReceiptID}, PackagedAt: fixedTime().Add(time.Minute)}); !errors.Is(err, ErrTenantMismatch) {
+		t.Fatalf("BuildPackage() error = %v, want ErrTenantMismatch", err)
+	}
+}
+
+func TestExtractedObligationRequiresHumanConfirmationAndPreservesSupersession(t *testing.T) {
+	now := fixedTime()
+	suggestion, err := SuggestObligation(validObligationInput(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := ReadService{Obligations: []Obligation{suggestion}}
+	if _, err := service.BuildPackage(PackageRequest{TenantID: suggestion.TenantID, Audience: DisclosureCustomer, ObligationIDs: []string{suggestion.ObligationID}, PackagedAt: now.Add(time.Minute)}); !errors.Is(err, ErrNotShareable) {
+		t.Fatalf("BuildPackage(suggestion) error = %v, want ErrNotShareable", err)
+	}
+	if _, err := ConfirmObligation(suggestion, ReviewerApproval{}, now.Add(time.Minute)); !errors.Is(err, ErrHumanConfirmationRequired) {
+		t.Fatalf("ConfirmObligation() error = %v, want ErrHumanConfirmationRequired", err)
+	}
+	confirmed, err := ConfirmObligation(suggestion, ReviewerApproval{ReviewerID: "reviewer-1", Decision: ApprovalApproved, ApprovedAt: now.Add(time.Minute)}, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if confirmed.Status != ObligationActive || confirmed.PreviousDigest != suggestion.Digest || confirmed.ConfirmedBy == nil {
+		t.Fatalf("confirmed obligation = %#v", confirmed)
+	}
+	service.Obligations = []Obligation{confirmed}
+	if _, err := service.BuildPackage(PackageRequest{TenantID: confirmed.TenantID, Audience: DisclosureCustomer, ObligationIDs: []string{confirmed.ObligationID}, PackagedAt: now.Add(2 * time.Minute)}); err != nil {
+		t.Fatalf("BuildPackage(confirmed) error = %v", err)
+	}
+	superseded, err := SupersedeObligation(confirmed, "obligation-b", now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if superseded.Status != ObligationSuperseded || superseded.SupersededBy != "obligation-b" || superseded.PreviousDigest != confirmed.Digest {
+		t.Fatalf("superseded obligation = %#v", superseded)
+	}
+}
+
+func TestExistingQuestionnaireAndEvidencePacketLineageIsPreserved(t *testing.T) {
+	now := fixedTime()
+	questionnaireCitation := CitationFromQuestionnaire(ports.QuestionnaireCitation{
+		ID: "citation-questionnaire", Source: "directory", EvidenceID: "evidence-a",
+		ResourceURN: "urn:resource:a", SourceEventIDs: []string{"event-b", "event-a"},
+		FreshnessStatus: "current", ObservedAt: now.Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano),
+	}, true)
+	if questionnaireCitation.State != CitationCurrent || questionnaireCitation.SourceID != "directory" || len(questionnaireCitation.ResourceRefs) != 1 {
+		t.Fatalf("questionnaire citation = %#v", questionnaireCitation)
+	}
+	packetCitation := CitationFromEvidencePacket(evidencepackets.QuestionnaireEvidenceRef{
+		ID: "evidence-b", SourceID: "directory", EvidencePacketID: "packet-a",
+		SourceEventIDs: []string{"event-a"}, GraphRootURNs: []string{"urn:resource:a"},
+		Freshness: evidencepackets.EvidenceFreshness{Status: "current", ObservedAt: now.Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano)},
+	}, true)
+	if packetCitation.State != CitationCurrent || packetCitation.EvidencePacketID != "packet-a" || packetCitation.SourceEventIDs[0] != "event-a" {
+		t.Fatalf("evidence-packet citation = %#v", packetCitation)
+	}
+}
+
+func validReceiptInput(now time.Time, status, disclosure string) ReceiptInput {
+	expires := now.Add(24 * time.Hour)
+	return ReceiptInput{
+		TenantID: "tenant-a", ReceiptID: "receipt-a", ClaimID: "claim-a", Version: 1,
+		Statement: "Administrative access requires a second authentication factor.", Origin: ClaimOriginAuthored,
+		RequestedStatus: status, DisclosureClass: disclosure,
+		Citations:    []Citation{validCitation("citation-a", now)},
+		Controls:     []VersionedRef{{ID: "control-access", Version: "3"}},
+		Policies:     []VersionedRef{{ID: "policy-access", Version: "7"}},
+		ResourceRefs: []ResourceRef{{URN: "urn:resource:identity-population", Revision: "42", Type: "identity_population"}},
+		Approval:     &ReviewerApproval{ReviewerID: "reviewer-1", Decision: ApprovalApproved, ApprovedAt: now},
+		FreshUntil:   &expires, ExpiresAt: &expires, IssuedAt: now,
+	}
+}
+
+func validCitation(id string, now time.Time) Citation {
+	expires := now.Add(24 * time.Hour)
+	return Citation{
+		ID: id, EvidenceID: "evidence-" + id, EvidencePacketID: "packet-a", EvidenceType: "configuration",
+		SourceID: "identity-source", RuntimeID: "runtime-a", SourceEventIDs: []string{"event-b", "event-a"},
+		ResourceRefs: []ResourceRef{{URN: "urn:resource:identity-population", Revision: "42"}},
+		State:        CitationCurrent, Trusted: true, ObservedAt: now.Add(-time.Minute), ExpiresAt: &expires,
+	}
+}
+
+func validObligationInput(now time.Time) ObligationInput {
+	deadline := now.Add(30 * 24 * time.Hour)
+	return ObligationInput{
+		TenantID: "tenant-a", ObligationID: "obligation-a", Version: 1,
+		ContractRef: VersionedRef{ID: "contract-a", Version: "signed-4"}, CommitmentRef: "section-4.2",
+		Controls:             []VersionedRef{{ID: "control-access", Version: "3"}},
+		EvidenceRequirements: []VersionedRef{{ID: "requirement-access-review", Version: "2"}},
+		ResourcePopulation:   []ResourceRef{{URN: "urn:resource:identity-population", Revision: "42"}},
+		OwnerID:              "owner-1", Deadline: &deadline,
+		SuggestedBy: &ExtractionReceipt{SourceRef: "contract-a#section-4.2", ExtractorID: "commitment-extractor", ModelVersion: "2026-07", PromptVersion: "prompt-v2"},
+		IssuedAt:    now,
+	}
+}
+
+func mustIssue(t *testing.T, input ReceiptInput) ClaimReceipt {
+	t.Helper()
+	receipt, err := IssueReceipt(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+func fixedTime() time.Time {
+	return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+}


### PR DESCRIPTION
## Summary

- add immutable, versioned receipts for factual claims with exact evidence, source-event, resource-revision, control, policy, freshness, expiry, generation, unsupported-claim, approval, and disclosure lineage
- fail closed when an external claim lacks current trusted citations or reviewer approval, and produce explicit withdrawal, reopen, and supersession transitions through the existing workflow decision contract
- add human-confirmed commitment obligations and tenant-scoped read/package contracts without adding a store, provider I/O, UI behavior, or autonomous mutation

## Validation

- `go test ./internal/trustclaims ./internal/questionnaire ./internal/evidencepackets ./internal/workflowevents -count=1`
- `go test -race ./internal/trustclaims -count=1`
- `go vet ./internal/trustclaims`
- `golangci-lint run ./internal/trustclaims/...`
- `make check-structural check-structural-test check-arch`
- `make contracts-check`