### PR TITLE
feat(slack): project multipart delivery receipts

### DIFF
--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -59,6 +59,7 @@ export * from "./operations/migration.js";
 export * from "./operations/schedules.js";
 export * from "./operations/status.js";
 export * from "./ports.js";
+export * from "./projections/multipart.js";
 export * from "./question-work/contracts.js";
 export * from "./question-work/coordinator.js";
 export * from "./question-work/dispatch-policy.js";

--- a/apps/slack-companion/src/projections/multipart.ts
+++ b/apps/slack-companion/src/projections/multipart.ts
@@ -1,0 +1,279 @@
+import { createHash } from "node:crypto";
+import type { DeliveryPartV1, DeliveryReceiptV1 } from "../delivery/contracts.js";
+
+export interface SlackMultipartAcceptanceV1 {
+  readonly accepted_at: string;
+  readonly destination_receipt: string;
+}
+
+export interface SlackMultipartPartProjectionV1 {
+  readonly acceptance?: SlackMultipartAcceptanceV1;
+  readonly client_message_id: string;
+  readonly part_id: string;
+  readonly payload_digest: string;
+  readonly payload_ref: string;
+  readonly schema_version: "slack-multipart-part-projection/v1";
+  readonly sequence: number;
+  readonly state: DeliveryPartV1["state"];
+}
+
+export interface SlackMultipartProjectionV1 {
+  readonly accepted_part_count: number;
+  readonly delivery_id: string;
+  readonly destination_ref: string;
+  readonly part_count: number;
+  readonly parts: readonly SlackMultipartPartProjectionV1[];
+  readonly projection_id: string;
+  readonly run_id: string;
+  readonly schema_version: "slack-multipart-projection/v1";
+  readonly state: DeliveryReceiptV1["state"];
+  readonly undelivered_part_count: number;
+  readonly updated_at: string;
+}
+
+export class SlackMultipartProjectionError extends Error {}
+
+/**
+ * Builds a transport-neutral view of one durable multipart message receipt.
+ * Payload contents and provider-specific send calls remain behind host ports.
+ */
+export function projectSlackMultipartDelivery(
+  receipt: DeliveryReceiptV1,
+): SlackMultipartProjectionV1 {
+  if (receipt.schema_version !== "delivery-receipt/v1") {
+    throw new SlackMultipartProjectionError(
+      "Slack multipart delivery version is unsupported.",
+    );
+  }
+  if (!Array.isArray(receipt.parts) || receipt.parts.length === 0) {
+    throw new SlackMultipartProjectionError(
+      "Slack multipart delivery requires at least one part.",
+    );
+  }
+  const deliveryId = requiredKey(receipt.delivery_id, "delivery_id");
+  const runId = requiredKey(receipt.run_id, "run_id");
+  const destinationRef = requiredRef(
+    receipt.destination_ref,
+    "destination_ref",
+  );
+  const updatedAt = requiredTimestamp(receipt.updated_at, "updated_at");
+  requiredTimestamp(receipt.created_at, "created_at");
+
+  const partIds = new Set<string>();
+  const messageIds = new Set<string>();
+  const parts = [...receipt.parts]
+    .sort((left, right) => left.sequence - right.sequence)
+    .map((part, index) =>
+      projectPart(part, index + 1, partIds, messageIds),
+    );
+  validateAggregateState(receipt.state, parts);
+  const acceptedPartCount = parts.filter(
+    (part) => part.state === "delivered",
+  ).length;
+  const projectionDigest = createHash("sha256")
+    .update(JSON.stringify({
+      delivery_id: deliveryId,
+      destination_ref: destinationRef,
+      parts,
+      run_id: runId,
+      state: receipt.state,
+      updated_at: updatedAt,
+    }))
+    .digest("hex");
+
+  return Object.freeze({
+    accepted_part_count: acceptedPartCount,
+    delivery_id: deliveryId,
+    destination_ref: destinationRef,
+    part_count: parts.length,
+    parts: Object.freeze(parts),
+    projection_id: `${deliveryId}:sha256:${projectionDigest}`,
+    run_id: runId,
+    schema_version: "slack-multipart-projection/v1",
+    state: receipt.state,
+    undelivered_part_count: parts.length - acceptedPartCount,
+    updated_at: updatedAt,
+  });
+}
+
+function projectPart(
+  part: DeliveryPartV1,
+  expectedSequence: number,
+  partIds: Set<string>,
+  messageIds: Set<string>,
+): SlackMultipartPartProjectionV1 {
+  if (part.sequence !== expectedSequence) {
+    throw new SlackMultipartProjectionError(
+      "Slack multipart part sequences must be contiguous.",
+    );
+  }
+  const partId = uniqueKey(part.part_id, "part_id", partIds);
+  const clientMessageId = uniqueKey(
+    part.idempotency_key,
+    "idempotency_key",
+    messageIds,
+  );
+  const payloadDigest = requiredKey(part.payload_digest, "payload_digest");
+  const payloadRef = requiredRef(part.payload_ref, "payload_ref");
+  let acceptance: SlackMultipartAcceptanceV1 | undefined;
+  if (part.state === "delivered") {
+    if (
+      part.destination_receipt === undefined
+      || part.delivered_at === undefined
+    ) {
+      throw new SlackMultipartProjectionError(
+        "Delivered Slack multipart parts require an acceptance receipt.",
+      );
+    }
+    acceptance = Object.freeze({
+      accepted_at: requiredTimestamp(part.delivered_at, "delivered_at"),
+      destination_receipt: requiredKey(
+        part.destination_receipt,
+        "destination_receipt",
+      ),
+    });
+  } else if (
+    part.destination_receipt !== undefined
+    || part.delivered_at !== undefined
+  ) {
+    throw new SlackMultipartProjectionError(
+      "Undelivered Slack multipart parts cannot carry an acceptance receipt.",
+    );
+  }
+
+  return Object.freeze({
+    ...(acceptance === undefined ? {} : { acceptance }),
+    client_message_id: clientMessageId,
+    part_id: partId,
+    payload_digest: payloadDigest,
+    payload_ref: payloadRef,
+    schema_version: "slack-multipart-part-projection/v1",
+    sequence: part.sequence,
+    state: part.state,
+  });
+}
+
+function validateAggregateState(
+  state: DeliveryReceiptV1["state"],
+  parts: readonly SlackMultipartPartProjectionV1[],
+): void {
+  if (state === "pending") {
+    requirePartStates(state, parts, ["pending"]);
+    return;
+  }
+  if (state === "delivering") {
+    requirePartStates(state, parts, [
+      "pending",
+      "delivering",
+      "delivered",
+      "failed",
+    ]);
+    if (parts.every((part) => part.state === "pending")) {
+      throw new SlackMultipartProjectionError(
+        "Delivering Slack multipart delivery requires a started part.",
+      );
+    }
+    if (parts.every((part) => part.state === "delivered")) {
+      throw new SlackMultipartProjectionError(
+        "Delivering Slack multipart delivery requires an unfinished part.",
+      );
+    }
+    return;
+  }
+  if (state === "completed") {
+    requirePartStates(state, parts, ["delivered"]);
+    return;
+  }
+  if (state === "paused") {
+    requirePartStates(state, parts, ["pending", "delivered", "paused"]);
+    requirePartState(state, parts, "paused");
+    return;
+  }
+  if (state === "abandoned") {
+    requirePartStates(state, parts, ["delivered", "abandoned"]);
+    requirePartState(state, parts, "abandoned");
+    return;
+  }
+  requirePartStates(state, parts, ["pending", "delivered", "failed"]);
+  requirePartState(state, parts, "failed");
+}
+
+function requirePartStates(
+  aggregateState: DeliveryReceiptV1["state"],
+  parts: readonly SlackMultipartPartProjectionV1[],
+  allowed: readonly DeliveryPartV1["state"][],
+): void {
+  if (parts.some((part) => !allowed.includes(part.state))) {
+    throw new SlackMultipartProjectionError(
+      `${aggregateState} Slack multipart delivery contains a contradictory part state.`,
+    );
+  }
+}
+
+function requirePartState(
+  aggregateState: DeliveryReceiptV1["state"],
+  parts: readonly SlackMultipartPartProjectionV1[],
+  required: DeliveryPartV1["state"],
+): void {
+  if (parts.every((part) => part.state !== required)) {
+    throw new SlackMultipartProjectionError(
+      `${aggregateState} Slack multipart delivery requires a ${required} part.`,
+    );
+  }
+}
+
+function uniqueKey(value: string, field: string, seen: Set<string>): string {
+  const normalized = requiredKey(value, field);
+  if (seen.has(normalized)) {
+    throw new SlackMultipartProjectionError(
+      `Slack multipart delivery repeats ${field}.`,
+    );
+  }
+  seen.add(normalized);
+  return normalized;
+}
+
+function requiredTimestamp(value: string, field: string): string {
+  const normalized = requiredText(value, field, 64);
+  const parsed = Date.parse(normalized);
+  if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== normalized) {
+    throw new SlackMultipartProjectionError(
+      `Slack multipart ${field} must be a canonical ISO-8601 timestamp.`,
+    );
+  }
+  return normalized;
+}
+
+function requiredRef(value: string, field: string): string {
+  const normalized = requiredText(value, field, 2_048);
+  if (!/^[a-z][a-z0-9+.-]*:\/\/\S+$/.test(normalized)) {
+    throw new SlackMultipartProjectionError(
+      `Slack multipart ${field} must be an opaque reference.`,
+    );
+  }
+  return normalized;
+}
+
+function requiredKey(value: string, field: string): string {
+  const normalized = requiredText(value, field, 512);
+  if (/\s/.test(normalized)) {
+    throw new SlackMultipartProjectionError(
+      `Slack multipart ${field} must not contain whitespace.`,
+    );
+  }
+  return normalized;
+}
+
+function requiredText(value: string, field: string, maximum: number): string {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value.length > maximum
+    || /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new SlackMultipartProjectionError(
+      `Slack multipart ${field} is invalid.`,
+    );
+  }
+  return value;
+}

--- a/apps/slack-companion/test/slack-multipart-projection.test.ts
+++ b/apps/slack-companion/test/slack-multipart-projection.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { DeliveryReceiptV1 } from "../src/delivery/contracts.js";
+import {
+  projectSlackMultipartDelivery,
+  SlackMultipartProjectionError,
+} from "../src/index.js";
+
+test("multipart projections preserve exact acceptance and partial progress", () => {
+  const projection = projectSlackMultipartDelivery(deliveryReceipt());
+
+  assert.equal(projection.accepted_part_count, 1);
+  assert.equal(projection.undelivered_part_count, 1);
+  assert.equal(projection.parts[0]?.client_message_id, "delivery-1:part:1");
+  assert.deepEqual(projection.parts[0]?.acceptance, {
+    accepted_at: "2026-07-18T10:00:02.000Z",
+    destination_receipt: "slack-receipt://message/one",
+  });
+  assert.equal(projection.parts[1]?.state, "pending");
+  assert.match(
+    projection.projection_id,
+    /^delivery-1:sha256:[0-9a-f]{64}$/,
+  );
+  assert.equal(
+    projection.projection_id,
+    projectSlackMultipartDelivery(deliveryReceipt()).projection_id,
+  );
+  assert.equal(Object.isFrozen(projection), true);
+  assert.equal(Object.isFrozen(projection.parts), true);
+});
+
+test("multipart projections accept the canonical delivering part state", () => {
+  const receipt = deliveryReceipt();
+  const projection = projectSlackMultipartDelivery({
+    ...receipt,
+    parts: [
+      receipt.parts[0]!,
+      { ...receipt.parts[1]!, state: "delivering" },
+    ],
+  });
+
+  assert.equal(projection.state, "delivering");
+  assert.equal(projection.parts[1]?.state, "delivering");
+});
+
+test("multipart projections preserve retryable failed parts", () => {
+  const receipt = deliveryReceipt();
+  const projection = projectSlackMultipartDelivery({
+    ...receipt,
+    parts: [
+      receipt.parts[0]!,
+      { ...receipt.parts[1]!, state: "failed" },
+    ],
+  });
+
+  assert.equal(projection.state, "delivering");
+  assert.equal(projection.parts[1]?.state, "failed");
+  assert.equal(projection.undelivered_part_count, 1);
+});
+
+test("multipart projection identities distinguish same-time state changes", () => {
+  const receipt = deliveryReceipt();
+  const paused = projectSlackMultipartDelivery({
+    ...receipt,
+    parts: [
+      receipt.parts[0]!,
+      { ...receipt.parts[1]!, state: "paused" },
+    ],
+    state: "paused",
+  });
+  const delivering = projectSlackMultipartDelivery(receipt);
+
+  assert.equal(paused.updated_at, delivering.updated_at);
+  assert.notEqual(paused.projection_id, delivering.projection_id);
+});
+
+test("multipart projections reject gaps and duplicate durable identities", () => {
+  const receipt = deliveryReceipt();
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        parts: [
+          receipt.parts[0]!,
+          { ...receipt.parts[1]!, sequence: 3 },
+        ],
+      }),
+    /sequences must be contiguous/,
+  );
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        parts: [
+          receipt.parts[0]!,
+          { ...receipt.parts[1]!, part_id: "part-1" },
+        ],
+      }),
+    /repeats part_id/,
+  );
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        parts: [
+          receipt.parts[0]!,
+          {
+            ...receipt.parts[1]!,
+            idempotency_key: "delivery-1:part:1",
+          },
+        ],
+      }),
+    /repeats idempotency_key/,
+  );
+});
+
+test("multipart projections reject contradictory acceptance receipts", () => {
+  const receipt = deliveryReceipt();
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        parts: [
+          { ...receipt.parts[0]!, destination_receipt: undefined },
+          receipt.parts[1]!,
+        ],
+      }),
+    SlackMultipartProjectionError,
+  );
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        parts: [
+          receipt.parts[0]!,
+          {
+            ...receipt.parts[1]!,
+            delivered_at: "2026-07-18T10:00:03.000Z",
+          },
+        ],
+      }),
+    /cannot carry an acceptance receipt/,
+  );
+});
+
+test("multipart projections enforce truthful aggregate states", () => {
+  const receipt = deliveryReceipt();
+  assert.throws(
+    () => projectSlackMultipartDelivery({ ...receipt, state: "completed" }),
+    /completed Slack multipart delivery contains a contradictory part state/,
+  );
+  assert.throws(
+    () => projectSlackMultipartDelivery({ ...receipt, state: "pending" }),
+    /pending Slack multipart delivery contains a contradictory part state/,
+  );
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        parts: receipt.parts.map((part) => ({
+          ...part,
+          delivered_at: undefined,
+          destination_receipt: undefined,
+          state: "pending" as const,
+        })),
+      }),
+    /requires a started part/,
+  );
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        state: "paused",
+      }),
+    /requires a paused part/,
+  );
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        parts: [
+          receipt.parts[0]!,
+          { ...receipt.parts[1]!, state: "abandoned" },
+        ],
+        state: "failed",
+      }),
+    /contains a contradictory part state/,
+  );
+});
+
+test("multipart projections support paused, abandoned, and failed truth", () => {
+  const receipt = deliveryReceipt();
+  for (const state of ["paused", "abandoned", "failed"] as const) {
+    const projection = projectSlackMultipartDelivery({
+      ...receipt,
+      parts: [
+        receipt.parts[0]!,
+        { ...receipt.parts[1]!, state },
+      ],
+      state,
+    });
+    assert.equal(projection.state, state);
+    assert.equal(projection.parts[1]?.state, state);
+  }
+});
+
+test("multipart projections require canonical timestamps and opaque refs", () => {
+  const receipt = deliveryReceipt();
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        updated_at: "2026-07-18T10:00:02Z",
+      }),
+    /canonical ISO-8601 timestamp/,
+  );
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        destination_ref: "channel-and-thread",
+      }),
+    /must be an opaque reference/,
+  );
+});
+
+function deliveryReceipt(): DeliveryReceiptV1 {
+  return {
+    created_at: "2026-07-18T10:00:00.000Z",
+    delivery_id: "delivery-1",
+    destination_ref: "slack-thread://channel/thread",
+    parts: [
+      {
+        delivered_at: "2026-07-18T10:00:02.000Z",
+        destination_receipt: "slack-receipt://message/one",
+        idempotency_key: "delivery-1:part:1",
+        part_id: "part-1",
+        payload_digest: "sha256:one",
+        payload_ref: "payload://delivery/one",
+        sequence: 1,
+        state: "delivered",
+      },
+      {
+        idempotency_key: "delivery-1:part:2",
+        part_id: "part-2",
+        payload_digest: "sha256:two",
+        payload_ref: "payload://delivery/two",
+        sequence: 2,
+        state: "pending",
+      },
+    ],
+    run_id: "run-1",
+    schema_version: "delivery-receipt/v1",
+    state: "delivering",
+    updated_at: "2026-07-18T10:00:02.000Z",
+  };
+}


### PR DESCRIPTION
Summary:
- add a portable projection for durable multipart delivery receipts
- enforce exact aggregate and part-state consistency
- derive deterministic content-bound projection identities
- cover retries, partial acceptance, pause, abandonment, and failure

Validation:
- npm test --workspace apps/slack-companion
- make app-workspace-check
- make droid-review-preflight droid-review-sast
- make oss-audit
- public leak check
- Practice Registry final gate