### PR TITLE
feat(slack): add portable command registry

### DIFF
--- a/apps/slack-companion/src/commands/registry.ts
+++ b/apps/slack-companion/src/commands/registry.ts
@@ -1,0 +1,130 @@
+export interface SlackCommandParseInput {
+  readonly rawRest: string;
+  readonly words: readonly string[];
+}
+
+export interface SlackCommandDefinition<Result> {
+  readonly command: string;
+  readonly aliases?: readonly string[];
+  readonly usage: string;
+  readonly summary: string;
+  readonly parse: (input: SlackCommandParseInput) => Result;
+}
+
+export interface SlackCommandHelpEntry {
+  readonly command: string;
+  readonly aliases: readonly string[];
+  readonly usage: string;
+  readonly summary: string;
+}
+
+export interface SlackCommandFallbacks<Result> {
+  readonly empty: () => Result;
+  readonly unknown: (text: string) => Result;
+}
+
+export interface SlackCommandRegistry<Result> {
+  readonly parse: (text: string) => Result;
+  readonly helpEntries: () => readonly SlackCommandHelpEntry[];
+}
+
+interface RegisteredCommand<Result> extends SlackCommandHelpEntry {
+  readonly parse: (input: SlackCommandParseInput) => Result;
+}
+
+const COMMAND_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
+
+/**
+ * Creates a portable command parser from caller-owned command definitions.
+ *
+ * The registry performs no I/O and does not own command handlers. Parse
+ * callbacks must also be pure so transport admission and execution remain
+ * separate durability boundaries.
+ */
+export function createSlackCommandRegistry<Result>(
+  definitions: readonly SlackCommandDefinition<Result>[],
+  fallbacks: SlackCommandFallbacks<Result>,
+): SlackCommandRegistry<Result> {
+  const registered = definitions.map(snapshotDefinition);
+  const lookup = buildLookup(registered);
+  const help = Object.freeze(
+    registered.map((definition) =>
+      Object.freeze({
+        command: definition.command,
+        aliases: definition.aliases,
+        usage: definition.usage,
+        summary: definition.summary,
+      }),
+    ),
+  );
+
+  return Object.freeze({
+    parse(text: string): Result {
+      const trimmed = text.trim();
+      if (!trimmed) return fallbacks.empty();
+
+      const { head, tail } = splitHead(trimmed);
+      const definition = lookup.get(head.toLowerCase());
+      if (!definition) return fallbacks.unknown(trimmed);
+
+      return definition.parse(
+        Object.freeze({
+          rawRest: tail,
+          words: Object.freeze(tail ? tail.split(/\s+/) : []),
+        }),
+      );
+    },
+    helpEntries(): readonly SlackCommandHelpEntry[] {
+      return help;
+    },
+  });
+}
+
+function snapshotDefinition<Result>(
+  definition: SlackCommandDefinition<Result>,
+): RegisteredCommand<Result> {
+  validateName(definition.command);
+  for (const alias of definition.aliases ?? []) validateName(alias);
+  if (!definition.usage.trim() || !definition.summary.trim()) {
+    throw new Error("command registry usage and summary must be non-empty");
+  }
+
+  return Object.freeze({
+    command: definition.command,
+    aliases: Object.freeze([...(definition.aliases ?? [])]),
+    usage: definition.usage,
+    summary: definition.summary,
+    parse: definition.parse,
+  });
+}
+
+function buildLookup<Result>(
+  definitions: readonly RegisteredCommand<Result>[],
+): ReadonlyMap<string, RegisteredCommand<Result>> {
+  const lookup = new Map<string, RegisteredCommand<Result>>();
+  for (const definition of definitions) {
+    for (const name of [definition.command, ...definition.aliases]) {
+      const normalized = name.toLowerCase();
+      if (lookup.has(normalized)) {
+        throw new Error("command registry name is registered more than once");
+      }
+      lookup.set(normalized, definition);
+    }
+  }
+  return lookup;
+}
+
+function validateName(name: string): void {
+  if (!COMMAND_NAME_PATTERN.test(name)) {
+    throw new Error("command registry names must be lowercase single words");
+  }
+}
+
+function splitHead(text: string): { head: string; tail: string } {
+  const splitAt = text.search(/\s/);
+  if (splitAt === -1) return { head: text, tail: "" };
+  return {
+    head: text.slice(0, splitAt),
+    tail: text.slice(splitAt).trimStart(),
+  };
+}

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -7,6 +7,7 @@ export * from "./assistance/contracts.js";
 export * from "./assistance/coordinator.js";
 export * from "./assistance/ports.js";
 export * from "./contracts.js";
+export * from "./commands/registry.js";
 export * from "./delivery/contracts.js";
 export * from "./delivery/coordinator.js";
 export * from "./delivery/ports.js";

--- a/apps/slack-companion/test/command-registry.test.ts
+++ b/apps/slack-companion/test/command-registry.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSlackCommandRegistry,
+  type SlackCommandDefinition,
+} from "../src/commands/registry.js";
+
+type ParsedCommand =
+  | { name: "help" }
+  | { name: "ask"; question: string }
+  | { name: "status"; target?: string }
+  | { name: "run"; subject: string; details: string };
+
+function registry(
+  definitions: readonly SlackCommandDefinition<ParsedCommand>[] = definitionsFixture(),
+) {
+  return createSlackCommandRegistry(definitions, {
+    empty: () => ({ name: "help" }),
+    unknown: (question) => ({ name: "ask", question }),
+  });
+}
+
+test("parses canonical names and aliases through caller-owned definitions", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("status runtime-a"), {
+    name: "status",
+    target: "runtime-a",
+  });
+  assert.deepEqual(commands.parse("S runtime-b"), {
+    name: "status",
+    target: "runtime-b",
+  });
+});
+
+test("provides exact raw remainder and normalized words to pure parsers", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("run control-a  include   history"), {
+    name: "run",
+    subject: "control-a",
+    details: "include history",
+  });
+});
+
+test("delegates empty and unknown text to explicit fallbacks", () => {
+  const commands = registry();
+
+  assert.deepEqual(commands.parse("   "), { name: "help" });
+  assert.deepEqual(commands.parse("why is this queued?"), {
+    name: "ask",
+    question: "why is this queued?",
+  });
+});
+
+test("snapshots immutable help metadata independently of caller mutation", () => {
+  const aliases = ["s"];
+  const definitions = definitionsFixture(aliases);
+  const commands = registry(definitions);
+  aliases.push("changed");
+
+  const help = commands.helpEntries();
+  assert.deepEqual(help[0], {
+    command: "status",
+    aliases: ["s"],
+    usage: "/assistant status [target]",
+    summary: "Show current status.",
+  });
+  assert.equal(Object.isFrozen(help), true);
+  assert.equal(Object.isFrozen(help[0]), true);
+  assert.equal(Object.isFrozen(help[0]?.aliases), true);
+});
+
+test("rejects ambiguous or malformed caller definitions", () => {
+  const parse = (): ParsedCommand => ({ name: "help" });
+  const definition = (command: string, aliases: readonly string[] = []) => ({
+    command,
+    aliases,
+    usage: `/assistant ${command}`,
+    summary: "Summary.",
+    parse,
+  });
+
+  assert.throws(
+    () => registry([definition("one", ["shared"]), definition("two", ["shared"])]),
+    /registered more than once/,
+  );
+  assert.throws(() => registry([definition("Upper")]), /lowercase single words/);
+  assert.throws(() => registry([definition("two words")]), /lowercase single words/);
+  assert.throws(
+    () => registry([{ ...definition("empty"), summary: "" }]),
+    /usage and summary must be non-empty/,
+  );
+});
+
+function definitionsFixture(
+  statusAliases: string[] = ["s"],
+): SlackCommandDefinition<ParsedCommand>[] {
+  return [
+    {
+      command: "status",
+      aliases: statusAliases,
+      usage: "/assistant status [target]",
+      summary: "Show current status.",
+      parse: ({ words }) => ({ name: "status", target: words[0] }),
+    },
+    {
+      command: "run",
+      usage: "/assistant run <subject> [details]",
+      summary: "Run one registered action.",
+      parse: ({ words }) => {
+        const subject = words[0];
+        if (!subject) throw new Error("run requires a subject");
+        return {
+          name: "run",
+          subject,
+          details: words.slice(1).join(" "),
+        };
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- add a generic caller-owned Slack command registry and parser
- keep command handlers, catalogs, prompts, and runtime adapters outside the portable package
- snapshot immutable help metadata and reject ambiguous command names
- cover canonical names, aliases, raw input, normalized words, fallbacks, immutability, and invalid definitions

## Validation

- 155 Slack companion tests
- TypeScript typecheck and build
- OSS and staged leak checks
- Practice Registry final gate

## Stack

Depends on #1973.
