### PR TITLE
feat(slack): add portable triage fallback

### DIFF
--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -92,6 +92,11 @@ channel membership lookup, source queries, prompts, persistence, and delivery
 adapters. Those adapters persist the versioned records and transition events
 without changing the portable decision policy.
 
+The deterministic fallback accepts host-supplied alert text and research
+records. It never authorizes a reply: explicit test markers are non-actionable,
+and every other degraded result needs more context. Model and research calls,
+credentials, transport, persistence, and deployment remain host-owned.
+
 ## History learning admission
 
 `slackLearningCandidateRejection` classifies a host-supplied message projection

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -93,6 +93,7 @@ export * from "./risk-attestation/policy.js";
 export * from "./thread-binding.js";
 export * from "./tools/catalog.js";
 export * from "./tools/contracts.js";
+export * from "./triage/alert-triage-fallback.js";
 export * from "./triage/alert-triage-signals.js";
 export * from "./triage/channel-policy.js";
 export * from "./triage/contracts.js";

--- a/apps/slack-companion/src/triage/alert-triage-fallback.ts
+++ b/apps/slack-companion/src/triage/alert-triage-fallback.ts
@@ -1,0 +1,96 @@
+import { hasSecuritySignal } from "./alert-triage-signals.js";
+import type {
+  AlertTriageClassificationV1,
+  AlertTriageSeverityV1,
+} from "./contracts.js";
+
+export interface AlertTriageFallbackInputV1 {
+  text: string;
+}
+
+export interface AlertTriageFallbackResultV1 {
+  actionsTaken: string[];
+  classification: AlertTriageClassificationV1;
+  confidence: number;
+  evidence: string[];
+  recommendedActions: string[];
+  research: string[];
+  responseReason: string;
+  severity: AlertTriageSeverityV1;
+  shouldRespond: boolean;
+  source: "cerebro_fallback";
+  summary: string;
+}
+
+export function heuristicTriage(
+  input: AlertTriageFallbackInputV1,
+  research: string[],
+): AlertTriageFallbackResultV1 {
+  const text = redactAlertText(input.text);
+  const normalized = text.toLowerCase();
+  const testSignal = /\b(canary|test-only|pipeline test|test alert|no action needed)\b/.test(normalized);
+  if (testSignal) {
+    return {
+      classification: "non_actionable",
+      severity: "informational",
+      confidence: 0.7,
+      shouldRespond: false,
+      responseReason: "The message is an explicit canary/test signal and does not need Cerebro to interrupt the thread.",
+      summary: "The alert text is explicitly marked as a canary or test and says no action is needed. Cerebro graph reasoning was unavailable, so no graph evidence was verified.",
+      evidence: ["Alert text contains a test or canary marker.", "Cerebro graph reasoning was unavailable during fallback."],
+      actionsTaken: actionsFromResearch(research),
+      recommendedActions: ["No response action is needed for the canary alert.", "Retry Cerebro graph reasoning if this was not intended as a test."],
+      research,
+      source: "cerebro_fallback",
+    };
+  }
+
+  const securitySignal = hasSecuritySignal(normalized);
+  return {
+    classification: "needs_context",
+    severity: securitySignal ? "medium" : "informational",
+    confidence: securitySignal ? 0.4 : 0.3,
+    shouldRespond: false,
+    responseReason: "Fallback did not verify enough signal to interrupt the thread.",
+    summary: securitySignal
+      ? "The alert text contains security-relevant terms, but Cerebro graph reasoning was unavailable. Treat this as unverified until the affected identity, resource, and related findings are checked."
+      : "Cerebro graph reasoning was unavailable and the alert text does not contain enough verified context for a security classification.",
+    evidence: ["Cerebro graph reasoning was unavailable during fallback.", "No graph evidence was verified for this alert."],
+    actionsTaken: actionsFromResearch(research),
+    recommendedActions: ["Review the source alert fields.", "Check related Cerebro findings or rerun triage when graph reasoning is available."],
+    research,
+    source: "cerebro_fallback",
+  };
+}
+
+export function actionsFromResearch(research: string[]): string[] {
+  return research
+    .filter((item) => /: checked|fallback/i.test(item))
+    .map((item) => item.replace(/_/g, " ").replace(/: checked$/i, "").replace(/^Pi fallback:/i, "Used fallback path:").trim())
+    .filter(Boolean)
+    .slice(0, 6);
+}
+
+export function shortError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/\s+/g, " ").slice(0, 160);
+}
+
+export function graphSummary(value: string | undefined): string {
+  return trimForSlack(value ?? "", 900);
+}
+
+function redactAlertText(value: string): string {
+  return value
+    .replace(/xox[baprs]-[A-Za-z0-9-]+/g, "[redacted_slack_token]")
+    .replace(/\b(AKIA|ASIA)[A-Z0-9]{16}\b/g, "[redacted_aws_access_key]")
+    .replace(/-----BEGIN [^-]+ PRIVATE KEY-----[\s\S]+?-----END [^-]+ PRIVATE KEY-----/g, "[redacted_private_key]")
+    .replace(/\b(bearer|api[_-]?key|token|secret|password)\s*[:=]\s*["']?[^"'\s]+/gi, "$1=[redacted_secret]");
+}
+
+function trimForSlack(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max - 1)}…`;
+}

--- a/apps/slack-companion/test/triage-fallback.test.ts
+++ b/apps/slack-companion/test/triage-fallback.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  actionsFromResearch,
+  graphSummary,
+  heuristicTriage,
+  shortError,
+} from "../src/triage/alert-triage-fallback.js";
+
+describe("deterministic alert-triage fallback", () => {
+  test("returns the fixed non-actionable result for every explicit test marker", () => {
+    const markers = [
+      "canary",
+      "test-only",
+      "pipeline test",
+      "test alert",
+      "no action needed",
+    ];
+    for (const marker of markers) {
+      const research = ["source_query: checked"];
+      const result = heuristicTriage({ text: `CRITICAL ${marker.toUpperCase()}` }, research);
+
+      assert.deepEqual(result, {
+        classification: "non_actionable",
+        severity: "informational",
+        confidence: 0.7,
+        shouldRespond: false,
+        responseReason: "The message is an explicit canary/test signal and does not need Cerebro to interrupt the thread.",
+        summary: "The alert text is explicitly marked as a canary or test and says no action is needed. Cerebro graph reasoning was unavailable, so no graph evidence was verified.",
+        evidence: ["Alert text contains a test or canary marker.", "Cerebro graph reasoning was unavailable during fallback."],
+        actionsTaken: ["source query"],
+        recommendedActions: ["No response action is needed for the canary alert.", "Retry Cerebro graph reasoning if this was not intended as a test."],
+        research,
+        source: "cerebro_fallback",
+      }, marker);
+      assert.equal(result.research, research);
+    }
+  });
+
+  test("checks test markers before security terms and preserves word boundaries", () => {
+    assert.equal(
+      heuristicTriage({ text: "Critical credential canary" }, []).classification,
+      "non_actionable",
+    );
+    assert.deepEqual(
+      fallbackDecision("The canarying service passed contest alerts."),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+  });
+
+  test("returns the fixed unverified result for security terms", () => {
+    const research = ["identity_lookup: checked", "ignored note"];
+    const result = heuristicTriage({ text: "Suspicious credential exposure" }, research);
+
+    assert.deepEqual(result, {
+      classification: "needs_context",
+      severity: "medium",
+      confidence: 0.4,
+      shouldRespond: false,
+      responseReason: "Fallback did not verify enough signal to interrupt the thread.",
+      summary: "The alert text contains security-relevant terms, but Cerebro graph reasoning was unavailable. Treat this as unverified until the affected identity, resource, and related findings are checked.",
+      evidence: ["Cerebro graph reasoning was unavailable during fallback.", "No graph evidence was verified for this alert."],
+      actionsTaken: ["identity lookup"],
+      recommendedActions: ["Review the source alert fields.", "Check related Cerebro findings or rerun triage when graph reasoning is available."],
+      research,
+      source: "cerebro_fallback",
+    });
+    assert.equal(result.research, research);
+  });
+
+  test("returns the fixed generic result when no security term is present", () => {
+    const research: string[] = [];
+    const result = heuristicTriage({ text: "Routine service update" }, research);
+
+    assert.deepEqual(result, {
+      classification: "needs_context",
+      severity: "informational",
+      confidence: 0.3,
+      shouldRespond: false,
+      responseReason: "Fallback did not verify enough signal to interrupt the thread.",
+      summary: "Cerebro graph reasoning was unavailable and the alert text does not contain enough verified context for a security classification.",
+      evidence: ["Cerebro graph reasoning was unavailable during fallback.", "No graph evidence was verified for this alert."],
+      actionsTaken: [],
+      recommendedActions: ["Review the source alert fields.", "Check related Cerebro findings or rerun triage when graph reasoning is available."],
+      research,
+      source: "cerebro_fallback",
+    });
+  });
+
+  test("redacts frozen secret forms before selecting the fallback branch", () => {
+    const keyLabel = "PRIVATE KEY";
+    const privateKeyFixture = [
+      `-----BEGIN TEST ${keyLabel}-----`,
+      "canary",
+      `-----END TEST ${keyLabel}-----`,
+    ].join("\n");
+    const awsAccessKeyFixture = ["AKIA", "1234567890ABCDEF"].join("");
+    const slackTokenFixture = ["xoxb", "canary"].join("-");
+
+    assert.deepEqual(
+      fallbackDecision("password=canary"),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+    assert.deepEqual(
+      fallbackDecision("token=canary"),
+      { classification: "needs_context", confidence: 0.4, severity: "medium" },
+    );
+    assert.deepEqual(
+      fallbackDecision(awsAccessKeyFixture),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+    assert.deepEqual(
+      fallbackDecision(privateKeyFixture),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+    assert.deepEqual(
+      fallbackDecision(slackTokenFixture),
+      { classification: "needs_context", confidence: 0.3, severity: "informational" },
+    );
+  });
+});
+
+describe("fallback result helpers", () => {
+  test("extracts checked and fallback research actions in order", () => {
+    assert.deepEqual(actionsFromResearch([
+      "source_query: checked",
+      "ignored note",
+      "PI FALLBACK: local_cache",
+      "middle: CHECKED extra",
+      ": checked",
+      "fallback only",
+    ]), [
+      "source query",
+      "Used fallback path: local cache",
+      "middle: CHECKED extra",
+      "fallback only",
+    ]);
+  });
+
+  test("returns no more than six research actions", () => {
+    const research = Array.from({ length: 8 }, (_, index) => `step_${index}: checked`);
+    assert.deepEqual(actionsFromResearch(research), [
+      "step 0",
+      "step 1",
+      "step 2",
+      "step 3",
+      "step 4",
+      "step 5",
+    ]);
+  });
+
+  test("normalizes error whitespace and caps the result at 160 characters", () => {
+    assert.equal(shortError(new Error("first\n\tsecond   third")), "first second third");
+    assert.equal(shortError({ code: "failed" }), "[object Object]");
+    assert.equal(shortError("x".repeat(200)), "x".repeat(160));
+  });
+
+  test("returns an empty graph summary for no value and truncates after 899 characters", () => {
+    assert.equal(graphSummary(undefined), "");
+    assert.equal(graphSummary("x".repeat(900)), "x".repeat(900));
+    assert.equal(graphSummary("x".repeat(901)), `${"x".repeat(899)}…`);
+  });
+});
+
+function fallbackDecision(text: string) {
+  const result = heuristicTriage({ text }, []);
+  return {
+    classification: result.classification,
+    confidence: result.confidence,
+    severity: result.severity,
+  };
+}


### PR DESCRIPTION
## What changed

Adds a portable fallback classifier for alert triage when graph-backed reasoning is unavailable. It redacts sensitive token and key forms before classification, treats explicit test signals as non-actionable, and keeps unverified security signals in a needs-context state.

The module transforms caller-provided text and research receipts only. Execution, persistence, credentials, transport, and deployment remain host-owned.

## Validation

- Focused fallback tests
- Full Slack companion check
- Workspace check and build
- OSS audit
- Staged leak check
- Practice Registry final gate