### PR TITLE
Persist immutable decision packet receipts

### DIFF
--- a/internal/decisionpacket/service.go
+++ b/internal/decisionpacket/service.go
@@ -1,7 +1,11 @@
 package decisionpacket
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -9,9 +13,11 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/agentplatform"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 var ErrInvalidRequest = errors.New("invalid decision packet request")
+var ErrReceiptIntegrity = errors.New("decision packet receipt integrity check failed")
 
 type Clock interface {
 	Now() time.Time
@@ -22,8 +28,10 @@ type SystemClock struct{}
 func (SystemClock) Now() time.Time { return time.Now().UTC() }
 
 type Service struct {
-	resolver Resolver
-	clock    Clock
+	resolver         Resolver
+	clock            Clock
+	receipts         ports.DecisionPacketReceiptStore
+	receiptRetention time.Duration
 }
 
 func NewService(resolver Resolver, clock Clock) *Service {
@@ -31,6 +39,42 @@ func NewService(resolver Resolver, clock Clock) *Service {
 		clock = SystemClock{}
 	}
 	return &Service{resolver: resolver, clock: clock}
+}
+
+func NewPersistentService(resolver Resolver, clock Clock, receipts ports.DecisionPacketReceiptStore, retention time.Duration) *Service {
+	service := NewService(resolver, clock)
+	service.receipts = receipts
+	service.receiptRetention = retention
+	return service
+}
+
+func (s *Service) GetReceipt(ctx context.Context, tenant AuthorizedTenant, packetID string) (*Packet, error) {
+	if s == nil || s.receipts == nil {
+		return nil, fmt.Errorf("%w: receipt store is required", ErrResolverUnavailable)
+	}
+	tenant.ID = strings.TrimSpace(tenant.ID)
+	packetID = strings.TrimSpace(packetID)
+	if tenant.ID == "" || packetID == "" {
+		return nil, fmt.Errorf("%w: tenant and packet id are required", ErrInvalidRequest)
+	}
+	receipt, err := s.receipts.GetDecisionPacketReceipt(ctx, tenant.ID, packetID)
+	if err != nil {
+		return nil, err
+	}
+	var packet Packet
+	decoder := json.NewDecoder(bytes.NewReader(receipt.PacketJSON))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&packet); err != nil {
+		return nil, fmt.Errorf("%w: decode packet: %w", ErrReceiptIntegrity, err)
+	}
+	verified, canonical, err := CanonicalizePacket(packet)
+	if err != nil {
+		return nil, fmt.Errorf("%w: canonicalize packet: %w", ErrReceiptIntegrity, err)
+	}
+	if verified.ID != packetID || verified.Scope.TenantID != tenant.ID || digestBytes(canonical) != receipt.PacketDigest {
+		return nil, ErrReceiptIntegrity
+	}
+	return &verified, nil
 }
 
 func (s *Service) Build(ctx context.Context, tenant AuthorizedTenant, actor AuthorizedActor, request Request) (*Packet, error) {
@@ -89,6 +133,14 @@ func (s *Service) Build(ctx context.Context, tenant AuthorizedTenant, actor Auth
 		OptionalGapMatters: optionalGapMatters, OutcomeTruncated: truncated,
 		GuardrailsPassed: guardrails.Readiness.State != agentplatform.AgentReadinessBlocked,
 	})
+	evidenceDigest, err := digestCanonicalJSON(facts.Evidence)
+	if err != nil {
+		return nil, err
+	}
+	coverageDigest, err := digestCanonicalJSON(facts.CoverageGaps)
+	if err != nil {
+		return nil, err
+	}
 	packet := Packet{
 		SchemaVersion: SchemaVersion, GeneratedAt: now,
 		Workflow:   Workflow{ID: request.Workflow, Question: request.Question},
@@ -97,14 +149,46 @@ func (s *Service) Build(ctx context.Context, tenant AuthorizedTenant, actor Auth
 		Freshness: deriveFreshness(facts.Evidence, requiredStale), Evidence: facts.Evidence,
 		Contradictions: contradictions, CoverageGaps: facts.CoverageGaps, Affected: facts.Affected,
 		Controls: facts.Controls, AuditPackets: facts.AuditPackets, Actions: safeActions(facts.Actions, decision.State),
-		Provenance: Provenance{ResolverIDs: facts.ResolverIDs, SourceIDs: facts.SourceIDs},
-		Limits:     resultLimits(rawFacts, len(allContradictions), request.Budgets),
+		Provenance: Provenance{
+			ResolverIDs: facts.ResolverIDs, SourceIDs: facts.SourceIDs,
+			EvidenceDigest: evidenceDigest, CoverageDigest: coverageDigest,
+		},
+		Limits: resultLimits(rawFacts, len(allContradictions), request.Budgets),
 	}
-	packet, _, err = CanonicalizePacket(packet)
+	packet, canonical, err := CanonicalizePacket(packet)
 	if err != nil {
 		return nil, err
 	}
+	if s.receipts != nil {
+		receipt := &ports.DecisionPacketReceipt{
+			TenantID: tenant.ID, PacketID: packet.ID, SchemaVersion: packet.SchemaVersion,
+			Workflow: packet.Workflow.ID, ScopeURN: packet.Scope.URN, DecisionState: packet.Decision.State,
+			Confidence: packet.Confidence.Level, PacketDigest: digestBytes(canonical),
+			EvidenceDigest: packet.Provenance.EvidenceDigest, CoverageDigest: packet.Provenance.CoverageDigest,
+			PacketJSON: canonical, CreatedAt: packet.GeneratedAt,
+		}
+		if s.receiptRetention > 0 {
+			expiresAt := packet.GeneratedAt.Add(s.receiptRetention)
+			receipt.ExpiresAt = &expiresAt
+		}
+		if err := s.receipts.PutDecisionPacketReceipt(ctx, receipt); err != nil {
+			return nil, fmt.Errorf("persist decision packet receipt: %w", err)
+		}
+	}
 	return &packet, nil
+}
+
+func digestCanonicalJSON(value any) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("marshal decision packet digest input: %w", err)
+	}
+	return digestBytes(encoded), nil
+}
+
+func digestBytes(value []byte) string {
+	digest := sha256.Sum256(value)
+	return "sha256:" + hex.EncodeToString(digest[:])
 }
 
 func validateResolvedFacts(tenantID string, facts ResolvedFacts) error {

--- a/internal/decisionpacket/service_test.go
+++ b/internal/decisionpacket/service_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/agentplatform"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 type fixedClock struct{ now time.Time }
@@ -18,6 +19,34 @@ type stubResolver struct {
 	facts ResolvedFacts
 	err   error
 	seen  AuthorizedTenant
+}
+
+type receiptStoreStub struct {
+	receipt *ports.DecisionPacketReceipt
+	putErr  error
+	getErr  error
+}
+
+func (s *receiptStoreStub) PutDecisionPacketReceipt(_ context.Context, receipt *ports.DecisionPacketReceipt) error {
+	if s.putErr != nil {
+		return s.putErr
+	}
+	copy := *receipt
+	copy.PacketJSON = append([]byte(nil), receipt.PacketJSON...)
+	s.receipt = &copy
+	return nil
+}
+
+func (s *receiptStoreStub) GetDecisionPacketReceipt(_ context.Context, tenantID, packetID string) (*ports.DecisionPacketReceipt, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.receipt == nil || s.receipt.TenantID != tenantID || s.receipt.PacketID != packetID {
+		return nil, ports.ErrDecisionPacketNotFound
+	}
+	copy := *s.receipt
+	copy.PacketJSON = append([]byte(nil), s.receipt.PacketJSON...)
+	return &copy, nil
 }
 
 func (r *stubResolver) Resolve(_ context.Context, tenant AuthorizedTenant, _ Request) (ResolvedFacts, error) {
@@ -159,5 +188,53 @@ func TestServiceRejectsForeignResolvedFactsAndExecutionStates(t *testing.T) {
 				t.Fatal("Build() error = nil, want fail-closed validation")
 			}
 		})
+	}
+}
+
+func TestPersistentServiceRequiresReceiptAndCanReopenIt(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store := &receiptStoreStub{}
+	resolver := &stubResolver{facts: ResolvedFacts{Evidence: []EvidenceReference{{ID: "evidence-1", Kind: "finding", ObservedAt: now}}}}
+	service := NewPersistentService(resolver, fixedClock{now: now}, store, 30*24*time.Hour)
+	packet, err := service.Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1", Scopes: []string{agentplatform.ScopeCosmoSecurityRead}}, Request{Workflow: "triage", Question: "Review this finding"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if store.receipt == nil || store.receipt.PacketID != packet.ID || store.receipt.PacketDigest == "" || store.receipt.EvidenceDigest == "" || store.receipt.CoverageDigest == "" {
+		t.Fatalf("receipt = %+v", store.receipt)
+	}
+	if store.receipt.ExpiresAt == nil || !store.receipt.ExpiresAt.Equal(now.Add(30*24*time.Hour)) {
+		t.Fatalf("receipt expiry = %v", store.receipt.ExpiresAt)
+	}
+	reopened, err := service.GetReceipt(context.Background(), AuthorizedTenant{ID: "tenant-1"}, packet.ID)
+	if err != nil {
+		t.Fatalf("GetReceipt() error = %v", err)
+	}
+	if reopened.ID != packet.ID || reopened.Decision.State != packet.Decision.State {
+		t.Fatalf("reopened packet = %+v, want id %q", reopened, packet.ID)
+	}
+}
+
+func TestPersistentServiceDoesNotReturnPacketWhenReceiptWriteFails(t *testing.T) {
+	want := errors.New("receipt store unavailable")
+	service := NewPersistentService(&stubResolver{}, fixedClock{now: time.Now()}, &receiptStoreStub{putErr: want}, 0)
+	packet, err := service.Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1"}, Request{Workflow: "triage", Question: "Review"})
+	if packet != nil || !errors.Is(err, want) {
+		t.Fatalf("Build() = packet %+v, error %v; want nil packet and %v", packet, err, want)
+	}
+}
+
+func TestGetReceiptRejectsTamperedPacket(t *testing.T) {
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	store := &receiptStoreStub{}
+	service := NewPersistentService(&stubResolver{facts: ResolvedFacts{Evidence: []EvidenceReference{{ID: "evidence-1", Kind: "finding"}}}}, fixedClock{now: now}, store, 0)
+	packet, err := service.Build(context.Background(), AuthorizedTenant{ID: "tenant-1"}, AuthorizedActor{ID: "actor-1"}, Request{Workflow: "triage", Question: "Review"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	store.receipt.PacketJSON = append(store.receipt.PacketJSON[:len(store.receipt.PacketJSON)-1], []byte(`,"tampered":true}`)...)
+	_, err = service.GetReceipt(context.Background(), AuthorizedTenant{ID: "tenant-1"}, packet.ID)
+	if !errors.Is(err, ErrReceiptIntegrity) {
+		t.Fatalf("GetReceipt() error = %v, want ErrReceiptIntegrity", err)
 	}
 }

--- a/internal/ports/decision_packets.go
+++ b/internal/ports/decision_packets.go
@@ -1,0 +1,33 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrDecisionPacketNotFound  = errors.New("decision packet receipt not found")
+	ErrDecisionPacketImmutable = errors.New("decision packet receipt is immutable")
+)
+
+type DecisionPacketReceipt struct {
+	TenantID       string
+	PacketID       string
+	SchemaVersion  string
+	Workflow       string
+	ScopeURN       string
+	DecisionState  string
+	Confidence     string
+	PacketDigest   string
+	EvidenceDigest string
+	CoverageDigest string
+	PacketJSON     []byte
+	CreatedAt      time.Time
+	ExpiresAt      *time.Time
+}
+
+type DecisionPacketReceiptStore interface {
+	PutDecisionPacketReceipt(context.Context, *DecisionPacketReceipt) error
+	GetDecisionPacketReceipt(context.Context, string, string) (*DecisionPacketReceipt, error)
+}

--- a/internal/statestore/postgres/decision_packets.go
+++ b/internal/statestore/postgres/decision_packets.go
@@ -1,0 +1,128 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureDecisionPacketStatements = []string{`
+CREATE TABLE IF NOT EXISTS decision_packet_receipts (
+  tenant_id TEXT NOT NULL,
+  packet_id TEXT NOT NULL,
+  schema_version TEXT NOT NULL,
+  workflow TEXT NOT NULL,
+  scope_urn TEXT NOT NULL DEFAULT '',
+  decision_state TEXT NOT NULL,
+  confidence_level TEXT NOT NULL,
+  packet_digest TEXT NOT NULL,
+  evidence_digest TEXT NOT NULL,
+  coverage_digest TEXT NOT NULL,
+  packet_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ,
+  PRIMARY KEY (tenant_id, packet_id)
+)`, `
+CREATE INDEX IF NOT EXISTS decision_packet_receipts_expiry_idx
+ON decision_packet_receipts (tenant_id, expires_at)
+WHERE expires_at IS NOT NULL`}
+
+func (s *Store) PutDecisionPacketReceipt(ctx context.Context, receipt *ports.DecisionPacketReceipt) error {
+	if err := validateDecisionPacketReceipt(receipt); err != nil {
+		return err
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureDecisionPacketTable(ctx); err != nil {
+		return err
+	}
+	var expiresAt any
+	if receipt.ExpiresAt != nil {
+		expiresAt = receipt.ExpiresAt.UTC()
+	}
+	result, err := s.db.ExecContext(ctx, `
+INSERT INTO decision_packet_receipts (
+  tenant_id, packet_id, schema_version, workflow, scope_urn, decision_state,
+  confidence_level, packet_digest, evidence_digest, coverage_digest,
+  packet_json, created_at, expires_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12,$13)
+ON CONFLICT (tenant_id, packet_id) DO NOTHING`,
+		receipt.TenantID, receipt.PacketID, receipt.SchemaVersion, receipt.Workflow,
+		receipt.ScopeURN, receipt.DecisionState, receipt.Confidence, receipt.PacketDigest,
+		receipt.EvidenceDigest, receipt.CoverageDigest, string(receipt.PacketJSON),
+		receipt.CreatedAt.UTC(), expiresAt)
+	if err != nil {
+		return fmt.Errorf("insert decision packet receipt: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows > 0 {
+		return nil
+	}
+	var existingDigest string
+	if err := s.db.QueryRowContext(ctx, `
+SELECT packet_digest FROM decision_packet_receipts
+WHERE tenant_id = $1 AND packet_id = $2`, receipt.TenantID, receipt.PacketID).Scan(&existingDigest); err != nil {
+		return fmt.Errorf("read existing decision packet receipt: %w", err)
+	}
+	if existingDigest != receipt.PacketDigest {
+		return ports.ErrDecisionPacketImmutable
+	}
+	return nil
+}
+
+func (s *Store) GetDecisionPacketReceipt(ctx context.Context, tenantID, packetID string) (*ports.DecisionPacketReceipt, error) {
+	tenantID = strings.TrimSpace(tenantID)
+	packetID = strings.TrimSpace(packetID)
+	if tenantID == "" || packetID == "" {
+		return nil, errors.New("tenant id and decision packet id are required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureDecisionPacketTable(ctx); err != nil {
+		return nil, err
+	}
+	receipt := &ports.DecisionPacketReceipt{TenantID: tenantID, PacketID: packetID}
+	var packetJSON string
+	var expiresAt sql.NullTime
+	if err := s.db.QueryRowContext(ctx, `
+SELECT schema_version, workflow, scope_urn, decision_state, confidence_level,
+       packet_digest, evidence_digest, coverage_digest, packet_json::text,
+       created_at, expires_at
+FROM decision_packet_receipts
+WHERE tenant_id = $1 AND packet_id = $2`, tenantID, packetID).Scan(
+		&receipt.SchemaVersion, &receipt.Workflow, &receipt.ScopeURN,
+		&receipt.DecisionState, &receipt.Confidence, &receipt.PacketDigest,
+		&receipt.EvidenceDigest, &receipt.CoverageDigest, &packetJSON,
+		&receipt.CreatedAt, &expiresAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ports.ErrDecisionPacketNotFound
+		}
+		return nil, fmt.Errorf("query decision packet receipt: %w", err)
+	}
+	receipt.PacketJSON = []byte(packetJSON)
+	if expiresAt.Valid {
+		value := expiresAt.Time.UTC()
+		receipt.ExpiresAt = &value
+	}
+	return receipt, nil
+}
+
+func (s *Store) ensureDecisionPacketTable(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.grc.decisionPackets, "decision_packet_receipts", ensureDecisionPacketStatements)
+}
+
+func validateDecisionPacketReceipt(receipt *ports.DecisionPacketReceipt) error {
+	if receipt == nil || strings.TrimSpace(receipt.TenantID) == "" || strings.TrimSpace(receipt.PacketID) == "" ||
+		strings.TrimSpace(receipt.SchemaVersion) == "" || strings.TrimSpace(receipt.Workflow) == "" ||
+		strings.TrimSpace(receipt.DecisionState) == "" || strings.TrimSpace(receipt.Confidence) == "" ||
+		strings.TrimSpace(receipt.PacketDigest) == "" || strings.TrimSpace(receipt.EvidenceDigest) == "" ||
+		strings.TrimSpace(receipt.CoverageDigest) == "" || len(receipt.PacketJSON) == 0 || receipt.CreatedAt.IsZero() {
+		return errors.New("decision packet receipt is incomplete")
+	}
+	return nil
+}

--- a/internal/statestore/postgres/decision_packets_test.go
+++ b/internal/statestore/postgres/decision_packets_test.go
@@ -1,0 +1,27 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecisionPacketSchemaIsTenantScopedImmutableAndRetained(t *testing.T) {
+	schema := strings.Join(ensureDecisionPacketStatements, "\n")
+	for _, required := range []string{
+		"PRIMARY KEY (tenant_id, packet_id)",
+		"schema_version TEXT NOT NULL",
+		"packet_digest TEXT NOT NULL",
+		"evidence_digest TEXT NOT NULL",
+		"coverage_digest TEXT NOT NULL",
+		"packet_json JSONB NOT NULL",
+		"expires_at TIMESTAMPTZ",
+		"decision_packet_receipts_expiry_idx",
+	} {
+		if !strings.Contains(schema, required) {
+			t.Fatalf("schema missing %q:\n%s", required, schema)
+		}
+	}
+	if strings.Contains(strings.ToUpper(schema), " DO UPDATE") {
+		t.Fatalf("decision packet schema must not install an update path:\n%s", schema)
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -69,6 +69,7 @@ type grcTablesReady struct {
 	evidenceLedger       bool
 	auditState           bool
 	auditPackets         bool
+	decisionPackets      bool
 }
 
 type appendLogTablesReady struct {


### PR DESCRIPTION
## Summary
- add a tenant-scoped immutable receipt contract and Postgres schema for decision packets
- persist canonical packet JSON with packet, evidence, and coverage digests before returning success
- support retention timestamps and integrity-checked receipt reopening

## Validation
- `go test ./internal/decisionpacket ./internal/statestore/postgres ./internal/ports -count=1`
- `make check-structural check-structural-test check-arch`
- `golangci-lint run ./internal/decisionpacket ./internal/statestore/postgres ./internal/ports`

## Compatibility
The receipt store is additive. Packet construction remains read-only and does not create approval or execution state.