### PR TITLE
Restore Droid credential bootstrap

### DIFF
--- a/.github/workflows/droid-create.yml
+++ b/.github/workflows/droid-create.yml
@@ -499,8 +499,32 @@ jobs:
           repository: ${{ steps.ctx.outputs.checkout_repository }}
           ref: ${{ steps.ctx.outputs.checkout_ref }}
 
-      - name: Fetch org-level secrets from Infisical
+      - name: Check Infisical bootstrap
         if: steps.ctx.outputs.should_run == 'true'
+        id: infisical
+        shell: bash
+        env:
+          INFISICAL_ORG_IDENTITY_UUID: ${{ secrets.INFISICAL_ORG_IDENTITY_UUID }}
+          INFISICAL_ORG_PROJECT_SLUG: ${{ secrets.INFISICAL_ORG_PROJECT_SLUG }}
+          INFISICAL_REPO_IDENTITY_UUID: ${{ secrets.INFISICAL_REPO_IDENTITY_UUID }}
+          INFISICAL_REPO_PROJECT_SLUG: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for key in INFISICAL_ORG_IDENTITY_UUID INFISICAL_ORG_PROJECT_SLUG INFISICAL_REPO_IDENTITY_UUID INFISICAL_REPO_PROJECT_SLUG; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("${key}")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Infisical bootstrap is incomplete; using the repository Droid credential."
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch org-level secrets from Infisical
+        if: steps.ctx.outputs.should_run == 'true' && steps.infisical.outputs.configured == 'true'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc
@@ -510,7 +534,7 @@ jobs:
           env-slug: prod
           export-type: env
       - name: Fetch repo-level secrets from Infisical
-        if: steps.ctx.outputs.should_run == 'true'
+        if: steps.ctx.outputs.should_run == 'true' && steps.infisical.outputs.configured == 'true'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc
@@ -519,23 +543,21 @@ jobs:
           project-slug: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
           env-slug: prod
           export-type: env
-      - name: Assert required Infisical secrets
+      - name: Resolve Droid credential
         if: steps.ctx.outputs.should_run == 'true'
         shell: bash
         env:
-          REQUIRED_KEYS: FACTORY_API_KEY
+          REPOSITORY_FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         run: |
           set -euo pipefail
-          missing=()
-          for key in ${REQUIRED_KEYS}; do
-            if [ -z "${!key:-}" ]; then
-              missing+=("${key}")
-            fi
-          done
-          if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::Infisical required keys missing: ${missing[*]}"
+          if [ -z "${FACTORY_API_KEY:-}" ]; then
+            FACTORY_API_KEY="${REPOSITORY_FACTORY_API_KEY:-}"
+          fi
+          if [ -z "${FACTORY_API_KEY:-}" ]; then
+            echo "::error::Droid credential missing: FACTORY_API_KEY"
             exit 1
           fi
+          echo "FACTORY_API_KEY=${FACTORY_API_KEY}" >> "$GITHUB_ENV"
 
       - name: Prepare working branch
         if: steps.ctx.outputs.should_run == 'true'

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -282,7 +282,30 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
+      - name: Check Infisical bootstrap
+        id: infisical
+        shell: bash
+        env:
+          INFISICAL_ORG_IDENTITY_UUID: ${{ secrets.INFISICAL_ORG_IDENTITY_UUID }}
+          INFISICAL_ORG_PROJECT_SLUG: ${{ secrets.INFISICAL_ORG_PROJECT_SLUG }}
+          INFISICAL_REPO_IDENTITY_UUID: ${{ secrets.INFISICAL_REPO_IDENTITY_UUID }}
+          INFISICAL_REPO_PROJECT_SLUG: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for key in INFISICAL_ORG_IDENTITY_UUID INFISICAL_ORG_PROJECT_SLUG INFISICAL_REPO_IDENTITY_UUID INFISICAL_REPO_PROJECT_SLUG; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("${key}")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Infisical bootstrap is incomplete; using the repository Droid credential."
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
       - name: Fetch org-level secrets from Infisical
+        if: steps.infisical.outputs.configured == 'true'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc
@@ -292,6 +315,7 @@ jobs:
           env-slug: prod
           export-type: env
       - name: Fetch repo-level secrets from Infisical
+        if: steps.infisical.outputs.configured == 'true'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc
@@ -300,22 +324,20 @@ jobs:
           project-slug: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
           env-slug: prod
           export-type: env
-      - name: Assert required Infisical secrets
+      - name: Resolve Droid credential
         shell: bash
         env:
-          REQUIRED_KEYS: FACTORY_API_KEY
+          REPOSITORY_FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         run: |
           set -euo pipefail
-          missing=()
-          for key in ${REQUIRED_KEYS}; do
-            if [ -z "${!key:-}" ]; then
-              missing+=("${key}")
-            fi
-          done
-          if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::Infisical required keys missing: ${missing[*]}"
+          if [ -z "${FACTORY_API_KEY:-}" ]; then
+            FACTORY_API_KEY="${REPOSITORY_FACTORY_API_KEY:-}"
+          fi
+          if [ -z "${FACTORY_API_KEY:-}" ]; then
+            echo "::error::Droid credential missing: FACTORY_API_KEY"
             exit 1
           fi
+          echo "FACTORY_API_KEY=${FACTORY_API_KEY}" >> "$GITHUB_ENV"
       - name: Run Droid Auto Review
         id: droid-review-first
         continue-on-error: true

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -132,8 +132,31 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-      - name: Fetch org-level secrets from Infisical
+      - name: Check Infisical bootstrap
         if: steps.target.outputs.should_run == 'true'
+        id: infisical
+        shell: bash
+        env:
+          INFISICAL_ORG_IDENTITY_UUID: ${{ secrets.INFISICAL_ORG_IDENTITY_UUID }}
+          INFISICAL_ORG_PROJECT_SLUG: ${{ secrets.INFISICAL_ORG_PROJECT_SLUG }}
+          INFISICAL_REPO_IDENTITY_UUID: ${{ secrets.INFISICAL_REPO_IDENTITY_UUID }}
+          INFISICAL_REPO_PROJECT_SLUG: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for key in INFISICAL_ORG_IDENTITY_UUID INFISICAL_ORG_PROJECT_SLUG INFISICAL_REPO_IDENTITY_UUID INFISICAL_REPO_PROJECT_SLUG; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("${key}")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Infisical bootstrap is incomplete; using the repository Droid credential."
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+      - name: Fetch org-level secrets from Infisical
+        if: steps.target.outputs.should_run == 'true' && steps.infisical.outputs.configured == 'true'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc
@@ -143,7 +166,7 @@ jobs:
           env-slug: prod
           export-type: env
       - name: Fetch repo-level secrets from Infisical
-        if: steps.target.outputs.should_run == 'true'
+        if: steps.target.outputs.should_run == 'true' && steps.infisical.outputs.configured == 'true'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc
@@ -152,23 +175,21 @@ jobs:
           project-slug: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
           env-slug: prod
           export-type: env
-      - name: Assert required Infisical secrets
+      - name: Resolve Droid credential
         if: steps.target.outputs.should_run == 'true'
         shell: bash
         env:
-          REQUIRED_KEYS: FACTORY_API_KEY
+          REPOSITORY_FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         run: |
           set -euo pipefail
-          missing=()
-          for key in ${REQUIRED_KEYS}; do
-            if [ -z "${!key:-}" ]; then
-              missing+=("${key}")
-            fi
-          done
-          if [ "${#missing[@]}" -ne 0 ]; then
-            echo "::error::Infisical required keys missing: ${missing[*]}"
+          if [ -z "${FACTORY_API_KEY:-}" ]; then
+            FACTORY_API_KEY="${REPOSITORY_FACTORY_API_KEY:-}"
+          fi
+          if [ -z "${FACTORY_API_KEY:-}" ]; then
+            echo "::error::Droid credential missing: FACTORY_API_KEY"
             exit 1
           fi
+          echo "FACTORY_API_KEY=${FACTORY_API_KEY}" >> "$GITHUB_ENV"
       - name: Run Droid Exec
         if: steps.target.outputs.should_run == 'true'
         uses: Factory-AI/droid-action@150e8c231191631016a9563bf5d8388e36382de9 # main

--- a/scripts/tests/test_droid_workflows.py
+++ b/scripts/tests/test_droid_workflows.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DROID_WORKFLOWS = (
+    REPOSITORY_ROOT / ".github/workflows/droid-create.yml",
+    REPOSITORY_ROOT / ".github/workflows/droid-review.yml",
+    REPOSITORY_ROOT / ".github/workflows/droid.yml",
+)
+
+
+class DroidWorkflowTests(unittest.TestCase):
+    def test_workflows_fall_back_when_infisical_bootstrap_is_incomplete(self):
+        for workflow in DROID_WORKFLOWS:
+            with self.subTest(workflow=workflow.name):
+                contents = workflow.read_text()
+                self.assertIn("id: infisical", contents)
+                self.assertGreaterEqual(
+                    contents.count("steps.infisical.outputs.configured == 'true'"),
+                    2,
+                )
+                self.assertIn(
+                    "REPOSITORY_FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}",
+                    contents,
+                )
+                self.assertIn(
+                    'echo "FACTORY_API_KEY=${FACTORY_API_KEY}" >> "$GITHUB_ENV"',
+                    contents,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- guard Infisical secret fetches until the complete bootstrap is available
- use the configured repository Droid credential when that bootstrap is incomplete
- apply the same credential resolution to automatic review, manual Droid runs, and Droid-created work
- add a regression test for the guarded fetch and fallback contract

## Validation

- `actionlint .github/workflows/droid-review.yml .github/workflows/droid-create.yml .github/workflows/droid.yml`
- `make script-test`
- `make changed-check`
- `make droid-review-preflight`