### PR TITLE
Document missing assessment plan response

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2628,6 +2628,8 @@ paths:
                 $ref: '#/components/schemas/AssessmentRunResponse'
         '400':
           description: The period, plan revision, or idempotency key is invalid.
+        '404':
+          description: The assessment plan revision was not found in the tenant.
         '409':
           description: The idempotency key is already bound to another request.
         '503':


### PR DESCRIPTION
## Scope

- document the 404 response from `POST /grc/assessment-runs` when the requested assessment plan revision is not found
- keep runtime behavior and generated TypeScript schema types unchanged

## Compatibility

This aligns the OpenAPI response contract with the existing handler error mapping. It does not change request handling, storage, or execution behavior.

## Validation

- focused assessment route test
- OpenAPI route parity and Spectral lint
- TypeScript OpenAPI generation and drift check
- structural linter, structural linter tests, and architecture tests
- full Droid review and diff whitespace check

## Exact proof

- source parent: `4efba035287f111a34cb49e3fc54ba4fdaf4ad94`
- current main: `bfaee618810763b15f90c0150cbc8c7b3bd91c1d`
- head: `85dda68d1f0fb53097df361a5a077671cf376c3c`
- head tree: `3ab10f51b585c47c755ecb086ac6e68e97c0e513`
- current-main merge tree: `93acfc17711c5d7c8a6d7e22d3dd3e532640270a`
- scope: 1 file, +2/-0
- changed-path SHA-256: `8cc54e4d2a87ba5ba44517ff5c0cff19cf52943353c667a6041378479c85cf82`
