### PR TITLE
Centralize embedded Wasm module checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
             command: make openapi-check openapi-lint
           - name: graph-actions
             command: make graph-action-check rust-wasm-check
+            setup_rust: true
           - name: docs-drift
             command: make docs-drift-check
           - name: readme
@@ -69,7 +70,7 @@ jobs:
           cache: false
 
       - name: Set up Rust
-        if: matrix.name == 'graph-actions'
+        if: matrix.setup_rust == true
         run: rustup toolchain install 1.93.1 --profile minimal --component clippy,rustfmt --target wasm32-unknown-unknown
 
       - name: Cache Go build data

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
             command: make catalog-check detection-catalog-check
           - name: graph-actions
             command: make graph-action-check rust-wasm-check
+            setup_rust: true
           - name: finding-dsl
             command: make finding-dsl-check
           - name: policy-rule
@@ -109,7 +110,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Set up Rust
-        if: matrix.name == 'graph-actions'
+        if: matrix.setup_rust == true
         run: rustup toolchain install 1.93.1 --profile minimal --component clippy,rustfmt --target wasm32-unknown-unknown
 
       - name: Run ${{ matrix.name }}

--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,6 @@
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
 CARGO ?= cargo
-STATIC_VALIDATOR_WASM := internal/graphagent/staticvalidator.wasm
-STATIC_VALIDATOR_BUILD := target/wasm32-unknown-unknown/release/cerebro_graphagent_staticvalidator.wasm
-SOURCECOVERAGE_EVALUATOR_WASM := internal/sourcecoverage/evaluator.wasm
-SOURCECOVERAGE_EVALUATOR_BUILD := target/wasm32-unknown-unknown/release/cerebro_sourcecoverage_evaluator.wasm
-PANOPTICON_RESOURCE_WASM := internal/sourceprojection/panopticonresources.wasm
-PANOPTICON_RESOURCE_BUILD := target/wasm32-unknown-unknown/release/cerebro_panopticon_resources.wasm
-MITRE_CONTEXT_WASM := internal/mitre/evaluator.wasm
-MITRE_CONTEXT_BUILD := target/wasm32-unknown-unknown/release/cerebro_mitre_evaluator.wasm
-WASM_CANONICAL_PLATFORM := Linux-x86_64
-WASM_HOST_PLATFORM := $(shell uname -s)-$(shell uname -m)
-RUST_WASM_FLAGS := --remap-path-prefix=$(CURDIR)=/workspace --remap-path-prefix=$${CARGO_HOME:-$$HOME/.cargo}=/cargo
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.4
 GOLANGCI_LINT_CONCURRENCY ?= 4
@@ -431,49 +420,31 @@ graph-action-check: rust-fmt-check rust-clippy rust-test ## Verify generated gra
 	$(CARGO) run --locked --quiet -p cerebro-graphactiongen -- --check
 
 graphagent-static-validator-generate: ## Rebuild the embedded static Cypher validator.
-	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-graphagent-staticvalidator
-	cp "$(STATIC_VALIDATOR_BUILD)" "$(STATIC_VALIDATOR_WASM)"
-	chmod 0644 "$(STATIC_VALIDATOR_WASM)"
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py generate graphagent-static-validator
 
 graphagent-static-validator-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded static Cypher validator is current.
-	$(CARGO) clippy --locked --target wasm32-unknown-unknown -p cerebro-graphagent-staticvalidator -- -D warnings
-	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-graphagent-staticvalidator
-	cmp "$(STATIC_VALIDATOR_BUILD)" "$(STATIC_VALIDATOR_WASM)"
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check graphagent-static-validator
 
 sourcecoverage-evaluator-generate: ## Rebuild the embedded source coverage evaluator.
-	@test "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" || (echo "source coverage artifact generation requires $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)" && exit 1)
-	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-sourcecoverage-evaluator
-	cp "$(SOURCECOVERAGE_EVALUATOR_BUILD)" "$(SOURCECOVERAGE_EVALUATOR_WASM)"
-	chmod 0644 "$(SOURCECOVERAGE_EVALUATOR_WASM)"
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py generate sourcecoverage-evaluator
 
 sourcecoverage-evaluator-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded source coverage evaluator is current.
-	$(CARGO) clippy --locked --target wasm32-unknown-unknown -p cerebro-sourcecoverage-evaluator -- -D warnings
-	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-sourcecoverage-evaluator
-	@if [ "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" ]; then cmp "$(SOURCECOVERAGE_EVALUATOR_BUILD)" "$(SOURCECOVERAGE_EVALUATOR_WASM)"; else echo "source coverage artifact byte comparison runs on $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)"; fi
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check sourcecoverage-evaluator
 
 panopticon-resource-extractor-generate: ## Rebuild the embedded Panopticon resource extractor.
-	@test "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" || (echo "Panopticon resource artifact generation requires $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)" && exit 1)
-	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-panopticon-resources
-	cp "$(PANOPTICON_RESOURCE_BUILD)" "$(PANOPTICON_RESOURCE_WASM)"
-	chmod 0644 "$(PANOPTICON_RESOURCE_WASM)"
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py generate panopticon-resource-extractor
 
 panopticon-resource-extractor-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded Panopticon resource extractor is current.
-	$(CARGO) clippy --locked --target wasm32-unknown-unknown -p cerebro-panopticon-resources -- -D warnings
-	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-panopticon-resources
-	@if [ "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" ]; then cmp "$(PANOPTICON_RESOURCE_BUILD)" "$(PANOPTICON_RESOURCE_WASM)"; else echo "Panopticon resource artifact byte comparison runs on $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)"; fi
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check panopticon-resource-extractor
 
 mitre-context-evaluator-generate: ## Rebuild the embedded MITRE context evaluator.
-	@test "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" || (echo "MITRE context artifact generation requires $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)" && exit 1)
-	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-mitre-evaluator
-	cp "$(MITRE_CONTEXT_BUILD)" "$(MITRE_CONTEXT_WASM)"
-	chmod 0644 "$(MITRE_CONTEXT_WASM)"
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py generate mitre-context-evaluator
 
 mitre-context-evaluator-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded MITRE context evaluator is current.
-	$(CARGO) clippy --locked --target wasm32-unknown-unknown -p cerebro-mitre-evaluator -- -D warnings
-	RUSTFLAGS="$(RUST_WASM_FLAGS)" $(CARGO) build --locked --release --target wasm32-unknown-unknown -p cerebro-mitre-evaluator
-	@if [ "$(WASM_HOST_PLATFORM)" = "$(WASM_CANONICAL_PLATFORM)" ]; then cmp "$(MITRE_CONTEXT_BUILD)" "$(MITRE_CONTEXT_WASM)"; else echo "MITRE context artifact byte comparison runs on $(WASM_CANONICAL_PLATFORM); current platform is $(WASM_HOST_PLATFORM)"; fi
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check mitre-context-evaluator
 
-rust-wasm-check: graphagent-static-validator-check sourcecoverage-evaluator-check panopticon-resource-extractor-check mitre-context-evaluator-check ## Verify every embedded Rust Wasm module.
+rust-wasm-check: rust-fmt-check rust-clippy rust-test ## Verify every embedded Rust Wasm module.
+	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check all
 
 finding-dsl-migrate: ## Convert legacy JSON policy files to PolicyFindingRule DSL YAML.
 	go run ./tools/findingdsl --migrate-policies --write

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -65,6 +65,18 @@ make graph-rebuild-dryrun
 make sourcecoverage-evaluator-check
 ```
 
+## Embedded Rust Wasm Modules
+
+`scripts/embedded_wasm.py` is the module registry for Rust packages embedded in
+the Go runtime. Each entry owns the Cargo package, checked-in artifact, stable
+Make targets, changed-path routing, and canonical artifact platform.
+
+Use the module's existing Make targets to check or regenerate an artifact. Add
+new modules to the registry instead of adding build commands directly to the
+Makefile or `scripts/changed_checks.py`. Artifact generation that requires
+`Linux-x86_64` fails on other platforms; checks still compile the module and
+report when byte comparison is deferred to CI.
+
 ## Architecture Notes
 
 - External data enters through source packages under `sources/`.

--- a/scripts/changed_checks.py
+++ b/scripts/changed_checks.py
@@ -10,6 +10,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+if __package__:
+    from .embedded_wasm import EMBEDDED_WASM_MODULES
+else:
+    from embedded_wasm import EMBEDDED_WASM_MODULES
+
 
 class CommandPlan:
     def __init__(self, name: str, argv: list[str], reason: str) -> None:
@@ -93,17 +98,28 @@ def select_commands(files: list[str], repo: Path) -> list[CommandPlan]:
     if any(path_matches(path, prefixes=("internal/graphactions/", "tools/graphactiongen/"), exact=("Cargo.toml", "Cargo.lock", "rust-toolchain.toml")) for path in files):
         add_command(commands, seen, "graph-action-check", ["make", "graph-action-check"], "Graph action catalog, generated registry, or generator changed.")
 
-    if any(path_matches(path, prefixes=("internal/graphagent/staticvalidator/",), exact=("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "internal/graphagent/staticvalidator.go", "internal/graphagent/staticvalidator.wasm")) for path in files):
-        add_command(commands, seen, "graphagent-static-validator-check", ["make", "graphagent-static-validator-check"], "Static Cypher validator source, host, or embedded module changed.")
-
-    if any(path_matches(path, prefixes=("internal/sourcecoverage/evaluator/",), exact=("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "internal/sourcecoverage/evaluator.go", "internal/sourcecoverage/evaluator.wasm")) for path in files):
-        add_command(commands, seen, "sourcecoverage-evaluator-check", ["make", "sourcecoverage-evaluator-check"], "Source coverage evaluator source, host, or embedded module changed.")
-
-    if any(path_matches(path, prefixes=("internal/sourceprojection/panopticonresources/",), exact=("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "internal/sourceprojection/panopticon_resources_host.go", "internal/sourceprojection/panopticonresources.wasm")) for path in files):
-        add_command(commands, seen, "panopticon-resource-extractor-check", ["make", "panopticon-resource-extractor-check"], "Panopticon resource extractor source, host, or embedded module changed.")
-
-    if any(path_matches(path, prefixes=("internal/mitre/evaluator/",), exact=("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "internal/mitre/evaluator.go", "internal/mitre/evaluator.wasm", "internal/mitre/mitre.go")) for path in files):
-        add_command(commands, seen, "mitre-context-evaluator-check", ["make", "mitre-context-evaluator-check"], "MITRE context normalization source, host, or embedded module changed.")
+    changed_wasm_modules = [
+        module
+        for module in EMBEDDED_WASM_MODULES
+        if any(module.matches_changed_path(path) for path in files)
+    ]
+    if len(changed_wasm_modules) == len(EMBEDDED_WASM_MODULES):
+        add_command(
+            commands,
+            seen,
+            "rust-wasm-check",
+            ["make", "rust-wasm-check"],
+            "Changes affect every embedded Rust Wasm module.",
+        )
+    else:
+        for module in changed_wasm_modules:
+            add_command(
+                commands,
+                seen,
+                module.check_target,
+                ["make", module.check_target],
+                module.changed_reason,
+            )
 
     if any(path_matches(path, prefixes=("sources/", "policies/", "internal/compliance/", "internal/findings/", "tools/catalogcheck/", "internal/connectorcatalog/catalog/")) for path in files):
         add_command(commands, seen, "catalog-check", ["make", "catalog-check"], "Source, policy, finding, connector, or compliance catalog changed.")

--- a/scripts/embedded_wasm.py
+++ b/scripts/embedded_wasm.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Build and verify Cerebro's embedded Rust Wasm modules."""
+
+from __future__ import annotations
+
+import argparse
+import filecmp
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+WASM_TARGET = "wasm32-unknown-unknown"
+CANONICAL_PLATFORM = "Linux-x86_64"
+COMMON_CHANGED_PATHS = frozenset(
+    {
+        "Cargo.lock",
+        "Cargo.toml",
+        "rust-toolchain.toml",
+        "scripts/embedded_wasm.py",
+    }
+)
+
+
+@dataclass(frozen=True)
+class EmbeddedWasmModule:
+    """Build, artifact, and changed-path contract for one embedded module."""
+
+    name: str
+    label: str
+    package: str
+    build_artifact: str
+    embedded_artifact: str
+    generate_target: str
+    check_target: str
+    changed_prefixes: tuple[str, ...]
+    changed_paths: frozenset[str]
+    changed_reason: str
+    canonical_generate_only: bool = True
+    canonical_compare_only: bool = True
+
+    def build_path(self, repo: Path) -> Path:
+        return repo / "target" / WASM_TARGET / "release" / self.build_artifact
+
+    def embedded_path(self, repo: Path) -> Path:
+        return repo / self.embedded_artifact
+
+    def matches_changed_path(self, path: str) -> bool:
+        return (
+            path in COMMON_CHANGED_PATHS
+            or path in self.changed_paths
+            or any(path.startswith(prefix) for prefix in self.changed_prefixes)
+        )
+
+
+EMBEDDED_WASM_MODULES = (
+    EmbeddedWasmModule(
+        name="graphagent-static-validator",
+        label="static Cypher validator",
+        package="cerebro-graphagent-staticvalidator",
+        build_artifact="cerebro_graphagent_staticvalidator.wasm",
+        embedded_artifact="internal/graphagent/staticvalidator.wasm",
+        generate_target="graphagent-static-validator-generate",
+        check_target="graphagent-static-validator-check",
+        changed_prefixes=("internal/graphagent/staticvalidator/",),
+        changed_paths=frozenset(
+            {
+                "internal/graphagent/staticvalidator.go",
+                "internal/graphagent/staticvalidator.wasm",
+            }
+        ),
+        changed_reason="Static Cypher validator source, host, or embedded module changed.",
+        canonical_generate_only=False,
+        canonical_compare_only=False,
+    ),
+    EmbeddedWasmModule(
+        name="sourcecoverage-evaluator",
+        label="source coverage",
+        package="cerebro-sourcecoverage-evaluator",
+        build_artifact="cerebro_sourcecoverage_evaluator.wasm",
+        embedded_artifact="internal/sourcecoverage/evaluator.wasm",
+        generate_target="sourcecoverage-evaluator-generate",
+        check_target="sourcecoverage-evaluator-check",
+        changed_prefixes=("internal/sourcecoverage/evaluator/",),
+        changed_paths=frozenset(
+            {
+                "internal/sourcecoverage/evaluator.go",
+                "internal/sourcecoverage/evaluator.wasm",
+            }
+        ),
+        changed_reason="Source coverage evaluator source, host, or embedded module changed.",
+    ),
+    EmbeddedWasmModule(
+        name="panopticon-resource-extractor",
+        label="Panopticon resource",
+        package="cerebro-panopticon-resources",
+        build_artifact="cerebro_panopticon_resources.wasm",
+        embedded_artifact="internal/sourceprojection/panopticonresources.wasm",
+        generate_target="panopticon-resource-extractor-generate",
+        check_target="panopticon-resource-extractor-check",
+        changed_prefixes=("internal/sourceprojection/panopticonresources/",),
+        changed_paths=frozenset(
+            {
+                "internal/sourceprojection/panopticon_resources_host.go",
+                "internal/sourceprojection/panopticonresources.wasm",
+            }
+        ),
+        changed_reason="Panopticon resource extractor source, host, or embedded module changed.",
+    ),
+    EmbeddedWasmModule(
+        name="mitre-context-evaluator",
+        label="MITRE context",
+        package="cerebro-mitre-evaluator",
+        build_artifact="cerebro_mitre_evaluator.wasm",
+        embedded_artifact="internal/mitre/evaluator.wasm",
+        generate_target="mitre-context-evaluator-generate",
+        check_target="mitre-context-evaluator-check",
+        changed_prefixes=("internal/mitre/evaluator/",),
+        changed_paths=frozenset(
+            {
+                "internal/mitre/evaluator.go",
+                "internal/mitre/evaluator.wasm",
+                "internal/mitre/mitre.go",
+            }
+        ),
+        changed_reason="MITRE context normalization source, host, or embedded module changed.",
+    ),
+)
+
+MODULES_BY_NAME = {module.name: module for module in EMBEDDED_WASM_MODULES}
+
+
+class EmbeddedWasmError(RuntimeError):
+    """Raised when an embedded module cannot be generated or verified."""
+
+
+def host_platform() -> str:
+    return f"{platform.system()}-{platform.machine()}"
+
+
+def cargo_command() -> list[str]:
+    return shlex.split(os.environ.get("CARGO", "cargo"))
+
+
+def rustflags(repo: Path) -> str:
+    cargo_home = os.environ.get("CARGO_HOME") or str(Path.home() / ".cargo")
+    return f"--remap-path-prefix={repo}=/workspace --remap-path-prefix={cargo_home}=/cargo"
+
+
+def build_module(module: EmbeddedWasmModule, repo: Path, *, lint: bool) -> None:
+    cargo = cargo_command()
+    if lint:
+        subprocess.run(
+            [*cargo, "clippy", "--locked", "--target", WASM_TARGET, "-p", module.package, "--", "-D", "warnings"],
+            cwd=repo,
+            check=True,
+        )
+    env = os.environ.copy()
+    env["RUSTFLAGS"] = rustflags(repo)
+    subprocess.run(
+        [*cargo, "build", "--locked", "--release", "--target", WASM_TARGET, "-p", module.package],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+
+
+def generate_module(module: EmbeddedWasmModule, repo: Path, *, current_platform: str | None = None) -> None:
+    current_platform = current_platform or host_platform()
+    if module.canonical_generate_only and current_platform != CANONICAL_PLATFORM:
+        raise EmbeddedWasmError(
+            f"{module.label} artifact generation requires {CANONICAL_PLATFORM}; current platform is {current_platform}"
+        )
+    build_module(module, repo, lint=False)
+    destination = module.embedded_path(repo)
+    shutil.copyfile(module.build_path(repo), destination)
+    destination.chmod(0o644)
+
+
+def check_module(module: EmbeddedWasmModule, repo: Path, *, current_platform: str | None = None) -> None:
+    current_platform = current_platform or host_platform()
+    build_module(module, repo, lint=True)
+    if module.canonical_compare_only and current_platform != CANONICAL_PLATFORM:
+        print(
+            f"{module.label} artifact byte comparison runs on {CANONICAL_PLATFORM}; "
+            f"current platform is {current_platform}"
+        )
+        return
+    if not filecmp.cmp(module.build_path(repo), module.embedded_path(repo), shallow=False):
+        platform_instruction = f" on {CANONICAL_PLATFORM}" if module.canonical_generate_only else ""
+        raise EmbeddedWasmError(
+            f"{module.embedded_artifact} is stale; run make {module.generate_target}{platform_instruction}"
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("generate", "check"))
+    parser.add_argument("module", choices=(*MODULES_BY_NAME, "all"))
+    parser.add_argument("--repo", default=str(Path(__file__).resolve().parents[1]))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo = Path(args.repo).resolve()
+    modules = EMBEDDED_WASM_MODULES if args.module == "all" else (MODULES_BY_NAME[args.module],)
+    try:
+        current_platform = host_platform()
+        if args.action == "generate" and current_platform != CANONICAL_PLATFORM:
+            restricted = next((module for module in modules if module.canonical_generate_only), None)
+            if restricted is not None:
+                raise EmbeddedWasmError(
+                    f"{restricted.label} artifact generation requires {CANONICAL_PLATFORM}; "
+                    f"current platform is {current_platform}"
+                )
+        for module in modules:
+            if args.action == "generate":
+                generate_module(module, repo, current_platform=current_platform)
+            else:
+                check_module(module, repo, current_platform=current_platform)
+    except (EmbeddedWasmError, OSError, subprocess.CalledProcessError) as exc:
+        print(f"embedded-wasm: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_changed_checks.py
+++ b/scripts/tests/test_changed_checks.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 
 import scripts.changed_checks as changed
+from scripts.embedded_wasm import EMBEDDED_WASM_MODULES
 
 
 class ChangedChecksTests(unittest.TestCase):
@@ -45,25 +46,23 @@ class ChangedChecksTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertIn("graph-action-check", self.command_names([path]))
 
-    def test_static_validator_paths_select_wasm_check(self):
-        for path in ("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "internal/graphagent/staticvalidator/src/lib.rs", "internal/graphagent/staticvalidator.go", "internal/graphagent/staticvalidator.wasm"):
+    def test_shared_embedded_wasm_paths_select_aggregate_check(self):
+        for path in ("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "scripts/embedded_wasm.py"):
             with self.subTest(path=path):
-                self.assertIn("graphagent-static-validator-check", self.command_names([path]))
+                names = self.command_names([path])
+                self.assertIn("rust-wasm-check", names)
+                for module in EMBEDDED_WASM_MODULES:
+                    self.assertNotIn(module.check_target, names)
 
-    def test_sourcecoverage_evaluator_paths_select_wasm_check(self):
-        for path in ("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "internal/sourcecoverage/evaluator/src/lib.rs", "internal/sourcecoverage/evaluator.go", "internal/sourcecoverage/evaluator.wasm"):
-            with self.subTest(path=path):
-                self.assertIn("sourcecoverage-evaluator-check", self.command_names([path]))
-
-    def test_panopticon_resource_paths_select_wasm_check(self):
-        for path in ("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "internal/sourceprojection/panopticonresources/src/lib.rs", "internal/sourceprojection/panopticon_resources_host.go", "internal/sourceprojection/panopticonresources.wasm"):
-            with self.subTest(path=path):
-                self.assertIn("panopticon-resource-extractor-check", self.command_names([path]))
-
-    def test_mitre_context_paths_select_wasm_check(self):
-        for path in ("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "internal/mitre/evaluator/src/lib.rs", "internal/mitre/evaluator.go", "internal/mitre/evaluator.wasm", "internal/mitre/mitre.go"):
-            with self.subTest(path=path):
-                self.assertIn("mitre-context-evaluator-check", self.command_names([path]))
+    def test_module_paths_select_registered_module_check(self):
+        for module in EMBEDDED_WASM_MODULES:
+            paths = [
+                *(f"{prefix}src/lib.rs" for prefix in module.changed_prefixes),
+                *module.changed_paths,
+            ]
+            for path in paths:
+                with self.subTest(module=module.name, path=path):
+                    self.assertIn(module.check_target, self.command_names([path]))
 
     def test_readme_source_paths_select_readme_check(self):
         names = self.command_names(["tools/controlindex/main.go"])

--- a/scripts/tests/test_embedded_wasm.py
+++ b/scripts/tests/test_embedded_wasm.py
@@ -1,0 +1,166 @@
+import os
+import stat
+import tempfile
+import tomllib
+import unittest
+import unittest.mock
+from pathlib import Path
+
+import scripts.embedded_wasm as embedded_wasm
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class EmbeddedWasmTests(unittest.TestCase):
+    def test_registry_names_packages_artifacts_and_targets_are_unique(self):
+        attributes = (
+            "name",
+            "package",
+            "build_artifact",
+            "embedded_artifact",
+            "generate_target",
+            "check_target",
+        )
+        for attribute in attributes:
+            with self.subTest(attribute=attribute):
+                values = [getattr(module, attribute) for module in embedded_wasm.EMBEDDED_WASM_MODULES]
+                self.assertEqual(len(values), len(set(values)))
+
+    def test_registered_sources_and_artifacts_exist(self):
+        for module in embedded_wasm.EMBEDDED_WASM_MODULES:
+            with self.subTest(module=module.name):
+                self.assertTrue((ROOT / module.embedded_artifact).is_file())
+                cargo_toml = ROOT / module.changed_prefixes[0] / "Cargo.toml"
+                self.assertTrue(cargo_toml.is_file())
+                self.assertIn(f'name = "{module.package}"', cargo_toml.read_text(encoding="utf-8"))
+
+    def test_registry_covers_every_workspace_cdylib(self):
+        workspace = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
+        cdylib_packages = set()
+        for member in workspace["workspace"]["members"]:
+            cargo_toml = ROOT / member / "Cargo.toml"
+            package = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
+            if "cdylib" in package.get("lib", {}).get("crate-type", []):
+                cdylib_packages.add(package["package"]["name"])
+
+        registered = {module.package for module in embedded_wasm.EMBEDDED_WASM_MODULES}
+        self.assertEqual(registered, cdylib_packages)
+
+    def test_generate_builds_and_installs_each_registered_artifact(self):
+        for module in embedded_wasm.EMBEDDED_WASM_MODULES:
+            with self.subTest(module=module.name), tempfile.TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                built = module.build_path(repo)
+                built.parent.mkdir(parents=True)
+                built.write_bytes(module.name.encode("utf-8"))
+                destination = module.embedded_path(repo)
+                destination.parent.mkdir(parents=True)
+
+                with unittest.mock.patch.object(embedded_wasm.subprocess, "run") as run:
+                    embedded_wasm.generate_module(
+                        module,
+                        repo,
+                        current_platform=embedded_wasm.CANONICAL_PLATFORM,
+                    )
+
+                self.assertEqual(destination.read_bytes(), built.read_bytes())
+                self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o644)
+                self.assertEqual(run.call_count, 1)
+                command = run.call_args.args[0]
+                self.assertEqual(command[-2:], ["-p", module.package])
+                self.assertIn("build", command)
+
+    def test_generate_preserves_static_validator_cross_platform_policy(self):
+        module = embedded_wasm.MODULES_BY_NAME["graphagent-static-validator"]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            built = module.build_path(repo)
+            built.parent.mkdir(parents=True)
+            built.write_bytes(b"module")
+            module.embedded_path(repo).parent.mkdir(parents=True)
+
+            with unittest.mock.patch.object(embedded_wasm.subprocess, "run"):
+                embedded_wasm.generate_module(module, repo, current_platform="Darwin-arm64")
+
+            self.assertEqual(module.embedded_path(repo).read_bytes(), b"module")
+
+    def test_generate_rejects_noncanonical_platform_for_restricted_modules(self):
+        restricted = [
+            module for module in embedded_wasm.EMBEDDED_WASM_MODULES if module.canonical_generate_only
+        ]
+        for module in restricted:
+            with self.subTest(module=module.name), tempfile.TemporaryDirectory() as tmp:
+                with self.assertRaisesRegex(embedded_wasm.EmbeddedWasmError, embedded_wasm.CANONICAL_PLATFORM):
+                    embedded_wasm.generate_module(module, Path(tmp), current_platform="Darwin-arm64")
+
+    def test_check_runs_module_clippy_and_release_build(self):
+        for module in embedded_wasm.EMBEDDED_WASM_MODULES:
+            with self.subTest(module=module.name), tempfile.TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                built = module.build_path(repo)
+                built.parent.mkdir(parents=True)
+                built.write_bytes(b"module")
+                embedded = module.embedded_path(repo)
+                embedded.parent.mkdir(parents=True)
+                embedded.write_bytes(b"module")
+
+                with unittest.mock.patch.object(embedded_wasm.subprocess, "run") as run:
+                    embedded_wasm.check_module(
+                        module,
+                        repo,
+                        current_platform=embedded_wasm.CANONICAL_PLATFORM,
+                    )
+
+                self.assertEqual(run.call_count, 2)
+                clippy = run.call_args_list[0].args[0]
+                build = run.call_args_list[1].args[0]
+                self.assertIn("clippy", clippy)
+                self.assertEqual(clippy[-4:], [module.package, "--", "-D", "warnings"])
+                self.assertIn("build", build)
+                self.assertEqual(build[-2:], ["-p", module.package])
+                build_env = run.call_args_list[1].kwargs["env"]
+                self.assertIn(f"--remap-path-prefix={repo}=/workspace", build_env["RUSTFLAGS"])
+
+    def test_check_defers_restricted_artifact_comparison_off_canonical_platform(self):
+        restricted = [
+            module for module in embedded_wasm.EMBEDDED_WASM_MODULES if module.canonical_compare_only
+        ]
+        for module in restricted:
+            with self.subTest(module=module.name), tempfile.TemporaryDirectory() as tmp:
+                with unittest.mock.patch.object(embedded_wasm, "build_module"):
+                    embedded_wasm.check_module(module, Path(tmp), current_platform="Darwin-arm64")
+
+    def test_check_rejects_stale_artifact_where_comparison_is_required(self):
+        module = embedded_wasm.MODULES_BY_NAME["graphagent-static-validator"]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            built = module.build_path(repo)
+            built.parent.mkdir(parents=True)
+            built.write_bytes(b"new")
+            embedded = module.embedded_path(repo)
+            embedded.parent.mkdir(parents=True)
+            embedded.write_bytes(b"old")
+
+            with unittest.mock.patch.object(embedded_wasm, "build_module"):
+                with self.assertRaisesRegex(embedded_wasm.EmbeddedWasmError, module.generate_target):
+                    embedded_wasm.check_module(module, repo, current_platform="Darwin-arm64")
+
+    def test_cargo_command_honors_make_override(self):
+        with unittest.mock.patch.dict(os.environ, {"CARGO": "/opt/cargo wrapper"}, clear=False):
+            self.assertEqual(embedded_wasm.cargo_command(), ["/opt/cargo", "wrapper"])
+
+    def test_ci_and_release_rust_setup_uses_explicit_matrix_flag(self):
+        for path in (".github/workflows/ci.yml", ".github/workflows/release.yml"):
+            with self.subTest(path=path):
+                workflow = (ROOT / path).read_text(encoding="utf-8")
+                self.assertIn(
+                    "command: make graph-action-check rust-wasm-check\n            setup_rust: true",
+                    workflow,
+                )
+                self.assertIn("if: matrix.setup_rust == true", workflow)
+                self.assertNotIn("if: matrix.name == 'graph-actions'", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_makefile_targets.py
+++ b/scripts/tests/test_makefile_targets.py
@@ -73,6 +73,22 @@ class MakefileTargetTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertFalse(password_file.exists())
 
+    def test_embedded_wasm_targets_keep_stable_names_and_use_registry(self):
+        makefile = self.makefile_text()
+        targets = (
+            "graphagent-static-validator",
+            "sourcecoverage-evaluator",
+            "panopticon-resource-extractor",
+            "mitre-context-evaluator",
+        )
+        for module in targets:
+            with self.subTest(module=module):
+                self.assertIn(f"{module}-generate:", makefile)
+                self.assertIn(f"{module}-check:", makefile)
+                self.assertIn(f"scripts/embedded_wasm.py generate {module}", makefile)
+                self.assertIn(f"scripts/embedded_wasm.py check {module}", makefile)
+        self.assertIn("scripts/embedded_wasm.py check all", makefile)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- Add a typed registry for every embedded Rust Wasm package, checked-in artifact, stable Make target, changed-path route, and artifact platform policy.
- Keep the existing Make target names as thin wrappers around the registry.
- Route shared Rust/Wasm changes through one aggregate check.
- Make Rust setup an explicit CI and release matrix property.
- Document how to add and regenerate embedded modules.

## Compatibility

- No guest, host, ABI, runtime, or checked-in artifact behavior changes.
- Linux x86_64 artifact generation and comparison policy is unchanged.
- Existing Make targets remain available.

## Validation

- Exact changed-check plan against the parent branch
- 121 Python script tests
- All Rust workspace and embedded Wasm checks
- Structural, architecture, documentation-drift, and OSS-audit checks
- Workflow YAML parsing and diff checks

## Stack

Depends on #1820. Review this PR after the Rust/Wasm source-projection integration.