### PR TITLE
Resolve decision evidence server side

### DIFF
--- a/internal/decisionpacket/adapters.go
+++ b/internal/decisionpacket/adapters.go
@@ -1,0 +1,345 @@
+package decisionpacket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/graphactions"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecoverage"
+)
+
+var (
+	ErrProtectedReference  = errors.New("decision packet reference is unavailable")
+	ErrResolverUnavailable = errors.New("decision packet resolver is unavailable")
+)
+
+type CoverageReader interface {
+	ReadCoverage(context.Context, string, []string) ([]sourcecoverage.Record, error)
+}
+
+type FindingReader interface {
+	GetFinding(context.Context, string) (*ports.FindingRecord, error)
+}
+
+type FindingEvidenceReader interface {
+	ListFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error)
+}
+
+type ClaimReader interface {
+	ListClaims(context.Context, ports.ListClaimsRequest) ([]*ports.ClaimRecord, error)
+}
+
+type AuditPacketReader interface {
+	GetGRCAuditPacket(context.Context, string) (*ports.GRCAuditPacketReceipt, error)
+}
+
+type GraphReader interface {
+	GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error)
+}
+
+// PortsResolver adapts current state-store and graph boundaries into bounded,
+// redacted decision facts. It never executes an action.
+type PortsResolver struct {
+	Findings        FindingReader
+	FindingEvidence FindingEvidenceReader
+	Claims          ClaimReader
+	AuditPackets    AuditPacketReader
+	Graph           GraphReader
+	Coverage        CoverageReader
+	Actions         graphactions.Registry
+}
+
+func (r PortsResolver) Resolve(ctx context.Context, tenant AuthorizedTenant, request Request) (ResolvedFacts, error) {
+	result := ResolvedFacts{ResolverIDs: []string{"ports"}}
+	findings, err := r.resolveFindings(ctx, tenant.ID, request.FindingIDs)
+	if err != nil {
+		return ResolvedFacts{}, err
+	}
+	r.addFindingFacts(&result, findings)
+	if err := r.addFindingEvidence(ctx, &result, request.FindingIDs); err != nil {
+		return ResolvedFacts{}, err
+	}
+	if err := r.addClaims(ctx, &result, tenant.ID, request.ClaimIDs); err != nil {
+		return ResolvedFacts{}, err
+	}
+	if err := r.addAuditPackets(ctx, &result, tenant.ID, request.AuditPacketIDs); err != nil {
+		return ResolvedFacts{}, err
+	}
+	r.addCoverage(ctx, &result, tenant.ID, request.RequiredSources)
+	r.addGraphContext(ctx, &result, request.ScopeURN, request.Budgets.GraphDepth)
+	if err := r.addActionPreview(&result, request.RequestedAction, findings); err != nil {
+		return ResolvedFacts{}, err
+	}
+	return result, nil
+}
+
+func (r PortsResolver) resolveFindings(ctx context.Context, tenantID string, ids []string) ([]*ports.FindingRecord, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if r.Findings == nil {
+		return nil, fmt.Errorf("%w: finding store", ErrResolverUnavailable)
+	}
+	result := make([]*ports.FindingRecord, 0, len(ids))
+	for _, id := range ids {
+		finding, err := r.Findings.GetFinding(ctx, id)
+		if err != nil || finding == nil || strings.TrimSpace(finding.TenantID) != tenantID {
+			return nil, ErrProtectedReference
+		}
+		result = append(result, finding)
+	}
+	return result, nil
+}
+
+func (r PortsResolver) addFindingFacts(result *ResolvedFacts, findings []*ports.FindingRecord) {
+	for _, finding := range findings {
+		result.Evidence = append(result.Evidence, EvidenceReference{
+			ID: finding.ID, Kind: "finding", SourceID: finding.RuntimeID,
+			ObservedAt: finding.LastObservedAt,
+		})
+		result.SourceIDs = append(result.SourceIDs, finding.RuntimeID)
+		for _, urn := range finding.ResourceURNs {
+			result.Affected = append(result.Affected, SubjectReference{URN: urn, Kind: "resource"})
+		}
+		for _, ref := range finding.ControlRefs {
+			result.Controls = append(result.Controls, ControlReference{ID: ref.ControlID, Framework: ref.FrameworkName, Applicability: "applicable"})
+		}
+	}
+}
+
+func (r PortsResolver) addFindingEvidence(ctx context.Context, result *ResolvedFacts, findingIDs []string) error {
+	if len(findingIDs) == 0 {
+		return nil
+	}
+	if r.FindingEvidence == nil {
+		return fmt.Errorf("%w: finding evidence store", ErrResolverUnavailable)
+	}
+	items, err := r.FindingEvidence.ListFindingEvidence(ctx, ports.ListFindingEvidenceRequest{FindingIDs: findingIDs, Limit: 100})
+	if err != nil {
+		return fmt.Errorf("resolve finding evidence: %w", err)
+	}
+	for _, item := range items {
+		if item == nil || !containsString(findingIDs, item.GetFindingId()) {
+			continue
+		}
+		observedAt := protobufTime(item.GetLastObservedAt())
+		if observedAt.IsZero() {
+			observedAt = protobufTime(item.GetCreatedAt())
+		}
+		result.Evidence = append(result.Evidence, EvidenceReference{ID: item.GetId(), Kind: "finding_evidence", SourceID: item.GetRuntimeId(), ObservedAt: observedAt})
+		for _, eventID := range item.GetEventIds() {
+			result.Evidence = append(result.Evidence, EvidenceReference{ID: eventID, Kind: "source_event", SourceID: item.GetRuntimeId(), ObservedAt: observedAt})
+		}
+		result.SourceIDs = append(result.SourceIDs, item.GetRuntimeId())
+	}
+	return nil
+}
+
+func (r PortsResolver) addClaims(ctx context.Context, result *ResolvedFacts, tenantID string, claimIDs []string) error {
+	if len(claimIDs) == 0 {
+		return nil
+	}
+	if r.Claims == nil {
+		return fmt.Errorf("%w: claim store", ErrResolverUnavailable)
+	}
+	for _, claimID := range claimIDs {
+		claims, err := r.Claims.ListClaims(ctx, ports.ListClaimsRequest{TenantID: tenantID, ClaimID: claimID, Limit: 2})
+		if err != nil || len(claims) != 1 || claims[0] == nil || claims[0].TenantID != tenantID {
+			return ErrProtectedReference
+		}
+		claim := claims[0]
+		evidence := EvidenceReference{
+			ID: claim.ID, Kind: "claim", SourceID: claim.RuntimeID, SubjectURN: claim.SubjectURN,
+			Predicate: claim.Predicate, Value: claimValue(claim), ObservedAt: claim.ObservedAt,
+			ValidFrom: claim.ValidFrom, ValidTo: claim.ValidTo,
+		}
+		result.Evidence = append(result.Evidence, evidence)
+		result.Observations = append(result.Observations, ClaimObservation{
+			TenantID: tenantID, SubjectURN: claim.SubjectURN, Predicate: claim.Predicate,
+			Value: claimValue(claim), ValidFrom: claim.ValidFrom, ValidTo: claim.ValidTo,
+			ObservedAt: claim.ObservedAt, SourceID: claim.RuntimeID, Evidence: evidence,
+		})
+		result.SourceIDs = append(result.SourceIDs, claim.RuntimeID)
+	}
+	return nil
+}
+
+func (r PortsResolver) addAuditPackets(ctx context.Context, result *ResolvedFacts, tenantID string, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if r.AuditPackets == nil {
+		return fmt.Errorf("%w: audit packet store", ErrResolverUnavailable)
+	}
+	for _, id := range ids {
+		receipt, err := r.AuditPackets.GetGRCAuditPacket(ctx, id)
+		if err != nil || receipt == nil || receipt.TenantID != tenantID {
+			return ErrProtectedReference
+		}
+		result.AuditPackets = append(result.AuditPackets, AuditPacketReference{ID: receipt.ID, Digest: receipt.Digest, GeneratedAt: receipt.CreatedAt, Freshness: "unknown"})
+	}
+	return nil
+}
+
+func (r PortsResolver) addCoverage(ctx context.Context, result *ResolvedFacts, tenantID string, requiredSources []string) {
+	if len(requiredSources) == 0 {
+		return
+	}
+	if r.Coverage == nil {
+		for _, sourceID := range requiredSources {
+			result.CoverageGaps = append(result.CoverageGaps, coverageGap(sourceID, "", CoverageUnconfigured, true, "coverage resolver is not configured"))
+		}
+		return
+	}
+	records, err := r.Coverage.ReadCoverage(ctx, tenantID, requiredSources)
+	if err != nil {
+		for _, sourceID := range requiredSources {
+			result.CoverageGaps = append(result.CoverageGaps, coverageGap(sourceID, "", CoverageFailed, true, "coverage resolution failed"))
+		}
+		return
+	}
+	seen := map[string]bool{}
+	for _, record := range records {
+		if !containsString(requiredSources, record.SourceID) {
+			continue
+		}
+		seen[record.SourceID] = true
+		state := decisionCoverageState(record.State, record.CertificationTier)
+		if state != CoverageComplete {
+			result.CoverageGaps = append(result.CoverageGaps, coverageGap(record.SourceID, record.DimensionID, state, true, record.Warning))
+		}
+	}
+	for _, sourceID := range requiredSources {
+		if !seen[sourceID] {
+			result.CoverageGaps = append(result.CoverageGaps, coverageGap(sourceID, "", CoverageUnconfigured, true, "required source has no coverage record"))
+		}
+	}
+}
+
+func (r PortsResolver) addGraphContext(ctx context.Context, result *ResolvedFacts, scopeURN string, depth int) {
+	if scopeURN == "" {
+		return
+	}
+	if r.Graph == nil {
+		result.CoverageGaps = append(result.CoverageGaps, coverageGap("graph", "context", CoverageUnconfigured, false, "graph context is not configured"))
+		return
+	}
+	neighborhood, err := r.Graph.GetEntityNeighborhood(ctx, scopeURN, depth)
+	if err != nil {
+		result.CoverageGaps = append(result.CoverageGaps, coverageGap("graph", "context", CoverageFailed, false, "graph context resolution failed"))
+		return
+	}
+	if neighborhood == nil {
+		return
+	}
+	if neighborhood.Root != nil {
+		if tenantScopedURN(tenantFromURN(scopeURN), neighborhood.Root.URN) {
+			result.Affected = append(result.Affected, SubjectReference{URN: neighborhood.Root.URN, Kind: neighborhood.Root.EntityType, Name: neighborhood.Root.Label})
+		}
+	}
+	for _, node := range neighborhood.Neighbors {
+		if node != nil && tenantScopedURN(tenantFromURN(scopeURN), node.URN) {
+			result.Affected = append(result.Affected, SubjectReference{URN: node.URN, Kind: node.EntityType, Name: node.Label})
+		}
+	}
+}
+
+func (r PortsResolver) addActionPreview(result *ResolvedFacts, actionID string, findings []*ports.FindingRecord) error {
+	if actionID == "" {
+		return nil
+	}
+	if len(findings) != 1 {
+		return fmt.Errorf("%w: action preview requires one resolved finding", ErrProtectedReference)
+	}
+	spec, err := r.Actions.Lookup(actionID)
+	if err != nil {
+		return fmt.Errorf("resolve action metadata: %w", err)
+	}
+	if spec.CheckEligibility != nil {
+		if err := spec.CheckEligibility(spec.ID, findings[0]); err != nil {
+			return fmt.Errorf("action is not eligible: %w", err)
+		}
+	}
+	target, err := graphactions.TargetForActionSpec(spec, findings[0], "")
+	if err != nil {
+		return fmt.Errorf("resolve action target: %w", err)
+	}
+	state := ActionStateProposal
+	requirements := []string{}
+	if spec.Destructive {
+		state = ActionApprovalRequired
+		requirements = append(requirements, "human_approval")
+	}
+	result.Actions = append(result.Actions, ActionProposal{
+		ID: "preview:" + spec.ID, ActionID: spec.ID, State: state, TargetURNs: []string{target},
+		Rationale:            "The resolved finding is eligible for this action preview.",
+		ApprovalRequirements: requirements, CatalogVersion: "generated",
+	})
+	return nil
+}
+
+func coverageGap(sourceID, dimension, state string, required bool, reason string) CoverageGap {
+	if strings.TrimSpace(reason) == "" {
+		reason = "required coverage is not complete"
+	}
+	id := strings.Join([]string{"coverage", sourceID, dimension, state}, ":")
+	return CoverageGap{ID: id, SourceID: sourceID, Dimension: dimension, State: state, Required: required, CouldChangeConclusion: true, Reason: reason}
+}
+
+func decisionCoverageState(state string, tier sourcecoverage.CertificationTier) string {
+	if sourcecoverage.BoundedCertificationTier(tier) == sourcecoverage.CertificationUnknown {
+		return CoverageUnverified
+	}
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case sourcecoverage.StateHealthy:
+		return CoverageComplete
+	case sourcecoverage.StatePartial:
+		return CoveragePartial
+	case sourcecoverage.StateStale:
+		return CoverageStale
+	case sourcecoverage.StateFailed:
+		return CoverageFailed
+	case sourcecoverage.StateUnsupported:
+		return CoverageUnsupported
+	case sourcecoverage.StateUnconfigured:
+		return CoverageUnconfigured
+	default:
+		return CoverageUnverified
+	}
+}
+
+func claimValue(claim *ports.ClaimRecord) string {
+	if strings.TrimSpace(claim.ObjectURN) != "" {
+		return claim.ObjectURN
+	}
+	return claim.ObjectValue
+}
+
+func tenantFromURN(urn string) string {
+	parts := strings.SplitN(strings.TrimSpace(urn), ":", 5)
+	if len(parts) < 4 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return ""
+	}
+	return parts[2]
+}
+
+func protobufTime(value interface {
+	AsTime() time.Time
+	IsValid() bool
+}) time.Time {
+	if value == nil || !value.IsValid() {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
+}
+
+func containsString(values []string, wanted string) bool {
+	index := sort.SearchStrings(values, wanted)
+	return index < len(values) && values[index] == wanted
+}

--- a/internal/decisionpacket/adapters_test.go
+++ b/internal/decisionpacket/adapters_test.go
@@ -1,0 +1,70 @@
+package decisionpacket
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type findingReaderStub struct {
+	finding *ports.FindingRecord
+	err     error
+}
+
+func (s findingReaderStub) GetFinding(context.Context, string) (*ports.FindingRecord, error) {
+	return s.finding, s.err
+}
+
+type graphReaderStub struct{ err error }
+
+func (s graphReaderStub) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
+	return nil, s.err
+}
+
+type evidenceReaderStub struct{}
+
+func (evidenceReaderStub) ListFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error) {
+	return nil, nil
+}
+
+func TestPortsResolverHidesForeignFindingExistence(t *testing.T) {
+	resolver := PortsResolver{Findings: findingReaderStub{finding: &ports.FindingRecord{ID: "finding-1", TenantID: "other"}}, FindingEvidence: evidenceReaderStub{}}
+	_, err := resolver.Resolve(context.Background(), AuthorizedTenant{ID: "tenant-1"}, Request{FindingIDs: []string{"finding-1"}, Budgets: budgetDefaults})
+	if !errors.Is(err, ErrProtectedReference) {
+		t.Fatalf("Resolve() error = %v, want ErrProtectedReference", err)
+	}
+}
+
+func TestPortsResolverRepresentsOptionalGraphFailureAsGap(t *testing.T) {
+	resolver := PortsResolver{Graph: graphReaderStub{err: errors.New("graph unavailable")}}
+	facts, err := resolver.Resolve(context.Background(), AuthorizedTenant{ID: "tenant-1"}, Request{ScopeURN: "urn:cerebro:tenant-1:asset:1", Budgets: budgetDefaults})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if len(facts.CoverageGaps) != 1 || facts.CoverageGaps[0].State != CoverageFailed || facts.CoverageGaps[0].Required {
+		t.Fatalf("coverage gaps = %+v", facts.CoverageGaps)
+	}
+}
+
+func TestPortsResolverReturnsBoundedFindingFacts(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	resolver := PortsResolver{
+		Findings: findingReaderStub{finding: &ports.FindingRecord{
+			ID: "finding-1", TenantID: "tenant-1", RuntimeID: "runtime-1", LastObservedAt: now,
+			ResourceURNs: []string{"urn:cerebro:tenant-1:asset:1"},
+			ControlRefs:  []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+		}},
+		FindingEvidence: evidenceReaderStub{},
+	}
+	facts, err := resolver.Resolve(context.Background(), AuthorizedTenant{ID: "tenant-1"}, Request{FindingIDs: []string{"finding-1"}, Budgets: budgetDefaults})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if len(facts.Evidence) != 1 || len(facts.Affected) != 1 || len(facts.Controls) != 1 || facts.Controls[0].ID != "CC6.1" {
+		t.Fatalf("resolved facts = %+v", facts)
+	}
+}

--- a/internal/decisionpacket/resolver.go
+++ b/internal/decisionpacket/resolver.go
@@ -1,0 +1,59 @@
+package decisionpacket
+
+import "context"
+
+type Resolver interface {
+	Resolve(context.Context, AuthorizedTenant, Request) (ResolvedFacts, error)
+}
+
+type ResolvedFacts struct {
+	Evidence     []EvidenceReference
+	Observations []ClaimObservation
+	CoverageGaps []CoverageGap
+	Affected     []SubjectReference
+	Controls     []ControlReference
+	AuditPackets []AuditPacketReference
+	Actions      []ActionProposal
+	ResolverIDs  []string
+	SourceIDs    []string
+	Applicable   *bool
+	Rationale    string
+}
+
+type CompositeResolver struct {
+	Resolvers []Resolver
+}
+
+func (r CompositeResolver) Resolve(ctx context.Context, tenant AuthorizedTenant, request Request) (ResolvedFacts, error) {
+	result := ResolvedFacts{}
+	for _, resolver := range r.Resolvers {
+		if resolver == nil {
+			continue
+		}
+		facts, err := resolver.Resolve(ctx, tenant, request)
+		if err != nil {
+			return ResolvedFacts{}, err
+		}
+		mergeResolvedFacts(&result, facts)
+	}
+	return result, nil
+}
+
+func mergeResolvedFacts(target *ResolvedFacts, source ResolvedFacts) {
+	target.Evidence = append(target.Evidence, source.Evidence...)
+	target.Observations = append(target.Observations, source.Observations...)
+	target.CoverageGaps = append(target.CoverageGaps, source.CoverageGaps...)
+	target.Affected = append(target.Affected, source.Affected...)
+	target.Controls = append(target.Controls, source.Controls...)
+	target.AuditPackets = append(target.AuditPackets, source.AuditPackets...)
+	target.Actions = append(target.Actions, source.Actions...)
+	target.ResolverIDs = append(target.ResolverIDs, source.ResolverIDs...)
+	target.SourceIDs = append(target.SourceIDs, source.SourceIDs...)
+	if source.Applicable != nil {
+		value := *source.Applicable
+		target.Applicable = &value
+	}
+	if source.Rationale != "" {
+		target.Rationale = source.Rationale
+	}
+}

--- a/internal/decisionpacket/service.go
+++ b/internal/decisionpacket/service.go
@@ -123,6 +123,11 @@ func validateResolvedFacts(tenantID string, facts ResolvedFacts) error {
 			return ErrProtectedReference
 		}
 	}
+	for _, auditPacket := range facts.AuditPackets {
+		if auditPacket.ScopeURN != "" && !tenantScopedURN(tenantID, auditPacket.ScopeURN) {
+			return ErrProtectedReference
+		}
+	}
 	for _, action := range facts.Actions {
 		switch action.State {
 		case ActionInformational, ActionStateProposal, ActionApprovalRequired:
@@ -153,11 +158,8 @@ func buildResolvedClaim(tenantID, actorID string, request Request, facts Resolve
 			missing = append(missing, gap.ID)
 		}
 	}
-	freshness := "fresh"
 	_, requiredStale, _, _ := gapFlags(facts.CoverageGaps)
-	if requiredStale {
-		freshness = "stale"
-	}
+	freshness := deriveFreshness(facts.Evidence, requiredStale).State
 	return agentplatform.BuildClaimVerification(agentplatform.ClaimVerificationRequest{
 		TenantID: tenantID, ActorID: actorID, Claim: request.Question, ClaimType: request.Workflow,
 		ScopeURN: request.ScopeURN, SupportingEvidenceURNs: supporting, CounterEvidenceURNs: counter,

--- a/internal/decisionpacket/service.go
+++ b/internal/decisionpacket/service.go
@@ -1,0 +1,323 @@
+package decisionpacket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+)
+
+var ErrInvalidRequest = errors.New("invalid decision packet request")
+
+type Clock interface {
+	Now() time.Time
+}
+
+type SystemClock struct{}
+
+func (SystemClock) Now() time.Time { return time.Now().UTC() }
+
+type Service struct {
+	resolver Resolver
+	clock    Clock
+}
+
+func NewService(resolver Resolver, clock Clock) *Service {
+	if clock == nil {
+		clock = SystemClock{}
+	}
+	return &Service{resolver: resolver, clock: clock}
+}
+
+func (s *Service) Build(ctx context.Context, tenant AuthorizedTenant, actor AuthorizedActor, request Request) (*Packet, error) {
+	if s == nil || s.resolver == nil {
+		return nil, fmt.Errorf("%w: resolver is required", ErrResolverUnavailable)
+	}
+	tenant.ID = strings.TrimSpace(tenant.ID)
+	actor.ID = strings.TrimSpace(actor.ID)
+	if tenant.ID == "" || actor.ID == "" {
+		return nil, fmt.Errorf("%w: authenticated tenant and actor are required", ErrInvalidRequest)
+	}
+	request, err := NormalizeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	if request.Workflow == "" || request.Question == "" {
+		return nil, fmt.Errorf("%w: workflow and question are required", ErrInvalidRequest)
+	}
+	if request.ScopeURN != "" && !tenantScopedURN(tenant.ID, request.ScopeURN) {
+		return nil, ErrProtectedReference
+	}
+
+	facts, err := s.resolver.Resolve(ctx, tenant, request)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateResolvedFacts(tenant.ID, facts); err != nil {
+		return nil, err
+	}
+	now := s.clock.Now().UTC()
+	facts = normalizeResolvedFacts(facts)
+	rawFacts := facts
+	allContradictions := DetectContradictions(rawFacts.Observations)
+	truncated := resultIsTruncated(rawFacts, len(allContradictions), request.Budgets)
+	facts = boundResolvedFacts(facts, request.Budgets)
+	contradictions := boundSlice(allContradictions, request.Budgets.Contradictions)
+	coverage := coverageContext(tenant.ID, facts.CoverageGaps, now)
+	guardrails := agentplatform.BuildAgentDecisionGuardrails(agentplatform.EvidencePacketRequest{
+		TenantID: tenant.ID, ActorID: actor.ID, Question: request.Question, ScopeURN: request.ScopeURN,
+		CapabilityIDs:   []string{"graph-reasoning", "knowledge-provenance"},
+		RequestedScopes: actor.Scopes, CoverageContext: coverage,
+		Action:      agentplatform.EvidencePacketAction{Stage: agentplatform.ActionStageRecommend},
+		GeneratedAt: now.Format(time.RFC3339Nano),
+	})
+	claim := buildResolvedClaim(tenant.ID, actor.ID, request, facts, contradictions, coverage)
+	requiredGap, requiredStale, requiredUnverified, optionalGapMatters := gapFlags(facts.CoverageGaps)
+	primaryConflict := hasPrimaryConflict(contradictions)
+	decision := DeriveDecision(DecisionInputs{
+		ClaimVerdict: claim.Verdict, Applicable: facts.Applicable, RequiredGap: requiredGap,
+		RequiredStale: requiredStale, PrimaryConflict: primaryConflict, OutcomeTruncated: truncated,
+	})
+	decision.Rationale = strings.TrimSpace(facts.Rationale)
+	confidence := DeriveConfidence(ConfidenceInputs{
+		SupportingEvidence: len(facts.Evidence), RequiredGap: requiredGap, RequiredStale: requiredStale,
+		RequiredUnverified: requiredUnverified, UnresolvedConflict: len(contradictions) > 0,
+		OptionalGapMatters: optionalGapMatters, OutcomeTruncated: truncated,
+		GuardrailsPassed: guardrails.Readiness.State != agentplatform.AgentReadinessBlocked,
+	})
+	packet := Packet{
+		SchemaVersion: SchemaVersion, GeneratedAt: now,
+		Workflow:   Workflow{ID: request.Workflow, Question: request.Question},
+		Scope:      Scope{TenantID: tenant.ID, ActorID: actor.ID, URN: request.ScopeURN},
+		Guardrails: guardrails, Claim: claim, Decision: decision, Confidence: confidence,
+		Freshness: deriveFreshness(facts.Evidence, requiredStale), Evidence: facts.Evidence,
+		Contradictions: contradictions, CoverageGaps: facts.CoverageGaps, Affected: facts.Affected,
+		Controls: facts.Controls, AuditPackets: facts.AuditPackets, Actions: safeActions(facts.Actions, decision.State),
+		Provenance: Provenance{ResolverIDs: facts.ResolverIDs, SourceIDs: facts.SourceIDs},
+		Limits:     resultLimits(rawFacts, len(allContradictions), request.Budgets),
+	}
+	packet, _, err = CanonicalizePacket(packet)
+	if err != nil {
+		return nil, err
+	}
+	return &packet, nil
+}
+
+func validateResolvedFacts(tenantID string, facts ResolvedFacts) error {
+	for _, evidence := range facts.Evidence {
+		if (evidence.URN != "" && !tenantScopedURN(tenantID, evidence.URN)) || (evidence.SubjectURN != "" && !tenantScopedURN(tenantID, evidence.SubjectURN)) {
+			return ErrProtectedReference
+		}
+	}
+	for _, observation := range facts.Observations {
+		if observation.TenantID != tenantID || (observation.SubjectURN != "" && !tenantScopedURN(tenantID, observation.SubjectURN)) {
+			return ErrProtectedReference
+		}
+	}
+	for _, subject := range facts.Affected {
+		if !tenantScopedURN(tenantID, subject.URN) {
+			return ErrProtectedReference
+		}
+	}
+	for _, action := range facts.Actions {
+		switch action.State {
+		case ActionInformational, ActionStateProposal, ActionApprovalRequired:
+		default:
+			return fmt.Errorf("%w: unsupported action proposal state", ErrInvalidRequest)
+		}
+		for _, target := range action.TargetURNs {
+			if strings.HasPrefix(target, "urn:cerebro:") && !tenantScopedURN(tenantID, target) {
+				return ErrProtectedReference
+			}
+		}
+	}
+	return nil
+}
+
+func buildResolvedClaim(tenantID, actorID string, request Request, facts ResolvedFacts, contradictions []Contradiction, coverage *agentplatform.AgentCoverageContext) agentplatform.ClaimVerification {
+	supporting := make([]string, 0, len(facts.Evidence))
+	for _, evidence := range facts.Evidence {
+		supporting = append(supporting, evidenceURN(tenantID, evidence))
+	}
+	counter := []string{}
+	for _, contradiction := range contradictions {
+		counter = append(counter, evidenceURN(tenantID, contradiction.Right))
+	}
+	missing := []string{}
+	for _, gap := range facts.CoverageGaps {
+		if gap.Required {
+			missing = append(missing, gap.ID)
+		}
+	}
+	freshness := "fresh"
+	_, requiredStale, _, _ := gapFlags(facts.CoverageGaps)
+	if requiredStale {
+		freshness = "stale"
+	}
+	return agentplatform.BuildClaimVerification(agentplatform.ClaimVerificationRequest{
+		TenantID: tenantID, ActorID: actorID, Claim: request.Question, ClaimType: request.Workflow,
+		ScopeURN: request.ScopeURN, SupportingEvidenceURNs: supporting, CounterEvidenceURNs: counter,
+		MissingEvidence: missing, FreshnessState: freshness, CoverageContext: coverage,
+		RequestedActionStage: agentplatform.ActionStageRecommend,
+	})
+}
+
+func boundResolvedFacts(facts ResolvedFacts, budgets Budgets) ResolvedFacts {
+	facts.Evidence = boundSlice(facts.Evidence, budgets.Evidence)
+	facts.CoverageGaps = boundSlice(facts.CoverageGaps, budgets.CoverageGaps)
+	facts.Affected = boundSlice(facts.Affected, budgets.Affected)
+	facts.Controls = boundSlice(facts.Controls, budgets.Controls)
+	facts.AuditPackets = boundSlice(facts.AuditPackets, budgets.AuditPackets)
+	facts.Actions = boundSlice(facts.Actions, budgets.Actions)
+	return facts
+}
+
+func normalizeResolvedFacts(facts ResolvedFacts) ResolvedFacts {
+	for index := range facts.Evidence {
+		facts.Evidence[index] = normalizeEvidenceReference(facts.Evidence[index])
+	}
+	facts.Evidence = dedupeEvidence(facts.Evidence)
+	sort.Slice(facts.CoverageGaps, func(i, j int) bool { return facts.CoverageGaps[i].ID < facts.CoverageGaps[j].ID })
+	facts.CoverageGaps = dedupeByKey(facts.CoverageGaps, func(value CoverageGap) string { return value.ID })
+	sort.Slice(facts.Affected, func(i, j int) bool { return facts.Affected[i].URN < facts.Affected[j].URN })
+	facts.Affected = dedupeByKey(facts.Affected, func(value SubjectReference) string { return value.URN })
+	sort.Slice(facts.Controls, func(i, j int) bool { return facts.Controls[i].ID < facts.Controls[j].ID })
+	facts.Controls = dedupeByKey(facts.Controls, func(value ControlReference) string { return value.Framework + "\x00" + value.ID })
+	sort.Slice(facts.AuditPackets, func(i, j int) bool { return facts.AuditPackets[i].ID < facts.AuditPackets[j].ID })
+	facts.AuditPackets = dedupeByKey(facts.AuditPackets, func(value AuditPacketReference) string { return value.ID })
+	sort.Slice(facts.Actions, func(i, j int) bool { return facts.Actions[i].ID < facts.Actions[j].ID })
+	facts.Actions = dedupeByKey(facts.Actions, func(value ActionProposal) string { return value.ID })
+	facts.ResolverIDs = normalizeStrings(facts.ResolverIDs)
+	facts.SourceIDs = normalizeStrings(facts.SourceIDs)
+	return facts
+}
+
+func dedupeByKey[T any](values []T, key func(T) string) []T {
+	result := make([]T, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		itemKey := key(value)
+		if _, found := seen[itemKey]; found {
+			continue
+		}
+		seen[itemKey] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func boundSlice[T any](values []T, limit int) []T {
+	if len(values) <= limit {
+		return values
+	}
+	return values[:limit]
+}
+
+func coverageContext(tenantID string, gaps []CoverageGap, now time.Time) *agentplatform.AgentCoverageContext {
+	context := &agentplatform.AgentCoverageContext{Version: agentplatform.ContractVersion, TenantID: tenantID, GeneratedAt: now.Format(time.RFC3339Nano)}
+	for _, gap := range gaps {
+		context.TotalDimensions++
+		switch gap.State {
+		case CoveragePartial:
+			context.PartialCount++
+		case CoverageStale:
+			context.StaleCount++
+		case CoverageFailed:
+			context.FailedCount++
+		case CoverageUnsupported:
+			context.UnsupportedCount++
+		case CoverageUnconfigured:
+			context.UnconfiguredCount++
+		}
+		context.BlindSpotCount++
+	}
+	return context
+}
+
+func gapFlags(gaps []CoverageGap) (requiredGap, requiredStale, requiredUnverified, optionalGapMatters bool) {
+	for _, gap := range gaps {
+		if gap.Required {
+			requiredGap = true
+			requiredStale = requiredStale || gap.State == CoverageStale
+			requiredUnverified = requiredUnverified || gap.State == CoverageUnverified
+		} else if gap.CouldChangeConclusion {
+			optionalGapMatters = true
+		}
+	}
+	return requiredGap, requiredStale, requiredUnverified, optionalGapMatters
+}
+
+func hasPrimaryConflict(values []Contradiction) bool {
+	for _, value := range values {
+		if value.PrimaryClaim && value.ResolutionState == ContradictionUnresolved {
+			return true
+		}
+	}
+	return false
+}
+
+func safeActions(actions []ActionProposal, decisionState string) []ActionProposal {
+	result := append([]ActionProposal(nil), actions...)
+	if decisionState == DecisionBlocked || decisionState == DecisionInsufficientEvidence {
+		for index := range result {
+			result[index].State = ActionInformational
+			result[index].ApprovalRequirements = nil
+		}
+	}
+	return result
+}
+
+func deriveFreshness(evidence []EvidenceReference, requiredStale bool) Freshness {
+	result := Freshness{State: "unknown", RequiredStale: requiredStale}
+	for _, item := range evidence {
+		if item.ObservedAt.IsZero() {
+			continue
+		}
+		if result.OldestObservedAt.IsZero() || item.ObservedAt.Before(result.OldestObservedAt) {
+			result.OldestObservedAt = item.ObservedAt
+		}
+		if result.NewestObservedAt.IsZero() || item.ObservedAt.After(result.NewestObservedAt) {
+			result.NewestObservedAt = item.ObservedAt
+		}
+	}
+	if !result.NewestObservedAt.IsZero() {
+		result.State = "fresh"
+	}
+	if requiredStale {
+		result.State = "stale"
+	}
+	return result
+}
+
+func evidenceURN(tenantID string, evidence EvidenceReference) string {
+	if evidence.URN != "" {
+		return evidence.URN
+	}
+	return "urn:cerebro:" + tenantID + ":evidence:" + evidence.ID
+}
+
+func tenantScopedURN(tenantID, urn string) bool {
+	return strings.HasPrefix(strings.TrimSpace(urn), "urn:cerebro:"+tenantID+":")
+}
+
+func resultLimits(facts ResolvedFacts, contradictionCount int, budgets Budgets) ResultLimits {
+	return ResultLimits{
+		Evidence: limitOf(len(facts.Evidence), budgets.Evidence), Contradictions: limitOf(contradictionCount, budgets.Contradictions),
+		CoverageGaps: limitOf(len(facts.CoverageGaps), budgets.CoverageGaps), Affected: limitOf(len(facts.Affected), budgets.Affected),
+		Controls: limitOf(len(facts.Controls), budgets.Controls), AuditPackets: limitOf(len(facts.AuditPackets), budgets.AuditPackets),
+		Actions: limitOf(len(facts.Actions), budgets.Actions), GraphRows: ResultLimit{Requested: budgets.GraphRows, Applied: budgets.GraphRows},
+		GraphDepth: ResultLimit{Requested: budgets.GraphDepth, Applied: budgets.GraphDepth},
+	}
+}
+
+func limitOf(count, limit int) ResultLimit {
+	return ResultLimit{Requested: limit, Applied: limit, Returned: min(count, limit), TotalKnown: count, Truncated: count > limit}
+}
+
+func resultIsTruncated(facts ResolvedFacts, contradictionCount int, budgets Budgets) bool {
+	return len(facts.Evidence) > budgets.Evidence || contradictionCount > budgets.Contradictions || len(facts.CoverageGaps) > budgets.CoverageGaps || len(facts.Affected) > budgets.Affected || len(facts.Controls) > budgets.Controls || len(facts.AuditPackets) > budgets.AuditPackets || len(facts.Actions) > budgets.Actions
+}

--- a/internal/decisionpacket/service_test.go
+++ b/internal/decisionpacket/service_test.go
@@ -85,6 +85,18 @@ func TestServiceMakesCoverageAndTruncationVisible(t *testing.T) {
 	}
 }
 
+func TestServiceKeepsUnknownEvidenceFreshnessVisible(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	resolver := &stubResolver{facts: ResolvedFacts{Evidence: []EvidenceReference{{ID: "evidence-1", Kind: "finding"}}}}
+	packet, err := NewService(resolver, fixedClock{now: now}).Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1"}, Request{Workflow: "triage", Question: "Is this finding current?"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if packet.Freshness.State != "unknown" || packet.Claim.FreshnessState != "unknown" || packet.Claim.Verdict != agentplatform.ClaimVerdictWeaklySupported || packet.Decision.State != DecisionSupportedWithGaps {
+		t.Fatalf("freshness = %+v claim = %+v decision = %+v", packet.Freshness, packet.Claim, packet.Decision)
+	}
+}
+
 func TestServiceBlocksPrimaryContradictionAndDowngradesActions(t *testing.T) {
 	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
 	base := ClaimObservation{TenantID: "tenant-1", SubjectURN: "urn:cerebro:tenant-1:asset:1", Predicate: "public", ValidFrom: now.Add(-time.Hour), PrimaryClaim: true}
@@ -137,6 +149,7 @@ func TestServiceRejectsForeignResolvedFactsAndExecutionStates(t *testing.T) {
 		facts ResolvedFacts
 	}{
 		{name: "foreign evidence", facts: ResolvedFacts{Evidence: []EvidenceReference{{ID: "evidence-1", Kind: "finding", URN: "urn:cerebro:other:evidence:1"}}}},
+		{name: "foreign audit packet", facts: ResolvedFacts{AuditPackets: []AuditPacketReference{{ID: "audit-1", ScopeURN: "urn:cerebro:other:scope:1"}}}},
 		{name: "executed action", facts: ResolvedFacts{Actions: []ActionProposal{{ID: "action-1", State: "executed"}}}},
 	}
 	for _, tt := range tests {

--- a/internal/decisionpacket/service_test.go
+++ b/internal/decisionpacket/service_test.go
@@ -1,0 +1,150 @@
+package decisionpacket
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/agentplatform"
+)
+
+type fixedClock struct{ now time.Time }
+
+func (c fixedClock) Now() time.Time { return c.now }
+
+type stubResolver struct {
+	facts ResolvedFacts
+	err   error
+	seen  AuthorizedTenant
+}
+
+func (r *stubResolver) Resolve(_ context.Context, tenant AuthorizedTenant, _ Request) (ResolvedFacts, error) {
+	r.seen = tenant
+	return r.facts, r.err
+}
+
+func TestServiceBuildsSupportedContentAddressedPacket(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	resolver := &stubResolver{facts: ResolvedFacts{
+		Evidence:    []EvidenceReference{{ID: "evidence-1", Kind: "finding", ObservedAt: now.Add(-time.Minute)}},
+		Affected:    []SubjectReference{{URN: "urn:cerebro:tenant-1:asset:1", Kind: "asset"}},
+		ResolverIDs: []string{"finding-store"}, SourceIDs: []string{"source-1"},
+		Rationale: "Current evidence supports the requested conclusion.",
+	}}
+	service := NewService(resolver, fixedClock{now: now})
+	request := Request{Workflow: "triage", Question: "Is this finding current?", ScopeURN: "urn:cerebro:tenant-1:finding:1"}
+	packet, err := service.Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1", Scopes: []string{agentplatform.ScopeCosmoSecurityRead}}, request)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if resolver.seen.ID != "tenant-1" || packet.Scope.TenantID != "tenant-1" || packet.Scope.ActorID != "actor-1" {
+		t.Fatalf("forced scope = %+v, resolver tenant = %+v", packet.Scope, resolver.seen)
+	}
+	if packet.Decision.State != DecisionSupported || packet.Confidence.Level != ConfidenceHigh {
+		t.Fatalf("decision = %+v confidence = %+v", packet.Decision, packet.Confidence)
+	}
+	if !strings.HasPrefix(packet.ID, "dpr_") || packet.Claim.Verdict != agentplatform.ClaimVerdictSupported {
+		t.Fatalf("packet id = %q claim = %+v", packet.ID, packet.Claim)
+	}
+	second, err := service.Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1", Scopes: []string{agentplatform.ScopeCosmoSecurityRead}}, request)
+	if err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if second.ID != packet.ID {
+		t.Fatalf("same facts and clock produced ids %q and %q", packet.ID, second.ID)
+	}
+}
+
+func TestServiceMakesCoverageAndTruncationVisible(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	evidence := make([]EvidenceReference, 0, 3)
+	for _, id := range []string{"evidence-3", "evidence-1", "evidence-2"} {
+		evidence = append(evidence, EvidenceReference{ID: id, Kind: "finding", ObservedAt: now})
+	}
+	resolver := &stubResolver{facts: ResolvedFacts{
+		Evidence:     evidence,
+		CoverageGaps: []CoverageGap{{ID: "coverage:source-1:users:stale", SourceID: "source-1", Dimension: "users", State: CoverageStale, Required: true, CouldChangeConclusion: true, Reason: "required source is stale"}},
+	}}
+	service := NewService(resolver, fixedClock{now: now})
+	packet, err := service.Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1", Scopes: []string{agentplatform.ScopeCosmoSecurityRead}}, Request{
+		Workflow: "triage", Question: "Is this finding current?", Budgets: Budgets{Evidence: 2},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if packet.Decision.State != DecisionSupportedWithGaps || packet.Confidence.Level != ConfidenceLow {
+		t.Fatalf("decision = %+v confidence = %+v", packet.Decision, packet.Confidence)
+	}
+	if !packet.Limits.Evidence.Truncated || packet.Limits.Evidence.TotalKnown != 3 || len(packet.Evidence) != 2 {
+		t.Fatalf("evidence limit = %+v evidence = %+v", packet.Limits.Evidence, packet.Evidence)
+	}
+	if packet.Freshness.State != "stale" || !packet.Freshness.RequiredStale {
+		t.Fatalf("freshness = %+v", packet.Freshness)
+	}
+}
+
+func TestServiceBlocksPrimaryContradictionAndDowngradesActions(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	base := ClaimObservation{TenantID: "tenant-1", SubjectURN: "urn:cerebro:tenant-1:asset:1", Predicate: "public", ValidFrom: now.Add(-time.Hour), PrimaryClaim: true}
+	left := base
+	left.Value, left.Evidence = "true", EvidenceReference{ID: "evidence-1", Kind: "claim"}
+	right := base
+	right.Value, right.Evidence = "false", EvidenceReference{ID: "evidence-2", Kind: "claim"}
+	resolver := &stubResolver{facts: ResolvedFacts{
+		Evidence: []EvidenceReference{left.Evidence, right.Evidence}, Observations: []ClaimObservation{left, right},
+		Actions: []ActionProposal{{ID: "preview:action", ActionID: "action", State: ActionApprovalRequired, ApprovalRequirements: []string{"human_approval"}}},
+	}}
+	packet, err := NewService(resolver, fixedClock{now: now}).Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1", Scopes: []string{agentplatform.ScopeCosmoSecurityRead}}, Request{Workflow: "triage", Question: "Is this asset public?"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if packet.Decision.State != DecisionBlocked || len(packet.Contradictions) != 1 {
+		t.Fatalf("decision = %+v contradictions = %+v", packet.Decision, packet.Contradictions)
+	}
+	if len(packet.Actions) != 1 || packet.Actions[0].State != ActionInformational || len(packet.Actions[0].ApprovalRequirements) != 0 {
+		t.Fatalf("blocked action = %+v", packet.Actions)
+	}
+}
+
+func TestServiceDoesNotResolveCrossTenantScope(t *testing.T) {
+	resolver := &stubResolver{}
+	_, err := NewService(resolver, fixedClock{now: time.Now()}).Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1"}, Request{
+		Workflow: "triage", Question: "Review", ScopeURN: "urn:cerebro:other:finding:1",
+	})
+	if !errors.Is(err, ErrProtectedReference) {
+		t.Fatalf("Build() error = %v, want ErrProtectedReference", err)
+	}
+	if resolver.seen.ID != "" {
+		t.Fatal("resolver was called for a cross-tenant scope")
+	}
+}
+
+func TestServicePropagatesRequiredResolverFailure(t *testing.T) {
+	want := errors.New("store unavailable")
+	resolver := &stubResolver{err: want}
+	_, err := NewService(resolver, fixedClock{now: time.Now()}).Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1"}, Request{Workflow: "triage", Question: "Review"})
+	if !errors.Is(err, want) {
+		t.Fatalf("Build() error = %v, want %v", err, want)
+	}
+}
+
+func TestServiceRejectsForeignResolvedFactsAndExecutionStates(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		facts ResolvedFacts
+	}{
+		{name: "foreign evidence", facts: ResolvedFacts{Evidence: []EvidenceReference{{ID: "evidence-1", Kind: "finding", URN: "urn:cerebro:other:evidence:1"}}}},
+		{name: "executed action", facts: ResolvedFacts{Actions: []ActionProposal{{ID: "action-1", State: "executed"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewService(&stubResolver{facts: tt.facts}, fixedClock{now: now}).Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1"}, Request{Workflow: "triage", Question: "Review"})
+			if err == nil {
+				t.Fatal("Build() error = nil, want fail-closed validation")
+			}
+		})
+	}
+}

--- a/internal/decisionpacket/types.go
+++ b/internal/decisionpacket/types.go
@@ -57,6 +57,17 @@ type Request struct {
 	Budgets         Budgets  `json:"budgets"`
 }
 
+// AuthorizedTenant and AuthorizedActor are forced by transport authentication.
+// They are intentionally separate from Request so callers cannot override them.
+type AuthorizedTenant struct {
+	ID string
+}
+
+type AuthorizedActor struct {
+	ID     string
+	Scopes []string
+}
+
 type Budgets struct {
 	Evidence       int `json:"evidence,omitempty"`
 	Contradictions int `json:"contradictions,omitempty"`


### PR DESCRIPTION
## Summary
- add a tenant-forced decision-packet service over narrow finding, claim, evidence, coverage, audit-packet, graph, and action metadata adapters
- derive claim verification, coverage gaps, contradictions, freshness, decision state, confidence, and bounded result metadata from resolved records
- fail closed on foreign references and unsupported action states while representing optional graph failures as explicit gaps

## Validation
- `go test ./internal/decisionpacket ./internal/agentplatform ./internal/sourcecoverage -count=1`
- `make check-structural check-structural-test check-arch`
- `make lint`

## Scope
The service resolves and previews only. It does not persist receipts, add a transport, accept approval state, or execute actions.