### PR TITLE
Add replayable Rust agent control protocol

### DIFF
--- a/crates/control-kernel/src/authority.rs
+++ b/crates/control-kernel/src/authority.rs
@@ -1,0 +1,227 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{ActorId, DecisionId, GrantId, TenantId, VerificationId};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CapabilityGrant {
+    pub tenant_id: TenantId,
+    pub grant_id: GrantId,
+    pub actor_id: ActorId,
+    pub actions: Vec<String>,
+    pub resource_urn_prefixes: Vec<String>,
+    pub issued_at_unix_ms: u64,
+    pub expires_at_unix_ms: u64,
+    pub revoked_at_unix_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AuthorizationRequest {
+    pub tenant_id: TenantId,
+    pub actor_id: ActorId,
+    pub action: String,
+    pub resource_urn: String,
+    pub observed_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "decision", rename_all = "snake_case")]
+pub enum AuthorizationDecision {
+    Allowed { grant_id: GrantId },
+    Denied { reason: AuthorizationDenial },
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorizationDenial {
+    InvalidGrant,
+    TenantMismatch,
+    ActorMismatch,
+    NotYetValid,
+    Expired,
+    Revoked,
+    ActionNotGranted,
+    ResourceNotGranted,
+}
+
+impl CapabilityGrant {
+    pub fn authorize(&self, request: &AuthorizationRequest) -> AuthorizationDecision {
+        let denial = if !self.is_well_formed() {
+            Some(AuthorizationDenial::InvalidGrant)
+        } else if self.tenant_id != request.tenant_id {
+            Some(AuthorizationDenial::TenantMismatch)
+        } else if self.actor_id != request.actor_id {
+            Some(AuthorizationDenial::ActorMismatch)
+        } else if request.observed_at_unix_ms < self.issued_at_unix_ms {
+            Some(AuthorizationDenial::NotYetValid)
+        } else if request.observed_at_unix_ms >= self.expires_at_unix_ms {
+            Some(AuthorizationDenial::Expired)
+        } else if self
+            .revoked_at_unix_ms
+            .is_some_and(|revoked| request.observed_at_unix_ms >= revoked)
+        {
+            Some(AuthorizationDenial::Revoked)
+        } else if !self.actions.iter().any(|action| action == &request.action) {
+            Some(AuthorizationDenial::ActionNotGranted)
+        } else if !self
+            .resource_urn_prefixes
+            .iter()
+            .any(|prefix| request.resource_urn.starts_with(prefix))
+        {
+            Some(AuthorizationDenial::ResourceNotGranted)
+        } else {
+            None
+        };
+
+        match denial {
+            Some(reason) => AuthorizationDecision::Denied { reason },
+            None => AuthorizationDecision::Allowed {
+                grant_id: self.grant_id.clone(),
+            },
+        }
+    }
+
+    fn is_well_formed(&self) -> bool {
+        self.issued_at_unix_ms < self.expires_at_unix_ms
+            && !self.actions.is_empty()
+            && !self.resource_urn_prefixes.is_empty()
+            && self.actions.iter().all(|value| valid_value(value))
+            && self
+                .resource_urn_prefixes
+                .iter()
+                .all(|value| valid_value(value))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DecisionReceipt {
+    pub decision_id: DecisionId,
+    pub proposal_digest: String,
+    pub approved: bool,
+    pub decided_by: ActorId,
+    pub decided_at_unix_ms: u64,
+}
+
+impl DecisionReceipt {
+    pub fn authorizes(&self, expected_proposal_digest: &str) -> bool {
+        self.approved
+            && valid_value(&self.proposal_digest)
+            && self.proposal_digest == expected_proposal_digest
+            && self.decided_at_unix_ms > 0
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VerificationReceipt {
+    pub verification_id: VerificationId,
+    pub executor_actor_id: ActorId,
+    pub verifier_actor_id: ActorId,
+    pub previous_source_revision: String,
+    pub observed_source_revision: String,
+    pub effective: bool,
+    pub evidence_urns: Vec<String>,
+    pub verified_at_unix_ms: u64,
+}
+
+impl VerificationReceipt {
+    pub fn independently_confirms_effect(&self) -> bool {
+        self.executor_actor_id != self.verifier_actor_id
+            && valid_value(&self.previous_source_revision)
+            && valid_value(&self.observed_source_revision)
+            && self.previous_source_revision != self.observed_source_revision
+            && self.effective
+            && !self.evidence_urns.is_empty()
+            && self.evidence_urns.iter().all(|urn| valid_value(urn))
+            && self.verified_at_unix_ms > 0
+    }
+}
+
+fn valid_value(value: &str) -> bool {
+    !value.trim().is_empty()
+        && value.trim() == value
+        && value.len() <= 1_024
+        && !value.chars().any(char::is_control)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grant() -> CapabilityGrant {
+        CapabilityGrant {
+            tenant_id: TenantId::parse("tenant-1").unwrap(),
+            grant_id: GrantId::parse("grant-1").unwrap(),
+            actor_id: ActorId::parse("worker-1").unwrap(),
+            actions: vec!["identity.disable".into()],
+            resource_urn_prefixes: vec!["urn:identity:".into()],
+            issued_at_unix_ms: 100,
+            expires_at_unix_ms: 200,
+            revoked_at_unix_ms: None,
+        }
+    }
+
+    fn request() -> AuthorizationRequest {
+        AuthorizationRequest {
+            tenant_id: TenantId::parse("tenant-1").unwrap(),
+            actor_id: ActorId::parse("worker-1").unwrap(),
+            action: "identity.disable".into(),
+            resource_urn: "urn:identity:123".into(),
+            observed_at_unix_ms: 150,
+        }
+    }
+
+    #[test]
+    fn grants_bind_tenant_actor_action_resource_and_time() {
+        assert!(matches!(
+            grant().authorize(&request()),
+            AuthorizationDecision::Allowed { .. }
+        ));
+
+        let mut wrong_tenant = request();
+        wrong_tenant.tenant_id = TenantId::parse("tenant-2").unwrap();
+        assert_eq!(
+            grant().authorize(&wrong_tenant),
+            AuthorizationDecision::Denied {
+                reason: AuthorizationDenial::TenantMismatch
+            }
+        );
+
+        let mut expired = request();
+        expired.observed_at_unix_ms = 200;
+        assert_eq!(
+            grant().authorize(&expired),
+            AuthorizationDecision::Denied {
+                reason: AuthorizationDenial::Expired
+            }
+        );
+    }
+
+    #[test]
+    fn decisions_bind_the_exact_proposal() {
+        let receipt = DecisionReceipt {
+            decision_id: DecisionId::parse("decision-1").unwrap(),
+            proposal_digest: "sha256:approved".into(),
+            approved: true,
+            decided_by: ActorId::parse("policy-engine").unwrap(),
+            decided_at_unix_ms: 10,
+        };
+        assert!(receipt.authorizes("sha256:approved"));
+        assert!(!receipt.authorizes("sha256:changed"));
+    }
+
+    #[test]
+    fn verification_requires_a_new_source_revision_and_independent_actor() {
+        let mut receipt = VerificationReceipt {
+            verification_id: VerificationId::parse("verification-1").unwrap(),
+            executor_actor_id: ActorId::parse("worker-1").unwrap(),
+            verifier_actor_id: ActorId::parse("observer-1").unwrap(),
+            previous_source_revision: "revision-1".into(),
+            observed_source_revision: "revision-2".into(),
+            effective: true,
+            evidence_urns: vec!["urn:evidence:1".into()],
+            verified_at_unix_ms: 20,
+        };
+        assert!(receipt.independently_confirms_effect());
+        receipt.verifier_actor_id = receipt.executor_actor_id.clone();
+        assert!(!receipt.independently_confirms_effect());
+    }
+}

--- a/crates/control-kernel/src/event.rs
+++ b/crates/control-kernel/src/event.rs
@@ -1,0 +1,262 @@
+use std::{collections::BTreeSet, error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ActorId, Mission, MissionError, MissionId, MissionInput, MissionState, MissionTransition,
+    TenantId, VerificationReceipt,
+};
+
+const MAX_IDEMPOTENCY_KEY_BYTES: usize = 512;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MissionEventEnvelope {
+    pub schema_version: String,
+    pub tenant_id: TenantId,
+    pub mission_id: MissionId,
+    pub sequence: u64,
+    pub observed_at_unix_ms: u64,
+    pub actor_id: ActorId,
+    pub idempotency_key: String,
+    pub event: MissionEvent,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MissionEvent {
+    Opened {
+        input: MissionInput,
+    },
+    Transitioned {
+        from: MissionState,
+        to: MissionState,
+        reason: String,
+    },
+    Verified {
+        from: MissionState,
+        reason: String,
+        receipt: VerificationReceipt,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MissionAggregate {
+    pub mission: Mission,
+    pub last_sequence: u64,
+    seen_idempotency_keys: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReplayError {
+    Empty,
+    InvalidSequence { expected: u64, actual: u64 },
+    InvalidEnvelope,
+    DuplicateIdempotencyKey,
+    IdentityMismatch,
+    StateMismatch,
+    Mission(MissionError),
+}
+
+impl fmt::Display for ReplayError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("mission event stream is empty"),
+            Self::InvalidSequence { expected, actual } => {
+                write!(
+                    formatter,
+                    "invalid mission sequence: expected {expected}, actual {actual}"
+                )
+            }
+            Self::InvalidEnvelope => formatter.write_str("mission event envelope is invalid"),
+            Self::DuplicateIdempotencyKey => {
+                formatter.write_str("mission idempotency key is duplicated")
+            }
+            Self::IdentityMismatch => {
+                formatter.write_str("mission event identity does not match stream")
+            }
+            Self::StateMismatch => {
+                formatter.write_str("mission event state does not match aggregate")
+            }
+            Self::Mission(error) => write!(formatter, "mission event is invalid: {error}"),
+        }
+    }
+}
+
+impl Error for ReplayError {}
+
+impl From<MissionError> for ReplayError {
+    fn from(value: MissionError) -> Self {
+        Self::Mission(value)
+    }
+}
+
+impl MissionAggregate {
+    pub fn replay(events: &[MissionEventEnvelope]) -> Result<Self, ReplayError> {
+        let first = events.first().ok_or(ReplayError::Empty)?;
+        validate_envelope(first, 1)?;
+        let MissionEvent::Opened { input } = &first.event else {
+            return Err(ReplayError::StateMismatch);
+        };
+        if input.tenant_id != first.tenant_id || input.mission_id != first.mission_id {
+            return Err(ReplayError::IdentityMismatch);
+        }
+        let mission = Mission::open(input.clone())?;
+        let mut aggregate = Self {
+            mission,
+            last_sequence: 1,
+            seen_idempotency_keys: BTreeSet::from([first.idempotency_key.clone()]),
+        };
+        for event in &events[1..] {
+            aggregate.apply(event)?;
+        }
+        Ok(aggregate)
+    }
+
+    pub fn apply(&mut self, envelope: &MissionEventEnvelope) -> Result<(), ReplayError> {
+        let expected_sequence = self.last_sequence + 1;
+        validate_envelope(envelope, expected_sequence)?;
+        if envelope.tenant_id != self.mission.tenant_id
+            || envelope.mission_id != self.mission.mission_id
+        {
+            return Err(ReplayError::IdentityMismatch);
+        }
+        if self
+            .seen_idempotency_keys
+            .contains(&envelope.idempotency_key)
+        {
+            return Err(ReplayError::DuplicateIdempotencyKey);
+        }
+        match &envelope.event {
+            MissionEvent::Opened { .. } => return Err(ReplayError::StateMismatch),
+            MissionEvent::Transitioned { from, to, reason } => {
+                if *from != self.mission.state {
+                    return Err(ReplayError::StateMismatch);
+                }
+                self.mission = self.mission.transition(MissionTransition {
+                    expected_revision: self.mission.revision,
+                    to: *to,
+                    actor_id: envelope.actor_id.clone(),
+                    reason: reason.clone(),
+                })?;
+            }
+            MissionEvent::Verified {
+                from,
+                reason,
+                receipt,
+            } => {
+                if *from != self.mission.state {
+                    return Err(ReplayError::StateMismatch);
+                }
+                self.mission =
+                    self.mission
+                        .verify(self.mission.revision, receipt, reason.clone())?;
+            }
+        }
+        self.last_sequence = envelope.sequence;
+        self.seen_idempotency_keys
+            .insert(envelope.idempotency_key.clone());
+        Ok(())
+    }
+}
+
+fn validate_envelope(
+    event: &MissionEventEnvelope,
+    expected_sequence: u64,
+) -> Result<(), ReplayError> {
+    if event.sequence != expected_sequence {
+        return Err(ReplayError::InvalidSequence {
+            expected: expected_sequence,
+            actual: event.sequence,
+        });
+    }
+    if event.schema_version != crate::SCHEMA_VERSION
+        || event.observed_at_unix_ms == 0
+        || event.idempotency_key.trim().is_empty()
+        || event.idempotency_key.trim() != event.idempotency_key
+        || event.idempotency_key.len() > MAX_IDEMPOTENCY_KEY_BYTES
+        || event.idempotency_key.chars().any(char::is_control)
+    {
+        return Err(ReplayError::InvalidEnvelope);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MandateId;
+
+    fn opened() -> MissionEventEnvelope {
+        let tenant_id = TenantId::parse("tenant-1").unwrap();
+        let mission_id = MissionId::parse("mission-1").unwrap();
+        MissionEventEnvelope {
+            schema_version: crate::SCHEMA_VERSION.into(),
+            tenant_id: tenant_id.clone(),
+            mission_id: mission_id.clone(),
+            sequence: 1,
+            observed_at_unix_ms: 10,
+            actor_id: ActorId::parse("kernel").unwrap(),
+            idempotency_key: "open-1".into(),
+            event: MissionEvent::Opened {
+                input: MissionInput {
+                    tenant_id,
+                    mission_id,
+                    mandate_id: MandateId::parse("mandate-1").unwrap(),
+                    mandate_revision: 1,
+                    objective: "Remove stale access".into(),
+                    subject_urns: vec!["urn:identity:1".into()],
+                    actor_id: ActorId::parse("kernel").unwrap(),
+                },
+            },
+        }
+    }
+
+    fn transition(sequence: u64, from: MissionState, to: MissionState) -> MissionEventEnvelope {
+        MissionEventEnvelope {
+            schema_version: crate::SCHEMA_VERSION.into(),
+            tenant_id: TenantId::parse("tenant-1").unwrap(),
+            mission_id: MissionId::parse("mission-1").unwrap(),
+            sequence,
+            observed_at_unix_ms: 10 + sequence,
+            actor_id: ActorId::parse("worker-1").unwrap(),
+            idempotency_key: format!("event-{sequence}"),
+            event: MissionEvent::Transitioned {
+                from,
+                to,
+                reason: format!("advance to {to:?}"),
+            },
+        }
+    }
+
+    #[test]
+    fn replay_is_deterministic() {
+        let events = vec![
+            opened(),
+            transition(2, MissionState::Open, MissionState::ResolvingScope),
+            transition(3, MissionState::ResolvingScope, MissionState::Planning),
+        ];
+        let first = MissionAggregate::replay(&events).unwrap();
+        let second = MissionAggregate::replay(&events).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.mission.state, MissionState::Planning);
+    }
+
+    #[test]
+    fn replay_rejects_gaps_and_duplicate_keys() {
+        let gap = vec![
+            opened(),
+            transition(3, MissionState::Open, MissionState::ResolvingScope),
+        ];
+        assert!(matches!(
+            MissionAggregate::replay(&gap),
+            Err(ReplayError::InvalidSequence { .. })
+        ));
+
+        let mut duplicate = transition(2, MissionState::Open, MissionState::ResolvingScope);
+        duplicate.idempotency_key = "open-1".into();
+        assert_eq!(
+            MissionAggregate::replay(&[opened(), duplicate]),
+            Err(ReplayError::DuplicateIdempotencyKey)
+        );
+    }
+}

--- a/crates/control-kernel/src/identity.rs
+++ b/crates/control-kernel/src/identity.rs
@@ -76,6 +76,10 @@ identifier!(TenantId, "tenant id");
 identifier!(MandateId, "mandate id");
 identifier!(MissionId, "mission id");
 identifier!(ActorId, "actor id");
+identifier!(GrantId, "grant id");
+identifier!(DecisionId, "decision id");
+identifier!(VerificationId, "verification id");
+identifier!(RequestId, "request id");
 
 fn validate_identifier(value: String, kind: &'static str) -> Result<String, IdentifierError> {
     if value.is_empty() {

--- a/crates/control-kernel/src/lib.rs
+++ b/crates/control-kernel/src/lib.rs
@@ -4,13 +4,25 @@
 //! model, and transport dependencies. It owns stable identity and pure domain
 //! behavior. Runtime adapters belong outside the kernel.
 
+mod authority;
+mod event;
 mod identity;
 mod mandate;
 mod mission;
+mod protocol;
 
-pub use identity::{ActorId, IdentifierError, MandateId, MissionId, TenantId};
+pub use authority::{
+    AuthorizationDecision, AuthorizationDenial, AuthorizationRequest, CapabilityGrant,
+    DecisionReceipt, VerificationReceipt,
+};
+pub use event::{MissionAggregate, MissionEvent, MissionEventEnvelope, ReplayError};
+pub use identity::{
+    ActorId, DecisionId, GrantId, IdentifierError, MandateId, MissionId, RequestId, TenantId,
+    VerificationId,
+};
 pub use mandate::{Mandate, MandateError, MandateInput, MandateStatus};
 pub use mission::{Mission, MissionError, MissionInput, MissionState, MissionTransition};
+pub use protocol::{CommandEnvelope, ControlCommand, ControlResponse, ProtocolError};
 
 /// Identifies the first public schema revision of the native control kernel.
 pub const SCHEMA_VERSION: &str = "cerebro.control-kernel.v1";

--- a/crates/control-kernel/src/mission.rs
+++ b/crates/control-kernel/src/mission.rs
@@ -2,7 +2,7 @@ use std::{error::Error, fmt};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ActorId, MandateId, MissionId, TenantId};
+use crate::{ActorId, MandateId, MissionId, TenantId, VerificationReceipt};
 
 const MAX_SUBJECT_URNS: usize = 256;
 const MAX_REASON_BYTES: usize = 4_096;
@@ -62,6 +62,7 @@ pub enum MissionError {
     InvalidSubjects,
     InvalidMandateRevision,
     InvalidReason,
+    InvalidVerification,
     RevisionConflict {
         expected: u64,
         actual: u64,
@@ -81,6 +82,9 @@ impl fmt::Display for MissionError {
                 formatter.write_str("mission mandate revision must be positive")
             }
             Self::InvalidReason => formatter.write_str("mission transition reason is invalid"),
+            Self::InvalidVerification => {
+                formatter.write_str("mission verification receipt is invalid")
+            }
             Self::RevisionConflict { expected, actual } => write!(
                 formatter,
                 "mission revision conflict: expected {expected}, actual {actual}"
@@ -136,6 +140,36 @@ impl Mission {
         next.last_reason = transition.reason;
         Ok(next)
     }
+
+    pub fn verify(
+        &self,
+        expected_revision: u64,
+        receipt: &VerificationReceipt,
+        reason: String,
+    ) -> Result<Self, MissionError> {
+        if expected_revision != self.revision {
+            return Err(MissionError::RevisionConflict {
+                expected: expected_revision,
+                actual: self.revision,
+            });
+        }
+        if self.state != MissionState::Verifying {
+            return Err(MissionError::InvalidTransition {
+                from: self.state,
+                to: MissionState::Verified,
+            });
+        }
+        validate_text(&reason).map_err(|_| MissionError::InvalidReason)?;
+        if !receipt.independently_confirms_effect() {
+            return Err(MissionError::InvalidVerification);
+        }
+        let mut next = self.clone();
+        next.revision += 1;
+        next.state = MissionState::Verified;
+        next.changed_by = receipt.verifier_actor_id.clone();
+        next.last_reason = reason;
+        Ok(next)
+    }
 }
 
 fn transition_allowed(from: MissionState, to: MissionState) -> bool {
@@ -152,7 +186,7 @@ fn transition_allowed(from: MissionState, to: MissionState) -> bool {
             | (WaitingOnApproval, ReadyToAct | Planning | Blocked)
             | (ReadyToAct, Acting | Planning | Blocked)
             | (Acting, Verifying | Blocked)
-            | (Verifying, Verified | Planning | WaitingOnEvidence | Blocked)
+            | (Verifying, Planning | WaitingOnEvidence | Blocked)
             | (Verified, Closed | ResolvingScope)
             | (
                 Blocked,
@@ -219,6 +253,19 @@ mod tests {
             .unwrap()
     }
 
+    fn verification() -> VerificationReceipt {
+        VerificationReceipt {
+            verification_id: crate::VerificationId::parse("verification-1").unwrap(),
+            executor_actor_id: ActorId::parse("worker-1").unwrap(),
+            verifier_actor_id: ActorId::parse("observer-1").unwrap(),
+            previous_source_revision: "revision-1".into(),
+            observed_source_revision: "revision-2".into(),
+            effective: true,
+            evidence_urns: vec!["urn:evidence:1".into()],
+            verified_at_unix_ms: 20,
+        }
+    }
+
     #[test]
     fn mission_happy_path_requires_verification_before_closure() {
         let mission = mission();
@@ -239,7 +286,9 @@ mod tests {
             Err(MissionError::InvalidTransition { .. })
         ));
 
-        let mission = advance(&mission, MissionState::Verified);
+        let mission = mission
+            .verify(mission.revision, &verification(), "effect observed".into())
+            .unwrap();
         assert_eq!(
             advance(&mission, MissionState::Closed).state,
             MissionState::Closed
@@ -254,7 +303,9 @@ mod tests {
         let mission = advance(&mission, MissionState::ReadyToAct);
         let mission = advance(&mission, MissionState::Acting);
         let mission = advance(&mission, MissionState::Verifying);
-        let mission = advance(&mission, MissionState::Verified);
+        let mission = mission
+            .verify(mission.revision, &verification(), "effect observed".into())
+            .unwrap();
         let mission = advance(&mission, MissionState::Closed);
         let reopened = advance(&mission, MissionState::ResolvingScope);
 

--- a/crates/control-kernel/src/protocol.rs
+++ b/crates/control-kernel/src/protocol.rs
@@ -1,0 +1,140 @@
+use std::{error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ActorId, AuthorizationDecision, AuthorizationRequest, DecisionReceipt, Mission, MissionId,
+    MissionInput, MissionState, RequestId, TenantId, VerificationReceipt,
+};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CommandEnvelope {
+    pub schema_version: String,
+    pub request_id: RequestId,
+    pub tenant_id: TenantId,
+    pub command: ControlCommand,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum ControlCommand {
+    OpenMission {
+        input: MissionInput,
+    },
+    AdvanceMission {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        expected_revision: u64,
+        to: MissionState,
+        actor_id: ActorId,
+        reason: String,
+    },
+    Authorize {
+        request: AuthorizationRequest,
+    },
+    RecordDecision {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        expected_proposal_digest: String,
+        receipt: DecisionReceipt,
+    },
+    RecordVerification {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        receipt: VerificationReceipt,
+    },
+}
+
+impl ControlCommand {
+    pub fn tenant_id(&self) -> &TenantId {
+        match self {
+            Self::OpenMission { input } => &input.tenant_id,
+            Self::AdvanceMission { tenant_id, .. }
+            | Self::RecordDecision { tenant_id, .. }
+            | Self::RecordVerification { tenant_id, .. } => tenant_id,
+            Self::Authorize { request } => &request.tenant_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum ControlResponse {
+    Mission { mission: Mission },
+    Authorization { decision: AuthorizationDecision },
+    Accepted { request_id: RequestId },
+    Rejected { code: String, message: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProtocolError {
+    UnsupportedSchema,
+    TenantMismatch,
+}
+
+impl fmt::Display for ProtocolError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedSchema => formatter.write_str("control command schema is unsupported"),
+            Self::TenantMismatch => {
+                formatter.write_str("control command tenant does not match envelope")
+            }
+        }
+    }
+}
+
+impl Error for ProtocolError {}
+
+impl CommandEnvelope {
+    pub fn validate(&self) -> Result<(), ProtocolError> {
+        if self.schema_version != crate::SCHEMA_VERSION {
+            return Err(ProtocolError::UnsupportedSchema);
+        }
+        if self.tenant_id != *self.command.tenant_id() {
+            return Err(ProtocolError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MandateId;
+
+    fn envelope() -> CommandEnvelope {
+        let tenant_id = TenantId::parse("tenant-1").unwrap();
+        CommandEnvelope {
+            schema_version: crate::SCHEMA_VERSION.into(),
+            request_id: RequestId::parse("request-1").unwrap(),
+            tenant_id: tenant_id.clone(),
+            command: ControlCommand::OpenMission {
+                input: MissionInput {
+                    tenant_id,
+                    mission_id: MissionId::parse("mission-1").unwrap(),
+                    mandate_id: MandateId::parse("mandate-1").unwrap(),
+                    mandate_revision: 1,
+                    objective: "Remove stale access".into(),
+                    subject_urns: vec!["urn:identity:1".into()],
+                    actor_id: ActorId::parse("agent-1").unwrap(),
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn command_envelopes_bind_schema_and_tenant() {
+        assert_eq!(envelope().validate(), Ok(()));
+
+        let mut wrong_schema = envelope();
+        wrong_schema.schema_version = "cerebro.control-kernel.v2".into();
+        assert_eq!(
+            wrong_schema.validate(),
+            Err(ProtocolError::UnsupportedSchema)
+        );
+
+        let mut wrong_tenant = envelope();
+        wrong_tenant.tenant_id = TenantId::parse("tenant-2").unwrap();
+        assert_eq!(wrong_tenant.validate(), Err(ProtocolError::TenantMismatch));
+    }
+}

--- a/docs/engineering/control-kernel-protocol.md
+++ b/docs/engineering/control-kernel-protocol.md
@@ -1,0 +1,41 @@
+# Control kernel protocol
+
+The control kernel accepts bounded commands from agents and operators. Every command carries a schema version, request ID, and tenant ID. The tenant ID in the envelope must match the command payload.
+
+## Command contract
+
+The first protocol revision supports these commands:
+
+- `open_mission`: create a mission against an exact mandate revision.
+- `advance_mission`: request one legal mission state transition using the current mission revision.
+- `authorize`: test one actor, action, resource, and observation time against one capability grant.
+- `record_decision`: bind an approval decision to the exact proposal digest that was evaluated.
+- `record_verification`: record an independent observation after an action.
+
+Agents do not receive general write access. A capability grant names the tenant, actor, allowed actions, resource prefixes, issue time, expiry time, and revocation time. Requests outside any of those bounds are denied.
+
+## Mission replay
+
+Mission events use a tenant-scoped, mission-scoped sequence beginning at one. Each envelope includes an observation time, actor, and idempotency key. Replay rejects:
+
+- sequence gaps or reordering;
+- duplicate idempotency keys;
+- tenant or mission changes inside a stream;
+- a second open event;
+- transitions whose recorded source state differs from the aggregate;
+- transitions that violate the mission state machine.
+
+Given the same ordered event stream, replay produces the same mission state and revision.
+
+## Action completion
+
+An approval authorizes only the proposal digest recorded in its receipt. Any mutation to the proposal requires another decision.
+
+A mission can reach `verified` only after the runtime accepts a verification receipt with all of these properties:
+
+- the verifier differs from the executor;
+- the observed source revision differs from the pre-action source revision;
+- the expected effect is present;
+- at least one evidence URN identifies the confirming observation.
+
+The protocol types define this boundary. Storage, scheduling, transport, and source adapters remain outside the pure kernel crate.


### PR DESCRIPTION
## What changed

- Add deterministic mission event replay with ordered sequences, tenant and mission identity checks, and duplicate idempotency rejection.
- Add expiring and revocable capability grants bound to one tenant, actor, action set, and resource scope.
- Bind decisions to exact proposal digests.
- Require an independent actor, changed source revision, successful effect, and evidence before a mission reaches `verified`.
- Define versioned agent command and response envelopes for mission, authority, decision, and verification operations.
- Document the first control-kernel protocol revision.

## Why

Agents need a narrow control surface with explicit authority and replayable state. This layer makes retries deterministic, rejects stale or cross-tenant work, and prevents an executor from declaring its own action successful.

## Compatibility

The protocol remains transport-neutral. Existing services do not change, and storage, schedulers, network listeners, and source adapters stay outside the pure kernel crate.

## Validation

- `cargo test --locked -p cerebro-control-kernel`
- `cargo clippy --locked -p cerebro-control-kernel --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `make docs-drift-check`
- `make check-arch`
- `git diff --check`
