### PR TITLE
feat(slack): consume scheduled mission wakes atomically

### DIFF
--- a/apps/slack-companion/src/autonomy/contracts.ts
+++ b/apps/slack-companion/src/autonomy/contracts.ts
@@ -5,6 +5,7 @@ import type {
   WorkLeaseV1,
 } from "@writer/cerebro-sdk";
 import type { ExecutionSession } from "../execution/model.js";
+import type { ScheduledLeaseClaim } from "../operations/schedules.js";
 import type { MissionPlanProjectionV1 } from "../mission/model.js";
 import {
   NATIVE_MISSION_CONTRACT_ID,
@@ -80,10 +81,17 @@ export interface TransitionMissionInput {
   event: MissionLedgerEventContext;
   expected_revision: number;
   next_run?: RunReceiptV1;
+  occurrence_outcome?: MissionScheduledOccurrenceOutcome;
   operation_id: string;
   plan?: MissionPlanProjectionV1;
   session: ExecutionSession;
   wake?: MissionWakeInput | null;
+}
+
+export interface MissionScheduledOccurrenceOutcome {
+  claim: ScheduledLeaseClaim;
+  occurrence_id: string;
+  state: "completed" | "failed";
 }
 
 /**
@@ -103,6 +111,7 @@ export interface PromoteLegacyMissionInput {
 }
 
 export interface MissionTransitionResult {
+  consumed_occurrence?: ScheduledOccurrenceV1;
   created: boolean;
   event: LifecycleEventV1;
   occurrence?: ScheduledOccurrenceV1;
@@ -127,6 +136,7 @@ export interface MissionEventPageRequest {
 }
 
 export interface MissionStoredCommit {
+  consumed_occurrence?: ScheduledOccurrenceV1;
   event: LifecycleEventV1;
   intent_digest: string;
   occurrence?: ScheduledOccurrenceV1;

--- a/apps/slack-companion/src/autonomy/ledger.ts
+++ b/apps/slack-companion/src/autonomy/ledger.ts
@@ -159,6 +159,14 @@ export class MissionLedger {
         "mission transition cannot change stable mission identity",
       );
     }
+    if (input.occurrence_outcome !== undefined) {
+      validateOccurrenceOutcome(current, input.occurrence_outcome);
+      if (input.wake === undefined) {
+        throw new MissionLedgerInvariantError(
+          "a consumed wake must be cleared or replaced",
+        );
+      }
+    }
 
     const revision = current.revision + 1;
     const event = createMissionLifecycleEvent({
@@ -191,6 +199,9 @@ export class MissionLedger {
       wake,
     };
     return this.store.commitTransition({
+      ...(input.occurrence_outcome === undefined
+        ? {}
+        : { consumed_occurrence: structuredClone(input.occurrence_outcome) }),
       event,
       expected_revision: input.expected_revision,
       idempotency_key: idempotencyKey,
@@ -344,11 +355,34 @@ export class MissionLedger {
     if (stored === undefined) return undefined;
     assertMatchingIntent(stored, intentDigest);
     return {
+      consumed_occurrence: stored.consumed_occurrence,
       created: false,
       event: stored.event,
       occurrence: stored.occurrence,
       snapshot: stored.snapshot,
     };
+  }
+}
+
+function validateOccurrenceOutcome(
+  current: MissionSnapshotV1,
+  outcome: NonNullable<TransitionMissionInput["occurrence_outcome"]>,
+): void {
+  requireRef(outcome.occurrence_id, "occurrence_id");
+  requireRef(outcome.claim.lease_token, "scheduled_claim.lease_token");
+  requireRef(outcome.claim.owner_id, "scheduled_claim.owner_id");
+  requirePositiveInteger(
+    outcome.claim.fencing_token,
+    "scheduled_claim.fencing_token",
+  );
+  requirePositiveInteger(
+    outcome.claim.generation,
+    "scheduled_claim.generation",
+  );
+  if (current.wake?.occurrence_ref !== outcome.occurrence_id) {
+    throw new MissionLedgerInvariantError(
+      "scheduled occurrence does not match the current mission wake",
+    );
   }
 }
 
@@ -726,5 +760,12 @@ export class MissionLedgerOccurrenceConflictError extends Error {
   constructor() {
     super("mission scheduled occurrence changed concurrently");
     this.name = "MissionLedgerOccurrenceConflictError";
+  }
+}
+
+export class MissionLedgerStaleOccurrenceError extends Error {
+  constructor(message = "scheduled occurrence claim is stale") {
+    super(message);
+    this.name = "MissionLedgerStaleOccurrenceError";
   }
 }

--- a/apps/slack-companion/src/autonomy/ports.ts
+++ b/apps/slack-companion/src/autonomy/ports.ts
@@ -2,6 +2,7 @@ import type {
   DueMissionRecord,
   LifecycleEventV1,
   MissionEventPageRequest,
+  MissionScheduledOccurrenceOutcome,
   MissionPromotionResult,
   MissionSnapshotV1,
   MissionStoredCommit,
@@ -11,6 +12,7 @@ import type {
 } from "./contracts.js";
 
 export interface MissionAtomicCommit {
+  consumed_occurrence?: MissionScheduledOccurrenceOutcome;
   event: LifecycleEventV1;
   expected_revision: number;
   idempotency_key: string;
@@ -55,8 +57,9 @@ export interface LegacyMissionAtomicCommit extends MissionAtomicCommit {
  */
 export interface DurableMissionLedgerPort {
   /**
-   * Atomically verifies an exact active execution lease at authority-owned time
-   * and commits the snapshot, event, and optional scheduled work item.
+   * Atomically verifies the active execution lease and optional scheduled
+   * occurrence claim at authority-owned time, then commits the consumed
+   * occurrence, snapshot, event, and optional next scheduled work item.
    */
   commitTransition(
     commit: MissionAtomicCommit,

--- a/apps/slack-companion/src/autonomy/reference-store.ts
+++ b/apps/slack-companion/src/autonomy/reference-store.ts
@@ -24,10 +24,14 @@ import {
   MissionLedgerInvariantError,
   MissionLedgerOccurrenceConflictError,
   MissionLedgerStaleLeaseError,
+  MissionLedgerStaleOccurrenceError,
   MissionLedgerStaleRevisionError,
   missionSnapshotReference,
 } from "./ledger.js";
-import { acquireScheduledOccurrence } from "../operations/schedules.js";
+import {
+  acquireScheduledOccurrence,
+  updateScheduledOccurrence,
+} from "../operations/schedules.js";
 
 export interface ReferenceMemoryMissionLedgerStoreOptions {
   lease_authority?: MissionLeaseAuthorityPort;
@@ -54,6 +58,7 @@ export class ReferenceMemoryMissionLedgerStore
     const prior = this.requireIdempotentCommit(commit);
     if (prior !== undefined) {
       return {
+        consumed_occurrence: prior.consumed_occurrence,
         created: false,
         event: prior.event,
         occurrence: prior.occurrence,
@@ -79,6 +84,11 @@ export class ReferenceMemoryMissionLedgerStore
   ): Promise<MissionPromotionResult> {
     requireRef(commit.adapter_ref, "adapter_ref");
     requireRef(commit.source_ref, "source_ref");
+    if (commit.consumed_occurrence !== undefined) {
+      throw new MissionLedgerInvariantError(
+        "legacy promotion cannot consume scheduled mission work",
+      );
+    }
     const prior = this.requireIdempotentCommit(commit);
     if (prior !== undefined) {
       return {
@@ -100,8 +110,12 @@ export class ReferenceMemoryMissionLedgerStore
       return { created: false, snapshot: clone(current) };
     }
 
-    this.validateCommit(commit, undefined, undefined);
-    this.applyCommit(commit);
+    const consumedOccurrence = this.validateCommit(
+      commit,
+      undefined,
+      undefined,
+    );
+    this.applyCommit(commit, consumedOccurrence);
     return {
       created: true,
       event: clone(commit.event),
@@ -231,6 +245,7 @@ export class ReferenceMemoryMissionLedgerStore
     const prior = this.requireIdempotentCommit(commit);
     if (prior !== undefined) {
       return {
+        consumed_occurrence: prior.consumed_occurrence,
         created: false,
         event: prior.event,
         occurrence: prior.occurrence,
@@ -238,9 +253,14 @@ export class ReferenceMemoryMissionLedgerStore
       };
     }
     const current = this.snapshots.get(commit.snapshot.subject_ref);
-    this.validateCommit(commit, current, authoritative);
-    this.applyCommit(commit);
+    const consumedOccurrence = this.validateCommit(
+      commit,
+      current,
+      authoritative,
+    );
+    this.applyCommit(commit, consumedOccurrence);
     return {
+      consumed_occurrence: cloneOptional(consumedOccurrence),
       created: true,
       event: clone(commit.event),
       occurrence: cloneOptional(commit.occurrence),
@@ -252,7 +272,7 @@ export class ReferenceMemoryMissionLedgerStore
     commit: MissionAtomicCommit,
     current: MissionSnapshotV1 | undefined,
     authoritative: AuthoritativeMissionLeaseRead | undefined,
-  ): void {
+  ): ScheduledOccurrenceV1 | undefined {
     const { event, snapshot } = commit;
     requireRef(commit.idempotency_key, "idempotency_key");
     requireRef(commit.intent_digest, "intent_digest");
@@ -324,6 +344,39 @@ export class ReferenceMemoryMissionLedgerStore
       );
     }
     this.validateOccurrence(commit);
+    return this.validateConsumedOccurrence(commit, current, authoritative);
+  }
+
+  private validateConsumedOccurrence(
+    commit: MissionAtomicCommit,
+    current: MissionSnapshotV1 | undefined,
+    authoritative: AuthoritativeMissionLeaseRead | undefined,
+  ): ScheduledOccurrenceV1 | undefined {
+    const outcome = commit.consumed_occurrence;
+    if (outcome === undefined) return undefined;
+    if (
+      current === undefined ||
+      authoritative === undefined ||
+      current.wake?.occurrence_ref !== outcome.occurrence_id ||
+      commit.occurrence?.occurrence_id === outcome.occurrence_id
+    ) {
+      throw new MissionLedgerStaleOccurrenceError();
+    }
+
+    const occurrence = this.occurrences.get(outcome.occurrence_id);
+    if (occurrence === undefined) {
+      throw new MissionLedgerStaleOccurrenceError();
+    }
+    const consumed = updateScheduledOccurrence(
+      occurrence,
+      outcome.claim,
+      outcome.state,
+      authoritative.observed_at,
+    );
+    if (consumed === undefined) {
+      throw new MissionLedgerStaleOccurrenceError();
+    }
+    return consumed;
   }
 
   private validateOccurrence(commit: MissionAtomicCommit): void {
@@ -400,10 +453,17 @@ export class ReferenceMemoryMissionLedgerStore
     }
   }
 
-  private applyCommit(commit: MissionAtomicCommit): void {
+  private applyCommit(
+    commit: MissionAtomicCommit,
+    consumedOccurrence: ScheduledOccurrenceV1 | undefined,
+  ): void {
     const snapshot = clone(commit.snapshot);
     const event = clone(commit.event);
     const occurrence = cloneOptional(commit.occurrence);
+    const consumed = cloneOptional(consumedOccurrence);
+    if (consumed !== undefined) {
+      this.occurrences.set(consumed.occurrence_id, consumed);
+    }
     if (occurrence !== undefined) {
       this.occurrences.set(occurrence.occurrence_id, occurrence);
     }
@@ -414,6 +474,7 @@ export class ReferenceMemoryMissionLedgerStore
       event,
     ]);
     this.commits.set(commit.idempotency_key, {
+      consumed_occurrence: consumed,
       event,
       intent_digest: commit.intent_digest,
       occurrence,

--- a/apps/slack-companion/src/commands/registry.ts
+++ b/apps/slack-companion/src/commands/registry.ts
@@ -1,0 +1,130 @@
+export interface SlackCommandParseInput {
+  readonly rawRest: string;
+  readonly words: readonly string[];
+}
+
+export interface SlackCommandDefinition<Result> {
+  readonly command: string;
+  readonly aliases?: readonly string[];
+  readonly usage: string;
+  readonly summary: string;
+  readonly parse: (input: SlackCommandParseInput) => Result;
+}
+
+export interface SlackCommandHelpEntry {
+  readonly command: string;
+  readonly aliases: readonly string[];
+  readonly usage: string;
+  readonly summary: string;
+}
+
+export interface SlackCommandFallbacks<Result> {
+  readonly empty: () => Result;
+  readonly unknown: (text: string) => Result;
+}
+
+export interface SlackCommandRegistry<Result> {
+  readonly parse: (text: string) => Result;
+  readonly helpEntries: () => readonly SlackCommandHelpEntry[];
+}
+
+interface RegisteredCommand<Result> extends SlackCommandHelpEntry {
+  readonly parse: (input: SlackCommandParseInput) => Result;
+}
+
+const COMMAND_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
+
+/**
+ * Creates a portable command parser from caller-owned command definitions.
+ *
+ * The registry performs no I/O and does not own command handlers. Parse
+ * callbacks must also be pure so transport admission and execution remain
+ * separate durability boundaries.
+ */
+export function createSlackCommandRegistry<Result>(
+  definitions: readonly SlackCommandDefinition<Result>[],
+  fallbacks: SlackCommandFallbacks<Result>,
+): SlackCommandRegistry<Result> {
+  const registered = definitions.map(snapshotDefinition);
+  const lookup = buildLookup(registered);
+  const help = Object.freeze(
+    registered.map((definition) =>
+      Object.freeze({
+        command: definition.command,
+        aliases: definition.aliases,
+        usage: definition.usage,
+        summary: definition.summary,
+      }),
+    ),
+  );
+
+  return Object.freeze({
+    parse(text: string): Result {
+      const trimmed = text.trim();
+      if (!trimmed) return fallbacks.empty();
+
+      const { head, tail } = splitHead(trimmed);
+      const definition = lookup.get(head.toLowerCase());
+      if (!definition) return fallbacks.unknown(trimmed);
+
+      return definition.parse(
+        Object.freeze({
+          rawRest: tail,
+          words: Object.freeze(tail ? tail.split(/\s+/) : []),
+        }),
+      );
+    },
+    helpEntries(): readonly SlackCommandHelpEntry[] {
+      return help;
+    },
+  });
+}
+
+function snapshotDefinition<Result>(
+  definition: SlackCommandDefinition<Result>,
+): RegisteredCommand<Result> {
+  validateName(definition.command);
+  for (const alias of definition.aliases ?? []) validateName(alias);
+  if (!definition.usage.trim() || !definition.summary.trim()) {
+    throw new Error("command registry usage and summary must be non-empty");
+  }
+
+  return Object.freeze({
+    command: definition.command,
+    aliases: Object.freeze([...(definition.aliases ?? [])]),
+    usage: definition.usage,
+    summary: definition.summary,
+    parse: definition.parse,
+  });
+}
+
+function buildLookup<Result>(
+  definitions: readonly RegisteredCommand<Result>[],
+): ReadonlyMap<string, RegisteredCommand<Result>> {
+  const lookup = new Map<string, RegisteredCommand<Result>>();
+  for (const definition of definitions) {
+    for (const name of [definition.command, ...definition.aliases]) {
+      const normalized = name.toLowerCase();
+      if (lookup.has(normalized)) {
+        throw new Error("command registry name is registered more than once");
+      }
+      lookup.set(normalized, definition);
+    }
+  }
+  return lookup;
+}
+
+function validateName(name: string): void {
+  if (!COMMAND_NAME_PATTERN.test(name)) {
+    throw new Error("command registry names must be lowercase single words");
+  }
+}
+
+function splitHead(text: string): { head: string; tail: string } {
+  const splitAt = text.search(/\s/);
+  if (splitAt === -1) return { head: text, tail: "" };
+  return {
+    head: text.slice(0, splitAt),
+    tail: text.slice(splitAt).trimStart(),
+  };
+}

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -7,6 +7,7 @@ export * from "./assistance/contracts.js";
 export * from "./assistance/coordinator.js";
 export * from "./assistance/ports.js";
 export * from "./contracts.js";
+export * from "./commands/registry.js";
 export * from "./delivery/contracts.js";
 export * from "./delivery/coordinator.js";
 export * from "./delivery/ports.js";

--- a/apps/slack-companion/test/autonomy-mission-runtime.test.ts
+++ b/apps/slack-companion/test/autonomy-mission-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   MissionLedger,
   MissionLedgerIdempotencyConflictError,
   MissionLedgerStaleLeaseError,
+  MissionLedgerStaleOccurrenceError,
   MissionLedgerStaleRevisionError,
 } from "../src/autonomy/ledger.js";
 import { ReferenceMemoryMissionLedgerStore } from "../src/autonomy/reference-store.js";
@@ -318,6 +319,171 @@ describe("portable autonomy mission ledger", () => {
       await store.readOccurrence(wake.occurrence.occurrence_id),
       reclaimed.occurrence,
     );
+  });
+
+  test("consumes a claimed wake with the mission transition and records its replacement", async () => {
+    const authority = new MutableMissionLeaseAuthority(BASE_TIME);
+    const store = new ReferenceMemoryMissionLedgerStore({
+      lease_authority: authority,
+    });
+    const ledger = new MissionLedger({ store });
+    const run = runReceipt("run-consume-wake", "subject-consume-wake");
+    const plan = missionPlan(run, "mission-consume-wake");
+    const wake = createMissionWake({
+      created_at: "2026-07-16T11:00:00.000Z",
+      due_at: "2026-07-16T11:30:00.000Z",
+      generation: 1,
+      misfire_policy: "coalesce_once",
+      mission_ref: plan.mission_ref,
+      mission_revision: plan.mission_revision,
+      wake_condition_ref: "wake/consume",
+    });
+    await ledger.initialize({
+      event: eventContext("2026-07-16T11:00:00.000Z", "mission.created"),
+      operation_id: "create-consume-wake",
+      seed: { plan, run, wake },
+    });
+
+    const claim = {
+      fencing_token: 5,
+      generation: 2,
+      lease_expires_at: "2026-07-16T12:01:00.000Z",
+      lease_token: "scheduled-lease-consume",
+      now: BASE_TIME,
+      owner_id: "scheduler-consume",
+    };
+    const due = (await ledger.listDue(BASE_TIME, 1))[0]!;
+    const claimed = await ledger.claimDue(due, claim);
+    if (!claimed.acquired) assert.fail("expected scheduled claim");
+
+    const execution = executionFixture(run, 2);
+    const session = await execution.session;
+    authority.install(session.lease);
+    const nextWake = createMissionWake({
+      created_at: BASE_TIME,
+      due_at: "2026-07-16T13:00:00.000Z",
+      generation: 2,
+      misfire_policy: "coalesce_once",
+      mission_ref: plan.mission_ref,
+      mission_revision: plan.mission_revision,
+      wake_condition_ref: "wake/consume",
+    });
+    const input = {
+      ...transitionInput(
+        session,
+        1,
+        "consume-scheduled-wake",
+        "2026-07-16T12:00:01.000Z",
+      ),
+      occurrence_outcome: {
+        claim: {
+          fencing_token: claim.fencing_token,
+          generation: claim.generation,
+          lease_token: claim.lease_token,
+          owner_id: claim.owner_id,
+        },
+        occurrence_id: claimed.occurrence.occurrence_id,
+        state: "completed" as const,
+      },
+      wake: nextWake,
+    };
+
+    const committed = await ledger.transition(input);
+    const replay = await ledger.transition(input);
+
+    assert.equal(committed.created, true);
+    assert.equal(committed.consumed_occurrence?.state, "completed");
+    assert.equal(
+      committed.consumed_occurrence?.updated_at,
+      new Date(BASE_TIME).toISOString(),
+    );
+    assert.deepEqual(committed.occurrence, nextWake.occurrence);
+    assert.equal(
+      committed.snapshot.wake?.occurrence_ref,
+      nextWake.occurrence.occurrence_id,
+    );
+    assert.deepEqual(
+      await store.readOccurrence(claimed.occurrence.occurrence_id),
+      committed.consumed_occurrence,
+    );
+    assert.deepEqual(
+      await store.readOccurrence(nextWake.occurrence.occurrence_id),
+      nextWake.occurrence,
+    );
+    assert.equal((await ledger.listDue(BASE_TIME, 10)).length, 0);
+    assert.equal(replay.created, false);
+    assert.deepEqual(replay.consumed_occurrence, committed.consumed_occurrence);
+    assert.deepEqual(replay.snapshot, committed.snapshot);
+  });
+
+  test("rejects an expired scheduled claim without partially committing the mission", async () => {
+    const authority = new MutableMissionLeaseAuthority(BASE_TIME);
+    const store = new ReferenceMemoryMissionLedgerStore({
+      lease_authority: authority,
+    });
+    const ledger = new MissionLedger({ store });
+    const run = runReceipt("run-expired-wake", "subject-expired-wake");
+    const plan = missionPlan(run, "mission-expired-wake");
+    const wake = createMissionWake({
+      created_at: "2026-07-16T11:00:00.000Z",
+      due_at: "2026-07-16T11:30:00.000Z",
+      generation: 1,
+      misfire_policy: "coalesce_once",
+      mission_ref: plan.mission_ref,
+      mission_revision: plan.mission_revision,
+      wake_condition_ref: "wake/expired",
+    });
+    await ledger.initialize({
+      event: eventContext("2026-07-16T11:00:00.000Z", "mission.created"),
+      operation_id: "create-expired-wake",
+      seed: { plan, run, wake },
+    });
+    const claim = {
+      fencing_token: 8,
+      generation: 2,
+      lease_expires_at: "2026-07-16T12:00:30.000Z",
+      lease_token: "scheduled-lease-expired",
+      now: BASE_TIME,
+      owner_id: "scheduler-expired",
+    };
+    const due = (await ledger.listDue(BASE_TIME, 1))[0]!;
+    const claimed = await ledger.claimDue(due, claim);
+    if (!claimed.acquired) assert.fail("expected scheduled claim");
+
+    const execution = executionFixture(run, 2);
+    const session = await execution.session;
+    authority.install(session.lease);
+    authority.setObservedAt("2026-07-16T12:00:45.000Z");
+
+    await assert.rejects(
+      ledger.transition({
+        ...transitionInput(
+          session,
+          1,
+          "consume-expired-wake",
+          "2026-07-16T12:00:01.000Z",
+        ),
+        occurrence_outcome: {
+          claim: {
+            fencing_token: claim.fencing_token,
+            generation: claim.generation,
+            lease_token: claim.lease_token,
+            owner_id: claim.owner_id,
+          },
+          occurrence_id: claimed.occurrence.occurrence_id,
+          state: "completed",
+        },
+        wake: null,
+      }),
+      MissionLedgerStaleOccurrenceError,
+    );
+
+    assert.deepEqual(
+      await store.readOccurrence(claimed.occurrence.occurrence_id),
+      claimed.occurrence,
+    );
+    assert.equal((await ledger.readBySubject(run.subject_ref))?.revision, 1);
+    assert.equal((await ledger.listEvents(run.subject_ref, 0, 10)).length, 1);
   });
 
   test("retries scheduled claims after a transient snapshot revision race", async () => {

--- a/apps/slack-companion/test/command-registry.test.ts
+++ b/apps/slack-companion/test/command-registry.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSlackCommandRegistry,
+  type SlackCommandDefinition,
+} from "../src/commands/registry.js";
+
+type ParsedCommand =
+  | { name: "help" }
+  | { name: "ask"; question: string }
+  | { name: "status"; target?: string }
+  | { name: "run"; subject: string; details: string };
+
+function registry(
+  definitions: readonly SlackCommandDefinition<ParsedCommand>[] = definitionsFixture(),
+) {
+  return createSlackCommandRegistry(definitions, {
+    empty: () => ({ name: "help" }),
+    unknown: (question) => ({ name: "ask", question }),
+  });
+}
+
+test("parses canonical names and aliases through caller-owned definitions", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("status runtime-a"), {
+    name: "status",
+    target: "runtime-a",
+  });
+  assert.deepEqual(commands.parse("S runtime-b"), {
+    name: "status",
+    target: "runtime-b",
+  });
+});
+
+test("provides exact raw remainder and normalized words to pure parsers", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("run control-a  include   history"), {
+    name: "run",
+    subject: "control-a",
+    details: "include history",
+  });
+});
+
+test("delegates empty and unknown text to explicit fallbacks", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("   "), { name: "help" });
+  assert.deepEqual(commands.parse("why is this queued?"), {
+    name: "ask",
+    question: "why is this queued?",
+  });
+});
+
+test("snapshots immutable help metadata independently of caller mutation", () => {
+  const aliases = ["s"];
+  const definitions = definitionsFixture(aliases);
+  const commands = registry(definitions);
+  aliases.push("changed");
+
+  const help = commands.helpEntries();
+  assert.deepEqual(help[0], {
+    command: "status",
+    aliases: ["s"],
+    usage: "/assistant status [target]",
+    summary: "Show current status.",
+  });
+  assert.equal(Object.isFrozen(help), true);
+  assert.equal(Object.isFrozen(help[0]), true);
+  assert.equal(Object.isFrozen(help[0]?.aliases), true);
+});
+
+test("rejects ambiguous or malformed caller definitions", () => {
+  const parse = (): ParsedCommand => ({ name: "help" });
+  const definition = (command: string, aliases: readonly string[] = []) => ({
+    command,
+    aliases,
+    usage: `/assistant ${command}`,
+    summary: "Summary.",
+    parse,
+  });
+
+  assert.throws(
+    () => registry([definition("one", ["shared"]), definition("two", ["shared"])]),
+    /registered more than once/,
+  );
+  assert.throws(() => registry([definition("Upper")]), /lowercase single words/);
+  assert.throws(() => registry([definition("two words")]), /lowercase single words/);
+  assert.throws(
+    () => registry([{ ...definition("empty"), summary: "" }]),
+    /usage and summary must be non-empty/,
+  );
+});
+
+function definitionsFixture(
+  statusAliases: string[] = ["s"],
+): SlackCommandDefinition<ParsedCommand>[] {
+  return [
+    {
+      command: "status",
+      aliases: statusAliases,
+      usage: "/assistant status [target]",
+      summary: "Show current status.",
+      parse: ({ words }) => ({ name: "status", target: words[0] }),
+    },
+    {
+      command: "run",
+      usage: "/assistant run <subject> [details]",
+      summary: "Run one registered action.",
+      parse: ({ words }) => {
+        const subject = words[0];
+        if (!subject) throw new Error("run requires a subject");
+        return {
+          name: "run",
+          subject,
+          details: words.slice(1).join(" "),
+        };
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- consume a leased scheduled mission occurrence in the same durable commit as the mission snapshot, lifecycle event, and optional next wake
- validate the exact schedule claim at authority-owned time and return the terminal occurrence on exact replay
- cover successful replacement and expired-claim rollback with portable conformance tests

## Why

A completed wake must not become queueable again after its lease expires. This commit makes occurrence completion and mission progress one atomic durability boundary.

## Validation

- npm run check --workspace @writer/cerebro-slack-companion
- make oss-audit
- Practice Registry final gate
- staged and commit-range leak checks

## Stack

Depends on #1971.