### PR TITLE
Fix Slack improvement outcome receipts

### DIFF
--- a/apps/slack-companion/src/improvement/contracts.ts
+++ b/apps/slack-companion/src/improvement/contracts.ts
@@ -156,13 +156,16 @@ export interface ImprovementAuthorVerification {
   state: "failed" | "verified";
 }
 
-export interface ImprovementEvidenceStateV1 {
-  author_generation: number;
-  candidate_id: string;
+export interface ImprovementEvidenceIdentityV1 {
+  readonly author_generation: number;
+  readonly candidate_id: string;
+  readonly kind: ImprovementEvidenceKind;
+}
+
+export interface ImprovementEvidenceStateV1 extends ImprovementEvidenceIdentityV1 {
   evidence_digest?: string;
   evidence_ref?: string;
   head_digest?: string;
-  kind: ImprovementEvidenceKind;
   schema_version: "improvement-evidence-state/v1";
   state: "invalidated" | "fresh";
   updated_at: string;
@@ -191,27 +194,33 @@ export interface ImprovementEvidenceInvalidationReceipt {
   invalidation_ref: string;
 }
 
-export interface ImprovementEvidenceRecord {
-  author_generation: number;
-  candidate_id: string;
-  evidence_digest: string;
-  evidence_ref: string;
-  expected_revision: number;
-  head_digest: string;
-  kind: ImprovementEvidenceKind;
+export interface ImprovementEvidenceRecord extends ImprovementEvidenceIdentityV1 {
+  readonly evidence_digest: string;
+  readonly evidence_ref: string;
+  readonly expected_revision: number;
+  readonly head_digest: string;
 }
 
 export interface ImprovementFreshEvidenceInput extends Omit<
   ImprovementEvidenceRecord,
   "kind"
 > {
-  kind: ImprovementIndependentEvidenceKind;
+  readonly kind: ImprovementIndependentEvidenceKind;
 }
 
 export interface ImprovementOutcomeEvaluationSetV1 {
-  /** Exact source head used to produce every evaluation in this set. */
-  evaluated_head_digest: string;
-  evaluations: readonly AssistantTurnEvaluationV1[];
+  /** Rows are sealed by the evaluator receipt; a caller-supplied head label is not authoritative. */
+  readonly evaluations: readonly AssistantTurnEvaluationV1[];
+  readonly receipt: ImprovementOutcomeEvaluationSetReceiptV1;
+}
+
+export interface ImprovementOutcomeEvaluationSetReceiptV1 {
+  /** Exact source head used to produce every ordered evaluation row. */
+  readonly evaluated_head_digest: string;
+  readonly evaluator_ref: string;
+  readonly ordered_row_digests: readonly string[];
+  readonly receipt_digest: string;
+  readonly schema_version: "improvement-outcome-evaluation-set-receipt/v1";
 }
 
 export interface ImprovementOutcomeEvidenceInput {

--- a/apps/slack-companion/src/improvement/coordinator.ts
+++ b/apps/slack-companion/src/improvement/coordinator.ts
@@ -36,6 +36,10 @@ import {
   type ImprovementOutcomeEvidenceInput,
   type ImprovementOutcomeEvidenceOutcome,
 } from "./contracts.js";
+import {
+  ImprovementEvaluationSetReceiptError,
+  validateImprovementOutcomeEvaluationSet,
+} from "./evaluation-set-receipt.js";
 import type {
   DurableImprovementCandidatePort,
   ImprovementAuthorPort,
@@ -261,8 +265,9 @@ export class ImprovementCoordinator {
     assertEvidenceCandidate(candidate, input);
     if (
       candidate.authoring_prior_head_digest === undefined ||
-      input.baseline.evaluated_head_digest !== candidate.authoring_prior_head_digest ||
-      input.candidate.evaluated_head_digest !== candidate.head_digest
+      input.baseline.receipt.evaluated_head_digest !==
+        candidate.authoring_prior_head_digest ||
+      input.candidate.receipt.evaluated_head_digest !== candidate.head_digest
     ) {
       throw new ImprovementConflictError(
         "Outcome evidence does not match the baseline and candidate heads.",
@@ -297,13 +302,28 @@ export class ImprovementCoordinator {
     input: ImprovementEvidenceRecord,
   ): Promise<ImprovementCandidateV1> {
     const snapshot = await this.evidence.recordFresh(input);
-    if (
-      !isBoundEvidenceSnapshot(snapshot, candidate) ||
-      !snapshotContainsEvidence(snapshot, input)
-    ) {
+    const exactSnapshot = isBoundEvidenceSnapshot(snapshot, candidate) &&
+      snapshotContainsEvidence(snapshot, input);
+    if (!exactSnapshot) {
+      if (candidate.status === "ready") {
+        throw new ImprovementConflictError(
+          "Ready evidence replay did not return the exact stored snapshot.",
+        );
+      }
       return candidate;
     }
     if (!snapshot.states.every((state) => state.state === "fresh")) return candidate;
+    if (candidate.status === "ready") {
+      if (
+        candidate.fresh_evidence_digest !== snapshot.bundle_digest ||
+        candidate.fresh_evidence_ref !== snapshot.bundle_ref
+      ) {
+        throw new ImprovementConflictError(
+          "Ready evidence completion conflicts with the stored snapshot.",
+        );
+      }
+      return candidate;
+    }
     return this.candidates.markEvidenceReady({
       author_generation: candidate.author_generation,
       candidate_id: candidate.candidate_id,
@@ -693,14 +713,11 @@ function validateOutcomeEvidence(input: ImprovementOutcomeEvidenceInput): void {
     throw new ImprovementInputError("Outcome evidence candidate revision is invalid.");
   }
   assertDigest(input.head_digest, "outcome head");
-  assertDigest(input.baseline.evaluated_head_digest, "baseline outcome head");
-  assertDigest(input.candidate.evaluated_head_digest, "candidate outcome head");
-  assertSafeRef(input.held_out_evidence_ref, "held-out evidence");
-  assertSafeRef(input.shadow_evidence_ref, "shadow evidence");
-  assertSafeRef(input.promotion_evidence_ref, "promotion evidence");
   if (
     !Array.isArray(input.baseline.evaluations) ||
     !Array.isArray(input.candidate.evaluations) ||
+    input.baseline.evaluations.length === 0 ||
+    input.candidate.evaluations.length === 0 ||
     input.baseline.evaluations.length > MAXIMUM_OUTCOME_EVALUATIONS_PER_POLICY ||
     input.candidate.evaluations.length > MAXIMUM_OUTCOME_EVALUATIONS_PER_POLICY
   ) {
@@ -708,6 +725,18 @@ function validateOutcomeEvidence(input: ImprovementOutcomeEvidenceInput): void {
       "Baseline and candidate outcome evaluations are required and bounded.",
     );
   }
+  try {
+    validateImprovementOutcomeEvaluationSet(input.baseline);
+    validateImprovementOutcomeEvaluationSet(input.candidate);
+  } catch (error) {
+    if (error instanceof ImprovementEvaluationSetReceiptError) {
+      throw new ImprovementInputError(error.message);
+    }
+    throw error;
+  }
+  assertSafeRef(input.held_out_evidence_ref, "held-out evidence");
+  assertSafeRef(input.shadow_evidence_ref, "shadow evidence");
+  assertSafeRef(input.promotion_evidence_ref, "promotion evidence");
 }
 
 function assertEvidenceCandidate(
@@ -717,10 +746,16 @@ function assertEvidenceCandidate(
     "author_generation" | "candidate_id" | "expected_revision" | "head_digest"
   >,
 ): void {
+  const exactAwaitingRevision = candidate.status === "awaiting_evidence" &&
+    candidate.revision === input.expected_revision;
+  const exactReadyReplay = candidate.status === "ready" &&
+    (candidate.revision === input.expected_revision ||
+      candidate.revision === input.expected_revision + 1) &&
+    candidate.fresh_evidence_digest !== undefined &&
+    candidate.fresh_evidence_ref !== undefined;
   if (
-    (candidate.status !== "awaiting_evidence" && candidate.status !== "ready") ||
+    (!exactAwaitingRevision && !exactReadyReplay) ||
     candidate.candidate_id !== input.candidate_id ||
-    candidate.revision !== input.expected_revision ||
     candidate.author_generation !== input.author_generation ||
     candidate.head_digest !== input.head_digest
   ) {
@@ -756,9 +791,11 @@ function outcomeEvidenceRecords(
     {
       ...common,
       evidence_digest: digest(JSON.stringify({
-        candidate_head_digest: input.candidate.evaluated_head_digest,
+        candidate_evaluation_receipt_digest: input.candidate.receipt.receipt_digest,
+        candidate_head_digest: input.candidate.receipt.evaluated_head_digest,
         decision,
-        baseline_head_digest: input.baseline.evaluated_head_digest,
+        baseline_evaluation_receipt_digest: input.baseline.receipt.receipt_digest,
+        baseline_head_digest: input.baseline.receipt.evaluated_head_digest,
       })),
       evidence_ref: input.promotion_evidence_ref,
       kind: "promotion",
@@ -771,17 +808,21 @@ function outcomePartition(
   partition: "held_out" | "shadow",
 ): {
   baseline: AssistantTurnEvaluationV1[];
+  baseline_evaluation_receipt_digest: string;
   baseline_head_digest: string;
   candidate: AssistantTurnEvaluationV1[];
+  candidate_evaluation_receipt_digest: string;
   candidate_head_digest: string;
   partition: "held_out" | "shadow";
   schema_version: "improvement-outcome-evidence/v1";
 } {
   return {
     baseline: canonicalEvaluations(input.baseline.evaluations, partition),
-    baseline_head_digest: input.baseline.evaluated_head_digest,
+    baseline_evaluation_receipt_digest: input.baseline.receipt.receipt_digest,
+    baseline_head_digest: input.baseline.receipt.evaluated_head_digest,
     candidate: canonicalEvaluations(input.candidate.evaluations, partition),
-    candidate_head_digest: input.candidate.evaluated_head_digest,
+    candidate_evaluation_receipt_digest: input.candidate.receipt.receipt_digest,
+    candidate_head_digest: input.candidate.receipt.evaluated_head_digest,
     partition,
     schema_version: "improvement-outcome-evidence/v1",
   };

--- a/apps/slack-companion/src/improvement/evaluation-set-receipt.ts
+++ b/apps/slack-companion/src/improvement/evaluation-set-receipt.ts
@@ -1,0 +1,126 @@
+import { createHash } from "node:crypto";
+import type { AssistantTurnEvaluationV1 } from "../assistant-turn/evaluation.js";
+import type {
+  ImprovementOutcomeEvaluationSetReceiptV1,
+  ImprovementOutcomeEvaluationSetV1,
+} from "./contracts.js";
+
+const EVALUATION_SET_RECEIPT_SCHEMA =
+  "improvement-outcome-evaluation-set-receipt/v1" as const;
+const SHA256_DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+export class ImprovementEvaluationSetReceiptError extends Error {}
+
+/** Seal an evaluator's exact ordered rows to the source head that produced them. */
+export function sealImprovementOutcomeEvaluationSet(
+  evaluatedHeadDigest: string,
+  evaluations: readonly AssistantTurnEvaluationV1[],
+): ImprovementOutcomeEvaluationSetV1 {
+  if (!SHA256_DIGEST_PATTERN.test(evaluatedHeadDigest)) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluated head must be a sha256 digest.",
+    );
+  }
+  const evaluatorRef = evaluations[0]?.evaluator_ref;
+  if (evaluatorRef === undefined || !evaluatorRef.trim()) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation set requires an evaluator identity.",
+    );
+  }
+  if (evaluations.some((evaluation) => evaluation.evaluator_ref !== evaluatorRef)) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation set must use one evaluator identity.",
+    );
+  }
+  const orderedRowDigests = evaluations.map(evaluationRowDigest);
+  const receiptContent = {
+    evaluated_head_digest: evaluatedHeadDigest,
+    evaluator_ref: evaluatorRef,
+    ordered_row_digests: orderedRowDigests,
+    schema_version: EVALUATION_SET_RECEIPT_SCHEMA,
+  };
+  return {
+    evaluations: structuredClone(evaluations),
+    receipt: {
+      ...receiptContent,
+      receipt_digest: evaluationSetReceiptDigest(receiptContent),
+    },
+  };
+}
+
+/** Verify the seal without accepting any unsealed outer head or evaluator label. */
+export function validateImprovementOutcomeEvaluationSet(
+  value: ImprovementOutcomeEvaluationSetV1,
+): void {
+  const receipt = value.receipt;
+  if (
+    receipt.schema_version !== EVALUATION_SET_RECEIPT_SCHEMA ||
+    !SHA256_DIGEST_PATTERN.test(receipt.evaluated_head_digest) ||
+    !receipt.evaluator_ref.trim() ||
+    receipt.ordered_row_digests.length !== value.evaluations.length ||
+    receipt.ordered_row_digests.some((rowDigest) => !SHA256_DIGEST_PATTERN.test(rowDigest))
+  ) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation set receipt fields are invalid.",
+    );
+  }
+  const orderedRowDigests = value.evaluations.map((evaluation) => {
+    if (evaluation.evaluator_ref !== receipt.evaluator_ref) {
+      throw new ImprovementEvaluationSetReceiptError(
+        "The evaluation set receipt evaluator identity changed.",
+      );
+    }
+    return evaluationRowDigest(evaluation);
+  });
+  if (
+    orderedRowDigests.some(
+      (rowDigest, index) => rowDigest !== receipt.ordered_row_digests[index],
+    )
+  ) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation set receipt rows changed.",
+    );
+  }
+  const { receipt_digest: receiptDigest, ...receiptContent } = receipt;
+  if (
+    !SHA256_DIGEST_PATTERN.test(receiptDigest) ||
+    receiptDigest !== evaluationSetReceiptDigest(receiptContent)
+  ) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation set receipt integrity is invalid.",
+    );
+  }
+}
+
+function evaluationRowDigest(evaluation: AssistantTurnEvaluationV1): string {
+  return sha256(stableStringify(evaluation));
+}
+
+function evaluationSetReceiptDigest(
+  receipt: Omit<ImprovementOutcomeEvaluationSetReceiptV1, "receipt_digest">,
+): string {
+  return sha256(JSON.stringify([
+    receipt.schema_version,
+    receipt.evaluated_head_digest,
+    receipt.evaluator_ref,
+    receipt.ordered_row_digests,
+  ]));
+}
+
+function sha256(value: string): string {
+  return `sha256:${createHash("sha256").update(value, "utf8").digest("hex")}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}

--- a/apps/slack-companion/src/improvement/ports.ts
+++ b/apps/slack-companion/src/improvement/ports.ts
@@ -70,7 +70,13 @@ export interface ImprovementVerificationPort {
   ): Promise<ImprovementAuthorVerification>;
 }
 
-/** Evidence remains invalidated until every required exact-head receipt is fresh. */
+/**
+ * Evidence remains invalidated until every required exact-head receipt is fresh.
+ * `recordFresh` uses the immutable `(candidate_id, author_generation, kind)` tuple
+ * as its identity. An exact replay must return the stored snapshot. A replay that
+ * changes the head, evidence digest, or evidence reference must reject as a
+ * conflict instead of replacing the stored receipt.
+ */
 export interface ImprovementEvidencePort {
   invalidate(
     request: ImprovementEvidenceInvalidationRequest,

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -54,6 +54,7 @@ export type {
 export * from "./installation.js";
 export * from "./improvement/contracts.js";
 export * from "./improvement/coordinator.js";
+export * from "./improvement/evaluation-set-receipt.js";
 export * from "./improvement/ports.js";
 export * from "./history/contracts.js";
 export * from "./history/message-policy.js";

--- a/apps/slack-companion/test/improvement.test.ts
+++ b/apps/slack-companion/test/improvement.test.ts
@@ -38,6 +38,9 @@ import type {
   ImprovementOutcomeEvidenceInput,
 } from "../src/improvement/contracts.js";
 import { IMPROVEMENT_EVIDENCE_KINDS } from "../src/improvement/contracts.js";
+import {
+  sealImprovementOutcomeEvaluationSet,
+} from "../src/improvement/evaluation-set-receipt.js";
 import type {
   DurableImprovementCandidatePort,
   ImprovementAuthorPort,
@@ -309,6 +312,64 @@ describe("ImprovementCoordinator", () => {
     );
   });
 
+  test("rejects relabeled, reordered, row-tampered, and evaluator-tampered evaluation sets", async () => {
+    const fixture = makeFixture();
+    const candidate = (await fixture.coordinator.register(candidateInput())).candidate;
+    const session = await fixture.session(1);
+    const authored = await fixture.coordinator.authorCandidate(
+      authorRequest(candidate, session),
+    );
+
+    const relabeled = outcomeEvidence(authored.candidate);
+    relabeled.candidate = {
+      ...relabeled.candidate,
+      receipt: {
+        ...relabeled.candidate.receipt,
+        evaluated_head_digest: sha("relabeled-head"),
+      },
+    };
+    await assert.rejects(
+      fixture.coordinator.recordOutcomeEvidence(relabeled),
+      /receipt integrity is invalid/,
+    );
+
+    const reordered = outcomeEvidence(authored.candidate);
+    reordered.candidate = {
+      ...reordered.candidate,
+      evaluations: reordered.candidate.evaluations.slice().reverse(),
+    };
+    await assert.rejects(
+      fixture.coordinator.recordOutcomeEvidence(reordered),
+      /receipt rows changed/,
+    );
+
+    const rowTampered = outcomeEvidence(authored.candidate);
+    rowTampered.candidate = {
+      ...rowTampered.candidate,
+      evaluations: rowTampered.candidate.evaluations.map((evaluation, index) =>
+        index === 0
+          ? { ...evaluation, observation_digest: sha("changed-observation") }
+          : evaluation),
+    };
+    await assert.rejects(
+      fixture.coordinator.recordOutcomeEvidence(rowTampered),
+      /receipt rows changed/,
+    );
+
+    const evaluatorTampered = outcomeEvidence(authored.candidate);
+    evaluatorTampered.candidate = {
+      ...evaluatorTampered.candidate,
+      evaluations: evaluatorTampered.candidate.evaluations.map((evaluation, index) =>
+        index === 0
+          ? { ...evaluation, evaluator_ref: "evaluation://changed-evaluator" }
+          : evaluation),
+    };
+    await assert.rejects(
+      fixture.coordinator.recordOutcomeEvidence(evaluatorTampered),
+      /receipt evaluator identity changed/,
+    );
+  });
+
   test("recovers idempotently when outcome evidence persists before a response failure", async () => {
     const fixture = makeFixture();
     const candidate = (await fixture.coordinator.register(candidateInput())).candidate;
@@ -330,6 +391,60 @@ describe("ImprovementCoordinator", () => {
     );
     assert.equal(recovered.candidate.status, "ready");
     assert.equal(recovered.decision.promotion_ready, true);
+  });
+
+  test("returns the exact ready candidate when its commit response was lost", async () => {
+    const fixture = makeFixture();
+    const candidate = (await fixture.coordinator.register(candidateInput())).candidate;
+    const session = await fixture.session(1);
+    let current = (await fixture.coordinator.authorCandidate(
+      authorRequest(candidate, session),
+    )).candidate;
+    current = await fixture.coordinator.recordFreshEvidence(freshEvidence(current, "ci"));
+    current = await fixture.coordinator.recordFreshEvidence(freshEvidence(current, "canary"));
+    fixture.candidates.failNextReadyResponse = true;
+    const request = outcomeEvidence(current);
+
+    await assert.rejects(
+      fixture.coordinator.recordOutcomeEvidence(request),
+      /injected ready response failure/,
+    );
+    assert.equal((await fixture.candidates.read(current.candidate_id))?.status, "ready");
+
+    const recovered = await fixture.coordinator.recordOutcomeEvidence(request);
+    assert.equal(recovered.candidate.status, "ready");
+    assert.equal(recovered.candidate.revision, current.revision + 1);
+    assert.equal(recovered.decision.promotion_ready, true);
+    assert.equal(fixture.candidates.markEvidenceReadyCalls, 1);
+  });
+
+  test("replays one immutable evidence identity exactly and rejects conflicting content", async () => {
+    const fixture = makeFixture();
+    const candidate = (await fixture.coordinator.register(candidateInput())).candidate;
+    const session = await fixture.session(1);
+    const authored = (await fixture.coordinator.authorCandidate(
+      authorRequest(candidate, session),
+    )).candidate;
+    const input = freshEvidence(authored, "ci");
+
+    const first = await fixture.evidence.recordFresh(input);
+    const replay = await fixture.evidence.recordFresh(input);
+    assert.deepEqual(replay, first);
+
+    for (const conflict of [
+      { evidence_digest: sha("changed-evidence") },
+      { evidence_ref: "evidence://changed-ref" },
+      { head_digest: sha("changed-head") },
+    ]) {
+      await assert.rejects(
+        async () => fixture.evidence.recordFresh({ ...input, ...conflict }),
+        /Fresh evidence changed/,
+      );
+    }
+    assert.deepEqual(
+      await fixture.evidence.read(input.candidate_id, input.author_generation),
+      first,
+    );
   });
 
   test("rejects fresh evidence snapshots with changed identity or receipt content", async () => {
@@ -408,6 +523,8 @@ function makeFixture() {
 
 class MemoryCandidateStore implements DurableImprovementCandidatePort {
   failNextCompletion = false;
+  failNextReadyResponse = false;
+  markEvidenceReadyCalls = 0;
   private readonly fingerprints = new Map<string, string>();
   private readonly records = new Map<string, ImprovementCandidateV1>();
 
@@ -524,8 +641,18 @@ class MemoryCandidateStore implements DurableImprovementCandidatePort {
   }
 
   markEvidenceReady(completion: ImprovementEvidenceCompletion) {
+    this.markEvidenceReadyCalls += 1;
     const candidate = this.require(completion.candidate_id);
-    if (candidate.status === "ready") return Promise.resolve(clone(candidate));
+    if (candidate.status === "ready") {
+      if (
+        candidate.revision === completion.expected_revision + 1 &&
+        candidate.author_generation === completion.author_generation &&
+        candidate.head_digest === completion.head_digest &&
+        candidate.fresh_evidence_digest === completion.fresh_evidence_digest &&
+        candidate.fresh_evidence_ref === completion.fresh_evidence_ref
+      ) return Promise.resolve(clone(candidate));
+      return Promise.reject(new ImprovementConflictError("Evidence completion changed."));
+    }
     if (
       candidate.status !== "awaiting_evidence" ||
       candidate.revision !== completion.expected_revision ||
@@ -541,6 +668,10 @@ class MemoryCandidateStore implements DurableImprovementCandidatePort {
       updated_at: completion.updated_at,
     };
     this.records.set(candidate.candidate_id, clone(next));
+    if (this.failNextReadyResponse) {
+      this.failNextReadyResponse = false;
+      return Promise.reject(new Error("injected ready response failure"));
+    }
     return Promise.resolve(clone(next));
   }
 
@@ -925,24 +1056,26 @@ function outcomeEvidence(
   const baselineHead = overrides.baseline_head_digest
     ?? candidate.authoring_prior_head_digest
     ?? assert.fail("authored candidate must preserve its prior head");
+  const baselineEvaluations = promotionEvaluations(
+    "policy://baseline",
+    0.72,
+    ["outcome_unknown"],
+  );
+  const candidateEvaluations = promotionEvaluations(
+    "policy://candidate",
+    overrides.candidate_score ?? 0.94,
+    overrides.candidate_blockers ?? [],
+  );
   return {
     author_generation: candidate.author_generation,
-    baseline: {
-      evaluated_head_digest: baselineHead,
-      evaluations: promotionEvaluations(
-        "policy://baseline",
-        0.72,
-        ["outcome_unknown"],
-      ),
-    },
-    candidate: {
-      evaluated_head_digest: overrides.candidate_head_digest ?? candidate.head_digest,
-      evaluations: promotionEvaluations(
-        "policy://candidate",
-        overrides.candidate_score ?? 0.94,
-        overrides.candidate_blockers ?? [],
-      ),
-    },
+    baseline: sealImprovementOutcomeEvaluationSet(
+      baselineHead,
+      baselineEvaluations,
+    ),
+    candidate: sealImprovementOutcomeEvaluationSet(
+      overrides.candidate_head_digest ?? candidate.head_digest,
+      candidateEvaluations,
+    ),
     candidate_id: candidate.candidate_id,
     expected_revision: candidate.revision,
     head_digest: candidate.head_digest,


### PR DESCRIPTION
## What changed

- Seal each outcome evaluation set to its exact evaluated head, ordered row digests, and evaluator identity.
- Return the already-committed ready candidate when an exact retry follows a lost response.
- Define immutable evidence identity and exact replay versus conflict behavior for evidence adapters.
- Add focused tamper, crash-recovery, replay, and conflicting-content tests.

## Why

Outcome validation previously accepted an outer head label that was not bound to the evaluated rows. A response lost after the ready-state commit could also make an exact retry appear stale, and the evidence adapter contract did not explicitly require conflicting content to fail closed.

## Impact

Promotion accepts only evaluation sets whose receipt matches the exact rows and head. Exact retries recover the committed ready state without a second commit, while changed evidence for an existing identity is rejected.

## Validation

- `make app-workspace-check workspace-check`
- Slack companion package archive inspection
- `python3 scripts/oss_audit.py`
- staged and commit-range leak checks
- Practice Registry preflight, plan, changed-line scan, and final gate