### PR TITLE
Collect trusted inputs for source-bound assessments

### DIFF
--- a/internal/complianceassessment/finding_evaluation_collector.go
+++ b/internal/complianceassessment/finding_evaluation_collector.go
@@ -1,0 +1,673 @@
+package complianceassessment
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const findingEvaluationCollectorRevision = "finding-evaluation-collector/v1"
+
+// AssessmentPlanReader loads the immutable plan revision pinned by a run.
+type AssessmentPlanReader interface {
+	GetPlan(context.Context, string, string) (AssessmentPlanRevision, error)
+}
+
+// SourceRuntimeLister resolves runtime ownership through a tenant-filtered read.
+type SourceRuntimeLister interface {
+	ListSourceRuntimes(context.Context, ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error)
+}
+
+// FindingEvaluationRunLister loads durable rule-evaluation envelopes.
+type FindingEvaluationRunLister interface {
+	ListFindingEvaluationRuns(context.Context, ports.ListFindingEvaluationRunsRequest) ([]*cerebrov1.FindingEvaluationRun, error)
+}
+
+// FindingEvaluationCollector converts bounded, durable finding-evaluation runs
+// into point-in-time objective results and reproducible collection receipts.
+type FindingEvaluationCollector struct {
+	plans       AssessmentPlanReader
+	runtimes    SourceRuntimeLister
+	evaluations FindingEvaluationRunLister
+	now         func() time.Time
+}
+
+func NewFindingEvaluationCollector(plans AssessmentPlanReader, runtimes SourceRuntimeLister, evaluations FindingEvaluationRunLister) *FindingEvaluationCollector {
+	if plans == nil || runtimes == nil || evaluations == nil {
+		return nil
+	}
+	return &FindingEvaluationCollector{
+		plans:       plans,
+		runtimes:    runtimes,
+		evaluations: evaluations,
+		now:         func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (c *FindingEvaluationCollector) Collect(ctx context.Context, run AssessmentRun) (InputManifest, []ObjectiveResult, error) {
+	if c == nil || c.plans == nil || c.runtimes == nil || c.evaluations == nil || c.now == nil {
+		return InputManifest{}, nil, fmt.Errorf("%w: finding evaluation collector is not configured", ErrIncompleteInput)
+	}
+	plan, err := c.plans.GetPlan(ctx, strings.TrimSpace(run.TenantID), strings.TrimSpace(run.PlanRevisionID))
+	if err != nil {
+		return InputManifest{}, nil, fmt.Errorf("load assessment plan: %w", err)
+	}
+	plan = normalizePlan(plan)
+	if err := validatePlan(plan); err != nil {
+		return InputManifest{}, nil, err
+	}
+	if plan.Status != PlanPublished || plan.TenantID != strings.TrimSpace(run.TenantID) || plan.RevisionID != strings.TrimSpace(run.PlanRevisionID) ||
+		plan.Scope.ProgramID != strings.TrimSpace(run.ProgramID) || plan.Scope.ScopeRevisionID != strings.TrimSpace(run.ScopeRevisionID) {
+		return InputManifest{}, nil, fmt.Errorf("%w: assessment run and plan binding do not match", ErrIncompleteInput)
+	}
+
+	cutoff := CanonicalTime(c.now())
+	if run.InputManifest != nil && !run.InputManifest.CollectionCutoff.IsZero() {
+		cutoff = CanonicalTime(run.InputManifest.CollectionCutoff)
+	}
+	periodStart := CanonicalTime(run.PeriodStart)
+	periodEnd := CanonicalTime(run.PeriodEnd)
+	if periodStart.IsZero() || periodEnd.IsZero() || periodEnd.Before(periodStart) || periodEnd.After(cutoff) {
+		return InputManifest{}, nil, fmt.Errorf("%w: assessment period is outside the collection cutoff", ErrIncompleteInput)
+	}
+
+	orderedTasks, err := orderedFindingEvaluationTasks(plan.Execution)
+	if err != nil {
+		return InputManifest{}, nil, err
+	}
+	runtimeIDs := make([]string, 0, MaxFindingEvaluationBindings)
+	for _, task := range orderedTasks {
+		runtimeIDs = append(runtimeIDs, task.RuntimeIDs...)
+	}
+	runtimeIDs = normalizedStrings(runtimeIDs)
+	resolvedRuntimes, err := c.runtimes.ListSourceRuntimes(ctx, ports.SourceRuntimeFilter{
+		TenantID:   run.TenantID,
+		RuntimeIDs: runtimeIDs,
+		Limit:      MaxFindingEvaluationBindings,
+	})
+	if err != nil {
+		return InputManifest{}, nil, fmt.Errorf("list assessment source runtimes: %w", err)
+	}
+	if err := validateResolvedRuntimes(run.TenantID, runtimeIDs, resolvedRuntimes); err != nil {
+		return InputManifest{}, nil, err
+	}
+	resolvedRuntimeByID := make(map[string]*cerebrov1.SourceRuntime, len(resolvedRuntimes))
+	for _, runtime := range resolvedRuntimes {
+		resolvedRuntimeByID[strings.TrimSpace(runtime.GetId())] = runtime
+	}
+
+	scopeDigest, err := semanticHash(plan.Scope)
+	if err != nil {
+		return InputManifest{}, nil, err
+	}
+	objectiveDigest, err := semanticHash(plan.Scope.ObjectiveIDs)
+	if err != nil {
+		return InputManifest{}, nil, err
+	}
+	mappingDigest, err := semanticHash(orderedTasks)
+	if err != nil {
+		return InputManifest{}, nil, err
+	}
+	manifest := InputManifest{
+		ProgramID:                  run.ProgramID,
+		ScopeRevisionID:            run.ScopeRevisionID,
+		PlanRevisionID:             run.PlanRevisionID,
+		PeriodStart:                periodStart,
+		PeriodEnd:                  periodEnd,
+		CollectionCutoff:           cutoff,
+		RequestedScopeDigest:       scopeDigest,
+		ResolvedObjectiveSetDigest: objectiveDigest,
+		MappingSetDigest:           mappingDigest,
+		Revisions: []ManifestRevision{{
+			Kind: "plan", ID: plan.ID, RevisionID: plan.RevisionID,
+			Version: plan.Version, Digest: plan.ContentDigest,
+		}},
+	}
+	results := make([]ObjectiveResult, 0, len(orderedTasks))
+	for _, task := range orderedTasks {
+		result, receipts, evaluationRunIDs, collectErr := c.collectTask(ctx, plan, run, task, cutoff, resolvedRuntimeByID)
+		if collectErr != nil {
+			return InputManifest{}, nil, collectErr
+		}
+		manifest.Receipts = append(manifest.Receipts, receipts...)
+		manifest.EvaluationRunIDs = append(manifest.EvaluationRunIDs, evaluationRunIDs...)
+		results = append(results, result)
+	}
+	manifest = NormalizeManifest(manifest)
+	if err := ValidateInputManifest(manifest); err != nil {
+		return InputManifest{}, nil, err
+	}
+	for index := range results {
+		results[index] = NormalizeResult(results[index])
+		if err := ValidateObjectiveResult(results[index]); err != nil {
+			return InputManifest{}, nil, fmt.Errorf("objective result %q: %w", results[index].ObjectiveID, err)
+		}
+	}
+	return manifest, results, nil
+}
+
+func orderedFindingEvaluationTasks(execution PlanExecution) ([]PlanTask, error) {
+	byID := make(map[string]PlanTask, len(execution.Tasks))
+	for _, task := range execution.Tasks {
+		if task.Kind != PlanTaskKindFindingEvaluation {
+			return nil, fmt.Errorf("%w: task %q requires unsupported collector %q", ErrIncompleteInput, task.ID, task.Kind)
+		}
+		byID[task.ID] = task
+	}
+	ordered := make([]PlanTask, 0, len(execution.OrderedTaskIDs))
+	for _, taskID := range execution.OrderedTaskIDs {
+		task, ok := byID[taskID]
+		if !ok {
+			return nil, fmt.Errorf("%w: ordered task %q is not defined", ErrIncompleteInput, taskID)
+		}
+		ordered = append(ordered, task)
+	}
+	return ordered, nil
+}
+
+func validateResolvedRuntimes(tenantID string, expectedIDs []string, values []*cerebrov1.SourceRuntime) error {
+	expected := make(map[string]struct{}, len(expectedIDs))
+	for _, runtimeID := range expectedIDs {
+		expected[runtimeID] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(values))
+	for _, runtime := range values {
+		if runtime == nil || strings.TrimSpace(runtime.GetTenantId()) != strings.TrimSpace(tenantID) {
+			return fmt.Errorf("%w: source runtime ownership could not be verified", ErrIncompleteInput)
+		}
+		runtimeID := strings.TrimSpace(runtime.GetId())
+		if _, ok := expected[runtimeID]; !ok {
+			return fmt.Errorf("%w: source runtime response exceeded the requested scope", ErrIncompleteInput)
+		}
+		if _, ok := seen[runtimeID]; ok {
+			return fmt.Errorf("%w: source runtime %q was returned more than once", ErrIncompleteInput, runtimeID)
+		}
+		seen[runtimeID] = struct{}{}
+	}
+	if len(seen) != len(expected) {
+		return fmt.Errorf("%w: one or more source runtimes are unavailable in the assessment tenant", ErrIncompleteInput)
+	}
+	return nil
+}
+
+type taskCollectionState struct {
+	evaluationRunIDs []string
+	findingIDs       []string
+	reasons          []ReasonCode
+	actions          []NextAction
+	evidenceState    EvidenceState
+	incomplete       bool
+}
+
+type findingEvaluationTaskQuery struct {
+	runtimeID   string
+	queryDigest string
+	runs        []*cerebrov1.FindingEvaluationRun
+}
+
+func (c *FindingEvaluationCollector) collectTask(ctx context.Context, plan AssessmentPlanRevision, assessmentRun AssessmentRun, task PlanTask, cutoff time.Time, resolvedRuntimeByID map[string]*cerebrov1.SourceRuntime) (ObjectiveResult, []CollectionReceipt, []string, error) {
+	maxAge, err := time.ParseDuration(task.MaxAge)
+	if err != nil || maxAge <= 0 {
+		return ObjectiveResult{}, nil, nil, fmt.Errorf("%w: task %q has invalid max_age", ErrIncompleteInput, task.ID)
+	}
+	queries := make([]findingEvaluationTaskQuery, 0, len(task.RuntimeIDs))
+	for _, runtimeID := range task.RuntimeIDs {
+		query := findingEvaluationQuery{
+			TaskID: task.ID, RuntimeID: runtimeID, RuntimeIDs: task.RuntimeIDs, RuleID: task.RuleID,
+			PeriodStart: assessmentRun.PeriodStart, PeriodEnd: assessmentRun.PeriodEnd,
+			Cutoff: cutoff, MaxAge: task.MaxAge,
+		}
+		queryDigest, hashErr := semanticHash(query)
+		if hashErr != nil {
+			return ObjectiveResult{}, nil, nil, hashErr
+		}
+		runs, listErr := c.evaluations.ListFindingEvaluationRuns(ctx, ports.ListFindingEvaluationRunsRequest{
+			RuntimeID:          runtimeID,
+			RuleID:             task.RuleID,
+			Status:             "completed",
+			FinishedAtOrBefore: CanonicalTime(assessmentRun.PeriodEnd),
+			Limit:              1,
+		})
+		if listErr != nil {
+			return ObjectiveResult{}, nil, nil, fmt.Errorf("list finding evaluations for task %q runtime %q: %w", task.ID, runtimeID, listErr)
+		}
+		queries = append(queries, findingEvaluationTaskQuery{runtimeID: runtimeID, queryDigest: queryDigest, runs: runs})
+	}
+
+	// Tenant-scoped graph rules run once per orchestration cycle and bind every
+	// source dependency in that run's source snapshots. Consume the newest such
+	// run once instead of requiring one duplicate graph run per dependency.
+	if graphQueryIndex := newestGraphEvaluationQueryIndex(queries); graphQueryIndex >= 0 {
+		queries = queries[graphQueryIndex : graphQueryIndex+1]
+	}
+
+	state := taskCollectionState{evidenceState: EvidenceSufficient}
+	receipts := make([]CollectionReceipt, 0, len(queries))
+	for _, query := range queries {
+		receipt, collected, receiptErr := evaluationReceipt(task, query.runtimeID, query.queryDigest, query.runs, assessmentRun.PeriodStart, assessmentRun.PeriodEnd, cutoff, maxAge, resolvedRuntimeByID)
+		if receiptErr != nil {
+			return ObjectiveResult{}, nil, nil, receiptErr
+		}
+		receipts = append(receipts, receipt)
+		state.evaluationRunIDs = append(state.evaluationRunIDs, collected.evaluationRunIDs...)
+		state.findingIDs = append(state.findingIDs, collected.findingIDs...)
+		if collected.incomplete {
+			state.incomplete = true
+			state.reasons = append(state.reasons, collected.reasons...)
+			state.actions = append(state.actions, collected.actions...)
+			state.evidenceState = strongerEvidenceFailure(state.evidenceState, collected.evidenceState)
+		}
+	}
+	state.evaluationRunIDs = normalizedStrings(state.evaluationRunIDs)
+	state.findingIDs = normalizedStrings(state.findingIDs)
+	state.reasons = normalizedEnums(state.reasons)
+	state.actions = normalizedEnums(state.actions)
+	result, err := taskObjectiveResult(plan, task, cutoff, state)
+	if err != nil {
+		return ObjectiveResult{}, nil, nil, err
+	}
+	return result, receipts, state.evaluationRunIDs, nil
+}
+
+func newestGraphEvaluationQueryIndex(queries []findingEvaluationTaskQuery) int {
+	newestIndex := -1
+	for index, query := range queries {
+		if len(query.runs) != 1 || query.runs[0] == nil || query.runs[0].GraphRule == nil || !query.runs[0].GetGraphRule() {
+			continue
+		}
+		if newestIndex < 0 || findingEvaluationRunNewer(query.runs[0], queries[newestIndex].runs[0]) {
+			newestIndex = index
+		}
+	}
+	return newestIndex
+}
+
+func findingEvaluationRunNewer(candidate, current *cerebrov1.FindingEvaluationRun) bool {
+	if candidate == nil {
+		return false
+	}
+	if current == nil {
+		return true
+	}
+	candidateFinishedAt := candidate.GetFinishedAt()
+	currentFinishedAt := current.GetFinishedAt()
+	if candidateFinishedAt != nil && candidateFinishedAt.CheckValid() == nil && currentFinishedAt != nil && currentFinishedAt.CheckValid() == nil {
+		candidateTime := CanonicalTime(candidateFinishedAt.AsTime())
+		currentTime := CanonicalTime(currentFinishedAt.AsTime())
+		if !candidateTime.Equal(currentTime) {
+			return candidateTime.After(currentTime)
+		}
+	} else if candidateFinishedAt != nil && candidateFinishedAt.CheckValid() == nil {
+		return true
+	} else if currentFinishedAt != nil && currentFinishedAt.CheckValid() == nil {
+		return false
+	}
+	return strings.TrimSpace(candidate.GetId()) > strings.TrimSpace(current.GetId())
+}
+
+type findingEvaluationQuery struct {
+	TaskID      string    `json:"task_id"`
+	RuntimeID   string    `json:"runtime_id"`
+	RuntimeIDs  []string  `json:"runtime_ids"`
+	RuleID      string    `json:"rule_id"`
+	PeriodStart time.Time `json:"period_start"`
+	PeriodEnd   time.Time `json:"period_end"`
+	Cutoff      time.Time `json:"cutoff"`
+	MaxAge      string    `json:"max_age"`
+}
+
+type findingEvaluationPage struct {
+	ID                       string                        `json:"id"`
+	RuntimeID                string                        `json:"runtime_id"`
+	RuleID                   string                        `json:"rule_id"`
+	Status                   string                        `json:"status"`
+	EventLimit               uint32                        `json:"event_limit"`
+	EventsEvaluated          uint32                        `json:"events_evaluated"`
+	EventsProcessed          uint32                        `json:"events_processed"`
+	FindingsUpserted         uint32                        `json:"findings_upserted"`
+	FindingsEmitted          uint32                        `json:"findings_emitted"`
+	FindingIDs               []string                      `json:"finding_ids"`
+	StartedAt                time.Time                     `json:"started_at"`
+	FinishedAt               time.Time                     `json:"finished_at"`
+	GraphRule                bool                          `json:"graph_rule"`
+	GraphRowsRead            uint32                        `json:"graph_rows_read"`
+	GraphTruncated           bool                          `json:"graph_truncated"`
+	GraphRowLimit            uint32                        `json:"graph_row_limit"`
+	SourceDependencyComplete bool                          `json:"source_dependency_complete"`
+	RuleApplicable           bool                          `json:"rule_applicable"`
+	SourceSnapshots          []findingEvaluationSourcePage `json:"source_snapshots"`
+}
+
+type findingEvaluationSourcePage struct {
+	RuntimeID             string    `json:"runtime_id"`
+	SourceID              string    `json:"source_id"`
+	Family                string    `json:"family"`
+	LastSyncedAt          time.Time `json:"last_synced_at"`
+	CheckpointWatermark   time.Time `json:"checkpoint_watermark"`
+	Complete              bool      `json:"complete"`
+	RecordsScanned        uint32    `json:"records_scanned"`
+	RecordsAccepted       uint32    `json:"records_accepted"`
+	RecordsRejected       uint32    `json:"records_rejected"`
+	SyncStatus            string    `json:"sync_status"`
+	ContractProbeState    string    `json:"contract_probe_state"`
+	ProgressConfigHash    string    `json:"progress_config_hash"`
+	GraphIngestRunID      string    `json:"graph_ingest_run_id,omitempty"`
+	GraphIngestStatus     string    `json:"graph_ingest_status,omitempty"`
+	GraphCheckpointID     string    `json:"graph_checkpoint_id,omitempty"`
+	GraphIngestedAt       time.Time `json:"graph_ingested_at,omitempty"`
+	GraphSnapshotComplete bool      `json:"graph_snapshot_complete,omitempty"`
+}
+
+func evaluationReceipt(task PlanTask, runtimeID, queryDigest string, runs []*cerebrov1.FindingEvaluationRun, periodStart, periodEnd, cutoff time.Time, maxAge time.Duration, resolvedRuntimeByID map[string]*cerebrov1.SourceRuntime) (CollectionReceipt, taskCollectionState, error) {
+	kind := PlanTaskKindFindingEvaluation + ":" + task.ID
+	zero := uint64(0)
+	missingDigest, err := semanticHash(struct {
+		QueryDigest string `json:"query_digest"`
+		State       string `json:"state"`
+	}{QueryDigest: queryDigest, State: "missing"})
+	if err != nil {
+		return CollectionReceipt{}, taskCollectionState{}, err
+	}
+	if len(runs) == 0 {
+		return CollectionReceipt{
+				Kind: kind, RuntimeID: runtimeID, QueryDigest: queryDigest, PageIndex: 0,
+				ExpectedTotal: &zero, Cutoff: cutoff, Completeness: CollectionUnknown, PageDigest: missingDigest,
+			}, taskCollectionState{
+				incomplete: true, evidenceState: EvidenceMissing,
+				reasons: []ReasonCode{ReasonEvidenceMissing}, actions: []NextAction{ActionCollectEvidence},
+			}, nil
+	}
+	if len(runs) != 1 || runs[0] == nil {
+		return CollectionReceipt{}, taskCollectionState{}, fmt.Errorf("%w: finding evaluation query for task %q returned an invalid page", ErrIncompleteInput, task.ID)
+	}
+	run := runs[0]
+	if strings.TrimSpace(run.GetId()) == "" || strings.TrimSpace(run.GetRuntimeId()) != runtimeID || strings.TrimSpace(run.GetRuleId()) != task.RuleID || strings.TrimSpace(run.GetStatus()) != "completed" ||
+		run.GetStartedAt() == nil || run.GetStartedAt().CheckValid() != nil || run.GetFinishedAt() == nil || run.GetFinishedAt().CheckValid() != nil {
+		return CollectionReceipt{}, taskCollectionState{}, fmt.Errorf("%w: finding evaluation run for task %q is invalid", ErrIncompleteInput, task.ID)
+	}
+	startedAt := CanonicalTime(run.GetStartedAt().AsTime())
+	finishedAt := CanonicalTime(run.GetFinishedAt().AsTime())
+	if finishedAt.Before(startedAt) {
+		return CollectionReceipt{}, taskCollectionState{}, fmt.Errorf("%w: finding evaluation run %q has an invalid time range", ErrIncompleteInput, run.GetId())
+	}
+	findingIDs := normalizedStrings(run.GetFindingIds())
+	if len(findingIDs) != len(run.GetFindingIds()) || uint64(len(findingIDs)) != uint64(run.GetFindingsUpserted()) || run.GetFindingsEmitted() != run.GetFindingsUpserted() {
+		return CollectionReceipt{}, taskCollectionState{}, fmt.Errorf("%w: finding evaluation run %q has inconsistent finding counts", ErrIncompleteInput, run.GetId())
+	}
+	population, truncated, err := evaluationPopulation(run)
+	if err != nil {
+		return CollectionReceipt{}, taskCollectionState{}, err
+	}
+	sourcePages := findingEvaluationSourcePages(run.GetSourceSnapshots())
+	pageDigest, err := semanticHash(findingEvaluationPage{
+		ID: run.GetId(), RuntimeID: run.GetRuntimeId(), RuleID: run.GetRuleId(), Status: run.GetStatus(),
+		EventLimit: run.GetEventLimit(), EventsEvaluated: run.GetEventsEvaluated(), EventsProcessed: run.GetEventsProcessed(),
+		FindingsUpserted: run.GetFindingsUpserted(), FindingsEmitted: run.GetFindingsEmitted(), FindingIDs: findingIDs,
+		StartedAt: startedAt, FinishedAt: finishedAt, GraphRule: run.GetGraphRule(), GraphRowsRead: run.GetGraphRowsRead(),
+		GraphTruncated: run.GetGraphTruncated(), GraphRowLimit: run.GetGraphRowLimit(),
+		SourceDependencyComplete: run.GetSourceDependencyComplete(), RuleApplicable: run.GetRuleApplicable(), SourceSnapshots: sourcePages,
+	})
+	if err != nil {
+		return CollectionReceipt{}, taskCollectionState{}, err
+	}
+	expected := population
+	receipt := CollectionReceipt{
+		Kind: kind, RuntimeID: runtimeID, QueryDigest: queryDigest, PageIndex: 0,
+		RawCount: population, Deduplicated: population, Included: population, ExpectedTotal: &expected,
+		Watermark: finishedAt, Cutoff: cutoff, Completeness: CollectionComplete, PageDigest: pageDigest,
+	}
+	collected := taskCollectionState{
+		evaluationRunIDs: []string{run.GetId()},
+		findingIDs:       findingIDs,
+		evidenceState:    EvidenceSufficient,
+	}
+	periodStart = CanonicalTime(periodStart)
+	periodEnd = CanonicalTime(periodEnd)
+	// Graph evaluation envelopes do not carry a tenant-wide graph generation.
+	// Source runtime snapshots therefore cannot prove that the shared graph was
+	// stable while the rule ran. Keep legacy and new graph runs inspectable, but
+	// do not admit them as assessment evidence until that fence is persisted and
+	// verified here at the consumer boundary.
+	if run.GetGraphRule() {
+		receipt.Completeness = CollectionUnknown
+		collected.incomplete = true
+		collected.evidenceState = EvidenceUntrusted
+		collected.reasons = []ReasonCode{ReasonSourceUntrusted}
+		collected.actions = []NextAction{ActionRestoreSource}
+	} else if finishedAt.Before(periodStart) || periodEnd.Sub(finishedAt) > maxAge {
+		receipt.Completeness = CollectionUnknown
+		collected.incomplete = true
+		collected.evidenceState = EvidenceStale
+		collected.reasons = []ReasonCode{ReasonEvidenceStale}
+		collected.actions = []NextAction{ActionRefreshEvidence}
+	} else if finishedAt.After(periodEnd) || finishedAt.After(cutoff) {
+		receipt.Completeness = CollectionUnknown
+		collected.incomplete = true
+		collected.evidenceState = EvidenceUntrusted
+		collected.reasons = []ReasonCode{ReasonEvidenceInvalid}
+		collected.actions = []NextAction{ActionReview}
+	} else if run.RuleApplicable == nil || !run.GetRuleApplicable() {
+		receipt.Completeness = CollectionUnknown
+		collected.incomplete = true
+		collected.evidenceState = EvidenceUntrusted
+		collected.reasons = []ReasonCode{ReasonSourceUnsupported}
+		collected.actions = []NextAction{ActionReview}
+	} else if sourceSnapshotErr := validateEvaluationSourceSnapshots(run, task.RuntimeIDs, startedAt, periodEnd, maxAge, resolvedRuntimeByID); sourceSnapshotErr != nil {
+		receipt.Completeness = CollectionUnknown
+		collected.incomplete = true
+		collected.evidenceState = EvidenceUntrusted
+		collected.reasons = []ReasonCode{ReasonSourceUntrusted}
+		collected.actions = []NextAction{ActionRestoreSource}
+	} else if truncated {
+		receipt.Completeness = CollectionTruncated
+		collected.incomplete = true
+		collected.evidenceState = EvidenceIncomplete
+		collected.reasons = []ReasonCode{ReasonCoverageIncomplete}
+		collected.actions = []NextAction{ActionCollectEvidence}
+	}
+	return receipt, collected, nil
+}
+
+func findingEvaluationSourcePages(snapshots []*cerebrov1.FindingEvaluationSourceSnapshot) []findingEvaluationSourcePage {
+	pages := make([]findingEvaluationSourcePage, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		if snapshot == nil {
+			continue
+		}
+		page := findingEvaluationSourcePage{
+			RuntimeID: snapshot.GetRuntimeId(), SourceID: snapshot.GetSourceId(), Family: snapshot.GetFamily(), Complete: snapshot.GetComplete(),
+			RecordsScanned: snapshot.GetRecordsScanned(), RecordsAccepted: snapshot.GetRecordsAccepted(), RecordsRejected: snapshot.GetRecordsRejected(),
+			SyncStatus: snapshot.GetSyncStatus(), ContractProbeState: snapshot.GetContractProbeState(), ProgressConfigHash: snapshot.GetProgressConfigHash(),
+			GraphIngestRunID: snapshot.GetGraphIngestRunId(), GraphIngestStatus: snapshot.GetGraphIngestStatus(), GraphCheckpointID: snapshot.GetGraphCheckpointId(),
+			GraphSnapshotComplete: snapshot.GetGraphSnapshotComplete(),
+		}
+		if value := snapshot.GetLastSyncedAt(); value != nil && value.CheckValid() == nil {
+			page.LastSyncedAt = CanonicalTime(value.AsTime())
+		}
+		if value := snapshot.GetCheckpointWatermark(); value != nil && value.CheckValid() == nil {
+			page.CheckpointWatermark = CanonicalTime(value.AsTime())
+		}
+		if value := snapshot.GetGraphIngestedAt(); value != nil && value.CheckValid() == nil {
+			page.GraphIngestedAt = CanonicalTime(value.AsTime())
+		}
+		pages = append(pages, page)
+	}
+	sort.Slice(pages, func(i, j int) bool { return pages[i].RuntimeID < pages[j].RuntimeID })
+	return pages
+}
+
+func validateEvaluationSourceSnapshots(run *cerebrov1.FindingEvaluationRun, taskRuntimeIDs []string, evaluationStartedAt, periodEnd time.Time, maxAge time.Duration, resolvedRuntimeByID map[string]*cerebrov1.SourceRuntime) error {
+	if run.SourceDependencyComplete == nil || !run.GetSourceDependencyComplete() || len(run.GetSourceSnapshots()) == 0 {
+		return fmt.Errorf("%w: finding evaluation run %q has incomplete source dependencies", ErrIncompleteInput, run.GetId())
+	}
+	allowedRuntimeIDs := make(map[string]struct{}, len(taskRuntimeIDs))
+	for _, runtimeID := range taskRuntimeIDs {
+		allowedRuntimeIDs[strings.TrimSpace(runtimeID)] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(run.GetSourceSnapshots()))
+	for _, snapshot := range run.GetSourceSnapshots() {
+		if snapshot == nil || snapshot.Complete == nil || !snapshot.GetComplete() || snapshot.GetLastSyncedAt() == nil || snapshot.GetLastSyncedAt().CheckValid() != nil ||
+			snapshot.GetCheckpointWatermark() == nil || snapshot.GetCheckpointWatermark().CheckValid() != nil || snapshot.GetSyncStatus() != "completed" ||
+			(snapshot.GetContractProbeState() != "passing" && snapshot.GetContractProbeState() != "not_configured") || snapshot.GetRecordsRejected() != 0 ||
+			snapshot.GetRecordsAccepted() > snapshot.GetRecordsScanned() || strings.TrimSpace(snapshot.GetProgressConfigHash()) == "" {
+			return fmt.Errorf("%w: finding evaluation run %q has an incomplete source snapshot", ErrIncompleteInput, run.GetId())
+		}
+		runtimeID := strings.TrimSpace(snapshot.GetRuntimeId())
+		if runtimeID == "" {
+			return fmt.Errorf("%w: finding evaluation run %q has an unnamed source snapshot", ErrIncompleteInput, run.GetId())
+		}
+		if _, ok := allowedRuntimeIDs[runtimeID]; !ok {
+			return fmt.Errorf("%w: finding evaluation run %q reads runtime %q outside the plan", ErrIncompleteInput, run.GetId(), runtimeID)
+		}
+		if _, ok := seen[runtimeID]; ok {
+			return fmt.Errorf("%w: finding evaluation run %q duplicates runtime %q", ErrIncompleteInput, run.GetId(), runtimeID)
+		}
+		seen[runtimeID] = struct{}{}
+		current := resolvedRuntimeByID[runtimeID]
+		if current == nil {
+			return fmt.Errorf("%w: finding evaluation run %q runtime %q is unavailable", ErrIncompleteInput, run.GetId(), runtimeID)
+		}
+		currentConfig := current.GetConfig()
+		if strings.TrimSpace(current.GetSourceId()) != strings.TrimSpace(snapshot.GetSourceId()) ||
+			strings.TrimSpace(current.GetConfig()["family"]) != strings.TrimSpace(snapshot.GetFamily()) ||
+			strings.TrimSpace(currentConfig["__cerebro_resolved_progress_config_hash"]) != strings.TrimSpace(snapshot.GetProgressConfigHash()) {
+			return fmt.Errorf("%w: finding evaluation run %q source scope changed for runtime %q", ErrIncompleteInput, run.GetId(), runtimeID)
+		}
+		lastSyncedAt := CanonicalTime(snapshot.GetLastSyncedAt().AsTime())
+		checkpointWatermark := CanonicalTime(snapshot.GetCheckpointWatermark().AsTime())
+		if current.GetLastSyncedAt() == nil || current.GetLastSyncedAt().CheckValid() != nil || current.GetCheckpoint().GetWatermark() == nil || current.GetCheckpoint().GetWatermark().CheckValid() != nil {
+			return fmt.Errorf("%w: finding evaluation run %q no longer matches runtime %q progress", ErrIncompleteInput, run.GetId(), runtimeID)
+		}
+		currentLastSyncedAt := CanonicalTime(current.GetLastSyncedAt().AsTime())
+		currentCheckpointWatermark := CanonicalTime(current.GetCheckpoint().GetWatermark().AsTime())
+		if !currentLastSyncedAt.Equal(lastSyncedAt) || !currentCheckpointWatermark.Equal(checkpointWatermark) {
+			return fmt.Errorf("%w: finding evaluation run %q no longer matches runtime %q progress", ErrIncompleteInput, run.GetId(), runtimeID)
+		}
+		if !currentRuntimeMatchesSnapshot(current, snapshot) {
+			return fmt.Errorf("%w: finding evaluation run %q no longer matches runtime %q state", ErrIncompleteInput, run.GetId(), runtimeID)
+		}
+		if lastSyncedAt.After(evaluationStartedAt) || lastSyncedAt.After(periodEnd) || checkpointWatermark.After(periodEnd) ||
+			periodEnd.Sub(lastSyncedAt) > maxAge || periodEnd.Sub(checkpointWatermark) > maxAge {
+			return fmt.Errorf("%w: finding evaluation run %q source snapshot is outside the assessment period", ErrIncompleteInput, run.GetId())
+		}
+		if run.GetGraphRule() {
+			if snapshot.GraphSnapshotComplete == nil || !snapshot.GetGraphSnapshotComplete() || snapshot.GetGraphIngestedAt() == nil || snapshot.GetGraphIngestedAt().CheckValid() != nil ||
+				snapshot.GetGraphIngestStatus() != "completed" || strings.TrimSpace(snapshot.GetGraphIngestRunId()) == "" || strings.TrimSpace(snapshot.GetGraphCheckpointId()) == "" {
+				return fmt.Errorf("%w: graph evaluation run %q has no complete graph snapshot for runtime %q", ErrIncompleteInput, run.GetId(), runtimeID)
+			}
+			graphIngestedAt := CanonicalTime(snapshot.GetGraphIngestedAt().AsTime())
+			if graphIngestedAt.Before(lastSyncedAt) || graphIngestedAt.After(evaluationStartedAt) || graphIngestedAt.After(periodEnd) || periodEnd.Sub(graphIngestedAt) > maxAge {
+				return fmt.Errorf("%w: graph evaluation run %q graph snapshot is outside the assessment period", ErrIncompleteInput, run.GetId())
+			}
+		}
+	}
+	if run.GetGraphRule() && len(seen) != len(allowedRuntimeIDs) {
+		return fmt.Errorf("%w: graph evaluation run %q does not cover every planned runtime", ErrIncompleteInput, run.GetId())
+	}
+	return nil
+}
+
+func parseRuntimeCounter(value string) (uint32, bool) {
+	parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+	return uint32(parsed), err == nil
+}
+
+func currentRuntimeMatchesSnapshot(current *cerebrov1.SourceRuntime, snapshot *cerebrov1.FindingEvaluationSourceSnapshot) bool {
+	if current == nil || snapshot == nil {
+		return false
+	}
+	config := current.GetConfig()
+	contractState := strings.TrimSpace(config["__cerebro_runtime_contract_probe_state"])
+	scanned, scannedOK := parseRuntimeCounter(config["__cerebro_runtime_records_scanned"])
+	accepted, acceptedOK := parseRuntimeCounter(config["__cerebro_runtime_records_accepted"])
+	rejected, rejectedOK := parseRuntimeCounter(config["__cerebro_runtime_records_rejected"])
+	return strings.TrimSpace(config["__cerebro_runtime_status"]) == "completed" && strings.TrimSpace(config["__cerebro_runtime_last_failure_category"]) == "" &&
+		scannedOK && acceptedOK && rejectedOK && scanned == snapshot.GetRecordsScanned() && accepted == snapshot.GetRecordsAccepted() &&
+		rejected == snapshot.GetRecordsRejected() && rejected == 0 && contractState == snapshot.GetContractProbeState() &&
+		(contractState == "passing" || contractState == "not_configured") &&
+		strings.TrimSpace(current.GetNextCursor().GetOpaque()) == ""
+}
+
+func evaluationPopulation(run *cerebrov1.FindingEvaluationRun) (uint64, bool, error) {
+	if run.GraphRule == nil {
+		return 0, false, fmt.Errorf("%w: finding evaluation run %q does not identify its rule type", ErrIncompleteInput, run.GetId())
+	}
+	if run.GetGraphRule() {
+		if run.GraphRowsRead == nil || run.GraphTruncated == nil || run.GraphRowLimit == nil || run.GetGraphRowLimit() == 0 ||
+			run.GetEventLimit() != 0 || run.GetEventsEvaluated() != 0 || run.GetEventsProcessed() != 0 || run.GetGraphRowsRead() > run.GetGraphRowLimit() ||
+			(run.GetGraphRowsRead() >= run.GetGraphRowLimit() && !run.GetGraphTruncated()) {
+			return 0, false, fmt.Errorf("%w: graph evaluation run %q has inconsistent population metadata", ErrIncompleteInput, run.GetId())
+		}
+		population := uint64(run.GetGraphRowsRead())
+		return population, run.GetGraphTruncated(), nil
+	}
+	if run.GetEventLimit() == 0 || run.GetEventsEvaluated() != run.GetEventsProcessed() {
+		return 0, false, fmt.Errorf("%w: event evaluation run %q has inconsistent population metadata", ErrIncompleteInput, run.GetId())
+	}
+	population := uint64(run.GetEventsProcessed())
+	return population, population >= uint64(run.GetEventLimit()), nil
+}
+
+func taskObjectiveResult(plan AssessmentPlanRevision, task PlanTask, cutoff time.Time, state taskCollectionState) (ObjectiveResult, error) {
+	identityDigest, err := semanticHash(struct {
+		PlanRevisionID  string    `json:"plan_revision_id"`
+		TaskID          string    `json:"task_id"`
+		ObjectiveID     string    `json:"objective_id"`
+		EvaluationRunID []string  `json:"evaluation_run_ids"`
+		Cutoff          time.Time `json:"cutoff"`
+	}{
+		PlanRevisionID: plan.RevisionID, TaskID: task.ID, ObjectiveID: task.ObjectiveID,
+		EvaluationRunID: state.evaluationRunIDs, Cutoff: cutoff,
+	})
+	if err != nil {
+		return ObjectiveResult{}, err
+	}
+	result := ObjectiveResult{
+		ID:         "assessment-result-" + strings.TrimPrefix(identityDigest, "sha256:")[:24],
+		ControlRef: task.ControlRef, ObjectiveID: task.ObjectiveID, ScopeState: ScopeInScope,
+		DesignState: DesignUnknown, OperatingEffectivenessState: OperatingNotTested,
+		DispositionState: DispositionNone, AuditorState: AuditorNotReviewed,
+		EvidenceIDs: state.evaluationRunIDs, FindingIDs: state.findingIDs, SourceRuntimeIDs: task.RuntimeIDs,
+		EvaluatorRevision: findingEvaluationCollectorRevision, EvaluatedAt: cutoff,
+	}
+	if state.incomplete {
+		result.AutomatedOutcome = OutcomeIndeterminate
+		result.EvidenceState = state.evidenceState
+		result.Assurance = AssuranceNone
+		result.ReasonCodes = state.reasons
+		result.NextActions = state.actions
+	} else if len(state.findingIDs) != 0 {
+		result.AutomatedOutcome = OutcomeNotSatisfied
+		result.EvidenceState = EvidenceSufficient
+		result.Assurance = AssuranceMedium
+		result.ReasonCodes = []ReasonCode{ReasonActiveFinding}
+		result.NextActions = []NextAction{ActionRemediate}
+	} else {
+		result.AutomatedOutcome = OutcomeSatisfied
+		result.EvidenceState = EvidenceSufficient
+		result.Assurance = AssuranceMedium
+		result.ReasonCodes = []ReasonCode{ReasonSatisfied}
+		result.NextActions = []NextAction{ActionNone}
+	}
+	return NormalizeResult(result), nil
+}
+
+func strongerEvidenceFailure(current, candidate EvidenceState) EvidenceState {
+	rank := map[EvidenceState]int{
+		EvidenceSufficient: 0,
+		EvidenceStale:      1,
+		EvidenceMissing:    2,
+		EvidenceIncomplete: 3,
+		EvidenceUntrusted:  4,
+	}
+	if rank[candidate] > rank[current] {
+		return candidate
+	}
+	return current
+}

--- a/internal/complianceassessment/finding_evaluation_collector_test.go
+++ b/internal/complianceassessment/finding_evaluation_collector_test.go
@@ -1,0 +1,464 @@
+package complianceassessment
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestFindingEvaluationCollectorProducesPointInTimeResults(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		evaluation       *cerebrov1.FindingEvaluationRun
+		wantOutcome      AutomatedOutcome
+		wantEvidence     EvidenceState
+		wantCompleteness CollectionCompleteness
+		wantReason       ReasonCode
+		wantFindings     int
+		mutateRuntime    func(*cerebrov1.SourceRuntime)
+	}{
+		{
+			name:        "satisfied event evaluation",
+			evaluation:  eventEvaluationRun("evaluation-1", cutoff.Add(-30*time.Minute), 100, 12),
+			wantOutcome: OutcomeSatisfied, wantEvidence: EvidenceSufficient,
+			wantCompleteness: CollectionComplete, wantReason: ReasonSatisfied,
+		},
+		{
+			name: "active finding",
+			evaluation: func() *cerebrov1.FindingEvaluationRun {
+				run := eventEvaluationRun("evaluation-2", cutoff.Add(-30*time.Minute), 100, 12)
+				run.FindingIds = []string{"finding-1"}
+				run.FindingsUpserted = 1
+				run.FindingsEmitted = 1
+				return run
+			}(),
+			wantOutcome: OutcomeNotSatisfied, wantEvidence: EvidenceSufficient,
+			wantCompleteness: CollectionComplete, wantReason: ReasonActiveFinding, wantFindings: 1,
+		},
+		{
+			name:        "truncated event evaluation",
+			evaluation:  eventEvaluationRun("evaluation-3", cutoff.Add(-30*time.Minute), 10, 10),
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceIncomplete,
+			wantCompleteness: CollectionTruncated, wantReason: ReasonCoverageIncomplete,
+		},
+		{
+			name:        "stale event evaluation",
+			evaluation:  eventEvaluationRun("evaluation-4", cutoff.Add(-3*time.Hour), 100, 12),
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceStale,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonEvidenceStale,
+		},
+		{
+			name:        "missing event evaluation",
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceMissing,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonEvidenceMissing,
+		},
+		{
+			name:        "legacy complete graph evaluation remains untrusted",
+			evaluation:  graphEvaluationRun("evaluation-5", cutoff.Add(-30*time.Minute), 14),
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUntrusted,
+		},
+		{
+			name: "internally truncated graph evaluation",
+			evaluation: func() *cerebrov1.FindingEvaluationRun {
+				run := graphEvaluationRun("evaluation-6", cutoff.Add(-30*time.Minute), 2)
+				run.GraphTruncated = boolPointer(true)
+				return run
+			}(),
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUntrusted,
+		},
+		{
+			name: "incomplete source snapshot",
+			evaluation: func() *cerebrov1.FindingEvaluationRun {
+				run := eventEvaluationRun("evaluation-7", cutoff.Add(-30*time.Minute), 100, 12)
+				run.SourceSnapshots[0].LastSyncedAt = nil
+				run.SourceSnapshots[0].CheckpointWatermark = nil
+				run.SourceSnapshots[0].Complete = boolPointer(false)
+				return run
+			}(),
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUntrusted,
+		},
+		{
+			name: "rejected source records",
+			evaluation: func() *cerebrov1.FindingEvaluationRun {
+				run := eventEvaluationRun("evaluation-8", cutoff.Add(-30*time.Minute), 100, 12)
+				run.SourceSnapshots[0].RecordsRejected = 1
+				run.SourceSnapshots[0].Complete = boolPointer(false)
+				return run
+			}(),
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUntrusted,
+		},
+		{
+			name:       "failed current runtime",
+			evaluation: eventEvaluationRun("evaluation-9", cutoff.Add(-30*time.Minute), 100, 12),
+			mutateRuntime: func(runtime *cerebrov1.SourceRuntime) {
+				runtime.Config["__cerebro_runtime_status"] = "failed"
+				runtime.Config["__cerebro_runtime_last_failure_category"] = "provider"
+			},
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUntrusted,
+		},
+		{
+			name:       "changed source scope",
+			evaluation: eventEvaluationRun("evaluation-10", cutoff.Add(-30*time.Minute), 100, 12),
+			mutateRuntime: func(runtime *cerebrov1.SourceRuntime) {
+				runtime.Config["__cerebro_resolved_progress_config_hash"] = "sha256:changed"
+			},
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUntrusted,
+		},
+		{
+			name:       "advanced current runtime progress",
+			evaluation: eventEvaluationRun("evaluation-advanced-runtime", cutoff.Add(-30*time.Minute), 100, 12),
+			mutateRuntime: func(runtime *cerebrov1.SourceRuntime) {
+				advanced := runtime.GetLastSyncedAt().AsTime().Add(time.Minute)
+				runtime.LastSyncedAt = timestamppb.New(advanced)
+				runtime.Checkpoint.Watermark = timestamppb.New(advanced)
+			},
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUntrusted,
+		},
+		{
+			name: "unsupported cleanup run",
+			evaluation: func() *cerebrov1.FindingEvaluationRun {
+				run := eventEvaluationRun("evaluation-11", cutoff.Add(-30*time.Minute), 100, 12)
+				run.RuleApplicable = boolPointer(false)
+				return run
+			}(),
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUnsupported,
+		},
+		{
+			name: "graph projection predates source",
+			evaluation: func() *cerebrov1.FindingEvaluationRun {
+				run := graphEvaluationRun("evaluation-12", cutoff.Add(-30*time.Minute), 14)
+				run.SourceSnapshots[0].GraphIngestedAt = timestamppb.New(run.SourceSnapshots[0].GetLastSyncedAt().AsTime().Add(-time.Minute))
+				return run
+			}(),
+			wantOutcome: OutcomeIndeterminate, wantEvidence: EvidenceUntrusted,
+			wantCompleteness: CollectionUnknown, wantReason: ReasonSourceUntrusted,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			plan := collectorTestPlan(cutoff)
+			plans := &collectorPlanReader{plan: plan}
+			runtime := collectorTestRuntimeForEvaluation(test.evaluation, cutoff)
+			if test.mutateRuntime != nil {
+				test.mutateRuntime(runtime)
+			}
+			runtimes := &collectorRuntimeLister{values: []*cerebrov1.SourceRuntime{runtime}}
+			evaluations := &collectorEvaluationLister{}
+			if test.evaluation != nil {
+				evaluations.values = []*cerebrov1.FindingEvaluationRun{test.evaluation}
+			}
+			collector := NewFindingEvaluationCollector(plans, runtimes, evaluations)
+			collector.now = func() time.Time { return cutoff }
+
+			manifest, results, err := collector.Collect(context.Background(), collectorTestRun(cutoff))
+			if err != nil {
+				t.Fatalf("Collect() error = %v", err)
+			}
+			if err := ValidateInputManifest(manifest); err != nil {
+				t.Fatalf("ValidateInputManifest() error = %v", err)
+			}
+			if len(manifest.Receipts) != 1 || manifest.Receipts[0].Completeness != test.wantCompleteness {
+				t.Fatalf("receipts = %#v, want one %q receipt", manifest.Receipts, test.wantCompleteness)
+			}
+			if len(results) != 1 {
+				t.Fatalf("len(results) = %d, want 1", len(results))
+			}
+			result := results[0]
+			if result.AutomatedOutcome != test.wantOutcome || result.EvidenceState != test.wantEvidence || result.OperatingEffectivenessState != OperatingNotTested {
+				t.Fatalf("result states = (%q, %q, %q), want (%q, %q, %q)", result.AutomatedOutcome, result.EvidenceState, result.OperatingEffectivenessState, test.wantOutcome, test.wantEvidence, OperatingNotTested)
+			}
+			if !containsReason(result.ReasonCodes, test.wantReason) || len(result.FindingIDs) != test.wantFindings {
+				t.Fatalf("result reasons/findings = (%#v, %#v)", result.ReasonCodes, result.FindingIDs)
+			}
+			if got := runtimes.filter.TenantID; got != "tenant-1" {
+				t.Fatalf("runtime tenant filter = %q, want tenant-1", got)
+			}
+			if got := evaluations.request; got.RuntimeID != "runtime-1" || got.RuleID != "rule-1" || got.Status != "completed" || !got.FinishedAtOrBefore.Equal(cutoff) || got.Limit != 1 {
+				t.Fatalf("evaluation request = %#v", got)
+			}
+		})
+	}
+}
+
+func TestFindingEvaluationCollectorRejectsPostPeriodEvidence(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	run := collectorTestRun(cutoff)
+	run.PeriodEnd = cutoff.Add(-time.Hour)
+	evaluation := eventEvaluationRun("evaluation-after-period", cutoff.Add(-30*time.Minute), 100, 12)
+	evaluations := &collectorEvaluationLister{values: []*cerebrov1.FindingEvaluationRun{evaluation}}
+	collector := NewFindingEvaluationCollector(
+		&collectorPlanReader{plan: collectorTestPlan(cutoff)},
+		&collectorRuntimeLister{values: []*cerebrov1.SourceRuntime{collectorTestRuntimeForEvaluation(evaluation, cutoff)}},
+		evaluations,
+	)
+	collector.now = func() time.Time { return cutoff }
+	manifest, results, err := collector.Collect(context.Background(), run)
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+	if !evaluations.request.FinishedAtOrBefore.Equal(run.PeriodEnd) {
+		t.Fatalf("FinishedAtOrBefore = %v, want %v", evaluations.request.FinishedAtOrBefore, run.PeriodEnd)
+	}
+	if manifest.Receipts[0].Completeness != CollectionUnknown || results[0].AutomatedOutcome != OutcomeIndeterminate || !containsReason(results[0].ReasonCodes, ReasonEvidenceInvalid) {
+		t.Fatalf("post-period result = receipt:%#v result:%#v", manifest.Receipts[0], results[0])
+	}
+}
+
+func TestFindingEvaluationCollectorRejectsRuntimeOutsideTenant(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	collector := NewFindingEvaluationCollector(
+		&collectorPlanReader{plan: collectorTestPlan(cutoff)},
+		&collectorRuntimeLister{values: []*cerebrov1.SourceRuntime{{Id: "runtime-1", TenantId: "tenant-2"}}},
+		&collectorEvaluationLister{},
+	)
+	collector.now = func() time.Time { return cutoff }
+	_, _, err := collector.Collect(context.Background(), collectorTestRun(cutoff))
+	if !errors.Is(err, ErrIncompleteInput) {
+		t.Fatalf("Collect() error = %v, want ErrIncompleteInput", err)
+	}
+}
+
+func TestFindingEvaluationCollectorRejectsInconsistentFindingCounts(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	evaluation := eventEvaluationRun("evaluation-1", cutoff.Add(-time.Minute), 100, 12)
+	evaluation.FindingIds = []string{"finding-1"}
+	collector := NewFindingEvaluationCollector(
+		&collectorPlanReader{plan: collectorTestPlan(cutoff)},
+		&collectorRuntimeLister{values: []*cerebrov1.SourceRuntime{collectorTestRuntimeForEvaluation(evaluation, cutoff)}},
+		&collectorEvaluationLister{values: []*cerebrov1.FindingEvaluationRun{evaluation}},
+	)
+	collector.now = func() time.Time { return cutoff }
+	_, _, err := collector.Collect(context.Background(), collectorTestRun(cutoff))
+	if !errors.Is(err, ErrIncompleteInput) {
+		t.Fatalf("Collect() error = %v, want ErrIncompleteInput", err)
+	}
+}
+
+func TestValidateEvaluationSourceSnapshotsRequiresEveryGraphSourceInPlan(t *testing.T) {
+	t.Parallel()
+	finishedAt := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	evaluation := graphEvaluationRun("evaluation-cross-source", finishedAt, 4)
+	second := collectorTestSourceSnapshot(evaluation.GetSourceSnapshots()[0].GetLastSyncedAt().AsTime(), true)
+	second.RuntimeId = "runtime-2"
+	second.SourceId = "github"
+	second.Family = "audit"
+	second.GraphIngestRunId = "graph-run-2"
+	second.GraphCheckpointId = "graph-checkpoint-2"
+	evaluation.SourceSnapshots = append(evaluation.SourceSnapshots, second)
+	runtimes := map[string]*cerebrov1.SourceRuntime{
+		"runtime-1": collectorTestRuntimeFromSnapshot(evaluation.GetSourceSnapshots()[0]),
+		"runtime-2": collectorTestRuntimeFromSnapshot(second),
+	}
+	startedAt := evaluation.GetStartedAt().AsTime()
+	if err := validateEvaluationSourceSnapshots(evaluation, []string{"runtime-1"}, startedAt, finishedAt, 2*time.Hour, runtimes); !errors.Is(err, ErrIncompleteInput) {
+		t.Fatalf("validateEvaluationSourceSnapshots() error = %v, want dependency outside plan", err)
+	}
+	if err := validateEvaluationSourceSnapshots(evaluation, []string{"runtime-1", "runtime-2"}, startedAt, finishedAt, 2*time.Hour, runtimes); err != nil {
+		t.Fatalf("validateEvaluationSourceSnapshots() with complete plan error = %v", err)
+	}
+	runtimes["runtime-3"] = collectorTestRuntimeFromSnapshot(evaluation.GetSourceSnapshots()[0])
+	runtimes["runtime-3"].Id = "runtime-3"
+	if err := validateEvaluationSourceSnapshots(evaluation, []string{"runtime-1", "runtime-2", "runtime-3"}, startedAt, finishedAt, 2*time.Hour, runtimes); !errors.Is(err, ErrIncompleteInput) {
+		t.Fatalf("validateEvaluationSourceSnapshots() error = %v, want missing planned dependency", err)
+	}
+}
+
+func TestFindingEvaluationCollectorConsumesSingleMultiSourceGraphRun(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	evaluation := graphEvaluationRun("evaluation-cross-source", cutoff.Add(-30*time.Minute), 4)
+	second := collectorTestSourceSnapshot(evaluation.GetSourceSnapshots()[0].GetLastSyncedAt().AsTime(), true)
+	second.RuntimeId = "runtime-2"
+	second.SourceId = "github"
+	second.Family = "audit"
+	second.GraphIngestRunId = "graph-run-2"
+	second.GraphCheckpointId = "graph-checkpoint-2"
+	evaluation.SourceSnapshots = append(evaluation.SourceSnapshots, second)
+
+	plan := collectorTestPlan(cutoff)
+	plan.Execution.Tasks[0].RuntimeIDs = []string{"runtime-1", "runtime-2"}
+	plan = normalizePlan(plan)
+	evaluations := &collectorEvaluationLister{valuesByRuntime: map[string][]*cerebrov1.FindingEvaluationRun{
+		"runtime-1": {evaluation},
+		"runtime-2": nil,
+	}}
+	collector := NewFindingEvaluationCollector(
+		&collectorPlanReader{plan: plan},
+		&collectorRuntimeLister{values: []*cerebrov1.SourceRuntime{
+			collectorTestRuntimeFromSnapshot(evaluation.GetSourceSnapshots()[0]),
+			collectorTestRuntimeFromSnapshot(second),
+		}},
+		evaluations,
+	)
+	collector.now = func() time.Time { return cutoff }
+
+	manifest, results, err := collector.Collect(context.Background(), collectorTestRun(cutoff))
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+	if len(evaluations.requests) != 2 {
+		t.Fatalf("evaluation queries = %d, want one lookup per planned runtime", len(evaluations.requests))
+	}
+	if len(manifest.Receipts) != 1 || manifest.Receipts[0].RuntimeID != "runtime-1" || manifest.Receipts[0].Completeness != CollectionUnknown {
+		t.Fatalf("graph receipts = %#v, want one untrusted trigger-runtime receipt", manifest.Receipts)
+	}
+	if len(manifest.EvaluationRunIDs) != 1 || manifest.EvaluationRunIDs[0] != evaluation.GetId() {
+		t.Fatalf("evaluation run ids = %#v, want only %q", manifest.EvaluationRunIDs, evaluation.GetId())
+	}
+	if len(results) != 1 || results[0].AutomatedOutcome != OutcomeIndeterminate || results[0].EvidenceState != EvidenceUntrusted ||
+		!containsReason(results[0].ReasonCodes, ReasonSourceUntrusted) {
+		t.Fatalf("graph result = %#v, want indeterminate with untrusted evidence", results)
+	}
+}
+
+func collectorTestPlan(now time.Time) AssessmentPlanRevision {
+	plan := planForValidation(now, []PlanTask{findingTaskForValidation(1, 1)})
+	plan.Status = PlanPublished
+	plan.Execution.Tasks[0].RuntimeIDs = []string{"runtime-1"}
+	plan.Execution.Tasks[0].MaxAge = "2h"
+	plan.ContentDigest = digestBytes([]byte("collector-test-plan"))
+	plan.PublishedAt = now.Add(-time.Hour)
+	plan.PublishedBy = "approver-1"
+	return normalizePlan(plan)
+}
+
+func collectorTestRun(cutoff time.Time) AssessmentRun {
+	return AssessmentRun{
+		ID: "assessment-run-1", TenantID: "tenant-1", ProgramID: "program-1",
+		ScopeRevisionID: "scope-revision-1", PlanRevisionID: "plan-revision-1",
+		PeriodStart: cutoff.Add(-24 * time.Hour), PeriodEnd: cutoff,
+		RequestedAt: cutoff, RequestedBy: "assessor-1",
+	}
+}
+
+func eventEvaluationRun(id string, finishedAt time.Time, eventLimit, eventsProcessed uint32) *cerebrov1.FindingEvaluationRun {
+	graphRule := false
+	startedAt := finishedAt.Add(-time.Minute)
+	sourceAt := startedAt.Add(-time.Minute)
+	return &cerebrov1.FindingEvaluationRun{
+		Id: id, RuntimeId: "runtime-1", RuleId: "rule-1", Status: "completed",
+		EventLimit: eventLimit, EventsEvaluated: eventsProcessed, EventsProcessed: eventsProcessed,
+		GraphRule: &graphRule, StartedAt: timestamppb.New(startedAt), FinishedAt: timestamppb.New(finishedAt),
+		RuleApplicable: boolPointer(true), SourceDependencyComplete: boolPointer(true),
+		SourceSnapshots: []*cerebrov1.FindingEvaluationSourceSnapshot{collectorTestSourceSnapshot(sourceAt, false)},
+	}
+}
+
+func graphEvaluationRun(id string, finishedAt time.Time, rows uint32) *cerebrov1.FindingEvaluationRun {
+	graphRule := true
+	startedAt := finishedAt.Add(-time.Minute)
+	sourceAt := startedAt.Add(-time.Minute)
+	rowLimit := uint32(100)
+	return &cerebrov1.FindingEvaluationRun{
+		Id: id, RuntimeId: "runtime-1", RuleId: "rule-1", Status: "completed",
+		GraphRule: &graphRule, GraphRowsRead: &rows, GraphTruncated: boolPointer(false), GraphRowLimit: &rowLimit,
+		StartedAt: timestamppb.New(startedAt), FinishedAt: timestamppb.New(finishedAt),
+		RuleApplicable: boolPointer(true), SourceDependencyComplete: boolPointer(true),
+		SourceSnapshots: []*cerebrov1.FindingEvaluationSourceSnapshot{collectorTestSourceSnapshot(sourceAt, true)},
+	}
+}
+
+func collectorTestSourceSnapshot(sourceAt time.Time, graph bool) *cerebrov1.FindingEvaluationSourceSnapshot {
+	snapshot := &cerebrov1.FindingEvaluationSourceSnapshot{
+		RuntimeId: "runtime-1", SourceId: "okta", Family: "user",
+		LastSyncedAt: timestamppb.New(sourceAt), CheckpointWatermark: timestamppb.New(sourceAt), Complete: boolPointer(true),
+		RecordsScanned: 12, RecordsAccepted: 12, RecordsRejected: 0, SyncStatus: "completed", ContractProbeState: "passing",
+		ProgressConfigHash: "sha256:collector-test-runtime",
+	}
+	if graph {
+		snapshot.GraphIngestRunId = "graph-run-1"
+		snapshot.GraphIngestStatus = "completed"
+		snapshot.GraphCheckpointId = "graph-checkpoint-1"
+		snapshot.GraphIngestedAt = timestamppb.New(sourceAt.Add(30 * time.Second))
+		snapshot.GraphSnapshotComplete = boolPointer(true)
+	}
+	return snapshot
+}
+
+func collectorTestRuntimeForEvaluation(evaluation *cerebrov1.FindingEvaluationRun, now time.Time) *cerebrov1.SourceRuntime {
+	snapshot := collectorTestSourceSnapshot(now.Add(-time.Hour), false)
+	if evaluation != nil && len(evaluation.GetSourceSnapshots()) != 0 && evaluation.GetSourceSnapshots()[0] != nil {
+		snapshot = evaluation.GetSourceSnapshots()[0]
+	}
+	return collectorTestRuntimeFromSnapshot(snapshot)
+}
+
+func collectorTestRuntimeFromSnapshot(snapshot *cerebrov1.FindingEvaluationSourceSnapshot) *cerebrov1.SourceRuntime {
+	return &cerebrov1.SourceRuntime{
+		Id: snapshot.GetRuntimeId(), TenantId: "tenant-1", SourceId: snapshot.GetSourceId(), LastSyncedAt: snapshot.GetLastSyncedAt(),
+		Checkpoint: &cerebrov1.SourceCheckpoint{Watermark: snapshot.GetCheckpointWatermark()},
+		Config: map[string]string{
+			"family": snapshot.GetFamily(), "__cerebro_runtime_status": "completed", "__cerebro_runtime_last_failure_category": "",
+			"__cerebro_runtime_contract_probe_state": snapshot.GetContractProbeState(), "__cerebro_resolved_progress_config_hash": snapshot.GetProgressConfigHash(),
+			"__cerebro_runtime_records_scanned":  strconv.FormatUint(uint64(snapshot.GetRecordsScanned()), 10),
+			"__cerebro_runtime_records_accepted": strconv.FormatUint(uint64(snapshot.GetRecordsAccepted()), 10),
+			"__cerebro_runtime_records_rejected": strconv.FormatUint(uint64(snapshot.GetRecordsRejected()), 10),
+		},
+	}
+}
+
+func boolPointer(value bool) *bool { return &value }
+
+func containsReason(values []ReasonCode, want ReasonCode) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+type collectorPlanReader struct {
+	plan AssessmentPlanRevision
+}
+
+func (s *collectorPlanReader) GetPlan(context.Context, string, string) (AssessmentPlanRevision, error) {
+	return s.plan, nil
+}
+
+type collectorRuntimeLister struct {
+	filter ports.SourceRuntimeFilter
+	values []*cerebrov1.SourceRuntime
+}
+
+func (s *collectorRuntimeLister) ListSourceRuntimes(_ context.Context, filter ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	s.filter = filter
+	return s.values, nil
+}
+
+type collectorEvaluationLister struct {
+	request         ports.ListFindingEvaluationRunsRequest
+	requests        []ports.ListFindingEvaluationRunsRequest
+	values          []*cerebrov1.FindingEvaluationRun
+	valuesByRuntime map[string][]*cerebrov1.FindingEvaluationRun
+}
+
+func (s *collectorEvaluationLister) ListFindingEvaluationRuns(_ context.Context, request ports.ListFindingEvaluationRunsRequest) ([]*cerebrov1.FindingEvaluationRun, error) {
+	s.request = request
+	s.requests = append(s.requests, request)
+	if s.valuesByRuntime != nil {
+		return s.valuesByRuntime[request.RuntimeID], nil
+	}
+	return s.values, nil
+}

--- a/internal/complianceassessment/plan.go
+++ b/internal/complianceassessment/plan.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
 )
 
 var (
@@ -27,6 +29,14 @@ const (
 	RunFailed         = "failed"
 	RunCancelled      = "cancelled"
 	RunSuperseded     = "superseded"
+
+	PlanTaskKindProcedure         = "procedure"
+	PlanTaskKindFindingEvaluation = "finding_evaluation"
+	EvaluationModePointInTime     = "point_in_time"
+
+	MaxFindingEvaluationTasks        = 25
+	MaxFindingEvaluationTaskRuntimes = 20
+	MaxFindingEvaluationBindings     = 100
 )
 
 type PlanScope struct {
@@ -39,14 +49,29 @@ type PlanScope struct {
 }
 
 type PlanExecution struct {
-	Methods          []string `json:"methods"`
-	Depth            string   `json:"depth"`
-	CoverageTarget   string   `json:"coverage_target"`
-	AssuranceTarget  string   `json:"assurance_target"`
-	SamplingRule     string   `json:"sampling_rule,omitempty"`
-	OrderedTaskIDs   []string `json:"ordered_task_ids"`
-	ToolRevisionIDs  []string `json:"tool_revision_ids,omitempty"`
-	CancellationRule string   `json:"cancellation_rule"`
+	Methods          []string   `json:"methods"`
+	Depth            string     `json:"depth"`
+	CoverageTarget   string     `json:"coverage_target"`
+	AssuranceTarget  string     `json:"assurance_target"`
+	SamplingRule     string     `json:"sampling_rule,omitempty"`
+	Tasks            []PlanTask `json:"tasks"`
+	OrderedTaskIDs   []string   `json:"ordered_task_ids"`
+	ToolRevisionIDs  []string   `json:"tool_revision_ids,omitempty"`
+	CancellationRule string     `json:"cancellation_rule"`
+}
+
+// PlanTask binds one assessment objective to one bounded procedure. Finding
+// evaluation tasks read only the latest durable evaluation run for each named
+// source runtime; they do not execute rules or issue graph queries.
+type PlanTask struct {
+	ID             string                `json:"id"`
+	ObjectiveID    string                `json:"objective_id"`
+	ControlRef     compliance.ControlRef `json:"control_ref"`
+	Kind           string                `json:"kind"`
+	RuleID         string                `json:"rule_id,omitempty"`
+	RuntimeIDs     []string              `json:"runtime_ids,omitempty"`
+	MaxAge         string                `json:"max_age,omitempty"`
+	EvaluationMode string                `json:"evaluation_mode,omitempty"`
 }
 
 type PlanGovernance struct {
@@ -92,6 +117,23 @@ func normalizePlan(plan AssessmentPlanRevision) AssessmentPlanRevision {
 	plan.Scope.IncludedSubjectIDs = normalizedStrings(plan.Scope.IncludedSubjectIDs)
 	plan.Scope.ExcludedSubjectIDs = normalizedStrings(plan.Scope.ExcludedSubjectIDs)
 	plan.Execution.Methods = normalizedStrings(plan.Execution.Methods)
+	plan.Execution.Depth = strings.TrimSpace(plan.Execution.Depth)
+	plan.Execution.CoverageTarget = strings.TrimSpace(plan.Execution.CoverageTarget)
+	plan.Execution.AssuranceTarget = strings.TrimSpace(plan.Execution.AssuranceTarget)
+	plan.Execution.SamplingRule = strings.TrimSpace(plan.Execution.SamplingRule)
+	plan.Execution.CancellationRule = strings.TrimSpace(plan.Execution.CancellationRule)
+	plan.Execution.Tasks = append([]PlanTask(nil), plan.Execution.Tasks...)
+	for index := range plan.Execution.Tasks {
+		task := &plan.Execution.Tasks[index]
+		task.ID = strings.TrimSpace(task.ID)
+		task.ObjectiveID = strings.TrimSpace(task.ObjectiveID)
+		task.ControlRef = compliance.NormalizeControlRef(task.ControlRef)
+		task.Kind = strings.TrimSpace(task.Kind)
+		task.RuleID = strings.TrimSpace(task.RuleID)
+		task.RuntimeIDs = normalizedStrings(task.RuntimeIDs)
+		task.MaxAge = strings.TrimSpace(task.MaxAge)
+		task.EvaluationMode = strings.TrimSpace(task.EvaluationMode)
+	}
 	plan.Execution.OrderedTaskIDs = orderedUniqueStrings(plan.Execution.OrderedTaskIDs)
 	plan.Execution.ToolRevisionIDs = normalizedStrings(plan.Execution.ToolRevisionIDs)
 	plan.Governance.AssessorIDs = normalizedStrings(plan.Governance.AssessorIDs)
@@ -109,8 +151,11 @@ func validatePlan(plan AssessmentPlanRevision) error {
 	if plan.Scope.ProgramID == "" || plan.Scope.ScopeRevisionID == "" || len(plan.Scope.ImplementationRevisions) == 0 || len(plan.Scope.ObjectiveIDs) == 0 {
 		return fmt.Errorf("%w: plan scope is incomplete", ErrInvalidResult)
 	}
-	if len(plan.Execution.Methods) == 0 || len(plan.Execution.OrderedTaskIDs) == 0 || plan.Execution.CoverageTarget == "" || plan.Execution.AssuranceTarget == "" {
+	if len(plan.Execution.Methods) == 0 || len(plan.Execution.Tasks) == 0 || len(plan.Execution.OrderedTaskIDs) == 0 || plan.Execution.CoverageTarget == "" || plan.Execution.AssuranceTarget == "" {
 		return fmt.Errorf("%w: plan execution contract is incomplete", ErrInvalidResult)
+	}
+	if err := validatePlanTasks(plan.Scope.ObjectiveIDs, plan.Execution); err != nil {
+		return err
 	}
 	if plan.Governance.OwnerID == "" || len(plan.Governance.ApproverIDs) == 0 || plan.Governance.RulesOfEngagement == "" {
 		return fmt.Errorf("%w: plan governance is incomplete", ErrInvalidResult)
@@ -119,6 +164,72 @@ func validatePlan(plan AssessmentPlanRevision) error {
 	case PlanDraft, PlanPublished, PlanRetired:
 	default:
 		return fmt.Errorf("%w: plan status %q", ErrInvalidResult, plan.Status)
+	}
+	return nil
+}
+
+func validatePlanTasks(objectiveIDs []string, execution PlanExecution) error {
+	objectives := make(map[string]struct{}, len(objectiveIDs))
+	for _, objectiveID := range objectiveIDs {
+		objectives[objectiveID] = struct{}{}
+	}
+	tasks := make(map[string]PlanTask, len(execution.Tasks))
+	taskObjectives := make(map[string]struct{}, len(execution.Tasks))
+	findingTasks := 0
+	findingBindings := 0
+	for index, task := range execution.Tasks {
+		if task.ID == "" || task.ObjectiveID == "" || task.Kind == "" || strings.TrimSpace(task.ControlRef.ControlID) == "" ||
+			(strings.TrimSpace(task.ControlRef.FrameworkID) == "" && strings.TrimSpace(task.ControlRef.FrameworkName) == "" && strings.TrimSpace(task.ControlRef.Framework) == "") {
+			return fmt.Errorf("%w: plan task %d is incomplete", ErrInvalidResult, index)
+		}
+		if _, ok := objectives[task.ObjectiveID]; !ok {
+			return fmt.Errorf("%w: plan task %q references objective %q outside scope", ErrInvalidResult, task.ID, task.ObjectiveID)
+		}
+		if _, ok := tasks[task.ID]; ok {
+			return fmt.Errorf("%w: duplicate plan task %q", ErrInvalidResult, task.ID)
+		}
+		if _, ok := taskObjectives[task.ObjectiveID]; ok {
+			return fmt.Errorf("%w: objective %q has more than one plan task", ErrInvalidResult, task.ObjectiveID)
+		}
+		tasks[task.ID] = task
+		taskObjectives[task.ObjectiveID] = struct{}{}
+		switch task.Kind {
+		case PlanTaskKindProcedure:
+		case PlanTaskKindFindingEvaluation:
+			findingTasks++
+			findingBindings += len(task.RuntimeIDs)
+			if task.RuleID == "" || len(task.RuntimeIDs) == 0 || task.MaxAge == "" || task.EvaluationMode != EvaluationModePointInTime {
+				return fmt.Errorf("%w: finding evaluation task %q is incomplete", ErrInvalidResult, task.ID)
+			}
+			if len(task.RuntimeIDs) > MaxFindingEvaluationTaskRuntimes {
+				return fmt.Errorf("%w: finding evaluation task %q has too many runtimes", ErrInvalidResult, task.ID)
+			}
+			maxAge, err := time.ParseDuration(task.MaxAge)
+			if err != nil || maxAge <= 0 {
+				return fmt.Errorf("%w: finding evaluation task %q has invalid max_age", ErrInvalidResult, task.ID)
+			}
+		default:
+			return fmt.Errorf("%w: plan task %q has unsupported kind %q", ErrInvalidResult, task.ID, task.Kind)
+		}
+	}
+	if len(taskObjectives) != len(objectives) {
+		return fmt.Errorf("%w: plan tasks do not cover every scoped objective", ErrInvalidResult)
+	}
+	if findingTasks > MaxFindingEvaluationTasks || findingBindings > MaxFindingEvaluationBindings {
+		return fmt.Errorf("%w: finding evaluation task bounds exceeded", ErrInvalidResult)
+	}
+	if len(execution.OrderedTaskIDs) != len(tasks) {
+		return fmt.Errorf("%w: ordered task ids do not cover every plan task", ErrInvalidResult)
+	}
+	seenOrdered := make(map[string]struct{}, len(execution.OrderedTaskIDs))
+	for _, taskID := range execution.OrderedTaskIDs {
+		if _, ok := tasks[taskID]; !ok {
+			return fmt.Errorf("%w: ordered task %q is not defined", ErrInvalidResult, taskID)
+		}
+		if _, ok := seenOrdered[taskID]; ok {
+			return fmt.Errorf("%w: ordered task %q is duplicated", ErrInvalidResult, taskID)
+		}
+		seenOrdered[taskID] = struct{}{}
 	}
 	return nil
 }

--- a/internal/complianceassessment/plan_test.go
+++ b/internal/complianceassessment/plan_test.go
@@ -1,0 +1,139 @@
+package complianceassessment
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+)
+
+func TestValidatePlanEnforcesFindingEvaluationBoundsAndCoverage(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	valid := planForValidation(now, []PlanTask{findingTaskForValidation(1, 1)})
+	if err := validatePlan(normalizePlan(valid)); err != nil {
+		t.Fatalf("validatePlan(valid) error = %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*AssessmentPlanRevision)
+	}{
+		{
+			name: "objective without task",
+			mutate: func(plan *AssessmentPlanRevision) {
+				plan.Scope.ObjectiveIDs = append(plan.Scope.ObjectiveIDs, "objective-2")
+			},
+		},
+		{
+			name: "duplicate objective task",
+			mutate: func(plan *AssessmentPlanRevision) {
+				duplicate := findingTaskForValidation(2, 1)
+				duplicate.ObjectiveID = "objective-1"
+				plan.Execution.Tasks = append(plan.Execution.Tasks, duplicate)
+				plan.Execution.OrderedTaskIDs = append(plan.Execution.OrderedTaskIDs, duplicate.ID)
+			},
+		},
+		{
+			name: "unknown ordered task",
+			mutate: func(plan *AssessmentPlanRevision) {
+				plan.Execution.OrderedTaskIDs[0] = "task-unknown"
+			},
+		},
+		{
+			name: "invalid max age",
+			mutate: func(plan *AssessmentPlanRevision) {
+				plan.Execution.Tasks[0].MaxAge = "later"
+			},
+		},
+		{
+			name: "too many runtimes for task",
+			mutate: func(plan *AssessmentPlanRevision) {
+				plan.Execution.Tasks[0] = findingTaskForValidation(1, MaxFindingEvaluationTaskRuntimes+1)
+			},
+		},
+		{
+			name: "too many finding tasks",
+			mutate: func(plan *AssessmentPlanRevision) {
+				plan.Scope.ObjectiveIDs = nil
+				plan.Execution.Tasks = nil
+				plan.Execution.OrderedTaskIDs = nil
+				for index := 1; index <= MaxFindingEvaluationTasks+1; index++ {
+					task := findingTaskForValidation(index, 1)
+					plan.Scope.ObjectiveIDs = append(plan.Scope.ObjectiveIDs, task.ObjectiveID)
+					plan.Execution.Tasks = append(plan.Execution.Tasks, task)
+					plan.Execution.OrderedTaskIDs = append(plan.Execution.OrderedTaskIDs, task.ID)
+				}
+			},
+		},
+		{
+			name: "too many runtime bindings",
+			mutate: func(plan *AssessmentPlanRevision) {
+				plan.Scope.ObjectiveIDs = nil
+				plan.Execution.Tasks = nil
+				plan.Execution.OrderedTaskIDs = nil
+				for index := 1; index <= 6; index++ {
+					task := findingTaskForValidation(index, MaxFindingEvaluationTaskRuntimes)
+					plan.Scope.ObjectiveIDs = append(plan.Scope.ObjectiveIDs, task.ObjectiveID)
+					plan.Execution.Tasks = append(plan.Execution.Tasks, task)
+					plan.Execution.OrderedTaskIDs = append(plan.Execution.OrderedTaskIDs, task.ID)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			plan := valid
+			plan.Scope.ObjectiveIDs = append([]string(nil), valid.Scope.ObjectiveIDs...)
+			plan.Execution.Tasks = append([]PlanTask(nil), valid.Execution.Tasks...)
+			plan.Execution.OrderedTaskIDs = append([]string(nil), valid.Execution.OrderedTaskIDs...)
+			test.mutate(&plan)
+			if err := validatePlan(normalizePlan(plan)); !errors.Is(err, ErrInvalidResult) {
+				t.Fatalf("validatePlan() error = %v, want ErrInvalidResult", err)
+			}
+		})
+	}
+}
+
+func planForValidation(now time.Time, tasks []PlanTask) AssessmentPlanRevision {
+	objectives := make([]string, 0, len(tasks))
+	ordered := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		objectives = append(objectives, task.ObjectiveID)
+		ordered = append(ordered, task.ID)
+	}
+	return AssessmentPlanRevision{
+		ID: "plan-1", TenantID: "tenant-1", RevisionID: "plan-revision-1", Version: 1,
+		Status: PlanDraft, Name: "Access assessment",
+		Scope: PlanScope{
+			ProgramID: "program-1", ScopeRevisionID: "scope-revision-1",
+			ImplementationRevisions: []string{"implementation-revision-1"}, ObjectiveIDs: objectives,
+		},
+		Execution: PlanExecution{
+			Methods: []string{"test"}, Depth: "moderate", CoverageTarget: "complete", AssuranceTarget: "medium",
+			Tasks: tasks, OrderedTaskIDs: ordered, CancellationRule: "stop_after_checkpoint",
+		},
+		Governance: PlanGovernance{
+			OwnerID: "owner-1", AssessorIDs: []string{"assessor-1"}, ApproverIDs: []string{"approver-1"},
+			IndependenceRule: "approver_not_assessor", RulesOfEngagement: "Read-only source access.",
+		},
+		CreatedAt: now, CreatedBy: "owner-1",
+	}
+}
+
+func findingTaskForValidation(index, runtimeCount int) PlanTask {
+	runtimeIDs := make([]string, 0, runtimeCount)
+	for runtimeIndex := 1; runtimeIndex <= runtimeCount; runtimeIndex++ {
+		runtimeIDs = append(runtimeIDs, fmt.Sprintf("runtime-%d-%d", index, runtimeIndex))
+	}
+	return PlanTask{
+		ID: fmt.Sprintf("task-%d", index), ObjectiveID: fmt.Sprintf("objective-%d", index),
+		ControlRef: compliance.ControlRef{FrameworkID: "framework-1", ControlID: fmt.Sprintf("control-%d", index)},
+		Kind:       PlanTaskKindFindingEvaluation, RuleID: fmt.Sprintf("rule-%d", index), RuntimeIDs: runtimeIDs,
+		MaxAge: "24h", EvaluationMode: EvaluationModePointInTime,
+	}
+}

--- a/internal/complianceassessment/query.go
+++ b/internal/complianceassessment/query.go
@@ -1,0 +1,55 @@
+package complianceassessment
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+var ErrResultPagingUnavailable = errors.New("assessment result paging is unavailable")
+
+const (
+	defaultResultChunkPageLimit = uint32(25)
+	maxResultChunkPageLimit     = uint32(100)
+)
+
+type ResultChunkPage struct {
+	Chunks       []ResultChunk `json:"chunks"`
+	NextSequence uint32        `json:"next_sequence,omitempty"`
+	HasMore      bool          `json:"has_more"`
+}
+
+type ResultChunkPageStore interface {
+	ListResultChunksPage(context.Context, string, string, uint32, uint32) (ResultChunkPage, error)
+}
+
+func (s *Service) GetPlan(ctx context.Context, tenantID, planID string) (AssessmentPlanRevision, error) {
+	if s == nil || s.store == nil {
+		return AssessmentPlanRevision{}, ErrPlanNotFound
+	}
+	return s.store.GetPlan(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(planID))
+}
+
+func (s *Service) GetRun(ctx context.Context, tenantID, runID string) (AssessmentRun, error) {
+	if s == nil || s.store == nil {
+		return AssessmentRun{}, ErrRunNotFound
+	}
+	return s.store.GetRun(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(runID))
+}
+
+func (s *Service) ListResultChunksPage(ctx context.Context, tenantID, runID string, afterSequence, limit uint32) (ResultChunkPage, error) {
+	if s == nil || s.store == nil {
+		return ResultChunkPage{}, ErrResultPagingUnavailable
+	}
+	store, ok := s.store.(ResultChunkPageStore)
+	if !ok {
+		return ResultChunkPage{}, ErrResultPagingUnavailable
+	}
+	if limit == 0 {
+		limit = defaultResultChunkPageLimit
+	}
+	if limit > maxResultChunkPageLimit {
+		return ResultChunkPage{}, ErrInvalidResult
+	}
+	return store.ListResultChunksPage(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(runID), afterSequence, limit)
+}

--- a/internal/complianceassessment/replay_verification_test.go
+++ b/internal/complianceassessment/replay_verification_test.go
@@ -103,10 +103,6 @@ func TestVerifyDeterministicReplayAcceptsStoredMultiChunkHashAcrossOrderPermutat
 		t.Fatalf("completed run = %#v", completed)
 	}
 	planArtifact := plan
-	planArtifact.Status = PlanDraft
-	planArtifact.PublishedAt = time.Time{}
-	planArtifact.PublishedBy = ""
-	planArtifact.Version--
 	planArtifact.ContentDigest = ""
 	encodedPlan, err := canonicalBytes(planArtifact)
 	if err != nil {

--- a/internal/complianceassessment/runner_test.go
+++ b/internal/complianceassessment/runner_test.go
@@ -116,6 +116,59 @@ func TestAssessmentRunBindsJobAndPersistsCompleteChunkChain(t *testing.T) {
 	}
 }
 
+func TestAssessmentRunCompletesFromTrustedFindingEvaluation(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	evaluation := eventEvaluationRun("evaluation-trusted", now.Add(-30*time.Minute), 100, 12)
+	store := newRunStore()
+	collector := NewFindingEvaluationCollector(
+		store,
+		&collectorRuntimeLister{values: []*cerebrov1.SourceRuntime{collectorTestRuntimeForEvaluation(evaluation, now)}},
+		&collectorEvaluationLister{values: []*cerebrov1.FindingEvaluationRun{evaluation}},
+	)
+	collector.now = func() time.Time { return now }
+	jobs := platformjobs.New(newRunJobStore(now))
+	service := NewAssessmentService(store, &runLog{}, jobs, collector)
+	service.now = func() time.Time { return now }
+	jobs.WithRunner(JobKindComplianceAssessment, service.Runner())
+
+	planInput := validPlan(now)
+	planInput.Execution.Tasks[0] = PlanTask{
+		ID: "task-1", ObjectiveID: "objective-1", ControlRef: planInput.Execution.Tasks[0].ControlRef,
+		Kind: PlanTaskKindFindingEvaluation, RuleID: "rule-1", RuntimeIDs: []string{"runtime-1"}, MaxAge: "2h", EvaluationMode: EvaluationModePointInTime,
+	}
+	draft, err := service.RecordPlan(context.Background(), planInput, "owner-1", 0)
+	if err != nil {
+		t.Fatalf("RecordPlan() error = %v", err)
+	}
+	plan, err := service.PublishPlan(context.Background(), draft.TenantID, draft.ID, "approver-1", draft.Version)
+	if err != nil {
+		t.Fatalf("PublishPlan() error = %v", err)
+	}
+	run, created, err := service.RequestRun(context.Background(), RunRequest{
+		TenantID: plan.TenantID, PlanRevisionID: plan.RevisionID, PeriodStart: now.Add(-24 * time.Hour), PeriodEnd: now,
+		IdempotencyKey: "trusted-loop-1", RequestedBy: "assessor-1",
+	})
+	if err != nil || !created || run.JobID == "" {
+		t.Fatalf("RequestRun() = (%#v, %v, %v)", run, created, err)
+	}
+	if err := jobs.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	completed, err := store.GetRun(context.Background(), run.TenantID, run.ID)
+	if err != nil || completed.State != RunComplete || completed.ResultCount != 1 || completed.InputHash == "" || completed.AutomatedResultHash == "" {
+		t.Fatalf("completed run = (%#v, %v), want one digest-bound result", completed, err)
+	}
+	chunks, err := store.ListResultChunks(context.Background(), run.TenantID, run.ID)
+	if err != nil || len(chunks) != 1 || len(chunks[0].Results) != 1 {
+		t.Fatalf("result chunks = (%#v, %v), want one result", chunks, err)
+	}
+	result := chunks[0].Results[0]
+	if result.AutomatedOutcome != OutcomeSatisfied || result.EvidenceState != EvidenceSufficient || len(result.EvidenceIDs) != 1 || result.EvidenceIDs[0] != evaluation.GetId() {
+		t.Fatalf("assessment result = %#v, want satisfied result bound to %q", result, evaluation.GetId())
+	}
+}
+
 func TestAssessmentRunIdempotencyBindsRequestBody(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
@@ -204,6 +257,11 @@ func TestAssessmentRejectsPartialObjectiveSet(t *testing.T) {
 	jobs.WithRunner(JobKindComplianceAssessment, service.Runner())
 	planInput := validPlan(now)
 	planInput.Scope.ObjectiveIDs = []string{"objective-0000", "objective-0001"}
+	planInput.Execution.Tasks = []PlanTask{
+		{ID: "task-0000", ObjectiveID: "objective-0000", ControlRef: compliance.ControlRef{FrameworkID: "framework-1", ControlID: "control-1"}, Kind: PlanTaskKindProcedure},
+		{ID: "task-0001", ObjectiveID: "objective-0001", ControlRef: compliance.ControlRef{FrameworkID: "framework-1", ControlID: "control-1"}, Kind: PlanTaskKindProcedure},
+	}
+	planInput.Execution.OrderedTaskIDs = []string{"task-0000", "task-0001"}
 	plan, err := service.RecordPlan(context.Background(), planInput, "owner-1", 0)
 	if err != nil {
 		t.Fatal(err)
@@ -614,22 +672,71 @@ func TestReconcileUnboundRunStartsExistingQueuedJob(t *testing.T) {
 	}
 }
 
+func TestAssessmentRunIdempotentRetryBindsExistingQueuedRun(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	store := newRunStore()
+	jobStore := newRunJobStore(now)
+	jobs := platformjobs.New(jobStore)
+	service := NewAssessmentService(store, &runLog{}, jobs, &testCollector{manifest: completeManifest(now), results: validResults(now, 1)})
+	service.now = func() time.Time { return now }
+	jobs.WithRunner(JobKindComplianceAssessment, service.Runner())
+	plan := recordPublishedPlan(t, service, now)
+	request := RunRequest{
+		TenantID: plan.TenantID, PlanRevisionID: plan.RevisionID,
+		PeriodStart: now.Add(-time.Hour), PeriodEnd: now,
+		IdempotencyKey: "retry-binds-existing-run", RequestedBy: "assessor-1",
+	}
+
+	store.applyRunVersion = 2
+	store.applyRunErr = errors.New("run projection unavailable")
+	first, _, err := service.RequestRun(context.Background(), request)
+	if err == nil || first.ID == "" || first.JobID == "" {
+		t.Fatalf("first RequestRun() = (%#v, %v), want run and binding projection error", first, err)
+	}
+	store.applyRunErr = nil
+
+	retried, created, err := service.RequestRun(context.Background(), request)
+	if err != nil || created || retried.ID != first.ID || retried.JobID != first.JobID {
+		t.Fatalf("retry RequestRun() = (%#v, %v, %v), want existing run bound to %q", retried, created, err, first.JobID)
+	}
+	if err := jobs.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	completed, err := store.GetRun(context.Background(), retried.TenantID, retried.ID)
+	if err != nil || completed.State != RunComplete {
+		t.Fatalf("completed run = (%#v, %v), want complete", completed, err)
+	}
+}
+
 func recordPublishedPlan(t *testing.T, service *Service, now time.Time) AssessmentPlanRevision {
 	t.Helper()
 	planInput := validPlan(now)
 	if collector, ok := service.collector.(*testCollector); ok && len(collector.results) != 0 {
 		planInput.Scope.ObjectiveIDs = make([]string, 0, len(collector.results))
-		for _, result := range collector.results {
+		planInput.Execution.Tasks = make([]PlanTask, 0, len(collector.results))
+		planInput.Execution.OrderedTaskIDs = make([]string, 0, len(collector.results))
+		for index, result := range collector.results {
+			taskID := fmt.Sprintf("task-%04d", index)
 			planInput.Scope.ObjectiveIDs = append(planInput.Scope.ObjectiveIDs, result.ObjectiveID)
+			planInput.Execution.Tasks = append(planInput.Execution.Tasks, PlanTask{
+				ID: taskID, ObjectiveID: result.ObjectiveID, ControlRef: result.ControlRef, Kind: PlanTaskKindProcedure,
+			})
+			planInput.Execution.OrderedTaskIDs = append(planInput.Execution.OrderedTaskIDs, taskID)
 		}
 	}
 	plan, err := service.RecordPlan(context.Background(), planInput, "owner-1", 0)
 	if err != nil {
 		t.Fatalf("RecordPlan() error = %v", err)
 	}
+	draftRevisionID := plan.RevisionID
+	draftDigest := plan.ContentDigest
 	plan, err = service.PublishPlan(context.Background(), plan.TenantID, plan.ID, "approver-1", plan.Version)
 	if err != nil {
 		t.Fatalf("PublishPlan() error = %v", err)
+	}
+	if plan.RevisionID == draftRevisionID || plan.PredecessorID != draftRevisionID || plan.ContentDigest == draftDigest {
+		t.Fatalf("published plan revision = %#v, want a new digest-bound revision after %q", plan, draftRevisionID)
 	}
 	if collector, ok := service.collector.(*testCollector); ok {
 		collector.plan = plan
@@ -640,8 +747,14 @@ func recordPublishedPlan(t *testing.T, service *Service, now time.Time) Assessme
 func validPlan(now time.Time) AssessmentPlanRevision {
 	return AssessmentPlanRevision{
 		TenantID: "tenant-1", Name: "Annual access assessment", Status: PlanDraft,
-		Scope:      PlanScope{ProgramID: "program-1", ScopeRevisionID: "scope-revision-1", ImplementationRevisions: []string{"implementation-revision-1"}, ObjectiveIDs: []string{"objective-1"}},
-		Execution:  PlanExecution{Methods: []string{"test"}, Depth: "moderate", CoverageTarget: "complete", AssuranceTarget: "high", OrderedTaskIDs: []string{"task-1"}, CancellationRule: "stop_after_checkpoint"},
+		Scope: PlanScope{ProgramID: "program-1", ScopeRevisionID: "scope-revision-1", ImplementationRevisions: []string{"implementation-revision-1"}, ObjectiveIDs: []string{"objective-1"}},
+		Execution: PlanExecution{
+			Methods: []string{"test"}, Depth: "moderate", CoverageTarget: "complete", AssuranceTarget: "high",
+			Tasks: []PlanTask{{
+				ID: "task-1", ObjectiveID: "objective-1", ControlRef: compliance.ControlRef{FrameworkID: "framework-1", ControlID: "control-1"}, Kind: PlanTaskKindProcedure,
+			}},
+			OrderedTaskIDs: []string{"task-1"}, CancellationRule: "stop_after_checkpoint",
+		},
 		Governance: PlanGovernance{OwnerID: "owner-1", AssessorIDs: []string{"assessor-1"}, ApproverIDs: []string{"approver-1"}, IndependenceRule: "approver_not_assessor", RulesOfEngagement: "Read-only source access."},
 		CreatedAt:  now, CreatedBy: "owner-1",
 	}

--- a/internal/complianceassessment/service.go
+++ b/internal/complianceassessment/service.go
@@ -97,10 +97,23 @@ func (s *Service) PublishPlan(ctx context.Context, tenantID, planID, actorID str
 	if plan.Version != expectedVersion || plan.Status != PlanDraft {
 		return AssessmentPlanRevision{}, ErrAssessmentConflict
 	}
+	predecessorID := plan.RevisionID
+	revisionID, err := compliance.NewRevisionIdentifier(compliance.IdentifierPlan)
+	if err != nil {
+		return AssessmentPlanRevision{}, err
+	}
+	plan.PredecessorID = predecessorID
+	plan.RevisionID = revisionID
 	plan.Status = PlanPublished
 	plan.PublishedAt = CanonicalTime(s.now())
 	plan.PublishedBy = strings.TrimSpace(actorID)
 	plan.Version++
+	plan.ContentDigest = ""
+	digest, err := semanticHash(plan)
+	if err != nil {
+		return AssessmentPlanRevision{}, err
+	}
+	plan.ContentDigest = digest
 	if err := validatePlan(plan); err != nil {
 		return AssessmentPlanRevision{}, err
 	}
@@ -146,6 +159,10 @@ func (s *Service) RequestRun(ctx context.Context, request RunRequest) (Assessmen
 	if existing, findErr := s.store.FindRunByIdempotency(ctx, request.TenantID, request.IdempotencyKey); findErr == nil {
 		if existing.RequestHash != requestHash {
 			return AssessmentRun{}, false, ports.ErrJobIdempotencyConflict
+		}
+		if existing.State == RunQueued && strings.TrimSpace(existing.JobID) == "" {
+			bound, _, bindErr := s.bindRunJob(ctx, existing)
+			return bound, false, bindErr
 		}
 		return existing, false, nil
 	} else if !errors.Is(findErr, ErrRunNotFound) {

--- a/internal/statestore/postgres/compliance_assessment.go
+++ b/internal/statestore/postgres/compliance_assessment.go
@@ -371,6 +371,42 @@ func (s *Store) ListResultChunks(ctx context.Context, tenantID, runID string) ([
 	return result, rows.Err()
 }
 
+func (s *Store) ListResultChunksPage(ctx context.Context, tenantID, runID string, afterSequence, limit uint32) (complianceassessment.ResultChunkPage, error) {
+	if err := s.ensureComplianceAssessmentConfigured(ctx); err != nil {
+		return complianceassessment.ResultChunkPage{}, err
+	}
+	if limit == 0 || limit > 100 {
+		return complianceassessment.ResultChunkPage{}, complianceassessment.ErrInvalidResult
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT record_json FROM compliance_assessment_result_chunks WHERE tenant_id=$1 AND run_id=$2 AND sequence>$3 ORDER BY sequence LIMIT $4`, strings.TrimSpace(tenantID), strings.TrimSpace(runID), afterSequence, limit+1)
+	if err != nil {
+		return complianceassessment.ResultChunkPage{}, err
+	}
+	defer func() { _ = rows.Close() }()
+	chunks := make([]complianceassessment.ResultChunk, 0, limit+1)
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return complianceassessment.ResultChunkPage{}, err
+		}
+		var chunk complianceassessment.ResultChunk
+		if err := json.Unmarshal(data, &chunk); err != nil {
+			return complianceassessment.ResultChunkPage{}, err
+		}
+		chunks = append(chunks, chunk)
+	}
+	if err := rows.Err(); err != nil {
+		return complianceassessment.ResultChunkPage{}, err
+	}
+	page := complianceassessment.ResultChunkPage{Chunks: chunks}
+	if len(chunks) > int(limit) {
+		page.HasMore = true
+		page.Chunks = chunks[:limit]
+		page.NextSequence = page.Chunks[len(page.Chunks)-1].Sequence
+	}
+	return page, nil
+}
+
 func (s *Store) ensureComplianceAssessmentConfigured(ctx context.Context) error {
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")

--- a/internal/statestore/postgres/findingevaluationruns.go
+++ b/internal/statestore/postgres/findingevaluationruns.go
@@ -174,8 +174,12 @@ func findingEvaluationRunListQuery(request ports.ListFindingEvaluationRunsReques
 	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
 	addFindingEvaluationRunFilter(&clauses, &args, "rule_id", request.RuleID)
 	addFindingEvaluationRunFilter(&clauses, &args, "status", request.Status)
+	if !request.FinishedAtOrBefore.IsZero() {
+		args = append(args, request.FinishedAtOrBefore.UTC())
+		clauses = append(clauses, fmt.Sprintf("finished_at <= $%d", len(args)))
+	}
 	selectClause := "SELECT finding_evaluation_run_json::text"
-	orderClause := "ORDER BY started_at DESC, id"
+	orderClause := "ORDER BY finished_at DESC NULLS LAST, started_at DESC, id"
 	if request.LatestByRuntime {
 		selectClause = "SELECT DISTINCT ON (runtime_id) finding_evaluation_run_json::text"
 		orderClause = "ORDER BY runtime_id, started_at DESC, id DESC"

--- a/internal/statestore/postgres/findingevaluationruns_test.go
+++ b/internal/statestore/postgres/findingevaluationruns_test.go
@@ -53,11 +53,13 @@ func TestFindingEvaluationRunTimeTreatsNilAsZero(t *testing.T) {
 }
 
 func TestFindingEvaluationRunListQueryIncludesOptionalFilters(t *testing.T) {
+	cutoff := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
 	query, args, err := findingEvaluationRunListQuery(ports.ListFindingEvaluationRunsRequest{
-		RuntimeID: "writer-okta-audit",
-		RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
-		Status:    "completed",
-		Limit:     25,
+		RuntimeID:          "writer-okta-audit",
+		RuleID:             "identity-okta-policy-rule-lifecycle-tampering",
+		Status:             "completed",
+		FinishedAtOrBefore: cutoff,
+		Limit:              25,
 	})
 	if err != nil {
 		t.Fatalf("findingEvaluationRunListQuery() error = %v", err)
@@ -66,14 +68,16 @@ func TestFindingEvaluationRunListQueryIncludesOptionalFilters(t *testing.T) {
 		"runtime_id = $1",
 		"rule_id = $2",
 		"status = $3",
-		"LIMIT $4",
+		"finished_at <= $4",
+		"ORDER BY finished_at DESC NULLS LAST, started_at DESC, id",
+		"LIMIT $5",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("findingEvaluationRunListQuery() query missing %q: %s", fragment, query)
 		}
 	}
-	if got := len(args); got != 4 {
-		t.Fatalf("len(findingEvaluationRunListQuery().args) = %d, want 4", got)
+	if got := len(args); got != 5 {
+		t.Fatalf("len(findingEvaluationRunListQuery().args) = %d, want 5", got)
 	}
 	if got := args[0]; got != "writer-okta-audit" {
 		t.Fatalf("findingEvaluationRunListQuery().args[0] = %#v, want writer-okta-audit", got)
@@ -84,8 +88,11 @@ func TestFindingEvaluationRunListQueryIncludesOptionalFilters(t *testing.T) {
 	if got := args[2]; got != "completed" {
 		t.Fatalf("findingEvaluationRunListQuery().args[2] = %#v, want completed", got)
 	}
-	if got := args[3]; got != int64(25) {
-		t.Fatalf("findingEvaluationRunListQuery().args[3] = %#v, want 25", got)
+	if got := args[3]; got != cutoff {
+		t.Fatalf("findingEvaluationRunListQuery().args[3] = %#v, want %v", got, cutoff)
+	}
+	if got := args[4]; got != int64(25) {
+		t.Fatalf("findingEvaluationRunListQuery().args[4] = %#v, want 25", got)
 	}
 }
 


### PR DESCRIPTION
## Stack

Layer 2 of the bounded replacement for #1839. Base: `main`. Current main: `f3b963441e0d6609ee79bbcb93439189f673285d`.

## Scope

- collect source-bound assessment inputs through persisted finding-evaluation runs
- enforce the assessment collection barrier with `finished_at <= as_of`
- complete trusted source-backed assessments while failing closed on incomplete graph evidence
- preserve published-plan replay immutability
- keep latest-runtime health reads and bounded assessment history ordering compatible

Exact head: `87169dc8b3aedd01d39bd61e7554a6b59be8b696`.

Exact layer scope: 11 files, +1,641/-26 (1,667 changed lines).

## Validation

- `go test -p 1 ./internal/complianceassessment ./internal/statestore/postgres -count=1`
- `go test -race -p 1 ./internal/complianceassessment ./internal/statestore/postgres -count=1`
- `go vet ./internal/complianceassessment ./internal/statestore/postgres`
- `make check-arch`
- `git diff --check origin/main...HEAD`
- exact-head merge simulation is clean against current main `f3b963441e0d6609ee79bbcb93439189f673285d` with tree `2a01553ebde5d70463f3554913a9df2cb4ebc074`

Authoritative CI run `29397310122` and Droid run `29397310185` are running on this exact head.