### PR TITLE
Route host inventory questions to asset search

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -2434,7 +2434,7 @@ func mcpTools() []mcpTool {
 		{
 			Name:        "cerebro.assets.search",
 			Title:       "Search Assets",
-			Description: "Find visible inventory and graph assets by query, URN, entity type, tenant, or runtime.",
+			Description: "Find visible inventory and graph assets, including hosts, by query, URN, entity type, tenant, or runtime.",
 			InputSchema: mcpObjectSchema(map[string]any{
 				"query":       map[string]any{"type": "string"},
 				"urn":         map[string]any{"type": "string"},

--- a/internal/mcpoperations/testdata/task_tools/selection_cases.json
+++ b/internal/mcpoperations/testdata/task_tools/selection_cases.json
@@ -548,5 +548,15 @@
     "forbidden_tools": ["cerebro.agent.control_plane"],
     "require_partial_handling": false,
     "maximum_call_count": 1
+  },
+  {
+    "id": "assets-host-inventory-language",
+    "user_request": "Which hosts are in our inventory?",
+    "permitted_scopes": ["cerebro.cosmo.security.read"],
+    "expected_tool": "cerebro.assets.search",
+    "allowed_followup_tools": [],
+    "forbidden_tools": ["cerebro.assets.get"],
+    "require_partial_handling": false,
+    "maximum_call_count": 1
   }
 ]


### PR DESCRIPTION
## Summary
- advertise host inventory in the `cerebro.assets.search` description
- add an adversarial host-inventory routing case
- improve that case's selection margin from 2 to 4 while keeping the corpus at 100% accuracy

## Validation
- `make mcp-tool-eval` (55/55 correct, 10/10 tools covered, zero ambiguity, minimum margin 4)
- `go test ./internal/mcpoperations -count=1`
- `make changed-check`
- `make lint-shard LINT_PACKAGES='./internal/...' LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=1`
- `git diff --check origin/main...HEAD`