### PR TITLE
Centralize Rust workspace policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,21 @@ edition = "2024"
 rust-version = "1.93.1"
 license = "Apache-2.0"
 
+[workspace.dependencies]
+cerebro-wasm-guest = { version = "0.1.0", path = "internal/wasmguest" }
+libc = "0.2.180"
+regex = { version = "1.12.3", default-features = false, features = ["perf", "std"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde-saphyr = { version = "0.0.29", default-features = false, features = ["deserialize"] }
+serde_json = "1.0.149"
+
+[workspace.lints.rust]
+unsafe_code = "deny"
+unsafe_op_in_unsafe_fn = "deny"
+
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"
+
 # The workspace's release artifacts include embedded WebAssembly modules.
 # Favor small, deterministic binaries over incremental release build speed.
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: release-train-test
 .PHONY: sourcegen-grammar-check sourcegen-repro-check sourcegen-proof-check
 .PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-shard lint-api-cmd lint-internal lint-sources lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check content-pack-check control-index-generate control-index-check sourcegen-check connector-catalog-fidelity-generate connector-catalog-fidelity-check connector-catalog-review connector-api-discovery connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status codegen-check codegen-catalog-generate codegen-catalog-check projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo github-business-demo github-business-demo-env agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
-.PHONY: rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-wasm-check rust-wasm-manifest-generate rust-wasm-manifest-check graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check
+.PHONY: rust-workspace-policy rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-wasm-check rust-wasm-manifest-generate rust-wasm-manifest-check graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -471,7 +471,10 @@ rust-wasm-manifest-generate: ## Regenerate embedded Wasm artifact evidence and s
 rust-wasm-manifest-check: ## Verify embedded Wasm artifact evidence, ABI versions, and size budgets.
 	go run ./tools/wasmartifactmanifest
 
-rust-wasm-check: rust-fmt-check rust-clippy rust-test ## Verify every embedded Rust Wasm module.
+rust-workspace-policy: ## Verify inherited Rust dependency and lint policy.
+	$(PYTHON) scripts/rust_workspace_policy.py
+
+rust-wasm-check: rust-workspace-policy rust-fmt-check rust-clippy rust-test ## Verify every embedded Rust Wasm module.
 	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check all
 	$(MAKE) rust-wasm-manifest-check
 

--- a/crates/control-kernel/Cargo.toml
+++ b/crates/control-kernel/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
+[lints]
+workspace = true

--- a/crates/control-kernel/src/lib.rs
+++ b/crates/control-kernel/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! Durable control-plane primitives for Cerebro mandates and missions.
 //!
 //! This crate is intentionally free of network, database, graph, provider,

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -72,6 +72,18 @@ The checks include formatting, Clippy, tests, warning-free rustdoc, dependency
 advisories and policy, the generated graph action registry, and all embedded
 Wasm artifacts.
 
+Rust dependency versions and shared features are owned by
+`[workspace.dependencies]` in the root `Cargo.toml`. Workspace members inherit
+those entries with `workspace = true`; a member may add features required by
+that crate but may not repeat or override a version, path, or Git source.
+
+Every workspace member also inherits `[workspace.lints]`. Unsafe code is denied
+by default, including unsafe operations inside unsafe functions. The only
+allowed exceptions are the narrow audited Wasm ABI modules that expose guest
+functions and the shared guest-memory module that contains their documented
+pointer operations. Run `make rust-workspace-policy` after adding a workspace
+member, dependency, or lint.
+
 Focused validation:
 
 ```bash

--- a/internal/graphagent/staticvalidator/Cargo.toml
+++ b/internal/graphagent/staticvalidator/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cerebro-wasm-guest = { version = "0.1.0", path = "../../wasmguest" }
-regex = { version = "1.12.3", default-features = false, features = ["perf", "std"] }
+cerebro-wasm-guest.workspace = true
+regex.workspace = true
 
-[lints.rust]
-unsafe_code = "deny"
+[lints]
+workspace = true

--- a/internal/mitre/evaluator/Cargo.toml
+++ b/internal/mitre/evaluator/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cerebro-wasm-guest = { version = "0.1.0", path = "../../wasmguest" }
-regex = { version = "1.12.3", default-features = false, features = ["perf", "std"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+cerebro-wasm-guest.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
-[lints.rust]
-unsafe_code = "deny"
+[lints]
+workspace = true

--- a/internal/sourcecoverage/evaluator/Cargo.toml
+++ b/internal/sourcecoverage/evaluator/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cerebro-wasm-guest = { version = "0.1.0", path = "../../wasmguest" }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+cerebro-wasm-guest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
-[lints.rust]
-unsafe_code = "deny"
+[lints]
+workspace = true

--- a/internal/sourceprojection/panopticonresources/Cargo.toml
+++ b/internal/sourceprojection/panopticonresources/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cerebro-wasm-guest = { version = "0.1.0", path = "../../wasmguest" }
-serde_json = { version = "1.0.149", features = ["preserve_order"] }
+cerebro-wasm-guest.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
 
-[lints.rust]
-unsafe_code = "deny"
+[lints]
+workspace = true

--- a/internal/wasmguest/Cargo.toml
+++ b/internal/wasmguest/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
-[lints.rust]
-unsafe_code = "allow"
+[lints]
+workspace = true

--- a/scripts/changed_checks.py
+++ b/scripts/changed_checks.py
@@ -98,6 +98,22 @@ def select_commands(files: list[str], repo: Path) -> list[CommandPlan]:
     if any(path_matches(path, exact=("Cargo.toml", "Cargo.lock", "deny.toml")) for path in files):
         add_command(commands, seen, "rust-deny", ["make", "rust-deny"], "Rust dependency manifest, lockfile, or policy changed.")
 
+    if any(
+        path_matches(
+            path,
+            exact=("Cargo.toml", "scripts/rust_workspace_policy.py", "scripts/tests/test_rust_workspace_policy.py"),
+            suffixes=("/Cargo.toml",),
+        )
+        for path in files
+    ):
+        add_command(
+            commands,
+            seen,
+            "rust-workspace-policy",
+            ["make", "rust-workspace-policy"],
+            "Rust workspace dependency or lint policy changed.",
+        )
+
     if any(path_matches(path, prefixes=("internal/graphactions/", "tools/graphactiongen/"), exact=("Cargo.toml", "Cargo.lock", "rust-toolchain.toml")) for path in files):
         add_command(commands, seen, "graph-action-check", ["make", "graph-action-check"], "Graph action catalog, generated registry, or generator changed.")
 

--- a/scripts/rust_workspace_policy.py
+++ b/scripts/rust_workspace_policy.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Validate inherited Rust workspace dependency and lint policy."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+REQUIRED_RUST_LINTS = {
+    "unsafe_code": "deny",
+    "unsafe_op_in_unsafe_fn": "deny",
+}
+REQUIRED_CLIPPY_LINTS = {"undocumented_unsafe_blocks": "deny"}
+DEPENDENCY_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+ALLOWED_UNSAFE_FILES = {
+    "internal/graphagent/staticvalidator/src/wasm_abi.rs",
+    "internal/mitre/evaluator/src/wasm_abi.rs",
+    "internal/sourcecoverage/evaluator/src/wasm_abi.rs",
+    "internal/sourceprojection/panopticonresources/src/wasm_abi.rs",
+    "internal/wasmguest/src/lib.rs",
+}
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as manifest:
+        return tomllib.load(manifest)
+
+
+def dependency_tables(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    tables = [manifest.get(name, {}) for name in DEPENDENCY_TABLES]
+    for target in manifest.get("target", {}).values():
+        tables.extend(target.get(name, {}) for name in DEPENDENCY_TABLES)
+    return tables
+
+
+def validate_workspace(root: Path) -> list[str]:
+    root = root.resolve()
+    root_manifest = load_toml(root / "Cargo.toml")
+    workspace = root_manifest.get("workspace", {})
+    errors: list[str] = []
+
+    workspace_lints = workspace.get("lints", {})
+    for lint, level in REQUIRED_RUST_LINTS.items():
+        if workspace_lints.get("rust", {}).get(lint) != level:
+            errors.append(f"Cargo.toml: workspace rust lint {lint} must be {level}")
+    for lint, level in REQUIRED_CLIPPY_LINTS.items():
+        if workspace_lints.get("clippy", {}).get(lint) != level:
+            errors.append(f"Cargo.toml: workspace Clippy lint {lint} must be {level}")
+
+    workspace_dependencies = workspace.get("dependencies", {})
+    if not workspace_dependencies:
+        errors.append("Cargo.toml: workspace.dependencies must not be empty")
+
+    for member in workspace.get("members", []):
+        manifest_path = root / member / "Cargo.toml"
+        relative_manifest = manifest_path.relative_to(root)
+        if not manifest_path.is_file():
+            errors.append(f"{relative_manifest}: workspace member manifest is missing")
+            continue
+        manifest = load_toml(manifest_path)
+        if manifest.get("lints") != {"workspace": True}:
+            errors.append(f"{relative_manifest}: [lints] must set workspace = true")
+
+        for dependencies in dependency_tables(manifest):
+            for name, specification in dependencies.items():
+                if name not in workspace_dependencies:
+                    errors.append(
+                        f"{relative_manifest}: dependency {name} must be declared in [workspace.dependencies]"
+                    )
+                    continue
+                if not isinstance(specification, dict) or specification.get("workspace") is not True:
+                    errors.append(f"{relative_manifest}: dependency {name} must inherit with workspace = true")
+                    continue
+                forbidden = {"version", "path", "git", "branch", "tag", "rev"}.intersection(specification)
+                if forbidden:
+                    fields = ", ".join(sorted(forbidden))
+                    errors.append(
+                        f"{relative_manifest}: dependency {name} overrides centralized fields: {fields}"
+                    )
+
+        for source_path in (root / member).rglob("*.rs"):
+            source = source_path.read_text(encoding="utf-8")
+            relative_source = source_path.relative_to(root).as_posix()
+            if "allow(unsafe_code)" in source and relative_source not in ALLOWED_UNSAFE_FILES:
+                errors.append(f"{relative_source}: unsafe_code allow is outside the audited ABI boundary")
+            if "unsafe {" in source and relative_source != "internal/wasmguest/src/lib.rs":
+                errors.append(f"{relative_source}: unsafe block must be isolated in internal/wasmguest")
+
+    return errors
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path(__file__).resolve().parents[1])
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    errors = validate_workspace(args.repo)
+    if errors:
+        for error in errors:
+            print(f"rust-workspace-policy: {error}", file=sys.stderr)
+        return 1
+    print("rust-workspace-policy: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rust_workspace_policy.py
+++ b/scripts/rust_workspace_policy.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import tomllib
 from pathlib import Path
@@ -16,13 +17,19 @@ REQUIRED_RUST_LINTS = {
 }
 REQUIRED_CLIPPY_LINTS = {"undocumented_unsafe_blocks": "deny"}
 DEPENDENCY_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
-ALLOWED_UNSAFE_FILES = {
-    "internal/graphagent/staticvalidator/src/wasm_abi.rs",
-    "internal/mitre/evaluator/src/wasm_abi.rs",
-    "internal/sourcecoverage/evaluator/src/wasm_abi.rs",
-    "internal/sourceprojection/panopticonresources/src/wasm_abi.rs",
-    "internal/wasmguest/src/lib.rs",
+AUDITED_UNSAFE_POLICIES = {
+    "internal/graphagent/staticvalidator/src/wasm_abi.rs": ("attribute",) * 3,
+    "internal/mitre/evaluator/src/wasm_abi.rs": ("attribute",) * 3,
+    "internal/sourcecoverage/evaluator/src/wasm_abi.rs": ("attribute",) * 3,
+    "internal/sourceprojection/panopticonresources/src/wasm_abi.rs": ("attribute",) * 3,
+    "internal/wasmguest/src/lib.rs": ("block", "block"),
 }
+SAFE_ONLY_CRATE_ROOTS = {
+    "crates/control-kernel/src/lib.rs": "crates/control-kernel",
+    "tools/graphactiongen/src/lib.rs": "tools/graphactiongen",
+    "tools/graphactiongen/src/main.rs": "tools/graphactiongen",
+}
+RAW_STRING_START = r'(?:br|rb|cr|rc|r)(?P<hashes>#{0,255})"'
 
 
 def load_toml(path: Path) -> dict[str, Any]:
@@ -35,6 +42,164 @@ def dependency_tables(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     for target in manifest.get("target", {}).values():
         tables.extend(target.get(name, {}) for name in DEPENDENCY_TABLES)
     return tables
+
+
+def rust_tokens(source: str) -> list[str]:
+    """Return Rust identifiers and punctuation, excluding comments and literals."""
+    tokens: list[str] = []
+    index = 0
+    while index < len(source):
+        if source.startswith("//", index):
+            newline = source.find("\n", index + 2)
+            index = len(source) if newline < 0 else newline + 1
+            continue
+        if source.startswith("/*", index):
+            depth = 1
+            index += 2
+            while index < len(source) and depth:
+                if source.startswith("/*", index):
+                    depth += 1
+                    index += 2
+                elif source.startswith("*/", index):
+                    depth -= 1
+                    index += 2
+                else:
+                    index += 1
+            continue
+
+        raw_string = re.match(RAW_STRING_START, source[index:])
+        if raw_string:
+            terminator = '"' + raw_string.group("hashes")
+            end = source.find(terminator, index + raw_string.end())
+            index = len(source) if end < 0 else end + len(terminator)
+            continue
+
+        prefix_length = 0
+        if source.startswith(('b"', 'c"'), index):
+            prefix_length = 1
+        if source[index + prefix_length : index + prefix_length + 1] == '"':
+            index += prefix_length + 1
+            while index < len(source):
+                if source[index] == "\\":
+                    index += 2
+                elif source[index] == '"':
+                    index += 1
+                    break
+                else:
+                    index += 1
+            continue
+
+        if source[index] == "'" and index + 2 < len(source):
+            cursor = index + 1
+            if source[cursor] == "\\":
+                cursor += 2
+            else:
+                cursor += 1
+            if cursor < len(source) and source[cursor] == "'":
+                index = cursor + 1
+                continue
+
+        if source[index].isalpha() or source[index] == "_":
+            end = index + 1
+            while end < len(source) and (source[end].isalnum() or source[end] == "_"):
+                end += 1
+            tokens.append(source[index:end])
+            index = end
+            continue
+        if not source[index].isspace():
+            tokens.append(source[index])
+        index += 1
+    return tokens
+
+
+def unsafe_code_control_attributes(tokens: list[str]) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Return allow/expect attributes that suppress unsafe_code."""
+    controls: list[tuple[str, tuple[str, ...]]] = []
+    index = 0
+    while index < len(tokens):
+        cursor = index
+        if tokens[cursor : cursor + 1] != ["#"]:
+            index += 1
+            continue
+        cursor += 1
+        if tokens[cursor : cursor + 1] == ["!"]:
+            cursor += 1
+        if tokens[cursor : cursor + 1] != ["["]:
+            index += 1
+            continue
+        cursor += 1
+        if tokens[cursor : cursor + 1] not in (["allow"], ["expect"]):
+            index += 1
+            continue
+        level = tokens[cursor]
+        cursor += 1
+        if tokens[cursor : cursor + 1] != ["("]:
+            index += 1
+            continue
+        cursor += 1
+        depth = 1
+        attribute_tokens: list[str] = []
+        while cursor < len(tokens) and depth:
+            if tokens[cursor] == "(":
+                depth += 1
+            elif tokens[cursor] == ")":
+                depth -= 1
+            if depth:
+                attribute_tokens.append(tokens[cursor])
+            cursor += 1
+        if "unsafe_code" in attribute_tokens:
+            lints = tuple(token for token in attribute_tokens if token.isidentifier())
+            controls.append((level, lints))
+        index = cursor
+    return tuple(controls)
+
+
+def unsafe_token_kinds(tokens: list[str]) -> tuple[str, ...]:
+    """Classify every Rust unsafe keyword by the syntax it introduces."""
+    kinds: list[str] = []
+    for index, token in enumerate(tokens):
+        if token != "unsafe":
+            continue
+        previous = tokens[index - 2 : index]
+        following = tokens[index + 1 : index + 2]
+        if previous == ["#", "["] and following == ["("]:
+            kinds.append("attribute")
+        elif following == ["{"]:
+            kinds.append("block")
+        elif following and following[0] in {"extern", "fn", "impl", "trait"}:
+            kinds.append(following[0])
+        else:
+            kinds.append("other")
+    return tuple(kinds)
+
+
+def validate_unsafe_source(relative_source: str, source: str) -> list[str]:
+    """Validate one Rust source file against the exact audited unsafe boundary."""
+    tokens = rust_tokens(source)
+    controls = unsafe_code_control_attributes(tokens)
+    unsafe_kinds = unsafe_token_kinds(tokens)
+    expected_kinds = AUDITED_UNSAFE_POLICIES.get(relative_source)
+    if expected_kinds is None:
+        errors = []
+        if controls:
+            errors.append(
+                f"{relative_source}: unsafe_code allow or expect is outside the audited ABI boundary"
+            )
+        if unsafe_kinds:
+            forms = ", ".join(unsafe_kinds)
+            errors.append(f"{relative_source}: unsafe syntax is outside the audited ABI boundary: {forms}")
+        return errors
+    if controls != (("allow", ("unsafe_code",)),):
+        return [
+            f"{relative_source}: audited unsafe module must contain exactly #![allow(unsafe_code)]"
+        ]
+    if unsafe_kinds != expected_kinds:
+        actual = ", ".join(unsafe_kinds) or "none"
+        expected = ", ".join(expected_kinds)
+        return [
+            f"{relative_source}: audited unsafe syntax changed: expected {expected}; found {actual}"
+        ]
+    return []
 
 
 def validate_workspace(root: Path) -> list[str]:
@@ -85,10 +250,20 @@ def validate_workspace(root: Path) -> list[str]:
         for source_path in (root / member).rglob("*.rs"):
             source = source_path.read_text(encoding="utf-8")
             relative_source = source_path.relative_to(root).as_posix()
-            if "allow(unsafe_code)" in source and relative_source not in ALLOWED_UNSAFE_FILES:
-                errors.append(f"{relative_source}: unsafe_code allow is outside the audited ABI boundary")
-            if "unsafe {" in source and relative_source != "internal/wasmguest/src/lib.rs":
-                errors.append(f"{relative_source}: unsafe block must be isolated in internal/wasmguest")
+            errors.extend(validate_unsafe_source(relative_source, source))
+
+    workspace_members = set(workspace.get("members", []))
+    for relative_root, member in SAFE_ONLY_CRATE_ROOTS.items():
+        if member not in workspace_members:
+            continue
+        root_path = root / relative_root
+        if not root_path.is_file():
+            errors.append(f"{relative_root}: safe-only crate root is missing")
+            continue
+        tokens = rust_tokens(root_path.read_text(encoding="utf-8"))
+        required = ["#", "!", "[", "forbid", "(", "unsafe_code", ")", "]"]
+        if tokens[: len(required)] != required:
+            errors.append(f"{relative_root}: safe-only crate must forbid unsafe_code")
 
     return errors
 

--- a/scripts/tests/test_changed_checks.py
+++ b/scripts/tests/test_changed_checks.py
@@ -51,6 +51,17 @@ class ChangedChecksTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertIn("rust-deny", self.command_names([path]))
 
+    def test_workspace_manifests_and_policy_select_workspace_check(self):
+        for path in (
+            "Cargo.toml",
+            "crates/control-kernel/Cargo.toml",
+            "internal/wasmguest/Cargo.toml",
+            "scripts/rust_workspace_policy.py",
+            "scripts/tests/test_rust_workspace_policy.py",
+        ):
+            with self.subTest(path=path):
+                self.assertIn("rust-workspace-policy", self.command_names([path]))
+
     def test_shared_embedded_wasm_paths_select_aggregate_check(self):
         for path in (
             "Cargo.toml",

--- a/scripts/tests/test_rust_workspace_policy.py
+++ b/scripts/tests/test_rust_workspace_policy.py
@@ -1,0 +1,112 @@
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts import rust_workspace_policy
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class RustWorkspacePolicyTests(unittest.TestCase):
+    def test_repository_workspace_satisfies_policy(self):
+        self.assertEqual(rust_workspace_policy.validate_workspace(ROOT), [])
+
+    def test_rejects_member_dependency_and_lint_drift(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.write_manifest(root / "Cargo.toml", self.root_manifest("serde = \"1.0.228\""))
+            self.write_manifest(
+                root / "member/Cargo.toml",
+                """
+                [package]
+                name = "member"
+                version = "0.1.0"
+
+                [dependencies]
+                serde = "1.0.229"
+                unknown = "2"
+
+                [lints.rust]
+                unsafe_code = "allow"
+                """,
+            )
+            errors = rust_workspace_policy.validate_workspace(root)
+
+        self.assertIn("member/Cargo.toml: [lints] must set workspace = true", errors)
+        self.assertIn("member/Cargo.toml: dependency serde must inherit with workspace = true", errors)
+        self.assertIn(
+            "member/Cargo.toml: dependency unknown must be declared in [workspace.dependencies]",
+            errors,
+        )
+
+    def test_allows_member_features_without_version_override(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.write_manifest(root / "Cargo.toml", self.root_manifest("serde_json = \"1.0.149\""))
+            self.write_manifest(
+                root / "member/Cargo.toml",
+                """
+                [package]
+                name = "member"
+                version = "0.1.0"
+
+                [dependencies]
+                serde_json = { workspace = true, features = ["preserve_order"] }
+
+                [lints]
+                workspace = true
+                """,
+            )
+            self.assertEqual(rust_workspace_policy.validate_workspace(root), [])
+
+    def test_rejects_unsafe_allow_outside_audited_boundary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.write_manifest(root / "Cargo.toml", self.root_manifest("serde = \"1.0.228\""))
+            self.write_manifest(
+                root / "member/Cargo.toml",
+                """
+                [package]
+                name = "member"
+                version = "0.1.0"
+
+                [dependencies]
+                serde.workspace = true
+
+                [lints]
+                workspace = true
+                """,
+            )
+            (root / "member/src").mkdir(parents=True)
+            (root / "member/src/lib.rs").write_text("#![allow(unsafe_code)]\n", encoding="utf-8")
+            errors = rust_workspace_policy.validate_workspace(root)
+
+        self.assertIn("member/src/lib.rs: unsafe_code allow is outside the audited ABI boundary", errors)
+
+    @staticmethod
+    def root_manifest(dependency: str) -> str:
+        return f"""
+        [workspace]
+        members = ["member"]
+
+        [workspace.dependencies]
+        {dependency}
+
+        [workspace.lints.rust]
+        unsafe_code = "deny"
+        unsafe_op_in_unsafe_fn = "deny"
+
+        [workspace.lints.clippy]
+        undocumented_unsafe_blocks = "deny"
+        """
+
+    @staticmethod
+    def write_manifest(path: Path, contents: str):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(contents), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_rust_workspace_policy.py
+++ b/scripts/tests/test_rust_workspace_policy.py
@@ -83,7 +83,106 @@ class RustWorkspacePolicyTests(unittest.TestCase):
             (root / "member/src/lib.rs").write_text("#![allow(unsafe_code)]\n", encoding="utf-8")
             errors = rust_workspace_policy.validate_workspace(root)
 
-        self.assertIn("member/src/lib.rs: unsafe_code allow is outside the audited ABI boundary", errors)
+        self.assertIn(
+            "member/src/lib.rs: unsafe_code allow or expect is outside the audited ABI boundary",
+            errors,
+        )
+
+    def test_rejects_combined_and_multiline_unsafe_allows(self):
+        for source in (
+            "#![allow(unused, unsafe_code)]\n",
+            "#![allow(\n  unused,\n  unsafe_code,\n)]\n",
+        ):
+            with self.subTest(source=source):
+                self.assertIn(
+                    "member/src/lib.rs: unsafe_code allow or expect is outside the audited ABI boundary",
+                    rust_workspace_policy.validate_unsafe_source("member/src/lib.rs", source),
+                )
+
+    def test_rejects_expect_unsafe_code_suppression(self):
+        errors = rust_workspace_policy.validate_unsafe_source(
+            "member/src/lib.rs", "#![expect(unsafe_code)]\nunsafe fn hidden() {}\n"
+        )
+        self.assertIn(
+            "member/src/lib.rs: unsafe_code allow or expect is outside the audited ABI boundary",
+            errors,
+        )
+
+    def test_rejects_every_unsafe_syntax_outside_audited_modules(self):
+        sources = {
+            "block": "fn f() { unsafe { call(); } }",
+            "fn": "unsafe fn f() {}",
+            "impl": "unsafe impl Trait for Type {}",
+            "extern": 'unsafe extern "C" { fn f(); }',
+            "trait": "unsafe trait Marker {}",
+            "attribute": "#[unsafe(no_mangle)] pub extern \"C\" fn f() {}",
+        }
+        for expected, source in sources.items():
+            with self.subTest(expected=expected):
+                errors = rust_workspace_policy.validate_unsafe_source("member/src/lib.rs", source)
+                self.assertEqual(
+                    errors,
+                    [
+                        "member/src/lib.rs: unsafe syntax is outside the audited ABI boundary: "
+                        + expected
+                    ],
+                )
+
+    def test_ignores_unsafe_text_in_comments_and_literals(self):
+        source = '''
+        // unsafe fn commented_out() {}
+        const NOTE: &str = "#[allow(unsafe_code)] unsafe { ignored(); }";
+        const RAW: &str = r#"unsafe impl Ignored for Text {}"#;
+        '''
+        self.assertEqual(
+            rust_workspace_policy.validate_unsafe_source("member/src/lib.rs", source), []
+        )
+
+    def test_accepts_only_exact_audited_abi_shapes(self):
+        abi_source = '''
+        #![allow(unsafe_code)]
+        #[unsafe(no_mangle)] pub extern "C" fn version() -> u32 { 1 }
+        #[unsafe(no_mangle)] pub extern "C" fn alloc() -> u32 { 0 }
+        #[unsafe(no_mangle)] pub extern "C" fn evaluate() -> u32 { 0 }
+        '''
+        abi_path = "internal/mitre/evaluator/src/wasm_abi.rs"
+        self.assertEqual(rust_workspace_policy.validate_unsafe_source(abi_path, abi_source), [])
+
+        widened = abi_source + "unsafe fn extra() {}\n"
+        self.assertIn(
+            "audited unsafe syntax changed",
+            rust_workspace_policy.validate_unsafe_source(abi_path, widened)[0],
+        )
+
+    def test_requires_compiler_forbid_for_safe_only_crates(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = self.root_manifest("serde = \"1.0.228\"").replace(
+                'members = ["member"]', 'members = ["crates/control-kernel"]'
+            )
+            self.write_manifest(root / "Cargo.toml", manifest)
+            self.write_manifest(
+                root / "crates/control-kernel/Cargo.toml",
+                """
+                [package]
+                name = "control-kernel"
+                version = "0.1.0"
+
+                [dependencies]
+                serde.workspace = true
+
+                [lints]
+                workspace = true
+                """,
+            )
+            source = root / "crates/control-kernel/src/lib.rs"
+            source.parent.mkdir(parents=True)
+            source.write_text("pub fn safe() {}\n", encoding="utf-8")
+            errors = rust_workspace_policy.validate_workspace(root)
+
+        self.assertIn(
+            "crates/control-kernel/src/lib.rs: safe-only crate must forbid unsafe_code", errors
+        )
 
     @staticmethod
     def root_manifest(dependency: str) -> str:

--- a/tools/graphactiongen/Cargo.toml
+++ b/tools/graphactiongen/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 publish = false
 
 [dependencies]
-libc = "0.2.180"
-serde = { version = "1.0.228", features = ["derive"] }
-serde-saphyr = { version = "0.0.29", default-features = false, features = ["deserialize"] }
-serde_json = "1.0.149"
+libc.workspace = true
+serde.workspace = true
+serde-saphyr.workspace = true
+serde_json.workspace = true
 
-[lints.rust]
-unsafe_code = "forbid"
+[lints]
+workspace = true

--- a/tools/graphactiongen/src/lib.rs
+++ b/tools/graphactiongen/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::error::Error as StdError;

--- a/tools/graphactiongen/src/main.rs
+++ b/tools/graphactiongen/src/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use cerebro_graphactiongen::{
     DEFAULT_CATALOG_PATH, DEFAULT_OUTPUT_PATH, ensure_supported_platform, generate,
     read_generated_file, write_generated_file,


### PR DESCRIPTION
## Summary
- centralize shared Rust dependency versions and features in the workspace manifest
- require every workspace member to inherit dependency and lint policy
- deny unsafe code by default and constrain exceptions to the audited Wasm ABI and guest-memory modules
- add a static policy check, regression tests, changed-check selection, and contributor documentation

## Validation
- `make rust-workspace-policy`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo deny --all-features check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --locked --no-deps`
- `make rust-wasm-check rust-deny`
- `python3 -m unittest discover scripts/tests` (133 tests)
- `go test ./tools/archtests -count=1`
- Linux x86_64 embedded Wasm regeneration produced no artifact or lockfile changes