### PR TITLE
Add native Rust control kernel boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "cerebro-control-kernel"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cerebro-graphactiongen"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/control-kernel",
     "internal/graphagent/staticvalidator",
     "internal/sourcecoverage/evaluator",
     "internal/sourceprojection/panopticonresources",

--- a/crates/control-kernel/Cargo.toml
+++ b/crates/control-kernel/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cerebro-control-kernel"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/control-kernel/src/identity.rs
+++ b/crates/control-kernel/src/identity.rs
@@ -1,0 +1,136 @@
+use std::{error::Error, fmt, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+const MAX_IDENTIFIER_BYTES: usize = 256;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum IdentifierError {
+    Empty {
+        kind: &'static str,
+    },
+    TooLong {
+        kind: &'static str,
+        max_bytes: usize,
+    },
+    SurroundingWhitespace {
+        kind: &'static str,
+    },
+    ControlCharacter {
+        kind: &'static str,
+    },
+}
+
+impl fmt::Display for IdentifierError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty { kind } => write!(formatter, "{kind} is required"),
+            Self::TooLong { kind, max_bytes } => {
+                write!(formatter, "{kind} exceeds {max_bytes} bytes")
+            }
+            Self::SurroundingWhitespace { kind } => {
+                write!(formatter, "{kind} contains surrounding whitespace")
+            }
+            Self::ControlCharacter { kind } => {
+                write!(formatter, "{kind} contains a control character")
+            }
+        }
+    }
+}
+
+impl Error for IdentifierError {}
+
+macro_rules! identifier {
+    ($name:ident, $kind:literal) => {
+        #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn parse(value: impl Into<String>) -> Result<Self, IdentifierError> {
+                validate_identifier(value.into(), $kind).map(Self)
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = IdentifierError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Self::parse(value)
+            }
+        }
+    };
+}
+
+identifier!(TenantId, "tenant id");
+identifier!(MandateId, "mandate id");
+identifier!(MissionId, "mission id");
+identifier!(ActorId, "actor id");
+
+fn validate_identifier(value: String, kind: &'static str) -> Result<String, IdentifierError> {
+    if value.is_empty() {
+        return Err(IdentifierError::Empty { kind });
+    }
+    if value.len() > MAX_IDENTIFIER_BYTES {
+        return Err(IdentifierError::TooLong {
+            kind,
+            max_bytes: MAX_IDENTIFIER_BYTES,
+        });
+    }
+    if value.trim() != value {
+        return Err(IdentifierError::SurroundingWhitespace { kind });
+    }
+    if value.chars().any(char::is_control) {
+        return Err(IdentifierError::ControlCharacter { kind });
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifiers_preserve_exact_valid_values() {
+        let tenant = TenantId::parse("tenant/acme").expect("valid tenant id");
+        let mandate = MandateId::parse("mandate:access-removal").expect("valid mandate id");
+
+        assert_eq!(tenant.as_str(), "tenant/acme");
+        assert_eq!(mandate.as_str(), "mandate:access-removal");
+    }
+
+    #[test]
+    fn identifiers_reject_ambiguous_or_unsafe_values() {
+        assert!(matches!(
+            MissionId::parse(" mission-1"),
+            Err(IdentifierError::SurroundingWhitespace { .. })
+        ));
+        assert!(matches!(
+            ActorId::parse("actor\nadmin"),
+            Err(IdentifierError::ControlCharacter { .. })
+        ));
+        assert!(matches!(
+            TenantId::parse(""),
+            Err(IdentifierError::Empty { .. })
+        ));
+    }
+
+    #[test]
+    fn identifiers_enforce_a_bounded_wire_size() {
+        let oversized = "a".repeat(MAX_IDENTIFIER_BYTES + 1);
+        assert!(matches!(
+            MissionId::parse(oversized),
+            Err(IdentifierError::TooLong { .. })
+        ));
+    }
+}

--- a/crates/control-kernel/src/lib.rs
+++ b/crates/control-kernel/src/lib.rs
@@ -1,0 +1,12 @@
+//! Durable control-plane primitives for Cerebro mandates and missions.
+//!
+//! This crate is intentionally free of network, database, graph, provider,
+//! model, and transport dependencies. It owns stable identity and pure domain
+//! behavior. Runtime adapters belong outside the kernel.
+
+mod identity;
+
+pub use identity::{ActorId, IdentifierError, MandateId, MissionId, TenantId};
+
+/// Identifies the first public schema revision of the native control kernel.
+pub const SCHEMA_VERSION: &str = "cerebro.control-kernel.v1";

--- a/docs/engineering/non-goals.md
+++ b/docs/engineering/non-goals.md
@@ -146,21 +146,21 @@ Each section lists what Cerebro will not do, why that boundary exists, where in 
 - `internal/actionengine` models `Signal`, `Trigger`, `Playbook`, `Step`, `Execution`, and `Event`. It is not a DAG runtime, not a long-running scheduler, and not a generic workflow product. Cerebro will not import Argo Workflows, Temporal, or Cadence-shaped semantics into the core just because remediation and runtime response can be expressed in those.
 - Why: every workflow engine pays for itself only when DAG-level orchestration is actually needed. Cerebro's substrate is "the minimum model needed to unify remediation and runtime response" and growing it past that without evidence imports complexity that the rest of the system has to live with.
 - Enforced in: the absence of a DAG/workflow runtime dependency and the current workflow event/projection packages.
-- What would change this: a documented execution shape that genuinely requires DAG-level fan-out, conditional branching beyond per-step failure policies, or sub-workflow composition, ratified before code lands.
+- What would change this: a documented execution shape that genuinely requires DAG-level fan-out, conditional branching beyond per-step failure policies, or sub-workflow composition, ratified before code lands. The native Rust control-kernel carve is that reviewed boundary for mandate and mission orchestration; it does not expand `internal/actionengine` into a generic workflow engine.
 
-### Workflow durability is event-and-projection. Not graph-direct, not transactional outbox today, not optimistic.
+### Workflow durability is event-and-projection. Not graph-direct.
 
 - Decisions, actions, outcomes, finding notes, ticket links, and lifecycle status changes write a `workflow.v1.*` event before any graph mutation. Append failure prevents graph writes; graph failure leaves a replayable event behind. Cerebro will not write workflow nodes directly to Neo4j, swallow projection errors, or skip the event when the append log is configured.
 - Why: the graph is a projection. Workflow writes that bypass the event are unreplayable and reintroduce the silent-drift class of bugs that workflow durability was designed to remove.
 - Enforced in: `internal/workflowevents`, `internal/workflowprojection`, and graph write arch tests.
-- What would change this: only a reviewed workflow durability proposal that preserves replay filters, finding workflow events, outbox behavior, and timeline reads. Skipping ahead is out of scope.
+- What would change this: only a reviewed workflow durability proposal that preserves replay filters, finding workflow events, outbox behavior, and timeline reads. [`rust-control-kernel-carve.md`](rust-control-kernel-carve.md) defines the reviewed path for optimistic mission revisions and transactional event publication without changing the graph projection boundary.
 
-### No autonomous remediation through agents.
+### No ungoverned remediation through agents.
 
 - The Agent primitive composes Events, Streams, Views, Rules, and Actions under a policy. It does not get a private path to mutate Postgres or Neo4j. It does not author Cypher writes. It does not call Actions without going through the typed Action contract, including approval gates and trusted actuation scope where required.
-- Why: autonomous remediation is the failure mode that justifies most of the safety surface in Cerebro. Letting an Agent route around any of it would erase the reason the safety surface exists.
+- Why: ungoverned remediation is the failure mode that justifies most of the safety surface in Cerebro. Letting an Agent route around any of it would erase the reason the safety surface exists.
 - Enforced in: `internal/graphagent/validator.go`; trusted runtime-response scope derivation in `internal/bootstrap/auth.go`; and mutation gating in `internal/runtimeresponse`.
-- What would change this: nothing structural. Agent capabilities grow by adding typed Actions and Rules, not by widening Agent's direct surface.
+- What would change this: nothing allows a direct mutation path. The native control kernel may continue pre-authorized work only through typed Actions, scoped capability grants, immutable receipts, and independent verification; it cannot widen an Agent's direct surface.
 
 ## Runtime Response
 
@@ -242,7 +242,7 @@ These framings will not be adopted as Cerebro's product description:
 
 - "Security graph" as a product surface noun. Cerebro exposes a graph; one of its applications is security.
 - "AI security" as a positioning frame. Cerebro uses LLMs in narrow, validator-gated places. The substrate, not the LLM, is the product.
-- "Autonomous remediation" or "self-healing security". Cerebro performs constrained Actions with typed approval and trusted actuation scope. It does not self-direct.
+- "Autonomous remediation" or "self-healing security". Cerebro performs constrained Actions under mandates, scoped capability grants, and independent verification. It does not get an unmediated mutation path.
 - "Replacement for [vendor product]". Cerebro is the platform underneath what those products would otherwise be the only source of truth for. Replacement framing misdescribes the seam.
 
 Vocabulary creep in docs, code comments, marketing surfaces, and AI-generated artifacts is in scope for this document the same way capability creep is. Wording PRs that flatten Cerebro into a single category should cite this section and propose a more precise phrasing.

--- a/docs/engineering/rust-control-kernel-carve.md
+++ b/docs/engineering/rust-control-kernel-carve.md
@@ -1,0 +1,119 @@
+# Native Rust Control Kernel Carve
+
+## Decision
+
+Cerebro will build its durable mandate and mission control plane as a native Rust kernel. The existing Go service remains the compatibility data plane for source runtimes, provider collection, graph projection, current findings and GRC APIs, and action adapters while callers migrate.
+
+This is a service carve, not a package-by-package language translation. New mandate, mission, authority, scheduling, actor-coordination, decision, and verification behavior belongs to the Rust kernel. Existing Go capabilities are reached through versioned events and authenticated APIs.
+
+## Customer Outcome
+
+The kernel lets an operator establish a standing condition, such as removing production access after a person leaves, and lets Cerebro keep working until the condition is independently verified. A chat response, provider receipt, merged change, or completed job is not closure.
+
+## Ownership
+
+The Rust control kernel owns:
+
+- mandate identity, immutable revisions, scope, desired conditions, and suspension;
+- mission identity, state, hypotheses, plan revisions, commitments, and wake conditions;
+- actor capability declarations, assignment, and exclusive work leases;
+- scoped capability grants, decision requests, and immutable decision receipts;
+- action proposals, expected effects, rollback references, and execution receipts;
+- independent verification challenges, verification receipts, outcomes, and reopening;
+- replayable mission events and projections used by agent-facing APIs.
+
+The Go compatibility plane owns during migration:
+
+- source runtimes and connector implementations;
+- provider-specific collection and normalization entry points;
+- existing finding evaluation and graph projection;
+- existing action adapters and verified-action APIs;
+- existing report and GRC compatibility routes.
+
+The graph remains a rebuildable projection. It is not a mission store, scheduler, authority system, or closure record.
+
+## Process Boundary
+
+The control kernel runs as a native Linux process. It does not use CGO, in-process Go/Rust FFI, or embedded Wasm for orchestration. The current embedded Rust/Wasm modules remain bounded deterministic helpers. The kernel communicates with the compatibility plane through:
+
+- versioned JetStream events for observed state and durable workflow facts;
+- authenticated HTTP or Connect calls for existing reads and actions;
+- idempotency keys, exact tenant and resource identifiers, source revisions, and receipts on every boundary.
+
+## Storage Boundary
+
+This carve preserves the existing storage contract:
+
+- JetStream remains the log of record.
+- Postgres remains the current state store and holds mission projections, leases, and queryable state.
+- Neo4j remains a rebuildable graph projection.
+
+The kernel does not introduce another database. Mission events are appended to JetStream before their Postgres projections become visible. A projection can be rebuilt from ordered events.
+
+## Kernel Rules
+
+The `cerebro-control-kernel` crate is pure domain code. It must not depend on network clients, databases, graph clients, provider SDKs, model clients, or transport frameworks.
+
+The deterministic kernel owns:
+
+- valid state transitions;
+- optimistic revision checks;
+- grant and approval requirements;
+- actor separation rules;
+- idempotency identities;
+- closure and reopening conditions.
+
+A model may propose hypotheses, plans, actor assignments, and explanations. Model output cannot advance mission state, manufacture authority, or mark verification successful.
+
+## First Mandate
+
+The first production mandate is:
+
+> No terminated identity retains production access for more than 24 hours.
+
+The vertical is complete only when Cerebro can:
+
+1. consume a termination or active-access observation;
+2. open or deduplicate a mission;
+3. resolve identity, access path, owner, and source freshness;
+4. prepare a typed remediation plan;
+5. request the minimum required human decision;
+6. invoke an existing approved action adapter;
+7. wait for a newer source revision;
+8. independently verify that the access path is gone;
+9. close, block, or reopen the mission from evidence;
+10. publish one reusable outcome and evidence receipt.
+
+## Migration Stages
+
+1. **Shadow:** consume real events and create missions without external writes.
+2. **Recommend:** produce plans, action proposals, and decision requests.
+3. **Governed execution:** invoke one allowlisted existing adapter under an exact capability grant.
+4. **Default control plane:** agent-facing mission reads and decisions use the Rust kernel.
+5. **Domain migration:** move deterministic domains only when the move removes a complete Go ownership boundary.
+6. **Deletion:** retire duplicate Go orchestration and contract-only agent work surfaces.
+
+## Release Gates
+
+The Rust kernel cannot become authoritative until tests prove:
+
+- replay produces the same mission state and digest;
+- duplicate events do not duplicate missions or actions;
+- worker crashes do not lose or repeat completed effects;
+- stale leases cannot commit;
+- revoked or expired grants block execution;
+- missing or stale evidence cannot produce verified closure;
+- provider success cannot produce verified closure;
+- executor and verifier identities are distinct;
+- cross-tenant references fail closed;
+- mission history remains available when the graph is unavailable;
+- the kernel can be rolled back without losing mission history.
+
+## Delivery Discipline
+
+- Keep no more than two dependent draft layers ahead of a mergeable foundation.
+- Every draft has code, tests, an exact base, and an independently reviewable ownership boundary.
+- Do not merge a child into a feature branch to simulate progress.
+- Do not raise architecture budgets to hide misplaced behavior.
+- Do not port connectors to increase the percentage of Rust.
+- Do not create a generic workflow DSL before the first mandate proves the required execution shape.


### PR DESCRIPTION
## What changed

- Add a native Rust control-kernel workspace crate with bounded tenant, mandate, mission, and actor identifiers.
- Define the ownership boundary between the new control kernel and the existing compatibility data plane.
- Record the first mandate, migration stages, release gates, and delivery constraints.
- Update the workflow and remediation non-goals for the reviewed carve.

## Why

Mandate, mission, authority, scheduling, decision, and verification behavior needs one durable owner. This foundation creates that owner without changing runtime behavior or adding another datastore.

## Compatibility

The existing Go service, source runtimes, graph projection, APIs, and embedded Rust modules are unchanged. This PR adds no deployed service or action path.

## Validation

- `cargo test -p cerebro-control-kernel`
- `cargo fmt --all -- --check`
- `make docs-drift-check`
- `make check-arch`
- `git diff --check`
