### PR TITLE
fix(policy): restore policy candidate lint

### DIFF
--- a/internal/bootstrap/policy_candidates.go
+++ b/internal/bootstrap/policy_candidates.go
@@ -23,7 +23,7 @@ func (a *App) handleCreatePolicyCandidate(w http.ResponseWriter, r *http.Request
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&request); err != nil {
-		writePolicyCandidateError(w, fmt.Errorf("%w: decode request: %v", policycandidate.ErrInvalidRequest, err))
+		writePolicyCandidateError(w, fmt.Errorf("%w: decode request: %w", policycandidate.ErrInvalidRequest, err))
 		return
 	}
 	tenantID, err := effectiveTenantFilter(r.Context(), request.TenantID)

--- a/internal/policycandidate/grounding.go
+++ b/internal/policycandidate/grounding.go
@@ -57,7 +57,7 @@ func groundGraphEvidence(ctx context.Context, graph ports.GraphQueryStore, tenan
 			return nil, fmt.Errorf("%w: graph evidence nodes[%d] type or source does not match current graph", ErrInvalidRequest, index)
 		}
 		if err := requireGroundedAttributes(node.Attributes, actual.attributes); err != nil {
-			return nil, fmt.Errorf("%w: graph evidence nodes[%d]: %v", ErrInvalidRequest, index, err)
+			return nil, fmt.Errorf("%w: graph evidence nodes[%d]: %w", ErrInvalidRequest, index, err)
 		}
 	}
 	edgeRows, err := graph.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: groundingEdgesQuery, Params: map[string]any{
@@ -83,7 +83,7 @@ func groundGraphEvidence(ctx context.Context, graph ports.GraphQueryStore, tenan
 			return nil, fmt.Errorf("%w: graph evidence edges[%d] source does not match current graph", ErrInvalidRequest, index)
 		}
 		if err := requireGroundedAttributes(edge.Attributes, actual.attributes); err != nil {
-			return nil, fmt.Errorf("%w: graph evidence edges[%d]: %v", ErrInvalidRequest, index, err)
+			return nil, fmt.Errorf("%w: graph evidence edges[%d]: %w", ErrInvalidRequest, index, err)
 		}
 	}
 	receiptID, err := newID()
@@ -195,7 +195,7 @@ func currentGroundingNodes(rows []ports.CypherRow) (map[string]currentGroundingO
 		}
 		attributes, err := groundingAttributes(row.Values["attributes_json"])
 		if err != nil {
-			return nil, fmt.Errorf("%w: current graph node attributes: %v", ErrInvalidRequest, err)
+			return nil, fmt.Errorf("%w: current graph node attributes: %w", ErrInvalidRequest, err)
 		}
 		result[urn] = currentGroundingObject{entityType: groundingRowString(row, "entity_type"), sourceID: groundingRowString(row, "source_id"), attributes: attributes}
 	}
@@ -213,7 +213,7 @@ func currentGroundingEdges(rows []ports.CypherRow) (map[string]currentGroundingO
 		}
 		attributes, err := groundingAttributes(row.Values["attributes_json"])
 		if err != nil {
-			return nil, fmt.Errorf("%w: current graph edge attributes: %v", ErrInvalidRequest, err)
+			return nil, fmt.Errorf("%w: current graph edge attributes: %w", ErrInvalidRequest, err)
 		}
 		result[groundingEdgeKey(fromURN, toURN, relation)] = currentGroundingObject{sourceID: groundingRowString(row, "source_id"), attributes: attributes}
 	}

--- a/internal/policycandidate/service.go
+++ b/internal/policycandidate/service.go
@@ -47,7 +47,7 @@ func (s Service) Create(ctx context.Context, request CreateRequest) (*Candidate,
 		return nil, fmt.Errorf("%w: graph_evidence is required for a grounded policy candidate", ErrInvalidRequest)
 	}
 	if _, err := policyauthor.GraphEvidenceModelContext(*request.GraphEvidence); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidRequest, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}
 	if len(request.Hypothesis) > 4000 {
 		return nil, fmt.Errorf("%w: hypothesis exceeds 4000 bytes", ErrInvalidRequest)

--- a/internal/statestore/postgres/policy_candidates.go
+++ b/internal/statestore/postgres/policy_candidates.go
@@ -104,7 +104,7 @@ func (s *Store) ListPolicyCandidates(ctx context.Context, request policycandidat
 	if err != nil {
 		return nil, fmt.Errorf("list policy candidates: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	result := make([]*policycandidate.Candidate, 0)
 	for rows.Next() {
 		var record []byte


### PR DESCRIPTION
## Summary
- preserve invalid-request classification while wrapping underlying parse and validation errors
- close policy-candidate query rows through the checked defer pattern
- restore the two policy-candidate lint shards currently failing on main

## Validation
- focused policy candidate, bootstrap, and PostgreSQL tests
- targeted golangci-lint for the three affected packages: 0 issues
- structural checks
- staged and range leak checks