### PR TITLE
ci: verify portable release provenance

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -375,7 +375,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - name: Build and verify portable Slack companion and SDK archives
+      - name: Build portable Slack companion and SDK archives
         run: |
           set -euo pipefail
           npm ci

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -367,14 +367,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.resolve.outputs.sha }}
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
-      - name: Build portable Slack companion and SDK archives
+      - name: Build and verify portable Slack companion and SDK archives
         run: |
           set -euo pipefail
           npm ci
+          make openapi-check openapi-ts-check agent-service-lifecycle-check
+          npm run check --workspace @writer/cerebro-sdk
+          npm run check --workspace @writer/cerebro-slack-companion
           npm run build --workspace @writer/cerebro-slack-companion
           mkdir -p .dist/product
           npm pack --workspace @writer/cerebro-slack-companion --pack-destination .dist/product
@@ -383,6 +390,14 @@ jobs:
           cp schemas/agent-service-lifecycle.schema.json .dist/product/agent-service-lifecycle.schema.json
           cp schemas/product-release.schema.json .dist/product/product-release.schema.json
           cp schemas/product-release-published.schema.json .dist/product/product-release-published.schema.json
+          slack_archive="$(find .dist/product -maxdepth 1 -type f -name 'writer-cerebro-slack-companion-*.tgz' -print -quit)"
+          sdk_archive="$(find .dist/product -maxdepth 1 -type f -name 'writer-cerebro-sdk-*.tgz' -print -quit)"
+          test -n "${slack_archive}"
+          test -n "${sdk_archive}"
+          python3 scripts/release/verify_portable_artifacts.py \
+            --bundle-root .dist/product \
+            --slack-archive "${slack_archive}" \
+            --sdk-archive "${sdk_archive}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: product-input-${{ needs.resolve.outputs.sha }}

--- a/scripts/release/verify_portable_artifacts.py
+++ b/scripts/release/verify_portable_artifacts.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Verify that portable release archives contain this checkout's exact outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+SDK_PACKAGE = "@writer/cerebro-sdk"
+SLACK_PACKAGE = "@writer/cerebro-slack-companion"
+MAX_ARCHIVE_MEMBERS = 10_000
+MAX_MEMBER_BYTES = 16 * 1024 * 1024
+MAX_PACKAGE_BYTES = 256 * 1024
+
+
+class VerificationError(ValueError):
+    """Raised when a portable artifact does not match the release checkout."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VerificationError(message)
+
+
+def load_json_object(data: bytes, label: str) -> dict[str, Any]:
+    require(len(data) <= MAX_PACKAGE_BYTES, f"{label} is too large")
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise VerificationError(f"{label} is invalid: {exc}") from exc
+    require(isinstance(value, dict), f"{label} must be an object")
+    return value
+
+
+def read_file_tree(root: Path, label: str) -> dict[str, bytes]:
+    require(root.is_dir(), f"{label} directory is missing: {root}")
+    files: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise VerificationError(f"{label} must not contain symbolic links: {path}")
+        if path.is_file():
+            relative = path.relative_to(root).as_posix()
+            data = path.read_bytes()
+            require(len(data) <= MAX_MEMBER_BYTES, f"{label} file is too large: {relative}")
+            files[relative] = data
+    require(files, f"{label} directory has no files")
+    return files
+
+
+def read_archive_tree(
+    archive_path: Path,
+    tree_prefix: str,
+    label: str,
+) -> tuple[dict[str, Any], dict[str, bytes]]:
+    package_data: bytes | None = None
+    files: dict[str, bytes] = {}
+    names: set[str] = set()
+    member_count = 0
+    prefix = f"package/{tree_prefix}/"
+
+    try:
+        with tarfile.open(archive_path, mode="r:gz") as archive:
+            for member in archive:
+                member_count += 1
+                require(member_count <= MAX_ARCHIVE_MEMBERS, f"{label} has too many members")
+                member_path = PurePosixPath(member.name)
+                require(
+                    member.name == member_path.as_posix()
+                    and not member_path.is_absolute()
+                    and ".." not in member_path.parts
+                    and len(member_path.parts) > 1
+                    and member_path.parts[0] == "package",
+                    f"{label} has an unsafe member: {member.name}",
+                )
+                require(member.name not in names, f"{label} has a duplicate member: {member.name}")
+                names.add(member.name)
+                require(
+                    member.isfile() or member.isdir(),
+                    f"{label} member must be a regular file or directory: {member.name}",
+                )
+                if member.isdir():
+                    continue
+                require(member.size <= MAX_MEMBER_BYTES, f"{label} member is too large: {member.name}")
+                if member.name != "package/package.json" and not member.name.startswith(prefix):
+                    continue
+                member_file = archive.extractfile(member)
+                require(member_file is not None, f"{label} member cannot be read: {member.name}")
+                data = member_file.read(MAX_MEMBER_BYTES + 1)
+                require(len(data) <= MAX_MEMBER_BYTES, f"{label} member is too large: {member.name}")
+                if member.name == "package/package.json":
+                    package_data = data
+                else:
+                    files[member.name.removeprefix(prefix)] = data
+    except VerificationError:
+        raise
+    except (OSError, tarfile.TarError) as exc:
+        raise VerificationError(f"{label} is invalid: {exc}") from exc
+
+    require(package_data is not None, f"{label} is missing package/package.json")
+    require(files, f"{label} is missing package/{tree_prefix}")
+    return load_json_object(package_data, f"{label} package metadata"), files
+
+
+def require_same_tree(
+    expected: dict[str, bytes],
+    actual: dict[str, bytes],
+    label: str,
+) -> None:
+    expected_names = set(expected)
+    actual_names = set(actual)
+    missing = sorted(expected_names - actual_names)
+    extra = sorted(actual_names - expected_names)
+    require(not missing, f"{label} is missing files: {', '.join(missing)}")
+    require(not extra, f"{label} has unexpected files: {', '.join(extra)}")
+    changed = sorted(name for name in expected_names if expected[name] != actual[name])
+    require(not changed, f"{label} has changed files: {', '.join(changed)}")
+
+
+def require_bundle_artifact(bundle_root: Path, artifact: Path, label: str) -> Path:
+    resolved = artifact.resolve()
+    try:
+        resolved.relative_to(bundle_root)
+    except ValueError as exc:
+        raise VerificationError(f"{label} must be inside the bundle root") from exc
+    require(resolved.is_file(), f"{label} is missing: {artifact}")
+    return resolved
+
+
+def verify_portable_artifacts(
+    repo: Path,
+    bundle_root: Path,
+    sdk_archive: Path,
+    slack_archive: Path,
+) -> None:
+    repo = repo.resolve()
+    bundle_root = bundle_root.resolve()
+    require(repo.is_dir(), f"repository root is missing: {repo}")
+    require(bundle_root.is_dir(), f"bundle root is missing: {bundle_root}")
+    sdk_archive = require_bundle_artifact(bundle_root, sdk_archive, "SDK archive")
+    slack_archive = require_bundle_artifact(bundle_root, slack_archive, "Slack companion archive")
+
+    contract_pairs = (
+        (repo / "api/openapi.yaml", bundle_root / "cerebro-openapi.yaml", "OpenAPI contract"),
+        (
+            repo / "schemas/agent-service-lifecycle.schema.json",
+            bundle_root / "agent-service-lifecycle.schema.json",
+            "agent service lifecycle contract",
+        ),
+    )
+    for source, bundled, label in contract_pairs:
+        require(source.is_file(), f"canonical {label} is missing: {source}")
+        require(bundled.is_file(), f"bundled {label} is missing: {bundled}")
+        require(source.read_bytes() == bundled.read_bytes(), f"bundled {label} does not match the checkout")
+
+    sdk_manifest, sdk_files = read_archive_tree(sdk_archive, "src", "SDK archive")
+    slack_manifest, slack_files = read_archive_tree(slack_archive, "dist/src", "Slack companion archive")
+    require_same_tree(read_file_tree(repo / "sdk/typescript/src", "SDK source"), sdk_files, "SDK archive")
+    require_same_tree(
+        read_file_tree(repo / "apps/slack-companion/dist/src", "Slack companion build"),
+        slack_files,
+        "Slack companion archive",
+    )
+
+    sdk_checkout = load_json_object((repo / "sdk/typescript/package.json").read_bytes(), "SDK package.json")
+    slack_checkout = load_json_object(
+        (repo / "apps/slack-companion/package.json").read_bytes(),
+        "Slack companion package.json",
+    )
+    sdk_version = sdk_checkout.get("version")
+    slack_version = slack_checkout.get("version")
+    require(sdk_manifest.get("name") == SDK_PACKAGE, "SDK archive has the wrong package name")
+    require(sdk_manifest.get("version") == sdk_version, "SDK archive version does not match the checkout")
+    require(slack_manifest.get("name") == SLACK_PACKAGE, "Slack companion archive has the wrong package name")
+    require(
+        slack_manifest.get("version") == slack_version,
+        "Slack companion archive version does not match the checkout",
+    )
+    dependencies = slack_manifest.get("dependencies")
+    require(isinstance(dependencies, dict), "Slack companion archive dependencies must be an object")
+    require(
+        dependencies.get(SDK_PACKAGE) == sdk_version,
+        "Slack companion archive must depend on the archived SDK version",
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path("."))
+    parser.add_argument("--bundle-root", type=Path, required=True)
+    parser.add_argument("--sdk-archive", type=Path, required=True)
+    parser.add_argument("--slack-archive", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        verify_portable_artifacts(
+            repo=args.repo,
+            bundle_root=args.bundle_root,
+            sdk_archive=args.sdk_archive,
+            slack_archive=args.slack_archive,
+        )
+    except (OSError, VerificationError) as exc:
+        print(f"portable artifact verification failed: {exc}", file=sys.stderr)
+        return 1
+    print("portable release contracts, SDK, and Slack archive match the checkout")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/verify_portable_artifacts.py
+++ b/scripts/release/verify_portable_artifacts.py
@@ -54,14 +54,11 @@ def read_file_tree(root: Path, label: str) -> dict[str, bytes]:
 
 def read_archive_tree(
     archive_path: Path,
-    tree_prefix: str,
     label: str,
-) -> tuple[dict[str, Any], dict[str, bytes]]:
-    package_data: bytes | None = None
+) -> dict[str, bytes]:
     files: dict[str, bytes] = {}
     names: set[str] = set()
     member_count = 0
-    prefix = f"package/{tree_prefix}/"
 
     try:
         with tarfile.open(archive_path, mode="r:gz") as archive:
@@ -86,24 +83,38 @@ def read_archive_tree(
                 if member.isdir():
                     continue
                 require(member.size <= MAX_MEMBER_BYTES, f"{label} member is too large: {member.name}")
-                if member.name != "package/package.json" and not member.name.startswith(prefix):
-                    continue
                 member_file = archive.extractfile(member)
                 require(member_file is not None, f"{label} member cannot be read: {member.name}")
                 data = member_file.read(MAX_MEMBER_BYTES + 1)
                 require(len(data) <= MAX_MEMBER_BYTES, f"{label} member is too large: {member.name}")
-                if member.name == "package/package.json":
-                    package_data = data
-                else:
-                    files[member.name.removeprefix(prefix)] = data
+                relative = PurePosixPath(*member_path.parts[1:]).as_posix()
+                files[relative] = data
     except VerificationError:
         raise
     except (OSError, tarfile.TarError) as exc:
         raise VerificationError(f"{label} is invalid: {exc}") from exc
 
-    require(package_data is not None, f"{label} is missing package/package.json")
-    require(files, f"{label} is missing package/{tree_prefix}")
-    return load_json_object(package_data, f"{label} package metadata"), files
+    require("package.json" in files, f"{label} is missing package/package.json")
+    require(len(files) > 1, f"{label} has no published package content")
+    return files
+
+
+def read_expected_package_tree(
+    package_root: Path,
+    subtrees: tuple[str, ...],
+    label: str,
+) -> dict[str, bytes]:
+    expected: dict[str, bytes] = {}
+    for filename in ("package.json", "README.md"):
+        path = package_root / filename
+        require(path.is_file() and not path.is_symlink(), f"{label} is missing {filename}")
+        data = path.read_bytes()
+        require(len(data) <= MAX_MEMBER_BYTES, f"{label} file is too large: {filename}")
+        expected[filename] = data
+    for subtree in subtrees:
+        for name, data in read_file_tree(package_root / subtree, f"{label} {subtree}").items():
+            expected[f"{subtree}/{name}"] = data
+    return expected
 
 
 def require_same_tree(
@@ -151,26 +162,50 @@ def verify_portable_artifacts(
             bundle_root / "agent-service-lifecycle.schema.json",
             "agent service lifecycle contract",
         ),
+        (
+            repo / "schemas/product-release.schema.json",
+            bundle_root / "product-release.schema.json",
+            "product release contract",
+        ),
+        (
+            repo / "schemas/product-release-published.schema.json",
+            bundle_root / "product-release-published.schema.json",
+            "published product release contract",
+        ),
     )
     for source, bundled, label in contract_pairs:
         require(source.is_file(), f"canonical {label} is missing: {source}")
         require(bundled.is_file(), f"bundled {label} is missing: {bundled}")
         require(source.read_bytes() == bundled.read_bytes(), f"bundled {label} does not match the checkout")
 
-    sdk_manifest, sdk_files = read_archive_tree(sdk_archive, "src", "SDK archive")
-    slack_manifest, slack_files = read_archive_tree(slack_archive, "dist/src", "Slack companion archive")
-    require_same_tree(read_file_tree(repo / "sdk/typescript/src", "SDK source"), sdk_files, "SDK archive")
+    sdk_files = read_archive_tree(sdk_archive, "SDK archive")
+    slack_files = read_archive_tree(slack_archive, "Slack companion archive")
     require_same_tree(
-        read_file_tree(repo / "apps/slack-companion/dist/src", "Slack companion build"),
+        read_expected_package_tree(
+            repo / "sdk/typescript",
+            ("src", "examples"),
+            "SDK package",
+        ),
+        sdk_files,
+        "SDK archive",
+    )
+    require_same_tree(
+        read_expected_package_tree(
+            repo / "apps/slack-companion",
+            ("dist/src",),
+            "Slack companion package",
+        ),
         slack_files,
         "Slack companion archive",
     )
 
-    sdk_checkout = load_json_object((repo / "sdk/typescript/package.json").read_bytes(), "SDK package.json")
-    slack_checkout = load_json_object(
-        (repo / "apps/slack-companion/package.json").read_bytes(),
-        "Slack companion package.json",
+    sdk_manifest = load_json_object(sdk_files["package.json"], "SDK archive package metadata")
+    slack_manifest = load_json_object(
+        slack_files["package.json"],
+        "Slack companion archive package metadata",
     )
+    sdk_checkout = load_json_object(sdk_files["package.json"], "SDK package.json")
+    slack_checkout = load_json_object(slack_files["package.json"], "Slack companion package.json")
     sdk_version = sdk_checkout.get("version")
     slack_version = slack_checkout.get("version")
     require(sdk_manifest.get("name") == SDK_PACKAGE, "SDK archive has the wrong package name")

--- a/scripts/release/verify_portable_artifacts.py
+++ b/scripts/release/verify_portable_artifacts.py
@@ -204,8 +204,14 @@ def verify_portable_artifacts(
         slack_files["package.json"],
         "Slack companion archive package metadata",
     )
-    sdk_checkout = load_json_object(sdk_files["package.json"], "SDK package.json")
-    slack_checkout = load_json_object(slack_files["package.json"], "Slack companion package.json")
+    sdk_checkout = load_json_object(
+        (repo / "sdk/typescript/package.json").read_bytes(),
+        "SDK package.json",
+    )
+    slack_checkout = load_json_object(
+        (repo / "apps/slack-companion/package.json").read_bytes(),
+        "Slack companion package.json",
+    )
     sdk_version = sdk_checkout.get("version")
     slack_version = slack_checkout.get("version")
     require(sdk_manifest.get("name") == SDK_PACKAGE, "SDK archive has the wrong package name")

--- a/scripts/tests/test_verify_portable_artifacts.py
+++ b/scripts/tests/test_verify_portable_artifacts.py
@@ -21,10 +21,14 @@ class PortableArtifactVerificationTests(unittest.TestCase):
 
         self.write("api/openapi.yaml", b"openapi: 3.0.3\n")
         self.write("schemas/agent-service-lifecycle.schema.json", b'{"type":"object"}\n')
+        self.write("schemas/product-release.schema.json", b'{"title":"release"}\n')
+        self.write("schemas/product-release-published.schema.json", b'{"title":"published"}\n')
         self.write_json(
             "sdk/typescript/package.json",
             {"name": "@writer/cerebro-sdk", "version": "0.1.0"},
         )
+        self.write("sdk/typescript/README.md", b"# SDK\n")
+        self.write("sdk/typescript/examples/example.ts", b"export const example = true;\n")
         self.write("sdk/typescript/src/index.ts", b"export type * from './generated/openapi-types.ts';\n")
         self.write("sdk/typescript/src/index.js", b"export {};\n")
         self.write("sdk/typescript/src/generated/openapi-types.ts", b"export type Runtime = {};\n")
@@ -41,6 +45,7 @@ class PortableArtifactVerificationTests(unittest.TestCase):
                 "dependencies": {"@writer/cerebro-sdk": "0.1.0"},
             },
         )
+        self.write("apps/slack-companion/README.md", b"# Slack companion\n")
         self.write("apps/slack-companion/dist/src/index.js", b"export * from './lifecycle.js';\n")
         self.write("apps/slack-companion/dist/src/index.d.ts", b"export * from './lifecycle.js';\n")
         self.write("apps/slack-companion/dist/src/lifecycle.js", b"export const ready = true;\n")
@@ -49,6 +54,12 @@ class PortableArtifactVerificationTests(unittest.TestCase):
         (self.bundle / "cerebro-openapi.yaml").write_bytes((self.repo / "api/openapi.yaml").read_bytes())
         (self.bundle / "agent-service-lifecycle.schema.json").write_bytes(
             (self.repo / "schemas/agent-service-lifecycle.schema.json").read_bytes()
+        )
+        (self.bundle / "product-release.schema.json").write_bytes(
+            (self.repo / "schemas/product-release.schema.json").read_bytes()
+        )
+        (self.bundle / "product-release-published.schema.json").write_bytes(
+            (self.repo / "schemas/product-release-published.schema.json").read_bytes()
         )
         self.write_archives()
 
@@ -73,14 +84,14 @@ class PortableArtifactVerificationTests(unittest.TestCase):
     def write_archive(
         self,
         path: Path,
-        package_manifest: dict[str, object],
+        package_manifest: bytes,
         members: dict[str, bytes],
         *,
         duplicate: str | None = None,
         symbolic_link: str | None = None,
     ) -> None:
         with tarfile.open(path, mode="w:gz") as archive:
-            all_members = {"package/package.json": (json.dumps(package_manifest) + "\n").encode(), **members}
+            all_members = {"package/package.json": package_manifest, **members}
             for name, data in all_members.items():
                 info = tarfile.TarInfo(name)
                 info.size = len(data)
@@ -102,26 +113,34 @@ class PortableArtifactVerificationTests(unittest.TestCase):
         sdk_overrides: dict[str, bytes] | None = None,
         slack_overrides: dict[str, bytes] | None = None,
         sdk_dependency: str = "0.1.0",
+        sdk_manifest_override: bytes | None = None,
+        slack_manifest_override: bytes | None = None,
         duplicate_sdk_member: str | None = None,
         slack_symbolic_link: str | None = None,
     ) -> None:
         sdk_members = self.tree_members(self.repo / "sdk/typescript/src", "package/src")
+        sdk_members.update(self.tree_members(self.repo / "sdk/typescript/examples", "package/examples"))
+        sdk_members["package/README.md"] = (self.repo / "sdk/typescript/README.md").read_bytes()
         sdk_members.update(sdk_overrides or {})
         slack_members = self.tree_members(self.repo / "apps/slack-companion/dist/src", "package/dist/src")
+        slack_members["package/README.md"] = (
+            self.repo / "apps/slack-companion/README.md"
+        ).read_bytes()
         slack_members.update(slack_overrides or {})
+        if sdk_dependency != "0.1.0":
+            manifest = json.loads((self.repo / "apps/slack-companion/package.json").read_text())
+            manifest["dependencies"]["@writer/cerebro-sdk"] = sdk_dependency
+            self.write_json("apps/slack-companion/package.json", manifest)
         self.write_archive(
             self.sdk_archive,
-            {"name": "@writer/cerebro-sdk", "version": "0.1.0"},
+            sdk_manifest_override or (self.repo / "sdk/typescript/package.json").read_bytes(),
             sdk_members,
             duplicate=duplicate_sdk_member,
         )
         self.write_archive(
             self.slack_archive,
-            {
-                "name": "@writer/cerebro-slack-companion",
-                "version": "0.1.0",
-                "dependencies": {"@writer/cerebro-sdk": sdk_dependency},
-            },
+            slack_manifest_override
+            or (self.repo / "apps/slack-companion/package.json").read_bytes(),
             slack_members,
             symbolic_link=slack_symbolic_link,
         )
@@ -137,18 +156,62 @@ class PortableArtifactVerificationTests(unittest.TestCase):
         with self.assertRaisesRegex(VerificationError, "OpenAPI contract does not match"):
             self.verify()
 
+    def test_rejects_unchecked_release_contract_from_another_checkout(self) -> None:
+        (self.bundle / "product-release.schema.json").write_text(
+            '{"title":"tampered"}\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(VerificationError, "product release contract does not match"):
+            self.verify()
+
+    def test_rejects_unchecked_published_contract_from_another_checkout(self) -> None:
+        (self.bundle / "product-release-published.schema.json").write_text(
+            '{"title":"tampered"}\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(
+            VerificationError,
+            "published product release contract does not match",
+        ):
+            self.verify()
+
     def test_rejects_generated_sdk_binding_from_another_checkout(self) -> None:
         self.write_archives(
             sdk_overrides={"package/src/generated/openapi-types.ts": b"export type Runtime = never;\n"}
         )
-        with self.assertRaisesRegex(VerificationError, "SDK archive has changed files: generated/openapi-types.ts"):
+        with self.assertRaisesRegex(
+            VerificationError,
+            "SDK archive has changed files: src/generated/openapi-types.ts",
+        ):
+            self.verify()
+
+    def test_rejects_changed_sdk_example(self) -> None:
+        self.write_archives(
+            sdk_overrides={"package/examples/example.ts": b"export const example = false;\n"}
+        )
+        with self.assertRaisesRegex(VerificationError, "changed files: examples/example.ts"):
+            self.verify()
+
+    def test_rejects_changed_sdk_package_manifest(self) -> None:
+        self.write_archives(
+            sdk_manifest_override=b'{"name":"@writer/cerebro-sdk","version":"0.1.0","exports":{}}\n'
+        )
+        with self.assertRaisesRegex(VerificationError, "changed files: package.json"):
+            self.verify()
+
+    def test_rejects_changed_published_readme(self) -> None:
+        self.write_archives(sdk_overrides={"package/README.md": b"changed\n"})
+        with self.assertRaisesRegex(VerificationError, "changed files: README.md"):
             self.verify()
 
     def test_rejects_stale_slack_companion_build(self) -> None:
         self.write_archives(
             slack_overrides={"package/dist/src/lifecycle.js": b"export const ready = false;\n"}
         )
-        with self.assertRaisesRegex(VerificationError, "Slack companion archive has changed files: lifecycle.js"):
+        with self.assertRaisesRegex(
+            VerificationError,
+            "Slack companion archive has changed files: dist/src/lifecycle.js",
+        ):
             self.verify()
 
     def test_rejects_slack_archive_bound_to_another_sdk_version(self) -> None:

--- a/scripts/tests/test_verify_portable_artifacts.py
+++ b/scripts/tests/test_verify_portable_artifacts.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.release.verify_portable_artifacts import VerificationError, verify_portable_artifacts
+
+
+class PortableArtifactVerificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.repo = self.root / "repo"
+        self.bundle = self.root / "bundle"
+        self.sdk_archive = self.bundle / "writer-cerebro-sdk-0.1.0.tgz"
+        self.slack_archive = self.bundle / "writer-cerebro-slack-companion-0.1.0.tgz"
+
+        self.write("api/openapi.yaml", b"openapi: 3.0.3\n")
+        self.write("schemas/agent-service-lifecycle.schema.json", b'{"type":"object"}\n')
+        self.write_json(
+            "sdk/typescript/package.json",
+            {"name": "@writer/cerebro-sdk", "version": "0.1.0"},
+        )
+        self.write("sdk/typescript/src/index.ts", b"export type * from './generated/openapi-types.ts';\n")
+        self.write("sdk/typescript/src/index.js", b"export {};\n")
+        self.write("sdk/typescript/src/generated/openapi-types.ts", b"export type Runtime = {};\n")
+        self.write("sdk/typescript/src/generated/agent-service-lifecycle.ts", b"export type Event = {};\n")
+        self.write(
+            "sdk/typescript/src/generated/agent-service-lifecycle-contract.ts",
+            b"export type Contract = {};\n",
+        )
+        self.write_json(
+            "apps/slack-companion/package.json",
+            {
+                "name": "@writer/cerebro-slack-companion",
+                "version": "0.1.0",
+                "dependencies": {"@writer/cerebro-sdk": "0.1.0"},
+            },
+        )
+        self.write("apps/slack-companion/dist/src/index.js", b"export * from './lifecycle.js';\n")
+        self.write("apps/slack-companion/dist/src/index.d.ts", b"export * from './lifecycle.js';\n")
+        self.write("apps/slack-companion/dist/src/lifecycle.js", b"export const ready = true;\n")
+
+        self.bundle.mkdir(parents=True)
+        (self.bundle / "cerebro-openapi.yaml").write_bytes((self.repo / "api/openapi.yaml").read_bytes())
+        (self.bundle / "agent-service-lifecycle.schema.json").write_bytes(
+            (self.repo / "schemas/agent-service-lifecycle.schema.json").read_bytes()
+        )
+        self.write_archives()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write(self, relative: str, data: bytes) -> None:
+        path = self.repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+    def write_json(self, relative: str, value: object) -> None:
+        self.write(relative, (json.dumps(value, sort_keys=True) + "\n").encode())
+
+    def tree_members(self, root: Path, archive_prefix: str) -> dict[str, bytes]:
+        return {
+            f"{archive_prefix}/{path.relative_to(root).as_posix()}": path.read_bytes()
+            for path in root.rglob("*")
+            if path.is_file()
+        }
+
+    def write_archive(
+        self,
+        path: Path,
+        package_manifest: dict[str, object],
+        members: dict[str, bytes],
+        *,
+        duplicate: str | None = None,
+        symbolic_link: str | None = None,
+    ) -> None:
+        with tarfile.open(path, mode="w:gz") as archive:
+            all_members = {"package/package.json": (json.dumps(package_manifest) + "\n").encode(), **members}
+            for name, data in all_members.items():
+                info = tarfile.TarInfo(name)
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
+            if duplicate is not None:
+                data = all_members[duplicate]
+                info = tarfile.TarInfo(duplicate)
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
+            if symbolic_link is not None:
+                info = tarfile.TarInfo(symbolic_link)
+                info.type = tarfile.SYMTYPE
+                info.linkname = "package/package.json"
+                archive.addfile(info)
+
+    def write_archives(
+        self,
+        *,
+        sdk_overrides: dict[str, bytes] | None = None,
+        slack_overrides: dict[str, bytes] | None = None,
+        sdk_dependency: str = "0.1.0",
+        duplicate_sdk_member: str | None = None,
+        slack_symbolic_link: str | None = None,
+    ) -> None:
+        sdk_members = self.tree_members(self.repo / "sdk/typescript/src", "package/src")
+        sdk_members.update(sdk_overrides or {})
+        slack_members = self.tree_members(self.repo / "apps/slack-companion/dist/src", "package/dist/src")
+        slack_members.update(slack_overrides or {})
+        self.write_archive(
+            self.sdk_archive,
+            {"name": "@writer/cerebro-sdk", "version": "0.1.0"},
+            sdk_members,
+            duplicate=duplicate_sdk_member,
+        )
+        self.write_archive(
+            self.slack_archive,
+            {
+                "name": "@writer/cerebro-slack-companion",
+                "version": "0.1.0",
+                "dependencies": {"@writer/cerebro-sdk": sdk_dependency},
+            },
+            slack_members,
+            symbolic_link=slack_symbolic_link,
+        )
+
+    def verify(self) -> None:
+        verify_portable_artifacts(self.repo, self.bundle, self.sdk_archive, self.slack_archive)
+
+    def test_accepts_exact_contracts_sdk_and_slack_build(self) -> None:
+        self.verify()
+
+    def test_rejects_bundled_contract_from_another_checkout(self) -> None:
+        (self.bundle / "cerebro-openapi.yaml").write_text("openapi: 3.1.0\n", encoding="utf-8")
+        with self.assertRaisesRegex(VerificationError, "OpenAPI contract does not match"):
+            self.verify()
+
+    def test_rejects_generated_sdk_binding_from_another_checkout(self) -> None:
+        self.write_archives(
+            sdk_overrides={"package/src/generated/openapi-types.ts": b"export type Runtime = never;\n"}
+        )
+        with self.assertRaisesRegex(VerificationError, "SDK archive has changed files: generated/openapi-types.ts"):
+            self.verify()
+
+    def test_rejects_stale_slack_companion_build(self) -> None:
+        self.write_archives(
+            slack_overrides={"package/dist/src/lifecycle.js": b"export const ready = false;\n"}
+        )
+        with self.assertRaisesRegex(VerificationError, "Slack companion archive has changed files: lifecycle.js"):
+            self.verify()
+
+    def test_rejects_slack_archive_bound_to_another_sdk_version(self) -> None:
+        self.write_archives(sdk_dependency="0.2.0")
+        with self.assertRaisesRegex(VerificationError, "must depend on the archived SDK version"):
+            self.verify()
+
+    def test_rejects_duplicate_archive_member(self) -> None:
+        self.write_archives(duplicate_sdk_member="package/src/index.ts")
+        with self.assertRaisesRegex(VerificationError, "duplicate member: package/src/index.ts"):
+            self.verify()
+
+    def test_rejects_non_regular_archive_member(self) -> None:
+        self.write_archives(slack_symbolic_link="package/dist/src/alias.js")
+        with self.assertRaisesRegex(VerificationError, "must be a regular file or directory"):
+            self.verify()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Adds fail-closed verification for the portable inputs assembled by the cut-release job. The verifier compares bundled contracts with the checkout, checks every archived SDK and compiled Slack source byte, validates package identities and exact SDK dependency compatibility, and rejects unsafe or duplicate archive members.

The release job now runs contract generation checks and SDK/Slack consumer checks before verifying the actual npm archives that it uploads.

## Validation

- Real npm pack release flow
- OpenAPI and lifecycle generation checks
- SDK and Slack package checks
- Focused archive tampering tests
- Full release script suite
- Workspace and OSS checks
- Actionlint and staged leak scan
- Practice Registry final gate