### PR TITLE
test(policies): prove six multi-hop identity paths

### DIFF
--- a/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
+++ b/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
@@ -1,22 +1,54 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: dormant admin role assignment fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-admin
-        primary_label: admin@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-admin|urn:cerebro:writer:okta_admin_role:org-admin
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-admin
-          - urn:cerebro:writer:okta_admin_role:org-admin
-        severity: HIGH
-        summary: Okta admin admin@example.com has stale login activity for role org-admin
-        action: Remove the admin role or document active break-glass review evidence
-        evidence:
-          - urn: urn:cerebro:writer:okta_admin_role:org-admin
+  - name: dormant user to admin capability path produces a finding
+    graphFixture:
+      tenantId: test-dormant-admin
+      nodes: &nodes
+        - urn: urn:cerebro:test-dormant-admin:okta:user:dormant-admin
+          sourceId: okta
+          entityType: okta.user
+          label: dormant-admin@example.com
+          attributes:
+            status: active
+            last_login_at: "2020-01-01T00:00:00Z"
+        - urn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          sourceId: okta
+          entityType: okta.admin_role
+          label: Organization administrator
+        - urn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Organization administrator
+        - urn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Identity administrator
+      edges:
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:user:dormant-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          sourceId: okta
+          relation: can_admin
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: recent admin role assignment passes
-    resource:
-      placeholder: true
+  - name: admin capability path without dormant user assignment passes
+    graphFixture:
+      tenantId: test-dormant-admin
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+          toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
+++ b/policies/identity/identity-okta-dormant-admin-role-assignment.test.yaml
@@ -37,6 +37,10 @@ cases:
           toUrn: urn:cerebro:test-dormant-admin:access:capability:identity-admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-dormant-admin:okta:admin-role:org-admin
+      - urn:cerebro:test-dormant-admin:okta:entitlement:org-admin
+      - urn:cerebro:test-dormant-admin:access:capability:identity-admin
     wantFinding: true
   - name: admin capability path without dormant user assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -12,12 +12,12 @@ cases:
         - urn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
           sourceId: okta
           entityType: okta.application
-          label: Cloud Console
+          label: Workforce Portal
         - urn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
           sourceId: okta
           entityType: okta.entitlement
           label: Console administrator
-        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           entityType: access.capability
           label: Cloud administrator
@@ -31,21 +31,21 @@ cases:
           sourceId: okta
           relation: grants_entitlement
         - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
-          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           relation: confers_capability
     wantFinding: true
-  - name: downstream capability path without group assignment passes
+  - name: group application entitlement path without admin capability passes
     graphFixture:
       tenantId: test-group-admin-path
       nodes: *nodes
       edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          toUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          relation: assigned_to
         - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
           toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
           sourceId: okta
           relation: grants_entitlement
-        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
-          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
-          sourceId: okta
-          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -1,22 +1,51 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: group grants admin app access fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_group:admins
-        primary_label: Finance Admins
-        primary_type: okta.group
-        fingerprint_key: urn:cerebro:writer:okta_group:admins|urn:cerebro:writer:okta_application:admin-console
-        resource_urns:
-          - urn:cerebro:writer:okta_group:admins
-          - urn:cerebro:writer:okta_application:admin-console
-        severity: HIGH
-        summary: Okta group Finance Admins grants admin-like access to Admin Console
-        action: Review group membership and split broad admin application access
-        evidence:
-          - urn: urn:cerebro:writer:okta_application:admin-console
+  - name: group to admin capability path produces a finding
+    graphFixture:
+      tenantId: test-group-admin-path
+      nodes: &nodes
+        - urn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          sourceId: okta
+          entityType: okta.group
+          label: Security Operators
+        - urn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          entityType: okta.application
+          label: Cloud Console
+        - urn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Console administrator
+        - urn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Cloud administrator
+      edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:group:security-operators
+          toUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: group scoped away from admin app passes
-    resource:
-      placeholder: true
+  - name: downstream capability path without group assignment passes
+    graphFixture:
+      tenantId: test-group-admin-path
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:application:cloud-console
+          toUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+          toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
+++ b/policies/identity/identity-okta-group-grants-admin-app-graph.test.yaml
@@ -34,6 +34,10 @@ cases:
           toUrn: urn:cerebro:test-group-admin-path:access:capability:cloud_admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-group-admin-path:okta:application:cloud-console
+      - urn:cerebro:test-group-admin-path:okta:entitlement:console-admin
+      - urn:cerebro:test-group-admin-path:access:capability:cloud_admin
     wantFinding: true
   - name: group application entitlement path without admin capability passes
     graphFixture:

--- a/policies/identity/identity-okta-privileged-missing-owner.test.yaml
+++ b/policies/identity/identity-okta-privileged-missing-owner.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: privileged account without owner fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-ownerless
-        primary_label: platform-admin@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-ownerless
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-ownerless
-          - urn:cerebro:writer:okta_admin_role:super-admin
-        severity: HIGH
-        summary: Okta privileged account platform-admin@example.com has no lifecycle owner evidence
-        action: Add manager or owner evidence before accepting privileged access
-        evidence:
-          - urn: urn:cerebro:writer:okta_admin_role:super-admin
+  - name: ownerless user to privileged capability path produces a finding
+    graphFixture:
+      tenantId: test-missing-owner
+      nodes: &nodes
+        - urn: urn:cerebro:test-missing-owner:okta:user:break-glass
+          sourceId: okta
+          entityType: okta.user
+          label: break-glass@example.com
+          attributes:
+            status: active
+        - urn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          sourceId: okta
+          entityType: okta.admin_role
+          label: Super administrator
+        - urn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Tenant administrator
+        - urn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          entityType: access.capability
+          label: Identity administrator
+      edges:
+        - fromUrn: urn:cerebro:test-missing-owner:okta:user:break-glass
+          toUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          sourceId: okta
+          relation: can_admin
+        - fromUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          toUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: privileged account with owner evidence passes
-    resource:
-      placeholder: true
+  - name: privileged capability path without user role assignment passes
+    graphFixture:
+      tenantId: test-missing-owner
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+          toUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+          toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-privileged-missing-owner.test.yaml
+++ b/policies/identity/identity-okta-privileged-missing-owner.test.yaml
@@ -36,6 +36,10 @@ cases:
           toUrn: urn:cerebro:test-missing-owner:access:capability:identity-admin
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-missing-owner:okta:admin-role:super-admin
+      - urn:cerebro:test-missing-owner:okta:entitlement:tenant-admin
+      - urn:cerebro:test-missing-owner:access:capability:identity-admin
     wantFinding: true
   - name: privileged capability path without user role assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
+++ b/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
@@ -20,10 +20,6 @@ cases:
           sourceId: okta
           entityType: okta.application
           label: Deployment console
-        - urn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          entityType: okta.entitlement
-          label: Deploy production
       edges:
         - fromUrn: urn:cerebro:test-stale-group:okta:user:bob
           toUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
@@ -33,10 +29,9 @@ cases:
           toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
-          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          relation: grants_entitlement
+    wantEvidenceUrns:
+      - urn:cerebro:test-stale-group:okta:group:engineering-admins
+      - urn:cerebro:test-stale-group:okta:application:deployment-console
     wantFinding: true
   - name: group application path without stale membership passes
     graphFixture:
@@ -47,8 +42,4 @@ cases:
           toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
-          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
-          sourceId: okta
-          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
+++ b/policies/identity/identity-okta-stale-group-membership-graph-90d.test.yaml
@@ -1,22 +1,54 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: stale group membership fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-dormant
-        primary_label: dormant@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-dormant|urn:cerebro:writer:okta_group:finance-users
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-dormant
-          - urn:cerebro:writer:okta_group:finance-users
-        severity: HIGH
-        summary: Okta group membership for dormant@example.com is stale in Finance Users
-        action: Remove stale group membership or document the approved need
-        evidence:
-          - urn: urn:cerebro:writer:okta_group:finance-users
+  - name: stale user through group to application path produces a finding
+    graphFixture:
+      tenantId: test-stale-group
+      nodes: &nodes
+        - urn: urn:cerebro:test-stale-group:okta:user:bob
+          sourceId: okta
+          entityType: okta.user
+          label: bob@example.com
+          attributes:
+            status: active
+            last_login_at: "2020-01-01T00:00:00Z"
+        - urn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          sourceId: okta
+          entityType: okta.group
+          label: Engineering administrators
+        - urn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          entityType: okta.application
+          label: Deployment console
+        - urn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Deploy production
+      edges:
+        - fromUrn: urn:cerebro:test-stale-group:okta:user:bob
+          toUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          sourceId: okta
+          relation: member_of
+        - fromUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: true
-  - name: recent group member passes
-    resource:
-      placeholder: true
+  - name: group application path without stale membership passes
+    graphFixture:
+      tenantId: test-stale-group
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-stale-group:okta:group:engineering-admins
+          toUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-stale-group:okta:application:deployment-console
+          toUrn: urn:cerebro:test-stale-group:okta:entitlement:deploy-production
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: suspended user with active app assignment fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-suspended
-        primary_label: suspended@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-suspended|urn:cerebro:writer:okta_application:app-payroll
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-suspended
-          - urn:cerebro:writer:okta_application:app-payroll
-        severity: HIGH
-        summary: Okta suspended user suspended@example.com still has active assignment to Payroll
-        action: Remove app assignment and verify downstream deprovisioning
-        evidence:
-          - urn: urn:cerebro:writer:okta_application:app-payroll
+  - name: suspended user to capability path produces a finding
+    graphFixture:
+      tenantId: test-suspended-assignment
+      nodes: &nodes
+        - urn: urn:cerebro:test-suspended-assignment:okta:user:alice
+          sourceId: okta
+          entityType: okta.user
+          label: alice@example.com
+          attributes:
+            status: suspended
+        - urn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          sourceId: okta
+          entityType: okta.application
+          label: Payroll
+        - urn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Payroll admin
+        - urn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          entityType: access.capability
+          label: Payroll write
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:user:alice
+          toUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          relation: confers_capability
     wantFinding: true
-  - name: suspended user without app assignment passes
-    resource:
-      placeholder: true
+  - name: entitlement path without user assignment passes
+    graphFixture:
+      tenantId: test-suspended-assignment
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          sourceId: okta
+          relation: grants_entitlement
+        - fromUrn: urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+          toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
+          sourceId: okta
+          relation: confers_capability
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-assignment.test.yaml
@@ -36,6 +36,10 @@ cases:
           toUrn: urn:cerebro:test-suspended-assignment:access:capability:payroll-write
           sourceId: okta
           relation: confers_capability
+    wantEvidenceUrns:
+      - urn:cerebro:test-suspended-assignment:okta:application:payroll
+      - urn:cerebro:test-suspended-assignment:okta:entitlement:payroll-admin
+      - urn:cerebro:test-suspended-assignment:access:capability:payroll-write
     wantFinding: true
   - name: entitlement path without user assignment passes
     graphFixture:

--- a/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
@@ -1,22 +1,53 @@
 apiVersion: cerebro.writer.com/v1alpha1
 kind: PolicyFindingRuleTest
 cases:
-  - name: suspended user with active group membership fails
-    queryRows:
-      - primary_urn: urn:cerebro:writer:okta_user:00u-suspended
-        primary_label: suspended@example.com
-        primary_type: okta.user
-        fingerprint_key: urn:cerebro:writer:okta_user:00u-suspended|urn:cerebro:writer:okta_group:finance-users
-        resource_urns:
-          - urn:cerebro:writer:okta_user:00u-suspended
-          - urn:cerebro:writer:okta_group:finance-users
-        severity: HIGH
-        summary: Okta suspended user suspended@example.com remains in group Finance Users
-        action: Remove stale group membership and verify downstream access removal
-        evidence:
-          - urn: urn:cerebro:writer:okta_group:finance-users
+  - name: suspended user through group to application path produces a finding
+    graphFixture:
+      tenantId: test-suspended-group
+      nodes: &nodes
+        - urn: urn:cerebro:test-suspended-group:okta:user:alice
+          sourceId: okta
+          entityType: okta.user
+          label: alice@example.com
+          attributes:
+            status: deprovisioned
+        - urn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          sourceId: okta
+          entityType: okta.group
+          label: Finance administrators
+        - urn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          entityType: okta.application
+          label: Payroll
+        - urn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          entityType: okta.entitlement
+          label: Payroll write
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-group:okta:user:alice
+          toUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          sourceId: okta
+          relation: member_of
+        - fromUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: true
-  - name: suspended user without group membership passes
-    resource:
-      placeholder: true
+  - name: group application path without suspended membership passes
+    graphFixture:
+      tenantId: test-suspended-group
+      nodes: *nodes
+      edges:
+        - fromUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
+          toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          sourceId: okta
+          relation: assigned_to
+        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
+          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
+          sourceId: okta
+          relation: grants_entitlement
     wantFinding: false

--- a/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
+++ b/policies/identity/identity-okta-suspended-user-active-group-membership.test.yaml
@@ -19,10 +19,6 @@ cases:
           sourceId: okta
           entityType: okta.application
           label: Payroll
-        - urn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          entityType: okta.entitlement
-          label: Payroll write
       edges:
         - fromUrn: urn:cerebro:test-suspended-group:okta:user:alice
           toUrn: urn:cerebro:test-suspended-group:okta:group:finance-admins
@@ -32,10 +28,9 @@ cases:
           toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
-          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          relation: grants_entitlement
+    wantEvidenceUrns:
+      - urn:cerebro:test-suspended-group:okta:group:finance-admins
+      - urn:cerebro:test-suspended-group:okta:application:payroll
     wantFinding: true
   - name: group application path without suspended membership passes
     graphFixture:
@@ -46,8 +41,4 @@ cases:
           toUrn: urn:cerebro:test-suspended-group:okta:application:payroll
           sourceId: okta
           relation: assigned_to
-        - fromUrn: urn:cerebro:test-suspended-group:okta:application:payroll
-          toUrn: urn:cerebro:test-suspended-group:okta:entitlement:payroll-write
-          sourceId: okta
-          relation: grants_entitlement
     wantFinding: false


### PR DESCRIPTION
## Intent

Replace shallow row fixtures for Cerebro identity graph policies with topology tests that execute the real multi-hop Cypher.

## Coverage

Upgrades six graph policies:

- dormant admin role assignment
- group grants admin application access
- privileged account missing owner
- stale group membership
- suspended user active application assignment
- suspended user active group membership

Each suite projects four real nodes and a three-edge finding topology. Its passing case keeps the same nodes and a real two-edge downstream path while removing exactly one policy-critical upstream edge.

## Proof

- all 743 PolicyFindingRuleTest suites pass
- all six topology suites pass against a fresh Neo4j 5 container
- finding cases execute the checked-in policy Cypher and return required graph finding aliases
- edge-mutated cases return no finding
- go test ./internal/findingdsl ./internal/graphstore/neo4j ./tools/findingdsl ./tools/testauthor
- git diff --check

## Stack

Base: #1919