### PR TITLE
Serialize stable release workflows

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -16,7 +16,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: cut-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || 'main' }}
+  group: stable-release-tag-reservation
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
   attestations: write
 
 concurrency:
-  group: release-${{ inputs.release_tag }}
+  group: stable-release-publication
   cancel-in-progress: false
 
 jobs:

--- a/scripts/tests/test_release_workflow_serialization.py
+++ b/scripts/tests/test_release_workflow_serialization.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+CUT_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "cut-release.yml"
+
+
+class ReleaseWorkflowSerializationTest(unittest.TestCase):
+    def test_release_publication_is_serialized_across_tags(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("group: stable-release-publication", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertNotIn("group: release-${{ inputs.release_tag }}", workflow)
+
+    def test_release_tag_reservation_is_serialized_across_triggers(self) -> None:
+        workflow = CUT_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("group: stable-release-tag-reservation", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertNotIn("group: cut-release-${{", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Serialize stable tag reservation across workflow triggers.
- Serialize release publication across release tags.
- Keep active release work running when another release is requested.
- Add workflow contract tests for the shared concurrency groups.

## Validation

- `make script-test` — 109 passed
- `actionlint`