### PR TITLE
Fix Postgres projection advisory lock keys

### DIFF
--- a/internal/statestore/postgres/assessment_sampling.go
+++ b/internal/statestore/postgres/assessment_sampling.go
@@ -53,7 +53,8 @@ func (s *Store) ApplyAssessmentSamplingEvent(ctx context.Context, envelope *cere
 		return false, fmt.Errorf("begin assessment sampling projection: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, assessmentSamplingAdvisoryLockSQL(), event.tenantID+"\x00"+event.aggregateType+"\x00"+event.aggregateID); err != nil {
+	lockKey := postgresAdvisoryLockKey(event.tenantID, event.aggregateType, event.aggregateID)
+	if _, err := tx.ExecContext(ctx, assessmentSamplingAdvisoryLockSQL(), lockKey); err != nil {
 		return false, fmt.Errorf("lock assessment sampling aggregate: %w", err)
 	}
 	existingDigest, exists, err := loadAssessmentSamplingReceipt(ctx, tx, event.tenantID, event.eventID)

--- a/internal/statestore/postgres/audit_state.go
+++ b/internal/statestore/postgres/audit_state.go
@@ -52,7 +52,8 @@ func (s *Store) ApplyAuditProjectionEvent(ctx context.Context, envelope *cerebro
 		return false, fmt.Errorf("begin audit projection: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, auditProjectionAdvisoryLockSQL(), event.tenantID+"\x00"+event.eventID); err != nil {
+	lockKey := postgresAdvisoryLockKey(event.tenantID, event.eventID)
+	if _, err := tx.ExecContext(ctx, auditProjectionAdvisoryLockSQL(), lockKey); err != nil {
 		return false, fmt.Errorf("lock audit projection event: %w", err)
 	}
 	existingDigest, exists, err := loadAuditEventReceipt(ctx, tx, event.tenantID, event.eventID)

--- a/internal/statestore/postgres/compliance_program_projector.go
+++ b/internal/statestore/postgres/compliance_program_projector.go
@@ -36,7 +36,8 @@ func (s *Store) ApplyComplianceProgramEvent(ctx context.Context, event *cerebrov
 		return false, fmt.Errorf("begin compliance program event application: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, complianceApplicationAdvisoryLockSQL(), application.tenantID+"\x00"+application.eventID); err != nil {
+	lockKey := postgresAdvisoryLockKey(application.tenantID, application.eventID)
+	if _, err := tx.ExecContext(ctx, complianceApplicationAdvisoryLockSQL(), lockKey); err != nil {
 		return false, fmt.Errorf("lock compliance event application: %w", err)
 	}
 	existingDigest, receiptExists, err := loadComplianceApplicationReceipt(ctx, tx, application.tenantID, application.eventID)

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -15,6 +16,17 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/telemetry"
 )
+
+func postgresAdvisoryLockKey(parts ...string) string {
+	var key strings.Builder
+	for _, part := range parts {
+		key.WriteString(strconv.Itoa(len(part)))
+		key.WriteByte(':')
+		key.WriteString(part)
+	}
+	digest := sha256.Sum256([]byte(key.String()))
+	return hex.EncodeToString(digest[:])
+}
 
 // findingIntelReady tracks lazy schema creation for finding-domain auxiliary
 // tables (candidate staging, finding memory, and risk scoring config). Grouping

--- a/internal/statestore/postgres/postgres_test.go
+++ b/internal/statestore/postgres/postgres_test.go
@@ -1,10 +1,25 @@
 package postgres
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/writer/cerebro/internal/config"
 )
+
+func TestPostgresAdvisoryLockKeyIsTextSafeAndBoundaryStable(t *testing.T) {
+	t.Parallel()
+	first := postgresAdvisoryLockKey("tenant-a", "event-a")
+	if first == "" || strings.ContainsRune(first, '\x00') {
+		t.Fatalf("postgresAdvisoryLockKey() = %q, want non-empty text without NUL bytes", first)
+	}
+	if got := postgresAdvisoryLockKey("tenant-a", "event-a"); got != first {
+		t.Fatalf("postgresAdvisoryLockKey() = %q, want stable key %q", got, first)
+	}
+	if got := postgresAdvisoryLockKey("tenant", "-aevent-a"); got == first {
+		t.Fatal("postgresAdvisoryLockKey() collapsed distinct part boundaries")
+	}
+}
 
 func TestOpenRejectsMissingDSN(t *testing.T) {
 	if _, err := Open(config.StateStoreConfig{Driver: config.StateStoreDriverPostgres}); err == nil {


### PR DESCRIPTION
## Summary
- encode advisory lock components into stable text-safe keys
- preserve tenant and aggregate boundaries before hashing
- cover key stability and boundary separation with a regression test

## Validation
- `go test ./internal/statestore/postgres -count=1`
- PostgreSQL 17: the three projection replay and tenant-isolation tests that failed in scheduled integration now pass
- `git diff --check`