### PR TITLE
feat(slack): add portable triage channel policy

### DIFF
--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -86,9 +86,11 @@ when every referenced receipt is current, accessible, and within its validity
 window. Planning uses stable caller-provided action identity so a retry produces
 the same suggestion identity.
 
-The host owns source queries, channel admission, prompts, persistence, and
-delivery adapters. Those adapters persist the versioned records and transition
-events without changing the portable decision policy.
+The portable channel policy classifies host-supplied message text and applies
+host-supplied channel membership and confidence thresholds. The host owns
+channel membership lookup, source queries, prompts, persistence, and delivery
+adapters. Those adapters persist the versioned records and transition events
+without changing the portable decision policy.
 
 ## History learning admission
 

--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -92,6 +92,11 @@ channel membership lookup, source queries, prompts, persistence, and delivery
 adapters. Those adapters persist the versioned records and transition events
 without changing the portable decision policy.
 
+The deterministic fallback accepts host-supplied alert text and research
+records. It never authorizes a reply: explicit test markers are non-actionable,
+and every other degraded result needs more context. Model and research calls,
+credentials, transport, persistence, and deployment remain host-owned.
+
 ## History learning admission
 
 `slackLearningCandidateRejection` classifies a host-supplied message projection

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -93,6 +93,8 @@ export * from "./risk-attestation/policy.js";
 export * from "./thread-binding.js";
 export * from "./tools/catalog.js";
 export * from "./tools/contracts.js";
+export * from "./triage/alert-triage-signals.js";
+export * from "./triage/channel-policy.js";
 export * from "./triage/contracts.js";
 export * from "./triage/policy.js";
 export * from "./transport/contracts.js";

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -93,6 +93,7 @@ export * from "./risk-attestation/policy.js";
 export * from "./thread-binding.js";
 export * from "./tools/catalog.js";
 export * from "./tools/contracts.js";
+export * from "./triage/alert-triage-fallback.js";
 export * from "./triage/alert-triage-signals.js";
 export * from "./triage/channel-policy.js";
 export * from "./triage/contracts.js";

--- a/apps/slack-companion/src/triage/alert-triage-fallback.ts
+++ b/apps/slack-companion/src/triage/alert-triage-fallback.ts
@@ -1,0 +1,96 @@
+import { hasSecuritySignal } from "./alert-triage-signals.js";
+import type {
+  AlertTriageClassificationV1,
+  AlertTriageSeverityV1,
+} from "./contracts.js";
+
+export interface AlertTriageFallbackInputV1 {
+  text: string;
+}
+
+export interface AlertTriageFallbackResultV1 {
+  actionsTaken: string[];
+  classification: AlertTriageClassificationV1;
+  confidence: number;
+  evidence: string[];
+  recommendedActions: string[];
+  research: string[];
+  responseReason: string;
+  severity: AlertTriageSeverityV1;
+  shouldRespond: boolean;
+  source: "cerebro_fallback";
+  summary: string;
+}
+
+export function heuristicTriage(
+  input: AlertTriageFallbackInputV1,
+  research: string[],
+): AlertTriageFallbackResultV1 {
+  const text = redactAlertText(input.text);
+  const normalized = text.toLowerCase();
+  const testSignal = /\b(canary|test-only|pipeline test|test alert|no action needed)\b/.test(normalized);
+  if (testSignal) {
+    return {
+      classification: "non_actionable",
+      severity: "informational",
+      confidence: 0.7,
+      shouldRespond: false,
+      responseReason: "The message is an explicit canary/test signal and does not need Cerebro to interrupt the thread.",
+      summary: "The alert text is explicitly marked as a canary or test and says no action is needed. Cerebro graph reasoning was unavailable, so no graph evidence was verified.",
+      evidence: ["Alert text contains a test or canary marker.", "Cerebro graph reasoning was unavailable during fallback."],
+      actionsTaken: actionsFromResearch(research),
+      recommendedActions: ["No response action is needed for the canary alert.", "Retry Cerebro graph reasoning if this was not intended as a test."],
+      research,
+      source: "cerebro_fallback",
+    };
+  }
+
+  const securitySignal = hasSecuritySignal(normalized);
+  return {
+    classification: "needs_context",
+    severity: securitySignal ? "medium" : "informational",
+    confidence: securitySignal ? 0.4 : 0.3,
+    shouldRespond: false,
+    responseReason: "Fallback did not verify enough signal to interrupt the thread.",
+    summary: securitySignal
+      ? "The alert text contains security-relevant terms, but Cerebro graph reasoning was unavailable. Treat this as unverified until the affected identity, resource, and related findings are checked."
+      : "Cerebro graph reasoning was unavailable and the alert text does not contain enough verified context for a security classification.",
+    evidence: ["Cerebro graph reasoning was unavailable during fallback.", "No graph evidence was verified for this alert."],
+    actionsTaken: actionsFromResearch(research),
+    recommendedActions: ["Review the source alert fields.", "Check related Cerebro findings or rerun triage when graph reasoning is available."],
+    research,
+    source: "cerebro_fallback",
+  };
+}
+
+export function actionsFromResearch(research: string[]): string[] {
+  return research
+    .filter((item) => /: checked|fallback/i.test(item))
+    .map((item) => item.replace(/_/g, " ").replace(/: checked$/i, "").replace(/^Pi fallback:/i, "Used fallback path:").trim())
+    .filter(Boolean)
+    .slice(0, 6);
+}
+
+export function shortError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/\s+/g, " ").slice(0, 160);
+}
+
+export function graphSummary(value: string | undefined): string {
+  return trimForSlack(value ?? "", 900);
+}
+
+function redactAlertText(value: string): string {
+  return value
+    .replace(/xox[baprs]-[A-Za-z0-9-]+/g, "[redacted_slack_token]")
+    .replace(/\b(AKIA|ASIA)[A-Z0-9]{16}\b/g, "[redacted_aws_access_key]")
+    .replace(/-----BEGIN [^-]+ PRIVATE KEY-----[\s\S]+?-----END [^-]+ PRIVATE KEY-----/g, "[redacted_private_key]")
+    .replace(/\b(bearer|api[_-]?key|token|secret|password)\s*[:=]\s*["']?[^"'\s]+/gi, "$1=[redacted_secret]");
+}
+
+function trimForSlack(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max - 1)}…`;
+}

--- a/apps/slack-companion/src/triage/alert-triage-signals.ts
+++ b/apps/slack-companion/src/triage/alert-triage-signals.ts
@@ -1,0 +1,15 @@
+export function hasSecuritySignal(value: string): boolean {
+  return /\b(admin|anomaly|attack|credential|critical|cve|exfil|exposure|high|malware|mfa|okta|phishing|privilege|root|secret|suspicious|token|vulnerability)\b/i.test(value);
+}
+
+export function hasSpecificText(items: readonly string[]): boolean {
+  return items.some((item) => {
+    const trimmed = item.trim();
+    if (trimmed.length < 12) return false;
+    return !isGenericTriageText(trimmed);
+  });
+}
+
+export function isGenericTriageText(value: string): boolean {
+  return /\b(not enough context|needs more context|review the source alert fields|check related cerebro findings|rerun triage|no response action is needed|does not contain enough verified context|graph reasoning was unavailable|generic advice)\b/i.test(value);
+}

--- a/apps/slack-companion/src/triage/channel-policy.ts
+++ b/apps/slack-companion/src/triage/channel-policy.ts
@@ -1,0 +1,76 @@
+import type { AlertTriageClassificationV1 } from "./contracts.js";
+import { hasSecuritySignal } from "./alert-triage-signals.js";
+
+export type TriageChannelPolicyV1 = "strict" | "quiet" | "watch" | "eager";
+
+export interface TriageChannelPolicyInputV1 {
+  channel_policies: ReadonlyMap<string, TriageChannelPolicyV1>;
+  minimum_confidence: number;
+  triage_channel_ids: ReadonlySet<string>;
+}
+
+export interface SlackMessageForTriageV1 {
+  bot_id?: string;
+  subtype?: string;
+  text?: string;
+  thread_ts?: string;
+  ts?: string;
+}
+
+export function channelPolicyFor(
+  input: TriageChannelPolicyInputV1,
+  channelId: string | undefined,
+): TriageChannelPolicyV1 {
+  if (!channelId) return "strict";
+  return input.channel_policies.get(channelId)
+    ?? (input.triage_channel_ids.has(channelId) ? "watch" : "strict");
+}
+
+export function minimumConfidenceForPolicy(
+  input: TriageChannelPolicyInputV1,
+  policy: TriageChannelPolicyV1,
+): number {
+  if (policy === "strict") return Math.max(input.minimum_confidence, 0.85);
+  if (policy === "quiet") return Math.max(input.minimum_confidence, 0.7);
+  if (policy === "eager") return Math.max(0, input.minimum_confidence - 0.15);
+  return input.minimum_confidence;
+}
+
+export function policyAllowsTriage(
+  event: SlackMessageForTriageV1,
+  policy: TriageChannelPolicyV1,
+): boolean {
+  const text = event.text ?? "";
+  const isThreadReply = Boolean(event.thread_ts && event.thread_ts !== event.ts);
+  const isBotMessage = Boolean(event.bot_id || event.subtype === "bot_message");
+  if (policy === "eager") return true;
+  if (policy === "watch") return true;
+  if (hasSecuritySignal(text)) return true;
+  if (
+    isBotMessage
+    && /\b(alert|incident|finding|runtime|deploy|deployment|rollback|failed|failure|blocked|policy|approval|pull request|pr #?\d+|ci|check run|sync failed)\b/i.test(text)
+  ) {
+    return true;
+  }
+  if (policy === "quiet") {
+    return isThreadReply
+      && /\b(false positive|what evidence|why|owner|admin|actions?|merged|shipped|fixed|resolved|blocked|failed)\b/i.test(text);
+  }
+  return false;
+}
+
+export function policyAllowsPost(
+  classification: AlertTriageClassificationV1,
+  policy: TriageChannelPolicyV1,
+): boolean {
+  if (policy === "strict" && classification !== "actionable") return false;
+  if (policy === "quiet" && classification === "non_actionable") return false;
+  return true;
+}
+
+export function policyContextLine(policy: TriageChannelPolicyV1): string {
+  if (policy === "strict") return "Channel policy: strict. Speak only for high-confidence security issues with verified evidence.";
+  if (policy === "quiet") return "Channel policy: quiet. Speak only when the reply changes an investigation, deploy, or security decision.";
+  if (policy === "eager") return "Channel policy: eager. Review more messages, but still post only concrete, evidence-backed help.";
+  return "Channel policy: watch. Review configured signals and post only when useful.";
+}

--- a/apps/slack-companion/test/triage-channel-policy.test.ts
+++ b/apps/slack-companion/test/triage-channel-policy.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  hasSecuritySignal,
+  hasSpecificText,
+  isGenericTriageText,
+} from "../src/triage/alert-triage-signals.js";
+import {
+  channelPolicyFor,
+  minimumConfidenceForPolicy,
+  policyAllowsPost,
+  policyAllowsTriage,
+  policyContextLine,
+  type TriageChannelPolicyInputV1,
+  type TriageChannelPolicyV1,
+} from "../src/triage/channel-policy.js";
+import type { AlertTriageClassificationV1 } from "../src/triage/contracts.js";
+
+const signalTokens = [
+  "admin",
+  "anomaly",
+  "attack",
+  "credential",
+  "critical",
+  "cve",
+  "exfil",
+  "exposure",
+  "high",
+  "malware",
+  "mfa",
+  "okta",
+  "phishing",
+  "privilege",
+  "root",
+  "secret",
+  "suspicious",
+  "token",
+  "vulnerability",
+] as const;
+
+const genericTriagePhrases = [
+  "not enough context",
+  "needs more context",
+  "review the source alert fields",
+  "check related cerebro findings",
+  "rerun triage",
+  "no response action is needed",
+  "does not contain enough verified context",
+  "graph reasoning was unavailable",
+  "generic advice",
+] as const;
+
+describe("portable alert-triage signals", () => {
+  test("preserves every security signal token and word boundary", () => {
+    for (const token of signalTokens) {
+      assert.equal(hasSecuritySignal(`Observed ${token} activity.`), true, token);
+      assert.equal(hasSecuritySignal(token.toUpperCase()), true, token);
+    }
+    assert.equal(hasSecuritySignal("administrator activity"), false);
+    assert.equal(hasSecuritySignal("tokenized output"), false);
+    assert.equal(hasSecuritySignal("routine maintenance"), false);
+  });
+
+  test("preserves every generic triage phrase", () => {
+    for (const phrase of genericTriagePhrases) {
+      assert.equal(isGenericTriageText(`Result: ${phrase}.`), true, phrase);
+      assert.equal(isGenericTriageText(phrase.toUpperCase()), true, phrase);
+    }
+    assert.equal(isGenericTriageText("Confirm the accountable owner."), false);
+  });
+
+  test("requires a non-generic trimmed item with at least twelve characters", () => {
+    assert.equal(hasSpecificText(["short text"]), false);
+    assert.equal(hasSpecificText(["  not enough context for this alert  "]), false);
+    assert.equal(hasSpecificText(["generic advice", "  Confirm the owner before rollout.  "]), true);
+  });
+});
+
+describe("portable triage channel policy", () => {
+  test("selects explicit, watched, and strict channel policies in order", () => {
+    const input = policyInput({
+      channel_policies: new Map([
+        ["channel-explicit", "quiet"],
+        ["channel-overridden", "eager"],
+      ]),
+      triage_channel_ids: new Set(["channel-watch", "channel-overridden"]),
+    });
+
+    assert.equal(channelPolicyFor(input, undefined), "strict");
+    assert.equal(channelPolicyFor(input, ""), "strict");
+    assert.equal(channelPolicyFor(input, "channel-explicit"), "quiet");
+    assert.equal(channelPolicyFor(input, "channel-overridden"), "eager");
+    assert.equal(channelPolicyFor(input, "channel-watch"), "watch");
+    assert.equal(channelPolicyFor(input, "channel-other"), "strict");
+  });
+
+  test("preserves confidence floors, eager reduction, and watch threshold", () => {
+    assert.deepEqual(confidenceByPolicy(0.5), {
+      eager: 0.35,
+      quiet: 0.7,
+      strict: 0.85,
+      watch: 0.5,
+    });
+    assert.deepEqual(confidenceByPolicy(0.1), {
+      eager: 0,
+      quiet: 0.7,
+      strict: 0.85,
+      watch: 0.1,
+    });
+    assert.deepEqual(confidenceByPolicy(0.9), {
+      eager: 0.75,
+      quiet: 0.9,
+      strict: 0.9,
+      watch: 0.9,
+    });
+  });
+
+  test("always admits eager and watch messages", () => {
+    assert.equal(policyAllowsTriage({}, "eager"), true);
+    assert.equal(policyAllowsTriage({}, "watch"), true);
+  });
+
+  test("admits security signals under strict and quiet policies", () => {
+    assert.equal(policyAllowsTriage({ text: "Critical credential exposure" }, "strict"), true);
+    assert.equal(policyAllowsTriage({ text: "Critical credential exposure" }, "quiet"), true);
+  });
+
+  test("preserves every bot-message admission phrase", () => {
+    const phrases = [
+      "alert",
+      "incident",
+      "finding",
+      "runtime",
+      "deploy",
+      "deployment",
+      "rollback",
+      "failed",
+      "failure",
+      "blocked",
+      "policy",
+      "approval",
+      "pull request",
+      "pr #42",
+      "ci",
+      "check run",
+      "sync failed",
+    ];
+    for (const text of phrases) {
+      assert.equal(policyAllowsTriage({ bot_id: "bot", text }, "strict"), true, text);
+    }
+    assert.equal(
+      policyAllowsTriage({ subtype: "bot_message", text: "deployment" }, "strict"),
+      true,
+    );
+    assert.equal(policyAllowsTriage({ text: "deployment" }, "strict"), false);
+  });
+
+  test("admits only matching quiet-policy thread replies", () => {
+    const phrases = [
+      "false positive",
+      "what evidence",
+      "why",
+      "owner",
+      "admin",
+      "action",
+      "actions",
+      "merged",
+      "shipped",
+      "fixed",
+      "resolved",
+      "blocked",
+      "failed",
+    ];
+    for (const text of phrases) {
+      assert.equal(
+        policyAllowsTriage({ text, thread_ts: "thread-1", ts: "reply-1" }, "quiet"),
+        true,
+        text,
+      );
+    }
+    assert.equal(policyAllowsTriage({ text: "what evidence" }, "quiet"), false);
+    assert.equal(
+      policyAllowsTriage({ text: "what evidence", thread_ts: "message-1", ts: "message-1" }, "quiet"),
+      false,
+    );
+    assert.equal(
+      policyAllowsTriage({ text: "routine update", thread_ts: "thread-1", ts: "reply-1" }, "quiet"),
+      false,
+    );
+  });
+
+  test("maps frozen post gates to the current public classifications", () => {
+    const expected: Record<TriageChannelPolicyV1, Record<AlertTriageClassificationV1, boolean>> = {
+      eager: { actionable: true, needs_context: true, non_actionable: true },
+      quiet: { actionable: true, needs_context: true, non_actionable: false },
+      strict: { actionable: true, needs_context: false, non_actionable: false },
+      watch: { actionable: true, needs_context: true, non_actionable: true },
+    };
+    for (const [policy, decisions] of Object.entries(expected)) {
+      for (const [classification, allowed] of Object.entries(decisions)) {
+        assert.equal(
+          policyAllowsPost(
+            classification as AlertTriageClassificationV1,
+            policy as TriageChannelPolicyV1,
+          ),
+          allowed,
+          `${policy}:${classification}`,
+        );
+      }
+    }
+  });
+
+  test("preserves each host-facing policy instruction", () => {
+    assert.equal(
+      policyContextLine("strict"),
+      "Channel policy: strict. Speak only for high-confidence security issues with verified evidence.",
+    );
+    assert.equal(
+      policyContextLine("quiet"),
+      "Channel policy: quiet. Speak only when the reply changes an investigation, deploy, or security decision.",
+    );
+    assert.equal(
+      policyContextLine("eager"),
+      "Channel policy: eager. Review more messages, but still post only concrete, evidence-backed help.",
+    );
+    assert.equal(
+      policyContextLine("watch"),
+      "Channel policy: watch. Review configured signals and post only when useful.",
+    );
+  });
+});
+
+function policyInput(
+  overrides: Partial<TriageChannelPolicyInputV1> = {},
+): TriageChannelPolicyInputV1 {
+  return {
+    channel_policies: new Map(),
+    minimum_confidence: 0.5,
+    triage_channel_ids: new Set(),
+    ...overrides,
+  };
+}
+
+function confidenceByPolicy(minimumConfidence: number): Record<TriageChannelPolicyV1, number> {
+  const input = policyInput({ minimum_confidence: minimumConfidence });
+  return {
+    eager: minimumConfidenceForPolicy(input, "eager"),
+    quiet: minimumConfidenceForPolicy(input, "quiet"),
+    strict: minimumConfidenceForPolicy(input, "strict"),
+    watch: minimumConfidenceForPolicy(input, "watch"),
+  };
+}

--- a/apps/slack-companion/test/triage-fallback.test.ts
+++ b/apps/slack-companion/test/triage-fallback.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  actionsFromResearch,
+  graphSummary,
+  heuristicTriage,
+  shortError,
+} from "../src/triage/alert-triage-fallback.js";
+
+describe("deterministic alert-triage fallback", () => {
+  test("returns the fixed non-actionable result for every explicit test marker", () => {
+    const markers = [
+      "canary",
+      "test-only",
+      "pipeline test",
+      "test alert",
+      "no action needed",
+    ];
+    for (const marker of markers) {
+      const research = ["source_query: checked"];
+      const result = heuristicTriage({ text: `CRITICAL ${marker.toUpperCase()}` }, research);
+
+      assert.deepEqual(result, {
+        classification: "non_actionable",
+        severity: "informational",
+        confidence: 0.7,
+        shouldRespond: false,
+        responseReason: "The message is an explicit canary/test signal and does not need Cerebro to interrupt the thread.",
+        summary: "The alert text is explicitly marked as a canary or test and says no action is needed. Cerebro graph reasoning was unavailable, so no graph evidence was verified.",
+        evidence: ["Alert text contains a test or canary marker.", "Cerebro graph reasoning was unavailable during fallback."],
+        actionsTaken: ["source query"],
+        recommendedActions: ["No response action is needed for the canary alert.", "Retry Cerebro graph reasoning if this was not intended as a test."],
+        research,
+        source: "cerebro_fallback",
+      }, marker);
+      assert.equal(result.research, research);
+    }
+  });
+
+  test("checks test markers before security terms and preserves word boundaries", () => {
+    assert.equal(
+      heuristicTriage({ text: "Critical credential canary" }, []).classification,
+      "non_actionable",
+    );
+    assert.deepEqual(
+      fallbackDecision("The canarying service passed contest alerts."),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+  });
+
+  test("returns the fixed unverified result for security terms", () => {
+    const research = ["identity_lookup: checked", "ignored note"];
+    const result = heuristicTriage({ text: "Suspicious credential exposure" }, research);
+
+    assert.deepEqual(result, {
+      classification: "needs_context",
+      severity: "medium",
+      confidence: 0.4,
+      shouldRespond: false,
+      responseReason: "Fallback did not verify enough signal to interrupt the thread.",
+      summary: "The alert text contains security-relevant terms, but Cerebro graph reasoning was unavailable. Treat this as unverified until the affected identity, resource, and related findings are checked.",
+      evidence: ["Cerebro graph reasoning was unavailable during fallback.", "No graph evidence was verified for this alert."],
+      actionsTaken: ["identity lookup"],
+      recommendedActions: ["Review the source alert fields.", "Check related Cerebro findings or rerun triage when graph reasoning is available."],
+      research,
+      source: "cerebro_fallback",
+    });
+    assert.equal(result.research, research);
+  });
+
+  test("returns the fixed generic result when no security term is present", () => {
+    const research: string[] = [];
+    const result = heuristicTriage({ text: "Routine service update" }, research);
+
+    assert.deepEqual(result, {
+      classification: "needs_context",
+      severity: "informational",
+      confidence: 0.3,
+      shouldRespond: false,
+      responseReason: "Fallback did not verify enough signal to interrupt the thread.",
+      summary: "Cerebro graph reasoning was unavailable and the alert text does not contain enough verified context for a security classification.",
+      evidence: ["Cerebro graph reasoning was unavailable during fallback.", "No graph evidence was verified for this alert."],
+      actionsTaken: [],
+      recommendedActions: ["Review the source alert fields.", "Check related Cerebro findings or rerun triage when graph reasoning is available."],
+      research,
+      source: "cerebro_fallback",
+    });
+  });
+
+  test("redacts frozen secret forms before selecting the fallback branch", () => {
+    const keyLabel = "PRIVATE KEY";
+    const privateKeyFixture = [
+      `-----BEGIN TEST ${keyLabel}-----`,
+      "canary",
+      `-----END TEST ${keyLabel}-----`,
+    ].join("\n");
+    const awsAccessKeyFixture = ["AKIA", "1234567890ABCDEF"].join("");
+    const slackTokenFixture = ["xoxb", "canary"].join("-");
+
+    assert.deepEqual(
+      fallbackDecision("password=canary"),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+    assert.deepEqual(
+      fallbackDecision("token=canary"),
+      { classification: "needs_context", confidence: 0.4, severity: "medium" },
+    );
+    assert.deepEqual(
+      fallbackDecision(awsAccessKeyFixture),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+    assert.deepEqual(
+      fallbackDecision(privateKeyFixture),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+    assert.deepEqual(
+      fallbackDecision(slackTokenFixture),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+  });
+});
+
+describe("fallback result helpers", () => {
+  test("extracts checked and fallback research actions in order", () => {
+    assert.deepEqual(actionsFromResearch([
+      "source_query: checked",
+      "ignored note",
+      "PI FALLBACK: local_cache",
+      "middle: CHECKED extra",
+      ": checked",
+      "fallback only",
+    ]), [
+      "source query",
+      "Used fallback path: local cache",
+      "middle: CHECKED extra",
+      "fallback only",
+    ]);
+  });
+
+  test("returns no more than six research actions", () => {
+    const research = Array.from({ length: 8 }, (_, index) => `step_${index}: checked`);
+    assert.deepEqual(actionsFromResearch(research), [
+      "step 0",
+      "step 1",
+      "step 2",
+      "step 3",
+      "step 4",
+      "step 5",
+    ]);
+  });
+
+  test("normalizes error whitespace and caps the result at 160 characters", () => {
+    assert.equal(shortError(new Error("first\n\tsecond   third")), "first second third");
+    assert.equal(shortError({ code: "failed" }), "[object Object]");
+    assert.equal(shortError("x".repeat(200)), "x".repeat(160));
+  });
+
+  test("returns an empty graph summary for no value and truncates after 899 characters", () => {
+    assert.equal(graphSummary(undefined), "");
+    assert.equal(graphSummary("x".repeat(900)), "x".repeat(900));
+    assert.equal(graphSummary("x".repeat(901)), `${"x".repeat(899)}…`);
+  });
+});
+
+function fallbackDecision(text: string) {
+  const result = heuristicTriage({ text }, []);
+  return {
+    classification: result.classification,
+    confidence: result.confidence,
+    severity: result.severity,
+  };
+}


### PR DESCRIPTION
Adds the portable signal and channel-policy primitives used before alert triage.

The policy consumes host-supplied channel membership, message text, and confidence thresholds. It preserves strict, quiet, watch, and eager admission and posting behavior without owning Slack configuration, persistence, transport, or deployment details.

Validation:

- focused policy tests: 11 passed
- Slack companion tests: 340 passed
- monorepo workspace checks and builds
- OSS and staged leak audits
- Practice Registry final gate
