### PR TITLE
fix(slack): harden improvement receipts

### DIFF
--- a/apps/slack-companion/src/improvement/contracts.ts
+++ b/apps/slack-companion/src/improvement/contracts.ts
@@ -201,6 +201,26 @@ export interface ImprovementEvidenceRecord extends ImprovementEvidenceIdentityV1
   readonly head_digest: string;
 }
 
+export interface ImprovementEvidencePutCommit {
+  /**
+   * Fingerprint of the immutable evidence payload. The candidate revision is a
+   * coordinator CAS value and is intentionally not part of this fingerprint so
+   * an exact retry can recover after the candidate advances to `ready`.
+   */
+  readonly payload_fingerprint: string;
+  readonly record: ImprovementEvidenceRecord;
+}
+
+export interface ImprovementEvidencePutReceiptV1 extends ImprovementEvidenceIdentityV1 {
+  readonly receipt_digest: string;
+  readonly receipt_ref: string;
+  readonly requested_payload_fingerprint: string;
+  readonly schema_version: "improvement-evidence-put-receipt/v1";
+  readonly snapshot: ImprovementEvidenceSnapshot;
+  readonly status: "conflict" | "created" | "replayed";
+  readonly stored_payload_fingerprint: string;
+}
+
 export interface ImprovementFreshEvidenceInput extends Omit<
   ImprovementEvidenceRecord,
   "kind"
@@ -209,9 +229,14 @@ export interface ImprovementFreshEvidenceInput extends Omit<
 }
 
 export interface ImprovementOutcomeEvaluationSetV1 {
-  /** Rows are sealed by the evaluator receipt; a caller-supplied head label is not authoritative. */
+  /** Rows are resolved from the trusted evaluator port, never supplied by the caller. */
   readonly evaluations: readonly AssistantTurnEvaluationV1[];
   readonly receipt: ImprovementOutcomeEvaluationSetReceiptV1;
+}
+
+export interface ImprovementOutcomeEvaluationReceiptReferenceV1 {
+  readonly receipt_digest: string;
+  readonly receipt_ref: string;
 }
 
 export interface ImprovementOutcomeEvaluationSetReceiptV1 {
@@ -225,8 +250,8 @@ export interface ImprovementOutcomeEvaluationSetReceiptV1 {
 
 export interface ImprovementOutcomeEvidenceInput {
   author_generation: number;
-  baseline: ImprovementOutcomeEvaluationSetV1;
-  candidate: ImprovementOutcomeEvaluationSetV1;
+  baseline_evaluation_receipt: ImprovementOutcomeEvaluationReceiptReferenceV1;
+  candidate_evaluation_receipt: ImprovementOutcomeEvaluationReceiptReferenceV1;
   candidate_id: string;
   expected_revision: number;
   head_digest: string;

--- a/apps/slack-companion/src/improvement/coordinator.ts
+++ b/apps/slack-companion/src/improvement/coordinator.ts
@@ -31,8 +31,10 @@ import {
   type ImprovementCandidateInput,
   type ImprovementCandidateV1,
   type ImprovementEvidenceRecord,
+  type ImprovementEvidencePutReceiptV1,
   type ImprovementEvidenceSnapshot,
   type ImprovementFreshEvidenceInput,
+  type ImprovementOutcomeEvaluationSetV1,
   type ImprovementOutcomeEvidenceInput,
   type ImprovementOutcomeEvidenceOutcome,
 } from "./contracts.js";
@@ -45,19 +47,27 @@ import type {
   ImprovementAuthorPort,
   ImprovementClockPort,
   ImprovementEvidencePort,
+  ImprovementOutcomeEvaluatorPort,
   ImprovementVerificationPort,
 } from "./ports.js";
 
 export class ImprovementConflictError extends Error {}
 export class ImprovementInputError extends Error {}
 
-const MAXIMUM_OUTCOME_EVALUATIONS_PER_POLICY = 512;
+type ResolvedImprovementOutcomeEvidence = Omit<
+  ImprovementOutcomeEvidenceInput,
+  "baseline_evaluation_receipt" | "candidate_evaluation_receipt"
+> & {
+  baseline: ImprovementOutcomeEvaluationSetV1;
+  candidate: ImprovementOutcomeEvaluationSetV1;
+};
 
 export interface ImprovementCoordinatorOptions {
   author: ImprovementAuthorPort;
   candidates: DurableImprovementCandidatePort;
   clock: ImprovementClockPort;
   evidence: ImprovementEvidencePort;
+  evaluator: ImprovementOutcomeEvaluatorPort;
   execution: ExecutionCoordinator;
   execution_store: Pick<
     DurableExecutionPort,
@@ -72,6 +82,7 @@ export class ImprovementCoordinator {
   private readonly clock: ImprovementClockPort;
   private readonly effects: ExternalEffectReconciler;
   private readonly evidence: ImprovementEvidencePort;
+  private readonly evaluator: ImprovementOutcomeEvaluatorPort;
   private readonly execution: ExecutionCoordinator;
 
   constructor(options: ImprovementCoordinatorOptions) {
@@ -79,6 +90,7 @@ export class ImprovementCoordinator {
     this.candidates = options.candidates;
     this.clock = options.clock;
     this.evidence = options.evidence;
+    this.evaluator = options.evaluator;
     this.execution = options.execution;
     this.effects = new ExternalEffectReconciler({
       clock: options.clock,
@@ -263,23 +275,24 @@ export class ImprovementCoordinator {
     validateOutcomeEvidence(input);
     const candidate = await this.requireCandidate(input.candidate_id);
     assertEvidenceCandidate(candidate, input);
+    const resolved = await this.resolveOutcomeEvidence(input);
     if (
       candidate.authoring_prior_head_digest === undefined ||
-      input.baseline.receipt.evaluated_head_digest !==
+      resolved.baseline.receipt.evaluated_head_digest !==
         candidate.authoring_prior_head_digest ||
-      input.candidate.receipt.evaluated_head_digest !== candidate.head_digest
+      resolved.candidate.receipt.evaluated_head_digest !== candidate.head_digest
     ) {
       throw new ImprovementConflictError(
         "Outcome evidence does not match the baseline and candidate heads.",
       );
     }
     const decision = decideAssistantTurnPromotion(
-      input.baseline.evaluations,
-      input.candidate.evaluations,
+      resolved.baseline.evaluations,
+      resolved.candidate.evaluations,
     );
     if (!decision.promotion_ready) return { candidate, decision };
 
-    const evidence = outcomeEvidenceRecords(input, decision);
+    const evidence = outcomeEvidenceRecords(resolved, decision);
     let current = candidate;
     for (const record of evidence) {
       const recorded = await this.recordEvidence(current, record);
@@ -301,7 +314,18 @@ export class ImprovementCoordinator {
     candidate: ImprovementCandidateV1,
     input: ImprovementEvidenceRecord,
   ): Promise<ImprovementCandidateV1> {
-    const snapshot = await this.evidence.recordFresh(input);
+    const payloadFingerprint = evidencePayloadFingerprint(input);
+    const receipt = await this.evidence.putFreshIfAbsent({
+      payload_fingerprint: payloadFingerprint,
+      record: input,
+    });
+    validateEvidencePutReceipt(receipt, input, payloadFingerprint);
+    if (receipt.status === "conflict") {
+      throw new ImprovementConflictError(
+        "Fresh evidence conflicts with the immutable stored receipt.",
+      );
+    }
+    const snapshot = receipt.snapshot;
     const exactSnapshot = isBoundEvidenceSnapshot(snapshot, candidate) &&
       snapshotContainsEvidence(snapshot, input);
     if (!exactSnapshot) {
@@ -333,6 +357,40 @@ export class ImprovementCoordinator {
       head_digest: candidate.head_digest,
       updated_at: this.clock.now().toISOString(),
     });
+  }
+
+  private async resolveOutcomeEvidence(
+    input: ImprovementOutcomeEvidenceInput,
+  ): Promise<ResolvedImprovementOutcomeEvidence> {
+    const [baseline, candidate] = await Promise.all([
+      this.evaluator.resolve(input.baseline_evaluation_receipt),
+      this.evaluator.resolve(input.candidate_evaluation_receipt),
+    ]);
+    if (baseline === undefined || candidate === undefined) {
+      throw new ImprovementConflictError(
+        "The trusted evaluator receipt is unavailable.",
+      );
+    }
+    try {
+      validateImprovementOutcomeEvaluationSet(baseline);
+      validateImprovementOutcomeEvaluationSet(candidate);
+    } catch (error) {
+      if (error instanceof ImprovementEvaluationSetReceiptError) {
+        throw new ImprovementInputError(error.message);
+      }
+      throw error;
+    }
+    if (
+      baseline.receipt.receipt_digest !==
+        input.baseline_evaluation_receipt.receipt_digest ||
+      candidate.receipt.receipt_digest !==
+        input.candidate_evaluation_receipt.receipt_digest
+    ) {
+      throw new ImprovementConflictError(
+        "The trusted evaluator receipt digest does not match the requested receipt.",
+      );
+    }
+    return { ...input, baseline, candidate };
   }
 
   private async requireCandidate(candidateId: string): Promise<ImprovementCandidateV1> {
@@ -703,6 +761,17 @@ function validateFreshEvidence(input: ImprovementEvidenceRecord): void {
 }
 
 function validateOutcomeEvidence(input: ImprovementOutcomeEvidenceInput): void {
+  assertExactPlainRecord(input, [
+    "author_generation",
+    "baseline_evaluation_receipt",
+    "candidate_evaluation_receipt",
+    "candidate_id",
+    "expected_revision",
+    "head_digest",
+    "held_out_evidence_ref",
+    "promotion_evidence_ref",
+    "shadow_evidence_ref",
+  ], "outcome evidence input");
   if (
     !/^improvement-[a-f0-9]{32}$/.test(input.candidate_id) ||
     !Number.isSafeInteger(input.author_generation) ||
@@ -713,26 +782,25 @@ function validateOutcomeEvidence(input: ImprovementOutcomeEvidenceInput): void {
     throw new ImprovementInputError("Outcome evidence candidate revision is invalid.");
   }
   assertDigest(input.head_digest, "outcome head");
+  for (const [label, reference] of [
+    ["baseline", input.baseline_evaluation_receipt],
+    ["candidate", input.candidate_evaluation_receipt],
+  ] as const) {
+    assertExactPlainRecord(
+      reference,
+      ["receipt_digest", "receipt_ref"],
+      `${label} evaluator receipt reference`,
+    );
+    assertDigest(reference.receipt_digest, `${label} evaluator receipt`);
+    assertSafeRef(reference.receipt_ref, `${label} evaluator receipt`);
+  }
   if (
-    !Array.isArray(input.baseline.evaluations) ||
-    !Array.isArray(input.candidate.evaluations) ||
-    input.baseline.evaluations.length === 0 ||
-    input.candidate.evaluations.length === 0 ||
-    input.baseline.evaluations.length > MAXIMUM_OUTCOME_EVALUATIONS_PER_POLICY ||
-    input.candidate.evaluations.length > MAXIMUM_OUTCOME_EVALUATIONS_PER_POLICY
+    input.baseline_evaluation_receipt.receipt_ref ===
+      input.candidate_evaluation_receipt.receipt_ref
   ) {
     throw new ImprovementInputError(
-      "Baseline and candidate outcome evaluations are required and bounded.",
+      "Baseline and candidate evaluator receipts must be distinct.",
     );
-  }
-  try {
-    validateImprovementOutcomeEvaluationSet(input.baseline);
-    validateImprovementOutcomeEvaluationSet(input.candidate);
-  } catch (error) {
-    if (error instanceof ImprovementEvaluationSetReceiptError) {
-      throw new ImprovementInputError(error.message);
-    }
-    throw error;
   }
   assertSafeRef(input.held_out_evidence_ref, "held-out evidence");
   assertSafeRef(input.shadow_evidence_ref, "shadow evidence");
@@ -764,7 +832,7 @@ function assertEvidenceCandidate(
 }
 
 function outcomeEvidenceRecords(
-  input: ImprovementOutcomeEvidenceInput,
+  input: ResolvedImprovementOutcomeEvidence,
   decision: AssistantTurnPromotionDecisionV1,
 ): ImprovementEvidenceRecord[] {
   const heldOut = outcomePartition(input, "held_out");
@@ -778,25 +846,25 @@ function outcomeEvidenceRecords(
   return [
     {
       ...common,
-      evidence_digest: digest(JSON.stringify(heldOut)),
+      evidence_digest: canonicalDigest(heldOut),
       evidence_ref: input.held_out_evidence_ref,
       kind: "eval",
     },
     {
       ...common,
-      evidence_digest: digest(JSON.stringify(shadow)),
+      evidence_digest: canonicalDigest(shadow),
       evidence_ref: input.shadow_evidence_ref,
       kind: "shadow",
     },
     {
       ...common,
-      evidence_digest: digest(JSON.stringify({
+      evidence_digest: canonicalDigest({
         candidate_evaluation_receipt_digest: input.candidate.receipt.receipt_digest,
         candidate_head_digest: input.candidate.receipt.evaluated_head_digest,
         decision,
         baseline_evaluation_receipt_digest: input.baseline.receipt.receipt_digest,
         baseline_head_digest: input.baseline.receipt.evaluated_head_digest,
-      })),
+      }),
       evidence_ref: input.promotion_evidence_ref,
       kind: "promotion",
     },
@@ -804,7 +872,7 @@ function outcomeEvidenceRecords(
 }
 
 function outcomePartition(
-  input: ImprovementOutcomeEvidenceInput,
+  input: ResolvedImprovementOutcomeEvidence,
   partition: "held_out" | "shadow",
 ): {
   baseline: AssistantTurnEvaluationV1[];
@@ -849,6 +917,14 @@ function isBoundEvidenceSnapshot(
 ): snapshot is ImprovementEvidenceSnapshot {
   if (
     snapshot === undefined ||
+    !isExactDataRecord(snapshot, [
+      "author_generation",
+      "bundle_digest",
+      "bundle_ref",
+      "candidate_id",
+      "states",
+    ]) ||
+    !isDenseDataArray(snapshot.states) ||
     snapshot.candidate_id !== candidate.candidate_id ||
     snapshot.author_generation !== candidate.author_generation ||
     !/^sha256:[a-f0-9]{64}$/.test(snapshot.bundle_digest) ||
@@ -858,9 +934,37 @@ function isBoundEvidenceSnapshot(
 
   const kinds = new Set<string>();
   for (const state of snapshot.states) {
+    if (state === null || typeof state !== "object") return false;
+    const stateDescriptor = Object.getOwnPropertyDescriptor(state, "state");
+    if (stateDescriptor === undefined || !("value" in stateDescriptor)) return false;
+    const stateValue = stateDescriptor.value;
+    const expectedKeys = stateValue === "fresh"
+      ? [
+          "author_generation",
+          "candidate_id",
+          "evidence_digest",
+          "evidence_ref",
+          "head_digest",
+          "kind",
+          "schema_version",
+          "state",
+          "updated_at",
+        ]
+      : stateValue === "invalidated" ? [
+          "author_generation",
+          "candidate_id",
+          "kind",
+          "schema_version",
+          "state",
+          "updated_at",
+        ] : undefined;
     if (
+      expectedKeys === undefined ||
+      !isExactDataRecord(state, expectedKeys) ||
       state.candidate_id !== candidate.candidate_id ||
       state.author_generation !== candidate.author_generation ||
+      state.schema_version !== "improvement-evidence-state/v1" ||
+      !isCanonicalTimestamp(state.updated_at) ||
       !IMPROVEMENT_EVIDENCE_KINDS.includes(state.kind) ||
       (state.state !== "fresh" && state.state !== "invalidated") ||
       kinds.has(state.kind)
@@ -869,7 +973,11 @@ function isBoundEvidenceSnapshot(
       state.state === "fresh" &&
       (state.head_digest !== candidate.head_digest ||
         state.evidence_digest === undefined ||
-        state.evidence_ref === undefined)
+        !/^sha256:[a-f0-9]{64}$/.test(state.evidence_digest) ||
+        state.evidence_ref === undefined ||
+        !/^[a-z][a-z0-9+.-]*:\/\/[a-z0-9][a-z0-9._-]{0,127}$/.test(
+          state.evidence_ref,
+        ))
     ) return false;
     if (
       state.state === "invalidated" &&
@@ -944,4 +1052,203 @@ function assertSafeRef(value: string, field: string): void {
 
 function digest(value: string): string {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function evidencePayloadFingerprint(input: Pick<
+  ImprovementEvidenceRecord,
+  | "author_generation"
+  | "candidate_id"
+  | "evidence_digest"
+  | "evidence_ref"
+  | "head_digest"
+  | "kind"
+>): string {
+  return digest(JSON.stringify([
+    "improvement-evidence-payload/v1",
+    input.candidate_id,
+    input.author_generation,
+    input.kind,
+    input.head_digest,
+    input.evidence_digest,
+    input.evidence_ref,
+  ]));
+}
+
+function validateEvidencePutReceipt(
+  receipt: ImprovementEvidencePutReceiptV1,
+  input: ImprovementEvidenceRecord,
+  payloadFingerprint: string,
+): void {
+  assertExactPlainRecord(receipt, [
+    "author_generation",
+    "candidate_id",
+    "kind",
+    "receipt_digest",
+    "receipt_ref",
+    "requested_payload_fingerprint",
+    "schema_version",
+    "snapshot",
+    "status",
+    "stored_payload_fingerprint",
+  ], "evidence put receipt");
+  if (
+    receipt.schema_version !== "improvement-evidence-put-receipt/v1" ||
+    receipt.candidate_id !== input.candidate_id ||
+    receipt.author_generation !== input.author_generation ||
+    receipt.kind !== input.kind ||
+    receipt.requested_payload_fingerprint !== payloadFingerprint ||
+    !/^sha256:[a-f0-9]{64}$/.test(receipt.stored_payload_fingerprint) ||
+    (receipt.status !== "created" &&
+      receipt.status !== "replayed" &&
+      receipt.status !== "conflict")
+  ) {
+    throw new ImprovementConflictError("The evidence put receipt identity is invalid.");
+  }
+  assertDigest(receipt.receipt_digest, "evidence put receipt");
+  assertSafeRef(receipt.receipt_ref, "evidence put receipt");
+  if (receipt.status === "conflict") {
+    const storedState = findFreshEvidenceState(receipt.snapshot, input.kind);
+    if (
+      receipt.stored_payload_fingerprint === payloadFingerprint ||
+      storedState?.state !== "fresh" ||
+      storedState.head_digest === undefined ||
+      storedState.evidence_digest === undefined ||
+      storedState.evidence_ref === undefined ||
+      !isBoundEvidenceSnapshot(receipt.snapshot, {
+        author_generation: input.author_generation,
+        candidate_id: input.candidate_id,
+        head_digest: storedState.head_digest,
+      }) ||
+      evidencePayloadFingerprint({
+        author_generation: storedState.author_generation,
+        candidate_id: storedState.candidate_id,
+        evidence_digest: storedState.evidence_digest,
+        evidence_ref: storedState.evidence_ref,
+        head_digest: storedState.head_digest,
+        kind: storedState.kind,
+      }) !== receipt.stored_payload_fingerprint
+    ) {
+      throw new ImprovementConflictError(
+        "The evidence conflict receipt does not prove the immutable stored payload.",
+      );
+    }
+    return;
+  }
+  if (
+    receipt.stored_payload_fingerprint !== payloadFingerprint ||
+    !isBoundEvidenceSnapshot(receipt.snapshot, input) ||
+    !snapshotContainsEvidence(receipt.snapshot, input)
+  ) {
+    throw new ImprovementConflictError(
+      "The evidence put receipt does not prove the exact stored payload.",
+    );
+  }
+}
+
+function findFreshEvidenceState(
+  snapshot: ImprovementEvidenceSnapshot,
+  kind: ImprovementEvidenceRecord["kind"],
+): ImprovementEvidenceSnapshot["states"][number] | undefined {
+  if (
+    !isExactDataRecord(snapshot, [
+      "author_generation",
+      "bundle_digest",
+      "bundle_ref",
+      "candidate_id",
+      "states",
+    ]) ||
+    !isDenseDataArray(snapshot.states)
+  ) return undefined;
+  for (const state of snapshot.states) {
+    if (state === null || typeof state !== "object") return undefined;
+    const kindDescriptor = Object.getOwnPropertyDescriptor(state, "kind");
+    const stateDescriptor = Object.getOwnPropertyDescriptor(state, "state");
+    if (
+      kindDescriptor === undefined || !("value" in kindDescriptor) ||
+      stateDescriptor === undefined || !("value" in stateDescriptor)
+    ) return undefined;
+    if (kindDescriptor.value === kind && stateDescriptor.value === "fresh") return state;
+  }
+  return undefined;
+}
+
+function assertExactPlainRecord(
+  value: unknown,
+  expectedKeys: readonly string[],
+  label: string,
+): asserts value is Record<string, unknown> {
+  if (!isExactDataRecord(value, expectedKeys)) {
+    throw new ImprovementInputError(
+      `The ${label} must contain exactly the supported plain-data fields.`,
+    );
+  }
+}
+
+function isExactDataRecord(
+  value: unknown,
+  expectedKeys: readonly string[],
+): value is Record<string, unknown> {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) return false;
+  const keys = Reflect.ownKeys(value);
+  if (
+    keys.length !== expectedKeys.length ||
+    keys.some((key) => typeof key !== "string" || !expectedKeys.includes(key))
+  ) return false;
+  return (keys as string[]).every((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor !== undefined && "value" in descriptor && descriptor.enumerable &&
+      descriptor.value !== undefined;
+  });
+}
+
+function isDenseDataArray(value: unknown): value is readonly unknown[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    return false;
+  }
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== value.length + 1) return false;
+  return keys.every((key) => {
+    if (key === "length") return true;
+    if (typeof key !== "string" || !/^(0|[1-9][0-9]*)$/.test(key)) return false;
+    const index = Number(key);
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return index < value.length && descriptor !== undefined &&
+      "value" in descriptor && descriptor.enumerable;
+  });
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === value;
+}
+
+function canonicalDigest(value: unknown): string {
+  return digest(canonicalStringify(value));
+}
+
+function canonicalStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    const items: string[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      items.push(canonicalStringify(value[index]));
+    }
+    return `[${items.join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((key) => (
+      `${JSON.stringify(key)}:${canonicalStringify((value as Record<string, unknown>)[key])}`
+    )).join(",")}}`;
+  }
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new ImprovementInputError("Outcome evidence contains a non-canonical value.");
+  }
+  return serialized;
 }

--- a/apps/slack-companion/src/improvement/evaluation-set-receipt.ts
+++ b/apps/slack-companion/src/improvement/evaluation-set-receipt.ts
@@ -1,5 +1,9 @@
 import { createHash } from "node:crypto";
-import type { AssistantTurnEvaluationV1 } from "../assistant-turn/evaluation.js";
+import {
+  ASSISTANT_TURN_EVALUATION_BLOCKERS,
+  type AssistantTurnEvaluationDimensionsV1,
+  type AssistantTurnEvaluationV1,
+} from "../assistant-turn/evaluation.js";
 import type {
   ImprovementOutcomeEvaluationSetReceiptV1,
   ImprovementOutcomeEvaluationSetV1,
@@ -7,69 +11,84 @@ import type {
 
 const EVALUATION_SET_RECEIPT_SCHEMA =
   "improvement-outcome-evaluation-set-receipt/v1" as const;
+const MAXIMUM_EVALUATIONS = 512;
+const MAXIMUM_OBJECT_FIELDS = 64;
+const MAXIMUM_PLAIN_DATA_DEPTH = 8;
+const MAXIMUM_PLAIN_DATA_NODES = 50_000;
+const MAXIMUM_REFERENCE_BYTES = 2_048;
 const SHA256_DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const OPAQUE_REFERENCE_PATTERN = /^[a-z][a-z0-9+.-]*:\/\/[a-z0-9][a-z0-9._/-]{0,2047}$/;
+
+const EVALUATION_KEYS = [
+  "blockers",
+  "case_digest",
+  "case_ref",
+  "dimensions",
+  "evaluator_ref",
+  "observation_digest",
+  "observation_ref",
+  "partition",
+  "passed",
+  "policy_ref",
+  "schema_version",
+  "score",
+] as const;
+const DIMENSION_KEYS = [
+  "coverage_honesty",
+  "delivery_completeness",
+  "evidence_use",
+  "execution_efficiency",
+  "grounding",
+  "human_burden",
+  "intervention_fit",
+  "latency_budget",
+  "outcome_closure",
+] as const satisfies readonly (keyof AssistantTurnEvaluationDimensionsV1)[];
+const RECEIPT_KEYS = [
+  "evaluated_head_digest",
+  "evaluator_ref",
+  "ordered_row_digests",
+  "receipt_digest",
+  "schema_version",
+] as const;
 
 export class ImprovementEvaluationSetReceiptError extends Error {}
 
-/** Seal an evaluator's exact ordered rows to the source head that produced them. */
-export function sealImprovementOutcomeEvaluationSet(
-  evaluatedHeadDigest: string,
-  evaluations: readonly AssistantTurnEvaluationV1[],
-): ImprovementOutcomeEvaluationSetV1 {
-  if (!SHA256_DIGEST_PATTERN.test(evaluatedHeadDigest)) {
-    throw new ImprovementEvaluationSetReceiptError(
-      "The evaluated head must be a sha256 digest.",
-    );
-  }
-  const evaluatorRef = evaluations[0]?.evaluator_ref;
-  if (evaluatorRef === undefined || !evaluatorRef.trim()) {
-    throw new ImprovementEvaluationSetReceiptError(
-      "The evaluation set requires an evaluator identity.",
-    );
-  }
-  if (evaluations.some((evaluation) => evaluation.evaluator_ref !== evaluatorRef)) {
-    throw new ImprovementEvaluationSetReceiptError(
-      "The evaluation set must use one evaluator identity.",
-    );
-  }
-  const orderedRowDigests = evaluations.map(evaluationRowDigest);
-  const receiptContent = {
-    evaluated_head_digest: evaluatedHeadDigest,
-    evaluator_ref: evaluatorRef,
-    ordered_row_digests: orderedRowDigests,
-    schema_version: EVALUATION_SET_RECEIPT_SCHEMA,
-  };
-  return {
-    evaluations: structuredClone(evaluations),
-    receipt: {
-      ...receiptContent,
-      receipt_digest: evaluationSetReceiptDigest(receiptContent),
-    },
-  };
-}
-
-/** Verify the seal without accepting any unsealed outer head or evaluator label. */
+/** Validate evaluator-owned rows before trusting their receipt integrity. */
 export function validateImprovementOutcomeEvaluationSet(
   value: ImprovementOutcomeEvaluationSetV1,
 ): void {
+  assertStrictPlainData(
+    value,
+    "evaluation set",
+    new WeakSet<object>(),
+    0,
+    { remaining: MAXIMUM_PLAIN_DATA_NODES },
+  );
+  assertExactKeys(value, ["evaluations", "receipt"], "evaluation set");
+  assertDenseArray(value.evaluations, "evaluation rows", 1, MAXIMUM_EVALUATIONS);
+  assertExactKeys(value.receipt, RECEIPT_KEYS, "evaluation receipt");
+
   const receipt = value.receipt;
-  if (
-    receipt.schema_version !== EVALUATION_SET_RECEIPT_SCHEMA ||
-    !SHA256_DIGEST_PATTERN.test(receipt.evaluated_head_digest) ||
-    !receipt.evaluator_ref.trim() ||
-    receipt.ordered_row_digests.length !== value.evaluations.length ||
-    receipt.ordered_row_digests.some((rowDigest) => !SHA256_DIGEST_PATTERN.test(rowDigest))
-  ) {
+  assertDigest(receipt.evaluated_head_digest, "evaluated head");
+  assertOpaqueReference(receipt.evaluator_ref, "evaluator");
+  if (receipt.schema_version !== EVALUATION_SET_RECEIPT_SCHEMA) {
     throw new ImprovementEvaluationSetReceiptError(
-      "The evaluation set receipt fields are invalid.",
+      "The evaluation set receipt version is unsupported.",
     );
   }
+  assertDenseArray(
+    receipt.ordered_row_digests,
+    "ordered row digests",
+    value.evaluations.length,
+    value.evaluations.length,
+  );
+  for (const rowDigest of receipt.ordered_row_digests) {
+    assertDigest(rowDigest, "evaluation row");
+  }
+
   const orderedRowDigests = value.evaluations.map((evaluation) => {
-    if (evaluation.evaluator_ref !== receipt.evaluator_ref) {
-      throw new ImprovementEvaluationSetReceiptError(
-        "The evaluation set receipt evaluator identity changed.",
-      );
-    }
+    validateEvaluation(evaluation, receipt.evaluator_ref);
     return evaluationRowDigest(evaluation);
   });
   if (
@@ -82,18 +101,68 @@ export function validateImprovementOutcomeEvaluationSet(
     );
   }
   const { receipt_digest: receiptDigest, ...receiptContent } = receipt;
-  if (
-    !SHA256_DIGEST_PATTERN.test(receiptDigest) ||
-    receiptDigest !== evaluationSetReceiptDigest(receiptContent)
-  ) {
+  assertDigest(receiptDigest, "evaluation receipt");
+  if (receiptDigest !== evaluationSetReceiptDigest(receiptContent)) {
     throw new ImprovementEvaluationSetReceiptError(
       "The evaluation set receipt integrity is invalid.",
     );
   }
 }
 
+function validateEvaluation(
+  evaluation: AssistantTurnEvaluationV1,
+  evaluatorRef: string,
+): void {
+  assertExactKeys(evaluation, EVALUATION_KEYS, "evaluation row");
+  assertDenseArray(
+    evaluation.blockers,
+    "evaluation blockers",
+    0,
+    ASSISTANT_TURN_EVALUATION_BLOCKERS.length,
+  );
+  if (
+    new Set(evaluation.blockers).size !== evaluation.blockers.length ||
+    evaluation.blockers.some(
+      (blocker) => !ASSISTANT_TURN_EVALUATION_BLOCKERS.includes(blocker),
+    )
+  ) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation blockers must be distinct supported values.",
+    );
+  }
+  assertDigest(evaluation.case_digest, "case");
+  assertOpaqueReference(evaluation.case_ref, "case");
+  assertExactKeys(evaluation.dimensions, DIMENSION_KEYS, "evaluation dimensions");
+  for (const key of DIMENSION_KEYS) assertUnitInterval(evaluation.dimensions[key], key);
+  if (evaluation.evaluator_ref !== evaluatorRef) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation set receipt evaluator identity changed.",
+    );
+  }
+  assertOpaqueReference(evaluation.evaluator_ref, "evaluator");
+  assertDigest(evaluation.observation_digest, "observation");
+  assertOpaqueReference(evaluation.observation_ref, "observation");
+  if (evaluation.partition !== "held_out" && evaluation.partition !== "shadow") {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation partition is unsupported for promotion.",
+    );
+  }
+  if (typeof evaluation.passed !== "boolean") {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation pass state must be boolean.",
+    );
+  }
+  assertOpaqueReference(evaluation.policy_ref, "policy");
+  if (evaluation.schema_version !== "assistant-turn-evaluation/v1") {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation row version is unsupported.",
+    );
+  }
+  assertUnitInterval(evaluation.score, "score");
+}
+
 function evaluationRowDigest(evaluation: AssistantTurnEvaluationV1): string {
-  return sha256(stableStringify(evaluation));
+  return sha256(canonicalStringify(evaluation));
 }
 
 function evaluationSetReceiptDigest(
@@ -107,20 +176,177 @@ function evaluationSetReceiptDigest(
   ]));
 }
 
-function sha256(value: string): string {
-  return `sha256:${createHash("sha256").update(value, "utf8").digest("hex")}`;
+function assertStrictPlainData(
+  value: unknown,
+  label: string,
+  ancestors: WeakSet<object>,
+  depth: number,
+  budget: { remaining: number },
+): void {
+  budget.remaining -= 1;
+  if (depth > MAXIMUM_PLAIN_DATA_DEPTH || budget.remaining < 0) {
+    throw new ImprovementEvaluationSetReceiptError(
+      `The ${label} exceeds the plain-data complexity bound.`,
+    );
+  }
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new ImprovementEvaluationSetReceiptError(
+        `The ${label} contains a non-finite number.`,
+      );
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new ImprovementEvaluationSetReceiptError(
+      `The ${label} contains a non-data value.`,
+    );
+  }
+  if (ancestors.has(value)) {
+    throw new ImprovementEvaluationSetReceiptError(`The ${label} contains a cycle.`);
+  }
+  ancestors.add(value);
+  if (Array.isArray(value)) {
+    assertDenseArray(value, label, 0, MAXIMUM_EVALUATIONS);
+    for (let index = 0; index < value.length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      if (descriptor === undefined || !("value" in descriptor) || !descriptor.enumerable) {
+        throw new ImprovementEvaluationSetReceiptError(
+          `The ${label} contains an accessor or hidden array value.`,
+        );
+      }
+      assertStrictPlainData(descriptor.value, label, ancestors, depth + 1, budget);
+    }
+  } else {
+    if (Object.getPrototypeOf(value) !== Object.prototype) {
+      throw new ImprovementEvaluationSetReceiptError(
+        `The ${label} contains a non-plain object.`,
+      );
+    }
+    const keys = Reflect.ownKeys(value);
+    if (keys.length > MAXIMUM_OBJECT_FIELDS || keys.some((key) => typeof key !== "string")) {
+      throw new ImprovementEvaluationSetReceiptError(
+        `The ${label} object fields are invalid or unbounded.`,
+      );
+    }
+    for (const key of keys as string[]) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor === undefined || !("value" in descriptor) || !descriptor.enumerable) {
+        throw new ImprovementEvaluationSetReceiptError(
+          `The ${label} contains an accessor or hidden field.`,
+        );
+      }
+      if (descriptor.value === undefined) {
+        throw new ImprovementEvaluationSetReceiptError(
+          `The ${label} contains an undefined field.`,
+        );
+      }
+      assertStrictPlainData(descriptor.value, label, ancestors, depth + 1, budget);
+    }
+  }
+  ancestors.delete(value);
 }
 
-function stableStringify(value: unknown): string {
+function assertExactKeys(
+  value: object,
+  expected: readonly string[],
+  label: string,
+): void {
+  const keys = Reflect.ownKeys(value);
+  if (
+    keys.length !== expected.length ||
+    keys.some((key) => typeof key !== "string" || !expected.includes(key))
+  ) {
+    throw new ImprovementEvaluationSetReceiptError(
+      `The ${label} must contain exactly the supported fields.`,
+    );
+  }
+}
+
+function assertDenseArray(
+  value: readonly unknown[],
+  label: string,
+  minimum: number,
+  maximum: number,
+): void {
+  if (
+    Object.getPrototypeOf(value) !== Array.prototype ||
+    !Number.isSafeInteger(value.length) ||
+    value.length < minimum ||
+    value.length > maximum
+  ) {
+    throw new ImprovementEvaluationSetReceiptError(`The ${label} is invalid or unbounded.`);
+  }
+  const keys = Reflect.ownKeys(value);
+  if (
+    keys.length !== value.length + 1 ||
+    keys.some((key) => (
+      typeof key !== "string" ||
+      (key !== "length" && (!/^(0|[1-9][0-9]*)$/.test(key) || Number(key) >= value.length))
+    ))
+  ) {
+    throw new ImprovementEvaluationSetReceiptError(
+      `The ${label} must be a dense array without extra fields.`,
+    );
+  }
+}
+
+function assertDigest(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !SHA256_DIGEST_PATTERN.test(value)) {
+    throw new ImprovementEvaluationSetReceiptError(
+      `The ${label} digest must use sha256.`,
+    );
+  }
+}
+
+function assertOpaqueReference(value: unknown, label: string): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    Buffer.byteLength(value, "utf8") > MAXIMUM_REFERENCE_BYTES ||
+    !OPAQUE_REFERENCE_PATTERN.test(value)
+  ) {
+    throw new ImprovementEvaluationSetReceiptError(
+      `The ${label} reference must be opaque and bounded.`,
+    );
+  }
+}
+
+function assertUnitInterval(value: unknown, label: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new ImprovementEvaluationSetReceiptError(
+      `The evaluation ${label} must be between zero and one.`,
+    );
+  }
+}
+
+function canonicalStringify(value: unknown): string {
   if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
+    const rows: string[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      rows.push(canonicalStringify(value[index]));
+    }
+    return `[${rows.join(",")}]`;
   }
   if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value as Record<string, unknown>)
-      .filter(([, nested]) => nested !== undefined)
-      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-      .map(([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`)
-      .join(",")}}`;
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((key) => (
+      `${JSON.stringify(key)}:${canonicalStringify((value as Record<string, unknown>)[key])}`
+    )).join(",")}}`;
   }
-  return JSON.stringify(value) ?? "null";
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new ImprovementEvaluationSetReceiptError(
+      "The evaluation set contains a non-canonical value.",
+    );
+  }
+  return serialized;
+}
+
+function sha256(value: string): string {
+  return `sha256:${createHash("sha256").update(value, "utf8").digest("hex")}`;
 }

--- a/apps/slack-companion/src/improvement/ports.ts
+++ b/apps/slack-companion/src/improvement/ports.ts
@@ -14,8 +14,11 @@ import type {
   ImprovementEvidenceCompletion,
   ImprovementEvidenceInvalidationReceipt,
   ImprovementEvidenceInvalidationRequest,
-  ImprovementEvidenceRecord,
+  ImprovementEvidencePutCommit,
+  ImprovementEvidencePutReceiptV1,
   ImprovementEvidenceSnapshot,
+  ImprovementOutcomeEvaluationReceiptReferenceV1,
+  ImprovementOutcomeEvaluationSetV1,
 } from "./contracts.js";
 
 export interface ImprovementClockPort {
@@ -70,12 +73,18 @@ export interface ImprovementVerificationPort {
   ): Promise<ImprovementAuthorVerification>;
 }
 
+/** Resolves evaluator-owned receipts from a trusted portable adapter. */
+export interface ImprovementOutcomeEvaluatorPort {
+  resolve(
+    reference: ImprovementOutcomeEvaluationReceiptReferenceV1,
+  ): Promise<ImprovementOutcomeEvaluationSetV1 | undefined>;
+}
+
 /**
  * Evidence remains invalidated until every required exact-head receipt is fresh.
- * `recordFresh` uses the immutable `(candidate_id, author_generation, kind)` tuple
- * as its identity. An exact replay must return the stored snapshot. A replay that
- * changes the head, evidence digest, or evidence reference must reject as a
- * conflict instead of replacing the stored receipt.
+ * `putFreshIfAbsent` uses the immutable `(candidate_id, author_generation, kind)`
+ * tuple as its identity. Its durable receipt distinguishes a create, an exact
+ * replay, and a conflicting payload without replacing the stored evidence.
  */
 export interface ImprovementEvidencePort {
   invalidate(
@@ -86,5 +95,7 @@ export interface ImprovementEvidencePort {
     candidateId: string,
     authorGeneration: number,
   ): Promise<ImprovementEvidenceSnapshot | undefined>;
-  recordFresh(input: ImprovementEvidenceRecord): Promise<ImprovementEvidenceSnapshot>;
+  putFreshIfAbsent(
+    commit: ImprovementEvidencePutCommit,
+  ): Promise<ImprovementEvidencePutReceiptV1>;
 }

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -58,7 +58,6 @@ export type {
 export * from "./installation.js";
 export * from "./improvement/contracts.js";
 export * from "./improvement/coordinator.js";
-export * from "./improvement/evaluation-set-receipt.js";
 export * from "./improvement/ports.js";
 export * from "./history/contracts.js";
 export * from "./history/message-policy.js";

--- a/apps/slack-companion/test/improvement.test.ts
+++ b/apps/slack-companion/test/improvement.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { describe, test } from "node:test";
+import * as publicApi from "../src/index.js";
 import type { RunReceiptV1, WorkLeaseV1 } from "@writer/cerebro-sdk";
 import { ExecutionCoordinator } from "../src/execution/coordinator.js";
 import type { ExecutionSession } from "../src/execution/model.js";
@@ -31,20 +32,23 @@ import type {
   ImprovementDraftSnapshot,
   ImprovementEvidenceCompletion,
   ImprovementEvidenceInvalidationRequest,
+  ImprovementEvidencePutCommit,
+  ImprovementEvidencePutReceiptV1,
   ImprovementEvidenceRecord,
   ImprovementEvidenceSnapshot,
   ImprovementEvidenceStateV1,
   ImprovementFreshEvidenceInput,
+  ImprovementOutcomeEvaluationReceiptReferenceV1,
+  ImprovementOutcomeEvaluationSetReceiptV1,
+  ImprovementOutcomeEvaluationSetV1,
   ImprovementOutcomeEvidenceInput,
 } from "../src/improvement/contracts.js";
 import { IMPROVEMENT_EVIDENCE_KINDS } from "../src/improvement/contracts.js";
-import {
-  sealImprovementOutcomeEvaluationSet,
-} from "../src/improvement/evaluation-set-receipt.js";
 import type {
   DurableImprovementCandidatePort,
   ImprovementAuthorPort,
   ImprovementEvidencePort,
+  ImprovementOutcomeEvaluatorPort,
   ImprovementVerificationPort,
 } from "../src/improvement/ports.js";
 
@@ -234,7 +238,7 @@ describe("ImprovementCoordinator", () => {
     assert.equal(current.status, "awaiting_evidence");
 
     const outcome = await fixture.coordinator.recordOutcomeEvidence(
-      outcomeEvidence(current),
+      fixture.outcomeEvidence(current),
     );
     current = outcome.candidate;
     assert.equal(outcome.decision.promotion_ready, true);
@@ -256,7 +260,7 @@ describe("ImprovementCoordinator", () => {
     );
 
     const outcome = await fixture.coordinator.recordOutcomeEvidence(
-      outcomeEvidence(authored.candidate, {
+      fixture.outcomeEvidence(authored.candidate, {
         candidate_score: 0.71,
         candidate_blockers: ["outcome_unknown"],
       }),
@@ -281,7 +285,7 @@ describe("ImprovementCoordinator", () => {
 
     await assert.rejects(
       fixture.coordinator.recordOutcomeEvidence(
-        outcomeEvidence(authored.candidate, {
+        fixture.outcomeEvidence(authored.candidate, {
           baseline_head_digest: sha("wrong-baseline-head"),
         }),
       ),
@@ -289,26 +293,52 @@ describe("ImprovementCoordinator", () => {
     );
     await assert.rejects(
       fixture.coordinator.recordOutcomeEvidence(
-        outcomeEvidence(authored.candidate, {
+        fixture.outcomeEvidence(authored.candidate, {
           candidate_head_digest: sha("wrong-candidate-head"),
         }),
       ),
       /does not match the baseline and candidate heads/,
     );
 
-    const oversized = outcomeEvidence(authored.candidate);
-    oversized.candidate = {
-      ...oversized.candidate,
-      evaluations: Array.from(
-        { length: 513 },
-        (_, index) => oversized.candidate.evaluations[
-          index % oversized.candidate.evaluations.length
-        ]!,
-      ),
-    };
+    const oversized = fixture.outcomeEvidence(authored.candidate, {
+      candidate_evaluation_count: 513,
+    });
     await assert.rejects(
       fixture.coordinator.recordOutcomeEvidence(oversized),
-      /evaluations are required and bounded/,
+      /evaluation set is invalid or unbounded/,
+    );
+  });
+
+  test("resolves opaque evaluator receipts without exposing caller sealing authority", async () => {
+    const fixture = makeFixture();
+    const candidate = (await fixture.coordinator.register(candidateInput())).candidate;
+    const session = await fixture.session(1);
+    const authored = await fixture.coordinator.authorCandidate(
+      authorRequest(candidate, session),
+    );
+    const valid = fixture.outcomeEvidence(authored.candidate);
+
+    assert.equal("sealImprovementOutcomeEvaluationSet" in publicApi, false);
+
+    await assert.rejects(
+      fixture.coordinator.recordOutcomeEvidence({
+        ...valid,
+        candidate_evaluation_receipt: {
+          receipt_digest: sha("caller-minted"),
+          receipt_ref: "evaluation-receipt://caller-minted",
+        },
+      }),
+      /trusted evaluator receipt is unavailable/,
+    );
+    await assert.rejects(
+      fixture.coordinator.recordOutcomeEvidence({
+        ...valid,
+        candidate_evaluation_receipt: {
+          ...valid.candidate_evaluation_receipt,
+          receipt_digest: sha("forged-digest"),
+        },
+      }),
+      /trusted evaluator receipt digest does not match/,
     );
   });
 
@@ -320,54 +350,78 @@ describe("ImprovementCoordinator", () => {
       authorRequest(candidate, session),
     );
 
-    const relabeled = outcomeEvidence(authored.candidate);
-    relabeled.candidate = {
-      ...relabeled.candidate,
-      receipt: {
-        ...relabeled.candidate.receipt,
-        evaluated_head_digest: sha("relabeled-head"),
-      },
-    };
+    const relabeled = fixture.outcomeEvidence(authored.candidate);
+    fixture.evaluator.corrupt(
+      relabeled.candidate_evaluation_receipt.receipt_ref,
+      "relabeled_head",
+    );
     await assert.rejects(
       fixture.coordinator.recordOutcomeEvidence(relabeled),
       /receipt integrity is invalid/,
     );
 
-    const reordered = outcomeEvidence(authored.candidate);
-    reordered.candidate = {
-      ...reordered.candidate,
-      evaluations: reordered.candidate.evaluations.slice().reverse(),
-    };
+    const reordered = fixture.outcomeEvidence(authored.candidate);
+    fixture.evaluator.corrupt(
+      reordered.candidate_evaluation_receipt.receipt_ref,
+      "reordered_rows",
+    );
     await assert.rejects(
       fixture.coordinator.recordOutcomeEvidence(reordered),
       /receipt rows changed/,
     );
 
-    const rowTampered = outcomeEvidence(authored.candidate);
-    rowTampered.candidate = {
-      ...rowTampered.candidate,
-      evaluations: rowTampered.candidate.evaluations.map((evaluation, index) =>
-        index === 0
-          ? { ...evaluation, observation_digest: sha("changed-observation") }
-          : evaluation),
-    };
+    const rowTampered = fixture.outcomeEvidence(authored.candidate);
+    fixture.evaluator.corrupt(
+      rowTampered.candidate_evaluation_receipt.receipt_ref,
+      "row_digest",
+    );
     await assert.rejects(
       fixture.coordinator.recordOutcomeEvidence(rowTampered),
       /receipt rows changed/,
     );
 
-    const evaluatorTampered = outcomeEvidence(authored.candidate);
-    evaluatorTampered.candidate = {
-      ...evaluatorTampered.candidate,
-      evaluations: evaluatorTampered.candidate.evaluations.map((evaluation, index) =>
-        index === 0
-          ? { ...evaluation, evaluator_ref: "evaluation://changed-evaluator" }
-          : evaluation),
-    };
+    const evaluatorTampered = fixture.outcomeEvidence(authored.candidate);
+    fixture.evaluator.corrupt(
+      evaluatorTampered.candidate_evaluation_receipt.receipt_ref,
+      "evaluator_ref",
+    );
     await assert.rejects(
       fixture.coordinator.recordOutcomeEvidence(evaluatorTampered),
       /receipt evaluator identity changed/,
     );
+  });
+
+  test("rejects non-canonical evaluator rows before receipt hashing", async () => {
+    const fixture = makeFixture();
+    const candidate = (await fixture.coordinator.register(candidateInput())).candidate;
+    const session = await fixture.session(1);
+    const authored = await fixture.coordinator.authorCandidate(
+      authorRequest(candidate, session),
+    );
+    const corruptions = [
+      "sparse_blockers",
+      "sparse_rows",
+      "accessor",
+      "custom_prototype",
+      "unknown_key",
+      "excessive_depth",
+      "undefined_value",
+      "non_finite",
+      "cycle",
+    ] as const;
+
+    for (const corruption of corruptions) {
+      const input = fixture.outcomeEvidence(authored.candidate);
+      fixture.evaluator.corrupt(
+        input.candidate_evaluation_receipt.receipt_ref,
+        corruption,
+      );
+      await assert.rejects(
+        fixture.coordinator.recordOutcomeEvidence(input),
+        ImprovementInputError,
+        corruption,
+      );
+    }
   });
 
   test("recovers idempotently when outcome evidence persists before a response failure", async () => {
@@ -382,12 +436,12 @@ describe("ImprovementCoordinator", () => {
     fixture.evidence.failNextFreshResponse();
 
     await assert.rejects(
-      fixture.coordinator.recordOutcomeEvidence(outcomeEvidence(current)),
+      fixture.coordinator.recordOutcomeEvidence(fixture.outcomeEvidence(current)),
       /injected fresh evidence response failure/,
     );
 
     const recovered = await fixture.coordinator.recordOutcomeEvidence(
-      outcomeEvidence(current),
+      fixture.outcomeEvidence(current),
     );
     assert.equal(recovered.candidate.status, "ready");
     assert.equal(recovered.decision.promotion_ready, true);
@@ -403,7 +457,7 @@ describe("ImprovementCoordinator", () => {
     current = await fixture.coordinator.recordFreshEvidence(freshEvidence(current, "ci"));
     current = await fixture.coordinator.recordFreshEvidence(freshEvidence(current, "canary"));
     fixture.candidates.failNextReadyResponse = true;
-    const request = outcomeEvidence(current);
+    const request = fixture.outcomeEvidence(current);
 
     await assert.rejects(
       fixture.coordinator.recordOutcomeEvidence(request),
@@ -418,7 +472,7 @@ describe("ImprovementCoordinator", () => {
     assert.equal(fixture.candidates.markEvidenceReadyCalls, 1);
   });
 
-  test("replays one immutable evidence identity exactly and rejects conflicting content", async () => {
+  test("evidence port conformance creates, replays, and reports immutable conflicts", async () => {
     const fixture = makeFixture();
     const candidate = (await fixture.coordinator.register(candidateInput())).candidate;
     const session = await fixture.session(1);
@@ -427,28 +481,51 @@ describe("ImprovementCoordinator", () => {
     )).candidate;
     const input = freshEvidence(authored, "ci");
 
-    const first = await fixture.evidence.recordFresh(input);
-    const replay = await fixture.evidence.recordFresh(input);
-    assert.deepEqual(replay, first);
+    const first = await fixture.evidence.putFreshIfAbsent(evidenceCommit(input));
+    const replay = await fixture.evidence.putFreshIfAbsent(evidenceCommit(input));
+    assert.equal(first.status, "created");
+    assert.equal(replay.status, "replayed");
+    assert.equal(replay.stored_payload_fingerprint, first.stored_payload_fingerprint);
+    assert.deepEqual(replay.snapshot, first.snapshot);
 
     for (const conflict of [
       { evidence_digest: sha("changed-evidence") },
       { evidence_ref: "evidence://changed-ref" },
       { head_digest: sha("changed-head") },
     ]) {
-      await assert.rejects(
-        async () => fixture.evidence.recordFresh({ ...input, ...conflict }),
-        /Fresh evidence changed/,
+      const changed = { ...input, ...conflict };
+      const result = await fixture.evidence.putFreshIfAbsent(
+        evidenceCommit(changed),
       );
+      assert.equal(result.status, "conflict");
+      assert.notEqual(
+        result.requested_payload_fingerprint,
+        result.stored_payload_fingerprint,
+      );
+      assert.deepEqual(result.snapshot, first.snapshot);
     }
     assert.deepEqual(
       await fixture.evidence.read(input.candidate_id, input.author_generation),
-      first,
+      first.snapshot,
+    );
+    await assert.rejects(
+      fixture.coordinator.recordFreshEvidence({
+        ...input,
+        evidence_digest: sha("coordinator-conflict"),
+      }),
+      /conflicts with the immutable stored receipt/,
     );
   });
 
-  test("rejects fresh evidence snapshots with changed identity or receipt content", async () => {
-    for (const corruption of ["candidate", "generation", "evidence"] as const) {
+  test("rejects evidence put receipts with changed identity or snapshot content", async () => {
+    for (const corruption of [
+      "candidate",
+      "generation",
+      "evidence",
+      "missing_kind",
+      "duplicate_kind",
+      "invalidated_kind",
+    ] as const) {
       const fixture = makeFixture();
       const candidate = (await fixture.coordinator.register(candidateInput())).candidate;
       const session = await fixture.session(1);
@@ -456,7 +533,7 @@ describe("ImprovementCoordinator", () => {
         authorRequest(candidate, session),
       )).candidate;
       const outcomes = await fixture.coordinator.recordOutcomeEvidence(
-        outcomeEvidence(current),
+        fixture.outcomeEvidence(current),
       );
       current = outcomes.candidate;
       current = await fixture.coordinator.recordFreshEvidence(
@@ -464,11 +541,13 @@ describe("ImprovementCoordinator", () => {
       );
 
       fixture.evidence.corruptNextFreshSnapshot(corruption);
-      const rejected = await fixture.coordinator.recordFreshEvidence(
-        freshEvidence(current, "canary"),
+      await assert.rejects(
+        fixture.coordinator.recordFreshEvidence(
+          freshEvidence(current, "canary"),
+        ),
+        ImprovementConflictError,
+        corruption,
       );
-      assert.equal(rejected.status, "awaiting_evidence", corruption);
-      assert.equal(rejected.fresh_evidence_ref, undefined, corruption);
     }
   });
 });
@@ -484,6 +563,7 @@ function makeFixture() {
   });
   const candidates = new MemoryCandidateStore();
   const evidence = new MemoryEvidencePort(clock, executionStore);
+  const evaluator = new MemoryOutcomeEvaluatorPort();
   const author = new MemoryAuthorPort(evidence);
   const verification = new MemoryVerificationPort(author, clock);
   const coordinator = new ImprovementCoordinator({
@@ -491,6 +571,7 @@ function makeFixture() {
     candidates,
     clock,
     evidence,
+    evaluator,
     execution,
     execution_store: executionStore,
     verification,
@@ -514,8 +595,13 @@ function makeFixture() {
     clock,
     coordinator,
     evidence,
+    evaluator,
     execution,
     executionStore,
+    outcomeEvidence: (
+      candidate: ImprovementCandidateV1,
+      overrides: OutcomeEvidenceOverrides = {},
+    ) => outcomeEvidence(candidate, evaluator, overrides),
     session,
     verification,
   };
@@ -693,12 +779,123 @@ class MemoryCandidateStore implements DurableImprovementCandidatePort {
   }
 }
 
+type EvaluationCorruption =
+  | "accessor"
+  | "custom_prototype"
+  | "cycle"
+  | "evaluator_ref"
+  | "excessive_depth"
+  | "non_finite"
+  | "relabeled_head"
+  | "reordered_rows"
+  | "row_digest"
+  | "sparse_blockers"
+  | "sparse_rows"
+  | "undefined_value"
+  | "unknown_key";
+
+class MemoryOutcomeEvaluatorPort implements ImprovementOutcomeEvaluatorPort {
+  private readonly receipts = new Map<string, ImprovementOutcomeEvaluationSetV1>();
+
+  publish(
+    evaluatedHeadDigest: string,
+    evaluations: readonly AssistantTurnEvaluationV1[],
+  ): ImprovementOutcomeEvaluationReceiptReferenceV1 {
+    const evaluationSet = trustedEvaluationSet(evaluatedHeadDigest, evaluations);
+    const receiptRef = `evaluation-receipt://${
+      evaluationSet.receipt.receipt_digest.slice("sha256:".length, 39)
+    }`;
+    this.receipts.set(receiptRef, evaluationSet);
+    return {
+      receipt_digest: evaluationSet.receipt.receipt_digest,
+      receipt_ref: receiptRef,
+    };
+  }
+
+  resolve(reference: ImprovementOutcomeEvaluationReceiptReferenceV1) {
+    return Promise.resolve(this.receipts.get(reference.receipt_ref));
+  }
+
+  corrupt(receiptRef: string, corruption: EvaluationCorruption): void {
+    const stored = this.receipts.get(receiptRef);
+    if (stored === undefined) assert.fail("expected evaluator receipt");
+    const mutable = stored as unknown as {
+      evaluations: AssistantTurnEvaluationV1[];
+      receipt: ImprovementOutcomeEvaluationSetReceiptV1;
+    };
+    const row = mutable.evaluations[0]!;
+    const rowRecord = row as unknown as Record<string, unknown>;
+    switch (corruption) {
+      case "accessor": {
+        const score = row.score;
+        Object.defineProperty(row, "score", {
+          configurable: true,
+          enumerable: true,
+          get: () => score,
+        });
+        break;
+      }
+      case "custom_prototype":
+        Object.setPrototypeOf(row.dimensions, { forged: true });
+        break;
+      case "cycle":
+        rowRecord.cycle = row;
+        break;
+      case "evaluator_ref":
+        rowRecord.evaluator_ref = "evaluation://changed-evaluator";
+        break;
+      case "excessive_depth": {
+        let nested: Record<string, unknown> = {};
+        rowRecord.unexpected = nested;
+        for (let depth = 0; depth < 12; depth += 1) {
+          const next: Record<string, unknown> = {};
+          nested.value = next;
+          nested = next;
+        }
+        break;
+      }
+      case "non_finite":
+        rowRecord.score = Number.NaN;
+        break;
+      case "relabeled_head":
+        (mutable.receipt as unknown as Record<string, unknown>).evaluated_head_digest =
+          sha("relabeled-head");
+        break;
+      case "reordered_rows":
+        mutable.evaluations.reverse();
+        break;
+      case "row_digest":
+        rowRecord.observation_digest = sha("changed-observation");
+        break;
+      case "sparse_blockers":
+        rowRecord.blockers = new Array(1);
+        break;
+      case "sparse_rows":
+        delete mutable.evaluations[0];
+        break;
+      case "undefined_value":
+        rowRecord.policy_ref = undefined;
+        break;
+      case "unknown_key":
+        rowRecord.unexpected = true;
+        break;
+    }
+  }
+}
+
 class MemoryEvidencePort implements ImprovementEvidencePort {
   readonly bundleRef = "evidence-bundle://opaque-improvement";
   observedIntentFirst = false;
-  private nextFreshCorruption?: "candidate" | "generation" | "evidence";
+  private nextFreshCorruption?:
+    | "candidate"
+    | "duplicate_kind"
+    | "evidence"
+    | "generation"
+    | "invalidated_kind"
+    | "missing_kind";
   private nextFreshResponseFailure = false;
   private nextInvalidationCorruption?: "duplicate" | "missing";
+  private readonly fingerprints = new Map<string, string>();
   private readonly records = new Map<string, ImprovementEvidenceSnapshot>();
 
   constructor(
@@ -710,7 +907,14 @@ class MemoryEvidencePort implements ImprovementEvidencePort {
     return this.records.size;
   }
 
-  corruptNextFreshSnapshot(corruption: "candidate" | "generation" | "evidence"): void {
+  corruptNextFreshSnapshot(corruption:
+    | "candidate"
+    | "duplicate_kind"
+    | "evidence"
+    | "generation"
+    | "invalidated_kind"
+    | "missing_kind"
+  ): void {
     this.nextFreshCorruption = corruption;
   }
 
@@ -776,20 +980,29 @@ class MemoryEvidencePort implements ImprovementEvidencePort {
     return Promise.resolve(snapshot === undefined ? undefined : clone(snapshot));
   }
 
-  recordFresh(input: ImprovementEvidenceRecord) {
+  putFreshIfAbsent(commit: ImprovementEvidencePutCommit) {
+    const input = commit.record;
     const key = evidenceKey(input.candidate_id, input.author_generation);
     const snapshot = this.records.get(key);
     if (snapshot === undefined) return Promise.reject(new ImprovementConflictError("Evidence was not invalidated."));
+    const identity = evidenceItemKey(input);
+    const priorFingerprint = this.fingerprints.get(identity);
+    if (priorFingerprint !== undefined) {
+      const status = priorFingerprint === commit.payload_fingerprint
+        ? "replayed" as const
+        : "conflict" as const;
+      return Promise.resolve(this.putReceipt(
+        commit,
+        status,
+        priorFingerprint,
+        snapshot,
+      ));
+    }
     const states = snapshot.states.map((state) => {
       if (state.kind !== input.kind) return state;
-      if (state.state === "fresh") {
-        if (
-          state.head_digest !== input.head_digest ||
-          state.evidence_digest !== input.evidence_digest ||
-          state.evidence_ref !== input.evidence_ref
-        ) throw new ImprovementConflictError("Fresh evidence changed.");
-        return state;
-      }
+      if (state.state === "fresh") throw new ImprovementConflictError(
+        "Fresh evidence is missing its immutable fingerprint.",
+      );
       return {
         ...state,
         evidence_digest: input.evidence_digest,
@@ -801,33 +1014,91 @@ class MemoryEvidencePort implements ImprovementEvidencePort {
     });
     const next = this.snapshot(input.candidate_id, input.author_generation, states);
     this.records.set(key, next);
+    this.fingerprints.set(identity, commit.payload_fingerprint);
     if (this.nextFreshResponseFailure) {
       this.nextFreshResponseFailure = false;
       return Promise.reject(new Error("injected fresh evidence response failure"));
     }
-    if (this.nextFreshCorruption === undefined) {
-      return Promise.resolve(clone(next));
-    }
-    const corrupted = clone(next);
+    const receipt = this.putReceipt(
+      commit,
+      "created",
+      commit.payload_fingerprint,
+      next,
+    );
+    if (this.nextFreshCorruption === undefined) return Promise.resolve(receipt);
+    const corrupted = clone(receipt);
     if (this.nextFreshCorruption === "candidate") {
-      corrupted.candidate_id = `improvement-${"f".repeat(32)}`;
-      corrupted.states = corrupted.states.map((state) => ({
+      corrupted.snapshot.candidate_id = `improvement-${"f".repeat(32)}`;
+      corrupted.snapshot.states = corrupted.snapshot.states.map((state) => ({
         ...state,
-        candidate_id: corrupted.candidate_id,
+        candidate_id: corrupted.snapshot.candidate_id,
       }));
     } else if (this.nextFreshCorruption === "generation") {
-      corrupted.author_generation += 1;
-      corrupted.states = corrupted.states.map((state) => ({
+      corrupted.snapshot.author_generation += 1;
+      corrupted.snapshot.states = corrupted.snapshot.states.map((state) => ({
         ...state,
-        author_generation: corrupted.author_generation,
+        author_generation: corrupted.snapshot.author_generation,
       }));
-    } else {
-      corrupted.states = corrupted.states.map((state) => state.kind === input.kind
+    } else if (this.nextFreshCorruption === "evidence") {
+      corrupted.snapshot.states = corrupted.snapshot.states.map((state) => state.kind === input.kind
         ? { ...state, evidence_digest: sha("corrupt-evidence") }
         : state);
+    } else if (this.nextFreshCorruption === "missing_kind") {
+      corrupted.snapshot.states = corrupted.snapshot.states.slice(0, -1);
+    } else if (this.nextFreshCorruption === "duplicate_kind") {
+      corrupted.snapshot.states = [
+        ...corrupted.snapshot.states.slice(0, -1),
+        clone(corrupted.snapshot.states[0]!),
+      ];
+    } else {
+      corrupted.snapshot.states = corrupted.snapshot.states.map((state) => (
+        state.kind === input.kind
+          ? {
+              author_generation: state.author_generation,
+              candidate_id: state.candidate_id,
+              kind: state.kind,
+              schema_version: state.schema_version,
+              state: "invalidated" as const,
+              updated_at: state.updated_at,
+            }
+          : state
+      ));
     }
     this.nextFreshCorruption = undefined;
     return Promise.resolve(corrupted);
+  }
+
+  private putReceipt(
+    commit: ImprovementEvidencePutCommit,
+    status: ImprovementEvidencePutReceiptV1["status"],
+    storedPayloadFingerprint: string,
+    snapshot: ImprovementEvidenceSnapshot,
+  ): ImprovementEvidencePutReceiptV1 {
+    const record = commit.record;
+    const receiptRef = `evidence-put-receipt://${sha(JSON.stringify([
+      record.candidate_id,
+      record.author_generation,
+      record.kind,
+      storedPayloadFingerprint,
+    ])).slice("sha256:".length, 39)}`;
+    return {
+      author_generation: record.author_generation,
+      candidate_id: record.candidate_id,
+      kind: record.kind,
+      receipt_digest: sha(JSON.stringify([
+        receiptRef,
+        commit.payload_fingerprint,
+        storedPayloadFingerprint,
+        status,
+        snapshot.bundle_digest,
+      ])),
+      receipt_ref: receiptRef,
+      requested_payload_fingerprint: commit.payload_fingerprint,
+      schema_version: "improvement-evidence-put-receipt/v1",
+      snapshot: clone(snapshot),
+      status,
+      stored_payload_fingerprint: storedPayloadFingerprint,
+    };
   }
 
   private snapshot(
@@ -1044,14 +1315,18 @@ function freshEvidence(
   };
 }
 
+interface OutcomeEvidenceOverrides {
+  baseline_head_digest?: string;
+  candidate_blockers?: AssistantTurnEvaluationBlockerV1[];
+  candidate_evaluation_count?: number;
+  candidate_head_digest?: string;
+  candidate_score?: number;
+}
+
 function outcomeEvidence(
   candidate: ImprovementCandidateV1,
-  overrides: {
-    baseline_head_digest?: string;
-    candidate_blockers?: AssistantTurnEvaluationBlockerV1[];
-    candidate_head_digest?: string;
-    candidate_score?: number;
-  } = {},
+  evaluator: MemoryOutcomeEvaluatorPort,
+  overrides: OutcomeEvidenceOverrides = {},
 ): ImprovementOutcomeEvidenceInput {
   const baselineHead = overrides.baseline_head_digest
     ?? candidate.authoring_prior_head_digest
@@ -1061,18 +1336,31 @@ function outcomeEvidence(
     0.72,
     ["outcome_unknown"],
   );
-  const candidateEvaluations = promotionEvaluations(
+  let candidateEvaluations = promotionEvaluations(
     "policy://candidate",
     overrides.candidate_score ?? 0.94,
     overrides.candidate_blockers ?? [],
   );
+  if (overrides.candidate_evaluation_count !== undefined) {
+    const templates = candidateEvaluations;
+    candidateEvaluations = Array.from(
+      { length: overrides.candidate_evaluation_count },
+      (_, index) => ({
+        ...clone(templates[index % templates.length]!),
+        case_digest: sha(`oversized-case-${index}`),
+        case_ref: `case://oversized-${index}`,
+        observation_digest: sha(`oversized-observation-${index}`),
+        observation_ref: `observation://oversized-${index}`,
+      }),
+    );
+  }
   return {
     author_generation: candidate.author_generation,
-    baseline: sealImprovementOutcomeEvaluationSet(
+    baseline_evaluation_receipt: evaluator.publish(
       baselineHead,
       baselineEvaluations,
     ),
-    candidate: sealImprovementOutcomeEvaluationSet(
+    candidate_evaluation_receipt: evaluator.publish(
       overrides.candidate_head_digest ?? candidate.head_digest,
       candidateEvaluations,
     ),
@@ -1083,6 +1371,44 @@ function outcomeEvidence(
     promotion_evidence_ref: "evidence://outcome-promotion",
     shadow_evidence_ref: "evidence://shadow-outcomes",
   };
+}
+
+function trustedEvaluationSet(
+  evaluatedHeadDigest: string,
+  evaluations: readonly AssistantTurnEvaluationV1[],
+): ImprovementOutcomeEvaluationSetV1 {
+  const rows = clone(evaluations);
+  const orderedRowDigests = rows.map((row) => sha(canonicalTestValue(row)));
+  const receiptContent = {
+    evaluated_head_digest: evaluatedHeadDigest,
+    evaluator_ref: rows[0]?.evaluator_ref ?? "evaluation://missing",
+    ordered_row_digests: orderedRowDigests,
+    schema_version: "improvement-outcome-evaluation-set-receipt/v1" as const,
+  };
+  return {
+    evaluations: rows,
+    receipt: {
+      ...receiptContent,
+      receipt_digest: sha(JSON.stringify([
+        receiptContent.schema_version,
+        receiptContent.evaluated_head_digest,
+        receiptContent.evaluator_ref,
+        receiptContent.ordered_row_digests,
+      ])),
+    },
+  };
+}
+
+function canonicalTestValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalTestValue).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => (
+      `${JSON.stringify(key)}:${canonicalTestValue((value as Record<string, unknown>)[key])}`
+    )).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? assert.fail("test receipt value must be serializable");
 }
 
 function promotionEvaluations(
@@ -1155,6 +1481,25 @@ function runReceipt(): RunReceiptV1 {
 
 function evidenceKey(candidateId: string, authorGeneration: number): string {
   return `${candidateId}:${authorGeneration}`;
+}
+
+function evidenceItemKey(input: ImprovementEvidenceRecord): string {
+  return `${input.candidate_id}:${input.author_generation}:${input.kind}`;
+}
+
+function evidenceCommit(input: ImprovementEvidenceRecord): ImprovementEvidencePutCommit {
+  return {
+    payload_fingerprint: sha(JSON.stringify([
+      "improvement-evidence-payload/v1",
+      input.candidate_id,
+      input.author_generation,
+      input.kind,
+      input.head_digest,
+      input.evidence_digest,
+      input.evidence_ref,
+    ])),
+    record: input,
+  };
 }
 
 function sha(value: string): string {


### PR DESCRIPTION
Hardens the portable improvement outcome contract at its two durable trust boundaries.

Evaluator rows are now resolved through an evaluator-owned receipt reference instead of being sealed by the caller. Evidence writes now return immutable put-if-absent receipts that distinguish creation, replay, and conflict, allowing safe recovery after a lost response without replacing stored evidence.

Canonical validation rejects accessors, custom prototypes, sparse arrays, unknown fields, undefined values, non-finite numbers, cycles, and unbounded data before receipt digests are trusted.

Validation:

- focused improvement tests: 16 passed
- Slack companion tests: 331 passed
- web tests: 549 passed
- TypeScript SDK tests: 7 passed
- monorepo workspace checks and builds
- OSS and leak-boundary audits
- Practice Registry final gate
