### PR TITLE
feat(slack): add recursive workcell continuity

### DIFF
--- a/apps/slack-companion/src/distributed/workcells/contracts.ts
+++ b/apps/slack-companion/src/distributed/workcells/contracts.ts
@@ -1,0 +1,136 @@
+import type {
+  CheckpointV1,
+  WorkLeaseV1,
+} from "@writer/cerebro-sdk";
+import type {
+  DistributedWorkPacketV1,
+  DistributedWorkReceiptV1,
+  RuntimeToolObservationV1,
+} from "../contracts.js";
+
+export type { CheckpointV1, WorkLeaseV1 };
+
+export const RECURSIVE_WORKCELL_CHILD_SCHEMA_VERSION =
+  "recursive-workcell-child/v1" as const;
+export const RECURSIVE_WORKCELL_PROGRESS_SCHEMA_VERSION =
+  "recursive-workcell-progress/v1" as const;
+export const RECURSIVE_WORKCELL_COUNTEREVIDENCE_SCHEMA_VERSION =
+  "recursive-workcell-counterevidence/v1" as const;
+export const RECURSIVE_WORKCELL_RESUME_SCHEMA_VERSION =
+  "recursive-workcell-resume/v1" as const;
+export const RECURSIVE_WORKCELL_RECONCILIATION_SCHEMA_VERSION =
+  "recursive-workcell-reconciliation/v1" as const;
+
+export const MAX_RECURSIVE_WORKCELL_DEPTH = 4;
+export const MAX_RECURSIVE_WORKCELL_CHILDREN = 8;
+export const MAX_RECURSIVE_WORKCELL_PROGRESS_RECORDS = 128;
+export const MAX_RECURSIVE_WORKCELL_CHECKPOINTS = 32;
+export const MAX_RECURSIVE_WORKCELL_COUNTEREVIDENCE = 128;
+export const MAX_RECURSIVE_WORKCELL_OBSERVATIONS = 256;
+
+export type RecursiveWorkcellAggregateState =
+  | "active"
+  | "partially_completed"
+  | "blocked"
+  | "completed";
+
+export type RecursiveWorkcellCoordinationState = "active" | "checkpointed";
+export type RecursiveWorkcellProgressPhase = "running" | "checkpointed";
+
+/** One deterministic child of an admitted distributed work packet. */
+export interface RecursiveWorkcellChildV1 {
+  ancestor_packet_ids: string[];
+  child_packet: DistributedWorkPacketV1;
+  child_sequence: number;
+  created_at: string;
+  depth: number;
+  parent_packet_id: string;
+  schema_version: typeof RECURSIVE_WORKCELL_CHILD_SCHEMA_VERSION;
+  workcell_id: string;
+}
+
+export interface RecursiveWorkcellCounterevidenceDraft {
+  claim_ref: string;
+  evidence_digest: string;
+  evidence_ref: string;
+  observed_at: string;
+}
+
+/** Append-only contradictory evidence. Payloads remain behind opaque refs. */
+export interface RecursiveWorkcellCounterevidenceV1
+  extends RecursiveWorkcellCounterevidenceDraft {
+  child_packet_id: string;
+  counterevidence_id: string;
+  schema_version: typeof RECURSIVE_WORKCELL_COUNTEREVIDENCE_SCHEMA_VERSION;
+}
+
+export interface RecursiveWorkcellObservationV1 {
+  child_packet_id: string;
+  observation: RuntimeToolObservationV1;
+}
+
+export interface RecursiveWorkcellProgressDraft {
+  checkpoint_ref?: string;
+  counterevidence: RecursiveWorkcellCounterevidenceDraft[];
+  idempotency_key: string;
+  phase: RecursiveWorkcellProgressPhase;
+  recorded_at: string;
+  runtime_observations: RuntimeToolObservationV1[];
+  sequence: number;
+}
+
+/** An immutable progress fact; retries use the same deterministic identity. */
+export interface RecursiveWorkcellProgressV1
+  extends RecursiveWorkcellProgressDraft {
+  child_packet_id: string;
+  counterevidence: RecursiveWorkcellCounterevidenceV1[];
+  progress_id: string;
+  schema_version: typeof RECURSIVE_WORKCELL_PROGRESS_SCHEMA_VERSION;
+  workcell_id: string;
+}
+
+export interface RecursiveWorkcellResumeV1 {
+  checkpoint_id: string;
+  fencing_token: number;
+  generation: number;
+  lease_token: string;
+  recorded_at: string;
+  resume_id: string;
+  schema_version: typeof RECURSIVE_WORKCELL_RESUME_SCHEMA_VERSION;
+}
+
+/**
+ * Revisioned parent truth. Full child receipts and ordered observations remain
+ * available even when siblings fail or the coordinator resumes elsewhere.
+ */
+export interface RecursiveWorkcellReconciliationV1 {
+  blocked_child_count: number;
+  checkpoints: CheckpointV1[];
+  child_receipts: DistributedWorkReceiptV1[];
+  children: RecursiveWorkcellChildV1[];
+  completed_child_count: number;
+  coordination_state: RecursiveWorkcellCoordinationState;
+  counterevidence: RecursiveWorkcellCounterevidenceV1[];
+  created_at: string;
+  observations: RecursiveWorkcellObservationV1[];
+  parent_packet: DistributedWorkPacketV1;
+  progress: RecursiveWorkcellProgressV1[];
+  resumes: RecursiveWorkcellResumeV1[];
+  revision: number;
+  schema_version: typeof RECURSIVE_WORKCELL_RECONCILIATION_SCHEMA_VERSION;
+  state: RecursiveWorkcellAggregateState;
+  unresolved_child_count: number;
+  updated_at: string;
+}
+
+export interface RecursiveWorkcellAdmissionDraft {
+  admitted_at: string;
+  child_packets: DistributedWorkPacketV1[];
+  parent_ancestor_packet_ids: string[];
+  parent_packet: DistributedWorkPacketV1;
+}
+
+export interface RecursiveWorkcellTerminalDraft {
+  counterevidence: RecursiveWorkcellCounterevidenceDraft[];
+  receipt: DistributedWorkReceiptV1;
+}

--- a/apps/slack-companion/src/distributed/workcells/contracts.ts
+++ b/apps/slack-companion/src/distributed/workcells/contracts.ts
@@ -126,6 +126,7 @@ export interface RecursiveWorkcellReconciliationV1 {
 export interface RecursiveWorkcellAdmissionDraft {
   admitted_at: string;
   child_packets: DistributedWorkPacketV1[];
+  /** Claimed lineage; admission verifies it against the durable parent binding. */
   parent_ancestor_packet_ids: string[];
   parent_packet: DistributedWorkPacketV1;
 }

--- a/apps/slack-companion/src/distributed/workcells/coordinator.ts
+++ b/apps/slack-companion/src/distributed/workcells/coordinator.ts
@@ -58,16 +58,58 @@ export class RecursiveWorkcellInvariantError extends Error {
 export class RecursiveWorkcellCoordinator {
   constructor(private readonly store: DurableRecursiveWorkcellPort) {}
 
-  admit(
+  async admit(
     draft: RecursiveWorkcellAdmissionDraft,
     lease: WorkLeaseV1,
   ): Promise<RecursiveWorkcellCommitResult> {
-    const reconciliation = createRecursiveWorkcellReconciliation(draft);
+    const parentBinding = await this.store.readChildBinding(
+      draft.parent_packet.packet_id,
+    );
+    if (
+      parentBinding === undefined &&
+      PACKET_ID.test(draft.parent_packet.parent_subject_ref)
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell durable parent binding does not exist",
+      );
+    }
+    if (
+      parentBinding !== undefined &&
+      stableStringify(parentBinding.child_packet) !==
+        stableStringify(draft.parent_packet)
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell durable parent identity changed",
+      );
+    }
+    const durableAncestors = parentBinding?.ancestor_packet_ids ?? [];
+    if (!sameStringArray(draft.parent_ancestor_packet_ids, durableAncestors)) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell ancestry does not match the durable parent binding",
+      );
+    }
+    const reconciliation = createRecursiveWorkcellReconciliation({
+      ...draft,
+      parent_ancestor_packet_ids: durableAncestors,
+    });
     validateLeaseForParent(reconciliation.parent_packet, lease, draft.admitted_at);
     return this.store.admitChildren({
       children: reconciliation.children,
       lease,
       reconciliation,
+    });
+  }
+
+  async claimActiveLease(
+    parentPacketId: string,
+    lease: WorkLeaseV1,
+    expectedRevision: number,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    requirePattern(parentPacketId, PACKET_ID, "parent_packet_id");
+    return this.store.claimActiveLease({
+      expected_revision: expectedRevision,
+      lease,
+      parent_packet_id: parentPacketId,
     });
   }
 
@@ -578,7 +620,7 @@ export function validateLeaseForParent(
       "recursive workcell lease does not own the parent run",
     );
   }
-  if (Date.parse(observedAt) > Date.parse(lease.lease_expires_at)) {
+  if (Date.parse(observedAt) >= Date.parse(lease.lease_expires_at)) {
     throw new RecursiveWorkcellInvariantError(
       "recursive workcell lease is expired",
     );
@@ -903,4 +945,11 @@ function stableStringify(value: unknown): string {
       .join(",")}}`;
   }
   return JSON.stringify(value) ?? "null";
+}
+
+function sameStringArray(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
 }

--- a/apps/slack-companion/src/distributed/workcells/coordinator.ts
+++ b/apps/slack-companion/src/distributed/workcells/coordinator.ts
@@ -1,0 +1,906 @@
+import { createHash } from "node:crypto";
+import type {
+  CheckpointV1,
+  RecursiveWorkcellAdmissionDraft,
+  RecursiveWorkcellChildV1,
+  RecursiveWorkcellCounterevidenceDraft,
+  RecursiveWorkcellCounterevidenceV1,
+  RecursiveWorkcellProgressDraft,
+  RecursiveWorkcellProgressV1,
+  RecursiveWorkcellReconciliationV1,
+  RecursiveWorkcellResumeV1,
+  RecursiveWorkcellTerminalDraft,
+  WorkLeaseV1,
+} from "./contracts.js";
+import {
+  MAX_RECURSIVE_WORKCELL_CHILDREN,
+  MAX_RECURSIVE_WORKCELL_COUNTEREVIDENCE,
+  MAX_RECURSIVE_WORKCELL_DEPTH,
+  MAX_RECURSIVE_WORKCELL_OBSERVATIONS,
+  RECURSIVE_WORKCELL_CHILD_SCHEMA_VERSION,
+  RECURSIVE_WORKCELL_COUNTEREVIDENCE_SCHEMA_VERSION,
+  RECURSIVE_WORKCELL_PROGRESS_SCHEMA_VERSION,
+  RECURSIVE_WORKCELL_RECONCILIATION_SCHEMA_VERSION,
+  RECURSIVE_WORKCELL_RESUME_SCHEMA_VERSION,
+} from "./contracts.js";
+import type {
+  DurableRecursiveWorkcellPort,
+  RecursiveWorkcellCommitResult,
+} from "./ports.js";
+import type {
+  DistributedWorkPacketV1,
+  RuntimeToolObservationV1,
+} from "../contracts.js";
+import {
+  runtimeToolObservationIdentity,
+  validateDistributedWorkPacket,
+  validateDistributedWorkReceipt,
+} from "../validation.js";
+
+const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/;
+const PACKET_ID = /^distributed-work-packet:\/\/sha256\/[a-f0-9]{64}$/;
+const WORKCELL_ID = /^recursive-workcell:\/\/sha256\/[a-f0-9]{64}$/;
+const PROGRESS_ID = /^recursive-workcell-progress:\/\/sha256\/[a-f0-9]{64}$/;
+const COUNTEREVIDENCE_ID =
+  /^recursive-workcell-counterevidence:\/\/sha256\/[a-f0-9]{64}$/;
+const RESUME_ID = /^recursive-workcell-resume:\/\/sha256\/[a-f0-9]{64}$/;
+const OPAQUE_REFERENCE = /^[a-z][a-z0-9+.-]*:\/\/\S+$/;
+const MAX_ID_LENGTH = 256;
+const MAX_REF_LENGTH = 1_024;
+
+export class RecursiveWorkcellInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RecursiveWorkcellInvariantError";
+  }
+}
+
+export class RecursiveWorkcellCoordinator {
+  constructor(private readonly store: DurableRecursiveWorkcellPort) {}
+
+  admit(
+    draft: RecursiveWorkcellAdmissionDraft,
+    lease: WorkLeaseV1,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const reconciliation = createRecursiveWorkcellReconciliation(draft);
+    validateLeaseForParent(reconciliation.parent_packet, lease, draft.admitted_at);
+    return this.store.admitChildren({
+      children: reconciliation.children,
+      lease,
+      reconciliation,
+    });
+  }
+
+  async recordProgress(
+    parentPacketId: string,
+    childPacketId: string,
+    draft: RecursiveWorkcellProgressDraft,
+    lease: WorkLeaseV1,
+    expectedRevision: number,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const reconciliation = await this.requireReconciliation(parentPacketId);
+    const child = requireChild(reconciliation, childPacketId);
+    const progress = createRecursiveWorkcellProgress(child, draft);
+    return this.store.appendProgress({
+      expected_revision: expectedRevision,
+      lease,
+      progress,
+    });
+  }
+
+  checkpoint(
+    checkpoint: CheckpointV1,
+    lease: WorkLeaseV1,
+    expectedRevision: number,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    return this.store.checkpoint({
+      checkpoint,
+      expected_revision: expectedRevision,
+      lease,
+    });
+  }
+
+  resume(
+    parentPacketId: string,
+    checkpointId: string,
+    lease: WorkLeaseV1,
+    recordedAt: string,
+    expectedRevision: number,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const resume = createRecursiveWorkcellResume(
+      parentPacketId,
+      checkpointId,
+      lease,
+      recordedAt,
+    );
+    return this.store.resume({
+      expected_revision: expectedRevision,
+      lease,
+      resume,
+    });
+  }
+
+  async reconcileTerminal(
+    parentPacketId: string,
+    childPacketId: string,
+    draft: RecursiveWorkcellTerminalDraft,
+    lease: WorkLeaseV1,
+    expectedRevision: number,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const reconciliation = await this.requireReconciliation(parentPacketId);
+    const child = requireChild(reconciliation, childPacketId);
+    validateDistributedWorkReceipt(child.child_packet, draft.receipt);
+    const counterevidence = draft.counterevidence.map((item) =>
+      createRecursiveWorkcellCounterevidence(childPacketId, item),
+    );
+    validateCounterevidenceSet(counterevidence);
+    return this.store.reconcileReceipt({
+      counterevidence,
+      expected_revision: expectedRevision,
+      lease,
+      receipt: structuredClone(draft.receipt),
+    });
+  }
+
+  private async requireReconciliation(
+    parentPacketId: string,
+  ): Promise<RecursiveWorkcellReconciliationV1> {
+    requirePattern(parentPacketId, PACKET_ID, "parent_packet_id");
+    const reconciliation = await this.store.readReconciliation(parentPacketId);
+    if (reconciliation === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell reconciliation does not exist",
+      );
+    }
+    return reconciliation;
+  }
+}
+
+export function recursiveWorkcellIdentity(
+  parentPacketId: string,
+  childPacketId: string,
+  childSequence: number,
+): string {
+  requirePattern(parentPacketId, PACKET_ID, "parent_packet_id");
+  requirePattern(childPacketId, PACKET_ID, "child_packet_id");
+  requireBoundedPositiveInteger(
+    childSequence,
+    MAX_RECURSIVE_WORKCELL_CHILDREN,
+    "child_sequence",
+  );
+  return `recursive-workcell://sha256/${hashHex(
+    stableStringify([parentPacketId, childPacketId, childSequence]),
+  )}`;
+}
+
+export function recursiveWorkcellProgressIdentity(
+  workcellId: string,
+  idempotencyKey: string,
+): string {
+  requirePattern(workcellId, WORKCELL_ID, "workcell_id");
+  requireId(idempotencyKey, "idempotency_key");
+  return `recursive-workcell-progress://sha256/${hashHex(
+    stableStringify([workcellId, idempotencyKey]),
+  )}`;
+}
+
+export function recursiveWorkcellCounterevidenceIdentity(
+  childPacketId: string,
+  draft: RecursiveWorkcellCounterevidenceDraft,
+): string {
+  requirePattern(childPacketId, PACKET_ID, "child_packet_id");
+  validateCounterevidenceDraft(draft);
+  return `recursive-workcell-counterevidence://sha256/${hashHex(
+    stableStringify([
+      childPacketId,
+      draft.claim_ref,
+      draft.evidence_ref,
+      draft.evidence_digest,
+    ]),
+  )}`;
+}
+
+export function recursiveWorkcellResumeIdentity(
+  parentPacketId: string,
+  checkpointId: string,
+  lease: WorkLeaseV1,
+): string {
+  requirePattern(parentPacketId, PACKET_ID, "parent_packet_id");
+  requireId(checkpointId, "checkpoint_id");
+  validateLeaseShape(lease);
+  return `recursive-workcell-resume://sha256/${hashHex(
+    stableStringify([
+      parentPacketId,
+      checkpointId,
+      lease.generation,
+      lease.fencing_token,
+      lease.lease_token,
+    ]),
+  )}`;
+}
+
+export function createRecursiveWorkcellChild(
+  parentPacket: DistributedWorkPacketV1,
+  parentAncestorPacketIds: string[],
+  childPacket: DistributedWorkPacketV1,
+  childSequence: number,
+  createdAt: string,
+): RecursiveWorkcellChildV1 {
+  validateDistributedWorkPacket(parentPacket);
+  validateDistributedWorkPacket(childPacket);
+  requireTimestamp(createdAt, "created_at");
+  validateAncestorPacketIds(parentAncestorPacketIds, parentPacket.packet_id);
+  requireBoundedPositiveInteger(
+    childSequence,
+    MAX_RECURSIVE_WORKCELL_CHILDREN,
+    "child_sequence",
+  );
+  const ancestorPacketIds = [
+    ...parentAncestorPacketIds,
+    parentPacket.packet_id,
+  ];
+  if (ancestorPacketIds.includes(childPacket.packet_id)) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell lineage contains a cycle",
+    );
+  }
+  if (ancestorPacketIds.length > MAX_RECURSIVE_WORKCELL_DEPTH) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell depth exceeds the contract bound",
+    );
+  }
+  if (
+    childPacket.parent_run_id !== parentPacket.child_run.run_id ||
+    childPacket.parent_subject_ref !== parentPacket.packet_id ||
+    childPacket.tenant_id !== parentPacket.tenant_id ||
+    childPacket.thread_ref !== parentPacket.thread_ref ||
+    childPacket.retention_policy_ref !== parentPacket.retention_policy_ref
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive child packet is not bound to its exact parent",
+    );
+  }
+
+  const child: RecursiveWorkcellChildV1 = {
+    ancestor_packet_ids: ancestorPacketIds,
+    child_packet: structuredClone(childPacket),
+    child_sequence: childSequence,
+    created_at: createdAt,
+    depth: ancestorPacketIds.length,
+    parent_packet_id: parentPacket.packet_id,
+    schema_version: RECURSIVE_WORKCELL_CHILD_SCHEMA_VERSION,
+    workcell_id: recursiveWorkcellIdentity(
+      parentPacket.packet_id,
+      childPacket.packet_id,
+      childSequence,
+    ),
+  };
+  validateRecursiveWorkcellChild(parentPacket, child);
+  return child;
+}
+
+export function validateRecursiveWorkcellChild(
+  parentPacket: DistributedWorkPacketV1,
+  child: RecursiveWorkcellChildV1,
+): void {
+  validateDistributedWorkPacket(parentPacket);
+  validateDistributedWorkPacket(child.child_packet);
+  if (child.schema_version !== RECURSIVE_WORKCELL_CHILD_SCHEMA_VERSION) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell child schema version is unsupported",
+    );
+  }
+  requirePattern(child.workcell_id, WORKCELL_ID, "workcell_id");
+  requireTimestamp(child.created_at, "created_at");
+  validateAncestorPacketIds(
+    child.ancestor_packet_ids.slice(0, -1),
+    parentPacket.packet_id,
+  );
+  const expectedAncestors = [
+    ...child.ancestor_packet_ids.slice(0, -1),
+    parentPacket.packet_id,
+  ];
+  if (
+    child.parent_packet_id !== parentPacket.packet_id ||
+    child.depth !== child.ancestor_packet_ids.length ||
+    child.depth < 1 ||
+    child.depth > MAX_RECURSIVE_WORKCELL_DEPTH ||
+    stableStringify(child.ancestor_packet_ids) !==
+      stableStringify(expectedAncestors) ||
+    child.ancestor_packet_ids.includes(child.child_packet.packet_id) ||
+    child.workcell_id !==
+      recursiveWorkcellIdentity(
+        parentPacket.packet_id,
+        child.child_packet.packet_id,
+        child.child_sequence,
+      )
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell child lineage or identity is invalid",
+    );
+  }
+  if (
+    child.child_packet.parent_run_id !== parentPacket.child_run.run_id ||
+    child.child_packet.parent_subject_ref !== parentPacket.packet_id ||
+    child.child_packet.tenant_id !== parentPacket.tenant_id ||
+    child.child_packet.thread_ref !== parentPacket.thread_ref ||
+    child.child_packet.retention_policy_ref !==
+      parentPacket.retention_policy_ref
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive child packet is not bound to its exact parent",
+    );
+  }
+}
+
+export function createRecursiveWorkcellProgress(
+  child: RecursiveWorkcellChildV1,
+  draft: RecursiveWorkcellProgressDraft,
+): RecursiveWorkcellProgressV1 {
+  validateRecursiveWorkcellChildBinding(child);
+  requireId(draft.idempotency_key, "idempotency_key");
+  requirePositiveInteger(draft.sequence, "sequence");
+  requireTimestamp(draft.recorded_at, "recorded_at");
+  validateProgressPhase(draft.phase, draft.checkpoint_ref);
+  validateRuntimeObservationBatch(child.child_packet, draft.runtime_observations);
+  if (draft.counterevidence.length > MAX_RECURSIVE_WORKCELL_COUNTEREVIDENCE) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell counterevidence exceeds the contract bound",
+    );
+  }
+  const counterevidence = draft.counterevidence.map((item) =>
+    createRecursiveWorkcellCounterevidence(
+      child.child_packet.packet_id,
+      item,
+    ),
+  );
+  validateCounterevidenceSet(counterevidence);
+  const progress: RecursiveWorkcellProgressV1 = {
+    ...structuredClone(draft),
+    child_packet_id: child.child_packet.packet_id,
+    counterevidence,
+    progress_id: recursiveWorkcellProgressIdentity(
+      child.workcell_id,
+      draft.idempotency_key,
+    ),
+    schema_version: RECURSIVE_WORKCELL_PROGRESS_SCHEMA_VERSION,
+    workcell_id: child.workcell_id,
+  };
+  validateRecursiveWorkcellProgress(child, progress);
+  return progress;
+}
+
+export function validateRecursiveWorkcellProgress(
+  child: RecursiveWorkcellChildV1,
+  progress: RecursiveWorkcellProgressV1,
+): void {
+  validateRecursiveWorkcellChildBinding(child);
+  if (progress.schema_version !== RECURSIVE_WORKCELL_PROGRESS_SCHEMA_VERSION) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell progress schema version is unsupported",
+    );
+  }
+  requirePattern(progress.progress_id, PROGRESS_ID, "progress_id");
+  requireId(progress.idempotency_key, "idempotency_key");
+  requirePositiveInteger(progress.sequence, "sequence");
+  requireTimestamp(progress.recorded_at, "recorded_at");
+  validateProgressPhase(progress.phase, progress.checkpoint_ref);
+  validateRuntimeObservationBatch(
+    child.child_packet,
+    progress.runtime_observations,
+  );
+  validateCounterevidenceSet(progress.counterevidence);
+  if (
+    progress.workcell_id !== child.workcell_id ||
+    progress.child_packet_id !== child.child_packet.packet_id ||
+    progress.progress_id !==
+      recursiveWorkcellProgressIdentity(
+        child.workcell_id,
+        progress.idempotency_key,
+      )
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell progress identity does not match its child",
+    );
+  }
+}
+
+export function createRecursiveWorkcellCounterevidence(
+  childPacketId: string,
+  draft: RecursiveWorkcellCounterevidenceDraft,
+): RecursiveWorkcellCounterevidenceV1 {
+  return {
+    ...structuredClone(draft),
+    child_packet_id: childPacketId,
+    counterevidence_id: recursiveWorkcellCounterevidenceIdentity(
+      childPacketId,
+      draft,
+    ),
+    schema_version: RECURSIVE_WORKCELL_COUNTEREVIDENCE_SCHEMA_VERSION,
+  };
+}
+
+export function createRecursiveWorkcellResume(
+  parentPacketId: string,
+  checkpointId: string,
+  lease: WorkLeaseV1,
+  recordedAt: string,
+): RecursiveWorkcellResumeV1 {
+  requireTimestamp(recordedAt, "recorded_at");
+  return {
+    checkpoint_id: checkpointId,
+    fencing_token: lease.fencing_token,
+    generation: lease.generation,
+    lease_token: lease.lease_token,
+    recorded_at: recordedAt,
+    resume_id: recursiveWorkcellResumeIdentity(
+      parentPacketId,
+      checkpointId,
+      lease,
+    ),
+    schema_version: RECURSIVE_WORKCELL_RESUME_SCHEMA_VERSION,
+  };
+}
+
+export function validateRecursiveWorkcellResume(
+  parentPacketId: string,
+  lease: WorkLeaseV1,
+  resume: RecursiveWorkcellResumeV1,
+): void {
+  if (resume.schema_version !== RECURSIVE_WORKCELL_RESUME_SCHEMA_VERSION) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell resume schema version is unsupported",
+    );
+  }
+  requirePattern(resume.resume_id, RESUME_ID, "resume_id");
+  requireId(resume.checkpoint_id, "checkpoint_id");
+  requireTimestamp(resume.recorded_at, "recorded_at");
+  if (
+    resume.generation !== lease.generation ||
+    resume.fencing_token !== lease.fencing_token ||
+    resume.lease_token !== lease.lease_token ||
+    resume.resume_id !==
+      recursiveWorkcellResumeIdentity(
+        parentPacketId,
+        resume.checkpoint_id,
+        lease,
+      )
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell resume does not match its lease proof",
+    );
+  }
+}
+
+export function createRecursiveWorkcellReconciliation(
+  draft: RecursiveWorkcellAdmissionDraft,
+): RecursiveWorkcellReconciliationV1 {
+  validateDistributedWorkPacket(draft.parent_packet);
+  requireTimestamp(draft.admitted_at, "admitted_at");
+  validateAncestorPacketIds(
+    draft.parent_ancestor_packet_ids,
+    draft.parent_packet.packet_id,
+  );
+  if (
+    draft.child_packets.length < 1 ||
+    draft.child_packets.length > MAX_RECURSIVE_WORKCELL_CHILDREN
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell children exceed the contract bound",
+    );
+  }
+  const children = draft.child_packets.map((packet, index) =>
+    createRecursiveWorkcellChild(
+      draft.parent_packet,
+      draft.parent_ancestor_packet_ids,
+      packet,
+      index + 1,
+      draft.admitted_at,
+    ),
+  );
+  if (
+    new Set(children.map((child) => child.child_packet.packet_id)).size !==
+      children.length ||
+    new Set(children.map((child) => child.child_packet.child_run.run_id)).size !==
+      children.length
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell children must have unique packet and run identities",
+    );
+  }
+  return {
+    blocked_child_count: 0,
+    checkpoints: [],
+    child_receipts: [],
+    children,
+    completed_child_count: 0,
+    coordination_state: "active",
+    counterevidence: [],
+    created_at: draft.admitted_at,
+    observations: [],
+    parent_packet: structuredClone(draft.parent_packet),
+    progress: [],
+    resumes: [],
+    revision: 1,
+    schema_version: RECURSIVE_WORKCELL_RECONCILIATION_SCHEMA_VERSION,
+    state: "active",
+    unresolved_child_count: children.length,
+    updated_at: draft.admitted_at,
+  };
+}
+
+export function deriveRecursiveWorkcellState(
+  childCount: number,
+  receipts: RecursiveWorkcellReconciliationV1["child_receipts"],
+): Pick<
+  RecursiveWorkcellReconciliationV1,
+  | "blocked_child_count"
+  | "completed_child_count"
+  | "state"
+  | "unresolved_child_count"
+> {
+  if (childCount < 1 || receipts.length > childCount) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell receipt count is inconsistent with its children",
+    );
+  }
+  const completed = receipts.filter(
+    (receipt) => receipt.status === "completed",
+  ).length;
+  const blocked = receipts.filter((receipt) => receipt.status === "blocked").length;
+  const unresolved = childCount - receipts.length;
+  const state =
+    unresolved === 0
+      ? blocked > 0
+        ? "blocked"
+        : "completed"
+      : receipts.length > 0
+        ? "partially_completed"
+        : "active";
+  return {
+    blocked_child_count: blocked,
+    completed_child_count: completed,
+    state,
+    unresolved_child_count: unresolved,
+  };
+}
+
+export function validateLeaseForParent(
+  parentPacket: DistributedWorkPacketV1,
+  lease: WorkLeaseV1,
+  observedAt: string,
+): void {
+  validateDistributedWorkPacket(parentPacket);
+  validateLeaseShape(lease);
+  requireTimestamp(observedAt, "observed_at");
+  if (lease.run_id !== parentPacket.child_run.run_id) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell lease does not own the parent run",
+    );
+  }
+  if (Date.parse(observedAt) > Date.parse(lease.lease_expires_at)) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell lease is expired",
+    );
+  }
+}
+
+function validateRecursiveWorkcellChildBinding(
+  child: RecursiveWorkcellChildV1,
+): void {
+  if (
+    child.schema_version !== RECURSIVE_WORKCELL_CHILD_SCHEMA_VERSION ||
+    child.parent_packet_id !== child.ancestor_packet_ids.at(-1) ||
+    child.ancestor_packet_ids.includes(child.child_packet.packet_id) ||
+    child.depth !== child.ancestor_packet_ids.length ||
+    child.depth < 1 ||
+    child.depth > MAX_RECURSIVE_WORKCELL_DEPTH ||
+    child.workcell_id !==
+      recursiveWorkcellIdentity(
+        child.parent_packet_id,
+        child.child_packet.packet_id,
+        child.child_sequence,
+      )
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell child binding is invalid",
+    );
+  }
+  validateDistributedWorkPacket(child.child_packet);
+}
+
+function requireChild(
+  reconciliation: RecursiveWorkcellReconciliationV1,
+  childPacketId: string,
+): RecursiveWorkcellChildV1 {
+  requirePattern(childPacketId, PACKET_ID, "child_packet_id");
+  const child = reconciliation.children.find(
+    (candidate) => candidate.child_packet.packet_id === childPacketId,
+  );
+  if (child === undefined) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell child does not belong to the parent",
+    );
+  }
+  return child;
+}
+
+function validateAncestorPacketIds(
+  ancestorPacketIds: string[],
+  parentPacketId: string,
+): void {
+  if (ancestorPacketIds.length >= MAX_RECURSIVE_WORKCELL_DEPTH) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell parent depth leaves no room for a child",
+    );
+  }
+  const identities = new Set<string>();
+  for (const packetId of ancestorPacketIds) {
+    requirePattern(packetId, PACKET_ID, "ancestor_packet_id");
+    if (identities.has(packetId) || packetId === parentPacketId) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell lineage contains a cycle",
+      );
+    }
+    identities.add(packetId);
+  }
+}
+
+function validateCounterevidenceSet(
+  items: RecursiveWorkcellCounterevidenceV1[],
+): void {
+  if (items.length > MAX_RECURSIVE_WORKCELL_COUNTEREVIDENCE) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell counterevidence exceeds the contract bound",
+    );
+  }
+  const ids = new Set<string>();
+  for (const item of items) {
+    if (
+      item.schema_version !== RECURSIVE_WORKCELL_COUNTEREVIDENCE_SCHEMA_VERSION
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell counterevidence schema version is unsupported",
+      );
+    }
+    requirePattern(
+      item.counterevidence_id,
+      COUNTEREVIDENCE_ID,
+      "counterevidence_id",
+    );
+    validateCounterevidenceDraft(item);
+    if (
+      item.counterevidence_id !==
+      recursiveWorkcellCounterevidenceIdentity(item.child_packet_id, item) ||
+      ids.has(item.counterevidence_id)
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell counterevidence identity repeats or changed",
+      );
+    }
+    ids.add(item.counterevidence_id);
+  }
+}
+
+function validateCounterevidenceDraft(
+  draft: RecursiveWorkcellCounterevidenceDraft,
+): void {
+  requireOpaqueRef(draft.claim_ref, "claim_ref");
+  requireOpaqueRef(draft.evidence_ref, "evidence_ref");
+  requirePattern(draft.evidence_digest, SHA256_DIGEST, "evidence_digest");
+  requireTimestamp(draft.observed_at, "observed_at");
+}
+
+function validateProgressPhase(
+  phase: RecursiveWorkcellProgressDraft["phase"],
+  checkpointRef: string | undefined,
+): void {
+  if (phase === "checkpointed") {
+    requireOpaqueRef(checkpointRef, "checkpoint_ref");
+    return;
+  }
+  if (phase !== "running") {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell progress phase is unsupported",
+    );
+  }
+  if (checkpointRef !== undefined) {
+    throw new RecursiveWorkcellInvariantError(
+      "running recursive workcell progress cannot carry a checkpoint",
+    );
+  }
+}
+
+function validateRuntimeObservationBatch(
+  packet: DistributedWorkPacketV1,
+  observations: RuntimeToolObservationV1[],
+): void {
+  if (observations.length > MAX_RECURSIVE_WORKCELL_OBSERVATIONS) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell observations exceed the contract bound",
+    );
+  }
+  const capabilities = new Set(
+    packet.required_capabilities.map(
+      (capability) => `${capability.capability_id}\u0000${capability.version}`,
+    ),
+  );
+  let lastSequence = 0;
+  const identities = new Set<string>();
+  for (const observation of observations) {
+    if (
+      observation.schema_version !== "distributed-work-observation/v1" ||
+      observation.sequence <= lastSequence ||
+      !Number.isSafeInteger(observation.sequence)
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell observations must preserve increasing runtime order",
+      );
+    }
+    requirePositiveInteger(observation.attempt, "observation.attempt");
+    requireId(observation.capability_id, "observation.capability_id");
+    requireId(observation.capability_version, "observation.capability_version");
+    requireOpaqueRef(observation.tool_ref, "observation.tool_ref");
+    requireTimestamp(observation.started_at, "observation.started_at");
+    requireTimestamp(observation.completed_at, "observation.completed_at");
+    if (
+      Date.parse(observation.completed_at) < Date.parse(observation.started_at) ||
+      !capabilities.has(
+        `${observation.capability_id}\u0000${observation.capability_version}`,
+      ) ||
+      observation.observation_id !==
+        runtimeToolObservationIdentity(
+          packet.packet_id,
+          observation.tool_ref,
+          observation.attempt,
+        ) ||
+      identities.has(observation.observation_id)
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell observation is not valid for its child packet",
+      );
+    }
+    validateObservationOutcome(observation);
+    identities.add(observation.observation_id);
+    lastSequence = observation.sequence;
+  }
+}
+
+function validateObservationOutcome(observation: RuntimeToolObservationV1): void {
+  if (observation.status === "completed") {
+    requireOpaqueRef(observation.result_ref, "observation.result_ref");
+    requirePattern(
+      observation.result_digest,
+      SHA256_DIGEST,
+      "observation.result_digest",
+    );
+    if (
+      observation.failure_ref !== undefined ||
+      observation.failure_digest !== undefined
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "completed observations cannot carry a failure result",
+      );
+    }
+    return;
+  }
+  if (observation.status !== "failed") {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell observation status is unsupported",
+    );
+  }
+  requireOpaqueRef(observation.failure_ref, "observation.failure_ref");
+  requirePattern(
+    observation.failure_digest,
+    SHA256_DIGEST,
+    "observation.failure_digest",
+  );
+  if (
+    observation.result_ref !== undefined ||
+    observation.result_digest !== undefined
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "failed observations cannot carry a successful result",
+    );
+  }
+}
+
+function validateLeaseShape(lease: WorkLeaseV1): void {
+  if (lease.schema_version !== "work-lease/v1") {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell lease schema version is unsupported",
+    );
+  }
+  requireId(lease.run_id, "lease.run_id");
+  requireId(lease.owner_id, "lease.owner_id");
+  requireId(lease.lease_token, "lease.lease_token");
+  requirePositiveInteger(lease.generation, "lease.generation");
+  requirePositiveInteger(lease.fencing_token, "lease.fencing_token");
+  requireTimestamp(lease.heartbeat_at, "lease.heartbeat_at");
+  requireTimestamp(lease.lease_expires_at, "lease.lease_expires_at");
+}
+
+function requireBoundedPositiveInteger(
+  value: number,
+  maximum: number,
+  label: string,
+): void {
+  requirePositiveInteger(value, label);
+  if (value > maximum) {
+    throw new RecursiveWorkcellInvariantError(
+      `${label} exceeds the contract bound`,
+    );
+  }
+}
+
+function requirePositiveInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RecursiveWorkcellInvariantError(
+      `${label} must be a positive integer`,
+    );
+  }
+}
+
+function requireId(
+  value: string | undefined,
+  label: string,
+): asserts value is string {
+  if (
+    value === undefined ||
+    value.trim() === "" ||
+    Buffer.byteLength(value, "utf8") > MAX_ID_LENGTH
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      `${label} must be a bounded identifier`,
+    );
+  }
+}
+
+function requireOpaqueRef(
+  value: string | undefined,
+  label: string,
+): asserts value is string {
+  if (
+    value === undefined ||
+    Buffer.byteLength(value, "utf8") > MAX_REF_LENGTH ||
+    !OPAQUE_REFERENCE.test(value)
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      `${label} must be a bounded opaque reference`,
+    );
+  }
+}
+
+function requirePattern(
+  value: string | undefined,
+  pattern: RegExp,
+  label: string,
+): asserts value is string {
+  if (value === undefined || !pattern.test(value)) {
+    throw new RecursiveWorkcellInvariantError(`${label} has an invalid format`);
+  }
+}
+
+function requireTimestamp(value: string, label: string): void {
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new RecursiveWorkcellInvariantError(`${label} must be a timestamp`);
+  }
+}
+
+function hashHex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}

--- a/apps/slack-companion/src/distributed/workcells/ports.ts
+++ b/apps/slack-companion/src/distributed/workcells/ports.ts
@@ -21,6 +21,12 @@ export interface RecursiveWorkcellProgressCommit {
   progress: RecursiveWorkcellProgressV1;
 }
 
+export interface RecursiveWorkcellActiveLeaseClaimCommit {
+  expected_revision: number;
+  lease: WorkLeaseV1;
+  parent_packet_id: string;
+}
+
 export interface RecursiveWorkcellCheckpointCommit {
   checkpoint: CheckpointV1;
   expected_revision: number;
@@ -58,6 +64,20 @@ export interface DurableRecursiveWorkcellPort {
   readReconciliation(
     parentPacketId: string,
   ): Promise<RecursiveWorkcellReconciliationV1 | undefined>;
+
+  /** Returns the durable binding when this packet was admitted as a child. */
+  readChildBinding(
+    childPacketId: string,
+  ): Promise<RecursiveWorkcellChildV1 | undefined>;
+
+  /**
+   * Atomically renews the active authority or recovers expired active work
+   * under a strictly newer generation and fence. Checkpointed work must use
+   * resume instead.
+   */
+  claimActiveLease(
+    commit: RecursiveWorkcellActiveLeaseClaimCommit,
+  ): Promise<RecursiveWorkcellCommitResult>;
 
   /** Appends one idempotent progress fact under the exact active fence. */
   appendProgress(

--- a/apps/slack-companion/src/distributed/workcells/ports.ts
+++ b/apps/slack-companion/src/distributed/workcells/ports.ts
@@ -1,0 +1,84 @@
+import type {
+  CheckpointV1,
+  RecursiveWorkcellChildV1,
+  RecursiveWorkcellCounterevidenceV1,
+  RecursiveWorkcellProgressV1,
+  RecursiveWorkcellReconciliationV1,
+  RecursiveWorkcellResumeV1,
+  WorkLeaseV1,
+} from "./contracts.js";
+import type { DistributedWorkReceiptV1 } from "../contracts.js";
+
+export interface RecursiveWorkcellAdmissionCommit {
+  children: RecursiveWorkcellChildV1[];
+  lease: WorkLeaseV1;
+  reconciliation: RecursiveWorkcellReconciliationV1;
+}
+
+export interface RecursiveWorkcellProgressCommit {
+  expected_revision: number;
+  lease: WorkLeaseV1;
+  progress: RecursiveWorkcellProgressV1;
+}
+
+export interface RecursiveWorkcellCheckpointCommit {
+  checkpoint: CheckpointV1;
+  expected_revision: number;
+  lease: WorkLeaseV1;
+}
+
+export interface RecursiveWorkcellResumeCommit {
+  expected_revision: number;
+  lease: WorkLeaseV1;
+  resume: RecursiveWorkcellResumeV1;
+}
+
+export interface RecursiveWorkcellReceiptCommit {
+  counterevidence: RecursiveWorkcellCounterevidenceV1[];
+  expected_revision: number;
+  lease: WorkLeaseV1;
+  receipt: DistributedWorkReceiptV1;
+}
+
+export interface RecursiveWorkcellCommitResult {
+  created: boolean;
+  reconciliation: RecursiveWorkcellReconciliationV1;
+}
+
+/**
+ * Durable topology-neutral workcell boundary. Production adapters must make
+ * every method atomic with the active lease record and exact revision check.
+ */
+export interface DurableRecursiveWorkcellPort {
+  /** Atomically persists the whole child set before any child is dispatched. */
+  admitChildren(
+    commit: RecursiveWorkcellAdmissionCommit,
+  ): Promise<RecursiveWorkcellCommitResult>;
+
+  readReconciliation(
+    parentPacketId: string,
+  ): Promise<RecursiveWorkcellReconciliationV1 | undefined>;
+
+  /** Appends one idempotent progress fact under the exact active fence. */
+  appendProgress(
+    commit: RecursiveWorkcellProgressCommit,
+  ): Promise<RecursiveWorkcellCommitResult>;
+
+  /** Persists a parent checkpoint before ownership can move. */
+  checkpoint(
+    commit: RecursiveWorkcellCheckpointCommit,
+  ): Promise<RecursiveWorkcellCommitResult>;
+
+  /** Resumes the exact checkpoint under a newer non-stale fence. */
+  resume(
+    commit: RecursiveWorkcellResumeCommit,
+  ): Promise<RecursiveWorkcellCommitResult>;
+
+  /**
+   * Commits one terminal child receipt and recomputes parent truth without
+   * discarding prior progress, observations, failures, or counterevidence.
+   */
+  reconcileReceipt(
+    commit: RecursiveWorkcellReceiptCommit,
+  ): Promise<RecursiveWorkcellCommitResult>;
+}

--- a/apps/slack-companion/src/distributed/workcells/reference-store.ts
+++ b/apps/slack-companion/src/distributed/workcells/reference-store.ts
@@ -21,6 +21,7 @@ import {
 import type {
   DurableRecursiveWorkcellPort,
   RecursiveWorkcellAdmissionCommit,
+  RecursiveWorkcellActiveLeaseClaimCommit,
   RecursiveWorkcellCheckpointCommit,
   RecursiveWorkcellCommitResult,
   RecursiveWorkcellProgressCommit,
@@ -33,6 +34,7 @@ import {
 } from "../validation.js";
 
 const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/;
+const PACKET_ID = /^distributed-work-packet:\/\/sha256\/[a-f0-9]{64}$/;
 const OPAQUE_REFERENCE = /^[a-z][a-z0-9+.-]*:\/\/\S+$/;
 const MAX_ID_LENGTH = 256;
 const MAX_REF_LENGTH = 1_024;
@@ -42,6 +44,10 @@ export class ReferenceMemoryRecursiveWorkcellStore
   implements DurableRecursiveWorkcellPort
 {
   private readonly activeLeaseByParent = new Map<string, WorkLeaseV1>();
+  private readonly childByPacket = new Map<
+    string,
+    RecursiveWorkcellReconciliationV1["children"][number]
+  >();
   private readonly parentByRun = new Map<string, string>();
   private readonly parentByWorkcell = new Map<string, string>();
   private readonly records = new Map<
@@ -55,6 +61,7 @@ export class ReferenceMemoryRecursiveWorkcellStore
     const incoming = commit.reconciliation;
     validateAdmission(commit);
     const parentPacketId = incoming.parent_packet.packet_id;
+    this.validateDurableParentLineage(incoming);
     const current = this.records.get(parentPacketId);
     if (current !== undefined) {
       if (
@@ -68,12 +75,25 @@ export class ReferenceMemoryRecursiveWorkcellStore
       return Promise.resolve(result(false, current));
     }
 
+    for (const child of incoming.children) {
+      const priorBinding = this.childByPacket.get(child.child_packet.packet_id);
+      if (priorBinding !== undefined && !sameValue(priorBinding, child)) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell child already has a different durable binding",
+        );
+      }
+    }
+
     const stored = structuredClone(incoming);
     this.records.set(parentPacketId, stored);
     this.activeLeaseByParent.set(parentPacketId, structuredClone(commit.lease));
     this.parentByRun.set(incoming.parent_packet.child_run.run_id, parentPacketId);
     for (const child of incoming.children) {
       this.parentByWorkcell.set(child.workcell_id, parentPacketId);
+      this.childByPacket.set(
+        child.child_packet.packet_id,
+        structuredClone(child),
+      );
     }
     return Promise.resolve(result(true, stored));
   }
@@ -87,6 +107,70 @@ export class ReferenceMemoryRecursiveWorkcellStore
         ? undefined
         : structuredClone(reconciliation),
     );
+  }
+
+  readChildBinding(
+    childPacketId: string,
+  ): Promise<RecursiveWorkcellReconciliationV1["children"][number] | undefined> {
+    const child = this.childByPacket.get(childPacketId);
+    return Promise.resolve(
+      child === undefined ? undefined : structuredClone(child),
+    );
+  }
+
+  claimActiveLease(
+    commit: RecursiveWorkcellActiveLeaseClaimCommit,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const current = this.requireRecord(commit.parent_packet_id);
+    if (current.coordination_state !== "active") {
+      throw new RecursiveWorkcellInvariantError(
+        "checkpointed recursive workcell ownership must use resume",
+      );
+    }
+    validateLeaseForParent(
+      current.parent_packet,
+      commit.lease,
+      commit.lease.heartbeat_at,
+    );
+
+    const active = this.requireActiveLease(commit.parent_packet_id);
+    if (sameLease(active, commit.lease)) {
+      return Promise.resolve(result(false, current));
+    }
+    requireRevision(current, commit.expected_revision);
+
+    if (sameLeaseAuthority(active, commit.lease)) {
+      if (
+        Date.parse(active.lease_expires_at) <=
+          Date.parse(commit.lease.heartbeat_at) ||
+        Date.parse(commit.lease.heartbeat_at) <= Date.parse(active.heartbeat_at) ||
+        Date.parse(commit.lease.lease_expires_at) <=
+          Date.parse(active.lease_expires_at)
+      ) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell lease renewal must advance before expiration",
+        );
+      }
+    } else if (
+      Date.parse(active.lease_expires_at) >
+        Date.parse(commit.lease.heartbeat_at) ||
+      commit.lease.generation <= active.generation ||
+      commit.lease.fencing_token <= active.fencing_token ||
+      commit.lease.lease_token === active.lease_token
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell recovery requires an expired lease and a newer generation and fence",
+      );
+    }
+
+    const next = structuredClone(current);
+    advance(next, commit.lease.heartbeat_at);
+    this.records.set(commit.parent_packet_id, next);
+    this.activeLeaseByParent.set(
+      commit.parent_packet_id,
+      structuredClone(commit.lease),
+    );
+    return Promise.resolve(result(true, next));
   }
 
   appendProgress(
@@ -391,6 +475,39 @@ export class ReferenceMemoryRecursiveWorkcellStore
     return lease;
   }
 
+  private validateDurableParentLineage(
+    reconciliation: RecursiveWorkcellReconciliationV1,
+  ): void {
+    const parentBinding = this.childByPacket.get(
+      reconciliation.parent_packet.packet_id,
+    );
+    if (
+      parentBinding === undefined &&
+      PACKET_ID.test(reconciliation.parent_packet.parent_subject_ref)
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell durable parent binding does not exist",
+      );
+    }
+    if (
+      parentBinding !== undefined &&
+      !sameValue(parentBinding.child_packet, reconciliation.parent_packet)
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell durable parent identity changed",
+      );
+    }
+    const durableAncestors = parentBinding?.ancestor_packet_ids ?? [];
+    for (const child of reconciliation.children) {
+      const suppliedAncestors = child.ancestor_packet_ids.slice(0, -1);
+      if (!sameValue(suppliedAncestors, durableAncestors)) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell ancestry does not match the durable parent binding",
+        );
+      }
+    }
+  }
+
   private requireRecord(
     parentPacketId: string,
   ): RecursiveWorkcellReconciliationV1 {
@@ -610,6 +727,16 @@ function sameLease(left: WorkLeaseV1, right: WorkLeaseV1): boolean {
     left.lease_token === right.lease_token &&
     left.heartbeat_at === right.heartbeat_at &&
     left.lease_expires_at === right.lease_expires_at
+  );
+}
+
+function sameLeaseAuthority(left: WorkLeaseV1, right: WorkLeaseV1): boolean {
+  return (
+    left.run_id === right.run_id &&
+    left.owner_id === right.owner_id &&
+    left.generation === right.generation &&
+    left.fencing_token === right.fencing_token &&
+    left.lease_token === right.lease_token
   );
 }
 

--- a/apps/slack-companion/src/distributed/workcells/reference-store.ts
+++ b/apps/slack-companion/src/distributed/workcells/reference-store.ts
@@ -1,0 +1,682 @@
+import {
+  deriveRecursiveWorkcellState,
+  RecursiveWorkcellInvariantError,
+  validateLeaseForParent,
+  validateRecursiveWorkcellChild,
+  validateRecursiveWorkcellProgress,
+  validateRecursiveWorkcellResume,
+} from "./coordinator.js";
+import type {
+  RecursiveWorkcellCounterevidenceV1,
+  RecursiveWorkcellObservationV1,
+  RecursiveWorkcellReconciliationV1,
+  WorkLeaseV1,
+} from "./contracts.js";
+import {
+  MAX_RECURSIVE_WORKCELL_CHECKPOINTS,
+  MAX_RECURSIVE_WORKCELL_COUNTEREVIDENCE,
+  MAX_RECURSIVE_WORKCELL_OBSERVATIONS,
+  MAX_RECURSIVE_WORKCELL_PROGRESS_RECORDS,
+} from "./contracts.js";
+import type {
+  DurableRecursiveWorkcellPort,
+  RecursiveWorkcellAdmissionCommit,
+  RecursiveWorkcellCheckpointCommit,
+  RecursiveWorkcellCommitResult,
+  RecursiveWorkcellProgressCommit,
+  RecursiveWorkcellReceiptCommit,
+  RecursiveWorkcellResumeCommit,
+} from "./ports.js";
+import {
+  validateDistributedWorkPacket,
+  validateDistributedWorkReceipt,
+} from "../validation.js";
+
+const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/;
+const OPAQUE_REFERENCE = /^[a-z][a-z0-9+.-]*:\/\/\S+$/;
+const MAX_ID_LENGTH = 256;
+const MAX_REF_LENGTH = 1_024;
+
+/** Conformance fixture only. Production adapters must use durable storage. */
+export class ReferenceMemoryRecursiveWorkcellStore
+  implements DurableRecursiveWorkcellPort
+{
+  private readonly activeLeaseByParent = new Map<string, WorkLeaseV1>();
+  private readonly parentByRun = new Map<string, string>();
+  private readonly parentByWorkcell = new Map<string, string>();
+  private readonly records = new Map<
+    string,
+    RecursiveWorkcellReconciliationV1
+  >();
+
+  admitChildren(
+    commit: RecursiveWorkcellAdmissionCommit,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const incoming = commit.reconciliation;
+    validateAdmission(commit);
+    const parentPacketId = incoming.parent_packet.packet_id;
+    const current = this.records.get(parentPacketId);
+    if (current !== undefined) {
+      if (
+        !sameValue(current.parent_packet, incoming.parent_packet) ||
+        !sameValue(current.children, incoming.children)
+      ) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell admission conflicts with durable parent intent",
+        );
+      }
+      return Promise.resolve(result(false, current));
+    }
+
+    const stored = structuredClone(incoming);
+    this.records.set(parentPacketId, stored);
+    this.activeLeaseByParent.set(parentPacketId, structuredClone(commit.lease));
+    this.parentByRun.set(incoming.parent_packet.child_run.run_id, parentPacketId);
+    for (const child of incoming.children) {
+      this.parentByWorkcell.set(child.workcell_id, parentPacketId);
+    }
+    return Promise.resolve(result(true, stored));
+  }
+
+  readReconciliation(
+    parentPacketId: string,
+  ): Promise<RecursiveWorkcellReconciliationV1 | undefined> {
+    const reconciliation = this.records.get(parentPacketId);
+    return Promise.resolve(
+      reconciliation === undefined
+        ? undefined
+        : structuredClone(reconciliation),
+    );
+  }
+
+  appendProgress(
+    commit: RecursiveWorkcellProgressCommit,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const parentPacketId = this.parentByWorkcell.get(commit.progress.workcell_id);
+    if (parentPacketId === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell progress has no admitted parent",
+      );
+    }
+    const current = this.requireRecord(parentPacketId);
+    const child = current.children.find(
+      (candidate) => candidate.workcell_id === commit.progress.workcell_id,
+    );
+    if (child === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell progress has no admitted child",
+      );
+    }
+    validateRecursiveWorkcellProgress(child, commit.progress);
+
+    const prior = current.progress.find(
+      (progress) => progress.progress_id === commit.progress.progress_id,
+    );
+    if (prior !== undefined) {
+      if (!sameValue(prior, commit.progress)) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell progress idempotency key changed intent",
+        );
+      }
+      this.assertLeaseProof(parentPacketId, commit.lease, commit.progress.recorded_at);
+      return Promise.resolve(result(false, current));
+    }
+
+    this.assertMutable(
+      parentPacketId,
+      current,
+      commit.lease,
+      commit.expected_revision,
+      commit.progress.recorded_at,
+    );
+    if (
+      current.child_receipts.some(
+        (receipt) => receipt.packet_id === commit.progress.child_packet_id,
+      )
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "terminal recursive workcell child cannot append progress",
+      );
+    }
+    const childProgress = current.progress.filter(
+      (progress) => progress.child_packet_id === commit.progress.child_packet_id,
+    );
+    if (commit.progress.sequence !== childProgress.length + 1) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell progress sequence is not contiguous",
+      );
+    }
+    if (current.progress.length >= MAX_RECURSIVE_WORKCELL_PROGRESS_RECORDS) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell progress exceeds the contract bound",
+      );
+    }
+
+    const next = structuredClone(current);
+    next.progress.push(structuredClone(commit.progress));
+    mergeObservations(
+      next,
+      commit.progress.child_packet_id,
+      commit.progress.runtime_observations,
+    );
+    mergeCounterevidence(next, commit.progress.counterevidence);
+    advance(next, commit.progress.recorded_at);
+    this.records.set(parentPacketId, next);
+    return Promise.resolve(result(true, next));
+  }
+
+  checkpoint(
+    commit: RecursiveWorkcellCheckpointCommit,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const parentPacketId = this.parentByRun.get(commit.lease.run_id);
+    if (parentPacketId === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell checkpoint has no admitted parent",
+      );
+    }
+    const current = this.requireRecord(parentPacketId);
+    const prior = current.checkpoints.find(
+      (checkpoint) => checkpoint.checkpoint_id === commit.checkpoint.checkpoint_id,
+    );
+    if (prior !== undefined) {
+      if (!sameValue(prior, commit.checkpoint)) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell checkpoint identity changed intent",
+        );
+      }
+      this.assertLeaseProof(
+        parentPacketId,
+        commit.lease,
+        commit.checkpoint.created_at,
+      );
+      return Promise.resolve(result(false, current));
+    }
+
+    this.assertMutable(
+      parentPacketId,
+      current,
+      commit.lease,
+      commit.expected_revision,
+      commit.checkpoint.created_at,
+    );
+    validateCheckpoint(current, commit.checkpoint, commit.lease);
+    if (current.checkpoints.length >= MAX_RECURSIVE_WORKCELL_CHECKPOINTS) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell checkpoints exceed the contract bound",
+      );
+    }
+    const next = structuredClone(current);
+    next.checkpoints.push(structuredClone(commit.checkpoint));
+    next.coordination_state = "checkpointed";
+    advance(next, commit.checkpoint.created_at);
+    this.records.set(parentPacketId, next);
+    return Promise.resolve(result(true, next));
+  }
+
+  resume(
+    commit: RecursiveWorkcellResumeCommit,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const parentPacketId = this.parentByRun.get(commit.lease.run_id);
+    if (parentPacketId === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell resume has no admitted parent",
+      );
+    }
+    const current = this.requireRecord(parentPacketId);
+    validateRecursiveWorkcellResume(parentPacketId, commit.lease, commit.resume);
+    const prior = current.resumes.find(
+      (resume) => resume.resume_id === commit.resume.resume_id,
+    );
+    if (prior !== undefined) {
+      if (!sameValue(prior, commit.resume)) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell resume identity changed intent",
+        );
+      }
+      const active = this.requireActiveLease(parentPacketId);
+      if (!sameLease(active, commit.lease)) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell resume retry does not own the active fence",
+        );
+      }
+      return Promise.resolve(result(false, current));
+    }
+    requireRevision(current, commit.expected_revision);
+    if (current.coordination_state !== "checkpointed") {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell must be checkpointed before resume",
+      );
+    }
+    const checkpoint = current.checkpoints.at(-1);
+    if (
+      checkpoint === undefined ||
+      checkpoint.checkpoint_id !== commit.resume.checkpoint_id
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell resume does not reference the latest checkpoint",
+      );
+    }
+    const oldLease = this.requireActiveLease(parentPacketId);
+    validateLeaseForParent(
+      current.parent_packet,
+      commit.lease,
+      commit.resume.recorded_at,
+    );
+    if (
+      commit.lease.generation < oldLease.generation ||
+      commit.lease.fencing_token <= oldLease.fencing_token ||
+      commit.lease.lease_token === oldLease.lease_token ||
+      checkpoint.generation !== oldLease.generation ||
+      Date.parse(commit.lease.heartbeat_at) < Date.parse(checkpoint.created_at)
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell resume requires a newer generation-compatible fence",
+      );
+    }
+
+    const next = structuredClone(current);
+    next.resumes.push(structuredClone(commit.resume));
+    next.coordination_state = "active";
+    advance(next, commit.resume.recorded_at);
+    this.records.set(parentPacketId, next);
+    this.activeLeaseByParent.set(parentPacketId, structuredClone(commit.lease));
+    return Promise.resolve(result(true, next));
+  }
+
+  reconcileReceipt(
+    commit: RecursiveWorkcellReceiptCommit,
+  ): Promise<RecursiveWorkcellCommitResult> {
+    const parentPacketId = this.parentByRun.get(commit.lease.run_id);
+    if (parentPacketId === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell receipt has no admitted parent",
+      );
+    }
+    const current = this.requireRecord(parentPacketId);
+    const child = current.children.find(
+      (candidate) =>
+        candidate.child_packet.packet_id === commit.receipt.packet_id,
+    );
+    if (child === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell receipt does not belong to the parent",
+      );
+    }
+    validateDistributedWorkReceipt(child.child_packet, commit.receipt);
+    const prior = current.child_receipts.find(
+      (receipt) => receipt.packet_id === commit.receipt.packet_id,
+    );
+    if (prior !== undefined) {
+      if (
+        !sameValue(prior, commit.receipt) ||
+        !counterevidenceAlreadyStored(current, commit.counterevidence)
+      ) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell terminal receipt changed durable truth",
+        );
+      }
+      this.assertLeaseProof(
+        parentPacketId,
+        commit.lease,
+        commit.receipt.recorded_at,
+      );
+      return Promise.resolve(result(false, current));
+    }
+
+    this.assertMutable(
+      parentPacketId,
+      current,
+      commit.lease,
+      commit.expected_revision,
+      commit.receipt.recorded_at,
+    );
+    const next = structuredClone(current);
+    next.child_receipts.push(structuredClone(commit.receipt));
+    next.child_receipts.sort(
+      (left, right) =>
+        childSequence(next, left.packet_id) - childSequence(next, right.packet_id),
+    );
+    mergeObservations(
+      next,
+      commit.receipt.packet_id,
+      commit.receipt.runtime_observations,
+    );
+    mergeCounterevidence(next, commit.counterevidence);
+    Object.assign(
+      next,
+      deriveRecursiveWorkcellState(next.children.length, next.child_receipts),
+    );
+    advance(next, commit.receipt.recorded_at);
+    this.records.set(parentPacketId, next);
+    return Promise.resolve(result(true, next));
+  }
+
+  private assertMutable(
+    parentPacketId: string,
+    current: RecursiveWorkcellReconciliationV1,
+    lease: WorkLeaseV1,
+    expectedRevision: number,
+    observedAt: string,
+  ): void {
+    requireRevision(current, expectedRevision);
+    if (current.coordination_state !== "active") {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell is checkpointed and must resume before mutation",
+      );
+    }
+    this.assertLeaseProof(parentPacketId, lease, observedAt);
+  }
+
+  private assertLeaseProof(
+    parentPacketId: string,
+    lease: WorkLeaseV1,
+    observedAt: string,
+  ): void {
+    const current = this.requireRecord(parentPacketId);
+    validateLeaseForParent(current.parent_packet, lease, observedAt);
+    if (!sameLease(this.requireActiveLease(parentPacketId), lease)) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell lease generation or fence is stale",
+      );
+    }
+  }
+
+  private requireActiveLease(parentPacketId: string): WorkLeaseV1 {
+    const lease = this.activeLeaseByParent.get(parentPacketId);
+    if (lease === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell has no active lease",
+      );
+    }
+    return lease;
+  }
+
+  private requireRecord(
+    parentPacketId: string,
+  ): RecursiveWorkcellReconciliationV1 {
+    const reconciliation = this.records.get(parentPacketId);
+    if (reconciliation === undefined) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell reconciliation does not exist",
+      );
+    }
+    return reconciliation;
+  }
+}
+
+function validateAdmission(commit: RecursiveWorkcellAdmissionCommit): void {
+  const reconciliation = commit.reconciliation;
+  if (
+    reconciliation.schema_version !== "recursive-workcell-reconciliation/v1" ||
+    reconciliation.revision !== 1 ||
+    reconciliation.state !== "active" ||
+    reconciliation.coordination_state !== "active" ||
+    reconciliation.child_receipts.length !== 0 ||
+    reconciliation.progress.length !== 0 ||
+    reconciliation.checkpoints.length !== 0 ||
+    reconciliation.resumes.length !== 0 ||
+    reconciliation.observations.length !== 0 ||
+    reconciliation.counterevidence.length !== 0 ||
+    reconciliation.unresolved_child_count !== reconciliation.children.length ||
+    reconciliation.completed_child_count !== 0 ||
+    reconciliation.blocked_child_count !== 0 ||
+    !sameValue(commit.children, reconciliation.children)
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell admission is not an initial reconciliation",
+    );
+  }
+  validateDistributedWorkPacket(reconciliation.parent_packet);
+  validateLeaseForParent(
+    reconciliation.parent_packet,
+    commit.lease,
+    reconciliation.created_at,
+  );
+  for (const child of reconciliation.children) {
+    validateRecursiveWorkcellChild(reconciliation.parent_packet, child);
+  }
+}
+
+function validateCheckpoint(
+  reconciliation: RecursiveWorkcellReconciliationV1,
+  checkpoint: RecursiveWorkcellReconciliationV1["checkpoints"][number],
+  lease: WorkLeaseV1,
+): void {
+  if (
+    checkpoint.schema_version !== "checkpoint/v1" ||
+    checkpoint.run_id !== reconciliation.parent_packet.child_run.run_id ||
+    checkpoint.generation !== lease.generation ||
+    checkpoint.sequence !== reconciliation.checkpoints.length + 1 ||
+    checkpoint.run_revision < reconciliation.parent_packet.child_run.revision
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell checkpoint does not match parent execution",
+    );
+  }
+  requireId(checkpoint.checkpoint_id, "checkpoint_id");
+  requireTimestamp(checkpoint.created_at, "checkpoint.created_at");
+  requireOpaqueRef(checkpoint.payload_ref, "checkpoint.payload_ref");
+  requirePattern(checkpoint.payload_digest, SHA256_DIGEST, "checkpoint.payload_digest");
+  requireId(checkpoint.resume_cursor, "checkpoint.resume_cursor");
+  for (const stepId of checkpoint.completed_step_ids) {
+    requireId(stepId, "checkpoint.completed_step_id");
+  }
+  for (const receiptId of checkpoint.effect_receipt_ids) {
+    requireId(receiptId, "checkpoint.effect_receipt_id");
+  }
+  if (checkpoint.waiting_on_ref !== undefined) {
+    requireOpaqueRef(checkpoint.waiting_on_ref, "checkpoint.waiting_on_ref");
+  }
+}
+
+function mergeObservations(
+  reconciliation: RecursiveWorkcellReconciliationV1,
+  childPacketId: string,
+  observations: RecursiveWorkcellReconciliationV1["child_receipts"][number]["runtime_observations"],
+): void {
+  for (const observation of observations) {
+    const prior = reconciliation.observations.find(
+      (candidate) =>
+        candidate.child_packet_id === childPacketId &&
+        candidate.observation.observation_id === observation.observation_id,
+    );
+    if (prior !== undefined) {
+      if (!sameValue(prior.observation, observation)) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell observation identity changed durable truth",
+        );
+      }
+      continue;
+    }
+    const childObservationCount = reconciliation.observations.filter(
+      (candidate) => candidate.child_packet_id === childPacketId,
+    ).length;
+    if (observation.sequence !== childObservationCount + 1) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell observations cannot skip runtime order",
+      );
+    }
+    if (reconciliation.observations.length >= MAX_RECURSIVE_WORKCELL_OBSERVATIONS) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell observations exceed the contract bound",
+      );
+    }
+    const wrapped: RecursiveWorkcellObservationV1 = {
+      child_packet_id: childPacketId,
+      observation: structuredClone(observation),
+    };
+    reconciliation.observations.push(wrapped);
+  }
+}
+
+function mergeCounterevidence(
+  reconciliation: RecursiveWorkcellReconciliationV1,
+  items: RecursiveWorkcellCounterevidenceV1[],
+): void {
+  for (const item of items) {
+    const childExists = reconciliation.children.some(
+      (child) => child.child_packet.packet_id === item.child_packet_id,
+    );
+    if (!childExists) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell counterevidence does not belong to a child",
+      );
+    }
+    const prior = reconciliation.counterevidence.find(
+      (candidate) => candidate.counterevidence_id === item.counterevidence_id,
+    );
+    if (prior !== undefined) {
+      if (!sameValue(prior, item)) {
+        throw new RecursiveWorkcellInvariantError(
+          "recursive workcell counterevidence changed durable truth",
+        );
+      }
+      continue;
+    }
+    if (
+      reconciliation.counterevidence.length >=
+      MAX_RECURSIVE_WORKCELL_COUNTEREVIDENCE
+    ) {
+      throw new RecursiveWorkcellInvariantError(
+        "recursive workcell counterevidence exceeds the contract bound",
+      );
+    }
+    reconciliation.counterevidence.push(structuredClone(item));
+  }
+}
+
+function counterevidenceAlreadyStored(
+  reconciliation: RecursiveWorkcellReconciliationV1,
+  items: RecursiveWorkcellCounterevidenceV1[],
+): boolean {
+  return items.every((item) =>
+    reconciliation.counterevidence.some(
+      (candidate) =>
+        candidate.counterevidence_id === item.counterevidence_id &&
+        sameValue(candidate, item),
+    ),
+  );
+}
+
+function childSequence(
+  reconciliation: RecursiveWorkcellReconciliationV1,
+  packetId: string,
+): number {
+  const child = reconciliation.children.find(
+    (candidate) => candidate.child_packet.packet_id === packetId,
+  );
+  if (child === undefined) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell child sequence does not exist",
+    );
+  }
+  return child.child_sequence;
+}
+
+function advance(
+  reconciliation: RecursiveWorkcellReconciliationV1,
+  updatedAt: string,
+): void {
+  if (Date.parse(updatedAt) < Date.parse(reconciliation.updated_at)) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell time cannot move backwards",
+    );
+  }
+  reconciliation.revision += 1;
+  reconciliation.updated_at = updatedAt;
+}
+
+function requireRevision(
+  reconciliation: RecursiveWorkcellReconciliationV1,
+  expectedRevision: number,
+): void {
+  if (
+    !Number.isSafeInteger(expectedRevision) ||
+    expectedRevision <= 0 ||
+    reconciliation.revision !== expectedRevision
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      "recursive workcell revision is stale",
+    );
+  }
+}
+
+function sameLease(left: WorkLeaseV1, right: WorkLeaseV1): boolean {
+  return (
+    left.run_id === right.run_id &&
+    left.owner_id === right.owner_id &&
+    left.generation === right.generation &&
+    left.fencing_token === right.fencing_token &&
+    left.lease_token === right.lease_token &&
+    left.heartbeat_at === right.heartbeat_at &&
+    left.lease_expires_at === right.lease_expires_at
+  );
+}
+
+function result(
+  created: boolean,
+  reconciliation: RecursiveWorkcellReconciliationV1,
+): RecursiveWorkcellCommitResult {
+  return { created, reconciliation: structuredClone(reconciliation) };
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function requireId(value: string | undefined, label: string): asserts value is string {
+  if (
+    value === undefined ||
+    value.trim() === "" ||
+    Buffer.byteLength(value, "utf8") > MAX_ID_LENGTH
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      `${label} must be a bounded identifier`,
+    );
+  }
+}
+
+function requireOpaqueRef(
+  value: string | undefined,
+  label: string,
+): asserts value is string {
+  if (
+    value === undefined ||
+    Buffer.byteLength(value, "utf8") > MAX_REF_LENGTH ||
+    !OPAQUE_REFERENCE.test(value)
+  ) {
+    throw new RecursiveWorkcellInvariantError(
+      `${label} must be a bounded opaque reference`,
+    );
+  }
+}
+
+function requirePattern(
+  value: string | undefined,
+  pattern: RegExp,
+  label: string,
+): asserts value is string {
+  if (value === undefined || !pattern.test(value)) {
+    throw new RecursiveWorkcellInvariantError(`${label} has an invalid format`);
+  }
+}
+
+function requireTimestamp(value: string, label: string): void {
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new RecursiveWorkcellInvariantError(`${label} must be a timestamp`);
+  }
+}

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -6,6 +6,10 @@ export * from "./delivery/ports.js";
 export * from "./distributed/contracts.js";
 export * from "./distributed/ports.js";
 export * from "./distributed/validation.js";
+export * from "./distributed/workcells/contracts.js";
+export * from "./distributed/workcells/coordinator.js";
+export * from "./distributed/workcells/ports.js";
+export * from "./distributed/workcells/reference-store.js";
 export {
   ExecutionCoordinator,
   ExecutionInvariantError,

--- a/apps/slack-companion/test/recursive-workcells.test.ts
+++ b/apps/slack-companion/test/recursive-workcells.test.ts
@@ -25,9 +25,11 @@ import type {
 } from "../src/distributed/contracts.js";
 import {
   createRecursiveWorkcellChild,
+  createRecursiveWorkcellReconciliation,
   RecursiveWorkcellCoordinator,
   recursiveWorkcellIdentity,
 } from "../src/distributed/workcells/coordinator.js";
+import { MAX_RECURSIVE_WORKCELL_DEPTH } from "../src/distributed/workcells/contracts.js";
 import { ReferenceMemoryRecursiveWorkcellStore } from "../src/distributed/workcells/reference-store.js";
 
 const T0 = "2026-07-16T12:00:00.000Z";
@@ -72,6 +74,304 @@ describe("topology-neutral recursive workcells", () => {
         ),
       /leaves no room for a child/,
     );
+  });
+
+  test("treats the exact lease expiration instant as expired", async () => {
+    const parent = parentPacket();
+    const coordinator = new RecursiveWorkcellCoordinator(
+      new ReferenceMemoryRecursiveWorkcellStore(),
+    );
+    const lease = {
+      ...leaseFixture(parent.child_run.run_id, 1, 1, T0),
+      lease_expires_at: T0,
+    };
+
+    await assert.rejects(
+      coordinator.admit(
+        {
+          admitted_at: T0,
+          child_packets: [childPacket(parent, 1)],
+          parent_ancestor_packet_ids: [],
+          parent_packet: parent,
+        },
+        lease,
+      ),
+      /lease is expired/,
+    );
+  });
+
+  test("derives lineage from durable bindings and rejects truncated depth", async () => {
+    const store = new ReferenceMemoryRecursiveWorkcellStore();
+    const coordinator = new RecursiveWorkcellCoordinator(store);
+    let parent = parentPacket();
+    let ancestors: string[] = [];
+
+    for (let depth = 1; depth <= MAX_RECURSIVE_WORKCELL_DEPTH; depth += 1) {
+      const child = nestedChildPacket(parent, depth);
+      const admitted = await coordinator.admit(
+        {
+          admitted_at: T0,
+          child_packets: [child],
+          parent_ancestor_packet_ids: ancestors,
+          parent_packet: parent,
+        },
+        leaseFixture(parent.child_run.run_id, 1, 1, T0),
+      );
+      assert.equal(admitted.reconciliation.children[0]?.depth, depth);
+      ancestors = [...ancestors, parent.packet_id];
+      parent = child;
+    }
+
+    const overflow = nestedChildPacket(
+      parent,
+      MAX_RECURSIVE_WORKCELL_DEPTH + 1,
+    );
+    await assert.rejects(
+      coordinator.admit(
+        {
+          admitted_at: T0,
+          child_packets: [overflow],
+          parent_ancestor_packet_ids: [],
+          parent_packet: parent,
+        },
+        leaseFixture(parent.child_run.run_id, 1, 1, T0),
+      ),
+      /ancestry does not match the durable parent binding/,
+    );
+    const forged = createRecursiveWorkcellReconciliation({
+      admitted_at: T0,
+      child_packets: [overflow],
+      parent_ancestor_packet_ids: [],
+      parent_packet: parent,
+    });
+    await assert.rejects(
+      async () =>
+        store.admitChildren({
+          children: forged.children,
+          lease: leaseFixture(parent.child_run.run_id, 1, 1, T0),
+          reconciliation: forged,
+        }),
+      /ancestry does not match the durable parent binding/,
+    );
+    await assert.rejects(
+      coordinator.admit(
+        {
+          admitted_at: T0,
+          child_packets: [overflow],
+          parent_ancestor_packet_ids: ancestors,
+          parent_packet: parent,
+        },
+        leaseFixture(parent.child_run.run_id, 1, 1, T0),
+      ),
+      /leaves no room for a child/,
+    );
+
+    const changedParent = structuredClone(parent);
+    changedParent.child_run.run_id = "changed-durable-parent-run";
+    await assert.rejects(
+      coordinator.admit(
+        {
+          admitted_at: T0,
+          child_packets: [
+            nestedChildPacket(
+              changedParent,
+              MAX_RECURSIVE_WORKCELL_DEPTH + 2,
+            ),
+          ],
+          parent_ancestor_packet_ids: ancestors,
+          parent_packet: changedParent,
+        },
+        leaseFixture(changedParent.child_run.run_id, 1, 1, T0),
+      ),
+      /durable parent identity changed/,
+    );
+
+    const unboundParent = nestedChildPacket(parentPacket(), 100);
+    const unboundCoordinator = new RecursiveWorkcellCoordinator(
+      new ReferenceMemoryRecursiveWorkcellStore(),
+    );
+    await assert.rejects(
+      unboundCoordinator.admit(
+        {
+          admitted_at: T0,
+          child_packets: [nestedChildPacket(unboundParent, 101)],
+          parent_ancestor_packet_ids: [],
+          parent_packet: unboundParent,
+        },
+        leaseFixture(unboundParent.child_run.run_id, 1, 1, T0),
+      ),
+      /durable parent binding does not exist/,
+    );
+  });
+
+  test("renews active work atomically under the same authority", async () => {
+    const { children, coordinator, lease, parent } = await admittedFixture();
+    const renewed = {
+      ...lease,
+      heartbeat_at: T1,
+      lease_expires_at: "2026-07-16T14:00:00.000Z",
+    };
+
+    await assert.rejects(
+      coordinator.claimActiveLease(parent.packet_id, renewed, 2),
+      /revision is stale/,
+    );
+
+    const claimed = await coordinator.claimActiveLease(
+      parent.packet_id,
+      renewed,
+      1,
+    );
+    assert.equal(claimed.created, true);
+    assert.equal(claimed.reconciliation.revision, 2);
+
+    const retry = await coordinator.claimActiveLease(
+      parent.packet_id,
+      renewed,
+      1,
+    );
+    assert.equal(retry.created, false);
+    assert.equal(retry.reconciliation.revision, 2);
+
+    const progressed = await coordinator.recordProgress(
+      parent.packet_id,
+      children[0]!.packet_id,
+      {
+        counterevidence: [],
+        idempotency_key: "progress-after-renewal",
+        phase: "running",
+        recorded_at: T2,
+        runtime_observations: [],
+        sequence: 1,
+      },
+      renewed,
+      2,
+    );
+    assert.equal(progressed.reconciliation.revision, 3);
+  });
+
+  test("recovers active work only after expiration under a newer fence", async () => {
+    const parent = parentPacket();
+    const child = childPacket(parent, 1);
+    const coordinator = new RecursiveWorkcellCoordinator(
+      new ReferenceMemoryRecursiveWorkcellStore(),
+    );
+    const original = {
+      ...leaseFixture(parent.child_run.run_id, 1, 1, T0),
+      lease_expires_at: T1,
+    };
+    await coordinator.admit(
+      {
+        admitted_at: T0,
+        child_packets: [child],
+        parent_ancestor_packet_ids: [],
+        parent_packet: parent,
+      },
+      original,
+    );
+
+    await assert.rejects(
+      coordinator.claimActiveLease(
+        parent.packet_id,
+        {
+          ...leaseFixture(parent.child_run.run_id, 2, 2, T0),
+          lease_expires_at: T3,
+        },
+        1,
+      ),
+      /requires an expired lease and a newer generation and fence/,
+    );
+    await assert.rejects(
+      coordinator.claimActiveLease(
+        parent.packet_id,
+        {
+          ...original,
+          heartbeat_at: T1,
+          lease_expires_at: T3,
+        },
+        1,
+      ),
+      /lease renewal must advance before expiration/,
+    );
+    await assert.rejects(
+      coordinator.claimActiveLease(
+        parent.packet_id,
+        {
+          ...leaseFixture(parent.child_run.run_id, 2, 1, T1),
+          lease_expires_at: T3,
+        },
+        1,
+      ),
+      /requires an expired lease and a newer generation and fence/,
+    );
+    await assert.rejects(
+      coordinator.claimActiveLease(
+        parent.packet_id,
+        {
+          ...original,
+          heartbeat_at: "2026-07-16T12:00:30.000Z",
+          lease_expires_at: T3,
+          owner_id: "changed-owner",
+        },
+        1,
+      ),
+      /requires an expired lease and a newer generation and fence/,
+    );
+
+    const replacement = {
+      ...leaseFixture(parent.child_run.run_id, 2, 2, T1),
+      lease_expires_at: T3,
+    };
+    const recovered = await coordinator.claimActiveLease(
+      parent.packet_id,
+      replacement,
+      1,
+    );
+    assert.equal(recovered.created, true);
+    assert.equal(recovered.reconciliation.coordination_state, "active");
+    assert.equal(recovered.reconciliation.revision, 2);
+
+    const recoveryRetry = await coordinator.claimActiveLease(
+      parent.packet_id,
+      replacement,
+      1,
+    );
+    assert.equal(recoveryRetry.created, false);
+    assert.equal(recoveryRetry.reconciliation.revision, 2);
+
+    await assert.rejects(
+      coordinator.recordProgress(
+        parent.packet_id,
+        child.packet_id,
+        {
+          counterevidence: [],
+          idempotency_key: "progress-under-stale-owner",
+          phase: "running",
+          recorded_at: T0,
+          runtime_observations: [],
+          sequence: 1,
+        },
+        original,
+        2,
+      ),
+      /generation or fence is stale/,
+    );
+
+    const progressed = await coordinator.recordProgress(
+      parent.packet_id,
+      child.packet_id,
+      {
+        counterevidence: [],
+        idempotency_key: "progress-after-recovery",
+        phase: "running",
+        recorded_at: T2,
+        runtime_observations: [],
+        sequence: 1,
+      },
+      replacement,
+      2,
+    );
+    assert.equal(progressed.reconciliation.revision, 3);
   });
 
   test("admits the whole child set and keeps progress idempotent under one fence", async () => {
@@ -157,6 +457,15 @@ describe("topology-neutral recursive workcells", () => {
     const checkpointed = await coordinator.checkpoint(checkpoint, lease, 2);
     assert.equal(checkpointed.reconciliation.coordination_state, "checkpointed");
     assert.equal(checkpointed.reconciliation.revision, 3);
+
+    await assert.rejects(
+      coordinator.claimActiveLease(
+        parent.packet_id,
+        leaseFixture(parent.child_run.run_id, 2, 2, T3),
+        3,
+      ),
+      /checkpointed recursive workcell ownership must use resume/,
+    );
 
     await assert.rejects(
       coordinator.recordProgress(
@@ -331,6 +640,21 @@ function childPacket(
     parent_subject_ref: parent.packet_id,
   });
   return packetFixture(input, `child-run-${sequence}`);
+}
+
+function nestedChildPacket(
+  parent: DistributedWorkPacketV1,
+  depth: number,
+): DistributedWorkPacketV1 {
+  const input = identityInput({
+    causation_id: parent.child_run.run_id,
+    idempotency_key: `nested-child-packet-${depth}`,
+    objective_digest: digest(`nested-child-objective-${depth}`),
+    objective_ref: `work-objective://opaque/nested-child-${depth}`,
+    parent_run_id: parent.child_run.run_id,
+    parent_subject_ref: parent.packet_id,
+  });
+  return packetFixture(input, `nested-child-run-${depth}`);
 }
 
 function identityInput(

--- a/apps/slack-companion/test/recursive-workcells.test.ts
+++ b/apps/slack-companion/test/recursive-workcells.test.ts
@@ -1,0 +1,539 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { describe, test } from "node:test";
+import type {
+  CapabilityRequirement,
+  CheckpointV1,
+  RunReceiptV1,
+  WorkLeaseV1,
+} from "@writer/cerebro-sdk";
+import {
+  createDistributedWorkReceipt,
+  distributedWorkIntentDigest,
+  distributedWorkLeaseReference,
+  distributedWorkPacketIdentity,
+  runtimeToolObservationIdentity,
+} from "../src/distributed/validation.js";
+import {
+  DISTRIBUTED_WORK_OBSERVATION_SCHEMA_VERSION,
+  DISTRIBUTED_WORK_PACKET_SCHEMA_VERSION,
+} from "../src/distributed/contracts.js";
+import type {
+  DistributedWorkPacketIdentityInput,
+  DistributedWorkPacketV1,
+  RuntimeToolObservationV1,
+} from "../src/distributed/contracts.js";
+import {
+  createRecursiveWorkcellChild,
+  RecursiveWorkcellCoordinator,
+  recursiveWorkcellIdentity,
+} from "../src/distributed/workcells/coordinator.js";
+import { ReferenceMemoryRecursiveWorkcellStore } from "../src/distributed/workcells/reference-store.js";
+
+const T0 = "2026-07-16T12:00:00.000Z";
+const T1 = "2026-07-16T12:01:00.000Z";
+const T2 = "2026-07-16T12:02:00.000Z";
+const T3 = "2026-07-16T12:03:00.000Z";
+const T4 = "2026-07-16T12:04:00.000Z";
+const EXPIRES = "2026-07-16T13:00:00.000Z";
+
+describe("topology-neutral recursive workcells", () => {
+  test("derives deterministic child identity and rejects cycles and unbounded depth", () => {
+    const parent = parentPacket();
+    const child = childPacket(parent, 1);
+    const first = createRecursiveWorkcellChild(parent, [], child, 1, T0);
+    const second = createRecursiveWorkcellChild(parent, [], child, 1, T0);
+
+    assert.equal(first.workcell_id, second.workcell_id);
+    assert.equal(
+      first.workcell_id,
+      recursiveWorkcellIdentity(parent.packet_id, child.packet_id, 1),
+    );
+    assert.deepEqual(first.ancestor_packet_ids, [parent.packet_id]);
+    assert.throws(
+      () =>
+        createRecursiveWorkcellChild(
+          parent,
+          [parent.packet_id],
+          child,
+          1,
+          T0,
+        ),
+      /lineage contains a cycle/,
+    );
+    assert.throws(
+      () =>
+        createRecursiveWorkcellChild(
+          parent,
+          [opaquePacketId("a"), opaquePacketId("b"), opaquePacketId("c"), opaquePacketId("d")],
+          child,
+          1,
+          T0,
+        ),
+      /leaves no room for a child/,
+    );
+  });
+
+  test("admits the whole child set and keeps progress idempotent under one fence", async () => {
+    const { children, coordinator, lease, parent } = await admittedFixture();
+    const observation = completedObservation(children[0]!, 1);
+    const progress = {
+      counterevidence: [counterevidence("first")],
+      idempotency_key: "progress-1",
+      phase: "running" as const,
+      recorded_at: T1,
+      runtime_observations: [observation],
+      sequence: 1,
+    };
+
+    const committed = await coordinator.recordProgress(
+      parent.packet_id,
+      children[0]!.packet_id,
+      progress,
+      lease,
+      1,
+    );
+    assert.equal(committed.created, true);
+    assert.equal(committed.reconciliation.revision, 2);
+    assert.equal(committed.reconciliation.observations.length, 1);
+    assert.equal(committed.reconciliation.counterevidence.length, 1);
+
+    observation.result_ref = "result://mutated-after-commit";
+    const retry = await coordinator.recordProgress(
+      parent.packet_id,
+      children[0]!.packet_id,
+      {
+        ...progress,
+        runtime_observations: [completedObservation(children[0]!, 1)],
+      },
+      lease,
+      1,
+    );
+    assert.equal(retry.created, false);
+    assert.equal(retry.reconciliation.revision, 2);
+    assert.equal(
+      retry.reconciliation.observations[0]?.observation.result_ref,
+      "result://opaque/1",
+    );
+
+    await assert.rejects(
+      coordinator.recordProgress(
+        parent.packet_id,
+        children[0]!.packet_id,
+        {
+          counterevidence: [],
+          idempotency_key: "progress-stale",
+          phase: "running",
+          recorded_at: T2,
+          runtime_observations: [],
+          sequence: 2,
+        },
+        { ...lease, fencing_token: lease.fencing_token + 1 },
+        2,
+      ),
+      /generation or fence is stale/,
+    );
+  });
+
+  test("checkpoints durably and resumes only under a newer fence", async () => {
+    const { children, coordinator, lease, parent } = await admittedFixture();
+    await coordinator.recordProgress(
+      parent.packet_id,
+      children[0]!.packet_id,
+      {
+        checkpoint_ref: "checkpoint://child/1",
+        counterevidence: [],
+        idempotency_key: "checkpoint-progress-1",
+        phase: "checkpointed",
+        recorded_at: T1,
+        runtime_observations: [],
+        sequence: 1,
+      },
+      lease,
+      1,
+    );
+
+    const checkpoint = checkpointFixture(parent, lease);
+    const checkpointed = await coordinator.checkpoint(checkpoint, lease, 2);
+    assert.equal(checkpointed.reconciliation.coordination_state, "checkpointed");
+    assert.equal(checkpointed.reconciliation.revision, 3);
+
+    await assert.rejects(
+      coordinator.recordProgress(
+        parent.packet_id,
+        children[0]!.packet_id,
+        {
+          counterevidence: [],
+          idempotency_key: "progress-before-resume",
+          phase: "running",
+          recorded_at: T3,
+          runtime_observations: [],
+          sequence: 2,
+        },
+        lease,
+        3,
+      ),
+      /must resume before mutation/,
+    );
+    await assert.rejects(
+      async () =>
+        coordinator.resume(
+          parent.packet_id,
+          checkpoint.checkpoint_id,
+          {
+            ...lease,
+            heartbeat_at: T3,
+            lease_token: "lease-stale",
+            owner_id: "worker-stale",
+          },
+          T3,
+          3,
+        ),
+      /newer generation-compatible fence/,
+    );
+
+    const resumedLease = leaseFixture(parent.child_run.run_id, 2, 2, T3);
+    const resumed = await coordinator.resume(
+      parent.packet_id,
+      checkpoint.checkpoint_id,
+      resumedLease,
+      T3,
+      3,
+    );
+    assert.equal(resumed.reconciliation.coordination_state, "active");
+    assert.equal(resumed.reconciliation.revision, 4);
+    assert.equal(resumed.reconciliation.checkpoints.length, 1);
+    assert.equal(resumed.reconciliation.resumes.length, 1);
+
+    const retry = await coordinator.resume(
+      parent.packet_id,
+      checkpoint.checkpoint_id,
+      resumedLease,
+      T3,
+      3,
+    );
+    assert.equal(retry.created, false);
+    assert.equal(retry.reconciliation.revision, 4);
+  });
+
+  test("keeps parent truth and evidence under partial completion and child failure", async () => {
+    const { children, coordinator, lease, parent } = await admittedFixture();
+    const firstObservation = completedObservation(children[0]!, 1);
+    await coordinator.recordProgress(
+      parent.packet_id,
+      children[0]!.packet_id,
+      {
+        counterevidence: [counterevidence("conflict")],
+        idempotency_key: "progress-first",
+        phase: "running",
+        recorded_at: T1,
+        runtime_observations: [firstObservation],
+        sequence: 1,
+      },
+      lease,
+      1,
+    );
+
+    const firstReceipt = terminalReceipt(
+      children[0]!,
+      "completed",
+      [firstObservation],
+      T2,
+    );
+    const partial = await coordinator.reconcileTerminal(
+      parent.packet_id,
+      children[0]!.packet_id,
+      { counterevidence: [], receipt: firstReceipt },
+      lease,
+      2,
+    );
+    assert.equal(partial.reconciliation.state, "partially_completed");
+    assert.equal(partial.reconciliation.completed_child_count, 1);
+    assert.equal(partial.reconciliation.unresolved_child_count, 1);
+    assert.equal(partial.reconciliation.observations.length, 1);
+    assert.equal(partial.reconciliation.counterevidence.length, 1);
+
+    const firstRetry = await coordinator.reconcileTerminal(
+      parent.packet_id,
+      children[0]!.packet_id,
+      { counterevidence: [], receipt: firstReceipt },
+      lease,
+      2,
+    );
+    assert.equal(firstRetry.created, false);
+    assert.equal(firstRetry.reconciliation.revision, 3);
+
+    const failed = failedObservation(children[1]!, 1);
+    const blocked = await coordinator.reconcileTerminal(
+      parent.packet_id,
+      children[1]!.packet_id,
+      {
+        counterevidence: [counterevidence("second-conflict")],
+        receipt: terminalReceipt(children[1]!, "blocked", [failed], T4),
+      },
+      lease,
+      3,
+    );
+    assert.equal(blocked.reconciliation.state, "blocked");
+    assert.equal(blocked.reconciliation.completed_child_count, 1);
+    assert.equal(blocked.reconciliation.blocked_child_count, 1);
+    assert.equal(blocked.reconciliation.unresolved_child_count, 0);
+    assert.equal(blocked.reconciliation.child_receipts.length, 2);
+    assert.equal(blocked.reconciliation.observations.length, 2);
+    assert.equal(blocked.reconciliation.counterevidence.length, 2);
+    assert.equal(
+      blocked.reconciliation.observations[1]?.observation.failure_ref,
+      "failure://opaque/1",
+    );
+  });
+});
+
+async function admittedFixture() {
+  const parent = parentPacket();
+  const children = [childPacket(parent, 1), childPacket(parent, 2)];
+  const store = new ReferenceMemoryRecursiveWorkcellStore();
+  const coordinator = new RecursiveWorkcellCoordinator(store);
+  const lease = leaseFixture(parent.child_run.run_id, 1, 1, T0);
+  const admission = await coordinator.admit(
+    {
+      admitted_at: T0,
+      child_packets: children,
+      parent_ancestor_packet_ids: [],
+      parent_packet: parent,
+    },
+    lease,
+  );
+  assert.equal(admission.created, true);
+  assert.equal(admission.reconciliation.children.length, 2);
+  assert.equal(admission.reconciliation.unresolved_child_count, 2);
+  return { children, coordinator, lease, parent, store };
+}
+
+function parentPacket(): DistributedWorkPacketV1 {
+  const input = identityInput({
+    idempotency_key: "parent-packet",
+    parent_run_id: "root-run",
+    parent_subject_ref: "root-subject",
+  });
+  return packetFixture(input, "parent-coordinator-run");
+}
+
+function childPacket(
+  parent: DistributedWorkPacketV1,
+  sequence: number,
+): DistributedWorkPacketV1 {
+  const input = identityInput({
+    causation_id: parent.child_run.run_id,
+    idempotency_key: `child-packet-${sequence}`,
+    objective_digest: digest(`child-objective-${sequence}`),
+    objective_ref: `work-objective://opaque/child-${sequence}`,
+    parent_run_id: parent.child_run.run_id,
+    parent_subject_ref: parent.packet_id,
+  });
+  return packetFixture(input, `child-run-${sequence}`);
+}
+
+function identityInput(
+  overrides: Partial<DistributedWorkPacketIdentityInput>,
+): DistributedWorkPacketIdentityInput {
+  return {
+    causation_id: "root-causation",
+    child_run_kind: "triage",
+    correlation_id: "correlation-opaque",
+    deliverables: [
+      {
+        deliverable_id: "deliverable-1",
+        requirement_digest: digest("requirement"),
+        requirement_ref: "deliverable-requirement://opaque/1",
+        sequence: 1,
+      },
+    ],
+    idempotency_key: "packet-idempotency",
+    objective_digest: digest("objective"),
+    objective_ref: "work-objective://opaque/1",
+    parent_run_id: "parent-run",
+    parent_subject_ref: "parent-subject",
+    required_capabilities: capabilities(),
+    retention_policy_ref: "retention-policy://portable/1",
+    tenant_id: "tenant-opaque",
+    thread_ref: "thread-binding://opaque/1",
+    turn_ref: "turn-receipt://opaque/1",
+    ...overrides,
+  };
+}
+
+function packetFixture(
+  input: DistributedWorkPacketIdentityInput,
+  runId: string,
+): DistributedWorkPacketV1 {
+  const packetId = distributedWorkPacketIdentity(input);
+  const intentDigest = distributedWorkIntentDigest(input);
+  return {
+    ...structuredClone(input),
+    child_run: runReceipt(input, packetId, intentDigest, runId),
+    created_at: T0,
+    intent_digest: intentDigest,
+    packet_id: packetId,
+    schema_version: DISTRIBUTED_WORK_PACKET_SCHEMA_VERSION,
+  };
+}
+
+function runReceipt(
+  input: DistributedWorkPacketIdentityInput,
+  packetId: string,
+  intentDigest: string,
+  runId: string,
+): RunReceiptV1 {
+  return {
+    admitted_at: T0,
+    binding_id: `binding-${runId}`,
+    idempotency_key: input.idempotency_key,
+    input_digest: intentDigest,
+    receipt_id: `receipt-${runId}`,
+    received_at: T0,
+    required_capabilities: structuredClone(input.required_capabilities),
+    retention_policy_ref: input.retention_policy_ref,
+    revision: 2,
+    run_id: runId,
+    run_kind: input.child_run_kind,
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: packetId,
+    tenant_id: input.tenant_id,
+    updated_at: T0,
+  };
+}
+
+function terminalReceipt(
+  packet: DistributedWorkPacketV1,
+  status: "blocked" | "completed",
+  observations: RuntimeToolObservationV1[],
+  recordedAt: string,
+) {
+  const childLease = leaseFixture(packet.child_run.run_id, 1, 1, T1);
+  return createDistributedWorkReceipt({
+    checkpoint_refs: [],
+    lease_ref: distributedWorkLeaseReference(childLease),
+    outcome_digest: digest(`outcome-${packet.packet_id}-${status}`),
+    outcome_ref: `work-outcome://opaque/${status}`,
+    packet,
+    recorded_at: recordedAt,
+    runtime_observations: observations,
+    runtime_status: status,
+  });
+}
+
+function completedObservation(
+  packet: DistributedWorkPacketV1,
+  sequence: number,
+): RuntimeToolObservationV1 {
+  const toolRef = "capability-tool://knowledge-read/1";
+  return {
+    attempt: sequence,
+    capability_id: "knowledge.read",
+    capability_version: "v1",
+    completed_at: T1,
+    observation_id: runtimeToolObservationIdentity(
+      packet.packet_id,
+      toolRef,
+      sequence,
+    ),
+    result_digest: digest(`result-${sequence}`),
+    result_ref: `result://opaque/${sequence}`,
+    schema_version: DISTRIBUTED_WORK_OBSERVATION_SCHEMA_VERSION,
+    sequence,
+    started_at: T0,
+    status: "completed",
+    tool_ref: toolRef,
+  };
+}
+
+function failedObservation(
+  packet: DistributedWorkPacketV1,
+  sequence: number,
+): RuntimeToolObservationV1 {
+  const toolRef = "capability-tool://knowledge-read/1";
+  return {
+    attempt: sequence,
+    capability_id: "knowledge.read",
+    capability_version: "v1",
+    completed_at: T4,
+    failure_digest: digest(`failure-${sequence}`),
+    failure_ref: `failure://opaque/${sequence}`,
+    observation_id: runtimeToolObservationIdentity(
+      packet.packet_id,
+      toolRef,
+      sequence,
+    ),
+    schema_version: DISTRIBUTED_WORK_OBSERVATION_SCHEMA_VERSION,
+    sequence,
+    started_at: T3,
+    status: "failed",
+    tool_ref: toolRef,
+  };
+}
+
+function counterevidence(suffix: string) {
+  return {
+    claim_ref: `claim://opaque/${suffix}`,
+    evidence_digest: digest(`counterevidence-${suffix}`),
+    evidence_ref: `evidence://opaque/${suffix}`,
+    observed_at: T1,
+  };
+}
+
+function checkpointFixture(
+  parent: DistributedWorkPacketV1,
+  lease: WorkLeaseV1,
+): CheckpointV1 {
+  return {
+    checkpoint_id: "parent-checkpoint-1",
+    completed_step_ids: ["child-progress-1"],
+    created_at: T2,
+    effect_receipt_ids: [],
+    generation: lease.generation,
+    payload_digest: digest("parent-checkpoint"),
+    payload_ref: "checkpoint-payload://opaque/parent-1",
+    resume_cursor: "child-sequence-1",
+    run_id: parent.child_run.run_id,
+    run_revision: parent.child_run.revision,
+    schema_version: "checkpoint/v1",
+    sequence: 1,
+  };
+}
+
+function leaseFixture(
+  runId: string,
+  generation: number,
+  fencingToken: number,
+  heartbeatAt: string,
+): WorkLeaseV1 {
+  return {
+    fencing_token: fencingToken,
+    generation,
+    heartbeat_at: heartbeatAt,
+    lease_expires_at: EXPIRES,
+    lease_token: `lease-${generation}-${fencingToken}`,
+    owner_id: `worker-${generation}-${fencingToken}`,
+    run_id: runId,
+    schema_version: "work-lease/v1",
+  };
+}
+
+function capabilities(): CapabilityRequirement[] {
+  return [
+    {
+      capability_id: "knowledge.read",
+      level: "required",
+      version: "v1",
+    },
+  ];
+}
+
+function opaquePacketId(seed: string): string {
+  return `distributed-work-packet://sha256/${seed.repeat(64)}`;
+}
+
+function digest(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}


### PR DESCRIPTION
## Summary

- Add deterministic identities for recursive parent and child work packets, progress records, counterevidence, and resume records.
- Persist each bounded child set atomically before child dispatch can begin.
- Derive lineage from durable parent bindings and enforce cycle, depth, child-count, observation, checkpoint, and evidence bounds.
- Preserve checkpoint and resume continuity under a newer generation-compatible fence.
- Support exact-revision active lease renewal and post-expiration recovery under a strictly newer generation and fencing value.
- Reconcile progress and terminal receipts idempotently while retaining ordered observations, failures, and counterevidence in parent truth.

## Boundary

This change contains portable, topology-neutral contracts, coordination behavior, a reference conformance store, and focused tests. Concrete deployment adapters and environment-specific operational policy remain outside this package.

## Validation

- `npm run check --workspace @writer/cerebro-slack-companion`
- `node --test apps/slack-companion/dist/test/recursive-workcells.test.js`
- `make check-arch`
- `make check-structural`
- `make oss-audit`
- `./scripts/leak_check.sh range agent/slack-companion-distributed-contract...HEAD`
- `git diff --check agent/slack-companion-distributed-contract...HEAD`
