### PR TITLE
Bound Cerebro's default MCP surface to ten tools

### DIFF
--- a/docs/domains/mcp-droid-setup.md
+++ b/docs/domains/mcp-droid-setup.md
@@ -20,15 +20,19 @@ The endpoint is a stateless Streamable HTTP MCP endpoint:
 
 Do not advertise or emulate a stateful SSE session on this route. Native Droid uses the MCP SDK Streamable HTTP client for `type: "http"` servers, and it treats stateful session/SSE signals as part of the transport contract.
 
-## Task profile
+## Default tool surface
 
-Set `X-Cerebro-MCP-Toolsets: task` when the client should start with a bounded,
-task-level tool list. The profile exposes six tools:
+Requests start with ten task-level tools. Clients can also request the same
+surface explicitly with `X-Cerebro-MCP-Toolsets: task`:
 
 | Tool | Result |
 | --- | --- |
 | `cerebro.health` | Service readiness |
 | `cerebro.version` | Running build identity |
+| `cerebro.findings.search` | Findings that match the requested risk or scope |
+| `cerebro.assets.search` | Assets that match the requested identity, type, runtime, or tenant |
+| `cerebro.graph.reason` | Answer grounded in tenant-scoped graph evidence |
+| `cerebro.investigation.context` | Finding, evidence, graph, and runtime context for triage |
 | `cerebro.risk.explain` | Finding, evidence, asset, and optional graph context |
 | `cerebro.evidence.packet` | Evidence packet for the requested question and authorized scope |
 | `cerebro.sources.health` | Configured source coverage and current blind spots |
@@ -45,10 +49,11 @@ Task tools do not mutate resources. `cerebro.action.plan` stops at
 The evidence-packet task accepts only `observe`, `explain`, `recommend`, and
 `dry_run` action stages.
 
-Requests without a toolset keep the full tool list for compatibility. Existing
-domain tools remain available as expert tools. Use
-`X-Cerebro-MCP-Toolsets: expert` for that profile, or the existing domain
-toolsets such as `graph`, `risk`, `findings`, and `assessments` for narrower access.
+Low-level domain tools remain available through explicit profiles. Use
+`X-Cerebro-MCP-Toolsets: expert` for expert tools, a domain toolset such as
+`graph`, `risk`, `findings`, or `assessments` for narrower access, or
+`X-Cerebro-MCP-Toolsets: full` for the previous complete tool list. New clients
+should use the default surface instead of `full`.
 
 ## Assessment operations
 

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -3262,9 +3262,6 @@ func mcpToolNameFromParams(method string, rawParams json.RawMessage) string {
 func mcpToolsForRequest(r *http.Request, rawParams json.RawMessage) []mcpTool {
 	tools := mcpTools()
 	enabled := mcpRequestedToolsets(r, rawParams)
-	if len(enabled) == 0 {
-		return tools
-	}
 	filtered := make([]mcpTool, 0, len(tools))
 	for _, tool := range tools {
 		if mcpoperations.EnabledForToolsets(tool.Name, enabled) {
@@ -3276,9 +3273,6 @@ func mcpToolsForRequest(r *http.Request, rawParams json.RawMessage) []mcpTool {
 
 func mcpToolAllowedForRequest(r *http.Request, name string) bool {
 	enabled := mcpRequestedToolsets(r, nil)
-	if len(enabled) == 0 {
-		return true
-	}
 	return mcpoperations.EnabledForToolsets(name, enabled)
 }
 
@@ -3287,7 +3281,11 @@ func mcpRequestedToolsets(r *http.Request, rawParams json.RawMessage) mcpoperati
 	if r != nil {
 		header = r.Header.Get("X-Cerebro-MCP-Toolsets")
 	}
-	return mcpoperations.ParseToolsets(header, rawParams)
+	toolsets := mcpoperations.ParseToolsets(header, rawParams)
+	if len(toolsets) == 0 {
+		toolsets["task"] = true
+	}
+	return toolsets
 }
 
 func mcpToolFamily(name string) string {

--- a/internal/bootstrap/mcp_tasks_test.go
+++ b/internal/bootstrap/mcp_tasks_test.go
@@ -71,7 +71,7 @@ func TestMCPBoolArgParsesJSONNumbers(t *testing.T) {
 	}
 }
 
-func TestMCPTaskProfileIsBoundedAndPreservesDefaultTools(t *testing.T) {
+func TestMCPDefaultAndTaskProfilesExposeTenTools(t *testing.T) {
 	server := newMCPTestServer(t, &stubRuntimeStore{})
 	defer server.Close()
 
@@ -82,12 +82,16 @@ func TestMCPTaskProfileIsBoundedAndPreservesDefaultTools(t *testing.T) {
 	})
 	tools := taskResponse["result"].(map[string]any)["tools"].([]any)
 	want := map[string]bool{
-		"cerebro.health":          true,
-		"cerebro.version":         true,
-		"cerebro.risk.explain":    true,
-		"cerebro.evidence.packet": true,
-		"cerebro.sources.health":  true,
-		"cerebro.action.plan":     true,
+		"cerebro.health":                true,
+		"cerebro.version":               true,
+		"cerebro.findings.search":       true,
+		"cerebro.assets.search":         true,
+		"cerebro.graph.reason":          true,
+		"cerebro.investigation.context": true,
+		"cerebro.risk.explain":          true,
+		"cerebro.evidence.packet":       true,
+		"cerebro.sources.health":        true,
+		"cerebro.action.plan":           true,
 	}
 	if len(tools) != len(want) {
 		t.Fatalf("task profile tool count = %d, want %d: %#v", len(tools), len(want), tools)
@@ -104,7 +108,7 @@ func TestMCPTaskProfileIsBoundedAndPreservesDefaultTools(t *testing.T) {
 		"id":      2,
 		"method":  "tools/call",
 		"params": map[string]any{
-			"name":      "cerebro.graph.reason",
+			"name":      "cerebro.graph.paths",
 			"arguments": map[string]any{"question": "show paths"},
 		},
 	})
@@ -112,14 +116,42 @@ func TestMCPTaskProfileIsBoundedAndPreservesDefaultTools(t *testing.T) {
 		t.Fatalf("task profile expert call = %#v, want tool error", expertCall)
 	}
 
-	defaultResponse, _ := postMCP(t, server, "", map[string]any{
+	defaultResponse := postMCPWithToolset(t, server, "", map[string]any{
 		"jsonrpc": "2.0",
 		"id":      3,
 		"method":  "tools/list",
 	})
 	defaultTools := defaultResponse["result"].(map[string]any)["tools"].([]any)
-	if !mcpToolListContains(defaultTools, "cerebro.graph.reason") {
-		t.Fatalf("default MCP profile no longer exposes expert tools")
+	if len(defaultTools) != len(want) {
+		t.Fatalf("default tool count = %d, want %d: %#v", len(defaultTools), len(want), defaultTools)
+	}
+	for _, raw := range defaultTools {
+		name := raw.(map[string]any)["name"].(string)
+		if !want[name] {
+			t.Fatalf("default profile exposed unexpected tool %q", name)
+		}
+	}
+	defaultExpertCall := postMCPWithToolset(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      4,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "cerebro.graph.paths",
+			"arguments": map[string]any{},
+		},
+	})
+	if defaultExpertCall["result"].(map[string]any)["isError"] != true {
+		t.Fatalf("default profile expert call = %#v, want tool error", defaultExpertCall)
+	}
+
+	fullResponse := postMCPWithToolset(t, server, "full", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      5,
+		"method":  "tools/list",
+	})
+	fullTools := fullResponse["result"].(map[string]any)["tools"].([]any)
+	if len(fullTools) != len(mcpTools()) || !mcpToolListContains(fullTools, "cerebro.graph.paths") || !mcpToolListContains(fullTools, "cerebro.assessments.plan.create") {
+		t.Fatalf("full compatibility profile = %#v", fullTools)
 	}
 }
 
@@ -239,6 +271,11 @@ func TestMCPTaskTelemetryRecordsOperationStateWithoutPrompt(t *testing.T) {
 
 func postMCPWithTaskProfile(t *testing.T, server *httptest.Server, payload map[string]any) map[string]any {
 	t.Helper()
+	return postMCPWithToolset(t, server, "task", payload)
+}
+
+func postMCPWithToolset(t *testing.T, server *httptest.Server, toolset string, payload map[string]any) map[string]any {
+	t.Helper()
 	body, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatalf("marshal MCP request: %v", err)
@@ -251,7 +288,9 @@ func postMCPWithTaskProfile(t *testing.T, server *httptest.Server, payload map[s
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("MCP-Protocol-Version", mcpProtocolVersion)
-	req.Header.Set("X-Cerebro-MCP-Toolsets", "task")
+	if toolset != "" {
+		req.Header.Set("X-Cerebro-MCP-Toolsets", toolset)
+	}
 	response, err := server.Client().Do(req)
 	if err != nil {
 		t.Fatalf("POST MCP request: %v", err)

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -3114,6 +3114,7 @@ func postMCPWithAuthHeader(t *testing.T, server *httptest.Server, sessionID stri
 		req.Header.Set("Authorization", authHeader)
 	}
 	req.Header.Set("MCP-Protocol-Version", mcpProtocolVersion)
+	req.Header.Set("X-Cerebro-MCP-Toolsets", "full")
 	if sessionID != "" {
 		req.Header.Set("Mcp-Session-Id", sessionID)
 	}

--- a/internal/mcpoperations/catalog.go
+++ b/internal/mcpoperations/catalog.go
@@ -54,11 +54,11 @@ func buildOperationRegistry() map[string]Operation {
 		expertRead("cerebro.connector_definitions.validate", "connectors", "connector definition validation"),
 		expertRead("cerebro.findings.list", "findings", "runtime finding list"),
 		expertRead("cerebro.findings.get", "findings", "finding record"),
-		expertRead("cerebro.findings.search", "findings", "finding search results"),
+		taskRead("cerebro.findings.search", "findings", "finding search results", "find findings", "search findings", "list risks", "open findings"),
 		expertRead("cerebro.runtimes.status", "source-runtime", "runtime status and risk summary"),
 		expertRead("cerebro.evidence.list", "findings", "finding evidence list"),
 		expertRead("cerebro.evidence.get", "findings", "finding evidence record"),
-		expertRead("cerebro.assets.search", "graph", "asset search results"),
+		taskRead("cerebro.assets.search", "graph", "asset search results", "find asset", "search assets", "inventory lookup", "affected asset"),
 		expertRead("cerebro.assets.get", "graph", "asset record"),
 		expertRead("cerebro.risk.summary", "risk", "finding risk summary"),
 		expertRead("cerebro.risk.actions.list", "risk", "risk action plan"),
@@ -74,8 +74,8 @@ func buildOperationRegistry() map[string]Operation {
 		expertRead("cerebro.agent.claims.verify", "agent-platform", "claim verification"),
 		expertRead("cerebro.agent.work.contract", "agent-platform", "agent work contract"),
 		expertRead("cerebro.agent.missions.contract", "agent-platform", "mission operating contract"),
-		expertRead("cerebro.graph.reason", "graph-agent", "graph reasoning trace"),
-		expertRead("cerebro.investigation.context", "findings", "finding investigation context"),
+		taskRead("cerebro.graph.reason", "graph-agent", "graph reasoning trace", "ask graph", "reason over graph", "relationship", "attack path"),
+		taskRead("cerebro.investigation.context", "findings", "finding investigation context", "investigate finding", "investigation context", "triage finding", "finding context"),
 		expertExecute("cerebro.assessments.plan.create", "compliance-assessment", "persisted assessment plan draft"),
 		expertExecute("cerebro.assessments.plan.publish", "compliance-assessment", "published assessment plan revision"),
 		expertRead("cerebro.assessments.plan.get", "compliance-assessment", "assessment plan revision"),
@@ -197,7 +197,10 @@ func ParseToolsets(header string, rawParams []byte) Toolsets {
 	toolsets := Toolsets{}
 	for _, value := range values {
 		value = strings.ToLower(strings.TrimSpace(value))
-		if value != "" && value != "all" && value != "full" {
+		if value == "all" {
+			value = "full"
+		}
+		if value != "" {
 			toolsets[value] = true
 		}
 	}
@@ -205,6 +208,9 @@ func ParseToolsets(header string, rawParams []byte) Toolsets {
 }
 
 func EnabledForToolsets(name string, enabled Toolsets) bool {
+	if enabled["full"] {
+		return true
+	}
 	operation, known := Lookup(name)
 	if enabled["task"] && known && operation.Classification == ClassificationTask {
 		return true

--- a/internal/mcpoperations/catalog_test.go
+++ b/internal/mcpoperations/catalog_test.go
@@ -50,15 +50,26 @@ func TestAssessmentExecutionToolsRequireReadAndWriteScopes(t *testing.T) {
 
 func TestTaskProfileIsBoundedAndContainsNoExecution(t *testing.T) {
 	tasks := TaskTools()
-	if len(tasks) > 8 {
-		t.Fatalf("task tools = %d, want at most 8", len(tasks))
+	if len(tasks) != 10 {
+		t.Fatalf("task tools = %d, want 10", len(tasks))
 	}
 	for _, operation := range tasks {
 		if operation.Name == "cerebro.action.execute" || operation.Behavior == "execute" {
 			t.Fatalf("task profile exposes execution: %#v", operation)
 		}
 	}
-	for _, name := range []string{"cerebro.health", "cerebro.version", "cerebro.risk.explain", "cerebro.evidence.packet", "cerebro.sources.health", "cerebro.action.plan"} {
+	for _, name := range []string{
+		"cerebro.health",
+		"cerebro.version",
+		"cerebro.findings.search",
+		"cerebro.assets.search",
+		"cerebro.graph.reason",
+		"cerebro.investigation.context",
+		"cerebro.risk.explain",
+		"cerebro.evidence.packet",
+		"cerebro.sources.health",
+		"cerebro.action.plan",
+	} {
 		if !IsTaskTool(name) {
 			t.Fatalf("task profile missing %s", name)
 		}
@@ -75,8 +86,11 @@ func TestToolsetProfilesPreserveDomainAndFullSelection(t *testing.T) {
 	if !EnabledForToolsets("cerebro.risk.explain", toolsets) || !EnabledForToolsets("cerebro.graph.reason", toolsets) || !EnabledForToolsets("cerebro.sources.list", toolsets) {
 		t.Fatalf("profile selection rejected an enabled task, graph, or expert tool")
 	}
-	if len(ParseToolsets("full", nil)) != 0 || len(ParseToolsets("all", nil)) != 0 {
-		t.Fatalf("full and all must preserve the default unfiltered profile")
+	for _, profile := range []string{"full", "all"} {
+		parsed := ParseToolsets(profile, nil)
+		if !parsed["full"] || !EnabledForToolsets("cerebro.assessments.plan.create", parsed) {
+			t.Fatalf("%s must select the full compatibility profile: %#v", profile, parsed)
+		}
 	}
 }
 

--- a/internal/mcpoperations/testdata/task_tools/selection_cases.json
+++ b/internal/mcpoperations/testdata/task_tools/selection_cases.json
@@ -68,5 +68,45 @@
     "forbidden_tools": ["cerebro.findings.action.execute"],
     "require_partial_handling": false,
     "maximum_call_count": 1
+  },
+  {
+    "id": "search-findings",
+    "user_request": "Search findings for open identity risks.",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.findings.search",
+    "allowed_followup_tools": ["cerebro.risk.explain"],
+    "forbidden_tools": ["cerebro.findings.list"],
+    "require_partial_handling": false,
+    "maximum_call_count": 2
+  },
+  {
+    "id": "search-assets",
+    "user_request": "Search assets for the affected database.",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.assets.search",
+    "allowed_followup_tools": ["cerebro.investigation.context"],
+    "forbidden_tools": ["cerebro.assets.get"],
+    "require_partial_handling": false,
+    "maximum_call_count": 2
+  },
+  {
+    "id": "reason-over-graph",
+    "user_request": "Reason over graph relationships for this attack path.",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.graph.reason",
+    "allowed_followup_tools": ["cerebro.investigation.context"],
+    "forbidden_tools": ["cerebro.graph.paths"],
+    "require_partial_handling": true,
+    "maximum_call_count": 2
+  },
+  {
+    "id": "build-investigation-context",
+    "user_request": "Build investigation context to triage this finding.",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.investigation.context",
+    "allowed_followup_tools": ["cerebro.risk.explain"],
+    "forbidden_tools": ["cerebro.findings.get"],
+    "require_partial_handling": true,
+    "maximum_call_count": 2
   }
 ]


### PR DESCRIPTION
## What changed

- make the ten task-level tools the default MCP tool list and call boundary
- add finding search, asset search, graph reasoning, and investigation context to the existing task profile
- keep the previous complete tool list behind the explicit full profile; expert and domain profiles remain available
- add selection fixtures and contract tests for the default, task, and full profiles

## Client impact

Clients that do not select a toolset now receive ten tools. Low-level operations require an explicit full, expert, or domain toolset. No tool handler or domain service was removed.

## Validation

- go test ./internal/mcpoperations ./internal/bootstrap -count=1
- go test -race ./internal/mcpoperations ./internal/bootstrap -run MCP|Task|Toolset -count=1
- make mcp-contract-check check-structural check-structural-test check-arch docs-drift-check readme-check oss-audit
- make changed-check
- changed-lines golangci-lint: 0 issues