### PR TITLE
build(deps): update PostCSS override to 8.5.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8500,9 +8500,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "typecheck:workspaces": "npm run typecheck --workspaces --if-present"
   },
   "overrides": {
-    "postcss": "8.5.15"
+    "postcss": "8.5.19"
   }
 }


### PR DESCRIPTION
## Summary

- update the existing root PostCSS override from 8.5.15 to 8.5.19
- refresh only the PostCSS lockfile entry
- keep the existing workspace dependency and ownership boundary unchanged

## Validation

- `npm ci`
- `npm audit`
- `npm run check --workspace @writer/cerebro-web`
- `npm run verify:build --workspace @writer/cerebro-web`
- `make app-workspace-check`
- `make oss-audit`
- `bash scripts/leak_check.sh range origin/main...HEAD`
- `make droid-review-preflight droid-review-sast`
- Practice Registry final gate: allowed, no findings

