### PR TITLE
feat(slack): make delivery resumable

### DIFF
--- a/apps/slack-companion/src/delivery/contracts.ts
+++ b/apps/slack-companion/src/delivery/contracts.ts
@@ -1,0 +1,103 @@
+import type {
+  DeliveryPartV1,
+  DeliveryReceiptV1,
+  WorkLeaseV1,
+} from "@writer/cerebro-sdk";
+
+export type { DeliveryPartV1, DeliveryReceiptV1, WorkLeaseV1 };
+
+export interface DeliveryPayloadPart {
+  payload_digest: string;
+  payload_ref: string;
+}
+
+/** One logical delivery. Reusing delivery_key with different content conflicts. */
+export interface DeliveryPlanRequest {
+  delivery_key: string;
+  destination_ref: string;
+  max_attempts: number;
+  parts: readonly DeliveryPayloadPart[];
+  run_id: string;
+}
+
+export interface DurableDeliveryPlan {
+  max_attempts: number;
+  payload_fingerprint: string;
+  receipt: DeliveryReceiptV1;
+}
+
+export interface DeliveryPlanResult {
+  created: boolean;
+  receipt: DeliveryReceiptV1;
+}
+
+export interface DeliveryPartClaim {
+  attempt: number;
+  client_message_id: string;
+  delivery_id: string;
+  lease: WorkLeaseV1;
+  part: DeliveryPartV1;
+}
+
+export type DeliveryClaimResult =
+  | { claim: DeliveryPartClaim; status: "claimed" }
+  | {
+      reason: "abandoned" | "busy" | "complete" | "paused" | "retry_exhausted";
+      receipt: DeliveryReceiptV1;
+      status: "idle";
+    };
+
+export interface DeliveryClaimRequest {
+  delivery_id: string;
+  lease: WorkLeaseV1;
+  now: string;
+}
+
+export interface DeliveryCompletionRequest {
+  accepted_at: string;
+  delivery_id: string;
+  destination_receipt: string;
+  lease: WorkLeaseV1;
+  part_id: string;
+}
+
+export interface DeliveryFailureRequest {
+  delivery_id: string;
+  failed_at: string;
+  lease: WorkLeaseV1;
+  part_id: string;
+}
+
+export interface DeliveryMaintenanceRequest {
+  delivery_id: string;
+  lease: WorkLeaseV1;
+  occurred_at: string;
+}
+
+export interface PlatformDeliveryRequest {
+  client_message_id: string;
+  destination_ref: string;
+  payload_digest: string;
+  payload_ref: string;
+}
+
+export interface PlatformAcceptanceReceipt {
+  accepted_at: string;
+  destination_receipt: string;
+}
+
+export type DeliveryStepResult =
+  | {
+      destination_receipt: string;
+      part_id: string;
+      receipt: DeliveryReceiptV1;
+      status: "delivered";
+    }
+  | {
+      receipt: DeliveryReceiptV1;
+      status: "abandoned" | "busy" | "complete" | "paused" | "retry_exhausted";
+    }
+  | {
+      receipt: DeliveryReceiptV1;
+      status: "retry_scheduled";
+    };

--- a/apps/slack-companion/src/delivery/coordinator.ts
+++ b/apps/slack-companion/src/delivery/coordinator.ts
@@ -1,0 +1,218 @@
+import { createHash } from "node:crypto";
+import type {
+  DeliveryPartV1,
+  DeliveryPlanRequest,
+  DeliveryPlanResult,
+  DeliveryStepResult,
+  WorkLeaseV1,
+} from "./contracts.js";
+import type {
+  DeliveryClockPort,
+  DurableDeliveryPort,
+  PlatformDeliveryPort,
+} from "./ports.js";
+
+export class DeliveryInputError extends Error {}
+
+export interface DeliveryCoordinatorOptions {
+  clock: DeliveryClockPort;
+  sender: PlatformDeliveryPort;
+  store: DurableDeliveryPort;
+}
+
+export class DeliveryCoordinator {
+  private readonly clock: DeliveryClockPort;
+  private readonly sender: PlatformDeliveryPort;
+  private readonly store: DurableDeliveryPort;
+
+  constructor(options: DeliveryCoordinatorOptions) {
+    this.clock = options.clock;
+    this.sender = options.sender;
+    this.store = options.store;
+  }
+
+  async plan(request: DeliveryPlanRequest): Promise<DeliveryPlanResult> {
+    validatePlan(request);
+    const now = this.clock.now().toISOString();
+    const deliveryId = stableIdentity("delivery", [
+      request.run_id,
+      request.destination_ref,
+      request.delivery_key,
+    ]);
+    const parts: DeliveryPartV1[] = request.parts.map((part, index) => {
+      const sequence = index + 1;
+      const partId = stableIdentity("part", [deliveryId, String(sequence)]);
+      return {
+        idempotency_key: stableIdentity("message", [deliveryId, partId]),
+        part_id: partId,
+        payload_digest: part.payload_digest,
+        payload_ref: part.payload_ref,
+        sequence,
+        state: "pending",
+      };
+    });
+
+    return this.store.plan({
+      max_attempts: request.max_attempts,
+      payload_fingerprint: payloadFingerprint(request),
+      receipt: {
+        created_at: now,
+        delivery_id: deliveryId,
+        destination_ref: request.destination_ref,
+        parts,
+        run_id: request.run_id,
+        schema_version: "delivery-receipt/v1",
+        state: "pending",
+        updated_at: now,
+      },
+    });
+  }
+
+  async deliverNext(
+    deliveryId: string,
+    lease: WorkLeaseV1,
+  ): Promise<DeliveryStepResult> {
+    const claimResult = await this.store.claimNext({
+      delivery_id: deliveryId,
+      lease,
+      now: this.clock.now().toISOString(),
+    });
+    if (claimResult.status === "idle") {
+      return {
+        receipt: claimResult.receipt,
+        status: claimResult.reason,
+      };
+    }
+
+    const { claim } = claimResult;
+    const plannedReceipt = await this.requireReceipt(deliveryId);
+    let acceptance;
+    try {
+      acceptance = await this.sender.send({
+        client_message_id: claim.client_message_id,
+        destination_ref: plannedReceipt.destination_ref,
+        payload_digest: claim.part.payload_digest,
+        payload_ref: claim.part.payload_ref,
+      });
+    } catch {
+      const receipt = await this.store.recordFailure({
+        delivery_id: deliveryId,
+        failed_at: this.clock.now().toISOString(),
+        lease,
+        part_id: claim.part.part_id,
+      });
+      return {
+        receipt,
+        status: receipt.state === "failed"
+          ? "retry_exhausted"
+          : "retry_scheduled",
+      };
+    }
+    if (!acceptance.destination_receipt) {
+      const receipt = await this.store.recordFailure({
+        delivery_id: deliveryId,
+        failed_at: this.clock.now().toISOString(),
+        lease,
+        part_id: claim.part.part_id,
+      });
+      return {
+        receipt,
+        status: receipt.state === "failed"
+          ? "retry_exhausted"
+          : "retry_scheduled",
+      };
+    }
+
+    // Once the destination accepts, never rewrite this as a send failure. If
+    // persistence is interrupted, the stable client_message_id makes recovery
+    // safe after the claim expires.
+    const receipt = await this.store.completePart({
+      accepted_at: acceptance.accepted_at,
+      delivery_id: deliveryId,
+      destination_receipt: acceptance.destination_receipt,
+      lease,
+      part_id: claim.part.part_id,
+    });
+    return {
+      destination_receipt: acceptance.destination_receipt,
+      part_id: claim.part.part_id,
+      receipt,
+      status: "delivered",
+    };
+  }
+
+  abandon(deliveryId: string, lease: WorkLeaseV1) {
+    return this.store.abandon({
+      delivery_id: deliveryId,
+      lease,
+      occurred_at: this.clock.now().toISOString(),
+    });
+  }
+
+  pause(deliveryId: string, lease: WorkLeaseV1) {
+    return this.store.pause({
+      delivery_id: deliveryId,
+      lease,
+      occurred_at: this.clock.now().toISOString(),
+    });
+  }
+
+  resume(deliveryId: string, lease: WorkLeaseV1) {
+    return this.store.resume({
+      delivery_id: deliveryId,
+      lease,
+      occurred_at: this.clock.now().toISOString(),
+    });
+  }
+
+  private async requireReceipt(deliveryId: string) {
+    const receipt = await this.store.read(deliveryId);
+    if (receipt === undefined) {
+      throw new DeliveryInputError("The delivery does not exist.");
+    }
+    return receipt;
+  }
+}
+
+function validatePlan(request: DeliveryPlanRequest): void {
+  if (
+    !request.delivery_key ||
+    !request.destination_ref ||
+    !request.run_id ||
+    request.parts.length === 0
+  ) {
+    throw new DeliveryInputError(
+      "Delivery key, destination, run, and at least one part are required.",
+    );
+  }
+  if (!Number.isInteger(request.max_attempts) || request.max_attempts < 1) {
+    throw new DeliveryInputError("max_attempts must be a positive integer.");
+  }
+  for (const part of request.parts) {
+    if (!part.payload_digest || !part.payload_ref) {
+      throw new DeliveryInputError(
+        "Each delivery part requires a payload reference and digest.",
+      );
+    }
+  }
+}
+
+function payloadFingerprint(request: DeliveryPlanRequest): string {
+  return digest(
+    JSON.stringify({
+      delivery_key: request.delivery_key,
+      destination_ref: request.destination_ref,
+      max_attempts: request.max_attempts,
+      parts: request.parts.map((part) => [part.payload_digest, part.payload_ref]),
+      run_id: request.run_id,
+    }),
+  );
+}
+
+export function stableIdentity(namespace: string, fields: readonly string[]): string {
+  return `${namespace}-${digest(JSON.stringify(fields)).slice(0, 32)}`;
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/apps/slack-companion/src/delivery/ports.ts
+++ b/apps/slack-companion/src/delivery/ports.ts
@@ -1,0 +1,37 @@
+import type {
+  DeliveryClaimRequest,
+  DeliveryClaimResult,
+  DeliveryCompletionRequest,
+  DeliveryFailureRequest,
+  DeliveryMaintenanceRequest,
+  DeliveryPlanResult,
+  DeliveryReceiptV1,
+  DurableDeliveryPlan,
+  PlatformAcceptanceReceipt,
+  PlatformDeliveryRequest,
+} from "./contracts.js";
+
+export interface DeliveryClockPort {
+  now(): Date;
+}
+
+/**
+ * A production adapter durably stores max_attempts and the payload fingerprint
+ * with the receipt. Each operation is atomic with its generation and fencing
+ * checks. Process-local queues are not a valid implementation.
+ */
+export interface DurableDeliveryPort {
+  abandon(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1>;
+  claimNext(request: DeliveryClaimRequest): Promise<DeliveryClaimResult>;
+  completePart(request: DeliveryCompletionRequest): Promise<DeliveryReceiptV1>;
+  pause(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1>;
+  plan(delivery: DurableDeliveryPlan): Promise<DeliveryPlanResult>;
+  read(deliveryId: string): Promise<DeliveryReceiptV1 | undefined>;
+  recordFailure(request: DeliveryFailureRequest): Promise<DeliveryReceiptV1>;
+  resume(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1>;
+}
+
+/** The transport must honor client_message_id as an idempotency identity. */
+export interface PlatformDeliveryPort {
+  send(request: PlatformDeliveryRequest): Promise<PlatformAcceptanceReceipt>;
+}

--- a/apps/slack-companion/src/delivery/reference-store.ts
+++ b/apps/slack-companion/src/delivery/reference-store.ts
@@ -1,0 +1,410 @@
+import type {
+  DeliveryClaimRequest,
+  DeliveryClaimResult,
+  DeliveryCompletionRequest,
+  DeliveryFailureRequest,
+  DeliveryMaintenanceRequest,
+  DeliveryPartClaim,
+  DeliveryPlanResult,
+  DeliveryReceiptV1,
+  DurableDeliveryPlan,
+  WorkLeaseV1,
+} from "./contracts.js";
+import type { DurableDeliveryPort } from "./ports.js";
+
+export class DeliveryConflictError extends Error {}
+export class DeliveryFenceError extends Error {}
+export class DeliveryNotFoundError extends Error {}
+
+interface StoredDelivery {
+  attempts: Map<string, number>;
+  claims: Map<string, DeliveryPartClaim>;
+  maxAttempts: number;
+  pausedStates: Map<string, DeliveryReceiptV1["parts"][number]["state"]>;
+  payloadFingerprint: string;
+  receipt: DeliveryReceiptV1;
+}
+
+/** Conformance fixture only. Production adapters must use durable storage. */
+export class ReferenceMemoryDeliveryStore implements DurableDeliveryPort {
+  private activeGeneration: number;
+  private readonly acceptedLeaseByRun = new Map<string, WorkLeaseV1>();
+  private readonly deliveries = new Map<string, StoredDelivery>();
+  private failPlan = false;
+  private failCompletion = false;
+
+  constructor(activeGeneration: number) {
+    this.activeGeneration = activeGeneration;
+  }
+
+  plan(delivery: DurableDeliveryPlan): Promise<DeliveryPlanResult> {
+    if (this.failPlan) {
+      this.failPlan = false;
+      return Promise.reject(new Error("injected delivery plan failure"));
+    }
+    const prior = this.deliveries.get(delivery.receipt.delivery_id);
+    if (prior !== undefined) {
+      if (prior.payloadFingerprint !== delivery.payload_fingerprint) {
+        return Promise.reject(
+          new DeliveryConflictError(
+            "The delivery identity already has a different payload.",
+          ),
+        );
+      }
+      return Promise.resolve({ created: false, receipt: copy(prior.receipt) });
+    }
+    this.deliveries.set(delivery.receipt.delivery_id, {
+      attempts: new Map(),
+      claims: new Map(),
+      maxAttempts: delivery.max_attempts,
+      pausedStates: new Map(),
+      payloadFingerprint: delivery.payload_fingerprint,
+      receipt: copy(delivery.receipt),
+    });
+    return Promise.resolve({ created: true, receipt: copy(delivery.receipt) });
+  }
+
+  async claimNext(request: DeliveryClaimRequest): Promise<DeliveryClaimResult> {
+    const stored = this.requireDelivery(request.delivery_id);
+    if (request.lease.run_id !== stored.receipt.run_id) {
+      throw new DeliveryFenceError("The lease belongs to another run.");
+    }
+    if (stored.receipt.state === "abandoned") {
+      return {
+        reason: "abandoned",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    if (stored.receipt.state === "paused") {
+      return {
+        reason: "paused",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    this.acceptLease(request.lease, request.now);
+
+    const part = [...stored.receipt.parts].sort(
+      (left, right) => left.sequence - right.sequence,
+    ).find((candidate) => candidate.state !== "delivered");
+    if (part === undefined) {
+      stored.receipt.state = "completed";
+      return {
+        reason: "complete",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    if (part.state === "abandoned") {
+      stored.receipt.state = "abandoned";
+      return {
+        reason: "abandoned",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    if (part.state === "paused") {
+      stored.receipt.state = "paused";
+      return {
+        reason: "paused",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+
+    const attempts = stored.attempts.get(part.part_id) ?? 0;
+    if (attempts >= stored.maxAttempts) {
+      stored.receipt.state = "failed";
+      return {
+        reason: "retry_exhausted",
+        receipt: copy(stored.receipt),
+        status: "idle",
+      };
+    }
+    const priorClaim = stored.claims.get(part.part_id);
+    if (priorClaim !== undefined) {
+      if (sameLease(priorClaim.lease, request.lease)) {
+        return { claim: copy(priorClaim), status: "claimed" };
+      }
+      if (Date.parse(priorClaim.lease.lease_expires_at) > Date.parse(request.now)) {
+        return {
+          reason: "busy",
+          receipt: copy(stored.receipt),
+          status: "idle",
+        };
+      }
+      if (request.lease.fencing_token <= priorClaim.lease.fencing_token) {
+        throw new DeliveryFenceError(
+          "Expired delivery claims require a newer fencing value.",
+        );
+      }
+    }
+
+    const claim: DeliveryPartClaim = {
+      attempt: attempts + 1,
+      client_message_id: part.idempotency_key,
+      delivery_id: request.delivery_id,
+      lease: copy(request.lease),
+      part: copy({ ...part, state: "delivering" }),
+    };
+    stored.attempts.set(part.part_id, claim.attempt);
+    stored.claims.set(part.part_id, copy(claim));
+    part.state = "delivering";
+    stored.receipt.state = "delivering";
+    stored.receipt.updated_at = request.now;
+    return { claim: copy(claim), status: "claimed" };
+  }
+
+  async pause(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1> {
+    const stored = this.requireDelivery(request.delivery_id);
+    if (["abandoned", "completed"].includes(stored.receipt.state)) {
+      return copy(stored.receipt);
+    }
+    this.requireRun(stored, request.lease);
+    this.acceptLease(request.lease, request.occurred_at);
+    for (const part of stored.receipt.parts) {
+      if (part.state === "delivered" || part.state === "abandoned") {
+        continue;
+      }
+      stored.pausedStates.set(
+        part.part_id,
+        part.state === "delivering" ? "pending" : part.state,
+      );
+      part.state = "paused";
+    }
+    stored.claims.clear();
+    stored.receipt.state = "paused";
+    stored.receipt.updated_at = request.occurred_at;
+    return copy(stored.receipt);
+  }
+
+  async resume(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1> {
+    const stored = this.requireDelivery(request.delivery_id);
+    if (stored.receipt.state === "abandoned") {
+      throw new DeliveryConflictError("An abandoned delivery cannot resume.");
+    }
+    if (stored.receipt.state === "completed") {
+      return copy(stored.receipt);
+    }
+    this.requireRun(stored, request.lease);
+    this.acceptLease(request.lease, request.occurred_at);
+    if (stored.receipt.state !== "paused") {
+      return copy(stored.receipt);
+    }
+    for (const part of stored.receipt.parts) {
+      if (part.state !== "paused") {
+        continue;
+      }
+      part.state = stored.pausedStates.get(part.part_id) ?? "pending";
+    }
+    stored.pausedStates.clear();
+    stored.receipt.state = aggregate(stored);
+    stored.receipt.updated_at = request.occurred_at;
+    return copy(stored.receipt);
+  }
+
+  async abandon(request: DeliveryMaintenanceRequest): Promise<DeliveryReceiptV1> {
+    const stored = this.requireDelivery(request.delivery_id);
+    if (stored.receipt.state === "abandoned") {
+      return copy(stored.receipt);
+    }
+    if (stored.receipt.state === "completed") {
+      return copy(stored.receipt);
+    }
+    this.requireRun(stored, request.lease);
+    this.acceptLease(request.lease, request.occurred_at);
+    for (const part of stored.receipt.parts) {
+      if (part.state !== "delivered") {
+        part.state = "abandoned";
+      }
+    }
+    stored.claims.clear();
+    stored.pausedStates.clear();
+    stored.receipt.state = "abandoned";
+    stored.receipt.updated_at = request.occurred_at;
+    return copy(stored.receipt);
+  }
+
+  async completePart(
+    request: DeliveryCompletionRequest,
+  ): Promise<DeliveryReceiptV1> {
+    if (this.failCompletion) {
+      this.failCompletion = false;
+      return Promise.reject(new Error("injected completion failure"));
+    }
+    const stored = this.requireDelivery(request.delivery_id);
+    if (!request.destination_receipt) {
+      throw new DeliveryConflictError("A destination receipt is required.");
+    }
+    const part = requirePart(stored.receipt, request.part_id);
+    if (part.state === "delivered") {
+      if (part.destination_receipt !== request.destination_receipt) {
+        return Promise.reject(
+          new DeliveryConflictError(
+            "The part already has a different destination receipt.",
+          ),
+        );
+      }
+      return Promise.resolve(copy(stored.receipt));
+    }
+    this.requireClaim(stored, request.part_id, request.lease, request.accepted_at);
+    part.delivered_at = request.accepted_at;
+    part.destination_receipt = request.destination_receipt;
+    part.state = "delivered";
+    stored.claims.delete(request.part_id);
+    stored.receipt.updated_at = request.accepted_at;
+    stored.receipt.state = aggregate(stored);
+    return Promise.resolve(copy(stored.receipt));
+  }
+
+  async recordFailure(request: DeliveryFailureRequest): Promise<DeliveryReceiptV1> {
+    const stored = this.requireDelivery(request.delivery_id);
+    const part = requirePart(stored.receipt, request.part_id);
+    this.requireClaim(stored, request.part_id, request.lease, request.failed_at);
+    part.state = "failed";
+    stored.claims.delete(request.part_id);
+    stored.receipt.updated_at = request.failed_at;
+    stored.receipt.state = aggregate(stored);
+    return Promise.resolve(copy(stored.receipt));
+  }
+
+  read(deliveryId: string): Promise<DeliveryReceiptV1 | undefined> {
+    const stored = this.deliveries.get(deliveryId);
+    return Promise.resolve(stored === undefined ? undefined : copy(stored.receipt));
+  }
+
+  failNextCompletion(): void {
+    this.failCompletion = true;
+  }
+
+  failNextPlan(): void {
+    this.failPlan = true;
+  }
+
+  claimCount(deliveryId: string): number {
+    return this.requireDelivery(deliveryId).claims.size;
+  }
+
+  setActiveGeneration(generation: number): void {
+    this.activeGeneration = generation;
+  }
+
+  private acceptLease(lease: WorkLeaseV1, now: string): void {
+    if (lease.generation !== this.activeGeneration) {
+      throw new DeliveryFenceError("The lease generation is not active.");
+    }
+    if (Date.parse(lease.lease_expires_at) <= Date.parse(now)) {
+      throw new DeliveryFenceError("The delivery lease has expired.");
+    }
+    const prior = this.acceptedLeaseByRun.get(lease.run_id);
+    if (prior !== undefined) {
+      if (lease.fencing_token < prior.fencing_token) {
+        throw new DeliveryFenceError("The fencing value is stale.");
+      }
+      if (
+        lease.fencing_token === prior.fencing_token &&
+        !sameLease(lease, prior)
+      ) {
+        throw new DeliveryFenceError(
+          "A fencing value cannot be reused by another lease.",
+        );
+      }
+    }
+    this.acceptedLeaseByRun.set(lease.run_id, copy(lease));
+  }
+
+  private requireClaim(
+    stored: StoredDelivery,
+    partId: string,
+    lease: WorkLeaseV1,
+    occurredAt: string,
+  ): DeliveryPartClaim {
+    if (lease.generation !== this.activeGeneration) {
+      throw new DeliveryFenceError("The lease generation is not active.");
+    }
+    const accepted = this.acceptedLeaseByRun.get(lease.run_id);
+    if (accepted === undefined || !sameLease(accepted, lease)) {
+      throw new DeliveryFenceError("A newer lease owns this delivery.");
+    }
+    const claim = stored.claims.get(partId);
+    if (claim === undefined || !sameLease(claim.lease, lease)) {
+      throw new DeliveryFenceError("The lease does not own this delivery part.");
+    }
+    if (Date.parse(lease.lease_expires_at) <= Date.parse(occurredAt)) {
+      throw new DeliveryFenceError("The delivery lease expired before this update.");
+    }
+    return claim;
+  }
+
+  private requireRun(stored: StoredDelivery, lease: WorkLeaseV1): void {
+    if (lease.run_id !== stored.receipt.run_id) {
+      throw new DeliveryFenceError("The lease belongs to another run.");
+    }
+  }
+
+  private requireDelivery(deliveryId: string): StoredDelivery {
+    const delivery = this.deliveries.get(deliveryId);
+    if (delivery === undefined) {
+      throw new DeliveryNotFoundError("The delivery does not exist.");
+    }
+    return delivery;
+  }
+}
+
+function aggregate(stored: StoredDelivery): DeliveryReceiptV1["state"] {
+  if (stored.receipt.parts.every((part) => part.state === "delivered")) {
+    return "completed";
+  }
+  if (stored.receipt.parts.some((part) => part.state === "abandoned")) {
+    return "abandoned";
+  }
+  if (stored.receipt.parts.some((part) => part.state === "paused")) {
+    return "paused";
+  }
+  if (
+    stored.receipt.parts.some(
+      (part) =>
+        part.state === "failed" &&
+        (stored.attempts.get(part.part_id) ?? 0) >= stored.maxAttempts,
+    )
+  ) {
+    return "failed";
+  }
+  if (
+    stored.receipt.parts.some((part) =>
+      ["delivering", "delivered", "failed"].includes(part.state)
+    )
+  ) {
+    return "delivering";
+  }
+  return "pending";
+}
+
+function requirePart(
+  receipt: DeliveryReceiptV1,
+  partId: string,
+): DeliveryReceiptV1["parts"][number] {
+  const part = receipt.parts.find((candidate) => candidate.part_id === partId);
+  if (part === undefined) {
+    throw new DeliveryNotFoundError("The delivery part does not exist.");
+  }
+  return part;
+}
+
+function sameLease(left: WorkLeaseV1, right: WorkLeaseV1): boolean {
+  return (
+    left.fencing_token === right.fencing_token &&
+    left.generation === right.generation &&
+    left.heartbeat_at === right.heartbeat_at &&
+    left.lease_expires_at === right.lease_expires_at &&
+    left.lease_token === right.lease_token &&
+    left.owner_id === right.owner_id &&
+    left.run_id === right.run_id &&
+    left.schema_version === right.schema_version
+  );
+}
+
+function copy<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/apps/slack-companion/src/thread-binding.ts
+++ b/apps/slack-companion/src/thread-binding.ts
@@ -1,0 +1,193 @@
+import { createHash } from "node:crypto";
+import type { DeliveryReceiptV1 } from "@writer/cerebro-sdk";
+
+export type ThreadBindingState = "active" | "closed" | "expired";
+
+export interface SlackThreadBindingV1 {
+  app_id: string;
+  binding_id: string;
+  closed_at?: string;
+  conversation_id: string;
+  created_at: string;
+  delivery_id: string;
+  destination_receipt: string;
+  destination_ref: string;
+  expires_at: string;
+  goal_ref: string;
+  installation_id: string;
+  schema_version: "slack-thread-binding/v1";
+  state: ThreadBindingState;
+  subject_ref: string;
+  thread_binding_id: string;
+  thread_id: string;
+  updated_at: string;
+}
+
+export interface BindSlackThreadRequest {
+  app_id: string;
+  binding_id: string;
+  conversation_id: string;
+  delivery_id: string;
+  destination_receipt: string;
+  expires_at: string;
+  goal_ref: string;
+  installation_id: string;
+  subject_ref: string;
+  thread_id: string;
+}
+
+export interface ThreadBindingCommit {
+  binding: SlackThreadBindingV1;
+  payload_fingerprint: string;
+}
+
+export interface ThreadBindingCommitResult {
+  binding: SlackThreadBindingV1;
+  created: boolean;
+}
+
+export interface ThreadBindingStorePort {
+  /** All writes are durable, idempotent, and compare the stored fingerprint. */
+  close(threadBindingId: string, closedAt: string): Promise<SlackThreadBindingV1>;
+  expire(threadBindingId: string, expiredAt: string): Promise<SlackThreadBindingV1>;
+  putIfAbsent(commit: ThreadBindingCommit): Promise<ThreadBindingCommitResult>;
+  read(threadBindingId: string): Promise<SlackThreadBindingV1 | undefined>;
+}
+
+export interface ThreadBindingClockPort {
+  now(): Date;
+}
+
+export class ThreadBindingConflictError extends Error {}
+export class ThreadBindingInputError extends Error {}
+
+export class SlackThreadBindingCoordinator {
+  constructor(
+    private readonly clock: ThreadBindingClockPort,
+    private readonly store: ThreadBindingStorePort,
+  ) {}
+
+  async bind(
+    request: BindSlackThreadRequest,
+    delivered: DeliveryReceiptV1,
+  ): Promise<ThreadBindingCommitResult> {
+    validateBindingRequest(request);
+    if (delivered.delivery_id !== request.delivery_id) {
+      throw new ThreadBindingInputError(
+        "A thread can only bind to its own delivery.",
+      );
+    }
+    const acceptedPart = delivered.parts.find(
+      (part) =>
+        part.state === "delivered" &&
+        part.destination_receipt === request.destination_receipt,
+    );
+    if (acceptedPart === undefined) {
+      throw new ThreadBindingInputError(
+        "The destination receipt was not persisted on the delivery.",
+      );
+    }
+    const now = this.clock.now().toISOString();
+    if (Date.parse(request.expires_at) <= Date.parse(now)) {
+      throw new ThreadBindingInputError("The thread binding expiry must be future.");
+    }
+    const threadBindingId = threadIdentity(request);
+    const binding: SlackThreadBindingV1 = {
+      app_id: request.app_id,
+      binding_id: request.binding_id,
+      conversation_id: request.conversation_id,
+      created_at: now,
+      delivery_id: request.delivery_id,
+      destination_receipt: request.destination_receipt,
+      destination_ref: delivered.destination_ref,
+      expires_at: request.expires_at,
+      goal_ref: request.goal_ref,
+      installation_id: request.installation_id,
+      schema_version: "slack-thread-binding/v1",
+      state: "active",
+      subject_ref: request.subject_ref,
+      thread_binding_id: threadBindingId,
+      thread_id: request.thread_id,
+      updated_at: now,
+    };
+    return this.store.putIfAbsent({
+      binding,
+      payload_fingerprint: fingerprint(binding),
+    });
+  }
+
+  async resume(
+    request: Pick<
+      BindSlackThreadRequest,
+      "app_id" | "binding_id" | "conversation_id" | "installation_id" | "thread_id"
+    >,
+  ): Promise<SlackThreadBindingV1 | undefined> {
+    if (Object.values(request).some((value) => value.length === 0)) {
+      throw new ThreadBindingInputError("Thread identity fields cannot be empty.");
+    }
+    const id = threadIdentity(request);
+    const binding = await this.store.read(id);
+    if (binding === undefined || binding.state === "closed") {
+      return undefined;
+    }
+    const now = this.clock.now().toISOString();
+    if (binding.state === "expired" || Date.parse(binding.expires_at) <= Date.parse(now)) {
+      await this.store.expire(id, now);
+      return undefined;
+    }
+    return binding;
+  }
+
+  close(threadBindingId: string): Promise<SlackThreadBindingV1> {
+    return this.store.close(threadBindingId, this.clock.now().toISOString());
+  }
+}
+
+function validateBindingRequest(request: BindSlackThreadRequest): void {
+  if (Object.values(request).some((value) => value.length === 0)) {
+    throw new ThreadBindingInputError("Thread binding fields cannot be empty.");
+  }
+  if (!Number.isFinite(Date.parse(request.expires_at))) {
+    throw new ThreadBindingInputError("Thread binding expiry must be a timestamp.");
+  }
+}
+
+function threadIdentity(
+  request: Pick<
+    BindSlackThreadRequest,
+    "app_id" | "binding_id" | "conversation_id" | "installation_id" | "thread_id"
+  >,
+): string {
+  return `thread-${createHash("sha256")
+    .update(
+      JSON.stringify([
+        request.app_id,
+        request.installation_id,
+        request.binding_id,
+        request.conversation_id,
+        request.thread_id,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 32)}`;
+}
+
+function fingerprint(binding: SlackThreadBindingV1): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        app_id: binding.app_id,
+        binding_id: binding.binding_id,
+        conversation_id: binding.conversation_id,
+        delivery_id: binding.delivery_id,
+        destination_receipt: binding.destination_receipt,
+        destination_ref: binding.destination_ref,
+        expires_at: binding.expires_at,
+        goal_ref: binding.goal_ref,
+        installation_id: binding.installation_id,
+        subject_ref: binding.subject_ref,
+        thread_id: binding.thread_id,
+      }),
+    )
+    .digest("hex");
+}

--- a/apps/slack-companion/test/delivery.test.ts
+++ b/apps/slack-companion/test/delivery.test.ts
@@ -1,0 +1,483 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type {
+  PlatformAcceptanceReceipt,
+  PlatformDeliveryRequest,
+  WorkLeaseV1,
+} from "../src/delivery/contracts.js";
+import {
+  DeliveryCoordinator,
+  type DeliveryCoordinatorOptions,
+} from "../src/delivery/coordinator.js";
+import type { PlatformDeliveryPort } from "../src/delivery/ports.js";
+import {
+  DeliveryConflictError,
+  DeliveryFenceError,
+  ReferenceMemoryDeliveryStore,
+} from "../src/delivery/reference-store.js";
+
+const start = "2026-07-16T12:00:00.000Z";
+
+describe("DeliveryCoordinator", () => {
+  test("persists every deterministic part before any platform send", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    store.failNextPlan();
+
+    await assert.rejects(() => coordinator.plan(planRequest()));
+    assert.equal(sender.callCount, 0);
+
+    const first = await coordinator.plan(planRequest());
+    const duplicate = await coordinator.plan(planRequest());
+    assert.equal(first.created, true);
+    assert.equal(duplicate.created, false);
+    assert.deepEqual(duplicate.receipt, first.receipt);
+    assert.equal(first.receipt.parts.length, 2);
+    assert.deepEqual(first.receipt.parts.map((part) => part.sequence), [1, 2]);
+    assert.equal(new Set(first.receipt.parts.map((part) => part.part_id)).size, 2);
+    assert.equal(first.receipt.parts.every((part) => part.state === "pending"), true);
+    assert.equal(sender.callCount, 0);
+  });
+
+  test("rejects a changed payload under the same logical delivery identity", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    await coordinator.plan(planRequest());
+
+    await assert.rejects(
+      () =>
+        coordinator.plan(
+          planRequest({
+            parts: [
+              { payload_digest: "sha256:changed", payload_ref: "payload://1" },
+            ],
+          }),
+        ),
+      DeliveryConflictError,
+    );
+    await assert.rejects(
+      () => coordinator.plan(planRequest({ max_attempts: 4 })),
+      DeliveryConflictError,
+    );
+  });
+
+  test("delivers multipart output and persists each acceptance receipt", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(planRequest());
+    const activeLease = lease();
+
+    const first = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      activeLease,
+    );
+    const second = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      activeLease,
+    );
+    const complete = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      activeLease,
+    );
+
+    assert.equal(first.status, "delivered");
+    assert.equal(second.status, "delivered");
+    assert.equal(complete.status, "complete");
+    assert.equal(complete.receipt.state, "completed");
+    assert.equal(
+      complete.receipt.parts.every(
+        (part) => part.state === "delivered" && part.destination_receipt,
+      ),
+      true,
+    );
+    assert.equal(sender.callCount, 2);
+    assert.equal(sender.acceptCount, 2);
+  });
+
+  test("resumes an accepted send after completion persistence fails without reposting", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    store.failNextCompletion();
+
+    await assert.rejects(
+      () => coordinator.deliverNext(planned.receipt.delivery_id, lease()),
+      /injected completion failure/,
+    );
+    assert.equal(sender.acceptCount, 1);
+
+    clock.set("2026-07-16T12:00:31.000Z");
+    const resumed = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      lease({
+        fencing_token: 2,
+        heartbeat_at: "2026-07-16T12:00:31.000Z",
+        lease_expires_at: "2026-07-16T12:01:01.000Z",
+        lease_token: "lease-2",
+      }),
+    );
+
+    assert.equal(resumed.status, "delivered");
+    assert.equal(resumed.receipt.state, "completed");
+    assert.equal(sender.callCount, 2);
+    assert.equal(sender.acceptCount, 1);
+    assert.equal(
+      resumed.receipt.parts[0]?.destination_receipt,
+      sender.acceptedReceipts[0],
+    );
+  });
+
+  test("enforces active generation and fencing ownership", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease(),
+      now: start,
+    });
+
+    await assert.rejects(
+      () =>
+        store.claimNext({
+          delivery_id: planned.receipt.delivery_id,
+          lease: lease({ lease_token: "lease-other", owner_id: "worker-2" }),
+          now: start,
+        }),
+      DeliveryFenceError,
+    );
+    await assert.rejects(
+      () =>
+        store.claimNext({
+          delivery_id: planned.receipt.delivery_id,
+          lease: lease({
+            heartbeat_at: "2026-07-16T12:00:01.000Z",
+            lease_expires_at: "2026-07-16T12:00:40.000Z",
+          }),
+          now: start,
+        }),
+      DeliveryFenceError,
+    );
+
+    store.setActiveGeneration(2);
+    await assert.rejects(
+      () =>
+        store.completePart({
+          accepted_at: start,
+          delivery_id: planned.receipt.delivery_id,
+          destination_receipt: "receipt-1",
+          lease: lease(),
+          part_id: planned.receipt.parts[0]!.part_id,
+        }),
+      DeliveryFenceError,
+    );
+  });
+
+  test("repeats claim and completion safely for the same lease and receipt", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    const activeLease = lease();
+    const claimRequest = {
+      delivery_id: planned.receipt.delivery_id,
+      lease: activeLease,
+      now: start,
+    };
+
+    const firstClaim = await store.claimNext(claimRequest);
+    const duplicateClaim = await store.claimNext(claimRequest);
+    assert.deepEqual(duplicateClaim, firstClaim);
+    assert.equal(firstClaim.status, "claimed");
+    if (firstClaim.status !== "claimed") {
+      assert.fail("expected claimed part");
+    }
+
+    const completion = {
+      accepted_at: start,
+      delivery_id: planned.receipt.delivery_id,
+      destination_receipt: "destination-1",
+      lease: activeLease,
+      part_id: firstClaim.claim.part.part_id,
+    };
+    const firstCompletion = await store.completePart(completion);
+    const duplicateCompletion = await store.completePart(completion);
+    assert.deepEqual(duplicateCompletion, firstCompletion);
+    assert.equal(firstCompletion.state, "completed");
+  });
+
+  test("reclaims an expired part only with a newer fencing value", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease(),
+      now: start,
+    });
+    const recoveryTime = "2026-07-16T12:00:31.000Z";
+
+    await assert.rejects(
+      () =>
+        store.claimNext({
+          delivery_id: planned.receipt.delivery_id,
+          lease: lease({
+            heartbeat_at: recoveryTime,
+            lease_expires_at: "2026-07-16T12:01:01.000Z",
+            lease_token: "lease-reused-fence",
+          }),
+          now: recoveryTime,
+        }),
+      DeliveryFenceError,
+    );
+
+    const recovered = await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease({
+        fencing_token: 2,
+        heartbeat_at: recoveryTime,
+        lease_expires_at: "2026-07-16T12:01:01.000Z",
+        lease_token: "lease-recovery",
+      }),
+      now: recoveryTime,
+    });
+    assert.equal(recovered.status, "claimed");
+    if (recovered.status === "claimed") {
+      assert.equal(recovered.claim.attempt, 2);
+    }
+  });
+
+  test("does not skip a busy earlier part to deliver a later part", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const coordinator = makeCoordinator(clock, store, new IdempotentSender(clock));
+    const planned = await coordinator.plan(planRequest());
+    await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease(),
+      now: start,
+    });
+
+    const blocked = await store.claimNext({
+      delivery_id: planned.receipt.delivery_id,
+      lease: lease({ fencing_token: 2, lease_token: "lease-2" }),
+      now: start,
+    });
+
+    assert.equal(blocked.status, "idle");
+    if (blocked.status === "idle") {
+      assert.equal(blocked.reason, "busy");
+      assert.equal(blocked.receipt.parts[0]?.state, "delivering");
+      assert.equal(blocked.receipt.parts[1]?.state, "pending");
+    }
+  });
+
+  test("stops retrying when the persisted attempt bound is reached", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    sender.rejectAll = true;
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(
+      planRequest({ max_attempts: 2 }),
+    );
+
+    const first = await coordinator.deliverNext(planned.receipt.delivery_id, lease());
+    const second = await coordinator.deliverNext(planned.receipt.delivery_id, lease());
+    const third = await coordinator.deliverNext(planned.receipt.delivery_id, lease());
+
+    assert.equal(first.status, "retry_scheduled");
+    assert.equal(second.status, "retry_exhausted");
+    assert.equal(third.status, "retry_exhausted");
+    assert.equal(third.receipt.state, "failed");
+    assert.equal(third.receipt.parts[1]?.state, "pending");
+    assert.equal(sender.callCount, 2);
+  });
+
+  test("pauses active work, fences stale resume, and resumes without duplicate send", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(planRequest({ parts: [part(1)] }));
+    const staleLease = lease();
+    store.failNextCompletion();
+    await assert.rejects(
+      () => coordinator.deliverNext(planned.receipt.delivery_id, staleLease),
+      /injected completion failure/,
+    );
+    assert.equal(store.claimCount(planned.receipt.delivery_id), 1);
+    assert.equal(sender.acceptCount, 1);
+
+    store.setActiveGeneration(2);
+    clock.set("2026-07-16T12:00:10.000Z");
+    const currentLease = lease({
+      fencing_token: 2,
+      generation: 2,
+      heartbeat_at: "2026-07-16T12:00:10.000Z",
+      lease_expires_at: "2026-07-16T12:00:40.000Z",
+      lease_token: "lease-current",
+    });
+    const paused = await coordinator.pause(
+      planned.receipt.delivery_id,
+      currentLease,
+    );
+    assert.equal(paused.state, "paused");
+    assert.equal(paused.parts[0]?.state, "paused");
+    assert.equal(store.claimCount(planned.receipt.delivery_id), 0);
+
+    await assert.rejects(
+      () => coordinator.resume(planned.receipt.delivery_id, staleLease),
+      DeliveryFenceError,
+    );
+    const resumed = await coordinator.resume(
+      planned.receipt.delivery_id,
+      currentLease,
+    );
+    assert.equal(resumed.state, "pending");
+    assert.equal(resumed.parts[0]?.state, "pending");
+
+    const delivered = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      currentLease,
+    );
+    assert.equal(delivered.status, "delivered");
+    assert.equal(delivered.receipt.state, "completed");
+    assert.equal(sender.callCount, 2);
+    assert.equal(sender.acceptCount, 1);
+  });
+
+  test("abandons unfinished parts as a terminal delivery", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(planRequest());
+
+    const abandoned = await coordinator.abandon(
+      planned.receipt.delivery_id,
+      lease(),
+    );
+    const duplicate = await coordinator.abandon(
+      planned.receipt.delivery_id,
+      lease(),
+    );
+    assert.equal(abandoned.state, "abandoned");
+    assert.equal(
+      abandoned.parts.every((deliveryPart) => deliveryPart.state === "abandoned"),
+      true,
+    );
+    assert.deepEqual(duplicate, abandoned);
+
+    const terminal = await coordinator.deliverNext(
+      planned.receipt.delivery_id,
+      lease(),
+    );
+    assert.equal(terminal.status, "abandoned");
+    assert.equal(sender.callCount, 0);
+    await assert.rejects(
+      () => coordinator.resume(planned.receipt.delivery_id, lease()),
+      DeliveryConflictError,
+    );
+  });
+});
+
+class MutableClock {
+  private instant: string;
+
+  constructor(instant: string) {
+    this.instant = instant;
+  }
+
+  now(): Date {
+    return new Date(this.instant);
+  }
+
+  set(instant: string): void {
+    this.instant = instant;
+  }
+}
+
+class IdempotentSender implements PlatformDeliveryPort {
+  readonly acceptedReceipts: string[] = [];
+  private readonly acceptedByMessage = new Map<string, PlatformAcceptanceReceipt>();
+  callCount = 0;
+  rejectAll = false;
+
+  constructor(private readonly clock: MutableClock) {}
+
+  get acceptCount(): number {
+    return this.acceptedByMessage.size;
+  }
+
+  send(request: PlatformDeliveryRequest): Promise<PlatformAcceptanceReceipt> {
+    this.callCount += 1;
+    if (this.rejectAll) {
+      return Promise.reject(new Error("injected destination rejection"));
+    }
+    const prior = this.acceptedByMessage.get(request.client_message_id);
+    if (prior !== undefined) {
+      return Promise.resolve(prior);
+    }
+    const destinationReceipt = `destination-${this.acceptedByMessage.size + 1}`;
+    const accepted = {
+      accepted_at: this.clock.now().toISOString(),
+      destination_receipt: destinationReceipt,
+    };
+    this.acceptedByMessage.set(request.client_message_id, accepted);
+    this.acceptedReceipts.push(destinationReceipt);
+    return Promise.resolve(accepted);
+  }
+}
+
+function makeCoordinator(
+  clock: MutableClock,
+  store: ReferenceMemoryDeliveryStore,
+  sender: IdempotentSender,
+): DeliveryCoordinator {
+  const options: DeliveryCoordinatorOptions = { clock, sender, store };
+  return new DeliveryCoordinator(options);
+}
+
+function part(sequence: number) {
+  return {
+    payload_digest: `sha256:payload-${sequence}`,
+    payload_ref: `payload://${sequence}`,
+  };
+}
+
+function planRequest(
+  changes: Partial<Parameters<DeliveryCoordinator["plan"]>[0]> = {},
+): Parameters<DeliveryCoordinator["plan"]>[0] {
+  return {
+    delivery_key: "final-response",
+    destination_ref: "conversation://conversation-1/thread-1",
+    max_attempts: 3,
+    parts: [part(1), part(2)],
+    run_id: "run-1",
+    ...changes,
+  };
+}
+
+function lease(changes: Partial<WorkLeaseV1> = {}): WorkLeaseV1 {
+  return {
+    fencing_token: 1,
+    generation: 1,
+    heartbeat_at: start,
+    lease_expires_at: "2026-07-16T12:00:30.000Z",
+    lease_token: "lease-1",
+    owner_id: "worker-1",
+    run_id: "run-1",
+    schema_version: "work-lease/v1",
+    ...changes,
+  };
+}

--- a/apps/slack-companion/test/thread-binding.test.ts
+++ b/apps/slack-companion/test/thread-binding.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { DeliveryReceiptV1 } from "@writer/cerebro-sdk";
+import {
+  SlackThreadBindingCoordinator,
+  ThreadBindingConflictError,
+  type BindSlackThreadRequest,
+  type SlackThreadBindingV1,
+  type ThreadBindingCommit,
+  type ThreadBindingCommitResult,
+  type ThreadBindingStorePort,
+} from "../src/thread-binding.js";
+
+const now = "2026-07-16T12:00:00.000Z";
+
+describe("SlackThreadBindingCoordinator", () => {
+  test("binds stable thread identity to the persisted platform receipt", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+
+    const first = await coordinator.bind(bindingRequest(), deliveredReceipt());
+    const duplicate = await coordinator.bind(bindingRequest(), deliveredReceipt());
+    const resumed = await coordinator.resume(bindingRequest());
+
+    assert.equal(first.created, true);
+    assert.equal(duplicate.created, false);
+    assert.deepEqual(duplicate.binding, first.binding);
+    assert.deepEqual(resumed, first.binding);
+    assert.equal(first.binding.destination_receipt, "destination-1");
+    assert.equal(first.binding.subject_ref, "subject://control-1");
+    assert.equal(first.binding.goal_ref, "goal://explain-control");
+    assert.equal(store.writeCount, 1);
+  });
+
+  test("does not bind before the destination acceptance is durable", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+    const receipt = deliveredReceipt();
+    receipt.parts[0] = {
+      ...receipt.parts[0]!,
+      destination_receipt: undefined,
+      state: "delivering",
+    };
+    receipt.state = "delivering";
+
+    await assert.rejects(() => coordinator.bind(bindingRequest(), receipt));
+    assert.equal(store.writeCount, 0);
+  });
+
+  test("binds after the referenced part is durable while later parts remain", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+    const receipt = deliveredReceipt();
+    receipt.parts.push({
+      idempotency_key: "message-2",
+      part_id: "part-2",
+      payload_digest: "sha256:payload-2",
+      payload_ref: "payload://2",
+      sequence: 2,
+      state: "pending",
+    });
+    receipt.state = "delivering";
+
+    const result = await coordinator.bind(bindingRequest(), receipt);
+
+    assert.equal(result.created, true);
+    assert.equal(result.binding.destination_receipt, "destination-1");
+  });
+
+  test("leaves no binding when its durable write fails", async () => {
+    const store = new MemoryThreadBindingStore();
+    store.failNext();
+    const coordinator = makeCoordinator(store);
+
+    await assert.rejects(
+      () => coordinator.bind(bindingRequest(), deliveredReceipt()),
+      /injected thread binding failure/,
+    );
+    assert.equal(store.writeCount, 0);
+    assert.equal(await coordinator.resume(bindingRequest()), undefined);
+  });
+
+  test("rejects identity reuse for a different subject or goal", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+    await coordinator.bind(bindingRequest(), deliveredReceipt());
+
+    await assert.rejects(
+      () =>
+        coordinator.bind(
+          bindingRequest({ goal_ref: "goal://different" }),
+          deliveredReceipt(),
+        ),
+      ThreadBindingConflictError,
+    );
+  });
+
+  test("closes idempotently and never resumes a closed binding", async () => {
+    const store = new MemoryThreadBindingStore();
+    const coordinator = makeCoordinator(store);
+    const bound = await coordinator.bind(bindingRequest(), deliveredReceipt());
+
+    const first = await coordinator.close(bound.binding.thread_binding_id);
+    const second = await coordinator.close(bound.binding.thread_binding_id);
+
+    assert.equal(first.state, "closed");
+    assert.deepEqual(second, first);
+    assert.equal(await coordinator.resume(bindingRequest()), undefined);
+  });
+
+  test("expires a binding before returning resume context", async () => {
+    const store = new MemoryThreadBindingStore();
+    const clock = new MutableClock(now);
+    const coordinator = new SlackThreadBindingCoordinator(clock, store);
+    const bound = await coordinator.bind(bindingRequest(), deliveredReceipt());
+    clock.set("2026-07-16T13:00:01.000Z");
+
+    assert.equal(await coordinator.resume(bindingRequest()), undefined);
+    assert.equal(
+      (await store.read(bound.binding.thread_binding_id))?.state,
+      "expired",
+    );
+  });
+});
+
+class MutableClock {
+  constructor(private instant: string) {}
+
+  now(): Date {
+    return new Date(this.instant);
+  }
+
+  set(instant: string): void {
+    this.instant = instant;
+  }
+}
+
+class MemoryThreadBindingStore implements ThreadBindingStorePort {
+  private readonly fingerprints = new Map<string, string>();
+  private readonly records = new Map<string, SlackThreadBindingV1>();
+  private failPut = false;
+  writeCount = 0;
+
+  putIfAbsent(commit: ThreadBindingCommit): Promise<ThreadBindingCommitResult> {
+    if (this.failPut) {
+      this.failPut = false;
+      return Promise.reject(new Error("injected thread binding failure"));
+    }
+    const id = commit.binding.thread_binding_id;
+    const prior = this.records.get(id);
+    if (prior !== undefined) {
+      if (this.fingerprints.get(id) !== commit.payload_fingerprint) {
+        return Promise.reject(
+          new ThreadBindingConflictError(
+            "The thread identity already has different intent.",
+          ),
+        );
+      }
+      return Promise.resolve({ binding: structuredClone(prior), created: false });
+    }
+    this.records.set(id, structuredClone(commit.binding));
+    this.fingerprints.set(id, commit.payload_fingerprint);
+    this.writeCount += 1;
+    return Promise.resolve({ binding: structuredClone(commit.binding), created: true });
+  }
+
+  read(threadBindingId: string): Promise<SlackThreadBindingV1 | undefined> {
+    const binding = this.records.get(threadBindingId);
+    return Promise.resolve(binding === undefined ? undefined : structuredClone(binding));
+  }
+
+  close(threadBindingId: string, closedAt: string): Promise<SlackThreadBindingV1> {
+    const binding = this.require(threadBindingId);
+    if (binding.state === "closed") {
+      return Promise.resolve(structuredClone(binding));
+    }
+    binding.closed_at = closedAt;
+    binding.state = "closed";
+    binding.updated_at = closedAt;
+    return Promise.resolve(structuredClone(binding));
+  }
+
+  expire(threadBindingId: string, expiredAt: string): Promise<SlackThreadBindingV1> {
+    const binding = this.require(threadBindingId);
+    if (binding.state === "active") {
+      binding.state = "expired";
+      binding.updated_at = expiredAt;
+    }
+    return Promise.resolve(structuredClone(binding));
+  }
+
+  failNext(): void {
+    this.failPut = true;
+  }
+
+  private require(threadBindingId: string): SlackThreadBindingV1 {
+    const binding = this.records.get(threadBindingId);
+    if (binding === undefined) {
+      throw new Error("thread binding does not exist");
+    }
+    return binding;
+  }
+}
+
+function makeCoordinator(
+  store: MemoryThreadBindingStore,
+): SlackThreadBindingCoordinator {
+  return new SlackThreadBindingCoordinator(new MutableClock(now), store);
+}
+
+function bindingRequest(
+  changes: Partial<BindSlackThreadRequest> = {},
+): BindSlackThreadRequest {
+  return {
+    app_id: "app-1",
+    binding_id: "binding-1",
+    conversation_id: "conversation-1",
+    delivery_id: "delivery-1",
+    destination_receipt: "destination-1",
+    expires_at: "2026-07-16T13:00:00.000Z",
+    goal_ref: "goal://explain-control",
+    installation_id: "installation-1",
+    subject_ref: "subject://control-1",
+    thread_id: "thread-1",
+    ...changes,
+  };
+}
+
+function deliveredReceipt(): DeliveryReceiptV1 {
+  return {
+    created_at: now,
+    delivery_id: "delivery-1",
+    destination_ref: "conversation://conversation-1/thread-1",
+    parts: [
+      {
+        delivered_at: now,
+        destination_receipt: "destination-1",
+        idempotency_key: "message-1",
+        part_id: "part-1",
+        payload_digest: "sha256:payload-1",
+        payload_ref: "payload://1",
+        sequence: 1,
+        state: "delivered",
+      },
+    ],
+    run_id: "run-1",
+    schema_version: "delivery-receipt/v1",
+    state: "completed",
+    updated_at: now,
+  };
+}


### PR DESCRIPTION
## Summary

- add durable multipart delivery receipts and stable part identities
- enforce lease generation and fencing across send, retry, pause, resume, and abandon operations
- preserve strict part ordering and resumable retry state
- bind Slack threads after the referenced destination receipt is durably recorded

The package defines portable contracts and reference stores only. Deployment adapters, credentials, routes, and environment policy are outside this repository.

## Correctness properties

- delivery part sequences start at one and advance in order
- retries reuse a stable destination idempotency identity
- stale or incomplete lease proofs cannot mutate delivery state
- thread state survives process replacement and does not wait for unrelated later parts

## Validation

- Slack companion typecheck and 26 tests
- `go test ./tools/archtests/... -count=1`
- public-boundary leak scan
- Practice Registry final gate
- `git diff --check`