### PR TITLE
ci(slack): inspect release package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,22 @@ jobs:
       - name: Check Slack companion workspace
         run: npm run check --workspace @writer/cerebro-slack-companion
 
+      - name: Inspect Slack companion package
+        shell: bash
+        run: |
+          set -euo pipefail
+          pack_dir="${RUNNER_TEMP}/slack-companion-package"
+          mkdir -p "${pack_dir}"
+          npm pack --workspace @writer/cerebro-slack-companion --pack-destination "${pack_dir}"
+          mapfile -t archives < <(find "${pack_dir}" -maxdepth 1 -type f -name '*.tgz' -print)
+          if [ "${#archives[@]}" -ne 1 ]; then
+            echo "Expected one Slack companion package, found ${#archives[@]}" >&2
+            exit 1
+          fi
+          tar -tzf "${archives[0]}" > "${pack_dir}/contents.txt"
+          grep -Fxq 'package/dist/src/index.js' "${pack_dir}/contents.txt"
+          grep -Fxq 'package/dist/src/index.d.ts' "${pack_dir}/contents.txt"
+
   typescript-sdk:
     runs-on: ubuntu-latest
     needs: ci-scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,13 @@ jobs:
           pack_dir="${RUNNER_TEMP}/slack-companion-package"
           mkdir -p "${pack_dir}"
           npm pack --workspace @writer/cerebro-slack-companion --pack-destination "${pack_dir}"
-          mapfile -t archives < <(find "${pack_dir}" -maxdepth 1 -type f -name '*.tgz' -print)
-          if [ "${#archives[@]}" -ne 1 ]; then
-            echo "Expected one Slack companion package, found ${#archives[@]}" >&2
+          archive_count=$(find "${pack_dir}" -maxdepth 1 -type f -name '*.tgz' -print | wc -l | tr -d '[:space:]')
+          if [ "${archive_count}" -ne 1 ]; then
+            echo "Expected one Slack companion package, found ${archive_count}" >&2
             exit 1
           fi
-          tar -tzf "${archives[0]}" > "${pack_dir}/contents.txt"
+          archive=$(find "${pack_dir}" -maxdepth 1 -type f -name '*.tgz' -print -quit)
+          tar -tzf "${archive}" > "${pack_dir}/contents.txt"
           grep -Fxq 'package/dist/src/index.js' "${pack_dir}/contents.txt"
           grep -Fxq 'package/dist/src/index.d.ts' "${pack_dir}/contents.txt"
 


### PR DESCRIPTION
## Summary

- pack the Slack companion after its existing build and test gate
- require exactly one generated archive
- verify the archive contains the declared JavaScript entry point and TypeScript declarations
- keep publishing, credentials, and deployment configuration out of CI

## Validation

- Slack companion check: 169 tests
- package inspection: 130 archive members; runtime and type entry points present
- actionlint
- 35 application CI and workspace tests
- app workspace contract
- OSS audit
- npm audit: 0 vulnerabilities