### PR TITLE
Add portable Slack assistant turn contracts

### DIFF
--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -39,6 +39,12 @@ sequenceDiagram
 
 The same shape applies to longer-running work. Slack-visible status can show queued, degraded, recovery, or completed states while leases, checkpoints, and receipts keep retries idempotent.
 
+## Assistant turns
+
+`assistantTurnBudget` maps the model-selected execution lane to bounded tool calls, selected capabilities, and latency. Hosts may lower those limits, but they cannot expand them past the portable contract. `normalizeAssistantTurnProgress` exposes the same planning, checking, synthesis, delivery, completion, and blocked phases across Slack hosts.
+
+Hosts should record the message parts Slack accepted, not an internal draft. Evaluation and conversation continuity then describe what the person actually received, including partial and failed deliveries.
+
 Production implementations of `DurableAdmissionPort` must use durable storage with one transaction or an equivalent recoverable commit protocol. The in-memory implementation under `src/testing` is a conformance fixture only.
 
 This workspace must not contain credentials, infrastructure identifiers, environment routes, deployment manifests, or provider-specific persistence adapters. Those belong in the private operational repository. A deployment may replace every port without changing the Slack application identity, binding identity, run identity, or thread identity.

--- a/apps/slack-companion/src/assistant-turn/contracts.ts
+++ b/apps/slack-companion/src/assistant-turn/contracts.ts
@@ -1,0 +1,49 @@
+export const ASSISTANT_EXECUTION_LANES = [
+  "ignore",
+  "converse",
+  "continue",
+  "lookup",
+  "investigate",
+  "act",
+] as const;
+
+export type AssistantExecutionLaneV1 = (typeof ASSISTANT_EXECUTION_LANES)[number];
+
+export const ASSISTANT_TURN_PROGRESS_PHASES = [
+  "planning",
+  "checking",
+  "synthesizing",
+  "delivering",
+  "completed",
+  "blocked",
+] as const;
+
+export type AssistantTurnProgressPhaseV1 =
+  (typeof ASSISTANT_TURN_PROGRESS_PHASES)[number];
+
+/** Portable execution bounds for one model-selected assistant lane. */
+export interface AssistantTurnBudgetV1 {
+  execution_lane: AssistantExecutionLaneV1;
+  latency_budget_ms: number;
+  max_selected_capabilities: number;
+  max_tool_calls: number;
+  schema_version: "assistant-turn-budget/v1";
+}
+
+/**
+ * A Slack host may render this state, while durable workers can persist it as
+ * opaque progress. Status text is bounded operator copy, never hidden model
+ * reasoning or raw tool output.
+ */
+export interface AssistantTurnProgressInput {
+  capability_ref?: string;
+  execution_lane?: AssistantExecutionLaneV1;
+  occurred_at: string;
+  phase: AssistantTurnProgressPhaseV1;
+  sequence: number;
+  status: string;
+}
+
+export interface AssistantTurnProgressV1 extends AssistantTurnProgressInput {
+  schema_version: "assistant-turn-progress/v1";
+}

--- a/apps/slack-companion/src/assistant-turn/policy.ts
+++ b/apps/slack-companion/src/assistant-turn/policy.ts
@@ -1,0 +1,82 @@
+import {
+  ASSISTANT_EXECUTION_LANES,
+  ASSISTANT_TURN_PROGRESS_PHASES,
+  type AssistantExecutionLaneV1,
+  type AssistantTurnBudgetV1,
+  type AssistantTurnProgressInput,
+  type AssistantTurnProgressV1,
+} from "./contracts.js";
+
+const TURN_BUDGETS: Record<AssistantExecutionLaneV1, Omit<AssistantTurnBudgetV1, "schema_version" | "execution_lane">> = {
+  ignore: { latency_budget_ms: 5_000, max_selected_capabilities: 0, max_tool_calls: 0 },
+  converse: { latency_budget_ms: 5_000, max_selected_capabilities: 0, max_tool_calls: 0 },
+  continue: { latency_budget_ms: 5_000, max_selected_capabilities: 0, max_tool_calls: 0 },
+  lookup: { latency_budget_ms: 30_000, max_selected_capabilities: 4, max_tool_calls: 3 },
+  investigate: { latency_budget_ms: 180_000, max_selected_capabilities: 10, max_tool_calls: 8 },
+  act: { latency_budget_ms: 300_000, max_selected_capabilities: 12, max_tool_calls: 12 },
+};
+
+export class AssistantTurnInputError extends Error {}
+
+export function assistantTurnBudget(
+  lane: AssistantExecutionLaneV1,
+  configured?: { max_tool_calls?: number; timeout_ms?: number },
+): AssistantTurnBudgetV1 {
+  if (!ASSISTANT_EXECUTION_LANES.includes(lane)) {
+    throw new AssistantTurnInputError("The assistant execution lane is unsupported.");
+  }
+  const policy = TURN_BUDGETS[lane];
+  return {
+    execution_lane: lane,
+    latency_budget_ms: boundedLimit(configured?.timeout_ms, policy.latency_budget_ms),
+    max_selected_capabilities: policy.max_selected_capabilities,
+    max_tool_calls: boundedLimit(configured?.max_tool_calls, policy.max_tool_calls),
+    schema_version: "assistant-turn-budget/v1",
+  };
+}
+
+export function normalizeAssistantTurnProgress(
+  input: AssistantTurnProgressInput,
+): AssistantTurnProgressV1 {
+  if (!ASSISTANT_TURN_PROGRESS_PHASES.includes(input.phase)) {
+    throw new AssistantTurnInputError("The assistant progress phase is unsupported.");
+  }
+  if (
+    input.execution_lane !== undefined
+    && !ASSISTANT_EXECUTION_LANES.includes(input.execution_lane)
+  ) {
+    throw new AssistantTurnInputError("The assistant progress lane is unsupported.");
+  }
+  if (!Number.isSafeInteger(input.sequence) || input.sequence < 1 || input.sequence > 128) {
+    throw new AssistantTurnInputError("The assistant progress sequence is out of bounds.");
+  }
+  if (!Number.isFinite(Date.parse(input.occurred_at))) {
+    throw new AssistantTurnInputError("Assistant progress requires a timestamp.");
+  }
+  const status = boundedText(input.status, 160);
+  if (!status) throw new AssistantTurnInputError("Assistant progress requires a concrete status.");
+  const capabilityRef = boundedText(input.capability_ref, 2_048);
+  return {
+    ...(capabilityRef ? { capability_ref: capabilityRef } : {}),
+    ...(input.execution_lane ? { execution_lane: input.execution_lane } : {}),
+    occurred_at: input.occurred_at,
+    phase: input.phase,
+    schema_version: "assistant-turn-progress/v1",
+    sequence: input.sequence,
+    status,
+  };
+}
+
+function boundedLimit(configured: number | undefined, policy: number): number {
+  if (configured === undefined) return policy;
+  if (!Number.isSafeInteger(configured) || configured < 0) {
+    throw new AssistantTurnInputError("Configured assistant bounds must be non-negative integers.");
+  }
+  return Math.min(configured, policy);
+}
+
+function boundedText(value: string | undefined, limit: number): string {
+  return typeof value === "string"
+    ? value.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim().slice(0, limit)
+    : "";
+}

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -6,6 +6,8 @@ export * from "./autonomy/reference-store.js";
 export * from "./assistance/contracts.js";
 export * from "./assistance/coordinator.js";
 export * from "./assistance/ports.js";
+export * from "./assistant-turn/contracts.js";
+export * from "./assistant-turn/policy.js";
 export * from "./contracts.js";
 export * from "./commands/registry.js";
 export * from "./delivery/contracts.js";

--- a/apps/slack-companion/test/assistant-turn.test.ts
+++ b/apps/slack-companion/test/assistant-turn.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AssistantTurnInputError,
+  assistantTurnBudget,
+  normalizeAssistantTurnProgress,
+} from "../src/index.js";
+
+test("assistant turn budgets bind model-selected lanes to proportional work", () => {
+  assert.deepEqual(assistantTurnBudget("converse"), {
+    execution_lane: "converse",
+    latency_budget_ms: 5_000,
+    max_selected_capabilities: 0,
+    max_tool_calls: 0,
+    schema_version: "assistant-turn-budget/v1",
+  });
+  assert.equal(assistantTurnBudget("lookup").max_tool_calls, 3);
+  assert.equal(assistantTurnBudget("investigate").max_tool_calls, 8);
+  assert.equal(assistantTurnBudget("act").max_tool_calls, 12);
+});
+
+test("assistant turn budgets cannot expand host bounds", () => {
+  assert.equal(assistantTurnBudget("investigate", { max_tool_calls: 4 }).max_tool_calls, 4);
+  assert.equal(assistantTurnBudget("act", { timeout_ms: 45_000 }).latency_budget_ms, 45_000);
+  assert.throws(
+    () => assistantTurnBudget("lookup", { max_tool_calls: -1 }),
+    AssistantTurnInputError,
+  );
+});
+test("assistant progress is concrete, bounded, and safe to persist", () => {
+  const progress = normalizeAssistantTurnProgress({
+    capability_ref: "source://github/membership",
+    execution_lane: "lookup",
+    occurred_at: "2026-07-18T12:00:00.000Z",
+    phase: "checking",
+    sequence: 2,
+    status: "  Checking\nGitHub membership  ",
+  });
+  assert.deepEqual(progress, {
+    capability_ref: "source://github/membership",
+    execution_lane: "lookup",
+    occurred_at: "2026-07-18T12:00:00.000Z",
+    phase: "checking",
+    schema_version: "assistant-turn-progress/v1",
+    sequence: 2,
+    status: "Checking GitHub membership",
+  });
+  assert.throws(
+    () => normalizeAssistantTurnProgress({ occurred_at: "bad", phase: "checking", sequence: 1, status: "Checking GitHub" }),
+    AssistantTurnInputError,
+  );
+});


### PR DESCRIPTION
## What changed

- Add versioned execution-lane budgets for tool calls, selected capabilities, and latency.
- Add normalized Slack assistant progress phases with bounded status text.
- Export and document the host contract for delivery-authoritative continuity.

## Validation

- `npm run check --workspace apps/slack-companion`
- `npm run check:workspaces`
- `make oss-audit`
- Practice Registry final gate: passed
