### PR TITLE
Bridge companion runs to the native mission lifecycle

### DIFF
--- a/apps/slack-companion/src/execution/coordinator.ts
+++ b/apps/slack-companion/src/execution/coordinator.ts
@@ -103,6 +103,24 @@ export class ExecutionCoordinator {
     );
   }
 
+  waitForDependency(
+    session: ExecutionSession,
+    draft: CheckpointDraft,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }> {
+    if (draft.waiting_on_ref === undefined) {
+      return Promise.reject(
+        new ExecutionInvariantError(
+          "a waiting checkpoint requires waiting_on_ref",
+        ),
+      );
+    }
+    return this.store.waitWithCheckpoint(
+      session.lease,
+      draft,
+      this.clock.now().toISOString(),
+    );
+  }
+
   finishExecution(session: ExecutionSession): Promise<RunReceiptV1> {
     return this.store.finishExecution(
       session.lease,

--- a/apps/slack-companion/src/execution/ports.ts
+++ b/apps/slack-companion/src/execution/ports.ts
@@ -61,6 +61,13 @@ export interface DurableExecutionPort {
     createdAt: string,
   ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }>;
 
+  /** Atomically appends a checkpoint, waits the run, and releases its lease. */
+  waitWithCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }>;
+
   /**
    * Atomically finishes execution, advances the run to durable delivery, and
    * releases its lease. An external intent without a succeeded, independently

--- a/apps/slack-companion/src/execution/reference-store.ts
+++ b/apps/slack-companion/src/execution/reference-store.ts
@@ -61,7 +61,11 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
       }
       return Promise.resolve(undefined);
     }
-    if (run.state !== "queued" && run.state !== "paused") {
+    if (
+      run.state !== "queued" &&
+      run.state !== "paused" &&
+      run.state !== "waiting"
+    ) {
       return Promise.resolve(undefined);
     }
 
@@ -163,6 +167,34 @@ export class ReferenceMemoryExecutionStore implements DurableExecutionPort {
     return Promise.resolve({
       checkpoint: structuredClone(stored),
       run: structuredClone(paused),
+    });
+  }
+
+  waitWithCheckpoint(
+    lease: WorkLeaseV1,
+    draft: CheckpointDraft,
+    createdAt: string,
+  ): Promise<{ checkpoint: CheckpointV1; run: RunReceiptV1 }> {
+    this.assertLease(lease, createdAt);
+    if (draft.waiting_on_ref === undefined) {
+      throw new ExecutionInvariantError(
+        "a waiting checkpoint requires waiting_on_ref",
+      );
+    }
+    const checkpoint = this.buildCheckpoint(lease, draft, createdAt);
+    const waiting = updateRun(
+      this.requireRun(lease.run_id),
+      "waiting",
+      createdAt,
+    );
+
+    // This block models one transaction: checkpoint first, then waiting truth.
+    const stored = this.storeCheckpoint(checkpoint);
+    this.runs.set(lease.run_id, waiting);
+    this.leases.delete(lease.run_id);
+    return Promise.resolve({
+      checkpoint: structuredClone(stored),
+      run: structuredClone(waiting),
     });
   }
 

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -19,4 +19,6 @@ export type {
 } from "./execution/ports.js";
 export * from "./installation.js";
 export * from "./lifecycle.js";
+export * from "./mission/coordinator.js";
+export * from "./mission/model.js";
 export * from "./ports.js";

--- a/apps/slack-companion/src/mission/coordinator.ts
+++ b/apps/slack-companion/src/mission/coordinator.ts
@@ -1,0 +1,487 @@
+import type {
+  CheckpointDraft,
+  ExecutionSession,
+} from "../execution/model.js";
+import {
+  ExecutionCoordinator,
+  ExecutionInvariantError,
+} from "../execution/coordinator.js";
+import type {
+  EvidenceProofV1,
+  MissionCapabilityBindingV1,
+  MissionCheckpointProjectionV1,
+  MissionClosureProjectionV1,
+  MissionClosureResult,
+  MissionDecisionProjectionV1,
+  MissionEffectReceipt,
+  MissionEffectResolutionV1,
+  MissionPlanProjectionV1,
+  MissionReadinessDecision,
+  MissionReadinessInput,
+  MissionStepProjectionV1,
+  MissionVerificationProjectionV1,
+  MissionWaitProjectionV1,
+  MissionWaitResult,
+  ReceiptProofV1,
+} from "./model.js";
+import {
+  NATIVE_MISSION_CONTRACT_ID,
+  NATIVE_MISSION_SCHEMA_VERSION,
+} from "./model.js";
+
+export class MissionBridgeCoordinator {
+  constructor(private readonly execution: ExecutionCoordinator) {}
+
+  readiness(
+    plan: MissionPlanProjectionV1,
+    input: MissionReadinessInput,
+  ): MissionReadinessDecision {
+    validatePlanShape(plan);
+    validateDistinctRefs(input.missing_input_refs, "missing input");
+    if (input.missing_input_refs.length > 0) {
+      return {
+        kind: "missing_input",
+        status: "waiting",
+        waiting_on_ref: input.missing_input_refs[0]!,
+      };
+    }
+
+    const bindings = indexBindings(input.capability_bindings);
+    for (const step of plan.steps) {
+      const binding = bindings.get(step.capability_ref);
+      if (
+        binding === undefined ||
+        binding.capability_version !== step.capability_version ||
+        binding.state !== "bound"
+      ) {
+        return {
+          kind: "missing_tool_binding",
+          status: "waiting",
+          waiting_on_ref: binding?.binding_ref ?? step.capability_ref,
+        };
+      }
+    }
+    return { status: "ready" };
+  }
+
+  wait(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    projection: MissionWaitProjectionV1,
+  ): Promise<MissionWaitResult> {
+    this.validateSessionPlan(session, plan);
+    requireRef(projection.waiting_on_ref, "waiting_on_ref");
+    return this.execution.waitForDependency(
+      session,
+      checkpointDraft(
+        plan,
+        projection,
+        projection.waiting_on_ref,
+        projection.kind,
+      ),
+    );
+  }
+
+  pauseForDrain(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    projection: MissionCheckpointProjectionV1,
+  ): Promise<MissionWaitResult> {
+    this.validateSessionPlan(session, plan);
+    return this.execution.pauseForDrain(
+      session,
+      checkpointDraft(plan, projection, undefined, "drain"),
+    );
+  }
+
+  beginEffect(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    stepId: string,
+    decision?: MissionDecisionProjectionV1,
+  ): Promise<MissionEffectReceipt> {
+    this.validateSessionPlan(session, plan);
+    const step = requireStep(plan, stepId);
+    requireRef(step.rollback_plan_ref, "rollback_plan_ref");
+
+    let approvalRef: string | undefined;
+    if (step.approval_required) {
+      if (decision === undefined) {
+        return Promise.reject(
+          new MissionBridgeInvariantError(
+            "an approval decision is required before this effect",
+          ),
+        );
+      }
+      validateDecision(plan, decision);
+      if (decision.decision !== "approved") {
+        return Promise.reject(
+          new MissionBridgeInvariantError(
+            "a rejected decision cannot authorize an effect",
+          ),
+        );
+      }
+      approvalRef = decision.receipt.receipt_ref;
+    }
+
+    return this.execution.beginEffect(session, {
+      approval_ref: approvalRef,
+      approval_required: step.approval_required,
+      effect_id: step.effect_id,
+      idempotency_key: step.idempotency_key,
+      request_digest: step.request_digest,
+      rollback_plan_ref: step.rollback_plan_ref,
+      step_id: step.step_id,
+      target_ref: step.target_ref,
+    });
+  }
+
+  markEffectExecuting(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    stepId: string,
+  ): Promise<MissionEffectReceipt> {
+    this.validateSessionPlan(session, plan);
+    const step = requireStep(plan, stepId);
+    return this.execution.markEffectExecuting(session, step.idempotency_key);
+  }
+
+  resolveEffect(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    stepId: string,
+    resolution: MissionEffectResolutionV1,
+  ): Promise<MissionEffectReceipt> {
+    this.validateSessionPlan(session, plan);
+    const step = requireStep(plan, stepId);
+    validateReceipt(resolution.result, "effect result");
+    validateVerification(resolution.executor_ref, resolution.verification);
+    return this.execution.resolveEffect(session, step.idempotency_key, {
+      result_digest: resolution.result.receipt_digest,
+      result_ref: resolution.result.receipt_ref,
+      state: resolution.state,
+      verification_receipt_ref: resolution.verification.receipt.receipt_ref,
+      verification_state:
+        resolution.state === "succeeded" ? "verified" : "failed",
+    });
+  }
+
+  async close(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+    projection: MissionClosureProjectionV1,
+  ): Promise<MissionClosureResult> {
+    this.validateSessionPlan(session, plan);
+    if (!projection.desired_condition_verified) {
+      throw new MissionBridgeInvariantError(
+        "mission closure requires a verified desired condition",
+      );
+    }
+    if (projection.armed_wake_condition_refs.length > 0) {
+      throw new MissionBridgeInvariantError(
+        "mission closure cannot retain an armed wake condition",
+      );
+    }
+    validateCompletedSteps(plan, projection.completed_step_ids);
+    validateVerification(projection.executor_ref, projection.verification);
+
+    const checkpoint = await this.execution.checkpoint(
+      session,
+      checkpointDraft(
+        plan,
+        {
+          ...projection,
+          state_receipt: projection.verification.receipt,
+        },
+        undefined,
+        "verified_closure",
+      ),
+    );
+    const run = await this.execution.finishExecution(session);
+    return { checkpoint, run };
+  }
+
+  private validateSessionPlan(
+    session: ExecutionSession,
+    plan: MissionPlanProjectionV1,
+  ): void {
+    validatePlanShape(plan);
+    if (
+      session.run.run_id !== plan.run_id ||
+      session.lease.run_id !== plan.run_id
+    ) {
+      throw new MissionBridgeInvariantError(
+        "mission plan does not belong to the execution run",
+      );
+    }
+    if (session.run.state !== "running") {
+      throw new MissionBridgeInvariantError(
+        "mission projection requires a running leased session",
+      );
+    }
+  }
+}
+
+export class MissionBridgeInvariantError extends ExecutionInvariantError {
+  constructor(message: string) {
+    super(message);
+    this.name = "MissionBridgeInvariantError";
+  }
+}
+
+function validatePlanShape(plan: MissionPlanProjectionV1): void {
+  if (plan.schema_version !== "mission-plan-projection/v1") {
+    throw new MissionBridgeInvariantError(
+      "mission plan projection schema version is unsupported",
+    );
+  }
+  if (plan.mission_contract_id !== NATIVE_MISSION_CONTRACT_ID) {
+    throw new MissionBridgeInvariantError("mission contract id is unsupported");
+  }
+  if (plan.mission_schema_version !== NATIVE_MISSION_SCHEMA_VERSION) {
+    throw new MissionBridgeInvariantError(
+      "mission contract schema version is unsupported",
+    );
+  }
+  for (const [value, label] of [
+    [plan.run_id, "run_id"],
+    [plan.mission_ref, "mission_ref"],
+    [plan.plan_ref, "plan_ref"],
+    [plan.plan_digest, "plan_digest"],
+  ] as const) {
+    requireRef(value, label);
+  }
+  requirePositiveRevision(plan.mission_revision, "mission_revision");
+  requirePositiveRevision(plan.plan_revision, "plan_revision");
+  if (plan.steps.length === 0) {
+    throw new MissionBridgeInvariantError("mission plan has no steps");
+  }
+  const stepIds = new Set<string>();
+  const effectKeys = new Set<string>();
+  for (const step of plan.steps) {
+    validateStep(step);
+    if (stepIds.has(step.step_id)) {
+      throw new MissionBridgeInvariantError("mission plan repeats a step id");
+    }
+    if (effectKeys.has(step.idempotency_key)) {
+      throw new MissionBridgeInvariantError(
+        "mission plan repeats an effect idempotency key",
+      );
+    }
+    stepIds.add(step.step_id);
+    effectKeys.add(step.idempotency_key);
+  }
+}
+
+function validateStep(step: MissionStepProjectionV1): void {
+  for (const [value, label] of [
+    [step.step_id, "step_id"],
+    [step.capability_ref, "capability_ref"],
+    [step.capability_version, "capability_version"],
+    [step.effect_id, "effect_id"],
+    [step.idempotency_key, "idempotency_key"],
+    [step.request_digest, "request_digest"],
+    [step.target_ref, "target_ref"],
+  ] as const) {
+    requireRef(value, label);
+  }
+}
+
+function indexBindings(
+  bindings: MissionCapabilityBindingV1[],
+): Map<string, MissionCapabilityBindingV1> {
+  const indexed = new Map<string, MissionCapabilityBindingV1>();
+  for (const binding of bindings) {
+    requireRef(binding.binding_ref, "binding_ref");
+    requireRef(binding.capability_ref, "capability_ref");
+    requireRef(binding.capability_version, "capability_version");
+    if (indexed.has(binding.capability_ref)) {
+      throw new MissionBridgeInvariantError(
+        "capability readiness repeats a capability ref",
+      );
+    }
+    indexed.set(binding.capability_ref, binding);
+  }
+  return indexed;
+}
+
+function checkpointDraft(
+  plan: MissionPlanProjectionV1,
+  projection: MissionCheckpointProjectionV1,
+  waitingOnRef?: string,
+  checkpointState = "checkpoint",
+): CheckpointDraft {
+  validateReceipt(projection.state_receipt, "mission state");
+  validateCheckpointSequence(projection.sequence);
+  validateCompletedStepSubset(plan, projection.completed_step_ids);
+  validateDistinctRefs(projection.effect_receipt_ids, "effect receipt");
+  requireRef(projection.checkpoint_id, "checkpoint_id");
+  return {
+    checkpoint_id: projection.checkpoint_id,
+    completed_step_ids: [...projection.completed_step_ids],
+    effect_receipt_ids: [...projection.effect_receipt_ids],
+    payload_digest: projection.state_receipt.receipt_digest,
+    payload_ref: projection.state_receipt.receipt_ref,
+    resume_cursor: [
+      plan.mission_ref,
+      plan.mission_revision,
+      plan.plan_ref,
+      plan.plan_revision,
+      checkpointState,
+      projection.sequence,
+    ].join(":"),
+    sequence: projection.sequence,
+    waiting_on_ref: waitingOnRef,
+  };
+}
+
+function validateDecision(
+  plan: MissionPlanProjectionV1,
+  decision: MissionDecisionProjectionV1,
+): void {
+  if (decision.schema_version !== "mission-decision-projection/v1") {
+    throw new MissionBridgeInvariantError(
+      "mission decision projection schema version is unsupported",
+    );
+  }
+  if (
+    decision.mission_ref !== plan.mission_ref ||
+    decision.mission_revision !== plan.mission_revision ||
+    decision.plan_ref !== plan.plan_ref ||
+    decision.plan_revision !== plan.plan_revision ||
+    decision.plan_digest !== plan.plan_digest
+  ) {
+    throw new MissionBridgeInvariantError(
+      "decision does not match the mission plan revision",
+    );
+  }
+  validateReceipt(decision.receipt, "decision");
+  validateEvidence(decision.evidence);
+}
+
+function validateVerification(
+  executorRef: string,
+  verification: MissionVerificationProjectionV1,
+): void {
+  requireRef(executorRef, "executor_ref");
+  requireRef(verification.verifier_ref, "verifier_ref");
+  if (executorRef === verification.verifier_ref) {
+    throw new MissionBridgeInvariantError(
+      "verification must be independent from execution",
+    );
+  }
+  requireRef(
+    verification.pre_action_source_revision,
+    "pre_action_source_revision",
+  );
+  requireRef(
+    verification.observed_source_revision,
+    "observed_source_revision",
+  );
+  if (
+    verification.pre_action_source_revision ===
+    verification.observed_source_revision
+  ) {
+    throw new MissionBridgeInvariantError(
+      "verification must observe a newer source revision",
+    );
+  }
+  validateReceipt(verification.receipt, "verification");
+  validateEvidence(verification.evidence);
+  if (
+    !verification.evidence.some(
+      (proof) => proof.source_revision === verification.observed_source_revision,
+    )
+  ) {
+    throw new MissionBridgeInvariantError(
+      "verification evidence does not prove the observed source revision",
+    );
+  }
+}
+
+function validateEvidence(evidence: EvidenceProofV1[]): void {
+  if (evidence.length === 0) {
+    throw new MissionBridgeInvariantError(
+      "a decision or verification requires evidence",
+    );
+  }
+  const refs = new Set<string>();
+  for (const proof of evidence) {
+    requireRef(proof.evidence_ref, "evidence_ref");
+    requireRef(proof.evidence_digest, "evidence_digest");
+    requireRef(proof.source_revision, "source_revision");
+    if (refs.has(proof.evidence_ref)) {
+      throw new MissionBridgeInvariantError("evidence repeats a receipt ref");
+    }
+    refs.add(proof.evidence_ref);
+  }
+}
+
+function validateReceipt(receipt: ReceiptProofV1, label: string): void {
+  requireRef(receipt.receipt_ref, `${label} receipt_ref`);
+  requireRef(receipt.receipt_digest, `${label} receipt_digest`);
+}
+
+function validateCompletedStepSubset(
+  plan: MissionPlanProjectionV1,
+  completedStepIds: string[],
+): void {
+  validateDistinctRefs(completedStepIds, "completed step");
+  const known = new Set(plan.steps.map((step) => step.step_id));
+  if (completedStepIds.some((stepId) => !known.has(stepId))) {
+    throw new MissionBridgeInvariantError(
+      "checkpoint contains a step outside the mission plan",
+    );
+  }
+}
+
+function validateCompletedSteps(
+  plan: MissionPlanProjectionV1,
+  completedStepIds: string[],
+): void {
+  validateCompletedStepSubset(plan, completedStepIds);
+  const completed = new Set(completedStepIds);
+  if (plan.steps.some((step) => !completed.has(step.step_id))) {
+    throw new MissionBridgeInvariantError(
+      "mission closure requires every plan step to be complete",
+    );
+  }
+}
+
+function requireStep(
+  plan: MissionPlanProjectionV1,
+  stepId: string,
+): MissionStepProjectionV1 {
+  const step = plan.steps.find((candidate) => candidate.step_id === stepId);
+  if (step === undefined) {
+    throw new MissionBridgeInvariantError("mission step does not exist");
+  }
+  return step;
+}
+
+function validateCheckpointSequence(sequence: number): void {
+  requirePositiveRevision(sequence, "checkpoint sequence");
+}
+
+function requirePositiveRevision(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new MissionBridgeInvariantError(`${label} must be a positive integer`);
+  }
+}
+
+function validateDistinctRefs(values: string[], label: string): void {
+  const refs = new Set<string>();
+  for (const value of values) {
+    requireRef(value, `${label} ref`);
+    if (refs.has(value)) {
+      throw new MissionBridgeInvariantError(`${label} refs must be distinct`);
+    }
+    refs.add(value);
+  }
+}
+
+function requireRef(value: string | undefined, label: string): asserts value is string {
+  if (value === undefined || value.trim() === "") {
+    throw new MissionBridgeInvariantError(`${label} must not be empty`);
+  }
+}

--- a/apps/slack-companion/src/mission/model.ts
+++ b/apps/slack-companion/src/mission/model.ts
@@ -1,0 +1,141 @@
+import type {
+  CheckpointV1,
+  EffectReceiptV1,
+  RunReceiptV1,
+} from "@writer/cerebro-sdk";
+
+export const NATIVE_MISSION_CONTRACT_ID =
+  "native-mission-operating-contract" as const;
+export const NATIVE_MISSION_SCHEMA_VERSION =
+  "cerebro.control-kernel.v1" as const;
+
+export interface ReceiptProofV1 {
+  receipt_digest: string;
+  receipt_ref: string;
+}
+
+export interface EvidenceProofV1 {
+  evidence_digest: string;
+  evidence_ref: string;
+  source_revision: string;
+}
+
+export interface MissionStepProjectionV1 {
+  approval_required: boolean;
+  capability_ref: string;
+  capability_version: string;
+  effect_id: string;
+  idempotency_key: string;
+  request_digest: string;
+  rollback_plan_ref?: string;
+  step_id: string;
+  target_ref: string;
+}
+
+/**
+ * A transport-neutral projection of an immutable mission plan. The durable
+ * mission record remains owned by the native mission contract referenced here.
+ */
+export interface MissionPlanProjectionV1 {
+  mission_contract_id: typeof NATIVE_MISSION_CONTRACT_ID;
+  mission_ref: string;
+  mission_revision: number;
+  mission_schema_version: typeof NATIVE_MISSION_SCHEMA_VERSION;
+  plan_digest: string;
+  plan_ref: string;
+  plan_revision: number;
+  run_id: string;
+  schema_version: "mission-plan-projection/v1";
+  steps: MissionStepProjectionV1[];
+}
+
+export type CapabilityBindingState = "bound" | "missing" | "incompatible";
+
+export interface MissionCapabilityBindingV1 {
+  binding_ref: string;
+  capability_ref: string;
+  capability_version: string;
+  state: CapabilityBindingState;
+}
+
+export interface MissionReadinessInput {
+  capability_bindings: MissionCapabilityBindingV1[];
+  missing_input_refs: string[];
+}
+
+export type MissionReadinessDecision =
+  | { status: "ready" }
+  | {
+      kind: "missing_input" | "missing_tool_binding";
+      status: "waiting";
+      waiting_on_ref: string;
+    };
+
+export type MissionWaitKind =
+  | "missing_input"
+  | "missing_tool_binding"
+  | "decision_required";
+
+export interface MissionCheckpointProjectionV1 {
+  checkpoint_id: string;
+  completed_step_ids: string[];
+  effect_receipt_ids: string[];
+  sequence: number;
+  state_receipt: ReceiptProofV1;
+}
+
+export interface MissionWaitProjectionV1
+  extends MissionCheckpointProjectionV1 {
+  kind: MissionWaitKind;
+  waiting_on_ref: string;
+}
+
+export interface MissionDecisionProjectionV1 {
+  decision: "approved" | "rejected";
+  evidence: EvidenceProofV1[];
+  mission_ref: string;
+  mission_revision: number;
+  plan_digest: string;
+  plan_ref: string;
+  plan_revision: number;
+  receipt: ReceiptProofV1;
+  schema_version: "mission-decision-projection/v1";
+}
+
+export interface MissionEffectResolutionV1 {
+  executor_ref: string;
+  result: ReceiptProofV1;
+  state: "succeeded" | "failed";
+  verification: MissionVerificationProjectionV1;
+}
+
+export interface MissionVerificationProjectionV1 {
+  evidence: EvidenceProofV1[];
+  observed_source_revision: string;
+  pre_action_source_revision: string;
+  receipt: ReceiptProofV1;
+  verifier_ref: string;
+}
+
+export interface MissionClosureProjectionV1 {
+  armed_wake_condition_refs: string[];
+  checkpoint_id: string;
+  completed_step_ids: string[];
+  desired_condition_verified: boolean;
+  effect_receipt_ids: string[];
+  executor_ref: string;
+  sequence: number;
+  verification: MissionVerificationProjectionV1;
+}
+
+export interface MissionWaitResult {
+  checkpoint: CheckpointV1;
+  run: RunReceiptV1;
+}
+
+export interface MissionClosureResult {
+  checkpoint: CheckpointV1;
+  run: RunReceiptV1;
+}
+
+export type MissionEffectReceipt = EffectReceiptV1;

--- a/apps/slack-companion/test/mission-bridge.test.ts
+++ b/apps/slack-companion/test/mission-bridge.test.ts
@@ -1,0 +1,421 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { RunReceiptV1 } from "@writer/cerebro-sdk";
+import { ExecutionCoordinator } from "../src/execution/coordinator.js";
+import type {
+  ExecutionSession,
+  ServiceAvailabilityState,
+} from "../src/execution/model.js";
+import { ReferenceMemoryExecutionStore } from "../src/execution/reference-store.js";
+import {
+  MissionBridgeCoordinator,
+  MissionBridgeInvariantError,
+} from "../src/mission/coordinator.js";
+import type {
+  MissionDecisionProjectionV1,
+  MissionPlanProjectionV1,
+  MissionVerificationProjectionV1,
+} from "../src/mission/model.js";
+
+describe("MissionBridgeCoordinator", () => {
+  test("projects missing inputs and capability bindings to explicit waits", () => {
+    const fixture = makeFixture();
+
+    assert.deepEqual(
+      fixture.bridge.readiness(plan(), {
+        capability_bindings: [],
+        missing_input_refs: ["input-request://scope"],
+      }),
+      {
+        kind: "missing_input",
+        status: "waiting",
+        waiting_on_ref: "input-request://scope",
+      },
+    );
+    assert.deepEqual(
+      fixture.bridge.readiness(plan(), {
+        capability_bindings: [],
+        missing_input_refs: [],
+      }),
+      {
+        kind: "missing_tool_binding",
+        status: "waiting",
+        waiting_on_ref: "capability://bounded-action/v1",
+      },
+    );
+    assert.deepEqual(
+      fixture.bridge.readiness(plan(), {
+        capability_bindings: [capabilityBinding("bound")],
+        missing_input_refs: [],
+      }),
+      { status: "ready" },
+    );
+  });
+
+  test("waits durably and resumes from the mission checkpoint", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    const waiting = await fixture.bridge.wait(session, plan(), {
+      checkpoint_id: "checkpoint-wait-1",
+      completed_step_ids: [],
+      effect_receipt_ids: [],
+      kind: "missing_input",
+      sequence: 1,
+      state_receipt: receipt("mission-state://wait-1", "sha256:wait-1"),
+      waiting_on_ref: "input-request://scope",
+    });
+
+    assert.equal(waiting.run.state, "waiting");
+    assert.equal(waiting.checkpoint.waiting_on_ref, "input-request://scope");
+    assert.equal(waiting.checkpoint.payload_digest, "sha256:wait-1");
+    assert.notEqual(waiting.run.state, "completed");
+
+    const resumed = await fixture.start("ready", 2, "executor-b", "lease-b");
+    if (resumed.status === "not_runnable") {
+      assert.fail("expected a waiting mission run to resume");
+    }
+    assert.equal(resumed.status, "resumed");
+    assert.equal(resumed.session.run.state, "running");
+    assert.equal(resumed.session.checkpoint?.checkpoint_id, "checkpoint-wait-1");
+    assert.equal(resumed.session.lease.generation, 2);
+  });
+
+  test("keeps drain pause resumable instead of reporting completion", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    const paused = await fixture.bridge.pauseForDrain(session, plan(), {
+      checkpoint_id: "checkpoint-drain-1",
+      completed_step_ids: [],
+      effect_receipt_ids: [],
+      sequence: 1,
+      state_receipt: receipt("mission-state://drain-1", "sha256:drain-1"),
+    });
+
+    assert.equal(paused.run.state, "paused");
+    assert.notEqual(paused.run.state, "completed");
+    const resumed = await fixture.start("ready", 2, "executor-b", "lease-b");
+    assert.notEqual(resumed.status, "not_runnable");
+  });
+
+  test("requires evidence-backed approval, rollback, and independent verification", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    await assert.rejects(
+      fixture.bridge.beginEffect(session, plan(), "step-1"),
+      MissionBridgeInvariantError,
+    );
+    await assert.rejects(
+      fixture.bridge.beginEffect(
+        session,
+        plan(),
+        "step-1",
+        decision("rejected"),
+      ),
+      MissionBridgeInvariantError,
+    );
+    await assert.rejects(
+      async () =>
+        fixture.bridge.beginEffect(session, plan(), "step-1", {
+          ...decision("approved"),
+          plan_digest: "sha256:another-plan",
+        }),
+      MissionBridgeInvariantError,
+    );
+
+    const planned = await fixture.bridge.beginEffect(
+      session,
+      plan(),
+      "step-1",
+      decision("approved"),
+    );
+    assert.equal(planned.approval_ref, "decision://approval-1");
+    assert.equal(planned.rollback_plan_ref, "rollback://step-1");
+    assert.equal(planned.request_digest, "sha256:effect-request-1");
+
+    await fixture.bridge.markEffectExecuting(session, plan(), "step-1");
+    await assert.rejects(
+      async () =>
+        fixture.bridge.resolveEffect(session, plan(), "step-1", {
+          executor_ref: "actor://executor-a",
+          result: receipt("effect-result://step-1", "sha256:effect-result-1"),
+          state: "succeeded",
+          verification: {
+            ...verification(),
+            verifier_ref: "actor://executor-a",
+          },
+        }),
+      MissionBridgeInvariantError,
+    );
+    await assert.rejects(
+      async () =>
+        fixture.bridge.resolveEffect(session, plan(), "step-1", {
+          executor_ref: "actor://executor-a",
+          result: receipt("effect-result://step-1", "sha256:effect-result-1"),
+          state: "succeeded",
+          verification: {
+            ...verification(),
+            evidence: [
+              {
+                ...evidence(),
+                source_revision: "source-revision-unrelated",
+              },
+            ],
+          },
+        }),
+      /verification evidence does not prove the observed source revision/,
+    );
+
+    const resolved = await fixture.bridge.resolveEffect(
+      session,
+      plan(),
+      "step-1",
+      {
+        executor_ref: "actor://executor-a",
+        result: receipt("effect-result://step-1", "sha256:effect-result-1"),
+        state: "succeeded",
+        verification: verification(),
+      },
+    );
+    assert.equal(resolved.state, "succeeded");
+    assert.equal(resolved.result_digest, "sha256:effect-result-1");
+    assert.equal(resolved.verification_receipt_ref, "verification://step-1");
+    assert.equal(resolved.verification_state, "verified");
+  });
+
+  test("hands off to delivery only after evidence-backed verified closure", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+    await resolveEffect(fixture, session);
+
+    await assert.rejects(
+      fixture.bridge.close(session, plan(), {
+        armed_wake_condition_refs: [],
+        checkpoint_id: "checkpoint-close-invalid",
+        completed_step_ids: ["step-1"],
+        desired_condition_verified: true,
+        effect_receipt_ids: ["effect-receipt://step-1"],
+        executor_ref: "actor://executor-a",
+        sequence: 1,
+        verification: {
+          ...verification(),
+          observed_source_revision: "source-revision-1",
+        },
+      }),
+      MissionBridgeInvariantError,
+    );
+
+    const closed = await fixture.bridge.close(session, plan(), {
+      armed_wake_condition_refs: [],
+      checkpoint_id: "checkpoint-close-1",
+      completed_step_ids: ["step-1"],
+      desired_condition_verified: true,
+      effect_receipt_ids: ["effect-receipt://step-1"],
+      executor_ref: "actor://executor-a",
+      sequence: 1,
+      verification: verification(),
+    });
+
+    assert.equal(closed.checkpoint.payload_ref, "verification://step-1");
+    assert.equal(closed.checkpoint.payload_digest, "sha256:verification-1");
+    assert.equal(closed.run.state, "delivering");
+    assert.notEqual(closed.run.state, "completed");
+  });
+
+  test("rejects a plan that does not match the native contract or run", async () => {
+    const fixture = makeFixture();
+    const session = await fixture.session();
+
+    await assert.rejects(
+      async () =>
+        fixture.bridge.wait(
+          session,
+          { ...plan(), run_id: "run-other" },
+          {
+            checkpoint_id: "checkpoint-invalid",
+            completed_step_ids: [],
+            effect_receipt_ids: [],
+            kind: "decision_required",
+            sequence: 1,
+            state_receipt: receipt(
+              "mission-state://invalid",
+              "sha256:invalid",
+            ),
+            waiting_on_ref: "decision-request://invalid",
+          },
+        ),
+      MissionBridgeInvariantError,
+    );
+    assert.throws(
+      () =>
+        fixture.bridge.readiness(
+          {
+            ...plan(),
+            mission_schema_version: "cerebro.control-kernel.v2" as never,
+          },
+          { capability_bindings: [], missing_input_refs: [] },
+        ),
+      MissionBridgeInvariantError,
+    );
+  });
+});
+
+async function resolveEffect(
+  fixture: ReturnType<typeof makeFixture>,
+  session: ExecutionSession,
+): Promise<void> {
+  await fixture.bridge.beginEffect(
+    session,
+    plan(),
+    "step-1",
+    decision("approved"),
+  );
+  await fixture.bridge.markEffectExecuting(session, plan(), "step-1");
+  await fixture.bridge.resolveEffect(session, plan(), "step-1", {
+    executor_ref: "actor://executor-a",
+    result: receipt("effect-result://step-1", "sha256:effect-result-1"),
+    state: "succeeded",
+    verification: verification(),
+  });
+}
+
+function makeFixture(runId = "run-1") {
+  const clock = new FixedClock();
+  const store = new ReferenceMemoryExecutionStore();
+  store.seedRun(runReceipt(runId));
+  const execution = new ExecutionCoordinator({
+    clock,
+    lease_duration_ms: 30_000,
+    store,
+  });
+  const start = (
+    serviceState: ServiceAvailabilityState,
+    generation: number,
+    ownerId: string,
+    leaseToken: string,
+  ) =>
+    execution.start({
+      generation,
+      lease_token: leaseToken,
+      owner_id: ownerId,
+      run_id: runId,
+      service_state: serviceState,
+    });
+  return {
+    bridge: new MissionBridgeCoordinator(execution),
+    execution,
+    session: async (): Promise<ExecutionSession> => {
+      const result = await start("ready", 1, "executor-a", "lease-a");
+      if (result.status === "not_runnable") {
+        throw new Error("fixture run was not runnable");
+      }
+      return result.session;
+    },
+    start,
+    store,
+  };
+}
+
+class FixedClock {
+  now(): Date {
+    return new Date("2026-07-16T12:00:00.000Z");
+  }
+}
+
+function runReceipt(runId: string): RunReceiptV1 {
+  const now = "2026-07-16T11:59:00.000Z";
+  return {
+    admitted_at: now,
+    binding_id: "binding-1",
+    idempotency_key: `event:${runId}`,
+    input_digest: "sha256:input",
+    receipt_id: `receipt-${runId}`,
+    received_at: now,
+    required_capabilities: [],
+    retention_policy_ref: "retention://default",
+    revision: 1,
+    run_id: runId,
+    run_kind: "interactive",
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: "thread://conversation/turn",
+    tenant_id: "tenant-1",
+    updated_at: now,
+  };
+}
+
+function plan(): MissionPlanProjectionV1 {
+  return {
+    mission_contract_id: "native-mission-operating-contract",
+    mission_ref: "mission://mission-1",
+    mission_revision: 3,
+    mission_schema_version: "cerebro.control-kernel.v1",
+    plan_digest: "sha256:plan-4",
+    plan_ref: "mission-plan://plan-1/revision/4",
+    plan_revision: 4,
+    run_id: "run-1",
+    schema_version: "mission-plan-projection/v1",
+    steps: [
+      {
+        approval_required: true,
+        capability_ref: "capability://bounded-action/v1",
+        capability_version: "1.0.0",
+        effect_id: "effect-1",
+        idempotency_key: "mission-1:plan-4:step-1",
+        request_digest: "sha256:effect-request-1",
+        rollback_plan_ref: "rollback://step-1",
+        step_id: "step-1",
+        target_ref: "resource://target-1",
+      },
+    ],
+  };
+}
+
+function capabilityBinding(state: "bound" | "missing" | "incompatible") {
+  return {
+    binding_ref: "capability-binding://bounded-action/v1",
+    capability_ref: "capability://bounded-action/v1",
+    capability_version: "1.0.0",
+    state,
+  } as const;
+}
+
+function receipt(receiptRef: string, receiptDigest: string) {
+  return { receipt_digest: receiptDigest, receipt_ref: receiptRef };
+}
+
+function evidence() {
+  return {
+    evidence_digest: "sha256:evidence-1",
+    evidence_ref: "evidence://observation-1",
+    source_revision: "source-revision-2",
+  };
+}
+
+function decision(
+  value: "approved" | "rejected",
+): MissionDecisionProjectionV1 {
+  return {
+    decision: value,
+    evidence: [evidence()],
+    mission_ref: "mission://mission-1",
+    mission_revision: 3,
+    plan_digest: "sha256:plan-4",
+    plan_ref: "mission-plan://plan-1/revision/4",
+    plan_revision: 4,
+    receipt: receipt("decision://approval-1", "sha256:decision-1"),
+    schema_version: "mission-decision-projection/v1",
+  };
+}
+
+function verification(): MissionVerificationProjectionV1 {
+  return {
+    evidence: [evidence()],
+    observed_source_revision: "source-revision-2",
+    pre_action_source_revision: "source-revision-1",
+    receipt: receipt("verification://step-1", "sha256:verification-1"),
+    verifier_ref: "actor://verifier-b",
+  };
+}


### PR DESCRIPTION
## What changed

- bind companion runs to the existing native mission contract, schema, mission revision, and plan revision
- persist missing input, missing capability binding, and decision waits as resumable checkpoints
- pause mission work durably during drain and resume it on a newer execution generation
- require evidence-backed approval and rollback metadata before an effect can execute
- require independent evidence from the claimed observed source revision before resolving an effect or closing a mission
- hand verified closure to durable delivery without reporting the run complete early

## Why

Companion turns should use the same durable mission, plan, effect, verification, and closure semantics as Cerebro core. This bridge preserves one mission record and one execution lifecycle instead of creating a Slack-specific mission store.

## Validation

- 33 combined Slack companion tests on the stacked effect-reconciliation base
- all workspace tests on the original mission slice: Slack companion, web app, and SDK
- architecture and structural checks
- OSS audit
- staged and commit-range leak checks
- diff check
- Practice Registry final gate

## Sequence

This PR is stacked on the outcome-unknown effect reconciler. It contains portable projections, behavior, and conformance tests only.
