### PR TITLE
feat(testauthor): prove authored policy tests

### DIFF
--- a/docs/domains/self-authoring-policy-tests.md
+++ b/docs/domains/self-authoring-policy-tests.md
@@ -28,10 +28,13 @@ Preview both artifacts, then write them:
 ```sh
 go run ./tools/testauthor author-policy --intent intent.yaml
 go run ./tools/testauthor author-policy --intent intent.yaml --write
+go run ./tools/testauthor prove-policy --intent intent.yaml
 go run ./tools/findingdsl test policies/aws/aws-s3-public-access.test.yaml
 ```
 
 The write is refused if either target exists. Before writing, the command renders both artifacts twice, requires byte-identical output, validates both artifacts, and executes the finding and passing cases against the authored policy.
+
+`prove-policy` emits artifact digests and two receipts. The protected-target receipt requires the generated suite to pass against the authored policy. The unprotected-target receipt removes the first condition and requires the generated suite to reject that weakened policy.
 
 ## Fill supported repository gaps
 

--- a/internal/testauthor/policy/proof.go
+++ b/internal/testauthor/policy/proof.go
@@ -1,0 +1,65 @@
+package policy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/writer/cerebro/internal/findingdsl"
+)
+
+type ProofReceipt struct {
+	Gate   string `json:"gate"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail"`
+}
+
+type ProofResult struct {
+	PolicyID     string         `json:"policy_id"`
+	PolicyPath   string         `json:"policy_path"`
+	TestPath     string         `json:"test_path"`
+	PolicyDigest string         `json:"policy_digest"`
+	TestDigest   string         `json:"test_digest"`
+	Receipts     []ProofReceipt `json:"receipts"`
+}
+
+func Prove(artifacts Artifacts) (ProofResult, error) {
+	result := ProofResult{
+		PolicyID: artifacts.Rule.Metadata.ID, PolicyPath: artifacts.PolicyPath, TestPath: artifacts.TestPath,
+		PolicyDigest: digest(artifacts.PolicyYAML), TestDigest: digest(artifacts.TestYAML),
+	}
+	protectedPassed, protectedDetail := suitePasses(artifacts.Rule, artifacts.Suite)
+	result.Receipts = append(result.Receipts, ProofReceipt{Gate: "protected_target", Passed: protectedPassed, Detail: protectedDetail})
+	if !protectedPassed {
+		return result, errors.New("authored tests do not pass against the authored policy")
+	}
+
+	weakened := artifacts.Rule
+	if len(weakened.Spec.Match.Conditions) == 0 {
+		return result, errors.New("authored policy has no condition to mutate")
+	}
+	weakened.Spec.Match.Conditions = append([]string(nil), weakened.Spec.Match.Conditions[1:]...)
+	unprotectedPassed, unprotectedDetail := suitePasses(weakened, artifacts.Suite)
+	killed := !unprotectedPassed
+	result.Receipts = append(result.Receipts, ProofReceipt{Gate: "unprotected_target", Passed: killed, Detail: "first policy condition removed: " + unprotectedDetail})
+	if !killed {
+		return result, errors.New("authored tests did not reject the weakened policy")
+	}
+	return result, nil
+}
+
+func suitePasses(rule findingdsl.PolicyFindingRule, suite findingdsl.PolicyRuleTestSuite) (bool, string) {
+	for _, testCase := range suite.Cases {
+		got, err := findingdsl.EvaluatePolicyRuleTestCase(rule, testCase)
+		if err != nil {
+			return false, fmt.Sprintf("case %q rejected policy: %v", testCase.Name, err)
+		}
+		if got != testCase.WantFinding {
+			return false, fmt.Sprintf("case %q finding=%t want=%t", testCase.Name, got, testCase.WantFinding)
+		}
+	}
+	return true, fmt.Sprintf("%d authored cases matched their expected outcomes", len(suite.Cases))
+}
+
+func digest(content []byte) string { sum := sha256.Sum256(content); return hex.EncodeToString(sum[:]) }

--- a/internal/testauthor/policy/proof_test.go
+++ b/internal/testauthor/policy/proof_test.go
@@ -1,0 +1,39 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/findingdsl"
+)
+
+func TestProvePassesProtectedAndRejectsWeakenedPolicy(t *testing.T) {
+	artifacts, err := Author(Intent{ID: "public-bucket", Domain: "aws", Name: "Public bucket", Description: "Flags public buckets.", Severity: "high", Conditions: []string{`cmp_eq(path(resource, "public"), true)`, `cmp_eq(path(resource, "approved"), false)`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Prove(artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Receipts) != 2 || !result.Receipts[0].Passed || !result.Receipts[1].Passed {
+		t.Fatalf("receipts = %#v", result.Receipts)
+	}
+	if result.PolicyDigest == "" || result.TestDigest == "" {
+		t.Fatalf("missing digests: %#v", result)
+	}
+}
+
+func TestProveRejectsSuiteThatSurvivesMutation(t *testing.T) {
+	artifacts, err := Author(Intent{ID: "public-bucket", Domain: "aws", Name: "Public bucket", Description: "Flags public buckets.", Severity: "high", Conditions: []string{`cmp_eq(path(resource, "public"), true)`, `cmp_eq(path(resource, "approved"), false)`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifacts.Suite.Cases = artifacts.Suite.Cases[:1]
+	result, err := Prove(artifacts)
+	if err == nil {
+		t.Fatal("Prove() error = nil")
+	}
+	if len(result.Receipts) != 2 || result.Receipts[1].Passed {
+		t.Fatalf("receipts = %#v", result.Receipts)
+	}
+}

--- a/tools/testauthor/main.go
+++ b/tools/testauthor/main.go
@@ -26,7 +26,7 @@ type gap struct {
 
 func main() {
 	if len(os.Args) < 2 {
-		fail(errors.New("command is required: scan, author-policy, or author-tests"))
+		fail(errors.New("command is required: scan, author-policy, author-tests, or prove-policy"))
 	}
 	var err error
 	switch os.Args[1] {
@@ -36,6 +36,8 @@ func main() {
 		err = runAuthorPolicy(os.Args[2:])
 	case "author-tests":
 		err = runAuthorTests(os.Args[2:])
+	case "prove-policy":
+		err = runProvePolicy(os.Args[2:])
 	default:
 		err = fmt.Errorf("unknown command %q", os.Args[1])
 	}
@@ -70,18 +72,9 @@ func runAuthorPolicy(args []string) error {
 	if strings.TrimSpace(*intentPath) == "" {
 		return errors.New("--intent is required")
 	}
-	content, err := os.ReadFile(*intentPath)
+	intent, err := loadIntent(*intentPath)
 	if err != nil {
 		return err
-	}
-	var intent policyauthor.Intent
-	decoder := yaml.NewDecoder(bytes.NewReader(content))
-	decoder.KnownFields(true)
-	if err := decoder.Decode(&intent); err != nil {
-		return fmt.Errorf("decode policy intent: %w", err)
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return errors.New("policy intent must contain one YAML document")
 	}
 	artifacts, err := policyauthor.Author(intent)
 	if err != nil {
@@ -100,6 +93,49 @@ func runAuthorPolicy(args []string) error {
 	}
 	_, err = fmt.Fprintf(os.Stdout, "testauthor: wrote %s and %s; finding and passing cases proved\n", artifacts.PolicyPath, artifacts.TestPath)
 	return err
+}
+
+func runProvePolicy(args []string) error {
+	flags := flag.NewFlagSet("testauthor prove-policy", flag.ContinueOnError)
+	intentPath := flags.String("intent", "", "policy intent YAML")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*intentPath) == "" {
+		return errors.New("--intent is required")
+	}
+	intent, err := loadIntent(*intentPath)
+	if err != nil {
+		return err
+	}
+	artifacts, err := policyauthor.Author(intent)
+	if err != nil {
+		return err
+	}
+	result, err := policyauthor.Prove(artifacts)
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if encodeErr := encoder.Encode(result); encodeErr != nil {
+		return errors.Join(err, encodeErr)
+	}
+	return err
+}
+
+func loadIntent(path string) (policyauthor.Intent, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return policyauthor.Intent{}, err
+	}
+	var intent policyauthor.Intent
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&intent); err != nil {
+		return intent, fmt.Errorf("decode policy intent: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return intent, errors.New("policy intent must contain one YAML document")
+	}
+	return intent, nil
 }
 
 func runAuthorTests(args []string) error {


### PR DESCRIPTION
## Intent

Close the policy-authoring loop with executable evidence that generated tests protect the authored policy contract.

## What changes

- add policy-specific protected and unprotected proof receipts
- require authored cases to pass against the generated policy
- weaken the policy by removing its first condition and require the generated suite to reject it
- include SHA-256 policy and test artifact digests
- expose machine-readable proof through `testauthor prove-policy`

## Validation

- `GOCACHE=/tmp/cerebro-test-foundry-gocache go test ./internal/testauthor/policy ./tools/testauthor ./internal/findingdsl`
- `git diff --cached --check`

Stacked on #1908. Keep draft until the dependency stack and automated review are clear.