### PR TITLE
Preserve source-specific checkpoint cursors

### DIFF
--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -1117,8 +1117,11 @@ func checkpointWithoutContinuationToken(checkpoint *cerebrov1.SourceCheckpoint) 
 	if opaque == "" {
 		return terminal
 	}
-	envelope, ok := sourcecdk.DecodeCursorEnvelope(opaque)
+	envelope, ok := decodeStandardCursorEnvelope(opaque)
 	if !ok {
+		if sourcecdk.ResumableCursorOpaque(opaque) {
+			return terminal
+		}
 		terminal.CursorOpaque = ""
 		return terminal
 	}
@@ -1136,8 +1139,8 @@ func checkpointWithoutContinuationToken(checkpoint *cerebrov1.SourceCheckpoint) 
 }
 
 func mergeEqualWatermarkCheckpoint(existing *cerebrov1.SourceCheckpoint, next *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
-	existingEnvelope, existingOK := sourcecdk.DecodeCursorEnvelope(existing.GetCursorOpaque())
-	nextEnvelope, nextOK := sourcecdk.DecodeCursorEnvelope(next.GetCursorOpaque())
+	existingEnvelope, existingOK := decodeStandardCursorEnvelope(existing.GetCursorOpaque())
+	nextEnvelope, nextOK := decodeStandardCursorEnvelope(next.GetCursorOpaque())
 	if !existingOK || !nextOK {
 		return next
 	}
@@ -1155,6 +1158,21 @@ func mergeEqualWatermarkCheckpoint(existing *cerebrov1.SourceCheckpoint, next *c
 	merged := cloneCheckpoint(next)
 	merged.CursorOpaque = opaque
 	return merged
+}
+
+func decodeStandardCursorEnvelope(opaque string) (sourcecdk.CursorEnvelope, bool) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(strings.TrimSpace(opaque)), &fields); err != nil {
+		return sourcecdk.CursorEnvelope{}, false
+	}
+	for field := range fields {
+		switch field {
+		case "version", "source", "family", "mode", "resumable_checkpoint", "token", "watermark", "boundary_ids", "extra":
+		default:
+			return sourcecdk.CursorEnvelope{}, false
+		}
+	}
+	return sourcecdk.DecodeCursorEnvelope(opaque)
 }
 
 func mergeCursorEnvelopeExtra(existing map[string]string, next map[string]string) map[string]string {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1905,6 +1905,37 @@ func TestSyncRuntimeMergesEqualWatermarkCheckpointBoundaries(t *testing.T) {
 	}
 }
 
+func TestMergeEqualWatermarkCheckpointPreservesProviderCursor(t *testing.T) {
+	watermark := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	existingCursor := `{"source":"cosmo.message","resumable_checkpoint":true,"since":"2026-06-14T00:00:00Z","until":"2026-06-15T00:00:00Z","event_type_index":1,"offset":100}`
+	nextCursor := `{"source":"cosmo.message","resumable_checkpoint":true,"since":"2026-06-15T00:00:00Z","until":"2026-06-16T00:00:00Z","event_type_index":2,"offset":200}`
+
+	merged := mergeEqualWatermarkCheckpoint(
+		&cerebrov1.SourceCheckpoint{
+			Watermark:    timestamppb.New(watermark),
+			CursorOpaque: existingCursor,
+		},
+		&cerebrov1.SourceCheckpoint{
+			Watermark:    timestamppb.New(watermark),
+			CursorOpaque: nextCursor,
+		},
+	)
+
+	if got := merged.GetCursorOpaque(); got != nextCursor {
+		t.Fatalf("merged provider cursor = %q, want %q", got, nextCursor)
+	}
+}
+
+func TestCheckpointWithoutContinuationTokenPreservesProviderCursor(t *testing.T) {
+	providerCursor := `{"source":"provider.events","resumable_checkpoint":true,"since":"2026-06-15T00:00:00Z","token":"provider-token"}`
+
+	terminal := checkpointWithoutContinuationToken(&cerebrov1.SourceCheckpoint{CursorOpaque: providerCursor})
+
+	if got := terminal.GetCursorOpaque(); got != providerCursor {
+		t.Fatalf("terminal provider cursor = %q, want %q", got, providerCursor)
+	}
+}
+
 func TestSyncRuntimeSkipsNilEvents(t *testing.T) {
 	registry, err := sourcecdk.NewRegistry(nilEventSource{})
 	if err != nil {


### PR DESCRIPTION
## Summary

- restrict common cursor merging to the known envelope schema
- preserve resumable source-specific cursor fields when checkpoints share a watermark
- preserve source-specific terminal cursors while removing only common continuation tokens

## Validation

- `go test ./internal/sourceruntime ./internal/sourcecdk`
- `make check-arch`
- `make lint-api-cmd`
- `git diff --check`