### PR TITLE
Share embedded JSON Wasm runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           - name: openapi
             command: make openapi-check openapi-lint
           - name: graph-actions
-            command: make graph-action-check graphagent-static-validator-check sourcecoverage-evaluator-check panopticon-resource-extractor-check
+            command: make graph-action-check rust-wasm-check
           - name: docs-drift
             command: make docs-drift-check
           - name: readme

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           - name: catalog
             command: make catalog-check detection-catalog-check
           - name: graph-actions
-            command: make graph-action-check graphagent-static-validator-check sourcecoverage-evaluator-check panopticon-resource-extractor-check
+            command: make graph-action-check rust-wasm-check
           - name: finding-dsl
             command: make finding-dsl-check
           - name: policy-rule

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 .PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-shard lint-api-cmd lint-internal lint-sources lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check control-index-generate control-index-check sourcegen-check connector-catalog-fidelity-generate connector-catalog-fidelity-check connector-catalog-review connector-api-discovery connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo github-business-demo github-business-demo-env agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
-.PHONY: rust-fmt-check rust-clippy rust-test graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check
+.PHONY: rust-fmt-check rust-clippy rust-test rust-wasm-check graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -10,11 +10,11 @@ STATIC_VALIDATOR_WASM := internal/graphagent/staticvalidator.wasm
 STATIC_VALIDATOR_BUILD := target/wasm32-unknown-unknown/release/cerebro_graphagent_staticvalidator.wasm
 SOURCECOVERAGE_EVALUATOR_WASM := internal/sourcecoverage/evaluator.wasm
 SOURCECOVERAGE_EVALUATOR_BUILD := target/wasm32-unknown-unknown/release/cerebro_sourcecoverage_evaluator.wasm
-SOURCECOVERAGE_CANONICAL_PLATFORM := Linux-x86_64
-HOST_PLATFORM := $(shell uname -s)-$(shell uname -m)
 PANOPTICON_RESOURCE_WASM := internal/sourceprojection/panopticonresources.wasm
 PANOPTICON_RESOURCE_BUILD := target/wasm32-unknown-unknown/release/cerebro_panopticon_resources.wasm
-PANOPTICON_CANONICAL_PLATFORM := Linux-x86_64
+WASM_CANONICAL_PLATFORM := Linux-x86_64
+WASM_HOST_PLATFORM := $(shell uname -s)-$(shell uname -m)
+RUST_WASM_FLAGS := --remap-path-prefix=$(CURDIR)=/workspace --remap-path-prefix=$${CARGO_HOME:-$$HOME/.cargo}=/cargo
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.4
 GOLANGCI_LINT_CONCURRENCY ?= 4
@@ -429,36 +429,38 @@ graph-action-check: rust-fmt-check rust-clippy rust-test ## Verify generated gra
 	$(CARGO) run --locked --quiet -p cerebro-graphactiongen -- --check
 
 graphagent-static-validator-generate: ## Rebuild the embedded static Cypher validator.
-	RUSTFLAGS="--remap-path-prefix=$(CURDIR)=/workspace --remap-path-prefix=$${CARGO_HOME:-$$HOME/.cargo}=/cargo" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-graphagent-staticvalidator
+	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-graphagent-staticvalidator
 	cp "$(STATIC_VALIDATOR_BUILD)" "$(STATIC_VALIDATOR_WASM)"
 	chmod 0644 "$(STATIC_VALIDATOR_WASM)"
 
 graphagent-static-validator-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded static Cypher validator is current.
 	$(CARGO) clippy --locked --target wasm32-unknown-unknown -p cerebro-graphagent-staticvalidator -- -D warnings
-	RUSTFLAGS="--remap-path-prefix=$(CURDIR)=/workspace --remap-path-prefix=$${CARGO_HOME:-$$HOME/.cargo}=/cargo" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-graphagent-staticvalidator
+	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-graphagent-staticvalidator
 	cmp "$(STATIC_VALIDATOR_BUILD)" "$(STATIC_VALIDATOR_WASM)"
 
 sourcecoverage-evaluator-generate: ## Rebuild the embedded source coverage evaluator.
-	@test "$(HOST_PLATFORM)" = "$(SOURCECOVERAGE_CANONICAL_PLATFORM)" || (echo "source coverage artifact generation requires $(SOURCECOVERAGE_CANONICAL_PLATFORM); current platform is $(HOST_PLATFORM)" && exit 1)
-	RUSTFLAGS="--remap-path-prefix=$(CURDIR)=/workspace --remap-path-prefix=$${CARGO_HOME:-$$HOME/.cargo}=/cargo" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-sourcecoverage-evaluator
+	@test "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" || (echo "source coverage artifact generation requires $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)" && exit 1)
+	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-sourcecoverage-evaluator
 	cp "$(SOURCECOVERAGE_EVALUATOR_BUILD)" "$(SOURCECOVERAGE_EVALUATOR_WASM)"
 	chmod 0644 "$(SOURCECOVERAGE_EVALUATOR_WASM)"
 
 sourcecoverage-evaluator-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded source coverage evaluator is current.
 	$(CARGO) clippy --locked --target wasm32-unknown-unknown -p cerebro-sourcecoverage-evaluator -- -D warnings
-	RUSTFLAGS="--remap-path-prefix=$(CURDIR)=/workspace --remap-path-prefix=$${CARGO_HOME:-$$HOME/.cargo}=/cargo" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-sourcecoverage-evaluator
-	@if [ "$(HOST_PLATFORM)" = "$(SOURCECOVERAGE_CANONICAL_PLATFORM)" ]; then cmp "$(SOURCECOVERAGE_EVALUATOR_BUILD)" "$(SOURCECOVERAGE_EVALUATOR_WASM)"; else echo "source coverage artifact byte comparison runs on $(SOURCECOVERAGE_CANONICAL_PLATFORM); current platform is $(HOST_PLATFORM)"; fi
+	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-sourcecoverage-evaluator
+	@if [ "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" ]; then cmp "$(SOURCECOVERAGE_EVALUATOR_BUILD)" "$(SOURCECOVERAGE_EVALUATOR_WASM)"; else echo "source coverage artifact byte comparison runs on $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)"; fi
 
 panopticon-resource-extractor-generate: ## Rebuild the embedded Panopticon resource extractor.
-	@test "$(HOST_PLATFORM)" = "$(PANOPTICON_CANONICAL_PLATFORM)" || (echo "Panopticon resource artifact generation requires $(PANOPTICON_CANONICAL_PLATFORM); current platform is $(HOST_PLATFORM)" && exit 1)
-	RUSTFLAGS="--remap-path-prefix=$(CURDIR)=/workspace --remap-path-prefix=$${CARGO_HOME:-$$HOME/.cargo}=/cargo" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-panopticon-resources
+	@test "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" || (echo "Panopticon resource artifact generation requires $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)" && exit 1)
+	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-panopticon-resources
 	cp "$(PANOPTICON_RESOURCE_BUILD)" "$(PANOPTICON_RESOURCE_WASM)"
 	chmod 0644 "$(PANOPTICON_RESOURCE_WASM)"
 
 panopticon-resource-extractor-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded Panopticon resource extractor is current.
 	$(CARGO) clippy --locked --target wasm32-unknown-unknown -p cerebro-panopticon-resources -- -D warnings
-	RUSTFLAGS="--remap-path-prefix=$(CURDIR)=/workspace --remap-path-prefix=$${CARGO_HOME:-$$HOME/.cargo}=/cargo" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-panopticon-resources
-	@if [ "$(HOST_PLATFORM)" = "$(PANOPTICON_CANONICAL_PLATFORM)" ]; then cmp "$(PANOPTICON_RESOURCE_BUILD)" "$(PANOPTICON_RESOURCE_WASM)"; else echo "Panopticon resource artifact byte comparison runs on $(PANOPTICON_CANONICAL_PLATFORM); current platform is $(HOST_PLATFORM)"; fi
+	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-panopticon-resources
+	@if [ "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" ]; then cmp "$(PANOPTICON_RESOURCE_BUILD)" "$(PANOPTICON_RESOURCE_WASM)"; else echo "Panopticon resource artifact byte comparison runs on $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)"; fi
+
+rust-wasm-check: graphagent-static-validator-check sourcecoverage-evaluator-check panopticon-resource-extractor-check ## Verify every embedded Rust Wasm module.
 
 finding-dsl-migrate: ## Convert legacy JSON policy files to PolicyFindingRule DSL YAML.
 	go run ./tools/findingdsl --migrate-policies --write
@@ -726,7 +728,7 @@ hooks: ## Install repository git hooks.
 pre-commit: ## Run local pre-commit checks.
 	./scripts/pre_commit_checks.sh
 
-check: build test script-test sdk-test lint proto-lint proto-generate-check graph-action-check graphagent-static-validator-check sourcecoverage-evaluator-check panopticon-resource-extractor-check finding-dsl-check policy-rule-check policy-mapping-check connector-contract-check docs-drift-check check-structural check-structural-test check-arch ## Run the main local validation suite.
+check: build test script-test sdk-test lint proto-lint proto-generate-check graph-action-check rust-wasm-check finding-dsl-check policy-rule-check policy-mapping-check connector-contract-check docs-drift-check check-structural check-structural-test check-arch ## Run the main local validation suite.
 
 check-structural: check-structural-build ## Run custom structural lints.
 	@$(LINTER_BIN) $(APP_PACKAGES)
@@ -742,4 +744,4 @@ check-arch: ## Run architectural guardrail tests.
 
 check-hook-integrity: check-arch ## Verify hook-integrity guardrails.
 
-verify: build test test-race cover script-test sdk-test sdk-dependency-audit mcp-contract-check mcp-sdk-compat lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check connector-contract-check graph-action-check graphagent-static-validator-check sourcecoverage-evaluator-check panopticon-resource-extractor-check finding-dsl-check policy-rule-check policy-mapping-check detection-catalog-check docs-drift-check readme-check oss-audit govulncheck release-smoke docker-smoke check-structural check-structural-test check-arch ## Run full CI-equivalent validation suite.
+verify: build test test-race cover script-test sdk-test sdk-dependency-audit mcp-contract-check mcp-sdk-compat lint proto-lint proto-generate-check proto-breaking openapi-check openapi-lint catalog-check connector-contract-check graph-action-check rust-wasm-check finding-dsl-check policy-rule-check policy-mapping-check detection-catalog-check docs-drift-check readme-check oss-audit govulncheck release-smoke docker-smoke check-structural check-structural-test check-arch ## Run full CI-equivalent validation suite.

--- a/internal/sourcecoverage/evaluator.go
+++ b/internal/sourcecoverage/evaluator.go
@@ -3,23 +3,17 @@ package sourcecoverage
 import (
 	"context"
 	_ "embed"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
-	"slices"
-	"sync"
 	"time"
 
-	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/api"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/wasmjson"
 )
 
 const (
 	coverageEvaluatorABIVersion = 1
-	coverageEvaluatorResultSize = 16
 	coverageEvaluatorMaxInput   = 8 << 20
 	coverageEvaluatorMaxOutput  = 16 << 20
 )
@@ -54,16 +48,19 @@ type coverageEvaluationResponse struct {
 	Records []Record `json:"records"`
 }
 
-type coverageEvaluatorEngine struct {
-	runtime  wazero.Runtime
-	compiled wazero.CompiledModule
-	err      error
-}
-
-var (
-	coverageEvaluatorOnce   sync.Once
-	coverageEvaluatorShared coverageEvaluatorEngine
-)
+var coverageEvaluator = wasmjson.New(wasmjson.Config{
+	Name:              "embedded source coverage evaluator",
+	Module:            coverageEvaluatorWasm,
+	ABIVersion:        coverageEvaluatorABIVersion,
+	ABIVersionExport:  "cerebro_sourcecoverage_abi_version",
+	AllocateExport:    "cerebro_sourcecoverage_alloc",
+	EvaluateExport:    "cerebro_sourcecoverage_evaluate",
+	MemoryLimitPages:  1024,
+	MaxInputBytes:     coverageEvaluatorMaxInput,
+	MaxOutputBytes:    coverageEvaluatorMaxOutput,
+	InitializeTimeout: 30 * time.Second,
+	CallTimeout:       2 * time.Second,
+})
 
 func evaluateCoverage(ctx context.Context, contracts []sourcecdk.CoverageContract, observations []RuntimeObservation, options Options) ([]Record, error) {
 	request := coverageEvaluationRequest{
@@ -93,150 +90,9 @@ func evaluateCoverage(ctx context.Context, contracts []sourcecdk.CoverageContrac
 }
 
 func runCoverageEvaluator(ctx context.Context, payload []byte) ([]byte, error) {
-	if len(payload) > coverageEvaluatorMaxInput {
-		return nil, fmt.Errorf("%w: evaluator input is %d bytes, maximum is %d", ErrEvaluatorUnavailable, len(payload), coverageEvaluatorMaxInput)
-	}
-	coverageEvaluatorOnce.Do(func() {
-		initCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		config := wazero.NewRuntimeConfig().WithCloseOnContextDone(true).WithMemoryLimitPages(1024)
-		coverageEvaluatorShared.runtime = wazero.NewRuntimeWithConfig(initCtx, config)
-		coverageEvaluatorShared.compiled, coverageEvaluatorShared.err = coverageEvaluatorShared.runtime.CompileModule(initCtx, coverageEvaluatorWasm)
-		if coverageEvaluatorShared.err != nil {
-			coverageEvaluatorShared.err = fmt.Errorf("compile embedded evaluator: %w", coverageEvaluatorShared.err)
-			return
-		}
-		if err := validateCoverageEvaluatorABI(coverageEvaluatorShared.compiled); err != nil {
-			coverageEvaluatorShared.err = err
-			return
-		}
-		module, err := coverageEvaluatorShared.runtime.InstantiateModule(initCtx, coverageEvaluatorShared.compiled, coverageEvaluatorModuleConfig())
-		if err != nil {
-			coverageEvaluatorShared.err = fmt.Errorf("instantiate embedded evaluator for ABI check: %w", err)
-			return
-		}
-		defer func() {
-			_ = module.Close(initCtx)
-		}()
-		versionFunction := module.ExportedFunction("cerebro_sourcecoverage_abi_version")
-		version, err := versionFunction.Call(initCtx)
-		if err != nil {
-			coverageEvaluatorShared.err = fmt.Errorf("read embedded evaluator ABI version: %w", err)
-			return
-		}
-		if len(version) != 1 || version[0] != coverageEvaluatorABIVersion {
-			coverageEvaluatorShared.err = fmt.Errorf("embedded evaluator ABI version = %v, want %d", version, coverageEvaluatorABIVersion)
-		}
-	})
-	if coverageEvaluatorShared.err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrEvaluatorUnavailable, coverageEvaluatorShared.err)
-	}
-	if uint64(len(payload)) > math.MaxUint32 {
-		return nil, fmt.Errorf("%w: request exceeds the Wasm32 address space", ErrEvaluatorUnavailable)
-	}
-
-	callCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	module, err := coverageEvaluatorShared.runtime.InstantiateModule(callCtx, coverageEvaluatorShared.compiled, coverageEvaluatorModuleConfig())
+	result, err := coverageEvaluator.Evaluate(ctx, payload)
 	if err != nil {
-		return nil, fmt.Errorf("%w: instantiate evaluator: %w", ErrEvaluatorUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrEvaluatorUnavailable, err)
 	}
-	defer func() {
-		_ = module.Close(callCtx)
-	}()
-
-	alloc := module.ExportedFunction("cerebro_sourcecoverage_alloc")
-	evaluate := module.ExportedFunction("cerebro_sourcecoverage_evaluate")
-	if alloc == nil || evaluate == nil || module.Memory() == nil {
-		return nil, fmt.Errorf("%w: embedded evaluator exports are incomplete", ErrEvaluatorUnavailable)
-	}
-	requestAllocation, err := alloc.Call(callCtx, uint64(len(payload)))
-	if err != nil {
-		return nil, fmt.Errorf("%w: allocate evaluator request: %w", ErrEvaluatorUnavailable, err)
-	}
-	resultAllocation, err := alloc.Call(callCtx, coverageEvaluatorResultSize)
-	if err != nil {
-		return nil, fmt.Errorf("%w: allocate evaluator result: %w", ErrEvaluatorUnavailable, err)
-	}
-	requestPointer, err := coverageEvaluatorPointer(requestAllocation, "request")
-	if err != nil {
-		return nil, err
-	}
-	resultPointer, err := coverageEvaluatorPointer(resultAllocation, "result")
-	if err != nil {
-		return nil, err
-	}
-	if !module.Memory().Write(requestPointer, payload) {
-		return nil, fmt.Errorf("%w: write evaluator request memory", ErrEvaluatorUnavailable)
-	}
-	status, err := evaluate.Call(callCtx, uint64(requestPointer), uint64(len(payload)), uint64(resultPointer))
-	if err != nil {
-		return nil, fmt.Errorf("%w: execute evaluator: %w", ErrEvaluatorUnavailable, err)
-	}
-	if len(status) != 1 || status[0] != 0 {
-		return nil, fmt.Errorf("%w: evaluator status = %v", ErrEvaluatorUnavailable, status)
-	}
-	result, ok := module.Memory().Read(resultPointer, coverageEvaluatorResultSize)
-	if !ok {
-		return nil, fmt.Errorf("%w: read evaluator result memory", ErrEvaluatorUnavailable)
-	}
-	if resultStatus := binary.LittleEndian.Uint32(result[0:4]); resultStatus != 0 {
-		return nil, fmt.Errorf("%w: evaluator result status = %d", ErrEvaluatorUnavailable, resultStatus)
-	}
-	if reserved := binary.LittleEndian.Uint32(result[12:16]); reserved != 0 {
-		return nil, fmt.Errorf("%w: evaluator reserved field = %d", ErrEvaluatorUnavailable, reserved)
-	}
-	outputPointer := binary.LittleEndian.Uint32(result[4:8])
-	outputLength := binary.LittleEndian.Uint32(result[8:12])
-	if outputLength > coverageEvaluatorMaxOutput {
-		return nil, fmt.Errorf("%w: evaluator output is %d bytes, maximum is %d", ErrEvaluatorUnavailable, outputLength, coverageEvaluatorMaxOutput)
-	}
-	output, ok := module.Memory().Read(outputPointer, outputLength)
-	if !ok {
-		return nil, fmt.Errorf("%w: read evaluator output memory", ErrEvaluatorUnavailable)
-	}
-	return append([]byte(nil), output...), nil
-}
-
-func coverageEvaluatorPointer(results []uint64, allocation string) (uint32, error) {
-	if len(results) != 1 {
-		return 0, fmt.Errorf("%w: allocate evaluator %s returned %d results", ErrEvaluatorUnavailable, allocation, len(results))
-	}
-	if results[0] > math.MaxUint32 {
-		return 0, fmt.Errorf("%w: evaluator %s pointer exceeds the Wasm32 address space", ErrEvaluatorUnavailable, allocation)
-	}
-	return uint32(results[0]), nil // #nosec G115 -- the value is bounded to MaxUint32 above.
-}
-
-func coverageEvaluatorModuleConfig() wazero.ModuleConfig {
-	return wazero.NewModuleConfig().WithName("").WithStartFunctions()
-}
-
-func validateCoverageEvaluatorABI(compiled wazero.CompiledModule) error {
-	if len(compiled.ImportedFunctions()) != 0 || len(compiled.ImportedMemories()) != 0 {
-		return errors.New("embedded source coverage evaluator must not import functions or memory")
-	}
-	if _, ok := compiled.ExportedMemories()["memory"]; !ok {
-		return errors.New("embedded source coverage evaluator memory export is missing")
-	}
-	exports := compiled.ExportedFunctions()
-	required := []struct {
-		name    string
-		params  []api.ValueType
-		results []api.ValueType
-	}{
-		{name: "cerebro_sourcecoverage_abi_version", results: []api.ValueType{api.ValueTypeI32}},
-		{name: "cerebro_sourcecoverage_alloc", params: []api.ValueType{api.ValueTypeI32}, results: []api.ValueType{api.ValueTypeI32}},
-		{name: "cerebro_sourcecoverage_evaluate", params: []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32}, results: []api.ValueType{api.ValueTypeI32}},
-	}
-	for _, expected := range required {
-		definition, ok := exports[expected.name]
-		if !ok {
-			return fmt.Errorf("embedded source coverage evaluator export %q is missing", expected.name)
-		}
-		if !slices.Equal(definition.ParamTypes(), expected.params) || !slices.Equal(definition.ResultTypes(), expected.results) {
-			return fmt.Errorf("embedded source coverage evaluator export %q has an incompatible signature", expected.name)
-		}
-	}
-	return nil
+	return result, nil
 }

--- a/internal/sourcecoverage/evaluator_parity_test.go
+++ b/internal/sourcecoverage/evaluator_parity_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -63,6 +64,39 @@ func TestCoverageEvaluatorRejectsMalformedAndOversizedInput(t *testing.T) {
 	oversized := make([]byte, coverageEvaluatorMaxInput+1)
 	if _, err := runCoverageEvaluator(context.Background(), oversized); !errors.Is(err, ErrEvaluatorUnavailable) {
 		t.Fatalf("runCoverageEvaluator(oversized) error = %v, want ErrEvaluatorUnavailable", err)
+	}
+}
+
+func TestCoverageEvaluatorSupportsConcurrentCalls(t *testing.T) {
+	t.Parallel()
+	contracts := []sourcecdk.CoverageContract{{
+		SourceID: "source-a",
+		Dimensions: []sourcecdk.CoverageDimension{{
+			ID: "users", Type: "entity_family", Title: "Users", Families: []string{"user"}, Support: sourcecdk.CoverageSupportSupported,
+		}},
+	}}
+	observations := []RuntimeObservation{{RuntimeID: "runtime-a", SourceID: "source-a", Family: "user", Status: "healthy"}}
+
+	var wait sync.WaitGroup
+	errors := make(chan error, 8)
+	for range 8 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			records, err := Evaluate(context.Background(), contracts, observations, Options{})
+			if err != nil {
+				errors <- err
+				return
+			}
+			if len(records) != 1 || records[0].State != StateHealthy {
+				errors <- fmt.Errorf("records = %#v; want one healthy record", records)
+			}
+		}()
+	}
+	wait.Wait()
+	close(errors)
+	for err := range errors {
+		t.Errorf("concurrent Evaluate() error = %v", err)
 	}
 }
 

--- a/internal/wasmjson/evaluator.go
+++ b/internal/wasmjson/evaluator.go
@@ -17,6 +17,13 @@ import (
 
 const descriptorSize = 16
 
+var (
+	// ErrInvalidConfig indicates that an evaluator cannot initialize with its supplied configuration.
+	ErrInvalidConfig = errors.New("embedded JSON Wasm evaluator configuration is invalid")
+	// ErrInputTooLarge indicates that an input exceeds either the configured limit or Wasm32 address space.
+	ErrInputTooLarge = errors.New("embedded JSON Wasm evaluator input exceeds maximum")
+)
+
 // Config defines one embedded, no-import Wasm module that accepts and returns JSON bytes.
 type Config struct {
 	Name              string
@@ -171,25 +178,25 @@ func (e *Evaluator) initialize(ctx context.Context) {
 func (e *Evaluator) validateConfig() error {
 	switch {
 	case e.config.Name == "":
-		return errors.New("embedded JSON Wasm evaluator name is required")
+		return e.errorfWith(ErrInvalidConfig, "name is required")
 	case len(e.config.Module) == 0:
-		return e.errorf("module is empty")
+		return e.errorfWith(ErrInvalidConfig, "module is empty")
 	case e.config.ABIVersionExport == "":
-		return e.errorf("ABI version export is required")
+		return e.errorfWith(ErrInvalidConfig, "ABI version export is required")
 	case e.config.AllocateExport == "":
-		return e.errorf("allocation export is required")
+		return e.errorfWith(ErrInvalidConfig, "allocation export is required")
 	case e.config.EvaluateExport == "":
-		return e.errorf("evaluation export is required")
+		return e.errorfWith(ErrInvalidConfig, "evaluation export is required")
 	case e.config.MemoryLimitPages == 0:
-		return e.errorf("memory limit must be positive")
+		return e.errorfWith(ErrInvalidConfig, "memory limit must be positive")
 	case e.config.MaxInputBytes == 0:
-		return e.errorf("input limit must be positive")
+		return e.errorfWith(ErrInvalidConfig, "input limit must be positive")
 	case e.config.MaxOutputBytes == 0:
-		return e.errorf("output limit must be positive")
+		return e.errorfWith(ErrInvalidConfig, "output limit must be positive")
 	case e.config.InitializeTimeout <= 0:
-		return e.errorf("initialization timeout must be positive")
+		return e.errorfWith(ErrInvalidConfig, "initialization timeout must be positive")
 	case e.config.CallTimeout <= 0:
-		return e.errorf("call timeout must be positive")
+		return e.errorfWith(ErrInvalidConfig, "call timeout must be positive")
 	default:
 		return nil
 	}
@@ -197,10 +204,10 @@ func (e *Evaluator) validateConfig() error {
 
 func (e *Evaluator) validatePayload(payload []byte) error {
 	if uint64(len(payload)) > uint64(e.config.MaxInputBytes) {
-		return e.errorf("input is %d bytes; maximum is %d", len(payload), e.config.MaxInputBytes)
+		return e.inputTooLargeError(uint64(len(payload)), uint64(e.config.MaxInputBytes))
 	}
 	if uint64(len(payload)) > math.MaxUint32 {
-		return e.errorf("input exceeds the Wasm32 address space")
+		return e.inputTooLargeError(uint64(len(payload)), math.MaxUint32)
 	}
 	return nil
 }
@@ -260,6 +267,18 @@ func (e *Evaluator) errorf(format string, args ...any) error {
 		return errors.New(message)
 	}
 	return fmt.Errorf("%s: %s", e.config.Name, message)
+}
+
+func (e *Evaluator) errorfWith(cause error, format string, args ...any) error {
+	message := fmt.Sprintf(format, args...)
+	if e.config.Name == "" {
+		return fmt.Errorf("%w: %s", cause, message)
+	}
+	return fmt.Errorf("%s: %w: %s", e.config.Name, cause, message)
+}
+
+func (e *Evaluator) inputTooLargeError(inputBytes, maxBytes uint64) error {
+	return e.errorfWith(ErrInputTooLarge, "input is %d bytes; maximum is %d", inputBytes, maxBytes)
 }
 
 func moduleConfig() wazero.ModuleConfig {

--- a/internal/wasmjson/evaluator.go
+++ b/internal/wasmjson/evaluator.go
@@ -1,0 +1,267 @@
+package wasmjson
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+)
+
+const descriptorSize = 16
+
+// Config defines one embedded, no-import Wasm module that accepts and returns JSON bytes.
+type Config struct {
+	Name              string
+	Module            []byte
+	ABIVersion        uint64
+	ABIVersionExport  string
+	AllocateExport    string
+	EvaluateExport    string
+	MemoryLimitPages  uint32
+	MaxInputBytes     uint32
+	MaxOutputBytes    uint32
+	InitializeTimeout time.Duration
+	CallTimeout       time.Duration
+}
+
+// Evaluator lazily compiles one embedded module and creates an isolated guest instance per call.
+type Evaluator struct {
+	config   Config
+	once     sync.Once
+	runtime  wazero.Runtime
+	compiled wazero.CompiledModule
+	err      error
+}
+
+// New returns a lazy evaluator. Configuration and module ABI errors are reported on the first call
+// and cached for subsequent calls.
+func New(config Config) *Evaluator {
+	config.Name = strings.TrimSpace(config.Name)
+	config.ABIVersionExport = strings.TrimSpace(config.ABIVersionExport)
+	config.AllocateExport = strings.TrimSpace(config.AllocateExport)
+	config.EvaluateExport = strings.TrimSpace(config.EvaluateExport)
+	return &Evaluator{config: config}
+}
+
+// Evaluate passes one bounded JSON payload through the embedded module.
+func (e *Evaluator) Evaluate(ctx context.Context, payload []byte) ([]byte, error) {
+	if err := e.validatePayload(payload); err != nil {
+		return nil, err
+	}
+	e.once.Do(func() {
+		e.initialize(ctx)
+	})
+	if e.err != nil {
+		return nil, e.err
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, e.config.CallTimeout)
+	defer cancel()
+	module, err := e.runtime.InstantiateModule(callCtx, e.compiled, moduleConfig())
+	if err != nil {
+		return nil, e.wrap("instantiate module", err)
+	}
+	defer func() {
+		_ = module.Close(callCtx)
+	}()
+
+	allocate := module.ExportedFunction(e.config.AllocateExport)
+	evaluate := module.ExportedFunction(e.config.EvaluateExport)
+	if allocate == nil || evaluate == nil || module.Memory() == nil {
+		return nil, e.errorf("exports are incomplete")
+	}
+	inputAllocation, err := allocate.Call(callCtx, uint64(len(payload)))
+	if err != nil {
+		return nil, e.wrap("allocate input", err)
+	}
+	inputPointer, err := e.pointer(inputAllocation, "input allocation")
+	if err != nil {
+		return nil, err
+	}
+	descriptorAllocation, err := allocate.Call(callCtx, descriptorSize)
+	if err != nil {
+		return nil, e.wrap("allocate result descriptor", err)
+	}
+	descriptorPointer, err := e.pointer(descriptorAllocation, "result descriptor allocation")
+	if err != nil {
+		return nil, err
+	}
+	if !module.Memory().Write(inputPointer, payload) {
+		return nil, e.errorf("write input memory")
+	}
+	status, err := evaluate.Call(callCtx, uint64(inputPointer), uint64(len(payload)), uint64(descriptorPointer))
+	if err != nil {
+		return nil, e.wrap("execute module", err)
+	}
+	if len(status) != 1 || status[0] != 0 {
+		return nil, e.errorf("execution status = %v", status)
+	}
+	descriptor, ok := module.Memory().Read(descriptorPointer, descriptorSize)
+	if !ok {
+		return nil, e.errorf("read result descriptor")
+	}
+	if resultStatus := binary.LittleEndian.Uint32(descriptor[0:4]); resultStatus != 0 {
+		return nil, e.errorf("result status = %d", resultStatus)
+	}
+	if reserved := binary.LittleEndian.Uint32(descriptor[12:16]); reserved != 0 {
+		return nil, e.errorf("result reserved field = %d", reserved)
+	}
+	outputPointer := binary.LittleEndian.Uint32(descriptor[4:8])
+	outputLength := binary.LittleEndian.Uint32(descriptor[8:12])
+	if outputLength > e.config.MaxOutputBytes {
+		return nil, e.errorf("output is %d bytes; maximum is %d", outputLength, e.config.MaxOutputBytes)
+	}
+	output, ok := module.Memory().Read(outputPointer, outputLength)
+	if !ok {
+		return nil, e.errorf("read output memory")
+	}
+	return append([]byte(nil), output...), nil
+}
+
+func (e *Evaluator) initialize(ctx context.Context) {
+	if err := e.validateConfig(); err != nil {
+		e.err = err
+		return
+	}
+	initCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), e.config.InitializeTimeout)
+	defer cancel()
+	config := wazero.NewRuntimeConfig().WithCloseOnContextDone(true).WithMemoryLimitPages(e.config.MemoryLimitPages)
+	e.runtime = wazero.NewRuntimeWithConfig(initCtx, config)
+	e.compiled, e.err = e.runtime.CompileModule(initCtx, e.config.Module)
+	if e.err != nil {
+		e.err = e.wrap("compile module", e.err)
+		e.closeRuntime(initCtx)
+		return
+	}
+	if err := e.validateABI(); err != nil {
+		e.err = err
+		e.closeRuntime(initCtx)
+		return
+	}
+	module, err := e.runtime.InstantiateModule(initCtx, e.compiled, moduleConfig())
+	if err != nil {
+		e.err = e.wrap("instantiate module for ABI check", err)
+		e.closeRuntime(initCtx)
+		return
+	}
+	defer func() {
+		_ = module.Close(initCtx)
+	}()
+	versionFunction := module.ExportedFunction(e.config.ABIVersionExport)
+	version, err := versionFunction.Call(initCtx)
+	if err != nil {
+		e.err = e.wrap("read ABI version", err)
+		e.closeRuntime(initCtx)
+		return
+	}
+	if len(version) != 1 || version[0] != e.config.ABIVersion {
+		e.err = e.errorf("ABI version = %v; want %d", version, e.config.ABIVersion)
+		e.closeRuntime(initCtx)
+	}
+}
+
+func (e *Evaluator) validateConfig() error {
+	switch {
+	case e.config.Name == "":
+		return errors.New("embedded JSON Wasm evaluator name is required")
+	case len(e.config.Module) == 0:
+		return e.errorf("module is empty")
+	case e.config.ABIVersionExport == "":
+		return e.errorf("ABI version export is required")
+	case e.config.AllocateExport == "":
+		return e.errorf("allocation export is required")
+	case e.config.EvaluateExport == "":
+		return e.errorf("evaluation export is required")
+	case e.config.MemoryLimitPages == 0:
+		return e.errorf("memory limit must be positive")
+	case e.config.MaxInputBytes == 0:
+		return e.errorf("input limit must be positive")
+	case e.config.MaxOutputBytes == 0:
+		return e.errorf("output limit must be positive")
+	case e.config.InitializeTimeout <= 0:
+		return e.errorf("initialization timeout must be positive")
+	case e.config.CallTimeout <= 0:
+		return e.errorf("call timeout must be positive")
+	default:
+		return nil
+	}
+}
+
+func (e *Evaluator) validatePayload(payload []byte) error {
+	if uint64(len(payload)) > uint64(e.config.MaxInputBytes) {
+		return e.errorf("input is %d bytes; maximum is %d", len(payload), e.config.MaxInputBytes)
+	}
+	if uint64(len(payload)) > math.MaxUint32 {
+		return e.errorf("input exceeds the Wasm32 address space")
+	}
+	return nil
+}
+
+func (e *Evaluator) validateABI() error {
+	if len(e.compiled.ImportedFunctions()) != 0 || len(e.compiled.ImportedMemories()) != 0 {
+		return e.errorf("module must not import functions or memory")
+	}
+	if _, ok := e.compiled.ExportedMemories()["memory"]; !ok {
+		return e.errorf("memory export is missing")
+	}
+	exports := e.compiled.ExportedFunctions()
+	required := []struct {
+		name    string
+		params  []api.ValueType
+		results []api.ValueType
+	}{
+		{name: e.config.ABIVersionExport, results: []api.ValueType{api.ValueTypeI32}},
+		{name: e.config.AllocateExport, params: []api.ValueType{api.ValueTypeI32}, results: []api.ValueType{api.ValueTypeI32}},
+		{name: e.config.EvaluateExport, params: []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI32}, results: []api.ValueType{api.ValueTypeI32}},
+	}
+	for _, expected := range required {
+		definition, ok := exports[expected.name]
+		if !ok {
+			return e.errorf("export %q is missing", expected.name)
+		}
+		if !slices.Equal(definition.ParamTypes(), expected.params) || !slices.Equal(definition.ResultTypes(), expected.results) {
+			return e.errorf("export %q has an incompatible signature", expected.name)
+		}
+	}
+	return nil
+}
+
+func (e *Evaluator) pointer(results []uint64, operation string) (uint32, error) {
+	if len(results) != 1 {
+		return 0, e.errorf("%s returned %d values; want 1", operation, len(results))
+	}
+	if results[0] > math.MaxUint32 {
+		return 0, e.errorf("%s pointer exceeds the Wasm32 address space", operation)
+	}
+	return uint32(results[0]), nil // #nosec G115 -- the value is bounded to MaxUint32 above.
+}
+
+func (e *Evaluator) closeRuntime(ctx context.Context) {
+	if e.runtime != nil {
+		_ = e.runtime.Close(ctx)
+	}
+}
+
+func (e *Evaluator) wrap(operation string, err error) error {
+	return fmt.Errorf("%s: %s: %w", e.config.Name, operation, err)
+}
+
+func (e *Evaluator) errorf(format string, args ...any) error {
+	message := fmt.Sprintf(format, args...)
+	if e.config.Name == "" {
+		return errors.New(message)
+	}
+	return fmt.Errorf("%s: %s", e.config.Name, message)
+}
+
+func moduleConfig() wazero.ModuleConfig {
+	return wazero.NewModuleConfig().WithName("").WithStartFunctions()
+}

--- a/internal/wasmjson/evaluator_test.go
+++ b/internal/wasmjson/evaluator_test.go
@@ -2,7 +2,7 @@ package wasmjson
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"testing"
 	"time"
 )
@@ -11,8 +11,8 @@ func TestEvaluatorRejectsInvalidConfiguration(t *testing.T) {
 	t.Parallel()
 	evaluator := New(Config{})
 	_, err := evaluator.Evaluate(context.Background(), nil)
-	if err == nil || !strings.Contains(err.Error(), "name is required") {
-		t.Fatalf("Evaluate() error = %v; want missing name", err)
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("Evaluate() error = %v; want %v", err, ErrInvalidConfig)
 	}
 }
 
@@ -21,11 +21,8 @@ func TestEvaluatorBoundsInputWithoutExposingPayload(t *testing.T) {
 	evaluator := New(testConfig())
 	marker := "input-marker-that-must-not-be-logged"
 	_, err := evaluator.Evaluate(context.Background(), []byte(marker))
-	if err == nil {
-		t.Fatal("Evaluate() error = nil")
-	}
-	if !strings.Contains(err.Error(), "input is") || strings.Contains(err.Error(), marker) {
-		t.Fatalf("Evaluate() error = %q; want bounded error without input", err)
+	if !errors.Is(err, ErrInputTooLarge) {
+		t.Fatalf("Evaluate() error = %v; want %v", err, ErrInputTooLarge)
 	}
 }
 
@@ -36,8 +33,8 @@ func TestEvaluatorCachesInitializationError(t *testing.T) {
 	evaluator := New(config)
 	for range 2 {
 		_, err := evaluator.Evaluate(context.Background(), nil)
-		if err == nil || !strings.Contains(err.Error(), "module is empty") {
-			t.Fatalf("Evaluate() error = %v; want empty module", err)
+		if !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("Evaluate() error = %v; want %v", err, ErrInvalidConfig)
 		}
 	}
 }

--- a/internal/wasmjson/evaluator_test.go
+++ b/internal/wasmjson/evaluator_test.go
@@ -1,0 +1,58 @@
+package wasmjson
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEvaluatorRejectsInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+	evaluator := New(Config{})
+	_, err := evaluator.Evaluate(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "name is required") {
+		t.Fatalf("Evaluate() error = %v; want missing name", err)
+	}
+}
+
+func TestEvaluatorBoundsInputWithoutExposingPayload(t *testing.T) {
+	t.Parallel()
+	evaluator := New(testConfig())
+	marker := "input-marker-that-must-not-be-logged"
+	_, err := evaluator.Evaluate(context.Background(), []byte(marker))
+	if err == nil {
+		t.Fatal("Evaluate() error = nil")
+	}
+	if !strings.Contains(err.Error(), "input is") || strings.Contains(err.Error(), marker) {
+		t.Fatalf("Evaluate() error = %q; want bounded error without input", err)
+	}
+}
+
+func TestEvaluatorCachesInitializationError(t *testing.T) {
+	t.Parallel()
+	config := testConfig()
+	config.MaxInputBytes = 1
+	evaluator := New(config)
+	for range 2 {
+		_, err := evaluator.Evaluate(context.Background(), nil)
+		if err == nil || !strings.Contains(err.Error(), "module is empty") {
+			t.Fatalf("Evaluate() error = %v; want empty module", err)
+		}
+	}
+}
+
+func testConfig() Config {
+	return Config{
+		Name:              "test evaluator",
+		ABIVersion:        1,
+		ABIVersionExport:  "abi_version",
+		AllocateExport:    "alloc",
+		EvaluateExport:    "evaluate",
+		MemoryLimitPages:  1,
+		MaxInputBytes:     1,
+		MaxOutputBytes:    1,
+		InitializeTimeout: time.Second,
+		CallTimeout:       time.Second,
+	}
+}


### PR DESCRIPTION
## What changed

- added one bounded host for embedded JSON-in/JSON-out Wasm modules
- moved source coverage onto the shared ABI, lifecycle, timeout, memory, and output checks
- added a stable `rust-wasm-check` aggregate for local, CI, and release validation
- consolidated canonical Wasm platform and path-remapping configuration

## Why

Each new JSON Wasm module otherwise repeats compilation, ABI validation, allocation, pointer checks, memory bounds, and module lifecycle code. A shared host makes the next Rust seams smaller and keeps the safety contract consistent.

## Compatibility

Source coverage request and response behavior is unchanged. The static Cypher validator keeps its specialized binary ABI, and the existing Panopticon host remains unchanged until its descriptor is standardized separately.

## Validation

- source coverage and shared-host normal and race tests
- concurrent source coverage evaluation
- focused Go lint
- Rust formatting, clippy, workspace tests, and embedded artifact checks
- changed-check routing and architecture tests
