### PR TITLE
feat(testauthor): execute multi-hop graph fixtures

### DIFF
--- a/internal/findingdsl/graph_test_fixture.go
+++ b/internal/findingdsl/graph_test_fixture.go
@@ -64,8 +64,14 @@ func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleT
 }
 
 func containsTwoEdgePath(adjacency map[string][]string) bool {
-	for _, neighbors := range adjacency {
-		if len(neighbors) >= 2 {
+	for node, neighbors := range adjacency {
+		distinct := map[string]struct{}{}
+		for _, neighbor := range neighbors {
+			if neighbor != node {
+				distinct[neighbor] = struct{}{}
+			}
+		}
+		if len(distinct) >= 2 {
 			return true
 		}
 	}
@@ -111,23 +117,24 @@ func graphFixtureSingleEdgeMutation(finding, passing *PolicyGraphFixture) bool {
 	if !sameGraphFixtureNodes(findingNodes, passingNodes) {
 		return false
 	}
-	findingEdges, passingEdges := graphFixtureEdgeSet(finding.Edges), graphFixtureEdgeSet(passing.Edges)
+	findingEdges, passingEdges := graphFixtureEdgeMap(finding.Edges), graphFixtureEdgeMap(passing.Edges)
 	if len(findingEdges) != len(passingEdges)+1 {
 		return false
 	}
-	for edge := range passingEdges {
-		if _, ok := findingEdges[edge]; !ok {
+	for key, passingEdge := range passingEdges {
+		findingEdge, ok := findingEdges[key]
+		if !ok || findingEdge.SourceID != passingEdge.SourceID || findingEdge.RuntimeID != passingEdge.RuntimeID || !maps.Equal(findingEdge.Attributes, passingEdge.Attributes) {
 			return false
 		}
 	}
 	return true
 }
 
-func graphFixtureEdgeSet(edges []PolicyGraphFixtureEdge) map[string]struct{} {
-	out := make(map[string]struct{}, len(edges))
+func graphFixtureEdgeMap(edges []PolicyGraphFixtureEdge) map[string]PolicyGraphFixtureEdge {
+	out := make(map[string]PolicyGraphFixtureEdge, len(edges))
 	for _, edge := range edges {
 		key := strings.TrimSpace(edge.FromURN) + "\x00" + strings.TrimSpace(edge.Relation) + "\x00" + strings.TrimSpace(edge.ToURN)
-		out[key] = struct{}{}
+		out[key] = edge
 	}
 	return out
 }

--- a/internal/findingdsl/graph_test_fixture.go
+++ b/internal/findingdsl/graph_test_fixture.go
@@ -62,6 +62,78 @@ func containsTwoEdgePath(adjacency map[string][]string) bool {
 	return false
 }
 
+func validatePolicyGraphMutationPair(path string, cases []PolicyRuleTestCase) []Issue {
+	var findingCases, passingCases []PolicyRuleTestCase
+	for _, testCase := range cases {
+		if testCase.GraphFixture == nil {
+			continue
+		}
+		if testCase.WantFinding {
+			findingCases = append(findingCases, testCase)
+		} else {
+			passingCases = append(passingCases, testCase)
+		}
+	}
+	if len(findingCases)+len(passingCases) == 0 {
+		return nil
+	}
+	for _, findingCase := range findingCases {
+		for _, passingCase := range passingCases {
+			if graphFixtureSingleEdgeMutation(findingCase.GraphFixture, passingCase.GraphFixture) {
+				return nil
+			}
+		}
+	}
+	return []Issue{{Path: path, Message: "graphFixture suites require a finding case and a passing case with identical nodes and exactly one policy-critical edge removed"}}
+}
+
+func graphFixtureSingleEdgeMutation(finding, passing *PolicyGraphFixture) bool {
+	if finding == nil || passing == nil || strings.TrimSpace(finding.TenantID) != strings.TrimSpace(passing.TenantID) {
+		return false
+	}
+	findingNodes, passingNodes := map[string]struct{}{}, map[string]struct{}{}
+	for _, node := range finding.Nodes {
+		findingNodes[strings.TrimSpace(node.URN)] = struct{}{}
+	}
+	for _, node := range passing.Nodes {
+		passingNodes[strings.TrimSpace(node.URN)] = struct{}{}
+	}
+	if !sameStringSet(findingNodes, passingNodes) {
+		return false
+	}
+	findingEdges, passingEdges := graphFixtureEdgeSet(finding.Edges), graphFixtureEdgeSet(passing.Edges)
+	if len(findingEdges) != len(passingEdges)+1 {
+		return false
+	}
+	for edge := range passingEdges {
+		if _, ok := findingEdges[edge]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func graphFixtureEdgeSet(edges []PolicyGraphFixtureEdge) map[string]struct{} {
+	out := make(map[string]struct{}, len(edges))
+	for _, edge := range edges {
+		key := strings.TrimSpace(edge.FromURN) + "\x00" + strings.TrimSpace(edge.Relation) + "\x00" + strings.TrimSpace(edge.ToURN)
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func sameStringSet(left, right map[string]struct{}) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for value := range left {
+		if _, ok := right[value]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule PolicyFindingRule, testCase PolicyRuleTestCase) (err error) {
 	fixture := testCase.GraphFixture
 	for _, node := range fixture.Nodes {

--- a/internal/findingdsl/graph_test_fixture.go
+++ b/internal/findingdsl/graph_test_fixture.go
@@ -3,6 +3,7 @@ package findingdsl
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -18,7 +19,7 @@ func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleT
 	if len(fixture.Nodes) < 3 {
 		issues = append(issues, Issue{Path: path, Message: prefix + " must contain at least three nodes"})
 	}
-	if len(fixture.Edges) < 2 {
+	if testCase.WantFinding && len(fixture.Edges) < 2 {
 		issues = append(issues, Issue{Path: path, Message: prefix + " must contain at least two edges"})
 	}
 	nodes := make(map[string]struct{}, len(fixture.Nodes))
@@ -33,6 +34,7 @@ func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleT
 		nodes[urn] = struct{}{}
 	}
 	adjacency := map[string][]string{}
+	edges := map[string]struct{}{}
 	for edgeIndex, edge := range fixture.Edges {
 		from, to := strings.TrimSpace(edge.FromURN), strings.TrimSpace(edge.ToURN)
 		if _, ok := nodes[from]; !ok {
@@ -44,10 +46,18 @@ func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleT
 		if strings.TrimSpace(edge.SourceID) == "" || strings.TrimSpace(edge.Relation) == "" {
 			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d] requires sourceId and relation", prefix, edgeIndex)})
 		}
+		if from != "" && from == to {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d] must connect two distinct nodes", prefix, edgeIndex)})
+		}
+		edgeKey := from + "\x00" + strings.TrimSpace(edge.Relation) + "\x00" + to
+		if _, exists := edges[edgeKey]; exists {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d] duplicates an earlier edge", prefix, edgeIndex)})
+		}
+		edges[edgeKey] = struct{}{}
 		adjacency[from] = append(adjacency[from], to)
 		adjacency[to] = append(adjacency[to], from)
 	}
-	if !containsTwoEdgePath(adjacency) {
+	if testCase.WantFinding && !containsTwoEdgePath(adjacency) {
 		issues = append(issues, Issue{Path: path, Message: prefix + " must contain a connected path spanning two edges"})
 	}
 	return issues
@@ -91,14 +101,14 @@ func graphFixtureSingleEdgeMutation(finding, passing *PolicyGraphFixture) bool {
 	if finding == nil || passing == nil || strings.TrimSpace(finding.TenantID) != strings.TrimSpace(passing.TenantID) {
 		return false
 	}
-	findingNodes, passingNodes := map[string]struct{}{}, map[string]struct{}{}
+	findingNodes, passingNodes := map[string]PolicyGraphFixtureNode{}, map[string]PolicyGraphFixtureNode{}
 	for _, node := range finding.Nodes {
-		findingNodes[strings.TrimSpace(node.URN)] = struct{}{}
+		findingNodes[strings.TrimSpace(node.URN)] = node
 	}
 	for _, node := range passing.Nodes {
-		passingNodes[strings.TrimSpace(node.URN)] = struct{}{}
+		passingNodes[strings.TrimSpace(node.URN)] = node
 	}
-	if !sameStringSet(findingNodes, passingNodes) {
+	if !sameGraphFixtureNodes(findingNodes, passingNodes) {
 		return false
 	}
 	findingEdges, passingEdges := graphFixtureEdgeSet(finding.Edges), graphFixtureEdgeSet(passing.Edges)
@@ -122,12 +132,13 @@ func graphFixtureEdgeSet(edges []PolicyGraphFixtureEdge) map[string]struct{} {
 	return out
 }
 
-func sameStringSet(left, right map[string]struct{}) bool {
+func sameGraphFixtureNodes(left, right map[string]PolicyGraphFixtureNode) bool {
 	if len(left) != len(right) {
 		return false
 	}
-	for value := range left {
-		if _, ok := right[value]; !ok {
+	for urn, leftNode := range left {
+		rightNode, ok := right[urn]
+		if !ok || leftNode.URN != rightNode.URN || leftNode.SourceID != rightNode.SourceID || leftNode.RuntimeID != rightNode.RuntimeID || leftNode.EntityType != rightNode.EntityType || leftNode.Label != rightNode.Label || !maps.Equal(leftNode.Attributes, rightNode.Attributes) {
 			return false
 		}
 	}
@@ -136,6 +147,15 @@ func sameStringSet(left, right map[string]struct{}) bool {
 
 func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule PolicyFindingRule, testCase PolicyRuleTestCase) (err error) {
 	fixture := testCase.GraphFixture
+	projectedURNs := make([]string, 0, len(fixture.Nodes))
+	defer func() {
+		cleanupCtx := context.WithoutCancel(ctx)
+		for index := len(projectedURNs) - 1; index >= 0; index-- {
+			if cleanupErr := store.DeleteProjectedEntity(cleanupCtx, projectedURNs[index]); cleanupErr != nil && err == nil {
+				err = fmt.Errorf("delete fixture node %q: %w", projectedURNs[index], cleanupErr)
+			}
+		}
+	}()
 	for _, node := range fixture.Nodes {
 		if err := store.UpsertProjectedEntity(ctx, &ports.ProjectedEntity{
 			URN: node.URN, TenantID: fixture.TenantID, SourceID: node.SourceID, RuntimeID: node.RuntimeID,
@@ -143,14 +163,8 @@ func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule
 		}); err != nil {
 			return fmt.Errorf("project node %q: %w", node.URN, err)
 		}
+		projectedURNs = append(projectedURNs, node.URN)
 	}
-	defer func() {
-		for index := len(fixture.Nodes) - 1; index >= 0; index-- {
-			if cleanupErr := store.DeleteProjectedEntity(ctx, fixture.Nodes[index].URN); cleanupErr != nil && err == nil {
-				err = fmt.Errorf("delete fixture node %q: %w", fixture.Nodes[index].URN, cleanupErr)
-			}
-		}
-	}()
 	for _, edge := range fixture.Edges {
 		if err := store.UpsertProjectedLink(ctx, &ports.ProjectedLink{
 			TenantID: fixture.TenantID, SourceID: edge.SourceID, RuntimeID: edge.RuntimeID,
@@ -179,12 +193,40 @@ func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule
 	if issues := validatePolicyRuleTestCaseAgainstRule("<graph-fixture>", rule, 0, rowCase); len(issues) != 0 {
 		return fmt.Errorf("query result violates graph finding contract: %s", issues[0].Message)
 	}
+	if err := validateGraphFixtureEvidence(rows, testCase.WantEvidenceURNs); err != nil {
+		return err
+	}
 	got, err := EvaluatePolicyRuleTestCase(rule, rowCase)
 	if err != nil {
 		return err
 	}
 	if got != testCase.WantFinding {
 		return fmt.Errorf("finding = %t, want %t (query returned %d row(s))", got, testCase.WantFinding, len(rows))
+	}
+	return nil
+}
+
+func validateGraphFixtureEvidence(rows []ports.CypherRow, expectedURNs []string) error {
+	if len(expectedURNs) == 0 {
+		return nil
+	}
+	actual := map[string]struct{}{}
+	for _, row := range rows {
+		items, _ := row.Values["evidence"].([]any)
+		for _, item := range items {
+			values, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if urn := strings.TrimSpace(fmt.Sprintf("%v", values["urn"])); urn != "" && urn != "<nil>" {
+				actual[urn] = struct{}{}
+			}
+		}
+	}
+	for _, expected := range expectedURNs {
+		if _, ok := actual[strings.TrimSpace(expected)]; !ok {
+			return fmt.Errorf("query evidence missing expected URN %q", expected)
+		}
 	}
 	return nil
 }

--- a/internal/findingdsl/graph_test_fixture.go
+++ b/internal/findingdsl/graph_test_fixture.go
@@ -1,0 +1,118 @@
+package findingdsl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func validatePolicyGraphFixture(path string, caseIndex int, testCase PolicyRuleTestCase) []Issue {
+	fixture := testCase.GraphFixture
+	prefix := fmt.Sprintf("cases[%d] %q graphFixture", caseIndex, testCase.Name)
+	var issues []Issue
+	if strings.TrimSpace(fixture.TenantID) == "" {
+		issues = append(issues, Issue{Path: path, Message: prefix + ".tenantId is required"})
+	}
+	if len(fixture.Nodes) < 3 {
+		issues = append(issues, Issue{Path: path, Message: prefix + " must contain at least three nodes"})
+	}
+	if len(fixture.Edges) < 2 {
+		issues = append(issues, Issue{Path: path, Message: prefix + " must contain at least two edges"})
+	}
+	nodes := make(map[string]struct{}, len(fixture.Nodes))
+	for nodeIndex, node := range fixture.Nodes {
+		urn := strings.TrimSpace(node.URN)
+		if urn == "" || strings.TrimSpace(node.SourceID) == "" || strings.TrimSpace(node.EntityType) == "" {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.nodes[%d] requires urn, sourceId, and entityType", prefix, nodeIndex)})
+		}
+		if _, exists := nodes[urn]; exists && urn != "" {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.nodes[%d].urn %q is duplicated", prefix, nodeIndex, urn)})
+		}
+		nodes[urn] = struct{}{}
+	}
+	adjacency := map[string][]string{}
+	for edgeIndex, edge := range fixture.Edges {
+		from, to := strings.TrimSpace(edge.FromURN), strings.TrimSpace(edge.ToURN)
+		if _, ok := nodes[from]; !ok {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d].fromUrn does not reference a fixture node", prefix, edgeIndex)})
+		}
+		if _, ok := nodes[to]; !ok {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d].toUrn does not reference a fixture node", prefix, edgeIndex)})
+		}
+		if strings.TrimSpace(edge.SourceID) == "" || strings.TrimSpace(edge.Relation) == "" {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("%s.edges[%d] requires sourceId and relation", prefix, edgeIndex)})
+		}
+		adjacency[from] = append(adjacency[from], to)
+		adjacency[to] = append(adjacency[to], from)
+	}
+	if !containsTwoEdgePath(adjacency) {
+		issues = append(issues, Issue{Path: path, Message: prefix + " must contain a connected path spanning two edges"})
+	}
+	return issues
+}
+
+func containsTwoEdgePath(adjacency map[string][]string) bool {
+	for _, neighbors := range adjacency {
+		if len(neighbors) >= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+func runPolicyGraphFixture(ctx context.Context, store PolicyGraphTestStore, rule PolicyFindingRule, testCase PolicyRuleTestCase) (err error) {
+	fixture := testCase.GraphFixture
+	for _, node := range fixture.Nodes {
+		if err := store.UpsertProjectedEntity(ctx, &ports.ProjectedEntity{
+			URN: node.URN, TenantID: fixture.TenantID, SourceID: node.SourceID, RuntimeID: node.RuntimeID,
+			EntityType: node.EntityType, Label: node.Label, Attributes: node.Attributes,
+		}); err != nil {
+			return fmt.Errorf("project node %q: %w", node.URN, err)
+		}
+	}
+	defer func() {
+		for index := len(fixture.Nodes) - 1; index >= 0; index-- {
+			if cleanupErr := store.DeleteProjectedEntity(ctx, fixture.Nodes[index].URN); cleanupErr != nil && err == nil {
+				err = fmt.Errorf("delete fixture node %q: %w", fixture.Nodes[index].URN, cleanupErr)
+			}
+		}
+	}()
+	for _, edge := range fixture.Edges {
+		if err := store.UpsertProjectedLink(ctx, &ports.ProjectedLink{
+			TenantID: fixture.TenantID, SourceID: edge.SourceID, RuntimeID: edge.RuntimeID,
+			FromURN: edge.FromURN, ToURN: edge.ToURN, Relation: edge.Relation, Attributes: edge.Attributes,
+		}); err != nil {
+			return fmt.Errorf("project edge %q -[%s]-> %q: %w", edge.FromURN, edge.Relation, edge.ToURN, err)
+		}
+	}
+	params := make(map[string]any, len(rule.Spec.Graph.Params)+2)
+	for key, value := range rule.Spec.Graph.Params {
+		params[key] = value
+	}
+	params["tenant_id"] = fixture.TenantID
+	params["row_limit"] = int64(rule.Spec.Graph.RowLimit)
+	rows, err := store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: rule.Spec.Graph.Query, Params: params, RowLimit: rule.Spec.Graph.RowLimit})
+	if err != nil {
+		return fmt.Errorf("execute policy graph query: %w", err)
+	}
+	queryRows := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		queryRows = append(queryRows, row.Values)
+	}
+	rowCase := testCase
+	rowCase.GraphFixture = nil
+	rowCase.QueryRows = queryRows
+	if issues := validatePolicyRuleTestCaseAgainstRule("<graph-fixture>", rule, 0, rowCase); len(issues) != 0 {
+		return fmt.Errorf("query result violates graph finding contract: %s", issues[0].Message)
+	}
+	got, err := EvaluatePolicyRuleTestCase(rule, rowCase)
+	if err != nil {
+		return err
+	}
+	if got != testCase.WantFinding {
+		return fmt.Errorf("finding = %t, want %t (query returned %d row(s))", got, testCase.WantFinding, len(rows))
+	}
+	return nil
+}

--- a/internal/findingdsl/graph_test_fixture_test.go
+++ b/internal/findingdsl/graph_test_fixture_test.go
@@ -57,6 +57,25 @@ func TestValidatePolicyGraphFixtureRequiresConnectedTwoEdgePath(t *testing.T) {
 	}
 }
 
+func TestValidatePolicyGraphFixtureRequiresSingleEdgeMutationPair(t *testing.T) {
+	nodes := []PolicyGraphFixtureNode{
+		{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+		{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+		{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+	}
+	edges := []PolicyGraphFixtureEdge{
+		{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+		{FromURN: "b", ToURN: "c", SourceID: "okta", Relation: "assigned_to"},
+	}
+	suite := PolicyRuleTestSuite{APIVersion: APIVersion, Kind: KindPolicyFindingRuleTest, Cases: []PolicyRuleTestCase{
+		{Name: "finding only", GraphFixture: &PolicyGraphFixture{TenantID: "fixture", Nodes: nodes, Edges: edges}, WantFinding: true},
+	}}
+	issues := ValidatePolicyRuleTestSuite(suite)
+	if !issuesContain(issues, "exactly one policy-critical edge removed") {
+		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want mutation-pair issue", issues)
+	}
+}
+
 func TestRunPolicyGraphFixtureProjectsTopologyAndExecutesPolicyCypher(t *testing.T) {
 	rule := PolicyFindingRule{Spec: PolicyFindingRuleSpec{Graph: PolicyRuleGraphFinding{
 		Query: "MATCH (a)-[:RELATION]->(b)-[:RELATION]->(c) RETURN a.urn AS primary_urn", RowLimit: 25,

--- a/internal/findingdsl/graph_test_fixture_test.go
+++ b/internal/findingdsl/graph_test_fixture_test.go
@@ -2,6 +2,7 @@ package findingdsl
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -9,11 +10,12 @@ import (
 )
 
 type recordingPolicyGraphStore struct {
-	entities []*ports.ProjectedEntity
-	links    []*ports.ProjectedLink
-	deleted  []string
-	request  ports.CypherQueryRequest
-	rows     []ports.CypherRow
+	entities    []*ports.ProjectedEntity
+	links       []*ports.ProjectedLink
+	deleted     []string
+	request     ports.CypherQueryRequest
+	rows        []ports.CypherRow
+	entityErrAt int
 }
 
 func (s *recordingPolicyGraphStore) Ping(context.Context) error { return nil }
@@ -21,8 +23,27 @@ func (s *recordingPolicyGraphStore) GetEntityNeighborhood(context.Context, strin
 	return nil, nil
 }
 func (s *recordingPolicyGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if s.entityErrAt > 0 && len(s.entities)+1 == s.entityErrAt {
+		return errors.New("projection failed")
+	}
 	s.entities = append(s.entities, entity)
 	return nil
+}
+
+func TestRunPolicyGraphFixtureCleansUpPartialProjection(t *testing.T) {
+	fixture := &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+		{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+		{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+		{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+	}}
+	store := &recordingPolicyGraphStore{entityErrAt: 2}
+	err := runPolicyGraphFixture(context.Background(), store, PolicyFindingRule{}, PolicyRuleTestCase{GraphFixture: fixture})
+	if err == nil || !strings.Contains(err.Error(), "projection failed") {
+		t.Fatalf("runPolicyGraphFixture() error = %v, want projection failure", err)
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != "a" {
+		t.Fatalf("deleted = %#v, want first projected node cleaned up", store.deleted)
+	}
 }
 func (s *recordingPolicyGraphStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
 	s.links = append(s.links, link)
@@ -49,7 +70,7 @@ func TestValidatePolicyGraphFixtureRequiresConnectedTwoEdgePath(t *testing.T) {
 				{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
 				{FromURN: "c", ToURN: "d", SourceID: "okta", Relation: "grants_entitlement"},
 			},
-		}, WantFinding: false,
+		}, WantEvidenceURNs: []string{"b", "c"}, WantFinding: true,
 	}}}
 	issues := ValidatePolicyRuleTestSuite(suite)
 	if !issuesContain(issues, "must contain a connected path spanning two edges") {
@@ -91,8 +112,9 @@ func TestRunPolicyGraphFixtureProjectsTopologyAndExecutesPolicyCypher(t *testing
 	}}
 	store := &recordingPolicyGraphStore{rows: []ports.CypherRow{{Values: map[string]any{
 		"primary_urn": "a", "fingerprint_key": "a|c", "summary": "multi-hop access", "resource_urns": []string{"a", "b", "c"},
+		"evidence": []any{map[string]any{"urn": "b"}, map[string]any{"urn": "c"}},
 	}}}}
-	if err := runPolicyGraphFixture(context.Background(), store, rule, PolicyRuleTestCase{Name: "complete path", GraphFixture: fixture, WantFinding: true}); err != nil {
+	if err := runPolicyGraphFixture(context.Background(), store, rule, PolicyRuleTestCase{Name: "complete path", GraphFixture: fixture, WantEvidenceURNs: []string{"b", "c"}, WantFinding: true}); err != nil {
 		t.Fatalf("runPolicyGraphFixture() error = %v", err)
 	}
 	if len(store.entities) != 3 || len(store.links) != 2 || len(store.deleted) != 3 {
@@ -103,5 +125,38 @@ func TestRunPolicyGraphFixtureProjectsTopologyAndExecutesPolicyCypher(t *testing
 	}
 	if store.request.Params["tenant_id"] != "fixture" || store.request.Params["row_limit"] != int64(25) {
 		t.Fatalf("executed params = %#v", store.request.Params)
+	}
+}
+
+func TestGraphFixtureMutationRejectsNodeAttributeChanges(t *testing.T) {
+	finding := &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+		{URN: "a", SourceID: "okta", EntityType: "okta.user", Attributes: map[string]string{"status": "suspended"}},
+		{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+		{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+	}, Edges: []PolicyGraphFixtureEdge{
+		{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+		{FromURN: "b", ToURN: "c", SourceID: "okta", Relation: "assigned_to"},
+	}}
+	passing := *finding
+	passing.Nodes = append([]PolicyGraphFixtureNode(nil), finding.Nodes...)
+	passing.Nodes[0].Attributes = map[string]string{"status": "active"}
+	passing.Edges = append([]PolicyGraphFixtureEdge(nil), finding.Edges[1:]...)
+	if graphFixtureSingleEdgeMutation(finding, &passing) {
+		t.Fatal("graphFixtureSingleEdgeMutation() = true when node attributes changed")
+	}
+}
+
+func TestValidatePolicyGraphFixtureRejectsDuplicateEdges(t *testing.T) {
+	edge := PolicyGraphFixtureEdge{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"}
+	suite := PolicyRuleTestSuite{APIVersion: APIVersion, Kind: KindPolicyFindingRuleTest, Cases: []PolicyRuleTestCase{{
+		Name: "duplicate edge", GraphFixture: &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+			{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+			{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+			{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+		}, Edges: []PolicyGraphFixtureEdge{edge, edge}}, WantEvidenceURNs: []string{"b", "c"}, WantFinding: true,
+	}}}
+	issues := ValidatePolicyRuleTestSuite(suite)
+	if !issuesContain(issues, "duplicates an earlier edge") {
+		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want duplicate-edge issue", issues)
 	}
 }

--- a/internal/findingdsl/graph_test_fixture_test.go
+++ b/internal/findingdsl/graph_test_fixture_test.go
@@ -1,0 +1,88 @@
+package findingdsl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type recordingPolicyGraphStore struct {
+	entities []*ports.ProjectedEntity
+	links    []*ports.ProjectedLink
+	deleted  []string
+	request  ports.CypherQueryRequest
+	rows     []ports.CypherRow
+}
+
+func (s *recordingPolicyGraphStore) Ping(context.Context) error { return nil }
+func (s *recordingPolicyGraphStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
+	return nil, nil
+}
+func (s *recordingPolicyGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	s.entities = append(s.entities, entity)
+	return nil
+}
+func (s *recordingPolicyGraphStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	s.links = append(s.links, link)
+	return nil
+}
+func (s *recordingPolicyGraphStore) DeleteProjectedEntity(_ context.Context, urn string) error {
+	s.deleted = append(s.deleted, urn)
+	return nil
+}
+func (s *recordingPolicyGraphStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	s.request = request
+	return s.rows, nil
+}
+
+func TestValidatePolicyGraphFixtureRequiresConnectedTwoEdgePath(t *testing.T) {
+	suite := PolicyRuleTestSuite{APIVersion: APIVersion, Kind: KindPolicyFindingRuleTest, Cases: []PolicyRuleTestCase{{
+		Name: "disconnected edges do not prove a multi-hop path", GraphFixture: &PolicyGraphFixture{
+			TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+				{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+				{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+				{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+				{URN: "d", SourceID: "okta", EntityType: "okta.entitlement"},
+			}, Edges: []PolicyGraphFixtureEdge{
+				{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+				{FromURN: "c", ToURN: "d", SourceID: "okta", Relation: "grants_entitlement"},
+			},
+		}, WantFinding: false,
+	}}}
+	issues := ValidatePolicyRuleTestSuite(suite)
+	if !issuesContain(issues, "must contain a connected path spanning two edges") {
+		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want connected-path issue", issues)
+	}
+}
+
+func TestRunPolicyGraphFixtureProjectsTopologyAndExecutesPolicyCypher(t *testing.T) {
+	rule := PolicyFindingRule{Spec: PolicyFindingRuleSpec{Graph: PolicyRuleGraphFinding{
+		Query: "MATCH (a)-[:RELATION]->(b)-[:RELATION]->(c) RETURN a.urn AS primary_urn", RowLimit: 25,
+		RequiredColumns: []string{"primary_urn", "fingerprint_key", "summary", "resource_urns"},
+	}}}
+	fixture := &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+		{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+		{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+		{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+	}, Edges: []PolicyGraphFixtureEdge{
+		{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+		{FromURN: "b", ToURN: "c", SourceID: "okta", Relation: "assigned_to"},
+	}}
+	store := &recordingPolicyGraphStore{rows: []ports.CypherRow{{Values: map[string]any{
+		"primary_urn": "a", "fingerprint_key": "a|c", "summary": "multi-hop access", "resource_urns": []string{"a", "b", "c"},
+	}}}}
+	if err := runPolicyGraphFixture(context.Background(), store, rule, PolicyRuleTestCase{Name: "complete path", GraphFixture: fixture, WantFinding: true}); err != nil {
+		t.Fatalf("runPolicyGraphFixture() error = %v", err)
+	}
+	if len(store.entities) != 3 || len(store.links) != 2 || len(store.deleted) != 3 {
+		t.Fatalf("projection counts = nodes %d links %d deleted %d", len(store.entities), len(store.links), len(store.deleted))
+	}
+	if !strings.Contains(store.request.Query, "(a)-[:RELATION]->(b)-[:RELATION]->(c)") {
+		t.Fatalf("executed query = %q, want policy Cypher", store.request.Query)
+	}
+	if store.request.Params["tenant_id"] != "fixture" || store.request.Params["row_limit"] != int64(25) {
+		t.Fatalf("executed params = %#v", store.request.Params)
+	}
+}

--- a/internal/findingdsl/graph_test_fixture_test.go
+++ b/internal/findingdsl/graph_test_fixture_test.go
@@ -18,13 +18,15 @@ type recordingPolicyGraphStore struct {
 	entityErrAt int
 }
 
+var errFixtureProjection = errors.New("fixture projection failed")
+
 func (s *recordingPolicyGraphStore) Ping(context.Context) error { return nil }
 func (s *recordingPolicyGraphStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
 	return nil, nil
 }
 func (s *recordingPolicyGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
 	if s.entityErrAt > 0 && len(s.entities)+1 == s.entityErrAt {
-		return errors.New("projection failed")
+		return errFixtureProjection
 	}
 	s.entities = append(s.entities, entity)
 	return nil
@@ -38,7 +40,7 @@ func TestRunPolicyGraphFixtureCleansUpPartialProjection(t *testing.T) {
 	}}
 	store := &recordingPolicyGraphStore{entityErrAt: 2}
 	err := runPolicyGraphFixture(context.Background(), store, PolicyFindingRule{}, PolicyRuleTestCase{GraphFixture: fixture})
-	if err == nil || !strings.Contains(err.Error(), "projection failed") {
+	if !errors.Is(err, errFixtureProjection) {
 		t.Fatalf("runPolicyGraphFixture() error = %v, want projection failure", err)
 	}
 	if len(store.deleted) != 1 || store.deleted[0] != "a" {
@@ -158,5 +160,22 @@ func TestValidatePolicyGraphFixtureRejectsDuplicateEdges(t *testing.T) {
 	issues := ValidatePolicyRuleTestSuite(suite)
 	if !issuesContain(issues, "duplicates an earlier edge") {
 		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want duplicate-edge issue", issues)
+	}
+}
+
+func TestValidatePolicyGraphFixtureRejectsParallelEdgesAsTwoHopPath(t *testing.T) {
+	suite := PolicyRuleTestSuite{APIVersion: APIVersion, Kind: KindPolicyFindingRuleTest, Cases: []PolicyRuleTestCase{{
+		Name: "parallel edges", GraphFixture: &PolicyGraphFixture{TenantID: "fixture", Nodes: []PolicyGraphFixtureNode{
+			{URN: "a", SourceID: "okta", EntityType: "okta.user"},
+			{URN: "b", SourceID: "okta", EntityType: "okta.group"},
+			{URN: "c", SourceID: "okta", EntityType: "okta.application"},
+		}, Edges: []PolicyGraphFixtureEdge{
+			{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "member_of"},
+			{FromURN: "a", ToURN: "b", SourceID: "okta", Relation: "assigned_to"},
+		}}, WantEvidenceURNs: []string{"b", "c"}, WantFinding: true,
+	}}}
+	issues := ValidatePolicyRuleTestSuite(suite)
+	if !issuesContain(issues, "must contain a connected path spanning two edges") {
+		t.Fatalf("ValidatePolicyRuleTestSuite() issues = %#v, want connected-path issue", issues)
 	}
 }

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -25,11 +25,12 @@ type PolicyRuleTestSuite struct {
 }
 
 type PolicyRuleTestCase struct {
-	Name         string              `json:"name" yaml:"name"`
-	Resource     map[string]any      `json:"resource,omitempty" yaml:"resource,omitempty"`
-	QueryRows    []map[string]any    `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
-	GraphFixture *PolicyGraphFixture `json:"graphFixture,omitempty" yaml:"graphFixture,omitempty"`
-	WantFinding  bool                `json:"wantFinding" yaml:"wantFinding"`
+	Name             string              `json:"name" yaml:"name"`
+	Resource         map[string]any      `json:"resource,omitempty" yaml:"resource,omitempty"`
+	QueryRows        []map[string]any    `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
+	GraphFixture     *PolicyGraphFixture `json:"graphFixture,omitempty" yaml:"graphFixture,omitempty"`
+	WantEvidenceURNs []string            `json:"wantEvidenceUrns,omitempty" yaml:"wantEvidenceUrns,omitempty"`
+	WantFinding      bool                `json:"wantFinding" yaml:"wantFinding"`
 }
 
 // PolicyGraphFixture is a deterministic projected graph used to execute a
@@ -144,6 +145,12 @@ func ValidatePolicyRuleTestSuite(suite PolicyRuleTestSuite) []Issue {
 		}
 		if testCase.GraphFixture != nil {
 			issues = append(issues, validatePolicyGraphFixture(path, idx, testCase)...)
+			if testCase.WantFinding && len(testCase.WantEvidenceURNs) < 2 {
+				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] %q graph finding cases require at least two wantEvidenceUrns", idx, testCase.Name)})
+			}
+			if !testCase.WantFinding && len(testCase.WantEvidenceURNs) != 0 {
+				issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] %q passing graph cases must not declare wantEvidenceUrns", idx, testCase.Name)})
+			}
 		}
 	}
 	issues = append(issues, validatePolicyGraphMutationPair(path, suite.Cases)...)

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -146,6 +146,7 @@ func ValidatePolicyRuleTestSuite(suite PolicyRuleTestSuite) []Issue {
 			issues = append(issues, validatePolicyGraphFixture(path, idx, testCase)...)
 		}
 	}
+	issues = append(issues, validatePolicyGraphMutationPair(path, suite.Cases)...)
 	return issues
 }
 

--- a/internal/findingdsl/test_suite.go
+++ b/internal/findingdsl/test_suite.go
@@ -2,6 +2,7 @@ package findingdsl
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/writer/cerebro/internal/ports"
 	"gopkg.in/yaml.v3"
 )
 
@@ -23,10 +25,44 @@ type PolicyRuleTestSuite struct {
 }
 
 type PolicyRuleTestCase struct {
-	Name        string           `json:"name" yaml:"name"`
-	Resource    map[string]any   `json:"resource,omitempty" yaml:"resource,omitempty"`
-	QueryRows   []map[string]any `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
-	WantFinding bool             `json:"wantFinding" yaml:"wantFinding"`
+	Name         string              `json:"name" yaml:"name"`
+	Resource     map[string]any      `json:"resource,omitempty" yaml:"resource,omitempty"`
+	QueryRows    []map[string]any    `json:"queryRows,omitempty" yaml:"queryRows,omitempty"`
+	GraphFixture *PolicyGraphFixture `json:"graphFixture,omitempty" yaml:"graphFixture,omitempty"`
+	WantFinding  bool                `json:"wantFinding" yaml:"wantFinding"`
+}
+
+// PolicyGraphFixture is a deterministic projected graph used to execute a
+// policy's real Cypher. Multi-hop fixtures require a connected path spanning
+// at least two edges; precomputed query rows do not satisfy this contract.
+type PolicyGraphFixture struct {
+	TenantID string                   `json:"tenantId" yaml:"tenantId"`
+	Nodes    []PolicyGraphFixtureNode `json:"nodes" yaml:"nodes"`
+	Edges    []PolicyGraphFixtureEdge `json:"edges" yaml:"edges"`
+}
+
+type PolicyGraphFixtureNode struct {
+	URN        string            `json:"urn" yaml:"urn"`
+	SourceID   string            `json:"sourceId" yaml:"sourceId"`
+	RuntimeID  string            `json:"runtimeId,omitempty" yaml:"runtimeId,omitempty"`
+	EntityType string            `json:"entityType" yaml:"entityType"`
+	Label      string            `json:"label,omitempty" yaml:"label,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
+}
+
+type PolicyGraphFixtureEdge struct {
+	FromURN    string            `json:"fromUrn" yaml:"fromUrn"`
+	ToURN      string            `json:"toUrn" yaml:"toUrn"`
+	SourceID   string            `json:"sourceId" yaml:"sourceId"`
+	RuntimeID  string            `json:"runtimeId,omitempty" yaml:"runtimeId,omitempty"`
+	Relation   string            `json:"relation" yaml:"relation"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
+}
+
+type PolicyGraphTestStore interface {
+	ports.GraphQueryStore
+	ports.ProjectionGraphStore
+	ports.ProjectionEntityDeleter
 }
 
 func DiscoverPolicyTestSuites(root string) ([]string, error) {
@@ -103,8 +139,11 @@ func ValidatePolicyRuleTestSuite(suite PolicyRuleTestSuite) []Issue {
 		if strings.TrimSpace(testCase.Name) == "" {
 			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d].name is required", idx)})
 		}
-		if len(testCase.Resource) == 0 && len(testCase.QueryRows) == 0 {
-			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] must include resource or queryRows", idx)})
+		if len(testCase.Resource) == 0 && len(testCase.QueryRows) == 0 && testCase.GraphFixture == nil {
+			issues = append(issues, Issue{Path: path, Message: fmt.Sprintf("cases[%d] must include resource, queryRows, or graphFixture", idx)})
+		}
+		if testCase.GraphFixture != nil {
+			issues = append(issues, validatePolicyGraphFixture(path, idx, testCase)...)
 		}
 	}
 	return issues
@@ -144,6 +183,11 @@ func RunPolicyRuleTestSuite(root string, suitePath string) []Issue {
 			out = append(out, caseIssues...)
 			continue
 		}
+		if testCase.GraphFixture != nil {
+			// The normal policy test lane validates the topology contract. The
+			// graph integration lane executes these cases against Neo4j.
+			continue
+		}
 		got, err := EvaluatePolicyRuleTestCase(rule, testCase)
 		if err != nil {
 			out = append(out, Issue{Path: suite.RelPath, Message: fmt.Sprintf("cases[%d] %q: %v", idx, testCase.Name, err)})
@@ -151,6 +195,42 @@ func RunPolicyRuleTestSuite(root string, suitePath string) []Issue {
 		}
 		if got != testCase.WantFinding {
 			out = append(out, Issue{Path: suite.RelPath, Message: fmt.Sprintf("cases[%d] %q: finding = %t, want %t", idx, testCase.Name, got, testCase.WantFinding)})
+		}
+	}
+	return out
+}
+
+// RunPolicyRuleTestSuiteWithGraphStore projects each authored topology and
+// executes the policy's real Cypher through the production graph boundary.
+func RunPolicyRuleTestSuiteWithGraphStore(ctx context.Context, root string, suitePath string, store PolicyGraphTestStore) []Issue {
+	suite, issues, err := LoadPolicyRuleTestSuite(root, suitePath)
+	if err != nil {
+		return []Issue{{Path: suitePath, Message: err.Error()}}
+	}
+	if len(issues) != 0 {
+		return issues
+	}
+	policyRel := strings.TrimSpace(suite.Policy)
+	if policyRel == "" {
+		policyRel = policyRelForSuite(suite.RelPath)
+	}
+	rule, ruleIssues, err := LoadPolicyRuleFile(root, filepath.Join(root, filepath.FromSlash(policyRel)))
+	if err != nil {
+		return []Issue{{Path: suite.RelPath, Message: err.Error()}}
+	}
+	if len(ruleIssues) != 0 {
+		return ruleIssues
+	}
+	if strings.TrimSpace(rule.Spec.Graph.Query) == "" {
+		return []Issue{{Path: suite.RelPath, Message: "graphFixture requires spec.graph.query"}}
+	}
+	var out []Issue
+	for idx, testCase := range suite.Cases {
+		if testCase.GraphFixture == nil {
+			continue
+		}
+		if err := runPolicyGraphFixture(ctx, store, rule, testCase); err != nil {
+			out = append(out, Issue{Path: suite.RelPath, Message: fmt.Sprintf("cases[%d] %q: %v", idx, testCase.Name, err)})
 		}
 	}
 	return out
@@ -176,6 +256,15 @@ func EvaluatePolicyRuleTestCase(rule PolicyFindingRule, testCase PolicyRuleTestC
 }
 
 func validatePolicyRuleTestCaseAgainstRule(path string, rule PolicyFindingRule, idx int, testCase PolicyRuleTestCase) []Issue {
+	if testCase.GraphFixture != nil {
+		if strings.TrimSpace(rule.Spec.Graph.Query) == "" {
+			return []Issue{{Path: path, Message: fmt.Sprintf("cases[%d] %q graphFixture requires spec.graph.query", idx, testCase.Name)}}
+		}
+		if len(testCase.Resource) != 0 || len(testCase.QueryRows) != 0 {
+			return []Issue{{Path: path, Message: fmt.Sprintf("cases[%d] %q graphFixture cannot be combined with resource or queryRows", idx, testCase.Name)}}
+		}
+		return nil
+	}
 	if strings.TrimSpace(rule.Spec.Graph.Query) == "" {
 		return nil
 	}

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -7,12 +7,14 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/findingdsl"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/projectionmeta"
 
@@ -580,6 +582,8 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 			t.Fatalf("preserved link missing: %s %s %s", link.FromURN, link.Relation, link.ToURN)
 		}
 	}
+
+	runAuthoredPolicyGraphFixtures(t, ctx, store)
 }
 
 func TestNeo4jDockerBackfillEntityTypedProperties(t *testing.T) {
@@ -682,6 +686,32 @@ func TestNeo4jDockerBackfillEntityTypedProperties(t *testing.T) {
 	}
 	if after.EntitiesMatched != 0 {
 		t.Fatalf("dry-run after backfill matched %d entities, want 0", after.EntitiesMatched)
+	}
+
+}
+
+func runAuthoredPolicyGraphFixtures(t *testing.T, ctx context.Context, store *Store) {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	paths, err := findingdsl.DiscoverPolicyTestSuites(repoRoot)
+	if err != nil {
+		t.Fatalf("discover authored policy graph fixtures: %v", err)
+	}
+	for _, path := range paths {
+		suite, issues, err := findingdsl.LoadPolicyRuleTestSuite(repoRoot, filepath.Join(repoRoot, filepath.FromSlash(path)))
+		if err != nil || len(issues) != 0 {
+			continue // The normal findingdsl lane reports malformed suites.
+		}
+		hasGraphFixture := false
+		for _, testCase := range suite.Cases {
+			hasGraphFixture = hasGraphFixture || testCase.GraphFixture != nil
+		}
+		if !hasGraphFixture {
+			continue
+		}
+		if issues := findingdsl.RunPolicyRuleTestSuiteWithGraphStore(ctx, repoRoot, filepath.Join(repoRoot, filepath.FromSlash(path)), store); len(issues) != 0 {
+			t.Fatalf("authored graph policy suite %s failed: %#v", path, issues)
+		}
 	}
 }
 

--- a/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
+++ b/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
@@ -1,22 +1,54 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: dormant admin role assignment fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-admin
-        primary_label: admin@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-admin|urn:cerebro:writer:okta_admin_role:org-admin
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-admin
-          - urn:cerebro:writer:okta_admin_role:org-admin
-        severity: HIGH
-        summary: Okta admin admin@example.com has stale login activity for role org-admin
-        action: Remove the admin role or document active break-glass review evidence
-        evidence:
-          - urn: urn:cerebro:writer:okta_admin_role:org-admin
+  - name: dormant user to admin capability path produces a finding
+    graphFixture:
+      tenantId: test-dormant-admin
+      nodes: &nodes
+        - urn: urn:cerebro:test-dormant-admin:okta:user:dormant-admin
+          sourceId: okta
+          entityType: okta.user
+          label: dormant-admin@example.com
+          attributes:
+            status: active
+            last_login_at: "2020-01-01T00:00:00Z"
+        - urn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          sourceId: okta
+          entityType: okta.admin_role
+          label: Organization administrator
+        - urn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Organization administrator
+        - urn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Identity administrator
+      edges:
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:user:dormant-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          sourceId: okta
+          relation: can_admin
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: recent admin role assignment passes
-    resource:
-      placeholder: true
+  - name: admin capability path without dormant user assignment passes
+    graphFixture:
+      tenantId: test-dormant-admin
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
+++ b/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
@@ -37,6 +37,10 @@ cases:
           toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+      - urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+      - urn:cerebro:test-dormant-admin:access:capability:identity-admin
     wantFinding: true
   - name: admin capability path without dormant user assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -12,12 +12,12 @@ cases:
         - urn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
           sourceId: okta
           entityType: okta.application
-          label: Cloud Console
+          label: Workforce Portal
         - urn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
           sourceId: okta
           entityType: okta.entitlement
           label: Console administrator
-        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           entityType: access.capability
           label: Cloud administrator
@@ -31,21 +31,21 @@ cases:
           sourceId: okta
           relation: grants_entitlement
         - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
-          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           relation: confers_capability
     wantFinding: true
-  - name: downstream capability path without group assignment passes
+  - name: group application entitlement path without admin capability passes
     graphFixture:
       tenantId: test-group-admin-path
       nodes: *nodes
       edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          toUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          relation: assigned_to
         - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
           toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
           sourceId: okta
           relation: grants_entitlement
-        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
-          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
-          sourceId: okta
-          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -1,22 +1,51 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: group grants admin app access fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_group:admins
-        primary_label: Finance Admins
-        primary_type: okta.group
-        fingerprint_key: urn:cerebro:writer:okta_group:admins|urn:cerebro:writer:okta_application:admin-console
-        resource_urns:
-          - urn:cerebro:writer:okta_group:admins
-          - urn:cerebro:writer:okta_application:admin-console
-        severity: HIGH
-        summary: Okta group Finance Admins grants admin-like access to Admin Console
-        action: Review group membership and split broad admin application access
-        evidence:
-          - urn: urn:cerebro:writer:okta_application:admin-console
+  - name: group to admin capability path produces a finding
+    graphFixture:
+      tenantId: test-group-admin-path
+      nodes: &nodes
+        - urn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          sourceId: okta
+          entityType: okta.group
+          label: Security Operators
+        - urn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          entityType: okta.application
+          label: Cloud Console
+        - urn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Console administrator
+        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Cloud administrator
+      edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          toUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: group scoped away from admin app passes
-    resource:
-      placeholder: true
+  - name: downstream capability path without group assignment passes
+    graphFixture:
+      tenantId: test-group-admin-path
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -34,6 +34,10 @@ cases:
           toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-group-admin-path:okta:application:cloud-console
+      - urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+      - urn:cerebro:test-group-admin-path:access:capability:cloud_admin
     wantFinding: true
   - name: group application entitlement path without admin capability passes
     graphFixture:

--- a/policies/identity/identity-okta-privileged-missing-owner.test.yaml
+++ b/policies/identity/identity-okta-privileged-missing-owner.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: privileged account without owner fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-ownerless
-        primary_label: platform-admin@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-ownerless
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-ownerless
-          - urn:cerebro:writer:okta_admin_role:super-admin
-        severity: HIGH
-        summary: Okta privileged account platform-admin@example.com has no lifecycle owner evidence
-        action: Add manager or owner evidence before accepting privileged access
-        evidence:
-          - urn: urn:cerebro:writer:okta_admin_role:super-admin
+  - name: ownerless user to privileged capability path produces a finding
+    graphFixture:
+      tenantId: test-missing-owner
+      nodes: &nodes
+        - urn: urn:cerebro:test-missing-owner:okta:user:break-glass
+          sourceId: okta
+          entityType: okta.user
+          label: break-glass@example.com
+          attributes:
+            status: active
+        - urn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          sourceId: okta
+          entityType: okta.admin_role
+          label: Super administrator
+        - urn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Tenant administrator
+        - urn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Identity administrator
+      edges:
+        - fromUrn: urn:cerebro:test-missing-owner:okta:user:break-glass
+          toUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          sourceId: okta
+          relation: can_admin
+        - fromUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          toUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: privileged account with owner evidence passes
-    resource:
-      placeholder: true
+  - name: privileged capability path without user role assignment passes
+    graphFixture:
+      tenantId: test-missing-owner
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          toUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-privileged-missing-owner.test.yaml
+++ b/policies/identity/identity-okta-privileged-missing-owner.test.yaml
@@ -36,6 +36,10 @@ cases:
           toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+      - urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+      - urn:cerebro:test-missing-owner:access:capability:identity-admin
     wantFinding: true
   - name: privileged capability path without user role assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
+++ b/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
@@ -20,10 +20,6 @@ cases:
           sourceId: okta
           entityType: okta.application
           label: Deployment console
-        - urn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          entityType: okta.entitlement
-          label: Deploy production
       edges:
         - fromUrn: urn:cerebro:test-stale-group:okta:user:bob
           toUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
@@ -33,10 +29,9 @@ cases:
           toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
-          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          relation: grants_entitlement
+    wantEvidenceUrns:
+      - urn:cerebro:test-stale-group:okta:group:engineering-admins
+      - urn:cerebro:test-stale-group:okta:application:deployment-console
     wantFinding: true
   - name: group application path without stale membership passes
     graphFixture:
@@ -47,8 +42,4 @@ cases:
           toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
-          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
+++ b/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
@@ -1,22 +1,54 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: stale group membership fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-dormant
-        primary_label: dormant@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-dormant|urn:cerebro:writer:okta_group:finance-users
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-dormant
-          - urn:cerebro:writer:okta_group:finance-users
-        severity: HIGH
-        summary: Okta group membership for dormant@example.com is stale in Finance Users
-        action: Remove stale group membership or document the approved need
-        evidence:
-          - urn: urn:cerebro:writer:okta_group:finance-users
+  - name: stale user through group to application path produces a finding
+    graphFixture:
+      tenantId: test-stale-group
+      nodes: &nodes
+        - urn: urn:cerebro:test-stale-group:okta:user:bob
+          sourceId: okta
+          entityType: okta.user
+          label: bob@example.com
+          attributes:
+            status: active
+            last_login_at: "2020-01-01T00:00:00Z"
+        - urn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          sourceId: okta
+          entityType: okta.group
+          label: Engineering administrators
+        - urn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          entityType: okta.application
+          label: Deployment console
+        - urn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Deploy production
+      edges:
+        - fromUrn: urn:cerebro:test-stale-group:okta:user:bob
+          toUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          sourceId: okta
+          relation: member_of
+        - fromUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: true
-  - name: recent group member passes
-    resource:
-      placeholder: true
+  - name: group application path without stale membership passes
+    graphFixture:
+      tenantId: test-stale-group
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: suspended user with active app assignment fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-suspended
-        primary_label: suspended@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-suspended|urn:cerebro:writer:okta_application:app-payroll
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-suspended
-          - urn:cerebro:writer:okta_application:app-payroll
-        severity: HIGH
-        summary: Okta suspended user suspended@example.com still has active assignment to Payroll
-        action: Remove app assignment and verify downstream deprovisioning
-        evidence:
-          - urn: urn:cerebro:writer:okta_application:app-payroll
+  - name: suspended user to capability path produces a finding
+    graphFixture:
+      tenantId: test-suspended-assignment
+      nodes: &nodes
+        - urn: urn:cerebro:test-suspended-assignment:okta:user:alice
+          sourceId: okta
+          entityType: okta.user
+          label: alice@example.com
+          attributes:
+            status: suspended
+        - urn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          sourceId: okta
+          entityType: okta.application
+          label: Payroll
+        - urn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Payroll admin
+        - urn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          entityType: access.capability
+          label: Payroll write
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:user:alice
+          toUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: suspended user without app assignment passes
-    resource:
-      placeholder: true
+  - name: entitlement path without user assignment passes
+    graphFixture:
+      tenantId: test-suspended-assignment
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
@@ -36,6 +36,10 @@ cases:
           toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-suspended-assignment:okta:application:payroll
+      - urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+      - urn:cerebro:test-suspended-assignment:access:capability:payroll-write
     wantFinding: true
   - name: entitlement path without user assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: suspended user with active group membership fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-suspended
-        primary_label: suspended@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-suspended|urn:cerebro:writer:okta_group:finance-users
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-suspended
-          - urn:cerebro:writer:okta_group:finance-users
-        severity: HIGH
-        summary: Okta suspended user suspended@example.com remains in group Finance Users
-        action: Remove stale group membership and verify downstream access removal
-        evidence:
-          - urn: urn:cerebro:writer:okta_group:finance-users
+  - name: suspended user through group to application path produces a finding
+    graphFixture:
+      tenantId: test-suspended-group
+      nodes: &nodes
+        - urn: urn:cerebro:test-suspended-group:okta:user:alice
+          sourceId: okta
+          entityType: okta.user
+          label: alice@example.com
+          attributes:
+            status: deprovisioned
+        - urn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          sourceId: okta
+          entityType: okta.group
+          label: Finance administrators
+        - urn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          entityType: okta.application
+          label: Payroll
+        - urn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Payroll write
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-group:okta:user:alice
+          toUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          sourceId: okta
+          relation: member_of
+        - fromUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: true
-  - name: suspended user without group membership passes
-    resource:
-      placeholder: true
+  - name: group application path without suspended membership passes
+    graphFixture:
+      tenantId: test-suspended-group
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
@@ -19,10 +19,6 @@ cases:
           sourceId: okta
           entityType: okta.application
           label: Payroll
-        - urn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          entityType: okta.entitlement
-          label: Payroll write
       edges:
         - fromUrn: urn:cerebro:test-suspended-group:okta:user:alice
           toUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
@@ -32,10 +28,9 @@ cases:
           toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
-          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          relation: grants_entitlement
+    wantEvidenceUrns:
+      - urn:cerebro:test-suspended-group:okta:group:finance-admins
+      - urn:cerebro:test-suspended-group:okta:application:payroll
     wantFinding: true
   - name: group application path without suspended membership passes
     graphFixture:
@@ -46,8 +41,4 @@ cases:
           toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
-          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          relation: grants_entitlement
     wantFinding: false


### PR DESCRIPTION
## Intent

Make authored graph-policy tests prove traversal through real projected topology instead of accepting precomputed query rows as graph coverage.

## What changed

- adds graphFixture nodes and edges to PolicyFindingRuleTest cases
- requires at least three nodes and a connected path spanning two edges
- projects fixtures through Cerebro graph projection ports
- executes each policy unchanged through the production read-only Cypher boundary
- validates graph finding return aliases and the expected finding outcome
- cleans each topology between cases
- runs authored topology suites in the existing Neo4j integration lane

## Verification

- go test ./internal/findingdsl ./internal/graphstore/neo4j ./tools/findingdsl ./tools/testauthor
- git diff --check

## Stack

Base: #1918