### PR TITLE
fix(orchestrator): record current graph ingest runs

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -683,48 +683,45 @@ func runOrchestratorIteration(
 				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_checkpoint_current", checkpointStatus.CheckpointCurrent)
 				if checkpointStatus.CheckpointCurrent {
 					runtimeResult.DownstreamSkipReason = downstreamSkipReason
-					runtimeResult.GraphIngest = "skipped"
 					runtimeResult.FindingRules = "skipped"
 					runtimeResult.GraphRules = "skipped"
 					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "downstream_skip_reason", downstreamSkipReason)
-					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_skip_reason", downstreamSkipReason)
 					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_skip_reason", downstreamSkipReason)
 					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", downstreamSkipReason)
-					recordOrchestratorPhaseSkip(runtimeCtx, runtime, "orchestrator.graph_ingest", downstreamSkipReason)
 					recordOrchestratorPhaseSkip(runtimeCtx, runtime, "orchestrator.finding_rules", downstreamSkipReason)
 					recordOrchestratorPhaseSkip(runtimeCtx, runtime, "orchestrator.graph_rules", downstreamSkipReason)
-					runtimeResult.Health = withOrchestratorFreshGraphHealth(runtimeResult.Health)
 				}
 			}
 		}
 
-		if runtimeResult.DownstreamSkipReason == "" {
-			graphPageLimit := orchestratorGraphPageLimit(options.GraphPageLimit, runtimeResult.PagesRead)
-			resetGraphCheckpoint := runtimeResult.EventsAppended > 0 && syncStartCursorOpaque == ""
-			resetCompletedGraphCheckpoint := runtimeResult.EventsAppended > 0
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "effective_graph_page_limit", graphPageLimit)
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reset_graph_checkpoint", resetGraphCheckpoint)
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reset_completed_graph_checkpoint", resetCompletedGraphCheckpoint)
-			graphResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_ingest", iteration, runtime, options.GraphTimeout, func(phaseCtx context.Context) (*graphingest.RunResult, error) {
-				return graphService.RunRuntime(phaseCtx, graphingest.RuntimeRequest{
-					RuntimeID:                runtime.GetId(),
-					PageLimit:                graphPageLimit,
-					ResetCheckpoint:          resetGraphCheckpoint,
-					ResetCompletedCheckpoint: resetCompletedGraphCheckpoint,
-					Trigger:                  "orchestrator",
-					RuntimeLeaseHeld:         true,
-				})
+		graphPageLimit := orchestratorGraphPageLimit(options.GraphPageLimit, runtimeResult.PagesRead)
+		resetGraphCheckpoint := runtimeResult.EventsAppended > 0 && syncStartCursorOpaque == ""
+		resetCompletedGraphCheckpoint := runtimeResult.EventsAppended > 0
+		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "effective_graph_page_limit", graphPageLimit)
+		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reset_graph_checkpoint", resetGraphCheckpoint)
+		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reset_completed_graph_checkpoint", resetCompletedGraphCheckpoint)
+		graphResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_ingest", iteration, runtime, options.GraphTimeout, func(phaseCtx context.Context) (*graphingest.RunResult, error) {
+			return graphService.RunRuntime(phaseCtx, graphingest.RuntimeRequest{
+				RuntimeID:                runtime.GetId(),
+				PageLimit:                graphPageLimit,
+				ResetCheckpoint:          resetGraphCheckpoint,
+				ResetCompletedCheckpoint: resetCompletedGraphCheckpoint,
+				Trigger:                  "orchestrator",
+				RuntimeLeaseHeld:         true,
 			})
-			runtimeSpanAttrs = applyGraphIngestCounters(runtimeResult, graphResult, runtimeSpanAttrs)
-			if err != nil {
-				runtimeResult.GraphIngest = "failed"
-				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
-				runErr = err
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error_kind", telemetry.ErrorKind(err))
-			} else {
-				runtimeResult.GraphIngest = "completed"
-			}
-			runtimeResult.Health = withOrchestratorGraphHealth(runtimeResult.Health, graphResult, runtimeResult.GraphIngest, time.Now().UTC())
+		})
+		runtimeSpanAttrs = applyGraphIngestCounters(runtimeResult, graphResult, runtimeSpanAttrs)
+		if err != nil {
+			runtimeResult.GraphIngest = "failed"
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
+			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error_kind", telemetry.ErrorKind(err))
+		} else {
+			runtimeResult.GraphIngest = "completed"
+		}
+		runtimeResult.Health = withOrchestratorGraphHealth(runtimeResult.Health, graphResult, runtimeResult.GraphIngest, time.Now().UTC())
+
+		if runtimeResult.DownstreamSkipReason == "" {
 			findingResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.finding_rules", iteration, runtime, options.PhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateRulesResult, error) {
 				return findingService.EvaluateSourceRuntimeRules(phaseCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit, RuntimeLeaseHeld: true})
 			})
@@ -1098,13 +1095,6 @@ func withOrchestratorGraphHealth(record sourcehealth.Record, graphResult *graphi
 	}
 	record.LatestGraphRun = &sourcehealth.GraphRun{Status: status}
 	record.GraphLagSeconds = orchestratorGraphRunLagSeconds(now, graphResult.Run.StartedAt, graphResult.Run.FinishedAt)
-	return record
-}
-
-func withOrchestratorFreshGraphHealth(record sourcehealth.Record) sourcehealth.Record {
-	lag := int64(0)
-	record.LatestGraphRun = &sourcehealth.GraphRun{Status: "fresh"}
-	record.GraphLagSeconds = &lag
 	return record
 }
 

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -940,7 +940,7 @@ func TestRunOrchestratorIterationRunsGraphRulesWhenOnlyRunRecordWriteFails(t *te
 	}
 }
 
-func TestRunOrchestratorIterationSkipsDownstreamWhenSourceAndGraphAreCurrent(t *testing.T) {
+func TestRunOrchestratorIterationRecordsGraphIngestWhenSourceAndGraphAreCurrent(t *testing.T) {
 	registry, err := sourcecdk.NewRegistry(orchestratorUnchangedSource{})
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
@@ -1001,14 +1001,18 @@ func TestRunOrchestratorIterationSkipsDownstreamWhenSourceAndGraphAreCurrent(t *
 	if runtimeResult.DownstreamSkipReason != "source_unchanged" {
 		t.Fatalf("downstream skip reason = %q, want source_unchanged", runtimeResult.DownstreamSkipReason)
 	}
-	if runtimeResult.GraphIngest != "skipped" || runtimeResult.FindingRules != "skipped" || runtimeResult.GraphRules != "skipped" {
-		t.Fatalf("downstream statuses = %q/%q/%q, want skipped/skipped/skipped", runtimeResult.GraphIngest, runtimeResult.FindingRules, runtimeResult.GraphRules)
+	if runtimeResult.GraphIngest != "completed" || runtimeResult.FindingRules != "skipped" || runtimeResult.GraphRules != "skipped" {
+		t.Fatalf("downstream statuses = %q/%q/%q, want completed/skipped/skipped", runtimeResult.GraphIngest, runtimeResult.FindingRules, runtimeResult.GraphRules)
 	}
 	if graphRule.calls != 0 {
 		t.Fatalf("graph rule calls = %d, want 0 when graph checkpoint is already current", graphRule.calls)
 	}
-	if len(graphStore.runs) != 0 {
-		t.Fatalf("graph ingest runs = %d, want 0 when downstream work is skipped", len(graphStore.runs))
+	runs, err := graphStore.ListIngestRuns(context.Background(), graphstore.IngestRunFilter{RuntimeID: "runtime-1", Status: graphstore.IngestRunStatusCompleted})
+	if err != nil {
+		t.Fatalf("ListIngestRuns() error = %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("completed graph ingest runs = %d, want 1 when the checkpoint is already current", len(runs))
 	}
 }
 


### PR DESCRIPTION
## What changed

- Persist a completed graph-ingest run when source sync is unchanged and the graph checkpoint is already current.
- Continue skipping finding and graph-rule evaluation on the unchanged-source path.
- Derive runtime graph health from the persisted run instead of an in-memory override.

## Why

Health and status consumers require durable ingest history. The unchanged-source optimization skipped the graph-ingest phase entirely, so a current checkpoint could still appear to have no ingest history.

## Impact

The checkpoint-current path remains a no-op for projection and rules. It now records the completed zero-work ingest run needed by health and verification surfaces.

## Validation

- `go test ./cmd/cerebro -run TestRunOrchestratorIteration\(RecordsGraphIngestWhenSourceAndGraphAreCurrent\|RunsGraphWhenSourceUnchangedButGraphCheckpointMissing\) -count=1`
- `make check-arch`
- `git diff --check`