### PR TITLE
Ship assurance decisions and canonical compliance work

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2798,6 +2798,69 @@ paths:
           description: The assessment run is not complete.
         '503':
           description: Assessment result paging is unavailable.
+  /grc/assurance-decisions:
+    post:
+      operationId: recordAssuranceDecision
+      summary: Record assurance decision
+      tags:
+        - GRC
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssuranceDecisionRecordRequest'
+      responses:
+        '200':
+          description: Existing assurance decision returned for the idempotency key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssuranceDecisionRecordResponse'
+        '201':
+          description: Assurance decision recorded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssuranceDecisionRecordResponse'
+        '400':
+          description: Decision time or proof declarations are invalid.
+        '404':
+          description: Assessment run or result was not found in the tenant.
+        '409':
+          description: Assessment artifacts changed or the idempotency key is bound to another request.
+        '503':
+          description: Assurance decision persistence is unavailable.
+  /grc/assurance-decisions/{decisionID}:
+    get:
+      operationId: getAssuranceDecision
+      summary: Get assurance decision
+      tags:
+        - GRC
+      parameters:
+        - name: decisionID
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/tenantIDQuery'
+      responses:
+        '200':
+          description: Immutable assurance decision and decision-time proof snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssuranceDecisionResponse'
+        '404':
+          description: Assurance decision was not found in the tenant.
+        '503':
+          description: Assurance decision persistence is unavailable.
   /grc/dashboards:
     get:
       summary: List custom GRC dashboards
@@ -6918,7 +6981,109 @@ components:
     AssessmentInputManifest:
       type: object
       description: Immutable revisions, receipts, cutoff, and digests used by one assessment run.
-      additionalProperties: true
+      required: [model_version, program_id, scope_revision_id, plan_revision_id, period_start, period_end, collection_cutoff, requested_scope_digest, resolved_objective_set_digest, mapping_set_digest, revisions, receipts, reason_registry, adapter_version]
+      properties:
+        model_version:
+          type: string
+        program_id:
+          type: string
+        scope_revision_id:
+          type: string
+        plan_revision_id:
+          type: string
+        period_start:
+          type: string
+          format: date-time
+        period_end:
+          type: string
+          format: date-time
+        collection_cutoff:
+          type: string
+          format: date-time
+        requested_scope_digest:
+          type: string
+        resolved_objective_set_digest:
+          type: string
+        mapping_set_digest:
+          type: string
+        revisions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssessmentManifestRevision'
+        receipts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssessmentCollectionReceipt'
+        evaluation_run_ids:
+          type: array
+          items:
+            type: string
+        reason_registry:
+          type: string
+        adapter_version:
+          type: string
+    AssessmentManifestRevision:
+      type: object
+      required: [kind, id, revision_id, version, digest]
+      properties:
+        kind:
+          type: string
+        id:
+          type: string
+        revision_id:
+          type: string
+        version:
+          type: integer
+          format: uint64
+        digest:
+          type: string
+    AssessmentCollectionReceipt:
+      type: object
+      required: [kind, query_digest, page_index, raw_count, deduplicated_count, included_count, excluded_count, watermark, cutoff, completeness, page_digest]
+      properties:
+        kind:
+          type: string
+        runtime_id:
+          type: string
+        query_digest:
+          type: string
+        page_index:
+          type: integer
+          format: uint32
+        cursor:
+          type: string
+        next_cursor:
+          type: string
+        raw_count:
+          type: integer
+          format: uint64
+        deduplicated_count:
+          type: integer
+          format: uint64
+        included_count:
+          type: integer
+          format: uint64
+        excluded_count:
+          type: integer
+          format: uint64
+        expected_total:
+          type: integer
+          format: uint64
+        first_key:
+          type: string
+        last_key:
+          type: string
+        watermark:
+          type: string
+          format: date-time
+        cutoff:
+          type: string
+          format: date-time
+        completeness:
+          type: string
+          enum: [complete, partial, truncated, changed_during_scan, unknown]
+        page_digest:
+          type: string
     AssessmentRun:
       type: object
       required: [id, tenant_id, program_id, scope_revision_id, plan_revision_id, state, version, period_start, period_end, requested_at, requested_by]
@@ -7002,8 +7167,7 @@ components:
         results:
           type: array
           items:
-            type: object
-            additionalProperties: true
+            $ref: '#/components/schemas/AssessmentObjectiveResult'
     AssessmentResultPageResponse:
       type: object
       required: [run_id, state, result_count, automated_result_hash, chunks, has_more]
@@ -7026,6 +7190,285 @@ components:
           type: integer
           format: uint32
         has_more:
+          type: boolean
+    AssessmentObjectiveResult:
+      type: object
+      required: [id, control_ref, objective_id, scope_state, automated_outcome, design_state, operating_effectiveness_state, evidence_state, disposition_state, assurance, auditor_state, reason_codes, next_actions, evaluator_revision, evaluated_at]
+      properties:
+        id:
+          type: string
+        control_ref:
+          $ref: '#/components/schemas/AssessmentControlRef'
+        objective_id:
+          type: string
+        scope_state:
+          type: string
+          enum: [in_scope, not_applicable, unresolved]
+        automated_outcome:
+          type: string
+          enum: [satisfied, not_satisfied, indeterminate, not_assessed]
+        design_state:
+          type: string
+          enum: [effective, ineffective, unknown, not_assessed]
+        operating_effectiveness_state:
+          type: string
+          enum: [effective, ineffective, unknown, not_tested]
+        evidence_state:
+          type: string
+          enum: [sufficient, missing, stale, conflicting, untrusted, incomplete, manual_review]
+        disposition_state:
+          type: string
+          enum: [none, accepted_exception, accepted_risk, review_override]
+        assurance:
+          type: string
+          enum: [high, medium, low, none]
+        auditor_state:
+          type: string
+          enum: [not_reviewed, accepted, changes_requested, rejected]
+        reason_codes:
+          type: array
+          items:
+            type: string
+        next_actions:
+          type: array
+          items:
+            type: string
+            enum: [none, review, collect_evidence, refresh_evidence, restore_source, resolve_scope, remediate, retest]
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        source_runtime_ids:
+          type: array
+          items:
+            type: string
+        evaluator_revision:
+          type: string
+        evaluated_at:
+          type: string
+          format: date-time
+    AssuranceSourceProof:
+      type: object
+      required: [runtime_id, state, observed_at, fresh_until]
+      properties:
+        runtime_id:
+          type: string
+        state:
+          type: string
+          enum: [supported, partial, stale, failed, unconfigured, unsupported, unverified, conflicting, unknown]
+        observed_at:
+          type: string
+          format: date-time
+        fresh_until:
+          type: string
+          format: date-time
+    AssuranceEvidenceProof:
+      type: object
+      required: [evidence_id, state, collected_at, valid_until]
+      properties:
+        evidence_id:
+          type: string
+        state:
+          type: string
+          enum: [sufficient, missing, stale, conflicting, untrusted, incomplete, manual_review]
+        collected_at:
+          type: string
+          format: date-time
+        valid_until:
+          type: string
+          format: date-time
+    AssuranceLimitation:
+      type: object
+      required: [code, detail, blocking]
+      properties:
+        code:
+          type: string
+        detail:
+          type: string
+        blocking:
+          type: boolean
+    AssuranceReviewRequirement:
+      type: object
+      required: [kind, required, status]
+      properties:
+        kind:
+          type: string
+        required:
+          type: boolean
+        status:
+          type: string
+          enum: [pending, approved, rejected]
+        completed_at:
+          type: string
+          format: date-time
+        valid_until:
+          type: string
+          format: date-time
+    AssuranceExceptionProof:
+      type: object
+      required: [exception_id, active, valid_until]
+      properties:
+        exception_id:
+          type: string
+        active:
+          type: boolean
+        valid_until:
+          type: string
+          format: date-time
+    AssuranceVerificationProof:
+      type: object
+      required: [required, state]
+      properties:
+        required:
+          type: boolean
+        state:
+          type: string
+          enum: [not_required, pending, passed, failed]
+        verified_at:
+          type: string
+          format: date-time
+        valid_until:
+          type: string
+          format: date-time
+    AssuranceProofInput:
+      type: object
+      required: [as_of, source_proofs, evidence_proofs, limitations, required_reviews, verification]
+      properties:
+        as_of:
+          type: string
+          format: date-time
+        source_proofs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssuranceSourceProof'
+        evidence_proofs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssuranceEvidenceProof'
+        limitations:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssuranceLimitation'
+        required_reviews:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssuranceReviewRequirement'
+        exceptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssuranceExceptionProof'
+        verification:
+          $ref: '#/components/schemas/AssuranceVerificationProof'
+    AssuranceDecisionRecordRequest:
+      allOf:
+        - $ref: '#/components/schemas/AssuranceProofInput'
+        - type: object
+          required: [tenant_id, run_id, result_id]
+          properties:
+            tenant_id:
+              type: string
+            run_id:
+              type: string
+            result_id:
+              type: string
+    AssuranceQualificationInput:
+      allOf:
+        - $ref: '#/components/schemas/AssuranceProofInput'
+        - type: object
+          required: [input_manifest, result]
+          properties:
+            input_manifest:
+              $ref: '#/components/schemas/AssessmentInputManifest'
+            result:
+              $ref: '#/components/schemas/AssessmentObjectiveResult'
+    QualifiedAssuranceDecision:
+      type: object
+      required: [version, qualified, manifest_hash, result_hash, proof_digest, as_of, reasons, limitations, required_reviews, decision_digest]
+      properties:
+        version:
+          type: string
+          enum: [qualified-decision/v1]
+        qualified:
+          type: boolean
+        manifest_hash:
+          type: string
+        result_hash:
+          type: string
+        proof_digest:
+          type: string
+        as_of:
+          type: string
+          format: date-time
+        reasons:
+          type: array
+          items:
+            type: string
+            enum: [manifest_invalid, scope_unpinned, population_incomplete, result_invalid, source_proof_missing, source_unhealthy, source_stale, evidence_proof_missing, evidence_not_current, evidence_conflicting, limitations_not_declared, blocking_limitation, review_requirements_not_declared, review_incomplete, exception_expired, verification_failed]
+        limitations:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssuranceLimitation'
+        required_reviews:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssuranceReviewRequirement'
+        decision_digest:
+          type: string
+    AssuranceDecision:
+      type: object
+      required: [id, tenant_id, run_id, result_id, objective_id, program_id, scope_revision_id, plan_revision_id, version, input_snapshot, decision, request_hash, idempotency_key, recorded_at, recorded_by, record_digest]
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        run_id:
+          type: string
+        result_id:
+          type: string
+        objective_id:
+          type: string
+        program_id:
+          type: string
+        scope_revision_id:
+          type: string
+        plan_revision_id:
+          type: string
+        version:
+          type: string
+          enum: [assurance-decision/v1]
+        input_snapshot:
+          $ref: '#/components/schemas/AssuranceQualificationInput'
+        decision:
+          $ref: '#/components/schemas/QualifiedAssuranceDecision'
+        request_hash:
+          type: string
+        idempotency_key:
+          type: string
+        recorded_at:
+          type: string
+          format: date-time
+        recorded_by:
+          type: string
+        record_digest:
+          type: string
+    AssuranceDecisionResponse:
+      type: object
+      required: [decision]
+      properties:
+        decision:
+          $ref: '#/components/schemas/AssuranceDecision'
+    AssuranceDecisionRecordResponse:
+      type: object
+      required: [decision, created]
+      properties:
+        decision:
+          $ref: '#/components/schemas/AssuranceDecision'
+        created:
           type: boolean
     GRCEvidencePacketsResponse:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6985,7 +6985,7 @@ components:
     AssessmentInputManifest:
       type: object
       description: Immutable revisions, receipts, cutoff, and digests used by one assessment run.
-      required: [model_version, program_id, scope_revision_id, plan_revision_id, period_start, period_end, collection_cutoff, requested_scope_digest, resolved_objective_set_digest, mapping_set_digest, revisions, receipts, reason_registry, adapter_version]
+      additionalProperties: true
       properties:
         model_version:
           type: string
@@ -7171,7 +7171,10 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/AssessmentObjectiveResult'
+            anyOf:
+              - $ref: '#/components/schemas/AssessmentObjectiveResult'
+              - type: object
+                additionalProperties: true
     AssessmentResultPageResponse:
       type: object
       required: [run_id, state, result_count, automated_result_hash, chunks, has_more]
@@ -7391,7 +7394,7 @@ components:
               $ref: '#/components/schemas/AssessmentObjectiveResult'
     QualifiedAssuranceDecision:
       type: object
-      required: [version, qualified, manifest_hash, result_hash, proof_digest, as_of, limitations, required_reviews, decision_digest]
+      required: [version, qualified, as_of, limitations, required_reviews, decision_digest]
       properties:
         version:
           type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2831,6 +2831,8 @@ paths:
                 $ref: '#/components/schemas/AssuranceDecisionRecordResponse'
         '400':
           description: Decision time or proof declarations are invalid.
+        '403':
+          description: The caller cannot record assurance decisions for the tenant.
         '404':
           description: Assessment run or result was not found in the tenant.
         '409':
@@ -2857,6 +2859,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssuranceDecisionResponse'
+        '403':
+          description: The caller cannot read assurance decisions for the tenant.
         '404':
           description: Assurance decision was not found in the tenant.
         '503':
@@ -7387,7 +7391,7 @@ components:
               $ref: '#/components/schemas/AssessmentObjectiveResult'
     QualifiedAssuranceDecision:
       type: object
-      required: [version, qualified, manifest_hash, result_hash, proof_digest, as_of, reasons, limitations, required_reviews, decision_digest]
+      required: [version, qualified, manifest_hash, result_hash, proof_digest, as_of, limitations, required_reviews, decision_digest]
       properties:
         version:
           type: string
@@ -7405,6 +7409,7 @@ components:
           format: date-time
         reasons:
           type: array
+          description: Qualification failures. Omitted when the decision is qualified.
           items:
             type: string
             enum: [manifest_invalid, scope_unpinned, population_incomplete, result_invalid, source_proof_missing, source_unhealthy, source_stale, evidence_proof_missing, evidence_not_current, evidence_conflicting, limitations_not_declared, blocking_limitation, review_requirements_not_declared, review_incomplete, exception_expired, verification_failed]

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3248,6 +3248,45 @@ paths:
         '200':
           description: GRC-friendly finding list.
   /grc/work-items:
+    get:
+      summary: List canonical compliance and security work
+      tags:
+        - GRC
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - name: state
+          in: query
+          schema:
+            $ref: '#/components/schemas/ComplianceWorkItemState'
+        - name: owner_id
+          in: query
+          schema:
+            type: string
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            format: uint32
+            minimum: 1
+            maximum: 200
+            default: 50
+      responses:
+        '200':
+          description: A bounded page from the tenant's canonical work queue.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceWorkItemPage'
+        '400':
+          description: A filter or cursor is invalid.
+        '403':
+          description: The authenticated principal cannot access the tenant.
+        '503':
+          description: The remediation runtime is unavailable.
     post:
       summary: Create work from a failed assessment result
       tags:
@@ -3282,11 +3321,14 @@ paths:
                 automated_result_hash:
                   type: string
                 result:
-                  type: object
-                  additionalProperties: true
+                  $ref: '#/components/schemas/AssessmentObjectiveResult'
       responses:
         '201':
           description: Stable work item with the failed-result occurrence.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceWorkItemRecord'
         '400':
           description: The result is not actionable or the work basis is incomplete.
         '403':
@@ -3308,6 +3350,10 @@ paths:
       responses:
         '200':
           description: Current work item with occurrences and action history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceWorkItemRecord'
         '403':
           description: The authenticated principal cannot access the tenant.
         '404':
@@ -3331,42 +3377,14 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required: [operation, expected_version]
-              properties:
-                operation:
-                  type: string
-                  enum: [action, invalidate]
-                expected_version:
-                  type: integer
-                  format: uint64
-                action:
-                  type: string
-                  enum: [assign, request_evidence, block, snooze, accept, remediate, verify, close, supersede]
-                owner_id:
-                  type: string
-                rationale:
-                  type: string
-                blocker_reason:
-                  type: string
-                snooze_until:
-                  type: string
-                  format: date-time
-                due_at:
-                  type: string
-                  format: date-time
-                evidence_ids:
-                  type: array
-                  items:
-                    type: string
-                trigger:
-                  type: string
-                  enum: [evidence_stale, evidence_revoked, finding_reopened, source_coverage_lost]
-                source_ref:
-                  type: string
+              $ref: '#/components/schemas/ComplianceWorkCommand'
       responses:
         '200':
           description: Updated work item and retained history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceWorkItemRecord'
         '400':
           description: The command violates the work lifecycle or independent verification rule.
         '403':
@@ -7478,6 +7496,232 @@ components:
           $ref: '#/components/schemas/AssuranceDecision'
         created:
           type: boolean
+    ComplianceWorkItemState:
+      type: string
+      enum: [open, in_progress, blocked, resolved, accepted, snoozed, superseded]
+    ComplianceWorkItemKind:
+      type: string
+      enum: [remediate_finding, collect_evidence, refresh_evidence, resolve_conflict, review_manual_evidence, repair_source, assign_owner, map_control, renew_exception, resolve_policy_gap, complete_access_change, answer_audit_request, review_vendor]
+    ComplianceWorkFingerprint:
+      type: object
+      required: [tenant_id, program_id, scope_revision_id, control_id, objective_id, kind, subject_id, reason, source_id]
+      properties:
+        tenant_id:
+          type: string
+        program_id:
+          type: string
+        scope_revision_id:
+          type: string
+        control_id:
+          type: string
+        objective_id:
+          type: string
+        kind:
+          $ref: '#/components/schemas/ComplianceWorkItemKind'
+        subject_id:
+          type: string
+        reason:
+          type: string
+        source_id:
+          type: string
+    ComplianceWorkOccurrence:
+      type: object
+      required: [id, work_item_id, assessment_run_id, objective_result_id, automated_result_hash, occurred_at, occurrence_hash]
+      properties:
+        id:
+          type: string
+        work_item_id:
+          type: string
+        assessment_run_id:
+          type: string
+        objective_result_id:
+          type: string
+        automated_result_hash:
+          type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        occurred_at:
+          type: string
+          format: date-time
+        occurrence_hash:
+          type: string
+    ComplianceWorkVerification:
+      type: object
+      required: [assurance_decision_id, assessment_run_id, objective_result_id, decision_digest, record_digest, evaluated_at, decision_as_of]
+      properties:
+        assurance_decision_id:
+          type: string
+        assessment_run_id:
+          type: string
+        objective_result_id:
+          type: string
+        decision_digest:
+          type: string
+        record_digest:
+          type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        evaluated_at:
+          type: string
+          format: date-time
+        decision_as_of:
+          type: string
+          format: date-time
+    ComplianceWorkItem:
+      type: object
+      required: [id, fingerprint_version, fingerprint, basis, state, owner_id, due_at, priority, verification_required, occurrences, version, updated_at]
+      properties:
+        id:
+          type: string
+        fingerprint_version:
+          type: string
+          enum: [compliance-work-fingerprint/v1]
+        fingerprint:
+          type: string
+        basis:
+          $ref: '#/components/schemas/ComplianceWorkFingerprint'
+        state:
+          $ref: '#/components/schemas/ComplianceWorkItemState'
+        owner_id:
+          type: string
+        due_at:
+          type: string
+          format: date-time
+        priority:
+          type: string
+        blocker_reason:
+          type: string
+        snooze_until:
+          type: string
+          format: date-time
+        risk_id:
+          type: string
+        exception_id:
+          type: string
+        verification_required:
+          type: boolean
+        verification_evidence_ids:
+          type: array
+          items:
+            type: string
+        verified_by:
+          type: string
+        last_remediated_by:
+          type: string
+        last_remediated_at:
+          type: string
+          format: date-time
+        verification:
+          $ref: '#/components/schemas/ComplianceWorkVerification'
+        occurrences:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceWorkOccurrence'
+        last_reopen_trigger:
+          type: string
+          enum: [exception_expired, evidence_stale, evidence_revoked, finding_reopened, source_coverage_lost, scope_subject_added]
+        version:
+          type: integer
+          format: uint64
+        updated_at:
+          type: string
+          format: date-time
+    ComplianceWorkActionRecord:
+      type: object
+      required: [id, work_item_id, action, from, to, owner_id, rationale, actor_id, created_at, action_hash]
+      properties:
+        id:
+          type: string
+        work_item_id:
+          type: string
+        action:
+          type: string
+          enum: [assign, request_evidence, block, snooze, accept, remediate, verify, verify_assurance, close, supersede]
+        from:
+          $ref: '#/components/schemas/ComplianceWorkItemState'
+        to:
+          $ref: '#/components/schemas/ComplianceWorkItemState'
+        owner_id:
+          type: string
+        rationale:
+          type: string
+        actor_id:
+          type: string
+        verification:
+          $ref: '#/components/schemas/ComplianceWorkVerification'
+        created_at:
+          type: string
+          format: date-time
+        action_hash:
+          type: string
+    ComplianceWorkItemRecord:
+      type: object
+      required: [item, occurrences, actions]
+      properties:
+        item:
+          $ref: '#/components/schemas/ComplianceWorkItem'
+        occurrences:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceWorkOccurrence'
+        actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceWorkActionRecord'
+    ComplianceWorkItemPage:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceWorkItem'
+        next_cursor:
+          type: string
+    ComplianceWorkCommand:
+      type: object
+      required: [operation, expected_version]
+      properties:
+        operation:
+          type: string
+          enum: [action, invalidate]
+        expected_version:
+          type: integer
+          format: uint64
+        action:
+          type: string
+          enum: [assign, request_evidence, block, snooze, accept, remediate, verify, verify_assurance, close, supersede]
+        owner_id:
+          type: string
+        rationale:
+          type: string
+        blocker_reason:
+          type: string
+        snooze_until:
+          type: string
+          format: date-time
+        due_at:
+          type: string
+          format: date-time
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        assurance_decision_id:
+          type: string
+        trigger:
+          type: string
+          enum: [exception_expired, evidence_stale, evidence_revoked, finding_reopened, source_coverage_lost, scope_subject_added]
+        source_ref:
+          type: string
     GRCEvidencePacketsResponse:
       type: object
       additionalProperties: true

--- a/docs/engineering/compliance-work-queue-contract.md
+++ b/docs/engineering/compliance-work-queue-contract.md
@@ -1,0 +1,57 @@
+# Compliance work queue contract
+
+## Canonical record
+
+Cerebro owns the canonical compliance and security work item. A work item keeps one stable fingerprint across assessment runs and retains its occurrences and actions in the append log. Postgres serves the current tenant-scoped projection. Companion cases and other clients are adapters over this record; they do not create a second authoritative queue.
+
+The supported HTTP journey is:
+
+1. `GET /grc/work-items` lists a bounded page of current work. Clients can filter by state and owner and continue with the opaque cursor.
+2. `GET /grc/work-items/{workItemID}` returns the current item with immutable occurrence and action history.
+3. `POST /grc/work-items/{workItemID}/commands` records a typed action against an expected version.
+
+Existing create, read, command, remediation-plan, and `verify` behavior remains available. New clients should retain the Cerebro work item ID and version in any local view so commands use optimistic concurrency instead of overwriting newer operator actions.
+
+## Post-change assurance verification
+
+`verify_assurance` resolves verification-required work only when the command references a persisted `AssuranceDecision` that meets every gate below:
+
+- the decision is qualified for production use;
+- the result is satisfied;
+- tenant, program, scope revision, control, objective, and source match the work fingerprint;
+- the result evaluation, decision time, and decision record time are after the most recent remediation action;
+- the verifier is not the owner or the actor who recorded remediation; and
+- the command version matches the current work item version.
+
+The service derives the verification receipt and evidence IDs from the decision. Caller-supplied evidence cannot replace or modify the decision proof. The work projection and immutable action record retain the decision ID, run ID, result ID, decision digest, record digest, evaluation time, and decision time.
+
+An invalidation clears the prior verification receipt and remediation anchor. The work must enter remediation again before another assurance decision can resolve it.
+
+## Companion adapter
+
+A companion security case may retain its own conversation and execution state, but it must use the Cerebro work item ID as its canonical reference. Queue reads come from `/grc/work-items`. State changes go through the typed command endpoint. Case closure follows a successful `verify_assurance` response; local finding reads or local completion receipts cannot close canonical work by themselves.
+
+## Rollout gates
+
+Deploy in dependency order:
+
+1. assurance-decision persistence and projection;
+2. assurance-decision HTTP contracts;
+3. canonical queue listing and `verify_assurance`;
+4. companion case adapter.
+
+Before enabling the adapter, verify:
+
+- append-log replay rebuilds work items and assurance decisions;
+- Postgres returns tenant-scoped list, item, and decision reads;
+- the API principal has security read and finding lifecycle write scopes;
+- stale, mismatched, unqualified, self-verified, and stale-version commands fail before append; and
+- a qualified post-remediation decision resolves exactly one expected work item version.
+
+No table rewrite is required. New verification fields live in the existing JSON work projection and immutable action payloads. Older payloads continue to decode without those fields.
+
+## Rollback
+
+Disable the companion adapter first and stop issuing `verify_assurance`. Existing clients can continue using their current list, read, command, remediation-plan, and `verify` paths. Keep appended events, assurance decisions, verification receipts, and projection columns intact. Do not delete or rewrite proof records during rollback.
+
+If the current projection must be rebuilt, replay assurance decisions before work actions so every retained verification receipt can be resolved to its immutable decision record.

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -117,6 +117,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/grc/assessment-plans", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Prefix: "/grc/assessment-plans/", Suffix: "/publish", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodPost, Exact: "/grc/assessment-runs", Scope: scopeGRCInventoryWrite, Static: true},
+	{Method: http.MethodPost, Exact: "/grc/assurance-decisions", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/dashboards", Scope: scopeDashboardsWrite, Static: true},
 	{Method: http.MethodPatch, Prefix: "/grc/dashboards/", Scope: scopeDashboardsWrite},
 	{Method: http.MethodDelete, Prefix: "/grc/dashboards/", Scope: scopeDashboardsWrite},

--- a/internal/bootstrap/compliance_remediation_handlers.go
+++ b/internal/bootstrap/compliance_remediation_handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -78,6 +79,38 @@ func (a *App) handleGetComplianceWorkItem(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, record)
+}
+
+func (a *App) handleListComplianceWorkItems(w http.ResponseWriter, r *http.Request) {
+	service := a.remediationService()
+	if service == nil {
+		writeComplianceRemediationError(w, complianceremediation.ErrUnavailable)
+		return
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		writeComplianceRemediationError(w, err)
+		return
+	}
+	limit := uint64(50)
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		limit, err = strconv.ParseUint(raw, 10, 32)
+		if err != nil || limit == 0 {
+			writeComplianceRemediationError(w, fmt.Errorf("%w: limit must be a positive integer", complianceremediation.ErrInvalidRequest))
+			return
+		}
+	}
+	page, err := service.ListWorkItems(r.Context(), tenantID, complianceremediation.WorkItemListFilter{
+		State:   complianceassessment.WorkItemState(strings.TrimSpace(r.URL.Query().Get("state"))),
+		OwnerID: r.URL.Query().Get("owner_id"),
+		Cursor:  r.URL.Query().Get("cursor"),
+		Limit:   uint32(limit),
+	})
+	if err != nil {
+		writeComplianceRemediationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
 }
 
 func (a *App) handleComplianceWorkCommand(w http.ResponseWriter, r *http.Request) {

--- a/internal/bootstrap/compliance_remediation_runtime_test.go
+++ b/internal/bootstrap/compliance_remediation_runtime_test.go
@@ -52,6 +52,25 @@ func TestComplianceWorkReadRejectsCrossTenantBeforeStoreLookup(t *testing.T) {
 	}
 }
 
+func TestComplianceWorkListUsesCanonicalTenantAndBoundedFilters(t *testing.T) {
+	state := &bootstrapRemediationState{}
+	log := &bootstrapRemediationLog{}
+	service := complianceremediation.New(state, state, log, log)
+	app := &App{services: appServices{remediation: service}}
+	request := httptest.NewRequest(http.MethodGet, "/grc/work-items?state=open&owner_id=owner-a&limit=25", nil)
+	request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{TenantID: "tenant-a"},
+	}))
+	recorder := httptest.NewRecorder()
+	app.handleListComplianceWorkItems(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if state.workLists != 1 || state.lastTenant != "tenant-a" || state.lastFilter.State != complianceassessment.WorkOpen || state.lastFilter.OwnerID != "owner-a" || state.lastFilter.Limit != 25 {
+		t.Fatalf("list call = count %d tenant %q filter %+v", state.workLists, state.lastTenant, state.lastFilter)
+	}
+}
+
 func TestComplianceRemediationRoutesUseReadAndLifecycleWriteScopes(t *testing.T) {
 	read, err := http.NewRequest(http.MethodGet, "/grc/work-items/work-a", nil)
 	if err != nil {
@@ -75,7 +94,17 @@ func TestComplianceRemediationRoutesUseReadAndLifecycleWriteScopes(t *testing.T)
 }
 
 type bootstrapRemediationState struct {
-	workReads int
+	workReads  int
+	workLists  int
+	lastTenant string
+	lastFilter complianceremediation.WorkItemListFilter
+}
+
+func (s *bootstrapRemediationState) ListWorkItems(_ context.Context, tenantID string, filter complianceremediation.WorkItemListFilter) (complianceremediation.WorkItemPage, error) {
+	s.workLists++
+	s.lastTenant = tenantID
+	s.lastFilter = filter
+	return complianceremediation.WorkItemPage{Items: []complianceassessment.WorkItem{}}, nil
 }
 
 func (s *bootstrapRemediationState) Ping(context.Context) error { return nil }

--- a/internal/bootstrap/grc_assessments_test.go
+++ b/internal/bootstrap/grc_assessments_test.go
@@ -3,12 +3,15 @@ package bootstrap
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -52,6 +55,15 @@ type testAssessmentResultPageResponse struct {
 	Chunks              []complianceassessment.ResultChunk `json:"chunks"`
 	NextSequence        uint32                             `json:"next_sequence"`
 	HasMore             bool                               `json:"has_more"`
+}
+
+type testAssuranceDecisionRecordResponse struct {
+	Decision complianceassessment.AssuranceDecision `json:"decision"`
+	Created  bool                                   `json:"created"`
+}
+
+type testAssuranceDecisionResponse struct {
+	Decision complianceassessment.AssuranceDecision `json:"decision"`
 }
 
 func TestGRCAssessmentPlanRunAndPagedResults(t *testing.T) {
@@ -154,6 +166,113 @@ func TestGRCAssessmentPlanRunAndPagedResults(t *testing.T) {
 	}
 }
 
+func TestGRCAssuranceDecisionRecordAndGet(t *testing.T) {
+	now := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Microsecond)
+	store := newAssessmentHTTPStore()
+	run, result := seedAssessmentHTTPDecisionRun(t, store, now)
+	service := complianceassessment.NewAssessmentService(store, &assessmentHTTPLog{}, nil, nil)
+	app := &App{}
+	app.services.assessments = service
+	mux := http.NewServeMux()
+	app.registerGRCRoutes(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	request := map[string]any{
+		"tenant_id": "tenant-1", "run_id": run.ID, "result_id": result.ID, "as_of": now.Add(time.Minute),
+		"source_proofs": []any{},
+		"evidence_proofs": []complianceassessment.EvidenceProof{{
+			EvidenceID: "evidence-1", State: complianceassessment.EvidenceSufficient,
+			CollectedAt: now, ValidUntil: now.Add(time.Hour),
+		}},
+		"limitations": []any{}, "required_reviews": []any{},
+		"verification": complianceassessment.VerificationProof{State: complianceassessment.VerificationNotRequired},
+	}
+	missingDeclarations := map[string]any{
+		"tenant_id": "tenant-1", "run_id": run.ID, "result_id": result.ID, "as_of": now.Add(time.Minute),
+	}
+	doAssessmentStatus(t, server.Client(), http.MethodPost, server.URL+"/grc/assurance-decisions", missingDeclarations, "decision-missing-declarations", http.StatusBadRequest)
+	recorded := doAssessmentRequest[testAssuranceDecisionRecordResponse](t, server.Client(), http.MethodPost,
+		server.URL+"/grc/assurance-decisions", request, "decision-key-1", http.StatusCreated)
+	if !recorded.Created || recorded.Decision.ID == "" || !recorded.Decision.Decision.Qualified || recorded.Decision.RunID != run.ID {
+		t.Fatalf("recorded decision = %+v", recorded)
+	}
+	replayed := doAssessmentRequest[testAssuranceDecisionRecordResponse](t, server.Client(), http.MethodPost,
+		server.URL+"/grc/assurance-decisions", request, "decision-key-1", http.StatusOK)
+	if replayed.Created || replayed.Decision.ID != recorded.Decision.ID {
+		t.Fatalf("replayed decision = %+v", replayed)
+	}
+	read := doAssessmentRequest[testAssuranceDecisionResponse](t, server.Client(), http.MethodGet,
+		server.URL+"/grc/assurance-decisions/"+recorded.Decision.ID+"?tenant_id=tenant-1", nil, "", http.StatusOK)
+	if read.Decision.RecordDigest != recorded.Decision.RecordDigest || read.Decision.InputSnapshot.Result.ID != result.ID {
+		t.Fatalf("read decision = %+v", read.Decision)
+	}
+	doAssessmentStatus(t, server.Client(), http.MethodGet,
+		server.URL+"/grc/assurance-decisions/"+recorded.Decision.ID+"?tenant_id=tenant-2", nil, "", http.StatusNotFound)
+}
+
+func seedAssessmentHTTPDecisionRun(t *testing.T, store *assessmentHTTPStore, now time.Time) (complianceassessment.AssessmentRun, complianceassessment.ObjectiveResult) {
+	t.Helper()
+	total := uint64(1)
+	digest := "sha256:" + strings.Repeat("a", 64)
+	manifest := complianceassessment.NormalizeManifest(complianceassessment.InputManifest{
+		ProgramID: "program-1", ScopeRevisionID: "scope-revision-1", PlanRevisionID: "plan-revision-1",
+		PeriodStart: now.Add(-24 * time.Hour), PeriodEnd: now, CollectionCutoff: now,
+		RequestedScopeDigest: digest, ResolvedObjectiveSetDigest: digest, MappingSetDigest: digest,
+		Revisions: []complianceassessment.ManifestRevision{{Kind: "plan", ID: "plan-1", RevisionID: "plan-revision-1", Version: 1, Digest: digest}},
+		Receipts:  []complianceassessment.CollectionReceipt{{Kind: "findings", QueryDigest: digest, RawCount: 1, Deduplicated: 1, Included: 1, ExpectedTotal: &total, Watermark: now, Cutoff: now, Completeness: complianceassessment.CollectionComplete, PageDigest: digest}},
+	})
+	result := complianceassessment.NormalizeResult(complianceassessment.ObjectiveResult{
+		ID: "result-1", ControlRef: compliance.ControlRef{FrameworkID: "framework-1", ControlID: "control-1"}, ObjectiveID: "objective-1",
+		ScopeState: complianceassessment.ScopeInScope, AutomatedOutcome: complianceassessment.OutcomeSatisfied,
+		DesignState: complianceassessment.DesignEffective, OperatingEffectivenessState: complianceassessment.OperatingEffective,
+		EvidenceState: complianceassessment.EvidenceSufficient, DispositionState: complianceassessment.DispositionNone,
+		Assurance: complianceassessment.AssuranceHigh, AuditorState: complianceassessment.AuditorNotReviewed,
+		ReasonCodes: []complianceassessment.ReasonCode{complianceassessment.ReasonSatisfied}, NextActions: []complianceassessment.NextAction{complianceassessment.ActionNone},
+		EvidenceIDs: []string{"evidence-1"}, EvaluatorRevision: "evaluator-1", EvaluatedAt: now,
+	})
+	inputHash, err := complianceassessment.CanonicalManifestDigest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultHash, err := complianceassessment.CanonicalResultSetDigest([]complianceassessment.ObjectiveResult{result})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := complianceassessment.AssessmentRun{
+		ID: "assessment-run-00000000000000000000000000000001", TenantID: "tenant-1", ProgramID: manifest.ProgramID,
+		ScopeRevisionID: manifest.ScopeRevisionID, PlanRevisionID: manifest.PlanRevisionID, State: complianceassessment.RunComplete,
+		Version: 4, RequestedAt: now.Add(-time.Hour), RequestedBy: "assessor-1", RequestHash: digest,
+		IdempotencyKey: "run-key-1", InputManifest: &manifest, InputHash: inputHash, AutomatedResultHash: resultHash,
+		ResultCount: 1, CollectionBarrierAt: now.Add(-time.Minute), CompletedAt: now,
+	}
+	payload, err := json.Marshal([]complianceassessment.ObjectiveResult{result})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var canonicalValue any
+	if err := decoder.Decode(&canonicalValue); err != nil {
+		t.Fatal(err)
+	}
+	canonicalPayload, err := json.Marshal(canonicalValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunkHash := sha256.Sum256(append([]byte("\n"), canonicalPayload...))
+	chunk := complianceassessment.ResultChunk{
+		RunID: run.ID, Sequence: 1, FirstResultID: result.ID, LastResultID: result.ID,
+		Count: 1, Digest: "sha256:" + hex.EncodeToString(chunkHash[:]), Results: []complianceassessment.ObjectiveResult{result},
+	}
+	store.mu.Lock()
+	store.runs[assessmentHTTPKey(run.TenantID, run.ID)] = run
+	store.byKey[assessmentHTTPKey(run.TenantID, run.IdempotencyKey)] = run.ID
+	store.chunks[assessmentHTTPKey(run.TenantID, run.ID)] = []complianceassessment.ResultChunk{chunk}
+	store.mu.Unlock()
+	return run, result
+}
+
 func doAssessmentRequest[T any](t *testing.T, client *http.Client, method, url string, body any, idempotencyKey string, wantStatus int) T {
 	t.Helper()
 	var payload []byte
@@ -232,11 +351,13 @@ func (*assessmentHTTPLog) Append(context.Context, *cerebrov1.EventEnvelope) erro
 
 type assessmentHTTPStore struct {
 	*a2ATestJobStore
-	mu     sync.Mutex
-	plans  map[string]complianceassessment.AssessmentPlanRevision
-	runs   map[string]complianceassessment.AssessmentRun
-	byKey  map[string]string
-	chunks map[string][]complianceassessment.ResultChunk
+	mu            sync.Mutex
+	plans         map[string]complianceassessment.AssessmentPlanRevision
+	runs          map[string]complianceassessment.AssessmentRun
+	byKey         map[string]string
+	chunks        map[string][]complianceassessment.ResultChunk
+	decisions     map[string]complianceassessment.AssuranceDecision
+	decisionByKey map[string]string
 }
 
 func newAssessmentHTTPStore() *assessmentHTTPStore {
@@ -246,7 +367,41 @@ func newAssessmentHTTPStore() *assessmentHTTPStore {
 		runs:            map[string]complianceassessment.AssessmentRun{},
 		byKey:           map[string]string{},
 		chunks:          map[string][]complianceassessment.ResultChunk{},
+		decisions:       map[string]complianceassessment.AssuranceDecision{},
+		decisionByKey:   map[string]string{},
 	}
+}
+
+func (s *assessmentHTTPStore) ApplyAssuranceDecision(_ context.Context, _ string, decision complianceassessment.AssuranceDecision) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := assessmentHTTPKey(decision.TenantID, decision.ID)
+	if existing, ok := s.decisions[key]; ok && existing.RecordDigest != decision.RecordDigest {
+		return complianceassessment.ErrAssessmentConflict
+	}
+	s.decisions[key] = decision
+	s.decisionByKey[assessmentHTTPKey(decision.TenantID, decision.IdempotencyKey)] = decision.ID
+	return nil
+}
+
+func (s *assessmentHTTPStore) GetAssuranceDecision(_ context.Context, tenantID, decisionID string) (complianceassessment.AssuranceDecision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	decision, ok := s.decisions[assessmentHTTPKey(tenantID, decisionID)]
+	if !ok {
+		return complianceassessment.AssuranceDecision{}, complianceassessment.ErrAssuranceDecisionNotFound
+	}
+	return decision, nil
+}
+
+func (s *assessmentHTTPStore) FindAssuranceDecisionByIdempotency(_ context.Context, tenantID, key string) (complianceassessment.AssuranceDecision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.decisionByKey[assessmentHTTPKey(tenantID, key)]
+	if id == "" {
+		return complianceassessment.AssuranceDecision{}, complianceassessment.ErrAssuranceDecisionNotFound
+	}
+	return s.decisions[assessmentHTTPKey(tenantID, id)], nil
 }
 
 func assessmentHTTPKey(tenantID, id string) string { return tenantID + "\x00" + id }
@@ -380,6 +535,7 @@ func (*assessmentHTTPStore) ListFindingEvaluationRuns(context.Context, ports.Lis
 
 var _ complianceassessment.Store = (*assessmentHTTPStore)(nil)
 var _ complianceassessment.ResultChunkPageStore = (*assessmentHTTPStore)(nil)
+var _ complianceassessment.AssuranceDecisionStore = (*assessmentHTTPStore)(nil)
 
 func (s *assessmentHTTPStore) String() string {
 	return fmt.Sprintf("assessmentHTTPStore(%d plans, %d runs)", len(s.plans), len(s.runs))

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -182,6 +182,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "DELETE /grc/risk-scoring-config", routeSurfacePlatformHTTP, app.handleDeleteRiskScoringConfig)
 	registerHTTPRoute(mux, "GET /grc/findings", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("findings", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCFindings))
 	registerHTTPRoute(mux, "POST /grc/work-items", routeSurfacePlatformHTTP, app.handleDeriveComplianceWork)
+	registerHTTPRoute(mux, "GET /grc/work-items", routeSurfacePlatformHTTP, app.handleListComplianceWorkItems)
 	registerHTTPRoute(mux, "GET /grc/work-items/{workItemID}", routeSurfacePlatformHTTP, app.handleGetComplianceWorkItem)
 	registerHTTPRoute(mux, "POST /grc/work-items/{workItemID}/commands", routeSurfacePlatformHTTP, app.handleComplianceWorkCommand)
 	registerHTTPRoute(mux, "POST /grc/remediation-plans", routeSurfacePlatformHTTP, app.handleCreateComplianceRemediationPlan)

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -165,6 +165,8 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /grc/assessment-runs", routeSurfacePlatformHTTP, assessments.RequestRun)
 	registerHTTPRoute(mux, "GET /grc/assessment-runs/{runID}", routeSurfacePlatformHTTP, assessments.GetRun)
 	registerHTTPRoute(mux, "GET /grc/assessment-runs/{runID}/results", routeSurfacePlatformHTTP, assessments.ListResults)
+	registerHTTPRoute(mux, "POST /grc/assurance-decisions", routeSurfacePlatformHTTP, assessments.RecordAssuranceDecision)
+	registerHTTPRoute(mux, "GET /grc/assurance-decisions/{decisionID}", routeSurfacePlatformHTTP, assessments.GetAssuranceDecision)
 	registerHTTPRoute(mux, "GET /grc/report-catalog", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("report.catalog", 5*time.Minute), app.handleGRCReportCatalog))
 	registerHTTPRoute(mux, "POST /grc/query", routeSurfacePlatformHTTP, app.handleGRCQuery)
 	registerHTTPRoute(mux, "GET /grc/dashboard", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("dashboard", 30*time.Second, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime, grcCacheScopeGraph), app.handleGRCDashboard))

--- a/internal/complianceassessment/assurance_decision.go
+++ b/internal/complianceassessment/assurance_decision.go
@@ -63,6 +63,41 @@ func (s *Service) RecordAssuranceDecision(ctx context.Context, request Assurance
 	if request.TenantID == "" || request.RunID == "" || request.ResultID == "" || request.IdempotencyKey == "" || request.RecordedBy == "" {
 		return AssuranceDecision{}, false, fmt.Errorf("%w: decision request identity is incomplete", ErrInvalidResult)
 	}
+	run, err := s.store.GetRun(ctx, request.TenantID, request.RunID)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	if run.State != RunComplete || run.InputManifest == nil || run.InputHash == "" || run.AutomatedResultHash == "" || run.CompletedAt.IsZero() {
+		return AssuranceDecision{}, false, fmt.Errorf("%w: assessment run is not complete", ErrAssessmentConflict)
+	}
+	storedManifest := NormalizeManifest(*run.InputManifest)
+	storedManifestHash, err := CanonicalManifestDigest(storedManifest)
+	if err != nil || storedManifestHash != run.InputHash {
+		return AssuranceDecision{}, false, fmt.Errorf("%w: persisted assessment manifest does not match its input hash", ErrAssessmentConflict)
+	}
+	if !qualificationManifestEmpty(request.Input.Manifest) {
+		manifestHash, manifestErr := CanonicalManifestDigest(request.Input.Manifest)
+		if manifestErr != nil || manifestHash != storedManifestHash {
+			return AssuranceDecision{}, false, fmt.Errorf("%w: decision manifest does not match assessment run", ErrAssessmentConflict)
+		}
+	}
+	result, err := s.findRunResult(ctx, request.TenantID, request.RunID, request.ResultID, run.AutomatedResultHash, run.ResultCount)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	wantResultHash, err := CanonicalResultDigest(result)
+	if err != nil {
+		return AssuranceDecision{}, false, err
+	}
+	if !qualificationResultEmpty(request.Input.Result) {
+		requestResultHash, resultErr := CanonicalResultDigest(request.Input.Result)
+		if resultErr != nil || requestResultHash != wantResultHash {
+			return AssuranceDecision{}, false, fmt.Errorf("%w: decision result does not match assessment result", ErrAssessmentConflict)
+		}
+	}
+	request.Input.Manifest = storedManifest
+	request.Input.Result = result
+	request = normalizeAssuranceDecisionRequest(request)
 	requestHash, err := semanticHash(request)
 	if err != nil {
 		return AssuranceDecision{}, false, err
@@ -74,34 +109,6 @@ func (s *Service) RecordAssuranceDecision(ctx context.Context, request Assurance
 		return existing, false, nil
 	} else if !errors.Is(findErr, ErrAssuranceDecisionNotFound) {
 		return AssuranceDecision{}, false, findErr
-	}
-
-	run, err := s.store.GetRun(ctx, request.TenantID, request.RunID)
-	if err != nil {
-		return AssuranceDecision{}, false, err
-	}
-	if run.State != RunComplete || run.InputManifest == nil || run.InputHash == "" || run.AutomatedResultHash == "" || run.CompletedAt.IsZero() {
-		return AssuranceDecision{}, false, fmt.Errorf("%w: assessment run is not complete", ErrAssessmentConflict)
-	}
-	manifestHash, err := CanonicalManifestDigest(request.Input.Manifest)
-	if err != nil || manifestHash != run.InputHash {
-		return AssuranceDecision{}, false, fmt.Errorf("%w: decision manifest does not match assessment run", ErrAssessmentConflict)
-	}
-	storedManifestHash, err := CanonicalManifestDigest(*run.InputManifest)
-	if err != nil || storedManifestHash != manifestHash {
-		return AssuranceDecision{}, false, fmt.Errorf("%w: persisted assessment manifest does not match its input hash", ErrAssessmentConflict)
-	}
-	result, err := s.findRunResult(ctx, request.TenantID, request.RunID, request.ResultID, run.AutomatedResultHash, run.ResultCount)
-	if err != nil {
-		return AssuranceDecision{}, false, err
-	}
-	wantResultHash, err := CanonicalResultDigest(result)
-	if err != nil {
-		return AssuranceDecision{}, false, err
-	}
-	requestResultHash, err := CanonicalResultDigest(request.Input.Result)
-	if err != nil || requestResultHash != wantResultHash {
-		return AssuranceDecision{}, false, fmt.Errorf("%w: decision result does not match assessment result", ErrAssessmentConflict)
 	}
 	recordedAt := CanonicalTime(s.now())
 	if request.Input.AsOf.Before(run.CompletedAt) || request.Input.AsOf.After(recordedAt) {
@@ -201,6 +208,8 @@ func (s *Service) findRunResult(ctx context.Context, tenantID, runID, resultID, 
 }
 
 func normalizeAssuranceDecisionRequest(request AssuranceDecisionRequest) AssuranceDecisionRequest {
+	sourceProofsDeclared := request.Input.SourceProofs != nil
+	evidenceProofsDeclared := request.Input.EvidenceProofs != nil
 	limitationsDeclared := request.Input.Limitations != nil
 	reviewsDeclared := request.Input.RequiredReviews != nil
 	request.TenantID = strings.TrimSpace(request.TenantID)
@@ -208,13 +217,17 @@ func normalizeAssuranceDecisionRequest(request AssuranceDecisionRequest) Assuran
 	request.ResultID = strings.TrimSpace(request.ResultID)
 	request.IdempotencyKey = strings.TrimSpace(request.IdempotencyKey)
 	request.RecordedBy = strings.TrimSpace(request.RecordedBy)
-	request.Input.Manifest = NormalizeManifest(request.Input.Manifest)
-	request.Input.Result = NormalizeResult(request.Input.Result)
 	request.Input.AsOf = CanonicalTime(request.Input.AsOf)
 	request.Input.SourceProofs = normalizeSourceProofs(request.Input.SourceProofs)
 	request.Input.EvidenceProofs = normalizeEvidenceProofs(request.Input.EvidenceProofs)
 	request.Input.Limitations = normalizeLimitations(request.Input.Limitations)
 	request.Input.RequiredReviews = normalizeReviews(request.Input.RequiredReviews)
+	if sourceProofsDeclared && request.Input.SourceProofs == nil {
+		request.Input.SourceProofs = []SourceProof{}
+	}
+	if evidenceProofsDeclared && request.Input.EvidenceProofs == nil {
+		request.Input.EvidenceProofs = []EvidenceProof{}
+	}
 	if limitationsDeclared && request.Input.Limitations == nil {
 		request.Input.Limitations = []Limitation{}
 	}
@@ -225,6 +238,16 @@ func normalizeAssuranceDecisionRequest(request AssuranceDecisionRequest) Assuran
 	request.Input.Verification.VerifiedAt = CanonicalTime(request.Input.Verification.VerifiedAt)
 	request.Input.Verification.ValidUntil = CanonicalTime(request.Input.Verification.ValidUntil)
 	return request
+}
+
+func qualificationManifestEmpty(value InputManifest) bool {
+	return strings.TrimSpace(value.ProgramID) == "" && strings.TrimSpace(value.ScopeRevisionID) == "" &&
+		strings.TrimSpace(value.PlanRevisionID) == "" && strings.TrimSpace(value.RequestedScopeDigest) == "" &&
+		len(value.Revisions) == 0 && len(value.Receipts) == 0
+}
+
+func qualificationResultEmpty(value ObjectiveResult) bool {
+	return strings.TrimSpace(value.ID) == "" && strings.TrimSpace(value.ObjectiveID) == ""
 }
 
 func assuranceDecisionDigest(record AssuranceDecision) (string, error) {

--- a/internal/complianceassessment/assurance_decision_test.go
+++ b/internal/complianceassessment/assurance_decision_test.go
@@ -47,6 +47,23 @@ func TestRecordAssuranceDecisionBindsCompletedRunArtifacts(t *testing.T) {
 	}
 }
 
+func TestRecordAssuranceDecisionLoadsRunArtifactsWhenRequestCarriesOnlyProofs(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store, run, result := completedDecisionRun(t, now)
+	service := NewAssessmentService(store, &runLog{}, nil, nil)
+	service.now = func() time.Time { return now.Add(2 * time.Minute) }
+	request := validAssuranceDecisionRequest(run, result, now.Add(time.Minute))
+	request.Input.Manifest = InputManifest{}
+	request.Input.Result = ObjectiveResult{}
+	recorded, created, err := service.RecordAssuranceDecision(context.Background(), request)
+	if err != nil || !created {
+		t.Fatalf("RecordAssuranceDecision() = (%+v, %v, %v)", recorded, created, err)
+	}
+	if recorded.InputSnapshot.Manifest.ProgramID != run.ProgramID || recorded.InputSnapshot.Result.ID != result.ID || !recorded.Decision.Qualified {
+		t.Fatalf("decision did not load persisted run artifacts: %+v", recorded)
+	}
+}
+
 func TestRecordAssuranceDecisionRejectsChangedArtifactsAndIdempotencyReuse(t *testing.T) {
 	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
 	store, run, result := completedDecisionRun(t, now)
@@ -57,11 +74,12 @@ func TestRecordAssuranceDecisionRejectsChangedArtifactsAndIdempotencyReuse(t *te
 		t.Fatalf("RecordAssuranceDecision() error = %v", err)
 	}
 
-	request.Input.Result.EvaluatorRevision = "changed-evaluator"
+	request.Input.EvidenceProofs[0].ValidUntil = request.Input.EvidenceProofs[0].ValidUntil.Add(time.Hour)
 	if _, _, err := service.RecordAssuranceDecision(context.Background(), request); !errors.Is(err, ports.ErrJobIdempotencyConflict) {
 		t.Fatalf("idempotency reuse error = %v, want conflict", err)
 	}
 	request.IdempotencyKey = "decision-request-2"
+	request.Input.Result.EvaluatorRevision = "changed-evaluator"
 	if _, _, err := service.RecordAssuranceDecision(context.Background(), request); !errors.Is(err, ErrAssessmentConflict) {
 		t.Fatalf("changed result error = %v, want assessment conflict", err)
 	}

--- a/internal/complianceassessment/reviews_phase7_test.go
+++ b/internal/complianceassessment/reviews_phase7_test.go
@@ -108,7 +108,8 @@ func TestWorkFingerprintOccurrencesAndReopenTriggers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReopenWorkItem(%s) error = %v", trigger, err)
 		}
-		if reopened.State != WorkOpen || reopened.OwnerID != "owner-b" || record.Trigger != trigger || record.RecordHash == "" {
+		if reopened.State != WorkOpen || reopened.OwnerID != "owner-b" || record.Trigger != trigger || record.RecordHash == "" ||
+			reopened.LastRemediatedBy != "" || !reopened.LastRemediatedAt.IsZero() {
 			t.Fatalf("ReopenWorkItem(%s) = %+v / %+v", trigger, reopened, record)
 		}
 	}
@@ -140,6 +141,57 @@ func TestVerificationRequiredWorkCannotBeSelfClosed(t *testing.T) {
 	resolved, _, err := ApplyWorkAction(inProgress, inProgress.Version, WorkActionInput{Action: WorkActionVerify, Rationale: "Verify the change.", EvidenceIDs: []string{"evidence-a"}, ActorID: "reviewer-a", At: now.Add(2 * time.Hour)})
 	if err != nil || resolved.State != WorkResolved || resolved.VerifiedBy != "reviewer-a" {
 		t.Fatalf("ApplyWorkAction(independent verify) = %+v, %v", resolved, err)
+	}
+}
+
+func TestAssuranceVerificationRecordsImmutableReceipt(t *testing.T) {
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	item, _, err := NewWorkItem(WorkItemInput{
+		Basis: WorkFingerprintInput{
+			TenantID: "tenant-a", ProgramID: "program-a", ScopeRevisionID: "scope-r1", ControlID: "CC-1",
+			ObjectiveID: "objective-a", Kind: WorkRemediateFinding, SubjectID: "subject-a", Reason: ReasonActiveFinding, SourceID: "source-a",
+		},
+		OwnerID: "owner-a", DueAt: now.Add(24 * time.Hour), Priority: "high", VerificationRequired: true,
+		Occurrence: WorkOccurrenceInput{AssessmentRunID: "run-a", ObjectiveResultID: "result-a", AutomatedResultHash: "sha256:" + strings.Repeat("e", 64), OccurredAt: now},
+	})
+	if err != nil {
+		t.Fatalf("NewWorkItem() error = %v", err)
+	}
+	inProgress, _, err := ApplyWorkAction(item, item.Version, WorkActionInput{
+		Action: WorkActionRemediate, Rationale: "Apply the control change.", ActorID: "owner-a", At: now.Add(time.Hour),
+	})
+	if err != nil || !inProgress.LastRemediatedAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("ApplyWorkAction(remediate) = %+v, %v", inProgress, err)
+	}
+	receipt := &WorkVerification{
+		AssuranceDecisionID: "assurance-decision-a", AssessmentRunID: "run-b", ObjectiveResultID: "result-b",
+		DecisionDigest: "sha256:" + strings.Repeat("a", 64), RecordDigest: "sha256:" + strings.Repeat("b", 64),
+		EvidenceIDs: []string{"evidence-b"}, EvaluatedAt: now.Add(2 * time.Hour), DecisionAsOf: now.Add(3 * time.Hour),
+	}
+	resolved, action, err := ApplyWorkAction(inProgress, inProgress.Version, WorkActionInput{
+		Action: WorkActionVerifyAssurance, Rationale: "Verify the post-change assessment.", Verification: receipt,
+		ActorID: "reviewer-a", At: now.Add(4 * time.Hour),
+	})
+	if err != nil || resolved.State != WorkResolved || resolved.Verification == nil || action.Verification == nil {
+		t.Fatalf("ApplyWorkAction(verify assurance) = %+v / %+v, %v", resolved, action, err)
+	}
+	receipt.EvidenceIDs[0] = "mutated"
+	if resolved.Verification.EvidenceIDs[0] != "evidence-b" || action.Verification.EvidenceIDs[0] != "evidence-b" {
+		t.Fatalf("verification receipt aliases caller input: %+v / %+v", resolved.Verification, action.Verification)
+	}
+}
+
+func TestAssuranceVerificationRequiresReceiptForAllWork(t *testing.T) {
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	current := WorkItem{
+		ID: "work-a", State: WorkInProgress, OwnerID: "owner-a", Version: 1,
+	}
+	_, _, err := ApplyWorkAction(current, current.Version, WorkActionInput{
+		Action: WorkActionVerifyAssurance, Rationale: "Verify the assessment result.",
+		ActorID: "reviewer-a", At: now,
+	})
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("ApplyWorkAction(verify assurance without receipt) error = %v, want ErrInvalidTransition", err)
 	}
 }
 

--- a/internal/complianceassessment/work_items.go
+++ b/internal/complianceassessment/work_items.go
@@ -57,6 +57,7 @@ const (
 	WorkActionAccept          WorkAction = "accept"
 	WorkActionRemediate       WorkAction = "remediate"
 	WorkActionVerify          WorkAction = "verify"
+	WorkActionVerifyAssurance WorkAction = "verify_assurance"
 	WorkActionClose           WorkAction = "close"
 	WorkActionSupersede       WorkAction = "supersede"
 )
@@ -127,10 +128,27 @@ type WorkItem struct {
 	VerificationEvidenceIDs []string             `json:"verification_evidence_ids,omitempty"`
 	VerifiedBy              string               `json:"verified_by,omitempty"`
 	LastRemediatedBy        string               `json:"last_remediated_by,omitempty"`
+	LastRemediatedAt        time.Time            `json:"last_remediated_at,omitempty"`
+	Verification            *WorkVerification    `json:"verification,omitempty"`
 	Occurrences             []WorkOccurrence     `json:"occurrences"`
 	LastReopenTrigger       WorkReopenTrigger    `json:"last_reopen_trigger,omitempty"`
 	Version                 uint64               `json:"version"`
 	UpdatedAt               time.Time            `json:"updated_at"`
+}
+
+// WorkVerification binds resolution to a qualified post-remediation assurance
+// decision. The referenced decision remains the immutable proof record; this
+// receipt carries the exact identity and digests needed to verify the link
+// without copying the decision snapshot into the work projection.
+type WorkVerification struct {
+	AssuranceDecisionID string    `json:"assurance_decision_id"`
+	AssessmentRunID     string    `json:"assessment_run_id"`
+	ObjectiveResultID   string    `json:"objective_result_id"`
+	DecisionDigest      string    `json:"decision_digest"`
+	RecordDigest        string    `json:"record_digest"`
+	EvidenceIDs         []string  `json:"evidence_ids,omitempty"`
+	EvaluatedAt         time.Time `json:"evaluated_at"`
+	DecisionAsOf        time.Time `json:"decision_as_of"`
 }
 
 // WorkItemInput creates one item and its first occurrence.
@@ -153,22 +171,24 @@ type WorkActionInput struct {
 	BlockerReason string
 	SnoozeUntil   time.Time
 	EvidenceIDs   []string
+	Verification  *WorkVerification
 	ActorID       string
 	At            time.Time
 }
 
 // WorkActionRecord is an immutable action record emitted with a work transition.
 type WorkActionRecord struct {
-	ID         string        `json:"id"`
-	WorkItemID string        `json:"work_item_id"`
-	Action     WorkAction    `json:"action"`
-	From       WorkItemState `json:"from"`
-	To         WorkItemState `json:"to"`
-	OwnerID    string        `json:"owner_id"`
-	Rationale  string        `json:"rationale"`
-	ActorID    string        `json:"actor_id"`
-	CreatedAt  time.Time     `json:"created_at"`
-	ActionHash string        `json:"action_hash"`
+	ID           string            `json:"id"`
+	WorkItemID   string            `json:"work_item_id"`
+	Action       WorkAction        `json:"action"`
+	From         WorkItemState     `json:"from"`
+	To           WorkItemState     `json:"to"`
+	OwnerID      string            `json:"owner_id"`
+	Rationale    string            `json:"rationale"`
+	ActorID      string            `json:"actor_id"`
+	Verification *WorkVerification `json:"verification,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+	ActionHash   string            `json:"action_hash"`
 }
 
 // WorkReopenRecord is the immutable reason a terminal item became active again.
@@ -285,24 +305,37 @@ func ApplyWorkAction(current WorkItem, expectedVersion uint64, input WorkActionI
 	}
 	if input.Action == WorkActionRemediate {
 		next.LastRemediatedBy = actorID
+		next.LastRemediatedAt = at
 		next.VerificationEvidenceIDs = nil
 		next.VerifiedBy = ""
+		next.Verification = nil
 	}
 	if input.Action == WorkActionVerify {
 		next.VerificationEvidenceIDs = normalizedStrings(input.EvidenceIDs)
 		next.VerifiedBy = actorID
 	}
+	if input.Action == WorkActionVerifyAssurance {
+		verification := cloneWorkVerification(input.Verification)
+		next.VerificationEvidenceIDs = append([]string(nil), verification.EvidenceIDs...)
+		next.VerifiedBy = actorID
+		next.Verification = verification
+	}
 	next.Version++
 	next.UpdatedAt = at
+	var verification *WorkVerification
+	if input.Action == WorkActionVerifyAssurance {
+		verification = cloneWorkVerification(input.Verification)
+	}
 	record := WorkActionRecord{
-		WorkItemID: current.ID,
-		Action:     input.Action,
-		From:       current.State,
-		To:         next.State,
-		OwnerID:    next.OwnerID,
-		Rationale:  rationale,
-		ActorID:    actorID,
-		CreatedAt:  at,
+		WorkItemID:   current.ID,
+		Action:       input.Action,
+		From:         current.State,
+		To:           next.State,
+		OwnerID:      next.OwnerID,
+		Rationale:    rationale,
+		ActorID:      actorID,
+		Verification: verification,
+		CreatedAt:    at,
 	}
 	hash, err := hashDomainValue(record)
 	if err != nil {
@@ -337,6 +370,9 @@ func ReopenWorkItem(current WorkItem, expectedVersion uint64, trigger WorkReopen
 	next.SnoozeUntil = time.Time{}
 	next.VerificationEvidenceIDs = nil
 	next.VerifiedBy = ""
+	next.Verification = nil
+	next.LastRemediatedBy = ""
+	next.LastRemediatedAt = time.Time{}
 	next.LastReopenTrigger = trigger
 	next.Version++
 	next.UpdatedAt = at
@@ -413,12 +449,17 @@ func workActionTarget(current WorkItem, input WorkActionInput, at time.Time) (Wo
 			return "", fmt.Errorf("%w: terminal work cannot enter remediation", ErrInvalidTransition)
 		}
 		return WorkInProgress, nil
-	case WorkActionVerify:
+	case WorkActionVerify, WorkActionVerifyAssurance:
 		if current.State != WorkInProgress && current.State != WorkBlocked {
 			return "", fmt.Errorf("%w: only active work can resolve", ErrInvalidTransition)
 		}
+		if input.Action == WorkActionVerifyAssurance {
+			if err := validateWorkVerification(input.Verification); err != nil {
+				return "", err
+			}
+		}
 		if current.VerificationRequired {
-			if len(normalizedStrings(input.EvidenceIDs)) == 0 {
+			if input.Action == WorkActionVerify && len(normalizedStrings(input.EvidenceIDs)) == 0 {
 				return "", fmt.Errorf("%w: verification evidence is required", ErrInvalidTransition)
 			}
 			actorID := strings.TrimSpace(input.ActorID)
@@ -458,12 +499,31 @@ func normalizeWorkFingerprintInput(input WorkFingerprintInput) WorkFingerprintIn
 
 func cloneWorkItem(value WorkItem) WorkItem {
 	value.VerificationEvidenceIDs = append([]string(nil), value.VerificationEvidenceIDs...)
+	value.Verification = cloneWorkVerification(value.Verification)
 	value.Occurrences = append([]WorkOccurrence(nil), value.Occurrences...)
 	for index := range value.Occurrences {
 		value.Occurrences[index].EvidenceIDs = append([]string(nil), value.Occurrences[index].EvidenceIDs...)
 		value.Occurrences[index].FindingIDs = append([]string(nil), value.Occurrences[index].FindingIDs...)
 	}
 	return value
+}
+
+func cloneWorkVerification(value *WorkVerification) *WorkVerification {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	cloned.EvidenceIDs = append([]string(nil), value.EvidenceIDs...)
+	return &cloned
+}
+
+func validateWorkVerification(value *WorkVerification) error {
+	if value == nil || strings.TrimSpace(value.AssuranceDecisionID) == "" || strings.TrimSpace(value.AssessmentRunID) == "" ||
+		strings.TrimSpace(value.ObjectiveResultID) == "" || !validDigestString(strings.TrimSpace(value.DecisionDigest)) ||
+		!validDigestString(strings.TrimSpace(value.RecordDigest)) || CanonicalTime(value.EvaluatedAt).IsZero() || CanonicalTime(value.DecisionAsOf).IsZero() {
+		return fmt.Errorf("%w: assurance verification receipt is incomplete", ErrInvalidTransition)
+	}
+	return nil
 }
 
 func validWorkKind(value WorkItemKind) bool {

--- a/internal/complianceremediation/service.go
+++ b/internal/complianceremediation/service.go
@@ -37,6 +37,30 @@ type WorkItemRecord struct {
 	Actions     []complianceassessment.WorkActionRecord `json:"actions"`
 }
 
+// WorkItemListFilter selects one bounded page from the canonical work queue.
+type WorkItemListFilter struct {
+	State   complianceassessment.WorkItemState
+	OwnerID string
+	Cursor  string
+	Limit   uint32
+}
+
+// WorkItemPage is a keyset-paginated canonical work queue page.
+type WorkItemPage struct {
+	Items      []complianceassessment.WorkItem `json:"items"`
+	NextCursor string                          `json:"next_cursor,omitempty"`
+}
+
+// WorkItemLister is optional so existing Store implementations retain their
+// read/write contract while durable stores can expose the shared queue.
+type WorkItemLister interface {
+	ListWorkItems(context.Context, string, WorkItemListFilter) (WorkItemPage, error)
+}
+
+type assuranceDecisionReader interface {
+	GetAssuranceDecision(context.Context, string, string) (complianceassessment.AssuranceDecision, error)
+}
+
 // Store is the tenant-scoped current-state read boundary.
 type Store interface {
 	GetWorkItem(context.Context, string, string) (WorkItemRecord, error)
@@ -128,21 +152,45 @@ func (s *Service) GetWorkItem(ctx context.Context, tenantID, workItemID string) 
 	return s.store.GetWorkItem(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(workItemID))
 }
 
+// ListWorkItems reads one bounded tenant-scoped page from the canonical queue.
+func (s *Service) ListWorkItems(ctx context.Context, tenantID string, filter WorkItemListFilter) (WorkItemPage, error) {
+	if err := s.ready(); err != nil {
+		return WorkItemPage{}, err
+	}
+	lister, ok := s.store.(WorkItemLister)
+	if !ok {
+		return WorkItemPage{}, ErrUnavailable
+	}
+	filter.OwnerID = strings.TrimSpace(filter.OwnerID)
+	filter.Cursor = strings.TrimSpace(filter.Cursor)
+	if filter.State != "" && !validWorkItemStateFilter(filter.State) {
+		return WorkItemPage{}, fmt.Errorf("%w: unknown work item state %q", ErrInvalidRequest, filter.State)
+	}
+	if filter.Limit == 0 {
+		filter.Limit = 50
+	}
+	if filter.Limit > 200 {
+		return WorkItemPage{}, fmt.Errorf("%w: limit must not exceed 200", ErrInvalidRequest)
+	}
+	return lister.ListWorkItems(ctx, strings.TrimSpace(tenantID), filter)
+}
+
 // WorkCommand applies an explicit operating action or invalidation.
 type WorkCommand struct {
-	Operation       string                                 `json:"operation"`
-	ExpectedVersion uint64                                 `json:"expected_version"`
-	Action          complianceassessment.WorkAction        `json:"action,omitempty"`
-	OwnerID         string                                 `json:"owner_id,omitempty"`
-	Rationale       string                                 `json:"rationale,omitempty"`
-	BlockerReason   string                                 `json:"blocker_reason,omitempty"`
-	SnoozeUntil     time.Time                              `json:"snooze_until,omitempty"`
-	EvidenceIDs     []string                               `json:"evidence_ids,omitempty"`
-	Trigger         complianceassessment.WorkReopenTrigger `json:"trigger,omitempty"`
-	SourceRef       string                                 `json:"source_ref,omitempty"`
-	DueAt           time.Time                              `json:"due_at,omitempty"`
-	ActorID         string                                 `json:"actor_id"`
-	At              time.Time                              `json:"at"`
+	Operation           string                                 `json:"operation"`
+	ExpectedVersion     uint64                                 `json:"expected_version"`
+	Action              complianceassessment.WorkAction        `json:"action,omitempty"`
+	OwnerID             string                                 `json:"owner_id,omitempty"`
+	Rationale           string                                 `json:"rationale,omitempty"`
+	BlockerReason       string                                 `json:"blocker_reason,omitempty"`
+	SnoozeUntil         time.Time                              `json:"snooze_until,omitempty"`
+	EvidenceIDs         []string                               `json:"evidence_ids,omitempty"`
+	AssuranceDecisionID string                                 `json:"assurance_decision_id,omitempty"`
+	Trigger             complianceassessment.WorkReopenTrigger `json:"trigger,omitempty"`
+	SourceRef           string                                 `json:"source_ref,omitempty"`
+	DueAt               time.Time                              `json:"due_at,omitempty"`
+	ActorID             string                                 `json:"actor_id"`
+	At                  time.Time                              `json:"at"`
 }
 
 // ApplyWorkCommand records a state transition without executing an external action.
@@ -159,10 +207,22 @@ func (s *Service) ApplyWorkCommand(ctx context.Context, tenantID, workItemID str
 	}
 	switch strings.TrimSpace(command.Operation) {
 	case "action":
+		var verification *complianceassessment.WorkVerification
+		if command.Action == complianceassessment.WorkActionVerifyAssurance {
+			if record.Item.Version != command.ExpectedVersion {
+				return WorkItemRecord{}, fmt.Errorf("%w: expected %d, current %d", complianceassessment.ErrVersionConflict, command.ExpectedVersion, record.Item.Version)
+			}
+			verification, err = s.verifyWorkAssurance(ctx, strings.TrimSpace(tenantID), record.Item, command)
+			if err != nil {
+				return WorkItemRecord{}, err
+			}
+		} else if strings.TrimSpace(command.AssuranceDecisionID) != "" {
+			return WorkItemRecord{}, fmt.Errorf("%w: assurance_decision_id requires verify_assurance", ErrInvalidRequest)
+		}
 		next, action, err := complianceassessment.ApplyWorkAction(record.Item, command.ExpectedVersion, complianceassessment.WorkActionInput{
 			Action: command.Action, OwnerID: command.OwnerID, Rationale: command.Rationale,
 			BlockerReason: command.BlockerReason, SnoozeUntil: command.SnoozeUntil,
-			EvidenceIDs: command.EvidenceIDs, ActorID: command.ActorID, At: command.At,
+			EvidenceIDs: command.EvidenceIDs, Verification: verification, ActorID: command.ActorID, At: command.At,
 		})
 		if err != nil {
 			return WorkItemRecord{}, err
@@ -195,6 +255,75 @@ func (s *Service) ApplyWorkCommand(ctx context.Context, tenantID, workItemID str
 		return WorkItemRecord{}, fmt.Errorf("%w: operation must be action or invalidate", ErrInvalidRequest)
 	}
 	return s.store.GetWorkItem(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(workItemID))
+}
+
+func (s *Service) verifyWorkAssurance(ctx context.Context, tenantID string, item complianceassessment.WorkItem, command WorkCommand) (*complianceassessment.WorkVerification, error) {
+	decisionID := strings.TrimSpace(command.AssuranceDecisionID)
+	reader, ok := s.store.(assuranceDecisionReader)
+	if !ok {
+		return nil, ErrUnavailable
+	}
+	if decisionID == "" {
+		return nil, fmt.Errorf("%w: assurance_decision_id is required", ErrInvalidRequest)
+	}
+	decision, err := reader.GetAssuranceDecision(ctx, tenantID, decisionID)
+	if errors.Is(err, complianceassessment.ErrAssuranceDecisionNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := decision.Decision.AuthorizeProductionUse(); err != nil {
+		return nil, fmt.Errorf("%w: assurance decision is not qualified", ErrInvalidRequest)
+	}
+	result := complianceassessment.NormalizeResult(decision.InputSnapshot.Result)
+	remediatedAt := complianceassessment.CanonicalTime(item.LastRemediatedAt)
+	decisionAsOf := complianceassessment.CanonicalTime(decision.Decision.AsOf)
+	evaluatedAt := complianceassessment.CanonicalTime(result.EvaluatedAt)
+	if remediatedAt.IsZero() || !evaluatedAt.After(remediatedAt) || !decisionAsOf.After(remediatedAt) || !decision.RecordedAt.After(remediatedAt) {
+		return nil, fmt.Errorf("%w: assurance decision must be recorded from a post-remediation assessment", ErrInvalidRequest)
+	}
+	if decision.ProgramID != item.Basis.ProgramID || decision.ScopeRevisionID != item.Basis.ScopeRevisionID ||
+		decision.ObjectiveID != item.Basis.ObjectiveID || result.ControlRef.ControlID != item.Basis.ControlID {
+		return nil, fmt.Errorf("%w: assurance decision does not match the work basis", ErrInvalidRequest)
+	}
+	if result.AutomatedOutcome != complianceassessment.OutcomeSatisfied {
+		return nil, fmt.Errorf("%w: assurance decision result is not satisfied", ErrInvalidRequest)
+	}
+	if !containsString(result.SourceRuntimeIDs, item.Basis.SourceID) {
+		return nil, fmt.Errorf("%w: assurance decision does not cover the work source", ErrInvalidRequest)
+	}
+	return &complianceassessment.WorkVerification{
+		AssuranceDecisionID: decision.ID,
+		AssessmentRunID:     decision.RunID,
+		ObjectiveResultID:   decision.ResultID,
+		DecisionDigest:      decision.Decision.DecisionDigest,
+		RecordDigest:        decision.RecordDigest,
+		EvidenceIDs:         append([]string(nil), result.EvidenceIDs...),
+		EvaluatedAt:         evaluatedAt,
+		DecisionAsOf:        decisionAsOf,
+	}, nil
+}
+
+func containsString(values []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func validWorkItemStateFilter(state complianceassessment.WorkItemState) bool {
+	switch state {
+	case complianceassessment.WorkOpen, complianceassessment.WorkInProgress, complianceassessment.WorkBlocked,
+		complianceassessment.WorkResolved, complianceassessment.WorkAccepted, complianceassessment.WorkSnoozed,
+		complianceassessment.WorkSuperseded:
+		return true
+	default:
+		return false
+	}
 }
 
 // CreateRemediationPlan creates an owned plan with mandatory independent verification.

--- a/internal/complianceremediation/service_test.go
+++ b/internal/complianceremediation/service_test.go
@@ -104,6 +104,75 @@ func TestFailedResultWorkReplaysOldestFirstAndReopensAfterInvalidation(t *testin
 	}
 }
 
+func TestVerifyAssuranceRequiresQualifiedPostRemediationDecision(t *testing.T) {
+	now := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+	runtime := newMemoryRuntime()
+	service := New(runtime, runtime, runtime, runtime)
+	record, err := service.DeriveWork(context.Background(), failedResultInput(now), "assessor-a")
+	if err != nil {
+		t.Fatalf("DeriveWork() error = %v", err)
+	}
+	record, err = service.ApplyWorkCommand(context.Background(), "tenant-a", record.Item.ID, WorkCommand{
+		Operation: "action", ExpectedVersion: record.Item.Version, Action: complianceassessment.WorkActionRemediate,
+		Rationale: "Apply the control change.", ActorID: "owner-a", At: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ApplyWorkCommand(remediate) error = %v", err)
+	}
+	decision := qualifiedWorkDecision(now.Add(2*time.Hour), now.Add(3*time.Hour), now.Add(4*time.Hour))
+	runtime.decisions["tenant-a\x00"+decision.ID] = decision
+	record, err = service.ApplyWorkCommand(context.Background(), "tenant-a", record.Item.ID, WorkCommand{
+		Operation: "action", ExpectedVersion: record.Item.Version, Action: complianceassessment.WorkActionVerifyAssurance,
+		AssuranceDecisionID: decision.ID, EvidenceIDs: []string{"caller-supplied"},
+		Rationale: "Verify the post-change assessment.", ActorID: "reviewer-a", At: now.Add(5 * time.Hour),
+	})
+	if err != nil || record.Item.State != complianceassessment.WorkResolved || record.Item.Verification == nil {
+		t.Fatalf("ApplyWorkCommand(verify assurance) = %+v, %v", record.Item, err)
+	}
+	if got := record.Item.Verification.EvidenceIDs; len(got) != 1 || got[0] != "evidence-fresh" {
+		t.Fatalf("verification evidence = %v, want decision evidence", got)
+	}
+
+	secondRuntime := newMemoryRuntime()
+	secondService := New(secondRuntime, secondRuntime, secondRuntime, secondRuntime)
+	stale, err := secondService.DeriveWork(context.Background(), failedResultInput(now), "assessor-a")
+	if err != nil {
+		t.Fatalf("DeriveWork(stale) error = %v", err)
+	}
+	stale, err = secondService.ApplyWorkCommand(context.Background(), "tenant-a", stale.Item.ID, WorkCommand{
+		Operation: "action", ExpectedVersion: stale.Item.Version, Action: complianceassessment.WorkActionRemediate,
+		Rationale: "Apply the control change.", ActorID: "owner-a", At: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ApplyWorkCommand(remediate stale) error = %v", err)
+	}
+	staleDecision := qualifiedWorkDecision(now, now.Add(3*time.Hour), now.Add(4*time.Hour))
+	secondRuntime.decisions["tenant-a\x00"+staleDecision.ID] = staleDecision
+	before := len(secondRuntime.events)
+	_, err = secondService.ApplyWorkCommand(context.Background(), "tenant-a", stale.Item.ID, WorkCommand{
+		Operation: "action", ExpectedVersion: stale.Item.Version, Action: complianceassessment.WorkActionVerifyAssurance,
+		AssuranceDecisionID: staleDecision.ID, Rationale: "Verify stale assessment.", ActorID: "reviewer-a", At: now.Add(5 * time.Hour),
+	})
+	if !errors.Is(err, ErrInvalidRequest) || len(secondRuntime.events) != before {
+		t.Fatalf("stale verification error/events = %v/%d, want rejection before append", err, len(secondRuntime.events))
+	}
+}
+
+func qualifiedWorkDecision(evaluatedAt, asOf, recordedAt time.Time) complianceassessment.AssuranceDecision {
+	digest := "sha256:" + strings.Repeat("b", 64)
+	return complianceassessment.AssuranceDecision{
+		ID: "assurance-decision-fresh", TenantID: "tenant-a", RunID: "run-fresh", ResultID: "result-fresh",
+		ObjectiveID: "objective-a", ProgramID: "program-a", ScopeRevisionID: "scope-a",
+		InputSnapshot: complianceassessment.QualificationInput{Result: complianceassessment.ObjectiveResult{
+			ID: "result-fresh", ControlRef: compliance.ControlRef{FrameworkID: "framework-a", ControlID: "control-a"},
+			ObjectiveID: "objective-a", AutomatedOutcome: complianceassessment.OutcomeSatisfied,
+			EvidenceIDs: []string{"evidence-fresh"}, SourceRuntimeIDs: []string{"runtime-a"}, EvaluatedAt: evaluatedAt,
+		}},
+		Decision:   complianceassessment.QualifiedDecision{Qualified: true, ProofDigest: digest, DecisionDigest: digest, AsOf: asOf},
+		RecordedAt: recordedAt, RecordDigest: digest,
+	}
+}
+
 func TestAppendSuccessProjectionFailureRecoversWork(t *testing.T) {
 	now := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
 	runtime := newMemoryRuntime()
@@ -210,11 +279,12 @@ type memoryRuntime struct {
 	work           map[string]WorkItemRecord
 	plans          map[string]complianceassessment.RemediationPlan
 	receipts       map[string]struct{}
+	decisions      map[string]complianceassessment.AssuranceDecision
 	failProjection bool
 }
 
 func newMemoryRuntime() *memoryRuntime {
-	return &memoryRuntime{work: map[string]WorkItemRecord{}, plans: map[string]complianceassessment.RemediationPlan{}, receipts: map[string]struct{}{}}
+	return &memoryRuntime{work: map[string]WorkItemRecord{}, plans: map[string]complianceassessment.RemediationPlan{}, receipts: map[string]struct{}{}, decisions: map[string]complianceassessment.AssuranceDecision{}}
 }
 
 func (m *memoryRuntime) Ping(context.Context) error { return nil }
@@ -274,6 +344,14 @@ func (m *memoryRuntime) GetRemediationPlan(_ context.Context, tenantID, planID s
 		return complianceassessment.RemediationPlan{}, ErrNotFound
 	}
 	return plan, nil
+}
+
+func (m *memoryRuntime) GetAssuranceDecision(_ context.Context, tenantID, decisionID string) (complianceassessment.AssuranceDecision, error) {
+	decision, ok := m.decisions[tenantID+"\x00"+decisionID]
+	if !ok {
+		return complianceassessment.AssuranceDecision{}, complianceassessment.ErrAssuranceDecisionNotFound
+	}
+	return decision, nil
 }
 
 func (m *memoryRuntime) ProjectWorkOccurrence(_ context.Context, metadata ProjectionMetadata, item complianceassessment.WorkItem, occurrence complianceassessment.WorkOccurrence) error {

--- a/internal/sourcehttp/complianceassessment/handler.go
+++ b/internal/sourcehttp/complianceassessment/handler.go
@@ -90,6 +90,28 @@ type assessmentResultPageResponse struct {
 	HasMore             bool                               `json:"has_more"`
 }
 
+type recordAssuranceDecisionRequest struct {
+	TenantID        string                                   `json:"tenant_id"`
+	RunID           string                                   `json:"run_id"`
+	ResultID        string                                   `json:"result_id"`
+	AsOf            time.Time                                `json:"as_of"`
+	SourceProofs    []complianceassessment.SourceProof       `json:"source_proofs"`
+	EvidenceProofs  []complianceassessment.EvidenceProof     `json:"evidence_proofs"`
+	Limitations     []complianceassessment.Limitation        `json:"limitations"`
+	RequiredReviews []complianceassessment.ReviewRequirement `json:"required_reviews"`
+	Exceptions      []complianceassessment.ExceptionProof    `json:"exceptions,omitempty"`
+	Verification    *complianceassessment.VerificationProof  `json:"verification"`
+}
+
+type assuranceDecisionResponse struct {
+	Decision complianceassessment.AssuranceDecision `json:"decision"`
+}
+
+type recordAssuranceDecisionResponse struct {
+	Decision complianceassessment.AssuranceDecision `json:"decision"`
+	Created  bool                                   `json:"created"`
+}
+
 func (h *Handler) CreatePlan(w http.ResponseWriter, r *http.Request) {
 	service := h.service
 	if service == nil {
@@ -289,6 +311,70 @@ func (h *Handler) ListResults(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *Handler) RecordAssuranceDecision(w http.ResponseWriter, r *http.Request) {
+	service := h.service
+	if service == nil {
+		h.writeError(w, complianceassessment.ErrAssuranceDecisionUnavailable)
+		return
+	}
+	var request recordAssuranceDecisionRequest
+	if err := h.decodeJSON(w, r, &request); err != nil {
+		h.writeError(w, err)
+		return
+	}
+	if request.SourceProofs == nil || request.EvidenceProofs == nil || request.Limitations == nil || request.RequiredReviews == nil || request.Verification == nil {
+		h.writeError(w, fmt.Errorf("%w: proof arrays and verification are required", complianceassessment.ErrInvalidResult))
+		return
+	}
+	tenantID, err := h.resolveTenant(r.Context(), request.TenantID)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+	if idempotencyKey == "" {
+		h.writeError(w, fmt.Errorf("%w: Idempotency-Key header is required", complianceassessment.ErrInvalidResult))
+		return
+	}
+	decision, created, err := service.RecordAssuranceDecision(r.Context(), complianceassessment.AssuranceDecisionRequest{
+		TenantID: tenantID, RunID: request.RunID, ResultID: request.ResultID,
+		IdempotencyKey: idempotencyKey, RecordedBy: h.actorID(r.Context()),
+		Input: complianceassessment.QualificationInput{
+			AsOf: request.AsOf, SourceProofs: request.SourceProofs, EvidenceProofs: request.EvidenceProofs,
+			Limitations: request.Limitations, RequiredReviews: request.RequiredReviews,
+			Exceptions: request.Exceptions, Verification: *request.Verification,
+		},
+	})
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	status := http.StatusCreated
+	if !created {
+		status = http.StatusOK
+	}
+	writeJSON(w, status, recordAssuranceDecisionResponse{Decision: decision, Created: created})
+}
+
+func (h *Handler) GetAssuranceDecision(w http.ResponseWriter, r *http.Request) {
+	service := h.service
+	if service == nil {
+		h.writeError(w, complianceassessment.ErrAssuranceDecisionUnavailable)
+		return
+	}
+	tenantID, err := h.resolveTenant(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	decision, err := service.GetAssuranceDecision(r.Context(), tenantID, r.PathValue("decisionID"))
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, assuranceDecisionResponse{Decision: decision})
+}
+
 func validateExecutablePlan(plan complianceassessment.AssessmentPlanRevision) error {
 	for _, task := range plan.Execution.Tasks {
 		if task.Kind != complianceassessment.PlanTaskKindFindingEvaluation {
@@ -345,11 +431,11 @@ func (h *Handler) writeError(w http.ResponseWriter, err error) {
 	switch {
 	case h.isForbidden != nil && h.isForbidden(err):
 		status = http.StatusForbidden
-	case errors.Is(err, complianceassessment.ErrPlanNotFound), errors.Is(err, complianceassessment.ErrRunNotFound):
+	case errors.Is(err, complianceassessment.ErrPlanNotFound), errors.Is(err, complianceassessment.ErrRunNotFound), errors.Is(err, complianceassessment.ErrAssuranceDecisionNotFound):
 		status = http.StatusNotFound
 	case errors.Is(err, complianceassessment.ErrAssessmentConflict), errors.Is(err, ports.ErrJobIdempotencyConflict):
 		status = http.StatusConflict
-	case errors.Is(err, complianceassessment.ErrResultPagingUnavailable):
+	case errors.Is(err, complianceassessment.ErrResultPagingUnavailable), errors.Is(err, complianceassessment.ErrAssuranceDecisionUnavailable):
 		status = http.StatusServiceUnavailable
 	case errors.Is(err, complianceassessment.ErrInvalidResult), errors.Is(err, complianceassessment.ErrInvalidManifest), errors.Is(err, complianceassessment.ErrIncompleteInput):
 		status = http.StatusBadRequest

--- a/internal/statestore/postgres/compliance_review_projection_test.go
+++ b/internal/statestore/postgres/compliance_review_projection_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/complianceassessment"
+	"github.com/writer/cerebro/internal/complianceremediation"
 	"github.com/writer/cerebro/internal/config"
 )
 
@@ -203,6 +204,10 @@ func TestComplianceReviewProjectionPostgresIntegration(t *testing.T) {
 	storedWork, err := store.GetComplianceWorkItem(ctx, tenantID, item.ID)
 	if err != nil || storedWork.Item.Version != 2 || len(storedWork.Occurrences) != 1 || len(storedWork.Actions) != 1 {
 		t.Fatalf("GetComplianceWorkItem() = %+v, %v", storedWork, err)
+	}
+	page, err := store.ListWorkItems(ctx, tenantID, complianceremediation.WorkItemListFilter{State: complianceassessment.WorkInProgress, OwnerID: "owner-a", Limit: 1})
+	if err != nil || len(page.Items) != 1 || page.Items[0].ID != item.ID || page.NextCursor != "" {
+		t.Fatalf("ListWorkItems() = %+v, %v", page, err)
 	}
 
 	plan, err := complianceassessment.NewRemediationPlan(complianceassessment.RemediationPlanInput{

--- a/internal/statestore/postgres/compliance_work_queue.go
+++ b/internal/statestore/postgres/compliance_work_queue.go
@@ -1,0 +1,134 @@
+package postgres
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/complianceassessment"
+	"github.com/writer/cerebro/internal/complianceremediation"
+)
+
+type complianceWorkItemCursor struct {
+	UpdatedAt time.Time `json:"updated_at"`
+	ID        string    `json:"id"`
+}
+
+// ListWorkItems exposes a bounded tenant-scoped page from the Postgres work
+// projection. The cursor is opaque to callers and uses projection update time
+// plus stable item identity for deterministic keyset pagination.
+func (s *Store) ListWorkItems(ctx context.Context, tenantID string, filter complianceremediation.WorkItemListFilter) (complianceremediation.WorkItemPage, error) {
+	if err := s.ensureComplianceReviewTables(ctx); err != nil {
+		return complianceremediation.WorkItemPage{}, err
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return complianceremediation.WorkItemPage{}, fmt.Errorf("%w: tenant_id is required", complianceremediation.ErrInvalidRequest)
+	}
+	limit := filter.Limit
+	if limit == 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		return complianceremediation.WorkItemPage{}, fmt.Errorf("%w: limit must be at most 200", complianceremediation.ErrInvalidRequest)
+	}
+	state := string(filter.State)
+	ownerID := strings.TrimSpace(filter.OwnerID)
+	var cursorUpdatedAt any
+	cursorID := ""
+	if cursorValue := strings.TrimSpace(filter.Cursor); cursorValue != "" {
+		cursor, err := decodeComplianceWorkItemCursor(cursorValue)
+		if err != nil {
+			return complianceremediation.WorkItemPage{}, err
+		}
+		cursorUpdatedAt = cursor.UpdatedAt.UTC()
+		cursorID = cursor.ID
+	}
+	const query = `
+SELECT id, updated_at, body_json
+FROM compliance_work_items
+WHERE tenant_id = $1
+  AND ($2 = '' OR body_json->>'state' = $2)
+  AND ($3 = '' OR body_json->>'owner_id' = $3)
+  AND ($4::timestamptz IS NULL OR (updated_at < $4 OR (updated_at = $4 AND id > $5)))
+ORDER BY updated_at DESC, id ASC
+LIMIT $6`
+	rows, err := s.db.QueryContext(ctx, query, tenantID, state, ownerID, cursorUpdatedAt, cursorID, int64(limit)+1)
+	if err != nil {
+		return complianceremediation.WorkItemPage{}, fmt.Errorf("list compliance work items: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	type rowValue struct {
+		id        string
+		updatedAt time.Time
+		item      complianceassessment.WorkItem
+	}
+	values := []rowValue{}
+	for rows.Next() {
+		var value rowValue
+		var body []byte
+		if err := rows.Scan(&value.id, &value.updatedAt, &body); err != nil {
+			return complianceremediation.WorkItemPage{}, fmt.Errorf("scan compliance work item: %w", err)
+		}
+		if err := json.Unmarshal(body, &value.item); err != nil {
+			return complianceremediation.WorkItemPage{}, fmt.Errorf("decode compliance work item: %w", err)
+		}
+		values = append(values, value)
+	}
+	if err := rows.Err(); err != nil {
+		return complianceremediation.WorkItemPage{}, fmt.Errorf("iterate compliance work items: %w", err)
+	}
+	page := complianceremediation.WorkItemPage{Items: []complianceassessment.WorkItem{}}
+	var lastIncluded rowValue
+	var included uint32
+	for _, value := range values {
+		if included == limit {
+			break
+		}
+		page.Items = append(page.Items, value.item)
+		lastIncluded = value
+		included++
+	}
+	if len(values) > len(page.Items) && len(page.Items) != 0 {
+		page.NextCursor, err = encodeComplianceWorkItemCursor(complianceWorkItemCursor{UpdatedAt: lastIncluded.updatedAt, ID: lastIncluded.id})
+		if err != nil {
+			return complianceremediation.WorkItemPage{}, err
+		}
+	}
+	return page, nil
+}
+
+func encodeComplianceWorkItemCursor(cursor complianceWorkItemCursor) (string, error) {
+	cursor.ID = strings.TrimSpace(cursor.ID)
+	cursor.UpdatedAt = cursor.UpdatedAt.UTC()
+	if cursor.ID == "" || cursor.UpdatedAt.IsZero() {
+		return "", fmt.Errorf("%w: work item cursor is incomplete", complianceremediation.ErrInvalidRequest)
+	}
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("encode compliance work item cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func decodeComplianceWorkItemCursor(value string) (complianceWorkItemCursor, error) {
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		return complianceWorkItemCursor{}, fmt.Errorf("%w: work item cursor is malformed", complianceremediation.ErrInvalidRequest)
+	}
+	var cursor complianceWorkItemCursor
+	if err := json.Unmarshal(payload, &cursor); err != nil {
+		return complianceWorkItemCursor{}, fmt.Errorf("%w: work item cursor is malformed", complianceremediation.ErrInvalidRequest)
+	}
+	cursor.ID = strings.TrimSpace(cursor.ID)
+	cursor.UpdatedAt = cursor.UpdatedAt.UTC()
+	if cursor.ID == "" || cursor.UpdatedAt.IsZero() {
+		return complianceWorkItemCursor{}, fmt.Errorf("%w: work item cursor is incomplete", complianceremediation.ErrInvalidRequest)
+	}
+	return cursor, nil
+}
+
+var _ complianceremediation.WorkItemLister = (*Store)(nil)

--- a/internal/statestore/postgres/compliance_work_queue_test.go
+++ b/internal/statestore/postgres/compliance_work_queue_test.go
@@ -1,0 +1,26 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/complianceremediation"
+)
+
+func TestComplianceWorkItemCursorRoundTripAndMalformedInput(t *testing.T) {
+	want := complianceWorkItemCursor{UpdatedAt: time.Date(2026, 7, 15, 12, 0, 0, 123, time.UTC), ID: "work-a"}
+	encoded, err := encodeComplianceWorkItemCursor(want)
+	if err != nil {
+		t.Fatalf("encodeComplianceWorkItemCursor() error = %v", err)
+	}
+	got, err := decodeComplianceWorkItemCursor(encoded)
+	if err != nil || got.ID != want.ID || !got.UpdatedAt.Equal(want.UpdatedAt) {
+		t.Fatalf("decodeComplianceWorkItemCursor() = %+v, %v; want %+v", got, err, want)
+	}
+	for _, value := range []string{"not-base64", "e30"} {
+		if _, err := decodeComplianceWorkItemCursor(value); !errors.Is(err, complianceremediation.ErrInvalidRequest) {
+			t.Fatalf("decodeComplianceWorkItemCursor(%q) error = %v, want ErrInvalidRequest", value, err)
+		}
+	}
+}

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -4041,7 +4041,7 @@ export type QualifiedAssuranceDecision = {
   manifest_hash: string;
   proof_digest: string;
   qualified: boolean;
-  reasons: ("manifest_invalid" | "scope_unpinned" | "population_incomplete" | "result_invalid" | "source_proof_missing" | "source_unhealthy" | "source_stale" | "evidence_proof_missing" | "evidence_not_current" | "evidence_conflicting" | "limitations_not_declared" | "blocking_limitation" | "review_requirements_not_declared" | "review_incomplete" | "exception_expired" | "verification_failed")[];
+  reasons?: ("manifest_invalid" | "scope_unpinned" | "population_incomplete" | "result_invalid" | "source_proof_missing" | "source_unhealthy" | "source_stale" | "evidence_proof_missing" | "evidence_not_current" | "evidence_conflicting" | "limitations_not_declared" | "blocking_limitation" | "review_requirements_not_declared" | "review_incomplete" | "exception_expired" | "verification_failed")[];
   required_reviews: AssuranceReviewRequirement[];
   result_hash: string;
   version: "qualified-decision/v1";

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -460,7 +460,7 @@ export type AgentPlatformGraphReasonProvenance = {
 };
 
 export type AgentPlatformGraphReasonRequest = {
-  history?: { content?: string; role?: "user" | "assistant" }[];
+  history?: ({ content?: string; role?: "user" | "assistant" })[];
   model?: string;
   question: string;
   scope_urn?: string;
@@ -701,6 +701,26 @@ export type AppendPolicyEvaluationDatasetRevisionRequest = {
   [key: string]: unknown;
 };
 
+export type AssessmentCollectionReceipt = {
+  completeness: "complete" | "partial" | "truncated" | "changed_during_scan" | "unknown";
+  cursor?: string;
+  cutoff: string;
+  deduplicated_count: number;
+  excluded_count: number;
+  expected_total?: number;
+  first_key?: string;
+  included_count: number;
+  kind: string;
+  last_key?: string;
+  next_cursor?: string;
+  page_digest: string;
+  page_index: number;
+  query_digest: string;
+  raw_count: number;
+  runtime_id?: string;
+  watermark: string;
+};
+
 export type AssessmentControlRef = {
   control_id: string;
   framework?: string;
@@ -709,7 +729,52 @@ export type AssessmentControlRef = {
 };
 
 /** Immutable revisions, receipts, cutoff, and digests used by one assessment run. */
-export type AssessmentInputManifest = Record<string, unknown>;
+export type AssessmentInputManifest = {
+  adapter_version: string;
+  collection_cutoff: string;
+  evaluation_run_ids?: string[];
+  mapping_set_digest: string;
+  model_version: string;
+  period_end: string;
+  period_start: string;
+  plan_revision_id: string;
+  program_id: string;
+  reason_registry: string;
+  receipts: AssessmentCollectionReceipt[];
+  requested_scope_digest: string;
+  resolved_objective_set_digest: string;
+  revisions: AssessmentManifestRevision[];
+  scope_revision_id: string;
+};
+
+export type AssessmentManifestRevision = {
+  digest: string;
+  id: string;
+  kind: string;
+  revision_id: string;
+  version: number;
+};
+
+export type AssessmentObjectiveResult = {
+  assurance: "high" | "medium" | "low" | "none";
+  auditor_state: "not_reviewed" | "accepted" | "changes_requested" | "rejected";
+  automated_outcome: "satisfied" | "not_satisfied" | "indeterminate" | "not_assessed";
+  control_ref: AssessmentControlRef;
+  design_state: "effective" | "ineffective" | "unknown" | "not_assessed";
+  disposition_state: "none" | "accepted_exception" | "accepted_risk" | "review_override";
+  evaluated_at: string;
+  evaluator_revision: string;
+  evidence_ids?: string[];
+  evidence_state: "sufficient" | "missing" | "stale" | "conflicting" | "untrusted" | "incomplete" | "manual_review";
+  finding_ids?: string[];
+  id: string;
+  next_actions: ("none" | "review" | "collect_evidence" | "refresh_evidence" | "restore_source" | "resolve_scope" | "remediate" | "retest")[];
+  objective_id: string;
+  operating_effectiveness_state: "effective" | "ineffective" | "unknown" | "not_tested";
+  reason_codes: string[];
+  scope_state: "in_scope" | "not_applicable" | "unresolved";
+  source_runtime_ids?: string[];
+};
 
 export type AssessmentPlan = {
   content_digest: string;
@@ -788,7 +853,7 @@ export type AssessmentResultChunk = {
   first_result_id: string;
   last_result_id: string;
   previous_digest?: string;
-  results: Record<string, unknown>[];
+  results: AssessmentObjectiveResult[];
   run_id: string;
   sequence: number;
 };
@@ -837,6 +902,110 @@ export type AssessmentRunRequest = {
 export type AssessmentRunResponse = {
   created: boolean;
   run: AssessmentRun;
+};
+
+export type AssuranceDecision = {
+  decision: QualifiedAssuranceDecision;
+  id: string;
+  idempotency_key: string;
+  input_snapshot: AssuranceQualificationInput;
+  objective_id: string;
+  plan_revision_id: string;
+  program_id: string;
+  record_digest: string;
+  recorded_at: string;
+  recorded_by: string;
+  request_hash: string;
+  result_id: string;
+  run_id: string;
+  scope_revision_id: string;
+  tenant_id: string;
+  version: "assurance-decision/v1";
+};
+
+export type AssuranceDecisionRecordRequest = {
+  as_of: string;
+  evidence_proofs: AssuranceEvidenceProof[];
+  exceptions?: AssuranceExceptionProof[];
+  limitations: AssuranceLimitation[];
+  required_reviews: AssuranceReviewRequirement[];
+  result_id: string;
+  run_id: string;
+  source_proofs: AssuranceSourceProof[];
+  tenant_id: string;
+  verification: AssuranceVerificationProof;
+};
+
+export type AssuranceDecisionRecordResponse = {
+  created: boolean;
+  decision: AssuranceDecision;
+};
+
+export type AssuranceDecisionResponse = {
+  decision: AssuranceDecision;
+};
+
+export type AssuranceEvidenceProof = {
+  collected_at: string;
+  evidence_id: string;
+  state: "sufficient" | "missing" | "stale" | "conflicting" | "untrusted" | "incomplete" | "manual_review";
+  valid_until: string;
+};
+
+export type AssuranceExceptionProof = {
+  active: boolean;
+  exception_id: string;
+  valid_until: string;
+};
+
+export type AssuranceLimitation = {
+  blocking: boolean;
+  code: string;
+  detail: string;
+};
+
+export type AssuranceProofInput = {
+  as_of: string;
+  evidence_proofs: AssuranceEvidenceProof[];
+  exceptions?: AssuranceExceptionProof[];
+  limitations: AssuranceLimitation[];
+  required_reviews: AssuranceReviewRequirement[];
+  source_proofs: AssuranceSourceProof[];
+  verification: AssuranceVerificationProof;
+};
+
+export type AssuranceQualificationInput = {
+  as_of: string;
+  evidence_proofs: AssuranceEvidenceProof[];
+  exceptions?: AssuranceExceptionProof[];
+  input_manifest: AssessmentInputManifest;
+  limitations: AssuranceLimitation[];
+  required_reviews: AssuranceReviewRequirement[];
+  result: AssessmentObjectiveResult;
+  source_proofs: AssuranceSourceProof[];
+  verification: AssuranceVerificationProof;
+};
+
+export type AssuranceReviewRequirement = {
+  completed_at?: string;
+  kind: string;
+  required: boolean;
+  status: "pending" | "approved" | "rejected";
+  valid_until?: string;
+};
+
+export type AssuranceSourceProof = {
+  fresh_until: string;
+  observed_at: string;
+  runtime_id: string;
+  state: "supported" | "partial" | "stale" | "failed" | "unconfigured" | "unsupported" | "unverified" | "conflicting" | "unknown";
+};
+
+export type AssuranceVerificationProof = {
+  required: boolean;
+  state: "not_required" | "pending" | "passed" | "failed";
+  valid_until?: string;
+  verified_at?: string;
 };
 
 export type AuthErrorResponse = {
@@ -1074,7 +1243,7 @@ export type ConnectorDefinitionScopeOption = {
 };
 
 export type ConnectorDefinitionSupportReport = {
-  checks?: { category?: string; detail?: string; id?: string; status?: "ready" | "missing" }[];
+  checks?: ({ category?: string; detail?: string; id?: string; status?: "ready" | "missing" })[];
   definition_id?: string;
   grammar_version?: string;
   missing_features?: string[];
@@ -1102,7 +1271,7 @@ export type ConnectorDefinitionVersionsResponse = {
   definition_id: string;
   generated_at?: string;
   tenant_id?: string;
-  versions: { created_at?: string; definition?: ConnectorDefinition; stage?: "draft" | "sandbox" | "pilot" | "approved" | "certified"; version?: number }[];
+  versions: ({ created_at?: string; definition?: ConnectorDefinition; stage?: "draft" | "sandbox" | "pilot" | "approved" | "certified"; version?: number })[];
 };
 
 export type ConnectorDepositRecordError = {
@@ -1822,7 +1991,7 @@ export type GRCAccessSourceFreshness = {
 };
 
 export type GRCAskRequest = {
-  history?: { content?: string; role?: "user" | "assistant" }[];
+  history?: ({ content?: string; role?: "user" | "assistant" })[];
   model?: string;
   question: string;
   scope_urn?: string;
@@ -3863,6 +4032,19 @@ export type PutSourceRuntimeRequest = {
 
 export type PutSourceRuntimeResponse = {
   runtime?: SourceRuntime;
+};
+
+export type QualifiedAssuranceDecision = {
+  as_of: string;
+  decision_digest: string;
+  limitations: AssuranceLimitation[];
+  manifest_hash: string;
+  proof_digest: string;
+  qualified: boolean;
+  reasons: ("manifest_invalid" | "scope_unpinned" | "population_incomplete" | "result_invalid" | "source_proof_missing" | "source_unhealthy" | "source_stale" | "evidence_proof_missing" | "evidence_not_current" | "evidence_conflicting" | "limitations_not_declared" | "blocking_limitation" | "review_requirements_not_declared" | "review_incomplete" | "exception_expired" | "verification_failed")[];
+  required_reviews: AssuranceReviewRequirement[];
+  result_hash: string;
+  version: "qualified-decision/v1";
 };
 
 export type ReconcileGraphActionRequest = {

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -1051,6 +1051,130 @@ export type Claim = {
   valid_to?: string;
 };
 
+export type ComplianceWorkActionRecord = {
+  action: "assign" | "request_evidence" | "block" | "snooze" | "accept" | "remediate" | "verify" | "verify_assurance" | "close" | "supersede";
+  action_hash: string;
+  actor_id: string;
+  created_at: string;
+  from: ComplianceWorkItemState;
+  id: string;
+  owner_id: string;
+  rationale: string;
+  to: ComplianceWorkItemState;
+  verification?: ComplianceWorkVerification;
+  work_item_id: string;
+};
+
+export type ComplianceWorkCommand = {
+  action?: "assign" | "request_evidence" | "block" | "snooze" | "accept" | "remediate" | "verify" | "verify_assurance" | "close" | "supersede";
+  assurance_decision_id?: string;
+  blocker_reason?: string;
+  due_at?: string;
+  evidence_ids?: string[];
+  expected_version: number;
+  operation: "action" | "invalidate";
+  owner_id?: string;
+  rationale?: string;
+  snooze_until?: string;
+  source_ref?: string;
+  trigger?: "exception_expired" | "evidence_stale" | "evidence_revoked" | "finding_reopened" | "source_coverage_lost" | "scope_subject_added";
+};
+
+export type ComplianceWorkFingerprint = {
+  control_id: string;
+  kind: ComplianceWorkItemKind;
+  objective_id: string;
+  program_id: string;
+  reason: string;
+  scope_revision_id: string;
+  source_id: string;
+  subject_id: string;
+  tenant_id: string;
+};
+
+export type ComplianceWorkItem = {
+  basis: ComplianceWorkFingerprint;
+  blocker_reason?: string;
+  due_at: string;
+  exception_id?: string;
+  fingerprint: string;
+  fingerprint_version: "compliance-work-fingerprint/v1";
+  id: string;
+  last_remediated_at?: string;
+  last_remediated_by?: string;
+  last_reopen_trigger?: "exception_expired" | "evidence_stale" | "evidence_revoked" | "finding_reopened" | "source_coverage_lost" | "scope_subject_added";
+  occurrences: ComplianceWorkOccurrence[];
+  owner_id: string;
+  priority: string;
+  risk_id?: string;
+  snooze_until?: string;
+  state: ComplianceWorkItemState;
+  updated_at: string;
+  verification?: ComplianceWorkVerification;
+  verification_evidence_ids?: string[];
+  verification_required: boolean;
+  verified_by?: string;
+  version: number;
+};
+
+export type ComplianceWorkItemKind =
+  | "remediate_finding"
+  | "collect_evidence"
+  | "refresh_evidence"
+  | "resolve_conflict"
+  | "review_manual_evidence"
+  | "repair_source"
+  | "assign_owner"
+  | "map_control"
+  | "renew_exception"
+  | "resolve_policy_gap"
+  | "complete_access_change"
+  | "answer_audit_request"
+  | "review_vendor";
+
+export type ComplianceWorkItemPage = {
+  items: ComplianceWorkItem[];
+  next_cursor?: string;
+};
+
+export type ComplianceWorkItemRecord = {
+  actions: ComplianceWorkActionRecord[];
+  item: ComplianceWorkItem;
+  occurrences: ComplianceWorkOccurrence[];
+};
+
+export type ComplianceWorkItemState =
+  | "open"
+  | "in_progress"
+  | "blocked"
+  | "resolved"
+  | "accepted"
+  | "snoozed"
+  | "superseded";
+
+export type ComplianceWorkOccurrence = {
+  assessment_run_id: string;
+  automated_result_hash: string;
+  evidence_ids?: string[];
+  finding_ids?: string[];
+  id: string;
+  objective_result_id: string;
+  occurred_at: string;
+  occurrence_hash: string;
+  work_item_id: string;
+};
+
+export type ComplianceWorkVerification = {
+  assessment_run_id: string;
+  assurance_decision_id: string;
+  decision_as_of: string;
+  decision_digest: string;
+  evaluated_at: string;
+  evidence_ids?: string[];
+  objective_result_id: string;
+  record_digest: string;
+};
+
 export type ConnectorCoveragePageResponse = {
   blind_spot_summaries?: SourceCoverageSummary[];
   blind_spots?: SourceCoverageRecord[];

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -730,21 +730,22 @@ export type AssessmentControlRef = {
 
 /** Immutable revisions, receipts, cutoff, and digests used by one assessment run. */
 export type AssessmentInputManifest = {
-  adapter_version: string;
-  collection_cutoff: string;
+  adapter_version?: string;
+  collection_cutoff?: string;
   evaluation_run_ids?: string[];
-  mapping_set_digest: string;
-  model_version: string;
-  period_end: string;
-  period_start: string;
-  plan_revision_id: string;
-  program_id: string;
-  reason_registry: string;
-  receipts: AssessmentCollectionReceipt[];
-  requested_scope_digest: string;
-  resolved_objective_set_digest: string;
-  revisions: AssessmentManifestRevision[];
-  scope_revision_id: string;
+  mapping_set_digest?: string;
+  model_version?: string;
+  period_end?: string;
+  period_start?: string;
+  plan_revision_id?: string;
+  program_id?: string;
+  reason_registry?: string;
+  receipts?: AssessmentCollectionReceipt[];
+  requested_scope_digest?: string;
+  resolved_objective_set_digest?: string;
+  revisions?: AssessmentManifestRevision[];
+  scope_revision_id?: string;
+  [key: string]: unknown;
 };
 
 export type AssessmentManifestRevision = {
@@ -853,7 +854,7 @@ export type AssessmentResultChunk = {
   first_result_id: string;
   last_result_id: string;
   previous_digest?: string;
-  results: AssessmentObjectiveResult[];
+  results: (AssessmentObjectiveResult | Record<string, unknown>)[];
   run_id: string;
   sequence: number;
 };
@@ -4038,12 +4039,12 @@ export type QualifiedAssuranceDecision = {
   as_of: string;
   decision_digest: string;
   limitations: AssuranceLimitation[];
-  manifest_hash: string;
-  proof_digest: string;
+  manifest_hash?: string;
+  proof_digest?: string;
   qualified: boolean;
   reasons?: ("manifest_invalid" | "scope_unpinned" | "population_incomplete" | "result_invalid" | "source_proof_missing" | "source_unhealthy" | "source_stale" | "evidence_proof_missing" | "evidence_not_current" | "evidence_conflicting" | "limitations_not_declared" | "blocking_limitation" | "review_requirements_not_declared" | "review_incomplete" | "exception_expired" | "verification_failed")[];
   required_reviews: AssuranceReviewRequirement[];
-  result_hash: string;
+  result_hash?: string;
   version: "qualified-decision/v1";
 };
 

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -55,6 +55,41 @@ export class Client {
         }
         return this.requestJson("GET", `/platform/graph/neighborhood?${query.toString()}`);
     }
+    async listComplianceWorkItems(options = {}) {
+        const query = new URLSearchParams();
+        if (options.tenantId)
+            query.set("tenant_id", options.tenantId);
+        if (options.state)
+            query.set("state", options.state);
+        if (options.ownerId)
+            query.set("owner_id", options.ownerId);
+        if (options.cursor)
+            query.set("cursor", options.cursor);
+        if (options.limit !== undefined)
+            query.set("limit", String(options.limit));
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return this.requestJson("GET", `/grc/work-items${suffix}`);
+    }
+    async getComplianceWorkItem(workItemId, tenantId = "") {
+        const normalizedID = workItemId.trim();
+        if (!normalizedID)
+            throw new Error("workItemId is required");
+        const query = new URLSearchParams();
+        if (tenantId)
+            query.set("tenant_id", tenantId);
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return this.requestJson("GET", `/grc/work-items/${encodeURIComponent(normalizedID)}${suffix}`);
+    }
+    async commandComplianceWorkItem(workItemId, command, tenantId = "") {
+        const normalizedID = workItemId.trim();
+        if (!normalizedID)
+            throw new Error("workItemId is required");
+        const query = new URLSearchParams();
+        if (tenantId)
+            query.set("tenant_id", tenantId);
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return this.requestJson("POST", `/grc/work-items/${encodeURIComponent(normalizedID)}/commands${suffix}`, command);
+    }
     async createJob(request, idempotencyKey = "") {
         const headers = {};
         if (idempotencyKey) {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,4 +1,8 @@
 import type {
+  ComplianceWorkCommand,
+  ComplianceWorkItemPage,
+  ComplianceWorkItemRecord,
+  ComplianceWorkItemState,
   CreatePlatformJobRequest,
   GetSourceRuntimeResponse,
   PlatformJobEventListResponse,
@@ -9,6 +13,15 @@ import type {
 } from "./generated/openapi-types.ts";
 
 export type {
+  ComplianceWorkActionRecord,
+  ComplianceWorkCommand,
+  ComplianceWorkItem,
+  ComplianceWorkItemKind,
+  ComplianceWorkItemPage,
+  ComplianceWorkItemRecord,
+  ComplianceWorkItemState,
+  ComplianceWorkOccurrence,
+  ComplianceWorkVerification,
   GetSourceRuntimeResponse,
   PlatformJob,
   PlatformJobEvent,
@@ -21,6 +34,14 @@ export type {
 
 export type * from "./generated/agent-service-lifecycle-contract.ts";
 export type * from "./generated/agent-service-lifecycle.ts";
+
+export interface ListComplianceWorkItemsOptions {
+  tenantId?: string;
+  state?: ComplianceWorkItemState;
+  ownerId?: string;
+  cursor?: string;
+  limit?: number;
+}
 
 export interface ClientConfig {
   baseUrl: string;
@@ -191,6 +212,35 @@ export class Client {
       query.set("limit", String(limit));
     }
     return this.requestJson<GraphNeighborhood>("GET", `/platform/graph/neighborhood?${query.toString()}`);
+  }
+
+  async listComplianceWorkItems(options: ListComplianceWorkItemsOptions = {}): Promise<ComplianceWorkItemPage> {
+    const query = new URLSearchParams();
+    if (options.tenantId) query.set("tenant_id", options.tenantId);
+    if (options.state) query.set("state", options.state);
+    if (options.ownerId) query.set("owner_id", options.ownerId);
+    if (options.cursor) query.set("cursor", options.cursor);
+    if (options.limit !== undefined) query.set("limit", String(options.limit));
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    return this.requestJson<ComplianceWorkItemPage>("GET", `/grc/work-items${suffix}`);
+  }
+
+  async getComplianceWorkItem(workItemId: string, tenantId = ""): Promise<ComplianceWorkItemRecord> {
+    const normalizedID = workItemId.trim();
+    if (!normalizedID) throw new Error("workItemId is required");
+    const query = new URLSearchParams();
+    if (tenantId) query.set("tenant_id", tenantId);
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    return this.requestJson<ComplianceWorkItemRecord>("GET", `/grc/work-items/${encodeURIComponent(normalizedID)}${suffix}`);
+  }
+
+  async commandComplianceWorkItem(workItemId: string, command: ComplianceWorkCommand, tenantId = ""): Promise<ComplianceWorkItemRecord> {
+    const normalizedID = workItemId.trim();
+    if (!normalizedID) throw new Error("workItemId is required");
+    const query = new URLSearchParams();
+    if (tenantId) query.set("tenant_id", tenantId);
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    return this.requestJson<ComplianceWorkItemRecord>("POST", `/grc/work-items/${encodeURIComponent(normalizedID)}/commands${suffix}`, command);
   }
 
   async createJob(request: CreateJobRequest, idempotencyKey = ""): Promise<PlatformJobResponse> {

--- a/sdk/typescript/test/compliance-work-items.test.mjs
+++ b/sdk/typescript/test/compliance-work-items.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Client } from "../src/index.js";
+
+test("compliance work item methods preserve canonical ids, filters, versions, and commands", async () => {
+  const requests = [];
+  const item = {
+    id: "compliance-work-item-a",
+    fingerprint_version: "compliance-work-fingerprint/v1",
+    fingerprint: "sha256:a",
+    basis: {
+      tenant_id: "tenant-a",
+      program_id: "program-a",
+      scope_revision_id: "scope-a",
+      control_id: "control-a",
+      objective_id: "objective-a",
+      kind: "remediate_finding",
+      subject_id: "subject-a",
+      reason: "active_finding",
+      source_id: "runtime-a",
+    },
+    state: "in_progress",
+    owner_id: "owner-a",
+    due_at: "2026-07-16T00:00:00Z",
+    priority: "high",
+    verification_required: true,
+    occurrences: [],
+    version: 2,
+    updated_at: "2026-07-15T00:00:00Z",
+  };
+  const record = { item, occurrences: [], actions: [] };
+  const client = new Client({
+    baseUrl: "https://cerebro.example.com/",
+    fetchImpl: async (url, init = {}) => {
+      requests.push({ url: String(url), method: init.method, body: init.body });
+      const payload = String(url).includes("/commands") ? record : String(url).includes("compliance-work-item-a") ? record : { items: [item], next_cursor: "cursor-b" };
+      return new Response(JSON.stringify(payload), { status: 200, headers: { "Content-Type": "application/json" } });
+    },
+  });
+
+  const page = await client.listComplianceWorkItems({ tenantId: "tenant-a", state: "in_progress", ownerId: "owner-a", cursor: "cursor-a", limit: 25 });
+  assert.equal(page.items[0].id, item.id);
+  assert.equal(page.next_cursor, "cursor-b");
+  const listURL = new URL(requests[0].url);
+  assert.equal(listURL.pathname, "/grc/work-items");
+  assert.deepEqual(Object.fromEntries(listURL.searchParams), {
+    tenant_id: "tenant-a",
+    state: "in_progress",
+    owner_id: "owner-a",
+    cursor: "cursor-a",
+    limit: "25",
+  });
+
+  const fetched = await client.getComplianceWorkItem(item.id, "tenant-a");
+  assert.equal(fetched.item.version, 2);
+  const command = {
+    operation: "action",
+    expected_version: 2,
+    action: "verify_assurance",
+    assurance_decision_id: "assurance-decision-a",
+    rationale: "Verify the post-change assessment.",
+  };
+  const updated = await client.commandComplianceWorkItem(item.id, command, "tenant-a");
+  assert.equal(updated.item.id, item.id);
+  assert.equal(requests[2].method, "POST");
+  assert.deepEqual(JSON.parse(requests[2].body), command);
+  assert.equal(new URL(requests[2].url).searchParams.get("tenant_id"), "tenant-a");
+});

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -146,7 +146,7 @@ import (
 // owns only their route-policy and OAuth discovery catalog entries.
 // Assurance decision routes add only service composition and route/auth
 // registration; decision validation and persistence remain in
-// internal/compliancedecision.
+// internal/complianceassessment.
 const bootstrapProductionGoLineBudget = 28960
 
 type bootstrapFileLineCount struct {

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -147,7 +147,10 @@ import (
 // Assurance decision routes add only service composition and route/auth
 // registration; decision validation and persistence remain in
 // internal/complianceassessment.
-const bootstrapProductionGoLineBudget = 28960
+// Canonical compliance work adds query composition and response mapping;
+// bounded queries and assurance verification remain in the domain and
+// state-store packages.
+const bootstrapProductionGoLineBudget = 28997
 
 type bootstrapFileLineCount struct {
 	path  string

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -144,6 +144,9 @@ import (
 // Dedicated evaluation-dataset read, proposal, and approval scope constants
 // keep future agent credentials separate from candidate execution. Bootstrap
 // owns only their route-policy and OAuth discovery catalog entries.
+// Assurance decision routes add only service composition and route/auth
+// registration; decision validation and persistence remain in
+// internal/compliancedecision.
 const bootstrapProductionGoLineBudget = 28960
 
 type bootstrapFileLineCount struct {

--- a/tools/openapitsgen/generator.go
+++ b/tools/openapitsgen/generator.go
@@ -203,6 +203,9 @@ func tsType(schema *Schema, all map[string]*Schema) string {
 		return "boolean"
 	case "array":
 		itemType := tsType(schema.Items, all)
+		if strings.Contains(itemType, " | ") {
+			itemType = "(" + itemType + ")"
+		}
 		return itemType + "[]"
 	case "object":
 		if schema.AdditionalProperties != nil {

--- a/tools/openapitsgen/generator_test.go
+++ b/tools/openapitsgen/generator_test.go
@@ -68,6 +68,29 @@ components:
 	}
 }
 
+func TestGenerateParenthesizesEnumUnionArrayItems(t *testing.T) {
+	spec := `
+components:
+  schemas:
+    Decision:
+      type: object
+      required: [reasons]
+      properties:
+        reasons:
+          type: array
+          items:
+            type: string
+            enum: [missing, stale, conflicting]
+`
+	result, err := Generate([]byte(spec))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result.TypeScript, `reasons: ("missing" | "stale" | "conflicting")[];`) {
+		t.Fatalf("generated enum array does not preserve union precedence:\n%s", result.TypeScript)
+	}
+}
+
 func TestGenerateAdditionalProperties(t *testing.T) {
 	spec := `
 components:


### PR DESCRIPTION
## Summary
- expose durable assurance decisions through the runtime API
- add tenant-scoped canonical compliance work-item reads and version-checked commands
- verify command outcomes with fresh assurance evidence
- provide the backend contract required by the Slack host consumer

## Validation
The stacked implementation passed its build, coverage, SDK, security, lint, test, race, and integration gates before rollup. Retargeted checks run against current main.

## Rollout
This rollup lands the already-reviewed assurance API and canonical work contract on main. The Slack host consumes these endpoints from the same monorepo.