### PR TITLE
Add self-authoring test specifications

### DIFF
--- a/docs/domains/self-authoring-tests.md
+++ b/docs/domains/self-authoring-tests.md
@@ -1,0 +1,197 @@
+# Self-Authoring Tests
+
+## Outcome
+
+Cerebro should turn a demonstrated test gap into a reviewable regression test:
+
+1. identify one behavior that is not proved by the current suite
+2. record the contract or runtime evidence that demonstrates the gap
+3. build a synthetic, minimal fixture
+4. render the fixture through a deterministic test-family generator
+5. prove that the test detects the gap
+6. publish a test-only draft change with validation receipts
+
+The initial release does not let a model write arbitrary `_test.go` files or change
+production behavior. It produces a typed test specification that existing Go
+generators render into repository-owned test patterns.
+
+## Why This Fits Cerebro
+
+Cerebro already has the required execution substrate:
+
+- finding-rule scaffolding emits a rule, fixture, and test
+- policy contracts require positive and pass fixtures
+- workflow and append-log events can be replayed
+- source generation carries grammar, reproducibility, and proof checks
+- agent behavior has fixture-backed golden evaluations
+- high-risk Rust kernels have property, fuzz, and mutation-oriented checks
+
+The missing component is a governed loop that converts those signals into a
+durable test proposal and rejects proposals that only repeat current output.
+
+## Test Specification
+
+`internal/testauthor` owns the in-repository specification and validation library.
+The specification is the source of truth; rendered Go code is an adapter.
+
+```yaml
+api_version: testauthor.cerebro.dev/v1alpha1
+id: finding-rule-unrelated-close
+family: finding_rule
+subject: github-secret-scanning-disabled
+behavior: unrelated events do not close an open finding
+signal:
+  kind: contract_gap
+  reference: finding-lifecycle/unrelated-close
+oracle:
+  kind: lifecycle_contract
+  assertion: finding_status == open
+fixture:
+  kind: synthetic_event_sequence
+  schema_ref: github/audit/v1
+generator:
+  name: finding_rule_fixture
+  version: v1
+```
+
+A valid specification contains:
+
+- a stable ID and test family
+- one subject and one observable behavior
+- provenance for the signal that requested the test
+- an oracle independent of the current implementation output
+- a synthetic fixture description
+- the deterministic generator and version
+
+Runtime evidence may identify a gap, but raw runtime payloads are not stored in
+the specification or copied into a pull request.
+
+## Authoring Signals
+
+### Contract gaps
+
+Repository declarations identify missing required cases. The first supported
+family is finding rules. Required cases are:
+
+- positive open
+- negative non-open
+- missing required attribute
+- stable fingerprint on repeated evidence
+- remediation close when the lifecycle supports closeout
+- unrelated-event non-close
+- deprovision or offboard close where applicable
+- cross-tenant isolation
+- repeat-event idempotency
+
+Later families can cover policy fixtures, connector contracts, OpenAPI behavior,
+assessment replay, and agent evaluation scenarios.
+
+### Runtime counterexamples
+
+Panics, dead letters, rejected events, schema mismatches, replay disagreements,
+and incorrect finding transitions can request a test. The author must minimize and
+replace the payload with synthetic values before rendering a fixture.
+
+### Change gaps
+
+A changed contract, matcher, lifecycle, endpoint, or projector can request a test
+when the affected behavior has no corresponding assertion.
+
+### Mutation survivors
+
+Bounded mutations can request tests for high-value invariants including tenant
+scope, authorization, finding fingerprints, closeout anchors, evidence freshness,
+and idempotency. Coverage can prioritize a mutation but cannot supply the oracle.
+
+## Validation Receipts
+
+Every proposal records machine-readable receipts for the gates it passed. A test
+proposal is publishable only when:
+
+- its specification is valid and has a stable identity
+- its oracle comes from an allowlisted contract family
+- its fixture is synthetic, bounded, deterministic, and free of credentials
+- it does not require network access or the wall clock
+- it fails on the relevant unprotected revision and passes on the protected
+  revision, or kills a named bounded mutation
+- it passes the focused package, race, contract, architecture, and fixture-safety
+  checks required by its family
+- repeated generation produces byte-identical output
+
+The first implementation records receipts locally. Persistence, runtime ingestion,
+and automatic pull-request creation are later adapters and must not be prerequisites
+for deterministic authoring.
+
+## Package Boundaries
+
+```text
+repository contracts / sanitized counterexamples / bounded mutations
+                              |
+                              v
+                    testauthor: TestSpec
+                     |                 |
+                     v                 v
+             deterministic author   deterministic validator
+                     |                 |
+                     +--------+--------+
+                              v
+                    generated test + receipt
+```
+
+- `internal/testauthor` owns types, normalization, validation, gap identities, and
+  validation receipts.
+- Test-family packages translate an allowlisted contract into a `TestSpec` and
+  render repository-owned fixtures or tests.
+- Existing packages remain owners of finding, connector, policy, replay, and agent
+  semantics. `testauthor` reads their exported contracts; it does not duplicate
+  their engines.
+- `internal/bootstrap` does not own authoring logic.
+- GitHub publication consumes validated output. It is not part of the correctness
+  boundary.
+
+## Initial Pull Request Series
+
+The work lands as stacked draft pull requests:
+
+| Pull request | Scope | Review boundary |
+| --- | --- | --- |
+| Intent and contract | This document and the stable ownership boundaries. | Confirm the safety model and the first test family. |
+| Specification core | `TestSpec`, normalization, validation, receipts, and tests. | Confirm deterministic identity and fail-closed validation. |
+| Finding-rule author | Detect missing finding-rule contract cases and emit deterministic specifications. | Confirm that repository declarations, not model output, choose required behavior. |
+| Proof runner | Validate reproducibility and mutation or revision proof for generated cases. | Confirm that a proposed test detects a real gap before publication. |
+
+Every pull request remains draft until its dependency is accepted. No dependent
+change should bypass a rejected ownership or oracle decision in an earlier pull
+request.
+
+## Safety Boundaries
+
+- Do not place tenant records, hostnames, account IDs, resource labels, URNs,
+  finding examples, or operational endpoints in generated fixtures or public pull
+  request metadata.
+- Do not derive expected results by snapshotting the current implementation.
+- Do not let a generated test update its own expected result.
+- Do not generate production code in the same authoring operation.
+- Do not overwrite an existing test or fixture.
+- Do not automatically merge a test-plus-fix change.
+- Do not treat line coverage as evidence that a behavior is correct.
+
+Automatic landing can be considered later for test-only changes from allowlisted
+deterministic families after their acceptance rate, flake rate, and incident value
+are measured. Until then, publication stops at a draft pull request.
+
+## Operating Measures
+
+Measure whether authored tests improve defect detection:
+
+- time from a demonstrated gap to a draft regression test
+- proposal acceptance and rejection reasons by test family
+- percentage of proposals that fail the unprotected revision
+- targeted mutation kill rate
+- generated-test flake rate
+- recurrence rate for defects with an accepted generated test
+- fixture-safety rejection rate
+- duplicate proposal rate
+
+Raw generated-test count and aggregate line coverage are inventory measures, not
+success measures.

--- a/internal/testauthor/receipt.go
+++ b/internal/testauthor/receipt.go
@@ -1,0 +1,47 @@
+package testauthor
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ReceiptStatus string
+
+const (
+	ReceiptPassed ReceiptStatus = "passed"
+	ReceiptFailed ReceiptStatus = "failed"
+)
+
+type ValidationReceipt struct {
+	SpecID           string        `json:"spec_id"`
+	SpecDigest       string        `json:"spec_digest"`
+	Gate             string        `json:"gate"`
+	Status           ReceiptStatus `json:"status"`
+	Detail           string        `json:"detail,omitempty"`
+	Generator        string        `json:"generator"`
+	GeneratorVersion string        `json:"generator_version"`
+}
+
+func NewValidationReceipt(spec TestSpec, gate string, status ReceiptStatus, detail string) (ValidationReceipt, error) {
+	spec = spec.Normalize()
+	digest, err := spec.Digest()
+	if err != nil {
+		return ValidationReceipt{}, err
+	}
+	gate = strings.TrimSpace(gate)
+	if gate == "" {
+		return ValidationReceipt{}, fmt.Errorf("validation receipt gate is required")
+	}
+	if status != ReceiptPassed && status != ReceiptFailed {
+		return ValidationReceipt{}, fmt.Errorf("unsupported validation receipt status %q", status)
+	}
+	return ValidationReceipt{
+		SpecID:           spec.ID,
+		SpecDigest:       digest,
+		Gate:             gate,
+		Status:           status,
+		Detail:           strings.TrimSpace(detail),
+		Generator:        spec.Generator.Name,
+		GeneratorVersion: spec.Generator.Version,
+	}, nil
+}

--- a/internal/testauthor/spec.go
+++ b/internal/testauthor/spec.go
@@ -1,0 +1,206 @@
+package testauthor
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const APIVersion = "testauthor.cerebro.dev/v1alpha1"
+
+type Family string
+
+const (
+	FamilyFindingRule Family = "finding_rule"
+)
+
+type SignalKind string
+
+const (
+	SignalContractGap           SignalKind = "contract_gap"
+	SignalRuntimeCounterexample SignalKind = "runtime_counterexample"
+	SignalChangeGap             SignalKind = "change_gap"
+	SignalMutationSurvivor      SignalKind = "mutation_survivor"
+)
+
+type OracleKind string
+
+const (
+	OracleLifecycleContract     OracleKind = "lifecycle_contract"
+	OracleSchemaContract        OracleKind = "schema_contract"
+	OracleAuthorizationContract OracleKind = "authorization_contract"
+	OracleIdempotencyContract   OracleKind = "idempotency_contract"
+	OracleMutation              OracleKind = "mutation"
+)
+
+type FixtureKind string
+
+const (
+	FixtureSyntheticEvent         FixtureKind = "synthetic_event"
+	FixtureSyntheticEventSequence FixtureKind = "synthetic_event_sequence"
+	FixtureContractCase           FixtureKind = "contract_case"
+)
+
+type TestSpec struct {
+	APIVersion string    `json:"api_version"`
+	ID         string    `json:"id"`
+	Family     Family    `json:"family"`
+	Subject    string    `json:"subject"`
+	Behavior   string    `json:"behavior"`
+	Signal     Signal    `json:"signal"`
+	Oracle     Oracle    `json:"oracle"`
+	Fixture    Fixture   `json:"fixture"`
+	Generator  Generator `json:"generator"`
+}
+
+type Signal struct {
+	Kind      SignalKind `json:"kind"`
+	Reference string     `json:"reference"`
+}
+
+type Oracle struct {
+	Kind      OracleKind `json:"kind"`
+	Assertion string     `json:"assertion"`
+}
+
+type Fixture struct {
+	Kind      FixtureKind `json:"kind"`
+	SchemaRef string      `json:"schema_ref"`
+}
+
+type Generator struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type ValidationIssue struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+type ValidationError struct {
+	Issues []ValidationIssue `json:"issues"`
+}
+
+func (e *ValidationError) Error() string {
+	parts := make([]string, 0, len(e.Issues))
+	for _, issue := range e.Issues {
+		parts = append(parts, issue.Field+": "+issue.Message)
+	}
+	return "invalid test specification: " + strings.Join(parts, "; ")
+}
+
+var stableIDPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+func (spec TestSpec) Normalize() TestSpec {
+	spec.APIVersion = strings.TrimSpace(spec.APIVersion)
+	spec.ID = strings.ToLower(strings.TrimSpace(spec.ID))
+	spec.Family = Family(strings.ToLower(strings.TrimSpace(string(spec.Family))))
+	spec.Subject = strings.TrimSpace(spec.Subject)
+	spec.Behavior = strings.TrimSpace(spec.Behavior)
+	spec.Signal.Kind = SignalKind(strings.ToLower(strings.TrimSpace(string(spec.Signal.Kind))))
+	spec.Signal.Reference = strings.TrimSpace(spec.Signal.Reference)
+	spec.Oracle.Kind = OracleKind(strings.ToLower(strings.TrimSpace(string(spec.Oracle.Kind))))
+	spec.Oracle.Assertion = strings.TrimSpace(spec.Oracle.Assertion)
+	spec.Fixture.Kind = FixtureKind(strings.ToLower(strings.TrimSpace(string(spec.Fixture.Kind))))
+	spec.Fixture.SchemaRef = strings.TrimSpace(spec.Fixture.SchemaRef)
+	spec.Generator.Name = strings.TrimSpace(spec.Generator.Name)
+	spec.Generator.Version = strings.TrimSpace(spec.Generator.Version)
+	return spec
+}
+
+func (spec TestSpec) Validate() error {
+	spec = spec.Normalize()
+	issues := make([]ValidationIssue, 0)
+	add := func(field string, message string) {
+		issues = append(issues, ValidationIssue{Field: field, Message: message})
+	}
+
+	if spec.APIVersion != APIVersion {
+		add("api_version", fmt.Sprintf("must equal %q", APIVersion))
+	}
+	if !stableIDPattern.MatchString(spec.ID) {
+		add("id", "must be a non-empty lowercase kebab-case identifier")
+	}
+	if spec.Family != FamilyFindingRule {
+		add("family", fmt.Sprintf("unsupported family %q", spec.Family))
+	}
+	if spec.Subject == "" {
+		add("subject", "is required")
+	}
+	if spec.Behavior == "" {
+		add("behavior", "is required")
+	}
+	if !validSignalKind(spec.Signal.Kind) {
+		add("signal.kind", fmt.Sprintf("unsupported signal kind %q", spec.Signal.Kind))
+	}
+	if spec.Signal.Reference == "" {
+		add("signal.reference", "is required")
+	}
+	if !validOracleKind(spec.Oracle.Kind) {
+		add("oracle.kind", fmt.Sprintf("unsupported oracle kind %q", spec.Oracle.Kind))
+	}
+	if spec.Oracle.Assertion == "" {
+		add("oracle.assertion", "is required")
+	}
+	if !validFixtureKind(spec.Fixture.Kind) {
+		add("fixture.kind", fmt.Sprintf("unsupported fixture kind %q", spec.Fixture.Kind))
+	}
+	if spec.Fixture.SchemaRef == "" {
+		add("fixture.schema_ref", "is required")
+	}
+	if spec.Generator.Name == "" {
+		add("generator.name", "is required")
+	}
+	if spec.Generator.Version == "" {
+		add("generator.version", "is required")
+	}
+
+	if len(issues) > 0 {
+		return &ValidationError{Issues: issues}
+	}
+	return nil
+}
+
+func (spec TestSpec) Digest() (string, error) {
+	spec = spec.Normalize()
+	if err := spec.Validate(); err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("marshal test specification: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func validSignalKind(kind SignalKind) bool {
+	switch kind {
+	case SignalContractGap, SignalRuntimeCounterexample, SignalChangeGap, SignalMutationSurvivor:
+		return true
+	default:
+		return false
+	}
+}
+
+func validOracleKind(kind OracleKind) bool {
+	switch kind {
+	case OracleLifecycleContract, OracleSchemaContract, OracleAuthorizationContract, OracleIdempotencyContract, OracleMutation:
+		return true
+	default:
+		return false
+	}
+}
+
+func validFixtureKind(kind FixtureKind) bool {
+	switch kind {
+	case FixtureSyntheticEvent, FixtureSyntheticEventSequence, FixtureContractCase:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/testauthor/spec_test.go
+++ b/internal/testauthor/spec_test.go
@@ -1,0 +1,130 @@
+package testauthor
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSpecNormalizeAndDigestAreDeterministic(t *testing.T) {
+	spec := validSpec()
+	spec.ID = "  FINDING-RULE-UNRELATED-CLOSE "
+	spec.Family = " FINDING_RULE "
+	spec.Signal.Kind = " CONTRACT_GAP "
+	spec.Oracle.Kind = " LIFECYCLE_CONTRACT "
+	spec.Fixture.Kind = " SYNTHETIC_EVENT_SEQUENCE "
+
+	first, err := spec.Digest()
+	if err != nil {
+		t.Fatalf("Digest() error = %v", err)
+	}
+	second, err := spec.Normalize().Digest()
+	if err != nil {
+		t.Fatalf("normalized Digest() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("digest mismatch: %q != %q", first, second)
+	}
+	if len(first) != 64 {
+		t.Fatalf("digest length = %d, want 64", len(first))
+	}
+}
+
+func TestSpecValidateRejectsIncompleteOrUnownedContracts(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*TestSpec)
+		field  string
+	}{
+		{name: "api version", mutate: func(spec *TestSpec) { spec.APIVersion = "v1" }, field: "api_version"},
+		{name: "stable id", mutate: func(spec *TestSpec) { spec.ID = "not stable!" }, field: "id"},
+		{name: "family", mutate: func(spec *TestSpec) { spec.Family = "free_form_go" }, field: "family"},
+		{name: "subject", mutate: func(spec *TestSpec) { spec.Subject = "" }, field: "subject"},
+		{name: "behavior", mutate: func(spec *TestSpec) { spec.Behavior = "" }, field: "behavior"},
+		{name: "signal kind", mutate: func(spec *TestSpec) { spec.Signal.Kind = "coverage" }, field: "signal.kind"},
+		{name: "signal reference", mutate: func(spec *TestSpec) { spec.Signal.Reference = "" }, field: "signal.reference"},
+		{name: "oracle kind", mutate: func(spec *TestSpec) { spec.Oracle.Kind = "implementation_snapshot" }, field: "oracle.kind"},
+		{name: "oracle assertion", mutate: func(spec *TestSpec) { spec.Oracle.Assertion = "" }, field: "oracle.assertion"},
+		{name: "fixture kind", mutate: func(spec *TestSpec) { spec.Fixture.Kind = "runtime_payload" }, field: "fixture.kind"},
+		{name: "schema ref", mutate: func(spec *TestSpec) { spec.Fixture.SchemaRef = "" }, field: "fixture.schema_ref"},
+		{name: "generator name", mutate: func(spec *TestSpec) { spec.Generator.Name = "" }, field: "generator.name"},
+		{name: "generator version", mutate: func(spec *TestSpec) { spec.Generator.Version = "" }, field: "generator.version"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := validSpec()
+			test.mutate(&spec)
+			err := spec.Validate()
+			var validationErr *ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("Validate() error = %v, want ValidationError", err)
+			}
+			if !hasIssue(validationErr.Issues, test.field) {
+				t.Fatalf("issues = %#v, want field %q", validationErr.Issues, test.field)
+			}
+		})
+	}
+}
+
+func TestNewValidationReceiptBindsGateToNormalizedSpec(t *testing.T) {
+	spec := validSpec()
+	receipt, err := NewValidationReceipt(spec, " reproducibility ", ReceiptPassed, " byte-identical output ")
+	if err != nil {
+		t.Fatalf("NewValidationReceipt() error = %v", err)
+	}
+	digest, err := spec.Digest()
+	if err != nil {
+		t.Fatalf("Digest() error = %v", err)
+	}
+	if receipt.SpecID != spec.ID || receipt.SpecDigest != digest {
+		t.Fatalf("receipt identity = %#v, want id %q digest %q", receipt, spec.ID, digest)
+	}
+	if receipt.Gate != "reproducibility" || receipt.Detail != "byte-identical output" {
+		t.Fatalf("receipt text = %#v, want normalized values", receipt)
+	}
+	if receipt.Generator != spec.Generator.Name || receipt.GeneratorVersion != spec.Generator.Version {
+		t.Fatalf("receipt generator = %#v, want specification generator", receipt)
+	}
+}
+
+func TestNewValidationReceiptRejectsUnknownStatus(t *testing.T) {
+	_, err := NewValidationReceipt(validSpec(), "contract", "unknown", "")
+	if err == nil {
+		t.Fatal("NewValidationReceipt() error = nil, want unsupported status")
+	}
+}
+
+func validSpec() TestSpec {
+	return TestSpec{
+		APIVersion: APIVersion,
+		ID:         "finding-rule-unrelated-close",
+		Family:     FamilyFindingRule,
+		Subject:    "github-secret-scanning-disabled",
+		Behavior:   "unrelated events do not close an open finding",
+		Signal: Signal{
+			Kind:      SignalContractGap,
+			Reference: "finding-lifecycle/unrelated-close",
+		},
+		Oracle: Oracle{
+			Kind:      OracleLifecycleContract,
+			Assertion: "finding_status == open",
+		},
+		Fixture: Fixture{
+			Kind:      FixtureSyntheticEventSequence,
+			SchemaRef: "github/audit/v1",
+		},
+		Generator: Generator{
+			Name:    "finding_rule_fixture",
+			Version: "v1",
+		},
+	}
+}
+
+func hasIssue(issues []ValidationIssue, field string) bool {
+	for _, issue := range issues {
+		if issue.Field == field {
+			return true
+		}
+	}
+	return false
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Findings Platform Architecture: domains/findings-platform-architecture.md
       - Finding Candidate Operations: domains/finding-candidate-operations.md
       - Agent Platform Contract: domains/agent-platform-contract.md
+      - Self-Authoring Tests: domains/self-authoring-tests.md
       - Endpoint Security Platform Integration: domains/endpoint-security-platform-integration.md
       - MCP Native Droid Setup: domains/mcp-droid-setup.md
   - Engineering:


### PR DESCRIPTION
## What changed

- add the normalized `TestSpec` contract for the first allowlisted test family
- reject unsupported signal, oracle, fixture, and generator inputs
- derive a deterministic digest from the normalized specification
- bind machine-readable validation receipts to the specification digest and generator version

## Why

Generated tests need a stable, reviewable contract before any author can emit fixtures or Go code. The specification prevents free-form generation and makes each validation result traceable to exact normalized input.

## Impact

This adds an internal library only. It does not add runtime ingestion, persistence, routes, production behavior, or pull request automation.

## Checks

- `go test ./internal/testauthor -count=1`
- `go test -race ./internal/testauthor -count=1`
- `make check-structural-test`
- `make lint-internal`
- `make check-arch`

## Stack

Depends on the self-authoring test intent and contract pull request.
