### PR TITLE
feat(slack): add durable transport boundary

### DIFF
--- a/apps/slack-companion/src/transport/contracts.ts
+++ b/apps/slack-companion/src/transport/contracts.ts
@@ -1,0 +1,161 @@
+import type { CapabilityRequirement, RunKind } from "@writer/cerebro-sdk";
+import type {
+  SlackAdmissionResult,
+  SlackIngressEnvelope,
+} from "../contracts.js";
+
+export type SlackIngressMode = "events_api" | "socket_mode";
+
+export interface SlackTransportRoute {
+  binding_id: string;
+  required_capabilities: CapabilityRequirement[];
+  retention_policy_ref: string;
+  run_kind: RunKind;
+  tenant_id: string;
+}
+
+export interface SlackEventsApiRequest {
+  raw_body: Uint8Array;
+  received_at: string;
+  request_signature: string;
+  request_timestamp: string;
+  route: SlackTransportRoute;
+}
+
+export interface SlackUrlVerificationEnvelope {
+  challenge: string;
+  type: "url_verification";
+}
+
+export interface SlackEventCallbackEnvelope {
+  api_app_id: string;
+  event: Record<string, unknown> & { type: string };
+  event_id: string;
+  event_time: number;
+  team_id: string;
+  type: "event_callback";
+}
+
+export type SlackEventsApiEnvelope =
+  | SlackEventCallbackEnvelope
+  | SlackUrlVerificationEnvelope;
+
+export interface SlackSocketModeEnvelope {
+  accepts_response_payload?: boolean;
+  envelope_id: string;
+  payload: unknown;
+  retry_attempt?: number;
+  retry_reason?: string;
+  type: "events_api" | "interactive" | "slash_commands";
+}
+
+export interface SlackSocketConnectionProof {
+  connection_ref: string;
+  generation: number;
+}
+
+export interface SlackSocketModeRequest {
+  connection: SlackSocketConnectionProof;
+  raw_body: Uint8Array;
+  received_at: string;
+  route: SlackTransportRoute;
+}
+
+export interface InboundPayloadCommit {
+  idempotency_key: string;
+  raw_body: Uint8Array;
+  received_at: string;
+  transport: SlackIngressMode;
+}
+
+export interface InboundPayloadReceipt {
+  digest: string;
+  payload_ref: string;
+}
+
+/**
+ * Stores the exact inbound bytes before normalization or durable admission.
+ * Implementations must return the original receipt for an idempotent retry.
+ */
+export interface DurableInboundPayloadPort {
+  persist(commit: InboundPayloadCommit): Promise<InboundPayloadReceipt>;
+}
+
+export interface DurableSocketPresencePort {
+  /** Confirms that the connection generation is current in durable state. */
+  isActive(proof: SlackSocketConnectionProof): Promise<boolean>;
+}
+
+export interface SlackAdmissionPort {
+  admit(envelope: SlackIngressEnvelope): Promise<SlackAdmissionResult>;
+}
+
+export interface SlackEventNormalizationInput {
+  envelope: SlackEventCallbackEnvelope;
+  payload: InboundPayloadReceipt;
+  received_at: string;
+  route: SlackTransportRoute;
+}
+
+export interface SlackEventNormalizer {
+  normalize(input: SlackEventNormalizationInput): SlackIngressEnvelope;
+}
+
+export interface EventsApiAcknowledgementCommand {
+  body: "";
+  kind: "events_api_ack";
+  status_code: 200;
+}
+
+export interface SocketModeAcknowledgementCommand {
+  envelope_id: string;
+  kind: "socket_mode_ack";
+}
+
+export interface UrlVerificationCommand {
+  body: string;
+  kind: "url_verification";
+  status_code: 200;
+}
+
+export type SlackAcknowledgementCommand =
+  | EventsApiAcknowledgementCommand
+  | SocketModeAcknowledgementCommand;
+
+export type TransportFailureStage =
+  | "verification"
+  | "parsing"
+  | "persistence"
+  | "normalization"
+  | "admission";
+
+export type SlackTransportOutcome =
+  | {
+      command: SlackAcknowledgementCommand;
+      kind: "acknowledge";
+      run_id: string;
+    }
+  | {
+      command: UrlVerificationCommand;
+      kind: "challenge";
+    }
+  | {
+      kind: "no_acknowledgement";
+      reason_code: string;
+      retryable: boolean;
+      stage: TransportFailureStage;
+    };
+
+export interface EventsApiHandlerDependencies {
+  admission: SlackAdmissionPort;
+  clock: { now(): Date };
+  normalizer: SlackEventNormalizer;
+  payloads: DurableInboundPayloadPort;
+}
+
+export interface SocketModeHandlerDependencies {
+  admission: SlackAdmissionPort;
+  normalizer: SlackEventNormalizer;
+  payloads: DurableInboundPayloadPort;
+  presence: DurableSocketPresencePort;
+}

--- a/apps/slack-companion/src/transport/handler.ts
+++ b/apps/slack-companion/src/transport/handler.ts
@@ -1,0 +1,189 @@
+import { createHash } from "node:crypto";
+import type {
+  EventsApiHandlerDependencies,
+  InboundPayloadReceipt,
+  SlackEventCallbackEnvelope,
+  SlackEventsApiRequest,
+  SlackSocketModeRequest,
+  SlackTransportOutcome,
+  SlackTransportRoute,
+  SocketModeHandlerDependencies,
+} from "./contracts.js";
+import {
+  eventCallbackFromSocketMode,
+  parseEventsApiEnvelope,
+  parseSocketModeEnvelope,
+} from "./normalization.js";
+import { verifySlackRequestSignature } from "./signatures.js";
+
+export async function handleEventsApiRequest(
+  request: SlackEventsApiRequest,
+  signingSecret: string | Uint8Array,
+  dependencies: EventsApiHandlerDependencies,
+): Promise<SlackTransportOutcome> {
+  const verification = verifySlackRequestSignature(
+    {
+      now: dependencies.clock.now(),
+      raw_body: request.raw_body,
+      request_signature: request.request_signature,
+      request_timestamp: request.request_timestamp,
+    },
+    signingSecret,
+  );
+  if (!verification.verified) {
+    return noAcknowledgement("verification", verification.reason, false);
+  }
+
+  let parsed;
+  try {
+    parsed = parseEventsApiEnvelope(request.raw_body);
+  } catch {
+    return noAcknowledgement("parsing", "invalid_envelope", false);
+  }
+
+  if (parsed.type === "url_verification") {
+    return {
+      command: {
+        body: parsed.challenge,
+        kind: "url_verification",
+        status_code: 200,
+      },
+      kind: "challenge",
+    };
+  }
+
+  return persistNormalizeAdmit(
+    "events_api",
+    parsed,
+    request.raw_body,
+    request.received_at,
+    request.route,
+    dependencies,
+    () => ({ body: "", kind: "events_api_ack", status_code: 200 }),
+  );
+}
+
+export async function handleSocketModeRequest(
+  request: SlackSocketModeRequest,
+  dependencies: SocketModeHandlerDependencies,
+): Promise<SlackTransportOutcome> {
+  let active = false;
+  try {
+    active = await dependencies.presence.isActive(request.connection);
+  } catch {
+    return noAcknowledgement("verification", "presence_unavailable", true);
+  }
+  if (!active) {
+    return noAcknowledgement("verification", "inactive_connection", false);
+  }
+
+  let envelope;
+  let event;
+  try {
+    envelope = parseSocketModeEnvelope(request.raw_body);
+    event = eventCallbackFromSocketMode(envelope);
+  } catch {
+    return noAcknowledgement("parsing", "invalid_envelope", false);
+  }
+
+  return persistNormalizeAdmit(
+    "socket_mode",
+    event,
+    request.raw_body,
+    request.received_at,
+    request.route,
+    dependencies,
+    () => ({
+      envelope_id: envelope.envelope_id,
+      kind: "socket_mode_ack",
+    }),
+  );
+}
+
+async function persistNormalizeAdmit(
+  transport: "events_api" | "socket_mode",
+  event: SlackEventCallbackEnvelope,
+  rawBody: Uint8Array,
+  receivedAt: string,
+  route: SlackTransportRoute,
+  dependencies:
+    | EventsApiHandlerDependencies
+    | SocketModeHandlerDependencies,
+  acknowledgement: () =>
+    | { body: ""; kind: "events_api_ack"; status_code: 200 }
+    | { envelope_id: string; kind: "socket_mode_ack" },
+): Promise<SlackTransportOutcome> {
+  let payload: InboundPayloadReceipt;
+  try {
+    payload = await dependencies.payloads.persist({
+      idempotency_key: payloadIdempotencyKey(event),
+      raw_body: rawBody,
+      received_at: receivedAt,
+      transport,
+    });
+  } catch {
+    return noAcknowledgement("persistence", "payload_not_durable", true);
+  }
+
+  if (!validPayloadReceipt(payload, rawBody)) {
+    return noAcknowledgement("persistence", "invalid_payload_receipt", true);
+  }
+
+  let normalized;
+  try {
+    normalized = dependencies.normalizer.normalize({
+      envelope: event,
+      payload,
+      received_at: receivedAt,
+      route,
+    });
+  } catch {
+    return noAcknowledgement("normalization", "invalid_event", false);
+  }
+
+  try {
+    const admission = await dependencies.admission.admit(normalized);
+    if (!admission.acknowledgement_permitted) {
+      return noAcknowledgement(
+        "admission",
+        "durable_admission_rejected",
+        admission.retryable,
+      );
+    }
+    return {
+      command: acknowledgement(),
+      kind: "acknowledge",
+      run_id: admission.run_id,
+    };
+  } catch {
+    return noAcknowledgement("admission", "durable_admission_failed", true);
+  }
+}
+
+function payloadIdempotencyKey(event: SlackEventCallbackEnvelope): string {
+  return `slack:${event.api_app_id}:${event.team_id}:${event.event_id}`;
+}
+
+function validPayloadReceipt(
+  receipt: InboundPayloadReceipt,
+  rawBody: Uint8Array,
+): boolean {
+  if (receipt.payload_ref.trim() === "") {
+    return false;
+  }
+  const digest = createHash("sha256").update(rawBody).digest("hex");
+  return receipt.digest === `sha256:${digest}`;
+}
+
+function noAcknowledgement(
+  stage: "verification" | "parsing" | "persistence" | "normalization" | "admission",
+  reasonCode: string,
+  retryable: boolean,
+): SlackTransportOutcome {
+  return {
+    kind: "no_acknowledgement",
+    reason_code: reasonCode,
+    retryable,
+    stage,
+  };
+}

--- a/apps/slack-companion/src/transport/normalization.ts
+++ b/apps/slack-companion/src/transport/normalization.ts
@@ -1,0 +1,201 @@
+import type { SlackIngressEnvelope } from "../contracts.js";
+import type {
+  SlackEventCallbackEnvelope,
+  SlackEventNormalizationInput,
+  SlackEventNormalizer,
+  SlackEventsApiEnvelope,
+  SlackSocketModeEnvelope,
+} from "./contracts.js";
+
+export class StructuralSlackEventNormalizer implements SlackEventNormalizer {
+  normalize(input: SlackEventNormalizationInput): SlackIngressEnvelope {
+    const { envelope, payload, received_at: receivedAt, route } = input;
+    const eventType = requiredString(envelope.event, "type");
+    const conversationId = requiredString(envelope.event, "channel");
+    const eventTimestamp = requiredString(envelope.event, "ts");
+    const threadId = optionalString(envelope.event, "thread_ts") ?? eventTimestamp;
+
+    return {
+      app_id: envelope.api_app_id,
+      binding_id: route.binding_id,
+      conversation_id: conversationId,
+      event_id: envelope.event_id,
+      event_type: eventType,
+      payload_digest: payload.digest,
+      payload_ref: payload.payload_ref,
+      received_at: receivedAt,
+      required_capabilities: route.required_capabilities,
+      retention_policy_ref: route.retention_policy_ref,
+      run_kind: route.run_kind,
+      subject_ref: `slack-thread:${conversationId}:${threadId}`,
+      tenant_id: route.tenant_id,
+      thread_id: threadId,
+    };
+  }
+}
+
+export function parseEventsApiEnvelope(
+  rawBody: Uint8Array,
+): SlackEventsApiEnvelope {
+  const value = parseObject(rawBody);
+  const type = requiredString(value, "type");
+  if (type === "url_verification") {
+    return {
+      challenge: requiredString(value, "challenge"),
+      type,
+    };
+  }
+  if (type !== "event_callback") {
+    throw new Error("unsupported Events API envelope type");
+  }
+
+  const event = requiredObject(value, "event");
+  return {
+    api_app_id: requiredString(value, "api_app_id"),
+    event: { ...event, type: requiredString(event, "type") },
+    event_id: requiredString(value, "event_id"),
+    event_time: requiredNumber(value, "event_time"),
+    team_id: requiredString(value, "team_id"),
+    type,
+  };
+}
+
+export function parseSocketModeEnvelope(
+  rawBody: Uint8Array,
+): SlackSocketModeEnvelope {
+  const value = parseObject(rawBody);
+  const type = requiredString(value, "type");
+  if (
+    type !== "events_api" &&
+    type !== "interactive" &&
+    type !== "slash_commands"
+  ) {
+    throw new Error("unsupported Socket Mode envelope type");
+  }
+  if (!("payload" in value)) {
+    throw new Error("payload is required");
+  }
+  const acceptsResponsePayload = optionalBoolean(
+    value,
+    "accepts_response_payload",
+  );
+  const retryAttempt = optionalNumber(value, "retry_attempt");
+  const retryReason = optionalString(value, "retry_reason");
+  return {
+    ...(acceptsResponsePayload === undefined
+      ? {}
+      : { accepts_response_payload: acceptsResponsePayload }),
+    envelope_id: requiredString(value, "envelope_id"),
+    payload: value.payload,
+    ...(retryAttempt === undefined ? {} : { retry_attempt: retryAttempt }),
+    ...(retryReason === undefined ? {} : { retry_reason: retryReason }),
+    type,
+  };
+}
+
+export function eventCallbackFromSocketMode(
+  envelope: SlackSocketModeEnvelope,
+): SlackEventCallbackEnvelope {
+  if (envelope.type !== "events_api") {
+    throw new Error("unsupported Socket Mode envelope type");
+  }
+  const payload = envelope.payload;
+  if (!isRecord(payload) || payload.type !== "event_callback") {
+    throw new Error("Socket Mode payload must contain an event callback");
+  }
+  const event = requiredObject(payload, "event");
+  return {
+    api_app_id: requiredString(payload, "api_app_id"),
+    event: { ...event, type: requiredString(event, "type") },
+    event_id: requiredString(payload, "event_id"),
+    event_time: requiredNumber(payload, "event_time"),
+    team_id: requiredString(payload, "team_id"),
+    type: "event_callback",
+  };
+}
+
+function parseObject(rawBody: Uint8Array): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(rawBody).toString("utf8"));
+  } catch {
+    throw new Error("request body must be valid JSON");
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("request body must be a JSON object");
+  }
+  return parsed;
+}
+
+function requiredObject(
+  value: Record<string, unknown>,
+  field: string,
+): Record<string, unknown> {
+  const candidate = value[field];
+  if (!isRecord(candidate)) {
+    throw new Error(`${field} must be an object`);
+  }
+  return candidate;
+}
+
+function requiredNumber(value: Record<string, unknown>, field: string): number {
+  const candidate = value[field];
+  if (typeof candidate !== "number" || !Number.isFinite(candidate)) {
+    throw new Error(`${field} must be a number`);
+  }
+  return candidate;
+}
+
+function requiredString(value: Record<string, unknown>, field: string): string {
+  const candidate = value[field];
+  if (typeof candidate !== "string" || candidate.trim() === "") {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return candidate;
+}
+
+function optionalString(
+  value: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  const candidate = value[field];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (typeof candidate !== "string" || candidate.trim() === "") {
+    throw new Error(`${field} must be a non-empty string when present`);
+  }
+  return candidate;
+}
+
+function optionalBoolean(
+  value: Record<string, unknown>,
+  field: string,
+): boolean | undefined {
+  const candidate = value[field];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (typeof candidate !== "boolean") {
+    throw new Error(`${field} must be a boolean when present`);
+  }
+  return candidate;
+}
+
+function optionalNumber(
+  value: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const candidate = value[field];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (typeof candidate !== "number" || !Number.isFinite(candidate)) {
+    throw new Error(`${field} must be a number when present`);
+  }
+  return candidate;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/slack-companion/src/transport/readiness.ts
+++ b/apps/slack-companion/src/transport/readiness.ts
@@ -1,0 +1,31 @@
+import type { SlackIngressMode } from "./contracts.js";
+
+export interface SlackIngressCapabilities {
+  durable_presence_relay: boolean;
+  public_ingress: boolean;
+}
+
+export type SlackIngressReadiness =
+  | { ready: true }
+  | {
+      ready: false;
+      reason_code:
+        | "durable_presence_relay_required"
+        | "public_ingress_required";
+    };
+
+export function evaluateSlackIngressReadiness(
+  mode: SlackIngressMode,
+  capabilities: SlackIngressCapabilities,
+): SlackIngressReadiness {
+  if (mode === "events_api" && !capabilities.public_ingress) {
+    return { ready: false, reason_code: "public_ingress_required" };
+  }
+  if (mode === "socket_mode" && !capabilities.durable_presence_relay) {
+    return {
+      ready: false,
+      reason_code: "durable_presence_relay_required",
+    };
+  }
+  return { ready: true };
+}

--- a/apps/slack-companion/src/transport/signatures.ts
+++ b/apps/slack-companion/src/transport/signatures.ts
@@ -1,0 +1,80 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const DEFAULT_SLACK_SIGNATURE_MAX_SKEW_SECONDS = 300;
+
+export type SlackSignatureVerification =
+  | { verified: true }
+  | {
+      reason:
+        | "invalid_signature"
+        | "invalid_timestamp"
+        | "stale_timestamp";
+      verified: false;
+    };
+
+export interface SlackSignatureInput {
+  max_skew_seconds?: number;
+  now: Date;
+  raw_body: Uint8Array;
+  request_signature: string;
+  request_timestamp: string;
+}
+
+/**
+ * Verifies Slack's v0 signature over the exact request bytes. The signing
+ * secret exists only for this call and is not captured or retained.
+ */
+export function verifySlackRequestSignature(
+  input: SlackSignatureInput,
+  signingSecret: string | Uint8Array,
+): SlackSignatureVerification {
+  const timestamp = parseTimestamp(input.request_timestamp);
+  if (timestamp === undefined) {
+    return { reason: "invalid_timestamp", verified: false };
+  }
+
+  const maxSkew =
+    input.max_skew_seconds ?? DEFAULT_SLACK_SIGNATURE_MAX_SKEW_SECONDS;
+  if (!Number.isSafeInteger(maxSkew) || maxSkew < 0) {
+    throw new Error("max_skew_seconds must be a non-negative safe integer");
+  }
+
+  const now = Math.floor(input.now.getTime() / 1_000);
+  if (!Number.isSafeInteger(now)) {
+    throw new Error("now must be a valid date");
+  }
+  if (Math.abs(now - timestamp) > maxSkew) {
+    return { reason: "stale_timestamp", verified: false };
+  }
+
+  const suppliedMatch = /^v0=([a-f0-9]{64})$/i.exec(input.request_signature);
+  if (suppliedMatch === null) {
+    return { reason: "invalid_signature", verified: false };
+  }
+
+  const rawBody = Buffer.from(
+    input.raw_body.buffer,
+    input.raw_body.byteOffset,
+    input.raw_body.byteLength,
+  );
+  const expected = createHmac("sha256", signingSecret)
+    .update("v0:")
+    .update(input.request_timestamp)
+    .update(":")
+    .update(rawBody)
+    .digest();
+  const supplied = Buffer.from(suppliedMatch[1], "hex");
+
+  if (!timingSafeEqual(expected, supplied)) {
+    return { reason: "invalid_signature", verified: false };
+  }
+  return { verified: true };
+}
+
+function parseTimestamp(value: string): number | undefined {
+  if (!/^\d+$/.test(value)) {
+    return undefined;
+  }
+  const timestamp = Number(value);
+  return Number.isSafeInteger(timestamp) ? timestamp : undefined;
+}

--- a/apps/slack-companion/test/transport.test.ts
+++ b/apps/slack-companion/test/transport.test.ts
@@ -1,0 +1,419 @@
+import assert from "node:assert/strict";
+import { createHash, createHmac, randomBytes } from "node:crypto";
+import { describe, test } from "node:test";
+import type {
+  SlackAdmissionResult,
+  SlackIngressEnvelope,
+} from "../src/contracts.js";
+import type {
+  DurableInboundPayloadPort,
+  InboundPayloadCommit,
+  InboundPayloadReceipt,
+  SlackEventNormalizationInput,
+  SlackEventsApiRequest,
+  SlackSocketModeEnvelope,
+} from "../src/transport/contracts.js";
+import {
+  handleEventsApiRequest,
+  handleSocketModeRequest,
+} from "../src/transport/handler.js";
+import { StructuralSlackEventNormalizer } from "../src/transport/normalization.js";
+import { evaluateSlackIngressReadiness } from "../src/transport/readiness.js";
+
+const now = new Date("2026-07-16T12:00:00.000Z");
+const timestamp = String(Math.floor(now.getTime() / 1_000));
+const signingKey = randomBytes(32);
+
+describe("Slack transport boundary", () => {
+  test("persists before normalization and admits before returning an Events API acknowledgement", async () => {
+    const order: string[] = [];
+    const payloads = new MemoryPayloadStore(order);
+    const request = eventsRequest(eventBody());
+
+    const outcome = await handleEventsApiRequest(request, requestKey(), {
+      admission: acceptingAdmission(order),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(order),
+      payloads,
+    });
+
+    assert.deepEqual(order, ["persist", "normalize", "admit"]);
+    assert.deepEqual(outcome, {
+      command: { body: "", kind: "events_api_ack", status_code: 200 },
+      kind: "acknowledge",
+      run_id: "run-event-1",
+    });
+    assert.deepEqual(payloads.rawBodies, [request.raw_body]);
+  });
+
+  test("does not normalize, admit, or acknowledge when payload persistence fails", async () => {
+    const order: string[] = [];
+    const payloads = new MemoryPayloadStore(order);
+    payloads.fail = true;
+
+    const outcome = await handleEventsApiRequest(
+      eventsRequest(eventBody()),
+      requestKey(),
+      {
+        admission: acceptingAdmission(order),
+        clock: { now: () => now },
+        normalizer: recordingNormalizer(order),
+        payloads,
+      },
+    );
+
+    assert.deepEqual(order, ["persist"]);
+    assert.deepEqual(outcome, {
+      kind: "no_acknowledgement",
+      reason_code: "payload_not_durable",
+      retryable: true,
+      stage: "persistence",
+    });
+  });
+
+  test("does not acknowledge when durable admission rejects the event", async () => {
+    const order: string[] = [];
+
+    const outcome = await handleEventsApiRequest(
+      eventsRequest(eventBody()),
+      requestKey(),
+      {
+        admission: {
+          admit: async () => {
+            order.push("admit");
+            return rejection(true);
+          },
+        },
+        clock: { now: () => now },
+        normalizer: recordingNormalizer(order),
+        payloads: new MemoryPayloadStore(order),
+      },
+    );
+
+    assert.deepEqual(order, ["persist", "normalize", "admit"]);
+    assert.deepEqual(outcome, {
+      kind: "no_acknowledgement",
+      reason_code: "durable_admission_rejected",
+      retryable: true,
+      stage: "admission",
+    });
+  });
+
+  test("reuses the durable payload and run when Slack retries an event", async () => {
+    const order: string[] = [];
+    const payloads = new MemoryPayloadStore(order);
+    const admitted = new Map<string, string>();
+    const request = eventsRequest(eventBody());
+    const admission = {
+      admit: async (envelope: SlackIngressEnvelope): Promise<SlackAdmissionResult> => {
+        const runId = admitted.get(envelope.event_id) ?? `run-${envelope.event_id}`;
+        const duplicate = admitted.has(envelope.event_id);
+        admitted.set(envelope.event_id, runId);
+        return accepted(runId, duplicate);
+      },
+    };
+    const dependencies = {
+      admission,
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(order),
+      payloads,
+    };
+
+    const first = await handleEventsApiRequest(request, requestKey(), dependencies);
+    const second = await handleEventsApiRequest(request, requestKey(), dependencies);
+
+    assert.equal(first.kind, "acknowledge");
+    assert.equal(second.kind, "acknowledge");
+    if (first.kind !== "acknowledge" || second.kind !== "acknowledge") {
+      assert.fail("expected both retries to be acknowledged");
+    }
+    assert.equal(second.run_id, first.run_id);
+    assert.equal(payloads.receiptCount, 1);
+    assert.deepEqual(payloads.commitKeys, [
+      "slack:app-1:team-1:event-1",
+      "slack:app-1:team-1:event-1",
+    ]);
+  });
+
+  test("rejects bad and stale signatures before payload persistence", async () => {
+    const badOrder: string[] = [];
+    const badRequest = eventsRequest(eventBody());
+    badRequest.request_signature = `v0=${"0".repeat(64)}`;
+
+    const bad = await handleEventsApiRequest(badRequest, requestKey(), {
+      admission: acceptingAdmission(badOrder),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(badOrder),
+      payloads: new MemoryPayloadStore(badOrder),
+    });
+
+    const staleOrder: string[] = [];
+    const staleTimestamp = String(Number(timestamp) - 301);
+    const staleRequest = eventsRequest(eventBody(), staleTimestamp);
+    const stale = await handleEventsApiRequest(staleRequest, requestKey(), {
+      admission: acceptingAdmission(staleOrder),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(staleOrder),
+      payloads: new MemoryPayloadStore(staleOrder),
+    });
+
+    assert.deepEqual(badOrder, []);
+    assert.deepEqual(staleOrder, []);
+    assert.deepEqual(bad, {
+      kind: "no_acknowledgement",
+      reason_code: "invalid_signature",
+      retryable: false,
+      stage: "verification",
+    });
+    assert.deepEqual(stale, {
+      kind: "no_acknowledgement",
+      reason_code: "stale_timestamp",
+      retryable: false,
+      stage: "verification",
+    });
+  });
+
+  test("verifies the signature against the exact raw request bytes", async () => {
+    const order: string[] = [];
+    const request = eventsRequest(eventBody());
+    request.raw_body = Buffer.concat([request.raw_body, Buffer.from(" ")]);
+
+    const outcome = await handleEventsApiRequest(request, requestKey(), {
+      admission: acceptingAdmission(order),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(order),
+      payloads: new MemoryPayloadStore(order),
+    });
+
+    assert.deepEqual(order, []);
+    assert.equal(outcome.kind, "no_acknowledgement");
+    if (outcome.kind !== "no_acknowledgement") {
+      assert.fail("expected a signature failure");
+    }
+    assert.equal(outcome.reason_code, "invalid_signature");
+  });
+
+  test("authenticates a URL verification challenge without persisting or admitting it", async () => {
+    const order: string[] = [];
+    const request = eventsRequest(
+      JSON.stringify({
+        api_app_id: "app-1",
+        challenge: "challenge-value",
+        type: "url_verification",
+      }),
+    );
+
+    const outcome = await handleEventsApiRequest(request, requestKey(), {
+      admission: acceptingAdmission(order),
+      clock: { now: () => now },
+      normalizer: recordingNormalizer(order),
+      payloads: new MemoryPayloadStore(order),
+    });
+
+    assert.deepEqual(order, []);
+    assert.deepEqual(outcome, {
+      command: {
+        body: "challenge-value",
+        kind: "url_verification",
+        status_code: 200,
+      },
+      kind: "challenge",
+    });
+  });
+
+  test("verifies durable Socket Mode presence before payload persistence", async () => {
+    const order: string[] = [];
+    const payload = JSON.parse(eventBody()) as Record<string, unknown>;
+    const envelope: SlackSocketModeEnvelope = {
+      envelope_id: "socket-envelope-1",
+      payload,
+      type: "events_api",
+    };
+
+    const outcome = await handleSocketModeRequest(
+      {
+        connection: { connection_ref: "connection-1", generation: 3 },
+        raw_body: Buffer.from(JSON.stringify(envelope)),
+        received_at: now.toISOString(),
+        route: route(),
+      },
+      {
+        admission: acceptingAdmission(order),
+        normalizer: recordingNormalizer(order),
+        payloads: new MemoryPayloadStore(order),
+        presence: {
+          isActive: async () => {
+            order.push("verify");
+            return true;
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(order, ["verify", "persist", "normalize", "admit"]);
+    assert.deepEqual(outcome, {
+      command: {
+        envelope_id: "socket-envelope-1",
+        kind: "socket_mode_ack",
+      },
+      kind: "acknowledge",
+      run_id: "run-event-1",
+    });
+  });
+});
+
+describe("Slack ingress readiness", () => {
+  test("Events API requires public ingress capability", () => {
+    assert.deepEqual(
+      evaluateSlackIngressReadiness("events_api", {
+        durable_presence_relay: true,
+        public_ingress: false,
+      }),
+      { ready: false, reason_code: "public_ingress_required" },
+    );
+  });
+
+  test("Socket Mode requires a durable presence relay", () => {
+    assert.deepEqual(
+      evaluateSlackIngressReadiness("socket_mode", {
+        durable_presence_relay: false,
+        public_ingress: true,
+      }),
+      { ready: false, reason_code: "durable_presence_relay_required" },
+    );
+  });
+});
+
+class MemoryPayloadStore implements DurableInboundPayloadPort {
+  fail = false;
+  readonly commitKeys: string[] = [];
+  readonly rawBodies: Uint8Array[] = [];
+  private readonly order: string[];
+  private readonly receipts = new Map<string, InboundPayloadReceipt>();
+
+  constructor(order: string[]) {
+    this.order = order;
+  }
+
+  get receiptCount(): number {
+    return this.receipts.size;
+  }
+
+  async persist(commit: InboundPayloadCommit): Promise<InboundPayloadReceipt> {
+    this.order.push("persist");
+    this.commitKeys.push(commit.idempotency_key);
+    this.rawBodies.push(commit.raw_body);
+    if (this.fail) {
+      throw new Error("persistence unavailable");
+    }
+    const existing = this.receipts.get(commit.idempotency_key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const digest = createHash("sha256").update(commit.raw_body).digest("hex");
+    const receipt = {
+      digest: `sha256:${digest}`,
+      payload_ref: `payload-ref:${commit.idempotency_key}`,
+    };
+    this.receipts.set(commit.idempotency_key, receipt);
+    return receipt;
+  }
+}
+
+function eventsRequest(
+  rawBody: string,
+  requestTimestamp = timestamp,
+): SlackEventsApiRequest {
+  const raw = Buffer.from(rawBody);
+  const key = requestKey();
+  return {
+    raw_body: raw,
+    received_at: now.toISOString(),
+    request_signature: sign(raw, requestTimestamp, key),
+    request_timestamp: requestTimestamp,
+    route: route(),
+  };
+}
+
+function eventBody(): string {
+  return JSON.stringify({
+    api_app_id: "app-1",
+    event: {
+      channel: "conversation-1",
+      thread_ts: "thread-1",
+      ts: "event-time-1",
+      type: "app_mention",
+    },
+    event_id: "event-1",
+    event_time: Math.floor(now.getTime() / 1_000),
+    team_id: "team-1",
+    type: "event_callback",
+  });
+}
+
+function route() {
+  return {
+    binding_id: "binding-1",
+    required_capabilities: [],
+    retention_policy_ref: "retention-policy-1",
+    run_kind: "interactive" as const,
+    tenant_id: "tenant-1",
+  };
+}
+
+function requestKey(): Uint8Array {
+  return signingKey;
+}
+
+function sign(
+  rawBody: Uint8Array,
+  requestTimestamp: string,
+  key: Uint8Array,
+): string {
+  return `v0=${createHmac("sha256", key)
+    .update("v0:")
+    .update(requestTimestamp)
+    .update(":")
+    .update(rawBody)
+    .digest("hex")}`;
+}
+
+function recordingNormalizer(order: string[]) {
+  const structural = new StructuralSlackEventNormalizer();
+  return {
+    normalize(input: SlackEventNormalizationInput): SlackIngressEnvelope {
+      order.push("normalize");
+      return structural.normalize(input);
+    },
+  };
+}
+
+function acceptingAdmission(order: string[]) {
+  return {
+    admit: async (envelope: SlackIngressEnvelope): Promise<SlackAdmissionResult> => {
+      order.push("admit");
+      return accepted(`run-${envelope.event_id}`, false);
+    },
+  };
+}
+
+function accepted(runId: string, duplicate: boolean): SlackAdmissionResult {
+  return {
+    acknowledgement_permitted: true,
+    duplicate,
+    message: "Request saved and queued.",
+    retryable: false,
+    run_id: runId,
+    status: "queued",
+  };
+}
+
+function rejection(retryable: boolean): SlackAdmissionResult {
+  return {
+    acknowledgement_permitted: false,
+    duplicate: false,
+    message: "Request was not admitted.",
+    retryable,
+    status: "rejected",
+  };
+}


### PR DESCRIPTION
## Summary

- verify Events API requests over exact request bytes with bounded timestamp skew
- persist the authenticated inbound payload before normalization, admission, or acknowledgement
- add Socket Mode presence proofs and acknowledgement ordering
- expose topology-neutral ingress readiness requirements
- keep URL verification isolated from event admission

The package defines portable transport behavior only. It contains no ingress resources, signing values, network routes, or environment configuration.

## Correctness properties

- invalid, stale, or unauthenticated Events API requests are not acknowledged
- a Slack event is acknowledged only after its payload and admitted run are durable
- inactive Socket Mode connections cannot acknowledge envelopes
- Events API readiness requires public ingress capability; Socket Mode readiness requires a durable presence relay

## Validation

- Slack companion workspace check: 18 tests
- focused transport suite: 10 tests
- `go test ./tools/archtests/... -count=1`
- OSS audit and public-boundary leak scan
- Practice Registry final gate
- `git diff --check`