### PR TITLE
Add trust receipts and bitemporal compliance truth

### DIFF
--- a/internal/compliancetruth/model.go
+++ b/internal/compliancetruth/model.go
@@ -1,0 +1,146 @@
+package compliancetruth
+
+import (
+	"time"
+
+	"github.com/writer/cerebro/internal/trustclaims"
+)
+
+const (
+	RevisionSchemaVersion     = "compliance-truth-revision.v1"
+	SupersessionSchemaVersion = "compliance-truth-supersession.v1"
+	ResolutionSchemaVersion   = "compliance-conflict-resolution.v1"
+
+	PositionSupports = "supports"
+	PositionRefutes  = "refutes"
+
+	EvaluationUnknown    = "unknown"
+	EvaluationQualified  = "qualified"
+	EvaluationConflicted = "conflicted"
+
+	ConflictValueDisagreement = "value_disagreement"
+	ConflictClaimMissing      = "claim_missing"
+	ConflictClaimState        = "claim_state"
+	ConflictCitationState     = "citation_state"
+
+	ResolutionAcceptRevision = "accept_revision"
+)
+
+type Interval struct {
+	From time.Time  `json:"from"`
+	To   *time.Time `json:"to,omitempty"`
+}
+
+// TruthRevision is one immutable assertion revision. ValidTime describes when
+// the assertion applies; RecordedTime describes when Cerebro learned it.
+type TruthRevision struct {
+	SchemaVersion  string                  `json:"schema_version"`
+	TenantID       string                  `json:"tenant_id"`
+	AssertionID    string                  `json:"assertion_id"`
+	RevisionID     string                  `json:"revision_id"`
+	Version        int                     `json:"version"`
+	Subject        trustclaims.ResourceRef `json:"subject"`
+	Predicate      string                  `json:"predicate"`
+	Value          string                  `json:"value"`
+	ValidTime      Interval                `json:"valid_time"`
+	RecordedTime   Interval                `json:"recorded_time"`
+	ClaimBindings  []ClaimBinding          `json:"claim_bindings"`
+	PreviousDigest string                  `json:"previous_digest,omitempty"`
+	Digest         string                  `json:"digest"`
+}
+
+type ClaimBinding struct {
+	ReceiptID     string `json:"receipt_id"`
+	ReceiptDigest string `json:"receipt_digest"`
+	Position      string `json:"position"`
+}
+
+type RevisionInput struct {
+	TenantID      string
+	AssertionID   string
+	RevisionID    string
+	Version       int
+	Subject       trustclaims.ResourceRef
+	Predicate     string
+	Value         string
+	ValidTime     Interval
+	RecordedAt    time.Time
+	ClaimBindings []ClaimBinding
+}
+
+// SupersessionReceipt closes a prior revision's recorded-time interval without
+// mutating that prior revision.
+type SupersessionReceipt struct {
+	SchemaVersion   string    `json:"schema_version"`
+	TenantID        string    `json:"tenant_id"`
+	AssertionID     string    `json:"assertion_id"`
+	PriorDigest     string    `json:"prior_digest"`
+	SuccessorDigest string    `json:"successor_digest"`
+	RecordedAt      time.Time `json:"recorded_at"`
+	Digest          string    `json:"digest"`
+}
+
+type Conflict struct {
+	ID               string   `json:"id"`
+	Kind             string   `json:"kind"`
+	InputDigests     []string `json:"input_digests"`
+	Values           []string `json:"values,omitempty"`
+	CitationIDs      []string `json:"citation_ids,omitempty"`
+	Reason           string   `json:"reason"`
+	Resolvable       bool     `json:"resolvable"`
+	ResolutionDigest string   `json:"resolution_digest,omitempty"`
+}
+
+type ConflictResolutionReceipt struct {
+	SchemaVersion          string                       `json:"schema_version"`
+	TenantID               string                       `json:"tenant_id"`
+	AssertionID            string                       `json:"assertion_id"`
+	ConflictID             string                       `json:"conflict_id"`
+	InputDigests           []string                     `json:"input_digests"`
+	Decision               string                       `json:"decision"`
+	SelectedRevisionDigest string                       `json:"selected_revision_digest"`
+	Reviewer               trustclaims.ReviewerApproval `json:"reviewer"`
+	RecordedAt             time.Time                    `json:"recorded_at"`
+	Digest                 string                       `json:"digest"`
+}
+
+type ResolutionInput struct {
+	TenantID               string
+	AssertionID            string
+	ConflictID             string
+	InputDigests           []string
+	Decision               string
+	SelectedRevisionDigest string
+	Reviewer               trustclaims.ReviewerApproval
+	RecordedAt             time.Time
+}
+
+type Ledger struct {
+	Revisions     []TruthRevision
+	Supersessions []SupersessionReceipt
+	Resolutions   []ConflictResolutionReceipt
+	Claims        []trustclaims.ClaimReceipt
+}
+
+type EvaluationQuery struct {
+	TenantID    string
+	AssertionID string
+	AsKnownAt   time.Time
+	EffectiveAt time.Time
+}
+
+type TruthEvaluation struct {
+	TenantID           string     `json:"tenant_id"`
+	AssertionID        string     `json:"assertion_id"`
+	AsKnownAt          time.Time  `json:"as_known_at"`
+	EffectiveAt        time.Time  `json:"effective_at"`
+	State              string     `json:"state"`
+	Qualified          bool       `json:"qualified"`
+	Shareable          bool       `json:"shareable"`
+	Value              string     `json:"value,omitempty"`
+	RevisionDigests    []string   `json:"revision_digests,omitempty"`
+	Conflicts          []Conflict `json:"conflicts,omitempty"`
+	ResolvedConflicts  []Conflict `json:"resolved_conflicts,omitempty"`
+	ResolutionReceipts []string   `json:"resolution_receipts,omitempty"`
+	Digest             string     `json:"digest"`
+}

--- a/internal/compliancetruth/service.go
+++ b/internal/compliancetruth/service.go
@@ -172,6 +172,10 @@ func Evaluate(ledger Ledger, query EvaluationQuery) (TruthEvaluation, error) {
 			evaluation.ResolvedConflicts = append(evaluation.ResolvedConflicts, *valueConflict)
 			evaluation.ResolutionReceipts = append(evaluation.ResolutionReceipts, resolution.Digest)
 			candidates = filterRevision(candidates, resolution.SelectedRevisionDigest)
+			blocking, err = claimConflicts(ledger.Claims, candidates, query)
+			if err != nil {
+				return TruthEvaluation{}, err
+			}
 		}
 	}
 	blocking = normalizeConflicts(blocking)

--- a/internal/compliancetruth/service.go
+++ b/internal/compliancetruth/service.go
@@ -1,0 +1,587 @@
+package compliancetruth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/trustclaims"
+)
+
+var (
+	ErrInvalidTruthRecord = errors.New("invalid compliance truth record")
+	ErrTenantMismatch     = errors.New("tenant mismatch")
+	ErrUnresolvedConflict = errors.New("unresolved compliance truth conflict")
+)
+
+func IssueRevision(input RevisionInput) (TruthRevision, error) {
+	normalizeRevisionInput(&input)
+	if err := validateRevisionInput(input); err != nil {
+		return TruthRevision{}, err
+	}
+	revision := TruthRevision{
+		SchemaVersion: RevisionSchemaVersion,
+		TenantID:      input.TenantID,
+		AssertionID:   input.AssertionID,
+		RevisionID:    input.RevisionID,
+		Version:       input.Version,
+		Subject:       input.Subject,
+		Predicate:     input.Predicate,
+		Value:         input.Value,
+		ValidTime:     input.ValidTime,
+		RecordedTime:  Interval{From: input.RecordedAt},
+		ClaimBindings: input.ClaimBindings,
+	}
+	digest, err := digestValue(revisionWithoutDigest(revision))
+	if err != nil {
+		return TruthRevision{}, err
+	}
+	revision.Digest = digest
+	return revision, nil
+}
+
+// CorrectRevision creates a late-arriving successor and a separate receipt
+// that closes the prior recorded-time interval. The prior revision is unchanged.
+func CorrectRevision(previous TruthRevision, input RevisionInput) (TruthRevision, SupersessionReceipt, error) {
+	if err := verifyRevision(previous); err != nil {
+		return TruthRevision{}, SupersessionReceipt{}, err
+	}
+	normalizeRevisionInput(&input)
+	if input.TenantID != previous.TenantID {
+		return TruthRevision{}, SupersessionReceipt{}, ErrTenantMismatch
+	}
+	if input.AssertionID != previous.AssertionID || !sameSubject(input.Subject, previous.Subject) || input.Predicate != previous.Predicate {
+		return TruthRevision{}, SupersessionReceipt{}, fmt.Errorf("%w: correction must preserve assertion identity", ErrInvalidTruthRecord)
+	}
+	if !input.RecordedAt.After(previous.RecordedTime.From) {
+		return TruthRevision{}, SupersessionReceipt{}, fmt.Errorf("%w: correction must be recorded after the prior revision", ErrInvalidTruthRecord)
+	}
+	input.Version = previous.Version + 1
+	successor, err := IssueRevision(input)
+	if err != nil {
+		return TruthRevision{}, SupersessionReceipt{}, err
+	}
+	successor.PreviousDigest = previous.Digest
+	digest, err := digestValue(revisionWithoutDigest(successor))
+	if err != nil {
+		return TruthRevision{}, SupersessionReceipt{}, err
+	}
+	successor.Digest = digest
+	receipt := SupersessionReceipt{
+		SchemaVersion:   SupersessionSchemaVersion,
+		TenantID:        previous.TenantID,
+		AssertionID:     previous.AssertionID,
+		PriorDigest:     previous.Digest,
+		SuccessorDigest: successor.Digest,
+		RecordedAt:      input.RecordedAt.UTC(),
+	}
+	receiptDigest, err := digestValue(supersessionWithoutDigest(receipt))
+	if err != nil {
+		return TruthRevision{}, SupersessionReceipt{}, err
+	}
+	receipt.Digest = receiptDigest
+	return successor, receipt, nil
+}
+
+func ResolveConflict(input ResolutionInput) (ConflictResolutionReceipt, error) {
+	normalizeResolutionInput(&input)
+	if input.TenantID == "" || input.AssertionID == "" || input.ConflictID == "" || input.RecordedAt.IsZero() {
+		return ConflictResolutionReceipt{}, fmt.Errorf("%w: resolution identity and recorded time are required", ErrInvalidTruthRecord)
+	}
+	if input.Decision != ResolutionAcceptRevision || len(input.InputDigests) < 2 || !contains(input.InputDigests, input.SelectedRevisionDigest) {
+		return ConflictResolutionReceipt{}, fmt.Errorf("%w: resolution must select one exact conflicting revision", ErrInvalidTruthRecord)
+	}
+	if input.Reviewer.Decision != trustclaims.ApprovalApproved || input.Reviewer.ReviewerID == "" || input.Reviewer.ApprovedAt.IsZero() || input.Reviewer.ApprovedAt.After(input.RecordedAt) {
+		return ConflictResolutionReceipt{}, fmt.Errorf("%w: reviewer approval must precede the recorded resolution", ErrInvalidTruthRecord)
+	}
+	receipt := ConflictResolutionReceipt{
+		SchemaVersion:          ResolutionSchemaVersion,
+		TenantID:               input.TenantID,
+		AssertionID:            input.AssertionID,
+		ConflictID:             input.ConflictID,
+		InputDigests:           input.InputDigests,
+		Decision:               input.Decision,
+		SelectedRevisionDigest: input.SelectedRevisionDigest,
+		Reviewer:               input.Reviewer,
+		RecordedAt:             input.RecordedAt.UTC(),
+	}
+	digest, err := digestValue(resolutionWithoutDigest(receipt))
+	if err != nil {
+		return ConflictResolutionReceipt{}, err
+	}
+	receipt.Digest = digest
+	return receipt, nil
+}
+
+func Evaluate(ledger Ledger, query EvaluationQuery) (TruthEvaluation, error) {
+	normalizeQuery(&query)
+	if query.TenantID == "" || query.AssertionID == "" || query.AsKnownAt.IsZero() || query.EffectiveAt.IsZero() {
+		return TruthEvaluation{}, fmt.Errorf("%w: tenant, assertion, as-known-at, and effective-at are required", ErrInvalidTruthRecord)
+	}
+	closures, err := supersessionClosures(ledger, query)
+	if err != nil {
+		return TruthEvaluation{}, err
+	}
+	candidates := []TruthRevision{}
+	for _, revision := range ledger.Revisions {
+		if strings.TrimSpace(revision.AssertionID) != query.AssertionID {
+			continue
+		}
+		if revision.TenantID != query.TenantID {
+			return TruthEvaluation{}, ErrTenantMismatch
+		}
+		if err := verifyRevision(revision); err != nil {
+			return TruthEvaluation{}, err
+		}
+		if !intervalContains(revision.ValidTime, query.EffectiveAt) || !recordedAtContains(revision, closures[revision.Digest], query.AsKnownAt) {
+			continue
+		}
+		candidates = append(candidates, revision)
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Digest < candidates[j].Digest })
+	evaluation := TruthEvaluation{
+		TenantID:    query.TenantID,
+		AssertionID: query.AssertionID,
+		AsKnownAt:   query.AsKnownAt,
+		EffectiveAt: query.EffectiveAt,
+		State:       EvaluationUnknown,
+	}
+	if len(candidates) == 0 {
+		return finishEvaluation(evaluation)
+	}
+
+	blocking, err := claimConflicts(ledger.Claims, candidates, query)
+	if err != nil {
+		return TruthEvaluation{}, err
+	}
+	valueConflict := conflictingValues(candidates)
+	if valueConflict != nil {
+		resolution, err := matchingResolution(ledger.Resolutions, query, *valueConflict)
+		if err != nil {
+			return TruthEvaluation{}, err
+		}
+		if resolution == nil {
+			blocking = append(blocking, *valueConflict)
+		} else {
+			valueConflict.ResolutionDigest = resolution.Digest
+			evaluation.ResolvedConflicts = append(evaluation.ResolvedConflicts, *valueConflict)
+			evaluation.ResolutionReceipts = append(evaluation.ResolutionReceipts, resolution.Digest)
+			candidates = filterRevision(candidates, resolution.SelectedRevisionDigest)
+		}
+	}
+	blocking = normalizeConflicts(blocking)
+	evaluation.RevisionDigests = revisionDigests(candidates)
+	evaluation.Conflicts = blocking
+	if len(blocking) != 0 {
+		evaluation.State = EvaluationConflicted
+		return finishEvaluation(evaluation)
+	}
+	values := revisionValues(candidates)
+	if len(values) != 1 {
+		return TruthEvaluation{}, ErrUnresolvedConflict
+	}
+	evaluation.State = EvaluationQualified
+	evaluation.Qualified = true
+	evaluation.Shareable = true
+	evaluation.Value = values[0]
+	return finishEvaluation(evaluation)
+}
+
+func validateRevisionInput(input RevisionInput) error {
+	if input.TenantID == "" || input.AssertionID == "" || input.RevisionID == "" || input.Version < 1 || input.Subject.URN == "" || input.Subject.Revision == "" || input.Predicate == "" || input.Value == "" || input.RecordedAt.IsZero() {
+		return fmt.Errorf("%w: revision identity, versioned subject, predicate, value, and recorded time are required", ErrInvalidTruthRecord)
+	}
+	if err := validateInterval(input.ValidTime); err != nil {
+		return err
+	}
+	if len(input.ClaimBindings) == 0 {
+		return fmt.Errorf("%w: at least one exact claim receipt binding is required", ErrInvalidTruthRecord)
+	}
+	for _, binding := range input.ClaimBindings {
+		if binding.ReceiptID == "" || binding.ReceiptDigest == "" || (binding.Position != PositionSupports && binding.Position != PositionRefutes) {
+			return fmt.Errorf("%w: claim bindings require receipt id, digest, and position", ErrInvalidTruthRecord)
+		}
+	}
+	return nil
+}
+
+func supersessionClosures(ledger Ledger, query EvaluationQuery) (map[string]time.Time, error) {
+	closures := map[string]time.Time{}
+	successors := map[string]string{}
+	revisions := map[string]TruthRevision{}
+	for _, revision := range ledger.Revisions {
+		if revision.AssertionID != query.AssertionID {
+			continue
+		}
+		if revision.TenantID != query.TenantID {
+			return nil, ErrTenantMismatch
+		}
+		if err := verifyRevision(revision); err != nil {
+			return nil, err
+		}
+		revisions[revision.Digest] = revision
+	}
+	for _, receipt := range ledger.Supersessions {
+		if receipt.AssertionID != query.AssertionID {
+			continue
+		}
+		if receipt.TenantID != query.TenantID {
+			return nil, ErrTenantMismatch
+		}
+		if err := verifySupersession(receipt); err != nil {
+			return nil, err
+		}
+		prior, priorOK := revisions[receipt.PriorDigest]
+		successor, successorOK := revisions[receipt.SuccessorDigest]
+		if !priorOK || !successorOK || successor.PreviousDigest != prior.Digest || !successor.RecordedTime.From.Equal(receipt.RecordedAt) {
+			return nil, fmt.Errorf("%w: supersession receipt does not bind an exact revision transition", ErrInvalidTruthRecord)
+		}
+		if existing, ok := successors[receipt.PriorDigest]; ok && existing != receipt.SuccessorDigest {
+			return nil, fmt.Errorf("%w: revision has multiple successor receipts", ErrInvalidTruthRecord)
+		}
+		successors[receipt.PriorDigest] = receipt.SuccessorDigest
+		closures[receipt.PriorDigest] = receipt.RecordedAt
+	}
+	return closures, nil
+}
+
+func claimConflicts(claims []trustclaims.ClaimReceipt, revisions []TruthRevision, query EvaluationQuery) ([]Conflict, error) {
+	byDigest := map[string]trustclaims.ClaimReceipt{}
+	for _, claim := range claims {
+		byDigest[claim.Digest] = claim
+	}
+	conflicts := []Conflict{}
+	for _, revision := range revisions {
+		for _, binding := range revision.ClaimBindings {
+			claim, ok := byDigest[binding.ReceiptDigest]
+			if !ok || claim.ReceiptID != binding.ReceiptID {
+				conflicts = append(conflicts, makeConflict(ConflictClaimMissing, []string{revision.Digest, binding.ReceiptDigest}, nil, nil, "The exact bound claim receipt is unavailable.", false))
+				continue
+			}
+			if claim.TenantID != query.TenantID {
+				return nil, ErrTenantMismatch
+			}
+			if _, err := (trustclaims.ReadService{Receipts: []trustclaims.ClaimReceipt{claim}}).GetReceipt(query.TenantID, claim.ReceiptID); err != nil {
+				return nil, err
+			}
+			hasLaterRevision, err := claimHasLaterRevision(claims, claim, query.AsKnownAt)
+			if err != nil {
+				return nil, err
+			}
+			if binding.Position == PositionRefutes || claim.IssuedAt.After(query.AsKnownAt) || claim.IssuedAt.After(revision.RecordedTime.From) || hasLaterRevision || (claim.Status != trustclaims.ClaimStatusShareable && claim.Status != trustclaims.ClaimStatusAuditorReady) || expiredAt(claim.FreshUntil, query.AsKnownAt) || expiredAt(claim.ExpiresAt, query.AsKnownAt) {
+				conflicts = append(conflicts, makeConflict(ConflictClaimState, []string{revision.Digest, claim.Digest}, []string{claim.Status, binding.Position}, nil, "A bound claim is not current and shareable for this assertion.", false))
+			}
+			for _, citation := range claim.Citations {
+				if citation.State != trustclaims.CitationCurrent || !citation.Trusted || expiredAt(citation.ExpiresAt, query.AsKnownAt) {
+					conflicts = append(conflicts, makeConflict(ConflictCitationState, []string{revision.Digest, claim.Digest}, []string{citation.State}, []string{citation.ID}, "A bound citation is stale, revoked, conflicted, expired, or untrusted.", false))
+				}
+			}
+		}
+	}
+	return normalizeConflicts(conflicts), nil
+}
+
+func conflictingValues(revisions []TruthRevision) *Conflict {
+	values := revisionValues(revisions)
+	if len(values) < 2 {
+		return nil
+	}
+	conflict := makeConflict(ConflictValueDisagreement, revisionDigests(revisions), values, nil, "Current evidence supports conflicting assertion values.", true)
+	return &conflict
+}
+
+func matchingResolution(receipts []ConflictResolutionReceipt, query EvaluationQuery, conflict Conflict) (*ConflictResolutionReceipt, error) {
+	matching := []ConflictResolutionReceipt{}
+	for _, receipt := range receipts {
+		if receipt.AssertionID != query.AssertionID || receipt.ConflictID != conflict.ID {
+			continue
+		}
+		if receipt.TenantID != query.TenantID {
+			return nil, ErrTenantMismatch
+		}
+		if err := verifyResolution(receipt); err != nil {
+			return nil, err
+		}
+		if receipt.RecordedAt.After(query.AsKnownAt) || !equalStrings(receipt.InputDigests, conflict.InputDigests) {
+			continue
+		}
+		matching = append(matching, receipt)
+	}
+	if len(matching) == 0 {
+		return nil, nil
+	}
+	sort.Slice(matching, func(i, j int) bool {
+		if matching[i].RecordedAt.Equal(matching[j].RecordedAt) {
+			return matching[i].Digest < matching[j].Digest
+		}
+		return matching[i].RecordedAt.Before(matching[j].RecordedAt)
+	})
+	selected := matching[len(matching)-1]
+	return &selected, nil
+}
+
+func makeConflict(kind string, inputs, values, citationIDs []string, reason string, resolvable bool) Conflict {
+	inputs = uniqueSortedStrings(inputs)
+	values = uniqueSortedStrings(values)
+	citationIDs = uniqueSortedStrings(citationIDs)
+	payload := struct {
+		Kind                      string
+		Inputs, Values, Citations []string
+	}{kind, inputs, values, citationIDs}
+	id, _ := digestValue(payload)
+	return Conflict{ID: id, Kind: kind, InputDigests: inputs, Values: values, CitationIDs: citationIDs, Reason: reason, Resolvable: resolvable}
+}
+
+func finishEvaluation(evaluation TruthEvaluation) (TruthEvaluation, error) {
+	evaluation.RevisionDigests = uniqueSortedStrings(evaluation.RevisionDigests)
+	evaluation.ResolutionReceipts = uniqueSortedStrings(evaluation.ResolutionReceipts)
+	evaluation.AsKnownAt = evaluation.AsKnownAt.UTC()
+	evaluation.EffectiveAt = evaluation.EffectiveAt.UTC()
+	digest, err := digestValue(evaluationWithoutDigest(evaluation))
+	if err != nil {
+		return TruthEvaluation{}, err
+	}
+	evaluation.Digest = digest
+	return evaluation, nil
+}
+
+func verifyRevision(revision TruthRevision) error {
+	digest, err := digestValue(revisionWithoutDigest(revision))
+	if err != nil {
+		return err
+	}
+	if revision.SchemaVersion != RevisionSchemaVersion || revision.Digest == "" || digest != revision.Digest {
+		return fmt.Errorf("%w: revision digest does not match content", ErrInvalidTruthRecord)
+	}
+	if revision.TenantID == "" || revision.AssertionID == "" || revision.RevisionID == "" || revision.Version < 1 || revision.Subject.URN == "" || revision.Subject.Revision == "" || revision.Predicate == "" || revision.Value == "" || revision.RecordedTime.From.IsZero() || len(revision.ClaimBindings) == 0 {
+		return fmt.Errorf("%w: revision content is incomplete", ErrInvalidTruthRecord)
+	}
+	if err := validateInterval(revision.ValidTime); err != nil {
+		return err
+	}
+	if revision.RecordedTime.To != nil && !revision.RecordedTime.To.After(revision.RecordedTime.From) {
+		return fmt.Errorf("%w: recorded-time interval end must follow its start", ErrInvalidTruthRecord)
+	}
+	for _, binding := range revision.ClaimBindings {
+		if binding.ReceiptID == "" || binding.ReceiptDigest == "" || (binding.Position != PositionSupports && binding.Position != PositionRefutes) {
+			return fmt.Errorf("%w: revision claim binding is incomplete", ErrInvalidTruthRecord)
+		}
+	}
+	return nil
+}
+
+func verifySupersession(receipt SupersessionReceipt) error {
+	digest, err := digestValue(supersessionWithoutDigest(receipt))
+	if err != nil {
+		return err
+	}
+	if receipt.SchemaVersion != SupersessionSchemaVersion || receipt.PriorDigest == "" || receipt.SuccessorDigest == "" || receipt.RecordedAt.IsZero() || receipt.Digest == "" || digest != receipt.Digest {
+		return fmt.Errorf("%w: supersession receipt digest does not match content", ErrInvalidTruthRecord)
+	}
+	return nil
+}
+
+func verifyResolution(receipt ConflictResolutionReceipt) error {
+	digest, err := digestValue(resolutionWithoutDigest(receipt))
+	if err != nil {
+		return err
+	}
+	if receipt.SchemaVersion != ResolutionSchemaVersion || receipt.Digest == "" || digest != receipt.Digest {
+		return fmt.Errorf("%w: conflict resolution digest does not match content", ErrInvalidTruthRecord)
+	}
+	if receipt.TenantID == "" || receipt.AssertionID == "" || receipt.ConflictID == "" || receipt.Decision != ResolutionAcceptRevision || len(receipt.InputDigests) < 2 || !contains(receipt.InputDigests, receipt.SelectedRevisionDigest) || receipt.Reviewer.Decision != trustclaims.ApprovalApproved || receipt.Reviewer.ReviewerID == "" || receipt.Reviewer.ApprovedAt.IsZero() || receipt.RecordedAt.IsZero() || receipt.Reviewer.ApprovedAt.After(receipt.RecordedAt) {
+		return fmt.Errorf("%w: conflict resolution content is incomplete", ErrInvalidTruthRecord)
+	}
+	return nil
+}
+
+func normalizeRevisionInput(input *RevisionInput) {
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.AssertionID = strings.TrimSpace(input.AssertionID)
+	input.RevisionID = strings.TrimSpace(input.RevisionID)
+	input.Subject.URN = strings.TrimSpace(input.Subject.URN)
+	input.Subject.Revision = strings.TrimSpace(input.Subject.Revision)
+	input.Subject.Type = strings.TrimSpace(input.Subject.Type)
+	input.Predicate = strings.TrimSpace(input.Predicate)
+	input.Value = strings.TrimSpace(input.Value)
+	if input.Version == 0 {
+		input.Version = 1
+	}
+	input.ValidTime = normalizeInterval(input.ValidTime)
+	input.RecordedAt = input.RecordedAt.UTC()
+	input.ClaimBindings = normalizeBindings(input.ClaimBindings)
+}
+
+func normalizeResolutionInput(input *ResolutionInput) {
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.AssertionID = strings.TrimSpace(input.AssertionID)
+	input.ConflictID = strings.TrimSpace(input.ConflictID)
+	input.InputDigests = uniqueSortedStrings(input.InputDigests)
+	input.Decision = strings.TrimSpace(input.Decision)
+	input.SelectedRevisionDigest = strings.TrimSpace(input.SelectedRevisionDigest)
+	input.Reviewer.ReviewerID = strings.TrimSpace(input.Reviewer.ReviewerID)
+	input.Reviewer.Decision = strings.TrimSpace(input.Reviewer.Decision)
+	input.Reviewer.Reason = strings.TrimSpace(input.Reviewer.Reason)
+	input.Reviewer.ApprovedAt = input.Reviewer.ApprovedAt.UTC()
+	input.RecordedAt = input.RecordedAt.UTC()
+}
+
+func normalizeQuery(query *EvaluationQuery) {
+	query.TenantID = strings.TrimSpace(query.TenantID)
+	query.AssertionID = strings.TrimSpace(query.AssertionID)
+	query.AsKnownAt = query.AsKnownAt.UTC()
+	query.EffectiveAt = query.EffectiveAt.UTC()
+}
+
+func normalizeBindings(bindings []ClaimBinding) []ClaimBinding {
+	result := append([]ClaimBinding(nil), bindings...)
+	for index := range result {
+		result[index].ReceiptID = strings.TrimSpace(result[index].ReceiptID)
+		result[index].ReceiptDigest = strings.TrimSpace(result[index].ReceiptDigest)
+		result[index].Position = strings.TrimSpace(result[index].Position)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ReceiptDigest == result[j].ReceiptDigest {
+			return result[i].Position < result[j].Position
+		}
+		return result[i].ReceiptDigest < result[j].ReceiptDigest
+	})
+	return result
+}
+
+func normalizeConflicts(conflicts []Conflict) []Conflict {
+	byID := map[string]Conflict{}
+	for _, conflict := range conflicts {
+		byID[conflict.ID] = conflict
+	}
+	result := make([]Conflict, 0, len(byID))
+	for _, conflict := range byID {
+		result = append(result, conflict)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+func validateInterval(interval Interval) error {
+	if interval.From.IsZero() || (interval.To != nil && !interval.To.After(interval.From)) {
+		return fmt.Errorf("%w: valid-time interval requires a start and an optional later end", ErrInvalidTruthRecord)
+	}
+	return nil
+}
+
+func normalizeInterval(interval Interval) Interval {
+	interval.From = interval.From.UTC()
+	if interval.To != nil {
+		value := interval.To.UTC()
+		interval.To = &value
+	}
+	return interval
+}
+
+func intervalContains(interval Interval, at time.Time) bool {
+	return !at.Before(interval.From) && (interval.To == nil || at.Before(*interval.To))
+}
+
+func recordedAtContains(revision TruthRevision, supersededAt time.Time, at time.Time) bool {
+	if at.Before(revision.RecordedTime.From) {
+		return false
+	}
+	if revision.RecordedTime.To != nil && !at.Before(*revision.RecordedTime.To) {
+		return false
+	}
+	return supersededAt.IsZero() || at.Before(supersededAt)
+}
+
+func expiredAt(value *time.Time, at time.Time) bool { return value != nil && !value.After(at) }
+func claimHasLaterRevision(claims []trustclaims.ClaimReceipt, claim trustclaims.ClaimReceipt, at time.Time) (bool, error) {
+	for _, candidate := range claims {
+		if candidate.TenantID == claim.TenantID && candidate.ClaimID == claim.ClaimID && candidate.PreviousDigest == claim.Digest && !candidate.IssuedAt.After(at) {
+			if _, err := (trustclaims.ReadService{Receipts: []trustclaims.ClaimReceipt{candidate}}).GetReceipt(claim.TenantID, candidate.ReceiptID); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+func sameSubject(a, b trustclaims.ResourceRef) bool {
+	return a.URN == b.URN && a.Revision == b.Revision && a.Type == b.Type
+}
+func contains(values []string, expected string) bool {
+	index := sort.SearchStrings(values, expected)
+	return index < len(values) && values[index] == expected
+}
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func revisionDigests(revisions []TruthRevision) []string {
+	result := make([]string, 0, len(revisions))
+	for _, revision := range revisions {
+		result = append(result, revision.Digest)
+	}
+	return uniqueSortedStrings(result)
+}
+func revisionValues(revisions []TruthRevision) []string {
+	result := make([]string, 0, len(revisions))
+	for _, revision := range revisions {
+		result = append(result, revision.Value)
+	}
+	return uniqueSortedStrings(result)
+}
+func filterRevision(revisions []TruthRevision, digest string) []TruthRevision {
+	for _, revision := range revisions {
+		if revision.Digest == digest {
+			return []TruthRevision{revision}
+		}
+	}
+	return nil
+}
+
+func uniqueSortedStrings(values []string) []string {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func digestValue(value any) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("canonical compliance truth encoding: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func revisionWithoutDigest(value TruthRevision) TruthRevision { value.Digest = ""; return value }
+func supersessionWithoutDigest(value SupersessionReceipt) SupersessionReceipt {
+	value.Digest = ""
+	return value
+}
+func resolutionWithoutDigest(value ConflictResolutionReceipt) ConflictResolutionReceipt {
+	value.Digest = ""
+	return value
+}
+func evaluationWithoutDigest(value TruthEvaluation) TruthEvaluation { value.Digest = ""; return value }

--- a/internal/compliancetruth/service.go
+++ b/internal/compliancetruth/service.go
@@ -238,7 +238,10 @@ func supersessionClosures(ledger Ledger, query EvaluationQuery) (map[string]time
 		}
 		prior, priorOK := revisions[receipt.PriorDigest]
 		successor, successorOK := revisions[receipt.SuccessorDigest]
-		if !priorOK || !successorOK || successor.PreviousDigest != prior.Digest || !successor.RecordedTime.From.Equal(receipt.RecordedAt) {
+		if !priorOK || !successorOK || successor.PreviousDigest != prior.Digest ||
+			successor.Version != prior.Version+1 || successor.AssertionID != prior.AssertionID ||
+			!sameSubject(successor.Subject, prior.Subject) || successor.Predicate != prior.Predicate ||
+			!successor.RecordedTime.From.Equal(receipt.RecordedAt) || !receipt.RecordedAt.After(prior.RecordedTime.From) {
 			return nil, fmt.Errorf("%w: supersession receipt does not bind an exact revision transition", ErrInvalidTruthRecord)
 		}
 		if existing, ok := successors[receipt.PriorDigest]; ok && existing != receipt.SuccessorDigest {

--- a/internal/compliancetruth/service_test.go
+++ b/internal/compliancetruth/service_test.go
@@ -80,6 +80,27 @@ func TestAsKnownAtAndEffectiveAtPreserveLateCorrectionHistory(t *testing.T) {
 	}
 }
 
+func TestEvaluationRejectsSupersessionThatChangesAssertionIdentity(t *testing.T) {
+	now := truthTime()
+	claim := validClaim(t, "claim-a", "receipt-a", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	prior := mustRevision(t, revisionInput("revision-a", "enabled", claim, now))
+	successor, supersession, err := CorrectRevision(prior, revisionInput("revision-b", "disabled", claim, now.Add(time.Hour)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor.Predicate = "password_rotation_required"
+	successor.Digest = mustDigest(t, revisionWithoutDigest(successor))
+	supersession.SuccessorDigest = successor.Digest
+	supersession.Digest = mustDigest(t, supersessionWithoutDigest(supersession))
+
+	_, err = Evaluate(Ledger{Revisions: []TruthRevision{prior, successor}, Supersessions: []SupersessionReceipt{supersession}, Claims: []trustclaims.ClaimReceipt{claim}}, EvaluationQuery{
+		TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(2 * time.Hour), EffectiveAt: now,
+	})
+	if !errors.Is(err, ErrInvalidTruthRecord) {
+		t.Fatalf("Evaluate() error = %v, want ErrInvalidTruthRecord", err)
+	}
+}
+
 func TestConflictResolutionBindsReviewerExactInputsAndDecisionTime(t *testing.T) {
 	now := truthTime()
 	claimA := validClaim(t, "claim-a", "receipt-a", "enabled", trustclaims.ClaimStatusAuditorReady, trustclaims.CitationCurrent, now)

--- a/internal/compliancetruth/service_test.go
+++ b/internal/compliancetruth/service_test.go
@@ -1,0 +1,317 @@
+package compliancetruth
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/trustclaims"
+)
+
+func TestConflictingCurrentTruthBlocksQualifiedAndShareableStatus(t *testing.T) {
+	now := truthTime()
+	claimA := validClaim(t, "claim-a", "receipt-a", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	claimB := validClaim(t, "claim-b", "receipt-b", "disabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	revisionA := mustRevision(t, revisionInput("revision-a", "enabled", claimA, now))
+	revisionB := mustRevision(t, revisionInput("revision-b", "disabled", claimB, now.Add(time.Minute)))
+
+	evaluation, err := Evaluate(Ledger{Revisions: []TruthRevision{revisionA, revisionB}, Claims: []trustclaims.ClaimReceipt{claimA, claimB}}, EvaluationQuery{
+		TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(time.Hour), EffectiveAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evaluation.State != EvaluationConflicted || evaluation.Qualified || evaluation.Shareable {
+		t.Fatalf("evaluation = %#v, want explicit blocking conflict", evaluation)
+	}
+	if len(evaluation.Conflicts) != 1 || evaluation.Conflicts[0].Kind != ConflictValueDisagreement || !evaluation.Conflicts[0].Resolvable {
+		t.Fatalf("conflicts = %#v", evaluation.Conflicts)
+	}
+	if !reflect.DeepEqual(evaluation.Conflicts[0].InputDigests, []string{min(revisionA.Digest, revisionB.Digest), max(revisionA.Digest, revisionB.Digest)}) {
+		t.Fatalf("conflict inputs = %#v, want exact sorted revision digests", evaluation.Conflicts[0].InputDigests)
+	}
+}
+
+func TestAsKnownAtAndEffectiveAtPreserveLateCorrectionHistory(t *testing.T) {
+	now := truthTime()
+	oldClaim := validClaim(t, "claim-old", "receipt-old", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	newClaim := validClaim(t, "claim-new", "receipt-new", "disabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	validTo := now.Add(90 * 24 * time.Hour)
+	oldInput := revisionInput("revision-old", "enabled", oldClaim, now)
+	oldInput.ValidTime = Interval{From: now.Add(-24 * time.Hour), To: &validTo}
+	oldRevision := mustRevision(t, oldInput)
+	oldSnapshot := oldRevision
+
+	correctionInput := revisionInput("revision-correction", "disabled", newClaim, now.Add(30*24*time.Hour))
+	correctionInput.ValidTime = Interval{From: now.Add(-24 * time.Hour), To: &validTo}
+	corrected, supersession, err := CorrectRevision(oldRevision, correctionInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(oldRevision, oldSnapshot) {
+		t.Fatal("CorrectRevision mutated the prior revision")
+	}
+	if corrected.PreviousDigest != oldRevision.Digest || supersession.PriorDigest != oldRevision.Digest || supersession.SuccessorDigest != corrected.Digest {
+		t.Fatalf("correction lineage missing: corrected=%#v supersession=%#v", corrected, supersession)
+	}
+	ledger := Ledger{Revisions: []TruthRevision{oldRevision, corrected}, Supersessions: []SupersessionReceipt{supersession}, Claims: []trustclaims.ClaimReceipt{oldClaim, newClaim}}
+
+	before, err := Evaluate(ledger, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(10 * 24 * time.Hour), EffectiveAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.State != EvaluationQualified || before.Value != "enabled" || !reflect.DeepEqual(before.RevisionDigests, []string{oldRevision.Digest}) {
+		t.Fatalf("before correction = %#v", before)
+	}
+	after, err := Evaluate(ledger, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(31 * 24 * time.Hour), EffectiveAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.State != EvaluationQualified || after.Value != "disabled" || !reflect.DeepEqual(after.RevisionDigests, []string{corrected.Digest}) {
+		t.Fatalf("after correction = %#v", after)
+	}
+	outside, err := Evaluate(ledger, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(31 * 24 * time.Hour), EffectiveAt: validTo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outside.State != EvaluationUnknown || outside.Qualified || outside.Shareable {
+		t.Fatalf("outside valid interval = %#v", outside)
+	}
+}
+
+func TestConflictResolutionBindsReviewerExactInputsAndDecisionTime(t *testing.T) {
+	now := truthTime()
+	claimA := validClaim(t, "claim-a", "receipt-a", "enabled", trustclaims.ClaimStatusAuditorReady, trustclaims.CitationCurrent, now)
+	claimB := validClaim(t, "claim-b", "receipt-b", "disabled", trustclaims.ClaimStatusAuditorReady, trustclaims.CitationCurrent, now)
+	revisionA := mustRevision(t, revisionInput("revision-a", "enabled", claimA, now))
+	revisionB := mustRevision(t, revisionInput("revision-b", "disabled", claimB, now.Add(time.Minute)))
+	ledger := Ledger{Revisions: []TruthRevision{revisionA, revisionB}, Claims: []trustclaims.ClaimReceipt{claimA, claimB}}
+	conflicted, err := Evaluate(ledger, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(time.Hour), EffectiveAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflict := conflicted.Conflicts[0]
+	approvedAt := now.Add(2 * time.Hour)
+	resolution, err := ResolveConflict(ResolutionInput{
+		TenantID: "tenant-a", AssertionID: "assertion-access", ConflictID: conflict.ID,
+		InputDigests: conflict.InputDigests, Decision: ResolutionAcceptRevision, SelectedRevisionDigest: revisionA.Digest,
+		Reviewer:   trustclaims.ReviewerApproval{ReviewerID: "reviewer-a", Decision: trustclaims.ApprovalApproved, Reason: "The current configuration record is authoritative.", ApprovedAt: approvedAt},
+		RecordedAt: approvedAt.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger.Resolutions = []ConflictResolutionReceipt{resolution}
+
+	beforeResolution, err := Evaluate(ledger, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: approvedAt, EffectiveAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if beforeResolution.State != EvaluationConflicted {
+		t.Fatalf("resolution applied before recorded time: %#v", beforeResolution)
+	}
+	afterResolution, err := Evaluate(ledger, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: approvedAt.Add(2 * time.Minute), EffectiveAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterResolution.State != EvaluationQualified || afterResolution.Value != "enabled" || len(afterResolution.ResolvedConflicts) != 1 || afterResolution.ResolvedConflicts[0].ResolutionDigest != resolution.Digest {
+		t.Fatalf("resolved evaluation = %#v", afterResolution)
+	}
+	if _, err := ResolveConflict(ResolutionInput{TenantID: "tenant-a", AssertionID: "assertion-access", ConflictID: conflict.ID, InputDigests: conflict.InputDigests, Decision: ResolutionAcceptRevision, SelectedRevisionDigest: revisionA.Digest, RecordedAt: approvedAt}); !errors.Is(err, ErrInvalidTruthRecord) {
+		t.Fatalf("unapproved resolution error = %v, want ErrInvalidTruthRecord", err)
+	}
+}
+
+func TestConflictedOrWithdrawnClaimRemainsExplicitAndUnresolvable(t *testing.T) {
+	now := truthTime()
+	tests := []struct {
+		name          string
+		status        string
+		citationState string
+		wantKind      string
+	}{
+		{name: "conflicting citation", status: trustclaims.ClaimStatusDraft, citationState: trustclaims.CitationConflicted, wantKind: ConflictCitationState},
+		{name: "withdrawn claim", status: trustclaims.ClaimStatusWithdrawn, citationState: trustclaims.CitationCurrent, wantKind: ConflictClaimState},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			claim := validClaim(t, "claim-a", "receipt-a", "enabled", test.status, test.citationState, now)
+			revision := mustRevision(t, revisionInput("revision-a", "enabled", claim, now))
+			evaluation, err := Evaluate(Ledger{Revisions: []TruthRevision{revision}, Claims: []trustclaims.ClaimReceipt{claim}}, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(time.Hour), EffectiveAt: now})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if evaluation.State != EvaluationConflicted || evaluation.Qualified || evaluation.Shareable {
+				t.Fatalf("evaluation = %#v", evaluation)
+			}
+			found := false
+			for _, conflict := range evaluation.Conflicts {
+				if conflict.Kind == test.wantKind {
+					found = true
+					if conflict.Resolvable {
+						t.Fatalf("source integrity conflict must not be overridable: %#v", conflict)
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("conflicts = %#v, want kind %s", evaluation.Conflicts, test.wantKind)
+			}
+		})
+	}
+}
+
+func TestLaterWithdrawalInvalidatesAPreviouslyBoundShareableReceipt(t *testing.T) {
+	now := truthTime()
+	claim := validClaim(t, "claim-a", "receipt-a", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	revision := mustRevision(t, revisionInput("revision-a", "enabled", claim, now))
+	withdrawal, err := trustclaims.ApplyEvidenceChange(claim, trustclaims.EvidenceChange{
+		TenantID: "tenant-a", CitationID: claim.Citations[0].ID, State: trustclaims.CitationRevoked,
+		Reason: "The source retracted the evidence.", ObservedAt: now.Add(30 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evaluation, err := Evaluate(Ledger{
+		Revisions: []TruthRevision{revision}, Claims: []trustclaims.ClaimReceipt{claim, withdrawal.Receipt},
+	}, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(time.Hour), EffectiveAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evaluation.State != EvaluationConflicted || len(evaluation.Conflicts) == 0 {
+		t.Fatalf("evaluation = %#v, want later withdrawal to block the older binding", evaluation)
+	}
+}
+
+func TestEvaluationIsTenantScoped(t *testing.T) {
+	now := truthTime()
+	claim := validClaim(t, "claim-a", "receipt-a", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	revision := mustRevision(t, revisionInput("revision-a", "enabled", claim, now))
+	if _, err := Evaluate(Ledger{Revisions: []TruthRevision{revision}, Claims: []trustclaims.ClaimReceipt{claim}}, EvaluationQuery{TenantID: "tenant-b", AssertionID: "assertion-access", AsKnownAt: now.Add(time.Hour), EffectiveAt: now}); !errors.Is(err, ErrTenantMismatch) {
+		t.Fatalf("Evaluate() error = %v, want ErrTenantMismatch", err)
+	}
+
+	otherClaimInput := validClaimInput("claim-b", "receipt-b", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	otherClaimInput.TenantID = "tenant-b"
+	otherClaim := mustClaim(t, otherClaimInput)
+	revisionWithOtherClaim := mustRevision(t, revisionInput("revision-b", "enabled", otherClaim, now))
+	revisionWithOtherClaim.TenantID = "tenant-a"
+	revisionWithOtherClaim.Digest = mustDigest(t, revisionWithoutDigest(revisionWithOtherClaim))
+	if _, err := Evaluate(Ledger{Revisions: []TruthRevision{revisionWithOtherClaim}, Claims: []trustclaims.ClaimReceipt{otherClaim}}, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(time.Hour), EffectiveAt: now}); !errors.Is(err, ErrTenantMismatch) {
+		t.Fatalf("Evaluate(cross-tenant claim) error = %v, want ErrTenantMismatch", err)
+	}
+}
+
+func TestDeterministicTruthReceiptsAndEvaluation(t *testing.T) {
+	now := truthTime()
+	claimA := validClaim(t, "claim-a", "receipt-a", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	claimB := validClaim(t, "claim-b", "receipt-b", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	input := revisionInput("revision-a", "enabled", claimA, now)
+	input.ClaimBindings = append(input.ClaimBindings, ClaimBinding{ReceiptID: claimB.ReceiptID, ReceiptDigest: claimB.Digest, Position: PositionSupports})
+	reversed := input
+	reversed.ClaimBindings = []ClaimBinding{input.ClaimBindings[1], input.ClaimBindings[0]}
+	revisionA := mustRevision(t, input)
+	revisionB := mustRevision(t, reversed)
+	if revisionA.Digest != revisionB.Digest {
+		t.Fatalf("revision digests differ: %s != %s", revisionA.Digest, revisionB.Digest)
+	}
+	query := EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: now.Add(time.Hour), EffectiveAt: now}
+	first, err := Evaluate(Ledger{Revisions: []TruthRevision{revisionA}, Claims: []trustclaims.ClaimReceipt{claimA, claimB}}, query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Evaluate(Ledger{Revisions: []TruthRevision{revisionA}, Claims: []trustclaims.ClaimReceipt{claimB, claimA}}, query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Digest != second.Digest || first.State != EvaluationQualified || !first.Shareable {
+		t.Fatalf("deterministic evaluations differ: %#v %#v", first, second)
+	}
+}
+
+func validClaim(t *testing.T, claimID, receiptID, value, status, citationState string, now time.Time) trustclaims.ClaimReceipt {
+	t.Helper()
+	if status == trustclaims.ClaimStatusWithdrawn {
+		input := validClaimInput(claimID, receiptID, value, trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+		base := mustClaim(t, input)
+		transition, err := trustclaims.ApplyEvidenceChange(base, trustclaims.EvidenceChange{TenantID: input.TenantID, CitationID: input.Citations[0].ID, State: trustclaims.CitationStale, Reason: "Evidence was invalidated.", ObservedAt: now.Add(time.Minute)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return transition.Receipt
+	}
+	return mustClaim(t, validClaimInput(claimID, receiptID, value, status, citationState, now))
+}
+
+func validClaimInput(claimID, receiptID, value, status, citationState string, now time.Time) trustclaims.ReceiptInput {
+	expires := now.Add(365 * 24 * time.Hour)
+	disclosure := trustclaims.DisclosureCustomer
+	if status == trustclaims.ClaimStatusAuditorReady {
+		disclosure = trustclaims.DisclosureAuditor
+	}
+	requestedStatus := status
+	if status == trustclaims.ClaimStatusWithdrawn {
+		requestedStatus = trustclaims.ClaimStatusDraft
+	}
+	return trustclaims.ReceiptInput{
+		TenantID: "tenant-a", ReceiptID: receiptID, ClaimID: claimID, Version: 1,
+		Statement: "The access control is " + value + ".", Origin: trustclaims.ClaimOriginAuthored,
+		RequestedStatus: requestedStatus, DisclosureClass: disclosure,
+		Citations: []trustclaims.Citation{{ID: "citation-" + receiptID, EvidenceID: "evidence-" + receiptID, SourceID: "source-a", SourceEventIDs: []string{"event-" + receiptID}, ResourceRefs: []trustclaims.ResourceRef{{URN: "urn:resource:access", Revision: "12"}}, State: citationState, Trusted: true, ObservedAt: now.Add(-time.Minute), ExpiresAt: &expires}},
+		Controls:  []trustclaims.VersionedRef{{ID: "control-access", Version: "3"}}, Policies: []trustclaims.VersionedRef{{ID: "policy-access", Version: "7"}},
+		ResourceRefs: []trustclaims.ResourceRef{{URN: "urn:resource:access", Revision: "12", Type: "access_control"}},
+		Approval:     &trustclaims.ReviewerApproval{ReviewerID: "reviewer-a", Decision: trustclaims.ApprovalApproved, ApprovedAt: now},
+		FreshUntil:   &expires, ExpiresAt: &expires, IssuedAt: now,
+	}
+}
+
+func mustClaim(t *testing.T, input trustclaims.ReceiptInput) trustclaims.ClaimReceipt {
+	t.Helper()
+	receipt, err := trustclaims.IssueReceipt(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+func revisionInput(revisionID, value string, claim trustclaims.ClaimReceipt, recordedAt time.Time) RevisionInput {
+	return RevisionInput{
+		TenantID: "tenant-a", AssertionID: "assertion-access", RevisionID: revisionID, Version: 1,
+		Subject:   trustclaims.ResourceRef{URN: "urn:resource:access", Revision: "12", Type: "access_control"},
+		Predicate: "second_factor_required", Value: value,
+		ValidTime: Interval{From: truthTime().Add(-24 * time.Hour)}, RecordedAt: recordedAt,
+		ClaimBindings: []ClaimBinding{{ReceiptID: claim.ReceiptID, ReceiptDigest: claim.Digest, Position: PositionSupports}},
+	}
+}
+
+func mustRevision(t *testing.T, input RevisionInput) TruthRevision {
+	t.Helper()
+	revision, err := IssueRevision(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return revision
+}
+
+func mustDigest(t *testing.T, value any) string {
+	t.Helper()
+	digest, err := digestValue(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digest
+}
+
+func truthTime() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+func min(a, b string) string {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b string) string {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/compliancetruth/service_test.go
+++ b/internal/compliancetruth/service_test.go
@@ -144,6 +144,42 @@ func TestConflictResolutionBindsReviewerExactInputsAndDecisionTime(t *testing.T)
 	}
 }
 
+func TestConflictResolutionDiscardsClaimConflictsFromRejectedRevision(t *testing.T) {
+	now := truthTime()
+	claimA := validClaim(t, "claim-a", "receipt-a", "enabled", trustclaims.ClaimStatusShareable, trustclaims.CitationCurrent, now)
+	claimB := validClaim(t, "claim-b", "receipt-b", "disabled", trustclaims.ClaimStatusWithdrawn, trustclaims.CitationCurrent, now)
+	revisionA := mustRevision(t, revisionInput("revision-a", "enabled", claimA, now))
+	revisionB := mustRevision(t, revisionInput("revision-b", "disabled", claimB, now.Add(2*time.Minute)))
+	conflict := conflictingValues([]TruthRevision{revisionA, revisionB})
+	if conflict == nil {
+		t.Fatal("conflictingValues() = nil")
+	}
+	approvedAt := now.Add(3 * time.Minute)
+	resolution, err := ResolveConflict(ResolutionInput{
+		TenantID: "tenant-a", AssertionID: "assertion-access", ConflictID: conflict.ID,
+		InputDigests: conflict.InputDigests, Decision: ResolutionAcceptRevision, SelectedRevisionDigest: revisionA.Digest,
+		Reviewer:   trustclaims.ReviewerApproval{ReviewerID: "reviewer-a", Decision: trustclaims.ApprovalApproved, ApprovedAt: approvedAt},
+		RecordedAt: approvedAt.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evaluation, err := Evaluate(Ledger{
+		Revisions: []TruthRevision{revisionA, revisionB},
+		Claims:    []trustclaims.ClaimReceipt{claimA, claimB},
+		Resolutions: []ConflictResolutionReceipt{
+			resolution,
+		},
+	}, EvaluationQuery{TenantID: "tenant-a", AssertionID: "assertion-access", AsKnownAt: approvedAt.Add(2 * time.Minute), EffectiveAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evaluation.State != EvaluationQualified || evaluation.Value != "enabled" || len(evaluation.Conflicts) != 0 || !reflect.DeepEqual(evaluation.RevisionDigests, []string{revisionA.Digest}) {
+		t.Fatalf("resolved evaluation = %#v, want only the selected valid revision", evaluation)
+	}
+}
+
 func TestConflictedOrWithdrawnClaimRemainsExplicitAndUnresolvable(t *testing.T) {
 	now := truthTime()
 	tests := []struct {

--- a/internal/trustclaims/adapters.go
+++ b/internal/trustclaims/adapters.go
@@ -1,0 +1,125 @@
+package trustclaims
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/evidencepackets"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+// CitationFromQuestionnaire preserves the source-event and resource lineage of
+// a questionnaire answer when it becomes an external factual claim.
+func CitationFromQuestionnaire(citation ports.QuestionnaireCitation, trusted bool) Citation {
+	observedAt, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(citation.ObservedAt))
+	expiresAt := parseOptionalTime(citation.ExpiresAt)
+	resourceRefs := make([]ResourceRef, 0, len(citation.GraphRootURNs)+1)
+	if resourceURN := strings.TrimSpace(citation.ResourceURN); resourceURN != "" {
+		resourceRefs = append(resourceRefs, ResourceRef{URN: resourceURN})
+	}
+	for _, urn := range citation.GraphRootURNs {
+		resourceRefs = append(resourceRefs, ResourceRef{URN: urn})
+	}
+	state := normalizeFreshnessState(citation.FreshnessStatus)
+	return Citation{
+		ID:               citation.ID,
+		EvidenceID:       firstNonEmpty(citation.EvidenceID, citation.ID),
+		EvidencePacketID: citation.EvidencePacketID,
+		EvidenceType:     citation.EvidenceType,
+		SourceID:         firstNonEmpty(citation.SourceID, citation.Source),
+		RuntimeID:        citation.RuntimeID,
+		SourceEventIDs:   citation.SourceEventIDs,
+		ResourceRefs:     resourceRefs,
+		State:            state,
+		Trusted:          trusted,
+		ObservedAt:       observedAt,
+		ExpiresAt:        expiresAt,
+	}
+}
+
+// CitationFromEvidencePacket converts the existing evidence-packet reasoning
+// contract without inferring trust or silently upgrading freshness.
+func CitationFromEvidencePacket(reference evidencepackets.QuestionnaireEvidenceRef, trusted bool) Citation {
+	observedAt, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(reference.Freshness.ObservedAt))
+	expiresAt := parseOptionalTime(reference.Freshness.ExpiresAt)
+	resources := make([]ResourceRef, 0, len(reference.GraphRootURNs))
+	for _, urn := range reference.GraphRootURNs {
+		resources = append(resources, ResourceRef{URN: urn})
+	}
+	return Citation{
+		ID:               reference.ID,
+		EvidenceID:       reference.ID,
+		EvidencePacketID: reference.EvidencePacketID,
+		EvidenceType:     reference.EvidenceType,
+		SourceID:         firstNonEmpty(reference.SourceID, reference.Source),
+		RuntimeID:        reference.RuntimeID,
+		SourceEventIDs:   reference.SourceEventIDs,
+		ResourceRefs:     resources,
+		State:            normalizeFreshnessState(reference.Freshness.Status),
+		Trusted:          trusted,
+		ObservedAt:       observedAt,
+		ExpiresAt:        expiresAt,
+	}
+}
+
+// WorkflowDecision maps a trust-claim transition onto the existing durable
+// knowledge-decision event contract. The caller remains responsible for
+// appending the event before projecting current state.
+func (transition ClaimTransition) WorkflowDecision() workflowevents.DecisionRecorded {
+	evidenceIDs := make([]string, 0, len(transition.Receipt.Citations))
+	for _, citation := range transition.Receipt.Citations {
+		evidenceIDs = append(evidenceIDs, citation.EvidenceID)
+	}
+	return workflowevents.DecisionRecorded{
+		TenantID:      transition.TenantID,
+		DecisionID:    transition.Receipt.ReceiptID + ":v" + fmt.Sprintf("%d", transition.Receipt.Version),
+		DecisionType:  transition.TransitionType,
+		Status:        transition.Receipt.Status,
+		Rationale:     transition.Receipt.TransitionReason,
+		TargetIDs:     uniqueSortedStrings([]string{transition.ClaimID, transition.Receipt.ReceiptID}),
+		EvidenceIDs:   uniqueSortedStrings(evidenceIDs),
+		SourceSystem:  "cerebro-trust-claims",
+		SourceEventID: transition.FromDigest,
+		ObservedAt:    transition.Receipt.IssuedAt.UTC().Format(time.RFC3339Nano),
+		ValidFrom:     transition.Receipt.IssuedAt.UTC().Format(time.RFC3339Nano),
+		Confidence:    1,
+		Metadata: map[string]any{
+			"receipt_digest":  transition.Receipt.Digest,
+			"previous_digest": transition.FromDigest,
+			"receipt_version": transition.Receipt.Version,
+			"transition_type": transition.TransitionType,
+		},
+	}
+}
+
+func normalizeFreshnessState(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "current", "fresh", "supported":
+		return CitationCurrent
+	case "conflict", "conflicted":
+		return CitationConflicted
+	case "revoked", "retracted":
+		return CitationRevoked
+	default:
+		return CitationStale
+	}
+}
+
+func parseOptionalTime(value string) *time.Time {
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/trustclaims/model.go
+++ b/internal/trustclaims/model.go
@@ -1,0 +1,209 @@
+package trustclaims
+
+import "time"
+
+const (
+	ReceiptSchemaVersion    = "trust-claim-receipt.v1"
+	PackageSchemaVersion    = "trust-claim-package.v1"
+	ObligationSchemaVersion = "trust-obligation.v1"
+
+	ClaimOriginAuthored  = "authored"
+	ClaimOriginGenerated = "generated"
+	ClaimOriginExtracted = "extracted"
+
+	ClaimStatusDraft        = "draft"
+	ClaimStatusShareable    = "shareable"
+	ClaimStatusAuditorReady = "auditor_ready"
+	ClaimStatusWithdrawn    = "withdrawn"
+	ClaimStatusReopened     = "reopened"
+	ClaimStatusSuperseded   = "superseded"
+
+	DisclosureInternal = "internal"
+	DisclosureCustomer = "customer"
+	DisclosureAuditor  = "auditor"
+
+	CitationCurrent    = "current"
+	CitationStale      = "stale"
+	CitationRevoked    = "revoked"
+	CitationConflicted = "conflicted"
+
+	ApprovalApproved = "approved"
+
+	TransitionClaimWithdrawn  = "trust_claim_withdrawn"
+	TransitionClaimReopened   = "trust_claim_reopened"
+	TransitionClaimSuperseded = "trust_claim_superseded"
+
+	ObligationSuggested  = "suggested"
+	ObligationActive     = "active"
+	ObligationSuperseded = "superseded"
+)
+
+// ClaimReceipt is an immutable version of a factual external claim. A changed
+// claim or dependency produces another receipt linked through PreviousDigest.
+type ClaimReceipt struct {
+	SchemaVersion     string             `json:"schema_version"`
+	TenantID          string             `json:"tenant_id"`
+	ReceiptID         string             `json:"receipt_id"`
+	ClaimID           string             `json:"claim_id"`
+	Version           int                `json:"version"`
+	Statement         string             `json:"statement"`
+	Origin            string             `json:"origin"`
+	Status            string             `json:"status"`
+	DisclosureClass   string             `json:"disclosure_class"`
+	Citations         []Citation         `json:"citations,omitempty"`
+	Controls          []VersionedRef     `json:"controls,omitempty"`
+	Policies          []VersionedRef     `json:"policies,omitempty"`
+	ResourceRefs      []ResourceRef      `json:"resource_refs,omitempty"`
+	Generation        *GenerationReceipt `json:"generation,omitempty"`
+	UnsupportedClaims []string           `json:"unsupported_claims,omitempty"`
+	Approval          *ReviewerApproval  `json:"approval,omitempty"`
+	FreshUntil        *time.Time         `json:"fresh_until,omitempty"`
+	ExpiresAt         *time.Time         `json:"expires_at,omitempty"`
+	IssuedAt          time.Time          `json:"issued_at"`
+	PreviousDigest    string             `json:"previous_digest,omitempty"`
+	TransitionReason  string             `json:"transition_reason,omitempty"`
+	Digest            string             `json:"digest"`
+}
+
+type Citation struct {
+	ID               string        `json:"id"`
+	EvidenceID       string        `json:"evidence_id"`
+	EvidencePacketID string        `json:"evidence_packet_id,omitempty"`
+	EvidenceType     string        `json:"evidence_type,omitempty"`
+	SourceID         string        `json:"source_id"`
+	RuntimeID        string        `json:"runtime_id,omitempty"`
+	SourceEventIDs   []string      `json:"source_event_ids"`
+	ResourceRefs     []ResourceRef `json:"resource_refs,omitempty"`
+	State            string        `json:"state"`
+	Trusted          bool          `json:"trusted"`
+	ObservedAt       time.Time     `json:"observed_at"`
+	ExpiresAt        *time.Time    `json:"expires_at,omitempty"`
+}
+
+type ResourceRef struct {
+	URN      string `json:"urn"`
+	Revision string `json:"revision,omitempty"`
+	Type     string `json:"type,omitempty"`
+}
+
+type VersionedRef struct {
+	ID      string `json:"id"`
+	Version string `json:"version"`
+}
+
+type GenerationReceipt struct {
+	ModelID       string `json:"model_id"`
+	ModelVersion  string `json:"model_version"`
+	PromptVersion string `json:"prompt_version"`
+	PromptDigest  string `json:"prompt_digest,omitempty"`
+}
+
+type ReviewerApproval struct {
+	ReviewerID string    `json:"reviewer_id"`
+	Decision   string    `json:"decision"`
+	Reason     string    `json:"reason,omitempty"`
+	ApprovedAt time.Time `json:"approved_at"`
+}
+
+type ReceiptInput struct {
+	TenantID          string
+	ReceiptID         string
+	ClaimID           string
+	Version           int
+	Statement         string
+	Origin            string
+	RequestedStatus   string
+	DisclosureClass   string
+	Citations         []Citation
+	Controls          []VersionedRef
+	Policies          []VersionedRef
+	ResourceRefs      []ResourceRef
+	Generation        *GenerationReceipt
+	UnsupportedClaims []string
+	Approval          *ReviewerApproval
+	FreshUntil        *time.Time
+	ExpiresAt         *time.Time
+	IssuedAt          time.Time
+	PreviousDigest    string
+}
+
+type EvidenceChange struct {
+	TenantID   string
+	CitationID string
+	State      string
+	Reason     string
+	ObservedAt time.Time
+}
+
+type ClaimTransition struct {
+	EventKind      string       `json:"event_kind"`
+	TransitionType string       `json:"transition_type"`
+	TenantID       string       `json:"tenant_id"`
+	ClaimID        string       `json:"claim_id"`
+	FromDigest     string       `json:"from_digest"`
+	Receipt        ClaimReceipt `json:"receipt"`
+}
+
+// Obligation binds a confirmed commitment to the exact controls, evidence
+// requirements, population, owner, and deadline used to operate it.
+type Obligation struct {
+	SchemaVersion        string             `json:"schema_version"`
+	TenantID             string             `json:"tenant_id"`
+	ObligationID         string             `json:"obligation_id"`
+	Version              int                `json:"version"`
+	Status               string             `json:"status"`
+	ContractRef          VersionedRef       `json:"contract_ref"`
+	CommitmentRef        string             `json:"commitment_ref"`
+	Controls             []VersionedRef     `json:"controls"`
+	EvidenceRequirements []VersionedRef     `json:"evidence_requirements"`
+	ResourcePopulation   []ResourceRef      `json:"resource_population"`
+	OwnerID              string             `json:"owner_id"`
+	Deadline             *time.Time         `json:"deadline,omitempty"`
+	SuggestedBy          *ExtractionReceipt `json:"suggested_by,omitempty"`
+	ConfirmedBy          *ReviewerApproval  `json:"confirmed_by,omitempty"`
+	PreviousDigest       string             `json:"previous_digest,omitempty"`
+	SupersededBy         string             `json:"superseded_by,omitempty"`
+	IssuedAt             time.Time          `json:"issued_at"`
+	Digest               string             `json:"digest"`
+}
+
+type ExtractionReceipt struct {
+	SourceRef     string `json:"source_ref"`
+	ExtractorID   string `json:"extractor_id"`
+	ModelVersion  string `json:"model_version,omitempty"`
+	PromptVersion string `json:"prompt_version,omitempty"`
+}
+
+type ObligationInput struct {
+	TenantID             string
+	ObligationID         string
+	Version              int
+	ContractRef          VersionedRef
+	CommitmentRef        string
+	Controls             []VersionedRef
+	EvidenceRequirements []VersionedRef
+	ResourcePopulation   []ResourceRef
+	OwnerID              string
+	Deadline             *time.Time
+	SuggestedBy          *ExtractionReceipt
+	IssuedAt             time.Time
+	PreviousDigest       string
+}
+
+type PackageRequest struct {
+	TenantID      string
+	Audience      string
+	ReceiptIDs    []string
+	ObligationIDs []string
+	PackagedAt    time.Time
+}
+
+type ClaimPackage struct {
+	SchemaVersion string         `json:"schema_version"`
+	TenantID      string         `json:"tenant_id"`
+	Audience      string         `json:"audience"`
+	Receipts      []ClaimReceipt `json:"receipts"`
+	Obligations   []Obligation   `json:"obligations,omitempty"`
+	PackagedAt    time.Time      `json:"packaged_at"`
+	Digest        string         `json:"digest"`
+}

--- a/internal/trustclaims/service.go
+++ b/internal/trustclaims/service.go
@@ -1,0 +1,690 @@
+package trustclaims
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+var (
+	ErrInvalidReceipt            = errors.New("invalid trust claim receipt")
+	ErrNotShareable              = errors.New("trust claim is not shareable")
+	ErrTenantMismatch            = errors.New("tenant mismatch")
+	ErrReceiptNotFound           = errors.New("trust claim receipt not found")
+	ErrObligationNotFound        = errors.New("trust obligation not found")
+	ErrHumanConfirmationRequired = errors.New("human confirmation is required")
+)
+
+func IssueReceipt(input ReceiptInput) (ClaimReceipt, error) {
+	normalizeReceiptInput(&input)
+	if err := validateReceiptInput(input); err != nil {
+		return ClaimReceipt{}, err
+	}
+	receipt := ClaimReceipt{
+		SchemaVersion:     ReceiptSchemaVersion,
+		TenantID:          input.TenantID,
+		ReceiptID:         input.ReceiptID,
+		ClaimID:           input.ClaimID,
+		Version:           input.Version,
+		Statement:         input.Statement,
+		Origin:            input.Origin,
+		Status:            input.RequestedStatus,
+		DisclosureClass:   input.DisclosureClass,
+		Citations:         input.Citations,
+		Controls:          input.Controls,
+		Policies:          input.Policies,
+		ResourceRefs:      input.ResourceRefs,
+		Generation:        input.Generation,
+		UnsupportedClaims: input.UnsupportedClaims,
+		Approval:          input.Approval,
+		FreshUntil:        utcTimePtr(input.FreshUntil),
+		ExpiresAt:         utcTimePtr(input.ExpiresAt),
+		IssuedAt:          input.IssuedAt.UTC(),
+		PreviousDigest:    input.PreviousDigest,
+	}
+	if receipt.Status == "" {
+		receipt.Status = ClaimStatusDraft
+	}
+	if isExternalStatus(receipt.Status) {
+		if err := validateExternalEligibility(receipt, receipt.IssuedAt); err != nil {
+			return ClaimReceipt{}, err
+		}
+	}
+	digest, err := digestValue(receiptWithoutDigest(receipt))
+	if err != nil {
+		return ClaimReceipt{}, err
+	}
+	receipt.Digest = digest
+	return receipt, nil
+}
+
+func validateReceiptInput(input ReceiptInput) error {
+	if input.TenantID == "" || input.ReceiptID == "" || input.ClaimID == "" || input.Statement == "" || input.IssuedAt.IsZero() {
+		return fmt.Errorf("%w: tenant_id, receipt_id, claim_id, statement, and issued_at are required", ErrInvalidReceipt)
+	}
+	if !utf8.ValidString(input.Statement) || strings.ContainsRune(input.Statement, '\x00') {
+		return fmt.Errorf("%w: statement must be valid text without NUL bytes", ErrInvalidReceipt)
+	}
+	if input.Version < 1 {
+		return fmt.Errorf("%w: version must be positive", ErrInvalidReceipt)
+	}
+	if len(input.Citations) == 0 {
+		if isExternalStatus(input.RequestedStatus) {
+			return fmt.Errorf("%w: current citations are required", ErrNotShareable)
+		}
+		return fmt.Errorf("%w: evidence citations are required", ErrInvalidReceipt)
+	}
+	if len(input.Controls) == 0 || len(input.Policies) == 0 || len(input.ResourceRefs) == 0 {
+		return fmt.Errorf("%w: versioned controls, versioned policies, and resource refs are required", ErrInvalidReceipt)
+	}
+	if input.FreshUntil == nil || input.ExpiresAt == nil || !input.FreshUntil.After(input.IssuedAt) || !input.ExpiresAt.After(input.IssuedAt) {
+		return fmt.Errorf("%w: future freshness and expiry bounds are required", ErrInvalidReceipt)
+	}
+	switch input.Origin {
+	case ClaimOriginAuthored, ClaimOriginGenerated, ClaimOriginExtracted:
+	default:
+		return fmt.Errorf("%w: unsupported claim origin %q", ErrInvalidReceipt, input.Origin)
+	}
+	if input.Origin == ClaimOriginGenerated {
+		if input.Generation == nil || input.Generation.ModelID == "" || input.Generation.ModelVersion == "" || input.Generation.PromptVersion == "" {
+			return fmt.Errorf("%w: generated claims require model and prompt versions", ErrInvalidReceipt)
+		}
+	}
+	switch input.RequestedStatus {
+	case "", ClaimStatusDraft, ClaimStatusShareable, ClaimStatusAuditorReady:
+	default:
+		return fmt.Errorf("%w: status %q cannot be issued directly", ErrInvalidReceipt, input.RequestedStatus)
+	}
+	switch input.DisclosureClass {
+	case DisclosureInternal, DisclosureCustomer, DisclosureAuditor:
+	default:
+		return fmt.Errorf("%w: unsupported disclosure class %q", ErrInvalidReceipt, input.DisclosureClass)
+	}
+	if isExternalStatus(input.RequestedStatus) && input.DisclosureClass == DisclosureInternal {
+		return fmt.Errorf("%w: external status requires customer or auditor disclosure", ErrInvalidReceipt)
+	}
+	for _, ref := range append(append([]VersionedRef(nil), input.Controls...), input.Policies...) {
+		if ref.ID == "" || ref.Version == "" {
+			return fmt.Errorf("%w: control and policy refs require exact versions", ErrInvalidReceipt)
+		}
+	}
+	for _, ref := range input.ResourceRefs {
+		if ref.URN == "" || ref.Revision == "" {
+			return fmt.Errorf("%w: resource refs require urn and revision", ErrInvalidReceipt)
+		}
+	}
+	for _, citation := range input.Citations {
+		if citation.ID == "" || citation.EvidenceID == "" || citation.SourceID == "" || citation.ObservedAt.IsZero() || len(citation.SourceEventIDs) == 0 {
+			return fmt.Errorf("%w: citations require id, evidence_id, source_id, observed_at, and source event ids", ErrInvalidReceipt)
+		}
+		if citation.ObservedAt.After(input.IssuedAt) {
+			return fmt.Errorf("%w: citation %s was observed after receipt issuance", ErrInvalidReceipt, citation.ID)
+		}
+		switch citation.State {
+		case CitationCurrent, CitationStale, CitationRevoked, CitationConflicted:
+		default:
+			return fmt.Errorf("%w: unsupported citation state %q", ErrInvalidReceipt, citation.State)
+		}
+	}
+	return nil
+}
+
+func validateExternalEligibility(receipt ClaimReceipt, at time.Time) error {
+	if len(receipt.Citations) == 0 {
+		return fmt.Errorf("%w: current citations are required", ErrNotShareable)
+	}
+	if receipt.Approval == nil || receipt.Approval.Decision != ApprovalApproved || receipt.Approval.ReviewerID == "" || receipt.Approval.ApprovedAt.IsZero() {
+		return fmt.Errorf("%w: reviewer approval is required", ErrNotShareable)
+	}
+	if len(receipt.UnsupportedClaims) != 0 {
+		return fmt.Errorf("%w: unsupported claims remain", ErrNotShareable)
+	}
+	if receipt.ExpiresAt != nil && !receipt.ExpiresAt.After(at) {
+		return fmt.Errorf("%w: receipt has expired", ErrNotShareable)
+	}
+	if receipt.FreshUntil != nil && !receipt.FreshUntil.After(at) {
+		return fmt.Errorf("%w: receipt freshness window has elapsed", ErrNotShareable)
+	}
+	for _, citation := range receipt.Citations {
+		if citation.State != CitationCurrent || !citation.Trusted {
+			return fmt.Errorf("%w: citation %s is not current and trusted", ErrNotShareable, citation.ID)
+		}
+		if citation.ExpiresAt != nil && !citation.ExpiresAt.After(at) {
+			return fmt.Errorf("%w: citation %s has expired", ErrNotShareable, citation.ID)
+		}
+	}
+	if receipt.Status == ClaimStatusAuditorReady && receipt.DisclosureClass != DisclosureAuditor {
+		return fmt.Errorf("%w: auditor-ready claims require auditor disclosure", ErrNotShareable)
+	}
+	return nil
+}
+
+// ApplyEvidenceChange creates a new immutable receipt version and a workflow
+// transition. It never updates citations in place or transfers prior approval.
+func ApplyEvidenceChange(receipt ClaimReceipt, change EvidenceChange) (ClaimTransition, error) {
+	if err := verifyReceipt(receipt); err != nil {
+		return ClaimTransition{}, err
+	}
+	if receipt.Status == ClaimStatusSuperseded {
+		return ClaimTransition{}, fmt.Errorf("%w: superseded claims cannot be reopened", ErrInvalidReceipt)
+	}
+	change.TenantID = strings.TrimSpace(change.TenantID)
+	change.CitationID = strings.TrimSpace(change.CitationID)
+	change.State = strings.TrimSpace(change.State)
+	change.Reason = strings.TrimSpace(change.Reason)
+	if change.TenantID != receipt.TenantID {
+		return ClaimTransition{}, ErrTenantMismatch
+	}
+	if change.ObservedAt.IsZero() || change.CitationID == "" {
+		return ClaimTransition{}, fmt.Errorf("%w: citation_id and observed_at are required", ErrInvalidReceipt)
+	}
+	switch change.State {
+	case CitationStale, CitationRevoked, CitationConflicted:
+	default:
+		return ClaimTransition{}, fmt.Errorf("%w: evidence changes must be stale, revoked, or conflicted", ErrInvalidReceipt)
+	}
+	citations := append([]Citation(nil), receipt.Citations...)
+	found := false
+	for index := range citations {
+		if citations[index].ID == change.CitationID {
+			citations[index].State = change.State
+			found = true
+		}
+	}
+	if !found {
+		return ClaimTransition{}, fmt.Errorf("%w: citation %s does not belong to receipt", ErrInvalidReceipt, change.CitationID)
+	}
+	status := ClaimStatusReopened
+	transitionType := TransitionClaimReopened
+	if receipt.Status == ClaimStatusShareable || receipt.Status == ClaimStatusAuditorReady {
+		status = ClaimStatusWithdrawn
+		transitionType = TransitionClaimWithdrawn
+	}
+	next := receipt
+	next.Version++
+	next.Status = status
+	next.Citations = citations
+	next.Approval = nil
+	next.IssuedAt = change.ObservedAt.UTC()
+	next.PreviousDigest = receipt.Digest
+	next.TransitionReason = change.Reason
+	next.Digest = ""
+	normalizeReceipt(&next)
+	digest, err := digestValue(receiptWithoutDigest(next))
+	if err != nil {
+		return ClaimTransition{}, err
+	}
+	next.Digest = digest
+	return ClaimTransition{
+		EventKind:      workflowevents.EventKindKnowledgeDecisionRecorded,
+		TransitionType: transitionType,
+		TenantID:       receipt.TenantID,
+		ClaimID:        receipt.ClaimID,
+		FromDigest:     receipt.Digest,
+		Receipt:        next,
+	}, nil
+}
+
+// ReconcileExpiry turns elapsed receipt or citation freshness into an explicit
+// transition. A nil transition means the immutable receipt remains current.
+func ReconcileExpiry(receipt ClaimReceipt, at time.Time) (*ClaimTransition, error) {
+	if err := verifyReceipt(receipt); err != nil {
+		return nil, err
+	}
+	if at.IsZero() {
+		return nil, fmt.Errorf("%w: reconciliation time is required", ErrInvalidReceipt)
+	}
+	for _, citation := range receipt.Citations {
+		if citation.ExpiresAt != nil && !citation.ExpiresAt.After(at) {
+			transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
+				TenantID: receipt.TenantID, CitationID: citation.ID, State: CitationStale,
+				Reason: "Cited evidence expired.", ObservedAt: at,
+			})
+			return &transition, err
+		}
+	}
+	if (receipt.ExpiresAt != nil && !receipt.ExpiresAt.After(at)) || (receipt.FreshUntil != nil && !receipt.FreshUntil.After(at)) {
+		if len(receipt.Citations) == 0 {
+			return nil, fmt.Errorf("%w: expiring receipt has no citation to invalidate", ErrInvalidReceipt)
+		}
+		transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
+			TenantID: receipt.TenantID, CitationID: receipt.Citations[0].ID, State: CitationStale,
+			Reason: "Claim freshness window elapsed.", ObservedAt: at,
+		})
+		return &transition, err
+	}
+	return nil, nil
+}
+
+func SupersedeReceipt(receipt ClaimReceipt, successorReceiptID string, at time.Time) (ClaimTransition, error) {
+	if err := verifyReceipt(receipt); err != nil {
+		return ClaimTransition{}, err
+	}
+	if strings.TrimSpace(successorReceiptID) == "" || at.IsZero() {
+		return ClaimTransition{}, fmt.Errorf("%w: successor receipt and transition time are required", ErrInvalidReceipt)
+	}
+	next := receipt
+	next.Version++
+	next.Status = ClaimStatusSuperseded
+	next.Approval = nil
+	next.IssuedAt = at.UTC()
+	next.PreviousDigest = receipt.Digest
+	next.TransitionReason = "Superseded by receipt " + strings.TrimSpace(successorReceiptID) + "."
+	next.Digest = ""
+	normalizeReceipt(&next)
+	digest, err := digestValue(receiptWithoutDigest(next))
+	if err != nil {
+		return ClaimTransition{}, err
+	}
+	next.Digest = digest
+	return ClaimTransition{EventKind: workflowevents.EventKindKnowledgeDecisionRecorded, TransitionType: TransitionClaimSuperseded, TenantID: receipt.TenantID, ClaimID: receipt.ClaimID, FromDigest: receipt.Digest, Receipt: next}, nil
+}
+
+func SuggestObligation(input ObligationInput) (Obligation, error) {
+	if input.SuggestedBy == nil {
+		return Obligation{}, fmt.Errorf("%w: extracted suggestion receipt is required", ErrInvalidReceipt)
+	}
+	return buildObligation(input, ObligationSuggested, nil)
+}
+
+func ConfirmObligation(suggestion Obligation, approval ReviewerApproval, at time.Time) (Obligation, error) {
+	if err := verifyObligation(suggestion); err != nil {
+		return Obligation{}, err
+	}
+	if suggestion.Status != ObligationSuggested {
+		return Obligation{}, fmt.Errorf("%w: only suggestions can be confirmed", ErrHumanConfirmationRequired)
+	}
+	normalizeApproval(&approval)
+	if approval.Decision != ApprovalApproved || approval.ReviewerID == "" || approval.ApprovedAt.IsZero() {
+		return Obligation{}, ErrHumanConfirmationRequired
+	}
+	if at.IsZero() {
+		return Obligation{}, fmt.Errorf("%w: confirmation time is required", ErrInvalidReceipt)
+	}
+	next := suggestion
+	next.Version++
+	next.Status = ObligationActive
+	next.ConfirmedBy = &approval
+	next.IssuedAt = at.UTC()
+	next.PreviousDigest = suggestion.Digest
+	next.Digest = ""
+	normalizeObligation(&next)
+	digest, err := digestValue(obligationWithoutDigest(next))
+	if err != nil {
+		return Obligation{}, err
+	}
+	next.Digest = digest
+	return next, nil
+}
+
+func SupersedeObligation(obligation Obligation, successorID string, at time.Time) (Obligation, error) {
+	if err := verifyObligation(obligation); err != nil {
+		return Obligation{}, err
+	}
+	if obligation.Status != ObligationActive || strings.TrimSpace(successorID) == "" || at.IsZero() {
+		return Obligation{}, fmt.Errorf("%w: active obligation, successor id, and transition time are required", ErrInvalidReceipt)
+	}
+	next := obligation
+	next.Version++
+	next.Status = ObligationSuperseded
+	next.SupersededBy = strings.TrimSpace(successorID)
+	next.IssuedAt = at.UTC()
+	next.PreviousDigest = obligation.Digest
+	next.Digest = ""
+	normalizeObligation(&next)
+	digest, err := digestValue(obligationWithoutDigest(next))
+	if err != nil {
+		return Obligation{}, err
+	}
+	next.Digest = digest
+	return next, nil
+}
+
+func buildObligation(input ObligationInput, status string, approval *ReviewerApproval) (Obligation, error) {
+	normalizeObligationInput(&input)
+	if input.TenantID == "" || input.ObligationID == "" || input.Version < 1 || input.ContractRef.ID == "" || input.ContractRef.Version == "" || input.CommitmentRef == "" || input.OwnerID == "" || input.IssuedAt.IsZero() {
+		return Obligation{}, fmt.Errorf("%w: obligation identity, contract version, commitment, owner, version, and issued_at are required", ErrInvalidReceipt)
+	}
+	if input.SuggestedBy == nil || input.SuggestedBy.SourceRef == "" || input.SuggestedBy.ExtractorID == "" {
+		return Obligation{}, fmt.Errorf("%w: extracted obligations require source and extractor receipts", ErrInvalidReceipt)
+	}
+	if len(input.Controls) == 0 || len(input.EvidenceRequirements) == 0 || len(input.ResourcePopulation) == 0 {
+		return Obligation{}, fmt.Errorf("%w: controls, evidence requirements, and resource population are required", ErrInvalidReceipt)
+	}
+	obligation := Obligation{
+		SchemaVersion:        ObligationSchemaVersion,
+		TenantID:             input.TenantID,
+		ObligationID:         input.ObligationID,
+		Version:              input.Version,
+		Status:               status,
+		ContractRef:          input.ContractRef,
+		CommitmentRef:        input.CommitmentRef,
+		Controls:             input.Controls,
+		EvidenceRequirements: input.EvidenceRequirements,
+		ResourcePopulation:   input.ResourcePopulation,
+		OwnerID:              input.OwnerID,
+		Deadline:             utcTimePtr(input.Deadline),
+		SuggestedBy:          input.SuggestedBy,
+		ConfirmedBy:          approval,
+		PreviousDigest:       input.PreviousDigest,
+		IssuedAt:             input.IssuedAt.UTC(),
+	}
+	digest, err := digestValue(obligationWithoutDigest(obligation))
+	if err != nil {
+		return Obligation{}, err
+	}
+	obligation.Digest = digest
+	return obligation, nil
+}
+
+// ReadService reads caller-supplied current-state records. Persistence remains
+// owned by the existing state store and workflow event projection.
+type ReadService struct {
+	Receipts    []ClaimReceipt
+	Obligations []Obligation
+}
+
+func (service ReadService) GetReceipt(tenantID, receiptID string) (ClaimReceipt, error) {
+	tenantID = strings.TrimSpace(tenantID)
+	receiptID = strings.TrimSpace(receiptID)
+	for _, receipt := range service.Receipts {
+		if receipt.ReceiptID != receiptID {
+			continue
+		}
+		if receipt.TenantID != tenantID {
+			return ClaimReceipt{}, ErrTenantMismatch
+		}
+		if err := verifyReceipt(receipt); err != nil {
+			return ClaimReceipt{}, err
+		}
+		return receipt, nil
+	}
+	return ClaimReceipt{}, ErrReceiptNotFound
+}
+
+func (service ReadService) BuildPackage(request PackageRequest) (ClaimPackage, error) {
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.Audience = strings.TrimSpace(request.Audience)
+	request.ReceiptIDs = uniqueSortedStrings(request.ReceiptIDs)
+	request.ObligationIDs = uniqueSortedStrings(request.ObligationIDs)
+	if request.TenantID == "" || request.PackagedAt.IsZero() || (request.Audience != DisclosureCustomer && request.Audience != DisclosureAuditor) {
+		return ClaimPackage{}, fmt.Errorf("%w: tenant, customer or auditor audience, and packaged_at are required", ErrInvalidReceipt)
+	}
+	pack := ClaimPackage{SchemaVersion: PackageSchemaVersion, TenantID: request.TenantID, Audience: request.Audience, PackagedAt: request.PackagedAt.UTC()}
+	for _, id := range request.ReceiptIDs {
+		receipt, err := service.GetReceipt(request.TenantID, id)
+		if err != nil {
+			return ClaimPackage{}, err
+		}
+		if request.Audience == DisclosureAuditor && receipt.Status != ClaimStatusAuditorReady {
+			return ClaimPackage{}, fmt.Errorf("%w: receipt %s is not auditor ready", ErrNotShareable, id)
+		}
+		if request.Audience == DisclosureCustomer && receipt.Status != ClaimStatusShareable && receipt.Status != ClaimStatusAuditorReady {
+			return ClaimPackage{}, fmt.Errorf("%w: receipt %s is not customer shareable", ErrNotShareable, id)
+		}
+		if err := validateExternalEligibility(receipt, request.PackagedAt); err != nil {
+			return ClaimPackage{}, err
+		}
+		pack.Receipts = append(pack.Receipts, receipt)
+	}
+	for _, id := range request.ObligationIDs {
+		obligation, err := service.getObligation(request.TenantID, id)
+		if err != nil {
+			return ClaimPackage{}, err
+		}
+		if obligation.Status != ObligationActive {
+			return ClaimPackage{}, fmt.Errorf("%w: obligation %s is not active", ErrNotShareable, id)
+		}
+		pack.Obligations = append(pack.Obligations, obligation)
+	}
+	digest, err := digestValue(packageWithoutDigest(pack))
+	if err != nil {
+		return ClaimPackage{}, err
+	}
+	pack.Digest = digest
+	return pack, nil
+}
+
+func (service ReadService) getObligation(tenantID, obligationID string) (Obligation, error) {
+	for _, obligation := range service.Obligations {
+		if obligation.ObligationID != obligationID {
+			continue
+		}
+		if obligation.TenantID != tenantID {
+			return Obligation{}, ErrTenantMismatch
+		}
+		if err := verifyObligation(obligation); err != nil {
+			return Obligation{}, err
+		}
+		return obligation, nil
+	}
+	return Obligation{}, ErrObligationNotFound
+}
+
+func verifyReceipt(receipt ClaimReceipt) error {
+	if receipt.SchemaVersion != ReceiptSchemaVersion || receipt.Digest == "" {
+		return fmt.Errorf("%w: schema version and digest are required", ErrInvalidReceipt)
+	}
+	digest, err := digestValue(receiptWithoutDigest(receipt))
+	if err != nil {
+		return err
+	}
+	if digest != receipt.Digest {
+		return fmt.Errorf("%w: receipt digest does not match content", ErrInvalidReceipt)
+	}
+	return nil
+}
+
+func verifyObligation(obligation Obligation) error {
+	digest, err := digestValue(obligationWithoutDigest(obligation))
+	if err != nil {
+		return err
+	}
+	if obligation.SchemaVersion != ObligationSchemaVersion || obligation.Digest == "" || digest != obligation.Digest {
+		return fmt.Errorf("%w: obligation digest does not match content", ErrInvalidReceipt)
+	}
+	return nil
+}
+
+func normalizeReceiptInput(input *ReceiptInput) {
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.ReceiptID = strings.TrimSpace(input.ReceiptID)
+	input.ClaimID = strings.TrimSpace(input.ClaimID)
+	input.Statement = strings.TrimSpace(input.Statement)
+	input.Origin = strings.TrimSpace(input.Origin)
+	input.RequestedStatus = strings.TrimSpace(input.RequestedStatus)
+	input.DisclosureClass = strings.TrimSpace(input.DisclosureClass)
+	input.PreviousDigest = strings.TrimSpace(input.PreviousDigest)
+	if input.Version == 0 {
+		input.Version = 1
+	}
+	input.IssuedAt = input.IssuedAt.UTC()
+	input.UnsupportedClaims = uniqueSortedStrings(input.UnsupportedClaims)
+	normalizeCitations(input.Citations)
+	input.Controls = normalizeVersionedRefs(input.Controls)
+	input.Policies = normalizeVersionedRefs(input.Policies)
+	input.ResourceRefs = normalizeResourceRefs(input.ResourceRefs)
+	if input.Generation != nil {
+		normalizeGeneration(input.Generation)
+	}
+	if input.Approval != nil {
+		normalizeApproval(input.Approval)
+	}
+}
+
+func normalizeReceipt(receipt *ClaimReceipt) {
+	normalizeCitations(receipt.Citations)
+	receipt.Controls = normalizeVersionedRefs(receipt.Controls)
+	receipt.Policies = normalizeVersionedRefs(receipt.Policies)
+	receipt.ResourceRefs = normalizeResourceRefs(receipt.ResourceRefs)
+	receipt.UnsupportedClaims = uniqueSortedStrings(receipt.UnsupportedClaims)
+	receipt.IssuedAt = receipt.IssuedAt.UTC()
+}
+
+func normalizeCitations(citations []Citation) {
+	for index := range citations {
+		citation := &citations[index]
+		citation.ID = strings.TrimSpace(citation.ID)
+		citation.EvidenceID = strings.TrimSpace(citation.EvidenceID)
+		citation.EvidencePacketID = strings.TrimSpace(citation.EvidencePacketID)
+		citation.EvidenceType = strings.TrimSpace(citation.EvidenceType)
+		citation.SourceID = strings.TrimSpace(citation.SourceID)
+		citation.RuntimeID = strings.TrimSpace(citation.RuntimeID)
+		citation.State = strings.TrimSpace(citation.State)
+		citation.SourceEventIDs = uniqueSortedStrings(citation.SourceEventIDs)
+		citation.ResourceRefs = normalizeResourceRefs(citation.ResourceRefs)
+		citation.ObservedAt = citation.ObservedAt.UTC()
+		citation.ExpiresAt = utcTimePtr(citation.ExpiresAt)
+	}
+	sort.Slice(citations, func(i, j int) bool { return citations[i].ID < citations[j].ID })
+}
+
+func normalizeVersionedRefs(refs []VersionedRef) []VersionedRef {
+	result := append([]VersionedRef(nil), refs...)
+	for index := range result {
+		result[index].ID = strings.TrimSpace(result[index].ID)
+		result[index].Version = strings.TrimSpace(result[index].Version)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ID == result[j].ID {
+			return result[i].Version < result[j].Version
+		}
+		return result[i].ID < result[j].ID
+	})
+	return dedupeVersionedRefs(result)
+}
+
+func normalizeResourceRefs(refs []ResourceRef) []ResourceRef {
+	result := append([]ResourceRef(nil), refs...)
+	for index := range result {
+		result[index].URN = strings.TrimSpace(result[index].URN)
+		result[index].Revision = strings.TrimSpace(result[index].Revision)
+		result[index].Type = strings.TrimSpace(result[index].Type)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return resourceKey(result[i]) < resourceKey(result[j])
+	})
+	return dedupeResourceRefs(result)
+}
+
+func normalizeObligationInput(input *ObligationInput) {
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.ObligationID = strings.TrimSpace(input.ObligationID)
+	input.ContractRef = normalizeVersionedRefs([]VersionedRef{input.ContractRef})[0]
+	input.CommitmentRef = strings.TrimSpace(input.CommitmentRef)
+	input.Controls = normalizeVersionedRefs(input.Controls)
+	input.EvidenceRequirements = normalizeVersionedRefs(input.EvidenceRequirements)
+	input.ResourcePopulation = normalizeResourceRefs(input.ResourcePopulation)
+	input.OwnerID = strings.TrimSpace(input.OwnerID)
+	input.IssuedAt = input.IssuedAt.UTC()
+	input.PreviousDigest = strings.TrimSpace(input.PreviousDigest)
+	if input.Version == 0 {
+		input.Version = 1
+	}
+	if input.SuggestedBy != nil {
+		input.SuggestedBy.SourceRef = strings.TrimSpace(input.SuggestedBy.SourceRef)
+		input.SuggestedBy.ExtractorID = strings.TrimSpace(input.SuggestedBy.ExtractorID)
+		input.SuggestedBy.ModelVersion = strings.TrimSpace(input.SuggestedBy.ModelVersion)
+		input.SuggestedBy.PromptVersion = strings.TrimSpace(input.SuggestedBy.PromptVersion)
+	}
+}
+
+func normalizeObligation(obligation *Obligation) {
+	obligation.Controls = normalizeVersionedRefs(obligation.Controls)
+	obligation.EvidenceRequirements = normalizeVersionedRefs(obligation.EvidenceRequirements)
+	obligation.ResourcePopulation = normalizeResourceRefs(obligation.ResourcePopulation)
+	obligation.IssuedAt = obligation.IssuedAt.UTC()
+}
+
+func normalizeGeneration(generation *GenerationReceipt) {
+	generation.ModelID = strings.TrimSpace(generation.ModelID)
+	generation.ModelVersion = strings.TrimSpace(generation.ModelVersion)
+	generation.PromptVersion = strings.TrimSpace(generation.PromptVersion)
+	generation.PromptDigest = strings.TrimSpace(generation.PromptDigest)
+}
+
+func normalizeApproval(approval *ReviewerApproval) {
+	approval.ReviewerID = strings.TrimSpace(approval.ReviewerID)
+	approval.Decision = strings.TrimSpace(approval.Decision)
+	approval.Reason = strings.TrimSpace(approval.Reason)
+	approval.ApprovedAt = approval.ApprovedAt.UTC()
+}
+
+func uniqueSortedStrings(values []string) []string {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func dedupeVersionedRefs(refs []VersionedRef) []VersionedRef {
+	result := refs[:0]
+	last := ""
+	for _, ref := range refs {
+		key := ref.ID + "\x00" + ref.Version
+		if ref.ID == "" || ref.Version == "" || key == last {
+			continue
+		}
+		result = append(result, ref)
+		last = key
+	}
+	return result
+}
+
+func dedupeResourceRefs(refs []ResourceRef) []ResourceRef {
+	result := refs[:0]
+	last := ""
+	for _, ref := range refs {
+		key := resourceKey(ref)
+		if ref.URN == "" || key == last {
+			continue
+		}
+		result = append(result, ref)
+		last = key
+	}
+	return result
+}
+
+func resourceKey(ref ResourceRef) string { return ref.URN + "\x00" + ref.Revision + "\x00" + ref.Type }
+func utcTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalized := value.UTC()
+	return &normalized
+}
+func isExternalStatus(status string) bool {
+	return status == ClaimStatusShareable || status == ClaimStatusAuditorReady
+}
+
+func digestValue(value any) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("canonical receipt encoding: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func receiptWithoutDigest(receipt ClaimReceipt) ClaimReceipt { receipt.Digest = ""; return receipt }
+func obligationWithoutDigest(obligation Obligation) Obligation {
+	obligation.Digest = ""
+	return obligation
+}
+func packageWithoutDigest(pack ClaimPackage) ClaimPackage { pack.Digest = ""; return pack }

--- a/internal/trustclaims/service.go
+++ b/internal/trustclaims/service.go
@@ -16,6 +16,8 @@ import (
 
 var (
 	ErrInvalidReceipt            = errors.New("invalid trust claim receipt")
+	ErrInvalidVersionedReference = errors.New("control and policy refs require exact versions")
+	ErrInvalidResourceReference  = errors.New("resource refs require urn and revision")
 	ErrNotShareable              = errors.New("trust claim is not shareable")
 	ErrTenantMismatch            = errors.New("tenant mismatch")
 	ErrReceiptNotFound           = errors.New("trust claim receipt not found")
@@ -72,12 +74,12 @@ func IssueReceipt(input ReceiptInput) (ClaimReceipt, error) {
 func validateReceiptReferenceInput(input ReceiptInput) error {
 	for _, ref := range append(append([]VersionedRef(nil), input.Controls...), input.Policies...) {
 		if strings.TrimSpace(ref.ID) == "" || strings.TrimSpace(ref.Version) == "" {
-			return fmt.Errorf("%w: control and policy refs require exact versions", ErrInvalidReceipt)
+			return fmt.Errorf("%w: %w", ErrInvalidReceipt, ErrInvalidVersionedReference)
 		}
 	}
 	for _, ref := range input.ResourceRefs {
 		if strings.TrimSpace(ref.URN) == "" || strings.TrimSpace(ref.Revision) == "" {
-			return fmt.Errorf("%w: resource refs require urn and revision", ErrInvalidReceipt)
+			return fmt.Errorf("%w: %w", ErrInvalidReceipt, ErrInvalidResourceReference)
 		}
 	}
 	return nil

--- a/internal/trustclaims/service.go
+++ b/internal/trustclaims/service.go
@@ -21,6 +21,7 @@ var (
 	ErrReceiptNotFound           = errors.New("trust claim receipt not found")
 	ErrObligationNotFound        = errors.New("trust obligation not found")
 	ErrHumanConfirmationRequired = errors.New("human confirmation is required")
+	ErrMalformedReference        = errors.New("malformed trust claim reference")
 )
 
 func IssueReceipt(input ReceiptInput) (ClaimReceipt, error) {
@@ -72,12 +73,12 @@ func IssueReceipt(input ReceiptInput) (ClaimReceipt, error) {
 func validateReceiptReferenceInput(input ReceiptInput) error {
 	for _, ref := range append(append([]VersionedRef(nil), input.Controls...), input.Policies...) {
 		if strings.TrimSpace(ref.ID) == "" || strings.TrimSpace(ref.Version) == "" {
-			return fmt.Errorf("%w: control and policy refs require exact versions", ErrInvalidReceipt)
+			return fmt.Errorf("%w: %w: control and policy refs require exact versions", ErrInvalidReceipt, ErrMalformedReference)
 		}
 	}
 	for _, ref := range input.ResourceRefs {
 		if strings.TrimSpace(ref.URN) == "" || strings.TrimSpace(ref.Revision) == "" {
-			return fmt.Errorf("%w: resource refs require urn and revision", ErrInvalidReceipt)
+			return fmt.Errorf("%w: %w: resource refs require urn and revision", ErrInvalidReceipt, ErrMalformedReference)
 		}
 	}
 	return nil

--- a/internal/trustclaims/service.go
+++ b/internal/trustclaims/service.go
@@ -578,7 +578,8 @@ func normalizeResourceRefs(refs []ResourceRef) []ResourceRef {
 func normalizeObligationInput(input *ObligationInput) {
 	input.TenantID = strings.TrimSpace(input.TenantID)
 	input.ObligationID = strings.TrimSpace(input.ObligationID)
-	input.ContractRef = normalizeVersionedRefs([]VersionedRef{input.ContractRef})[0]
+	input.ContractRef.ID = strings.TrimSpace(input.ContractRef.ID)
+	input.ContractRef.Version = strings.TrimSpace(input.ContractRef.Version)
 	input.CommitmentRef = strings.TrimSpace(input.CommitmentRef)
 	input.Controls = normalizeVersionedRefs(input.Controls)
 	input.EvidenceRequirements = normalizeVersionedRefs(input.EvidenceRequirements)

--- a/internal/trustclaims/service.go
+++ b/internal/trustclaims/service.go
@@ -24,6 +24,9 @@ var (
 )
 
 func IssueReceipt(input ReceiptInput) (ClaimReceipt, error) {
+	if err := validateReceiptReferenceInput(input); err != nil {
+		return ClaimReceipt{}, err
+	}
 	normalizeReceiptInput(&input)
 	if err := validateReceiptInput(input); err != nil {
 		return ClaimReceipt{}, err
@@ -64,6 +67,20 @@ func IssueReceipt(input ReceiptInput) (ClaimReceipt, error) {
 	}
 	receipt.Digest = digest
 	return receipt, nil
+}
+
+func validateReceiptReferenceInput(input ReceiptInput) error {
+	for _, ref := range append(append([]VersionedRef(nil), input.Controls...), input.Policies...) {
+		if strings.TrimSpace(ref.ID) == "" || strings.TrimSpace(ref.Version) == "" {
+			return fmt.Errorf("%w: control and policy refs require exact versions", ErrInvalidReceipt)
+		}
+	}
+	for _, ref := range input.ResourceRefs {
+		if strings.TrimSpace(ref.URN) == "" || strings.TrimSpace(ref.Revision) == "" {
+			return fmt.Errorf("%w: resource refs require urn and revision", ErrInvalidReceipt)
+		}
+	}
+	return nil
 }
 
 func validateReceiptInput(input ReceiptInput) error {
@@ -110,16 +127,6 @@ func validateReceiptInput(input ReceiptInput) error {
 	}
 	if isExternalStatus(input.RequestedStatus) && input.DisclosureClass == DisclosureInternal {
 		return fmt.Errorf("%w: external status requires customer or auditor disclosure", ErrInvalidReceipt)
-	}
-	for _, ref := range append(append([]VersionedRef(nil), input.Controls...), input.Policies...) {
-		if ref.ID == "" || ref.Version == "" {
-			return fmt.Errorf("%w: control and policy refs require exact versions", ErrInvalidReceipt)
-		}
-	}
-	for _, ref := range input.ResourceRefs {
-		if ref.URN == "" || ref.Revision == "" {
-			return fmt.Errorf("%w: resource refs require urn and revision", ErrInvalidReceipt)
-		}
 	}
 	for _, citation := range input.Citations {
 		if citation.ID == "" || citation.EvidenceID == "" || citation.SourceID == "" || citation.ObservedAt.IsZero() || len(citation.SourceEventIDs) == 0 {
@@ -204,7 +211,7 @@ func ApplyEvidenceChange(receipt ClaimReceipt, change EvidenceChange) (ClaimTran
 	}
 	status := ClaimStatusReopened
 	transitionType := TransitionClaimReopened
-	if receipt.Status == ClaimStatusShareable || receipt.Status == ClaimStatusAuditorReady {
+	if receipt.Status == ClaimStatusShareable || receipt.Status == ClaimStatusAuditorReady || receipt.Status == ClaimStatusWithdrawn {
 		status = ClaimStatusWithdrawn
 		transitionType = TransitionClaimWithdrawn
 	}

--- a/internal/trustclaims/service.go
+++ b/internal/trustclaims/service.go
@@ -243,6 +243,9 @@ func ReconcileExpiry(receipt ClaimReceipt, at time.Time) (*ClaimTransition, erro
 		return nil, fmt.Errorf("%w: reconciliation time is required", ErrInvalidReceipt)
 	}
 	for _, citation := range receipt.Citations {
+		if citation.State != CitationCurrent {
+			continue
+		}
 		if citation.ExpiresAt != nil && !citation.ExpiresAt.After(at) {
 			transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
 				TenantID: receipt.TenantID, CitationID: citation.ID, State: CitationStale,
@@ -252,11 +255,18 @@ func ReconcileExpiry(receipt ClaimReceipt, at time.Time) (*ClaimTransition, erro
 		}
 	}
 	if (receipt.ExpiresAt != nil && !receipt.ExpiresAt.After(at)) || (receipt.FreshUntil != nil && !receipt.FreshUntil.After(at)) {
-		if len(receipt.Citations) == 0 {
-			return nil, fmt.Errorf("%w: expiring receipt has no citation to invalidate", ErrInvalidReceipt)
+		citationID := ""
+		for _, citation := range receipt.Citations {
+			if citation.State == CitationCurrent {
+				citationID = citation.ID
+				break
+			}
+		}
+		if citationID == "" {
+			return nil, nil
 		}
 		transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
-			TenantID: receipt.TenantID, CitationID: receipt.Citations[0].ID, State: CitationStale,
+			TenantID: receipt.TenantID, CitationID: citationID, State: CitationStale,
 			Reason: "Claim freshness window elapsed.", ObservedAt: at,
 		})
 		return &transition, err

--- a/internal/trustclaims/service_test.go
+++ b/internal/trustclaims/service_test.go
@@ -2,7 +2,6 @@ package trustclaims
 
 import (
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -134,30 +133,30 @@ func TestEvidenceInvalidationKeepsWithdrawnClaimWithdrawn(t *testing.T) {
 func TestIssueReceiptRejectsMalformedReferencesBeforeNormalization(t *testing.T) {
 	now := fixedTime()
 	tests := []struct {
-		name    string
-		mutate  func(*ReceiptInput)
-		message string
+		name   string
+		mutate func(*ReceiptInput)
+		target error
 	}{
 		{name: "control version", mutate: func(input *ReceiptInput) {
 			input.Controls = append(input.Controls, VersionedRef{ID: "control-other", Version: " "})
-		}, message: "control and policy refs require exact versions"},
+		}, target: ErrInvalidVersionedReference},
 		{name: "policy id", mutate: func(input *ReceiptInput) {
 			input.Policies = append(input.Policies, VersionedRef{ID: " ", Version: "2"})
-		}, message: "control and policy refs require exact versions"},
+		}, target: ErrInvalidVersionedReference},
 		{name: "resource urn", mutate: func(input *ReceiptInput) {
 			input.ResourceRefs = append(input.ResourceRefs, ResourceRef{URN: " ", Revision: "2"})
-		}, message: "resource refs require urn and revision"},
+		}, target: ErrInvalidResourceReference},
 		{name: "resource revision", mutate: func(input *ReceiptInput) {
 			input.ResourceRefs = append(input.ResourceRefs, ResourceRef{URN: "urn:resource:other", Revision: " "})
-		}, message: "resource refs require urn and revision"},
+		}, target: ErrInvalidResourceReference},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			input := validReceiptInput(now, ClaimStatusDraft, DisclosureInternal)
 			test.mutate(&input)
 			_, err := IssueReceipt(input)
-			if !errors.Is(err, ErrInvalidReceipt) || !strings.Contains(err.Error(), test.message) {
-				t.Fatalf("IssueReceipt() error = %v, want %q", err, test.message)
+			if !errors.Is(err, ErrInvalidReceipt) || !errors.Is(err, test.target) {
+				t.Fatalf("IssueReceipt() error = %v, want ErrInvalidReceipt and %v", err, test.target)
 			}
 		})
 	}

--- a/internal/trustclaims/service_test.go
+++ b/internal/trustclaims/service_test.go
@@ -229,6 +229,14 @@ func TestExtractedObligationRequiresHumanConfirmationAndPreservesSupersession(t 
 	}
 }
 
+func TestInvalidObligationContractReturnsError(t *testing.T) {
+	input := validObligationInput(fixedTime())
+	input.ContractRef = VersionedRef{}
+	if _, err := SuggestObligation(input); !errors.Is(err, ErrInvalidReceipt) {
+		t.Fatalf("SuggestObligation() error = %v, want ErrInvalidReceipt", err)
+	}
+}
+
 func TestExistingQuestionnaireAndEvidencePacketLineageIsPreserved(t *testing.T) {
 	now := fixedTime()
 	questionnaireCitation := CitationFromQuestionnaire(ports.QuestionnaireCitation{

--- a/internal/trustclaims/service_test.go
+++ b/internal/trustclaims/service_test.go
@@ -2,6 +2,7 @@ package trustclaims
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -103,6 +104,62 @@ func TestEvidenceInvalidationWithdrawsShareableClaimWithoutRefreshingApproval(t 
 	}
 	if _, err := workflowevents.NewDecisionRecordedEvent(decision); err != nil {
 		t.Fatalf("NewDecisionRecordedEvent() error = %v", err)
+	}
+}
+
+func TestEvidenceInvalidationKeepsWithdrawnClaimWithdrawn(t *testing.T) {
+	now := fixedTime()
+	input := validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer)
+	input.Citations = append(input.Citations, validCitation("citation-b", now))
+	receipt := mustIssue(t, input)
+	first, err := ApplyEvidenceChange(receipt, EvidenceChange{
+		TenantID: receipt.TenantID, CitationID: "citation-a", State: CitationConflicted,
+		Reason: "Two current sources disagree.", ObservedAt: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ApplyEvidenceChange(first.Receipt, EvidenceChange{
+		TenantID: receipt.TenantID, CitationID: "citation-b", State: CitationRevoked,
+		Reason: "The remaining source retracted the record.", ObservedAt: now.Add(2 * time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.TransitionType != TransitionClaimWithdrawn || second.Receipt.Status != ClaimStatusWithdrawn {
+		t.Fatalf("second transition = %#v, want withdrawn claim to remain withdrawn", second)
+	}
+}
+
+func TestIssueReceiptRejectsMalformedReferencesBeforeNormalization(t *testing.T) {
+	now := fixedTime()
+	tests := []struct {
+		name    string
+		mutate  func(*ReceiptInput)
+		message string
+	}{
+		{name: "control version", mutate: func(input *ReceiptInput) {
+			input.Controls = append(input.Controls, VersionedRef{ID: "control-other", Version: " "})
+		}, message: "control and policy refs require exact versions"},
+		{name: "policy id", mutate: func(input *ReceiptInput) {
+			input.Policies = append(input.Policies, VersionedRef{ID: " ", Version: "2"})
+		}, message: "control and policy refs require exact versions"},
+		{name: "resource urn", mutate: func(input *ReceiptInput) {
+			input.ResourceRefs = append(input.ResourceRefs, ResourceRef{URN: " ", Revision: "2"})
+		}, message: "resource refs require urn and revision"},
+		{name: "resource revision", mutate: func(input *ReceiptInput) {
+			input.ResourceRefs = append(input.ResourceRefs, ResourceRef{URN: "urn:resource:other", Revision: " "})
+		}, message: "resource refs require urn and revision"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validReceiptInput(now, ClaimStatusDraft, DisclosureInternal)
+			test.mutate(&input)
+			_, err := IssueReceipt(input)
+			if !errors.Is(err, ErrInvalidReceipt) || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("IssueReceipt() error = %v, want %q", err, test.message)
+			}
+		})
 	}
 }
 

--- a/internal/trustclaims/service_test.go
+++ b/internal/trustclaims/service_test.go
@@ -2,7 +2,6 @@ package trustclaims
 
 import (
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -134,30 +133,29 @@ func TestEvidenceInvalidationKeepsWithdrawnClaimWithdrawn(t *testing.T) {
 func TestIssueReceiptRejectsMalformedReferencesBeforeNormalization(t *testing.T) {
 	now := fixedTime()
 	tests := []struct {
-		name    string
-		mutate  func(*ReceiptInput)
-		message string
+		name   string
+		mutate func(*ReceiptInput)
 	}{
 		{name: "control version", mutate: func(input *ReceiptInput) {
 			input.Controls = append(input.Controls, VersionedRef{ID: "control-other", Version: " "})
-		}, message: "control and policy refs require exact versions"},
+		}},
 		{name: "policy id", mutate: func(input *ReceiptInput) {
 			input.Policies = append(input.Policies, VersionedRef{ID: " ", Version: "2"})
-		}, message: "control and policy refs require exact versions"},
+		}},
 		{name: "resource urn", mutate: func(input *ReceiptInput) {
 			input.ResourceRefs = append(input.ResourceRefs, ResourceRef{URN: " ", Revision: "2"})
-		}, message: "resource refs require urn and revision"},
+		}},
 		{name: "resource revision", mutate: func(input *ReceiptInput) {
 			input.ResourceRefs = append(input.ResourceRefs, ResourceRef{URN: "urn:resource:other", Revision: " "})
-		}, message: "resource refs require urn and revision"},
+		}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			input := validReceiptInput(now, ClaimStatusDraft, DisclosureInternal)
 			test.mutate(&input)
 			_, err := IssueReceipt(input)
-			if !errors.Is(err, ErrInvalidReceipt) || !strings.Contains(err.Error(), test.message) {
-				t.Fatalf("IssueReceipt() error = %v, want %q", err, test.message)
+			if !errors.Is(err, ErrInvalidReceipt) || !errors.Is(err, ErrMalformedReference) {
+				t.Fatalf("IssueReceipt() error = %v, want invalid receipt and malformed reference", err)
 			}
 		})
 	}

--- a/internal/trustclaims/service_test.go
+++ b/internal/trustclaims/service_test.go
@@ -135,6 +135,37 @@ func TestExpiryEmitsWithdrawal(t *testing.T) {
 	if transition == nil || transition.TransitionType != TransitionClaimWithdrawn || transition.Receipt.Status != ClaimStatusWithdrawn {
 		t.Fatalf("transition = %#v, want withdrawal", transition)
 	}
+	repeated, err := ReconcileExpiry(transition.Receipt, expires.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repeated != nil {
+		t.Fatalf("repeated transition = %#v, want nil after citation is stale", repeated)
+	}
+}
+
+func TestReceiptExpiryStopsAfterAllCurrentCitationsAreInvalidated(t *testing.T) {
+	now := fixedTime()
+	input := validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer)
+	expires := now.Add(time.Hour)
+	input.FreshUntil = &expires
+	input.ExpiresAt = &expires
+	receipt := mustIssue(t, input)
+
+	transition, err := ReconcileExpiry(receipt, expires.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition == nil || transition.Receipt.Citations[0].State != CitationStale {
+		t.Fatalf("transition = %#v, want current citation invalidated", transition)
+	}
+	repeated, err := ReconcileExpiry(transition.Receipt, expires.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repeated != nil {
+		t.Fatalf("repeated transition = %#v, want nil when no current citation remains", repeated)
+	}
 }
 
 func TestSupersededClaimCannotBePackaged(t *testing.T) {

--- a/internal/trustclaims/service_test.go
+++ b/internal/trustclaims/service_test.go
@@ -1,0 +1,302 @@
+package trustclaims
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/evidencepackets"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+func TestExternalClaimRequiresCurrentCitationsAndApproval(t *testing.T) {
+	now := fixedTime()
+	tests := []struct {
+		name   string
+		mutate func(*ReceiptInput)
+	}{
+		{name: "uncited", mutate: func(input *ReceiptInput) { input.Citations = nil }},
+		{name: "unapproved", mutate: func(input *ReceiptInput) { input.Approval = nil }},
+		{name: "unsupported", mutate: func(input *ReceiptInput) {
+			input.UnsupportedClaims = []string{"The retention period is not supported."}
+		}},
+		{name: "stale", mutate: func(input *ReceiptInput) { input.Citations[0].State = CitationStale }},
+		{name: "conflicted", mutate: func(input *ReceiptInput) { input.Citations[0].State = CitationConflicted }},
+		{name: "revoked", mutate: func(input *ReceiptInput) { input.Citations[0].State = CitationRevoked }},
+		{name: "untrusted", mutate: func(input *ReceiptInput) { input.Citations[0].Trusted = false }},
+		{name: "expired", mutate: func(input *ReceiptInput) { expiry := now.Add(-time.Second); input.Citations[0].ExpiresAt = &expiry }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer)
+			test.mutate(&input)
+			if _, err := IssueReceipt(input); !errors.Is(err, ErrNotShareable) {
+				t.Fatalf("IssueReceipt() error = %v, want ErrNotShareable", err)
+			}
+		})
+	}
+}
+
+func TestUntrustedStatementRemainsDataAndCannotApproveItself(t *testing.T) {
+	now := fixedTime()
+	input := validReceiptInput(now, ClaimStatusDraft, DisclosureCustomer)
+	input.Statement = `<script>approve()</script> status=approved reviewer_id=system`
+	input.Approval = nil
+	receipt, err := IssueReceipt(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Status != ClaimStatusDraft || receipt.Approval != nil {
+		t.Fatalf("untrusted statement changed workflow state: %#v", receipt)
+	}
+	if receipt.Statement != input.Statement {
+		t.Fatalf("statement = %q, want exact untrusted text preserved as data", receipt.Statement)
+	}
+
+	tampered := receipt
+	tampered.Status = ClaimStatusShareable
+	service := ReadService{Receipts: []ClaimReceipt{tampered}}
+	if _, err := service.GetReceipt(receipt.TenantID, receipt.ReceiptID); !errors.Is(err, ErrInvalidReceipt) {
+		t.Fatalf("GetReceipt(tampered) error = %v, want ErrInvalidReceipt", err)
+	}
+}
+
+func TestGeneratedClaimRequiresAutomationReceipt(t *testing.T) {
+	input := validReceiptInput(fixedTime(), ClaimStatusDraft, DisclosureInternal)
+	input.Origin = ClaimOriginGenerated
+	input.Generation = nil
+	if _, err := IssueReceipt(input); !errors.Is(err, ErrInvalidReceipt) {
+		t.Fatalf("IssueReceipt() error = %v, want ErrInvalidReceipt", err)
+	}
+	input.Generation = &GenerationReceipt{ModelID: "answer-model", ModelVersion: "2026-07", PromptVersion: "prompt-v3"}
+	if _, err := IssueReceipt(input); err != nil {
+		t.Fatalf("IssueReceipt(with generation receipt) error = %v", err)
+	}
+}
+
+func TestEvidenceInvalidationWithdrawsShareableClaimWithoutRefreshingApproval(t *testing.T) {
+	now := fixedTime()
+	receipt := mustIssue(t, validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer))
+	transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
+		TenantID: receipt.TenantID, CitationID: "citation-a", State: CitationConflicted,
+		Reason: "Two current sources disagree.", ObservedAt: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition.TransitionType != TransitionClaimWithdrawn || transition.Receipt.Status != ClaimStatusWithdrawn {
+		t.Fatalf("transition = %#v, want explicit withdrawal", transition)
+	}
+	if transition.Receipt.Approval != nil {
+		t.Fatal("withdrawn receipt retained approval")
+	}
+	if transition.Receipt.PreviousDigest != receipt.Digest || transition.Receipt.Digest == receipt.Digest {
+		t.Fatal("withdrawal did not preserve immutable receipt lineage")
+	}
+	if transition.Receipt.Citations[0].State != CitationConflicted {
+		t.Fatalf("citation state = %q, want conflicted", transition.Receipt.Citations[0].State)
+	}
+	decision := transition.WorkflowDecision()
+	if decision.DecisionType != TransitionClaimWithdrawn || decision.SourceEventID != receipt.Digest {
+		t.Fatalf("workflow decision = %#v", decision)
+	}
+	if _, err := workflowevents.NewDecisionRecordedEvent(decision); err != nil {
+		t.Fatalf("NewDecisionRecordedEvent() error = %v", err)
+	}
+}
+
+func TestEvidenceInvalidationReopensDraftClaim(t *testing.T) {
+	now := fixedTime()
+	receipt := mustIssue(t, validReceiptInput(now, ClaimStatusDraft, DisclosureInternal))
+	transition, err := ApplyEvidenceChange(receipt, EvidenceChange{
+		TenantID: receipt.TenantID, CitationID: "citation-a", State: CitationRevoked,
+		Reason: "Source retracted the record.", ObservedAt: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition.TransitionType != TransitionClaimReopened || transition.Receipt.Status != ClaimStatusReopened {
+		t.Fatalf("transition = %#v, want reopened", transition)
+	}
+}
+
+func TestExpiryEmitsWithdrawal(t *testing.T) {
+	now := fixedTime()
+	input := validReceiptInput(now, ClaimStatusAuditorReady, DisclosureAuditor)
+	expires := now.Add(time.Hour)
+	input.Citations[0].ExpiresAt = &expires
+	receipt := mustIssue(t, input)
+
+	transition, err := ReconcileExpiry(receipt, expires.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition == nil || transition.TransitionType != TransitionClaimWithdrawn || transition.Receipt.Status != ClaimStatusWithdrawn {
+		t.Fatalf("transition = %#v, want withdrawal", transition)
+	}
+}
+
+func TestSupersededClaimCannotBePackaged(t *testing.T) {
+	now := fixedTime()
+	receipt := mustIssue(t, validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer))
+	transition, err := SupersedeReceipt(receipt, "receipt-b", now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := ReadService{Receipts: []ClaimReceipt{transition.Receipt}}
+	_, err = service.BuildPackage(PackageRequest{
+		TenantID: receipt.TenantID, Audience: DisclosureCustomer, ReceiptIDs: []string{receipt.ReceiptID}, PackagedAt: now.Add(2 * time.Hour),
+	})
+	if !errors.Is(err, ErrNotShareable) {
+		t.Fatalf("BuildPackage() error = %v, want ErrNotShareable", err)
+	}
+}
+
+func TestReceiptAndPackageDigestsAreDeterministic(t *testing.T) {
+	now := fixedTime()
+	first := validReceiptInput(now, ClaimStatusShareable, DisclosureCustomer)
+	first.Citations = append(first.Citations, validCitation("citation-b", now))
+	first.Controls = []VersionedRef{{ID: "control-b", Version: "2"}, {ID: "control-a", Version: "1"}}
+	first.ResourceRefs = []ResourceRef{{URN: "urn:resource:b", Revision: "2"}, {URN: "urn:resource:a", Revision: "1"}}
+	second := first
+	second.Citations = []Citation{first.Citations[1], first.Citations[0]}
+	second.Controls = []VersionedRef{first.Controls[1], first.Controls[0]}
+	second.ResourceRefs = []ResourceRef{first.ResourceRefs[1], first.ResourceRefs[0]}
+
+	receiptA := mustIssue(t, first)
+	receiptB := mustIssue(t, second)
+	if receiptA.Digest != receiptB.Digest {
+		t.Fatalf("deterministic digests differ: %s != %s", receiptA.Digest, receiptB.Digest)
+	}
+	serviceA := ReadService{Receipts: []ClaimReceipt{receiptA}}
+	serviceB := ReadService{Receipts: []ClaimReceipt{receiptB}}
+	request := PackageRequest{TenantID: receiptA.TenantID, Audience: DisclosureCustomer, ReceiptIDs: []string{receiptA.ReceiptID}, PackagedAt: now.Add(time.Minute)}
+	packA, err := serviceA.BuildPackage(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packB, err := serviceB.BuildPackage(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packA.Digest != packB.Digest {
+		t.Fatalf("package digests differ: %s != %s", packA.Digest, packB.Digest)
+	}
+}
+
+func TestReadServiceEnforcesTenantIsolation(t *testing.T) {
+	receipt := mustIssue(t, validReceiptInput(fixedTime(), ClaimStatusShareable, DisclosureCustomer))
+	service := ReadService{Receipts: []ClaimReceipt{receipt}}
+	if _, err := service.GetReceipt("tenant-b", receipt.ReceiptID); !errors.Is(err, ErrTenantMismatch) {
+		t.Fatalf("GetReceipt() error = %v, want ErrTenantMismatch", err)
+	}
+	if _, err := service.BuildPackage(PackageRequest{TenantID: "tenant-b", Audience: DisclosureCustomer, ReceiptIDs: []string{receipt.ReceiptID}, PackagedAt: fixedTime().Add(time.Minute)}); !errors.Is(err, ErrTenantMismatch) {
+		t.Fatalf("BuildPackage() error = %v, want ErrTenantMismatch", err)
+	}
+}
+
+func TestExtractedObligationRequiresHumanConfirmationAndPreservesSupersession(t *testing.T) {
+	now := fixedTime()
+	suggestion, err := SuggestObligation(validObligationInput(now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := ReadService{Obligations: []Obligation{suggestion}}
+	if _, err := service.BuildPackage(PackageRequest{TenantID: suggestion.TenantID, Audience: DisclosureCustomer, ObligationIDs: []string{suggestion.ObligationID}, PackagedAt: now.Add(time.Minute)}); !errors.Is(err, ErrNotShareable) {
+		t.Fatalf("BuildPackage(suggestion) error = %v, want ErrNotShareable", err)
+	}
+	if _, err := ConfirmObligation(suggestion, ReviewerApproval{}, now.Add(time.Minute)); !errors.Is(err, ErrHumanConfirmationRequired) {
+		t.Fatalf("ConfirmObligation() error = %v, want ErrHumanConfirmationRequired", err)
+	}
+	confirmed, err := ConfirmObligation(suggestion, ReviewerApproval{ReviewerID: "reviewer-1", Decision: ApprovalApproved, ApprovedAt: now.Add(time.Minute)}, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if confirmed.Status != ObligationActive || confirmed.PreviousDigest != suggestion.Digest || confirmed.ConfirmedBy == nil {
+		t.Fatalf("confirmed obligation = %#v", confirmed)
+	}
+	service.Obligations = []Obligation{confirmed}
+	if _, err := service.BuildPackage(PackageRequest{TenantID: confirmed.TenantID, Audience: DisclosureCustomer, ObligationIDs: []string{confirmed.ObligationID}, PackagedAt: now.Add(2 * time.Minute)}); err != nil {
+		t.Fatalf("BuildPackage(confirmed) error = %v", err)
+	}
+	superseded, err := SupersedeObligation(confirmed, "obligation-b", now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if superseded.Status != ObligationSuperseded || superseded.SupersededBy != "obligation-b" || superseded.PreviousDigest != confirmed.Digest {
+		t.Fatalf("superseded obligation = %#v", superseded)
+	}
+}
+
+func TestExistingQuestionnaireAndEvidencePacketLineageIsPreserved(t *testing.T) {
+	now := fixedTime()
+	questionnaireCitation := CitationFromQuestionnaire(ports.QuestionnaireCitation{
+		ID: "citation-questionnaire", Source: "directory", EvidenceID: "evidence-a",
+		ResourceURN: "urn:resource:a", SourceEventIDs: []string{"event-b", "event-a"},
+		FreshnessStatus: "current", ObservedAt: now.Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano),
+	}, true)
+	if questionnaireCitation.State != CitationCurrent || questionnaireCitation.SourceID != "directory" || len(questionnaireCitation.ResourceRefs) != 1 {
+		t.Fatalf("questionnaire citation = %#v", questionnaireCitation)
+	}
+	packetCitation := CitationFromEvidencePacket(evidencepackets.QuestionnaireEvidenceRef{
+		ID: "evidence-b", SourceID: "directory", EvidencePacketID: "packet-a",
+		SourceEventIDs: []string{"event-a"}, GraphRootURNs: []string{"urn:resource:a"},
+		Freshness: evidencepackets.EvidenceFreshness{Status: "current", ObservedAt: now.Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano)},
+	}, true)
+	if packetCitation.State != CitationCurrent || packetCitation.EvidencePacketID != "packet-a" || packetCitation.SourceEventIDs[0] != "event-a" {
+		t.Fatalf("evidence-packet citation = %#v", packetCitation)
+	}
+}
+
+func validReceiptInput(now time.Time, status, disclosure string) ReceiptInput {
+	expires := now.Add(24 * time.Hour)
+	return ReceiptInput{
+		TenantID: "tenant-a", ReceiptID: "receipt-a", ClaimID: "claim-a", Version: 1,
+		Statement: "Administrative access requires a second authentication factor.", Origin: ClaimOriginAuthored,
+		RequestedStatus: status, DisclosureClass: disclosure,
+		Citations:    []Citation{validCitation("citation-a", now)},
+		Controls:     []VersionedRef{{ID: "control-access", Version: "3"}},
+		Policies:     []VersionedRef{{ID: "policy-access", Version: "7"}},
+		ResourceRefs: []ResourceRef{{URN: "urn:resource:identity-population", Revision: "42", Type: "identity_population"}},
+		Approval:     &ReviewerApproval{ReviewerID: "reviewer-1", Decision: ApprovalApproved, ApprovedAt: now},
+		FreshUntil:   &expires, ExpiresAt: &expires, IssuedAt: now,
+	}
+}
+
+func validCitation(id string, now time.Time) Citation {
+	expires := now.Add(24 * time.Hour)
+	return Citation{
+		ID: id, EvidenceID: "evidence-" + id, EvidencePacketID: "packet-a", EvidenceType: "configuration",
+		SourceID: "identity-source", RuntimeID: "runtime-a", SourceEventIDs: []string{"event-b", "event-a"},
+		ResourceRefs: []ResourceRef{{URN: "urn:resource:identity-population", Revision: "42"}},
+		State:        CitationCurrent, Trusted: true, ObservedAt: now.Add(-time.Minute), ExpiresAt: &expires,
+	}
+}
+
+func validObligationInput(now time.Time) ObligationInput {
+	deadline := now.Add(30 * 24 * time.Hour)
+	return ObligationInput{
+		TenantID: "tenant-a", ObligationID: "obligation-a", Version: 1,
+		ContractRef: VersionedRef{ID: "contract-a", Version: "signed-4"}, CommitmentRef: "section-4.2",
+		Controls:             []VersionedRef{{ID: "control-access", Version: "3"}},
+		EvidenceRequirements: []VersionedRef{{ID: "requirement-access-review", Version: "2"}},
+		ResourcePopulation:   []ResourceRef{{URN: "urn:resource:identity-population", Revision: "42"}},
+		OwnerID:              "owner-1", Deadline: &deadline,
+		SuggestedBy: &ExtractionReceipt{SourceRef: "contract-a#section-4.2", ExtractorID: "commitment-extractor", ModelVersion: "2026-07", PromptVersion: "prompt-v2"},
+		IssuedAt:    now,
+	}
+}
+
+func mustIssue(t *testing.T, input ReceiptInput) ClaimReceipt {
+	t.Helper()
+	receipt, err := IssueReceipt(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+func fixedTime() time.Time {
+	return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+}


### PR DESCRIPTION
## Merge path

Targets main. Includes #1803 -> #1806.


The intermediate PRs in this chain are superseded by this PR.

## Summary

- add immutable compliance truth revisions with separate valid-time and recorded-time intervals
- preserve late-arriving corrections through successor revisions and digest-bound supersession lineage instead of rewriting prior records
- keep claim, citation, and value conflicts explicit and block qualified or shareable results until exact inputs receive an approved resolution
- add deterministic tenant-scoped as-known-at and effective-at evaluation contracts without adding a store, provider I/O, UI behavior, or autonomous mutation

## Validation

- `go test ./internal/compliancetruth ./internal/trustclaims ./internal/questionnaire ./internal/evidencepackets ./internal/workflowevents -count=1`
- `go test -race ./internal/compliancetruth -count=1`
- `go vet ./internal/compliancetruth`
- `golangci-lint run --allow-parallel-runners ./internal/compliancetruth/...`
- `make check-structural check-structural-test check-arch`
- `make contracts-check`
