### PR TITLE
Fix release deployment credential fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,31 @@ jobs:
           - target_environment: go-prod
             apply_mode: pull_request
     steps:
+      - name: Check Infisical bootstrap
+        id: infisical
+        shell: bash
+        env:
+          INFISICAL_ORG_IDENTITY_UUID: ${{ secrets.INFISICAL_ORG_IDENTITY_UUID }}
+          INFISICAL_ORG_PROJECT_SLUG: ${{ secrets.INFISICAL_ORG_PROJECT_SLUG }}
+          INFISICAL_REPO_IDENTITY_UUID: ${{ secrets.INFISICAL_REPO_IDENTITY_UUID }}
+          INFISICAL_REPO_PROJECT_SLUG: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for key in INFISICAL_ORG_IDENTITY_UUID INFISICAL_ORG_PROJECT_SLUG INFISICAL_REPO_IDENTITY_UUID INFISICAL_REPO_PROJECT_SLUG; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("${key}")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Deployment credential bootstrap is incomplete; using the repository fallback."
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
       - name: Fetch org-level secrets from Infisical
+        if: steps.infisical.outputs.configured == 'true'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc
@@ -333,6 +357,7 @@ jobs:
           env-slug: prod
           export-type: env
       - name: Fetch repo-level secrets from Infisical
+        if: steps.infisical.outputs.configured == 'true'
         uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -91,6 +91,8 @@ func TestReleaseWorkflowKeepsCIParityAndStableLatestGuard(t *testing.T) {
 		"target_environment: go-prod",
 		"apply_mode: pull_request",
 		"TARGET_ENVIRONMENT: ${{ matrix.target_environment }}",
+		"name: Check Infisical bootstrap",
+		`echo "configured=false" >> "$GITHUB_OUTPUT"`,
 		`payload_keys="$(jq '.client_payload | length' <<<"${payload}")"`,
 		"GitHub allows at most 10",
 		`gh api --method POST "repos/${INFRA_REPOSITORY}/dispatches" --input - <<<"${payload}"`,
@@ -127,6 +129,20 @@ func TestReleaseWorkflowKeepsCIParityAndStableLatestGuard(t *testing.T) {
 	matrixIndex := strings.Index(release, "target_environment: sec-dev")
 	if dispatchIndex == -1 || matrixIndex == -1 || matrixIndex > dispatchIndex {
 		t.Fatal("release workflow must fan out infra dispatches before the dispatch step")
+	}
+	orgSecretsIndex := strings.Index(release, "name: Fetch org-level secrets from Infisical")
+	repoSecretsIndex := strings.Index(release, "name: Fetch repo-level secrets from Infisical")
+	bootstrapIndex := strings.Index(release, "name: Check Infisical bootstrap")
+	if bootstrapIndex == -1 || orgSecretsIndex == -1 || repoSecretsIndex == -1 || bootstrapIndex > orgSecretsIndex || orgSecretsIndex > repoSecretsIndex {
+		t.Fatal("release workflow must check Infisical bootstrap before fetching deployment credentials")
+	}
+	for name, section := range map[string]string{
+		"org":  release[orgSecretsIndex:repoSecretsIndex],
+		"repo": release[repoSecretsIndex:dispatchIndex],
+	} {
+		if !strings.Contains(section, "if: steps.infisical.outputs.configured == 'true'") {
+			t.Fatalf("release workflow must guard %s secret fetch behind the bootstrap check", name)
+		}
 	}
 
 	makefile, err := os.ReadFile(filepath.Join(root, "Makefile"))

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -133,8 +133,8 @@ func TestReleaseWorkflowKeepsCIParityAndStableLatestGuard(t *testing.T) {
 	orgSecretsIndex := strings.Index(release, "name: Fetch org-level secrets from Infisical")
 	repoSecretsIndex := strings.Index(release, "name: Fetch repo-level secrets from Infisical")
 	bootstrapIndex := strings.Index(release, "name: Check Infisical bootstrap")
-	if bootstrapIndex == -1 || orgSecretsIndex == -1 || repoSecretsIndex == -1 || bootstrapIndex > orgSecretsIndex || orgSecretsIndex > repoSecretsIndex {
-		t.Fatal("release workflow must check Infisical bootstrap before fetching deployment credentials")
+	if bootstrapIndex == -1 || orgSecretsIndex == -1 || repoSecretsIndex == -1 || bootstrapIndex > orgSecretsIndex || orgSecretsIndex > repoSecretsIndex || repoSecretsIndex > dispatchIndex {
+		t.Fatal("release workflow must check Infisical bootstrap before fetching deployment credentials and dispatching the release")
 	}
 	for name, section := range map[string]string{
 		"org":  release[orgSecretsIndex:repoSecretsIndex],


### PR DESCRIPTION
## Summary

- check whether the optional external credential bootstrap is complete before loading release credentials
- preserve the existing repository fallback when that bootstrap is unavailable
- add a structural regression test for both guarded credential-loading steps

## Validation

- `go test ./tools/archtests -run TestReleaseWorkflowKeepsCIParityAndStableLatestGuard -count=1`
- `actionlint .github/workflows/release.yml`
