### PR TITLE
Add deterministic graph rows query intent

### DIFF
--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -1281,7 +1281,7 @@ func unsupportedQuery(reason string, traceID string, code string) UnsupportedQue
 	return UnsupportedQuery{
 		Code:             firstNonEmpty(code, unsupportedQueryCode(reason)),
 		Reason:           reason,
-		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentFailingControls, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth, IntentOktaPrivilegedWeakMFA, IntentOktaDormantAccess, IntentOktaGroupAccessRisk, IntentQuestionnaireEvidence, IntentMITREAttackCoverage},
+		SupportedIntents: []string{IntentGraphRows, IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentFailingControls, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth, IntentOktaPrivilegedWeakMFA, IntentOktaDormantAccess, IntentOktaGroupAccessRisk, IntentQuestionnaireEvidence, IntentMITREAttackCoverage},
 		SuggestedRewrites: []string{
 			"Summarize open high-risk findings and cite the affected entities.",
 			"Show controls with open findings and cite the affected resources.",

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -131,6 +131,55 @@ func TestServiceUsesDeterministicFastPathForCommonTopRiskAsk(t *testing.T) {
 	}
 }
 
+func TestServiceUsesDeterministicFastPathForGenericGraphRows(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"entity_urn":                      "urn:cerebro:writer:asset:alpha",
+				"entity_label":                    "Asset Alpha",
+				"entity_type":                     "asset",
+				"source_id":                       "github",
+				"runtime_id":                      "github-runtime",
+				"entity_attributes_json_internal": `{"owner":"security"}`,
+			},
+		}},
+	}
+	llm := &StubLLMClient{
+		DraftErr: errors.New("draft should be skipped"),
+		Summary:  "Asset Alpha is present at `urn:cerebro:writer:asset:alpha`.",
+	}
+	service := NewServiceWithOptions(store, llm, ValidatorOptions{}, ServiceOptions{EnableDeterministicFastPath: true})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "show graph rows",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	if len(llm.DraftRequests) != 0 {
+		t.Fatalf("DraftCypher called %#v, want deterministic graph rows fast path to skip drafting", llm.DraftRequests)
+	}
+	planEvent := events[2].Data.(QueryPlanEvent)
+	if planEvent.Source != "deterministic_fast_path" || !planEvent.Deterministic || planEvent.Plan.Intent != IntentGraphRows {
+		t.Fatalf("query plan event = %#v, want deterministic graph rows plan", planEvent)
+	}
+	if len(store.requests) != 1 || strings.Contains(store.requests[0].Query, "MATCH (n)") || !strings.Contains(store.requests[0].Query, "tenant_id: $tenant_id") {
+		t.Fatalf("store query = %q, want tenant-scoped Entity template", store.requests[0].Query)
+	}
+	rowsEvent := events[6].Data.(RowsEvent)
+	if len(rowsEvent.Rows) != 1 || rowsEvent.Rows[0]["entity_urn"] != "urn:cerebro:writer:asset:alpha" {
+		t.Fatalf("rows = %#v, want graph entity row", rowsEvent.Rows)
+	}
+	if _, leaked := rowsEvent.Rows[0]["entity_attributes_json_internal"]; leaked {
+		t.Fatalf("rows leaked raw internal attributes: %#v", rowsEvent.Rows[0])
+	}
+}
+
 func TestServiceUsesGraphEvidenceBeforeQuestionnaireSummary(t *testing.T) {
 	store := &askStore{
 		rows: []ports.CypherRow{{

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -270,7 +270,7 @@ All plan.filters values must be JSON strings, even for numbers or booleans (for 
 If the question asks for mutation, deletion, credential disclosure, or anything unsafe, return:
 {"rationale":"why refused","plan":{"intent":"raw_cypher","confidence":0},"cypher":null,"refusal":"safe refusal message"}
 
-Preferred plan intents: aggregate_findings_by_source, top_risk_findings, failing_controls, explain_finding, identity_bridge, connector_health, okta_privileged_weak_mfa, okta_dormant_access, okta_group_access_risk, raw_cypher.
+Preferred plan intents: graph_rows, aggregate_findings_by_source, top_risk_findings, failing_controls, explain_finding, identity_bridge, connector_health, okta_privileged_weak_mfa, okta_dormant_access, okta_group_access_risk, raw_cypher.
 Use a deterministic intent whenever the question matches one; the backend will convert that plan into canonical Cypher.`, req.Question, normalizeModel(req.Model), req.Schema, req.Guardrail, probe, history.String())
 }
 

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	IntentRawCypher                 = "raw_cypher"
+	IntentGraphRows                 = "graph_rows"
 	IntentAggregateFindingsBySource = "aggregate_findings_by_source"
 	IntentTopRiskFindings           = "top_risk_findings"
 	IntentFailingControls           = "failing_controls"
@@ -215,7 +216,7 @@ func deterministicFastPathPlan(request AskRequest) (AskQueryPlan, bool) {
 	switch intent {
 	case IntentTopRiskFindings:
 		plan.Filters = fastPathTopRiskFilters(question)
-	case IntentFailingControls, IntentAggregateFindingsBySource, IntentConnectorHealth, IntentIdentityBridge, IntentOktaPrivilegedWeakMFA, IntentOktaDormantAccess, IntentOktaGroupAccessRisk:
+	case IntentGraphRows, IntentFailingControls, IntentAggregateFindingsBySource, IntentConnectorHealth, IntentIdentityBridge, IntentOktaPrivilegedWeakMFA, IntentOktaDormantAccess, IntentOktaGroupAccessRisk:
 		plan.Filters = map[string]string{}
 	case IntentMITREAttackCoverage:
 		plan.Filters = fastPathMITREAttackCoverageFilters(question)
@@ -527,6 +528,8 @@ func canonicalIntent(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "", "raw", "cypher", "raw_cypher":
 		return IntentRawCypher
+	case "graph_rows", "entity_rows", "query_rows", "rows", "entities", "nodes", "graph_entities", "graph_nodes":
+		return IntentGraphRows
 	case "aggregate_findings_by_source", "finding_source_counts", "findings_by_source", "source_breakdown":
 		return IntentAggregateFindingsBySource
 	case "top_risk_findings", "high_risk_findings", "findings":
@@ -581,9 +584,21 @@ func inferIntent(question string, cypher string) string {
 		return IntentQuestionnaireEvidence
 	case looksLikeMITREAttackCoverageQuestion(haystack):
 		return IntentMITREAttackCoverage
+	case looksLikeGraphRowsQuestion(haystack):
+		return IntentGraphRows
 	default:
 		return IntentRawCypher
 	}
+}
+
+func looksLikeGraphRowsQuestion(haystack string) bool {
+	if !containsAny(haystack, "graph row", "graph rows", "entity row", "entity rows", "query row", "query rows", "list entities", "show entities", "list nodes", "show nodes", "list graph nodes", "show graph nodes", "list graph entities", "show graph entities") {
+		return false
+	}
+	return !containsAny(haystack,
+		"risk", "risky", "finding", "findings", "control", "controls", "evidence", "questionnaire",
+		"connector", "source health", "runtime health", "okta", "mitre", "attack", "bridge", "explain",
+	)
 }
 
 func looksLikeMITREAttackCoverageQuestion(haystack string) bool {
@@ -599,6 +614,17 @@ func renderDeterministicPlan(plan AskQueryPlan, defaultMaxRows int) (string, boo
 	}
 	limit := boundedLimit(plan.Limit, defaultMaxRows)
 	switch plan.Intent {
+	case IntentGraphRows:
+		return fmt.Sprintf(`MATCH (entity:Entity {tenant_id: $tenant_id})
+WHERE $scope_urn = '' OR entity.urn = $scope_urn
+RETURN entity.urn AS entity_urn,
+       coalesce(entity.label, entity.urn) AS entity_label,
+       entity.entity_type AS entity_type,
+       entity.source_id AS source_id,
+       entity.runtime_id AS runtime_id,
+       coalesce(entity.attributes_json, '') AS entity_attributes_json_internal
+ORDER BY entity_type, entity_label, entity_urn
+LIMIT %d`, limit), true
 	case IntentAggregateFindingsBySource:
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(f:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = '' OR resource.urn = $scope_urn OR f.urn = $scope_urn
@@ -1238,6 +1264,8 @@ func hasUnsupportedDeterministicModifiers(plan AskQueryPlan) bool {
 	for key := range plan.Filters {
 		normalized := strings.ToLower(strings.TrimSpace(key))
 		switch plan.Intent {
+		case IntentGraphRows:
+			return true
 		case IntentTopRiskFindings:
 			if normalized != "severity" && normalized != "status" && normalized != "resource_type" && normalized != "entity_type" {
 				return true

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -230,6 +230,28 @@ func TestInferIntentRecognizesMITREAttackCoverage(t *testing.T) {
 	}
 }
 
+func TestInferIntentRecognizesGenericGraphRows(t *testing.T) {
+	for _, question := range []string{
+		"show graph rows",
+		"list entity rows",
+		"show entities",
+		"list graph nodes",
+	} {
+		if got := inferIntent(question, ""); got != IntentGraphRows {
+			t.Fatalf("inferIntent(%q) = %q, want %q", question, got, IntentGraphRows)
+		}
+	}
+	for _, question := range []string{
+		"Which entities are risky?",
+		"show finding rows",
+		"show source health rows",
+	} {
+		if got := inferIntent(question, ""); got == IntentGraphRows {
+			t.Fatalf("inferIntent(%q) = %q, want a more specific or raw intent", question, got)
+		}
+	}
+}
+
 func TestInferIntentDoesNotStealGenericAttackQuestions(t *testing.T) {
 	for _, tc := range []struct {
 		question string
@@ -242,6 +264,34 @@ func TestInferIntentDoesNotStealGenericAttackQuestions(t *testing.T) {
 		if got := inferIntent(tc.question, ""); got != tc.want {
 			t.Fatalf("inferIntent(%q) = %q, want %q", tc.question, got, tc.want)
 		}
+	}
+}
+
+func TestConvertDraftToQueryCanonicalizesGenericRowsBeforeValidation(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "show graph rows"}, &DraftResponse{
+		Cypher: `MATCH (n) RETURN n LIMIT 25`,
+	})
+
+	if result.Plan.Intent != IntentGraphRows || !result.Deterministic || !result.Corrected {
+		t.Fatalf("conversion result = %#v, want corrected deterministic graph rows", result)
+	}
+	for _, want := range []string{
+		"MATCH (entity:Entity {tenant_id: $tenant_id})",
+		"WHERE $scope_urn = '' OR entity.urn = $scope_urn",
+		"entity.urn AS entity_urn",
+		"entity_attributes_json_internal",
+		"LIMIT 25",
+	} {
+		if !strings.Contains(result.Cypher, want) {
+			t.Fatalf("graph rows cypher missing %q:\n%s", want, result.Cypher)
+		}
+	}
+	if strings.Contains(result.Cypher, "MATCH (n)") || strings.Contains(result.Cypher, "RETURN n") {
+		t.Fatalf("graph rows cypher preserved unscoped draft:\n%s", result.Cypher)
+	}
+	validation, limit, err := NewValidator(nil, ValidatorOptions{DisableExplain: true, MaxRows: 100}).validate(context.Background(), result.Cypher, nil)
+	if err != nil || !validation.OK || limit != 25 {
+		t.Fatalf("validate(converted cypher) = (%#v, %d, %v), want allowed LIMIT 25", validation, limit, err)
 	}
 }
 
@@ -1188,6 +1238,7 @@ func TestDeterministicTemplatesUseProjectedGraphContract(t *testing.T) {
 		scope   string
 		filters map[string]string
 	}{
+		{name: "graph rows", intent: IntentGraphRows, scope: "urn:cerebro:writer:asset:alpha"},
 		{name: "source aggregation", intent: IntentAggregateFindingsBySource, scope: "urn:cerebro:writer:asset:alpha"},
 		{name: "top risk", intent: IntentTopRiskFindings, scope: "urn:cerebro:writer:asset:alpha"},
 		{name: "failing controls", intent: IntentFailingControls, scope: "urn:cerebro:writer:asset:alpha"},
@@ -1306,7 +1357,7 @@ func containsDiagnosticCode(diagnostics []ConversionDiagnostic, code string) boo
 }
 
 func TestConvertDraftToQueryInjectsFallbackLimit(t *testing.T) {
-	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "show entities"}, &DraftResponse{
+	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "run this custom read query"}, &DraftResponse{
 		Cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn AS urn`,
 	})
 
@@ -1320,7 +1371,7 @@ func TestConvertDraftToQueryInjectsFallbackLimit(t *testing.T) {
 
 func TestConvertDraftToQueryInjectsLimitAfterLimitNamedArithmetic(t *testing.T) {
 	cypher := `MATCH (e:Entity {tenant_id:$tenant_id}) WITH e, 1 AS limit RETURN e, limit + 1`
-	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "show entities"}, &DraftResponse{
+	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "run this custom read query"}, &DraftResponse{
 		Cypher: cypher,
 	})
 
@@ -1342,7 +1393,7 @@ func TestConvertDraftToQueryPreservesParenthesizedLimitForValidatorRefusal(t *te
 		`MATCH (e:Entity {tenant_id:$tenant_id}) RETURN e LIMIT (1 + 2)`,
 	}
 	for _, cypher := range queries {
-		result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "show entities"}, &DraftResponse{Cypher: cypher})
+		result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "run this custom read query"}, &DraftResponse{Cypher: cypher})
 		if result.Cypher != cypher || result.Corrected || containsDiagnosticCode(result.Diagnostics, "limit_injected") {
 			t.Fatalf("conversion result = %#v, want parenthesized LIMIT preserved for validation", result)
 		}
@@ -1354,7 +1405,7 @@ func TestConvertDraftToQueryPreservesParenthesizedLimitForValidatorRefusal(t *te
 }
 
 func TestConvertDraftToQueryCapsFallbackLimit(t *testing.T) {
-	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "show entities"}, &DraftResponse{
+	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "run this custom read query"}, &DraftResponse{
 		Cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn AS urn LIMIT 500`,
 	})
 


### PR DESCRIPTION
## Summary
- add a deterministic graph_rows query intent for generic graph/entity row asks
- render generic graph-row requests through a tenant-scoped Entity template before validator checks
- cover inference, conversion, validator, and fast-path behavior with regression tests

## Tests
- go test ./internal/graphagent -count=1 -v
- make verify (blocked locally by disk exhaustion during build cache writes)