### PR TITLE
Cache compressed GRC responses

### DIFF
--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/querycache"
+	httpcompression "github.com/writer/cerebro/internal/sourcehttp/compression"
 	"github.com/writer/cerebro/internal/telemetry"
 )
 
@@ -73,7 +74,7 @@ func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.Ha
 				return
 			case querycache.StateStale:
 				response, refreshErr := a.queryCacheGroup.Do(key, func() (*capturedHTTPResponse, error) {
-					return captureHTTPResponse(next, r), nil
+					return captureCacheResponse(next, r), nil
 				})
 				if refreshErr == nil && response.cacheableJSON() {
 					setErr := cache.Set(r.Context(), key, response.body.Bytes(), policy.TTL, policy.StaleTTL)
@@ -94,7 +95,7 @@ func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.Ha
 		}
 
 		response, err := a.queryCacheGroup.Do(key, func() (*capturedHTTPResponse, error) {
-			return captureHTTPResponse(next, r), nil
+			return captureCacheResponse(next, r), nil
 		})
 		if err != nil || response == nil {
 			w.Header().Set("X-Cerebro-Cache", "bypass")
@@ -147,13 +148,14 @@ func (a *App) grcCacheKey(r *http.Request, policy grcCachePolicy) string {
 	tenantID := grcCacheTenantID(r)
 	versions := a.grcCacheVersions(r, tenantID, policy.VersionScopes)
 	material := map[string]any{
-		"family":   policy.Family,
-		"method":   r.Method,
-		"path":     r.URL.EscapedPath(),
-		"query":    canonicalRawQuery(r),
-		"auth":     grcCacheAuthMaterial(r),
-		"tenant":   tenantID,
-		"versions": versions,
+		"family":            policy.Family,
+		"method":            r.Method,
+		"path":              r.URL.EscapedPath(),
+		"query":             canonicalRawQuery(r),
+		"auth":              grcCacheAuthMaterial(r),
+		"tenant":            tenantID,
+		"versions":          versions,
+		"response_encoding": grcCacheResponseEncoding(r),
 	}
 	raw, err := json.Marshal(material)
 	if err != nil {
@@ -280,6 +282,10 @@ func captureHTTPResponse(handler http.HandlerFunc, r *http.Request) *capturedHTT
 	return response
 }
 
+func captureCacheResponse(handler http.HandlerFunc, r *http.Request) *capturedHTTPResponse {
+	return captureHTTPResponse(httpcompression.Middleware(handler).ServeHTTP, r)
+}
+
 func (w *capturedHTTPResponse) Header() http.Header {
 	return w.header
 }
@@ -314,6 +320,11 @@ func (w *capturedHTTPResponse) writeTo(dst http.ResponseWriter, cacheState strin
 
 func writeCachedJSON(w http.ResponseWriter, statusCode int, payload []byte, cacheState string, policy grcCachePolicy) {
 	w.Header().Set("Content-Type", "application/json")
+	if cachedPayloadIsGzip(payload) {
+		w.Header().Set("Content-Encoding", "gzip")
+	} else {
+		w.Header().Del("Content-Encoding")
+	}
 	setGRCQueryCacheHeaders(w.Header(), cacheState, policy)
 	w.WriteHeader(statusCode)
 	_, _ = w.Write(payload)
@@ -330,7 +341,7 @@ func copyHeaders(dst http.Header, src http.Header) {
 
 func setGRCQueryCacheHeaders(header http.Header, cacheState string, policy grcCachePolicy) {
 	header.Set("X-Cerebro-Cache", cacheState)
-	header.Set("Vary", appendVary(header.Get("Vary"), "Authorization", "X-Cerebro-API-Key", "X-Cerebro-Tenant"))
+	header.Set("Vary", appendVary(header.Get("Vary"), "Accept-Encoding", "Authorization", "X-Cerebro-API-Key", "X-Cerebro-Tenant"))
 	if (cacheState == "hit" || cacheState == "miss" || cacheState == "stale") && policy.TTL > 0 {
 		maxAge := int(policy.TTL / time.Second)
 		if maxAge < 1 {
@@ -346,6 +357,17 @@ func setGRCQueryCacheHeaders(header http.Header, cacheState string, policy grcCa
 		}
 		header.Set("Cache-Control", value)
 	}
+}
+
+func grcCacheResponseEncoding(r *http.Request) string {
+	if r != nil && httpcompression.AcceptsGzip(r.Header.Get("Accept-Encoding")) {
+		return "gzip"
+	}
+	return "identity"
+}
+
+func cachedPayloadIsGzip(payload []byte) bool {
+	return len(payload) >= 2 && payload[0] == 0x1f && payload[1] == 0x8b
 }
 
 func appendVary(existing string, values ...string) string {

--- a/internal/bootstrap/grc_cache_test.go
+++ b/internal/bootstrap/grc_cache_test.go
@@ -1,8 +1,11 @@
 package bootstrap
 
 import (
+	"compress/gzip"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +42,132 @@ func TestGRCQueryCacheServesFreshHit(t *testing.T) {
 	}
 	if first.Body.String() != second.Body.String() {
 		t.Fatalf("cached body = %q, want %q", second.Body.String(), first.Body.String())
+	}
+}
+
+func TestGRCQueryCacheStoresCompressedRepresentation(t *testing.T) {
+	const maxPayloadBytes = 256
+	payload := `{"items":["` + strings.Repeat("compressible-content-", 512) + `"]}`
+	app := &App{
+		cfg: config.Config{Cache: config.CacheConfig{DefaultTTL: time.Minute, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{
+			Namespace:       "test",
+			MaxPayloadBytes: maxPayloadBytes,
+		})},
+	}
+	calls := 0
+	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Minute), func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	})
+	request := func(acceptEncoding string) *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/grc/dashboard", nil)
+		req.Header.Set("Accept-Encoding", acceptEncoding)
+		return req
+	}
+
+	first := httptest.NewRecorder()
+	handler(first, request("gzip"))
+	second := httptest.NewRecorder()
+	handler(second, request("gzip"))
+
+	if got := first.Header().Get("X-Cerebro-Cache"); got != "miss" {
+		t.Fatalf("first X-Cerebro-Cache = %q, want miss", got)
+	}
+	if got := second.Header().Get("X-Cerebro-Cache"); got != "hit" {
+		t.Fatalf("second X-Cerebro-Cache = %q, want hit", got)
+	}
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+	if got := second.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("second Content-Encoding = %q, want gzip", got)
+	}
+	if second.Body.Len() >= maxPayloadBytes {
+		t.Fatalf("compressed body = %d bytes, want below cache limit %d", second.Body.Len(), maxPayloadBytes)
+	}
+	reader, err := gzip.NewReader(second.Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	decompressed, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read compressed response: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close gzip reader: %v", err)
+	}
+	if got := string(decompressed); got != payload {
+		t.Fatalf("decompressed body mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+
+	identity := httptest.NewRecorder()
+	handler(identity, request("gzip;q=0"))
+	if got := identity.Header().Get("X-Cerebro-Cache"); got != "skip" {
+		t.Fatalf("identity X-Cerebro-Cache = %q, want skip for oversized identity payload", got)
+	}
+	if got := identity.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("identity Content-Encoding = %q, want empty", got)
+	}
+	if calls != 2 {
+		t.Fatalf("handler calls after identity variant = %d, want 2", calls)
+	}
+}
+
+func TestGRCQueryCacheKeepsSmallGzipRequestIdentityEncoded(t *testing.T) {
+	app := &App{
+		cfg:  config.Config{Cache: config.CacheConfig{DefaultTTL: time.Minute, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{Namespace: "test"})},
+	}
+	calls := 0
+	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Minute), func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	})
+
+	for index := 0; index < 2; index++ {
+		req := httptest.NewRequest(http.MethodGet, "/grc/dashboard", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		resp := httptest.NewRecorder()
+		handler(resp, req)
+		if got := resp.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("response %d Content-Encoding = %q, want empty", index, got)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+}
+
+func BenchmarkGRCQueryCacheCompressedHit(b *testing.B) {
+	payload := []byte(`{"items":["` + strings.Repeat("compressible-content-", 50000) + `"]}`)
+	app := &App{
+		cfg: config.Config{Cache: config.CacheConfig{DefaultTTL: time.Minute, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{
+			Namespace:       "benchmark",
+			MaxPayloadBytes: 1 << 20,
+			MaxEntries:      256,
+		})},
+	}
+	handler := app.cacheGRCJSON(app.grcCachePolicy("runtime.health", time.Minute), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(payload)
+	})
+	request := httptest.NewRequest(http.MethodGet, "/source-runtimes/health?view=full", nil)
+	request.Header.Set("Accept-Encoding", "gzip")
+	warm := httptest.NewRecorder()
+	handler(warm, request)
+	if got := warm.Header().Get("X-Cerebro-Cache"); got != "miss" {
+		b.Fatalf("warm X-Cerebro-Cache = %q, want miss", got)
+	}
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(float64(warm.Body.Len()), "wire-bytes")
+	for range b.N {
+		response := httptest.NewRecorder()
+		handler(response, request)
 	}
 }
 

--- a/internal/sourcehttp/compression/middleware.go
+++ b/internal/sourcehttp/compression/middleware.go
@@ -13,6 +13,11 @@ import (
 
 const responseThreshold = 1024
 
+// AcceptsGzip reports whether an Accept-Encoding header permits gzip.
+func AcceptsGzip(value string) bool {
+	return acceptsGzip(value)
+}
+
 // Middleware compresses JSON responses larger than one KiB when the client
 // accepts gzip. Smaller and non-JSON responses pass through unchanged.
 func Middleware(next http.Handler) http.Handler {


### PR DESCRIPTION
## Summary

- cache negotiated gzip and identity representations separately
- store the post-compression response so cache hits avoid repeated compression work
- preserve identity responses, gzip opt-out behavior, and cache variation headers

## Validation

- focused compression and GRC cache tests
- focused race tests
- structural and architecture checks
- compressed-cache benchmark
