### PR TITLE
Add fenced Slack turn execution

### DIFF
--- a/apps/slack-companion/src/delivery/contracts.ts
+++ b/apps/slack-companion/src/delivery/contracts.ts
@@ -1,0 +1,103 @@
+import type {
+  DeliveryPartV1,
+  DeliveryReceiptV1,
+  WorkLeaseV1,
+} from "@writer/cerebro-sdk";
+
+export type { DeliveryPartV1, DeliveryReceiptV1, WorkLeaseV1 };
+
+export interface DeliveryPayloadPart {
+  payload_digest: string;
+  payload_ref: string;
+}
+
+/** One logical delivery. Reusing delivery_key with different content conflicts. */
+export interface DeliveryPlanRequest {
+  delivery_key: string;
+  destination_ref: string;
+  max_attempts: number;
+  parts: readonly DeliveryPayloadPart[];
+  run_id: string;
+}
+
+export interface DurableDeliveryPlan {
+  max_attempts: number;
+  payload_fingerprint: string;
+  receipt: DeliveryReceiptV1;
+}
+
+export interface DeliveryPlanResult {
+  created: boolean;
+  receipt: DeliveryReceiptV1;
+}
+
+export interface DeliveryPartClaim {
+  attempt: number;
+  client_message_id: string;
+  delivery_id: string;
+  lease: WorkLeaseV1;
+  part: DeliveryPartV1;
+}
+
+export type DeliveryClaimResult =
+  | { claim: DeliveryPartClaim; status: "claimed" }
+  | {
+      reason: "abandoned" | "busy" | "complete" | "paused" | "retry_exhausted";
+      receipt: DeliveryReceiptV1;
+      status: "idle";
+    };
+
+export interface DeliveryClaimRequest {
+  delivery_id: string;
+  lease: WorkLeaseV1;
+  now: string;
+}
+
+export interface DeliveryCompletionRequest {
+  accepted_at: string;
+  delivery_id: string;
+  destination_receipt: string;
+  lease: WorkLeaseV1;
+  part_id: string;
+}
+
+export interface DeliveryFailureRequest {
+  delivery_id: string;
+  failed_at: string;
+  lease: WorkLeaseV1;
+  part_id: string;
+}
+
+export interface DeliveryMaintenanceRequest {
+  delivery_id: string;
+  lease: WorkLeaseV1;
+  occurred_at: string;
+}
+
+export interface PlatformDeliveryRequest {
+  client_message_id: string;
+  destination_ref: string;
+  payload_digest: string;
+  payload_ref: string;
+}
+
+export interface PlatformAcceptanceReceipt {
+  accepted_at: string;
+  destination_receipt: string;
+}
+
+export type DeliveryStepResult =
+  | {
+      destination_receipt: string;
+      part_id: string;
+      receipt: DeliveryReceiptV1;
+      status: "delivered";
+    }
+  | {
+      receipt: DeliveryReceiptV1;
+      status: "abandoned" | "busy" | "complete" | "paused" | "retry_exhausted";
+    }
+  | {
+      receipt: DeliveryReceiptV1;
+      status: "retry_scheduled";
+    };

--- a/apps/slack-companion/src/delivery/coordinator.ts
+++ b/apps/slack-companion/src/delivery/coordinator.ts
@@ -1,0 +1,218 @@
+import { createHash } from "node:crypto";
+import type {
+  DeliveryPartV1,
+  DeliveryPlanRequest,
+  DeliveryPlanResult,
+  DeliveryStepResult,
+  WorkLeaseV1,
+} from "./contracts.js";
+import type {
+  DeliveryClockPort,
+  DurableDeliveryPort,
+  PlatformDeliveryPort,
+} from "./ports.js";
+
+export class DeliveryInputError extends Error {}
+
+export interface DeliveryCoordinatorOptions {
+  clock: DeliveryClockPort;
+  sender: PlatformDeliveryPort;
+  store: DurableDeliveryPort;
+}
+
+export class DeliveryCoordinator {
+  private readonly clock: DeliveryClockPort;
+  private readonly sender: PlatformDeliveryPort;
+  private readonly store: DurableDeliveryPort;
+
+  constructor(options: DeliveryCoordinatorOptions) {
+    this.clock = options.clock;
+    this.sender = options.sender;
+    this.store = options.store;
+  }
+
+  async plan(request: DeliveryPlanRequest): Promise<DeliveryPlanResult> {
+    validatePlan(request);
+    const now = this.clock.now().toISOString();
+    const deliveryId = stableIdentity("delivery", [
+      request.run_id,
+      request.destination_ref,
+      request.delivery_key,
+    ]);
+    const parts: DeliveryPartV1[] = request.parts.map((part, index) => {
+      const sequence = index + 1;
+      const partId = stableIdentity("part", [deliveryId, String(sequence)]);
+      return {
+        idempotency_key: stableIdentity("message", [deliveryId, partId]),
+        part_id: partId,
+        payload_digest: part.payload_digest,
+        payload_ref: part.payload_ref,
+        sequence,
+        state: "pending",
+      };
+    });
+
+    return this.store.plan({
+      max_attempts: request.max_attempts,
+      payload_fingerprint: payloadFingerprint(request),
+      receipt: {
+        created_at: now,
+        delivery_id: deliveryId,
+        destination_ref: request.destination_ref,
+        parts,
+        run_id: request.run_id,
+        schema_version: "delivery-receipt/v1",
+        state: "pending",
+        updated_at: now,
+      },
+    });
+  }
+
+  async deliverNext(
+    deliveryId: string,
+    lease: WorkLeaseV1,
+  ): Promise<DeliveryStepResult> {
+    const claimResult = await this.store.claimNext({
+      delivery_id: deliveryId,
+      lease,
+      now: this.clock.now().toISOString(),
+    });
+    if (claimResult.status === "idle") {
+      return {
+        receipt: claimResult.receipt,
+        status: claimResult.reason,
+      };
+    }
+
+    const { claim } = claimResult;
+    const plannedReceipt = await this.requireReceipt(deliveryId);
+    let acceptance;
+    try {
+      acceptance = await this.sender.send({
+        client_message_id: claim.client_message_id,
+        destination_ref: plannedReceipt.destination_ref,
+        payload_digest: claim.part.payload_digest,
+        payload_ref: claim.part.payload_ref,
+      });
+    } catch {
+      const receipt = await this.store.recordFailure({
+        delivery_id: deliveryId,
+        failed_at: this.clock.now().toISOString(),
+        lease,
+        part_id: claim.part.part_id,
+      });
+      return {
+        receipt,
+        status: receipt.state === "failed"
+          ? "retry_exhausted"
+          : "retry_scheduled",
+      };
+    }
+    if (!acceptance.destination_receipt) {
+      const receipt = await this.store.recordFailure({
+        delivery_id: deliveryId,
+        failed_at: this.clock.now().toISOString(),
+        lease,
+        part_id: claim.part.part_id,
+      });
+      return {
+        receipt,
+        status: receipt.state === "failed"
+          ? "retry_exhausted"
+          : "retry_scheduled",
+      };
+    }
+
+    // Once the destination accepts, never rewrite this as a send failure. If
+    // persistence is interrupted, the stable client_message_id makes recovery
+    // safe after the claim expires.
+    const receipt = await this.store.completePart({
+      accepted_at: acceptance.accepted_at,
+      delivery_id: deliveryId,
+      destination_receipt: acceptance.destination_receipt,
+      lease,
+      part_id: claim.part.part_id,
+    });
+    return {
+      destination_receipt: acceptance.destination_receipt,
+      part_id: claim.part.part_id,
+      receipt,
+      status: "delivered",
+    };
+  }
+
+  abandon(deliveryId: string, lease: WorkLeaseV1) {
+    return this.store.abandon({
+      delivery_id: deliveryId,
+      lease,
+      occurred_at: this.clock.now().toISOString(),
+    });
+  }
+
+  pause(deliveryId: string, lease: WorkLeaseV1) {
+    return this.store.pause({
+      delivery_id: deliveryId,
+      lease,
+      occurred_at: this.clock.now().toISOString(),
+    });
+  }
+
+  resume(deliveryId: string, lease: WorkLeaseV1) {
+    return this.store.resume({
+      delivery_id: deliveryId,
+      lease,
+      occurred_at: this.clock.now().toISOString(),
+    });
+  }
+
+  private async requireReceipt(deliveryId: string) {
+    const receipt = await this.store.read(deliveryId);
+    if (receipt === undefined) {
+      throw new DeliveryInputError("The delivery does not exist.");
+    }
+    return receipt;
+  }
+}
+
+function validatePlan(request: DeliveryPlanRequest): void {
+  if (
+    !request.delivery_key ||
+    !request.destination_ref ||
+    !request.run_id ||
+    request.parts.length === 0
+  ) {
+    throw new DeliveryInputError(
+      "Delivery key, destination, run, and at least one part are required.",
+    );
+  }
+  if (!Number.isInteger(request.max_attempts) || request.max_attempts < 1) {
+    throw new DeliveryInputError("max_attempts must be a positive integer.");
+  }
+  for (const part of request.parts) {
+    if (!part.payload_digest || !part.payload_ref) {
+      throw new DeliveryInputError(
+        "Each delivery part requires a payload reference and digest.",
+      );
+    }
+  }
+}
+
+function payloadFingerprint(request: DeliveryPlanRequest): string {
+  return digest(
+    JSON.stringify({
+      delivery_key: request.delivery_key,
+      destination_ref: request.destination_ref,
+      max_attempts: request.max_attempts,
+      parts: request.parts.map((part) => [part.payload_digest, part.payload_ref]),
+      run_id: request.run_id,
+    }),
+  );
+}
+
+export function stableIdentity(namespace: string, fields: readonly string[]): string {
+  return `${namespace}-${digest(JSON.stringify(fields)).slice(0, 32)}`;
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/apps/slack-companion/src/delivery/ports.ts
+++ b/apps/slack-companion/src/delivery/ports.ts
@@ -1,0 +1,37 @@
+import type {
+  DeliveryClaimRequest,
+  DeliveryClaimResult,
+  DeliveryCompletionRequest,
+  DeliveryFailureRequest,
+  DeliveryMaintenanceRequest,
+  DeliveryPlanResult,
+  DeliveryReceiptV1,
+  DurableDeliveryPlan,
+  PlatformAcceptanceReceipt,
+  PlatformDeliveryRequest,
+} from "./contracts.js";
+
+export interface DeliveryClockPort {
+  now(): Date;
+}
+
+/**
+ * A production adapter durably stores max_attempts and the payload fingerprint
+ * with the receipt. Each operation is atomic with its generation and fencing
+ * checks. Process-local queues are not a valid implementation.
+ */
+export interface DurableDeliveryPort {
+  abandon(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1>;
+  claimNext(request: DeliveryClaimRequest): Promise<DeliveryClaimResult>;
+  completePart(request: DeliveryCompletionRequest): Promise<DeliveryReceiptV1>;
+  pause(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1>;
+  plan(delivery: DurableDeliveryPlan): Promise<DeliveryPlanResult>;
+  read(deliveryId: string): Promise<DeliveryReceiptV1 | undefined>;
+  recordFailure(request: DeliveryFailureRequest): Promise<DeliveryReceiptV1>;
+  resume(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1>;
+}
+
+/** The transport must honor client_message_id as an idempotency identity. */
+export interface PlatformDeliveryPort {
+  send(request: PlatformDeliveryRequest): Promise<PlatformAcceptanceReceipt>;
+}

--- a/apps/slack-companion/src/delivery/reference-store.ts
+++ b/apps/slack-companion/src/delivery/reference-store.ts
@@ -1,0 +1,410 @@
+import type {
+  DeliveryClaimRequest,
+  DeliveryClaimResult,
+  DeliveryCompletionRequest,
+  DeliveryFailureRequest,
+  DeliveryMaintenanceRequest,
+  DeliveryPartClaim,
+  DeliveryPlanResult,
+  DeliveryReceiptV1,
+  DurableDeliveryPlan,
+  WorkLeaseV1,
+} from "./contracts.js";
+import type { DurableDeliveryPort } from "./ports.js";
+
+export class DeliveryConflictError extends Error {}
+export class DeliveryFenceError extends Error {}
+export class DeliveryNotFoundError extends Error {}
+
+interface StoredDelivery {
+  attempts: Map<string, number>;
+  claims: Map<string, DeliveryPartClaim>;
+  maxAttempts: number;
+  pausedStates: Map<string, DeliveryReceiptV1["parts"][number]["state"]>;
+  payloadFingerprint: string;
+  receipt: DeliveryReceiptV1;
+}
+
+/** Conformance fixture only. Production adapters must use durable storage. */
+export class ReferenceMemoryDeliveryStore implements DurableDeliveryPort {
+  private activeGeneration: number;
+  private readonly acceptedLeaseByRun = new Map<string, WorkLeaseV1>();
+  private readonly deliveries = new Map<string, StoredDelivery>();
+  private failPlan = false;
+  private failCompletion = false;
+
+  constructor(activeGeneration: number) {
+    this.activeGeneration = activeGeneration;
+  }
+
+  plan(delivery: DurableDeliveryPlan): Promise<DeliveryPlanResult> {
+    if (this.failPlan) {
+      this.failPlan = false;
+      return Promise.reject(new Error("injected delivery plan failure"));
+    }
+    const prior = this.deliveries.get(delivery.receipt.delivery_id);
+    if (prior !== undefined) {
+      if (prior.payloadFingerprint !== delivery.payload_fingerprint) {
+        return Promise.reject(
+          new DeliveryConflictError(
+            "The delivery identity already has a different payload.",
+          ),
+        );
+      }
+      return Promise.resolve({ created: false, receipt: copy(prior.receipt) });
+    }
+    this.deliveries.set(delivery.receipt.delivery_id, {
+      attempts: new Map(),
+      claims: new Map(),
+      maxAttempts: delivery.max_attempts,
+      pausedStates: new Map(),
+      payloadFingerprint: delivery.payload_fingerprint,
+      receipt: copy(delivery.receipt),
+    });
+    return Promise.resolve({ created: true, receipt: copy(delivery.receipt) });
+  }
+
+  async claimNext(request: DeliveryClaimRequest): Promise<DeliveryClaimResult> {
+    const stored = this.requireDelivery(request.delivery_id);
+    if (request.lease.run_id !== stored.receipt.run_id) {
+      throw new DeliveryFenceError("The lease belongs to another run.");
+    }
+    if (stored.receipt.state === "abandoned") {
+      return {
+        reason: "abandoned",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    if (stored.receipt.state === "paused") {
+      return {
+        reason: "paused",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    this.acceptLease(request.lease, request.now);
+
+    const part = [...stored.receipt.parts].sort(
+      (left, right) => left.sequence - right.sequence,
+    ).find((candidate) => candidate.state !== "delivered");
+    if (part === undefined) {
+      stored.receipt.state = "completed";
+      return {
+        reason: "complete",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    if (part.state === "abandoned") {
+      stored.receipt.state = "abandoned";
+      return {
+        reason: "abandoned",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    if (part.state === "paused") {
+      stored.receipt.state = "paused";
+      return {
+        reason: "paused",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+
+    const attempts = stored.attempts.get(part.part_id) ?? 0;
+    if (attempts >= stored.maxAttempts) {
+      stored.receipt.state = "failed";
+      return {
+        reason: "retry_exhausted",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    const priorClaim = stored.claims.get(part.part_id);
+    if (priorClaim !== undefined) {
+      if (sameLease(priorClaim.lease, request.lease)) {
+        return { claim: copy(priorClaim), status: "claimed" };
+      }
+      if (Date.parse(priorClaim.lease.lease_expires_at) > Date.parse(request.now)) {
+        return {
+          reason: "busy",
+          receipt: copy(stored.receipt),
+          status: "idle",
+        };
+      }
+      if (request.lease.fencing_token <= priorClaim.lease.fencing_token) {
+        throw new DeliveryFenceError(
+          "Expired delivery claims require a newer fencing value.",
+        );
+      }
+    }
+
+    const claim: DeliveryPartClaim = {
+      attempt: attempts + 1,
+      client_message_id: part.idempotency_key,
+      delivery_id: request.delivery_id,
+      lease: copy(request.lease),
+      part: copy({ ...part, state: "delivering" }),
+    };
+    stored.attempts.set(part.part_id, claim.attempt);
+    stored.claims.set(part.part_id, copy(claim));
+    part.state = "delivering";
+    stored.receipt.state = "delivering";
+    stored.receipt.updated_at = request.now;
+    return { claim: copy(claim), status: "claimed" };
+  }
+
+  async pause(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1> {
+    const stored = this.requireDelivery(request.delivery_id);
+    if (["abandoned", "completed"].includes(stored.receipt.state)) {
+      return copy(stored.receipt);
+    }
+    this.requireRun(stored, request.lease);
+    this.acceptLease(request.lease, request.occurred_at);
+    for (const part of stored.receipt.parts) {
+      if (part.state === "delivered" || part.state === "abandoned") {
+        continue;
+      }
+      stored.pausedStates.set(
+        part.part_id,
+        part.state === "delivering" ? "pending" : part.state,
+      );
+      part.state = "paused";
+    }
+    stored.claims.clear();
+    stored.receipt.state = "paused";
+    stored.receipt.updated_at = request.occurred_at;
+    return copy(stored.receipt);
+  }
+
+  async resume(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1> {
+    const stored = this.requireDelivery(request.delivery_id);
+    if (stored.receipt.state === "abandoned") {
+      throw new DeliveryConflictError("An abandoned delivery cannot resume.");
+    }
+    if (stored.receipt.state === "completed") {
+      return copy(stored.receipt);
+    }
+    this.requireRun(stored, request.lease);
+    this.acceptLease(request.lease, request.occurred_at);
+    if (stored.receipt.state !== "paused") {
+      return copy(stored.receipt);
+    }
+    for (const part of stored.receipt.parts) {
+      if (part.state !== "paused") {
+        continue;
+      }
+      part.state = stored.pausedStates.get(part.part_id) ?? "pending";
+    }
+    stored.pausedStates.clear();
+    stored.receipt.state = aggregate(stored);
+    stored.receipt.updated_at = request.occurred_at;
+    return copy(stored.receipt);
+  }
+
+  async abandon(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1> {
+    const stored = this.requireDelivery(request.delivery_id);
+    if (stored.receipt.state === "abandoned") {
+      return copy(stored.receipt);
+    }
+    if (stored.receipt.state === "completed") {
+      return copy(stored.receipt);
+    }
+    this.requireRun(stored, request.lease);
+    this.acceptLease(request.lease, request.occurred_at);
+    for (const part of stored.receipt.parts) {
+      if (part.state !== "delivered") {
+        part.state = "abandoned";
+      }
+    }
+    stored.claims.clear();
+    stored.pausedStates.clear();
+    stored.receipt.state = "abandoned";
+    stored.receipt.updated_at = request.occurred_at;
+    return copy(stored.receipt);
+  }
+
+  async completePart(
+    request: DeliveryCompletionRequest,
+  ): Promise<DeliveryReceiptV1> {
+    if (this.failCompletion) {
+      this.failCompletion = false;
+      return Promise.reject(new Error("injected completion failure"));
+    }
+    const stored = this.requireDelivery(request.delivery_id);
+    if (!request.destination_receipt) {
+      throw new DeliveryConflictError("A destination receipt is required.");
+    }
+    const part = requirePart(stored.receipt, request.part_id);
+    if (part.state === "delivered") {
+      if (part.destination_receipt !== request.destination_receipt) {
+        return Promise.reject(
+          new DeliveryConflictError(
+            "The part already has a different destination receipt.",
+          ),
+        );
+      }
+      return Promise.resolve(copy(stored.receipt));
+    }
+    this.requireClaim(stored, request.part_id, request.lease, request.accepted_at);
+    part.delivered_at = request.accepted_at;
+    part.destination_receipt = request.destination_receipt;
+    part.state = "delivered";
+    stored.claims.delete(request.part_id);
+    stored.receipt.updated_at = request.accepted_at;
+    stored.receipt.state = aggregate(stored);
+    return Promise.resolve(copy(stored.receipt));
+  }
+
+  async recordFailure(request: DeliveryFailureRequest): Promise<DeliveryReceiptV1> {
+    const stored = this.requireDelivery(request.delivery_id);
+    const part = requirePart(stored.receipt, request.part_id);
+    this.requireClaim(stored, request.part_id, request.lease, request.failed_at);
+    part.state = "failed";
+    stored.claims.delete(request.part_id);
+    stored.receipt.updated_at = request.failed_at;
+    stored.receipt.state = aggregate(stored);
+    return Promise.resolve(copy(stored.receipt));
+  }
+
+  read(deliveryId: string): Promise<DeliveryReceiptV1 | undefined> {
+    const stored = this.deliveries.get(deliveryId);
+    return Promise.resolve(stored === undefined ? undefined : copy(stored.receipt));
+  }
+
+  failNextCompletion(): void {
+    this.failCompletion = true;
+  }
+
+  failNextPlan(): void {
+    this.failPlan = true;
+  }
+
+  claimCount(deliveryId: string): number {
+    return this.requireDelivery(deliveryId).claims.size;
+  }
+
+  setActiveGeneration(generation: number): void {
+    this.activeGeneration = generation;
+  }
+
+  private acceptLease(lease: WorkLeaseV1, now: string): void {
+    if (lease.generation !== this.activeGeneration) {
+      throw new DeliveryFenceError("The lease generation is not active.");
+    }
+    if (Date.parse(lease.lease_expires_at) <= Date.parse(now)) {
+      throw new DeliveryFenceError("The delivery lease has expired.");
+    }
+    const prior = this.acceptedLeaseByRun.get(lease.run_id);
+    if (prior !== undefined) {
+      if (lease.fencing_token < prior.fencing_token) {
+        throw new DeliveryFenceError("The fencing value is stale.");
+      }
+      if (
+        lease.fencing_token === prior.fencing_token &&
+        !sameLease(lease, prior)
+      ) {
+        throw new DeliveryFenceError(
+          "A fencing value cannot be reused by another lease.",
+        );
+      }
+    }
+    this.acceptedLeaseByRun.set(lease.run_id, copy(lease));
+  }
+
+  private requireClaim(
+    stored: StoredDelivery,
+    partId: string,
+    lease: WorkLeaseV1,
+    occurredAt: string,
+  ): DeliveryPartClaim {
+    if (lease.generation !== this.activeGeneration) {
+      throw new DeliveryFenceError("The lease generation is not active.");
+    }
+    const accepted = this.acceptedLeaseByRun.get(lease.run_id);
+    if (accepted === undefined || !sameLease(accepted, lease)) {
+      throw new DeliveryFenceError("A newer lease owns this delivery.");
+    }
+    const claim = stored.claims.get(partId);
+    if (claim === undefined || !sameLease(claim.lease, lease)) {
+      throw new DeliveryFenceError("The lease does not own this delivery part.");
+    }
+    if (Date.parse(lease.lease_expires_at) <= Date.parse(occurredAt)) {
+      throw new DeliveryFenceError("The delivery lease expired before this update.");
+    }
+    return claim;
+  }
+
+  private requireRun(stored: StoredDelivery, lease: WorkLeaseV1): void {
+    if (lease.run_id !== stored.receipt.run_id) {
+      throw new DeliveryFenceError("The lease belongs to another run.");
+    }
+  }
+
+  private requireDelivery(deliveryId: string): StoredDelivery {
+    const delivery = this.deliveries.get(deliveryId);
+    if (delivery === undefined) {
+      throw new DeliveryNotFoundError("The delivery does not exist.");
+    }
+    return delivery;
+  }
+}
+
+function aggregate(stored: StoredDelivery): DeliveryReceiptV1["state"] {
+  if (stored.receipt.parts.every((part) => part.state === "delivered")) {
+    return "completed";
+  }
+  if (stored.receipt.parts.some((part) => part.state === "abandoned")) {
+    return "abandoned";
+  }
+  if (stored.receipt.parts.some((part) => part.state === "paused")) {
+    return "paused";
+  }
+  if (
+    stored.receipt.parts.some(
+      (part) =>
+        part.state === "failed" &&
+        (stored.attempts.get(part.part_id) ?? 0) >= stored.maxAttempts,
+    )
+  ) {
+    return "failed";
+  }
+  if (
+    stored.receipt.parts.some((part) =>
+      ["delivering", "delivered", "failed"].includes(part.state)
+    )
+  ) {
+    return "delivering";
+  }
+  return "pending";
+}
+
+function requirePart(
+  receipt: DeliveryReceiptV1,
+  partId: string,
+): DeliveryReceiptV1["parts"][number] {
+  const part = receipt.parts.find((candidate) => candidate.part_id === partId);
+  if (part === undefined) {
+    throw new DeliveryNotFoundError("The delivery part does not exist.");
+  }
+  return part;
+}
+
+function sameLease(left: WorkLeaseV1, right: WorkLeaseV1): boolean {
+  return (
+    left.fencing_token === right.fencing_token &&
+    left.generation === right.generation &&
+    left.heartbeat_at === right.heartbeat_at &&
+    left.lease_expires_at === right.lease_expires_at &&
+    left.lease_token === right.lease_token &&
+    left.owner_id === right.owner_id &&
+    left.run_id === right.run_id &&
+    left.schema_version === right.schema_version
+  );
+}
+
+function copy<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/apps/slack-companion/src/execution/coordinator.ts
+++ b/apps/slack-companion/src/execution/coordinator.ts
@@ -1,0 +1,193 @@
+import type {
+  CheckpointDraft,
+  CheckpointV1,
+  EffectDraft,
+  EffectReceiptV1,
+  EffectResolution,
+  ExecutionSession,
+  ExecutionStartResult,
+  LeaseClaim,
+  RecoveredRun,
+  RunReceiptV1,
+  ServiceAvailabilityState,
+  WorkLeaseV1,
+} from "./model.js";
+import { mayAcquireNewLease } from "./model.js";
+import type {
+  DurableExecutionPort,
+  ExecutionClockPort,
+} from "./ports.js";
+
+export interface ExecutionCoordinatorOptions {
+  clock: ExecutionClockPort;
+  lease_duration_ms: number;
+  store: DurableExecutionPort;
+}
+
+export interface StartExecutionInput extends LeaseClaim {
+  service_state: ServiceAvailabilityState;
+}
+
+export class ExecutionCoordinator {
+  private readonly clock: ExecutionClockPort;
+  private readonly leaseDurationMs: number;
+  private readonly store: DurableExecutionPort;
+
+  constructor(options: ExecutionCoordinatorOptions) {
+    if (!Number.isSafeInteger(options.lease_duration_ms) || options.lease_duration_ms <= 0) {
+      throw new Error("lease_duration_ms must be a positive integer");
+    }
+    this.clock = options.clock;
+    this.leaseDurationMs = options.lease_duration_ms;
+    this.store = options.store;
+  }
+
+  async start(input: StartExecutionInput): Promise<ExecutionStartResult> {
+    if (!mayAcquireNewLease(input.service_state)) {
+      return { status: "not_runnable" };
+    }
+
+    const now = this.clock.now();
+    const acquired = await this.store.acquireLease(
+      input,
+      now.toISOString(),
+      this.expiresAt(now),
+    );
+    if (acquired === undefined) {
+      return { status: "not_runnable" };
+    }
+
+    const run =
+      acquired.run.state === "leased"
+        ? await this.store.markRunning(acquired.lease, now.toISOString())
+        : acquired.run;
+    const checkpoint = await this.store.latestCheckpoint(input.run_id);
+
+    return {
+      session: { checkpoint, lease: acquired.lease, run },
+      status: checkpoint === undefined ? "started" : "resumed",
+    };
+  }
+
+  renew(lease: WorkLeaseV1): Promise<WorkLeaseV1> {
+    const now = this.clock.now();
+    return this.store.renewLease(lease, now.toISOString(), this.expiresAt(now));
+  }
+
+  release(session: ExecutionSession): Promise<RunReceiptV1> {
+    return this.store.releaseLease(
+      session.lease,
+      this.clock.now().toISOString(),
+    );
+  }
+
+  checkpoint(
+    session: ExecutionSession,
+    draft: CheckpointDraft,
+  ): Promise<CheckpointV1> {
+    return this.store.appendCheckpoint(
+      session.lease,
+      draft,
+      this.clock.now().toISOString(),
+    );
+  }
+
+  pauseForDrain(
+    session: ExecutionSession,
+    draft: CheckpointDraft,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }> {
+    return this.store.pauseWithCheckpoint(
+      session.lease,
+      draft,
+      this.clock.now().toISOString(),
+    );
+  }
+
+  finishExecution(session: ExecutionSession): Promise<RunReceiptV1> {
+    return this.store.finishExecution(
+      session.lease,
+      this.clock.now().toISOString(),
+    );
+  }
+
+  beginEffect(
+    session: ExecutionSession,
+    draft: EffectDraft,
+  ): Promise<EffectReceiptV1> {
+    if (draft.approval_required && draft.approval_ref === undefined) {
+      return Promise.reject(
+        new ExecutionInvariantError("required effect approval is missing"),
+      );
+    }
+    return this.store.beginEffect(
+      session.lease,
+      draft,
+      this.clock.now().toISOString(),
+    );
+  }
+
+  markEffectExecuting(
+    session: ExecutionSession,
+    idempotencyKey: string,
+  ): Promise<EffectReceiptV1> {
+    return this.store.markEffectExecuting(
+      session.lease,
+      idempotencyKey,
+      this.clock.now().toISOString(),
+    );
+  }
+
+  resolveEffect(
+    session: ExecutionSession,
+    idempotencyKey: string,
+    resolution: EffectResolution,
+  ): Promise<EffectReceiptV1> {
+    if (
+      resolution.state === "succeeded" &&
+      resolution.verification_state !== "verified"
+    ) {
+      return Promise.reject(
+        new ExecutionInvariantError(
+          "a successful effect requires successful independent verification",
+        ),
+      );
+    }
+    if (resolution.verification_receipt_ref === resolution.result_ref) {
+      return Promise.reject(
+        new ExecutionInvariantError(
+          "effect result and verification must use different receipts",
+        ),
+      );
+    }
+    return this.store.resolveEffect(
+      session.lease,
+      idempotencyKey,
+      resolution,
+      this.clock.now().toISOString(),
+    );
+  }
+
+  async reconcileExpired(): Promise<RecoveredRun[]> {
+    const now = this.clock.now().toISOString();
+    const expired = await this.store.listExpiredLeases(now);
+    const recovered: RecoveredRun[] = [];
+    for (const lease of expired) {
+      const result = await this.store.recoverExpiredLease(lease, now);
+      if (result.recovered) {
+        recovered.push(result);
+      }
+    }
+    return recovered;
+  }
+
+  private expiresAt(now: Date): string {
+    return new Date(now.getTime() + this.leaseDurationMs).toISOString();
+  }
+}
+
+export class ExecutionInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExecutionInvariantError";
+  }
+}

--- a/apps/slack-companion/src/execution/coordinator.ts
+++ b/apps/slack-companion/src/execution/coordinator.ts
@@ -103,6 +103,24 @@ export class ExecutionCoordinator {
     );
   }
 
+  waitForDependency(
+    session: ExecutionSession,
+    draft: CheckpointDraft,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }> {
+    if (draft.waiting_on_ref === undefined) {
+      return Promise.reject(
+        new ExecutionInvariantError(
+          "a waiting checkpoint requires waiting_on_ref",
+        ),
+      );
+    }
+    return this.store.waitWithCheckpoint(
+      session.lease,
+      draft,
+      this.clock.now().toISOString(),
+    );
+  }
+
   finishExecution(session: ExecutionSession): Promise<RunReceiptV1> {
     return this.store.finishExecution(
       session.lease,

--- a/apps/slack-companion/src/execution/effect-intent.ts
+++ b/apps/slack-companion/src/execution/effect-intent.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { ExecutionInvariantError } from "./coordinator.js";
+import type {
+  EffectIntentValue,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
+} from "./model.js";
+
+export function normalizeEffectIntentValue(value: unknown): EffectIntentValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new ExecutionInvariantError("effect intent numbers must be finite");
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeEffectIntentValue(item));
+  }
+  if (typeof value !== "object") {
+    throw new ExecutionInvariantError("effect intent must contain JSON values only");
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new ExecutionInvariantError("effect intent objects must be plain records");
+  }
+
+  const normalized: Record<string, EffectIntentValue> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    if (key.trim() === "") {
+      throw new ExecutionInvariantError("effect intent keys must not be empty");
+    }
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      throw new ExecutionInvariantError("effect intent contains an unsafe key");
+    }
+    normalized[key] = normalizeEffectIntentValue(
+      (value as Record<string, unknown>)[key],
+    );
+  }
+  return normalized;
+}
+
+export type ExternalEffectIntentDigestInput = Omit<
+  ExternalEffectIntentDraft,
+  "request_digest"
+>;
+
+export function effectIntentDigest(
+  input: ExternalEffectIntentDigestInput,
+): string {
+  const digestInput: EffectIntentValue = {
+    approval_ref: input.approval_ref ?? null,
+    approval_required: input.approval_required,
+    candidate_version: input.candidate_version,
+    effect_id: input.effect_id,
+    idempotency_key: input.idempotency_key,
+    request: input.request,
+    rollback_plan_ref: input.rollback_plan_ref ?? null,
+    step_id: input.step_id,
+    target_ref: input.target_ref,
+  };
+  return `sha256:${createHash("sha256").update(JSON.stringify(digestInput)).digest("hex")}`;
+}
+
+export function sameExternalEffectIntent(
+  intent: ExternalEffectIntentV1,
+  draft: ExternalEffectIntentDraft,
+): boolean {
+  return (
+    intent.approval_ref === draft.approval_ref &&
+    intent.approval_required === draft.approval_required &&
+    intent.candidate_version === draft.candidate_version &&
+    intent.effect_id === draft.effect_id &&
+    intent.idempotency_key === draft.idempotency_key &&
+    intent.request_digest === draft.request_digest &&
+    intent.rollback_plan_ref === draft.rollback_plan_ref &&
+    intent.step_id === draft.step_id &&
+    intent.target_ref === draft.target_ref &&
+    JSON.stringify(intent.request) === JSON.stringify(draft.request)
+  );
+}

--- a/apps/slack-companion/src/execution/effect-reconciliation.ts
+++ b/apps/slack-companion/src/execution/effect-reconciliation.ts
@@ -1,0 +1,330 @@
+import type { ExecutionCoordinator } from "./coordinator.js";
+import { ExecutionInvariantError } from "./coordinator.js";
+import {
+  effectIntentDigest,
+  normalizeEffectIntentValue,
+} from "./effect-intent.js";
+import type {
+  EffectReceiptV1,
+  ExecutionSession,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
+  WorkLeaseV1,
+} from "./model.js";
+import type {
+  DurableExecutionPort,
+  ExecutionClockPort,
+} from "./ports.js";
+
+export interface ExternalEffectJob {
+  candidate_version: string;
+  fencing_token: number;
+  generation: number;
+  idempotency_key: string;
+  lease_token: string;
+  run_id: string;
+}
+
+export interface ExternalEffectDraft {
+  approval_ref?: string;
+  approval_required: boolean;
+  candidate_version: string;
+  effect_id: string;
+  idempotency_key: string;
+  request: unknown;
+  rollback_plan_ref?: string;
+  step_id: string;
+  target_ref: string;
+}
+
+export interface ExternalEffectResult {
+  candidate_version: string;
+  result_digest: string;
+  result_ref: string;
+}
+
+export interface ExternalEffectVerification {
+  candidate_version: string;
+  receipt_ref: string;
+  state: "failed" | "verified";
+}
+
+export type RecoverableExternalEffectInspection =
+  | {
+      candidate_version: string;
+      resume_token: string;
+      state: "materialized" | "prepared";
+    };
+
+export type ExternalEffectInspection =
+  | { state: "absent" }
+  | RecoverableExternalEffectInspection
+  | { result: ExternalEffectResult; state: "applied" }
+  | {
+      reason_code: string;
+      state: "ambiguous" | "boundary_mismatch" | "target_moved";
+    };
+
+/** External I/O stays behind this port; credentials and placement are adapter-owned. */
+export interface ExternalEffectPort {
+  apply(
+    intent: ExternalEffectIntentV1,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult>;
+
+  inspect(
+    intent: ExternalEffectIntentV1,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectInspection>;
+
+  resume(
+    intent: ExternalEffectIntentV1,
+    inspection: RecoverableExternalEffectInspection,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult>;
+
+  verify(
+    intent: ExternalEffectIntentV1,
+    result: ExternalEffectResult,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectVerification>;
+}
+
+export type StaleExternalEffectJobReason =
+  | "candidate_version_mismatch"
+  | "fencing_token_mismatch"
+  | "generation_mismatch"
+  | "idempotency_key_mismatch"
+  | "lease_token_mismatch"
+  | "run_mismatch";
+
+export type ExternalEffectExecutionResult =
+  | {
+      effect: EffectReceiptV1;
+      intent: ExternalEffectIntentV1;
+      status: "applied" | "duplicate" | "recovered";
+    }
+  | { reason: StaleExternalEffectJobReason; status: "stale" };
+
+export interface ExternalEffectReconcilerOptions {
+  clock: ExecutionClockPort;
+  execution: ExecutionCoordinator;
+  external: ExternalEffectPort;
+  store: Pick<
+    DurableExecutionPort,
+    "getEffectIntent" | "persistEffectIntent"
+  >;
+}
+
+export class ExternalEffectReconciler {
+  private readonly clock: ExecutionClockPort;
+  private readonly execution: ExecutionCoordinator;
+  private readonly external: ExternalEffectPort;
+  private readonly store: ExternalEffectReconcilerOptions["store"];
+
+  constructor(options: ExternalEffectReconcilerOptions) {
+    this.clock = options.clock;
+    this.execution = options.execution;
+    this.external = options.external;
+    this.store = options.store;
+  }
+
+  async execute(
+    session: ExecutionSession,
+    job: ExternalEffectJob,
+    draft: ExternalEffectDraft,
+  ): Promise<ExternalEffectExecutionResult> {
+    validateDraft(draft);
+    const staleReason = staleJobReason(session, job, draft);
+    if (staleReason !== undefined) {
+      return { reason: staleReason, status: "stale" };
+    }
+
+    const currentIntent = await this.store.getEffectIntent(
+      session.run.run_id,
+      draft.idempotency_key,
+    );
+    if (
+      currentIntent !== undefined &&
+      currentIntent.candidate_version !== draft.candidate_version
+    ) {
+      return { reason: "candidate_version_mismatch", status: "stale" };
+    }
+
+    const request = normalizeEffectIntentValue(draft.request);
+    const intentFields = {
+      approval_ref: draft.approval_ref,
+      approval_required: draft.approval_required,
+      candidate_version: draft.candidate_version,
+      effect_id: draft.effect_id,
+      idempotency_key: draft.idempotency_key,
+      request,
+      rollback_plan_ref: draft.rollback_plan_ref,
+      step_id: draft.step_id,
+      target_ref: draft.target_ref,
+    };
+    const intentDraft: ExternalEffectIntentDraft = {
+      ...intentFields,
+      request_digest: effectIntentDigest(intentFields),
+    };
+    const committed = await this.store.persistEffectIntent(
+      session.lease,
+      intentDraft,
+      this.clock.now().toISOString(),
+    );
+    const effect = await this.execution.beginEffect(session, {
+      approval_ref: committed.intent.approval_ref,
+      approval_required: committed.intent.approval_required,
+      effect_id: committed.intent.effect_id,
+      idempotency_key: committed.intent.idempotency_key,
+      request_digest: committed.intent.request_digest,
+      rollback_plan_ref: committed.intent.rollback_plan_ref,
+      step_id: committed.intent.step_id,
+      target_ref: committed.intent.target_ref,
+    });
+
+    if (effect.state === "failed" || effect.state === "succeeded") {
+      return { effect, intent: committed.intent, status: "duplicate" };
+    }
+    if (effect.state === "planned") {
+      await this.execution.markEffectExecuting(
+        session,
+        committed.intent.idempotency_key,
+      );
+      const result = await this.external.apply(committed.intent, session.lease);
+      return this.resolve(
+        session,
+        committed.intent,
+        result,
+        "applied",
+      );
+    }
+    if (effect.state !== "executing" && effect.state !== "unknown") {
+      throw new ExecutionInvariantError(
+        `effect state ${effect.state} cannot be reconciled`,
+      );
+    }
+
+    const inspection = await this.external.inspect(
+      committed.intent,
+      session.lease,
+    );
+    const result = await this.recoverResult(
+      committed.intent,
+      inspection,
+      session.lease,
+    );
+    return this.resolve(
+      session,
+      committed.intent,
+      result,
+      "recovered",
+    );
+  }
+
+  private recoverResult(
+    intent: ExternalEffectIntentV1,
+    inspection: ExternalEffectInspection,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult> {
+    switch (inspection.state) {
+      case "absent":
+        return this.external.apply(intent, lease);
+      case "applied":
+        return Promise.resolve(inspection.result);
+      case "materialized":
+      case "prepared":
+        assertCandidateVersion(intent, inspection.candidate_version);
+        return this.external.resume(intent, inspection, lease);
+      case "ambiguous":
+      case "boundary_mismatch":
+      case "target_moved":
+        throw new EffectReconciliationBlockedError(inspection.state);
+    }
+  }
+
+  private async resolve(
+    session: ExecutionSession,
+    intent: ExternalEffectIntentV1,
+    result: ExternalEffectResult,
+    status: "applied" | "recovered",
+  ): Promise<ExternalEffectExecutionResult> {
+    assertCandidateVersion(intent, result.candidate_version);
+    const verification = await this.external.verify(
+      intent,
+      result,
+      session.lease,
+    );
+    assertCandidateVersion(intent, verification.candidate_version);
+    const effect = await this.execution.resolveEffect(
+      session,
+      intent.idempotency_key,
+      {
+        result_digest: result.result_digest,
+        result_ref: result.result_ref,
+        state: verification.state === "verified" ? "succeeded" : "failed",
+        verification_receipt_ref: verification.receipt_ref,
+        verification_state: verification.state,
+      },
+    );
+    return { effect, intent, status };
+  }
+}
+
+export class EffectReconciliationBlockedError extends Error {
+  constructor(
+    readonly code:
+      | "ambiguous"
+      | "boundary_mismatch"
+      | "candidate_version_mismatch"
+      | "target_moved",
+  ) {
+    super(`external effect reconciliation blocked: ${code}`);
+    this.name = "EffectReconciliationBlockedError";
+  }
+}
+
+function staleJobReason(
+  session: ExecutionSession,
+  job: ExternalEffectJob,
+  draft: ExternalEffectDraft,
+): StaleExternalEffectJobReason | undefined {
+  if (job.run_id !== session.run.run_id) return "run_mismatch";
+  if (job.generation !== session.lease.generation) return "generation_mismatch";
+  if (job.fencing_token !== session.lease.fencing_token) {
+    return "fencing_token_mismatch";
+  }
+  if (job.lease_token !== session.lease.lease_token) {
+    return "lease_token_mismatch";
+  }
+  if (job.idempotency_key !== draft.idempotency_key) {
+    return "idempotency_key_mismatch";
+  }
+  if (job.candidate_version !== draft.candidate_version) {
+    return "candidate_version_mismatch";
+  }
+  return undefined;
+}
+
+function assertCandidateVersion(
+  intent: ExternalEffectIntentV1,
+  candidateVersion: string,
+): void {
+  if (intent.candidate_version !== candidateVersion) {
+    throw new EffectReconciliationBlockedError("candidate_version_mismatch");
+  }
+}
+
+function validateDraft(draft: ExternalEffectDraft): void {
+  for (const [field, value] of [
+    ["candidate_version", draft.candidate_version],
+    ["effect_id", draft.effect_id],
+    ["idempotency_key", draft.idempotency_key],
+    ["step_id", draft.step_id],
+    ["target_ref", draft.target_ref],
+  ] as const) {
+    if (value.trim() === "") {
+      throw new ExecutionInvariantError(`${field} must not be empty`);
+    }
+  }
+}

--- a/apps/slack-companion/src/execution/model.ts
+++ b/apps/slack-companion/src/execution/model.ts
@@ -1,0 +1,78 @@
+import type {
+  CheckpointV1,
+  EffectReceiptV1,
+  RunReceiptV1,
+  ServiceAvailabilityState,
+  WorkLeaseV1,
+} from "@writer/cerebro-sdk";
+
+export type {
+  CheckpointV1,
+  EffectReceiptV1,
+  RunReceiptV1,
+  ServiceAvailabilityState,
+  WorkLeaseV1,
+};
+
+export interface LeaseClaim {
+  generation: number;
+  lease_token: string;
+  owner_id: string;
+  run_id: string;
+}
+
+export interface ExecutionSession {
+  checkpoint?: CheckpointV1;
+  lease: WorkLeaseV1;
+  run: RunReceiptV1;
+}
+
+export interface CheckpointDraft {
+  checkpoint_id: string;
+  completed_step_ids: string[];
+  effect_receipt_ids: string[];
+  payload_digest: string;
+  payload_ref: string;
+  resume_cursor: string;
+  sequence: number;
+  waiting_on_ref?: string;
+}
+
+export interface EffectDraft {
+  approval_ref?: string;
+  approval_required: boolean;
+  effect_id: string;
+  idempotency_key: string;
+  request_digest: string;
+  rollback_plan_ref?: string;
+  step_id: string;
+  target_ref: string;
+}
+
+export interface EffectResolution {
+  result_digest: string;
+  result_ref: string;
+  state: "succeeded" | "failed";
+  verification_receipt_ref: string;
+  verification_state: "verified" | "failed";
+}
+
+export interface LeaseAcquisition {
+  created: boolean;
+  lease: WorkLeaseV1;
+  run: RunReceiptV1;
+}
+
+export interface RecoveredRun {
+  recovered: boolean;
+  run?: RunReceiptV1;
+  uncertain_effect_ids: string[];
+}
+
+export type ExecutionStartResult =
+  | { session: ExecutionSession; status: "started" | "resumed" }
+  | { status: "not_runnable" };
+
+export const mayAcquireNewLease = (
+  state: ServiceAvailabilityState,
+): boolean => state === "ready" || state === "degraded";

--- a/apps/slack-companion/src/execution/model.ts
+++ b/apps/slack-companion/src/execution/model.ts
@@ -57,6 +57,41 @@ export interface EffectResolution {
   verification_state: "verified" | "failed";
 }
 
+export type EffectIntentValue =
+  | boolean
+  | null
+  | number
+  | string
+  | EffectIntentValue[]
+  | { [key: string]: EffectIntentValue };
+
+export interface ExternalEffectIntentDraft {
+  approval_ref?: string;
+  approval_required: boolean;
+  candidate_version: string;
+  effect_id: string;
+  idempotency_key: string;
+  request: EffectIntentValue;
+  request_digest: string;
+  rollback_plan_ref?: string;
+  step_id: string;
+  target_ref: string;
+}
+
+export interface ExternalEffectIntentV1 extends ExternalEffectIntentDraft {
+  fencing_token: number;
+  generation: number;
+  lease_token: string;
+  persisted_at: string;
+  run_id: string;
+  schema_version: "external-effect-intent/v1";
+}
+
+export interface ExternalEffectIntentCommit {
+  created: boolean;
+  intent: ExternalEffectIntentV1;
+}
+
 export interface LeaseAcquisition {
   created: boolean;
   lease: WorkLeaseV1;

--- a/apps/slack-companion/src/execution/ports.ts
+++ b/apps/slack-companion/src/execution/ports.ts
@@ -1,0 +1,104 @@
+import type {
+  CheckpointDraft,
+  CheckpointV1,
+  EffectDraft,
+  EffectReceiptV1,
+  EffectResolution,
+  LeaseAcquisition,
+  LeaseClaim,
+  RecoveredRun,
+  RunReceiptV1,
+  WorkLeaseV1,
+} from "./model.js";
+
+export interface ExecutionClockPort {
+  now(): Date;
+}
+
+/**
+ * Durable execution operations. Production adapters must make each method's
+ * documented state change atomic and reject an outdated lease proof.
+ */
+export interface DurableExecutionPort {
+  /** Atomically advances the run to leased and installs one fenced lease. */
+  acquireLease(
+    claim: LeaseClaim,
+    heartbeatAt: string,
+    leaseExpiresAt: string,
+  ): Promise<LeaseAcquisition | undefined>;
+
+  /** Returns the lease only when every ownership and fencing field is current. */
+  renewLease(
+    lease: WorkLeaseV1,
+    heartbeatAt: string,
+    leaseExpiresAt: string,
+  ): Promise<WorkLeaseV1>;
+
+  /** Atomically releases ownership and returns a non-terminal run to queued. */
+  releaseLease(
+    lease: WorkLeaseV1,
+    releasedAt: string,
+  ): Promise<RunReceiptV1>;
+
+  /** Atomically advances a leased run to running under the same lease proof. */
+  markRunning(lease: WorkLeaseV1, updatedAt: string): Promise<RunReceiptV1>;
+
+  latestCheckpoint(runId: string): Promise<CheckpointV1 | undefined>;
+
+  appendCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): Promise<CheckpointV1>;
+
+  /** Atomically appends the checkpoint, pauses the run, and releases the lease. */
+  pauseWithCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }>;
+
+  /**
+   * Atomically finishes execution, advances the run to durable delivery, and
+   * releases its lease. Delivery reconciliation alone may complete the run.
+   */
+  finishExecution(
+    lease: WorkLeaseV1,
+    finishedAt: string,
+  ): Promise<RunReceiptV1>;
+
+  beginEffect(
+    lease: WorkLeaseV1,
+    draft: EffectDraft,
+    recordedAt: string,
+  ): Promise<EffectReceiptV1>;
+
+  markEffectExecuting(
+    lease: WorkLeaseV1,
+    idempotencyKey: string,
+    recordedAt: string,
+  ): Promise<EffectReceiptV1>;
+
+  resolveEffect(
+    lease: WorkLeaseV1,
+    idempotencyKey: string,
+    resolution: EffectResolution,
+    recordedAt: string,
+  ): Promise<EffectReceiptV1>;
+
+  getEffect(
+    runId: string,
+    idempotencyKey: string,
+  ): Promise<EffectReceiptV1 | undefined>;
+
+  listExpiredLeases(observedAt: string): Promise<WorkLeaseV1[]>;
+
+  /**
+   * Atomically removes the expired lease, returns the run to queued, and marks
+   * effects left executing by that lease as unknown.
+   */
+  recoverExpiredLease(
+    lease: WorkLeaseV1,
+    recoveredAt: string,
+  ): Promise<RecoveredRun>;
+}

--- a/apps/slack-companion/src/execution/ports.ts
+++ b/apps/slack-companion/src/execution/ports.ts
@@ -4,6 +4,9 @@ import type {
   EffectDraft,
   EffectReceiptV1,
   EffectResolution,
+  ExternalEffectIntentCommit,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
   LeaseAcquisition,
   LeaseClaim,
   RecoveredRun,
@@ -60,12 +63,29 @@ export interface DurableExecutionPort {
 
   /**
    * Atomically finishes execution, advances the run to durable delivery, and
-   * releases its lease. Delivery reconciliation alone may complete the run.
+   * releases its lease. An external intent without a succeeded, independently
+   * verified effect must block this transition. Delivery reconciliation alone
+   * may complete the run.
    */
   finishExecution(
     lease: WorkLeaseV1,
     finishedAt: string,
   ): Promise<RunReceiptV1>;
+
+  /**
+   * Persists the exact external write intent under the active lease. Repeating
+   * the same logical intent is idempotent; changing it is a conflict.
+   */
+  persistEffectIntent(
+    lease: WorkLeaseV1,
+    draft: ExternalEffectIntentDraft,
+    persistedAt: string,
+  ): Promise<ExternalEffectIntentCommit>;
+
+  getEffectIntent(
+    runId: string,
+    idempotencyKey: string,
+  ): Promise<ExternalEffectIntentV1 | undefined>;
 
   beginEffect(
     lease: WorkLeaseV1,

--- a/apps/slack-companion/src/execution/ports.ts
+++ b/apps/slack-companion/src/execution/ports.ts
@@ -61,6 +61,13 @@ export interface DurableExecutionPort {
     createdAt: string,
   ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }>;
 
+  /** Atomically appends a checkpoint, waits the run, and releases its lease. */
+  waitWithCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }>;
+
   /**
    * Atomically finishes execution, advances the run to durable delivery, and
    * releases its lease. An external intent without a succeeded, independently

--- a/apps/slack-companion/src/execution/reference-store.ts
+++ b/apps/slack-companion/src/execution/reference-store.ts
@@ -1,3 +1,9 @@
+import { IdempotencyConflictError } from "../admission.js";
+import type {
+  AdmissionCommit,
+  AdmissionCommitResult,
+} from "../contracts.js";
+import type { DurableAdmissionPort } from "../ports.js";
 import { ExecutionInvariantError } from "./coordinator.js";
 import {
   effectIntentDigest,
@@ -22,17 +28,55 @@ import type {
 import type { DurableExecutionPort } from "./ports.js";
 
 /** Conformance fixture only. Production adapters must use durable storage. */
-export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
+export class ReferenceMemoryExecutionStore
+  implements DurableAdmissionPort, DurableExecutionPort
+{
   private readonly checkpoints = new Map<string, CheckpointV1[]>();
   private readonly effects = new Map<string, EffectReceiptV1>();
   private readonly effectIntents = new Map<string, ExternalEffectIntentV1>();
   private readonly fencingTokens = new Map<string, number>();
   private readonly highestGenerations = new Map<string, number>();
+  private readonly runIdByIdempotencyKey = new Map<string, string>();
   private readonly leases = new Map<string, WorkLeaseV1>();
   private readonly runs = new Map<string, RunReceiptV1>();
 
   seedRun(run: RunReceiptV1): void {
     this.runs.set(run.run_id, structuredClone(run));
+    this.runIdByIdempotencyKey.set(run.idempotency_key, run.run_id);
+  }
+
+  admitAndEnqueue(
+    commit: AdmissionCommit,
+  ): Promise<AdmissionCommitResult> {
+    const priorRunId = this.runIdByIdempotencyKey.get(
+      commit.receipt.idempotency_key,
+    );
+    if (priorRunId !== undefined) {
+      const prior = this.requireRun(priorRunId);
+      if (prior.input_digest !== commit.receipt.input_digest) {
+        return Promise.reject(new IdempotencyConflictError());
+      }
+      return Promise.resolve({
+        created: false,
+        receipt: structuredClone(prior),
+      });
+    }
+    if (commit.receipt.state !== "queued") {
+      return Promise.reject(
+        new ExecutionInvariantError("admission must commit a queued run"),
+      );
+    }
+    if (this.runs.has(commit.receipt.run_id)) {
+      return Promise.reject(
+        new ExecutionInvariantError("run id already belongs to another input"),
+      );
+    }
+
+    // These mutations model one transaction shared by admission and execution.
+    const receipt = structuredClone(commit.receipt);
+    this.runs.set(receipt.run_id, receipt);
+    this.runIdByIdempotencyKey.set(receipt.idempotency_key, receipt.run_id);
+    return Promise.resolve({ created: true, receipt: structuredClone(receipt) });
   }
 
   acquireLease(
@@ -61,7 +105,11 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
       }
       return Promise.resolve(undefined);
     }
-    if (run.state !== "queued" && run.state !== "paused") {
+    if (
+      run.state !== "queued" &&
+      run.state !== "paused" &&
+      run.state !== "waiting"
+    ) {
       return Promise.resolve(undefined);
     }
 
@@ -163,6 +211,34 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
     return Promise.resolve({
       checkpoint: structuredClone(stored),
       run: structuredClone(paused),
+    });
+  }
+
+  waitWithCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }> {
+    this.assertLease(lease, createdAt);
+    if (draft.waiting_on_ref === undefined) {
+      throw new ExecutionInvariantError(
+        "a waiting checkpoint requires waiting_on_ref",
+      );
+    }
+    const checkpoint = this.buildCheckpoint(lease, draft, createdAt);
+    const waiting = updateRun(
+      this.requireRun(lease.run_id),
+      "waiting",
+      createdAt,
+    );
+
+    // This block models one transaction: checkpoint first, then waiting truth.
+    const stored = this.storeCheckpoint(checkpoint);
+    this.runs.set(lease.run_id, waiting);
+    this.leases.delete(lease.run_id);
+    return Promise.resolve({
+      checkpoint: structuredClone(stored),
+      run: structuredClone(waiting),
     });
   }
 
@@ -417,6 +493,10 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
   readRun(runId: string): RunReceiptV1 | undefined {
     const run = this.runs.get(runId);
     return run === undefined ? undefined : structuredClone(run);
+  }
+
+  runCount(): number {
+    return this.runs.size;
   }
 
   private assertLease(lease: WorkLeaseV1, observedAt: string): void {

--- a/apps/slack-companion/src/execution/reference-store.ts
+++ b/apps/slack-companion/src/execution/reference-store.ts
@@ -1,0 +1,525 @@
+import { ExecutionInvariantError } from "./coordinator.js";
+import type {
+  CheckpointDraft,
+  CheckpointV1,
+  EffectDraft,
+  EffectReceiptV1,
+  EffectResolution,
+  LeaseAcquisition,
+  LeaseClaim,
+  RecoveredRun,
+  RunReceiptV1,
+  WorkLeaseV1,
+} from "./model.js";
+import type { DurableExecutionPort } from "./ports.js";
+
+/** Conformance fixture only. Production adapters must use durable storage. */
+export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
+  private readonly checkpoints = new Map<string, CheckpointV1[]>();
+  private readonly effects = new Map<string, EffectReceiptV1>();
+  private readonly fencingTokens = new Map<string, number>();
+  private readonly highestGenerations = new Map<string, number>();
+  private readonly leases = new Map<string, WorkLeaseV1>();
+  private readonly runs = new Map<string, RunReceiptV1>();
+
+  seedRun(run: RunReceiptV1): void {
+    this.runs.set(run.run_id, structuredClone(run));
+  }
+
+  acquireLease(
+    claim: LeaseClaim,
+    heartbeatAt: string,
+    leaseExpiresAt: string,
+  ): Promise<LeaseAcquisition | undefined> {
+    validateLeaseClaim(claim);
+    const run = this.runs.get(claim.run_id);
+    if (run === undefined) {
+      throw new ExecutionInvariantError("run does not exist");
+    }
+    const highestGeneration = this.highestGenerations.get(claim.run_id) ?? 0;
+    if (claim.generation < highestGeneration) {
+      throw new ExecutionInvariantError("lease generation regressed");
+    }
+
+    const current = this.leases.get(claim.run_id);
+    if (current !== undefined) {
+      if (sameLeaseClaim(current, claim)) {
+        return Promise.resolve({
+          created: false,
+          lease: structuredClone(current),
+          run: structuredClone(run),
+        });
+      }
+      return Promise.resolve(undefined);
+    }
+    if (run.state !== "queued" && run.state !== "paused") {
+      return Promise.resolve(undefined);
+    }
+
+    const fencingToken = (this.fencingTokens.get(claim.run_id) ?? 0) + 1;
+    this.fencingTokens.set(claim.run_id, fencingToken);
+    this.highestGenerations.set(claim.run_id, claim.generation);
+    const lease: WorkLeaseV1 = {
+      fencing_token: fencingToken,
+      generation: claim.generation,
+      heartbeat_at: heartbeatAt,
+      lease_expires_at: leaseExpiresAt,
+      lease_token: claim.lease_token,
+      owner_id: claim.owner_id,
+      run_id: claim.run_id,
+      schema_version: "work-lease/v1",
+    };
+    const leasedRun = updateRun(run, "leased", heartbeatAt);
+    this.leases.set(claim.run_id, lease);
+    this.runs.set(claim.run_id, leasedRun);
+    return Promise.resolve({
+      created: true,
+      lease: structuredClone(lease),
+      run: structuredClone(leasedRun),
+    });
+  }
+
+  renewLease(
+    lease: WorkLeaseV1,
+    heartbeatAt: string,
+    leaseExpiresAt: string,
+  ): Promise<WorkLeaseV1> {
+    this.assertLease(lease, heartbeatAt);
+    const renewed = {
+      ...lease,
+      heartbeat_at: heartbeatAt,
+      lease_expires_at: leaseExpiresAt,
+    };
+    this.leases.set(lease.run_id, renewed);
+    return Promise.resolve(structuredClone(renewed));
+  }
+
+  releaseLease(
+    lease: WorkLeaseV1,
+    releasedAt: string,
+  ): Promise<RunReceiptV1> {
+    this.assertLease(lease, releasedAt);
+    const queued = updateRun(this.requireRun(lease.run_id), "queued", releasedAt);
+    this.runs.set(lease.run_id, queued);
+    this.leases.delete(lease.run_id);
+    return Promise.resolve(structuredClone(queued));
+  }
+
+  markRunning(lease: WorkLeaseV1, updatedAt: string): Promise<RunReceiptV1> {
+    this.assertLease(lease, updatedAt);
+    const run = this.requireRun(lease.run_id);
+    if (run.state === "running") {
+      return Promise.resolve(structuredClone(run));
+    }
+    if (run.state !== "leased") {
+      throw new ExecutionInvariantError("only a leased run can start");
+    }
+    const running = updateRun(run, "running", updatedAt);
+    this.runs.set(run.run_id, running);
+    return Promise.resolve(structuredClone(running));
+  }
+
+  latestCheckpoint(runId: string): Promise<CheckpointV1 | undefined> {
+    const records = this.checkpoints.get(runId) ?? [];
+    const checkpoint = records.at(-1);
+    return Promise.resolve(
+      checkpoint === undefined ? undefined : structuredClone(checkpoint),
+    );
+  }
+
+  appendCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): Promise<CheckpointV1> {
+    this.assertLease(lease, createdAt);
+    const checkpoint = this.buildCheckpoint(lease, draft, createdAt);
+    const stored = this.storeCheckpoint(checkpoint);
+    return Promise.resolve(structuredClone(stored));
+  }
+
+  pauseWithCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }> {
+    this.assertLease(lease, createdAt);
+    const checkpoint = this.buildCheckpoint(lease, draft, createdAt);
+    const paused = updateRun(this.requireRun(lease.run_id), "paused", createdAt);
+
+    // This block models one transaction: checkpoint first, then paused truth.
+    const stored = this.storeCheckpoint(checkpoint);
+    this.runs.set(lease.run_id, paused);
+    this.leases.delete(lease.run_id);
+    return Promise.resolve({
+      checkpoint: structuredClone(stored),
+      run: structuredClone(paused),
+    });
+  }
+
+  finishExecution(
+    lease: WorkLeaseV1,
+    finishedAt: string,
+  ): Promise<RunReceiptV1> {
+    this.assertLease(lease, finishedAt);
+    for (const effect of this.effects.values()) {
+      if (effect.run_id !== lease.run_id) {
+        continue;
+      }
+      if (effect.state !== "succeeded" || effect.verification_state !== "verified") {
+        throw new ExecutionInvariantError(
+          "run has an unresolved or unsuccessful effect",
+        );
+      }
+    }
+    const delivering = updateRun(
+      this.requireRun(lease.run_id),
+      "delivering",
+      finishedAt,
+    );
+    this.runs.set(lease.run_id, delivering);
+    this.leases.delete(lease.run_id);
+    return Promise.resolve(structuredClone(delivering));
+  }
+
+  beginEffect(
+    lease: WorkLeaseV1,
+    draft: EffectDraft,
+    recordedAt: string,
+  ): Promise<EffectReceiptV1> {
+    this.assertLease(lease, recordedAt);
+    const key = effectKey(lease.run_id, draft.idempotency_key);
+    const current = this.effects.get(key);
+    if (current !== undefined) {
+      if (!sameEffectIntent(current, draft)) {
+        throw new ExecutionInvariantError(
+          "effect idempotency key has different intent",
+        );
+      }
+      return Promise.resolve(structuredClone(current));
+    }
+    if (draft.approval_required && draft.approval_ref === undefined) {
+      throw new ExecutionInvariantError("required effect approval is missing");
+    }
+    const effect: EffectReceiptV1 = {
+      approval_ref: draft.approval_ref,
+      approval_required: draft.approval_required,
+      effect_id: draft.effect_id,
+      fencing_token: lease.fencing_token,
+      generation: lease.generation,
+      idempotency_key: draft.idempotency_key,
+      lease_token: lease.lease_token,
+      recorded_at: recordedAt,
+      request_digest: draft.request_digest,
+      rollback_plan_ref: draft.rollback_plan_ref,
+      run_id: lease.run_id,
+      schema_version: "effect-receipt/v1",
+      state: "planned",
+      step_id: draft.step_id,
+      target_ref: draft.target_ref,
+      verification_state: "pending",
+    };
+    this.effects.set(key, effect);
+    return Promise.resolve(structuredClone(effect));
+  }
+
+  markEffectExecuting(
+    lease: WorkLeaseV1,
+    idempotencyKey: string,
+    recordedAt: string,
+  ): Promise<EffectReceiptV1> {
+    this.assertLease(lease, recordedAt);
+    const key = effectKey(lease.run_id, idempotencyKey);
+    const current = this.requireEffect(key);
+    if (current.state === "executing") {
+      return Promise.resolve(structuredClone(current));
+    }
+    if (current.state !== "planned") {
+      throw new ExecutionInvariantError("effect cannot enter executing state");
+    }
+    this.assertEffectOwner(current, lease);
+    const executing = { ...current, recorded_at: recordedAt, state: "executing" as const };
+    this.effects.set(key, executing);
+    return Promise.resolve(structuredClone(executing));
+  }
+
+  resolveEffect(
+    lease: WorkLeaseV1,
+    idempotencyKey: string,
+    resolution: EffectResolution,
+    recordedAt: string,
+  ): Promise<EffectReceiptV1> {
+    this.assertLease(lease, recordedAt);
+    const key = effectKey(lease.run_id, idempotencyKey);
+    const current = this.requireEffect(key);
+    if (current.state === resolution.state) {
+      if (
+        current.result_digest !== resolution.result_digest ||
+        current.result_ref !== resolution.result_ref ||
+        current.verification_receipt_ref !== resolution.verification_receipt_ref ||
+        current.verification_state !== resolution.verification_state
+      ) {
+        throw new ExecutionInvariantError("effect result conflicts with prior result");
+      }
+      return Promise.resolve(structuredClone(current));
+    }
+    if (current.state !== "executing" && current.state !== "unknown") {
+      throw new ExecutionInvariantError("effect is not awaiting a result");
+    }
+    if (current.state === "executing") {
+      this.assertEffectOwner(current, lease);
+    }
+    const resolved: EffectReceiptV1 = {
+      ...current,
+      fencing_token: lease.fencing_token,
+      generation: lease.generation,
+      lease_token: lease.lease_token,
+      recorded_at: recordedAt,
+      result_digest: resolution.result_digest,
+      result_ref: resolution.result_ref,
+      state: resolution.state,
+      verification_receipt_ref: resolution.verification_receipt_ref,
+      verification_state: resolution.verification_state,
+    };
+    this.effects.set(key, resolved);
+    return Promise.resolve(structuredClone(resolved));
+  }
+
+  getEffect(
+    runId: string,
+    idempotencyKey: string,
+  ): Promise<EffectReceiptV1 | undefined> {
+    const effect = this.effects.get(effectKey(runId, idempotencyKey));
+    return Promise.resolve(
+      effect === undefined ? undefined : structuredClone(effect),
+    );
+  }
+
+  listExpiredLeases(observedAt: string): Promise<WorkLeaseV1[]> {
+    const observed = Date.parse(observedAt);
+    return Promise.resolve(
+      [...this.leases.values()]
+        .filter((lease) => Date.parse(lease.lease_expires_at) <= observed)
+        .map((lease) => structuredClone(lease)),
+    );
+  }
+
+  recoverExpiredLease(
+    lease: WorkLeaseV1,
+    recoveredAt: string,
+  ): Promise<RecoveredRun> {
+    const current = this.leases.get(lease.run_id);
+    if (current === undefined || !sameLease(current, lease)) {
+      return Promise.resolve({ recovered: false, uncertain_effect_ids: [] });
+    }
+    if (Date.parse(current.lease_expires_at) > Date.parse(recoveredAt)) {
+      return Promise.resolve({ recovered: false, uncertain_effect_ids: [] });
+    }
+
+    const uncertainEffectIds: string[] = [];
+    for (const [key, effect] of this.effects) {
+      if (
+        effect.run_id === lease.run_id &&
+        effect.state === "executing" &&
+        sameEffectLease(effect, lease)
+      ) {
+        this.effects.set(key, {
+          ...effect,
+          recorded_at: recoveredAt,
+          state: "unknown",
+        });
+        uncertainEffectIds.push(effect.effect_id);
+      }
+    }
+
+    const queued = updateRun(this.requireRun(lease.run_id), "queued", recoveredAt);
+    this.runs.set(lease.run_id, queued);
+    this.leases.delete(lease.run_id);
+    return Promise.resolve({
+      recovered: true,
+      run: structuredClone(queued),
+      uncertain_effect_ids: uncertainEffectIds,
+    });
+  }
+
+  readRun(runId: string): RunReceiptV1 | undefined {
+    const run = this.runs.get(runId);
+    return run === undefined ? undefined : structuredClone(run);
+  }
+
+  private assertLease(lease: WorkLeaseV1, observedAt: string): void {
+    const current = this.leases.get(lease.run_id);
+    if (current === undefined || !sameLease(current, lease)) {
+      throw new StaleLeaseError();
+    }
+    if (Date.parse(current.lease_expires_at) <= Date.parse(observedAt)) {
+      throw new StaleLeaseError();
+    }
+  }
+
+  private assertEffectOwner(
+    effect: EffectReceiptV1,
+    lease: WorkLeaseV1,
+  ): void {
+    if (!sameEffectLease(effect, lease)) {
+      throw new StaleLeaseError();
+    }
+  }
+
+  private buildCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): CheckpointV1 {
+    const run = this.requireRun(lease.run_id);
+    return {
+      checkpoint_id: draft.checkpoint_id,
+      completed_step_ids: [...draft.completed_step_ids],
+      effect_receipt_ids: [...draft.effect_receipt_ids],
+      generation: lease.generation,
+      payload_digest: draft.payload_digest,
+      payload_ref: draft.payload_ref,
+      resume_cursor: draft.resume_cursor,
+      run_id: lease.run_id,
+      run_revision: run.revision,
+      schema_version: "checkpoint/v1",
+      sequence: draft.sequence,
+      waiting_on_ref: draft.waiting_on_ref,
+      created_at: createdAt,
+    };
+  }
+
+  private storeCheckpoint(checkpoint: CheckpointV1): CheckpointV1 {
+    const records = this.checkpoints.get(checkpoint.run_id) ?? [];
+    const latest = records.at(-1);
+    if (latest !== undefined && checkpoint.sequence <= latest.sequence) {
+      if (
+        checkpoint.sequence === latest.sequence &&
+        sameCheckpointIntent(checkpoint, latest)
+      ) {
+        return latest;
+      }
+      throw new ExecutionInvariantError("checkpoint sequence is not monotonic");
+    }
+    records.push(checkpoint);
+    this.checkpoints.set(checkpoint.run_id, records);
+    return checkpoint;
+  }
+
+  private requireEffect(key: string): EffectReceiptV1 {
+    const effect = this.effects.get(key);
+    if (effect === undefined) {
+      throw new ExecutionInvariantError("effect does not exist");
+    }
+    return effect;
+  }
+
+  private requireRun(runId: string): RunReceiptV1 {
+    const run = this.runs.get(runId);
+    if (run === undefined) {
+      throw new ExecutionInvariantError("run does not exist");
+    }
+    return run;
+  }
+}
+
+export class StaleLeaseError extends Error {
+  constructor() {
+    super("lease ownership is stale or expired");
+    this.name = "StaleLeaseError";
+  }
+}
+
+function updateRun(
+  run: RunReceiptV1,
+  state: RunReceiptV1["state"],
+  updatedAt: string,
+): RunReceiptV1 {
+  return { ...run, revision: run.revision + 1, state, updated_at: updatedAt };
+}
+
+function validateLeaseClaim(claim: LeaseClaim): void {
+  if (!Number.isSafeInteger(claim.generation) || claim.generation <= 0) {
+    throw new ExecutionInvariantError("lease generation must be a positive integer");
+  }
+  if (claim.owner_id.trim() === "") {
+    throw new ExecutionInvariantError("lease owner_id must not be empty");
+  }
+  if (claim.lease_token.trim() === "") {
+    throw new ExecutionInvariantError("lease_token must not be empty");
+  }
+}
+
+function sameCheckpointIntent(
+  left: CheckpointV1,
+  right: CheckpointV1,
+): boolean {
+  return (
+    left.checkpoint_id === right.checkpoint_id &&
+    left.run_id === right.run_id &&
+    left.run_revision === right.run_revision &&
+    left.generation === right.generation &&
+    left.sequence === right.sequence &&
+    left.resume_cursor === right.resume_cursor &&
+    sameStringArray(left.completed_step_ids, right.completed_step_ids) &&
+    sameStringArray(left.effect_receipt_ids, right.effect_receipt_ids) &&
+    left.waiting_on_ref === right.waiting_on_ref &&
+    left.payload_ref === right.payload_ref &&
+    left.payload_digest === right.payload_digest
+  );
+}
+
+function sameStringArray(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function sameLeaseClaim(lease: WorkLeaseV1, claim: LeaseClaim): boolean {
+  return (
+    lease.run_id === claim.run_id &&
+    lease.owner_id === claim.owner_id &&
+    lease.generation === claim.generation &&
+    lease.lease_token === claim.lease_token
+  );
+}
+
+function sameLease(left: WorkLeaseV1, right: WorkLeaseV1): boolean {
+  return (
+    sameLeaseClaim(left, right) &&
+    left.fencing_token === right.fencing_token &&
+    left.lease_expires_at === right.lease_expires_at &&
+    left.heartbeat_at === right.heartbeat_at
+  );
+}
+
+function sameEffectLease(
+  effect: EffectReceiptV1,
+  lease: WorkLeaseV1,
+): boolean {
+  return (
+    effect.generation === lease.generation &&
+    effect.lease_token === lease.lease_token &&
+    effect.fencing_token === lease.fencing_token
+  );
+}
+
+function sameEffectIntent(
+  effect: EffectReceiptV1,
+  draft: EffectDraft,
+): boolean {
+  return (
+    effect.effect_id === draft.effect_id &&
+    effect.step_id === draft.step_id &&
+    effect.target_ref === draft.target_ref &&
+    effect.request_digest === draft.request_digest &&
+    effect.approval_required === draft.approval_required &&
+    effect.approval_ref === draft.approval_ref &&
+    effect.rollback_plan_ref === draft.rollback_plan_ref
+  );
+}
+
+function effectKey(runId: string, idempotencyKey: string): string {
+  return `${runId}\u0000${idempotencyKey}`;
+}

--- a/apps/slack-companion/src/execution/reference-store.ts
+++ b/apps/slack-companion/src/execution/reference-store.ts
@@ -1,10 +1,18 @@
 import { ExecutionInvariantError } from "./coordinator.js";
+import {
+  effectIntentDigest,
+  normalizeEffectIntentValue,
+  sameExternalEffectIntent,
+} from "./effect-intent.js";
 import type {
   CheckpointDraft,
   CheckpointV1,
   EffectDraft,
   EffectReceiptV1,
   EffectResolution,
+  ExternalEffectIntentCommit,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
   LeaseAcquisition,
   LeaseClaim,
   RecoveredRun,
@@ -17,6 +25,7 @@ import type { DurableExecutionPort } from "./ports.js";
 export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
   private readonly checkpoints = new Map<string, CheckpointV1[]>();
   private readonly effects = new Map<string, EffectReceiptV1>();
+  private readonly effectIntents = new Map<string, ExternalEffectIntentV1>();
   private readonly fencingTokens = new Map<string, number>();
   private readonly highestGenerations = new Map<string, number>();
   private readonly leases = new Map<string, WorkLeaseV1>();
@@ -162,6 +171,17 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
     finishedAt: string,
   ): Promise<RunReceiptV1> {
     this.assertLease(lease, finishedAt);
+    for (const [key, intent] of this.effectIntents) {
+      if (intent.run_id !== lease.run_id) {
+        continue;
+      }
+      const effect = this.effects.get(key);
+      if (effect?.state !== "succeeded" || effect.verification_state !== "verified") {
+        throw new ExecutionInvariantError(
+          "run has an external intent without a verified effect",
+        );
+      }
+    }
     for (const effect of this.effects.values()) {
       if (effect.run_id !== lease.run_id) {
         continue;
@@ -180,6 +200,58 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
     this.runs.set(lease.run_id, delivering);
     this.leases.delete(lease.run_id);
     return Promise.resolve(structuredClone(delivering));
+  }
+
+  persistEffectIntent(
+    lease: WorkLeaseV1,
+    draft: ExternalEffectIntentDraft,
+    persistedAt: string,
+  ): Promise<ExternalEffectIntentCommit> {
+    this.assertLease(lease, persistedAt);
+    if (
+      JSON.stringify(normalizeEffectIntentValue(draft.request)) !==
+      JSON.stringify(draft.request)
+    ) {
+      throw new ExecutionInvariantError("effect intent request is not canonical");
+    }
+    if (effectIntentDigest(draft) !== draft.request_digest) {
+      throw new ExecutionInvariantError("effect intent digest does not match its request");
+    }
+    const key = effectKey(lease.run_id, draft.idempotency_key);
+    const current = this.effectIntents.get(key);
+    if (current !== undefined) {
+      if (!sameExternalEffectIntent(current, draft)) {
+        throw new ExecutionInvariantError(
+          "effect idempotency key has a different external intent",
+        );
+      }
+      return Promise.resolve({
+        created: false,
+        intent: structuredClone(current),
+      });
+    }
+
+    const intent: ExternalEffectIntentV1 = {
+      ...structuredClone(draft),
+      fencing_token: lease.fencing_token,
+      generation: lease.generation,
+      lease_token: lease.lease_token,
+      persisted_at: persistedAt,
+      run_id: lease.run_id,
+      schema_version: "external-effect-intent/v1",
+    };
+    this.effectIntents.set(key, intent);
+    return Promise.resolve({ created: true, intent: structuredClone(intent) });
+  }
+
+  getEffectIntent(
+    runId: string,
+    idempotencyKey: string,
+  ): Promise<ExternalEffectIntentV1 | undefined> {
+    const intent = this.effectIntents.get(effectKey(runId, idempotencyKey));
+    return Promise.resolve(
+      intent === undefined ? undefined : structuredClone(intent),
+    );
   }
 
   beginEffect(

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -1,5 +1,22 @@
 export * from "./admission.js";
 export * from "./contracts.js";
+export {
+  ExecutionCoordinator,
+  ExecutionInvariantError,
+} from "./execution/coordinator.js";
+export * from "./execution/effect-reconciliation.js";
+export * from "./execution/effect-intent.js";
+export type {
+  EffectIntentValue,
+  ExecutionSession,
+  ExternalEffectIntentCommit,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
+} from "./execution/model.js";
+export type {
+  DurableExecutionPort,
+  ExecutionClockPort,
+} from "./execution/ports.js";
 export * from "./installation.js";
 export * from "./lifecycle.js";
 export * from "./ports.js";

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -1,5 +1,8 @@
 export * from "./admission.js";
 export * from "./contracts.js";
+export * from "./delivery/contracts.js";
+export * from "./delivery/coordinator.js";
+export * from "./delivery/ports.js";
 export {
   ExecutionCoordinator,
   ExecutionInvariantError,
@@ -19,4 +22,17 @@ export type {
 } from "./execution/ports.js";
 export * from "./installation.js";
 export * from "./lifecycle.js";
+export * from "./mission/coordinator.js";
+export * from "./mission/model.js";
+export * from "./operations/compatibility.js";
+export * from "./operations/maintenance.js";
+export * from "./operations/migration.js";
+export * from "./operations/schedules.js";
+export * from "./operations/status.js";
 export * from "./ports.js";
+export * from "./thread-binding.js";
+export * from "./transport/contracts.js";
+export * from "./transport/handler.js";
+export * from "./transport/normalization.js";
+export * from "./transport/readiness.js";
+export * from "./transport/signatures.js";

--- a/apps/slack-companion/src/mission/coordinator.ts
+++ b/apps/slack-companion/src/mission/coordinator.ts
@@ -1,0 +1,487 @@
+import type {
+  CheckpointDraft,
+  ExecutionSession,
+} from "../execution/model.js";
+import {
+  ExecutionCoordinator,
+  ExecutionInvariantError,
+} from "../execution/coordinator.js";
+import type {
+  EvidenceProofV1,
+  MissionCapabilityBindingV1,
+  MissionCheckpointProjectionV1,
+  MissionClosureProjectionV1,
+  MissionClosureResult,
+  MissionDecisionProjectionV1,
+  MissionEffectReceipt,
+  MissionEffectResolutionV1,
+  MissionPlanProjectionV1,
+  MissionReadinessDecision,
+  MissionReadinessInput,
+  MissionStepProjectionV1,
+  MissionVerificationProjectionV1,
+  MissionWaitProjectionV1,
+  MissionWaitResult,
+  ReceiptProofV1,
+} from "./model.js";
+import {
+  NATIVE_MISSION_CONTRACT_ID,
+  NATIVE_MISSION_SCHEMA_VERSION,
+} from "./model.js";
+
+export class MissionBridgeCoordinator {
+  constructor(private readonly execution: ExecutionCoordinator) {}
+
+  readiness(
+    plan: MissionPlanProjectionV1,
+    input: MissionReadinessInput,
+  ): MissionReadinessDecision {
+    validatePlanShape(plan);
+    validateDistinctRefs(input.missing_input_refs, "missing input");
+    if (input.missing_input_refs.length > 0) {
+      return {
+        kind: "missing_input",
+        status: "waiting",
+        waiting_on_ref: input.missing_input_refs[0]!,
+      };
+    }
+
+    const bindings = indexBindings(input.capability_bindings);
+    for (const step of plan.steps) {
+      const binding = bindings.get(step.capability_ref);
+      if (
+        binding === undefined ||
+        binding.capability_version !== step.capability_version ||
+        binding.state !== "bound"
+      ) {
+        return {
+          kind: "missing_tool_binding",
+          status: "waiting",
+          waiting_on_ref: binding?.binding_ref ?? step.capability_ref,
+        };
+      }
+    }
+    return { status: "ready" };
+  }
+
+  wait(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    projection: MissionWaitProjectionV1,
+  ): Promise<MissionWaitResult> {
+    this.validateSessionPlan(session, plan);
+    requireRef(projection.waiting_on_ref, "waiting_on_ref");
+    return this.execution.waitForDependency(
+      session,
+      checkpointDraft(
+        plan,
+        projection,
+        projection.waiting_on_ref,
+        projection.kind,
+      ),
+    );
+  }
+
+  pauseForDrain(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    projection: MissionCheckpointProjectionV1,
+  ): Promise<MissionWaitResult> {
+    this.validateSessionPlan(session, plan);
+    return this.execution.pauseForDrain(
+      session,
+      checkpointDraft(plan, projection, undefined, "drain"),
+    );
+  }
+
+  beginEffect(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    stepId: string,
+    decision?: MissionDecisionProjectionV1,
+  ): Promise<MissionEffectReceipt> {
+    this.validateSessionPlan(session, plan);
+    const step = requireStep(plan, stepId);
+    requireRef(step.rollback_plan_ref, "rollback_plan_ref");
+
+    let approvalRef: string | undefined;
+    if (step.approval_required) {
+      if (decision === undefined) {
+        return Promise.reject(
+          new MissionBridgeInvariantError(
+            "an approval decision is required before this effect",
+          ),
+        );
+      }
+      validateDecision(plan, decision);
+      if (decision.decision !== "approved") {
+        return Promise.reject(
+          new MissionBridgeInvariantError(
+            "a rejected decision cannot authorize an effect",
+          ),
+        );
+      }
+      approvalRef = decision.receipt.receipt_ref;
+    }
+
+    return this.execution.beginEffect(session, {
+      approval_ref: approvalRef,
+      approval_required: step.approval_required,
+      effect_id: step.effect_id,
+      idempotency_key: step.idempotency_key,
+      request_digest: step.request_digest,
+      rollback_plan_ref: step.rollback_plan_ref,
+      step_id: step.step_id,
+      target_ref: step.target_ref,
+    });
+  }
+
+  markEffectExecuting(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    stepId: string,
+  ): Promise<MissionEffectReceipt> {
+    this.validateSessionPlan(session, plan);
+    const step = requireStep(plan, stepId);
+    return this.execution.markEffectExecuting(session, step.idempotency_key);
+  }
+
+  resolveEffect(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    stepId: string,
+    resolution: MissionEffectResolutionV1,
+  ): Promise<MissionEffectReceipt> {
+    this.validateSessionPlan(session, plan);
+    const step = requireStep(plan, stepId);
+    validateReceipt(resolution.result, "effect result");
+    validateVerification(resolution.executor_ref, resolution.verification);
+    return this.execution.resolveEffect(session, step.idempotency_key, {
+      result_digest: resolution.result.receipt_digest,
+      result_ref: resolution.result.receipt_ref,
+      state: resolution.state,
+      verification_receipt_ref: resolution.verification.receipt.receipt_ref,
+      verification_state:
+        resolution.state === "succeeded" ? "verified" : "failed",
+    });
+  }
+
+  async close(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    projection: MissionClosureProjectionV1,
+  ): Promise<MissionClosureResult> {
+    this.validateSessionPlan(session, plan);
+    if (!projection.desired_condition_verified) {
+      throw new MissionBridgeInvariantError(
+        "mission closure requires a verified desired condition",
+      );
+    }
+    if (projection.armed_wake_condition_refs.length > 0) {
+      throw new MissionBridgeInvariantError(
+        "mission closure cannot retain an armed wake condition",
+      );
+    }
+    validateCompletedSteps(plan, projection.completed_step_ids);
+    validateVerification(projection.executor_ref, projection.verification);
+
+    const checkpoint = await this.execution.checkpoint(
+      session,
+      checkpointDraft(
+        plan,
+        {
+          ...projection,
+          state_receipt: projection.verification.receipt,
+        },
+        undefined,
+        "verified_closure",
+      ),
+    );
+    const run = await this.execution.finishExecution(session);
+    return { checkpoint, run };
+  }
+
+  private validateSessionPlan(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+  ): void {
+    validatePlanShape(plan);
+    if (
+      session.run.run_id !== plan.run_id ||
+      session.lease.run_id !== plan.run_id
+    ) {
+      throw new MissionBridgeInvariantError(
+        "mission plan does not belong to the execution run",
+      );
+    }
+    if (session.run.state !== "running") {
+      throw new MissionBridgeInvariantError(
+        "mission projection requires a running leased session",
+      );
+    }
+  }
+}
+
+export class MissionBridgeInvariantError extends ExecutionInvariantError {
+  constructor(message: string) {
+    super(message);
+    this.name = "MissionBridgeInvariantError";
+  }
+}
+
+function validatePlanShape(plan: MissionPlanProjectionV1): void {
+  if (plan.schema_version !== "mission-plan-projection/v1") {
+    throw new MissionBridgeInvariantError(
+      "mission plan projection schema version is unsupported",
+    );
+  }
+  if (plan.mission_contract_id !== NATIVE_MISSION_CONTRACT_ID) {
+    throw new MissionBridgeInvariantError("mission contract id is unsupported");
+  }
+  if (plan.mission_schema_version !== NATIVE_MISSION_SCHEMA_VERSION) {
+    throw new MissionBridgeInvariantError(
+      "mission contract schema version is unsupported",
+    );
+  }
+  for (const [value, label] of [
+    [plan.run_id, "run_id"],
+    [plan.mission_ref, "mission_ref"],
+    [plan.plan_ref, "plan_ref"],
+    [plan.plan_digest, "plan_digest"],
+  ] as const) {
+    requireRef(value, label);
+  }
+  requirePositiveRevision(plan.mission_revision, "mission_revision");
+  requirePositiveRevision(plan.plan_revision, "plan_revision");
+  if (plan.steps.length === 0) {
+    throw new MissionBridgeInvariantError("mission plan has no steps");
+  }
+  const stepIds = new Set<string>();
+  const effectKeys = new Set<string>();
+  for (const step of plan.steps) {
+    validateStep(step);
+    if (stepIds.has(step.step_id)) {
+      throw new MissionBridgeInvariantError("mission plan repeats a step id");
+    }
+    if (effectKeys.has(step.idempotency_key)) {
+      throw new MissionBridgeInvariantError(
+        "mission plan repeats an effect idempotency key",
+      );
+    }
+    stepIds.add(step.step_id);
+    effectKeys.add(step.idempotency_key);
+  }
+}
+
+function validateStep(step: MissionStepProjectionV1): void {
+  for (const [value, label] of [
+    [step.step_id, "step_id"],
+    [step.capability_ref, "capability_ref"],
+    [step.capability_version, "capability_version"],
+    [step.effect_id, "effect_id"],
+    [step.idempotency_key, "idempotency_key"],
+    [step.request_digest, "request_digest"],
+    [step.target_ref, "target_ref"],
+  ] as const) {
+    requireRef(value, label);
+  }
+}
+
+function indexBindings(
+  bindings: MissionCapabilityBindingV1[],
+): Map<string, MissionCapabilityBindingV1> {
+  const indexed = new Map<string, MissionCapabilityBindingV1>();
+  for (const binding of bindings) {
+    requireRef(binding.binding_ref, "binding_ref");
+    requireRef(binding.capability_ref, "capability_ref");
+    requireRef(binding.capability_version, "capability_version");
+    if (indexed.has(binding.capability_ref)) {
+      throw new MissionBridgeInvariantError(
+        "capability readiness repeats a capability ref",
+      );
+    }
+    indexed.set(binding.capability_ref, binding);
+  }
+  return indexed;
+}
+
+function checkpointDraft(
+  plan: MissionPlanProjectionV1,
+  projection: MissionCheckpointProjectionV1,
+  waitingOnRef?: string,
+  checkpointState = "checkpoint",
+): CheckpointDraft {
+  validateReceipt(projection.state_receipt, "mission state");
+  validateCheckpointSequence(projection.sequence);
+  validateCompletedStepSubset(plan, projection.completed_step_ids);
+  validateDistinctRefs(projection.effect_receipt_ids, "effect receipt");
+  requireRef(projection.checkpoint_id, "checkpoint_id");
+  return {
+    checkpoint_id: projection.checkpoint_id,
+    completed_step_ids: [...projection.completed_step_ids],
+    effect_receipt_ids: [...projection.effect_receipt_ids],
+    payload_digest: projection.state_receipt.receipt_digest,
+    payload_ref: projection.state_receipt.receipt_ref,
+    resume_cursor: [
+      plan.mission_ref,
+      plan.mission_revision,
+      plan.plan_ref,
+      plan.plan_revision,
+      checkpointState,
+      projection.sequence,
+    ].join(":"),
+    sequence: projection.sequence,
+    waiting_on_ref: waitingOnRef,
+  };
+}
+
+function validateDecision(
+  plan: MissionPlanProjectionV1,
+  decision: MissionDecisionProjectionV1,
+): void {
+  if (decision.schema_version !== "mission-decision-projection/v1") {
+    throw new MissionBridgeInvariantError(
+      "mission decision projection schema version is unsupported",
+    );
+  }
+  if (
+    decision.mission_ref !== plan.mission_ref ||
+    decision.mission_revision !== plan.mission_revision ||
+    decision.plan_ref !== plan.plan_ref ||
+    decision.plan_revision !== plan.plan_revision ||
+    decision.plan_digest !== plan.plan_digest
+  ) {
+    throw new MissionBridgeInvariantError(
+      "decision does not match the mission plan revision",
+    );
+  }
+  validateReceipt(decision.receipt, "decision");
+  validateEvidence(decision.evidence);
+}
+
+function validateVerification(
+  executorRef: string,
+  verification: MissionVerificationProjectionV1,
+): void {
+  requireRef(executorRef, "executor_ref");
+  requireRef(verification.verifier_ref, "verifier_ref");
+  if (executorRef === verification.verifier_ref) {
+    throw new MissionBridgeInvariantError(
+      "verification must be independent from execution",
+    );
+  }
+  requireRef(
+    verification.pre_action_source_revision,
+    "pre_action_source_revision",
+  );
+  requireRef(
+    verification.observed_source_revision,
+    "observed_source_revision",
+  );
+  if (
+    verification.pre_action_source_revision ===
+    verification.observed_source_revision
+  ) {
+    throw new MissionBridgeInvariantError(
+      "verification must observe a newer source revision",
+    );
+  }
+  validateReceipt(verification.receipt, "verification");
+  validateEvidence(verification.evidence);
+  if (
+    !verification.evidence.some(
+      (proof) => proof.source_revision === verification.observed_source_revision,
+    )
+  ) {
+    throw new MissionBridgeInvariantError(
+      "verification evidence does not prove the observed source revision",
+    );
+  }
+}
+
+function validateEvidence(evidence: EvidenceProofV1[]): void {
+  if (evidence.length === 0) {
+    throw new MissionBridgeInvariantError(
+      "a decision or verification requires evidence",
+    );
+  }
+  const refs = new Set<string>();
+  for (const proof of evidence) {
+    requireRef(proof.evidence_ref, "evidence_ref");
+    requireRef(proof.evidence_digest, "evidence_digest");
+    requireRef(proof.source_revision, "source_revision");
+    if (refs.has(proof.evidence_ref)) {
+      throw new MissionBridgeInvariantError("evidence repeats a receipt ref");
+    }
+    refs.add(proof.evidence_ref);
+  }
+}
+
+function validateReceipt(receipt: ReceiptProofV1, label: string): void {
+  requireRef(receipt.receipt_ref, `${label} receipt_ref`);
+  requireRef(receipt.receipt_digest, `${label} receipt_digest`);
+}
+
+function validateCompletedStepSubset(
+  plan: MissionPlanProjectionV1,
+  completedStepIds: string[],
+): void {
+  validateDistinctRefs(completedStepIds, "completed step");
+  const known = new Set(plan.steps.map((step) => step.step_id));
+  if (completedStepIds.some((stepId) => !known.has(stepId))) {
+    throw new MissionBridgeInvariantError(
+      "checkpoint contains a step outside the mission plan",
+    );
+  }
+}
+
+function validateCompletedSteps(
+  plan: MissionPlanProjectionV1,
+  completedStepIds: string[],
+): void {
+  validateCompletedStepSubset(plan, completedStepIds);
+  const completed = new Set(completedStepIds);
+  if (plan.steps.some((step) => !completed.has(step.step_id))) {
+    throw new MissionBridgeInvariantError(
+      "mission closure requires every plan step to be complete",
+    );
+  }
+}
+
+function requireStep(
+  plan: MissionPlanProjectionV1,
+  stepId: string,
+): MissionStepProjectionV1 {
+  const step = plan.steps.find((candidate) => candidate.step_id === stepId);
+  if (step === undefined) {
+    throw new MissionBridgeInvariantError("mission step does not exist");
+  }
+  return step;
+}
+
+function validateCheckpointSequence(sequence: number): void {
+  requirePositiveRevision(sequence, "checkpoint sequence");
+}
+
+function requirePositiveRevision(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new MissionBridgeInvariantError(`${label} must be a positive integer`);
+  }
+}
+
+function validateDistinctRefs(values: string[], label: string): void {
+  const refs = new Set<string>();
+  for (const value of values) {
+    requireRef(value, `${label} ref`);
+    if (refs.has(value)) {
+      throw new MissionBridgeInvariantError(`${label} refs must be distinct`);
+    }
+    refs.add(value);
+  }
+}
+
+function requireRef(value: string | undefined, label: string): asserts value is string {
+  if (value === undefined || value.trim() === "") {
+    throw new MissionBridgeInvariantError(`${label} must not be empty`);
+  }
+}

--- a/apps/slack-companion/src/mission/model.ts
+++ b/apps/slack-companion/src/mission/model.ts
@@ -1,0 +1,141 @@
+import type {
+  CheckpointV1,
+  EffectReceiptV1,
+  RunReceiptV1,
+} from "@writer/cerebro-sdk";
+
+export const NATIVE_MISSION_CONTRACT_ID =
+  "native-mission-operating-contract" as const;
+export const NATIVE_MISSION_SCHEMA_VERSION =
+  "cerebro.control-kernel.v1" as const;
+
+export interface ReceiptProofV1 {
+  receipt_digest: string;
+  receipt_ref: string;
+}
+
+export interface EvidenceProofV1 {
+  evidence_digest: string;
+  evidence_ref: string;
+  source_revision: string;
+}
+
+export interface MissionStepProjectionV1 {
+  approval_required: boolean;
+  capability_ref: string;
+  capability_version: string;
+  effect_id: string;
+  idempotency_key: string;
+  request_digest: string;
+  rollback_plan_ref?: string;
+  step_id: string;
+  target_ref: string;
+}
+
+/**
+ * A transport-neutral projection of an immutable mission plan. The durable
+ * mission record remains owned by the native mission contract referenced here.
+ */
+export interface MissionPlanProjectionV1 {
+  mission_contract_id: typeof NATIVE_MISSION_CONTRACT_ID;
+  mission_ref: string;
+  mission_revision: number;
+  mission_schema_version: typeof NATIVE_MISSION_SCHEMA_VERSION;
+  plan_digest: string;
+  plan_ref: string;
+  plan_revision: number;
+  run_id: string;
+  schema_version: "mission-plan-projection/v1";
+  steps: MissionStepProjectionV1[];
+}
+
+export type CapabilityBindingState = "bound" | "missing" | "incompatible";
+
+export interface MissionCapabilityBindingV1 {
+  binding_ref: string;
+  capability_ref: string;
+  capability_version: string;
+  state: CapabilityBindingState;
+}
+
+export interface MissionReadinessInput {
+  capability_bindings: MissionCapabilityBindingV1[];
+  missing_input_refs: string[];
+}
+
+export type MissionReadinessDecision =
+  | { status: "ready" }
+  | {
+      kind: "missing_input" | "missing_tool_binding";
+      status: "waiting";
+      waiting_on_ref: string;
+    };
+
+export type MissionWaitKind =
+  | "missing_input"
+  | "missing_tool_binding"
+  | "decision_required";
+
+export interface MissionCheckpointProjectionV1 {
+  checkpoint_id: string;
+  completed_step_ids: string[];
+  effect_receipt_ids: string[];
+  sequence: number;
+  state_receipt: ReceiptProofV1;
+}
+
+export interface MissionWaitProjectionV1
+  extends MissionCheckpointProjectionV1 {
+  kind: MissionWaitKind;
+  waiting_on_ref: string;
+}
+
+export interface MissionDecisionProjectionV1 {
+  decision: "approved" | "rejected";
+  evidence: EvidenceProofV1[];
+  mission_ref: string;
+  mission_revision: number;
+  plan_digest: string;
+  plan_ref: string;
+  plan_revision: number;
+  receipt: ReceiptProofV1;
+  schema_version: "mission-decision-projection/v1";
+}
+
+export interface MissionEffectResolutionV1 {
+  executor_ref: string;
+  result: ReceiptProofV1;
+  state: "succeeded" | "failed";
+  verification: MissionVerificationProjectionV1;
+}
+
+export interface MissionVerificationProjectionV1 {
+  evidence: EvidenceProofV1[];
+  observed_source_revision: string;
+  pre_action_source_revision: string;
+  receipt: ReceiptProofV1;
+  verifier_ref: string;
+}
+
+export interface MissionClosureProjectionV1 {
+  armed_wake_condition_refs: string[];
+  checkpoint_id: string;
+  completed_step_ids: string[];
+  desired_condition_verified: boolean;
+  effect_receipt_ids: string[];
+  executor_ref: string;
+  sequence: number;
+  verification: MissionVerificationProjectionV1;
+}
+
+export interface MissionWaitResult {
+  checkpoint: CheckpointV1;
+  run: RunReceiptV1;
+}
+
+export interface MissionClosureResult {
+  checkpoint: CheckpointV1;
+  run: RunReceiptV1;
+}
+
+export type MissionEffectReceipt = EffectReceiptV1;

--- a/apps/slack-companion/src/operations/compatibility.ts
+++ b/apps/slack-companion/src/operations/compatibility.ts
@@ -1,0 +1,171 @@
+import type {
+  CapabilityCompatibilityDecision,
+  CapabilityManifestV1,
+  CapabilityRequirement,
+  PresenceSnapshotV1,
+  SchemaCompatibility,
+} from "@writer/cerebro-sdk";
+
+export interface CompatibilityAssessment {
+  decision: CapabilityCompatibilityDecision;
+  negotiated_write_version?: string;
+  reasons: string[];
+}
+
+export interface CompatibilityInput {
+  companion_manifest: CapabilityManifestV1;
+  companion_schema: SchemaCompatibility;
+  core_manifest: CapabilityManifestV1;
+  core_schema: SchemaCompatibility;
+}
+
+export interface ContinuityGate {
+  allowed: boolean;
+  reason: string;
+}
+
+export function assessCompatibility(
+  input: CompatibilityInput,
+): CompatibilityAssessment {
+  const reasons: string[] = [];
+  const schemaReadable =
+    input.core_schema.read_versions.includes(input.companion_schema.current_version) &&
+    input.companion_schema.read_versions.includes(input.core_schema.current_version);
+  const sharedContractVersions = input.core_manifest.contract_versions.filter(
+    (version) => input.companion_manifest.contract_versions.includes(version),
+  );
+
+  if (!schemaReadable || sharedContractVersions.length === 0) {
+    if (!schemaReadable) {
+      reasons.push("contract_version_not_readable");
+    }
+    if (sharedContractVersions.length === 0) {
+      reasons.push("manifest_contract_version_not_shared");
+    }
+    return { decision: "incompatible", reasons };
+  }
+
+  const negotiatedWriteVersion = input.core_schema.write_versions.find((version) =>
+    input.companion_schema.write_versions.includes(version),
+  );
+  if (negotiatedWriteVersion === undefined) {
+    return { decision: "blocked", reasons: ["no_shared_write_version"] };
+  }
+
+  const missingRequired = [
+    ...missingCapabilities(
+      input.core_manifest.capabilities,
+      input.companion_manifest.capabilities,
+      "companion",
+    ),
+    ...missingCapabilities(
+      input.companion_manifest.capabilities,
+      input.core_manifest.capabilities,
+      "core",
+    ),
+  ];
+  if (missingRequired.length > 0) {
+    return {
+      decision: "blocked",
+      negotiated_write_version: negotiatedWriteVersion,
+      reasons: missingRequired,
+    };
+  }
+
+  const optionalMismatches = [
+    ...optionalCapabilityMismatches(
+      input.core_manifest.capabilities,
+      input.companion_manifest.capabilities,
+      "companion",
+    ),
+    ...optionalCapabilityMismatches(
+      input.companion_manifest.capabilities,
+      input.core_manifest.capabilities,
+      "core",
+    ),
+  ];
+  return {
+    decision: optionalMismatches.length > 0 ? "degraded" : "supported",
+    negotiated_write_version: negotiatedWriteVersion,
+    reasons: optionalMismatches,
+  };
+}
+
+export function readinessGate(
+  presence: PresenceSnapshotV1,
+  assessment: CompatibilityAssessment,
+  now: string,
+): ContinuityGate {
+  if (Date.parse(presence.expires_at) <= Date.parse(now)) {
+    return { allowed: false, reason: "presence_expired" };
+  }
+  if (assessment.decision === "blocked" || assessment.decision === "incompatible") {
+    return { allowed: false, reason: "compatibility_blocked" };
+  }
+  if (presence.compatibility === "blocked" || presence.compatibility === "incompatible") {
+    return { allowed: false, reason: "presence_compatibility_blocked" };
+  }
+  if (presence.service_state !== "ready" && presence.service_state !== "degraded") {
+    return { allowed: false, reason: `service_${presence.service_state}` };
+  }
+  return { allowed: true, reason: "ready" };
+}
+
+export function newLeaseGate(
+  presence: PresenceSnapshotV1,
+  assessment: CompatibilityAssessment,
+  expectedGeneration: number,
+  expectedRouteGeneration: number,
+  now: string,
+): ContinuityGate {
+  const readiness = readinessGate(presence, assessment, now);
+  if (!readiness.allowed) {
+    return readiness;
+  }
+  if (presence.active_generation !== expectedGeneration) {
+    return { allowed: false, reason: "generation_changed" };
+  }
+  if (presence.route_generation !== expectedRouteGeneration) {
+    return { allowed: false, reason: "route_generation_changed" };
+  }
+  return { allowed: true, reason: "lease_allowed" };
+}
+
+function missingCapabilities(
+  requirements: readonly CapabilityRequirement[],
+  offered: readonly CapabilityRequirement[],
+  provider: string,
+): string[] {
+  return requirements
+    .filter((requirement) => requirement.level === "required")
+    .filter((requirement) => !hasCapability(offered, requirement))
+    .map(
+      (requirement) =>
+        `${provider}_missing_${requirement.capability_id}@${requirement.version}`,
+    );
+}
+
+function optionalCapabilityMismatches(
+  requirements: readonly CapabilityRequirement[],
+  offered: readonly CapabilityRequirement[],
+  provider: string,
+): string[] {
+  return requirements
+    .filter((requirement) => requirement.level === "optional")
+    .filter((requirement) => !hasCapability(offered, requirement))
+    .map(
+      (requirement) =>
+        `${provider}_optional_${requirement.capability_id}@${requirement.version}`,
+    );
+}
+
+function hasCapability(
+  offered: readonly CapabilityRequirement[],
+  requirement: CapabilityRequirement,
+): boolean {
+  return offered.some(
+    (capability) =>
+      capability.capability_id === requirement.capability_id &&
+      capability.version === requirement.version,
+  );
+}

--- a/apps/slack-companion/src/operations/maintenance.ts
+++ b/apps/slack-companion/src/operations/maintenance.ts
@@ -1,0 +1,126 @@
+import type {
+  CapabilityCompatibilityDecision,
+  PresenceSnapshotV1,
+  ReleaseReceiptV2,
+} from "@writer/cerebro-sdk";
+import { readinessGate } from "./compatibility.js";
+
+export type MaintenanceMode = "forced" | "graceful";
+
+export interface MaintenanceRun {
+  checkpointable: boolean;
+  run_id: string;
+}
+
+export interface MaintenanceDelivery {
+  delivery_id: string;
+  state: "delivering" | "pending";
+}
+
+export interface MaintenanceAction {
+  action:
+    | "checkpoint_and_pause"
+    | "drain_delivery"
+    | "mark_for_reconciliation"
+    | "pause_delivery"
+    | "stop_new_leases"
+    | "wait_for_safe_boundary";
+  subject_id: string;
+}
+
+export interface MaintenancePlan {
+  actions: MaintenanceAction[];
+  admission_behavior: "durable_queue";
+  blockers: string[];
+  forced_stop_permitted_after_actions: boolean;
+  mode: MaintenanceMode;
+  new_leases_allowed: false;
+  safe_to_stop: boolean;
+}
+
+export interface MaintenanceInput {
+  active_runs: readonly MaintenanceRun[];
+  compatibility: CapabilityCompatibilityDecision;
+  deliveries: readonly MaintenanceDelivery[];
+  mode: MaintenanceMode;
+  now: string;
+  replacement_presence?: PresenceSnapshotV1;
+}
+
+export interface ReleaseVerification {
+  passed: boolean;
+  reasons: string[];
+}
+
+export function planMaintenance(input: MaintenanceInput): MaintenancePlan {
+  const actions: MaintenanceAction[] = [
+    { action: "stop_new_leases", subject_id: "service" },
+  ];
+  const blockers: string[] = [];
+
+  if (input.mode === "graceful") {
+    if (input.replacement_presence === undefined) {
+      blockers.push("replacement_presence_missing");
+    } else {
+      const replacement = readinessGate(
+        input.replacement_presence,
+        { decision: input.compatibility, reasons: [] },
+        input.now,
+      );
+      if (!replacement.allowed) {
+        blockers.push(`replacement_${replacement.reason}`);
+      }
+    }
+  }
+
+  for (const run of input.active_runs) {
+    if (run.checkpointable) {
+      actions.push({ action: "checkpoint_and_pause", subject_id: run.run_id });
+    } else if (input.mode === "forced") {
+      actions.push({ action: "mark_for_reconciliation", subject_id: run.run_id });
+    } else {
+      actions.push({ action: "wait_for_safe_boundary", subject_id: run.run_id });
+      blockers.push(`run_not_checkpointable:${run.run_id}`);
+    }
+  }
+
+  for (const delivery of input.deliveries) {
+    actions.push({
+      action: input.mode === "forced" ? "pause_delivery" : "drain_delivery",
+      subject_id: delivery.delivery_id,
+    });
+  }
+
+  const activeWorkRemains =
+    input.active_runs.length > 0 || input.deliveries.length > 0;
+
+  return {
+    actions,
+    admission_behavior: "durable_queue",
+    blockers,
+    forced_stop_permitted_after_actions: input.mode === "forced",
+    mode: input.mode,
+    new_leases_allowed: false,
+    safe_to_stop:
+      !activeWorkRemains && (input.mode === "forced" || blockers.length === 0),
+  };
+}
+
+export function verifyReleaseReceipt(
+  receipt: ReleaseReceiptV2,
+): ReleaseVerification {
+  const reasons: string[] = [];
+  if (receipt.orphaned_run_count > 0) {
+    reasons.push("orphaned_runs_present");
+  }
+  if (receipt.stuck_delivery_count > 0) {
+    reasons.push("stuck_deliveries_present");
+  }
+  if (receipt.compatibility === "blocked" || receipt.compatibility === "incompatible") {
+    reasons.push("release_incompatible");
+  }
+  if (receipt.state === "failed") {
+    reasons.push("release_failed");
+  }
+  return { passed: reasons.length === 0, reasons };
+}

--- a/apps/slack-companion/src/operations/migration.ts
+++ b/apps/slack-companion/src/operations/migration.ts
@@ -1,0 +1,148 @@
+import type { MigrationReceiptV1 } from "@writer/cerebro-sdk";
+
+export interface SlackThreadIdentity {
+  binding_id: string;
+  conversation_id: string;
+  durable_thread_state_digest: string;
+  installation_id: string;
+  slack_app_id: string;
+  thread_id: string;
+}
+
+export interface CreateMigrationInput {
+  binding_id: string;
+  checkpoint_count: number;
+  created_at: string;
+  migration_id: string;
+  pending_delivery_count: number;
+  rollback_generation: number;
+  route_generation: number;
+  source_generation: number;
+  target_generation: number;
+}
+
+export type MigrationChangeResult =
+  | { changed: true; receipt: MigrationReceiptV1 }
+  | {
+      changed: false;
+      reason: "identity_changed" | "invalid_state" | "route_generation_conflict";
+      receipt: MigrationReceiptV1;
+    };
+
+const transitions: Readonly<Record<MigrationReceiptV1["state"], readonly MigrationReceiptV1["state"][]>> = {
+  completed: [],
+  cutting_over: ["recovering", "rolling_back", "failed"],
+  draining: ["cutting_over", "rolling_back", "failed"],
+  failed: ["rolling_back"],
+  proposed: ["validating", "failed"],
+  recovering: ["completed", "rolling_back", "failed"],
+  rolled_back: [],
+  rolling_back: ["rolled_back", "failed"],
+  validating: ["draining", "rolling_back", "failed"],
+};
+
+export function createMigrationReceipt(
+  input: CreateMigrationInput,
+): MigrationReceiptV1 {
+  return {
+    binding_id: input.binding_id,
+    checkpoint_count: input.checkpoint_count,
+    created_at: input.created_at,
+    migration_id: input.migration_id,
+    pending_delivery_count: input.pending_delivery_count,
+    rollback_generation: input.rollback_generation,
+    route_generation: input.route_generation,
+    schema_version: "migration-receipt/v1",
+    source_generation: input.source_generation,
+    state: "proposed",
+    target_generation: input.target_generation,
+    updated_at: input.created_at,
+  };
+}
+
+export function advanceMigration(
+  receipt: MigrationReceiptV1,
+  state: MigrationReceiptV1["state"],
+  now: string,
+): MigrationChangeResult {
+  if (!transitions[receipt.state].includes(state)) {
+    return { changed: false, reason: "invalid_state", receipt };
+  }
+  return { changed: true, receipt: { ...receipt, state, updated_at: now } };
+}
+
+export function cutOverRoute(
+  receipt: MigrationReceiptV1,
+  observedRouteGeneration: number,
+  before: SlackThreadIdentity,
+  after: SlackThreadIdentity,
+  now: string,
+): MigrationChangeResult {
+  if (receipt.state !== "cutting_over") {
+    return { changed: false, reason: "invalid_state", receipt };
+  }
+  if (observedRouteGeneration !== receipt.route_generation) {
+    return { changed: false, reason: "route_generation_conflict", receipt };
+  }
+  if (!sameIdentity(before, after) || receipt.binding_id !== before.binding_id) {
+    return {
+      changed: false,
+      reason: "identity_changed",
+      receipt: { ...receipt, state: "failed", updated_at: now },
+    };
+  }
+  return {
+    changed: true,
+    receipt: {
+      ...receipt,
+      route_generation: receipt.route_generation + 1,
+      state: "recovering",
+      updated_at: now,
+    },
+  };
+}
+
+export function rollBackRoute(
+  receipt: MigrationReceiptV1,
+  observedRouteGeneration: number,
+  before: SlackThreadIdentity,
+  after: SlackThreadIdentity,
+  now: string,
+): MigrationChangeResult {
+  if (receipt.state !== "rolling_back") {
+    return { changed: false, reason: "invalid_state", receipt };
+  }
+  if (observedRouteGeneration !== receipt.route_generation) {
+    return { changed: false, reason: "route_generation_conflict", receipt };
+  }
+  if (!sameIdentity(before, after) || receipt.binding_id !== before.binding_id) {
+    return {
+      changed: false,
+      reason: "identity_changed",
+      receipt: { ...receipt, state: "failed", updated_at: now },
+    };
+  }
+  return {
+    changed: true,
+    receipt: {
+      ...receipt,
+      route_generation: receipt.route_generation + 1,
+      state: "rolled_back",
+      updated_at: now,
+    },
+  };
+}
+
+function sameIdentity(
+  before: SlackThreadIdentity,
+  after: SlackThreadIdentity,
+): boolean {
+  return (
+    before.slack_app_id === after.slack_app_id &&
+    before.binding_id === after.binding_id &&
+    before.installation_id === after.installation_id &&
+    before.conversation_id === after.conversation_id &&
+    before.thread_id === after.thread_id &&
+    before.durable_thread_state_digest === after.durable_thread_state_digest
+  );
+}

--- a/apps/slack-companion/src/operations/schedules.ts
+++ b/apps/slack-companion/src/operations/schedules.ts
@@ -1,0 +1,263 @@
+import type {
+  ScheduleMisfirePolicy,
+  ScheduledOccurrenceState,
+  ScheduledOccurrenceV1,
+} from "@writer/cerebro-sdk";
+
+export interface ScheduledOccurrenceInput {
+  due_at: string;
+  generation: number;
+  misfire_policy: ScheduleMisfirePolicy;
+  schedule_id: string;
+  schedule_revision: number;
+}
+
+export interface ScheduledOccurrenceCommitResult {
+  created: boolean;
+  occurrence: ScheduledOccurrenceV1;
+}
+
+/**
+ * Durable scheduled-occurrence state. Production adapters must make create and
+ * compare-and-set atomic; a process-local timer is not a valid implementation.
+ */
+export interface ScheduledOccurrenceStorePort {
+  compareAndSet(
+    expected: ScheduledOccurrenceV1,
+    next: ScheduledOccurrenceV1,
+  ): Promise<ScheduledOccurrenceV1>;
+  putIfAbsent(
+    occurrence: ScheduledOccurrenceV1,
+  ): Promise<ScheduledOccurrenceCommitResult>;
+  read(occurrenceId: string): Promise<ScheduledOccurrenceV1 | undefined>;
+}
+
+export interface MisfirePlan {
+  enqueue: string[];
+  pending: string[];
+  skip: string[];
+}
+
+export interface ScheduledLeaseRequest {
+  fencing_token: number;
+  generation: number;
+  lease_expires_at: string;
+  lease_token: string;
+  now: string;
+  owner_id: string;
+}
+
+export type ScheduledLeaseDecision =
+  | { acquired: true; occurrence: ScheduledOccurrenceV1 }
+  | {
+      acquired: false;
+      reason:
+        | "active_lease"
+        | "invalid_expiry"
+        | "invalid_fencing_token"
+        | "invalid_generation"
+        | "invalid_lease_identity"
+        | "not_queueable"
+        | "stale_fencing_token"
+        | "stale_generation";
+    };
+
+export interface ScheduledLeaseClaim {
+  fencing_token: number;
+  generation: number;
+  lease_token: string;
+  owner_id: string;
+}
+
+export function scheduledOccurrenceIdentity(
+  scheduleId: string,
+  dueAt: string,
+  scheduleRevision: number,
+): string {
+  if (scheduleId.length === 0) {
+    throw new Error("schedule_id is required");
+  }
+  if (!Number.isSafeInteger(scheduleRevision) || scheduleRevision < 1) {
+    throw new Error("schedule_revision must be a positive integer");
+  }
+
+  const normalizedDueAt = normalizeTime(dueAt, "due_at");
+  return `schedule/${encodeURIComponent(scheduleId)}/due/${encodeURIComponent(normalizedDueAt)}/revision/${scheduleRevision}`;
+}
+
+export function createScheduledOccurrence(
+  input: ScheduledOccurrenceInput,
+  createdAt: string,
+): ScheduledOccurrenceV1 {
+  requirePositiveInteger(input.generation, "generation");
+  const normalizedCreatedAt = normalizeTime(createdAt, "created_at");
+  const normalizedDueAt = normalizeTime(input.due_at, "due_at");
+  const occurrenceId = scheduledOccurrenceIdentity(
+    input.schedule_id,
+    normalizedDueAt,
+    input.schedule_revision,
+  );
+
+  return {
+    created_at: normalizedCreatedAt,
+    due_at: normalizedDueAt,
+    generation: input.generation,
+    idempotency_key: occurrenceId,
+    misfire_policy: input.misfire_policy,
+    occurrence_id: occurrenceId,
+    run_id: `run/${occurrenceId}`,
+    schedule_id: input.schedule_id,
+    schedule_revision: input.schedule_revision,
+    schema_version: "scheduled-occurrence/v1",
+    state: "queued",
+    updated_at: normalizedCreatedAt,
+  };
+}
+
+export function planMisfires(
+  dueTimes: readonly string[],
+  now: string,
+  policy: ScheduleMisfirePolicy,
+  runAllLimit = 1,
+): MisfirePlan {
+  if (!Number.isSafeInteger(runAllLimit) || runAllLimit < 1) {
+    throw new Error("runAllLimit must be a positive integer");
+  }
+
+  const normalizedNow = normalizeTime(now, "now");
+  const ordered = [...new Set(dueTimes.map((dueAt) => normalizeTime(dueAt, "due_at")))]
+    .sort((left, right) => Date.parse(left) - Date.parse(right));
+  const due = ordered.filter((dueAt) => dueAt <= normalizedNow);
+  const pending = ordered.filter((dueAt) => dueAt > normalizedNow);
+
+  if (policy === "skip") {
+    return { enqueue: [], pending, skip: due };
+  }
+  if (policy === "coalesce_once") {
+    const latest = due.at(-1);
+    return {
+      enqueue: latest === undefined ? [] : [latest],
+      pending,
+      skip: latest === undefined ? [] : due.slice(0, -1),
+    };
+  }
+
+  return {
+    enqueue: due.slice(0, runAllLimit),
+    pending: [...due.slice(runAllLimit), ...pending],
+    skip: [],
+  };
+}
+
+export function acquireScheduledOccurrence(
+  occurrence: ScheduledOccurrenceV1,
+  request: ScheduledLeaseRequest,
+): ScheduledLeaseDecision {
+  if (!isPositiveInteger(request.generation)) {
+    return { acquired: false, reason: "invalid_generation" };
+  }
+  if (!isPositiveInteger(request.fencing_token)) {
+    return { acquired: false, reason: "invalid_fencing_token" };
+  }
+  if (
+    request.owner_id.trim().length === 0 ||
+    request.lease_token.trim().length === 0
+  ) {
+    return { acquired: false, reason: "invalid_lease_identity" };
+  }
+  const now = normalizeTime(request.now, "now");
+  const leaseExpiresAt = normalizeTime(
+    request.lease_expires_at,
+    "lease_expires_at",
+  );
+  if (leaseExpiresAt <= now) {
+    return { acquired: false, reason: "invalid_expiry" };
+  }
+  if (request.generation < occurrence.generation) {
+    return { acquired: false, reason: "stale_generation" };
+  }
+
+  const leaseIsActive =
+    occurrence.lease_expires_at !== undefined &&
+    normalizeTime(occurrence.lease_expires_at, "lease_expires_at") > now;
+  if (leaseIsActive) {
+    return { acquired: false, reason: "active_lease" };
+  }
+
+  if (occurrence.state !== "queued" && occurrence.state !== "leased" && occurrence.state !== "running") {
+    return { acquired: false, reason: "not_queueable" };
+  }
+  if (
+    occurrence.fencing_token !== undefined &&
+    request.fencing_token <= occurrence.fencing_token
+  ) {
+    return { acquired: false, reason: "stale_fencing_token" };
+  }
+
+  return {
+    acquired: true,
+    occurrence: {
+      ...occurrence,
+      fencing_token: request.fencing_token,
+      generation: request.generation,
+      heartbeat_at: now,
+      lease_expires_at: leaseExpiresAt,
+      lease_token: request.lease_token,
+      owner_id: request.owner_id,
+      state: "leased",
+      updated_at: now,
+    },
+  };
+}
+
+export function updateScheduledOccurrence(
+  occurrence: ScheduledOccurrenceV1,
+  claim: ScheduledLeaseClaim,
+  state: Extract<ScheduledOccurrenceState, "running" | "completed" | "failed">,
+  now: string,
+): ScheduledOccurrenceV1 | undefined {
+  const normalizedNow = normalizeTime(now, "now");
+  if (!ownsActiveLease(occurrence, claim, normalizedNow)) {
+    return undefined;
+  }
+
+  return {
+    ...occurrence,
+    heartbeat_at: normalizedNow,
+    state,
+    updated_at: normalizedNow,
+  };
+}
+
+function ownsActiveLease(
+  occurrence: ScheduledOccurrenceV1,
+  claim: ScheduledLeaseClaim,
+  now: string,
+): boolean {
+  return (
+    occurrence.fencing_token === claim.fencing_token &&
+    occurrence.generation === claim.generation &&
+    occurrence.lease_token === claim.lease_token &&
+    occurrence.owner_id === claim.owner_id &&
+    occurrence.lease_expires_at !== undefined &&
+    normalizeTime(occurrence.lease_expires_at, "lease_expires_at") > now
+  );
+}
+
+function normalizeTime(value: string, field: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${field} must be an ISO-8601 timestamp`);
+  }
+  return new Date(timestamp).toISOString();
+}
+
+function requirePositiveInteger(value: number, field: string): void {
+  if (!isPositiveInteger(value)) {
+    throw new Error(`${field} must be a positive integer`);
+  }
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}

--- a/apps/slack-companion/src/operations/status.ts
+++ b/apps/slack-companion/src/operations/status.ts
@@ -1,0 +1,97 @@
+import type {
+  PresenceSnapshotV1,
+  RunReceiptV1,
+} from "@writer/cerebro-sdk";
+
+export type SlackVisibleStatusCode =
+  | "degraded"
+  | "partial_source"
+  | "queued"
+  | "recovering";
+
+export interface SourceCoverage {
+  available_source_count: number;
+  expected_source_count: number;
+}
+
+export interface SlackVisibleStatus {
+  code: SlackVisibleStatusCode;
+  expires_at: string;
+  idempotency_key: string;
+  message: string;
+  observed_at: string;
+  run_id: string;
+}
+
+export function deriveSlackVisibleStatuses(
+  run: RunReceiptV1,
+  presence: PresenceSnapshotV1,
+  now: string,
+  coverage?: SourceCoverage,
+): SlackVisibleStatus[] {
+  if (Date.parse(presence.expires_at) <= Date.parse(now)) {
+    return [];
+  }
+
+  const statuses: SlackVisibleStatus[] = [];
+  if (run.state === "queued") {
+    statuses.push(
+      createStatus(
+        "queued",
+        "Cerebro saved this request. It is queued for execution.",
+        run.run_id,
+        presence,
+      ),
+    );
+  }
+  if (presence.service_state === "degraded") {
+    statuses.push(
+      createStatus(
+        "degraded",
+        "Cerebro accepted this request, but service capacity is reduced. Work remains durably queued.",
+        run.run_id,
+        presence,
+      ),
+    );
+  }
+  if (presence.service_state === "recovering") {
+    statuses.push(
+      createStatus(
+        "recovering",
+        "Cerebro is recovering this request from its last durable checkpoint.",
+        run.run_id,
+        presence,
+      ),
+    );
+  }
+  if (
+    coverage !== undefined &&
+    coverage.available_source_count < coverage.expected_source_count
+  ) {
+    statuses.push(
+      createStatus(
+        "partial_source",
+        `Cerebro can reach ${coverage.available_source_count} of ${coverage.expected_source_count} expected sources. The response will identify missing coverage.`,
+        run.run_id,
+        presence,
+      ),
+    );
+  }
+  return statuses;
+}
+
+function createStatus(
+  code: SlackVisibleStatusCode,
+  message: string,
+  runId: string,
+  presence: PresenceSnapshotV1,
+): SlackVisibleStatus {
+  return {
+    code,
+    expires_at: presence.expires_at,
+    idempotency_key: `${runId}:${code}:${presence.observed_at}`,
+    message,
+    observed_at: presence.observed_at,
+    run_id: runId,
+  };
+}

--- a/apps/slack-companion/src/thread-binding.ts
+++ b/apps/slack-companion/src/thread-binding.ts
@@ -1,0 +1,193 @@
+import { createHash } from "node:crypto";
+import type { DeliveryReceiptV1 } from "@writer/cerebro-sdk";
+
+export type ThreadBindingState = "active" | "closed" | "expired";
+
+export interface SlackThreadBindingV1 {
+  app_id: string;
+  binding_id: string;
+  closed_at?: string;
+  conversation_id: string;
+  created_at: string;
+  delivery_id: string;
+  destination_receipt: string;
+  destination_ref: string;
+  expires_at: string;
+  goal_ref: string;
+  installation_id: string;
+  schema_version: "slack-thread-binding/v1";
+  state: ThreadBindingState;
+  subject_ref: string;
+  thread_binding_id: string;
+  thread_id: string;
+  updated_at: string;
+}
+
+export interface BindSlackThreadRequest {
+  app_id: string;
+  binding_id: string;
+  conversation_id: string;
+  delivery_id: string;
+  destination_receipt: string;
+  expires_at: string;
+  goal_ref: string;
+  installation_id: string;
+  subject_ref: string;
+  thread_id: string;
+}
+
+export interface ThreadBindingCommit {
+  binding: SlackThreadBindingV1;
+  payload_fingerprint: string;
+}
+
+export interface ThreadBindingCommitResult {
+  binding: SlackThreadBindingV1;
+  created: boolean;
+}
+
+export interface ThreadBindingStorePort {
+  /** All writes are durable, idempotent, and compare the stored fingerprint. */
+  close(threadBindingId: string, closedAt: string): Promise<SlackThreadBindingV1>;
+  expire(threadBindingId: string, expiredAt: string): Promise<SlackThreadBindingV1>;
+  putIfAbsent(commit: ThreadBindingCommit): Promise<ThreadBindingCommitResult>;
+  read(threadBindingId: string): Promise<SlackThreadBindingV1 | undefined>;
+}
+
+export interface ThreadBindingClockPort {
+  now(): Date;
+}
+
+export class ThreadBindingConflictError extends Error {}
+export class ThreadBindingInputError extends Error {}
+
+export class SlackThreadBindingCoordinator {
+  constructor(
+    private readonly clock: ThreadBindingClockPort,
+    private readonly store: ThreadBindingStorePort,
+  ) {}
+
+  async bind(
+    request: BindSlackThreadRequest,
+    delivered: DeliveryReceiptV1,
+  ): Promise<ThreadBindingCommitResult> {
+    validateBindingRequest(request);
+    if (delivered.delivery_id !== request.delivery_id) {
+      throw new ThreadBindingInputError(
+        "A thread can only bind to its own delivery.",
+      );
+    }
+    const acceptedPart = delivered.parts.find(
+      (part) =>
+        part.state === "delivered" &&
+        part.destination_receipt === request.destination_receipt,
+    );
+    if (acceptedPart === undefined) {
+      throw new ThreadBindingInputError(
+        "The destination receipt was not persisted on the delivery.",
+      );
+    }
+    const now = this.clock.now().toISOString();
+    if (Date.parse(request.expires_at) <= Date.parse(now)) {
+      throw new ThreadBindingInputError("The thread binding expiry must be future.");
+    }
+    const threadBindingId = threadIdentity(request);
+    const binding: SlackThreadBindingV1 = {
+      app_id: request.app_id,
+      binding_id: request.binding_id,
+      conversation_id: request.conversation_id,
+      created_at: now,
+      delivery_id: request.delivery_id,
+      destination_receipt: request.destination_receipt,
+      destination_ref: delivered.destination_ref,
+      expires_at: request.expires_at,
+      goal_ref: request.goal_ref,
+      installation_id: request.installation_id,
+      schema_version: "slack-thread-binding/v1",
+      state: "active",
+      subject_ref: request.subject_ref,
+      thread_binding_id: threadBindingId,
+      thread_id: request.thread_id,
+      updated_at: now,
+    };
+    return this.store.putIfAbsent({
+      binding,
+      payload_fingerprint: fingerprint(binding),
+    });
+  }
+
+  async resume(
+    request: Pick<
+      BindSlackThreadRequest,
+      "app_id" | "binding_id" | "conversation_id" | "installation_id" | "thread_id"
+    >,
+  ): Promise<SlackThreadBindingV1 | undefined> {
+    if (Object.values(request).some((value) => value.length === 0)) {
+      throw new ThreadBindingInputError("Thread identity fields cannot be empty.");
+    }
+    const id = threadIdentity(request);
+    const binding = await this.store.read(id);
+    if (binding === undefined || binding.state === "closed") {
+      return undefined;
+    }
+    const now = this.clock.now().toISOString();
+    if (binding.state === "expired" || Date.parse(binding.expires_at) <= Date.parse(now)) {
+      await this.store.expire(id, now);
+      return undefined;
+    }
+    return binding;
+  }
+
+  close(threadBindingId: string): Promise<SlackThreadBindingV1> {
+    return this.store.close(threadBindingId, this.clock.now().toISOString());
+  }
+}
+
+function validateBindingRequest(request: BindSlackThreadRequest): void {
+  if (Object.values(request).some((value) => value.length === 0)) {
+    throw new ThreadBindingInputError("Thread binding fields cannot be empty.");
+  }
+  if (!Number.isFinite(Date.parse(request.expires_at))) {
+    throw new ThreadBindingInputError("Thread binding expiry must be a timestamp.");
+  }
+}
+
+function threadIdentity(
+  request: Pick<
+    BindSlackThreadRequest,
+    "app_id" | "binding_id" | "conversation_id" | "installation_id" | "thread_id"
+  >,
+): string {
+  return `thread-${createHash("sha256")
+    .update(
+      JSON.stringify([
+        request.app_id,
+        request.installation_id,
+        request.binding_id,
+        request.conversation_id,
+        request.thread_id,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 32)}`;
+}
+
+function fingerprint(binding: SlackThreadBindingV1): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        app_id: binding.app_id,
+        binding_id: binding.binding_id,
+        conversation_id: binding.conversation_id,
+        delivery_id: binding.delivery_id,
+        destination_receipt: binding.destination_receipt,
+        destination_ref: binding.destination_ref,
+        expires_at: binding.expires_at,
+        goal_ref: binding.goal_ref,
+        installation_id: binding.installation_id,
+        subject_ref: binding.subject_ref,
+        thread_id: binding.thread_id,
+      }),
+    )
+    .digest("hex");
+}

--- a/apps/slack-companion/src/transport/contracts.ts
+++ b/apps/slack-companion/src/transport/contracts.ts
@@ -1,0 +1,161 @@
+import type { CapabilityRequirement, RunKind } from "@writer/cerebro-sdk";
+import type {
+  SlackAdmissionResult,
+  SlackIngressEnvelope,
+} from "../contracts.js";
+
+export type SlackIngressMode = "events_api" | "socket_mode";
+
+export interface SlackTransportRoute {
+  binding_id: string;
+  required_capabilities: CapabilityRequirement[];
+  retention_policy_ref: string;
+  run_kind: RunKind;
+  tenant_id: string;
+}
+
+export interface SlackEventsApiRequest {
+  raw_body: Uint8Array;
+  received_at: string;
+  request_signature: string;
+  request_timestamp: string;
+  route: SlackTransportRoute;
+}
+
+export interface SlackUrlVerificationEnvelope {
+  challenge: string;
+  type: "url_verification";
+}
+
+export interface SlackEventCallbackEnvelope {
+  api_app_id: string;
+  event: Record<string, unknown> & { type: string };
+  event_id: string;
+  event_time: number;
+  team_id: string;
+  type: "event_callback";
+}
+
+export type SlackEventsApiEnvelope =
+  | SlackEventCallbackEnvelope
+  | SlackUrlVerificationEnvelope;
+
+export interface SlackSocketModeEnvelope {
+  accepts_response_payload?: boolean;
+  envelope_id: string;
+  payload: unknown;
+  retry_attempt?: number;
+  retry_reason?: string;
+  type: "events_api" | "interactive" | "slash_commands";
+}
+
+export interface SlackSocketConnectionProof {
+  connection_ref: string;
+  generation: number;
+}
+
+export interface SlackSocketModeRequest {
+  connection: SlackSocketConnectionProof;
+  raw_body: Uint8Array;
+  received_at: string;
+  route: SlackTransportRoute;
+}
+
+export interface InboundPayloadCommit {
+  idempotency_key: string;
+  raw_body: Uint8Array;
+  received_at: string;
+  transport: SlackIngressMode;
+}
+
+export interface InboundPayloadReceipt {
+  digest: string;
+  payload_ref: string;
+}
+
+/**
+ * Stores the exact inbound bytes before normalization or durable admission.
+ * Implementations must return the original receipt for an idempotent retry.
+ */
+export interface DurableInboundPayloadPort {
+  persist(commit: InboundPayloadCommit): Promise<InboundPayloadReceipt>;
+}
+
+export interface DurableSocketPresencePort {
+  /** Confirms that the connection generation is current in durable state. */
+  isActive(proof: SlackSocketConnectionProof): Promise<boolean>;
+}
+
+export interface SlackAdmissionPort {
+  admit(envelope: SlackIngressEnvelope): Promise<SlackAdmissionResult>;
+}
+
+export interface SlackEventNormalizationInput {
+  envelope: SlackEventCallbackEnvelope;
+  payload: InboundPayloadReceipt;
+  received_at: string;
+  route: SlackTransportRoute;
+}
+
+export interface SlackEventNormalizer {
+  normalize(input: SlackEventNormalizationInput): SlackIngressEnvelope;
+}
+
+export interface EventsApiAcknowledgementCommand {
+  body: "";
+  kind: "events_api_ack";
+  status_code: 200;
+}
+
+export interface SocketModeAcknowledgementCommand {
+  envelope_id: string;
+  kind: "socket_mode_ack";
+}
+
+export interface UrlVerificationCommand {
+  body: string;
+  kind: "url_verification";
+  status_code: 200;
+}
+
+export type SlackAcknowledgementCommand =
+  | EventsApiAcknowledgementCommand
+  | SocketModeAcknowledgementCommand;
+
+export type TransportFailureStage =
+  | "verification"
+  | "parsing"
+  | "persistence"
+  | "normalization"
+  | "admission";
+
+export type SlackTransportOutcome =
+  | {
+      command: SlackAcknowledgementCommand;
+      kind: "acknowledge";
+      run_id: string;
+    }
+  | {
+      command: UrlVerificationCommand;
+      kind: "challenge";
+    }
+  | {
+      kind: "no_acknowledgement";
+      reason_code: string;
+      retryable: boolean;
+      stage: TransportFailureStage;
+    };
+
+export interface EventsApiHandlerDependencies {
+  admission: SlackAdmissionPort;
+  clock: { now(): Date };
+  normalizer: SlackEventNormalizer;
+  payloads: DurableInboundPayloadPort;
+}
+
+export interface SocketModeHandlerDependencies {
+  admission: SlackAdmissionPort;
+  normalizer: SlackEventNormalizer;
+  payloads: DurableInboundPayloadPort;
+  presence: DurableSocketPresencePort;
+}

--- a/apps/slack-companion/src/transport/handler.ts
+++ b/apps/slack-companion/src/transport/handler.ts
@@ -1,0 +1,189 @@
+import { createHash } from "node:crypto";
+import type {
+  EventsApiHandlerDependencies,
+  InboundPayloadReceipt,
+  SlackEventCallbackEnvelope,
+  SlackEventsApiRequest,
+  SlackSocketModeRequest,
+  SlackTransportOutcome,
+  SlackTransportRoute,
+  SocketModeHandlerDependencies,
+} from "./contracts.js";
+import {
+  eventCallbackFromSocketMode,
+  parseEventsApiEnvelope,
+  parseSocketModeEnvelope,
+} from "./normalization.js";
+import { verifySlackRequestSignature } from "./signatures.js";
+
+export async function handleEventsApiRequest(
+  request: SlackEventsApiRequest,
+  signingSecret: string | Uint8Array,
+  dependencies: EventsApiHandlerDependencies,
+): Promise<SlackTransportOutcome> {
+  const verification = verifySlackRequestSignature(
+    {
+      now: dependencies.clock.now(),
+      raw_body: request.raw_body,
+      request_signature: request.request_signature,
+      request_timestamp: request.request_timestamp,
+    },
+    signingSecret,
+  );
+  if (!verification.verified) {
+    return noAcknowledgement("verification", verification.reason, false);
+  }
+
+  let parsed;
+  try {
+    parsed = parseEventsApiEnvelope(request.raw_body);
+  } catch {
+    return noAcknowledgement("parsing", "invalid_envelope", false);
+  }
+
+  if (parsed.type === "url_verification") {
+    return {
+      command: {
+        body: parsed.challenge,
+        kind: "url_verification",
+        status_code: 200,
+      },
+      kind: "challenge",
+    };
+  }
+
+  return persistNormalizeAdmit(
+    "events_api",
+    parsed,
+    request.raw_body,
+    request.received_at,
+    request.route,
+    dependencies,
+    () => ({ body: "", kind: "events_api_ack", status_code: 200 }),
+  );
+}
+
+export async function handleSocketModeRequest(
+  request: SlackSocketModeRequest,
+  dependencies: SocketModeHandlerDependencies,
+): Promise<SlackTransportOutcome> {
+  let active = false;
+  try {
+    active = await dependencies.presence.isActive(request.connection);
+  } catch {
+    return noAcknowledgement("verification", "presence_unavailable", true);
+  }
+  if (!active) {
+    return noAcknowledgement("verification", "inactive_connection", false);
+  }
+
+  let envelope;
+  let event;
+  try {
+    envelope = parseSocketModeEnvelope(request.raw_body);
+    event = eventCallbackFromSocketMode(envelope);
+  } catch {
+    return noAcknowledgement("parsing", "invalid_envelope", false);
+  }
+
+  return persistNormalizeAdmit(
+    "socket_mode",
+    event,
+    request.raw_body,
+    request.received_at,
+    request.route,
+    dependencies,
+    () => ({
+      envelope_id: envelope.envelope_id,
+      kind: "socket_mode_ack",
+    }),
+  );
+}
+
+async function persistNormalizeAdmit(
+  transport: "events_api" | "socket_mode",
+  event: SlackEventCallbackEnvelope,
+  rawBody: Uint8Array,
+  receivedAt: string,
+  route: SlackTransportRoute,
+  dependencies:
+    | EventsApiHandlerDependencies
+    | SocketModeHandlerDependencies,
+  acknowledgement: () =>
+    | { body: ""; kind: "events_api_ack"; status_code: 200 }
+    | { envelope_id: string; kind: "socket_mode_ack" },
+): Promise<SlackTransportOutcome> {
+  let payload: InboundPayloadReceipt;
+  try {
+    payload = await dependencies.payloads.persist({
+      idempotency_key: payloadIdempotencyKey(event),
+      raw_body: rawBody,
+      received_at: receivedAt,
+      transport,
+    });
+  } catch {
+    return noAcknowledgement("persistence", "payload_not_durable", true);
+  }
+
+  if (!validPayloadReceipt(payload, rawBody)) {
+    return noAcknowledgement("persistence", "invalid_payload_receipt", true);
+  }
+
+  let normalized;
+  try {
+    normalized = dependencies.normalizer.normalize({
+      envelope: event,
+      payload,
+      received_at: receivedAt,
+      route,
+    });
+  } catch {
+    return noAcknowledgement("normalization", "invalid_event", false);
+  }
+
+  try {
+    const admission = await dependencies.admission.admit(normalized);
+    if (!admission.acknowledgement_permitted) {
+      return noAcknowledgement(
+        "admission",
+        "durable_admission_rejected",
+        admission.retryable,
+      );
+    }
+    return {
+      command: acknowledgement(),
+      kind: "acknowledge",
+      run_id: admission.run_id,
+    };
+  } catch {
+    return noAcknowledgement("admission", "durable_admission_failed", true);
+  }
+}
+
+function payloadIdempotencyKey(event: SlackEventCallbackEnvelope): string {
+  return `slack:${event.api_app_id}:${event.team_id}:${event.event_id}`;
+}
+
+function validPayloadReceipt(
+  receipt: InboundPayloadReceipt,
+  rawBody: Uint8Array,
+): boolean {
+  if (receipt.payload_ref.trim() === "") {
+    return false;
+  }
+  const digest = createHash("sha256").update(rawBody).digest("hex");
+  return receipt.digest === `sha256:${digest}`;
+}
+
+function noAcknowledgement(
+  stage: "verification" | "parsing" | "persistence" | "normalization" | "admission",
+  reasonCode: string,
+  retryable: boolean,
+): SlackTransportOutcome {
+  return {
+    kind: "no_acknowledgement",
+    reason_code: reasonCode,
+    retryable,
+    stage,
+  };
+}

--- a/apps/slack-companion/src/transport/normalization.ts
+++ b/apps/slack-companion/src/transport/normalization.ts
@@ -1,0 +1,201 @@
+import type { SlackIngressEnvelope } from "../contracts.js";
+import type {
+  SlackEventCallbackEnvelope,
+  SlackEventNormalizationInput,
+  SlackEventNormalizer,
+  SlackEventsApiEnvelope,
+  SlackSocketModeEnvelope,
+} from "./contracts.js";
+
+export class StructuralSlackEventNormalizer implements SlackEventNormalizer {
+  normalize(input: SlackEventNormalizationInput): SlackIngressEnvelope {
+    const { envelope, payload, received_at: receivedAt, route } = input;
+    const eventType = requiredString(envelope.event, "type");
+    const conversationId = requiredString(envelope.event, "channel");
+    const eventTimestamp = requiredString(envelope.event, "ts");
+    const threadId = optionalString(envelope.event, "thread_ts") ?? eventTimestamp;
+
+    return {
+      app_id: envelope.api_app_id,
+      binding_id: route.binding_id,
+      conversation_id: conversationId,
+      event_id: envelope.event_id,
+      event_type: eventType,
+      payload_digest: payload.digest,
+      payload_ref: payload.payload_ref,
+      received_at: receivedAt,
+      required_capabilities: route.required_capabilities,
+      retention_policy_ref: route.retention_policy_ref,
+      run_kind: route.run_kind,
+      subject_ref: `slack-thread:${conversationId}:${threadId}`,
+      tenant_id: route.tenant_id,
+      thread_id: threadId,
+    };
+  }
+}
+
+export function parseEventsApiEnvelope(
+  rawBody: Uint8Array,
+): SlackEventsApiEnvelope {
+  const value = parseObject(rawBody);
+  const type = requiredString(value, "type");
+  if (type === "url_verification") {
+    return {
+      challenge: requiredString(value, "challenge"),
+      type,
+    };
+  }
+  if (type !== "event_callback") {
+    throw new Error("unsupported Events API envelope type");
+  }
+
+  const event = requiredObject(value, "event");
+  return {
+    api_app_id: requiredString(value, "api_app_id"),
+    event: { ...event, type: requiredString(event, "type") },
+    event_id: requiredString(value, "event_id"),
+    event_time: requiredNumber(value, "event_time"),
+    team_id: requiredString(value, "team_id"),
+    type,
+  };
+}
+
+export function parseSocketModeEnvelope(
+  rawBody: Uint8Array,
+): SlackSocketModeEnvelope {
+  const value = parseObject(rawBody);
+  const type = requiredString(value, "type");
+  if (
+    type !== "events_api" &&
+    type !== "interactive" &&
+    type !== "slash_commands"
+  ) {
+    throw new Error("unsupported Socket Mode envelope type");
+  }
+  if (!("payload" in value)) {
+    throw new Error("payload is required");
+  }
+  const acceptsResponsePayload = optionalBoolean(
+    value,
+    "accepts_response_payload",
+  );
+  const retryAttempt = optionalNumber(value, "retry_attempt");
+  const retryReason = optionalString(value, "retry_reason");
+  return {
+    ...(acceptsResponsePayload === undefined
+      ? {}
+      : { accepts_response_payload: acceptsResponsePayload }),
+    envelope_id: requiredString(value, "envelope_id"),
+    payload: value.payload,
+    ...(retryAttempt === undefined ? {} : { retry_attempt: retryAttempt }),
+    ...(retryReason === undefined ? {} : { retry_reason: retryReason }),
+    type,
+  };
+}
+
+export function eventCallbackFromSocketMode(
+  envelope: SlackSocketModeEnvelope,
+): SlackEventCallbackEnvelope {
+  if (envelope.type !== "events_api") {
+    throw new Error("unsupported Socket Mode envelope type");
+  }
+  const payload = envelope.payload;
+  if (!isRecord(payload) || payload.type !== "event_callback") {
+    throw new Error("Socket Mode payload must contain an event callback");
+  }
+  const event = requiredObject(payload, "event");
+  return {
+    api_app_id: requiredString(payload, "api_app_id"),
+    event: { ...event, type: requiredString(event, "type") },
+    event_id: requiredString(payload, "event_id"),
+    event_time: requiredNumber(payload, "event_time"),
+    team_id: requiredString(payload, "team_id"),
+    type: "event_callback",
+  };
+}
+
+function parseObject(rawBody: Uint8Array): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(rawBody).toString("utf8"));
+  } catch {
+    throw new Error("request body must be valid JSON");
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("request body must be a JSON object");
+  }
+  return parsed;
+}
+
+function requiredObject(
+  value: Record<string, unknown>,
+  field: string,
+): Record<string, unknown> {
+  const candidate = value[field];
+  if (!isRecord(candidate)) {
+    throw new Error(`${field} must be an object`);
+  }
+  return candidate;
+}
+
+function requiredNumber(value: Record<string, unknown>, field: string): number {
+  const candidate = value[field];
+  if (typeof candidate !== "number" || !Number.isFinite(candidate)) {
+    throw new Error(`${field} must be a number`);
+  }
+  return candidate;
+}
+
+function requiredString(value: Record<string, unknown>, field: string): string {
+  const candidate = value[field];
+  if (typeof candidate !== "string" || candidate.trim() === "") {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return candidate;
+}
+
+function optionalString(
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  const candidate = value[field];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (typeof candidate !== "string" || candidate.trim() === "") {
+    throw new Error(`${field} must be a non-empty string when present`);
+  }
+  return candidate;
+}
+
+function optionalBoolean(
+  value: Record<string, unknown>,
+  field: string,
+): boolean | undefined {
+  const candidate = value[field];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (typeof candidate !== "boolean") {
+    throw new Error(`${field} must be a boolean when present`);
+  }
+  return candidate;
+}
+
+function optionalNumber(
+  value: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const candidate = value[field];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (typeof candidate !== "number" || !Number.isFinite(candidate)) {
+    throw new Error(`${field} must be a number when present`);
+  }
+  return candidate;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/slack-companion/src/transport/readiness.ts
+++ b/apps/slack-companion/src/transport/readiness.ts
@@ -1,0 +1,31 @@
+import type { SlackIngressMode } from "./contracts.js";
+
+export interface SlackIngressCapabilities {
+  durable_presence_relay: boolean;
+  public_ingress: boolean;
+}
+
+export type SlackIngressReadiness =
+  | { ready: true }
+  | {
+      ready: false;
+      reason_code:
+        | "durable_presence_relay_required"
+        | "public_ingress_required";
+    };
+
+export function evaluateSlackIngressReadiness(
+  mode: SlackIngressMode,
+  capabilities: SlackIngressCapabilities,
+): SlackIngressReadiness {
+  if (mode === "events_api" && !capabilities.public_ingress) {
+    return { ready: false, reason_code: "public_ingress_required" };
+  }
+  if (mode === "socket_mode" && !capabilities.durable_presence_relay) {
+    return {
+      ready: false,
+      reason_code: "durable_presence_relay_required",
+    };
+  }
+  return { ready: true };
+}

--- a/apps/slack-companion/src/transport/signatures.ts
+++ b/apps/slack-companion/src/transport/signatures.ts
@@ -1,0 +1,80 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const DEFAULT_SLACK_SIGNATURE_MAX_SKEW_SECONDS = 300;
+
+export type SlackSignatureVerification =
+  | { verified: true }
+  | {
+      reason:
+        | "invalid_signature"
+        | "invalid_timestamp"
+        | "stale_timestamp";
+      verified: false;
+    };
+
+export interface SlackSignatureInput {
+  max_skew_seconds?: number;
+  now: Date;
+  raw_body: Uint8Array;
+  request_signature: string;
+  request_timestamp: string;
+}
+
+/**
+ * Verifies Slack's v0 signature over the exact request bytes. The signing
+ * secret exists only for this call and is not captured or retained.
+ */
+export function verifySlackRequestSignature(
+  input: SlackSignatureInput,
+  signingSecret: string | Uint8Array,
+): SlackSignatureVerification {
+  const timestamp = parseTimestamp(input.request_timestamp);
+  if (timestamp === undefined) {
+    return { reason: "invalid_timestamp", verified: false };
+  }
+
+  const maxSkew =
+    input.max_skew_seconds ?? DEFAULT_SLACK_SIGNATURE_MAX_SKEW_SECONDS;
+  if (!Number.isSafeInteger(maxSkew) || maxSkew < 0) {
+    throw new Error("max_skew_seconds must be a non-negative safe integer");
+  }
+
+  const now = Math.floor(input.now.getTime() / 1_000);
+  if (!Number.isSafeInteger(now)) {
+    throw new Error("now must be a valid date");
+  }
+  if (Math.abs(now - timestamp) > maxSkew) {
+    return { reason: "stale_timestamp", verified: false };
+  }
+
+  const suppliedMatch = /^v0=([a-f0-9]{64})$/i.exec(input.request_signature);
+  if (suppliedMatch === null) {
+    return { reason: "invalid_signature", verified: false };
+  }
+
+  const rawBody = Buffer.from(
+    input.raw_body.buffer,
+    input.raw_body.byteOffset,
+    input.raw_body.byteLength,
+  );
+  const expected = createHmac("sha256", signingSecret)
+    .update("v0:")
+    .update(input.request_timestamp)
+    .update(":")
+    .update(rawBody)
+    .digest();
+  const supplied = Buffer.from(suppliedMatch[1], "hex");
+
+  if (!timingSafeEqual(expected, supplied)) {
+    return { reason: "invalid_signature", verified: false };
+  }
+  return { verified: true };
+}
+
+function parseTimestamp(value: string): number | undefined {
+  if (!/^\d+$/.test(value)) {
+    return undefined;
+  }
+  const timestamp = Number(value);
+  return Number.isSafeInteger(timestamp) ? timestamp : undefined;
+}

--- a/apps/slack-companion/test/delivery.test.ts
+++ b/apps/slack-companion/test/delivery.test.ts
@@ -1,0 +1,483 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type {
+  PlatformAcceptanceReceipt,
+  PlatformDeliveryRequest,
+  WorkLeaseV1,
+} from "../src/delivery/contracts.js";
+import {
+  DeliveryCoordinator,
+  type DeliveryCoordinatorOptions,
+} from "../src/delivery/coordinator.js";
+import type { PlatformDeliveryPort } from "../src/delivery/ports.js";
+import {
+  DeliveryConflictError,
+  DeliveryFenceError,
+  ReferenceMemoryDeliveryStore,
+} from "../src/delivery/reference-store.js";
+
+const start = "2026-07-16T12:00:00.000Z";
+
+describe("DeliveryCoordinator", () => {
+  test("persists every deterministic part before any platform send", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    store.failNextPlan();
+
+    await assert.rejects(() => coordinator.plan(planRequest()));
+    assert.equal(sender.callCount, 0);
+
+    const first = await coordinator.plan(planRequest());
+    const duplicate = await coordinator.plan(planRequest());
+    assert.equal(first.created, true);
+    assert.equal(duplicate.created, false);
+    assert.deepEqual(duplicate.receipt, first.receipt);
+    assert.equal(first.receipt.parts.length, 2);
+    assert.deepEqual(first.receipt.parts.map((part) => part.sequence), [1, 2]);
+    assert.equal(new Set(first.receipt.parts.map((part) => part.part_id)).size, 2);
+    assert.equal(first.receipt.parts.every((part) => part.state === "pending"), true);
+    assert.equal(sender.callCount, 0);
+  });
+
+  test("rejects a changed payload under the same logical delivery identity", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    await coordinator.plan(planRequest());
+
+    await assert.rejects(
+      () =>
+        coordinator.plan(
+          planRequest({
+            parts: [
+              { payload_digest: "sha256:changed", payload_ref: "payload://1" },
+            ],
+          }),
+        ),
+      DeliveryConflictError,
+    );
+    await assert.rejects(
+      () => coordinator.plan(planRequest({ max_attempts: 4 })),
+      DeliveryConflictError,
+    );
+  });
+
+  test("delivers multipart output and persists each acceptance receipt", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(planRequest());
+    const activeLease = lease();
+
+    const first = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      activeLease,
+    );
+    const second = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      activeLease,
+    );
+    const complete = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      activeLease,
+    );
+
+    assert.equal(first.status, "delivered");
+    assert.equal(second.status, "delivered");
+    assert.equal(complete.status, "complete");
+    assert.equal(complete.receipt.state, "completed");
+    assert.equal(
+      complete.receipt.parts.every(
+        (part) => part.state === "delivered" && part.destination_receipt,
+      ),
+      true,
+    );
+    assert.equal(sender.callCount, 2);
+    assert.equal(sender.acceptCount, 2);
+  });
+
+  test("resumes an accepted send after completion persistence fails without reposting", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    store.failNextCompletion();
+
+    await assert.rejects(
+      () => coordinator.deliverNext(planned.receipt.delivery_id, lease()),
+      /injected completion failure/,
+    );
+    assert.equal(sender.acceptCount, 1);
+
+    clock.set("2026-07-16T12:00:31.000Z");
+    const resumed = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      lease({
+        fencing_token: 2,
+        heartbeat_at: "2026-07-16T12:00:31.000Z",
+        lease_expires_at: "2026-07-16T12:01:01.000Z",
+        lease_token: "lease-2",
+      }),
+    );
+
+    assert.equal(resumed.status, "delivered");
+    assert.equal(resumed.receipt.state, "completed");
+    assert.equal(sender.callCount, 2);
+    assert.equal(sender.acceptCount, 1);
+    assert.equal(
+      resumed.receipt.parts[0]?.destination_receipt,
+      sender.acceptedReceipts[0],
+    );
+  });
+
+  test("enforces active generation and fencing ownership", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease(),
+      now: start,
+    });
+
+    await assert.rejects(
+      () =>
+        store.claimNext({
+          delivery_id: planned.receipt.delivery_id,
+          lease: lease({ lease_token: "lease-other", owner_id: "worker-2" }),
+          now: start,
+        }),
+      DeliveryFenceError,
+    );
+    await assert.rejects(
+      () =>
+        store.claimNext({
+          delivery_id: planned.receipt.delivery_id,
+          lease: lease({
+            heartbeat_at: "2026-07-16T12:00:01.000Z",
+            lease_expires_at: "2026-07-16T12:00:40.000Z",
+          }),
+          now: start,
+        }),
+      DeliveryFenceError,
+    );
+
+    store.setActiveGeneration(2);
+    await assert.rejects(
+      () =>
+        store.completePart({
+          accepted_at: start,
+          delivery_id: planned.receipt.delivery_id,
+          destination_receipt: "receipt-1",
+          lease: lease(),
+          part_id: planned.receipt.parts[0]!.part_id,
+        }),
+      DeliveryFenceError,
+    );
+  });
+
+  test("repeats claim and completion safely for the same lease and receipt", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    const activeLease = lease();
+    const claimRequest = {
+      delivery_id: planned.receipt.delivery_id,
+      lease: activeLease,
+      now: start,
+    };
+
+    const firstClaim = await store.claimNext(claimRequest);
+    const duplicateClaim = await store.claimNext(claimRequest);
+    assert.deepEqual(duplicateClaim, firstClaim);
+    assert.equal(firstClaim.status, "claimed");
+    if (firstClaim.status !== "claimed") {
+      assert.fail("expected claimed part");
+    }
+
+    const completion = {
+      accepted_at: start,
+      delivery_id: planned.receipt.delivery_id,
+      destination_receipt: "destination-1",
+      lease: activeLease,
+      part_id: firstClaim.claim.part.part_id,
+    };
+    const firstCompletion = await store.completePart(completion);
+    const duplicateCompletion = await store.completePart(completion);
+    assert.deepEqual(duplicateCompletion, firstCompletion);
+    assert.equal(firstCompletion.state, "completed");
+  });
+
+  test("reclaims an expired part only with a newer fencing value", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease(),
+      now: start,
+    });
+    const recoveryTime = "2026-07-16T12:00:31.000Z";
+
+    await assert.rejects(
+      () =>
+        store.claimNext({
+          delivery_id: planned.receipt.delivery_id,
+          lease: lease({
+            heartbeat_at: recoveryTime,
+            lease_expires_at: "2026-07-16T12:01:01.000Z",
+            lease_token: "lease-reused-fence",
+          }),
+          now: recoveryTime,
+        }),
+      DeliveryFenceError,
+    );
+
+    const recovered = await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease({
+        fencing_token: 2,
+        heartbeat_at: recoveryTime,
+        lease_expires_at: "2026-07-16T12:01:01.000Z",
+        lease_token: "lease-recovery",
+      }),
+      now: recoveryTime,
+    });
+    assert.equal(recovered.status, "claimed");
+    if (recovered.status === "claimed") {
+      assert.equal(recovered.claim.attempt, 2);
+    }
+  });
+
+  test("does not skip a busy earlier part to deliver a later part", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    const planned = await coordinator.plan(planRequest());
+    await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease(),
+      now: start,
+    });
+
+    const blocked = await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease({ fencing_token: 2, lease_token: "lease-2" }),
+      now: start,
+    });
+
+    assert.equal(blocked.status, "idle");
+    if (blocked.status === "idle") {
+      assert.equal(blocked.reason, "busy");
+      assert.equal(blocked.receipt.parts[0]?.state, "delivering");
+      assert.equal(blocked.receipt.parts[1]?.state, "pending");
+    }
+  });
+
+  test("stops retrying when the persisted attempt bound is reached", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    sender.rejectAll = true;
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(
+      planRequest({ max_attempts: 2 }),
+    );
+
+    const first = await coordinator.deliverNext(planned.receipt.delivery_id, lease());
+    const second = await coordinator.deliverNext(planned.receipt.delivery_id, lease());
+    const third = await coordinator.deliverNext(planned.receipt.delivery_id, lease());
+
+    assert.equal(first.status, "retry_scheduled");
+    assert.equal(second.status, "retry_exhausted");
+    assert.equal(third.status, "retry_exhausted");
+    assert.equal(third.receipt.state, "failed");
+    assert.equal(third.receipt.parts[1]?.state, "pending");
+    assert.equal(sender.callCount, 2);
+  });
+
+  test("pauses active work, fences stale resume, and resumes without duplicate send", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    const staleLease = lease();
+    store.failNextCompletion();
+    await assert.rejects(
+      () => coordinator.deliverNext(planned.receipt.delivery_id, staleLease),
+      /injected completion failure/,
+    );
+    assert.equal(store.claimCount(planned.receipt.delivery_id), 1);
+    assert.equal(sender.acceptCount, 1);
+
+    store.setActiveGeneration(2);
+    clock.set("2026-07-16T12:00:10.000Z");
+    const currentLease = lease({
+      fencing_token: 2,
+      generation: 2,
+      heartbeat_at: "2026-07-16T12:00:10.000Z",
+      lease_expires_at: "2026-07-16T12:00:40.000Z",
+      lease_token: "lease-current",
+    });
+    const paused = await coordinator.pause(
+      planned.receipt.delivery_id,
+      currentLease,
+    );
+    assert.equal(paused.state, "paused");
+    assert.equal(paused.parts[0]?.state, "paused");
+    assert.equal(store.claimCount(planned.receipt.delivery_id), 0);
+
+    await assert.rejects(
+      () => coordinator.resume(planned.receipt.delivery_id, staleLease),
+      DeliveryFenceError,
+    );
+    const resumed = await coordinator.resume(
+      planned.receipt.delivery_id,
+      currentLease,
+    );
+    assert.equal(resumed.state, "pending");
+    assert.equal(resumed.parts[0]?.state, "pending");
+
+    const delivered = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      currentLease,
+    );
+    assert.equal(delivered.status, "delivered");
+    assert.equal(delivered.receipt.state, "completed");
+    assert.equal(sender.callCount, 2);
+    assert.equal(sender.acceptCount, 1);
+  });
+
+  test("abandons unfinished parts as a terminal delivery", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(planRequest());
+
+    const abandoned = await coordinator.abandon(
+      planned.receipt.delivery_id,
+      lease(),
+    );
+    const duplicate = await coordinator.abandon(
+      planned.receipt.delivery_id,
+      lease(),
+    );
+    assert.equal(abandoned.state, "abandoned");
+    assert.equal(
+      abandoned.parts.every((deliveryPart) => deliveryPart.state === "abandoned"),
+      true,
+    );
+    assert.deepEqual(duplicate, abandoned);
+
+    const terminal = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      lease(),
+    );
+    assert.equal(terminal.status, "abandoned");
+    assert.equal(sender.callCount, 0);
+    await assert.rejects(
+      () => coordinator.resume(planned.receipt.delivery_id, lease()),
+      DeliveryConflictError,
+    );
+  });
+});
+
+class MutableClock {
+  private instant: string;
+
+  constructor(instant: string) {
+    this.instant = instant;
+  }
+
+  now(): Date {
+    return new Date(this.instant);
+  }
+
+  set(instant: string): void {
+    this.instant = instant;
+  }
+}
+
+class IdempotentSender implements PlatformDeliveryPort {
+  readonly acceptedReceipts: string[] = [];
+  private readonly acceptedByMessage = new Map<string, PlatformAcceptanceReceipt>();
+  callCount = 0;
+  rejectAll = false;
+
+  constructor(private readonly clock: MutableClock) {}
+
+  get acceptCount(): number {
+    return this.acceptedByMessage.size;
+  }
+
+  send(request: PlatformDeliveryRequest): Promise<PlatformAcceptanceReceipt> {
+    this.callCount += 1;
+    if (this.rejectAll) {
+      return Promise.reject(new Error("injected destination rejection"));
+    }
+    const prior = this.acceptedByMessage.get(request.client_message_id);
+    if (prior !== undefined) {
+      return Promise.resolve(prior);
+    }
+    const destinationReceipt = `destination-${this.acceptedByMessage.size + 1}`;
+    const accepted = {
+      accepted_at: this.clock.now().toISOString(),
+      destination_receipt: destinationReceipt,
+    };
+    this.acceptedByMessage.set(request.client_message_id, accepted);
+    this.acceptedReceipts.push(destinationReceipt);
+    return Promise.resolve(accepted);
+  }
+}
+
+function makeCoordinator(
+  clock: MutableClock,
+  store: ReferenceMemoryDeliveryStore,
+  sender: IdempotentSender,
+): DeliveryCoordinator {
+  const options: DeliveryCoordinatorOptions = { clock, sender, store };
+  return new DeliveryCoordinator(options);
+}
+
+function part(sequence: number) {
+  return {
+    payload_digest: `sha256:payload-${sequence}`,
+    payload_ref: `payload://${sequence}`,
+  };
+}
+
+function planRequest(
+  changes: Partial<Parameters<DeliveryCoordinator["plan"]>[0]> = {},
+): Parameters<DeliveryCoordinator["plan"]>[0] {
+  return {
+    delivery_key: "final-response",
+    destination_ref: "conversation://conversation-1/thread-1",
+    max_attempts: 3,
+    parts: [part(1), part(2)],
+    run_id: "run-1",
+    ...changes,
+  };
+}
+
+function lease(changes: Partial<WorkLeaseV1> = {}): WorkLeaseV1 {
+  return {
+    fencing_token: 1,
+    generation: 1,
+    heartbeat_at: start,
+    lease_expires_at: "2026-07-16T12:00:30.000Z",
+    lease_token: "lease-1",
+    owner_id: "worker-1",
+    run_id: "run-1",
+    schema_version: "work-lease/v1",
+    ...changes,
+  };
+}

--- a/apps/slack-companion/test/effect-reconciliation.test.ts
+++ b/apps/slack-companion/test/effect-reconciliation.test.ts
@@ -1,0 +1,501 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { RunReceiptV1, WorkLeaseV1 } from "@writer/cerebro-sdk";
+import { ExecutionCoordinator } from "../src/execution/coordinator.js";
+import {
+  effectIntentDigest,
+  normalizeEffectIntentValue,
+} from "../src/execution/effect-intent.js";
+import {
+  EffectReconciliationBlockedError,
+  ExternalEffectReconciler,
+} from "../src/execution/effect-reconciliation.js";
+import type {
+  ExternalEffectDraft,
+  ExternalEffectInspection,
+  ExternalEffectJob,
+  ExternalEffectPort,
+  ExternalEffectResult,
+  ExternalEffectVerification,
+  RecoverableExternalEffectInspection,
+} from "../src/execution/effect-reconciliation.js";
+import type {
+  ExecutionSession,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
+} from "../src/execution/model.js";
+import { ReferenceMemoryExecutionStore } from "../src/execution/reference-store.js";
+
+describe("ExternalEffectReconciler", () => {
+  test("continues from an immutable intent persisted before the external call", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session(1);
+    const input = effectDraft();
+    const persisted = await fixture.store.persistEffectIntent(
+      session.lease,
+      intentDraft(input),
+      fixture.clock.now().toISOString(),
+    );
+
+    assert.equal(persisted.created, true);
+    assert.deepEqual(persisted.intent.request, {
+      change: { mode: "bounded", target: "opaque-target-1" },
+      scope: "opaque-scope-1",
+    });
+    await assert.rejects(
+      async () => fixture.execution.finishExecution(session),
+      /external intent without a verified effect/,
+    );
+
+    const result = await fixture.reconciler.execute(
+      session,
+      effectJob(session, input),
+      input,
+    );
+
+    assert.equal(result.status, "applied");
+    assert.equal(fixture.external.applyCalls, 1);
+    assert.equal(fixture.external.inspectCalls, 0);
+    assert.equal(
+      (await fixture.store.getEffectIntent(session.run.run_id, input.idempotency_key))
+        ?.request_digest,
+      persisted.intent.request_digest,
+    );
+  });
+
+  test("rejects a changed request under the same durable effect identity", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session(1);
+    const input = effectDraft();
+    await fixture.store.persistEffectIntent(
+      session.lease,
+      intentDraft(input),
+      fixture.clock.now().toISOString(),
+    );
+
+    await assert.rejects(
+      fixture.reconciler.execute(
+        session,
+        effectJob(session, input),
+        {
+          ...input,
+          request: {
+            change: { mode: "expanded", target: "opaque-target-2" },
+            scope: "opaque-scope-1",
+          },
+        },
+      ),
+      /different external intent/,
+    );
+    assert.equal(fixture.external.callCount, 0);
+  });
+
+  test("inspects an outcome-unknown effect after a post-call crash without duplicating it", async () => {
+    const fixture = makeFixture();
+    const firstSession = await fixture.session(1);
+    const input = effectDraft();
+    fixture.external.crashAfterApply = true;
+
+    await assert.rejects(
+      fixture.reconciler.execute(
+        firstSession,
+        effectJob(firstSession, input),
+        input,
+      ),
+      /simulated crash/,
+    );
+    assert.equal(fixture.external.applyCalls, 1);
+
+    const resumed = await fixture.recover(firstSession, 2);
+    fixture.external.crashAfterApply = false;
+    const result = await fixture.reconciler.execute(
+      resumed,
+      effectJob(resumed, input),
+      input,
+    );
+
+    assert.equal(result.status, "recovered");
+    assert.equal(fixture.external.inspectCalls, 1);
+    assert.equal(fixture.external.applyCalls, 1);
+    assert.equal(result.effect.generation, 2);
+  });
+
+  for (const partialState of ["prepared", "materialized"] as const) {
+    test(`resumes the ${partialState} partial window exactly once`, async () => {
+      const fixture = makeFixture();
+      const firstSession = await fixture.session(1);
+      const input = effectDraft();
+      await seedExecuting(fixture, firstSession, input);
+      fixture.external.inspection = {
+        candidate_version: input.candidate_version,
+        resume_token: `resume-${partialState}`,
+        state: partialState,
+      };
+
+      const resumed = await fixture.recover(firstSession, 2);
+      const result = await fixture.reconciler.execute(
+        resumed,
+        effectJob(resumed, input),
+        input,
+      );
+
+      assert.equal(result.status, "recovered");
+      assert.equal(fixture.external.inspectCalls, 1);
+      assert.equal(fixture.external.resumeCalls, 1);
+      assert.equal(fixture.external.applyCalls, 0);
+      assert.equal(fixture.external.inspection.state, "applied");
+    });
+  }
+
+  test("consumes stale generation and fencing jobs without creating an intent", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session(4);
+    const input = effectDraft();
+
+    const staleGeneration = await fixture.reconciler.execute(
+      session,
+      { ...effectJob(session, input), generation: 3 },
+      input,
+    );
+    const staleFence = await fixture.reconciler.execute(
+      session,
+      { ...effectJob(session, input), fencing_token: session.lease.fencing_token + 1 },
+      input,
+    );
+
+    assert.deepEqual(staleGeneration, {
+      reason: "generation_mismatch",
+      status: "stale",
+    });
+    assert.deepEqual(staleFence, {
+      reason: "fencing_token_mismatch",
+      status: "stale",
+    });
+    assert.equal(
+      await fixture.store.getEffectIntent(session.run.run_id, input.idempotency_key),
+      undefined,
+    );
+    assert.equal(fixture.external.callCount, 0);
+  });
+
+  test("consumes a superseded candidate job without retargeting its durable intent", async () => {
+    const fixture = makeFixture();
+    const firstSession = await fixture.session(1);
+    const original = effectDraft("candidate-version-1");
+    const committed = await fixture.store.persistEffectIntent(
+      firstSession.lease,
+      intentDraft(original),
+      fixture.clock.now().toISOString(),
+    );
+    await fixture.execution.release(firstSession);
+    const resumed = await fixture.session(2);
+    const superseding = effectDraft("candidate-version-2");
+
+    const result = await fixture.reconciler.execute(
+      resumed,
+      effectJob(resumed, superseding),
+      superseding,
+    );
+
+    assert.deepEqual(result, {
+      reason: "candidate_version_mismatch",
+      status: "stale",
+    });
+    assert.equal(
+      (await fixture.store.getEffectIntent(resumed.run.run_id, original.idempotency_key))
+        ?.candidate_version,
+      committed.intent.candidate_version,
+    );
+    assert.equal(fixture.external.callCount, 0);
+  });
+
+  for (const blockedState of [
+    "ambiguous",
+    "boundary_mismatch",
+    "target_moved",
+  ] as const) {
+    test(`fails closed when inspection reports ${blockedState}`, async () => {
+      const fixture = makeFixture();
+      const firstSession = await fixture.session(1);
+      const input = effectDraft();
+      await seedExecuting(fixture, firstSession, input);
+      fixture.external.inspection = {
+        reason_code: `fake-${blockedState}`,
+        state: blockedState,
+      };
+      const resumed = await fixture.recover(firstSession, 2);
+
+      await assert.rejects(
+        fixture.reconciler.execute(
+          resumed,
+          effectJob(resumed, input),
+          input,
+        ),
+        (error: unknown) =>
+          error instanceof EffectReconciliationBlockedError &&
+          error.code === blockedState,
+      );
+      assert.equal(fixture.external.inspectCalls, 1);
+      assert.equal(fixture.external.applyCalls, 0);
+      assert.equal(fixture.external.resumeCalls, 0);
+      assert.equal(
+        (await fixture.store.getEffect(resumed.run.run_id, input.idempotency_key))
+          ?.state,
+        "unknown",
+      );
+    });
+  }
+
+  test("returns the terminal effect on an exact retry without another external call", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session(1);
+    const input = effectDraft();
+
+    const first = await fixture.reconciler.execute(
+      session,
+      effectJob(session, input),
+      input,
+    );
+    const duplicate = await fixture.reconciler.execute(
+      session,
+      effectJob(session, input),
+      input,
+    );
+
+    assert.equal(first.status, "applied");
+    assert.equal(duplicate.status, "duplicate");
+    assert.equal(fixture.external.applyCalls, 1);
+    assert.equal(fixture.external.inspectCalls, 0);
+    assert.equal(fixture.external.verifyCalls, 1);
+  });
+});
+
+function makeFixture(runId = "run-effect-1") {
+  const clock = new MutableClock();
+  const store = new ReferenceMemoryExecutionStore();
+  store.seedRun(runReceipt(runId));
+  const execution = new ExecutionCoordinator({
+    clock,
+    lease_duration_ms: 30_000,
+    store,
+  });
+  const external = new FakeExternalEffectPort();
+  const reconciler = new ExternalEffectReconciler({
+    clock,
+    execution,
+    external,
+    store,
+  });
+
+  const session = async (generation: number): Promise<ExecutionSession> => {
+    const result = await execution.start({
+      generation,
+      lease_token: `lease-${generation}`,
+      owner_id: `worker-${generation}`,
+      run_id: runId,
+      service_state: "ready",
+    });
+    if (result.status === "not_runnable") {
+      throw new Error("fixture run was not runnable");
+    }
+    return result.session;
+  };
+
+  return {
+    clock,
+    execution,
+    external,
+    reconciler,
+    recover: async (
+      staleSession: ExecutionSession,
+      generation: number,
+    ): Promise<ExecutionSession> => {
+      clock.advance(31_000);
+      assert.equal((await execution.reconcileExpired()).length, 1);
+      assert.equal(
+        (await store.getEffect(staleSession.run.run_id, effectDraft().idempotency_key))
+          ?.state,
+        "unknown",
+      );
+      return session(generation);
+    },
+    session,
+    store,
+  };
+}
+
+class FakeExternalEffectPort implements ExternalEffectPort {
+  applyCalls = 0;
+  crashAfterApply = false;
+  inspectCalls = 0;
+  inspection: ExternalEffectInspection = { state: "absent" };
+  resumeCalls = 0;
+  verifyCalls = 0;
+
+  get callCount(): number {
+    return this.applyCalls + this.inspectCalls + this.resumeCalls + this.verifyCalls;
+  }
+
+  apply(
+    intent: ExternalEffectIntentV1,
+    _lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult> {
+    this.applyCalls += 1;
+    const result = externalResult(intent.candidate_version);
+    this.inspection = { result, state: "applied" };
+    if (this.crashAfterApply) {
+      return Promise.reject(new Error("simulated crash after external apply"));
+    }
+    return Promise.resolve(result);
+  }
+
+  inspect(
+    _intent: ExternalEffectIntentV1,
+    _lease: WorkLeaseV1,
+  ): Promise<ExternalEffectInspection> {
+    this.inspectCalls += 1;
+    return Promise.resolve(structuredClone(this.inspection));
+  }
+
+  resume(
+    intent: ExternalEffectIntentV1,
+    _inspection: RecoverableExternalEffectInspection,
+    _lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult> {
+    this.resumeCalls += 1;
+    const result = externalResult(intent.candidate_version);
+    this.inspection = { result, state: "applied" };
+    return Promise.resolve(result);
+  }
+
+  verify(
+    intent: ExternalEffectIntentV1,
+    _result: ExternalEffectResult,
+    _lease: WorkLeaseV1,
+  ): Promise<ExternalEffectVerification> {
+    this.verifyCalls += 1;
+    return Promise.resolve({
+      candidate_version: intent.candidate_version,
+      receipt_ref: `verification://${intent.effect_id}`,
+      state: "verified",
+    });
+  }
+}
+
+async function seedExecuting(
+  fixture: ReturnType<typeof makeFixture>,
+  session: ExecutionSession,
+  draft: ExternalEffectDraft,
+): Promise<void> {
+  const committed = await fixture.store.persistEffectIntent(
+    session.lease,
+    intentDraft(draft),
+    fixture.clock.now().toISOString(),
+  );
+  await fixture.execution.beginEffect(session, {
+    approval_ref: committed.intent.approval_ref,
+    approval_required: committed.intent.approval_required,
+    effect_id: committed.intent.effect_id,
+    idempotency_key: committed.intent.idempotency_key,
+    request_digest: committed.intent.request_digest,
+    rollback_plan_ref: committed.intent.rollback_plan_ref,
+    step_id: committed.intent.step_id,
+    target_ref: committed.intent.target_ref,
+  });
+  await fixture.execution.markEffectExecuting(
+    session,
+    committed.intent.idempotency_key,
+  );
+}
+
+function effectDraft(candidateVersion = "candidate-version-1"): ExternalEffectDraft {
+  return {
+    approval_ref: "approval://effect-1",
+    approval_required: true,
+    candidate_version: candidateVersion,
+    effect_id: "effect-1",
+    idempotency_key: "turn-1:step-1",
+    request: {
+      scope: "opaque-scope-1",
+      change: { mode: "bounded", target: "opaque-target-1" },
+    },
+    rollback_plan_ref: "rollback://effect-1",
+    step_id: "step-1",
+    target_ref: "target://opaque-1",
+  };
+}
+
+function intentDraft(draft: ExternalEffectDraft): ExternalEffectIntentDraft {
+  const request = normalizeEffectIntentValue(draft.request);
+  const intentFields = {
+    approval_ref: draft.approval_ref,
+    approval_required: draft.approval_required,
+    candidate_version: draft.candidate_version,
+    effect_id: draft.effect_id,
+    idempotency_key: draft.idempotency_key,
+    request,
+    rollback_plan_ref: draft.rollback_plan_ref,
+    step_id: draft.step_id,
+    target_ref: draft.target_ref,
+  };
+  return {
+    ...intentFields,
+    request_digest: effectIntentDigest(intentFields),
+  };
+}
+
+function effectJob(
+  session: ExecutionSession,
+  draft: ExternalEffectDraft,
+): ExternalEffectJob {
+  return {
+    candidate_version: draft.candidate_version,
+    fencing_token: session.lease.fencing_token,
+    generation: session.lease.generation,
+    idempotency_key: draft.idempotency_key,
+    lease_token: session.lease.lease_token,
+    run_id: session.run.run_id,
+  };
+}
+
+function externalResult(candidateVersion: string): ExternalEffectResult {
+  return {
+    candidate_version: candidateVersion,
+    result_digest: `sha256:result-${candidateVersion}`,
+    result_ref: `result://${candidateVersion}`,
+  };
+}
+
+class MutableClock {
+  private milliseconds = Date.parse("2026-07-16T12:00:00.000Z");
+
+  advance(durationMs: number): void {
+    this.milliseconds += durationMs;
+  }
+
+  now(): Date {
+    return new Date(this.milliseconds);
+  }
+}
+
+function runReceipt(runId: string): RunReceiptV1 {
+  const now = "2026-07-16T11:59:00.000Z";
+  return {
+    admitted_at: now,
+    binding_id: "binding-1",
+    idempotency_key: `event:${runId}`,
+    input_digest: "sha256:input",
+    receipt_id: `receipt-${runId}`,
+    received_at: now,
+    required_capabilities: [],
+    retention_policy_ref: "retention://default",
+    revision: 1,
+    run_id: runId,
+    run_kind: "interactive",
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: "conversation://opaque/thread",
+    tenant_id: "tenant-1",
+    updated_at: now,
+  };
+}

--- a/apps/slack-companion/test/execution-continuity.test.ts
+++ b/apps/slack-companion/test/execution-continuity.test.ts
@@ -1,0 +1,414 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { RunReceiptV1 } from "@writer/cerebro-sdk";
+import {
+  ExecutionCoordinator,
+  ExecutionInvariantError,
+} from "../src/execution/coordinator.js";
+import type {
+  CheckpointDraft,
+  ExecutionSession,
+  ServiceAvailabilityState,
+} from "../src/execution/model.js";
+import {
+  ReferenceMemoryExecutionStore,
+  StaleLeaseError,
+} from "../src/execution/reference-store.js";
+
+describe("ExecutionCoordinator", () => {
+  test("claims a turn idempotently and admits leases only while executable", async () => {
+    const fixture = makeFixture();
+    const first = await fixture.start("ready", 1, "worker-a", "lease-a");
+    const duplicate = await fixture.start("ready", 1, "worker-a", "lease-a");
+    const competing = await fixture.start("ready", 1, "worker-b", "lease-b");
+
+    if (first.status === "not_runnable" || duplicate.status === "not_runnable") {
+      assert.fail("expected the stable lease claim to be idempotent");
+    }
+    assert.equal(first.status, "started");
+    assert.equal(duplicate.status, "started");
+    assert.equal(competing.status, "not_runnable");
+    assert.equal(
+      duplicate.session.lease.fencing_token,
+      first.session.lease.fencing_token,
+    );
+    assert.equal(duplicate.session.run.revision, first.session.run.revision);
+
+    assert.equal((await fixture.coordinator.release(first.session)).state, "queued");
+    const replacement = await fixture.start("ready", 2, "worker-b", "lease-b");
+    if (replacement.status === "not_runnable") {
+      assert.fail("expected released work to be claimable");
+    }
+    assert.equal(
+      replacement.session.lease.fencing_token,
+      first.session.lease.fencing_token + 1,
+    );
+
+    for (const state of ["draining", "recovering", "offline"] as const) {
+      const other = makeFixture(`run-${state}`);
+      assert.equal(
+        (await other.start(state, 2, "worker-c", `lease-${state}`)).status,
+        "not_runnable",
+      );
+    }
+  });
+
+  test("renews ownership and rejects the pre-renewal proof", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+    fixture.clock.advance(1_000);
+
+    const renewed = await fixture.coordinator.renew(session.lease);
+
+    assert.equal(renewed.fencing_token, session.lease.fencing_token);
+    assert.notEqual(renewed.lease_expires_at, session.lease.lease_expires_at);
+    await assert.rejects(
+      async () => fixture.coordinator.checkpoint(session, checkpoint(1)),
+      StaleLeaseError,
+    );
+  });
+
+  test("checkpoints before drain pause and resumes on a newer generation", async () => {
+    const fixture = makeFixture();
+    const oldSession = await fixture.session();
+
+    const paused = await fixture.coordinator.pauseForDrain(
+      oldSession,
+      checkpoint(1),
+    );
+    assert.equal(paused.run.state, "paused");
+    assert.equal(paused.checkpoint.resume_cursor, "cursor-1");
+
+    const resumed = await fixture.start("ready", 2, "worker-b", "lease-b");
+    if (resumed.status === "not_runnable") {
+      assert.fail("expected a resumable run");
+    }
+    assert.equal(resumed.status, "resumed");
+    assert.equal(resumed.session.checkpoint?.sequence, 1);
+    assert.equal(resumed.session.lease.generation, 2);
+    assert.equal(
+      resumed.session.lease.fencing_token,
+      oldSession.lease.fencing_token + 1,
+    );
+
+    await assert.rejects(
+      async () => fixture.coordinator.checkpoint(oldSession, checkpoint(2)),
+      StaleLeaseError,
+    );
+    await assert.rejects(
+      async () => fixture.coordinator.beginEffect(oldSession, effect()),
+      StaleLeaseError,
+    );
+    await assert.rejects(
+      async () => fixture.coordinator.finishExecution(oldSession),
+      StaleLeaseError,
+    );
+  });
+
+  test("rejects generation regression after release and expiry recovery", async () => {
+    const fixture = makeFixture();
+
+    for (const invalid of [
+      { generation: 0, ownerId: "worker-a", leaseToken: "lease-a" },
+      { generation: 1, ownerId: " ", leaseToken: "lease-a" },
+      { generation: 1, ownerId: "worker-a", leaseToken: " " },
+    ]) {
+      await assert.rejects(
+        async () =>
+          fixture.start(
+            "ready",
+            invalid.generation,
+            invalid.ownerId,
+            invalid.leaseToken,
+          ),
+        ExecutionInvariantError,
+      );
+    }
+
+    const generationFour = await fixture.start(
+      "ready",
+      4,
+      "worker-a",
+      "lease-a",
+    );
+    if (generationFour.status === "not_runnable") {
+      assert.fail("expected generation four to claim the run");
+    }
+    await fixture.coordinator.release(generationFour.session);
+    await assert.rejects(
+      async () => fixture.start("ready", 3, "worker-b", "lease-b"),
+      ExecutionInvariantError,
+    );
+
+    const generationFive = await fixture.start(
+      "ready",
+      5,
+      "worker-b",
+      "lease-b",
+    );
+    assert.notEqual(generationFive.status, "not_runnable");
+    fixture.clock.advance(31_000);
+    assert.equal((await fixture.coordinator.reconcileExpired()).length, 1);
+    await assert.rejects(
+      async () => fixture.start("ready", 4, "worker-c", "lease-c"),
+      ExecutionInvariantError,
+    );
+  });
+
+  test("accepts only exact checkpoint retries for the same sequence", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+    const original = checkpoint(1);
+    const first = await fixture.coordinator.checkpoint(session, original);
+    fixture.clock.advance(1_000);
+    const duplicate = await fixture.coordinator.checkpoint(session, original);
+
+    assert.deepEqual(duplicate, first);
+    for (const conflict of [
+      { ...original, checkpoint_id: "checkpoint-other" },
+      { ...original, completed_step_ids: ["step-other"] },
+      { ...original, effect_receipt_ids: ["effect-other"] },
+      { ...original, resume_cursor: "cursor-other" },
+    ]) {
+      await assert.rejects(
+        async () => fixture.coordinator.checkpoint(session, conflict),
+        ExecutionInvariantError,
+      );
+    }
+  });
+
+  test("records effect intent before execution and requires approval and verification", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    await assert.rejects(
+      fixture.coordinator.beginEffect(session, {
+        ...effect(),
+        approval_ref: undefined,
+      }),
+      ExecutionInvariantError,
+    );
+
+    const planned = await fixture.coordinator.beginEffect(session, effect());
+    const duplicate = await fixture.coordinator.beginEffect(session, effect());
+    assert.equal(planned.state, "planned");
+    assert.equal(duplicate.effect_id, planned.effect_id);
+
+    const executing = await fixture.coordinator.markEffectExecuting(
+      session,
+      effect().idempotency_key,
+    );
+    assert.equal(executing.state, "executing");
+
+    await assert.rejects(
+      fixture.coordinator.resolveEffect(session, effect().idempotency_key, {
+        result_digest: "sha256:result",
+        result_ref: "result://effect-1",
+        state: "succeeded",
+        verification_receipt_ref: "verification://effect-1",
+        verification_state: "failed",
+      }),
+      ExecutionInvariantError,
+    );
+
+    const resolved = await fixture.coordinator.resolveEffect(
+      session,
+      effect().idempotency_key,
+      {
+        result_digest: "sha256:result",
+        result_ref: "result://effect-1",
+        state: "succeeded",
+        verification_receipt_ref: "verification://effect-1",
+        verification_state: "verified",
+      },
+    );
+    assert.equal(resolved.state, "succeeded");
+    assert.equal(resolved.verification_state, "verified");
+    assert.equal(
+      (await fixture.coordinator.finishExecution(session)).state,
+      "delivering",
+    );
+    assert.equal(
+      (await fixture.start("ready", 2, "worker-b", "lease-b")).status,
+      "not_runnable",
+    );
+  });
+
+  test("keeps a verified failed effect terminal and blocks delivery handoff", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+    await fixture.coordinator.beginEffect(session, effect());
+    await fixture.coordinator.markEffectExecuting(
+      session,
+      effect().idempotency_key,
+    );
+
+    const failed = await fixture.coordinator.resolveEffect(
+      session,
+      effect().idempotency_key,
+      {
+        result_digest: "sha256:failure",
+        result_ref: "result://failure",
+        state: "failed",
+        verification_receipt_ref: "verification://failure",
+        verification_state: "verified",
+      },
+    );
+
+    assert.equal(failed.state, "failed");
+    await assert.rejects(
+      async () => fixture.coordinator.finishExecution(session),
+      ExecutionInvariantError,
+    );
+  });
+
+  test("recovers an expired run and preserves uncertain effect truth", async () => {
+    const fixture = makeFixture();
+    const staleSession = await fixture.session();
+    await fixture.coordinator.beginEffect(staleSession, effect());
+    await fixture.coordinator.markEffectExecuting(
+      staleSession,
+      effect().idempotency_key,
+    );
+
+    fixture.clock.advance(31_000);
+    const recovered = await fixture.coordinator.reconcileExpired();
+
+    assert.equal(recovered.length, 1);
+    assert.equal(recovered[0]?.run?.state, "queued");
+    assert.deepEqual(recovered[0]?.uncertain_effect_ids, ["effect-1"]);
+    assert.equal(
+      (await fixture.store.getEffect("run-1", effect().idempotency_key))?.state,
+      "unknown",
+    );
+    await assert.rejects(
+      async () => fixture.coordinator.checkpoint(staleSession, checkpoint(1)),
+      StaleLeaseError,
+    );
+
+    const resumed = await fixture.start("ready", 2, "worker-b", "lease-b");
+    if (resumed.status === "not_runnable") {
+      assert.fail("expected recovered work to be runnable");
+    }
+    const adopted = await fixture.coordinator.beginEffect(
+      resumed.session,
+      effect(),
+    );
+    assert.equal(adopted.state, "unknown");
+    const verified = await fixture.coordinator.resolveEffect(
+      resumed.session,
+      effect().idempotency_key,
+      {
+        result_digest: "sha256:observed-result",
+        result_ref: "result://observed-effect-1",
+        state: "succeeded",
+        verification_receipt_ref: "verification://observed-effect-1",
+        verification_state: "verified",
+      },
+    );
+    assert.equal(verified.generation, 2);
+    assert.equal(verified.fencing_token, resumed.session.lease.fencing_token);
+    assert.equal(
+      (await fixture.coordinator.finishExecution(resumed.session)).state,
+      "delivering",
+    );
+  });
+});
+
+function makeFixture(runId = "run-1") {
+  const clock = new MutableClock();
+  const store = new ReferenceMemoryExecutionStore();
+  store.seedRun(runReceipt(runId));
+  const coordinator = new ExecutionCoordinator({
+    clock,
+    lease_duration_ms: 30_000,
+    store,
+  });
+
+  const start = (
+    serviceState: ServiceAvailabilityState,
+    generation: number,
+    ownerId: string,
+    leaseToken: string,
+  ) =>
+    coordinator.start({
+      generation,
+      lease_token: leaseToken,
+      owner_id: ownerId,
+      run_id: runId,
+      service_state: serviceState,
+    });
+
+  return {
+    clock,
+    coordinator,
+    session: async (): Promise<ExecutionSession> => {
+      const result = await start("ready", 1, "worker-a", "lease-a");
+      if (result.status === "not_runnable") {
+        throw new Error("fixture run was not runnable");
+      }
+      return result.session;
+    },
+    start,
+    store,
+  };
+}
+
+class MutableClock {
+  private milliseconds = Date.parse("2026-07-16T12:00:00.000Z");
+
+  advance(durationMs: number): void {
+    this.milliseconds += durationMs;
+  }
+
+  now(): Date {
+    return new Date(this.milliseconds);
+  }
+}
+
+function runReceipt(runId: string): RunReceiptV1 {
+  const now = "2026-07-16T11:59:00.000Z";
+  return {
+    admitted_at: now,
+    binding_id: "binding-1",
+    idempotency_key: `event:${runId}`,
+    input_digest: "sha256:input",
+    receipt_id: `receipt-${runId}`,
+    received_at: now,
+    required_capabilities: [],
+    retention_policy_ref: "retention://default",
+    revision: 1,
+    run_id: runId,
+    run_kind: "interactive",
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: "slack-thread://conversation/thread",
+    tenant_id: "tenant-1",
+    updated_at: now,
+  };
+}
+
+function checkpoint(sequence: number): CheckpointDraft {
+  return {
+    checkpoint_id: `checkpoint-${sequence}`,
+    completed_step_ids: [`step-${sequence}`],
+    effect_receipt_ids: [],
+    payload_digest: `sha256:checkpoint-${sequence}`,
+    payload_ref: `checkpoint://payload-${sequence}`,
+    resume_cursor: `cursor-${sequence}`,
+    sequence,
+  };
+}
+
+function effect() {
+  return {
+    approval_ref: "approval://effect-1",
+    approval_required: true,
+    effect_id: "effect-1",
+    idempotency_key: "turn-1:step-1",
+    request_digest: "sha256:request",
+    rollback_plan_ref: "rollback://effect-1",
+    step_id: "step-1",
+    target_ref: "resource://target-1",
+  } as const;
+}

--- a/apps/slack-companion/test/mission-bridge.test.ts
+++ b/apps/slack-companion/test/mission-bridge.test.ts
@@ -1,0 +1,421 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { RunReceiptV1 } from "@writer/cerebro-sdk";
+import { ExecutionCoordinator } from "../src/execution/coordinator.js";
+import type {
+  ExecutionSession,
+  ServiceAvailabilityState,
+} from "../src/execution/model.js";
+import { ReferenceMemoryExecutionStore } from "../src/execution/reference-store.js";
+import {
+  MissionBridgeCoordinator,
+  MissionBridgeInvariantError,
+} from "../src/mission/coordinator.js";
+import type {
+  MissionDecisionProjectionV1,
+  MissionPlanProjectionV1,
+  MissionVerificationProjectionV1,
+} from "../src/mission/model.js";
+
+describe("MissionBridgeCoordinator", () => {
+  test("projects missing inputs and capability bindings to explicit waits", () => {
+    const fixture = makeFixture();
+
+    assert.deepEqual(
+      fixture.bridge.readiness(plan(), {
+        capability_bindings: [],
+        missing_input_refs: ["input-request://scope"],
+      }),
+      {
+        kind: "missing_input",
+        status: "waiting",
+        waiting_on_ref: "input-request://scope",
+      },
+    );
+    assert.deepEqual(
+      fixture.bridge.readiness(plan(), {
+        capability_bindings: [],
+        missing_input_refs: [],
+      }),
+      {
+        kind: "missing_tool_binding",
+        status: "waiting",
+        waiting_on_ref: "capability://bounded-action/v1",
+      },
+    );
+    assert.deepEqual(
+      fixture.bridge.readiness(plan(), {
+        capability_bindings: [capabilityBinding("bound")],
+        missing_input_refs: [],
+      }),
+      { status: "ready" },
+    );
+  });
+
+  test("waits durably and resumes from the mission checkpoint", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    const waiting = await fixture.bridge.wait(session, plan(), {
+      checkpoint_id: "checkpoint-wait-1",
+      completed_step_ids: [],
+      effect_receipt_ids: [],
+      kind: "missing_input",
+      sequence: 1,
+      state_receipt: receipt("mission-state://wait-1", "sha256:wait-1"),
+      waiting_on_ref: "input-request://scope",
+    });
+
+    assert.equal(waiting.run.state, "waiting");
+    assert.equal(waiting.checkpoint.waiting_on_ref, "input-request://scope");
+    assert.equal(waiting.checkpoint.payload_digest, "sha256:wait-1");
+    assert.notEqual(waiting.run.state, "completed");
+
+    const resumed = await fixture.start("ready", 2, "executor-b", "lease-b");
+    if (resumed.status === "not_runnable") {
+      assert.fail("expected a waiting mission run to resume");
+    }
+    assert.equal(resumed.status, "resumed");
+    assert.equal(resumed.session.run.state, "running");
+    assert.equal(resumed.session.checkpoint?.checkpoint_id, "checkpoint-wait-1");
+    assert.equal(resumed.session.lease.generation, 2);
+  });
+
+  test("keeps drain pause resumable instead of reporting completion", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    const paused = await fixture.bridge.pauseForDrain(session, plan(), {
+      checkpoint_id: "checkpoint-drain-1",
+      completed_step_ids: [],
+      effect_receipt_ids: [],
+      sequence: 1,
+      state_receipt: receipt("mission-state://drain-1", "sha256:drain-1"),
+    });
+
+    assert.equal(paused.run.state, "paused");
+    assert.notEqual(paused.run.state, "completed");
+    const resumed = await fixture.start("ready", 2, "executor-b", "lease-b");
+    assert.notEqual(resumed.status, "not_runnable");
+  });
+
+  test("requires evidence-backed approval, rollback, and independent verification", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    await assert.rejects(
+      fixture.bridge.beginEffect(session, plan(), "step-1"),
+      MissionBridgeInvariantError,
+    );
+    await assert.rejects(
+      fixture.bridge.beginEffect(
+        session,
+        plan(),
+        "step-1",
+        decision("rejected"),
+      ),
+      MissionBridgeInvariantError,
+    );
+    await assert.rejects(
+      async () =>
+        fixture.bridge.beginEffect(session, plan(), "step-1", {
+          ...decision("approved"),
+          plan_digest: "sha256:another-plan",
+        }),
+      MissionBridgeInvariantError,
+    );
+
+    const planned = await fixture.bridge.beginEffect(
+      session,
+      plan(),
+      "step-1",
+      decision("approved"),
+    );
+    assert.equal(planned.approval_ref, "decision://approval-1");
+    assert.equal(planned.rollback_plan_ref, "rollback://step-1");
+    assert.equal(planned.request_digest, "sha256:effect-request-1");
+
+    await fixture.bridge.markEffectExecuting(session, plan(), "step-1");
+    await assert.rejects(
+      async () =>
+        fixture.bridge.resolveEffect(session, plan(), "step-1", {
+          executor_ref: "actor://executor-a",
+          result: receipt("effect-result://step-1", "sha256:effect-result-1"),
+          state: "succeeded",
+          verification: {
+            ...verification(),
+            verifier_ref: "actor://executor-a",
+          },
+        }),
+      MissionBridgeInvariantError,
+    );
+    await assert.rejects(
+      async () =>
+        fixture.bridge.resolveEffect(session, plan(), "step-1", {
+          executor_ref: "actor://executor-a",
+          result: receipt("effect-result://step-1", "sha256:effect-result-1"),
+          state: "succeeded",
+          verification: {
+            ...verification(),
+            evidence: [
+              {
+                ...evidence(),
+                source_revision: "source-revision-unrelated",
+              },
+            ],
+          },
+        }),
+      /verification evidence does not prove the observed source revision/,
+    );
+
+    const resolved = await fixture.bridge.resolveEffect(
+      session,
+      plan(),
+      "step-1",
+      {
+        executor_ref: "actor://executor-a",
+        result: receipt("effect-result://step-1", "sha256:effect-result-1"),
+        state: "succeeded",
+        verification: verification(),
+      },
+    );
+    assert.equal(resolved.state, "succeeded");
+    assert.equal(resolved.result_digest, "sha256:effect-result-1");
+    assert.equal(resolved.verification_receipt_ref, "verification://step-1");
+    assert.equal(resolved.verification_state, "verified");
+  });
+
+  test("hands off to delivery only after evidence-backed verified closure", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+    await resolveEffect(fixture, session);
+
+    await assert.rejects(
+      fixture.bridge.close(session, plan(), {
+        armed_wake_condition_refs: [],
+        checkpoint_id: "checkpoint-close-invalid",
+        completed_step_ids: ["step-1"],
+        desired_condition_verified: true,
+        effect_receipt_ids: ["effect-receipt://step-1"],
+        executor_ref: "actor://executor-a",
+        sequence: 1,
+        verification: {
+          ...verification(),
+          observed_source_revision: "source-revision-1",
+        },
+      }),
+      MissionBridgeInvariantError,
+    );
+
+    const closed = await fixture.bridge.close(session, plan(), {
+      armed_wake_condition_refs: [],
+      checkpoint_id: "checkpoint-close-1",
+      completed_step_ids: ["step-1"],
+      desired_condition_verified: true,
+      effect_receipt_ids: ["effect-receipt://step-1"],
+      executor_ref: "actor://executor-a",
+      sequence: 1,
+      verification: verification(),
+    });
+
+    assert.equal(closed.checkpoint.payload_ref, "verification://step-1");
+    assert.equal(closed.checkpoint.payload_digest, "sha256:verification-1");
+    assert.equal(closed.run.state, "delivering");
+    assert.notEqual(closed.run.state, "completed");
+  });
+
+  test("rejects a plan that does not match the native contract or run", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    await assert.rejects(
+      async () =>
+        fixture.bridge.wait(
+          session,
+          { ...plan(), run_id: "run-other" },
+          {
+            checkpoint_id: "checkpoint-invalid",
+            completed_step_ids: [],
+            effect_receipt_ids: [],
+            kind: "decision_required",
+            sequence: 1,
+            state_receipt: receipt(
+              "mission-state://invalid",
+              "sha256:invalid",
+            ),
+            waiting_on_ref: "decision-request://invalid",
+          },
+        ),
+      MissionBridgeInvariantError,
+    );
+    assert.throws(
+      () =>
+        fixture.bridge.readiness(
+          {
+            ...plan(),
+            mission_schema_version: "cerebro.control-kernel.v2" as never,
+          },
+          { capability_bindings: [], missing_input_refs: [] },
+        ),
+      MissionBridgeInvariantError,
+    );
+  });
+});
+
+async function resolveEffect(
+  fixture: ReturnType<typeof makeFixture>,
+  session: ExecutionSession,
+): Promise<void> {
+  await fixture.bridge.beginEffect(
+    session,
+    plan(),
+    "step-1",
+    decision("approved"),
+  );
+  await fixture.bridge.markEffectExecuting(session, plan(), "step-1");
+  await fixture.bridge.resolveEffect(session, plan(), "step-1", {
+    executor_ref: "actor://executor-a",
+    result: receipt("effect-result://step-1", "sha256:effect-result-1"),
+    state: "succeeded",
+    verification: verification(),
+  });
+}
+
+function makeFixture(runId = "run-1") {
+  const clock = new FixedClock();
+  const store = new ReferenceMemoryExecutionStore();
+  store.seedRun(runReceipt(runId));
+  const execution = new ExecutionCoordinator({
+    clock,
+    lease_duration_ms: 30_000,
+    store,
+  });
+  const start = (
+    serviceState: ServiceAvailabilityState,
+    generation: number,
+    ownerId: string,
+    leaseToken: string,
+  ) =>
+    execution.start({
+      generation,
+      lease_token: leaseToken,
+      owner_id: ownerId,
+      run_id: runId,
+      service_state: serviceState,
+    });
+  return {
+    bridge: new MissionBridgeCoordinator(execution),
+    execution,
+    session: async (): Promise<ExecutionSession> => {
+      const result = await start("ready", 1, "executor-a", "lease-a");
+      if (result.status === "not_runnable") {
+        throw new Error("fixture run was not runnable");
+      }
+      return result.session;
+    },
+    start,
+    store,
+  };
+}
+
+class FixedClock {
+  now(): Date {
+    return new Date("2026-07-16T12:00:00.000Z");
+  }
+}
+
+function runReceipt(runId: string): RunReceiptV1 {
+  const now = "2026-07-16T11:59:00.000Z";
+  return {
+    admitted_at: now,
+    binding_id: "binding-1",
+    idempotency_key: `event:${runId}`,
+    input_digest: "sha256:input",
+    receipt_id: `receipt-${runId}`,
+    received_at: now,
+    required_capabilities: [],
+    retention_policy_ref: "retention://default",
+    revision: 1,
+    run_id: runId,
+    run_kind: "interactive",
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: "thread://conversation/turn",
+    tenant_id: "tenant-1",
+    updated_at: now,
+  };
+}
+
+function plan(): MissionPlanProjectionV1 {
+  return {
+    mission_contract_id: "native-mission-operating-contract",
+    mission_ref: "mission://mission-1",
+    mission_revision: 3,
+    mission_schema_version: "cerebro.control-kernel.v1",
+    plan_digest: "sha256:plan-4",
+    plan_ref: "mission-plan://plan-1/revision/4",
+    plan_revision: 4,
+    run_id: "run-1",
+    schema_version: "mission-plan-projection/v1",
+    steps: [
+      {
+        approval_required: true,
+        capability_ref: "capability://bounded-action/v1",
+        capability_version: "1.0.0",
+        effect_id: "effect-1",
+        idempotency_key: "mission-1:plan-4:step-1",
+        request_digest: "sha256:effect-request-1",
+        rollback_plan_ref: "rollback://step-1",
+        step_id: "step-1",
+        target_ref: "resource://target-1",
+      },
+    ],
+  };
+}
+
+function capabilityBinding(state: "bound" | "missing" | "incompatible") {
+  return {
+    binding_ref: "capability-binding://bounded-action/v1",
+    capability_ref: "capability://bounded-action/v1",
+    capability_version: "1.0.0",
+    state,
+  } as const;
+}
+
+function receipt(receiptRef: string, receiptDigest: string) {
+  return { receipt_digest: receiptDigest, receipt_ref: receiptRef };
+}
+
+function evidence() {
+  return {
+    evidence_digest: "sha256:evidence-1",
+    evidence_ref: "evidence://observation-1",
+    source_revision: "source-revision-2",
+  };
+}
+
+function decision(
+  value: "approved" | "rejected",
+): MissionDecisionProjectionV1 {
+  return {
+    decision: value,
+    evidence: [evidence()],
+    mission_ref: "mission://mission-1",
+    mission_revision: 3,
+    plan_digest: "sha256:plan-4",
+    plan_ref: "mission-plan://plan-1/revision/4",
+    plan_revision: 4,
+    receipt: receipt("decision://approval-1", "sha256:decision-1"),
+    schema_version: "mission-decision-projection/v1",
+  };
+}
+
+function verification(): MissionVerificationProjectionV1 {
+  return {
+    evidence: [evidence()],
+    observed_source_revision: "source-revision-2",
+    pre_action_source_revision: "source-revision-1",
+    receipt: receipt("verification://step-1", "sha256:verification-1"),
+    verifier_ref: "actor://verifier-b",
+  };
+}

--- a/apps/slack-companion/test/operations.test.ts
+++ b/apps/slack-companion/test/operations.test.ts
@@ -1,0 +1,631 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type {
+  CapabilityManifestV1,
+  PresenceSnapshotV1,
+  ReleaseReceiptV2,
+  RunReceiptV1,
+  SchemaCompatibility,
+} from "@writer/cerebro-sdk";
+import {
+  assessCompatibility,
+  newLeaseGate,
+  readinessGate,
+} from "../src/operations/compatibility.js";
+import {
+  planMaintenance,
+  verifyReleaseReceipt,
+} from "../src/operations/maintenance.js";
+import {
+  advanceMigration,
+  createMigrationReceipt,
+  cutOverRoute,
+  rollBackRoute,
+  type SlackThreadIdentity,
+} from "../src/operations/migration.js";
+import {
+  acquireScheduledOccurrence,
+  createScheduledOccurrence,
+  planMisfires,
+  scheduledOccurrenceIdentity,
+  updateScheduledOccurrence,
+} from "../src/operations/schedules.js";
+import { deriveSlackVisibleStatuses } from "../src/operations/status.js";
+
+const now = "2026-07-16T12:00:00.000Z";
+
+describe("scheduled operation continuity", () => {
+  test("uses schedule, due time, and revision as deterministic identity", () => {
+    const first = createScheduledOccurrence(
+      {
+        due_at: "2026-07-16T11:00:00Z",
+        generation: 3,
+        misfire_policy: "coalesce_once",
+        schedule_id: "daily summary",
+        schedule_revision: 4,
+      },
+      now,
+    );
+    const retried = createScheduledOccurrence(
+      {
+        due_at: "2026-07-16T11:00:00.000Z",
+        generation: 4,
+        misfire_policy: "coalesce_once",
+        schedule_id: "daily summary",
+        schedule_revision: 4,
+      },
+      now,
+    );
+
+    assert.equal(first.occurrence_id, retried.occurrence_id);
+    assert.equal(first.idempotency_key, retried.idempotency_key);
+    assert.equal(
+      first.occurrence_id,
+      scheduledOccurrenceIdentity(
+        "daily summary",
+        "2026-07-16T11:00:00Z",
+        4,
+      ),
+    );
+    assert.notEqual(
+      first.occurrence_id,
+      scheduledOccurrenceIdentity(
+        "daily summary",
+        "2026-07-16T11:00:00Z",
+        5,
+      ),
+    );
+  });
+
+  test("applies skip, coalesce, and bounded catch-up policies", () => {
+    const due = [
+      "2026-07-16T09:00:00Z",
+      "2026-07-16T10:00:00Z",
+      "2026-07-16T11:00:00Z",
+      "2026-07-16T13:00:00Z",
+    ];
+
+    assert.deepEqual(planMisfires(due, now, "skip"), {
+      enqueue: [],
+      pending: ["2026-07-16T13:00:00.000Z"],
+      skip: [
+        "2026-07-16T09:00:00.000Z",
+        "2026-07-16T10:00:00.000Z",
+        "2026-07-16T11:00:00.000Z",
+      ],
+    });
+    assert.deepEqual(planMisfires(due, now, "coalesce_once"), {
+      enqueue: ["2026-07-16T11:00:00.000Z"],
+      pending: ["2026-07-16T13:00:00.000Z"],
+      skip: [
+        "2026-07-16T09:00:00.000Z",
+        "2026-07-16T10:00:00.000Z",
+      ],
+    });
+    assert.deepEqual(planMisfires(due, now, "run_all_bounded", 2), {
+      enqueue: [
+        "2026-07-16T09:00:00.000Z",
+        "2026-07-16T10:00:00.000Z",
+      ],
+      pending: [
+        "2026-07-16T11:00:00.000Z",
+        "2026-07-16T13:00:00.000Z",
+      ],
+      skip: [],
+    });
+  });
+
+  test("fences overlapping schedulers and stale completion", () => {
+    const occurrence = createScheduledOccurrence(
+      {
+        due_at: "2026-07-16T11:00:00Z",
+        generation: 3,
+        misfire_policy: "coalesce_once",
+        schedule_id: "summary",
+        schedule_revision: 2,
+      },
+      now,
+    );
+    const first = acquireScheduledOccurrence(occurrence, {
+      fencing_token: 10,
+      generation: 3,
+      lease_expires_at: "2026-07-16T12:01:00Z",
+      lease_token: "lease-a",
+      now,
+      owner_id: "worker-a",
+    });
+    assert.equal(first.acquired, true);
+    if (!first.acquired) {
+      assert.fail("expected first scheduler to acquire the occurrence");
+    }
+
+    const overlap = acquireScheduledOccurrence(first.occurrence, {
+      fencing_token: 11,
+      generation: 4,
+      lease_expires_at: "2026-07-16T12:02:00Z",
+      lease_token: "lease-b",
+      now: "2026-07-16T12:00:30Z",
+      owner_id: "worker-b",
+    });
+    assert.deepEqual(overlap, { acquired: false, reason: "active_lease" });
+
+    const recovered = acquireScheduledOccurrence(first.occurrence, {
+      fencing_token: 11,
+      generation: 4,
+      lease_expires_at: "2026-07-16T12:04:00Z",
+      lease_token: "lease-b",
+      now: "2026-07-16T12:02:00Z",
+      owner_id: "worker-b",
+    });
+    assert.equal(recovered.acquired, true);
+    if (!recovered.acquired) {
+      assert.fail("expected expired lease to be recovered");
+    }
+
+    assert.equal(
+      updateScheduledOccurrence(
+        recovered.occurrence,
+        {
+          fencing_token: 10,
+          generation: 3,
+          lease_token: "lease-a",
+          owner_id: "worker-a",
+        },
+        "completed",
+        "2026-07-16T12:02:30Z",
+      ),
+      undefined,
+    );
+    assert.equal(
+      updateScheduledOccurrence(
+        recovered.occurrence,
+        {
+          fencing_token: 11,
+          generation: 4,
+          lease_token: "lease-b",
+          owner_id: "worker-b",
+        },
+        "completed",
+        "2026-07-16T12:02:30Z",
+      )?.state,
+      "completed",
+    );
+  });
+
+  test("rejects invalid schedule and lease identity fields", () => {
+    assert.throws(
+      () =>
+        createScheduledOccurrence(
+          {
+            due_at: "2026-07-16T11:00:00Z",
+            generation: 0,
+            misfire_policy: "coalesce_once",
+            schedule_id: "summary",
+            schedule_revision: 2,
+          },
+          now,
+        ),
+      /generation must be a positive integer/,
+    );
+
+    const occurrence = createScheduledOccurrence(
+      {
+        due_at: "2026-07-16T11:00:00Z",
+        generation: 1,
+        misfire_policy: "coalesce_once",
+        schedule_id: "summary",
+        schedule_revision: 2,
+      },
+      now,
+    );
+    const lease = {
+      fencing_token: 1,
+      generation: 1,
+      lease_expires_at: "2026-07-16T12:01:00Z",
+      lease_token: "lease-1",
+      now,
+      owner_id: "worker-1",
+    };
+
+    assert.deepEqual(
+      acquireScheduledOccurrence(occurrence, { ...lease, generation: 0 }),
+      { acquired: false, reason: "invalid_generation" },
+    );
+    assert.deepEqual(
+      acquireScheduledOccurrence(occurrence, { ...lease, fencing_token: 0 }),
+      { acquired: false, reason: "invalid_fencing_token" },
+    );
+    assert.deepEqual(
+      acquireScheduledOccurrence(occurrence, { ...lease, owner_id: " " }),
+      { acquired: false, reason: "invalid_lease_identity" },
+    );
+    assert.deepEqual(
+      acquireScheduledOccurrence(occurrence, { ...lease, lease_token: "" }),
+      { acquired: false, reason: "invalid_lease_identity" },
+    );
+  });
+});
+
+describe("compatibility and service gates", () => {
+  test("requires bidirectional reads, a shared write version, and required capabilities", () => {
+    const supported = assessCompatibility({
+      companion_manifest: manifest("companion", ["v1", "v2"]),
+      companion_schema: schema("v2", ["v1", "v2"], ["v2"]),
+      core_manifest: manifest("core", ["v1", "v2"]),
+      core_schema: schema("v1", ["v1", "v2"], ["v2"]),
+    });
+    assert.deepEqual(supported, {
+      decision: "supported",
+      negotiated_write_version: "v2",
+      reasons: [],
+    });
+
+    const blocked = assessCompatibility({
+      companion_manifest: manifest("companion", ["v1", "v2"], []),
+      companion_schema: schema("v2", ["v1", "v2"], ["v2"]),
+      core_manifest: manifest("core", ["v1", "v2"]),
+      core_schema: schema("v1", ["v1", "v2"], ["v2"]),
+    });
+    assert.equal(blocked.decision, "blocked");
+    assert.deepEqual(blocked.reasons, ["companion_missing_turns@1"]);
+  });
+
+  test("blocks readiness and leases on stale presence, recovery, or generation changes", () => {
+    const assessment = {
+      decision: "supported" as const,
+      negotiated_write_version: "v1",
+      reasons: [],
+    };
+    assert.equal(readinessGate(presence(), assessment, now).allowed, true);
+    assert.deepEqual(
+      newLeaseGate(presence(), assessment, 1, 2, now),
+      { allowed: true, reason: "lease_allowed" },
+    );
+    assert.deepEqual(
+      newLeaseGate(presence({ route_generation: 3 }), assessment, 1, 2, now),
+      { allowed: false, reason: "route_generation_changed" },
+    );
+    assert.deepEqual(
+      readinessGate(
+        presence({ service_state: "recovering" }),
+        assessment,
+        now,
+      ),
+      { allowed: false, reason: "service_recovering" },
+    );
+    assert.deepEqual(
+      readinessGate(
+        presence({ compatibility: "blocked" }),
+        assessment,
+        now,
+      ),
+      { allowed: false, reason: "presence_compatibility_blocked" },
+    );
+    assert.deepEqual(
+      readinessGate(
+        presence({ expires_at: "2026-07-16T11:59:59Z" }),
+        assessment,
+        now,
+      ),
+      { allowed: false, reason: "presence_expired" },
+    );
+  });
+});
+
+describe("Slack-visible continuity status", () => {
+  test("derives queued, degraded, and partial-source facts with expiry", () => {
+    const statuses = deriveSlackVisibleStatuses(
+      run(),
+      presence({ service_state: "degraded" }),
+      now,
+      { available_source_count: 2, expected_source_count: 3 },
+    );
+
+    assert.deepEqual(
+      statuses.map((status) => status.code),
+      ["queued", "degraded", "partial_source"],
+    );
+    assert.equal(statuses.every((status) => status.expires_at === "2026-07-16T12:05:00.000Z"), true);
+    assert.equal(new Set(statuses.map((status) => status.idempotency_key)).size, 3);
+  });
+
+  test("does not show stale recovery state", () => {
+    assert.deepEqual(
+      deriveSlackVisibleStatuses(
+        run(),
+        presence({
+          expires_at: "2026-07-16T11:59:00Z",
+          service_state: "recovering",
+        }),
+        now,
+      ),
+      [],
+    );
+  });
+});
+
+describe("maintenance and release continuity", () => {
+  test("keeps a graceful drain blocked until replacement and active work are safe", () => {
+    const plan = planMaintenance({
+      active_runs: [
+        { checkpointable: true, run_id: "run-1" },
+        { checkpointable: false, run_id: "run-2" },
+      ],
+      compatibility: "supported",
+      deliveries: [{ delivery_id: "delivery-1", state: "delivering" }],
+      mode: "graceful",
+      now,
+      replacement_presence: presence(),
+    });
+
+    assert.equal(plan.new_leases_allowed, false);
+    assert.equal(plan.admission_behavior, "durable_queue");
+    assert.equal(plan.safe_to_stop, false);
+    assert.equal(plan.forced_stop_permitted_after_actions, false);
+    assert.deepEqual(plan.blockers, ["run_not_checkpointable:run-2"]);
+    assert.equal(
+      plan.actions.some((action) => action.action === "checkpoint_and_pause"),
+      true,
+    );
+    assert.equal(
+      plan.actions.some((action) => action.action === "drain_delivery"),
+      true,
+    );
+  });
+
+  test("keeps forced maintenance unsafe until reconciliation and delivery pause finish", () => {
+    const plan = planMaintenance({
+      active_runs: [{ checkpointable: false, run_id: "run-1" }],
+      compatibility: "supported",
+      deliveries: [{ delivery_id: "delivery-1", state: "pending" }],
+      mode: "forced",
+      now,
+    });
+
+    assert.equal(plan.safe_to_stop, false);
+    assert.equal(plan.forced_stop_permitted_after_actions, true);
+    assert.deepEqual(plan.blockers, []);
+    assert.equal(
+      plan.actions.some(
+        (action) => action.action === "mark_for_reconciliation",
+      ),
+      true,
+    );
+    assert.equal(
+      plan.actions.some((action) => action.action === "pause_delivery"),
+      true,
+    );
+  });
+
+  test("marks a clean graceful drain safe after replacement readiness", () => {
+    const plan = planMaintenance({
+      active_runs: [],
+      compatibility: "supported",
+      deliveries: [],
+      mode: "graceful",
+      now,
+      replacement_presence: presence(),
+    });
+
+    assert.equal(plan.safe_to_stop, true);
+    assert.equal(plan.forced_stop_permitted_after_actions, false);
+    assert.deepEqual(plan.blockers, []);
+    assert.deepEqual(plan.actions, [
+      { action: "stop_new_leases", subject_id: "service" },
+    ]);
+  });
+
+  test("fails release verification for orphaned work and stuck delivery", () => {
+    const verification = verifyReleaseReceipt(
+      releaseReceipt({ orphaned_run_count: 1, stuck_delivery_count: 2 }),
+    );
+    assert.deepEqual(verification, {
+      passed: false,
+      reasons: ["orphaned_runs_present", "stuck_deliveries_present"],
+    });
+    assert.equal(verifyReleaseReceipt(releaseReceipt()).passed, true);
+  });
+});
+
+describe("topology-neutral route migration", () => {
+  test("uses route-generation compare-and-swap and preserves Slack thread identity", () => {
+    let receipt = createMigrationReceipt({
+      binding_id: "binding-1",
+      checkpoint_count: 2,
+      created_at: now,
+      migration_id: "migration-1",
+      pending_delivery_count: 1,
+      rollback_generation: 8,
+      route_generation: 12,
+      source_generation: 8,
+      target_generation: 9,
+    });
+    for (const state of ["validating", "draining", "cutting_over"] as const) {
+      const advanced = advanceMigration(receipt, state, now);
+      assert.equal(advanced.changed, true);
+      if (!advanced.changed) {
+        assert.fail(`expected transition to ${state}`);
+      }
+      receipt = advanced.receipt;
+    }
+
+    const conflict = cutOverRoute(receipt, 11, identity(), identity(), now);
+    assert.deepEqual(conflict, {
+      changed: false,
+      reason: "route_generation_conflict",
+      receipt,
+    });
+
+    const cutover = cutOverRoute(receipt, 12, identity(), identity(), now);
+    assert.equal(cutover.changed, true);
+    if (!cutover.changed) {
+      assert.fail("expected route cutover");
+    }
+    assert.equal(cutover.receipt.route_generation, 13);
+    assert.equal(cutover.receipt.state, "recovering");
+    assert.equal(cutover.receipt.source_generation, 8);
+    assert.equal(cutover.receipt.target_generation, 9);
+  });
+
+  test("fails cutover if app, binding, conversation, thread, or durable state changes", () => {
+    const receipt = receiptAtCutover();
+    const changed = identity({ durable_thread_state_digest: "sha256:changed" });
+    const result = cutOverRoute(receipt, 12, identity(), changed, now);
+
+    assert.equal(result.changed, false);
+    assert.equal(result.reason, "identity_changed");
+    assert.equal(result.receipt.state, "failed");
+    assert.equal(result.receipt.route_generation, 12);
+  });
+
+  test("rolls back through the same route-generation compare-and-swap", () => {
+    const receipt = {
+      ...receiptAtCutover(),
+      route_generation: 13,
+      state: "rolling_back" as const,
+    };
+    const stale = rollBackRoute(receipt, 12, identity(), identity(), now);
+    assert.equal(stale.changed, false);
+    assert.equal(stale.reason, "route_generation_conflict");
+
+    const rolledBack = rollBackRoute(
+      receipt,
+      13,
+      identity(),
+      identity(),
+      now,
+    );
+    assert.equal(rolledBack.changed, true);
+    if (!rolledBack.changed) {
+      assert.fail("expected route rollback");
+    }
+    assert.equal(rolledBack.receipt.state, "rolled_back");
+    assert.equal(rolledBack.receipt.route_generation, 14);
+    assert.equal(rolledBack.receipt.rollback_generation, 8);
+  });
+});
+
+function schema(
+  currentVersion: string,
+  readVersions: string[],
+  writeVersions: string[],
+): SchemaCompatibility {
+  return {
+    capability_decisions: ["supported", "degraded", "blocked", "incompatible"],
+    current_version: currentVersion,
+    read_versions: readVersions,
+    rolling_upgrade_rule: "Readers accept the previous version during rollout.",
+    write_versions: writeVersions,
+  };
+}
+
+function manifest(
+  serviceId: string,
+  contractVersions: string[],
+  capabilities: CapabilityManifestV1["capabilities"] = [
+    { capability_id: "turns", level: "required", version: "1" },
+  ],
+): CapabilityManifestV1 {
+  return {
+    capabilities,
+    contract_versions: contractVersions,
+    digest: `sha256:${serviceId}`,
+    generation: 1,
+    produced_at: now,
+    schema_version: "capability-manifest/v1",
+    service_id: serviceId,
+  };
+}
+
+function presence(
+  changes: Partial<PresenceSnapshotV1> = {},
+): PresenceSnapshotV1 {
+  return {
+    active_generation: 1,
+    binding_id: "binding-1",
+    compatibility: "supported",
+    expires_at: "2026-07-16T12:05:00.000Z",
+    observed_at: now,
+    reason_code: "ready",
+    route_generation: 2,
+    schema_version: "presence-snapshot/v1",
+    service_state: "ready",
+    ...changes,
+  };
+}
+
+function run(): RunReceiptV1 {
+  return {
+    admitted_at: now,
+    binding_id: "binding-1",
+    idempotency_key: "event-1",
+    input_digest: "sha256:input",
+    receipt_id: "receipt-1",
+    received_at: now,
+    required_capabilities: [],
+    retention_policy_ref: "retention://standard",
+    revision: 1,
+    run_id: "run-1",
+    run_kind: "interactive",
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: "conversation://thread-1",
+    tenant_id: "tenant-1",
+    updated_at: now,
+  };
+}
+
+function releaseReceipt(
+  changes: Partial<ReleaseReceiptV2> = {},
+): ReleaseReceiptV2 {
+  return {
+    active_lease_count: 0,
+    compatibility: "supported",
+    created_at: now,
+    drained_run_count: 3,
+    generation: 2,
+    orphaned_run_count: 0,
+    pending_delivery_count: 0,
+    recoverable_run_count: 0,
+    release_id: "release-2",
+    resumed_run_count: 3,
+    schema_version: "release-receipt/v2",
+    service_id: "companion",
+    state: "active",
+    stuck_delivery_count: 0,
+    updated_at: now,
+    verification_receipt_refs: ["verification://release-2"],
+    ...changes,
+  };
+}
+
+function identity(
+  changes: Partial<SlackThreadIdentity> = {},
+): SlackThreadIdentity {
+  return {
+    binding_id: "binding-1",
+    conversation_id: "conversation-1",
+    durable_thread_state_digest: "sha256:thread-state",
+    installation_id: "installation-1",
+    slack_app_id: "app-1",
+    thread_id: "thread-1",
+    ...changes,
+  };
+}
+
+function receiptAtCutover() {
+  return {
+    binding_id: "binding-1",
+    checkpoint_count: 2,
+    created_at: now,
+    migration_id: "migration-1",
+    pending_delivery_count: 1,
+    rollback_generation: 8,
+    route_generation: 12,
+    schema_version: "migration-receipt/v1" as const,
+    source_generation: 8,
+    state: "cutting_over" as const,
+    target_generation: 9,
+    updated_at: now,
+  };
+}

--- a/apps/slack-companion/test/portable-continuity.test.ts
+++ b/apps/slack-companion/test/portable-continuity.test.ts
@@ -1,0 +1,494 @@
+import assert from "node:assert/strict";
+import { createHash, createHmac } from "node:crypto";
+import { test } from "node:test";
+import type {
+  AdmissionContext,
+  DurableInboundPayloadPort,
+  InboundPayloadCommit,
+  InboundPayloadReceipt,
+  PlatformAcceptanceReceipt,
+  PlatformDeliveryRequest,
+  PlatformDeliveryPort,
+  ScheduledOccurrenceCommitResult,
+  ScheduledOccurrenceStorePort,
+  SlackEventsApiRequest,
+  SlackThreadBindingV1,
+  ThreadBindingCommit,
+  ThreadBindingCommitResult,
+  ThreadBindingStorePort,
+  WorkLeaseV1,
+} from "../src/index.js";
+import {
+  acquireScheduledOccurrence,
+  createScheduledOccurrence,
+  DeliveryCoordinator,
+  ExecutionCoordinator,
+  handleEventsApiRequest,
+  SlackAdmissionController,
+  SlackThreadBindingCoordinator,
+  StructuralSlackEventNormalizer,
+  ThreadBindingConflictError,
+  updateScheduledOccurrence,
+} from "../src/index.js";
+import { ReferenceMemoryDeliveryStore } from "../src/delivery/reference-store.js";
+import { ReferenceMemoryExecutionStore } from "../src/execution/reference-store.js";
+
+const now = "2026-07-16T12:00:00.000Z";
+const requestTimestamp = String(Date.parse(now) / 1_000);
+const signingKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+
+test("one scheduled Slack run remains durable across transport, execution, and delivery", async () => {
+  const clock = { now: () => new Date(now) };
+  const occurrenceStore = new MemoryOccurrenceStore();
+  const occurrence = createScheduledOccurrence(
+    {
+      due_at: now,
+      generation: 1,
+      misfire_policy: "coalesce_once",
+      schedule_id: "portable-continuity",
+      schedule_revision: 1,
+    },
+    "2026-07-16T11:59:00.000Z",
+  );
+  assert.equal((await occurrenceStore.putIfAbsent(occurrence)).created, true);
+  assert.equal((await occurrenceStore.putIfAbsent(occurrence)).created, false);
+
+  const scheduledClaim = {
+    fencing_token: 1,
+    generation: 1,
+    lease_token: "schedule-lease-1",
+    owner_id: "scheduler-1",
+  };
+  const scheduledLease = acquireScheduledOccurrence(occurrence, {
+    ...scheduledClaim,
+    lease_expires_at: "2026-07-16T12:05:00.000Z",
+    now,
+  });
+  assert.equal(scheduledLease.acquired, true);
+  if (!scheduledLease.acquired) {
+    assert.fail("expected the scheduled occurrence lease");
+  }
+  await occurrenceStore.compareAndSet(occurrence, scheduledLease.occurrence);
+  const runningOccurrence = updateScheduledOccurrence(
+    scheduledLease.occurrence,
+    scheduledClaim,
+    "running",
+    now,
+  );
+  assert.notEqual(runningOccurrence, undefined);
+  if (runningOccurrence === undefined) {
+    assert.fail("expected the scheduled occurrence to start");
+  }
+  await occurrenceStore.compareAndSet(
+    scheduledLease.occurrence,
+    runningOccurrence,
+  );
+
+  const continuityStore = new ReferenceMemoryExecutionStore();
+  const admission = new SlackAdmissionController({
+    clock,
+    context: { read: async () => readyContext() },
+    identities: {
+      nextReceiptId: () => "receipt-portable-continuity",
+      nextRunId: () => occurrence.run_id,
+    },
+    policy: { admit_while_degraded: true, offline_behavior: "queue" },
+    store: continuityStore,
+  });
+  const payloads = new MemoryInboundPayloadStore();
+  const request = eventsApiRequest();
+  const dependencies = {
+    admission,
+    clock,
+    normalizer: new StructuralSlackEventNormalizer(),
+    payloads,
+  };
+
+  const first = await handleEventsApiRequest(request, signingKey, dependencies);
+  const duplicate = await handleEventsApiRequest(
+    request,
+    signingKey,
+    dependencies,
+  );
+  assert.equal(first.kind, "acknowledge");
+  assert.equal(duplicate.kind, "acknowledge");
+  if (first.kind !== "acknowledge" || duplicate.kind !== "acknowledge") {
+    assert.fail("expected durable transport acknowledgement");
+  }
+  assert.equal(first.run_id, occurrence.run_id);
+  assert.equal(duplicate.run_id, first.run_id);
+  assert.equal(payloads.recordCount, 1);
+  assert.equal(continuityStore.runCount(), 1);
+  assert.equal(continuityStore.readRun(first.run_id)?.state, "queued");
+
+  const execution = new ExecutionCoordinator({
+    clock,
+    lease_duration_ms: 60_000,
+    store: continuityStore,
+  });
+  const started = await execution.start({
+    generation: 1,
+    lease_token: "execution-lease-1",
+    owner_id: "executor-1",
+    run_id: first.run_id,
+    service_state: "ready",
+  });
+  if (started.status === "not_runnable") {
+    assert.fail("expected the admitted run to execute");
+  }
+  const checkpoint = await execution.checkpoint(started.session, {
+    checkpoint_id: "checkpoint-portable-continuity",
+    completed_step_ids: ["prepare-response"],
+    effect_receipt_ids: [],
+    payload_digest: "sha256:checkpoint-portable-continuity",
+    payload_ref: "checkpoint://portable-continuity",
+    resume_cursor: "delivery-ready",
+    sequence: 1,
+  });
+  assert.equal(checkpoint.run_id, first.run_id);
+  const deliveringRun = await execution.finishExecution(started.session);
+  assert.equal(deliveringRun.state, "delivering");
+  assert.equal(continuityStore.runCount(), 1);
+
+  const deliveryStore = new ReferenceMemoryDeliveryStore(1);
+  const sender = new IdempotentDestination(clock);
+  const delivery = new DeliveryCoordinator({
+    clock,
+    sender,
+    store: deliveryStore,
+  });
+  const plan = {
+    delivery_key: "scheduled-response",
+    destination_ref: "conversation://conversation-1/thread-1",
+    max_attempts: 3,
+    parts: [
+      {
+        payload_digest: "sha256:response-part-1",
+        payload_ref: "response://portable-continuity/part-1",
+      },
+    ],
+    run_id: first.run_id,
+  } as const;
+  const planned = await delivery.plan(plan);
+  const duplicatePlan = await delivery.plan(plan);
+  assert.equal(planned.created, true);
+  assert.equal(duplicatePlan.created, false);
+  assert.equal(duplicatePlan.receipt.delivery_id, planned.receipt.delivery_id);
+
+  const delivered = await delivery.deliverNext(
+    planned.receipt.delivery_id,
+    deliveryLease(first.run_id),
+  );
+  assert.equal(delivered.status, "delivered");
+  if (delivered.status !== "delivered") {
+    assert.fail("expected the durable outbox part to be delivered");
+  }
+  assert.equal(delivered.receipt.state, "completed");
+  assert.deepEqual(
+    await deliveryStore.read(planned.receipt.delivery_id),
+    delivered.receipt,
+  );
+  assert.equal(sender.uniqueAcceptanceCount, 1);
+
+  const threadStore = new MemoryThreadBindingStore();
+  const threads = new SlackThreadBindingCoordinator(clock, threadStore);
+  const bound = await threads.bind(
+    {
+      app_id: "app-1",
+      binding_id: "binding-1",
+      conversation_id: "conversation-1",
+      delivery_id: delivered.receipt.delivery_id,
+      destination_receipt: delivered.destination_receipt,
+      expires_at: "2026-07-16T13:00:00.000Z",
+      goal_ref: "goal://portable-continuity",
+      installation_id: "installation-1",
+      subject_ref: deliveringRun.subject_ref,
+      thread_id: "thread-1",
+    },
+    delivered.receipt,
+  );
+  assert.equal(bound.created, true);
+  assert.equal(threadStore.recordCount, 1);
+  assert.equal(bound.binding.delivery_id, planned.receipt.delivery_id);
+
+  const completedOccurrence = updateScheduledOccurrence(
+    runningOccurrence,
+    scheduledClaim,
+    "completed",
+    now,
+  );
+  assert.notEqual(completedOccurrence, undefined);
+  if (completedOccurrence === undefined) {
+    assert.fail("expected the scheduled occurrence to complete");
+  }
+  await occurrenceStore.compareAndSet(
+    runningOccurrence,
+    completedOccurrence,
+  );
+  assert.equal(
+    (await occurrenceStore.read(occurrence.occurrence_id))?.run_id,
+    first.run_id,
+  );
+  assert.equal(
+    (await occurrenceStore.read(occurrence.occurrence_id))?.state,
+    "completed",
+  );
+  assert.equal(occurrenceStore.recordCount, 1);
+});
+
+class MemoryInboundPayloadStore implements DurableInboundPayloadPort {
+  private readonly records = new Map<
+    string,
+    { body_digest: string; receipt: InboundPayloadReceipt }
+  >();
+
+  get recordCount(): number {
+    return this.records.size;
+  }
+
+  persist(commit: InboundPayloadCommit): Promise<InboundPayloadReceipt> {
+    const bodyDigest = digest(commit.raw_body);
+    const prior = this.records.get(commit.idempotency_key);
+    if (prior !== undefined) {
+      if (prior.body_digest !== bodyDigest) {
+        return Promise.reject(
+          new Error("inbound payload identity has different bytes"),
+        );
+      }
+      return Promise.resolve(structuredClone(prior.receipt));
+    }
+    const receipt = {
+      digest: bodyDigest,
+      payload_ref: `payload://${commit.idempotency_key}`,
+    };
+    this.records.set(commit.idempotency_key, {
+      body_digest: bodyDigest,
+      receipt,
+    });
+    return Promise.resolve(structuredClone(receipt));
+  }
+}
+
+class MemoryOccurrenceStore implements ScheduledOccurrenceStorePort {
+  private readonly records = new Map<
+    string,
+    Parameters<ScheduledOccurrenceStorePort["putIfAbsent"]>[0]
+  >();
+
+  get recordCount(): number {
+    return this.records.size;
+  }
+
+  putIfAbsent(
+    occurrence: Parameters<ScheduledOccurrenceStorePort["putIfAbsent"]>[0],
+  ): Promise<ScheduledOccurrenceCommitResult> {
+    const prior = this.records.get(occurrence.occurrence_id);
+    if (prior !== undefined) {
+      if (!sameValue(prior, occurrence)) {
+        return Promise.reject(
+          new Error("scheduled occurrence identity has different intent"),
+        );
+      }
+      return Promise.resolve({
+        created: false,
+        occurrence: structuredClone(prior),
+      });
+    }
+    this.records.set(occurrence.occurrence_id, structuredClone(occurrence));
+    return Promise.resolve({
+      created: true,
+      occurrence: structuredClone(occurrence),
+    });
+  }
+
+  compareAndSet(
+    expected: Parameters<ScheduledOccurrenceStorePort["compareAndSet"]>[0],
+    next: Parameters<ScheduledOccurrenceStorePort["compareAndSet"]>[1],
+  ) {
+    const current = this.records.get(expected.occurrence_id);
+    if (
+      current === undefined ||
+      !sameValue(current, expected) ||
+      next.occurrence_id !== expected.occurrence_id
+    ) {
+      return Promise.reject(new Error("scheduled occurrence changed"));
+    }
+    this.records.set(next.occurrence_id, structuredClone(next));
+    return Promise.resolve(structuredClone(next));
+  }
+
+  read(occurrenceId: string) {
+    const occurrence = this.records.get(occurrenceId);
+    return Promise.resolve(
+      occurrence === undefined ? undefined : structuredClone(occurrence),
+    );
+  }
+}
+
+class IdempotentDestination implements PlatformDeliveryPort {
+  private readonly acceptances = new Map<string, PlatformAcceptanceReceipt>();
+
+  constructor(private readonly clock: { now(): Date }) {}
+
+  get uniqueAcceptanceCount(): number {
+    return this.acceptances.size;
+  }
+
+  send(request: PlatformDeliveryRequest): Promise<PlatformAcceptanceReceipt> {
+    const prior = this.acceptances.get(request.client_message_id);
+    if (prior !== undefined) {
+      return Promise.resolve(structuredClone(prior));
+    }
+    const receipt = {
+      accepted_at: this.clock.now().toISOString(),
+      destination_receipt: `destination://${request.client_message_id}`,
+    };
+    this.acceptances.set(request.client_message_id, receipt);
+    return Promise.resolve(structuredClone(receipt));
+  }
+}
+
+class MemoryThreadBindingStore implements ThreadBindingStorePort {
+  private readonly fingerprints = new Map<string, string>();
+  private readonly records = new Map<string, SlackThreadBindingV1>();
+
+  get recordCount(): number {
+    return this.records.size;
+  }
+
+  putIfAbsent(commit: ThreadBindingCommit): Promise<ThreadBindingCommitResult> {
+    const id = commit.binding.thread_binding_id;
+    const prior = this.records.get(id);
+    if (prior !== undefined) {
+      if (this.fingerprints.get(id) !== commit.payload_fingerprint) {
+        return Promise.reject(
+          new ThreadBindingConflictError(
+            "thread identity has different continuity intent",
+          ),
+        );
+      }
+      return Promise.resolve({ binding: structuredClone(prior), created: false });
+    }
+    this.records.set(id, structuredClone(commit.binding));
+    this.fingerprints.set(id, commit.payload_fingerprint);
+    return Promise.resolve({
+      binding: structuredClone(commit.binding),
+      created: true,
+    });
+  }
+
+  read(threadBindingId: string) {
+    const binding = this.records.get(threadBindingId);
+    return Promise.resolve(
+      binding === undefined ? undefined : structuredClone(binding),
+    );
+  }
+
+  close(threadBindingId: string, closedAt: string) {
+    const binding = this.require(threadBindingId);
+    binding.closed_at = binding.closed_at ?? closedAt;
+    binding.state = "closed";
+    binding.updated_at = binding.closed_at;
+    return Promise.resolve(structuredClone(binding));
+  }
+
+  expire(threadBindingId: string, expiredAt: string) {
+    const binding = this.require(threadBindingId);
+    if (binding.state === "active") {
+      binding.state = "expired";
+      binding.updated_at = expiredAt;
+    }
+    return Promise.resolve(structuredClone(binding));
+  }
+
+  private require(threadBindingId: string): SlackThreadBindingV1 {
+    const binding = this.records.get(threadBindingId);
+    if (binding === undefined) {
+      throw new Error("thread binding does not exist");
+    }
+    return binding;
+  }
+}
+
+function eventsApiRequest(): SlackEventsApiRequest {
+  const rawBody = Buffer.from(
+    JSON.stringify({
+      api_app_id: "app-1",
+      event: {
+        channel: "conversation-1",
+        thread_ts: "thread-1",
+        ts: "event-time-1",
+        type: "app_mention",
+      },
+      event_id: "event-portable-continuity",
+      event_time: Date.parse(now) / 1_000,
+      team_id: "team-1",
+      type: "event_callback",
+    }),
+  );
+  return {
+    raw_body: rawBody,
+    received_at: now,
+    request_signature: `v0=${createHmac("sha256", signingKey)
+      .update(`v0:${requestTimestamp}:`)
+      .update(rawBody)
+      .digest("hex")}`,
+    request_timestamp: requestTimestamp,
+    route: {
+      binding_id: "binding-1",
+      required_capabilities: [],
+      retention_policy_ref: "retention://default",
+      run_kind: "scheduled",
+      tenant_id: "tenant-1",
+    },
+  };
+}
+
+function readyContext(): AdmissionContext {
+  return {
+    binding: {
+      binding_id: "binding-1",
+      created_at: now,
+      installation_generation: 1,
+      retention_policy_ref: "retention://default",
+      route_generation: 1,
+      schema_version: "agent-service-binding/v1",
+      service_id: "service-1",
+      state: "active",
+      tenant_id: "tenant-1",
+      updated_at: now,
+    },
+    presence: {
+      active_generation: 1,
+      binding_id: "binding-1",
+      compatibility: "supported",
+      expires_at: "2026-07-16T12:10:00.000Z",
+      observed_at: now,
+      reason_code: "ready",
+      route_generation: 1,
+      schema_version: "presence-snapshot/v1",
+      service_state: "ready",
+    },
+  };
+}
+
+function deliveryLease(runId: string): WorkLeaseV1 {
+  return {
+    fencing_token: 2,
+    generation: 1,
+    heartbeat_at: now,
+    lease_expires_at: "2026-07-16T12:05:00.000Z",
+    lease_token: "delivery-lease-1",
+    owner_id: "delivery-reconciler-1",
+    run_id: runId,
+    schema_version: "work-lease/v1",
+  };
+}
+
+function digest(value: Uint8Array): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/apps/slack-companion/test/thread-binding.test.ts
+++ b/apps/slack-companion/test/thread-binding.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { DeliveryReceiptV1 } from "@writer/cerebro-sdk";
+import {
+  SlackThreadBindingCoordinator,
+  ThreadBindingConflictError,
+  type BindSlackThreadRequest,
+  type SlackThreadBindingV1,
+  type ThreadBindingCommit,
+  type ThreadBindingCommitResult,
+  type ThreadBindingStorePort,
+} from "../src/thread-binding.js";
+
+const now = "2026-07-16T12:00:00.000Z";
+
+describe("SlackThreadBindingCoordinator", () => {
+  test("binds stable thread identity to the persisted platform receipt", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+
+    const first = await coordinator.bind(bindingRequest(), deliveredReceipt());
+    const duplicate = await coordinator.bind(bindingRequest(), deliveredReceipt());
+    const resumed = await coordinator.resume(bindingRequest());
+
+    assert.equal(first.created, true);
+    assert.equal(duplicate.created, false);
+    assert.deepEqual(duplicate.binding, first.binding);
+    assert.deepEqual(resumed, first.binding);
+    assert.equal(first.binding.destination_receipt, "destination-1");
+    assert.equal(first.binding.subject_ref, "subject://control-1");
+    assert.equal(first.binding.goal_ref, "goal://explain-control");
+    assert.equal(store.writeCount, 1);
+  });
+
+  test("does not bind before the destination acceptance is durable", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+    const receipt = deliveredReceipt();
+    receipt.parts[0] = {
+      ...receipt.parts[0]!,
+      destination_receipt: undefined,
+      state: "delivering",
+    };
+    receipt.state = "delivering";
+
+    await assert.rejects(() => coordinator.bind(bindingRequest(), receipt));
+    assert.equal(store.writeCount, 0);
+  });
+
+  test("binds after the referenced part is durable while later parts remain", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+    const receipt = deliveredReceipt();
+    receipt.parts.push({
+      idempotency_key: "message-2",
+      part_id: "part-2",
+      payload_digest: "sha256:payload-2",
+      payload_ref: "payload://2",
+      sequence: 2,
+      state: "pending",
+    });
+    receipt.state = "delivering";
+
+    const result = await coordinator.bind(bindingRequest(), receipt);
+
+    assert.equal(result.created, true);
+    assert.equal(result.binding.destination_receipt, "destination-1");
+  });
+
+  test("leaves no binding when its durable write fails", async () => {
+    const store = new MemoryThreadBindingStore();
+    store.failNext();
+    const coordinator = makeCoordinator(store);
+
+    await assert.rejects(
+      () => coordinator.bind(bindingRequest(), deliveredReceipt()),
+      /injected thread binding failure/,
+    );
+    assert.equal(store.writeCount, 0);
+    assert.equal(await coordinator.resume(bindingRequest()), undefined);
+  });
+
+  test("rejects identity reuse for a different subject or goal", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+    await coordinator.bind(bindingRequest(), deliveredReceipt());
+
+    await assert.rejects(
+      () =>
+        coordinator.bind(
+          bindingRequest({ goal_ref: "goal://different" }),
+          deliveredReceipt(),
+        ),
+      ThreadBindingConflictError,
+    );
+  });
+
+  test("closes idempotently and never resumes a closed binding", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+    const bound = await coordinator.bind(bindingRequest(), deliveredReceipt());
+
+    const first = await coordinator.close(bound.binding.thread_binding_id);
+    const second = await coordinator.close(bound.binding.thread_binding_id);
+
+    assert.equal(first.state, "closed");
+    assert.deepEqual(second, first);
+    assert.equal(await coordinator.resume(bindingRequest()), undefined);
+  });
+
+  test("expires a binding before returning resume context", async () => {
+    const store = new MemoryThreadBindingStore();
+    const clock = new MutableClock(now);
+    const coordinator = new SlackThreadBindingCoordinator(clock, store);
+    const bound = await coordinator.bind(bindingRequest(), deliveredReceipt());
+    clock.set("2026-07-16T13:00:01.000Z");
+
+    assert.equal(await coordinator.resume(bindingRequest()), undefined);
+    assert.equal(
+      (await store.read(bound.binding.thread_binding_id))?.state,
+      "expired",
+    );
+  });
+});
+
+class MutableClock {
+  constructor(private instant: string) {}
+
+  now(): Date {
+    return new Date(this.instant);
+  }
+
+  set(instant: string): void {
+    this.instant = instant;
+  }
+}
+
+class MemoryThreadBindingStore implements ThreadBindingStorePort {
+  private readonly fingerprints = new Map<string, string>();
+  private readonly records = new Map<string, SlackThreadBindingV1>();
+  private failPut = false;
+  writeCount = 0;
+
+  putIfAbsent(commit: ThreadBindingCommit): Promise<ThreadBindingCommitResult> {
+    if (this.failPut) {
+      this.failPut = false;
+      return Promise.reject(new Error("injected thread binding failure"));
+    }
+    const id = commit.binding.thread_binding_id;
+    const prior = this.records.get(id);
+    if (prior !== undefined) {
+      if (this.fingerprints.get(id) !== commit.payload_fingerprint) {
+        return Promise.reject(
+          new ThreadBindingConflictError(
+            "The thread identity already has different intent.",
+          ),
+        );
+      }
+      return Promise.resolve({ binding: structuredClone(prior), created: false });
+    }
+    this.records.set(id, structuredClone(commit.binding));
+    this.fingerprints.set(id, commit.payload_fingerprint);
+    this.writeCount += 1;
+    return Promise.resolve({ binding: structuredClone(commit.binding), created: true });
+  }
+
+  read(threadBindingId: string): Promise<SlackThreadBindingV1 | undefined> {
+    const binding = this.records.get(threadBindingId);
+    return Promise.resolve(binding === undefined ? undefined : structuredClone(binding));
+  }
+
+  close(threadBindingId: string, closedAt: string): Promise<SlackThreadBindingV1> {
+    const binding = this.require(threadBindingId);
+    if (binding.state === "closed") {
+      return Promise.resolve(structuredClone(binding));
+    }
+    binding.closed_at = closedAt;
+    binding.state = "closed";
+    binding.updated_at = closedAt;
+    return Promise.resolve(structuredClone(binding));
+  }
+
+  expire(threadBindingId: string, expiredAt: string): Promise<SlackThreadBindingV1> {
+    const binding = this.require(threadBindingId);
+    if (binding.state === "active") {
+      binding.state = "expired";
+      binding.updated_at = expiredAt;
+    }
+    return Promise.resolve(structuredClone(binding));
+  }
+
+  failNext(): void {
+    this.failPut = true;
+  }
+
+  private require(threadBindingId: string): SlackThreadBindingV1 {
+    const binding = this.records.get(threadBindingId);
+    if (binding === undefined) {
+      throw new Error("thread binding does not exist");
+    }
+    return binding;
+  }
+}
+
+function makeCoordinator(
+  store: MemoryThreadBindingStore,
+): SlackThreadBindingCoordinator {
+  return new SlackThreadBindingCoordinator(new MutableClock(now), store);
+}
+
+function bindingRequest(
+  changes: Partial<BindSlackThreadRequest> = {},
+): BindSlackThreadRequest {
+  return {
+    app_id: "app-1",
+    binding_id: "binding-1",
+    conversation_id: "conversation-1",
+    delivery_id: "delivery-1",
+    destination_receipt: "destination-1",
+    expires_at: "2026-07-16T13:00:00.000Z",
+    goal_ref: "goal://explain-control",
+    installation_id: "installation-1",
+    subject_ref: "subject://control-1",
+    thread_id: "thread-1",
+    ...changes,
+  };
+}
+
+function deliveredReceipt(): DeliveryReceiptV1 {
+  return {
+    created_at: now,
+    delivery_id: "delivery-1",
+    destination_ref: "conversation://conversation-1/thread-1",
+    parts: [
+      {
+        delivered_at: now,
+        destination_receipt: "destination-1",
+        idempotency_key: "message-1",
+        part_id: "part-1",
+        payload_digest: "sha256:payload-1",
+        payload_ref: "payload://1",
+        sequence: 1,
+        state: "delivered",
+      },
+    ],
+    run_id: "run-1",
+    schema_version: "delivery-receipt/v1",
+    state: "completed",
+    updated_at: now,
+  };
+}

--- a/apps/slack-companion/test/transport.test.ts
+++ b/apps/slack-companion/test/transport.test.ts
@@ -1,0 +1,419 @@
+import assert from "node:assert/strict";
+import { createHash, createHmac, randomBytes } from "node:crypto";
+import { describe, test } from "node:test";
+import type {
+  SlackAdmissionResult,
+  SlackIngressEnvelope,
+} from "../src/contracts.js";
+import type {
+  DurableInboundPayloadPort,
+  InboundPayloadCommit,
+  InboundPayloadReceipt,
+  SlackEventNormalizationInput,
+  SlackEventsApiRequest,
+  SlackSocketModeEnvelope,
+} from "../src/transport/contracts.js";
+import {
+  handleEventsApiRequest,
+  handleSocketModeRequest,
+} from "../src/transport/handler.js";
+import { StructuralSlackEventNormalizer } from "../src/transport/normalization.js";
+import { evaluateSlackIngressReadiness } from "../src/transport/readiness.js";
+
+const now = new Date("2026-07-16T12:00:00.000Z");
+const timestamp = String(Math.floor(now.getTime() / 1_000));
+const signingKey = randomBytes(32);
+
+describe("Slack transport boundary", () => {
+  test("persists before normalization and admits before returning an Events API acknowledgement", async () => {
+    const order: string[] = [];
+    const payloads = new MemoryPayloadStore(order);
+    const request = eventsRequest(eventBody());
+
+    const outcome = await handleEventsApiRequest(request, requestKey(), {
+      admission: acceptingAdmission(order),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(order),
+      payloads,
+    });
+
+    assert.deepEqual(order, ["persist", "normalize", "admit"]);
+    assert.deepEqual(outcome, {
+      command: { body: "", kind: "events_api_ack", status_code: 200 },
+      kind: "acknowledge",
+      run_id: "run-event-1",
+    });
+    assert.deepEqual(payloads.rawBodies, [request.raw_body]);
+  });
+
+  test("does not normalize, admit, or acknowledge when payload persistence fails", async () => {
+    const order: string[] = [];
+    const payloads = new MemoryPayloadStore(order);
+    payloads.fail = true;
+
+    const outcome = await handleEventsApiRequest(
+      eventsRequest(eventBody()),
+      requestKey(),
+      {
+        admission: acceptingAdmission(order),
+        clock: { now: () => now },
+        normalizer: recordingNormalizer(order),
+        payloads,
+      },
+    );
+
+    assert.deepEqual(order, ["persist"]);
+    assert.deepEqual(outcome, {
+      kind: "no_acknowledgement",
+      reason_code: "payload_not_durable",
+      retryable: true,
+      stage: "persistence",
+    });
+  });
+
+  test("does not acknowledge when durable admission rejects the event", async () => {
+    const order: string[] = [];
+
+    const outcome = await handleEventsApiRequest(
+      eventsRequest(eventBody()),
+      requestKey(),
+      {
+        admission: {
+          admit: async () => {
+            order.push("admit");
+            return rejection(true);
+          },
+        },
+        clock: { now: () => now },
+        normalizer: recordingNormalizer(order),
+        payloads: new MemoryPayloadStore(order),
+      },
+    );
+
+    assert.deepEqual(order, ["persist", "normalize", "admit"]);
+    assert.deepEqual(outcome, {
+      kind: "no_acknowledgement",
+      reason_code: "durable_admission_rejected",
+      retryable: true,
+      stage: "admission",
+    });
+  });
+
+  test("reuses the durable payload and run when Slack retries an event", async () => {
+    const order: string[] = [];
+    const payloads = new MemoryPayloadStore(order);
+    const admitted = new Map<string, string>();
+    const request = eventsRequest(eventBody());
+    const admission = {
+      admit: async (envelope: SlackIngressEnvelope): Promise<SlackAdmissionResult> => {
+        const runId = admitted.get(envelope.event_id) ?? `run-${envelope.event_id}`;
+        const duplicate = admitted.has(envelope.event_id);
+        admitted.set(envelope.event_id, runId);
+        return accepted(runId, duplicate);
+      },
+    };
+    const dependencies = {
+      admission,
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(order),
+      payloads,
+    };
+
+    const first = await handleEventsApiRequest(request, requestKey(), dependencies);
+    const second = await handleEventsApiRequest(request, requestKey(), dependencies);
+
+    assert.equal(first.kind, "acknowledge");
+    assert.equal(second.kind, "acknowledge");
+    if (first.kind !== "acknowledge" || second.kind !== "acknowledge") {
+      assert.fail("expected both retries to be acknowledged");
+    }
+    assert.equal(second.run_id, first.run_id);
+    assert.equal(payloads.receiptCount, 1);
+    assert.deepEqual(payloads.commitKeys, [
+      "slack:app-1:team-1:event-1",
+      "slack:app-1:team-1:event-1",
+    ]);
+  });
+
+  test("rejects bad and stale signatures before payload persistence", async () => {
+    const badOrder: string[] = [];
+    const badRequest = eventsRequest(eventBody());
+    badRequest.request_signature = `v0=${"0".repeat(64)}`;
+
+    const bad = await handleEventsApiRequest(badRequest, requestKey(), {
+      admission: acceptingAdmission(badOrder),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(badOrder),
+      payloads: new MemoryPayloadStore(badOrder),
+    });
+
+    const staleOrder: string[] = [];
+    const staleTimestamp = String(Number(timestamp) - 301);
+    const staleRequest = eventsRequest(eventBody(), staleTimestamp);
+    const stale = await handleEventsApiRequest(staleRequest, requestKey(), {
+      admission: acceptingAdmission(staleOrder),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(staleOrder),
+      payloads: new MemoryPayloadStore(staleOrder),
+    });
+
+    assert.deepEqual(badOrder, []);
+    assert.deepEqual(staleOrder, []);
+    assert.deepEqual(bad, {
+      kind: "no_acknowledgement",
+      reason_code: "invalid_signature",
+      retryable: false,
+      stage: "verification",
+    });
+    assert.deepEqual(stale, {
+      kind: "no_acknowledgement",
+      reason_code: "stale_timestamp",
+      retryable: false,
+      stage: "verification",
+    });
+  });
+
+  test("verifies the signature against the exact raw request bytes", async () => {
+    const order: string[] = [];
+    const request = eventsRequest(eventBody());
+    request.raw_body = Buffer.concat([request.raw_body, Buffer.from(" ")]);
+
+    const outcome = await handleEventsApiRequest(request, requestKey(), {
+      admission: acceptingAdmission(order),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(order),
+      payloads: new MemoryPayloadStore(order),
+    });
+
+    assert.deepEqual(order, []);
+    assert.equal(outcome.kind, "no_acknowledgement");
+    if (outcome.kind !== "no_acknowledgement") {
+      assert.fail("expected a signature failure");
+    }
+    assert.equal(outcome.reason_code, "invalid_signature");
+  });
+
+  test("authenticates a URL verification challenge without persisting or admitting it", async () => {
+    const order: string[] = [];
+    const request = eventsRequest(
+      JSON.stringify({
+        api_app_id: "app-1",
+        challenge: "challenge-value",
+        type: "url_verification",
+      }),
+    );
+
+    const outcome = await handleEventsApiRequest(request, requestKey(), {
+      admission: acceptingAdmission(order),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(order),
+      payloads: new MemoryPayloadStore(order),
+    });
+
+    assert.deepEqual(order, []);
+    assert.deepEqual(outcome, {
+      command: {
+        body: "challenge-value",
+        kind: "url_verification",
+        status_code: 200,
+      },
+      kind: "challenge",
+    });
+  });
+
+  test("verifies durable Socket Mode presence before payload persistence", async () => {
+    const order: string[] = [];
+    const payload = JSON.parse(eventBody()) as Record<string, unknown>;
+    const envelope: SlackSocketModeEnvelope = {
+      envelope_id: "socket-envelope-1",
+      payload,
+      type: "events_api",
+    };
+
+    const outcome = await handleSocketModeRequest(
+      {
+        connection: { connection_ref: "connection-1", generation: 3 },
+        raw_body: Buffer.from(JSON.stringify(envelope)),
+        received_at: now.toISOString(),
+        route: route(),
+      },
+      {
+        admission: acceptingAdmission(order),
+        normalizer: recordingNormalizer(order),
+        payloads: new MemoryPayloadStore(order),
+        presence: {
+          isActive: async () => {
+            order.push("verify");
+            return true;
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(order, ["verify", "persist", "normalize", "admit"]);
+    assert.deepEqual(outcome, {
+      command: {
+        envelope_id: "socket-envelope-1",
+        kind: "socket_mode_ack",
+      },
+      kind: "acknowledge",
+      run_id: "run-event-1",
+    });
+  });
+});
+
+describe("Slack ingress readiness", () => {
+  test("Events API requires public ingress capability", () => {
+    assert.deepEqual(
+      evaluateSlackIngressReadiness("events_api", {
+        durable_presence_relay: true,
+        public_ingress: false,
+      }),
+      { ready: false, reason_code: "public_ingress_required" },
+    );
+  });
+
+  test("Socket Mode requires a durable presence relay", () => {
+    assert.deepEqual(
+      evaluateSlackIngressReadiness("socket_mode", {
+        durable_presence_relay: false,
+        public_ingress: true,
+      }),
+      { ready: false, reason_code: "durable_presence_relay_required" },
+    );
+  });
+});
+
+class MemoryPayloadStore implements DurableInboundPayloadPort {
+  fail = false;
+  readonly commitKeys: string[] = [];
+  readonly rawBodies: Uint8Array[] = [];
+  private readonly order: string[];
+  private readonly receipts = new Map<string, InboundPayloadReceipt>();
+
+  constructor(order: string[]) {
+    this.order = order;
+  }
+
+  get receiptCount(): number {
+    return this.receipts.size;
+  }
+
+  async persist(commit: InboundPayloadCommit): Promise<InboundPayloadReceipt> {
+    this.order.push("persist");
+    this.commitKeys.push(commit.idempotency_key);
+    this.rawBodies.push(commit.raw_body);
+    if (this.fail) {
+      throw new Error("persistence unavailable");
+    }
+    const existing = this.receipts.get(commit.idempotency_key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const digest = createHash("sha256").update(commit.raw_body).digest("hex");
+    const receipt = {
+      digest: `sha256:${digest}`,
+      payload_ref: `payload-ref:${commit.idempotency_key}`,
+    };
+    this.receipts.set(commit.idempotency_key, receipt);
+    return receipt;
+  }
+}
+
+function eventsRequest(
+  rawBody: string,
+  requestTimestamp = timestamp,
+): SlackEventsApiRequest {
+  const raw = Buffer.from(rawBody);
+  const key = requestKey();
+  return {
+    raw_body: raw,
+    received_at: now.toISOString(),
+    request_signature: sign(raw, requestTimestamp, key),
+    request_timestamp: requestTimestamp,
+    route: route(),
+  };
+}
+
+function eventBody(): string {
+  return JSON.stringify({
+    api_app_id: "app-1",
+    event: {
+      channel: "conversation-1",
+      thread_ts: "thread-1",
+      ts: "event-time-1",
+      type: "app_mention",
+    },
+    event_id: "event-1",
+    event_time: Math.floor(now.getTime() / 1_000),
+    team_id: "team-1",
+    type: "event_callback",
+  });
+}
+
+function route() {
+  return {
+    binding_id: "binding-1",
+    required_capabilities: [],
+    retention_policy_ref: "retention-policy-1",
+    run_kind: "interactive" as const,
+    tenant_id: "tenant-1",
+  };
+}
+
+function requestKey(): Uint8Array {
+  return signingKey;
+}
+
+function sign(
+  rawBody: Uint8Array,
+  requestTimestamp: string,
+  key: Uint8Array,
+): string {
+  return `v0=${createHmac("sha256", key)
+    .update("v0:")
+    .update(requestTimestamp)
+    .update(":")
+    .update(rawBody)
+    .digest("hex")}`;
+}
+
+function recordingNormalizer(order: string[]) {
+  const structural = new StructuralSlackEventNormalizer();
+  return {
+    normalize(input: SlackEventNormalizationInput): SlackIngressEnvelope {
+      order.push("normalize");
+      return structural.normalize(input);
+    },
+  };
+}
+
+function acceptingAdmission(order: string[]) {
+  return {
+    admit: async (envelope: SlackIngressEnvelope): Promise<SlackAdmissionResult> => {
+      order.push("admit");
+      return accepted(`run-${envelope.event_id}`, false);
+    },
+  };
+}
+
+function accepted(runId: string, duplicate: boolean): SlackAdmissionResult {
+  return {
+    acknowledgement_permitted: true,
+    duplicate,
+    message: "Request saved and queued.",
+    retryable: false,
+    run_id: runId,
+    status: "queued",
+  };
+}
+
+function rejection(retryable: boolean): SlackAdmissionResult {
+  return {
+    acknowledgement_permitted: false,
+    duplicate: false,
+    message: "Request was not admitted.",
+    retryable,
+    status: "rejected",
+  };
+}


### PR DESCRIPTION
## Summary

- acquire, renew, release, and recover durable run leases with generation and fencing proofs
- reject generation regression and stale owners during rolling replacement
- checkpoint long turns and resume from the latest exact durable checkpoint
- record external effect intent before execution, including approval, rollback, unknown-outcome, and independent verification truth
- reconcile expired leases and mark executing effects unknown instead of guessing their outcome
- hand finished execution to `delivering`; delivery reconciliation alone may mark a Slack run complete

## Safety boundary

This slice defines portable execution ports and an in-memory conformance fixture. It includes no worker placement, persistence provider, credential resolution, deployment values, or rollout policy.

## Validation

- Slack companion typecheck
- Slack companion tests (16 passed)
- `go test ./tools/archtests/...`
- disclosure and configuration scans
- Practice Registry plan, diff, scan, and final gates passed
