### PR TITLE
Define deterministic decision packet rules

### DIFF
--- a/internal/agentplatform/decision_guardrails.go
+++ b/internal/agentplatform/decision_guardrails.go
@@ -1,0 +1,74 @@
+package agentplatform
+
+const (
+	AgentReadinessReady             = "ready"
+	AgentReadinessReadyWithWarnings = "ready_with_warnings"
+	AgentReadinessBlocked           = "blocked"
+)
+
+// AgentDecisionGuardrails is the reusable policy projection applied before a
+// caller reasons about a decision. Readiness describes whether the agent may
+// proceed; it does not describe confidence in a decision outcome.
+type AgentDecisionGuardrails struct {
+	Version            string                      `json:"version"`
+	Preflight          AgentRunPreflight           `json:"preflight"`
+	VerifierResults    []AgentVerifierResult       `json:"verifier_results"`
+	ActionLadder       []AgentActionStageStatus    `json:"action_ladder"`
+	ConnectorToolGates []ConnectorToolGateDecision `json:"connector_tool_gates"`
+	Readiness          AgentReadinessAssessment    `json:"readiness"`
+	RequiredWriteBack  []string                    `json:"required_write_back"`
+}
+
+type AgentReadinessAssessment struct {
+	State   string   `json:"state"`
+	Reasons []string `json:"reasons"`
+}
+
+// BuildAgentDecisionGuardrails applies the existing preflight, verifier,
+// connector, and action policies without loading or resolving decision facts.
+func BuildAgentDecisionGuardrails(request EvidencePacketRequest) AgentDecisionGuardrails {
+	request = normalizeEvidencePacketRequest(request)
+	preflight := PreflightAgentRun(AgentRunPreflightRequest{
+		TenantID:              request.TenantID,
+		ActorID:               request.ActorID,
+		CapabilityIDs:         request.CapabilityIDs,
+		Question:              request.Question,
+		ScopeURN:              request.ScopeURN,
+		Model:                 request.Model,
+		RequestedScopes:       request.RequestedScopes,
+		ScopeUnrestricted:     request.ScopeUnrestricted,
+		ConnectorReadiness:    request.ConnectorReadiness,
+		EvalStatusOverrides:   request.EvalStatusOverrides,
+		AllowPreview:          request.AllowPreview,
+		SelectionReason:       "evidence_packet",
+		ProvenanceRequirement: "",
+		CoverageContext:       request.CoverageContext,
+	})
+	agents := selectedSecurityAgentProfiles(request, preflight)
+	verifiers := evaluateAgentVerifiers(request, preflight, agents)
+
+	return AgentDecisionGuardrails{
+		Version:            ContractVersion,
+		Preflight:          preflight,
+		VerifierResults:    verifiers,
+		ActionLadder:       actionStageStatuses(request, verifiers),
+		ConnectorToolGates: decideConnectorToolGates(preflight),
+		Readiness:          agentReadinessAssessment(preflight, verifiers),
+		RequiredWriteBack:  evidencePacketWriteBack(preflight),
+	}
+}
+
+func agentReadinessAssessment(preflight AgentRunPreflight, verifiers []AgentVerifierResult) AgentReadinessAssessment {
+	state := AgentReadinessReady
+	reasons := []string{"guardrails_passed"}
+
+	if !preflight.Enabled || verifierStatusCount(verifiers, "blocked") > 0 {
+		state = AgentReadinessBlocked
+		reasons = []string{"guardrails_blocked"}
+	} else if verifierStatusCount(verifiers, "warning") > 0 {
+		state = AgentReadinessReadyWithWarnings
+		reasons = []string{"guardrail_warnings"}
+	}
+
+	return AgentReadinessAssessment{State: state, Reasons: reasons}
+}

--- a/internal/agentplatform/decision_guardrails_test.go
+++ b/internal/agentplatform/decision_guardrails_test.go
@@ -1,0 +1,128 @@
+package agentplatform
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestBuildAgentDecisionGuardrailsReadiness(t *testing.T) {
+	tests := []struct {
+		name string
+		req  EvidencePacketRequest
+		want string
+	}{
+		{
+			name: "ready",
+			req: EvidencePacketRequest{
+				TenantID:        "tenant-1",
+				ActorID:         "analyst-1",
+				Question:        "Review this finding",
+				ScopeURN:        "urn:cerebro:tenant-1:finding:finding-1",
+				CapabilityIDs:   []string{"graph-reasoning"},
+				RequestedScopes: []string{ScopeCosmoSecurityRead},
+				Action:          EvidencePacketAction{Stage: ActionStageRecommend},
+				CoverageContext: &AgentCoverageContext{Version: ContractVersion, TenantID: "tenant-1"},
+			},
+			want: AgentReadinessReady,
+		},
+		{
+			name: "ready with warnings",
+			req: EvidencePacketRequest{
+				TenantID:        "tenant-1",
+				ActorID:         "analyst-1",
+				Question:        "Review this finding",
+				ScopeURN:        "urn:cerebro:tenant-1:finding:finding-1",
+				CapabilityIDs:   []string{"graph-reasoning"},
+				RequestedScopes: []string{ScopeCosmoSecurityRead},
+				Action:          EvidencePacketAction{Stage: ActionStageRecommend},
+				CoverageContext: &AgentCoverageContext{Version: ContractVersion, TenantID: "tenant-1", BlindSpotCount: 1},
+			},
+			want: AgentReadinessReadyWithWarnings,
+		},
+		{
+			name: "blocked",
+			req: EvidencePacketRequest{
+				TenantID:        "tenant-1",
+				ActorID:         "analyst-1",
+				Question:        "Execute this action",
+				ScopeURN:        "urn:cerebro:tenant-1:finding:finding-1",
+				CapabilityIDs:   []string{"graph-reasoning", "runtime-response-actions"},
+				RequestedScopes: []string{ScopeCosmoSecurityRead, ScopeRuntimeResponseWrite},
+				AllowPreview:    true,
+				Action:          EvidencePacketAction{Stage: ActionStageExecute},
+			},
+			want: AgentReadinessBlocked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildAgentDecisionGuardrails(tt.req)
+			if got.Readiness.State != tt.want {
+				t.Fatalf("readiness = %+v, want %q", got.Readiness, tt.want)
+			}
+			if len(got.Readiness.Reasons) == 0 {
+				t.Fatal("readiness reasons are empty")
+			}
+		})
+	}
+}
+
+func TestBuildEvidencePacketCanonicalJSONCompatibility(t *testing.T) {
+	request := EvidencePacketRequest{
+		TenantID:        " tenant-1 ",
+		ActorID:         " analyst-1 ",
+		Question:        " Review this finding ",
+		ScopeURN:        " urn:cerebro:tenant-1:finding:finding-1 ",
+		CapabilityIDs:   []string{"knowledge-provenance", "graph-reasoning", "graph-reasoning"},
+		RequestedScopes: []string{ScopeCosmoSecurityRead},
+		EvidenceURNs:    []string{"urn:cerebro:tenant-1:evidence:evidence-1"},
+		GeneratedAt:     "2026-07-15T08:00:00Z",
+		Action:          EvidencePacketAction{Stage: ActionStageRecommend},
+		CoverageContext: &AgentCoverageContext{Version: ContractVersion, TenantID: "tenant-1"},
+	}
+
+	want := buildLegacyEvidencePacketForTest(request)
+	got := BuildEvidencePacket(request)
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal legacy packet: %v", err)
+	}
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal adapted packet: %v", err)
+	}
+	if !reflect.DeepEqual(gotJSON, wantJSON) {
+		t.Fatalf("canonical JSON changed\n got: %s\nwant: %s", gotJSON, wantJSON)
+	}
+}
+
+// buildLegacyEvidencePacketForTest preserves the pre-extraction assembly so
+// the compatibility test detects any change in the existing response.
+func buildLegacyEvidencePacketForTest(request EvidencePacketRequest) AgentEvidencePacket {
+	request = normalizeEvidencePacketRequest(request)
+	preflight := PreflightAgentRun(AgentRunPreflightRequest{
+		TenantID: request.TenantID, ActorID: request.ActorID, CapabilityIDs: request.CapabilityIDs,
+		Question: request.Question, ScopeURN: request.ScopeURN, Model: request.Model,
+		RequestedScopes: request.RequestedScopes, ScopeUnrestricted: request.ScopeUnrestricted,
+		ConnectorReadiness: request.ConnectorReadiness, EvalStatusOverrides: request.EvalStatusOverrides,
+		AllowPreview: request.AllowPreview, SelectionReason: "evidence_packet",
+		CoverageContext: request.CoverageContext,
+	})
+	agents := selectedSecurityAgentProfiles(request, preflight)
+	verifiers := evaluateAgentVerifiers(request, preflight, agents)
+	packet := AgentEvidencePacket{
+		Version: ContractVersion, TenantID: request.TenantID, ActorID: request.ActorID,
+		Question: request.Question, ScopeURN: request.ScopeURN,
+		GeneratedAt: evidencePacketGeneratedAt(request.GeneratedAt), Preflight: preflight,
+		EvidenceRefs: evidenceReferences(request, preflight), RecommendedAgents: agents,
+		VerifierResults: verifiers, ActionLadder: actionStageStatuses(request, verifiers),
+		EvalChecklist: evalChecklistForAgents(agents), SecurityMemory: securityMemoryPlan(request),
+		ConnectorToolGates: decideConnectorToolGates(preflight),
+		SimulationPlan:     defensiveSimulationPlan(request, verifiers),
+		RequiredWriteBack:  evidencePacketWriteBack(preflight),
+	}
+	packet.Confidence = evidencePacketConfidence(packet)
+	return packet
+}

--- a/internal/agentplatform/security_control_plane.go
+++ b/internal/agentplatform/security_control_plane.go
@@ -274,42 +274,25 @@ func SecurityControlPlaneSnapshot() SecurityControlPlane {
 
 func BuildEvidencePacket(request EvidencePacketRequest) AgentEvidencePacket {
 	request = normalizeEvidencePacketRequest(request)
-	preflight := PreflightAgentRun(AgentRunPreflightRequest{
-		TenantID:              request.TenantID,
-		ActorID:               request.ActorID,
-		CapabilityIDs:         request.CapabilityIDs,
-		Question:              request.Question,
-		ScopeURN:              request.ScopeURN,
-		Model:                 request.Model,
-		RequestedScopes:       request.RequestedScopes,
-		ScopeUnrestricted:     request.ScopeUnrestricted,
-		ConnectorReadiness:    request.ConnectorReadiness,
-		EvalStatusOverrides:   request.EvalStatusOverrides,
-		AllowPreview:          request.AllowPreview,
-		SelectionReason:       "evidence_packet",
-		ProvenanceRequirement: "",
-		CoverageContext:       request.CoverageContext,
-	})
-	agents := selectedSecurityAgentProfiles(request, preflight)
-	verifiers := evaluateAgentVerifiers(request, preflight, agents)
-	gates := decideConnectorToolGates(preflight)
+	guardrails := BuildAgentDecisionGuardrails(request)
+	agents := selectedSecurityAgentProfiles(request, guardrails.Preflight)
 	packet := AgentEvidencePacket{
-		Version:            ContractVersion,
+		Version:            guardrails.Version,
 		TenantID:           request.TenantID,
 		ActorID:            request.ActorID,
 		Question:           request.Question,
 		ScopeURN:           request.ScopeURN,
 		GeneratedAt:        evidencePacketGeneratedAt(request.GeneratedAt),
-		Preflight:          preflight,
-		EvidenceRefs:       evidenceReferences(request, preflight),
+		Preflight:          guardrails.Preflight,
+		EvidenceRefs:       evidenceReferences(request, guardrails.Preflight),
 		RecommendedAgents:  agents,
-		VerifierResults:    verifiers,
-		ActionLadder:       actionStageStatuses(request, verifiers),
+		VerifierResults:    guardrails.VerifierResults,
+		ActionLadder:       guardrails.ActionLadder,
 		EvalChecklist:      evalChecklistForAgents(agents),
 		SecurityMemory:     securityMemoryPlan(request),
-		ConnectorToolGates: gates,
-		SimulationPlan:     defensiveSimulationPlan(request, verifiers),
-		RequiredWriteBack:  evidencePacketWriteBack(preflight),
+		ConnectorToolGates: guardrails.ConnectorToolGates,
+		SimulationPlan:     defensiveSimulationPlan(request, guardrails.VerifierResults),
+		RequiredWriteBack:  guardrails.RequiredWriteBack,
 	}
 	packet.Confidence = evidencePacketConfidence(packet)
 	return packet

--- a/internal/decisionpacket/confidence.go
+++ b/internal/decisionpacket/confidence.go
@@ -1,0 +1,94 @@
+package decisionpacket
+
+import "github.com/writer/cerebro/internal/agentplatform"
+
+func DeriveDecision(inputs DecisionInputs) Decision {
+	if inputs.Applicable != nil && !*inputs.Applicable {
+		return Decision{State: DecisionNotApplicable, Reasons: []string{"explicitly_not_applicable"}}
+	}
+
+	state := DecisionInsufficientEvidence
+	reasons := []string{}
+	switch inputs.ClaimVerdict {
+	case agentplatform.ClaimVerdictSupported:
+		state = DecisionSupported
+	case agentplatform.ClaimVerdictWeaklySupported:
+		state = DecisionSupportedWithGaps
+		reasons = append(reasons, "weak_claim_support")
+	case agentplatform.ClaimVerdictContradicted:
+		state = DecisionBlocked
+		reasons = append(reasons, "claim_contradicted")
+	default:
+		reasons = append(reasons, "claim_evidence_insufficient")
+	}
+
+	if inputs.PrimaryConflict {
+		state = DecisionBlocked
+		reasons = append(reasons, "primary_claim_contradiction")
+	}
+	if state == DecisionSupported && (inputs.RequiredGap || inputs.RequiredStale || inputs.OutcomeTruncated) {
+		state = DecisionSupportedWithGaps
+	}
+	if inputs.RequiredGap {
+		reasons = append(reasons, "required_coverage_gap")
+	}
+	if inputs.RequiredStale {
+		reasons = append(reasons, "required_evidence_stale")
+	}
+	if inputs.OutcomeTruncated {
+		reasons = append(reasons, "decision_inputs_truncated")
+	}
+	if len(reasons) == 0 {
+		reasons = append(reasons, "claim_supported")
+	}
+	return Decision{State: state, Reasons: uniqueSortedStrings(reasons)}
+}
+
+func DeriveConfidence(inputs ConfidenceInputs) Confidence {
+	if inputs.SupportingEvidence == 0 {
+		return Confidence{Level: ConfidenceUnknown, Basis: []string{"no_supporting_evidence"}}
+	}
+
+	level := ConfidenceHigh
+	basis := []string{}
+	if !inputs.GuardrailsPassed {
+		level = ConfidenceLow
+		basis = append(basis, "guardrails_not_passed")
+	}
+	if inputs.RequiredGap {
+		level = ConfidenceLow
+		basis = append(basis, "required_coverage_gap")
+	}
+	if inputs.RequiredStale {
+		level = ConfidenceLow
+		basis = append(basis, "required_evidence_stale")
+	}
+	if inputs.RequiredUnverified {
+		level = ConfidenceLow
+		basis = append(basis, "required_source_unverified")
+	}
+	if inputs.OutcomeTruncated {
+		level = ConfidenceLow
+		basis = append(basis, "decision_inputs_truncated")
+	}
+	if inputs.UnresolvedConflict {
+		level = lowerConfidence(level, ConfidenceMedium)
+		basis = append(basis, "unresolved_contradiction")
+	}
+	if inputs.OptionalGapMatters {
+		level = lowerConfidence(level, ConfidenceMedium)
+		basis = append(basis, "material_optional_coverage_gap")
+	}
+	if len(basis) == 0 {
+		basis = append(basis, "fresh_complete_nonconflicting_evidence")
+	}
+	return Confidence{Level: level, Basis: uniqueSortedStrings(basis)}
+}
+
+func lowerConfidence(current, cap string) string {
+	rank := map[string]int{ConfidenceUnknown: 0, ConfidenceLow: 1, ConfidenceMedium: 2, ConfidenceHigh: 3}
+	if rank[current] > rank[cap] {
+		return cap
+	}
+	return current
+}

--- a/internal/decisionpacket/contradictions.go
+++ b/internal/decisionpacket/contradictions.go
@@ -1,0 +1,85 @@
+package decisionpacket
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+func DetectContradictions(observations []ClaimObservation) []Contradiction {
+	normalized := normalizeObservations(observations)
+	result := []Contradiction{}
+	for leftIndex := 0; leftIndex < len(normalized); leftIndex++ {
+		for rightIndex := leftIndex + 1; rightIndex < len(normalized); rightIndex++ {
+			left, right := normalized[leftIndex], normalized[rightIndex]
+			if !sameClaimKey(left, right) || left.Value == right.Value || !validityOverlaps(left, right) {
+				continue
+			}
+			if cleanlySuperseded(left, right) {
+				continue
+			}
+			idInput := strings.Join([]string{left.TenantID, left.SubjectURN, left.Predicate, left.Evidence.ID, right.Evidence.ID}, "\x00")
+			digest := sha256.Sum256([]byte(idInput))
+			result = append(result, Contradiction{
+				ID: fmt.Sprintf("con_%x", digest[:16]), SubjectURN: left.SubjectURN, Predicate: left.Predicate,
+				Left: left.Evidence, Right: right.Evidence, ResolutionState: ContradictionUnresolved,
+				PrimaryClaim: left.PrimaryClaim || right.PrimaryClaim,
+			})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+func normalizeObservations(values []ClaimObservation) []ClaimObservation {
+	result := make([]ClaimObservation, 0, len(values))
+	for _, value := range values {
+		value.TenantID = strings.TrimSpace(value.TenantID)
+		value.SubjectURN = strings.TrimSpace(value.SubjectURN)
+		value.Predicate = strings.ToLower(strings.TrimSpace(value.Predicate))
+		value.Value = strings.ToLower(strings.TrimSpace(value.Value))
+		value.SourceID = strings.TrimSpace(value.SourceID)
+		value.ValidFrom = value.ValidFrom.UTC()
+		value.ValidTo = value.ValidTo.UTC()
+		value.ObservedAt = value.ObservedAt.UTC()
+		value.Evidence = normalizeEvidenceReference(value.Evidence)
+		result = append(result, value)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left, right := result[i], result[j]
+		return observationKey(left) < observationKey(right)
+	})
+	return result
+}
+
+func sameClaimKey(left, right ClaimObservation) bool {
+	return left.TenantID == right.TenantID && left.SubjectURN == right.SubjectURN && left.Predicate == right.Predicate
+}
+
+func validityOverlaps(left, right ClaimObservation) bool {
+	leftEnd, rightEnd := left.ValidTo, right.ValidTo
+	if leftEnd.IsZero() {
+		leftEnd = time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
+	}
+	if rightEnd.IsZero() {
+		rightEnd = time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
+	}
+	return !leftEnd.Before(right.ValidFrom) && !rightEnd.Before(left.ValidFrom)
+}
+
+func cleanlySuperseded(left, right ClaimObservation) bool {
+	if left.SourceID == "" || left.SourceID != right.SourceID || left.ObservedAt.Equal(right.ObservedAt) {
+		return false
+	}
+	older, newer := left, right
+	if newer.ObservedAt.Before(older.ObservedAt) {
+		older, newer = newer, older
+	}
+	return !older.ValidTo.IsZero() && !older.ValidTo.After(newer.ValidFrom)
+}
+
+func observationKey(value ClaimObservation) string {
+	return strings.Join([]string{value.TenantID, value.SubjectURN, value.Predicate, value.Value, value.ValidFrom.Format(time.RFC3339Nano), value.Evidence.ID}, "\x00")
+}

--- a/internal/decisionpacket/contradictions.go
+++ b/internal/decisionpacket/contradictions.go
@@ -20,7 +20,7 @@ func DetectContradictions(observations []ClaimObservation) []Contradiction {
 			if cleanlySuperseded(left, right) {
 				continue
 			}
-			idInput := strings.Join([]string{left.TenantID, left.SubjectURN, left.Predicate, left.Evidence.ID, right.Evidence.ID}, "\x00")
+			idInput := observationIdentity(left) + "\x00" + observationIdentity(right)
 			digest := sha256.Sum256([]byte(idInput))
 			result = append(result, Contradiction{
 				ID: fmt.Sprintf("con_%x", digest[:16]), SubjectURN: left.SubjectURN, Predicate: left.Predicate,
@@ -34,7 +34,7 @@ func DetectContradictions(observations []ClaimObservation) []Contradiction {
 }
 
 func normalizeObservations(values []ClaimObservation) []ClaimObservation {
-	result := make([]ClaimObservation, 0, len(values))
+	byIdentity := make(map[string]ClaimObservation, len(values))
 	for _, value := range values {
 		value.TenantID = strings.TrimSpace(value.TenantID)
 		value.SubjectURN = strings.TrimSpace(value.SubjectURN)
@@ -45,11 +45,14 @@ func normalizeObservations(values []ClaimObservation) []ClaimObservation {
 		value.ValidTo = value.ValidTo.UTC()
 		value.ObservedAt = value.ObservedAt.UTC()
 		value.Evidence = normalizeEvidenceReference(value.Evidence)
+		byIdentity[observationIdentity(value)] = value
+	}
+	result := make([]ClaimObservation, 0, len(byIdentity))
+	for _, value := range byIdentity {
 		result = append(result, value)
 	}
 	sort.Slice(result, func(i, j int) bool {
-		left, right := result[i], result[j]
-		return observationKey(left) < observationKey(right)
+		return observationIdentity(result[i]) < observationIdentity(result[j])
 	})
 	return result
 }
@@ -80,6 +83,13 @@ func cleanlySuperseded(left, right ClaimObservation) bool {
 	return !older.ValidTo.IsZero() && !older.ValidTo.After(newer.ValidFrom)
 }
 
-func observationKey(value ClaimObservation) string {
-	return strings.Join([]string{value.TenantID, value.SubjectURN, value.Predicate, value.Value, value.ValidFrom.Format(time.RFC3339Nano), value.Evidence.ID}, "\x00")
+func observationIdentity(value ClaimObservation) string {
+	return strings.Join([]string{
+		value.TenantID, value.SubjectURN, value.Predicate, value.Value, value.SourceID,
+		value.ValidFrom.Format(time.RFC3339Nano), value.ValidTo.Format(time.RFC3339Nano), value.ObservedAt.Format(time.RFC3339Nano),
+		value.Evidence.ID, value.Evidence.URN, value.Evidence.Kind, value.Evidence.SourceID, value.Evidence.SubjectURN,
+		value.Evidence.Predicate, value.Evidence.Value, value.Evidence.ObservedAt.Format(time.RFC3339Nano),
+		value.Evidence.ValidFrom.Format(time.RFC3339Nano), value.Evidence.ValidTo.Format(time.RFC3339Nano), value.Evidence.Digest,
+		fmt.Sprintf("%t", value.PrimaryClaim),
+	}, "\x00")
 }

--- a/internal/decisionpacket/normalize.go
+++ b/internal/decisionpacket/normalize.go
@@ -64,6 +64,7 @@ func normalizePacket(packet Packet) Packet {
 	packet.Decision.Reasons = normalizeStrings(packet.Decision.Reasons)
 	packet.Confidence.Level = strings.ToLower(strings.TrimSpace(packet.Confidence.Level))
 	packet.Confidence.Basis = normalizeStrings(packet.Confidence.Basis)
+	packet.Freshness.State = strings.ToLower(strings.TrimSpace(packet.Freshness.State))
 	packet.Freshness.OldestObservedAt = packet.Freshness.OldestObservedAt.UTC()
 	packet.Freshness.NewestObservedAt = packet.Freshness.NewestObservedAt.UTC()
 	packet.Provenance.ResolverIDs = normalizeStrings(packet.Provenance.ResolverIDs)
@@ -72,6 +73,10 @@ func normalizePacket(packet Packet) Packet {
 		packet.Evidence[index] = normalizeEvidenceReference(packet.Evidence[index])
 	}
 	packet.Evidence = dedupeEvidence(packet.Evidence)
+	for index := range packet.Contradictions {
+		packet.Contradictions[index].Left = normalizeEvidenceReference(packet.Contradictions[index].Left)
+		packet.Contradictions[index].Right = normalizeEvidenceReference(packet.Contradictions[index].Right)
+	}
 	for index := range packet.Actions {
 		packet.Actions[index].TargetURNs = normalizeStrings(packet.Actions[index].TargetURNs)
 		packet.Actions[index].ApprovalRequirements = normalizeStrings(packet.Actions[index].ApprovalRequirements)

--- a/internal/decisionpacket/normalize.go
+++ b/internal/decisionpacket/normalize.go
@@ -269,6 +269,18 @@ func normalizeCanonicalReflectValue(value reflect.Value) {
 		for index := 0; index < value.Len(); index++ {
 			normalizeCanonicalReflectValue(value.Index(index))
 		}
+		if value.Type().Elem().Kind() == reflect.String && value.CanSet() {
+			stringsValue := make([]string, value.Len())
+			for index := 0; index < value.Len(); index++ {
+				stringsValue[index] = value.Index(index).String()
+			}
+			stringsValue = normalizeStrings(stringsValue)
+			normalized := reflect.MakeSlice(value.Type(), len(stringsValue), len(stringsValue))
+			for index := range stringsValue {
+				normalized.Index(index).SetString(stringsValue[index])
+			}
+			value.Set(normalized)
+		}
 	case reflect.Map:
 		if value.IsNil() && value.CanSet() {
 			value.Set(reflect.MakeMap(value.Type()))

--- a/internal/decisionpacket/normalize.go
+++ b/internal/decisionpacket/normalize.go
@@ -64,6 +64,8 @@ func normalizePacket(packet Packet) Packet {
 	packet.Decision.Reasons = normalizeStrings(packet.Decision.Reasons)
 	packet.Confidence.Level = strings.ToLower(strings.TrimSpace(packet.Confidence.Level))
 	packet.Confidence.Basis = normalizeStrings(packet.Confidence.Basis)
+	packet.Freshness.OldestObservedAt = packet.Freshness.OldestObservedAt.UTC()
+	packet.Freshness.NewestObservedAt = packet.Freshness.NewestObservedAt.UTC()
 	packet.Provenance.ResolverIDs = normalizeStrings(packet.Provenance.ResolverIDs)
 	packet.Provenance.SourceIDs = normalizeStrings(packet.Provenance.SourceIDs)
 	for index := range packet.Evidence {
@@ -73,6 +75,9 @@ func normalizePacket(packet Packet) Packet {
 	for index := range packet.Actions {
 		packet.Actions[index].TargetURNs = normalizeStrings(packet.Actions[index].TargetURNs)
 		packet.Actions[index].ApprovalRequirements = normalizeStrings(packet.Actions[index].ApprovalRequirements)
+	}
+	for index := range packet.AuditPackets {
+		packet.AuditPackets[index].GeneratedAt = packet.AuditPackets[index].GeneratedAt.UTC()
 	}
 	sort.Slice(packet.Contradictions, func(i, j int) bool { return packet.Contradictions[i].ID < packet.Contradictions[j].ID })
 	sort.Slice(packet.CoverageGaps, func(i, j int) bool { return packet.CoverageGaps[i].ID < packet.CoverageGaps[j].ID })

--- a/internal/decisionpacket/normalize.go
+++ b/internal/decisionpacket/normalize.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 )
@@ -59,6 +60,33 @@ func normalizePacket(packet Packet) Packet {
 	packet.Scope.TenantID = strings.TrimSpace(packet.Scope.TenantID)
 	packet.Scope.ActorID = strings.TrimSpace(packet.Scope.ActorID)
 	packet.Scope.URN = strings.TrimSpace(packet.Scope.URN)
+	normalizeEmbeddedCanonicalValue(&packet.Guardrails)
+	normalizeEmbeddedCanonicalValue(&packet.Claim)
+	packet.Guardrails.Readiness.State = strings.ToLower(packet.Guardrails.Readiness.State)
+	for index := range packet.Guardrails.VerifierResults {
+		packet.Guardrails.VerifierResults[index].Status = strings.ToLower(packet.Guardrails.VerifierResults[index].Status)
+	}
+	for index := range packet.Guardrails.ActionLadder {
+		packet.Guardrails.ActionLadder[index].Status = strings.ToLower(packet.Guardrails.ActionLadder[index].Status)
+	}
+	for index := range packet.Guardrails.ConnectorToolGates {
+		packet.Guardrails.ConnectorToolGates[index].Status = strings.ToLower(packet.Guardrails.ConnectorToolGates[index].Status)
+	}
+	packet.Claim.Verdict = strings.ToLower(packet.Claim.Verdict)
+	packet.Claim.AllowedNextStage = strings.ToLower(packet.Claim.AllowedNextStage)
+	packet.Claim.RequestedActionStage = strings.ToLower(packet.Claim.RequestedActionStage)
+	packet.Claim.FreshnessState = strings.ToLower(packet.Claim.FreshnessState)
+	for index := range packet.Claim.SupportingEvidence {
+		packet.Claim.SupportingEvidence[index].Kind = strings.ToLower(packet.Claim.SupportingEvidence[index].Kind)
+		packet.Claim.SupportingEvidence[index].CitationStatus = strings.ToLower(packet.Claim.SupportingEvidence[index].CitationStatus)
+	}
+	for index := range packet.Claim.CounterEvidence {
+		packet.Claim.CounterEvidence[index].Kind = strings.ToLower(packet.Claim.CounterEvidence[index].Kind)
+		packet.Claim.CounterEvidence[index].CitationStatus = strings.ToLower(packet.Claim.CounterEvidence[index].CitationStatus)
+	}
+	for index := range packet.Claim.VerifierResults {
+		packet.Claim.VerifierResults[index].Status = strings.ToLower(packet.Claim.VerifierResults[index].Status)
+	}
 	packet.Decision.State = strings.ToLower(strings.TrimSpace(packet.Decision.State))
 	packet.Decision.Rationale = strings.TrimSpace(packet.Decision.Rationale)
 	packet.Decision.Reasons = normalizeStrings(packet.Decision.Reasons)
@@ -202,6 +230,66 @@ func nonNilSlice[T any](values []T) []T {
 		return []T{}
 	}
 	return values
+}
+
+// normalizeEmbeddedCanonicalValue keeps imported, typed agent contracts stable
+// under whitespace and nil-versus-empty representation differences.
+func normalizeEmbeddedCanonicalValue(value any) {
+	normalizeCanonicalReflectValue(reflect.ValueOf(value))
+}
+
+func normalizeCanonicalReflectValue(value reflect.Value) {
+	if !value.IsValid() {
+		return
+	}
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return
+		}
+		normalizeCanonicalReflectValue(value.Elem())
+		return
+	}
+	switch value.Kind() {
+	case reflect.String:
+		if value.CanSet() {
+			value.SetString(strings.TrimSpace(value.String()))
+		}
+	case reflect.Struct:
+		for index := 0; index < value.NumField(); index++ {
+			field := value.Field(index)
+			normalizeCanonicalReflectValue(field)
+			if field.Kind() == reflect.String && field.CanSet() && canonicalLowercaseField(value.Type().Field(index).Name) {
+				field.SetString(strings.ToLower(field.String()))
+			}
+		}
+	case reflect.Slice:
+		if value.IsNil() && value.CanSet() {
+			value.Set(reflect.MakeSlice(value.Type(), 0, 0))
+		}
+		for index := 0; index < value.Len(); index++ {
+			normalizeCanonicalReflectValue(value.Index(index))
+		}
+	case reflect.Map:
+		if value.IsNil() && value.CanSet() {
+			value.Set(reflect.MakeMap(value.Type()))
+		}
+		iterator := value.MapRange()
+		for iterator.Next() {
+			item := reflect.New(value.Type().Elem()).Elem()
+			item.Set(iterator.Value())
+			normalizeCanonicalReflectValue(item)
+			value.SetMapIndex(iterator.Key(), item)
+		}
+	}
+}
+
+func canonicalLowercaseField(name string) bool {
+	switch name {
+	case "ActionStage", "AllowedNextStage", "Applicability", "CitationStatus", "ClaimType", "CredentialBoundary", "DimensionType", "FreshnessState", "Kind", "Level", "MCPSurface", "Mode", "OAuthSurface", "QueryMode", "Readiness", "ReasoningSurface", "RequestedActionStage", "Stage", "State", "Status", "SupportLevel", "TokenOwner", "Type", "Verdict", "WritePolicy":
+		return true
+	default:
+		return false
+	}
 }
 
 func uniqueSortedStrings(values []string) []string { return normalizeStrings(values) }

--- a/internal/decisionpacket/normalize.go
+++ b/internal/decisionpacket/normalize.go
@@ -152,12 +152,22 @@ func normalizePacket(packet Packet) Packet {
 	packet.Controls = nonNilSlice(packet.Controls)
 	packet.AuditPackets = nonNilSlice(packet.AuditPackets)
 	packet.Actions = nonNilSlice(packet.Actions)
-	sort.Slice(packet.Contradictions, func(i, j int) bool { return packet.Contradictions[i].ID < packet.Contradictions[j].ID })
-	sort.Slice(packet.CoverageGaps, func(i, j int) bool { return packet.CoverageGaps[i].ID < packet.CoverageGaps[j].ID })
-	sort.Slice(packet.Affected, func(i, j int) bool { return packet.Affected[i].URN < packet.Affected[j].URN })
-	sort.Slice(packet.Controls, func(i, j int) bool { return packet.Controls[i].ID < packet.Controls[j].ID })
-	sort.Slice(packet.AuditPackets, func(i, j int) bool { return packet.AuditPackets[i].ID < packet.AuditPackets[j].ID })
-	sort.Slice(packet.Actions, func(i, j int) bool { return packet.Actions[i].ID < packet.Actions[j].ID })
+	sort.Slice(packet.Contradictions, func(i, j int) bool {
+		return canonicalSortKey(packet.Contradictions[i]) < canonicalSortKey(packet.Contradictions[j])
+	})
+	sort.Slice(packet.CoverageGaps, func(i, j int) bool {
+		return canonicalSortKey(packet.CoverageGaps[i]) < canonicalSortKey(packet.CoverageGaps[j])
+	})
+	sort.Slice(packet.Affected, func(i, j int) bool {
+		return canonicalSortKey(packet.Affected[i]) < canonicalSortKey(packet.Affected[j])
+	})
+	sort.Slice(packet.Controls, func(i, j int) bool {
+		return canonicalSortKey(packet.Controls[i]) < canonicalSortKey(packet.Controls[j])
+	})
+	sort.Slice(packet.AuditPackets, func(i, j int) bool {
+		return canonicalSortKey(packet.AuditPackets[i]) < canonicalSortKey(packet.AuditPackets[j])
+	})
+	sort.Slice(packet.Actions, func(i, j int) bool { return canonicalSortKey(packet.Actions[i]) < canonicalSortKey(packet.Actions[j]) })
 	return packet
 }
 
@@ -180,7 +190,8 @@ func dedupeEvidence(values []EvidenceReference) []EvidenceReference {
 	byKey := make(map[string]EvidenceReference, len(values))
 	for _, value := range values {
 		key := value.Kind + "\x00" + value.ID
-		if _, found := byKey[key]; !found {
+		current, found := byKey[key]
+		if !found || canonicalSortKey(value) < canonicalSortKey(current) {
 			byKey[key] = value
 		}
 	}
@@ -230,6 +241,14 @@ func nonNilSlice[T any](values []T) []T {
 		return []T{}
 	}
 	return values
+}
+
+func canonicalSortKey(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%#v", value)
+	}
+	return string(raw)
 }
 
 // normalizeEmbeddedCanonicalValue keeps imported, typed agent contracts stable
@@ -297,7 +316,7 @@ func normalizeCanonicalReflectValue(value reflect.Value) {
 
 func canonicalLowercaseField(name string) bool {
 	switch name {
-	case "ActionStage", "AllowedNextStage", "Applicability", "CitationStatus", "ClaimType", "CredentialBoundary", "DimensionType", "FreshnessState", "Kind", "Level", "MCPSurface", "Mode", "OAuthSurface", "QueryMode", "Readiness", "ReasoningSurface", "RequestedActionStage", "Stage", "State", "Status", "SupportLevel", "TokenOwner", "Type", "Verdict", "WritePolicy":
+	case "ActionStage", "AllowedNextStage", "Applicability", "CitationStatus", "ClaimType", "CredentialBoundary", "DimensionType", "FreshnessState", "Kind", "Level", "MaxActionStage", "MCPSurface", "Mode", "OAuthSurface", "QueryMode", "Readiness", "ReasoningSurface", "RequestedActionStage", "Stage", "State", "Status", "SupportLevel", "TokenOwner", "Type", "Verdict", "WritePolicy":
 		return true
 	default:
 		return false

--- a/internal/decisionpacket/normalize.go
+++ b/internal/decisionpacket/normalize.go
@@ -118,6 +118,12 @@ func normalizePacket(packet Packet) Packet {
 		packet.AuditPackets[index].Freshness = strings.ToLower(strings.TrimSpace(packet.AuditPackets[index].Freshness))
 		packet.AuditPackets[index].GeneratedAt = packet.AuditPackets[index].GeneratedAt.UTC()
 	}
+	packet.Contradictions = nonNilSlice(packet.Contradictions)
+	packet.CoverageGaps = nonNilSlice(packet.CoverageGaps)
+	packet.Affected = nonNilSlice(packet.Affected)
+	packet.Controls = nonNilSlice(packet.Controls)
+	packet.AuditPackets = nonNilSlice(packet.AuditPackets)
+	packet.Actions = nonNilSlice(packet.Actions)
 	sort.Slice(packet.Contradictions, func(i, j int) bool { return packet.Contradictions[i].ID < packet.Contradictions[j].ID })
 	sort.Slice(packet.CoverageGaps, func(i, j int) bool { return packet.CoverageGaps[i].ID < packet.CoverageGaps[j].ID })
 	sort.Slice(packet.Affected, func(i, j int) bool { return packet.Affected[i].URN < packet.Affected[j].URN })
@@ -189,6 +195,13 @@ func normalizeStrings(values []string) []string {
 	}
 	sort.Strings(result)
 	return result
+}
+
+func nonNilSlice[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
 }
 
 func uniqueSortedStrings(values []string) []string { return normalizeStrings(values) }

--- a/internal/decisionpacket/normalize.go
+++ b/internal/decisionpacket/normalize.go
@@ -69,19 +69,53 @@ func normalizePacket(packet Packet) Packet {
 	packet.Freshness.NewestObservedAt = packet.Freshness.NewestObservedAt.UTC()
 	packet.Provenance.ResolverIDs = normalizeStrings(packet.Provenance.ResolverIDs)
 	packet.Provenance.SourceIDs = normalizeStrings(packet.Provenance.SourceIDs)
+	packet.Provenance.TraceID = strings.TrimSpace(packet.Provenance.TraceID)
+	packet.Provenance.EvidenceDigest = strings.TrimSpace(packet.Provenance.EvidenceDigest)
+	packet.Provenance.CoverageDigest = strings.TrimSpace(packet.Provenance.CoverageDigest)
 	for index := range packet.Evidence {
 		packet.Evidence[index] = normalizeEvidenceReference(packet.Evidence[index])
 	}
 	packet.Evidence = dedupeEvidence(packet.Evidence)
 	for index := range packet.Contradictions {
+		packet.Contradictions[index].ID = strings.TrimSpace(packet.Contradictions[index].ID)
+		packet.Contradictions[index].SubjectURN = strings.TrimSpace(packet.Contradictions[index].SubjectURN)
+		packet.Contradictions[index].Predicate = strings.ToLower(strings.TrimSpace(packet.Contradictions[index].Predicate))
+		packet.Contradictions[index].ResolutionState = strings.ToLower(strings.TrimSpace(packet.Contradictions[index].ResolutionState))
 		packet.Contradictions[index].Left = normalizeEvidenceReference(packet.Contradictions[index].Left)
 		packet.Contradictions[index].Right = normalizeEvidenceReference(packet.Contradictions[index].Right)
 	}
+	for index := range packet.CoverageGaps {
+		packet.CoverageGaps[index].ID = strings.TrimSpace(packet.CoverageGaps[index].ID)
+		packet.CoverageGaps[index].SourceID = strings.TrimSpace(packet.CoverageGaps[index].SourceID)
+		packet.CoverageGaps[index].Dimension = strings.ToLower(strings.TrimSpace(packet.CoverageGaps[index].Dimension))
+		packet.CoverageGaps[index].State = strings.ToLower(strings.TrimSpace(packet.CoverageGaps[index].State))
+		packet.CoverageGaps[index].Reason = strings.TrimSpace(packet.CoverageGaps[index].Reason)
+	}
+	for index := range packet.Affected {
+		packet.Affected[index].URN = strings.TrimSpace(packet.Affected[index].URN)
+		packet.Affected[index].Kind = strings.ToLower(strings.TrimSpace(packet.Affected[index].Kind))
+		packet.Affected[index].Name = strings.TrimSpace(packet.Affected[index].Name)
+	}
+	for index := range packet.Controls {
+		packet.Controls[index].ID = strings.TrimSpace(packet.Controls[index].ID)
+		packet.Controls[index].Framework = strings.TrimSpace(packet.Controls[index].Framework)
+		packet.Controls[index].Applicability = strings.ToLower(strings.TrimSpace(packet.Controls[index].Applicability))
+	}
 	for index := range packet.Actions {
+		packet.Actions[index].ID = strings.TrimSpace(packet.Actions[index].ID)
+		packet.Actions[index].ActionID = strings.TrimSpace(packet.Actions[index].ActionID)
+		packet.Actions[index].State = strings.ToLower(strings.TrimSpace(packet.Actions[index].State))
+		packet.Actions[index].Rationale = strings.TrimSpace(packet.Actions[index].Rationale)
+		packet.Actions[index].CatalogVersion = strings.TrimSpace(packet.Actions[index].CatalogVersion)
+		packet.Actions[index].ProposalDigest = strings.TrimSpace(packet.Actions[index].ProposalDigest)
 		packet.Actions[index].TargetURNs = normalizeStrings(packet.Actions[index].TargetURNs)
 		packet.Actions[index].ApprovalRequirements = normalizeStrings(packet.Actions[index].ApprovalRequirements)
 	}
 	for index := range packet.AuditPackets {
+		packet.AuditPackets[index].ID = strings.TrimSpace(packet.AuditPackets[index].ID)
+		packet.AuditPackets[index].ScopeURN = strings.TrimSpace(packet.AuditPackets[index].ScopeURN)
+		packet.AuditPackets[index].Digest = strings.TrimSpace(packet.AuditPackets[index].Digest)
+		packet.AuditPackets[index].Freshness = strings.ToLower(strings.TrimSpace(packet.AuditPackets[index].Freshness))
 		packet.AuditPackets[index].GeneratedAt = packet.AuditPackets[index].GeneratedAt.UTC()
 	}
 	sort.Slice(packet.Contradictions, func(i, j int) bool { return packet.Contradictions[i].ID < packet.Contradictions[j].ID })

--- a/internal/decisionpacket/normalize.go
+++ b/internal/decisionpacket/normalize.go
@@ -1,0 +1,150 @@
+package decisionpacket
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var ErrInvalidBudget = errors.New("invalid decision packet budget")
+
+var budgetDefaults = Budgets{Evidence: 50, Contradictions: 10, CoverageGaps: 10, Affected: 50, Controls: 50, AuditPackets: 10, Actions: 5, GraphRows: 25, GraphDepth: 2}
+var budgetMaximums = Budgets{Evidence: 100, Contradictions: 25, CoverageGaps: 25, Affected: 100, Controls: 100, AuditPackets: 25, Actions: 10, GraphRows: 100, GraphDepth: 3}
+
+func NormalizeRequest(request Request) (Request, error) {
+	request.Workflow = strings.ToLower(strings.TrimSpace(request.Workflow))
+	request.Question = strings.TrimSpace(request.Question)
+	request.ScopeURN = strings.TrimSpace(request.ScopeURN)
+	request.RequestedAction = strings.TrimSpace(request.RequestedAction)
+	request.FindingIDs = normalizeStrings(request.FindingIDs)
+	request.ClaimIDs = normalizeStrings(request.ClaimIDs)
+	request.EvidenceURNs = normalizeStrings(request.EvidenceURNs)
+	request.AuditPacketIDs = normalizeStrings(request.AuditPacketIDs)
+	request.RequiredSources = normalizeStrings(request.RequiredSources)
+	budgets, err := normalizeBudgets(request.Budgets)
+	if err != nil {
+		return Request{}, err
+	}
+	request.Budgets = budgets
+	return request, nil
+}
+
+func CanonicalizePacket(packet Packet) (Packet, []byte, error) {
+	packet = normalizePacket(packet)
+	packet.ID = ""
+	hashInput, err := json.Marshal(packet)
+	if err != nil {
+		return Packet{}, nil, fmt.Errorf("marshal decision packet hash input: %w", err)
+	}
+	digest := sha256.Sum256(hashInput)
+	packet.ID = fmt.Sprintf("dpr_%x", digest[:16])
+	canonical, err := json.Marshal(packet)
+	if err != nil {
+		return Packet{}, nil, fmt.Errorf("marshal decision packet: %w", err)
+	}
+	return packet, canonical, nil
+}
+
+func normalizePacket(packet Packet) Packet {
+	packet.SchemaVersion = strings.TrimSpace(packet.SchemaVersion)
+	if packet.SchemaVersion == "" {
+		packet.SchemaVersion = SchemaVersion
+	}
+	packet.GeneratedAt = packet.GeneratedAt.UTC()
+	packet.Workflow.ID = strings.ToLower(strings.TrimSpace(packet.Workflow.ID))
+	packet.Workflow.Question = strings.TrimSpace(packet.Workflow.Question)
+	packet.Scope.TenantID = strings.TrimSpace(packet.Scope.TenantID)
+	packet.Scope.ActorID = strings.TrimSpace(packet.Scope.ActorID)
+	packet.Scope.URN = strings.TrimSpace(packet.Scope.URN)
+	packet.Decision.State = strings.ToLower(strings.TrimSpace(packet.Decision.State))
+	packet.Decision.Rationale = strings.TrimSpace(packet.Decision.Rationale)
+	packet.Decision.Reasons = normalizeStrings(packet.Decision.Reasons)
+	packet.Confidence.Level = strings.ToLower(strings.TrimSpace(packet.Confidence.Level))
+	packet.Confidence.Basis = normalizeStrings(packet.Confidence.Basis)
+	packet.Provenance.ResolverIDs = normalizeStrings(packet.Provenance.ResolverIDs)
+	packet.Provenance.SourceIDs = normalizeStrings(packet.Provenance.SourceIDs)
+	for index := range packet.Evidence {
+		packet.Evidence[index] = normalizeEvidenceReference(packet.Evidence[index])
+	}
+	packet.Evidence = dedupeEvidence(packet.Evidence)
+	for index := range packet.Actions {
+		packet.Actions[index].TargetURNs = normalizeStrings(packet.Actions[index].TargetURNs)
+		packet.Actions[index].ApprovalRequirements = normalizeStrings(packet.Actions[index].ApprovalRequirements)
+	}
+	sort.Slice(packet.Contradictions, func(i, j int) bool { return packet.Contradictions[i].ID < packet.Contradictions[j].ID })
+	sort.Slice(packet.CoverageGaps, func(i, j int) bool { return packet.CoverageGaps[i].ID < packet.CoverageGaps[j].ID })
+	sort.Slice(packet.Affected, func(i, j int) bool { return packet.Affected[i].URN < packet.Affected[j].URN })
+	sort.Slice(packet.Controls, func(i, j int) bool { return packet.Controls[i].ID < packet.Controls[j].ID })
+	sort.Slice(packet.AuditPackets, func(i, j int) bool { return packet.AuditPackets[i].ID < packet.AuditPackets[j].ID })
+	sort.Slice(packet.Actions, func(i, j int) bool { return packet.Actions[i].ID < packet.Actions[j].ID })
+	return packet
+}
+
+func normalizeEvidenceReference(value EvidenceReference) EvidenceReference {
+	value.ID = strings.TrimSpace(value.ID)
+	value.URN = strings.TrimSpace(value.URN)
+	value.Kind = strings.ToLower(strings.TrimSpace(value.Kind))
+	value.SourceID = strings.TrimSpace(value.SourceID)
+	value.SubjectURN = strings.TrimSpace(value.SubjectURN)
+	value.Predicate = strings.ToLower(strings.TrimSpace(value.Predicate))
+	value.Value = strings.TrimSpace(value.Value)
+	value.Digest = strings.TrimSpace(value.Digest)
+	value.ObservedAt = value.ObservedAt.UTC()
+	value.ValidFrom = value.ValidFrom.UTC()
+	value.ValidTo = value.ValidTo.UTC()
+	return value
+}
+
+func dedupeEvidence(values []EvidenceReference) []EvidenceReference {
+	byKey := make(map[string]EvidenceReference, len(values))
+	for _, value := range values {
+		key := value.Kind + "\x00" + value.ID
+		if _, found := byKey[key]; !found {
+			byKey[key] = value
+		}
+	}
+	result := make([]EvidenceReference, 0, len(byKey))
+	for _, value := range byKey {
+		result = append(result, value)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Kind+"\x00"+result[i].ID < result[j].Kind+"\x00"+result[j].ID
+	})
+	return result
+}
+
+func normalizeBudgets(value Budgets) (Budgets, error) {
+	values := []*int{&value.Evidence, &value.Contradictions, &value.CoverageGaps, &value.Affected, &value.Controls, &value.AuditPackets, &value.Actions, &value.GraphRows, &value.GraphDepth}
+	defaults := []int{budgetDefaults.Evidence, budgetDefaults.Contradictions, budgetDefaults.CoverageGaps, budgetDefaults.Affected, budgetDefaults.Controls, budgetDefaults.AuditPackets, budgetDefaults.Actions, budgetDefaults.GraphRows, budgetDefaults.GraphDepth}
+	maximums := []int{budgetMaximums.Evidence, budgetMaximums.Contradictions, budgetMaximums.CoverageGaps, budgetMaximums.Affected, budgetMaximums.Controls, budgetMaximums.AuditPackets, budgetMaximums.Actions, budgetMaximums.GraphRows, budgetMaximums.GraphDepth}
+	for index, item := range values {
+		if *item < 0 || *item > maximums[index] {
+			return Budgets{}, fmt.Errorf("%w: value %d exceeds range 0..%d", ErrInvalidBudget, *item, maximums[index])
+		}
+		if *item == 0 {
+			*item = defaults[index]
+		}
+	}
+	return value, nil
+}
+
+func normalizeStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for value := range seen {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func uniqueSortedStrings(values []string) []string { return normalizeStrings(values) }

--- a/internal/decisionpacket/rules_test.go
+++ b/internal/decisionpacket/rules_test.go
@@ -159,3 +159,34 @@ func TestCanonicalizePacketIsStableAndContentAddressed(t *testing.T) {
 		t.Fatal("packet ID did not change with decision inputs")
 	}
 }
+
+func TestCanonicalizePacketNormalizesFreshnessAndAuditTimesToUTC(t *testing.T) {
+	instant := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	offset := time.FixedZone("test-offset", -7*60*60)
+	packet := Packet{
+		GeneratedAt: instant,
+		Workflow:    Workflow{ID: "triage", Question: "Review finding"},
+		Scope:       Scope{TenantID: "tenant-1", ActorID: "analyst-1"},
+		Freshness: Freshness{
+			State: "fresh", OldestObservedAt: instant.In(offset), NewestObservedAt: instant.Add(time.Hour).In(offset),
+		},
+		AuditPackets: []AuditPacketReference{{ID: "audit-1", Digest: "sha256:test", GeneratedAt: instant.In(offset)}},
+	}
+	localPacket, localJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(local) error = %v", err)
+	}
+	packet.Freshness.OldestObservedAt = instant
+	packet.Freshness.NewestObservedAt = instant.Add(time.Hour)
+	packet.AuditPackets = []AuditPacketReference{{ID: "audit-1", Digest: "sha256:test", GeneratedAt: instant}}
+	utcPacket, utcJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(UTC) error = %v", err)
+	}
+	if localPacket.ID != utcPacket.ID || string(localJSON) != string(utcJSON) {
+		t.Fatalf("timezone changed canonical packet: local=%s UTC=%s", localJSON, utcJSON)
+	}
+	if localPacket.Freshness.OldestObservedAt.Location() != time.UTC || localPacket.Freshness.NewestObservedAt.Location() != time.UTC || localPacket.AuditPackets[0].GeneratedAt.Location() != time.UTC {
+		t.Fatalf("canonical times are not UTC: freshness=%+v audit=%+v", localPacket.Freshness, localPacket.AuditPackets[0])
+	}
+}

--- a/internal/decisionpacket/rules_test.go
+++ b/internal/decisionpacket/rules_test.go
@@ -269,6 +269,33 @@ func TestCanonicalizePacketNormalizesNestedDecisionFields(t *testing.T) {
 	}
 }
 
+func TestCanonicalizePacketUsesTotalOrderingForDuplicateKeys(t *testing.T) {
+	packet := Packet{
+		GeneratedAt: time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC),
+		Evidence: []EvidenceReference{
+			{ID: "evidence-1", Kind: "finding", Value: "z"},
+			{ID: "evidence-1", Kind: "finding", Value: "a"},
+		},
+		Affected: []SubjectReference{
+			{URN: "urn:asset:1", Kind: "service", Name: "Zulu"},
+			{URN: "urn:asset:1", Kind: "resource", Name: "Alpha"},
+		},
+	}
+	first, firstJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(first order) error = %v", err)
+	}
+	packet.Evidence[0], packet.Evidence[1] = packet.Evidence[1], packet.Evidence[0]
+	packet.Affected[0], packet.Affected[1] = packet.Affected[1], packet.Affected[0]
+	second, secondJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(reverse order) error = %v", err)
+	}
+	if first.ID != second.ID || string(firstJSON) != string(secondJSON) {
+		t.Fatalf("duplicate-key input order changed canonical packet: first=%s second=%s", firstJSON, secondJSON)
+	}
+}
+
 func TestCanonicalizePacketTreatsNilAndEmptyResultSlicesEqually(t *testing.T) {
 	packet := Packet{GeneratedAt: time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)}
 	withNil, nilJSON, err := CanonicalizePacket(packet)

--- a/internal/decisionpacket/rules_test.go
+++ b/internal/decisionpacket/rules_test.go
@@ -294,20 +294,22 @@ func TestCanonicalizePacketNormalizesEmbeddedAgentContracts(t *testing.T) {
 	packet := Packet{
 		GeneratedAt: time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC),
 		Guardrails: agentplatform.AgentDecisionGuardrails{
-			Version:         " v1 ",
-			Readiness:       agentplatform.AgentReadinessAssessment{State: " READY ", Reasons: nil},
-			VerifierResults: []agentplatform.AgentVerifierResult{{ID: " verifier-1 ", Status: " PASS ", Evidence: nil}},
+			Version:           " v1 ",
+			Readiness:         agentplatform.AgentReadinessAssessment{State: " READY ", Reasons: []string{" warning-b ", "warning-a", "warning-a"}},
+			RequiredWriteBack: []string{" event-b ", "event-a", "event-a"},
+			VerifierResults:   []agentplatform.AgentVerifierResult{{ID: " verifier-1 ", Status: " PASS ", Evidence: nil}},
 		},
-		Claim: agentplatform.ClaimVerification{Claim: " Asset is public ", Verdict: " SUPPORTED ", SupportingEvidence: nil, RequiredWriteBack: nil},
+		Claim: agentplatform.ClaimVerification{Claim: " Asset is public ", Verdict: " SUPPORTED ", SupportingEvidence: nil, Warnings: []string{" warning-b ", "warning-a", "warning-a"}, RequiredWriteBack: nil},
 	}
 	spaced, spacedJSON, err := CanonicalizePacket(packet)
 	if err != nil {
 		t.Fatalf("CanonicalizePacket(spaced agent contracts) error = %v", err)
 	}
 	packet.Guardrails.Version = "v1"
-	packet.Guardrails.Readiness = agentplatform.AgentReadinessAssessment{State: "ready", Reasons: []string{}}
+	packet.Guardrails.Readiness = agentplatform.AgentReadinessAssessment{State: "ready", Reasons: []string{"warning-a", "warning-b"}}
+	packet.Guardrails.RequiredWriteBack = []string{"event-a", "event-b"}
 	packet.Guardrails.VerifierResults[0] = agentplatform.AgentVerifierResult{ID: "verifier-1", Status: "pass", Evidence: []string{}}
-	packet.Claim = agentplatform.ClaimVerification{Claim: "Asset is public", Verdict: "supported", SupportingEvidence: []agentplatform.EvidenceReference{}, RequiredWriteBack: []string{}, Blockers: []agentplatform.CapabilityDecisionBlocker{}, Warnings: []string{}, CounterEvidence: []agentplatform.EvidenceReference{}, MissingEvidence: []string{}, VerifierResults: []agentplatform.AgentVerifierResult{}}
+	packet.Claim = agentplatform.ClaimVerification{Claim: "Asset is public", Verdict: "supported", SupportingEvidence: []agentplatform.EvidenceReference{}, RequiredWriteBack: []string{}, Blockers: []agentplatform.CapabilityDecisionBlocker{}, Warnings: []string{"warning-a", "warning-b"}, CounterEvidence: []agentplatform.EvidenceReference{}, MissingEvidence: []string{}, VerifierResults: []agentplatform.AgentVerifierResult{}}
 	plain, plainJSON, err := CanonicalizePacket(packet)
 	if err != nil {
 		t.Fatalf("CanonicalizePacket(plain agent contracts) error = %v", err)

--- a/internal/decisionpacket/rules_test.go
+++ b/internal/decisionpacket/rules_test.go
@@ -1,0 +1,161 @@
+package decisionpacket
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+)
+
+func TestDecisionRuleGoldenFixtures(t *testing.T) {
+	type fixture struct {
+		Name               string `json:"name"`
+		ClaimVerdict       string `json:"claim_verdict"`
+		SupportingEvidence int    `json:"supporting_evidence"`
+		GuardrailsPassed   bool   `json:"guardrails_passed"`
+		RequiredGap        bool   `json:"required_gap"`
+		RequiredStale      bool   `json:"required_stale"`
+		UnresolvedConflict bool   `json:"unresolved_conflict"`
+		PrimaryConflict    bool   `json:"primary_conflict"`
+		DecisionState      string `json:"decision_state"`
+		ConfidenceLevel    string `json:"confidence_level"`
+	}
+	raw, err := os.ReadFile("testdata/decision_rules.golden.json")
+	if err != nil {
+		t.Fatalf("read golden fixtures: %v", err)
+	}
+	var fixtures []fixture
+	if err := json.Unmarshal(raw, &fixtures); err != nil {
+		t.Fatalf("decode golden fixtures: %v", err)
+	}
+	for _, item := range fixtures {
+		t.Run(item.Name, func(t *testing.T) {
+			decision := DeriveDecision(DecisionInputs{
+				ClaimVerdict: item.ClaimVerdict, RequiredGap: item.RequiredGap,
+				RequiredStale: item.RequiredStale, PrimaryConflict: item.PrimaryConflict,
+			})
+			confidence := DeriveConfidence(ConfidenceInputs{
+				SupportingEvidence: item.SupportingEvidence, RequiredGap: item.RequiredGap,
+				RequiredStale: item.RequiredStale, UnresolvedConflict: item.UnresolvedConflict,
+				GuardrailsPassed: item.GuardrailsPassed,
+			})
+			if decision.State != item.DecisionState || confidence.Level != item.ConfidenceLevel {
+				t.Fatalf("got decision=%q confidence=%q, want decision=%q confidence=%q", decision.State, confidence.Level, item.DecisionState, item.ConfidenceLevel)
+			}
+		})
+	}
+}
+
+func TestDeriveDecision(t *testing.T) {
+	falseValue := false
+	tests := []struct {
+		name string
+		in   DecisionInputs
+		want string
+	}{
+		{name: "supported", in: DecisionInputs{ClaimVerdict: agentplatform.ClaimVerdictSupported}, want: DecisionSupported},
+		{name: "required gap", in: DecisionInputs{ClaimVerdict: agentplatform.ClaimVerdictSupported, RequiredGap: true}, want: DecisionSupportedWithGaps},
+		{name: "contradicted", in: DecisionInputs{ClaimVerdict: agentplatform.ClaimVerdictContradicted}, want: DecisionBlocked},
+		{name: "unknown", in: DecisionInputs{ClaimVerdict: agentplatform.ClaimVerdictUnknown}, want: DecisionInsufficientEvidence},
+		{name: "explicit not applicable", in: DecisionInputs{ClaimVerdict: agentplatform.ClaimVerdictSupported, Applicable: &falseValue}, want: DecisionNotApplicable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeriveDecision(tt.in); got.State != tt.want {
+				t.Fatalf("state = %q, want %q (%+v)", got.State, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDeriveConfidenceCaps(t *testing.T) {
+	tests := []struct {
+		name string
+		in   ConfidenceInputs
+		want string
+	}{
+		{name: "no evidence", in: ConfidenceInputs{GuardrailsPassed: true}, want: ConfidenceUnknown},
+		{name: "complete", in: ConfidenceInputs{SupportingEvidence: 2, GuardrailsPassed: true}, want: ConfidenceHigh},
+		{name: "optional gap", in: ConfidenceInputs{SupportingEvidence: 2, GuardrailsPassed: true, OptionalGapMatters: true}, want: ConfidenceMedium},
+		{name: "required stale", in: ConfidenceInputs{SupportingEvidence: 2, GuardrailsPassed: true, RequiredStale: true}, want: ConfidenceLow},
+		{name: "required unverified", in: ConfidenceInputs{SupportingEvidence: 2, GuardrailsPassed: true, RequiredUnverified: true}, want: ConfidenceLow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeriveConfidence(tt.in); got.Level != tt.want {
+				t.Fatalf("level = %q, want %q (%+v)", got.Level, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDetectContradictionsRequiresOverlappingValidity(t *testing.T) {
+	start := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	common := ClaimObservation{TenantID: "tenant-1", SubjectURN: "urn:cerebro:tenant-1:asset:1", Predicate: "public", SourceID: "source-1", ValidFrom: start}
+	left := common
+	left.Value, left.Evidence = "true", EvidenceReference{ID: "evidence-1", Kind: "observation"}
+	right := common
+	right.Value, right.Evidence = "false", EvidenceReference{ID: "evidence-2", Kind: "observation"}
+	if got := DetectContradictions([]ClaimObservation{right, left}); len(got) != 1 || got[0].ResolutionState != ContradictionUnresolved {
+		t.Fatalf("contradictions = %+v, want one unresolved conflict", got)
+	}
+
+	left.ValidTo = start.Add(time.Hour)
+	right.ValidFrom = start.Add(2 * time.Hour)
+	left.ObservedAt = start
+	right.ObservedAt = start.Add(2 * time.Hour)
+	if got := DetectContradictions([]ClaimObservation{left, right}); len(got) != 0 {
+		t.Fatalf("superseded observations produced contradictions: %+v", got)
+	}
+}
+
+func TestNormalizeRequestBudgets(t *testing.T) {
+	got, err := NormalizeRequest(Request{Workflow: " Triage ", FindingIDs: []string{"b", "a", "a"}})
+	if err != nil {
+		t.Fatalf("NormalizeRequest() error = %v", err)
+	}
+	if got.Workflow != "triage" || strings.Join(got.FindingIDs, ",") != "a,b" || got.Budgets.Evidence != 50 || got.Budgets.GraphDepth != 2 {
+		t.Fatalf("normalized request = %+v", got)
+	}
+	_, err = NormalizeRequest(Request{Budgets: Budgets{Evidence: 101}})
+	if !errors.Is(err, ErrInvalidBudget) {
+		t.Fatalf("budget error = %v, want ErrInvalidBudget", err)
+	}
+}
+
+func TestCanonicalizePacketIsStableAndContentAddressed(t *testing.T) {
+	generatedAt := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	packet := Packet{
+		GeneratedAt: generatedAt, Workflow: Workflow{ID: " Triage ", Question: " Review finding "},
+		Scope:      Scope{TenantID: "tenant-1", ActorID: "analyst-1"},
+		Decision:   Decision{State: DecisionSupported, Reasons: []string{"z", "a"}},
+		Confidence: Confidence{Level: ConfidenceHigh, Basis: []string{"fresh_complete_nonconflicting_evidence"}},
+		Evidence:   []EvidenceReference{{ID: "b", Kind: "finding"}, {ID: "a", Kind: "finding"}, {ID: "a", Kind: "finding"}},
+	}
+	first, firstJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket() error = %v", err)
+	}
+	second, secondJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket() second error = %v", err)
+	}
+	if first.ID != second.ID || string(firstJSON) != string(secondJSON) {
+		t.Fatalf("canonical output changed: %q / %q", first.ID, second.ID)
+	}
+	if !strings.HasPrefix(first.ID, "dpr_") || len(first.ID) != 36 || len(first.Evidence) != 2 {
+		t.Fatalf("canonical packet = %+v", first)
+	}
+	packet.Decision.Reasons = append(packet.Decision.Reasons, "new_fact")
+	changed, _, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket() changed error = %v", err)
+	}
+	if changed.ID == first.ID {
+		t.Fatal("packet ID did not change with decision inputs")
+	}
+}

--- a/internal/decisionpacket/rules_test.go
+++ b/internal/decisionpacket/rules_test.go
@@ -105,11 +105,15 @@ func TestDetectContradictionsRequiresOverlappingValidity(t *testing.T) {
 	}
 
 	left.ValidTo = start.Add(time.Hour)
-	right.ValidFrom = start.Add(2 * time.Hour)
+	right.ValidFrom = left.ValidTo
 	left.ObservedAt = start
 	right.ObservedAt = start.Add(2 * time.Hour)
 	if got := DetectContradictions([]ClaimObservation{left, right}); len(got) != 0 {
 		t.Fatalf("superseded observations produced contradictions: %+v", got)
+	}
+	right.SourceID = "source-2"
+	if got := DetectContradictions([]ClaimObservation{left, right}); len(got) != 1 {
+		t.Fatalf("boundary observations from different sources = %+v, want one contradiction", got)
 	}
 }
 
@@ -168,8 +172,13 @@ func TestCanonicalizePacketNormalizesFreshnessAndAuditTimesToUTC(t *testing.T) {
 		Workflow:    Workflow{ID: "triage", Question: "Review finding"},
 		Scope:       Scope{TenantID: "tenant-1", ActorID: "analyst-1"},
 		Freshness: Freshness{
-			State: "fresh", OldestObservedAt: instant.In(offset), NewestObservedAt: instant.Add(time.Hour).In(offset),
+			State: " FRESH ", OldestObservedAt: instant.In(offset), NewestObservedAt: instant.Add(time.Hour).In(offset),
 		},
+		Contradictions: []Contradiction{{
+			ID:    "conflict-1",
+			Left:  EvidenceReference{ID: "left", Kind: " Finding ", ObservedAt: instant.In(offset)},
+			Right: EvidenceReference{ID: "right", Kind: " Finding ", ObservedAt: instant.Add(time.Hour).In(offset)},
+		}},
 		AuditPackets: []AuditPacketReference{{ID: "audit-1", Digest: "sha256:test", GeneratedAt: instant.In(offset)}},
 	}
 	localPacket, localJSON, err := CanonicalizePacket(packet)
@@ -178,6 +187,12 @@ func TestCanonicalizePacketNormalizesFreshnessAndAuditTimesToUTC(t *testing.T) {
 	}
 	packet.Freshness.OldestObservedAt = instant
 	packet.Freshness.NewestObservedAt = instant.Add(time.Hour)
+	packet.Freshness.State = "fresh"
+	packet.Contradictions = []Contradiction{{
+		ID:    "conflict-1",
+		Left:  EvidenceReference{ID: "left", Kind: "finding", ObservedAt: instant},
+		Right: EvidenceReference{ID: "right", Kind: "finding", ObservedAt: instant.Add(time.Hour)},
+	}}
 	packet.AuditPackets = []AuditPacketReference{{ID: "audit-1", Digest: "sha256:test", GeneratedAt: instant}}
 	utcPacket, utcJSON, err := CanonicalizePacket(packet)
 	if err != nil {
@@ -186,7 +201,7 @@ func TestCanonicalizePacketNormalizesFreshnessAndAuditTimesToUTC(t *testing.T) {
 	if localPacket.ID != utcPacket.ID || string(localJSON) != string(utcJSON) {
 		t.Fatalf("timezone changed canonical packet: local=%s UTC=%s", localJSON, utcJSON)
 	}
-	if localPacket.Freshness.OldestObservedAt.Location() != time.UTC || localPacket.Freshness.NewestObservedAt.Location() != time.UTC || localPacket.AuditPackets[0].GeneratedAt.Location() != time.UTC {
+	if localPacket.Freshness.State != "fresh" || localPacket.Contradictions[0].Left.Kind != "finding" || localPacket.Contradictions[0].Left.ObservedAt.Location() != time.UTC || localPacket.Freshness.OldestObservedAt.Location() != time.UTC || localPacket.Freshness.NewestObservedAt.Location() != time.UTC || localPacket.AuditPackets[0].GeneratedAt.Location() != time.UTC {
 		t.Fatalf("canonical times are not UTC: freshness=%+v audit=%+v", localPacket.Freshness, localPacket.AuditPackets[0])
 	}
 }

--- a/internal/decisionpacket/rules_test.go
+++ b/internal/decisionpacket/rules_test.go
@@ -154,6 +154,9 @@ func TestCanonicalizePacketIsStableAndContentAddressed(t *testing.T) {
 	if !strings.HasPrefix(first.ID, "dpr_") || len(first.ID) != 36 || len(first.Evidence) != 2 {
 		t.Fatalf("canonical packet = %+v", first)
 	}
+	if strings.Contains(string(firstJSON), "0001-01-01") {
+		t.Fatalf("canonical packet contains zero-time sentinels: %s", firstJSON)
+	}
 	packet.Decision.Reasons = append(packet.Decision.Reasons, "new_fact")
 	changed, _, err := CanonicalizePacket(packet)
 	if err != nil {
@@ -203,5 +206,44 @@ func TestCanonicalizePacketNormalizesFreshnessAndAuditTimesToUTC(t *testing.T) {
 	}
 	if localPacket.Freshness.State != "fresh" || localPacket.Contradictions[0].Left.Kind != "finding" || localPacket.Contradictions[0].Left.ObservedAt.Location() != time.UTC || localPacket.Freshness.OldestObservedAt.Location() != time.UTC || localPacket.Freshness.NewestObservedAt.Location() != time.UTC || localPacket.AuditPackets[0].GeneratedAt.Location() != time.UTC {
 		t.Fatalf("canonical times are not UTC: freshness=%+v audit=%+v", localPacket.Freshness, localPacket.AuditPackets[0])
+	}
+}
+
+func TestCanonicalizePacketNormalizesNestedDecisionFields(t *testing.T) {
+	instant := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	packet := Packet{
+		GeneratedAt: instant,
+		Contradictions: []Contradiction{{
+			ID: " conflict-1 ", SubjectURN: " urn:asset:1 ", Predicate: " Public ", ResolutionState: " UNRESOLVED ",
+			Left: EvidenceReference{ID: " left ", Kind: " Finding "}, Right: EvidenceReference{ID: " right ", Kind: " Finding "},
+		}},
+		CoverageGaps: []CoverageGap{{ID: " gap-1 ", SourceID: " source-1 ", Dimension: " Coverage ", State: " PARTIAL ", Reason: " Missing data "}},
+		Affected:     []SubjectReference{{URN: " urn:asset:1 ", Kind: " Resource ", Name: " Asset 1 "}},
+		Controls:     []ControlReference{{ID: " control-1 ", Framework: " SOC 2 ", Applicability: " APPLICABLE "}},
+		AuditPackets: []AuditPacketReference{{ID: " audit-1 ", ScopeURN: " urn:asset:1 ", Digest: " sha256:audit ", GeneratedAt: instant, Freshness: " FRESH "}},
+		Actions: []ActionProposal{{
+			ID: " proposal-1 ", ActionID: " action-1 ", State: " PROPOSAL ", TargetURNs: []string{" urn:asset:1 "},
+			Rationale: " Investigate ", ApprovalRequirements: []string{" security "}, CatalogVersion: " v1 ", ProposalDigest: " sha256:proposal ",
+		}},
+		Provenance: Provenance{TraceID: " trace-1 ", ResolverIDs: []string{" resolver-1 "}, SourceIDs: []string{" source-1 "}, EvidenceDigest: " sha256:evidence ", CoverageDigest: " sha256:coverage "},
+	}
+	canonical, canonicalJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(spaced) error = %v", err)
+	}
+
+	packet.Contradictions[0] = Contradiction{ID: "conflict-1", SubjectURN: "urn:asset:1", Predicate: "public", ResolutionState: "unresolved", Left: EvidenceReference{ID: "left", Kind: "finding"}, Right: EvidenceReference{ID: "right", Kind: "finding"}}
+	packet.CoverageGaps[0] = CoverageGap{ID: "gap-1", SourceID: "source-1", Dimension: "coverage", State: "partial", Reason: "Missing data"}
+	packet.Affected[0] = SubjectReference{URN: "urn:asset:1", Kind: "resource", Name: "Asset 1"}
+	packet.Controls[0] = ControlReference{ID: "control-1", Framework: "SOC 2", Applicability: "applicable"}
+	packet.AuditPackets[0] = AuditPacketReference{ID: "audit-1", ScopeURN: "urn:asset:1", Digest: "sha256:audit", GeneratedAt: instant, Freshness: "fresh"}
+	packet.Actions[0] = ActionProposal{ID: "proposal-1", ActionID: "action-1", State: "proposal", TargetURNs: []string{"urn:asset:1"}, Rationale: "Investigate", ApprovalRequirements: []string{"security"}, CatalogVersion: "v1", ProposalDigest: "sha256:proposal"}
+	packet.Provenance = Provenance{TraceID: "trace-1", ResolverIDs: []string{"resolver-1"}, SourceIDs: []string{"source-1"}, EvidenceDigest: "sha256:evidence", CoverageDigest: "sha256:coverage"}
+	plain, plainJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(plain) error = %v", err)
+	}
+	if canonical.ID != plain.ID || string(canonicalJSON) != string(plainJSON) {
+		t.Fatalf("nested formatting changed canonical packet: spaced=%s plain=%s", canonicalJSON, plainJSON)
 	}
 }

--- a/internal/decisionpacket/rules_test.go
+++ b/internal/decisionpacket/rules_test.go
@@ -247,3 +247,24 @@ func TestCanonicalizePacketNormalizesNestedDecisionFields(t *testing.T) {
 		t.Fatalf("nested formatting changed canonical packet: spaced=%s plain=%s", canonicalJSON, plainJSON)
 	}
 }
+
+func TestCanonicalizePacketTreatsNilAndEmptyResultSlicesEqually(t *testing.T) {
+	packet := Packet{GeneratedAt: time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)}
+	withNil, nilJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(nil) error = %v", err)
+	}
+	packet.Contradictions = []Contradiction{}
+	packet.CoverageGaps = []CoverageGap{}
+	packet.Affected = []SubjectReference{}
+	packet.Controls = []ControlReference{}
+	packet.AuditPackets = []AuditPacketReference{}
+	packet.Actions = []ActionProposal{}
+	withEmpty, emptyJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(empty) error = %v", err)
+	}
+	if withNil.ID != withEmpty.ID || string(nilJSON) != string(emptyJSON) {
+		t.Fatalf("nil and empty slices changed canonical packet: nil=%s empty=%s", nilJSON, emptyJSON)
+	}
+}

--- a/internal/decisionpacket/rules_test.go
+++ b/internal/decisionpacket/rules_test.go
@@ -117,6 +117,27 @@ func TestDetectContradictionsRequiresOverlappingValidity(t *testing.T) {
 	}
 }
 
+func TestDetectContradictionsDistinguishesRepeatedEvidenceAcrossValidityWindows(t *testing.T) {
+	start := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	common := ClaimObservation{TenantID: "tenant-1", SubjectURN: "urn:asset:1", Predicate: "public", ValidTo: start.Add(4 * time.Hour)}
+	first := common
+	first.Value, first.ValidFrom, first.Evidence = "true", start, EvidenceReference{ID: "evidence-1", Kind: "observation", ValidFrom: start}
+	second := common
+	second.Value, second.ValidFrom, second.Evidence = "false", start, EvidenceReference{ID: "evidence-2", Kind: "observation", ValidFrom: start}
+	third := common
+	third.Value, third.ValidFrom, third.Evidence = "true", start.Add(time.Hour), EvidenceReference{ID: "evidence-1", Kind: "observation", ValidFrom: start.Add(time.Hour)}
+	got := DetectContradictions([]ClaimObservation{third, second, first})
+	if len(got) != 2 || got[0].ID == got[1].ID {
+		t.Fatalf("contradictions = %+v, want two distinct content-addressed conflicts", got)
+	}
+	reordered := DetectContradictions([]ClaimObservation{first, second, third})
+	leftJSON, _ := json.Marshal(got)
+	rightJSON, _ := json.Marshal(reordered)
+	if string(leftJSON) != string(rightJSON) {
+		t.Fatalf("input order changed contradictions: first=%s reordered=%s", leftJSON, rightJSON)
+	}
+}
+
 func TestNormalizeRequestBudgets(t *testing.T) {
 	got, err := NormalizeRequest(Request{Workflow: " Triage ", FindingIDs: []string{"b", "a", "a"}})
 	if err != nil {
@@ -266,5 +287,32 @@ func TestCanonicalizePacketTreatsNilAndEmptyResultSlicesEqually(t *testing.T) {
 	}
 	if withNil.ID != withEmpty.ID || string(nilJSON) != string(emptyJSON) {
 		t.Fatalf("nil and empty slices changed canonical packet: nil=%s empty=%s", nilJSON, emptyJSON)
+	}
+}
+
+func TestCanonicalizePacketNormalizesEmbeddedAgentContracts(t *testing.T) {
+	packet := Packet{
+		GeneratedAt: time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC),
+		Guardrails: agentplatform.AgentDecisionGuardrails{
+			Version:         " v1 ",
+			Readiness:       agentplatform.AgentReadinessAssessment{State: " READY ", Reasons: nil},
+			VerifierResults: []agentplatform.AgentVerifierResult{{ID: " verifier-1 ", Status: " PASS ", Evidence: nil}},
+		},
+		Claim: agentplatform.ClaimVerification{Claim: " Asset is public ", Verdict: " SUPPORTED ", SupportingEvidence: nil, RequiredWriteBack: nil},
+	}
+	spaced, spacedJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(spaced agent contracts) error = %v", err)
+	}
+	packet.Guardrails.Version = "v1"
+	packet.Guardrails.Readiness = agentplatform.AgentReadinessAssessment{State: "ready", Reasons: []string{}}
+	packet.Guardrails.VerifierResults[0] = agentplatform.AgentVerifierResult{ID: "verifier-1", Status: "pass", Evidence: []string{}}
+	packet.Claim = agentplatform.ClaimVerification{Claim: "Asset is public", Verdict: "supported", SupportingEvidence: []agentplatform.EvidenceReference{}, RequiredWriteBack: []string{}, Blockers: []agentplatform.CapabilityDecisionBlocker{}, Warnings: []string{}, CounterEvidence: []agentplatform.EvidenceReference{}, MissingEvidence: []string{}, VerifierResults: []agentplatform.AgentVerifierResult{}}
+	plain, plainJSON, err := CanonicalizePacket(packet)
+	if err != nil {
+		t.Fatalf("CanonicalizePacket(plain agent contracts) error = %v", err)
+	}
+	if spaced.ID != plain.ID || string(spacedJSON) != string(plainJSON) {
+		t.Fatalf("agent contract formatting changed canonical packet: spaced=%s plain=%s", spacedJSON, plainJSON)
 	}
 }

--- a/internal/decisionpacket/testdata/decision_rules.golden.json
+++ b/internal/decisionpacket/testdata/decision_rules.golden.json
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "fresh_complete",
+    "claim_verdict": "supported",
+    "supporting_evidence": 2,
+    "guardrails_passed": true,
+    "decision_state": "supported",
+    "confidence_level": "high"
+  },
+  {
+    "name": "partial_coverage",
+    "claim_verdict": "supported",
+    "supporting_evidence": 2,
+    "guardrails_passed": true,
+    "required_gap": true,
+    "decision_state": "supported_with_gaps",
+    "confidence_level": "low"
+  },
+  {
+    "name": "stale_required_evidence",
+    "claim_verdict": "supported",
+    "supporting_evidence": 1,
+    "guardrails_passed": true,
+    "required_stale": true,
+    "decision_state": "supported_with_gaps",
+    "confidence_level": "low"
+  },
+  {
+    "name": "conflicting_primary_claim",
+    "claim_verdict": "contradicted",
+    "supporting_evidence": 1,
+    "guardrails_passed": true,
+    "unresolved_conflict": true,
+    "primary_conflict": true,
+    "decision_state": "blocked",
+    "confidence_level": "medium"
+  },
+  {
+    "name": "no_evidence",
+    "claim_verdict": "unknown",
+    "guardrails_passed": true,
+    "decision_state": "insufficient_evidence",
+    "confidence_level": "unknown"
+  }
+]

--- a/internal/decisionpacket/types.go
+++ b/internal/decisionpacket/types.go
@@ -115,8 +115,8 @@ type Confidence struct {
 
 type Freshness struct {
 	State            string    `json:"state"`
-	OldestObservedAt time.Time `json:"oldest_observed_at,omitempty"`
-	NewestObservedAt time.Time `json:"newest_observed_at,omitempty"`
+	OldestObservedAt time.Time `json:"oldest_observed_at,omitzero"`
+	NewestObservedAt time.Time `json:"newest_observed_at,omitzero"`
 	RequiredStale    bool      `json:"required_stale"`
 }
 
@@ -128,9 +128,9 @@ type EvidenceReference struct {
 	SubjectURN string    `json:"subject_urn,omitempty"`
 	Predicate  string    `json:"predicate,omitempty"`
 	Value      string    `json:"value,omitempty"`
-	ObservedAt time.Time `json:"observed_at,omitempty"`
-	ValidFrom  time.Time `json:"valid_from,omitempty"`
-	ValidTo    time.Time `json:"valid_to,omitempty"`
+	ObservedAt time.Time `json:"observed_at,omitzero"`
+	ValidFrom  time.Time `json:"valid_from,omitzero"`
+	ValidTo    time.Time `json:"valid_to,omitzero"`
 	Digest     string    `json:"digest,omitempty"`
 }
 

--- a/internal/decisionpacket/types.go
+++ b/internal/decisionpacket/types.go
@@ -1,0 +1,247 @@
+package decisionpacket
+
+import (
+	"time"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+)
+
+const SchemaVersion = "2026-07-15"
+
+const (
+	DecisionSupported            = "supported"
+	DecisionSupportedWithGaps    = "supported_with_gaps"
+	DecisionBlocked              = "blocked"
+	DecisionInsufficientEvidence = "insufficient_evidence"
+	DecisionNotApplicable        = "not_applicable"
+)
+
+const (
+	ConfidenceHigh    = "high"
+	ConfidenceMedium  = "medium"
+	ConfidenceLow     = "low"
+	ConfidenceUnknown = "unknown"
+)
+
+const (
+	CoverageComplete     = "complete"
+	CoveragePartial      = "partial"
+	CoverageStale        = "stale"
+	CoverageFailed       = "failed"
+	CoverageUnconfigured = "unconfigured"
+	CoverageUnsupported  = "unsupported"
+	CoverageUnverified   = "unverified"
+)
+
+const (
+	ActionInformational    = "informational"
+	ActionStateProposal    = "proposal"
+	ActionApprovalRequired = "approval_required"
+)
+
+const (
+	ContradictionUnresolved = "unresolved"
+	ContradictionResolved   = "resolved"
+)
+
+type Request struct {
+	Workflow        string   `json:"workflow"`
+	Question        string   `json:"question"`
+	ScopeURN        string   `json:"scope_urn,omitempty"`
+	FindingIDs      []string `json:"finding_ids,omitempty"`
+	ClaimIDs        []string `json:"claim_ids,omitempty"`
+	EvidenceURNs    []string `json:"evidence_urns,omitempty"`
+	AuditPacketIDs  []string `json:"audit_packet_ids,omitempty"`
+	RequiredSources []string `json:"required_sources,omitempty"`
+	RequestedAction string   `json:"requested_action,omitempty"`
+	Budgets         Budgets  `json:"budgets"`
+}
+
+type Budgets struct {
+	Evidence       int `json:"evidence,omitempty"`
+	Contradictions int `json:"contradictions,omitempty"`
+	CoverageGaps   int `json:"coverage_gaps,omitempty"`
+	Affected       int `json:"affected,omitempty"`
+	Controls       int `json:"controls,omitempty"`
+	AuditPackets   int `json:"audit_packets,omitempty"`
+	Actions        int `json:"actions,omitempty"`
+	GraphRows      int `json:"graph_rows,omitempty"`
+	GraphDepth     int `json:"graph_depth,omitempty"`
+}
+
+type Packet struct {
+	SchemaVersion  string                                `json:"schema_version"`
+	ID             string                                `json:"id"`
+	GeneratedAt    time.Time                             `json:"generated_at"`
+	Workflow       Workflow                              `json:"workflow"`
+	Scope          Scope                                 `json:"scope"`
+	Guardrails     agentplatform.AgentDecisionGuardrails `json:"guardrails"`
+	Claim          agentplatform.ClaimVerification       `json:"claim"`
+	Decision       Decision                              `json:"decision"`
+	Confidence     Confidence                            `json:"confidence"`
+	Freshness      Freshness                             `json:"freshness"`
+	Evidence       []EvidenceReference                   `json:"evidence"`
+	Contradictions []Contradiction                       `json:"contradictions"`
+	CoverageGaps   []CoverageGap                         `json:"coverage_gaps"`
+	Affected       []SubjectReference                    `json:"affected"`
+	Controls       []ControlReference                    `json:"controls"`
+	AuditPackets   []AuditPacketReference                `json:"audit_packets"`
+	Actions        []ActionProposal                      `json:"actions"`
+	Provenance     Provenance                            `json:"provenance"`
+	Limits         ResultLimits                          `json:"limits"`
+}
+
+type Workflow struct {
+	ID       string `json:"id"`
+	Question string `json:"question"`
+}
+
+type Scope struct {
+	TenantID string `json:"tenant_id"`
+	ActorID  string `json:"actor_id"`
+	URN      string `json:"urn,omitempty"`
+}
+
+type Decision struct {
+	State     string   `json:"state"`
+	Rationale string   `json:"rationale"`
+	Reasons   []string `json:"reasons"`
+}
+
+type Confidence struct {
+	Level string   `json:"level"`
+	Basis []string `json:"basis"`
+}
+
+type Freshness struct {
+	State            string    `json:"state"`
+	OldestObservedAt time.Time `json:"oldest_observed_at,omitempty"`
+	NewestObservedAt time.Time `json:"newest_observed_at,omitempty"`
+	RequiredStale    bool      `json:"required_stale"`
+}
+
+type EvidenceReference struct {
+	ID         string    `json:"id"`
+	URN        string    `json:"urn,omitempty"`
+	Kind       string    `json:"kind"`
+	SourceID   string    `json:"source_id,omitempty"`
+	SubjectURN string    `json:"subject_urn,omitempty"`
+	Predicate  string    `json:"predicate,omitempty"`
+	Value      string    `json:"value,omitempty"`
+	ObservedAt time.Time `json:"observed_at,omitempty"`
+	ValidFrom  time.Time `json:"valid_from,omitempty"`
+	ValidTo    time.Time `json:"valid_to,omitempty"`
+	Digest     string    `json:"digest,omitempty"`
+}
+
+type Contradiction struct {
+	ID              string            `json:"id"`
+	SubjectURN      string            `json:"subject_urn"`
+	Predicate       string            `json:"predicate"`
+	Left            EvidenceReference `json:"left"`
+	Right           EvidenceReference `json:"right"`
+	ResolutionState string            `json:"resolution_state"`
+	PrimaryClaim    bool              `json:"primary_claim"`
+}
+
+type CoverageGap struct {
+	ID                    string `json:"id"`
+	SourceID              string `json:"source_id,omitempty"`
+	Dimension             string `json:"dimension,omitempty"`
+	State                 string `json:"state"`
+	Required              bool   `json:"required"`
+	CouldChangeConclusion bool   `json:"could_change_conclusion"`
+	Reason                string `json:"reason"`
+}
+
+type SubjectReference struct {
+	URN  string `json:"urn"`
+	Kind string `json:"kind"`
+	Name string `json:"name,omitempty"`
+}
+
+type ControlReference struct {
+	ID            string `json:"id"`
+	Framework     string `json:"framework,omitempty"`
+	Applicability string `json:"applicability"`
+}
+
+type AuditPacketReference struct {
+	ID          string    `json:"id"`
+	ScopeURN    string    `json:"scope_urn,omitempty"`
+	Digest      string    `json:"digest"`
+	GeneratedAt time.Time `json:"generated_at"`
+	Freshness   string    `json:"freshness"`
+}
+
+type ActionProposal struct {
+	ID                   string   `json:"id"`
+	ActionID             string   `json:"action_id"`
+	State                string   `json:"state"`
+	TargetURNs           []string `json:"target_urns"`
+	Rationale            string   `json:"rationale"`
+	ApprovalRequirements []string `json:"approval_requirements,omitempty"`
+	CatalogVersion       string   `json:"catalog_version,omitempty"`
+	ProposalDigest       string   `json:"proposal_digest,omitempty"`
+}
+
+type Provenance struct {
+	TraceID        string   `json:"trace_id,omitempty"`
+	ResolverIDs    []string `json:"resolver_ids"`
+	SourceIDs      []string `json:"source_ids"`
+	EvidenceDigest string   `json:"evidence_digest,omitempty"`
+	CoverageDigest string   `json:"coverage_digest,omitempty"`
+}
+
+type ResultLimits struct {
+	Evidence       ResultLimit `json:"evidence"`
+	Contradictions ResultLimit `json:"contradictions"`
+	CoverageGaps   ResultLimit `json:"coverage_gaps"`
+	Affected       ResultLimit `json:"affected"`
+	Controls       ResultLimit `json:"controls"`
+	AuditPackets   ResultLimit `json:"audit_packets"`
+	Actions        ResultLimit `json:"actions"`
+	GraphRows      ResultLimit `json:"graph_rows"`
+	GraphDepth     ResultLimit `json:"graph_depth"`
+}
+
+type ResultLimit struct {
+	Requested  int  `json:"requested"`
+	Applied    int  `json:"applied"`
+	Returned   int  `json:"returned"`
+	TotalKnown int  `json:"total_known,omitempty"`
+	Truncated  bool `json:"truncated"`
+}
+
+type DecisionInputs struct {
+	ClaimVerdict     string
+	Applicable       *bool
+	RequiredGap      bool
+	RequiredStale    bool
+	PrimaryConflict  bool
+	OutcomeTruncated bool
+}
+
+type ConfidenceInputs struct {
+	SupportingEvidence int
+	RequiredGap        bool
+	RequiredStale      bool
+	RequiredUnverified bool
+	UnresolvedConflict bool
+	OptionalGapMatters bool
+	OutcomeTruncated   bool
+	GuardrailsPassed   bool
+}
+
+type ClaimObservation struct {
+	TenantID     string
+	SubjectURN   string
+	Predicate    string
+	Value        string
+	ValidFrom    time.Time
+	ValidTo      time.Time
+	ObservedAt   time.Time
+	SourceID     string
+	Evidence     EvidenceReference
+	PrimaryClaim bool
+}


### PR DESCRIPTION
## Summary
- define the versioned decision packet, bounded request, evidence, coverage, contradiction, action, provenance, and result-limit types
- derive decision state and confidence from explicit claim, freshness, coverage, conflict, truncation, and guardrail inputs
- normalize and content-address packets deterministically, with fixed rule fixtures for complete, partial, stale, conflicting, and no-evidence cases

## Validation
- `go test ./internal/decisionpacket ./internal/agentplatform -count=1`
- `make check-structural check-structural-test check-arch`
- `make lint`

## Scope
This change adds pure types and rules only. It does not add storage, graph access, transport, approval state, or action execution.