### PR TITLE
Track reproducible embedded Wasm artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: release-train-test
 .PHONY: sourcegen-grammar-check sourcegen-repro-check sourcegen-proof-check
 .PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-shard lint-api-cmd lint-internal lint-sources lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check content-pack-check control-index-generate control-index-check sourcegen-check connector-catalog-fidelity-generate connector-catalog-fidelity-check connector-catalog-review connector-api-discovery connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status codegen-check codegen-catalog-generate codegen-catalog-check projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo github-business-demo github-business-demo-env agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
-.PHONY: rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-wasm-check graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check
+.PHONY: rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-wasm-check rust-wasm-manifest-generate rust-wasm-manifest-check graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -465,8 +465,15 @@ mitre-context-evaluator-generate: ## Rebuild the embedded MITRE context evaluato
 mitre-context-evaluator-check: rust-fmt-check rust-clippy rust-test ## Verify the embedded MITRE context evaluator is current.
 	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check mitre-context-evaluator
 
+rust-wasm-manifest-generate: ## Regenerate embedded Wasm artifact evidence and size budgets.
+	go run ./tools/wasmartifactmanifest -write
+
+rust-wasm-manifest-check: ## Verify embedded Wasm artifact evidence, ABI versions, and size budgets.
+	go run ./tools/wasmartifactmanifest
+
 rust-wasm-check: rust-fmt-check rust-clippy rust-test ## Verify every embedded Rust Wasm module.
 	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check all
+	$(MAKE) rust-wasm-manifest-check
 
 finding-dsl-migrate: ## Convert legacy JSON policy files to PolicyFindingRule DSL YAML.
 	go run ./tools/findingdsl --migrate-policies --write

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -94,6 +94,14 @@ Makefile or `scripts/changed_checks.py`. Artifact generation that requires
 `Linux-x86_64` fails on other platforms; checks still compile the module and
 report when byte comparison is deferred to CI.
 
+`tools/archtests/embedded_wasm_artifacts.json` records the canonical artifact
+path, SHA-256 digest, exact byte size, ABI version, pinned Rust builder inputs,
+and an explicit maximum size for every registered module. After regenerating
+the Wasm files on `Linux-x86_64`, run `make rust-wasm-manifest-generate` and
+commit the manifest update. `make rust-wasm-manifest-check` reports digest,
+ABI, size, or budget drift; increasing a budget requires an intentional change
+to `internal/wasmartifacts/manifest.go`.
+
 ## Architecture Notes
 
 - External data enters through source packages under `sources/`.

--- a/internal/wasmartifacts/manifest.go
+++ b/internal/wasmartifacts/manifest.go
@@ -12,12 +12,38 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
-	ManifestPath  = "tools/archtests/embedded_wasm_artifacts.json"
-	SchemaVersion = 1
+	ManifestPath     = "tools/archtests/embedded_wasm_artifacts.json"
+	SchemaVersion    = 1
+	maxManifestBytes = 1 << 20
 )
+
+var (
+	ErrArtifactOverBudget  = errors.New("embedded Wasm artifact exceeds its size budget")
+	ErrManifestDigestDrift = errors.New("embedded Wasm manifest digest drift")
+	ErrManifestBudgetDrift = errors.New("embedded Wasm manifest size budget drift")
+	ErrUnsafeArtifactPath  = errors.New("embedded Wasm artifact path is unsafe")
+)
+
+type ArtifactBudgetError struct {
+	Module      string
+	Path        string
+	SizeBytes   int64
+	BudgetBytes int64
+}
+
+func (e *ArtifactBudgetError) Error() string {
+	overage := e.SizeBytes - e.BudgetBytes
+	return fmt.Sprintf(
+		"%s artifact %s is %d bytes, exceeding its %d-byte budget by %d %s; reduce the artifact or make a reviewed budget change in internal/wasmartifacts/manifest.go",
+		e.Module, e.Path, e.SizeBytes, e.BudgetBytes, overage, byteUnit(overage),
+	)
+}
+
+func (e *ArtifactBudgetError) Unwrap() error { return ErrArtifactOverBudget }
 
 type BuilderIdentity struct {
 	ID            string `json:"id"`
@@ -110,22 +136,17 @@ func build(repoRoot string, specs []ModuleSpec) (Manifest, error) {
 		Modules:          make([]ModuleArtifact, 0, len(specs)),
 	}
 	for _, spec := range specs {
-		body, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(spec.ArtifactPath)))
+		artifactPath, err := repositoryPath(repoRoot, spec.ArtifactPath)
+		if err != nil {
+			return Manifest{}, fmt.Errorf("resolve %s artifact %s: %w", spec.Name, spec.ArtifactPath, err)
+		}
+		body, err := readRegularFile(artifactPath, spec.MaxSizeBytes)
 		if err != nil {
 			return Manifest{}, fmt.Errorf("read %s artifact %s: %w", spec.Name, spec.ArtifactPath, err)
 		}
 		size := int64(len(body))
 		if size > spec.MaxSizeBytes {
-			overage := size - spec.MaxSizeBytes
-			return Manifest{}, fmt.Errorf(
-				"%s artifact %s is %d bytes, exceeding its %d-byte budget by %d %s; reduce the artifact or make a reviewed budget change in internal/wasmartifacts/manifest.go",
-				spec.Name,
-				spec.ArtifactPath,
-				size,
-				spec.MaxSizeBytes,
-				overage,
-				byteUnit(overage),
-			)
+			return Manifest{}, &ArtifactBudgetError{Module: spec.Name, Path: spec.ArtifactPath, SizeBytes: size, BudgetBytes: spec.MaxSizeBytes}
 		}
 		digest := sha256.Sum256(body)
 		manifest.Modules = append(manifest.Modules, ModuleArtifact{
@@ -149,12 +170,14 @@ func Marshal(manifest Manifest) ([]byte, error) {
 }
 
 func Load(path string) (Manifest, error) {
-	file, err := os.Open(path)
+	body, err := readRegularFile(path, maxManifestBytes)
 	if err != nil {
 		return Manifest{}, fmt.Errorf("open embedded Wasm artifact manifest: %w", err)
 	}
-	defer file.Close()
-	decoder := json.NewDecoder(file)
+	if len(body) > maxManifestBytes {
+		return Manifest{}, fmt.Errorf("embedded Wasm artifact manifest exceeds %d bytes", maxManifestBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
 	var manifest Manifest
 	if err := decoder.Decode(&manifest); err != nil {
@@ -175,7 +198,10 @@ func Write(repoRoot string) error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(repoRoot, filepath.FromSlash(ManifestPath))
+	path, err := repositoryPath(repoRoot, ManifestPath)
+	if err != nil {
+		return fmt.Errorf("resolve manifest %s: %w", ManifestPath, err)
+	}
 	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing to replace symlinked manifest %s", ManifestPath)
 	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -186,18 +212,15 @@ func Write(repoRoot string) error {
 		return fmt.Errorf("create temporary manifest: %w", err)
 	}
 	temporaryPath := file.Name()
-	defer os.Remove(temporaryPath)
+	defer func() { _ = os.Remove(temporaryPath) }()
 	if err := file.Chmod(0o644); err != nil {
-		file.Close()
-		return fmt.Errorf("set temporary manifest mode: %w", err)
+		return errors.Join(fmt.Errorf("set temporary manifest mode: %w", err), closeTemporary(file))
 	}
 	if _, err := file.Write(body); err != nil {
-		file.Close()
-		return fmt.Errorf("write temporary manifest: %w", err)
+		return errors.Join(fmt.Errorf("write temporary manifest: %w", err), closeTemporary(file))
 	}
 	if err := file.Sync(); err != nil {
-		file.Close()
-		return fmt.Errorf("sync temporary manifest: %w", err)
+		return errors.Join(fmt.Errorf("sync temporary manifest: %w", err), closeTemporary(file))
 	}
 	if err := file.Close(); err != nil {
 		return fmt.Errorf("close temporary manifest: %w", err)
@@ -206,6 +229,64 @@ func Write(repoRoot string) error {
 		return fmt.Errorf("replace manifest %s: %w", ManifestPath, err)
 	}
 	return nil
+}
+
+func closeTemporary(file *os.File) error {
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temporary manifest: %w", err)
+	}
+	return nil
+}
+
+func repositoryPath(repoRoot string, relativePath string) (string, error) {
+	if relativePath == "" || filepath.IsAbs(relativePath) {
+		return "", fmt.Errorf("path must be repository-relative")
+	}
+	clean := filepath.Clean(filepath.FromSlash(relativePath))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes the repository")
+	}
+	root, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root: %w", err)
+	}
+	path := filepath.Join(root, clean)
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes the repository")
+	}
+	return path, nil
+}
+
+func readRegularFile(path string, limit int64) (body []byte, resultErr error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: %s is not a regular file", ErrUnsafeArtifactPath, path)
+	}
+	file, err := os.Open(path) // #nosec G304 -- callers constrain repository paths and the identity check below rejects link replacement.
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("close %s: %w", path, err))
+		}
+	}()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("inspect opened file %s: %w", path, err)
+	}
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		return nil, fmt.Errorf("%w: %s changed while opening", ErrUnsafeArtifactPath, path)
+	}
+	body, err = io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return body, nil
 }
 
 func byteUnit(value int64) string {
@@ -220,7 +301,10 @@ func Check(repoRoot string) error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(repoRoot, filepath.FromSlash(ManifestPath))
+	path, err := repositoryPath(repoRoot, ManifestPath)
+	if err != nil {
+		return fmt.Errorf("resolve manifest %s: %w", ManifestPath, err)
+	}
 	actual, err := Load(path)
 	if err != nil {
 		return err
@@ -232,9 +316,12 @@ func Check(repoRoot string) error {
 	if err != nil {
 		return err
 	}
-	actualBody, err := os.ReadFile(path)
+	actualBody, err := readRegularFile(path, maxManifestBytes)
 	if err != nil {
 		return fmt.Errorf("read manifest %s: %w", ManifestPath, err)
+	}
+	if len(actualBody) > maxManifestBytes {
+		return fmt.Errorf("manifest %s exceeds %d bytes", ManifestPath, maxManifestBytes)
 	}
 	if !bytes.Equal(actualBody, expectedBody) {
 		return fmt.Errorf("manifest %s is not in canonical JSON form; run make rust-wasm-manifest-generate", ManifestPath)
@@ -262,13 +349,13 @@ func compare(expected Manifest, actual Manifest) error {
 			return fmt.Errorf("%s manifest ABI version is %d, expected %d", want.Name, got.ABIVersion, want.ABIVersion)
 		}
 		if got.MaxSizeBytes != want.MaxSizeBytes {
-			return fmt.Errorf("%s manifest size budget is %d bytes, expected %d", want.Name, got.MaxSizeBytes, want.MaxSizeBytes)
+			return fmt.Errorf("%w: %s manifest size budget is %d bytes, expected %d", ErrManifestBudgetDrift, want.Name, got.MaxSizeBytes, want.MaxSizeBytes)
 		}
 		if got.SizeBytes != want.SizeBytes {
 			return fmt.Errorf("%s manifest size is %d bytes, artifact is %d bytes", want.Name, got.SizeBytes, want.SizeBytes)
 		}
 		if got.SHA256 != want.SHA256 {
-			return fmt.Errorf("%s manifest SHA-256 is %s, artifact SHA-256 is %s", want.Name, got.SHA256, want.SHA256)
+			return fmt.Errorf("%w: %s manifest SHA-256 is %s, artifact SHA-256 is %s", ErrManifestDigestDrift, want.Name, got.SHA256, want.SHA256)
 		}
 	}
 	return nil

--- a/internal/wasmartifacts/manifest.go
+++ b/internal/wasmartifacts/manifest.go
@@ -1,0 +1,275 @@
+// Package wasmartifacts defines and verifies the reproducible embedded Wasm
+// artifact manifest.
+package wasmartifacts
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	ManifestPath  = "tools/archtests/embedded_wasm_artifacts.json"
+	SchemaVersion = 1
+)
+
+type BuilderIdentity struct {
+	ID            string `json:"id"`
+	Platform      string `json:"platform"`
+	Registry      string `json:"registry"`
+	RustToolchain string `json:"rust_toolchain"`
+	Target        string `json:"target"`
+	Profile       string `json:"profile"`
+}
+
+type ModuleSpec struct {
+	Name         string
+	ArtifactPath string
+	SourcePath   string
+	ABIVersion   uint32
+	MaxSizeBytes int64
+}
+
+type ModuleArtifact struct {
+	Name         string `json:"name"`
+	Path         string `json:"path"`
+	SHA256       string `json:"sha256"`
+	SizeBytes    int64  `json:"size_bytes"`
+	MaxSizeBytes int64  `json:"max_size_bytes"`
+	ABIVersion   uint32 `json:"abi_version"`
+}
+
+type Manifest struct {
+	SchemaVersion    int              `json:"schema_version"`
+	CanonicalBuilder BuilderIdentity  `json:"canonical_builder"`
+	Modules          []ModuleArtifact `json:"modules"`
+}
+
+var canonicalBuilder = BuilderIdentity{
+	ID:            "cerebro-embedded-wasm-v1",
+	Platform:      "Linux-x86_64",
+	Registry:      "scripts/embedded_wasm.py",
+	RustToolchain: "1.93.1",
+	Target:        "wasm32-unknown-unknown",
+	Profile:       "release",
+}
+
+var moduleSpecs = []ModuleSpec{
+	{
+		Name:         "graphagent-static-validator",
+		ArtifactPath: "internal/graphagent/staticvalidator.wasm",
+		SourcePath:   "internal/graphagent/staticvalidator/src/lib.rs",
+		ABIVersion:   2,
+		MaxSizeBytes: 700_000,
+	},
+	{
+		Name:         "sourcecoverage-evaluator",
+		ArtifactPath: "internal/sourcecoverage/evaluator.wasm",
+		SourcePath:   "internal/sourcecoverage/evaluator/src/lib.rs",
+		ABIVersion:   1,
+		MaxSizeBytes: 175_000,
+	},
+	{
+		Name:         "panopticon-resource-extractor",
+		ArtifactPath: "internal/sourceprojection/panopticonresources.wasm",
+		SourcePath:   "internal/sourceprojection/panopticonresources/src/lib.rs",
+		ABIVersion:   2,
+		MaxSizeBytes: 160_000,
+	},
+	{
+		Name:         "mitre-context-evaluator",
+		ArtifactPath: "internal/mitre/evaluator.wasm",
+		SourcePath:   "internal/mitre/evaluator/src/lib.rs",
+		ABIVersion:   1,
+		MaxSizeBytes: 800_000,
+	},
+}
+
+func CanonicalBuilder() BuilderIdentity {
+	return canonicalBuilder
+}
+
+func ModuleSpecs() []ModuleSpec {
+	return append([]ModuleSpec(nil), moduleSpecs...)
+}
+
+func Build(repoRoot string) (Manifest, error) {
+	return build(repoRoot, moduleSpecs)
+}
+
+func build(repoRoot string, specs []ModuleSpec) (Manifest, error) {
+	manifest := Manifest{
+		SchemaVersion:    SchemaVersion,
+		CanonicalBuilder: canonicalBuilder,
+		Modules:          make([]ModuleArtifact, 0, len(specs)),
+	}
+	for _, spec := range specs {
+		body, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(spec.ArtifactPath)))
+		if err != nil {
+			return Manifest{}, fmt.Errorf("read %s artifact %s: %w", spec.Name, spec.ArtifactPath, err)
+		}
+		size := int64(len(body))
+		if size > spec.MaxSizeBytes {
+			overage := size - spec.MaxSizeBytes
+			return Manifest{}, fmt.Errorf(
+				"%s artifact %s is %d bytes, exceeding its %d-byte budget by %d %s; reduce the artifact or make a reviewed budget change in internal/wasmartifacts/manifest.go",
+				spec.Name,
+				spec.ArtifactPath,
+				size,
+				spec.MaxSizeBytes,
+				overage,
+				byteUnit(overage),
+			)
+		}
+		digest := sha256.Sum256(body)
+		manifest.Modules = append(manifest.Modules, ModuleArtifact{
+			Name:         spec.Name,
+			Path:         spec.ArtifactPath,
+			SHA256:       hex.EncodeToString(digest[:]),
+			SizeBytes:    size,
+			MaxSizeBytes: spec.MaxSizeBytes,
+			ABIVersion:   spec.ABIVersion,
+		})
+	}
+	return manifest, nil
+}
+
+func Marshal(manifest Manifest) ([]byte, error) {
+	body, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode embedded Wasm artifact manifest: %w", err)
+	}
+	return append(body, '\n'), nil
+}
+
+func Load(path string) (Manifest, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("open embedded Wasm artifact manifest: %w", err)
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	var manifest Manifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return Manifest{}, fmt.Errorf("decode embedded Wasm artifact manifest: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return Manifest{}, fmt.Errorf("decode embedded Wasm artifact manifest: trailing JSON content")
+	}
+	return manifest, nil
+}
+
+func Write(repoRoot string) error {
+	manifest, err := Build(repoRoot)
+	if err != nil {
+		return err
+	}
+	body, err := Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(repoRoot, filepath.FromSlash(ManifestPath))
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to replace symlinked manifest %s", ManifestPath)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect manifest %s: %w", ManifestPath, err)
+	}
+	file, err := os.CreateTemp(filepath.Dir(path), ".embedded-wasm-artifacts-*.json")
+	if err != nil {
+		return fmt.Errorf("create temporary manifest: %w", err)
+	}
+	temporaryPath := file.Name()
+	defer os.Remove(temporaryPath)
+	if err := file.Chmod(0o644); err != nil {
+		file.Close()
+		return fmt.Errorf("set temporary manifest mode: %w", err)
+	}
+	if _, err := file.Write(body); err != nil {
+		file.Close()
+		return fmt.Errorf("write temporary manifest: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return fmt.Errorf("sync temporary manifest: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temporary manifest: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace manifest %s: %w", ManifestPath, err)
+	}
+	return nil
+}
+
+func byteUnit(value int64) string {
+	if value == 1 {
+		return "byte"
+	}
+	return "bytes"
+}
+
+func Check(repoRoot string) error {
+	expected, err := Build(repoRoot)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(repoRoot, filepath.FromSlash(ManifestPath))
+	actual, err := Load(path)
+	if err != nil {
+		return err
+	}
+	if err := compare(expected, actual); err != nil {
+		return fmt.Errorf("%w; regenerate canonical Wasm artifacts, then run make rust-wasm-manifest-generate", err)
+	}
+	expectedBody, err := Marshal(expected)
+	if err != nil {
+		return err
+	}
+	actualBody, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read manifest %s: %w", ManifestPath, err)
+	}
+	if !bytes.Equal(actualBody, expectedBody) {
+		return fmt.Errorf("manifest %s is not in canonical JSON form; run make rust-wasm-manifest-generate", ManifestPath)
+	}
+	return nil
+}
+
+func compare(expected Manifest, actual Manifest) error {
+	if actual.SchemaVersion != expected.SchemaVersion {
+		return fmt.Errorf("manifest schema_version is %d, expected %d", actual.SchemaVersion, expected.SchemaVersion)
+	}
+	if actual.CanonicalBuilder != expected.CanonicalBuilder {
+		return fmt.Errorf("manifest canonical_builder does not match the pinned builder identity")
+	}
+	if len(actual.Modules) != len(expected.Modules) {
+		return fmt.Errorf("manifest has %d modules, expected %d", len(actual.Modules), len(expected.Modules))
+	}
+	for index := range expected.Modules {
+		want := expected.Modules[index]
+		got := actual.Modules[index]
+		if got.Name != want.Name || got.Path != want.Path {
+			return fmt.Errorf("manifest module %d is %s at %s, expected %s at %s", index, got.Name, got.Path, want.Name, want.Path)
+		}
+		if got.ABIVersion != want.ABIVersion {
+			return fmt.Errorf("%s manifest ABI version is %d, expected %d", want.Name, got.ABIVersion, want.ABIVersion)
+		}
+		if got.MaxSizeBytes != want.MaxSizeBytes {
+			return fmt.Errorf("%s manifest size budget is %d bytes, expected %d", want.Name, got.MaxSizeBytes, want.MaxSizeBytes)
+		}
+		if got.SizeBytes != want.SizeBytes {
+			return fmt.Errorf("%s manifest size is %d bytes, artifact is %d bytes", want.Name, got.SizeBytes, want.SizeBytes)
+		}
+		if got.SHA256 != want.SHA256 {
+			return fmt.Errorf("%s manifest SHA-256 is %s, artifact SHA-256 is %s", want.Name, got.SHA256, want.SHA256)
+		}
+	}
+	return nil
+}

--- a/internal/wasmartifacts/manifest_test.go
+++ b/internal/wasmartifacts/manifest_test.go
@@ -1,0 +1,84 @@
+package wasmartifacts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildIsDeterministicAndContainsArtifactEvidence(t *testing.T) {
+	root := t.TempDir()
+	specs := testSpecs(t, root)
+	manifest, err := build(root, specs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if !strings.Contains(text, `"sha256": "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81"`) {
+		t.Fatalf("manifest missing deterministic digest: %s", text)
+	}
+	if !strings.Contains(text, `"size_bytes": 3`) || !strings.Contains(text, `"abi_version": 7`) {
+		t.Fatalf("manifest missing size or ABI evidence: %s", text)
+	}
+	if strings.Contains(text, root) || strings.Contains(text, "timestamp") {
+		t.Fatalf("manifest contains environment-dependent data: %s", text)
+	}
+}
+
+func TestBuildRejectsArtifactOverBudgetWithActionableError(t *testing.T) {
+	root := t.TempDir()
+	specs := testSpecs(t, root)
+	specs[0].MaxSizeBytes = 2
+	_, err := build(root, specs)
+	if err == nil {
+		t.Fatal("expected size budget failure")
+	}
+	for _, fragment := range []string{"test-module", "3 bytes", "2-byte budget", "by 1 byte", "reviewed budget change"} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("error %q missing %q", err, fragment)
+		}
+	}
+}
+
+func TestCompareReportsDigestAndBudgetDrift(t *testing.T) {
+	root := t.TempDir()
+	specs := testSpecs(t, root)
+	expected, err := build(root, specs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := expected
+	actual.Modules = append([]ModuleArtifact(nil), expected.Modules...)
+	actual.Modules[0].SHA256 = strings.Repeat("0", 64)
+	if err := compare(expected, actual); err == nil || !strings.Contains(err.Error(), "manifest SHA-256") {
+		t.Fatalf("expected digest drift error, got %v", err)
+	}
+	actual.Modules[0] = expected.Modules[0]
+	actual.Modules[0].MaxSizeBytes++
+	if err := compare(expected, actual); err == nil || !strings.Contains(err.Error(), "size budget") {
+		t.Fatalf("expected budget drift error, got %v", err)
+	}
+}
+
+func testSpecs(t *testing.T, root string) []ModuleSpec {
+	t.Helper()
+	path := filepath.Join(root, "artifacts", "test.wasm")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte{1, 2, 3}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return []ModuleSpec{{
+		Name:         "test-module",
+		ArtifactPath: "artifacts/test.wasm",
+		SourcePath:   "src/lib.rs",
+		ABIVersion:   7,
+		MaxSizeBytes: 10,
+	}}
+}

--- a/internal/wasmartifacts/manifest_test.go
+++ b/internal/wasmartifacts/manifest_test.go
@@ -1,6 +1,7 @@
 package wasmartifacts
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,13 +36,31 @@ func TestBuildRejectsArtifactOverBudgetWithActionableError(t *testing.T) {
 	specs := testSpecs(t, root)
 	specs[0].MaxSizeBytes = 2
 	_, err := build(root, specs)
-	if err == nil {
-		t.Fatal("expected size budget failure")
+	if !errors.Is(err, ErrArtifactOverBudget) {
+		t.Fatalf("build() error = %v, want ErrArtifactOverBudget", err)
 	}
-	for _, fragment := range []string{"test-module", "3 bytes", "2-byte budget", "by 1 byte", "reviewed budget change"} {
-		if !strings.Contains(err.Error(), fragment) {
-			t.Fatalf("error %q missing %q", err, fragment)
-		}
+	var budgetError *ArtifactBudgetError
+	if !errors.As(err, &budgetError) {
+		t.Fatalf("build() error = %v, want ArtifactBudgetError", err)
+	}
+	if budgetError.Module != "test-module" || budgetError.SizeBytes != 3 || budgetError.BudgetBytes != 2 {
+		t.Fatalf("ArtifactBudgetError = %+v, want module=test-module size=3 budget=2", budgetError)
+	}
+}
+
+func TestBuildRejectsSymlinkedArtifact(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target.wasm")
+	if err := os.WriteFile(target, []byte{1}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	artifact := filepath.Join(root, "artifact.wasm")
+	if err := os.Symlink(target, artifact); err != nil {
+		t.Fatal(err)
+	}
+	_, err := build(root, []ModuleSpec{{Name: "test", ArtifactPath: "artifact.wasm", MaxSizeBytes: 10}})
+	if !errors.Is(err, ErrUnsafeArtifactPath) {
+		t.Fatalf("build() error = %v, want ErrUnsafeArtifactPath", err)
 	}
 }
 
@@ -55,23 +74,23 @@ func TestCompareReportsDigestAndBudgetDrift(t *testing.T) {
 	actual := expected
 	actual.Modules = append([]ModuleArtifact(nil), expected.Modules...)
 	actual.Modules[0].SHA256 = strings.Repeat("0", 64)
-	if err := compare(expected, actual); err == nil || !strings.Contains(err.Error(), "manifest SHA-256") {
-		t.Fatalf("expected digest drift error, got %v", err)
+	if err := compare(expected, actual); !errors.Is(err, ErrManifestDigestDrift) {
+		t.Fatalf("compare() error = %v, want ErrManifestDigestDrift", err)
 	}
 	actual.Modules[0] = expected.Modules[0]
 	actual.Modules[0].MaxSizeBytes++
-	if err := compare(expected, actual); err == nil || !strings.Contains(err.Error(), "size budget") {
-		t.Fatalf("expected budget drift error, got %v", err)
+	if err := compare(expected, actual); !errors.Is(err, ErrManifestBudgetDrift) {
+		t.Fatalf("compare() error = %v, want ErrManifestBudgetDrift", err)
 	}
 }
 
 func testSpecs(t *testing.T, root string) []ModuleSpec {
 	t.Helper()
 	path := filepath.Join(root, "artifacts", "test.wasm")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte{1, 2, 3}, 0o644); err != nil {
+	if err := os.WriteFile(path, []byte{1, 2, 3}, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return []ModuleSpec{{

--- a/tools/archtests/embedded_wasm_artifacts.json
+++ b/tools/archtests/embedded_wasm_artifacts.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "canonical_builder": {
+    "id": "cerebro-embedded-wasm-v1",
+    "platform": "Linux-x86_64",
+    "registry": "scripts/embedded_wasm.py",
+    "rust_toolchain": "1.93.1",
+    "target": "wasm32-unknown-unknown",
+    "profile": "release"
+  },
+  "modules": [
+    {
+      "name": "graphagent-static-validator",
+      "path": "internal/graphagent/staticvalidator.wasm",
+      "sha256": "d698b12ec2e0698af5503d48f7c23d6ad5d1ca09270559b72028979912ce1829",
+      "size_bytes": 652086,
+      "max_size_bytes": 700000,
+      "abi_version": 2
+    },
+    {
+      "name": "sourcecoverage-evaluator",
+      "path": "internal/sourcecoverage/evaluator.wasm",
+      "sha256": "388966fe3d994e4029ab161cca7098c4ce0a7363ff9870b974004e3252b100f9",
+      "size_bytes": 149563,
+      "max_size_bytes": 175000,
+      "abi_version": 1
+    },
+    {
+      "name": "panopticon-resource-extractor",
+      "path": "internal/sourceprojection/panopticonresources.wasm",
+      "sha256": "58cb2f0f7aa5dd54d570a8ebbedac1d5bd484d0300d07e1561f99d9ffa40427c",
+      "size_bytes": 134504,
+      "max_size_bytes": 160000,
+      "abi_version": 2
+    },
+    {
+      "name": "mitre-context-evaluator",
+      "path": "internal/mitre/evaluator.wasm",
+      "sha256": "fa904c9b15cb4f4f499deb3238fbf6dbc0c4967df0201d88b33742a67ff7161d",
+      "size_bytes": 729536,
+      "max_size_bytes": 800000,
+      "abi_version": 1
+    }
+  ]
+}

--- a/tools/archtests/wasm_artifact_manifest_test.go
+++ b/tools/archtests/wasm_artifact_manifest_test.go
@@ -1,0 +1,70 @@
+package archtests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/wasmartifacts"
+)
+
+func TestEmbeddedWasmArtifactManifestMatchesRegistriesAndABIs(t *testing.T) {
+	root := repoRoot(t)
+	if err := wasmartifacts.Check(root); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := wasmartifacts.Load(filepath.Join(root, filepath.FromSlash(wasmartifacts.ManifestPath)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	specs := wasmartifacts.ModuleSpecs()
+	if len(manifest.Modules) != len(specs) {
+		t.Fatalf("manifest has %d modules, registry has %d", len(manifest.Modules), len(specs))
+	}
+
+	pythonRegistry := readArchitectureFile(t, root, "scripts/embedded_wasm.py")
+	for index, spec := range specs {
+		entry := manifest.Modules[index]
+		if entry.Name != spec.Name || entry.Path != spec.ArtifactPath || entry.ABIVersion != spec.ABIVersion {
+			t.Fatalf("manifest module %d does not match Go registry: got %+v want %+v", index, entry, spec)
+		}
+		for _, fragment := range []string{
+			fmt.Sprintf(`name="%s"`, spec.Name),
+			fmt.Sprintf(`embedded_artifact="%s"`, spec.ArtifactPath),
+		} {
+			if !strings.Contains(pythonRegistry, fragment) {
+				t.Errorf("Python Wasm registry missing %s contract %q", spec.Name, fragment)
+			}
+		}
+		rustSource := readArchitectureFile(t, root, spec.SourcePath)
+		abiDeclaration := fmt.Sprintf("pub const ABI_VERSION: u32 = %d;", spec.ABIVersion)
+		if !strings.Contains(rustSource, abiDeclaration) {
+			t.Errorf("%s must declare %q in %s", spec.Name, abiDeclaration, spec.SourcePath)
+		}
+	}
+
+	builder := wasmartifacts.CanonicalBuilder()
+	toolchain := readArchitectureFile(t, root, "rust-toolchain.toml")
+	if !strings.Contains(toolchain, fmt.Sprintf(`channel = "%s"`, builder.RustToolchain)) {
+		t.Errorf("rust-toolchain.toml must pin canonical builder toolchain %s", builder.RustToolchain)
+	}
+	for _, fragment := range []string{
+		fmt.Sprintf(`WASM_TARGET = "%s"`, builder.Target),
+		fmt.Sprintf(`CANONICAL_PLATFORM = "%s"`, builder.Platform),
+	} {
+		if !strings.Contains(pythonRegistry, fragment) {
+			t.Errorf("Python Wasm registry missing canonical builder input %q", fragment)
+		}
+	}
+}
+
+func readArchitectureFile(t *testing.T, root string, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(body)
+}

--- a/tools/wasmartifactmanifest/main.go
+++ b/tools/wasmartifactmanifest/main.go
@@ -1,0 +1,30 @@
+// Command wasmartifactmanifest generates or verifies the embedded Wasm
+// artifact manifest.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/writer/cerebro/internal/wasmartifacts"
+)
+
+func main() {
+	var repoRoot string
+	var write bool
+	flag.StringVar(&repoRoot, "repo", ".", "repository root")
+	flag.BoolVar(&write, "write", false, "write the manifest instead of checking it")
+	flag.Parse()
+
+	var err error
+	if write {
+		err = wasmartifacts.Write(repoRoot)
+	} else {
+		err = wasmartifacts.Check(repoRoot)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wasmartifactmanifest: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## What changed

- add a committed manifest for all four embedded Wasm modules with SHA-256, exact bytes, ABI versions, canonical builder inputs, and maximum size budgets
- add a Go generator and checker with canonical JSON, atomic writes, symlink protection, and actionable drift errors
- add architecture contracts that match the manifest to the build registry, Rust ABI constants, toolchain pin, artifacts, and existing changed-check routing
- run the manifest check from the existing Rust Wasm validation lane and document the regeneration workflow

## Validation

- canonical Linux x86_64 regeneration and byte comparison for all four Wasm modules
- `make rust-doc-check rust-deny graph-action-check rust-wasm-check`
- `go test ./internal/wasmartifacts ./tools/wasmartifactmanifest ./tools/archtests -count=1`
- `python3 -m unittest discover -s scripts/tests`
- `actionlint .github/workflows/*.yml`
- `make docs-drift-check check-structural-test check-arch`
- `make connector-catalog-review`