### PR TITLE
Centralize Rust workspace policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,21 @@ edition = "2024"
 rust-version = "1.93.1"
 license = "Apache-2.0"
 
+[workspace.dependencies]
+cerebro-wasm-guest = { version = "0.1.0", path = "internal/wasmguest" }
+libc = "0.2.180"
+regex = { version = "1.12.3", default-features = false, features = ["perf", "std"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde-saphyr = { version = "0.0.29", default-features = false, features = ["deserialize"] }
+serde_json = "1.0.149"
+
+[workspace.lints.rust]
+unsafe_code = "deny"
+unsafe_op_in_unsafe_fn = "deny"
+
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"
+
 # The workspace's release artifacts include embedded WebAssembly modules.
 # Favor small, deterministic binaries over incremental release build speed.
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: release-train-test
 .PHONY: sourcegen-grammar-check sourcegen-repro-check sourcegen-proof-check
 .PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-shard lint-api-cmd lint-internal lint-sources lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check content-pack-check control-index-generate control-index-check sourcegen-check connector-catalog-fidelity-generate connector-catalog-fidelity-check connector-catalog-review connector-api-discovery connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status codegen-check codegen-catalog-generate codegen-catalog-check projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo github-business-demo github-business-demo-env agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
-.PHONY: rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-wasm-check graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check
+.PHONY: rust-workspace-policy rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-wasm-check graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -465,7 +465,10 @@ mitre-context-evaluator-generate: ## Rebuild the embedded MITRE context evaluato
 mitre-context-evaluator-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded MITRE context evaluator is current.
 	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check mitre-context-evaluator
 
-rust-wasm-check: rust-fmt-check rust-clippy rust-test ## Verify every embedded Rust Wasm module.
+rust-workspace-policy: ## Verify inherited Rust dependency and lint policy.
+	$(PYTHON) scripts/rust_workspace_policy.py
+
+rust-wasm-check: rust-workspace-policy rust-fmt-check rust-clippy rust-test ## Verify every embedded Rust Wasm module.
 	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check all
 
 finding-dsl-migrate: ## Convert legacy JSON policy files to PolicyFindingRule DSL YAML.

--- a/crates/control-kernel/Cargo.toml
+++ b/crates/control-kernel/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
+[lints]
+workspace = true

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -72,6 +72,18 @@ The checks include formatting, Clippy, tests, warning-free rustdoc, dependency
 advisories and policy, the generated graph action registry, and all embedded
 Wasm artifacts.
 
+Rust dependency versions and shared features are owned by
+`[workspace.dependencies]` in the root `Cargo.toml`. Workspace members inherit
+those entries with `workspace = true`; a member may add features required by
+that crate but may not repeat or override a version, path, or Git source.
+
+Every workspace member also inherits `[workspace.lints]`. Unsafe code is denied
+by default, including unsafe operations inside unsafe functions. The only
+allowed exceptions are the narrow audited Wasm ABI modules that expose guest
+functions and the shared guest-memory module that contains their documented
+pointer operations. Run `make rust-workspace-policy` after adding a workspace
+member, dependency, or lint.
+
 Focused validation:
 
 ```bash

--- a/internal/graphagent/staticvalidator/Cargo.toml
+++ b/internal/graphagent/staticvalidator/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cerebro-wasm-guest = { version = "0.1.0", path = "../../wasmguest" }
-regex = { version = "1.12.3", default-features = false, features = ["perf", "std"] }
+cerebro-wasm-guest.workspace = true
+regex.workspace = true
 
-[lints.rust]
-unsafe_code = "deny"
+[lints]
+workspace = true

--- a/internal/mitre/evaluator/Cargo.toml
+++ b/internal/mitre/evaluator/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cerebro-wasm-guest = { version = "0.1.0", path = "../../wasmguest" }
-regex = { version = "1.12.3", default-features = false, features = ["perf", "std"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+cerebro-wasm-guest.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
-[lints.rust]
-unsafe_code = "deny"
+[lints]
+workspace = true

--- a/internal/sourcecoverage/evaluator/Cargo.toml
+++ b/internal/sourcecoverage/evaluator/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cerebro-wasm-guest = { version = "0.1.0", path = "../../wasmguest" }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+cerebro-wasm-guest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
-[lints.rust]
-unsafe_code = "deny"
+[lints]
+workspace = true

--- a/internal/sourceprojection/panopticonresources/Cargo.toml
+++ b/internal/sourceprojection/panopticonresources/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cerebro-wasm-guest = { version = "0.1.0", path = "../../wasmguest" }
-serde_json = { version = "1.0.149", features = ["preserve_order"] }
+cerebro-wasm-guest.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
 
-[lints.rust]
-unsafe_code = "deny"
+[lints]
+workspace = true

--- a/internal/wasmguest/Cargo.toml
+++ b/internal/wasmguest/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
-[lints.rust]
-unsafe_code = "allow"
+[lints]
+workspace = true

--- a/scripts/changed_checks.py
+++ b/scripts/changed_checks.py
@@ -98,6 +98,22 @@ def select_commands(files: list[str], repo: Path) -> list[CommandPlan]:
     if any(path_matches(path, exact=("Cargo.toml", "Cargo.lock", "deny.toml")) for path in files):
         add_command(commands, seen, "rust-deny", ["make", "rust-deny"], "Rust dependency manifest, lockfile, or policy changed.")
 
+    if any(
+        path_matches(
+            path,
+            exact=("Cargo.toml", "scripts/rust_workspace_policy.py", "scripts/tests/test_rust_workspace_policy.py"),
+            suffixes=("/Cargo.toml",),
+        )
+        for path in files
+    ):
+        add_command(
+            commands,
+            seen,
+            "rust-workspace-policy",
+            ["make", "rust-workspace-policy"],
+            "Rust workspace dependency or lint policy changed.",
+        )
+
     if any(path_matches(path, prefixes=("internal/graphactions/", "tools/graphactiongen/"), exact=("Cargo.toml", "Cargo.lock", "rust-toolchain.toml")) for path in files):
         add_command(commands, seen, "graph-action-check", ["make", "graph-action-check"], "Graph action catalog, generated registry, or generator changed.")
 

--- a/scripts/rust_workspace_policy.py
+++ b/scripts/rust_workspace_policy.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Validate inherited Rust workspace dependency and lint policy."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+REQUIRED_RUST_LINTS = {
+    "unsafe_code": "deny",
+    "unsafe_op_in_unsafe_fn": "deny",
+}
+REQUIRED_CLIPPY_LINTS = {"undocumented_unsafe_blocks": "deny"}
+DEPENDENCY_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+ALLOWED_UNSAFE_FILES = {
+    "internal/graphagent/staticvalidator/src/wasm_abi.rs",
+    "internal/mitre/evaluator/src/wasm_abi.rs",
+    "internal/sourcecoverage/evaluator/src/wasm_abi.rs",
+    "internal/sourceprojection/panopticonresources/src/wasm_abi.rs",
+    "internal/wasmguest/src/lib.rs",
+}
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as manifest:
+        return tomllib.load(manifest)
+
+
+def dependency_tables(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    tables = [manifest.get(name, {}) for name in DEPENDENCY_TABLES]
+    for target in manifest.get("target", {}).values():
+        tables.extend(target.get(name, {}) for name in DEPENDENCY_TABLES)
+    return tables
+
+
+def validate_workspace(root: Path) -> list[str]:
+    root = root.resolve()
+    root_manifest = load_toml(root / "Cargo.toml")
+    workspace = root_manifest.get("workspace", {})
+    errors: list[str] = []
+
+    workspace_lints = workspace.get("lints", {})
+    for lint, level in REQUIRED_RUST_LINTS.items():
+        if workspace_lints.get("rust", {}).get(lint) != level:
+            errors.append(f"Cargo.toml: workspace rust lint {lint} must be {level}")
+    for lint, level in REQUIRED_CLIPPY_LINTS.items():
+        if workspace_lints.get("clippy", {}).get(lint) != level:
+            errors.append(f"Cargo.toml: workspace Clippy lint {lint} must be {level}")
+
+    workspace_dependencies = workspace.get("dependencies", {})
+    if not workspace_dependencies:
+        errors.append("Cargo.toml: workspace.dependencies must not be empty")
+
+    for member in workspace.get("members", []):
+        manifest_path = root / member / "Cargo.toml"
+        relative_manifest = manifest_path.relative_to(root)
+        if not manifest_path.is_file():
+            errors.append(f"{relative_manifest}: workspace member manifest is missing")
+            continue
+        manifest = load_toml(manifest_path)
+        if manifest.get("lints") != {"workspace": True}:
+            errors.append(f"{relative_manifest}: [lints] must set workspace = true")
+
+        for dependencies in dependency_tables(manifest):
+            for name, specification in dependencies.items():
+                if name not in workspace_dependencies:
+                    errors.append(
+                        f"{relative_manifest}: dependency {name} must be declared in [workspace.dependencies]"
+                    )
+                    continue
+                if not isinstance(specification, dict) or specification.get("workspace") is not True:
+                    errors.append(f"{relative_manifest}: dependency {name} must inherit with workspace = true")
+                    continue
+                forbidden = {"version", "path", "git", "branch", "tag", "rev"}.intersection(specification)
+                if forbidden:
+                    fields = ", ".join(sorted(forbidden))
+                    errors.append(
+                        f"{relative_manifest}: dependency {name} overrides centralized fields: {fields}"
+                    )
+
+        for source_path in (root / member).rglob("*.rs"):
+            source = source_path.read_text(encoding="utf-8")
+            relative_source = source_path.relative_to(root).as_posix()
+            if "allow(unsafe_code)" in source and relative_source not in ALLOWED_UNSAFE_FILES:
+                errors.append(f"{relative_source}: unsafe_code allow is outside the audited ABI boundary")
+            if "unsafe {" in source and relative_source != "internal/wasmguest/src/lib.rs":
+                errors.append(f"{relative_source}: unsafe block must be isolated in internal/wasmguest")
+
+    return errors
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path(__file__).resolve().parents[1])
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    errors = validate_workspace(args.repo)
+    if errors:
+        for error in errors:
+            print(f"rust-workspace-policy: {error}", file=sys.stderr)
+        return 1
+    print("rust-workspace-policy: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_changed_checks.py
+++ b/scripts/tests/test_changed_checks.py
@@ -51,6 +51,17 @@ class ChangedChecksTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertIn("rust-deny", self.command_names([path]))
 
+    def test_workspace_manifests_and_policy_select_workspace_check(self):
+        for path in (
+            "Cargo.toml",
+            "crates/control-kernel/Cargo.toml",
+            "internal/wasmguest/Cargo.toml",
+            "scripts/rust_workspace_policy.py",
+            "scripts/tests/test_rust_workspace_policy.py",
+        ):
+            with self.subTest(path=path):
+                self.assertIn("rust-workspace-policy", self.command_names([path]))
+
     def test_shared_embedded_wasm_paths_select_aggregate_check(self):
         for path in (
             "Cargo.toml",

--- a/scripts/tests/test_rust_workspace_policy.py
+++ b/scripts/tests/test_rust_workspace_policy.py
@@ -1,0 +1,112 @@
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts import rust_workspace_policy
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class RustWorkspacePolicyTests(unittest.TestCase):
+    def test_repository_workspace_satisfies_policy(self):
+        self.assertEqual(rust_workspace_policy.validate_workspace(ROOT), [])
+
+    def test_rejects_member_dependency_and_lint_drift(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.write_manifest(root / "Cargo.toml", self.root_manifest("serde = \"1.0.228\""))
+            self.write_manifest(
+                root / "member/Cargo.toml",
+                """
+                [package]
+                name = "member"
+                version = "0.1.0"
+
+                [dependencies]
+                serde = "1.0.229"
+                unknown = "2"
+
+                [lints.rust]
+                unsafe_code = "allow"
+                """,
+            )
+            errors = rust_workspace_policy.validate_workspace(root)
+
+        self.assertIn("member/Cargo.toml: [lints] must set workspace = true", errors)
+        self.assertIn("member/Cargo.toml: dependency serde must inherit with workspace = true", errors)
+        self.assertIn(
+            "member/Cargo.toml: dependency unknown must be declared in [workspace.dependencies]",
+            errors,
+        )
+
+    def test_allows_member_features_without_version_override(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.write_manifest(root / "Cargo.toml", self.root_manifest("serde_json = \"1.0.149\""))
+            self.write_manifest(
+                root / "member/Cargo.toml",
+                """
+                [package]
+                name = "member"
+                version = "0.1.0"
+
+                [dependencies]
+                serde_json = { workspace = true, features = ["preserve_order"] }
+
+                [lints]
+                workspace = true
+                """,
+            )
+            self.assertEqual(rust_workspace_policy.validate_workspace(root), [])
+
+    def test_rejects_unsafe_allow_outside_audited_boundary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.write_manifest(root / "Cargo.toml", self.root_manifest("serde = \"1.0.228\""))
+            self.write_manifest(
+                root / "member/Cargo.toml",
+                """
+                [package]
+                name = "member"
+                version = "0.1.0"
+
+                [dependencies]
+                serde.workspace = true
+
+                [lints]
+                workspace = true
+                """,
+            )
+            (root / "member/src").mkdir(parents=True)
+            (root / "member/src/lib.rs").write_text("#![allow(unsafe_code)]\n", encoding="utf-8")
+            errors = rust_workspace_policy.validate_workspace(root)
+
+        self.assertIn("member/src/lib.rs: unsafe_code allow is outside the audited ABI boundary", errors)
+
+    @staticmethod
+    def root_manifest(dependency: str) -> str:
+        return f"""
+        [workspace]
+        members = ["member"]
+
+        [workspace.dependencies]
+        {dependency}
+
+        [workspace.lints.rust]
+        unsafe_code = "deny"
+        unsafe_op_in_unsafe_fn = "deny"
+
+        [workspace.lints.clippy]
+        undocumented_unsafe_blocks = "deny"
+        """
+
+    @staticmethod
+    def write_manifest(path: Path, contents: str):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(contents), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/graphactiongen/Cargo.toml
+++ b/tools/graphactiongen/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 publish = false
 
 [dependencies]
-libc = "0.2.180"
-serde = { version = "1.0.228", features = ["derive"] }
-serde-saphyr = { version = "0.0.29", default-features = false, features = ["deserialize"] }
-serde_json = "1.0.149"
+libc.workspace = true
+serde.workspace = true
+serde-saphyr.workspace = true
+serde_json.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary
- centralize shared Rust dependency versions and features in the workspace manifest
- require every workspace member to inherit dependency and lint policy
- deny unsafe code by default and constrain exceptions to the audited Wasm ABI and guest-memory modules
- add a static policy check, regression tests, changed-check selection, and contributor documentation

## Validation
- `make rust-workspace-policy`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo deny --all-features check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --locked --no-deps`
- `make rust-wasm-check rust-deny`
- `python3 -m unittest discover scripts/tests` (133 tests)
- `go test ./tools/archtests -count=1`
- Linux x86_64 embedded Wasm regeneration produced no artifact or lockfile changes