### PR TITLE
ci: retry candidate manifest inspection

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -205,10 +205,22 @@ jobs:
           IMAGE_BASE: ghcr.io/${{ github.repository }}
           IMAGE_TAG: ${{ needs.resolve.outputs.image_tag }}
         run: |
+          set -euo pipefail
           docker buildx imagetools create -t "${IMAGE_BASE}:${IMAGE_TAG}" \
             "${IMAGE_BASE}:${IMAGE_TAG}-amd64" "${IMAGE_BASE}:${IMAGE_TAG}-arm64"
-          digest="$(docker buildx imagetools inspect "${IMAGE_BASE}:${IMAGE_TAG}" --format '{{.Manifest.Digest}}')"
-          test -n "${digest}"
+          digest=""
+          for attempt in 1 2 3 4 5 6; do
+            if digest="$(docker buildx imagetools inspect "${IMAGE_BASE}:${IMAGE_TAG}" --format '{{.Manifest.Digest}}')" \
+              && [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              break
+            fi
+            digest=""
+            if [ "${attempt}" -eq 6 ]; then
+              echo "ERROR: candidate manifest was not readable after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 2))"
+          done
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
       - name: Set up cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -291,8 +303,19 @@ jobs:
           set -euo pipefail
           docker buildx imagetools create -t "${IMAGE_BASE}:${IMAGE_TAG}" \
             "${IMAGE_BASE}:${IMAGE_TAG}-amd64" "${IMAGE_BASE}:${IMAGE_TAG}-arm64"
-          digest="$(docker buildx imagetools inspect "${IMAGE_BASE}:${IMAGE_TAG}" --format '{{.Manifest.Digest}}')"
-          [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          digest=""
+          for attempt in 1 2 3 4 5 6; do
+            if digest="$(docker buildx imagetools inspect "${IMAGE_BASE}:${IMAGE_TAG}" --format '{{.Manifest.Digest}}')" \
+              && [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              break
+            fi
+            digest=""
+            if [ "${attempt}" -eq 6 ]; then
+              echo "ERROR: candidate web manifest was not readable after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 2))"
+          done
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:

--- a/scripts/tests/test_release_manifest_visibility.py
+++ b/scripts/tests/test_release_manifest_visibility.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CANDIDATE_WORKFLOW = ROOT / ".github" / "workflows" / "cut-release.yml"
+
+
+class ReleaseManifestVisibilityTest(unittest.TestCase):
+    def test_candidate_manifests_retry_registry_visibility(self) -> None:
+        workflow = CANDIDATE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertEqual(workflow.count("for attempt in 1 2 3 4 5 6; do"), 2)
+        self.assertEqual(
+            workflow.count('if digest="$(docker buildx imagetools inspect'),
+            2,
+        )
+        self.assertEqual(workflow.count('sleep "$((attempt * 2))"'), 2)
+        self.assertIn("candidate manifest was not readable", workflow)
+        self.assertIn("candidate web manifest was not readable", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Retry GHCR manifest inspection after publishing runtime and web multi-architecture tags.
- Keep digest validation bounded to six attempts.
- Add a workflow contract test for both candidate manifests.

## Validation

- `actionlint .github/workflows/cut-release.yml`
- `make script-test`