### PR TITLE
Complete Postgres advisory lock key migration

### DIFF
--- a/internal/statestore/postgres/grc_vendor.go
+++ b/internal/statestore/postgres/grc_vendor.go
@@ -89,7 +89,8 @@ func (s *Store) UpsertGRCVendorDiscoveryDecision(ctx context.Context, record por
 		return nil, fmt.Errorf("begin vendor discovery decision upsert: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, grcVendorDiscoveryDecisionAdvisoryLockSQL(), record.TenantID+"\x00"+record.DiscoveryURN); err != nil {
+	lockKey := postgresAdvisoryLockKey(record.TenantID, record.DiscoveryURN)
+	if _, err := tx.ExecContext(ctx, grcVendorDiscoveryDecisionAdvisoryLockSQL(), lockKey); err != nil {
 		return nil, fmt.Errorf("lock vendor discovery decision: %w", err)
 	}
 	var supersedesEventID string

--- a/internal/statestore/postgres/questionnaire.go
+++ b/internal/statestore/postgres/questionnaire.go
@@ -98,7 +98,8 @@ func (s *Store) UpsertQuestionnaireRun(ctx context.Context, record ports.Questio
 		return nil, fmt.Errorf("begin questionnaire run upsert: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, questionnaireRunAdvisoryLockSQL(), record.TenantID+"\x00"+record.RunID); err != nil {
+	lockKey := postgresAdvisoryLockKey(record.TenantID, record.RunID)
+	if _, err := tx.ExecContext(ctx, questionnaireRunAdvisoryLockSQL(), lockKey); err != nil {
 		return nil, fmt.Errorf("lock questionnaire run: %w", err)
 	}
 	var previousVersion int

--- a/internal/statestore/postgres/source_trust.go
+++ b/internal/statestore/postgres/source_trust.go
@@ -52,7 +52,8 @@ func (s *Store) ApplySourceTrustEvent(ctx context.Context, envelope *cerebrov1.E
 		return false, fmt.Errorf("begin source trust projection: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, sourceTrustAdvisoryLockSQL(), event.tenantID+"\x00"+event.aggregateType+"\x00"+event.aggregateID); err != nil {
+	lockKey := postgresAdvisoryLockKey(event.tenantID, event.aggregateType, event.aggregateID)
+	if _, err := tx.ExecContext(ctx, sourceTrustAdvisoryLockSQL(), lockKey); err != nil {
 		return false, fmt.Errorf("lock source trust aggregate: %w", err)
 	}
 	existingDigest, exists, err := loadSourceTrustReceipt(ctx, tx, event.tenantID, event.eventID)


### PR DESCRIPTION
## Summary
- migrate the remaining source trust, questionnaire, and vendor advisory lock callers to text-safe keys
- preserve component boundaries through the shared length-prefixed hash helper
- remove every NUL-delimited advisory lock argument in the Postgres package

## Validation
- `go test ./internal/statestore/postgres -count=1`
- PostgreSQL 17: source trust integration and the three projection replay/isolation regressions pass
- verified no Postgres `ExecContext` advisory lock call retains a NUL-delimited argument
- `git diff --check`