### PR TITLE
ci: make application checks path-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             python3 scripts/app_ci_scope.py --all --github-output "${GITHUB_OUTPUT}" </dev/null
             exit 0
           fi
-          git diff --name-only --no-renames --diff-filter=ACMRD -z "${BASE_SHA}" "${HEAD_SHA}" \
+          git diff --name-only --no-renames -z "${BASE_SHA}" "${HEAD_SHA}" \
             | python3 scripts/app_ci_scope.py --null --github-output "${GITHUB_OUTPUT}"
 
   app-workspace-contract:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           cache: npm
 
       - name: Audit JavaScript workspace dependencies
-        run: npm audit --audit-level=high
+        run: npm audit --omit=dev --audit-level=moderate
 
   verify-shard:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,136 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ci-scope:
+    name: scope
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.select.outputs.core }}
+      sdk: ${{ steps.select.outputs.sdk }}
+      slack: ${{ steps.select.outputs.slack }}
+      web: ${{ steps.select.outputs.web }}
+      web_image: ${{ steps.select.outputs.web_image }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Select CI scopes
+        id: select
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            python3 scripts/app_ci_scope.py --all --github-output "${GITHUB_OUTPUT}" </dev/null
+            exit 0
+          fi
+          git diff --name-only --diff-filter=ACMR -z "${BASE_SHA}" "${HEAD_SHA}" \
+            | python3 scripts/app_ci_scope.py --null --github-output "${GITHUB_OUTPUT}"
+
+  app-workspace-contract:
+    runs-on: ubuntu-latest
+    needs: ci-scope
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check application workspace ownership
+        run: make app-workspace-check
+
+  web:
+    runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.web == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install JavaScript workspaces
+        run: npm ci
+
+      - name: Check web workspace
+        run: npm run check --workspace @writer/cerebro-web
+
+      - name: Build and smoke web workspace
+        run: |
+          npm run build --workspace @writer/cerebro-web
+          npm run smoke:standalone --workspace @writer/cerebro-web -- --skip-build
+
+  web-image:
+    runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.web_image == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build and smoke web image
+        run: DOCKER_BUILD='docker buildx build --load' DOCKER_BUILD_CACHE_ARGS='--cache-from type=gha,scope=cerebro-web-ci --cache-to type=gha,mode=max,ignore-error=true,scope=cerebro-web-ci' make web-docker-smoke
+
+  slack-companion:
+    runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.slack == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install JavaScript workspaces
+        run: npm ci
+
+      - name: Check Slack companion workspace
+        run: npm run check --workspace @writer/cerebro-slack-companion
+
+  typescript-sdk:
+    runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.sdk == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install JavaScript workspaces
+        run: npm ci
+
+      - name: Check TypeScript SDK workspace
+        run: npm run check --workspace @writer/cerebro-sdk
+
+  javascript-dependency-audit:
+    runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.web == 'true' || needs.ci-scope.outputs.slack == 'true' || needs.ci-scope.outputs.sdk == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Audit JavaScript workspace dependencies
+        run: npm audit --audit-level=high
+
   verify-shard:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.core == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -25,8 +152,6 @@ jobs:
             command: make cover
           - name: sdk
             command: make sdk-test
-          - name: workspace
-            command: make workspace-check workspace-build
           - name: sdk-dependency-audit
             command: make sdk-dependency-audit
           - name: script-test
@@ -57,8 +182,6 @@ jobs:
             command: make release-smoke
           - name: docker-smoke
             command: DOCKER_BUILD='docker buildx build --load' DOCKER_BUILD_CACHE_ARGS='--cache-from type=gha --cache-to type=gha,mode=max,ignore-error=true' make docker-smoke
-          - name: web-docker-smoke
-            command: DOCKER_BUILD='docker buildx build --load' DOCKER_BUILD_CACHE_ARGS='--cache-from type=gha,scope=cerebro-web-ci --cache-to type=gha,mode=max,ignore-error=true,scope=cerebro-web-ci' make web-docker-smoke
           - name: structural
             command: make check-structural check-structural-test check-arch
     steps:
@@ -128,7 +251,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-go-v2-
 
       - name: Set up Docker Buildx
-        if: matrix.name == 'docker-smoke' || matrix.name == 'web-docker-smoke'
+        if: matrix.name == 'docker-smoke'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Run ${{ matrix.name }}
@@ -137,6 +260,8 @@ jobs:
   go-lint-shard:
     name: lint-${{ matrix.name }}
     runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.core == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -231,6 +356,8 @@ jobs:
   catalog-shard:
     name: catalog-${{ matrix.name }}
     runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.core == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -269,6 +396,8 @@ jobs:
   go-test-shard:
     name: test-${{ matrix.shard_index }}
     runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.core == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -306,6 +435,8 @@ jobs:
   go-race-shard:
     name: race-${{ matrix.shard_index }}
     runs-on: ubuntu-latest
+    needs: ci-scope
+    if: needs.ci-scope.outputs.core == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -342,8 +473,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [go-test-shard]
-    if: always()
+    needs: [ci-scope, go-test-shard]
+    if: always() && needs.ci-scope.outputs.core == 'true'
     steps:
       - name: Check Go test shards
         run: |
@@ -355,8 +486,8 @@ jobs:
 
   race:
     runs-on: ubuntu-latest
-    needs: [go-race-shard]
-    if: always()
+    needs: [ci-scope, go-race-shard]
+    if: always() && needs.ci-scope.outputs.core == 'true'
     steps:
       - name: Check Go race shards
         run: |
@@ -368,8 +499,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    needs: [go-lint-shard]
-    if: always()
+    needs: [ci-scope, go-lint-shard]
+    if: always() && needs.ci-scope.outputs.core == 'true'
     steps:
       - name: Check Go lint shards
         run: |
@@ -381,8 +512,8 @@ jobs:
 
   catalog:
     runs-on: ubuntu-latest
-    needs: [catalog-shard]
-    if: always()
+    needs: [ci-scope, catalog-shard]
+    if: always() && needs.ci-scope.outputs.core == 'true'
     steps:
       - name: Check catalog shards
         run: |
@@ -394,29 +525,62 @@ jobs:
 
   verify:
     runs-on: ubuntu-latest
-    needs: [verify-shard, catalog, test, race, lint]
+    needs: [ci-scope, app-workspace-contract, web, web-image, slack-companion, typescript-sdk, javascript-dependency-audit, verify-shard, catalog, test, race, lint]
     if: always()
     steps:
-      - name: Check verify shards
+      - name: Check selected CI scopes
         run: |
-          if [ "${{ needs.verify-shard.result }}" != "success" ]; then
-            echo "One or more verify shards failed"
+          if [ "${{ needs.ci-scope.result }}" != "success" ]; then
+            echo "CI scope selection failed"
             exit 1
           fi
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "One or more Go test shards failed"
+          if [ "${{ needs.app-workspace-contract.result }}" != "success" ]; then
+            echo "Application workspace ownership check failed"
             exit 1
           fi
-          if [ "${{ needs.race.result }}" != "success" ]; then
-            echo "One or more Go race shards failed"
+
+          if [ "${{ needs.ci-scope.outputs.web }}" = "true" ] && [ "${{ needs.web.result }}" != "success" ]; then
+            echo "Web workspace checks failed"
             exit 1
           fi
-          if [ "${{ needs.lint.result }}" != "success" ]; then
-            echo "One or more Go lint shards failed"
+          if [ "${{ needs.ci-scope.outputs.web_image }}" = "true" ] && [ "${{ needs.web-image.result }}" != "success" ]; then
+            echo "Web image checks failed"
             exit 1
           fi
-          if [ "${{ needs.catalog.result }}" != "success" ]; then
-            echo "One or more catalog shards failed"
+          if [ "${{ needs.ci-scope.outputs.slack }}" = "true" ] && [ "${{ needs.slack-companion.result }}" != "success" ]; then
+            echo "Slack companion checks failed"
             exit 1
           fi
-          echo "All verify shards passed"
+          if [ "${{ needs.ci-scope.outputs.sdk }}" = "true" ] && [ "${{ needs.typescript-sdk.result }}" != "success" ]; then
+            echo "TypeScript SDK checks failed"
+            exit 1
+          fi
+          if { [ "${{ needs.ci-scope.outputs.web }}" = "true" ] || [ "${{ needs.ci-scope.outputs.slack }}" = "true" ] || [ "${{ needs.ci-scope.outputs.sdk }}" = "true" ]; } \
+            && [ "${{ needs.javascript-dependency-audit.result }}" != "success" ]; then
+            echo "JavaScript dependency audit failed"
+            exit 1
+          fi
+
+          if [ "${{ needs.ci-scope.outputs.core }}" = "true" ]; then
+            if [ "${{ needs.verify-shard.result }}" != "success" ]; then
+              echo "One or more core verify shards failed"
+              exit 1
+            fi
+            if [ "${{ needs.test.result }}" != "success" ]; then
+              echo "One or more Go test shards failed"
+              exit 1
+            fi
+            if [ "${{ needs.race.result }}" != "success" ]; then
+              echo "One or more Go race shards failed"
+              exit 1
+            fi
+            if [ "${{ needs.lint.result }}" != "success" ]; then
+              echo "One or more Go lint shards failed"
+              exit 1
+            fi
+            if [ "${{ needs.catalog.result }}" != "success" ]; then
+              echo "One or more catalog checks failed"
+              exit 1
+            fi
+          fi
+          echo "All selected CI scopes passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             python3 scripts/app_ci_scope.py --all --github-output "${GITHUB_OUTPUT}" </dev/null
             exit 0
           fi
-          git diff --name-only --diff-filter=ACMR -z "${BASE_SHA}" "${HEAD_SHA}" \
+          git diff --name-only --no-renames --diff-filter=ACMRD -z "${BASE_SHA}" "${HEAD_SHA}" \
             | python3 scripts/app_ci_scope.py --null --github-output "${GITHUB_OUTPUT}"
 
   app-workspace-contract:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 .PHONY: release-train-test
-.PHONY: web-docker-smoke
+.PHONY: app-workspace-check web-docker-smoke
 .PHONY: sourcegen-grammar-check sourcegen-repro-check sourcegen-proof-check
 .PHONY: help build serve serve-dev test test-race cover test-coverage sdk-test sdk-go-test sdk-python-test sdk-python-build-check sdk-typescript-test sdk-typescript-check sdk-dependency-audit workspace-install workspace-build workspace-check workspace-test script-test workflow-e2e-test workflow-replay-test finding-rule-test finding-rule-scaffold-test sourcegen-test openapi-definition-gen-test agent-platform-eval agent-service-lifecycle-generate agent-service-lifecycle-check github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke mcp-contract-check mcp-tool-eval mcp-smoke mcp-sdk-compat lint lint-shard lint-api-cmd lint-internal lint-sources lint-bootstrap proto-lint proto-generate proto-generate-check proto-breaking openapi-check openapi-lint openapi-sync catalog-check content-pack-check control-index-generate control-index-check sourcegen-check connector-catalog-fidelity-generate connector-catalog-fidelity-check connector-catalog-review connector-api-discovery connector-catalog-maintenance connector-contract-check connector-import connector-import-promote graph-action-generate graph-action-check finding-dsl-migrate finding-dsl-test finding-dsl-lint finding-dsl-schema-generate finding-dsl-schema-check finding-dsl-check policy-rule-generate policy-rule-check policy-mapping-export policy-mapping-check detection-catalog-generate detection-catalog-check new-aws-collector openapi-ts-generate openapi-ts-check connector-onboard codegen-status codegen-check codegen-catalog-generate codegen-catalog-check projection-template-check definition-migrate docs-autogen docs-drift-check readme-check oss-audit govulncheck contracts-check changed-check secure-business-demo github-business-demo github-business-demo-env agent-onboard agent-onboard-test agent-onboard-e2e docker-smoke release-smoke load-smoke doctor droid-review-preflight droid-review-sast droid-ci-context droid-review-context droid-post-merge-health droid-feedback land-pr clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 .PHONY: rust-workspace-policy rust-fmt-check rust-clippy rust-test rust-doc-check rust-deny rust-coverage rust-benchmark-smoke rust-wasm-check rust-wasm-manifest-generate rust-wasm-manifest-check rust-validator-properties rust-validator-fuzz-smoke graphagent-static-validator-generate graphagent-static-validator-check sourcecoverage-evaluator-generate sourcecoverage-evaluator-check panopticon-resource-extractor-generate panopticon-resource-extractor-check mitre-context-evaluator-generate mitre-context-evaluator-check sourceruntime-record-kernel-generate sourceruntime-record-kernel-check rust-source-kernel-evidence
@@ -232,6 +232,9 @@ sdk-typescript-check: workspace-install ## Install workspace dependencies and ru
 
 workspace-install: ## Install root npm workspace dependencies from the shared lockfile.
 	npm ci
+
+app-workspace-check: ## Verify public applications remain owned npm workspaces.
+	$(PYTHON) scripts/app_workspace_contract.py
 
 workspace-build: workspace-install ## Build every npm workspace that declares a build script.
 	npm run build:workspaces

--- a/scripts/app_ci_scope.py
+++ b/scripts/app_ci_scope.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Select first-class application and core CI scopes from changed paths."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TextIO
+
+
+ROOT_NPM_PATHS = frozenset({"package.json", "package-lock.json"})
+CI_CONTROLLER_PATHS = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        "Makefile",
+        "scripts/app_ci_scope.py",
+        "scripts/app_workspace_contract.py",
+        "scripts/tests/test_app_ci_scope.py",
+        "scripts/tests/test_app_ci_workflow.py",
+        "scripts/tests/test_app_workspace_contract.py",
+    }
+)
+WEB_CONTRACT_PATHS = frozenset({"api/openapi.yaml"})
+SLACK_CONTRACT_PREFIXES = (
+    "internal/agentplatform/lifecyclecontract/",
+    "schemas/agent-service-lifecycle",
+)
+JAVASCRIPT_ONLY_PREFIXES = (
+    "apps/",
+    "sdk/typescript/",
+)
+
+
+@dataclass(frozen=True)
+class CIScope:
+    core: bool
+    sdk: bool
+    slack: bool
+    web: bool
+    web_image: bool
+
+    @classmethod
+    def all(cls) -> "CIScope":
+        return cls(core=True, sdk=True, slack=True, web=True, web_image=True)
+
+    def as_outputs(self) -> dict[str, str]:
+        return {
+            key: "true" if value else "false"
+            for key, value in asdict(self).items()
+        }
+
+
+def normalize_paths(paths: list[str]) -> list[str]:
+    return sorted(
+        {
+            path.strip().removeprefix("./")
+            for path in paths
+            if path.strip()
+        }
+    )
+
+
+def select_scope(paths: list[str], *, run_all: bool = False) -> CIScope:
+    normalized = normalize_paths(paths)
+    if run_all or not normalized:
+        return CIScope.all()
+    if any(path in CI_CONTROLLER_PATHS for path in normalized):
+        return CIScope.all()
+
+    root_npm_changed = any(path in ROOT_NPM_PATHS for path in normalized)
+    web = root_npm_changed or any(path.startswith("apps/web/") for path in normalized)
+    slack = root_npm_changed or any(
+        path.startswith("apps/slack-companion/")
+        or path.startswith("sdk/typescript/")
+        or path.startswith(SLACK_CONTRACT_PREFIXES)
+        for path in normalized
+    )
+    sdk_contract_changed = any(
+        path in WEB_CONTRACT_PATHS or path.startswith(SLACK_CONTRACT_PREFIXES)
+        for path in normalized
+    )
+    sdk = root_npm_changed or sdk_contract_changed or any(
+        path.startswith("sdk/typescript/") for path in normalized
+    )
+
+    if any(path in WEB_CONTRACT_PATHS for path in normalized):
+        web = True
+    if "apps/README.md" in normalized:
+        web = True
+        slack = True
+
+    javascript_only = all(
+        path in ROOT_NPM_PATHS
+        or path == "apps/README.md"
+        or path.startswith(JAVASCRIPT_ONLY_PREFIXES)
+        for path in normalized
+    )
+    return CIScope(
+        core=not javascript_only,
+        sdk=sdk,
+        slack=slack,
+        web=web,
+        web_image=web,
+    )
+
+
+def write_github_outputs(scope: CIScope, output: TextIO) -> None:
+    for key, value in scope.as_outputs().items():
+        output.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        dest="run_all",
+        help="Select every scope, as required for main branch pushes.",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Append constant-key Boolean outputs for GitHub Actions.",
+    )
+    parser.add_argument(
+        "--null",
+        action="store_true",
+        help="Read NUL-delimited paths from stdin.",
+    )
+    args = parser.parse_args()
+
+    input_data = sys.stdin.read()
+    paths = input_data.split("\0") if args.null else input_data.splitlines()
+    scope = select_scope(paths, run_all=args.run_all)
+    if args.github_output is not None:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            write_github_outputs(scope, output)
+    else:
+        json.dump(asdict(scope), sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/app_ci_scope.py
+++ b/scripts/app_ci_scope.py
@@ -71,9 +71,12 @@ def select_scope(paths: list[str], *, run_all: bool = False) -> CIScope:
     if any(path in CI_CONTROLLER_PATHS for path in normalized):
         return CIScope.all()
     if any(
-        len(parts := path.split("/", 2)) == 3
-        and parts[0] == "apps"
-        and parts[1] not in MAPPED_APP_DIRS
+        path.startswith("apps/")
+        and path != "apps/README.md"
+        and not any(
+            path == f"apps/{app_dir}" or path.startswith(f"apps/{app_dir}/")
+            for app_dir in MAPPED_APP_DIRS
+        )
         for path in normalized
     ):
         return CIScope.all()

--- a/scripts/app_ci_scope.py
+++ b/scripts/app_ci_scope.py
@@ -12,6 +12,7 @@ from typing import TextIO
 
 
 ROOT_NPM_PATHS = frozenset({"package.json", "package-lock.json"})
+MAPPED_APP_DIRS = frozenset({"slack-companion", "web"})
 CI_CONTROLLER_PATHS = frozenset(
     {
         ".github/workflows/ci.yml",
@@ -68,6 +69,13 @@ def select_scope(paths: list[str], *, run_all: bool = False) -> CIScope:
     if run_all or not normalized:
         return CIScope.all()
     if any(path in CI_CONTROLLER_PATHS for path in normalized):
+        return CIScope.all()
+    if any(
+        len(parts := path.split("/", 2)) == 3
+        and parts[0] == "apps"
+        and parts[1] not in MAPPED_APP_DIRS
+        for path in normalized
+    ):
         return CIScope.all()
 
     root_npm_changed = any(path in ROOT_NPM_PATHS for path in normalized)

--- a/scripts/app_workspace_contract.py
+++ b/scripts/app_workspace_contract.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Validate portable application ownership in the npm monorepo."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CANONICAL_REPOSITORY = "git+https://github.com/writer/cerebro.git"
+
+
+@dataclass(frozen=True)
+class ContractFailure:
+    path: str
+    message: str
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def workspace_matches(patterns: list[str], relative_path: str) -> bool:
+    return any(fnmatch.fnmatchcase(relative_path, pattern) for pattern in patterns)
+
+
+def validate_app_workspaces(repo: Path) -> list[ContractFailure]:
+    failures: list[ContractFailure] = []
+    root_manifest = load_json(repo / "package.json")
+    lock = load_json(repo / "package-lock.json")
+    workspaces = root_manifest.get("workspaces")
+    if not isinstance(workspaces, list) or not all(isinstance(item, str) for item in workspaces):
+        return [ContractFailure("package.json", "workspaces must be a string array")]
+
+    lock_packages = lock.get("packages")
+    if not isinstance(lock_packages, dict):
+        return [ContractFailure("package-lock.json", "packages must be an object")]
+    lock_root = lock_packages.get("")
+    if not isinstance(lock_root, dict) or lock_root.get("workspaces") != workspaces:
+        failures.append(
+            ContractFailure(
+                "package-lock.json",
+                "root workspace declarations must match package.json",
+            )
+        )
+
+    app_root = repo / "apps"
+    app_dirs = sorted(path for path in app_root.iterdir() if (path / "package.json").is_file())
+    if not app_dirs:
+        failures.append(ContractFailure("apps", "at least one application workspace is required"))
+
+    for app_dir in app_dirs:
+        relative = app_dir.relative_to(repo).as_posix()
+        manifest_path = f"{relative}/package.json"
+        manifest = load_json(app_dir / "package.json")
+        expected_name = f"@writer/cerebro-{app_dir.name}"
+
+        if not workspace_matches(workspaces, relative):
+            failures.append(ContractFailure(manifest_path, "application is not covered by root workspaces"))
+        if manifest.get("name") != expected_name:
+            failures.append(ContractFailure(manifest_path, f"name must be {expected_name}"))
+        if manifest.get("private") is not True:
+            failures.append(ContractFailure(manifest_path, "application packages must be private"))
+        if not isinstance(manifest.get("license"), str) or not manifest["license"].strip():
+            failures.append(ContractFailure(manifest_path, "license must be declared"))
+
+        repository = manifest.get("repository")
+        if not isinstance(repository, dict):
+            failures.append(ContractFailure(manifest_path, "repository must be an object"))
+        else:
+            if repository.get("type") != "git" or repository.get("url") != CANONICAL_REPOSITORY:
+                failures.append(ContractFailure(manifest_path, "repository must point to the canonical monorepo"))
+            if repository.get("directory") != relative:
+                failures.append(ContractFailure(manifest_path, f"repository.directory must be {relative}"))
+
+        scripts = manifest.get("scripts")
+        if not isinstance(scripts, dict):
+            failures.append(ContractFailure(manifest_path, "scripts must be an object"))
+        else:
+            for script in ("build", "check", "test"):
+                if not isinstance(scripts.get(script), str) or not scripts[script].strip():
+                    failures.append(ContractFailure(manifest_path, f"scripts.{script} must be declared"))
+            if any("publish" in key.lower() for key in scripts):
+                failures.append(ContractFailure(manifest_path, "application packages must not declare publish scripts"))
+
+        if "publishConfig" in manifest:
+            failures.append(ContractFailure(manifest_path, "application packages must not declare publishConfig"))
+        if (app_dir / "package-lock.json").exists():
+            failures.append(ContractFailure(f"{relative}/package-lock.json", "use the root workspace lockfile"))
+
+        lock_entry = lock_packages.get(relative)
+        if not isinstance(lock_entry, dict):
+            failures.append(ContractFailure("package-lock.json", f"missing workspace entry for {relative}"))
+        elif lock_entry.get("name") != expected_name:
+            failures.append(ContractFailure("package-lock.json", f"workspace entry for {relative} has the wrong name"))
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path("."))
+    args = parser.parse_args()
+
+    failures = validate_app_workspaces(args.repo.resolve())
+    if failures:
+        for failure in failures:
+            print(f"app-workspace-contract: {failure.path}: {failure.message}")
+        return 1
+    print("app-workspace-contract: application workspaces are owned by the monorepo")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/app_workspace_contract.py
+++ b/scripts/app_workspace_contract.py
@@ -14,6 +14,7 @@ from typing import Any
 
 
 CANONICAL_REPOSITORY = "git+https://github.com/writer/cerebro.git"
+MAPPED_APP_DIRS = frozenset({"slack-companion", "web"})
 DIGEST_PINNED_IMAGE_PATTERN = r"^[^\s@]+:[^\s/@:]+@sha256:[0-9a-f]{64}$"
 
 
@@ -163,6 +164,8 @@ def validate_app_workspaces(repo: Path) -> list[ContractFailure]:
         manifest = load_json(app_dir / "package.json")
         expected_name = f"@writer/cerebro-{app_dir.name}"
 
+        if app_dir.name not in MAPPED_APP_DIRS:
+            failures.append(ContractFailure(manifest_path, "application has no CI scope mapping"))
         if not workspace_matches(workspaces, relative):
             failures.append(ContractFailure(manifest_path, "application is not covered by root workspaces"))
         if manifest.get("name") != expected_name:

--- a/scripts/app_workspace_contract.py
+++ b/scripts/app_workspace_contract.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import json
+import re
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 
 CANONICAL_REPOSITORY = "git+https://github.com/writer/cerebro.git"
+DIGEST_PINNED_IMAGE_PATTERN = r"^[^\s@]+:[^\s/@:]+@sha256:[0-9a-f]{64}$"
 
 
 @dataclass(frozen=True)
@@ -29,6 +32,104 @@ def load_json(path: Path) -> dict[str, Any]:
 
 def workspace_matches(patterns: list[str], relative_path: str) -> bool:
     return any(fnmatch.fnmatchcase(relative_path, pattern) for pattern in patterns)
+
+
+def is_app_dockerfile(path: Path) -> bool:
+    name = path.name
+    if name.endswith(".dockerignore"):
+        return False
+    return (
+        name == "Dockerfile"
+        or name.startswith("Dockerfile.")
+        or name.endswith(".Dockerfile")
+    )
+
+
+def docker_instructions(path: Path) -> list[tuple[int, str]]:
+    instructions: list[tuple[int, str]] = []
+    logical_line = ""
+    start_line = 0
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not logical_line and (not stripped or stripped.startswith("#")):
+            continue
+        if not logical_line:
+            start_line = line_number
+        continued = stripped.endswith("\\")
+        content = stripped[:-1].rstrip() if continued else stripped
+        logical_line = f"{logical_line} {content}".strip()
+        if continued:
+            continue
+        instructions.append((start_line, logical_line))
+        logical_line = ""
+    if logical_line:
+        instructions.append((start_line, logical_line))
+    return instructions
+
+
+def validate_dockerfile(path: Path, repo: Path) -> list[ContractFailure]:
+    relative = path.relative_to(repo).as_posix()
+    failures: list[ContractFailure] = []
+    from_count = 0
+    for line_number, instruction in docker_instructions(path):
+        try:
+            tokens = shlex.split(instruction, comments=False, posix=True)
+        except ValueError:
+            tokens = []
+        if not tokens or tokens[0].upper() != "FROM":
+            continue
+        from_count += 1
+        index = 1
+        while index < len(tokens) and tokens[index].startswith("--"):
+            if "=" not in tokens[index]:
+                failures.append(
+                    ContractFailure(
+                        f"{relative}:{line_number}",
+                        "FROM flags must use --name=value syntax",
+                    )
+                )
+                index = len(tokens)
+                break
+            index += 1
+        if index >= len(tokens):
+            failures.append(
+                ContractFailure(
+                    f"{relative}:{line_number}",
+                    "FROM must name a digest-pinned base image",
+                )
+            )
+            continue
+
+        image = tokens[index]
+        remainder = tokens[index + 1 :]
+        valid_alias = not remainder or (
+            len(remainder) == 2
+            and remainder[0].upper() == "AS"
+            and bool(re.fullmatch(r"[A-Za-z0-9_.-]+", remainder[1]))
+        )
+        if not valid_alias:
+            failures.append(
+                ContractFailure(
+                    f"{relative}:{line_number}",
+                    "FROM must contain only an optional AS stage alias after the image",
+                )
+            )
+        if not re.fullmatch(DIGEST_PINNED_IMAGE_PATTERN, image) or ":latest@sha256:" in image.lower():
+            failures.append(
+                ContractFailure(
+                    f"{relative}:{line_number}",
+                    "base image must use name:tag@sha256 with a 64-character lowercase digest",
+                )
+            )
+
+    if from_count == 0:
+        failures.append(
+            ContractFailure(
+                relative,
+                "Dockerfile must declare at least one digest-pinned FROM instruction",
+            )
+        )
+    return failures
 
 
 def validate_app_workspaces(repo: Path) -> list[ContractFailure]:
@@ -100,6 +201,14 @@ def validate_app_workspaces(repo: Path) -> list[ContractFailure]:
             failures.append(ContractFailure("package-lock.json", f"missing workspace entry for {relative}"))
         elif lock_entry.get("name") != expected_name:
             failures.append(ContractFailure("package-lock.json", f"workspace entry for {relative} has the wrong name"))
+
+    dockerfiles = sorted(
+        path
+        for path in app_root.rglob("*")
+        if path.is_file() and is_app_dockerfile(path)
+    )
+    for dockerfile in dockerfiles:
+        failures.extend(validate_dockerfile(dockerfile, repo))
 
     return failures
 

--- a/scripts/tests/test_app_ci_scope.py
+++ b/scripts/tests/test_app_ci_scope.py
@@ -1,0 +1,72 @@
+import io
+import unittest
+
+from scripts.app_ci_scope import CIScope, select_scope, write_github_outputs
+
+
+class AppCIScopeTests(unittest.TestCase):
+    def test_web_only_change_skips_core_and_selects_image(self):
+        self.assertEqual(
+            select_scope(["apps/web/src/app/page.tsx"]),
+            CIScope(core=False, sdk=False, slack=False, web=True, web_image=True),
+        )
+
+    def test_slack_only_change_skips_core(self):
+        self.assertEqual(
+            select_scope(["apps/slack-companion/src/admission.ts"]),
+            CIScope(core=False, sdk=False, slack=True, web=False, web_image=False),
+        )
+
+    def test_sdk_change_checks_sdk_and_its_consumer(self):
+        self.assertEqual(
+            select_scope(["sdk/typescript/src/index.ts"]),
+            CIScope(core=False, sdk=True, slack=True, web=False, web_image=False),
+        )
+
+    def test_root_npm_change_selects_every_javascript_workspace(self):
+        self.assertEqual(
+            select_scope(["package-lock.json"]),
+            CIScope(core=False, sdk=True, slack=True, web=True, web_image=True),
+        )
+
+    def test_core_contract_changes_select_consuming_apps(self):
+        scope = select_scope(
+            [
+                "api/openapi.yaml",
+                "schemas/agent-service-lifecycle.schema.json",
+            ]
+        )
+        self.assertEqual(scope, CIScope(core=True, sdk=True, slack=True, web=True, web_image=True))
+
+    def test_ci_controller_changes_run_every_scope(self):
+        for path in (
+            ".github/workflows/ci.yml",
+            "Makefile",
+            "scripts/app_ci_scope.py",
+            "scripts/app_workspace_contract.py",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(select_scope([path]), CIScope.all())
+
+    def test_mixed_change_runs_core_and_changed_app(self):
+        self.assertEqual(
+            select_scope(["apps/web/src/app/page.tsx", "internal/bootstrap/bootstrap.go"]),
+            CIScope(core=True, sdk=False, slack=False, web=True, web_image=True),
+        )
+
+    def test_empty_diff_and_explicit_all_fail_safe_to_every_scope(self):
+        self.assertEqual(select_scope([]), CIScope.all())
+        self.assertEqual(select_scope(["apps/web/README.md"], run_all=True), CIScope.all())
+
+    def test_filenames_are_written_only_as_constant_boolean_outputs(self):
+        scope = select_scope(["apps/web/$(touch unexpected).tsx"])
+        output = io.StringIO()
+        write_github_outputs(scope, output)
+        self.assertEqual(
+            output.getvalue(),
+            "core=false\nsdk=false\nslack=false\nweb=true\nweb_image=true\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_app_ci_scope.py
+++ b/scripts/tests/test_app_ci_scope.py
@@ -1,7 +1,8 @@
 import io
 import unittest
 
-from scripts.app_ci_scope import CIScope, select_scope, write_github_outputs
+from scripts.app_ci_scope import CIScope, MAPPED_APP_DIRS, select_scope, write_github_outputs
+from scripts.app_workspace_contract import MAPPED_APP_DIRS as CONTRACT_MAPPED_APP_DIRS
 
 
 class AppCIScopeTests(unittest.TestCase):
@@ -16,6 +17,29 @@ class AppCIScopeTests(unittest.TestCase):
             select_scope(["apps/slack-companion/src/admission.ts"]),
             CIScope(core=False, sdk=False, slack=True, web=False, web_image=False),
         )
+
+    def test_deleted_known_app_path_selects_its_owned_checks(self):
+        self.assertEqual(
+            select_scope(["apps/web/src/removed.ts"]),
+            CIScope(core=False, sdk=False, slack=False, web=True, web_image=True),
+        )
+
+    def test_rename_old_and_new_paths_cannot_hide_owned_checks(self):
+        self.assertEqual(
+            select_scope(
+                [
+                    "apps/slack-companion/src/old-name.ts",
+                    "docs/new-name.ts",
+                ]
+            ),
+            CIScope(core=True, sdk=False, slack=True, web=False, web_image=False),
+        )
+
+    def test_unknown_application_path_fails_safe_to_every_scope(self):
+        self.assertEqual(select_scope(["apps/new-surface/package.json"]), CIScope.all())
+
+    def test_scope_and_workspace_contract_share_the_same_app_mapping(self):
+        self.assertEqual(MAPPED_APP_DIRS, CONTRACT_MAPPED_APP_DIRS)
 
     def test_sdk_change_checks_sdk_and_its_consumer(self):
         self.assertEqual(

--- a/scripts/tests/test_app_ci_scope.py
+++ b/scripts/tests/test_app_ci_scope.py
@@ -24,6 +24,12 @@ class AppCIScopeTests(unittest.TestCase):
             CIScope(core=False, sdk=False, slack=False, web=True, web_image=True),
         )
 
+    def test_type_changed_known_app_path_selects_its_owned_checks(self):
+        self.assertEqual(
+            select_scope(["apps/web/src/linked-config.ts"]),
+            CIScope(core=False, sdk=False, slack=False, web=True, web_image=True),
+        )
+
     def test_rename_old_and_new_paths_cannot_hide_owned_checks(self):
         self.assertEqual(
             select_scope(
@@ -37,6 +43,12 @@ class AppCIScopeTests(unittest.TestCase):
 
     def test_unknown_application_path_fails_safe_to_every_scope(self):
         self.assertEqual(select_scope(["apps/new-surface/package.json"]), CIScope.all())
+
+    def test_unknown_two_component_application_path_fails_safe_to_every_scope(self):
+        self.assertEqual(select_scope(["apps/new-surface"]), CIScope.all())
+
+    def test_unknown_application_root_file_fails_safe_to_every_scope(self):
+        self.assertEqual(select_scope(["apps/shared-config.ts"]), CIScope.all())
 
     def test_scope_and_workspace_contract_share_the_same_app_mapping(self):
         self.assertEqual(MAPPED_APP_DIRS, CONTRACT_MAPPED_APP_DIRS)

--- a/scripts/tests/test_app_ci_workflow.py
+++ b/scripts/tests/test_app_ci_workflow.py
@@ -25,6 +25,13 @@ class AppCIWorkflowTests(unittest.TestCase):
         for job in ("verify-shard", "go-lint-shard", "catalog-shard", "go-test-shard", "go-race-shard"):
             self.assertIn(f"  {job}:\n", self.workflow)
 
+    def test_scope_diff_includes_deletions_and_both_rename_paths(self):
+        self.assertIn(
+            "git diff --name-only --no-renames --diff-filter=ACMRD -z",
+            self.workflow,
+        )
+        self.assertNotIn("--diff-filter=ACMR -z", self.workflow)
+
     def test_app_jobs_are_first_class_verify_dependencies(self):
         expected_jobs = (
             "app-workspace-contract",

--- a/scripts/tests/test_app_ci_workflow.py
+++ b/scripts/tests/test_app_ci_workflow.py
@@ -1,0 +1,52 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class AppCIWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_keeps_stable_terminal_verify_job(self):
+        self.assertIn("\n  verify:\n", self.workflow)
+        self.assertIn("if: always()", self.workflow)
+        self.assertIn("All selected CI scopes passed", self.workflow)
+        self.assertNotIn("paths-ignore:", self.workflow)
+
+    def test_core_matrices_use_the_tested_scope(self):
+        self.assertEqual(
+            self.workflow.count("if: needs.ci-scope.outputs.core == 'true'"),
+            5,
+        )
+        for job in ("verify-shard", "go-lint-shard", "catalog-shard", "go-test-shard", "go-race-shard"):
+            self.assertIn(f"  {job}:\n", self.workflow)
+
+    def test_app_jobs_are_first_class_verify_dependencies(self):
+        expected_jobs = (
+            "app-workspace-contract",
+            "web",
+            "web-image",
+            "slack-companion",
+            "typescript-sdk",
+            "javascript-dependency-audit",
+        )
+        for job in expected_jobs:
+            self.assertIn(f"  {job}:\n", self.workflow)
+        self.assertIn(
+            "needs: [ci-scope, app-workspace-contract, web, web-image, slack-companion, typescript-sdk, javascript-dependency-audit, verify-shard, catalog, test, race, lint]",
+            self.workflow,
+        )
+
+    def test_app_jobs_run_owned_checks(self):
+        self.assertIn("npm run check --workspace @writer/cerebro-web", self.workflow)
+        self.assertIn("make web-docker-smoke", self.workflow)
+        self.assertIn("npm run check --workspace @writer/cerebro-slack-companion", self.workflow)
+        self.assertIn("npm run check --workspace @writer/cerebro-sdk", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_app_ci_workflow.py
+++ b/scripts/tests/test_app_ci_workflow.py
@@ -47,6 +47,10 @@ class AppCIWorkflowTests(unittest.TestCase):
         self.assertIn("npm run check --workspace @writer/cerebro-slack-companion", self.workflow)
         self.assertIn("npm run check --workspace @writer/cerebro-sdk", self.workflow)
 
+    def test_javascript_audit_blocks_production_advisories_at_moderate(self):
+        self.assertIn("npm audit --omit=dev --audit-level=moderate", self.workflow)
+        self.assertNotIn("npm audit --audit-level=high", self.workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_app_ci_workflow.py
+++ b/scripts/tests/test_app_ci_workflow.py
@@ -25,12 +25,12 @@ class AppCIWorkflowTests(unittest.TestCase):
         for job in ("verify-shard", "go-lint-shard", "catalog-shard", "go-test-shard", "go-race-shard"):
             self.assertIn(f"  {job}:\n", self.workflow)
 
-    def test_scope_diff_includes_deletions_and_both_rename_paths(self):
+    def test_scope_diff_includes_every_change_type_and_both_rename_paths(self):
         self.assertIn(
-            "git diff --name-only --no-renames --diff-filter=ACMRD -z",
+            "git diff --name-only --no-renames -z",
             self.workflow,
         )
-        self.assertNotIn("--diff-filter=ACMR -z", self.workflow)
+        self.assertNotIn("--diff-filter=", self.workflow)
 
     def test_app_jobs_are_first_class_verify_dependencies(self):
         expected_jobs = (

--- a/scripts/tests/test_app_workspace_contract.py
+++ b/scripts/tests/test_app_workspace_contract.py
@@ -125,6 +125,27 @@ class AppWorkspaceContractTests(unittest.TestCase):
         self.assertIn("application packages must not declare publishConfig", messages)
         self.assertIn("application packages must not declare publish scripts", messages)
 
+    def test_rejects_application_without_ci_scope_mapping(self):
+        self.write_json(
+            "apps/new-surface/package.json",
+            {
+                "name": "@writer/cerebro-new-surface",
+                "private": True,
+                "license": "Apache-2.0",
+                "repository": {
+                    "type": "git",
+                    "url": CANONICAL_REPOSITORY,
+                    "directory": "apps/new-surface",
+                },
+                "scripts": {"build": "build", "check": "check", "test": "test"},
+            },
+        )
+        lock = json.loads((self.repo / "package-lock.json").read_text(encoding="utf-8"))
+        lock["packages"]["apps/new-surface"] = {"name": "@writer/cerebro-new-surface"}
+        self.write_json("package-lock.json", lock)
+
+        self.assertIn("application has no CI scope mapping", self.messages())
+
     def test_rejects_repository_or_directory_drift(self):
         manifest = self.manifest()
         manifest["repository"]["url"] = "https://example.invalid/other.git"

--- a/scripts/tests/test_app_workspace_contract.py
+++ b/scripts/tests/test_app_workspace_contract.py
@@ -1,0 +1,104 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.app_workspace_contract import CANONICAL_REPOSITORY, validate_app_workspaces
+
+
+class AppWorkspaceContractTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp.name)
+        self.write_json(
+            "package.json",
+            {"name": "monorepo", "workspaces": ["apps/*", "sdk/typescript"]},
+        )
+        self.write_json(
+            "apps/web/package.json",
+            {
+                "name": "@writer/cerebro-web",
+                "private": True,
+                "license": "MIT",
+                "repository": {
+                    "type": "git",
+                    "url": CANONICAL_REPOSITORY,
+                    "directory": "apps/web",
+                },
+                "scripts": {"build": "build", "check": "check", "test": "test"},
+            },
+        )
+        self.write_json(
+            "package-lock.json",
+            {
+                "packages": {
+                    "": {"workspaces": ["apps/*", "sdk/typescript"]},
+                    "apps/web": {"name": "@writer/cerebro-web"},
+                }
+            },
+        )
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def write_json(self, path: str, value: object) -> None:
+        target = self.repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(value), encoding="utf-8")
+
+    def manifest(self) -> dict:
+        return json.loads((self.repo / "apps/web/package.json").read_text(encoding="utf-8"))
+
+    def messages(self) -> list[str]:
+        return [failure.message for failure in validate_app_workspaces(self.repo)]
+
+    def test_accepts_owned_application_workspace(self):
+        self.assertEqual(validate_app_workspaces(self.repo), [])
+
+    def test_rejects_non_private_or_publishable_application(self):
+        manifest = self.manifest()
+        manifest["private"] = False
+        manifest["publishConfig"] = {"access": "public"}
+        manifest["scripts"]["prepublishOnly"] = "build"
+        self.write_json("apps/web/package.json", manifest)
+
+        messages = self.messages()
+        self.assertIn("application packages must be private", messages)
+        self.assertIn("application packages must not declare publishConfig", messages)
+        self.assertIn("application packages must not declare publish scripts", messages)
+
+    def test_rejects_repository_or_directory_drift(self):
+        manifest = self.manifest()
+        manifest["repository"]["url"] = "https://example.invalid/other.git"
+        manifest["repository"]["directory"] = "web"
+        self.write_json("apps/web/package.json", manifest)
+
+        messages = self.messages()
+        self.assertIn("repository must point to the canonical monorepo", messages)
+        self.assertIn("repository.directory must be apps/web", messages)
+
+    def test_rejects_nested_lock_and_missing_root_lock_entry(self):
+        (self.repo / "apps/web/package-lock.json").write_text("{}", encoding="utf-8")
+        lock = json.loads((self.repo / "package-lock.json").read_text(encoding="utf-8"))
+        del lock["packages"]["apps/web"]
+        self.write_json("package-lock.json", lock)
+
+        messages = self.messages()
+        self.assertIn("use the root workspace lockfile", messages)
+        self.assertIn("missing workspace entry for apps/web", messages)
+
+    def test_rejects_missing_owned_scripts(self):
+        manifest = self.manifest()
+        del manifest["scripts"]["check"]
+        self.write_json("apps/web/package.json", manifest)
+        self.assertIn("scripts.check must be declared", self.messages())
+
+    def test_rejects_root_lock_workspace_drift(self):
+        lock = json.loads((self.repo / "package-lock.json").read_text(encoding="utf-8"))
+        lock["packages"][""]["workspaces"] = ["apps/*"]
+        self.write_json("package-lock.json", lock)
+        self.assertIn("root workspace declarations must match package.json", self.messages())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_app_workspace_contract.py
+++ b/scripts/tests/test_app_workspace_contract.py
@@ -3,7 +3,14 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.app_workspace_contract import CANONICAL_REPOSITORY, validate_app_workspaces
+from scripts.app_workspace_contract import (
+    CANONICAL_REPOSITORY,
+    is_app_dockerfile,
+    validate_app_workspaces,
+)
+
+
+DIGEST = "a" * 64
 
 
 class AppWorkspaceContractTests(unittest.TestCase):
@@ -53,6 +60,57 @@ class AppWorkspaceContractTests(unittest.TestCase):
         return [failure.message for failure in validate_app_workspaces(self.repo)]
 
     def test_accepts_owned_application_workspace(self):
+        self.assertEqual(validate_app_workspaces(self.repo), [])
+
+    def test_accepts_digest_pinned_multistage_dockerfile_with_platform_flag(self):
+        dockerfile = self.repo / "apps/web/Dockerfile"
+        dockerfile.write_text(
+            "\n".join(
+                (
+                    f"FROM --platform=linux/amd64 node:22-alpine@sha256:{DIGEST} AS build",
+                    f"FROM node:22-alpine@sha256:{DIGEST} AS runtime",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        self.assertEqual(validate_app_workspaces(self.repo), [])
+
+    def test_rejects_mutable_or_malformed_base_images(self):
+        cases = (
+            ("node:22-alpine", "tag only"),
+            (f"node:latest@sha256:{DIGEST}", "latest tag"),
+            (f"node@sha256:{DIGEST}", "digest without tag"),
+            ("${BASE_IMAGE}", "variable"),
+            (f"node:22-alpine@sha256:{'A' * 64}", "uppercase digest"),
+            (f"node:22-alpine@sha256:{'a' * 63}", "short digest"),
+            ("scratch", "scratch"),
+        )
+        for image, label in cases:
+            with self.subTest(label=label):
+                dockerfile = self.repo / "apps/web/Dockerfile"
+                dockerfile.write_text(f"FROM {image}\n", encoding="utf-8")
+                self.assertIn(
+                    "base image must use name:tag@sha256 with a 64-character lowercase digest",
+                    self.messages(),
+                )
+
+    def test_rejects_missing_or_malformed_from_instruction(self):
+        dockerfile = self.repo / "apps/web/Dockerfile"
+        dockerfile.write_text("RUN echo ready\n", encoding="utf-8")
+        self.assertIn(
+            "Dockerfile must declare at least one digest-pinned FROM instruction",
+            self.messages(),
+        )
+
+        dockerfile.write_text(f"FROM --platform linux/amd64 node:22@sha256:{DIGEST}\n", encoding="utf-8")
+        self.assertIn("FROM flags must use --name=value syntax", self.messages())
+
+    def test_excludes_dockerfile_ignore_files_from_base_validation(self):
+        for name in ("Dockerfile.dockerignore", "Dockerfile.prod.dockerignore", "build.Dockerfile.dockerignore"):
+            ignored = self.repo / "apps/web" / name
+            ignored.write_text("node_modules\n", encoding="utf-8")
+            self.assertFalse(is_app_dockerfile(ignored))
         self.assertEqual(validate_app_workspaces(self.repo), [])
 
     def test_rejects_non_private_or_publishable_application(self):


### PR DESCRIPTION
## What changed

- select core, web, web image, Slack companion, and TypeScript SDK CI scopes from changed paths
- classify every Git change type and both sides of renames so application changes cannot disappear from CI scope
- fail closed when any path below apps has no declared CI mapping, and reject unmapped application workspaces
- keep the terminal verify check stable while skipping Go, Rust, and catalog matrices for application-only pull requests
- run application workspaces and the web image as first-class jobs
- audit production JavaScript dependencies at the moderate advisory threshold
- enforce private package, root lockfile, canonical repository metadata, and owned build/check/test contracts for every application workspace
- reject application Dockerfiles unless every base image uses a tag plus a full immutable sha256 digest

## Why

Application-only changes currently run the complete core matrix. The monorepo needs focused application checks without weakening mixed contract changes or main branch verification.

The selector fails safe: empty diffs, pushes, CI-controller changes, and unmapped application paths run every scope. Deletions, type changes, and both sides of renames remain visible to the selector. Core contract paths also select the applications and SDKs that consume them. The workspace contract blocks new application packages until their CI ownership is declared. It also fails closed on mutable image inputs, variables, malformed digests, and incomplete Dockerfiles. The dependency gate blocks moderate-or-higher production advisories.

## Validation

- 33 focused scope, workflow, workspace, image-reference, and dependency-audit contract tests
- 175 repository script tests
- 143 Slack companion tests
- 471 web tests plus lint and production build
- 6 TypeScript SDK tests plus typecheck
- standalone smoke; refreshed image smoke runs in GitHub CI
- actionlint
- production npm dependency audit with zero vulnerabilities
- OSS audit
- tenant-data leak checks
- Practice Registry final gates