### PR TITLE
feat(slack): add durable evidence recheck contracts

### DIFF
--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -68,8 +68,10 @@ unchanged. A missing or conflicting receipt lookup fails closed.
 
 `src/recheck` admits a recheck only for evidence already bound server-side to a
 fully delivered answer and its durable conversation thread. The requester does
-not select an evidence location. Only the original requester or a recorded
-operator can use the binding. The binding includes a canonical digest of the
+not select an evidence location or submit the binding contents. A required
+host-owned lookup resolves the immutable binding before authorization policy
+runs. Only the original requester or a recorded operator can use the binding.
+The binding includes a canonical digest of the
 completed delivery receipt and its ordered part receipts; duplicate part or
 idempotency identities fail closed.
 

--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -64,6 +64,24 @@ commit with the watch update. Later retries return that receipt even after
 other observations or retirement, while the current watch revision remains
 unchanged. A missing or conflicting receipt lookup fails closed.
 
+## Evidence rechecks
+
+`src/recheck` admits a recheck only for evidence already bound server-side to a
+fully delivered answer and its durable conversation thread. The requester does
+not select an evidence location. Only the original requester or a recorded
+operator can use the binding.
+
+Admission derives stable recheck, run, queue-item, and receipt identities. The
+host must commit the immutable request, canonical reconciliation run, admission
+transitions, queue item, and receipt in one durable transaction before transport
+acknowledgement is permitted. Exact retries return the existing receipt;
+conflicting receipt reuse fails closed. Portable status projections show queued,
+duplicate, in-progress, completed, degraded, and rejected states.
+
+The public module contains only records, validation, deterministic policy, and
+synthetic tests. Evidence resolution, persistence, execution, authorization
+lookup, and Slack transport remain host-owned.
+
 Production implementations of `DurableAdmissionPort` must use durable storage with one transaction or an equivalent recoverable commit protocol. The in-memory implementation under `src/testing` is a conformance fixture only.
 
 This workspace must not contain credentials, infrastructure identifiers, environment routes, deployment manifests, or provider-specific persistence adapters. Those belong in the private operational repository. A deployment may replace every port without changing the Slack application identity, binding identity, run identity, or thread identity.

--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -69,7 +69,9 @@ unchanged. A missing or conflicting receipt lookup fails closed.
 `src/recheck` admits a recheck only for evidence already bound server-side to a
 fully delivered answer and its durable conversation thread. The requester does
 not select an evidence location. Only the original requester or a recorded
-operator can use the binding.
+operator can use the binding. The binding includes a canonical digest of the
+completed delivery receipt and its ordered part receipts; duplicate part or
+idempotency identities fail closed.
 
 Admission derives stable recheck, run, queue-item, and receipt identities. The
 host must commit the immutable request, canonical reconciliation run, admission

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -64,6 +64,8 @@ export * from "./question-work/coordinator.js";
 export * from "./question-work/dispatch-policy.js";
 export * from "./question-work/ports.js";
 export * from "./question-work/reference-store.js";
+export * from "./recheck/contracts.js";
+export * from "./recheck/policy.js";
 export * from "./thread-binding.js";
 export * from "./transport/contracts.js";
 export * from "./transport/handler.js";

--- a/apps/slack-companion/src/recheck/contracts.ts
+++ b/apps/slack-companion/src/recheck/contracts.ts
@@ -1,0 +1,223 @@
+import type {
+  CapabilityRequirement,
+  DeliveryReceiptV1,
+  RunReceiptV1,
+} from "@writer/cerebro-sdk";
+
+export const EVIDENCE_RECHECK_LIMITS = {
+  delivery_parts: 256,
+  evidence_artifact_ids: 32,
+  operator_refs: 64,
+  ref_utf8_bytes: 2_048,
+  request_key_utf8_bytes: 256,
+  required_capabilities: 32,
+} as const;
+
+export type EvidenceRecheckStateV1 =
+  | "queued"
+  | "running"
+  | "completed"
+  | "degraded";
+
+export type SlackEvidenceRecheckStatusKindV1 =
+  | "queued"
+  | "duplicate"
+  | "in_progress"
+  | "completed"
+  | "degraded"
+  | "rejected";
+
+/**
+ * Immutable server-owned binding for evidence already attached to a fully
+ * delivered answer. Interactive requests carry only `binding_ref`.
+ */
+export interface DeliveredAnswerEvidenceBindingV1 {
+  answer_ref: string;
+  answer_run_id: string;
+  binding_digest: string;
+  binding_ref: string;
+  bound_at: string;
+  conversation_ref: string;
+  delivery_id: string;
+  evidence_artifact_ids: string[];
+  operator_refs: string[];
+  requester_ref: string;
+  schema_version: "delivered-answer-evidence-binding/v1";
+  thread_ref: string;
+}
+
+export interface BindDeliveredAnswerEvidenceInputV1 {
+  answer_ref: string;
+  answer_run_id: string;
+  bound_at: string;
+  conversation_ref: string;
+  delivery: DeliveryReceiptV1;
+  evidence_artifact_ids: readonly string[];
+  operator_refs: readonly string[];
+  requester_ref: string;
+  thread_ref: string;
+}
+
+export type EvidenceRecheckAuthorizationV1 =
+  | {
+      allowed: true;
+      role: "requester" | "operator";
+      schema_version: "evidence-recheck-authorization/v1";
+    }
+  | {
+      allowed: false;
+      reason_code: "actor_not_authorized" | "binding_reference_mismatch";
+      schema_version: "evidence-recheck-authorization/v1";
+    };
+
+/** Server-derived lifecycle context for the admitted reconciliation run. */
+export interface EvidenceRecheckRunContextV1 {
+  required_capabilities: readonly CapabilityRequirement[];
+  retention_policy_ref: string;
+  service_binding_id: string;
+  subject_ref: string;
+  tenant_id: string;
+}
+
+/**
+ * Transport-neutral input. It contains no answer text, prompt, transport
+ * payload, destination address, or caller-selected evidence location.
+ */
+export interface AdmitEvidenceRecheckInputV1 {
+  actor_ref: string;
+  admitted_at: string;
+  binding: DeliveredAnswerEvidenceBindingV1;
+  binding_ref: string;
+  received_at: string;
+  request_key: string;
+  run_context: EvidenceRecheckRunContextV1;
+}
+
+export interface EvidenceRecheckV1 {
+  actor_ref: string;
+  answer_ref: string;
+  binding_digest: string;
+  binding_ref: string;
+  completed_at?: string;
+  created_at: string;
+  evidence_artifact_ids: string[];
+  outcome_digest?: string;
+  outcome_ref?: string;
+  reason_code: string;
+  recheck_id: string;
+  request_key: string;
+  revision: number;
+  run_id: string;
+  schema_version: "evidence-recheck/v1";
+  state: EvidenceRecheckStateV1;
+  thread_ref: string;
+  updated_at: string;
+}
+
+export interface EvidenceRecheckQueueItemV1 {
+  available_at: string;
+  binding_digest: string;
+  binding_ref: string;
+  evidence_artifact_ids: string[];
+  idempotency_key: string;
+  queue_item_id: string;
+  recheck_id: string;
+  run_id: string;
+  schema_version: "evidence-recheck-queue-item/v1";
+  thread_ref: string;
+}
+
+export interface EvidenceRecheckAdmissionReceiptV1 {
+  input_digest: string;
+  queue_item: EvidenceRecheckQueueItemV1;
+  receipt_id: string;
+  recheck: EvidenceRecheckV1;
+  run: RunReceiptV1;
+  schema_version: "evidence-recheck-admission-receipt/v1";
+}
+
+/** The host resolves this durable receipt lookup before policy execution. */
+export type EvidenceRecheckAdmissionReceiptLookupV1 =
+  | {
+      found: false;
+      receipt_id: string;
+      schema_version: "evidence-recheck-admission-receipt-lookup/v1";
+    }
+  | {
+      found: true;
+      receipt: EvidenceRecheckAdmissionReceiptV1;
+      schema_version: "evidence-recheck-admission-receipt-lookup/v1";
+    };
+
+export interface EvidenceRecheckAdmissionCommitV1 {
+  receipt: EvidenceRecheckAdmissionReceiptV1;
+  transitions: readonly [
+    { from: "received"; to: "admitted" },
+    { from: "admitted"; to: "queued" },
+  ];
+}
+
+export interface EvidenceRecheckAdmissionCommitResultV1 {
+  created: boolean;
+  receipt: EvidenceRecheckAdmissionReceiptV1;
+}
+
+/**
+ * The production adapter commits the immutable receipt, recheck snapshot,
+ * canonical run receipt, transitions, and queue item as one durable unit.
+ */
+export interface DurableEvidenceRecheckAdmissionPort {
+  admitAndEnqueue(
+    commit: EvidenceRecheckAdmissionCommitV1,
+  ): Promise<EvidenceRecheckAdmissionCommitResultV1>;
+}
+
+export type AdmitEvidenceRecheckResultV1 =
+  | {
+      acknowledgement_permitted: true;
+      authorization: Extract<EvidenceRecheckAuthorizationV1, { allowed: true }>;
+      duplicate: boolean;
+      receipt: EvidenceRecheckAdmissionReceiptV1;
+      retryable: false;
+      schema_version: "admit-evidence-recheck-result/v1";
+      status: "queued" | "duplicate";
+    }
+  | {
+      acknowledgement_permitted: false;
+      authorization: Extract<EvidenceRecheckAuthorizationV1, { allowed: false }>;
+      duplicate: false;
+      reason_code: "actor_not_authorized" | "binding_reference_mismatch";
+      retryable: false;
+      schema_version: "admit-evidence-recheck-result/v1";
+      status: "rejected";
+    }
+  | {
+      acknowledgement_permitted: false;
+      authorization: Extract<EvidenceRecheckAuthorizationV1, { allowed: true }>;
+      duplicate: false;
+      reason_code: "durable_admission_unavailable";
+      retryable: true;
+      schema_version: "admit-evidence-recheck-result/v1";
+      status: "degraded";
+    };
+
+export interface SlackEvidenceRecheckStatusV1 {
+  message: string;
+  recheck_id?: string;
+  retryable: boolean;
+  schema_version: "slack-evidence-recheck-status/v1";
+  status: SlackEvidenceRecheckStatusKindV1;
+  terminal: boolean;
+}
+
+export type EvidenceRecheckStatusInputV1 =
+  | {
+      kind: "admission";
+      result: AdmitEvidenceRecheckResultV1;
+      schema_version: "evidence-recheck-status-input/v1";
+    }
+  | {
+      kind: "recheck";
+      recheck: EvidenceRecheckV1;
+      schema_version: "evidence-recheck-status-input/v1";
+    };

--- a/apps/slack-companion/src/recheck/contracts.ts
+++ b/apps/slack-companion/src/recheck/contracts.ts
@@ -87,12 +87,27 @@ export interface EvidenceRecheckRunContextV1 {
 export interface AdmitEvidenceRecheckInputV1 {
   actor_ref: string;
   admitted_at: string;
-  binding: DeliveredAnswerEvidenceBindingV1;
   binding_ref: string;
   received_at: string;
   request_key: string;
   run_context: EvidenceRecheckRunContextV1;
 }
+
+/**
+ * Trusted, host-resolved lookup for the immutable binding. This receipt is a
+ * policy dependency, never a field accepted from the interactive request.
+ */
+export type DeliveredAnswerEvidenceBindingLookupV1 =
+  | {
+      binding_ref: string;
+      found: false;
+      schema_version: "delivered-answer-evidence-binding-lookup/v1";
+    }
+  | {
+      binding: DeliveredAnswerEvidenceBindingV1;
+      found: true;
+      schema_version: "delivered-answer-evidence-binding-lookup/v1";
+    };
 
 export interface EvidenceRecheckV1 {
   actor_ref: string;

--- a/apps/slack-companion/src/recheck/contracts.ts
+++ b/apps/slack-companion/src/recheck/contracts.ts
@@ -38,6 +38,7 @@ export interface DeliveredAnswerEvidenceBindingV1 {
   binding_ref: string;
   bound_at: string;
   conversation_ref: string;
+  delivery_digest: string;
   delivery_id: string;
   evidence_artifact_ids: string[];
   operator_refs: string[];

--- a/apps/slack-companion/src/recheck/policy.ts
+++ b/apps/slack-companion/src/recheck/policy.ts
@@ -1,0 +1,947 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import type { CapabilityRequirement, RunReceiptV1 } from "@writer/cerebro-sdk";
+import {
+  EVIDENCE_RECHECK_LIMITS,
+  type AdmitEvidenceRecheckInputV1,
+  type AdmitEvidenceRecheckResultV1,
+  type BindDeliveredAnswerEvidenceInputV1,
+  type DeliveredAnswerEvidenceBindingV1,
+  type DurableEvidenceRecheckAdmissionPort,
+  type EvidenceRecheckAdmissionCommitResultV1,
+  type EvidenceRecheckAdmissionReceiptLookupV1,
+  type EvidenceRecheckAdmissionReceiptV1,
+  type EvidenceRecheckAuthorizationV1,
+  type EvidenceRecheckQueueItemV1,
+  type EvidenceRecheckStatusInputV1,
+  type EvidenceRecheckV1,
+  type SlackEvidenceRecheckStatusV1,
+} from "./contracts.js";
+
+const UNSAFE_TEXT_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+const OPAQUE_ARTIFACT_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const RECHECK_STATES: readonly EvidenceRecheckV1["state"][] = [
+  "queued",
+  "running",
+  "completed",
+  "degraded",
+];
+
+export class EvidenceRecheckInvariantError extends Error {}
+
+export function bindDeliveredAnswerEvidence(
+  input: BindDeliveredAnswerEvidenceInputV1,
+): DeliveredAnswerEvidenceBindingV1 {
+  assertExactKeys(input, [
+    "answer_ref",
+    "answer_run_id",
+    "bound_at",
+    "conversation_ref",
+    "delivery",
+    "evidence_artifact_ids",
+    "operator_refs",
+    "requester_ref",
+    "thread_ref",
+  ], "delivered answer evidence input");
+  requireRef(input.answer_ref, "answer_ref");
+  requireRef(input.answer_run_id, "answer_run_id");
+  requireRef(input.conversation_ref, "conversation_ref");
+  requireRef(input.requester_ref, "requester_ref");
+  requireRef(input.thread_ref, "thread_ref");
+  const boundAt = normalizeTimestamp(input.bound_at, "bound_at");
+  validateCompletedDelivery(input.delivery, input.answer_run_id);
+  const evidenceArtifactIds = canonicalArtifactIds(input.evidence_artifact_ids);
+  const operatorRefs = canonicalRefs(
+    input.operator_refs,
+    EVIDENCE_RECHECK_LIMITS.operator_refs,
+    "operator_refs",
+  );
+  const bindingDigest = deliveredAnswerEvidenceBindingDigest({
+    answer_ref: input.answer_ref,
+    answer_run_id: input.answer_run_id,
+    bound_at: boundAt,
+    conversation_ref: input.conversation_ref,
+    delivery_id: input.delivery.delivery_id,
+    evidence_artifact_ids: evidenceArtifactIds,
+    operator_refs: operatorRefs,
+    requester_ref: input.requester_ref,
+    thread_ref: input.thread_ref,
+  });
+  return {
+    answer_ref: input.answer_ref,
+    answer_run_id: input.answer_run_id,
+    binding_digest: bindingDigest,
+    binding_ref: evidenceBindingIdentity(bindingDigest),
+    bound_at: boundAt,
+    conversation_ref: input.conversation_ref,
+    delivery_id: input.delivery.delivery_id,
+    evidence_artifact_ids: evidenceArtifactIds,
+    operator_refs: operatorRefs,
+    requester_ref: input.requester_ref,
+    schema_version: "delivered-answer-evidence-binding/v1",
+    thread_ref: input.thread_ref,
+  };
+}
+
+export function authorizeEvidenceRecheck(
+  actorRef: string,
+  bindingRef: string,
+  binding: DeliveredAnswerEvidenceBindingV1,
+): EvidenceRecheckAuthorizationV1 {
+  requireRef(actorRef, "actor_ref");
+  requireRef(bindingRef, "binding_ref");
+  validateDeliveredAnswerEvidenceBinding(binding);
+  if (bindingRef !== binding.binding_ref) {
+    return deniedAuthorization("binding_reference_mismatch");
+  }
+  if (actorRef === binding.requester_ref) {
+    return allowedAuthorization("requester");
+  }
+  if (binding.operator_refs.includes(actorRef)) {
+    return allowedAuthorization("operator");
+  }
+  return deniedAuthorization("actor_not_authorized");
+}
+
+export function evidenceRecheckIdentity(bindingRef: string, requestKey: string): string {
+  requireRef(bindingRef, "binding_ref");
+  requireRequestKey(requestKey);
+  return `evidence-recheck:${stableDigest([bindingRef, requestKey]).slice(0, 32)}`;
+}
+
+export function evidenceRecheckAdmissionReceiptIdentity(recheckId: string): string {
+  requireRef(recheckId, "recheck_id");
+  return `evidence-recheck-admission-receipt:${stableDigest([recheckId])}`;
+}
+
+export async function admitEvidenceRecheck(
+  input: AdmitEvidenceRecheckInputV1,
+  receiptLookup: EvidenceRecheckAdmissionReceiptLookupV1,
+  store: DurableEvidenceRecheckAdmissionPort,
+): Promise<AdmitEvidenceRecheckResultV1> {
+  validateAdmissionInput(input);
+  const authorization = authorizeEvidenceRecheck(
+    input.actor_ref,
+    input.binding_ref,
+    input.binding,
+  );
+  if (!authorization.allowed) {
+    return {
+      acknowledgement_permitted: false,
+      authorization,
+      duplicate: false,
+      reason_code: authorization.reason_code,
+      retryable: false,
+      schema_version: "admit-evidence-recheck-result/v1",
+      status: "rejected",
+    };
+  }
+
+  const receivedAt = normalizeTimestamp(input.received_at, "received_at");
+  const admittedAt = normalizeTimestamp(input.admitted_at, "admitted_at");
+  if (Date.parse(admittedAt) < Date.parse(receivedAt)) {
+    throw new EvidenceRecheckInvariantError("admitted_at cannot precede received_at.");
+  }
+  const capabilities = canonicalCapabilities(input.run_context.required_capabilities);
+  const recheckId = evidenceRecheckIdentity(input.binding.binding_ref, input.request_key);
+  const runId = evidenceRecheckRunIdentity(recheckId);
+  const receiptId = evidenceRecheckAdmissionReceiptIdentity(recheckId);
+  const inputDigest = evidenceRecheckInputDigest(input, receivedAt, capabilities);
+  validateReceiptLookup(receiptLookup, receiptId);
+
+  if (receiptLookup.found) {
+    validateAdmissionReceipt(receiptLookup.receipt, {
+      binding: input.binding,
+      capabilities,
+      input_digest: inputDigest,
+      receipt_id: receiptId,
+      received_at: receivedAt,
+      recheck_id: recheckId,
+      run_context: input.run_context,
+      run_id: runId,
+    });
+    return acceptedResult(authorization, receiptLookup.receipt, true);
+  }
+
+  const receipt = createAdmissionReceipt({
+    admitted_at: admittedAt,
+    actor_ref: input.actor_ref,
+    binding: input.binding,
+    capabilities,
+    input_digest: inputDigest,
+    receipt_id: receiptId,
+    received_at: receivedAt,
+    recheck_id: recheckId,
+    request_key: input.request_key,
+    run_context: input.run_context,
+    run_id: runId,
+  });
+
+  let committed: EvidenceRecheckAdmissionCommitResultV1;
+  try {
+    committed = await store.admitAndEnqueue({
+      receipt,
+      transitions: [
+        { from: "received", to: "admitted" },
+        { from: "admitted", to: "queued" },
+      ],
+    });
+  } catch {
+    return {
+      acknowledgement_permitted: false,
+      authorization,
+      duplicate: false,
+      reason_code: "durable_admission_unavailable",
+      retryable: true,
+      schema_version: "admit-evidence-recheck-result/v1",
+      status: "degraded",
+    };
+  }
+
+  if (typeof committed.created !== "boolean") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission commit result is invalid.");
+  }
+  validateAdmissionReceipt(committed.receipt, {
+    binding: input.binding,
+    capabilities,
+    input_digest: inputDigest,
+    receipt_id: receiptId,
+    received_at: receivedAt,
+    recheck_id: recheckId,
+    run_context: input.run_context,
+    run_id: runId,
+  });
+  return acceptedResult(authorization, committed.receipt, !committed.created);
+}
+
+export function projectEvidenceRecheckStatus(
+  input: EvidenceRecheckStatusInputV1,
+): SlackEvidenceRecheckStatusV1 {
+  if (input.schema_version !== "evidence-recheck-status-input/v1") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck status input version is unsupported.");
+  }
+  if (input.kind === "admission") {
+    const result = input.result;
+    if (result.schema_version !== "admit-evidence-recheck-result/v1") {
+      throw new EvidenceRecheckInvariantError("Evidence recheck admission result version is unsupported.");
+    }
+    if (result.status === "queued") {
+      return slackStatus("queued", "Evidence recheck queued.", false, false, result.receipt.recheck.recheck_id);
+    }
+    if (result.status === "duplicate") {
+      return slackStatus(
+        "duplicate",
+        "This evidence recheck is already queued.",
+        false,
+        false,
+        result.receipt.recheck.recheck_id,
+      );
+    }
+    if (result.status === "degraded") {
+      return slackStatus(
+        "degraded",
+        "Evidence recheck was not queued. Retry after service recovers.",
+        true,
+        false,
+      );
+    }
+    if (result.status !== "rejected") {
+      throw new EvidenceRecheckInvariantError("Evidence recheck admission status is unsupported.");
+    }
+    return slackStatus(
+      "rejected",
+      "Evidence recheck was not accepted.",
+      result.retryable,
+      true,
+    );
+  }
+  if (input.kind !== "recheck") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck status input kind is unsupported.");
+  }
+  validateEvidenceRecheck(input.recheck);
+  switch (input.recheck.state) {
+    case "queued":
+      return slackStatus("queued", "Evidence recheck queued.", false, false, input.recheck.recheck_id);
+    case "running":
+      return slackStatus(
+        "in_progress",
+        "Evidence recheck in progress.",
+        false,
+        false,
+        input.recheck.recheck_id,
+      );
+    case "completed":
+      return slackStatus(
+        "completed",
+        "Evidence recheck completed.",
+        false,
+        true,
+        input.recheck.recheck_id,
+      );
+    case "degraded":
+      return slackStatus(
+        "degraded",
+        "Evidence recheck is delayed. It will continue after service recovers.",
+        true,
+        false,
+        input.recheck.recheck_id,
+      );
+  }
+}
+
+export function validateDeliveredAnswerEvidenceBinding(
+  binding: DeliveredAnswerEvidenceBindingV1,
+): void {
+  assertExactKeys(binding, [
+    "answer_ref",
+    "answer_run_id",
+    "binding_digest",
+    "binding_ref",
+    "bound_at",
+    "conversation_ref",
+    "delivery_id",
+    "evidence_artifact_ids",
+    "operator_refs",
+    "requester_ref",
+    "schema_version",
+    "thread_ref",
+  ], "delivered answer evidence binding");
+  if (binding.schema_version !== "delivered-answer-evidence-binding/v1") {
+    throw new EvidenceRecheckInvariantError("Delivered answer evidence binding version is unsupported.");
+  }
+  for (const [value, label] of [
+    [binding.answer_ref, "answer_ref"],
+    [binding.answer_run_id, "answer_run_id"],
+    [binding.binding_digest, "binding_digest"],
+    [binding.binding_ref, "binding_ref"],
+    [binding.conversation_ref, "conversation_ref"],
+    [binding.delivery_id, "delivery_id"],
+    [binding.requester_ref, "requester_ref"],
+    [binding.thread_ref, "thread_ref"],
+  ] as const) {
+    requireRef(value, label);
+  }
+  requireCanonicalTimestamp(binding.bound_at, "bound_at");
+  const artifactIds = canonicalArtifactIds(binding.evidence_artifact_ids);
+  const operatorRefs = canonicalRefs(
+    binding.operator_refs,
+    EVIDENCE_RECHECK_LIMITS.operator_refs,
+    "operator_refs",
+  );
+  if (!sameStrings(artifactIds, binding.evidence_artifact_ids)) {
+    throw new EvidenceRecheckInvariantError("Evidence artifact ids must be canonical and distinct.");
+  }
+  if (!sameStrings(operatorRefs, binding.operator_refs)) {
+    throw new EvidenceRecheckInvariantError("Operator refs must be canonical and distinct.");
+  }
+  const expectedDigest = deliveredAnswerEvidenceBindingDigest(binding);
+  if (
+    binding.binding_digest !== expectedDigest ||
+    binding.binding_ref !== evidenceBindingIdentity(expectedDigest)
+  ) {
+    throw new EvidenceRecheckInvariantError("Delivered answer evidence binding digest is invalid.");
+  }
+}
+
+export function validateEvidenceRecheck(recheck: EvidenceRecheckV1): void {
+  assertExactKeys(recheck, [
+    "actor_ref",
+    "answer_ref",
+    "binding_digest",
+    "binding_ref",
+    "completed_at",
+    "created_at",
+    "evidence_artifact_ids",
+    "outcome_digest",
+    "outcome_ref",
+    "reason_code",
+    "recheck_id",
+    "request_key",
+    "revision",
+    "run_id",
+    "schema_version",
+    "state",
+    "thread_ref",
+    "updated_at",
+  ], "evidence recheck");
+  if (recheck.schema_version !== "evidence-recheck/v1") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck version is unsupported.");
+  }
+  if (!RECHECK_STATES.includes(recheck.state)) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck state is unsupported.");
+  }
+  for (const [value, label] of [
+    [recheck.actor_ref, "actor_ref"],
+    [recheck.answer_ref, "answer_ref"],
+    [recheck.binding_digest, "binding_digest"],
+    [recheck.binding_ref, "binding_ref"],
+    [recheck.reason_code, "reason_code"],
+    [recheck.recheck_id, "recheck_id"],
+    [recheck.request_key, "request_key"],
+    [recheck.run_id, "run_id"],
+    [recheck.thread_ref, "thread_ref"],
+  ] as const) {
+    requireRef(value, label);
+  }
+  requireCanonicalTimestamp(recheck.created_at, "created_at");
+  requireCanonicalTimestamp(recheck.updated_at, "updated_at");
+  requirePositiveInteger(recheck.revision, "revision");
+  const artifactIds = canonicalArtifactIds(recheck.evidence_artifact_ids);
+  if (!sameStrings(artifactIds, recheck.evidence_artifact_ids)) {
+    throw new EvidenceRecheckInvariantError("Recheck evidence artifact ids must be canonical.");
+  }
+  const outcomeFields = [recheck.completed_at, recheck.outcome_digest, recheck.outcome_ref];
+  if (recheck.state === "completed") {
+    if (outcomeFields.some((value) => value === undefined)) {
+      throw new EvidenceRecheckInvariantError("Completed evidence rechecks require a durable outcome.");
+    }
+    requireCanonicalTimestamp(recheck.completed_at!, "completed_at");
+    requireRef(recheck.outcome_digest!, "outcome_digest");
+    requireRef(recheck.outcome_ref!, "outcome_ref");
+  } else if (outcomeFields.some((value) => value !== undefined)) {
+    throw new EvidenceRecheckInvariantError("Only completed evidence rechecks may carry an outcome.");
+  }
+}
+
+function createAdmissionReceipt(input: {
+  admitted_at: string;
+  actor_ref: string;
+  binding: DeliveredAnswerEvidenceBindingV1;
+  capabilities: CapabilityRequirement[];
+  input_digest: string;
+  receipt_id: string;
+  received_at: string;
+  recheck_id: string;
+  request_key: string;
+  run_context: AdmitEvidenceRecheckInputV1["run_context"];
+  run_id: string;
+}): EvidenceRecheckAdmissionReceiptV1 {
+  const run: RunReceiptV1 = {
+    admitted_at: input.admitted_at,
+    binding_id: input.run_context.service_binding_id,
+    idempotency_key: `evidence-recheck:${stableDigest([input.recheck_id])}`,
+    input_digest: input.input_digest,
+    receipt_id: `run-receipt:${stableDigest([input.run_id])}`,
+    received_at: input.received_at,
+    required_capabilities: structuredClone(input.capabilities),
+    retention_policy_ref: input.run_context.retention_policy_ref,
+    revision: 1,
+    run_id: input.run_id,
+    run_kind: "reconciliation",
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: input.run_context.subject_ref,
+    tenant_id: input.run_context.tenant_id,
+    updated_at: input.admitted_at,
+  };
+  const recheck: EvidenceRecheckV1 = {
+    actor_ref: input.actor_ref,
+    answer_ref: input.binding.answer_ref,
+    binding_digest: input.binding.binding_digest,
+    binding_ref: input.binding.binding_ref,
+    created_at: input.admitted_at,
+    evidence_artifact_ids: structuredClone(input.binding.evidence_artifact_ids),
+    reason_code: "admitted",
+    recheck_id: input.recheck_id,
+    request_key: input.request_key,
+    revision: 1,
+    run_id: input.run_id,
+    schema_version: "evidence-recheck/v1",
+    state: "queued",
+    thread_ref: input.binding.thread_ref,
+    updated_at: input.admitted_at,
+  };
+  const queueItem: EvidenceRecheckQueueItemV1 = {
+    available_at: input.admitted_at,
+    binding_digest: input.binding.binding_digest,
+    binding_ref: input.binding.binding_ref,
+    evidence_artifact_ids: structuredClone(input.binding.evidence_artifact_ids),
+    idempotency_key: `evidence-recheck-queue:${stableDigest([input.recheck_id])}`,
+    queue_item_id: `evidence-recheck-queue-item:${stableDigest([input.recheck_id])}`,
+    recheck_id: input.recheck_id,
+    run_id: input.run_id,
+    schema_version: "evidence-recheck-queue-item/v1",
+    thread_ref: input.binding.thread_ref,
+  };
+  return {
+    input_digest: input.input_digest,
+    queue_item: queueItem,
+    receipt_id: input.receipt_id,
+    recheck,
+    run,
+    schema_version: "evidence-recheck-admission-receipt/v1",
+  };
+}
+
+function validateAdmissionInput(input: AdmitEvidenceRecheckInputV1): void {
+  assertExactKeys(input, [
+    "actor_ref",
+    "admitted_at",
+    "binding",
+    "binding_ref",
+    "received_at",
+    "request_key",
+    "run_context",
+  ], "evidence recheck admission input");
+  assertExactKeys(input.run_context, [
+    "required_capabilities",
+    "retention_policy_ref",
+    "service_binding_id",
+    "subject_ref",
+    "tenant_id",
+  ], "evidence recheck run context");
+  requireRef(input.actor_ref, "actor_ref");
+  requireRef(input.binding_ref, "binding_ref");
+  requireRequestKey(input.request_key);
+  for (const [value, label] of [
+    [input.run_context.retention_policy_ref, "retention_policy_ref"],
+    [input.run_context.service_binding_id, "service_binding_id"],
+    [input.run_context.subject_ref, "subject_ref"],
+    [input.run_context.tenant_id, "tenant_id"],
+  ] as const) {
+    requireRef(value, label);
+  }
+  canonicalCapabilities(input.run_context.required_capabilities);
+}
+
+function validateAdmissionReceipt(
+  receipt: EvidenceRecheckAdmissionReceiptV1,
+  expected: {
+    binding: DeliveredAnswerEvidenceBindingV1;
+    capabilities: CapabilityRequirement[];
+    input_digest: string;
+    receipt_id: string;
+    received_at: string;
+    recheck_id: string;
+    run_context: AdmitEvidenceRecheckInputV1["run_context"];
+    run_id: string;
+  },
+): void {
+  assertExactKeys(receipt, [
+    "input_digest",
+    "queue_item",
+    "receipt_id",
+    "recheck",
+    "run",
+    "schema_version",
+  ], "evidence recheck admission receipt");
+  if (receipt.schema_version !== "evidence-recheck-admission-receipt/v1") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission receipt version is unsupported.");
+  }
+  if (receipt.receipt_id !== expected.receipt_id || receipt.input_digest !== expected.input_digest) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission receipt conflicts with this request.");
+  }
+  validateEvidenceRecheck(receipt.recheck);
+  if (
+    receipt.recheck.recheck_id !== expected.recheck_id ||
+    receipt.recheck.run_id !== expected.run_id ||
+    receipt.recheck.binding_ref !== expected.binding.binding_ref ||
+    receipt.recheck.binding_digest !== expected.binding.binding_digest ||
+    receipt.recheck.answer_ref !== expected.binding.answer_ref ||
+    receipt.recheck.thread_ref !== expected.binding.thread_ref ||
+    receipt.recheck.state !== "queued" ||
+    receipt.recheck.reason_code !== "admitted"
+  ) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck receipt contains a mismatched recheck.");
+  }
+  validateRunReceipt(receipt.run, expected);
+  validateQueueItem(receipt.queue_item, receipt.recheck);
+  if (
+    receipt.recheck.created_at !== receipt.run.admitted_at ||
+    receipt.recheck.updated_at !== receipt.run.admitted_at ||
+    receipt.queue_item.available_at !== receipt.run.admitted_at
+  ) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission timestamps are not atomic.");
+  }
+}
+
+function validateRunReceipt(
+  run: RunReceiptV1,
+  expected: {
+    capabilities: CapabilityRequirement[];
+    input_digest: string;
+    received_at: string;
+    run_context: AdmitEvidenceRecheckInputV1["run_context"];
+    run_id: string;
+  },
+): void {
+  if (
+    run.schema_version !== "run-receipt/v1" ||
+    run.run_id !== expected.run_id ||
+    run.run_kind !== "reconciliation" ||
+    run.state !== "queued" ||
+    run.revision !== 1 ||
+    run.binding_id !== expected.run_context.service_binding_id ||
+    run.tenant_id !== expected.run_context.tenant_id ||
+    run.subject_ref !== expected.run_context.subject_ref ||
+    run.retention_policy_ref !== expected.run_context.retention_policy_ref ||
+    run.input_digest !== expected.input_digest ||
+    run.received_at !== expected.received_at
+  ) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck canonical run receipt is invalid.");
+  }
+  requireCanonicalTimestamp(run.admitted_at, "run admitted_at");
+  requireCanonicalTimestamp(run.updated_at, "run updated_at");
+  requireRef(run.receipt_id, "run receipt_id");
+  requireRef(run.idempotency_key, "run idempotency_key");
+  if (run.updated_at !== run.admitted_at) {
+    throw new EvidenceRecheckInvariantError("Queued evidence recheck run timestamps must match.");
+  }
+  if (!sameCapabilities(canonicalCapabilities(run.required_capabilities), expected.capabilities)) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck run capabilities do not match admission.");
+  }
+}
+
+function validateQueueItem(queueItem: EvidenceRecheckQueueItemV1, recheck: EvidenceRecheckV1): void {
+  assertExactKeys(queueItem, [
+    "available_at",
+    "binding_digest",
+    "binding_ref",
+    "evidence_artifact_ids",
+    "idempotency_key",
+    "queue_item_id",
+    "recheck_id",
+    "run_id",
+    "schema_version",
+    "thread_ref",
+  ], "evidence recheck queue item");
+  if (queueItem.schema_version !== "evidence-recheck-queue-item/v1") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck queue item version is unsupported.");
+  }
+  for (const [value, label] of [
+    [queueItem.binding_digest, "queue binding_digest"],
+    [queueItem.binding_ref, "queue binding_ref"],
+    [queueItem.idempotency_key, "queue idempotency_key"],
+    [queueItem.queue_item_id, "queue_item_id"],
+    [queueItem.recheck_id, "queue recheck_id"],
+    [queueItem.run_id, "queue run_id"],
+    [queueItem.thread_ref, "queue thread_ref"],
+  ] as const) {
+    requireRef(value, label);
+  }
+  requireCanonicalTimestamp(queueItem.available_at, "queue available_at");
+  const artifactIds = canonicalArtifactIds(queueItem.evidence_artifact_ids);
+  if (
+    queueItem.recheck_id !== recheck.recheck_id ||
+    queueItem.run_id !== recheck.run_id ||
+    queueItem.binding_ref !== recheck.binding_ref ||
+    queueItem.binding_digest !== recheck.binding_digest ||
+    queueItem.thread_ref !== recheck.thread_ref ||
+    !sameStrings(artifactIds, recheck.evidence_artifact_ids)
+  ) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck queue item is not correlated to the recheck.");
+  }
+}
+
+function validateReceiptLookup(
+  lookup: EvidenceRecheckAdmissionReceiptLookupV1,
+  expectedReceiptId: string,
+): void {
+  if (lookup.found !== true && lookup.found !== false) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck receipt lookup result is invalid.");
+  }
+  assertExactKeys(
+    lookup,
+    lookup.found
+      ? ["found", "receipt", "schema_version"]
+      : ["found", "receipt_id", "schema_version"],
+    "evidence recheck receipt lookup",
+  );
+  if (lookup.schema_version !== "evidence-recheck-admission-receipt-lookup/v1") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck receipt lookup version is unsupported.");
+  }
+  if (lookup.found) {
+    if (lookup.receipt.receipt_id !== expectedReceiptId) {
+      throw new EvidenceRecheckInvariantError("Evidence recheck receipt lookup returned another receipt.");
+    }
+  } else if (lookup.receipt_id !== expectedReceiptId) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck receipt lookup used another identity.");
+  }
+}
+
+function validateCompletedDelivery(
+  delivery: BindDeliveredAnswerEvidenceInputV1["delivery"],
+  answerRunId: string,
+): void {
+  if (
+    delivery.schema_version !== "delivery-receipt/v1" ||
+    delivery.run_id !== answerRunId ||
+    delivery.state !== "completed"
+  ) {
+    throw new EvidenceRecheckInvariantError(
+      "Evidence rechecks require a completed delivery for the original answer run.",
+    );
+  }
+  requireRef(delivery.delivery_id, "delivery_id");
+  requireRef(delivery.destination_ref, "delivery destination_ref");
+  requireCanonicalTimestamp(delivery.created_at, "delivery created_at");
+  requireCanonicalTimestamp(delivery.updated_at, "delivery updated_at");
+  if (
+    delivery.parts.length === 0 ||
+    delivery.parts.length > EVIDENCE_RECHECK_LIMITS.delivery_parts
+  ) {
+    throw new EvidenceRecheckInvariantError("Delivered answers require bounded delivery parts.");
+  }
+  let expectedSequence = 1;
+  for (const part of [...delivery.parts].sort((left, right) => left.sequence - right.sequence)) {
+    if (
+      part.state !== "delivered" ||
+      part.destination_receipt === undefined ||
+      part.delivered_at === undefined ||
+      part.sequence !== expectedSequence
+    ) {
+      throw new EvidenceRecheckInvariantError(
+        "Every original answer part must have a durable delivered receipt.",
+      );
+    }
+    requireRef(part.part_id, "delivery part_id");
+    requireRef(part.idempotency_key, "delivery part idempotency_key");
+    requireRef(part.payload_digest, "delivery part payload_digest");
+    requireRef(part.payload_ref, "delivery part payload_ref");
+    requireRef(part.destination_receipt, "delivery part destination_receipt");
+    requireCanonicalTimestamp(part.delivered_at, "delivery part delivered_at");
+    expectedSequence += 1;
+  }
+}
+
+function evidenceRecheckInputDigest(
+  input: AdmitEvidenceRecheckInputV1,
+  receivedAt: string,
+  capabilities: CapabilityRequirement[],
+): string {
+  return `sha256:${stableDigest([
+    input.actor_ref,
+    input.binding.binding_ref,
+    input.binding.binding_digest,
+    input.request_key,
+    receivedAt,
+    input.run_context.service_binding_id,
+    input.run_context.tenant_id,
+    input.run_context.subject_ref,
+    input.run_context.retention_policy_ref,
+    ...capabilities.flatMap((capability) => [
+      capability.capability_id,
+      capability.level,
+      capability.version,
+    ]),
+  ])}`;
+}
+
+function deliveredAnswerEvidenceBindingDigest(input: {
+  answer_ref: string;
+  answer_run_id: string;
+  bound_at: string;
+  conversation_ref: string;
+  delivery_id: string;
+  evidence_artifact_ids: readonly string[];
+  operator_refs: readonly string[];
+  requester_ref: string;
+  thread_ref: string;
+}): string {
+  return `sha256:${stableDigest([
+    input.answer_ref,
+    input.answer_run_id,
+    input.delivery_id,
+    input.conversation_ref,
+    input.thread_ref,
+    input.requester_ref,
+    input.bound_at,
+    ...input.operator_refs,
+    "evidence",
+    ...input.evidence_artifact_ids,
+  ])}`;
+}
+
+function evidenceBindingIdentity(bindingDigest: string): string {
+  return `delivered-answer-evidence-binding:${bindingDigest.slice("sha256:".length, 39)}`;
+}
+
+function evidenceRecheckRunIdentity(recheckId: string): string {
+  return `evidence-recheck-run:${stableDigest([recheckId]).slice(0, 32)}`;
+}
+
+function acceptedResult(
+  authorization: Extract<EvidenceRecheckAuthorizationV1, { allowed: true }>,
+  receipt: EvidenceRecheckAdmissionReceiptV1,
+  duplicate: boolean,
+): AdmitEvidenceRecheckResultV1 {
+  return {
+    acknowledgement_permitted: true,
+    authorization,
+    duplicate,
+    receipt: structuredClone(receipt),
+    retryable: false,
+    schema_version: "admit-evidence-recheck-result/v1",
+    status: duplicate ? "duplicate" : "queued",
+  };
+}
+
+function allowedAuthorization(
+  role: "requester" | "operator",
+): Extract<EvidenceRecheckAuthorizationV1, { allowed: true }> {
+  return { allowed: true, role, schema_version: "evidence-recheck-authorization/v1" };
+}
+
+function deniedAuthorization(
+  reasonCode: "actor_not_authorized" | "binding_reference_mismatch",
+): Extract<EvidenceRecheckAuthorizationV1, { allowed: false }> {
+  return {
+    allowed: false,
+    reason_code: reasonCode,
+    schema_version: "evidence-recheck-authorization/v1",
+  };
+}
+
+function slackStatus(
+  status: SlackEvidenceRecheckStatusV1["status"],
+  message: string,
+  retryable: boolean,
+  terminal: boolean,
+  recheckId?: string,
+): SlackEvidenceRecheckStatusV1 {
+  return {
+    message,
+    ...(recheckId === undefined ? {} : { recheck_id: recheckId }),
+    retryable,
+    schema_version: "slack-evidence-recheck-status/v1",
+    status,
+    terminal,
+  };
+}
+
+function canonicalArtifactIds(values: readonly string[]): string[] {
+  if (
+    values.length === 0 ||
+    values.length > EVIDENCE_RECHECK_LIMITS.evidence_artifact_ids
+  ) {
+    throw new EvidenceRecheckInvariantError("Evidence artifact ids must be present and bounded.");
+  }
+  const result = values.map((value) => {
+    requireRef(value, "evidence_artifact_id");
+    if (!OPAQUE_ARTIFACT_ID.test(value)) {
+      throw new EvidenceRecheckInvariantError(
+        "Evidence artifact ids must be opaque server-owned identifiers.",
+      );
+    }
+    return value;
+  }).sort();
+  if (new Set(result).size !== result.length) {
+    throw new EvidenceRecheckInvariantError("Evidence artifact ids must be distinct.");
+  }
+  return result;
+}
+
+function canonicalRefs(values: readonly string[], maximum: number, label: string): string[] {
+  if (values.length > maximum) {
+    throw new EvidenceRecheckInvariantError(`${label} exceeds the portable limit.`);
+  }
+  const result = values.map((value) => {
+    requireRef(value, label);
+    return value;
+  }).sort();
+  if (new Set(result).size !== result.length) {
+    throw new EvidenceRecheckInvariantError(`${label} must be distinct.`);
+  }
+  return result;
+}
+
+function canonicalCapabilities(
+  capabilities: readonly CapabilityRequirement[],
+): CapabilityRequirement[] {
+  if (capabilities.length > EVIDENCE_RECHECK_LIMITS.required_capabilities) {
+    throw new EvidenceRecheckInvariantError("Required capabilities exceed the portable limit.");
+  }
+  const result = capabilities.map((capability) => {
+    assertExactKeys(
+      capability,
+      ["capability_id", "level", "version"],
+      "capability requirement",
+    );
+    requireRef(capability.capability_id, "capability_id");
+    requireRef(capability.version, "capability version");
+    if (capability.level !== "required" && capability.level !== "optional") {
+      throw new EvidenceRecheckInvariantError("Capability requirement level is unsupported.");
+    }
+    return structuredClone(capability);
+  }).sort((left, right) =>
+    `${left.capability_id}\u0000${left.version}\u0000${left.level}`.localeCompare(
+      `${right.capability_id}\u0000${right.version}\u0000${right.level}`,
+    ),
+  );
+  const identities = result.map((capability) => `${capability.capability_id}\u0000${capability.version}`);
+  if (new Set(identities).size !== identities.length) {
+    throw new EvidenceRecheckInvariantError("Required capability identities must be distinct.");
+  }
+  return result;
+}
+
+function sameCapabilities(
+  left: readonly CapabilityRequirement[],
+  right: readonly CapabilityRequirement[],
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function assertExactKeys(
+  value: object,
+  allowedKeys: readonly string[],
+  label: string,
+): void {
+  const allowed = new Set(allowedKeys);
+  const unexpected = Object.keys(value).filter((key) => !allowed.has(key));
+  if (unexpected.length !== 0) {
+    throw new EvidenceRecheckInvariantError(`${label} contains unsupported fields.`);
+  }
+}
+
+function requireRequestKey(value: string): void {
+  requireBoundedText(
+    value,
+    EVIDENCE_RECHECK_LIMITS.request_key_utf8_bytes,
+    "request_key",
+  );
+}
+
+function requireRef(value: string, label: string): void {
+  requireBoundedText(value, EVIDENCE_RECHECK_LIMITS.ref_utf8_bytes, label);
+}
+
+function requireBoundedText(value: string, maximumBytes: number, label: string): void {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.trim() !== value ||
+    UNSAFE_TEXT_CONTROL_CHARACTERS.test(value) ||
+    Buffer.byteLength(value, "utf8") > maximumBytes
+  ) {
+    throw new EvidenceRecheckInvariantError(`${label} is not a bounded canonical value.`);
+  }
+}
+
+function requirePositiveInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new EvidenceRecheckInvariantError(`${label} must be a positive safe integer.`);
+  }
+}
+
+function normalizeTimestamp(value: string, label: string): string {
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) {
+    throw new EvidenceRecheckInvariantError(`${label} must be an ISO timestamp.`);
+  }
+  return new Date(milliseconds).toISOString();
+}
+
+function requireCanonicalTimestamp(value: string, label: string): void {
+  if (normalizeTimestamp(value, label) !== value) {
+    throw new EvidenceRecheckInvariantError(`${label} must use canonical UTC form.`);
+  }
+}
+
+function stableDigest(values: readonly string[]): string {
+  return createHash("sha256").update(JSON.stringify(values)).digest("hex");
+}

--- a/apps/slack-companion/src/recheck/policy.ts
+++ b/apps/slack-companion/src/recheck/policy.ts
@@ -52,6 +52,11 @@ export function bindDeliveredAnswerEvidence(
   requireRef(input.thread_ref, "thread_ref");
   const boundAt = normalizeTimestamp(input.bound_at, "bound_at");
   validateCompletedDelivery(input.delivery, input.answer_run_id);
+  if (Date.parse(boundAt) < Date.parse(input.delivery.updated_at)) {
+    throw new EvidenceRecheckInvariantError(
+      "Evidence binding cannot precede completed delivery.",
+    );
+  }
   const deliveryDigest = completedDeliveryDigest(input.delivery);
   const evidenceArtifactIds = canonicalArtifactIds(input.evidence_artifact_ids);
   const operatorRefs = canonicalRefs(
@@ -421,6 +426,11 @@ export function validateEvidenceRecheck(recheck: EvidenceRecheckV1): void {
   }
   requireRequestKey(recheck.request_key);
   requireSha256Digest(recheck.binding_digest, "binding_digest");
+  if (recheck.binding_ref !== evidenceBindingIdentity(recheck.binding_digest)) {
+    throw new EvidenceRecheckInvariantError(
+      "Evidence recheck binding reference does not match its digest.",
+    );
+  }
   requireCanonicalTimestamp(recheck.created_at, "created_at");
   requireCanonicalTimestamp(recheck.updated_at, "updated_at");
   if (Date.parse(recheck.updated_at) < Date.parse(recheck.created_at)) {
@@ -1002,6 +1012,11 @@ function validateCompletedDelivery(
   requireRef(delivery.destination_ref, "delivery destination_ref");
   requireCanonicalTimestamp(delivery.created_at, "delivery created_at");
   requireCanonicalTimestamp(delivery.updated_at, "delivery updated_at");
+  if (Date.parse(delivery.updated_at) < Date.parse(delivery.created_at)) {
+    throw new EvidenceRecheckInvariantError(
+      "Completed delivery timestamps must be monotonic.",
+    );
+  }
   if (
     delivery.parts.length === 0 ||
     delivery.parts.length > EVIDENCE_RECHECK_LIMITS.delivery_parts
@@ -1009,6 +1024,7 @@ function validateCompletedDelivery(
     throw new EvidenceRecheckInvariantError("Delivered answers require bounded delivery parts.");
   }
   let expectedSequence = 1;
+  let previousDeliveredAt = delivery.created_at;
   const partIds = new Set<string>();
   const idempotencyKeys = new Set<string>();
   for (const part of [...delivery.parts].sort((left, right) => left.sequence - right.sequence)) {
@@ -1038,6 +1054,14 @@ function validateCompletedDelivery(
     requireRef(part.payload_ref, "delivery part payload_ref");
     requireRef(part.destination_receipt, "delivery part destination_receipt");
     requireCanonicalTimestamp(part.delivered_at, "delivery part delivered_at");
+    if (
+      Date.parse(part.delivered_at) < Date.parse(previousDeliveredAt) ||
+      Date.parse(part.delivered_at) > Date.parse(delivery.updated_at)
+    ) {
+      throw new EvidenceRecheckInvariantError(
+        "Completed delivery part timestamps must be monotonic.",
+      );
+    }
     if (partIds.has(part.part_id) || idempotencyKeys.has(part.idempotency_key)) {
       throw new EvidenceRecheckInvariantError(
         "Completed delivery part identities must be distinct.",
@@ -1045,6 +1069,7 @@ function validateCompletedDelivery(
     }
     partIds.add(part.part_id);
     idempotencyKeys.add(part.idempotency_key);
+    previousDeliveredAt = part.delivered_at;
     expectedSequence += 1;
   }
 }

--- a/apps/slack-companion/src/recheck/policy.ts
+++ b/apps/slack-companion/src/recheck/policy.ts
@@ -247,10 +247,13 @@ export function projectEvidenceRecheckStatus(
     throw new EvidenceRecheckInvariantError("Evidence recheck status input version is unsupported.");
   }
   if (input.kind === "admission") {
+    assertExactKeys(
+      input,
+      ["kind", "result", "schema_version"],
+      "evidence recheck admission status input",
+    );
     const result = input.result;
-    if (result.schema_version !== "admit-evidence-recheck-result/v1") {
-      throw new EvidenceRecheckInvariantError("Evidence recheck admission result version is unsupported.");
-    }
+    validateAdmissionResultForStatus(result);
     if (result.status === "queued") {
       return slackStatus("queued", "Evidence recheck queued.", false, false, result.receipt.recheck.recheck_id);
     }
@@ -284,6 +287,11 @@ export function projectEvidenceRecheckStatus(
   if (input.kind !== "recheck") {
     throw new EvidenceRecheckInvariantError("Evidence recheck status input kind is unsupported.");
   }
+  assertExactKeys(
+    input,
+    ["kind", "recheck", "schema_version"],
+    "evidence recheck lifecycle status input",
+  );
   validateEvidenceRecheck(input.recheck);
   switch (input.recheck.state) {
     case "queued":
@@ -412,6 +420,7 @@ export function validateEvidenceRecheck(recheck: EvidenceRecheckV1): void {
     requireRef(value, label);
   }
   requireRequestKey(recheck.request_key);
+  requireSha256Digest(recheck.binding_digest, "binding_digest");
   requireCanonicalTimestamp(recheck.created_at, "created_at");
   requireCanonicalTimestamp(recheck.updated_at, "updated_at");
   if (Date.parse(recheck.updated_at) < Date.parse(recheck.created_at)) {
@@ -421,6 +430,13 @@ export function validateEvidenceRecheck(recheck: EvidenceRecheckV1): void {
   const artifactIds = canonicalArtifactIds(recheck.evidence_artifact_ids);
   if (!sameStrings(artifactIds, recheck.evidence_artifact_ids)) {
     throw new EvidenceRecheckInvariantError("Recheck evidence artifact ids must be canonical.");
+  }
+  const expectedRecheckId = evidenceRecheckIdentity(recheck.binding_ref, recheck.request_key);
+  if (
+    recheck.recheck_id !== expectedRecheckId ||
+    recheck.run_id !== evidenceRecheckRunIdentity(expectedRecheckId)
+  ) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck identities are invalid.");
   }
   const outcomeFields = [recheck.completed_at, recheck.outcome_digest, recheck.outcome_ref];
   if (recheck.state === "completed") {
@@ -605,6 +621,178 @@ function validateAdmissionReceipt(
   }
 }
 
+function validateAdmissionResultForStatus(result: AdmitEvidenceRecheckResultV1): void {
+  if (result.schema_version !== "admit-evidence-recheck-result/v1") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission result version is unsupported.");
+  }
+  if (result.status === "queued" || result.status === "duplicate") {
+    assertExactKeys(result, [
+      "acknowledgement_permitted",
+      "authorization",
+      "duplicate",
+      "receipt",
+      "retryable",
+      "schema_version",
+      "status",
+    ], "accepted evidence recheck admission result");
+    if (
+      result.acknowledgement_permitted !== true ||
+      result.retryable !== false ||
+      result.duplicate !== (result.status === "duplicate")
+    ) {
+      throw new EvidenceRecheckInvariantError(
+        "Accepted evidence recheck admission result is contradictory.",
+      );
+    }
+    validateAllowedAuthorization(result.authorization);
+    validateAdmissionReceiptForStatus(result.receipt);
+    return;
+  }
+  if (result.status === "degraded") {
+    assertExactKeys(result, [
+      "acknowledgement_permitted",
+      "authorization",
+      "duplicate",
+      "reason_code",
+      "retryable",
+      "schema_version",
+      "status",
+    ], "degraded evidence recheck admission result");
+    if (
+      result.acknowledgement_permitted !== false ||
+      result.duplicate !== false ||
+      result.reason_code !== "durable_admission_unavailable" ||
+      result.retryable !== true
+    ) {
+      throw new EvidenceRecheckInvariantError(
+        "Degraded evidence recheck admission result is contradictory.",
+      );
+    }
+    validateAllowedAuthorization(result.authorization);
+    return;
+  }
+  if (result.status !== "rejected") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission status is unsupported.");
+  }
+  assertExactKeys(result, [
+    "acknowledgement_permitted",
+    "authorization",
+    "duplicate",
+    "reason_code",
+    "retryable",
+    "schema_version",
+    "status",
+  ], "rejected evidence recheck admission result");
+  if (
+    result.acknowledgement_permitted !== false ||
+    result.duplicate !== false ||
+    result.retryable !== false
+  ) {
+    throw new EvidenceRecheckInvariantError(
+      "Rejected evidence recheck admission result is contradictory.",
+    );
+  }
+  validateDeniedAuthorization(result.authorization);
+  if (result.reason_code !== result.authorization.reason_code) {
+    throw new EvidenceRecheckInvariantError(
+      "Rejected evidence recheck reason does not match authorization.",
+    );
+  }
+}
+
+function validateAllowedAuthorization(
+  authorization: Extract<EvidenceRecheckAuthorizationV1, { allowed: true }>,
+): void {
+  assertExactKeys(
+    authorization,
+    ["allowed", "role", "schema_version"],
+    "allowed evidence recheck authorization",
+  );
+  if (
+    authorization.allowed !== true ||
+    (authorization.role !== "requester" && authorization.role !== "operator") ||
+    authorization.schema_version !== "evidence-recheck-authorization/v1"
+  ) {
+    throw new EvidenceRecheckInvariantError("Allowed evidence recheck authorization is invalid.");
+  }
+}
+
+function validateDeniedAuthorization(
+  authorization: Extract<EvidenceRecheckAuthorizationV1, { allowed: false }>,
+): void {
+  assertExactKeys(
+    authorization,
+    ["allowed", "reason_code", "schema_version"],
+    "denied evidence recheck authorization",
+  );
+  if (
+    authorization.allowed !== false ||
+    (authorization.reason_code !== "actor_not_authorized" &&
+      authorization.reason_code !== "binding_reference_mismatch") ||
+    authorization.schema_version !== "evidence-recheck-authorization/v1"
+  ) {
+    throw new EvidenceRecheckInvariantError("Denied evidence recheck authorization is invalid.");
+  }
+}
+
+function validateAdmissionReceiptForStatus(
+  receipt: EvidenceRecheckAdmissionReceiptV1,
+): void {
+  assertExactKeys(receipt, [
+    "input_digest",
+    "queue_item",
+    "receipt_id",
+    "recheck",
+    "run",
+    "schema_version",
+  ], "evidence recheck admission receipt");
+  if (receipt.schema_version !== "evidence-recheck-admission-receipt/v1") {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission receipt version is unsupported.");
+  }
+  validateEvidenceRecheck(receipt.recheck);
+  requireSha256Digest(receipt.input_digest, "admission input_digest");
+  if (
+    receipt.receipt_id !== evidenceRecheckAdmissionReceiptIdentity(receipt.recheck.recheck_id) ||
+    receipt.recheck.state !== "queued" ||
+    receipt.recheck.reason_code !== "admitted" ||
+    receipt.recheck.revision !== 1
+  ) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission receipt is not queued truth.");
+  }
+  const capabilities = canonicalCapabilities(receipt.run.required_capabilities);
+  const expectedInputDigest = evidenceRecheckInputDigestFromReceipt(
+    receipt.recheck,
+    receipt.run,
+    capabilities,
+  );
+  if (receipt.input_digest !== expectedInputDigest) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission input digest is invalid.");
+  }
+  validateRunReceipt(receipt.run, {
+    admitted_at: receipt.recheck.created_at,
+    capabilities,
+    input_digest: receipt.input_digest,
+    recheck_id: receipt.recheck.recheck_id,
+    received_at: receipt.run.received_at,
+    run_context: {
+      required_capabilities: capabilities,
+      retention_policy_ref: receipt.run.retention_policy_ref,
+      service_binding_id: receipt.run.binding_id,
+      subject_ref: receipt.run.subject_ref,
+      tenant_id: receipt.run.tenant_id,
+    },
+    run_id: receipt.recheck.run_id,
+  });
+  validateQueueItem(receipt.queue_item, receipt.recheck);
+  if (
+    receipt.recheck.created_at !== receipt.run.admitted_at ||
+    receipt.recheck.updated_at !== receipt.run.admitted_at ||
+    receipt.queue_item.available_at !== receipt.run.admitted_at
+  ) {
+    throw new EvidenceRecheckInvariantError("Evidence recheck admission timestamps are not atomic.");
+  }
+}
+
 function validateRunReceipt(
   run: RunReceiptV1,
   expected: {
@@ -655,13 +843,30 @@ function validateRunReceipt(
     throw new EvidenceRecheckInvariantError("Evidence recheck canonical run receipt is invalid.");
   }
   requireCanonicalTimestamp(run.admitted_at, "run admitted_at");
+  requireCanonicalTimestamp(run.received_at, "run received_at");
   requireCanonicalTimestamp(run.updated_at, "run updated_at");
+  requireSha256Digest(run.input_digest, "run input_digest");
+  for (const [value, label] of [
+    [run.binding_id, "run binding_id"],
+    [run.retention_policy_ref, "run retention_policy_ref"],
+    [run.subject_ref, "run subject_ref"],
+    [run.tenant_id, "run tenant_id"],
+  ] as const) {
+    requireRef(value, label);
+  }
   requireRef(run.receipt_id, "run receipt_id");
   requireRef(run.idempotency_key, "run idempotency_key");
-  if (run.updated_at !== run.admitted_at) {
+  if (
+    run.updated_at !== run.admitted_at ||
+    Date.parse(run.admitted_at) < Date.parse(run.received_at)
+  ) {
     throw new EvidenceRecheckInvariantError("Queued evidence recheck run timestamps must match.");
   }
-  if (!sameCapabilities(canonicalCapabilities(run.required_capabilities), expected.capabilities)) {
+  const canonicalRunCapabilities = canonicalCapabilities(run.required_capabilities);
+  if (
+    !sameCapabilities(run.required_capabilities, canonicalRunCapabilities) ||
+    !sameCapabilities(canonicalRunCapabilities, expected.capabilities)
+  ) {
     throw new EvidenceRecheckInvariantError("Evidence recheck run capabilities do not match admission.");
   }
 }
@@ -894,6 +1099,29 @@ function evidenceRecheckInputDigest(
   ])}`;
 }
 
+function evidenceRecheckInputDigestFromReceipt(
+  recheck: EvidenceRecheckV1,
+  run: RunReceiptV1,
+  capabilities: CapabilityRequirement[],
+): string {
+  return `sha256:${stableDigest([
+    recheck.actor_ref,
+    recheck.binding_ref,
+    recheck.binding_digest,
+    recheck.request_key,
+    run.received_at,
+    run.binding_id,
+    run.tenant_id,
+    run.subject_ref,
+    run.retention_policy_ref,
+    ...capabilities.flatMap((capability) => [
+      capability.capability_id,
+      capability.level,
+      capability.version,
+    ]),
+  ])}`;
+}
+
 function deliveredAnswerEvidenceBindingDigest(input: {
   answer_ref: string;
   answer_run_id: string;
@@ -1034,16 +1262,19 @@ function canonicalCapabilities(
       throw new EvidenceRecheckInvariantError("Capability requirement level is unsupported.");
     }
     return structuredClone(capability);
-  }).sort((left, right) =>
-    `${left.capability_id}\u0000${left.version}\u0000${left.level}`.localeCompare(
-      `${right.capability_id}\u0000${right.version}\u0000${right.level}`,
-    ),
-  );
+  }).sort((left, right) => compareOrdinal(
+    `${left.capability_id}\u0000${left.version}\u0000${left.level}`,
+    `${right.capability_id}\u0000${right.version}\u0000${right.level}`,
+  ));
   const identities = result.map((capability) => `${capability.capability_id}\u0000${capability.version}`);
   if (new Set(identities).size !== identities.length) {
     throw new EvidenceRecheckInvariantError("Required capability identities must be distinct.");
   }
   return result;
+}
+
+function compareOrdinal(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function sameCapabilities(

--- a/apps/slack-companion/src/recheck/policy.ts
+++ b/apps/slack-companion/src/recheck/policy.ts
@@ -7,6 +7,7 @@ import {
   type AdmitEvidenceRecheckResultV1,
   type BindDeliveredAnswerEvidenceInputV1,
   type DeliveredAnswerEvidenceBindingV1,
+  type DeliveredAnswerEvidenceBindingLookupV1,
   type DurableEvidenceRecheckAdmissionPort,
   type EvidenceRecheckAdmissionCommitResultV1,
   type EvidenceRecheckAdmissionReceiptLookupV1,
@@ -120,14 +121,29 @@ export function evidenceRecheckAdmissionReceiptIdentity(recheckId: string): stri
 
 export async function admitEvidenceRecheck(
   input: AdmitEvidenceRecheckInputV1,
+  bindingLookup: DeliveredAnswerEvidenceBindingLookupV1,
   receiptLookup: EvidenceRecheckAdmissionReceiptLookupV1,
   store: DurableEvidenceRecheckAdmissionPort,
 ): Promise<AdmitEvidenceRecheckResultV1> {
   validateAdmissionInput(input);
+  validateBindingLookup(bindingLookup, input.binding_ref);
+  if (!bindingLookup.found) {
+    const authorization = deniedAuthorization("binding_reference_mismatch");
+    return {
+      acknowledgement_permitted: false,
+      authorization,
+      duplicate: false,
+      reason_code: authorization.reason_code,
+      retryable: false,
+      schema_version: "admit-evidence-recheck-result/v1",
+      status: "rejected",
+    };
+  }
+  const binding = bindingLookup.binding;
   const authorization = authorizeEvidenceRecheck(
     input.actor_ref,
     input.binding_ref,
-    input.binding,
+    binding,
   );
   if (!authorization.allowed) {
     return {
@@ -147,15 +163,15 @@ export async function admitEvidenceRecheck(
     throw new EvidenceRecheckInvariantError("admitted_at cannot precede received_at.");
   }
   const capabilities = canonicalCapabilities(input.run_context.required_capabilities);
-  const recheckId = evidenceRecheckIdentity(input.binding.binding_ref, input.request_key);
+  const recheckId = evidenceRecheckIdentity(binding.binding_ref, input.request_key);
   const runId = evidenceRecheckRunIdentity(recheckId);
   const receiptId = evidenceRecheckAdmissionReceiptIdentity(recheckId);
-  const inputDigest = evidenceRecheckInputDigest(input, receivedAt, capabilities);
+  const inputDigest = evidenceRecheckInputDigest(input, binding, receivedAt, capabilities);
   validateReceiptLookup(receiptLookup, receiptId);
 
   if (receiptLookup.found) {
     validateAdmissionReceipt(receiptLookup.receipt, {
-      binding: input.binding,
+      binding,
       actor_ref: input.actor_ref,
       admitted_at: receiptLookup.receipt.run.admitted_at,
       capabilities,
@@ -173,7 +189,7 @@ export async function admitEvidenceRecheck(
   const receipt = createAdmissionReceipt({
     admitted_at: admittedAt,
     actor_ref: input.actor_ref,
-    binding: input.binding,
+    binding,
     capabilities,
     input_digest: inputDigest,
     receipt_id: receiptId,
@@ -210,8 +226,8 @@ export async function admitEvidenceRecheck(
   }
   validateAdmissionReceipt(committed.receipt, {
     actor_ref: input.actor_ref,
-    admitted_at: admittedAt,
-    binding: input.binding,
+    admitted_at: committed.created ? admittedAt : committed.receipt.run.admitted_at,
+    binding,
     capabilities,
     input_digest: inputDigest,
     receipt_id: receiptId,
@@ -398,6 +414,9 @@ export function validateEvidenceRecheck(recheck: EvidenceRecheckV1): void {
   requireRequestKey(recheck.request_key);
   requireCanonicalTimestamp(recheck.created_at, "created_at");
   requireCanonicalTimestamp(recheck.updated_at, "updated_at");
+  if (Date.parse(recheck.updated_at) < Date.parse(recheck.created_at)) {
+    throw new EvidenceRecheckInvariantError("updated_at cannot precede created_at.");
+  }
   requirePositiveInteger(recheck.revision, "revision");
   const artifactIds = canonicalArtifactIds(recheck.evidence_artifact_ids);
   if (!sameStrings(artifactIds, recheck.evidence_artifact_ids)) {
@@ -409,8 +428,16 @@ export function validateEvidenceRecheck(recheck: EvidenceRecheckV1): void {
       throw new EvidenceRecheckInvariantError("Completed evidence rechecks require a durable outcome.");
     }
     requireCanonicalTimestamp(recheck.completed_at!, "completed_at");
-    requireRef(recheck.outcome_digest!, "outcome_digest");
+    requireSha256Digest(recheck.outcome_digest!, "outcome_digest");
     requireRef(recheck.outcome_ref!, "outcome_ref");
+    if (
+      Date.parse(recheck.completed_at!) < Date.parse(recheck.created_at) ||
+      Date.parse(recheck.updated_at) < Date.parse(recheck.completed_at!)
+    ) {
+      throw new EvidenceRecheckInvariantError(
+        "Completed evidence recheck timestamps must be monotonic.",
+      );
+    }
   } else if (outcomeFields.some((value) => value !== undefined)) {
     throw new EvidenceRecheckInvariantError("Only completed evidence rechecks may carry an outcome.");
   }
@@ -490,7 +517,6 @@ function validateAdmissionInput(input: AdmitEvidenceRecheckInputV1): void {
   assertExactKeys(input, [
     "actor_ref",
     "admitted_at",
-    "binding",
     "binding_ref",
     "received_at",
     "request_key",
@@ -675,9 +701,46 @@ function validateQueueItem(queueItem: EvidenceRecheckQueueItemV1, recheck: Evide
     queueItem.binding_ref !== recheck.binding_ref ||
     queueItem.binding_digest !== recheck.binding_digest ||
     queueItem.thread_ref !== recheck.thread_ref ||
+    queueItem.idempotency_key !==
+      `evidence-recheck-queue:${stableDigest([recheck.recheck_id])}` ||
+    queueItem.queue_item_id !==
+      `evidence-recheck-queue-item:${stableDigest([recheck.recheck_id])}` ||
     !sameStrings(artifactIds, recheck.evidence_artifact_ids)
   ) {
     throw new EvidenceRecheckInvariantError("Evidence recheck queue item is not correlated to the recheck.");
+  }
+}
+
+function validateBindingLookup(
+  lookup: DeliveredAnswerEvidenceBindingLookupV1,
+  expectedBindingRef: string,
+): void {
+  if (lookup.found !== true && lookup.found !== false) {
+    throw new EvidenceRecheckInvariantError("Delivered answer evidence binding lookup is invalid.");
+  }
+  assertExactKeys(
+    lookup,
+    lookup.found
+      ? ["binding", "found", "schema_version"]
+      : ["binding_ref", "found", "schema_version"],
+    "delivered answer evidence binding lookup",
+  );
+  if (lookup.schema_version !== "delivered-answer-evidence-binding-lookup/v1") {
+    throw new EvidenceRecheckInvariantError(
+      "Delivered answer evidence binding lookup version is unsupported.",
+    );
+  }
+  if (lookup.found) {
+    validateDeliveredAnswerEvidenceBinding(lookup.binding);
+    if (lookup.binding.binding_ref !== expectedBindingRef) {
+      throw new EvidenceRecheckInvariantError(
+        "Delivered answer evidence binding lookup returned another binding.",
+      );
+    }
+  } else if (lookup.binding_ref !== expectedBindingRef) {
+    throw new EvidenceRecheckInvariantError(
+      "Delivered answer evidence binding lookup used another identity.",
+    );
   }
 }
 
@@ -809,13 +872,14 @@ function completedDeliveryDigest(
 
 function evidenceRecheckInputDigest(
   input: AdmitEvidenceRecheckInputV1,
+  binding: DeliveredAnswerEvidenceBindingV1,
   receivedAt: string,
   capabilities: CapabilityRequirement[],
 ): string {
   return `sha256:${stableDigest([
     input.actor_ref,
-    input.binding.binding_ref,
-    input.binding.binding_digest,
+    binding.binding_ref,
+    binding.binding_digest,
     input.request_key,
     receivedAt,
     input.run_context.service_binding_id,

--- a/apps/slack-companion/src/recheck/policy.ts
+++ b/apps/slack-companion/src/recheck/policy.ts
@@ -20,6 +20,7 @@ import {
 
 const UNSAFE_TEXT_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
 const OPAQUE_ARTIFACT_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/;
 const RECHECK_STATES: readonly EvidenceRecheckV1["state"][] = [
   "queued",
   "running",
@@ -50,6 +51,7 @@ export function bindDeliveredAnswerEvidence(
   requireRef(input.thread_ref, "thread_ref");
   const boundAt = normalizeTimestamp(input.bound_at, "bound_at");
   validateCompletedDelivery(input.delivery, input.answer_run_id);
+  const deliveryDigest = completedDeliveryDigest(input.delivery);
   const evidenceArtifactIds = canonicalArtifactIds(input.evidence_artifact_ids);
   const operatorRefs = canonicalRefs(
     input.operator_refs,
@@ -61,6 +63,7 @@ export function bindDeliveredAnswerEvidence(
     answer_run_id: input.answer_run_id,
     bound_at: boundAt,
     conversation_ref: input.conversation_ref,
+    delivery_digest: deliveryDigest,
     delivery_id: input.delivery.delivery_id,
     evidence_artifact_ids: evidenceArtifactIds,
     operator_refs: operatorRefs,
@@ -74,6 +77,7 @@ export function bindDeliveredAnswerEvidence(
     binding_ref: evidenceBindingIdentity(bindingDigest),
     bound_at: boundAt,
     conversation_ref: input.conversation_ref,
+    delivery_digest: deliveryDigest,
     delivery_id: input.delivery.delivery_id,
     evidence_artifact_ids: evidenceArtifactIds,
     operator_refs: operatorRefs,
@@ -152,11 +156,14 @@ export async function admitEvidenceRecheck(
   if (receiptLookup.found) {
     validateAdmissionReceipt(receiptLookup.receipt, {
       binding: input.binding,
+      actor_ref: input.actor_ref,
+      admitted_at: receiptLookup.receipt.run.admitted_at,
       capabilities,
       input_digest: inputDigest,
       receipt_id: receiptId,
       received_at: receivedAt,
       recheck_id: recheckId,
+      request_key: input.request_key,
       run_context: input.run_context,
       run_id: runId,
     });
@@ -202,12 +209,15 @@ export async function admitEvidenceRecheck(
     throw new EvidenceRecheckInvariantError("Evidence recheck admission commit result is invalid.");
   }
   validateAdmissionReceipt(committed.receipt, {
+    actor_ref: input.actor_ref,
+    admitted_at: admittedAt,
     binding: input.binding,
     capabilities,
     input_digest: inputDigest,
     receipt_id: receiptId,
     received_at: receivedAt,
     recheck_id: recheckId,
+    request_key: input.request_key,
     run_context: input.run_context,
     run_id: runId,
   });
@@ -299,6 +309,7 @@ export function validateDeliveredAnswerEvidenceBinding(
     "binding_ref",
     "bound_at",
     "conversation_ref",
+    "delivery_digest",
     "delivery_id",
     "evidence_artifact_ids",
     "operator_refs",
@@ -315,6 +326,7 @@ export function validateDeliveredAnswerEvidenceBinding(
     [binding.binding_digest, "binding_digest"],
     [binding.binding_ref, "binding_ref"],
     [binding.conversation_ref, "conversation_ref"],
+    [binding.delivery_digest, "delivery_digest"],
     [binding.delivery_id, "delivery_id"],
     [binding.requester_ref, "requester_ref"],
     [binding.thread_ref, "thread_ref"],
@@ -322,6 +334,7 @@ export function validateDeliveredAnswerEvidenceBinding(
     requireRef(value, label);
   }
   requireCanonicalTimestamp(binding.bound_at, "bound_at");
+  requireSha256Digest(binding.delivery_digest, "delivery_digest");
   const artifactIds = canonicalArtifactIds(binding.evidence_artifact_ids);
   const operatorRefs = canonicalRefs(
     binding.operator_refs,
@@ -377,12 +390,12 @@ export function validateEvidenceRecheck(recheck: EvidenceRecheckV1): void {
     [recheck.binding_ref, "binding_ref"],
     [recheck.reason_code, "reason_code"],
     [recheck.recheck_id, "recheck_id"],
-    [recheck.request_key, "request_key"],
     [recheck.run_id, "run_id"],
     [recheck.thread_ref, "thread_ref"],
   ] as const) {
     requireRef(value, label);
   }
+  requireRequestKey(recheck.request_key);
   requireCanonicalTimestamp(recheck.created_at, "created_at");
   requireCanonicalTimestamp(recheck.updated_at, "updated_at");
   requirePositiveInteger(recheck.revision, "revision");
@@ -507,12 +520,15 @@ function validateAdmissionInput(input: AdmitEvidenceRecheckInputV1): void {
 function validateAdmissionReceipt(
   receipt: EvidenceRecheckAdmissionReceiptV1,
   expected: {
+    actor_ref: string;
+    admitted_at: string;
     binding: DeliveredAnswerEvidenceBindingV1;
     capabilities: CapabilityRequirement[];
     input_digest: string;
     receipt_id: string;
     received_at: string;
     recheck_id: string;
+    request_key: string;
     run_context: AdmitEvidenceRecheckInputV1["run_context"];
     run_id: string;
   },
@@ -535,10 +551,18 @@ function validateAdmissionReceipt(
   if (
     receipt.recheck.recheck_id !== expected.recheck_id ||
     receipt.recheck.run_id !== expected.run_id ||
+    receipt.recheck.actor_ref !== expected.actor_ref ||
     receipt.recheck.binding_ref !== expected.binding.binding_ref ||
     receipt.recheck.binding_digest !== expected.binding.binding_digest ||
     receipt.recheck.answer_ref !== expected.binding.answer_ref ||
+    receipt.recheck.request_key !== expected.request_key ||
     receipt.recheck.thread_ref !== expected.binding.thread_ref ||
+    !sameStrings(
+      receipt.recheck.evidence_artifact_ids,
+      expected.binding.evidence_artifact_ids,
+    ) ||
+    receipt.recheck.created_at !== expected.admitted_at ||
+    receipt.recheck.updated_at !== expected.admitted_at ||
     receipt.recheck.state !== "queued" ||
     receipt.recheck.reason_code !== "admitted"
   ) {
@@ -558,13 +582,33 @@ function validateAdmissionReceipt(
 function validateRunReceipt(
   run: RunReceiptV1,
   expected: {
+    admitted_at: string;
     capabilities: CapabilityRequirement[];
     input_digest: string;
+    recheck_id: string;
     received_at: string;
     run_context: AdmitEvidenceRecheckInputV1["run_context"];
     run_id: string;
   },
 ): void {
+  assertExactKeys(run, [
+    "admitted_at",
+    "binding_id",
+    "idempotency_key",
+    "input_digest",
+    "receipt_id",
+    "received_at",
+    "required_capabilities",
+    "retention_policy_ref",
+    "revision",
+    "run_id",
+    "run_kind",
+    "schema_version",
+    "state",
+    "subject_ref",
+    "tenant_id",
+    "updated_at",
+  ], "evidence recheck canonical run receipt");
   if (
     run.schema_version !== "run-receipt/v1" ||
     run.run_id !== expected.run_id ||
@@ -576,7 +620,11 @@ function validateRunReceipt(
     run.subject_ref !== expected.run_context.subject_ref ||
     run.retention_policy_ref !== expected.run_context.retention_policy_ref ||
     run.input_digest !== expected.input_digest ||
-    run.received_at !== expected.received_at
+    run.received_at !== expected.received_at ||
+    run.admitted_at !== expected.admitted_at ||
+    run.updated_at !== expected.admitted_at ||
+    run.receipt_id !== `run-receipt:${stableDigest([expected.run_id])}` ||
+    run.idempotency_key !== `evidence-recheck:${stableDigest([expected.recheck_id])}`
   ) {
     throw new EvidenceRecheckInvariantError("Evidence recheck canonical run receipt is invalid.");
   }
@@ -663,6 +711,16 @@ function validateCompletedDelivery(
   delivery: BindDeliveredAnswerEvidenceInputV1["delivery"],
   answerRunId: string,
 ): void {
+  assertExactKeys(delivery, [
+    "created_at",
+    "delivery_id",
+    "destination_ref",
+    "parts",
+    "run_id",
+    "schema_version",
+    "state",
+    "updated_at",
+  ], "completed delivery receipt");
   if (
     delivery.schema_version !== "delivery-receipt/v1" ||
     delivery.run_id !== answerRunId ||
@@ -683,7 +741,19 @@ function validateCompletedDelivery(
     throw new EvidenceRecheckInvariantError("Delivered answers require bounded delivery parts.");
   }
   let expectedSequence = 1;
+  const partIds = new Set<string>();
+  const idempotencyKeys = new Set<string>();
   for (const part of [...delivery.parts].sort((left, right) => left.sequence - right.sequence)) {
+    assertExactKeys(part, [
+      "delivered_at",
+      "destination_receipt",
+      "idempotency_key",
+      "part_id",
+      "payload_digest",
+      "payload_ref",
+      "sequence",
+      "state",
+    ], "completed delivery part");
     if (
       part.state !== "delivered" ||
       part.destination_receipt === undefined ||
@@ -700,8 +770,41 @@ function validateCompletedDelivery(
     requireRef(part.payload_ref, "delivery part payload_ref");
     requireRef(part.destination_receipt, "delivery part destination_receipt");
     requireCanonicalTimestamp(part.delivered_at, "delivery part delivered_at");
+    if (partIds.has(part.part_id) || idempotencyKeys.has(part.idempotency_key)) {
+      throw new EvidenceRecheckInvariantError(
+        "Completed delivery part identities must be distinct.",
+      );
+    }
+    partIds.add(part.part_id);
+    idempotencyKeys.add(part.idempotency_key);
     expectedSequence += 1;
   }
+}
+
+function completedDeliveryDigest(
+  delivery: BindDeliveredAnswerEvidenceInputV1["delivery"],
+): string {
+  return `sha256:${stableDigest({
+    created_at: delivery.created_at,
+    delivery_id: delivery.delivery_id,
+    destination_ref: delivery.destination_ref,
+    parts: [...delivery.parts]
+      .sort((left, right) => left.sequence - right.sequence)
+      .map((part) => ({
+        delivered_at: part.delivered_at,
+        destination_receipt: part.destination_receipt,
+        idempotency_key: part.idempotency_key,
+        part_id: part.part_id,
+        payload_digest: part.payload_digest,
+        payload_ref: part.payload_ref,
+        sequence: part.sequence,
+        state: part.state,
+      })),
+    run_id: delivery.run_id,
+    schema_version: delivery.schema_version,
+    state: delivery.state,
+    updated_at: delivery.updated_at,
+  })}`;
 }
 
 function evidenceRecheckInputDigest(
@@ -732,28 +835,32 @@ function deliveredAnswerEvidenceBindingDigest(input: {
   answer_run_id: string;
   bound_at: string;
   conversation_ref: string;
+  delivery_digest: string;
   delivery_id: string;
   evidence_artifact_ids: readonly string[];
   operator_refs: readonly string[];
   requester_ref: string;
   thread_ref: string;
 }): string {
-  return `sha256:${stableDigest([
-    input.answer_ref,
-    input.answer_run_id,
-    input.delivery_id,
-    input.conversation_ref,
-    input.thread_ref,
-    input.requester_ref,
-    input.bound_at,
-    ...input.operator_refs,
-    "evidence",
-    ...input.evidence_artifact_ids,
-  ])}`;
+  return `sha256:${stableDigest({
+    answer_ref: input.answer_ref,
+    answer_run_id: input.answer_run_id,
+    bound_at: input.bound_at,
+    conversation_ref: input.conversation_ref,
+    delivery_digest: input.delivery_digest,
+    delivery_id: input.delivery_id,
+    evidence_artifact_ids: input.evidence_artifact_ids,
+    operator_refs: input.operator_refs,
+    requester_ref: input.requester_ref,
+    thread_ref: input.thread_ref,
+  })}`;
 }
 
 function evidenceBindingIdentity(bindingDigest: string): string {
-  return `delivered-answer-evidence-binding:${bindingDigest.slice("sha256:".length, 39)}`;
+  return `delivered-answer-evidence-binding:${bindingDigest.slice(
+    "sha256:".length,
+    "sha256:".length + 32,
+  )}`;
 }
 
 function evidenceRecheckRunIdentity(recheckId: string): string {
@@ -910,6 +1017,12 @@ function requireRef(value: string, label: string): void {
   requireBoundedText(value, EVIDENCE_RECHECK_LIMITS.ref_utf8_bytes, label);
 }
 
+function requireSha256Digest(value: string, label: string): void {
+  if (typeof value !== "string" || !SHA256_DIGEST.test(value)) {
+    throw new EvidenceRecheckInvariantError(`${label} must be a canonical SHA-256 digest.`);
+  }
+}
+
 function requireBoundedText(value: string, maximumBytes: number, label: string): void {
   if (
     typeof value !== "string" ||
@@ -942,6 +1055,6 @@ function requireCanonicalTimestamp(value: string, label: string): void {
   }
 }
 
-function stableDigest(values: readonly string[]): string {
-  return createHash("sha256").update(JSON.stringify(values)).digest("hex");
+function stableDigest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
 }

--- a/apps/slack-companion/src/recheck/policy.ts
+++ b/apps/slack-companion/src/recheck/policy.ts
@@ -21,6 +21,8 @@ import {
 
 const UNSAFE_TEXT_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
 const OPAQUE_ARTIFACT_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const RFC3339_TIMESTAMP =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
 const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/;
 const RECHECK_STATES: readonly EvidenceRecheckV1["state"][] = [
   "queued",
@@ -1362,6 +1364,11 @@ function requirePositiveInteger(value: number, label: string): void {
 }
 
 function normalizeTimestamp(value: string, label: string): string {
+  if (typeof value !== "string" || !RFC3339_TIMESTAMP.test(value)) {
+    throw new EvidenceRecheckInvariantError(
+      `${label} must be an RFC 3339 timestamp with a timezone.`,
+    );
+  }
   const milliseconds = Date.parse(value);
   if (!Number.isFinite(milliseconds)) {
     throw new EvidenceRecheckInvariantError(`${label} must be an ISO timestamp.`);

--- a/apps/slack-companion/test/recheck.test.ts
+++ b/apps/slack-companion/test/recheck.test.ts
@@ -4,13 +4,13 @@ import type { DeliveryReceiptV1 } from "@writer/cerebro-sdk";
 import type {
   AdmitEvidenceRecheckInputV1,
   DurableEvidenceRecheckAdmissionPort,
+  DeliveredAnswerEvidenceBindingLookupV1,
   EvidenceRecheckAdmissionCommitResultV1,
   EvidenceRecheckAdmissionCommitV1,
   EvidenceRecheckAdmissionReceiptLookupV1,
   EvidenceRecheckAdmissionReceiptV1,
 } from "../src/recheck/contracts.js";
 import {
-  EvidenceRecheckInvariantError,
   admitEvidenceRecheck,
   authorizeEvidenceRecheck,
   bindDeliveredAnswerEvidence,
@@ -152,7 +152,12 @@ describe("durable evidence recheck admission", () => {
   test("commits request, canonical run, transitions, and queue item before acknowledgement", async () => {
     const input = admissionInput();
     const store = new RecordingStore();
-    const result = await admitEvidenceRecheck(input, missingLookup(input), store);
+    const result = await admitEvidenceRecheck(
+      input,
+      foundBindingLookup(input),
+      missingLookup(input),
+      store,
+    );
 
     assert.equal(store.commits.length, 1);
     assert.equal(result.acknowledgement_permitted, true);
@@ -166,7 +171,7 @@ describe("durable evidence recheck admission", () => {
     assert.equal(result.receipt.run.state, "queued");
     assert.equal(result.receipt.recheck.run_id, result.receipt.run.run_id);
     assert.equal(result.receipt.queue_item.run_id, result.receipt.run.run_id);
-    assert.equal(result.receipt.queue_item.thread_ref, input.binding.thread_ref);
+    assert.equal(result.receipt.queue_item.thread_ref, foundBindingLookup(input).binding.thread_ref);
     assert.equal(result.receipt.queue_item.available_at, result.receipt.run.admitted_at);
   });
 
@@ -174,7 +179,12 @@ describe("durable evidence recheck admission", () => {
     const input = admissionInput();
     const store = new RecordingStore();
     store.failure = new Error("storage unavailable");
-    const result = await admitEvidenceRecheck(input, missingLookup(input), store);
+    const result = await admitEvidenceRecheck(
+      input,
+      foundBindingLookup(input),
+      missingLookup(input),
+      store,
+    );
     assert.deepEqual(result, {
       acknowledgement_permitted: false,
       authorization: {
@@ -193,12 +203,18 @@ describe("durable evidence recheck admission", () => {
   test("replays the durable receipt without another transaction", async () => {
     const input = admissionInput();
     const firstStore = new RecordingStore();
-    const first = await admitEvidenceRecheck(input, missingLookup(input), firstStore);
+    const first = await admitEvidenceRecheck(
+      input,
+      foundBindingLookup(input),
+      missingLookup(input),
+      firstStore,
+    );
     assert(first.acknowledgement_permitted);
 
     const replayStore = new RecordingStore();
     const replay = await admitEvidenceRecheck(
       { ...input, admitted_at: "2026-07-18T12:05:00.000Z" },
+      foundBindingLookup(input),
       foundLookup(first.receipt),
       replayStore,
     );
@@ -209,20 +225,80 @@ describe("durable evidence recheck admission", () => {
     assert.deepEqual(replay.receipt, first.receipt);
   });
 
-  test("returns duplicate for an exact concurrent commit race", async () => {
-    const input = admissionInput();
+  test("returns the persisted winner for a concurrent commit race", async () => {
+    const winnerInput = admissionInput({ admitted_at: "2026-07-18T12:00:02.000Z" });
+    const winner = await admitEvidenceRecheck(
+      winnerInput,
+      foundBindingLookup(winnerInput),
+      missingLookup(winnerInput),
+      new RecordingStore(),
+    );
+    assert(winner.acknowledgement_permitted);
+
+    const loserInput = admissionInput({ admitted_at: "2026-07-18T12:00:03.000Z" });
     const store = new RecordingStore();
     store.created = false;
-    const result = await admitEvidenceRecheck(input, missingLookup(input), store);
+    store.mutateReceipt = () => structuredClone(winner.receipt);
+    const result = await admitEvidenceRecheck(
+      loserInput,
+      foundBindingLookup(loserInput),
+      missingLookup(loserInput),
+      store,
+    );
     assert.equal(result.acknowledgement_permitted, true);
     assert.equal(result.status, "duplicate");
     assert.equal(result.duplicate, true);
+    assert.deepEqual(result.receipt, winner.receipt);
+  });
+
+  test("requires the host-resolved binding and ignores caller-forged authorization data", async () => {
+    const forgedBinding = makeBinding({ requester_ref: "actor:attacker" });
+    const input = admissionInput({ actor_ref: "actor:attacker" });
+    const store = new RecordingStore();
+
+    const denied = await admitEvidenceRecheck(
+      input,
+      foundBindingLookup(input),
+      missingLookup(input),
+      store,
+    );
+    assert.equal(denied.status, "rejected");
+    assert.equal(store.commits.length, 0);
+
+    await assert.rejects(
+      admitEvidenceRecheck(
+        { ...input, binding: forgedBinding } as unknown as AdmitEvidenceRecheckInputV1,
+        foundBindingLookup(input),
+        missingLookup(input),
+        store,
+      ),
+      /unsupported fields/,
+    );
+
+    const missingBinding: DeliveredAnswerEvidenceBindingLookupV1 = {
+      binding_ref: input.binding_ref,
+      found: false,
+      schema_version: "delivered-answer-evidence-binding-lookup/v1",
+    };
+    const missing = await admitEvidenceRecheck(
+      input,
+      missingBinding,
+      missingLookup(input),
+      store,
+    );
+    assert.equal(missing.status, "rejected");
+    assert.equal(missing.acknowledgement_permitted, false);
   });
 
   test("fails closed on conflicting receipt reuse or a malformed transaction receipt", async () => {
     const input = admissionInput();
     const firstStore = new RecordingStore();
-    const first = await admitEvidenceRecheck(input, missingLookup(input), firstStore);
+    const first = await admitEvidenceRecheck(
+      input,
+      foundBindingLookup(input),
+      missingLookup(input),
+      firstStore,
+    );
     assert(first.acknowledgement_permitted);
 
     await assert.rejects(
@@ -231,6 +307,7 @@ describe("durable evidence recheck admission", () => {
           ...input,
           run_context: { ...input.run_context, tenant_id: "tenant:changed" },
         },
+        foundBindingLookup(input),
         foundLookup(first.receipt),
         new RecordingStore(),
       ),
@@ -243,7 +320,12 @@ describe("durable evidence recheck admission", () => {
       run: { ...receipt.run, run_id: "evidence-recheck-run:changed" },
     });
     await assert.rejects(
-      admitEvidenceRecheck(input, missingLookup(input), malformedStore),
+      admitEvidenceRecheck(
+        input,
+        foundBindingLookup(input),
+        missingLookup(input),
+        malformedStore,
+      ),
       /canonical run receipt is invalid/,
     );
   });
@@ -275,6 +357,14 @@ describe("durable evidence recheck admission", () => {
       }),
       (receipt) => ({
         ...receipt,
+        queue_item: { ...receipt.queue_item, queue_item_id: "queue-item:forged" },
+      }),
+      (receipt) => ({
+        ...receipt,
+        queue_item: { ...receipt.queue_item, idempotency_key: "queue:forged" },
+      }),
+      (receipt) => ({
+        ...receipt,
         run: {
           ...receipt.run,
           raw_payload: "not portable",
@@ -286,8 +376,13 @@ describe("durable evidence recheck admission", () => {
       const store = new RecordingStore();
       store.mutateReceipt = mutateReceipt;
       await assert.rejects(
-        admitEvidenceRecheck(input, missingLookup(input), store),
-        /mismatched recheck|unsupported fields/,
+        admitEvidenceRecheck(
+          input,
+          foundBindingLookup(input),
+          missingLookup(input),
+          store,
+        ),
+        /mismatched recheck|not correlated|unsupported fields|updated_at cannot precede/,
       );
     }
   });
@@ -297,6 +392,7 @@ describe("durable evidence recheck admission", () => {
     const deniedStore = new RecordingStore();
     const denied = await admitEvidenceRecheck(
       unauthorized,
+      foundBindingLookup(unauthorized),
       missingLookup(unauthorized),
       deniedStore,
     );
@@ -308,6 +404,7 @@ describe("durable evidence recheck admission", () => {
     await assert.rejects(
       admitEvidenceRecheck(
         { ...admissionInput(), raw_payload: "not portable" } as unknown as AdmitEvidenceRecheckInputV1,
+        foundBindingLookup(admissionInput()),
         missingLookup(admissionInput()),
         unmodeledStore,
       ),
@@ -319,6 +416,7 @@ describe("durable evidence recheck admission", () => {
     await assert.rejects(
       admitEvidenceRecheck(
         oversizedInput,
+        foundBindingLookup(oversizedInput),
         missingLookup(admissionInput()),
         new RecordingStore(),
       ),
@@ -342,12 +440,18 @@ describe("durable evidence recheck admission", () => {
 describe("Slack-visible evidence recheck status", () => {
   test("projects queued, duplicate, degraded, rejected, running, and completed truth", async () => {
     const input = admissionInput();
-    const first = await admitEvidenceRecheck(input, missingLookup(input), new RecordingStore());
+    const first = await admitEvidenceRecheck(
+      input,
+      foundBindingLookup(input),
+      missingLookup(input),
+      new RecordingStore(),
+    );
     assert(first.acknowledgement_permitted);
     assert.equal(projectAdmission(first).status, "queued");
 
     const duplicate = await admitEvidenceRecheck(
       input,
+      foundBindingLookup(input),
       foundLookup(first.receipt),
       new RecordingStore(),
     );
@@ -357,6 +461,7 @@ describe("Slack-visible evidence recheck status", () => {
     failedStore.failure = new Error("unavailable");
     const degradedAdmission = await admitEvidenceRecheck(
       input,
+      foundBindingLookup(input),
       missingLookup(input),
       failedStore,
     );
@@ -365,6 +470,7 @@ describe("Slack-visible evidence recheck status", () => {
     const rejectedInput = admissionInput({ actor_ref: "actor:other" });
     const rejected = await admitEvidenceRecheck(
       rejectedInput,
+      foundBindingLookup(rejectedInput),
       missingLookup(rejectedInput),
       new RecordingStore(),
     );
@@ -375,7 +481,7 @@ describe("Slack-visible evidence recheck status", () => {
       projectRecheck({
         ...first.receipt.recheck,
         completed_at: "2026-07-18T12:05:00.000Z",
-        outcome_digest: "sha256:recheck-outcome",
+        outcome_digest: `sha256:${"a".repeat(64)}`,
         outcome_ref: "evidence-recheck-outcome:1",
         reason_code: "evidence_rechecked",
         revision: 3,
@@ -398,7 +504,12 @@ describe("Slack-visible evidence recheck status", () => {
 
   test("rejects invalid runtime states and incomplete completion truth", async () => {
     const input = admissionInput();
-    const result = await admitEvidenceRecheck(input, missingLookup(input), new RecordingStore());
+    const result = await admitEvidenceRecheck(
+      input,
+      foundBindingLookup(input),
+      missingLookup(input),
+      new RecordingStore(),
+    );
     assert(result.acknowledgement_permitted);
     assert.throws(
       () => projectRecheck({ ...result.receipt.recheck, state: "unknown" as "queued" }),
@@ -423,6 +534,30 @@ describe("Slack-visible evidence recheck status", () => {
     assert.throws(
       () => projectRecheck({ ...result.receipt.recheck, state: "completed" }),
       /require a durable outcome/,
+    );
+    assert.throws(
+      () =>
+        projectRecheck({
+          ...result.receipt.recheck,
+          completed_at: "2026-07-18T12:05:00.000Z",
+          outcome_digest: "not-a-digest",
+          outcome_ref: "evidence-recheck-outcome:1",
+          state: "completed",
+          updated_at: "2026-07-18T12:05:00.000Z",
+        }),
+      /outcome_digest must be a canonical SHA-256 digest/,
+    );
+    assert.throws(
+      () =>
+        projectRecheck({
+          ...result.receipt.recheck,
+          completed_at: "2000-01-01T00:00:00.000Z",
+          outcome_digest: `sha256:${"b".repeat(64)}`,
+          outcome_ref: "evidence-recheck-outcome:1",
+          state: "completed",
+          updated_at: "2000-01-01T00:00:00.000Z",
+        }),
+      /updated_at cannot precede created_at|timestamps must be monotonic/,
     );
     assert.throws(
       () =>
@@ -478,7 +613,7 @@ function projectRecheck(
 function missingLookup(
   input: AdmitEvidenceRecheckInputV1,
 ): EvidenceRecheckAdmissionReceiptLookupV1 {
-  const recheckId = evidenceRecheckIdentity(input.binding.binding_ref, input.request_key);
+  const recheckId = evidenceRecheckIdentity(input.binding_ref, input.request_key);
   return {
     found: false,
     receipt_id: evidenceRecheckAdmissionReceiptIdentity(recheckId),
@@ -499,12 +634,10 @@ function foundLookup(
 function admissionInput(
   overrides: Partial<AdmitEvidenceRecheckInputV1> = {},
 ): AdmitEvidenceRecheckInputV1 {
-  const binding = overrides.binding ?? makeBinding();
   return {
     actor_ref: "actor:requester",
     admitted_at: ADMITTED_AT,
-    binding,
-    binding_ref: binding.binding_ref,
+    binding_ref: makeBinding().binding_ref,
     received_at: RECEIVED_AT,
     request_key: "event:recheck-1",
     run_context: {
@@ -517,6 +650,18 @@ function admissionInput(
       tenant_id: "tenant:1",
     },
     ...overrides,
+  };
+}
+
+function foundBindingLookup(
+  input: AdmitEvidenceRecheckInputV1,
+  binding = makeBinding(),
+): Extract<DeliveredAnswerEvidenceBindingLookupV1, { found: true }> {
+  assert.equal(binding.binding_ref, input.binding_ref);
+  return {
+    binding,
+    found: true,
+    schema_version: "delivered-answer-evidence-binding-lookup/v1",
   };
 }
 

--- a/apps/slack-companion/test/recheck.test.ts
+++ b/apps/slack-companion/test/recheck.test.ts
@@ -142,6 +142,14 @@ describe("server-bound delivered answer evidence", () => {
         }),
       /part timestamps must be monotonic/,
     );
+    assert.throws(
+      () => makeBinding({ bound_at: new Date("2026-07-18T11:59:00.000Z") as unknown as string }),
+      /RFC 3339 timestamp/,
+    );
+    assert.throws(
+      () => makeBinding({ bound_at: "July 18, 2026 11:59 UTC" }),
+      /RFC 3339 timestamp/,
+    );
   });
 
   test("accepts no caller-selected evidence location or unmodeled content", () => {
@@ -456,6 +464,19 @@ describe("durable evidence recheck admission", () => {
         new RecordingStore(),
       ),
       /request_key is not a bounded canonical value/,
+    );
+
+    const dateObjectInput = admissionInput({
+      admitted_at: new Date(ADMITTED_AT) as unknown as string,
+    });
+    await assert.rejects(
+      admitEvidenceRecheck(
+        dateObjectInput,
+        foundBindingLookup(dateObjectInput),
+        missingLookup(dateObjectInput),
+        new RecordingStore(),
+      ),
+      /RFC 3339 timestamp/,
     );
   });
 

--- a/apps/slack-companion/test/recheck.test.ts
+++ b/apps/slack-companion/test/recheck.test.ts
@@ -27,6 +27,7 @@ describe("server-bound delivered answer evidence", () => {
     const binding = makeBinding();
     assert.equal(binding.answer_run_id, "run:answer-1");
     assert.equal(binding.delivery_id, "delivery:answer-1");
+    assert.match(binding.delivery_digest, /^sha256:[a-f0-9]{64}$/);
     assert.deepEqual(binding.evidence_artifact_ids, ["artifact:a", "artifact:b"]);
     assert.deepEqual(binding.operator_refs, ["actor:operator-a", "actor:operator-b"]);
     assert.match(binding.binding_digest, /^sha256:[a-f0-9]{64}$/);
@@ -55,6 +56,56 @@ describe("server-bound delivered answer evidence", () => {
     assert.throws(
       () => makeBinding({ evidence_artifact_ids: [] }),
       /must be present and bounded/,
+    );
+  });
+
+  test("hashes operator and evidence arrays as separate canonical fields", () => {
+    const first = makeBinding({
+      evidence_artifact_ids: ["evidence", "z"],
+      operator_refs: ["a"],
+    });
+    const second = makeBinding({
+      evidence_artifact_ids: ["z"],
+      operator_refs: ["a", "evidence"],
+    });
+
+    assert.notEqual(first.binding_digest, second.binding_digest);
+    assert.notEqual(first.binding_ref, second.binding_ref);
+  });
+
+  test("binds the immutable completed delivery receipt and rejects duplicate part identities", () => {
+    const original = makeBinding();
+    const firstPart = delivery().parts[0]!;
+    const changedDelivery = makeBinding({
+      delivery: delivery({
+        parts: [{ ...firstPart, destination_receipt: "destination-receipt:changed" }],
+      }),
+    });
+    assert.notEqual(original.delivery_digest, changedDelivery.delivery_digest);
+    assert.notEqual(original.binding_digest, changedDelivery.binding_digest);
+
+    const secondPart = {
+      ...firstPart,
+      delivered_at: "2026-07-18T11:58:31.000Z",
+      destination_receipt: "destination-receipt:2",
+      idempotency_key: "delivery-part:2",
+      sequence: 2,
+    };
+    assert.throws(
+      () => makeBinding({ delivery: delivery({ parts: [firstPart, secondPart] }) }),
+      /part identities must be distinct/,
+    );
+    assert.throws(
+      () =>
+        makeBinding({
+          delivery: delivery({
+            parts: [
+              firstPart,
+              { ...secondPart, idempotency_key: firstPart.idempotency_key, part_id: "part:2" },
+            ],
+          }),
+        }),
+      /part identities must be distinct/,
     );
   });
 
@@ -195,6 +246,50 @@ describe("durable evidence recheck admission", () => {
       admitEvidenceRecheck(input, missingLookup(input), malformedStore),
       /canonical run receipt is invalid/,
     );
+  });
+
+  test("binds every returned durable record to the admitted request", async () => {
+    const input = admissionInput();
+    const mutations: Array<
+      (receipt: EvidenceRecheckAdmissionReceiptV1) => EvidenceRecheckAdmissionReceiptV1
+    > = [
+      (receipt) => ({
+        ...receipt,
+        recheck: { ...receipt.recheck, actor_ref: "actor:operator-a" },
+      }),
+      (receipt) => ({
+        ...receipt,
+        recheck: { ...receipt.recheck, request_key: "event:another-recheck" },
+      }),
+      (receipt) => ({
+        ...receipt,
+        recheck: { ...receipt.recheck, evidence_artifact_ids: ["artifact:other"] },
+      }),
+      (receipt) => ({
+        ...receipt,
+        recheck: { ...receipt.recheck, created_at: "2026-07-18T12:00:02.000Z" },
+      }),
+      (receipt) => ({
+        ...receipt,
+        recheck: { ...receipt.recheck, updated_at: "2026-07-18T12:00:02.000Z" },
+      }),
+      (receipt) => ({
+        ...receipt,
+        run: {
+          ...receipt.run,
+          raw_payload: "not portable",
+        } as unknown as EvidenceRecheckAdmissionReceiptV1["run"],
+      }),
+    ];
+
+    for (const mutateReceipt of mutations) {
+      const store = new RecordingStore();
+      store.mutateReceipt = mutateReceipt;
+      await assert.rejects(
+        admitEvidenceRecheck(input, missingLookup(input), store),
+        /mismatched recheck|unsupported fields/,
+      );
+    }
   });
 
   test("rejects unauthorized, unbounded, and unmodeled requests before persistence", async () => {

--- a/apps/slack-companion/test/recheck.test.ts
+++ b/apps/slack-companion/test/recheck.test.ts
@@ -92,7 +92,13 @@ describe("server-bound delivered answer evidence", () => {
       sequence: 2,
     };
     assert.throws(
-      () => makeBinding({ delivery: delivery({ parts: [firstPart, secondPart] }) }),
+      () =>
+        makeBinding({
+          delivery: delivery({
+            parts: [firstPart, secondPart],
+            updated_at: secondPart.delivered_at,
+          }),
+        }),
       /part identities must be distinct/,
     );
     assert.throws(
@@ -103,9 +109,38 @@ describe("server-bound delivered answer evidence", () => {
               firstPart,
               { ...secondPart, idempotency_key: firstPart.idempotency_key, part_id: "part:2" },
             ],
+            updated_at: secondPart.delivered_at,
           }),
         }),
       /part identities must be distinct/,
+    );
+  });
+
+  test("requires monotonic delivery and binding timestamps", () => {
+    assert.throws(
+      () => makeBinding({ bound_at: "2026-07-18T11:58:29.000Z" }),
+      /cannot precede completed delivery/,
+    );
+    assert.throws(
+      () =>
+        makeBinding({
+          delivery: delivery({ updated_at: "2026-07-18T11:57:59.000Z" }),
+        }),
+      /delivery timestamps must be monotonic/,
+    );
+    assert.throws(
+      () =>
+        makeBinding({
+          delivery: delivery({
+            parts: [
+              {
+                ...delivery().parts[0]!,
+                delivered_at: "2026-07-18T11:57:59.000Z",
+              },
+            ],
+          }),
+        }),
+      /part timestamps must be monotonic/,
     );
   });
 
@@ -647,6 +682,14 @@ describe("Slack-visible evidence recheck status", () => {
           binding_digest: "not-a-digest",
         }),
       /binding_digest must be a canonical SHA-256 digest/,
+    );
+    assert.throws(
+      () =>
+        projectRecheck({
+          ...result.receipt.recheck,
+          binding_digest: `sha256:${"c".repeat(64)}`,
+        }),
+      /binding reference does not match its digest/,
     );
     assert.throws(
       () =>

--- a/apps/slack-companion/test/recheck.test.ts
+++ b/apps/slack-companion/test/recheck.test.ts
@@ -382,7 +382,7 @@ describe("durable evidence recheck admission", () => {
           missingLookup(input),
           store,
         ),
-        /mismatched recheck|not correlated|unsupported fields|updated_at cannot precede/,
+        /identities are invalid|mismatched recheck|not correlated|unsupported fields|updated_at cannot precede/,
       );
     }
   });
@@ -434,6 +434,46 @@ describe("durable evidence recheck admission", () => {
       evidenceRecheckAdmissionReceiptIdentity(first),
       /^evidence-recheck-admission-receipt:[a-f0-9]{64}$/,
     );
+  });
+
+  test("canonicalizes capability identity without host locale ordering", async () => {
+    const input = admissionInput({
+      run_context: {
+        ...admissionInput().run_context,
+        required_capabilities: [
+          { capability_id: "ä", level: "required", version: "v1" },
+          { capability_id: "z", level: "required", version: "v1" },
+        ],
+      },
+    });
+    const first = await admitEvidenceRecheck(
+      input,
+      foundBindingLookup(input),
+      missingLookup(input),
+      new RecordingStore(),
+    );
+    assert(first.acknowledgement_permitted);
+    assert.deepEqual(
+      first.receipt.run.required_capabilities.map((capability) => capability.capability_id),
+      ["z", "ä"],
+    );
+
+    const replayInput = {
+      ...input,
+      admitted_at: "2026-07-18T12:05:00.000Z",
+      run_context: {
+        ...input.run_context,
+        required_capabilities: [...input.run_context.required_capabilities].reverse(),
+      },
+    };
+    const replay = await admitEvidenceRecheck(
+      replayInput,
+      foundBindingLookup(replayInput),
+      foundLookup(first.receipt),
+      new RecordingStore(),
+    );
+    assert(replay.acknowledgement_permitted);
+    assert.deepEqual(replay.receipt, first.receipt);
   });
 });
 
@@ -532,6 +572,39 @@ describe("Slack-visible evidence recheck status", () => {
       /status is unsupported/,
     );
     assert.throws(
+      () =>
+        projectAdmission({
+          ...result,
+          acknowledgement_permitted: false,
+          authorization: {
+            allowed: false,
+            reason_code: "actor_not_authorized",
+            schema_version: "evidence-recheck-authorization/v1",
+          },
+          duplicate: true,
+          receipt: {
+            recheck: { recheck_id: "forged:recheck" },
+          },
+          retryable: true,
+          status: "queued",
+        } as unknown as Awaited<ReturnType<typeof admitEvidenceRecheck>>),
+      /contradictory/,
+    );
+    assert.throws(
+      () =>
+        projectAdmission({
+          ...result,
+          receipt: {
+            ...result.receipt,
+            queue_item: {
+              ...result.receipt.queue_item,
+              queue_item_id: "queue-item:forged",
+            },
+          },
+        }),
+      /not correlated/,
+    );
+    assert.throws(
       () => projectRecheck({ ...result.receipt.recheck, state: "completed" }),
       /require a durable outcome/,
     );
@@ -566,6 +639,33 @@ describe("Slack-visible evidence recheck status", () => {
           created_at: "2026-07-18T05:00:01-07:00",
         }),
       /canonical UTC form/,
+    );
+    assert.throws(
+      () =>
+        projectRecheck({
+          ...result.receipt.recheck,
+          binding_digest: "not-a-digest",
+        }),
+      /binding_digest must be a canonical SHA-256 digest/,
+    );
+    assert.throws(
+      () =>
+        projectRecheck({
+          ...result.receipt.recheck,
+          recheck_id: "recheck:unrelated",
+          run_id: "run:unrelated",
+        }),
+      /identities are invalid/,
+    );
+    assert.throws(
+      () =>
+        projectEvidenceRecheckStatus({
+          kind: "recheck",
+          raw_payload: "not portable",
+          recheck: result.receipt.recheck,
+          schema_version: "evidence-recheck-status-input/v1",
+        } as unknown as Parameters<typeof projectEvidenceRecheckStatus>[0]),
+      /unsupported fields/,
     );
   });
 });

--- a/apps/slack-companion/test/recheck.test.ts
+++ b/apps/slack-companion/test/recheck.test.ts
@@ -1,0 +1,471 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { DeliveryReceiptV1 } from "@writer/cerebro-sdk";
+import type {
+  AdmitEvidenceRecheckInputV1,
+  DurableEvidenceRecheckAdmissionPort,
+  EvidenceRecheckAdmissionCommitResultV1,
+  EvidenceRecheckAdmissionCommitV1,
+  EvidenceRecheckAdmissionReceiptLookupV1,
+  EvidenceRecheckAdmissionReceiptV1,
+} from "../src/recheck/contracts.js";
+import {
+  EvidenceRecheckInvariantError,
+  admitEvidenceRecheck,
+  authorizeEvidenceRecheck,
+  bindDeliveredAnswerEvidence,
+  evidenceRecheckAdmissionReceiptIdentity,
+  evidenceRecheckIdentity,
+  projectEvidenceRecheckStatus,
+} from "../src/recheck/policy.js";
+
+const RECEIVED_AT = "2026-07-18T12:00:00.000Z";
+const ADMITTED_AT = "2026-07-18T12:00:01.000Z";
+
+describe("server-bound delivered answer evidence", () => {
+  test("binds only evidence attached to every durably delivered answer part", () => {
+    const binding = makeBinding();
+    assert.equal(binding.answer_run_id, "run:answer-1");
+    assert.equal(binding.delivery_id, "delivery:answer-1");
+    assert.deepEqual(binding.evidence_artifact_ids, ["artifact:a", "artifact:b"]);
+    assert.deepEqual(binding.operator_refs, ["actor:operator-a", "actor:operator-b"]);
+    assert.match(binding.binding_digest, /^sha256:[a-f0-9]{64}$/);
+    assert.match(binding.binding_ref, /^delivered-answer-evidence-binding:[a-f0-9]{32}$/);
+
+    assert.throws(
+      () => makeBinding({ delivery: delivery({ state: "delivering" }) }),
+      /completed delivery/,
+    );
+    assert.throws(
+      () =>
+        makeBinding({
+          delivery: delivery({
+            parts: [
+              {
+                ...delivery().parts[0]!,
+                delivered_at: undefined,
+                destination_receipt: undefined,
+                state: "failed",
+              },
+            ],
+          }),
+        }),
+      /Every original answer part/,
+    );
+    assert.throws(
+      () => makeBinding({ evidence_artifact_ids: [] }),
+      /must be present and bounded/,
+    );
+  });
+
+  test("accepts no caller-selected evidence location or unmodeled content", () => {
+    assert.throws(
+      () => makeBinding({ evidence_artifact_ids: ["https://example.invalid/evidence"] }),
+      /opaque server-owned identifiers/,
+    );
+    assert.throws(
+      () =>
+        bindDeliveredAnswerEvidence({
+          ...bindingInput(),
+          prompt: "unmodeled caller content",
+        } as unknown as Parameters<typeof bindDeliveredAnswerEvidence>[0]),
+      /unsupported fields/,
+    );
+  });
+
+  test("authorizes only the original requester or a recorded operator", () => {
+    const binding = makeBinding();
+    assert.deepEqual(authorizeEvidenceRecheck("actor:requester", binding.binding_ref, binding), {
+      allowed: true,
+      role: "requester",
+      schema_version: "evidence-recheck-authorization/v1",
+    });
+    assert.equal(
+      authorizeEvidenceRecheck("actor:operator-b", binding.binding_ref, binding).allowed,
+      true,
+    );
+    assert.deepEqual(authorizeEvidenceRecheck("actor:other", binding.binding_ref, binding), {
+      allowed: false,
+      reason_code: "actor_not_authorized",
+      schema_version: "evidence-recheck-authorization/v1",
+    });
+    assert.deepEqual(authorizeEvidenceRecheck("actor:requester", "binding:other", binding), {
+      allowed: false,
+      reason_code: "binding_reference_mismatch",
+      schema_version: "evidence-recheck-authorization/v1",
+    });
+  });
+});
+
+describe("durable evidence recheck admission", () => {
+  test("commits request, canonical run, transitions, and queue item before acknowledgement", async () => {
+    const input = admissionInput();
+    const store = new RecordingStore();
+    const result = await admitEvidenceRecheck(input, missingLookup(input), store);
+
+    assert.equal(store.commits.length, 1);
+    assert.equal(result.acknowledgement_permitted, true);
+    assert.equal(result.status, "queued");
+    assert.equal(result.duplicate, false);
+    assert.deepEqual(store.commits[0]?.transitions, [
+      { from: "received", to: "admitted" },
+      { from: "admitted", to: "queued" },
+    ]);
+    assert.equal(result.receipt.run.run_kind, "reconciliation");
+    assert.equal(result.receipt.run.state, "queued");
+    assert.equal(result.receipt.recheck.run_id, result.receipt.run.run_id);
+    assert.equal(result.receipt.queue_item.run_id, result.receipt.run.run_id);
+    assert.equal(result.receipt.queue_item.thread_ref, input.binding.thread_ref);
+    assert.equal(result.receipt.queue_item.available_at, result.receipt.run.admitted_at);
+  });
+
+  test("does not permit acknowledgement when the durable transaction is unavailable", async () => {
+    const input = admissionInput();
+    const store = new RecordingStore();
+    store.failure = new Error("storage unavailable");
+    const result = await admitEvidenceRecheck(input, missingLookup(input), store);
+    assert.deepEqual(result, {
+      acknowledgement_permitted: false,
+      authorization: {
+        allowed: true,
+        role: "requester",
+        schema_version: "evidence-recheck-authorization/v1",
+      },
+      duplicate: false,
+      reason_code: "durable_admission_unavailable",
+      retryable: true,
+      schema_version: "admit-evidence-recheck-result/v1",
+      status: "degraded",
+    });
+  });
+
+  test("replays the durable receipt without another transaction", async () => {
+    const input = admissionInput();
+    const firstStore = new RecordingStore();
+    const first = await admitEvidenceRecheck(input, missingLookup(input), firstStore);
+    assert(first.acknowledgement_permitted);
+
+    const replayStore = new RecordingStore();
+    const replay = await admitEvidenceRecheck(
+      { ...input, admitted_at: "2026-07-18T12:05:00.000Z" },
+      foundLookup(first.receipt),
+      replayStore,
+    );
+    assert.equal(replayStore.commits.length, 0);
+    assert.equal(replay.acknowledgement_permitted, true);
+    assert.equal(replay.status, "duplicate");
+    assert.equal(replay.duplicate, true);
+    assert.deepEqual(replay.receipt, first.receipt);
+  });
+
+  test("returns duplicate for an exact concurrent commit race", async () => {
+    const input = admissionInput();
+    const store = new RecordingStore();
+    store.created = false;
+    const result = await admitEvidenceRecheck(input, missingLookup(input), store);
+    assert.equal(result.acknowledgement_permitted, true);
+    assert.equal(result.status, "duplicate");
+    assert.equal(result.duplicate, true);
+  });
+
+  test("fails closed on conflicting receipt reuse or a malformed transaction receipt", async () => {
+    const input = admissionInput();
+    const firstStore = new RecordingStore();
+    const first = await admitEvidenceRecheck(input, missingLookup(input), firstStore);
+    assert(first.acknowledgement_permitted);
+
+    await assert.rejects(
+      admitEvidenceRecheck(
+        {
+          ...input,
+          run_context: { ...input.run_context, tenant_id: "tenant:changed" },
+        },
+        foundLookup(first.receipt),
+        new RecordingStore(),
+      ),
+      /conflicts with this request/,
+    );
+
+    const malformedStore = new RecordingStore();
+    malformedStore.mutateReceipt = (receipt) => ({
+      ...receipt,
+      run: { ...receipt.run, run_id: "evidence-recheck-run:changed" },
+    });
+    await assert.rejects(
+      admitEvidenceRecheck(input, missingLookup(input), malformedStore),
+      /canonical run receipt is invalid/,
+    );
+  });
+
+  test("rejects unauthorized, unbounded, and unmodeled requests before persistence", async () => {
+    const unauthorized = admissionInput({ actor_ref: "actor:other" });
+    const deniedStore = new RecordingStore();
+    const denied = await admitEvidenceRecheck(
+      unauthorized,
+      missingLookup(unauthorized),
+      deniedStore,
+    );
+    assert.equal(denied.status, "rejected");
+    assert.equal(denied.acknowledgement_permitted, false);
+    assert.equal(deniedStore.commits.length, 0);
+
+    const unmodeledStore = new RecordingStore();
+    await assert.rejects(
+      admitEvidenceRecheck(
+        { ...admissionInput(), raw_payload: "not portable" } as unknown as AdmitEvidenceRecheckInputV1,
+        missingLookup(admissionInput()),
+        unmodeledStore,
+      ),
+      /unsupported fields/,
+    );
+    assert.equal(unmodeledStore.commits.length, 0);
+
+    const oversizedInput = admissionInput({ request_key: `event:${"x".repeat(300)}` });
+    await assert.rejects(
+      admitEvidenceRecheck(
+        oversizedInput,
+        missingLookup(admissionInput()),
+        new RecordingStore(),
+      ),
+      /request_key is not a bounded canonical value/,
+    );
+  });
+
+  test("derives stable recheck correlation and changes it with the request identity", () => {
+    const binding = makeBinding();
+    const first = evidenceRecheckIdentity(binding.binding_ref, "event:recheck-1");
+    assert.equal(first, evidenceRecheckIdentity(binding.binding_ref, "event:recheck-1"));
+    assert.notEqual(first, evidenceRecheckIdentity(binding.binding_ref, "event:recheck-2"));
+    assert.match(first, /^evidence-recheck:[a-f0-9]{32}$/);
+    assert.match(
+      evidenceRecheckAdmissionReceiptIdentity(first),
+      /^evidence-recheck-admission-receipt:[a-f0-9]{64}$/,
+    );
+  });
+});
+
+describe("Slack-visible evidence recheck status", () => {
+  test("projects queued, duplicate, degraded, rejected, running, and completed truth", async () => {
+    const input = admissionInput();
+    const first = await admitEvidenceRecheck(input, missingLookup(input), new RecordingStore());
+    assert(first.acknowledgement_permitted);
+    assert.equal(projectAdmission(first).status, "queued");
+
+    const duplicate = await admitEvidenceRecheck(
+      input,
+      foundLookup(first.receipt),
+      new RecordingStore(),
+    );
+    assert.equal(projectAdmission(duplicate).status, "duplicate");
+
+    const failedStore = new RecordingStore();
+    failedStore.failure = new Error("unavailable");
+    const degradedAdmission = await admitEvidenceRecheck(
+      input,
+      missingLookup(input),
+      failedStore,
+    );
+    assert.equal(projectAdmission(degradedAdmission).status, "degraded");
+
+    const rejectedInput = admissionInput({ actor_ref: "actor:other" });
+    const rejected = await admitEvidenceRecheck(
+      rejectedInput,
+      missingLookup(rejectedInput),
+      new RecordingStore(),
+    );
+    assert.equal(projectAdmission(rejected).status, "rejected");
+
+    assert.equal(projectRecheck({ ...first.receipt.recheck, state: "running" }).status, "in_progress");
+    assert.equal(
+      projectRecheck({
+        ...first.receipt.recheck,
+        completed_at: "2026-07-18T12:05:00.000Z",
+        outcome_digest: "sha256:recheck-outcome",
+        outcome_ref: "evidence-recheck-outcome:1",
+        reason_code: "evidence_rechecked",
+        revision: 3,
+        state: "completed",
+        updated_at: "2026-07-18T12:05:00.000Z",
+      }).status,
+      "completed",
+    );
+    assert.equal(
+      projectRecheck({
+        ...first.receipt.recheck,
+        reason_code: "evidence_temporarily_unavailable",
+        revision: 2,
+        state: "degraded",
+        updated_at: "2026-07-18T12:03:00.000Z",
+      }).status,
+      "degraded",
+    );
+  });
+
+  test("rejects invalid runtime states and incomplete completion truth", async () => {
+    const input = admissionInput();
+    const result = await admitEvidenceRecheck(input, missingLookup(input), new RecordingStore());
+    assert(result.acknowledgement_permitted);
+    assert.throws(
+      () => projectRecheck({ ...result.receipt.recheck, state: "unknown" as "queued" }),
+      /state is unsupported/,
+    );
+    assert.throws(
+      () =>
+        projectRecheck({
+          ...result.receipt.recheck,
+          raw_payload: "not portable",
+        } as unknown as EvidenceRecheckAdmissionReceiptV1["recheck"]),
+      /unsupported fields/,
+    );
+    assert.throws(
+      () =>
+        projectAdmission({
+          ...result,
+          status: "unknown",
+        } as unknown as Awaited<ReturnType<typeof admitEvidenceRecheck>>),
+      /status is unsupported/,
+    );
+    assert.throws(
+      () => projectRecheck({ ...result.receipt.recheck, state: "completed" }),
+      /require a durable outcome/,
+    );
+    assert.throws(
+      () =>
+        projectRecheck({
+          ...result.receipt.recheck,
+          created_at: "2026-07-18T05:00:01-07:00",
+        }),
+      /canonical UTC form/,
+    );
+  });
+});
+
+class RecordingStore implements DurableEvidenceRecheckAdmissionPort {
+  commits: EvidenceRecheckAdmissionCommitV1[] = [];
+  created = true;
+  failure?: Error;
+  mutateReceipt?: (
+    receipt: EvidenceRecheckAdmissionReceiptV1,
+  ) => EvidenceRecheckAdmissionReceiptV1;
+
+  async admitAndEnqueue(
+    commit: EvidenceRecheckAdmissionCommitV1,
+  ): Promise<EvidenceRecheckAdmissionCommitResultV1> {
+    this.commits.push(structuredClone(commit));
+    if (this.failure !== undefined) {
+      throw this.failure;
+    }
+    return {
+      created: this.created,
+      receipt: this.mutateReceipt?.(commit.receipt) ?? structuredClone(commit.receipt),
+    };
+  }
+}
+
+function projectAdmission(result: Awaited<ReturnType<typeof admitEvidenceRecheck>>) {
+  return projectEvidenceRecheckStatus({
+    kind: "admission",
+    result,
+    schema_version: "evidence-recheck-status-input/v1",
+  });
+}
+
+function projectRecheck(
+  recheck: EvidenceRecheckAdmissionReceiptV1["recheck"],
+) {
+  return projectEvidenceRecheckStatus({
+    kind: "recheck",
+    recheck,
+    schema_version: "evidence-recheck-status-input/v1",
+  });
+}
+
+function missingLookup(
+  input: AdmitEvidenceRecheckInputV1,
+): EvidenceRecheckAdmissionReceiptLookupV1 {
+  const recheckId = evidenceRecheckIdentity(input.binding.binding_ref, input.request_key);
+  return {
+    found: false,
+    receipt_id: evidenceRecheckAdmissionReceiptIdentity(recheckId),
+    schema_version: "evidence-recheck-admission-receipt-lookup/v1",
+  };
+}
+
+function foundLookup(
+  receipt: EvidenceRecheckAdmissionReceiptV1,
+): EvidenceRecheckAdmissionReceiptLookupV1 {
+  return {
+    found: true,
+    receipt,
+    schema_version: "evidence-recheck-admission-receipt-lookup/v1",
+  };
+}
+
+function admissionInput(
+  overrides: Partial<AdmitEvidenceRecheckInputV1> = {},
+): AdmitEvidenceRecheckInputV1 {
+  const binding = overrides.binding ?? makeBinding();
+  return {
+    actor_ref: "actor:requester",
+    admitted_at: ADMITTED_AT,
+    binding,
+    binding_ref: binding.binding_ref,
+    received_at: RECEIVED_AT,
+    request_key: "event:recheck-1",
+    run_context: {
+      required_capabilities: [
+        { capability_id: "evidence.read", level: "required", version: "v1" },
+      ],
+      retention_policy_ref: "retention:standard",
+      service_binding_id: "service-binding:1",
+      subject_ref: "subject:1",
+      tenant_id: "tenant:1",
+    },
+    ...overrides,
+  };
+}
+
+function makeBinding(
+  overrides: Partial<ReturnType<typeof bindingInput>> = {},
+) {
+  return bindDeliveredAnswerEvidence({ ...bindingInput(), ...overrides });
+}
+
+function bindingInput() {
+  return {
+    answer_ref: "answer:1",
+    answer_run_id: "run:answer-1",
+    bound_at: "2026-07-18T11:59:00.000Z",
+    conversation_ref: "conversation:1",
+    delivery: delivery(),
+    evidence_artifact_ids: ["artifact:b", "artifact:a"] as readonly string[],
+    operator_refs: ["actor:operator-b", "actor:operator-a"] as readonly string[],
+    requester_ref: "actor:requester",
+    thread_ref: "thread:1",
+  };
+}
+
+function delivery(overrides: Partial<DeliveryReceiptV1> = {}): DeliveryReceiptV1 {
+  return {
+    created_at: "2026-07-18T11:58:00.000Z",
+    delivery_id: "delivery:answer-1",
+    destination_ref: "destination:conversation-1",
+    parts: [
+      {
+        delivered_at: "2026-07-18T11:58:30.000Z",
+        destination_receipt: "destination-receipt:1",
+        idempotency_key: "delivery-part:1",
+        part_id: "part:1",
+        payload_digest: "sha256:answer-part-1",
+        payload_ref: "answer-part:1",
+        sequence: 1,
+        state: "delivered",
+      },
+    ],
+    run_id: "run:answer-1",
+    schema_version: "delivery-receipt/v1",
+    state: "completed",
+    updated_at: "2026-07-18T11:58:30.000Z",
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

- bind rechecks to evidence already attached to a fully delivered answer
- authorize only the original requester or a recorded operator
- derive stable recheck, run, queue, and receipt identities
- commit durable reconciliation work before transport acknowledgement
- project queued, duplicate, in-progress, completed, degraded, and rejected states

## Boundary

This change contains portable records, deterministic policy, and synthetic tests only. Evidence resolution, persistence, execution, authorization lookup, and transport adapters remain host-owned.

## Validation

- workspace checks passed
- contract checks passed
- open-source boundary audit passed