### PR TITLE
Classify and measure embedded Wasm hosts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Set up Rust
         if: matrix.setup_rust == true
-        run: rustup toolchain install 1.93.1 --profile minimal --component clippy,rustfmt --target wasm32-unknown-unknown
+        run: rustup toolchain install 1.93.1 --profile minimal --component clippy,rustfmt,llvm-tools-preview --target wasm32-unknown-unknown
 
       - name: Cache Rust build data
         if: matrix.setup_rust == true
@@ -82,11 +82,12 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/cargo-deny
+            ~/.cargo/bin/cargo-llvm-cov
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target
-          key: ${{ runner.os }}-${{ runner.arch }}-rust-v1-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', '**/Cargo.toml') }}-cargo-deny-0.20.2
+          key: ${{ runner.os }}-${{ runner.arch }}-rust-v1-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', '**/Cargo.toml') }}-cargo-deny-0.20.2-cargo-llvm-cov-0.8.7
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-rust-v1-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', '**/Cargo.toml') }}-
             ${{ runner.os }}-${{ runner.arch }}-rust-v1-
@@ -98,6 +99,15 @@ jobs:
           set -euo pipefail
           if ! cargo deny --version 2>/dev/null | grep -Fxq 'cargo-deny 0.20.2'; then
             cargo install cargo-deny --version 0.20.2 --locked
+          fi
+
+      - name: Install Rust coverage tool
+        if: matrix.setup_rust == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! cargo llvm-cov --version 2>/dev/null | grep -Fxq 'cargo-llvm-cov 0.8.7'; then
+            cargo install cargo-llvm-cov --version 0.8.7 --locked
           fi
 
       - name: Cache Go build data

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: release-train-test
 .PHONY: sourcegen-grammar-check sourcegen-repro-check sourcegen-proof-check
 .PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-smoke mcp-sdk-compat lint lint-shard lint-api-cmd lint-internal lint-sources lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check content-pack-check control-index-generate control-index-check sourcegen-check connector-catalog-fidelity-generate connector-catalog-fidelity-check connector-catalog-review connector-api-discovery connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status codegen-check codegen-catalog-generate codegen-catalog-check projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo github-business-demo github-business-demo-env agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
-.PHONY: rust-workspace-policy rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-wasm-check rust-wasm-manifest-generate rust-wasm-manifest-check rust-validator-properties rust-validator-fuzz-smoke graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check sourceruntime-record-kernel-generate sourceruntime-record-kernel-check rust-source-kernel-evidence
+.PHONY: rust-workspace-policy rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-coverage rust-benchmark-smoke rust-wasm-check rust-wasm-manifest-generate rust-wasm-manifest-check rust-validator-properties rust-validator-fuzz-smoke graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check sourceruntime-record-kernel-generate sourceruntime-record-kernel-check rust-source-kernel-evidence
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 PYTHON ?= python3
@@ -452,6 +452,15 @@ rust-validator-fuzz-smoke: ## Run a bounded static validator fuzz session (requi
 	cp $(RUST_VALIDATOR_FUZZ_DIR)/corpus/validate/* "$(RUST_VALIDATOR_FUZZ_CORPUS)/"
 	$(CARGO) +$(RUST_FUZZ_TOOLCHAIN) fuzz run validate --fuzz-dir $(RUST_VALIDATOR_FUZZ_DIR) "$(RUST_VALIDATOR_FUZZ_CORPUS)" -- -runs=$(RUST_FUZZ_RUNS) -max_len=$(RUST_FUZZ_MAX_LEN) -dict=$(RUST_VALIDATOR_FUZZ_DIR)/cypher.dict
 
+rust-coverage: ## Enforce the Rust workspace line-coverage floor with the pinned coverage tool.
+	@actual="$$($(CARGO) llvm-cov --version 2>/dev/null || true)"; \
+		test "$$actual" = "cargo-llvm-cov 0.8.7" || { echo "rust-coverage: install cargo-llvm-cov 0.8.7 with 'cargo install cargo-llvm-cov --version 0.8.7 --locked'"; exit 1; }
+	$(CARGO) llvm-cov --workspace --all-features --locked --ignore-filename-regex '(^|/)wasm_abi\.rs$$' --fail-under-lines 90 --summary-only
+
+rust-benchmark-smoke: ## Run bounded embedded Wasm host benchmarks and record their output.
+	@mkdir -p tmp
+	@go test ./internal/wasmhost ./internal/graphagent ./internal/sourcecoverage ./internal/mitre ./internal/sourceprojection -run '^$$' -bench '^(BenchmarkRuntimeRun|BenchmarkStaticValidator|BenchmarkCoverageEvaluator|BenchmarkContextEvaluator|BenchmarkPanopticonResourceExtractor)$$' -benchtime=20x -count=1 > tmp/rust-wasm-benchmark.txt 2>&1; status=$$?; cat tmp/rust-wasm-benchmark.txt; exit $$status
+
 graph-action-check: rust-fmt-check rust-clippy rust-test rust-doc-check ## Verify generated graph action registry is current.
 	$(CARGO) run --locked --quiet -p cerebro-graphactiongen -- --check
 
@@ -497,7 +506,7 @@ sourceruntime-record-kernel-check: rust-fmt-check rust-clippy rust-test ## Verif
 rust-source-kernel-evidence: ## Compare the embedded kernel with the standard Go Wasm runtime floor.
 	./scripts/rust-source-kernel-evidence.sh
 
-rust-wasm-check: rust-workspace-policy rust-fmt-check rust-clippy rust-test ## Verify every embedded Rust Wasm module.
+rust-wasm-check: rust-workspace-policy rust-fmt-check rust-clippy rust-test rust-coverage rust-benchmark-smoke ## Verify every embedded Rust Wasm module.
 	CARGO="$(CARGO)" $(PYTHON) scripts/embedded_wasm.py check all
 	$(MAKE) rust-wasm-manifest-check
 

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -8,6 +8,7 @@ This document describes the current bootstrap service on `main`. Historical ware
 - Rust 1.93.1 with Cargo; `rust-toolchain.toml` installs the pinned toolchain, rustfmt, Clippy, and the Wasm build target.
 - `cargo-deny` 0.20.2 for local Rust dependency-policy checks.
 - The `nightly-2026-06-09` toolchain and `cargo-fuzz` 0.13.1 only when running the static validator fuzz target locally.
+- `cargo-llvm-cov` 0.8.7 plus the `llvm-tools-preview` Rust component for the Rust coverage gate.
 - Docker and Docker Compose for the durable local stack.
 - Make.
 
@@ -120,6 +121,27 @@ guest. The second reports the guest's imports, exports, and byte size next to
 the runtime floor produced by the repository's pinned standard Go toolchain.
 The comparison is a capability-surface check, not a throughput benchmark.
 
+`make rust-wasm-check` also enforces a 90% Rust workspace line-coverage floor
+and runs 20 fixed iterations of each embedded Wasm benchmark. The coverage
+floor was set below the measured 90.09% workspace baseline so the gate catches
+meaningful regressions without treating rounding noise as a failure.
+`wasm_abi.rs` files are excluded because they are target-specific allocation
+and descriptor glue exercised by the Go/Wasm integration tests, not by native
+Rust coverage. No validator or evaluator logic is excluded.
+
+Run these lanes directly with:
+
+```bash
+make rust-coverage
+make rust-benchmark-smoke
+```
+
+The benchmark smoke lane covers the static validator, source coverage, MITRE,
+Panopticon extraction, and the shared Go host invocation path. It writes the
+complete Go benchmark output to `tmp/rust-wasm-benchmark.txt`. CI checks that
+the harnesses compile and finish; latency numbers remain evidence for
+comparison and are not pass/fail thresholds.
+
 Focused validation:
 
 ```bash
@@ -149,6 +171,12 @@ the Wasm files on `Linux-x86_64`, run `make rust-wasm-manifest-generate` and
 commit the manifest update. `make rust-wasm-manifest-check` reports digest,
 ABI, size, or budget drift; increasing a budget requires an intentional change
 to `internal/wasmartifacts/manifest.go`.
+
+Embedded host failures expose a typed diagnostic through
+`wasmhost.DiagnosticKindOf` and `errors.Is` sentinels for invalid input, ABI or
+memory violations, guest status, invalid output, timeout, and cancellation.
+The diagnostic wrapper preserves the existing error text and wrapped causes so
+operator output and caller fallback behavior do not change.
 
 ## Architecture Notes
 

--- a/internal/graphagent/staticvalidator.go
+++ b/internal/graphagent/staticvalidator.go
@@ -78,16 +78,16 @@ func runStaticValidator(ctx context.Context, query string, maxRows int) (staticV
 		alloc := module.ExportedFunction("cerebro_validator_alloc")
 		validate := module.ExportedFunction("cerebro_validator_validate")
 		if alloc == nil || validate == nil || module.Memory() == nil {
-			return errors.New("embedded validator exports are incomplete")
+			return wasmhost.Diagnose(wasmhost.DiagnosticABIViolation, errors.New("embedded validator exports are incomplete"))
 		}
 		queryLength := uint64(len(query)) // #nosec G115 -- string lengths are non-negative and widened for the Wasm ABI.
 		queryAllocation, err := alloc.Call(callCtx, queryLength)
 		if err != nil {
-			return fmt.Errorf("allocate validator query: %w", err)
+			return wasmhost.DiagnoseContextOr(callCtx, wasmhost.DiagnosticMemoryViolation, fmt.Errorf("allocate validator query: %w", err))
 		}
 		resultAllocation, err := alloc.Call(callCtx, staticValidatorResultSize)
 		if err != nil {
-			return fmt.Errorf("allocate validator result: %w", err)
+			return wasmhost.DiagnoseContextOr(callCtx, wasmhost.DiagnosticMemoryViolation, fmt.Errorf("allocate validator result: %w", err))
 		}
 		queryPointer, err := wasmhost.Pointer(queryAllocation, "validator query allocation")
 		if err != nil {
@@ -98,22 +98,22 @@ func runStaticValidator(ctx context.Context, query string, maxRows int) (staticV
 			return err
 		}
 		if !module.Memory().Write(queryPointer, []byte(query)) {
-			return errors.New("write validator query memory")
+			return wasmhost.Diagnose(wasmhost.DiagnosticMemoryViolation, errors.New("write validator query memory"))
 		}
 		maxRowCount := uint64(maxRows) // #nosec G115 -- NewValidator normalizes MaxRows to a positive value.
 		status, err := validate.Call(callCtx, uint64(queryPointer), queryLength, maxRowCount, uint64(resultPointer))
 		if err != nil {
-			return fmt.Errorf("execute static validator: %w", err)
+			return wasmhost.DiagnoseContextOr(callCtx, wasmhost.DiagnosticMemoryViolation, fmt.Errorf("execute static validator: %w", err))
 		}
 		if len(status) != 1 || status[0] != uint64(staticValidatorStatusSuccess) {
-			return fmt.Errorf("static validator status = %v", status)
+			return wasmhost.Diagnose(wasmhost.DiagnosticGuestStatus, fmt.Errorf("static validator status = %v", status))
 		}
 		result, ok := module.Memory().Read(resultPointer, staticValidatorResultSize)
 		if !ok {
-			return errors.New("read validator result memory")
+			return wasmhost.Diagnose(wasmhost.DiagnosticMemoryViolation, errors.New("read validator result memory"))
 		}
 		if reserved := binary.LittleEndian.Uint32(result[4:8]); reserved != 0 {
-			return fmt.Errorf("static validator reserved field = %d", reserved)
+			return wasmhost.Diagnose(wasmhost.DiagnosticMemoryViolation, fmt.Errorf("static validator reserved field = %d", reserved))
 		}
 		validation = staticValidation{
 			decision: staticValidatorDecision(binary.LittleEndian.Uint32(result[0:4])),
@@ -121,7 +121,7 @@ func runStaticValidator(ctx context.Context, query string, maxRows int) (staticV
 			detail:   binary.LittleEndian.Uint64(result[16:24]),
 		}
 		if validation.decision > staticValidatorQueryTooLarge {
-			return fmt.Errorf("unknown static validator decision %d", validation.decision)
+			return wasmhost.Diagnose(wasmhost.DiagnosticOutputInvalid, fmt.Errorf("unknown static validator decision %d", validation.decision))
 		}
 		return nil
 	})

--- a/internal/graphagent/staticvalidator_abi_test.go
+++ b/internal/graphagent/staticvalidator_abi_test.go
@@ -3,6 +3,7 @@ package graphagent
 import (
 	"bufio"
 	"context"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
@@ -10,7 +11,18 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/writer/cerebro/internal/wasmhost"
 )
+
+func TestStaticValidatorReportsCanceledDiagnostic(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := runStaticValidator(ctx, "MATCH (e:Entity {tenant_id:$tenant_id}) RETURN e LIMIT 1", 10)
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, wasmhost.ErrCanceled) {
+		t.Fatalf("runStaticValidator() error = %v, want cancellation diagnostic", err)
+	}
+}
 
 func TestStaticValidatorWasmMatchesABIGoldenCases(t *testing.T) {
 	file, err := os.Open("staticvalidator/testdata/abi_golden.tsv")

--- a/internal/mitre/evaluator.go
+++ b/internal/mitre/evaluator.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/writer/cerebro/internal/wasmhost"
 	"github.com/writer/cerebro/internal/wasmjson"
 )
 
@@ -87,7 +88,7 @@ func EvaluateContext(ctx context.Context, input ContextInput) (Context, error) {
 	}
 	var result Context
 	if err := json.Unmarshal(output, &result); err != nil {
-		return Context{}, fmt.Errorf("%w: decode response: %w", ErrEvaluatorUnavailable, err)
+		return Context{}, wasmhost.Diagnose(wasmhost.DiagnosticOutputInvalid, fmt.Errorf("%w: decode response: %w", ErrEvaluatorUnavailable, err))
 	}
 	if result.AttackTactics == nil {
 		result.AttackTactics = []AttackTactic{}

--- a/internal/mitre/evaluator_parity_test.go
+++ b/internal/mitre/evaluator_parity_test.go
@@ -6,11 +6,22 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/writer/cerebro/internal/wasmhost"
 	"github.com/writer/cerebro/internal/wasmjson"
 	"github.com/writer/cerebro/internal/wasmjson/wasmjsontest"
 )
 
 const contextEvaluatorFuzzMaxInput = 64 << 10
+
+func TestContextEvaluatorReportsCanceledDiagnostic(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := runContextEvaluator(ctx, []byte(`{}`))
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, wasmhost.ErrCanceled) {
+		t.Fatalf("runContextEvaluator() error = %v, want cancellation diagnostic", err)
+	}
+}
 
 //go:embed testdata/wasmjson/*.json
 var contextEvaluatorCorpus embed.FS
@@ -68,6 +79,21 @@ func TestContextEvaluatorRejectsMalformedAndOversizedInput(t *testing.T) {
 	}
 	if !errors.Is(err, wasmjson.ErrInputTooLarge) {
 		t.Fatalf("runContextEvaluator(oversized) error = %v; want ErrInputTooLarge", err)
+	}
+}
+
+func BenchmarkContextEvaluator(b *testing.B) {
+	ctx := context.Background()
+	payload := []byte(`{"attack_tactic_values":["TA0001","Initial Access"],"attack_technique_values":["T1190 Exploit Public-Facing Application"],"defend_artifact_values":["d3f:Credential"]}`)
+	if _, err := runContextEvaluator(ctx, payload); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := runContextEvaluator(ctx, payload); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/internal/sourcecoverage/evaluator.go
+++ b/internal/sourcecoverage/evaluator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/wasmhost"
 	"github.com/writer/cerebro/internal/wasmjson"
 )
 
@@ -85,7 +86,7 @@ func evaluateCoverage(ctx context.Context, contracts []sourcecdk.CoverageContrac
 	}
 	var response coverageEvaluationResponse
 	if err := json.Unmarshal(result, &response); err != nil {
-		return nil, fmt.Errorf("%w: decode response: %w", ErrEvaluatorUnavailable, err)
+		return nil, wasmhost.Diagnose(wasmhost.DiagnosticOutputInvalid, fmt.Errorf("%w: decode response: %w", ErrEvaluatorUnavailable, err))
 	}
 	if response.Records == nil {
 		response.Records = []Record{}

--- a/internal/sourcecoverage/evaluator_parity_test.go
+++ b/internal/sourcecoverage/evaluator_parity_test.go
@@ -11,10 +11,21 @@ import (
 	"testing"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/wasmhost"
 	"github.com/writer/cerebro/internal/wasmjson/wasmjsontest"
 )
 
 const coverageEvaluatorFuzzMaxInput = 64 << 10
+
+func TestCoverageEvaluatorReportsCanceledDiagnostic(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := runCoverageEvaluator(ctx, []byte(`{"contracts":[],"observations":[],"options":{}}`))
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, wasmhost.ErrCanceled) {
+		t.Fatalf("runCoverageEvaluator() error = %v, want cancellation diagnostic", err)
+	}
+}
 
 //go:embed testdata/wasmjson/*.json
 var coverageEvaluatorCorpus embed.FS
@@ -74,6 +85,21 @@ func TestCoverageEvaluatorSupportsConcurrentCalls(t *testing.T) {
 	close(errors)
 	for err := range errors {
 		t.Errorf("concurrent Evaluate() error = %v", err)
+	}
+}
+
+func BenchmarkCoverageEvaluator(b *testing.B) {
+	ctx := context.Background()
+	payload := []byte(`{"contracts":[{"source_id":"aws","dimensions":[{"id":"users","type":"entity_family","title":"Users","families":["user"],"support":"supported"}]}],"observations":[{"runtime_id":"runtime-a","source_id":"aws","family":"user","status":"healthy"}],"options":{}}`)
+	if _, err := runCoverageEvaluator(ctx, payload); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := runCoverageEvaluator(ctx, payload); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/internal/sourceprojection/panopticon_resources_host.go
+++ b/internal/sourceprojection/panopticon_resources_host.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/writer/cerebro/internal/wasmhost"
 	"github.com/writer/cerebro/internal/wasmjson"
 )
 
@@ -38,10 +39,10 @@ var panopticonResourcesEvaluator = wasmjson.New(wasmjson.Config{
 
 func panopticonResourceObjectsWasm(ctx context.Context, payload []byte) ([]map[string]any, error) {
 	if ctx == nil {
-		return nil, fmt.Errorf("%w: context is required", errPanopticonResourceExtractorUnavailable)
+		return nil, wasmhost.Diagnose(wasmhost.DiagnosticInvalidInput, fmt.Errorf("%w: context is required", errPanopticonResourceExtractorUnavailable))
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("%w: %w", errPanopticonResourceExtractorUnavailable, err)
+		return nil, wasmhost.DiagnoseContext(ctx, fmt.Errorf("%w: %w", errPanopticonResourceExtractorUnavailable, err))
 	}
 	if len(payload) == 0 {
 		return nil, nil
@@ -52,10 +53,17 @@ func panopticonResourceObjectsWasm(ctx context.Context, payload []byte) ([]map[s
 	}
 	var resources []map[string]any
 	if err := json.Unmarshal(output, &resources); err != nil {
-		return nil, fmt.Errorf("%w: decode response: %w", errPanopticonResourceExtractorUnavailable, err)
+		return nil, wasmhost.Diagnose(wasmhost.DiagnosticOutputInvalid, fmt.Errorf("%w: decode response: %w", errPanopticonResourceExtractorUnavailable, err))
 	}
-	if len(resources) > maxPanopticonResourceObjects {
-		return nil, fmt.Errorf("%w: returned %d objects; maximum is %d", errPanopticonResourceExtractorUnavailable, len(resources), maxPanopticonResourceObjects)
+	if err := validatePanopticonResourceCount(resources); err != nil {
+		return nil, err
 	}
 	return resources, nil
+}
+
+func validatePanopticonResourceCount(resources []map[string]any) error {
+	if len(resources) <= maxPanopticonResourceObjects {
+		return nil
+	}
+	return wasmhost.Diagnose(wasmhost.DiagnosticOutputInvalid, fmt.Errorf("%w: returned %d objects; maximum is %d", errPanopticonResourceExtractorUnavailable, len(resources), maxPanopticonResourceObjects))
 }

--- a/internal/sourceprojection/panopticon_resources_host_test.go
+++ b/internal/sourceprojection/panopticon_resources_host_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/writer/cerebro/internal/wasmhost"
 	"github.com/writer/cerebro/internal/wasmjson"
 	"github.com/writer/cerebro/internal/wasmjson/wasmjsontest"
 )
@@ -148,6 +149,18 @@ func TestPanopticonResourceObjectsWasmAcceptsEmptyPayloadWithLiveContext(t *test
 	}
 }
 
+func TestValidatePanopticonResourceCountClassifiesOversizedOutput(t *testing.T) {
+	t.Parallel()
+	resources := make([]map[string]any, maxPanopticonResourceObjects+1)
+	err := validatePanopticonResourceCount(resources)
+	if !errors.Is(err, errPanopticonResourceExtractorUnavailable) {
+		t.Fatalf("validatePanopticonResourceCount() error = %v, want extractor unavailable", err)
+	}
+	if !errors.Is(err, wasmhost.ErrOutputInvalid) {
+		t.Fatalf("validatePanopticonResourceCount() error = %v, want output invalid", err)
+	}
+}
+
 func TestPanopticonResourceObjectsWasmHonorsCanceledContextForEmptyPayload(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -156,6 +169,24 @@ func TestPanopticonResourceObjectsWasmHonorsCanceledContextForEmptyPayload(t *te
 	_, err := panopticonResourceObjectsWasm(ctx, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("canceled extraction error = %v, want %v", err, context.Canceled)
+	}
+	if !errors.Is(err, wasmhost.ErrCanceled) {
+		t.Fatalf("canceled extraction error = %v, want Wasm cancellation diagnostic", err)
+	}
+}
+
+func BenchmarkPanopticonResourceExtractor(b *testing.B) {
+	ctx := context.Background()
+	payload := []byte(`{"alerts":[{"resourceResults":[{"ResourceID":"resource-1","ResourceName":"audit"}]}],"affectedResources":["arn:aws:s3:::audit"]}`)
+	if _, err := panopticonResourceObjectsWasm(ctx, payload); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := panopticonResourceObjectsWasm(ctx, payload); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/internal/wasmhost/diagnostic.go
+++ b/internal/wasmhost/diagnostic.go
@@ -1,0 +1,116 @@
+package wasmhost
+
+import (
+	"context"
+	"errors"
+)
+
+// DiagnosticKind identifies a stable class of embedded Wasm host failure.
+type DiagnosticKind string
+
+const (
+	DiagnosticInvalidInput    DiagnosticKind = "invalid_input"
+	DiagnosticABIViolation    DiagnosticKind = "abi_violation"
+	DiagnosticMemoryViolation DiagnosticKind = "memory_violation"
+	DiagnosticGuestStatus     DiagnosticKind = "guest_status"
+	DiagnosticOutputInvalid   DiagnosticKind = "output_invalid"
+	DiagnosticTimeout         DiagnosticKind = "timeout"
+	DiagnosticCanceled        DiagnosticKind = "canceled"
+)
+
+var (
+	ErrInvalidInput    = errors.New("embedded Wasm input is invalid")
+	ErrABIViolation    = errors.New("embedded Wasm ABI contract was violated")
+	ErrMemoryViolation = errors.New("embedded Wasm memory contract was violated")
+	ErrGuestStatus     = errors.New("embedded Wasm guest returned a failure status")
+	ErrOutputInvalid   = errors.New("embedded Wasm output is invalid")
+	ErrTimeout         = errors.New("embedded Wasm call timed out")
+	ErrCanceled        = errors.New("embedded Wasm call was canceled")
+)
+
+// Diagnostic adds a machine-readable kind without changing the rendered error.
+// Cause remains available through errors.Is and errors.As.
+type Diagnostic struct {
+	kind  DiagnosticKind
+	cause error
+}
+
+func (d *Diagnostic) Error() string        { return d.cause.Error() }
+func (d *Diagnostic) Unwrap() error        { return d.cause }
+func (d *Diagnostic) Kind() DiagnosticKind { return d.kind }
+
+func (d *Diagnostic) Is(target error) bool {
+	return target == sentinelForKind(d.kind)
+}
+
+// Diagnose assigns kind to err. It returns nil when err is nil and does not
+// replace an existing Wasm diagnostic.
+func Diagnose(kind DiagnosticKind, err error) error {
+	if err == nil {
+		return nil
+	}
+	var diagnostic *Diagnostic
+	if errors.As(err, &diagnostic) {
+		return err
+	}
+	return &Diagnostic{kind: kind, cause: err}
+}
+
+// DiagnoseContext assigns cancellation and deadline kinds when the error or
+// active context reports either state. Other errors are returned unchanged.
+func DiagnoseContext(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, context.Canceled) || ctx != nil && errors.Is(ctx.Err(), context.Canceled):
+		return &Diagnostic{kind: DiagnosticCanceled, cause: err}
+	case errors.Is(err, context.DeadlineExceeded) || ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return &Diagnostic{kind: DiagnosticTimeout, cause: err}
+	default:
+		return err
+	}
+}
+
+// DiagnoseContextOr uses a cancellation or deadline kind when present and
+// otherwise assigns fallback.
+func DiagnoseContextOr(ctx context.Context, fallback DiagnosticKind, err error) error {
+	if err == nil {
+		return nil
+	}
+	contextual := DiagnoseContext(ctx, err)
+	if _, ok := DiagnosticKindOf(contextual); ok {
+		return contextual
+	}
+	return Diagnose(fallback, err)
+}
+
+// DiagnosticKindOf returns the first embedded Wasm diagnostic kind in err.
+func DiagnosticKindOf(err error) (DiagnosticKind, bool) {
+	var diagnostic *Diagnostic
+	if !errors.As(err, &diagnostic) {
+		return "", false
+	}
+	return diagnostic.kind, true
+}
+
+func sentinelForKind(kind DiagnosticKind) error {
+	switch kind {
+	case DiagnosticInvalidInput:
+		return ErrInvalidInput
+	case DiagnosticABIViolation:
+		return ErrABIViolation
+	case DiagnosticMemoryViolation:
+		return ErrMemoryViolation
+	case DiagnosticGuestStatus:
+		return ErrGuestStatus
+	case DiagnosticOutputInvalid:
+		return ErrOutputInvalid
+	case DiagnosticTimeout:
+		return ErrTimeout
+	case DiagnosticCanceled:
+		return ErrCanceled
+	default:
+		return nil
+	}
+}

--- a/internal/wasmhost/runtime.go
+++ b/internal/wasmhost/runtime.go
@@ -64,13 +64,13 @@ func New(config Config) *Runtime {
 // Run invokes call with a fresh module instance governed by the configured timeout.
 func (r *Runtime) Run(ctx context.Context, call func(context.Context, api.Module) error) error {
 	if r == nil {
-		return fmt.Errorf("%w: runtime is required", ErrInvalidConfig)
+		return Diagnose(DiagnosticInvalidInput, fmt.Errorf("%w: runtime is required", ErrInvalidConfig))
 	}
 	if ctx == nil {
-		return r.errorfWith(ErrInvalidConfig, "context is required")
+		return Diagnose(DiagnosticInvalidInput, r.errorfWith(ErrInvalidConfig, "context is required"))
 	}
 	if call == nil {
-		return r.errorfWith(ErrInvalidConfig, "call function is required")
+		return Diagnose(DiagnosticInvalidInput, r.errorfWith(ErrInvalidConfig, "call function is required"))
 	}
 	r.once.Do(func() {
 		r.initialize(ctx)
@@ -83,12 +83,12 @@ func (r *Runtime) Run(ctx context.Context, call func(context.Context, api.Module
 	defer cancel()
 	module, err := r.runtime.InstantiateModule(callCtx, r.compiled, moduleConfig())
 	if err != nil {
-		return r.wrap("instantiate module", err)
+		return DiagnoseContextOr(callCtx, DiagnosticMemoryViolation, r.wrap("instantiate module", err))
 	}
 	defer func() {
 		_ = module.Close(callCtx)
 	}()
-	return call(callCtx, module)
+	return DiagnoseContext(callCtx, call(callCtx, module))
 }
 
 // Pointer returns the single Wasm32 pointer produced by an allocation call.
@@ -98,10 +98,10 @@ func Pointer(results []uint64, operation string) (uint32, error) {
 		operation = "allocation"
 	}
 	if len(results) != 1 {
-		return 0, fmt.Errorf("%s returned %d values; want 1", operation, len(results))
+		return 0, Diagnose(DiagnosticMemoryViolation, fmt.Errorf("%s returned %d values; want 1", operation, len(results)))
 	}
 	if results[0] > math.MaxUint32 {
-		return 0, fmt.Errorf("%s pointer exceeds the Wasm32 address space", operation)
+		return 0, Diagnose(DiagnosticMemoryViolation, fmt.Errorf("%s pointer exceeds the Wasm32 address space", operation))
 	}
 	return uint32(results[0]), nil // #nosec G115 -- the value is bounded to MaxUint32 above.
 }
@@ -117,7 +117,7 @@ func (r *Runtime) initialize(ctx context.Context) {
 	r.runtime = wazero.NewRuntimeWithConfig(initCtx, config)
 	r.compiled, r.err = r.runtime.CompileModule(initCtx, r.config.Module)
 	if r.err != nil {
-		r.err = r.wrap("compile module", r.err)
+		r.err = DiagnoseContextOr(initCtx, DiagnosticABIViolation, r.wrap("compile module", r.err))
 		r.closeRuntime(initCtx)
 		return
 	}
@@ -128,7 +128,7 @@ func (r *Runtime) initialize(ctx context.Context) {
 	}
 	module, err := r.runtime.InstantiateModule(initCtx, r.compiled, moduleConfig())
 	if err != nil {
-		r.err = r.wrap("instantiate module for ABI check", err)
+		r.err = DiagnoseContextOr(initCtx, DiagnosticMemoryViolation, r.wrap("instantiate module for ABI check", err))
 		r.closeRuntime(initCtx)
 		return
 	}
@@ -138,42 +138,46 @@ func (r *Runtime) initialize(ctx context.Context) {
 	versionFunction := module.ExportedFunction(r.config.ABIVersionExport)
 	version, err := versionFunction.Call(initCtx)
 	if err != nil {
-		r.err = r.wrap("read ABI version", err)
+		r.err = DiagnoseContextOr(initCtx, DiagnosticABIViolation, r.wrap("read ABI version", err))
 		r.closeRuntime(initCtx)
 		return
 	}
 	if len(version) != 1 || version[0] != r.config.ABIVersion {
-		r.err = r.errorf("ABI version = %v; want %d", version, r.config.ABIVersion)
+		r.err = Diagnose(DiagnosticABIViolation, r.errorf("ABI version = %v; want %d", version, r.config.ABIVersion))
 		r.closeRuntime(initCtx)
 	}
 }
 
 func (r *Runtime) validateConfig() error {
+	var err error
 	switch {
 	case r.config.Name == "":
-		return r.errorfWith(ErrInvalidConfig, "name is required")
+		err = r.errorfWith(ErrInvalidConfig, "name is required")
 	case len(r.config.Module) == 0:
-		return r.errorfWith(ErrInvalidConfig, "module is empty")
+		err = r.errorfWith(ErrInvalidConfig, "module is empty")
 	case r.config.ABIVersionExport == "":
-		return r.errorfWith(ErrInvalidConfig, "ABI version export is required")
+		err = r.errorfWith(ErrInvalidConfig, "ABI version export is required")
 	case len(r.config.Functions) == 0:
-		return r.errorfWith(ErrInvalidConfig, "required functions are empty")
+		err = r.errorfWith(ErrInvalidConfig, "required functions are empty")
 	case r.config.MemoryLimitPages == 0:
-		return r.errorfWith(ErrInvalidConfig, "memory limit must be positive")
+		err = r.errorfWith(ErrInvalidConfig, "memory limit must be positive")
 	case r.config.MemoryLimitPages > wasm32MaxMemoryPages:
-		return r.errorfWith(ErrInvalidConfig, "memory limit must not exceed %d pages", wasm32MaxMemoryPages)
+		err = r.errorfWith(ErrInvalidConfig, "memory limit must not exceed %d pages", wasm32MaxMemoryPages)
 	case r.config.InitializeTimeout <= 0:
-		return r.errorfWith(ErrInvalidConfig, "initialization timeout must be positive")
+		err = r.errorfWith(ErrInvalidConfig, "initialization timeout must be positive")
 	case r.config.CallTimeout <= 0:
-		return r.errorfWith(ErrInvalidConfig, "call timeout must be positive")
+		err = r.errorfWith(ErrInvalidConfig, "call timeout must be positive")
+	}
+	if err != nil {
+		return Diagnose(DiagnosticInvalidInput, err)
 	}
 	seen := make(map[string]struct{}, len(r.config.Functions))
 	for _, function := range r.config.Functions {
 		if function.Name == "" {
-			return r.errorfWith(ErrInvalidConfig, "required function name is empty")
+			return Diagnose(DiagnosticInvalidInput, r.errorfWith(ErrInvalidConfig, "required function name is empty"))
 		}
 		if _, ok := seen[function.Name]; ok {
-			return r.errorfWith(ErrInvalidConfig, "required function %q is duplicated", function.Name)
+			return Diagnose(DiagnosticInvalidInput, r.errorfWith(ErrInvalidConfig, "required function %q is duplicated", function.Name))
 		}
 		seen[function.Name] = struct{}{}
 	}
@@ -182,10 +186,10 @@ func (r *Runtime) validateConfig() error {
 
 func (r *Runtime) validateABI() error {
 	if len(r.compiled.ImportedFunctions()) != 0 || len(r.compiled.ImportedMemories()) != 0 {
-		return r.errorf("module must not import functions or memory")
+		return Diagnose(DiagnosticABIViolation, r.errorf("module must not import functions or memory"))
 	}
 	if _, ok := r.compiled.ExportedMemories()["memory"]; !ok {
-		return r.errorf("memory export is missing")
+		return Diagnose(DiagnosticMemoryViolation, r.errorf("memory export is missing"))
 	}
 	exports := r.compiled.ExportedFunctions()
 	required := append([]Function{{
@@ -195,10 +199,10 @@ func (r *Runtime) validateABI() error {
 	for _, expected := range required {
 		definition, ok := exports[expected.Name]
 		if !ok {
-			return r.errorf("export %q is missing", expected.Name)
+			return Diagnose(DiagnosticABIViolation, r.errorf("export %q is missing", expected.Name))
 		}
 		if !slices.Equal(definition.ParamTypes(), expected.Params) || !slices.Equal(definition.ResultTypes(), expected.Results) {
-			return r.errorf("export %q has an incompatible signature", expected.Name)
+			return Diagnose(DiagnosticABIViolation, r.errorf("export %q has an incompatible signature", expected.Name))
 		}
 	}
 	return nil

--- a/internal/wasmhost/runtime_test.go
+++ b/internal/wasmhost/runtime_test.go
@@ -18,6 +18,68 @@ func TestRuntimeRejectsInvalidConfiguration(t *testing.T) {
 	if !errors.Is(err, ErrInvalidConfig) {
 		t.Fatalf("Run() error = %v, want %v", err, ErrInvalidConfig)
 	}
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("Run() error = %v, want %v", err, ErrInvalidInput)
+	}
+}
+
+func TestDiagnosticKindsPreserveCauses(t *testing.T) {
+	t.Parallel()
+	cause := errors.New("stable operator message")
+	for _, test := range []struct {
+		kind DiagnosticKind
+		want error
+	}{
+		{DiagnosticInvalidInput, ErrInvalidInput},
+		{DiagnosticABIViolation, ErrABIViolation},
+		{DiagnosticMemoryViolation, ErrMemoryViolation},
+		{DiagnosticGuestStatus, ErrGuestStatus},
+		{DiagnosticOutputInvalid, ErrOutputInvalid},
+		{DiagnosticTimeout, ErrTimeout},
+		{DiagnosticCanceled, ErrCanceled},
+	} {
+		err := Diagnose(test.kind, cause)
+		if !errors.Is(err, cause) || !errors.Is(err, test.want) {
+			t.Errorf("Diagnose(%q) = %v; cause or sentinel not preserved", test.kind, err)
+		}
+		if got, ok := DiagnosticKindOf(err); !ok || got != test.kind {
+			t.Errorf("DiagnosticKindOf(Diagnose(%q)) = (%q, %t)", test.kind, got, ok)
+		}
+	}
+}
+
+func TestDiagnoseContextKinds(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		context func() context.Context
+		cause   error
+		want    error
+	}{
+		{
+			name: "canceled context",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			cause: errors.New("guest stopped"),
+			want:  ErrCanceled,
+		},
+		{
+			name:    "deadline cause",
+			context: context.Background,
+			cause:   context.DeadlineExceeded,
+			want:    ErrTimeout,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if err := DiagnoseContext(test.context(), test.cause); !errors.Is(err, test.want) || !errors.Is(err, test.cause) {
+				t.Fatalf("DiagnoseContext() error = %v, want %v and original cause", err, test.want)
+			}
+		})
+	}
 }
 
 func TestRuntimeRejectsMemoryLimitAboveWasm32Maximum(t *testing.T) {
@@ -55,8 +117,9 @@ func TestRuntimeValidatesABIVersionAndSignatures(t *testing.T) {
 			config := testRuntimeConfig()
 			test.mutate(&config)
 			runtime := New(config)
-			if err := runtime.Run(context.Background(), func(context.Context, api.Module) error { return nil }); err == nil {
-				t.Fatal("Run() error = nil")
+			err := runtime.Run(context.Background(), func(context.Context, api.Module) error { return nil })
+			if !errors.Is(err, ErrABIViolation) {
+				t.Fatalf("Run() error = %v, want %v", err, ErrABIViolation)
 			}
 		})
 	}
@@ -124,7 +187,26 @@ func TestPointer(t *testing.T) {
 			if (err != nil) != test.wantErr || got != test.want {
 				t.Fatalf("Pointer() = (%d, %v), want (%d, error=%t)", got, err, test.want, test.wantErr)
 			}
+			if test.wantErr && !errors.Is(err, ErrMemoryViolation) {
+				t.Fatalf("Pointer() error = %v, want %v", err, ErrMemoryViolation)
+			}
 		})
+	}
+}
+
+func BenchmarkRuntimeRun(b *testing.B) {
+	runtime := New(testRuntimeConfig())
+	ctx := context.Background()
+	call := func(context.Context, api.Module) error { return nil }
+	if err := runtime.Run(ctx, call); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := runtime.Run(ctx, call); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/internal/wasmjson/evaluator.go
+++ b/internal/wasmjson/evaluator.go
@@ -84,11 +84,11 @@ func (e *Evaluator) Evaluate(ctx context.Context, payload []byte) ([]byte, error
 		allocate := module.ExportedFunction(e.config.AllocateExport)
 		evaluate := module.ExportedFunction(e.config.EvaluateExport)
 		if allocate == nil || evaluate == nil || module.Memory() == nil {
-			return e.errorf("exports are incomplete")
+			return wasmhost.Diagnose(wasmhost.DiagnosticABIViolation, e.errorf("exports are incomplete"))
 		}
 		inputAllocation, err := allocate.Call(callCtx, uint64(len(payload)))
 		if err != nil {
-			return e.wrap("allocate input", err)
+			return wasmhost.DiagnoseContextOr(callCtx, wasmhost.DiagnosticMemoryViolation, e.wrap("allocate input", err))
 		}
 		inputPointer, err := e.pointer(inputAllocation, "input allocation")
 		if err != nil {
@@ -96,40 +96,40 @@ func (e *Evaluator) Evaluate(ctx context.Context, payload []byte) ([]byte, error
 		}
 		descriptorAllocation, err := allocate.Call(callCtx, descriptorSize)
 		if err != nil {
-			return e.wrap("allocate result descriptor", err)
+			return wasmhost.DiagnoseContextOr(callCtx, wasmhost.DiagnosticMemoryViolation, e.wrap("allocate result descriptor", err))
 		}
 		descriptorPointer, err := e.pointer(descriptorAllocation, "result descriptor allocation")
 		if err != nil {
 			return err
 		}
 		if !module.Memory().Write(inputPointer, payload) {
-			return e.errorf("write input memory")
+			return wasmhost.Diagnose(wasmhost.DiagnosticMemoryViolation, e.errorf("write input memory"))
 		}
 		status, err := evaluate.Call(callCtx, uint64(inputPointer), uint64(len(payload)), uint64(descriptorPointer))
 		if err != nil {
-			return e.wrap("execute module", err)
+			return wasmhost.DiagnoseContextOr(callCtx, wasmhost.DiagnosticMemoryViolation, e.wrap("execute module", err))
 		}
 		if len(status) != 1 || status[0] != 0 {
-			return e.errorf("execution status = %v", status)
+			return wasmhost.Diagnose(wasmhost.DiagnosticGuestStatus, e.errorf("execution status = %v", status))
 		}
 		descriptor, ok := module.Memory().Read(descriptorPointer, descriptorSize)
 		if !ok {
-			return e.errorf("read result descriptor")
+			return wasmhost.Diagnose(wasmhost.DiagnosticMemoryViolation, e.errorf("read result descriptor"))
 		}
 		if resultStatus := binary.LittleEndian.Uint32(descriptor[0:4]); resultStatus != 0 {
-			return e.errorf("result status = %d", resultStatus)
+			return wasmhost.Diagnose(wasmhost.DiagnosticGuestStatus, e.errorf("result status = %d", resultStatus))
 		}
 		if reserved := binary.LittleEndian.Uint32(descriptor[12:16]); reserved != 0 {
-			return e.errorf("result reserved field = %d", reserved)
+			return wasmhost.Diagnose(wasmhost.DiagnosticMemoryViolation, e.errorf("result reserved field = %d", reserved))
 		}
 		outputPointer := binary.LittleEndian.Uint32(descriptor[4:8])
 		outputLength := binary.LittleEndian.Uint32(descriptor[8:12])
 		if outputLength > e.config.MaxOutputBytes {
-			return e.errorf("output is %d bytes; maximum is %d", outputLength, e.config.MaxOutputBytes)
+			return wasmhost.Diagnose(wasmhost.DiagnosticOutputInvalid, e.errorf("output is %d bytes; maximum is %d", outputLength, e.config.MaxOutputBytes))
 		}
 		outputBytes, ok := module.Memory().Read(outputPointer, outputLength)
 		if !ok {
-			return e.errorf("read output memory")
+			return wasmhost.Diagnose(wasmhost.DiagnosticMemoryViolation, e.errorf("read output memory"))
 		}
 		output = append([]byte(nil), outputBytes...)
 		return nil
@@ -141,30 +141,30 @@ func (e *Evaluator) Evaluate(ctx context.Context, payload []byte) ([]byte, error
 }
 
 func (e *Evaluator) validateConfig() error {
+	var err error
 	switch {
 	case e.config.Name == "":
-		return e.errorfWith(ErrInvalidConfig, "name is required")
+		err = e.errorfWith(ErrInvalidConfig, "name is required")
 	case len(e.config.Module) == 0:
-		return e.errorfWith(ErrInvalidConfig, "module is empty")
+		err = e.errorfWith(ErrInvalidConfig, "module is empty")
 	case e.config.ABIVersionExport == "":
-		return e.errorfWith(ErrInvalidConfig, "ABI version export is required")
+		err = e.errorfWith(ErrInvalidConfig, "ABI version export is required")
 	case e.config.AllocateExport == "":
-		return e.errorfWith(ErrInvalidConfig, "allocation export is required")
+		err = e.errorfWith(ErrInvalidConfig, "allocation export is required")
 	case e.config.EvaluateExport == "":
-		return e.errorfWith(ErrInvalidConfig, "evaluation export is required")
+		err = e.errorfWith(ErrInvalidConfig, "evaluation export is required")
 	case e.config.MemoryLimitPages == 0:
-		return e.errorfWith(ErrInvalidConfig, "memory limit must be positive")
+		err = e.errorfWith(ErrInvalidConfig, "memory limit must be positive")
 	case e.config.MaxInputBytes == 0:
-		return e.errorfWith(ErrInvalidConfig, "input limit must be positive")
+		err = e.errorfWith(ErrInvalidConfig, "input limit must be positive")
 	case e.config.MaxOutputBytes == 0:
-		return e.errorfWith(ErrInvalidConfig, "output limit must be positive")
+		err = e.errorfWith(ErrInvalidConfig, "output limit must be positive")
 	case e.config.InitializeTimeout <= 0:
-		return e.errorfWith(ErrInvalidConfig, "initialization timeout must be positive")
+		err = e.errorfWith(ErrInvalidConfig, "initialization timeout must be positive")
 	case e.config.CallTimeout <= 0:
-		return e.errorfWith(ErrInvalidConfig, "call timeout must be positive")
-	default:
-		return nil
+		err = e.errorfWith(ErrInvalidConfig, "call timeout must be positive")
 	}
+	return wasmhost.Diagnose(wasmhost.DiagnosticInvalidInput, err)
 }
 
 func (e *Evaluator) validatePayload(payload []byte) error {
@@ -180,7 +180,10 @@ func (e *Evaluator) validatePayload(payload []byte) error {
 func (e *Evaluator) pointer(results []uint64, operation string) (uint32, error) {
 	pointer, err := wasmhost.Pointer(results, operation)
 	if err != nil {
-		return 0, e.errorf("%s", err)
+		if e.config.Name == "" {
+			return 0, err
+		}
+		return 0, fmt.Errorf("%s: %w", e.config.Name, err)
 	}
 	return pointer, nil
 }
@@ -206,5 +209,5 @@ func (e *Evaluator) errorfWith(cause error, format string, args ...any) error {
 }
 
 func (e *Evaluator) inputTooLargeError(inputBytes, maxBytes uint64) error {
-	return e.errorfWith(ErrInputTooLarge, "input is %d bytes; maximum is %d", inputBytes, maxBytes)
+	return wasmhost.Diagnose(wasmhost.DiagnosticInvalidInput, e.errorfWith(ErrInputTooLarge, "input is %d bytes; maximum is %d", inputBytes, maxBytes))
 }

--- a/internal/wasmjson/evaluator_test.go
+++ b/internal/wasmjson/evaluator_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/writer/cerebro/internal/wasmhost"
 )
 
 func TestEvaluatorRejectsInvalidConfiguration(t *testing.T) {
@@ -14,6 +16,9 @@ func TestEvaluatorRejectsInvalidConfiguration(t *testing.T) {
 		_, err := evaluator.Evaluate(context.Background(), payload)
 		if !errors.Is(err, ErrInvalidConfig) {
 			t.Fatalf("Evaluate(%d bytes) error = %v; want %v", len(payload), err, ErrInvalidConfig)
+		}
+		if !errors.Is(err, wasmhost.ErrInvalidInput) {
+			t.Fatalf("Evaluate(%d bytes) error = %v; want typed invalid input", len(payload), err)
 		}
 	}
 }
@@ -27,6 +32,9 @@ func TestEvaluatorBoundsInputWithoutExposingPayload(t *testing.T) {
 	_, err := evaluator.Evaluate(context.Background(), []byte(marker))
 	if !errors.Is(err, ErrInputTooLarge) {
 		t.Fatalf("Evaluate() error = %v; want %v", err, ErrInputTooLarge)
+	}
+	if !errors.Is(err, wasmhost.ErrInvalidInput) {
+		t.Fatalf("Evaluate() error = %v; want typed invalid input", err)
 	}
 }
 
@@ -45,6 +53,15 @@ func TestEvaluatorCachesInitializationError(t *testing.T) {
 			t.Fatalf("Evaluate() error = %v; want cached error %v", err, cached)
 		}
 		cached = err
+	}
+}
+
+func TestEvaluatorPointerPreservesMemoryViolation(t *testing.T) {
+	t.Parallel()
+	evaluator := New(testConfig())
+	_, err := evaluator.pointer(nil, "test allocation")
+	if !errors.Is(err, wasmhost.ErrMemoryViolation) {
+		t.Fatalf("pointer() error = %v; want typed memory violation", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- add stable typed diagnostic kinds and errors.Is sentinels for invalid input, ABI and memory violations, guest status, invalid output, timeout, and cancellation
- classify failures in the shared host, JSON evaluator, static validator, source coverage, MITRE, and Panopticon adapters while preserving existing rendered errors and wrapped causes
- pin cargo-llvm-cov 0.8.7 and enforce a 90% Rust workspace line-coverage floor through the existing Rust changed-path lane
- add bounded 20-iteration benchmark smoke runs for the shared host and four validator or evaluator paths, with output recorded in tmp/rust-wasm-benchmark.txt and no latency pass/fail threshold
- document the coverage exclusion and local validation commands

## Coverage evidence

The measured Rust workspace line baseline is 90.09%. The gate fails below 90%. Only wasm_abi.rs target-specific allocation and descriptor glue is excluded because native Rust coverage cannot execute that Wasm export boundary; validator and evaluator logic remains included.

## Benchmark smoke

Local Apple M4 Pro output for 20 iterations:

- shared host invocation: 12,604 ns/op
- static validator: 7,328,977 ns/op
- source coverage evaluator: 300,050 ns/op
- MITRE evaluator: 3,805,856 ns/op
- Panopticon extractor: 752,842 ns/op

These values are recorded evidence, not CI thresholds.

## Validation

- affected Go package lint, tests, and race tests
- make rust-workspace-policy rust-doc-check rust-deny graph-action-check rust-wasm-check
- make docs-drift-check check-structural check-structural-test check-arch
- python3 -m unittest discover -s scripts/tests
- actionlint .github/workflows/*.yml
- embedded Wasm manifest and artifact identity checks