### PR TITLE
feat(slack): retain queued question work with bounded dispatch backoff

### DIFF
--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -38,6 +38,7 @@ export * from "./operations/status.js";
 export * from "./ports.js";
 export * from "./question-work/contracts.js";
 export * from "./question-work/coordinator.js";
+export * from "./question-work/dispatch-policy.js";
 export * from "./question-work/ports.js";
 export * from "./question-work/reference-store.js";
 export * from "./thread-binding.js";

--- a/apps/slack-companion/src/question-work/dispatch-policy.ts
+++ b/apps/slack-companion/src/question-work/dispatch-policy.ts
@@ -1,0 +1,115 @@
+export type QuestionWorkDispatchOutcome = "publication_failed" | "published";
+
+export interface QuestionWorkDispatchBackoffPolicyV1 {
+  initial_delay_ms: number;
+  max_delay_ms: number;
+  schema_version: "question-work-dispatch-backoff-policy/v1";
+}
+
+export interface QuestionWorkDispatchBackoffStateV1 {
+  consecutive_failures: number;
+  schema_version: "question-work-dispatch-backoff-state/v1";
+}
+
+export interface QuestionWorkDispatchDecisionV1 {
+  delay_ms: number;
+  next_state: QuestionWorkDispatchBackoffStateV1;
+  queued_work_disposition: "retain";
+  schema_version: "question-work-dispatch-decision/v1";
+}
+
+export class QuestionWorkDispatchPolicyError extends Error {}
+
+export const QUESTION_WORK_DISPATCH_INITIAL_STATE: QuestionWorkDispatchBackoffStateV1 = {
+  consecutive_failures: 0,
+  schema_version: "question-work-dispatch-backoff-state/v1",
+};
+
+/**
+ * Computes portable retry timing only. A durable adapter persists the returned
+ * state and schedules another publication attempt; this decision never removes
+ * or terminally changes the already-queued work.
+ */
+export function decideQuestionWorkDispatch(
+  policy: QuestionWorkDispatchBackoffPolicyV1,
+  state: QuestionWorkDispatchBackoffStateV1,
+  outcome: QuestionWorkDispatchOutcome,
+): QuestionWorkDispatchDecisionV1 {
+  validatePolicy(policy);
+  validateState(state);
+  if (outcome !== "publication_failed" && outcome !== "published") {
+    throw new QuestionWorkDispatchPolicyError("The dispatch outcome is unsupported.");
+  }
+
+  if (outcome === "published") {
+    return decision(0, 0);
+  }
+
+  const consecutiveFailures = Math.min(
+    Number.MAX_SAFE_INTEGER,
+    state.consecutive_failures + 1,
+  );
+  return decision(backoffDelay(policy, consecutiveFailures), consecutiveFailures);
+}
+
+function backoffDelay(
+  policy: QuestionWorkDispatchBackoffPolicyV1,
+  consecutiveFailures: number,
+): number {
+  const maximumDoublings = Math.ceil(
+    Math.log2(policy.max_delay_ms / policy.initial_delay_ms),
+  );
+  const doublings = Math.min(consecutiveFailures - 1, maximumDoublings);
+  let delay = policy.initial_delay_ms;
+  for (let index = 0; index < doublings; index += 1) {
+    delay = delay >= Math.ceil(policy.max_delay_ms / 2)
+      ? policy.max_delay_ms
+      : delay * 2;
+  }
+  return Math.min(delay, policy.max_delay_ms);
+}
+
+function decision(
+  delayMs: number,
+  consecutiveFailures: number,
+): QuestionWorkDispatchDecisionV1 {
+  return {
+    delay_ms: delayMs,
+    next_state: {
+      consecutive_failures: consecutiveFailures,
+      schema_version: "question-work-dispatch-backoff-state/v1",
+    },
+    queued_work_disposition: "retain",
+    schema_version: "question-work-dispatch-decision/v1",
+  };
+}
+
+function validatePolicy(policy: QuestionWorkDispatchBackoffPolicyV1): void {
+  if (policy.schema_version !== "question-work-dispatch-backoff-policy/v1") {
+    throw new QuestionWorkDispatchPolicyError("The dispatch policy version is unsupported.");
+  }
+  requirePositiveSafeInteger(policy.initial_delay_ms, "initial_delay_ms");
+  requirePositiveSafeInteger(policy.max_delay_ms, "max_delay_ms");
+  if (policy.max_delay_ms < policy.initial_delay_ms) {
+    throw new QuestionWorkDispatchPolicyError(
+      "max_delay_ms cannot be less than initial_delay_ms.",
+    );
+  }
+}
+
+function validateState(state: QuestionWorkDispatchBackoffStateV1): void {
+  if (state.schema_version !== "question-work-dispatch-backoff-state/v1") {
+    throw new QuestionWorkDispatchPolicyError("The dispatch state version is unsupported.");
+  }
+  if (!Number.isSafeInteger(state.consecutive_failures) || state.consecutive_failures < 0) {
+    throw new QuestionWorkDispatchPolicyError(
+      "consecutive_failures must be a non-negative safe integer.",
+    );
+  }
+}
+
+function requirePositiveSafeInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new QuestionWorkDispatchPolicyError(`${label} must be a positive safe integer.`);
+  }
+}

--- a/apps/slack-companion/test/question-work-dispatch-policy.test.ts
+++ b/apps/slack-companion/test/question-work-dispatch-policy.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  QUESTION_WORK_DISPATCH_INITIAL_STATE,
+  QuestionWorkDispatchPolicyError,
+  decideQuestionWorkDispatch,
+  type QuestionWorkDispatchBackoffPolicyV1,
+  type QuestionWorkDispatchBackoffStateV1,
+} from "../src/question-work/dispatch-policy.js";
+
+const POLICY: QuestionWorkDispatchBackoffPolicyV1 = {
+  initial_delay_ms: 100,
+  max_delay_ms: 1_000,
+  schema_version: "question-work-dispatch-backoff-policy/v1",
+};
+
+describe("question-work dispatch backoff", () => {
+  test("applies capped exponential delay while retaining durable queued work", () => {
+    let state = QUESTION_WORK_DISPATCH_INITIAL_STATE;
+    const delays: number[] = [];
+
+    for (let attempt = 0; attempt < 7; attempt += 1) {
+      const result = decideQuestionWorkDispatch(POLICY, state, "publication_failed");
+      assert.equal(result.queued_work_disposition, "retain");
+      delays.push(result.delay_ms);
+      state = result.next_state;
+    }
+
+    assert.deepEqual(delays, [100, 200, 400, 800, 1_000, 1_000, 1_000]);
+    assert.equal(state.consecutive_failures, 7);
+  });
+
+  test("returns the same decision for the same failure state", () => {
+    const state: QuestionWorkDispatchBackoffStateV1 = {
+      consecutive_failures: 3,
+      schema_version: "question-work-dispatch-backoff-state/v1",
+    };
+
+    const first = decideQuestionWorkDispatch(POLICY, state, "publication_failed");
+    const second = decideQuestionWorkDispatch(POLICY, state, "publication_failed");
+
+    assert.deepEqual(first, second);
+    assert.deepEqual(state, {
+      consecutive_failures: 3,
+      schema_version: "question-work-dispatch-backoff-state/v1",
+    });
+  });
+
+  test("resets failure state after publication succeeds", () => {
+    const failed = decideQuestionWorkDispatch(
+      POLICY,
+      QUESTION_WORK_DISPATCH_INITIAL_STATE,
+      "publication_failed",
+    );
+    const published = decideQuestionWorkDispatch(POLICY, failed.next_state, "published");
+
+    assert.deepEqual(published, {
+      delay_ms: 0,
+      next_state: QUESTION_WORK_DISPATCH_INITIAL_STATE,
+      queued_work_disposition: "retain",
+      schema_version: "question-work-dispatch-decision/v1",
+    });
+    const nextFailure = decideQuestionWorkDispatch(
+      POLICY,
+      published.next_state,
+      "publication_failed",
+    );
+    assert.equal(nextFailure.delay_ms, POLICY.initial_delay_ms);
+    assert.equal(nextFailure.next_state.consecutive_failures, 1);
+  });
+
+  test("rejects invalid policy, state, and outcome inputs", () => {
+    assert.throws(
+      () =>
+        decideQuestionWorkDispatch(
+          { ...POLICY, initial_delay_ms: 0 },
+          QUESTION_WORK_DISPATCH_INITIAL_STATE,
+          "publication_failed",
+        ),
+      QuestionWorkDispatchPolicyError,
+    );
+    assert.throws(
+      () =>
+        decideQuestionWorkDispatch(
+          { ...POLICY, max_delay_ms: 99 },
+          QUESTION_WORK_DISPATCH_INITIAL_STATE,
+          "publication_failed",
+        ),
+      /max_delay_ms cannot be less/,
+    );
+    assert.throws(
+      () =>
+        decideQuestionWorkDispatch(
+          POLICY,
+          {
+            consecutive_failures: -1,
+            schema_version: "question-work-dispatch-backoff-state/v1",
+          },
+          "publication_failed",
+        ),
+      /non-negative safe integer/,
+    );
+    assert.throws(
+      () =>
+        decideQuestionWorkDispatch(
+          POLICY,
+          QUESTION_WORK_DISPATCH_INITIAL_STATE,
+          "unknown" as never,
+        ),
+      /outcome is unsupported/,
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Add a versioned, portable decision contract for dispatch retry timing after a publication failure.
- Apply capped exponential delay while retaining already-queued question work.
- Reset the failure count after publication succeeds.
- Export the contract and cover its behavior with focused tests.

## Why

Publication can fail after question work is already durable. This keeps retry timing deterministic without discarding accepted work. Storage and scheduling remain adapter responsibilities.

## Validation

- `npm run check --workspace @writer/cerebro-slack-companion` (101 tests)
- `node --test apps/slack-companion/dist/test/question-work-dispatch-policy.test.js` (4 tests)
- `make check-arch`
- `make check-structural check-structural-test`
- `make oss-audit`
- `bash scripts/leak_check.sh range agent/slack-companion-question-work...HEAD`
- `git diff --check`
