### PR TITLE
Harden product release archive validation

### DIFF
--- a/scripts/release/product_release.py
+++ b/scripts/release/product_release.py
@@ -195,7 +195,6 @@ def read_npm_archive_manifest(path: Path, label: str) -> tuple[dict[str, Any], f
                 if member.name != NPM_PACKAGE_JSON:
                     continue
                 require(member.isfile(), f"{label} {NPM_PACKAGE_JSON} must be a regular file")
-                require(package_manifest is None, f"{label} archive has duplicate package metadata")
                 require(
                     0 < member.size <= MAX_NPM_PACKAGE_JSON_BYTES,
                     f"{label} package metadata size is invalid",

--- a/scripts/release/product_release.py
+++ b/scripts/release/product_release.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import re
 import sys
+import tarfile
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -23,6 +24,24 @@ IMAGE_RE = re.compile(
 )
 PACKAGE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$")
 REPOSITORY_PATTERN = r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+MAX_NPM_ARCHIVE_MEMBERS = 10_000
+MAX_NPM_PACKAGE_JSON_BYTES = 256 * 1024
+NPM_PACKAGE_JSON = "package/package.json"
+SDK_REQUIRED_MEMBERS = frozenset(
+    {
+        "package/src/index.js",
+        "package/src/index.ts",
+        "package/src/generated/openapi-types.ts",
+        "package/src/generated/agent-service-lifecycle.ts",
+        "package/src/generated/agent-service-lifecycle-contract.ts",
+    }
+)
+SLACK_REQUIRED_MEMBERS = frozenset(
+    {
+        "package/dist/src/index.js",
+        "package/dist/src/index.d.ts",
+    }
+)
 
 
 class ManifestError(ValueError):
@@ -145,6 +164,82 @@ def validate_file_record(
         require(sha256_file(artifact) == record["sha256"], f"{label} artifact digest does not match")
 
 
+def read_npm_archive_manifest(path: Path, label: str) -> tuple[dict[str, Any], frozenset[str]]:
+    members: set[str] = set()
+    package_manifest: dict[str, Any] | None = None
+    member_count = 0
+
+    try:
+        with tarfile.open(path, mode="r|gz") as archive:
+            for member in archive:
+                member_count += 1
+                require(
+                    member_count <= MAX_NPM_ARCHIVE_MEMBERS,
+                    f"{label} archive has too many members",
+                )
+                member_path = PurePosixPath(member.name)
+                require(
+                    member.name == member_path.as_posix()
+                    and not member_path.is_absolute()
+                    and ".." not in member_path.parts
+                    and len(member_path.parts) > 1
+                    and member_path.parts[0] == "package",
+                    f"{label} archive member is unsafe: {member.name}",
+                )
+                require(member.name not in members, f"{label} archive has duplicate member: {member.name}")
+                members.add(member.name)
+                require(
+                    member.isfile() or member.isdir(),
+                    f"{label} archive member must be a regular file or directory: {member.name}",
+                )
+                if member.name != NPM_PACKAGE_JSON:
+                    continue
+                require(member.isfile(), f"{label} {NPM_PACKAGE_JSON} must be a regular file")
+                require(package_manifest is None, f"{label} archive has duplicate package metadata")
+                require(
+                    0 < member.size <= MAX_NPM_PACKAGE_JSON_BYTES,
+                    f"{label} package metadata size is invalid",
+                )
+                package_file = archive.extractfile(member)
+                require(package_file is not None, f"{label} package metadata cannot be read")
+                package_bytes = package_file.read(MAX_NPM_PACKAGE_JSON_BYTES + 1)
+                require(
+                    len(package_bytes) <= MAX_NPM_PACKAGE_JSON_BYTES,
+                    f"{label} package metadata is too large",
+                )
+                parsed = json.loads(package_bytes.decode("utf-8"))
+                require(isinstance(parsed, dict), f"{label} package metadata must be an object")
+                package_manifest = parsed
+    except ManifestError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, tarfile.TarError) as exc:
+        raise ManifestError(f"{label} archive is invalid: {exc}") from exc
+
+    require(package_manifest is not None, f"{label} archive is missing {NPM_PACKAGE_JSON}")
+    return package_manifest, frozenset(members)
+
+
+def validate_npm_archive(
+    record: dict[str, Any],
+    label: str,
+    bundle_root: Path,
+    *,
+    expected_package: str,
+    required_members: frozenset[str],
+) -> dict[str, Any]:
+    archive_path = bundle_root / PurePosixPath(record["file"])
+    package_manifest, members = read_npm_archive_manifest(archive_path, label)
+    require(record["package"] == expected_package, f"{label}.package is invalid")
+    require(package_manifest.get("name") == expected_package, f"{label} archive package name does not match")
+    require(
+        package_manifest.get("version") == record["package_version"],
+        f"{label} archive package version does not match",
+    )
+    missing = sorted(required_members - members)
+    require(not missing, f"{label} archive is missing required members: {', '.join(missing)}")
+    return package_manifest
+
+
 def validate_manifest(manifest: Any, bundle_root: Path | None = None) -> None:
     require(isinstance(manifest, dict), "manifest must be an object")
     require(
@@ -180,6 +275,35 @@ def validate_manifest(manifest: Any, bundle_root: Path | None = None) -> None:
 
     validate_file_record(components["slack_companion"], "components.slack_companion", bundle_root, archive=True)
     validate_file_record(components["typescript_sdk"], "components.typescript_sdk", bundle_root, archive=True)
+    require(
+        components["slack_companion"]["package"] == "@writer/cerebro-slack-companion",
+        "components.slack_companion.package is invalid",
+    )
+    require(
+        components["typescript_sdk"]["package"] == "@writer/cerebro-sdk",
+        "components.typescript_sdk.package is invalid",
+    )
+    if bundle_root is not None:
+        sdk_manifest = validate_npm_archive(
+            components["typescript_sdk"],
+            "components.typescript_sdk",
+            bundle_root,
+            expected_package="@writer/cerebro-sdk",
+            required_members=SDK_REQUIRED_MEMBERS,
+        )
+        slack_manifest = validate_npm_archive(
+            components["slack_companion"],
+            "components.slack_companion",
+            bundle_root,
+            expected_package="@writer/cerebro-slack-companion",
+            required_members=SLACK_REQUIRED_MEMBERS,
+        )
+        slack_dependencies = slack_manifest.get("dependencies")
+        require(
+            isinstance(slack_dependencies, dict)
+            and slack_dependencies.get("@writer/cerebro-sdk") == sdk_manifest.get("version"),
+            "components.slack_companion archive must depend on the archived TypeScript SDK version",
+        )
 
     contracts = manifest.get("contracts")
     require(isinstance(contracts, dict), "contracts must be an object")

--- a/scripts/release/test_product_release.py
+++ b/scripts/release/test_product_release.py
@@ -159,7 +159,7 @@ class ProductReleaseTest(unittest.TestCase):
         with self.assertRaisesRegex(ManifestError, "must depend on the archived TypeScript SDK version"):
             validate_manifest(manifest, self.root)
 
-    def test_rejects_archive_with_duplicate_package_metadata(self) -> None:
+    def test_rejects_archive_with_duplicate_package_json_member(self) -> None:
         package_json = json.dumps({"name": "@writer/cerebro-sdk", "version": "0.1.0"})
         write_archive(
             self.root / "sdk.tgz",

--- a/scripts/release/test_product_release.py
+++ b/scripts/release/test_product_release.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
+import tarfile
 import tempfile
 import unittest
 from pathlib import Path
 
 from scripts.release.product_release import (
     EVENT_SCHEMA_VERSION,
+    MAX_NPM_PACKAGE_JSON_BYTES,
     ManifestError,
     build_manifest,
     build_release_event,
@@ -18,16 +21,50 @@ from scripts.release.product_release import (
 
 COMMIT = "a" * 40
 DIGEST = "sha256:" + "b" * 64
+SDK_MEMBERS = {
+    "package/src/index.js": "export {};\n",
+    "package/src/index.ts": "export {};\n",
+    "package/src/generated/openapi-types.ts": "export {};\n",
+    "package/src/generated/agent-service-lifecycle.ts": "export {};\n",
+    "package/src/generated/agent-service-lifecycle-contract.ts": "export {};\n",
+}
+SLACK_MEMBERS = {
+    "package/dist/src/index.js": "export {};\n",
+    "package/dist/src/index.d.ts": "export {};\n",
+}
+
+
+def write_npm_archive(
+    path: Path,
+    package_manifest: dict[str, object],
+    members: dict[str, str],
+) -> None:
+    write_archive(
+        path,
+        [("package/package.json", json.dumps(package_manifest)), *members.items()],
+    )
+
+
+def write_archive(path: Path, members: list[tuple[str, str]]) -> None:
+    with tarfile.open(path, mode="w:gz") as archive:
+        for name, content in members:
+            payload = content.encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            info.mtime = 0
+            archive.addfile(info, io.BytesIO(payload))
 
 
 class ProductReleaseTest(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
         self.root = Path(self.tempdir.name)
-        for name in ("slack.tgz", "sdk.tgz", "contracts/openapi.yaml", "contracts/lifecycle.json"):
+        for name in ("contracts/openapi.yaml", "contracts/lifecycle.json"):
             path = self.root / name
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(name, encoding="utf-8")
+        self.write_sdk_archive()
+        self.write_slack_archive()
 
     def tearDown(self) -> None:
         self.tempdir.cleanup()
@@ -58,6 +95,34 @@ class ProductReleaseTest(unittest.TestCase):
             manifest_sha256="c" * 64,
         )
 
+    def write_sdk_archive(
+        self,
+        *,
+        name: str = "@writer/cerebro-sdk",
+        version: str = "0.1.0",
+        members: dict[str, str] | None = None,
+    ) -> None:
+        write_npm_archive(
+            self.root / "sdk.tgz",
+            {"name": name, "version": version},
+            SDK_MEMBERS if members is None else members,
+        )
+
+    def write_slack_archive(
+        self,
+        *,
+        sdk_version: str = "0.1.0",
+    ) -> None:
+        write_npm_archive(
+            self.root / "slack.tgz",
+            {
+                "name": "@writer/cerebro-slack-companion",
+                "version": "0.1.0",
+                "dependencies": {"@writer/cerebro-sdk": sdk_version},
+            },
+            SLACK_MEMBERS,
+        )
+
     def test_build_is_deterministic_and_validates_bundle_digests(self) -> None:
         manifest = build_manifest(self.args())
         validate_manifest(manifest, self.root)
@@ -69,6 +134,67 @@ class ProductReleaseTest(unittest.TestCase):
         manifest = build_manifest(self.args())
         (self.root / "slack.tgz").write_text("changed", encoding="utf-8")
         with self.assertRaisesRegex(ManifestError, "artifact digest does not match"):
+            validate_manifest(manifest, self.root)
+
+    def test_rejects_archive_with_wrong_embedded_package_identity(self) -> None:
+        self.write_sdk_archive(name="@writer/not-cerebro-sdk")
+        manifest = build_manifest(self.args())
+
+        with self.assertRaisesRegex(ManifestError, "archive package name does not match"):
+            validate_manifest(manifest, self.root)
+
+    def test_rejects_sdk_archive_without_generated_contract_binding(self) -> None:
+        members = dict(SDK_MEMBERS)
+        del members["package/src/generated/agent-service-lifecycle-contract.ts"]
+        self.write_sdk_archive(members=members)
+        manifest = build_manifest(self.args())
+
+        with self.assertRaisesRegex(ManifestError, "archive is missing required members"):
+            validate_manifest(manifest, self.root)
+
+    def test_rejects_slack_archive_with_another_sdk_version(self) -> None:
+        self.write_slack_archive(sdk_version="0.2.0")
+        manifest = build_manifest(self.args())
+
+        with self.assertRaisesRegex(ManifestError, "must depend on the archived TypeScript SDK version"):
+            validate_manifest(manifest, self.root)
+
+    def test_rejects_archive_with_duplicate_package_metadata(self) -> None:
+        package_json = json.dumps({"name": "@writer/cerebro-sdk", "version": "0.1.0"})
+        write_archive(
+            self.root / "sdk.tgz",
+            [
+                ("package/package.json", package_json),
+                ("package/package.json", package_json),
+                *SDK_MEMBERS.items(),
+            ],
+        )
+        manifest = build_manifest(self.args())
+
+        with self.assertRaisesRegex(ManifestError, "archive has duplicate member"):
+            validate_manifest(manifest, self.root)
+
+    def test_rejects_archive_with_malformed_package_metadata(self) -> None:
+        write_archive(
+            self.root / "sdk.tgz",
+            [("package/package.json", "{"), *SDK_MEMBERS.items()],
+        )
+        manifest = build_manifest(self.args())
+
+        with self.assertRaisesRegex(ManifestError, "archive is invalid"):
+            validate_manifest(manifest, self.root)
+
+    def test_rejects_oversized_package_metadata(self) -> None:
+        write_archive(
+            self.root / "sdk.tgz",
+            [
+                ("package/package.json", "x" * (MAX_NPM_PACKAGE_JSON_BYTES + 1)),
+                *SDK_MEMBERS.items(),
+            ],
+        )
+        manifest = build_manifest(self.args())
+
+        with self.assertRaisesRegex(ManifestError, "package metadata size is invalid"):
             validate_manifest(manifest, self.root)
 
     def test_rejects_candidate_version_for_another_commit(self) -> None:


### PR DESCRIPTION
Makes product-release validation prove the contents and compatibility of the archived public packages.

Release validation now inspects npm archives without extraction, verifies embedded package identity and version, requires generated OpenAPI and lifecycle bindings in the SDK, requires compiled Slack entrypoints, and checks that the Slack archive depends on the exact archived SDK version. Unsafe paths, links, duplicate members, malformed metadata, and bounded-size violations fail closed.

The product-release schema and correctly packed artifacts remain compatible.

Validation:

- release smoke: 14 tests
- script tests: 187 tests
- real SDK and Slack pack/manifest validation
- lifecycle and OpenAPI generation checks
- SDK, Slack, and web package checks
- OSS and staged leak audits
- Practice Registry final gate
