### PR TITLE
feat(slack): normalize assistant triage transcripts

### DIFF
--- a/apps/slack-companion/package.json
+++ b/apps/slack-companion/package.json
@@ -15,6 +15,10 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
+    },
+    "./triage/transcript": {
+      "types": "./dist/src/triage/alert-triage-transcript.d.ts",
+      "default": "./dist/src/triage/alert-triage-transcript.js"
     }
   },
   "repository": {

--- a/apps/slack-companion/src/triage/alert-triage-transcript.ts
+++ b/apps/slack-companion/src/triage/alert-triage-transcript.ts
@@ -1,0 +1,15 @@
+export function latestAssistantText(messages: readonly unknown[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index] as { role?: string; content?: unknown };
+    if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
+    return message.content
+      .flatMap((part) => {
+        if (part === null || typeof part !== "object") return [];
+        const item = part as { type?: string; text?: unknown };
+        return item.type === "text" && typeof item.text === "string" ? [item.text] : [];
+      })
+      .join("\n")
+      .trim();
+  }
+  return "";
+}

--- a/apps/slack-companion/test/triage-transcript.test.ts
+++ b/apps/slack-companion/test/triage-transcript.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { latestAssistantText } from "../src/triage/alert-triage-transcript.js";
+
+test("returns text parts from the latest assistant message in source order", () => {
+  assert.equal(
+    latestAssistantText([
+      { role: "assistant", content: [{ type: "text", text: "stale answer" }] },
+      { role: "user", content: [{ type: "text", text: "follow-up" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "  current conclusion" },
+          { type: "toolCall", name: "lookup" },
+          { type: "text", text: "next action  " },
+        ],
+      },
+      { role: "tool", content: [{ type: "text", text: "tool output" }] },
+    ]),
+    "current conclusion\nnext action",
+  );
+});
+
+test("skips assistant records whose content is not an array", () => {
+  assert.equal(
+    latestAssistantText([
+      { role: "assistant", content: [{ type: "text", text: "usable answer" }] },
+      { role: "assistant", content: "not structured content" },
+    ]),
+    "usable answer",
+  );
+});
+
+test("does not reuse stale text when the latest assistant message has no text", () => {
+  assert.equal(
+    latestAssistantText([
+      { role: "assistant", content: [{ type: "text", text: "stale answer" }] },
+      {
+        role: "assistant",
+        content: [null, "invalid", { type: "toolCall", name: "lookup" }, { type: "text", text: 42 }],
+      },
+    ]),
+    "",
+  );
+});
+
+test("returns empty text when no structured assistant message exists", () => {
+  assert.equal(latestAssistantText([null, 42, { role: "user", content: [] }]), "");
+});


### PR DESCRIPTION
## What changed

Adds a portable helper that extracts ordered text from the latest structured assistant response and exports it as a package subpath.

The helper treats the latest valid assistant record as authoritative, skips malformed records, and does not fall back to stale text when that record contains no text parts.

## Validation

- Focused transcript tests
- Full Slack companion check
- Workspace contract check
- OSS audit
- Packed package import and declaration checks
- Practice Registry final gate