### PR TITLE
Lock generated sources to provider contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ finding-rule-scaffold-test: ## Run finding rule scaffold generator tests.
 	go test ./cmd/cerebro -run 'Test(ParseFindingRuleNewArgs|ScaffoldFindingRule|FindingRuleScaffold|RenderFindingRuleGo)' -count=1 -v
 
 sourcegen-test: ## Run source generator and generated runtime projection tests.
-	go test ./internal/sourcegen ./internal/sourcegen/grammarproof ./internal/connectordefinitions ./internal/connectordefinitions/openapigen ./internal/connectorcatalog ./internal/connectorimport ./sources/internal/catalogruntime ./internal/sourceregistry ./internal/sourceprojection ./tools/openapidefgen ./tools/sourcegrammarcheck -count=1
+	go test ./internal/sourcegen ./internal/sourcegen/grammarproof ./internal/providercontractlock ./internal/connectordefinitions ./internal/connectordefinitions/openapigen ./internal/connectorcatalog ./internal/connectorimport ./sources/internal/catalogruntime ./internal/sourceregistry ./internal/sourceprojection ./tools/openapidefgen ./tools/sourcegrammarcheck -count=1
 
 sourcegen-grammar-check: ## Prove every declared connector grammar feature is executable by sourcegen.
 	go run ./tools/sourcegrammarcheck

--- a/internal/providercontractlock/lock.go
+++ b/internal/providercontractlock/lock.go
@@ -1,0 +1,367 @@
+// Package providercontractlock creates deterministic locks for the portions of
+// a provider OpenAPI contract selected by connector generation.
+package providercontractlock
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/writer/cerebro/internal/sourcegen/stampfile"
+)
+
+const (
+	SchemaVersion        = "cerebro.provider-contract-lock/v1"
+	NormalizationVersion = "openapi-json-ref-closure/v1"
+
+	DriftNew              = "new"
+	DriftUnchanged        = "unchanged"
+	DriftAdditive         = "additive"
+	DriftBehavioralReview = "behavioral_review"
+	DriftBreaking         = "breaking"
+)
+
+// Selection identifies one provider operation chosen for generation.
+type Selection struct {
+	FamilyID    string
+	Method      string
+	Path        string
+	OperationID string
+}
+
+// Lock binds generated resource families to normalized provider contract
+// content without including run timestamps.
+type Lock struct {
+	SchemaVersion        string          `json:"schema_version"`
+	NormalizationVersion string          `json:"normalization_version"`
+	SourceID             string          `json:"source_id"`
+	DocumentDigest       string          `json:"document_digest"`
+	AuthDigest           string          `json:"auth_digest"`
+	Operations           []OperationLock `json:"operations"`
+}
+
+// OperationLock binds one selected method and path to its operation and
+// transitive local-reference content.
+type OperationLock struct {
+	FamilyID    string `json:"family_id"`
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	OperationID string `json:"operation_id,omitempty"`
+	Digest      string `json:"digest"`
+}
+
+// Drift classifies the effect of a current provider contract on a reviewed
+// lock.
+type Drift struct {
+	Status  string   `json:"status"`
+	Summary string   `json:"summary"`
+	Changes []string `json:"changes,omitempty"`
+}
+
+// Build creates a deterministic lock for a normalized OpenAPI document and
+// selected operations.
+func Build(doc *openapi3.T, sourceID string, selections []Selection) (Lock, error) {
+	if doc == nil {
+		return Lock{}, fmt.Errorf("provider OpenAPI document is required")
+	}
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return Lock{}, fmt.Errorf("source id is required")
+	}
+	root, documentPayload, err := normalizedDocument(doc)
+	if err != nil {
+		return Lock{}, err
+	}
+	documentDigest, err := stampfile.HashReader(bytes.NewReader(documentPayload))
+	if err != nil {
+		return Lock{}, fmt.Errorf("hash provider document: %w", err)
+	}
+	authDigest, err := digestValue(authContract(root, selections))
+	if err != nil {
+		return Lock{}, fmt.Errorf("hash provider auth contract: %w", err)
+	}
+	operations := make([]OperationLock, 0, len(selections))
+	for _, selection := range selections {
+		operation, err := lockOperation(root, selection)
+		if err != nil {
+			return Lock{}, err
+		}
+		operations = append(operations, operation)
+	}
+	sort.Slice(operations, func(left, right int) bool {
+		if operations[left].Method != operations[right].Method {
+			return operations[left].Method < operations[right].Method
+		}
+		if operations[left].Path != operations[right].Path {
+			return operations[left].Path < operations[right].Path
+		}
+		return operations[left].FamilyID < operations[right].FamilyID
+	})
+	return Lock{
+		SchemaVersion:        SchemaVersion,
+		NormalizationVersion: NormalizationVersion,
+		SourceID:             sourceID,
+		DocumentDigest:       documentDigest,
+		AuthDigest:           authDigest,
+		Operations:           operations,
+	}, nil
+}
+
+// Compare classifies provider drift against a previously reviewed lock.
+func Compare(previous *Lock, current Lock) Drift {
+	if previous == nil {
+		return Drift{Status: DriftNew, Summary: "No provider contract lock exists yet."}
+	}
+	if previous.SourceID != current.SourceID || previous.NormalizationVersion != current.NormalizationVersion {
+		return Drift{Status: DriftBreaking, Summary: "The provider contract lock identity or normalization version changed.", Changes: []string{"lock.identity"}}
+	}
+	changes := []string{}
+	if previous.AuthDigest != current.AuthDigest {
+		changes = append(changes, "auth")
+	}
+	previousOperations := operationMap(previous.Operations)
+	currentOperations := operationMap(current.Operations)
+	removed := false
+	changed := false
+	for key, before := range previousOperations {
+		after, ok := currentOperations[key]
+		if !ok {
+			removed = true
+			changes = append(changes, "operation.removed:"+key)
+			continue
+		}
+		if before.Digest != after.Digest || before.FamilyID != after.FamilyID {
+			changed = true
+			changes = append(changes, "operation.changed:"+key)
+		}
+	}
+	for key := range currentOperations {
+		if _, ok := previousOperations[key]; !ok {
+			changed = true
+			changes = append(changes, "operation.added:"+key)
+		}
+	}
+	sort.Strings(changes)
+	switch {
+	case previous.AuthDigest != current.AuthDigest || removed:
+		return Drift{Status: DriftBreaking, Summary: "Provider auth or a selected operation changed incompatibly.", Changes: changes}
+	case changed:
+		return Drift{Status: DriftBehavioralReview, Summary: "A selected provider operation or generated family mapping changed.", Changes: changes}
+	case previous.DocumentDigest != current.DocumentDigest:
+		return Drift{Status: DriftAdditive, Summary: "The provider document changed outside selected operations and auth.", Changes: []string{"document.unselected"}}
+	default:
+		return Drift{Status: DriftUnchanged, Summary: "The provider contract matches the reviewed lock."}
+	}
+}
+
+// Read decodes a provider contract lock from disk.
+func Read(path string) (Lock, error) {
+	payload, err := os.ReadFile(path) // #nosec G304 -- operator-provided build-time lock path.
+	if err != nil {
+		return Lock{}, err
+	}
+	var lock Lock
+	if err := json.Unmarshal(payload, &lock); err != nil {
+		return Lock{}, fmt.Errorf("decode provider contract lock %s: %w", path, err)
+	}
+	if lock.SchemaVersion != SchemaVersion || lock.SourceID == "" || lock.DocumentDigest == "" || lock.AuthDigest == "" {
+		return Lock{}, fmt.Errorf("provider contract lock %s is incomplete or unsupported", path)
+	}
+	return lock, nil
+}
+
+// Write atomically writes one provider contract lock.
+func Write(path string, lock Lock) error {
+	payload, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".provider-contract-lock-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(payload); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}
+
+// Digest returns the deterministic digest used to bind a lock into another
+// proof artifact.
+func Digest(lock Lock) (string, error) {
+	return digestValue(lock)
+}
+
+func normalizedDocument(doc *openapi3.T) (map[string]any, []byte, error) {
+	payload, err := json.Marshal(doc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("normalize provider document: %w", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return nil, nil, fmt.Errorf("decode normalized provider document: %w", err)
+	}
+	return root, payload, nil
+}
+
+func lockOperation(root map[string]any, selection Selection) (OperationLock, error) {
+	method := strings.ToUpper(strings.TrimSpace(selection.Method))
+	path := strings.TrimSpace(selection.Path)
+	pathItem, operation, err := selectedOperation(root, method, path)
+	if err != nil {
+		return OperationLock{}, err
+	}
+	references := map[string]any{}
+	if err := collectReferences(operation, root, references); err != nil {
+		return OperationLock{}, fmt.Errorf("resolve %s %s references: %w", method, path, err)
+	}
+	if parameters, ok := pathItem["parameters"]; ok {
+		if err := collectReferences(parameters, root, references); err != nil {
+			return OperationLock{}, fmt.Errorf("resolve %s %s path parameters: %w", method, path, err)
+		}
+	}
+	payload := map[string]any{
+		"method":          method,
+		"path":            path,
+		"operation":       operation,
+		"path_parameters": pathItem["parameters"],
+		"references":      references,
+	}
+	digest, err := digestValue(payload)
+	if err != nil {
+		return OperationLock{}, fmt.Errorf("hash provider operation %s %s: %w", method, path, err)
+	}
+	operationID := strings.TrimSpace(selection.OperationID)
+	if operationID == "" {
+		operationID, _ = operation["operationId"].(string)
+	}
+	return OperationLock{
+		FamilyID:    strings.TrimSpace(selection.FamilyID),
+		Method:      method,
+		Path:        path,
+		OperationID: strings.TrimSpace(operationID),
+		Digest:      digest,
+	}, nil
+}
+
+func selectedOperation(root map[string]any, method string, path string) (map[string]any, map[string]any, error) {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	path = strings.TrimSpace(path)
+	paths, ok := root["paths"].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("provider document has no paths")
+	}
+	pathItem, ok := paths[path].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("selected provider path %q is missing", path)
+	}
+	operation, ok := pathItem[strings.ToLower(method)].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("selected provider operation %s %s is missing", method, path)
+	}
+	return pathItem, operation, nil
+}
+
+func authContract(root map[string]any, selections []Selection) map[string]any {
+	operations := map[string]any{}
+	for _, selection := range selections {
+		_, operation, err := selectedOperation(root, selection.Method, selection.Path)
+		if err != nil {
+			continue
+		}
+		if security, ok := operation["security"]; ok {
+			operations[operationKey(selection.Method, selection.Path)] = security
+		}
+	}
+	components, _ := root["components"].(map[string]any)
+	return map[string]any{
+		"global_security":    root["security"],
+		"operation_security": operations,
+		"security_schemes":   components["securitySchemes"],
+	}
+}
+
+func collectReferences(value any, root map[string]any, references map[string]any) error {
+	switch typed := value.(type) {
+	case map[string]any:
+		if rawReference, ok := typed["$ref"].(string); ok && strings.HasPrefix(rawReference, "#/") {
+			if _, exists := references[rawReference]; !exists {
+				resolved, err := resolveLocalReference(root, rawReference)
+				if err != nil {
+					return err
+				}
+				references[rawReference] = resolved
+				if err := collectReferences(resolved, root, references); err != nil {
+					return err
+				}
+			}
+		}
+		for _, child := range typed {
+			if err := collectReferences(child, root, references); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if err := collectReferences(child, root, references); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func resolveLocalReference(root map[string]any, reference string) (any, error) {
+	var current any = root
+	for _, token := range strings.Split(strings.TrimPrefix(reference, "#/"), "/") {
+		token = strings.ReplaceAll(strings.ReplaceAll(token, "~1", "/"), "~0", "~")
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("local reference %q crosses a non-object value", reference)
+		}
+		current, ok = object[token]
+		if !ok {
+			return nil, fmt.Errorf("local reference %q is missing token %q", reference, token)
+		}
+	}
+	return current, nil
+}
+
+func digestValue(value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return stampfile.HashReader(bytes.NewReader(payload))
+}
+
+func operationMap(operations []OperationLock) map[string]OperationLock {
+	result := make(map[string]OperationLock, len(operations))
+	for _, operation := range operations {
+		result[operationKey(operation.Method, operation.Path)] = operation
+	}
+	return result
+}
+
+func operationKey(method string, path string) string {
+	return strings.ToUpper(strings.TrimSpace(method)) + " " + strings.TrimSpace(path)
+}

--- a/internal/providercontractlock/lock_test.go
+++ b/internal/providercontractlock/lock_test.go
@@ -1,0 +1,141 @@
+package providercontractlock
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestBuildIsDeterministicAndIncludesReferenceClosure(t *testing.T) {
+	selection := []Selection{{FamilyID: "users", Method: "GET", Path: "/users", OperationID: "listUsers"}}
+	first, err := Build(loadDocument(t, providerFixture), "example", selection)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	second, err := Build(loadDocument(t, strings.ReplaceAll(providerFixture, `"title":"Example"`, `"title": "Example"`)), "example", selection)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if first.DocumentDigest != second.DocumentDigest || first.AuthDigest != second.AuthDigest || first.Operations[0].Digest != second.Operations[0].Digest {
+		t.Fatalf("lock changed across input formatting:\nfirst=%#v\nsecond=%#v", first, second)
+	}
+
+	changedSchema := strings.Replace(providerFixture, `"email":{"type":"string"}`, `"email":{"type":"string","format":"email"}`, 1)
+	changed, err := Build(loadDocument(t, changedSchema), "example", selection)
+	if err != nil {
+		t.Fatalf("Build(changed schema) error = %v", err)
+	}
+	if first.Operations[0].Digest == changed.Operations[0].Digest {
+		t.Fatal("selected operation digest did not include referenced response schema")
+	}
+}
+
+func TestCompareClassifiesProviderDrift(t *testing.T) {
+	selection := []Selection{{FamilyID: "users", Method: "GET", Path: "/users", OperationID: "listUsers"}}
+	baseline, err := Build(loadDocument(t, providerFixture), "example", selection)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if drift := Compare(nil, baseline); drift.Status != DriftNew {
+		t.Fatalf("new drift = %#v", drift)
+	}
+	if drift := Compare(&baseline, baseline); drift.Status != DriftUnchanged {
+		t.Fatalf("unchanged drift = %#v", drift)
+	}
+
+	additiveDocument := strings.Replace(providerFixture, `"schemas":{`, `"schemas":{"Unused":{"type":"string"},`, 1)
+	additive, err := Build(loadDocument(t, additiveDocument), "example", selection)
+	if err != nil {
+		t.Fatalf("Build(additive) error = %v", err)
+	}
+	if drift := Compare(&baseline, additive); drift.Status != DriftAdditive {
+		t.Fatalf("additive drift = %#v", drift)
+	}
+
+	changedSchema := strings.Replace(providerFixture, `"email":{"type":"string"}`, `"email":{"type":"string","format":"email"}`, 1)
+	behavioral, err := Build(loadDocument(t, changedSchema), "example", selection)
+	if err != nil {
+		t.Fatalf("Build(behavioral) error = %v", err)
+	}
+	if drift := Compare(&baseline, behavioral); drift.Status != DriftBehavioralReview {
+		t.Fatalf("behavioral drift = %#v", drift)
+	}
+
+	changedAuth := strings.Replace(providerFixture, `"scheme":"bearer"`, `"scheme":"basic"`, 1)
+	breaking, err := Build(loadDocument(t, changedAuth), "example", selection)
+	if err != nil {
+		t.Fatalf("Build(breaking) error = %v", err)
+	}
+	if drift := Compare(&baseline, breaking); drift.Status != DriftBreaking {
+		t.Fatalf("breaking drift = %#v", drift)
+	}
+
+	withoutSelection, err := Build(loadDocument(t, providerFixture), "example", nil)
+	if err != nil {
+		t.Fatalf("Build(without selection) error = %v", err)
+	}
+	if drift := Compare(&baseline, withoutSelection); drift.Status != DriftBreaking {
+		t.Fatalf("removed operation drift = %#v", drift)
+	}
+}
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	lock, err := Build(loadDocument(t, providerFixture), "example", []Selection{{FamilyID: "users", Method: "GET", Path: "/users"}})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "locks", "provider.json")
+	if err := Write(path, lock); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	loaded, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if Compare(&lock, loaded).Status != DriftUnchanged {
+		t.Fatalf("round-trip lock changed: %#v", loaded)
+	}
+	before, err := Digest(lock)
+	if err != nil {
+		t.Fatalf("Digest(lock) error = %v", err)
+	}
+	after, err := Digest(loaded)
+	if err != nil {
+		t.Fatalf("Digest(loaded) error = %v", err)
+	}
+	if before != after {
+		t.Fatalf("lock digest changed after round trip: %s != %s", before, after)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat lock: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("lock mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func loadDocument(t *testing.T, payload string) *openapi3.T {
+	t.Helper()
+	doc, err := openapi3.NewLoader().LoadFromData([]byte(payload))
+	if err != nil {
+		t.Fatalf("load OpenAPI document: %v\n%s", err, payload)
+	}
+	return doc
+}
+
+const providerFixture = `{
+  "openapi":"3.0.3",
+  "info":{"title":"Example","version":"1.0.0"},
+  "security":[{"Bearer":[]}],
+  "components":{
+    "securitySchemes":{"Bearer":{"type":"http","scheme":"bearer"}},
+    "schemas":{"User":{"type":"object","properties":{"id":{"type":"string"},"email":{"type":"string"}}}}
+  },
+  "paths":{
+    "/users":{"get":{"operationId":"listUsers","responses":{"200":{"description":"ok","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}
+  }
+}`

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -69,11 +69,20 @@ type Request struct {
 // DefinitionRequest describes a generated integration backed by a connector definition.
 type DefinitionRequest struct {
 	Definition           connectordefinitions.Definition
+	ProviderContract     *ProviderContractEvidence
 	FreshnessExpectation string
 	HealthPath           string
 	OutputDir            string
 	DryRun               bool
 	Force                bool
+}
+
+// ProviderContractEvidence binds a reviewed provider contract lock to a
+// sourcegen proof bundle.
+type ProviderContractEvidence struct {
+	LockDigest  string `json:"lock_digest"`
+	DriftStatus string `json:"drift_status"`
+	Reviewed    bool   `json:"reviewed"`
 }
 
 // Result describes the files and operator receipt produced by the generator.
@@ -103,6 +112,7 @@ type normalizedRequest struct {
 	OAuthTokenParams  map[string]string
 	OAuthTokenMethod  string
 	ProviderAPI       *connectordefinitions.ProviderAPISpec
+	ProviderContract  *ProviderContractEvidence
 	EnvPrefix         string
 	PackageName       string
 	DefaultFamily     string
@@ -331,6 +341,7 @@ func normalizeDefinitionRequest(request DefinitionRequest) (normalizedRequest, e
 		OAuthTokenParams:  cloneStringMap(definition.Auth.TokenParams),
 		OAuthTokenMethod:  strings.TrimSpace(definition.Auth.TokenRequestAuthMethod),
 		ProviderAPI:       cloneProviderAPI(definition.ProviderAPI),
+		ProviderContract:  cloneProviderContractEvidence(request.ProviderContract),
 		EnvPrefix:         strings.ToUpper(strings.NewReplacer("-", "_").Replace(sourceID)),
 		PackageName:       packageName(sourceID),
 		BaseURLTemplate:   transportBaseURL(definition.Transport),
@@ -352,6 +363,16 @@ func normalizeDefinitionRequest(request DefinitionRequest) (normalizedRequest, e
 	normalized.DefaultFamily = normalized.Families[0].Name
 	normalized.DefaultPath = normalized.Families[0].Path
 	return normalized, nil
+}
+
+func cloneProviderContractEvidence(evidence *ProviderContractEvidence) *ProviderContractEvidence {
+	if evidence == nil {
+		return nil
+	}
+	cloned := *evidence
+	cloned.LockDigest = strings.TrimSpace(cloned.LockDigest)
+	cloned.DriftStatus = strings.TrimSpace(cloned.DriftStatus)
+	return &cloned
 }
 
 func normalizeRequest(request Request) (normalizedRequest, error) {

--- a/internal/sourcegen/proof_bundle.go
+++ b/internal/sourcegen/proof_bundle.go
@@ -19,13 +19,14 @@ const (
 // ProofBundle records the deterministic inputs, outputs, ownership, capability
 // claims, and remaining obligations for one sourcegen run.
 type ProofBundle struct {
-	SchemaVersion    string            `json:"schema_version"`
-	GeneratorVersion string            `json:"generator_version"`
-	SourceID         string            `json:"source_id"`
-	InputDigest      string            `json:"input_digest"`
-	GrammarFeatures  []string          `json:"grammar_features"`
-	Outputs          []ProofOutput     `json:"outputs"`
-	Obligations      []ProofObligation `json:"obligations"`
+	SchemaVersion    string                    `json:"schema_version"`
+	GeneratorVersion string                    `json:"generator_version"`
+	SourceID         string                    `json:"source_id"`
+	InputDigest      string                    `json:"input_digest"`
+	GrammarFeatures  []string                  `json:"grammar_features"`
+	ProviderContract *ProviderContractEvidence `json:"provider_contract,omitempty"`
+	Outputs          []ProofOutput             `json:"outputs"`
+	Obligations      []ProofObligation         `json:"obligations"`
 }
 
 // ProofOutput identifies one sourcegen-owned artifact by content digest.
@@ -59,6 +60,17 @@ func buildProofBundle(request normalizedRequest, manifest generationManifest) Pr
 		providerDetail = "Provider API metadata is recorded, but no reviewed contract lock is attached."
 		providerAction = "Generate and review a provider contract lock before promotion."
 	}
+	if request.ProviderContract != nil && request.ProviderContract.LockDigest != "" {
+		providerDetail = "The proof bundle is bound to the current provider contract lock."
+		providerAction = ""
+		if request.ProviderContract.Reviewed {
+			providerStatus = ProofStatusPassed
+		} else {
+			providerStatus = ProofStatusPending
+			providerDetail = "The proof bundle is bound to a new provider contract lock that still needs review."
+			providerAction = "Review the selected operations and auth contract before promotion."
+		}
+	}
 
 	return ProofBundle{
 		SchemaVersion:    ProofBundleSchemaVersion,
@@ -66,6 +78,7 @@ func buildProofBundle(request normalizedRequest, manifest generationManifest) Pr
 		SourceID:         manifest.SourceID,
 		InputDigest:      manifest.InputDigest,
 		GrammarFeatures:  grammarFeatures(request),
+		ProviderContract: cloneProviderContractEvidence(request.ProviderContract),
 		Outputs:          outputs,
 		Obligations: []ProofObligation{
 			{ID: "sourcegen.input_digest", Status: ProofStatusPassed, Detail: "Normalized generator inputs have a deterministic content digest."},

--- a/internal/sourcegen/proof_bundle_test.go
+++ b/internal/sourcegen/proof_bundle_test.go
@@ -1,0 +1,64 @@
+package sourcegen
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/connectordefinitions"
+)
+
+func TestBuildProofBundleBindsReviewedProviderContract(t *testing.T) {
+	request := normalizedRequest{
+		Request: Request{SourceID: "example", SourceType: SourceTypeJSONAPI, AuthModel: AuthModelBearerToken},
+		ProviderAPI: &connectordefinitions.ProviderAPISpec{
+			Status: "verified",
+		},
+		ProviderContract: &ProviderContractEvidence{
+			LockDigest:  "contract-digest",
+			DriftStatus: "unchanged",
+			Reviewed:    true,
+		},
+	}
+	bundle := buildProofBundle(request, generationManifest{
+		GeneratorVersion: generatorVersion,
+		SourceID:         "example",
+		InputDigest:      "input-digest",
+		Outputs:          map[string]string{"sources/example/source.go": "output-digest"},
+	})
+	if bundle.ProviderContract == nil || bundle.ProviderContract.LockDigest != "contract-digest" {
+		t.Fatalf("provider contract evidence = %#v", bundle.ProviderContract)
+	}
+	for _, obligation := range bundle.Obligations {
+		if obligation.ID == "provider.contract_lock" {
+			if obligation.Status != ProofStatusPassed || obligation.Action != "" {
+				t.Fatalf("provider contract obligation = %#v", obligation)
+			}
+			return
+		}
+	}
+	t.Fatal("provider contract obligation not found")
+}
+
+func TestBuildProofBundleKeepsNewProviderContractPending(t *testing.T) {
+	request := normalizedRequest{
+		Request: Request{SourceID: "example", SourceType: SourceTypeJSONAPI, AuthModel: AuthModelBearerToken},
+		ProviderContract: &ProviderContractEvidence{
+			LockDigest:  "contract-digest",
+			DriftStatus: "new",
+		},
+	}
+	bundle := buildProofBundle(request, generationManifest{
+		GeneratorVersion: generatorVersion,
+		SourceID:         "example",
+		InputDigest:      "input-digest",
+		Outputs:          map[string]string{},
+	})
+	for _, obligation := range bundle.Obligations {
+		if obligation.ID == "provider.contract_lock" {
+			if obligation.Status != ProofStatusPending || obligation.Action == "" {
+				t.Fatalf("provider contract obligation = %#v", obligation)
+			}
+			return
+		}
+	}
+	t.Fatal("provider contract obligation not found")
+}

--- a/tools/connectoronboard/main.go
+++ b/tools/connectoronboard/main.go
@@ -11,11 +11,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/connectordefinitions/openapigen"
+	"github.com/writer/cerebro/internal/providercontractlock"
 	"github.com/writer/cerebro/internal/sourcegen"
 )
 
@@ -38,11 +40,21 @@ type OnboardResult struct {
 	GenerationManifest string                          `json:"generation_manifest,omitempty"`
 	ProofBundle        string                          `json:"proof_bundle,omitempty"`
 	ChangePlan         *sourcegen.ChangePlan           `json:"change_plan,omitempty"`
+	ProviderContract   ProviderContractResult          `json:"provider_contract"`
 	WiredFiles         []string                        `json:"wired_files,omitempty"`
 	Definition         connectordefinitions.Definition `json:"definition"`
 	NextSteps          []string                        `json:"next_steps"`
 	CatalogPath        string                          `json:"catalog_path,omitempty"`
 	DryRun             bool                            `json:"dry_run"`
+}
+
+// ProviderContractResult reports the lock and drift decision used by this run.
+type ProviderContractResult struct {
+	LockPath string                     `json:"lock_path"`
+	Lock     providercontractlock.Lock  `json:"lock"`
+	Drift    providercontractlock.Drift `json:"drift"`
+	Accepted bool                       `json:"accepted"`
+	Written  bool                       `json:"written"`
 }
 
 func main() {
@@ -59,8 +71,11 @@ func main() {
 	var allFamilies bool
 	var outputDir string
 	var catalogOut string
+	var contractLock string
+	var contractLockOut string
 	var dryRun bool
 	var wire bool
+	var acceptContractChange bool
 	flag.StringVar(&specPath, "spec", "", "OpenAPI document path (required)")
 	flag.StringVar(&sourceID, "source-id", "", "connector source id; inferred from spec title when empty")
 	flag.StringVar(&tenantID, "tenant-id", "builtin_catalog", "tenant id for the catalog entry")
@@ -74,8 +89,11 @@ func main() {
 	flag.BoolVar(&allFamilies, "all-families", false, "select every endpoint")
 	flag.StringVar(&outputDir, "output-dir", ".", "output directory for sourcegen files")
 	flag.StringVar(&catalogOut, "catalog-out", "", "write catalog entry YAML to this path")
+	flag.StringVar(&contractLock, "contract-lock", "", "reviewed provider contract lock to compare")
+	flag.StringVar(&contractLockOut, "contract-lock-out", "", "provider contract lock output path; defaults to the generated source directory")
 	flag.BoolVar(&dryRun, "dry-run", true, "dry-run mode (default true); set -dry-run=false to write files")
 	flag.BoolVar(&wire, "wire", true, "wire generated source, projection, and documentation entries when writing")
+	flag.BoolVar(&acceptContractChange, "accept-contract-change", false, "record reviewed selected-operation or auth changes in the provider contract lock")
 	flag.Parse()
 
 	if strings.TrimSpace(specPath) == "" {
@@ -108,6 +126,31 @@ func main() {
 	}
 	fmt.Fprintf(os.Stderr, "onboard: generated definition for %s (%d endpoints selected, %d skipped)\n",
 		definition.SourceID, len(report.Selected), len(report.Skipped))
+	currentLock, err := providercontractlock.Build(doc, definition.SourceID, contractSelections(report.Selected))
+	if err != nil {
+		fail(fmt.Errorf("build provider contract lock: %w", err))
+	}
+	lockOutputPath := providerContractOutputPath(outputDir, definition.SourceID, contractLock, contractLockOut)
+	comparePath := strings.TrimSpace(contractLock)
+	if comparePath == "" {
+		comparePath = lockOutputPath
+	}
+	previousLock, err := readProviderContractLock(comparePath)
+	if err != nil {
+		fail(err)
+	}
+	contractDrift := providercontractlock.Compare(previousLock, currentLock)
+	contractBlocked := contractChangeNeedsReview(contractDrift) && !acceptContractChange
+	contractDigest, err := providercontractlock.Digest(currentLock)
+	if err != nil {
+		fail(fmt.Errorf("hash provider contract lock: %w", err))
+	}
+	contractReviewAccepted := acceptContractChange && contractDrift.Status != providercontractlock.DriftUnchanged
+	contractReviewed := previousLock != nil && (contractDrift.Status == providercontractlock.DriftUnchanged || contractDrift.Status == providercontractlock.DriftAdditive)
+	if contractReviewAccepted {
+		contractReviewed = true
+	}
+	fmt.Fprintf(os.Stderr, "onboard: provider contract: %s\n", contractDrift.Status)
 
 	// Step 3: Classify against the grammar.
 	grammar := connectordefinitions.DefaultGrammar()
@@ -132,12 +175,26 @@ func main() {
 		MissingFeatures:  supportReport.MissingFeatures,
 		Definition:       definition,
 		DryRun:           dryRun,
+		ProviderContract: ProviderContractResult{
+			LockPath: lockOutputPath,
+			Lock:     currentLock,
+			Drift:    contractDrift,
+			Accepted: contractReviewAccepted,
+		},
 	}
-	if supportReport.Verdict == connectordefinitions.SupportVerdictSupported {
+	if contractBlocked {
+		result.SourcegenError = "Provider contract changes require review before source generation."
+	}
+	if supportReport.Verdict == connectordefinitions.SupportVerdictSupported && !contractBlocked {
 		genResult, err := sourcegen.GenerateDefinition(sourcegen.DefinitionRequest{
 			Definition: definition,
-			OutputDir:  outputDir,
-			DryRun:     dryRun,
+			ProviderContract: &sourcegen.ProviderContractEvidence{
+				LockDigest:  contractDigest,
+				DriftStatus: contractDrift.Status,
+				Reviewed:    contractReviewed,
+			},
+			OutputDir: outputDir,
+			DryRun:    dryRun,
 		})
 		if err != nil {
 			result.SourcegenError = err.Error()
@@ -163,12 +220,19 @@ func main() {
 			}
 		}
 	}
+	if result.Generateable && !dryRun {
+		if err := providercontractlock.Write(lockOutputPath, currentLock); err != nil {
+			fail(fmt.Errorf("write provider contract lock: %w", err))
+		}
+		result.ProviderContract.Written = true
+		fmt.Fprintf(os.Stderr, "onboard: wrote provider contract lock to %s\n", lockOutputPath)
+	}
 
 	// Step 5: Build next steps.
 	result.NextSteps = buildNextSteps(result)
 
 	// Step 6: Write catalog entry if requested.
-	if strings.TrimSpace(catalogOut) != "" && !dryRun {
+	if strings.TrimSpace(catalogOut) != "" && !dryRun && !contractBlocked {
 		if err := writeCatalogEntry(catalogOut, definition, supportReport.Verdict); err != nil {
 			fail(fmt.Errorf("write catalog entry: %w", err))
 		}
@@ -186,6 +250,18 @@ func main() {
 
 func buildNextSteps(result OnboardResult) []string {
 	var steps []string
+	if contractChangeNeedsReview(result.ProviderContract.Drift) && !result.ProviderContract.Accepted {
+		return []string{
+			fmt.Sprintf("Review provider contract changes: %s", strings.Join(result.ProviderContract.Drift.Changes, ", ")),
+			"Re-run with -accept-contract-change after reviewing the selected operations and auth contract.",
+		}
+	}
+	if result.ProviderContract.Drift.Status == providercontractlock.DriftNew && !result.ProviderContract.Accepted {
+		steps = append(steps,
+			fmt.Sprintf("Review the provider contract lock at %s.", result.ProviderContract.LockPath),
+			"Re-run with -accept-contract-change to record the initial contract review in the proof bundle.",
+		)
+	}
 	switch result.Verdict {
 	case connectordefinitions.SupportVerdictSupported:
 		if result.Generateable {
@@ -223,6 +299,44 @@ func buildNextSteps(result OnboardResult) []string {
 		)
 	}
 	return steps
+}
+
+func contractSelections(endpoints []openapigen.Endpoint) []providercontractlock.Selection {
+	selections := make([]providercontractlock.Selection, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		selections = append(selections, providercontractlock.Selection{
+			FamilyID:    endpoint.FamilyID,
+			Method:      endpoint.Method,
+			Path:        endpoint.Path,
+			OperationID: endpoint.OperationID,
+		})
+	}
+	return selections
+}
+
+func providerContractOutputPath(outputDir string, sourceID string, inputPath string, outputPath string) string {
+	if path := strings.TrimSpace(outputPath); path != "" {
+		return path
+	}
+	if path := strings.TrimSpace(inputPath); path != "" {
+		return path
+	}
+	return filepath.Join(outputDir, "sources", sourceID, ".provider-contract-lock.json")
+}
+
+func readProviderContractLock(path string) (*providercontractlock.Lock, error) {
+	lock, err := providercontractlock.Read(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read provider contract lock: %w", err)
+	}
+	return &lock, nil
+}
+
+func contractChangeNeedsReview(drift providercontractlock.Drift) bool {
+	return drift.Status == providercontractlock.DriftBehavioralReview || drift.Status == providercontractlock.DriftBreaking
 }
 
 func writeCatalogEntry(path string, definition connectordefinitions.Definition, verdict string) error {

--- a/tools/connectoronboard/main_test.go
+++ b/tools/connectoronboard/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/writer/cerebro/internal/connectordefinitions/openapigen"
+	"github.com/writer/cerebro/internal/providercontractlock"
+)
+
+func TestContractSelectionsPreserveGeneratedEndpointIdentity(t *testing.T) {
+	selections := contractSelections([]openapigen.Endpoint{{
+		FamilyID:    "audit_events",
+		Method:      "GET",
+		Path:        "/v1/audit/events",
+		OperationID: "listAuditEvents",
+	}})
+	if len(selections) != 1 {
+		t.Fatalf("selections = %#v", selections)
+	}
+	selection := selections[0]
+	if selection.FamilyID != "audit_events" || selection.Method != "GET" || selection.Path != "/v1/audit/events" || selection.OperationID != "listAuditEvents" {
+		t.Fatalf("selection = %#v", selection)
+	}
+}
+
+func TestProviderContractOutputPath(t *testing.T) {
+	if got := providerContractOutputPath("/workspace", "example", "", ""); got != filepath.Join("/workspace", "sources", "example", ".provider-contract-lock.json") {
+		t.Fatalf("default output path = %q", got)
+	}
+	if got := providerContractOutputPath("/workspace", "example", "/reviewed.json", ""); got != "/reviewed.json" {
+		t.Fatalf("input-backed output path = %q", got)
+	}
+	if got := providerContractOutputPath("/workspace", "example", "/reviewed.json", "/next.json"); got != "/next.json" {
+		t.Fatalf("explicit output path = %q", got)
+	}
+}
+
+func TestContractChangeNeedsReview(t *testing.T) {
+	for _, status := range []string{providercontractlock.DriftBehavioralReview, providercontractlock.DriftBreaking} {
+		if !contractChangeNeedsReview(providercontractlock.Drift{Status: status}) {
+			t.Fatalf("status %q did not require review", status)
+		}
+	}
+	for _, status := range []string{providercontractlock.DriftNew, providercontractlock.DriftUnchanged, providercontractlock.DriftAdditive} {
+		if contractChangeNeedsReview(providercontractlock.Drift{Status: status}) {
+			t.Fatalf("status %q unexpectedly required a blocking review", status)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- create deterministic provider contract locks for normalized OpenAPI documents, auth schemes, selected operations, path parameters, and local reference closures
- classify drift as new, unchanged, additive, behavioral review, or breaking
- block connector onboarding when selected operations or auth change without explicit review
- bind the reviewed lock digest and drift state into the sourcegen proof bundle
- write the accepted lock beside the generated source and include the lock package in sourcegen checks

## Why

Regeneration needs to distinguish unrelated provider documentation changes from changes that affect generated requests, response schemas, or credentials. The proof receipt now records the exact provider contract used for generation.

## Validation

- go test ./internal/providercontractlock ./internal/sourcegen ./internal/sourcegen/grammarproof ./tools/connectoronboard -count=1
- make sourcegen-test
- make lint-internal
- golangci-lint run -j 4 --timeout 20m ./tools/connectoronboard/...
- connector onboarding write and unchanged-lock smoke test with api/openapi.yaml
- git diff --check