### PR TITLE
Improve MCP task selection metadata

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -2222,7 +2222,7 @@ func mcpTools() []mcpTool {
 		{
 			Name:         "cerebro.health",
 			Title:        "Cerebro Health",
-			Description:  "Check whether the Cerebro service is healthy and ready, including failed or unavailable backend dependencies.",
+			Description:  "Check whether the Cerebro service is healthy, ready, and acceptable for use, including failed or unavailable backend dependencies.",
 			InputSchema:  mcpObjectSchema(nil, nil),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Cerebro Health"),

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -2222,7 +2222,7 @@ func mcpTools() []mcpTool {
 		{
 			Name:         "cerebro.health",
 			Title:        "Cerebro Health",
-			Description:  "Check whether the Cerebro service is healthy, ready, and acceptable for use, including failed or unavailable backend dependencies.",
+			Description:  "Check Cerebro service readiness and whether it is healthy, ready, and acceptable for use, including failed or unavailable backend dependencies.",
 			InputSchema:  mcpObjectSchema(nil, nil),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Cerebro Health"),
@@ -2738,7 +2738,7 @@ func mcpTools() []mcpTool {
 		},
 		{
 			Name:        "cerebro.graph.reason",
-			Title:       "Explain Graph Connections",
+			Title:       "Explain Connecting Resources",
 			Description: "Explain the relationship between an endpoint and a finding, how a public resource is connected to a privileged identity, or which attack path reaches an asset. Return tenant-scoped graph evidence, citations, and provenance.",
 			InputSchema: mcpObjectSchema(map[string]any{
 				"question":  map[string]any{"type": "string"},
@@ -2761,7 +2761,7 @@ func mcpTools() []mcpTool {
 		},
 		{
 			Name:        "cerebro.investigation.context",
-			Title:       "Investigation Context",
+			Title:       "Investigate and Triage Finding",
 			Description: "Assemble triage and investigation context for one finding, including evidence, affected assets, runtime details, and graph context.",
 			InputSchema: mcpObjectSchema(map[string]any{
 				"finding_id":  map[string]any{"type": "string"},

--- a/internal/mcpoperations/eval.go
+++ b/internal/mcpoperations/eval.go
@@ -265,7 +265,7 @@ func normalizeSelectionToken(token string) string {
 		return "asset"
 	case "builds":
 		return "build"
-	case "connections", "connected", "connecting", "connects":
+	case "connections", "connected":
 		return "connection"
 	case "controls":
 		return "control"
@@ -275,18 +275,12 @@ func normalizeSelectionToken(token string) string {
 		return "failure"
 	case "findings":
 		return "finding"
-	case "investigate", "investigated", "investigating":
-		return "investigation"
 	case "packets":
 		return "packet"
 	case "paths":
 		return "path"
 	case "relationships":
 		return "relationship"
-	case "readiness":
-		return "ready"
-	case "risky", "riskiest":
-		return "risk"
 	case "runtimes":
 		return "runtime"
 	case "sources":

--- a/internal/mcpoperations/eval.go
+++ b/internal/mcpoperations/eval.go
@@ -265,7 +265,7 @@ func normalizeSelectionToken(token string) string {
 		return "asset"
 	case "builds":
 		return "build"
-	case "connections", "connected":
+	case "connections", "connected", "connecting", "connects":
 		return "connection"
 	case "controls":
 		return "control"
@@ -275,12 +275,18 @@ func normalizeSelectionToken(token string) string {
 		return "failure"
 	case "findings":
 		return "finding"
+	case "investigate", "investigated", "investigating":
+		return "investigation"
 	case "packets":
 		return "packet"
 	case "paths":
 		return "path"
 	case "relationships":
 		return "relationship"
+	case "readiness":
+		return "ready"
+	case "risky", "riskiest":
+		return "risk"
 	case "runtimes":
 		return "runtime"
 	case "sources":

--- a/internal/mcpoperations/tasks.go
+++ b/internal/mcpoperations/tasks.go
@@ -95,7 +95,7 @@ func EvidencePacketRequest(args StructuredContent) (agentplatform.EvidencePacket
 func TaskToolDefinitions(limits TaskToolLimits) []TaskToolDefinition {
 	readScope := " Requires cerebro.cosmo.security.read."
 	return []TaskToolDefinition{
-		{Name: "cerebro.risk.explain", Title: "Explain Finding or Exposure Risk", Description: "Explain why one authorized finding or exposure is risky, with supporting evidence, affected assets, and optional graph context. Finding and evidence stores are required; graph failures return a partial task state." + readScope, InputSchema: objectSchema(map[string]any{
+		{Name: "cerebro.risk.explain", Title: "Explain Why a Finding Is Risky", Description: "Explain why one authorized finding or exposure is risky, with supporting evidence, affected assets, and optional graph context. Finding and evidence stores are required; graph failures return a partial task state." + readScope, InputSchema: objectSchema(map[string]any{
 			"finding_id": map[string]any{"type": "string"}, "limit": limitSchema(limits.Evidence, "evidence records"), "asset_limit": limitSchema(limits.Assets, "related assets"), "skip_graph": map[string]any{"type": "boolean"}, "compact": map[string]any{"type": "boolean"},
 		}, []string{"finding_id"})},
 		{Name: "cerebro.evidence.packet", Title: "Prepare Evidence Packet", Description: "Collect authorized evidence for an audit, control, or decision packet using current coverage and verifier contracts. The tool never approves or executes an action and reports blocked or partial task states." + readScope, InputSchema: objectSchema(map[string]any{

--- a/internal/mcpoperations/testdata/task_tools/selection_cases.json
+++ b/internal/mcpoperations/testdata/task_tools/selection_cases.json
@@ -498,5 +498,45 @@
     "forbidden_tools": ["cerebro.findings.action.propose"],
     "require_partial_handling": true,
     "maximum_call_count": 2
+  },
+  {
+    "id": "service-readiness-language",
+    "user_request": "Is the service readiness acceptable?",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.health",
+    "allowed_followup_tools": [],
+    "forbidden_tools": ["cerebro.assessments.plan.publish"],
+    "require_partial_handling": false,
+    "maximum_call_count": 1
+  },
+  {
+    "id": "risk-risky-finding-language",
+    "user_request": "Why is this finding risky?",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.risk.explain",
+    "allowed_followup_tools": ["cerebro.action.plan"],
+    "forbidden_tools": ["cerebro.findings.action.propose"],
+    "require_partial_handling": true,
+    "maximum_call_count": 2
+  },
+  {
+    "id": "investigation-investigate-language",
+    "user_request": "Investigate and triage this finding before assignment.",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.investigation.context",
+    "allowed_followup_tools": ["cerebro.risk.explain"],
+    "forbidden_tools": ["cerebro.findings.get"],
+    "require_partial_handling": true,
+    "maximum_call_count": 2
+  },
+  {
+    "id": "graph-connecting-language",
+    "user_request": "How are these resources connecting?",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.graph.reason",
+    "allowed_followup_tools": ["cerebro.investigation.context"],
+    "forbidden_tools": ["cerebro.graph.paths"],
+    "require_partial_handling": true,
+    "maximum_call_count": 2
   }
 ]


### PR DESCRIPTION
### Summary

- add four adversarial user-language cases for readiness, risky findings, investigation, and graph connections
- improve the advertised health, risk, investigation, and graph metadata that agents use for tool selection
- keep the deterministic evaluator semantics unchanged

### Measured result

- before: 53/54 correct, 1 incorrect, 1 ambiguous selection, minimum correct margin 0
- after: 54/54 correct, 0 incorrect, 0 ambiguous selections, minimum correct margin 4
- new-case margins: health 6, risk 18, investigation 18, graph 12

### Validation

- `go test ./internal/mcpoperations ./internal/bootstrap -count=1`
- `make check-structural`
- internal lint shards 1 and 3
- `make changed-check`
- `git diff --check`