### PR TITLE
Extract reusable agent decision guardrails

### DIFF
--- a/internal/agentplatform/decision_guardrails.go
+++ b/internal/agentplatform/decision_guardrails.go
@@ -1,0 +1,74 @@
+package agentplatform
+
+const (
+	AgentReadinessReady             = "ready"
+	AgentReadinessReadyWithWarnings = "ready_with_warnings"
+	AgentReadinessBlocked           = "blocked"
+)
+
+// AgentDecisionGuardrails is the reusable policy projection applied before a
+// caller reasons about a decision. Readiness describes whether the agent may
+// proceed; it does not describe confidence in a decision outcome.
+type AgentDecisionGuardrails struct {
+	Version            string                      `json:"version"`
+	Preflight          AgentRunPreflight           `json:"preflight"`
+	VerifierResults    []AgentVerifierResult       `json:"verifier_results"`
+	ActionLadder       []AgentActionStageStatus    `json:"action_ladder"`
+	ConnectorToolGates []ConnectorToolGateDecision `json:"connector_tool_gates"`
+	Readiness          AgentReadinessAssessment    `json:"readiness"`
+	RequiredWriteBack  []string                    `json:"required_write_back"`
+}
+
+type AgentReadinessAssessment struct {
+	State   string   `json:"state"`
+	Reasons []string `json:"reasons"`
+}
+
+// BuildAgentDecisionGuardrails applies the existing preflight, verifier,
+// connector, and action policies without loading or resolving decision facts.
+func BuildAgentDecisionGuardrails(request EvidencePacketRequest) AgentDecisionGuardrails {
+	request = normalizeEvidencePacketRequest(request)
+	preflight := PreflightAgentRun(AgentRunPreflightRequest{
+		TenantID:              request.TenantID,
+		ActorID:               request.ActorID,
+		CapabilityIDs:         request.CapabilityIDs,
+		Question:              request.Question,
+		ScopeURN:              request.ScopeURN,
+		Model:                 request.Model,
+		RequestedScopes:       request.RequestedScopes,
+		ScopeUnrestricted:     request.ScopeUnrestricted,
+		ConnectorReadiness:    request.ConnectorReadiness,
+		EvalStatusOverrides:   request.EvalStatusOverrides,
+		AllowPreview:          request.AllowPreview,
+		SelectionReason:       "evidence_packet",
+		ProvenanceRequirement: "",
+		CoverageContext:       request.CoverageContext,
+	})
+	agents := selectedSecurityAgentProfiles(request, preflight)
+	verifiers := evaluateAgentVerifiers(request, preflight, agents)
+
+	return AgentDecisionGuardrails{
+		Version:            ContractVersion,
+		Preflight:          preflight,
+		VerifierResults:    verifiers,
+		ActionLadder:       actionStageStatuses(request, verifiers),
+		ConnectorToolGates: decideConnectorToolGates(preflight),
+		Readiness:          agentReadinessAssessment(preflight, verifiers),
+		RequiredWriteBack:  evidencePacketWriteBack(preflight),
+	}
+}
+
+func agentReadinessAssessment(preflight AgentRunPreflight, verifiers []AgentVerifierResult) AgentReadinessAssessment {
+	state := AgentReadinessReady
+	reasons := []string{"guardrails_passed"}
+
+	if !preflight.Enabled || verifierStatusCount(verifiers, "blocked") > 0 {
+		state = AgentReadinessBlocked
+		reasons = []string{"guardrails_blocked"}
+	} else if verifierStatusCount(verifiers, "warning") > 0 {
+		state = AgentReadinessReadyWithWarnings
+		reasons = []string{"guardrail_warnings"}
+	}
+
+	return AgentReadinessAssessment{State: state, Reasons: reasons}
+}

--- a/internal/agentplatform/decision_guardrails_test.go
+++ b/internal/agentplatform/decision_guardrails_test.go
@@ -1,0 +1,128 @@
+package agentplatform
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestBuildAgentDecisionGuardrailsReadiness(t *testing.T) {
+	tests := []struct {
+		name string
+		req  EvidencePacketRequest
+		want string
+	}{
+		{
+			name: "ready",
+			req: EvidencePacketRequest{
+				TenantID:        "tenant-1",
+				ActorID:         "analyst-1",
+				Question:        "Review this finding",
+				ScopeURN:        "urn:cerebro:tenant-1:finding:finding-1",
+				CapabilityIDs:   []string{"graph-reasoning"},
+				RequestedScopes: []string{ScopeCosmoSecurityRead},
+				Action:          EvidencePacketAction{Stage: ActionStageRecommend},
+				CoverageContext: &AgentCoverageContext{Version: ContractVersion, TenantID: "tenant-1"},
+			},
+			want: AgentReadinessReady,
+		},
+		{
+			name: "ready with warnings",
+			req: EvidencePacketRequest{
+				TenantID:        "tenant-1",
+				ActorID:         "analyst-1",
+				Question:        "Review this finding",
+				ScopeURN:        "urn:cerebro:tenant-1:finding:finding-1",
+				CapabilityIDs:   []string{"graph-reasoning"},
+				RequestedScopes: []string{ScopeCosmoSecurityRead},
+				Action:          EvidencePacketAction{Stage: ActionStageRecommend},
+				CoverageContext: &AgentCoverageContext{Version: ContractVersion, TenantID: "tenant-1", BlindSpotCount: 1},
+			},
+			want: AgentReadinessReadyWithWarnings,
+		},
+		{
+			name: "blocked",
+			req: EvidencePacketRequest{
+				TenantID:        "tenant-1",
+				ActorID:         "analyst-1",
+				Question:        "Execute this action",
+				ScopeURN:        "urn:cerebro:tenant-1:finding:finding-1",
+				CapabilityIDs:   []string{"graph-reasoning", "runtime-response-actions"},
+				RequestedScopes: []string{ScopeCosmoSecurityRead, ScopeRuntimeResponseWrite},
+				AllowPreview:    true,
+				Action:          EvidencePacketAction{Stage: ActionStageExecute},
+			},
+			want: AgentReadinessBlocked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildAgentDecisionGuardrails(tt.req)
+			if got.Readiness.State != tt.want {
+				t.Fatalf("readiness = %+v, want %q", got.Readiness, tt.want)
+			}
+			if len(got.Readiness.Reasons) == 0 {
+				t.Fatal("readiness reasons are empty")
+			}
+		})
+	}
+}
+
+func TestBuildEvidencePacketCanonicalJSONCompatibility(t *testing.T) {
+	request := EvidencePacketRequest{
+		TenantID:        " tenant-1 ",
+		ActorID:         " analyst-1 ",
+		Question:        " Review this finding ",
+		ScopeURN:        " urn:cerebro:tenant-1:finding:finding-1 ",
+		CapabilityIDs:   []string{"knowledge-provenance", "graph-reasoning", "graph-reasoning"},
+		RequestedScopes: []string{ScopeCosmoSecurityRead},
+		EvidenceURNs:    []string{"urn:cerebro:tenant-1:evidence:evidence-1"},
+		GeneratedAt:     "2026-07-15T08:00:00Z",
+		Action:          EvidencePacketAction{Stage: ActionStageRecommend},
+		CoverageContext: &AgentCoverageContext{Version: ContractVersion, TenantID: "tenant-1"},
+	}
+
+	want := buildLegacyEvidencePacketForTest(request)
+	got := BuildEvidencePacket(request)
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal legacy packet: %v", err)
+	}
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal adapted packet: %v", err)
+	}
+	if !reflect.DeepEqual(gotJSON, wantJSON) {
+		t.Fatalf("canonical JSON changed\n got: %s\nwant: %s", gotJSON, wantJSON)
+	}
+}
+
+// buildLegacyEvidencePacketForTest preserves the pre-extraction assembly so
+// the compatibility test detects any change in the existing response.
+func buildLegacyEvidencePacketForTest(request EvidencePacketRequest) AgentEvidencePacket {
+	request = normalizeEvidencePacketRequest(request)
+	preflight := PreflightAgentRun(AgentRunPreflightRequest{
+		TenantID: request.TenantID, ActorID: request.ActorID, CapabilityIDs: request.CapabilityIDs,
+		Question: request.Question, ScopeURN: request.ScopeURN, Model: request.Model,
+		RequestedScopes: request.RequestedScopes, ScopeUnrestricted: request.ScopeUnrestricted,
+		ConnectorReadiness: request.ConnectorReadiness, EvalStatusOverrides: request.EvalStatusOverrides,
+		AllowPreview: request.AllowPreview, SelectionReason: "evidence_packet",
+		CoverageContext: request.CoverageContext,
+	})
+	agents := selectedSecurityAgentProfiles(request, preflight)
+	verifiers := evaluateAgentVerifiers(request, preflight, agents)
+	packet := AgentEvidencePacket{
+		Version: ContractVersion, TenantID: request.TenantID, ActorID: request.ActorID,
+		Question: request.Question, ScopeURN: request.ScopeURN,
+		GeneratedAt: evidencePacketGeneratedAt(request.GeneratedAt), Preflight: preflight,
+		EvidenceRefs: evidenceReferences(request, preflight), RecommendedAgents: agents,
+		VerifierResults: verifiers, ActionLadder: actionStageStatuses(request, verifiers),
+		EvalChecklist: evalChecklistForAgents(agents), SecurityMemory: securityMemoryPlan(request),
+		ConnectorToolGates: decideConnectorToolGates(preflight),
+		SimulationPlan:     defensiveSimulationPlan(request, verifiers),
+		RequiredWriteBack:  evidencePacketWriteBack(preflight),
+	}
+	packet.Confidence = evidencePacketConfidence(packet)
+	return packet
+}

--- a/internal/agentplatform/security_control_plane.go
+++ b/internal/agentplatform/security_control_plane.go
@@ -274,42 +274,25 @@ func SecurityControlPlaneSnapshot() SecurityControlPlane {
 
 func BuildEvidencePacket(request EvidencePacketRequest) AgentEvidencePacket {
 	request = normalizeEvidencePacketRequest(request)
-	preflight := PreflightAgentRun(AgentRunPreflightRequest{
-		TenantID:              request.TenantID,
-		ActorID:               request.ActorID,
-		CapabilityIDs:         request.CapabilityIDs,
-		Question:              request.Question,
-		ScopeURN:              request.ScopeURN,
-		Model:                 request.Model,
-		RequestedScopes:       request.RequestedScopes,
-		ScopeUnrestricted:     request.ScopeUnrestricted,
-		ConnectorReadiness:    request.ConnectorReadiness,
-		EvalStatusOverrides:   request.EvalStatusOverrides,
-		AllowPreview:          request.AllowPreview,
-		SelectionReason:       "evidence_packet",
-		ProvenanceRequirement: "",
-		CoverageContext:       request.CoverageContext,
-	})
-	agents := selectedSecurityAgentProfiles(request, preflight)
-	verifiers := evaluateAgentVerifiers(request, preflight, agents)
-	gates := decideConnectorToolGates(preflight)
+	guardrails := BuildAgentDecisionGuardrails(request)
+	agents := selectedSecurityAgentProfiles(request, guardrails.Preflight)
 	packet := AgentEvidencePacket{
-		Version:            ContractVersion,
+		Version:            guardrails.Version,
 		TenantID:           request.TenantID,
 		ActorID:            request.ActorID,
 		Question:           request.Question,
 		ScopeURN:           request.ScopeURN,
 		GeneratedAt:        evidencePacketGeneratedAt(request.GeneratedAt),
-		Preflight:          preflight,
-		EvidenceRefs:       evidenceReferences(request, preflight),
+		Preflight:          guardrails.Preflight,
+		EvidenceRefs:       evidenceReferences(request, guardrails.Preflight),
 		RecommendedAgents:  agents,
-		VerifierResults:    verifiers,
-		ActionLadder:       actionStageStatuses(request, verifiers),
+		VerifierResults:    guardrails.VerifierResults,
+		ActionLadder:       guardrails.ActionLadder,
 		EvalChecklist:      evalChecklistForAgents(agents),
 		SecurityMemory:     securityMemoryPlan(request),
-		ConnectorToolGates: gates,
-		SimulationPlan:     defensiveSimulationPlan(request, verifiers),
-		RequiredWriteBack:  evidencePacketWriteBack(preflight),
+		ConnectorToolGates: guardrails.ConnectorToolGates,
+		SimulationPlan:     defensiveSimulationPlan(request, guardrails.VerifierResults),
+		RequiredWriteBack:  guardrails.RequiredWriteBack,
 	}
 	packet.Confidence = evidencePacketConfidence(packet)
 	return packet


### PR DESCRIPTION
## Summary
- extract a reusable decision guardrail projection from the existing agent evidence packet builder
- distinguish agent readiness from decision confidence
- preserve the existing evidence-packet response across HTTP, MCP, and A2A callers

## Validation
- `go test ./internal/agentplatform -count=1`
- `go test ./internal/bootstrap ./internal/agentplatform -count=1`
- `make check-structural check-structural-test check-arch`
- `make lint`

## Compatibility
The existing evidence-packet route, skill, fields, and fixed-input JSON remain unchanged.