### PR TITLE
feat(slack): project bounded ephemeral responses

### DIFF
--- a/apps/slack-companion/src/projections/blocks.ts
+++ b/apps/slack-companion/src/projections/blocks.ts
@@ -61,7 +61,70 @@ export interface SlackBlocksProjectionV1 {
   readonly schema_version: "slack-blocks-projection/v1";
 }
 
+export interface SlackEphemeralResponseInputV1 {
+  readonly actions?: readonly SlackActionInputV1[];
+  readonly fallback_text: string;
+  readonly response_key: string;
+  readonly sections: readonly string[];
+  readonly title?: string;
+}
+
+export interface SlackEphemeralResponsePayloadV1 {
+  readonly blocks: readonly SlackBlockV1[];
+  readonly response_type: "ephemeral";
+  readonly text: string;
+}
+
+export interface SlackEphemeralResponseProjectionV1 {
+  readonly payload: SlackEphemeralResponsePayloadV1;
+  readonly projection_id: string;
+  readonly schema_version: "slack-ephemeral-response-projection/v1";
+}
+
 export class SlackBlockProjectionError extends Error {}
+
+/**
+ * Projects a command response without performing delivery. The private host
+ * owns the callback that submits this bounded payload to Slack.
+ */
+export function projectSlackEphemeralResponse(
+  input: SlackEphemeralResponseInputV1,
+): SlackEphemeralResponseProjectionV1 {
+  requireExactInputRecord(
+    input,
+    ["actions", "fallback_text", "response_key", "sections", "title"],
+    "Slack ephemeral response input",
+  );
+  const responseKey = requireSlackKey(input.response_key, "response key");
+  const fallbackText = normalizeSlackText(
+    input.fallback_text,
+    "response fallback text",
+    MAX_SLACK_SECTION_LENGTH,
+  );
+  const blockProjection = projectSlackBlocks({
+    ...(input.actions === undefined ? {} : { actions: input.actions }),
+    projection_key: responseKey,
+    sections: input.sections,
+    ...(input.title === undefined ? {} : { title: input.title }),
+  });
+  const payload = Object.freeze({
+    blocks: blockProjection.blocks,
+    response_type: "ephemeral" as const,
+    text: fallbackText,
+  });
+  const truth = {
+    payload,
+    schema_version: "slack-ephemeral-response-projection/v1" as const,
+  };
+  return Object.freeze({
+    ...truth,
+    projection_id: contentBoundSlackIdentifier(
+      "ephemeral_response",
+      responseKey,
+      truth,
+    ),
+  });
+}
 
 /**
  * Produces a bounded Block Kit subset. Display values are always plain_text,
@@ -272,4 +335,32 @@ function requireSlackActionKey(value: string): string {
     );
   }
   return normalized;
+}
+
+function requireExactInputRecord(
+  value: object,
+  allowedFields: readonly string[],
+  field: string,
+): void {
+  if (
+    typeof value !== "object"
+    || value === null
+    || Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new SlackBlockProjectionError(`${field} must be a plain record.`);
+  }
+  const allowed = new Set(allowedFields);
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== "string" || !allowed.has(key)) {
+      throw new SlackBlockProjectionError(`${field} contains unsupported fields.`);
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (
+      descriptor === undefined
+      || descriptor.get !== undefined
+      || descriptor.set !== undefined
+    ) {
+      throw new SlackBlockProjectionError(`${field} must contain data fields.`);
+    }
+  }
 }

--- a/apps/slack-companion/test/slack-block-projections.test.ts
+++ b/apps/slack-companion/test/slack-block-projections.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_SLACK_ACTIONS,
   MAX_SLACK_BLOCKS,
   projectSlackBlocks,
+  projectSlackEphemeralResponse,
   SlackBlockProjectionError,
 } from "../src/index.js";
 
@@ -119,5 +120,81 @@ test("block projections reject malformed, duplicate, and oversized input", () =>
   assert.throws(
     () => projectSlackBlocks({ projection_key: "run one", sections: ["Status"] }),
     /must not contain whitespace/,
+  );
+});
+
+test("ephemeral command responses are deterministic bounded projections", () => {
+  const input = {
+    actions: [{
+      action_key: "open_result",
+      label: "Open result",
+      value: "result://run/one",
+    }],
+    fallback_text: "The command completed.",
+    response_key: "command-one:result",
+    sections: ["The command completed for <@U_SAMPLE>."],
+    title: "Command result",
+  };
+
+  const first = projectSlackEphemeralResponse(input);
+  const repeat = projectSlackEphemeralResponse({ ...input });
+
+  assert.deepEqual(repeat, first);
+  assert.deepEqual(first.payload, {
+    blocks: first.payload.blocks,
+    response_type: "ephemeral",
+    text: "The command completed.",
+  });
+  assert.equal(JSON.stringify(first.payload).includes('"type":"mrkdwn"'), false);
+  assert.match(
+    first.projection_id,
+    /^cerebro\.ephemeral_response\.[0-9a-f]{32}:sha256:[0-9a-f]{64}$/,
+  );
+  assert.equal(Object.isFrozen(first), true);
+  assert.equal(Object.isFrozen(first.payload), true);
+  assert.equal(Object.isFrozen(first.payload.blocks), true);
+});
+
+test("ephemeral command responses snapshot input and reject unsafe shapes", () => {
+  const sections = ["Original result"];
+  const projection = projectSlackEphemeralResponse({
+    fallback_text: "Original result",
+    response_key: "command-two:result",
+    sections,
+  });
+  sections[0] = "Changed after projection";
+
+  assert.equal(projection.payload.text, "Original result");
+  assert.equal(projection.payload.blocks[0]?.type, "section");
+  assert.equal(
+    projection.payload.blocks[0]?.type === "section"
+      ? projection.payload.blocks[0].text.text
+      : undefined,
+    "Original result",
+  );
+  assert.throws(
+    () => projectSlackEphemeralResponse({
+      fallback_text: "Unsafe\u0000fallback",
+      response_key: "command-two:unsafe",
+      sections: ["Result"],
+    }),
+    SlackBlockProjectionError,
+  );
+  assert.throws(
+    () => projectSlackEphemeralResponse({
+      fallback_text: "x".repeat(3_001),
+      response_key: "command-two:oversized",
+      sections: ["Result"],
+    }),
+    /response fallback text is invalid/,
+  );
+  assert.throws(
+    () => projectSlackEphemeralResponse({
+      fallback_text: "Result",
+      response_key: "command-two:unexpected",
+      sections: ["Result"],
+      unexpected: true,
+    } as never),
+    /unsupported fields/,
   );
 });


### PR DESCRIPTION
## What changed

Adds a portable projector for bounded ephemeral Slack command responses. It produces inert plain-text blocks and actions, a bounded accessibility fallback, an immutable payload snapshot, and a deterministic content-bound identity.

The projector performs no callback, network, credential, persistence, or deployment work. Delivery remains a host adapter responsibility.

## Validation

- Focused projection tests
- Full Slack companion and workspace checks
- Workspace ownership contract
- OSS audit
- Staged leak scan
- Practice Registry final gate