### PR TITLE
Define durable mission operating primitives

### DIFF
--- a/crates/control-kernel/src/authority.rs
+++ b/crates/control-kernel/src/authority.rs
@@ -196,6 +196,59 @@ mod tests {
     }
 
     #[test]
+    fn grants_fail_closed_for_every_binding() {
+        let mut invalid = grant();
+        invalid.actions.clear();
+        assert_eq!(
+            invalid.authorize(&request()),
+            AuthorizationDecision::Denied {
+                reason: AuthorizationDenial::InvalidGrant
+            }
+        );
+
+        let mut wrong_actor = request();
+        wrong_actor.actor_id = ActorId::parse("worker-2").unwrap();
+        assert_eq!(
+            grant().authorize(&wrong_actor),
+            AuthorizationDecision::Denied {
+                reason: AuthorizationDenial::ActorMismatch
+            }
+        );
+        let mut early = request();
+        early.observed_at_unix_ms = 99;
+        assert_eq!(
+            grant().authorize(&early),
+            AuthorizationDecision::Denied {
+                reason: AuthorizationDenial::NotYetValid
+            }
+        );
+        let mut revoked = grant();
+        revoked.revoked_at_unix_ms = Some(150);
+        assert_eq!(
+            revoked.authorize(&request()),
+            AuthorizationDecision::Denied {
+                reason: AuthorizationDenial::Revoked
+            }
+        );
+        let mut wrong_action = request();
+        wrong_action.action = "identity.delete".into();
+        assert_eq!(
+            grant().authorize(&wrong_action),
+            AuthorizationDecision::Denied {
+                reason: AuthorizationDenial::ActionNotGranted
+            }
+        );
+        let mut wrong_resource = request();
+        wrong_resource.resource_urn = "urn:database:1".into();
+        assert_eq!(
+            grant().authorize(&wrong_resource),
+            AuthorizationDecision::Denied {
+                reason: AuthorizationDenial::ResourceNotGranted
+            }
+        );
+    }
+
+    #[test]
     fn decisions_bind_the_exact_proposal() {
         let receipt = DecisionReceipt {
             decision_id: DecisionId::parse("decision-1").unwrap(),

--- a/crates/control-kernel/src/belief.rs
+++ b/crates/control-kernel/src/belief.rs
@@ -1,0 +1,253 @@
+use std::{collections::BTreeSet, error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ActorId, BeliefId};
+
+const MAX_TEXT_BYTES: usize = 4_096;
+const MAX_REFERENCES: usize = 256;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BeliefBasis {
+    Observed,
+    DeterministicallyDerived,
+    Asserted,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BeliefVerdict {
+    Candidate,
+    Supported,
+    WeaklySupported,
+    Contradicted,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BeliefInput {
+    pub belief_id: BeliefId,
+    pub statement: String,
+    pub basis: BeliefBasis,
+    pub verdict: BeliefVerdict,
+    pub subject_urns: Vec<String>,
+    pub supporting_evidence_urns: Vec<String>,
+    pub counterevidence_urns: Vec<String>,
+    pub missing_evidence: Vec<String>,
+    pub invalidation_conditions: Vec<String>,
+    pub confidence_basis_points: u16,
+    pub source_revision: Option<String>,
+    pub actor_id: ActorId,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Belief {
+    pub belief_id: BeliefId,
+    pub revision: u64,
+    pub statement: String,
+    pub basis: BeliefBasis,
+    pub verdict: BeliefVerdict,
+    pub subject_urns: Vec<String>,
+    pub supporting_evidence_urns: Vec<String>,
+    pub counterevidence_urns: Vec<String>,
+    pub missing_evidence: Vec<String>,
+    pub invalidation_conditions: Vec<String>,
+    pub confidence_basis_points: u16,
+    pub source_revision: Option<String>,
+    pub changed_by: ActorId,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BeliefRevision {
+    pub expected_revision: u64,
+    pub verdict: BeliefVerdict,
+    pub supporting_evidence_urns: Vec<String>,
+    pub counterevidence_urns: Vec<String>,
+    pub missing_evidence: Vec<String>,
+    pub invalidation_conditions: Vec<String>,
+    pub confidence_basis_points: u16,
+    pub source_revision: Option<String>,
+    pub actor_id: ActorId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BeliefError {
+    InvalidStatement,
+    InvalidReferences,
+    InvalidConfidence,
+    InvalidVerdict,
+    RevisionConflict { expected: u64, actual: u64 },
+}
+
+impl fmt::Display for BeliefError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidStatement => formatter.write_str("belief statement is invalid"),
+            Self::InvalidReferences => formatter.write_str("belief references are invalid"),
+            Self::InvalidConfidence => formatter.write_str("belief confidence is invalid"),
+            Self::InvalidVerdict => {
+                formatter.write_str("belief verdict conflicts with its evidence")
+            }
+            Self::RevisionConflict { expected, actual } => write!(
+                formatter,
+                "belief revision conflict: expected {expected}, actual {actual}"
+            ),
+        }
+    }
+}
+
+impl Error for BeliefError {}
+
+impl Belief {
+    pub fn record(input: BeliefInput) -> Result<Self, BeliefError> {
+        validate_text(&input.statement).map_err(|_| BeliefError::InvalidStatement)?;
+        validate_confidence(input.confidence_basis_points)?;
+        let belief = Self {
+            belief_id: input.belief_id,
+            revision: 1,
+            statement: input.statement,
+            basis: input.basis,
+            verdict: input.verdict,
+            subject_urns: normalize_required(input.subject_urns)?,
+            supporting_evidence_urns: normalize_optional(input.supporting_evidence_urns)?,
+            counterevidence_urns: normalize_optional(input.counterevidence_urns)?,
+            missing_evidence: normalize_optional(input.missing_evidence)?,
+            invalidation_conditions: normalize_required(input.invalidation_conditions)?,
+            confidence_basis_points: input.confidence_basis_points,
+            source_revision: normalize_optional_text(input.source_revision)?,
+            changed_by: input.actor_id,
+        };
+        belief.validate_verdict()?;
+        Ok(belief)
+    }
+
+    pub fn revise(&self, revision: BeliefRevision) -> Result<Self, BeliefError> {
+        if revision.expected_revision != self.revision {
+            return Err(BeliefError::RevisionConflict {
+                expected: revision.expected_revision,
+                actual: self.revision,
+            });
+        }
+        validate_confidence(revision.confidence_basis_points)?;
+        let mut next = self.clone();
+        next.revision += 1;
+        next.verdict = revision.verdict;
+        next.supporting_evidence_urns = normalize_optional(revision.supporting_evidence_urns)?;
+        next.counterevidence_urns = normalize_optional(revision.counterevidence_urns)?;
+        next.missing_evidence = normalize_optional(revision.missing_evidence)?;
+        next.invalidation_conditions = normalize_required(revision.invalidation_conditions)?;
+        next.confidence_basis_points = revision.confidence_basis_points;
+        next.source_revision = normalize_optional_text(revision.source_revision)?;
+        next.changed_by = revision.actor_id;
+        next.validate_verdict()?;
+        Ok(next)
+    }
+
+    fn validate_verdict(&self) -> Result<(), BeliefError> {
+        if self.verdict == BeliefVerdict::Supported
+            && (self.supporting_evidence_urns.is_empty()
+                || !self.counterevidence_urns.is_empty()
+                || !self.missing_evidence.is_empty())
+        {
+            return Err(BeliefError::InvalidVerdict);
+        }
+        if self.verdict == BeliefVerdict::Contradicted && self.counterevidence_urns.is_empty() {
+            return Err(BeliefError::InvalidVerdict);
+        }
+        Ok(())
+    }
+}
+
+fn validate_confidence(value: u16) -> Result<(), BeliefError> {
+    if value > 10_000 {
+        return Err(BeliefError::InvalidConfidence);
+    }
+    Ok(())
+}
+
+fn normalize_required(values: Vec<String>) -> Result<Vec<String>, BeliefError> {
+    let values = normalize_optional(values)?;
+    if values.is_empty() {
+        return Err(BeliefError::InvalidReferences);
+    }
+    Ok(values)
+}
+
+fn normalize_optional(values: Vec<String>) -> Result<Vec<String>, BeliefError> {
+    if values.len() > MAX_REFERENCES {
+        return Err(BeliefError::InvalidReferences);
+    }
+    let mut normalized = BTreeSet::new();
+    for value in values {
+        validate_text(&value).map_err(|_| BeliefError::InvalidReferences)?;
+        normalized.insert(value);
+    }
+    Ok(normalized.into_iter().collect())
+}
+
+fn normalize_optional_text(value: Option<String>) -> Result<Option<String>, BeliefError> {
+    value
+        .map(|value| {
+            validate_text(&value).map_err(|_| BeliefError::InvalidReferences)?;
+            Ok(value)
+        })
+        .transpose()
+}
+
+fn validate_text(value: &str) -> Result<(), ()> {
+    if value.trim().is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input() -> BeliefInput {
+        BeliefInput {
+            belief_id: BeliefId::parse("belief-1").unwrap(),
+            statement: "A terminated identity retains production access".into(),
+            basis: BeliefBasis::DeterministicallyDerived,
+            verdict: BeliefVerdict::Candidate,
+            subject_urns: vec!["urn:identity:1".into()],
+            supporting_evidence_urns: vec![],
+            counterevidence_urns: vec![],
+            missing_evidence: vec!["fresh access snapshot".into()],
+            invalidation_conditions: vec!["access source revision changes".into()],
+            confidence_basis_points: 5_000,
+            source_revision: Some("rev-1".into()),
+            actor_id: ActorId::parse("resolver").unwrap(),
+        }
+    }
+
+    #[test]
+    fn supported_beliefs_require_uncontested_complete_evidence() {
+        let belief = Belief::record(input()).unwrap();
+        let supported = belief
+            .revise(BeliefRevision {
+                expected_revision: 1,
+                verdict: BeliefVerdict::Supported,
+                supporting_evidence_urns: vec!["urn:evidence:access:1".into()],
+                counterevidence_urns: vec![],
+                missing_evidence: vec![],
+                invalidation_conditions: vec!["access source revision changes".into()],
+                confidence_basis_points: 9_500,
+                source_revision: Some("rev-2".into()),
+                actor_id: ActorId::parse("verifier").unwrap(),
+            })
+            .unwrap();
+        assert_eq!(supported.revision, 2);
+        assert_eq!(supported.verdict, BeliefVerdict::Supported);
+
+        let mut invalid = input();
+        invalid.verdict = BeliefVerdict::Supported;
+        assert_eq!(Belief::record(invalid), Err(BeliefError::InvalidVerdict));
+    }
+}

--- a/crates/control-kernel/src/commitment.rs
+++ b/crates/control-kernel/src/commitment.rs
@@ -1,0 +1,266 @@
+use std::{error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ActorId, CommitmentId, DecisionId, GrantId, PlanId};
+
+const MAX_TEXT_BYTES: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitmentState {
+    Proposed,
+    WaitingOnApproval,
+    Ready,
+    Executing,
+    WaitingOnVerification,
+    Fulfilled,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CommitmentInput {
+    pub commitment_id: CommitmentId,
+    pub plan_id: PlanId,
+    pub plan_revision: u64,
+    pub step_id: String,
+    pub actor_id: ActorId,
+    pub capability: String,
+    pub resource_urn: String,
+    pub expected_effect: String,
+    pub rollback_reference: Option<String>,
+    pub requires_decision: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Commitment {
+    pub commitment_id: CommitmentId,
+    pub revision: u64,
+    pub plan_id: PlanId,
+    pub plan_revision: u64,
+    pub step_id: String,
+    pub actor_id: ActorId,
+    pub capability: String,
+    pub resource_urn: String,
+    pub expected_effect: String,
+    pub rollback_reference: Option<String>,
+    pub state: CommitmentState,
+    pub grant_id: Option<GrantId>,
+    pub decision_id: Option<DecisionId>,
+    pub receipt_urns: Vec<String>,
+    pub last_reason: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CommitmentTransition {
+    pub expected_revision: u64,
+    pub to: CommitmentState,
+    pub grant_id: Option<GrantId>,
+    pub decision_id: Option<DecisionId>,
+    pub receipt_urns: Vec<String>,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CommitmentError {
+    InvalidInput,
+    InvalidTransition,
+    MissingAuthority,
+    MissingReceipt,
+    RevisionConflict { expected: u64, actual: u64 },
+}
+
+impl fmt::Display for CommitmentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidInput => formatter.write_str("commitment input is invalid"),
+            Self::InvalidTransition => formatter.write_str("commitment transition is invalid"),
+            Self::MissingAuthority => formatter.write_str("commitment authority is missing"),
+            Self::MissingReceipt => formatter.write_str("commitment receipt is missing"),
+            Self::RevisionConflict { expected, actual } => write!(
+                formatter,
+                "commitment revision conflict: expected {expected}, actual {actual}"
+            ),
+        }
+    }
+}
+
+impl Error for CommitmentError {}
+
+impl Commitment {
+    pub fn propose(input: CommitmentInput) -> Result<Self, CommitmentError> {
+        if input.plan_revision == 0 {
+            return Err(CommitmentError::InvalidInput);
+        }
+        for value in [
+            &input.step_id,
+            &input.capability,
+            &input.resource_urn,
+            &input.expected_effect,
+        ] {
+            validate_text(value).map_err(|_| CommitmentError::InvalidInput)?;
+        }
+        if let Some(reference) = &input.rollback_reference {
+            validate_text(reference).map_err(|_| CommitmentError::InvalidInput)?;
+        }
+        let initial_state = if input.requires_decision {
+            CommitmentState::WaitingOnApproval
+        } else {
+            CommitmentState::Ready
+        };
+        Ok(Self {
+            commitment_id: input.commitment_id,
+            revision: 1,
+            plan_id: input.plan_id,
+            plan_revision: input.plan_revision,
+            step_id: input.step_id,
+            actor_id: input.actor_id,
+            capability: input.capability,
+            resource_urn: input.resource_urn,
+            expected_effect: input.expected_effect,
+            rollback_reference: input.rollback_reference,
+            state: initial_state,
+            grant_id: None,
+            decision_id: None,
+            receipt_urns: vec![],
+            last_reason: "commitment proposed".into(),
+        })
+    }
+
+    pub fn transition(&self, transition: CommitmentTransition) -> Result<Self, CommitmentError> {
+        if transition.expected_revision != self.revision {
+            return Err(CommitmentError::RevisionConflict {
+                expected: transition.expected_revision,
+                actual: self.revision,
+            });
+        }
+        validate_text(&transition.reason).map_err(|_| CommitmentError::InvalidInput)?;
+        if !transition_allowed(self.state, transition.to) {
+            return Err(CommitmentError::InvalidTransition);
+        }
+        if transition.to == CommitmentState::Ready
+            && self.state == CommitmentState::WaitingOnApproval
+            && transition.decision_id.is_none()
+        {
+            return Err(CommitmentError::MissingAuthority);
+        }
+        if transition.to == CommitmentState::Executing && transition.grant_id.is_none() {
+            return Err(CommitmentError::MissingAuthority);
+        }
+        if matches!(
+            transition.to,
+            CommitmentState::WaitingOnVerification | CommitmentState::Fulfilled
+        ) && transition.receipt_urns.is_empty()
+        {
+            return Err(CommitmentError::MissingReceipt);
+        }
+        let mut receipt_urns = transition.receipt_urns;
+        receipt_urns.sort();
+        receipt_urns.dedup();
+        if receipt_urns
+            .iter()
+            .any(|value| validate_text(value).is_err())
+        {
+            return Err(CommitmentError::InvalidInput);
+        }
+        let mut next = self.clone();
+        next.revision += 1;
+        next.state = transition.to;
+        if transition.grant_id.is_some() {
+            next.grant_id = transition.grant_id;
+        }
+        if transition.decision_id.is_some() {
+            next.decision_id = transition.decision_id;
+        }
+        next.receipt_urns.extend(receipt_urns);
+        next.receipt_urns.sort();
+        next.receipt_urns.dedup();
+        next.last_reason = transition.reason;
+        Ok(next)
+    }
+}
+
+fn transition_allowed(from: CommitmentState, to: CommitmentState) -> bool {
+    use CommitmentState::*;
+    matches!(
+        (from, to),
+        (Proposed, WaitingOnApproval | Ready | Cancelled)
+            | (WaitingOnApproval, Ready | Cancelled)
+            | (Ready, Executing | Cancelled)
+            | (Executing, WaitingOnVerification | Failed)
+            | (WaitingOnVerification, Fulfilled | Failed | Ready)
+            | (Failed, Ready | Cancelled)
+    )
+}
+
+fn validate_text(value: &str) -> Result<(), ()> {
+    if value.trim().is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn commitment() -> Commitment {
+        Commitment::propose(CommitmentInput {
+            commitment_id: CommitmentId::parse("commitment-1").unwrap(),
+            plan_id: PlanId::parse("plan-1").unwrap(),
+            plan_revision: 1,
+            step_id: "remove-access".into(),
+            actor_id: ActorId::parse("executor").unwrap(),
+            capability: "identity.access.revoke".into(),
+            resource_urn: "urn:identity:1".into(),
+            expected_effect: "Production access is removed".into(),
+            rollback_reference: Some("runbook:restore-access".into()),
+            requires_decision: true,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn execution_requires_a_decision_and_grant() {
+        let commitment = commitment();
+        assert_eq!(commitment.state, CommitmentState::WaitingOnApproval);
+        assert_eq!(
+            commitment.transition(CommitmentTransition {
+                expected_revision: 1,
+                to: CommitmentState::Ready,
+                grant_id: None,
+                decision_id: None,
+                receipt_urns: vec![],
+                reason: "approved".into(),
+            }),
+            Err(CommitmentError::MissingAuthority)
+        );
+
+        let ready = commitment
+            .transition(CommitmentTransition {
+                expected_revision: 1,
+                to: CommitmentState::Ready,
+                grant_id: None,
+                decision_id: Some(DecisionId::parse("decision-1").unwrap()),
+                receipt_urns: vec![],
+                reason: "operator approved the exact effect".into(),
+            })
+            .unwrap();
+        assert_eq!(
+            ready.transition(CommitmentTransition {
+                expected_revision: 2,
+                to: CommitmentState::Executing,
+                grant_id: None,
+                decision_id: None,
+                receipt_urns: vec![],
+                reason: "execute".into(),
+            }),
+            Err(CommitmentError::MissingAuthority)
+        );
+    }
+}

--- a/crates/control-kernel/src/conversation.rs
+++ b/crates/control-kernel/src/conversation.rs
@@ -1,0 +1,140 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{MissionId, MissionState};
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionDepth {
+    ReadCurrentState,
+    TargetedVerification,
+    DeepInvestigation,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct EncounterProfile {
+    pub is_follow_up: bool,
+    pub explicit_deep_request: bool,
+    pub consequential_action_requested: bool,
+    pub current_state_available: bool,
+    pub current_state_fresh: bool,
+    pub material_evidence_gap: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MissionReference {
+    pub mission_id: MissionId,
+    pub state: MissionState,
+    pub subject_urns: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "resolution", rename_all = "snake_case")]
+pub enum ConversationResolution {
+    ContinueMission {
+        mission_id: MissionId,
+    },
+    OpenMission,
+    NeedsMissionChoice {
+        candidate_mission_ids: Vec<MissionId>,
+    },
+    UnknownMissionReference {
+        mission_id: MissionId,
+    },
+}
+
+pub fn route_execution_depth(profile: &EncounterProfile) -> ExecutionDepth {
+    if profile.explicit_deep_request
+        || (profile.consequential_action_requested && profile.material_evidence_gap)
+    {
+        return ExecutionDepth::DeepInvestigation;
+    }
+    if profile.current_state_available
+        && profile.current_state_fresh
+        && !profile.material_evidence_gap
+        && profile.is_follow_up
+    {
+        return ExecutionDepth::ReadCurrentState;
+    }
+    ExecutionDepth::TargetedVerification
+}
+
+pub fn resolve_conversation(
+    explicit_mission_id: Option<&MissionId>,
+    subject_urns: &[String],
+    missions: &[MissionReference],
+) -> ConversationResolution {
+    if let Some(explicit) = explicit_mission_id {
+        return missions
+            .iter()
+            .find(|mission| &mission.mission_id == explicit)
+            .map(|mission| ConversationResolution::ContinueMission {
+                mission_id: mission.mission_id.clone(),
+            })
+            .unwrap_or_else(|| ConversationResolution::UnknownMissionReference {
+                mission_id: explicit.clone(),
+            });
+    }
+    let requested_subjects = subject_urns.iter().collect::<BTreeSet<_>>();
+    let mut candidates = missions
+        .iter()
+        .filter(|mission| !matches!(mission.state, MissionState::Closed))
+        .filter(|mission| {
+            mission
+                .subject_urns
+                .iter()
+                .any(|subject| requested_subjects.contains(subject))
+        })
+        .map(|mission| mission.mission_id.clone())
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates.dedup();
+    match candidates.as_slice() {
+        [] => ConversationResolution::OpenMission,
+        [mission_id] => ConversationResolution::ContinueMission {
+            mission_id: mission_id.clone(),
+        },
+        _ => ConversationResolution::NeedsMissionChoice {
+            candidate_mission_ids: candidates,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_fresh_follow_ups_do_not_launch_research() {
+        assert_eq!(
+            route_execution_depth(&EncounterProfile {
+                is_follow_up: true,
+                explicit_deep_request: false,
+                consequential_action_requested: false,
+                current_state_available: true,
+                current_state_fresh: true,
+                material_evidence_gap: false,
+            }),
+            ExecutionDepth::ReadCurrentState
+        );
+    }
+
+    #[test]
+    fn subject_overlap_continues_existing_work() {
+        let mission_id = MissionId::parse("mission-1").unwrap();
+        let resolution = resolve_conversation(
+            None,
+            &["urn:identity:1".into()],
+            &[MissionReference {
+                mission_id: mission_id.clone(),
+                state: MissionState::WaitingOnEvidence,
+                subject_urns: vec!["urn:identity:1".into()],
+            }],
+        );
+        assert_eq!(
+            resolution,
+            ConversationResolution::ContinueMission { mission_id }
+        );
+    }
+}

--- a/crates/control-kernel/src/conversation.rs
+++ b/crates/control-kernel/src/conversation.rs
@@ -105,6 +105,14 @@ pub fn resolve_conversation(
 mod tests {
     use super::*;
 
+    fn mission(id: &str, state: MissionState, subjects: &[&str]) -> MissionReference {
+        MissionReference {
+            mission_id: MissionId::parse(id).unwrap(),
+            state,
+            subject_urns: subjects.iter().map(|subject| (*subject).into()).collect(),
+        }
+    }
+
     #[test]
     fn short_fresh_follow_ups_do_not_launch_research() {
         assert_eq!(
@@ -135,6 +143,73 @@ mod tests {
         assert_eq!(
             resolution,
             ConversationResolution::ContinueMission { mission_id }
+        );
+    }
+
+    #[test]
+    fn execution_depth_tracks_the_cost_of_being_wrong() {
+        let mut profile = EncounterProfile {
+            is_follow_up: false,
+            explicit_deep_request: false,
+            consequential_action_requested: false,
+            current_state_available: false,
+            current_state_fresh: false,
+            material_evidence_gap: false,
+        };
+        assert_eq!(
+            route_execution_depth(&profile),
+            ExecutionDepth::TargetedVerification
+        );
+        profile.explicit_deep_request = true;
+        assert_eq!(
+            route_execution_depth(&profile),
+            ExecutionDepth::DeepInvestigation
+        );
+        profile.explicit_deep_request = false;
+        profile.consequential_action_requested = true;
+        profile.material_evidence_gap = true;
+        assert_eq!(
+            route_execution_depth(&profile),
+            ExecutionDepth::DeepInvestigation
+        );
+    }
+
+    #[test]
+    fn conversation_resolution_is_explicit_and_deterministic() {
+        let first = mission("mission-1", MissionState::Planning, &["urn:identity:1"]);
+        let second = mission(
+            "mission-2",
+            MissionState::WaitingOnEvidence,
+            &["urn:identity:1"],
+        );
+        let closed = mission("mission-3", MissionState::Closed, &["urn:identity:2"]);
+
+        assert_eq!(
+            resolve_conversation(Some(&first.mission_id), &[], std::slice::from_ref(&first)),
+            ConversationResolution::ContinueMission {
+                mission_id: first.mission_id.clone()
+            }
+        );
+        let missing = MissionId::parse("mission-missing").unwrap();
+        assert_eq!(
+            resolve_conversation(Some(&missing), &[], std::slice::from_ref(&first)),
+            ConversationResolution::UnknownMissionReference {
+                mission_id: missing
+            }
+        );
+        assert_eq!(
+            resolve_conversation(None, &["urn:identity:2".into()], &[closed]),
+            ConversationResolution::OpenMission
+        );
+        assert_eq!(
+            resolve_conversation(
+                None,
+                &["urn:identity:1".into()],
+                &[second.clone(), first.clone(), second.clone()],
+            ),
+            ConversationResolution::NeedsMissionChoice {
+                candidate_mission_ids: vec![first.mission_id, second.mission_id]
+            }
         );
     }
 }

--- a/crates/control-kernel/src/event.rs
+++ b/crates/control-kernel/src/event.rs
@@ -1,10 +1,17 @@
-use std::{collections::BTreeSet, error::Error, fmt};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    error::Error,
+    fmt,
+};
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ActorId, Mission, MissionError, MissionId, MissionInput, MissionState, MissionTransition,
-    TenantId, VerificationReceipt,
+    ActorId, Belief, BeliefError, BeliefId, BeliefInput, BeliefRevision, Commitment,
+    CommitmentError, CommitmentId, CommitmentInput, CommitmentTransition, Mission, MissionError,
+    MissionId, MissionInput, MissionState, MissionTransition, PlanError, PlanRevision, TenantId,
+    VerificationReceipt, WakeCondition, WakeConditionError, WakeConditionId, WakeConditionKind,
+    WakeSignal,
 };
 
 const MAX_IDEMPOTENCY_KEY_BYTES: usize = 512;
@@ -37,12 +44,46 @@ pub enum MissionEvent {
         reason: String,
         receipt: VerificationReceipt,
     },
+    BeliefRecorded {
+        input: BeliefInput,
+    },
+    BeliefRevised {
+        belief_id: BeliefId,
+        revision: BeliefRevision,
+    },
+    PlanRevised {
+        revision: PlanRevision,
+    },
+    CommitmentProposed {
+        input: CommitmentInput,
+    },
+    CommitmentTransitioned {
+        commitment_id: CommitmentId,
+        transition: CommitmentTransition,
+    },
+    WakeConditionArmed {
+        wake_condition_id: WakeConditionId,
+        kind: WakeConditionKind,
+        reason: String,
+    },
+    WakeConditionSatisfied {
+        wake_condition_id: WakeConditionId,
+        signal: WakeSignal,
+    },
+    WakeConditionCancelled {
+        wake_condition_id: WakeConditionId,
+        reason: String,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MissionAggregate {
     pub mission: Mission,
     pub last_sequence: u64,
+    pub beliefs: BTreeMap<BeliefId, Belief>,
+    pub plan_revisions: Vec<PlanRevision>,
+    pub commitments: BTreeMap<CommitmentId, Commitment>,
+    pub wake_conditions: BTreeMap<WakeConditionId, WakeCondition>,
     seen_idempotency_keys: BTreeSet<String>,
 }
 
@@ -54,7 +95,14 @@ pub enum ReplayError {
     DuplicateIdempotencyKey,
     IdentityMismatch,
     StateMismatch,
+    DuplicateRecord,
+    MissingRecord,
+    ClosureBlocked,
     Mission(MissionError),
+    Belief(BeliefError),
+    Plan(PlanError),
+    Commitment(CommitmentError),
+    WakeCondition(WakeConditionError),
 }
 
 impl fmt::Display for ReplayError {
@@ -77,7 +125,18 @@ impl fmt::Display for ReplayError {
             Self::StateMismatch => {
                 formatter.write_str("mission event state does not match aggregate")
             }
+            Self::DuplicateRecord => formatter.write_str("mission record is duplicated"),
+            Self::MissingRecord => formatter.write_str("mission record is missing"),
+            Self::ClosureBlocked => formatter.write_str(
+                "mission verification is blocked by active commitments or wake conditions",
+            ),
             Self::Mission(error) => write!(formatter, "mission event is invalid: {error}"),
+            Self::Belief(error) => write!(formatter, "mission belief is invalid: {error}"),
+            Self::Plan(error) => write!(formatter, "mission plan is invalid: {error}"),
+            Self::Commitment(error) => write!(formatter, "mission commitment is invalid: {error}"),
+            Self::WakeCondition(error) => {
+                write!(formatter, "mission wake condition is invalid: {error}")
+            }
         }
     }
 }
@@ -90,6 +149,30 @@ impl From<MissionError> for ReplayError {
     }
 }
 
+impl From<BeliefError> for ReplayError {
+    fn from(value: BeliefError) -> Self {
+        Self::Belief(value)
+    }
+}
+
+impl From<PlanError> for ReplayError {
+    fn from(value: PlanError) -> Self {
+        Self::Plan(value)
+    }
+}
+
+impl From<CommitmentError> for ReplayError {
+    fn from(value: CommitmentError) -> Self {
+        Self::Commitment(value)
+    }
+}
+
+impl From<WakeConditionError> for ReplayError {
+    fn from(value: WakeConditionError) -> Self {
+        Self::WakeCondition(value)
+    }
+}
+
 impl MissionAggregate {
     pub fn replay(events: &[MissionEventEnvelope]) -> Result<Self, ReplayError> {
         let first = events.first().ok_or(ReplayError::Empty)?;
@@ -97,13 +180,20 @@ impl MissionAggregate {
         let MissionEvent::Opened { input } = &first.event else {
             return Err(ReplayError::StateMismatch);
         };
-        if input.tenant_id != first.tenant_id || input.mission_id != first.mission_id {
+        if input.tenant_id != first.tenant_id
+            || input.mission_id != first.mission_id
+            || input.actor_id != first.actor_id
+        {
             return Err(ReplayError::IdentityMismatch);
         }
         let mission = Mission::open(input.clone())?;
         let mut aggregate = Self {
             mission,
             last_sequence: 1,
+            beliefs: BTreeMap::new(),
+            plan_revisions: vec![],
+            commitments: BTreeMap::new(),
+            wake_conditions: BTreeMap::new(),
             seen_idempotency_keys: BTreeSet::from([first.idempotency_key.clone()]),
         };
         for event in &events[1..] {
@@ -147,9 +237,131 @@ impl MissionAggregate {
                 if *from != self.mission.state {
                     return Err(ReplayError::StateMismatch);
                 }
+                if envelope.actor_id != receipt.verifier_actor_id
+                    || self.commitments.values().any(|commitment| {
+                        !matches!(
+                            commitment.state,
+                            crate::CommitmentState::Fulfilled | crate::CommitmentState::Cancelled
+                        )
+                    })
+                    || self
+                        .wake_conditions
+                        .values()
+                        .any(|condition| condition.state == crate::WakeConditionState::Armed)
+                {
+                    return Err(ReplayError::ClosureBlocked);
+                }
                 self.mission =
                     self.mission
                         .verify(self.mission.revision, receipt, reason.clone())?;
+            }
+            MissionEvent::BeliefRecorded { input } => {
+                if input.actor_id != envelope.actor_id {
+                    return Err(ReplayError::IdentityMismatch);
+                }
+                if self.beliefs.contains_key(&input.belief_id) {
+                    return Err(ReplayError::DuplicateRecord);
+                }
+                let belief = Belief::record(input.clone())?;
+                self.beliefs.insert(belief.belief_id.clone(), belief);
+            }
+            MissionEvent::BeliefRevised {
+                belief_id,
+                revision,
+            } => {
+                if revision.actor_id != envelope.actor_id {
+                    return Err(ReplayError::IdentityMismatch);
+                }
+                let belief = self
+                    .beliefs
+                    .get(belief_id)
+                    .ok_or(ReplayError::MissingRecord)?
+                    .revise(revision.clone())?;
+                self.beliefs.insert(belief_id.clone(), belief);
+            }
+            MissionEvent::PlanRevised { revision } => {
+                if revision.created_by != envelope.actor_id {
+                    return Err(ReplayError::IdentityMismatch);
+                }
+                if revision
+                    .hypothesis_ids
+                    .iter()
+                    .any(|belief_id| !self.beliefs.contains_key(belief_id))
+                {
+                    return Err(ReplayError::MissingRecord);
+                }
+                revision.validate(self.plan_revisions.last())?;
+                self.plan_revisions.push(revision.clone());
+            }
+            MissionEvent::CommitmentProposed { input } => {
+                if self.commitments.contains_key(&input.commitment_id) {
+                    return Err(ReplayError::DuplicateRecord);
+                }
+                let plan = self
+                    .plan_revisions
+                    .iter()
+                    .find(|plan| {
+                        plan.plan_id == input.plan_id && plan.revision == input.plan_revision
+                    })
+                    .ok_or(ReplayError::MissingRecord)?;
+                if !plan.steps.iter().any(|step| step.step_id == input.step_id) {
+                    return Err(ReplayError::MissingRecord);
+                }
+                let commitment = Commitment::propose(input.clone())?;
+                self.commitments
+                    .insert(commitment.commitment_id.clone(), commitment);
+            }
+            MissionEvent::CommitmentTransitioned {
+                commitment_id,
+                transition,
+            } => {
+                let commitment = self
+                    .commitments
+                    .get(commitment_id)
+                    .ok_or(ReplayError::MissingRecord)?
+                    .transition(transition.clone())?;
+                self.commitments.insert(commitment_id.clone(), commitment);
+            }
+            MissionEvent::WakeConditionArmed {
+                wake_condition_id,
+                kind,
+                reason,
+            } => {
+                if self.wake_conditions.contains_key(wake_condition_id) {
+                    return Err(ReplayError::DuplicateRecord);
+                }
+                let condition = WakeCondition::arm(
+                    wake_condition_id.clone(),
+                    kind.clone(),
+                    envelope.observed_at_unix_ms,
+                    reason.clone(),
+                )?;
+                self.wake_conditions
+                    .insert(wake_condition_id.clone(), condition);
+            }
+            MissionEvent::WakeConditionSatisfied {
+                wake_condition_id,
+                signal,
+            } => {
+                let condition = self
+                    .wake_conditions
+                    .get(wake_condition_id)
+                    .ok_or(ReplayError::MissingRecord)?
+                    .satisfy(signal, envelope.observed_at_unix_ms)?;
+                self.wake_conditions
+                    .insert(wake_condition_id.clone(), condition);
+            }
+            MissionEvent::WakeConditionCancelled {
+                wake_condition_id,
+                reason,
+            } => {
+                let condition = self
+                    .wake_conditions
+                    .get(wake_condition_id)
+                    .ok_or(ReplayError::MissingRecord)?
+                    .cancel(reason.clone())?;
+                self.wake_conditions
+                    .insert(wake_condition_id.clone(), condition);
             }
         }
         self.last_sequence = envelope.sequence;

--- a/crates/control-kernel/src/identity.rs
+++ b/crates/control-kernel/src/identity.rs
@@ -75,6 +75,11 @@ macro_rules! identifier {
 identifier!(TenantId, "tenant id");
 identifier!(MandateId, "mandate id");
 identifier!(MissionId, "mission id");
+identifier!(BeliefId, "belief id");
+identifier!(PlanId, "plan id");
+identifier!(CommitmentId, "commitment id");
+identifier!(WakeConditionId, "wake condition id");
+identifier!(ConversationId, "conversation id");
 identifier!(ActorId, "actor id");
 identifier!(GrantId, "grant id");
 identifier!(DecisionId, "decision id");

--- a/crates/control-kernel/src/lib.rs
+++ b/crates/control-kernel/src/lib.rs
@@ -7,24 +7,43 @@
 //! behavior. Runtime adapters belong outside the kernel.
 
 mod authority;
+mod belief;
+mod commitment;
+mod conversation;
 mod event;
 mod identity;
 mod mandate;
 mod mission;
+mod plan;
 mod protocol;
+mod supervisor;
+mod wake;
 
 pub use authority::{
     AuthorizationDecision, AuthorizationDenial, AuthorizationRequest, CapabilityGrant,
     DecisionReceipt, VerificationReceipt,
 };
+pub use belief::{Belief, BeliefBasis, BeliefError, BeliefInput, BeliefRevision, BeliefVerdict};
+pub use commitment::{
+    Commitment, CommitmentError, CommitmentInput, CommitmentState, CommitmentTransition,
+};
+pub use conversation::{
+    ConversationResolution, EncounterProfile, ExecutionDepth, MissionReference,
+    resolve_conversation, route_execution_depth,
+};
 pub use event::{MissionAggregate, MissionEvent, MissionEventEnvelope, ReplayError};
 pub use identity::{
-    ActorId, DecisionId, GrantId, IdentifierError, MandateId, MissionId, RequestId, TenantId,
-    VerificationId,
+    ActorId, BeliefId, CommitmentId, ConversationId, DecisionId, GrantId, IdentifierError,
+    MandateId, MissionId, PlanId, RequestId, TenantId, VerificationId, WakeConditionId,
 };
 pub use mandate::{Mandate, MandateError, MandateInput, MandateStatus};
 pub use mission::{Mission, MissionError, MissionInput, MissionState, MissionTransition};
+pub use plan::{PlanError, PlanRevision, PlanStep};
 pub use protocol::{CommandEnvelope, ControlCommand, ControlResponse, ProtocolError};
+pub use supervisor::{MissionDirective, SupervisorSnapshot, next_directive};
+pub use wake::{
+    WakeCondition, WakeConditionError, WakeConditionKind, WakeConditionState, WakeSignal,
+};
 
 /// Identifies the first public schema revision of the native control kernel.
 pub const SCHEMA_VERSION: &str = "cerebro.control-kernel.v1";

--- a/crates/control-kernel/src/plan.rs
+++ b/crates/control-kernel/src/plan.rs
@@ -1,0 +1,197 @@
+use std::{collections::BTreeSet, error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ActorId, BeliefId, PlanId};
+
+const MAX_TEXT_BYTES: usize = 4_096;
+const MAX_STEPS: usize = 128;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PlanStep {
+    pub step_id: String,
+    pub capability: String,
+    pub subject_urn: String,
+    pub expected_effect: String,
+    pub depends_on: Vec<String>,
+    pub requires_decision: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PlanRevision {
+    pub plan_id: PlanId,
+    pub revision: u64,
+    pub previous_revision: Option<u64>,
+    pub rationale: String,
+    pub hypothesis_ids: Vec<BeliefId>,
+    pub steps: Vec<PlanStep>,
+    pub superseded_step_ids: Vec<String>,
+    pub created_by: ActorId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PlanError {
+    InvalidRevision,
+    InvalidRationale,
+    InvalidHypotheses,
+    InvalidSteps,
+    DuplicateStep,
+    InvalidDependency,
+}
+
+impl fmt::Display for PlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRevision => formatter.write_str("plan revision is invalid"),
+            Self::InvalidRationale => formatter.write_str("plan rationale is invalid"),
+            Self::InvalidHypotheses => formatter.write_str("plan hypotheses are invalid"),
+            Self::InvalidSteps => formatter.write_str("plan steps are invalid"),
+            Self::DuplicateStep => formatter.write_str("plan step id is duplicated"),
+            Self::InvalidDependency => formatter.write_str("plan dependency is invalid"),
+        }
+    }
+}
+
+impl Error for PlanError {}
+
+impl PlanRevision {
+    pub fn validate(&self, previous: Option<&Self>) -> Result<(), PlanError> {
+        if self.revision == 0
+            || (self.revision == 1 && self.previous_revision.is_some())
+            || (self.revision > 1 && self.previous_revision != Some(self.revision - 1))
+        {
+            return Err(PlanError::InvalidRevision);
+        }
+        if let Some(previous) = previous
+            && (previous.plan_id != self.plan_id || self.revision != previous.revision + 1)
+        {
+            return Err(PlanError::InvalidRevision);
+        }
+        validate_text(&self.rationale).map_err(|_| PlanError::InvalidRationale)?;
+        if self.hypothesis_ids.is_empty() {
+            return Err(PlanError::InvalidHypotheses);
+        }
+        let hypothesis_ids = self.hypothesis_ids.iter().collect::<BTreeSet<_>>();
+        if hypothesis_ids.len() != self.hypothesis_ids.len() {
+            return Err(PlanError::InvalidHypotheses);
+        }
+        if self.steps.is_empty() || self.steps.len() > MAX_STEPS {
+            return Err(PlanError::InvalidSteps);
+        }
+        let mut step_ids = BTreeSet::new();
+        for step in &self.steps {
+            validate_text(&step.step_id).map_err(|_| PlanError::InvalidSteps)?;
+            validate_text(&step.capability).map_err(|_| PlanError::InvalidSteps)?;
+            validate_text(&step.subject_urn).map_err(|_| PlanError::InvalidSteps)?;
+            validate_text(&step.expected_effect).map_err(|_| PlanError::InvalidSteps)?;
+            if !step_ids.insert(step.step_id.as_str()) {
+                return Err(PlanError::DuplicateStep);
+            }
+        }
+        for step in &self.steps {
+            for dependency in &step.depends_on {
+                if dependency == &step.step_id || !step_ids.contains(dependency.as_str()) {
+                    return Err(PlanError::InvalidDependency);
+                }
+            }
+        }
+        let mut completed = BTreeSet::new();
+        loop {
+            let before = completed.len();
+            for step in &self.steps {
+                if step
+                    .depends_on
+                    .iter()
+                    .all(|dependency| completed.contains(dependency.as_str()))
+                {
+                    completed.insert(step.step_id.as_str());
+                }
+            }
+            if completed.len() == self.steps.len() {
+                break;
+            }
+            if completed.len() == before {
+                return Err(PlanError::InvalidDependency);
+            }
+        }
+        let mut superseded_ids = BTreeSet::new();
+        for superseded in &self.superseded_step_ids {
+            validate_text(superseded).map_err(|_| PlanError::InvalidSteps)?;
+            if !superseded_ids.insert(superseded.as_str()) {
+                return Err(PlanError::InvalidSteps);
+            }
+            let Some(previous) = previous else {
+                return Err(PlanError::InvalidSteps);
+            };
+            if !previous
+                .steps
+                .iter()
+                .any(|step| step.step_id == *superseded)
+            {
+                return Err(PlanError::InvalidSteps);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_text(value: &str) -> Result<(), ()> {
+    if value.trim().is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan(revision: u64) -> PlanRevision {
+        PlanRevision {
+            plan_id: PlanId::parse("plan-1").unwrap(),
+            revision,
+            previous_revision: (revision > 1).then_some(revision - 1),
+            rationale: "Remove direct access, then verify a newer source revision".into(),
+            hypothesis_ids: vec![BeliefId::parse("belief-1").unwrap()],
+            steps: vec![
+                PlanStep {
+                    step_id: "remove-access".into(),
+                    capability: "identity.access.revoke".into(),
+                    subject_urn: "urn:identity:1".into(),
+                    expected_effect: "Production access is removed".into(),
+                    depends_on: vec![],
+                    requires_decision: true,
+                },
+                PlanStep {
+                    step_id: "verify-access".into(),
+                    capability: "identity.access.observe".into(),
+                    subject_urn: "urn:identity:1".into(),
+                    expected_effect: "A newer source revision shows no access path".into(),
+                    depends_on: vec!["remove-access".into()],
+                    requires_decision: false,
+                },
+            ],
+            superseded_step_ids: vec![],
+            created_by: ActorId::parse("planner").unwrap(),
+        }
+    }
+
+    #[test]
+    fn revisions_are_ordered_and_dependencies_reference_current_steps() {
+        let first = plan(1);
+        first.validate(None).unwrap();
+        plan(2).validate(Some(&first)).unwrap();
+
+        let mut invalid = plan(1);
+        invalid.steps[1].depends_on = vec!["missing".into()];
+        assert_eq!(invalid.validate(None), Err(PlanError::InvalidDependency));
+
+        let mut cycle = plan(1);
+        cycle.steps[0].depends_on = vec!["verify-access".into()];
+        assert_eq!(cycle.validate(None), Err(PlanError::InvalidDependency));
+    }
+}

--- a/crates/control-kernel/src/protocol.rs
+++ b/crates/control-kernel/src/protocol.rs
@@ -3,8 +3,11 @@ use std::{error::Error, fmt};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ActorId, AuthorizationDecision, AuthorizationRequest, DecisionReceipt, Mission, MissionId,
-    MissionInput, MissionState, RequestId, TenantId, VerificationReceipt,
+    ActorId, AuthorizationDecision, AuthorizationRequest, BeliefId, BeliefInput, BeliefRevision,
+    CommitmentId, CommitmentInput, CommitmentTransition, ConversationResolution, DecisionReceipt,
+    EncounterProfile, ExecutionDepth, Mission, MissionDirective, MissionId, MissionInput,
+    MissionReference, MissionState, PlanRevision, RequestId, SupervisorSnapshot, TenantId,
+    VerificationReceipt, WakeConditionId, WakeConditionKind, WakeSignal,
 };
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -43,6 +46,67 @@ pub enum ControlCommand {
         mission_id: MissionId,
         receipt: VerificationReceipt,
     },
+    RecordBelief {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        input: BeliefInput,
+    },
+    ReviseBelief {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        belief_id: BeliefId,
+        revision: BeliefRevision,
+    },
+    RevisePlan {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        revision: PlanRevision,
+    },
+    ProposeCommitment {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        input: CommitmentInput,
+    },
+    TransitionCommitment {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        commitment_id: CommitmentId,
+        transition: CommitmentTransition,
+    },
+    ArmWakeCondition {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        wake_condition_id: WakeConditionId,
+        kind: WakeConditionKind,
+        reason: String,
+    },
+    SatisfyWakeCondition {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        wake_condition_id: WakeConditionId,
+        signal: WakeSignal,
+    },
+    CancelWakeCondition {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        wake_condition_id: WakeConditionId,
+        reason: String,
+    },
+    RouteEncounter {
+        tenant_id: TenantId,
+        profile: EncounterProfile,
+    },
+    ResolveConversation {
+        tenant_id: TenantId,
+        explicit_mission_id: Option<MissionId>,
+        subject_urns: Vec<String>,
+        missions: Vec<MissionReference>,
+    },
+    EvaluateMission {
+        tenant_id: TenantId,
+        mission_id: MissionId,
+        snapshot: SupervisorSnapshot,
+    },
 }
 
 impl ControlCommand {
@@ -51,7 +115,18 @@ impl ControlCommand {
             Self::OpenMission { input } => &input.tenant_id,
             Self::AdvanceMission { tenant_id, .. }
             | Self::RecordDecision { tenant_id, .. }
-            | Self::RecordVerification { tenant_id, .. } => tenant_id,
+            | Self::RecordVerification { tenant_id, .. }
+            | Self::RecordBelief { tenant_id, .. }
+            | Self::ReviseBelief { tenant_id, .. }
+            | Self::RevisePlan { tenant_id, .. }
+            | Self::ProposeCommitment { tenant_id, .. }
+            | Self::TransitionCommitment { tenant_id, .. }
+            | Self::ArmWakeCondition { tenant_id, .. }
+            | Self::SatisfyWakeCondition { tenant_id, .. }
+            | Self::CancelWakeCondition { tenant_id, .. }
+            | Self::RouteEncounter { tenant_id, .. }
+            | Self::ResolveConversation { tenant_id, .. }
+            | Self::EvaluateMission { tenant_id, .. } => tenant_id,
             Self::Authorize { request } => &request.tenant_id,
         }
     }
@@ -62,6 +137,9 @@ impl ControlCommand {
 pub enum ControlResponse {
     Mission { mission: Mission },
     Authorization { decision: AuthorizationDecision },
+    ExecutionDepth { depth: ExecutionDepth },
+    Conversation { resolution: ConversationResolution },
+    Directive { directive: MissionDirective },
     Accepted { request_id: RequestId },
     Rejected { code: String, message: String },
 }

--- a/crates/control-kernel/src/supervisor.rs
+++ b/crates/control-kernel/src/supervisor.rs
@@ -1,0 +1,158 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Commitment, CommitmentId, CommitmentState, MissionState, WakeConditionId};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SupervisorSnapshot {
+    pub mission_state: MissionState,
+    pub has_current_plan: bool,
+    pub commitments: Vec<Commitment>,
+    pub armed_wake_condition_ids: Vec<WakeConditionId>,
+    pub satisfied_wake_condition_ids: Vec<WakeConditionId>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "directive", rename_all = "snake_case")]
+pub enum MissionDirective {
+    ResolveScope,
+    RevisePlan,
+    RequestDecision {
+        commitment_id: CommitmentId,
+    },
+    Execute {
+        commitment_id: CommitmentId,
+    },
+    Verify {
+        commitment_id: CommitmentId,
+    },
+    Wait {
+        wake_condition_ids: Vec<WakeConditionId>,
+    },
+    ReplanFromWake {
+        wake_condition_ids: Vec<WakeConditionId>,
+    },
+    Blocked {
+        code: String,
+    },
+    Close,
+    NoAction,
+}
+
+pub fn next_directive(snapshot: &SupervisorSnapshot) -> MissionDirective {
+    match snapshot.mission_state {
+        MissionState::Open | MissionState::ResolvingScope => MissionDirective::ResolveScope,
+        MissionState::Planning => {
+            if snapshot.has_current_plan {
+                next_commitment_directive(&snapshot.commitments)
+                    .unwrap_or_else(|| blocked("plan_has_no_active_commitment"))
+            } else {
+                MissionDirective::RevisePlan
+            }
+        }
+        MissionState::WaitingOnEvidence | MissionState::Blocked => {
+            if !snapshot.satisfied_wake_condition_ids.is_empty() {
+                MissionDirective::ReplanFromWake {
+                    wake_condition_ids: snapshot.satisfied_wake_condition_ids.clone(),
+                }
+            } else if !snapshot.armed_wake_condition_ids.is_empty() {
+                MissionDirective::Wait {
+                    wake_condition_ids: snapshot.armed_wake_condition_ids.clone(),
+                }
+            } else {
+                blocked("no_wake_condition")
+            }
+        }
+        MissionState::WaitingOnApproval => snapshot
+            .commitments
+            .iter()
+            .find(|commitment| commitment.state == CommitmentState::WaitingOnApproval)
+            .map(|commitment| MissionDirective::RequestDecision {
+                commitment_id: commitment.commitment_id.clone(),
+            })
+            .unwrap_or_else(|| blocked("no_pending_decision")),
+        MissionState::ReadyToAct | MissionState::Acting => {
+            next_commitment_directive(&snapshot.commitments)
+                .unwrap_or_else(|| blocked("no_executable_commitment"))
+        }
+        MissionState::Verifying => snapshot
+            .commitments
+            .iter()
+            .find(|commitment| {
+                commitment.state == CommitmentState::WaitingOnVerification
+                    || commitment.state == CommitmentState::Executing
+            })
+            .map(|commitment| MissionDirective::Verify {
+                commitment_id: commitment.commitment_id.clone(),
+            })
+            .unwrap_or_else(|| blocked("no_commitment_to_verify")),
+        MissionState::Verified => MissionDirective::Close,
+        MissionState::Closed => MissionDirective::NoAction,
+    }
+}
+
+fn blocked(code: &str) -> MissionDirective {
+    MissionDirective::Blocked { code: code.into() }
+}
+
+fn next_commitment_directive(commitments: &[Commitment]) -> Option<MissionDirective> {
+    commitments
+        .iter()
+        .find(|commitment| commitment.state == CommitmentState::WaitingOnApproval)
+        .map(|commitment| MissionDirective::RequestDecision {
+            commitment_id: commitment.commitment_id.clone(),
+        })
+        .or_else(|| {
+            commitments
+                .iter()
+                .find(|commitment| commitment.state == CommitmentState::Ready)
+                .map(|commitment| MissionDirective::Execute {
+                    commitment_id: commitment.commitment_id.clone(),
+                })
+        })
+        .or_else(|| {
+            commitments
+                .iter()
+                .find(|commitment| {
+                    commitment.state == CommitmentState::WaitingOnVerification
+                        || commitment.state == CommitmentState::Executing
+                })
+                .map(|commitment| MissionDirective::Verify {
+                    commitment_id: commitment.commitment_id.clone(),
+                })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ActorId, CommitmentInput, PlanId};
+
+    #[test]
+    fn supervisor_interrupts_only_for_the_pending_decision() {
+        let commitment = Commitment::propose(CommitmentInput {
+            commitment_id: CommitmentId::parse("commitment-1").unwrap(),
+            plan_id: PlanId::parse("plan-1").unwrap(),
+            plan_revision: 1,
+            step_id: "remove-access".into(),
+            actor_id: ActorId::parse("executor").unwrap(),
+            capability: "identity.access.revoke".into(),
+            resource_urn: "urn:identity:1".into(),
+            expected_effect: "Production access is removed".into(),
+            rollback_reference: Some("runbook:restore-access".into()),
+            requires_decision: true,
+        })
+        .unwrap();
+        assert_eq!(
+            next_directive(&SupervisorSnapshot {
+                mission_state: MissionState::WaitingOnApproval,
+                has_current_plan: true,
+                commitments: vec![commitment],
+                armed_wake_condition_ids: vec![],
+                satisfied_wake_condition_ids: vec![],
+            }),
+            MissionDirective::RequestDecision {
+                commitment_id: CommitmentId::parse("commitment-1").unwrap()
+            }
+        );
+    }
+}

--- a/crates/control-kernel/src/supervisor.rs
+++ b/crates/control-kernel/src/supervisor.rs
@@ -127,6 +127,34 @@ mod tests {
     use super::*;
     use crate::{ActorId, CommitmentInput, PlanId};
 
+    fn commitment(state: CommitmentState) -> Commitment {
+        let mut commitment = Commitment::propose(CommitmentInput {
+            commitment_id: CommitmentId::parse(format!("commitment-{state:?}")).unwrap(),
+            plan_id: PlanId::parse("plan-1").unwrap(),
+            plan_revision: 1,
+            step_id: "remove-access".into(),
+            actor_id: ActorId::parse("executor").unwrap(),
+            capability: "identity.access.revoke".into(),
+            resource_urn: "urn:identity:1".into(),
+            expected_effect: "Production access is removed".into(),
+            rollback_reference: Some("runbook:restore-access".into()),
+            requires_decision: true,
+        })
+        .unwrap();
+        commitment.state = state;
+        commitment
+    }
+
+    fn snapshot(state: MissionState) -> SupervisorSnapshot {
+        SupervisorSnapshot {
+            mission_state: state,
+            has_current_plan: true,
+            commitments: vec![],
+            armed_wake_condition_ids: vec![],
+            satisfied_wake_condition_ids: vec![],
+        }
+    }
+
     #[test]
     fn supervisor_interrupts_only_for_the_pending_decision() {
         let commitment = Commitment::propose(CommitmentInput {
@@ -153,6 +181,94 @@ mod tests {
             MissionDirective::RequestDecision {
                 commitment_id: CommitmentId::parse("commitment-1").unwrap()
             }
+        );
+    }
+
+    #[test]
+    fn supervisor_emits_a_bounded_directive_for_every_mission_state() {
+        assert_eq!(
+            next_directive(&snapshot(MissionState::Open)),
+            MissionDirective::ResolveScope
+        );
+        assert_eq!(
+            next_directive(&snapshot(MissionState::ResolvingScope)),
+            MissionDirective::ResolveScope
+        );
+
+        let mut planning = snapshot(MissionState::Planning);
+        planning.has_current_plan = false;
+        assert_eq!(next_directive(&planning), MissionDirective::RevisePlan);
+        planning.has_current_plan = true;
+        assert_eq!(
+            next_directive(&planning),
+            blocked("plan_has_no_active_commitment")
+        );
+        planning.commitments = vec![commitment(CommitmentState::WaitingOnApproval)];
+        assert!(matches!(
+            next_directive(&planning),
+            MissionDirective::RequestDecision { .. }
+        ));
+        planning.commitments = vec![commitment(CommitmentState::Ready)];
+        assert!(matches!(
+            next_directive(&planning),
+            MissionDirective::Execute { .. }
+        ));
+        planning.commitments = vec![commitment(CommitmentState::Executing)];
+        assert!(matches!(
+            next_directive(&planning),
+            MissionDirective::Verify { .. }
+        ));
+
+        for state in [MissionState::WaitingOnEvidence, MissionState::Blocked] {
+            let mut waiting = snapshot(state);
+            assert_eq!(next_directive(&waiting), blocked("no_wake_condition"));
+            waiting.armed_wake_condition_ids = vec![WakeConditionId::parse("wake-1").unwrap()];
+            assert!(matches!(
+                next_directive(&waiting),
+                MissionDirective::Wait { .. }
+            ));
+            waiting.satisfied_wake_condition_ids = vec![WakeConditionId::parse("wake-2").unwrap()];
+            assert!(matches!(
+                next_directive(&waiting),
+                MissionDirective::ReplanFromWake { .. }
+            ));
+        }
+
+        let mut approval = snapshot(MissionState::WaitingOnApproval);
+        assert_eq!(next_directive(&approval), blocked("no_pending_decision"));
+        approval.commitments = vec![commitment(CommitmentState::WaitingOnApproval)];
+        assert!(matches!(
+            next_directive(&approval),
+            MissionDirective::RequestDecision { .. }
+        ));
+
+        for state in [MissionState::ReadyToAct, MissionState::Acting] {
+            let mut acting = snapshot(state);
+            assert_eq!(next_directive(&acting), blocked("no_executable_commitment"));
+            acting.commitments = vec![commitment(CommitmentState::Ready)];
+            assert!(matches!(
+                next_directive(&acting),
+                MissionDirective::Execute { .. }
+            ));
+        }
+
+        let mut verifying = snapshot(MissionState::Verifying);
+        assert_eq!(
+            next_directive(&verifying),
+            blocked("no_commitment_to_verify")
+        );
+        verifying.commitments = vec![commitment(CommitmentState::WaitingOnVerification)];
+        assert!(matches!(
+            next_directive(&verifying),
+            MissionDirective::Verify { .. }
+        ));
+        assert_eq!(
+            next_directive(&snapshot(MissionState::Verified)),
+            MissionDirective::Close
+        );
+        assert_eq!(
+            next_directive(&snapshot(MissionState::Closed)),
+            MissionDirective::NoAction
         );
     }
 }

--- a/crates/control-kernel/src/wake.rs
+++ b/crates/control-kernel/src/wake.rs
@@ -219,6 +219,16 @@ fn validate_text(value: &str) -> Result<(), ()> {
 mod tests {
     use super::*;
 
+    fn arm(id: &str, kind: WakeConditionKind) -> WakeCondition {
+        WakeCondition::arm(
+            WakeConditionId::parse(id).unwrap(),
+            kind,
+            10,
+            "wait for a durable signal".into(),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn source_wake_requires_a_different_revision() {
         let condition = WakeCondition::arm(
@@ -246,6 +256,195 @@ mod tests {
         assert_eq!(
             condition.satisfy(&changed, 12).unwrap().state,
             WakeConditionState::Satisfied
+        );
+    }
+
+    #[test]
+    fn every_wake_kind_matches_only_its_bound_signal() {
+        let event = arm(
+            "wake-event",
+            WakeConditionKind::EventObserved {
+                event_type: "identity.offboarded".into(),
+                subject_urn: "urn:identity:1".into(),
+            },
+        );
+        assert_eq!(
+            event
+                .satisfy(
+                    &WakeSignal::Event {
+                        event_type: "identity.offboarded".into(),
+                        subject_urn: "urn:identity:1".into(),
+                    },
+                    11,
+                )
+                .unwrap()
+                .state,
+            WakeConditionState::Satisfied
+        );
+
+        let deadline = arm(
+            "wake-deadline",
+            WakeConditionKind::DeadlineReached {
+                not_before_unix_ms: 20,
+            },
+        );
+        assert_eq!(
+            deadline.satisfy(
+                &WakeSignal::Clock {
+                    observed_at_unix_ms: 19
+                },
+                19
+            ),
+            Err(WakeConditionError::SignalMismatch)
+        );
+        assert!(
+            deadline
+                .satisfy(
+                    &WakeSignal::Clock {
+                        observed_at_unix_ms: 20
+                    },
+                    20
+                )
+                .is_ok()
+        );
+
+        let conversation_id = ConversationId::parse("conversation-1").unwrap();
+        let conversation = arm(
+            "wake-conversation",
+            WakeConditionKind::ConversationAdvanced {
+                conversation_id: conversation_id.clone(),
+                after_sequence: 4,
+            },
+        );
+        assert!(
+            conversation
+                .satisfy(
+                    &WakeSignal::Conversation {
+                        conversation_id,
+                        sequence: 5,
+                    },
+                    12,
+                )
+                .is_ok()
+        );
+
+        let decision_id = DecisionId::parse("decision-1").unwrap();
+        let decision = arm(
+            "wake-decision",
+            WakeConditionKind::DecisionRecorded {
+                decision_id: decision_id.clone(),
+            },
+        );
+        assert!(
+            decision
+                .satisfy(&WakeSignal::Decision { decision_id }, 13)
+                .is_ok()
+        );
+        assert_eq!(
+            decision.satisfy(
+                &WakeSignal::Clock {
+                    observed_at_unix_ms: 100
+                },
+                13
+            ),
+            Err(WakeConditionError::SignalMismatch)
+        );
+    }
+
+    #[test]
+    fn wake_conditions_reject_invalid_or_terminal_changes() {
+        assert_eq!(
+            WakeCondition::arm(
+                WakeConditionId::parse("wake-invalid").unwrap(),
+                WakeConditionKind::DeadlineReached {
+                    not_before_unix_ms: 0
+                },
+                10,
+                "wait".into(),
+            ),
+            Err(WakeConditionError::InvalidCondition)
+        );
+        assert_eq!(
+            WakeCondition::arm(
+                WakeConditionId::parse("wake-invalid-time").unwrap(),
+                WakeConditionKind::DecisionRecorded {
+                    decision_id: DecisionId::parse("decision-1").unwrap(),
+                },
+                0,
+                "wait".into(),
+            ),
+            Err(WakeConditionError::InvalidCondition)
+        );
+        assert_eq!(
+            WakeCondition::arm(
+                WakeConditionId::parse("wake-invalid-text").unwrap(),
+                WakeConditionKind::SourceRevisionChanged {
+                    source_urn: "".into(),
+                    baseline_revision: "rev-1".into(),
+                },
+                10,
+                "wait".into(),
+            ),
+            Err(WakeConditionError::InvalidCondition)
+        );
+        assert_eq!(
+            WakeCondition::arm(
+                WakeConditionId::parse("wake-invalid-event").unwrap(),
+                WakeConditionKind::EventObserved {
+                    event_type: "identity.offboarded".into(),
+                    subject_urn: " urn:identity:1".into(),
+                },
+                10,
+                "wait".into(),
+            ),
+            Err(WakeConditionError::InvalidCondition)
+        );
+        assert_eq!(
+            WakeCondition::arm(
+                WakeConditionId::parse("wake-invalid-conversation").unwrap(),
+                WakeConditionKind::ConversationAdvanced {
+                    conversation_id: ConversationId::parse("conversation-1").unwrap(),
+                    after_sequence: 0,
+                },
+                10,
+                "wait".into(),
+            ),
+            Err(WakeConditionError::InvalidCondition)
+        );
+
+        let condition = arm(
+            "wake-cancel",
+            WakeConditionKind::DecisionRecorded {
+                decision_id: DecisionId::parse("decision-1").unwrap(),
+            },
+        );
+        assert_eq!(
+            condition.cancel("".into()),
+            Err(WakeConditionError::InvalidCondition)
+        );
+        assert_eq!(
+            condition.satisfy(
+                &WakeSignal::Decision {
+                    decision_id: DecisionId::parse("decision-1").unwrap(),
+                },
+                9,
+            ),
+            Err(WakeConditionError::SignalMismatch)
+        );
+        let cancelled = condition.cancel("mission retired".into()).unwrap();
+        assert_eq!(cancelled.state, WakeConditionState::Cancelled);
+        assert_eq!(
+            cancelled.cancel("cancel again".into()),
+            Err(WakeConditionError::AlreadyTerminal)
+        );
+        assert_eq!(
+            cancelled.satisfy(
+                &WakeSignal::Decision {
+                    decision_id: DecisionId::parse("decision-1").unwrap(),
+                },
+                12,
+            ),
+            Err(WakeConditionError::AlreadyTerminal)
         );
     }
 }

--- a/crates/control-kernel/src/wake.rs
+++ b/crates/control-kernel/src/wake.rs
@@ -1,0 +1,251 @@
+use std::{error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ConversationId, DecisionId, WakeConditionId};
+
+const MAX_TEXT_BYTES: usize = 4_096;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WakeConditionKind {
+    SourceRevisionChanged {
+        source_urn: String,
+        baseline_revision: String,
+    },
+    EventObserved {
+        event_type: String,
+        subject_urn: String,
+    },
+    DeadlineReached {
+        not_before_unix_ms: u64,
+    },
+    ConversationAdvanced {
+        conversation_id: ConversationId,
+        after_sequence: u64,
+    },
+    DecisionRecorded {
+        decision_id: DecisionId,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "signal", rename_all = "snake_case")]
+pub enum WakeSignal {
+    SourceRevision {
+        source_urn: String,
+        revision: String,
+    },
+    Event {
+        event_type: String,
+        subject_urn: String,
+    },
+    Clock {
+        observed_at_unix_ms: u64,
+    },
+    Conversation {
+        conversation_id: ConversationId,
+        sequence: u64,
+    },
+    Decision {
+        decision_id: DecisionId,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WakeConditionState {
+    Armed,
+    Satisfied,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WakeCondition {
+    pub wake_condition_id: WakeConditionId,
+    pub kind: WakeConditionKind,
+    pub state: WakeConditionState,
+    pub armed_at_unix_ms: u64,
+    pub satisfied_at_unix_ms: Option<u64>,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WakeConditionError {
+    InvalidCondition,
+    AlreadyTerminal,
+    SignalMismatch,
+}
+
+impl fmt::Display for WakeConditionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCondition => formatter.write_str("wake condition is invalid"),
+            Self::AlreadyTerminal => formatter.write_str("wake condition is already terminal"),
+            Self::SignalMismatch => formatter.write_str("wake signal does not satisfy condition"),
+        }
+    }
+}
+
+impl Error for WakeConditionError {}
+
+impl WakeCondition {
+    pub fn arm(
+        wake_condition_id: WakeConditionId,
+        kind: WakeConditionKind,
+        armed_at_unix_ms: u64,
+        reason: String,
+    ) -> Result<Self, WakeConditionError> {
+        if armed_at_unix_ms == 0 || !kind.is_valid() || validate_text(&reason).is_err() {
+            return Err(WakeConditionError::InvalidCondition);
+        }
+        Ok(Self {
+            wake_condition_id,
+            kind,
+            state: WakeConditionState::Armed,
+            armed_at_unix_ms,
+            satisfied_at_unix_ms: None,
+            reason,
+        })
+    }
+
+    pub fn satisfy(
+        &self,
+        signal: &WakeSignal,
+        observed_at_unix_ms: u64,
+    ) -> Result<Self, WakeConditionError> {
+        if self.state != WakeConditionState::Armed {
+            return Err(WakeConditionError::AlreadyTerminal);
+        }
+        if observed_at_unix_ms < self.armed_at_unix_ms || !self.kind.matches(signal) {
+            return Err(WakeConditionError::SignalMismatch);
+        }
+        let mut next = self.clone();
+        next.state = WakeConditionState::Satisfied;
+        next.satisfied_at_unix_ms = Some(observed_at_unix_ms);
+        Ok(next)
+    }
+
+    pub fn cancel(&self, reason: String) -> Result<Self, WakeConditionError> {
+        if self.state != WakeConditionState::Armed {
+            return Err(WakeConditionError::AlreadyTerminal);
+        }
+        validate_text(&reason).map_err(|_| WakeConditionError::InvalidCondition)?;
+        let mut next = self.clone();
+        next.state = WakeConditionState::Cancelled;
+        next.reason = reason;
+        Ok(next)
+    }
+}
+
+impl WakeConditionKind {
+    fn is_valid(&self) -> bool {
+        match self {
+            Self::SourceRevisionChanged {
+                source_urn,
+                baseline_revision,
+            } => validate_text(source_urn).is_ok() && validate_text(baseline_revision).is_ok(),
+            Self::EventObserved {
+                event_type,
+                subject_urn,
+            } => validate_text(event_type).is_ok() && validate_text(subject_urn).is_ok(),
+            Self::DeadlineReached { not_before_unix_ms } => *not_before_unix_ms > 0,
+            Self::ConversationAdvanced { after_sequence, .. } => *after_sequence > 0,
+            Self::DecisionRecorded { .. } => true,
+        }
+    }
+
+    fn matches(&self, signal: &WakeSignal) -> bool {
+        match (self, signal) {
+            (
+                Self::SourceRevisionChanged {
+                    source_urn,
+                    baseline_revision,
+                },
+                WakeSignal::SourceRevision {
+                    source_urn: observed_source,
+                    revision,
+                },
+            ) => source_urn == observed_source && baseline_revision != revision,
+            (
+                Self::EventObserved {
+                    event_type,
+                    subject_urn,
+                },
+                WakeSignal::Event {
+                    event_type: observed_type,
+                    subject_urn: observed_subject,
+                },
+            ) => event_type == observed_type && subject_urn == observed_subject,
+            (
+                Self::DeadlineReached { not_before_unix_ms },
+                WakeSignal::Clock {
+                    observed_at_unix_ms,
+                },
+            ) => observed_at_unix_ms >= not_before_unix_ms,
+            (
+                Self::ConversationAdvanced {
+                    conversation_id,
+                    after_sequence,
+                },
+                WakeSignal::Conversation {
+                    conversation_id: observed_conversation,
+                    sequence,
+                },
+            ) => conversation_id == observed_conversation && sequence > after_sequence,
+            (
+                Self::DecisionRecorded { decision_id },
+                WakeSignal::Decision {
+                    decision_id: observed_decision,
+                },
+            ) => decision_id == observed_decision,
+            _ => false,
+        }
+    }
+}
+
+fn validate_text(value: &str) -> Result<(), ()> {
+    if value.trim().is_empty()
+        || value.trim() != value
+        || value.len() > MAX_TEXT_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_wake_requires_a_different_revision() {
+        let condition = WakeCondition::arm(
+            WakeConditionId::parse("wake-1").unwrap(),
+            WakeConditionKind::SourceRevisionChanged {
+                source_urn: "urn:source:identity".into(),
+                baseline_revision: "rev-1".into(),
+            },
+            10,
+            "wait for authoritative access state".into(),
+        )
+        .unwrap();
+        let unchanged = WakeSignal::SourceRevision {
+            source_urn: "urn:source:identity".into(),
+            revision: "rev-1".into(),
+        };
+        assert_eq!(
+            condition.satisfy(&unchanged, 11),
+            Err(WakeConditionError::SignalMismatch)
+        );
+        let changed = WakeSignal::SourceRevision {
+            source_urn: "urn:source:identity".into(),
+            revision: "rev-2".into(),
+        };
+        assert_eq!(
+            condition.satisfy(&changed, 12).unwrap().state,
+            WakeConditionState::Satisfied
+        );
+    }
+}

--- a/crates/control-kernel/tests/mission_operating_loop.rs
+++ b/crates/control-kernel/tests/mission_operating_loop.rs
@@ -1,0 +1,323 @@
+use cerebro_control_kernel::{
+    ActorId, BeliefBasis, BeliefId, BeliefInput, BeliefRevision, BeliefVerdict, CommitmentId,
+    CommitmentInput, CommitmentState, CommitmentTransition, DecisionId, GrantId, MandateId,
+    MissionAggregate, MissionEvent, MissionEventEnvelope, MissionId, MissionInput, MissionState,
+    PlanId, PlanRevision, PlanStep, TenantId, VerificationId, VerificationReceipt, WakeConditionId,
+    WakeConditionKind, WakeConditionState, WakeSignal,
+};
+
+fn envelope(sequence: u64, actor: &str, event: MissionEvent) -> MissionEventEnvelope {
+    MissionEventEnvelope {
+        schema_version: cerebro_control_kernel::SCHEMA_VERSION.into(),
+        tenant_id: TenantId::parse("tenant-1").unwrap(),
+        mission_id: MissionId::parse("mission-offboarding-1").unwrap(),
+        sequence,
+        observed_at_unix_ms: 1_000 + sequence,
+        actor_id: ActorId::parse(actor).unwrap(),
+        idempotency_key: format!("mission-offboarding-1:{sequence}"),
+        event,
+    }
+}
+
+fn transition(from: MissionState, to: MissionState, reason: &str) -> MissionEvent {
+    MissionEvent::Transitioned {
+        from,
+        to,
+        reason: reason.into(),
+    }
+}
+
+#[test]
+fn offboarding_mission_survives_approval_execution_verification_and_reopen() {
+    let belief_id = BeliefId::parse("belief-access-remains").unwrap();
+    let plan_id = PlanId::parse("plan-remove-access").unwrap();
+    let commitment_id = CommitmentId::parse("commitment-remove-access").unwrap();
+    let wake_condition_id = WakeConditionId::parse("wake-access-revision").unwrap();
+    let events = vec![
+        envelope(
+            1,
+            "kernel",
+            MissionEvent::Opened {
+                input: MissionInput {
+                    tenant_id: TenantId::parse("tenant-1").unwrap(),
+                    mission_id: MissionId::parse("mission-offboarding-1").unwrap(),
+                    mandate_id: MandateId::parse("mandate-offboarding").unwrap(),
+                    mandate_revision: 1,
+                    objective: "Remove production access for a terminated identity".into(),
+                    subject_urns: vec!["urn:identity:former-worker".into()],
+                    actor_id: ActorId::parse("kernel").unwrap(),
+                },
+            },
+        ),
+        envelope(
+            2,
+            "resolver",
+            transition(
+                MissionState::Open,
+                MissionState::ResolvingScope,
+                "resolve the identity and effective access path",
+            ),
+        ),
+        envelope(
+            3,
+            "resolver",
+            MissionEvent::BeliefRecorded {
+                input: BeliefInput {
+                    belief_id: belief_id.clone(),
+                    statement: "The terminated identity retains production access".into(),
+                    basis: BeliefBasis::DeterministicallyDerived,
+                    verdict: BeliefVerdict::Candidate,
+                    subject_urns: vec!["urn:identity:former-worker".into()],
+                    supporting_evidence_urns: vec!["urn:evidence:access:rev-1".into()],
+                    counterevidence_urns: vec![],
+                    missing_evidence: vec!["post-change access snapshot".into()],
+                    invalidation_conditions: vec!["access source revision changes".into()],
+                    confidence_basis_points: 8_000,
+                    source_revision: Some("rev-1".into()),
+                    actor_id: ActorId::parse("resolver").unwrap(),
+                },
+            },
+        ),
+        envelope(
+            4,
+            "planner",
+            transition(
+                MissionState::ResolvingScope,
+                MissionState::Planning,
+                "the subject and effective path are known",
+            ),
+        ),
+        envelope(
+            5,
+            "planner",
+            MissionEvent::PlanRevised {
+                revision: PlanRevision {
+                    plan_id: plan_id.clone(),
+                    revision: 1,
+                    previous_revision: None,
+                    rationale:
+                        "Remove the effective access path and verify a newer source revision".into(),
+                    hypothesis_ids: vec![belief_id.clone()],
+                    steps: vec![PlanStep {
+                        step_id: "remove-access".into(),
+                        capability: "identity.access.revoke".into(),
+                        subject_urn: "urn:identity:former-worker".into(),
+                        expected_effect: "No production access path remains".into(),
+                        depends_on: vec![],
+                        requires_decision: true,
+                    }],
+                    superseded_step_ids: vec![],
+                    created_by: ActorId::parse("planner").unwrap(),
+                },
+            },
+        ),
+        envelope(
+            6,
+            "planner",
+            MissionEvent::CommitmentProposed {
+                input: CommitmentInput {
+                    commitment_id: commitment_id.clone(),
+                    plan_id: plan_id.clone(),
+                    plan_revision: 1,
+                    step_id: "remove-access".into(),
+                    actor_id: ActorId::parse("executor").unwrap(),
+                    capability: "identity.access.revoke".into(),
+                    resource_urn: "urn:identity:former-worker".into(),
+                    expected_effect: "No production access path remains".into(),
+                    rollback_reference: Some("runbook:restore-access".into()),
+                    requires_decision: true,
+                },
+            },
+        ),
+        envelope(
+            7,
+            "planner",
+            transition(
+                MissionState::Planning,
+                MissionState::WaitingOnApproval,
+                "the production mutation needs an exact decision",
+            ),
+        ),
+        envelope(
+            8,
+            "operator",
+            MissionEvent::CommitmentTransitioned {
+                commitment_id: commitment_id.clone(),
+                transition: CommitmentTransition {
+                    expected_revision: 1,
+                    to: CommitmentState::Ready,
+                    grant_id: None,
+                    decision_id: Some(DecisionId::parse("decision-remove-access").unwrap()),
+                    receipt_urns: vec![],
+                    reason: "operator approved the exact removal".into(),
+                },
+            },
+        ),
+        envelope(
+            9,
+            "kernel",
+            transition(
+                MissionState::WaitingOnApproval,
+                MissionState::ReadyToAct,
+                "the exact commitment is approved",
+            ),
+        ),
+        envelope(
+            10,
+            "executor",
+            MissionEvent::CommitmentTransitioned {
+                commitment_id: commitment_id.clone(),
+                transition: CommitmentTransition {
+                    expected_revision: 2,
+                    to: CommitmentState::Executing,
+                    grant_id: Some(GrantId::parse("grant-remove-access").unwrap()),
+                    decision_id: None,
+                    receipt_urns: vec![],
+                    reason: "execute through the approved identity adapter".into(),
+                },
+            },
+        ),
+        envelope(
+            11,
+            "executor",
+            transition(
+                MissionState::ReadyToAct,
+                MissionState::Acting,
+                "the approved commitment is executing",
+            ),
+        ),
+        envelope(
+            12,
+            "executor",
+            MissionEvent::CommitmentTransitioned {
+                commitment_id: commitment_id.clone(),
+                transition: CommitmentTransition {
+                    expected_revision: 3,
+                    to: CommitmentState::WaitingOnVerification,
+                    grant_id: None,
+                    decision_id: None,
+                    receipt_urns: vec!["urn:receipt:execution:remove-access".into()],
+                    reason: "the provider accepted the removal".into(),
+                },
+            },
+        ),
+        envelope(
+            13,
+            "kernel",
+            MissionEvent::WakeConditionArmed {
+                wake_condition_id: wake_condition_id.clone(),
+                kind: WakeConditionKind::SourceRevisionChanged {
+                    source_urn: "urn:source:identity-access".into(),
+                    baseline_revision: "rev-1".into(),
+                },
+                reason: "wait for an authoritative post-change snapshot".into(),
+            },
+        ),
+        envelope(
+            14,
+            "kernel",
+            transition(
+                MissionState::Acting,
+                MissionState::Verifying,
+                "provider success is not closure",
+            ),
+        ),
+        envelope(
+            15,
+            "source-runtime",
+            MissionEvent::WakeConditionSatisfied {
+                wake_condition_id: wake_condition_id.clone(),
+                signal: WakeSignal::SourceRevision {
+                    source_urn: "urn:source:identity-access".into(),
+                    revision: "rev-2".into(),
+                },
+            },
+        ),
+        envelope(
+            16,
+            "verifier",
+            MissionEvent::BeliefRevised {
+                belief_id: belief_id.clone(),
+                revision: BeliefRevision {
+                    expected_revision: 1,
+                    verdict: BeliefVerdict::Contradicted,
+                    supporting_evidence_urns: vec![],
+                    counterevidence_urns: vec!["urn:evidence:access:rev-2".into()],
+                    missing_evidence: vec![],
+                    invalidation_conditions: vec!["access source revision changes".into()],
+                    confidence_basis_points: 9_900,
+                    source_revision: Some("rev-2".into()),
+                    actor_id: ActorId::parse("verifier").unwrap(),
+                },
+            },
+        ),
+        envelope(
+            17,
+            "verifier",
+            MissionEvent::CommitmentTransitioned {
+                commitment_id: commitment_id.clone(),
+                transition: CommitmentTransition {
+                    expected_revision: 4,
+                    to: CommitmentState::Fulfilled,
+                    grant_id: None,
+                    decision_id: None,
+                    receipt_urns: vec!["urn:receipt:verification:access-rev-2".into()],
+                    reason: "a newer authoritative snapshot shows no access path".into(),
+                },
+            },
+        ),
+        envelope(
+            18,
+            "verifier",
+            MissionEvent::Verified {
+                from: MissionState::Verifying,
+                reason: "production access is independently absent".into(),
+                receipt: VerificationReceipt {
+                    verification_id: VerificationId::parse("verification-access-rev-2").unwrap(),
+                    executor_actor_id: ActorId::parse("executor").unwrap(),
+                    verifier_actor_id: ActorId::parse("verifier").unwrap(),
+                    previous_source_revision: "rev-1".into(),
+                    observed_source_revision: "rev-2".into(),
+                    effective: true,
+                    evidence_urns: vec!["urn:evidence:access:rev-2".into()],
+                    verified_at_unix_ms: 1_018,
+                },
+            },
+        ),
+        envelope(
+            19,
+            "kernel",
+            transition(
+                MissionState::Verified,
+                MissionState::Closed,
+                "the desired condition is verified",
+            ),
+        ),
+        envelope(
+            20,
+            "source-runtime",
+            transition(
+                MissionState::Closed,
+                MissionState::ResolvingScope,
+                "a later source event requires the condition to be checked again",
+            ),
+        ),
+    ];
+
+    let first = MissionAggregate::replay(&events).unwrap();
+    let second = MissionAggregate::replay(&events).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(first.mission.state, MissionState::ResolvingScope);
+    assert_eq!(
+        first.beliefs[&belief_id].verdict,
+        BeliefVerdict::Contradicted
+    );
+    assert_eq!(
+        first.commitments[&commitment_id].state,
+        CommitmentState::Fulfilled
+    );
+    assert_eq!(
+        first.wake_conditions[&wake_condition_id].state,
+        WakeConditionState::Satisfied
+    );
+}

--- a/docs/engineering/native-mission-operating-contract.md
+++ b/docs/engineering/native-mission-operating-contract.md
@@ -1,0 +1,171 @@
+# Native Mission Operating Contract
+
+## Decision
+
+Cerebro will treat a mission as the durable unit of agent work. A mission records the condition Cerebro must change,
+the current beliefs about that condition, the active plan, exact commitments, authority, verification requirements,
+and the events that should resume work.
+
+A finding, case, ticket, pull request, chat response, provider receipt, or completed job can contribute to a mission.
+None of them closes it. Closure requires an independently verified desired condition.
+
+## Customer Outcome
+
+An operator can state a continuing objective once. Cerebro resumes when relevant facts change, performs work covered
+by existing authority, requests only decisions it cannot make, verifies the result from a newer authoritative
+observation, and reopens the mission if the condition later becomes false.
+
+The operator should not have to reconstruct the objective, prior investigation, attempted actions, or remaining
+decision every time they continue the conversation.
+
+## Durable Records
+
+The native control kernel owns six records:
+
+1. **Mandate:** the desired condition, scope, maximum violation age, and lifecycle revision.
+2. **Mission:** one concrete unresolved difference between observed state and the mandate.
+3. **Belief:** a versioned statement with evidence, counterevidence, missing evidence, confidence, source revision,
+   and explicit invalidation conditions.
+4. **Plan revision:** an immutable hypothesis-bound set of ordered capability steps. A revision states why the plan
+   changed and which steps it superseded.
+5. **Commitment:** one actor's exact capability, target, expected effect, authority, execution state, rollback
+   reference, and receipts.
+6. **Wake condition:** a source revision, event, deadline, conversation sequence, or decision that should resume work.
+
+Application records remain useful projections. Findings explain current risk. Controls and claims explain assurance.
+Tickets and pull requests coordinate external work. Evidence packages support a recipient and period. They do not
+become parallel mission stores.
+
+## Belief Rules
+
+- Every material belief has stable identity and optimistic revision checks.
+- `supported` requires supporting evidence with no counterevidence or named missing evidence.
+- `contradicted` requires counterevidence.
+- Confidence is bounded data, not a substitute for evidence.
+- Every belief names what would invalidate it.
+- Source revisions remain opaque. A later observation is proven by a different committed revision, not by ordering
+  arbitrary revision strings.
+- Model text may propose a belief. Only a validated event records or revises it.
+
+## Plan And Commitment Rules
+
+- Plans are immutable revisions, not mutable model scratchpads.
+- Every plan references the beliefs it is intended to test or change.
+- Every step names a capability, stable subject, expected effect, dependencies, and whether a decision is required.
+- A commitment binds one plan step to an actor and resource.
+- Approval binds the exact commitment. A changed target or effect requires a new decision.
+- Execution requires a current scoped grant.
+- Provider acceptance moves a commitment to verification; it does not fulfill it.
+- Fulfillment requires a receipt from the verification path.
+
+## Wake Rules
+
+Missions sleep durably. They do not poll through model calls.
+
+Supported wake conditions are:
+
+- a committed source revision changes;
+- a typed event is observed for the exact subject;
+- a deadline is reached;
+- a bound conversation advances;
+- an exact decision is recorded.
+
+Wake conditions are armed, satisfied, or cancelled. Replay must derive the same status. A wake signal cannot widen
+tenant, mission, subject, or decision scope.
+
+## Conversation Resolution
+
+Chat and agent protocols are command surfaces over missions, not mission storage.
+
+An encounter resolves in this order:
+
+1. Continue an explicitly referenced mission when it exists.
+2. Continue the only open mission that overlaps the resolved subjects.
+3. Ask the operator to choose when multiple open missions match.
+4. Open a mission when no existing mission matches.
+
+Subject extraction may use a model. The kernel receives typed subject identifiers and applies deterministic resolution.
+The raw transcript is retained for traceability but does not replace mission state.
+
+## Adaptive Execution Depth
+
+The kernel routes each encounter to the least expensive sufficient path:
+
+- **Read current state:** a follow-up can be answered from fresh durable mission state with no material evidence gap.
+- **Targeted verification:** the answer needs a newer fact or one bounded capability call.
+- **Deep investigation:** the operator explicitly requests it, or a consequential action has a material evidence gap.
+
+This routing decision is recorded. A short follow-up must not launch a default research pipeline merely because a
+model is available.
+
+## Supervisor Directives
+
+The supervisor emits one typed directive from replayed state:
+
+- resolve scope;
+- revise the plan;
+- request one exact decision;
+- execute one ready commitment;
+- verify one executed commitment;
+- wait on named wake conditions;
+- replan from satisfied wake conditions;
+- block with a stable code when the state has no executable commitment or valid wake condition;
+- close a verified mission;
+- take no action.
+
+The supervisor does not generate prose, call providers, or advance state. Runtime adapters execute a directive and
+append the resulting event or failure.
+
+## Interruption Policy
+
+Cerebro contacts an operator when:
+
+- a decision is required for a named commitment;
+- evidence invalidates the current plan;
+- authority, time, or execution budget is exhausted;
+- the mission is blocked with no valid wake condition;
+- the desired condition is independently verified;
+- a previously verified condition becomes false again.
+
+Routine observations, plan updates, retries inside policy, and progress already visible in mission state do not need
+separate notifications.
+
+## First Complete Mandate
+
+The first complete mandate remains: no terminated identity retains production access for more than 24 hours.
+
+The acceptance trajectory is:
+
+1. Resolve a termination and effective access observation to one mission.
+2. Record the belief that access remains, including missing post-change evidence and an invalidation condition.
+3. Record an immutable plan and exact removal commitment.
+4. Request the minimum required decision.
+5. Execute through a scoped identity capability grant.
+6. Record provider acceptance as an execution receipt.
+7. Arm a wake condition for a changed authoritative source revision.
+8. Revise the belief from the newer observation.
+9. Fulfill the commitment and verify the mission using a distinct verifier.
+10. Close the mission, then reopen scope resolution when a later source event requires a new check.
+
+The control-kernel integration test replays this trajectory twice and requires identical aggregates.
+
+## Measures
+
+Measure the operating result:
+
+- time from mandate violation to verified condition;
+- human decisions per verified mission;
+- missions closed without an avoidable interruption;
+- time waiting without a valid wake condition;
+- verification failure and false-closure rate;
+- reopened missions;
+- receipts reused by findings, assurance, and disclosure projections;
+- time to answer a follow-up from current mission state.
+
+Do not use model calls, tool calls, plan steps, generated findings, or messages sent as outcome measures.
+
+## Boundary
+
+The kernel remains pure Rust domain code. JetStream is the event log, Postgres holds current projections and leases,
+and Neo4j remains rebuildable. Runtime adapters own transport, storage, model calls, provider calls, and notifications.
+No new database, graph write path, unmediated action surface, or generic workflow language is introduced.

--- a/docs/engineering/rust-control-kernel-carve.md
+++ b/docs/engineering/rust-control-kernel-carve.md
@@ -34,6 +34,10 @@ Provider execution has its own staged carve. [`rust-source-runtime-adr.md`](rust
 
 The graph remains a rebuildable projection. It is not a mission store, scheduler, authority system, or closure record.
 
+[`native-mission-operating-contract.md`](native-mission-operating-contract.md) defines how beliefs, plan revisions,
+commitments, wake conditions, conversation resolution, and supervisor directives make that mission ownership
+executable without granting a model authority over state transitions.
+
 ## Process Boundary
 
 The control kernel runs as a native Linux process. It does not use CGO, in-process Go/Rust FFI, or embedded Wasm for orchestration. The current embedded Rust/Wasm modules remain bounded deterministic helpers. The kernel communicates with the compatibility plane through:


### PR DESCRIPTION
## What changed

- adds typed beliefs with evidence, counterevidence, revision checks, and invalidation conditions
- adds immutable plan revisions with dependency validation and cycle rejection
- adds governed commitments with approval, grant, execution, and verification receipt gates
- adds durable wake conditions for source revisions, events, deadlines, conversations, and decisions
- adds deterministic conversation routing, adaptive execution depth, and supervisor directives
- extends mission replay and the public control protocol with the new records and commands
- documents the native mission operating contract

## Why

Mission state previously recorded lifecycle and authority but not the beliefs, plans, commitments, or wake conditions needed to continue work across agent runs. The kernel now preserves those records and refuses verified closure while commitments or wake conditions remain active.

## Impact

Runtime adapters can continue an existing mission, select the least expensive sufficient execution path, request one exact decision, execute a granted commitment, wait for authoritative state, and close only after independent verification. Existing mission events and commands remain supported.

## Validation

- `make rust-workspace-policy rust-fmt-check rust-clippy rust-test rust-doc-check`
- `make docs-drift-check`
- `cargo test -p cerebro-control-kernel`
- `cargo clippy -p cerebro-control-kernel --all-targets --all-features -- -D warnings`
