### PR TITLE
Record MCP response payload size

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -26,6 +26,7 @@ import (
 	"github.com/writer/cerebro/internal/graphfacts"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/mcpoperations"
+	"github.com/writer/cerebro/internal/mcptransport"
 	"github.com/writer/cerebro/internal/ports"
 	linktransport "github.com/writer/cerebro/internal/resourcelinks/transport"
 	"github.com/writer/cerebro/internal/riskplan"
@@ -81,17 +82,8 @@ type mcpJSONRPCRequest struct {
 	Error   *mcpError       `json:"error,omitempty"`
 }
 
-type mcpJSONRPCResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      json.RawMessage `json:"id,omitempty"`
-	Result  any             `json:"result,omitempty"`
-	Error   *mcpError       `json:"error,omitempty"`
-}
-
-type mcpError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-}
+type mcpJSONRPCResponse = mcptransport.Response
+type mcpError = mcptransport.Error
 
 type mcpGraphStoreNeighborhoodResult struct {
 	urn          string
@@ -322,6 +314,7 @@ type mcpTelemetryDetails struct {
 	JSONRPCIDPresent bool
 	ParamsPresent    bool
 	Response         *mcpJSONRPCResponse
+	ResponseBytes    int
 }
 
 func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
@@ -342,11 +335,11 @@ func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
 	decoder.UseNumber()
 	var request mcpJSONRPCRequest
 	if err := decoder.Decode(&request); err != nil {
-		mcpWriteJSONRPC(w, mcpJSONRPCResponse{
+		responseBytes := mcpWriteJSONRPC(w, mcpJSONRPCResponse{
 			JSONRPC: "2.0",
 			Error:   &mcpError{Code: -32700, Message: "parse error"},
 		})
-		mcpTelemetryEvent(r, "", "", http.StatusOK, -32700, "parse_error", "", time.Since(started), mcpTelemetryDetails{RequestKind: "parse_error"})
+		mcpTelemetryEvent(r, "", "", http.StatusOK, -32700, "parse_error", "", time.Since(started), mcpTelemetryDetails{RequestKind: "parse_error", ResponseBytes: responseBytes})
 		return
 	}
 	if request.Method == "" && (len(request.Result) != 0 || request.Error != nil) {
@@ -376,12 +369,13 @@ func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
 		clearLongRunningWriteDeadline(w)
 	}
 	response := app.handleMCPRequest(r, request)
-	mcpWriteJSONRPC(w, response)
+	responseBytes := mcpWriteJSONRPC(w, response)
 	mcpTelemetryEvent(r, request.Method, mcpToolNameFromParams(request.Method, request.Params), http.StatusOK, mcpResponseErrorCode(response), mcpResponseOutcome(response), mcpResponseToolErrorKind(response), time.Since(started), mcpTelemetryDetails{
 		RequestKind:      "request",
 		ParamsPresent:    len(request.Params) != 0,
 		JSONRPCIDPresent: len(request.ID) != 0,
 		Response:         &response,
+		ResponseBytes:    responseBytes,
 	})
 }
 
@@ -2945,6 +2939,7 @@ func mcpTelemetryEvent(r *http.Request, method string, tool string, statusCode i
 		telemetry.Field{Key: "mcp.session_header_present", Value: strings.TrimSpace(r.Header.Get("Mcp-Session-Id")) != ""},
 		telemetry.Field{Key: "mcp.jsonrpc_id_present", Value: detail.JSONRPCIDPresent},
 		telemetry.Field{Key: "mcp.params_present", Value: detail.ParamsPresent},
+		telemetry.Field{Key: "mcp.response_bytes", Value: detail.ResponseBytes},
 		telemetry.Field{Key: "duration_ms", Value: duration.Milliseconds()},
 	)
 	if contentType := mcpMediaType(r.Header.Get("Content-Type")); contentType != "" {
@@ -3016,6 +3011,7 @@ func mcpTelemetryEvent(r *http.Request, method string, tool string, statusCode i
 		telemetry.Field{Key: "mcp.session_header_present", Value: strings.TrimSpace(r.Header.Get("Mcp-Session-Id")) != ""},
 		telemetry.Field{Key: "mcp.jsonrpc_id_present", Value: detail.JSONRPCIDPresent},
 		telemetry.Field{Key: "mcp.params_present", Value: detail.ParamsPresent},
+		telemetry.Field{Key: "mcp.response_bytes", Value: detail.ResponseBytes},
 		telemetry.Field{Key: "mcp.duration_ms", Value: duration.Milliseconds()},
 	)
 	if contentType := mcpMediaType(r.Header.Get("Content-Type")); contentType != "" {
@@ -4424,12 +4420,12 @@ func mcpUint32Arg(args map[string]any, key string) (uint32, error) {
 	return uint32(parsed), nil
 }
 
-func mcpWriteJSONRPC(w http.ResponseWriter, response mcpJSONRPCResponse) {
+func mcpWriteJSONRPC(w http.ResponseWriter, response mcpJSONRPCResponse) int {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("MCP-Protocol-Version", mcpProtocolVersion)
 	w.Header().Set("X-Cerebro-MCP-Stateless", "true")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(response)
+	return mcptransport.WriteJSON(w, response)
 }
 
 func mcpNegotiatedProtocolVersion(r *http.Request, rawParams json.RawMessage) string {

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -853,6 +853,9 @@ func TestMCPTelemetryIncludesSafeToolContext(t *testing.T) {
 			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
 		}
 	}
+	if got, ok := payload["mcp.response_bytes"].(float64); !ok || got <= 0 {
+		t.Fatalf("telemetry mcp.response_bytes = %#v, want positive number; payload=%#v", payload["mcp.response_bytes"], payload)
+	}
 	if _, exists := payload["arguments"]; exists {
 		t.Fatalf("telemetry recorded raw arguments: %#v", payload)
 	}

--- a/internal/mcptransport/response.go
+++ b/internal/mcptransport/response.go
@@ -1,0 +1,37 @@
+package mcptransport
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
+}
+
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type responseByteCounter struct {
+	io.Writer
+	written int
+}
+
+func (w *responseByteCounter) Write(payload []byte) (int, error) {
+	written, err := w.Writer.Write(payload)
+	w.written += written
+	return written, err
+}
+
+// WriteJSON writes one JSON-RPC response and returns the exact number of bytes
+// accepted by the writer.
+func WriteJSON(w io.Writer, response Response) int {
+	counter := &responseByteCounter{Writer: w}
+	_ = json.NewEncoder(counter).Encode(response)
+	return counter.written
+}

--- a/internal/mcptransport/response_test.go
+++ b/internal/mcptransport/response_test.go
@@ -1,0 +1,17 @@
+package mcptransport
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteJSONReportsResponseBytes(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	written := WriteJSON(recorder, Response{
+		JSONRPC: "2.0",
+		Result:  map[string]any{"status": "ok"},
+	})
+	if written != recorder.Body.Len() || written <= 0 {
+		t.Fatalf("WriteJSON() bytes = %d, body bytes = %d", written, recorder.Body.Len())
+	}
+}


### PR DESCRIPTION
## Summary
- record exact JSON-RPC response bytes for normal and parse-error MCP requests
- keep JSON encoding and byte counting behind the `internal/mcptransport` boundary
- attach `mcp.response_bytes` to the MCP event and main trace span without re-serializing responses
- keep raw tool arguments out of telemetry

## Hillclimb signal
This adds the payload-size measurement needed to compare the ten task tools on runtime efficiency alongside existing duration, outcome, authorization, and task-state telemetry.

## Validation
- `go test ./internal/mcptransport ./internal/bootstrap -count=1`
- `make check-structural check-structural-test check-arch`
- `make lint-shard LINT_PACKAGES='./internal/...' LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=1`
- `make lint-shard LINT_PACKAGES='./internal/mcptransport' LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0`
- `make changed-check`
- `git diff --check`