### PR TITLE
Capture quarantined events with source page commits

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1571,9 +1571,24 @@ paths:
         - Sources
       parameters:
         - $ref: '#/components/parameters/runtimeID'
+        - name: state
+          in: query
+          description: Queue state to return. Defaults to pending.
+          schema:
+            type: string
+            enum: [pending, resolved, discarded]
+            default: pending
+        - name: limit
+          in: query
+          description: Maximum number of quarantine records to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 50
       responses:
         '200':
-          description: Operator-inspectable invalid event diagnostics.
+          description: Durable quarantined event diagnostics. Stored event payloads are never returned.
           content:
             application/json:
               schema:
@@ -14956,6 +14971,8 @@ components:
     SourceRuntimeInvalidEventRecord:
       type: object
       properties:
+        id:
+          type: string
         runtime_id:
           type: string
         source_id:
@@ -14982,6 +14999,29 @@ components:
         source_event_id:
           type: string
         diagnostic:
+          type: string
+        queue_state:
+          type: string
+          enum: [pending, resolved, discarded]
+        event_kind:
+          type: string
+        event_sha256:
+          type: string
+        occurrence_count:
+          type: integer
+          minimum: 0
+        first_observed_at:
+          type: string
+          format: date-time
+        last_observed_at:
+          type: string
+          format: date-time
+        admission_abi_version:
+          type: integer
+          minimum: 0
+        admission_contracts_sha256:
+          type: string
+        admission_result_sha256:
           type: string
     SourceRuntimeHealthGraphRun:
       type: object

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -756,6 +756,18 @@ type stubRuntimeStore struct {
 	runtimeIndexWatermarks          []uint64
 }
 
+type quarantineRuntimeStore struct {
+	*stubRuntimeStore
+	records []ports.SourceRuntimeQuarantineRecord
+	filter  ports.SourceRuntimeQuarantineFilter
+	err     error
+}
+
+func (s *quarantineRuntimeStore) ListSourceRuntimeQuarantines(_ context.Context, filter ports.SourceRuntimeQuarantineFilter) ([]ports.SourceRuntimeQuarantineRecord, error) {
+	s.filter = filter
+	return append([]ports.SourceRuntimeQuarantineRecord(nil), s.records...), s.err
+}
+
 // leaseAwareRuntimeStore embeds stubRuntimeStore and additionally
 // implements ports.SourceRuntimeLeaseStore so the bootstrap layer's
 // SyncWithLease path can be exercised end-to-end. holdsAll=true makes
@@ -5134,6 +5146,102 @@ func TestSourceRuntimeInvalidEventsEndpointReturnsSafeDiagnostic(t *testing.T) {
 	}
 	if _, present := record["payload"]; present {
 		t.Fatalf("invalid event leaked payload: %#v", record["payload"])
+	}
+}
+
+func TestSourceRuntimeInvalidEventsEndpointListsDurablePendingQueueWithoutPayload(t *testing.T) {
+	firstObserved := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+	lastObserved := firstObserved.Add(5 * time.Minute)
+	store := &quarantineRuntimeStore{
+		stubRuntimeStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-directory": {Id: "writer-directory", SourceId: "directory", TenantId: "writer"},
+		}},
+		records: []ports.SourceRuntimeQuarantineRecord{{
+			ID:                       "quarantine-1",
+			RuntimeID:                "writer-directory",
+			SourceID:                 "directory",
+			TenantID:                 "writer",
+			EventID:                  "event-1",
+			EventKind:                "directory.identity",
+			EventSHA256:              "sha256:event",
+			FailureCategory:          "missing_required_payload_field",
+			FailureField:             "identity.id",
+			State:                    ports.SourceRuntimeQuarantineStatePending,
+			OccurrenceCount:          2,
+			FirstObservedAt:          firstObserved,
+			LastObservedAt:           lastObserved,
+			OccurredAt:               firstObserved.Add(-time.Minute),
+			AdmissionABIVersion:      2,
+			AdmissionContractsSHA256: "sha256:contracts",
+			AdmissionResultSHA256:    "sha256:result",
+		}},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/source-runtimes/writer-directory/invalid-events?limit=2&state=pending")
+	if err != nil {
+		t.Fatalf("GET durable invalid events error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET durable invalid events status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode durable invalid events response: %v", err)
+	}
+	events, ok := payload["events"].([]any)
+	if !ok || len(events) != 1 {
+		t.Fatalf("durable invalid events = %#v, want one", payload["events"])
+	}
+	record, ok := events[0].(map[string]any)
+	if !ok {
+		t.Fatalf("durable invalid event = %#v, want object", events[0])
+	}
+	if record["id"] != "quarantine-1" || record["queue_state"] != "pending" || record["event_kind"] != "directory.identity" || record["occurrence_count"] != float64(2) {
+		t.Fatalf("durable invalid event identity/state = %#v", record)
+	}
+	if record["diagnostic"] != "Missing required payload field identity.id" {
+		t.Fatalf("durable invalid event diagnostic = %#v", record["diagnostic"])
+	}
+	for _, forbidden := range []string{"payload", "event_json", "attributes"} {
+		if _, present := record[forbidden]; present {
+			t.Fatalf("durable invalid event leaked %s: %#v", forbidden, record[forbidden])
+		}
+	}
+	if store.filter.TenantID != "writer" || store.filter.RuntimeID != "writer-directory" || store.filter.State != ports.SourceRuntimeQuarantineStatePending || store.filter.Limit != 2 {
+		t.Fatalf("durable quarantine filter = %#v, want exact tenant/runtime/state/limit", store.filter)
+	}
+
+	store.records = nil
+	store.runtimes["writer-directory"].Config = map[string]string{
+		runtimeLastFailureCategoryConfigKey: "missing_required_attribute",
+		runtimeLastInvalidFieldConfigKey:    "legacy_field",
+	}
+	empty, err := server.Client().Get(server.URL + "/source-runtimes/writer-directory/invalid-events")
+	if err != nil {
+		t.Fatalf("GET empty durable invalid events error = %v", err)
+	}
+	defer func() { _ = empty.Body.Close() }()
+	var emptyPayload struct {
+		Events []sourceRuntimeInvalidEventRecord `json:"events"`
+	}
+	if err := json.NewDecoder(empty.Body).Decode(&emptyPayload); err != nil {
+		t.Fatalf("decode empty durable invalid events response: %v", err)
+	}
+	if len(emptyPayload.Events) != 0 {
+		t.Fatalf("empty durable invalid events resurrected legacy diagnostic: %#v", emptyPayload.Events)
+	}
+
+	invalid, err := server.Client().Get(server.URL + "/source-runtimes/writer-directory/invalid-events?limit=0")
+	if err != nil {
+		t.Fatalf("GET invalid durable invalid-events limit error = %v", err)
+	}
+	defer func() { _ = invalid.Body.Close() }()
+	if invalid.StatusCode != http.StatusBadRequest {
+		t.Fatalf("GET invalid durable invalid-events limit status = %d, want %d", invalid.StatusCode, http.StatusBadRequest)
 	}
 }
 

--- a/internal/bootstrap/source_runtime_invalid_events.go
+++ b/internal/bootstrap/source_runtime_invalid_events.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcequarantine"
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
@@ -15,19 +16,7 @@ type sourceRuntimeInvalidEventsResponse struct {
 	Events      []sourceRuntimeInvalidEventRecord `json:"events"`
 }
 
-type sourceRuntimeInvalidEventRecord struct {
-	RuntimeID       string   `json:"runtime_id"`
-	SourceID        string   `json:"source_id"`
-	TenantID        string   `json:"tenant_id"`
-	FailureCategory string   `json:"failure_category"`
-	Fields          []string `json:"fields,omitempty"`
-	Status          string   `json:"status"`
-	Retryable       bool     `json:"retryable"`
-	ObservedAt      string   `json:"observed_at,omitempty"`
-	OccurredAt      string   `json:"occurred_at,omitempty"`
-	SourceEventID   string   `json:"source_event_id,omitempty"`
-	Diagnostic      string   `json:"diagnostic,omitempty"`
-}
+type sourceRuntimeInvalidEventRecord = sourcequarantine.View
 
 func (a *App) handleListSourceRuntimeInvalidEvents(w http.ResponseWriter, r *http.Request) {
 	runtimeID := strings.TrimSpace(r.PathValue("runtimeID"))
@@ -57,7 +46,33 @@ func (a *App) handleListSourceRuntimeInvalidEvents(w http.ResponseWriter, r *htt
 		writeJSON(w, http.StatusOK, sourceRuntimeInvalidEventsResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)})
 		return
 	}
-	record, ok := invalidEventRecordFromRuntime(runtime)
+	if quarantineStore, ok := a.deps.StateStore.(ports.SourceRuntimeQuarantineStore); ok {
+		limit, state, valid := sourcequarantine.ParseListFilter(r.URL.Query().Get("limit"), r.URL.Query().Get("state"))
+		if !valid {
+			writeSourceRuntimeError(w, sourceruntime.ErrInvalidRequest)
+			return
+		}
+		records, err := quarantineStore.ListSourceRuntimeQuarantines(r.Context(), ports.SourceRuntimeQuarantineFilter{
+			TenantID:  runtime.GetTenantId(),
+			RuntimeID: runtime.GetId(),
+			State:     state,
+			Limit:     limit,
+		})
+		if err != nil {
+			writeSourceRuntimeError(w, err)
+			return
+		}
+		response := sourceRuntimeInvalidEventsResponse{
+			GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Events:      make([]sourceRuntimeInvalidEventRecord, 0, len(records)),
+		}
+		for _, record := range records {
+			response.Events = append(response.Events, sourcequarantine.FromDurable(record))
+		}
+		writeJSON(w, http.StatusOK, response)
+		return
+	}
+	record, ok := sourcequarantine.FromLegacy(runtime)
 	response := sourceRuntimeInvalidEventsResponse{
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano),
 	}
@@ -65,46 +80,4 @@ func (a *App) handleListSourceRuntimeInvalidEvents(w http.ResponseWriter, r *htt
 		response.Events = []sourceRuntimeInvalidEventRecord{record}
 	}
 	writeJSON(w, http.StatusOK, response)
-}
-
-func invalidEventRecordFromRuntime(runtime interface {
-	GetId() string
-	GetSourceId() string
-	GetTenantId() string
-	GetConfig() map[string]string
-}) (sourceRuntimeInvalidEventRecord, bool) {
-	if runtime == nil {
-		return sourceRuntimeInvalidEventRecord{}, false
-	}
-	config := runtime.GetConfig()
-	category := strings.TrimSpace(config[runtimeLastFailureCategoryConfigKey])
-	field := strings.TrimSpace(config[runtimeLastInvalidFieldConfigKey])
-	if category == "" && field == "" {
-		return sourceRuntimeInvalidEventRecord{}, false
-	}
-	record := sourceRuntimeInvalidEventRecord{
-		RuntimeID:       strings.TrimSpace(runtime.GetId()),
-		SourceID:        strings.TrimSpace(runtime.GetSourceId()),
-		TenantID:        strings.TrimSpace(runtime.GetTenantId()),
-		FailureCategory: category,
-		Status:          firstNonEmptyString(config[runtimeLastInvalidStatusConfigKey], "terminal"),
-		Retryable:       strings.EqualFold(strings.TrimSpace(config[runtimeLastInvalidRetryableConfigKey]), "true"),
-		ObservedAt:      strings.TrimSpace(config[runtimeLastInvalidObservedAtConfigKey]),
-		OccurredAt:      strings.TrimSpace(config[runtimeLastInvalidOccurredAtConfigKey]),
-		SourceEventID:   strings.TrimSpace(config[runtimeLastInvalidEventIDConfigKey]),
-		Diagnostic:      strings.TrimSpace(config[runtimeLastInvalidDiagnosticConfigKey]),
-	}
-	if field != "" {
-		record.Fields = []string{field}
-	}
-	return record, true
-}
-
-func firstNonEmptyString(values ...string) string {
-	for _, value := range values {
-		if value = strings.TrimSpace(value); value != "" {
-			return value
-		}
-	}
-	return ""
 }

--- a/internal/ports/source_runtime_quarantine.go
+++ b/internal/ports/source_runtime_quarantine.go
@@ -1,0 +1,49 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	SourceRuntimeQuarantineStateCaptured  = "captured"
+	SourceRuntimeQuarantineStatePending   = "pending"
+	SourceRuntimeQuarantineStateResolved  = "resolved"
+	SourceRuntimeQuarantineStateDiscarded = "discarded"
+)
+
+// SourceRuntimeQuarantineRecord is a safe durable view of one rejected event.
+// The original event payload remains inside the store.
+type SourceRuntimeQuarantineRecord struct {
+	ID                       string
+	RuntimeID                string
+	SourceID                 string
+	TenantID                 string
+	EventID                  string
+	EventKind                string
+	EventSHA256              string
+	FailureCategory          string
+	FailureField             string
+	State                    string
+	OccurrenceCount          uint64
+	FirstObservedAt          time.Time
+	LastObservedAt           time.Time
+	OccurredAt               time.Time
+	AdmissionABIVersion      uint32
+	AdmissionContractsSHA256 string
+	AdmissionResultSHA256    string
+}
+
+// SourceRuntimeQuarantineFilter scopes durable quarantine reads.
+type SourceRuntimeQuarantineFilter struct {
+	TenantID  string
+	RuntimeID string
+	State     string
+	Limit     uint32
+}
+
+// SourceRuntimeQuarantineStore lists durable quarantine records without
+// returning stored event payloads.
+type SourceRuntimeQuarantineStore interface {
+	ListSourceRuntimeQuarantines(context.Context, SourceRuntimeQuarantineFilter) ([]SourceRuntimeQuarantineRecord, error)
+}

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -33,7 +33,19 @@ type SourceRuntimePageAttempt struct {
 	PageNumber     uint32
 	RecordsScanned uint32
 	Events         []*cerebrov1.EventEnvelope
+	Quarantines    []SourceRuntimePageQuarantine
 	Admission      SourceRuntimePageAdmission
+}
+
+// SourceRuntimePageQuarantine binds one captured envelope to its kernel proof.
+type SourceRuntimePageQuarantine struct {
+	ID          string
+	InputIndex  uint32
+	Event       *cerebrov1.EventEnvelope
+	EventID     string
+	EventSHA256 string
+	Code        string
+	Field       string
 }
 
 // SourceRuntimePageAdmission records the exact kernel decision made before append.
@@ -44,6 +56,7 @@ type SourceRuntimePageAdmission struct {
 	Accepted        uint32
 	Quarantined     uint32
 	Duplicates      uint32
+	ContractsJSON   []byte
 	ContractsSHA256 string
 	ScannedSHA256   string
 	AcceptedSHA256  string

--- a/internal/sourcequarantine/view.go
+++ b/internal/sourcequarantine/view.go
@@ -1,0 +1,164 @@
+// Package sourcequarantine defines safe operator views and list semantics for
+// durable source-event quarantine records.
+package sourcequarantine
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	defaultListLimit = 50
+	maxListLimit     = 500
+
+	legacyFailureCategoryKey = "__cerebro_runtime_last_failure_category"
+	legacyEventIDKey         = "__cerebro_runtime_last_invalid_event_id"
+	legacyFieldKey           = "__cerebro_runtime_last_invalid_field"
+	legacyStatusKey          = "__cerebro_runtime_last_invalid_status"
+	legacyObservedAtKey      = "__cerebro_runtime_last_invalid_observed_at"
+	legacyOccurredAtKey      = "__cerebro_runtime_last_invalid_occurred_at"
+	legacyDiagnosticKey      = "__cerebro_runtime_last_invalid_diagnostic"
+	legacyRetryableKey       = "__cerebro_runtime_last_invalid_retryable"
+)
+
+// View excludes the stored event payload and attributes.
+type View struct {
+	ID                       string   `json:"id,omitempty"`
+	RuntimeID                string   `json:"runtime_id"`
+	SourceID                 string   `json:"source_id"`
+	TenantID                 string   `json:"tenant_id"`
+	FailureCategory          string   `json:"failure_category"`
+	Fields                   []string `json:"fields,omitempty"`
+	Status                   string   `json:"status"`
+	Retryable                bool     `json:"retryable"`
+	ObservedAt               string   `json:"observed_at,omitempty"`
+	OccurredAt               string   `json:"occurred_at,omitempty"`
+	SourceEventID            string   `json:"source_event_id,omitempty"`
+	Diagnostic               string   `json:"diagnostic,omitempty"`
+	QueueState               string   `json:"queue_state,omitempty"`
+	EventKind                string   `json:"event_kind,omitempty"`
+	EventSHA256              string   `json:"event_sha256,omitempty"`
+	OccurrenceCount          uint64   `json:"occurrence_count,omitempty"`
+	FirstObservedAt          string   `json:"first_observed_at,omitempty"`
+	LastObservedAt           string   `json:"last_observed_at,omitempty"`
+	AdmissionABIVersion      uint32   `json:"admission_abi_version,omitempty"`
+	AdmissionContractsSHA256 string   `json:"admission_contracts_sha256,omitempty"`
+	AdmissionResultSHA256    string   `json:"admission_result_sha256,omitempty"`
+}
+
+// ParseListFilter accepts public queue states and a bounded result limit.
+func ParseListFilter(limitRaw, stateRaw string) (uint32, string, bool) {
+	limit := uint64(defaultListLimit)
+	if raw := strings.TrimSpace(limitRaw); raw != "" {
+		parsed, err := strconv.ParseUint(raw, 10, 32)
+		if err != nil || parsed == 0 || parsed > maxListLimit {
+			return 0, "", false
+		}
+		limit = parsed
+	}
+	state := strings.TrimSpace(stateRaw)
+	if state == "" {
+		state = ports.SourceRuntimeQuarantineStatePending
+	}
+	switch state {
+	case ports.SourceRuntimeQuarantineStatePending,
+		ports.SourceRuntimeQuarantineStateResolved,
+		ports.SourceRuntimeQuarantineStateDiscarded:
+		return uint32(limit), state, true
+	default:
+		return 0, "", false
+	}
+}
+
+// FromDurable returns a payload-free operator view.
+func FromDurable(record ports.SourceRuntimeQuarantineRecord) View {
+	result := View{
+		ID:                       record.ID,
+		RuntimeID:                record.RuntimeID,
+		SourceID:                 record.SourceID,
+		TenantID:                 record.TenantID,
+		FailureCategory:          record.FailureCategory,
+		Status:                   "terminal",
+		OccurredAt:               formatTime(record.OccurredAt),
+		SourceEventID:            record.EventID,
+		Diagnostic:               diagnostic(record.FailureCategory, record.FailureField),
+		QueueState:               record.State,
+		EventKind:                record.EventKind,
+		EventSHA256:              record.EventSHA256,
+		OccurrenceCount:          record.OccurrenceCount,
+		FirstObservedAt:          formatTime(record.FirstObservedAt),
+		LastObservedAt:           formatTime(record.LastObservedAt),
+		ObservedAt:               formatTime(record.LastObservedAt),
+		AdmissionABIVersion:      record.AdmissionABIVersion,
+		AdmissionContractsSHA256: record.AdmissionContractsSHA256,
+		AdmissionResultSHA256:    record.AdmissionResultSHA256,
+	}
+	if record.FailureField != "" {
+		result.Fields = []string{record.FailureField}
+	}
+	return result
+}
+
+// FromLegacy adapts the single diagnostic stored on source-runtime config.
+func FromLegacy(runtime interface {
+	GetId() string
+	GetSourceId() string
+	GetTenantId() string
+	GetConfig() map[string]string
+}) (View, bool) {
+	if runtime == nil {
+		return View{}, false
+	}
+	config := runtime.GetConfig()
+	category := strings.TrimSpace(config[legacyFailureCategoryKey])
+	field := strings.TrimSpace(config[legacyFieldKey])
+	if category == "" && field == "" {
+		return View{}, false
+	}
+	result := View{
+		RuntimeID:       strings.TrimSpace(runtime.GetId()),
+		SourceID:        strings.TrimSpace(runtime.GetSourceId()),
+		TenantID:        strings.TrimSpace(runtime.GetTenantId()),
+		FailureCategory: category,
+		Status:          firstNonEmpty(config[legacyStatusKey], "terminal"),
+		Retryable:       strings.EqualFold(strings.TrimSpace(config[legacyRetryableKey]), "true"),
+		ObservedAt:      strings.TrimSpace(config[legacyObservedAtKey]),
+		OccurredAt:      strings.TrimSpace(config[legacyOccurredAtKey]),
+		SourceEventID:   strings.TrimSpace(config[legacyEventIDKey]),
+		Diagnostic:      strings.TrimSpace(config[legacyDiagnosticKey]),
+	}
+	if field != "" {
+		result.Fields = []string{field}
+	}
+	return result, true
+}
+
+func diagnostic(category, field string) string {
+	switch category {
+	case "missing_required_attribute":
+		return "Missing required attribute " + field
+	case "missing_required_payload_field":
+		return "Missing required payload field " + field
+	default:
+		return "Event failed source admission: " + category
+	}
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/sourcequarantine/view_test.go
+++ b/internal/sourcequarantine/view_test.go
@@ -1,0 +1,103 @@
+package sourcequarantine
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestParseListFilter(t *testing.T) {
+	tests := []struct {
+		limitRaw  string
+		stateRaw  string
+		wantLimit uint32
+		wantState string
+		wantValid bool
+	}{
+		{wantLimit: 50, wantState: "pending", wantValid: true},
+		{limitRaw: "2", stateRaw: "resolved", wantLimit: 2, wantState: "resolved", wantValid: true},
+		{limitRaw: "0"},
+		{limitRaw: "501"},
+		{limitRaw: "bad"},
+		{stateRaw: "captured"},
+	}
+	for _, test := range tests {
+		limit, state, valid := ParseListFilter(test.limitRaw, test.stateRaw)
+		if limit != test.wantLimit || state != test.wantState || valid != test.wantValid {
+			t.Fatalf("ParseListFilter(%q, %q) = %d, %q, %t; want %d, %q, %t", test.limitRaw, test.stateRaw, limit, state, valid, test.wantLimit, test.wantState, test.wantValid)
+		}
+	}
+}
+
+func TestFromDurableReturnsProofWithoutStoredPayloadFields(t *testing.T) {
+	observedAt := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+	view := FromDurable(ports.SourceRuntimeQuarantineRecord{
+		ID:                       "quarantine-1",
+		RuntimeID:                "runtime-1",
+		SourceID:                 "directory",
+		TenantID:                 "writer",
+		EventID:                  "event-1",
+		EventKind:                "directory.identity",
+		EventSHA256:              "sha256:event",
+		FailureCategory:          "missing_required_attribute",
+		FailureField:             "resource_id",
+		State:                    "pending",
+		OccurrenceCount:          2,
+		FirstObservedAt:          observedAt,
+		LastObservedAt:           observedAt,
+		AdmissionABIVersion:      2,
+		AdmissionContractsSHA256: "sha256:contracts",
+		AdmissionResultSHA256:    "sha256:result",
+	})
+	body, err := json.Marshal(view)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(body), `"diagnostic":"Missing required attribute resource_id"`) {
+		t.Fatalf("safe view = %s, want concrete diagnostic", body)
+	}
+	for _, forbidden := range []string{"payload", "event_json", "attributes"} {
+		if strings.Contains(string(body), forbidden) {
+			t.Fatalf("safe view leaked %q: %s", forbidden, body)
+		}
+	}
+}
+
+func TestFromLegacyReturnsTheStoredDiagnostic(t *testing.T) {
+	runtime := legacyRuntime{
+		id:       "runtime-1",
+		sourceID: "directory",
+		tenantID: "writer",
+		config: map[string]string{
+			legacyFailureCategoryKey: "missing_required_attribute",
+			legacyFieldKey:           "resource_id",
+			legacyRetryableKey:       "true",
+			legacyEventIDKey:         "event-1",
+		},
+	}
+	view, ok := FromLegacy(runtime)
+	if !ok {
+		t.Fatal("FromLegacy() did not return the stored diagnostic")
+	}
+	if view.RuntimeID != "runtime-1" || view.Status != "terminal" || !view.Retryable {
+		t.Fatalf("FromLegacy() = %#v", view)
+	}
+	if len(view.Fields) != 1 || view.Fields[0] != "resource_id" {
+		t.Fatalf("FromLegacy().Fields = %v", view.Fields)
+	}
+}
+
+type legacyRuntime struct {
+	id       string
+	sourceID string
+	tenantID string
+	config   map[string]string
+}
+
+func (r legacyRuntime) GetId() string                { return r.id }
+func (r legacyRuntime) GetSourceId() string          { return r.sourceID }
+func (r legacyRuntime) GetTenantId() string          { return r.tenantID }
+func (r legacyRuntime) GetConfig() map[string]string { return r.config }

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -454,6 +454,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "source_runtime.page.last_events_read", Value: eventsRead},
 			telemetry.Field{Key: "source_runtime.page.last_has_next_cursor", Value: pull.NextCursor != nil},
 		)))
+		pageQuarantines := make([]ports.SourceRuntimePageQuarantine, 0, len(admission.Quarantined))
 		for _, rejection := range admission.Quarantined {
 			if rejection.InputIndex == nil {
 				return nil, fmt.Errorf("validate source event batch: %w: quarantine is missing its input index", sourcecdk.ErrInvalidEventEnvelope)
@@ -462,6 +463,15 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			category := rejection.Code
 			lastQuarantineCategory = category
 			syncedEvent := materializedEvents[*rejection.InputIndex]
+			pageQuarantines = append(pageQuarantines, ports.SourceRuntimePageQuarantine{
+				ID:          sourceRuntimeQuarantineID(runtime.GetTenantId(), runtime.GetId(), rejection.EventSHA256, rejection.Code, rejection.Field),
+				InputIndex:  boundedUint32(*rejection.InputIndex),
+				Event:       syncedEvent,
+				EventID:     rejection.EventID,
+				EventSHA256: rejection.EventSHA256,
+				Code:        rejection.Code,
+				Field:       rejection.Field,
+			})
 			recordRuntimeInvalidEventField(candidateRuntime, syncedEvent, category, rejection.Field, time.Now().UTC(), len(eventContracts) > 0)
 			telemetry.Event(ctx, "source_runtime.invalid_event", telemetry.Attrs(
 				telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
@@ -501,6 +511,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		ledger, ledgerEnabled := s.store.(ports.SourceRuntimePageLedgerStore)
 		attemptID := sourceRuntimePageAttemptID(runtime.GetId(), pageNumber, started)
 		if ledgerEnabled {
+			contractsJSON, err := json.Marshal(eventContracts)
+			if err != nil {
+				return nil, fmt.Errorf("encode source runtime admission contracts: %w", err)
+			}
 			if err := ledger.BeginSourceRuntimePage(ctx, ports.SourceRuntimePageAttempt{
 				AttemptID:      attemptID,
 				RuntimeID:      candidateRuntime.GetId(),
@@ -509,6 +523,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				PageNumber:     pageNumber,
 				RecordsScanned: boundedUint32(admission.Receipt.Scanned),
 				Events:         acceptedEvents,
+				Quarantines:    pageQuarantines,
 				Admission: ports.SourceRuntimePageAdmission{
 					Kernel:          "sourceruntime-event-admission",
 					ABIVersion:      eventadmission.ABIVersion,
@@ -516,6 +531,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 					Accepted:        boundedUint32(admission.Receipt.Accepted),
 					Quarantined:     boundedUint32(admission.Receipt.Quarantined),
 					Duplicates:      boundedUint32(admission.Receipt.Duplicates),
+					ContractsJSON:   contractsJSON,
 					ContractsSHA256: admission.Receipt.ContractsSHA256,
 					ScannedSHA256:   admission.Receipt.ScannedSHA256,
 					AcceptedSHA256:  admission.Receipt.AcceptedSHA256,
@@ -1458,6 +1474,15 @@ func sourceRuntimePageAttemptID(runtimeID string, pageNumber uint32, started tim
 	hash.Write([]byte(started.UTC().Format(time.RFC3339Nano)))
 	hash.Write([]byte{0})
 	hash.Write([]byte(strconv.FormatUint(uint64(pageNumber), 10)))
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func sourceRuntimeQuarantineID(tenantID, runtimeID, eventSHA256, code, field string) string {
+	hash := sha256.New()
+	for _, value := range []string{tenantID, runtimeID, eventSHA256, code, field} {
+		hash.Write([]byte(strings.TrimSpace(value)))
+		hash.Write([]byte{0})
+	}
 	return hex.EncodeToString(hash.Sum(nil))
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -122,8 +122,8 @@ type ledgerRuntimeStore struct {
 func (s *ledgerRuntimeStore) BeginSourceRuntimePage(_ context.Context, attempt ports.SourceRuntimePageAttempt) error {
 	s.calls = append(s.calls, "begin")
 	s.attempts = append(s.attempts, attempt)
-	if len(attempt.Events) == 0 {
-		return errors.New("ledger attempt events are required")
+	if len(attempt.Events) == 0 && len(attempt.Quarantines) == 0 {
+		return errors.New("ledger attempt evidence is required")
 	}
 	return nil
 }
@@ -2378,6 +2378,70 @@ func TestSyncRuntimeAdmissionQuarantineNeverReachesBatchAppend(t *testing.T) {
 	}
 	if got := store.runtimes["writer-admission-quarantine"].GetConfig()[runtimeRecordsRejectedConfigKey]; got != "1" {
 		t.Fatalf("records rejected = %q, want 1", got)
+	}
+}
+
+func TestSyncRuntimePageLedgerCapturesExactQuarantineProof(t *testing.T) {
+	accepted := runtimeTestEvent("event-1", "admission_quarantine_ledger", "admission_quarantine_ledger.event")
+	quarantined := runtimeTestEvent("event-2", "admission_quarantine_ledger", "admission_quarantine_ledger.event")
+	quarantined.Payload = []byte(`{}`)
+	source := admissionTestSource{
+		id:     "admission_quarantine_ledger",
+		events: []*cerebrov1.EventEnvelope{accepted, quarantined},
+		contracts: []sourcecdk.EventContract{{
+			Kind:                  "admission_quarantine_ledger.event",
+			SchemaRef:             "admission_quarantine_ledger/event/v1",
+			RequiredAttributes:    []string{"event_type"},
+			RequiredPayloadFields: []string{"fixture"},
+		}},
+	}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &ledgerRuntimeStore{runtimeStore: runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-admission-quarantine-ledger": {Id: "writer-admission-quarantine-ledger", SourceId: source.id, TenantId: "writer"},
+	}}}
+	service := New(registry, store, &batchAppendLog{}, &projector{result: ports.ProjectionResult{EntitiesProjected: 1}})
+
+	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-admission-quarantine-ledger"}); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if len(store.attempts) != 1 {
+		t.Fatalf("ledger attempts = %d, want 1", len(store.attempts))
+	}
+	if len(store.attempts[0].Quarantines) != 1 {
+		t.Fatalf("ledger quarantines = %d, want 1", len(store.attempts[0].Quarantines))
+	}
+	attempt := store.attempts[0]
+	proof := attempt.Quarantines[0]
+	if proof.InputIndex != 1 || proof.EventID != "event-2" || proof.Event.GetId() != "event-2" || !strings.HasPrefix(proof.EventSHA256, "sha256:") {
+		t.Fatalf("quarantine proof = %#v, want exact event-2 identity at input 1", proof)
+	}
+	wantID := sourceRuntimeQuarantineID("writer", "writer-admission-quarantine-ledger", proof.EventSHA256, proof.Code, proof.Field)
+	if proof.ID != wantID || proof.Code != "missing_required_payload_field" || proof.Field != "fixture" {
+		t.Fatalf("quarantine proof identity = %#v, want stable missing-field proof", proof)
+	}
+	if len(attempt.Admission.ContractsJSON) == 0 || !strings.HasPrefix(attempt.Admission.ContractsSHA256, "sha256:") {
+		t.Fatalf("admission contract proof = %#v, want snapshot and digest", attempt.Admission)
+	}
+}
+
+func TestSourceRuntimeQuarantineIDBindsTenantRuntimeEventAndDecision(t *testing.T) {
+	base := sourceRuntimeQuarantineID("tenant-1", "runtime-1", "sha256:event", "missing_required_attribute", "resource_id")
+	if base != sourceRuntimeQuarantineID("tenant-1", "runtime-1", "sha256:event", "missing_required_attribute", "resource_id") {
+		t.Fatal("sourceRuntimeQuarantineID() is not deterministic")
+	}
+	for _, changed := range []string{
+		sourceRuntimeQuarantineID("tenant-2", "runtime-1", "sha256:event", "missing_required_attribute", "resource_id"),
+		sourceRuntimeQuarantineID("tenant-1", "runtime-2", "sha256:event", "missing_required_attribute", "resource_id"),
+		sourceRuntimeQuarantineID("tenant-1", "runtime-1", "sha256:other", "missing_required_attribute", "resource_id"),
+		sourceRuntimeQuarantineID("tenant-1", "runtime-1", "sha256:event", "missing_required_payload_field", "resource_id"),
+		sourceRuntimeQuarantineID("tenant-1", "runtime-1", "sha256:event", "missing_required_attribute", "other"),
+	} {
+		if changed == base {
+			t.Fatalf("sourceRuntimeQuarantineID() did not bind all identity fields: %q", base)
+		}
 	}
 }
 

--- a/internal/statestore/postgres/source_runtime_page_ledger.go
+++ b/internal/statestore/postgres/source_runtime_page_ledger.go
@@ -27,6 +27,7 @@ var ensureSourceRuntimePageLedgerStatements = []string{`CREATE TABLE IF NOT EXIS
   duplicate_events INTEGER NOT NULL DEFAULT 0,
   admission_kernel TEXT NOT NULL DEFAULT '',
   admission_abi_version INTEGER NOT NULL DEFAULT 0,
+  admission_contracts_json JSONB NOT NULL DEFAULT '[]'::jsonb,
   admission_contracts_sha256 TEXT NOT NULL DEFAULT '',
   admission_scanned_sha256 TEXT NOT NULL DEFAULT '',
   admission_accepted_sha256 TEXT NOT NULL DEFAULT '',
@@ -45,6 +46,7 @@ var ensureSourceRuntimePageLedgerStatements = []string{`CREATE TABLE IF NOT EXIS
   ADD COLUMN IF NOT EXISTS duplicate_events INTEGER NOT NULL DEFAULT 0,
   ADD COLUMN IF NOT EXISTS admission_kernel TEXT NOT NULL DEFAULT '',
   ADD COLUMN IF NOT EXISTS admission_abi_version INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS admission_contracts_json JSONB NOT NULL DEFAULT '[]'::jsonb,
   ADD COLUMN IF NOT EXISTS admission_contracts_sha256 TEXT NOT NULL DEFAULT '',
   ADD COLUMN IF NOT EXISTS admission_scanned_sha256 TEXT NOT NULL DEFAULT '',
   ADD COLUMN IF NOT EXISTS admission_accepted_sha256 TEXT NOT NULL DEFAULT '',
@@ -61,6 +63,33 @@ var ensureSourceRuntimePageLedgerStatements = []string{`CREATE TABLE IF NOT EXIS
   PRIMARY KEY (attempt_id, ordinal),
   UNIQUE (attempt_id, event_id)
 )`,
+	`CREATE TABLE IF NOT EXISTS source_runtime_event_quarantine (
+  tenant_id TEXT NOT NULL,
+  quarantine_id TEXT NOT NULL,
+  runtime_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  event_sha256 TEXT NOT NULL,
+  rejection_code TEXT NOT NULL,
+  rejection_field TEXT NOT NULL DEFAULT '',
+  event_json JSONB NOT NULL,
+  state TEXT NOT NULL DEFAULT 'captured' CHECK (state IN ('captured', 'pending', 'resolved', 'discarded')),
+  occurrence_count BIGINT NOT NULL DEFAULT 0,
+  first_observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, quarantine_id)
+)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtime_event_quarantine_runtime_state_idx ON source_runtime_event_quarantine (tenant_id, runtime_id, state, last_observed_at DESC, quarantine_id DESC)`,
+	`CREATE TABLE IF NOT EXISTS source_runtime_page_quarantine (
+  attempt_id TEXT NOT NULL REFERENCES source_runtime_page_ledger(attempt_id) ON DELETE CASCADE,
+  input_index INTEGER NOT NULL,
+  tenant_id TEXT NOT NULL,
+  quarantine_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (attempt_id, input_index),
+  FOREIGN KEY (tenant_id, quarantine_id) REFERENCES source_runtime_event_quarantine(tenant_id, quarantine_id) ON DELETE CASCADE
+)`,
 }
 
 func (s *Store) BeginSourceRuntimePage(ctx context.Context, attempt ports.SourceRuntimePageAttempt) error {
@@ -74,6 +103,10 @@ func (s *Store) BeginSourceRuntimePage(ctx context.Context, attempt ports.Source
 	if attemptID == "" {
 		return errors.New("source runtime page attempt id is required")
 	}
+	contractsJSON := strings.TrimSpace(string(attempt.Admission.ContractsJSON))
+	if contractsJSON == "" {
+		contractsJSON = "[]"
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin source runtime page ledger: %w", err)
@@ -83,10 +116,11 @@ func (s *Store) BeginSourceRuntimePage(ctx context.Context, attempt ports.Source
 INSERT INTO source_runtime_page_ledger (
   attempt_id, runtime_id, source_id, tenant_id, page_number, status,
   records_scanned, records_accepted, records_quarantined, duplicate_events,
-  admission_kernel, admission_abi_version, admission_contracts_sha256,
-  admission_scanned_sha256, admission_accepted_sha256, admission_result_sha256
+  admission_kernel, admission_abi_version, admission_contracts_json,
+  admission_contracts_sha256, admission_scanned_sha256,
+  admission_accepted_sha256, admission_result_sha256
 )
-VALUES ($1, $2, $3, $4, $5, 'started', $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+VALUES ($1, $2, $3, $4, $5, 'started', $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16)
 ON CONFLICT (attempt_id)
 DO UPDATE SET status = 'started',
               records_scanned = EXCLUDED.records_scanned,
@@ -95,6 +129,7 @@ DO UPDATE SET status = 'started',
               duplicate_events = EXCLUDED.duplicate_events,
               admission_kernel = EXCLUDED.admission_kernel,
               admission_abi_version = EXCLUDED.admission_abi_version,
+              admission_contracts_json = EXCLUDED.admission_contracts_json,
               admission_contracts_sha256 = EXCLUDED.admission_contracts_sha256,
               admission_scanned_sha256 = EXCLUDED.admission_scanned_sha256,
               admission_accepted_sha256 = EXCLUDED.admission_accepted_sha256,
@@ -111,6 +146,7 @@ DO UPDATE SET status = 'started',
 		attempt.Admission.Duplicates,
 		strings.TrimSpace(attempt.Admission.Kernel),
 		attempt.Admission.ABIVersion,
+		contractsJSON,
 		strings.TrimSpace(attempt.Admission.ContractsSHA256),
 		strings.TrimSpace(attempt.Admission.ScannedSHA256),
 		strings.TrimSpace(attempt.Admission.AcceptedSHA256),
@@ -130,6 +166,57 @@ DO UPDATE SET status = 'started',
 INSERT INTO source_runtime_page_outbox (attempt_id, ordinal, event_id, event_json)
 VALUES ($1, $2, $3, $4::jsonb)`, attemptID, index, event.GetId(), string(payload)); err != nil {
 			return fmt.Errorf("insert source runtime page outbox event %q: %w", event.GetId(), err)
+		}
+	}
+	for _, quarantine := range attempt.Quarantines {
+		if strings.TrimSpace(quarantine.ID) == "" || quarantine.Event == nil || strings.TrimSpace(quarantine.EventID) == "" || quarantine.Event.GetId() != quarantine.EventID || strings.TrimSpace(quarantine.EventSHA256) == "" || strings.TrimSpace(quarantine.Code) == "" {
+			return errors.New("source runtime page quarantine proof is incomplete")
+		}
+		payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(quarantine.Event)
+		if err != nil {
+			return fmt.Errorf("marshal quarantined source runtime event %q: %w", quarantine.EventID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO source_runtime_event_quarantine (
+  tenant_id, quarantine_id, runtime_id, source_id, event_id, event_sha256,
+  rejection_code, rejection_field, event_json
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+ON CONFLICT (tenant_id, quarantine_id)
+DO UPDATE SET event_json = EXCLUDED.event_json,
+              updated_at = NOW()`,
+			strings.TrimSpace(attempt.TenantID),
+			strings.TrimSpace(quarantine.ID),
+			strings.TrimSpace(attempt.RuntimeID),
+			strings.TrimSpace(attempt.SourceID),
+			strings.TrimSpace(quarantine.EventID),
+			strings.TrimSpace(quarantine.EventSHA256),
+			strings.TrimSpace(quarantine.Code),
+			strings.TrimSpace(quarantine.Field),
+			string(payload),
+		); err != nil {
+			return fmt.Errorf("upsert source runtime quarantine %q: %w", quarantine.ID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+WITH linked AS (
+  INSERT INTO source_runtime_page_quarantine (attempt_id, input_index, tenant_id, quarantine_id)
+  VALUES ($1, $2, $3, $4)
+  ON CONFLICT (attempt_id, input_index) DO NOTHING
+  RETURNING tenant_id, quarantine_id
+)
+UPDATE source_runtime_event_quarantine AS quarantine
+SET occurrence_count = quarantine.occurrence_count + 1,
+    last_observed_at = NOW(),
+    updated_at = NOW()
+FROM linked
+WHERE linked.tenant_id = quarantine.tenant_id
+  AND linked.quarantine_id = quarantine.quarantine_id`,
+			attemptID,
+			quarantine.InputIndex,
+			strings.TrimSpace(attempt.TenantID),
+			strings.TrimSpace(quarantine.ID),
+		); err != nil {
+			return fmt.Errorf("link source runtime quarantine %q to page %q: %w", quarantine.ID, attemptID, err)
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -181,6 +268,17 @@ WHERE attempt_id = $1`, strings.TrimSpace(attemptID), string(payload))
 	}
 	if rows == 0 {
 		return fmt.Errorf("source runtime page ledger attempt %q not found", attemptID)
+	}
+	if _, err := tx.ExecContext(ctx, `
+UPDATE source_runtime_event_quarantine AS quarantine
+SET state = 'pending',
+    updated_at = NOW()
+FROM source_runtime_page_quarantine AS page_quarantine
+WHERE page_quarantine.attempt_id = $1
+  AND page_quarantine.tenant_id = quarantine.tenant_id
+  AND page_quarantine.quarantine_id = quarantine.quarantine_id
+  AND quarantine.state IN ('captured', 'resolved')`, strings.TrimSpace(attemptID)); err != nil {
+		return fmt.Errorf("activate source runtime page quarantines %q: %w", attemptID, err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit source runtime page progress %q: %w", attemptID, err)

--- a/internal/statestore/postgres/source_runtime_page_ledger.go
+++ b/internal/statestore/postgres/source_runtime_page_ledger.go
@@ -69,10 +69,15 @@ var ensureSourceRuntimePageLedgerStatements = []string{`CREATE TABLE IF NOT EXIS
   runtime_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
   event_id TEXT NOT NULL,
+  event_kind TEXT NOT NULL DEFAULT '',
   event_sha256 TEXT NOT NULL,
   rejection_code TEXT NOT NULL,
   rejection_field TEXT NOT NULL DEFAULT '',
   event_json JSONB NOT NULL,
+  occurred_at TIMESTAMPTZ,
+  admission_abi_version INTEGER NOT NULL DEFAULT 0,
+  admission_contracts_sha256 TEXT NOT NULL DEFAULT '',
+  admission_result_sha256 TEXT NOT NULL DEFAULT '',
   state TEXT NOT NULL DEFAULT 'captured' CHECK (state IN ('captured', 'pending', 'resolved', 'discarded')),
   occurrence_count BIGINT NOT NULL DEFAULT 0,
   first_observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -80,6 +85,12 @@ var ensureSourceRuntimePageLedgerStatements = []string{`CREATE TABLE IF NOT EXIS
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (tenant_id, quarantine_id)
 )`,
+	`ALTER TABLE source_runtime_event_quarantine
+  ADD COLUMN IF NOT EXISTS event_kind TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS occurred_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS admission_abi_version INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS admission_contracts_sha256 TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS admission_result_sha256 TEXT NOT NULL DEFAULT ''`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtime_event_quarantine_runtime_state_idx ON source_runtime_event_quarantine (tenant_id, runtime_id, state, last_observed_at DESC, quarantine_id DESC)`,
 	`CREATE TABLE IF NOT EXISTS source_runtime_page_quarantine (
   attempt_id TEXT NOT NULL REFERENCES source_runtime_page_ledger(attempt_id) ON DELETE CASCADE,
@@ -178,22 +189,31 @@ VALUES ($1, $2, $3, $4::jsonb)`, attemptID, index, event.GetId(), string(payload
 		}
 		if _, err := tx.ExecContext(ctx, `
 INSERT INTO source_runtime_event_quarantine (
-  tenant_id, quarantine_id, runtime_id, source_id, event_id, event_sha256,
-  rejection_code, rejection_field, event_json
+  tenant_id, quarantine_id, runtime_id, source_id, event_id, event_kind,
+  event_sha256, rejection_code, rejection_field, event_json, occurred_at,
+  admission_abi_version, admission_contracts_sha256, admission_result_sha256
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12, $13, $14)
 ON CONFLICT (tenant_id, quarantine_id)
 DO UPDATE SET event_json = EXCLUDED.event_json,
+              admission_abi_version = EXCLUDED.admission_abi_version,
+              admission_contracts_sha256 = EXCLUDED.admission_contracts_sha256,
+              admission_result_sha256 = EXCLUDED.admission_result_sha256,
               updated_at = NOW()`,
 			strings.TrimSpace(attempt.TenantID),
 			strings.TrimSpace(quarantine.ID),
 			strings.TrimSpace(attempt.RuntimeID),
 			strings.TrimSpace(attempt.SourceID),
 			strings.TrimSpace(quarantine.EventID),
+			strings.TrimSpace(quarantine.Event.GetKind()),
 			strings.TrimSpace(quarantine.EventSHA256),
 			strings.TrimSpace(quarantine.Code),
 			strings.TrimSpace(quarantine.Field),
 			string(payload),
+			sourceRuntimeEventOccurredAt(quarantine.Event),
+			attempt.Admission.ABIVersion,
+			strings.TrimSpace(attempt.Admission.ContractsSHA256),
+			strings.TrimSpace(attempt.Admission.ResultSHA256),
 		); err != nil {
 			return fmt.Errorf("upsert source runtime quarantine %q: %w", quarantine.ID, err)
 		}
@@ -345,3 +365,10 @@ func (s *Store) ensureSourceRuntimePageLedgerTables(ctx context.Context) error {
 
 var _ ports.SourceRuntimePageLedgerStore = (*Store)(nil)
 var _ sourceRuntimeExecutor = (*sql.Tx)(nil)
+
+func sourceRuntimeEventOccurredAt(event *cerebrov1.EventEnvelope) any {
+	if event == nil || event.GetOccurredAt() == nil || event.GetOccurredAt().CheckValid() != nil {
+		return nil
+	}
+	return event.GetOccurredAt().AsTime().UTC()
+}

--- a/internal/statestore/postgres/source_runtime_page_ledger_test.go
+++ b/internal/statestore/postgres/source_runtime_page_ledger_test.go
@@ -1,0 +1,24 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSourceRuntimePageLedgerSchemaSeparatesCapturedAndPendingQuarantines(t *testing.T) {
+	joined := strings.Join(ensureSourceRuntimePageLedgerStatements, "\n")
+	for _, fragment := range []string{
+		"admission_contracts_json JSONB",
+		"source_runtime_event_quarantine",
+		"PRIMARY KEY (tenant_id, quarantine_id)",
+		"state IN ('captured', 'pending', 'resolved', 'discarded')",
+		"source_runtime_event_quarantine_runtime_state_idx",
+		"source_runtime_page_quarantine",
+		"PRIMARY KEY (attempt_id, input_index)",
+		"FOREIGN KEY (tenant_id, quarantine_id)",
+	} {
+		if !strings.Contains(joined, fragment) {
+			t.Fatalf("source runtime page ledger schema missing %q:\n%s", fragment, joined)
+		}
+	}
+}

--- a/internal/statestore/postgres/source_runtime_page_ledger_test.go
+++ b/internal/statestore/postgres/source_runtime_page_ledger_test.go
@@ -10,6 +10,9 @@ func TestSourceRuntimePageLedgerSchemaSeparatesCapturedAndPendingQuarantines(t *
 	for _, fragment := range []string{
 		"admission_contracts_json JSONB",
 		"source_runtime_event_quarantine",
+		"event_kind TEXT",
+		"admission_contracts_sha256 TEXT",
+		"admission_result_sha256 TEXT",
 		"PRIMARY KEY (tenant_id, quarantine_id)",
 		"state IN ('captured', 'pending', 'resolved', 'discarded')",
 		"source_runtime_event_quarantine_runtime_state_idx",
@@ -19,6 +22,19 @@ func TestSourceRuntimePageLedgerSchemaSeparatesCapturedAndPendingQuarantines(t *
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("source runtime page ledger schema missing %q:\n%s", fragment, joined)
+		}
+	}
+}
+
+func TestValidSourceRuntimeQuarantineState(t *testing.T) {
+	for _, state := range []string{"captured", "pending", "resolved", "discarded"} {
+		if !validSourceRuntimeQuarantineState(state) {
+			t.Fatalf("validSourceRuntimeQuarantineState(%q) = false, want true", state)
+		}
+	}
+	for _, state := range []string{"", "retrying", "unknown"} {
+		if validSourceRuntimeQuarantineState(state) {
+			t.Fatalf("validSourceRuntimeQuarantineState(%q) = true, want false", state)
 		}
 	}
 }

--- a/internal/statestore/postgres/source_runtime_quarantine.go
+++ b/internal/statestore/postgres/source_runtime_quarantine.go
@@ -1,0 +1,114 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	defaultSourceRuntimeQuarantineLimit = 50
+	maxSourceRuntimeQuarantineLimit     = 500
+)
+
+func (s *Store) ListSourceRuntimeQuarantines(ctx context.Context, filter ports.SourceRuntimeQuarantineFilter) ([]ports.SourceRuntimeQuarantineRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	tenantID := strings.TrimSpace(filter.TenantID)
+	runtimeID := strings.TrimSpace(filter.RuntimeID)
+	state := strings.TrimSpace(filter.State)
+	if tenantID == "" || runtimeID == "" {
+		return nil, errors.New("source runtime quarantine tenant and runtime are required")
+	}
+	if !validSourceRuntimeQuarantineState(state) {
+		return nil, fmt.Errorf("source runtime quarantine state %q is invalid", state)
+	}
+	limit := filter.Limit
+	if limit == 0 {
+		limit = defaultSourceRuntimeQuarantineLimit
+	}
+	if limit > maxSourceRuntimeQuarantineLimit {
+		limit = maxSourceRuntimeQuarantineLimit
+	}
+	if err := s.ensureSourceRuntimePageLedgerTables(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT quarantine_id, runtime_id, source_id, tenant_id, event_id, event_kind,
+       event_sha256, rejection_code, rejection_field, state, occurrence_count,
+       first_observed_at, last_observed_at, occurred_at, admission_abi_version,
+       admission_contracts_sha256, admission_result_sha256
+FROM source_runtime_event_quarantine
+WHERE tenant_id = $1
+  AND runtime_id = $2
+  AND state = $3
+ORDER BY last_observed_at DESC, quarantine_id DESC
+LIMIT $4`, tenantID, runtimeID, state, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list source runtime quarantines: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]ports.SourceRuntimeQuarantineRecord, 0)
+	for rows.Next() {
+		var record ports.SourceRuntimeQuarantineRecord
+		var occurrenceCount int64
+		var abiVersion int64
+		var occurredAt sql.NullTime
+		if err := rows.Scan(
+			&record.ID,
+			&record.RuntimeID,
+			&record.SourceID,
+			&record.TenantID,
+			&record.EventID,
+			&record.EventKind,
+			&record.EventSHA256,
+			&record.FailureCategory,
+			&record.FailureField,
+			&record.State,
+			&occurrenceCount,
+			&record.FirstObservedAt,
+			&record.LastObservedAt,
+			&occurredAt,
+			&abiVersion,
+			&record.AdmissionContractsSHA256,
+			&record.AdmissionResultSHA256,
+		); err != nil {
+			return nil, fmt.Errorf("scan source runtime quarantine: %w", err)
+		}
+		if occurrenceCount < 0 || abiVersion < 0 || abiVersion > math.MaxUint32 {
+			return nil, errors.New("source runtime quarantine counters are invalid")
+		}
+		record.OccurrenceCount = uint64(occurrenceCount)
+		record.AdmissionABIVersion = uint32(abiVersion)
+		if occurredAt.Valid {
+			record.OccurredAt = occurredAt.Time.UTC()
+		}
+		record.FirstObservedAt = record.FirstObservedAt.UTC()
+		record.LastObservedAt = record.LastObservedAt.UTC()
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list source runtime quarantines rows: %w", err)
+	}
+	return records, nil
+}
+
+func validSourceRuntimeQuarantineState(state string) bool {
+	switch state {
+	case ports.SourceRuntimeQuarantineStateCaptured,
+		ports.SourceRuntimeQuarantineStatePending,
+		ports.SourceRuntimeQuarantineStateResolved,
+		ports.SourceRuntimeQuarantineStateDiscarded:
+		return true
+	default:
+		return false
+	}
+}
+
+var _ ports.SourceRuntimeQuarantineStore = (*Store)(nil)

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -4032,11 +4032,21 @@ export type SourceRuntimeHealthSummary = {
 };
 
 export type SourceRuntimeInvalidEventRecord = {
+  admission_abi_version?: number;
+  admission_contracts_sha256?: string;
+  admission_result_sha256?: string;
   diagnostic?: string;
+  event_kind?: string;
+  event_sha256?: string;
   failure_category?: string;
   fields?: string[];
+  first_observed_at?: string;
+  id?: string;
+  last_observed_at?: string;
   observed_at?: string;
   occurred_at?: string;
+  occurrence_count?: number;
+  queue_state?: "pending" | "resolved" | "discarded";
   retryable?: boolean;
   runtime_id?: string;
   source_event_id?: string;


### PR DESCRIPTION
## Customer problem

When a source event fails admission, Cerebro currently overwrites one diagnostic on the runtime and discards the rejected envelope. Operators and agents cannot inspect the full history, and an exact-event repair flow has nothing durable to act on.

## What changes

- carries proof-bearing quarantines from the admission kernel into each page attempt
- assigns a stable quarantine identity bound to tenant, runtime, canonical event digest, rejection code, and field
- stores the original event envelope and proof in a tenant-scoped Postgres quarantine table
- records every page occurrence without duplicating the underlying queue item
- stores the exact admission contract snapshot and contract digest on the page ledger
- inserts quarantine evidence as captured in the same transaction that starts the page ledger
- changes captured or re-observed resolved records to pending only in the transaction that commits runtime progress

## Why the commit boundary matters

A page can fail after admission but before append, projection, or checkpoint commit. Those failures must not create actionable repair work for progress Cerebro did not commit. Captured records remain hidden from the future pending queue until CommitSourceRuntimePage atomically persists the candidate runtime and activates them.

A later successful observation reopens a resolved record. A repeated Begin call for the same page occurrence does not inflate occurrence counts.

## Customer outcome

Cerebro retains every rejected source event with exact identity and decision evidence. The next read/API slice can list pending records without reconstructing them from mutable runtime config, and the later retry path can operate on one stored envelope without advancing the source checkpoint.

## Validation

- go test ./internal/sourceruntime ./internal/statestore/postgres -count=1
- go test -race ./internal/sourceruntime -count=1
- make check-structural check-structural-test check-arch

## Stack

Depends on #1909. Keep this PR stacked until its base lands.