### PR TITLE
Add Slack companion operation continuity

### DIFF
--- a/apps/slack-companion/src/operations/compatibility.ts
+++ b/apps/slack-companion/src/operations/compatibility.ts
@@ -1,0 +1,171 @@
+import type {
+  CapabilityCompatibilityDecision,
+  CapabilityManifestV1,
+  CapabilityRequirement,
+  PresenceSnapshotV1,
+  SchemaCompatibility,
+} from "@writer/cerebro-sdk";
+
+export interface CompatibilityAssessment {
+  decision: CapabilityCompatibilityDecision;
+  negotiated_write_version?: string;
+  reasons: string[];
+}
+
+export interface CompatibilityInput {
+  companion_manifest: CapabilityManifestV1;
+  companion_schema: SchemaCompatibility;
+  core_manifest: CapabilityManifestV1;
+  core_schema: SchemaCompatibility;
+}
+
+export interface ContinuityGate {
+  allowed: boolean;
+  reason: string;
+}
+
+export function assessCompatibility(
+  input: CompatibilityInput,
+): CompatibilityAssessment {
+  const reasons: string[] = [];
+  const schemaReadable =
+    input.core_schema.read_versions.includes(input.companion_schema.current_version) &&
+    input.companion_schema.read_versions.includes(input.core_schema.current_version);
+  const sharedContractVersions = input.core_manifest.contract_versions.filter(
+    (version) => input.companion_manifest.contract_versions.includes(version),
+  );
+
+  if (!schemaReadable || sharedContractVersions.length === 0) {
+    if (!schemaReadable) {
+      reasons.push("contract_version_not_readable");
+    }
+    if (sharedContractVersions.length === 0) {
+      reasons.push("manifest_contract_version_not_shared");
+    }
+    return { decision: "incompatible", reasons };
+  }
+
+  const negotiatedWriteVersion = input.core_schema.write_versions.find((version) =>
+    input.companion_schema.write_versions.includes(version),
+  );
+  if (negotiatedWriteVersion === undefined) {
+    return { decision: "blocked", reasons: ["no_shared_write_version"] };
+  }
+
+  const missingRequired = [
+    ...missingCapabilities(
+      input.core_manifest.capabilities,
+      input.companion_manifest.capabilities,
+      "companion",
+    ),
+    ...missingCapabilities(
+      input.companion_manifest.capabilities,
+      input.core_manifest.capabilities,
+      "core",
+    ),
+  ];
+  if (missingRequired.length > 0) {
+    return {
+      decision: "blocked",
+      negotiated_write_version: negotiatedWriteVersion,
+      reasons: missingRequired,
+    };
+  }
+
+  const optionalMismatches = [
+    ...optionalCapabilityMismatches(
+      input.core_manifest.capabilities,
+      input.companion_manifest.capabilities,
+      "companion",
+    ),
+    ...optionalCapabilityMismatches(
+      input.companion_manifest.capabilities,
+      input.core_manifest.capabilities,
+      "core",
+    ),
+  ];
+  return {
+    decision: optionalMismatches.length > 0 ? "degraded" : "supported",
+    negotiated_write_version: negotiatedWriteVersion,
+    reasons: optionalMismatches,
+  };
+}
+
+export function readinessGate(
+  presence: PresenceSnapshotV1,
+  assessment: CompatibilityAssessment,
+  now: string,
+): ContinuityGate {
+  if (Date.parse(presence.expires_at) <= Date.parse(now)) {
+    return { allowed: false, reason: "presence_expired" };
+  }
+  if (assessment.decision === "blocked" || assessment.decision === "incompatible") {
+    return { allowed: false, reason: "compatibility_blocked" };
+  }
+  if (presence.compatibility === "blocked" || presence.compatibility === "incompatible") {
+    return { allowed: false, reason: "presence_compatibility_blocked" };
+  }
+  if (presence.service_state !== "ready" && presence.service_state !== "degraded") {
+    return { allowed: false, reason: `service_${presence.service_state}` };
+  }
+  return { allowed: true, reason: "ready" };
+}
+
+export function newLeaseGate(
+  presence: PresenceSnapshotV1,
+  assessment: CompatibilityAssessment,
+  expectedGeneration: number,
+  expectedRouteGeneration: number,
+  now: string,
+): ContinuityGate {
+  const readiness = readinessGate(presence, assessment, now);
+  if (!readiness.allowed) {
+    return readiness;
+  }
+  if (presence.active_generation !== expectedGeneration) {
+    return { allowed: false, reason: "generation_changed" };
+  }
+  if (presence.route_generation !== expectedRouteGeneration) {
+    return { allowed: false, reason: "route_generation_changed" };
+  }
+  return { allowed: true, reason: "lease_allowed" };
+}
+
+function missingCapabilities(
+  requirements: readonly CapabilityRequirement[],
+  offered: readonly CapabilityRequirement[],
+  provider: string,
+): string[] {
+  return requirements
+    .filter((requirement) => requirement.level === "required")
+    .filter((requirement) => !hasCapability(offered, requirement))
+    .map(
+      (requirement) =>
+        `${provider}_missing_${requirement.capability_id}@${requirement.version}`,
+    );
+}
+
+function optionalCapabilityMismatches(
+  requirements: readonly CapabilityRequirement[],
+  offered: readonly CapabilityRequirement[],
+  provider: string,
+): string[] {
+  return requirements
+    .filter((requirement) => requirement.level === "optional")
+    .filter((requirement) => !hasCapability(offered, requirement))
+    .map(
+      (requirement) =>
+        `${provider}_optional_${requirement.capability_id}@${requirement.version}`,
+    );
+}
+
+function hasCapability(
+  offered: readonly CapabilityRequirement[],
+  requirement: CapabilityRequirement,
+): boolean {
+  return offered.some(
+    (capability) =>
+      capability.capability_id === requirement.capability_id &&
+      capability.version === requirement.version,
+  );
+}

--- a/apps/slack-companion/src/operations/maintenance.ts
+++ b/apps/slack-companion/src/operations/maintenance.ts
@@ -1,0 +1,126 @@
+import type {
+  CapabilityCompatibilityDecision,
+  PresenceSnapshotV1,
+  ReleaseReceiptV2,
+} from "@writer/cerebro-sdk";
+import { readinessGate } from "./compatibility.js";
+
+export type MaintenanceMode = "forced" | "graceful";
+
+export interface MaintenanceRun {
+  checkpointable: boolean;
+  run_id: string;
+}
+
+export interface MaintenanceDelivery {
+  delivery_id: string;
+  state: "delivering" | "pending";
+}
+
+export interface MaintenanceAction {
+  action:
+    | "checkpoint_and_pause"
+    | "drain_delivery"
+    | "mark_for_reconciliation"
+    | "pause_delivery"
+    | "stop_new_leases"
+    | "wait_for_safe_boundary";
+  subject_id: string;
+}
+
+export interface MaintenancePlan {
+  actions: MaintenanceAction[];
+  admission_behavior: "durable_queue";
+  blockers: string[];
+  forced_stop_permitted_after_actions: boolean;
+  mode: MaintenanceMode;
+  new_leases_allowed: false;
+  safe_to_stop: boolean;
+}
+
+export interface MaintenanceInput {
+  active_runs: readonly MaintenanceRun[];
+  compatibility: CapabilityCompatibilityDecision;
+  deliveries: readonly MaintenanceDelivery[];
+  mode: MaintenanceMode;
+  now: string;
+  replacement_presence?: PresenceSnapshotV1;
+}
+
+export interface ReleaseVerification {
+  passed: boolean;
+  reasons: string[];
+}
+
+export function planMaintenance(input: MaintenanceInput): MaintenancePlan {
+  const actions: MaintenanceAction[] = [
+    { action: "stop_new_leases", subject_id: "service" },
+  ];
+  const blockers: string[] = [];
+
+  if (input.mode === "graceful") {
+    if (input.replacement_presence === undefined) {
+      blockers.push("replacement_presence_missing");
+    } else {
+      const replacement = readinessGate(
+        input.replacement_presence,
+        { decision: input.compatibility, reasons: [] },
+        input.now,
+      );
+      if (!replacement.allowed) {
+        blockers.push(`replacement_${replacement.reason}`);
+      }
+    }
+  }
+
+  for (const run of input.active_runs) {
+    if (run.checkpointable) {
+      actions.push({ action: "checkpoint_and_pause", subject_id: run.run_id });
+    } else if (input.mode === "forced") {
+      actions.push({ action: "mark_for_reconciliation", subject_id: run.run_id });
+    } else {
+      actions.push({ action: "wait_for_safe_boundary", subject_id: run.run_id });
+      blockers.push(`run_not_checkpointable:${run.run_id}`);
+    }
+  }
+
+  for (const delivery of input.deliveries) {
+    actions.push({
+      action: input.mode === "forced" ? "pause_delivery" : "drain_delivery",
+      subject_id: delivery.delivery_id,
+    });
+  }
+
+  const activeWorkRemains =
+    input.active_runs.length > 0 || input.deliveries.length > 0;
+
+  return {
+    actions,
+    admission_behavior: "durable_queue",
+    blockers,
+    forced_stop_permitted_after_actions: input.mode === "forced",
+    mode: input.mode,
+    new_leases_allowed: false,
+    safe_to_stop:
+      !activeWorkRemains && (input.mode === "forced" || blockers.length === 0),
+  };
+}
+
+export function verifyReleaseReceipt(
+  receipt: ReleaseReceiptV2,
+): ReleaseVerification {
+  const reasons: string[] = [];
+  if (receipt.orphaned_run_count > 0) {
+    reasons.push("orphaned_runs_present");
+  }
+  if (receipt.stuck_delivery_count > 0) {
+    reasons.push("stuck_deliveries_present");
+  }
+  if (receipt.compatibility === "blocked" || receipt.compatibility === "incompatible") {
+    reasons.push("release_incompatible");
+  }
+  if (receipt.state === "failed") {
+    reasons.push("release_failed");
+  }
+  return { passed: reasons.length === 0, reasons };
+}

--- a/apps/slack-companion/src/operations/migration.ts
+++ b/apps/slack-companion/src/operations/migration.ts
@@ -1,0 +1,148 @@
+import type { MigrationReceiptV1 } from "@writer/cerebro-sdk";
+
+export interface SlackThreadIdentity {
+  binding_id: string;
+  conversation_id: string;
+  durable_thread_state_digest: string;
+  installation_id: string;
+  slack_app_id: string;
+  thread_id: string;
+}
+
+export interface CreateMigrationInput {
+  binding_id: string;
+  checkpoint_count: number;
+  created_at: string;
+  migration_id: string;
+  pending_delivery_count: number;
+  rollback_generation: number;
+  route_generation: number;
+  source_generation: number;
+  target_generation: number;
+}
+
+export type MigrationChangeResult =
+  | { changed: true; receipt: MigrationReceiptV1 }
+  | {
+      changed: false;
+      reason: "identity_changed" | "invalid_state" | "route_generation_conflict";
+      receipt: MigrationReceiptV1;
+    };
+
+const transitions: Readonly<Record<MigrationReceiptV1["state"], readonly MigrationReceiptV1["state"][]>> = {
+  completed: [],
+  cutting_over: ["recovering", "rolling_back", "failed"],
+  draining: ["cutting_over", "rolling_back", "failed"],
+  failed: ["rolling_back"],
+  proposed: ["validating", "failed"],
+  recovering: ["completed", "rolling_back", "failed"],
+  rolled_back: [],
+  rolling_back: ["rolled_back", "failed"],
+  validating: ["draining", "rolling_back", "failed"],
+};
+
+export function createMigrationReceipt(
+  input: CreateMigrationInput,
+): MigrationReceiptV1 {
+  return {
+    binding_id: input.binding_id,
+    checkpoint_count: input.checkpoint_count,
+    created_at: input.created_at,
+    migration_id: input.migration_id,
+    pending_delivery_count: input.pending_delivery_count,
+    rollback_generation: input.rollback_generation,
+    route_generation: input.route_generation,
+    schema_version: "migration-receipt/v1",
+    source_generation: input.source_generation,
+    state: "proposed",
+    target_generation: input.target_generation,
+    updated_at: input.created_at,
+  };
+}
+
+export function advanceMigration(
+  receipt: MigrationReceiptV1,
+  state: MigrationReceiptV1["state"],
+  now: string,
+): MigrationChangeResult {
+  if (!transitions[receipt.state].includes(state)) {
+    return { changed: false, reason: "invalid_state", receipt };
+  }
+  return { changed: true, receipt: { ...receipt, state, updated_at: now } };
+}
+
+export function cutOverRoute(
+  receipt: MigrationReceiptV1,
+  observedRouteGeneration: number,
+  before: SlackThreadIdentity,
+  after: SlackThreadIdentity,
+  now: string,
+): MigrationChangeResult {
+  if (receipt.state !== "cutting_over") {
+    return { changed: false, reason: "invalid_state", receipt };
+  }
+  if (observedRouteGeneration !== receipt.route_generation) {
+    return { changed: false, reason: "route_generation_conflict", receipt };
+  }
+  if (!sameIdentity(before, after) || receipt.binding_id !== before.binding_id) {
+    return {
+      changed: false,
+      reason: "identity_changed",
+      receipt: { ...receipt, state: "failed", updated_at: now },
+    };
+  }
+  return {
+    changed: true,
+    receipt: {
+      ...receipt,
+      route_generation: receipt.route_generation + 1,
+      state: "recovering",
+      updated_at: now,
+    },
+  };
+}
+
+export function rollBackRoute(
+  receipt: MigrationReceiptV1,
+  observedRouteGeneration: number,
+  before: SlackThreadIdentity,
+  after: SlackThreadIdentity,
+  now: string,
+): MigrationChangeResult {
+  if (receipt.state !== "rolling_back") {
+    return { changed: false, reason: "invalid_state", receipt };
+  }
+  if (observedRouteGeneration !== receipt.route_generation) {
+    return { changed: false, reason: "route_generation_conflict", receipt };
+  }
+  if (!sameIdentity(before, after) || receipt.binding_id !== before.binding_id) {
+    return {
+      changed: false,
+      reason: "identity_changed",
+      receipt: { ...receipt, state: "failed", updated_at: now },
+    };
+  }
+  return {
+    changed: true,
+    receipt: {
+      ...receipt,
+      route_generation: receipt.route_generation + 1,
+      state: "rolled_back",
+      updated_at: now,
+    },
+  };
+}
+
+function sameIdentity(
+  before: SlackThreadIdentity,
+  after: SlackThreadIdentity,
+): boolean {
+  return (
+    before.slack_app_id === after.slack_app_id &&
+    before.binding_id === after.binding_id &&
+    before.installation_id === after.installation_id &&
+    before.conversation_id === after.conversation_id &&
+    before.thread_id === after.thread_id &&
+    before.durable_thread_state_digest === after.durable_thread_state_digest
+  );
+}

--- a/apps/slack-companion/src/operations/schedules.ts
+++ b/apps/slack-companion/src/operations/schedules.ts
@@ -1,0 +1,243 @@
+import type {
+  ScheduleMisfirePolicy,
+  ScheduledOccurrenceState,
+  ScheduledOccurrenceV1,
+} from "@writer/cerebro-sdk";
+
+export interface ScheduledOccurrenceInput {
+  due_at: string;
+  generation: number;
+  misfire_policy: ScheduleMisfirePolicy;
+  schedule_id: string;
+  schedule_revision: number;
+}
+
+export interface MisfirePlan {
+  enqueue: string[];
+  pending: string[];
+  skip: string[];
+}
+
+export interface ScheduledLeaseRequest {
+  fencing_token: number;
+  generation: number;
+  lease_expires_at: string;
+  lease_token: string;
+  now: string;
+  owner_id: string;
+}
+
+export type ScheduledLeaseDecision =
+  | { acquired: true; occurrence: ScheduledOccurrenceV1 }
+  | {
+      acquired: false;
+      reason:
+        | "active_lease"
+        | "invalid_expiry"
+        | "invalid_fencing_token"
+        | "invalid_generation"
+        | "invalid_lease_identity"
+        | "not_queueable"
+        | "stale_fencing_token"
+        | "stale_generation";
+    };
+
+export interface ScheduledLeaseClaim {
+  fencing_token: number;
+  generation: number;
+  lease_token: string;
+  owner_id: string;
+}
+
+export function scheduledOccurrenceIdentity(
+  scheduleId: string,
+  dueAt: string,
+  scheduleRevision: number,
+): string {
+  if (scheduleId.length === 0) {
+    throw new Error("schedule_id is required");
+  }
+  if (!Number.isSafeInteger(scheduleRevision) || scheduleRevision < 1) {
+    throw new Error("schedule_revision must be a positive integer");
+  }
+
+  const normalizedDueAt = normalizeTime(dueAt, "due_at");
+  return `schedule/${encodeURIComponent(scheduleId)}/due/${encodeURIComponent(normalizedDueAt)}/revision/${scheduleRevision}`;
+}
+
+export function createScheduledOccurrence(
+  input: ScheduledOccurrenceInput,
+  createdAt: string,
+): ScheduledOccurrenceV1 {
+  requirePositiveInteger(input.generation, "generation");
+  const normalizedCreatedAt = normalizeTime(createdAt, "created_at");
+  const normalizedDueAt = normalizeTime(input.due_at, "due_at");
+  const occurrenceId = scheduledOccurrenceIdentity(
+    input.schedule_id,
+    normalizedDueAt,
+    input.schedule_revision,
+  );
+
+  return {
+    created_at: normalizedCreatedAt,
+    due_at: normalizedDueAt,
+    generation: input.generation,
+    idempotency_key: occurrenceId,
+    misfire_policy: input.misfire_policy,
+    occurrence_id: occurrenceId,
+    run_id: `run/${occurrenceId}`,
+    schedule_id: input.schedule_id,
+    schedule_revision: input.schedule_revision,
+    schema_version: "scheduled-occurrence/v1",
+    state: "queued",
+    updated_at: normalizedCreatedAt,
+  };
+}
+
+export function planMisfires(
+  dueTimes: readonly string[],
+  now: string,
+  policy: ScheduleMisfirePolicy,
+  runAllLimit = 1,
+): MisfirePlan {
+  if (!Number.isSafeInteger(runAllLimit) || runAllLimit < 1) {
+    throw new Error("runAllLimit must be a positive integer");
+  }
+
+  const normalizedNow = normalizeTime(now, "now");
+  const ordered = [...new Set(dueTimes.map((dueAt) => normalizeTime(dueAt, "due_at")))]
+    .sort((left, right) => Date.parse(left) - Date.parse(right));
+  const due = ordered.filter((dueAt) => dueAt <= normalizedNow);
+  const pending = ordered.filter((dueAt) => dueAt > normalizedNow);
+
+  if (policy === "skip") {
+    return { enqueue: [], pending, skip: due };
+  }
+  if (policy === "coalesce_once") {
+    const latest = due.at(-1);
+    return {
+      enqueue: latest === undefined ? [] : [latest],
+      pending,
+      skip: latest === undefined ? [] : due.slice(0, -1),
+    };
+  }
+
+  return {
+    enqueue: due.slice(0, runAllLimit),
+    pending: [...due.slice(runAllLimit), ...pending],
+    skip: [],
+  };
+}
+
+export function acquireScheduledOccurrence(
+  occurrence: ScheduledOccurrenceV1,
+  request: ScheduledLeaseRequest,
+): ScheduledLeaseDecision {
+  if (!isPositiveInteger(request.generation)) {
+    return { acquired: false, reason: "invalid_generation" };
+  }
+  if (!isPositiveInteger(request.fencing_token)) {
+    return { acquired: false, reason: "invalid_fencing_token" };
+  }
+  if (
+    request.owner_id.trim().length === 0 ||
+    request.lease_token.trim().length === 0
+  ) {
+    return { acquired: false, reason: "invalid_lease_identity" };
+  }
+  const now = normalizeTime(request.now, "now");
+  const leaseExpiresAt = normalizeTime(
+    request.lease_expires_at,
+    "lease_expires_at",
+  );
+  if (leaseExpiresAt <= now) {
+    return { acquired: false, reason: "invalid_expiry" };
+  }
+  if (request.generation < occurrence.generation) {
+    return { acquired: false, reason: "stale_generation" };
+  }
+
+  const leaseIsActive =
+    occurrence.lease_expires_at !== undefined &&
+    normalizeTime(occurrence.lease_expires_at, "lease_expires_at") > now;
+  if (leaseIsActive) {
+    return { acquired: false, reason: "active_lease" };
+  }
+
+  if (occurrence.state !== "queued" && occurrence.state !== "leased" && occurrence.state !== "running") {
+    return { acquired: false, reason: "not_queueable" };
+  }
+  if (
+    occurrence.fencing_token !== undefined &&
+    request.fencing_token <= occurrence.fencing_token
+  ) {
+    return { acquired: false, reason: "stale_fencing_token" };
+  }
+
+  return {
+    acquired: true,
+    occurrence: {
+      ...occurrence,
+      fencing_token: request.fencing_token,
+      generation: request.generation,
+      heartbeat_at: now,
+      lease_expires_at: leaseExpiresAt,
+      lease_token: request.lease_token,
+      owner_id: request.owner_id,
+      state: "leased",
+      updated_at: now,
+    },
+  };
+}
+
+export function updateScheduledOccurrence(
+  occurrence: ScheduledOccurrenceV1,
+  claim: ScheduledLeaseClaim,
+  state: Extract<ScheduledOccurrenceState, "running" | "completed" | "failed">,
+  now: string,
+): ScheduledOccurrenceV1 | undefined {
+  const normalizedNow = normalizeTime(now, "now");
+  if (!ownsActiveLease(occurrence, claim, normalizedNow)) {
+    return undefined;
+  }
+
+  return {
+    ...occurrence,
+    heartbeat_at: normalizedNow,
+    state,
+    updated_at: normalizedNow,
+  };
+}
+
+function ownsActiveLease(
+  occurrence: ScheduledOccurrenceV1,
+  claim: ScheduledLeaseClaim,
+  now: string,
+): boolean {
+  return (
+    occurrence.fencing_token === claim.fencing_token &&
+    occurrence.generation === claim.generation &&
+    occurrence.lease_token === claim.lease_token &&
+    occurrence.owner_id === claim.owner_id &&
+    occurrence.lease_expires_at !== undefined &&
+    normalizeTime(occurrence.lease_expires_at, "lease_expires_at") > now
+  );
+}
+
+function normalizeTime(value: string, field: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${field} must be an ISO-8601 timestamp`);
+  }
+  return new Date(timestamp).toISOString();
+}
+
+function requirePositiveInteger(value: number, field: string): void {
+  if (!isPositiveInteger(value)) {
+    throw new Error(`${field} must be a positive integer`);
+  }
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}

--- a/apps/slack-companion/src/operations/status.ts
+++ b/apps/slack-companion/src/operations/status.ts
@@ -1,0 +1,97 @@
+import type {
+  PresenceSnapshotV1,
+  RunReceiptV1,
+} from "@writer/cerebro-sdk";
+
+export type SlackVisibleStatusCode =
+  | "degraded"
+  | "partial_source"
+  | "queued"
+  | "recovering";
+
+export interface SourceCoverage {
+  available_source_count: number;
+  expected_source_count: number;
+}
+
+export interface SlackVisibleStatus {
+  code: SlackVisibleStatusCode;
+  expires_at: string;
+  idempotency_key: string;
+  message: string;
+  observed_at: string;
+  run_id: string;
+}
+
+export function deriveSlackVisibleStatuses(
+  run: RunReceiptV1,
+  presence: PresenceSnapshotV1,
+  now: string,
+  coverage?: SourceCoverage,
+): SlackVisibleStatus[] {
+  if (Date.parse(presence.expires_at) <= Date.parse(now)) {
+    return [];
+  }
+
+  const statuses: SlackVisibleStatus[] = [];
+  if (run.state === "queued") {
+    statuses.push(
+      createStatus(
+        "queued",
+        "Cerebro saved this request. It is queued for execution.",
+        run.run_id,
+        presence,
+      ),
+    );
+  }
+  if (presence.service_state === "degraded") {
+    statuses.push(
+      createStatus(
+        "degraded",
+        "Cerebro accepted this request, but service capacity is reduced. Work remains durably queued.",
+        run.run_id,
+        presence,
+      ),
+    );
+  }
+  if (presence.service_state === "recovering") {
+    statuses.push(
+      createStatus(
+        "recovering",
+        "Cerebro is recovering this request from its last durable checkpoint.",
+        run.run_id,
+        presence,
+      ),
+    );
+  }
+  if (
+    coverage !== undefined &&
+    coverage.available_source_count < coverage.expected_source_count
+  ) {
+    statuses.push(
+      createStatus(
+        "partial_source",
+        `Cerebro can reach ${coverage.available_source_count} of ${coverage.expected_source_count} expected sources. The response will identify missing coverage.`,
+        run.run_id,
+        presence,
+      ),
+    );
+  }
+  return statuses;
+}
+
+function createStatus(
+  code: SlackVisibleStatusCode,
+  message: string,
+  runId: string,
+  presence: PresenceSnapshotV1,
+): SlackVisibleStatus {
+  return {
+    code,
+    expires_at: presence.expires_at,
+    idempotency_key: `${runId}:${code}:${presence.observed_at}`,
+    message,
+    observed_at: presence.observed_at,
+    run_id: runId,
+  };
+}

--- a/apps/slack-companion/test/operations.test.ts
+++ b/apps/slack-companion/test/operations.test.ts
@@ -1,0 +1,631 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type {
+  CapabilityManifestV1,
+  PresenceSnapshotV1,
+  ReleaseReceiptV2,
+  RunReceiptV1,
+  SchemaCompatibility,
+} from "@writer/cerebro-sdk";
+import {
+  assessCompatibility,
+  newLeaseGate,
+  readinessGate,
+} from "../src/operations/compatibility.js";
+import {
+  planMaintenance,
+  verifyReleaseReceipt,
+} from "../src/operations/maintenance.js";
+import {
+  advanceMigration,
+  createMigrationReceipt,
+  cutOverRoute,
+  rollBackRoute,
+  type SlackThreadIdentity,
+} from "../src/operations/migration.js";
+import {
+  acquireScheduledOccurrence,
+  createScheduledOccurrence,
+  planMisfires,
+  scheduledOccurrenceIdentity,
+  updateScheduledOccurrence,
+} from "../src/operations/schedules.js";
+import { deriveSlackVisibleStatuses } from "../src/operations/status.js";
+
+const now = "2026-07-16T12:00:00.000Z";
+
+describe("scheduled operation continuity", () => {
+  test("uses schedule, due time, and revision as deterministic identity", () => {
+    const first = createScheduledOccurrence(
+      {
+        due_at: "2026-07-16T11:00:00Z",
+        generation: 3,
+        misfire_policy: "coalesce_once",
+        schedule_id: "daily summary",
+        schedule_revision: 4,
+      },
+      now,
+    );
+    const retried = createScheduledOccurrence(
+      {
+        due_at: "2026-07-16T11:00:00.000Z",
+        generation: 4,
+        misfire_policy: "coalesce_once",
+        schedule_id: "daily summary",
+        schedule_revision: 4,
+      },
+      now,
+    );
+
+    assert.equal(first.occurrence_id, retried.occurrence_id);
+    assert.equal(first.idempotency_key, retried.idempotency_key);
+    assert.equal(
+      first.occurrence_id,
+      scheduledOccurrenceIdentity(
+        "daily summary",
+        "2026-07-16T11:00:00Z",
+        4,
+      ),
+    );
+    assert.notEqual(
+      first.occurrence_id,
+      scheduledOccurrenceIdentity(
+        "daily summary",
+        "2026-07-16T11:00:00Z",
+        5,
+      ),
+    );
+  });
+
+  test("applies skip, coalesce, and bounded catch-up policies", () => {
+    const due = [
+      "2026-07-16T09:00:00Z",
+      "2026-07-16T10:00:00Z",
+      "2026-07-16T11:00:00Z",
+      "2026-07-16T13:00:00Z",
+    ];
+
+    assert.deepEqual(planMisfires(due, now, "skip"), {
+      enqueue: [],
+      pending: ["2026-07-16T13:00:00.000Z"],
+      skip: [
+        "2026-07-16T09:00:00.000Z",
+        "2026-07-16T10:00:00.000Z",
+        "2026-07-16T11:00:00.000Z",
+      ],
+    });
+    assert.deepEqual(planMisfires(due, now, "coalesce_once"), {
+      enqueue: ["2026-07-16T11:00:00.000Z"],
+      pending: ["2026-07-16T13:00:00.000Z"],
+      skip: [
+        "2026-07-16T09:00:00.000Z",
+        "2026-07-16T10:00:00.000Z",
+      ],
+    });
+    assert.deepEqual(planMisfires(due, now, "run_all_bounded", 2), {
+      enqueue: [
+        "2026-07-16T09:00:00.000Z",
+        "2026-07-16T10:00:00.000Z",
+      ],
+      pending: [
+        "2026-07-16T11:00:00.000Z",
+        "2026-07-16T13:00:00.000Z",
+      ],
+      skip: [],
+    });
+  });
+
+  test("fences overlapping schedulers and stale completion", () => {
+    const occurrence = createScheduledOccurrence(
+      {
+        due_at: "2026-07-16T11:00:00Z",
+        generation: 3,
+        misfire_policy: "coalesce_once",
+        schedule_id: "summary",
+        schedule_revision: 2,
+      },
+      now,
+    );
+    const first = acquireScheduledOccurrence(occurrence, {
+      fencing_token: 10,
+      generation: 3,
+      lease_expires_at: "2026-07-16T12:01:00Z",
+      lease_token: "lease-a",
+      now,
+      owner_id: "worker-a",
+    });
+    assert.equal(first.acquired, true);
+    if (!first.acquired) {
+      assert.fail("expected first scheduler to acquire the occurrence");
+    }
+
+    const overlap = acquireScheduledOccurrence(first.occurrence, {
+      fencing_token: 11,
+      generation: 4,
+      lease_expires_at: "2026-07-16T12:02:00Z",
+      lease_token: "lease-b",
+      now: "2026-07-16T12:00:30Z",
+      owner_id: "worker-b",
+    });
+    assert.deepEqual(overlap, { acquired: false, reason: "active_lease" });
+
+    const recovered = acquireScheduledOccurrence(first.occurrence, {
+      fencing_token: 11,
+      generation: 4,
+      lease_expires_at: "2026-07-16T12:04:00Z",
+      lease_token: "lease-b",
+      now: "2026-07-16T12:02:00Z",
+      owner_id: "worker-b",
+    });
+    assert.equal(recovered.acquired, true);
+    if (!recovered.acquired) {
+      assert.fail("expected expired lease to be recovered");
+    }
+
+    assert.equal(
+      updateScheduledOccurrence(
+        recovered.occurrence,
+        {
+          fencing_token: 10,
+          generation: 3,
+          lease_token: "lease-a",
+          owner_id: "worker-a",
+        },
+        "completed",
+        "2026-07-16T12:02:30Z",
+      ),
+      undefined,
+    );
+    assert.equal(
+      updateScheduledOccurrence(
+        recovered.occurrence,
+        {
+          fencing_token: 11,
+          generation: 4,
+          lease_token: "lease-b",
+          owner_id: "worker-b",
+        },
+        "completed",
+        "2026-07-16T12:02:30Z",
+      )?.state,
+      "completed",
+    );
+  });
+
+  test("rejects invalid schedule and lease identity fields", () => {
+    assert.throws(
+      () =>
+        createScheduledOccurrence(
+          {
+            due_at: "2026-07-16T11:00:00Z",
+            generation: 0,
+            misfire_policy: "coalesce_once",
+            schedule_id: "summary",
+            schedule_revision: 2,
+          },
+          now,
+        ),
+      /generation must be a positive integer/,
+    );
+
+    const occurrence = createScheduledOccurrence(
+      {
+        due_at: "2026-07-16T11:00:00Z",
+        generation: 1,
+        misfire_policy: "coalesce_once",
+        schedule_id: "summary",
+        schedule_revision: 2,
+      },
+      now,
+    );
+    const lease = {
+      fencing_token: 1,
+      generation: 1,
+      lease_expires_at: "2026-07-16T12:01:00Z",
+      lease_token: "lease-1",
+      now,
+      owner_id: "worker-1",
+    };
+
+    assert.deepEqual(
+      acquireScheduledOccurrence(occurrence, { ...lease, generation: 0 }),
+      { acquired: false, reason: "invalid_generation" },
+    );
+    assert.deepEqual(
+      acquireScheduledOccurrence(occurrence, { ...lease, fencing_token: 0 }),
+      { acquired: false, reason: "invalid_fencing_token" },
+    );
+    assert.deepEqual(
+      acquireScheduledOccurrence(occurrence, { ...lease, owner_id: " " }),
+      { acquired: false, reason: "invalid_lease_identity" },
+    );
+    assert.deepEqual(
+      acquireScheduledOccurrence(occurrence, { ...lease, lease_token: "" }),
+      { acquired: false, reason: "invalid_lease_identity" },
+    );
+  });
+});
+
+describe("compatibility and service gates", () => {
+  test("requires bidirectional reads, a shared write version, and required capabilities", () => {
+    const supported = assessCompatibility({
+      companion_manifest: manifest("companion", ["v1", "v2"]),
+      companion_schema: schema("v2", ["v1", "v2"], ["v2"]),
+      core_manifest: manifest("core", ["v1", "v2"]),
+      core_schema: schema("v1", ["v1", "v2"], ["v2"]),
+    });
+    assert.deepEqual(supported, {
+      decision: "supported",
+      negotiated_write_version: "v2",
+      reasons: [],
+    });
+
+    const blocked = assessCompatibility({
+      companion_manifest: manifest("companion", ["v1", "v2"], []),
+      companion_schema: schema("v2", ["v1", "v2"], ["v2"]),
+      core_manifest: manifest("core", ["v1", "v2"]),
+      core_schema: schema("v1", ["v1", "v2"], ["v2"]),
+    });
+    assert.equal(blocked.decision, "blocked");
+    assert.deepEqual(blocked.reasons, ["companion_missing_turns@1"]);
+  });
+
+  test("blocks readiness and leases on stale presence, recovery, or generation changes", () => {
+    const assessment = {
+      decision: "supported" as const,
+      negotiated_write_version: "v1",
+      reasons: [],
+    };
+    assert.equal(readinessGate(presence(), assessment, now).allowed, true);
+    assert.deepEqual(
+      newLeaseGate(presence(), assessment, 1, 2, now),
+      { allowed: true, reason: "lease_allowed" },
+    );
+    assert.deepEqual(
+      newLeaseGate(presence({ route_generation: 3 }), assessment, 1, 2, now),
+      { allowed: false, reason: "route_generation_changed" },
+    );
+    assert.deepEqual(
+      readinessGate(
+        presence({ service_state: "recovering" }),
+        assessment,
+        now,
+      ),
+      { allowed: false, reason: "service_recovering" },
+    );
+    assert.deepEqual(
+      readinessGate(
+        presence({ compatibility: "blocked" }),
+        assessment,
+        now,
+      ),
+      { allowed: false, reason: "presence_compatibility_blocked" },
+    );
+    assert.deepEqual(
+      readinessGate(
+        presence({ expires_at: "2026-07-16T11:59:59Z" }),
+        assessment,
+        now,
+      ),
+      { allowed: false, reason: "presence_expired" },
+    );
+  });
+});
+
+describe("Slack-visible continuity status", () => {
+  test("derives queued, degraded, and partial-source facts with expiry", () => {
+    const statuses = deriveSlackVisibleStatuses(
+      run(),
+      presence({ service_state: "degraded" }),
+      now,
+      { available_source_count: 2, expected_source_count: 3 },
+    );
+
+    assert.deepEqual(
+      statuses.map((status) => status.code),
+      ["queued", "degraded", "partial_source"],
+    );
+    assert.equal(statuses.every((status) => status.expires_at === "2026-07-16T12:05:00.000Z"), true);
+    assert.equal(new Set(statuses.map((status) => status.idempotency_key)).size, 3);
+  });
+
+  test("does not show stale recovery state", () => {
+    assert.deepEqual(
+      deriveSlackVisibleStatuses(
+        run(),
+        presence({
+          expires_at: "2026-07-16T11:59:00Z",
+          service_state: "recovering",
+        }),
+        now,
+      ),
+      [],
+    );
+  });
+});
+
+describe("maintenance and release continuity", () => {
+  test("keeps a graceful drain blocked until replacement and active work are safe", () => {
+    const plan = planMaintenance({
+      active_runs: [
+        { checkpointable: true, run_id: "run-1" },
+        { checkpointable: false, run_id: "run-2" },
+      ],
+      compatibility: "supported",
+      deliveries: [{ delivery_id: "delivery-1", state: "delivering" }],
+      mode: "graceful",
+      now,
+      replacement_presence: presence(),
+    });
+
+    assert.equal(plan.new_leases_allowed, false);
+    assert.equal(plan.admission_behavior, "durable_queue");
+    assert.equal(plan.safe_to_stop, false);
+    assert.equal(plan.forced_stop_permitted_after_actions, false);
+    assert.deepEqual(plan.blockers, ["run_not_checkpointable:run-2"]);
+    assert.equal(
+      plan.actions.some((action) => action.action === "checkpoint_and_pause"),
+      true,
+    );
+    assert.equal(
+      plan.actions.some((action) => action.action === "drain_delivery"),
+      true,
+    );
+  });
+
+  test("keeps forced maintenance unsafe until reconciliation and delivery pause finish", () => {
+    const plan = planMaintenance({
+      active_runs: [{ checkpointable: false, run_id: "run-1" }],
+      compatibility: "supported",
+      deliveries: [{ delivery_id: "delivery-1", state: "pending" }],
+      mode: "forced",
+      now,
+    });
+
+    assert.equal(plan.safe_to_stop, false);
+    assert.equal(plan.forced_stop_permitted_after_actions, true);
+    assert.deepEqual(plan.blockers, []);
+    assert.equal(
+      plan.actions.some(
+        (action) => action.action === "mark_for_reconciliation",
+      ),
+      true,
+    );
+    assert.equal(
+      plan.actions.some((action) => action.action === "pause_delivery"),
+      true,
+    );
+  });
+
+  test("marks a clean graceful drain safe after replacement readiness", () => {
+    const plan = planMaintenance({
+      active_runs: [],
+      compatibility: "supported",
+      deliveries: [],
+      mode: "graceful",
+      now,
+      replacement_presence: presence(),
+    });
+
+    assert.equal(plan.safe_to_stop, true);
+    assert.equal(plan.forced_stop_permitted_after_actions, false);
+    assert.deepEqual(plan.blockers, []);
+    assert.deepEqual(plan.actions, [
+      { action: "stop_new_leases", subject_id: "service" },
+    ]);
+  });
+
+  test("fails release verification for orphaned work and stuck delivery", () => {
+    const verification = verifyReleaseReceipt(
+      releaseReceipt({ orphaned_run_count: 1, stuck_delivery_count: 2 }),
+    );
+    assert.deepEqual(verification, {
+      passed: false,
+      reasons: ["orphaned_runs_present", "stuck_deliveries_present"],
+    });
+    assert.equal(verifyReleaseReceipt(releaseReceipt()).passed, true);
+  });
+});
+
+describe("topology-neutral route migration", () => {
+  test("uses route-generation compare-and-swap and preserves Slack thread identity", () => {
+    let receipt = createMigrationReceipt({
+      binding_id: "binding-1",
+      checkpoint_count: 2,
+      created_at: now,
+      migration_id: "migration-1",
+      pending_delivery_count: 1,
+      rollback_generation: 8,
+      route_generation: 12,
+      source_generation: 8,
+      target_generation: 9,
+    });
+    for (const state of ["validating", "draining", "cutting_over"] as const) {
+      const advanced = advanceMigration(receipt, state, now);
+      assert.equal(advanced.changed, true);
+      if (!advanced.changed) {
+        assert.fail(`expected transition to ${state}`);
+      }
+      receipt = advanced.receipt;
+    }
+
+    const conflict = cutOverRoute(receipt, 11, identity(), identity(), now);
+    assert.deepEqual(conflict, {
+      changed: false,
+      reason: "route_generation_conflict",
+      receipt,
+    });
+
+    const cutover = cutOverRoute(receipt, 12, identity(), identity(), now);
+    assert.equal(cutover.changed, true);
+    if (!cutover.changed) {
+      assert.fail("expected route cutover");
+    }
+    assert.equal(cutover.receipt.route_generation, 13);
+    assert.equal(cutover.receipt.state, "recovering");
+    assert.equal(cutover.receipt.source_generation, 8);
+    assert.equal(cutover.receipt.target_generation, 9);
+  });
+
+  test("fails cutover if app, binding, conversation, thread, or durable state changes", () => {
+    const receipt = receiptAtCutover();
+    const changed = identity({ durable_thread_state_digest: "sha256:changed" });
+    const result = cutOverRoute(receipt, 12, identity(), changed, now);
+
+    assert.equal(result.changed, false);
+    assert.equal(result.reason, "identity_changed");
+    assert.equal(result.receipt.state, "failed");
+    assert.equal(result.receipt.route_generation, 12);
+  });
+
+  test("rolls back through the same route-generation compare-and-swap", () => {
+    const receipt = {
+      ...receiptAtCutover(),
+      route_generation: 13,
+      state: "rolling_back" as const,
+    };
+    const stale = rollBackRoute(receipt, 12, identity(), identity(), now);
+    assert.equal(stale.changed, false);
+    assert.equal(stale.reason, "route_generation_conflict");
+
+    const rolledBack = rollBackRoute(
+      receipt,
+      13,
+      identity(),
+      identity(),
+      now,
+    );
+    assert.equal(rolledBack.changed, true);
+    if (!rolledBack.changed) {
+      assert.fail("expected route rollback");
+    }
+    assert.equal(rolledBack.receipt.state, "rolled_back");
+    assert.equal(rolledBack.receipt.route_generation, 14);
+    assert.equal(rolledBack.receipt.rollback_generation, 8);
+  });
+});
+
+function schema(
+  currentVersion: string,
+  readVersions: string[],
+  writeVersions: string[],
+): SchemaCompatibility {
+  return {
+    capability_decisions: ["supported", "degraded", "blocked", "incompatible"],
+    current_version: currentVersion,
+    read_versions: readVersions,
+    rolling_upgrade_rule: "Readers accept the previous version during rollout.",
+    write_versions: writeVersions,
+  };
+}
+
+function manifest(
+  serviceId: string,
+  contractVersions: string[],
+  capabilities: CapabilityManifestV1["capabilities"] = [
+    { capability_id: "turns", level: "required", version: "1" },
+  ],
+): CapabilityManifestV1 {
+  return {
+    capabilities,
+    contract_versions: contractVersions,
+    digest: `sha256:${serviceId}`,
+    generation: 1,
+    produced_at: now,
+    schema_version: "capability-manifest/v1",
+    service_id: serviceId,
+  };
+}
+
+function presence(
+  changes: Partial<PresenceSnapshotV1> = {},
+): PresenceSnapshotV1 {
+  return {
+    active_generation: 1,
+    binding_id: "binding-1",
+    compatibility: "supported",
+    expires_at: "2026-07-16T12:05:00.000Z",
+    observed_at: now,
+    reason_code: "ready",
+    route_generation: 2,
+    schema_version: "presence-snapshot/v1",
+    service_state: "ready",
+    ...changes,
+  };
+}
+
+function run(): RunReceiptV1 {
+  return {
+    admitted_at: now,
+    binding_id: "binding-1",
+    idempotency_key: "event-1",
+    input_digest: "sha256:input",
+    receipt_id: "receipt-1",
+    received_at: now,
+    required_capabilities: [],
+    retention_policy_ref: "retention://standard",
+    revision: 1,
+    run_id: "run-1",
+    run_kind: "interactive",
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: "conversation://thread-1",
+    tenant_id: "tenant-1",
+    updated_at: now,
+  };
+}
+
+function releaseReceipt(
+  changes: Partial<ReleaseReceiptV2> = {},
+): ReleaseReceiptV2 {
+  return {
+    active_lease_count: 0,
+    compatibility: "supported",
+    created_at: now,
+    drained_run_count: 3,
+    generation: 2,
+    orphaned_run_count: 0,
+    pending_delivery_count: 0,
+    recoverable_run_count: 0,
+    release_id: "release-2",
+    resumed_run_count: 3,
+    schema_version: "release-receipt/v2",
+    service_id: "companion",
+    state: "active",
+    stuck_delivery_count: 0,
+    updated_at: now,
+    verification_receipt_refs: ["verification://release-2"],
+    ...changes,
+  };
+}
+
+function identity(
+  changes: Partial<SlackThreadIdentity> = {},
+): SlackThreadIdentity {
+  return {
+    binding_id: "binding-1",
+    conversation_id: "conversation-1",
+    durable_thread_state_digest: "sha256:thread-state",
+    installation_id: "installation-1",
+    slack_app_id: "app-1",
+    thread_id: "thread-1",
+    ...changes,
+  };
+}
+
+function receiptAtCutover() {
+  return {
+    binding_id: "binding-1",
+    checkpoint_count: 2,
+    created_at: now,
+    migration_id: "migration-1",
+    pending_delivery_count: 1,
+    rollback_generation: 8,
+    route_generation: 12,
+    schema_version: "migration-receipt/v1" as const,
+    source_generation: 8,
+    state: "cutting_over" as const,
+    target_generation: 9,
+    updated_at: now,
+  };
+}


### PR DESCRIPTION
## Summary

- create deterministic scheduled occurrences with bounded misfire handling and generation-fenced leases
- negotiate companion/core contract versions and capabilities before readiness or lease acquisition
- derive expiring Slack-visible queued, degraded, recovery, and partial-source status from durable records
- model graceful drain and forced-maintenance actions without claiming work is safe before those actions commit
- fail release verification on orphaned runs or stuck deliveries
- perform topology-neutral route cutover and rollback with compare-and-swap generations while preserving Slack and thread identity

## Safety boundary

This slice contains portable decisions, record transformations, and conformance tests. It contains no placement classes, infrastructure resources, environment values, deployment adapters, routes, credentials, or operational thresholds.

## Validation

- Slack companion typecheck
- Slack companion tests (23 passed)
- `go test ./tools/archtests/...`
- disclosure and configuration scans
- Practice Registry plan and final gates passed
