### PR TITLE
ci(web): keep image on selected Node line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -119,6 +119,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       web-base-images:
         patterns:


### PR DESCRIPTION
## Summary

- keep automated web-image updates within the repository-selected Node major line
- continue digest, patch, and minor updates for that line
- reserve Node major upgrades for one coordinated change across CI, packaging, and the production image
- supersede the uncoordinated Node 26 proposal in #1999 after this gate lands

## Validation

- Dependabot YAML parsed successfully
- exact /apps/web Docker updater, node dependency, major-ignore rule, and update group asserted
- OSS audit
- git diff check