### PR TITLE
Fix candidate artifact uploads from hidden build paths

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -126,6 +126,7 @@ jobs:
           name: candidate-binaries-${{ needs.resolve.outputs.sha }}
           path: .dist/release
           if-no-files-found: error
+          include-hidden-files: true
 
   image:
     runs-on: ubuntu-latest
@@ -264,6 +265,7 @@ jobs:
           name: candidate-contract-${{ matrix.target }}-${{ needs.resolve.outputs.sha }}
           path: .dist
           if-no-files-found: error
+          include-hidden-files: true
 
   receipt:
     runs-on: ubuntu-latest

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -202,6 +202,8 @@ func TestReleaseWorkflowsKeepCandidateAndStableBoundaries(t *testing.T) {
 		"cerebro.release-candidate/v1",
 		"bundle-checksums.txt",
 		"| head -n 1 || true",
+		"path: .dist/release\n          if-no-files-found: error\n          include-hidden-files: true",
+		"path: .dist\n          if-no-files-found: error\n          include-hidden-files: true",
 	} {
 		if !strings.Contains(candidate, marker) {
 			t.Fatalf("candidate workflow missing required marker %q", marker)


### PR DESCRIPTION
## What changed

- Include hidden build paths when uploading candidate binary and contract artifacts.
- Add a workflow invariant that protects both uploads from regressing.

## Why

The pinned artifact action excludes hidden files by default. Candidate generation and signing succeeded, but uploads rooted under `.dist` were treated as empty.

## Validation

- `actionlint .github/workflows/cut-release.yml`
- `go test ./tools/archtests -count=1`
- `python3 -m unittest discover -s scripts/tests`
- `make check-structural-test check-arch`
