### PR TITLE
feat(compliance): persist assurance decisions

### DIFF
--- a/docs/engineering/assurance-decision-contract.md
+++ b/docs/engineering/assurance-decision-contract.md
@@ -1,0 +1,49 @@
+# Assurance Decision Contract
+
+An assurance decision is an immutable record of one compliance objective verdict at one decision time. It binds a completed assessment run, the run's exact input manifest, one result from the run's validated result set, the proofs evaluated at decision time, and the fail-closed qualification outcome.
+
+## Durable identity
+
+- Resource IDs use the `assurance-decision-<opaque>` format.
+- Every record is tenant scoped.
+- `run_id`, `result_id`, and `objective_id` identify the assessed fact.
+- `program_id`, `scope_revision_id`, and `plan_revision_id` preserve the governed assessment scope.
+- `decision_digest` addresses the qualification outcome.
+- `record_digest` addresses the complete immutable record, including its input snapshot and actor.
+- An idempotency key identifies one record request. Reusing it with different proof material returns a conflict.
+
+## Write path
+
+The service accepts a decision only when all of these checks pass:
+
+1. The assessment run is complete and has a persisted input hash, result-set hash, result count, and completion time.
+2. The supplied manifest matches both the persisted manifest and the run input hash.
+3. Result chunks form a contiguous digest chain.
+4. Recomputing all chunk results matches the run result-set hash and result count.
+5. The supplied objective result matches the selected persisted result.
+6. The decision time is not earlier than assessment completion.
+7. Recomputing qualification from the input snapshot produces the stored verdict and decision digest.
+8. The record time is not earlier than the decision time.
+
+An unqualified verdict can be recorded. It cannot authorize production use because `AuthorizeProductionUse` continues to fail closed.
+
+## Storage boundaries
+
+- JetStream receives `workflow.v1.compliance.assessment_assurance_decision_recorded` before the read projection is updated.
+- Postgres stores the immutable current read projection in `compliance_assurance_decisions`.
+- The projection can be rebuilt through the existing assessment event replay path.
+- Neo4j remains a rebuildable relationship projection. It is not an assurance-decision store of record.
+- Evidence payload bytes remain in EvidenceCAS. The decision snapshot carries evidence identifiers, states, collection times, and validity times.
+
+## Rollout gate
+
+Enable decision writes only after the assessment projection contains completed runs and result chunks. A rollout is ready when:
+
+- focused qualification, record, idempotency, tamper, replay, and Postgres schema tests pass;
+- race tests pass for the decision record and replay paths;
+- architecture checks confirm the existing store boundaries;
+- replay in a non-production environment reconstructs the same `record_digest` values.
+
+## Rollback
+
+Disable the decision write route before rolling back application code. Existing events and Postgres rows remain readable data. Do not delete the event kind or table during rollback. A later deployment can replay the events to restore the projection. Because decision rows are immutable and no existing assessment API is replaced, rollback does not require rewriting assessment runs or results.

--- a/internal/compliance/identifiers.go
+++ b/internal/compliance/identifiers.go
@@ -23,6 +23,7 @@ const (
 	IdentifierClaim          IdentifierKind = "evidence-claim"
 	IdentifierRun            IdentifierKind = "assessment-run"
 	IdentifierResult         IdentifierKind = "assessment-result"
+	IdentifierDecision       IdentifierKind = "assurance-decision"
 	IdentifierReview         IdentifierKind = "assessment-review"
 	IdentifierArtifact       IdentifierKind = "artifact"
 	IdentifierMapping        IdentifierKind = "control-mapping"

--- a/internal/complianceassessment/assurance_decision.go
+++ b/internal/complianceassessment/assurance_decision.go
@@ -1,0 +1,262 @@
+package complianceassessment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+var (
+	ErrAssuranceDecisionNotFound    = errors.New("assurance decision not found")
+	ErrAssuranceDecisionUnavailable = errors.New("assurance decision persistence is unavailable")
+)
+
+const AssuranceDecisionVersion = "assurance-decision/v1"
+
+// AssuranceDecision is an immutable decision-time record. InputSnapshot
+// preserves the exact proof material evaluated by Qualification; Decision
+// preserves the resulting fail-closed verdict and its content-addressed digest.
+type AssuranceDecision struct {
+	ID              string             `json:"id"`
+	TenantID        string             `json:"tenant_id"`
+	RunID           string             `json:"run_id"`
+	ResultID        string             `json:"result_id"`
+	ObjectiveID     string             `json:"objective_id"`
+	ProgramID       string             `json:"program_id"`
+	ScopeRevisionID string             `json:"scope_revision_id"`
+	PlanRevisionID  string             `json:"plan_revision_id"`
+	Version         string             `json:"version"`
+	InputSnapshot   QualificationInput `json:"input_snapshot"`
+	Decision        QualifiedDecision  `json:"decision"`
+	RequestHash     string             `json:"request_hash"`
+	IdempotencyKey  string             `json:"idempotency_key"`
+	RecordedAt      time.Time          `json:"recorded_at"`
+	RecordedBy      string             `json:"recorded_by"`
+	RecordDigest    string             `json:"record_digest"`
+}
+
+type AssuranceDecisionRequest struct {
+	TenantID       string
+	RunID          string
+	ResultID       string
+	Input          QualificationInput
+	IdempotencyKey string
+	RecordedBy     string
+}
+
+// RecordAssuranceDecision records a decision only after binding its manifest
+// and result to the completed assessment run. An unqualified verdict is still
+// a valid durable decision; production authorization remains fail closed via
+// QualifiedDecision.AuthorizeProductionUse.
+func (s *Service) RecordAssuranceDecision(ctx context.Context, request AssuranceDecisionRequest) (AssuranceDecision, bool, error) {
+	decisionStore, ok := s.assuranceDecisionStore()
+	if !ok || s.log == nil {
+		return AssuranceDecision{}, false, ErrAssuranceDecisionUnavailable
+	}
+	request = normalizeAssuranceDecisionRequest(request)
+	if request.TenantID == "" || request.RunID == "" || request.ResultID == "" || request.IdempotencyKey == "" || request.RecordedBy == "" {
+		return AssuranceDecision{}, false, fmt.Errorf("%w: decision request identity is incomplete", ErrInvalidResult)
+	}
+	requestHash, err := semanticHash(request)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	if existing, findErr := decisionStore.FindAssuranceDecisionByIdempotency(ctx, request.TenantID, request.IdempotencyKey); findErr == nil {
+		if existing.RequestHash != requestHash {
+			return AssuranceDecision{}, false, ports.ErrJobIdempotencyConflict
+		}
+		return existing, false, nil
+	} else if !errors.Is(findErr, ErrAssuranceDecisionNotFound) {
+		return AssuranceDecision{}, false, findErr
+	}
+
+	run, err := s.store.GetRun(ctx, request.TenantID, request.RunID)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	if run.State != RunComplete || run.InputManifest == nil || run.InputHash == "" || run.AutomatedResultHash == "" || run.CompletedAt.IsZero() {
+		return AssuranceDecision{}, false, fmt.Errorf("%w: assessment run is not complete", ErrAssessmentConflict)
+	}
+	manifestHash, err := CanonicalManifestDigest(request.Input.Manifest)
+	if err != nil || manifestHash != run.InputHash {
+		return AssuranceDecision{}, false, fmt.Errorf("%w: decision manifest does not match assessment run", ErrAssessmentConflict)
+	}
+	storedManifestHash, err := CanonicalManifestDigest(*run.InputManifest)
+	if err != nil || storedManifestHash != manifestHash {
+		return AssuranceDecision{}, false, fmt.Errorf("%w: persisted assessment manifest does not match its input hash", ErrAssessmentConflict)
+	}
+	result, err := s.findRunResult(ctx, request.TenantID, request.RunID, request.ResultID, run.AutomatedResultHash, run.ResultCount)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	wantResultHash, err := CanonicalResultDigest(result)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	requestResultHash, err := CanonicalResultDigest(request.Input.Result)
+	if err != nil || requestResultHash != wantResultHash {
+		return AssuranceDecision{}, false, fmt.Errorf("%w: decision result does not match assessment result", ErrAssessmentConflict)
+	}
+	recordedAt := CanonicalTime(s.now())
+	if request.Input.AsOf.Before(run.CompletedAt) || request.Input.AsOf.After(recordedAt) {
+		return AssuranceDecision{}, false, fmt.Errorf("%w: decision time is outside the completed assessment window", ErrInvalidResult)
+	}
+
+	qualified := QualifyDecision(ctx, request.Input)
+	id, err := compliance.NewIdentifier(compliance.IdentifierDecision)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	record := AssuranceDecision{
+		ID: id, TenantID: request.TenantID, RunID: run.ID, ResultID: result.ID,
+		ObjectiveID: result.ObjectiveID, ProgramID: run.ProgramID,
+		ScopeRevisionID: run.ScopeRevisionID, PlanRevisionID: run.PlanRevisionID,
+		Version: AssuranceDecisionVersion, InputSnapshot: request.Input, Decision: qualified,
+		RequestHash: requestHash, IdempotencyKey: request.IdempotencyKey,
+		RecordedAt: recordedAt, RecordedBy: request.RecordedBy,
+	}
+	record.RecordDigest, err = assuranceDecisionDigest(record)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	if err := validateAssuranceDecision(record); err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	payload, err := canonicalBytes(record)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	event, err := workflowevents.NewComplianceAggregateEvent(workflowevents.ComplianceAggregateRecorded{
+		Kind:     workflowevents.EventKindComplianceAssuranceDecisionRecorded,
+		TenantID: record.TenantID, AggregateType: "assurance_decision", AggregateID: record.ID,
+		AggregateVersion: 1, Operation: "assurance_decision_recorded",
+		ContentDigest: record.RecordDigest, PayloadJSON: string(payload), ActorID: record.RecordedBy,
+		RecordedAt: record.RecordedAt.Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	if err := s.log.Append(ctx, event); err != nil {
+		return AssuranceDecision{}, false, fmt.Errorf("append assurance decision: %w", err)
+	}
+	if err := decisionStore.ApplyAssuranceDecision(ctx, event.GetId(), record); err != nil {
+		return AssuranceDecision{}, false, fmt.Errorf("project assurance decision: %w", err)
+	}
+	return record, true, nil
+}
+
+func (s *Service) GetAssuranceDecision(ctx context.Context, tenantID, decisionID string) (AssuranceDecision, error) {
+	store, ok := s.assuranceDecisionStore()
+	if !ok {
+		return AssuranceDecision{}, ErrAssuranceDecisionUnavailable
+	}
+	return store.GetAssuranceDecision(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(decisionID))
+}
+
+func (s *Service) assuranceDecisionStore() (AssuranceDecisionStore, bool) {
+	if s == nil || s.store == nil {
+		return nil, false
+	}
+	store, ok := s.store.(AssuranceDecisionStore)
+	return store, ok
+}
+
+func (s *Service) findRunResult(ctx context.Context, tenantID, runID, resultID, resultSetHash string, resultCount uint64) (ObjectiveResult, error) {
+	chunks, err := s.store.ListResultChunks(ctx, tenantID, runID)
+	if err != nil {
+		return ObjectiveResult{}, err
+	}
+	var (
+		allResults []ObjectiveResult
+		found      *ObjectiveResult
+		previous   string
+	)
+	for index, chunk := range chunks {
+		if err := validateRecoveredResultChunk(chunk); err != nil || chunk.Sequence != uint32(index+1) || chunk.PreviousDigest != previous {
+			return ObjectiveResult{}, fmt.Errorf("%w: assessment result chunk chain is invalid", ErrAssessmentConflict)
+		}
+		previous = chunk.Digest
+		allResults = append(allResults, chunk.Results...)
+		for _, result := range chunk.Results {
+			if result.ID == resultID {
+				normalized := NormalizeResult(result)
+				found = &normalized
+			}
+		}
+	}
+	setDigest, err := CanonicalResultSetDigest(allResults)
+	if err != nil || setDigest != resultSetHash || uint64(len(allResults)) != resultCount {
+		return ObjectiveResult{}, fmt.Errorf("%w: assessment results do not match completed run", ErrAssessmentConflict)
+	}
+	if found == nil {
+		return ObjectiveResult{}, ErrAssuranceDecisionNotFound
+	}
+	return *found, nil
+}
+
+func normalizeAssuranceDecisionRequest(request AssuranceDecisionRequest) AssuranceDecisionRequest {
+	limitationsDeclared := request.Input.Limitations != nil
+	reviewsDeclared := request.Input.RequiredReviews != nil
+	request.TenantID = strings.TrimSpace(request.TenantID)
+	request.RunID = strings.TrimSpace(request.RunID)
+	request.ResultID = strings.TrimSpace(request.ResultID)
+	request.IdempotencyKey = strings.TrimSpace(request.IdempotencyKey)
+	request.RecordedBy = strings.TrimSpace(request.RecordedBy)
+	request.Input.Manifest = NormalizeManifest(request.Input.Manifest)
+	request.Input.Result = NormalizeResult(request.Input.Result)
+	request.Input.AsOf = CanonicalTime(request.Input.AsOf)
+	request.Input.SourceProofs = normalizeSourceProofs(request.Input.SourceProofs)
+	request.Input.EvidenceProofs = normalizeEvidenceProofs(request.Input.EvidenceProofs)
+	request.Input.Limitations = normalizeLimitations(request.Input.Limitations)
+	request.Input.RequiredReviews = normalizeReviews(request.Input.RequiredReviews)
+	if limitationsDeclared && request.Input.Limitations == nil {
+		request.Input.Limitations = []Limitation{}
+	}
+	if reviewsDeclared && request.Input.RequiredReviews == nil {
+		request.Input.RequiredReviews = []ReviewRequirement{}
+	}
+	request.Input.Exceptions = normalizeExceptionProofs(request.Input.Exceptions)
+	request.Input.Verification.VerifiedAt = CanonicalTime(request.Input.Verification.VerifiedAt)
+	request.Input.Verification.ValidUntil = CanonicalTime(request.Input.Verification.ValidUntil)
+	return request
+}
+
+func assuranceDecisionDigest(record AssuranceDecision) (string, error) {
+	record.RecordDigest = ""
+	return semanticHash(record)
+}
+
+func validateAssuranceDecision(record AssuranceDecision) error {
+	if compliance.ValidateIdentifier(compliance.IdentifierDecision, record.ID) != nil ||
+		record.TenantID == "" || record.RunID == "" || record.ResultID == "" || record.ObjectiveID == "" ||
+		record.ProgramID == "" || record.ScopeRevisionID == "" || record.PlanRevisionID == "" ||
+		record.Version != AssuranceDecisionVersion || record.RequestHash == "" || record.IdempotencyKey == "" ||
+		record.RecordedAt.IsZero() || record.RecordedBy == "" || record.RecordDigest == "" ||
+		record.Decision.DecisionDigest == "" || record.Decision.ManifestHash == "" || record.Decision.ResultHash == "" {
+		return fmt.Errorf("%w: assurance decision is incomplete", ErrInvalidResult)
+	}
+	if record.RecordedAt.Before(record.Decision.AsOf) || !record.Decision.AsOf.Equal(record.InputSnapshot.AsOf) ||
+		record.InputSnapshot.Manifest.ProgramID != record.ProgramID ||
+		record.InputSnapshot.Manifest.ScopeRevisionID != record.ScopeRevisionID ||
+		record.InputSnapshot.Manifest.PlanRevisionID != record.PlanRevisionID ||
+		record.InputSnapshot.Result.ID != record.ResultID || record.InputSnapshot.Result.ObjectiveID != record.ObjectiveID {
+		return fmt.Errorf("%w: assurance decision identity does not match its input snapshot", ErrInvalidResult)
+	}
+	expected := evaluateQualification(record.InputSnapshot)
+	expectedDigest, expectedErr := semanticHash(expected)
+	decisionDigest, decisionErr := semanticHash(record.Decision)
+	if expectedErr != nil || decisionErr != nil || expectedDigest != decisionDigest {
+		return fmt.Errorf("%w: assurance decision verdict does not match its input snapshot", ErrInvalidResult)
+	}
+	digest, err := assuranceDecisionDigest(record)
+	if err != nil || digest != record.RecordDigest {
+		return fmt.Errorf("%w: assurance decision record digest does not match", ErrInvalidResult)
+	}
+	return nil
+}

--- a/internal/complianceassessment/assurance_decision.go
+++ b/internal/complianceassessment/assurance_decision.go
@@ -195,7 +195,7 @@ func (s *Service) findRunResult(ctx context.Context, tenantID, runID, resultID, 
 		return ObjectiveResult{}, fmt.Errorf("%w: assessment results do not match completed run", ErrAssessmentConflict)
 	}
 	if found == nil {
-		return ObjectiveResult{}, ErrAssuranceDecisionNotFound
+		return ObjectiveResult{}, fmt.Errorf("%w: assessment result %q was not found", ErrInvalidResult, resultID)
 	}
 	return *found, nil
 }

--- a/internal/complianceassessment/assurance_decision_test.go
+++ b/internal/complianceassessment/assurance_decision_test.go
@@ -1,0 +1,245 @@
+package complianceassessment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+func TestRecordAssuranceDecisionBindsCompletedRunArtifacts(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store, run, result := completedDecisionRun(t, now)
+	log := &runLog{}
+	service := NewAssessmentService(store, log, nil, nil)
+	service.now = func() time.Time { return now.Add(2 * time.Minute) }
+	request := validAssuranceDecisionRequest(run, result, now.Add(time.Minute))
+
+	recorded, created, err := service.RecordAssuranceDecision(context.Background(), request)
+	if err != nil {
+		t.Fatalf("RecordAssuranceDecision() error = %v", err)
+	}
+	if !created || recorded.RunID != run.ID || recorded.ResultID != result.ID || recorded.ObjectiveID != result.ObjectiveID {
+		t.Fatalf("RecordAssuranceDecision() = (%+v, %v), want bound decision", recorded, created)
+	}
+	if !recorded.Decision.Qualified || recorded.Decision.DecisionDigest == "" || recorded.RecordDigest == "" {
+		t.Fatalf("recorded decision is not qualified and content addressed: reasons=%v record=%+v", recorded.Decision.Reasons, recorded)
+	}
+	if err := recorded.Decision.AuthorizeProductionUse(); err != nil {
+		t.Fatalf("AuthorizeProductionUse() error = %v", err)
+	}
+	read, err := service.GetAssuranceDecision(context.Background(), run.TenantID, recorded.ID)
+	if err != nil || read.RecordDigest != recorded.RecordDigest {
+		t.Fatalf("GetAssuranceDecision() = (%+v, %v)", read, err)
+	}
+	if len(log.events) != 1 || log.events[0].GetKind() != workflowevents.EventKindComplianceAssuranceDecisionRecorded {
+		t.Fatalf("appended events = %+v", log.events)
+	}
+
+	replayed, created, err := service.RecordAssuranceDecision(context.Background(), request)
+	if err != nil || created || replayed.ID != recorded.ID || len(log.events) != 1 {
+		t.Fatalf("idempotent RecordAssuranceDecision() = (%+v, %v, %v), events=%d", replayed, created, err, len(log.events))
+	}
+}
+
+func TestRecordAssuranceDecisionRejectsChangedArtifactsAndIdempotencyReuse(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store, run, result := completedDecisionRun(t, now)
+	service := NewAssessmentService(store, &runLog{}, nil, nil)
+	service.now = func() time.Time { return now.Add(2 * time.Minute) }
+	request := validAssuranceDecisionRequest(run, result, now.Add(time.Minute))
+	if _, _, err := service.RecordAssuranceDecision(context.Background(), request); err != nil {
+		t.Fatalf("RecordAssuranceDecision() error = %v", err)
+	}
+
+	request.Input.Result.EvaluatorRevision = "changed-evaluator"
+	if _, _, err := service.RecordAssuranceDecision(context.Background(), request); !errors.Is(err, ports.ErrJobIdempotencyConflict) {
+		t.Fatalf("idempotency reuse error = %v, want conflict", err)
+	}
+	request.IdempotencyKey = "decision-request-2"
+	if _, _, err := service.RecordAssuranceDecision(context.Background(), request); !errors.Is(err, ErrAssessmentConflict) {
+		t.Fatalf("changed result error = %v, want assessment conflict", err)
+	}
+}
+
+func TestRecordAssuranceDecisionRejectsResultProjectionThatDoesNotMatchRun(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store, run, result := completedDecisionRun(t, now)
+	result.EvaluatorRevision = "altered-projection"
+	chunk := store.chunks[runKey(run.TenantID, run.ID)][1]
+	chunk.Results = []ObjectiveResult{result}
+	payload, err := canonicalBytes(chunk.Results)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk.Digest = digestResultChunkPayload("", payload)
+	store.chunks[runKey(run.TenantID, run.ID)][1] = chunk
+	service := NewAssessmentService(store, &runLog{}, nil, nil)
+	service.now = func() time.Time { return now.Add(2 * time.Minute) }
+	_, _, err = service.RecordAssuranceDecision(context.Background(), validAssuranceDecisionRequest(run, result, now.Add(time.Minute)))
+	if !errors.Is(err, ErrAssessmentConflict) {
+		t.Fatalf("RecordAssuranceDecision() error = %v, want run result hash conflict", err)
+	}
+}
+
+func TestProjectEventRebuildsAssuranceDecisionProjection(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store, run, result := completedDecisionRun(t, now)
+	log := &runLog{}
+	service := NewAssessmentService(store, log, nil, nil)
+	service.now = func() time.Time { return now.Add(2 * time.Minute) }
+	recorded, _, err := service.RecordAssuranceDecision(context.Background(), validAssuranceDecisionRequest(run, result, now.Add(time.Minute)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rebuildStore, _, _ := completedDecisionRun(t, now)
+	rebuildService := NewAssessmentService(rebuildStore, &runLog{}, nil, nil)
+	projected, err := rebuildService.ProjectEvent(context.Background(), log.events[0])
+	if err != nil || !projected {
+		t.Fatalf("ProjectEvent() = (%v, %v)", projected, err)
+	}
+	read, err := rebuildService.GetAssuranceDecision(context.Background(), run.TenantID, recorded.ID)
+	if err != nil || read.RecordDigest != recorded.RecordDigest {
+		t.Fatalf("rebuilt decision = (%+v, %v)", read, err)
+	}
+}
+
+func TestProjectEventRejectsAssuranceVerdictChangedAfterQualification(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store, run, result := completedDecisionRun(t, now)
+	log := &runLog{}
+	service := NewAssessmentService(store, log, nil, nil)
+	service.now = func() time.Time { return now.Add(2 * time.Minute) }
+	recorded, _, err := service.RecordAssuranceDecision(context.Background(), validAssuranceDecisionRequest(run, result, now.Add(time.Minute)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorded.Decision.Qualified = false
+	recorded.RecordDigest, err = assuranceDecisionDigest(recorded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(recorded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event, err := workflowevents.NewComplianceAggregateEvent(workflowevents.ComplianceAggregateRecorded{
+		Kind: workflowevents.EventKindComplianceAssuranceDecisionRecorded, TenantID: recorded.TenantID,
+		AggregateType: "assurance_decision", AggregateID: recorded.ID, AggregateVersion: 1,
+		Operation: "assurance_decision_recorded", ContentDigest: recorded.RecordDigest,
+		PayloadJSON: string(payload), ActorID: recorded.RecordedBy, RecordedAt: recorded.RecordedAt.Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rebuildStore, _, _ := completedDecisionRun(t, now)
+	projected, err := NewAssessmentService(rebuildStore, &runLog{}, nil, nil).ProjectEvent(context.Background(), event)
+	if err == nil || projected {
+		t.Fatalf("ProjectEvent() = (%v, %v), want verdict mismatch", projected, err)
+	}
+}
+
+func validAssuranceDecisionRequest(run AssessmentRun, result ObjectiveResult, asOf time.Time) AssuranceDecisionRequest {
+	return AssuranceDecisionRequest{
+		TenantID: run.TenantID, RunID: run.ID, ResultID: result.ID,
+		IdempotencyKey: "decision-request-1", RecordedBy: "assessor-1",
+		Input: QualificationInput{
+			Manifest: *run.InputManifest, Result: result, AsOf: asOf,
+			EvidenceProofs: []EvidenceProof{{
+				EvidenceID: result.EvidenceIDs[0], State: EvidenceSufficient,
+				CollectedAt: asOf.Add(-time.Minute), ValidUntil: asOf.Add(time.Hour),
+			}},
+			Limitations: []Limitation{}, RequiredReviews: []ReviewRequirement{},
+			Verification: VerificationProof{State: VerificationNotRequired},
+		},
+	}
+}
+
+func completedDecisionRun(t *testing.T, now time.Time) (*decisionRunStore, AssessmentRun, ObjectiveResult) {
+	t.Helper()
+	manifest := NormalizeManifest(completeManifest(now))
+	inputHash, err := CanonicalManifestDigest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := NormalizeResult(validResults(now, 1)[0])
+	result.EvidenceIDs = []string{"evidence-1"}
+	resultSetHash, err := CanonicalResultSetDigest([]ObjectiveResult{result})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := AssessmentRun{
+		ID: "assessment-run-00000000000000000000000000000001", TenantID: "tenant-1",
+		ProgramID: manifest.ProgramID, ScopeRevisionID: manifest.ScopeRevisionID, PlanRevisionID: manifest.PlanRevisionID,
+		State: RunComplete, Version: 4, RequestedAt: now.Add(-time.Hour), RequestedBy: "assessor-1",
+		RequestHash: "sha256:request", IdempotencyKey: "run-request-1", InputManifest: &manifest,
+		InputHash: inputHash, AutomatedResultHash: resultSetHash, ResultCount: 1,
+		CollectionBarrierAt: now.Add(-time.Minute), CompletedAt: now,
+	}
+	base := newRunStore()
+	base.runs[runKey(run.TenantID, run.ID)] = run
+	base.byKey[runKey(run.TenantID, run.IdempotencyKey)] = run.ID
+	base.chunks[runKey(run.TenantID, run.ID)] = map[uint32]ResultChunk{1: {
+		RunID: run.ID, Sequence: 1, FirstResultID: result.ID, LastResultID: result.ID,
+		Count: 1, Digest: decisionTestChunkDigest(t, result), Results: []ObjectiveResult{result},
+	}}
+	return &decisionRunStore{runStore: base, decisions: map[string]AssuranceDecision{}, decisionByKey: map[string]string{}}, run, result
+}
+
+func decisionTestChunkDigest(t *testing.T, result ObjectiveResult) string {
+	t.Helper()
+	payload, err := canonicalBytes([]ObjectiveResult{result})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digestResultChunkPayload("", payload)
+}
+
+type decisionRunStore struct {
+	*runStore
+	decisionMu    sync.Mutex
+	decisions     map[string]AssuranceDecision
+	decisionByKey map[string]string
+}
+
+func (s *decisionRunStore) ApplyAssuranceDecision(_ context.Context, eventID string, decision AssuranceDecision) error {
+	s.decisionMu.Lock()
+	defer s.decisionMu.Unlock()
+	key := runKey(decision.TenantID, decision.ID)
+	if existing, ok := s.decisions[key]; ok {
+		if existing.RecordDigest != decision.RecordDigest {
+			return ErrAssessmentConflict
+		}
+		return nil
+	}
+	s.decisions[key] = decision
+	s.decisionByKey[runKey(decision.TenantID, decision.IdempotencyKey)] = decision.ID
+	_ = eventID
+	return nil
+}
+
+func (s *decisionRunStore) GetAssuranceDecision(_ context.Context, tenantID, decisionID string) (AssuranceDecision, error) {
+	s.decisionMu.Lock()
+	defer s.decisionMu.Unlock()
+	decision, ok := s.decisions[runKey(tenantID, decisionID)]
+	if !ok {
+		return AssuranceDecision{}, ErrAssuranceDecisionNotFound
+	}
+	return decision, nil
+}
+
+func (s *decisionRunStore) FindAssuranceDecisionByIdempotency(_ context.Context, tenantID, key string) (AssuranceDecision, error) {
+	s.decisionMu.Lock()
+	defer s.decisionMu.Unlock()
+	id := s.decisionByKey[runKey(tenantID, key)]
+	if id == "" {
+		return AssuranceDecision{}, ErrAssuranceDecisionNotFound
+	}
+	return s.decisions[runKey(tenantID, id)], nil
+}

--- a/internal/complianceassessment/assurance_decision_test.go
+++ b/internal/complianceassessment/assurance_decision_test.go
@@ -87,6 +87,20 @@ func TestRecordAssuranceDecisionRejectsResultProjectionThatDoesNotMatchRun(t *te
 	}
 }
 
+func TestRecordAssuranceDecisionReportsMissingAssessmentResult(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store, run, result := completedDecisionRun(t, now)
+	service := NewAssessmentService(store, &runLog{}, nil, nil)
+	service.now = func() time.Time { return now.Add(2 * time.Minute) }
+	request := validAssuranceDecisionRequest(run, result, now.Add(time.Minute))
+	request.ResultID = "missing-result"
+
+	_, _, err := service.RecordAssuranceDecision(context.Background(), request)
+	if !errors.Is(err, ErrInvalidResult) || errors.Is(err, ErrAssuranceDecisionNotFound) {
+		t.Fatalf("RecordAssuranceDecision() error = %v, want missing assessment result", err)
+	}
+}
+
 func TestProjectEventRebuildsAssuranceDecisionProjection(t *testing.T) {
 	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
 	store, run, result := completedDecisionRun(t, now)

--- a/internal/complianceassessment/recovery.go
+++ b/internal/complianceassessment/recovery.go
@@ -152,6 +152,24 @@ func (s *Service) ProjectEvent(ctx context.Context, event *cerebrov1.EventEnvelo
 			return false, errors.New("assessment result chunk digest does not match envelope")
 		}
 		return true, s.store.ApplyResultChunk(ctx, event.GetId(), record.TenantID, chunk)
+	case workflowevents.EventKindComplianceAssuranceDecisionRecorded:
+		store, ok := s.store.(AssuranceDecisionStore)
+		if !ok {
+			return false, ErrAssuranceDecisionUnavailable
+		}
+		var decision AssuranceDecision
+		if err := json.Unmarshal([]byte(record.PayloadJSON), &decision); err != nil {
+			return false, fmt.Errorf("decode assurance decision event: %w", err)
+		}
+		if strings.TrimSpace(record.AggregateType) != "assurance_decision" ||
+			strings.TrimSpace(record.TenantID) != decision.TenantID || strings.TrimSpace(record.AggregateID) != decision.ID ||
+			record.AggregateVersion != 1 || strings.TrimSpace(record.ContentDigest) != decision.RecordDigest {
+			return false, errors.New("assurance decision envelope does not match payload")
+		}
+		if err := validateAssuranceDecision(decision); err != nil {
+			return false, err
+		}
+		return true, store.ApplyAssuranceDecision(ctx, event.GetId(), decision)
 	default:
 		return false, nil
 	}

--- a/internal/complianceassessment/store.go
+++ b/internal/complianceassessment/store.go
@@ -22,3 +22,12 @@ type NonterminalRunStore interface {
 type Collector interface {
 	Collect(context.Context, AssessmentRun) (InputManifest, []ObjectiveResult, error)
 }
+
+// AssuranceDecisionStore is the durable read projection for immutable
+// evidence-backed decisions. It remains a separate capability so assessment
+// collection stores cannot silently claim decision persistence support.
+type AssuranceDecisionStore interface {
+	ApplyAssuranceDecision(context.Context, string, AssuranceDecision) error
+	GetAssuranceDecision(context.Context, string, string) (AssuranceDecision, error)
+	FindAssuranceDecisionByIdempotency(context.Context, string, string) (AssuranceDecision, error)
+}

--- a/internal/statestore/postgres/compliance_assessment.go
+++ b/internal/statestore/postgres/compliance_assessment.go
@@ -68,6 +68,25 @@ var ensureComplianceAssessmentStatements = []string{
   PRIMARY KEY (tenant_id, run_id, sequence),
   FOREIGN KEY (tenant_id, run_id) REFERENCES compliance_assessment_runs (tenant_id, id)
 )`,
+	`CREATE TABLE IF NOT EXISTS compliance_assurance_decisions (
+  tenant_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  result_id TEXT NOT NULL,
+  objective_id TEXT NOT NULL,
+  decision_digest TEXT NOT NULL,
+  record_digest TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  qualified BOOLEAN NOT NULL,
+  as_of TIMESTAMPTZ NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  record_json JSONB NOT NULL,
+  PRIMARY KEY (tenant_id, id),
+  UNIQUE (tenant_id, idempotency_key),
+  UNIQUE (tenant_id, run_id, result_id, decision_digest),
+  FOREIGN KEY (tenant_id, run_id) REFERENCES compliance_assessment_runs (tenant_id, id)
+)`,
+	`CREATE INDEX IF NOT EXISTS compliance_assurance_decisions_run_idx ON compliance_assurance_decisions (tenant_id, run_id, recorded_at, id)`,
 	`CREATE TABLE IF NOT EXISTS compliance_assessment_event_receipts (
   event_id TEXT PRIMARY KEY,
   tenant_id TEXT NOT NULL,
@@ -87,6 +106,77 @@ ON CONFLICT (tenant_id,run_id,sequence) DO NOTHING`
 
 func (s *Store) ensureComplianceAssessmentTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.grc.complianceAssessment, "compliance_assessment", ensureComplianceAssessmentStatements)
+}
+
+func (s *Store) ApplyAssuranceDecision(ctx context.Context, eventID string, decision complianceassessment.AssuranceDecision) error {
+	if err := s.ensureComplianceAssessmentConfigured(ctx); err != nil {
+		return err
+	}
+	recordJSON, err := json.Marshal(decision)
+	if err != nil {
+		return fmt.Errorf("marshal assurance decision: %w", err)
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("begin assurance decision projection: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	applied, err := assessmentEventApplied(ctx, tx, eventID, decision.RecordDigest)
+	if err != nil || applied {
+		if applied {
+			return tx.Commit()
+		}
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `
+INSERT INTO compliance_assurance_decisions
+  (tenant_id,id,run_id,result_id,objective_id,decision_digest,record_digest,idempotency_key,qualified,as_of,recorded_at,record_json)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)
+ON CONFLICT (tenant_id,id) DO NOTHING`, decision.TenantID, decision.ID, decision.RunID, decision.ResultID,
+		decision.ObjectiveID, decision.Decision.DecisionDigest, decision.RecordDigest, decision.IdempotencyKey,
+		decision.Decision.Qualified, decision.Decision.AsOf.UTC(), decision.RecordedAt.UTC(), string(recordJSON))
+	if err != nil {
+		return fmt.Errorf("project assurance decision: %w", err)
+	}
+	if count, _ := result.RowsAffected(); count == 0 {
+		var existingDigest string
+		if err := tx.QueryRowContext(ctx, `SELECT record_digest FROM compliance_assurance_decisions WHERE tenant_id=$1 AND id=$2`, decision.TenantID, decision.ID).Scan(&existingDigest); err != nil {
+			return fmt.Errorf("read existing assurance decision: %w", err)
+		}
+		if existingDigest != decision.RecordDigest {
+			return complianceassessment.ErrAssessmentConflict
+		}
+	}
+	if err := insertAssessmentReceipt(ctx, tx, eventID, decision.TenantID, "assurance_decision", decision.ID, 1, decision.RecordDigest); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) GetAssuranceDecision(ctx context.Context, tenantID, decisionID string) (complianceassessment.AssuranceDecision, error) {
+	return s.getAssuranceDecision(ctx, `SELECT record_json FROM compliance_assurance_decisions WHERE tenant_id=$1 AND id=$2`, strings.TrimSpace(tenantID), strings.TrimSpace(decisionID))
+}
+
+func (s *Store) FindAssuranceDecisionByIdempotency(ctx context.Context, tenantID, key string) (complianceassessment.AssuranceDecision, error) {
+	return s.getAssuranceDecision(ctx, `SELECT record_json FROM compliance_assurance_decisions WHERE tenant_id=$1 AND idempotency_key=$2`, strings.TrimSpace(tenantID), strings.TrimSpace(key))
+}
+
+func (s *Store) getAssuranceDecision(ctx context.Context, query string, args ...any) (complianceassessment.AssuranceDecision, error) {
+	if err := s.ensureComplianceAssessmentConfigured(ctx); err != nil {
+		return complianceassessment.AssuranceDecision{}, err
+	}
+	var recordJSON []byte
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&recordJSON); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return complianceassessment.AssuranceDecision{}, complianceassessment.ErrAssuranceDecisionNotFound
+		}
+		return complianceassessment.AssuranceDecision{}, fmt.Errorf("get assurance decision: %w", err)
+	}
+	var decision complianceassessment.AssuranceDecision
+	if err := json.Unmarshal(recordJSON, &decision); err != nil {
+		return complianceassessment.AssuranceDecision{}, fmt.Errorf("decode assurance decision: %w", err)
+	}
+	return decision, nil
 }
 
 func (s *Store) ApplyPlan(ctx context.Context, eventID string, plan complianceassessment.AssessmentPlanRevision, expectedVersion uint64) error {

--- a/internal/statestore/postgres/compliance_assessment.go
+++ b/internal/statestore/postgres/compliance_assessment.go
@@ -104,6 +104,23 @@ INSERT INTO compliance_assessment_result_chunks (tenant_id,run_id,sequence,first
 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb)
 ON CONFLICT (tenant_id,run_id,sequence) DO NOTHING`
 
+const insertComplianceAssuranceDecision = `
+INSERT INTO compliance_assurance_decisions
+  (tenant_id,id,run_id,result_id,objective_id,decision_digest,record_digest,idempotency_key,qualified,as_of,recorded_at,record_json)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)
+ON CONFLICT DO NOTHING`
+
+const selectConflictingAssuranceDecisionDigest = `
+SELECT record_digest
+FROM compliance_assurance_decisions
+WHERE tenant_id=$1 AND (
+  id=$2 OR
+  idempotency_key=$3 OR
+  (run_id=$4 AND result_id=$5 AND decision_digest=$6)
+)
+ORDER BY CASE WHEN id=$2 THEN 0 WHEN idempotency_key=$3 THEN 1 ELSE 2 END
+LIMIT 1`
+
 func (s *Store) ensureComplianceAssessmentTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.grc.complianceAssessment, "compliance_assessment", ensureComplianceAssessmentStatements)
 }
@@ -128,11 +145,7 @@ func (s *Store) ApplyAssuranceDecision(ctx context.Context, eventID string, deci
 		}
 		return err
 	}
-	result, err := tx.ExecContext(ctx, `
-INSERT INTO compliance_assurance_decisions
-  (tenant_id,id,run_id,result_id,objective_id,decision_digest,record_digest,idempotency_key,qualified,as_of,recorded_at,record_json)
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)
-ON CONFLICT (tenant_id,id) DO NOTHING`, decision.TenantID, decision.ID, decision.RunID, decision.ResultID,
+	result, err := tx.ExecContext(ctx, insertComplianceAssuranceDecision, decision.TenantID, decision.ID, decision.RunID, decision.ResultID,
 		decision.ObjectiveID, decision.Decision.DecisionDigest, decision.RecordDigest, decision.IdempotencyKey,
 		decision.Decision.Qualified, decision.Decision.AsOf.UTC(), decision.RecordedAt.UTC(), string(recordJSON))
 	if err != nil {
@@ -140,7 +153,11 @@ ON CONFLICT (tenant_id,id) DO NOTHING`, decision.TenantID, decision.ID, decision
 	}
 	if count, _ := result.RowsAffected(); count == 0 {
 		var existingDigest string
-		if err := tx.QueryRowContext(ctx, `SELECT record_digest FROM compliance_assurance_decisions WHERE tenant_id=$1 AND id=$2`, decision.TenantID, decision.ID).Scan(&existingDigest); err != nil {
+		if err := tx.QueryRowContext(ctx, selectConflictingAssuranceDecisionDigest,
+			decision.TenantID, decision.ID, decision.IdempotencyKey, decision.RunID, decision.ResultID, decision.Decision.DecisionDigest,
+		).Scan(&existingDigest); errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("%w: conflicting assurance decision is unavailable", complianceassessment.ErrAssessmentConflict)
+		} else if err != nil {
 			return fmt.Errorf("read existing assurance decision: %w", err)
 		}
 		if existingDigest != decision.RecordDigest {

--- a/internal/statestore/postgres/compliance_assessment_test.go
+++ b/internal/statestore/postgres/compliance_assessment_test.go
@@ -18,6 +18,9 @@ func TestComplianceAssessmentSchemaPinsTenantRevisionAndChunkBoundaries(t *testi
 		"UNIQUE (tenant_id, plan_id, revision_version)",
 		"UNIQUE (tenant_id, idempotency_key)",
 		"PRIMARY KEY (tenant_id, run_id, sequence)",
+		"PRIMARY KEY (tenant_id, id)",
+		"UNIQUE (tenant_id, idempotency_key)",
+		"UNIQUE (tenant_id, run_id, result_id, decision_digest)",
 		"FOREIGN KEY (tenant_id, plan_revision_id)",
 		"payload_digest TEXT NOT NULL",
 	} {

--- a/internal/statestore/postgres/compliance_assessment_test.go
+++ b/internal/statestore/postgres/compliance_assessment_test.go
@@ -38,6 +38,20 @@ func TestComplianceAssessmentChunkProjectionDoesNotRewriteExistingPayload(t *tes
 	}
 }
 
+func TestComplianceAssuranceDecisionProjectionHandlesEveryUniqueIdentity(t *testing.T) {
+	t.Parallel()
+	insert := strings.ToUpper(insertComplianceAssuranceDecision)
+	if strings.Contains(insert, "ON CONFLICT (") || !strings.Contains(insert, "ON CONFLICT DO NOTHING") {
+		t.Fatalf("assurance decision insert must handle every unique constraint: %s", insertComplianceAssuranceDecision)
+	}
+	lookup := strings.ToLower(selectConflictingAssuranceDecisionDigest)
+	for _, identity := range []string{"id=$2", "idempotency_key=$3", "run_id=$4", "result_id=$5", "decision_digest=$6"} {
+		if !strings.Contains(lookup, identity) {
+			t.Fatalf("assurance decision conflict lookup missing %q: %s", identity, selectConflictingAssuranceDecisionDigest)
+		}
+	}
+}
+
 func TestComplianceAssessmentChunkReplayRequiresExactPayload(t *testing.T) {
 	t.Parallel()
 	chunk := complianceassessment.ResultChunk{

--- a/internal/workflowevents/compliance.go
+++ b/internal/workflowevents/compliance.go
@@ -25,6 +25,7 @@ const (
 	EventKindComplianceResultChunkRecorded         = "workflow.v1.compliance.assessment_result_chunk_recorded"
 	EventKindComplianceAssessmentCompleted         = "workflow.v1.compliance.assessment_completed"
 	EventKindComplianceAssessmentCancelled         = "workflow.v1.compliance.assessment_cancelled"
+	EventKindComplianceAssuranceDecisionRecorded   = "workflow.v1.compliance.assessment_assurance_decision_recorded"
 	EventKindComplianceActivityRecorded            = "workflow.v1.compliance.assessment_activity_recorded"
 	EventKindCompliancePopulationRecorded          = "workflow.v1.compliance.assessment_population_recorded"
 	EventKindComplianceSampleRecorded              = "workflow.v1.compliance.assessment_sample_recorded"
@@ -123,7 +124,8 @@ func registeredComplianceKinds() []string {
 		EventKindCompliancePlanPublished, EventKindComplianceAssessmentRequested,
 		EventKindComplianceAssessmentJobBound, EventKindComplianceInputManifestRecorded,
 		EventKindComplianceResultChunkRecorded, EventKindComplianceAssessmentCompleted,
-		EventKindComplianceAssessmentCancelled, EventKindComplianceActivityRecorded,
+		EventKindComplianceAssessmentCancelled, EventKindComplianceAssuranceDecisionRecorded,
+		EventKindComplianceActivityRecorded,
 		EventKindCompliancePopulationRecorded, EventKindComplianceSampleRecorded,
 		EventKindComplianceSourceCheckRecorded,
 		EventKindComplianceReviewRecorded, EventKindComplianceRiskDecisionRecorded,

--- a/internal/workflowevents/compliance_test.go
+++ b/internal/workflowevents/compliance_test.go
@@ -72,6 +72,13 @@ func TestComplianceSourceCheckUsesItsOwnRegisteredFact(t *testing.T) {
 	}
 }
 
+func TestComplianceAssuranceDecisionKindIsRegistered(t *testing.T) {
+	t.Parallel()
+	if !KindRegistered(EventKindComplianceAssuranceDecisionRecorded) {
+		t.Fatalf("assurance decision kind %q is not registered", EventKindComplianceAssuranceDecisionRecorded)
+	}
+}
+
 func TestComplianceAggregateIdentityIncludesAggregateType(t *testing.T) {
 	t.Parallel()
 	base := ComplianceAggregateRecorded{


### PR DESCRIPTION
## Summary
- add an immutable `AssuranceDecision` resource bound to a completed assessment run, its exact input manifest, and one persisted objective result
- append a typed compliance event before projecting the decision into Postgres, with replay-time verdict and digest verification
- reject broken result chunk chains, result-set hash drift, future decision times, and idempotency-key reuse with different proof material
- document durability, rollout, and rollback gates

## Validation
- `make test`
- `go test -p 1 ./internal/complianceassessment ./internal/statestore/postgres ./internal/workflowevents ./internal/compliance -count=1`
- `go test -race ./internal/complianceassessment -run 'Test(RecordAssuranceDecision|ProjectEvent.*Assurance)' -count=1`
- `go vet ./internal/complianceassessment ./internal/statestore/postgres ./internal/workflowevents`
- `make docs-drift-check check-structural-test check-arch`

## Stack
- depends on #1849 for the assessment HTTP and completed-run foundation
- this PR contains the durable domain and projection layer; typed HTTP/OpenAPI resources follow in the next stack layer
