### PR TITLE
Upgrade Go toolchain to 1.26.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.4
+golang 1.26.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Build stage - use buildx cross-compilation (no QEMU needed)
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
 ARG TARGETOS

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ GO_TEST_SHARD_WEIGHTS ?= scripts/go_package_test_weights.json
 GO_TEST_SHARD_DEFAULT_WEIGHT ?= 1
 GO_RACE_SHARD_WEIGHTS ?= scripts/go_package_race_weights.json
 GO_RACE_SHARD_DEFAULT_WEIGHT ?= 5
-BUF := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
-GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
+BUF := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
+GOVULNCHECK := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4
 SPECTRAL := npx --yes @stoplight/spectral-cli@6.15.0
-GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.4 go run github.com/goreleaser/goreleaser/v2@v2.16.0
+GORELEASER := GOFLAGS= GOTOOLCHAIN=go1.26.5 go run github.com/goreleaser/goreleaser/v2@v2.16.0
 PROTO_BREAKING_BASE ?= origin/main
 README_CHECK_BASE ?= origin/main
 DOCKER_SMOKE_IMAGE ?= cerebro-runtime-smoke:local
@@ -341,7 +341,7 @@ lint-sources: lint-bootstrap ## Run golangci-lint over source packages.
 	$(GOLANGCI_LINT) run -j "$(GOLANGCI_LINT_CONCURRENCY)" --timeout $(GOLANGCI_LINT_TIMEOUT) $(APP_SOURCE_PACKAGES)
 
 lint-bootstrap: ## Install golangci-lint if missing.
-	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
+	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.5 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
 
 proto-lint: ## Lint protobuf definitions.
 	$(BUF) lint

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The site entry point is [docs/index.md](docs/index.md), and `mkdocs.yml` defines
 
 | Component | Technology |
 | --- | --- |
-| Language | Go 1.26+ with `go1.26.4` toolchain |
+| Language | Go 1.26+ with `go1.26.5` toolchain |
 | HTTP server | Go `net/http` `ServeMux` |
 | RPC | Connect |
 | CLI | Standard Go CLI under `cmd/cerebro` |

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -4,7 +4,7 @@ This document describes the current bootstrap service on `main`. Historical ware
 
 ## Prerequisites
 
-- Go 1.26+; the repository pins `go1.26.4` in `go.mod`.
+- Go 1.26+; the repository pins `go1.26.5` in `go.mod`.
 - Docker and Docker Compose for the durable local stack.
 - Make.
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/writer/cerebro
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 replace github.com/WriterInternal/event-registry/clients/go => ./internal/eventregistry
 

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -72,7 +72,7 @@ def is_reachable_finding(finding: dict[str, Any]) -> bool:
 def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
     env = os.environ.copy()
     env["GOFLAGS"] = ""
-    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.4")
+    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.5")
     command = ["go", "run", DEFAULT_TOOL, "-format", "json", *patterns]
     completed = subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
     return completed.returncode, completed.stdout, completed.stderr


### PR DESCRIPTION
## Summary
- pin Go 1.26.5 across the module, local tooling, container build, and operator documentation
- clear the reachable standard-library findings GO-2026-4970 and GO-2026-5856
- keep the vulnerability gate strict; no findings are suppressed or accepted

## Validation
- make govulncheck
- make check-structural
- go test ./...
- git diff --check

## Risk
Patch-level Go toolchain update. The module dependency graph is unchanged.