### PR TITLE
feat(slack): parse bounded triage output

### DIFF
--- a/apps/slack-companion/src/triage/output.ts
+++ b/apps/slack-companion/src/triage/output.ts
@@ -1,0 +1,334 @@
+import type {
+  AlertTriageClassificationV1,
+  AlertTriageSeverityV1,
+} from "./contracts.js";
+
+const MAX_INPUT_CODE_UNITS = 65_536;
+const MAX_SUMMARY_CODE_POINTS = 900;
+const MAX_REASON_CODE_POINTS = 400;
+const MAX_ITEM_CODE_POINTS = 400;
+const MAX_RESEARCH_CODE_POINTS = 240;
+const MAX_ITEMS = 6;
+const MAX_RESEARCH_ITEMS = 8;
+
+const SLACK_TOKEN_PATTERN = /xox[baprs]-[A-Za-z0-9-]+/g;
+const CLOUD_ACCESS_KEY_PATTERN = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
+const PRIVATE_KEY_PATTERN =
+  /-----BEGIN ([A-Z0-9 ]{1,32}) PRIVATE KEY-----[\s\S]*?-----END \1 PRIVATE KEY-----/g;
+const ASSIGNED_SECRET_PATTERN =
+  /\b(bearer|api[_-]?key|token|secret|password)\b["']?\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)/gi;
+const UNSAFE_CONTROL_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+
+export type TriageAgentTopicV1 =
+  | "security_alert"
+  | "assistant_follow_up"
+  | "operational_update"
+  | "other";
+
+export interface TriageAgentOutputV1 {
+  actions_taken: string[];
+  classification: AlertTriageClassificationV1;
+  confidence: number;
+  evidence: string[];
+  recommended_actions: string[];
+  redaction_state: "redacted";
+  research: string[];
+  response_reason?: string;
+  schema_version: "triage-agent-output/v1";
+  severity?: AlertTriageSeverityV1;
+  should_respond: boolean;
+  summary: string;
+  topic?: TriageAgentTopicV1;
+}
+
+export type TriageOutputRejectionReasonV1 =
+  | "input_too_large"
+  | "json_envelope_invalid"
+  | "json_invalid"
+  | "schema_invalid";
+
+export type TriageOutputParseResultV1 =
+  | {
+      disposition: "accepted";
+      output: TriageAgentOutputV1;
+      schema_version: "triage-output-parse-result/v1";
+    }
+  | {
+      disposition: "rejected";
+      reason_code: TriageOutputRejectionReasonV1;
+      schema_version: "triage-output-parse-result/v1";
+    };
+
+export interface ParseTriageAgentOutputOptionsV1 {
+  research_trail?: readonly string[];
+}
+
+/**
+ * Parse one untrusted agent result into bounded, redacted triage data.
+ *
+ * The returned value is not a durable triage decision. Evidence receipts and
+ * decision identity must still be bound by the triage lifecycle before policy
+ * can plan a suggestion or delivery.
+ */
+export function parseTriageAgentOutput(
+  raw: string,
+  options: ParseTriageAgentOutputOptionsV1 = {},
+): TriageOutputParseResultV1 {
+  if (typeof raw !== "string" || raw.length > MAX_INPUT_CODE_UNITS) {
+    return rejected("input_too_large");
+  }
+
+  const jsonText = unwrapJsonObject(raw);
+  if (jsonText === undefined) return rejected("json_envelope_invalid");
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(jsonText);
+  } catch {
+    return rejected("json_invalid");
+  }
+  if (!isRecord(decoded)) return rejected("schema_invalid");
+
+  const classification = classificationValue(decoded.classification);
+  const confidence = confidenceValue(decoded.confidence);
+  const summary = requiredString(decoded.summary);
+  if (classification === undefined || confidence === undefined || summary === undefined) {
+    return rejected("schema_invalid");
+  }
+
+  const topic = topicValue(decoded.topic);
+  if (decoded.topic !== undefined && topic === undefined) return rejected("schema_invalid");
+  const severity = severityValue(decoded.severity);
+  if (decoded.severity !== undefined && severity === undefined) return rejected("schema_invalid");
+
+  const evidence = stringList(decoded.evidence);
+  const actionsSnake = stringList(decoded.actions_taken);
+  const actionsCamel = stringList(decoded.actionsTaken);
+  const recommendationsSnake = stringList(decoded.recommended_actions);
+  const recommendationsCamel = stringList(decoded.recommendedActions);
+  const research = stringList(decoded.research);
+  if (
+    evidence === undefined ||
+    actionsSnake === undefined ||
+    actionsCamel === undefined ||
+    recommendationsSnake === undefined ||
+    recommendationsCamel === undefined ||
+    research === undefined
+  ) {
+    return rejected("schema_invalid");
+  }
+
+  const responseReason = optionalString(decoded.response_reason ?? decoded.responseReason);
+  if (
+    (decoded.response_reason !== undefined || decoded.responseReason !== undefined) &&
+    responseReason === undefined
+  ) {
+    return rejected("schema_invalid");
+  }
+  const explicitShouldRespond = optionalBoolean(
+    decoded.should_respond ?? decoded.shouldRespond,
+  );
+  if (
+    (decoded.should_respond !== undefined || decoded.shouldRespond !== undefined) &&
+    explicitShouldRespond === undefined
+  ) {
+    return rejected("schema_invalid");
+  }
+
+  const boundedEvidence = boundedList(evidence, MAX_ITEMS, MAX_ITEM_CODE_POINTS);
+  const actions = actionsSnake.length > 0 ? actionsSnake : actionsCamel;
+  const recommendations = recommendationsSnake.length > 0
+    ? recommendationsSnake
+    : recommendationsCamel;
+  const boundedRecommendations = boundedList(
+    recommendations,
+    MAX_ITEMS,
+    MAX_ITEM_CODE_POINTS,
+  );
+  const researchTrail = research.length > 0
+    ? research
+    : stringList(options.research_trail ?? []);
+  if (researchTrail === undefined) return rejected("schema_invalid");
+
+  const output: TriageAgentOutputV1 = {
+    actions_taken: boundedList(actions, MAX_ITEMS, MAX_ITEM_CODE_POINTS),
+    classification,
+    confidence,
+    evidence: boundedEvidence,
+    recommended_actions: boundedRecommendations,
+    redaction_state: "redacted",
+    research: boundedList(
+      researchTrail,
+      MAX_RESEARCH_ITEMS,
+      MAX_RESEARCH_CODE_POINTS,
+    ),
+    schema_version: "triage-agent-output/v1",
+    should_respond: explicitShouldRespond ?? defaultShouldRespond(
+      classification,
+      boundedEvidence,
+      boundedRecommendations,
+    ),
+    summary: boundedText(summary, MAX_SUMMARY_CODE_POINTS),
+    ...(topic === undefined ? {} : { topic }),
+    ...(severity === undefined ? {} : { severity }),
+  };
+  const boundedReason = responseReason === undefined
+    ? ""
+    : boundedText(responseReason, MAX_REASON_CODE_POINTS);
+  if (boundedReason !== "") output.response_reason = boundedReason;
+
+  return {
+    disposition: "accepted",
+    output,
+    schema_version: "triage-output-parse-result/v1",
+  };
+}
+
+function rejected(reasonCode: TriageOutputRejectionReasonV1): TriageOutputParseResultV1 {
+  return {
+    disposition: "rejected",
+    reason_code: reasonCode,
+    schema_version: "triage-output-parse-result/v1",
+  };
+}
+
+function unwrapJsonObject(raw: string): string | undefined {
+  let value = raw.trim();
+  if (value.startsWith("```")) {
+    const match = /^```(?:json)?[ \t]*\r?\n([\s\S]*?)\r?\n```$/i.exec(value);
+    if (match === null) return undefined;
+    value = match[1]?.trim() ?? "";
+  }
+  if (!value.startsWith("{") || !value.endsWith("}")) return undefined;
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function classificationValue(value: unknown): AlertTriageClassificationV1 | undefined {
+  switch (value) {
+    case "actionable":
+    case "likely_security_issue":
+      return "actionable";
+    case "needs_context":
+      return "needs_context";
+    case "non_actionable":
+    case "likely_noise":
+      return "non_actionable";
+    default:
+      return undefined;
+  }
+}
+
+function severityValue(value: unknown): AlertTriageSeverityV1 | undefined {
+  switch (value) {
+    case undefined:
+      return undefined;
+    case "critical":
+    case "high":
+    case "medium":
+    case "low":
+    case "informational":
+      return value;
+    case "info":
+      return "informational";
+    default:
+      return undefined;
+  }
+}
+
+function topicValue(value: unknown): TriageAgentTopicV1 | undefined {
+  switch (value) {
+    case undefined:
+      return undefined;
+    case "security_alert":
+    case "assistant_follow_up":
+    case "operational_update":
+    case "other":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function confidenceValue(value: unknown): number | undefined {
+  const parsed = typeof value === "number"
+    ? value
+    : typeof value === "string" && value.trim() !== ""
+      ? Number(value)
+      : Number.NaN;
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : undefined;
+}
+
+function requiredString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return value === undefined || typeof value === "string" ? value : undefined;
+}
+
+function stringList(value: unknown): string[] | undefined {
+  if (value === undefined || value === null || value === "") return [];
+  if (typeof value === "string") return value.trim() === "" ? [] : [value];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    return undefined;
+  }
+  return value.filter((item) => item.trim() !== "");
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  switch (value.trim().toLowerCase()) {
+    case "true":
+    case "yes":
+    case "1":
+      return true;
+    case "false":
+    case "no":
+    case "0":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+function defaultShouldRespond(
+  classification: AlertTriageClassificationV1,
+  evidence: readonly string[],
+  recommendations: readonly string[],
+): boolean {
+  return classification !== "non_actionable" &&
+    (evidence.length > 0 || recommendations.length > 0);
+}
+
+function boundedList(values: readonly string[], maximum: number, textLimit: number): string[] {
+  return values
+    .map((value) => boundedText(value, textLimit))
+    .filter((value) => value !== "")
+    .slice(0, maximum);
+}
+
+function boundedText(value: string, maximumCodePoints: number): string {
+  const redacted = redactCredentialShapes(value)
+    .replace(UNSAFE_CONTROL_PATTERN, " ")
+    .trim();
+  return [...redacted].slice(0, maximumCodePoints).join("");
+}
+
+function redactCredentialShapes(value: string): string {
+  return value
+    .replace(SLACK_TOKEN_PATTERN, "[redacted_token]")
+    .replace(CLOUD_ACCESS_KEY_PATTERN, "[redacted_access_key]")
+    .replace(PRIVATE_KEY_PATTERN, "[redacted_private_key]")
+    .replace(ASSIGNED_SECRET_PATTERN, "$1=[redacted_secret]");
+}

--- a/apps/slack-companion/src/triage/policy.ts
+++ b/apps/slack-companion/src/triage/policy.ts
@@ -15,6 +15,8 @@ import type {
   TriageSuggestionV1,
 } from "./contracts.js";
 
+export * from "./output.js";
+
 const TRIAGE_TRANSITIONS: Readonly<Record<AlertTriageStateV1, readonly AlertTriageStateV1[]>> = {
   awaiting_evidence: ["investigating", "ready_for_decision", "suppressed"],
   closed: [],

--- a/apps/slack-companion/test/triage-output.test.ts
+++ b/apps/slack-companion/test/triage-output.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { parseTriageAgentOutput } from "../src/index.js";
+
+describe("portable triage output boundary", () => {
+  test("normalizes fenced output, aliases, and fallback research", () => {
+    const result = parseTriageAgentOutput(
+      `\`\`\`json
+{
+  "topic": "assistant_follow_up",
+  "classification": "likely_security_issue",
+  "severity": "info",
+  "confidence": "0.82",
+  "shouldRespond": "yes",
+  "responseReason": "The current evidence needs an owner response.",
+  "summary": "A privileged change needs an accountable owner.",
+  "evidence": "The change has no recorded owner.",
+  "actionsTaken": ["Checked the evidence receipt."],
+  "recommendedActions": ["Confirm the accountable owner."],
+  "research": []
+}
+\`\`\``,
+      { research_trail: ["evidence://sample/current"] },
+    );
+
+    assert.equal(result.disposition, "accepted");
+    if (result.disposition !== "accepted") assert.fail("expected accepted output");
+    assert.deepEqual(result.output, {
+      actions_taken: ["Checked the evidence receipt."],
+      classification: "actionable",
+      confidence: 0.82,
+      evidence: ["The change has no recorded owner."],
+      recommended_actions: ["Confirm the accountable owner."],
+      redaction_state: "redacted",
+      research: ["evidence://sample/current"],
+      response_reason: "The current evidence needs an owner response.",
+      schema_version: "triage-agent-output/v1",
+      severity: "informational",
+      should_respond: true,
+      summary: "A privileged change needs an accountable owner.",
+      topic: "assistant_follow_up",
+    });
+  });
+
+  test("redacts every returned text surface before accepting output", () => {
+    const tokenLike = ["xoxb", "synthetic", "fixture"].join("-");
+    const accessKeyLike = ["AK", "IA", "A".repeat(16)].join("");
+    const assignmentLike = ["password", "=", "synthetic-fixture"].join("");
+    const result = parseTriageAgentOutput(JSON.stringify({
+      actions_taken: [`Removed ${assignmentLike}`],
+      classification: "needs_context",
+      confidence: 0.6,
+      evidence: [`Observed ${tokenLike}`],
+      recommended_actions: [`Rotate ${accessKeyLike}`],
+      research: [`reference ${assignmentLike}`],
+      response_reason: `Review ${tokenLike}`,
+      summary: `Potential exposure: ${tokenLike}`,
+    }));
+
+    assert.equal(result.disposition, "accepted");
+    if (result.disposition !== "accepted") assert.fail("expected accepted output");
+    assert.equal(result.output.redaction_state, "redacted");
+    assert.doesNotMatch(JSON.stringify(result.output), /synthetic-fixture|xoxb-/);
+    assert.match(result.output.summary, /\[redacted_token\]/);
+    assert.match(result.output.actions_taken[0] ?? "", /password=\[redacted_secret\]/);
+    assert.match(result.output.recommended_actions[0] ?? "", /\[redacted_access_key\]/);
+  });
+
+  test("bounds output collections and each text field", () => {
+    const result = parseTriageAgentOutput(JSON.stringify({
+      actions_taken: Array.from({ length: 9 }, (_, index) => `action-${index}-${"a".repeat(500)}`),
+      classification: "actionable",
+      confidence: 1,
+      evidence: Array.from({ length: 9 }, (_, index) => `evidence-${index}`),
+      recommended_actions: Array.from({ length: 9 }, (_, index) => `recommendation-${index}`),
+      research: Array.from({ length: 12 }, (_, index) => `research-${index}`),
+      response_reason: "r".repeat(500),
+      summary: "s".repeat(1_000),
+    }));
+
+    assert.equal(result.disposition, "accepted");
+    if (result.disposition !== "accepted") assert.fail("expected accepted output");
+    assert.equal(result.output.actions_taken.length, 6);
+    assert.equal(result.output.evidence.length, 6);
+    assert.equal(result.output.recommended_actions.length, 6);
+    assert.equal(result.output.research.length, 8);
+    assert.equal(result.output.actions_taken[0]?.length, 400);
+    assert.equal(result.output.response_reason?.length, 400);
+    assert.equal(result.output.summary.length, 900);
+  });
+
+  test("defaults response policy without overriding explicit false", () => {
+    const actionable = parseTriageAgentOutput(JSON.stringify({
+      classification: "actionable",
+      confidence: 0.75,
+      evidence: ["Current evidence exists."],
+      summary: "Review the current evidence.",
+    }));
+    const explicitFalse = parseTriageAgentOutput(JSON.stringify({
+      classification: "actionable",
+      confidence: 0.75,
+      evidence: ["Current evidence exists."],
+      should_respond: false,
+      summary: "Do not post this result.",
+    }));
+    const noise = parseTriageAgentOutput(JSON.stringify({
+      classification: "likely_noise",
+      confidence: 0.9,
+      evidence: ["The event matches the expected baseline."],
+      summary: "No action is needed.",
+    }));
+
+    assert.equal(
+      actionable.disposition === "accepted" && actionable.output.should_respond,
+      true,
+    );
+    assert.equal(
+      explicitFalse.disposition === "accepted" && explicitFalse.output.should_respond,
+      false,
+    );
+    assert.equal(
+      noise.disposition === "accepted" && noise.output.should_respond,
+      false,
+    );
+  });
+
+  test("rejects oversized, ambiguous, malformed, and schema-invalid output", () => {
+    assert.deepEqual(parseTriageAgentOutput("x".repeat(65_537)), {
+      disposition: "rejected",
+      reason_code: "input_too_large",
+      schema_version: "triage-output-parse-result/v1",
+    });
+    assert.equal(
+      parseTriageAgentOutput("preface {\"classification\":\"actionable\"}").disposition,
+      "rejected",
+    );
+    assert.equal(parseTriageAgentOutput("{not-json}").disposition, "rejected");
+    assert.equal(
+      parseTriageAgentOutput(JSON.stringify({
+        classification: "actionable",
+        confidence: 2,
+        evidence: [{}],
+        summary: "Invalid output.",
+      })).disposition,
+      "rejected",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Parse one triage-agent result through a strict JSON boundary.
- Normalize supported aliases and bound every returned text field and list.
- Redact credential-shaped content before returning data.
- Return explicit accepted or rejected receipts while leaving durable lifecycle binding to the caller.

## Why

Triage execution needs a deterministic boundary between untrusted output and durable decision planning.

## Impact

Callers receive bounded, redacted triage data or a stable rejection reason.

## Validation

- 334 Slack companion tests
- Workspace check, including 549 web tests and seven SDK tests
- Public-source and leak audits
- Practice Registry final gate