### PR TITLE
ci: verify portable consumer chain

### DIFF
--- a/.github/workflows/portable-consumer-chain.yml
+++ b/.github/workflows/portable-consumer-chain.yml
@@ -1,0 +1,66 @@
+name: Portable Consumer Chain
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/portable-consumer-chain.yml
+      - api/openapi.yaml
+      - schemas/agent-service-lifecycle*.json
+      - schemas/product-release*.json
+      - internal/agentplatform/**
+      - tools/agentlifecyclegen/**
+      - tools/openapitsgen/**
+      - sdk/typescript/**
+      - apps/web/**
+      - apps/slack-companion/**
+      - package.json
+      - package-lock.json
+      - scripts/release/product_release.py
+      - scripts/release/verify_portable_consumer_chain.sh
+      - tools/archtests/portable_consumer_chain_test.go
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/portable-consumer-chain.yml
+      - api/openapi.yaml
+      - schemas/agent-service-lifecycle*.json
+      - schemas/product-release*.json
+      - internal/agentplatform/**
+      - tools/agentlifecyclegen/**
+      - tools/openapitsgen/**
+      - sdk/typescript/**
+      - apps/web/**
+      - apps/slack-companion/**
+      - package.json
+      - package-lock.json
+      - scripts/release/product_release.py
+      - scripts/release/verify_portable_consumer_chain.sh
+      - tools/archtests/portable_consumer_chain_test.go
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  portable-consumer-chain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Verify portable contract consumers and release inputs
+        run: scripts/release/verify_portable_consumer_chain.sh

--- a/scripts/release/verify_portable_consumer_chain.sh
+++ b/scripts/release/verify_portable_consumer_chain.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+commit="${PORTABLE_CHAIN_COMMIT:-$(git rev-parse HEAD)}"
+if ! [[ "${commit}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "portable consumer chain: commit must be a 40-character lowercase Git object ID" >&2
+  exit 1
+fi
+
+bundle_root="$(mktemp -d "${TMPDIR:-/tmp}/cerebro-portable-consumer-chain.XXXXXX")"
+cleanup() {
+  rm -rf "${bundle_root}"
+}
+trap cleanup EXIT
+
+make agent-service-lifecycle-check openapi-check openapi-ts-check
+
+npm ci
+npm run check --workspace @writer/cerebro-sdk
+npm run check --workspace @writer/cerebro-web
+npm run build --workspace @writer/cerebro-web
+npm run check --workspace @writer/cerebro-slack-companion
+npm run build --workspace @writer/cerebro-slack-companion
+
+npm pack --workspace @writer/cerebro-sdk --pack-destination "${bundle_root}"
+npm pack --workspace @writer/cerebro-slack-companion --pack-destination "${bundle_root}"
+cp api/openapi.yaml "${bundle_root}/cerebro-openapi.yaml"
+cp schemas/agent-service-lifecycle.schema.json "${bundle_root}/agent-service-lifecycle.schema.json"
+
+sdk_archive_count="$(find "${bundle_root}" -maxdepth 1 -type f -name 'writer-cerebro-sdk-*.tgz' -print | wc -l | tr -d '[:space:]')"
+slack_archive_count="$(find "${bundle_root}" -maxdepth 1 -type f -name 'writer-cerebro-slack-companion-*.tgz' -print | wc -l | tr -d '[:space:]')"
+if [ "${sdk_archive_count}" -ne 1 ] || [ "${slack_archive_count}" -ne 1 ]; then
+  echo "portable consumer chain: expected exactly one SDK archive and one Slack companion archive" >&2
+  exit 1
+fi
+sdk_archive="$(find "${bundle_root}" -maxdepth 1 -type f -name 'writer-cerebro-sdk-*.tgz' -print -quit)"
+slack_archive="$(find "${bundle_root}" -maxdepth 1 -type f -name 'writer-cerebro-slack-companion-*.tgz' -print -quit)"
+
+version="candidate-${commit}"
+runtime_digest="sha256:$(printf '0%.0s' {1..64})"
+web_digest="sha256:$(printf '1%.0s' {1..64})"
+manifest="${bundle_root}/cerebro-product-release.json"
+
+python3 scripts/release/product_release.py build \
+  --channel candidate \
+  --version "${version}" \
+  --commit "${commit}" \
+  --runtime-image "ghcr.io/example/cerebro:${version}" \
+  --runtime-digest "${runtime_digest}" \
+  --web-image "ghcr.io/example/cerebro-web:${version}" \
+  --web-digest "${web_digest}" \
+  --slack-archive "${slack_archive}" \
+  --slack-version "$(jq -r .version apps/slack-companion/package.json)" \
+  --sdk-archive "${sdk_archive}" \
+  --sdk-version "$(jq -r .version sdk/typescript/package.json)" \
+  --openapi "${bundle_root}/cerebro-openapi.yaml" \
+  --lifecycle-schema "${bundle_root}/agent-service-lifecycle.schema.json" \
+  --bundle-root "${bundle_root}" \
+  --out "${manifest}"
+
+python3 scripts/release/product_release.py validate "${manifest}" --bundle-root "${bundle_root}"

--- a/tools/archtests/portable_consumer_chain_test.go
+++ b/tools/archtests/portable_consumer_chain_test.go
@@ -1,0 +1,74 @@
+package archtests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPortableConsumerChainKeepsDependencyOrder(t *testing.T) {
+	root := repoRoot(t)
+	scriptBody, err := os.ReadFile(filepath.Join(root, "scripts", "release", "verify_portable_consumer_chain.sh"))
+	if err != nil {
+		t.Fatalf("read portable consumer chain: %v", err)
+	}
+	script := string(scriptBody)
+	orderedMarkers := []string{
+		"make agent-service-lifecycle-check openapi-check openapi-ts-check",
+		"npm run check --workspace @writer/cerebro-sdk",
+		"npm run check --workspace @writer/cerebro-web",
+		"npm run build --workspace @writer/cerebro-web",
+		"npm run check --workspace @writer/cerebro-slack-companion",
+		"npm run build --workspace @writer/cerebro-slack-companion",
+		"npm pack --workspace @writer/cerebro-sdk",
+		"npm pack --workspace @writer/cerebro-slack-companion",
+		"python3 scripts/release/product_release.py build",
+		"python3 scripts/release/product_release.py validate",
+	}
+	previous := -1
+	for _, marker := range orderedMarkers {
+		index := strings.Index(script, marker)
+		if index == -1 {
+			t.Fatalf("portable consumer chain missing %q", marker)
+		}
+		if index <= previous {
+			t.Fatalf("portable consumer chain marker %q is out of dependency order", marker)
+		}
+		previous = index
+	}
+
+	workflowBody, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "portable-consumer-chain.yml"))
+	if err != nil {
+		t.Fatalf("read portable consumer workflow: %v", err)
+	}
+	workflow := string(workflowBody)
+	for _, marker := range []string{
+		"api/openapi.yaml",
+		"schemas/agent-service-lifecycle*.json",
+		"internal/agentplatform/**",
+		"sdk/typescript/**",
+		"apps/web/**",
+		"apps/slack-companion/**",
+		"scripts/release/product_release.py",
+		"scripts/release/verify_portable_consumer_chain.sh",
+		"permissions:\n  contents: read",
+	} {
+		if !strings.Contains(workflow, marker) {
+			t.Fatalf("portable consumer workflow missing %q", marker)
+		}
+	}
+	for _, forbidden := range []string{
+		"environment:",
+		"secrets.",
+		"id-token: write",
+		"packages: write",
+		"deploy",
+		"terraform",
+		"pulumi",
+	} {
+		if strings.Contains(strings.ToLower(workflow), forbidden) {
+			t.Fatalf("portable consumer workflow contains operational marker %q", forbidden)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- Add one path-aware CI lane that validates portable contracts and generated bindings first.
- Run SDK, web, and Slack consumers in dependency order.
- Pack the exact SDK and Slack archives and validate a portable product-release manifest.
- Add an architecture test that keeps the workflow ordered and read-only.

## Why

Parallel green jobs do not prove that one exact contract revision can flow through generated bindings, application consumers, release archives, and the release manifest.

## Impact

Changes to public contracts, generated clients, apps, or release inputs now receive one end-to-end compatibility result. The workflow has read-only repository permissions and performs no deployment.

## Validation

- End-to-end portable consumer chain
- 549 web tests and production build
- 329 Slack tests and build
- SDK tests, archive packing, and release-manifest validation
- Full architecture tests, workspace check, release smoke, OSS audit, Actionlint, ShellCheck, and leak check