### PR TITLE
Validate reviewed finding profile exclusions

### DIFF
--- a/internal/compliance/builtin.go
+++ b/internal/compliance/builtin.go
@@ -17,6 +17,9 @@ var builtinControlCoverageIndexYAML []byte
 //go:embed finding_profile_index.json.gz
 var builtinFindingProfileIndexJSONGZ []byte
 
+//go:embed finding_profile_exclusions.yaml
+var builtinFindingProfileExclusionsYAML []byte
+
 //go:embed control_archetypes.yaml
 var builtinControlArchetypesYAML []byte
 
@@ -52,6 +55,10 @@ func LoadBuiltinFindingProfileIndex() (FindingProfileIndex, error) {
 		return FindingProfileIndex{}, fmt.Errorf("built-in finding profile index source digest mismatch: got %q, want %q", index.SourceDigest, digest)
 	}
 	return index, nil
+}
+
+func LoadBuiltinFindingProfileExclusionLedger() (FindingProfileExclusionLedger, error) {
+	return LoadFindingProfileExclusionLedger(builtinFindingProfileExclusionsYAML)
 }
 
 func LoadBuiltinControlArchetypeSet() (ControlArchetypeSet, error) {

--- a/internal/compliance/finding_profile_exclusions.go
+++ b/internal/compliance/finding_profile_exclusions.go
@@ -1,0 +1,191 @@
+package compliance
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	findinganalysis "github.com/writer/cerebro/internal/findings"
+	"gopkg.in/yaml.v3"
+)
+
+const DefaultFindingProfileExclusionsPath = "internal/compliance/finding_profile_exclusions.yaml"
+
+// ErrInvalidFindingProfileExclusionLedger identifies malformed ledger YAML.
+var ErrInvalidFindingProfileExclusionLedger = errors.New("invalid finding profile exclusion ledger")
+
+const (
+	findingProfileExclusionReviewStateReviewed = "reviewed"
+	findingProfileExclusionReviewDateLayout    = "2006-01-02"
+)
+
+// FindingProfileExclusionLedger records reviewed decisions not to associate
+// public findings with a named compliance profile.
+type FindingProfileExclusionLedger struct {
+	Version        string                    `json:"version" yaml:"version"`
+	CatalogVersion string                    `json:"catalog_version" yaml:"catalog_version"`
+	Exclusions     []FindingProfileExclusion `json:"exclusions" yaml:"exclusions"`
+}
+
+type FindingProfileExclusion struct {
+	FindingID   string `json:"finding_id" yaml:"finding_id"`
+	Reason      string `json:"reason" yaml:"reason"`
+	Owner       string `json:"owner" yaml:"owner"`
+	ReviewState string `json:"review_state" yaml:"review_state"`
+	ReviewedAt  string `json:"reviewed_at" yaml:"reviewed_at"`
+}
+
+func LoadFindingProfileExclusionLedger(content []byte) (FindingProfileExclusionLedger, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+	var ledger FindingProfileExclusionLedger
+	if err := decoder.Decode(&ledger); err != nil {
+		return FindingProfileExclusionLedger{}, fmt.Errorf("%w: %w", ErrInvalidFindingProfileExclusionLedger, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return FindingProfileExclusionLedger{}, fmt.Errorf("%w: %w", ErrInvalidFindingProfileExclusionLedger, err)
+		}
+		return FindingProfileExclusionLedger{}, fmt.Errorf("%w: multiple YAML documents are not allowed", ErrInvalidFindingProfileExclusionLedger)
+	}
+	return ledger, nil
+}
+
+// ValidateFindingProfileCoverage requires every public finding to resolve to a
+// named compliance profile or have a complete reviewed exclusion.
+func ValidateFindingProfileCoverage(index FindingProfileIndex, ledger FindingProfileExclusionLedger, catalog findinganalysis.PublicDetectionCatalog) []ValidationIssue {
+	issues := []ValidationIssue{}
+	if strings.TrimSpace(ledger.Version) == "" {
+		issues = append(issues, ValidationIssue{Path: "version", Message: "is required"})
+	}
+	catalogVersion := strings.TrimSpace(catalog.Version)
+	ledgerCatalogVersion := strings.TrimSpace(ledger.CatalogVersion)
+	if catalogVersion == "" {
+		issues = append(issues, ValidationIssue{Path: "public_catalog.version", Message: "is required"})
+	}
+	if ledgerCatalogVersion == "" {
+		issues = append(issues, ValidationIssue{Path: "catalog_version", Message: "is required"})
+	} else if catalogVersion != "" && ledgerCatalogVersion != catalogVersion {
+		issues = append(issues, ValidationIssue{
+			Path:    "catalog_version",
+			Message: fmt.Sprintf("%q does not match public catalog version %q", ledgerCatalogVersion, catalogVersion),
+		})
+	}
+
+	detectionsByID := make(map[string]findinganalysis.PublicDetection, len(catalog.Detections))
+	linked := make(map[string]struct{}, len(catalog.Detections))
+	for idx, detection := range catalog.Detections {
+		path := fmt.Sprintf("public_catalog.detections[%d].id", idx)
+		id := strings.TrimSpace(detection.ID)
+		if id == "" {
+			issues = append(issues, ValidationIssue{Path: path, Message: "is required"})
+			continue
+		}
+		if _, duplicate := detectionsByID[id]; duplicate {
+			issues = append(issues, ValidationIssue{Path: path, Message: fmt.Sprintf("public finding id %q is duplicated", id)})
+			continue
+		}
+		detectionsByID[id] = detection
+		refs := make([]ControlRef, 0, len(detection.ControlRefs))
+		for _, ref := range detection.ControlRefs {
+			refs = append(refs, ControlRef{FrameworkName: ref.FrameworkName, ControlID: ref.ControlID})
+		}
+		if len(ResolveFindingProfileMatches(index, id, refs)) != 0 {
+			linked[id] = struct{}{}
+		}
+	}
+
+	exclusionIDs := make(map[string]struct{}, len(ledger.Exclusions))
+	reviewedExclusions := make(map[string]struct{}, len(ledger.Exclusions))
+	for idx, exclusion := range ledger.Exclusions {
+		path := fmt.Sprintf("exclusions[%d]", idx)
+		id := strings.TrimSpace(exclusion.FindingID)
+		valid := true
+		if id == "" {
+			issues = append(issues, ValidationIssue{Path: path + ".finding_id", Message: "is required"})
+			continue
+		}
+		if _, duplicate := exclusionIDs[id]; duplicate {
+			issues = append(issues, ValidationIssue{Path: path + ".finding_id", Message: fmt.Sprintf("exclusion for public finding %q is duplicated", id)})
+			valid = false
+		} else {
+			exclusionIDs[id] = struct{}{}
+		}
+		if _, known := detectionsByID[id]; !known {
+			issues = append(issues, ValidationIssue{Path: path + ".finding_id", Message: fmt.Sprintf("public finding %q is not in the catalog", id)})
+			valid = false
+		}
+		if _, stale := linked[id]; stale {
+			issues = append(issues, ValidationIssue{Path: path + ".finding_id", Message: fmt.Sprintf("public finding %q now resolves to a named profile", id)})
+			valid = false
+		}
+		if !concreteFindingProfileReviewValue(exclusion.Reason) {
+			issues = append(issues, ValidationIssue{Path: path + ".reason", Message: "a concrete reason is required"})
+			valid = false
+		}
+		if !concreteFindingProfileReviewValue(exclusion.Owner) {
+			issues = append(issues, ValidationIssue{Path: path + ".owner", Message: "a concrete owner is required"})
+			valid = false
+		}
+		if strings.TrimSpace(exclusion.ReviewState) != findingProfileExclusionReviewStateReviewed {
+			issues = append(issues, ValidationIssue{Path: path + ".review_state", Message: fmt.Sprintf("must be %q", findingProfileExclusionReviewStateReviewed)})
+			valid = false
+		}
+		if _, err := time.Parse(findingProfileExclusionReviewDateLayout, strings.TrimSpace(exclusion.ReviewedAt)); err != nil {
+			issues = append(issues, ValidationIssue{Path: path + ".reviewed_at", Message: "must be a valid YYYY-MM-DD date"})
+			valid = false
+		}
+		if valid {
+			reviewedExclusions[id] = struct{}{}
+		}
+	}
+
+	for id := range detectionsByID {
+		if _, ok := linked[id]; ok {
+			continue
+		}
+		if _, ok := reviewedExclusions[id]; ok {
+			continue
+		}
+		issues = append(issues, ValidationIssue{
+			Path:    "public_catalog",
+			Message: fmt.Sprintf("public finding %q has no named profile link or reviewed exclusion", id),
+		})
+	}
+	sort.Slice(issues, func(i, j int) bool { return issues[i].Error() < issues[j].Error() })
+	return issues
+}
+
+func ValidateBuiltinFindingProfileCoverage(catalog findinganalysis.PublicDetectionCatalog) error {
+	ledger, err := LoadBuiltinFindingProfileExclusionLedger()
+	if err != nil {
+		return fmt.Errorf("load %s: %w", DefaultFindingProfileExclusionsPath, err)
+	}
+	index, err := LoadBuiltinFindingProfileIndex()
+	if err != nil {
+		return fmt.Errorf("load %s: %w", DefaultFindingProfileIndexPath, err)
+	}
+	issues := ValidateFindingProfileCoverage(index, ledger, catalog)
+	if len(issues) == 0 {
+		return nil
+	}
+	messages := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		messages = append(messages, issue.Error())
+	}
+	return fmt.Errorf("validate %s: %s", DefaultFindingProfileExclusionsPath, strings.Join(messages, "; "))
+}
+
+func concreteFindingProfileReviewValue(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "-", "n/a", "na", "none", "placeholder", "tbd", "todo", "unknown", "unassigned":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/compliance/finding_profile_exclusions.yaml
+++ b/internal/compliance/finding_profile_exclusions.yaml
@@ -1,0 +1,88 @@
+version: "2026-07-14"
+catalog_version: "2026-05-21"
+exclusions:
+  - finding_id: contract-billing-mismatch
+    reason: The finding targets contract-to-billing reconciliation. No named compliance profile currently selects the internal financial control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: hubspot-excessive-discount
+    reason: The finding targets sales discount authorization. No named compliance profile currently selects the internal revenue or financial control families, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: hubspot-no-next-step
+    reason: The finding targets sales pipeline execution. No named compliance profile currently selects the internal revenue operations control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: hubspot-stale-deal
+    reason: The finding targets sales pipeline freshness and forecasting. No named compliance profile currently selects the internal revenue operations control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: org-bottleneck-critical
+    reason: The finding targets organizational dependency concentration. No named compliance profile currently selects the internal organizational resilience control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: org-bus-factor-critical
+    reason: The finding targets single-person operational dependency. No named compliance profile currently selects the internal organizational resilience control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: org-customer-relationship-health-low
+    reason: The finding targets customer relationship concentration and health. No named compliance profile currently selects the internal organizational resilience or revenue operations control families, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: org-customer-topology-churn-risk
+    reason: The finding targets customer relationship topology and churn risk. No named compliance profile currently selects the internal organizational resilience or revenue operations control families, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: org-customer-touchpoints-low
+    reason: The finding targets customer contact coverage. No named compliance profile currently selects the internal organizational resilience control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: org-relationship-decay-customer
+    reason: The finding targets customer relationship decay. No named compliance profile currently selects the internal organizational resilience or revenue operations control families, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: org-silo-shared-dependency
+    reason: The finding targets coordination risk across teams that share dependencies. No named compliance profile currently selects the internal organizational resilience control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: org-tenure-risk
+    reason: The finding targets knowledge concentration and employee disengagement. No named compliance profile currently selects the internal organizational resilience control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: sf-close-date-slip
+    reason: The finding targets sales forecast changes. No named compliance profile currently selects the internal revenue operations control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: sf-stale-enterprise-opp
+    reason: The finding targets sales pipeline freshness and forecasting. No named compliance profile currently selects the internal revenue operations control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: stripe-large-refund
+    reason: The finding targets refund approval. No named compliance profile currently selects the internal financial control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: stripe-payment-failure-streak
+    reason: The finding targets customer payment collection. No named compliance profile currently selects the internal revenue operations control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"
+  - finding_id: stripe-trial-no-payment-method
+    reason: The finding targets trial conversion and payment readiness. No named compliance profile currently selects the internal revenue operations control family, and no reviewed crosswalk supports an external profile link.
+    owner: compliance-mapping
+    review_state: reviewed
+    reviewed_at: "2026-07-14"

--- a/internal/compliance/finding_profile_exclusions_test.go
+++ b/internal/compliance/finding_profile_exclusions_test.go
@@ -1,0 +1,191 @@
+package compliance
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	findinganalysis "github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestLoadFindingProfileExclusionLedgerIsStrict(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "unknown field",
+			content: `version: "2026-07-14"
+catalog_version: "2026-05-21"
+unexpected: true
+exclusions: []
+`,
+		},
+		{
+			name: "multiple documents",
+			content: `version: "2026-07-14"
+catalog_version: "2026-05-21"
+exclusions: []
+---
+version: "2026-07-15"
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadFindingProfileExclusionLedger([]byte(tt.content))
+			if !errors.Is(err, ErrInvalidFindingProfileExclusionLedger) {
+				t.Fatalf("LoadFindingProfileExclusionLedger() error = %v, want ErrInvalidFindingProfileExclusionLedger", err)
+			}
+		})
+	}
+}
+
+func TestValidateFindingProfileCoverageAcceptsRuleControlAndReviewedExclusion(t *testing.T) {
+	index, ledger, catalog := validFindingProfileCoverageFixture()
+	if issues := ValidateFindingProfileCoverage(index, ledger, catalog); len(issues) != 0 {
+		t.Fatalf("ValidateFindingProfileCoverage() issues = %#v", issues)
+	}
+}
+
+func TestValidateFindingProfileCoverageRejectsInvalidCoverage(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*FindingProfileIndex, *FindingProfileExclusionLedger, *findinganalysis.PublicDetectionCatalog)
+		wantErr string
+	}{
+		{
+			name: "catalog version mismatch",
+			mutate: func(_ *FindingProfileIndex, ledger *FindingProfileExclusionLedger, _ *findinganalysis.PublicDetectionCatalog) {
+				ledger.CatalogVersion = "2026-05-20"
+			},
+			wantErr: "does not match public catalog version",
+		},
+		{
+			name: "duplicate public finding id",
+			mutate: func(_ *FindingProfileIndex, _ *FindingProfileExclusionLedger, catalog *findinganalysis.PublicDetectionCatalog) {
+				catalog.Detections = append(catalog.Detections, catalog.Detections[0])
+			},
+			wantErr: "public finding id \"rule-linked\" is duplicated",
+		},
+		{
+			name: "duplicate exclusion",
+			mutate: func(_ *FindingProfileIndex, ledger *FindingProfileExclusionLedger, _ *findinganalysis.PublicDetectionCatalog) {
+				ledger.Exclusions = append(ledger.Exclusions, ledger.Exclusions[0])
+			},
+			wantErr: "exclusion for public finding \"reviewed-exclusion\" is duplicated",
+		},
+		{
+			name: "unknown exclusion",
+			mutate: func(_ *FindingProfileIndex, ledger *FindingProfileExclusionLedger, _ *findinganalysis.PublicDetectionCatalog) {
+				ledger.Exclusions[0].FindingID = "missing"
+			},
+			wantErr: "public finding \"missing\" is not in the catalog",
+		},
+		{
+			name: "stale exclusion",
+			mutate: func(_ *FindingProfileIndex, ledger *FindingProfileExclusionLedger, _ *findinganalysis.PublicDetectionCatalog) {
+				ledger.Exclusions[0].FindingID = "rule-linked"
+			},
+			wantErr: "public finding \"rule-linked\" now resolves to a named profile",
+		},
+		{
+			name: "placeholder reason",
+			mutate: func(_ *FindingProfileIndex, ledger *FindingProfileExclusionLedger, _ *findinganalysis.PublicDetectionCatalog) {
+				ledger.Exclusions[0].Reason = "TBD"
+			},
+			wantErr: "a concrete reason is required",
+		},
+		{
+			name: "placeholder owner",
+			mutate: func(_ *FindingProfileIndex, ledger *FindingProfileExclusionLedger, _ *findinganalysis.PublicDetectionCatalog) {
+				ledger.Exclusions[0].Owner = "unassigned"
+			},
+			wantErr: "a concrete owner is required",
+		},
+		{
+			name: "unreviewed state",
+			mutate: func(_ *FindingProfileIndex, ledger *FindingProfileExclusionLedger, _ *findinganalysis.PublicDetectionCatalog) {
+				ledger.Exclusions[0].ReviewState = "pending"
+			},
+			wantErr: "must be \"reviewed\"",
+		},
+		{
+			name: "invalid review date",
+			mutate: func(_ *FindingProfileIndex, ledger *FindingProfileExclusionLedger, _ *findinganalysis.PublicDetectionCatalog) {
+				ledger.Exclusions[0].ReviewedAt = "2026-02-30"
+			},
+			wantErr: "must be a valid YYYY-MM-DD date",
+		},
+		{
+			name: "uncovered public finding",
+			mutate: func(_ *FindingProfileIndex, _ *FindingProfileExclusionLedger, catalog *findinganalysis.PublicDetectionCatalog) {
+				catalog.Detections = append(catalog.Detections, findinganalysis.PublicDetection{ID: "uncovered"})
+			},
+			wantErr: "public finding \"uncovered\" has no named profile link or reviewed exclusion",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			index, ledger, catalog := validFindingProfileCoverageFixture()
+			tt.mutate(&index, &ledger, &catalog)
+			issues := ValidateFindingProfileCoverage(index, ledger, catalog)
+			if !findingProfileIssuesContain(issues, tt.wantErr) {
+				t.Fatalf("ValidateFindingProfileCoverage() issues = %#v, want %q", issues, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateBuiltinFindingProfileCoverageCoversPublicCatalog(t *testing.T) {
+	if err := ValidateBuiltinFindingProfileCoverage(findinganalysis.BuiltinPublicDetectionCatalog()); err != nil {
+		t.Fatalf("ValidateBuiltinFindingProfileCoverage() error = %v", err)
+	}
+}
+
+func validFindingProfileCoverageFixture() (FindingProfileIndex, FindingProfileExclusionLedger, findinganalysis.PublicDetectionCatalog) {
+	profileMatch := FindingProfileMatch{
+		ProfileID:       "security-audit",
+		MappingBasis:    FindingProfileMappingDirect,
+		MatchedControls: []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+		DirectControls:  []ControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+	}
+	index := FindingProfileIndex{
+		MatchesByRuleID: map[string][]FindingProfileMatch{
+			"rule-linked": {profileMatch},
+		},
+		MatchesByControl: map[string][]FindingProfileMatch{
+			ControlKey(ControlRef{FrameworkName: "SOC 2", ControlID: "CC6.1"}): {profileMatch},
+		},
+	}
+	ledger := FindingProfileExclusionLedger{
+		Version:        "2026-07-14",
+		CatalogVersion: "2026-05-21",
+		Exclusions: []FindingProfileExclusion{{
+			FindingID:   "reviewed-exclusion",
+			Reason:      "The finding does not apply to a named compliance profile.",
+			Owner:       "compliance-mapping",
+			ReviewState: findingProfileExclusionReviewStateReviewed,
+			ReviewedAt:  "2026-07-14",
+		}},
+	}
+	catalog := findinganalysis.PublicDetectionCatalog{
+		Version: "2026-05-21",
+		Detections: []findinganalysis.PublicDetection{
+			{ID: "rule-linked"},
+			{ID: "control-linked", ControlRefs: []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}}},
+			{ID: "reviewed-exclusion"},
+		},
+	}
+	return index, ledger, catalog
+}
+
+func findingProfileIssuesContain(issues []ValidationIssue, want string) bool {
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/detectioncatalog/detectioncatalog.go
+++ b/tools/detectioncatalog/detectioncatalog.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/writer/cerebro/internal/compliance"
 	findinganalysis "github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/sourceregistry"
 )
@@ -88,6 +89,9 @@ func generateCatalog() ([]byte, error) {
 	}
 	if errs := findinganalysis.ValidatePublicDetectionAuditDepth(catalog); len(errs) != 0 {
 		return nil, errs[0]
+	}
+	if err := compliance.ValidateBuiltinFindingProfileCoverage(catalog); err != nil {
+		return nil, err
 	}
 	content, err := json.MarshalIndent(catalog, "", "  ")
 	if err != nil {


### PR DESCRIPTION
## What changed

- Add the reviewed finding-profile exclusion ledger to the compliance domain.
- Load the ledger with strict YAML field and document validation.
- Validate the ledger against the built-in finding profile index and public finding catalog, including catalog version agreement, unique known finding IDs, stale exclusions, review ownership and dates, and complete profile-or-exclusion coverage.
- Make public detection catalog generation and freshness checks fail when the coverage contract is incomplete.

## Why

Named compliance profile coverage needs a checked-in review path for public findings that do not resolve to a profile. Keeping the ledger and validator in the compliance domain makes the contract reusable without adding finding-profile policy to bootstrap wiring.

## Impact

This adds an internal validation gate only. It does not change API contracts, runtime finding behavior, or generated export formats.

## Validation

- `go test ./internal/compliance ./internal/findings ./tools/detectioncatalog -count=1`
- `go test -race ./internal/compliance -count=1`
- `go vet ./internal/compliance ./internal/findings ./tools/detectioncatalog`
- changed-line `golangci-lint` for `./internal/compliance` and `./tools/detectioncatalog`
- `make detection-catalog-check`
- `make changed-check DROID_REVIEW_BASE=6cc7b6e5b7e4d3d925bd0040cc1d5d8e0c7eb66c DROID_REVIEW_HEAD=HEAD`
- `make check-structural check-structural-test check-arch`
- `make droid-review-preflight DROID_REVIEW_BASE=6cc7b6e5b7e4d3d925bd0040cc1d5d8e0c7eb66c DROID_REVIEW_HEAD=d84f7d39bc0441f6958bf8a99004a51dc78557cf`
