### PR TITLE
feat(agentauthoring): draft proved policy bundles

### DIFF
--- a/docs/domains/self-authoring-policy-tests.md
+++ b/docs/domains/self-authoring-policy-tests.md
@@ -2,6 +2,8 @@
 
 `testauthor` turns a bounded policy intent into a policy and an executable finding/passing test suite. It can also scan existing policies and author missing suites when every condition is a simple scalar equality.
 
+The native agent-authoring service exposes the same path as `DraftPolicyBundle`. A schema-bound model draft is normalized and validated, then passed through the deterministic test author and protected/unprotected proof. Callers receive policy YAML, test YAML, repository paths, artifact digests, and proof receipts as one result.
+
 The authoring boundary is deliberate. The tool accepts `cmp_eq(path(resource, "field"), scalar)` conditions. It rejects query, graph, inequality, collection, and compound-expression semantics until a generator has an explicit fixture contract for them.
 
 ## Author a policy and its tests

--- a/internal/agentauthoring/authoring.go
+++ b/internal/agentauthoring/authoring.go
@@ -10,6 +10,7 @@ import (
 	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/findingdsl"
 	"github.com/writer/cerebro/internal/sourcegen"
+	policyauthor "github.com/writer/cerebro/internal/testauthor/policy"
 )
 
 var (
@@ -44,6 +45,22 @@ type PolicyRuleDraftResult struct {
 	YAML       []byte                       `json:"yaml,omitempty"`
 	Issues     []findingdsl.Issue           `json:"issues,omitempty"`
 	SchemaJSON []byte                       `json:"schema_json,omitempty"`
+}
+
+type PolicyBundleDraftRequest struct {
+	Prompt  string
+	Domain  string
+	Context map[string]any
+}
+
+type PolicyBundleDraftResult struct {
+	Rule       findingdsl.PolicyFindingRule   `json:"rule"`
+	PolicyPath string                         `json:"policy_path"`
+	PolicyYAML []byte                         `json:"policy_yaml"`
+	Suite      findingdsl.PolicyRuleTestSuite `json:"suite"`
+	TestPath   string                         `json:"test_path"`
+	TestYAML   []byte                         `json:"test_yaml"`
+	Proof      policyauthor.ProofResult       `json:"proof"`
 }
 
 type ConnectorDefinitionDraftRequest struct {
@@ -97,6 +114,34 @@ func (s Service) DraftPolicyRule(ctx context.Context, request PolicyRuleDraftReq
 		return result, fmt.Errorf("%w: format policy rule draft: %w", ErrDraftValidationFail, err)
 	}
 	result.YAML = yamlBytes
+	return result, nil
+}
+
+// DraftPolicyBundle authors a schema-bound policy from the model response,
+// derives executable tests, and proves them against authored and weakened rules.
+func (s Service) DraftPolicyBundle(ctx context.Context, request PolicyBundleDraftRequest) (*PolicyBundleDraftResult, error) {
+	contextValues := make(map[string]any, len(request.Context)+1)
+	for key, value := range request.Context {
+		contextValues[key] = value
+	}
+	contextValues["test_author_contract"] = map[string]any{
+		"condition_shape": `cmp_eq(path(resource, "field"), scalar)`,
+		"required_cases":  []string{"finding", "passing"},
+		"proof":           "generated suite must reject a policy with its first condition removed",
+	}
+	draft, err := s.DraftPolicyRule(ctx, PolicyRuleDraftRequest{Prompt: request.Prompt, Context: contextValues})
+	if err != nil {
+		return nil, err
+	}
+	artifacts, err := policyauthor.ArtifactsForRule(request.Domain, draft.Rule)
+	if err != nil {
+		return nil, fmt.Errorf("%w: author policy bundle: %w", ErrDraftValidationFail, err)
+	}
+	proof, err := policyauthor.Prove(artifacts)
+	result := &PolicyBundleDraftResult{Rule: artifacts.Rule, PolicyPath: artifacts.PolicyPath, PolicyYAML: artifacts.PolicyYAML, Suite: artifacts.Suite, TestPath: artifacts.TestPath, TestYAML: artifacts.TestYAML, Proof: proof}
+	if err != nil {
+		return result, fmt.Errorf("%w: prove policy bundle: %w", ErrDraftValidationFail, err)
+	}
 	return result, nil
 }
 

--- a/internal/agentauthoring/authoring_test.go
+++ b/internal/agentauthoring/authoring_test.go
@@ -65,6 +65,40 @@ func TestDraftPolicyRuleRejectsInvalidDraft(t *testing.T) {
 	}
 }
 
+func TestDraftPolicyBundleAuthorsRunnableTestsAndProof(t *testing.T) {
+	rule := findingdsl.NewPolicyRule(findingdsl.NewPolicyRuleInput{ID: "agent-public-bucket", Name: "Agent public bucket", Description: "Flags public buckets drafted by the agent.", Severity: "high", Conditions: []string{`cmp_eq(path(resource, "public"), true)`, `cmp_eq(path(resource, "approved"), false)`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"2.1.5"}}}})
+	raw, err := json.Marshal(rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := &stubDraftModel{raw: raw}
+	result, err := (Service{Model: model}).DraftPolicyBundle(context.Background(), PolicyBundleDraftRequest{Prompt: "author a policy for public buckets", Domain: "aws", Context: map[string]any{"source_kind": "aws.s3.bucket"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model.req.Kind != "policy_finding_rule" || model.req.Context["source_kind"] != "aws.s3.bucket" || model.req.Context["test_author_contract"] == nil {
+		t.Fatalf("model request = %#v", model.req)
+	}
+	if result.PolicyPath != "policies/aws/agent-public-bucket.yaml" || result.TestPath != "policies/aws/agent-public-bucket.test.yaml" {
+		t.Fatalf("paths = %q %q", result.PolicyPath, result.TestPath)
+	}
+	if len(result.Suite.Cases) != 2 || len(result.Proof.Receipts) != 2 || !result.Proof.Receipts[0].Passed || !result.Proof.Receipts[1].Passed {
+		t.Fatalf("bundle = %#v", result)
+	}
+}
+
+func TestDraftPolicyBundleRejectsPolicyWithoutSafeFixtureContract(t *testing.T) {
+	rule := findingdsl.NewPolicyRule(findingdsl.NewPolicyRuleInput{ID: "agent-complex", Name: "Agent complex", Description: "Complex agent policy.", Severity: "high", Conditions: []string{`cmp_ne(path(resource, "state"), "safe")`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}})
+	raw, err := json.Marshal(rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := (Service{Model: &stubDraftModel{raw: raw}}).DraftPolicyBundle(context.Background(), PolicyBundleDraftRequest{Prompt: "author complex policy", Domain: "aws"})
+	if !errors.Is(err, ErrDraftValidationFail) || result != nil {
+		t.Fatalf("result = %#v, error = %v", result, err)
+	}
+}
+
 func TestDraftConnectorDefinitionClassifiesAndDryRunsSourcegen(t *testing.T) {
 	definition := connectordefinitions.Definition{
 		ID:          "tenant-a-demo",

--- a/internal/testauthor/policy/author.go
+++ b/internal/testauthor/policy/author.go
@@ -39,16 +39,23 @@ type Artifacts struct {
 }
 
 func Author(intent Intent) (Artifacts, error) {
-	domain := strings.TrimSpace(intent.Domain)
-	if !domainPattern.MatchString(domain) {
-		return Artifacts{}, fmt.Errorf("policy domain %q must use lowercase dash-separated alphanumeric segments", intent.Domain)
-	}
 	rule := findingdsl.NewPolicyRule(findingdsl.NewPolicyRuleInput{
-		ID: intent.ID, Domain: domain, Name: intent.Name, Description: intent.Description,
+		ID: intent.ID, Domain: intent.Domain, Name: intent.Name, Description: intent.Description,
 		Severity: intent.Severity, Resource: intent.Resource, Conditions: intent.Conditions,
 		References: intent.References, Tags: intent.Tags, RiskCategories: intent.RiskCategories,
 		Frameworks: intent.Frameworks, Remediation: intent.Remediation, RemediationStep: intent.RemediationSteps,
 	})
+	return ArtifactsForRule(intent.Domain, rule)
+}
+
+func ArtifactsForRule(domain string, rule findingdsl.PolicyFindingRule) (Artifacts, error) {
+	domain = strings.TrimSpace(domain)
+	if !domainPattern.MatchString(domain) {
+		return Artifacts{}, fmt.Errorf("policy domain %q must use lowercase dash-separated alphanumeric segments", domain)
+	}
+	rule = findingdsl.NormalizePolicyRule(rule)
+	rule.Domain = domain
+	rule.RelPath = findingdsl.PolicyRuleRelPath(domain, rule.Metadata.ID)
 	if issues := findingdsl.ValidatePolicyRule(rule); len(issues) != 0 {
 		return Artifacts{}, fmt.Errorf("authored policy is invalid: %s", joinIssues(issues))
 	}


### PR DESCRIPTION
## Intent

Make policy self-authoring an actual native agent loop, not a compiler for human-written condition YAML.

## What changes

- add `DraftPolicyBundle` to the schema-bound agent-authoring service
- pass the bounded executable-test contract into model context
- normalize and validate the model-authored policy
- derive runnable finding and passing suites deterministically
- prove the suite against authored and weakened policy targets
- return repository paths, policy/test YAML, digests, and proof receipts together
- constrain generated policy domains to safe repository path segments

## Validation

- `GOCACHE=/tmp/cerebro-test-foundry-gocache go test ./internal/agentauthoring ./internal/testauthor/policy ./tools/testauthor ./internal/findingdsl`
- `git diff --cached --check`

Stacked on #1910. Keep draft until the dependency stack and automated review are clear.