### PR TITLE
ci(web): own base image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,6 +111,21 @@ updates:
           - "golang"
           - "alpine"
 
+  - package-ecosystem: "docker"
+    directory: "/apps/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+      - "web"
+    groups:
+      web-base-images:
+        patterns:
+          - "node"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,7 +120,6 @@ updates:
     labels:
       - "dependencies"
       - "docker"
-      - "web"
     groups:
       web-base-images:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -119,7 +119,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "docker"
     groups:
       web-base-images:
         patterns:


### PR DESCRIPTION
## Summary

- register the web Dockerfile for weekly base-image updates
- group Node base-image updates under the existing dependency workflow
- preserve the current runtime baseline and digest pinning

## Validation

- Dependabot YAML parses successfully
- exactly one Docker updater targets `/apps/web`
- the updater matches the `node` base image
- diff and staged leak checks passed

## Boundary

This change adds updater ownership only. It does not add deployment configuration, credentials, endpoints, environment values, or release routing.