### PR TITLE
Reconcile outcome-unknown companion effects

### DIFF
--- a/apps/slack-companion/src/execution/effect-intent.ts
+++ b/apps/slack-companion/src/execution/effect-intent.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { ExecutionInvariantError } from "./coordinator.js";
+import type {
+  EffectIntentValue,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
+} from "./model.js";
+
+export function normalizeEffectIntentValue(value: unknown): EffectIntentValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new ExecutionInvariantError("effect intent numbers must be finite");
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeEffectIntentValue(item));
+  }
+  if (typeof value !== "object") {
+    throw new ExecutionInvariantError("effect intent must contain JSON values only");
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new ExecutionInvariantError("effect intent objects must be plain records");
+  }
+
+  const normalized: Record<string, EffectIntentValue> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    if (key.trim() === "") {
+      throw new ExecutionInvariantError("effect intent keys must not be empty");
+    }
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      throw new ExecutionInvariantError("effect intent contains an unsafe key");
+    }
+    normalized[key] = normalizeEffectIntentValue(
+      (value as Record<string, unknown>)[key],
+    );
+  }
+  return normalized;
+}
+
+export type ExternalEffectIntentDigestInput = Omit<
+  ExternalEffectIntentDraft,
+  "request_digest"
+>;
+
+export function effectIntentDigest(
+  input: ExternalEffectIntentDigestInput,
+): string {
+  const digestInput: EffectIntentValue = {
+    approval_ref: input.approval_ref ?? null,
+    approval_required: input.approval_required,
+    candidate_version: input.candidate_version,
+    effect_id: input.effect_id,
+    idempotency_key: input.idempotency_key,
+    request: input.request,
+    rollback_plan_ref: input.rollback_plan_ref ?? null,
+    step_id: input.step_id,
+    target_ref: input.target_ref,
+  };
+  return `sha256:${createHash("sha256").update(JSON.stringify(digestInput)).digest("hex")}`;
+}
+
+export function sameExternalEffectIntent(
+  intent: ExternalEffectIntentV1,
+  draft: ExternalEffectIntentDraft,
+): boolean {
+  return (
+    intent.approval_ref === draft.approval_ref &&
+    intent.approval_required === draft.approval_required &&
+    intent.candidate_version === draft.candidate_version &&
+    intent.effect_id === draft.effect_id &&
+    intent.idempotency_key === draft.idempotency_key &&
+    intent.request_digest === draft.request_digest &&
+    intent.rollback_plan_ref === draft.rollback_plan_ref &&
+    intent.step_id === draft.step_id &&
+    intent.target_ref === draft.target_ref &&
+    JSON.stringify(intent.request) === JSON.stringify(draft.request)
+  );
+}

--- a/apps/slack-companion/src/execution/effect-reconciliation.ts
+++ b/apps/slack-companion/src/execution/effect-reconciliation.ts
@@ -1,0 +1,330 @@
+import type { ExecutionCoordinator } from "./coordinator.js";
+import { ExecutionInvariantError } from "./coordinator.js";
+import {
+  effectIntentDigest,
+  normalizeEffectIntentValue,
+} from "./effect-intent.js";
+import type {
+  EffectReceiptV1,
+  ExecutionSession,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
+  WorkLeaseV1,
+} from "./model.js";
+import type {
+  DurableExecutionPort,
+  ExecutionClockPort,
+} from "./ports.js";
+
+export interface ExternalEffectJob {
+  candidate_version: string;
+  fencing_token: number;
+  generation: number;
+  idempotency_key: string;
+  lease_token: string;
+  run_id: string;
+}
+
+export interface ExternalEffectDraft {
+  approval_ref?: string;
+  approval_required: boolean;
+  candidate_version: string;
+  effect_id: string;
+  idempotency_key: string;
+  request: unknown;
+  rollback_plan_ref?: string;
+  step_id: string;
+  target_ref: string;
+}
+
+export interface ExternalEffectResult {
+  candidate_version: string;
+  result_digest: string;
+  result_ref: string;
+}
+
+export interface ExternalEffectVerification {
+  candidate_version: string;
+  receipt_ref: string;
+  state: "failed" | "verified";
+}
+
+export type RecoverableExternalEffectInspection =
+  | {
+      candidate_version: string;
+      resume_token: string;
+      state: "materialized" | "prepared";
+    };
+
+export type ExternalEffectInspection =
+  | { state: "absent" }
+  | RecoverableExternalEffectInspection
+  | { result: ExternalEffectResult; state: "applied" }
+  | {
+      reason_code: string;
+      state: "ambiguous" | "boundary_mismatch" | "target_moved";
+    };
+
+/** External I/O stays behind this port; credentials and placement are adapter-owned. */
+export interface ExternalEffectPort {
+  apply(
+    intent: ExternalEffectIntentV1,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult>;
+
+  inspect(
+    intent: ExternalEffectIntentV1,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectInspection>;
+
+  resume(
+    intent: ExternalEffectIntentV1,
+    inspection: RecoverableExternalEffectInspection,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult>;
+
+  verify(
+    intent: ExternalEffectIntentV1,
+    result: ExternalEffectResult,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectVerification>;
+}
+
+export type StaleExternalEffectJobReason =
+  | "candidate_version_mismatch"
+  | "fencing_token_mismatch"
+  | "generation_mismatch"
+  | "idempotency_key_mismatch"
+  | "lease_token_mismatch"
+  | "run_mismatch";
+
+export type ExternalEffectExecutionResult =
+  | {
+      effect: EffectReceiptV1;
+      intent: ExternalEffectIntentV1;
+      status: "applied" | "duplicate" | "recovered";
+    }
+  | { reason: StaleExternalEffectJobReason; status: "stale" };
+
+export interface ExternalEffectReconcilerOptions {
+  clock: ExecutionClockPort;
+  execution: ExecutionCoordinator;
+  external: ExternalEffectPort;
+  store: Pick<
+    DurableExecutionPort,
+    "getEffectIntent" | "persistEffectIntent"
+  >;
+}
+
+export class ExternalEffectReconciler {
+  private readonly clock: ExecutionClockPort;
+  private readonly execution: ExecutionCoordinator;
+  private readonly external: ExternalEffectPort;
+  private readonly store: ExternalEffectReconcilerOptions["store"];
+
+  constructor(options: ExternalEffectReconcilerOptions) {
+    this.clock = options.clock;
+    this.execution = options.execution;
+    this.external = options.external;
+    this.store = options.store;
+  }
+
+  async execute(
+    session: ExecutionSession,
+    job: ExternalEffectJob,
+    draft: ExternalEffectDraft,
+  ): Promise<ExternalEffectExecutionResult> {
+    validateDraft(draft);
+    const staleReason = staleJobReason(session, job, draft);
+    if (staleReason !== undefined) {
+      return { reason: staleReason, status: "stale" };
+    }
+
+    const currentIntent = await this.store.getEffectIntent(
+      session.run.run_id,
+      draft.idempotency_key,
+    );
+    if (
+      currentIntent !== undefined &&
+      currentIntent.candidate_version !== draft.candidate_version
+    ) {
+      return { reason: "candidate_version_mismatch", status: "stale" };
+    }
+
+    const request = normalizeEffectIntentValue(draft.request);
+    const intentFields = {
+      approval_ref: draft.approval_ref,
+      approval_required: draft.approval_required,
+      candidate_version: draft.candidate_version,
+      effect_id: draft.effect_id,
+      idempotency_key: draft.idempotency_key,
+      request,
+      rollback_plan_ref: draft.rollback_plan_ref,
+      step_id: draft.step_id,
+      target_ref: draft.target_ref,
+    };
+    const intentDraft: ExternalEffectIntentDraft = {
+      ...intentFields,
+      request_digest: effectIntentDigest(intentFields),
+    };
+    const committed = await this.store.persistEffectIntent(
+      session.lease,
+      intentDraft,
+      this.clock.now().toISOString(),
+    );
+    const effect = await this.execution.beginEffect(session, {
+      approval_ref: committed.intent.approval_ref,
+      approval_required: committed.intent.approval_required,
+      effect_id: committed.intent.effect_id,
+      idempotency_key: committed.intent.idempotency_key,
+      request_digest: committed.intent.request_digest,
+      rollback_plan_ref: committed.intent.rollback_plan_ref,
+      step_id: committed.intent.step_id,
+      target_ref: committed.intent.target_ref,
+    });
+
+    if (effect.state === "failed" || effect.state === "succeeded") {
+      return { effect, intent: committed.intent, status: "duplicate" };
+    }
+    if (effect.state === "planned") {
+      await this.execution.markEffectExecuting(
+        session,
+        committed.intent.idempotency_key,
+      );
+      const result = await this.external.apply(committed.intent, session.lease);
+      return this.resolve(
+        session,
+        committed.intent,
+        result,
+        "applied",
+      );
+    }
+    if (effect.state !== "executing" && effect.state !== "unknown") {
+      throw new ExecutionInvariantError(
+        `effect state ${effect.state} cannot be reconciled`,
+      );
+    }
+
+    const inspection = await this.external.inspect(
+      committed.intent,
+      session.lease,
+    );
+    const result = await this.recoverResult(
+      committed.intent,
+      inspection,
+      session.lease,
+    );
+    return this.resolve(
+      session,
+      committed.intent,
+      result,
+      "recovered",
+    );
+  }
+
+  private recoverResult(
+    intent: ExternalEffectIntentV1,
+    inspection: ExternalEffectInspection,
+    lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult> {
+    switch (inspection.state) {
+      case "absent":
+        return this.external.apply(intent, lease);
+      case "applied":
+        return Promise.resolve(inspection.result);
+      case "materialized":
+      case "prepared":
+        assertCandidateVersion(intent, inspection.candidate_version);
+        return this.external.resume(intent, inspection, lease);
+      case "ambiguous":
+      case "boundary_mismatch":
+      case "target_moved":
+        throw new EffectReconciliationBlockedError(inspection.state);
+    }
+  }
+
+  private async resolve(
+    session: ExecutionSession,
+    intent: ExternalEffectIntentV1,
+    result: ExternalEffectResult,
+    status: "applied" | "recovered",
+  ): Promise<ExternalEffectExecutionResult> {
+    assertCandidateVersion(intent, result.candidate_version);
+    const verification = await this.external.verify(
+      intent,
+      result,
+      session.lease,
+    );
+    assertCandidateVersion(intent, verification.candidate_version);
+    const effect = await this.execution.resolveEffect(
+      session,
+      intent.idempotency_key,
+      {
+        result_digest: result.result_digest,
+        result_ref: result.result_ref,
+        state: verification.state === "verified" ? "succeeded" : "failed",
+        verification_receipt_ref: verification.receipt_ref,
+        verification_state: verification.state,
+      },
+    );
+    return { effect, intent, status };
+  }
+}
+
+export class EffectReconciliationBlockedError extends Error {
+  constructor(
+    readonly code:
+      | "ambiguous"
+      | "boundary_mismatch"
+      | "candidate_version_mismatch"
+      | "target_moved",
+  ) {
+    super(`external effect reconciliation blocked: ${code}`);
+    this.name = "EffectReconciliationBlockedError";
+  }
+}
+
+function staleJobReason(
+  session: ExecutionSession,
+  job: ExternalEffectJob,
+  draft: ExternalEffectDraft,
+): StaleExternalEffectJobReason | undefined {
+  if (job.run_id !== session.run.run_id) return "run_mismatch";
+  if (job.generation !== session.lease.generation) return "generation_mismatch";
+  if (job.fencing_token !== session.lease.fencing_token) {
+    return "fencing_token_mismatch";
+  }
+  if (job.lease_token !== session.lease.lease_token) {
+    return "lease_token_mismatch";
+  }
+  if (job.idempotency_key !== draft.idempotency_key) {
+    return "idempotency_key_mismatch";
+  }
+  if (job.candidate_version !== draft.candidate_version) {
+    return "candidate_version_mismatch";
+  }
+  return undefined;
+}
+
+function assertCandidateVersion(
+  intent: ExternalEffectIntentV1,
+  candidateVersion: string,
+): void {
+  if (intent.candidate_version !== candidateVersion) {
+    throw new EffectReconciliationBlockedError("candidate_version_mismatch");
+  }
+}
+
+function validateDraft(draft: ExternalEffectDraft): void {
+  for (const [field, value] of [
+    ["candidate_version", draft.candidate_version],
+    ["effect_id", draft.effect_id],
+    ["idempotency_key", draft.idempotency_key],
+    ["step_id", draft.step_id],
+    ["target_ref", draft.target_ref],
+  ] as const) {
+    if (value.trim() === "") {
+      throw new ExecutionInvariantError(`${field} must not be empty`);
+    }
+  }
+}

--- a/apps/slack-companion/src/execution/model.ts
+++ b/apps/slack-companion/src/execution/model.ts
@@ -57,6 +57,41 @@ export interface EffectResolution {
   verification_state: "verified" | "failed";
 }
 
+export type EffectIntentValue =
+  | boolean
+  | null
+  | number
+  | string
+  | EffectIntentValue[]
+  | { [key: string]: EffectIntentValue };
+
+export interface ExternalEffectIntentDraft {
+  approval_ref?: string;
+  approval_required: boolean;
+  candidate_version: string;
+  effect_id: string;
+  idempotency_key: string;
+  request: EffectIntentValue;
+  request_digest: string;
+  rollback_plan_ref?: string;
+  step_id: string;
+  target_ref: string;
+}
+
+export interface ExternalEffectIntentV1 extends ExternalEffectIntentDraft {
+  fencing_token: number;
+  generation: number;
+  lease_token: string;
+  persisted_at: string;
+  run_id: string;
+  schema_version: "external-effect-intent/v1";
+}
+
+export interface ExternalEffectIntentCommit {
+  created: boolean;
+  intent: ExternalEffectIntentV1;
+}
+
 export interface LeaseAcquisition {
   created: boolean;
   lease: WorkLeaseV1;

--- a/apps/slack-companion/src/execution/ports.ts
+++ b/apps/slack-companion/src/execution/ports.ts
@@ -4,6 +4,9 @@ import type {
   EffectDraft,
   EffectReceiptV1,
   EffectResolution,
+  ExternalEffectIntentCommit,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
   LeaseAcquisition,
   LeaseClaim,
   RecoveredRun,
@@ -60,12 +63,29 @@ export interface DurableExecutionPort {
 
   /**
    * Atomically finishes execution, advances the run to durable delivery, and
-   * releases its lease. Delivery reconciliation alone may complete the run.
+   * releases its lease. An external intent without a succeeded, independently
+   * verified effect must block this transition. Delivery reconciliation alone
+   * may complete the run.
    */
   finishExecution(
     lease: WorkLeaseV1,
     finishedAt: string,
   ): Promise<RunReceiptV1>;
+
+  /**
+   * Persists the exact external write intent under the active lease. Repeating
+   * the same logical intent is idempotent; changing it is a conflict.
+   */
+  persistEffectIntent(
+    lease: WorkLeaseV1,
+    draft: ExternalEffectIntentDraft,
+    persistedAt: string,
+  ): Promise<ExternalEffectIntentCommit>;
+
+  getEffectIntent(
+    runId: string,
+    idempotencyKey: string,
+  ): Promise<ExternalEffectIntentV1 | undefined>;
 
   beginEffect(
     lease: WorkLeaseV1,

--- a/apps/slack-companion/src/execution/reference-store.ts
+++ b/apps/slack-companion/src/execution/reference-store.ts
@@ -1,10 +1,18 @@
 import { ExecutionInvariantError } from "./coordinator.js";
+import {
+  effectIntentDigest,
+  normalizeEffectIntentValue,
+  sameExternalEffectIntent,
+} from "./effect-intent.js";
 import type {
   CheckpointDraft,
   CheckpointV1,
   EffectDraft,
   EffectReceiptV1,
   EffectResolution,
+  ExternalEffectIntentCommit,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
   LeaseAcquisition,
   LeaseClaim,
   RecoveredRun,
@@ -17,6 +25,7 @@ import type { DurableExecutionPort } from "./ports.js";
 export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
   private readonly checkpoints = new Map<string, CheckpointV1[]>();
   private readonly effects = new Map<string, EffectReceiptV1>();
+  private readonly effectIntents = new Map<string, ExternalEffectIntentV1>();
   private readonly fencingTokens = new Map<string, number>();
   private readonly highestGenerations = new Map<string, number>();
   private readonly leases = new Map<string, WorkLeaseV1>();
@@ -162,6 +171,17 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
     finishedAt: string,
   ): Promise<RunReceiptV1> {
     this.assertLease(lease, finishedAt);
+    for (const [key, intent] of this.effectIntents) {
+      if (intent.run_id !== lease.run_id) {
+        continue;
+      }
+      const effect = this.effects.get(key);
+      if (effect?.state !== "succeeded" || effect.verification_state !== "verified") {
+        throw new ExecutionInvariantError(
+          "run has an external intent without a verified effect",
+        );
+      }
+    }
     for (const effect of this.effects.values()) {
       if (effect.run_id !== lease.run_id) {
         continue;
@@ -180,6 +200,58 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
     this.runs.set(lease.run_id, delivering);
     this.leases.delete(lease.run_id);
     return Promise.resolve(structuredClone(delivering));
+  }
+
+  persistEffectIntent(
+    lease: WorkLeaseV1,
+    draft: ExternalEffectIntentDraft,
+    persistedAt: string,
+  ): Promise<ExternalEffectIntentCommit> {
+    this.assertLease(lease, persistedAt);
+    if (
+      JSON.stringify(normalizeEffectIntentValue(draft.request)) !==
+      JSON.stringify(draft.request)
+    ) {
+      throw new ExecutionInvariantError("effect intent request is not canonical");
+    }
+    if (effectIntentDigest(draft) !== draft.request_digest) {
+      throw new ExecutionInvariantError("effect intent digest does not match its request");
+    }
+    const key = effectKey(lease.run_id, draft.idempotency_key);
+    const current = this.effectIntents.get(key);
+    if (current !== undefined) {
+      if (!sameExternalEffectIntent(current, draft)) {
+        throw new ExecutionInvariantError(
+          "effect idempotency key has a different external intent",
+        );
+      }
+      return Promise.resolve({
+        created: false,
+        intent: structuredClone(current),
+      });
+    }
+
+    const intent: ExternalEffectIntentV1 = {
+      ...structuredClone(draft),
+      fencing_token: lease.fencing_token,
+      generation: lease.generation,
+      lease_token: lease.lease_token,
+      persisted_at: persistedAt,
+      run_id: lease.run_id,
+      schema_version: "external-effect-intent/v1",
+    };
+    this.effectIntents.set(key, intent);
+    return Promise.resolve({ created: true, intent: structuredClone(intent) });
+  }
+
+  getEffectIntent(
+    runId: string,
+    idempotencyKey: string,
+  ): Promise<ExternalEffectIntentV1 | undefined> {
+    const intent = this.effectIntents.get(effectKey(runId, idempotencyKey));
+    return Promise.resolve(
+      intent === undefined ? undefined : structuredClone(intent),
+    );
   }
 
   beginEffect(

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -1,5 +1,22 @@
 export * from "./admission.js";
 export * from "./contracts.js";
+export {
+  ExecutionCoordinator,
+  ExecutionInvariantError,
+} from "./execution/coordinator.js";
+export * from "./execution/effect-reconciliation.js";
+export * from "./execution/effect-intent.js";
+export type {
+  EffectIntentValue,
+  ExecutionSession,
+  ExternalEffectIntentCommit,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
+} from "./execution/model.js";
+export type {
+  DurableExecutionPort,
+  ExecutionClockPort,
+} from "./execution/ports.js";
 export * from "./installation.js";
 export * from "./lifecycle.js";
 export * from "./ports.js";

--- a/apps/slack-companion/test/effect-reconciliation.test.ts
+++ b/apps/slack-companion/test/effect-reconciliation.test.ts
@@ -1,0 +1,501 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { RunReceiptV1, WorkLeaseV1 } from "@writer/cerebro-sdk";
+import { ExecutionCoordinator } from "../src/execution/coordinator.js";
+import {
+  effectIntentDigest,
+  normalizeEffectIntentValue,
+} from "../src/execution/effect-intent.js";
+import {
+  EffectReconciliationBlockedError,
+  ExternalEffectReconciler,
+} from "../src/execution/effect-reconciliation.js";
+import type {
+  ExternalEffectDraft,
+  ExternalEffectInspection,
+  ExternalEffectJob,
+  ExternalEffectPort,
+  ExternalEffectResult,
+  ExternalEffectVerification,
+  RecoverableExternalEffectInspection,
+} from "../src/execution/effect-reconciliation.js";
+import type {
+  ExecutionSession,
+  ExternalEffectIntentDraft,
+  ExternalEffectIntentV1,
+} from "../src/execution/model.js";
+import { ReferenceMemoryExecutionStore } from "../src/execution/reference-store.js";
+
+describe("ExternalEffectReconciler", () => {
+  test("continues from an immutable intent persisted before the external call", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session(1);
+    const input = effectDraft();
+    const persisted = await fixture.store.persistEffectIntent(
+      session.lease,
+      intentDraft(input),
+      fixture.clock.now().toISOString(),
+    );
+
+    assert.equal(persisted.created, true);
+    assert.deepEqual(persisted.intent.request, {
+      change: { mode: "bounded", target: "opaque-target-1" },
+      scope: "opaque-scope-1",
+    });
+    await assert.rejects(
+      async () => fixture.execution.finishExecution(session),
+      /external intent without a verified effect/,
+    );
+
+    const result = await fixture.reconciler.execute(
+      session,
+      effectJob(session, input),
+      input,
+    );
+
+    assert.equal(result.status, "applied");
+    assert.equal(fixture.external.applyCalls, 1);
+    assert.equal(fixture.external.inspectCalls, 0);
+    assert.equal(
+      (await fixture.store.getEffectIntent(session.run.run_id, input.idempotency_key))
+        ?.request_digest,
+      persisted.intent.request_digest,
+    );
+  });
+
+  test("rejects a changed request under the same durable effect identity", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session(1);
+    const input = effectDraft();
+    await fixture.store.persistEffectIntent(
+      session.lease,
+      intentDraft(input),
+      fixture.clock.now().toISOString(),
+    );
+
+    await assert.rejects(
+      fixture.reconciler.execute(
+        session,
+        effectJob(session, input),
+        {
+          ...input,
+          request: {
+            change: { mode: "expanded", target: "opaque-target-2" },
+            scope: "opaque-scope-1",
+          },
+        },
+      ),
+      /different external intent/,
+    );
+    assert.equal(fixture.external.callCount, 0);
+  });
+
+  test("inspects an outcome-unknown effect after a post-call crash without duplicating it", async () => {
+    const fixture = makeFixture();
+    const firstSession = await fixture.session(1);
+    const input = effectDraft();
+    fixture.external.crashAfterApply = true;
+
+    await assert.rejects(
+      fixture.reconciler.execute(
+        firstSession,
+        effectJob(firstSession, input),
+        input,
+      ),
+      /simulated crash/,
+    );
+    assert.equal(fixture.external.applyCalls, 1);
+
+    const resumed = await fixture.recover(firstSession, 2);
+    fixture.external.crashAfterApply = false;
+    const result = await fixture.reconciler.execute(
+      resumed,
+      effectJob(resumed, input),
+      input,
+    );
+
+    assert.equal(result.status, "recovered");
+    assert.equal(fixture.external.inspectCalls, 1);
+    assert.equal(fixture.external.applyCalls, 1);
+    assert.equal(result.effect.generation, 2);
+  });
+
+  for (const partialState of ["prepared", "materialized"] as const) {
+    test(`resumes the ${partialState} partial window exactly once`, async () => {
+      const fixture = makeFixture();
+      const firstSession = await fixture.session(1);
+      const input = effectDraft();
+      await seedExecuting(fixture, firstSession, input);
+      fixture.external.inspection = {
+        candidate_version: input.candidate_version,
+        resume_token: `resume-${partialState}`,
+        state: partialState,
+      };
+
+      const resumed = await fixture.recover(firstSession, 2);
+      const result = await fixture.reconciler.execute(
+        resumed,
+        effectJob(resumed, input),
+        input,
+      );
+
+      assert.equal(result.status, "recovered");
+      assert.equal(fixture.external.inspectCalls, 1);
+      assert.equal(fixture.external.resumeCalls, 1);
+      assert.equal(fixture.external.applyCalls, 0);
+      assert.equal(fixture.external.inspection.state, "applied");
+    });
+  }
+
+  test("consumes stale generation and fencing jobs without creating an intent", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session(4);
+    const input = effectDraft();
+
+    const staleGeneration = await fixture.reconciler.execute(
+      session,
+      { ...effectJob(session, input), generation: 3 },
+      input,
+    );
+    const staleFence = await fixture.reconciler.execute(
+      session,
+      { ...effectJob(session, input), fencing_token: session.lease.fencing_token + 1 },
+      input,
+    );
+
+    assert.deepEqual(staleGeneration, {
+      reason: "generation_mismatch",
+      status: "stale",
+    });
+    assert.deepEqual(staleFence, {
+      reason: "fencing_token_mismatch",
+      status: "stale",
+    });
+    assert.equal(
+      await fixture.store.getEffectIntent(session.run.run_id, input.idempotency_key),
+      undefined,
+    );
+    assert.equal(fixture.external.callCount, 0);
+  });
+
+  test("consumes a superseded candidate job without retargeting its durable intent", async () => {
+    const fixture = makeFixture();
+    const firstSession = await fixture.session(1);
+    const original = effectDraft("candidate-version-1");
+    const committed = await fixture.store.persistEffectIntent(
+      firstSession.lease,
+      intentDraft(original),
+      fixture.clock.now().toISOString(),
+    );
+    await fixture.execution.release(firstSession);
+    const resumed = await fixture.session(2);
+    const superseding = effectDraft("candidate-version-2");
+
+    const result = await fixture.reconciler.execute(
+      resumed,
+      effectJob(resumed, superseding),
+      superseding,
+    );
+
+    assert.deepEqual(result, {
+      reason: "candidate_version_mismatch",
+      status: "stale",
+    });
+    assert.equal(
+      (await fixture.store.getEffectIntent(resumed.run.run_id, original.idempotency_key))
+        ?.candidate_version,
+      committed.intent.candidate_version,
+    );
+    assert.equal(fixture.external.callCount, 0);
+  });
+
+  for (const blockedState of [
+    "ambiguous",
+    "boundary_mismatch",
+    "target_moved",
+  ] as const) {
+    test(`fails closed when inspection reports ${blockedState}`, async () => {
+      const fixture = makeFixture();
+      const firstSession = await fixture.session(1);
+      const input = effectDraft();
+      await seedExecuting(fixture, firstSession, input);
+      fixture.external.inspection = {
+        reason_code: `fake-${blockedState}`,
+        state: blockedState,
+      };
+      const resumed = await fixture.recover(firstSession, 2);
+
+      await assert.rejects(
+        fixture.reconciler.execute(
+          resumed,
+          effectJob(resumed, input),
+          input,
+        ),
+        (error: unknown) =>
+          error instanceof EffectReconciliationBlockedError &&
+          error.code === blockedState,
+      );
+      assert.equal(fixture.external.inspectCalls, 1);
+      assert.equal(fixture.external.applyCalls, 0);
+      assert.equal(fixture.external.resumeCalls, 0);
+      assert.equal(
+        (await fixture.store.getEffect(resumed.run.run_id, input.idempotency_key))
+          ?.state,
+        "unknown",
+      );
+    });
+  }
+
+  test("returns the terminal effect on an exact retry without another external call", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session(1);
+    const input = effectDraft();
+
+    const first = await fixture.reconciler.execute(
+      session,
+      effectJob(session, input),
+      input,
+    );
+    const duplicate = await fixture.reconciler.execute(
+      session,
+      effectJob(session, input),
+      input,
+    );
+
+    assert.equal(first.status, "applied");
+    assert.equal(duplicate.status, "duplicate");
+    assert.equal(fixture.external.applyCalls, 1);
+    assert.equal(fixture.external.inspectCalls, 0);
+    assert.equal(fixture.external.verifyCalls, 1);
+  });
+});
+
+function makeFixture(runId = "run-effect-1") {
+  const clock = new MutableClock();
+  const store = new ReferenceMemoryExecutionStore();
+  store.seedRun(runReceipt(runId));
+  const execution = new ExecutionCoordinator({
+    clock,
+    lease_duration_ms: 30_000,
+    store,
+  });
+  const external = new FakeExternalEffectPort();
+  const reconciler = new ExternalEffectReconciler({
+    clock,
+    execution,
+    external,
+    store,
+  });
+
+  const session = async (generation: number): Promise<ExecutionSession> => {
+    const result = await execution.start({
+      generation,
+      lease_token: `lease-${generation}`,
+      owner_id: `worker-${generation}`,
+      run_id: runId,
+      service_state: "ready",
+    });
+    if (result.status === "not_runnable") {
+      throw new Error("fixture run was not runnable");
+    }
+    return result.session;
+  };
+
+  return {
+    clock,
+    execution,
+    external,
+    reconciler,
+    recover: async (
+      staleSession: ExecutionSession,
+      generation: number,
+    ): Promise<ExecutionSession> => {
+      clock.advance(31_000);
+      assert.equal((await execution.reconcileExpired()).length, 1);
+      assert.equal(
+        (await store.getEffect(staleSession.run.run_id, effectDraft().idempotency_key))
+          ?.state,
+        "unknown",
+      );
+      return session(generation);
+    },
+    session,
+    store,
+  };
+}
+
+class FakeExternalEffectPort implements ExternalEffectPort {
+  applyCalls = 0;
+  crashAfterApply = false;
+  inspectCalls = 0;
+  inspection: ExternalEffectInspection = { state: "absent" };
+  resumeCalls = 0;
+  verifyCalls = 0;
+
+  get callCount(): number {
+    return this.applyCalls + this.inspectCalls + this.resumeCalls + this.verifyCalls;
+  }
+
+  apply(
+    intent: ExternalEffectIntentV1,
+    _lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult> {
+    this.applyCalls += 1;
+    const result = externalResult(intent.candidate_version);
+    this.inspection = { result, state: "applied" };
+    if (this.crashAfterApply) {
+      return Promise.reject(new Error("simulated crash after external apply"));
+    }
+    return Promise.resolve(result);
+  }
+
+  inspect(
+    _intent: ExternalEffectIntentV1,
+    _lease: WorkLeaseV1,
+  ): Promise<ExternalEffectInspection> {
+    this.inspectCalls += 1;
+    return Promise.resolve(structuredClone(this.inspection));
+  }
+
+  resume(
+    intent: ExternalEffectIntentV1,
+    _inspection: RecoverableExternalEffectInspection,
+    _lease: WorkLeaseV1,
+  ): Promise<ExternalEffectResult> {
+    this.resumeCalls += 1;
+    const result = externalResult(intent.candidate_version);
+    this.inspection = { result, state: "applied" };
+    return Promise.resolve(result);
+  }
+
+  verify(
+    intent: ExternalEffectIntentV1,
+    _result: ExternalEffectResult,
+    _lease: WorkLeaseV1,
+  ): Promise<ExternalEffectVerification> {
+    this.verifyCalls += 1;
+    return Promise.resolve({
+      candidate_version: intent.candidate_version,
+      receipt_ref: `verification://${intent.effect_id}`,
+      state: "verified",
+    });
+  }
+}
+
+async function seedExecuting(
+  fixture: ReturnType<typeof makeFixture>,
+  session: ExecutionSession,
+  draft: ExternalEffectDraft,
+): Promise<void> {
+  const committed = await fixture.store.persistEffectIntent(
+    session.lease,
+    intentDraft(draft),
+    fixture.clock.now().toISOString(),
+  );
+  await fixture.execution.beginEffect(session, {
+    approval_ref: committed.intent.approval_ref,
+    approval_required: committed.intent.approval_required,
+    effect_id: committed.intent.effect_id,
+    idempotency_key: committed.intent.idempotency_key,
+    request_digest: committed.intent.request_digest,
+    rollback_plan_ref: committed.intent.rollback_plan_ref,
+    step_id: committed.intent.step_id,
+    target_ref: committed.intent.target_ref,
+  });
+  await fixture.execution.markEffectExecuting(
+    session,
+    committed.intent.idempotency_key,
+  );
+}
+
+function effectDraft(candidateVersion = "candidate-version-1"): ExternalEffectDraft {
+  return {
+    approval_ref: "approval://effect-1",
+    approval_required: true,
+    candidate_version: candidateVersion,
+    effect_id: "effect-1",
+    idempotency_key: "turn-1:step-1",
+    request: {
+      scope: "opaque-scope-1",
+      change: { mode: "bounded", target: "opaque-target-1" },
+    },
+    rollback_plan_ref: "rollback://effect-1",
+    step_id: "step-1",
+    target_ref: "target://opaque-1",
+  };
+}
+
+function intentDraft(draft: ExternalEffectDraft): ExternalEffectIntentDraft {
+  const request = normalizeEffectIntentValue(draft.request);
+  const intentFields = {
+    approval_ref: draft.approval_ref,
+    approval_required: draft.approval_required,
+    candidate_version: draft.candidate_version,
+    effect_id: draft.effect_id,
+    idempotency_key: draft.idempotency_key,
+    request,
+    rollback_plan_ref: draft.rollback_plan_ref,
+    step_id: draft.step_id,
+    target_ref: draft.target_ref,
+  };
+  return {
+    ...intentFields,
+    request_digest: effectIntentDigest(intentFields),
+  };
+}
+
+function effectJob(
+  session: ExecutionSession,
+  draft: ExternalEffectDraft,
+): ExternalEffectJob {
+  return {
+    candidate_version: draft.candidate_version,
+    fencing_token: session.lease.fencing_token,
+    generation: session.lease.generation,
+    idempotency_key: draft.idempotency_key,
+    lease_token: session.lease.lease_token,
+    run_id: session.run.run_id,
+  };
+}
+
+function externalResult(candidateVersion: string): ExternalEffectResult {
+  return {
+    candidate_version: candidateVersion,
+    result_digest: `sha256:result-${candidateVersion}`,
+    result_ref: `result://${candidateVersion}`,
+  };
+}
+
+class MutableClock {
+  private milliseconds = Date.parse("2026-07-16T12:00:00.000Z");
+
+  advance(durationMs: number): void {
+    this.milliseconds += durationMs;
+  }
+
+  now(): Date {
+    return new Date(this.milliseconds);
+  }
+}
+
+function runReceipt(runId: string): RunReceiptV1 {
+  const now = "2026-07-16T11:59:00.000Z";
+  return {
+    admitted_at: now,
+    binding_id: "binding-1",
+    idempotency_key: `event:${runId}`,
+    input_digest: "sha256:input",
+    receipt_id: `receipt-${runId}`,
+    received_at: now,
+    required_capabilities: [],
+    retention_policy_ref: "retention://default",
+    revision: 1,
+    run_id: runId,
+    run_kind: "interactive",
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: "conversation://opaque/thread",
+    tenant_id: "tenant-1",
+    updated_at: now,
+  };
+}


### PR DESCRIPTION
## What changed

- persist the complete canonical external-effect intent before any external call
- fence effect jobs by run, generation, lease, fencing token, idempotency key, and candidate version
- inspect and resume partial or outcome-unknown work before retrying
- require independent verification before execution can hand work to delivery
- fail closed on ambiguous, moved, or mismatched targets

## Why

A process can stop after an external system accepted a write but before the companion recorded completion. The durable intent and reconciliation path prevent an acknowledged run from duplicating or silently losing that effect across recovery and rolling execution generations.

## Validation

- 27 Slack companion tests
- all workspace tests: Slack companion, web app, and SDK
- architecture and structural checks
- OSS audit
- staged and commit-range leak checks
- diff check
- Practice Registry final gate

## Sequence

This PR is stacked on the fenced execution-continuity slice. It contains portable behavior, contracts, and conformance tests only.
