### PR TITLE
Route deployed revision questions to version

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -2230,7 +2230,7 @@ func mcpTools() []mcpTool {
 		{
 			Name:         "cerebro.version",
 			Title:        "Running Cerebro Build",
-			Description:  "Identify the release running on this server, including service version, commit, build date, and API version.",
+			Description:  "Identify which Cerebro revision is deployed and running on this server, including release, service version, commit, build date, and API version.",
 			InputSchema:  mcpObjectSchema(nil, nil),
 			OutputSchema: mcpOutputSchema(nil),
 			Annotations:  mcpReadOnlyAnnotations("Cerebro Version"),

--- a/internal/mcpoperations/testdata/task_tools/selection_cases.json
+++ b/internal/mcpoperations/testdata/task_tools/selection_cases.json
@@ -538,5 +538,15 @@
     "forbidden_tools": ["cerebro.graph.paths"],
     "require_partial_handling": true,
     "maximum_call_count": 2
+  },
+  {
+    "id": "version-deployed-revision-language",
+    "user_request": "Which revision is deployed?",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.version",
+    "allowed_followup_tools": [],
+    "forbidden_tools": ["cerebro.agent.control_plane"],
+    "require_partial_handling": false,
+    "maximum_call_count": 1
   }
 ]


### PR DESCRIPTION
### Summary

- add a task-selection case for “Which revision is deployed?”
- include deployed revision language in the advertised Cerebro version description
- keep evaluator semantics unchanged

### Measured result

- before: 54/55 correct, 1 unselected case, version accuracy 5/6
- after: 55/55 correct, 0 unselected cases, version accuracy 6/6
- new-case winning margin: 6
- corpus minimum winning margin remains 4

### Validation

- `go test ./internal/mcpoperations ./internal/bootstrap -count=1`
- `make check-structural`
- internal lint shard 1
- `make changed-check`
- `git diff --check origin/main...HEAD`