### PR TITLE
docs: clarify monorepo application layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,80 @@
 [![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-Cerebro is Writer's public monorepo for turning security, identity, cloud, SaaS, workflow, policy, and compliance data into evidence-backed context that people, coding agents, and automation can use. The Go runtime exposes source integration, evidence, findings, controls, and graph capabilities through a CLI, JSON HTTP API, Connect RPC, MCP, and SDK helpers. Public applications live under `apps/`, consume those typed contracts, and stay portable across environments.
+Cerebro turns security, identity, cloud, SaaS, workflow, policy, and compliance data into evidence-backed context for people, coding agents, and automation. It answers questions such as what changed, what is risky, which controls apply, and whether an action is supported by current evidence.
 
-Cerebro is not a SIEM, SOAR, CSPM replacement, LLM host, or data warehouse. Its runtime and contract layer lets clients ask grounded questions such as:
+This repository is a monorepo because Cerebro is one product with several operator surfaces:
 
-- What evidence exists for this repo, asset, identity, control, or workflow?
-- Which policies, controls, findings, approvals, and owners apply?
-- What changed, what is risky, and what should be fixed first?
-- Which connected systems, identities, and resources explain the risk?
-- Is a proposed action supported by current evidence?
+- the Go runtime is the source of truth for evidence, graph, policy, findings, MCP, JSON HTTP, Connect RPC, and CLI behavior;
+- the web app is a browser operator surface over those contracts;
+- the Slack companion is a chat operator surface for durable intake, execution, delivery, and lifecycle status;
+- SDKs, generated schemas, and applications can move together when a contract changes.
 
-## How The Runtime Works
+```mermaid
+flowchart LR
+  Runtime["Go runtime<br/>evidence, graph, policy, MCP, API, CLI"]
+  Contracts["Public contracts<br/>OpenAPI, proto, schemas, SDKs"]
+  Web["apps/web<br/>browser operator surface"]
+  Slack["apps/slack-companion<br/>chat operator surface"]
 
-Cerebro has two useful operating shapes:
+  Runtime --> Contracts
+  Contracts --> Web
+  Contracts --> Slack
+```
+
+Cerebro is not a SIEM, SOAR, CSPM replacement, LLM host, or data warehouse. It is the contract and evidence layer that lets those systems, humans, and agents ask grounded questions.
+
+## Why The Public Boundary Matters
+
+This public repository is authoritative for runtime behavior, portable application behavior, CLI/API contracts, source catalogs, configuration semantics, validation checks, and release artifacts. Environment-specific deployment details, stack configuration, account wiring, hostnames, secret addresses, rollout procedures, and recovery procedures intentionally live outside this public repo.
+
+That split is part of the design, not an afterthought. Public code defines portable behavior, contracts, fixtures, and conformance tests. Private operations bind those contracts to real accounts, networks, routes, secrets, rollout thresholds, and recovery policy.
+
+```mermaid
+flowchart LR
+  Public["writer/cerebro<br/>portable behavior, contracts, tests, release artifacts"]
+  Handoff["release handoff<br/>images + runtime contract"]
+  Private["private operations<br/>environment adapters and promotion policy"]
+
+  Public --> Handoff
+  Handoff --> Private
+```
+
+The deployment handoff is the release payload: container images plus a runtime contract, such as `cerebro-runtime-contract.json` in local preflight flows. Treat that contract as the bridge between public runtime releases and environment-specific promotion automation. See [Monorepo Ownership And Boundaries](docs/engineering/monorepo.md) for ownership rules and [Release Contract](docs/operations/release-contract.md) for artifact naming.
+
+## Runtime Shapes
+
+Cerebro can run in two useful modes:
 
 1. **Live source preview:** run the Go server and call source tools directly. This path can read provider data through the source service without Postgres, NATS, or Neo4j.
 2. **Durable evidence runtime:** add NATS JetStream, Postgres, and Neo4j/Aura to persist source runtime syncs, append-log events, findings, reports, and graph projections.
 
-The same source contracts, API contracts, policy catalogs, and validation tools are used in both shapes. Routes that need a configured durable store fail closed when that store is absent.
+The same source contracts, API contracts, policy catalogs, and validation tools apply in both modes. Routes that require a durable store fail closed when that store is absent.
+
+```mermaid
+flowchart TB
+  Sources["Provider sources<br/>cloud, SaaS, identity, workflow, compliance"]
+  SourceService["Source service<br/>catalogs and runtime reads"]
+  Live["Live source preview<br/>direct tool/API responses"]
+  AppendLog["Append log<br/>durable events"]
+  Stores["Durable stores<br/>NATS, Postgres, Neo4j"]
+  Context["Evidence context<br/>findings, reports, graph projections"]
+  Surfaces["Surfaces<br/>CLI, HTTP, RPC, MCP, apps"]
+
+  Sources --> SourceService
+  SourceService --> Live
+  SourceService --> AppendLog
+  AppendLog --> Stores
+  Stores --> Context
+  Live --> Surfaces
+  Context --> Surfaces
+```
 
 ## Quick Start
 
 ```bash
 git clone https://github.com/writer/cerebro.git
 cd cerebro
-
-make doctor
 make serve-dev
 ```
 
@@ -41,7 +89,7 @@ curl -sS http://127.0.0.1:8080/health
 curl -sS http://127.0.0.1:8080/sources
 ```
 
-Build the binary directly when you want to run the CLI:
+Build the CLI when you need command-line workflows:
 
 ```bash
 make build
@@ -49,14 +97,45 @@ make build
 ./bin/cerebro source list
 ```
 
-Check all npm workspaces when you touch public applications or generated TypeScript helpers:
+Use `make doctor` when you want to validate the full contributor toolchain, including npm and Rust workspace tooling.
 
-```bash
-npm ci
-npm run check:workspaces
-npm run build --workspace @writer/cerebro-web
-npm run check --workspace @writer/cerebro-slack-companion
-```
+## Repository Layout
+
+| Area | Paths | Purpose |
+| --- | --- | --- |
+| Runtime and CLI | `cmd/cerebro`, `internal/bootstrap` | Go server, CLI, HTTP, Connect RPC, MCP, auth, rate-limit, and route wiring. |
+| Applications | `apps/web`, `apps/slack-companion` | Portable operator surfaces that consume Cerebro contracts. See [Applications](apps/README.md). |
+| Source and evidence contracts | `internal/sourcecdk`, `internal/sourceregistry`, `sources/` | Source contract plus built-in catalog for cloud, SaaS, identity, endpoint, vulnerability, workflow, and compliance signals. |
+| Durable workflows | `internal/appendlog`, `internal/sourceprojection`, `internal/findings`, graph packages | Append-log, runtime sync, finding, report, and graph projection behavior. |
+| Policies and detections | `policies/`, `internal/findingdsl`, `internal/findings` | Policy, control mapping, finding rule, and detection catalogs. |
+| API contracts | `api/openapi.yaml`, `proto/cerebro/v1/bootstrap.proto` | JSON HTTP and Connect RPC contracts. |
+| SDK helpers | `sdk/python`, `sdk/typescript`, `sdk/go/cerebroapi` | Generated and hand-written helpers for public API surfaces. |
+| DevEx and guardrails | `docs/`, `scripts/`, `tools/` | Operating guides, validation checks, generators, and repository-specific structural tests. |
+
+Applications are peers of the Go runtime, not embedded assets and not deployment overlays. The runtime can build, test, and publish its contracts without serving app bundles, and applications can build against those contracts without carrying private topology.
+
+Top-level commands are `serve`, `version`, `source`, `source-runtime`, `connector-catalog`, `append-log`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
+
+## Workflows
+
+| Goal | Start here |
+| --- | --- |
+| Get the shortest runnable path | [Quick reference](docs/start/quick-reference.md) |
+| Walk through a local end-to-end flow | [Getting started](docs/start/getting-started.md) |
+| Hand setup to a coding agent | [Agent onboarding](docs/start/agent-onboarding.md) |
+| Configure auth, tenancy, stores, MCP, or device auth | [Configuration variables](docs/reference/config-env-vars.md) and [.env.example](.env.example) |
+| Understand runtime shape and stores | [Architecture](docs/reference/architecture.md) |
+| Explore JSON HTTP or Connect APIs | [API reference](docs/reference/api-reference.md), `api/openapi.yaml`, and `proto/cerebro/v1/bootstrap.proto` |
+| Use SDK helpers | [Python SDK](sdk/python/README.md), [TypeScript SDK](sdk/typescript/README.md), and `sdk/go/cerebroapi` |
+| Browse built-in integrations | [Source catalog](docs/reference/sources.md) |
+| Persist and sync source runtimes | [Source runtime guide](docs/domains/source-runtime-guide.md) |
+| Work on graph behavior | [Graph operations](docs/domains/graph-operations.md) |
+| Design persona-specific graph views | [Persona view lenses](docs/domains/persona-view-lenses.md) |
+| Integrate MCP clients | [MCP native Droid setup](docs/domains/mcp-droid-setup.md) |
+| Integrate endpoint telemetry | [Endpoint security platform integration](docs/domains/endpoint-security-platform-integration.md) |
+| Author policies, control mappings, or finding rules | [Policies](docs/domains/policies.md), [compliance controls](docs/domains/compliance-controls.md), `policies/`, `internal/findingdsl`, and `internal/findings` |
+| Host or operate Cerebro | [Hosting](docs/operations/hosting.md), [runtime profiles](docs/operations/runtime-profiles.md), [deployment readiness](docs/operations/deployment-readiness.md), [cloud deployment](docs/operations/cloud-deployment.md), [deployment examples](docs/operations/deployment-examples.md), and [operations runbook](docs/operations/operations-runbook.md) |
+| Contribute code or docs | [Development](docs/engineering/development.md), [non-goals](docs/engineering/non-goals.md), and the Makefile |
 
 ## Give A Coding Agent Context
 
@@ -81,7 +160,22 @@ Do not commit provider credentials, customer names, tenant-specific hostnames,
 account IDs, or live secret values.
 ```
 
-The MCP source tools, `cerebro.sources.list`, `cerebro.sources.check`, `cerebro.sources.discover`, and `cerebro.sources.read`, call the same source service used by the HTTP and CLI surfaces. For durable graph and evidence context, run `make github-business-demo` with `GITHUB_OWNER`, `GITHUB_REPO`, and `GITHUB_TOKEN`, then hand `tmp/onboarding/github-receipt.json` to the agent.
+The MCP source tools, `cerebro.sources.list`, `cerebro.sources.check`, `cerebro.sources.discover`, and `cerebro.sources.read`, call the same source service used by HTTP and CLI surfaces. For durable graph and evidence context, run `make github-business-demo` with `GITHUB_OWNER`, `GITHUB_REPO`, and `GITHUB_TOKEN`, then hand `tmp/onboarding/github-receipt.json` to the agent.
+
+```mermaid
+sequenceDiagram
+  participant Agent as Coding agent
+  participant MCP as Cerebro MCP
+  participant Runtime as Cerebro runtime
+  participant Evidence as Sources and durable stores
+
+  Agent->>MCP: Ask for security or compliance context
+  MCP->>Runtime: Call typed Cerebro tools
+  Runtime->>Evidence: Read live source data or durable evidence
+  Evidence-->>Runtime: Return grounded facts
+  Runtime-->>MCP: Normalize evidence, controls, risks, and links
+  MCP-->>Agent: Provide context before code or review decisions
+```
 
 See [Agent onboarding](docs/start/agent-onboarding.md), [MCP native Droid setup](docs/domains/mcp-droid-setup.md), and [Agent platform contract](docs/domains/agent-platform-contract.md).
 
@@ -98,66 +192,17 @@ The compose stack runs Cerebro with NATS JetStream, Postgres, Neo4j, and the loc
 
 Plain Compose initializes the local Postgres volume with the compose-file password. The onboarding Make targets use `tmp/local-postgres-password`. If you switch between those modes, recreate local volumes with `docker compose down -v` or run the Make target with an explicit local Postgres password that matches the existing volume. `docker compose down -v` deletes local stack data.
 
-## Repository Layout
+```mermaid
+flowchart LR
+  Runtime["Cerebro server"]
+  NATS["NATS JetStream<br/>append-log events"]
+  Postgres["Postgres<br/>state and receipts"]
+  Neo4j["Neo4j/Aura<br/>graph projections"]
 
-| Area | Paths | Purpose |
-| --- | --- | --- |
-| Runtime and CLI | `cmd/cerebro`, `internal/bootstrap` | Go server, CLI, HTTP, Connect RPC, MCP, auth, rate-limit, and route wiring. |
-| Public applications | `apps/web`, `apps/slack-companion` | Portable browser and Slack companion workspaces that consume Cerebro contracts. |
-| Source and evidence contracts | `internal/sourcecdk`, `internal/sourceregistry`, `sources/` | Source contract plus built-in catalog for cloud, SaaS, identity, endpoint, vulnerability, workflow, and compliance signals. |
-| Durable workflows | `internal/appendlog`, `internal/sourceprojection`, `internal/findings`, graph packages | Append-log, runtime sync, finding, report, and graph projection behavior. |
-| Policies and detections | `policies/`, `internal/findingdsl`, `internal/findings` | Policy, control mapping, finding rule, and detection catalogs. |
-| API contracts | `api/openapi.yaml`, `proto/cerebro/v1/bootstrap.proto` | JSON HTTP and Connect RPC contracts. |
-| SDK helpers | `sdk/python`, `sdk/typescript`, `sdk/go/cerebroapi` | Generated and hand-written helpers for public API surfaces. |
-| DevEx and guardrails | `docs/`, `scripts/`, `tools/` | Operating guides, validation checks, generators, and repository-specific structural tests. |
-
-The application workspaces are peers of the Go runtime, not embedded assets. The runtime can build, test, and publish its contracts without serving app bundles, and applications can build against those contracts without carrying deployment-specific overlays.
-
-## Main Surfaces
-
-| Surface | Use it for | Start here |
-| --- | --- | --- |
-| CLI | Local development, source checks, runtime syncs, graph operations, finding rules, deploy preflights | `./bin/cerebro --help`, [CLI reference](docs/reference/cli.md) |
-| JSON HTTP | Simple service integrations and local smoke checks | [API reference](docs/reference/api-reference.md), `api/openapi.yaml` |
-| Connect RPC | Typed service clients and generated contracts | `proto/cerebro/v1/bootstrap.proto` |
-| MCP | Agent-readable source, policy, graph, and evidence context | `POST /api/v1/mcp`, `docs/domains/mcp-droid-setup.md` |
-| SDK helpers | Client helper packages for generated API surfaces | `sdk/python/README.md`, `sdk/typescript/README.md`, `sdk/go/cerebroapi` |
-
-Top-level commands are `serve`, `version`, `source`, `source-runtime`, `connector-catalog`, `append-log`, `finding-rule`, `graph`, `orchestrator`, `vulndb`, `closeout`, and `deploy`.
-
-## Choose A Path
-
-| Goal | Start here |
-| --- | --- |
-| Get the shortest runnable path | [Quick reference](docs/start/quick-reference.md) |
-| Walk through a local end-to-end flow | [Getting started](docs/start/getting-started.md) |
-| Hand setup to a coding agent | [Agent onboarding](docs/start/agent-onboarding.md) |
-| Understand runtime shape and stores | [Architecture](docs/reference/architecture.md) |
-| Configure auth, tenancy, stores, MCP, or device auth | [Configuration variables](docs/reference/config-env-vars.md) and [.env.example](.env.example) |
-| Host or operate Cerebro | [Hosting](docs/operations/hosting.md), [runtime profiles](docs/operations/runtime-profiles.md), [deployment readiness](docs/operations/deployment-readiness.md), [cloud deployment](docs/operations/cloud-deployment.md), [deployment examples](docs/operations/deployment-examples.md), and [operations runbook](docs/operations/operations-runbook.md) |
-| Explore JSON HTTP or Connect APIs | [API reference](docs/reference/api-reference.md), `api/openapi.yaml`, and `proto/cerebro/v1/bootstrap.proto` |
-| Use the CLI | [CLI reference](docs/reference/cli.md) |
-| Browse built-in integrations | [Source catalog](docs/reference/sources.md) |
-| Use SDK helpers | [Python SDK](sdk/python/README.md), [TypeScript SDK](sdk/typescript/README.md), and `sources/sdk` |
-| Persist and sync source runtimes | [Source runtime guide](docs/domains/source-runtime-guide.md) |
-| Work on graph behavior | [Graph operations](docs/domains/graph-operations.md) |
-| Design persona-specific graph views | [Persona view lenses](docs/domains/persona-view-lenses.md) |
-| Integrate MCP clients | [MCP native Droid setup](docs/domains/mcp-droid-setup.md) |
-| Integrate endpoint telemetry | [Endpoint security platform integration](docs/domains/endpoint-security-platform-integration.md) |
-| Author policies, control mappings, or finding rules | [Policies](docs/domains/policies.md), [compliance controls](docs/domains/compliance-controls.md), `policies/`, `internal/findingdsl`, and `internal/findings` |
-| Contribute code or docs | [Development](docs/engineering/development.md), [non-goals](docs/engineering/non-goals.md), and the Makefile |
-
-## Runtime Boundaries
-
-This public repository is authoritative for runtime behavior, portable application behavior, CLI/API contracts, source catalogs, configuration semantics, validation checks, and release artifacts. Environment-specific deployment details, stack configuration, account wiring, hostnames, secret addresses, rollout procedures, and recovery procedures intentionally live outside this public repo.
-
-The deployment handoff is the release payload: container images plus `cerebro-runtime-contract.json`. Treat that contract as the bridge between public runtime releases and environment-specific promotion and deployment automation.
-
-Volatile details should stay in their source-of-truth files and be linked from here: configuration variables in `docs/reference/config-env-vars.md`, API shape in `api/openapi.yaml`, source capabilities in `sources/*/catalog.yaml`, and release handoff data in `cerebro-runtime-contract.json`.
-
-Do not add infrastructure manifests, environment routes, credential references, deployment overlays, or private rollout policy under `apps/`. Application packages should expose portable behavior, tests, and typed seams for private deployment adapters.
-
-Read [Non-goals](docs/engineering/non-goals.md) before changing storage shape, Source CDK boundaries, graph/Cypher behavior, findings workflow contracts, action/runtime response semantics, platform/security namespace boundaries, or public product language.
+  Runtime <--> NATS
+  Runtime <--> Postgres
+  Runtime <--> Neo4j
+```
 
 ## Common Commands
 
@@ -170,7 +215,8 @@ make verify                   # CI-parity local verification
 make readme-check             # README formatting and drift checks
 make docs-drift-check         # documentation drift checks
 make oss-audit                # public repository hygiene scan
-make workspace-check          # install, test, and type-check npm workspaces
+make workspace-check          # install dependencies and run declared npm workspace checks
+make workspace-build          # build npm workspaces that declare a build script
 make sdk-test                 # SDK tests and type checks
 make secure-business-demo     # run local security onboarding and write a receipt
 make github-business-demo     # seed durable graph context from a real GitHub repo
@@ -183,18 +229,9 @@ make control-index-check      # validate compliance control index output
 cerebro deploy preflight      # emit a redacted deployment readiness receipt
 ```
 
+When you touch public applications or generated TypeScript helpers, use `make workspace-check` and `make workspace-build`.
+
 Control extension packs are documented in [Compliance controls](docs/domains/compliance-controls.md) and use `--init-extension`, `--extension`, `--profile`, `--output`, and `--write` workflows.
-
-## Optional Docs Site
-
-The Markdown docs work directly on GitHub. To browse them as a local site:
-
-```bash
-python3 -m pip install mkdocs
-mkdocs serve
-```
-
-The site entry point is [docs/index.md](docs/index.md), and `mkdocs.yml` defines the navigation.
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-Cerebro is Writer's public monorepo for turning security, identity, cloud, SaaS, workflow, policy, and compliance data into evidence-backed context that people, coding agents, and automation can use. The Go runtime exposes source integration, evidence, findings, controls, and graph capabilities through a CLI, JSON HTTP API, Connect RPC, MCP, and SDK helpers. Independently built clients live under `apps/` and consume those typed contracts.
+Cerebro is Writer's public monorepo for turning security, identity, cloud, SaaS, workflow, policy, and compliance data into evidence-backed context that people, coding agents, and automation can use. The Go runtime exposes source integration, evidence, findings, controls, and graph capabilities through a CLI, JSON HTTP API, Connect RPC, MCP, and SDK helpers. Public applications live under `apps/`, consume those typed contracts, and stay portable across environments.
 
 Cerebro is not a SIEM, SOAR, CSPM replacement, LLM host, or data warehouse. Its runtime and contract layer lets clients ask grounded questions such as:
 
@@ -49,6 +49,15 @@ make build
 ./bin/cerebro source list
 ```
 
+Check all npm workspaces when you touch public applications or generated TypeScript helpers:
+
+```bash
+npm ci
+npm run check:workspaces
+npm run build --workspace @writer/cerebro-web
+npm run check --workspace @writer/cerebro-slack-companion
+```
+
 ## Give A Coding Agent Context
 
 Start Cerebro, connect an MCP client to the local MCP endpoint, then let the agent read live source data through Cerebro.
@@ -89,17 +98,20 @@ The compose stack runs Cerebro with NATS JetStream, Postgres, Neo4j, and the loc
 
 Plain Compose initializes the local Postgres volume with the compose-file password. The onboarding Make targets use `tmp/local-postgres-password`. If you switch between those modes, recreate local volumes with `docker compose down -v` or run the Make target with an explicit local Postgres password that matches the existing volume. `docker compose down -v` deletes local stack data.
 
-## What Is In This Repo
+## Repository Layout
 
-- `apps/`: independently built browser and companion clients that consume public contracts.
-- `cmd/cerebro`: the main Go binary. It defaults to `serve` and also exposes source, runtime, graph, finding, closeout, deploy, and orchestration commands.
-- `internal/bootstrap`: HTTP, Connect RPC, MCP, auth, rate-limit, and route wiring for the runtime.
-- `internal/sourcecdk`, `internal/sourceregistry`, and `sources/`: the source contract and built-in source catalog for cloud, SaaS, identity, endpoint, vulnerability, workflow, and compliance signals.
-- `internal/appendlog`, `internal/sourceprojection`, `internal/findings`, and graph packages: durable event, runtime sync, finding, report, and graph workflows.
-- `policies/`, `internal/findingdsl`, and `internal/findings`: policy, control mapping, finding rule, and detection catalogs.
-- `api/openapi.yaml` and `proto/cerebro/v1/bootstrap.proto`: JSON HTTP and Connect RPC contracts.
-- `sdk/python/README.md`, `sdk/typescript/README.md`, and `sdk/go/cerebroapi`: SDK helper packages.
-- `docs/`, `scripts/`, and `tools/`: operating guides, validation checks, generators, and repository-specific guardrails.
+| Area | Paths | Purpose |
+| --- | --- | --- |
+| Runtime and CLI | `cmd/cerebro`, `internal/bootstrap` | Go server, CLI, HTTP, Connect RPC, MCP, auth, rate-limit, and route wiring. |
+| Public applications | `apps/web`, `apps/slack-companion` | Portable browser and Slack companion workspaces that consume Cerebro contracts. |
+| Source and evidence contracts | `internal/sourcecdk`, `internal/sourceregistry`, `sources/` | Source contract plus built-in catalog for cloud, SaaS, identity, endpoint, vulnerability, workflow, and compliance signals. |
+| Durable workflows | `internal/appendlog`, `internal/sourceprojection`, `internal/findings`, graph packages | Append-log, runtime sync, finding, report, and graph projection behavior. |
+| Policies and detections | `policies/`, `internal/findingdsl`, `internal/findings` | Policy, control mapping, finding rule, and detection catalogs. |
+| API contracts | `api/openapi.yaml`, `proto/cerebro/v1/bootstrap.proto` | JSON HTTP and Connect RPC contracts. |
+| SDK helpers | `sdk/python`, `sdk/typescript`, `sdk/go/cerebroapi` | Generated and hand-written helpers for public API surfaces. |
+| DevEx and guardrails | `docs/`, `scripts/`, `tools/` | Operating guides, validation checks, generators, and repository-specific structural tests. |
+
+The application workspaces are peers of the Go runtime, not embedded assets. The runtime can build, test, and publish its contracts without serving app bundles, and applications can build against those contracts without carrying deployment-specific overlays.
 
 ## Main Surfaces
 
@@ -137,11 +149,13 @@ Top-level commands are `serve`, `version`, `source`, `source-runtime`, `connecto
 
 ## Runtime Boundaries
 
-This public repository is authoritative for runtime behavior, CLI/API contracts, source catalogs, configuration semantics, validation checks, and release artifacts. Environment-specific deployment details, stack configuration, account wiring, hostnames, and rollout procedures intentionally live outside this public repo.
+This public repository is authoritative for runtime behavior, portable application behavior, CLI/API contracts, source catalogs, configuration semantics, validation checks, and release artifacts. Environment-specific deployment details, stack configuration, account wiring, hostnames, secret addresses, rollout procedures, and recovery procedures intentionally live outside this public repo.
 
 The deployment handoff is the release payload: container images plus `cerebro-runtime-contract.json`. Treat that contract as the bridge between public runtime releases and environment-specific promotion and deployment automation.
 
-Volatile details should stay in their source-of-truth files and be linked from here: configuration variables in `docs/reference/config-env-vars.md`, API shape in `api/openapi.yaml`, source capabilities in `sources/*/catalog.yaml`, and release/deploy handoff data in `cerebro-runtime-contract.json`.
+Volatile details should stay in their source-of-truth files and be linked from here: configuration variables in `docs/reference/config-env-vars.md`, API shape in `api/openapi.yaml`, source capabilities in `sources/*/catalog.yaml`, and release handoff data in `cerebro-runtime-contract.json`.
+
+Do not add infrastructure manifests, environment routes, credential references, deployment overlays, or private rollout policy under `apps/`. Application packages should expose portable behavior, tests, and typed seams for private deployment adapters.
 
 Read [Non-goals](docs/engineering/non-goals.md) before changing storage shape, Source CDK boundaries, graph/Cypher behavior, findings workflow contracts, action/runtime response semantics, platform/security namespace boundaries, or public product language.
 
@@ -156,6 +170,7 @@ make verify                   # CI-parity local verification
 make readme-check             # README formatting and drift checks
 make docs-drift-check         # documentation drift checks
 make oss-audit                # public repository hygiene scan
+make workspace-check          # install, test, and type-check npm workspaces
 make sdk-test                 # SDK tests and type checks
 make secure-business-demo     # run local security onboarding and write a receipt
 make github-business-demo     # seed durable graph context from a real GitHub repo

--- a/apps/README.md
+++ b/apps/README.md
@@ -5,7 +5,7 @@
 | Workspace | Package | Owns |
 | --- | --- | --- |
 | `web` | `@writer/cerebro-web` | Browser operator UI, server-side web boundary, UI contracts, and web tests. |
-| `slack-companion` | `@writer/cerebro-slack-companion` | Slack intake, durable run coordination, delivery, background work, and Slack-visible lifecycle behavior. |
+| `slack-companion` | `@writer/cerebro-slack-companion` | Slack intake, durable run coordination, delivery, background work, and Slack-visible lifecycle behavior. See [Slack companion](slack-companion/README.md). |
 
 Each app is an npm workspace with its own `package.json`. The package manifests use `private: true` to prevent accidental npm publication; that does not mean the code belongs in a private repository.
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,20 +1,14 @@
 # Applications
 
-Applications in this directory are public, portable clients of Cerebro contracts.
-They are npm workspaces owned by the public monorepo and built independently
-from the Go runtime.
+`apps/` contains Cerebro's public operator surfaces. They live in this monorepo because they consume the same contracts as the Go runtime and should move with those contracts when behavior changes.
 
 | Workspace | Package | Owns |
 | --- | --- | --- |
-| `web` | `@writer/cerebro-web` | Browser application, server-side web proxy, UI contracts, and web tests. |
-| `slack-companion` | `@writer/cerebro-slack-companion` | Slack admission, durable run coordination, delivery, question work, distributed workcells, and Slack-visible lifecycle behavior. |
+| `web` | `@writer/cerebro-web` | Browser operator UI, server-side web boundary, UI contracts, and web tests. |
+| `slack-companion` | `@writer/cerebro-slack-companion` | Slack intake, durable run coordination, delivery, background work, and Slack-visible lifecycle behavior. |
 
-Each application has its own private package manifest and independent build
-entrypoint. Applications may depend on public schemas and SDKs in this
-repository. The Go runtime does not import application code, serve application
-assets, or require an application to start.
+Each app is an npm workspace with its own `package.json`. The package manifests use `private: true` to prevent accidental npm publication; that does not mean the code belongs in a private repository.
 
-Environment-specific deployment adapters, network configuration, secret
-addresses, rollout policy, and recovery policy do not belong under `apps/`.
-Keep those concerns in private deployment repositories and expose only portable
-interfaces, fixtures, and tests here.
+Apps may depend on public schemas, generated bindings, and SDKs in this repo. The Go runtime does not import app code, serve app assets, or require an app to start.
+
+Do not put environment-specific deployment adapters, network configuration, secret addresses, rollout policy, or recovery policy under `apps/`. Keep those in private operations repositories and expose only portable interfaces, fixtures, and conformance tests here. See [Monorepo Ownership And Boundaries](../docs/engineering/monorepo.md) for the canonical split.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,12 +1,20 @@
 # Applications
 
 Applications in this directory are public, portable clients of Cerebro contracts.
-The following workspaces are imported by the sequence in `docs/engineering/monorepo.md`;
-they may not exist on an earlier commit in that sequence.
+They are npm workspaces owned by the public monorepo and built independently
+from the Go runtime.
 
-- `web` will own the browser application, server-side web proxy, and UI tests.
-- `slack-companion` will own Slack admission, durable run coordination, delivery, and Slack-visible lifecycle behavior.
+| Workspace | Package | Owns |
+| --- | --- | --- |
+| `web` | `@writer/cerebro-web` | Browser application, server-side web proxy, UI contracts, and web tests. |
+| `slack-companion` | `@writer/cerebro-slack-companion` | Slack admission, durable run coordination, delivery, question work, distributed workcells, and Slack-visible lifecycle behavior. |
 
-Each imported application is an npm workspace with its own private package manifest and independent build entrypoint. Applications may depend on public schemas and SDKs in this repository. The Go runtime does not import application code, serve application assets, or require an application to start.
+Each application has its own private package manifest and independent build
+entrypoint. Applications may depend on public schemas and SDKs in this
+repository. The Go runtime does not import application code, serve application
+assets, or require an application to start.
 
-Environment-specific deployment adapters, network configuration, secret addresses, rollout policy, and recovery policy do not belong under `apps/`.
+Environment-specific deployment adapters, network configuration, secret
+addresses, rollout policy, and recovery policy do not belong under `apps/`.
+Keep those concerns in private deployment repositories and expose only portable
+interfaces, fixtures, and tests here.

--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -9,6 +9,36 @@ The first supported path is durable admission:
 3. Permit the Slack acknowledgement only after that transaction succeeds.
 4. Return the existing receipt when Slack retries the same input.
 
+## Slack To Cerebro And Back
+
+The companion treats Slack as transport and attention, not as the system of record. It persists and acknowledges Slack input first, performs work through portable Cerebro contracts, then delivers the result back through a durable outbox.
+
+```mermaid
+sequenceDiagram
+  participant Slack as Slack
+  participant Transport as Transport handler
+  participant Admission as Durable admission
+  participant Queue as Run and work queue
+  participant Worker as Companion worker
+  participant Cerebro as Cerebro contracts/API
+  participant Delivery as Delivery outbox
+
+  Slack->>Transport: event, mention, or interaction
+  Transport->>Transport: verify signature or socket presence
+  Transport->>Admission: persist payload and normalize envelope
+  Admission->>Queue: dedupe, write run receipt, enqueue work
+  Admission-->>Slack: acknowledge only after durable commit
+  Worker->>Queue: claim work with lease and fencing
+  Worker->>Cerebro: read evidence, graph, policy, and source context
+  Cerebro-->>Worker: return grounded context and contract-shaped results
+  Worker->>Delivery: plan response parts with stable ids
+  Delivery->>Slack: send message or status update
+  Slack-->>Delivery: destination receipt
+  Delivery->>Queue: record delivered, retry, paused, or abandoned state
+```
+
+The same shape applies to longer-running work. Slack-visible status can show queued, degraded, recovery, or completed states while leases, checkpoints, and receipts keep retries idempotent.
+
 Production implementations of `DurableAdmissionPort` must use durable storage with one transaction or an equivalent recoverable commit protocol. The in-memory implementation under `src/testing` is a conformance fixture only.
 
 This workspace must not contain credentials, infrastructure identifiers, environment routes, deployment manifests, or provider-specific persistence adapters. Those belong in the private operational repository. A deployment may replace every port without changing the Slack application identity, binding identity, run identity, or thread identity.

--- a/docs/engineering/monorepo.md
+++ b/docs/engineering/monorepo.md
@@ -4,6 +4,12 @@
 
 This document defines the public repository layout used to consolidate Cerebro runtime and client development. It does not define a deployment topology or authorize a production migration.
 
+## Rationale
+
+Cerebro is one product with multiple operator surfaces. The Go runtime owns the system of record for evidence, graph, policy, source, MCP, HTTP, RPC, and CLI behavior. The web app and Slack companion are public clients of those contracts, not separate products with independent semantics.
+
+Keeping the clients in this repository lets contract changes land with their generated SDKs, UI behavior, Slack lifecycle behavior, and conformance tests. Keeping deployment topology out of this repository prevents public source from accumulating environment values, secret locations, account wiring, hostnames, rollout thresholds, and recovery policy.
+
 ## Layout
 
 | Path | Owns | Must not own |
@@ -17,11 +23,22 @@ This document defines the public repository layout used to consolidate Cerebro r
 
 ## Dependency Direction
 
-```text
-apps/web ---------------------> public HTTP/OpenAPI contracts
-apps/slack-companion --------> lifecycle schemas + TypeScript SDK + public HTTP contracts
-sdk/typescript --------------> generated public schemas
-Go runtime ------------------> internal domain packages + public schemas
+```mermaid
+flowchart TB
+  Schemas["public schemas"]
+  Runtime["Go runtime<br/>cmd/, internal/, sources/"]
+  HTTP["public HTTP/OpenAPI contracts"]
+  SDK["sdk/typescript"]
+  Web["apps/web"]
+  Slack["apps/slack-companion"]
+
+  Schemas --> Runtime
+  Runtime --> HTTP
+  Schemas --> SDK
+  HTTP --> Web
+  HTTP --> Slack
+  SDK --> Slack
+  Schemas --> Slack
 ```
 
 Dependencies do not point from the Go runtime into `apps/`. Applications are built and released independently even when a contract and its consumers change in one pull-request stack.


### PR DESCRIPTION
## Summary

- clarify the public monorepo application layout in the root README
- update apps/README.md now that web and Slack companion workspaces are present
- reinforce that environment-specific deployment and rollout material stays outside apps/

## Validation

- make readme-check docs-drift-check check-structural oss-audit
