### PR TITLE
Expose verified assessment tools to agents

### DIFF
--- a/docs/domains/mcp-droid-setup.md
+++ b/docs/domains/mcp-droid-setup.md
@@ -48,7 +48,36 @@ The evidence-packet task accepts only `observe`, `explain`, `recommend`, and
 Requests without a toolset keep the full tool list for compatibility. Existing
 domain tools remain available as expert tools. Use
 `X-Cerebro-MCP-Toolsets: expert` for that profile, or the existing domain
-toolsets such as `graph`, `risk`, and `findings` for narrower access.
+toolsets such as `graph`, `risk`, `findings`, and `assessments` for narrower access.
+
+## Assessment operations
+
+Set `X-Cerebro-MCP-Toolsets: assessments` to expose the assessment lifecycle:
+
+| Tool | Required scope | Result |
+| --- | --- | --- |
+| `cerebro.assessments.plan.create` | security read + GRC inventory write | Persisted plan draft with server-owned identity and digest |
+| `cerebro.assessments.plan.publish` | security read + GRC inventory write | Published immutable plan revision using `expected_version` |
+| `cerebro.assessments.plan.get` | security read | One tenant-scoped plan revision |
+| `cerebro.assessments.run.request` | security read + GRC inventory write | Recoverable run; repeated key and body return the existing run |
+| `cerebro.assessments.run.get` | security read | Current state, pinned input manifest, result availability, and hashes |
+| `cerebro.assessments.results.list` | security read | Bounded result page with recomputed payload and predecessor-digest verification |
+| `cerebro.assessments.run.diff` | security read | Complete bounded comparison with the explicit or pinned baseline |
+| `cerebro.assessments.result.explain` | security read | Verified result, manifest, evidence, findings, and exact provenance follow-up calls |
+| `cerebro.assessments.remediation.propose` | security read | Non-mutating work request for the existing approval-gated GRC work endpoint |
+
+Start result paging with `after_sequence: 0` and no predecessor digest. For each
+following page, pass the preceding response's
+`verification.next_previous_digest` as `expected_previous_digest`. A page fails
+if its run ID, sequence, result boundaries, canonical payload digest, or
+predecessor link does not match.
+
+Plan creation, plan publication, and run requests are the only mutating tools in
+this profile. They call the existing assessment domain service, preserve its
+append-first records and Postgres projections, and require the same GRC write
+scope as the HTTP routes. Run requests are idempotent. The other assessment
+tools are read-only. Remediation remains a proposal and requires a separate
+call to `POST /grc/work-items` with `cerebro.findings.write`.
 
 ## Tool/domain parity
 
@@ -58,9 +87,12 @@ or explicitly named composite of those surfaces. Agent-oriented tools such as
 investigation context and risk action planning may bundle multiple reads, but
 their source domain surfaces must stay listed in the MCP parity test.
 
-Mutating workflows are exposed only as proposal tools with `dry_run=true`,
-`readOnlyHint=true`, and a response that describes the required write scope
-without applying the action.
+Action and remediation workflows are exposed only as proposal tools with
+`dry_run=true`, `readOnlyHint=true`, and a response that describes the required
+write scope without applying the action. Domain-owned assessment plan and run
+writes may execute only through the existing assessment service, with the same
+tenant, write-scope, optimistic-concurrency, idempotency, append-log, and
+projection contracts as their HTTP routes.
 
 Agent control-loop tools expose the security-agent control plane without adding
 write access. `cerebro.agent.control_plane` returns the evidence packet, claim

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -228,6 +228,17 @@ and MCP request/response mapping for the control-plane snapshot, claim
 verification request shape, tenant/URN authorization boundary, and durable work
 contract response.
 
+Agent assessment operations reuse `internal/complianceassessment` as the
+domain owner. That package owns plan and run semantics, canonical result-chunk
+verification, bounded complete-run collection, baseline comparison, and
+remediation proposal shaping. `internal/mcpoperations` owns the checked-in tool
+inventory and JSON schemas. The bootstrap budget includes only assessment MCP
+registration, argument decoding, tenant and per-tool scope enforcement,
+evidence/finding response composition through existing safe MCP adapters, and
+transport metadata. Assessment writes use the same append-first service,
+Postgres projection, optimistic version, and idempotency contracts as the HTTP
+routes; no MCP-specific state or graph write path exists.
+
 The append-log runtime replay index is populated by a global maintenance job
 whose scan-and-persist loop lives in `internal/appendlogindex`. The bootstrap
 budget includes only the job registration, admin authorization, payload

--- a/internal/agentplatform/contracts_test.go
+++ b/internal/agentplatform/contracts_test.go
@@ -183,8 +183,17 @@ func TestA2AAgentCardIsPublicSafeAndHonest(t *testing.T) {
 	if card.Capabilities.Streaming || card.Capabilities.PushNotifications || card.Capabilities.ExtendedAgentCard {
 		t.Fatalf("card over-advertises unsupported capabilities: %+v", card.Capabilities)
 	}
-	if len(card.Skills) < 4 {
-		t.Fatalf("card skills = %+v, want protocol, evidence-packet, webhook, and idempotency skills", card.Skills)
+	if len(card.Skills) < 5 {
+		t.Fatalf("card skills = %+v, want protocol, evidence-packet, assessment, webhook, and idempotency skills", card.Skills)
+	}
+	foundAssessment := false
+	for _, skill := range card.Skills {
+		if skill.ID == "continuous-assessment" {
+			foundAssessment = true
+		}
+	}
+	if !foundAssessment {
+		t.Fatalf("card skills = %+v, want continuous-assessment", card.Skills)
 	}
 }
 

--- a/internal/agentplatform/public_contracts.go
+++ b/internal/agentplatform/public_contracts.go
@@ -249,6 +249,15 @@ func BuildA2AAgentCard(origin string) A2AAgentCard {
 				OutputModes: []string{"application/json"},
 			},
 			{
+				ID:          "continuous-assessment",
+				Name:        "Compliance assessment operations",
+				Description: "Create and publish bounded assessment plans, request idempotent runs, verify paged result digests, compare a completed run with its baseline, explain one result from its evidence and finding references, and prepare approval-gated remediation work. Write operations require cerebro.grc.inventory.write in addition to the default read scope.",
+				Tags:        []string{"compliance", "assessment", "evidence", "remediation"},
+				Examples:    []string{"Run the published access assessment, verify every result page, explain changed failures, and prepare owner work without executing remediation."},
+				InputModes:  []string{"text/plain", "application/json"},
+				OutputModes: []string{"application/json"},
+			},
+			{
 				ID:          "event-subscription-contract",
 				Name:        "Outbound event subscription contract discovery",
 				Description: "Explain supported outbound webhook trigger families, signing, retry, and idempotency semantics.",

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -489,8 +489,21 @@ func authorizeMCPMethodScope(ctx context.Context, method string) error {
 	}
 }
 
-func authorizeMCPToolScope(ctx context.Context, _ string) error {
-	return authorizeMCPReadScope(ctx)
+func authorizeMCPToolScope(ctx context.Context, name string) error {
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok || !principalScopeRestricted(auth.principal) {
+		return nil
+	}
+	operation, known := mcpoperations.Lookup(name)
+	if !known {
+		return authorizePrincipalScope(auth.principal, scopeCosmoSecurityRead)
+	}
+	for _, required := range operation.RequiredScopes {
+		if err := authorizePrincipalScope(auth.principal, required); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func authorizeMCPResourceScope(ctx context.Context, _ string) error {
@@ -629,6 +642,24 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 		return app.mcpGraphReason(r, args)
 	case "cerebro.investigation.context":
 		return app.mcpInvestigationContext(r, args)
+	case "cerebro.assessments.plan.create":
+		return app.mcpAssessmentPlanCreate(r, args)
+	case "cerebro.assessments.plan.publish":
+		return app.mcpAssessmentPlanPublish(r, args)
+	case "cerebro.assessments.plan.get":
+		return app.mcpAssessmentPlanGet(r, args)
+	case "cerebro.assessments.run.request":
+		return app.mcpAssessmentRunRequest(r, args)
+	case "cerebro.assessments.run.get":
+		return app.mcpAssessmentRunGet(r, args)
+	case "cerebro.assessments.results.list":
+		return app.mcpAssessmentResultsList(r, args)
+	case "cerebro.assessments.run.diff":
+		return app.mcpAssessmentRunDiff(r, args)
+	case "cerebro.assessments.result.explain":
+		return app.mcpAssessmentResultExplain(r, args)
+	case "cerebro.assessments.remediation.propose":
+		return app.mcpAssessmentRemediationPropose(r, args)
 	case "cerebro.findings.action.propose":
 		return app.mcpProposeFindingAction(r, args)
 	case "cerebro.source_runtimes.refresh.propose":
@@ -2744,6 +2775,7 @@ func mcpTools() []mcpTool {
 			Annotations: mcpReadOnlyAnnotations("Propose Runtime Refresh"),
 		},
 	}
+	tools = append(tools, mcpAssessmentTools()...)
 	for _, definition := range mcpoperations.TaskToolDefinitions(mcpoperations.TaskToolLimits{Evidence: maxMCPEvidenceLimit, Assets: maxMCPAssetLimit, Actions: riskplan.MaxCandidateLimit, Findings: maxMCPRiskLimit, ResourceRoots: maxMCPRiskActionRoots, Graph: maxMCPRiskActionGraph}) {
 		tools = append(tools, mcpTool{Name: definition.Name, Title: definition.Title, Description: definition.Description, InputSchema: definition.InputSchema, OutputSchema: mcpoperations.TaskOutputSchema(), Annotations: mcpReadOnlyAnnotations(definition.Title)})
 	}
@@ -2844,6 +2876,16 @@ func mcpReadOnlyAnnotations(title string) map[string]any {
 		"destructiveHint": false,
 		"idempotentHint":  true,
 		"openWorldHint":   true,
+	}
+}
+
+func mcpWriteAnnotations(title string, idempotent bool) map[string]any {
+	return map[string]any{
+		"title":           title,
+		"readOnlyHint":    false,
+		"destructiveHint": false,
+		"idempotentHint":  idempotent,
+		"openWorldHint":   false,
 	}
 }
 

--- a/internal/bootstrap/mcp_assessments.go
+++ b/internal/bootstrap/mcp_assessments.go
@@ -121,15 +121,20 @@ func (app *App) mcpAssessmentResultsList(r *http.Request, args map[string]any) (
 	if err != nil {
 		return nil, err
 	}
+	// #nosec G115 -- mcpBoundedLimit caps this value at 100.
 	verified, err := service.VerifiedResultsPage(r.Context(), tenantID, mcpStringArg(args, "run_id"), afterSequence, uint32(limit), mcpStringArg(args, "expected_previous_digest"))
 	if err != nil {
 		return nil, err
+	}
+	returnedResults := 0
+	for _, chunk := range verified.Page.Chunks {
+		returnedResults += len(chunk.Results)
 	}
 	return map[string]any{
 		"run_id": verified.Run.ID, "state": verified.Run.State, "result_count": verified.Run.ResultCount,
 		"input_hash": verified.Run.InputHash, "automated_result_hash": verified.Run.AutomatedResultHash,
 		"chunks": verified.Page.Chunks, "next_sequence": verified.Page.NextSequence, "has_more": verified.Page.HasMore,
-		"verification": verified.Verification, "metadata": mcpResponseMetadata(limit, int(verified.Verification.ResultCount), nil),
+		"verification": verified.Verification, "metadata": mcpResponseMetadata(limit, returnedResults, nil),
 	}, nil
 }
 
@@ -229,12 +234,12 @@ func mcpAssessmentObjectArg(args map[string]any, key string, target any) error {
 	}
 	data, err := json.Marshal(value)
 	if err != nil {
-		return fmt.Errorf("%w: encode %s: %v", complianceassessment.ErrInvalidResult, key, err)
+		return fmt.Errorf("%w: encode %s: %w", complianceassessment.ErrInvalidResult, key, err)
 	}
 	decoder := json.NewDecoder(strings.NewReader(string(data)))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
-		return fmt.Errorf("%w: decode %s: %v", complianceassessment.ErrInvalidResult, key, err)
+		return fmt.Errorf("%w: decode %s: %w", complianceassessment.ErrInvalidResult, key, err)
 	}
 	return nil
 }

--- a/internal/bootstrap/mcp_assessments.go
+++ b/internal/bootstrap/mcp_assessments.go
@@ -1,0 +1,288 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/complianceassessment"
+	"github.com/writer/cerebro/internal/mcpoperations"
+)
+
+func (app *App) mcpAssessmentPlanCreate(r *http.Request, args map[string]any) (any, error) {
+	service, err := app.mcpAssessmentService()
+	if err != nil {
+		return nil, err
+	}
+	var plan complianceassessment.AssessmentPlanRevision
+	if err := mcpAssessmentObjectArg(args, "plan", &plan); err != nil {
+		return nil, err
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), plan.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	plan, err = service.CreatePlanForAgent(r.Context(), tenantID, customDashboardActorID(r.Context()), plan)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"plan": plan, "created": true}, nil
+}
+
+func (app *App) mcpAssessmentPlanPublish(r *http.Request, args map[string]any) (any, error) {
+	service, tenantID, err := app.mcpAssessmentContext(r, args)
+	if err != nil {
+		return nil, err
+	}
+	planID := mcpStringArg(args, "plan_id")
+	expectedVersion, err := mcpAssessmentUint64Arg(args, "expected_version")
+	if planID == "" || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: plan_id is required", complianceassessment.ErrInvalidResult)
+	}
+	plan, err := service.PublishPlanForAgent(r.Context(), tenantID, planID, customDashboardActorID(r.Context()), expectedVersion)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"plan": plan, "published": true}, nil
+}
+
+func (app *App) mcpAssessmentPlanGet(r *http.Request, args map[string]any) (any, error) {
+	service, tenantID, err := app.mcpAssessmentContext(r, args)
+	if err != nil {
+		return nil, err
+	}
+	planID := mcpStringArg(args, "plan_id")
+	if planID == "" {
+		return nil, fmt.Errorf("%w: plan_id is required", complianceassessment.ErrInvalidResult)
+	}
+	plan, err := service.GetPlan(r.Context(), tenantID, planID)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"plan": plan}, nil
+}
+
+func (app *App) mcpAssessmentRunRequest(r *http.Request, args map[string]any) (any, error) {
+	service, tenantID, err := app.mcpAssessmentContext(r, args)
+	if err != nil {
+		return nil, err
+	}
+	periodStart, err := mcpAssessmentTimeArg(args, "period_start")
+	if err != nil {
+		return nil, err
+	}
+	periodEnd, err := mcpAssessmentTimeArg(args, "period_end")
+	if err != nil {
+		return nil, err
+	}
+	run, created, err := service.RequestRunForAgent(r.Context(), complianceassessment.AgentRunRequest{
+		TenantID: tenantID, PlanRevisionID: mcpStringArg(args, "plan_revision_id"),
+		PeriodStart: periodStart, PeriodEnd: periodEnd, BaselineRunID: mcpStringArg(args, "baseline_run_id"),
+		IdempotencyKey: mcpStringArg(args, "idempotency_key"), ActorID: customDashboardActorID(r.Context()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"run": run, "created": created}, nil
+}
+
+func (app *App) mcpAssessmentRunGet(r *http.Request, args map[string]any) (any, error) {
+	service, tenantID, err := app.mcpAssessmentContext(r, args)
+	if err != nil {
+		return nil, err
+	}
+	runID := mcpStringArg(args, "run_id")
+	if runID == "" {
+		return nil, fmt.Errorf("%w: run_id is required", complianceassessment.ErrInvalidResult)
+	}
+	run, err := service.GetRun(r.Context(), tenantID, runID)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"run": run, "terminal": complianceassessment.AgentRunTerminal(run.State), "results_available": run.State == complianceassessment.RunComplete}, nil
+}
+
+func (app *App) mcpAssessmentResultsList(r *http.Request, args map[string]any) (any, error) {
+	service, tenantID, err := app.mcpAssessmentContext(r, args)
+	if err != nil {
+		return nil, err
+	}
+	afterSequence, err := mcpAssessmentOptionalUint32Arg(args, "after_sequence")
+	if err != nil {
+		return nil, err
+	}
+	limit, err := mcpBoundedLimit(args, "limit", 25, 100)
+	if err != nil {
+		return nil, err
+	}
+	verified, err := service.VerifiedResultsPage(r.Context(), tenantID, mcpStringArg(args, "run_id"), afterSequence, uint32(limit), mcpStringArg(args, "expected_previous_digest"))
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"run_id": verified.Run.ID, "state": verified.Run.State, "result_count": verified.Run.ResultCount,
+		"input_hash": verified.Run.InputHash, "automated_result_hash": verified.Run.AutomatedResultHash,
+		"chunks": verified.Page.Chunks, "next_sequence": verified.Page.NextSequence, "has_more": verified.Page.HasMore,
+		"verification": verified.Verification, "metadata": mcpResponseMetadata(limit, int(verified.Verification.ResultCount), nil),
+	}, nil
+}
+
+func (app *App) mcpAssessmentRunDiff(r *http.Request, args map[string]any) (any, error) {
+	service, tenantID, err := app.mcpAssessmentContext(r, args)
+	if err != nil {
+		return nil, err
+	}
+	diff, err := service.DiffRunsForAgent(r.Context(), tenantID, mcpStringArg(args, "run_id"), mcpStringArg(args, "baseline_run_id"), complianceassessment.DefaultAgentResultBound)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"run_id": diff.Run.ID, "baseline_run_id": diff.Baseline.ID,
+		"current_result_hash": diff.Run.AutomatedResultHash, "baseline_result_hash": diff.Baseline.AutomatedResultHash,
+		"current_verification": diff.CurrentVerification, "baseline_verification": diff.BaselineVerification, "diff": diff.Diff,
+	}, nil
+}
+
+func (app *App) mcpAssessmentResultExplain(r *http.Request, args map[string]any) (any, error) {
+	service, tenantID, err := app.mcpAssessmentContext(r, args)
+	if err != nil {
+		return nil, err
+	}
+	run, result, verification, err := service.FindVerifiedResult(r.Context(), tenantID, mcpStringArg(args, "run_id"), mcpStringArg(args, "result_id"), complianceassessment.DefaultAgentResultBound)
+	if err != nil {
+		return nil, err
+	}
+	partialErrors := []string{}
+	evidence := make([]any, 0, len(result.EvidenceIDs))
+	findings := make([]any, 0, len(result.FindingIDs))
+	handoffs := make([]map[string]any, 0, len(result.EvidenceIDs)+len(result.FindingIDs)+len(result.SourceRuntimeIDs))
+	for _, id := range boundedAssessmentRefs(result.EvidenceIDs, 20) {
+		value, getErr := app.mcpGetEvidence(r, map[string]any{"evidence_id": id})
+		if getErr != nil {
+			partialErrors = append(partialErrors, "evidence "+id+": "+safeMCPToolError(getErr))
+		} else {
+			evidence = append(evidence, value)
+		}
+		handoffs = append(handoffs, map[string]any{"tool": "cerebro.evidence.get", "arguments": map[string]any{"evidence_id": id}})
+	}
+	for _, id := range boundedAssessmentRefs(result.FindingIDs, 20) {
+		value, getErr := app.mcpGetFinding(r, map[string]any{"finding_id": id})
+		if getErr != nil {
+			partialErrors = append(partialErrors, "finding "+id+": "+safeMCPToolError(getErr))
+		} else {
+			findings = append(findings, value)
+		}
+		handoffs = append(handoffs, map[string]any{"tool": "cerebro.findings.get", "arguments": map[string]any{"finding_id": id}})
+	}
+	for _, id := range boundedAssessmentRefs(result.SourceRuntimeIDs, 20) {
+		handoffs = append(handoffs, map[string]any{"tool": "cerebro.runtimes.status", "arguments": map[string]any{"runtime_id": id}})
+	}
+	return map[string]any{
+		"run": run, "result": result, "input_manifest": run.InputManifest, "verification": verification,
+		"evidence": evidence, "findings": findings, "provenance_handoffs": handoffs,
+		"metadata": mcpResponseMetadata(20, len(evidence)+len(findings), partialErrors),
+	}, nil
+}
+
+func (app *App) mcpAssessmentRemediationPropose(r *http.Request, args map[string]any) (any, error) {
+	service, tenantID, err := app.mcpAssessmentContext(r, args)
+	if err != nil {
+		return nil, err
+	}
+	proposal, err := service.ProposeRemediationForAgent(r.Context(), tenantID, mcpStringArg(args, "run_id"), mcpStringArg(args, "result_id"), mcpStringArg(args, "subject_id"), mcpStringArg(args, "source_id"), mcpStringArg(args, "owner_id"), mcpStringArg(args, "due_at"), mcpStringArg(args, "priority"), complianceassessment.DefaultAgentResultBound)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"dry_run": true, "would_mutate": false, "approval_required": true,
+		"required_scope": scopeFindingLifecycleWrite, "operation": "POST /grc/work-items",
+		"ready": proposal.Ready, "missing_fields": proposal.MissingFields, "request": proposal.Request, "verification": proposal.Verification,
+	}, nil
+}
+
+func (app *App) mcpAssessmentService() (*complianceassessment.Service, error) {
+	if app == nil || app.services.assessments == nil {
+		return nil, complianceassessment.ErrResultPagingUnavailable
+	}
+	return app.services.assessments, nil
+}
+
+func (app *App) mcpAssessmentContext(r *http.Request, args map[string]any) (*complianceassessment.Service, string, error) {
+	service, err := app.mcpAssessmentService()
+	if err != nil {
+		return nil, "", err
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), mcpStringArg(args, "tenant_id"))
+	return service, tenantID, err
+}
+
+func mcpAssessmentObjectArg(args map[string]any, key string, target any) error {
+	value, ok := args[key]
+	if !ok || value == nil {
+		return fmt.Errorf("%w: %s is required", complianceassessment.ErrInvalidResult, key)
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("%w: encode %s: %v", complianceassessment.ErrInvalidResult, key, err)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("%w: decode %s: %v", complianceassessment.ErrInvalidResult, key, err)
+	}
+	return nil
+}
+
+func mcpAssessmentTimeArg(args map[string]any, key string) (time.Time, error) {
+	value, err := time.Parse(time.RFC3339Nano, mcpStringArg(args, key))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%w: %s must be an RFC3339 timestamp", complianceassessment.ErrInvalidResult, key)
+	}
+	return value, nil
+}
+
+func mcpAssessmentUint64Arg(args map[string]any, key string) (uint64, error) {
+	value, err := strconv.ParseUint(mcpStringArg(args, key), 10, 64)
+	if err != nil || value == 0 {
+		return 0, fmt.Errorf("%w: %s must be a positive integer", complianceassessment.ErrInvalidResult, key)
+	}
+	return value, nil
+}
+
+func mcpAssessmentOptionalUint32Arg(args map[string]any, key string) (uint32, error) {
+	raw := mcpStringArg(args, key)
+	if raw == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be an unsigned integer", complianceassessment.ErrInvalidResult, key)
+	}
+	return uint32(value), nil
+}
+
+func boundedAssessmentRefs(values []string, limit int) []string {
+	if len(values) > limit {
+		return values[:limit]
+	}
+	return values
+}
+
+func mcpAssessmentTools() []mcpTool {
+	definitions := mcpoperations.AssessmentToolDefinitions()
+	tools := make([]mcpTool, 0, len(definitions))
+	for _, definition := range definitions {
+		annotations := mcpReadOnlyAnnotations(definition.Title)
+		if operation, ok := mcpoperations.Lookup(definition.Name); ok && operation.Behavior == mcpoperations.BehaviorExecute {
+			annotations = mcpWriteAnnotations(definition.Title, definition.Idempotent)
+		}
+		tools = append(tools, mcpTool{Name: definition.Name, Title: definition.Title, Description: definition.Description, InputSchema: definition.InputSchema, OutputSchema: definition.OutputSchema, Annotations: annotations})
+	}
+	return tools
+}

--- a/internal/bootstrap/mcp_assessments_test.go
+++ b/internal/bootstrap/mcp_assessments_test.go
@@ -1,0 +1,181 @@
+package bootstrap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/compliance"
+	"github.com/writer/cerebro/internal/complianceassessment"
+	platformjobs "github.com/writer/cerebro/internal/jobs"
+)
+
+func TestMCPAssessmentExecutionToolsRequireWriteScope(t *testing.T) {
+	readOnly := context.WithValue(context.Background(), authContextKey{}, authContext{principal: authPrincipal{
+		TenantID: "tenant-1", Scopes: []string{scopeCosmoSecurityRead},
+	}})
+	if err := authorizeMCPToolScope(readOnly, "cerebro.assessments.plan.create"); err == nil {
+		t.Fatal("read-only principal authorized to create an assessment plan")
+	}
+	readWrite := context.WithValue(context.Background(), authContextKey{}, authContext{principal: authPrincipal{
+		TenantID: "tenant-1", Scopes: []string{scopeCosmoSecurityRead, scopeGRCInventoryWrite},
+	}})
+	if err := authorizeMCPToolScope(readWrite, "cerebro.assessments.plan.create"); err != nil {
+		t.Fatalf("read-write principal rejected: %v", err)
+	}
+	if err := authorizeMCPToolScope(readOnly, "cerebro.assessments.run.get"); err != nil {
+		t.Fatalf("read-only principal rejected for assessment read: %v", err)
+	}
+}
+
+func TestMCPAssessmentPlanLifecycleAndIdempotentRunRequest(t *testing.T) {
+	store := newAssessmentHTTPStore()
+	app := &App{}
+	app.services.jobs = platformjobs.New(store.a2ATestJobStore)
+	app.services.assessments = complianceassessment.NewAssessmentService(store, &assessmentHTTPLog{}, app.services.jobs, nil)
+	app.services.jobs.WithRunner(complianceassessment.JobKindComplianceAssessment, app.services.assessments.Runner())
+
+	request := mcpAssessmentRequest(t, []string{scopeCosmoSecurityRead, scopeGRCInventoryWrite})
+	created, err := app.mcpAssessmentPlanCreate(request, map[string]any{"plan": mcpAssessmentTestPlan()})
+	if err != nil {
+		t.Fatalf("mcpAssessmentPlanCreate() error = %v", err)
+	}
+	plan := created.(map[string]any)["plan"].(complianceassessment.AssessmentPlanRevision)
+	if plan.Status != complianceassessment.PlanDraft || plan.Version != 1 || plan.TenantID != "tenant-1" {
+		t.Fatalf("created plan = %#v", plan)
+	}
+	published, err := app.mcpAssessmentPlanPublish(request, map[string]any{"plan_id": plan.ID, "expected_version": plan.Version})
+	if err != nil {
+		t.Fatalf("mcpAssessmentPlanPublish() error = %v", err)
+	}
+	plan = published.(map[string]any)["plan"].(complianceassessment.AssessmentPlanRevision)
+	if plan.Status != complianceassessment.PlanPublished || plan.Version != 2 {
+		t.Fatalf("published plan = %#v", plan)
+	}
+
+	args := map[string]any{
+		"plan_revision_id": plan.RevisionID, "period_start": "2026-07-01T00:00:00Z", "period_end": "2026-07-15T00:00:00Z",
+		"idempotency_key": "agent-assessment-1",
+	}
+	first, err := app.mcpAssessmentRunRequest(request, args)
+	if err != nil {
+		t.Fatalf("mcpAssessmentRunRequest() error = %v", err)
+	}
+	second, err := app.mcpAssessmentRunRequest(request, args)
+	if err != nil {
+		t.Fatalf("replayed mcpAssessmentRunRequest() error = %v", err)
+	}
+	firstRun := first.(map[string]any)["run"].(complianceassessment.AssessmentRun)
+	secondRun := second.(map[string]any)["run"].(complianceassessment.AssessmentRun)
+	if !first.(map[string]any)["created"].(bool) || second.(map[string]any)["created"].(bool) || firstRun.ID != secondRun.ID {
+		t.Fatalf("idempotent runs = first %#v second %#v", first, second)
+	}
+}
+
+func TestMCPAssessmentResultsDiffExplainAndRemediationProposal(t *testing.T) {
+	store := newAssessmentHTTPStore()
+	app := &App{}
+	app.services.assessments = complianceassessment.NewAssessmentService(store, &assessmentHTTPLog{}, nil, nil)
+	request := mcpAssessmentRequest(t, []string{scopeCosmoSecurityRead})
+
+	baselineResult := mcpAssessmentTestResult("result-baseline", "objective-1", complianceassessment.OutcomeNotSatisfied)
+	currentResult := mcpAssessmentTestResult("result-current", "objective-1", complianceassessment.OutcomeIndeterminate)
+	baselineChunk := mcpAssessmentTestChunk(t, "run-baseline", baselineResult)
+	currentChunk := mcpAssessmentTestChunk(t, "run-current", currentResult)
+	store.mu.Lock()
+	store.runs[assessmentHTTPKey("tenant-1", "run-baseline")] = complianceassessment.AssessmentRun{
+		ID: "run-baseline", TenantID: "tenant-1", State: complianceassessment.RunComplete,
+		ProgramID: "program-1", ScopeRevisionID: "scope-1", ResultCount: 1, AutomatedResultHash: "sha256:baseline",
+	}
+	store.runs[assessmentHTTPKey("tenant-1", "run-current")] = complianceassessment.AssessmentRun{
+		ID: "run-current", TenantID: "tenant-1", State: complianceassessment.RunComplete,
+		ProgramID: "program-1", ScopeRevisionID: "scope-1", BaselineRunID: "run-baseline",
+		ResultCount: 1, AutomatedResultHash: "sha256:current", InputHash: "sha256:input",
+	}
+	store.chunks[assessmentHTTPKey("tenant-1", "run-baseline")] = []complianceassessment.ResultChunk{baselineChunk}
+	store.chunks[assessmentHTTPKey("tenant-1", "run-current")] = []complianceassessment.ResultChunk{currentChunk}
+	store.mu.Unlock()
+
+	listed, err := app.mcpAssessmentResultsList(request, map[string]any{"run_id": "run-current", "limit": 1})
+	if err != nil {
+		t.Fatalf("mcpAssessmentResultsList() error = %v", err)
+	}
+	verification := listed.(map[string]any)["verification"].(complianceassessment.ResultPageVerification)
+	if !verification.Verified || verification.ResultCount != 1 || verification.NextPreviousDigest != currentChunk.Digest {
+		t.Fatalf("verification = %#v", verification)
+	}
+
+	diff, err := app.mcpAssessmentRunDiff(request, map[string]any{"run_id": "run-current"})
+	if err != nil {
+		t.Fatalf("mcpAssessmentRunDiff() error = %v", err)
+	}
+	diffBody := diff.(map[string]any)["diff"].(complianceassessment.AgentResultDiff)
+	if len(diffBody.Changed) != 1 || len(diffBody.Added) != 0 || len(diffBody.Removed) != 0 {
+		t.Fatalf("diff = %#v", diffBody)
+	}
+
+	explained, err := app.mcpAssessmentResultExplain(request, map[string]any{"run_id": "run-current", "result_id": "result-current"})
+	if err != nil {
+		t.Fatalf("mcpAssessmentResultExplain() error = %v", err)
+	}
+	if explained.(map[string]any)["result"].(complianceassessment.ObjectiveResult).ID != "result-current" {
+		t.Fatalf("explanation = %#v", explained)
+	}
+
+	proposal, err := app.mcpAssessmentRemediationPropose(request, map[string]any{"run_id": "run-current", "result_id": "result-current"})
+	if err != nil {
+		t.Fatalf("mcpAssessmentRemediationPropose() error = %v", err)
+	}
+	proposalBody := proposal.(map[string]any)
+	if proposalBody["would_mutate"] != false || proposalBody["approval_required"] != true || proposalBody["ready"] != false {
+		t.Fatalf("proposal = %#v", proposalBody)
+	}
+}
+
+func mcpAssessmentRequest(t *testing.T, scopes []string) *http.Request {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, mcpEndpointPath, nil)
+	return request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{principal: authPrincipal{
+		Name: "assessment-agent", TenantID: "tenant-1", Scopes: scopes,
+	}}))
+}
+
+func mcpAssessmentTestPlan() complianceassessment.AssessmentPlanRevision {
+	return complianceassessment.AssessmentPlanRevision{
+		TenantID: "tenant-1", Name: "Access review",
+		Scope: complianceassessment.PlanScope{ProgramID: "program-1", ScopeRevisionID: "scope-1", ImplementationRevisions: []string{"implementation-1"}, ObjectiveIDs: []string{"objective-1"}},
+		Execution: complianceassessment.PlanExecution{
+			Methods: []string{"automated_test"}, Depth: "moderate", CoverageTarget: "complete", AssuranceTarget: "high",
+			Tasks:          []complianceassessment.PlanTask{{ID: "task-1", ObjectiveID: "objective-1", ControlRef: compliance.ControlRef{FrameworkID: "framework-1", ControlID: "control-1"}, Kind: complianceassessment.PlanTaskKindFindingEvaluation, RuleID: "rule-1", RuntimeIDs: []string{"runtime-1"}, MaxAge: "24h", EvaluationMode: complianceassessment.EvaluationModePointInTime}},
+			OrderedTaskIDs: []string{"task-1"}, CancellationRule: "stop_after_checkpoint",
+		},
+		Governance: complianceassessment.PlanGovernance{OwnerID: "owner-1", ApproverIDs: []string{"approver-1"}, RulesOfEngagement: "Read source records only."},
+	}
+}
+
+func mcpAssessmentTestResult(id, objectiveID string, outcome complianceassessment.AutomatedOutcome) complianceassessment.ObjectiveResult {
+	return complianceassessment.ObjectiveResult{
+		ID: id, ObjectiveID: objectiveID, ControlRef: compliance.ControlRef{FrameworkID: "framework-1", ControlID: "control-1"},
+		ScopeState: complianceassessment.ScopeInScope, AutomatedOutcome: outcome,
+		DesignState: complianceassessment.DesignUnknown, OperatingEffectivenessState: complianceassessment.OperatingUnknown,
+		EvidenceState: complianceassessment.EvidenceIncomplete, DispositionState: complianceassessment.DispositionNone,
+		Assurance: complianceassessment.AssuranceLow, AuditorState: complianceassessment.AuditorNotReviewed,
+		ReasonCodes: []complianceassessment.ReasonCode{complianceassessment.ReasonCoverageIncomplete}, NextActions: []complianceassessment.NextAction{complianceassessment.ActionCollectEvidence},
+		EvaluatorRevision: "evaluator-v1", EvaluatedAt: time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func mcpAssessmentTestChunk(t *testing.T, runID string, result complianceassessment.ObjectiveResult) complianceassessment.ResultChunk {
+	t.Helper()
+	results := []complianceassessment.ObjectiveResult{result}
+	digest, err := complianceassessment.CanonicalResultChunkDigest("", results)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return complianceassessment.ResultChunk{
+		RunID: runID, Sequence: 1, FirstResultID: result.ID, LastResultID: result.ID, Count: 1,
+		Digest: digest, Results: results,
+	}
+}

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -17,6 +17,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/mcpoperations"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
@@ -221,8 +222,10 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 			}
 		}
 		annotations := tool["annotations"].(map[string]any)
-		if annotations["readOnlyHint"] != true {
-			t.Fatalf("tool missing readOnlyHint annotation: %#v", item)
+		operation, known := mcpoperations.Lookup(name)
+		expectedReadOnly := !known || operation.Behavior != mcpoperations.BehaviorExecute
+		if annotations["readOnlyHint"] != expectedReadOnly {
+			t.Fatalf("%s readOnlyHint = %#v, want %v", name, annotations["readOnlyHint"], expectedReadOnly)
 		}
 		if strings.HasSuffix(name, ".propose") {
 			inputSchema := tool["inputSchema"].(map[string]any)
@@ -570,6 +573,15 @@ var mcpToolDomainSurfaceContracts = map[string]mcpToolDomainSurfaceContract{
 	"cerebro.agent.work.contract":             {Markers: []string{"agent-work-ledger"}},
 	"cerebro.graph.reason":                    {Markers: []string{"POST /api/v1/agent-platform/graph/reason"}},
 	"cerebro.investigation.context":           {Markers: []string{"GET /findings/{findingID}", "GET /source-runtimes/{runtimeID}/finding-evidence", "GET /platform/graph/neighborhood"}},
+	"cerebro.assessments.plan.create":         {Markers: []string{"POST /grc/assessment-plans"}},
+	"cerebro.assessments.plan.publish":        {Markers: []string{"POST /grc/assessment-plans/{planID}/publish"}},
+	"cerebro.assessments.plan.get":            {Markers: []string{"GET /grc/assessment-plans/{planID}"}},
+	"cerebro.assessments.run.request":         {Markers: []string{"POST /grc/assessment-runs"}},
+	"cerebro.assessments.run.get":             {Markers: []string{"GET /grc/assessment-runs/{runID}"}},
+	"cerebro.assessments.results.list":        {Markers: []string{"GET /grc/assessment-runs/{runID}/results"}},
+	"cerebro.assessments.run.diff":            {Markers: []string{"GET /grc/assessment-runs/{runID}/results"}},
+	"cerebro.assessments.result.explain":      {Markers: []string{"GET /grc/assessment-runs/{runID}/results", "GET /finding-evidence/{evidenceID}"}},
+	"cerebro.assessments.remediation.propose": {Markers: []string{"POST /grc/work-items"}},
 	"cerebro.findings.action.propose":         {Markers: []string{"POST /findings/{findingID}/resolve", "POST /findings/{findingID}/suppress", "POST /findings/{findingID}/notes", "POST /findings/{findingID}/tickets"}},
 	"cerebro.source_runtimes.refresh.propose": {Markers: []string{"POST /source-runtimes/{runtimeID}/sync"}},
 }

--- a/internal/complianceassessment/agent_operations.go
+++ b/internal/complianceassessment/agent_operations.go
@@ -1,0 +1,345 @@
+package complianceassessment
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const DefaultAgentResultBound = 2000
+
+type AgentRunRequest struct {
+	TenantID       string
+	PlanRevisionID string
+	PeriodStart    time.Time
+	PeriodEnd      time.Time
+	BaselineRunID  string
+	IdempotencyKey string
+	ActorID        string
+}
+
+type VerifiedResultPage struct {
+	Run          AssessmentRun          `json:"run"`
+	Page         ResultChunkPage        `json:"page"`
+	Verification ResultPageVerification `json:"verification"`
+}
+
+type VerifiedResultSet struct {
+	Results      []ObjectiveResult      `json:"results"`
+	Verification ResultPageVerification `json:"verification"`
+}
+
+type AgentResultChange struct {
+	ObjectiveID string          `json:"objective_id"`
+	Before      ObjectiveResult `json:"before"`
+	After       ObjectiveResult `json:"after"`
+}
+
+type AgentResultDiff struct {
+	Added          []ObjectiveResult   `json:"added"`
+	Removed        []ObjectiveResult   `json:"removed"`
+	Changed        []AgentResultChange `json:"changed"`
+	UnchangedCount int                 `json:"unchanged_count"`
+}
+
+type AgentRunDiff struct {
+	Run                  AssessmentRun          `json:"run"`
+	Baseline             AssessmentRun          `json:"baseline"`
+	CurrentVerification  ResultPageVerification `json:"current_verification"`
+	BaselineVerification ResultPageVerification `json:"baseline_verification"`
+	Diff                 AgentResultDiff        `json:"diff"`
+}
+
+type AgentRemediationWorkRequest struct {
+	TenantID            string          `json:"tenant_id"`
+	ProgramID           string          `json:"program_id"`
+	ScopeRevisionID     string          `json:"scope_revision_id"`
+	SubjectID           string          `json:"subject_id"`
+	SourceID            string          `json:"source_id,omitempty"`
+	OwnerID             string          `json:"owner_id"`
+	DueAt               string          `json:"due_at"`
+	Priority            string          `json:"priority"`
+	AssessmentRunID     string          `json:"assessment_run_id"`
+	AutomatedResultHash string          `json:"automated_result_hash"`
+	Result              ObjectiveResult `json:"result"`
+}
+
+type AgentRemediationProposal struct {
+	Ready         bool                        `json:"ready"`
+	MissingFields []string                    `json:"missing_fields"`
+	Request       AgentRemediationWorkRequest `json:"request"`
+	Verification  ResultPageVerification      `json:"verification"`
+}
+
+func (s *Service) CreatePlanForAgent(ctx context.Context, tenantID, actorID string, plan AssessmentPlanRevision) (AssessmentPlanRevision, error) {
+	plan.ID = ""
+	plan.TenantID = strings.TrimSpace(tenantID)
+	plan.RevisionID = ""
+	plan.Version = 0
+	plan.PredecessorID = ""
+	plan.Status = PlanDraft
+	plan.ContentDigest = ""
+	plan.CreatedAt = time.Time{}
+	plan.CreatedBy = ""
+	plan.PublishedAt = time.Time{}
+	plan.PublishedBy = ""
+	if err := validateAgentExecutablePlan(plan); err != nil {
+		return AssessmentPlanRevision{}, err
+	}
+	return s.RecordPlan(ctx, plan, actorID, 0)
+}
+
+func (s *Service) PublishPlanForAgent(ctx context.Context, tenantID, planID, actorID string, expectedVersion uint64) (AssessmentPlanRevision, error) {
+	draft, err := s.GetPlan(ctx, tenantID, planID)
+	if err != nil {
+		return AssessmentPlanRevision{}, err
+	}
+	if err := validateAgentExecutablePlan(draft); err != nil {
+		return AssessmentPlanRevision{}, err
+	}
+	return s.PublishPlan(ctx, tenantID, planID, actorID, expectedVersion)
+}
+
+func (s *Service) RequestRunForAgent(ctx context.Context, request AgentRunRequest) (AssessmentRun, bool, error) {
+	plan, err := s.GetPlan(ctx, request.TenantID, request.PlanRevisionID)
+	if err != nil {
+		return AssessmentRun{}, false, err
+	}
+	if err := validateAgentExecutablePlan(plan); err != nil {
+		return AssessmentRun{}, false, err
+	}
+	return s.RequestRun(ctx, RunRequest{
+		TenantID: request.TenantID, PlanRevisionID: request.PlanRevisionID,
+		PeriodStart: request.PeriodStart, PeriodEnd: request.PeriodEnd,
+		BaselineRunID: request.BaselineRunID, IdempotencyKey: request.IdempotencyKey,
+		RequestedBy: request.ActorID,
+	})
+}
+
+func (s *Service) GetCompletedRun(ctx context.Context, tenantID, runID string) (AssessmentRun, error) {
+	run, err := s.GetRun(ctx, tenantID, runID)
+	if err != nil {
+		return AssessmentRun{}, err
+	}
+	if run.State != RunComplete {
+		return AssessmentRun{}, fmt.Errorf("%w: assessment results are available only when the run is complete", ErrAssessmentConflict)
+	}
+	return run, nil
+}
+
+func (s *Service) VerifiedResultsPage(ctx context.Context, tenantID, runID string, afterSequence, limit uint32, expectedPreviousDigest string) (VerifiedResultPage, error) {
+	run, err := s.GetCompletedRun(ctx, tenantID, runID)
+	if err != nil {
+		return VerifiedResultPage{}, err
+	}
+	page, err := s.ListResultChunksPage(ctx, tenantID, runID, afterSequence, limit)
+	if err != nil {
+		return VerifiedResultPage{}, err
+	}
+	verification, err := VerifyResultChunkPage(runID, afterSequence, expectedPreviousDigest, page)
+	if err != nil {
+		return VerifiedResultPage{}, err
+	}
+	return VerifiedResultPage{Run: run, Page: page, Verification: verification}, nil
+}
+
+func (s *Service) CollectVerifiedResults(ctx context.Context, tenantID, runID string, maxResults int) (VerifiedResultSet, error) {
+	if maxResults < 1 {
+		maxResults = DefaultAgentResultBound
+	}
+	run, err := s.GetCompletedRun(ctx, tenantID, runID)
+	if err != nil {
+		return VerifiedResultSet{}, err
+	}
+	results := []ObjectiveResult{}
+	afterSequence := uint32(0)
+	previousDigest := ""
+	combined := ResultPageVerification{Verified: true}
+	for {
+		verified, err := s.VerifiedResultsPage(ctx, tenantID, runID, afterSequence, 100, previousDigest)
+		if err != nil {
+			return VerifiedResultSet{}, err
+		}
+		if combined.ChunkCount == 0 {
+			combined.FirstSequence = verified.Verification.FirstSequence
+		}
+		combined.LastSequence = verified.Verification.LastSequence
+		combined.ChunkCount += verified.Verification.ChunkCount
+		combined.ResultCount += verified.Verification.ResultCount
+		combined.NextPreviousDigest = verified.Verification.NextPreviousDigest
+		for _, chunk := range verified.Page.Chunks {
+			results = append(results, chunk.Results...)
+			if len(results) > maxResults {
+				return VerifiedResultSet{}, fmt.Errorf("%w: assessment has more than %d results; page results instead", ErrInvalidResult, maxResults)
+			}
+		}
+		if !verified.Page.HasMore {
+			break
+		}
+		afterSequence = verified.Page.NextSequence
+		previousDigest = verified.Verification.NextPreviousDigest
+	}
+	if uint64(len(results)) != run.ResultCount {
+		return VerifiedResultSet{}, fmt.Errorf("%w: verified result count does not match the completed run", ErrInvalidResult)
+	}
+	return VerifiedResultSet{Results: results, Verification: combined}, nil
+}
+
+func (s *Service) FindVerifiedResult(ctx context.Context, tenantID, runID, resultID string, maxResults int) (AssessmentRun, ObjectiveResult, ResultPageVerification, error) {
+	resultID = strings.TrimSpace(resultID)
+	if resultID == "" {
+		return AssessmentRun{}, ObjectiveResult{}, ResultPageVerification{}, fmt.Errorf("%w: result_id is required", ErrInvalidResult)
+	}
+	run, err := s.GetCompletedRun(ctx, tenantID, runID)
+	if err != nil {
+		return AssessmentRun{}, ObjectiveResult{}, ResultPageVerification{}, err
+	}
+	set, err := s.CollectVerifiedResults(ctx, tenantID, runID, maxResults)
+	if err != nil {
+		return AssessmentRun{}, ObjectiveResult{}, set.Verification, err
+	}
+	for _, result := range set.Results {
+		if result.ID == resultID {
+			return run, result, set.Verification, nil
+		}
+	}
+	return AssessmentRun{}, ObjectiveResult{}, set.Verification, fmt.Errorf("%w: assessment result %q was not found", ErrInvalidResult, resultID)
+}
+
+func (s *Service) DiffRunsForAgent(ctx context.Context, tenantID, runID, baselineRunID string, maxResults int) (AgentRunDiff, error) {
+	run, err := s.GetCompletedRun(ctx, tenantID, runID)
+	if err != nil {
+		return AgentRunDiff{}, err
+	}
+	baselineRunID = strings.TrimSpace(baselineRunID)
+	if baselineRunID == "" {
+		baselineRunID = strings.TrimSpace(run.BaselineRunID)
+	}
+	if baselineRunID == "" || baselineRunID == run.ID {
+		return AgentRunDiff{}, fmt.Errorf("%w: a different baseline_run_id is required", ErrInvalidResult)
+	}
+	baseline, err := s.GetCompletedRun(ctx, tenantID, baselineRunID)
+	if err != nil {
+		return AgentRunDiff{}, err
+	}
+	currentSet, err := s.CollectVerifiedResults(ctx, tenantID, run.ID, maxResults)
+	if err != nil {
+		return AgentRunDiff{}, err
+	}
+	baselineSet, err := s.CollectVerifiedResults(ctx, tenantID, baseline.ID, maxResults)
+	if err != nil {
+		return AgentRunDiff{}, err
+	}
+	diff, err := diffAgentResults(baselineSet.Results, currentSet.Results)
+	if err != nil {
+		return AgentRunDiff{}, err
+	}
+	return AgentRunDiff{Run: run, Baseline: baseline, CurrentVerification: currentSet.Verification, BaselineVerification: baselineSet.Verification, Diff: diff}, nil
+}
+
+func (s *Service) ProposeRemediationForAgent(ctx context.Context, tenantID, runID, resultID, subjectID, sourceID, ownerID, dueAt, priority string, maxResults int) (AgentRemediationProposal, error) {
+	run, result, verification, err := s.FindVerifiedResult(ctx, tenantID, runID, resultID, maxResults)
+	if err != nil {
+		return AgentRemediationProposal{}, err
+	}
+	if result.AutomatedOutcome == OutcomeSatisfied || result.AutomatedOutcome == OutcomeNotAssessed {
+		return AgentRemediationProposal{}, fmt.Errorf("%w: the assessment result does not support remediation work", ErrInvalidResult)
+	}
+	request := AgentRemediationWorkRequest{
+		TenantID: tenantID, ProgramID: run.ProgramID, ScopeRevisionID: run.ScopeRevisionID,
+		SubjectID: strings.TrimSpace(subjectID), SourceID: strings.TrimSpace(sourceID),
+		OwnerID: strings.TrimSpace(ownerID), DueAt: strings.TrimSpace(dueAt), Priority: strings.TrimSpace(priority),
+		AssessmentRunID: run.ID, AutomatedResultHash: run.AutomatedResultHash, Result: result,
+	}
+	missing := []string{}
+	for name, value := range map[string]string{"subject_id": request.SubjectID, "owner_id": request.OwnerID, "due_at": request.DueAt, "priority": request.Priority} {
+		if value == "" {
+			missing = append(missing, name)
+		}
+	}
+	if request.SourceID == "" && len(result.SourceRuntimeIDs) == 0 {
+		missing = append(missing, "source_id")
+	}
+	if request.DueAt != "" {
+		if _, err := time.Parse(time.RFC3339Nano, request.DueAt); err != nil {
+			return AgentRemediationProposal{}, fmt.Errorf("%w: due_at must be an RFC3339 timestamp", ErrInvalidResult)
+		}
+	}
+	sort.Strings(missing)
+	return AgentRemediationProposal{Ready: len(missing) == 0, MissingFields: missing, Request: request, Verification: verification}, nil
+}
+
+func AgentRunTerminal(state string) bool {
+	switch state {
+	case RunComplete, RunFailed, RunCancelled, RunSuperseded:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateAgentExecutablePlan(plan AssessmentPlanRevision) error {
+	for _, task := range plan.Execution.Tasks {
+		if task.Kind != PlanTaskKindFindingEvaluation {
+			return fmt.Errorf("%w: assessment task %q uses unsupported kind %q", ErrInvalidResult, task.ID, task.Kind)
+		}
+	}
+	return nil
+}
+
+func diffAgentResults(baseline, current []ObjectiveResult) (AgentResultDiff, error) {
+	baselineByObjective := make(map[string]ObjectiveResult, len(baseline))
+	currentByObjective := make(map[string]ObjectiveResult, len(current))
+	for _, result := range baseline {
+		if _, exists := baselineByObjective[result.ObjectiveID]; exists {
+			return AgentResultDiff{}, fmt.Errorf("%w: baseline contains duplicate objective %q", ErrInvalidResult, result.ObjectiveID)
+		}
+		baselineByObjective[result.ObjectiveID] = result
+	}
+	for _, result := range current {
+		if _, exists := currentByObjective[result.ObjectiveID]; exists {
+			return AgentResultDiff{}, fmt.Errorf("%w: current run contains duplicate objective %q", ErrInvalidResult, result.ObjectiveID)
+		}
+		currentByObjective[result.ObjectiveID] = result
+	}
+	keys := make([]string, 0, len(baselineByObjective)+len(currentByObjective))
+	seen := map[string]struct{}{}
+	for key := range baselineByObjective {
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	for key := range currentByObjective {
+		if _, ok := seen[key]; !ok {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	diff := AgentResultDiff{Added: []ObjectiveResult{}, Removed: []ObjectiveResult{}, Changed: []AgentResultChange{}}
+	for _, key := range keys {
+		before, hadBefore := baselineByObjective[key]
+		after, hasAfter := currentByObjective[key]
+		switch {
+		case !hadBefore:
+			diff.Added = append(diff.Added, after)
+		case !hasAfter:
+			diff.Removed = append(diff.Removed, before)
+		default:
+			beforeDigest, err := CanonicalResultDigest(before)
+			if err != nil {
+				return AgentResultDiff{}, err
+			}
+			afterDigest, err := CanonicalResultDigest(after)
+			if err != nil {
+				return AgentResultDiff{}, err
+			}
+			if beforeDigest == afterDigest {
+				diff.UnchangedCount++
+			} else {
+				diff.Changed = append(diff.Changed, AgentResultChange{ObjectiveID: key, Before: before, After: after})
+			}
+		}
+	}
+	return diff, nil
+}

--- a/internal/complianceassessment/verification.go
+++ b/internal/complianceassessment/verification.go
@@ -61,7 +61,7 @@ func VerifyResultChunkPage(runID string, afterSequence uint32, expectedPreviousD
 			return verification, fmt.Errorf("%w: result chunk %d predecessor digest does not match", ErrInvalidResult, chunk.Sequence)
 		}
 		if err := validateRecoveredResultChunk(chunk); err != nil {
-			return verification, fmt.Errorf("%w: verify result chunk %d: %v", ErrInvalidResult, chunk.Sequence, err)
+			return verification, fmt.Errorf("%w: verify result chunk %d: %w", ErrInvalidResult, chunk.Sequence, err)
 		}
 		if index == 0 {
 			verification.FirstSequence = chunk.Sequence

--- a/internal/complianceassessment/verification.go
+++ b/internal/complianceassessment/verification.go
@@ -1,0 +1,82 @@
+package complianceassessment
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CanonicalResultChunkDigest returns the digest used by persisted result
+// chunks. It is exported so transports and SDK conformance tests can verify
+// the exact canonical bytes without reimplementing the encoding contract.
+func CanonicalResultChunkDigest(previousDigest string, results []ObjectiveResult) (string, error) {
+	payload, err := canonicalBytes(results)
+	if err != nil {
+		return "", err
+	}
+	return digestResultChunkPayload(strings.TrimSpace(previousDigest), payload), nil
+}
+
+// ResultPageVerification records the independently checked boundaries of one
+// paged result response. Callers pass NextPreviousDigest into the next page to
+// verify the chain across transport boundaries.
+type ResultPageVerification struct {
+	Verified               bool   `json:"verified"`
+	ChunkCount             uint32 `json:"chunk_count"`
+	ResultCount            uint64 `json:"result_count"`
+	FirstSequence          uint32 `json:"first_sequence,omitempty"`
+	LastSequence           uint32 `json:"last_sequence,omitempty"`
+	ExpectedPreviousDigest string `json:"expected_previous_digest,omitempty"`
+	NextPreviousDigest     string `json:"next_previous_digest,omitempty"`
+}
+
+// VerifyResultChunkPage recomputes each chunk digest, validates result
+// boundaries, and verifies the predecessor chain for a page returned after the
+// supplied sequence.
+func VerifyResultChunkPage(runID string, afterSequence uint32, expectedPreviousDigest string, page ResultChunkPage) (ResultPageVerification, error) {
+	verification := ResultPageVerification{
+		ExpectedPreviousDigest: strings.TrimSpace(expectedPreviousDigest),
+	}
+	if afterSequence == 0 && verification.ExpectedPreviousDigest != "" {
+		return verification, fmt.Errorf("%w: the first result page cannot have a predecessor digest", ErrInvalidResult)
+	}
+	if len(page.Chunks) == 0 {
+		if page.HasMore || page.NextSequence != 0 {
+			return verification, fmt.Errorf("%w: an empty result page cannot advertise a continuation", ErrInvalidResult)
+		}
+		verification.Verified = true
+		verification.NextPreviousDigest = verification.ExpectedPreviousDigest
+		return verification, nil
+	}
+
+	expectedSequence := afterSequence + 1
+	previousDigest := verification.ExpectedPreviousDigest
+	for index, chunk := range page.Chunks {
+		if strings.TrimSpace(chunk.RunID) != strings.TrimSpace(runID) {
+			return verification, fmt.Errorf("%w: result chunk run does not match the requested run", ErrInvalidResult)
+		}
+		if chunk.Sequence != expectedSequence {
+			return verification, fmt.Errorf("%w: result chunk sequence %d does not follow %d", ErrInvalidResult, chunk.Sequence, expectedSequence-1)
+		}
+		if strings.TrimSpace(chunk.PreviousDigest) != previousDigest {
+			return verification, fmt.Errorf("%w: result chunk %d predecessor digest does not match", ErrInvalidResult, chunk.Sequence)
+		}
+		if err := validateRecoveredResultChunk(chunk); err != nil {
+			return verification, fmt.Errorf("%w: verify result chunk %d: %v", ErrInvalidResult, chunk.Sequence, err)
+		}
+		if index == 0 {
+			verification.FirstSequence = chunk.Sequence
+		}
+		verification.LastSequence = chunk.Sequence
+		verification.ChunkCount++
+		verification.ResultCount += uint64(chunk.Count)
+		previousDigest = strings.TrimSpace(chunk.Digest)
+		expectedSequence++
+	}
+	if page.HasMore && page.NextSequence != verification.LastSequence {
+		return verification, fmt.Errorf("%w: next sequence does not match the verified page boundary", ErrInvalidResult)
+	}
+
+	verification.Verified = true
+	verification.NextPreviousDigest = previousDigest
+	return verification, nil
+}

--- a/internal/complianceassessment/verification_test.go
+++ b/internal/complianceassessment/verification_test.go
@@ -51,6 +51,7 @@ func verificationTestChunk(t *testing.T, runID string, sequence uint32, previous
 	return ResultChunk{
 		RunID: runID, Sequence: sequence,
 		FirstResultID: results[0].ID, LastResultID: results[len(results)-1].ID,
+		// #nosec G115 -- every test fixture in this helper contains one or two results.
 		Count: uint32(len(results)), PreviousDigest: previous,
 		Digest: digest, Results: results,
 	}

--- a/internal/complianceassessment/verification_test.go
+++ b/internal/complianceassessment/verification_test.go
@@ -1,0 +1,57 @@
+package complianceassessment
+
+import "testing"
+
+func TestVerifyResultChunkPageChecksPayloadAndContinuation(t *testing.T) {
+	firstResult := validObjectiveResult()
+	secondResult := validObjectiveResult()
+	secondResult.ID = "assessment-result-00000000000000000000000000000002"
+	secondResult.ObjectiveID = "objective-2"
+	first := verificationTestChunk(t, "run-1", 1, "", []ObjectiveResult{firstResult})
+	second := verificationTestChunk(t, "run-1", 2, first.Digest, []ObjectiveResult{secondResult})
+
+	verification, err := VerifyResultChunkPage("run-1", 0, "", ResultChunkPage{
+		Chunks: []ResultChunk{first, second},
+	})
+	if err != nil {
+		t.Fatalf("VerifyResultChunkPage() error = %v", err)
+	}
+	if !verification.Verified || verification.ChunkCount != 2 || verification.ResultCount != 2 || verification.NextPreviousDigest != second.Digest {
+		t.Fatalf("VerifyResultChunkPage() = %#v", verification)
+	}
+
+	second.Results[0].ID = "tampered"
+	if _, err := VerifyResultChunkPage("run-1", 1, first.Digest, ResultChunkPage{Chunks: []ResultChunk{second}}); err == nil {
+		t.Fatal("VerifyResultChunkPage() accepted a tampered result payload")
+	}
+}
+
+func TestVerifyResultChunkPageRejectsBrokenSequenceAndPredecessor(t *testing.T) {
+	chunk := verificationTestChunk(t, "run-1", 2, "sha256:previous", []ObjectiveResult{validObjectiveResult()})
+	if _, err := VerifyResultChunkPage("run-1", 0, "", ResultChunkPage{Chunks: []ResultChunk{chunk}}); err == nil {
+		t.Fatal("VerifyResultChunkPage() accepted a missing first chunk")
+	}
+	if _, err := VerifyResultChunkPage("run-1", 1, "sha256:other", ResultChunkPage{Chunks: []ResultChunk{chunk}}); err == nil {
+		t.Fatal("VerifyResultChunkPage() accepted a broken predecessor")
+	}
+}
+
+func TestVerifyResultChunkPageRejectsEmptyContinuation(t *testing.T) {
+	if _, err := VerifyResultChunkPage("run-1", 0, "", ResultChunkPage{HasMore: true, NextSequence: 1}); err == nil {
+		t.Fatal("VerifyResultChunkPage() accepted an empty page with a continuation")
+	}
+}
+
+func verificationTestChunk(t *testing.T, runID string, sequence uint32, previous string, results []ObjectiveResult) ResultChunk {
+	t.Helper()
+	digest, err := CanonicalResultChunkDigest(previous, results)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ResultChunk{
+		RunID: runID, Sequence: sequence,
+		FirstResultID: results[0].ID, LastResultID: results[len(results)-1].ID,
+		Count: uint32(len(results)), PreviousDigest: previous,
+		Digest: digest, Results: results,
+	}
+}

--- a/internal/mcpoperations/assessments.go
+++ b/internal/mcpoperations/assessments.go
@@ -1,0 +1,82 @@
+package mcpoperations
+
+type AssessmentToolDefinition struct {
+	Name         string
+	Title        string
+	Description  string
+	InputSchema  InputSchema
+	OutputSchema OutputSchema
+	Idempotent   bool
+}
+
+func AssessmentToolDefinitions() []AssessmentToolDefinition {
+	tenant := map[string]any{"type": "string", "description": "Tenant scope. Omit only when the authenticated principal is bound to one tenant."}
+	identifier := func(description string) map[string]any {
+		return map[string]any{"type": "string", "description": description}
+	}
+	output := func(properties map[string]any) OutputSchema { return ResponseSchema(Properties(properties)) }
+	return []AssessmentToolDefinition{
+		{
+			Name: "cerebro.assessments.plan.create", Title: "Create Assessment Plan",
+			Description:  "Create one tenant-scoped assessment plan draft. Requires cerebro.cosmo.security.read and cerebro.grc.inventory.write.",
+			InputSchema:  objectSchema(map[string]any{"plan": map[string]any{"type": "object", "description": "Typed AssessmentPlanRevision content. Server-owned identity, revision, status, digest, actor, and timestamp fields are ignored.", "additionalProperties": true}}, []string{"plan"}),
+			OutputSchema: output(map[string]any{"plan": map[string]any{"type": "object"}, "created": map[string]any{"type": "boolean"}}),
+		},
+		{
+			Name: "cerebro.assessments.plan.publish", Title: "Publish Assessment Plan",
+			Description:  "Publish one validated assessment plan revision using optimistic concurrency. Requires cerebro.cosmo.security.read and cerebro.grc.inventory.write.",
+			InputSchema:  objectSchema(map[string]any{"tenant_id": tenant, "plan_id": identifier("Assessment plan ID."), "expected_version": map[string]any{"type": "integer", "minimum": 1}}, []string{"plan_id", "expected_version"}),
+			OutputSchema: output(map[string]any{"plan": map[string]any{"type": "object"}, "published": map[string]any{"type": "boolean"}}),
+		},
+		{
+			Name: "cerebro.assessments.plan.get", Title: "Get Assessment Plan", Description: "Read one tenant-scoped assessment plan revision by ID.",
+			InputSchema:  objectSchema(map[string]any{"tenant_id": tenant, "plan_id": identifier("Assessment plan ID or revision ID.")}, []string{"plan_id"}),
+			OutputSchema: output(map[string]any{"plan": map[string]any{"type": "object"}}), Idempotent: true,
+		},
+		{
+			Name: "cerebro.assessments.run.request", Title: "Request Assessment Run",
+			Description: "Request a recoverable assessment run for a published plan. Reusing the same idempotency key and body returns the existing run. Requires cerebro.cosmo.security.read and cerebro.grc.inventory.write.",
+			InputSchema: objectSchema(map[string]any{
+				"tenant_id": tenant, "plan_revision_id": identifier("Published assessment plan revision ID."),
+				"period_start": map[string]any{"type": "string", "format": "date-time"}, "period_end": map[string]any{"type": "string", "format": "date-time"},
+				"baseline_run_id": identifier("Optional completed run to compare after execution."), "idempotency_key": identifier("Caller-owned retry key."),
+			}, []string{"plan_revision_id", "period_start", "period_end", "idempotency_key"}),
+			OutputSchema: output(map[string]any{"run": map[string]any{"type": "object"}, "created": map[string]any{"type": "boolean"}}), Idempotent: true,
+		},
+		{
+			Name: "cerebro.assessments.run.get", Title: "Get Assessment Run", Description: "Read one assessment run, including its state, pinned input manifest, hashes, and terminal-result availability.",
+			InputSchema:  objectSchema(map[string]any{"tenant_id": tenant, "run_id": identifier("Assessment run ID.")}, []string{"run_id"}),
+			OutputSchema: output(map[string]any{"run": map[string]any{"type": "object"}, "terminal": map[string]any{"type": "boolean"}, "results_available": map[string]any{"type": "boolean"}}), Idempotent: true,
+		},
+		{
+			Name: "cerebro.assessments.results.list", Title: "List Verified Assessment Results",
+			Description: "Read one bounded result page and independently verify its sequence, boundaries, payload digests, and predecessor chain. Pass verification.next_previous_digest into expected_previous_digest for the next page.",
+			InputSchema: objectSchema(map[string]any{
+				"tenant_id": tenant, "run_id": identifier("Completed assessment run ID."),
+				"after_sequence": map[string]any{"type": "integer", "minimum": 0}, "expected_previous_digest": identifier("Verified digest from the preceding page."),
+				"limit": limitSchema(100, "result chunks"),
+			}, []string{"run_id"}),
+			OutputSchema: output(map[string]any{"chunks": map[string]any{"type": "array"}, "verification": map[string]any{"type": "object"}, "has_more": map[string]any{"type": "boolean"}}), Idempotent: true,
+		},
+		{
+			Name: "cerebro.assessments.run.diff", Title: "Compare Assessment Runs", Description: "Verify and compare one completed run with its explicit or pinned baseline. Fails closed when the bounded comparison cannot cover every result.",
+			InputSchema:  objectSchema(map[string]any{"tenant_id": tenant, "run_id": identifier("Completed current assessment run ID."), "baseline_run_id": identifier("Optional completed baseline run ID; defaults to the run's pinned baseline.")}, []string{"run_id"}),
+			OutputSchema: output(map[string]any{"diff": map[string]any{"type": "object"}, "current_verification": map[string]any{"type": "object"}, "baseline_verification": map[string]any{"type": "object"}}), Idempotent: true,
+		},
+		{
+			Name: "cerebro.assessments.result.explain", Title: "Explain Assessment Result", Description: "Verify one completed run, return the selected objective result and pinned manifest, resolve bounded evidence and finding records, and provide exact provenance follow-up tool calls.",
+			InputSchema:  objectSchema(map[string]any{"tenant_id": tenant, "run_id": identifier("Completed assessment run ID."), "result_id": identifier("Objective result ID.")}, []string{"run_id", "result_id"}),
+			OutputSchema: output(map[string]any{"run": map[string]any{"type": "object"}, "result": map[string]any{"type": "object"}, "verification": map[string]any{"type": "object"}, "evidence": map[string]any{"type": "array"}, "findings": map[string]any{"type": "array"}, "provenance_handoffs": map[string]any{"type": "array"}}), Idempotent: true,
+		},
+		{
+			Name: "cerebro.assessments.remediation.propose", Title: "Propose Assessment Remediation", Description: "Build a non-mutating, approval-gated work request from one verified non-passing assessment result. The tool never creates work or executes remediation.",
+			InputSchema: objectSchema(map[string]any{
+				"dry_run":   map[string]any{"type": "boolean", "const": true},
+				"tenant_id": tenant, "run_id": identifier("Completed assessment run ID."), "result_id": identifier("Non-passing objective result ID."),
+				"subject_id": identifier("Stable affected subject ID."), "source_id": identifier("Optional source owner ID."), "owner_id": identifier("Work owner ID."),
+				"due_at": map[string]any{"type": "string", "format": "date-time"}, "priority": map[string]any{"type": "string"},
+			}, []string{"dry_run", "run_id", "result_id"}),
+			OutputSchema: output(map[string]any{"dry_run": map[string]any{"type": "boolean"}, "ready": map[string]any{"type": "boolean"}, "request": map[string]any{"type": "object"}, "verification": map[string]any{"type": "object"}}), Idempotent: true,
+		},
+	}
+}

--- a/internal/mcpoperations/catalog.go
+++ b/internal/mcpoperations/catalog.go
@@ -6,13 +6,17 @@ import (
 	"strings"
 )
 
-const ScopeSecurityRead = "cerebro.cosmo.security.read"
+const (
+	ScopeSecurityRead      = "cerebro.cosmo.security.read"
+	ScopeGRCInventoryWrite = "cerebro.grc.inventory.write"
+)
 
 type Behavior string
 
 const (
 	BehaviorRead    Behavior = "read"
 	BehaviorPropose Behavior = "propose"
+	BehaviorExecute Behavior = "execute"
 )
 
 type Classification string
@@ -71,6 +75,15 @@ func buildOperationRegistry() map[string]Operation {
 		expertRead("cerebro.agent.work.contract", "agent-platform", "agent work contract"),
 		expertRead("cerebro.graph.reason", "graph-agent", "graph reasoning trace"),
 		expertRead("cerebro.investigation.context", "findings", "finding investigation context"),
+		expertExecute("cerebro.assessments.plan.create", "compliance-assessment", "persisted assessment plan draft"),
+		expertExecute("cerebro.assessments.plan.publish", "compliance-assessment", "published assessment plan revision"),
+		expertRead("cerebro.assessments.plan.get", "compliance-assessment", "assessment plan revision"),
+		expertExecute("cerebro.assessments.run.request", "compliance-assessment", "idempotent assessment run request"),
+		expertRead("cerebro.assessments.run.get", "compliance-assessment", "assessment run with pinned input manifest"),
+		expertRead("cerebro.assessments.results.list", "compliance-assessment", "verified assessment result page"),
+		expertRead("cerebro.assessments.run.diff", "compliance-assessment", "bounded baseline assessment diff"),
+		expertRead("cerebro.assessments.result.explain", "compliance-assessment", "assessment result with evidence and provenance handoffs"),
+		expertPropose("cerebro.assessments.remediation.propose", "compliance-assessment", "approval-gated remediation work proposal"),
 		expertPropose("cerebro.findings.action.propose", "findings", "finding action proposal"),
 		expertPropose("cerebro.source_runtimes.refresh.propose", "source-runtime", "runtime refresh proposal"),
 		taskRead("cerebro.risk.explain", "findings", "task result with finding, evidence, assets, and optional graph context", "explain risk", "investigate finding", "why is this risky", "finding evidence"),
@@ -99,6 +112,12 @@ func expertRead(name string, domain string, response string) Operation {
 
 func expertPropose(name string, domain string, response string) Operation {
 	return operation(name, domain, BehaviorPropose, ClassificationExpert, response, nil)
+}
+
+func expertExecute(name string, domain string, response string) Operation {
+	result := operation(name, domain, BehaviorExecute, ClassificationExpert, response, nil)
+	result.RequiredScopes = []string{ScopeSecurityRead, ScopeGRCInventoryWrite}
+	return result
 }
 
 func operation(name string, domain string, behavior Behavior, classification Classification, response string, terms []string) Operation {
@@ -206,6 +225,8 @@ func ToolsetForName(name string) string {
 		return "findings"
 	case strings.HasPrefix(name, "assets."):
 		return "assets"
+	case strings.HasPrefix(name, "assessments."):
+		return "assessments"
 	case strings.HasPrefix(name, "sources."), strings.HasPrefix(name, "connectors."), strings.HasPrefix(name, "source_runtimes."), strings.HasPrefix(name, "runtimes."), strings.HasPrefix(name, "connector_definitions."):
 		return "operations"
 	case strings.HasPrefix(name, "agent."):

--- a/internal/mcpoperations/catalog_test.go
+++ b/internal/mcpoperations/catalog_test.go
@@ -11,7 +11,7 @@ func TestCatalogOperationsAreCompleteAndSorted(t *testing.T) {
 		if operation.Name == "" || operation.OwnerDomain == "" || operation.ResponseContract == "" {
 			t.Fatalf("operation %d is incomplete: %#v", i, operation)
 		}
-		if operation.Behavior != BehaviorRead && operation.Behavior != BehaviorPropose {
+		if operation.Behavior != BehaviorRead && operation.Behavior != BehaviorPropose && operation.Behavior != BehaviorExecute {
 			t.Fatalf("operation %q behavior = %q", operation.Name, operation.Behavior)
 		}
 		if operation.Classification != ClassificationTask && operation.Classification != ClassificationExpert {
@@ -23,6 +23,28 @@ func TestCatalogOperationsAreCompleteAndSorted(t *testing.T) {
 		if i > 0 && operations[i-1].Name >= operation.Name {
 			t.Fatalf("operations are not strictly sorted: %q before %q", operations[i-1].Name, operation.Name)
 		}
+	}
+}
+
+func TestAssessmentExecutionToolsRequireReadAndWriteScopes(t *testing.T) {
+	for _, name := range []string{
+		"cerebro.assessments.plan.create",
+		"cerebro.assessments.plan.publish",
+		"cerebro.assessments.run.request",
+	} {
+		operation, ok := Lookup(name)
+		if !ok {
+			t.Fatalf("Lookup(%q) missing", name)
+		}
+		if operation.Behavior != BehaviorExecute {
+			t.Fatalf("Lookup(%q).Behavior = %q, want %q", name, operation.Behavior, BehaviorExecute)
+		}
+		if len(operation.RequiredScopes) != 2 || operation.RequiredScopes[0] != ScopeSecurityRead || operation.RequiredScopes[1] != ScopeGRCInventoryWrite {
+			t.Fatalf("Lookup(%q).RequiredScopes = %#v", name, operation.RequiredScopes)
+		}
+	}
+	if got := ToolsetForName("cerebro.assessments.run.get"); got != "assessments" {
+		t.Fatalf("ToolsetForName(assessment) = %q, want assessments", got)
 	}
 }
 

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -108,7 +108,13 @@ import (
 // persistence, projection replay, and invalidation reopening stay behind
 // internal/complianceremediation, while Postgres adaptation stays in the
 // concrete state-store package.
-const bootstrapProductionGoLineBudget = 27684
+// Agent assessment MCP tools add only tool registration, argument decoding,
+// tenant and scope enforcement, safe evidence/finding response composition,
+// and transport metadata. Plan/run semantics, canonical result verification,
+// bounded baseline comparison, and remediation proposal shaping stay in
+// internal/complianceassessment; schemas and tool inventory stay in
+// internal/mcpoperations.
+const bootstrapProductionGoLineBudget = 27982
 
 type bootstrapFileLineCount struct {
 	path  string

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -114,7 +114,7 @@ import (
 // bounded baseline comparison, and remediation proposal shaping stay in
 // internal/complianceassessment; schemas and tool inventory stay in
 // internal/mcpoperations.
-const bootstrapProductionGoLineBudget = 27982
+const bootstrapProductionGoLineBudget = 27987
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Scope

- expose assessment plan creation, publication, idempotent run requests, state monitoring, verified result paging, baseline comparison, result explanation, and remediation proposals through MCP
- enforce tenant binding and separate read/write scopes while reusing the existing append-first assessment service and projection paths
- advertise the assessment contract through A2A discovery and document the agent workflow
- keep result verification, bounded comparisons, and proposal shaping in the assessment domain

## Validation

- `go test ./internal/bootstrap ./internal/agentplatform ./internal/complianceassessment ./internal/mcpoperations -count=1`
- `make contracts-check`
- `make mcp-contract-check`
- `make docs-drift-check`
- `make check-structural check-structural-test check-arch`
- `make oss-audit`