### PR TITLE
Accept finalized Droid review comments

### DIFF
--- a/scripts/land_pr.py
+++ b/scripts/land_pr.py
@@ -267,7 +267,7 @@ def check_droid_finished(comments: list[dict[str, object]]) -> tuple[bool, str]:
         superseded = "Superseded Droid error" in body or "Superseded Droid review" in body
         if "Droid encountered an error" in body and not superseded:
             return False, f"Droid has an unsuperseded error comment: {comment.get('url') or ''}"
-        if "Droid is reviewing code and running a security check" in body and not superseded:
+        if "Droid is reviewing code and running a security check" in body and not superseded and not is_finished_droid_review(body):
             return False, f"Droid has an unsuperseded in progress comment: {comment.get('url') or ''}"
     comment = latest_droid_comment(comments)
     if not comment:

--- a/scripts/tests/test_land_pr.py
+++ b/scripts/tests/test_land_pr.py
@@ -74,6 +74,19 @@ class LandPRTests(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(reason, "")
 
+    def test_check_droid_finished_accepts_progress_boilerplate_in_finished_review(self):
+        ok, reason = land_pr.check_droid_finished(
+            [
+                {
+                    "user": {"login": "factory-droid[bot]", "type": "Bot"},
+                    "body": "**Droid finished @alice's task**\n\nDroid is reviewing code and running a security check...\n\nReview approved.",
+                    "url": "https://comment",
+                }
+            ]
+        )
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
     def test_check_droid_finished_accepts_review_complete_comment(self):
         ok, reason = land_pr.check_droid_finished(
             [


### PR DESCRIPTION
## Summary

- treat a Droid comment as finished when it has a terminal marker, even if the finalized body retains progress boilerplate
- keep bare in-progress and unsuperseded error comments blocking
- add the exact finalized-comment regression case

## Why

A completed approved Droid comment can retain its initial progress sentence after the bot updates the body. The landing helper was treating that sentence as an active review after the check and final result were green.

## Verification

- python3 -m unittest scripts.tests.test_land_pr
- make script-test
- make check-structural
- make changed-check