### PR TITLE
Serve compliance profile finding views

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2827,6 +2827,11 @@ paths:
           in: query
           schema:
             type: string
+        - name: profile_id
+          in: query
+          description: Return findings associated with this built-in compliance profile. The profile predicate is applied before ordering and pagination.
+          schema:
+            type: string
         - name: opened_after
           in: query
           schema:
@@ -2864,6 +2869,12 @@ paths:
       responses:
         '200':
           description: GRC-friendly finding list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GRCFindingsResponse'
+        '400':
+          description: Invalid query parameter or unknown compliance profile.
   /grc/findings/triage:
     post:
       summary: Bulk update finding triage dispositions
@@ -2918,9 +2929,24 @@ paths:
           in: query
           schema:
             type: string
+        - name: profile_id
+          in: query
+          description: Export findings associated with this built-in compliance profile.
+          schema:
+            type: string
       responses:
         '200':
-          description: Auditor-friendly CSV of the full findings dataset.
+          description: Auditor-friendly CSV containing up to 500 matching findings. Boundary and profile headers state whether more matches exist and which profile was applied.
+          headers:
+            X-Cerebro-Result-Limit:
+              schema:
+                type: integer
+            X-Cerebro-Result-Truncated:
+              schema:
+                type: boolean
+            X-Cerebro-Profile-ID:
+              schema:
+                type: string
           content:
             text/csv:
               schema:
@@ -4001,11 +4027,14 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              description: Stateless custom control-pack build request.
+              $ref: '#/components/schemas/GRCControlPackBuildRequest'
       responses:
         '200':
           description: Generated YAML preview plus live evidence packet for the generated profile.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GRCCustomControlPacketResponse'
   /grc/evidence-packets:
     get:
       summary: Packaged evidence workflow records for a compliance profile
@@ -4123,11 +4152,17 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              description: Stateless custom control-pack build request.
+              $ref: '#/components/schemas/GRCControlPackBuildRequest'
       responses:
         '200':
           description: Markdown or JSON export for the generated control evidence packet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GRCCustomControlPacketResponse'
+            text/markdown:
+              schema:
+                type: string
   /grc/audit-packets/{packetID}:
     get:
       summary: GRC audit packet for one finding
@@ -5628,6 +5663,431 @@ components:
       schema:
         type: string
   schemas:
+    GRCControlPackBuildRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        extension_id:
+          type: string
+        extension_name:
+          type: string
+        description:
+          type: string
+        framework_id:
+          type: string
+        framework_name:
+          type: string
+        framework_version:
+          type: string
+        profile_id:
+          type: string
+        profile_name:
+          type: string
+        archetype_ids:
+          type: array
+          items:
+            type: string
+        include_profiles:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+    GRCCustomControlPacketResponse:
+      type: object
+      required: [profile, packet, controls, profile_finding_matches, profile_match_evaluation, preview, metadata, generated_at]
+      properties:
+        profile:
+          type: object
+          additionalProperties: true
+        packet:
+          type: object
+          additionalProperties: true
+        controls:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        profile_finding_matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCProfileFindingMatch'
+        profile_match_evaluation:
+          $ref: '#/components/schemas/GRCProfileMatchEvaluation'
+        preview:
+          type: object
+          additionalProperties: true
+        metadata:
+          $ref: '#/components/schemas/GRCReportMetadata'
+        generated_at:
+          type: string
+          format: date-time
+    GRCProfileMatchEvaluation:
+      type: object
+      required: [evaluated_findings, matched_findings, evaluation_limit, scan_truncated]
+      properties:
+        evaluated_findings:
+          type: integer
+          minimum: 0
+        matched_findings:
+          type: integer
+          minimum: 0
+        evaluation_limit:
+          type: integer
+          minimum: 1
+          maximum: 500
+        scan_truncated:
+          type: boolean
+    GRCProfileFindingMatch:
+      type: object
+      required: [finding_id, profile_id, coverage_index_version, coverage_index_revision, mapping_basis]
+      properties:
+        finding_id:
+          type: string
+        finding_title:
+          type: string
+        rule_id:
+          type: string
+        severity:
+          type: string
+        status:
+          type: string
+        profile_id:
+          type: string
+        profile_name:
+          type: string
+        coverage_index_version:
+          type: string
+        coverage_index_revision:
+          type: string
+        mapping_basis:
+          type: string
+          enum: [direct, catalog_mapping, direct_and_catalog_mapping]
+        matched_controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingControlRef'
+        direct_controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingControlRef'
+        catalog_mapped_controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingControlRef'
+        mapping_paths:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+    GRCFindingsResponse:
+      type: object
+      required: [findings, meta, generated_at]
+      properties:
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCRiskInboxFinding'
+        meta:
+          $ref: '#/components/schemas/GRCListMetadata'
+        profile_summary:
+          $ref: '#/components/schemas/GRCFindingProfileSummary'
+        generated_at:
+          type: string
+          format: date-time
+    GRCListMetadata:
+      type: object
+      required: [limit, returned, truncated]
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 500
+        returned:
+          type: integer
+          minimum: 0
+        truncated:
+          type: boolean
+    GRCFindingProfileSummary:
+      type: object
+      required: [profile_id, profile_name, coverage_index_version, coverage_index_revision, matched_findings, open_findings, critical_findings, high_findings, unassigned_findings, evidence_items, evaluated_findings, evaluation_limit, evaluation_truncated, has_more_matches, scan_truncated]
+      properties:
+        profile_id:
+          type: string
+        profile_name:
+          type: string
+        coverage_index_version:
+          type: string
+        coverage_index_revision:
+          type: string
+          description: Immutable content revision for the serving index used to resolve this page.
+        matched_findings:
+          type: integer
+          minimum: 0
+        open_findings:
+          type: integer
+          minimum: 0
+        critical_findings:
+          type: integer
+          minimum: 0
+        high_findings:
+          type: integer
+          minimum: 0
+        unassigned_findings:
+          type: integer
+          minimum: 0
+        evidence_items:
+          type: integer
+          minimum: 0
+        evaluated_findings:
+          type: integer
+          minimum: 0
+        evaluation_limit:
+          type: integer
+          minimum: 1
+          maximum: 501
+        evaluation_truncated:
+          type: boolean
+          deprecated: true
+          description: Retained for compatibility. Profile predicates are applied before pagination; use has_more_matches and scan_truncated.
+        has_more_matches:
+          type: boolean
+          description: True when another profile-matching finding exists beyond the returned page.
+        scan_truncated:
+          type: boolean
+          description: True only when association evaluation stopped before the persisted profile predicate was complete.
+    GRCRiskInboxFinding:
+      type: object
+      required: [id, title, severity, status, evidence_count, owner, sla_status]
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        severity:
+          type: string
+        status:
+          type: string
+        summary:
+          type: string
+        tenant_id:
+          type: string
+        runtime_id:
+          type: string
+        source_id:
+          type: string
+        entity:
+          type: string
+        resource_urns:
+          type: array
+          items:
+            type: string
+        rule_id:
+          type: string
+        policy_id:
+          type: string
+        policy_name:
+          type: string
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingControlRef'
+        compliance_profiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingProfileRef'
+        disposition:
+          type: string
+        status_reason:
+          type: string
+        assignee:
+          type: string
+        due_at:
+          type: string
+          format: date-time
+        status_updated_at:
+          type: string
+          format: date-time
+        notes:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingNote'
+        tickets:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingTicket'
+        external_refs:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingExternalRef'
+        risk_score:
+          type: integer
+        likelihood_score:
+          type: integer
+        impact_score:
+          type: integer
+        confidence_score:
+          type: integer
+        likelihood_level:
+          type: string
+        impact_level:
+          type: string
+        risk_reasons:
+          type: array
+          items:
+            type: string
+        risk_model_version:
+          type: string
+        evidence_count:
+          type: integer
+          minimum: 0
+        owner:
+          type: string
+        sla_status:
+          type: string
+        first_observed_at:
+          type: string
+          format: date-time
+        last_observed_at:
+          type: string
+          format: date-time
+    GRCFindingControlRef:
+      type: object
+      required: [framework_name, control_id]
+      properties:
+        framework_name:
+          type: string
+        control_id:
+          type: string
+    GRCFindingProfileRef:
+      type: object
+      required: [id, name, coverage_index_version, coverage_index_revision]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        coverage_index_version:
+          type: string
+        coverage_index_revision:
+          type: string
+        mapping_basis:
+          type: string
+          enum: [direct, catalog_mapping, direct_and_catalog_mapping]
+        matched_controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingControlRef'
+        matched_finding_controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingControlRef'
+        direct_controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingControlRef'
+        catalog_mapped_controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingControlRef'
+        mapping_paths:
+          type: array
+          items:
+            $ref: '#/components/schemas/GRCFindingProfileMappingPath'
+    GRCFindingProfileMappingPath:
+      type: object
+      required: [source, target, match_direction, declared_source, declared_target, coverage_credit]
+      properties:
+        source:
+          $ref: '#/components/schemas/GRCFindingControlRef'
+        target:
+          $ref: '#/components/schemas/GRCFindingControlRef'
+        match_direction:
+          type: string
+          enum: [finding_control_to_profile_control]
+          description: Direction used to associate a finding with the selected profile control.
+        declared_source:
+          $ref: '#/components/schemas/GRCFindingControlRef'
+        declared_target:
+          $ref: '#/components/schemas/GRCFindingControlRef'
+        coverage_credit:
+          type: string
+          enum: [legacy_catalog_mapping, reviewed_catalog_mapping]
+          description: Governance basis for granting full profile coverage through this path.
+        relationship:
+          type: string
+          enum: [equal-to, equivalent-to, subset-of, superset-of, intersects-with, no-relationship]
+        matching_rationale:
+          type: string
+          enum: [syntactic, semantic, functional]
+        mapping_description:
+          type: string
+        mapping_authority:
+          type: string
+        mapping_source:
+          type: string
+          format: uri
+        review_status:
+          type: string
+          enum: [complete, not-complete, draft, deprecated, superseded]
+        reviewed_at:
+          description: Review date or timestamp recorded by the mapping authority.
+          oneOf:
+            - type: string
+              format: date
+            - type: string
+              format: date-time
+        mapping_version:
+          type: string
+    GRCFindingNote:
+      type: object
+      required: [id, body, created_at]
+      properties:
+        id:
+          type: string
+        body:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    GRCFindingTicket:
+      type: object
+      required: [url, name, external_id, linked_at]
+      properties:
+        url:
+          type: string
+          format: uri
+        name:
+          type: string
+        external_id:
+          type: string
+        linked_at:
+          type: string
+          format: date-time
+    GRCFindingExternalRef:
+      type: object
+      required: [system, kind, external_id, url, external_status, external_status_reason, lifecycle_owner, observed_at]
+      properties:
+        system:
+          type: string
+        kind:
+          type: string
+        external_id:
+          type: string
+        url:
+          type: string
+          format: uri
+        external_status:
+          type: string
+        external_status_reason:
+          type: string
+        lifecycle_owner:
+          type: string
+        observed_at:
+          type: string
+          format: date-time
     GRCEvidencePacketsResponse:
       type: object
       additionalProperties: true

--- a/docs/domains/compliance-controls.md
+++ b/docs/domains/compliance-controls.md
@@ -49,11 +49,23 @@ frameworks:
             maps_to:
               - framework_name: SOC 2
                 control_id: CC6.1
+                relationship: equivalent-to
+                matching_rationale: functional
+                mapping_description: Both controls require MFA before privileged access is granted.
+                mapping_authority: Compliance Engineering
+                mapping_source: https://example.com/crosswalks/identity
+                review_status: complete
+                reviewed_at: 2026-07-14
+                mapping_version: "1.0"
 ```
 
 Required fields are intentionally small for compatibility: catalog `version`, framework `name`, family `id` and `name`, and control `id`. Rich controls should add `title`, `objective`, `intent`, `assessment_methods`, `implementation_guidance`, `audit_procedure`, `failure_modes`, `remediation_guidance`, `evidence_expectations`, and `maps_to` as soon as they are known.
 
 Assessment methods are limited to `examine`, `interview`, and `test`. Evidence expectations require `id` and `type` when present. `maps_to` entries must reference controls that exist in the merged catalog.
+
+Typed `maps_to` relationships use `equal-to`, `equivalent-to`, `subset-of`, `superset-of`, `intersects-with`, or `no-relationship`. Set `matching_rationale` to `syntactic`, `semantic`, or `functional`, explain the assertion in `mapping_description`, and record its `review_status`. `relationship` and `matching_rationale` must be provided together. Existing entries without those fields remain valid and retain the legacy untyped behavior; an omitted relationship does not claim equivalence.
+
+Use `mapping_authority`, `mapping_source`, `review_status`, `reviewed_at`, and `mapping_version` to make the assertion reproducible. `review_status` accepts `complete`, `not-complete`, `draft`, `deprecated`, or `superseded`. A completed review requires all four provenance fields. `mapping_source` must be an absolute URI, and `reviewed_at` must be an ISO 8601 date or RFC 3339 timestamp.
 
 Source coverage contracts can point back into this catalog with per-dimension `control_refs`. Use those refs when a source family directly supplies evidence for a control, and keep the dimension's `evidence_types` aligned with the control's `evidence_expectations.type` values. `catalogcheck` validates explicit source coverage refs against the built-in merged catalog so typos do not become silent compliance gaps.
 
@@ -71,7 +83,7 @@ catalog, err := compliance.LoadControlCatalogFiles(
 index, issues := compliance.BuildCatalogIndex(catalog)
 ```
 
-Use `maps_to` to connect custom controls to controls already covered by generated policy rules. Rule coverage resolution credits the selected custom control when a rule maps to any equivalent control in `maps_to`.
+Use `maps_to` to connect custom controls to controls already covered by generated policy rules. Rule coverage resolution credits the selected source control for untyped legacy mappings and completed `equal-to`, `equivalent-to`, or `superset-of` relationships. Draft, incomplete, deprecated, superseded, partial, and negative assertions remain in the generated coverage index without establishing full target-control coverage.
 
 ## Control Extension Packs
 
@@ -236,6 +248,10 @@ Coverage is resolved in two steps:
 The result reports selected control count, mapped rule IDs, controls without rule coverage, rules by control, and controls by rule. This is the foundation for later control posture and auditor evidence packets.
 
 `BuildControlCoverageIndex` applies this process to a full profile set. The checked-in `internal/compliance/control_coverage_index.yaml` is generated from the built-in profiles and builtin rule metadata. It gives reviewers a stable YAML view of selected controls, coverage status, audit-readiness counts, per-control readiness scores, rule counts, mapped rules, mapped equivalent controls, evidence expectations, unmapped controls, and per-profile coverage summaries.
+
+The same generation step writes `internal/compliance/finding_profile_index.json.gz`, a compressed serving projection keyed by finding rule and control reference. `/grc/findings` loads and validates this projection during startup instead of parsing the full audit document on the first request. The serving projection retains mapping basis, source-to-target paths, typed relationship metadata, review provenance, and the coverage-index version.
+
+Built-in profile IDs can be used with `GET /grc/findings?profile_id=<id>`. Custom control-packet requests build the same profile association index from the request-scoped extension coverage and return `profile_finding_matches`. Request-scoped custom profiles are not stored as durable program revisions.
 
 Regenerate and verify the index with:
 

--- a/docs/domains/grc-architecture.md
+++ b/docs/domains/grc-architecture.md
@@ -114,12 +114,17 @@ Boundaries:
 GRC-facing rows for risk-inbox, dashboard, control-posture, audit-packet, CSV,
 and inventory-detail surfaces. It owns finding status normalization, SLA state,
 control grouping, evidence row mapping, summary counts, recommended finding
-actions, and connector freshness labels used by GRC views.
+actions, connector freshness labels, and the serving projection that joins
+findings to built-in compliance profiles.
 
 Key exports:
 
 - `FindingItems`, `EvidenceItems`, `ControlItems` — transform persisted records
   into bounded GRC response rows
+- `BuiltinFindingProfile`, `BuiltinFindingProfilePredicate` — resolve profile
+  identity and the exact rule/control selector applied before finding pagination
+- `PageForProfile` — returns a bounded profile page with separate match and scan
+  boundary states
 - `BuildSummary` — builds dashboard-level counts from row previews or aggregate
   store summaries
 - `SLAStatus`, `NormalizedFindingStatus`, `RecommendedAction` — common
@@ -129,11 +134,20 @@ Boundaries:
 
 - Does not list findings, evidence, runtimes, or graph records; bootstrap and
   stores still own tenant-scoped data access
+- Finding page size never limits runtime scope. GRC reads enumerate up to 500
+  runtimes independently and reject a larger scope with an action to select a
+  source or explicit runtime IDs.
+- Does not persist profile membership. `internal/compliance` generates the
+  immutable serving index; `grcfindings` validates it at startup and interprets
+  it for response rows.
+- Match traversal and catalog assertion direction remain explicit. A finding
+  control can be traversed to a selected profile control while the declared
+  catalog relationship points from the selected control to the mapped control.
 - Does not own finding lifecycle, rule evaluation, or workflow persistence
 - Does not define control catalog semantics; control coverage and packet
   readiness stay in `internal/compliance` and `internal/grccontrol`
 
-Dependencies: `ports`
+Dependencies: `compliance`, `ports`
 
 ### grcinventory — Inventory Posture
 
@@ -318,10 +332,16 @@ Dependencies: `ports`
 3. `grccontrol` builds control evidence packets from findings, evidence, and runtime context using compliance control definitions.
 4. `grcprogram` consumes control packets to score readiness and generate work items.
 5. `grctrends` queries persisted findings for time-bucketed trend analysis.
-6. `grcfindings` builds GRC-facing finding, control, evidence, and summary rows.
-7. `grcinventory` applies scope and accountability posture to graph inventory assets and builds inventory detail sections.
-8. `grcvendor` reads vendor graph facts, overlays local discovery decisions, and bootstrap enriches vendors with open findings and evidence counts.
-9. All reads are tenant-scoped; the bootstrap layer enforces tenant authorization before dispatching to any GRC package.
+6. `compliance` generates a versioned finding-profile serving index from control
+   coverage and rule mappings. Startup rejects missing, stale, or empty profile
+   associations.
+7. Profile-filtered finding reads derive an exact rule/control predicate from
+   that index, apply it in the finding store before ordering and pagination,
+   then use `grcfindings` to verify and explain each returned association.
+8. `grcfindings` builds GRC-facing finding, control, evidence, and summary rows.
+9. `grcinventory` applies scope and accountability posture to graph inventory assets and builds inventory detail sections.
+10. `grcvendor` reads vendor graph facts, overlays local discovery decisions, and bootstrap enriches vendors with open findings and evidence counts.
+11. All reads are tenant-scoped; the bootstrap layer enforces tenant authorization before dispatching to any GRC package.
 
 ## RBAC Ownership
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -39,6 +39,7 @@ import (
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/grcfindings"
 	platformjobs "github.com/writer/cerebro/internal/jobs"
 	"github.com/writer/cerebro/internal/knowledge"
 	"github.com/writer/cerebro/internal/mcpoauth"
@@ -140,6 +141,9 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 // security-sensitive surfaces fail closed when misconfigured.
 func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) (*App, error) {
 	app := &App{cfg: cfg, deps: deps, sources: sources}
+	if err := grcfindings.ValidateBuiltinFindingProfileIndex(); err != nil {
+		return nil, fmt.Errorf("GRC finding profile bootstrap failed: %w", err)
+	}
 	transitKey, err := connectorTransitKeyFromConfig(cfg.ConnectorCredentials)
 	if err != nil {
 		return nil, err

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -829,9 +829,10 @@ func (s *stubRuntimeStore) ListSourceRuntimes(_ context.Context, filter ports.So
 	}
 	sort.Strings(ids)
 	var runtimes []*cerebrov1.SourceRuntime
+	allowedRuntimeIDs := normalizedTestStrings(append(filter.RuntimeIDs, filter.RuntimeID))
 	for _, id := range ids {
 		runtime := s.runtimes[id]
-		if filter.RuntimeID != "" && runtime.GetId() != filter.RuntimeID {
+		if len(allowedRuntimeIDs) != 0 && !containsTrimmed(allowedRuntimeIDs, runtime.GetId()) {
 			continue
 		}
 		if filter.TenantID != "" && runtime.GetTenantId() != filter.TenantID {
@@ -841,6 +842,9 @@ func (s *stubRuntimeStore) ListSourceRuntimes(_ context.Context, filter ports.So
 			continue
 		}
 		runtimes = append(runtimes, proto.Clone(runtime).(*cerebrov1.SourceRuntime))
+	}
+	if filter.Limit != 0 && len(runtimes) > int(filter.Limit) {
+		runtimes = runtimes[:filter.Limit]
 	}
 	return runtimes, nil
 }
@@ -8254,6 +8258,20 @@ func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRec
 	}
 	if request.RuleID != "" && strings.TrimSpace(finding.RuleID) != strings.TrimSpace(request.RuleID) {
 		return false
+	}
+	if len(request.ProfilePredicate.RuleIDs) != 0 || len(request.ProfilePredicate.ControlRefs) != 0 {
+		profileMatch := containsTrimmed(request.ProfilePredicate.RuleIDs, finding.RuleID)
+		for _, wanted := range request.ProfilePredicate.ControlRefs {
+			for _, actual := range finding.ControlRefs {
+				if strings.EqualFold(strings.TrimSpace(actual.FrameworkName), strings.TrimSpace(wanted.FrameworkName)) &&
+					strings.EqualFold(strings.TrimSpace(actual.ControlID), strings.TrimSpace(wanted.ControlID)) {
+					profileMatch = true
+				}
+			}
+		}
+		if !profileMatch {
+			return false
+		}
 	}
 	if request.Severity != "" && strings.TrimSpace(finding.Severity) != strings.TrimSpace(request.Severity) {
 		return false

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -27,13 +27,14 @@ import (
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
-	grcDefaultLimit          = uint32(100)
-	grcMaxLimit              = uint32(500)
-	grcDashboardPreviewLimit = uint32(25)
+	grcDefaultLimit           = uint32(100)
+	grcMaxLimit               = uint32(500)
+	grcMaxRuntimeScope        = uint32(500)
+	grcRuntimeScopeFetchLimit = grcMaxRuntimeScope + 1
+	grcDashboardPreviewLimit  = uint32(25)
 )
 
 type grcScope struct {
@@ -66,18 +67,9 @@ type grcControlRef = grcfindings.ControlRef
 type grcControlItem = grcfindings.ControlItem
 type grcEvidenceItem = grcfindings.EvidenceItem
 
-type grcConnector struct {
-	RuntimeID           string     `json:"runtime_id"`
-	SourceID            string     `json:"source_id,omitempty"`
-	TenantID            string     `json:"tenant_id,omitempty"`
-	Status              string     `json:"status"`
-	Freshness           string     `json:"freshness"`
-	SyncLagSeconds      *int64     `json:"sync_lag_seconds,omitempty"`
-	CheckpointWatermark *time.Time `json:"checkpoint_watermark,omitempty"`
-	WatermarkLagSeconds *int64     `json:"watermark_lag_seconds,omitempty"`
-	WatermarkFreshness  string     `json:"watermark_freshness,omitempty"`
-	LastSyncedAt        *time.Time `json:"last_synced_at,omitempty"`
-}
+type grcFindingItemsPage = grcfindings.ProfilePage
+type grcFindingProfileSummary = grcfindings.ProfileSummary
+type grcConnector = grcfindings.ConnectorItem
 
 type grcEntityImpactResponse struct {
 	EntityURN   string                    `json:"entity_urn"`
@@ -235,7 +227,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		Findings:           grcLimitFindings(findingItems, 25),
 		Controls:           grcLimitControls(controls, 25),
 		Evidence:           grcLimitEvidence(evidenceItems, 25),
-		Connectors:         grcConnectorItems(runtimes),
+		Connectors:         grcfindings.ConnectorItems(runtimes),
 		SourceSummaries:    sourceSummaries,
 		CoverageBlindSpots: coverageBlindSpots,
 		CoverageSummaries:  sourcecoverage.Summaries(coverage),
@@ -352,33 +344,57 @@ func (a *App) grcFindingTrends(r *http.Request, runtimes []*cerebrov1.SourceRunt
 	})
 }
 func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {
-	items, limit, err := a.grcFindingItemsFromRequest(r, 0)
+	page, err := a.grcFindingItemsFromRequest(r, 0)
 	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"findings":     items,
-		"meta":         map[string]any{"limit": limit, "returned": len(items), "truncated": limit > 0 && len(items) >= int(limit)},
+	payload := map[string]any{
+		"findings":     page.Items,
+		"meta":         map[string]any{"limit": page.Limit, "returned": len(page.Items), "truncated": page.Truncated},
 		"generated_at": time.Now().UTC(),
-	})
+	}
+	if page.ProfileSummary != nil {
+		payload["profile_summary"] = page.ProfileSummary
+	}
+	writeJSON(w, http.StatusOK, payload)
 }
 
 // grcFindingItemsFromRequest gathers risk-inbox finding items for a request,
 // shared by the JSON list handler and the CSV export. A non-zero limitOverride
 // replaces the request's scope limit (the export pulls the full dataset).
-func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) ([]grcFindingItem, uint32, error) {
+func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) (grcFindingItemsPage, error) {
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
-		return nil, 0, err
-	}
-	runtimes, err := a.grcListRuntimes(r, scope)
-	if err != nil {
-		return nil, 0, err
+		return grcFindingItemsPage{}, err
 	}
 	limit := scope.Limit
 	if limitOverride > 0 {
 		limit = limitOverride
+	}
+	profileID := strings.TrimSpace(r.URL.Query().Get("profile_id"))
+	var selectedProfile grcfindings.ProfileRef
+	var profilePredicate grcfindings.ProfilePredicate
+	if profileID != "" {
+		var ok bool
+		selectedProfile, ok, err = grcfindings.BuiltinFindingProfile(profileID)
+		if err != nil {
+			return grcFindingItemsPage{}, err
+		}
+		if !ok {
+			return grcFindingItemsPage{}, fmt.Errorf("%w: unknown profile_id %q", errInvalidHTTPRequest, profileID)
+		}
+		profilePredicate, ok, err = grcfindings.BuiltinFindingProfilePredicate(profileID)
+		if err != nil {
+			return grcFindingItemsPage{}, err
+		}
+		if !ok {
+			return grcFindingItemsPage{}, fmt.Errorf("%w: unknown profile_id %q", errInvalidHTTPRequest, profileID)
+		}
+	}
+	runtimes, err := a.grcListRuntimes(r, scope)
+	if err != nil {
+		return grcFindingItemsPage{}, err
 	}
 	status := strings.TrimSpace(r.URL.Query().Get("status"))
 	if status == "" {
@@ -388,11 +404,15 @@ func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) 
 	}
 	drilldown, err := grctrends.ParseDrilldownFilters(r.URL.Query())
 	if err != nil {
-		return nil, 0, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
+		return grcFindingItemsPage{}, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
 	}
+	// Fetch one additional row so truncation is exact. For profile reads the
+	// immutable rule/control predicate is applied by the store first.
+	fetchLimit := limit + 1
 	filter := grcFindingFilter{
 		FindingID:           strings.TrimSpace(r.URL.Query().Get("finding_id")),
 		RuleID:              strings.TrimSpace(r.URL.Query().Get("rule_id")),
+		ProfilePredicate:    profilePredicate,
 		Severity:            strings.TrimSpace(r.URL.Query().Get("severity")),
 		Status:              status,
 		ResourceURN:         strings.TrimSpace(r.URL.Query().Get("resource_urn")),
@@ -406,26 +426,37 @@ func (a *App) grcFindingItemsFromRequest(r *http.Request, limitOverride uint32) 
 		MinAgeDays:          drilldown.MinAgeDays,
 		MaxAgeDays:          drilldown.MaxAgeDays,
 		SLAStatus:           drilldown.SLAStatus,
-		Limit:               limit,
+		Limit:               fetchLimit,
 	}
 	findings, err := a.grcListFindingRecords(r, runtimes, filter)
 	if err != nil {
-		return nil, 0, err
+		return grcFindingItemsPage{}, err
 	}
 	evidenceCounts, counted, err := a.grcEvidenceCountsByFindingID(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings)})
 	if err != nil {
-		return nil, 0, err
+		return grcFindingItemsPage{}, err
 	}
 	if !counted {
-		evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: limit})
+		evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: fetchLimit})
 		if err != nil {
-			return nil, 0, err
+			return grcFindingItemsPage{}, err
 		}
 		evidenceCounts = grcEvidenceCounts(evidence)
 	}
 	items := grcFindingItems(findings, grcRuntimeSourceIDs(runtimes), evidenceCounts)
 	grcApplyFindingDispositions(items, a.grcFindingDispositions(r, findings))
-	return items, limit, nil
+	page := grcFindingItemsPage{
+		Items:     items,
+		Limit:     limit,
+		Truncated: limit > 0 && len(items) > int(limit),
+	}
+	if profileID == "" {
+		if page.Truncated {
+			page.Items = page.Items[:limit]
+		}
+		return page, nil
+	}
+	return grcfindings.PageForProfile(selectedProfile, items, len(findings), fetchLimit, limit), nil
 }
 func (a *App) handleGRCControls(w http.ResponseWriter, r *http.Request) {
 	controls, err := a.grcControlItemsFromRequest(r, 0)
@@ -877,10 +908,15 @@ func (a *App) grcListRuntimes(r *http.Request, scope grcScope) ([]*cerebrov1.Sou
 		RuntimeIDs: scope.RuntimeIDs,
 		TenantID:   scope.TenantID,
 		SourceID:   scope.SourceID,
-		Limit:      scope.Limit,
+		// Runtime scope is independent from the response row limit. Otherwise a
+		// small page can silently exclude findings from later runtimes.
+		Limit: grcRuntimeScopeFetchLimit,
 	})
 	if err != nil {
 		return nil, err
+	}
+	if len(runtimes) > int(grcMaxRuntimeScope) {
+		return nil, fmt.Errorf("%w: runtime scope exceeds %d runtimes; select a source or explicit runtime ids", errInvalidHTTPRequest, grcMaxRuntimeScope)
 	}
 	return runtimes, nil
 }
@@ -895,7 +931,7 @@ func (a *App) grcReportScopeRuntimes(r *http.Request, scope grcScope, fallback [
 		RuntimeIDs: scope.RuntimeIDs,
 		TenantID:   scope.TenantID,
 		SourceID:   scope.SourceID,
-		Limit:      scope.Limit,
+		Limit:      grcMaxRuntimeScope,
 	})
 	if err != nil {
 		return grccontrol.ReportScopeRuntimeSnapshots(fallback)
@@ -931,6 +967,7 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 			RuntimeIDs:          runtimeIDs,
 			FindingID:           filter.FindingID,
 			RuleID:              filter.RuleID,
+			ProfilePredicate:    filter.ProfilePredicate,
 			Severity:            filter.Severity,
 			Status:              filter.Status,
 			ResourceURN:         filter.ResourceURN,
@@ -1009,6 +1046,7 @@ func (a *App) grcFindingSummary(r *http.Request, runtimes []*cerebrov1.SourceRun
 			RuntimeIDs:          runtimeIDs,
 			FindingID:           filter.FindingID,
 			RuleID:              filter.RuleID,
+			ProfilePredicate:    filter.ProfilePredicate,
 			Severity:            filter.Severity,
 			Status:              filter.Status,
 			ResourceURN:         filter.ResourceURN,
@@ -1339,30 +1377,6 @@ func grcControlItems(findings []grcFindingItem, evidence []grcEvidenceItem) []gr
 	return grcfindings.ControlItems(findings, evidence)
 }
 
-func grcConnectorItems(runtimes []*cerebrov1.SourceRuntime) []grcConnector {
-	items := make([]grcConnector, 0, len(runtimes))
-	for _, runtime := range runtimes {
-		if runtime == nil {
-			continue
-		}
-		lastSyncedAt := timestampPtr(runtime.GetLastSyncedAt())
-		checkpointWatermark := grcRuntimeCheckpointWatermark(runtime)
-		items = append(items, grcConnector{
-			RuntimeID:           runtime.GetId(),
-			SourceID:            runtime.GetSourceId(),
-			TenantID:            runtime.GetTenantId(),
-			Status:              connectorStatus(lastSyncedAt),
-			Freshness:           connectorFreshness(lastSyncedAt),
-			SyncLagSeconds:      timestampLagSeconds(lastSyncedAt),
-			CheckpointWatermark: checkpointWatermark,
-			WatermarkLagSeconds: timestampLagSeconds(checkpointWatermark),
-			WatermarkFreshness:  connectorFreshness(checkpointWatermark),
-			LastSyncedAt:        lastSyncedAt,
-		})
-	}
-	return items
-}
-
 func grcBuildSummary(findings []grcFindingItem, controls []grcControlItem, evidence []grcEvidenceItem, runtimes []*cerebrov1.SourceRuntime, findingSummary *ports.FindingSummary, evidenceCount *int) grcSummary {
 	return grcfindings.BuildSummary(findings, controls, evidence, runtimes, findingSummary, evidenceCount)
 }
@@ -1383,33 +1397,6 @@ func grcRecommendedAction(finding grcFindingItem) string {
 	return grcfindings.RecommendedAction(finding)
 }
 
-func connectorStatus(lastSyncedAt *time.Time) string {
-	return grcfindings.ConnectorStatus(lastSyncedAt)
-}
-
-func connectorFreshness(lastSyncedAt *time.Time) string {
-	return grcfindings.ConnectorFreshness(lastSyncedAt)
-}
-
-func grcRuntimeCheckpointWatermark(runtime *cerebrov1.SourceRuntime) *time.Time {
-	if runtime == nil {
-		return nil
-	}
-	return timestampPtr(runtime.GetCheckpoint().GetWatermark())
-}
-
-func timestampLagSeconds(value *time.Time) *int64 {
-	if value == nil {
-		return nil
-	}
-	lag := time.Since(*value)
-	if lag < 0 {
-		lag = 0
-	}
-	seconds := int64(lag.Seconds())
-	return &seconds
-}
-
 func severityRank(severity string) int {
 	return grcfindings.SeverityRank(severity)
 }
@@ -1421,21 +1408,6 @@ func fallbackString(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func timePtr(value time.Time) *time.Time {
-	if value.IsZero() {
-		return nil
-	}
-	utc := value.UTC()
-	return &utc
-}
-
-func timestampPtr(value *timestamppb.Timestamp) *time.Time {
-	if value == nil {
-		return nil
-	}
-	return timePtr(value.AsTime())
 }
 
 func writeGRCError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/grc_control_packs.go
+++ b/internal/bootstrap/grc_control_packs.go
@@ -104,12 +104,14 @@ func (a *App) handleGRCCustomControlEvidencePacket(w http.ResponseWriter, r *htt
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"profile":      result.Profile,
-		"packet":       result.Packet,
-		"controls":     result.Controls,
-		"preview":      result.Preview,
-		"metadata":     result.Metadata,
-		"generated_at": result.Packet.GeneratedAt,
+		"profile":                  result.Profile,
+		"packet":                   result.Packet,
+		"controls":                 result.Controls,
+		"profile_finding_matches":  result.ProfileFindingMatches,
+		"profile_match_evaluation": result.ProfileMatchEvaluation,
+		"preview":                  result.Preview,
+		"metadata":                 result.Metadata,
+		"generated_at":             result.Packet.GeneratedAt,
 	})
 }
 
@@ -125,12 +127,14 @@ func (a *App) handleGRCCustomControlEvidencePacketExport(w http.ResponseWriter, 
 	}
 	if strings.EqualFold(r.URL.Query().Get("format"), "json") {
 		writeJSON(w, http.StatusOK, map[string]any{
-			"profile":      result.Profile,
-			"packet":       result.Packet,
-			"controls":     result.Controls,
-			"preview":      result.Preview,
-			"metadata":     result.Metadata,
-			"generated_at": result.Packet.GeneratedAt,
+			"profile":                  result.Profile,
+			"packet":                   result.Packet,
+			"controls":                 result.Controls,
+			"profile_finding_matches":  result.ProfileFindingMatches,
+			"profile_match_evaluation": result.ProfileMatchEvaluation,
+			"preview":                  result.Preview,
+			"metadata":                 result.Metadata,
+			"generated_at":             result.Packet.GeneratedAt,
 		})
 		return
 	}
@@ -198,23 +202,29 @@ func (a *App) buildGRCCustomControlEvidencePacket(w http.ResponseWriter, r *http
 		return grccontrol.CustomPacketResult{}, nil, err
 	}
 	reportScopeRuntimes := a.grcReportScopeRuntimes(r, scope, runtimes)
-	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{Status: "open", Limit: scope.Limit})
+	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{Status: "open", Limit: grcMaxLimit + 1})
 	if err != nil {
 		return grccontrol.CustomPacketResult{}, nil, err
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{Limit: scope.Limit})
+	scanTruncated := len(findings) > int(grcMaxLimit)
+	if scanTruncated {
+		findings = findings[:grcMaxLimit]
+	}
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: grcMaxLimit})
 	if err != nil {
 		return grccontrol.CustomPacketResult{}, nil, err
 	}
 	return grccontrol.BuildCustomEvidencePacket(grccontrol.CustomBuildInput{
-		Request:   request,
-		Framework: r.URL.Query().Get("framework"),
-		ControlID: r.URL.Query().Get("control"),
-		Findings:  findings,
-		Evidence:  evidence,
-		SourceIDs: grcRuntimeSourceIDs(runtimes),
-		Runtimes:  reportScopeRuntimes,
-		Now:       time.Now().UTC(),
+		Request:                request,
+		Framework:              r.URL.Query().Get("framework"),
+		ControlID:              r.URL.Query().Get("control"),
+		Findings:               findings,
+		Evidence:               evidence,
+		SourceIDs:              grcRuntimeSourceIDs(runtimes),
+		Runtimes:               reportScopeRuntimes,
+		Now:                    time.Now().UTC(),
+		FindingEvaluationLimit: grcMaxLimit,
+		FindingScanTruncated:   scanTruncated,
 	})
 }
 

--- a/internal/bootstrap/grc_control_packs_test.go
+++ b/internal/bootstrap/grc_control_packs_test.go
@@ -373,10 +373,11 @@ func TestGRCCustomControlEvidencePacketEndpointBuildsGeneratedProfilePacket(t *t
 		t.Fatalf("POST /grc/control-packets status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	var payload struct {
-		Profile  grccontrol.Profile               `json:"profile"`
-		Packet   compliance.ControlEvidencePacket `json:"packet"`
-		Controls []grccontrol.ControlItem         `json:"controls"`
-		Preview  compliance.ControlPackPreview    `json:"preview"`
+		Profile               grccontrol.Profile               `json:"profile"`
+		Packet                compliance.ControlEvidencePacket `json:"packet"`
+		Controls              []grccontrol.ControlItem         `json:"controls"`
+		ProfileFindingMatches []grccontrol.ProfileFindingMatch `json:"profile_finding_matches"`
+		Preview               compliance.ControlPackPreview    `json:"preview"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode custom control packet: %v", err)
@@ -389,6 +390,12 @@ func TestGRCCustomControlEvidencePacketEndpointBuildsGeneratedProfilePacket(t *t
 	}
 	if len(payload.Controls) != 1 || payload.Controls[0].EvidenceQuality == "" {
 		t.Fatalf("custom controls = %#v, want summarized audit quality", payload.Controls)
+	}
+	if len(payload.ProfileFindingMatches) == 0 {
+		t.Fatal("profile_finding_matches is empty, want request-scoped custom profile associations")
+	}
+	if got := payload.ProfileFindingMatches[0]; got.ProfileID != "customer-security-audit" || got.CoverageIndexVersion == "" || got.MappingBasis == "" {
+		t.Fatalf("profile finding match = %#v, want versioned custom profile association", got)
 	}
 }
 

--- a/internal/bootstrap/grc_export.go
+++ b/internal/bootstrap/grc_export.go
@@ -15,14 +15,19 @@ import (
 const grcExportLimit = grcMaxLimit
 
 func (a *App) handleGRCFindingsExport(w http.ResponseWriter, r *http.Request) {
-	items, _, err := a.grcFindingItemsFromRequest(r, grcExportLimit)
+	page, err := a.grcFindingItemsFromRequest(r, grcExportLimit)
 	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
-	rows := make([][]string, 0, len(items))
-	for _, item := range items {
+	rows := make([][]string, 0, len(page.Items))
+	for _, item := range page.Items {
 		rows = append(rows, grcFindingExportRow(item))
+	}
+	w.Header().Set("X-Cerebro-Result-Limit", strconv.FormatUint(uint64(page.Limit), 10))
+	w.Header().Set("X-Cerebro-Result-Truncated", strconv.FormatBool(page.Truncated))
+	if page.ProfileSummary != nil {
+		w.Header().Set("X-Cerebro-Profile-ID", page.ProfileSummary.ProfileID)
 	}
 	writeGRCCSV(w, grcExportFilename("findings"), grcFindingExportHeader(), rows)
 }
@@ -47,6 +52,8 @@ func grcFindingExportHeader() []string {
 		"owner", "assignee", "sla_status", "due_at",
 		"tenant_id", "runtime_id", "source_id", "entity",
 		"resource_urns", "rule_id", "policy_id", "policy_name", "controls",
+		"compliance_profile_ids", "compliance_profile_names", "coverage_index_versions", "coverage_index_revisions", "mapping_bases",
+		"matched_profile_controls", "matched_finding_controls", "mapping_paths",
 		"evidence_count", "first_observed_at", "last_observed_at",
 	}
 }
@@ -56,12 +63,15 @@ func grcFindingExportRow(item grcFindingItem) []string {
 	for _, control := range item.Controls {
 		controls = append(controls, strings.TrimSpace(control.FrameworkName+" "+control.ControlID))
 	}
+	profileFields := item.ProfileExportFields()
 	return []string{
 		item.ID, item.Title, item.Severity, item.Status, item.Disposition,
 		strconv.Itoa(item.RiskScore), item.LikelihoodLevel, item.ImpactLevel,
 		item.Owner, item.Assignee, item.SLAStatus, grcExportTime(item.DueAt),
 		item.TenantID, item.RuntimeID, item.SourceID, item.Entity,
 		strings.Join(item.ResourceURNs, "; "), item.RuleID, item.PolicyID, item.PolicyName, strings.Join(controls, "; "),
+		strings.Join(profileFields.IDs, "; "), strings.Join(profileFields.Names, "; "), strings.Join(profileFields.CoverageVersions, "; "), strings.Join(profileFields.CoverageRevisions, "; "), strings.Join(profileFields.MappingBases, "; "),
+		strings.Join(profileFields.MatchedProfileControls, "; "), strings.Join(profileFields.MatchedFindingControls, "; "), strings.Join(profileFields.MappingPaths, "; "),
 		strconv.Itoa(item.EvidenceCount), grcExportTime(item.FirstObservedAt), grcExportTime(item.LastObservedAt),
 	}
 }

--- a/internal/bootstrap/grc_export_test.go
+++ b/internal/bootstrap/grc_export_test.go
@@ -157,6 +157,9 @@ func TestGRCFindingsExportReturnsCSV(t *testing.T) {
 	if disposition := resp.Header.Get("Content-Disposition"); !strings.Contains(disposition, "cerebro-findings-") {
 		t.Fatalf("content-disposition = %q, want cerebro-findings filename", disposition)
 	}
+	if resp.Header.Get("X-Cerebro-Result-Limit") != "500" || resp.Header.Get("X-Cerebro-Result-Truncated") != "false" {
+		t.Fatalf("export boundary headers = limit %q truncated %q", resp.Header.Get("X-Cerebro-Result-Limit"), resp.Header.Get("X-Cerebro-Result-Truncated"))
+	}
 	records := parseCSVResponse(t, resp)
 	if len(records) != 3 {
 		t.Fatalf("records = %d, want header + 2 findings", len(records))
@@ -180,11 +183,43 @@ func TestGRCFindingsExportReturnsCSV(t *testing.T) {
 	if finding1["controls"] != "SOC 2 CC6.1" {
 		t.Fatalf("finding-1 controls = %q, want SOC 2 CC6.1", finding1["controls"])
 	}
+	if !strings.Contains(finding1["compliance_profile_ids"], "soc2-security-core") || finding1["coverage_index_versions"] == "" || finding1["coverage_index_revisions"] == "" || finding1["mapping_bases"] == "" {
+		t.Fatalf("finding-1 compliance columns = %#v, want profile, revision, and mapping basis", finding1)
+	}
+	if !strings.Contains(finding1["matched_finding_controls"], "SOC 2 CC6.1") {
+		t.Fatalf("finding-1 matched finding controls = %q", finding1["matched_finding_controls"])
+	}
 	if finding1["title"] != "Risky, finding" {
 		t.Fatalf("finding-1 title = %q, want comma-safe title", finding1["title"])
 	}
 	if rows["finding-2"]["evidence_count"] != "1" {
 		t.Fatalf("finding-2 evidence_count = %q, want 1", rows["finding-2"]["evidence_count"])
+	}
+}
+
+func TestGRCFindingsExportAcceptsProfileFilterAndExplainsRows(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	tenantID, runtimeID := "tenant", "runtime-alpha"
+	store := grcExportTestStore(tenantID, runtimeID, now)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/findings/export?tenant_id=" + tenantID + "&profile_id=soc2-security-core")
+	if err != nil {
+		t.Fatalf("GET profile findings export error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	records := parseCSVResponse(t, resp)
+	if len(records) != 2 {
+		t.Fatalf("records = %d, want header + one profile finding", len(records))
+	}
+	if resp.Header.Get("X-Cerebro-Profile-ID") != "soc2-security-core" {
+		t.Fatalf("X-Cerebro-Profile-ID = %q", resp.Header.Get("X-Cerebro-Profile-ID"))
+	}
+	row := indexCSVByColumn(records, "id")["finding-1"]
+	if row["compliance_profile_ids"] == "" || row["matched_profile_controls"] == "" || row["matched_finding_controls"] == "" {
+		t.Fatalf("profile export row = %#v, want link explanation columns", row)
 	}
 }
 

--- a/internal/bootstrap/grc_program_readiness.go
+++ b/internal/bootstrap/grc_program_readiness.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/writer/cerebro/internal/grcfindings"
 	"github.com/writer/cerebro/internal/grcprogram"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecoverage"
@@ -50,7 +51,7 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 		Result:             result,
 		Query:              r.URL.Query(),
 		TenantID:           scope.TenantID,
-		Connectors:         grcProgramConnectors(grcConnectorItems(runtimes)),
+		Connectors:         grcProgramConnectors(grcfindings.ConnectorItems(runtimes)),
 		CoverageBlindSpots: len(coverageBlindSpots),
 		CoverageRecords:    coverage,
 		GeneratedAt:        generatedAt,

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -16,6 +16,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/grcfindings"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	grcuploadhttp "github.com/writer/cerebro/internal/sourcehttp/grcupload"
@@ -404,7 +405,7 @@ func TestGRCConnectorHealthUsesLastSyncedAtSeparatelyFromWatermark(t *testing.T)
 		},
 	}
 
-	connectors := grcConnectorItems(runtimes)
+	connectors := grcfindings.ConnectorItems(runtimes)
 	byID := map[string]grcConnector{}
 	for _, connector := range connectors {
 		byID[connector.RuntimeID] = connector
@@ -803,8 +804,117 @@ func TestGRCFindingsUsesGroupedEvidenceCounts(t *testing.T) {
 	if store.groupedCountRequest.Limit != 0 {
 		t.Fatalf("grouped count limit = %d, want unpaginated 0", store.groupedCountRequest.Limit)
 	}
-	if len(store.groupedCountRequest.FindingIDs) != 1 || store.groupedCountRequest.FindingIDs[0] != "finding-1" {
-		t.Fatalf("grouped count finding ids = %#v, want finding-1", store.groupedCountRequest.FindingIDs)
+	if len(store.groupedCountRequest.FindingIDs) != 2 {
+		t.Fatalf("grouped count finding ids = %#v, want the returned row plus one boundary row", store.groupedCountRequest.FindingIDs)
+	}
+}
+
+func TestGRCFindingsProfileFilterEvaluatesBeforePageLimit(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "runtime-alpha"
+	matchingRuntimeID := "runtime-beta"
+	tenantID := "tenant"
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID:         {Id: runtimeID, SourceId: "okta", TenantId: tenantID},
+			matchingRuntimeID: {Id: matchingRuntimeID, SourceId: "github", TenantId: tenantID},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"higher-risk-non-match": {
+				ID:             "higher-risk-non-match",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Higher risk finding outside the selected profile",
+				Severity:       "CRITICAL",
+				Status:         "open",
+				FindingRisk:    ports.FindingRisk{RiskScore: 99},
+				LastObservedAt: now,
+			},
+			"lower-risk-match": {
+				ID:          "lower-risk-match",
+				TenantID:    tenantID,
+				RuntimeID:   matchingRuntimeID,
+				Title:       "Finding mapped to the selected profile",
+				Severity:    "HIGH",
+				Status:      "open",
+				FindingRisk: ports.FindingRisk{RiskScore: 50},
+				ControlRefs: []ports.FindingControlRef{{
+					FrameworkName: "SOC 2",
+					ControlID:     "CC6.1",
+				}},
+				LastObservedAt: now.Add(-time.Hour),
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/findings?tenant_id=" + tenantID + "&profile_id=soc2-security-core&limit=1")
+	if err != nil {
+		t.Fatalf("GET /grc/findings error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/findings status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload struct {
+		Findings       []grcFindingItem         `json:"findings"`
+		ProfileSummary grcFindingProfileSummary `json:"profile_summary"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /grc/findings: %v", err)
+	}
+	if len(payload.Findings) != 1 || payload.Findings[0].ID != "lower-risk-match" {
+		t.Fatalf("findings = %#v, want lower-risk-match", payload.Findings)
+	}
+	if store.sourceRuntimeListFilter.Limit != grcRuntimeScopeFetchLimit {
+		t.Fatalf("runtime scope limit = %d, want independent GRC boundary limit %d", store.sourceRuntimeListFilter.Limit, grcRuntimeScopeFetchLimit)
+	}
+	if payload.ProfileSummary.ProfileID != "soc2-security-core" || payload.ProfileSummary.MatchedFindings != 1 {
+		t.Fatalf("profile summary = %#v, want one SOC 2 match", payload.ProfileSummary)
+	}
+	if payload.ProfileSummary.EvaluatedFindings != 1 || payload.ProfileSummary.EvaluationLimit != 2 || payload.ProfileSummary.ScanTruncated || payload.ProfileSummary.EvaluationTruncated {
+		t.Fatalf("profile evaluation = %#v, want the exact profile predicate applied before the two-row boundary", payload.ProfileSummary)
+	}
+	profile := payload.Findings[0].Profiles[0]
+	if profile.CoverageIndexVersion == "" || profile.CoverageIndexRevision == "" || len(profile.MappingBasis) == 0 || len(profile.MatchedFindingControls) == 0 {
+		t.Fatalf("profile provenance = %#v, want version, basis, and matched finding controls", profile)
+	}
+}
+
+func TestGRCFindingsRejectsUnknownProfileFilter(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: &stubRuntimeStore{}}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/findings?tenant_id=tenant&profile_id=not-a-profile")
+	if err != nil {
+		t.Fatalf("GET /grc/findings error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("GET /grc/findings status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestGRCFindingsRejectsOversizedRuntimeScope(t *testing.T) {
+	runtimes := make(map[string]*cerebrov1.SourceRuntime, grcRuntimeScopeFetchLimit)
+	for idx := 0; idx < int(grcRuntimeScopeFetchLimit); idx++ {
+		id := fmt.Sprintf("runtime-%03d", idx)
+		runtimes[id] = &cerebrov1.SourceRuntime{Id: id, SourceId: "source", TenantId: "tenant"}
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: &stubRuntimeStore{runtimes: runtimes}}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/findings?tenant_id=tenant&limit=1")
+	if err != nil {
+		t.Fatalf("GET /grc/findings error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("GET /grc/findings status = %d, want explicit oversized-scope rejection", resp.StatusCode)
 	}
 }
 

--- a/internal/grccatalog/catalog.go
+++ b/internal/grccatalog/catalog.go
@@ -227,6 +227,7 @@ func buildCatalog() []Source {
 				Param{ID: "event_id", Type: ParamString, Description: "Restrict to findings from one event."},
 				Param{ID: "policy_id", Type: ParamString, Description: "Restrict to findings from one policy."},
 				Param{ID: "framework", Type: ParamString, Description: "Restrict to findings mapped to one framework."},
+				Param{ID: "profile_id", Type: ParamString, Description: "Restrict to findings linked to one built-in compliance profile."},
 				Param{ID: "age_min_days", Type: ParamInt, Description: "Minimum finding age in days."},
 				Param{ID: "age_max_days", Type: ParamInt, Description: "Maximum finding age in days."},
 				Param{ID: "sla_status", Type: ParamString, Description: "SLA posture filter (e.g. overdue)."},

--- a/internal/grccatalog/catalog_test.go
+++ b/internal/grccatalog/catalog_test.go
@@ -39,6 +39,12 @@ func TestValidateWidgetQueryRejectsUnknownParameter(t *testing.T) {
 	}
 }
 
+func TestFindingsSourceAcceptsComplianceProfile(t *testing.T) {
+	if err := ValidateWidgetQuery(WidgetQuery{SourceID: "findings", Params: map[string]string{"profile_id": "soc2-security-core"}}); err != nil {
+		t.Fatalf("ValidateWidgetQuery(profile_id) error = %v", err)
+	}
+}
+
 func TestValidateWidgetQueryEnforcesEnum(t *testing.T) {
 	if err := ValidateWidgetQuery(WidgetQuery{SourceID: "trends", Params: map[string]string{"interval": "fortnight"}}); !errors.Is(err, ErrInvalidQuery) {
 		t.Fatalf("bad interval error = %v, want ErrInvalidQuery", err)

--- a/internal/grccontrol/helpers_test.go
+++ b/internal/grccontrol/helpers_test.go
@@ -563,9 +563,22 @@ func TestRenderCustomMarkdownDelegates(t *testing.T) {
 				ByStatus: map[compliance.ControlPostureStatus]int{},
 			},
 		},
+		ProfileFindingMatches: []ProfileFindingMatch{{
+			FindingID:             "finding-1",
+			FindingTitle:          "Privileged access review",
+			RuleID:                "privileged-access",
+			Status:                "open",
+			MappingBasis:          compliance.FindingProfileMappingDirect,
+			CoverageIndexVersion:  "revision-1",
+			CoverageIndexRevision: "content-revision-1",
+			MatchedControls:       []compliance.ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+		}},
+		ProfileMatchEvaluation: ProfileMatchEvaluation{EvaluatedFindings: 5, MatchedFindings: 1, EvaluationLimit: 500, ScanTruncated: true},
 	}
 	md := RenderCustomMarkdown(result)
-	if !strings.Contains(md, "Test Profile") {
-		t.Fatal("RenderCustomMarkdown should delegate to RenderMarkdown")
+	for _, want := range []string{"Test Profile", "## Profile Findings", "Privileged access review", "direct", "revision-1", "Scan truncated: true"} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("RenderCustomMarkdown() missing %q:\n%s", want, md)
+		}
 	}
 }

--- a/internal/grccontrol/helpers_test.go
+++ b/internal/grccontrol/helpers_test.go
@@ -569,14 +569,14 @@ func TestRenderCustomMarkdownDelegates(t *testing.T) {
 			RuleID:                "privileged-access",
 			Status:                "open",
 			MappingBasis:          compliance.FindingProfileMappingDirect,
-			CoverageIndexVersion:  "revision-1",
-			CoverageIndexRevision: "content-revision-1",
+			CoverageIndexVersion:  "2026-07-14",
+			CoverageIndexRevision: "sha256:content-revision-1",
 			MatchedControls:       []compliance.ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
 		}},
 		ProfileMatchEvaluation: ProfileMatchEvaluation{EvaluatedFindings: 5, MatchedFindings: 1, EvaluationLimit: 500, ScanTruncated: true},
 	}
 	md := RenderCustomMarkdown(result)
-	for _, want := range []string{"Test Profile", "## Profile Findings", "Privileged access review", "direct", "revision-1", "Scan truncated: true"} {
+	for _, want := range []string{"Test Profile", "## Profile Findings", "Privileged access review", "direct", "| Privileged access review | privileged-access | open | direct | SOC 2 CC6.1 | sha256:content-revision-1 |", "Scan truncated: true"} {
 		if !strings.Contains(md, want) {
 			t.Fatalf("RenderCustomMarkdown() missing %q:\n%s", want, md)
 		}

--- a/internal/grccontrol/packets.go
+++ b/internal/grccontrol/packets.go
@@ -29,14 +29,16 @@ type BuildInput struct {
 }
 
 type CustomBuildInput struct {
-	Request   compliance.ControlPackBuildRequest
-	Framework string
-	ControlID string
-	Findings  []*ports.FindingRecord
-	Evidence  []*cerebrov1.FindingEvidence
-	SourceIDs map[string]string
-	Runtimes  []*cerebrov1.SourceRuntime
-	Now       time.Time
+	Request                compliance.ControlPackBuildRequest
+	Framework              string
+	ControlID              string
+	Findings               []*ports.FindingRecord
+	Evidence               []*cerebrov1.FindingEvidence
+	SourceIDs              map[string]string
+	Runtimes               []*cerebrov1.SourceRuntime
+	Now                    time.Time
+	FindingEvaluationLimit uint32
+	FindingScanTruncated   bool
 }
 
 type PacketResult struct {
@@ -51,11 +53,37 @@ type PacketResult struct {
 }
 
 type CustomPacketResult struct {
-	Profile  Profile                          `json:"profile"`
-	Packet   compliance.ControlEvidencePacket `json:"packet"`
-	Controls []ControlItem                    `json:"controls"`
-	Preview  compliance.ControlPackPreview    `json:"preview"`
-	Metadata ReportMetadata                   `json:"metadata,omitempty"`
+	Profile                Profile                          `json:"profile"`
+	Packet                 compliance.ControlEvidencePacket `json:"packet"`
+	Controls               []ControlItem                    `json:"controls"`
+	ProfileFindingMatches  []ProfileFindingMatch            `json:"profile_finding_matches,omitempty"`
+	ProfileMatchEvaluation ProfileMatchEvaluation           `json:"profile_match_evaluation"`
+	Preview                compliance.ControlPackPreview    `json:"preview"`
+	Metadata               ReportMetadata                   `json:"metadata,omitempty"`
+}
+
+type ProfileMatchEvaluation struct {
+	EvaluatedFindings int    `json:"evaluated_findings"`
+	MatchedFindings   int    `json:"matched_findings"`
+	EvaluationLimit   uint32 `json:"evaluation_limit"`
+	ScanTruncated     bool   `json:"scan_truncated"`
+}
+
+type ProfileFindingMatch struct {
+	FindingID             string                                 `json:"finding_id"`
+	FindingTitle          string                                 `json:"finding_title,omitempty"`
+	RuleID                string                                 `json:"rule_id,omitempty"`
+	Severity              string                                 `json:"severity,omitempty"`
+	Status                string                                 `json:"status,omitempty"`
+	ProfileID             string                                 `json:"profile_id"`
+	ProfileName           string                                 `json:"profile_name,omitempty"`
+	CoverageIndexVersion  string                                 `json:"coverage_index_version"`
+	CoverageIndexRevision string                                 `json:"coverage_index_revision"`
+	MappingBasis          string                                 `json:"mapping_basis"`
+	MatchedControls       []compliance.ControlRef                `json:"matched_controls,omitempty"`
+	DirectControls        []compliance.ControlRef                `json:"direct_controls,omitempty"`
+	CatalogMappedControls []compliance.ControlRef                `json:"catalog_mapped_controls,omitempty"`
+	MappingPaths          []compliance.FindingProfileMappingPath `json:"mapping_paths,omitempty"`
 }
 
 type Profile struct {
@@ -257,6 +285,13 @@ func BuildCustomEvidencePacket(input CustomBuildInput) (CustomPacketResult, []co
 	if err != nil || len(issues) != 0 {
 		return CustomPacketResult{}, issues, err
 	}
+	profileFindingIndex, err := compliance.BuildFindingProfileIndex(compliance.ControlCoverageIndex{
+		Version:  preview.Version,
+		Profiles: []compliance.ControlCoverageProfile{preview.Coverage},
+	}, compliance.BuiltinRuleControlMappings())
+	if err != nil {
+		return CustomPacketResult{}, nil, fmt.Errorf("build custom finding profile index: %w", err)
+	}
 	catalogIndex, catalogIssues := compliance.BuildCatalogIndex(compliance.MergeControlCatalogs(baseCatalog, preview.Catalog))
 	if len(catalogIssues) != 0 {
 		return CustomPacketResult{}, catalogIssues, fmt.Errorf("%w: generated control catalog has validation issues", ErrInvalidRequest)
@@ -282,15 +317,23 @@ func BuildCustomEvidencePacket(input CustomBuildInput) (CustomPacketResult, []co
 		packet.Controls = FilterPacketControls(packet.Controls, input.Framework, input.ControlID)
 		packet.Summary = SummarizePacket(packet.SelectionID, packet.Controls)
 		controls := ControlItemsFromPacket(packet.Controls, input.Findings, input.SourceIDs)
+		profileMatches := profileFindingMatches(profileFindingIndex, input.Findings, profileID)
 		return CustomPacketResult{
 			Profile: Profile{
 				ID:          item.Profile.ID,
 				Name:        item.Profile.Name,
 				Description: item.Profile.Description,
 			},
-			Packet:   packet,
-			Controls: controls,
-			Preview:  preview,
+			Packet:                packet,
+			Controls:              controls,
+			ProfileFindingMatches: profileMatches,
+			ProfileMatchEvaluation: ProfileMatchEvaluation{
+				EvaluatedFindings: len(input.Findings),
+				MatchedFindings:   len(profileMatches),
+				EvaluationLimit:   input.FindingEvaluationLimit,
+				ScanTruncated:     input.FindingScanTruncated,
+			},
+			Preview: preview,
 			Metadata: BuildReportMetadata(ReportMetadataInput{
 				ReportType:    "control",
 				Profile:       Profile{ID: item.Profile.ID, Name: item.Profile.Name, Description: item.Profile.Description},
@@ -305,6 +348,42 @@ func BuildCustomEvidencePacket(input CustomBuildInput) (CustomPacketResult, []co
 		}, nil, nil
 	}
 	return CustomPacketResult{}, []compliance.ValidationIssue{{Path: "profile_id", Message: fmt.Sprintf("generated profile %q was not resolved", profileID)}}, nil
+}
+
+func profileFindingMatches(index compliance.FindingProfileIndex, findings []*ports.FindingRecord, profileID string) []ProfileFindingMatch {
+	result := []ProfileFindingMatch{}
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		refs := make([]compliance.ControlRef, 0, len(finding.ControlRefs))
+		for _, ref := range finding.ControlRefs {
+			refs = append(refs, compliance.ControlRef{FrameworkName: ref.FrameworkName, ControlID: ref.ControlID})
+		}
+		for _, match := range compliance.ResolveFindingProfileMatches(index, finding.RuleID, refs) {
+			if match.ProfileID != profileID {
+				continue
+			}
+			result = append(result, ProfileFindingMatch{
+				FindingID:             finding.ID,
+				FindingTitle:          finding.Title,
+				RuleID:                finding.RuleID,
+				Severity:              finding.Severity,
+				Status:                finding.Status,
+				ProfileID:             match.ProfileID,
+				ProfileName:           match.ProfileName,
+				CoverageIndexVersion:  index.Version,
+				CoverageIndexRevision: index.ContentRevision,
+				MappingBasis:          match.MappingBasis,
+				MatchedControls:       append([]compliance.ControlRef(nil), match.MatchedControls...),
+				DirectControls:        append([]compliance.ControlRef(nil), match.DirectControls...),
+				CatalogMappedControls: append([]compliance.ControlRef(nil), match.CatalogMappedControls...),
+				MappingPaths:          append([]compliance.FindingProfileMappingPath(nil), match.MappingPaths...),
+			})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].FindingID < result[j].FindingID })
+	return result
 }
 
 func ResolveBuiltinProfile(profileID string) (Profile, compliance.SelectionResolution, error) {
@@ -623,10 +702,41 @@ func RenderMarkdown(result PacketResult) string {
 }
 
 func RenderCustomMarkdown(result CustomPacketResult) string {
-	return RenderMarkdown(PacketResult{
-		Profile: result.Profile,
-		Packet:  result.Packet,
+	base := RenderMarkdown(PacketResult{
+		Profile:  result.Profile,
+		Packet:   result.Packet,
+		Metadata: result.Metadata,
 	})
+	var builder strings.Builder
+	builder.WriteString(strings.TrimRight(base, "\n"))
+	writeMarkdownLine(&builder, "")
+	writeMarkdownLine(&builder, "")
+	writeMarkdownLine(&builder, "## Profile Findings")
+	writeMarkdownLine(&builder, "")
+	writeMarkdownLine(&builder, "- Evaluated findings: "+fmt.Sprintf("%d", result.ProfileMatchEvaluation.EvaluatedFindings))
+	writeMarkdownLine(&builder, "- Matched findings: "+fmt.Sprintf("%d", result.ProfileMatchEvaluation.MatchedFindings))
+	writeMarkdownLine(&builder, "- Evaluation limit: "+fmt.Sprintf("%d", result.ProfileMatchEvaluation.EvaluationLimit))
+	writeMarkdownLine(&builder, "- Scan truncated: "+fmt.Sprintf("%t", result.ProfileMatchEvaluation.ScanTruncated))
+	if len(result.ProfileFindingMatches) != 0 {
+		writeMarkdownLine(&builder, "")
+		writeMarkdownLine(&builder, "| Finding | Rule | Status | Mapping basis | Matched controls | Coverage revision |")
+		writeMarkdownLine(&builder, "| --- | --- | --- | --- | --- | --- |")
+		for _, match := range result.ProfileFindingMatches {
+			controls := make([]string, 0, len(match.MatchedControls))
+			for _, control := range match.MatchedControls {
+				controls = append(controls, strings.TrimSpace(control.FrameworkName+" "+control.ControlID))
+			}
+			writeMarkdownRow(&builder,
+				markdownCell(fallbackString(match.FindingTitle, match.FindingID)),
+				markdownCell(match.RuleID),
+				markdownCell(match.Status),
+				markdownCell(match.MappingBasis),
+				markdownCell(strings.Join(controls, ", ")),
+				markdownCell(match.CoverageIndexVersion),
+			)
+		}
+	}
+	return strings.TrimRight(builder.String(), "\n") + "\n"
 }
 
 func writeExpectationsMarkdown(builder *strings.Builder, expectations []compliance.ControlEvidenceExpectationPosture) {

--- a/internal/grccontrol/packets.go
+++ b/internal/grccontrol/packets.go
@@ -732,7 +732,7 @@ func RenderCustomMarkdown(result CustomPacketResult) string {
 				markdownCell(match.Status),
 				markdownCell(match.MappingBasis),
 				markdownCell(strings.Join(controls, ", ")),
-				markdownCell(match.CoverageIndexVersion),
+				markdownCell(match.CoverageIndexRevision),
 			)
 		}
 	}

--- a/internal/grcfindings/connectors.go
+++ b/internal/grcfindings/connectors.go
@@ -1,0 +1,65 @@
+package grcfindings
+
+import (
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type ConnectorItem struct {
+	RuntimeID           string     `json:"runtime_id"`
+	SourceID            string     `json:"source_id,omitempty"`
+	TenantID            string     `json:"tenant_id,omitempty"`
+	Status              string     `json:"status"`
+	Freshness           string     `json:"freshness"`
+	SyncLagSeconds      *int64     `json:"sync_lag_seconds,omitempty"`
+	CheckpointWatermark *time.Time `json:"checkpoint_watermark,omitempty"`
+	WatermarkLagSeconds *int64     `json:"watermark_lag_seconds,omitempty"`
+	WatermarkFreshness  string     `json:"watermark_freshness,omitempty"`
+	LastSyncedAt        *time.Time `json:"last_synced_at,omitempty"`
+}
+
+func ConnectorItems(runtimes []*cerebrov1.SourceRuntime) []ConnectorItem {
+	items := make([]ConnectorItem, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		lastSyncedAt := protobufTime(runtime.GetLastSyncedAt())
+		checkpointWatermark := protobufTime(runtime.GetCheckpoint().GetWatermark())
+		items = append(items, ConnectorItem{
+			RuntimeID:           runtime.GetId(),
+			SourceID:            runtime.GetSourceId(),
+			TenantID:            runtime.GetTenantId(),
+			Status:              ConnectorStatus(lastSyncedAt),
+			Freshness:           ConnectorFreshness(lastSyncedAt),
+			SyncLagSeconds:      lagSeconds(lastSyncedAt),
+			CheckpointWatermark: checkpointWatermark,
+			WatermarkLagSeconds: lagSeconds(checkpointWatermark),
+			WatermarkFreshness:  ConnectorFreshness(checkpointWatermark),
+			LastSyncedAt:        lastSyncedAt,
+		})
+	}
+	return items
+}
+
+func protobufTime(value *timestamppb.Timestamp) *time.Time {
+	if value == nil || !value.IsValid() {
+		return nil
+	}
+	result := value.AsTime().UTC()
+	return &result
+}
+
+func lagSeconds(value *time.Time) *int64 {
+	if value == nil {
+		return nil
+	}
+	lag := time.Since(*value)
+	if lag < 0 {
+		lag = 0
+	}
+	seconds := int64(lag.Seconds())
+	return &seconds
+}

--- a/internal/grcfindings/items.go
+++ b/internal/grcfindings/items.go
@@ -37,6 +37,7 @@ type FindingItem struct {
 	PolicyID     string       `json:"policy_id,omitempty"`
 	PolicyName   string       `json:"policy_name,omitempty"`
 	Controls     []ControlRef `json:"controls,omitempty"`
+	Profiles     []ProfileRef `json:"compliance_profiles,omitempty"`
 	GRCFindingRisk
 	GRCFindingWorkflowMetadata
 	EvidenceCount   int        `json:"evidence_count"`
@@ -71,6 +72,36 @@ type GRCFindingRisk struct {
 type ControlRef struct {
 	FrameworkName string `json:"framework_name"`
 	ControlID     string `json:"control_id"`
+}
+
+type ProfileRef struct {
+	ID                     string               `json:"id"`
+	Name                   string               `json:"name"`
+	CoverageIndexVersion   string               `json:"coverage_index_version"`
+	CoverageIndexRevision  string               `json:"coverage_index_revision"`
+	MappingBasis           string               `json:"mapping_basis"`
+	MatchedControls        []ControlRef         `json:"matched_controls,omitempty"`
+	DirectControls         []ControlRef         `json:"direct_controls,omitempty"`
+	CatalogMappedControls  []ControlRef         `json:"catalog_mapped_controls,omitempty"`
+	MatchedFindingControls []ControlRef         `json:"matched_finding_controls,omitempty"`
+	MappingPaths           []ProfileMappingPath `json:"mapping_paths,omitempty"`
+}
+
+type ProfileMappingPath struct {
+	Source             ControlRef `json:"source"`
+	Target             ControlRef `json:"target"`
+	MatchDirection     string     `json:"match_direction"`
+	DeclaredSource     ControlRef `json:"declared_source"`
+	DeclaredTarget     ControlRef `json:"declared_target"`
+	CoverageCredit     string     `json:"coverage_credit"`
+	Relationship       string     `json:"relationship,omitempty"`
+	MatchingRationale  string     `json:"matching_rationale,omitempty"`
+	MappingDescription string     `json:"mapping_description,omitempty"`
+	MappingAuthority   string     `json:"mapping_authority,omitempty"`
+	MappingSource      string     `json:"mapping_source,omitempty"`
+	ReviewStatus       string     `json:"review_status,omitempty"`
+	ReviewedAt         string     `json:"reviewed_at,omitempty"`
+	MappingVersion     string     `json:"mapping_version,omitempty"`
 }
 
 type ControlItem struct {
@@ -118,6 +149,7 @@ func FindingItems(findings []*ports.FindingRecord, sourceIDs map[string]string, 
 			PolicyID:     finding.PolicyID,
 			PolicyName:   finding.PolicyName,
 			Controls:     ControlRefs(finding.ControlRefs),
+			Profiles:     builtinFindingProfiles(finding.RuleID, finding.ControlRefs),
 			GRCFindingRisk: GRCFindingRisk{
 				RiskScore:       finding.RiskScore,
 				LikelihoodScore: finding.LikelihoodScore,

--- a/internal/grcfindings/items_test.go
+++ b/internal/grcfindings/items_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -63,6 +64,114 @@ func TestFindingItemsNormalizeRiskInboxRows(t *testing.T) {
 	}
 	if len(item.Controls) != 1 || item.Controls[0].ControlID != "CC6.1" {
 		t.Fatalf("Controls = %#v, want SOC 2 CC6.1", item.Controls)
+	}
+	if len(item.Profiles) == 0 {
+		t.Fatal("ComplianceProfiles is empty, want profiles linked through SOC 2 CC6.1")
+	}
+}
+
+func TestFindingProfileIndexLinksRulesAndMappedControlsWithoutDuplicates(t *testing.T) {
+	target := compliance.ControlRef{FrameworkName: "Custom Framework", ControlID: "IAM-1"}
+	source := compliance.ControlRef{
+		FrameworkName:      "SOC 2",
+		ControlID:          "CC6.1",
+		Relationship:       compliance.ControlMappingRelationshipSupersetOf,
+		MatchingRationale:  compliance.ControlMappingRationaleFunctional,
+		MappingDescription: "The selected profile control covers the finding control.",
+		MappingAuthority:   "Compliance mapping review",
+		MappingSource:      "https://example.invalid/mappings/access-program",
+		ReviewStatus:       compliance.ControlMappingReviewStatusComplete,
+		ReviewedAt:         "2026-07-14",
+		MappingVersion:     "v1",
+	}
+	match := compliance.FindingProfileMatch{
+		ProfileID:             "access-program",
+		ProfileName:           "Access Program",
+		MappingBasis:          compliance.FindingProfileMappingCatalog,
+		MatchedControls:       []compliance.ControlRef{target},
+		CatalogMappedControls: []compliance.ControlRef{target},
+		MappingPaths:          []compliance.FindingProfileMappingPath{{Source: source, Target: target}},
+	}
+	index := buildFindingProfileIndex(compliance.FindingProfileIndex{
+		Version:          "2026-07-14",
+		ContentRevision:  "sha256:test-revision",
+		MatchesByRuleID:  map[string][]compliance.FindingProfileMatch{"privileged-mfa": {match}},
+		MatchesByControl: map[string][]compliance.FindingProfileMatch{compliance.ControlKey(source): {match}},
+	})
+
+	profiles := index.profilesForFinding("privileged-mfa", []ControlRef{{
+		FrameworkName: "SOC 2",
+		ControlID:     "CC6.1",
+	}})
+	if len(profiles) != 1 {
+		t.Fatalf("len(profiles) = %d, want 1: %#v", len(profiles), profiles)
+	}
+	if profiles[0].ID != "access-program" || len(profiles[0].MatchedControls) != 1 {
+		t.Fatalf("profiles[0] = %#v, want one access-program IAM-1 match", profiles[0])
+	}
+	if profiles[0].CoverageIndexVersion != "2026-07-14" {
+		t.Fatalf("coverage index version = %q, want 2026-07-14", profiles[0].CoverageIndexVersion)
+	}
+	if got := profiles[0].MappingBasis; got != compliance.FindingProfileMappingCatalog {
+		t.Fatalf("mapping basis = %q, want catalog mapping provenance", got)
+	}
+	if got := profiles[0].MatchedFindingControls; len(got) != 1 || got[0].FrameworkName != "SOC 2" || got[0].ControlID != "CC6.1" {
+		t.Fatalf("matched finding controls = %#v, want SOC 2 CC6.1", got)
+	}
+	if got := profiles[0].MatchedControls[0]; got.FrameworkName != "Custom Framework" || got.ControlID != "IAM-1" {
+		t.Fatalf("matched control = %#v, want Custom Framework IAM-1", got)
+	}
+	path := profiles[0].MappingPaths[0]
+	if path.MatchDirection != "finding_control_to_profile_control" || path.Source.ControlID != "CC6.1" || path.Target.ControlID != "IAM-1" {
+		t.Fatalf("match traversal = %#v, want finding control to profile control", path)
+	}
+	if path.DeclaredSource.ControlID != "IAM-1" || path.DeclaredTarget.ControlID != "CC6.1" || path.Relationship != compliance.ControlMappingRelationshipSupersetOf || path.CoverageCredit != "reviewed_catalog_mapping" {
+		t.Fatalf("declared relationship = %#v, want IAM-1 superset-of CC6.1 with reviewed credit", path)
+	}
+	profiles = index.profilesForFinding("unknown-rule", []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}})
+	if len(profiles) != 1 || profiles[0].ID != "access-program" {
+		t.Fatalf("control fallback profiles = %#v, want access-program", profiles)
+	}
+	if profiles := index.profilesForFinding("unknown-rule", []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC7.1"}}); len(profiles) != 0 {
+		t.Fatalf("unrelated control profiles = %#v, want none", profiles)
+	}
+}
+
+func TestFindingProfileIndexValidationRejectsMissingRevisionAndProfiles(t *testing.T) {
+	if err := (findingProfileIndex{}).validate(); err == nil {
+		t.Fatal("validate() error = nil, want missing coverage index version")
+	}
+	index := findingProfileIndex{version: "2026-07-14", contentRevision: "sha256:test-revision", profiles: map[string]ProfileRef{}}
+	if err := index.validate(); err == nil {
+		t.Fatal("validate() error = nil, want missing profiles")
+	}
+}
+
+func TestFindingProfileIndexRejectsEmptyAssociationsAndVersionDrift(t *testing.T) {
+	profileSet := compliance.ControlProfileSet{
+		Version:  "2026-07-14",
+		Profiles: []compliance.ControlSelection{{ID: "access-program", Name: "Access Program"}},
+	}
+	empty := findingProfileIndex{
+		version:         "2026-07-14",
+		contentRevision: "sha256:test-revision",
+		byRuleID:        map[string][]findingProfileMatch{},
+		byControlID:     map[string][]findingProfileMatch{},
+		profiles:        map[string]ProfileRef{},
+	}
+	if err := empty.applyProfiles(profileSet); err == nil {
+		t.Fatal("applyProfiles() error = nil, want empty serving index rejection")
+	}
+	matched := findingProfileMatch{profileID: "access-program", profileName: "Access Program"}
+	index := findingProfileIndex{
+		version:         "2026-07-13",
+		contentRevision: "sha256:test-revision",
+		byRuleID:        map[string][]findingProfileMatch{"rule": {matched}},
+		byControlID:     map[string][]findingProfileMatch{},
+		profiles:        map[string]ProfileRef{"access-program": {ID: "access-program", Name: "Access Program"}},
+	}
+	if err := index.applyProfiles(profileSet); err == nil {
+		t.Fatal("applyProfiles() error = nil, want profile/index version drift rejection")
 	}
 }
 

--- a/internal/grcfindings/profile_export.go
+++ b/internal/grcfindings/profile_export.go
@@ -1,0 +1,50 @@
+package grcfindings
+
+import "strings"
+
+// FindingProfileExportFields is the stable CSV projection of one finding's
+// compliance profile associations.
+type FindingProfileExportFields struct {
+	IDs                    []string
+	Names                  []string
+	CoverageVersions       []string
+	CoverageRevisions      []string
+	MappingBases           []string
+	MatchedProfileControls []string
+	MatchedFindingControls []string
+	MappingPaths           []string
+}
+
+// ProfileExportFields renders profile link explanations without moving profile
+// semantics into the HTTP export adapter.
+func (item FindingItem) ProfileExportFields() FindingProfileExportFields {
+	fields := FindingProfileExportFields{}
+	for _, profile := range item.Profiles {
+		fields.IDs = append(fields.IDs, profile.ID)
+		fields.Names = append(fields.Names, profile.Name)
+		fields.CoverageVersions = append(fields.CoverageVersions, profile.CoverageIndexVersion)
+		fields.CoverageRevisions = append(fields.CoverageRevisions, profile.CoverageIndexRevision)
+		fields.MappingBases = append(fields.MappingBases, profile.MappingBasis)
+		for _, control := range profile.MatchedControls {
+			fields.MatchedProfileControls = append(fields.MatchedProfileControls, profile.ID+":"+profileExportControl(control))
+		}
+		for _, control := range profile.MatchedFindingControls {
+			fields.MatchedFindingControls = append(fields.MatchedFindingControls, profile.ID+":"+profileExportControl(control))
+		}
+		for _, path := range profile.MappingPaths {
+			value := profile.ID + ":matched " + profileExportControl(path.Source) + " -> " + profileExportControl(path.Target)
+			if path.Relationship != "" {
+				value += "; declared " + profileExportControl(path.DeclaredSource) + " " + path.Relationship + " " + profileExportControl(path.DeclaredTarget)
+			}
+			if path.CoverageCredit != "" {
+				value += "; credit " + path.CoverageCredit
+			}
+			fields.MappingPaths = append(fields.MappingPaths, value)
+		}
+	}
+	return fields
+}
+
+func profileExportControl(control ControlRef) string {
+	return strings.TrimSpace(control.FrameworkName + " " + control.ControlID)
+}

--- a/internal/grcfindings/profile_page.go
+++ b/internal/grcfindings/profile_page.go
@@ -1,0 +1,90 @@
+package grcfindings
+
+type ProfilePage struct {
+	Items          []FindingItem
+	Limit          uint32
+	Truncated      bool
+	ProfileSummary *ProfileSummary
+}
+
+type ProfileSummary struct {
+	ProfileID             string `json:"profile_id"`
+	ProfileName           string `json:"profile_name"`
+	CoverageIndexVersion  string `json:"coverage_index_version"`
+	CoverageIndexRevision string `json:"coverage_index_revision"`
+	MatchedFindings       int    `json:"matched_findings"`
+	OpenFindings          int    `json:"open_findings"`
+	CriticalFindings      int    `json:"critical_findings"`
+	HighFindings          int    `json:"high_findings"`
+	UnassignedFindings    int    `json:"unassigned_findings"`
+	EvidenceItems         int    `json:"evidence_items"`
+	EvaluatedFindings     int    `json:"evaluated_findings"`
+	EvaluationLimit       uint32 `json:"evaluation_limit"`
+	EvaluationTruncated   bool   `json:"evaluation_truncated"`
+	HasMoreMatches        bool   `json:"has_more_matches"`
+	ScanTruncated         bool   `json:"scan_truncated"`
+}
+
+func PageForProfile(profile ProfileRef, items []FindingItem, evaluated int, evaluationLimit, pageLimit uint32) ProfilePage {
+	matched := make([]FindingItem, 0, len(items))
+	for _, item := range items {
+		if findingHasProfile(item, profile.ID) {
+			matched = append(matched, item)
+		}
+	}
+	hasMoreMatches := pageLimit > 0 && len(matched) > int(pageLimit)
+	if hasMoreMatches {
+		matched = matched[:pageLimit]
+	}
+	summary := buildProfileSummary(profile, matched, evaluated, evaluationLimit)
+	summary.HasMoreMatches = hasMoreMatches
+	page := ProfilePage{
+		Items:          matched,
+		Limit:          pageLimit,
+		Truncated:      hasMoreMatches,
+		ProfileSummary: summary,
+	}
+	return page
+}
+
+func findingHasProfile(item FindingItem, profileID string) bool {
+	for _, profile := range item.Profiles {
+		if profile.ID == profileID {
+			return true
+		}
+	}
+	return false
+}
+
+func buildProfileSummary(profile ProfileRef, items []FindingItem, evaluated int, evaluationLimit uint32) *ProfileSummary {
+	summary := &ProfileSummary{
+		ProfileID:             profile.ID,
+		ProfileName:           profile.Name,
+		CoverageIndexVersion:  profile.CoverageIndexVersion,
+		CoverageIndexRevision: profile.CoverageIndexRevision,
+		MatchedFindings:       len(items),
+		EvaluatedFindings:     evaluated,
+		EvaluationLimit:       evaluationLimit,
+		// The store applies the immutable profile predicate before its row limit.
+		// A bounded result can have more matches, but the returned rows were not
+		// produced by scanning and discarding unrelated findings.
+		EvaluationTruncated: false,
+		ScanTruncated:       false,
+	}
+	for _, item := range items {
+		if item.Status == "OPEN" {
+			summary.OpenFindings++
+		}
+		switch item.Severity {
+		case "CRITICAL":
+			summary.CriticalFindings++
+		case "HIGH":
+			summary.HighFindings++
+		}
+		if item.Owner == "Unassigned" {
+			summary.UnassignedFindings++
+		}
+		summary.EvidenceItems += item.EvidenceCount
+	}
+	return summary
+}

--- a/internal/grcfindings/profile_page_test.go
+++ b/internal/grcfindings/profile_page_test.go
@@ -1,0 +1,22 @@
+package grcfindings
+
+import "testing"
+
+func TestPageForProfileFiltersBeforeLimitAndReportsBoundary(t *testing.T) {
+	profile := ProfileRef{ID: "access-audit", Name: "Access Audit", CoverageIndexVersion: "2026-07-14", CoverageIndexRevision: "revision-1"}
+	items := []FindingItem{
+		{ID: "unmatched", Status: "OPEN"},
+		{ID: "critical", Status: "OPEN", Severity: "CRITICAL", Owner: "Unassigned", EvidenceCount: 2, Profiles: []ProfileRef{profile}},
+		{ID: "high", Status: "OPEN", Severity: "HIGH", EvidenceCount: 1, Profiles: []ProfileRef{profile}},
+	}
+	page := PageForProfile(profile, items, 2, 2, 1)
+	if len(page.Items) != 1 || page.Items[0].ID != "critical" {
+		t.Fatalf("page items = %#v", page.Items)
+	}
+	if !page.Truncated || page.ProfileSummary == nil || !page.ProfileSummary.HasMoreMatches || page.ProfileSummary.ScanTruncated || page.ProfileSummary.EvaluationTruncated {
+		t.Fatalf("page boundary = %#v", page)
+	}
+	if page.ProfileSummary.MatchedFindings != 1 || page.ProfileSummary.OpenFindings != 1 || page.ProfileSummary.CriticalFindings != 1 || page.ProfileSummary.HighFindings != 0 || page.ProfileSummary.UnassignedFindings != 1 || page.ProfileSummary.EvidenceItems != 2 {
+		t.Fatalf("profile summary = %#v", page.ProfileSummary)
+	}
+}

--- a/internal/grcfindings/profiles.go
+++ b/internal/grcfindings/profiles.go
@@ -1,0 +1,422 @@
+package grcfindings
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type findingProfileMatch struct {
+	profileID             string
+	profileName           string
+	mappingBasis          string
+	controls              []ControlRef
+	directControls        []ControlRef
+	catalogMappedControls []ControlRef
+	mappingPaths          []ProfileMappingPath
+}
+
+type findingProfileIndex struct {
+	version         string
+	contentRevision string
+	byRuleID        map[string][]findingProfileMatch
+	byControlID     map[string][]findingProfileMatch
+	profiles        map[string]ProfileRef
+}
+
+// ProfilePredicate is the persisted finding selector for one immutable
+// compliance profile. Rule IDs and control references are alternatives: a
+// finding belongs to the profile when either selector matches.
+type ProfilePredicate = ports.FindingProfilePredicate
+
+var builtinFindingProfileIndex = sync.OnceValues(func() (findingProfileIndex, error) {
+	index, err := compliance.LoadBuiltinFindingProfileIndex()
+	if err != nil {
+		return findingProfileIndex{}, fmt.Errorf("load built-in finding profile index: %w", err)
+	}
+	result := buildFindingProfileIndex(index)
+	profiles, err := compliance.LoadBuiltinControlProfileSet()
+	if err != nil {
+		return findingProfileIndex{}, fmt.Errorf("load built-in control profiles: %w", err)
+	}
+	if err := result.applyProfiles(profiles); err != nil {
+		return findingProfileIndex{}, fmt.Errorf("join built-in finding profile metadata: %w", err)
+	}
+	if err := result.validate(); err != nil {
+		return findingProfileIndex{}, fmt.Errorf("validate built-in finding profile index: %w", err)
+	}
+	return result, nil
+})
+
+// ValidateBuiltinFindingProfileIndex loads and validates the immutable index
+// used to annotate GRC findings. Production startup calls this so a damaged or
+// incompatible embedded index stops the process instead of removing every
+// compliance association from otherwise successful responses.
+func ValidateBuiltinFindingProfileIndex() error {
+	_, err := builtinFindingProfileIndex()
+	return err
+}
+
+func (index *findingProfileIndex) applyProfiles(set compliance.ControlProfileSet) error {
+	if strings.TrimSpace(set.Version) == "" || strings.TrimSpace(set.Version) != index.version {
+		return fmt.Errorf("control profile version %q does not match serving index version %q", strings.TrimSpace(set.Version), index.version)
+	}
+	if len(index.byRuleID) == 0 && len(index.byControlID) == 0 {
+		return fmt.Errorf("serving index contains no finding associations")
+	}
+	matchedProfiles := make(map[string]struct{}, len(index.profiles))
+	for id := range index.profiles {
+		matchedProfiles[id] = struct{}{}
+	}
+	configured := make(map[string]struct{}, len(set.Profiles))
+	for _, selection := range set.Profiles {
+		id := strings.TrimSpace(selection.ID)
+		name := strings.TrimSpace(selection.Name)
+		if id == "" || name == "" {
+			return fmt.Errorf("profile id and name are required")
+		}
+		configured[id] = struct{}{}
+		if _, ok := matchedProfiles[id]; !ok {
+			return fmt.Errorf("configured profile %q has no serving index associations", id)
+		}
+		if matched, ok := index.profiles[id]; ok && matched.Name != name {
+			return fmt.Errorf("profile %q name %q does not match serving index name %q", id, name, matched.Name)
+		}
+		index.profiles[id] = ProfileRef{ID: id, Name: name, CoverageIndexVersion: index.version, CoverageIndexRevision: index.contentRevision}
+	}
+	for id := range index.profiles {
+		if _, ok := configured[id]; !ok {
+			return fmt.Errorf("serving index references unknown profile %q", id)
+		}
+	}
+	return nil
+}
+
+// BuiltinFindingProfile returns metadata for a known built-in profile. The
+// boolean is false for an unknown profile ID.
+func BuiltinFindingProfile(profileID string) (ProfileRef, bool, error) {
+	index, err := builtinFindingProfileIndex()
+	if err != nil {
+		return ProfileRef{}, false, err
+	}
+	profile, ok := index.profiles[strings.TrimSpace(profileID)]
+	return profile, ok, nil
+}
+
+// BuiltinFindingProfilePredicate returns the exact persisted finding selector
+// for a built-in profile. Callers apply it before ordering and pagination, then
+// retain profilesForFinding as a defensive serving-index verification step.
+func BuiltinFindingProfilePredicate(profileID string) (ProfilePredicate, bool, error) {
+	index, err := builtinFindingProfileIndex()
+	if err != nil {
+		return ProfilePredicate{}, false, err
+	}
+	profileID = strings.TrimSpace(profileID)
+	if _, ok := index.profiles[profileID]; !ok {
+		return ProfilePredicate{}, false, nil
+	}
+	predicate := ProfilePredicate{}
+	for ruleID, matches := range index.byRuleID {
+		if profileMatchesID(matches, profileID) {
+			predicate.RuleIDs = append(predicate.RuleIDs, ruleID)
+		}
+	}
+	for controlKey, matches := range index.byControlID {
+		if !profileMatchesID(matches, profileID) {
+			continue
+		}
+		frameworkName, controlID, ok := strings.Cut(controlKey, "\x00")
+		if !ok || strings.TrimSpace(frameworkName) == "" || strings.TrimSpace(controlID) == "" {
+			return ProfilePredicate{}, false, fmt.Errorf("profile %q has invalid control selector %q", profileID, controlKey)
+		}
+		predicate.ControlRefs = append(predicate.ControlRefs, ports.FindingControlRef{
+			FrameworkName: frameworkName,
+			ControlID:     controlID,
+		})
+	}
+	sort.Strings(predicate.RuleIDs)
+	sort.Slice(predicate.ControlRefs, func(i, j int) bool {
+		left := predicate.ControlRefs[i].FrameworkName + "\x00" + predicate.ControlRefs[i].ControlID
+		right := predicate.ControlRefs[j].FrameworkName + "\x00" + predicate.ControlRefs[j].ControlID
+		return left < right
+	})
+	return predicate, true, nil
+}
+
+func profileMatchesID(matches []findingProfileMatch, profileID string) bool {
+	for _, match := range matches {
+		if match.profileID == profileID {
+			return true
+		}
+	}
+	return false
+}
+
+func builtinFindingProfiles(ruleID string, refs []ports.FindingControlRef) []ProfileRef {
+	index, err := builtinFindingProfileIndex()
+	if err != nil {
+		// NewWithError validates the immutable index before any production route
+		// is registered. Keep this helper total for package-level callers; the
+		// bootstrap boundary is the fail-closed contract.
+		return nil
+	}
+	controls := make([]ControlRef, 0, len(refs))
+	for _, ref := range refs {
+		controls = append(controls, ControlRef{
+			FrameworkName: ref.FrameworkName,
+			ControlID:     ref.ControlID,
+		})
+	}
+	return index.profilesForFinding(ruleID, controls)
+}
+
+func buildFindingProfileIndex(index compliance.FindingProfileIndex) findingProfileIndex {
+	result := findingProfileIndex{
+		version:         strings.TrimSpace(index.Version),
+		contentRevision: strings.TrimSpace(index.ContentRevision),
+		byRuleID:        map[string][]findingProfileMatch{},
+		byControlID:     map[string][]findingProfileMatch{},
+		profiles:        map[string]ProfileRef{},
+	}
+	for ruleID, matches := range index.MatchesByRuleID {
+		for _, match := range matches {
+			converted := findingProfileMatchFromCompliance(match)
+			result.addProfile(converted)
+			result.byRuleID[strings.TrimSpace(ruleID)] = appendProfileMatch(result.byRuleID[strings.TrimSpace(ruleID)], converted)
+		}
+	}
+	for controlKey, matches := range index.MatchesByControl {
+		for _, match := range matches {
+			converted := findingProfileMatchFromCompliance(match)
+			result.addProfile(converted)
+			result.byControlID[controlKey] = appendProfileMatch(result.byControlID[controlKey], converted)
+		}
+	}
+	return result
+}
+
+func (index *findingProfileIndex) addProfile(match findingProfileMatch) {
+	if match.profileID == "" {
+		return
+	}
+	index.profiles[match.profileID] = ProfileRef{
+		ID:                    match.profileID,
+		Name:                  match.profileName,
+		CoverageIndexVersion:  index.version,
+		CoverageIndexRevision: index.contentRevision,
+	}
+}
+
+func findingProfileMatchFromCompliance(match compliance.FindingProfileMatch) findingProfileMatch {
+	paths := make([]ProfileMappingPath, 0, len(match.MappingPaths))
+	for _, path := range match.MappingPaths {
+		coverageCredit := "reviewed_catalog_mapping"
+		if strings.TrimSpace(path.Source.Relationship) == "" {
+			coverageCredit = "legacy_catalog_mapping"
+		}
+		paths = append(paths, ProfileMappingPath{
+			Source:             controlRefFromCompliance(path.Source),
+			Target:             controlRefFromCompliance(path.Target),
+			MatchDirection:     "finding_control_to_profile_control",
+			DeclaredSource:     controlRefFromCompliance(path.Target),
+			DeclaredTarget:     controlRefFromCompliance(path.Source),
+			CoverageCredit:     coverageCredit,
+			Relationship:       strings.TrimSpace(path.Source.Relationship),
+			MatchingRationale:  strings.TrimSpace(path.Source.MatchingRationale),
+			MappingDescription: strings.TrimSpace(path.Source.MappingDescription),
+			MappingAuthority:   strings.TrimSpace(path.Source.MappingAuthority),
+			MappingSource:      strings.TrimSpace(path.Source.MappingSource),
+			ReviewStatus:       strings.TrimSpace(path.Source.ReviewStatus),
+			ReviewedAt:         strings.TrimSpace(path.Source.ReviewedAt),
+			MappingVersion:     strings.TrimSpace(path.Source.MappingVersion),
+		})
+	}
+	return findingProfileMatch{
+		profileID:             strings.TrimSpace(match.ProfileID),
+		profileName:           strings.TrimSpace(match.ProfileName),
+		mappingBasis:          strings.TrimSpace(match.MappingBasis),
+		controls:              complianceControlRefsForGRC(match.MatchedControls),
+		directControls:        complianceControlRefsForGRC(match.DirectControls),
+		catalogMappedControls: complianceControlRefsForGRC(match.CatalogMappedControls),
+		mappingPaths:          paths,
+	}
+}
+
+func (index findingProfileIndex) profilesForFinding(ruleID string, refs []ControlRef) []ProfileRef {
+	matches := map[string]ProfileRef{}
+	add := func(match findingProfileMatch, findingControl *ControlRef) {
+		profile := matches[match.profileID]
+		profile.ID = match.profileID
+		profile.Name = match.profileName
+		profile.CoverageIndexVersion = index.version
+		profile.CoverageIndexRevision = index.contentRevision
+		profile.MatchedControls = appendUniqueControlRefs(profile.MatchedControls, match.controls...)
+		profile.DirectControls = appendUniqueControlRefs(profile.DirectControls, match.directControls...)
+		profile.CatalogMappedControls = appendUniqueControlRefs(profile.CatalogMappedControls, match.catalogMappedControls...)
+		profile.MappingPaths = appendUniqueProfileMappingPaths(profile.MappingPaths, match.mappingPaths...)
+		for _, control := range match.directControls {
+			profile.MatchedFindingControls = appendUniqueControlRefs(profile.MatchedFindingControls, control)
+		}
+		for _, path := range match.mappingPaths {
+			profile.MatchedFindingControls = appendUniqueControlRefs(profile.MatchedFindingControls, path.Source)
+		}
+		if findingControl != nil {
+			profile.MatchedFindingControls = appendUniqueControlRefs(profile.MatchedFindingControls, *findingControl)
+		}
+		profile.MappingBasis = findingProfileMappingBasis(profile.DirectControls, profile.CatalogMappedControls, match.mappingBasis)
+		matches[match.profileID] = profile
+	}
+	for _, match := range index.byRuleID[strings.TrimSpace(ruleID)] {
+		add(match, nil)
+	}
+	for _, ref := range refs {
+		key := compliance.ControlKey(compliance.ControlRef{
+			FrameworkName: ref.FrameworkName,
+			ControlID:     ref.ControlID,
+		})
+		for _, match := range index.byControlID[key] {
+			matched := ref
+			add(match, &matched)
+		}
+	}
+	profiles := make([]ProfileRef, 0, len(matches))
+	for _, profile := range matches {
+		sort.Slice(profile.MatchedControls, func(i, j int) bool {
+			return controlRefKey(profile.MatchedControls[i]) < controlRefKey(profile.MatchedControls[j])
+		})
+		sort.Slice(profile.DirectControls, func(i, j int) bool {
+			return controlRefKey(profile.DirectControls[i]) < controlRefKey(profile.DirectControls[j])
+		})
+		sort.Slice(profile.CatalogMappedControls, func(i, j int) bool {
+			return controlRefKey(profile.CatalogMappedControls[i]) < controlRefKey(profile.CatalogMappedControls[j])
+		})
+		sort.Slice(profile.MatchedFindingControls, func(i, j int) bool {
+			return controlRefKey(profile.MatchedFindingControls[i]) < controlRefKey(profile.MatchedFindingControls[j])
+		})
+		sort.Slice(profile.MappingPaths, func(i, j int) bool {
+			left := controlRefKey(profile.MappingPaths[i].Source) + "->" + controlRefKey(profile.MappingPaths[i].Target)
+			right := controlRefKey(profile.MappingPaths[j].Source) + "->" + controlRefKey(profile.MappingPaths[j].Target)
+			return left < right
+		})
+		profiles = append(profiles, profile)
+	}
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].ID < profiles[j].ID })
+	return profiles
+}
+
+func appendProfileMatch(matches []findingProfileMatch, candidate findingProfileMatch) []findingProfileMatch {
+	for i := range matches {
+		if matches[i].profileID != candidate.profileID {
+			continue
+		}
+		matches[i].controls = appendUniqueControlRefs(matches[i].controls, candidate.controls...)
+		matches[i].directControls = appendUniqueControlRefs(matches[i].directControls, candidate.directControls...)
+		matches[i].catalogMappedControls = appendUniqueControlRefs(matches[i].catalogMappedControls, candidate.catalogMappedControls...)
+		matches[i].mappingPaths = appendUniqueProfileMappingPaths(matches[i].mappingPaths, candidate.mappingPaths...)
+		matches[i].mappingBasis = findingProfileMappingBasis(matches[i].directControls, matches[i].catalogMappedControls, candidate.mappingBasis)
+		return matches
+	}
+	return append(matches, candidate)
+}
+
+func (index findingProfileIndex) validate() error {
+	if index.version == "" {
+		return fmt.Errorf("coverage index version is required")
+	}
+	if index.contentRevision == "" {
+		return fmt.Errorf("coverage index content revision is required")
+	}
+	if len(index.profiles) == 0 {
+		return fmt.Errorf("at least one profile is required")
+	}
+	for id, profile := range index.profiles {
+		if strings.TrimSpace(profile.Name) == "" {
+			return fmt.Errorf("profile %q name is required", id)
+		}
+	}
+	return nil
+}
+
+func findingProfileMappingBasis(direct, catalog []ControlRef, fallback string) string {
+	switch {
+	case len(direct) != 0 && len(catalog) != 0:
+		return compliance.FindingProfileMappingDirectAndCatalog
+	case len(catalog) != 0:
+		return compliance.FindingProfileMappingCatalog
+	case len(direct) != 0:
+		return compliance.FindingProfileMappingDirect
+	default:
+		return strings.TrimSpace(fallback)
+	}
+}
+
+func appendUniqueProfileMappingPaths(paths []ProfileMappingPath, candidates ...ProfileMappingPath) []ProfileMappingPath {
+	seen := make(map[string]struct{}, len(paths)+len(candidates))
+	for _, path := range paths {
+		seen[controlRefKey(path.Source)+"->"+controlRefKey(path.Target)] = struct{}{}
+	}
+	for _, candidate := range candidates {
+		key := controlRefKey(candidate.Source) + "->" + controlRefKey(candidate.Target)
+		if key == "\x00->\x00" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		paths = append(paths, candidate)
+	}
+	return paths
+}
+
+func complianceControlRefsForGRC(refs []compliance.ControlRef) []ControlRef {
+	result := make([]ControlRef, 0, len(refs))
+	for _, ref := range refs {
+		ref = compliance.NormalizeControlRef(ref)
+		if ref.FrameworkName == "" || ref.ControlID == "" {
+			continue
+		}
+		result = appendUniqueControlRefs(result, ControlRef{
+			FrameworkName: ref.FrameworkName,
+			ControlID:     ref.ControlID,
+		})
+	}
+	return result
+}
+
+func controlRefFromCompliance(ref compliance.ControlRef) ControlRef {
+	ref = compliance.NormalizeControlRef(ref)
+	return ControlRef{FrameworkName: ref.FrameworkName, ControlID: ref.ControlID}
+}
+
+func appendUniqueControlRefs(refs []ControlRef, candidates ...ControlRef) []ControlRef {
+	seen := make(map[string]struct{}, len(refs)+len(candidates))
+	for _, ref := range refs {
+		seen[controlRefKey(ref)] = struct{}{}
+	}
+	for _, ref := range candidates {
+		ref.FrameworkName = strings.TrimSpace(ref.FrameworkName)
+		ref.ControlID = strings.TrimSpace(ref.ControlID)
+		if ref.FrameworkName == "" || ref.ControlID == "" {
+			continue
+		}
+		key := controlRefKey(ref)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func controlRefKey(ref ControlRef) string {
+	return compliance.ControlKey(compliance.ControlRef{
+		FrameworkName: ref.FrameworkName,
+		ControlID:     ref.ControlID,
+	})
+}

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -14,6 +14,13 @@ type FindingControlRef struct {
 	ControlID     string `json:"control_id"`
 }
 
+// FindingProfilePredicate scopes persisted findings to the union of profile
+// rule IDs and profile control references.
+type FindingProfilePredicate struct {
+	RuleIDs     []string
+	ControlRefs []FindingControlRef
+}
+
 // FindingNote captures one analyst note attached to one finding.
 type FindingNote struct {
 	ID        string    `json:"id"`
@@ -123,6 +130,7 @@ type ListFindingsRequest struct {
 	RuntimeIDs          []string
 	FindingID           string
 	RuleID              string
+	ProfilePredicate    FindingProfilePredicate
 	Severity            string
 	Status              string
 	ResourceURN         string

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -33,8 +33,10 @@ const (
 	defaultPageLimit = 1
 	maxPageLimit     = 100
 	defaultListLimit = 100
-	maxListLimit     = 500
-	redactedValue    = "[redacted]"
+	// One internal GRC caller fetches one boundary row to reject oversized
+	// runtime scopes instead of silently omitting the last runtimes.
+	maxListLimit  = 501
+	redactedValue = "[redacted]"
 
 	runtimeProgressConfigHashKey = "__cerebro_resolved_progress_config_hash"
 

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -195,7 +195,9 @@ const findingStatusReasonBackfillCollision findingStatusReason = "backfill_colli
 const (
 	tenantScopedFingerprintBackfillActor = "tenant_scoped_fingerprint_backfill"
 	tenantScopedFingerprintBackfillRunID = "tenant_scoped_fingerprint_backfill"
-	maxFindingListLimit                  = uint32(500)
+	// Profile-filtered GRC reads request one row beyond the public 500-row
+	// boundary so has-more state is exact without a second row query.
+	maxFindingListLimit = uint32(501)
 )
 
 var errTenantScopedFingerprintBackfillRetry = errors.New("retry tenant-scoped fingerprint backfill")
@@ -1416,6 +1418,9 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
 	addFindingFilter(&clauses, &args, "id", request.FindingID)
 	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
+	if err := addFindingProfilePredicate(&clauses, &args, request.ProfilePredicate.RuleIDs, request.ProfilePredicate.ControlRefs); err != nil {
+		return nil, nil, err
+	}
 	addFindingSeverityFilter(&clauses, &args, request.Severity)
 	addFindingFilter(&clauses, &args, "status", request.Status)
 	addFindingFilter(&clauses, &args, "policy_id", request.PolicyID)
@@ -1437,6 +1442,49 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 		return nil, nil, err
 	}
 	return clauses, args, nil
+}
+
+func addFindingProfilePredicate(clauses *[]string, args *[]any, ruleIDs []string, controlRefs []ports.FindingControlRef) error {
+	ruleIDs = normalizedNonEmptyStrings(ruleIDs)
+	sort.Strings(ruleIDs)
+	controls := make([]ports.FindingControlRef, 0, len(controlRefs))
+	seenControls := map[string]struct{}{}
+	for _, ref := range controlRefs {
+		frameworkName := strings.TrimSpace(ref.FrameworkName)
+		controlID := strings.TrimSpace(ref.ControlID)
+		if frameworkName == "" || controlID == "" {
+			continue
+		}
+		key := strings.ToLower(frameworkName) + "\x00" + strings.ToLower(controlID)
+		if _, ok := seenControls[key]; ok {
+			continue
+		}
+		seenControls[key] = struct{}{}
+		controls = append(controls, ports.FindingControlRef{FrameworkName: frameworkName, ControlID: controlID})
+	}
+	if len(ruleIDs) == 0 && len(controls) == 0 {
+		return nil
+	}
+	predicateJSON, err := json.Marshal(struct {
+		RuleIDs     []string                  `json:"rule_ids"`
+		ControlRefs []ports.FindingControlRef `json:"control_refs"`
+	}{RuleIDs: ruleIDs, ControlRefs: controls})
+	if err != nil {
+		return fmt.Errorf("marshal finding profile predicate: %w", err)
+	}
+	*args = append(*args, string(predicateJSON))
+	argument := len(*args)
+	*clauses = append(*clauses, fmt.Sprintf(`(
+  rule_id IN (SELECT jsonb_array_elements_text($%d::jsonb->'rule_ids'))
+  OR EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(COALESCE(control_refs_json, '[]'::jsonb)) AS actual
+    JOIN jsonb_array_elements($%d::jsonb->'control_refs') AS wanted
+      ON LOWER(TRIM(COALESCE(actual->>'framework_name', actual->>'framework_id', ''))) = LOWER(TRIM(wanted->>'framework_name'))
+     AND LOWER(TRIM(COALESCE(actual->>'control_id', ''))) = LOWER(TRIM(wanted->>'control_id'))
+  )
+)`, argument, argument))
+	return nil
 }
 
 func findingListLimit(limit uint32) uint32 {

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -323,6 +323,40 @@ func TestFindingGRCListQueryAvoidsFullPayload(t *testing.T) {
 	}
 }
 
+func TestFindingFilterClausesApplyProfilePredicateBeforeLimit(t *testing.T) {
+	clauses, args, err := findingFilterClauses(ports.ListFindingsRequest{
+		TenantID:   "tenant",
+		RuntimeIDs: []string{"runtime-alpha"},
+		ProfilePredicate: ports.FindingProfilePredicate{
+			RuleIDs: []string{"rule-b", "rule-a", "rule-a"},
+			ControlRefs: []ports.FindingControlRef{
+				{FrameworkName: "SOC 2", ControlID: "CC6.1"},
+				{FrameworkName: "soc 2", ControlID: "cc6.1"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("findingFilterClauses() error = %v", err)
+	}
+	query := strings.Join(clauses, " AND ")
+	for _, fragment := range []string{
+		"rule_id IN (SELECT jsonb_array_elements_text($3::jsonb->'rule_ids'))",
+		"jsonb_array_elements(COALESCE(control_refs_json, '[]'::jsonb)) AS actual",
+		"jsonb_array_elements($3::jsonb->'control_refs') AS wanted",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("profile predicate missing %q in %s", fragment, query)
+		}
+	}
+	if len(args) != 3 {
+		t.Fatalf("len(args) = %d, want 3", len(args))
+	}
+	payload, ok := args[2].(string)
+	if !ok || strings.Count(payload, "framework_name") != 1 || !strings.Contains(payload, `"rule_ids":["rule-a","rule-b"]`) {
+		t.Fatalf("profile predicate payload = %#v, want normalized selectors", args[2])
+	}
+}
+
 func TestFindingFilterClausesSupportTrendDrilldownFilters(t *testing.T) {
 	openedAfter := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
 	openedBefore := openedAfter.AddDate(0, 0, 7)


### PR DESCRIPTION
## Summary

- apply built-in compliance profile predicates before ordering and pagination
- separate finding page size from source-runtime enumeration and return explicit truncation state
- expose profile controls, finding controls, mapping basis, serving-index revision, and result boundaries
- carry the same context into finding CSV exports and custom control-packet responses
- add the finding catalog, HTTP, store, and OpenAPI contracts for profile-filtered reads

## Dependency

#1823 provides the generated serving index and governed mapping inputs. This PR will retarget `main` after that change lands.

## Validation

- focused Go tests for bootstrap, GRC catalogs and packets, finding reads, source runtime, and Postgres
- `make openapi-check openapi-lint`
- `make check-structural check-structural-test check-arch`
- `make docs-drift-check`
- `make oss-audit`
- `make droid-review-preflight`