### PR TITLE
Reduce GRC response payloads and query fan-out

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1432,6 +1432,11 @@ paths:
           in: query
           schema:
             type: string
+        - name: runtime_ids
+          in: query
+          schema:
+            type: string
+          description: Comma-separated runtime IDs.
         - name: tenant_id
           in: query
           schema:
@@ -1440,6 +1445,8 @@ paths:
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/responseViewQuery'
+        - $ref: '#/components/parameters/coverageScopeQuery'
         - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':
@@ -2309,6 +2316,8 @@ paths:
         - $ref: '#/components/parameters/runtimeIDQuery'
         - $ref: '#/components/parameters/sourceIDQuery'
         - $ref: '#/components/parameters/limitQuery'
+        - $ref: '#/components/parameters/responseViewQuery'
+        - $ref: '#/components/parameters/coverageScopeQuery'
       responses:
         '200':
           description: GRC dashboard summary, priority findings, controls, evidence, and connector health.
@@ -2326,6 +2335,8 @@ paths:
         - $ref: '#/components/parameters/runtimeIDQuery'
         - $ref: '#/components/parameters/sourceIDQuery'
         - $ref: '#/components/parameters/limitQuery'
+        - $ref: '#/components/parameters/responseViewQuery'
+        - $ref: '#/components/parameters/coverageScopeQuery'
         - name: profile
           in: query
           schema:
@@ -4832,6 +4843,8 @@ paths:
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/responseViewQuery'
+        - $ref: '#/components/parameters/coverageScopeQuery'
         - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':
@@ -5635,13 +5648,39 @@ paths:
           schema:
             type: string
           description: Optional connector/source identifier to scope the report.
+        - $ref: '#/components/parameters/coverageScopeQuery'
+        - name: coverage_view
+          in: query
+          schema:
+            type: string
+            enum: [summary, page]
+          description: Pass summary for aggregate counts or page for bounded coverage records. Omit for the complete report.
+        - name: page_size
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+          description: Coverage records returned when coverage_view is page. Defaults to 100.
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          description: Cursor from the previous coverage page.
+        - name: blind_spots_only
+          in: query
+          schema:
+            type: boolean
+          description: Return only blind-spot records when coverage_view is page.
       responses:
         '200':
           description: Tenant-scoped connector coverage report with per-dimension state, summaries, and blind spots.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConnectorCoverageResponse'
+                oneOf:
+                  - $ref: '#/components/schemas/ConnectorCoverageResponse'
+                  - $ref: '#/components/schemas/ConnectorCoveragePageResponse'
   /platform/graph/provenance:
     get:
       summary: Explain graph entity projection provenance
@@ -5994,6 +6033,20 @@ components:
       in: query
       schema:
         type: string
+    responseViewQuery:
+      name: view
+      in: query
+      schema:
+        type: string
+        enum: [summary]
+      description: Pass summary to omit per-dimension coverage records while retaining aggregate counts. Omit for the expanded response.
+    coverageScopeQuery:
+      name: coverage_scope
+      in: query
+      schema:
+        type: string
+        enum: [catalog, configured]
+      description: Use configured for sources with a visible runtime or catalog for every registered source. Summary responses default to configured; expanded responses default to catalog.
     inventorySurfaceQuery:
       name: surface
       in: query
@@ -11183,6 +11236,27 @@ components:
           properties:
             nhi_coverage:
               $ref: '#/components/schemas/NHICoverageReport'
+    ConnectorCoveragePageResponse:
+      allOf:
+        - $ref: '#/components/schemas/ConnectorCoverageResponse'
+        - type: object
+          required: [page]
+          properties:
+            page:
+              type: object
+              required: [page_size, returned, total]
+              properties:
+                page_size:
+                  type: integer
+                  minimum: 1
+                returned:
+                  type: integer
+                  minimum: 0
+                total:
+                  type: integer
+                  minimum: 0
+                next_cursor:
+                  type: string
     SourceCoverageReport:
       type: object
       properties:

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -52,6 +52,7 @@ import (
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	httpcompression "github.com/writer/cerebro/internal/sourcehttp/compression"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceprojection"
 	"github.com/writer/cerebro/internal/sourceruntime"
@@ -255,12 +256,12 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	mux := http.NewServeMux()
 	app.mux = mux
 	app.registerRoutes(mux, cfg, deps, sources)
-	app.handler = observability.Middleware(rateLimitMiddleware(cfg.RateLimit, cfg.Auth.RequestOrigin)(authMiddleware(cfg.Auth, AuthDependencies{
+	app.handler = observability.Middleware(httpcompression.Middleware(rateLimitMiddleware(cfg.RateLimit, cfg.Auth.RequestOrigin)(authMiddleware(cfg.Auth, AuthDependencies{
 		DeviceVerifier: app.deviceVerifier,
 		DPoPVerifier:   app.dpopVerifier,
 		RiskScorer:     app.riskScorer,
 		Observations:   app.observationStore,
-	}, mux)))
+	}, mux))))
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           app.handler,

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1548,6 +1548,18 @@ func (s *stubRuntimeStore) ListFindingEvaluationRuns(_ context.Context, request 
 			return left.GetStartedAt().AsTime().After(right.GetStartedAt().AsTime())
 		}
 	})
+	if request.LatestByRuntime {
+		latest := make([]*cerebrov1.FindingEvaluationRun, 0, len(runs))
+		seen := map[string]struct{}{}
+		for _, run := range runs {
+			if _, ok := seen[run.GetRuntimeId()]; ok {
+				continue
+			}
+			seen[run.GetRuntimeId()] = struct{}{}
+			latest = append(latest, run)
+		}
+		runs = latest
+	}
 	if request.Limit != 0 && len(runs) > int(request.Limit) {
 		runs = runs[:int(request.Limit)]
 	}
@@ -1726,7 +1738,8 @@ func (s *stubGraphStore) ListIngestRuns(_ context.Context, filter graphstore.Ing
 	s.ingestRunListFilter = filter
 	runs := make([]graphstore.IngestRun, 0, len(s.ingestRuns))
 	for _, run := range s.ingestRuns {
-		if filter.RuntimeID != "" && run.RuntimeID != filter.RuntimeID {
+		runtimeIDs := normalizedTestStrings(append(filter.RuntimeIDs, filter.RuntimeID))
+		if len(runtimeIDs) != 0 && !containsTrimmed(runtimeIDs, run.RuntimeID) {
 			continue
 		}
 		if filter.Status != "" && run.Status != filter.Status {
@@ -1742,6 +1755,18 @@ func (s *stubGraphStore) ListIngestRuns(_ context.Context, filter graphstore.Ing
 		}
 		return left.StartedAt > right.StartedAt
 	})
+	if filter.LatestByRuntime {
+		latest := make([]graphstore.IngestRun, 0, len(runs))
+		seen := map[string]struct{}{}
+		for _, run := range runs {
+			if _, ok := seen[run.RuntimeID]; ok {
+				continue
+			}
+			seen[run.RuntimeID] = struct{}{}
+			latest = append(latest, run)
+		}
+		runs = latest
+	}
 	if filter.Limit > 0 && len(runs) > filter.Limit {
 		runs = runs[:filter.Limit]
 	}
@@ -8475,7 +8500,8 @@ func findingEvaluationRunMatches(request ports.ListFindingEvaluationRunsRequest,
 	if run == nil {
 		return false
 	}
-	if strings.TrimSpace(run.GetRuntimeId()) != strings.TrimSpace(request.RuntimeID) {
+	runtimeIDs := normalizedTestStrings(append(request.RuntimeIDs, request.RuntimeID))
+	if len(runtimeIDs) == 0 || !containsTrimmed(runtimeIDs, run.GetRuntimeId()) {
 		return false
 	}
 	if request.RuleID != "" && strings.TrimSpace(run.GetRuleId()) != strings.TrimSpace(request.RuleID) {

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -100,11 +100,13 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 		deps.QueryCache = querycache.NewMemory(querycache.Options{
 			Namespace:       cfg.Cache.Namespace,
 			MaxPayloadBytes: cfg.Cache.MaxPayloadBytes,
+			MaxEntries:      cfg.Cache.MaxEntries,
 		})
 	case config.CacheDriverRedis, config.CacheDriverValkey:
 		cache, err := querycache.OpenRedis(cfg.Cache.URL, querycache.Options{
 			Namespace:       cfg.Cache.Namespace,
 			MaxPayloadBytes: cfg.Cache.MaxPayloadBytes,
+			MaxEntries:      cfg.Cache.MaxEntries,
 		})
 		if err != nil {
 			return fail(fmt.Errorf("open query cache: %w", err))

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	questionnairehttp "github.com/writer/cerebro/internal/sourcehttp/questionnaire"
+	"github.com/writer/cerebro/internal/sourcehttp/responseview"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
 	"golang.org/x/sync/errgroup"
@@ -112,6 +113,20 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		telemetry.AnnotateMainPhase(dashboardCtx, "grc.dashboard", status, endAttrs)
 		telemetry.End(span, status, endAttrs)
 	}()
+	view, err := responseview.FromRequest(r)
+	if err != nil {
+		statusCode = http.StatusBadRequest
+		status, endAttrs = grcTelemetryError(endAttrs, err)
+		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
+		return
+	}
+	coverageScope, err := responseview.CoverageScopeFromRequest(r, view)
+	if err != nil {
+		statusCode = http.StatusBadRequest
+		status, endAttrs = grcTelemetryError(endAttrs, err)
+		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
+		return
+	}
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
 		statusCode = grcHTTPStatusCode(err)
@@ -220,8 +235,14 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	coverage := a.sourceCoverageRecords(runtimes, ports.SourceRuntimeFilter{RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID, SourceID: scope.SourceID, Limit: scope.Limit}, generatedAt)
+	coverage := a.sourceCoverageRecordsScoped(runtimes, ports.SourceRuntimeFilter{RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID, SourceID: scope.SourceID, Limit: scope.Limit}, generatedAt, coverageScope)
 	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
+	serializedCoverageBlindSpots := coverageBlindSpots
+	productAreas := grcproductareas.BuildCoverageViews(coverage)
+	if view == responseview.Summary {
+		serializedCoverageBlindSpots = nil
+		productAreas = responseview.CompactProductAreas(productAreas)
+	}
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "runtime_count", Value: len(runtimes)})
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "finding_count", Value: len(findingItems)})
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "evidence_count", Value: len(evidenceItems)})
@@ -232,9 +253,9 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		Evidence:           grcLimitEvidence(evidenceItems, 25),
 		Connectors:         grcConnectorItems(runtimes),
 		SourceSummaries:    sourceSummaries,
-		CoverageBlindSpots: coverageBlindSpots,
+		CoverageBlindSpots: serializedCoverageBlindSpots,
 		CoverageSummaries:  sourcecoverage.Summaries(coverage),
-		ProductAreas:       grcproductareas.BuildCoverageViews(coverage),
+		ProductAreas:       productAreas,
 		GeneratedAt:        generatedAt,
 	})
 }

--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/querycache"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const (
@@ -75,8 +76,8 @@ func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.Ha
 					return captureHTTPResponse(next, r), nil
 				})
 				if refreshErr == nil && response.cacheableJSON() {
-					_ = cache.Set(r.Context(), key, response.body.Bytes(), policy.TTL, policy.StaleTTL)
-					response.writeTo(w, "miss", policy)
+					setErr := cache.Set(r.Context(), key, response.body.Bytes(), policy.TTL, policy.StaleTTL)
+					response.writeTo(w, queryCacheWriteState(r.Context(), setErr), policy)
 					return
 				}
 				if refreshErr != nil || response == nil || response.statusCode >= http.StatusInternalServerError {
@@ -101,12 +102,24 @@ func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.Ha
 			return
 		}
 		if response.cacheableJSON() {
-			_ = cache.Set(r.Context(), key, response.body.Bytes(), policy.TTL, policy.StaleTTL)
-			response.writeTo(w, "miss", policy)
+			setErr := cache.Set(r.Context(), key, response.body.Bytes(), policy.TTL, policy.StaleTTL)
+			response.writeTo(w, queryCacheWriteState(r.Context(), setErr), policy)
 			return
 		}
 		response.writeTo(w, "bypass", policy)
 	}
+}
+
+func queryCacheWriteState(ctx context.Context, err error) string {
+	if err == nil {
+		return "miss"
+	}
+	if errors.Is(err, querycache.ErrPayloadTooLarge) {
+		telemetry.IncrementMain(ctx, "query_cache.payload_too_large.count", 1)
+		return "skip"
+	}
+	telemetry.IncrementMain(ctx, "query_cache.write_error.count", 1)
+	return "bypass"
 }
 
 func (a *App) grcCachePolicy(family string, ttl time.Duration, scopes ...string) grcCachePolicy {
@@ -318,7 +331,7 @@ func copyHeaders(dst http.Header, src http.Header) {
 func setGRCQueryCacheHeaders(header http.Header, cacheState string, policy grcCachePolicy) {
 	header.Set("X-Cerebro-Cache", cacheState)
 	header.Set("Vary", appendVary(header.Get("Vary"), "Authorization", "X-Cerebro-API-Key", "X-Cerebro-Tenant"))
-	if cacheState != "bypass" && policy.TTL > 0 {
+	if (cacheState == "hit" || cacheState == "miss" || cacheState == "stale") && policy.TTL > 0 {
 		maxAge := int(policy.TTL / time.Second)
 		if maxAge < 1 {
 			maxAge = 1

--- a/internal/bootstrap/grc_cache_test.go
+++ b/internal/bootstrap/grc_cache_test.go
@@ -124,6 +124,34 @@ func TestGRCQueryCacheDoesNotEmitCacheControlForErrorResponse(t *testing.T) {
 	}
 }
 
+func TestGRCQueryCacheReportsOversizedResponseWithoutClientCacheHeaders(t *testing.T) {
+	app := &App{
+		cfg: config.Config{Cache: config.CacheConfig{DefaultTTL: time.Minute, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{
+			Namespace:       "test",
+			MaxPayloadBytes: 10,
+		})},
+	}
+	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Minute), func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"payload": "larger than ten bytes"})
+	})
+
+	first := httptest.NewRecorder()
+	handler(first, httptest.NewRequest(http.MethodGet, "/grc/dashboard", nil))
+	second := httptest.NewRecorder()
+	handler(second, httptest.NewRequest(http.MethodGet, "/grc/dashboard", nil))
+
+	if got := first.Header().Get("X-Cerebro-Cache"); got != "skip" {
+		t.Fatalf("first X-Cerebro-Cache = %q, want skip", got)
+	}
+	if got := first.Header().Get("Cache-Control"); got != "" {
+		t.Fatalf("first Cache-Control = %q, want empty", got)
+	}
+	if got := second.Header().Get("X-Cerebro-Cache"); got != "skip" {
+		t.Fatalf("second X-Cerebro-Cache = %q, want skip", got)
+	}
+}
+
 func TestGRCQueryCacheServesStaleOnRefreshError(t *testing.T) {
 	app := &App{
 		cfg:  config.Config{Cache: config.CacheConfig{DefaultTTL: time.Millisecond, StaleTTL: time.Minute}},

--- a/internal/bootstrap/grc_program_readiness.go
+++ b/internal/bootstrap/grc_program_readiness.go
@@ -1,12 +1,14 @@
 package bootstrap
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/writer/cerebro/internal/grcprogram"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecoverage"
+	"github.com/writer/cerebro/internal/sourcehttp/responseview"
 )
 
 type grcProgramReadinessResponse struct {
@@ -17,6 +19,16 @@ type grcProgramReadinessResponse struct {
 }
 
 func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) {
+	view, err := responseview.FromRequest(r)
+	if err != nil {
+		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
+		return
+	}
+	coverageScope, err := responseview.CoverageScopeFromRequest(r, view)
+	if err != nil {
+		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
+		return
+	}
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
 		writeGRCError(w, err)
@@ -38,13 +50,13 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 		writeGRCError(w, err)
 		return
 	}
-	coverage := a.sourceCoverageRecords(runtimes, ports.SourceRuntimeFilter{
+	coverage := a.sourceCoverageRecordsScoped(runtimes, ports.SourceRuntimeFilter{
 		RuntimeID:  scope.RuntimeID,
 		RuntimeIDs: scope.RuntimeIDs,
 		TenantID:   scope.TenantID,
 		SourceID:   scope.SourceID,
 		Limit:      scope.Limit,
-	}, generatedAt)
+	}, generatedAt, coverageScope)
 	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
 	readiness := grcprogram.Build(grcprogram.BuildInput{
 		Result:             result,
@@ -55,10 +67,15 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 		CoverageRecords:    coverage,
 		GeneratedAt:        generatedAt,
 	})
+	serializedCoverageBlindSpots := coverageBlindSpots
+	if view == responseview.Summary {
+		serializedCoverageBlindSpots = nil
+		readiness.ProductAreas = responseview.CompactProductAreas(readiness.ProductAreas)
+	}
 	writeJSON(w, http.StatusOK, grcProgramReadinessResponse{
 		Readiness:          readiness,
 		SourceSummaries:    sourceSummaries,
-		CoverageBlindSpots: coverageBlindSpots,
+		CoverageBlindSpots: serializedCoverageBlindSpots,
 		CoverageSummaries:  sourcecoverage.Summaries(coverage),
 	})
 }

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -230,7 +230,7 @@ func (app *App) registerConnectorRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /credential-stores", routeSurfacePlatformHTTP, credentialStores.List)
 	registerHTTPRoute(mux, "GET /credential-stores/{storeID}", routeSurfacePlatformHTTP, credentialStores.Get)
 	registerHTTPRoute(mux, "GET /connectors", routeSurfacePlatformHTTP, app.handleListConnectors)
-	registerHTTPRoute(mux, "GET /connectors/coverage", routeSurfacePlatformHTTP, app.handleGetConnectorCoverage)
+	registerHTTPRoute(mux, "GET /connectors/coverage", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("connector.coverage", time.Minute, grcCacheScopeRuntime), app.handleGetConnectorCoverage))
 	registerHTTPRoute(mux, "GET /connectors/credential-key", routeSurfacePlatformHTTP, app.handleConnectorCredentialKey)
 	registerHTTPRoute(mux, "GET /connector-definitions", routeSurfacePlatformHTTP, app.handleListConnectorDefinitions)
 	registerHTTPRoute(mux, "POST /connector-definitions", routeSurfacePlatformHTTP, app.handleCreateConnectorDefinition)
@@ -282,7 +282,7 @@ func (app *App) registerKnowledgeRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /platform/workflow/replay", routeSurfacePlatformHTTP, app.handleReplayWorkflowEvents)
 }
 func (app *App) registerGraphRoutes(mux *http.ServeMux) {
-	registerHTTPRoute(mux, "GET /platform/runtime-freshness", routeSurfacePlatformHTTP, app.handleListRuntimeFreshness)
+	registerHTTPRoute(mux, "GET /platform/runtime-freshness", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("runtime.freshness", 30*time.Second, grcCacheScopeRuntime, grcCacheScopeGraph, grcCacheScopeFindings), app.handleListRuntimeFreshness))
 	registerHTTPRoute(mux, "GET /platform/graph/neighborhood", routeSurfacePlatformHTTP, app.handleGetEntityNeighborhood)
 	registerHTTPRoute(mux, "POST /platform/graph/actions", routeSurfacePlatformHTTP, app.handleExecuteGraphAction)
 	registerHTTPRoute(mux, "POST /platform/graph/actions/reconcile", routeSurfacePlatformHTTP, app.handleReconcileGraphAction)
@@ -314,7 +314,7 @@ func (app *App) registerRuntimeResponseRoutes(mux *http.ServeMux) {
 }
 func (app *App) registerSourceRuntimeRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /source-runtimes", routeSurfacePlatformHTTP, app.handleListSourceRuntimes)
-	registerHTTPRoute(mux, "GET /source-runtimes/health", routeSurfacePlatformHTTP, app.handleListSourceRuntimeHealth)
+	registerHTTPRoute(mux, "GET /source-runtimes/health", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("runtime.health", 30*time.Second, grcCacheScopeRuntime, grcCacheScopeGraph, grcCacheScopeFindings), app.handleListSourceRuntimeHealth))
 	registerHTTPRoute(mux, "PUT /source-runtimes/{runtimeID}", routeSurfacePlatformHTTP, app.handlePutSourceRuntime)
 	registerHTTPRoute(mux, "GET /source-runtimes/{runtimeID}", routeSurfacePlatformHTTP, app.handleGetSourceRuntime)
 	registerHTTPRoute(mux, "POST /source-runtimes/{runtimeID}/sync", routeSurfacePlatformHTTP, app.handleSyncSourceRuntime)

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -15,14 +15,14 @@ import (
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/nhicoverage"
 	"github.com/writer/cerebro/internal/ports"
-	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourcehealth"
 	"github.com/writer/cerebro/internal/sourcehealthview"
+	"github.com/writer/cerebro/internal/sourcehttp/coverageview"
+	"github.com/writer/cerebro/internal/sourcehttp/responseview"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type sourceRuntimeHealthResponse struct {
@@ -31,6 +31,8 @@ type sourceRuntimeHealthResponse struct {
 	SourceSummaries []sourceRuntimeHealthSummary `json:"source_summaries"`
 	Coverage        []sourcecoverage.Record      `json:"coverage,omitempty"`
 	CoverageSummary []sourcecoverage.Summary     `json:"coverage_summaries,omitempty"`
+	view            responseview.View
+	coverageRecords []sourcecoverage.Record
 }
 type runtimeFreshnessResponse struct {
 	GeneratedAt          string                    `json:"generated_at"`
@@ -123,7 +125,6 @@ type sourceRuntimeHealthSummary struct {
 }
 
 type sourceRuntimeHealthRecord = sourcehealthview.Record
-type sourceRuntimeHealthSync = sourcehealthview.Sync
 type sourceRuntimeHealthGraphRun = sourcehealthview.GraphRun
 type sourceRuntimeHealthFindingEvaluation = sourcehealthview.FindingEvaluation
 
@@ -143,8 +144,6 @@ const (
 	runtimeLastInvalidOccurredAtConfigKey = "__cerebro_runtime_last_invalid_occurred_at"
 	runtimeLastInvalidDiagnosticConfigKey = "__cerebro_runtime_last_invalid_diagnostic"
 	runtimeLastInvalidRetryableConfigKey  = "__cerebro_runtime_last_invalid_retryable"
-
-	sourceRuntimeHealthRecordConcurrency = 8
 )
 
 func (a *App) handleListSourceRuntimeHealth(w http.ResponseWriter, r *http.Request) {
@@ -170,11 +169,41 @@ func (a *App) handleGetConnectorCoverage(w http.ResponseWriter, r *http.Request)
 		writeSourceRuntimeError(w, err)
 		return
 	}
-	report := sourcecoverage.BuildScopedReport(health.Coverage, r.URL.Query().Get("tenant_id"), r.URL.Query().Get("source_id"), health.GeneratedAt)
+	coverage := health.coverageRecords
+	if coverage == nil {
+		coverage = health.Coverage
+	}
+	report := sourcecoverage.BuildScopedReport(coverage, r.URL.Query().Get("tenant_id"), r.URL.Query().Get("source_id"), health.GeneratedAt)
 	emitSourceCoverageGateTelemetry(r.Context(), report)
-	writeJSON(w, http.StatusOK, nhicoverage.WithSourceCoverage(report))
+	response := nhicoverage.WithSourceCoverage(report)
+	view, err := coverageview.FromRequest(r)
+	if err != nil {
+		writeSourceRuntimeError(w, errors.Join(sourceruntime.ErrInvalidRequest, err))
+		return
+	}
+	switch view {
+	case coverageview.Expanded:
+		writeJSON(w, http.StatusOK, response)
+	case coverageview.Summary:
+		writeJSON(w, http.StatusOK, coverageview.Compact(response))
+	case coverageview.Page:
+		page, err := coverageview.Paginate(r, response, report.Records)
+		if err != nil {
+			writeSourceRuntimeError(w, errors.Join(sourceruntime.ErrInvalidRequest, err))
+			return
+		}
+		writeJSON(w, http.StatusOK, page)
+	}
 }
 func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthResponse, error) {
+	view, err := responseview.FromRequest(r)
+	if err != nil {
+		return sourceRuntimeHealthResponse{}, errors.Join(sourceruntime.ErrInvalidRequest, err)
+	}
+	coverageScope, err := responseview.CoverageScopeFromRequest(r, view)
+	if err != nil {
+		return sourceRuntimeHealthResponse{}, errors.Join(sourceruntime.ErrInvalidRequest, err)
+	}
 	limit, err := uint32QueryParam(r, "limit")
 	if err != nil {
 		return sourceRuntimeHealthResponse{}, err
@@ -247,13 +276,19 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 	if err != nil {
 		return sourceRuntimeHealthResponse{}, err
 	}
-	coverage := a.sourceCoverageRecords(visibleRuntimes, filter, generatedAt)
+	coverage := a.sourceCoverageRecordsScoped(visibleRuntimes, filter, generatedAt, coverageScope)
+	serializedCoverage := coverage
+	if view == responseview.Summary {
+		serializedCoverage = nil
+	}
 	return sourceRuntimeHealthResponse{
 		GeneratedAt:     generatedAt.Format(time.RFC3339Nano),
 		Runtimes:        records,
 		SourceSummaries: sourceRuntimeHealthSummaries(records),
-		Coverage:        coverage,
+		Coverage:        serializedCoverage,
 		CoverageSummary: sourcecoverage.Summaries(coverage),
+		view:            view,
+		coverageRecords: coverage,
 	}, nil
 }
 
@@ -277,22 +312,52 @@ func runtimeFreshnessFromHealth(health sourceRuntimeHealthResponse) runtimeFresh
 			break
 		}
 	}
-	blindSpots := sourcecoverage.BlindSpots(health.Coverage)
+	coverage := health.coverageRecords
+	if coverage == nil {
+		coverage = health.Coverage
+	}
+	blindSpots := sourcecoverage.BlindSpots(coverage)
+	serializedBlindSpots := blindSpots
+	if health.view == responseview.Summary {
+		serializedBlindSpots = nil
+	}
 	return runtimeFreshnessResponse{
 		GeneratedAt:          health.GeneratedAt,
 		Status:               status,
 		Runtimes:             records,
 		Summaries:            runtimeFreshnessSummaries(records),
-		CoverageBlindSpots:   blindSpots,
+		CoverageBlindSpots:   serializedBlindSpots,
 		CoverageBlindSummary: sourcecoverage.Summaries(blindSpots),
 	}
 }
 
 func (a *App) sourceCoverageRecords(runtimes []*cerebrov1.SourceRuntime, filter ports.SourceRuntimeFilter, generatedAt time.Time) []sourcecoverage.Record {
+	return a.sourceCoverageRecordsScoped(runtimes, filter, generatedAt, responseview.CoverageCatalog)
+}
+
+func (a *App) sourceCoverageRecordsScoped(runtimes []*cerebrov1.SourceRuntime, filter ports.SourceRuntimeFilter, generatedAt time.Time, scope responseview.CoverageScope) []sourcecoverage.Record {
 	if a == nil || a.sources == nil {
 		return nil
 	}
 	contracts := sourcecoverage.ContractsFromRegistry(a.sources)
+	if scope == responseview.CoverageConfigured {
+		configuredSources := make(map[string]struct{}, len(runtimes))
+		for _, runtime := range runtimes {
+			if runtime == nil {
+				continue
+			}
+			if sourceID := strings.TrimSpace(runtime.GetSourceId()); sourceID != "" {
+				configuredSources[sourceID] = struct{}{}
+			}
+		}
+		configuredContracts := contracts[:0]
+		for _, contract := range contracts {
+			if _, ok := configuredSources[strings.TrimSpace(contract.SourceID)]; ok {
+				configuredContracts = append(configuredContracts, contract)
+			}
+		}
+		contracts = configuredContracts
+	}
 	if len(contracts) == 0 {
 		return nil
 	}
@@ -533,99 +598,49 @@ func sourceRuntimeGraphState(record sourceRuntimeHealthRecord) string {
 
 func (a *App) sourceRuntimeHealthRecords(ctx context.Context, runtimes []*cerebrov1.SourceRuntime, generatedAt time.Time) ([]sourceRuntimeHealthRecord, error) {
 	visibleRuntimes := make([]*cerebrov1.SourceRuntime, 0, len(runtimes))
+	runtimeIDs := make([]string, 0, len(runtimes))
 	for _, runtime := range runtimes {
 		if runtime != nil {
 			visibleRuntimes = append(visibleRuntimes, runtime)
+			runtimeIDs = append(runtimeIDs, strings.TrimSpace(runtime.GetId()))
 		}
 	}
-	records := make([]sourceRuntimeHealthRecord, len(visibleRuntimes))
+	var graphRuns map[string]*graphstore.IngestRun
+	var findingRuns map[string]*cerebrov1.FindingEvaluationRun
 	group, groupCtx := errgroup.WithContext(ctx)
-	group.SetLimit(sourceRuntimeHealthRecordConcurrency)
-	for index, runtime := range visibleRuntimes {
-		index, runtime := index, runtime
-		group.Go(func() error {
-			record, err := a.sourceRuntimeHealthRecord(groupCtx, runtime, generatedAt)
-			if err != nil {
-				return err
-			}
-			records[index] = record
+	group.Go(func() error {
+		runStore, ok := a.deps.GraphStore.(graphingest.RunStore)
+		if !ok || isNilInterface(runStore) {
+			graphRuns = map[string]*graphstore.IngestRun{}
 			return nil
-		})
-	}
+		}
+		var loadErr error
+		graphRuns, loadErr = sourcehealth.LatestGraphIngestRuns(groupCtx, runStore, runtimeIDs)
+		return loadErr
+	})
+	group.Go(func() error {
+		runStore := findingEvaluationRunStore(a.deps.StateStore)
+		if runStore == nil {
+			findingRuns = map[string]*cerebrov1.FindingEvaluationRun{}
+			return nil
+		}
+		var loadErr error
+		findingRuns, loadErr = sourcehealth.LatestFindingEvaluationRuns(groupCtx, runStore, runtimeIDs)
+		if errors.Is(loadErr, findings.ErrRuntimeUnavailable) {
+			findingRuns = map[string]*cerebrov1.FindingEvaluationRun{}
+			return nil
+		}
+		return loadErr
+	})
 	if err := group.Wait(); err != nil {
 		return nil, err
 	}
+	records := make([]sourceRuntimeHealthRecord, len(visibleRuntimes))
+	for index, runtime := range visibleRuntimes {
+		runtimeID := strings.TrimSpace(runtime.GetId())
+		records[index] = sourcehealthview.FromRuntime(runtime, generatedAt, graphRuns[runtimeID], findingRuns[runtimeID])
+	}
 	return records, nil
-}
-
-func (a *App) sourceRuntimeHealthRecord(ctx context.Context, runtime *cerebrov1.SourceRuntime, generatedAt time.Time) (sourceRuntimeHealthRecord, error) {
-	record := sourceRuntimeHealthRecord{
-		RuntimeID:    strings.TrimSpace(runtime.GetId()),
-		SourceID:     strings.TrimSpace(runtime.GetSourceId()),
-		TenantID:     strings.TrimSpace(runtime.GetTenantId()),
-		Family:       strings.TrimSpace(runtime.GetConfig()["family"]),
-		EnabledState: runtimeEnabledState(runtime),
-		Status:       runtimeHealthStatus(runtime, generatedAt),
-		RecentSync: sourceRuntimeHealthSync{
-			RecordsScanned:    runtimeConfigUint32(runtime, runtimeRecordsScannedConfigKey),
-			RecordsAccepted:   runtimeConfigUint32(runtime, runtimeRecordsAcceptedConfigKey),
-			RecordsRejected:   runtimeConfigUint32(runtime, runtimeRecordsRejectedConfigKey),
-			EntitiesProjected: runtimeConfigUint32(runtime, runtimeEntitiesProjectedConfigKey),
-			LinksProjected:    runtimeConfigUint32(runtime, runtimeLinksProjectedConfigKey),
-		},
-		LastFailureCategory:     strings.TrimSpace(runtime.GetConfig()[runtimeLastFailureCategoryConfigKey]),
-		ContractProbeState:      runtimeContractProbeState(runtime),
-		CursorPending:           strings.TrimSpace(runtime.GetNextCursor().GetOpaque()) != "",
-		CheckpointCursorPresent: strings.TrimSpace(runtime.GetCheckpoint().GetCursorOpaque()) != "",
-		// Schedule cadence/SLA is currently deployment configuration, not runtime state.
-		ScheduleContextConfigured: false,
-		GeneratedAt:               generatedAt.Format(time.RFC3339Nano),
-	}
-	if policy, err := resourcescope.FromConfig(runtime.GetConfig()); err == nil && !policy.Empty() {
-		record.ScopePolicy = &policy
-	}
-	if lastSynced := timestampValue(runtime.GetLastSyncedAt()); !lastSynced.IsZero() {
-		lastSynced = lastSynced.UTC()
-		record.LastSyncedAt = lastSynced.Format(time.RFC3339Nano)
-		record.SyncLagSeconds = secondsSince(generatedAt, lastSynced)
-	}
-	if watermark := timestampValue(runtime.GetCheckpoint().GetWatermark()); !watermark.IsZero() {
-		watermark = watermark.UTC()
-		record.CheckpointWatermark = watermark.Format(time.RFC3339Nano)
-		record.WatermarkLagSeconds = secondsSince(generatedAt, watermark)
-	}
-	var graphRun *graphstore.IngestRun
-	var findingRun *cerebrov1.FindingEvaluationRun
-	group, groupCtx := errgroup.WithContext(ctx)
-	group.Go(func() error {
-		var err error
-		graphRun, err = a.latestGraphIngestRun(groupCtx, record.RuntimeID)
-		return err
-	})
-	group.Go(func() error {
-		var err error
-		findingRun, err = a.latestFindingEvaluationRun(groupCtx, record.RuntimeID)
-		return err
-	})
-	if err := group.Wait(); err != nil {
-		return record, err
-	}
-	if graphRun != nil {
-		record.LatestGraphRun = sourceRuntimeGraphRunHealth(*graphRun)
-		record.GraphLagSeconds = graphRunLagSeconds(generatedAt, *graphRun)
-	}
-	if findingRun != nil {
-		record.LatestFindingEvaluation = sourceRuntimeFindingEvaluationHealth(findingRun)
-	}
-	if expectedCadence := runtimeConfigInt64(runtime, "expected_cadence_seconds"); expectedCadence > 0 {
-		record.ExpectedCadenceSeconds = &expectedCadence
-		record.ScheduleContextConfigured = true
-	}
-	if staleAfter := runtimeConfigInt64(runtime, "stale_after_seconds"); staleAfter > 0 {
-		record.StaleAfterSeconds = &staleAfter
-		record.ScheduleContextConfigured = true
-	}
-	return record, nil
 }
 
 func runtimeConfigUint32(runtime *cerebrov1.SourceRuntime, key string) uint32 {
@@ -693,148 +708,6 @@ func runtimeContractProbeState(runtime *cerebrov1.SourceRuntime) string {
 		return "unknown"
 	}
 	return "passing"
-}
-
-func (a *App) latestGraphIngestRun(ctx context.Context, runtimeID string) (*graphstore.IngestRun, error) {
-	runStore, ok := a.deps.GraphStore.(graphingest.RunStore)
-	if !ok || isNilInterface(runStore) {
-		return nil, nil
-	}
-	runs, err := runStore.ListIngestRuns(ctx, graphstore.IngestRunFilter{RuntimeID: runtimeID, Limit: 1})
-	if err != nil {
-		return nil, err
-	}
-	if len(runs) == 0 {
-		return nil, nil
-	}
-	return &runs[0], nil
-}
-
-func (a *App) latestFindingEvaluationRun(ctx context.Context, runtimeID string) (*cerebrov1.FindingEvaluationRun, error) {
-	runStore := findingEvaluationRunStore(a.deps.StateStore)
-	if runStore == nil {
-		return nil, nil
-	}
-	runs, err := runStore.ListFindingEvaluationRuns(ctx, ports.ListFindingEvaluationRunsRequest{RuntimeID: runtimeID, Limit: 1})
-	if err != nil {
-		if errors.Is(err, findings.ErrRuntimeUnavailable) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	if len(runs) == 0 {
-		return nil, nil
-	}
-	return runs[0], nil
-}
-
-func sourceRuntimeGraphRunHealth(run graphstore.IngestRun) *sourceRuntimeHealthGraphRun {
-	return &sourceRuntimeHealthGraphRun{
-		ID:                run.ID,
-		Status:            run.Status,
-		StartedAt:         run.StartedAt,
-		FinishedAt:        run.FinishedAt,
-		Error:             run.Error,
-		PagesRead:         run.PagesRead,
-		EventsRead:        run.EventsRead,
-		EntitiesProjected: run.EntitiesProjected,
-		LinksProjected:    run.LinksProjected,
-		GraphNodesBefore:  run.GraphNodesBefore,
-		GraphLinksBefore:  run.GraphLinksBefore,
-		GraphNodesAfter:   run.GraphNodesAfter,
-		GraphLinksAfter:   run.GraphLinksAfter,
-		GraphNodeDelta:    run.GraphNodesAfter - run.GraphNodesBefore,
-		GraphLinkDelta:    run.GraphLinksAfter - run.GraphLinksBefore,
-		DurationSeconds:   durationSeconds(run.StartedAt, run.FinishedAt),
-	}
-}
-
-func sourceRuntimeFindingEvaluationHealth(run *cerebrov1.FindingEvaluationRun) *sourceRuntimeHealthFindingEvaluation {
-	if run == nil {
-		return nil
-	}
-	var graphRowsRead uint32
-	if run.GraphRowsRead != nil {
-		graphRowsRead = run.GetGraphRowsRead()
-	}
-	return &sourceRuntimeHealthFindingEvaluation{
-		ID:               run.GetId(),
-		RuntimeID:        run.GetRuntimeId(),
-		RuleID:           run.GetRuleId(),
-		Status:           run.GetStatus(),
-		StartedAt:        timestampString(run.GetStartedAt()),
-		FinishedAt:       timestampString(run.GetFinishedAt()),
-		Error:            run.GetError(),
-		EventsEvaluated:  run.GetEventsEvaluated(),
-		EventsProcessed:  run.GetEventsProcessed(),
-		EventsMatched:    run.GetEventsMatched(),
-		FindingsUpserted: run.GetFindingsUpserted(),
-		FindingsEmitted:  run.GetFindingsEmitted(),
-		GraphRule:        run.GraphRule,
-		GraphRowsRead:    graphRowsRead,
-		DurationSeconds:  timestampDurationSeconds(run.GetStartedAt(), run.GetFinishedAt()),
-	}
-}
-
-func timestampString(value *timestamppb.Timestamp) string {
-	if value == nil {
-		return ""
-	}
-	timestamp := value.AsTime()
-	if timestamp.IsZero() {
-		return ""
-	}
-	return timestamp.UTC().Format(time.RFC3339Nano)
-}
-
-func secondsSince(now time.Time, then time.Time) *int64 {
-	seconds := int64(now.UTC().Sub(then.UTC()).Seconds())
-	if seconds < 0 {
-		seconds = 0
-	}
-	return &seconds
-}
-
-func graphRunLagSeconds(now time.Time, run graphstore.IngestRun) *int64 {
-	if finished, ok := parseRFC3339(run.FinishedAt); ok {
-		return secondsSince(now, finished)
-	}
-	if started, ok := parseRFC3339(run.StartedAt); ok {
-		return secondsSince(now, started)
-	}
-	return nil
-}
-
-func durationSeconds(startedAt string, finishedAt string) *int64 {
-	started, ok := parseRFC3339(startedAt)
-	if !ok {
-		return nil
-	}
-	finished, ok := parseRFC3339(finishedAt)
-	if !ok {
-		return nil
-	}
-	seconds := int64(finished.Sub(started).Seconds())
-	if seconds < 0 {
-		seconds = 0
-	}
-	return &seconds
-}
-
-func timestampDurationSeconds(startedAt *timestamppb.Timestamp, finishedAt *timestamppb.Timestamp) *int64 {
-	if startedAt == nil || finishedAt == nil {
-		return nil
-	}
-	started := startedAt.AsTime()
-	finished := finishedAt.AsTime()
-	if started.IsZero() || finished.IsZero() {
-		return nil
-	}
-	seconds := int64(finished.UTC().Sub(started.UTC()).Seconds())
-	if seconds < 0 {
-		seconds = 0
-	}
-	return &seconds
 }
 
 func parseRFC3339(value string) (time.Time, bool) {

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,8 @@ import (
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcecoverage"
+	"github.com/writer/cerebro/internal/sourcehealthview"
+	"github.com/writer/cerebro/internal/sourcehttp/responseview"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -34,10 +37,7 @@ func TestSourceRuntimeHealthRecordIncludesScheduleReceipt(t *testing.T) {
 		},
 	}
 
-	record, err := (&App{}).sourceRuntimeHealthRecord(context.Background(), runtime, now)
-	if err != nil {
-		t.Fatalf("sourceRuntimeHealthRecord() error = %v", err)
-	}
+	record := sourcehealthview.FromRuntime(runtime, now, nil, nil)
 	if record.ExpectedCadenceSeconds == nil || *record.ExpectedCadenceSeconds != 3600 {
 		t.Fatalf("ExpectedCadenceSeconds = %v, want 3600", record.ExpectedCadenceSeconds)
 	}
@@ -63,10 +63,7 @@ func TestSourceRuntimeHealthRecordIgnoresMalformedStoredScopePolicy(t *testing.T
 		},
 	}
 
-	record, err := (&App{}).sourceRuntimeHealthRecord(context.Background(), runtime, now)
-	if err != nil {
-		t.Fatalf("sourceRuntimeHealthRecord() error = %v", err)
-	}
+	record := sourcehealthview.FromRuntime(runtime, now, nil, nil)
 	if record.ScopePolicy != nil {
 		t.Fatalf("ScopePolicy = %#v, want nil for malformed stored policy", record.ScopePolicy)
 	}
@@ -128,16 +125,13 @@ func TestSourceRuntimeHealthRecordHandlesPartialAndInvalidScheduleReceipt(t *tes
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			record, err := (&App{}).sourceRuntimeHealthRecord(context.Background(), &cerebrov1.SourceRuntime{
+			record := sourcehealthview.FromRuntime(&cerebrov1.SourceRuntime{
 				Id:           "runtime-1",
 				SourceId:     "generated",
 				TenantId:     "tenant",
 				LastSyncedAt: timestamppb.New(now),
 				Config:       test.config,
-			}, now)
-			if err != nil {
-				t.Fatalf("sourceRuntimeHealthRecord() error = %v", err)
-			}
+			}, now, nil, nil)
 			assertOptionalInt64(t, "ExpectedCadenceSeconds", record.ExpectedCadenceSeconds, test.wantCadence)
 			assertOptionalInt64(t, "StaleAfterSeconds", record.StaleAfterSeconds, test.wantStale)
 			if record.ScheduleContextConfigured != test.wantConfigured {
@@ -247,7 +241,7 @@ func TestSourceRuntimeHealthSummariesAggregateBySource(t *testing.T) {
 			SourceID:           "okta",
 			Status:             "healthy",
 			ContractProbeState: "passing",
-			LatestGraphRun:     sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "completed"}),
+			LatestGraphRun:     sourcehealthview.GraphRunFromStore(graphstore.IngestRun{Status: "completed"}),
 			GraphLagSeconds:    &graphLag,
 			StaleAfterSeconds:  &staleAfter,
 		},
@@ -257,7 +251,7 @@ func TestSourceRuntimeHealthSummariesAggregateBySource(t *testing.T) {
 			Status:             "failing",
 			CursorPending:      true,
 			ContractProbeState: "failure",
-			LatestGraphRun:     sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "failed"}),
+			LatestGraphRun:     sourcehealthview.GraphRunFromStore(graphstore.IngestRun{Status: "failed"}),
 			StaleAfterSeconds:  &staleAfter,
 		},
 		{
@@ -300,7 +294,7 @@ func TestRuntimeFreshnessFromHealthClassifiesBackfillWorklist(t *testing.T) {
 				SourceID:          "okta",
 				EnabledState:      "enabled",
 				Status:            "healthy",
-				LatestGraphRun:    sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "completed"}),
+				LatestGraphRun:    sourcehealthview.GraphRunFromStore(graphstore.IngestRun{Status: "completed"}),
 				GraphLagSeconds:   int64Ptr(60),
 				StaleAfterSeconds: &staleAfter,
 			},
@@ -318,7 +312,7 @@ func TestRuntimeFreshnessFromHealthClassifiesBackfillWorklist(t *testing.T) {
 				EnabledState:        "enabled",
 				Status:              "failing",
 				LastFailureCategory: "auth_error",
-				LatestGraphRun:      sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "completed"}),
+				LatestGraphRun:      sourcehealthview.GraphRunFromStore(graphstore.IngestRun{Status: "completed"}),
 				StaleAfterSeconds:   &staleAfter,
 			},
 			{
@@ -368,7 +362,7 @@ func TestRuntimeFreshnessFromHealthTreatsRunningGraphAsHealthy(t *testing.T) {
 				SourceID:       "okta",
 				EnabledState:   "enabled",
 				Status:         "healthy",
-				LatestGraphRun: sourceRuntimeGraphRunHealth(graphstore.IngestRun{Status: "running"}),
+				LatestGraphRun: sourcehealthview.GraphRunFromStore(graphstore.IngestRun{Status: "running"}),
 			},
 		},
 	}
@@ -472,6 +466,86 @@ func TestListSourceRuntimeHealthFiltersCoverageByAllowedTenant(t *testing.T) {
 	}
 	if got := byDimension["applications"].RuntimeID; got != "" {
 		t.Fatalf("applications runtime_id = %q, want empty", got)
+	}
+}
+
+func TestListSourceRuntimeHealthSummaryKeepsAggregatesAndOmitsRecords(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-okta-user": {
+			Id:           "writer-okta-user",
+			SourceId:     "okta",
+			TenantId:     "writer",
+			LastSyncedAt: timestamppb.Now(),
+			Config:       map[string]string{"family": "user"},
+		},
+	}}
+	app := &App{deps: Dependencies{StateStore: store}, sources: registry}
+	request := httptest.NewRequest(http.MethodGet, "/source-runtimes/health?view=summary", nil)
+
+	response, err := app.listSourceRuntimeHealth(request)
+	if err != nil {
+		t.Fatalf("listSourceRuntimeHealth() error = %v", err)
+	}
+	if len(response.Coverage) != 0 {
+		t.Fatalf("Coverage length = %d, want 0", len(response.Coverage))
+	}
+	if len(response.coverageRecords) != 3 || len(response.CoverageSummary) != 1 {
+		t.Fatalf("summary coverage records/summaries = %d/%d, want 3/1", len(response.coverageRecords), len(response.CoverageSummary))
+	}
+	if response.view != responseview.Summary {
+		t.Fatalf("view = %q, want summary", response.view)
+	}
+
+	freshness := runtimeFreshnessFromHealth(response)
+	if len(freshness.CoverageBlindSpots) != 0 {
+		t.Fatalf("freshness raw blind spots length = %d, want 0", len(freshness.CoverageBlindSpots))
+	}
+	if len(freshness.CoverageBlindSummary) != 1 || freshness.CoverageBlindSummary[0].BlindSpots != 2 {
+		t.Fatalf("freshness blind spot summary = %#v, want two blind spots", freshness.CoverageBlindSummary)
+	}
+}
+
+func TestSourceCoverageConfiguredScopeExcludesUnconfiguredSources(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{}, secondaryCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := &App{sources: registry}
+	runtimes := []*cerebrov1.SourceRuntime{{Id: "writer-okta", SourceId: "okta", TenantId: "writer"}}
+
+	records := app.sourceCoverageRecordsScoped(runtimes, ports.SourceRuntimeFilter{TenantID: "writer"}, time.Now().UTC(), responseview.CoverageConfigured)
+
+	for _, record := range records {
+		if record.SourceID == "secondary" {
+			t.Fatalf("configured coverage included unconfigured source: %#v", record)
+		}
+	}
+	if len(records) != 3 {
+		t.Fatalf("configured coverage length = %d, want 3", len(records))
+	}
+}
+
+func TestSourceRuntimeHealthRecordsBatchLatestRunQueries(t *testing.T) {
+	stateStore := &stubRuntimeStore{findingEvaluationRuns: map[string]*cerebrov1.FindingEvaluationRun{}}
+	graphStore := &stubGraphStore{ingestRuns: map[string]graphstore.IngestRun{}}
+	app := &App{deps: Dependencies{StateStore: stateStore, GraphStore: graphStore}}
+	runtimes := []*cerebrov1.SourceRuntime{
+		{Id: "runtime-b", SourceId: "aws", TenantId: "writer"},
+		{Id: "runtime-a", SourceId: "okta", TenantId: "writer"},
+	}
+
+	if _, err := app.sourceRuntimeHealthRecords(context.Background(), runtimes, time.Now().UTC()); err != nil {
+		t.Fatalf("sourceRuntimeHealthRecords() error = %v", err)
+	}
+	if !graphStore.ingestRunListFilter.LatestByRuntime || len(graphStore.ingestRunListFilter.RuntimeIDs) != 2 {
+		t.Fatalf("graph run filter = %#v, want one latest run for two runtimes", graphStore.ingestRunListFilter)
+	}
+	if !stateStore.findingEvaluationRunListRequest.LatestByRuntime || len(stateStore.findingEvaluationRunListRequest.RuntimeIDs) != 2 {
+		t.Fatalf("finding run request = %#v, want one latest run for two runtimes", stateStore.findingEvaluationRunListRequest)
 	}
 }
 
@@ -612,6 +686,48 @@ func TestRuntimeFreshnessIncludesCoverageBlindSpots(t *testing.T) {
 	}
 }
 
+func BenchmarkSourceRuntimeHealthSerialization(b *testing.B) {
+	coverage := make([]sourcecoverage.Record, 5143)
+	for index := range coverage {
+		coverage[index] = sourcecoverage.Record{
+			SourceID:      "connector",
+			DimensionID:   "dimension-" + strconv.Itoa(index),
+			DimensionType: "entity_family",
+			Title:         "Coverage dimension",
+			State:         sourcecoverage.StateUnconfigured,
+			SupportLevel:  sourcecdk.CoverageSupportSupported,
+			BlindSpot:     true,
+		}
+	}
+	cases := map[string]sourceRuntimeHealthResponse{
+		"expanded": {
+			GeneratedAt:     "2026-07-14T00:00:00Z",
+			Coverage:        coverage,
+			CoverageSummary: sourcecoverage.Summaries(coverage),
+		},
+		"summary": {
+			GeneratedAt:     "2026-07-14T00:00:00Z",
+			CoverageSummary: sourcecoverage.Summaries(coverage),
+		},
+	}
+	for name, response := range cases {
+		b.Run(name, func(b *testing.B) {
+			payload, err := json.Marshal(response)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if _, err := json.Marshal(response); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(len(payload)), "response-bytes")
+		})
+	}
+}
+
 func FuzzRuntimeHealthConfigParsing(f *testing.F) {
 	f.Add("", "", "")
 	f.Add("3600", "7200", "passing")
@@ -644,6 +760,8 @@ func FuzzRuntimeHealthConfigParsing(f *testing.F) {
 
 type sourceCoverageHealthSource struct{}
 
+type secondaryCoverageHealthSource struct{}
+
 func (sourceCoverageHealthSource) Spec() *cerebrov1.SourceSpec {
 	return &cerebrov1.SourceSpec{Id: "okta", Name: "Okta"}
 }
@@ -670,6 +788,33 @@ func (sourceCoverageHealthSource) Discover(context.Context, sourcecdk.Config) ([
 }
 
 func (sourceCoverageHealthSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{}, nil
+}
+
+func (secondaryCoverageHealthSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "secondary", Name: "Secondary"}
+}
+
+func (secondaryCoverageHealthSource) CoverageContract() sourcecdk.CoverageContract {
+	return sourcecdk.CoverageContract{
+		SourceID:        "secondary",
+		OwnerDomain:     "inventory",
+		AuthorityDomain: "secondary",
+		Dimensions: []sourcecdk.CoverageDimension{
+			{ID: "assets", Type: "entity_family", Title: "Assets", Families: []string{"asset"}, Support: sourcecdk.CoverageSupportSupported},
+		},
+	}
+}
+
+func (secondaryCoverageHealthSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (secondaryCoverageHealthSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (secondaryCoverageHealthSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return sourcecdk.Pull{}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,7 @@ type CacheConfig struct {
 	DefaultTTL      time.Duration
 	StaleTTL        time.Duration
 	MaxPayloadBytes int
+	MaxEntries      int
 }
 
 // GraphAgentLLMConfig selects and configures the graph ask LLM adapter.
@@ -731,6 +732,12 @@ func Load() (Config, error) {
 	}
 	if cfg.Cache.MaxPayloadBytes <= 0 {
 		return Config{}, fmt.Errorf("CEREBRO_CACHE_MAX_PAYLOAD_BYTES must be greater than zero")
+	}
+	if cfg.Cache.MaxEntries, err = parseIntEnv("CEREBRO_CACHE_MAX_ENTRIES", 4096); err != nil {
+		return Config{}, err
+	}
+	if cfg.Cache.MaxEntries <= 0 {
+		return Config{}, fmt.Errorf("CEREBRO_CACHE_MAX_ENTRIES must be greater than zero")
 	}
 	if cfg.Cache.Namespace == "" {
 		cfg.Cache.Namespace = "cerebro"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_CACHE_DEFAULT_TTL", "")
 	t.Setenv("CEREBRO_CACHE_STALE_TTL", "")
 	t.Setenv("CEREBRO_CACHE_MAX_PAYLOAD_BYTES", "")
+	t.Setenv("CEREBRO_CACHE_MAX_ENTRIES", "")
 	t.Setenv("CEREBRO_CACHE_ENABLED", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_NEO4J_URI", "")
@@ -117,7 +118,7 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.StateStore.Driver != "" {
 		t.Fatalf("StateStore.Driver = %q, want empty", cfg.StateStore.Driver)
 	}
-	if cfg.Cache.Driver != CacheDriverOff || cfg.Cache.DefaultTTL != 30*time.Second || cfg.Cache.StaleTTL != 5*time.Minute || cfg.Cache.MaxPayloadBytes != 1<<20 {
+	if cfg.Cache.Driver != CacheDriverOff || cfg.Cache.DefaultTTL != 30*time.Second || cfg.Cache.StaleTTL != 5*time.Minute || cfg.Cache.MaxPayloadBytes != 1<<20 || cfg.Cache.MaxEntries != 4096 {
 		t.Fatalf("Cache defaults = %#v", cfg.Cache)
 	}
 	if cfg.GraphStore.Driver != "" {
@@ -223,6 +224,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CACHE_DEFAULT_TTL", "45s")
 	t.Setenv("CEREBRO_CACHE_STALE_TTL", "10m")
 	t.Setenv("CEREBRO_CACHE_MAX_PAYLOAD_BYTES", "2097152")
+	t.Setenv("CEREBRO_CACHE_MAX_ENTRIES", "256")
 	t.Setenv("CEREBRO_CACHE_ENABLED", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", GraphStoreDriverNeo4j)
 	t.Setenv("CEREBRO_NEO4J_URI", "neo4j+s://example.databases.neo4j.io")
@@ -361,7 +363,7 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.StateStore.DeadLetterPendingRetention != 9*24*time.Hour || cfg.StateStore.DeadLetterTerminalRetention != 48*time.Hour || cfg.StateStore.DeadLetterWarningRecords != 80 || cfg.StateStore.DeadLetterHardRecords != 100 || cfg.StateStore.DeadLetterWarningBytes != 8000 || cfg.StateStore.DeadLetterHardBytes != 10000 {
 		t.Fatalf("StateStore dead-letter policy = %#v", cfg.StateStore)
 	}
-	if cfg.Cache.Driver != CacheDriverValkey || cfg.Cache.URL != "rediss://cache.example.internal:6379" || cfg.Cache.Namespace != "cerebro:test" || cfg.Cache.DefaultTTL != 45*time.Second || cfg.Cache.StaleTTL != 10*time.Minute || cfg.Cache.MaxPayloadBytes != 2097152 {
+	if cfg.Cache.Driver != CacheDriverValkey || cfg.Cache.URL != "rediss://cache.example.internal:6379" || cfg.Cache.Namespace != "cerebro:test" || cfg.Cache.DefaultTTL != 45*time.Second || cfg.Cache.StaleTTL != 10*time.Minute || cfg.Cache.MaxPayloadBytes != 2097152 || cfg.Cache.MaxEntries != 256 {
 		t.Fatalf("Cache config = %#v", cfg.Cache)
 	}
 	if cfg.GraphStore.Driver != GraphStoreDriverNeo4j {
@@ -676,6 +678,7 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CACHE_DEFAULT_TTL", "")
 	t.Setenv("CEREBRO_CACHE_STALE_TTL", "")
 	t.Setenv("CEREBRO_CACHE_MAX_PAYLOAD_BYTES", "")
+	t.Setenv("CEREBRO_CACHE_MAX_ENTRIES", "")
 	t.Setenv("CEREBRO_CACHE_ENABLED", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_NEO4J_URI", "")

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -384,10 +384,12 @@ type FindingExternalRefLink struct {
 
 // ListFindingEvaluationRunsRequest scopes one finding evaluation run query.
 type ListFindingEvaluationRunsRequest struct {
-	RuntimeID string
-	RuleID    string
-	Status    string
-	Limit     uint32
+	RuntimeID       string
+	RuntimeIDs      []string
+	RuleID          string
+	Status          string
+	Limit           uint32
+	LatestByRuntime bool
 }
 
 // ListFindingEvidenceRequest scopes one finding evidence query.

--- a/internal/querycache/cache.go
+++ b/internal/querycache/cache.go
@@ -7,7 +7,10 @@ import (
 	"time"
 )
 
-var ErrMiss = errors.New("query cache miss")
+var (
+	ErrMiss            = errors.New("query cache miss")
+	ErrPayloadTooLarge = errors.New("query cache payload exceeds configured limit")
+)
 
 type State string
 

--- a/internal/querycache/cache_test.go
+++ b/internal/querycache/cache_test.go
@@ -167,8 +167,8 @@ func TestMemoryCacheSetSkipsEmptyPayload(t *testing.T) {
 func TestMemoryCacheSetSkipsOversizedPayload(t *testing.T) {
 	cache := NewMemory(Options{Namespace: "test", MaxPayloadBytes: 10})
 	big := make([]byte, 11)
-	if err := cache.Set(context.Background(), "key1", big, time.Minute, time.Minute); err != nil {
-		t.Fatalf("Set(oversized) error = %v", err)
+	if err := cache.Set(context.Background(), "key1", big, time.Minute, time.Minute); !errors.Is(err, ErrPayloadTooLarge) {
+		t.Fatalf("Set(oversized) error = %v, want ErrPayloadTooLarge", err)
 	}
 	_, err := cache.Get(context.Background(), "key1")
 	if !errors.Is(err, ErrMiss) {

--- a/internal/querycache/memory.go
+++ b/internal/querycache/memory.go
@@ -45,6 +45,9 @@ func (c *MemoryCache) Get(_ context.Context, key string) (Entry, error) {
 
 func (c *MemoryCache) Set(_ context.Context, key string, payload []byte, ttl time.Duration, staleTTL time.Duration) error {
 	if len(payload) == 0 || len(payload) > c.options.MaxPayloadBytes {
+		if len(payload) > c.options.MaxPayloadBytes {
+			return ErrPayloadTooLarge
+		}
 		return nil
 	}
 	now := time.Now().UTC()

--- a/internal/querycache/redis.go
+++ b/internal/querycache/redis.go
@@ -61,6 +61,9 @@ func (c *RedisCache) Set(ctx context.Context, key string, payload []byte, ttl ti
 	if len(payload) == 0 || len(payload) > c.options.MaxPayloadBytes {
 		redisAnnotateMain(ctx, c.options.Namespace, "set", "skipped")
 		telemetry.End(span, "skipped", telemetry.Attrs(telemetry.Field{Key: "status_detail", Value: "payload_size"}))
+		if len(payload) > c.options.MaxPayloadBytes {
+			return ErrPayloadTooLarge
+		}
 		return nil
 	}
 	now := time.Now().UTC()

--- a/internal/sourcehealth/latest_runs.go
+++ b/internal/sourcehealth/latest_runs.go
@@ -18,14 +18,18 @@ func LatestGraphIngestRuns(ctx context.Context, store graphingest.RunStore, runt
 	if len(runtimeIDs) == 0 {
 		return byRuntime, nil
 	}
-	runs, err := store.ListIngestRuns(ctx, graphstore.IngestRunFilter{RuntimeIDs: runtimeIDs, Limit: len(runtimeIDs), LatestByRuntime: true})
-	if err != nil {
-		return nil, err
-	}
-	for index := range runs {
-		run := runs[index]
-		if runtimeID := strings.TrimSpace(run.RuntimeID); runtimeID != "" {
-			byRuntime[runtimeID] = &run
+	for start := 0; start < len(runtimeIDs); start += graphingest.MaxStatusLimit {
+		end := min(start+graphingest.MaxStatusLimit, len(runtimeIDs))
+		batch := runtimeIDs[start:end]
+		runs, err := store.ListIngestRuns(ctx, graphstore.IngestRunFilter{RuntimeIDs: batch, Limit: len(batch), LatestByRuntime: true})
+		if err != nil {
+			return nil, err
+		}
+		for index := range runs {
+			run := runs[index]
+			if runtimeID := strings.TrimSpace(run.RuntimeID); runtimeID != "" {
+				byRuntime[runtimeID] = &run
+			}
 		}
 	}
 	return byRuntime, nil

--- a/internal/sourcehealth/latest_runs.go
+++ b/internal/sourcehealth/latest_runs.go
@@ -1,0 +1,75 @@
+package sourcehealth
+
+import (
+	"context"
+	"math"
+	"sort"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/graphingest"
+	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func LatestGraphIngestRuns(ctx context.Context, store graphingest.RunStore, runtimeIDs []string) (map[string]*graphstore.IngestRun, error) {
+	byRuntime := map[string]*graphstore.IngestRun{}
+	runtimeIDs = normalizeRuntimeIDs(runtimeIDs)
+	if len(runtimeIDs) == 0 {
+		return byRuntime, nil
+	}
+	runs, err := store.ListIngestRuns(ctx, graphstore.IngestRunFilter{RuntimeIDs: runtimeIDs, Limit: len(runtimeIDs), LatestByRuntime: true})
+	if err != nil {
+		return nil, err
+	}
+	for index := range runs {
+		run := runs[index]
+		if runtimeID := strings.TrimSpace(run.RuntimeID); runtimeID != "" {
+			byRuntime[runtimeID] = &run
+		}
+	}
+	return byRuntime, nil
+}
+
+func LatestFindingEvaluationRuns(ctx context.Context, store ports.FindingEvaluationRunStore, runtimeIDs []string) (map[string]*cerebrov1.FindingEvaluationRun, error) {
+	byRuntime := map[string]*cerebrov1.FindingEvaluationRun{}
+	runtimeIDs = normalizeRuntimeIDs(runtimeIDs)
+	if len(runtimeIDs) == 0 {
+		return byRuntime, nil
+	}
+	runs, err := store.ListFindingEvaluationRuns(ctx, ports.ListFindingEvaluationRunsRequest{RuntimeIDs: runtimeIDs, Limit: uint32Limit(len(runtimeIDs)), LatestByRuntime: true})
+	if err != nil {
+		return nil, err
+	}
+	for _, run := range runs {
+		if run == nil {
+			continue
+		}
+		if runtimeID := strings.TrimSpace(run.GetRuntimeId()); runtimeID != "" {
+			byRuntime[runtimeID] = run
+		}
+	}
+	return byRuntime, nil
+}
+
+func normalizeRuntimeIDs(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func uint32Limit(value int) uint32 {
+	if value > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(value) // #nosec G115 -- values above MaxUint32 return before this conversion.
+}

--- a/internal/sourcehealth/latest_runs_test.go
+++ b/internal/sourcehealth/latest_runs_test.go
@@ -1,0 +1,85 @@
+package sourcehealth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/writer/cerebro/internal/graphingest"
+	"github.com/writer/cerebro/internal/graphstore"
+)
+
+type boundedRunStore struct {
+	filters  []graphstore.IngestRunFilter
+	failCall int
+}
+
+var errListIngestRuns = errors.New("list ingest runs failed")
+
+func (*boundedRunStore) PutIngestRun(context.Context, graphstore.IngestRun) error {
+	return nil
+}
+
+func (*boundedRunStore) GetIngestRun(context.Context, string) (graphstore.IngestRun, bool, error) {
+	return graphstore.IngestRun{}, false, nil
+}
+
+func (s *boundedRunStore) ListIngestRuns(_ context.Context, filter graphstore.IngestRunFilter) ([]graphstore.IngestRun, error) {
+	s.filters = append(s.filters, filter)
+	if s.failCall == len(s.filters) {
+		return nil, errListIngestRuns
+	}
+	if filter.Limit > graphingest.MaxStatusLimit {
+		return nil, errors.New("ingest run limit exceeded")
+	}
+	runs := make([]graphstore.IngestRun, 0, len(filter.RuntimeIDs))
+	for _, runtimeID := range filter.RuntimeIDs {
+		runs = append(runs, graphstore.IngestRun{ID: "run-" + runtimeID, RuntimeID: runtimeID})
+	}
+	return runs, nil
+}
+
+func TestLatestGraphIngestRunsChunksRuntimeIDsAtStoreLimit(t *testing.T) {
+	runtimeIDs := make([]string, graphingest.MaxStatusLimit+1)
+	for index := range runtimeIDs {
+		runtimeIDs[index] = fmt.Sprintf("runtime-%03d", index)
+	}
+	store := &boundedRunStore{}
+
+	runs, err := LatestGraphIngestRuns(context.Background(), store, runtimeIDs)
+	if err != nil {
+		t.Fatalf("LatestGraphIngestRuns() error = %v", err)
+	}
+	if len(runs) != len(runtimeIDs) {
+		t.Fatalf("LatestGraphIngestRuns() returned %d runs, want %d", len(runs), len(runtimeIDs))
+	}
+	if len(store.filters) != 2 {
+		t.Fatalf("ListIngestRuns() calls = %d, want 2", len(store.filters))
+	}
+	for index, wantSize := range []int{graphingest.MaxStatusLimit, 1} {
+		filter := store.filters[index]
+		if len(filter.RuntimeIDs) != wantSize || filter.Limit != wantSize || !filter.LatestByRuntime {
+			t.Fatalf("ListIngestRuns() filter %d = %#v, want %d runtime IDs with matching limit and LatestByRuntime", index, filter, wantSize)
+		}
+	}
+}
+
+func TestLatestGraphIngestRunsReturnsBatchError(t *testing.T) {
+	runtimeIDs := make([]string, graphingest.MaxStatusLimit+1)
+	for index := range runtimeIDs {
+		runtimeIDs[index] = fmt.Sprintf("runtime-%03d", index)
+	}
+	store := &boundedRunStore{failCall: 2}
+
+	runs, err := LatestGraphIngestRuns(context.Background(), store, runtimeIDs)
+	if !errors.Is(err, errListIngestRuns) {
+		t.Fatalf("LatestGraphIngestRuns() error = %v, want %v", err, errListIngestRuns)
+	}
+	if runs != nil {
+		t.Fatalf("LatestGraphIngestRuns() runs = %#v, want nil", runs)
+	}
+	if len(store.filters) != 2 {
+		t.Fatalf("ListIngestRuns() calls = %d, want 2", len(store.filters))
+	}
+}

--- a/internal/sourcehealthview/build.go
+++ b/internal/sourcehealthview/build.go
@@ -1,0 +1,139 @@
+package sourcehealthview
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/resourcescope"
+	"github.com/writer/cerebro/internal/sourcehealth"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func FromRuntime(runtime *cerebrov1.SourceRuntime, generatedAt time.Time, graphRun *graphstore.IngestRun, findingRun *cerebrov1.FindingEvaluationRun) Record {
+	health := sourcehealth.RecordFromRuntime(runtime, generatedAt)
+	record := Record{
+		RuntimeID: health.RuntimeID, SourceID: health.SourceID, TenantID: health.TenantID, Family: health.Family,
+		EnabledState: health.EnabledState, Status: health.Status, RecentSync: syncFromRuntime(runtime),
+		LastFailureCategory: health.LastFailureCategory, ContractProbeState: health.ContractProbeState,
+		CursorPending: health.CursorPending, CheckpointCursorPresent: health.CheckpointCursorPresent,
+		ExpectedCadenceSeconds: health.ExpectedCadenceSeconds, StaleAfterSeconds: health.StaleAfterSeconds,
+		ScheduleContextConfigured: health.ScheduleContextConfigured, GeneratedAt: generatedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if policy, err := resourcescope.FromConfig(runtime.GetConfig()); err == nil && !policy.Empty() {
+		record.ScopePolicy = &policy
+	}
+	if lastSynced := timestampValue(runtime.GetLastSyncedAt()); !lastSynced.IsZero() {
+		record.LastSyncedAt, record.SyncLagSeconds = lastSynced.Format(time.RFC3339Nano), health.SyncLagSeconds
+	}
+	if watermark := timestampValue(runtime.GetCheckpoint().GetWatermark()); !watermark.IsZero() {
+		record.CheckpointWatermark, record.WatermarkLagSeconds = watermark.Format(time.RFC3339Nano), health.WatermarkLagSeconds
+	}
+	if graphRun != nil {
+		record.LatestGraphRun, record.GraphLagSeconds = GraphRunFromStore(*graphRun), graphRunLagSeconds(generatedAt, *graphRun)
+	}
+	record.LatestFindingEvaluation = FindingEvaluationFromRun(findingRun)
+	return record
+}
+
+func GraphRunFromStore(run graphstore.IngestRun) *GraphRun {
+	return &GraphRun{
+		ID: run.ID, Status: run.Status, StartedAt: run.StartedAt, FinishedAt: run.FinishedAt, Error: run.Error,
+		PagesRead: run.PagesRead, EventsRead: run.EventsRead, EntitiesProjected: run.EntitiesProjected, LinksProjected: run.LinksProjected,
+		GraphNodesBefore: run.GraphNodesBefore, GraphLinksBefore: run.GraphLinksBefore, GraphNodesAfter: run.GraphNodesAfter, GraphLinksAfter: run.GraphLinksAfter,
+		GraphNodeDelta: run.GraphNodesAfter - run.GraphNodesBefore, GraphLinkDelta: run.GraphLinksAfter - run.GraphLinksBefore,
+		DurationSeconds: durationSeconds(run.StartedAt, run.FinishedAt),
+	}
+}
+
+func FindingEvaluationFromRun(run *cerebrov1.FindingEvaluationRun) *FindingEvaluation {
+	if run == nil {
+		return nil
+	}
+	var graphRowsRead uint32
+	if run.GraphRowsRead != nil {
+		graphRowsRead = run.GetGraphRowsRead()
+	}
+	return &FindingEvaluation{
+		ID: run.GetId(), RuntimeID: run.GetRuntimeId(), RuleID: run.GetRuleId(), Status: run.GetStatus(),
+		StartedAt: timestampString(run.GetStartedAt()), FinishedAt: timestampString(run.GetFinishedAt()), Error: run.GetError(),
+		EventsEvaluated: run.GetEventsEvaluated(), EventsProcessed: run.GetEventsProcessed(), EventsMatched: run.GetEventsMatched(),
+		FindingsUpserted: run.GetFindingsUpserted(), FindingsEmitted: run.GetFindingsEmitted(), GraphRule: run.GraphRule,
+		GraphRowsRead: graphRowsRead, DurationSeconds: timestampDurationSeconds(run.GetStartedAt(), run.GetFinishedAt()),
+	}
+}
+
+func syncFromRuntime(runtime *cerebrov1.SourceRuntime) Sync {
+	return Sync{
+		RecordsScanned: configUint32(runtime, "__cerebro_runtime_records_scanned"), RecordsAccepted: configUint32(runtime, "__cerebro_runtime_records_accepted"),
+		RecordsRejected: configUint32(runtime, "__cerebro_runtime_records_rejected"), EntitiesProjected: configUint32(runtime, "__cerebro_runtime_entities_projected"),
+		LinksProjected: configUint32(runtime, "__cerebro_runtime_links_projected"),
+	}
+}
+
+func configUint32(runtime *cerebrov1.SourceRuntime, key string) uint32 {
+	if runtime == nil {
+		return 0
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(runtime.GetConfig()[key]), 10, 32)
+	if err != nil {
+		return 0
+	}
+	return uint32(value)
+}
+
+func timestampValue(value *timestamppb.Timestamp) time.Time {
+	if value == nil || (value.GetSeconds() == 0 && value.GetNanos() == 0) || value.CheckValid() != nil {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
+}
+
+func timestampString(value *timestamppb.Timestamp) string {
+	if timestamp := timestampValue(value); !timestamp.IsZero() {
+		return timestamp.Format(time.RFC3339Nano)
+	}
+	return ""
+}
+
+func graphRunLagSeconds(now time.Time, run graphstore.IngestRun) *int64 {
+	if finished, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(run.FinishedAt)); err == nil {
+		return secondsSince(now, finished)
+	}
+	if started, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(run.StartedAt)); err == nil {
+		return secondsSince(now, started)
+	}
+	return nil
+}
+
+func durationSeconds(startedAt, finishedAt string) *int64 {
+	started, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(startedAt))
+	if err != nil {
+		return nil
+	}
+	finished, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(finishedAt))
+	if err != nil {
+		return nil
+	}
+	return nonnegativeSeconds(finished.Sub(started))
+}
+
+func timestampDurationSeconds(startedAt, finishedAt *timestamppb.Timestamp) *int64 {
+	started, finished := timestampValue(startedAt), timestampValue(finishedAt)
+	if started.IsZero() || finished.IsZero() {
+		return nil
+	}
+	return nonnegativeSeconds(finished.Sub(started))
+}
+
+func secondsSince(now, then time.Time) *int64 { return nonnegativeSeconds(now.UTC().Sub(then.UTC())) }
+
+func nonnegativeSeconds(duration time.Duration) *int64 {
+	seconds := int64(duration.Seconds())
+	if seconds < 0 {
+		seconds = 0
+	}
+	return &seconds
+}

--- a/internal/sourcehttp/compression/middleware.go
+++ b/internal/sourcehttp/compression/middleware.go
@@ -1,0 +1,212 @@
+package httpcompression
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const responseThreshold = 1024
+
+// Middleware compresses JSON responses larger than one KiB when the client
+// accepts gzip. Smaller and non-JSON responses pass through unchanged.
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writer := &responseWriter{
+			dst:       w,
+			allowGzip: r.Method != http.MethodHead && acceptsGzip(r.Header.Get("Accept-Encoding")),
+			status:    http.StatusOK,
+		}
+		next.ServeHTTP(writer, r)
+		_ = writer.finish()
+	})
+}
+
+type responseWriter struct {
+	dst         http.ResponseWriter
+	allowGzip   bool
+	status      int
+	wroteHeader bool
+	committed   bool
+	compressed  bool
+	buffer      bytes.Buffer
+	gzip        *gzip.Writer
+}
+
+func (w *responseWriter) Header() http.Header {
+	return w.dst.Header()
+}
+
+func (w *responseWriter) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+	w.status = status
+	w.wroteHeader = true
+	if !w.allowGzip || !statusAllowsResponseBody(status) {
+		_ = w.commit(false)
+	}
+}
+
+func (w *responseWriter) Write(payload []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if w.committed {
+		if w.compressed {
+			return w.gzip.Write(payload)
+		}
+		return copyPayload(w.dst, payload)
+	}
+	if _, err := w.buffer.Write(payload); err != nil {
+		return 0, err
+	}
+	if w.buffer.Len() < responseThreshold {
+		return len(payload), nil
+	}
+	if err := w.commit(w.shouldCompress()); err != nil {
+		return 0, err
+	}
+	return len(payload), nil
+}
+
+func (w *responseWriter) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if !w.committed {
+		_ = w.commit(w.shouldCompress())
+	}
+	if w.compressed && w.gzip != nil {
+		_ = w.gzip.Flush()
+	}
+	if flusher, ok := w.dst.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := w.dst.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
+	w.committed = true
+	w.wroteHeader = true
+	return hijacker.Hijack()
+}
+
+func (w *responseWriter) Push(target string, options *http.PushOptions) error {
+	pusher, ok := w.dst.(http.Pusher)
+	if !ok {
+		return http.ErrNotSupported
+	}
+	return pusher.Push(target, options)
+}
+
+func (w *responseWriter) Unwrap() http.ResponseWriter {
+	return w.dst
+}
+
+func (w *responseWriter) finish() error {
+	if !w.committed {
+		if err := w.commit(w.shouldCompress()); err != nil {
+			return err
+		}
+	}
+	if w.compressed && w.gzip != nil {
+		return w.gzip.Close()
+	}
+	return nil
+}
+
+func (w *responseWriter) shouldCompress() bool {
+	return w.allowGzip &&
+		w.buffer.Len() >= responseThreshold &&
+		statusAllowsResponseBody(w.status) &&
+		strings.TrimSpace(w.Header().Get("Content-Encoding")) == "" &&
+		isJSONContentType(w.Header().Get("Content-Type"))
+}
+
+func (w *responseWriter) commit(compress bool) error {
+	if w.committed {
+		return nil
+	}
+	w.committed = true
+	if isJSONContentType(w.Header().Get("Content-Type")) {
+		w.Header().Set("Vary", appendVary(w.Header().Get("Vary"), "Accept-Encoding"))
+	}
+	if compress {
+		w.compressed = true
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Del("Content-Length")
+	}
+	w.dst.WriteHeader(w.status)
+	if compress {
+		w.gzip = gzip.NewWriter(w.dst)
+		if _, err := w.gzip.Write(w.buffer.Bytes()); err != nil {
+			return err
+		}
+	} else if w.buffer.Len() > 0 {
+		if _, err := io.Copy(w.dst, &w.buffer); err != nil {
+			return err
+		}
+	}
+	w.buffer.Reset()
+	return nil
+}
+
+func copyPayload(dst io.Writer, payload []byte) (int, error) {
+	// codeql[go/reflected-xss] The middleware only selects JSON responses and preserves their application/json content type.
+	written, err := io.Copy(dst, bytes.NewReader(payload))
+	if err != nil {
+		return int(written), err // #nosec G115 -- bytes.Reader bounds written to len(payload), which is an int.
+	}
+	return len(payload), nil
+}
+
+func acceptsGzip(value string) bool {
+	for _, encoding := range strings.Split(strings.ToLower(value), ",") {
+		parts := strings.Split(strings.TrimSpace(encoding), ";")
+		if len(parts) == 0 || parts[0] != "gzip" {
+			continue
+		}
+		for _, parameter := range parts[1:] {
+			name, raw, ok := strings.Cut(strings.TrimSpace(parameter), "=")
+			if !ok || strings.TrimSpace(name) != "q" {
+				continue
+			}
+			quality, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+			if err == nil && quality <= 0 {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func isJSONContentType(value string) bool {
+	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(value, ";")[0]))
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+func statusAllowsResponseBody(status int) bool {
+	return status >= http.StatusOK && status != http.StatusNoContent && status != http.StatusNotModified
+}
+
+func appendVary(current, value string) string {
+	for _, item := range strings.Split(current, ",") {
+		if strings.EqualFold(strings.TrimSpace(item), value) {
+			return current
+		}
+	}
+	if strings.TrimSpace(current) == "" {
+		return value
+	}
+	return current + ", " + value
+}

--- a/internal/sourcehttp/compression/middleware_test.go
+++ b/internal/sourcehttp/compression/middleware_test.go
@@ -1,0 +1,72 @@
+package httpcompression
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMiddlewareCompressesLargeJSON(t *testing.T) {
+	payload := `{"items":["` + strings.Repeat("compressible-content-", 256) + `"]}`
+	handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Accept-Encoding", "gzip")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+	response := recorder.Result()
+	if got := response.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	reader, err := gzip.NewReader(response.Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	decompressed, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read compressed body: %v", err)
+	}
+	if got := string(decompressed); got != payload {
+		t.Fatalf("decompressed body mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestMiddlewareLeavesSmallJSONUncompressed(t *testing.T) {
+	handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Accept-Encoding", "gzip")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+	response := recorder.Result()
+	if got := response.Header.Get("Content-Encoding"); got != "" {
+		t.Fatalf("Content-Encoding = %q, want empty", got)
+	}
+	if got := recorder.Body.String(); got != `{"ok":true}` {
+		t.Fatalf("body = %q", got)
+	}
+}
+
+func TestMiddlewareHonorsDisabledGzipQuality(t *testing.T) {
+	handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(strings.Repeat("x", responseThreshold+1)))
+	}))
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Accept-Encoding", "gzip;q=0")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+	if got := recorder.Result().Header.Get("Content-Encoding"); got != "" {
+		t.Fatalf("Content-Encoding = %q, want empty", got)
+	}
+}

--- a/internal/sourcehttp/coverageview/coverage_view.go
+++ b/internal/sourcehttp/coverageview/coverage_view.go
@@ -1,0 +1,105 @@
+package coverageview
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/writer/cerebro/internal/nhicoverage"
+	"github.com/writer/cerebro/internal/sourcecoverage"
+)
+
+type View string
+
+const (
+	Expanded View = "expanded"
+	Summary  View = "summary"
+	Page     View = "page"
+)
+
+var ErrInvalidView = errors.New("coverage_view must be summary or page when provided")
+
+type PageMetadata struct {
+	PageSize   int    `json:"page_size"`
+	Returned   int    `json:"returned"`
+	Total      int    `json:"total"`
+	NextCursor string `json:"next_cursor,omitempty"`
+}
+
+type PageResponse struct {
+	nhicoverage.SourceCoverageResponse
+	Page PageMetadata `json:"page"`
+}
+
+func FromRequest(r *http.Request) (View, error) {
+	switch strings.ToLower(strings.TrimSpace(r.URL.Query().Get("coverage_view"))) {
+	case "":
+		return Expanded, nil
+	case string(Summary):
+		return Summary, nil
+	case string(Page):
+		return Page, nil
+	default:
+		return Expanded, ErrInvalidView
+	}
+}
+
+func Compact(response nhicoverage.SourceCoverageResponse) nhicoverage.SourceCoverageResponse {
+	response.Records = nil
+	response.BlindSpots = nil
+	response.NHICoverage.Records = nil
+	response.NHICoverage.BlindSpots = nil
+	return response
+}
+
+func Paginate(r *http.Request, response nhicoverage.SourceCoverageResponse, records []sourcecoverage.Record) (PageResponse, error) {
+	if strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("blind_spots_only")), "true") {
+		records = sourcecoverage.BlindSpots(records)
+	}
+	page, metadata, err := RecordsPage(r, records)
+	if err != nil {
+		return PageResponse{}, err
+	}
+	response.Records = page
+	response.BlindSpots = nil
+	response.NHICoverage.Records = nhicoverage.RecordsFromCoverage(page)
+	response.NHICoverage.BlindSpots = nil
+	return PageResponse{SourceCoverageResponse: response, Page: metadata}, nil
+}
+
+func RecordsPage(r *http.Request, records []sourcecoverage.Record) ([]sourcecoverage.Record, PageMetadata, error) {
+	pageSize := uint64(100)
+	if raw := strings.TrimSpace(r.URL.Query().Get("page_size")); raw != "" {
+		parsed, err := strconv.ParseUint(raw, 10, 32)
+		if err != nil || parsed == 0 || parsed > 500 {
+			return nil, PageMetadata{}, errors.New("page_size must be between 1 and 500")
+		}
+		pageSize = parsed
+	}
+	offset := uint64(0)
+	if raw := strings.TrimSpace(r.URL.Query().Get("cursor")); raw != "" {
+		decoded, err := base64.RawURLEncoding.DecodeString(raw)
+		if err != nil {
+			return nil, PageMetadata{}, errors.New("cursor is invalid")
+		}
+		parsed, err := strconv.ParseUint(string(decoded), 10, 64)
+		if err != nil {
+			return nil, PageMetadata{}, errors.New("cursor is invalid")
+		}
+		offset = parsed
+	}
+	if offset > uint64(len(records)) {
+		return nil, PageMetadata{}, errors.New("cursor is beyond the result set")
+	}
+	end := min(offset+pageSize, uint64(len(records)))
+	startIndex, endIndex := int(offset), int(end) // #nosec G115 -- both values are bounded by len(records).
+	page := append([]sourcecoverage.Record(nil), records[startIndex:endIndex]...)
+	metadata := PageMetadata{PageSize: int(pageSize), Returned: len(page), Total: len(records)}
+	if end < uint64(len(records)) {
+		metadata.NextCursor = base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%d", end)))
+	}
+	return page, metadata, nil
+}

--- a/internal/sourcehttp/coverageview/coverage_view.go
+++ b/internal/sourcehttp/coverageview/coverage_view.go
@@ -20,7 +20,10 @@ const (
 	Page     View = "page"
 )
 
-var ErrInvalidView = errors.New("coverage_view must be summary or page when provided")
+var (
+	ErrInvalidView   = errors.New("coverage_view must be summary or page when provided")
+	errInvalidCursor = errors.New("cursor is invalid")
+)
 
 type PageMetadata struct {
 	PageSize   int    `json:"page_size"`
@@ -71,34 +74,33 @@ func Paginate(r *http.Request, response nhicoverage.SourceCoverageResponse, reco
 }
 
 func RecordsPage(r *http.Request, records []sourcecoverage.Record) ([]sourcecoverage.Record, PageMetadata, error) {
-	pageSize := uint64(100)
+	pageSize := 100
 	if raw := strings.TrimSpace(r.URL.Query().Get("page_size")); raw != "" {
-		parsed, err := strconv.ParseUint(raw, 10, 32)
-		if err != nil || parsed == 0 || parsed > 500 {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > 500 {
 			return nil, PageMetadata{}, errors.New("page_size must be between 1 and 500")
 		}
 		pageSize = parsed
 	}
-	offset := uint64(0)
+	offset := 0
 	if raw := strings.TrimSpace(r.URL.Query().Get("cursor")); raw != "" {
 		decoded, err := base64.RawURLEncoding.DecodeString(raw)
 		if err != nil {
-			return nil, PageMetadata{}, errors.New("cursor is invalid")
+			return nil, PageMetadata{}, errInvalidCursor
 		}
-		parsed, err := strconv.ParseUint(string(decoded), 10, 64)
-		if err != nil {
-			return nil, PageMetadata{}, errors.New("cursor is invalid")
+		parsed, err := strconv.Atoi(string(decoded))
+		if err != nil || parsed < 0 {
+			return nil, PageMetadata{}, errInvalidCursor
 		}
 		offset = parsed
 	}
-	if offset > uint64(len(records)) {
+	if offset > len(records) {
 		return nil, PageMetadata{}, errors.New("cursor is beyond the result set")
 	}
-	end := min(offset+pageSize, uint64(len(records)))
-	startIndex, endIndex := int(offset), int(end) // #nosec G115 -- both values are bounded by len(records).
-	page := append([]sourcecoverage.Record(nil), records[startIndex:endIndex]...)
-	metadata := PageMetadata{PageSize: int(pageSize), Returned: len(page), Total: len(records)}
-	if end < uint64(len(records)) {
+	end := min(offset+pageSize, len(records))
+	page := append([]sourcecoverage.Record(nil), records[offset:end]...)
+	metadata := PageMetadata{PageSize: pageSize, Returned: len(page), Total: len(records)}
+	if end < len(records) {
 		metadata.NextCursor = base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%d", end)))
 	}
 	return page, metadata, nil

--- a/internal/sourcehttp/coverageview/coverage_view_test.go
+++ b/internal/sourcehttp/coverageview/coverage_view_test.go
@@ -1,0 +1,30 @@
+package coverageview
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecoverage"
+)
+
+func TestRecordsPageUsesBoundedCursor(t *testing.T) {
+	records := []sourcecoverage.Record{{DimensionID: "a"}, {DimensionID: "b"}, {DimensionID: "c"}}
+	request := httptest.NewRequest(http.MethodGet, "/connectors/coverage?coverage_view=page&page_size=2", nil)
+
+	first, metadata, err := RecordsPage(request, records)
+	if err != nil {
+		t.Fatalf("RecordsPage(first) error = %v", err)
+	}
+	if len(first) != 2 || metadata.Total != 3 || metadata.Returned != 2 || metadata.NextCursor == "" {
+		t.Fatalf("first page = %#v metadata=%#v", first, metadata)
+	}
+	request = httptest.NewRequest(http.MethodGet, "/connectors/coverage?coverage_view=page&page_size=2&cursor="+metadata.NextCursor, nil)
+	second, metadata, err := RecordsPage(request, records)
+	if err != nil {
+		t.Fatalf("RecordsPage(second) error = %v", err)
+	}
+	if len(second) != 1 || second[0].DimensionID != "c" || metadata.NextCursor != "" {
+		t.Fatalf("second page = %#v metadata=%#v", second, metadata)
+	}
+}

--- a/internal/sourcehttp/coverageview/coverage_view_test.go
+++ b/internal/sourcehttp/coverageview/coverage_view_test.go
@@ -1,6 +1,8 @@
 package coverageview
 
 import (
+	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,5 +28,18 @@ func TestRecordsPageUsesBoundedCursor(t *testing.T) {
 	}
 	if len(second) != 1 || second[0].DimensionID != "c" || metadata.NextCursor != "" {
 		t.Fatalf("second page = %#v metadata=%#v", second, metadata)
+	}
+}
+
+func TestRecordsPageRejectsCursorOutsideValidIntRange(t *testing.T) {
+	for _, rawCursor := range []string{"-1", "18446744073709551615"} {
+		t.Run(rawCursor, func(t *testing.T) {
+			cursor := base64.RawURLEncoding.EncodeToString([]byte(rawCursor))
+			request := httptest.NewRequest(http.MethodGet, "/connectors/coverage?coverage_view=page&cursor="+cursor, nil)
+
+			if _, _, err := RecordsPage(request, nil); !errors.Is(err, errInvalidCursor) {
+				t.Fatalf("RecordsPage() error = %v, want %v", err, errInvalidCursor)
+			}
+		})
 	}
 }

--- a/internal/sourcehttp/responseview/response_view.go
+++ b/internal/sourcehttp/responseview/response_view.go
@@ -1,0 +1,68 @@
+package responseview
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/writer/cerebro/internal/grcproductareas"
+)
+
+type View string
+
+const (
+	Expanded View = "expanded"
+	Summary  View = "summary"
+)
+
+type CoverageScope string
+
+const (
+	CoverageCatalog    CoverageScope = "catalog"
+	CoverageConfigured CoverageScope = "configured"
+)
+
+var (
+	ErrInvalidView          = errors.New("view must be summary when provided")
+	ErrInvalidCoverageScope = errors.New("coverage_scope must be catalog or configured")
+)
+
+func FromRequest(r *http.Request) (View, error) {
+	if r == nil || r.URL == nil {
+		return Expanded, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(r.URL.Query().Get("view"))) {
+	case "":
+		return Expanded, nil
+	case string(Summary):
+		return Summary, nil
+	default:
+		return Expanded, ErrInvalidView
+	}
+}
+
+func CoverageScopeFromRequest(r *http.Request, view View) (CoverageScope, error) {
+	if r == nil || r.URL == nil {
+		return CoverageCatalog, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(r.URL.Query().Get("coverage_scope"))) {
+	case "":
+		if view == Summary {
+			return CoverageConfigured, nil
+		}
+		return CoverageCatalog, nil
+	case string(CoverageCatalog):
+		return CoverageCatalog, nil
+	case string(CoverageConfigured):
+		return CoverageConfigured, nil
+	default:
+		return CoverageCatalog, ErrInvalidCoverageScope
+	}
+}
+
+func CompactProductAreas(views []grcproductareas.View) []grcproductareas.View {
+	for index := range views {
+		views[index].BlindSpots = nil
+	}
+	return views
+}

--- a/internal/sourcehttp/responseview/response_view_test.go
+++ b/internal/sourcehttp/responseview/response_view_test.go
@@ -1,0 +1,43 @@
+package responseview
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDefaultViewUsesExpandedCatalogCoverage(t *testing.T) {
+	request := httptest.NewRequest("GET", "/grc/dashboard", nil)
+	view, err := FromRequest(request)
+	if err != nil {
+		t.Fatalf("FromRequest() error = %v", err)
+	}
+	scope, err := CoverageScopeFromRequest(request, view)
+	if err != nil {
+		t.Fatalf("CoverageScopeFromRequest() error = %v", err)
+	}
+	if view != Expanded || scope != CoverageCatalog {
+		t.Fatalf("view/scope = %q/%q, want expanded/catalog", view, scope)
+	}
+}
+
+func TestSummaryViewDefaultsToConfiguredCoverage(t *testing.T) {
+	request := httptest.NewRequest("GET", "/grc/dashboard?view=summary", nil)
+	view, err := FromRequest(request)
+	if err != nil {
+		t.Fatalf("FromRequest() error = %v", err)
+	}
+	scope, err := CoverageScopeFromRequest(request, view)
+	if err != nil {
+		t.Fatalf("CoverageScopeFromRequest() error = %v", err)
+	}
+	if view != Summary || scope != CoverageConfigured {
+		t.Fatalf("view/scope = %q/%q, want summary/configured", view, scope)
+	}
+}
+
+func TestViewRejectsUnsupportedValues(t *testing.T) {
+	request := httptest.NewRequest("GET", "/grc/dashboard?view=compact", nil)
+	if _, err := FromRequest(request); err == nil {
+		t.Fatal("FromRequest() error = nil, want invalid view")
+	}
+}

--- a/internal/statestore/postgres/findingevaluationruns.go
+++ b/internal/statestore/postgres/findingevaluationruns.go
@@ -165,19 +165,25 @@ func (s *Store) ensureFindingEvaluationRunTables(ctx context.Context) error {
 }
 
 func findingEvaluationRunListQuery(request ports.ListFindingEvaluationRunsRequest) (string, []any, error) {
-	runtimeID := strings.TrimSpace(request.RuntimeID)
-	if runtimeID == "" {
+	runtimeIDs := normalizedNonEmptyStrings(append(append([]string(nil), request.RuntimeIDs...), request.RuntimeID))
+	if len(runtimeIDs) == 0 {
 		return "", nil, errors.New("finding evaluation runtime id is required")
 	}
-	clauses := []string{"runtime_id = $1"}
-	args := []any{runtimeID}
+	clauses := []string{}
+	args := []any{}
+	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
 	addFindingEvaluationRunFilter(&clauses, &args, "rule_id", request.RuleID)
 	addFindingEvaluationRunFilter(&clauses, &args, "status", request.Status)
-	query := `
-SELECT finding_evaluation_run_json::text
+	selectClause := "SELECT finding_evaluation_run_json::text"
+	orderClause := "ORDER BY started_at DESC, id"
+	if request.LatestByRuntime {
+		selectClause = "SELECT DISTINCT ON (runtime_id) finding_evaluation_run_json::text"
+		orderClause = "ORDER BY runtime_id, started_at DESC, id DESC"
+	}
+	query := "\n" + selectClause + `
 FROM finding_evaluation_runs
 WHERE ` + strings.Join(clauses, " AND ") + `
-ORDER BY started_at DESC, id`
+` + orderClause
 	if request.Limit != 0 {
 		args = append(args, int64(request.Limit))
 		query += fmt.Sprintf(" LIMIT $%d", len(args))

--- a/internal/statestore/postgres/findingevaluationruns_test.go
+++ b/internal/statestore/postgres/findingevaluationruns_test.go
@@ -88,3 +88,27 @@ func TestFindingEvaluationRunListQueryIncludesOptionalFilters(t *testing.T) {
 		t.Fatalf("findingEvaluationRunListQuery().args[3] = %#v, want 25", got)
 	}
 }
+
+func TestFindingEvaluationRunListQuerySelectsLatestForEachRuntime(t *testing.T) {
+	query, args, err := findingEvaluationRunListQuery(ports.ListFindingEvaluationRunsRequest{
+		RuntimeIDs:      []string{"runtime-b", "runtime-a"},
+		Limit:           2,
+		LatestByRuntime: true,
+	})
+	if err != nil {
+		t.Fatalf("findingEvaluationRunListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"SELECT DISTINCT ON (runtime_id)",
+		"runtime_id IN ($1, $2)",
+		"ORDER BY runtime_id, started_at DESC, id DESC",
+		"LIMIT $3",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvaluationRunListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if len(args) != 3 || args[0] != "runtime-b" || args[1] != "runtime-a" || args[2] != int64(2) {
+		t.Fatalf("findingEvaluationRunListQuery().args = %#v", args)
+	}
+}

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -707,6 +707,21 @@ export type Claim = {
   valid_to?: string;
 };
 
+export type ConnectorCoveragePageResponse = {
+  blind_spot_summaries?: SourceCoverageSummary[];
+  blind_spots?: SourceCoverageRecord[];
+  gate?: SourceCoverageGate;
+  generated_at?: string;
+  nhi_coverage?: NHICoverageReport;
+  page: { next_cursor?: string; page_size?: number; returned?: number; total?: number };
+  records?: SourceCoverageRecord[];
+  source_id?: string;
+  summaries?: SourceCoverageSummary[];
+  tenant_id?: string;
+  totals?: SourceCoverageTotals;
+  version?: string;
+};
+
 export type ConnectorCoverageResponse = {
   blind_spot_summaries?: SourceCoverageSummary[];
   blind_spots?: SourceCoverageRecord[];


### PR DESCRIPTION
Summary:
- Add explicit summary views for dashboard, readiness, and runtime health responses while preserving expanded defaults.
- Add bounded connector coverage pages and batch latest graph and finding-run lookups.
- Compress large JSON responses and cache hot health endpoints with observable oversize skips and bounded in-process entries.

Validation:
- go test ./internal/bootstrap ./internal/config ./internal/querycache ./internal/statestore/postgres
- make openapi-check openapi-lint openapi-ts-check
- make detection-catalog-check
- Synthetic 5,143-record serialization benchmark compares expanded and summary responses.