### PR TITLE
feat(testauthor): synthesize scalar policy expressions

### DIFF
--- a/internal/agentauthoring/authoring_test.go
+++ b/internal/agentauthoring/authoring_test.go
@@ -88,7 +88,7 @@ func TestDraftPolicyBundleAuthorsRunnableTestsAndProof(t *testing.T) {
 }
 
 func TestDraftPolicyBundleRejectsPolicyWithoutSafeFixtureContract(t *testing.T) {
-	rule := findingdsl.NewPolicyRule(findingdsl.NewPolicyRuleInput{ID: "agent-complex", Name: "Agent complex", Description: "Complex agent policy.", Severity: "high", Conditions: []string{`cmp_ne(path(resource, "state"), "safe")`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}})
+	rule := findingdsl.NewPolicyRule(findingdsl.NewPolicyRuleInput{ID: "agent-complex", Name: "Agent complex", Description: "Complex agent policy.", Severity: "high", Conditions: []string{`cmp_eq(path(resource, "state"), path(resource, "expected_state"))`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}})
 	raw, err := json.Marshal(rule)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/findingdsl/expression.go
+++ b/internal/findingdsl/expression.go
@@ -231,73 +231,141 @@ func EvaluatePolicyConditions(conditions []string, resource PolicyResource) (boo
 }
 
 // SynthesizeEqualityConditionFixtures derives a finding and passing resource for
-// policies made entirely from cmp_eq(path(resource, field), scalar) conditions.
-// It intentionally rejects broader expressions rather than guessing semantics.
+// policies made entirely from supported scalar comparisons. It intentionally
+// rejects broader expressions rather than guessing semantics.
 func SynthesizeEqualityConditionFixtures(conditions []string) (PolicyResource, PolicyResource, error) {
 	if len(conditions) == 0 {
 		return nil, nil, fmt.Errorf("at least one condition is required")
 	}
 	finding := PolicyResource{}
 	passing := PolicyResource{}
-	var firstField string
 	for idx, condition := range conditions {
 		expr, err := parsePolicyExpression(condition)
 		if err != nil {
 			return nil, nil, fmt.Errorf("condition[%d]: %w", idx, err)
 		}
-		call, ok := expr.(callExpression)
-		if !ok || call.name != "cmp_eq" || len(call.args) != 2 {
-			return nil, nil, fmt.Errorf("condition[%d] is not a simple equality condition", idx)
+		fixture, err := scalarConditionFixture(expr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("condition[%d]: %w", idx, err)
 		}
-		pathCall, ok := call.args[0].(callExpression)
-		if !ok || pathCall.name != "path" || len(pathCall.args) != 2 {
-			return nil, nil, fmt.Errorf("condition[%d] does not compare a resource path", idx)
+		if err := setPolicyFixturePath(finding, fixture.field, fixture.finding); err != nil {
+			return nil, nil, fmt.Errorf("condition[%d] field %q: %w", idx, fixture.field, err)
 		}
-		root, rootOK := pathCall.args[0].(identExpression)
-		fieldExpr, fieldOK := pathCall.args[1].(literalExpression)
-		field, stringOK := fieldExpr.value.(string)
-		valueExpr, valueOK := call.args[1].(literalExpression)
-		if !rootOK || root.name != "resource" || !fieldOK || !stringOK || strings.TrimSpace(field) == "" || !valueOK {
-			return nil, nil, fmt.Errorf("condition[%d] must compare path(resource, field) with a scalar literal", idx)
+		passingValue := fixture.finding
+		if idx == 0 {
+			passingValue = fixture.passing
 		}
-		if _, err := alternatePolicyFixtureValue(valueExpr.value); err != nil {
-			return nil, nil, fmt.Errorf("condition[%d] field %q: %w", idx, field, err)
+		if err := setPolicyFixturePath(passing, fixture.field, passingValue); err != nil {
+			return nil, nil, fmt.Errorf("condition[%d] field %q: %w", idx, fixture.field, err)
 		}
-		if err := setPolicyFixturePath(finding, field, valueExpr.value); err != nil {
-			return nil, nil, fmt.Errorf("condition[%d] field %q: %w", idx, field, err)
-		}
-		if err := setPolicyFixturePath(passing, field, valueExpr.value); err != nil {
-			return nil, nil, fmt.Errorf("condition[%d] field %q: %w", idx, field, err)
-		}
-		if firstField == "" {
-			firstField = field
-		}
-	}
-	alternate, _ := alternatePolicyFixtureValue(policyFixturePathValue(finding, firstField))
-	if err := replacePolicyFixturePath(passing, firstField, alternate); err != nil {
-		return nil, nil, err
 	}
 	return finding, passing, nil
 }
 
-func replacePolicyFixturePath(resource PolicyResource, path string, value any) error {
-	parts := strings.Split(path, ".")
-	current := map[string]any(resource)
-	for idx, part := range parts {
-		if idx == len(parts)-1 {
-			if _, exists := current[part]; !exists {
-				return fmt.Errorf("resource path %q does not exist", path)
-			}
-			current[part] = value
-			return nil
-		}
-		next, ok := current[part].(map[string]any)
-		if !ok {
-			return fmt.Errorf("resource path %q does not exist", path)
-		}
-		current = next
+type scalarFixture struct {
+	field   string
+	finding any
+	passing any
+}
+
+func scalarConditionFixture(expr expression) (scalarFixture, error) {
+	call, ok := expr.(callExpression)
+	if !ok || len(call.args) != 2 {
+		return scalarFixture{}, fmt.Errorf("expression is not a supported scalar comparison")
 	}
-	return nil
+	field, err := policyResourcePath(call.args[0])
+	if err != nil {
+		return scalarFixture{}, err
+	}
+	switch call.name {
+	case "cmp_eq", "cmp_ne", "cmp_gt", "cmp_lt", "cmp_ge", "cmp_le":
+		literal, ok := call.args[1].(literalExpression)
+		if !ok {
+			return scalarFixture{}, fmt.Errorf("%s must compare the resource path with a scalar literal", call.name)
+		}
+		finding, passing, err := scalarComparisonValues(call.name, literal.value)
+		return scalarFixture{field: field, finding: finding, passing: passing}, err
+	case "in_list":
+		list, ok := call.args[1].(listExpression)
+		if !ok || len(list.items) == 0 {
+			return scalarFixture{}, fmt.Errorf("in_list requires a non-empty literal list")
+		}
+		values := make([]any, 0, len(list.items))
+		for _, item := range list.items {
+			literal, ok := item.(literalExpression)
+			if !ok {
+				return scalarFixture{}, fmt.Errorf("in_list values must be scalar literals")
+			}
+			values = append(values, literal.value)
+		}
+		passing, err := valueOutsidePolicyList(values)
+		return scalarFixture{field: field, finding: values[0], passing: passing}, err
+	default:
+		return scalarFixture{}, fmt.Errorf("function %q is not a supported scalar comparison", call.name)
+	}
+}
+
+func policyResourcePath(expr expression) (string, error) {
+	pathCall, ok := expr.(callExpression)
+	if !ok || pathCall.name != "path" || len(pathCall.args) != 2 {
+		return "", fmt.Errorf("comparison does not use a resource path")
+	}
+	root, rootOK := pathCall.args[0].(identExpression)
+	fieldExpr, fieldOK := pathCall.args[1].(literalExpression)
+	field, stringOK := fieldExpr.value.(string)
+	if !rootOK || root.name != "resource" || !fieldOK || !stringOK || strings.TrimSpace(field) == "" {
+		return "", fmt.Errorf("comparison must use path(resource, field)")
+	}
+	return field, nil
+}
+
+func scalarComparisonValues(name string, literal any) (any, any, error) {
+	switch name {
+	case "cmp_eq":
+		alternate, err := alternatePolicyFixtureValue(literal)
+		return literal, alternate, err
+	case "cmp_ne":
+		alternate, err := alternatePolicyFixtureValue(literal)
+		return alternate, literal, err
+	case "cmp_gt":
+		greater, err := orderedPolicyFixtureValue(literal, 1)
+		return greater, literal, err
+	case "cmp_lt":
+		lesser, err := orderedPolicyFixtureValue(literal, -1)
+		return lesser, literal, err
+	case "cmp_ge":
+		lesser, err := orderedPolicyFixtureValue(literal, -1)
+		return literal, lesser, err
+	case "cmp_le":
+		greater, err := orderedPolicyFixtureValue(literal, 1)
+		return literal, greater, err
+	default:
+		return nil, nil, fmt.Errorf("unsupported comparison %q", name)
+	}
+}
+
+func valueOutsidePolicyList(values []any) (any, error) {
+	candidate, err := alternatePolicyFixtureValue(values[0])
+	if err != nil {
+		return nil, err
+	}
+	for attempts := 0; attempts < len(values)+1; attempts++ {
+		inside := false
+		for _, value := range values {
+			if compareValues(candidate, value) == 0 {
+				inside = true
+				break
+			}
+		}
+		if !inside {
+			return candidate, nil
+		}
+		candidate, err = alternatePolicyFixtureValue(candidate)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("could not derive a value outside the list")
 }
 
 func setPolicyFixturePath(resource PolicyResource, path string, value any) error {
@@ -330,11 +398,6 @@ func setPolicyFixturePath(resource PolicyResource, path string, value any) error
 	return nil
 }
 
-func policyFixturePathValue(resource PolicyResource, path string) any {
-	value, _, _ := pathLookupArgs([]any{resource, path})
-	return value
-}
-
 func alternatePolicyFixtureValue(value any) (any, error) {
 	switch typed := value.(type) {
 	case bool:
@@ -343,8 +406,27 @@ func alternatePolicyFixtureValue(value any) (any, error) {
 		return typed + "-passing", nil
 	case float64:
 		return typed + 1, nil
+	case nil:
+		return true, nil
 	default:
 		return nil, fmt.Errorf("literal type %T is not supported", value)
+	}
+}
+
+func orderedPolicyFixtureValue(value any, direction float64) (any, error) {
+	switch typed := value.(type) {
+	case float64:
+		return typed + direction, nil
+	case string:
+		if direction > 0 {
+			return typed + "\uffff", nil
+		}
+		if typed == "" {
+			return nil, fmt.Errorf("cannot derive a string ordered below the empty string")
+		}
+		return "", nil
+	default:
+		return nil, fmt.Errorf("literal type %T does not have a deterministic ordered fixture", value)
 	}
 }
 

--- a/internal/findingdsl/graph_test_fixture.go
+++ b/internal/findingdsl/graph_test_fixture.go
@@ -64,8 +64,14 @@ func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleT
 }
 
 func containsTwoEdgePath(adjacency map[string][]string) bool {
-	for _, neighbors := range adjacency {
-		if len(neighbors) >= 2 {
+	for node, neighbors := range adjacency {
+		distinct := map[string]struct{}{}
+		for _, neighbor := range neighbors {
+			if neighbor != node {
+				distinct[neighbor] = struct{}{}
+			}
+		}
+		if len(distinct) >= 2 {
 			return true
 		}
 	}
@@ -111,23 +117,24 @@ func graphFixtureSingleEdgeMutation(finding, passing *PolicyGraphFixture) bool {
 	if !sameGraphFixtureNodes(findingNodes, passingNodes) {
 		return false
 	}
-	findingEdges, passingEdges := graphFixtureEdgeSet(finding.Edges), graphFixtureEdgeSet(passing.Edges)
+	findingEdges, passingEdges := graphFixtureEdgeMap(finding.Edges), graphFixtureEdgeMap(passing.Edges)
 	if len(findingEdges) != len(passingEdges)+1 {
 		return false
 	}
-	for edge := range passingEdges {
-		if _, ok := findingEdges[edge]; !ok {
+	for key, passingEdge := range passingEdges {
+		findingEdge, ok := findingEdges[key]
+		if !ok || findingEdge.SourceID != passingEdge.SourceID || findingEdge.RuntimeID != passingEdge.RuntimeID || !maps.Equal(findingEdge.Attributes, passingEdge.Attributes) {
 			return false
 		}
 	}
 	return true
 }
 
-func graphFixtureEdgeSet(edges []PolicyGraphFixtureEdge) map[string]struct{} {
-	out := make(map[string]struct{}, len(edges))
+func graphFixtureEdgeMap(edges []PolicyGraphFixtureEdge) map[string]PolicyGraphFixtureEdge {
+	out := make(map[string]PolicyGraphFixtureEdge, len(edges))
 	for _, edge := range edges {
 		key := strings.TrimSpace(edge.FromURN) + "\x00" + strings.TrimSpace(edge.Relation) + "\x00" + strings.TrimSpace(edge.ToURN)
-		out[key] = struct{}{}
+		out[key] = edge
 	}
 	return out
 }

--- a/internal/findingdsl/graph_test_fixture.go
+++ b/internal/findingdsl/graph_test_fixture.go
@@ -62,6 +62,78 @@ func containsTwoEdgePath(adjacency map[string][]string) bool {
 	return false
 }
 
+func validatePolicyGraphMutationPair(path string, cases []PolicyRuleTestCase) []Issue {
+	var findingCases, passingCases []PolicyRuleTestCase
+	for _, testCase := range cases {
+		if testCase.GraphFixture == nil {
+			continue
+		}
+		if testCase.WantFinding {
+			findingCases = append(findingCases, testCase)
+		} else {
+			passingCases = append(passingCases, testCase)
+		}
+	}
+	if len(findingCases)+len(passingCases) == 0 {
+		return nil
+	}
+	for _, findingCase := range findingCases {
+		for _, passingCase := range passingCases {
+			if graphFixtureSingleEdgeMutation(findingCase.GraphFixture, passingCase.GraphFixture) {
+				return nil
+			}
+		}
+	}
+	return []Issue{{Path: path, Message: "graphFixture suites require a finding case and a passing case with identical nodes and exactly one policy-critical edge removed"}}
+}
+
+func graphFixtureSingleEdgeMutation(finding, passing *PolicyGraphFixture) bool {
+	if finding == nil || passing == nil || strings.TrimSpace(finding.TenantID) != strings.TrimSpace(passing.TenantID) {
+		return false
+	}
+	findingNodes, passingNodes := map[string]struct{}{}, map[string]struct{}{}
+	for _, node := range finding.Nodes {
+		findingNodes[strings.TrimSpace(node.URN)] = struct{}{}
+	}
+	for _, node := range passing.Nodes {
+		passingNodes[strings.TrimSpace(node.URN)] = struct{}{}
+	}
+	if !sameStringSet(findingNodes, passingNodes) {
+		return false
+	}
+	findingEdges, passingEdges := graphFixtureEdgeSet(finding.Edges), graphFixtureEdgeSet(passing.Edges)
+	if len(findingEdges) != len(passingEdges)+1 {
+		return false
+	}
+	for edge := range passingEdges {
+		if _, ok := findingEdges[edge]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func graphFixtureEdgeSet(edges []PolicyGraphFixtureEdge) map[string]struct{} {
+	out := make(map[string]struct{}, len(edges))
+	for _, edge := range edges {
+		key := strings.TrimSpace(edge.FromURN) + "\x00" + strings.TrimSpace(edge.Relation) + "\x00" + strings.TrimSpace(edge.ToURN)
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func sameStringSet(left, right map[string]struct{}) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for value := range left {
+		if _, ok := right[value]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule PolicyFindingRule, testCase PolicyRuleTestCase) (err error) {
 	fixture := testCase.GraphFixture
 	for _, node := range fixture.Nodes {

--- a/internal/findingdsl/graph_test_fixture.go
+++ b/internal/findingdsl/graph_test_fixture.go
@@ -3,6 +3,7 @@ package findingdsl
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -18,7 +19,7 @@ func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleT
 	if len(fixture.Nodes) < 3 {
 		issues = append(issues, Issue{Path: path, Message: prefix + " must contain at least three nodes"})
 	}
-	if len(fixture.Edges) < 2 {
+	if testCase.WantFinding && len(fixture.Edges) < 2 {
 		issues = append(issues, Issue{Path: path, Message: prefix + " must contain at least two edges"})
 	}
 	nodes := make(map[string]struct{}, len(fixture.Nodes))
@@ -33,6 +34,7 @@ func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleT
 		nodes[urn] = struct{}{}
 	}
 	adjacency := map[string][]string{}
+	edges := map[string]struct{}{}
 	for edgeIndex, edge := range fixture.Edges {
 		from, to := strings.TrimSpace(edge.FromURN), strings.TrimSpace(edge.ToURN)
 		if _, ok := nodes[from]; !ok {
@@ -44,10 +46,18 @@ func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleT
 		if strings.TrimSpace(edge.SourceID) == "" || strings.TrimSpace(edge.Relation) == "" {
 			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d] requires sourceId and relation", prefix, edgeIndex)})
 		}
+		if from != "" && from == to {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d] must connect two distinct nodes", prefix, edgeIndex)})
+		}
+		edgeKey := from + "\x00" + strings.TrimSpace(edge.Relation) + "\x00" + to
+		if _, exists := edges[edgeKey]; exists {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d] duplicates an earlier edge", prefix, edgeIndex)})
+		}
+		edges[edgeKey] = struct{}{}
 		adjacency[from] = append(adjacency[from], to)
 		adjacency[to] = append(adjacency[to], from)
 	}
-	if !containsTwoEdgePath(adjacency) {
+	if testCase.WantFinding && !containsTwoEdgePath(adjacency) {
 		issues = append(issues, Issue{Path: path, Message: prefix + " must contain a connected path spanning two edges"})
 	}
 	return issues
@@ -91,14 +101,14 @@ func graphFixtureSingleEdgeMutation(finding, passing *PolicyGraphFixture) bool {
 	if finding == nil || passing == nil || strings.TrimSpace(finding.TenantID) != strings.TrimSpace(passing.TenantID) {
 		return false
 	}
-	findingNodes, passingNodes := map[string]struct{}{}, map[string]struct{}{}
+	findingNodes, passingNodes := map[string]PolicyGraphFixtureNode{}, map[string]PolicyGraphFixtureNode{}
 	for _, node := range finding.Nodes {
-		findingNodes[strings.TrimSpace(node.URN)] = struct{}{}
+		findingNodes[strings.TrimSpace(node.URN)] = node
 	}
 	for _, node := range passing.Nodes {
-		passingNodes[strings.TrimSpace(node.URN)] = struct{}{}
+		passingNodes[strings.TrimSpace(node.URN)] = node
 	}
-	if !sameStringSet(findingNodes, passingNodes) {
+	if !sameGraphFixtureNodes(findingNodes, passingNodes) {
 		return false
 	}
 	findingEdges, passingEdges := graphFixtureEdgeSet(finding.Edges), graphFixtureEdgeSet(passing.Edges)
@@ -122,12 +132,13 @@ func graphFixtureEdgeSet(edges []PolicyGraphFixtureEdge) map[string]struct{} {
 	return out
 }
 
-func sameStringSet(left, right map[string]struct{}) bool {
+func sameGraphFixtureNodes(left, right map[string]PolicyGraphFixtureNode) bool {
 	if len(left) != len(right) {
 		return false
 	}
-	for value := range left {
-		if _, ok := right[value]; !ok {
+	for urn, leftNode := range left {
+		rightNode, ok := right[urn]
+		if !ok || leftNode.URN != rightNode.URN || leftNode.SourceID != rightNode.SourceID || leftNode.RuntimeID != rightNode.RuntimeID || leftNode.EntityType != rightNode.EntityType || leftNode.Label != rightNode.Label || !maps.Equal(leftNode.Attributes, rightNode.Attributes) {
 			return false
 		}
 	}
@@ -136,6 +147,15 @@ func sameStringSet(left, right map[string]struct{}) bool {
 
 func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule PolicyFindingRule, testCase PolicyRuleTestCase) (err error) {
 	fixture := testCase.GraphFixture
+	projectedURNs := make([]string, 0, len(fixture.Nodes))
+	defer func() {
+		cleanupCtx := context.WithoutCancel(ctx)
+		for index := len(projectedURNs) - 1; index >= 0; index-- {
+			if cleanupErr := store.DeleteProjectedEntity(cleanupCtx, projectedURNs[index]); cleanupErr != nil && err == nil {
+				err = fmt.Errorf("delete fixture node %q: %w", projectedURNs[index], cleanupErr)
+			}
+		}
+	}()
 	for _, node := range fixture.Nodes {
 		if err := store.UpsertProjectedEntity(ctx, &ports.ProjectedEntity{
 			URN: node.URN, TenantID: fixture.TenantID, SourceID: node.SourceID, RuntimeID: node.RuntimeID,
@@ -143,14 +163,8 @@ func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule
 		}); err != nil {
 			return fmt.Errorf("project node %q: %w", node.URN, err)
 		}
+		projectedURNs = append(projectedURNs, node.URN)
 	}
-	defer func() {
-		for index := len(fixture.Nodes) - 1; index >= 0; index-- {
-			if cleanupErr := store.DeleteProjectedEntity(ctx, fixture.Nodes[index].URN); cleanupErr != nil && err == nil {
-				err = fmt.Errorf("delete fixture node %q: %w", fixture.Nodes[index].URN, cleanupErr)
-			}
-		}
-	}()
 	for _, edge := range fixture.Edges {
 		if err := store.UpsertProjectedLink(ctx, &ports.ProjectedLink{
 			TenantID: fixture.TenantID, SourceID: edge.SourceID, RuntimeID: edge.RuntimeID,
@@ -179,12 +193,40 @@ func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule
 	if issues := validatePolicyRuleTestCaseAgainstRule("<graph-fixture>", rule, 0, rowCase); len(issues) != 0 {
 		return fmt.Errorf("query result violates graph finding contract: %s", issues[0].Message)
 	}
+	if err := validateGraphFixtureEvidence(rows, testCase.WantEvidenceURNs); err != nil {
+		return err
+	}
 	got, err := EvaluatePolicyRuleTestCase(rule, rowCase)
 	if err != nil {
 		return err
 	}
 	if got != testCase.WantFinding {
 		return fmt.Errorf("finding = %t, want %t (query returned %d row(s))", got, testCase.WantFinding, len(rows))
+	}
+	return nil
+}
+
+func validateGraphFixtureEvidence(rows []ports.CypherRow, expectedURNs []string) error {
+	if len(expectedURNs) == 0 {
+		return nil
+	}
+	actual := map[string]struct{}{}
+	for _, row := range rows {
+		items, _ := row.Values["evidence"].([]any)
+		for _, item := range items {
+			values, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if urn := strings.TrimSpace(fmt.Sprintf("%v", values["urn"])); urn != "" && urn != "<nil>" {
+				actual[urn] = struct{}{}
+			}
+		}
+	}
+	for _, expected := range expectedURNs {
+		if _, ok := actual[strings.TrimSpace(expected)]; !ok {
+			return fmt.Errorf("query evidence missing expected URN %q", expected)
+		}
 	}
 	return nil
 }

--- a/internal/findingdsl/graph_test_fixture.go
+++ b/internal/findingdsl/graph_test_fixture.go
@@ -1,0 +1,118 @@
+package findingdsl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleTestCase) []Issue {
+	fixture := testCase.GraphFixture
+	prefix := fmt.Sprintf("cases[%d] %q graphFixture", caseIndex, testCase.Name)
+	var issues []Issue
+	if strings.TrimSpace(fixture.TenantID) == "" {
+		issues = append(issues, Issue{Path: path, Message: prefix + ".tenantId is required"})
+	}
+	if len(fixture.Nodes) < 3 {
+		issues = append(issues, Issue{Path: path, Message: prefix + " must contain at least three nodes"})
+	}
+	if len(fixture.Edges) < 2 {
+		issues = append(issues, Issue{Path: path, Message: prefix + " must contain at least two edges"})
+	}
+	nodes := make(map[string]struct{}, len(fixture.Nodes))
+	for nodeIndex, node := range fixture.Nodes {
+		urn := strings.TrimSpace(node.URN)
+		if urn == "" || strings.TrimSpace(node.SourceID) == "" || strings.TrimSpace(node.EntityType) == "" {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.nodes[%d] requires urn, sourceId, and entityType", prefix, nodeIndex)})
+		}
+		if _, exists := nodes[urn]; exists && urn != "" {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.nodes[%d].urn %q is duplicated", prefix, nodeIndex, urn)})
+		}
+		nodes[urn] = struct{}{}
+	}
+	adjacency := map[string][]string{}
+	for edgeIndex, edge := range fixture.Edges {
+		from, to := strings.TrimSpace(edge.FromURN), strings.TrimSpace(edge.ToURN)
+		if _, ok := nodes[from]; !ok {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d].fromUrn does not reference a fixture node", prefix, edgeIndex)})
+		}
+		if _, ok := nodes[to]; !ok {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d].toUrn does not reference a fixture node", prefix, edgeIndex)})
+		}
+		if strings.TrimSpace(edge.SourceID) == "" || strings.TrimSpace(edge.Relation) == "" {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d] requires sourceId and relation", prefix, edgeIndex)})
+		}
+		adjacency[from] = append(adjacency[from], to)
+		adjacency[to] = append(adjacency[to], from)
+	}
+	if !containsTwoEdgePath(adjacency) {
+		issues = append(issues, Issue{Path: path, Message: prefix + " must contain a connected path spanning two edges"})
+	}
+	return issues
+}
+
+func containsTwoEdgePath(adjacency map[string][]string) bool {
+	for _, neighbors := range adjacency {
+		if len(neighbors) >= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule PolicyFindingRule, testCase PolicyRuleTestCase) (err error) {
+	fixture := testCase.GraphFixture
+	for _, node := range fixture.Nodes {
+		if err := store.UpsertProjectedEntity(ctx, &ports.ProjectedEntity{
+			URN: node.URN, TenantID: fixture.TenantID, SourceID: node.SourceID, RuntimeID: node.RuntimeID,
+			EntityType: node.EntityType, Label: node.Label, Attributes: node.Attributes,
+		}); err != nil {
+			return fmt.Errorf("project node %q: %w", node.URN, err)
+		}
+	}
+	defer func() {
+		for index := len(fixture.Nodes) - 1; index >= 0; index-- {
+			if cleanupErr := store.DeleteProjectedEntity(ctx, fixture.Nodes[index].URN); cleanupErr != nil && err == nil {
+				err = fmt.Errorf("delete fixture node %q: %w", fixture.Nodes[index].URN, cleanupErr)
+			}
+		}
+	}()
+	for _, edge := range fixture.Edges {
+		if err := store.UpsertProjectedLink(ctx, &ports.ProjectedLink{
+			TenantID: fixture.TenantID, SourceID: edge.SourceID, RuntimeID: edge.RuntimeID,
+			FromURN: edge.FromURN, ToURN: edge.ToURN, Relation: edge.Relation, Attributes: edge.Attributes,
+		}); err != nil {
+			return fmt.Errorf("project edge %q -[%s]-> %q: %w", edge.FromURN, edge.Relation, edge.ToURN, err)
+		}
+	}
+	params := make(map[string]any, len(rule.Spec.Graph.Params)+2)
+	for key, value := range rule.Spec.Graph.Params {
+		params[key] = value
+	}
+	params["tenant_id"] = fixture.TenantID
+	params["row_limit"] = int64(rule.Spec.Graph.RowLimit)
+	rows, err := store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: rule.Spec.Graph.Query, Params: params, RowLimit: rule.Spec.Graph.RowLimit})
+	if err != nil {
+		return fmt.Errorf("execute policy graph query: %w", err)
+	}
+	queryRows := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		queryRows = append(queryRows, row.Values)
+	}
+	rowCase := testCase
+	rowCase.GraphFixture = nil
+	rowCase.QueryRows = queryRows
+	if issues := validatePolicyRuleTestCaseAgainstRule("<graph-fixture>", rule, 0, rowCase); len(issues) != 0 {
+		return fmt.Errorf("query result violates graph finding contract: %s", issues[0].Message)
+	}
+	got, err := EvaluatePolicyRuleTestCase(rule, rowCase)
+	if err != nil {
+		return err
+	}
+	if got != testCase.WantFinding {
+		return fmt.Errorf("finding = %t, want %t (query returned %d row(s))", got, testCase.WantFinding, len(rows))
+	}
+	return nil
+}

--- a/internal/findingdsl/graph_test_fixture_test.go
+++ b/internal/findingdsl/graph_test_fixture_test.go
@@ -57,6 +57,25 @@ func TestValidatePolicyGraphFixtureRequiresConnectedTwoEdgePath(t *testing.T) {
 	}
 }
 
+func TestValidatePolicyGraphFixtureRequiresSingleEdgeMutationPair(t *testing.T) {
+	nodes := []PolicyGraphFixtureNode{
+		{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+		{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+		{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+	}
+	edges := []PolicyGraphFixtureEdge{
+		{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+		{FromURN: "b", ToURN: "c", SourceID: "okta", Relation: "assigned_to"},
+	}
+	suite := PolicyRuleTestSuite{APIVersion: APIVersion, Kind: KindPolicyFindingRuleTest, Cases: []PolicyRuleTestCase{
+		{Name: "finding only", GraphFixture: &PolicyGraphFixture{TenantID: "fixture", Nodes: nodes, Edges: edges}, WantFinding: true},
+	}}
+	issues := ValidatePolicyRuleTestSuite(suite)
+	if !issuesContain(issues, "exactly one policy-critical edge removed") {
+		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want mutation-pair issue", issues)
+	}
+}
+
 func TestRunPolicyGraphFixtureProjectsTopologyAndExecutesPolicyCypher(t *testing.T) {
 	rule := PolicyFindingRule{Spec: PolicyFindingRuleSpec{Graph: PolicyRuleGraphFinding{
 		Query: "MATCH (a)-[:RELATION]->(b)-[:RELATION]->(c) RETURN a.urn AS primary_urn", RowLimit: 25,

--- a/internal/findingdsl/graph_test_fixture_test.go
+++ b/internal/findingdsl/graph_test_fixture_test.go
@@ -2,6 +2,7 @@ package findingdsl
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -9,11 +10,12 @@ import (
 )
 
 type recordingPolicyGraphStore struct {
-	entities []*ports.ProjectedEntity
-	links    []*ports.ProjectedLink
-	deleted  []string
-	request  ports.CypherQueryRequest
-	rows     []ports.CypherRow
+	entities    []*ports.ProjectedEntity
+	links       []*ports.ProjectedLink
+	deleted     []string
+	request     ports.CypherQueryRequest
+	rows        []ports.CypherRow
+	entityErrAt int
 }
 
 func (s *recordingPolicyGraphStore) Ping(context.Context) error { return nil }
@@ -21,8 +23,27 @@ func (s *recordingPolicyGraphStore) GetEntityNeighborhood(context.Context, strin
 	return nil, nil
 }
 func (s *recordingPolicyGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if s.entityErrAt > 0 && len(s.entities)+1 == s.entityErrAt {
+		return errors.New("projection failed")
+	}
 	s.entities = append(s.entities, entity)
 	return nil
+}
+
+func TestRunPolicyGraphFixtureCleansUpPartialProjection(t *testing.T) {
+	fixture := &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+		{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+		{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+		{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+	}}
+	store := &recordingPolicyGraphStore{entityErrAt: 2}
+	err := runPolicyGraphFixture(context.Background(), store, PolicyFindingRule{}, PolicyRuleTestCase{GraphFixture: fixture})
+	if err == nil || !strings.Contains(err.Error(), "projection failed") {
+		t.Fatalf("runPolicyGraphFixture() error = %v, want projection failure", err)
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != "a" {
+		t.Fatalf("deleted = %#v, want first projected node cleaned up", store.deleted)
+	}
 }
 func (s *recordingPolicyGraphStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
 	s.links = append(s.links, link)
@@ -49,7 +70,7 @@ func TestValidatePolicyGraphFixtureRequiresConnectedTwoEdgePath(t *testing.T) {
 				{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
 				{FromURN: "c", ToURN: "d", SourceID: "okta", Relation: "grants_entitlement"},
 			},
-		}, WantFinding: false,
+		}, WantEvidenceURNs: []string{"b", "c"}, WantFinding: true,
 	}}}
 	issues := ValidatePolicyRuleTestSuite(suite)
 	if !issuesContain(issues, "must contain a connected path spanning two edges") {
@@ -91,8 +112,9 @@ func TestRunPolicyGraphFixtureProjectsTopologyAndExecutesPolicyCypher(t *testing
 	}}
 	store := &recordingPolicyGraphStore{rows: []ports.CypherRow{{Values: map[string]any{
 		"primary_urn": "a", "fingerprint_key": "a|c", "summary": "multi-hop access", "resource_urns": []string{"a", "b", "c"},
+		"evidence": []any{map[string]any{"urn": "b"}, map[string]any{"urn": "c"}},
 	}}}}
-	if err := runPolicyGraphFixture(context.Background(), store, rule, PolicyRuleTestCase{Name: "complete path", GraphFixture: fixture, WantFinding: true}); err != nil {
+	if err := runPolicyGraphFixture(context.Background(), store, rule, PolicyRuleTestCase{Name: "complete path", GraphFixture: fixture, WantEvidenceURNs: []string{"b", "c"}, WantFinding: true}); err != nil {
 		t.Fatalf("runPolicyGraphFixture() error = %v", err)
 	}
 	if len(store.entities) != 3 || len(store.links) != 2 || len(store.deleted) != 3 {
@@ -103,5 +125,38 @@ func TestRunPolicyGraphFixtureProjectsTopologyAndExecutesPolicyCypher(t *testing
 	}
 	if store.request.Params["tenant_id"] != "fixture" || store.request.Params["row_limit"] != int64(25) {
 		t.Fatalf("executed params = %#v", store.request.Params)
+	}
+}
+
+func TestGraphFixtureMutationRejectsNodeAttributeChanges(t *testing.T) {
+	finding := &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+		{URN: "a", SourceID: "okta", EntityType: "okta.user", Attributes: map[string]string{"status": "suspended"}},
+		{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+		{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+	}, Edges: []PolicyGraphFixtureEdge{
+		{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+		{FromURN: "b", ToURN: "c", SourceID: "okta", Relation: "assigned_to"},
+	}}
+	passing := *finding
+	passing.Nodes = append([]PolicyGraphFixtureNode(nil), finding.Nodes...)
+	passing.Nodes[0].Attributes = map[string]string{"status": "active"}
+	passing.Edges = append([]PolicyGraphFixtureEdge(nil), finding.Edges[1:]...)
+	if graphFixtureSingleEdgeMutation(finding, &passing) {
+		t.Fatal("graphFixtureSingleEdgeMutation() = true when node attributes changed")
+	}
+}
+
+func TestValidatePolicyGraphFixtureRejectsDuplicateEdges(t *testing.T) {
+	edge := PolicyGraphFixtureEdge{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"}
+	suite := PolicyRuleTestSuite{APIVersion: APIVersion, Kind: KindPolicyFindingRuleTest, Cases: []PolicyRuleTestCase{{
+		Name: "duplicate edge", GraphFixture: &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+			{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+			{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+			{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+		}, Edges: []PolicyGraphFixtureEdge{edge, edge}}, WantEvidenceURNs: []string{"b", "c"}, WantFinding: true,
+	}}}
+	issues := ValidatePolicyRuleTestSuite(suite)
+	if !issuesContain(issues, "duplicates an earlier edge") {
+		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want duplicate-edge issue", issues)
 	}
 }

--- a/internal/findingdsl/graph_test_fixture_test.go
+++ b/internal/findingdsl/graph_test_fixture_test.go
@@ -1,0 +1,88 @@
+package findingdsl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type recordingPolicyGraphStore struct {
+	entities []*ports.ProjectedEntity
+	links    []*ports.ProjectedLink
+	deleted  []string
+	request  ports.CypherQueryRequest
+	rows     []ports.CypherRow
+}
+
+func (s *recordingPolicyGraphStore) Ping(context.Context) error { return nil }
+func (s *recordingPolicyGraphStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
+	return nil, nil
+}
+func (s *recordingPolicyGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	s.entities = append(s.entities, entity)
+	return nil
+}
+func (s *recordingPolicyGraphStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	s.links = append(s.links, link)
+	return nil
+}
+func (s *recordingPolicyGraphStore) DeleteProjectedEntity(_ context.Context, urn string) error {
+	s.deleted = append(s.deleted, urn)
+	return nil
+}
+func (s *recordingPolicyGraphStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	s.request = request
+	return s.rows, nil
+}
+
+func TestValidatePolicyGraphFixtureRequiresConnectedTwoEdgePath(t *testing.T) {
+	suite := PolicyRuleTestSuite{APIVersion: APIVersion, Kind: KindPolicyFindingRuleTest, Cases: []PolicyRuleTestCase{{
+		Name: "disconnected edges do not prove a multi-hop path", GraphFixture: &PolicyGraphFixture{
+			TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+				{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+				{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+				{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+				{URN: "d", SourceID: "okta", EntityType: "okta.entitlement"},
+			}, Edges: []PolicyGraphFixtureEdge{
+				{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+				{FromURN: "c", ToURN: "d", SourceID: "okta", Relation: "grants_entitlement"},
+			},
+		}, WantFinding: false,
+	}}}
+	issues := ValidatePolicyRuleTestSuite(suite)
+	if !issuesContain(issues, "must contain a connected path spanning two edges") {
+		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want connected-path issue", issues)
+	}
+}
+
+func TestRunPolicyGraphFixtureProjectsTopologyAndExecutesPolicyCypher(t *testing.T) {
+	rule := PolicyFindingRule{Spec: PolicyFindingRuleSpec{Graph: PolicyRuleGraphFinding{
+		Query: "MATCH (a)-[:RELATION]->(b)-[:RELATION]->(c) RETURN a.urn AS primary_urn", RowLimit: 25,
+		RequiredColumns: []string{"primary_urn", "fingerprint_key", "summary", "resource_urns"},
+	}}}
+	fixture := &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+		{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+		{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+		{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+	}, Edges: []PolicyGraphFixtureEdge{
+		{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+		{FromURN: "b", ToURN: "c", SourceID: "okta", Relation: "assigned_to"},
+	}}
+	store := &recordingPolicyGraphStore{rows: []ports.CypherRow{{Values: map[string]any{
+		"primary_urn": "a", "fingerprint_key": "a|c", "summary": "multi-hop access", "resource_urns": []string{"a", "b", "c"},
+	}}}}
+	if err := runPolicyGraphFixture(context.Background(), store, rule, PolicyRuleTestCase{Name: "complete path", GraphFixture: fixture, WantFinding: true}); err != nil {
+		t.Fatalf("runPolicyGraphFixture() error = %v", err)
+	}
+	if len(store.entities) != 3 || len(store.links) != 2 || len(store.deleted) != 3 {
+		t.Fatalf("projection counts = nodes %d links %d deleted %d", len(store.entities), len(store.links), len(store.deleted))
+	}
+	if !strings.Contains(store.request.Query, "(a)-[:RELATION]->(b)-[:RELATION]->(c)") {
+		t.Fatalf("executed query = %q, want policy Cypher", store.request.Query)
+	}
+	if store.request.Params["tenant_id"] != "fixture" || store.request.Params["row_limit"] != int64(25) {
+		t.Fatalf("executed params = %#v", store.request.Params)
+	}
+}

--- a/internal/findingdsl/graph_test_fixture_test.go
+++ b/internal/findingdsl/graph_test_fixture_test.go
@@ -18,13 +18,15 @@ type recordingPolicyGraphStore struct {
 	entityErrAt int
 }
 
+var errFixtureProjection = errors.New("fixture projection failed")
+
 func (s *recordingPolicyGraphStore) Ping(context.Context) error { return nil }
 func (s *recordingPolicyGraphStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
 	return nil, nil
 }
 func (s *recordingPolicyGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
 	if s.entityErrAt > 0 && len(s.entities)+1 == s.entityErrAt {
-		return errors.New("projection failed")
+		return errFixtureProjection
 	}
 	s.entities = append(s.entities, entity)
 	return nil
@@ -38,7 +40,7 @@ func TestRunPolicyGraphFixtureCleansUpPartialProjection(t *testing.T) {
 	}}
 	store := &recordingPolicyGraphStore{entityErrAt: 2}
 	err := runPolicyGraphFixture(context.Background(), store, PolicyFindingRule{}, PolicyRuleTestCase{GraphFixture: fixture})
-	if err == nil || !strings.Contains(err.Error(), "projection failed") {
+	if !errors.Is(err, errFixtureProjection) {
 		t.Fatalf("runPolicyGraphFixture() error = %v, want projection failure", err)
 	}
 	if len(store.deleted) != 1 || store.deleted[0] != "a" {
@@ -158,5 +160,22 @@ func TestValidatePolicyGraphFixtureRejectsDuplicateEdges(t *testing.T) {
 	issues := ValidatePolicyRuleTestSuite(suite)
 	if !issuesContain(issues, "duplicates an earlier edge") {
 		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want duplicate-edge issue", issues)
+	}
+}
+
+func TestValidatePolicyGraphFixtureRejectsParallelEdgesAsTwoHopPath(t *testing.T) {
+	suite := PolicyRuleTestSuite{APIVersion: APIVersion, Kind: KindPolicyFindingRuleTest, Cases: []PolicyRuleTestCase{{
+		Name: "parallel edges", GraphFixture: &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+			{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+			{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+			{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+		}, Edges: []PolicyGraphFixtureEdge{
+			{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+			{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "assigned_to"},
+		}}, WantEvidenceURNs: []string{"b", "c"}, WantFinding: true,
+	}}}
+	issues := ValidatePolicyRuleTestSuite(suite)
+	if !issuesContain(issues, "must contain a connected path spanning two edges") {
+		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want connected-path issue", issues)
 	}
 }

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -25,11 +25,12 @@ type PolicyRuleTestSuite struct {
 }
 
 type PolicyRuleTestCase struct {
-	Name         string              `json:"name" yaml:"name"`
-	Resource     map[string]any      `json:"resource,omitempty" yaml:"resource,omitempty"`
-	QueryRows    []map[string]any    `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
-	GraphFixture *PolicyGraphFixture `json:"graphFixture,omitempty" yaml:"graphFixture,omitempty"`
-	WantFinding  bool                `json:"wantFinding" yaml:"wantFinding"`
+	Name             string              `json:"name" yaml:"name"`
+	Resource         map[string]any      `json:"resource,omitempty" yaml:"resource,omitempty"`
+	QueryRows        []map[string]any    `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
+	GraphFixture     *PolicyGraphFixture `json:"graphFixture,omitempty" yaml:"graphFixture,omitempty"`
+	WantEvidenceURNs []string            `json:"wantEvidenceUrns,omitempty" yaml:"wantEvidenceUrns,omitempty"`
+	WantFinding      bool                `json:"wantFinding" yaml:"wantFinding"`
 }
 
 // PolicyGraphFixture is a deterministic projected graph used to execute a
@@ -144,6 +145,12 @@ func ValidatePolicyRuleTestSuite(suite PolicyRuleTestSuite) []Issue {
 		}
 		if testCase.GraphFixture != nil {
 			issues = append(issues, validatePolicyGraphFixture(path, idx, testCase)...)
+			if testCase.WantFinding && len(testCase.WantEvidenceURNs) < 2 {
+				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] %q graph finding cases require at least two wantEvidenceUrns", idx, testCase.Name)})
+			}
+			if !testCase.WantFinding && len(testCase.WantEvidenceURNs) != 0 {
+				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] %q passing graph cases must not declare wantEvidenceUrns", idx, testCase.Name)})
+			}
 		}
 	}
 	issues = append(issues, validatePolicyGraphMutationPair(path, suite.Cases)...)

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -146,6 +146,7 @@ func ValidatePolicyRuleTestSuite(suite PolicyRuleTestSuite) []Issue {
 			issues = append(issues, validatePolicyGraphFixture(path, idx, testCase)...)
 		}
 	}
+	issues = append(issues, validatePolicyGraphMutationPair(path, suite.Cases)...)
 	return issues
 }
 

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -2,6 +2,7 @@ package findingdsl
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/writer/cerebro/internal/ports"
 	"gopkg.in/yaml.v3"
 )
 
@@ -23,10 +25,44 @@ type PolicyRuleTestSuite struct {
 }
 
 type PolicyRuleTestCase struct {
-	Name        string           `json:"name" yaml:"name"`
-	Resource    map[string]any   `json:"resource,omitempty" yaml:"resource,omitempty"`
-	QueryRows   []map[string]any `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
-	WantFinding bool             `json:"wantFinding" yaml:"wantFinding"`
+	Name         string              `json:"name" yaml:"name"`
+	Resource     map[string]any      `json:"resource,omitempty" yaml:"resource,omitempty"`
+	QueryRows    []map[string]any    `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
+	GraphFixture *PolicyGraphFixture `json:"graphFixture,omitempty" yaml:"graphFixture,omitempty"`
+	WantFinding  bool                `json:"wantFinding" yaml:"wantFinding"`
+}
+
+// PolicyGraphFixture is a deterministic projected graph used to execute a
+// policy's real Cypher. Multi-hop fixtures require a connected path spanning
+// at least two edges; precomputed query rows do not satisfy this contract.
+type PolicyGraphFixture struct {
+	TenantID string                   `json:"tenantId" yaml:"tenantId"`
+	Nodes    []PolicyGraphFixtureNode `json:"nodes" yaml:"nodes"`
+	Edges    []PolicyGraphFixtureEdge `json:"edges" yaml:"edges"`
+}
+
+type PolicyGraphFixtureNode struct {
+	URN        string            `json:"urn" yaml:"urn"`
+	SourceID   string            `json:"sourceId" yaml:"sourceId"`
+	RuntimeID  string            `json:"runtimeId,omitempty" yaml:"runtimeId,omitempty"`
+	EntityType string            `json:"entityType" yaml:"entityType"`
+	Label      string            `json:"label,omitempty" yaml:"label,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
+}
+
+type PolicyGraphFixtureEdge struct {
+	FromURN    string            `json:"fromUrn" yaml:"fromUrn"`
+	ToURN      string            `json:"toUrn" yaml:"toUrn"`
+	SourceID   string            `json:"sourceId" yaml:"sourceId"`
+	RuntimeID  string            `json:"runtimeId,omitempty" yaml:"runtimeId,omitempty"`
+	Relation   string            `json:"relation" yaml:"relation"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
+}
+
+type PolicyGraphTestStore interface {
+	ports.GraphQueryStore
+	ports.ProjectionGraphStore
+	ports.ProjectionEntityDeleter
 }
 
 func DiscoverPolicyTestSuites(root string) ([]string, error) {
@@ -103,8 +139,11 @@ func ValidatePolicyRuleTestSuite(suite PolicyRuleTestSuite) []Issue {
 		if strings.TrimSpace(testCase.Name) == "" {
 			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d].name is required", idx)})
 		}
-		if len(testCase.Resource) == 0 && len(testCase.QueryRows) == 0 {
-			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] must include resource or queryRows", idx)})
+		if len(testCase.Resource) == 0 && len(testCase.QueryRows) == 0 && testCase.GraphFixture == nil {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] must include resource, queryRows, or graphFixture", idx)})
+		}
+		if testCase.GraphFixture != nil {
+			issues = append(issues, validatePolicyGraphFixture(path, idx, testCase)...)
 		}
 	}
 	return issues
@@ -144,6 +183,11 @@ func RunPolicyRuleTestSuite(root string, suitePath string) []Issue {
 			out = append(out, caseIssues...)
 			continue
 		}
+		if testCase.GraphFixture != nil {
+			// The normal policy test lane validates the topology contract. The
+			// graph integration lane executes these cases against Neo4j.
+			continue
+		}
 		got, err := EvaluatePolicyRuleTestCase(rule, testCase)
 		if err != nil {
 			out = append(out, Issue{Path: suite.RelPath, Message: fmt.Sprintf("cases[%d] %q: %v", idx, testCase.Name, err)})
@@ -151,6 +195,42 @@ func RunPolicyRuleTestSuite(root string, suitePath string) []Issue {
 		}
 		if got != testCase.WantFinding {
 			out = append(out, Issue{Path: suite.RelPath, Message: fmt.Sprintf("cases[%d] %q: finding = %t, want %t", idx, testCase.Name, got, testCase.WantFinding)})
+		}
+	}
+	return out
+}
+
+// RunPolicyRuleTestSuiteWithGraphStore projects each authored topology and
+// executes the policy's real Cypher through the production graph boundary.
+func RunPolicyRuleTestSuiteWithGraphStore(ctx context.Context, root string, suitePath string, store PolicyGraphTestStore) []Issue {
+	suite, issues, err := LoadPolicyRuleTestSuite(root, suitePath)
+	if err != nil {
+		return []Issue{{Path: suitePath, Message: err.Error()}}
+	}
+	if len(issues) != 0 {
+		return issues
+	}
+	policyRel := strings.TrimSpace(suite.Policy)
+	if policyRel == "" {
+		policyRel = policyRelForSuite(suite.RelPath)
+	}
+	rule, ruleIssues, err := LoadPolicyRuleFile(root, filepath.Join(root, filepath.FromSlash(policyRel)))
+	if err != nil {
+		return []Issue{{Path: suite.RelPath, Message: err.Error()}}
+	}
+	if len(ruleIssues) != 0 {
+		return ruleIssues
+	}
+	if strings.TrimSpace(rule.Spec.Graph.Query) == "" {
+		return []Issue{{Path: suite.RelPath, Message: "graphFixture requires spec.graph.query"}}
+	}
+	var out []Issue
+	for idx, testCase := range suite.Cases {
+		if testCase.GraphFixture == nil {
+			continue
+		}
+		if err := runPolicyGraphFixture(ctx, store, rule, testCase); err != nil {
+			out = append(out, Issue{Path: suite.RelPath, Message: fmt.Sprintf("cases[%d] %q: %v", idx, testCase.Name, err)})
 		}
 	}
 	return out
@@ -176,6 +256,15 @@ func EvaluatePolicyRuleTestCase(rule PolicyFindingRule, testCase PolicyRuleTestC
 }
 
 func validatePolicyRuleTestCaseAgainstRule(path string, rule PolicyFindingRule, idx int, testCase PolicyRuleTestCase) []Issue {
+	if testCase.GraphFixture != nil {
+		if strings.TrimSpace(rule.Spec.Graph.Query) == "" {
+			return []Issue{{Path: path, Message: fmt.Sprintf("cases[%d] %q graphFixture requires spec.graph.query", idx, testCase.Name)}}
+		}
+		if len(testCase.Resource) != 0 || len(testCase.QueryRows) != 0 {
+			return []Issue{{Path: path, Message: fmt.Sprintf("cases[%d] %q graphFixture cannot be combined with resource or queryRows", idx, testCase.Name)}}
+		}
+		return nil
+	}
 	if strings.TrimSpace(rule.Spec.Graph.Query) == "" {
 		return nil
 	}

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -7,12 +7,14 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/findingdsl"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/projectionmeta"
 
@@ -580,6 +582,8 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 			t.Fatalf("preserved link missing: %s %s %s", link.FromURN, link.Relation, link.ToURN)
 		}
 	}
+
+	runAuthoredPolicyGraphFixtures(t, ctx, store)
 }
 
 func TestNeo4jDockerBackfillEntityTypedProperties(t *testing.T) {
@@ -682,6 +686,32 @@ func TestNeo4jDockerBackfillEntityTypedProperties(t *testing.T) {
 	}
 	if after.EntitiesMatched != 0 {
 		t.Fatalf("dry-run after backfill matched %d entities, want 0", after.EntitiesMatched)
+	}
+
+}
+
+func runAuthoredPolicyGraphFixtures(t *testing.T, ctx context.Context, store *Store) {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	paths, err := findingdsl.DiscoverPolicyTestSuites(repoRoot)
+	if err != nil {
+		t.Fatalf("discover authored policy graph fixtures: %v", err)
+	}
+	for _, path := range paths {
+		suite, issues, err := findingdsl.LoadPolicyRuleTestSuite(repoRoot, filepath.Join(repoRoot, filepath.FromSlash(path)))
+		if err != nil || len(issues) != 0 {
+			continue // The normal findingdsl lane reports malformed suites.
+		}
+		hasGraphFixture := false
+		for _, testCase := range suite.Cases {
+			hasGraphFixture = hasGraphFixture || testCase.GraphFixture != nil
+		}
+		if !hasGraphFixture {
+			continue
+		}
+		if issues := findingdsl.RunPolicyRuleTestSuiteWithGraphStore(ctx, repoRoot, filepath.Join(repoRoot, filepath.FromSlash(path)), store); len(issues) != 0 {
+			t.Fatalf("authored graph policy suite %s failed: %#v", path, issues)
+		}
 	}
 }
 

--- a/internal/testauthor/policy/author_test.go
+++ b/internal/testauthor/policy/author_test.go
@@ -32,7 +32,7 @@ func TestAuthorWritesRunnablePolicyAndTestsDeterministically(t *testing.T) {
 }
 
 func TestAuthorRejectsUnsupportedPolicySemantics(t *testing.T) {
-	intent := Intent{ID: "complex", Domain: "aws", Name: "Complex", Description: "Complex policy.", Severity: "high", Conditions: []string{`cmp_ne(path(resource, "state"), "safe")`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}}
+	intent := Intent{ID: "complex", Domain: "aws", Name: "Complex", Description: "Complex policy.", Severity: "high", Conditions: []string{`matches_value(path(resource, "state"), "unsafe.*")`}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}}
 	if _, err := Author(intent); err == nil {
 		t.Fatal("Author() error = nil")
 	}
@@ -59,5 +59,32 @@ func TestAuthorBuildsNestedResourceFixtures(t *testing.T) {
 	}
 	if _, flat := artifacts.Suite.Cases[0].Resource["authentication.type"]; flat {
 		t.Fatalf("fixture used a flat nested path: %#v", artifacts.Suite.Cases[0].Resource)
+	}
+}
+
+func TestAuthorBuildsScalarComparisonFixtures(t *testing.T) {
+	tests := []struct{ name, condition string }{
+		{name: "not equal", condition: `cmp_ne(path(resource, "compliant"), true)`},
+		{name: "greater", condition: `cmp_gt(path(resource, "age_days"), 90)`},
+		{name: "less", condition: `cmp_lt(path(resource, "score"), 10)`},
+		{name: "greater equal", condition: `cmp_ge(path(resource, "count"), 2)`},
+		{name: "less equal", condition: `cmp_le(path(resource, "count"), 2)`},
+		{name: "membership", condition: `in_list(path(resource, "state"), ["open","pending"])`},
+		{name: "null equality", condition: `cmp_eq(path(resource, "key_id"), null)`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			intent := Intent{ID: "scalar", Domain: "aws", Name: "Scalar", Description: "Scalar policy.", Severity: "high", Conditions: []string{test.condition}, Frameworks: []findingdsl.PolicyFramework{{Name: "CIS", Controls: []string{"1"}}}}
+			artifacts, err := Author(intent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, testCase := range artifacts.Suite.Cases {
+				got, err := findingdsl.EvaluatePolicyRuleTestCase(artifacts.Rule, testCase)
+				if err != nil || got != testCase.WantFinding {
+					t.Fatalf("case %q got %t want %t err %v", testCase.Name, got, testCase.WantFinding, err)
+				}
+			}
+		})
 	}
 }

--- a/policies/ai/ai-agent-human-approval-destructive-actions.test.yaml
+++ b/policies/ai/ai-agent-human-approval-destructive-actions.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        agent_human_approval_destructive_actions_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        agent_human_approval_destructive_actions_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-agent-secret-redaction.test.yaml
+++ b/policies/ai/ai-agent-secret-redaction.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        agent_secret_redaction_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        agent_secret_redaction_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-agent-tool-allowlist-required.test.yaml
+++ b/policies/ai/ai-agent-tool-allowlist-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        agent_tool_allowlist_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        agent_tool_allowlist_required: true
+      wantFinding: false

--- a/policies/ai/ai-data-retention-reviewed.test.yaml
+++ b/policies/ai/ai-data-retention-reviewed.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        data_retention_reviewed_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        data_retention_reviewed_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-embedding-store-encrypted.test.yaml
+++ b/policies/ai/ai-embedding-store-encrypted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        embedding_store_encrypted: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        embedding_store_encrypted: true
+      wantFinding: false

--- a/policies/ai/ai-foundation-model-safety-card-required.test.yaml
+++ b/policies/ai/ai-foundation-model-safety-card-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        foundation_model_safety_card_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        foundation_model_safety_card_required: true
+      wantFinding: false

--- a/policies/ai/ai-genai-secure-development-review.test.yaml
+++ b/policies/ai/ai-genai-secure-development-review.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        genai_secure_development_review_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        genai_secure_development_review_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-high-risk-use-case-registered.test.yaml
+++ b/policies/ai/ai-high-risk-use-case-registered.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        high_risk_use_case_registered_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        high_risk_use_case_registered_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-model-evaluation-before-release.test.yaml
+++ b/policies/ai/ai-model-evaluation-before-release.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        model_evaluation_before_release_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        model_evaluation_before_release_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-model-incident-runbook.test.yaml
+++ b/policies/ai/ai-model-incident-runbook.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        model_incident_runbook_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        model_incident_runbook_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-model-monitoring-drift-threshold.test.yaml
+++ b/policies/ai/ai-model-monitoring-drift-threshold.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        model_monitoring_drift_threshold_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        model_monitoring_drift_threshold_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-model-rate-limit-cost-guardrail.test.yaml
+++ b/policies/ai/ai-model-rate-limit-cost-guardrail.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        model_rate_limit_cost_guardrail_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        model_rate_limit_cost_guardrail_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-model-supply-chain-attestation.test.yaml
+++ b/policies/ai/ai-model-supply-chain-attestation.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        model_supply_chain_attestation_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        model_supply_chain_attestation_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-prompt-injection-test-coverage.test.yaml
+++ b/policies/ai/ai-prompt-injection-test-coverage.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        prompt_injection_test_coverage_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        prompt_injection_test_coverage_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-rag-source-citation-required.test.yaml
+++ b/policies/ai/ai-rag-source-citation-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        rag_source_citation_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        rag_source_citation_required: true
+      wantFinding: false

--- a/policies/ai/ai-rag-vector-index-access-control.test.yaml
+++ b/policies/ai/ai-rag-vector-index-access-control.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        rag_vector_index_access_control_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        rag_vector_index_access_control_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-sensitive-output-filtering.test.yaml
+++ b/policies/ai/ai-sensitive-output-filtering.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        sensitive_output_filtering_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        sensitive_output_filtering_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-system-owner-assigned.test.yaml
+++ b/policies/ai/ai-system-owner-assigned.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        system_owner_assigned: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        system_owner_assigned: true
+      wantFinding: false

--- a/policies/ai/ai-third-party-model-risk-review.test.yaml
+++ b/policies/ai/ai-third-party-model-risk-review.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        third_party_model_risk_review_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        third_party_model_risk_review_compliant: true
+      wantFinding: false

--- a/policies/ai/ai-training-data-provenance.test.yaml
+++ b/policies/ai/ai-training-data-provenance.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        training_data_provenance_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        training_data_provenance_compliant: true
+      wantFinding: false

--- a/policies/ai/aws-bedrock-agent-action-group-approval-required.test.yaml
+++ b/policies/ai/aws-bedrock-agent-action-group-approval-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        bedrock_agent_action_group_approval_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        bedrock_agent_action_group_approval_required: true
+      wantFinding: false

--- a/policies/ai/aws-bedrock-guardrail-content-filter-enabled.test.yaml
+++ b/policies/ai/aws-bedrock-guardrail-content-filter-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        bedrock_guardrail_content_filter_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        bedrock_guardrail_content_filter_enabled: true
+      wantFinding: false

--- a/policies/ai/aws-bedrock-knowledge-base-encrypted.test.yaml
+++ b/policies/ai/aws-bedrock-knowledge-base-encrypted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        bedrock_knowledge_base_encrypted: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        bedrock_knowledge_base_encrypted: true
+      wantFinding: false

--- a/policies/ai/aws-bedrock-model-invocation-logging-enabled.test.yaml
+++ b/policies/ai/aws-bedrock-model-invocation-logging-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        bedrock_model_invocation_logging_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        bedrock_model_invocation_logging_enabled: true
+      wantFinding: false

--- a/policies/ai/aws-bedrock-no-guardrails.test.yaml
+++ b/policies/ai/aws-bedrock-no-guardrails.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        guardrail_identifier: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        guardrail_identifier: true
+      wantFinding: false

--- a/policies/ai/aws-sagemaker-endpoint-encryption.test.yaml
+++ b/policies/ai/aws-sagemaker-endpoint-encryption.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        kms_key_id: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        kms_key_id: true
+      wantFinding: false

--- a/policies/ai/aws-sagemaker-endpoint-network-isolated.test.yaml
+++ b/policies/ai/aws-sagemaker-endpoint-network-isolated.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        sagemaker_endpoint_network_isolated_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        sagemaker_endpoint_network_isolated_compliant: true
+      wantFinding: false

--- a/policies/ai/aws-sagemaker-notebook-no-direct-internet.test.yaml
+++ b/policies/ai/aws-sagemaker-notebook-no-direct-internet.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        sagemaker_notebook_no_direct_internet_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        sagemaker_notebook_no_direct_internet_compliant: true
+      wantFinding: false

--- a/policies/ai/aws-sagemaker-training-encryption.test.yaml
+++ b/policies/ai/aws-sagemaker-training-encryption.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        output_data_config:
+            kms_key_id: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        output_data_config:
+            kms_key_id: true
+      wantFinding: false

--- a/policies/ai/aws-sagemaker-training-vpc.test.yaml
+++ b/policies/ai/aws-sagemaker-training-vpc.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        vpc_config: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        vpc_config: true
+      wantFinding: false

--- a/policies/ai/azure-openai-content-filter-enabled.test.yaml
+++ b/policies/ai/azure-openai-content-filter-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        openai_content_filter_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        openai_content_filter_enabled: true
+      wantFinding: false

--- a/policies/ai/gcp-vertex-dataset-cmek.test.yaml
+++ b/policies/ai/gcp-vertex-dataset-cmek.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        vertex_dataset_cmek_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        vertex_dataset_cmek_compliant: true
+      wantFinding: false

--- a/policies/ai/gcp-vertex-endpoint-public.test.yaml
+++ b/policies/ai/gcp-vertex-endpoint-public.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        network: null
+        private_service_connect_config: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        network: true
+        private_service_connect_config: null
+      wantFinding: false

--- a/policies/ai/gcp-vertex-model-endpoint-private.test.yaml
+++ b/policies/ai/gcp-vertex-model-endpoint-private.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        vertex_model_endpoint_private_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        vertex_model_endpoint_private_compliant: true
+      wantFinding: false

--- a/policies/ai/huggingface-model-no-scanning.test.yaml
+++ b/policies/ai/huggingface-model-no-scanning.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        security_scan_status: passed-passing
+        source_type: external
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        security_scan_status: passed-passing
+        source_type: external-passing
+      wantFinding: false

--- a/policies/api/api-endpoint-no-authentication.test.yaml
+++ b/policies/api/api-endpoint-no-authentication.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        endpoint_no_authentication_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        endpoint_no_authentication_compliant: true
+      wantFinding: false

--- a/policies/api/api-mtls-required-missing-sensitive-service.test.yaml
+++ b/policies/api/api-mtls-required-missing-sensitive-service.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        mtls_required_missing_sensitive_service: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        mtls_required_missing_sensitive_service: true
+      wantFinding: false

--- a/policies/api/api-shadow-endpoint-detected.test.yaml
+++ b/policies/api/api-shadow-endpoint-detected.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        shadow_endpoint_detected_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        shadow_endpoint_detected_compliant: true
+      wantFinding: false

--- a/policies/api/aws-api-gateway-no-auth.test.yaml
+++ b/policies/api/aws-api-gateway-no-auth.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        api_key_required: false
+        authorization_type: NONE
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        api_key_required: false
+        authorization_type: NONE-passing
+      wantFinding: false

--- a/policies/aws/aws-access-analyzer-unused-access-finding.test.yaml
+++ b/policies/aws/aws-access-analyzer-unused-access-finding.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        access_analyzer_unused_access_finding_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        access_analyzer_unused_access_finding_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-account-alternate-contact-security.test.yaml
+++ b/policies/aws/aws-account-alternate-contact-security.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        account_alternate_contact_security_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        account_alternate_contact_security_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-account-security-contact-configured.test.yaml
+++ b/policies/aws/aws-account-security-contact-configured.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        account_security_contact_configured: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        account_security_contact_configured: true
+      wantFinding: false

--- a/policies/aws/aws-backup-vault-encrypted.test.yaml
+++ b/policies/aws/aws-backup-vault-encrypted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        backup_vault_encrypted: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        backup_vault_encrypted: true
+      wantFinding: false

--- a/policies/aws/aws-backup-vault-locked.test.yaml
+++ b/policies/aws/aws-backup-vault-locked.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        backup_vault_locked_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        backup_vault_locked_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-cloudformation-stack-drift-detected.test.yaml
+++ b/policies/aws/aws-cloudformation-stack-drift-detected.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cloudformation_stack_drift_detected_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cloudformation_stack_drift_detected_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-cloudformation-stack-termination-protection.test.yaml
+++ b/policies/aws/aws-cloudformation-stack-termination-protection.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cloudformation_stack_termination_protection_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cloudformation_stack_termination_protection_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-cloudfront-origin-access-control-required.test.yaml
+++ b/policies/aws/aws-cloudfront-origin-access-control-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cloudfront_origin_access_control_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cloudfront_origin_access_control_required: true
+      wantFinding: false

--- a/policies/aws/aws-cloudfront-response-headers-policy-security.test.yaml
+++ b/policies/aws/aws-cloudfront-response-headers-policy-security.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cloudfront_response_headers_policy_security_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cloudfront_response_headers_policy_security_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-cloudfront-waf-enabled.test.yaml
+++ b/policies/aws/aws-cloudfront-waf-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cloudfront_waf_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cloudfront_waf_enabled: true
+      wantFinding: false

--- a/policies/aws/aws-cloudtrail-enabled.test.yaml
+++ b/policies/aws/aws-cloudtrail-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        is_multi_region_trail: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        is_multi_region_trail: true
+      wantFinding: false

--- a/policies/aws/aws-cloudtrail-kms-encryption.test.yaml
+++ b/policies/aws/aws-cloudtrail-kms-encryption.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        kms_key_id: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        kms_key_id: true
+      wantFinding: false

--- a/policies/aws/aws-cloudtrail-log-integrity.test.yaml
+++ b/policies/aws/aws-cloudtrail-log-integrity.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        log_file_validation_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        log_file_validation_enabled: true
+      wantFinding: false

--- a/policies/aws/aws-cloudwatch-alarm-missing.test.yaml
+++ b/policies/aws/aws-cloudwatch-alarm-missing.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        associated_alarms_count: 0
+        cloud_watch_logs_log_group_arn: true
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        associated_alarms_count: 0
+        cloud_watch_logs_log_group_arn: null
+      wantFinding: false

--- a/policies/aws/aws-cloudwatch-log-group-encrypted.test.yaml
+++ b/policies/aws/aws-cloudwatch-log-group-encrypted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        kms_key_id: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        kms_key_id: true
+      wantFinding: false

--- a/policies/aws/aws-cloudwatch-log-group-retention.test.yaml
+++ b/policies/aws/aws-cloudwatch-log-group-retention.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        retention_in_days: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        retention_in_days: true
+      wantFinding: false

--- a/policies/aws/aws-codebuild-source-credential.test.yaml
+++ b/policies/aws/aws-codebuild-source-credential.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        auth_type: BASIC_AUTH
+        server_type: GITHUB
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        auth_type: BASIC_AUTH-passing
+        server_type: GITHUB
+      wantFinding: false

--- a/policies/aws/aws-config-enabled.test.yaml
+++ b/policies/aws/aws-config-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        recording: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        recording: true
+      wantFinding: false

--- a/policies/aws/aws-ebs-encryption-default.test.yaml
+++ b/policies/aws/aws-ebs-encryption-default.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        ebs_encryption_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        ebs_encryption_enabled: true
+      wantFinding: false

--- a/policies/aws/aws-ec2-detailed-monitoring.test.yaml
+++ b/policies/aws/aws-ec2-detailed-monitoring.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        monitoring:
+            state: enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        monitoring:
+            state: enabled
+      wantFinding: false

--- a/policies/aws/aws-ec2-ebs-volume-encrypted.test.yaml
+++ b/policies/aws/aws-ec2-ebs-volume-encrypted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        encrypted: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        encrypted: true
+      wantFinding: false

--- a/policies/aws/aws-ec2-instance-profile.test.yaml
+++ b/policies/aws/aws-ec2-instance-profile.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        iam_instance_profile: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        iam_instance_profile: true
+      wantFinding: false

--- a/policies/aws/aws-ecr-immutable-tags.test.yaml
+++ b/policies/aws/aws-ecr-immutable-tags.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        image_tag_mutability: IMMUTABLE-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        image_tag_mutability: IMMUTABLE
+      wantFinding: false

--- a/policies/aws/aws-ecr-scan-on-push.test.yaml
+++ b/policies/aws/aws-ecr-scan-on-push.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        image_scanning_configuration:
+            scan_on_push: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        image_scanning_configuration:
+            scan_on_push: true
+      wantFinding: false

--- a/policies/aws/aws-ecs-task-definition-no-privileged.test.yaml
+++ b/policies/aws/aws-ecs-task-definition-no-privileged.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        ecs_task_definition_no_privileged_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        ecs_task_definition_no_privileged_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-ecs-task-definition-nonroot-user.test.yaml
+++ b/policies/aws/aws-ecs-task-definition-nonroot-user.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        ecs_task_definition_nonroot_user_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        ecs_task_definition_nonroot_user_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-ecs-task-definition-readonly-root.test.yaml
+++ b/policies/aws/aws-ecs-task-definition-readonly-root.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        ecs_task_definition_readonly_root_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        ecs_task_definition_readonly_root_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-efs-backup-enabled.test.yaml
+++ b/policies/aws/aws-efs-backup-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        efs_backup_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        efs_backup_enabled: true
+      wantFinding: false

--- a/policies/aws/aws-efs-encrypted.test.yaml
+++ b/policies/aws/aws-efs-encrypted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        efs_encrypted: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        efs_encrypted: true
+      wantFinding: false

--- a/policies/aws/aws-eks-logging.test.yaml
+++ b/policies/aws/aws-eks-logging.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        logging:
+            cluster_logging:
+                enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        logging:
+            cluster_logging:
+                enabled: true
+      wantFinding: false

--- a/policies/aws/aws-eks-private-endpoint.test.yaml
+++ b/policies/aws/aws-eks-private-endpoint.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        resources_vpc_config:
+            endpoint_private_access: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        resources_vpc_config:
+            endpoint_private_access: true
+      wantFinding: false

--- a/policies/aws/aws-eks-secrets-encryption.test.yaml
+++ b/policies/aws/aws-eks-secrets-encryption.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        encryption_config: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        encryption_config: true
+      wantFinding: false

--- a/policies/aws/aws-elb-internet-facing-no-waf.test.yaml
+++ b/policies/aws/aws-elb-internet-facing-no-waf.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        scheme: internet-facing
+        type: application
+        waf_web_acl_arn: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        scheme: internet-facing-passing
+        type: application
+        waf_web_acl_arn: null
+      wantFinding: false

--- a/policies/aws/aws-eventbridge-rule-cross-account-target.test.yaml
+++ b/policies/aws/aws-eventbridge-rule-cross-account-target.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        eventbridge_rule_cross_account_target_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        eventbridge_rule_cross_account_target_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-guardduty-disabled.test.yaml
+++ b/policies/aws/aws-guardduty-disabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        status: ENABLED-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        status: ENABLED
+      wantFinding: false

--- a/policies/aws/aws-iam-access-key-old.test.yaml
+++ b/policies/aws/aws-iam-access-key-old.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        create_date_days: 91
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        create_date_days: 90
+      wantFinding: false

--- a/policies/aws/aws-iam-expired-certificates.test.yaml
+++ b/policies/aws/aws-iam-expired-certificates.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        expiration: ""
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        expiration: now()
+      wantFinding: false

--- a/policies/aws/aws-iam-mfa.test.yaml
+++ b/policies/aws/aws-iam-mfa.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        mfa_active: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        mfa_active: true
+      wantFinding: false

--- a/policies/aws/aws-iam-password-policy.test.yaml
+++ b/policies/aws/aws-iam-password-policy.test.yaml
@@ -1,0 +1,21 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        max_password_age: 91
+        minimum_password_length: 13
+        require_lowercase_characters: false
+        require_numbers: false
+        require_symbols: false
+        require_uppercase_characters: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        max_password_age: 91
+        minimum_password_length: 14
+        require_lowercase_characters: false
+        require_numbers: false
+        require_symbols: false
+        require_uppercase_characters: false
+      wantFinding: false

--- a/policies/aws/aws-iam-root-mfa.test.yaml
+++ b/policies/aws/aws-iam-root-mfa.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        account_mfa_enabled: 2
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        account_mfa_enabled: 1
+      wantFinding: false

--- a/policies/aws/aws-iam-saml-provider-stale.test.yaml
+++ b/policies/aws/aws-iam-saml-provider-stale.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        valid_until_days: -1
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        valid_until_days: 0
+      wantFinding: false

--- a/policies/aws/aws-iam-single-access-key.test.yaml
+++ b/policies/aws/aws-iam-single-access-key.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        active_access_key_count: 2
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        active_access_key_count: 1
+      wantFinding: false

--- a/policies/aws/aws-iam-user-console-inactive.test.yaml
+++ b/policies/aws/aws-iam-user-console-inactive.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        password_enabled: true
+        password_last_used_days: 91
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        password_enabled: false
+        password_last_used_days: 91
+      wantFinding: false

--- a/policies/aws/aws-iam-users-via-groups.test.yaml
+++ b/policies/aws/aws-iam-users-via-groups.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        attached_policy_count: 1
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        attached_policy_count: 0
+      wantFinding: false

--- a/policies/aws/aws-kms-key-deletion-scheduled.test.yaml
+++ b/policies/aws/aws-kms-key-deletion-scheduled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        kms_key_deletion_scheduled_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        kms_key_deletion_scheduled_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-kms-key-rotation.test.yaml
+++ b/policies/aws/aws-kms-key-rotation.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        key_manager: CUSTOMER
+        key_rotation_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        key_manager: CUSTOMER-passing
+        key_rotation_enabled: false
+      wantFinding: false

--- a/policies/aws/aws-lambda-runtime-supported.test.yaml
+++ b/policies/aws/aws-lambda-runtime-supported.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        runtime: '[''python2.7'
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        runtime: '[''python2.7-passing'
+      wantFinding: false

--- a/policies/aws/aws-lambda-vpc.test.yaml
+++ b/policies/aws/aws-lambda-vpc.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        vpc_config:
+            subnet_ids: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        vpc_config:
+            subnet_ids: true
+      wantFinding: false

--- a/policies/aws/aws-organizations-policy-detached.test.yaml
+++ b/policies/aws/aws-organizations-policy-detached.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        organizations_policy_detached_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        organizations_policy_detached_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-organizations-scp-root-guardrail.test.yaml
+++ b/policies/aws/aws-organizations-scp-root-guardrail.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        organizations_scp_root_guardrail_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        organizations_scp_root_guardrail_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-password-policy-length.test.yaml
+++ b/policies/aws/aws-password-policy-length.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        minimum_password_length: 13
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        minimum_password_length: 14
+      wantFinding: false

--- a/policies/aws/aws-password-policy-reuse.test.yaml
+++ b/policies/aws/aws-password-policy-reuse.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        password_reuse_prevention: 23
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        password_reuse_prevention: 24
+      wantFinding: false

--- a/policies/aws/aws-rds-auto-minor-upgrade.test.yaml
+++ b/policies/aws/aws-rds-auto-minor-upgrade.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        auto_minor_version_upgrade: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        auto_minor_version_upgrade: true
+      wantFinding: false

--- a/policies/aws/aws-rds-backup-enabled.test.yaml
+++ b/policies/aws/aws-rds-backup-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        backup_retention_period: 6
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        backup_retention_period: 7
+      wantFinding: false

--- a/policies/aws/aws-rds-deletion-protection.test.yaml
+++ b/policies/aws/aws-rds-deletion-protection.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        deletion_protection: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        deletion_protection: true
+      wantFinding: false

--- a/policies/aws/aws-rds-encryption.test.yaml
+++ b/policies/aws/aws-rds-encryption.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        storage_encrypted: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        storage_encrypted: true
+      wantFinding: false

--- a/policies/aws/aws-rds-iam-auth.test.yaml
+++ b/policies/aws/aws-rds-iam-auth.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        iam_database_authentication_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        iam_database_authentication_enabled: true
+      wantFinding: false

--- a/policies/aws/aws-rds-logging-enabled.test.yaml
+++ b/policies/aws/aws-rds-logging-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        enabled_cloudwatch_logs_exports: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        enabled_cloudwatch_logs_exports: true
+      wantFinding: false

--- a/policies/aws/aws-rds-multi-az.test.yaml
+++ b/policies/aws/aws-rds-multi-az.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        engine: aurora-passing
+        multi_az: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        engine: aurora-passing
+        multi_az: true
+      wantFinding: false

--- a/policies/aws/aws-route53-resolver-query-logging.test.yaml
+++ b/policies/aws/aws-route53-resolver-query-logging.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        route53_resolver_query_logging_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        route53_resolver_query_logging_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-s3-bucket-encryption.test.yaml
+++ b/policies/aws/aws-s3-bucket-encryption.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        encryption_configuration: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        encryption_configuration: true
+      wantFinding: false

--- a/policies/aws/aws-s3-bucket-logging.test.yaml
+++ b/policies/aws/aws-s3-bucket-logging.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        logging_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        logging_enabled: true
+      wantFinding: false

--- a/policies/aws/aws-s3-bucket-mfa-delete.test.yaml
+++ b/policies/aws/aws-s3-bucket-mfa-delete.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        versioning:
+            mfa_delete: Enabled-passing
+            status: Enabled
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        versioning:
+            mfa_delete: Enabled-passing
+            status: Enabled-passing
+      wantFinding: false

--- a/policies/aws/aws-s3-bucket-policy-public.test.yaml
+++ b/policies/aws/aws-s3-bucket-policy-public.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        policy:
+            Statement:
+                Condition: null
+                Effect: Allow
+                Principal: '*'
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        policy:
+            Statement:
+                Condition: null
+                Effect: Allow
+                Principal: '*-passing'
+      wantFinding: false

--- a/policies/aws/aws-s3-bucket-ssl-only.test.yaml
+++ b/policies/aws/aws-s3-bucket-ssl-only.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        policy_requires_ssl: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        policy_requires_ssl: true
+      wantFinding: false

--- a/policies/aws/aws-s3-bucket-versioning.test.yaml
+++ b/policies/aws/aws-s3-bucket-versioning.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        versioning:
+            status: Enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        versioning:
+            status: Enabled
+      wantFinding: false

--- a/policies/aws/aws-s3-cross-region-replication.test.yaml
+++ b/policies/aws/aws-s3-cross-region-replication.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        replication_configuration: null
+        tags:
+            critical: true
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        replication_configuration: true
+        tags:
+            critical: true
+      wantFinding: false

--- a/policies/aws/aws-s3-https-only.test.yaml
+++ b/policies/aws/aws-s3-https-only.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        policy_requires_ssl: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        policy_requires_ssl: true
+      wantFinding: false

--- a/policies/aws/aws-secretsmanager-rotation.test.yaml
+++ b/policies/aws/aws-secretsmanager-rotation.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        rotation_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        rotation_enabled: true
+      wantFinding: false

--- a/policies/aws/aws-secretsmanager-secret-replicated-critical.test.yaml
+++ b/policies/aws/aws-secretsmanager-secret-replicated-critical.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        secretsmanager_secret_replicated_critical_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        secretsmanager_secret_replicated_critical_compliant: true
+      wantFinding: false

--- a/policies/aws/aws-secretsmanager-unused.test.yaml
+++ b/policies/aws/aws-secretsmanager-unused.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        last_accessed_date_days: 91
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        last_accessed_date_days: 90
+      wantFinding: false

--- a/policies/aws/aws-security-hub-enabled.test.yaml
+++ b/policies/aws/aws-security-hub-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        hub_arn: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        hub_arn: true
+      wantFinding: false

--- a/policies/aws/aws-sns-topic-encrypted.test.yaml
+++ b/policies/aws/aws-sns-topic-encrypted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        kms_master_key_id: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        kms_master_key_id: true
+      wantFinding: false

--- a/policies/aws/aws-sqs-queue-encrypted.test.yaml
+++ b/policies/aws/aws-sqs-queue-encrypted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        kms_master_key_id: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        kms_master_key_id: true
+      wantFinding: false

--- a/policies/azure/azure-aks-local-accounts-enabled.test.yaml
+++ b/policies/azure/azure-aks-local-accounts-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        aks_local_accounts_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        aks_local_accounts_enabled: true
+      wantFinding: false

--- a/policies/azure/azure-aks-rbac.test.yaml
+++ b/policies/azure/azure-aks-rbac.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        enable_rbac: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        enable_rbac: true
+      wantFinding: false

--- a/policies/azure/azure-appservice-https.test.yaml
+++ b/policies/azure/azure-appservice-https.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        https_only: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        https_only: true
+      wantFinding: false

--- a/policies/azure/azure-cosmosdb-local-auth-enabled.test.yaml
+++ b/policies/azure/azure-cosmosdb-local-auth-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cosmosdb_local_auth_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cosmosdb_local_auth_enabled: true
+      wantFinding: false

--- a/policies/azure/azure-cosmosdb-public.test.yaml
+++ b/policies/azure/azure-cosmosdb-public.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        is_virtual_network_filter_enabled: false
+        public_network_access: Enabled
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        is_virtual_network_filter_enabled: false
+        public_network_access: Enabled-passing
+      wantFinding: false

--- a/policies/azure/azure-defender-storage.test.yaml
+++ b/policies/azure/azure-defender-storage.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        defender_for_storage_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        defender_for_storage_enabled: true
+      wantFinding: false

--- a/policies/azure/azure-keyvault-expiry.test.yaml
+++ b/policies/azure/azure-keyvault-expiry.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        attributes:
+            expires: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        attributes:
+            expires: true
+      wantFinding: false

--- a/policies/azure/azure-keyvault-public-network-enabled.test.yaml
+++ b/policies/azure/azure-keyvault-public-network-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        keyvault_public_network_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        keyvault_public_network_enabled: true
+      wantFinding: false

--- a/policies/azure/azure-keyvault-purge-protection.test.yaml
+++ b/policies/azure/azure-keyvault-purge-protection.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        properties:
+            enable_purge_protection: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        properties:
+            enable_purge_protection: true
+      wantFinding: false

--- a/policies/azure/azure-keyvault-soft-delete.test.yaml
+++ b/policies/azure/azure-keyvault-soft-delete.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        properties:
+            enable_soft_delete: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        properties:
+            enable_soft_delete: true
+      wantFinding: false

--- a/policies/azure/azure-postgresql-ssl.test.yaml
+++ b/policies/azure/azure-postgresql-ssl.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        ssl_enforcement: Enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        ssl_enforcement: Enabled
+      wantFinding: false

--- a/policies/azure/azure-service-principal-secret-no-expiry.test.yaml
+++ b/policies/azure/azure-service-principal-secret-no-expiry.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        service_principal_secret_no_expiry_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        service_principal_secret_no_expiry_compliant: true
+      wantFinding: false

--- a/policies/azure/azure-sp-credential-expiring.test.yaml
+++ b/policies/azure/azure-sp-credential-expiring.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        password_credentials:
+            end_date_time_days: 29
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        password_credentials:
+            end_date_time_days: 30
+      wantFinding: false

--- a/policies/azure/azure-sql-ad-admin.test.yaml
+++ b/policies/azure/azure-sql-ad-admin.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        azure_ad_administrator: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        azure_ad_administrator: true
+      wantFinding: false

--- a/policies/azure/azure-sql-auditing.test.yaml
+++ b/policies/azure/azure-sql-auditing.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        auditing_state: Enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        auditing_state: Enabled
+      wantFinding: false

--- a/policies/azure/azure-sql-public-network-enabled.test.yaml
+++ b/policies/azure/azure-sql-public-network-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        sql_public_network_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        sql_public_network_enabled: true
+      wantFinding: false

--- a/policies/azure/azure-sql-tde.test.yaml
+++ b/policies/azure/azure-sql-tde.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        transparent_data_encryption:
+            status: Enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        transparent_data_encryption:
+            status: Enabled
+      wantFinding: false

--- a/policies/azure/azure-storage-https.test.yaml
+++ b/policies/azure/azure-storage-https.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        enable_https_traffic_only: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        enable_https_traffic_only: true
+      wantFinding: false

--- a/policies/azure/azure-storage-min-tls.test.yaml
+++ b/policies/azure/azure-storage-min-tls.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        minimum_tls_version: TLS1_2-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        minimum_tls_version: TLS1_2
+      wantFinding: false

--- a/policies/azure/azure-storage-network-default-deny.test.yaml
+++ b/policies/azure/azure-storage-network-default-deny.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        network_rule_set:
+            default_action: Deny-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        network_rule_set:
+            default_action: Deny
+      wantFinding: false

--- a/policies/azure/azure-storage-public-write.test.yaml
+++ b/policies/azure/azure-storage-public-write.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        immutability_policy: null
+        public_access: None-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        immutability_policy: null
+        public_access: None
+      wantFinding: false

--- a/policies/azure/azure-storage-shared-key-access-enabled.test.yaml
+++ b/policies/azure/azure-storage-shared-key-access-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        storage_shared_key_access_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        storage_shared_key_access_enabled: true
+      wantFinding: false

--- a/policies/azure/azure-vm-disk-encryption.test.yaml
+++ b/policies/azure/azure-vm-disk-encryption.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        storage_profile:
+            os_disk:
+                encryption_settings:
+                    enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        storage_profile:
+            os_disk:
+                encryption_settings:
+                    enabled: true
+      wantFinding: false

--- a/policies/azure/azure-vm-public-ip-rdp.test.yaml
+++ b/policies/azure/azure-vm-public-ip-rdp.test.yaml
@@ -1,0 +1,21 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        network_security_group:
+            rules:
+                access: Allow
+                destination_port: "3389"
+                source_address_prefix: '*'
+        public_ip_address: true
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        network_security_group:
+            rules:
+                access: Allow
+                destination_port: "3389"
+                source_address_prefix: '*'
+        public_ip_address: null
+      wantFinding: false

--- a/policies/azure/azure-vm-public-ip-ssh.test.yaml
+++ b/policies/azure/azure-vm-public-ip-ssh.test.yaml
@@ -1,0 +1,21 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        network_security_group:
+            rules:
+                access: Allow
+                destination_port: "22"
+                source_address_prefix: '*'
+        public_ip_address: true
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        network_security_group:
+            rules:
+                access: Allow
+                destination_port: "22"
+                source_address_prefix: '*'
+        public_ip_address: null
+      wantFinding: false

--- a/policies/azure/azure-vm-unmanaged-disk.test.yaml
+++ b/policies/azure/azure-vm-unmanaged-disk.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        storage_profile:
+            os_disk:
+                managed_disk: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        storage_profile:
+            os_disk:
+                managed_disk: true
+      wantFinding: false

--- a/policies/cerebro/aws-user-inactive-admin-no-mfa.test.yaml
+++ b/policies/cerebro/aws-user-inactive-admin-no-mfa.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        has_admin_role: true
+        last_activity_days_ago: 91
+        mfa_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        has_admin_role: false
+        last_activity_days_ago: 91
+        mfa_enabled: false
+      wantFinding: false

--- a/policies/cerebro/aws-user-inactive-data-no-mfa.test.yaml
+++ b/policies/cerebro/aws-user-inactive-data-no-mfa.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        has_sensitive_data_access: true
+        last_activity_days_ago: 91
+        mfa_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        has_sensitive_data_access: false
+        last_activity_days_ago: 91
+        mfa_enabled: false
+      wantFinding: false

--- a/policies/cerebro/bucket-public-low-exposure.test.yaml
+++ b/policies/cerebro/bucket-public-low-exposure.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        is_public: true
+        object_count: 1
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        is_public: false
+        object_count: 1
+      wantFinding: false

--- a/policies/cerebro/group-excessive-high-priv.test.yaml
+++ b/policies/cerebro/group-excessive-high-priv.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        high_privilege_role_count: 6
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        high_privilege_role_count: 5
+      wantFinding: false

--- a/policies/cerebro/sa-inactive-assigned.test.yaml
+++ b/policies/cerebro/sa-inactive-assigned.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        assigned_resources_count: 1
+        has_high_privilege: true
+        last_activity_days_ago: 91
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        assigned_resources_count: 1
+        has_high_privilege: false
+        last_activity_days_ago: 91
+      wantFinding: false

--- a/policies/cerebro/sa-inactive-privileged.test.yaml
+++ b/policies/cerebro/sa-inactive-privileged.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        has_high_privilege: true
+        last_activity_days_ago: 91
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        has_high_privilege: false
+        last_activity_days_ago: 91
+      wantFinding: false

--- a/policies/cerebro/user-excessive-high-priv.test.yaml
+++ b/policies/cerebro/user-excessive-high-priv.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        high_privilege_role_count: 6
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        high_privilege_role_count: 5
+      wantFinding: false

--- a/policies/cerebro/vm-dormant-sa.test.yaml
+++ b/policies/cerebro/vm-dormant-sa.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        service_account:
+            has_high_privilege: true
+            last_activity_days_ago: 91
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        service_account:
+            has_high_privilege: false
+            last_activity_days_ago: 91
+      wantFinding: false

--- a/policies/cicd/cicd-artifact-signature-required.test.yaml
+++ b/policies/cicd/cicd-artifact-signature-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        artifact_signature_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        artifact_signature_required: true
+      wantFinding: false

--- a/policies/cicd/cicd-build-provenance-required.test.yaml
+++ b/policies/cicd/cicd-build-provenance-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        build_provenance_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        build_provenance_required: true
+      wantFinding: false

--- a/policies/cicd/cicd-build-provenance-verified.test.yaml
+++ b/policies/cicd/cicd-build-provenance-verified.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        build_provenance_verified: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        build_provenance_verified: true
+      wantFinding: false

--- a/policies/cicd/cicd-dependency-review-required.test.yaml
+++ b/policies/cicd/cicd-dependency-review-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_review_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_review_required: true
+      wantFinding: false

--- a/policies/cicd/cicd-iac-plan-approval-required.test.yaml
+++ b/policies/cicd/cicd-iac-plan-approval-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        iac_plan_approval_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        iac_plan_approval_required: true
+      wantFinding: false

--- a/policies/cicd/cicd-release-separation-of-duties.test.yaml
+++ b/policies/cicd/cicd-release-separation-of-duties.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        release_separation_of_duties_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        release_separation_of_duties_compliant: true
+      wantFinding: false

--- a/policies/cicd/cicd-secret-scanning-blocking-required.test.yaml
+++ b/policies/cicd/cicd-secret-scanning-blocking-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        secret_scanning_blocking_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        secret_scanning_blocking_required: true
+      wantFinding: false

--- a/policies/cicd/cicd-slsa-build-level-below-2.test.yaml
+++ b/policies/cicd/cicd-slsa-build-level-below-2.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        slsa_build_level_below_2: 2
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        slsa_build_level_below_2: 3
+      wantFinding: false

--- a/policies/cicd/cicd-slsa-build-level-below-3-critical-service.test.yaml
+++ b/policies/cicd/cicd-slsa-build-level-below-3-critical-service.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        slsa_build_level_below_3_critical_service: 2
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        slsa_build_level_below_3_critical_service: 3
+      wantFinding: false

--- a/policies/cicd/cicd-unpinned-third-party-action.test.yaml
+++ b/policies/cicd/cicd-unpinned-third-party-action.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        unpinned_third_party_action_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        unpinned_third_party_action_compliant: true
+      wantFinding: false

--- a/policies/cicd/cicd-untrusted-fork-write-token.test.yaml
+++ b/policies/cicd/cicd-untrusted-fork-write-token.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        untrusted_fork_write_token_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        untrusted_fork_write_token_compliant: true
+      wantFinding: false

--- a/policies/compliance/compliance-p1-security-issues.test.yaml
+++ b/policies/compliance/compliance-p1-security-issues.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        created_at: ""
+        priority: P1
+        status: resolved-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        created_at: ""
+        priority: P1-passing
+        status: resolved-passing
+      wantFinding: false

--- a/policies/compliance/compliance-p2-security-issues.test.yaml
+++ b/policies/compliance/compliance-p2-security-issues.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        created_at: ""
+        priority: P2
+        status: resolved-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        created_at: ""
+        priority: P2-passing
+        status: resolved-passing
+      wantFinding: false

--- a/policies/compliance/uptime-breach-enterprise.test.yaml
+++ b/policies/compliance/uptime-breach-enterprise.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        plan_tier: enterprise
+        uptime_pct_30d: 98.9
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        plan_tier: enterprise-passing
+        uptime_pct_30d: 98.9
+      wantFinding: false

--- a/policies/container/container-base-image-eol.test.yaml
+++ b/policies/container/container-base-image-eol.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        base_image_eol_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        base_image_eol_compliant: true
+      wantFinding: false

--- a/policies/container/container-image-critical-vulnerability.test.yaml
+++ b/policies/container/container-image-critical-vulnerability.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        image_critical_vulnerability_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        image_critical_vulnerability_compliant: true
+      wantFinding: false

--- a/policies/container/container-image-no-sbom.test.yaml
+++ b/policies/container/container-image-no-sbom.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        image_no_sbom_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        image_no_sbom_compliant: true
+      wantFinding: false

--- a/policies/container/container-image-not-signed.test.yaml
+++ b/policies/container/container-image-not-signed.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        image_not_signed: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        image_not_signed: true
+      wantFinding: false

--- a/policies/cross-provider/cross-provider-dormant-privileged.test.yaml
+++ b/policies/cross-provider/cross-provider-dormant-privileged.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        has_admin_role: true
+        last_login_days_ago: 91
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        has_admin_role: false
+        last_login_days_ago: 91
+      wantFinding: false

--- a/policies/dspm/aws-redshift-encryption.test.yaml
+++ b/policies/dspm/aws-redshift-encryption.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        encrypted: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        encrypted: true
+      wantFinding: false

--- a/policies/dspm/gcp-bigquery-cmek.test.yaml
+++ b/policies/dspm/gcp-bigquery-cmek.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        default_encryption_configuration:
+            kms_key_name: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        default_encryption_configuration:
+            kms_key_name: true
+      wantFinding: false

--- a/policies/gcp/gcp-audit-logging.test.yaml
+++ b/policies/gcp/gcp-audit-logging.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        audit_configs: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        audit_configs: true
+      wantFinding: false

--- a/policies/gcp/gcp-bigquery-dataset-no-default-cmek.test.yaml
+++ b/policies/gcp/gcp-bigquery-dataset-no-default-cmek.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        bigquery_dataset_no_default_cmek_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        bigquery_dataset_no_default_cmek_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-cloudrun-ingress-all.test.yaml
+++ b/policies/gcp/gcp-cloudrun-ingress-all.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cloudrun_ingress_all_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cloudrun_ingress_all_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-cloudrun-service-account-default.test.yaml
+++ b/policies/gcp/gcp-cloudrun-service-account-default.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cloudrun_service_account_default_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cloudrun_service_account_default_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-compute-metadata-v1.test.yaml
+++ b/policies/gcp/gcp-compute-metadata-v1.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        metadata:
+            enable-legacy-endpoints: false-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        metadata:
+            enable-legacy-endpoints: "false"
+      wantFinding: false

--- a/policies/gcp/gcp-compute-public-ip.test.yaml
+++ b/policies/gcp/gcp-compute-public-ip.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        labels:
+            allow_public_ip: true-passing
+        network_interfaces:
+            access_configs: true
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        labels:
+            allow_public_ip: true-passing
+        network_interfaces:
+            access_configs: null
+      wantFinding: false

--- a/policies/gcp/gcp-compute-shielded-vm.test.yaml
+++ b/policies/gcp/gcp-compute-shielded-vm.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        shielded_instance_config:
+            enable_secure_boot: false
+            enable_vtpm: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        shielded_instance_config:
+            enable_secure_boot: true
+            enable_vtpm: false
+      wantFinding: false

--- a/policies/gcp/gcp-container-vuln-critical.test.yaml
+++ b/policies/gcp/gcp-container-vuln-critical.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        discovered_at: ""
+        severity: CRITICAL
+        state: ACTIVE
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        discovered_at: ""
+        severity: CRITICAL-passing
+        state: ACTIVE
+      wantFinding: false

--- a/policies/gcp/gcp-container-vuln-high.test.yaml
+++ b/policies/gcp/gcp-container-vuln-high.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        discovered_at: ""
+        severity: HIGH
+        state: ACTIVE
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        discovered_at: ""
+        severity: HIGH-passing
+        state: ACTIVE
+      wantFinding: false

--- a/policies/gcp/gcp-container-vuln-low.test.yaml
+++ b/policies/gcp/gcp-container-vuln-low.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        discovered_at: ""
+        severity: LOW
+        state: ACTIVE
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        discovered_at: ""
+        severity: LOW-passing
+        state: ACTIVE
+      wantFinding: false

--- a/policies/gcp/gcp-container-vuln-medium.test.yaml
+++ b/policies/gcp/gcp-container-vuln-medium.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        discovered_at: ""
+        severity: MEDIUM
+        state: ACTIVE
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        discovered_at: ""
+        severity: MEDIUM-passing
+        state: ACTIVE
+      wantFinding: false

--- a/policies/gcp/gcp-dns-dnssec.test.yaml
+++ b/policies/gcp/gcp-dns-dnssec.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dnssec_config:
+            state: on-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dnssec_config:
+            state: "on"
+      wantFinding: false

--- a/policies/gcp/gcp-gke-auto-repair.test.yaml
+++ b/policies/gcp/gcp-gke-auto-repair.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        management:
+            auto_repair: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        management:
+            auto_repair: true
+      wantFinding: false

--- a/policies/gcp/gcp-gke-auto-upgrade.test.yaml
+++ b/policies/gcp/gcp-gke-auto-upgrade.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        management:
+            auto_upgrade: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        management:
+            auto_upgrade: true
+      wantFinding: false

--- a/policies/gcp/gcp-gke-dashboard-disabled.test.yaml
+++ b/policies/gcp/gcp-gke-dashboard-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        addons_config:
+            kubernetes_dashboard:
+                disabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        addons_config:
+            kubernetes_dashboard:
+                disabled: true
+      wantFinding: false

--- a/policies/gcp/gcp-gke-network-policy.test.yaml
+++ b/policies/gcp/gcp-gke-network-policy.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        network_policy:
+            enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        network_policy:
+            enabled: true
+      wantFinding: false

--- a/policies/gcp/gcp-gke-private-cluster.test.yaml
+++ b/policies/gcp/gcp-gke-private-cluster.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        private_cluster_config:
+            enable_private_endpoint: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        private_cluster_config:
+            enable_private_endpoint: true
+      wantFinding: false

--- a/policies/gcp/gcp-gke-shielded-nodes.test.yaml
+++ b/policies/gcp/gcp-gke-shielded-nodes.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        shielded_nodes:
+            enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        shielded_nodes:
+            enabled: true
+      wantFinding: false

--- a/policies/gcp/gcp-organization-policy-disable-service-account-key-creation.test.yaml
+++ b/policies/gcp/gcp-organization-policy-disable-service-account-key-creation.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        organization_policy_disable_service_account_key_creation_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        organization_policy_disable_service_account_key_creation_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-organization-policy-restrict-vm-external-ip.test.yaml
+++ b/policies/gcp/gcp-organization-policy-restrict-vm-external-ip.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        organization_policy_restrict_vm_external_ip_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        organization_policy_restrict_vm_external_ip_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-organization-policy-uniform-bucket-level-access.test.yaml
+++ b/policies/gcp/gcp-organization-policy-uniform-bucket-level-access.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        organization_policy_uniform_bucket_level_access_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        organization_policy_uniform_bucket_level_access_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-project-audit-logs-data-access.test.yaml
+++ b/policies/gcp/gcp-project-audit-logs-data-access.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        project_audit_logs_data_access_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        project_audit_logs_data_access_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-project-essential-contacts-security.test.yaml
+++ b/policies/gcp/gcp-project-essential-contacts-security.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        project_essential_contacts_security_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        project_essential_contacts_security_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-scc-event-threat-detection-enabled.test.yaml
+++ b/policies/gcp/gcp-scc-event-threat-detection-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        scc_event_threat_detection_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        scc_event_threat_detection_enabled: true
+      wantFinding: false

--- a/policies/gcp/gcp-scc-security-health-analytics-enabled.test.yaml
+++ b/policies/gcp/gcp-scc-security-health-analytics-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        scc_security_health_analytics_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        scc_security_health_analytics_enabled: true
+      wantFinding: false

--- a/policies/gcp/gcp-secret-manager-secret-unreplicated.test.yaml
+++ b/policies/gcp/gcp-secret-manager-secret-unreplicated.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        secret_manager_secret_unreplicated_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        secret_manager_secret_unreplicated_compliant: true
+      wantFinding: false

--- a/policies/gcp/gcp-service-account-keys.test.yaml
+++ b/policies/gcp/gcp-service-account-keys.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        key_type: USER_MANAGED
+        valid_after_time: ""
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        key_type: USER_MANAGED-passing
+        valid_after_time: ""
+      wantFinding: false

--- a/policies/gcp/gcp-sql-backup.test.yaml
+++ b/policies/gcp/gcp-sql-backup.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        settings:
+            backup_configuration:
+                enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        settings:
+            backup_configuration:
+                enabled: true
+      wantFinding: false

--- a/policies/gcp/gcp-sql-ssl-required.test.yaml
+++ b/policies/gcp/gcp-sql-ssl-required.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        settings:
+            ip_configuration:
+                require_ssl: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        settings:
+            ip_configuration:
+                require_ssl: true
+      wantFinding: false

--- a/policies/gcp/gcp-storage-uniform-access.test.yaml
+++ b/policies/gcp/gcp-storage-uniform-access.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        iam_configuration:
+            uniform_bucket_level_access:
+                enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        iam_configuration:
+            uniform_bucket_level_access:
+                enabled: true
+      wantFinding: false

--- a/policies/github/github-actions-oidc-subject-too-broad.test.yaml
+++ b/policies/github/github-actions-oidc-subject-too-broad.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        actions_oidc_subject_too_broad_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        actions_oidc_subject_too_broad_compliant: true
+      wantFinding: false

--- a/policies/github/github-admin-without-2fa.test.yaml
+++ b/policies/github/github-admin-without-2fa.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        role: admin
+        two_factor_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        role: admin-passing
+        two_factor_enabled: false
+      wantFinding: false

--- a/policies/github/github-branch-protection.test.yaml
+++ b/policies/github/github-branch-protection.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        default_branch_protection:
+            enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        default_branch_protection:
+            enabled: true
+      wantFinding: false

--- a/policies/github/github-branch-requires-linear-history.test.yaml
+++ b/policies/github/github-branch-requires-linear-history.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        branch_requires_linear_history_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        branch_requires_linear_history_compliant: true
+      wantFinding: false

--- a/policies/github/github-branch-requires-signed-commits.test.yaml
+++ b/policies/github/github-branch-requires-signed-commits.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        branch_requires_signed_commits: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        branch_requires_signed_commits: true
+      wantFinding: false

--- a/policies/github/github-dependabot-critical.test.yaml
+++ b/policies/github/github-dependabot-critical.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        created_at_days: 8
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        created_at_days: 8
+        severity: critical-passing
+        state: open
+      wantFinding: false

--- a/policies/github/github-dependabot-high.test.yaml
+++ b/policies/github/github-dependabot-high.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        created_at_days: 15
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        created_at_days: 15
+        severity: high-passing
+        state: open
+      wantFinding: false

--- a/policies/github/github-org-2fa-disabled.test.yaml
+++ b/policies/github/github-org-2fa-disabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        two_factor_requirement_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        two_factor_requirement_enabled: true
+      wantFinding: false

--- a/policies/github/github-repo-branch-protection.test.yaml
+++ b/policies/github/github-repo-branch-protection.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        default_branch_protection_enabled: false
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        default_branch_protection_enabled: false
+        visibility: public-passing
+      wantFinding: false

--- a/policies/github/github-repo-webhook-insecure-ssl.test.yaml
+++ b/policies/github/github-repo-webhook-insecure-ssl.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        repo_webhook_insecure_ssl_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        repo_webhook_insecure_ssl_compliant: true
+      wantFinding: false

--- a/policies/github/github-ruleset-required.test.yaml
+++ b/policies/github/github-ruleset-required.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        ruleset_required: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        ruleset_required: true
+      wantFinding: false

--- a/policies/github/github-secops-audit-repo-branch-policy-override.test.yaml
+++ b/policies/github/github-secops-audit-repo-branch-policy-override.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        action: protected_branch.policy_override
+        branch: true
+        resource_type: protected_branch
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        action: protected_branch.policy_override
+        branch: true
+        resource_type: protected_branch-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-cargo-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-cargo-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: cargo
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: cargo
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-cargo-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-cargo-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: cargo
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: cargo
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-composer-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-composer-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: composer
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: composer
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-composer-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-composer-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: composer
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: composer
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-docker-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-docker-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: docker
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: docker
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-docker-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-docker-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: docker
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: docker
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-github-actions-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-github-actions-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: github-actions
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: github-actions
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-github-actions-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-github-actions-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: github-actions
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: github-actions
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-go-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-go-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: go
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: go
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-go-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-go-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: go
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: go
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-maven-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-maven-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: maven
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: maven
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-maven-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-maven-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: maven
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: maven
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-npm-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-npm-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: npm
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: npm
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-npm-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-npm-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: npm
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: npm
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-nuget-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-nuget-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: nuget
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: nuget
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-nuget-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-nuget-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: nuget
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: nuget
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-pip-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-pip-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: pip
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: pip
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-pip-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-pip-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: pip
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: pip
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-pub-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-pub-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: pub
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: pub
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-pub-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-pub-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: pub
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: pub
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-rubygems-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-rubygems-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: rubygems
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: rubygems
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-rubygems-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-rubygems-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: rubygems
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: rubygems
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-terraform-critical-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-terraform-critical-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: terraform
+        first_patched_version: null
+        severity: critical
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: terraform
+        first_patched_version: null
+        severity: critical
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-dependabot-terraform-high-runtime-no-patch.test.yaml
+++ b/policies/github/github-secops-dependabot-terraform-high-runtime-no-patch.test.yaml
@@ -1,0 +1,19 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependency_scope: runtime
+        ecosystem: terraform
+        first_patched_version: null
+        severity: high
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependency_scope: runtime
+        ecosystem: terraform
+        first_patched_version: null
+        severity: high
+        state: open-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-default-branch-missing.test.yaml
+++ b/policies/github/github-secops-repo-default-branch-missing.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        default_branch: null
+        resource_type: code_repository
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        default_branch: null
+        resource_type: code_repository-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-all-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-all-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        resource_type: code_repository
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        resource_type: code_repository-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-all-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-all-push-protection-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-all-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-all-secret-scanning-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-fork-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-fork-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "true"
+        resource_type: code_repository
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "true"
+        resource_type: code_repository-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-fork-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-fork-push-protection-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "true"
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "true"
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-fork-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-fork-secret-scanning-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "true"
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "true"
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-primary-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-primary-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "false"
+        resource_type: code_repository
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "false"
+        resource_type: code_repository-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-primary-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-primary-push-protection-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "false"
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "false"
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-internal-primary-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-internal-primary-secret-scanning-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "false"
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+        visibility: internal
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "false"
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+        visibility: internal
+      wantFinding: false

--- a/policies/github/github-secops-repo-owner-login-missing.test.yaml
+++ b/policies/github/github-secops-repo-owner-login-missing.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        owner_login: null
+        resource_type: code_repository
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        owner_login: null
+        resource_type: code_repository-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-all-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-all-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        private: "true"
+        resource_type: code_repository
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        private: "true"
+        resource_type: code_repository-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-all-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-all-push-protection-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        private: "true"
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        private: "true"
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-all-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-all-secret-scanning-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        private: "true"
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        private: "true"
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-fork-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-fork-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "true"
+        private: "true"
+        resource_type: code_repository
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "true"
+        private: "true"
+        resource_type: code_repository-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-fork-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-fork-push-protection-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "true"
+        private: "true"
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "true"
+        private: "true"
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-fork-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-fork-secret-scanning-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "true"
+        private: "true"
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "true"
+        private: "true"
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-primary-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-primary-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "false"
+        private: "true"
+        resource_type: code_repository
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "false"
+        private: "true"
+        resource_type: code_repository-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-primary-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-primary-push-protection-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "false"
+        private: "true"
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "false"
+        private: "true"
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-private-primary-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-private-primary-secret-scanning-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "false"
+        private: "true"
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "false"
+        private: "true"
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-all-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-all-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        resource_type: code_repository
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        resource_type: code_repository-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-all-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-all-push-protection-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-all-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-all-secret-scanning-disabled.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-fork-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-fork-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "true"
+        resource_type: code_repository
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "true"
+        resource_type: code_repository-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-fork-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-fork-push-protection-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "true"
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "true"
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-fork-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-fork-secret-scanning-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "true"
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "true"
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-primary-dependabot-security-updates-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-primary-dependabot-security-updates-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "false"
+        resource_type: code_repository
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dependabot_security_updates: enabled-passing
+        fork: "false"
+        resource_type: code_repository-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-primary-push-protection-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-primary-push-protection-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "false"
+        resource_type: code_repository
+        secret_scanning_push_protection: enabled-passing
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "false"
+        resource_type: code_repository-passing
+        secret_scanning_push_protection: enabled-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-secops-repo-public-primary-secret-scanning-disabled.test.yaml
+++ b/policies/github/github-secops-repo-public-primary-secret-scanning-disabled.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fork: "false"
+        resource_type: code_repository
+        secret_scanning: enabled-passing
+        visibility: public
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fork: "false"
+        resource_type: code_repository-passing
+        secret_scanning: enabled-passing
+        visibility: public
+      wantFinding: false

--- a/policies/github/github-vuln-low.test.yaml
+++ b/policies/github/github-vuln-low.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        created_at: ""
+        severity: low
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        created_at: ""
+        severity: low-passing
+        state: open
+      wantFinding: false

--- a/policies/github/github-vuln-medium.test.yaml
+++ b/policies/github/github-vuln-medium.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        created_at: ""
+        severity: moderate
+        state: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        created_at: ""
+        severity: moderate-passing
+        state: open
+      wantFinding: false

--- a/policies/hubspot/hubspot-excessive-discount.test.yaml
+++ b/policies/hubspot/hubspot-excessive-discount.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        properties:
+            amount: 49999
+            discount_percentage: 31
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        properties:
+            amount: 49999
+            discount_percentage: 30
+      wantFinding: false

--- a/policies/identity/identity-break-glass-account-review.test.yaml
+++ b/policies/identity/identity-break-glass-account-review.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        break_glass_account_review_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        break_glass_account_review_compliant: true
+      wantFinding: false

--- a/policies/identity/identity-conditional-access-high-risk-signin.test.yaml
+++ b/policies/identity/identity-conditional-access-high-risk-signin.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        conditional_access_high_risk_signin_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        conditional_access_high_risk_signin_compliant: true
+      wantFinding: false

--- a/policies/identity/identity-idp-risky-user-unresolved.test.yaml
+++ b/policies/identity/identity-idp-risky-user-unresolved.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        idp_risky_user_unresolved_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        idp_risky_user_unresolved_compliant: true
+      wantFinding: false

--- a/policies/identity/identity-offboarding-sla.test.yaml
+++ b/policies/identity/identity-offboarding-sla.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        days_since_termination: 4
+        offboarding_complete: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        days_since_termination: 4
+        offboarding_complete: true
+      wantFinding: false

--- a/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
+++ b/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
@@ -1,22 +1,54 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: dormant admin role assignment fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-admin
-        primary_label: admin@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-admin|urn:cerebro:writer:okta_admin_role:org-admin
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-admin
-          - urn:cerebro:writer:okta_admin_role:org-admin
-        severity: HIGH
-        summary: Okta admin admin@example.com has stale login activity for role org-admin
-        action: Remove the admin role or document active break-glass review evidence
-        evidence:
-          - urn: urn:cerebro:writer:okta_admin_role:org-admin
+  - name: dormant user to admin capability path produces a finding
+    graphFixture:
+      tenantId: test-dormant-admin
+      nodes: &nodes
+        - urn: urn:cerebro:test-dormant-admin:okta:user:dormant-admin
+          sourceId: okta
+          entityType: okta.user
+          label: dormant-admin@example.com
+          attributes:
+            status: active
+            last_login_at: "2020-01-01T00:00:00Z"
+        - urn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          sourceId: okta
+          entityType: okta.admin_role
+          label: Organization administrator
+        - urn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Organization administrator
+        - urn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Identity administrator
+      edges:
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:user:dormant-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          sourceId: okta
+          relation: can_admin
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: recent admin role assignment passes
-    resource:
-      placeholder: true
+  - name: admin capability path without dormant user assignment passes
+    graphFixture:
+      tenantId: test-dormant-admin
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
+++ b/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
@@ -37,6 +37,10 @@ cases:
           toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+      - urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+      - urn:cerebro:test-dormant-admin:access:capability:identity-admin
     wantFinding: true
   - name: admin capability path without dormant user assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -12,12 +12,12 @@ cases:
         - urn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
           sourceId: okta
           entityType: okta.application
-          label: Cloud Console
+          label: Workforce Portal
         - urn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
           sourceId: okta
           entityType: okta.entitlement
           label: Console administrator
-        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           entityType: access.capability
           label: Cloud administrator
@@ -31,21 +31,21 @@ cases:
           sourceId: okta
           relation: grants_entitlement
         - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
-          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           relation: confers_capability
     wantFinding: true
-  - name: downstream capability path without group assignment passes
+  - name: group application entitlement path without admin capability passes
     graphFixture:
       tenantId: test-group-admin-path
       nodes: *nodes
       edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          toUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          relation: assigned_to
         - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
           toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
           sourceId: okta
           relation: grants_entitlement
-        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
-          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
-          sourceId: okta
-          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -1,22 +1,51 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: group grants admin app access fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_group:admins
-        primary_label: Finance Admins
-        primary_type: okta.group
-        fingerprint_key: urn:cerebro:writer:okta_group:admins|urn:cerebro:writer:okta_application:admin-console
-        resource_urns:
-          - urn:cerebro:writer:okta_group:admins
-          - urn:cerebro:writer:okta_application:admin-console
-        severity: HIGH
-        summary: Okta group Finance Admins grants admin-like access to Admin Console
-        action: Review group membership and split broad admin application access
-        evidence:
-          - urn: urn:cerebro:writer:okta_application:admin-console
+  - name: group to admin capability path produces a finding
+    graphFixture:
+      tenantId: test-group-admin-path
+      nodes: &nodes
+        - urn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          sourceId: okta
+          entityType: okta.group
+          label: Security Operators
+        - urn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          entityType: okta.application
+          label: Cloud Console
+        - urn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Console administrator
+        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Cloud administrator
+      edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          toUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: group scoped away from admin app passes
-    resource:
-      placeholder: true
+  - name: downstream capability path without group assignment passes
+    graphFixture:
+      tenantId: test-group-admin-path
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -34,6 +34,10 @@ cases:
           toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-group-admin-path:okta:application:cloud-console
+      - urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+      - urn:cerebro:test-group-admin-path:access:capability:cloud_admin
     wantFinding: true
   - name: group application entitlement path without admin capability passes
     graphFixture:

--- a/policies/identity/identity-okta-privileged-missing-owner.test.yaml
+++ b/policies/identity/identity-okta-privileged-missing-owner.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: privileged account without owner fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-ownerless
-        primary_label: platform-admin@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-ownerless
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-ownerless
-          - urn:cerebro:writer:okta_admin_role:super-admin
-        severity: HIGH
-        summary: Okta privileged account platform-admin@example.com has no lifecycle owner evidence
-        action: Add manager or owner evidence before accepting privileged access
-        evidence:
-          - urn: urn:cerebro:writer:okta_admin_role:super-admin
+  - name: ownerless user to privileged capability path produces a finding
+    graphFixture:
+      tenantId: test-missing-owner
+      nodes: &nodes
+        - urn: urn:cerebro:test-missing-owner:okta:user:break-glass
+          sourceId: okta
+          entityType: okta.user
+          label: break-glass@example.com
+          attributes:
+            status: active
+        - urn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          sourceId: okta
+          entityType: okta.admin_role
+          label: Super administrator
+        - urn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Tenant administrator
+        - urn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Identity administrator
+      edges:
+        - fromUrn: urn:cerebro:test-missing-owner:okta:user:break-glass
+          toUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          sourceId: okta
+          relation: can_admin
+        - fromUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          toUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: privileged account with owner evidence passes
-    resource:
-      placeholder: true
+  - name: privileged capability path without user role assignment passes
+    graphFixture:
+      tenantId: test-missing-owner
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          toUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-privileged-missing-owner.test.yaml
+++ b/policies/identity/identity-okta-privileged-missing-owner.test.yaml
@@ -36,6 +36,10 @@ cases:
           toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+      - urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+      - urn:cerebro:test-missing-owner:access:capability:identity-admin
     wantFinding: true
   - name: privileged capability path without user role assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
+++ b/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
@@ -20,10 +20,6 @@ cases:
           sourceId: okta
           entityType: okta.application
           label: Deployment console
-        - urn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          entityType: okta.entitlement
-          label: Deploy production
       edges:
         - fromUrn: urn:cerebro:test-stale-group:okta:user:bob
           toUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
@@ -33,10 +29,9 @@ cases:
           toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
-          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          relation: grants_entitlement
+    wantEvidenceUrns:
+      - urn:cerebro:test-stale-group:okta:group:engineering-admins
+      - urn:cerebro:test-stale-group:okta:application:deployment-console
     wantFinding: true
   - name: group application path without stale membership passes
     graphFixture:
@@ -47,8 +42,4 @@ cases:
           toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
-          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
+++ b/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
@@ -1,22 +1,54 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: stale group membership fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-dormant
-        primary_label: dormant@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-dormant|urn:cerebro:writer:okta_group:finance-users
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-dormant
-          - urn:cerebro:writer:okta_group:finance-users
-        severity: HIGH
-        summary: Okta group membership for dormant@example.com is stale in Finance Users
-        action: Remove stale group membership or document the approved need
-        evidence:
-          - urn: urn:cerebro:writer:okta_group:finance-users
+  - name: stale user through group to application path produces a finding
+    graphFixture:
+      tenantId: test-stale-group
+      nodes: &nodes
+        - urn: urn:cerebro:test-stale-group:okta:user:bob
+          sourceId: okta
+          entityType: okta.user
+          label: bob@example.com
+          attributes:
+            status: active
+            last_login_at: "2020-01-01T00:00:00Z"
+        - urn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          sourceId: okta
+          entityType: okta.group
+          label: Engineering administrators
+        - urn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          entityType: okta.application
+          label: Deployment console
+        - urn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Deploy production
+      edges:
+        - fromUrn: urn:cerebro:test-stale-group:okta:user:bob
+          toUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          sourceId: okta
+          relation: member_of
+        - fromUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: true
-  - name: recent group member passes
-    resource:
-      placeholder: true
+  - name: group application path without stale membership passes
+    graphFixture:
+      tenantId: test-stale-group
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: suspended user with active app assignment fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-suspended
-        primary_label: suspended@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-suspended|urn:cerebro:writer:okta_application:app-payroll
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-suspended
-          - urn:cerebro:writer:okta_application:app-payroll
-        severity: HIGH
-        summary: Okta suspended user suspended@example.com still has active assignment to Payroll
-        action: Remove app assignment and verify downstream deprovisioning
-        evidence:
-          - urn: urn:cerebro:writer:okta_application:app-payroll
+  - name: suspended user to capability path produces a finding
+    graphFixture:
+      tenantId: test-suspended-assignment
+      nodes: &nodes
+        - urn: urn:cerebro:test-suspended-assignment:okta:user:alice
+          sourceId: okta
+          entityType: okta.user
+          label: alice@example.com
+          attributes:
+            status: suspended
+        - urn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          sourceId: okta
+          entityType: okta.application
+          label: Payroll
+        - urn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Payroll admin
+        - urn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          entityType: access.capability
+          label: Payroll write
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:user:alice
+          toUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: suspended user without app assignment passes
-    resource:
-      placeholder: true
+  - name: entitlement path without user assignment passes
+    graphFixture:
+      tenantId: test-suspended-assignment
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
@@ -36,6 +36,10 @@ cases:
           toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-suspended-assignment:okta:application:payroll
+      - urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+      - urn:cerebro:test-suspended-assignment:access:capability:payroll-write
     wantFinding: true
   - name: entitlement path without user assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: suspended user with active group membership fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-suspended
-        primary_label: suspended@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-suspended|urn:cerebro:writer:okta_group:finance-users
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-suspended
-          - urn:cerebro:writer:okta_group:finance-users
-        severity: HIGH
-        summary: Okta suspended user suspended@example.com remains in group Finance Users
-        action: Remove stale group membership and verify downstream access removal
-        evidence:
-          - urn: urn:cerebro:writer:okta_group:finance-users
+  - name: suspended user through group to application path produces a finding
+    graphFixture:
+      tenantId: test-suspended-group
+      nodes: &nodes
+        - urn: urn:cerebro:test-suspended-group:okta:user:alice
+          sourceId: okta
+          entityType: okta.user
+          label: alice@example.com
+          attributes:
+            status: deprovisioned
+        - urn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          sourceId: okta
+          entityType: okta.group
+          label: Finance administrators
+        - urn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          entityType: okta.application
+          label: Payroll
+        - urn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Payroll write
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-group:okta:user:alice
+          toUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          sourceId: okta
+          relation: member_of
+        - fromUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: true
-  - name: suspended user without group membership passes
-    resource:
-      placeholder: true
+  - name: group application path without suspended membership passes
+    graphFixture:
+      tenantId: test-suspended-group
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
@@ -19,10 +19,6 @@ cases:
           sourceId: okta
           entityType: okta.application
           label: Payroll
-        - urn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          entityType: okta.entitlement
-          label: Payroll write
       edges:
         - fromUrn: urn:cerebro:test-suspended-group:okta:user:alice
           toUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
@@ -32,10 +28,9 @@ cases:
           toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
-          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          relation: grants_entitlement
+    wantEvidenceUrns:
+      - urn:cerebro:test-suspended-group:okta:group:finance-admins
+      - urn:cerebro:test-suspended-group:okta:application:payroll
     wantFinding: true
   - name: group application path without suspended membership passes
     graphFixture:
@@ -46,8 +41,4 @@ cases:
           toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
-          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-passkey-enrollment-admins.test.yaml
+++ b/policies/identity/identity-passkey-enrollment-admins.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        passkey_enrollment_admins_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        passkey_enrollment_admins_compliant: true
+      wantFinding: false

--- a/policies/identity/identity-phishing-resistant-mfa-admins.test.yaml
+++ b/policies/identity/identity-phishing-resistant-mfa-admins.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        phishing_resistant_mfa_admins: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        phishing_resistant_mfa_admins: true
+      wantFinding: false

--- a/policies/identity/identity-privileged-access-review-overdue.test.yaml
+++ b/policies/identity/identity-privileged-access-review-overdue.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        privileged_access_review_overdue_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        privileged_access_review_overdue_compliant: true
+      wantFinding: false

--- a/policies/identity/identity-saas-mfa.test.yaml
+++ b/policies/identity/identity-saas-mfa.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        account_active: true
+        is_human_user: true
+        mfa_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        account_active: true
+        is_human_user: true
+        mfa_enabled: true
+      wantFinding: false

--- a/policies/identity/identity-sso-required-for-saas-admins.test.yaml
+++ b/policies/identity/identity-sso-required-for-saas-admins.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        sso_required_for_saas_admins: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        sso_required_for_saas_admins: true
+      wantFinding: false

--- a/policies/identity/identity-stale-accounts.test.yaml
+++ b/policies/identity/identity-stale-accounts.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        account_active: true
+        days_since_last_login: 91
+        is_service_account: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        account_active: true
+        days_since_last_login: 90
+        is_service_account: false
+      wantFinding: false

--- a/policies/kubernetes/k8s-deployment-replicas.test.yaml
+++ b/policies/kubernetes/k8s-deployment-replicas.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        metadata:
+            namespace: kube-system-passing
+        spec:
+            replicas: 1
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        metadata:
+            namespace: kube-system-passing
+        spec:
+            replicas: 2
+      wantFinding: false

--- a/policies/kubernetes/k8s-mutating-webhook-failure-policy-ignore.test.yaml
+++ b/policies/kubernetes/k8s-mutating-webhook-failure-policy-ignore.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        mutating_webhook_failure_policy_ignore_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        mutating_webhook_failure_policy_ignore_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-namespace-pss-enforce-not-restricted.test.yaml
+++ b/policies/kubernetes/k8s-namespace-pss-enforce-not-restricted.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        namespace_pss_enforce_not_restricted_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        namespace_pss_enforce_not_restricted_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-apparmor-unconfined.test.yaml
+++ b/policies/kubernetes/k8s-pod-apparmor-unconfined.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        pod_apparmor_unconfined_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        pod_apparmor_unconfined_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-automount-service-account-token.test.yaml
+++ b/policies/kubernetes/k8s-pod-automount-service-account-token.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        pod_automount_service_account_token_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        pod_automount_service_account_token_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-capability-net-raw.test.yaml
+++ b/policies/kubernetes/k8s-pod-capability-net-raw.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        pod_capability_net_raw_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        pod_capability_net_raw_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-hostpath-sensitive-path.test.yaml
+++ b/policies/kubernetes/k8s-pod-hostpath-sensitive-path.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        pod_hostpath_sensitive_path_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        pod_hostpath_sensitive_path_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-image-pinned-by-digest.test.yaml
+++ b/policies/kubernetes/k8s-pod-image-pinned-by-digest.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        spec:
+            all_images_pinned_by_digest: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        spec:
+            all_images_pinned_by_digest: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-liveness-probe-required.test.yaml
+++ b/policies/kubernetes/k8s-pod-liveness-probe-required.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        spec:
+            all_containers_have_liveness_probe: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        spec:
+            all_containers_have_liveness_probe: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-proc-mount-unmasked.test.yaml
+++ b/policies/kubernetes/k8s-pod-proc-mount-unmasked.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        pod_proc_mount_unmasked_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        pod_proc_mount_unmasked_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-readiness-probe-required.test.yaml
+++ b/policies/kubernetes/k8s-pod-readiness-probe-required.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        spec:
+            all_containers_have_readiness_probe: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        spec:
+            all_containers_have_readiness_probe: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-readonly-root.test.yaml
+++ b/policies/kubernetes/k8s-pod-readonly-root.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        spec:
+            containers:
+                security_context:
+                    read_only_root_filesystem: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        spec:
+            containers:
+                security_context:
+                    read_only_root_filesystem: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-resource-limits.test.yaml
+++ b/policies/kubernetes/k8s-pod-resource-limits.test.yaml
@@ -1,0 +1,21 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        spec:
+            containers:
+                resources:
+                    limits:
+                        cpu: null
+                        memory: null
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        spec:
+            containers:
+                resources:
+                    limits:
+                        cpu: null
+                        memory: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-root.test.yaml
+++ b/policies/kubernetes/k8s-pod-root.test.yaml
@@ -1,0 +1,21 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        spec:
+            containers:
+                security_context:
+                    run_as_user: 0
+            security_context:
+                run_as_non_root: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        spec:
+            containers:
+                security_context:
+                    run_as_user: 0
+            security_context:
+                run_as_non_root: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-seccomp-runtime-default.test.yaml
+++ b/policies/kubernetes/k8s-pod-seccomp-runtime-default.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        spec:
+            all_containers_runtime_default_seccomp: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        spec:
+            all_containers_runtime_default_seccomp: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-pod-sysctls-unsafe.test.yaml
+++ b/policies/kubernetes/k8s-pod-sysctls-unsafe.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        pod_sysctls_unsafe_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        pod_sysctls_unsafe_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-rbac-cluster-admin-used.test.yaml
+++ b/policies/kubernetes/k8s-rbac-cluster-admin-used.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        role_ref_kind: ClusterRole
+        role_ref_name: cluster-admin
+        subject_kind: User
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        role_ref_kind: ClusterRole
+        role_ref_name: cluster-admin
+        subject_kind: User-passing
+      wantFinding: false

--- a/policies/kubernetes/k8s-secret-not-externalized.test.yaml
+++ b/policies/kubernetes/k8s-secret-not-externalized.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        secret_not_externalized_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        secret_not_externalized_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-service-account-cluster-admin.test.yaml
+++ b/policies/kubernetes/k8s-service-account-cluster-admin.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        service_account_cluster_admin_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        service_account_cluster_admin_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-service-external-ip.test.yaml
+++ b/policies/kubernetes/k8s-service-external-ip.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        spec:
+            external_ips: true
+            external_ips_count: 1
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        spec:
+            external_ips: null
+            external_ips_count: 1
+      wantFinding: false

--- a/policies/kubernetes/k8s-service-loadbalancer.test.yaml
+++ b/policies/kubernetes/k8s-service-loadbalancer.test.yaml
@@ -1,0 +1,29 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        metadata:
+            annotations['cloud:
+                google:
+                    com/load-balancer-type']: Internal-passing
+            annotations['service:
+                beta:
+                    kubernetes:
+                        io/aws-load-balancer-internal']: true-passing
+        spec:
+            type: LoadBalancer
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        metadata:
+            annotations['cloud:
+                google:
+                    com/load-balancer-type']: Internal-passing
+            annotations['service:
+                beta:
+                    kubernetes:
+                        io/aws-load-balancer-internal']: true-passing
+        spec:
+            type: LoadBalancer-passing
+      wantFinding: false

--- a/policies/kubernetes/k8s-validating-webhook-failure-policy-ignore.test.yaml
+++ b/policies/kubernetes/k8s-validating-webhook-failure-policy-ignore.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        validating_webhook_failure_policy_ignore_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        validating_webhook_failure_policy_ignore_compliant: true
+      wantFinding: false

--- a/policies/kubernetes/k8s-workload-uses-default-service-account.test.yaml
+++ b/policies/kubernetes/k8s-workload-uses-default-service-account.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        workload_uses_default_service_account_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        workload_uses_default_service_account_compliant: true
+      wantFinding: false

--- a/policies/m365/m365-external-forwarding-enabled.test.yaml
+++ b/policies/m365/m365-external-forwarding-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        external_forwarding_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        external_forwarding_enabled: true
+      wantFinding: false

--- a/policies/m365/m365-file-shared-externally.test.yaml
+++ b/policies/m365/m365-file-shared-externally.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        external_sharing_enabled: true
+        external_user_count: 1
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        external_sharing_enabled: false
+        external_user_count: 1
+      wantFinding: false

--- a/policies/m365/m365-sharepoint-anonymous-link.test.yaml
+++ b/policies/m365/m365-sharepoint-anonymous-link.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        anonymous_link_count: 1
+        sharing_capability: ExternalUserAndGuestSharing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        anonymous_link_count: 1
+        sharing_capability: ExternalUserAndGuestSharing-passing
+      wantFinding: false

--- a/policies/m365/m365-sharepoint-external-sharing-anyone.test.yaml
+++ b/policies/m365/m365-sharepoint-external-sharing-anyone.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        sharepoint_external_sharing_anyone_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        sharepoint_external_sharing_anyone_compliant: true
+      wantFinding: false

--- a/policies/m365/m365-tenant-legacy-auth-enabled.test.yaml
+++ b/policies/m365/m365-tenant-legacy-auth-enabled.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        tenant_legacy_auth_enabled: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        tenant_legacy_auth_enabled: true
+      wantFinding: false

--- a/policies/okta/okta-admin-dormant.test.yaml
+++ b/policies/okta/okta-admin-dormant.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        is_admin: true
+        last_login_days_ago: 91
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        is_admin: false
+        last_login_days_ago: 91
+      wantFinding: false

--- a/policies/org/org-bottleneck-critical.test.yaml
+++ b/policies/org/org-bottleneck-critical.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        betweenness_centrality: 1.8
+        bridged_teams: 2
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        betweenness_centrality: 0.8
+        bridged_teams: 2
+      wantFinding: false

--- a/policies/org/org-bus-factor-critical.test.yaml
+++ b/policies/org/org-bus-factor-critical.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        bus_factor: 1
+        criticality: high
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        bus_factor: 1
+        criticality: high-passing
+      wantFinding: false

--- a/policies/org/org-customer-topology-churn-risk.test.yaml
+++ b/policies/org/org-customer-topology-churn-risk.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        churn_risk: 1.7
+        cohort_percentile: 39
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        churn_risk: 0.7
+        cohort_percentile: 39
+      wantFinding: false

--- a/policies/org/org-customer-touchpoints-low.test.yaml
+++ b/policies/org/org-customer-touchpoints-low.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        renewal_days: 119
+        touchpoint_count: 1
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        renewal_days: 119
+        touchpoint_count: 2
+      wantFinding: false

--- a/policies/org/org-relationship-decay-customer.test.yaml
+++ b/policies/org/org-relationship-decay-customer.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        previous_strength: 1.7
+        relationship_strength: -0.7
+        renewal_days: 89
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        previous_strength: 1.7
+        relationship_strength: 0.3
+        renewal_days: 89
+      wantFinding: false

--- a/policies/org/org-silo-shared-dependency.test.yaml
+++ b/policies/org/org-silo-shared-dependency.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        interaction_edges: 0
+        shared_dependencies: 3
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        interaction_edges: 0
+        shared_dependencies: 2
+      wantFinding: false

--- a/policies/org/org-tenure-risk.test.yaml
+++ b/policies/org/org-tenure-risk.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        activity_trend: declining
+        bus_factor_1_systems: 1
+        tenure_years: 3
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        activity_trend: declining
+        bus_factor_1_systems: 0
+        tenure_years: 3
+      wantFinding: false

--- a/policies/runtime/kev-vulnerability-detected.test.yaml
+++ b/policies/runtime/kev-vulnerability-detected.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        cve_id: cisa_kev_list
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        cve_id: cisa_kev_list-passing
+      wantFinding: false

--- a/policies/runtime/runtime-c2-connection-critical-asset.test.yaml
+++ b/policies/runtime/runtime-c2-connection-critical-asset.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        c2_connection_critical_asset_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        c2_connection_critical_asset_compliant: true
+      wantFinding: false

--- a/policies/runtime/runtime-dns-newly-registered-domain.test.yaml
+++ b/policies/runtime/runtime-dns-newly-registered-domain.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dns_newly_registered_domain_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dns_newly_registered_domain_compliant: true
+      wantFinding: false

--- a/policies/runtime/runtime-identity-provider-risky-session.test.yaml
+++ b/policies/runtime/runtime-identity-provider-risky-session.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        identity_provider_risky_session_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        identity_provider_risky_session_compliant: true
+      wantFinding: false

--- a/policies/runtime/runtime-impossible-travel-admin.test.yaml
+++ b/policies/runtime/runtime-impossible-travel-admin.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        impossible_travel_admin_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        impossible_travel_admin_compliant: true
+      wantFinding: false

--- a/policies/runtime/runtime-k8s-exec-privileged-pod.test.yaml
+++ b/policies/runtime/runtime-k8s-exec-privileged-pod.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        k8s_exec_privileged_pod_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        k8s_exec_privileged_pod_compliant: true
+      wantFinding: false

--- a/policies/runtime/runtime-k8s-serviceaccount-token-access.test.yaml
+++ b/policies/runtime/runtime-k8s-serviceaccount-token-access.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        k8s_serviceaccount_token_access_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        k8s_serviceaccount_token_access_compliant: true
+      wantFinding: false

--- a/policies/runtime/runtime-malware-not-contained.test.yaml
+++ b/policies/runtime/runtime-malware-not-contained.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        malware_not_contained_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        malware_not_contained_compliant: true
+      wantFinding: false

--- a/policies/runtime/sentinelone-threat.test.yaml
+++ b/policies/runtime/sentinelone-threat.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        threat_info:
+            confidence_level: '[''malicious'
+            incident_status: resolved-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        threat_info:
+            confidence_level: '[''malicious'
+            incident_status: resolved
+      wantFinding: false

--- a/policies/runtime/threat-intel-domain-match.test.yaml
+++ b/policies/runtime/threat-intel-domain-match.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        domain: threat_intel.malicious_domains
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        domain: threat_intel.malicious_domains-passing
+      wantFinding: false

--- a/policies/runtime/threat-intel-ip-match.test.yaml
+++ b/policies/runtime/threat-intel-ip-match.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        destination_ip: threat_intel.malicious_ips
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        destination_ip: threat_intel.malicious_ips-passing
+      wantFinding: false

--- a/policies/salesforce/salesforce-admin-mfa-missing.test.yaml
+++ b/policies/salesforce/salesforce-admin-mfa-missing.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        admin_mfa_missing: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        admin_mfa_missing: true
+      wantFinding: false

--- a/policies/salesforce/salesforce-connected-app-unreviewed.test.yaml
+++ b/policies/salesforce/salesforce-connected-app-unreviewed.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        connected_app_unreviewed_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        connected_app_unreviewed_compliant: true
+      wantFinding: false

--- a/policies/salesforce/salesforce-profile-modify-all-data.test.yaml
+++ b/policies/salesforce/salesforce-profile-modify-all-data.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        profile_modify_all_data_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        profile_modify_all_data_compliant: true
+      wantFinding: false

--- a/policies/salesforce/salesforce-user-never-logged-in-90d.test.yaml
+++ b/policies/salesforce/salesforce-user-never-logged-in-90d.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        user_never_logged_in_90d_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        user_never_logged_in_90d_compliant: true
+      wantFinding: false

--- a/policies/salesforce/sf-close-date-slip.test.yaml
+++ b/policies/salesforce/sf-close-date-slip.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        StageName: Closed Won-passing
+        close_date_push_count: 3
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        StageName: Closed Won-passing
+        close_date_push_count: 2
+      wantFinding: false

--- a/policies/sentinelone/sentinelone-vuln-medium.test.yaml
+++ b/policies/sentinelone/sentinelone-vuln-medium.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        detected_at: ""
+        severity: Medium
+        status: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        detected_at: ""
+        severity: Medium-passing
+        status: open
+      wantFinding: false

--- a/policies/slack/slack-admin-without-sso.test.yaml
+++ b/policies/slack/slack-admin-without-sso.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        admin_without_sso_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        admin_without_sso_compliant: true
+      wantFinding: false

--- a/policies/slack/slack-app-bot-token-unreviewed.test.yaml
+++ b/policies/slack/slack-app-bot-token-unreviewed.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        app_bot_token_unreviewed_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        app_bot_token_unreviewed_compliant: true
+      wantFinding: false

--- a/policies/slack/slack-external-shared-channel-unreviewed.test.yaml
+++ b/policies/slack/slack-external-shared-channel-unreviewed.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        external_shared_channel_unreviewed_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        external_shared_channel_unreviewed_compliant: true
+      wantFinding: false

--- a/policies/slack/slack-guest-user-no-expiry.test.yaml
+++ b/policies/slack/slack-guest-user-no-expiry.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        guest_user_no_expiry_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        guest_user_no_expiry_compliant: true
+      wantFinding: false

--- a/policies/stripe/stripe-large-refund.test.yaml
+++ b/policies/stripe/stripe-large-refund.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        amount_refunded: 500001
+        metadata:
+            approved: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        amount_refunded: 500000
+        metadata:
+            approved: false
+      wantFinding: false

--- a/policies/stripe/stripe-payment-failure-streak.test.yaml
+++ b/policies/stripe/stripe-payment-failure-streak.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        failed_payment_count: 3
+        past_due: true
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        failed_payment_count: 3
+        past_due: false
+      wantFinding: false

--- a/policies/stripe/stripe-trial-no-payment-method.test.yaml
+++ b/policies/stripe/stripe-trial-no-payment-method.test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        days_until_trial_end: 6
+        default_payment_method: null
+        status: trialing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        days_until_trial_end: 6
+        default_payment_method: null
+        status: trialing-passing
+      wantFinding: false

--- a/policies/telemetry/telemetry-repo-secret-key.test.yaml
+++ b/policies/telemetry/telemetry-repo-secret-key.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        secret_type: aws_access_key
+        status: open
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        secret_type: aws_access_key
+        status: open-passing
+      wantFinding: false

--- a/policies/vendor/vendor-dpa-exists.test.yaml
+++ b/policies/vendor/vendor-dpa-exists.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        dpa_signed: false
+        processes_personal_data: true
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        dpa_signed: false
+        processes_personal_data: false
+      wantFinding: false

--- a/policies/vulnerability/vuln-container-critical-runtime.test.yaml
+++ b/policies/vulnerability/vuln-container-critical-runtime.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        container_critical_runtime_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        container_critical_runtime_compliant: true
+      wantFinding: false

--- a/policies/vulnerability/vuln-critical-exception-expired.test.yaml
+++ b/policies/vulnerability/vuln-critical-exception-expired.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        critical_exception_expired_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        critical_exception_expired_compliant: true
+      wantFinding: false

--- a/policies/vulnerability/vuln-critical-no-owner.test.yaml
+++ b/policies/vulnerability/vuln-critical-no-owner.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        critical_no_owner_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        critical_no_owner_compliant: true
+      wantFinding: false

--- a/policies/vulnerability/vuln-critical-privileged-asset.test.yaml
+++ b/policies/vulnerability/vuln-critical-privileged-asset.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        critical_privileged_asset_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        critical_privileged_asset_compliant: true
+      wantFinding: false

--- a/policies/vulnerability/vuln-fix-available-not-patched.test.yaml
+++ b/policies/vulnerability/vuln-fix-available-not-patched.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        fix_available_not_patched_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        fix_available_not_patched_compliant: true
+      wantFinding: false

--- a/policies/vulnerability/vuln-kev-overdue.test.yaml
+++ b/policies/vulnerability/vuln-kev-overdue.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        kev_overdue_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        kev_overdue_compliant: true
+      wantFinding: false

--- a/policies/vulnerability/vuln-sla-breach-crown-jewel.test.yaml
+++ b/policies/vulnerability/vuln-sla-breach-crown-jewel.test.yaml
@@ -1,0 +1,11 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        sla_breach_crown_jewel_compliant: false
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        sla_breach_crown_jewel_compliant: true
+      wantFinding: false

--- a/policies/zendesk/resolution-time-breach.test.yaml
+++ b/policies/zendesk/resolution-time-breach.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        resolution_sla_breached: true
+        status: closed-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        resolution_sla_breached: false
+        status: closed-passing
+      wantFinding: false

--- a/policies/zendesk/zendesk-sla-breach.test.yaml
+++ b/policies/zendesk/zendesk-sla-breach.test.yaml
@@ -1,0 +1,13 @@
+apiVersion: cerebro.writer.com/v1alpha1
+kind: PolicyFindingRuleTest
+cases:
+    - name: matching resource produces a finding
+      resource:
+        first_response_sla_breached: true
+        status: closed-passing
+      wantFinding: true
+    - name: non-matching resource passes
+      resource:
+        first_response_sla_breached: false
+        status: closed-passing
+      wantFinding: false


### PR DESCRIPTION
## Intent

Expand deterministic policy-test authorship across the largest remaining scalar expression families while preserving executable proof as the admission gate.

## What changes

- support `cmp_ne`, `cmp_gt`, `cmp_lt`, `cmp_ge`, and `cmp_le`
- support scalar `in_list` membership fixtures
- support null equality and inequality
- derive ordered numeric and string boundary fixtures
- keep every later condition true while the passing fixture falsifies only the first condition
- reject path-to-path, compound, collection, and non-scalar semantics instead of guessing

## Validation

- `GOCACHE=/tmp/cerebro-test-foundry-gocache go test ./internal/findingdsl ./internal/testauthor/policy ./tools/testauthor`
- live scan identifies 347 newly authorable policies
- protected and weakened-policy proof tests pass

Stacked on #1916.