### PR TITLE
Record MCP task response states

### DIFF
--- a/docs/domains/mcp-droid-setup.md
+++ b/docs/domains/mcp-droid-setup.md
@@ -77,9 +77,8 @@ This gate is a deterministic metadata check, not a substitute for model and
 runtime evaluation. Validate promoted changes with representative MCP clients,
 then compare task request counts, errors, latency, partial states, and blocked
 states by tool. Cerebro telemetry records the bounded task result state as
-`mcp.task_state` and increments `mcp.task.response.<state>.count`, alongside
-tool classification, behavior, and owner domain. It does not record the user
-request.
+`mcp.task_state`, alongside tool classification, behavior, and owner domain.
+It does not record the user request.
 
 ## Assessment operations
 

--- a/docs/domains/mcp-droid-setup.md
+++ b/docs/domains/mcp-droid-setup.md
@@ -76,8 +76,10 @@ the change only when it preserves or improves the checked-in baseline in
 This gate is a deterministic metadata check, not a substitute for model and
 runtime evaluation. Validate promoted changes with representative MCP clients,
 then compare task request counts, errors, latency, partial states, and blocked
-states by tool. Cerebro telemetry records tool classification, behavior, and
-owner domain without recording the user request.
+states by tool. Cerebro telemetry records the bounded task result state as
+`mcp.task_state` and increments `mcp.task.response.<state>.count`, alongside
+tool classification, behavior, and owner domain. It does not record the user
+request.
 
 ## Assessment operations
 

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -3161,10 +3161,6 @@ func mcpTaskStateFromResponse(response *mcpJSONRPCResponse) string {
 		if structured != nil {
 			state = structured.State
 		}
-	case mcpoperations.StructuredContent:
-		state = mcpAnyString(structured["state"])
-	case map[string]any:
-		state = mcpAnyString(structured["state"])
 	}
 	state = strings.TrimSpace(state)
 	switch state {

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -3002,6 +3002,9 @@ func mcpTelemetryEvent(r *http.Request, method string, tool string, statusCode i
 		if mcpoperations.TelemetryOutcomeFailed(outcome) {
 			telemetry.IncrementMain(r.Context(), "mcp.task.request.error.count", 1)
 		}
+		if taskState := mcpTaskStateFromResponse(detail.Response); taskState != "" {
+			telemetry.IncrementMain(r.Context(), "mcp.task.response."+taskState+".count", 1)
+		}
 	}
 	mainAttrs := telemetry.Attrs(
 		telemetry.Field{Key: "mcp.status_code", Value: statusCode},
@@ -3114,12 +3117,16 @@ func mcpResponseTelemetryFields(response *mcpJSONRPCResponse) []telemetry.Field 
 	}
 	switch result := response.Result.(type) {
 	case mcpToolResult:
-		return []telemetry.Field{
+		fields := []telemetry.Field{
 			{Key: "mcp.response_shape", Value: "tool_result"},
 			{Key: "mcp.tool_result_error", Value: result.IsError},
 			{Key: "mcp.tool_result_content_count", Value: len(result.Content)},
 			{Key: "mcp.structured_content_present", Value: result.StructuredContent != nil},
 		}
+		if taskState := mcpTaskStateFromResponse(response); taskState != "" {
+			fields = append(fields, telemetry.Field{Key: "mcp.task_state", Value: taskState})
+		}
+		return fields
 	case map[string]any:
 		fields := []telemetry.Field{{Key: "mcp.response_shape", Value: mcpMapResponseShape(result)}}
 		if version := mcpAnyString(result["protocolVersion"]); version != "" {
@@ -3135,6 +3142,36 @@ func mcpResponseTelemetryFields(response *mcpJSONRPCResponse) []telemetry.Field 
 		return fields
 	default:
 		return []telemetry.Field{{Key: "mcp.response_shape", Value: "other"}}
+	}
+}
+
+func mcpTaskStateFromResponse(response *mcpJSONRPCResponse) string {
+	if response == nil || response.Error != nil {
+		return ""
+	}
+	result, ok := response.Result.(mcpToolResult)
+	if !ok || result.IsError {
+		return ""
+	}
+	state := ""
+	switch structured := result.StructuredContent.(type) {
+	case mcpoperations.TaskResponse:
+		state = structured.State
+	case *mcpoperations.TaskResponse:
+		if structured != nil {
+			state = structured.State
+		}
+	case mcpoperations.StructuredContent:
+		state = mcpAnyString(structured["state"])
+	case map[string]any:
+		state = mcpAnyString(structured["state"])
+	}
+	state = strings.TrimSpace(state)
+	switch state {
+	case mcpoperations.TaskStateComplete, mcpoperations.TaskStatePartial, mcpoperations.TaskStateBlocked:
+		return state
+	default:
+		return ""
 	}
 }
 

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -3002,9 +3002,6 @@ func mcpTelemetryEvent(r *http.Request, method string, tool string, statusCode i
 		if mcpoperations.TelemetryOutcomeFailed(outcome) {
 			telemetry.IncrementMain(r.Context(), "mcp.task.request.error.count", 1)
 		}
-		if taskState := mcpTaskStateFromResponse(detail.Response); taskState != "" {
-			telemetry.IncrementMain(r.Context(), "mcp.task.response."+taskState+".count", 1)
-		}
 	}
 	mainAttrs := telemetry.Attrs(
 		telemetry.Field{Key: "mcp.status_code", Value: statusCode},
@@ -3117,13 +3114,9 @@ func mcpResponseTelemetryFields(response *mcpJSONRPCResponse) []telemetry.Field 
 	}
 	switch result := response.Result.(type) {
 	case mcpToolResult:
-		fields := []telemetry.Field{
-			{Key: "mcp.response_shape", Value: "tool_result"},
-			{Key: "mcp.tool_result_error", Value: result.IsError},
-			{Key: "mcp.tool_result_content_count", Value: len(result.Content)},
-			{Key: "mcp.structured_content_present", Value: result.StructuredContent != nil},
-		}
-		if taskState := mcpTaskStateFromResponse(response); taskState != "" {
+		fields := []telemetry.Field{{Key: "mcp.response_shape", Value: "tool_result"}, {Key: "mcp.tool_result_error", Value: result.IsError}, {Key: "mcp.tool_result_content_count", Value: len(result.Content)}, {Key: "mcp.structured_content_present", Value: result.StructuredContent != nil}}
+		taskResponse, isTaskResponse := result.StructuredContent.(mcpoperations.TaskResponse)
+		if taskState := mcpoperations.TaskResponseState(taskResponse); !result.IsError && isTaskResponse && taskState != "" {
 			fields = append(fields, telemetry.Field{Key: "mcp.task_state", Value: taskState})
 		}
 		return fields
@@ -3142,32 +3135,6 @@ func mcpResponseTelemetryFields(response *mcpJSONRPCResponse) []telemetry.Field 
 		return fields
 	default:
 		return []telemetry.Field{{Key: "mcp.response_shape", Value: "other"}}
-	}
-}
-
-func mcpTaskStateFromResponse(response *mcpJSONRPCResponse) string {
-	if response == nil || response.Error != nil {
-		return ""
-	}
-	result, ok := response.Result.(mcpToolResult)
-	if !ok || result.IsError {
-		return ""
-	}
-	state := ""
-	switch structured := result.StructuredContent.(type) {
-	case mcpoperations.TaskResponse:
-		state = structured.State
-	case *mcpoperations.TaskResponse:
-		if structured != nil {
-			state = structured.State
-		}
-	}
-	state = strings.TrimSpace(state)
-	switch state {
-	case mcpoperations.TaskStateComplete, mcpoperations.TaskStatePartial, mcpoperations.TaskStateBlocked:
-		return state
-	default:
-		return ""
 	}
 }
 

--- a/internal/bootstrap/mcp_tasks_test.go
+++ b/internal/bootstrap/mcp_tasks_test.go
@@ -270,29 +270,6 @@ func TestMCPTaskTelemetryRecordsOperationStateWithoutPrompt(t *testing.T) {
 	}
 }
 
-func TestMCPTaskStateFromResponseAllowsKnownStatesOnly(t *testing.T) {
-	tests := []struct {
-		name       string
-		structured any
-		want       string
-	}{
-		{name: "value response", structured: mcpoperations.TaskResponse{State: mcpoperations.TaskStateComplete}, want: mcpoperations.TaskStateComplete},
-		{name: "pointer response", structured: &mcpoperations.TaskResponse{State: mcpoperations.TaskStatePartial}, want: mcpoperations.TaskStatePartial},
-		{name: "blocked response", structured: mcpoperations.TaskResponse{State: mcpoperations.TaskStateBlocked}, want: mcpoperations.TaskStateBlocked},
-		{name: "unknown state", structured: mcpoperations.TaskResponse{State: "running"}},
-		{name: "generic state map", structured: map[string]any{"state": mcpoperations.TaskStateComplete}},
-		{name: "missing state", structured: map[string]any{"result": "ok"}},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			response := &mcpJSONRPCResponse{Result: mcpToolResult{StructuredContent: test.structured}}
-			if got := mcpTaskStateFromResponse(response); got != test.want {
-				t.Fatalf("mcpTaskStateFromResponse() = %q, want %q", got, test.want)
-			}
-		})
-	}
-}
-
 func postMCPWithTaskProfile(t *testing.T, server *httptest.Server, payload map[string]any) map[string]any {
 	t.Helper()
 	return postMCPWithToolset(t, server, "task", payload)

--- a/internal/bootstrap/mcp_tasks_test.go
+++ b/internal/bootstrap/mcp_tasks_test.go
@@ -262,10 +262,34 @@ func TestMCPTaskTelemetryRecordsOperationStateWithoutPrompt(t *testing.T) {
 		"mcp.tool_behavior":       "read",
 		"mcp.tool_owner":          "agent-platform",
 		"mcp.task":                true,
+		"mcp.task_state":          "partial",
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
 		}
+	}
+}
+
+func TestMCPTaskStateFromResponseAllowsKnownStatesOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		structured any
+		want       string
+	}{
+		{name: "value response", structured: mcpoperations.TaskResponse{State: mcpoperations.TaskStateComplete}, want: mcpoperations.TaskStateComplete},
+		{name: "pointer response", structured: &mcpoperations.TaskResponse{State: mcpoperations.TaskStatePartial}, want: mcpoperations.TaskStatePartial},
+		{name: "structured map", structured: mcpoperations.StructuredContent{"state": mcpoperations.TaskStateBlocked}, want: mcpoperations.TaskStateBlocked},
+		{name: "generic map", structured: map[string]any{"state": mcpoperations.TaskStateComplete}, want: mcpoperations.TaskStateComplete},
+		{name: "unknown state", structured: map[string]any{"state": "running"}},
+		{name: "missing state", structured: map[string]any{"result": "ok"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := &mcpJSONRPCResponse{Result: mcpToolResult{StructuredContent: test.structured}}
+			if got := mcpTaskStateFromResponse(response); got != test.want {
+				t.Fatalf("mcpTaskStateFromResponse() = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/bootstrap/mcp_tasks_test.go
+++ b/internal/bootstrap/mcp_tasks_test.go
@@ -278,9 +278,9 @@ func TestMCPTaskStateFromResponseAllowsKnownStatesOnly(t *testing.T) {
 	}{
 		{name: "value response", structured: mcpoperations.TaskResponse{State: mcpoperations.TaskStateComplete}, want: mcpoperations.TaskStateComplete},
 		{name: "pointer response", structured: &mcpoperations.TaskResponse{State: mcpoperations.TaskStatePartial}, want: mcpoperations.TaskStatePartial},
-		{name: "structured map", structured: mcpoperations.StructuredContent{"state": mcpoperations.TaskStateBlocked}, want: mcpoperations.TaskStateBlocked},
-		{name: "generic map", structured: map[string]any{"state": mcpoperations.TaskStateComplete}, want: mcpoperations.TaskStateComplete},
-		{name: "unknown state", structured: map[string]any{"state": "running"}},
+		{name: "blocked response", structured: mcpoperations.TaskResponse{State: mcpoperations.TaskStateBlocked}, want: mcpoperations.TaskStateBlocked},
+		{name: "unknown state", structured: mcpoperations.TaskResponse{State: "running"}},
+		{name: "generic state map", structured: map[string]any{"state": mcpoperations.TaskStateComplete}},
 		{name: "missing state", structured: map[string]any{"result": "ok"}},
 	}
 	for _, test := range tests {

--- a/internal/mcpoperations/eval_test.go
+++ b/internal/mcpoperations/eval_test.go
@@ -154,6 +154,26 @@ func TestTaskResponsesPreserveStructuredContentPartialErrors(t *testing.T) {
 	}
 }
 
+func TestTaskResponseStateAllowsKnownStatesOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		response TaskResponse
+		want     string
+	}{
+		{name: "value response", response: TaskResponse{State: TaskStateComplete}, want: TaskStateComplete},
+		{name: "partial response", response: TaskResponse{State: TaskStatePartial}, want: TaskStatePartial},
+		{name: "blocked response", response: TaskResponse{State: TaskStateBlocked}, want: TaskStateBlocked},
+		{name: "unknown state", response: TaskResponse{State: "running"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := TaskResponseState(test.response); got != test.want {
+				t.Fatalf("TaskResponseState() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func readTaskSelectionCases(t *testing.T) []TaskSelectionCase {
 	t.Helper()
 	body, err := os.ReadFile(filepath.Join("testdata", "task_tools", "selection_cases.json"))

--- a/internal/mcpoperations/tasks.go
+++ b/internal/mcpoperations/tasks.go
@@ -40,6 +40,17 @@ type TaskResponse struct {
 	GeneratedAt    string           `json:"generated_at"`
 }
 
+// TaskResponseState returns the bounded state for a task response.
+func TaskResponseState(response TaskResponse) string {
+	state := strings.TrimSpace(response.State)
+	switch state {
+	case TaskStateComplete, TaskStatePartial, TaskStateBlocked:
+		return state
+	default:
+		return ""
+	}
+}
+
 type OutputSchema map[string]any
 
 type StructuredContent map[string]any


### PR DESCRIPTION
## Summary

- record complete, partial, or blocked task result state on MCP telemetry events
- validate the state behind the typed MCP task response contract
- reject unknown states and preserve prompt-free telemetry
- document the runtime hillclimb signal

## Why

The selection gate measures whether clients can choose the right task tool. This adds the matching runtime outcome signal so tool changes can be compared by complete, partial, and blocked results without recording request content.

## Verification

- go test ./internal/mcpoperations ./internal/bootstrap -count=1
- make check-structural check-structural-test check-arch
- make lint-shard LINT_PACKAGES=./internal/... LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=1
- make docs-drift-check
- make mcp-tool-eval