### PR TITLE
Qualify effective access paths with source lineage

### DIFF
--- a/internal/graphquery/effective_access.go
+++ b/internal/graphquery/effective_access.go
@@ -56,19 +56,22 @@ type EffectiveAccessPathCounts struct {
 }
 
 type EffectiveAccessPath struct {
-	Identity       GraphEntityRef                      `json:"identity"`
-	Principal      GraphEntityRef                      `json:"principal"`
-	Mediator       *GraphEntityRef                     `json:"mediator,omitempty"`
-	AccessTarget   GraphEntityRef                      `json:"access_target"`
-	Entitlement    GraphEntityRef                      `json:"entitlement"`
-	Capability     GraphEntityRef                      `json:"capability"`
-	AssignmentKind string                              `json:"assignment_kind"`
-	RelationChain  []string                            `json:"relation_chain"`
-	Edges          []EffectiveAccessPathEdge           `json:"edges"`
-	Lineage        EffectiveAccessLineageQualification `json:"lineage"`
+	Identity              GraphEntityRef                      `json:"identity"`
+	Principal             GraphEntityRef                      `json:"principal"`
+	Mediator              *GraphEntityRef                     `json:"mediator,omitempty"`
+	AccessTarget          GraphEntityRef                      `json:"access_target"`
+	Entitlement           GraphEntityRef                      `json:"entitlement"`
+	Capability            GraphEntityRef                      `json:"capability"`
+	AssignmentKind        string                              `json:"assignment_kind"`
+	IdentityRelationChain []string                            `json:"identity_relation_chain,omitempty"`
+	IdentityEdges         []EffectiveAccessPathEdge           `json:"identity_edges,omitempty"`
+	RelationChain         []string                            `json:"relation_chain"`
+	Edges                 []EffectiveAccessPathEdge           `json:"edges"`
+	Lineage               EffectiveAccessLineageQualification `json:"lineage"`
 }
 
 type EffectiveAccessLineageGap struct {
+	Segment   string   `json:"segment"`
 	EdgeIndex int      `json:"edge_index"`
 	Fields    []string `json:"fields"`
 }
@@ -176,80 +179,108 @@ func (p EffectiveAccessPath) SupportsOperationProof(changedDuringPeriod bool) bo
 // QualifyLineage fails closed unless the graph path is structurally complete
 // and every edge carries source, runtime, event, and observation-time lineage.
 func (p EffectiveAccessPath) QualifyLineage() EffectiveAccessLineageQualification {
-	qualification := EffectiveAccessLineageQualification{EdgeCount: len(p.Edges)}
+	qualification := EffectiveAccessLineageQualification{EdgeCount: len(p.IdentityEdges) + len(p.Edges)}
 	sources, runtimes, events := []string{}, []string{}, []string{}
-	for index, edge := range p.Edges {
-		missing := []string{}
-		for field, value := range map[string]string{
-			"from_urn":    edge.From.URN,
-			"relation":    edge.Relation,
-			"to_urn":      edge.To.URN,
-			"source_id":   edge.SourceID,
-			"runtime_id":  edge.RuntimeID,
-			"event_id":    edge.EventID,
-			"observed_at": edge.At,
-		} {
-			if strings.TrimSpace(value) == "" {
-				missing = append(missing, field)
+	for _, segment := range []struct {
+		name  string
+		edges []EffectiveAccessPathEdge
+	}{
+		{name: "identity", edges: p.IdentityEdges},
+		{name: "access", edges: p.Edges},
+	} {
+		for index, edge := range segment.edges {
+			missing := []string{}
+			for field, value := range map[string]string{
+				"from_urn":    edge.From.URN,
+				"relation":    edge.Relation,
+				"to_urn":      edge.To.URN,
+				"source_id":   edge.SourceID,
+				"runtime_id":  edge.RuntimeID,
+				"event_id":    edge.EventID,
+				"observed_at": edge.At,
+			} {
+				if strings.TrimSpace(value) == "" {
+					missing = append(missing, field)
+				}
 			}
-		}
-		if edge.At != "" {
-			if _, err := time.Parse(time.RFC3339, edge.At); err != nil {
-				missing = append(missing, "observed_at")
+			if edge.At != "" {
+				if _, err := time.Parse(time.RFC3339, edge.At); err != nil {
+					missing = append(missing, "observed_at")
+				}
 			}
+			if index > 0 && segment.edges[index-1].To.URN != edge.From.URN {
+				missing = append(missing, "edge_continuity")
+			}
+			missing = uniqueEffectiveAccessLabels(missing)
+			if len(missing) != 0 {
+				qualification.Gaps = append(qualification.Gaps, EffectiveAccessLineageGap{Segment: segment.name, EdgeIndex: index, Fields: missing})
+				continue
+			}
+			qualification.CompleteEdgeCount++
+			sources = append(sources, edge.SourceID)
+			runtimes = append(runtimes, edge.RuntimeID)
+			events = append(events, edge.EventID)
 		}
-		if index > 0 && p.Edges[index-1].To.URN != edge.From.URN {
-			missing = append(missing, "edge_continuity")
-		}
-		missing = uniqueEffectiveAccessLabels(missing)
-		if len(missing) != 0 {
-			qualification.Gaps = append(qualification.Gaps, EffectiveAccessLineageGap{EdgeIndex: index, Fields: missing})
-			continue
-		}
-		qualification.CompleteEdgeCount++
-		sources = append(sources, edge.SourceID)
-		runtimes = append(runtimes, edge.RuntimeID)
-		events = append(events, edge.EventID)
 	}
 	qualification.SourceIDs = uniqueEffectiveAccessLabels(sources)
 	qualification.RuntimeIDs = uniqueEffectiveAccessLabels(runtimes)
 	qualification.EventIDs = uniqueEffectiveAccessLabels(events)
-	pathGaps := []string{}
+	identityGaps := []string{}
+	if p.Identity.URN != p.Principal.URN && len(p.IdentityEdges) == 0 {
+		identityGaps = append(identityGaps, "identity_path")
+	}
+	if len(p.IdentityEdges) != 0 {
+		if p.IdentityEdges[0].From.URN != p.Identity.URN {
+			identityGaps = append(identityGaps, "identity")
+		}
+		if p.IdentityEdges[len(p.IdentityEdges)-1].To.URN != p.Principal.URN {
+			identityGaps = append(identityGaps, "principal")
+		}
+		if !effectiveAccessPathEdgesMatch(p.IdentityRelationChain, p.IdentityEdges) {
+			identityGaps = append(identityGaps, "relation_chain")
+		}
+	}
+	if identityGaps = uniqueEffectiveAccessLabels(identityGaps); len(identityGaps) != 0 {
+		qualification.Gaps = append(qualification.Gaps, EffectiveAccessLineageGap{Segment: "identity", EdgeIndex: -1, Fields: identityGaps})
+	}
+	accessGaps := []string{}
 	if len(p.Edges) == 0 {
-		pathGaps = append(pathGaps, "edges")
+		accessGaps = append(accessGaps, "edges")
 	} else {
 		if p.Edges[0].From.URN != p.Principal.URN {
-			pathGaps = append(pathGaps, "principal")
+			accessGaps = append(accessGaps, "principal")
 		}
 		if p.Edges[len(p.Edges)-1].To.URN != p.Capability.URN {
-			pathGaps = append(pathGaps, "capability")
+			accessGaps = append(accessGaps, "capability")
 		}
 	}
 	if !effectiveAccessPathEdgesMatch(p.RelationChain, p.Edges) {
-		pathGaps = append(pathGaps, "relation_chain")
+		accessGaps = append(accessGaps, "relation_chain")
 	}
 	if !accessPathContainsURN(p.Edges, p.AccessTarget.URN) {
-		pathGaps = append(pathGaps, "access_target")
+		accessGaps = append(accessGaps, "access_target")
 	}
 	if !accessPathContainsURN(p.Edges, p.Entitlement.URN) {
-		pathGaps = append(pathGaps, "entitlement")
+		accessGaps = append(accessGaps, "entitlement")
 	}
-	if pathGaps = uniqueEffectiveAccessLabels(pathGaps); len(pathGaps) != 0 {
-		qualification.Gaps = append(qualification.Gaps, EffectiveAccessLineageGap{EdgeIndex: -1, Fields: pathGaps})
+	if accessGaps = uniqueEffectiveAccessLabels(accessGaps); len(accessGaps) != 0 {
+		qualification.Gaps = append(qualification.Gaps, EffectiveAccessLineageGap{Segment: "access", EdgeIndex: -1, Fields: accessGaps})
 	}
 	qualification.Qualified = len(qualification.Gaps) == 0
 	if qualification.Qualified {
 		payload, err := json.Marshal(struct {
-			Identity       GraphEntityRef            `json:"identity"`
-			Principal      GraphEntityRef            `json:"principal"`
-			Mediator       *GraphEntityRef           `json:"mediator,omitempty"`
-			AccessTarget   GraphEntityRef            `json:"access_target"`
-			Entitlement    GraphEntityRef            `json:"entitlement"`
-			Capability     GraphEntityRef            `json:"capability"`
-			AssignmentKind string                    `json:"assignment_kind"`
-			RelationChain  []string                  `json:"relation_chain"`
-			Edges          []EffectiveAccessPathEdge `json:"edges"`
-		}{p.Identity, p.Principal, p.Mediator, p.AccessTarget, p.Entitlement, p.Capability, p.AssignmentKind, p.RelationChain, p.Edges})
+			Identity              GraphEntityRef            `json:"identity"`
+			Principal             GraphEntityRef            `json:"principal"`
+			Mediator              *GraphEntityRef           `json:"mediator,omitempty"`
+			AccessTarget          GraphEntityRef            `json:"access_target"`
+			Entitlement           GraphEntityRef            `json:"entitlement"`
+			Capability            GraphEntityRef            `json:"capability"`
+			AssignmentKind        string                    `json:"assignment_kind"`
+			IdentityRelationChain []string                  `json:"identity_relation_chain,omitempty"`
+			IdentityEdges         []EffectiveAccessPathEdge `json:"identity_edges,omitempty"`
+			RelationChain         []string                  `json:"relation_chain"`
+			Edges                 []EffectiveAccessPathEdge `json:"edges"`
+		}{p.Identity, p.Principal, p.Mediator, p.AccessTarget, p.Entitlement, p.Capability, p.AssignmentKind, p.IdentityRelationChain, p.IdentityEdges, p.RelationChain, p.Edges})
 		if err == nil {
 			digest := sha256.Sum256(payload)
 			qualification.ProofDigest = "sha256:" + hex.EncodeToString(digest[:])
@@ -411,33 +442,33 @@ ORDER BY subject.label, subject.urn
 LIMIT $sample_limit
 CALL {
   WITH subject
-  RETURN subject AS principal
+  RETURN subject AS principal, [] AS identity_rels, [subject] AS identity_nodes
   UNION
   WITH subject
   MATCH (principal:Entity {tenant_id: $tenant_id})-[identity_link:RELATION]->(subject)
   WHERE identity_link.tenant_id = $tenant_id
     AND identity_link.relation IN ['represents_identity', 'same_actor']
-  RETURN principal
+  RETURN principal, [identity_link] AS identity_rels, [subject, principal] AS identity_nodes
   UNION
   WITH subject
   MATCH (subject)-[identity_link:RELATION]->(principal:Entity {tenant_id: $tenant_id})
   WHERE identity_link.tenant_id = $tenant_id
     AND identity_link.relation = 'same_actor'
-  RETURN principal
+  RETURN principal, [identity_link] AS identity_rels, [subject, principal] AS identity_nodes
   UNION
   WITH subject
   MATCH (subject)-[subject_link:RELATION {relation: 'represents_identity'}]->(identity:Entity {tenant_id: $tenant_id})<-[principal_link:RELATION {relation: 'represents_identity'}]-(principal:Entity {tenant_id: $tenant_id})
   WHERE subject_link.tenant_id = $tenant_id
     AND principal_link.tenant_id = $tenant_id
-  RETURN principal
+  RETURN principal, [subject_link, principal_link] AS identity_rels, [subject, identity, principal] AS identity_nodes
   UNION
   WITH subject
   MATCH (subject)-[same_actor:RELATION {relation: 'same_actor'}]-(identity:Entity {tenant_id: $tenant_id})<-[principal_link:RELATION {relation: 'represents_identity'}]-(principal:Entity {tenant_id: $tenant_id})
   WHERE same_actor.tenant_id = $tenant_id
     AND principal_link.tenant_id = $tenant_id
-  RETURN principal
+  RETURN principal, [same_actor, principal_link] AS identity_rels, [subject, identity, principal] AS identity_nodes
 }
-WITH DISTINCT subject, principal
+WITH DISTINCT subject, principal, identity_rels, identity_nodes
 WHERE principal.tenant_id = $tenant_id
 CALL {
   WITH subject, principal
@@ -510,6 +541,19 @@ RETURN subject.urn AS identity_urn,
        capability.entity_type AS capability_entity_type,
        capability.label AS capability_label,
        assignment_kind AS assignment_kind,
+       [rel IN identity_rels | rel.relation] AS identity_relation_chain,
+       [idx IN range(0, size(identity_rels) - 1) | {
+         from_urn: identity_nodes[idx].urn,
+         from_entity_type: identity_nodes[idx].entity_type,
+         from_label: identity_nodes[idx].label,
+         relation: identity_rels[idx].relation,
+         to_urn: identity_nodes[idx + 1].urn,
+         to_entity_type: identity_nodes[idx + 1].entity_type,
+         to_label: identity_nodes[idx + 1].label,
+         source_id: coalesce(identity_rels[idx].source_id, ''),
+         runtime_id: coalesce(identity_rels[idx].runtime_id, ''),
+         attributes_json: coalesce(identity_rels[idx].attributes_json, '{}')
+       }] AS identity_edges,
        [rel IN rels | rel.relation] AS relation_chain,
        [idx IN range(0, size(rels) - 1) | {
          from_urn: path_nodes[idx].urn,
@@ -555,9 +599,11 @@ func effectiveAccessPathsFromRows(rows []ports.CypherRow) []EffectiveAccessPath 
 				EntityType: cypherString(row, "capability_entity_type"),
 				Label:      cypherString(row, "capability_label"),
 			},
-			AssignmentKind: strings.TrimSpace(cypherString(row, "assignment_kind")),
-			RelationChain:  cypherStringList(row.Values["relation_chain"]),
-			Edges:          effectiveAccessPathEdgesFromRow(row),
+			AssignmentKind:        strings.TrimSpace(cypherString(row, "assignment_kind")),
+			IdentityRelationChain: cypherStringList(row.Values["identity_relation_chain"]),
+			IdentityEdges:         effectiveAccessPathEdgesFromRow(row, "identity_edges"),
+			RelationChain:         cypherStringList(row.Values["relation_chain"]),
+			Edges:                 effectiveAccessPathEdgesFromRow(row, "edges"),
 		}
 		if mediator := prefixedGraphRef(row, "mediator"); mediator.URN != "" {
 			path.Mediator = &mediator
@@ -571,8 +617,8 @@ func effectiveAccessPathsFromRows(rows []ports.CypherRow) []EffectiveAccessPath 
 	return paths
 }
 
-func effectiveAccessPathEdgesFromRow(row ports.CypherRow) []EffectiveAccessPathEdge {
-	items, ok := row.Values["edges"].([]any)
+func effectiveAccessPathEdgesFromRow(row ports.CypherRow, key string) []EffectiveAccessPathEdge {
+	items, ok := row.Values[key].([]any)
 	if !ok || len(items) == 0 {
 		return nil
 	}

--- a/internal/graphquery/effective_access.go
+++ b/internal/graphquery/effective_access.go
@@ -2,12 +2,15 @@ package graphquery
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -42,24 +45,46 @@ type EffectiveAccessPathFilters struct {
 }
 
 type EffectiveAccessPathCounts struct {
-	Paths                int `json:"paths"`
-	DirectAssignments    int `json:"direct_assignments"`
-	GroupMediatedPaths   int `json:"group_mediated_paths"`
-	RolePaths            int `json:"role_paths"`
-	AdminRolePaths       int `json:"admin_role_paths"`
-	CapabilitiesReturned int `json:"capabilities_returned"`
+	Paths                  int `json:"paths"`
+	LineageQualifiedPaths  int `json:"lineage_qualified_paths"`
+	LineageIncompletePaths int `json:"lineage_incomplete_paths"`
+	DirectAssignments      int `json:"direct_assignments"`
+	GroupMediatedPaths     int `json:"group_mediated_paths"`
+	RolePaths              int `json:"role_paths"`
+	AdminRolePaths         int `json:"admin_role_paths"`
+	CapabilitiesReturned   int `json:"capabilities_returned"`
 }
 
 type EffectiveAccessPath struct {
-	Identity       GraphEntityRef            `json:"identity"`
-	Principal      GraphEntityRef            `json:"principal"`
-	Mediator       *GraphEntityRef           `json:"mediator,omitempty"`
-	AccessTarget   GraphEntityRef            `json:"access_target"`
-	Entitlement    GraphEntityRef            `json:"entitlement"`
-	Capability     GraphEntityRef            `json:"capability"`
-	AssignmentKind string                    `json:"assignment_kind"`
-	RelationChain  []string                  `json:"relation_chain"`
-	Edges          []EffectiveAccessPathEdge `json:"edges"`
+	Identity       GraphEntityRef                      `json:"identity"`
+	Principal      GraphEntityRef                      `json:"principal"`
+	Mediator       *GraphEntityRef                     `json:"mediator,omitempty"`
+	AccessTarget   GraphEntityRef                      `json:"access_target"`
+	Entitlement    GraphEntityRef                      `json:"entitlement"`
+	Capability     GraphEntityRef                      `json:"capability"`
+	AssignmentKind string                              `json:"assignment_kind"`
+	RelationChain  []string                            `json:"relation_chain"`
+	Edges          []EffectiveAccessPathEdge           `json:"edges"`
+	Lineage        EffectiveAccessLineageQualification `json:"lineage"`
+}
+
+type EffectiveAccessLineageGap struct {
+	EdgeIndex int      `json:"edge_index"`
+	Fields    []string `json:"fields"`
+}
+
+// EffectiveAccessLineageQualification describes whether every relation in an
+// access path can be traced to a source observation. An incomplete path remains
+// visible to callers, but it cannot be presented as qualified proof.
+type EffectiveAccessLineageQualification struct {
+	Qualified         bool                        `json:"qualified"`
+	EdgeCount         int                         `json:"edge_count"`
+	CompleteEdgeCount int                         `json:"complete_edge_count"`
+	SourceIDs         []string                    `json:"source_ids"`
+	RuntimeIDs        []string                    `json:"runtime_ids"`
+	EventIDs          []string                    `json:"event_ids"`
+	Gaps              []EffectiveAccessLineageGap `json:"gaps,omitempty"`
+	ProofDigest       string                      `json:"proof_digest,omitempty"`
 }
 
 type EffectiveAccessPathEdge struct {
@@ -146,6 +171,103 @@ func (p EffectiveAccessPath) AccessClassification() []string {
 
 func (p EffectiveAccessPath) SupportsOperationProof(changedDuringPeriod bool) bool {
 	return changedDuringPeriod && (p.IsPrivileged() || p.IsSensitive())
+}
+
+// QualifyLineage fails closed unless the graph path is structurally complete
+// and every edge carries source, runtime, event, and observation-time lineage.
+func (p EffectiveAccessPath) QualifyLineage() EffectiveAccessLineageQualification {
+	qualification := EffectiveAccessLineageQualification{EdgeCount: len(p.Edges)}
+	sources, runtimes, events := []string{}, []string{}, []string{}
+	for index, edge := range p.Edges {
+		missing := []string{}
+		for field, value := range map[string]string{
+			"from_urn":    edge.From.URN,
+			"relation":    edge.Relation,
+			"to_urn":      edge.To.URN,
+			"source_id":   edge.SourceID,
+			"runtime_id":  edge.RuntimeID,
+			"event_id":    edge.EventID,
+			"observed_at": edge.At,
+		} {
+			if strings.TrimSpace(value) == "" {
+				missing = append(missing, field)
+			}
+		}
+		if edge.At != "" {
+			if _, err := time.Parse(time.RFC3339, edge.At); err != nil {
+				missing = append(missing, "observed_at")
+			}
+		}
+		if index > 0 && p.Edges[index-1].To.URN != edge.From.URN {
+			missing = append(missing, "edge_continuity")
+		}
+		missing = uniqueEffectiveAccessLabels(missing)
+		if len(missing) != 0 {
+			qualification.Gaps = append(qualification.Gaps, EffectiveAccessLineageGap{EdgeIndex: index, Fields: missing})
+			continue
+		}
+		qualification.CompleteEdgeCount++
+		sources = append(sources, edge.SourceID)
+		runtimes = append(runtimes, edge.RuntimeID)
+		events = append(events, edge.EventID)
+	}
+	qualification.SourceIDs = uniqueEffectiveAccessLabels(sources)
+	qualification.RuntimeIDs = uniqueEffectiveAccessLabels(runtimes)
+	qualification.EventIDs = uniqueEffectiveAccessLabels(events)
+	pathGaps := []string{}
+	if len(p.Edges) == 0 {
+		pathGaps = append(pathGaps, "edges")
+	} else {
+		if p.Edges[0].From.URN != p.Principal.URN {
+			pathGaps = append(pathGaps, "principal")
+		}
+		if p.Edges[len(p.Edges)-1].To.URN != p.Capability.URN {
+			pathGaps = append(pathGaps, "capability")
+		}
+	}
+	if !effectiveAccessPathEdgesMatch(p.RelationChain, p.Edges) {
+		pathGaps = append(pathGaps, "relation_chain")
+	}
+	if !accessPathContainsURN(p.Edges, p.AccessTarget.URN) {
+		pathGaps = append(pathGaps, "access_target")
+	}
+	if !accessPathContainsURN(p.Edges, p.Entitlement.URN) {
+		pathGaps = append(pathGaps, "entitlement")
+	}
+	if pathGaps = uniqueEffectiveAccessLabels(pathGaps); len(pathGaps) != 0 {
+		qualification.Gaps = append(qualification.Gaps, EffectiveAccessLineageGap{EdgeIndex: -1, Fields: pathGaps})
+	}
+	qualification.Qualified = len(qualification.Gaps) == 0
+	if qualification.Qualified {
+		payload, err := json.Marshal(struct {
+			Identity       GraphEntityRef            `json:"identity"`
+			Principal      GraphEntityRef            `json:"principal"`
+			Mediator       *GraphEntityRef           `json:"mediator,omitempty"`
+			AccessTarget   GraphEntityRef            `json:"access_target"`
+			Entitlement    GraphEntityRef            `json:"entitlement"`
+			Capability     GraphEntityRef            `json:"capability"`
+			AssignmentKind string                    `json:"assignment_kind"`
+			RelationChain  []string                  `json:"relation_chain"`
+			Edges          []EffectiveAccessPathEdge `json:"edges"`
+		}{p.Identity, p.Principal, p.Mediator, p.AccessTarget, p.Entitlement, p.Capability, p.AssignmentKind, p.RelationChain, p.Edges})
+		if err == nil {
+			digest := sha256.Sum256(payload)
+			qualification.ProofDigest = "sha256:" + hex.EncodeToString(digest[:])
+		}
+	}
+	return qualification
+}
+
+func accessPathContainsURN(edges []EffectiveAccessPathEdge, urn string) bool {
+	if strings.TrimSpace(urn) == "" {
+		return false
+	}
+	for _, edge := range edges {
+		if edge.From.URN == urn || edge.To.URN == urn {
+			return true
+		}
+	}
+	return false
 }
 
 func EffectiveAccessPathRequestFromQuery(values url.Values) (EffectiveAccessPathRequest, error) {
@@ -443,6 +565,7 @@ func effectiveAccessPathsFromRows(rows []ports.CypherRow) []EffectiveAccessPath 
 		if path.Identity.URN == "" || path.Principal.URN == "" || path.AccessTarget.URN == "" || path.Entitlement.URN == "" || path.Capability.URN == "" || len(path.RelationChain) == 0 || !effectiveAccessPathEdgesMatch(path.RelationChain, path.Edges) {
 			continue
 		}
+		path.Lineage = path.QualifyLineage()
 		paths = append(paths, path)
 	}
 	return paths
@@ -520,6 +643,15 @@ func effectiveAccessPathCounts(paths []EffectiveAccessPath) EffectiveAccessPathC
 	counts := EffectiveAccessPathCounts{Paths: len(paths)}
 	capabilities := map[string]struct{}{}
 	for _, path := range paths {
+		lineage := path.Lineage
+		if lineage.EdgeCount == 0 {
+			lineage = path.QualifyLineage()
+		}
+		if lineage.Qualified {
+			counts.LineageQualifiedPaths++
+		} else {
+			counts.LineageIncompletePaths++
+		}
 		switch path.AssignmentKind {
 		case "direct_app_assignment":
 			counts.DirectAssignments++

--- a/internal/graphquery/effective_access_test.go
+++ b/internal/graphquery/effective_access_test.go
@@ -130,6 +130,12 @@ func TestGetEffectiveAccessPathsQueriesAndParsesRows(t *testing.T) {
 	if got := path.Edges[1].Attributes["assignment_id"]; got != "asg-1" {
 		t.Fatalf("assignment attribute = %q, want asg-1", got)
 	}
+	if !path.Lineage.Qualified || path.Lineage.CompleteEdgeCount != 4 || path.Lineage.ProofDigest == "" {
+		t.Fatalf("lineage = %#v, want four qualified edges", path.Lineage)
+	}
+	if result.Counts.LineageQualifiedPaths != 1 || result.Counts.LineageIncompletePaths != 0 {
+		t.Fatalf("lineage counts = %#v", result.Counts)
+	}
 }
 
 func TestEffectiveAccessPathsFromRowsDropsIncompleteProofs(t *testing.T) {
@@ -167,6 +173,37 @@ func TestEffectiveAccessPathCountsSplitRoleAssignments(t *testing.T) {
 	})
 	if counts.DirectAssignments != 1 || counts.GroupMediatedPaths != 1 || counts.RolePaths != 1 || counts.AdminRolePaths != 1 || counts.CapabilitiesReturned != 3 {
 		t.Fatalf("counts = %#v", counts)
+	}
+}
+
+func TestEffectiveAccessPathLineageFailsClosedWhenAnEventIsMissing(t *testing.T) {
+	path := effectiveAccessTestPath()
+	first := path.QualifyLineage()
+	second := path.QualifyLineage()
+	if !first.Qualified || first.ProofDigest == "" || first.ProofDigest != second.ProofDigest {
+		t.Fatalf("qualified lineage is not deterministic: first=%#v second=%#v", first, second)
+	}
+
+	path.Edges[1].EventID = ""
+	incomplete := path.QualifyLineage()
+	if incomplete.Qualified || incomplete.ProofDigest != "" || incomplete.CompleteEdgeCount != 3 {
+		t.Fatalf("incomplete lineage = %#v", incomplete)
+	}
+	if len(incomplete.Gaps) != 1 || incomplete.Gaps[0].EdgeIndex != 1 || strings.Join(incomplete.Gaps[0].Fields, ",") != "event_id" {
+		t.Fatalf("lineage gaps = %#v", incomplete.Gaps)
+	}
+}
+
+func TestEffectiveAccessPathLineageReportsStructuralGaps(t *testing.T) {
+	path := effectiveAccessTestPath()
+	path.Principal.URN = "urn:cerebro:writer:okta_user:different"
+	qualification := path.QualifyLineage()
+	if qualification.Qualified || qualification.ProofDigest != "" {
+		t.Fatalf("structurally invalid lineage = %#v", qualification)
+	}
+	last := qualification.Gaps[len(qualification.Gaps)-1]
+	if last.EdgeIndex != -1 || strings.Join(last.Fields, ",") != "principal" {
+		t.Fatalf("structural gaps = %#v", qualification.Gaps)
 	}
 }
 
@@ -276,4 +313,25 @@ func effectiveAccessPathTestEdges() []any {
 			"attributes_json":  `{"event_id":"evt-capability","at":"2026-06-10T18:00:00Z"}`,
 		},
 	}
+}
+
+func effectiveAccessTestPath() EffectiveAccessPath {
+	mediator := GraphEntityRef{URN: "urn:cerebro:writer:okta_group:grp-security", EntityType: "okta.group", Label: "Security Engineering"}
+	path := EffectiveAccessPath{
+		Identity:       GraphEntityRef{URN: "urn:cerebro:writer:identity:email:alice@example.com", EntityType: "identity.email", Label: "alice@example.com"},
+		Principal:      GraphEntityRef{URN: "urn:cerebro:writer:okta_user:00u1", EntityType: "okta.user", Label: "alice@example.com"},
+		Mediator:       &mediator,
+		AccessTarget:   GraphEntityRef{URN: "urn:cerebro:writer:okta_application:app-aws-admin", EntityType: "okta.application", Label: "AWS Admin Console"},
+		Entitlement:    GraphEntityRef{URN: "urn:cerebro:writer:okta_entitlement:administratoraccess", EntityType: "okta.entitlement", Label: "AdministratorAccess"},
+		Capability:     GraphEntityRef{URN: "urn:cerebro:writer:privileged_capability:cloud_admin", EntityType: "privileged.capability", Label: "Cloud administrator"},
+		AssignmentKind: "group_app_assignment",
+		RelationChain:  []string{"member_of", "assigned_to", "grants_entitlement", "confers_capability"},
+		Edges: []EffectiveAccessPathEdge{
+			{From: GraphEntityRef{URN: "urn:cerebro:writer:okta_user:00u1"}, Relation: "member_of", To: mediator, SourceID: "okta", RuntimeID: "writer-okta", EventID: "evt-member", At: "2026-06-10T17:00:00Z"},
+			{From: mediator, Relation: "assigned_to", To: GraphEntityRef{URN: "urn:cerebro:writer:okta_application:app-aws-admin"}, SourceID: "okta", RuntimeID: "writer-okta", EventID: "evt-assign", At: "2026-06-10T18:00:00Z"},
+			{From: GraphEntityRef{URN: "urn:cerebro:writer:okta_application:app-aws-admin"}, Relation: "grants_entitlement", To: GraphEntityRef{URN: "urn:cerebro:writer:okta_entitlement:administratoraccess"}, SourceID: "okta", RuntimeID: "writer-okta", EventID: "evt-entitlement", At: "2026-06-10T18:00:00Z"},
+			{From: GraphEntityRef{URN: "urn:cerebro:writer:okta_entitlement:administratoraccess"}, Relation: "confers_capability", To: GraphEntityRef{URN: "urn:cerebro:writer:privileged_capability:cloud_admin"}, SourceID: "okta", RuntimeID: "writer-okta", EventID: "evt-capability", At: "2026-06-10T18:00:00Z"},
+		},
+	}
+	return path
 }

--- a/internal/graphquery/effective_access_test.go
+++ b/internal/graphquery/effective_access_test.go
@@ -65,6 +65,8 @@ func TestGetEffectiveAccessPathsQueriesAndParsesRows(t *testing.T) {
 			"capability_entity_type":  "privileged.capability",
 			"capability_label":        "Cloud administrator",
 			"assignment_kind":         "group_app_assignment",
+			"identity_relation_chain": []any{"represents_identity"},
+			"identity_edges":          effectiveAccessIdentityTestEdges(),
 			"relation_chain":          []any{"member_of", "assigned_to", "grants_entitlement", "confers_capability"},
 			"edges":                   effectiveAccessPathTestEdges(),
 		}}},
@@ -97,6 +99,9 @@ func TestGetEffectiveAccessPathsQueriesAndParsesRows(t *testing.T) {
 		"subject:Entity {tenant_id: $tenant_id}",
 		"ORDER BY subject.label, subject.urn",
 		"principal_link.tenant_id = $tenant_id",
+		"[subject, principal] AS identity_nodes",
+		"identity_relation_chain",
+		"identity_edges",
 		"MATCH (principal)-[assignment:RELATION {relation: 'assigned_to'}]->(target:Entity {tenant_id: $tenant_id})",
 		"MATCH (principal)-[membership:RELATION {relation: 'member_of'}]->(mediator:Entity {tenant_id: $tenant_id})-[assignment:RELATION {relation: 'assigned_to'}]->(target:Entity {tenant_id: $tenant_id})",
 		"membership.tenant_id = $tenant_id",
@@ -130,8 +135,8 @@ func TestGetEffectiveAccessPathsQueriesAndParsesRows(t *testing.T) {
 	if got := path.Edges[1].Attributes["assignment_id"]; got != "asg-1" {
 		t.Fatalf("assignment attribute = %q, want asg-1", got)
 	}
-	if !path.Lineage.Qualified || path.Lineage.CompleteEdgeCount != 4 || path.Lineage.ProofDigest == "" {
-		t.Fatalf("lineage = %#v, want four qualified edges", path.Lineage)
+	if !path.Lineage.Qualified || path.Lineage.CompleteEdgeCount != 5 || path.Lineage.ProofDigest == "" {
+		t.Fatalf("lineage = %#v, want five qualified edges", path.Lineage)
 	}
 	if result.Counts.LineageQualifiedPaths != 1 || result.Counts.LineageIncompletePaths != 0 {
 		t.Fatalf("lineage counts = %#v", result.Counts)
@@ -186,11 +191,35 @@ func TestEffectiveAccessPathLineageFailsClosedWhenAnEventIsMissing(t *testing.T)
 
 	path.Edges[1].EventID = ""
 	incomplete := path.QualifyLineage()
-	if incomplete.Qualified || incomplete.ProofDigest != "" || incomplete.CompleteEdgeCount != 3 {
+	if incomplete.Qualified || incomplete.ProofDigest != "" || incomplete.CompleteEdgeCount != 4 {
 		t.Fatalf("incomplete lineage = %#v", incomplete)
 	}
-	if len(incomplete.Gaps) != 1 || incomplete.Gaps[0].EdgeIndex != 1 || strings.Join(incomplete.Gaps[0].Fields, ",") != "event_id" {
+	if len(incomplete.Gaps) != 1 || incomplete.Gaps[0].Segment != "access" || incomplete.Gaps[0].EdgeIndex != 1 || strings.Join(incomplete.Gaps[0].Fields, ",") != "event_id" {
 		t.Fatalf("lineage gaps = %#v", incomplete.Gaps)
+	}
+}
+
+func TestEffectiveAccessPathLineageRequiresIdentityToPrincipalProof(t *testing.T) {
+	path := effectiveAccessTestPath()
+	path.IdentityRelationChain = nil
+	path.IdentityEdges = nil
+	qualification := path.QualifyLineage()
+	if qualification.Qualified || qualification.ProofDigest != "" {
+		t.Fatalf("identity-unbound lineage = %#v", qualification)
+	}
+	if len(qualification.Gaps) != 1 || qualification.Gaps[0].Segment != "identity" || qualification.Gaps[0].EdgeIndex != -1 || strings.Join(qualification.Gaps[0].Fields, ",") != "identity_path" {
+		t.Fatalf("identity gaps = %#v", qualification.Gaps)
+	}
+}
+
+func TestEffectiveAccessPathLineageAllowsIdentityAsPrincipal(t *testing.T) {
+	path := effectiveAccessTestPath()
+	path.Identity = path.Principal
+	path.IdentityRelationChain = nil
+	path.IdentityEdges = nil
+	qualification := path.QualifyLineage()
+	if !qualification.Qualified || qualification.ProofDigest == "" || qualification.EdgeCount != len(path.Edges) {
+		t.Fatalf("direct-principal lineage = %#v", qualification)
 	}
 }
 
@@ -202,7 +231,7 @@ func TestEffectiveAccessPathLineageReportsStructuralGaps(t *testing.T) {
 		t.Fatalf("structurally invalid lineage = %#v", qualification)
 	}
 	last := qualification.Gaps[len(qualification.Gaps)-1]
-	if last.EdgeIndex != -1 || strings.Join(last.Fields, ",") != "principal" {
+	if last.Segment != "access" || last.EdgeIndex != -1 || strings.Join(last.Fields, ",") != "principal" {
 		t.Fatalf("structural gaps = %#v", qualification.Gaps)
 	}
 }
@@ -315,17 +344,38 @@ func effectiveAccessPathTestEdges() []any {
 	}
 }
 
+func effectiveAccessIdentityTestEdges() []any {
+	return []any{
+		map[string]any{
+			"from_urn":         "urn:cerebro:writer:identity:email:alice@example.com",
+			"from_entity_type": "identity.email",
+			"from_label":       "alice@example.com",
+			"relation":         "represents_identity",
+			"to_urn":           "urn:cerebro:writer:okta_user:00u1",
+			"to_entity_type":   "okta.user",
+			"to_label":         "alice@example.com",
+			"source_id":        "okta",
+			"runtime_id":       "writer-okta",
+			"attributes_json":  `{"event_id":"evt-identity","at":"2026-06-10T16:00:00Z"}`,
+		},
+	}
+}
+
 func effectiveAccessTestPath() EffectiveAccessPath {
 	mediator := GraphEntityRef{URN: "urn:cerebro:writer:okta_group:grp-security", EntityType: "okta.group", Label: "Security Engineering"}
 	path := EffectiveAccessPath{
-		Identity:       GraphEntityRef{URN: "urn:cerebro:writer:identity:email:alice@example.com", EntityType: "identity.email", Label: "alice@example.com"},
-		Principal:      GraphEntityRef{URN: "urn:cerebro:writer:okta_user:00u1", EntityType: "okta.user", Label: "alice@example.com"},
-		Mediator:       &mediator,
-		AccessTarget:   GraphEntityRef{URN: "urn:cerebro:writer:okta_application:app-aws-admin", EntityType: "okta.application", Label: "AWS Admin Console"},
-		Entitlement:    GraphEntityRef{URN: "urn:cerebro:writer:okta_entitlement:administratoraccess", EntityType: "okta.entitlement", Label: "AdministratorAccess"},
-		Capability:     GraphEntityRef{URN: "urn:cerebro:writer:privileged_capability:cloud_admin", EntityType: "privileged.capability", Label: "Cloud administrator"},
-		AssignmentKind: "group_app_assignment",
-		RelationChain:  []string{"member_of", "assigned_to", "grants_entitlement", "confers_capability"},
+		Identity:              GraphEntityRef{URN: "urn:cerebro:writer:identity:email:alice@example.com", EntityType: "identity.email", Label: "alice@example.com"},
+		Principal:             GraphEntityRef{URN: "urn:cerebro:writer:okta_user:00u1", EntityType: "okta.user", Label: "alice@example.com"},
+		Mediator:              &mediator,
+		AccessTarget:          GraphEntityRef{URN: "urn:cerebro:writer:okta_application:app-aws-admin", EntityType: "okta.application", Label: "AWS Admin Console"},
+		Entitlement:           GraphEntityRef{URN: "urn:cerebro:writer:okta_entitlement:administratoraccess", EntityType: "okta.entitlement", Label: "AdministratorAccess"},
+		Capability:            GraphEntityRef{URN: "urn:cerebro:writer:privileged_capability:cloud_admin", EntityType: "privileged.capability", Label: "Cloud administrator"},
+		AssignmentKind:        "group_app_assignment",
+		IdentityRelationChain: []string{"represents_identity"},
+		IdentityEdges: []EffectiveAccessPathEdge{
+			{From: GraphEntityRef{URN: "urn:cerebro:writer:identity:email:alice@example.com"}, Relation: "represents_identity", To: GraphEntityRef{URN: "urn:cerebro:writer:okta_user:00u1"}, SourceID: "okta", RuntimeID: "writer-okta", EventID: "evt-identity", At: "2026-06-10T16:00:00Z"},
+		},
+		RelationChain: []string{"member_of", "assigned_to", "grants_entitlement", "confers_capability"},
 		Edges: []EffectiveAccessPathEdge{
 			{From: GraphEntityRef{URN: "urn:cerebro:writer:okta_user:00u1"}, Relation: "member_of", To: mediator, SourceID: "okta", RuntimeID: "writer-okta", EventID: "evt-member", At: "2026-06-10T17:00:00Z"},
 			{From: mediator, Relation: "assigned_to", To: GraphEntityRef{URN: "urn:cerebro:writer:okta_application:app-aws-admin"}, SourceID: "okta", RuntimeID: "writer-okta", EventID: "evt-assign", At: "2026-06-10T18:00:00Z"},


### PR DESCRIPTION
## Summary

- qualify effective-access paths only when identity and access relations carry complete source lineage
- report qualified and incomplete path counts without hiding incomplete paths
- emit a deterministic content digest for fully qualified paths
- preserve the existing access relation chain and add the identity relation chain as an additive response field

## Dependency

- #1732 updates the Go toolchain required for the current vulnerability gate

## Validation

- `go test ./internal/graphquery ./internal/bootstrap ./internal/evidencepackets -count=1`
- `go test -race ./internal/graphquery -count=1`
- `go vet ./internal/graphquery ./internal/bootstrap ./internal/evidencepackets`
- `make check-arch`
- `make contracts-check`
- `GOTOOLCHAIN=go1.26.5 make govulncheck`