### PR TITLE
Add Rust mandate and mission state machines

### DIFF
--- a/crates/control-kernel/src/lib.rs
+++ b/crates/control-kernel/src/lib.rs
@@ -5,8 +5,12 @@
 //! behavior. Runtime adapters belong outside the kernel.
 
 mod identity;
+mod mandate;
+mod mission;
 
 pub use identity::{ActorId, IdentifierError, MandateId, MissionId, TenantId};
+pub use mandate::{Mandate, MandateError, MandateInput, MandateStatus};
+pub use mission::{Mission, MissionError, MissionInput, MissionState, MissionTransition};
 
 /// Identifies the first public schema revision of the native control kernel.
 pub const SCHEMA_VERSION: &str = "cerebro.control-kernel.v1";

--- a/crates/control-kernel/src/mandate.rs
+++ b/crates/control-kernel/src/mandate.rs
@@ -1,0 +1,259 @@
+use std::{error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ActorId, MandateId, TenantId};
+
+const MAX_CONDITION_BYTES: usize = 4_096;
+const MAX_SCOPE_URNS: usize = 256;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MandateStatus {
+    Active,
+    Suspended,
+    Retired,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MandateInput {
+    pub tenant_id: TenantId,
+    pub mandate_id: MandateId,
+    pub desired_condition: String,
+    pub scope_urns: Vec<String>,
+    pub maximum_violation_age_seconds: u64,
+    pub actor_id: ActorId,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Mandate {
+    pub tenant_id: TenantId,
+    pub mandate_id: MandateId,
+    pub revision: u64,
+    pub status: MandateStatus,
+    pub desired_condition: String,
+    pub scope_urns: Vec<String>,
+    pub maximum_violation_age_seconds: u64,
+    pub changed_by: ActorId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MandateError {
+    InvalidCondition,
+    InvalidScope,
+    InvalidMaximumViolationAge,
+    RevisionConflict {
+        expected: u64,
+        actual: u64,
+    },
+    InvalidTransition {
+        from: MandateStatus,
+        to: MandateStatus,
+    },
+}
+
+impl fmt::Display for MandateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCondition => formatter.write_str("mandate desired condition is invalid"),
+            Self::InvalidScope => formatter.write_str("mandate scope is invalid"),
+            Self::InvalidMaximumViolationAge => {
+                formatter.write_str("mandate maximum violation age must be positive")
+            }
+            Self::RevisionConflict { expected, actual } => write!(
+                formatter,
+                "mandate revision conflict: expected {expected}, actual {actual}"
+            ),
+            Self::InvalidTransition { from, to } => {
+                write!(formatter, "invalid mandate transition: {from:?} -> {to:?}")
+            }
+        }
+    }
+}
+
+impl Error for MandateError {}
+
+impl Mandate {
+    pub fn create(input: MandateInput) -> Result<Self, MandateError> {
+        validate_condition(&input.desired_condition)?;
+        let scope_urns = normalize_scope(input.scope_urns)?;
+        if input.maximum_violation_age_seconds == 0 {
+            return Err(MandateError::InvalidMaximumViolationAge);
+        }
+        Ok(Self {
+            tenant_id: input.tenant_id,
+            mandate_id: input.mandate_id,
+            revision: 1,
+            status: MandateStatus::Active,
+            desired_condition: input.desired_condition,
+            scope_urns,
+            maximum_violation_age_seconds: input.maximum_violation_age_seconds,
+            changed_by: input.actor_id,
+        })
+    }
+
+    pub fn revise(
+        &self,
+        expected_revision: u64,
+        desired_condition: String,
+        scope_urns: Vec<String>,
+        maximum_violation_age_seconds: u64,
+        actor_id: ActorId,
+    ) -> Result<Self, MandateError> {
+        self.require_revision(expected_revision)?;
+        if self.status == MandateStatus::Retired {
+            return Err(MandateError::InvalidTransition {
+                from: self.status,
+                to: self.status,
+            });
+        }
+        validate_condition(&desired_condition)?;
+        let scope_urns = normalize_scope(scope_urns)?;
+        if maximum_violation_age_seconds == 0 {
+            return Err(MandateError::InvalidMaximumViolationAge);
+        }
+        Ok(Self {
+            tenant_id: self.tenant_id.clone(),
+            mandate_id: self.mandate_id.clone(),
+            revision: self.revision + 1,
+            status: self.status,
+            desired_condition,
+            scope_urns,
+            maximum_violation_age_seconds,
+            changed_by: actor_id,
+        })
+    }
+
+    pub fn transition(
+        &self,
+        expected_revision: u64,
+        status: MandateStatus,
+        actor_id: ActorId,
+    ) -> Result<Self, MandateError> {
+        self.require_revision(expected_revision)?;
+        let allowed = matches!(
+            (self.status, status),
+            (MandateStatus::Active, MandateStatus::Suspended)
+                | (MandateStatus::Suspended, MandateStatus::Active)
+                | (MandateStatus::Active, MandateStatus::Retired)
+                | (MandateStatus::Suspended, MandateStatus::Retired)
+        );
+        if !allowed {
+            return Err(MandateError::InvalidTransition {
+                from: self.status,
+                to: status,
+            });
+        }
+        let mut next = self.clone();
+        next.revision += 1;
+        next.status = status;
+        next.changed_by = actor_id;
+        Ok(next)
+    }
+
+    fn require_revision(&self, expected_revision: u64) -> Result<(), MandateError> {
+        if expected_revision != self.revision {
+            return Err(MandateError::RevisionConflict {
+                expected: expected_revision,
+                actual: self.revision,
+            });
+        }
+        Ok(())
+    }
+}
+
+fn validate_condition(condition: &str) -> Result<(), MandateError> {
+    if condition.trim().is_empty()
+        || condition.trim() != condition
+        || condition.len() > MAX_CONDITION_BYTES
+        || condition.chars().any(char::is_control)
+    {
+        return Err(MandateError::InvalidCondition);
+    }
+    Ok(())
+}
+
+fn normalize_scope(mut scope_urns: Vec<String>) -> Result<Vec<String>, MandateError> {
+    if scope_urns.is_empty() || scope_urns.len() > MAX_SCOPE_URNS {
+        return Err(MandateError::InvalidScope);
+    }
+    for urn in &scope_urns {
+        if urn.trim().is_empty()
+            || urn.trim() != urn
+            || urn.len() > 1_024
+            || urn.chars().any(char::is_control)
+        {
+            return Err(MandateError::InvalidScope);
+        }
+    }
+    scope_urns.sort();
+    scope_urns.dedup();
+    Ok(scope_urns)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mandate() -> Mandate {
+        Mandate::create(MandateInput {
+            tenant_id: TenantId::parse("tenant-1").unwrap(),
+            mandate_id: MandateId::parse("mandate-1").unwrap(),
+            desired_condition: "Terminated identities have no production access".into(),
+            scope_urns: vec!["urn:scope:prod".into(), "urn:scope:prod".into()],
+            maximum_violation_age_seconds: 86_400,
+            actor_id: ActorId::parse("operator-1").unwrap(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn mandate_revisions_are_optimistic_and_immutable() {
+        let original = mandate();
+        let revised = original
+            .revise(
+                1,
+                "Terminated identities have no effective production access".into(),
+                vec!["urn:scope:prod".into()],
+                43_200,
+                ActorId::parse("operator-2").unwrap(),
+            )
+            .unwrap();
+
+        assert_eq!(original.revision, 1);
+        assert_eq!(revised.revision, 2);
+        assert!(matches!(
+            revised.revise(
+                1,
+                revised.desired_condition.clone(),
+                revised.scope_urns.clone(),
+                revised.maximum_violation_age_seconds,
+                ActorId::parse("operator-3").unwrap(),
+            ),
+            Err(MandateError::RevisionConflict { .. })
+        ));
+    }
+
+    #[test]
+    fn retired_mandates_cannot_reactivate_or_change() {
+        let actor = ActorId::parse("operator-2").unwrap();
+        let retired = mandate()
+            .transition(1, MandateStatus::Retired, actor.clone())
+            .unwrap();
+
+        assert!(matches!(
+            retired.transition(2, MandateStatus::Active, actor.clone()),
+            Err(MandateError::InvalidTransition { .. })
+        ));
+        assert!(matches!(
+            retired.revise(
+                2,
+                retired.desired_condition.clone(),
+                retired.scope_urns.clone(),
+                retired.maximum_violation_age_seconds,
+                actor,
+            ),
+            Err(MandateError::InvalidTransition { .. })
+        ));
+    }
+}

--- a/crates/control-kernel/src/mission.rs
+++ b/crates/control-kernel/src/mission.rs
@@ -1,0 +1,280 @@
+use std::{error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ActorId, MandateId, MissionId, TenantId};
+
+const MAX_SUBJECT_URNS: usize = 256;
+const MAX_REASON_BYTES: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionState {
+    Open,
+    ResolvingScope,
+    Planning,
+    WaitingOnEvidence,
+    WaitingOnApproval,
+    ReadyToAct,
+    Acting,
+    Verifying,
+    Verified,
+    Blocked,
+    Closed,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MissionInput {
+    pub tenant_id: TenantId,
+    pub mission_id: MissionId,
+    pub mandate_id: MandateId,
+    pub mandate_revision: u64,
+    pub objective: String,
+    pub subject_urns: Vec<String>,
+    pub actor_id: ActorId,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Mission {
+    pub tenant_id: TenantId,
+    pub mission_id: MissionId,
+    pub mandate_id: MandateId,
+    pub mandate_revision: u64,
+    pub revision: u64,
+    pub state: MissionState,
+    pub objective: String,
+    pub subject_urns: Vec<String>,
+    pub changed_by: ActorId,
+    pub last_reason: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MissionTransition {
+    pub expected_revision: u64,
+    pub to: MissionState,
+    pub actor_id: ActorId,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MissionError {
+    InvalidObjective,
+    InvalidSubjects,
+    InvalidMandateRevision,
+    InvalidReason,
+    RevisionConflict {
+        expected: u64,
+        actual: u64,
+    },
+    InvalidTransition {
+        from: MissionState,
+        to: MissionState,
+    },
+}
+
+impl fmt::Display for MissionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidObjective => formatter.write_str("mission objective is invalid"),
+            Self::InvalidSubjects => formatter.write_str("mission subjects are invalid"),
+            Self::InvalidMandateRevision => {
+                formatter.write_str("mission mandate revision must be positive")
+            }
+            Self::InvalidReason => formatter.write_str("mission transition reason is invalid"),
+            Self::RevisionConflict { expected, actual } => write!(
+                formatter,
+                "mission revision conflict: expected {expected}, actual {actual}"
+            ),
+            Self::InvalidTransition { from, to } => {
+                write!(formatter, "invalid mission transition: {from:?} -> {to:?}")
+            }
+        }
+    }
+}
+
+impl Error for MissionError {}
+
+impl Mission {
+    pub fn open(input: MissionInput) -> Result<Self, MissionError> {
+        validate_text(&input.objective).map_err(|_| MissionError::InvalidObjective)?;
+        if input.mandate_revision == 0 {
+            return Err(MissionError::InvalidMandateRevision);
+        }
+        let subject_urns = normalize_subjects(input.subject_urns)?;
+        Ok(Self {
+            tenant_id: input.tenant_id,
+            mission_id: input.mission_id,
+            mandate_id: input.mandate_id,
+            mandate_revision: input.mandate_revision,
+            revision: 1,
+            state: MissionState::Open,
+            objective: input.objective,
+            subject_urns,
+            changed_by: input.actor_id,
+            last_reason: "mission opened".into(),
+        })
+    }
+
+    pub fn transition(&self, transition: MissionTransition) -> Result<Self, MissionError> {
+        if transition.expected_revision != self.revision {
+            return Err(MissionError::RevisionConflict {
+                expected: transition.expected_revision,
+                actual: self.revision,
+            });
+        }
+        validate_text(&transition.reason).map_err(|_| MissionError::InvalidReason)?;
+        if !transition_allowed(self.state, transition.to) {
+            return Err(MissionError::InvalidTransition {
+                from: self.state,
+                to: transition.to,
+            });
+        }
+        let mut next = self.clone();
+        next.revision += 1;
+        next.state = transition.to;
+        next.changed_by = transition.actor_id;
+        next.last_reason = transition.reason;
+        Ok(next)
+    }
+}
+
+fn transition_allowed(from: MissionState, to: MissionState) -> bool {
+    use MissionState::*;
+    matches!(
+        (from, to),
+        (Open, ResolvingScope)
+            | (ResolvingScope, Planning | WaitingOnEvidence | Blocked)
+            | (
+                Planning,
+                WaitingOnEvidence | WaitingOnApproval | ReadyToAct | Blocked
+            )
+            | (WaitingOnEvidence, Planning | Blocked)
+            | (WaitingOnApproval, ReadyToAct | Planning | Blocked)
+            | (ReadyToAct, Acting | Planning | Blocked)
+            | (Acting, Verifying | Blocked)
+            | (Verifying, Verified | Planning | WaitingOnEvidence | Blocked)
+            | (Verified, Closed | ResolvingScope)
+            | (
+                Blocked,
+                ResolvingScope | Planning | WaitingOnEvidence | WaitingOnApproval
+            )
+            | (Closed, ResolvingScope)
+    )
+}
+
+fn validate_text(value: &str) -> Result<(), ()> {
+    if value.trim().is_empty()
+        || value.trim() != value
+        || value.len() > MAX_REASON_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn normalize_subjects(mut subjects: Vec<String>) -> Result<Vec<String>, MissionError> {
+    if subjects.is_empty() || subjects.len() > MAX_SUBJECT_URNS {
+        return Err(MissionError::InvalidSubjects);
+    }
+    for subject in &subjects {
+        if subject.trim().is_empty()
+            || subject.trim() != subject
+            || subject.len() > 1_024
+            || subject.chars().any(char::is_control)
+        {
+            return Err(MissionError::InvalidSubjects);
+        }
+    }
+    subjects.sort();
+    subjects.dedup();
+    Ok(subjects)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mission() -> Mission {
+        Mission::open(MissionInput {
+            tenant_id: TenantId::parse("tenant-1").unwrap(),
+            mission_id: MissionId::parse("mission-1").unwrap(),
+            mandate_id: MandateId::parse("mandate-1").unwrap(),
+            mandate_revision: 1,
+            objective: "Remove effective access for a terminated identity".into(),
+            subject_urns: vec!["urn:identity:1".into()],
+            actor_id: ActorId::parse("kernel").unwrap(),
+        })
+        .unwrap()
+    }
+
+    fn advance(mission: &Mission, to: MissionState) -> Mission {
+        mission
+            .transition(MissionTransition {
+                expected_revision: mission.revision,
+                to,
+                actor_id: ActorId::parse("kernel").unwrap(),
+                reason: format!("advance to {to:?}"),
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn mission_happy_path_requires_verification_before_closure() {
+        let mission = mission();
+        let mission = advance(&mission, MissionState::ResolvingScope);
+        let mission = advance(&mission, MissionState::Planning);
+        let mission = advance(&mission, MissionState::WaitingOnApproval);
+        let mission = advance(&mission, MissionState::ReadyToAct);
+        let mission = advance(&mission, MissionState::Acting);
+        let mission = advance(&mission, MissionState::Verifying);
+
+        assert!(matches!(
+            mission.transition(MissionTransition {
+                expected_revision: mission.revision,
+                to: MissionState::Closed,
+                actor_id: ActorId::parse("kernel").unwrap(),
+                reason: "close".into(),
+            }),
+            Err(MissionError::InvalidTransition { .. })
+        ));
+
+        let mission = advance(&mission, MissionState::Verified);
+        assert_eq!(
+            advance(&mission, MissionState::Closed).state,
+            MissionState::Closed
+        );
+    }
+
+    #[test]
+    fn closed_missions_reopen_in_scope_resolution() {
+        let mission = mission();
+        let mission = advance(&mission, MissionState::ResolvingScope);
+        let mission = advance(&mission, MissionState::Planning);
+        let mission = advance(&mission, MissionState::ReadyToAct);
+        let mission = advance(&mission, MissionState::Acting);
+        let mission = advance(&mission, MissionState::Verifying);
+        let mission = advance(&mission, MissionState::Verified);
+        let mission = advance(&mission, MissionState::Closed);
+        let reopened = advance(&mission, MissionState::ResolvingScope);
+
+        assert_eq!(reopened.state, MissionState::ResolvingScope);
+        assert_eq!(reopened.revision, mission.revision + 1);
+    }
+
+    #[test]
+    fn stale_workers_cannot_advance_a_mission() {
+        let mission = mission();
+        let next = advance(&mission, MissionState::ResolvingScope);
+
+        assert!(matches!(
+            next.transition(MissionTransition {
+                expected_revision: 1,
+                to: MissionState::Planning,
+                actor_id: ActorId::parse("stale-worker").unwrap(),
+                reason: "stale plan".into(),
+            }),
+            Err(MissionError::RevisionConflict { .. })
+        ));
+    }
+}


### PR DESCRIPTION
## What changed

- Add immutable mandate revisions with active, suspended, and retired states.
- Add mission transitions from scope resolution through planning, approval, action, verification, closure, and reopening.
- Enforce bounded inputs, optimistic revisions, and explicit legal transitions.

## Why

The control kernel needs deterministic domain behavior before storage, scheduling, and transport are attached. These types make stale work and invalid lifecycle transitions fail at the domain boundary.

## Compatibility

This change is a pure Rust domain layer. It does not add storage, network listeners, background workers, or changes to existing Go services.

## Validation

- `cargo test --locked -p cerebro-control-kernel`
- `cargo fmt --all -- --check`
- `make check-arch`
- `git diff --check`
