### PR TITLE
feat(slack): complete durable command and schedule intake

### DIFF
--- a/apps/slack-companion/src/autonomy/contracts.ts
+++ b/apps/slack-companion/src/autonomy/contracts.ts
@@ -5,6 +5,7 @@ import type {
   WorkLeaseV1,
 } from "@writer/cerebro-sdk";
 import type { ExecutionSession } from "../execution/model.js";
+import type { ScheduledLeaseClaim } from "../operations/schedules.js";
 import type { MissionPlanProjectionV1 } from "../mission/model.js";
 import {
   NATIVE_MISSION_CONTRACT_ID,
@@ -80,10 +81,17 @@ export interface TransitionMissionInput {
   event: MissionLedgerEventContext;
   expected_revision: number;
   next_run?: RunReceiptV1;
+  occurrence_outcome?: MissionScheduledOccurrenceOutcome;
   operation_id: string;
   plan?: MissionPlanProjectionV1;
   session: ExecutionSession;
   wake?: MissionWakeInput | null;
+}
+
+export interface MissionScheduledOccurrenceOutcome {
+  claim: ScheduledLeaseClaim;
+  occurrence_id: string;
+  state: "completed" | "failed";
 }
 
 /**
@@ -103,6 +111,7 @@ export interface PromoteLegacyMissionInput {
 }
 
 export interface MissionTransitionResult {
+  consumed_occurrence?: ScheduledOccurrenceV1;
   created: boolean;
   event: LifecycleEventV1;
   occurrence?: ScheduledOccurrenceV1;
@@ -127,6 +136,7 @@ export interface MissionEventPageRequest {
 }
 
 export interface MissionStoredCommit {
+  consumed_occurrence?: ScheduledOccurrenceV1;
   event: LifecycleEventV1;
   intent_digest: string;
   occurrence?: ScheduledOccurrenceV1;

--- a/apps/slack-companion/src/autonomy/ledger.ts
+++ b/apps/slack-companion/src/autonomy/ledger.ts
@@ -159,6 +159,14 @@ export class MissionLedger {
         "mission transition cannot change stable mission identity",
       );
     }
+    if (input.occurrence_outcome !== undefined) {
+      validateOccurrenceOutcome(current, input.occurrence_outcome);
+      if (input.wake === undefined) {
+        throw new MissionLedgerInvariantError(
+          "a consumed wake must be cleared or replaced",
+        );
+      }
+    }
 
     const revision = current.revision + 1;
     const event = createMissionLifecycleEvent({
@@ -191,6 +199,9 @@ export class MissionLedger {
       wake,
     };
     return this.store.commitTransition({
+      ...(input.occurrence_outcome === undefined
+        ? {}
+        : { consumed_occurrence: structuredClone(input.occurrence_outcome) }),
       event,
       expected_revision: input.expected_revision,
       idempotency_key: idempotencyKey,
@@ -344,11 +355,34 @@ export class MissionLedger {
     if (stored === undefined) return undefined;
     assertMatchingIntent(stored, intentDigest);
     return {
+      consumed_occurrence: stored.consumed_occurrence,
       created: false,
       event: stored.event,
       occurrence: stored.occurrence,
       snapshot: stored.snapshot,
     };
+  }
+}
+
+function validateOccurrenceOutcome(
+  current: MissionSnapshotV1,
+  outcome: NonNullable<TransitionMissionInput["occurrence_outcome"]>,
+): void {
+  requireRef(outcome.occurrence_id, "occurrence_id");
+  requireRef(outcome.claim.lease_token, "scheduled_claim.lease_token");
+  requireRef(outcome.claim.owner_id, "scheduled_claim.owner_id");
+  requirePositiveInteger(
+    outcome.claim.fencing_token,
+    "scheduled_claim.fencing_token",
+  );
+  requirePositiveInteger(
+    outcome.claim.generation,
+    "scheduled_claim.generation",
+  );
+  if (current.wake?.occurrence_ref !== outcome.occurrence_id) {
+    throw new MissionLedgerInvariantError(
+      "scheduled occurrence does not match the current mission wake",
+    );
   }
 }
 
@@ -726,5 +760,12 @@ export class MissionLedgerOccurrenceConflictError extends Error {
   constructor() {
     super("mission scheduled occurrence changed concurrently");
     this.name = "MissionLedgerOccurrenceConflictError";
+  }
+}
+
+export class MissionLedgerStaleOccurrenceError extends Error {
+  constructor(message = "scheduled occurrence claim is stale") {
+    super(message);
+    this.name = "MissionLedgerStaleOccurrenceError";
   }
 }

--- a/apps/slack-companion/src/autonomy/ports.ts
+++ b/apps/slack-companion/src/autonomy/ports.ts
@@ -2,6 +2,7 @@ import type {
   DueMissionRecord,
   LifecycleEventV1,
   MissionEventPageRequest,
+  MissionScheduledOccurrenceOutcome,
   MissionPromotionResult,
   MissionSnapshotV1,
   MissionStoredCommit,
@@ -11,6 +12,7 @@ import type {
 } from "./contracts.js";
 
 export interface MissionAtomicCommit {
+  consumed_occurrence?: MissionScheduledOccurrenceOutcome;
   event: LifecycleEventV1;
   expected_revision: number;
   idempotency_key: string;
@@ -55,8 +57,9 @@ export interface LegacyMissionAtomicCommit extends MissionAtomicCommit {
  */
 export interface DurableMissionLedgerPort {
   /**
-   * Atomically verifies an exact active execution lease at authority-owned time
-   * and commits the snapshot, event, and optional scheduled work item.
+   * Atomically verifies the active execution lease and optional scheduled
+   * occurrence claim at authority-owned time, then commits the consumed
+   * occurrence, snapshot, event, and optional next scheduled work item.
    */
   commitTransition(
     commit: MissionAtomicCommit,

--- a/apps/slack-companion/src/autonomy/reference-store.ts
+++ b/apps/slack-companion/src/autonomy/reference-store.ts
@@ -24,10 +24,14 @@ import {
   MissionLedgerInvariantError,
   MissionLedgerOccurrenceConflictError,
   MissionLedgerStaleLeaseError,
+  MissionLedgerStaleOccurrenceError,
   MissionLedgerStaleRevisionError,
   missionSnapshotReference,
 } from "./ledger.js";
-import { acquireScheduledOccurrence } from "../operations/schedules.js";
+import {
+  acquireScheduledOccurrence,
+  updateScheduledOccurrence,
+} from "../operations/schedules.js";
 
 export interface ReferenceMemoryMissionLedgerStoreOptions {
   lease_authority?: MissionLeaseAuthorityPort;
@@ -54,6 +58,7 @@ export class ReferenceMemoryMissionLedgerStore
     const prior = this.requireIdempotentCommit(commit);
     if (prior !== undefined) {
       return {
+        consumed_occurrence: prior.consumed_occurrence,
         created: false,
         event: prior.event,
         occurrence: prior.occurrence,
@@ -79,6 +84,11 @@ export class ReferenceMemoryMissionLedgerStore
   ): Promise<MissionPromotionResult> {
     requireRef(commit.adapter_ref, "adapter_ref");
     requireRef(commit.source_ref, "source_ref");
+    if (commit.consumed_occurrence !== undefined) {
+      throw new MissionLedgerInvariantError(
+        "legacy promotion cannot consume scheduled mission work",
+      );
+    }
     const prior = this.requireIdempotentCommit(commit);
     if (prior !== undefined) {
       return {
@@ -100,8 +110,12 @@ export class ReferenceMemoryMissionLedgerStore
       return { created: false, snapshot: clone(current) };
     }
 
-    this.validateCommit(commit, undefined, undefined);
-    this.applyCommit(commit);
+    const consumedOccurrence = this.validateCommit(
+      commit,
+      undefined,
+      undefined,
+    );
+    this.applyCommit(commit, consumedOccurrence);
     return {
       created: true,
       event: clone(commit.event),
@@ -231,6 +245,7 @@ export class ReferenceMemoryMissionLedgerStore
     const prior = this.requireIdempotentCommit(commit);
     if (prior !== undefined) {
       return {
+        consumed_occurrence: prior.consumed_occurrence,
         created: false,
         event: prior.event,
         occurrence: prior.occurrence,
@@ -238,9 +253,14 @@ export class ReferenceMemoryMissionLedgerStore
       };
     }
     const current = this.snapshots.get(commit.snapshot.subject_ref);
-    this.validateCommit(commit, current, authoritative);
-    this.applyCommit(commit);
+    const consumedOccurrence = this.validateCommit(
+      commit,
+      current,
+      authoritative,
+    );
+    this.applyCommit(commit, consumedOccurrence);
     return {
+      consumed_occurrence: cloneOptional(consumedOccurrence),
       created: true,
       event: clone(commit.event),
       occurrence: cloneOptional(commit.occurrence),
@@ -252,7 +272,7 @@ export class ReferenceMemoryMissionLedgerStore
     commit: MissionAtomicCommit,
     current: MissionSnapshotV1 | undefined,
     authoritative: AuthoritativeMissionLeaseRead | undefined,
-  ): void {
+  ): ScheduledOccurrenceV1 | undefined {
     const { event, snapshot } = commit;
     requireRef(commit.idempotency_key, "idempotency_key");
     requireRef(commit.intent_digest, "intent_digest");
@@ -324,6 +344,39 @@ export class ReferenceMemoryMissionLedgerStore
       );
     }
     this.validateOccurrence(commit);
+    return this.validateConsumedOccurrence(commit, current, authoritative);
+  }
+
+  private validateConsumedOccurrence(
+    commit: MissionAtomicCommit,
+    current: MissionSnapshotV1 | undefined,
+    authoritative: AuthoritativeMissionLeaseRead | undefined,
+  ): ScheduledOccurrenceV1 | undefined {
+    const outcome = commit.consumed_occurrence;
+    if (outcome === undefined) return undefined;
+    if (
+      current === undefined ||
+      authoritative === undefined ||
+      current.wake?.occurrence_ref !== outcome.occurrence_id ||
+      commit.occurrence?.occurrence_id === outcome.occurrence_id
+    ) {
+      throw new MissionLedgerStaleOccurrenceError();
+    }
+
+    const occurrence = this.occurrences.get(outcome.occurrence_id);
+    if (occurrence === undefined) {
+      throw new MissionLedgerStaleOccurrenceError();
+    }
+    const consumed = updateScheduledOccurrence(
+      occurrence,
+      outcome.claim,
+      outcome.state,
+      authoritative.observed_at,
+    );
+    if (consumed === undefined) {
+      throw new MissionLedgerStaleOccurrenceError();
+    }
+    return consumed;
   }
 
   private validateOccurrence(commit: MissionAtomicCommit): void {
@@ -400,10 +453,17 @@ export class ReferenceMemoryMissionLedgerStore
     }
   }
 
-  private applyCommit(commit: MissionAtomicCommit): void {
+  private applyCommit(
+    commit: MissionAtomicCommit,
+    consumedOccurrence: ScheduledOccurrenceV1 | undefined,
+  ): void {
     const snapshot = clone(commit.snapshot);
     const event = clone(commit.event);
     const occurrence = cloneOptional(commit.occurrence);
+    const consumed = cloneOptional(consumedOccurrence);
+    if (consumed !== undefined) {
+      this.occurrences.set(consumed.occurrence_id, consumed);
+    }
     if (occurrence !== undefined) {
       this.occurrences.set(occurrence.occurrence_id, occurrence);
     }
@@ -414,6 +474,7 @@ export class ReferenceMemoryMissionLedgerStore
       event,
     ]);
     this.commits.set(commit.idempotency_key, {
+      consumed_occurrence: consumed,
       event,
       intent_digest: commit.intent_digest,
       occurrence,

--- a/apps/slack-companion/src/commands/registry.ts
+++ b/apps/slack-companion/src/commands/registry.ts
@@ -1,0 +1,130 @@
+export interface SlackCommandParseInput {
+  readonly rawRest: string;
+  readonly words: readonly string[];
+}
+
+export interface SlackCommandDefinition<Result> {
+  readonly command: string;
+  readonly aliases?: readonly string[];
+  readonly usage: string;
+  readonly summary: string;
+  readonly parse: (input: SlackCommandParseInput) => Result;
+}
+
+export interface SlackCommandHelpEntry {
+  readonly command: string;
+  readonly aliases: readonly string[];
+  readonly usage: string;
+  readonly summary: string;
+}
+
+export interface SlackCommandFallbacks<Result> {
+  readonly empty: () => Result;
+  readonly unknown: (text: string) => Result;
+}
+
+export interface SlackCommandRegistry<Result> {
+  readonly parse: (text: string) => Result;
+  readonly helpEntries: () => readonly SlackCommandHelpEntry[];
+}
+
+interface RegisteredCommand<Result> extends SlackCommandHelpEntry {
+  readonly parse: (input: SlackCommandParseInput) => Result;
+}
+
+const COMMAND_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
+
+/**
+ * Creates a portable command parser from caller-owned command definitions.
+ *
+ * The registry performs no I/O and does not own command handlers. Parse
+ * callbacks must also be pure so transport admission and execution remain
+ * separate durability boundaries.
+ */
+export function createSlackCommandRegistry<Result>(
+  definitions: readonly SlackCommandDefinition<Result>[],
+  fallbacks: SlackCommandFallbacks<Result>,
+): SlackCommandRegistry<Result> {
+  const registered = definitions.map(snapshotDefinition);
+  const lookup = buildLookup(registered);
+  const help = Object.freeze(
+    registered.map((definition) =>
+      Object.freeze({
+        command: definition.command,
+        aliases: definition.aliases,
+        usage: definition.usage,
+        summary: definition.summary,
+      }),
+    ),
+  );
+
+  return Object.freeze({
+    parse(text: string): Result {
+      const trimmed = text.trim();
+      if (!trimmed) return fallbacks.empty();
+
+      const { head, tail } = splitHead(trimmed);
+      const definition = lookup.get(head.toLowerCase());
+      if (!definition) return fallbacks.unknown(trimmed);
+
+      return definition.parse(
+        Object.freeze({
+          rawRest: tail,
+          words: Object.freeze(tail ? tail.split(/\s+/) : []),
+        }),
+      );
+    },
+    helpEntries(): readonly SlackCommandHelpEntry[] {
+      return help;
+    },
+  });
+}
+
+function snapshotDefinition<Result>(
+  definition: SlackCommandDefinition<Result>,
+): RegisteredCommand<Result> {
+  validateName(definition.command);
+  for (const alias of definition.aliases ?? []) validateName(alias);
+  if (!definition.usage.trim() || !definition.summary.trim()) {
+    throw new Error("command registry usage and summary must be non-empty");
+  }
+
+  return Object.freeze({
+    command: definition.command,
+    aliases: Object.freeze([...(definition.aliases ?? [])]),
+    usage: definition.usage,
+    summary: definition.summary,
+    parse: definition.parse,
+  });
+}
+
+function buildLookup<Result>(
+  definitions: readonly RegisteredCommand<Result>[],
+): ReadonlyMap<string, RegisteredCommand<Result>> {
+  const lookup = new Map<string, RegisteredCommand<Result>>();
+  for (const definition of definitions) {
+    for (const name of [definition.command, ...definition.aliases]) {
+      const normalized = name.toLowerCase();
+      if (lookup.has(normalized)) {
+        throw new Error("command registry name is registered more than once");
+      }
+      lookup.set(normalized, definition);
+    }
+  }
+  return lookup;
+}
+
+function validateName(name: string): void {
+  if (!COMMAND_NAME_PATTERN.test(name)) {
+    throw new Error("command registry names must be lowercase single words");
+  }
+}
+
+function splitHead(text: string): { head: string; tail: string } {
+  const splitAt = text.search(/\s/);
+  if (splitAt === -1) return { head: text, tail: "" };
+  return {
+    head: text.slice(0, splitAt),
+    tail: text.slice(splitAt).trimStart(),
+  };
+}

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -7,6 +7,7 @@ export * from "./assistance/contracts.js";
 export * from "./assistance/coordinator.js";
 export * from "./assistance/ports.js";
 export * from "./contracts.js";
+export * from "./commands/registry.js";
 export * from "./delivery/contracts.js";
 export * from "./delivery/coordinator.js";
 export * from "./delivery/ports.js";

--- a/apps/slack-companion/src/transport/contracts.ts
+++ b/apps/slack-companion/src/transport/contracts.ts
@@ -4,17 +4,31 @@ import type {
   SlackIngressEnvelope,
 } from "../contracts.js";
 
-export type SlackIngressMode = "events_api" | "socket_mode";
+export type SlackIngressMode =
+  | "events_api"
+  | "interactive"
+  | "slash_commands"
+  | "socket_mode";
 
 export interface SlackTransportRoute {
   binding_id: string;
+  conversation_id?: string;
   required_capabilities: CapabilityRequirement[];
   retention_policy_ref: string;
   run_kind: RunKind;
   tenant_id: string;
+  thread_id?: string;
 }
 
 export interface SlackEventsApiRequest {
+  raw_body: Uint8Array;
+  received_at: string;
+  request_signature: string;
+  request_timestamp: string;
+  route: SlackTransportRoute;
+}
+
+export interface SlackSignedInvocationRequest {
   raw_body: Uint8Array;
   received_at: string;
   request_signature: string;
@@ -48,6 +62,33 @@ export interface SlackSocketModeEnvelope {
   retry_reason?: string;
   type: "events_api" | "interactive" | "slash_commands";
 }
+
+export interface SlackSlashCommandEnvelope {
+  api_app_id: string;
+  channel_id: string;
+  command: string;
+  team_id: string;
+  text: string;
+  trigger_id: string;
+  type: "slash_command";
+  user_id: string;
+}
+
+export interface SlackInteractiveEnvelope {
+  action_id: string;
+  api_app_id: string;
+  conversation_id?: string;
+  interaction_type: string;
+  team_id: string;
+  thread_id?: string;
+  trigger_id: string;
+  type: "interactive";
+  user_id: string;
+}
+
+export type SlackInvocationEnvelope =
+  | SlackInteractiveEnvelope
+  | SlackSlashCommandEnvelope;
 
 export interface SlackSocketConnectionProof {
   connection_ref: string;
@@ -101,6 +142,17 @@ export interface SlackEventNormalizer {
   normalize(input: SlackEventNormalizationInput): SlackIngressEnvelope;
 }
 
+export interface SlackInvocationNormalizationInput {
+  envelope: SlackInvocationEnvelope;
+  payload: InboundPayloadReceipt;
+  received_at: string;
+  route: SlackTransportRoute;
+}
+
+export interface SlackInvocationNormalizer {
+  normalize(input: SlackInvocationNormalizationInput): SlackIngressEnvelope;
+}
+
 export interface EventsApiAcknowledgementCommand {
   body: "";
   kind: "events_api_ack";
@@ -112,6 +164,13 @@ export interface SocketModeAcknowledgementCommand {
   kind: "socket_mode_ack";
 }
 
+export interface SignedInvocationAcknowledgementCommand {
+  body: "";
+  invocation: "interactive" | "slash_command";
+  kind: "signed_invocation_ack";
+  status_code: 200;
+}
+
 export interface UrlVerificationCommand {
   body: string;
   kind: "url_verification";
@@ -120,6 +179,7 @@ export interface UrlVerificationCommand {
 
 export type SlackAcknowledgementCommand =
   | EventsApiAcknowledgementCommand
+  | SignedInvocationAcknowledgementCommand
   | SocketModeAcknowledgementCommand;
 
 export type TransportFailureStage =
@@ -155,7 +215,15 @@ export interface EventsApiHandlerDependencies {
 
 export interface SocketModeHandlerDependencies {
   admission: SlackAdmissionPort;
+  invocation_normalizer?: SlackInvocationNormalizer;
   normalizer: SlackEventNormalizer;
   payloads: DurableInboundPayloadPort;
   presence: DurableSocketPresencePort;
+}
+
+export interface SignedInvocationHandlerDependencies {
+  admission: SlackAdmissionPort;
+  clock: { now(): Date };
+  normalizer: SlackInvocationNormalizer;
+  payloads: DurableInboundPayloadPort;
 }

--- a/apps/slack-companion/src/transport/handler.ts
+++ b/apps/slack-companion/src/transport/handler.ts
@@ -2,16 +2,21 @@ import { createHash } from "node:crypto";
 import type {
   EventsApiHandlerDependencies,
   InboundPayloadReceipt,
+  SignedInvocationHandlerDependencies,
   SlackEventCallbackEnvelope,
   SlackEventsApiRequest,
+  SlackInvocationEnvelope,
+  SlackSignedInvocationRequest,
   SlackSocketModeRequest,
   SlackTransportOutcome,
-  SlackTransportRoute,
   SocketModeHandlerDependencies,
 } from "./contracts.js";
 import {
   eventCallbackFromSocketMode,
+  invocationFromSocketMode,
+  parseInteractiveEnvelope,
   parseEventsApiEnvelope,
+  parseSlashCommandEnvelope,
   parseSocketModeEnvelope,
 } from "./normalization.js";
 import { verifySlackRequestSignature } from "./signatures.js";
@@ -54,11 +59,16 @@ export async function handleEventsApiRequest(
 
   return persistNormalizeAdmit(
     "events_api",
-    parsed,
+    payloadIdempotencyKey(parsed),
     request.raw_body,
     request.received_at,
-    request.route,
     dependencies,
+    (payload) => dependencies.normalizer.normalize({
+      envelope: parsed,
+      payload,
+      received_at: request.received_at,
+      route: request.route,
+    }),
     () => ({ body: "", kind: "events_api_ack", status_code: 200 }),
   );
 }
@@ -78,21 +88,35 @@ export async function handleSocketModeRequest(
   }
 
   let envelope;
-  let event;
+  let event: SlackEventCallbackEnvelope | SlackInvocationEnvelope;
   try {
     envelope = parseSocketModeEnvelope(request.raw_body);
-    event = eventCallbackFromSocketMode(envelope);
+    event = envelope.type === "events_api"
+      ? eventCallbackFromSocketMode(envelope)
+      : invocationFromSocketMode(envelope);
   } catch {
     return noAcknowledgement("parsing", "invalid_envelope", false);
   }
 
   return persistNormalizeAdmit(
     "socket_mode",
-    event,
+    socketPayloadIdempotencyKey(event),
     request.raw_body,
     request.received_at,
-    request.route,
     dependencies,
+    (payload) => event.type === "event_callback"
+      ? dependencies.normalizer.normalize({
+          envelope: event,
+          payload,
+          received_at: request.received_at,
+          route: request.route,
+        })
+      : requireInvocationNormalizer(dependencies).normalize({
+        envelope: event,
+        payload,
+        received_at: request.received_at,
+        route: request.route,
+      }),
     () => ({
       envelope_id: envelope.envelope_id,
       kind: "socket_mode_ack",
@@ -100,23 +124,108 @@ export async function handleSocketModeRequest(
   );
 }
 
+export function handleSlashCommandRequest(
+  request: SlackSignedInvocationRequest,
+  signingSecret: string | Uint8Array,
+  dependencies: SignedInvocationHandlerDependencies,
+): Promise<SlackTransportOutcome> {
+  return handleSignedInvocation(
+    "slash_commands",
+    request,
+    signingSecret,
+    dependencies,
+    parseSlashCommandEnvelope,
+  );
+}
+
+export function handleInteractiveRequest(
+  request: SlackSignedInvocationRequest,
+  signingSecret: string | Uint8Array,
+  dependencies: SignedInvocationHandlerDependencies,
+): Promise<SlackTransportOutcome> {
+  return handleSignedInvocation(
+    "interactive",
+    request,
+    signingSecret,
+    dependencies,
+    parseInteractiveEnvelope,
+  );
+}
+
+async function handleSignedInvocation(
+  transport: "interactive" | "slash_commands",
+  request: SlackSignedInvocationRequest,
+  signingSecret: string | Uint8Array,
+  dependencies: SignedInvocationHandlerDependencies,
+  parse: (rawBody: Uint8Array) => SlackInvocationEnvelope,
+): Promise<SlackTransportOutcome> {
+  const verification = verifySlackRequestSignature(
+    {
+      now: dependencies.clock.now(),
+      raw_body: request.raw_body,
+      request_signature: request.request_signature,
+      request_timestamp: request.request_timestamp,
+    },
+    signingSecret,
+  );
+  if (!verification.verified) {
+    return noAcknowledgement("verification", verification.reason, false);
+  }
+
+  let envelope;
+  try {
+    envelope = parse(request.raw_body);
+  } catch {
+    return noAcknowledgement("parsing", "invalid_envelope", false);
+  }
+
+  return persistNormalizeAdmit(
+    transport,
+    invocationPayloadIdempotencyKey(envelope),
+    request.raw_body,
+    request.received_at,
+    dependencies,
+    (payload) => dependencies.normalizer.normalize({
+      envelope,
+      payload,
+      received_at: request.received_at,
+      route: request.route,
+    }),
+    () => ({
+      body: "",
+      invocation: envelope.type,
+      kind: "signed_invocation_ack",
+      status_code: 200,
+    }),
+  );
+}
+
 async function persistNormalizeAdmit(
-  transport: "events_api" | "socket_mode",
-  event: SlackEventCallbackEnvelope,
+  transport: "events_api" | "interactive" | "slash_commands" | "socket_mode",
+  idempotencyKey: string,
   rawBody: Uint8Array,
   receivedAt: string,
-  route: SlackTransportRoute,
   dependencies:
     | EventsApiHandlerDependencies
+    | SignedInvocationHandlerDependencies
     | SocketModeHandlerDependencies,
+  normalize: (
+    payload: InboundPayloadReceipt,
+  ) => ReturnType<EventsApiHandlerDependencies["normalizer"]["normalize"]>,
   acknowledgement: () =>
     | { body: ""; kind: "events_api_ack"; status_code: 200 }
+    | {
+        body: "";
+        invocation: "interactive" | "slash_command";
+        kind: "signed_invocation_ack";
+        status_code: 200;
+      }
     | { envelope_id: string; kind: "socket_mode_ack" },
 ): Promise<SlackTransportOutcome> {
   let payload: InboundPayloadReceipt;
   try {
     payload = await dependencies.payloads.persist({
-      idempotency_key: payloadIdempotencyKey(event),
+      idempotency_key: idempotencyKey,
       raw_body: rawBody,
       received_at: receivedAt,
       transport,
@@ -131,12 +240,7 @@ async function persistNormalizeAdmit(
 
   let normalized;
   try {
-    normalized = dependencies.normalizer.normalize({
-      envelope: event,
-      payload,
-      received_at: receivedAt,
-      route,
-    });
+    normalized = normalize(payload);
   } catch {
     return noAcknowledgement("normalization", "invalid_event", false);
   }
@@ -162,6 +266,29 @@ async function persistNormalizeAdmit(
 
 function payloadIdempotencyKey(event: SlackEventCallbackEnvelope): string {
   return `slack:${event.api_app_id}:${event.team_id}:${event.event_id}`;
+}
+
+function invocationPayloadIdempotencyKey(
+  envelope: SlackInvocationEnvelope,
+): string {
+  return `slack:${envelope.api_app_id}:${envelope.team_id}:${envelope.type}:${envelope.trigger_id}`;
+}
+
+function socketPayloadIdempotencyKey(
+  envelope: SlackEventCallbackEnvelope | SlackInvocationEnvelope,
+): string {
+  return envelope.type === "event_callback"
+    ? payloadIdempotencyKey(envelope)
+    : invocationPayloadIdempotencyKey(envelope);
+}
+
+function requireInvocationNormalizer(
+  dependencies: SocketModeHandlerDependencies,
+) {
+  if (dependencies.invocation_normalizer === undefined) {
+    throw new Error("Socket Mode invocation normalizer is required");
+  }
+  return dependencies.invocation_normalizer;
 }
 
 function validPayloadReceipt(

--- a/apps/slack-companion/src/transport/normalization.ts
+++ b/apps/slack-companion/src/transport/normalization.ts
@@ -4,6 +4,11 @@ import type {
   SlackEventNormalizationInput,
   SlackEventNormalizer,
   SlackEventsApiEnvelope,
+  SlackInteractiveEnvelope,
+  SlackInvocationEnvelope,
+  SlackInvocationNormalizationInput,
+  SlackInvocationNormalizer,
+  SlackSlashCommandEnvelope,
   SlackSocketModeEnvelope,
 } from "./contracts.js";
 
@@ -21,6 +26,54 @@ export class StructuralSlackEventNormalizer implements SlackEventNormalizer {
       conversation_id: conversationId,
       event_id: envelope.event_id,
       event_type: eventType,
+      payload_digest: payload.digest,
+      payload_ref: payload.payload_ref,
+      received_at: receivedAt,
+      required_capabilities: route.required_capabilities,
+      retention_policy_ref: route.retention_policy_ref,
+      run_kind: route.run_kind,
+      subject_ref: `slack-thread:${conversationId}:${threadId}`,
+      tenant_id: route.tenant_id,
+      thread_id: threadId,
+    };
+  }
+}
+
+export class StructuralSlackInvocationNormalizer
+  implements SlackInvocationNormalizer
+{
+  normalize(input: SlackInvocationNormalizationInput): SlackIngressEnvelope {
+    const { envelope, payload, received_at: receivedAt, route } = input;
+    if (envelope.type === "slash_command") {
+      return {
+        app_id: envelope.api_app_id,
+        binding_id: route.binding_id,
+        conversation_id: envelope.channel_id,
+        event_id: `slash_command:${envelope.trigger_id}`,
+        event_type: `slash_command:${envelope.command}`,
+        payload_digest: payload.digest,
+        payload_ref: payload.payload_ref,
+        received_at: receivedAt,
+        required_capabilities: route.required_capabilities,
+        retention_policy_ref: route.retention_policy_ref,
+        run_kind: route.run_kind,
+        subject_ref: `slack-command:${envelope.channel_id}:${envelope.trigger_id}`,
+        tenant_id: route.tenant_id,
+        thread_id: envelope.trigger_id,
+      };
+    }
+
+    const conversationId = envelope.conversation_id ?? route.conversation_id;
+    if (conversationId === undefined) {
+      throw new Error("interactive conversation identity is required");
+    }
+    const threadId = envelope.thread_id ?? route.thread_id ?? envelope.trigger_id;
+    return {
+      app_id: envelope.api_app_id,
+      binding_id: route.binding_id,
+      conversation_id: conversationId,
+      event_id: `interactive:${envelope.trigger_id}`,
+      event_type: `interactive:${envelope.interaction_type}:${envelope.action_id}`,
       payload_digest: payload.digest,
       payload_ref: payload.payload_ref,
       received_at: receivedAt,
@@ -93,6 +146,31 @@ export function parseSocketModeEnvelope(
   };
 }
 
+export function parseSlashCommandEnvelope(
+  rawBody: Uint8Array,
+): SlackSlashCommandEnvelope {
+  const form = parseForm(rawBody);
+  return {
+    api_app_id: requiredFormValue(form, "api_app_id"),
+    channel_id: requiredFormValue(form, "channel_id"),
+    command: requiredFormValue(form, "command"),
+    team_id: requiredFormValue(form, "team_id"),
+    text: optionalFormValue(form, "text") ?? "",
+    trigger_id: requiredFormValue(form, "trigger_id"),
+    type: "slash_command",
+    user_id: requiredFormValue(form, "user_id"),
+  };
+}
+
+export function parseInteractiveEnvelope(
+  rawBody: Uint8Array,
+): SlackInteractiveEnvelope {
+  const form = parseForm(rawBody);
+  return interactiveEnvelopeFromValue(
+    parseJsonObject(requiredFormValue(form, "payload")),
+  );
+}
+
 export function eventCallbackFromSocketMode(
   envelope: SlackSocketModeEnvelope,
 ): SlackEventCallbackEnvelope {
@@ -114,17 +192,112 @@ export function eventCallbackFromSocketMode(
   };
 }
 
-function parseObject(rawBody: Uint8Array): Record<string, unknown> {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(Buffer.from(rawBody).toString("utf8"));
-  } catch {
-    throw new Error("request body must be valid JSON");
+export function invocationFromSocketMode(
+  envelope: SlackSocketModeEnvelope,
+): SlackInvocationEnvelope {
+  if (envelope.type === "slash_commands") {
+    const payload = requiredRecord(envelope.payload, "payload");
+    return {
+      api_app_id: requiredString(payload, "api_app_id"),
+      channel_id: requiredString(payload, "channel_id"),
+      command: requiredString(payload, "command"),
+      team_id: requiredString(payload, "team_id"),
+      text: optionalString(payload, "text") ?? "",
+      trigger_id: requiredString(payload, "trigger_id"),
+      type: "slash_command",
+      user_id: requiredString(payload, "user_id"),
+    };
   }
+  if (envelope.type !== "interactive") {
+    throw new Error("Socket Mode envelope is not an invocation");
+  }
+  return interactiveEnvelopeFromValue(requiredRecord(envelope.payload, "payload"));
+}
+
+function interactiveEnvelopeFromValue(
+  value: Record<string, unknown>,
+): SlackInteractiveEnvelope {
+  const team = requiredObject(value, "team");
+  const user = requiredObject(value, "user");
+  const channel = optionalObject(value, "channel");
+  const container = optionalObject(value, "container");
+  const actions = optionalArray(value, "actions");
+  const action = actions === undefined
+    ? undefined
+    : requiredRecord(actions[0], "actions[0]");
+  const interactionType = requiredString(value, "type");
+  const callbackId = optionalString(value, "callback_id");
+  const actionId =
+    (action === undefined ? undefined : optionalString(action, "action_id")) ??
+    callbackId ??
+    interactionType;
+  const conversationId =
+    optionalString(container ?? {}, "channel_id") ??
+    optionalString(channel ?? {}, "id");
+  const threadId =
+    optionalString(container ?? {}, "thread_ts") ??
+    optionalString(container ?? {}, "message_ts");
+  return {
+    action_id: actionId,
+    api_app_id: requiredString(value, "api_app_id"),
+    ...(conversationId === undefined ? {} : { conversation_id: conversationId }),
+    interaction_type: interactionType,
+    team_id: requiredString(team, "id"),
+    ...(threadId === undefined ? {} : { thread_id: threadId }),
+    trigger_id: requiredString(value, "trigger_id"),
+    type: "interactive",
+    user_id: requiredString(user, "id"),
+  };
+}
+
+function parseObject(rawBody: Uint8Array): Record<string, unknown> {
+  const parsed = parseJson(Buffer.from(rawBody).toString("utf8"));
   if (!isRecord(parsed)) {
     throw new Error("request body must be a JSON object");
   }
   return parsed;
+}
+
+function parseJsonObject(value: string): Record<string, unknown> {
+  const parsed = parseJson(value);
+  if (!isRecord(parsed)) {
+    throw new Error("payload must be a JSON object");
+  }
+  return parsed;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error("request body must be valid JSON");
+  }
+}
+
+function parseForm(rawBody: Uint8Array): URLSearchParams {
+  return new URLSearchParams(Buffer.from(rawBody).toString("utf8"));
+}
+
+function requiredFormValue(form: URLSearchParams, field: string): string {
+  const values = form.getAll(field);
+  if (values.length !== 1 || values[0]?.trim() === "") {
+    throw new Error(`${field} must occur once with a non-empty value`);
+  }
+  return values[0];
+}
+
+function optionalFormValue(
+  form: URLSearchParams,
+  field: string,
+): string | undefined {
+  const values = form.getAll(field);
+  if (values.length === 0) {
+    return undefined;
+  }
+  if (values.length !== 1) {
+    throw new Error(`${field} must occur at most once`);
+  }
+  return values[0];
 }
 
 function requiredObject(
@@ -134,6 +307,38 @@ function requiredObject(
   const candidate = value[field];
   if (!isRecord(candidate)) {
     throw new Error(`${field} must be an object`);
+  }
+  return candidate;
+}
+
+function requiredRecord(value: unknown, field: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${field} must be an object`);
+  }
+  return value;
+}
+
+function optionalObject(
+  value: Record<string, unknown>,
+  field: string,
+): Record<string, unknown> | undefined {
+  const candidate = value[field];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  return requiredRecord(candidate, field);
+}
+
+function optionalArray(
+  value: Record<string, unknown>,
+  field: string,
+): unknown[] | undefined {
+  const candidate = value[field];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(candidate) || candidate.length === 0) {
+    throw new Error(`${field} must be a non-empty array when present`);
   }
   return candidate;
 }

--- a/apps/slack-companion/test/autonomy-mission-runtime.test.ts
+++ b/apps/slack-companion/test/autonomy-mission-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   MissionLedger,
   MissionLedgerIdempotencyConflictError,
   MissionLedgerStaleLeaseError,
+  MissionLedgerStaleOccurrenceError,
   MissionLedgerStaleRevisionError,
 } from "../src/autonomy/ledger.js";
 import { ReferenceMemoryMissionLedgerStore } from "../src/autonomy/reference-store.js";
@@ -318,6 +319,171 @@ describe("portable autonomy mission ledger", () => {
       await store.readOccurrence(wake.occurrence.occurrence_id),
       reclaimed.occurrence,
     );
+  });
+
+  test("consumes a claimed wake with the mission transition and records its replacement", async () => {
+    const authority = new MutableMissionLeaseAuthority(BASE_TIME);
+    const store = new ReferenceMemoryMissionLedgerStore({
+      lease_authority: authority,
+    });
+    const ledger = new MissionLedger({ store });
+    const run = runReceipt("run-consume-wake", "subject-consume-wake");
+    const plan = missionPlan(run, "mission-consume-wake");
+    const wake = createMissionWake({
+      created_at: "2026-07-16T11:00:00.000Z",
+      due_at: "2026-07-16T11:30:00.000Z",
+      generation: 1,
+      misfire_policy: "coalesce_once",
+      mission_ref: plan.mission_ref,
+      mission_revision: plan.mission_revision,
+      wake_condition_ref: "wake/consume",
+    });
+    await ledger.initialize({
+      event: eventContext("2026-07-16T11:00:00.000Z", "mission.created"),
+      operation_id: "create-consume-wake",
+      seed: { plan, run, wake },
+    });
+
+    const claim = {
+      fencing_token: 5,
+      generation: 2,
+      lease_expires_at: "2026-07-16T12:01:00.000Z",
+      lease_token: "scheduled-lease-consume",
+      now: BASE_TIME,
+      owner_id: "scheduler-consume",
+    };
+    const due = (await ledger.listDue(BASE_TIME, 1))[0]!;
+    const claimed = await ledger.claimDue(due, claim);
+    if (!claimed.acquired) assert.fail("expected scheduled claim");
+
+    const execution = executionFixture(run, 2);
+    const session = await execution.session;
+    authority.install(session.lease);
+    const nextWake = createMissionWake({
+      created_at: BASE_TIME,
+      due_at: "2026-07-16T13:00:00.000Z",
+      generation: 2,
+      misfire_policy: "coalesce_once",
+      mission_ref: plan.mission_ref,
+      mission_revision: plan.mission_revision,
+      wake_condition_ref: "wake/consume",
+    });
+    const input = {
+      ...transitionInput(
+        session,
+        1,
+        "consume-scheduled-wake",
+        "2026-07-16T12:00:01.000Z",
+      ),
+      occurrence_outcome: {
+        claim: {
+          fencing_token: claim.fencing_token,
+          generation: claim.generation,
+          lease_token: claim.lease_token,
+          owner_id: claim.owner_id,
+        },
+        occurrence_id: claimed.occurrence.occurrence_id,
+        state: "completed" as const,
+      },
+      wake: nextWake,
+    };
+
+    const committed = await ledger.transition(input);
+    const replay = await ledger.transition(input);
+
+    assert.equal(committed.created, true);
+    assert.equal(committed.consumed_occurrence?.state, "completed");
+    assert.equal(
+      committed.consumed_occurrence?.updated_at,
+      new Date(BASE_TIME).toISOString(),
+    );
+    assert.deepEqual(committed.occurrence, nextWake.occurrence);
+    assert.equal(
+      committed.snapshot.wake?.occurrence_ref,
+      nextWake.occurrence.occurrence_id,
+    );
+    assert.deepEqual(
+      await store.readOccurrence(claimed.occurrence.occurrence_id),
+      committed.consumed_occurrence,
+    );
+    assert.deepEqual(
+      await store.readOccurrence(nextWake.occurrence.occurrence_id),
+      nextWake.occurrence,
+    );
+    assert.equal((await ledger.listDue(BASE_TIME, 10)).length, 0);
+    assert.equal(replay.created, false);
+    assert.deepEqual(replay.consumed_occurrence, committed.consumed_occurrence);
+    assert.deepEqual(replay.snapshot, committed.snapshot);
+  });
+
+  test("rejects an expired scheduled claim without partially committing the mission", async () => {
+    const authority = new MutableMissionLeaseAuthority(BASE_TIME);
+    const store = new ReferenceMemoryMissionLedgerStore({
+      lease_authority: authority,
+    });
+    const ledger = new MissionLedger({ store });
+    const run = runReceipt("run-expired-wake", "subject-expired-wake");
+    const plan = missionPlan(run, "mission-expired-wake");
+    const wake = createMissionWake({
+      created_at: "2026-07-16T11:00:00.000Z",
+      due_at: "2026-07-16T11:30:00.000Z",
+      generation: 1,
+      misfire_policy: "coalesce_once",
+      mission_ref: plan.mission_ref,
+      mission_revision: plan.mission_revision,
+      wake_condition_ref: "wake/expired",
+    });
+    await ledger.initialize({
+      event: eventContext("2026-07-16T11:00:00.000Z", "mission.created"),
+      operation_id: "create-expired-wake",
+      seed: { plan, run, wake },
+    });
+    const claim = {
+      fencing_token: 8,
+      generation: 2,
+      lease_expires_at: "2026-07-16T12:00:30.000Z",
+      lease_token: "scheduled-lease-expired",
+      now: BASE_TIME,
+      owner_id: "scheduler-expired",
+    };
+    const due = (await ledger.listDue(BASE_TIME, 1))[0]!;
+    const claimed = await ledger.claimDue(due, claim);
+    if (!claimed.acquired) assert.fail("expected scheduled claim");
+
+    const execution = executionFixture(run, 2);
+    const session = await execution.session;
+    authority.install(session.lease);
+    authority.setObservedAt("2026-07-16T12:00:45.000Z");
+
+    await assert.rejects(
+      ledger.transition({
+        ...transitionInput(
+          session,
+          1,
+          "consume-expired-wake",
+          "2026-07-16T12:00:01.000Z",
+        ),
+        occurrence_outcome: {
+          claim: {
+            fencing_token: claim.fencing_token,
+            generation: claim.generation,
+            lease_token: claim.lease_token,
+            owner_id: claim.owner_id,
+          },
+          occurrence_id: claimed.occurrence.occurrence_id,
+          state: "completed",
+        },
+        wake: null,
+      }),
+      MissionLedgerStaleOccurrenceError,
+    );
+
+    assert.deepEqual(
+      await store.readOccurrence(claimed.occurrence.occurrence_id),
+      claimed.occurrence,
+    );
+    assert.equal((await ledger.readBySubject(run.subject_ref))?.revision, 1);
+    assert.equal((await ledger.listEvents(run.subject_ref, 0, 10)).length, 1);
   });
 
   test("retries scheduled claims after a transient snapshot revision race", async () => {

--- a/apps/slack-companion/test/command-registry.test.ts
+++ b/apps/slack-companion/test/command-registry.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSlackCommandRegistry,
+  type SlackCommandDefinition,
+} from "../src/commands/registry.js";
+
+type ParsedCommand =
+  | { name: "help" }
+  | { name: "ask"; question: string }
+  | { name: "status"; target?: string }
+  | { name: "run"; subject: string; details: string };
+
+function registry(
+  definitions: readonly SlackCommandDefinition<ParsedCommand>[] = definitionsFixture(),
+) {
+  return createSlackCommandRegistry(definitions, {
+    empty: () => ({ name: "help" }),
+    unknown: (question) => ({ name: "ask", question }),
+  });
+}
+
+test("parses canonical names and aliases through caller-owned definitions", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("status runtime-a"), {
+    name: "status",
+    target: "runtime-a",
+  });
+  assert.deepEqual(commands.parse("S runtime-b"), {
+    name: "status",
+    target: "runtime-b",
+  });
+});
+
+test("provides exact raw remainder and normalized words to pure parsers", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("run control-a  include   history"), {
+    name: "run",
+    subject: "control-a",
+    details: "include history",
+  });
+});
+
+test("delegates empty and unknown text to explicit fallbacks", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("   "), { name: "help" });
+  assert.deepEqual(commands.parse("why is this queued?"), {
+    name: "ask",
+    question: "why is this queued?",
+  });
+});
+
+test("snapshots immutable help metadata independently of caller mutation", () => {
+  const aliases = ["s"];
+  const definitions = definitionsFixture(aliases);
+  const commands = registry(definitions);
+  aliases.push("changed");
+
+  const help = commands.helpEntries();
+  assert.deepEqual(help[0], {
+    command: "status",
+    aliases: ["s"],
+    usage: "/assistant status [target]",
+    summary: "Show current status.",
+  });
+  assert.equal(Object.isFrozen(help), true);
+  assert.equal(Object.isFrozen(help[0]), true);
+  assert.equal(Object.isFrozen(help[0]?.aliases), true);
+});
+
+test("rejects ambiguous or malformed caller definitions", () => {
+  const parse = (): ParsedCommand => ({ name: "help" });
+  const definition = (command: string, aliases: readonly string[] = []) => ({
+    command,
+    aliases,
+    usage: `/assistant ${command}`,
+    summary: "Summary.",
+    parse,
+  });
+
+  assert.throws(
+    () => registry([definition("one", ["shared"]), definition("two", ["shared"])]),
+    /registered more than once/,
+  );
+  assert.throws(() => registry([definition("Upper")]), /lowercase single words/);
+  assert.throws(() => registry([definition("two words")]), /lowercase single words/);
+  assert.throws(
+    () => registry([{ ...definition("empty"), summary: "" }]),
+    /usage and summary must be non-empty/,
+  );
+});
+
+function definitionsFixture(
+  statusAliases: string[] = ["s"],
+): SlackCommandDefinition<ParsedCommand>[] {
+  return [
+    {
+      command: "status",
+      aliases: statusAliases,
+      usage: "/assistant status [target]",
+      summary: "Show current status.",
+      parse: ({ words }) => ({ name: "status", target: words[0] }),
+    },
+    {
+      command: "run",
+      usage: "/assistant run <subject> [details]",
+      summary: "Run one registered action.",
+      parse: ({ words }) => {
+        const subject = words[0];
+        if (!subject) throw new Error("run requires a subject");
+        return {
+          name: "run",
+          subject,
+          details: words.slice(1).join(" "),
+        };
+      },
+    },
+  ];
+}

--- a/apps/slack-companion/test/transport.test.ts
+++ b/apps/slack-companion/test/transport.test.ts
@@ -11,13 +11,20 @@ import type {
   InboundPayloadReceipt,
   SlackEventNormalizationInput,
   SlackEventsApiRequest,
+  SlackInvocationNormalizationInput,
+  SlackSignedInvocationRequest,
   SlackSocketModeEnvelope,
 } from "../src/transport/contracts.js";
 import {
   handleEventsApiRequest,
+  handleInteractiveRequest,
+  handleSlashCommandRequest,
   handleSocketModeRequest,
 } from "../src/transport/handler.js";
-import { StructuralSlackEventNormalizer } from "../src/transport/normalization.js";
+import {
+  StructuralSlackEventNormalizer,
+  StructuralSlackInvocationNormalizer,
+} from "../src/transport/normalization.js";
 import { evaluateSlackIngressReadiness } from "../src/transport/readiness.js";
 
 const now = new Date("2026-07-16T12:00:00.000Z");
@@ -289,6 +296,175 @@ describe("Slack transport boundary", () => {
       run_id: "run-event-1",
     });
   });
+
+  test("persists a signed slash command and durably admits it before acknowledgement", async () => {
+    const order: string[] = [];
+    const payloads = new MemoryPayloadStore(order);
+    const request = signedInvocationRequest(slashCommandBody());
+
+    const outcome = await handleSlashCommandRequest(request, requestKey(), {
+      admission: acceptingAdmission(order),
+      clock: { now: () => now },
+      normalizer: recordingInvocationNormalizer(order),
+      payloads,
+    });
+
+    assert.deepEqual(order, ["persist", "normalize", "admit"]);
+    assert.deepEqual(payloads.commitKeys, [
+      "slack:app-1:team-1:slash_command:trigger-command-1",
+    ]);
+    assert.deepEqual(outcome, {
+      command: {
+        body: "",
+        invocation: "slash_command",
+        kind: "signed_invocation_ack",
+        status_code: 200,
+      },
+      kind: "acknowledge",
+      run_id: "run-slash_command:trigger-command-1",
+    });
+  });
+
+  test("persists a signed interaction without exposing response transport fields", async () => {
+    const order: string[] = [];
+    const payloads = new MemoryPayloadStore(order);
+    const request = signedInvocationRequest(interactiveBody());
+    let admitted: SlackIngressEnvelope | undefined;
+
+    const outcome = await handleInteractiveRequest(request, requestKey(), {
+      admission: {
+        admit: async (envelope) => {
+          order.push("admit");
+          admitted = envelope;
+          return accepted(`run-${envelope.event_id}`, false);
+        },
+      },
+      clock: { now: () => now },
+      normalizer: recordingInvocationNormalizer(order),
+      payloads,
+    });
+
+    assert.deepEqual(order, ["persist", "normalize", "admit"]);
+    assert.deepEqual(outcome, {
+      command: {
+        body: "",
+        invocation: "interactive",
+        kind: "signed_invocation_ack",
+        status_code: 200,
+      },
+      kind: "acknowledge",
+      run_id: "run-interactive:trigger-action-1",
+    });
+    assert.equal(admitted?.conversation_id, "conversation-1");
+    assert.equal(admitted?.thread_id, "thread-1");
+    assert.equal(admitted?.event_type, "interactive:block_actions:approve");
+    assert.equal(JSON.stringify(admitted).includes("response_url"), false);
+  });
+
+  test("does not persist or acknowledge a malformed signed invocation", async () => {
+    const order: string[] = [];
+    const request = signedInvocationRequest("command=%2Fcerebro");
+
+    const outcome = await handleSlashCommandRequest(request, requestKey(), {
+      admission: acceptingAdmission(order),
+      clock: { now: () => now },
+      normalizer: recordingInvocationNormalizer(order),
+      payloads: new MemoryPayloadStore(order),
+    });
+
+    assert.deepEqual(order, []);
+    assert.deepEqual(outcome, {
+      kind: "no_acknowledgement",
+      reason_code: "invalid_envelope",
+      retryable: false,
+      stage: "parsing",
+    });
+  });
+
+  test("normalizes a modal interaction through a durable thread route", async () => {
+    const order: string[] = [];
+    const rawBody = new URLSearchParams({
+      payload: JSON.stringify({
+        api_app_id: "app-1",
+        callback_id: "schedule_review",
+        team: { id: "team-1" },
+        trigger_id: "trigger-modal-1",
+        type: "view_submission",
+        user: { id: "user-1" },
+      }),
+    }).toString();
+    const request = signedInvocationRequest(rawBody);
+    request.route = {
+      ...request.route,
+      conversation_id: "conversation-1",
+      thread_id: "thread-1",
+    };
+    let admitted: SlackIngressEnvelope | undefined;
+
+    const outcome = await handleInteractiveRequest(request, requestKey(), {
+      admission: {
+        admit: async (envelope) => {
+          order.push("admit");
+          admitted = envelope;
+          return accepted(`run-${envelope.event_id}`, false);
+        },
+      },
+      clock: { now: () => now },
+      normalizer: recordingInvocationNormalizer(order),
+      payloads: new MemoryPayloadStore(order),
+    });
+
+    assert.equal(outcome.kind, "acknowledge");
+    assert.equal(admitted?.conversation_id, "conversation-1");
+    assert.equal(admitted?.thread_id, "thread-1");
+    assert.equal(
+      admitted?.event_type,
+      "interactive:view_submission:schedule_review",
+    );
+  });
+
+  test("admits Socket Mode commands only after durable presence and payload storage", async () => {
+    const order: string[] = [];
+    const payload = Object.fromEntries(
+      new URLSearchParams(slashCommandBody()).entries(),
+    );
+    const envelope: SlackSocketModeEnvelope = {
+      envelope_id: "socket-command-1",
+      payload,
+      type: "slash_commands",
+    };
+
+    const outcome = await handleSocketModeRequest(
+      {
+        connection: { connection_ref: "connection-1", generation: 3 },
+        raw_body: Buffer.from(JSON.stringify(envelope)),
+        received_at: now.toISOString(),
+        route: route(),
+      },
+      {
+        admission: acceptingAdmission(order),
+        invocation_normalizer: recordingInvocationNormalizer(order),
+        normalizer: recordingNormalizer(order),
+        payloads: new MemoryPayloadStore(order),
+        presence: {
+          isActive: async () => {
+            order.push("verify");
+            return true;
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(order, ["verify", "persist", "normalize", "admit"]);
+    assert.deepEqual(outcome, {
+      command: {
+        envelope_id: "socket-command-1",
+        kind: "socket_mode_ack",
+      },
+      kind: "acknowledge",
+      run_id: "run-slash_command:trigger-command-1",
+    });
+  });
 });
 
 describe("Slack ingress readiness", () => {
@@ -380,6 +556,49 @@ function eventBody(): string {
   });
 }
 
+function slashCommandBody(): string {
+  return new URLSearchParams({
+    api_app_id: "app-1",
+    channel_id: "conversation-1",
+    command: "/cerebro",
+    response_url: "https://slack.invalid/opaque-response",
+    team_id: "team-1",
+    text: "inspect this thread",
+    trigger_id: "trigger-command-1",
+    user_id: "user-1",
+  }).toString();
+}
+
+function interactiveBody(): string {
+  return new URLSearchParams({
+    payload: JSON.stringify({
+      actions: [{ action_id: "approve", action_ts: "1" }],
+      api_app_id: "app-1",
+      container: {
+        channel_id: "conversation-1",
+        thread_ts: "thread-1",
+      },
+      response_url: "https://slack.invalid/opaque-response",
+      team: { id: "team-1" },
+      trigger_id: "trigger-action-1",
+      type: "block_actions",
+      user: { id: "user-1" },
+    }),
+  }).toString();
+}
+
+function signedInvocationRequest(rawBody: string): SlackSignedInvocationRequest {
+  const raw = Buffer.from(rawBody);
+  const key = requestKey();
+  return {
+    raw_body: raw,
+    received_at: now.toISOString(),
+    request_signature: sign(raw, timestamp, key),
+    request_timestamp: timestamp,
+    route: route(),
+  };
+}
+
 function route() {
   return {
     binding_id: "binding-1",
@@ -411,6 +630,16 @@ function recordingNormalizer(order: string[]) {
   const structural = new StructuralSlackEventNormalizer();
   return {
     normalize(input: SlackEventNormalizationInput): SlackIngressEnvelope {
+      order.push("normalize");
+      return structural.normalize(input);
+    },
+  };
+}
+
+function recordingInvocationNormalizer(order: string[]) {
+  const structural = new StructuralSlackInvocationNormalizer();
+  return {
+    normalize(input: SlackInvocationNormalizationInput): SlackIngressEnvelope {
       order.push("normalize");
       return structural.normalize(input);
     },


### PR DESCRIPTION
## Summary

- persist exact authenticated command and interaction bytes before normalization and durable admission
- acknowledge HTTP and Socket Mode requests only after resumable work is accepted
- consume leased scheduled occurrences in the same durable commit as mission progress and the optional next wake
- add a caller-owned command registry and parser with immutable help metadata, aliases, and duplicate-name rejection
- keep handlers, command catalogs, prompts, runtime adapters, credentials, and deployment configuration outside the portable application

## Validation

- 155 Slack companion tests
- TypeScript typecheck and build
- OSS, staged, commit-range, and PR metadata leak checks
- Practice Registry final gates

## Merge gate

This pull request contains the complete portable Slack intake slice. Main-branch approval remains required; no reviewer requests were added.