### PR TITLE
Start HTTP before durable projection recovery

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -141,9 +141,6 @@ func serve() error {
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	if _, err := app.RecoverPlatformJobs(ctx); err != nil {
-		return fmt.Errorf("recover platform jobs: %w", err)
-	}
 	jobRecoveryDone := app.StartPlatformJobRecovery(ctx, log.Printf)
 	grcWarmupDone := startGRCReadModelWarmup(ctx, deps.StateStore, log.Printf)
 	riskBackfillDone := startFindingRiskBackfill(ctx, app, log.Printf)

--- a/internal/bootstrap/assessment_runtime_test.go
+++ b/internal/bootstrap/assessment_runtime_test.go
@@ -2,6 +2,10 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -90,12 +94,125 @@ func TestStartPlatformJobRecoveryIncludesAssessmentLoop(t *testing.T) {
 	}
 }
 
+func TestStartPlatformJobRecoveryDoesNotBlockOnProjectionReplay(t *testing.T) {
+	started := make(chan struct{})
+	store := &assessmentRuntimeStore{a2ATestJobStore: newA2ATestJobStore()}
+	log := &blockingAssessmentRuntimeLog{started: started}
+	app := &App{}
+	app.services.jobs = platformjobs.New(store)
+	app.services.assessments = complianceassessment.NewAssessmentService(
+		store,
+		log,
+		app.services.jobs,
+		nil,
+	).WithEventReplayPager(log)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := app.StartPlatformJobRecovery(ctx, nil)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		cancel()
+		t.Fatal("projection replay did not start asynchronously")
+	}
+	select {
+	case <-done:
+		cancel()
+		t.Fatal("platform recovery stopped while projection replay was active")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("platform recovery did not stop after projection replay cancellation")
+	}
+}
+
+func TestStartPlatformJobRecoveryRetriesProjectionReplayBeforeContinuousRecovery(t *testing.T) {
+	recovered := make(chan struct{})
+	log := &retryingAssessmentRuntimeLog{recovered: recovered}
+	store := &assessmentRuntimeStore{a2ATestJobStore: newA2ATestJobStore()}
+	app := &App{}
+	app.services.jobs = platformjobs.New(store)
+	app.services.assessments = complianceassessment.NewAssessmentService(store, log, app.services.jobs, nil).WithEventReplayPager(log)
+	ctx, cancel := context.WithCancel(context.Background())
+	logged := make(chan string, 1)
+	done := app.startPlatformJobRecovery(ctx, func(format string, args ...any) {
+		logged <- fmt.Sprintf(format, args...)
+	}, time.Millisecond)
+
+	select {
+	case <-recovered:
+	case <-time.After(time.Second):
+		cancel()
+		t.Fatal("projection replay was not retried")
+	}
+	select {
+	case message := <-logged:
+		if !strings.Contains(message, "temporary replay failure") {
+			cancel()
+			t.Fatalf("recovery log = %q, want replay failure", message)
+		}
+	default:
+		cancel()
+		t.Fatal("initial projection replay failure was not logged")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("platform recovery did not stop after retry cancellation")
+	}
+}
+
 type assessmentRuntimeLog struct{}
 
 func (*assessmentRuntimeLog) Ping(context.Context) error                             { return nil }
 func (*assessmentRuntimeLog) Append(context.Context, *cerebrov1.EventEnvelope) error { return nil }
 func (*assessmentRuntimeLog) ReplayPage(context.Context, ports.ReplayRequest) (ports.ReplayPage, error) {
 	return ports.ReplayPage{Complete: true}, nil
+}
+
+type blockingAssessmentRuntimeLog struct {
+	started chan struct{}
+}
+
+type retryingAssessmentRuntimeLog struct {
+	calls     atomic.Uint32
+	recovered chan struct{}
+}
+
+func (*retryingAssessmentRuntimeLog) Ping(context.Context) error { return nil }
+func (*retryingAssessmentRuntimeLog) Append(context.Context, *cerebrov1.EventEnvelope) error {
+	return nil
+}
+func (l *retryingAssessmentRuntimeLog) ReplayPage(context.Context, ports.ReplayRequest) (ports.ReplayPage, error) {
+	if l.calls.Add(1) == 1 {
+		return ports.ReplayPage{}, errors.New("temporary replay failure")
+	}
+	select {
+	case <-l.recovered:
+	default:
+		close(l.recovered)
+	}
+	return ports.ReplayPage{Complete: true}, nil
+}
+
+func (*blockingAssessmentRuntimeLog) Ping(context.Context) error { return nil }
+func (*blockingAssessmentRuntimeLog) Append(context.Context, *cerebrov1.EventEnvelope) error {
+	return nil
+}
+func (l *blockingAssessmentRuntimeLog) ReplayPage(ctx context.Context, _ ports.ReplayRequest) (ports.ReplayPage, error) {
+	select {
+	case <-l.started:
+	default:
+		close(l.started)
+	}
+	<-ctx.Done()
+	return ports.ReplayPage{}, ctx.Err()
 }
 
 type assessmentRuntimeStore struct {

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -21,6 +22,8 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
+
+const platformJobRecoveryRetryInterval = 15 * time.Second
 
 type createJobHTTPRequest struct {
 	Kind           string         `json:"kind"`
@@ -95,17 +98,46 @@ func (a *App) RecoverPlatformJobs(ctx context.Context) (int, error) {
 	return recovered + jobs, err
 }
 
-// StartPlatformJobRecovery continuously makes expired leases runnable. The
-// returned channel closes after cancellation and is included in shutdown waits.
+// StartPlatformJobRecovery restores durable projections and continuously makes
+// expired leases runnable. Recovery starts asynchronously so a large append log
+// cannot prevent the HTTP server from becoming healthy. The returned channel
+// closes after cancellation and is included in shutdown waits.
 func (a *App) StartPlatformJobRecovery(ctx context.Context, logf func(string, ...any)) <-chan struct{} {
-	jobsDone := a.jobService().StartRecovery(ctx, logf)
-	if a == nil || a.services.assessments == nil {
-		return jobsDone
-	}
-	assessmentsDone := a.services.assessments.StartInterruptedRunRecovery(ctx, 0, logf)
+	return a.startPlatformJobRecovery(ctx, logf, platformJobRecoveryRetryInterval)
+}
+
+func (a *App) startPlatformJobRecovery(ctx context.Context, logf func(string, ...any), retryInterval time.Duration) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+		for {
+			_, err := a.RecoverPlatformJobs(ctx)
+			if err == nil {
+				break
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			if logf != nil {
+				logf("recover platform jobs: %v", err)
+			}
+			timer := time.NewTimer(retryInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		jobsDone := a.jobService().StartRecovery(ctx, logf)
+		if a == nil || a.services.assessments == nil {
+			<-jobsDone
+			return
+		}
+		assessmentsDone := a.services.assessments.StartInterruptedRunRecovery(ctx, 0, logf)
 		<-jobsDone
 		<-assessmentsDone
 	}()


### PR DESCRIPTION
## What changed
- start durable projection and platform-job recovery in the existing shutdown-tracked background supervisor
- let the HTTP server bind before a large assessment replay completes
- retry transient recovery failures before continuous job and assessment reconciliation starts
- cover blocked replay, retry, and cancellation behavior with regression tests

## Why
Production tasks were terminated by load-balancer health checks while startup synchronously scanned more than 1.5 million assessment events. The API never opened its health port, so the previous task revision remained active. A transient replay failure also must not leave an API serving indefinitely with incomplete recovered projections.

## Verification
- go test ./internal/bootstrap ./cmd/cerebro
- git diff --check origin/main...HEAD