### PR TITLE
Expose native mission operating contract

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -380,6 +380,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentPlatformSecurityControlPlane'
+  /api/v1/agent-platform/missions/contract:
+    get:
+      operationId: getAgentPlatformMissionOperatingContract
+      summary: Get mission operating contract
+      tags:
+        - Platform
+      responses:
+        '200':
+          description: Durable mandate, mission, belief, plan revision, commitment, wake, interruption, and verified-closure contract.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentPlatformMissionOperatingContract'
   /api/v1/event-subscriptions/contract:
     get:
       operationId: getEventSubscriptionContract
@@ -8915,6 +8928,9 @@ components:
       required:
         - version
         - evidence_packet
+        - claim_verification
+        - agent_work
+        - mission_operating
         - agent_profiles
         - verifier_layer
         - action_ladder
@@ -8929,6 +8945,14 @@ components:
         evidence_packet:
           type: object
           additionalProperties: true
+        claim_verification:
+          type: object
+          additionalProperties: true
+        agent_work:
+          type: object
+          additionalProperties: true
+        mission_operating:
+          $ref: '#/components/schemas/AgentPlatformMissionOperatingContract'
         agent_profiles:
           type: array
           items:
@@ -8963,6 +8987,62 @@ components:
           items:
             type: object
             additionalProperties: true
+    AgentPlatformMissionOperatingContract:
+      type: object
+      required:
+        - id
+        - purpose
+        - schema_version
+        - durable_records
+        - execution_depths
+        - supervisor_directives
+        - wake_conditions
+        - interruption_triggers
+        - close_conditions
+        - first_mandate
+      properties:
+        id:
+          type: string
+        purpose:
+          type: string
+        schema_version:
+          type: string
+        durable_records:
+          type: array
+          items:
+            type: object
+            required: [id, purpose, required]
+            properties:
+              id:
+                type: string
+              purpose:
+                type: string
+              required:
+                type: array
+                items:
+                  type: string
+        execution_depths:
+          type: array
+          items:
+            type: string
+        supervisor_directives:
+          type: array
+          items:
+            type: string
+        wake_conditions:
+          type: array
+          items:
+            type: string
+        interruption_triggers:
+          type: array
+          items:
+            type: string
+        close_conditions:
+          type: array
+          items:
+            type: string
+        first_mandate:
+          type: string
     AgentPlatformEvidencePacketRequest:
       type: object
       properties:

--- a/docs/domains/agent-platform-contract.md
+++ b/docs/domains/agent-platform-contract.md
@@ -64,6 +64,10 @@ Security-agent behavior is exposed through `internal/agentplatform.SecurityContr
 `/api/v1/agent-platform/security-control-plane` route. The control plane is the registry that agents should reason
 from before touching graph context, connector tools, findings, memory, or remediation surfaces.
 
+The `mission_operating` block and `/api/v1/agent-platform/missions/contract` route define durable mandates,
+missions, beliefs, plan revisions, commitments, and wake conditions. Existing agent work is a projection of that
+contract, not a parallel transcript-backed lifecycle.
+
 The first supported integration strategies are:
 
 - A2A protocol boundary: public discovery is limited to `/.well-known/agent-card.json` and the legacy

--- a/docs/domains/mcp-droid-setup.md
+++ b/docs/domains/mcp-droid-setup.md
@@ -103,6 +103,9 @@ counterevidence, missing evidence, freshness state, coverage caveats, a verdict,
 and the highest allowed next action stage. `cerebro.agent.work.contract` returns
 the `agent-work-ledger` state model and closure contract for resumable
 investigations.
+`cerebro.agent.missions.contract` returns the mandate, mission, belief, plan
+revision, commitment, wake condition, interruption, and verified-closure
+contract that agent work projects from.
 
 ## Native Droid client configuration
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -28,6 +28,7 @@ Set `CEREBRO_API_AUTH_ENABLED=true` and pass `Authorization: Bearer <key>` or `X
 - `GET /api/v1/agent-platform/contract`
 - `GET /api/v1/agent-platform/capabilities`
 - `GET /api/v1/agent-platform/security-control-plane`
+- `GET /api/v1/agent-platform/missions/contract`
 - `GET /api/v1/event-subscriptions/contract`
 - `GET /api/v1/idempotency-contract`
 - `POST /platform/knowledge/decisions`

--- a/internal/agentplatform/claim_verification.go
+++ b/internal/agentplatform/claim_verification.go
@@ -34,6 +34,7 @@ type ClaimVerifierGate struct {
 type AgentWorkContract struct {
 	ID                string   `json:"id"`
 	Purpose           string   `json:"purpose"`
+	ProjectionOf      string   `json:"projection_of"`
 	RequiredFields    []string `json:"required_fields"`
 	StateModel        []string `json:"state_model"`
 	RequiredArtifacts []string `json:"required_artifacts"`
@@ -117,8 +118,9 @@ func claimVerificationContract() ClaimVerificationContract {
 
 func agentWorkContract() AgentWorkContract {
 	return AgentWorkContract{
-		ID:      "agent-work-ledger",
-		Purpose: "Represent an agent investigation as a durable work object so claims, evidence, verifier results, action proposals, approvals, and closure can survive context loss.",
+		ID:           "agent-work-ledger",
+		Purpose:      "Represent an agent investigation as a durable work object so claims, evidence, verifier results, action proposals, approvals, and closure can survive context loss.",
+		ProjectionOf: "native-mission-operating-contract",
 		RequiredFields: []string{
 			"work_id",
 			"tenant_id",

--- a/internal/agentplatform/contracts.go
+++ b/internal/agentplatform/contracts.go
@@ -809,6 +809,33 @@ var Capabilities = []Capability{
 			RequiredApprovers: []string{"platform", "security"},
 		},
 	},
+	{
+		ID:              "native-mission-operating-contract",
+		Name:            "Native mission operating contract",
+		DomainID:        "streaming-replay",
+		Kind:            "mission-control-contract",
+		Version:         "1.0.0",
+		Owner:           "cerebro-platform",
+		Risk:            "high",
+		DefaultOn:       true,
+		Summary:         "Defines durable mandates, missions, beliefs, plan revisions, commitments, wake conditions, supervisor directives, and verified closure.",
+		ConsoleSurfaces: []string{"Agent platform API", "MCP", "workflow replay"},
+		RequiredScopes:  []string{ScopeCosmoSecurityRead},
+		Eval: EvalStatus{
+			Required:      true,
+			Status:        "required",
+			LocalCommands: []string{"go test ./internal/agentplatform -run TestMissionOperatingContract"},
+			ScenarioSets:  []string{"agent-work-ledger", "trace-replay", "remediation-safety"},
+			Rubrics:       []string{"continuing intent", "belief provenance", "plan revision", "commitment authority", "wake semantics", "verified closure"},
+		},
+		RuntimeEvents: []string{"agent.work.created", "agent.work.updated", "claim.verification.completed", "verifier.completed", "agent.work.closed"},
+		Provenance:    []string{"agent-work", "claim-verification", "replay-record", "verifier-result", "evidence-record"},
+		Review: ReviewStatus{
+			State:             "required",
+			Cadence:           "before mission state, authority, wake, or closure semantics change",
+			RequiredApprovers: []string{"platform", "security"},
+		},
+	},
 }
 
 var RuntimeEvents = []RuntimeEvent{

--- a/internal/agentplatform/mission_operating.go
+++ b/internal/agentplatform/mission_operating.go
@@ -1,0 +1,79 @@
+package agentplatform
+
+type MissionOperatingContract struct {
+	ID                   string                  `json:"id"`
+	Purpose              string                  `json:"purpose"`
+	SchemaVersion        string                  `json:"schema_version"`
+	DurableRecords       []MissionRecordContract `json:"durable_records"`
+	ExecutionDepths      []string                `json:"execution_depths"`
+	SupervisorDirectives []string                `json:"supervisor_directives"`
+	WakeConditions       []string                `json:"wake_conditions"`
+	InterruptionTriggers []string                `json:"interruption_triggers"`
+	CloseConditions      []string                `json:"close_conditions"`
+	FirstMandate         string                  `json:"first_mandate"`
+}
+
+type MissionRecordContract struct {
+	ID       string   `json:"id"`
+	Purpose  string   `json:"purpose"`
+	Required []string `json:"required"`
+}
+
+func missionOperatingContract() MissionOperatingContract {
+	return MissionOperatingContract{
+		ID:            "native-mission-operating-contract",
+		Purpose:       "Keep one objective, beliefs, plan revisions, commitments, wake conditions, authority, and verification state durable across agent runs.",
+		SchemaVersion: "cerebro.control-kernel.v1",
+		DurableRecords: []MissionRecordContract{
+			{ID: "mandate", Purpose: "Define the desired condition, scope, maximum violation age, and lifecycle revision.", Required: []string{"mandate_id", "revision", "desired_condition", "scope_urns", "maximum_violation_age_seconds", "status"}},
+			{ID: "mission", Purpose: "Track one unresolved difference between observed state and the mandate.", Required: []string{"mission_id", "mandate_id", "mandate_revision", "objective", "subject_urns", "state", "revision"}},
+			{ID: "belief", Purpose: "Preserve a versioned statement with support, contradiction, gaps, confidence, source revision, and invalidation conditions.", Required: []string{"belief_id", "revision", "statement", "basis", "verdict", "subject_urns", "invalidation_conditions"}},
+			{ID: "plan_revision", Purpose: "Bind immutable capability steps to the beliefs they test or change.", Required: []string{"plan_id", "revision", "rationale", "hypothesis_ids", "steps", "created_by"}},
+			{ID: "commitment", Purpose: "Bind one plan step to an actor, capability, target, expected effect, authority, rollback, and receipts.", Required: []string{"commitment_id", "plan_id", "plan_revision", "actor_id", "capability", "resource_urn", "expected_effect", "state"}},
+			{ID: "wake_condition", Purpose: "Name the exact source change, event, deadline, conversation, or decision that resumes work.", Required: []string{"wake_condition_id", "kind", "state", "armed_at_unix_ms", "reason"}},
+		},
+		ExecutionDepths: []string{"read_current_state", "targeted_verification", "deep_investigation"},
+		SupervisorDirectives: []string{
+			"resolve_scope",
+			"revise_plan",
+			"request_decision",
+			"execute",
+			"verify",
+			"wait",
+			"replan_from_wake",
+			"blocked",
+			"close",
+			"no_action",
+		},
+		WakeConditions: []string{"source_revision_changed", "event_observed", "deadline_reached", "conversation_advanced", "decision_recorded"},
+		InterruptionTriggers: []string{
+			"exact decision required",
+			"evidence invalidated the current plan",
+			"authority or execution budget exhausted",
+			"mission blocked without a valid wake condition",
+			"desired condition independently verified",
+			"previously verified condition became false",
+		},
+		CloseConditions: []string{
+			"all commitments are fulfilled or cancelled",
+			"no wake condition remains armed",
+			"verifier differs from executor",
+			"observed source revision differs from the pre-action revision",
+			"verification cites at least one evidence URN",
+		},
+		FirstMandate: "No terminated identity retains production access for more than 24 hours.",
+	}
+}
+
+func cloneMissionOperatingContract(contract MissionOperatingContract) MissionOperatingContract {
+	contract.DurableRecords = append([]MissionRecordContract(nil), contract.DurableRecords...)
+	for index := range contract.DurableRecords {
+		contract.DurableRecords[index].Required = cloneStrings(contract.DurableRecords[index].Required)
+	}
+	contract.ExecutionDepths = cloneStrings(contract.ExecutionDepths)
+	contract.SupervisorDirectives = cloneStrings(contract.SupervisorDirectives)
+	contract.WakeConditions = cloneStrings(contract.WakeConditions)
+	contract.InterruptionTriggers = cloneStrings(contract.InterruptionTriggers)
+	contract.CloseConditions = cloneStrings(contract.CloseConditions)
+	return contract
+}

--- a/internal/agentplatform/mission_operating_test.go
+++ b/internal/agentplatform/mission_operating_test.go
@@ -1,0 +1,40 @@
+package agentplatform
+
+import "testing"
+
+func TestMissionOperatingContractDefinesOneDurableControlLoop(t *testing.T) {
+	contract := SecurityControlPlaneSnapshot().MissionOperating
+	if contract.ID != "native-mission-operating-contract" || contract.SchemaVersion != "cerebro.control-kernel.v1" {
+		t.Fatalf("mission operating contract = %+v", contract)
+	}
+	for _, recordID := range []string{"mandate", "mission", "belief", "plan_revision", "commitment", "wake_condition"} {
+		found := false
+		for _, record := range contract.DurableRecords {
+			if record.ID == recordID && len(record.Required) > 0 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("mission contract missing durable record %q: %+v", recordID, contract.DurableRecords)
+		}
+	}
+	for _, directive := range []string{"request_decision", "execute", "verify", "wait", "blocked", "close"} {
+		if !containsString(contract.SupervisorDirectives, directive) {
+			t.Fatalf("mission contract missing directive %q: %+v", directive, contract.SupervisorDirectives)
+		}
+	}
+	if len(contract.CloseConditions) < 5 || contract.FirstMandate == "" {
+		t.Fatalf("mission contract missing closure or first mandate: %+v", contract)
+	}
+}
+
+func TestMissionOperatingContractSnapshotIsDefensivelyCloned(t *testing.T) {
+	first := SecurityControlPlaneSnapshot()
+	first.MissionOperating.DurableRecords[0].Required[0] = "mutated"
+	first.MissionOperating.ExecutionDepths[0] = "mutated"
+	second := SecurityControlPlaneSnapshot()
+	if second.MissionOperating.DurableRecords[0].Required[0] == "mutated" || second.MissionOperating.ExecutionDepths[0] == "mutated" {
+		t.Fatalf("mission operating snapshot shares mutable slices: %+v", second.MissionOperating)
+	}
+}

--- a/internal/agentplatform/public_contracts.go
+++ b/internal/agentplatform/public_contracts.go
@@ -315,11 +315,12 @@ func a2AContractMessage(card A2AAgentCard) map[string]any {
 			"text": "Cerebro exposes governed agent-platform, event subscription, and idempotency contracts. Use the links in metadata for the canonical JSON contracts.",
 		}},
 		"metadata": map[string]any{
-			"contractVersion":           ContractVersion,
-			"agentPlatformContractPath": "/api/v1/agent-platform/contract",
-			"eventSubscriptionContract": EventSubscriptionContractPath,
-			"idempotencyContract":       IdempotencyContractPath,
-			"skills":                    card.Skills,
+			"contractVersion":              ContractVersion,
+			"agentPlatformContractPath":    "/api/v1/agent-platform/contract",
+			"missionOperatingContractPath": "/api/v1/agent-platform/missions/contract",
+			"eventSubscriptionContract":    EventSubscriptionContractPath,
+			"idempotencyContract":          IdempotencyContractPath,
+			"skills":                       card.Skills,
 		},
 	}
 }

--- a/internal/agentplatform/security_control_plane.go
+++ b/internal/agentplatform/security_control_plane.go
@@ -21,6 +21,7 @@ type SecurityControlPlane struct {
 	EvidencePacket        EvidencePacketContract     `json:"evidence_packet"`
 	ClaimVerification     ClaimVerificationContract  `json:"claim_verification"`
 	AgentWork             AgentWorkContract          `json:"agent_work"`
+	MissionOperating      MissionOperatingContract   `json:"mission_operating"`
 	AgentProfiles         []SecurityAgentProfile     `json:"agent_profiles"`
 	VerifierLayer         []AgentVerifier            `json:"verifier_layer"`
 	RubricVerifiers       []AgentRubricVerifier      `json:"rubric_verifiers"`
@@ -258,6 +259,7 @@ func SecurityControlPlaneSnapshot() SecurityControlPlane {
 		EvidencePacket:        evidencePacketContract(),
 		ClaimVerification:     cloneClaimVerificationContract(claimVerificationContract()),
 		AgentWork:             cloneAgentWorkContract(agentWorkContract()),
+		MissionOperating:      cloneMissionOperatingContract(missionOperatingContract()),
 		AgentProfiles:         cloneSecurityAgentProfiles(securityAgentProfiles()),
 		VerifierLayer:         cloneAgentVerifiers(agentVerifiers()),
 		RubricVerifiers:       cloneAgentRubricVerifiers(agentRubricVerifiers()),
@@ -590,6 +592,7 @@ func integrationStrategies() []IntegrationStrategy {
 		{ID: "public-idempotency-contract", Purpose: "Make retry-safe mutating API behavior and webhook delivery dedupe a documented public API contract.", Benefits: []string{"safe retries", "SDK consistency"}, Controls: []string{"Idempotency-Key", "key scope", "409 conflict", "replay headers"}},
 		{ID: "security-memory", Purpose: "Promote accepted risks, false positives, prior investigations, remediation outcomes, and detector learnings into typed memory.", Benefits: []string{"operational learning", "less repeated triage"}, Controls: []string{"TTL", "required fields", "no raw transcripts"}},
 		{ID: "agent-work-ledger", Purpose: "Track investigation state as a durable work object rather than relying on agent context windows.", Benefits: []string{"resumable work", "audit trail", "closed-loop handoff"}, Controls: []string{"state model", "claim links", "trace links", "closure conditions"}},
+		{ID: "native-mission-operating-contract", Purpose: "Continue bounded work across agent runs using one mandate, mission, belief, plan, commitment, wake, and verification contract.", Benefits: []string{"continuing intent", "bounded interruptions", "verified closure"}, Controls: []string{"optimistic revisions", "scoped authority", "wake conditions", "independent verification"}},
 		{ID: "connector-oauth-agent-infra", Purpose: "Make connector readiness, OAuth ownership, scopes, and MCP exposure first-class agent preconditions.", Benefits: []string{"safe tool use", "clear token boundaries"}, Controls: []string{"connector gates", "scope gates", "credential boundaries"}},
 		{ID: "defensive-simulation-harness", Purpose: "Let agents simulate paths and remediation effects from graph data and fixtures only.", Benefits: []string{"proactive defense", "no live exploit risk"}, Controls: []string{"graph-only mode", "forbidden inputs", "verifier outputs"}},
 	}

--- a/internal/agentplatform/testdata/agent_platform_eval_cases.json
+++ b/internal/agentplatform/testdata/agent_platform_eval_cases.json
@@ -172,7 +172,7 @@
       "required_capability_ids": ["agent-work-ledger"],
       "required_runtime_events": ["agent.work.created", "agent.work.updated", "claim.verification.completed", "agent.work.closed"],
       "required_provenance_surfaces": ["agent-work", "claim-verification", "replay-record", "security-memory"],
-      "required_integration_strategy_ids": ["agent-work-ledger", "security-memory"]
+      "required_integration_strategy_ids": ["agent-work-ledger", "security-memory", "native-mission-operating-contract"]
     }
   }
 ]

--- a/internal/agentplatform/testdata/security_agent_eval_cases.json
+++ b/internal/agentplatform/testdata/security_agent_eval_cases.json
@@ -3,7 +3,7 @@
     "id": "evidence-packet-high-confidence",
     "scenario_id": "tenant-isolation",
     "description": "A fully scoped read-only packet carries all required blocks without warnings.",
-    "covered_strategy_ids": ["agent-evidence-packets", "specialized-agents", "security-memory", "agent-work-ledger"],
+    "covered_strategy_ids": ["agent-evidence-packets", "specialized-agents", "security-memory", "agent-work-ledger", "native-mission-operating-contract"],
     "request": {
       "tenant_id": "tenant-1",
       "actor_id": "eval-analyst",

--- a/internal/bootstrap/agent_platform.go
+++ b/internal/bootstrap/agent_platform.go
@@ -78,6 +78,9 @@ func (a *App) handleAgentPlatformCapabilities(w http.ResponseWriter, r *http.Req
 func (a *App) handleAgentPlatformSecurityControlPlane(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, agentplatform.SecurityControlPlaneSnapshot())
 }
+func (a *App) handleAgentPlatformMissionContract(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, agentplatform.SecurityControlPlaneSnapshot().MissionOperating)
+}
 
 func (a *App) handleAgentPlatformCapabilityDecision(w http.ResponseWriter, r *http.Request) {
 	var request agentplatform.CapabilityDecisionRequest

--- a/internal/bootstrap/agent_platform_test.go
+++ b/internal/bootstrap/agent_platform_test.go
@@ -627,6 +627,27 @@ func TestHandleAgentPlatformSecurityControlPlane(t *testing.T) {
 	if len(controlPlane.AgentProfiles) == 0 || len(controlPlane.VerifierLayer) == 0 || len(controlPlane.ActionLadder) == 0 {
 		t.Fatalf("control plane missing core registries: %+v", controlPlane)
 	}
+	if controlPlane.MissionOperating.ID != "native-mission-operating-contract" || len(controlPlane.MissionOperating.DurableRecords) != 6 {
+		t.Fatalf("control plane missing mission operating contract: %+v", controlPlane.MissionOperating)
+	}
+}
+
+func TestHandleAgentPlatformMissionContract(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/agent-platform/missions/contract", nil)
+
+	(&App{}).handleAgentPlatformMissionContract(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var contract agentplatform.MissionOperatingContract
+	if err := json.Unmarshal(recorder.Body.Bytes(), &contract); err != nil {
+		t.Fatalf("decode mission contract: %v", err)
+	}
+	if contract.ID != "native-mission-operating-contract" || len(contract.DurableRecords) != 6 {
+		t.Fatalf("mission contract = %+v", contract)
+	}
 }
 
 func TestHandleAgentPlatformCapabilities(t *testing.T) {

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -31,6 +31,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/contract", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/capabilities", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/security-control-plane", Scope: scopeCosmoSecurityRead, Static: true},
+	{Method: http.MethodGet, Exact: "/api/v1/agent-platform/missions/contract", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: agentplatform.EventSubscriptionContractPath, Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodGet, Exact: agentplatform.IdempotencyContractPath, Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/api/v1/agent-platform/capability-decisions", Scope: scopeCosmoSecurityRead, Static: true},

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -638,6 +638,8 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 		return app.mcpAgentClaimVerify(r, args)
 	case "cerebro.agent.work.contract":
 		return app.mcpAgentWorkContract(r, args)
+	case "cerebro.agent.missions.contract":
+		return app.mcpAgentMissionContract(r, args)
 	case "cerebro.graph.reason":
 		return app.mcpGraphReason(r, args)
 	case "cerebro.investigation.context":
@@ -1938,6 +1940,18 @@ func (app *App) mcpAgentWorkContract(_ *http.Request, _ map[string]any) (any, er
 	return value, nil
 }
 
+func (app *App) mcpAgentMissionContract(_ *http.Request, _ map[string]any) (any, error) {
+	contract := agentplatform.SecurityControlPlaneSnapshot().MissionOperating
+	value, err := jsonValue(contract)
+	if err != nil {
+		return nil, err
+	}
+	if typed, ok := value.(map[string]any); ok {
+		return mcpAddResponseMetadata(typed, mcpResponseMetadata(0, len(contract.DurableRecords), nil)), nil
+	}
+	return value, nil
+}
+
 func mcpClaimVerificationRequest(args map[string]any) (agentplatform.ClaimVerificationRequest, error) {
 	request := agentplatform.ClaimVerificationRequest{
 		TenantID:               mcpStringArg(args, "tenant_id"),
@@ -2713,6 +2727,14 @@ func mcpTools() []mcpTool {
 			InputSchema:  mcpObjectSchema(nil, nil),
 			OutputSchema: mcpOutputSchema(map[string]any{"id": map[string]any{"type": "string"}, "state_model": map[string]any{"type": "array"}, "required_artifacts": map[string]any{"type": "array"}, "event_vocabulary": map[string]any{"type": "array"}, "close_conditions": map[string]any{"type": "array"}}),
 			Annotations:  mcpReadOnlyAnnotations("Agent Work Contract"),
+		},
+		{
+			Name:         "cerebro.agent.missions.contract",
+			Title:        "Mission Operating Contract",
+			Description:  "Return the durable mandate, mission, belief, plan, commitment, wake, interruption, and verified-closure contract used across agent runs.",
+			InputSchema:  mcpObjectSchema(nil, nil),
+			OutputSchema: mcpOutputSchema(map[string]any{"id": map[string]any{"type": "string"}, "schema_version": map[string]any{"type": "string"}, "durable_records": map[string]any{"type": "array"}, "execution_depths": map[string]any{"type": "array"}, "supervisor_directives": map[string]any{"type": "array"}, "wake_conditions": map[string]any{"type": "array"}, "interruption_triggers": map[string]any{"type": "array"}, "close_conditions": map[string]any{"type": "array"}}),
+			Annotations:  mcpReadOnlyAnnotations("Mission Operating Contract"),
 		},
 		{
 			Name:        "cerebro.graph.reason",

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -271,6 +271,7 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 		"cerebro.agent.preflight",
 		"cerebro.agent.claims.verify",
 		"cerebro.agent.work.contract",
+		"cerebro.agent.missions.contract",
 		"cerebro.graph.reason",
 		"cerebro.investigation.context",
 		"cerebro.findings.action.propose",
@@ -571,6 +572,7 @@ var mcpToolDomainSurfaceContracts = map[string]mcpToolDomainSurfaceContract{
 	"cerebro.agent.preflight":                 {Markers: []string{"POST /api/v1/agent-platform/preflight"}},
 	"cerebro.agent.claims.verify":             {Markers: []string{"agent-claim-verification"}},
 	"cerebro.agent.work.contract":             {Markers: []string{"agent-work-ledger"}},
+	"cerebro.agent.missions.contract":         {Markers: []string{"/api/v1/agent-platform/missions/contract"}},
 	"cerebro.graph.reason":                    {Markers: []string{"POST /api/v1/agent-platform/graph/reason"}},
 	"cerebro.investigation.context":           {Markers: []string{"GET /findings/{findingID}", "GET /source-runtimes/{runtimeID}/finding-evidence", "GET /platform/graph/neighborhood"}},
 	"cerebro.assessments.plan.create":         {Markers: []string{"POST /grc/assessment-plans"}},
@@ -2661,8 +2663,8 @@ func TestMCPAgentControlPlaneAndWorkContract(t *testing.T) {
 		t.Fatalf("agent.control_plane error = %#v", controlPlaneResp["error"])
 	}
 	controlPlane := controlPlaneResp["result"].(map[string]any)["structuredContent"].(map[string]any)
-	if controlPlane["claim_verification"] == nil || controlPlane["agent_work"] == nil {
-		t.Fatalf("control plane missing claim/work contracts: %#v", controlPlane)
+	if controlPlane["claim_verification"] == nil || controlPlane["agent_work"] == nil || controlPlane["mission_operating"] == nil {
+		t.Fatalf("control plane missing claim/work/mission contracts: %#v", controlPlane)
 	}
 
 	workResp, _ := postMCP(t, server, "", map[string]any{
@@ -2680,6 +2682,23 @@ func TestMCPAgentControlPlaneAndWorkContract(t *testing.T) {
 	work := workResp["result"].(map[string]any)["structuredContent"].(map[string]any)
 	if work["id"] != "agent-work-ledger" || len(work["state_model"].([]any)) == 0 {
 		t.Fatalf("work contract = %#v", work)
+	}
+
+	missionResp, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "cerebro.agent.missions.contract",
+			"arguments": map[string]any{},
+		},
+	})
+	if missionResp["error"] != nil {
+		t.Fatalf("agent.missions.contract error = %#v", missionResp["error"])
+	}
+	mission := missionResp["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if mission["id"] != "native-mission-operating-contract" || len(mission["durable_records"].([]any)) != 6 {
+		t.Fatalf("mission contract = %#v", mission)
 	}
 }
 

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -81,6 +81,7 @@ func (app *App) registerAgentPlatformRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/contract", routeSurfacePlatformHTTP, app.handleAgentPlatformContract)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/capabilities", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilities)
 	registerHTTPRoute(mux, "GET /api/v1/agent-platform/security-control-plane", routeSurfacePlatformHTTP, app.handleAgentPlatformSecurityControlPlane)
+	registerHTTPRoute(mux, "GET /api/v1/agent-platform/missions/contract", routeSurfacePlatformHTTP, app.handleAgentPlatformMissionContract)
 	registerHTTPRoute(mux, "GET /api/v1/event-subscriptions/contract", routeSurfacePlatformHTTP, app.handleEventSubscriptionContract)
 	registerHTTPRoute(mux, "GET /api/v1/idempotency-contract", routeSurfacePlatformHTTP, app.handleIdempotencyContract)
 	registerHTTPRoute(mux, "POST /api/v1/agent-platform/capability-decisions", routeSurfacePlatformHTTP, app.handleAgentPlatformCapabilityDecision)

--- a/internal/mcpoperations/catalog.go
+++ b/internal/mcpoperations/catalog.go
@@ -73,6 +73,7 @@ func buildOperationRegistry() map[string]Operation {
 		expertRead("cerebro.agent.preflight", "agent-platform", "agent preflight"),
 		expertRead("cerebro.agent.claims.verify", "agent-platform", "claim verification"),
 		expertRead("cerebro.agent.work.contract", "agent-platform", "agent work contract"),
+		expertRead("cerebro.agent.missions.contract", "agent-platform", "mission operating contract"),
 		expertRead("cerebro.graph.reason", "graph-agent", "graph reasoning trace"),
 		expertRead("cerebro.investigation.context", "findings", "finding investigation context"),
 		expertExecute("cerebro.assessments.plan.create", "compliance-assessment", "persisted assessment plan draft"),

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -622,6 +622,7 @@ var exactRouteLabels = map[string]struct{}{
 	"/api/v1/agent-platform/contract":                                     {},
 	"/api/v1/agent-platform/capabilities":                                 {},
 	"/api/v1/agent-platform/security-control-plane":                       {},
+	"/api/v1/agent-platform/missions/contract":                            {},
 	"/api/v1/agent-platform/capability-decisions":                         {},
 	"/api/v1/agent-platform/preflight":                                    {},
 	"/api/v1/agent-platform/evidence-packets":                             {},

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -512,6 +512,19 @@ export type AgentPlatformInvariant = {
   statement: string;
 };
 
+export type AgentPlatformMissionOperatingContract = {
+  close_conditions: string[];
+  durable_records: { id?: string; purpose?: string; required?: string[] }[];
+  execution_depths: string[];
+  first_mandate: string;
+  id: string;
+  interruption_triggers: string[];
+  purpose: string;
+  schema_version: string;
+  supervisor_directives: string[];
+  wake_conditions: string[];
+};
+
 export type AgentPlatformPolicyCheck = {
   fields?: string[];
   id: string;
@@ -589,10 +602,13 @@ export type AgentPlatformRuntimeEvent = {
 export type AgentPlatformSecurityControlPlane = {
   action_ladder: Record<string, unknown>[];
   agent_profiles: Record<string, unknown>[];
+  agent_work: Record<string, unknown>;
+  claim_verification: Record<string, unknown>;
   connector_tool_gates: Record<string, unknown>[];
   eval_suite: Record<string, unknown>;
   evidence_packet: Record<string, unknown>;
   integration_strategies: Record<string, unknown>[];
+  mission_operating: AgentPlatformMissionOperatingContract;
   security_memory: Record<string, unknown>;
   simulation_harness: Record<string, unknown>;
   verifier_layer: Record<string, unknown>[];


### PR DESCRIPTION
## What changed

- adds the native mission operating contract to the agent-platform control-plane response
- defines mandate, mission, belief, plan revision, commitment, and wake records for agent clients
- marks the existing agent work ledger as a projection of the mission contract
- adds a tenant-authorized HTTP contract route and read-only MCP tool
- registers the capability, integration strategy, eval coverage, route metrics, and generated TypeScript contract

## Why

Agent clients need one stable contract for continuing intent, bounded execution, interruption rules, wake conditions, and verified closure. Without it, each chat or protocol surface can recreate mission behavior independently.

## Impact

Clients can discover the native mission schema and operating rules through the existing security control plane, `GET /api/v1/agent-platform/missions/contract`, or `cerebro.agent.missions.contract`. The change adds read-only contract surfaces and does not add a mutation path.

## Validation

- `go test ./internal/agentplatform ./internal/bootstrap ./internal/mcpoperations ./internal/observability -count=1`
- `make openapi-check openapi-lint openapi-ts-check mcp-contract-check docs-drift-check`
- `make check-structural check-structural-test check-arch`
- `make agent-platform-eval`
