### PR TITLE
feat(compliance): verify canonical work with assurance

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3168,6 +3168,45 @@ paths:
         '200':
           description: GRC-friendly finding list.
   /grc/work-items:
+    get:
+      summary: List canonical compliance and security work
+      tags:
+        - GRC
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - name: state
+          in: query
+          schema:
+            $ref: '#/components/schemas/ComplianceWorkItemState'
+        - name: owner_id
+          in: query
+          schema:
+            type: string
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            format: uint32
+            minimum: 1
+            maximum: 200
+            default: 50
+      responses:
+        '200':
+          description: A bounded page from the tenant's canonical work queue.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceWorkItemPage'
+        '400':
+          description: A filter or cursor is invalid.
+        '403':
+          description: The authenticated principal cannot access the tenant.
+        '503':
+          description: The remediation runtime is unavailable.
     post:
       summary: Create work from a failed assessment result
       tags:
@@ -3202,11 +3241,14 @@ paths:
                 automated_result_hash:
                   type: string
                 result:
-                  type: object
-                  additionalProperties: true
+                  $ref: '#/components/schemas/AssessmentObjectiveResult'
       responses:
         '201':
           description: Stable work item with the failed-result occurrence.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceWorkItemRecord'
         '400':
           description: The result is not actionable or the work basis is incomplete.
         '403':
@@ -3228,6 +3270,10 @@ paths:
       responses:
         '200':
           description: Current work item with occurrences and action history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceWorkItemRecord'
         '403':
           description: The authenticated principal cannot access the tenant.
         '404':
@@ -3251,42 +3297,14 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required: [operation, expected_version]
-              properties:
-                operation:
-                  type: string
-                  enum: [action, invalidate]
-                expected_version:
-                  type: integer
-                  format: uint64
-                action:
-                  type: string
-                  enum: [assign, request_evidence, block, snooze, accept, remediate, verify, close, supersede]
-                owner_id:
-                  type: string
-                rationale:
-                  type: string
-                blocker_reason:
-                  type: string
-                snooze_until:
-                  type: string
-                  format: date-time
-                due_at:
-                  type: string
-                  format: date-time
-                evidence_ids:
-                  type: array
-                  items:
-                    type: string
-                trigger:
-                  type: string
-                  enum: [evidence_stale, evidence_revoked, finding_reopened, source_coverage_lost]
-                source_ref:
-                  type: string
+              $ref: '#/components/schemas/ComplianceWorkCommand'
       responses:
         '200':
           description: Updated work item and retained history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceWorkItemRecord'
         '400':
           description: The command violates the work lifecycle or independent verification rule.
         '403':
@@ -7053,6 +7071,232 @@ components:
           $ref: '#/components/schemas/AssuranceDecision'
         created:
           type: boolean
+    ComplianceWorkItemState:
+      type: string
+      enum: [open, in_progress, blocked, resolved, accepted, snoozed, superseded]
+    ComplianceWorkItemKind:
+      type: string
+      enum: [remediate_finding, collect_evidence, refresh_evidence, resolve_conflict, review_manual_evidence, repair_source, assign_owner, map_control, renew_exception, resolve_policy_gap, complete_access_change, answer_audit_request, review_vendor]
+    ComplianceWorkFingerprint:
+      type: object
+      required: [tenant_id, program_id, scope_revision_id, control_id, objective_id, kind, subject_id, reason, source_id]
+      properties:
+        tenant_id:
+          type: string
+        program_id:
+          type: string
+        scope_revision_id:
+          type: string
+        control_id:
+          type: string
+        objective_id:
+          type: string
+        kind:
+          $ref: '#/components/schemas/ComplianceWorkItemKind'
+        subject_id:
+          type: string
+        reason:
+          type: string
+        source_id:
+          type: string
+    ComplianceWorkOccurrence:
+      type: object
+      required: [id, work_item_id, assessment_run_id, objective_result_id, automated_result_hash, occurred_at, occurrence_hash]
+      properties:
+        id:
+          type: string
+        work_item_id:
+          type: string
+        assessment_run_id:
+          type: string
+        objective_result_id:
+          type: string
+        automated_result_hash:
+          type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        occurred_at:
+          type: string
+          format: date-time
+        occurrence_hash:
+          type: string
+    ComplianceWorkVerification:
+      type: object
+      required: [assurance_decision_id, assessment_run_id, objective_result_id, decision_digest, record_digest, evaluated_at, decision_as_of]
+      properties:
+        assurance_decision_id:
+          type: string
+        assessment_run_id:
+          type: string
+        objective_result_id:
+          type: string
+        decision_digest:
+          type: string
+        record_digest:
+          type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        evaluated_at:
+          type: string
+          format: date-time
+        decision_as_of:
+          type: string
+          format: date-time
+    ComplianceWorkItem:
+      type: object
+      required: [id, fingerprint_version, fingerprint, basis, state, owner_id, due_at, priority, verification_required, occurrences, version, updated_at]
+      properties:
+        id:
+          type: string
+        fingerprint_version:
+          type: string
+          enum: [compliance-work-fingerprint/v1]
+        fingerprint:
+          type: string
+        basis:
+          $ref: '#/components/schemas/ComplianceWorkFingerprint'
+        state:
+          $ref: '#/components/schemas/ComplianceWorkItemState'
+        owner_id:
+          type: string
+        due_at:
+          type: string
+          format: date-time
+        priority:
+          type: string
+        blocker_reason:
+          type: string
+        snooze_until:
+          type: string
+          format: date-time
+        risk_id:
+          type: string
+        exception_id:
+          type: string
+        verification_required:
+          type: boolean
+        verification_evidence_ids:
+          type: array
+          items:
+            type: string
+        verified_by:
+          type: string
+        last_remediated_by:
+          type: string
+        last_remediated_at:
+          type: string
+          format: date-time
+        verification:
+          $ref: '#/components/schemas/ComplianceWorkVerification'
+        occurrences:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceWorkOccurrence'
+        last_reopen_trigger:
+          type: string
+          enum: [exception_expired, evidence_stale, evidence_revoked, finding_reopened, source_coverage_lost, scope_subject_added]
+        version:
+          type: integer
+          format: uint64
+        updated_at:
+          type: string
+          format: date-time
+    ComplianceWorkActionRecord:
+      type: object
+      required: [id, work_item_id, action, from, to, owner_id, rationale, actor_id, created_at, action_hash]
+      properties:
+        id:
+          type: string
+        work_item_id:
+          type: string
+        action:
+          type: string
+          enum: [assign, request_evidence, block, snooze, accept, remediate, verify, verify_assurance, close, supersede]
+        from:
+          $ref: '#/components/schemas/ComplianceWorkItemState'
+        to:
+          $ref: '#/components/schemas/ComplianceWorkItemState'
+        owner_id:
+          type: string
+        rationale:
+          type: string
+        actor_id:
+          type: string
+        verification:
+          $ref: '#/components/schemas/ComplianceWorkVerification'
+        created_at:
+          type: string
+          format: date-time
+        action_hash:
+          type: string
+    ComplianceWorkItemRecord:
+      type: object
+      required: [item, occurrences, actions]
+      properties:
+        item:
+          $ref: '#/components/schemas/ComplianceWorkItem'
+        occurrences:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceWorkOccurrence'
+        actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceWorkActionRecord'
+    ComplianceWorkItemPage:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComplianceWorkItem'
+        next_cursor:
+          type: string
+    ComplianceWorkCommand:
+      type: object
+      required: [operation, expected_version]
+      properties:
+        operation:
+          type: string
+          enum: [action, invalidate]
+        expected_version:
+          type: integer
+          format: uint64
+        action:
+          type: string
+          enum: [assign, request_evidence, block, snooze, accept, remediate, verify, verify_assurance, close, supersede]
+        owner_id:
+          type: string
+        rationale:
+          type: string
+        blocker_reason:
+          type: string
+        snooze_until:
+          type: string
+          format: date-time
+        due_at:
+          type: string
+          format: date-time
+        evidence_ids:
+          type: array
+          items:
+            type: string
+        assurance_decision_id:
+          type: string
+        trigger:
+          type: string
+          enum: [exception_expired, evidence_stale, evidence_revoked, finding_reopened, source_coverage_lost, scope_subject_added]
+        source_ref:
+          type: string
     GRCEvidencePacketsResponse:
       type: object
       additionalProperties: true

--- a/docs/engineering/compliance-work-queue-contract.md
+++ b/docs/engineering/compliance-work-queue-contract.md
@@ -1,0 +1,57 @@
+# Compliance work queue contract
+
+## Canonical record
+
+Cerebro owns the canonical compliance and security work item. A work item keeps one stable fingerprint across assessment runs and retains its occurrences and actions in the append log. Postgres serves the current tenant-scoped projection. Companion cases and other clients are adapters over this record; they do not create a second authoritative queue.
+
+The supported HTTP journey is:
+
+1. `GET /grc/work-items` lists a bounded page of current work. Clients can filter by state and owner and continue with the opaque cursor.
+2. `GET /grc/work-items/{workItemID}` returns the current item with immutable occurrence and action history.
+3. `POST /grc/work-items/{workItemID}/commands` records a typed action against an expected version.
+
+Existing create, read, command, remediation-plan, and `verify` behavior remains available. New clients should retain the Cerebro work item ID and version in any local view so commands use optimistic concurrency instead of overwriting newer operator actions.
+
+## Post-change assurance verification
+
+`verify_assurance` resolves verification-required work only when the command references a persisted `AssuranceDecision` that meets every gate below:
+
+- the decision is qualified for production use;
+- the result is satisfied;
+- tenant, program, scope revision, control, objective, and source match the work fingerprint;
+- the result evaluation, decision time, and decision record time are after the most recent remediation action;
+- the verifier is not the owner or the actor who recorded remediation; and
+- the command version matches the current work item version.
+
+The service derives the verification receipt and evidence IDs from the decision. Caller-supplied evidence cannot replace or modify the decision proof. The work projection and immutable action record retain the decision ID, run ID, result ID, decision digest, record digest, evaluation time, and decision time.
+
+An invalidation clears the prior verification receipt and remediation anchor. The work must enter remediation again before another assurance decision can resolve it.
+
+## Companion adapter
+
+A companion security case may retain its own conversation and execution state, but it must use the Cerebro work item ID as its canonical reference. Queue reads come from `/grc/work-items`. State changes go through the typed command endpoint. Case closure follows a successful `verify_assurance` response; local finding reads or local completion receipts cannot close canonical work by themselves.
+
+## Rollout gates
+
+Deploy in dependency order:
+
+1. assurance-decision persistence and projection;
+2. assurance-decision HTTP contracts;
+3. canonical queue listing and `verify_assurance`;
+4. companion case adapter.
+
+Before enabling the adapter, verify:
+
+- append-log replay rebuilds work items and assurance decisions;
+- Postgres returns tenant-scoped list, item, and decision reads;
+- the API principal has security read and finding lifecycle write scopes;
+- stale, mismatched, unqualified, self-verified, and stale-version commands fail before append; and
+- a qualified post-remediation decision resolves exactly one expected work item version.
+
+No table rewrite is required. New verification fields live in the existing JSON work projection and immutable action payloads. Older payloads continue to decode without those fields.
+
+## Rollback
+
+Disable the companion adapter first and stop issuing `verify_assurance`. Existing clients can continue using their current list, read, command, remediation-plan, and `verify` paths. Keep appended events, assurance decisions, verification receipts, and projection columns intact. Do not delete or rewrite proof records during rollback.
+
+If the current projection must be rebuilt, replay assurance decisions before work actions so every retained verification receipt can be resolved to its immutable decision record.

--- a/internal/bootstrap/compliance_remediation_handlers.go
+++ b/internal/bootstrap/compliance_remediation_handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -78,6 +79,38 @@ func (a *App) handleGetComplianceWorkItem(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, record)
+}
+
+func (a *App) handleListComplianceWorkItems(w http.ResponseWriter, r *http.Request) {
+	service := a.remediationService()
+	if service == nil {
+		writeComplianceRemediationError(w, complianceremediation.ErrUnavailable)
+		return
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), r.URL.Query().Get("tenant_id"))
+	if err != nil {
+		writeComplianceRemediationError(w, err)
+		return
+	}
+	limit := uint64(50)
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		limit, err = strconv.ParseUint(raw, 10, 32)
+		if err != nil || limit == 0 {
+			writeComplianceRemediationError(w, fmt.Errorf("%w: limit must be a positive integer", complianceremediation.ErrInvalidRequest))
+			return
+		}
+	}
+	page, err := service.ListWorkItems(r.Context(), tenantID, complianceremediation.WorkItemListFilter{
+		State:   complianceassessment.WorkItemState(strings.TrimSpace(r.URL.Query().Get("state"))),
+		OwnerID: r.URL.Query().Get("owner_id"),
+		Cursor:  r.URL.Query().Get("cursor"),
+		Limit:   uint32(limit),
+	})
+	if err != nil {
+		writeComplianceRemediationError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
 }
 
 func (a *App) handleComplianceWorkCommand(w http.ResponseWriter, r *http.Request) {

--- a/internal/bootstrap/compliance_remediation_runtime_test.go
+++ b/internal/bootstrap/compliance_remediation_runtime_test.go
@@ -52,6 +52,25 @@ func TestComplianceWorkReadRejectsCrossTenantBeforeStoreLookup(t *testing.T) {
 	}
 }
 
+func TestComplianceWorkListUsesCanonicalTenantAndBoundedFilters(t *testing.T) {
+	state := &bootstrapRemediationState{}
+	log := &bootstrapRemediationLog{}
+	service := complianceremediation.New(state, state, log, log)
+	app := &App{services: appServices{remediation: service}}
+	request := httptest.NewRequest(http.MethodGet, "/grc/work-items?state=open&owner_id=owner-a&limit=25", nil)
+	request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{TenantID: "tenant-a"},
+	}))
+	recorder := httptest.NewRecorder()
+	app.handleListComplianceWorkItems(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if state.workLists != 1 || state.lastTenant != "tenant-a" || state.lastFilter.State != complianceassessment.WorkOpen || state.lastFilter.OwnerID != "owner-a" || state.lastFilter.Limit != 25 {
+		t.Fatalf("list call = count %d tenant %q filter %+v", state.workLists, state.lastTenant, state.lastFilter)
+	}
+}
+
 func TestComplianceRemediationRoutesUseReadAndLifecycleWriteScopes(t *testing.T) {
 	read, err := http.NewRequest(http.MethodGet, "/grc/work-items/work-a", nil)
 	if err != nil {
@@ -75,7 +94,17 @@ func TestComplianceRemediationRoutesUseReadAndLifecycleWriteScopes(t *testing.T)
 }
 
 type bootstrapRemediationState struct {
-	workReads int
+	workReads  int
+	workLists  int
+	lastTenant string
+	lastFilter complianceremediation.WorkItemListFilter
+}
+
+func (s *bootstrapRemediationState) ListWorkItems(_ context.Context, tenantID string, filter complianceremediation.WorkItemListFilter) (complianceremediation.WorkItemPage, error) {
+	s.workLists++
+	s.lastTenant = tenantID
+	s.lastFilter = filter
+	return complianceremediation.WorkItemPage{Items: []complianceassessment.WorkItem{}}, nil
 }
 
 func (s *bootstrapRemediationState) Ping(context.Context) error { return nil }

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -156,6 +156,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "DELETE /grc/risk-scoring-config", routeSurfacePlatformHTTP, app.handleDeleteRiskScoringConfig)
 	registerHTTPRoute(mux, "GET /grc/findings", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("findings", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCFindings))
 	registerHTTPRoute(mux, "POST /grc/work-items", routeSurfacePlatformHTTP, app.handleDeriveComplianceWork)
+	registerHTTPRoute(mux, "GET /grc/work-items", routeSurfacePlatformHTTP, app.handleListComplianceWorkItems)
 	registerHTTPRoute(mux, "GET /grc/work-items/{workItemID}", routeSurfacePlatformHTTP, app.handleGetComplianceWorkItem)
 	registerHTTPRoute(mux, "POST /grc/work-items/{workItemID}/commands", routeSurfacePlatformHTTP, app.handleComplianceWorkCommand)
 	registerHTTPRoute(mux, "POST /grc/remediation-plans", routeSurfacePlatformHTTP, app.handleCreateComplianceRemediationPlan)

--- a/internal/complianceassessment/reviews_phase7_test.go
+++ b/internal/complianceassessment/reviews_phase7_test.go
@@ -108,7 +108,8 @@ func TestWorkFingerprintOccurrencesAndReopenTriggers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReopenWorkItem(%s) error = %v", trigger, err)
 		}
-		if reopened.State != WorkOpen || reopened.OwnerID != "owner-b" || record.Trigger != trigger || record.RecordHash == "" {
+		if reopened.State != WorkOpen || reopened.OwnerID != "owner-b" || record.Trigger != trigger || record.RecordHash == "" ||
+			reopened.LastRemediatedBy != "" || !reopened.LastRemediatedAt.IsZero() {
 			t.Fatalf("ReopenWorkItem(%s) = %+v / %+v", trigger, reopened, record)
 		}
 	}
@@ -140,6 +141,43 @@ func TestVerificationRequiredWorkCannotBeSelfClosed(t *testing.T) {
 	resolved, _, err := ApplyWorkAction(inProgress, inProgress.Version, WorkActionInput{Action: WorkActionVerify, Rationale: "Verify the change.", EvidenceIDs: []string{"evidence-a"}, ActorID: "reviewer-a", At: now.Add(2 * time.Hour)})
 	if err != nil || resolved.State != WorkResolved || resolved.VerifiedBy != "reviewer-a" {
 		t.Fatalf("ApplyWorkAction(independent verify) = %+v, %v", resolved, err)
+	}
+}
+
+func TestAssuranceVerificationRecordsImmutableReceipt(t *testing.T) {
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	item, _, err := NewWorkItem(WorkItemInput{
+		Basis: WorkFingerprintInput{
+			TenantID: "tenant-a", ProgramID: "program-a", ScopeRevisionID: "scope-r1", ControlID: "CC-1",
+			ObjectiveID: "objective-a", Kind: WorkRemediateFinding, SubjectID: "subject-a", Reason: ReasonActiveFinding, SourceID: "source-a",
+		},
+		OwnerID: "owner-a", DueAt: now.Add(24 * time.Hour), Priority: "high", VerificationRequired: true,
+		Occurrence: WorkOccurrenceInput{AssessmentRunID: "run-a", ObjectiveResultID: "result-a", AutomatedResultHash: "sha256:" + strings.Repeat("e", 64), OccurredAt: now},
+	})
+	if err != nil {
+		t.Fatalf("NewWorkItem() error = %v", err)
+	}
+	inProgress, _, err := ApplyWorkAction(item, item.Version, WorkActionInput{
+		Action: WorkActionRemediate, Rationale: "Apply the control change.", ActorID: "owner-a", At: now.Add(time.Hour),
+	})
+	if err != nil || !inProgress.LastRemediatedAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("ApplyWorkAction(remediate) = %+v, %v", inProgress, err)
+	}
+	receipt := &WorkVerification{
+		AssuranceDecisionID: "assurance-decision-a", AssessmentRunID: "run-b", ObjectiveResultID: "result-b",
+		DecisionDigest: "sha256:" + strings.Repeat("a", 64), RecordDigest: "sha256:" + strings.Repeat("b", 64),
+		EvidenceIDs: []string{"evidence-b"}, EvaluatedAt: now.Add(2 * time.Hour), DecisionAsOf: now.Add(3 * time.Hour),
+	}
+	resolved, action, err := ApplyWorkAction(inProgress, inProgress.Version, WorkActionInput{
+		Action: WorkActionVerifyAssurance, Rationale: "Verify the post-change assessment.", Verification: receipt,
+		ActorID: "reviewer-a", At: now.Add(4 * time.Hour),
+	})
+	if err != nil || resolved.State != WorkResolved || resolved.Verification == nil || action.Verification == nil {
+		t.Fatalf("ApplyWorkAction(verify assurance) = %+v / %+v, %v", resolved, action, err)
+	}
+	receipt.EvidenceIDs[0] = "mutated"
+	if resolved.Verification.EvidenceIDs[0] != "evidence-b" || action.Verification.EvidenceIDs[0] != "evidence-b" {
+		t.Fatalf("verification receipt aliases caller input: %+v / %+v", resolved.Verification, action.Verification)
 	}
 }
 

--- a/internal/complianceassessment/reviews_phase7_test.go
+++ b/internal/complianceassessment/reviews_phase7_test.go
@@ -181,6 +181,20 @@ func TestAssuranceVerificationRecordsImmutableReceipt(t *testing.T) {
 	}
 }
 
+func TestAssuranceVerificationRequiresReceiptForAllWork(t *testing.T) {
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	current := WorkItem{
+		ID: "work-a", State: WorkInProgress, OwnerID: "owner-a", Version: 1,
+	}
+	_, _, err := ApplyWorkAction(current, current.Version, WorkActionInput{
+		Action: WorkActionVerifyAssurance, Rationale: "Verify the assessment result.",
+		ActorID: "reviewer-a", At: now,
+	})
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("ApplyWorkAction(verify assurance without receipt) error = %v, want ErrInvalidTransition", err)
+	}
+}
+
 func TestWorkActionsClearStateSpecificMetadata(t *testing.T) {
 	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
 	tests := []struct {

--- a/internal/complianceassessment/work_items.go
+++ b/internal/complianceassessment/work_items.go
@@ -57,6 +57,7 @@ const (
 	WorkActionAccept          WorkAction = "accept"
 	WorkActionRemediate       WorkAction = "remediate"
 	WorkActionVerify          WorkAction = "verify"
+	WorkActionVerifyAssurance WorkAction = "verify_assurance"
 	WorkActionClose           WorkAction = "close"
 	WorkActionSupersede       WorkAction = "supersede"
 )
@@ -127,10 +128,27 @@ type WorkItem struct {
 	VerificationEvidenceIDs []string             `json:"verification_evidence_ids,omitempty"`
 	VerifiedBy              string               `json:"verified_by,omitempty"`
 	LastRemediatedBy        string               `json:"last_remediated_by,omitempty"`
+	LastRemediatedAt        time.Time            `json:"last_remediated_at,omitempty"`
+	Verification            *WorkVerification    `json:"verification,omitempty"`
 	Occurrences             []WorkOccurrence     `json:"occurrences"`
 	LastReopenTrigger       WorkReopenTrigger    `json:"last_reopen_trigger,omitempty"`
 	Version                 uint64               `json:"version"`
 	UpdatedAt               time.Time            `json:"updated_at"`
+}
+
+// WorkVerification binds resolution to a qualified post-remediation assurance
+// decision. The referenced decision remains the immutable proof record; this
+// receipt carries the exact identity and digests needed to verify the link
+// without copying the decision snapshot into the work projection.
+type WorkVerification struct {
+	AssuranceDecisionID string    `json:"assurance_decision_id"`
+	AssessmentRunID     string    `json:"assessment_run_id"`
+	ObjectiveResultID   string    `json:"objective_result_id"`
+	DecisionDigest      string    `json:"decision_digest"`
+	RecordDigest        string    `json:"record_digest"`
+	EvidenceIDs         []string  `json:"evidence_ids,omitempty"`
+	EvaluatedAt         time.Time `json:"evaluated_at"`
+	DecisionAsOf        time.Time `json:"decision_as_of"`
 }
 
 // WorkItemInput creates one item and its first occurrence.
@@ -153,22 +171,24 @@ type WorkActionInput struct {
 	BlockerReason string
 	SnoozeUntil   time.Time
 	EvidenceIDs   []string
+	Verification  *WorkVerification
 	ActorID       string
 	At            time.Time
 }
 
 // WorkActionRecord is an immutable action record emitted with a work transition.
 type WorkActionRecord struct {
-	ID         string        `json:"id"`
-	WorkItemID string        `json:"work_item_id"`
-	Action     WorkAction    `json:"action"`
-	From       WorkItemState `json:"from"`
-	To         WorkItemState `json:"to"`
-	OwnerID    string        `json:"owner_id"`
-	Rationale  string        `json:"rationale"`
-	ActorID    string        `json:"actor_id"`
-	CreatedAt  time.Time     `json:"created_at"`
-	ActionHash string        `json:"action_hash"`
+	ID           string            `json:"id"`
+	WorkItemID   string            `json:"work_item_id"`
+	Action       WorkAction        `json:"action"`
+	From         WorkItemState     `json:"from"`
+	To           WorkItemState     `json:"to"`
+	OwnerID      string            `json:"owner_id"`
+	Rationale    string            `json:"rationale"`
+	ActorID      string            `json:"actor_id"`
+	Verification *WorkVerification `json:"verification,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+	ActionHash   string            `json:"action_hash"`
 }
 
 // WorkReopenRecord is the immutable reason a terminal item became active again.
@@ -285,24 +305,37 @@ func ApplyWorkAction(current WorkItem, expectedVersion uint64, input WorkActionI
 	}
 	if input.Action == WorkActionRemediate {
 		next.LastRemediatedBy = actorID
+		next.LastRemediatedAt = at
 		next.VerificationEvidenceIDs = nil
 		next.VerifiedBy = ""
+		next.Verification = nil
 	}
 	if input.Action == WorkActionVerify {
 		next.VerificationEvidenceIDs = normalizedStrings(input.EvidenceIDs)
 		next.VerifiedBy = actorID
 	}
+	if input.Action == WorkActionVerifyAssurance {
+		verification := cloneWorkVerification(input.Verification)
+		next.VerificationEvidenceIDs = append([]string(nil), verification.EvidenceIDs...)
+		next.VerifiedBy = actorID
+		next.Verification = verification
+	}
 	next.Version++
 	next.UpdatedAt = at
+	var verification *WorkVerification
+	if input.Action == WorkActionVerifyAssurance {
+		verification = cloneWorkVerification(input.Verification)
+	}
 	record := WorkActionRecord{
-		WorkItemID: current.ID,
-		Action:     input.Action,
-		From:       current.State,
-		To:         next.State,
-		OwnerID:    next.OwnerID,
-		Rationale:  rationale,
-		ActorID:    actorID,
-		CreatedAt:  at,
+		WorkItemID:   current.ID,
+		Action:       input.Action,
+		From:         current.State,
+		To:           next.State,
+		OwnerID:      next.OwnerID,
+		Rationale:    rationale,
+		ActorID:      actorID,
+		Verification: verification,
+		CreatedAt:    at,
 	}
 	hash, err := hashDomainValue(record)
 	if err != nil {
@@ -337,6 +370,9 @@ func ReopenWorkItem(current WorkItem, expectedVersion uint64, trigger WorkReopen
 	next.SnoozeUntil = time.Time{}
 	next.VerificationEvidenceIDs = nil
 	next.VerifiedBy = ""
+	next.Verification = nil
+	next.LastRemediatedBy = ""
+	next.LastRemediatedAt = time.Time{}
 	next.LastReopenTrigger = trigger
 	next.Version++
 	next.UpdatedAt = at
@@ -413,13 +449,18 @@ func workActionTarget(current WorkItem, input WorkActionInput, at time.Time) (Wo
 			return "", fmt.Errorf("%w: terminal work cannot enter remediation", ErrInvalidTransition)
 		}
 		return WorkInProgress, nil
-	case WorkActionVerify:
+	case WorkActionVerify, WorkActionVerifyAssurance:
 		if current.State != WorkInProgress && current.State != WorkBlocked {
 			return "", fmt.Errorf("%w: only active work can resolve", ErrInvalidTransition)
 		}
 		if current.VerificationRequired {
-			if len(normalizedStrings(input.EvidenceIDs)) == 0 {
+			if input.Action == WorkActionVerify && len(normalizedStrings(input.EvidenceIDs)) == 0 {
 				return "", fmt.Errorf("%w: verification evidence is required", ErrInvalidTransition)
+			}
+			if input.Action == WorkActionVerifyAssurance {
+				if err := validateWorkVerification(input.Verification); err != nil {
+					return "", err
+				}
 			}
 			actorID := strings.TrimSpace(input.ActorID)
 			if actorID == current.OwnerID || actorID == current.LastRemediatedBy {
@@ -458,12 +499,31 @@ func normalizeWorkFingerprintInput(input WorkFingerprintInput) WorkFingerprintIn
 
 func cloneWorkItem(value WorkItem) WorkItem {
 	value.VerificationEvidenceIDs = append([]string(nil), value.VerificationEvidenceIDs...)
+	value.Verification = cloneWorkVerification(value.Verification)
 	value.Occurrences = append([]WorkOccurrence(nil), value.Occurrences...)
 	for index := range value.Occurrences {
 		value.Occurrences[index].EvidenceIDs = append([]string(nil), value.Occurrences[index].EvidenceIDs...)
 		value.Occurrences[index].FindingIDs = append([]string(nil), value.Occurrences[index].FindingIDs...)
 	}
 	return value
+}
+
+func cloneWorkVerification(value *WorkVerification) *WorkVerification {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	cloned.EvidenceIDs = append([]string(nil), value.EvidenceIDs...)
+	return &cloned
+}
+
+func validateWorkVerification(value *WorkVerification) error {
+	if value == nil || strings.TrimSpace(value.AssuranceDecisionID) == "" || strings.TrimSpace(value.AssessmentRunID) == "" ||
+		strings.TrimSpace(value.ObjectiveResultID) == "" || !validDigestString(strings.TrimSpace(value.DecisionDigest)) ||
+		!validDigestString(strings.TrimSpace(value.RecordDigest)) || CanonicalTime(value.EvaluatedAt).IsZero() || CanonicalTime(value.DecisionAsOf).IsZero() {
+		return fmt.Errorf("%w: assurance verification receipt is incomplete", ErrInvalidTransition)
+	}
+	return nil
 }
 
 func validWorkKind(value WorkItemKind) bool {

--- a/internal/complianceassessment/work_items.go
+++ b/internal/complianceassessment/work_items.go
@@ -453,14 +453,14 @@ func workActionTarget(current WorkItem, input WorkActionInput, at time.Time) (Wo
 		if current.State != WorkInProgress && current.State != WorkBlocked {
 			return "", fmt.Errorf("%w: only active work can resolve", ErrInvalidTransition)
 		}
+		if input.Action == WorkActionVerifyAssurance {
+			if err := validateWorkVerification(input.Verification); err != nil {
+				return "", err
+			}
+		}
 		if current.VerificationRequired {
 			if input.Action == WorkActionVerify && len(normalizedStrings(input.EvidenceIDs)) == 0 {
 				return "", fmt.Errorf("%w: verification evidence is required", ErrInvalidTransition)
-			}
-			if input.Action == WorkActionVerifyAssurance {
-				if err := validateWorkVerification(input.Verification); err != nil {
-					return "", err
-				}
 			}
 			actorID := strings.TrimSpace(input.ActorID)
 			if actorID == current.OwnerID || actorID == current.LastRemediatedBy {

--- a/internal/complianceremediation/service.go
+++ b/internal/complianceremediation/service.go
@@ -37,6 +37,30 @@ type WorkItemRecord struct {
 	Actions     []complianceassessment.WorkActionRecord `json:"actions"`
 }
 
+// WorkItemListFilter selects one bounded page from the canonical work queue.
+type WorkItemListFilter struct {
+	State   complianceassessment.WorkItemState
+	OwnerID string
+	Cursor  string
+	Limit   uint32
+}
+
+// WorkItemPage is a keyset-paginated canonical work queue page.
+type WorkItemPage struct {
+	Items      []complianceassessment.WorkItem `json:"items"`
+	NextCursor string                          `json:"next_cursor,omitempty"`
+}
+
+// WorkItemLister is optional so existing Store implementations retain their
+// read/write contract while durable stores can expose the shared queue.
+type WorkItemLister interface {
+	ListWorkItems(context.Context, string, WorkItemListFilter) (WorkItemPage, error)
+}
+
+type assuranceDecisionReader interface {
+	GetAssuranceDecision(context.Context, string, string) (complianceassessment.AssuranceDecision, error)
+}
+
 // Store is the tenant-scoped current-state read boundary.
 type Store interface {
 	GetWorkItem(context.Context, string, string) (WorkItemRecord, error)
@@ -128,21 +152,45 @@ func (s *Service) GetWorkItem(ctx context.Context, tenantID, workItemID string) 
 	return s.store.GetWorkItem(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(workItemID))
 }
 
+// ListWorkItems reads one bounded tenant-scoped page from the canonical queue.
+func (s *Service) ListWorkItems(ctx context.Context, tenantID string, filter WorkItemListFilter) (WorkItemPage, error) {
+	if err := s.ready(); err != nil {
+		return WorkItemPage{}, err
+	}
+	lister, ok := s.store.(WorkItemLister)
+	if !ok {
+		return WorkItemPage{}, ErrUnavailable
+	}
+	filter.OwnerID = strings.TrimSpace(filter.OwnerID)
+	filter.Cursor = strings.TrimSpace(filter.Cursor)
+	if filter.State != "" && !validWorkItemStateFilter(filter.State) {
+		return WorkItemPage{}, fmt.Errorf("%w: unknown work item state %q", ErrInvalidRequest, filter.State)
+	}
+	if filter.Limit == 0 {
+		filter.Limit = 50
+	}
+	if filter.Limit > 200 {
+		return WorkItemPage{}, fmt.Errorf("%w: limit must not exceed 200", ErrInvalidRequest)
+	}
+	return lister.ListWorkItems(ctx, strings.TrimSpace(tenantID), filter)
+}
+
 // WorkCommand applies an explicit operating action or invalidation.
 type WorkCommand struct {
-	Operation       string                                 `json:"operation"`
-	ExpectedVersion uint64                                 `json:"expected_version"`
-	Action          complianceassessment.WorkAction        `json:"action,omitempty"`
-	OwnerID         string                                 `json:"owner_id,omitempty"`
-	Rationale       string                                 `json:"rationale,omitempty"`
-	BlockerReason   string                                 `json:"blocker_reason,omitempty"`
-	SnoozeUntil     time.Time                              `json:"snooze_until,omitempty"`
-	EvidenceIDs     []string                               `json:"evidence_ids,omitempty"`
-	Trigger         complianceassessment.WorkReopenTrigger `json:"trigger,omitempty"`
-	SourceRef       string                                 `json:"source_ref,omitempty"`
-	DueAt           time.Time                              `json:"due_at,omitempty"`
-	ActorID         string                                 `json:"actor_id"`
-	At              time.Time                              `json:"at"`
+	Operation           string                                 `json:"operation"`
+	ExpectedVersion     uint64                                 `json:"expected_version"`
+	Action              complianceassessment.WorkAction        `json:"action,omitempty"`
+	OwnerID             string                                 `json:"owner_id,omitempty"`
+	Rationale           string                                 `json:"rationale,omitempty"`
+	BlockerReason       string                                 `json:"blocker_reason,omitempty"`
+	SnoozeUntil         time.Time                              `json:"snooze_until,omitempty"`
+	EvidenceIDs         []string                               `json:"evidence_ids,omitempty"`
+	AssuranceDecisionID string                                 `json:"assurance_decision_id,omitempty"`
+	Trigger             complianceassessment.WorkReopenTrigger `json:"trigger,omitempty"`
+	SourceRef           string                                 `json:"source_ref,omitempty"`
+	DueAt               time.Time                              `json:"due_at,omitempty"`
+	ActorID             string                                 `json:"actor_id"`
+	At                  time.Time                              `json:"at"`
 }
 
 // ApplyWorkCommand records a state transition without executing an external action.
@@ -159,10 +207,22 @@ func (s *Service) ApplyWorkCommand(ctx context.Context, tenantID, workItemID str
 	}
 	switch strings.TrimSpace(command.Operation) {
 	case "action":
+		var verification *complianceassessment.WorkVerification
+		if command.Action == complianceassessment.WorkActionVerifyAssurance {
+			if record.Item.Version != command.ExpectedVersion {
+				return WorkItemRecord{}, fmt.Errorf("%w: expected %d, current %d", complianceassessment.ErrVersionConflict, command.ExpectedVersion, record.Item.Version)
+			}
+			verification, err = s.verifyWorkAssurance(ctx, strings.TrimSpace(tenantID), record.Item, command)
+			if err != nil {
+				return WorkItemRecord{}, err
+			}
+		} else if strings.TrimSpace(command.AssuranceDecisionID) != "" {
+			return WorkItemRecord{}, fmt.Errorf("%w: assurance_decision_id requires verify_assurance", ErrInvalidRequest)
+		}
 		next, action, err := complianceassessment.ApplyWorkAction(record.Item, command.ExpectedVersion, complianceassessment.WorkActionInput{
 			Action: command.Action, OwnerID: command.OwnerID, Rationale: command.Rationale,
 			BlockerReason: command.BlockerReason, SnoozeUntil: command.SnoozeUntil,
-			EvidenceIDs: command.EvidenceIDs, ActorID: command.ActorID, At: command.At,
+			EvidenceIDs: command.EvidenceIDs, Verification: verification, ActorID: command.ActorID, At: command.At,
 		})
 		if err != nil {
 			return WorkItemRecord{}, err
@@ -195,6 +255,75 @@ func (s *Service) ApplyWorkCommand(ctx context.Context, tenantID, workItemID str
 		return WorkItemRecord{}, fmt.Errorf("%w: operation must be action or invalidate", ErrInvalidRequest)
 	}
 	return s.store.GetWorkItem(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(workItemID))
+}
+
+func (s *Service) verifyWorkAssurance(ctx context.Context, tenantID string, item complianceassessment.WorkItem, command WorkCommand) (*complianceassessment.WorkVerification, error) {
+	decisionID := strings.TrimSpace(command.AssuranceDecisionID)
+	reader, ok := s.store.(assuranceDecisionReader)
+	if !ok {
+		return nil, ErrUnavailable
+	}
+	if decisionID == "" {
+		return nil, fmt.Errorf("%w: assurance_decision_id is required", ErrInvalidRequest)
+	}
+	decision, err := reader.GetAssuranceDecision(ctx, tenantID, decisionID)
+	if errors.Is(err, complianceassessment.ErrAssuranceDecisionNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := decision.Decision.AuthorizeProductionUse(); err != nil {
+		return nil, fmt.Errorf("%w: assurance decision is not qualified", ErrInvalidRequest)
+	}
+	result := complianceassessment.NormalizeResult(decision.InputSnapshot.Result)
+	remediatedAt := complianceassessment.CanonicalTime(item.LastRemediatedAt)
+	decisionAsOf := complianceassessment.CanonicalTime(decision.Decision.AsOf)
+	evaluatedAt := complianceassessment.CanonicalTime(result.EvaluatedAt)
+	if remediatedAt.IsZero() || !evaluatedAt.After(remediatedAt) || !decisionAsOf.After(remediatedAt) || !decision.RecordedAt.After(remediatedAt) {
+		return nil, fmt.Errorf("%w: assurance decision must be recorded from a post-remediation assessment", ErrInvalidRequest)
+	}
+	if decision.ProgramID != item.Basis.ProgramID || decision.ScopeRevisionID != item.Basis.ScopeRevisionID ||
+		decision.ObjectiveID != item.Basis.ObjectiveID || result.ControlRef.ControlID != item.Basis.ControlID {
+		return nil, fmt.Errorf("%w: assurance decision does not match the work basis", ErrInvalidRequest)
+	}
+	if result.AutomatedOutcome != complianceassessment.OutcomeSatisfied {
+		return nil, fmt.Errorf("%w: assurance decision result is not satisfied", ErrInvalidRequest)
+	}
+	if !containsString(result.SourceRuntimeIDs, item.Basis.SourceID) {
+		return nil, fmt.Errorf("%w: assurance decision does not cover the work source", ErrInvalidRequest)
+	}
+	return &complianceassessment.WorkVerification{
+		AssuranceDecisionID: decision.ID,
+		AssessmentRunID:     decision.RunID,
+		ObjectiveResultID:   decision.ResultID,
+		DecisionDigest:      decision.Decision.DecisionDigest,
+		RecordDigest:        decision.RecordDigest,
+		EvidenceIDs:         append([]string(nil), result.EvidenceIDs...),
+		EvaluatedAt:         evaluatedAt,
+		DecisionAsOf:        decisionAsOf,
+	}, nil
+}
+
+func containsString(values []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func validWorkItemStateFilter(state complianceassessment.WorkItemState) bool {
+	switch state {
+	case complianceassessment.WorkOpen, complianceassessment.WorkInProgress, complianceassessment.WorkBlocked,
+		complianceassessment.WorkResolved, complianceassessment.WorkAccepted, complianceassessment.WorkSnoozed,
+		complianceassessment.WorkSuperseded:
+		return true
+	default:
+		return false
+	}
 }
 
 // CreateRemediationPlan creates an owned plan with mandatory independent verification.

--- a/internal/complianceremediation/service_test.go
+++ b/internal/complianceremediation/service_test.go
@@ -104,6 +104,75 @@ func TestFailedResultWorkReplaysOldestFirstAndReopensAfterInvalidation(t *testin
 	}
 }
 
+func TestVerifyAssuranceRequiresQualifiedPostRemediationDecision(t *testing.T) {
+	now := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+	runtime := newMemoryRuntime()
+	service := New(runtime, runtime, runtime, runtime)
+	record, err := service.DeriveWork(context.Background(), failedResultInput(now), "assessor-a")
+	if err != nil {
+		t.Fatalf("DeriveWork() error = %v", err)
+	}
+	record, err = service.ApplyWorkCommand(context.Background(), "tenant-a", record.Item.ID, WorkCommand{
+		Operation: "action", ExpectedVersion: record.Item.Version, Action: complianceassessment.WorkActionRemediate,
+		Rationale: "Apply the control change.", ActorID: "owner-a", At: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ApplyWorkCommand(remediate) error = %v", err)
+	}
+	decision := qualifiedWorkDecision(now.Add(2*time.Hour), now.Add(3*time.Hour), now.Add(4*time.Hour))
+	runtime.decisions["tenant-a\x00"+decision.ID] = decision
+	record, err = service.ApplyWorkCommand(context.Background(), "tenant-a", record.Item.ID, WorkCommand{
+		Operation: "action", ExpectedVersion: record.Item.Version, Action: complianceassessment.WorkActionVerifyAssurance,
+		AssuranceDecisionID: decision.ID, EvidenceIDs: []string{"caller-supplied"},
+		Rationale: "Verify the post-change assessment.", ActorID: "reviewer-a", At: now.Add(5 * time.Hour),
+	})
+	if err != nil || record.Item.State != complianceassessment.WorkResolved || record.Item.Verification == nil {
+		t.Fatalf("ApplyWorkCommand(verify assurance) = %+v, %v", record.Item, err)
+	}
+	if got := record.Item.Verification.EvidenceIDs; len(got) != 1 || got[0] != "evidence-fresh" {
+		t.Fatalf("verification evidence = %v, want decision evidence", got)
+	}
+
+	secondRuntime := newMemoryRuntime()
+	secondService := New(secondRuntime, secondRuntime, secondRuntime, secondRuntime)
+	stale, err := secondService.DeriveWork(context.Background(), failedResultInput(now), "assessor-a")
+	if err != nil {
+		t.Fatalf("DeriveWork(stale) error = %v", err)
+	}
+	stale, err = secondService.ApplyWorkCommand(context.Background(), "tenant-a", stale.Item.ID, WorkCommand{
+		Operation: "action", ExpectedVersion: stale.Item.Version, Action: complianceassessment.WorkActionRemediate,
+		Rationale: "Apply the control change.", ActorID: "owner-a", At: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ApplyWorkCommand(remediate stale) error = %v", err)
+	}
+	staleDecision := qualifiedWorkDecision(now, now.Add(3*time.Hour), now.Add(4*time.Hour))
+	secondRuntime.decisions["tenant-a\x00"+staleDecision.ID] = staleDecision
+	before := len(secondRuntime.events)
+	_, err = secondService.ApplyWorkCommand(context.Background(), "tenant-a", stale.Item.ID, WorkCommand{
+		Operation: "action", ExpectedVersion: stale.Item.Version, Action: complianceassessment.WorkActionVerifyAssurance,
+		AssuranceDecisionID: staleDecision.ID, Rationale: "Verify stale assessment.", ActorID: "reviewer-a", At: now.Add(5 * time.Hour),
+	})
+	if !errors.Is(err, ErrInvalidRequest) || len(secondRuntime.events) != before {
+		t.Fatalf("stale verification error/events = %v/%d, want rejection before append", err, len(secondRuntime.events))
+	}
+}
+
+func qualifiedWorkDecision(evaluatedAt, asOf, recordedAt time.Time) complianceassessment.AssuranceDecision {
+	digest := "sha256:" + strings.Repeat("b", 64)
+	return complianceassessment.AssuranceDecision{
+		ID: "assurance-decision-fresh", TenantID: "tenant-a", RunID: "run-fresh", ResultID: "result-fresh",
+		ObjectiveID: "objective-a", ProgramID: "program-a", ScopeRevisionID: "scope-a",
+		InputSnapshot: complianceassessment.QualificationInput{Result: complianceassessment.ObjectiveResult{
+			ID: "result-fresh", ControlRef: compliance.ControlRef{FrameworkID: "framework-a", ControlID: "control-a"},
+			ObjectiveID: "objective-a", AutomatedOutcome: complianceassessment.OutcomeSatisfied,
+			EvidenceIDs: []string{"evidence-fresh"}, SourceRuntimeIDs: []string{"runtime-a"}, EvaluatedAt: evaluatedAt,
+		}},
+		Decision:   complianceassessment.QualifiedDecision{Qualified: true, ProofDigest: digest, DecisionDigest: digest, AsOf: asOf},
+		RecordedAt: recordedAt, RecordDigest: digest,
+	}
+}
+
 func TestAppendSuccessProjectionFailureRecoversWork(t *testing.T) {
 	now := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
 	runtime := newMemoryRuntime()
@@ -210,11 +279,12 @@ type memoryRuntime struct {
 	work           map[string]WorkItemRecord
 	plans          map[string]complianceassessment.RemediationPlan
 	receipts       map[string]struct{}
+	decisions      map[string]complianceassessment.AssuranceDecision
 	failProjection bool
 }
 
 func newMemoryRuntime() *memoryRuntime {
-	return &memoryRuntime{work: map[string]WorkItemRecord{}, plans: map[string]complianceassessment.RemediationPlan{}, receipts: map[string]struct{}{}}
+	return &memoryRuntime{work: map[string]WorkItemRecord{}, plans: map[string]complianceassessment.RemediationPlan{}, receipts: map[string]struct{}{}, decisions: map[string]complianceassessment.AssuranceDecision{}}
 }
 
 func (m *memoryRuntime) Ping(context.Context) error { return nil }
@@ -274,6 +344,14 @@ func (m *memoryRuntime) GetRemediationPlan(_ context.Context, tenantID, planID s
 		return complianceassessment.RemediationPlan{}, ErrNotFound
 	}
 	return plan, nil
+}
+
+func (m *memoryRuntime) GetAssuranceDecision(_ context.Context, tenantID, decisionID string) (complianceassessment.AssuranceDecision, error) {
+	decision, ok := m.decisions[tenantID+"\x00"+decisionID]
+	if !ok {
+		return complianceassessment.AssuranceDecision{}, complianceassessment.ErrAssuranceDecisionNotFound
+	}
+	return decision, nil
 }
 
 func (m *memoryRuntime) ProjectWorkOccurrence(_ context.Context, metadata ProjectionMetadata, item complianceassessment.WorkItem, occurrence complianceassessment.WorkOccurrence) error {

--- a/internal/statestore/postgres/compliance_review_projection_test.go
+++ b/internal/statestore/postgres/compliance_review_projection_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/complianceassessment"
+	"github.com/writer/cerebro/internal/complianceremediation"
 	"github.com/writer/cerebro/internal/config"
 )
 
@@ -203,6 +204,10 @@ func TestComplianceReviewProjectionPostgresIntegration(t *testing.T) {
 	storedWork, err := store.GetComplianceWorkItem(ctx, tenantID, item.ID)
 	if err != nil || storedWork.Item.Version != 2 || len(storedWork.Occurrences) != 1 || len(storedWork.Actions) != 1 {
 		t.Fatalf("GetComplianceWorkItem() = %+v, %v", storedWork, err)
+	}
+	page, err := store.ListWorkItems(ctx, tenantID, complianceremediation.WorkItemListFilter{State: complianceassessment.WorkInProgress, OwnerID: "owner-a", Limit: 1})
+	if err != nil || len(page.Items) != 1 || page.Items[0].ID != item.ID || page.NextCursor != "" {
+		t.Fatalf("ListWorkItems() = %+v, %v", page, err)
 	}
 
 	plan, err := complianceassessment.NewRemediationPlan(complianceassessment.RemediationPlanInput{

--- a/internal/statestore/postgres/compliance_work_queue.go
+++ b/internal/statestore/postgres/compliance_work_queue.go
@@ -32,32 +32,31 @@ func (s *Store) ListWorkItems(ctx context.Context, tenantID string, filter compl
 	if limit == 0 {
 		limit = 50
 	}
-	where := []string{"tenant_id = $1"}
-	args := []any{tenantID}
-	if filter.State != "" {
-		args = append(args, string(filter.State))
-		where = append(where, fmt.Sprintf("body_json->>'state' = $%d", len(args)))
+	if limit > 200 {
+		return complianceremediation.WorkItemPage{}, fmt.Errorf("%w: limit must be at most 200", complianceremediation.ErrInvalidRequest)
 	}
-	if ownerID := strings.TrimSpace(filter.OwnerID); ownerID != "" {
-		args = append(args, ownerID)
-		where = append(where, fmt.Sprintf("body_json->>'owner_id' = $%d", len(args)))
-	}
+	state := string(filter.State)
+	ownerID := strings.TrimSpace(filter.OwnerID)
+	var cursorUpdatedAt any
+	cursorID := ""
 	if cursorValue := strings.TrimSpace(filter.Cursor); cursorValue != "" {
 		cursor, err := decodeComplianceWorkItemCursor(cursorValue)
 		if err != nil {
 			return complianceremediation.WorkItemPage{}, err
 		}
-		args = append(args, cursor.UpdatedAt.UTC(), cursor.ID)
-		where = append(where, fmt.Sprintf("(updated_at < $%d OR (updated_at = $%d AND id > $%d))", len(args)-1, len(args)-1, len(args)))
+		cursorUpdatedAt = cursor.UpdatedAt.UTC()
+		cursorID = cursor.ID
 	}
-	args = append(args, int64(limit)+1)
-	query := fmt.Sprintf(`
+	const query = `
 SELECT id, updated_at, body_json
 FROM compliance_work_items
-WHERE %s
+WHERE tenant_id = $1
+  AND ($2 = '' OR body_json->>'state' = $2)
+  AND ($3 = '' OR body_json->>'owner_id' = $3)
+  AND ($4::timestamptz IS NULL OR (updated_at < $4 OR (updated_at = $4 AND id > $5)))
 ORDER BY updated_at DESC, id ASC
-LIMIT $%d`, strings.Join(where, " AND "), len(args))
-	rows, err := s.db.QueryContext(ctx, query, args...)
+LIMIT $6`
+	rows, err := s.db.QueryContext(ctx, query, tenantID, state, ownerID, cursorUpdatedAt, cursorID, int64(limit)+1)
 	if err != nil {
 		return complianceremediation.WorkItemPage{}, fmt.Errorf("list compliance work items: %w", err)
 	}
@@ -67,7 +66,7 @@ LIMIT $%d`, strings.Join(where, " AND "), len(args))
 		updatedAt time.Time
 		item      complianceassessment.WorkItem
 	}
-	values := make([]rowValue, 0, limit+1)
+	values := []rowValue{}
 	for rows.Next() {
 		var value rowValue
 		var body []byte
@@ -82,16 +81,19 @@ LIMIT $%d`, strings.Join(where, " AND "), len(args))
 	if err := rows.Err(); err != nil {
 		return complianceremediation.WorkItemPage{}, fmt.Errorf("iterate compliance work items: %w", err)
 	}
-	page := complianceremediation.WorkItemPage{Items: make([]complianceassessment.WorkItem, 0, min(len(values), int(limit)))}
-	for index, value := range values {
-		if index >= int(limit) {
+	page := complianceremediation.WorkItemPage{Items: []complianceassessment.WorkItem{}}
+	var lastIncluded rowValue
+	var included uint32
+	for _, value := range values {
+		if included == limit {
 			break
 		}
 		page.Items = append(page.Items, value.item)
+		lastIncluded = value
+		included++
 	}
-	if len(values) > int(limit) && len(page.Items) != 0 {
-		last := values[int(limit)-1]
-		page.NextCursor, err = encodeComplianceWorkItemCursor(complianceWorkItemCursor{UpdatedAt: last.updatedAt, ID: last.id})
+	if len(values) > len(page.Items) && len(page.Items) != 0 {
+		page.NextCursor, err = encodeComplianceWorkItemCursor(complianceWorkItemCursor{UpdatedAt: lastIncluded.updatedAt, ID: lastIncluded.id})
 		if err != nil {
 			return complianceremediation.WorkItemPage{}, err
 		}

--- a/internal/statestore/postgres/compliance_work_queue.go
+++ b/internal/statestore/postgres/compliance_work_queue.go
@@ -1,0 +1,132 @@
+package postgres
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/complianceassessment"
+	"github.com/writer/cerebro/internal/complianceremediation"
+)
+
+type complianceWorkItemCursor struct {
+	UpdatedAt time.Time `json:"updated_at"`
+	ID        string    `json:"id"`
+}
+
+// ListWorkItems exposes a bounded tenant-scoped page from the Postgres work
+// projection. The cursor is opaque to callers and uses projection update time
+// plus stable item identity for deterministic keyset pagination.
+func (s *Store) ListWorkItems(ctx context.Context, tenantID string, filter complianceremediation.WorkItemListFilter) (complianceremediation.WorkItemPage, error) {
+	if err := s.ensureComplianceReviewTables(ctx); err != nil {
+		return complianceremediation.WorkItemPage{}, err
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return complianceremediation.WorkItemPage{}, fmt.Errorf("%w: tenant_id is required", complianceremediation.ErrInvalidRequest)
+	}
+	limit := filter.Limit
+	if limit == 0 {
+		limit = 50
+	}
+	where := []string{"tenant_id = $1"}
+	args := []any{tenantID}
+	if filter.State != "" {
+		args = append(args, string(filter.State))
+		where = append(where, fmt.Sprintf("body_json->>'state' = $%d", len(args)))
+	}
+	if ownerID := strings.TrimSpace(filter.OwnerID); ownerID != "" {
+		args = append(args, ownerID)
+		where = append(where, fmt.Sprintf("body_json->>'owner_id' = $%d", len(args)))
+	}
+	if cursorValue := strings.TrimSpace(filter.Cursor); cursorValue != "" {
+		cursor, err := decodeComplianceWorkItemCursor(cursorValue)
+		if err != nil {
+			return complianceremediation.WorkItemPage{}, err
+		}
+		args = append(args, cursor.UpdatedAt.UTC(), cursor.ID)
+		where = append(where, fmt.Sprintf("(updated_at < $%d OR (updated_at = $%d AND id > $%d))", len(args)-1, len(args)-1, len(args)))
+	}
+	args = append(args, int64(limit)+1)
+	query := fmt.Sprintf(`
+SELECT id, updated_at, body_json
+FROM compliance_work_items
+WHERE %s
+ORDER BY updated_at DESC, id ASC
+LIMIT $%d`, strings.Join(where, " AND "), len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return complianceremediation.WorkItemPage{}, fmt.Errorf("list compliance work items: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	type rowValue struct {
+		id        string
+		updatedAt time.Time
+		item      complianceassessment.WorkItem
+	}
+	values := make([]rowValue, 0, limit+1)
+	for rows.Next() {
+		var value rowValue
+		var body []byte
+		if err := rows.Scan(&value.id, &value.updatedAt, &body); err != nil {
+			return complianceremediation.WorkItemPage{}, fmt.Errorf("scan compliance work item: %w", err)
+		}
+		if err := json.Unmarshal(body, &value.item); err != nil {
+			return complianceremediation.WorkItemPage{}, fmt.Errorf("decode compliance work item: %w", err)
+		}
+		values = append(values, value)
+	}
+	if err := rows.Err(); err != nil {
+		return complianceremediation.WorkItemPage{}, fmt.Errorf("iterate compliance work items: %w", err)
+	}
+	page := complianceremediation.WorkItemPage{Items: make([]complianceassessment.WorkItem, 0, min(len(values), int(limit)))}
+	for index, value := range values {
+		if index >= int(limit) {
+			break
+		}
+		page.Items = append(page.Items, value.item)
+	}
+	if len(values) > int(limit) && len(page.Items) != 0 {
+		last := values[int(limit)-1]
+		page.NextCursor, err = encodeComplianceWorkItemCursor(complianceWorkItemCursor{UpdatedAt: last.updatedAt, ID: last.id})
+		if err != nil {
+			return complianceremediation.WorkItemPage{}, err
+		}
+	}
+	return page, nil
+}
+
+func encodeComplianceWorkItemCursor(cursor complianceWorkItemCursor) (string, error) {
+	cursor.ID = strings.TrimSpace(cursor.ID)
+	cursor.UpdatedAt = cursor.UpdatedAt.UTC()
+	if cursor.ID == "" || cursor.UpdatedAt.IsZero() {
+		return "", fmt.Errorf("%w: work item cursor is incomplete", complianceremediation.ErrInvalidRequest)
+	}
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("encode compliance work item cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func decodeComplianceWorkItemCursor(value string) (complianceWorkItemCursor, error) {
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		return complianceWorkItemCursor{}, fmt.Errorf("%w: work item cursor is malformed", complianceremediation.ErrInvalidRequest)
+	}
+	var cursor complianceWorkItemCursor
+	if err := json.Unmarshal(payload, &cursor); err != nil {
+		return complianceWorkItemCursor{}, fmt.Errorf("%w: work item cursor is malformed", complianceremediation.ErrInvalidRequest)
+	}
+	cursor.ID = strings.TrimSpace(cursor.ID)
+	cursor.UpdatedAt = cursor.UpdatedAt.UTC()
+	if cursor.ID == "" || cursor.UpdatedAt.IsZero() {
+		return complianceWorkItemCursor{}, fmt.Errorf("%w: work item cursor is incomplete", complianceremediation.ErrInvalidRequest)
+	}
+	return cursor, nil
+}
+
+var _ complianceremediation.WorkItemLister = (*Store)(nil)

--- a/internal/statestore/postgres/compliance_work_queue_test.go
+++ b/internal/statestore/postgres/compliance_work_queue_test.go
@@ -1,0 +1,26 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/complianceremediation"
+)
+
+func TestComplianceWorkItemCursorRoundTripAndMalformedInput(t *testing.T) {
+	want := complianceWorkItemCursor{UpdatedAt: time.Date(2026, 7, 15, 12, 0, 0, 123, time.UTC), ID: "work-a"}
+	encoded, err := encodeComplianceWorkItemCursor(want)
+	if err != nil {
+		t.Fatalf("encodeComplianceWorkItemCursor() error = %v", err)
+	}
+	got, err := decodeComplianceWorkItemCursor(encoded)
+	if err != nil || got.ID != want.ID || !got.UpdatedAt.Equal(want.UpdatedAt) {
+		t.Fatalf("decodeComplianceWorkItemCursor() = %+v, %v; want %+v", got, err, want)
+	}
+	for _, value := range []string{"not-base64", "e30"} {
+		if _, err := decodeComplianceWorkItemCursor(value); !errors.Is(err, complianceremediation.ErrInvalidRequest) {
+			t.Fatalf("decodeComplianceWorkItemCursor(%q) error = %v, want ErrInvalidRequest", value, err)
+		}
+	}
+}

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -1015,6 +1015,130 @@ export type Claim = {
   valid_to?: string;
 };
 
+export type ComplianceWorkActionRecord = {
+  action: "assign" | "request_evidence" | "block" | "snooze" | "accept" | "remediate" | "verify" | "verify_assurance" | "close" | "supersede";
+  action_hash: string;
+  actor_id: string;
+  created_at: string;
+  from: ComplianceWorkItemState;
+  id: string;
+  owner_id: string;
+  rationale: string;
+  to: ComplianceWorkItemState;
+  verification?: ComplianceWorkVerification;
+  work_item_id: string;
+};
+
+export type ComplianceWorkCommand = {
+  action?: "assign" | "request_evidence" | "block" | "snooze" | "accept" | "remediate" | "verify" | "verify_assurance" | "close" | "supersede";
+  assurance_decision_id?: string;
+  blocker_reason?: string;
+  due_at?: string;
+  evidence_ids?: string[];
+  expected_version: number;
+  operation: "action" | "invalidate";
+  owner_id?: string;
+  rationale?: string;
+  snooze_until?: string;
+  source_ref?: string;
+  trigger?: "exception_expired" | "evidence_stale" | "evidence_revoked" | "finding_reopened" | "source_coverage_lost" | "scope_subject_added";
+};
+
+export type ComplianceWorkFingerprint = {
+  control_id: string;
+  kind: ComplianceWorkItemKind;
+  objective_id: string;
+  program_id: string;
+  reason: string;
+  scope_revision_id: string;
+  source_id: string;
+  subject_id: string;
+  tenant_id: string;
+};
+
+export type ComplianceWorkItem = {
+  basis: ComplianceWorkFingerprint;
+  blocker_reason?: string;
+  due_at: string;
+  exception_id?: string;
+  fingerprint: string;
+  fingerprint_version: "compliance-work-fingerprint/v1";
+  id: string;
+  last_remediated_at?: string;
+  last_remediated_by?: string;
+  last_reopen_trigger?: "exception_expired" | "evidence_stale" | "evidence_revoked" | "finding_reopened" | "source_coverage_lost" | "scope_subject_added";
+  occurrences: ComplianceWorkOccurrence[];
+  owner_id: string;
+  priority: string;
+  risk_id?: string;
+  snooze_until?: string;
+  state: ComplianceWorkItemState;
+  updated_at: string;
+  verification?: ComplianceWorkVerification;
+  verification_evidence_ids?: string[];
+  verification_required: boolean;
+  verified_by?: string;
+  version: number;
+};
+
+export type ComplianceWorkItemKind =
+  | "remediate_finding"
+  | "collect_evidence"
+  | "refresh_evidence"
+  | "resolve_conflict"
+  | "review_manual_evidence"
+  | "repair_source"
+  | "assign_owner"
+  | "map_control"
+  | "renew_exception"
+  | "resolve_policy_gap"
+  | "complete_access_change"
+  | "answer_audit_request"
+  | "review_vendor";
+
+export type ComplianceWorkItemPage = {
+  items: ComplianceWorkItem[];
+  next_cursor?: string;
+};
+
+export type ComplianceWorkItemRecord = {
+  actions: ComplianceWorkActionRecord[];
+  item: ComplianceWorkItem;
+  occurrences: ComplianceWorkOccurrence[];
+};
+
+export type ComplianceWorkItemState =
+  | "open"
+  | "in_progress"
+  | "blocked"
+  | "resolved"
+  | "accepted"
+  | "snoozed"
+  | "superseded";
+
+export type ComplianceWorkOccurrence = {
+  assessment_run_id: string;
+  automated_result_hash: string;
+  evidence_ids?: string[];
+  finding_ids?: string[];
+  id: string;
+  objective_result_id: string;
+  occurred_at: string;
+  occurrence_hash: string;
+  work_item_id: string;
+};
+
+export type ComplianceWorkVerification = {
+  assessment_run_id: string;
+  assurance_decision_id: string;
+  decision_as_of: string;
+  decision_digest: string;
+  evaluated_at: string;
+  evidence_ids?: string[];
+  objective_result_id: string;
+  record_digest: string;
+};
+
 export type ConnectorCoveragePageResponse = {
   blind_spot_summaries?: SourceCoverageSummary[];
   blind_spots?: SourceCoverageRecord[];

--- a/sdk/typescript/src/index.js
+++ b/sdk/typescript/src/index.js
@@ -55,6 +55,41 @@ export class Client {
         }
         return this.requestJson("GET", `/platform/graph/neighborhood?${query.toString()}`);
     }
+    async listComplianceWorkItems(options = {}) {
+        const query = new URLSearchParams();
+        if (options.tenantId)
+            query.set("tenant_id", options.tenantId);
+        if (options.state)
+            query.set("state", options.state);
+        if (options.ownerId)
+            query.set("owner_id", options.ownerId);
+        if (options.cursor)
+            query.set("cursor", options.cursor);
+        if (options.limit !== undefined)
+            query.set("limit", String(options.limit));
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return this.requestJson("GET", `/grc/work-items${suffix}`);
+    }
+    async getComplianceWorkItem(workItemId, tenantId = "") {
+        const normalizedID = workItemId.trim();
+        if (!normalizedID)
+            throw new Error("workItemId is required");
+        const query = new URLSearchParams();
+        if (tenantId)
+            query.set("tenant_id", tenantId);
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return this.requestJson("GET", `/grc/work-items/${encodeURIComponent(normalizedID)}${suffix}`);
+    }
+    async commandComplianceWorkItem(workItemId, command, tenantId = "") {
+        const normalizedID = workItemId.trim();
+        if (!normalizedID)
+            throw new Error("workItemId is required");
+        const query = new URLSearchParams();
+        if (tenantId)
+            query.set("tenant_id", tenantId);
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return this.requestJson("POST", `/grc/work-items/${encodeURIComponent(normalizedID)}/commands${suffix}`, command);
+    }
     async createJob(request, idempotencyKey = "") {
         const headers = {};
         if (idempotencyKey) {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,4 +1,8 @@
 import type {
+  ComplianceWorkCommand,
+  ComplianceWorkItemPage,
+  ComplianceWorkItemRecord,
+  ComplianceWorkItemState,
   CreatePlatformJobRequest,
   GetSourceRuntimeResponse,
   PlatformJobEventListResponse,
@@ -9,6 +13,15 @@ import type {
 } from "./generated/openapi-types.ts";
 
 export type {
+  ComplianceWorkActionRecord,
+  ComplianceWorkCommand,
+  ComplianceWorkItem,
+  ComplianceWorkItemKind,
+  ComplianceWorkItemPage,
+  ComplianceWorkItemRecord,
+  ComplianceWorkItemState,
+  ComplianceWorkOccurrence,
+  ComplianceWorkVerification,
   GetSourceRuntimeResponse,
   PlatformJob,
   PlatformJobEvent,
@@ -18,6 +31,14 @@ export type {
   PutSourceRuntimeResponse,
   SourceRuntime,
 } from "./generated/openapi-types.ts";
+
+export interface ListComplianceWorkItemsOptions {
+  tenantId?: string;
+  state?: ComplianceWorkItemState;
+  ownerId?: string;
+  cursor?: string;
+  limit?: number;
+}
 
 export interface ClientConfig {
   baseUrl: string;
@@ -188,6 +209,35 @@ export class Client {
       query.set("limit", String(limit));
     }
     return this.requestJson<GraphNeighborhood>("GET", `/platform/graph/neighborhood?${query.toString()}`);
+  }
+
+  async listComplianceWorkItems(options: ListComplianceWorkItemsOptions = {}): Promise<ComplianceWorkItemPage> {
+    const query = new URLSearchParams();
+    if (options.tenantId) query.set("tenant_id", options.tenantId);
+    if (options.state) query.set("state", options.state);
+    if (options.ownerId) query.set("owner_id", options.ownerId);
+    if (options.cursor) query.set("cursor", options.cursor);
+    if (options.limit !== undefined) query.set("limit", String(options.limit));
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    return this.requestJson<ComplianceWorkItemPage>("GET", `/grc/work-items${suffix}`);
+  }
+
+  async getComplianceWorkItem(workItemId: string, tenantId = ""): Promise<ComplianceWorkItemRecord> {
+    const normalizedID = workItemId.trim();
+    if (!normalizedID) throw new Error("workItemId is required");
+    const query = new URLSearchParams();
+    if (tenantId) query.set("tenant_id", tenantId);
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    return this.requestJson<ComplianceWorkItemRecord>("GET", `/grc/work-items/${encodeURIComponent(normalizedID)}${suffix}`);
+  }
+
+  async commandComplianceWorkItem(workItemId: string, command: ComplianceWorkCommand, tenantId = ""): Promise<ComplianceWorkItemRecord> {
+    const normalizedID = workItemId.trim();
+    if (!normalizedID) throw new Error("workItemId is required");
+    const query = new URLSearchParams();
+    if (tenantId) query.set("tenant_id", tenantId);
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    return this.requestJson<ComplianceWorkItemRecord>("POST", `/grc/work-items/${encodeURIComponent(normalizedID)}/commands${suffix}`, command);
   }
 
   async createJob(request: CreateJobRequest, idempotencyKey = ""): Promise<PlatformJobResponse> {

--- a/sdk/typescript/test/compliance-work-items.test.mjs
+++ b/sdk/typescript/test/compliance-work-items.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Client } from "../src/index.js";
+
+test("compliance work item methods preserve canonical ids, filters, versions, and commands", async () => {
+  const requests = [];
+  const item = {
+    id: "compliance-work-item-a",
+    fingerprint_version: "compliance-work-fingerprint/v1",
+    fingerprint: "sha256:a",
+    basis: {
+      tenant_id: "tenant-a",
+      program_id: "program-a",
+      scope_revision_id: "scope-a",
+      control_id: "control-a",
+      objective_id: "objective-a",
+      kind: "remediate_finding",
+      subject_id: "subject-a",
+      reason: "active_finding",
+      source_id: "runtime-a",
+    },
+    state: "in_progress",
+    owner_id: "owner-a",
+    due_at: "2026-07-16T00:00:00Z",
+    priority: "high",
+    verification_required: true,
+    occurrences: [],
+    version: 2,
+    updated_at: "2026-07-15T00:00:00Z",
+  };
+  const record = { item, occurrences: [], actions: [] };
+  const client = new Client({
+    baseUrl: "https://cerebro.example.com/",
+    fetchImpl: async (url, init = {}) => {
+      requests.push({ url: String(url), method: init.method, body: init.body });
+      const payload = String(url).includes("/commands") ? record : String(url).includes("compliance-work-item-a") ? record : { items: [item], next_cursor: "cursor-b" };
+      return new Response(JSON.stringify(payload), { status: 200, headers: { "Content-Type": "application/json" } });
+    },
+  });
+
+  const page = await client.listComplianceWorkItems({ tenantId: "tenant-a", state: "in_progress", ownerId: "owner-a", cursor: "cursor-a", limit: 25 });
+  assert.equal(page.items[0].id, item.id);
+  assert.equal(page.next_cursor, "cursor-b");
+  const listURL = new URL(requests[0].url);
+  assert.equal(listURL.pathname, "/grc/work-items");
+  assert.deepEqual(Object.fromEntries(listURL.searchParams), {
+    tenant_id: "tenant-a",
+    state: "in_progress",
+    owner_id: "owner-a",
+    cursor: "cursor-a",
+    limit: "25",
+  });
+
+  const fetched = await client.getComplianceWorkItem(item.id, "tenant-a");
+  assert.equal(fetched.item.version, 2);
+  const command = {
+    operation: "action",
+    expected_version: 2,
+    action: "verify_assurance",
+    assurance_decision_id: "assurance-decision-a",
+    rationale: "Verify the post-change assessment.",
+  };
+  const updated = await client.commandComplianceWorkItem(item.id, command, "tenant-a");
+  assert.equal(updated.item.id, item.id);
+  assert.equal(requests[2].method, "POST");
+  assert.deepEqual(JSON.parse(requests[2].body), command);
+  assert.equal(new URL(requests[2].url).searchParams.get("tenant_id"), "tenant-a");
+});

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -120,7 +120,10 @@ import (
 // Assurance decision routes add only service composition and route/auth
 // registration; decision validation and persistence remain in
 // internal/complianceassessment.
-const bootstrapProductionGoLineBudget = 28037
+// Canonical compliance work adds query composition and response mapping;
+// bounded queries and assurance verification remain in the domain and
+// state-store packages.
+const bootstrapProductionGoLineBudget = 28071
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## What changed

- add a tenant-scoped, cursor-paginated API for the canonical compliance and security work queue
- add `verify_assurance`, which binds work resolution to a qualified, matching, post-remediation assurance decision
- retain existing work-item creation, read, command, remediation-plan, and verification behavior
- expose typed work-item list, read, and command methods in the TypeScript SDK
- document the canonical-record boundary, rollout gates, and rollback sequence

## Behavior

Assurance verification fails before append when the command version is stale or the decision is unqualified, unsatisfied, mismatched, not source-bound, or not newer than the remediation action. The service derives the verification receipt from the persisted decision instead of trusting caller-supplied evidence.

## Validation

- focused Go tests for the domain, service, Postgres adapter, HTTP composition, and generator
- race tests for compliance assessment and remediation packages
- OpenAPI route parity, lint, and generated-type freshness
- TypeScript SDK typecheck and runtime tests
- structural and architecture checks
- documentation drift and contract checks

## Dependency

This change is stacked on the assurance-decision API change in #1865.
