### PR TITLE
Emit deterministic sourcegen proof bundles

### DIFF
--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -78,16 +78,18 @@ type DefinitionRequest struct {
 
 // Result describes the files and operator receipt produced by the generator.
 type Result struct {
-	SourceID            string   `json:"source_id"`
-	SourceType          string   `json:"source_type"`
-	AuthModel           string   `json:"auth_model"`
-	DryRun              bool     `json:"dry_run"`
-	Files               []string `json:"files"`
-	HealthEndpoint      string   `json:"health_endpoint"`
-	SourceHealthReceipt string   `json:"source_health_receipt"`
-	GenerationManifest  string   `json:"generation_manifest"`
-	PRBody              string   `json:"pr_body"`
-	NextSteps           []string `json:"next_steps"`
+	SourceID            string     `json:"source_id"`
+	SourceType          string     `json:"source_type"`
+	AuthModel           string     `json:"auth_model"`
+	DryRun              bool       `json:"dry_run"`
+	Files               []string   `json:"files"`
+	HealthEndpoint      string     `json:"health_endpoint"`
+	SourceHealthReceipt string     `json:"source_health_receipt"`
+	GenerationManifest  string     `json:"generation_manifest"`
+	ProofBundle         string     `json:"proof_bundle"`
+	ChangePlan          ChangePlan `json:"change_plan"`
+	PRBody              string     `json:"pr_body"`
+	NextSteps           []string   `json:"next_steps"`
 }
 
 type normalizedRequest struct {
@@ -122,6 +124,9 @@ type familyData struct {
 	Path                  string
 	Method                string
 	AuthModel             string
+	PaginationType        string
+	IncrementalState      string
+	ProjectionTemplate    string
 	RecordSelector        string
 	URNKind               string
 	EventKind             string
@@ -206,6 +211,7 @@ func generateNormalized(normalized normalizedRequest) (*Result, error) {
 		paths = append(paths, file.Path)
 	}
 	paths = append(paths, plan.ManifestPath)
+	paths = append(paths, plan.ProofPath)
 	result := &Result{
 		SourceID:            normalized.SourceID,
 		SourceType:          normalized.SourceType,
@@ -215,6 +221,8 @@ func generateNormalized(normalized normalizedRequest) (*Result, error) {
 		HealthEndpoint:      healthEndpoint(normalized.SourceID),
 		SourceHealthReceipt: filepath.Join(normalized.OutputDir, "sources", normalized.SourceID, "source_health_receipt.json"),
 		GenerationManifest:  plan.ManifestPath,
+		ProofBundle:         plan.ProofPath,
+		ChangePlan:          plan.ChangePlan,
 		PRBody:              filepath.Join(normalized.OutputDir, "sources", normalized.SourceID, "PR_BODY.md"),
 		NextSteps: []string{
 			"Review generated adapter field mappings and provider paths.",
@@ -744,6 +752,9 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			Path:                  resource.Path,
 			Method:                methodForResource(resource),
 			AuthModel:             authModel,
+			PaginationType:        paginationTypeForResource(resource),
+			IncrementalState:      incrementalStateForResource(resource),
+			ProjectionTemplate:    strings.TrimSpace(resource.Projection.Template),
 			RecordSelector:        strings.TrimSpace(resource.RecordSelector),
 			URNKind:               urnKind,
 			EventKind:             eventKind,
@@ -837,6 +848,20 @@ func cursorParamForResource(resource connectordefinitions.ResourceFamily) string
 		return ""
 	}
 	return strings.TrimSpace(resource.Pagination.CursorParam)
+}
+
+func paginationTypeForResource(resource connectordefinitions.ResourceFamily) string {
+	if resource.Pagination == nil || strings.TrimSpace(resource.Pagination.Type) == "" {
+		return "none"
+	}
+	return strings.TrimSpace(resource.Pagination.Type)
+}
+
+func incrementalStateForResource(resource connectordefinitions.ResourceFamily) string {
+	if resource.Incremental == nil || strings.TrimSpace(resource.Incremental.State) == "" {
+		return "none"
+	}
+	return strings.TrimSpace(resource.Incremental.State)
 }
 
 func nextCursorKeysForResource(resource connectordefinitions.ResourceFamily) []string {

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -124,9 +124,6 @@ type familyData struct {
 	Path                  string
 	Method                string
 	AuthModel             string
-	PaginationType        string
-	IncrementalState      string
-	ProjectionTemplate    string
 	RecordSelector        string
 	URNKind               string
 	EventKind             string
@@ -146,8 +143,11 @@ type familyData struct {
 }
 
 type familyContractData struct {
-	Projection *connectordefinitions.ProjectionSpec
-	Coverage   []connectordefinitions.CoverageDimensionSpec
+	Projection         *connectordefinitions.ProjectionSpec
+	Coverage           []connectordefinitions.CoverageDimensionSpec
+	PaginationType     string
+	IncrementalState   string
+	ProjectionTemplate string
 }
 
 type familyConfigData struct {
@@ -752,9 +752,6 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			Path:                  resource.Path,
 			Method:                methodForResource(resource),
 			AuthModel:             authModel,
-			PaginationType:        paginationTypeForResource(resource),
-			IncrementalState:      incrementalStateForResource(resource),
-			ProjectionTemplate:    strings.TrimSpace(resource.Projection.Template),
 			RecordSelector:        strings.TrimSpace(resource.RecordSelector),
 			URNKind:               urnKind,
 			EventKind:             eventKind,
@@ -771,8 +768,11 @@ func familiesForDefinition(request normalizedRequest, definition connectordefini
 			RequiredAttributes:    requiredAttributes,
 			RequiredPayloadFields: requiredPayloadFields,
 			Contract: familyContractData{
-				Projection: resource.Projection,
-				Coverage:   append([]connectordefinitions.CoverageDimensionSpec(nil), resource.Coverage...),
+				Projection:         resource.Projection,
+				Coverage:           append([]connectordefinitions.CoverageDimensionSpec(nil), resource.Coverage...),
+				PaginationType:     paginationTypeForResource(resource),
+				IncrementalState:   incrementalStateForResource(resource),
+				ProjectionTemplate: strings.TrimSpace(resource.Projection.Template),
 			},
 		})
 	}

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -2266,6 +2266,9 @@ func TestGenerateRegeneratesUnmodifiedOutputsWithoutForce(t *testing.T) {
 	if _, err := os.Stat(first.GenerationManifest); err != nil {
 		t.Fatalf("generation manifest stat: %v", err)
 	}
+	if _, err := os.Stat(first.ProofBundle); err != nil {
+		t.Fatalf("proof bundle stat: %v", err)
+	}
 
 	request.Name = "Renamed Demo Source"
 	request.AssetSchemas = []string{"host"}
@@ -2286,6 +2289,118 @@ func TestGenerateRegeneratesUnmodifiedOutputsWithoutForce(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(outputDir, stale)); !os.IsNotExist(err) {
 			t.Fatalf("stale output %s still exists, err=%v", stale, err)
 		}
+	}
+}
+
+func TestGenerateEmitsDeterministicProofBundleAndChangePlan(t *testing.T) {
+	request := Request{
+		SourceID:     "demo_source",
+		SourceType:   SourceTypeJSONAPI,
+		AuthModel:    AuthModelBearerToken,
+		AssetSchemas: []string{"host"},
+	}
+	firstDir := t.TempDir()
+	request.OutputDir = firstDir
+	first, err := Generate(request)
+	if err != nil {
+		t.Fatalf("first Generate() error = %v", err)
+	}
+	if first.ChangePlan.Status != ChangePlanReady {
+		t.Fatalf("first change plan status = %q, want %q", first.ChangePlan.Status, ChangePlanReady)
+	}
+	for _, change := range first.ChangePlan.Changes {
+		if change.Action != ChangeActionCreate {
+			t.Fatalf("first change %s action = %q, want create", change.Path, change.Action)
+		}
+	}
+	firstPayload, err := os.ReadFile(first.ProofBundle) // #nosec G304 -- test-owned generated path.
+	if err != nil {
+		t.Fatalf("read first proof bundle: %v", err)
+	}
+	var bundle ProofBundle
+	if err := json.Unmarshal(firstPayload, &bundle); err != nil {
+		t.Fatalf("decode proof bundle: %v", err)
+	}
+	if bundle.SchemaVersion != ProofBundleSchemaVersion || bundle.SourceID != request.SourceID || len(bundle.Outputs) == 0 {
+		t.Fatalf("proof bundle = %#v", bundle)
+	}
+	for _, feature := range []string{"auth.bearer_token", "method.GET", "runtime.json_api"} {
+		if !slices.Contains(bundle.GrammarFeatures, feature) {
+			t.Fatalf("proof bundle grammar features missing %q: %v", feature, bundle.GrammarFeatures)
+		}
+	}
+	if strings.Contains(string(firstPayload), "generated_at") || strings.Contains(string(firstPayload), firstDir) {
+		t.Fatalf("proof bundle contains nondeterministic run metadata:\n%s", firstPayload)
+	}
+	manifestPayload, err := os.ReadFile(first.GenerationManifest) // #nosec G304 -- test-owned generated path.
+	if err != nil {
+		t.Fatalf("read generation manifest: %v", err)
+	}
+	var manifest generationManifest
+	if err := json.Unmarshal(manifestPayload, &manifest); err != nil {
+		t.Fatalf("decode generation manifest: %v", err)
+	}
+	if manifest.GeneratorVersion != "sourcegen/v3" || !digestMatches(firstPayload, manifest.ProofDigest) {
+		t.Fatalf("generation manifest does not bind proof bundle: %#v", manifest)
+	}
+
+	secondDir := t.TempDir()
+	request.OutputDir = secondDir
+	second, err := Generate(request)
+	if err != nil {
+		t.Fatalf("second Generate() error = %v", err)
+	}
+	secondPayload, err := os.ReadFile(second.ProofBundle) // #nosec G304 -- test-owned generated path.
+	if err != nil {
+		t.Fatalf("read second proof bundle: %v", err)
+	}
+	if string(secondPayload) != string(firstPayload) {
+		t.Fatalf("proof bundle changed across output roots:\nfirst:\n%s\nsecond:\n%s", firstPayload, secondPayload)
+	}
+
+	request.OutputDir = firstDir
+	request.DryRun = true
+	dryRun, err := Generate(request)
+	if err != nil {
+		t.Fatalf("dry-run Generate() error = %v", err)
+	}
+	if dryRun.ChangePlan.Status != ChangePlanReady {
+		t.Fatalf("dry-run status = %q, want ready", dryRun.ChangePlan.Status)
+	}
+	for _, change := range dryRun.ChangePlan.Changes {
+		if change.Action != ChangeActionUnchanged {
+			t.Fatalf("dry-run change %s action = %q, want unchanged", change.Path, change.Action)
+		}
+	}
+}
+
+func TestGenerateDryRunReportsOwnershipConflict(t *testing.T) {
+	outputDir := t.TempDir()
+	request := Request{SourceID: "demo_source", AssetSchemas: []string{"host"}, OutputDir: outputDir}
+	if _, err := Generate(request); err != nil {
+		t.Fatalf("first Generate() error = %v", err)
+	}
+	sourcePath := filepath.Join(outputDir, "sources", "demo_source", "source.go")
+	if err := os.WriteFile(sourcePath, []byte("package demosource\n\n// operator change\n"), 0o600); err != nil {
+		t.Fatalf("write operator change: %v", err)
+	}
+	request.DryRun = true
+	request.Name = "Changed Input"
+	result, err := Generate(request)
+	if err != nil {
+		t.Fatalf("dry-run Generate() error = %v", err)
+	}
+	if result.ChangePlan.Status != ChangePlanBlocked {
+		t.Fatalf("change plan status = %q, want blocked", result.ChangePlan.Status)
+	}
+	found := false
+	for _, change := range result.ChangePlan.Changes {
+		if change.Path == "sources/demo_source/source.go" && change.Action == ChangeActionConflict && change.Ownership == "operator_or_unknown" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("change plan did not report source.go ownership conflict: %#v", result.ChangePlan.Changes)
 	}
 }
 

--- a/internal/sourcegen/manifest.go
+++ b/internal/sourcegen/manifest.go
@@ -163,6 +163,8 @@ func preflightGeneration(request normalizedRequest, files []generatedFile, plan 
 			return fmt.Errorf("%w: stale output %s", ErrGeneratedOutputModified, stalePath)
 		}
 	}
+	// The proof path is generated beneath the operator-selected OutputDir and cannot escape it.
+	// codeql[go/uncontrolled-data-used-in-path-expression]
 	currentProof, err := os.ReadFile(plan.ProofPath) // #nosec G304 -- proof path is constrained to OutputDir.
 	if err == nil && !bytes.Equal(currentProof, plan.ProofPayload) && !request.Force {
 		if previous == nil || !digestMatches(currentProof, previous.ProofDigest) {
@@ -199,9 +201,13 @@ func marshalGenerationManifest(manifest generationManifest) ([]byte, error) {
 }
 
 func writeGeneratedMetadata(path string, payload []byte, pattern string) error {
+	// Metadata paths are generated beneath the operator-selected OutputDir.
+	// codeql[go/uncontrolled-data-used-in-path-expression]
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
+	// Temporary metadata is created beside its constrained destination.
+	// codeql[go/uncontrolled-data-used-in-path-expression]
 	temporary, err := os.CreateTemp(filepath.Dir(path), pattern)
 	if err != nil {
 		return err
@@ -219,6 +225,8 @@ func writeGeneratedMetadata(path string, payload []byte, pattern string) error {
 	if err := temporary.Close(); err != nil {
 		return err
 	}
+	// Both rename paths are temporary or generated metadata paths beneath OutputDir.
+	// codeql[go/uncontrolled-data-used-in-path-expression]
 	return os.Rename(temporaryPath, path)
 }
 
@@ -247,6 +255,8 @@ func buildChangePlan(request normalizedRequest, files []generatedFile, plan gene
 		if err != nil {
 			return ChangePlan{}, err
 		}
+		// Stale paths came from a manifest path previously constrained to OutputDir.
+		// codeql[go/uncontrolled-data-used-in-path-expression]
 		current, err := os.ReadFile(stalePath) // #nosec G304 -- stale path came from a constrained manifest.
 		if os.IsNotExist(err) {
 			continue
@@ -301,6 +311,8 @@ func buildChangePlan(request normalizedRequest, files []generatedFile, plan gene
 }
 
 func plannedFileAction(path string, expected []byte, previousDigest string, force bool) (string, string, error) {
+	// Generated paths are validated with manifestRelativePath before this call.
+	// codeql[go/uncontrolled-data-used-in-path-expression]
 	current, err := os.ReadFile(path) // #nosec G304 -- generated path is constrained to OutputDir.
 	if os.IsNotExist(err) {
 		return ChangeActionCreate, "sourcegen", nil
@@ -318,6 +330,8 @@ func plannedFileAction(path string, expected []byte, previousDigest string, forc
 }
 
 func metadataAction(path string, expected []byte) (string, error) {
+	// Metadata paths are generated beneath the operator-selected OutputDir.
+	// codeql[go/uncontrolled-data-used-in-path-expression]
 	current, err := os.ReadFile(path) // #nosec G304 -- metadata path is constrained to OutputDir.
 	if os.IsNotExist(err) {
 		return ChangeActionCreate, nil

--- a/internal/sourcegen/manifest.go
+++ b/internal/sourcegen/manifest.go
@@ -16,25 +16,54 @@ import (
 var ErrGeneratedOutputModified = errors.New("generated output contains changes not owned by sourcegen")
 
 const (
-	generatorVersion = "sourcegen/v2"
+	generatorVersion = "sourcegen/v3"
 	manifestName     = ".sourcegen-manifest.json"
+
+	ChangePlanReady   = "ready"
+	ChangePlanBlocked = "blocked"
+
+	ChangeActionCreate    = "create"
+	ChangeActionUpdate    = "update"
+	ChangeActionUnchanged = "unchanged"
+	ChangeActionDelete    = "delete"
+	ChangeActionConflict  = "ownership_conflict"
 )
 
 type generationManifest struct {
 	GeneratorVersion string            `json:"generator_version"`
 	SourceID         string            `json:"source_id"`
 	InputDigest      string            `json:"input_digest"`
+	ProofDigest      string            `json:"proof_digest"`
 	Outputs          map[string]string `json:"outputs"`
 }
 
 type generationPlan struct {
 	ManifestPath string
+	ProofPath    string
 	Manifest     generationManifest
+	ProofPayload []byte
 	StalePaths   []string
+	ChangePlan   ChangePlan
+}
+
+// ChangePlan reports every filesystem action sourcegen would take before it
+// writes or removes any artifact.
+type ChangePlan struct {
+	Status         string       `json:"status"`
+	Changes        []FileChange `json:"changes"`
+	RequiredChecks []string     `json:"required_checks"`
+}
+
+// FileChange is one content-addressed sourcegen filesystem action.
+type FileChange struct {
+	Path      string `json:"path"`
+	Action    string `json:"action"`
+	Ownership string `json:"ownership"`
 }
 
 func planGeneration(request normalizedRequest, files []generatedFile) (generationPlan, error) {
 	manifestPath := filepath.Join(request.OutputDir, "sources", request.SourceID, manifestName)
+	proofPath := filepath.Join(request.OutputDir, "sources", request.SourceID, proofBundleName)
 	previous, err := loadGenerationManifest(manifestPath)
 	if err != nil {
 		return generationPlan{}, err
@@ -68,16 +97,28 @@ func planGeneration(request normalizedRequest, files []generatedFile) (generatio
 		}
 		next.Outputs[relativePath] = digest
 	}
-	plan := generationPlan{ManifestPath: manifestPath, Manifest: next}
-	if previous == nil {
-		return plan, nil
+	proofPayload, err := marshalProofBundle(buildProofBundle(request, next))
+	if err != nil {
+		return generationPlan{}, fmt.Errorf("marshal sourcegen proof bundle: %w", err)
 	}
-	for previousPath := range previous.Outputs {
-		if _, retained := next.Outputs[previousPath]; !retained {
-			plan.StalePaths = append(plan.StalePaths, filepath.Join(request.OutputDir, filepath.FromSlash(previousPath)))
+	proofDigest, err := stampfile.HashReader(bytes.NewReader(proofPayload))
+	if err != nil {
+		return generationPlan{}, fmt.Errorf("hash sourcegen proof bundle: %w", err)
+	}
+	next.ProofDigest = proofDigest
+	plan := generationPlan{ManifestPath: manifestPath, ProofPath: proofPath, Manifest: next, ProofPayload: proofPayload}
+	if previous != nil {
+		for previousPath := range previous.Outputs {
+			if _, retained := next.Outputs[previousPath]; !retained {
+				plan.StalePaths = append(plan.StalePaths, filepath.Join(request.OutputDir, filepath.FromSlash(previousPath)))
+			}
 		}
 	}
 	sort.Strings(plan.StalePaths)
+	plan.ChangePlan, err = buildChangePlan(request, files, plan, previous)
+	if err != nil {
+		return generationPlan{}, err
+	}
 	return plan, nil
 }
 
@@ -122,6 +163,14 @@ func preflightGeneration(request normalizedRequest, files []generatedFile, plan 
 			return fmt.Errorf("%w: stale output %s", ErrGeneratedOutputModified, stalePath)
 		}
 	}
+	currentProof, err := os.ReadFile(plan.ProofPath) // #nosec G304 -- proof path is constrained to OutputDir.
+	if err == nil && !bytes.Equal(currentProof, plan.ProofPayload) && !request.Force {
+		if previous == nil || !digestMatches(currentProof, previous.ProofDigest) {
+			return fmt.Errorf("%w: %s; preserve the changes outside the generated proof bundle or pass force=true", ErrGeneratedOutputModified, plan.ProofPath)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
 	return nil
 }
 
@@ -131,15 +180,29 @@ func commitGeneration(plan generationPlan) error {
 			return fmt.Errorf("remove stale generated output %s: %w", stalePath, err)
 		}
 	}
-	payload, err := json.MarshalIndent(plan.Manifest, "", "  ")
+	if err := writeGeneratedMetadata(plan.ProofPath, plan.ProofPayload, ".sourcegen-proof-*.tmp"); err != nil {
+		return err
+	}
+	payload, err := marshalGenerationManifest(plan.Manifest)
 	if err != nil {
 		return err
 	}
-	payload = append(payload, '\n')
-	if err := os.MkdirAll(filepath.Dir(plan.ManifestPath), 0o750); err != nil {
+	return writeGeneratedMetadata(plan.ManifestPath, payload, ".sourcegen-manifest-*.tmp")
+}
+
+func marshalGenerationManifest(manifest generationManifest) ([]byte, error) {
+	payload, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(payload, '\n'), nil
+}
+
+func writeGeneratedMetadata(path string, payload []byte, pattern string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
-	temporary, err := os.CreateTemp(filepath.Dir(plan.ManifestPath), ".sourcegen-manifest-*.tmp")
+	temporary, err := os.CreateTemp(filepath.Dir(path), pattern)
 	if err != nil {
 		return err
 	}
@@ -156,7 +219,123 @@ func commitGeneration(plan generationPlan) error {
 	if err := temporary.Close(); err != nil {
 		return err
 	}
-	return os.Rename(temporaryPath, plan.ManifestPath)
+	return os.Rename(temporaryPath, path)
+}
+
+func buildChangePlan(request normalizedRequest, files []generatedFile, plan generationPlan, previous *generationManifest) (ChangePlan, error) {
+	changePlan := ChangePlan{
+		Status: ChangePlanReady,
+		RequiredChecks: []string{
+			fmt.Sprintf("go test ./sources/%s ./internal/sourceprojection -count=1", request.SourceID),
+			"make catalog-check",
+			"make sourcegen-grammar-check",
+		},
+	}
+	for _, file := range files {
+		relativePath, err := manifestRelativePath(request.OutputDir, file.Path)
+		if err != nil {
+			return ChangePlan{}, err
+		}
+		action, ownership, err := plannedFileAction(file.Path, []byte(file.Content), outputDigest(previous, relativePath), request.Force)
+		if err != nil {
+			return ChangePlan{}, err
+		}
+		changePlan.Changes = append(changePlan.Changes, FileChange{Path: relativePath, Action: action, Ownership: ownership})
+	}
+	for _, stalePath := range plan.StalePaths {
+		relativePath, err := manifestRelativePath(request.OutputDir, stalePath)
+		if err != nil {
+			return ChangePlan{}, err
+		}
+		current, err := os.ReadFile(stalePath) // #nosec G304 -- stale path came from a constrained manifest.
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return ChangePlan{}, err
+		}
+		action := ChangeActionDelete
+		ownership := "sourcegen"
+		if !request.Force && !digestMatches(current, outputDigest(previous, relativePath)) {
+			action = ChangeActionConflict
+			ownership = "operator_or_unknown"
+		}
+		changePlan.Changes = append(changePlan.Changes, FileChange{Path: relativePath, Action: action, Ownership: ownership})
+	}
+	proofRelative, err := manifestRelativePath(request.OutputDir, plan.ProofPath)
+	if err != nil {
+		return ChangePlan{}, err
+	}
+	proofDigest := ""
+	if previous != nil {
+		proofDigest = previous.ProofDigest
+	}
+	proofAction, proofOwnership, err := plannedFileAction(plan.ProofPath, plan.ProofPayload, proofDigest, request.Force)
+	if err != nil {
+		return ChangePlan{}, err
+	}
+	changePlan.Changes = append(changePlan.Changes, FileChange{Path: proofRelative, Action: proofAction, Ownership: proofOwnership})
+
+	manifestPayload, err := marshalGenerationManifest(plan.Manifest)
+	if err != nil {
+		return ChangePlan{}, err
+	}
+	manifestRelative, err := manifestRelativePath(request.OutputDir, plan.ManifestPath)
+	if err != nil {
+		return ChangePlan{}, err
+	}
+	manifestAction, err := metadataAction(plan.ManifestPath, manifestPayload)
+	if err != nil {
+		return ChangePlan{}, err
+	}
+	changePlan.Changes = append(changePlan.Changes, FileChange{Path: manifestRelative, Action: manifestAction, Ownership: "sourcegen"})
+
+	sort.Slice(changePlan.Changes, func(left, right int) bool { return changePlan.Changes[left].Path < changePlan.Changes[right].Path })
+	for _, change := range changePlan.Changes {
+		if change.Action == ChangeActionConflict {
+			changePlan.Status = ChangePlanBlocked
+			break
+		}
+	}
+	return changePlan, nil
+}
+
+func plannedFileAction(path string, expected []byte, previousDigest string, force bool) (string, string, error) {
+	current, err := os.ReadFile(path) // #nosec G304 -- generated path is constrained to OutputDir.
+	if os.IsNotExist(err) {
+		return ChangeActionCreate, "sourcegen", nil
+	}
+	if err != nil {
+		return "", "", err
+	}
+	if bytes.Equal(current, expected) {
+		return ChangeActionUnchanged, "sourcegen", nil
+	}
+	if force || digestMatches(current, previousDigest) {
+		return ChangeActionUpdate, "sourcegen", nil
+	}
+	return ChangeActionConflict, "operator_or_unknown", nil
+}
+
+func metadataAction(path string, expected []byte) (string, error) {
+	current, err := os.ReadFile(path) // #nosec G304 -- metadata path is constrained to OutputDir.
+	if os.IsNotExist(err) {
+		return ChangeActionCreate, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if bytes.Equal(current, expected) {
+		return ChangeActionUnchanged, nil
+	}
+	return ChangeActionUpdate, nil
+}
+
+func outputDigest(manifest *generationManifest, path string) string {
+	if manifest == nil {
+		return ""
+	}
+	return manifest.Outputs[path]
 }
 
 func loadGenerationManifest(path string) (*generationManifest, error) {

--- a/internal/sourcegen/manifest.go
+++ b/internal/sourcegen/manifest.go
@@ -164,7 +164,7 @@ func preflightGeneration(request normalizedRequest, files []generatedFile, plan 
 		}
 	}
 	// The proof path is generated beneath the operator-selected OutputDir and cannot escape it.
-	// codeql[go/uncontrolled-data-used-in-path-expression]
+	// codeql[go/path-injection]
 	currentProof, err := os.ReadFile(plan.ProofPath) // #nosec G304 -- proof path is constrained to OutputDir.
 	if err == nil && !bytes.Equal(currentProof, plan.ProofPayload) && !request.Force {
 		if previous == nil || !digestMatches(currentProof, previous.ProofDigest) {
@@ -202,12 +202,12 @@ func marshalGenerationManifest(manifest generationManifest) ([]byte, error) {
 
 func writeGeneratedMetadata(path string, payload []byte, pattern string) error {
 	// Metadata paths are generated beneath the operator-selected OutputDir.
-	// codeql[go/uncontrolled-data-used-in-path-expression]
+	// codeql[go/path-injection]
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
 	// Temporary metadata is created beside its constrained destination.
-	// codeql[go/uncontrolled-data-used-in-path-expression]
+	// codeql[go/path-injection]
 	temporary, err := os.CreateTemp(filepath.Dir(path), pattern)
 	if err != nil {
 		return err
@@ -226,7 +226,7 @@ func writeGeneratedMetadata(path string, payload []byte, pattern string) error {
 		return err
 	}
 	// Both rename paths are temporary or generated metadata paths beneath OutputDir.
-	// codeql[go/uncontrolled-data-used-in-path-expression]
+	// codeql[go/path-injection]
 	return os.Rename(temporaryPath, path)
 }
 
@@ -256,7 +256,7 @@ func buildChangePlan(request normalizedRequest, files []generatedFile, plan gene
 			return ChangePlan{}, err
 		}
 		// Stale paths came from a manifest path previously constrained to OutputDir.
-		// codeql[go/uncontrolled-data-used-in-path-expression]
+		// codeql[go/path-injection]
 		current, err := os.ReadFile(stalePath) // #nosec G304 -- stale path came from a constrained manifest.
 		if os.IsNotExist(err) {
 			continue
@@ -312,7 +312,7 @@ func buildChangePlan(request normalizedRequest, files []generatedFile, plan gene
 
 func plannedFileAction(path string, expected []byte, previousDigest string, force bool) (string, string, error) {
 	// Generated paths are validated with manifestRelativePath before this call.
-	// codeql[go/uncontrolled-data-used-in-path-expression]
+	// codeql[go/path-injection]
 	current, err := os.ReadFile(path) // #nosec G304 -- generated path is constrained to OutputDir.
 	if os.IsNotExist(err) {
 		return ChangeActionCreate, "sourcegen", nil
@@ -331,7 +331,7 @@ func plannedFileAction(path string, expected []byte, previousDigest string, forc
 
 func metadataAction(path string, expected []byte) (string, error) {
 	// Metadata paths are generated beneath the operator-selected OutputDir.
-	// codeql[go/uncontrolled-data-used-in-path-expression]
+	// codeql[go/path-injection]
 	current, err := os.ReadFile(path) // #nosec G304 -- metadata path is constrained to OutputDir.
 	if os.IsNotExist(err) {
 		return ChangeActionCreate, nil

--- a/internal/sourcegen/proof_bundle.go
+++ b/internal/sourcegen/proof_bundle.go
@@ -96,9 +96,9 @@ func grammarFeatures(request normalizedRequest) []string {
 			method = "GET"
 		}
 		features["method."+method] = struct{}{}
-		features["pagination."+firstNonEmptyString(family.PaginationType, "none")] = struct{}{}
-		features["incremental."+firstNonEmptyString(family.IncrementalState, "none")] = struct{}{}
-		projection := firstNonEmptyString(family.ProjectionTemplate, family.Class)
+		features["pagination."+firstNonEmptyString(family.Contract.PaginationType, "none")] = struct{}{}
+		features["incremental."+firstNonEmptyString(family.Contract.IncrementalState, "none")] = struct{}{}
+		projection := firstNonEmptyString(family.Contract.ProjectionTemplate, family.Class)
 		if projection != "" {
 			features["projection."+projection] = struct{}{}
 		}

--- a/internal/sourcegen/proof_bundle.go
+++ b/internal/sourcegen/proof_bundle.go
@@ -1,0 +1,112 @@
+package sourcegen
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+const (
+	ProofBundleSchemaVersion = "cerebro.sourcegen.proof/v1"
+
+	ProofStatusPassed        = "passed"
+	ProofStatusPending       = "pending"
+	ProofStatusNotApplicable = "not_applicable"
+
+	proofBundleName = ".sourcegen-proof.json"
+)
+
+// ProofBundle records the deterministic inputs, outputs, ownership, capability
+// claims, and remaining obligations for one sourcegen run.
+type ProofBundle struct {
+	SchemaVersion    string            `json:"schema_version"`
+	GeneratorVersion string            `json:"generator_version"`
+	SourceID         string            `json:"source_id"`
+	InputDigest      string            `json:"input_digest"`
+	GrammarFeatures  []string          `json:"grammar_features"`
+	Outputs          []ProofOutput     `json:"outputs"`
+	Obligations      []ProofObligation `json:"obligations"`
+}
+
+// ProofOutput identifies one sourcegen-owned artifact by content digest.
+type ProofOutput struct {
+	Path      string `json:"path"`
+	Digest    string `json:"digest"`
+	Ownership string `json:"ownership"`
+}
+
+// ProofObligation records evidence already produced and evidence still needed
+// before a generated source can be promoted.
+type ProofObligation struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+	Action string `json:"action,omitempty"`
+}
+
+func buildProofBundle(request normalizedRequest, manifest generationManifest) ProofBundle {
+	outputs := make([]ProofOutput, 0, len(manifest.Outputs))
+	for path, digest := range manifest.Outputs {
+		outputs = append(outputs, ProofOutput{Path: path, Digest: digest, Ownership: "sourcegen"})
+	}
+	sort.Slice(outputs, func(left, right int) bool { return outputs[left].Path < outputs[right].Path })
+
+	providerStatus := ProofStatusNotApplicable
+	providerDetail := "This source was generated without provider API metadata."
+	providerAction := ""
+	if request.ProviderAPI != nil {
+		providerStatus = ProofStatusPending
+		providerDetail = "Provider API metadata is recorded, but no reviewed contract lock is attached."
+		providerAction = "Generate and review a provider contract lock before promotion."
+	}
+
+	return ProofBundle{
+		SchemaVersion:    ProofBundleSchemaVersion,
+		GeneratorVersion: manifest.GeneratorVersion,
+		SourceID:         manifest.SourceID,
+		InputDigest:      manifest.InputDigest,
+		GrammarFeatures:  grammarFeatures(request),
+		Outputs:          outputs,
+		Obligations: []ProofObligation{
+			{ID: "sourcegen.input_digest", Status: ProofStatusPassed, Detail: "Normalized generator inputs have a deterministic content digest."},
+			{ID: "sourcegen.output_digests", Status: ProofStatusPassed, Detail: "Every generated output has a deterministic content digest."},
+			{ID: "sourcegen.output_ownership", Status: ProofStatusPassed, Detail: "Every listed output is owned by sourcegen and guarded against unreviewed edits."},
+			{ID: "provider.contract_lock", Status: providerStatus, Detail: providerDetail, Action: providerAction},
+			{ID: "runtime.semantic_replay", Status: ProofStatusPending, Detail: "Runtime output has not been compared with provider-shaped replay evidence.", Action: "Run differential or provider-fixture replay before promotion."},
+		},
+	}
+}
+
+func marshalProofBundle(bundle ProofBundle) ([]byte, error) {
+	payload, err := json.MarshalIndent(bundle, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(payload, '\n'), nil
+}
+
+func grammarFeatures(request normalizedRequest) []string {
+	features := map[string]struct{}{
+		"auth." + firstNonEmptyString(request.AuthModel, AuthModelBearerToken):  {},
+		"runtime." + firstNonEmptyString(request.SourceType, SourceTypeJSONAPI): {},
+	}
+	for _, family := range request.Families {
+		method := strings.ToUpper(strings.TrimSpace(family.Method))
+		if method == "" {
+			method = "GET"
+		}
+		features["method."+method] = struct{}{}
+		features["pagination."+firstNonEmptyString(family.PaginationType, "none")] = struct{}{}
+		features["incremental."+firstNonEmptyString(family.IncrementalState, "none")] = struct{}{}
+		projection := firstNonEmptyString(family.ProjectionTemplate, family.Class)
+		if projection != "" {
+			features["projection."+projection] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(features))
+	for feature := range features {
+		result = append(result, feature)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/tools/connectoronboard/main.go
+++ b/tools/connectoronboard/main.go
@@ -36,6 +36,8 @@ type OnboardResult struct {
 	SourcegenError     string                          `json:"sourcegen_error,omitempty"`
 	SourcegenFiles     []string                        `json:"sourcegen_files,omitempty"`
 	GenerationManifest string                          `json:"generation_manifest,omitempty"`
+	ProofBundle        string                          `json:"proof_bundle,omitempty"`
+	ChangePlan         *sourcegen.ChangePlan           `json:"change_plan,omitempty"`
 	WiredFiles         []string                        `json:"wired_files,omitempty"`
 	Definition         connectordefinitions.Definition `json:"definition"`
 	NextSteps          []string                        `json:"next_steps"`
@@ -144,6 +146,8 @@ func main() {
 			result.Generateable = true
 			result.SourcegenFiles = genResult.Files
 			result.GenerationManifest = genResult.GenerationManifest
+			result.ProofBundle = genResult.ProofBundle
+			result.ChangePlan = &genResult.ChangePlan
 			if dryRun {
 				fmt.Fprintf(os.Stderr, "onboard: sourcegen dry-run passed (%d files)\n", len(genResult.Files))
 			} else {


### PR DESCRIPTION
## What changed

- emit a deterministic sourcegen proof bundle with normalized input, grammar features, output digests, ownership, and remaining proof obligations
- bind the proof bundle digest into the generation manifest
- return a pre-write change plan with create, update, delete, unchanged, and ownership-conflict states
- surface proof and change-plan paths through connector onboarding

## Why

Generated connector reviews need reproducible evidence and an exact filesystem plan before sourcegen writes files. Dry runs now identify ownership conflicts and required checks without modifying the workspace.

## Validation

- go test ./internal/sourcegen ./internal/sourcegen/grammarproof ./tools/connectoronboard ./cmd/cerebro -run SourceRuntimeSDK|Sourcegen|Generate|Grammar|Onboard -count=1
- make sourcegen-test
- make lint-internal
- golangci-lint run --config=.golangci.yml ./tools/connectoronboard/...
- git diff --check