### PR TITLE
Remove background context from policy proof

### DIFF
--- a/internal/testauthor/policy/proof.go
+++ b/internal/testauthor/policy/proof.go
@@ -31,9 +31,9 @@ type ProofResult struct {
 	Receipts     []ProofReceipt `json:"receipts"`
 }
 
-func Prove(artifacts Artifacts) (ProofResult, error) {
+func Prove(ctx context.Context, artifacts Artifacts) (ProofResult, error) {
 	if strings.TrimSpace(artifacts.Rule.Spec.Graph.Query) != "" {
-		return proveGraph(context.Background(), artifacts, nil)
+		return proveGraph(ctx, artifacts, nil)
 	}
 	return proveScalar(artifacts)
 }

--- a/internal/testauthor/policy/proof.go
+++ b/internal/testauthor/policy/proof.go
@@ -31,9 +31,13 @@ type ProofResult struct {
 	Receipts     []ProofReceipt `json:"receipts"`
 }
 
-func Prove(ctx context.Context, artifacts Artifacts) (ProofResult, error) {
+func Prove(artifacts Artifacts) (ProofResult, error) {
 	if strings.TrimSpace(artifacts.Rule.Spec.Graph.Query) != "" {
-		return proveGraph(ctx, artifacts, nil)
+		result, err := validateGraphFixtureContract(artifacts)
+		if err != nil {
+			return result, err
+		}
+		return graphStoreRequired(result)
 	}
 	return proveScalar(artifacts)
 }
@@ -73,23 +77,12 @@ func ProveWithGraphStore(ctx context.Context, artifacts Artifacts, store finding
 }
 
 func proveGraph(ctx context.Context, artifacts Artifacts, store findingdsl.PolicyGraphTestStore) (ProofResult, error) {
-	result := ProofResult{
-		PolicyID: artifacts.Rule.Metadata.ID, PolicyPath: artifacts.PolicyPath, TestPath: artifacts.TestPath,
-		PolicyDigest: digest(artifacts.PolicyYAML), TestDigest: digest(artifacts.TestYAML),
-	}
-	issues := findingdsl.ValidatePolicyRuleTestSuite(artifacts.Suite)
-	contractPassed := len(issues) == 0
-	contractDetail := "finding and passing graph fixtures have identical topology except for one critical edge"
-	if !contractPassed {
-		contractDetail = "graph fixture contract failed: " + joinIssues(issues)
-	}
-	result.Receipts = append(result.Receipts, ProofReceipt{Gate: "graph_fixture_contract", Passed: contractPassed, Execution: "in_process", Detail: contractDetail})
-	if !contractPassed {
-		return result, errors.New("authored graph fixture contract failed")
+	result, err := validateGraphFixtureContract(artifacts)
+	if err != nil {
+		return result, err
 	}
 	if store == nil {
-		result.Receipts = append(result.Receipts, ProofReceipt{Gate: "graph_execution", Passed: false, Execution: "not_run", Detail: "graph store was not injected; authored Cypher and topology were not executed"})
-		return result, ErrGraphStoreRequired
+		return graphStoreRequired(result)
 	}
 
 	root, err := os.MkdirTemp("", "cerebro-authored-graph-proof-")
@@ -118,6 +111,29 @@ func proveGraph(ctx context.Context, artifacts Artifacts, store findingdsl.Polic
 		return result, errors.New("authored graph tests failed against injected graph store")
 	}
 	return result, nil
+}
+
+func validateGraphFixtureContract(artifacts Artifacts) (ProofResult, error) {
+	result := ProofResult{
+		PolicyID: artifacts.Rule.Metadata.ID, PolicyPath: artifacts.PolicyPath, TestPath: artifacts.TestPath,
+		PolicyDigest: digest(artifacts.PolicyYAML), TestDigest: digest(artifacts.TestYAML),
+	}
+	issues := findingdsl.ValidatePolicyRuleTestSuite(artifacts.Suite)
+	contractPassed := len(issues) == 0
+	contractDetail := "finding and passing graph fixtures have identical topology except for one critical edge"
+	if !contractPassed {
+		contractDetail = "graph fixture contract failed: " + joinIssues(issues)
+	}
+	result.Receipts = append(result.Receipts, ProofReceipt{Gate: "graph_fixture_contract", Passed: contractPassed, Execution: "in_process", Detail: contractDetail})
+	if !contractPassed {
+		return result, errors.New("authored graph fixture contract failed")
+	}
+	return result, nil
+}
+
+func graphStoreRequired(result ProofResult) (ProofResult, error) {
+	result.Receipts = append(result.Receipts, ProofReceipt{Gate: "graph_execution", Passed: false, Execution: "not_run", Detail: "graph store was not injected; authored Cypher and topology were not executed"})
+	return result, ErrGraphStoreRequired
 }
 
 func writeProofArtifact(root string, rel string, content []byte) error {

--- a/internal/testauthor/policy/proof_test.go
+++ b/internal/testauthor/policy/proof_test.go
@@ -14,7 +14,7 @@ func TestProvePassesProtectedAndRejectsWeakenedPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := Prove(artifacts)
+	result, err := Prove(t.Context(), artifacts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestProveGraphRequiresAndExecutesInjectedStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	notRun, err := Prove(artifacts)
+	notRun, err := Prove(t.Context(), artifacts)
 	if !errors.Is(err, ErrGraphStoreRequired) {
 		t.Fatalf("Prove() error = %v, want ErrGraphStoreRequired", err)
 	}
@@ -41,7 +41,7 @@ func TestProveGraphRequiresAndExecutesInjectedStore(t *testing.T) {
 	}
 
 	store := newProofGraphStore()
-	result, err := ProveWithGraphStore(context.Background(), artifacts, store)
+	result, err := ProveWithGraphStore(t.Context(), artifacts, store)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestProveRejectsSuiteThatSurvivesMutation(t *testing.T) {
 		t.Fatal(err)
 	}
 	artifacts.Suite.Cases = artifacts.Suite.Cases[:1]
-	result, err := Prove(artifacts)
+	result, err := Prove(t.Context(), artifacts)
 	if err == nil {
 		t.Fatal("Prove() error = nil")
 	}

--- a/internal/testauthor/policy/proof_test.go
+++ b/internal/testauthor/policy/proof_test.go
@@ -14,7 +14,7 @@ func TestProvePassesProtectedAndRejectsWeakenedPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := Prove(t.Context(), artifacts)
+	result, err := Prove(artifacts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestProveGraphRequiresAndExecutesInjectedStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	notRun, err := Prove(t.Context(), artifacts)
+	notRun, err := Prove(artifacts)
 	if !errors.Is(err, ErrGraphStoreRequired) {
 		t.Fatalf("Prove() error = %v, want ErrGraphStoreRequired", err)
 	}
@@ -114,7 +114,7 @@ func TestProveRejectsSuiteThatSurvivesMutation(t *testing.T) {
 		t.Fatal(err)
 	}
 	artifacts.Suite.Cases = artifacts.Suite.Cases[:1]
-	result, err := Prove(t.Context(), artifacts)
+	result, err := Prove(artifacts)
 	if err == nil {
 		t.Fatal("Prove() error = nil")
 	}

--- a/tools/testauthor/main.go
+++ b/tools/testauthor/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -112,7 +113,7 @@ func runProvePolicy(args []string) error {
 	if err != nil {
 		return err
 	}
-	result, err := policyauthor.Prove(artifacts)
+	result, err := policyauthor.Prove(context.Background(), artifacts)
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	if encodeErr := encoder.Encode(result); encodeErr != nil {

--- a/tools/testauthor/main.go
+++ b/tools/testauthor/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -113,7 +112,7 @@ func runProvePolicy(args []string) error {
 	if err != nil {
 		return err
 	}
-	result, err := policyauthor.Prove(context.Background(), artifacts)
+	result, err := policyauthor.Prove(artifacts)
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	if encodeErr := encoder.Encode(result); encodeErr != nil {


### PR DESCRIPTION
## Summary
- keep the context-free policy proof API for callers that do not execute graph queries
- share graph fixture validation between context-free and graph-store proof paths
- reserve caller-provided context for graph-store execution
- remove the structural violation introduced on main

## Validation
- `go test ./internal/testauthor/policy ./tools/testauthor -count=1`
- `make check-structural`
- `make changed-check`
- `git diff --check origin/main...HEAD`