### PR TITLE
feat(testauthor): author policies with runnable tests

### DIFF
--- a/docs/domains/self-authoring-policy-tests.md
+++ b/docs/domains/self-authoring-policy-tests.md
@@ -1,0 +1,44 @@
+# Self-authoring policy tests
+
+`testauthor` turns a bounded policy intent into a policy and an executable finding/passing test suite. It can also scan existing policies and author missing suites when every condition is a simple scalar equality.
+
+The authoring boundary is deliberate. The tool accepts `cmp_eq(path(resource, "field"), scalar)` conditions. It rejects query, graph, inequality, collection, and compound-expression semantics until a generator has an explicit fixture contract for them.
+
+## Author a policy and its tests
+
+Create a strict YAML intent:
+
+```yaml
+id: aws-s3-public-access
+domain: aws
+name: S3 public access
+description: Flags buckets with public access enabled.
+severity: high
+resource: aws::s3::bucket
+conditions:
+  - cmp_eq(path(resource, "public"), true)
+frameworks:
+  - name: CIS
+    controls: [2.1.5]
+remediation: Block public access.
+```
+
+Preview both artifacts, then write them:
+
+```sh
+go run ./tools/testauthor author-policy --intent intent.yaml
+go run ./tools/testauthor author-policy --intent intent.yaml --write
+go run ./tools/findingdsl test policies/aws/aws-s3-public-access.test.yaml
+```
+
+The write is refused if either target exists. Before writing, the command renders both artifacts twice, requires byte-identical output, validates both artifacts, and executes the finding and passing cases against the authored policy.
+
+## Fill supported repository gaps
+
+```sh
+go run ./tools/testauthor scan --root .
+go run ./tools/testauthor author-tests --root .
+go run ./tools/testauthor author-tests --root . --write
+```
+
+`scan` returns every policy without a sibling `.test.yaml`, whether it is supported, and the rejection reason for unsupported semantics. `author-tests` previews or writes only the supported subset. Repository owners can review that set in small batches instead of accepting a repository-wide generated change.

--- a/docs/domains/self-authoring-tests.md
+++ b/docs/domains/self-authoring-tests.md
@@ -1,0 +1,197 @@
+# Self-Authoring Tests
+
+## Outcome
+
+Cerebro should turn a demonstrated test gap into a reviewable regression test:
+
+1. identify one behavior that is not proved by the current suite
+2. record the contract or runtime evidence that demonstrates the gap
+3. build a synthetic, minimal fixture
+4. render the fixture through a deterministic test-family generator
+5. prove that the test detects the gap
+6. publish a test-only draft change with validation receipts
+
+The initial release does not let a model write arbitrary `_test.go` files or change
+production behavior. It produces a typed test specification that existing Go
+generators render into repository-owned test patterns.
+
+## Why This Fits Cerebro
+
+Cerebro already has the required execution substrate:
+
+- finding-rule scaffolding emits a rule, fixture, and test
+- policy contracts require positive and pass fixtures
+- workflow and append-log events can be replayed
+- source generation carries grammar, reproducibility, and proof checks
+- agent behavior has fixture-backed golden evaluations
+- high-risk Rust kernels have property, fuzz, and mutation-oriented checks
+
+The missing component is a governed loop that converts those signals into a
+durable test proposal and rejects proposals that only repeat current output.
+
+## Test Specification
+
+`internal/testauthor` owns the in-repository specification and validation library.
+The specification is the source of truth; rendered Go code is an adapter.
+
+```yaml
+api_version: testauthor.cerebro.dev/v1alpha1
+id: finding-rule-unrelated-close
+family: finding_rule
+subject: github-secret-scanning-disabled
+behavior: unrelated events do not close an open finding
+signal:
+  kind: contract_gap
+  reference: finding-lifecycle/unrelated-close
+oracle:
+  kind: lifecycle_contract
+  assertion: finding_status == open
+fixture:
+  kind: synthetic_event_sequence
+  schema_ref: github/audit/v1
+generator:
+  name: finding_rule_fixture
+  version: v1
+```
+
+A valid specification contains:
+
+- a stable ID and test family
+- one subject and one observable behavior
+- provenance for the signal that requested the test
+- an oracle independent of the current implementation output
+- a synthetic fixture description
+- the deterministic generator and version
+
+Runtime evidence may identify a gap, but raw runtime payloads are not stored in
+the specification or copied into a pull request.
+
+## Authoring Signals
+
+### Contract gaps
+
+Repository declarations identify missing required cases. The first supported
+family is finding rules. Required cases are:
+
+- positive open
+- negative non-open
+- missing required attribute
+- stable fingerprint on repeated evidence
+- remediation close when the lifecycle supports closeout
+- unrelated-event non-close
+- deprovision or offboard close where applicable
+- cross-tenant isolation
+- repeat-event idempotency
+
+Later families can cover policy fixtures, connector contracts, OpenAPI behavior,
+assessment replay, and agent evaluation scenarios.
+
+### Runtime counterexamples
+
+Panics, dead letters, rejected events, schema mismatches, replay disagreements,
+and incorrect finding transitions can request a test. The author must minimize and
+replace the payload with synthetic values before rendering a fixture.
+
+### Change gaps
+
+A changed contract, matcher, lifecycle, endpoint, or projector can request a test
+when the affected behavior has no corresponding assertion.
+
+### Mutation survivors
+
+Bounded mutations can request tests for high-value invariants including tenant
+scope, authorization, finding fingerprints, closeout anchors, evidence freshness,
+and idempotency. Coverage can prioritize a mutation but cannot supply the oracle.
+
+## Validation Receipts
+
+Every proposal records machine-readable receipts for the gates it passed. A test
+proposal is publishable only when:
+
+- its specification is valid and has a stable identity
+- its oracle comes from an allowlisted contract family
+- its fixture is synthetic, bounded, deterministic, and free of credentials
+- it does not require network access or the wall clock
+- it fails on the relevant unprotected revision and passes on the protected
+  revision, or kills a named bounded mutation
+- it passes the focused package, race, contract, architecture, and fixture-safety
+  checks required by its family
+- repeated generation produces byte-identical output
+
+The first implementation records receipts locally. Persistence, runtime ingestion,
+and automatic pull-request creation are later adapters and must not be prerequisites
+for deterministic authoring.
+
+## Package Boundaries
+
+```text
+repository contracts / sanitized counterexamples / bounded mutations
+                              |
+                              v
+                    testauthor: TestSpec
+                     |                 |
+                     v                 v
+             deterministic author   deterministic validator
+                     |                 |
+                     +--------+--------+
+                              v
+                    generated test + receipt
+```
+
+- `internal/testauthor` owns types, normalization, validation, gap identities, and
+  validation receipts.
+- Test-family packages translate an allowlisted contract into a `TestSpec` and
+  render repository-owned fixtures or tests.
+- Existing packages remain owners of finding, connector, policy, replay, and agent
+  semantics. `testauthor` reads their exported contracts; it does not duplicate
+  their engines.
+- `internal/bootstrap` does not own authoring logic.
+- GitHub publication consumes validated output. It is not part of the correctness
+  boundary.
+
+## Initial Pull Request Series
+
+The work lands as stacked draft pull requests:
+
+| Pull request | Scope | Review boundary |
+| --- | --- | --- |
+| Intent and contract | This document and the stable ownership boundaries. | Confirm the safety model and the first test family. |
+| Specification core | `TestSpec`, normalization, validation, receipts, and tests. | Confirm deterministic identity and fail-closed validation. |
+| Finding-rule author | Detect missing finding-rule contract cases and emit deterministic specifications. | Confirm that repository declarations, not model output, choose required behavior. |
+| Proof runner | Validate reproducibility and mutation or revision proof for generated cases. | Confirm that a proposed test detects a real gap before publication. |
+
+Every pull request remains draft until its dependency is accepted. No dependent
+change should bypass a rejected ownership or oracle decision in an earlier pull
+request.
+
+## Safety Boundaries
+
+- Do not place tenant records, hostnames, account IDs, resource labels, URNs,
+  finding examples, or operational endpoints in generated fixtures or public pull
+  request metadata.
+- Do not derive expected results by snapshotting the current implementation.
+- Do not let a generated test update its own expected result.
+- Do not generate production code in the same authoring operation.
+- Do not overwrite an existing test or fixture.
+- Do not automatically merge a test-plus-fix change.
+- Do not treat line coverage as evidence that a behavior is correct.
+
+Automatic landing can be considered later for test-only changes from allowlisted
+deterministic families after their acceptance rate, flake rate, and incident value
+are measured. Until then, publication stops at a draft pull request.
+
+## Operating Measures
+
+Measure whether authored tests improve defect detection:
+
+- time from a demonstrated gap to a draft regression test
+- proposal acceptance and rejection reasons by test family
+- percentage of proposals that fail the unprotected revision
+- targeted mutation kill rate
+- generated-test flake rate
+- recurrence rate for defects with an accepted generated test
+- fixture-safety rejection rate
+- duplicate proposal rate
+
+Raw generated-test count and aggregate line coverage are inventory measures, not
+success measures.

--- a/internal/findingdsl/expression.go
+++ b/internal/findingdsl/expression.go
@@ -230,6 +230,65 @@ func EvaluatePolicyConditions(conditions []string, resource PolicyResource) (boo
 	return true, nil
 }
 
+// SynthesizeEqualityConditionFixtures derives a finding and passing resource for
+// policies made entirely from cmp_eq(path(resource, field), scalar) conditions.
+// It intentionally rejects broader expressions rather than guessing semantics.
+func SynthesizeEqualityConditionFixtures(conditions []string) (PolicyResource, PolicyResource, error) {
+	if len(conditions) == 0 {
+		return nil, nil, fmt.Errorf("at least one condition is required")
+	}
+	finding := PolicyResource{}
+	passing := PolicyResource{}
+	var firstField string
+	for idx, condition := range conditions {
+		expr, err := parsePolicyExpression(condition)
+		if err != nil {
+			return nil, nil, fmt.Errorf("condition[%d]: %w", idx, err)
+		}
+		call, ok := expr.(callExpression)
+		if !ok || call.name != "cmp_eq" || len(call.args) != 2 {
+			return nil, nil, fmt.Errorf("condition[%d] is not a simple equality condition", idx)
+		}
+		pathCall, ok := call.args[0].(callExpression)
+		if !ok || pathCall.name != "path" || len(pathCall.args) != 2 {
+			return nil, nil, fmt.Errorf("condition[%d] does not compare a resource path", idx)
+		}
+		root, rootOK := pathCall.args[0].(identExpression)
+		fieldExpr, fieldOK := pathCall.args[1].(literalExpression)
+		field, stringOK := fieldExpr.value.(string)
+		valueExpr, valueOK := call.args[1].(literalExpression)
+		if !rootOK || root.name != "resource" || !fieldOK || !stringOK || strings.TrimSpace(field) == "" || !valueOK {
+			return nil, nil, fmt.Errorf("condition[%d] must compare path(resource, field) with a scalar literal", idx)
+		}
+		if _, exists := finding[field]; exists {
+			return nil, nil, fmt.Errorf("condition[%d] repeats resource field %q", idx, field)
+		}
+		if _, err := alternatePolicyFixtureValue(valueExpr.value); err != nil {
+			return nil, nil, fmt.Errorf("condition[%d] field %q: %w", idx, field, err)
+		}
+		finding[field] = valueExpr.value
+		passing[field] = valueExpr.value
+		if firstField == "" {
+			firstField = field
+		}
+	}
+	passing[firstField], _ = alternatePolicyFixtureValue(finding[firstField])
+	return finding, passing, nil
+}
+
+func alternatePolicyFixtureValue(value any) (any, error) {
+	switch typed := value.(type) {
+	case bool:
+		return !typed, nil
+	case string:
+		return typed + "-passing", nil
+	case float64:
+		return typed + 1, nil
+	default:
+		return nil, fmt.Errorf("literal type %T is not supported", value)
+	}
+}
+
 func collectPolicyResourceFields(expr expression, seen map[string]struct{}) {
 	switch typed := expr.(type) {
 	case callExpression:

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -110,6 +110,11 @@ func ValidatePolicyRuleTestSuite(suite PolicyRuleTestSuite) []Issue {
 	return issues
 }
 
+func FormatPolicyRuleTestSuiteYAML(suite PolicyRuleTestSuite) ([]byte, error) {
+	suite.RelPath = ""
+	return yaml.Marshal(suite)
+}
+
 func RunPolicyRuleTestSuite(root string, suitePath string) []Issue {
 	suite, issues, err := LoadPolicyRuleTestSuite(root, suitePath)
 	if err != nil {

--- a/internal/testauthor/findingrule/author.go
+++ b/internal/testauthor/findingrule/author.go
@@ -1,0 +1,211 @@
+package findingrule
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/testauthor"
+)
+
+type Case string
+
+const (
+	CasePositiveOpen             Case = "positive_open"
+	CaseNegativeNonOpen          Case = "negative_non_open"
+	CaseMissingRequiredAttribute Case = "missing_required_attribute"
+	CaseStableFingerprint        Case = "stable_fingerprint"
+	CaseRemediationClose         Case = "remediation_close"
+	CaseUnrelatedNonClose        Case = "unrelated_non_close"
+	CaseDeprovisionClose         Case = "deprovision_close"
+	CaseCrossTenantIsolation     Case = "cross_tenant_isolation"
+	CaseRepeatEventIdempotency   Case = "repeat_event_idempotency"
+	CaseRetiredNonOpen           Case = "retired_non_open"
+)
+
+type Contract struct {
+	Definition               findings.RuleDefinition
+	SupportsCounterEvents    bool
+	SupportsDeprovisionClose bool
+}
+
+func RequiredCases(contract Contract) ([]Case, error) {
+	if err := validateContract(contract); err != nil {
+		return nil, err
+	}
+	definition := contract.Definition
+	if definition.Lifecycle.Kind == findings.LifecycleRetired {
+		return []Case{CaseRetiredNonOpen}, nil
+	}
+
+	cases := []Case{
+		CasePositiveOpen,
+		CaseNegativeNonOpen,
+	}
+	if len(definition.RequiredAttributes) > 0 || len(definition.RequiredAttributesByKind) > 0 {
+		cases = append(cases, CaseMissingRequiredAttribute)
+	}
+	if len(definition.FingerprintFields) > 0 {
+		cases = append(cases, CaseStableFingerprint)
+	}
+	if contract.SupportsCounterEvents {
+		cases = append(cases, CaseRemediationClose)
+	}
+	if definition.Lifecycle.Kind == findings.LifecycleDurableState {
+		cases = append(cases, CaseUnrelatedNonClose)
+	}
+	if contract.SupportsDeprovisionClose {
+		cases = append(cases, CaseDeprovisionClose)
+	}
+	cases = append(cases, CaseCrossTenantIsolation, CaseRepeatEventIdempotency)
+	return cases, nil
+}
+
+func AuthorMissing(contract Contract, covered []Case) ([]testauthor.TestSpec, error) {
+	required, err := RequiredCases(contract)
+	if err != nil {
+		return nil, err
+	}
+	coveredSet := make(map[Case]struct{}, len(covered))
+	for _, testCase := range covered {
+		if !validCase(testCase) {
+			return nil, fmt.Errorf("unsupported finding-rule test case %q", testCase)
+		}
+		coveredSet[testCase] = struct{}{}
+	}
+
+	specs := make([]testauthor.TestSpec, 0, len(required))
+	for _, testCase := range required {
+		if _, ok := coveredSet[testCase]; ok {
+			continue
+		}
+		spec := specForCase(contract.Definition, testCase)
+		if err := spec.Validate(); err != nil {
+			return nil, fmt.Errorf("validate generated specification for %s: %w", testCase, err)
+		}
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+func validateContract(contract Contract) error {
+	if err := contract.Definition.Validate(); err != nil {
+		return fmt.Errorf("validate finding rule definition: %w", err)
+	}
+	if contract.SupportsCounterEvents && contract.Definition.Lifecycle.Kind != findings.LifecycleDurableState {
+		return fmt.Errorf("finding rule %q counter events require durable_state lifecycle", contract.Definition.ID)
+	}
+	if contract.SupportsDeprovisionClose && !contract.SupportsCounterEvents {
+		return fmt.Errorf("finding rule %q deprovision close requires counter-event support", contract.Definition.ID)
+	}
+	return nil
+}
+
+func specForCase(definition findings.RuleDefinition, testCase Case) testauthor.TestSpec {
+	oracle, fixture, behavior := caseContract(testCase)
+	return testauthor.TestSpec{
+		APIVersion: testauthor.APIVersion,
+		ID:         stablePart(definition.ID) + "-" + strings.ReplaceAll(string(testCase), "_", "-"),
+		Family:     testauthor.FamilyFindingRule,
+		Subject:    strings.TrimSpace(definition.ID),
+		Behavior:   behavior,
+		Signal: testauthor.Signal{
+			Kind:      testauthor.SignalContractGap,
+			Reference: "finding-rule/" + strings.TrimSpace(definition.ID) + "/" + string(testCase),
+		},
+		Oracle: testauthor.Oracle{
+			Kind:      oracle,
+			Assertion: assertionForCase(testCase),
+		},
+		Fixture: testauthor.Fixture{
+			Kind:      fixture,
+			SchemaRef: strings.TrimSpace(definition.SourceID) + "/synthetic/v1",
+		},
+		Generator: testauthor.Generator{
+			Name:    "finding_rule_fixture",
+			Version: "v1",
+		},
+	}
+}
+
+func caseContract(testCase Case) (testauthor.OracleKind, testauthor.FixtureKind, string) {
+	switch testCase {
+	case CasePositiveOpen:
+		return testauthor.OracleSchemaContract, testauthor.FixtureSyntheticEvent, "matching evidence opens the finding"
+	case CaseNegativeNonOpen:
+		return testauthor.OracleSchemaContract, testauthor.FixtureSyntheticEvent, "unmatched evidence does not open the finding"
+	case CaseMissingRequiredAttribute:
+		return testauthor.OracleSchemaContract, testauthor.FixtureSyntheticEvent, "evidence missing a required attribute does not open the finding"
+	case CaseStableFingerprint:
+		return testauthor.OracleIdempotencyContract, testauthor.FixtureSyntheticEventSequence, "equivalent evidence preserves the finding fingerprint"
+	case CaseRemediationClose:
+		return testauthor.OracleLifecycleContract, testauthor.FixtureSyntheticEventSequence, "matching remediation evidence closes the finding"
+	case CaseUnrelatedNonClose:
+		return testauthor.OracleLifecycleContract, testauthor.FixtureSyntheticEventSequence, "unrelated evidence does not close the finding"
+	case CaseDeprovisionClose:
+		return testauthor.OracleLifecycleContract, testauthor.FixtureSyntheticEventSequence, "deprovision evidence closes the resource finding"
+	case CaseCrossTenantIsolation:
+		return testauthor.OracleAuthorizationContract, testauthor.FixtureSyntheticEventSequence, "evidence from another tenant cannot change the finding"
+	case CaseRepeatEventIdempotency:
+		return testauthor.OracleIdempotencyContract, testauthor.FixtureSyntheticEventSequence, "repeated evidence does not duplicate the finding"
+	case CaseRetiredNonOpen:
+		return testauthor.OracleLifecycleContract, testauthor.FixtureSyntheticEvent, "retired rules do not open findings"
+	default:
+		return "", "", ""
+	}
+}
+
+func assertionForCase(testCase Case) string {
+	switch testCase {
+	case CasePositiveOpen:
+		return "finding_count == 1"
+	case CaseNegativeNonOpen, CaseMissingRequiredAttribute, CaseRetiredNonOpen:
+		return "finding_count == 0"
+	case CaseStableFingerprint:
+		return "first_fingerprint == repeated_fingerprint"
+	case CaseRemediationClose, CaseDeprovisionClose:
+		return "finding_status == closed"
+	case CaseUnrelatedNonClose, CaseCrossTenantIsolation:
+		return "finding_status == open"
+	case CaseRepeatEventIdempotency:
+		return "finding_count == 1"
+	default:
+		return ""
+	}
+}
+
+func stablePart(value string) string {
+	var result strings.Builder
+	separator := false
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if separator && result.Len() > 0 {
+				result.WriteByte('-')
+			}
+			result.WriteRune(r)
+			separator = false
+			continue
+		}
+		separator = true
+	}
+	return strings.Trim(result.String(), "-")
+}
+
+func validCase(testCase Case) bool {
+	switch testCase {
+	case CasePositiveOpen,
+		CaseNegativeNonOpen,
+		CaseMissingRequiredAttribute,
+		CaseStableFingerprint,
+		CaseRemediationClose,
+		CaseUnrelatedNonClose,
+		CaseDeprovisionClose,
+		CaseCrossTenantIsolation,
+		CaseRepeatEventIdempotency,
+		CaseRetiredNonOpen:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/testauthor/findingrule/author_test.go
+++ b/internal/testauthor/findingrule/author_test.go
@@ -1,0 +1,122 @@
+package findingrule
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/writer/cerebro/internal/findings"
+)
+
+func TestRequiredCasesDerivesDurableSourceStateContract(t *testing.T) {
+	contract := Contract{
+		Definition:               durableDefinition(),
+		SupportsCounterEvents:    true,
+		SupportsDeprovisionClose: true,
+	}
+	want := []Case{
+		CasePositiveOpen,
+		CaseNegativeNonOpen,
+		CaseMissingRequiredAttribute,
+		CaseStableFingerprint,
+		CaseRemediationClose,
+		CaseUnrelatedNonClose,
+		CaseDeprovisionClose,
+		CaseCrossTenantIsolation,
+		CaseRepeatEventIdempotency,
+	}
+	got, err := RequiredCases(contract)
+	if err != nil {
+		t.Fatalf("RequiredCases() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RequiredCases() = %v, want %v", got, want)
+	}
+}
+
+func TestAuthorMissingEmitsDeterministicValidatedSpecifications(t *testing.T) {
+	contract := Contract{Definition: durableDefinition(), SupportsCounterEvents: true}
+	covered := []Case{CasePositiveOpen, CaseNegativeNonOpen, CaseMissingRequiredAttribute}
+
+	first, err := AuthorMissing(contract, covered)
+	if err != nil {
+		t.Fatalf("AuthorMissing() error = %v", err)
+	}
+	second, err := AuthorMissing(contract, covered)
+	if err != nil {
+		t.Fatalf("second AuthorMissing() error = %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("AuthorMissing() is not deterministic:\nfirst=%#v\nsecond=%#v", first, second)
+	}
+	if len(first) != 5 {
+		t.Fatalf("AuthorMissing() count = %d, want 5", len(first))
+	}
+	for _, spec := range first {
+		if err := spec.Validate(); err != nil {
+			t.Fatalf("generated spec %q Validate() error = %v", spec.ID, err)
+		}
+		if spec.Subject != contract.Definition.ID {
+			t.Fatalf("generated spec subject = %q, want %q", spec.Subject, contract.Definition.ID)
+		}
+	}
+	if first[0].ID != "example-risk-stable-fingerprint" {
+		t.Fatalf("first missing spec id = %q, want stable fingerprint case", first[0].ID)
+	}
+}
+
+func TestAuthorMissingRejectsUnknownCoveredCase(t *testing.T) {
+	_, err := AuthorMissing(Contract{Definition: durableDefinition()}, []Case{"coverage_only"})
+	if err == nil {
+		t.Fatal("AuthorMissing() error = nil, want unsupported case")
+	}
+}
+
+func TestRequiredCasesRetiredRuleOnlyRequiresNonOpen(t *testing.T) {
+	definition := durableDefinition()
+	definition.Lifecycle = findings.Lifecycle{Kind: findings.LifecycleRetired, Anchor: findings.AnchorNone}
+	got, err := RequiredCases(Contract{Definition: definition})
+	if err != nil {
+		t.Fatalf("RequiredCases() error = %v", err)
+	}
+	want := []Case{CaseRetiredNonOpen}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RequiredCases() = %v, want %v", got, want)
+	}
+}
+
+func TestRequiredCasesRejectsUnsupportedCloseCapabilities(t *testing.T) {
+	tests := []Contract{
+		{
+			Definition: func() findings.RuleDefinition {
+				definition := durableDefinition()
+				definition.Lifecycle = findings.Lifecycle{Kind: findings.LifecycleAuditEvidence, Anchor: findings.AnchorNone}
+				return definition
+			}(),
+			SupportsCounterEvents: true,
+		},
+		{
+			Definition:               durableDefinition(),
+			SupportsDeprovisionClose: true,
+		},
+	}
+	for _, contract := range tests {
+		if _, err := RequiredCases(contract); err == nil {
+			t.Fatalf("RequiredCases(%#v) error = nil, want invalid capability", contract)
+		}
+	}
+}
+
+func durableDefinition() findings.RuleDefinition {
+	return findings.RuleDefinition{
+		ID:                 "example_risk",
+		Name:               "Example risk",
+		SourceID:           "example",
+		OutputKind:         "finding.example_risk",
+		RequiredAttributes: []string{"resource_id"},
+		FingerprintFields:  []string{"resource_id"},
+		Lifecycle: findings.Lifecycle{
+			Kind:   findings.LifecycleDurableState,
+			Anchor: findings.AnchorSourceState,
+		},
+	}
+}

--- a/internal/testauthor/policy/author.go
+++ b/internal/testauthor/policy/author.go
@@ -1,0 +1,109 @@
+package policy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/writer/cerebro/internal/findingdsl"
+)
+
+type Intent struct {
+	ID               string                       `json:"id" yaml:"id"`
+	Domain           string                       `json:"domain" yaml:"domain"`
+	Name             string                       `json:"name" yaml:"name"`
+	Description      string                       `json:"description" yaml:"description"`
+	Severity         string                       `json:"severity" yaml:"severity"`
+	Resource         string                       `json:"resource" yaml:"resource"`
+	Conditions       []string                     `json:"conditions" yaml:"conditions"`
+	References       []string                     `json:"references,omitempty" yaml:"references,omitempty"`
+	Tags             []string                     `json:"tags,omitempty" yaml:"tags,omitempty"`
+	RiskCategories   []string                     `json:"riskCategories,omitempty" yaml:"riskCategories,omitempty"`
+	Frameworks       []findingdsl.PolicyFramework `json:"frameworks" yaml:"frameworks"`
+	Remediation      string                       `json:"remediation" yaml:"remediation"`
+	RemediationSteps []string                     `json:"remediationSteps,omitempty" yaml:"remediationSteps,omitempty"`
+}
+
+type Artifacts struct {
+	PolicyPath string
+	PolicyYAML []byte
+	TestPath   string
+	TestYAML   []byte
+	Rule       findingdsl.PolicyFindingRule
+	Suite      findingdsl.PolicyRuleTestSuite
+}
+
+func Author(intent Intent) (Artifacts, error) {
+	rule := findingdsl.NewPolicyRule(findingdsl.NewPolicyRuleInput{
+		ID: intent.ID, Domain: intent.Domain, Name: intent.Name, Description: intent.Description,
+		Severity: intent.Severity, Resource: intent.Resource, Conditions: intent.Conditions,
+		References: intent.References, Tags: intent.Tags, RiskCategories: intent.RiskCategories,
+		Frameworks: intent.Frameworks, Remediation: intent.Remediation, RemediationStep: intent.RemediationSteps,
+	})
+	if issues := findingdsl.ValidatePolicyRule(rule); len(issues) != 0 {
+		return Artifacts{}, fmt.Errorf("authored policy is invalid: %s", joinIssues(issues))
+	}
+	suite, err := SuiteForRule(rule)
+	if err != nil {
+		return Artifacts{}, err
+	}
+	policyYAML, err := findingdsl.FormatPolicyRuleYAML(rule)
+	if err != nil {
+		return Artifacts{}, err
+	}
+	testYAML, err := findingdsl.FormatPolicyRuleTestSuiteYAML(suite)
+	if err != nil {
+		return Artifacts{}, err
+	}
+	policyCheck, err := findingdsl.FormatPolicyRuleYAML(rule)
+	if err != nil {
+		return Artifacts{}, err
+	}
+	testCheck, err := findingdsl.FormatPolicyRuleTestSuiteYAML(suite)
+	if err != nil {
+		return Artifacts{}, err
+	}
+	if !bytes.Equal(policyYAML, policyCheck) || !bytes.Equal(testYAML, testCheck) {
+		return Artifacts{}, errors.New("authored policy artifacts are not reproducible")
+	}
+	testPath := strings.TrimSuffix(rule.RelPath, filepath.Ext(rule.RelPath)) + ".test.yaml"
+	return Artifacts{PolicyPath: rule.RelPath, PolicyYAML: policyYAML, TestPath: testPath, TestYAML: testYAML, Rule: rule, Suite: suite}, nil
+}
+
+func SuiteForRule(rule findingdsl.PolicyFindingRule) (findingdsl.PolicyRuleTestSuite, error) {
+	finding, passing, err := findingdsl.SynthesizeEqualityConditionFixtures(rule.Spec.Match.Conditions)
+	if err != nil {
+		return findingdsl.PolicyRuleTestSuite{}, fmt.Errorf("author policy tests: %w", err)
+	}
+	suite := findingdsl.PolicyRuleTestSuite{APIVersion: findingdsl.APIVersion, Kind: findingdsl.KindPolicyFindingRuleTest, Cases: []findingdsl.PolicyRuleTestCase{
+		{Name: "matching resource produces a finding", Resource: finding, WantFinding: true},
+		{Name: "non-matching resource passes", Resource: passing, WantFinding: false},
+	}}
+	if issues := findingdsl.ValidatePolicyRuleTestSuite(suite); len(issues) != 0 {
+		return suite, fmt.Errorf("authored test suite is invalid: %s", joinIssues(issues))
+	}
+	for _, testCase := range suite.Cases {
+		got, evalErr := findingdsl.EvaluatePolicyRuleTestCase(rule, testCase)
+		if evalErr != nil || got != testCase.WantFinding {
+			return suite, fmt.Errorf("prove authored case %q: finding=%t want=%t: %w", testCase.Name, got, testCase.WantFinding, evalErr)
+		}
+	}
+	return suite, nil
+}
+
+func joinIssues(issues []findingdsl.Issue) string {
+	messages := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		messages = append(messages, issue.Path+": "+issue.Message)
+	}
+	return strings.Join(messages, "; ")
+}
+
+func IsSupported(rule findingdsl.PolicyFindingRule) bool {
+	_, _, err := findingdsl.SynthesizeEqualityConditionFixtures(rule.Spec.Match.Conditions)
+	return err == nil
+}
+
+var ErrExistingTestSuite = errors.New("policy already has a test suite")

--- a/internal/testauthor/policy/author.go
+++ b/internal/testauthor/policy/author.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/writer/cerebro/internal/findingdsl"
 )
+
+var domainPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
 type Intent struct {
 	ID               string                       `json:"id" yaml:"id"`
@@ -36,8 +39,12 @@ type Artifacts struct {
 }
 
 func Author(intent Intent) (Artifacts, error) {
+	domain := strings.TrimSpace(intent.Domain)
+	if !domainPattern.MatchString(domain) {
+		return Artifacts{}, fmt.Errorf("policy domain %q must use lowercase dash-separated alphanumeric segments", intent.Domain)
+	}
 	rule := findingdsl.NewPolicyRule(findingdsl.NewPolicyRuleInput{
-		ID: intent.ID, Domain: intent.Domain, Name: intent.Name, Description: intent.Description,
+		ID: intent.ID, Domain: domain, Name: intent.Name, Description: intent.Description,
 		Severity: intent.Severity, Resource: intent.Resource, Conditions: intent.Conditions,
 		References: intent.References, Tags: intent.Tags, RiskCategories: intent.RiskCategories,
 		Frameworks: intent.Frameworks, Remediation: intent.Remediation, RemediationStep: intent.RemediationSteps,

--- a/internal/testauthor/policy/author_test.go
+++ b/internal/testauthor/policy/author_test.go
@@ -1,0 +1,39 @@
+package policy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/writer/cerebro/internal/findingdsl"
+)
+
+func TestAuthorWritesRunnablePolicyAndTestsDeterministically(t *testing.T) {
+	intent := Intent{ID: "aws-s3-public-access", Domain: "aws", Name: "S3 public access", Description: "Flags buckets with public access enabled.", Severity: "high", Resource: "aws::s3::bucket", Conditions: []string{`cmp_eq(path(resource, "public"), true)`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"2.1.5"}}}, Remediation: "Block public access."}
+	first, err := Author(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Author(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first.PolicyYAML, second.PolicyYAML) || !bytes.Equal(first.TestYAML, second.TestYAML) {
+		t.Fatal("authored artifacts are not deterministic")
+	}
+	if first.PolicyPath != "policies/aws/aws-s3-public-access.yaml" || first.TestPath != "policies/aws/aws-s3-public-access.test.yaml" {
+		t.Fatalf("unexpected paths: %s %s", first.PolicyPath, first.TestPath)
+	}
+	for _, testCase := range first.Suite.Cases {
+		got, err := findingdsl.EvaluatePolicyRuleTestCase(first.Rule, testCase)
+		if err != nil || got != testCase.WantFinding {
+			t.Fatalf("case %q got %t want %t err %v", testCase.Name, got, testCase.WantFinding, err)
+		}
+	}
+}
+
+func TestAuthorRejectsUnsupportedPolicySemantics(t *testing.T) {
+	intent := Intent{ID: "complex", Domain: "aws", Name: "Complex", Description: "Complex policy.", Severity: "high", Conditions: []string{`cmp_ne(path(resource, "state"), "safe")`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}}
+	if _, err := Author(intent); err == nil {
+		t.Fatal("Author() error = nil")
+	}
+}

--- a/internal/testauthor/policy/author_test.go
+++ b/internal/testauthor/policy/author_test.go
@@ -37,3 +37,10 @@ func TestAuthorRejectsUnsupportedPolicySemantics(t *testing.T) {
 		t.Fatal("Author() error = nil")
 	}
 }
+
+func TestAuthorRejectsDomainOutsidePolicyDirectory(t *testing.T) {
+	intent := Intent{ID: "example", Domain: "../docs", Name: "Example", Description: "Example policy.", Severity: "high", Conditions: []string{`cmp_eq(path(resource, "enabled"), false)`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}}
+	if _, err := Author(intent); err == nil {
+		t.Fatal("Author() error = nil")
+	}
+}

--- a/internal/testauthor/proof/runner.go
+++ b/internal/testauthor/proof/runner.go
@@ -1,0 +1,148 @@
+package proof
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/testauthor"
+)
+
+var (
+	ErrNonReproducible   = errors.New("generated test artifact is not reproducible")
+	ErrUnexpectedOutcome = errors.New("generated test produced an unexpected proof outcome")
+)
+
+type Mode string
+
+const (
+	ModeRevision Mode = "revision"
+	ModeMutation Mode = "mutation"
+)
+
+type GenerateFunc func(context.Context, testauthor.TestSpec) ([]byte, error)
+
+type ProbeFunc func(context.Context, string, []byte) (ProbeResult, error)
+
+type ProbeResult struct {
+	Passed bool
+	Detail string
+}
+
+type Request struct {
+	Spec           testauthor.TestSpec
+	Mode           Mode
+	UnprotectedRef string
+	ProtectedRef   string
+}
+
+type Result struct {
+	SpecID         string                         `json:"spec_id"`
+	ArtifactDigest string                         `json:"artifact_digest,omitempty"`
+	Receipts       []testauthor.ValidationReceipt `json:"receipts"`
+}
+
+type Runner struct {
+	generate GenerateFunc
+	probe    ProbeFunc
+}
+
+func NewRunner(generate GenerateFunc, probe ProbeFunc) (*Runner, error) {
+	if generate == nil {
+		return nil, errors.New("test proof generator is required")
+	}
+	if probe == nil {
+		return nil, errors.New("test proof probe is required")
+	}
+	return &Runner{generate: generate, probe: probe}, nil
+}
+
+func (runner *Runner) Run(ctx context.Context, request Request) (Result, error) {
+	if runner == nil || runner.generate == nil || runner.probe == nil {
+		return Result{}, errors.New("test proof runner is not configured")
+	}
+	request.Spec = request.Spec.Normalize()
+	if err := validateRequest(request); err != nil {
+		return Result{}, err
+	}
+	result := Result{SpecID: request.Spec.ID, Receipts: []testauthor.ValidationReceipt{}}
+
+	first, err := runner.generate(ctx, request.Spec)
+	if err != nil {
+		return result, fmt.Errorf("generate test artifact: %w", err)
+	}
+	second, err := runner.generate(ctx, request.Spec)
+	if err != nil {
+		return result, fmt.Errorf("regenerate test artifact: %w", err)
+	}
+	if len(first) == 0 || !bytes.Equal(first, second) {
+		receipt, receiptErr := testauthor.NewValidationReceipt(request.Spec, "reproducibility", testauthor.ReceiptFailed, "generation did not produce identical non-empty output")
+		if receiptErr != nil {
+			return result, errors.Join(ErrNonReproducible, receiptErr)
+		}
+		result.Receipts = append(result.Receipts, receipt)
+		return result, ErrNonReproducible
+	}
+	sum := sha256.Sum256(first)
+	result.ArtifactDigest = hex.EncodeToString(sum[:])
+	receipt, err := testauthor.NewValidationReceipt(request.Spec, "reproducibility", testauthor.ReceiptPassed, "generated output is byte-identical")
+	if err != nil {
+		return result, err
+	}
+	result.Receipts = append(result.Receipts, receipt)
+
+	proofErrs := make([]error, 0, 2)
+	result, err = runner.probeTarget(ctx, result, request.Spec, "unprotected_target", request.UnprotectedRef, false, first)
+	if err != nil {
+		proofErrs = append(proofErrs, err)
+	}
+	result, err = runner.probeTarget(ctx, result, request.Spec, "protected_target", request.ProtectedRef, true, first)
+	if err != nil {
+		proofErrs = append(proofErrs, err)
+	}
+	return result, errors.Join(proofErrs...)
+}
+
+func (runner *Runner) probeTarget(ctx context.Context, result Result, spec testauthor.TestSpec, gate string, reference string, expectedPass bool, artifact []byte) (Result, error) {
+	probe, err := runner.probe(ctx, reference, artifact)
+	if err != nil {
+		return result, fmt.Errorf("probe %s %q: %w", gate, reference, err)
+	}
+	status := testauthor.ReceiptPassed
+	var outcomeErr error
+	if probe.Passed != expectedPass {
+		status = testauthor.ReceiptFailed
+		outcomeErr = fmt.Errorf("%w: %s %q passed=%t, want %t", ErrUnexpectedOutcome, gate, reference, probe.Passed, expectedPass)
+	}
+	receipt, err := testauthor.NewValidationReceipt(spec, gate, status, probe.Detail)
+	if err != nil {
+		return result, errors.Join(outcomeErr, err)
+	}
+	result.Receipts = append(result.Receipts, receipt)
+	return result, outcomeErr
+}
+
+func validateRequest(request Request) error {
+	if err := request.Spec.Validate(); err != nil {
+		return err
+	}
+	if request.Mode != ModeRevision && request.Mode != ModeMutation {
+		return fmt.Errorf("unsupported test proof mode %q", request.Mode)
+	}
+	unprotected := strings.TrimSpace(request.UnprotectedRef)
+	protected := strings.TrimSpace(request.ProtectedRef)
+	if unprotected == "" {
+		return errors.New("unprotected test proof reference is required")
+	}
+	if protected == "" {
+		return errors.New("protected test proof reference is required")
+	}
+	if unprotected == protected {
+		return errors.New("unprotected and protected test proof references must differ")
+	}
+	return nil
+}

--- a/internal/testauthor/proof/runner_test.go
+++ b/internal/testauthor/proof/runner_test.go
@@ -1,0 +1,165 @@
+package proof
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/writer/cerebro/internal/testauthor"
+)
+
+func TestRunnerProvesReproducibleFailThenPass(t *testing.T) {
+	generated := 0
+	var probed []string
+	runner, err := NewRunner(
+		func(context.Context, testauthor.TestSpec) ([]byte, error) {
+			generated++
+			return []byte("generated-test"), nil
+		},
+		func(_ context.Context, reference string, artifact []byte) (ProbeResult, error) {
+			if string(artifact) != "generated-test" {
+				t.Fatalf("probe artifact = %q, want generated test", artifact)
+			}
+			probed = append(probed, reference)
+			return ProbeResult{Passed: reference == "protected", Detail: reference + " result"}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), Request{
+		Spec:           proofSpec(),
+		Mode:           ModeRevision,
+		UnprotectedRef: "unprotected",
+		ProtectedRef:   "protected",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if generated != 2 {
+		t.Fatalf("generate calls = %d, want 2", generated)
+	}
+	if !reflect.DeepEqual(probed, []string{"unprotected", "protected"}) {
+		t.Fatalf("probe refs = %v, want unprotected then protected", probed)
+	}
+	if len(result.ArtifactDigest) != 64 {
+		t.Fatalf("artifact digest length = %d, want 64", len(result.ArtifactDigest))
+	}
+	if len(result.Receipts) != 3 {
+		t.Fatalf("receipt count = %d, want 3", len(result.Receipts))
+	}
+	for _, receipt := range result.Receipts {
+		if receipt.Status != testauthor.ReceiptPassed {
+			t.Fatalf("receipt = %#v, want passed", receipt)
+		}
+	}
+}
+
+func TestRunnerRejectsNonReproducibleArtifactBeforeProbe(t *testing.T) {
+	generated := 0
+	probed := false
+	runner, err := NewRunner(
+		func(context.Context, testauthor.TestSpec) ([]byte, error) {
+			generated++
+			if generated == 1 {
+				return []byte("first"), nil
+			}
+			return []byte("second"), nil
+		},
+		func(context.Context, string, []byte) (ProbeResult, error) {
+			probed = true
+			return ProbeResult{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+	result, err := runner.Run(context.Background(), proofRequest())
+	if !errors.Is(err, ErrNonReproducible) {
+		t.Fatalf("Run() error = %v, want ErrNonReproducible", err)
+	}
+	if probed {
+		t.Fatal("probe called for non-reproducible artifact")
+	}
+	if len(result.Receipts) != 1 || result.Receipts[0].Status != testauthor.ReceiptFailed {
+		t.Fatalf("receipts = %#v, want failed reproducibility receipt", result.Receipts)
+	}
+}
+
+func TestRunnerRecordsBothUnexpectedProofOutcomes(t *testing.T) {
+	runner, err := NewRunner(
+		func(context.Context, testauthor.TestSpec) ([]byte, error) { return []byte("test"), nil },
+		func(_ context.Context, reference string, _ []byte) (ProbeResult, error) {
+			return ProbeResult{Passed: reference == "unprotected"}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+	result, err := runner.Run(context.Background(), proofRequest())
+	if !errors.Is(err, ErrUnexpectedOutcome) {
+		t.Fatalf("Run() error = %v, want ErrUnexpectedOutcome", err)
+	}
+	if len(result.Receipts) != 3 {
+		t.Fatalf("receipt count = %d, want 3", len(result.Receipts))
+	}
+	if result.Receipts[1].Status != testauthor.ReceiptFailed || result.Receipts[2].Status != testauthor.ReceiptFailed {
+		t.Fatalf("proof receipts = %#v, want both failed", result.Receipts[1:])
+	}
+}
+
+func TestRunnerRejectsInvalidRequestBeforeGeneration(t *testing.T) {
+	generated := false
+	runner, err := NewRunner(
+		func(context.Context, testauthor.TestSpec) ([]byte, error) {
+			generated = true
+			return []byte("test"), nil
+		},
+		func(context.Context, string, []byte) (ProbeResult, error) { return ProbeResult{}, nil },
+	)
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+	request := proofRequest()
+	request.ProtectedRef = request.UnprotectedRef
+	if _, err := runner.Run(context.Background(), request); err == nil {
+		t.Fatal("Run() error = nil, want invalid references")
+	}
+	if generated {
+		t.Fatal("generator called for invalid request")
+	}
+}
+
+func proofRequest() Request {
+	return Request{
+		Spec:           proofSpec(),
+		Mode:           ModeMutation,
+		UnprotectedRef: "unprotected",
+		ProtectedRef:   "protected",
+	}
+}
+
+func proofSpec() testauthor.TestSpec {
+	return testauthor.TestSpec{
+		APIVersion: testauthor.APIVersion,
+		ID:         "finding-rule-unrelated-close",
+		Family:     testauthor.FamilyFindingRule,
+		Subject:    "example-risk",
+		Behavior:   "unrelated evidence does not close the finding",
+		Signal: testauthor.Signal{
+			Kind:      testauthor.SignalMutationSurvivor,
+			Reference: "mutation/unrelated-close",
+		},
+		Oracle: testauthor.Oracle{
+			Kind:      testauthor.OracleLifecycleContract,
+			Assertion: "finding_status == open",
+		},
+		Fixture: testauthor.Fixture{
+			Kind:      testauthor.FixtureSyntheticEventSequence,
+			SchemaRef: "example/synthetic/v1",
+		},
+		Generator: testauthor.Generator{Name: "finding_rule_fixture", Version: "v1"},
+	}
+}

--- a/internal/testauthor/receipt.go
+++ b/internal/testauthor/receipt.go
@@ -1,0 +1,47 @@
+package testauthor
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ReceiptStatus string
+
+const (
+	ReceiptPassed ReceiptStatus = "passed"
+	ReceiptFailed ReceiptStatus = "failed"
+)
+
+type ValidationReceipt struct {
+	SpecID           string        `json:"spec_id"`
+	SpecDigest       string        `json:"spec_digest"`
+	Gate             string        `json:"gate"`
+	Status           ReceiptStatus `json:"status"`
+	Detail           string        `json:"detail,omitempty"`
+	Generator        string        `json:"generator"`
+	GeneratorVersion string        `json:"generator_version"`
+}
+
+func NewValidationReceipt(spec TestSpec, gate string, status ReceiptStatus, detail string) (ValidationReceipt, error) {
+	spec = spec.Normalize()
+	digest, err := spec.Digest()
+	if err != nil {
+		return ValidationReceipt{}, err
+	}
+	gate = strings.TrimSpace(gate)
+	if gate == "" {
+		return ValidationReceipt{}, fmt.Errorf("validation receipt gate is required")
+	}
+	if status != ReceiptPassed && status != ReceiptFailed {
+		return ValidationReceipt{}, fmt.Errorf("unsupported validation receipt status %q", status)
+	}
+	return ValidationReceipt{
+		SpecID:           spec.ID,
+		SpecDigest:       digest,
+		Gate:             gate,
+		Status:           status,
+		Detail:           strings.TrimSpace(detail),
+		Generator:        spec.Generator.Name,
+		GeneratorVersion: spec.Generator.Version,
+	}, nil
+}

--- a/internal/testauthor/spec.go
+++ b/internal/testauthor/spec.go
@@ -1,0 +1,206 @@
+package testauthor
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const APIVersion = "testauthor.cerebro.dev/v1alpha1"
+
+type Family string
+
+const (
+	FamilyFindingRule Family = "finding_rule"
+)
+
+type SignalKind string
+
+const (
+	SignalContractGap           SignalKind = "contract_gap"
+	SignalRuntimeCounterexample SignalKind = "runtime_counterexample"
+	SignalChangeGap             SignalKind = "change_gap"
+	SignalMutationSurvivor      SignalKind = "mutation_survivor"
+)
+
+type OracleKind string
+
+const (
+	OracleLifecycleContract     OracleKind = "lifecycle_contract"
+	OracleSchemaContract        OracleKind = "schema_contract"
+	OracleAuthorizationContract OracleKind = "authorization_contract"
+	OracleIdempotencyContract   OracleKind = "idempotency_contract"
+	OracleMutation              OracleKind = "mutation"
+)
+
+type FixtureKind string
+
+const (
+	FixtureSyntheticEvent         FixtureKind = "synthetic_event"
+	FixtureSyntheticEventSequence FixtureKind = "synthetic_event_sequence"
+	FixtureContractCase           FixtureKind = "contract_case"
+)
+
+type TestSpec struct {
+	APIVersion string    `json:"api_version"`
+	ID         string    `json:"id"`
+	Family     Family    `json:"family"`
+	Subject    string    `json:"subject"`
+	Behavior   string    `json:"behavior"`
+	Signal     Signal    `json:"signal"`
+	Oracle     Oracle    `json:"oracle"`
+	Fixture    Fixture   `json:"fixture"`
+	Generator  Generator `json:"generator"`
+}
+
+type Signal struct {
+	Kind      SignalKind `json:"kind"`
+	Reference string     `json:"reference"`
+}
+
+type Oracle struct {
+	Kind      OracleKind `json:"kind"`
+	Assertion string     `json:"assertion"`
+}
+
+type Fixture struct {
+	Kind      FixtureKind `json:"kind"`
+	SchemaRef string      `json:"schema_ref"`
+}
+
+type Generator struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type ValidationIssue struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+type ValidationError struct {
+	Issues []ValidationIssue `json:"issues"`
+}
+
+func (e *ValidationError) Error() string {
+	parts := make([]string, 0, len(e.Issues))
+	for _, issue := range e.Issues {
+		parts = append(parts, issue.Field+": "+issue.Message)
+	}
+	return "invalid test specification: " + strings.Join(parts, "; ")
+}
+
+var stableIDPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+func (spec TestSpec) Normalize() TestSpec {
+	spec.APIVersion = strings.TrimSpace(spec.APIVersion)
+	spec.ID = strings.ToLower(strings.TrimSpace(spec.ID))
+	spec.Family = Family(strings.ToLower(strings.TrimSpace(string(spec.Family))))
+	spec.Subject = strings.TrimSpace(spec.Subject)
+	spec.Behavior = strings.TrimSpace(spec.Behavior)
+	spec.Signal.Kind = SignalKind(strings.ToLower(strings.TrimSpace(string(spec.Signal.Kind))))
+	spec.Signal.Reference = strings.TrimSpace(spec.Signal.Reference)
+	spec.Oracle.Kind = OracleKind(strings.ToLower(strings.TrimSpace(string(spec.Oracle.Kind))))
+	spec.Oracle.Assertion = strings.TrimSpace(spec.Oracle.Assertion)
+	spec.Fixture.Kind = FixtureKind(strings.ToLower(strings.TrimSpace(string(spec.Fixture.Kind))))
+	spec.Fixture.SchemaRef = strings.TrimSpace(spec.Fixture.SchemaRef)
+	spec.Generator.Name = strings.TrimSpace(spec.Generator.Name)
+	spec.Generator.Version = strings.TrimSpace(spec.Generator.Version)
+	return spec
+}
+
+func (spec TestSpec) Validate() error {
+	spec = spec.Normalize()
+	issues := make([]ValidationIssue, 0)
+	add := func(field string, message string) {
+		issues = append(issues, ValidationIssue{Field: field, Message: message})
+	}
+
+	if spec.APIVersion != APIVersion {
+		add("api_version", fmt.Sprintf("must equal %q", APIVersion))
+	}
+	if !stableIDPattern.MatchString(spec.ID) {
+		add("id", "must be a non-empty lowercase kebab-case identifier")
+	}
+	if spec.Family != FamilyFindingRule {
+		add("family", fmt.Sprintf("unsupported family %q", spec.Family))
+	}
+	if spec.Subject == "" {
+		add("subject", "is required")
+	}
+	if spec.Behavior == "" {
+		add("behavior", "is required")
+	}
+	if !validSignalKind(spec.Signal.Kind) {
+		add("signal.kind", fmt.Sprintf("unsupported signal kind %q", spec.Signal.Kind))
+	}
+	if spec.Signal.Reference == "" {
+		add("signal.reference", "is required")
+	}
+	if !validOracleKind(spec.Oracle.Kind) {
+		add("oracle.kind", fmt.Sprintf("unsupported oracle kind %q", spec.Oracle.Kind))
+	}
+	if spec.Oracle.Assertion == "" {
+		add("oracle.assertion", "is required")
+	}
+	if !validFixtureKind(spec.Fixture.Kind) {
+		add("fixture.kind", fmt.Sprintf("unsupported fixture kind %q", spec.Fixture.Kind))
+	}
+	if spec.Fixture.SchemaRef == "" {
+		add("fixture.schema_ref", "is required")
+	}
+	if spec.Generator.Name == "" {
+		add("generator.name", "is required")
+	}
+	if spec.Generator.Version == "" {
+		add("generator.version", "is required")
+	}
+
+	if len(issues) > 0 {
+		return &ValidationError{Issues: issues}
+	}
+	return nil
+}
+
+func (spec TestSpec) Digest() (string, error) {
+	spec = spec.Normalize()
+	if err := spec.Validate(); err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("marshal test specification: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func validSignalKind(kind SignalKind) bool {
+	switch kind {
+	case SignalContractGap, SignalRuntimeCounterexample, SignalChangeGap, SignalMutationSurvivor:
+		return true
+	default:
+		return false
+	}
+}
+
+func validOracleKind(kind OracleKind) bool {
+	switch kind {
+	case OracleLifecycleContract, OracleSchemaContract, OracleAuthorizationContract, OracleIdempotencyContract, OracleMutation:
+		return true
+	default:
+		return false
+	}
+}
+
+func validFixtureKind(kind FixtureKind) bool {
+	switch kind {
+	case FixtureSyntheticEvent, FixtureSyntheticEventSequence, FixtureContractCase:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/testauthor/spec_test.go
+++ b/internal/testauthor/spec_test.go
@@ -1,0 +1,130 @@
+package testauthor
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSpecNormalizeAndDigestAreDeterministic(t *testing.T) {
+	spec := validSpec()
+	spec.ID = "  FINDING-RULE-UNRELATED-CLOSE "
+	spec.Family = " FINDING_RULE "
+	spec.Signal.Kind = " CONTRACT_GAP "
+	spec.Oracle.Kind = " LIFECYCLE_CONTRACT "
+	spec.Fixture.Kind = " SYNTHETIC_EVENT_SEQUENCE "
+
+	first, err := spec.Digest()
+	if err != nil {
+		t.Fatalf("Digest() error = %v", err)
+	}
+	second, err := spec.Normalize().Digest()
+	if err != nil {
+		t.Fatalf("normalized Digest() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("digest mismatch: %q != %q", first, second)
+	}
+	if len(first) != 64 {
+		t.Fatalf("digest length = %d, want 64", len(first))
+	}
+}
+
+func TestSpecValidateRejectsIncompleteOrUnownedContracts(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*TestSpec)
+		field  string
+	}{
+		{name: "api version", mutate: func(spec *TestSpec) { spec.APIVersion = "v1" }, field: "api_version"},
+		{name: "stable id", mutate: func(spec *TestSpec) { spec.ID = "not stable!" }, field: "id"},
+		{name: "family", mutate: func(spec *TestSpec) { spec.Family = "free_form_go" }, field: "family"},
+		{name: "subject", mutate: func(spec *TestSpec) { spec.Subject = "" }, field: "subject"},
+		{name: "behavior", mutate: func(spec *TestSpec) { spec.Behavior = "" }, field: "behavior"},
+		{name: "signal kind", mutate: func(spec *TestSpec) { spec.Signal.Kind = "coverage" }, field: "signal.kind"},
+		{name: "signal reference", mutate: func(spec *TestSpec) { spec.Signal.Reference = "" }, field: "signal.reference"},
+		{name: "oracle kind", mutate: func(spec *TestSpec) { spec.Oracle.Kind = "implementation_snapshot" }, field: "oracle.kind"},
+		{name: "oracle assertion", mutate: func(spec *TestSpec) { spec.Oracle.Assertion = "" }, field: "oracle.assertion"},
+		{name: "fixture kind", mutate: func(spec *TestSpec) { spec.Fixture.Kind = "runtime_payload" }, field: "fixture.kind"},
+		{name: "schema ref", mutate: func(spec *TestSpec) { spec.Fixture.SchemaRef = "" }, field: "fixture.schema_ref"},
+		{name: "generator name", mutate: func(spec *TestSpec) { spec.Generator.Name = "" }, field: "generator.name"},
+		{name: "generator version", mutate: func(spec *TestSpec) { spec.Generator.Version = "" }, field: "generator.version"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := validSpec()
+			test.mutate(&spec)
+			err := spec.Validate()
+			var validationErr *ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("Validate() error = %v, want ValidationError", err)
+			}
+			if !hasIssue(validationErr.Issues, test.field) {
+				t.Fatalf("issues = %#v, want field %q", validationErr.Issues, test.field)
+			}
+		})
+	}
+}
+
+func TestNewValidationReceiptBindsGateToNormalizedSpec(t *testing.T) {
+	spec := validSpec()
+	receipt, err := NewValidationReceipt(spec, " reproducibility ", ReceiptPassed, " byte-identical output ")
+	if err != nil {
+		t.Fatalf("NewValidationReceipt() error = %v", err)
+	}
+	digest, err := spec.Digest()
+	if err != nil {
+		t.Fatalf("Digest() error = %v", err)
+	}
+	if receipt.SpecID != spec.ID || receipt.SpecDigest != digest {
+		t.Fatalf("receipt identity = %#v, want id %q digest %q", receipt, spec.ID, digest)
+	}
+	if receipt.Gate != "reproducibility" || receipt.Detail != "byte-identical output" {
+		t.Fatalf("receipt text = %#v, want normalized values", receipt)
+	}
+	if receipt.Generator != spec.Generator.Name || receipt.GeneratorVersion != spec.Generator.Version {
+		t.Fatalf("receipt generator = %#v, want specification generator", receipt)
+	}
+}
+
+func TestNewValidationReceiptRejectsUnknownStatus(t *testing.T) {
+	_, err := NewValidationReceipt(validSpec(), "contract", "unknown", "")
+	if err == nil {
+		t.Fatal("NewValidationReceipt() error = nil, want unsupported status")
+	}
+}
+
+func validSpec() TestSpec {
+	return TestSpec{
+		APIVersion: APIVersion,
+		ID:         "finding-rule-unrelated-close",
+		Family:     FamilyFindingRule,
+		Subject:    "github-secret-scanning-disabled",
+		Behavior:   "unrelated events do not close an open finding",
+		Signal: Signal{
+			Kind:      SignalContractGap,
+			Reference: "finding-lifecycle/unrelated-close",
+		},
+		Oracle: Oracle{
+			Kind:      OracleLifecycleContract,
+			Assertion: "finding_status == open",
+		},
+		Fixture: Fixture{
+			Kind:      FixtureSyntheticEventSequence,
+			SchemaRef: "github/audit/v1",
+		},
+		Generator: Generator{
+			Name:    "finding_rule_fixture",
+			Version: "v1",
+		},
+	}
+}
+
+func hasIssue(issues []ValidationIssue, field string) bool {
+	for _, issue := range issues {
+		if issue.Field == field {
+			return true
+		}
+	}
+	return false
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Findings Platform Architecture: domains/findings-platform-architecture.md
       - Finding Candidate Operations: domains/finding-candidate-operations.md
       - Agent Platform Contract: domains/agent-platform-contract.md
+      - Self-Authoring Tests: domains/self-authoring-tests.md
       - Endpoint Security Platform Integration: domains/endpoint-security-platform-integration.md
       - MCP Native Droid Setup: domains/mcp-droid-setup.md
   - Engineering:

--- a/tools/testauthor/main.go
+++ b/tools/testauthor/main.go
@@ -183,20 +183,24 @@ func writeNew(root, rel string, content []byte) error {
 		return err
 	}
 	defer repo.Close()
-	if _, err := repo.Lstat(rel); err == nil {
-		return fmt.Errorf("refusing to overwrite %s", rel)
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
 	if dir := filepath.ToSlash(filepath.Dir(rel)); dir != "." {
 		if err := repo.MkdirAll(dir, 0o750); err != nil {
 			return err
 		}
 	}
-	if err := repo.WriteFile(rel, content, 0o600); err != nil {
+	file, err := repo.OpenFile(rel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return fmt.Errorf("refusing to overwrite %s", rel)
+		}
 		return err
 	}
-	return nil
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		_ = repo.Remove(rel)
+		return err
+	}
+	return file.Close()
 }
 
 func fail(err error) { fmt.Fprintln(os.Stderr, "testauthor:", err); os.Exit(1) }

--- a/tools/testauthor/main.go
+++ b/tools/testauthor/main.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/writer/cerebro/internal/findingdsl"
+	policyauthor "github.com/writer/cerebro/internal/testauthor/policy"
+	"gopkg.in/yaml.v3"
+)
+
+type gap struct {
+	Policy    string `json:"policy"`
+	Test      string `json:"test"`
+	Supported bool   `json:"supported"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fail(errors.New("command is required: scan, author-policy, or author-tests"))
+	}
+	var err error
+	switch os.Args[1] {
+	case "scan":
+		err = runScan(os.Args[2:])
+	case "author-policy":
+		err = runAuthorPolicy(os.Args[2:])
+	case "author-tests":
+		err = runAuthorTests(os.Args[2:])
+	default:
+		err = fmt.Errorf("unknown command %q", os.Args[1])
+	}
+	if err != nil {
+		fail(err)
+	}
+}
+
+func runScan(args []string) error {
+	flags := flag.NewFlagSet("testauthor scan", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	gaps, err := findGaps(*root)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(gaps)
+}
+
+func runAuthorPolicy(args []string) error {
+	flags := flag.NewFlagSet("testauthor author-policy", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	intentPath := flags.String("intent", "", "policy intent YAML")
+	write := flags.Bool("write", false, "write policy and test files")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*intentPath) == "" {
+		return errors.New("--intent is required")
+	}
+	content, err := os.ReadFile(*intentPath)
+	if err != nil {
+		return err
+	}
+	var intent policyauthor.Intent
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&intent); err != nil {
+		return fmt.Errorf("decode policy intent: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("policy intent must contain one YAML document")
+	}
+	artifacts, err := policyauthor.Author(intent)
+	if err != nil {
+		return err
+	}
+	if !*write {
+		_, err = fmt.Fprintf(os.Stdout, "# %s\n%s---\n# %s\n%s", artifacts.PolicyPath, artifacts.PolicyYAML, artifacts.TestPath, artifacts.TestYAML)
+		return err
+	}
+	if err := writeNew(*root, artifacts.PolicyPath, artifacts.PolicyYAML); err != nil {
+		return err
+	}
+	if err := writeNew(*root, artifacts.TestPath, artifacts.TestYAML); err != nil {
+		_ = os.Remove(filepath.Join(*root, filepath.FromSlash(artifacts.PolicyPath)))
+		return err
+	}
+	_, err = fmt.Fprintf(os.Stdout, "testauthor: wrote %s and %s; finding and passing cases proved\n", artifacts.PolicyPath, artifacts.TestPath)
+	return err
+}
+
+func runAuthorTests(args []string) error {
+	flags := flag.NewFlagSet("testauthor author-tests", flag.ContinueOnError)
+	root := flags.String("root", ".", "repository root")
+	write := flags.Bool("write", false, "write supported missing test suites")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	gaps, rules, err := gapsAndRules(*root)
+	if err != nil {
+		return err
+	}
+	authored := 0
+	for _, item := range gaps {
+		if !item.Supported {
+			continue
+		}
+		rule := rules[item.Policy]
+		suite, err := policyauthor.SuiteForRule(rule)
+		if err != nil {
+			return err
+		}
+		content, err := findingdsl.FormatPolicyRuleTestSuiteYAML(suite)
+		if err != nil {
+			return err
+		}
+		if *write {
+			if err := writeNew(*root, item.Test, content); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fmt.Fprintf(os.Stdout, "# %s\n%s", item.Test, content); err != nil {
+				return err
+			}
+		}
+		authored++
+	}
+	_, err = fmt.Fprintf(os.Stdout, "testauthor: authored %d supported test suite(s); %d gap(s) require explicit intent\n", authored, len(gaps)-authored)
+	return err
+}
+
+func findGaps(root string) ([]gap, error) { gaps, _, err := gapsAndRules(root); return gaps, err }
+
+func gapsAndRules(root string) ([]gap, map[string]findingdsl.PolicyFindingRule, error) {
+	rules, issues, err := findingdsl.LoadPolicyRules(filepath.Clean(root))
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(issues) != 0 {
+		return nil, nil, fmt.Errorf("policy repository has %d validation issue(s)", len(issues))
+	}
+	result := []gap{}
+	byPath := map[string]findingdsl.PolicyFindingRule{}
+	for _, rule := range rules {
+		testPath := strings.TrimSuffix(rule.RelPath, filepath.Ext(rule.RelPath)) + ".test.yaml"
+		if _, err := os.Lstat(filepath.Join(root, filepath.FromSlash(testPath))); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return nil, nil, err
+		}
+		item := gap{Policy: rule.RelPath, Test: testPath}
+		if _, _, synthErr := findingdsl.SynthesizeEqualityConditionFixtures(rule.Spec.Match.Conditions); synthErr == nil {
+			item.Supported = true
+		} else {
+			item.Reason = synthErr.Error()
+		}
+		result = append(result, item)
+		byPath[rule.RelPath] = rule
+	}
+	return result, byPath, nil
+}
+
+func writeNew(root, rel string, content []byte) error {
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if filepath.IsAbs(rel) || rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return fmt.Errorf("unsafe repository path %q", rel)
+	}
+	repo, err := os.OpenRoot(filepath.Clean(root))
+	if err != nil {
+		return err
+	}
+	defer repo.Close()
+	if _, err := repo.Lstat(rel); err == nil {
+		return fmt.Errorf("refusing to overwrite %s", rel)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if dir := filepath.ToSlash(filepath.Dir(rel)); dir != "." {
+		if err := repo.MkdirAll(dir, 0o750); err != nil {
+			return err
+		}
+	}
+	if err := repo.WriteFile(rel, content, 0o600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func fail(err error) { fmt.Fprintln(os.Stderr, "testauthor:", err); os.Exit(1) }

--- a/tools/testauthor/main_test.go
+++ b/tools/testauthor/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/writer/cerebro/internal/findingdsl"
+	policyauthor "github.com/writer/cerebro/internal/testauthor/policy"
+	"gopkg.in/yaml.v3"
+)
+
+func TestWriteNewRefusesOverwrite(t *testing.T) {
+	root := t.TempDir()
+	if err := writeNew(root, "policies/aws/example.yaml", []byte("first")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeNew(root, "policies/aws/example.yaml", []byte("second")); err == nil {
+		t.Fatal("writeNew() overwrite error = nil")
+	}
+	content, err := os.ReadFile(filepath.Join(root, "policies/aws/example.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, []byte("first")) {
+		t.Fatalf("content = %q", content)
+	}
+}
+
+func TestFindGapsClassifiesSupportedPolicies(t *testing.T) {
+	root := t.TempDir()
+	intent := policyauthor.Intent{ID: "public-bucket", Domain: "aws", Name: "Public bucket", Description: "Flags public buckets.", Severity: "high", Conditions: []string{`cmp_eq(path(resource, "public"), true)`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}}
+	artifacts, err := policyauthor.Author(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeNew(root, artifacts.PolicyPath, artifacts.PolicyYAML); err != nil {
+		t.Fatal(err)
+	}
+	gaps, err := findGaps(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gaps) != 1 || !gaps[0].Supported || gaps[0].Test != artifacts.TestPath {
+		t.Fatalf("gaps = %#v", gaps)
+	}
+	if err := writeNew(root, artifacts.TestPath, artifacts.TestYAML); err != nil {
+		t.Fatal(err)
+	}
+	gaps, err = findGaps(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gaps) != 0 {
+		t.Fatalf("gaps after test write = %#v", gaps)
+	}
+}
+
+func TestIntentYAMLUsesKnownFields(t *testing.T) {
+	content, err := yaml.Marshal(policyauthor.Intent{ID: "example"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(content, []byte("id: example")) {
+		t.Fatalf("intent YAML = %s", content)
+	}
+}

--- a/tools/testauthor/main_test.go
+++ b/tools/testauthor/main_test.go
@@ -28,6 +28,30 @@ func TestWriteNewRefusesOverwrite(t *testing.T) {
 	}
 }
 
+func TestWriteNewRefusesSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "policies", "aws"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "target.yaml")
+	if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../target.yaml", filepath.Join(root, "policies", "aws", "example.yaml")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeNew(root, "policies/aws/example.yaml", []byte("replacement")); err == nil {
+		t.Fatal("writeNew() symlink error = nil")
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, []byte("target")) {
+		t.Fatalf("target content = %q", content)
+	}
+}
+
 func TestFindGapsClassifiesSupportedPolicies(t *testing.T) {
 	root := t.TempDir()
 	intent := policyauthor.Intent{ID: "public-bucket", Domain: "aws", Name: "Public bucket", Description: "Flags public buckets.", Severity: "high", Conditions: []string{`cmp_eq(path(resource, "public"), true)`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}}


### PR DESCRIPTION
## Intent

Make Cerebro author real policy and test artifacts, not only specifications. Keep the first generator bounded to policy conditions whose fixtures can be derived without guessing semantics.

## What changes

- add a structured policy-intent author that emits a PolicyFindingRule and sibling PolicyFindingRuleTest
- synthesize deterministic finding and passing resources for simple scalar equality conditions
- validate and execute both cases before returning or writing artifacts
- add repository scan and explicit write commands for supported missing suites
- refuse overwrites and report unsupported policy semantics with reasons

## Validation

- `GOCACHE=/tmp/cerebro-test-foundry-gocache go test ./internal/findingdsl ./internal/testauthor/... ./tools/testauthor ./tools/findingdsl`
- `go run ./tools/testauthor scan --root .` found 1,498 policies without sibling suites; 364 are supported by this bounded generator
- `git diff --cached --check`

Stacked on #1906. Keep draft until the dependency stack and automated review are clear.