### PR TITLE
feat(slack): normalize assistant turn output

### DIFF
--- a/apps/slack-companion/src/assistant-turn/contracts.ts
+++ b/apps/slack-companion/src/assistant-turn/contracts.ts
@@ -21,6 +21,34 @@ export const ASSISTANT_TURN_PROGRESS_PHASES = [
 export type AssistantTurnProgressPhaseV1 =
   (typeof ASSISTANT_TURN_PROGRESS_PHASES)[number];
 
+export const ASSISTANT_TURN_OUTPUT_STATES = [
+  "answered",
+  "partial",
+  "needs_input",
+  "blocked",
+] as const;
+
+export type AssistantTurnOutputStateV1 =
+  (typeof ASSISTANT_TURN_OUTPUT_STATES)[number];
+
+/**
+ * User-facing content produced by an assistant turn before Slack projection.
+ * Evidence, tool results, errors, and host metadata stay in their own durable
+ * records rather than crossing this display boundary.
+ */
+export interface AssistantTurnOutputInputV1 {
+  answer?: string;
+  coverage_notice?: string;
+  next_action?: string;
+  question?: string;
+  state: AssistantTurnOutputStateV1;
+}
+
+export interface AssistantTurnOutputV1 extends AssistantTurnOutputInputV1 {
+  content_digest: `sha256:${string}`;
+  schema_version: "assistant-turn-output/v1";
+}
+
 /** Portable execution bounds for one model-selected assistant lane. */
 export interface AssistantTurnBudgetV1 {
   execution_lane: AssistantExecutionLaneV1;

--- a/apps/slack-companion/src/assistant-turn/policy.ts
+++ b/apps/slack-companion/src/assistant-turn/policy.ts
@@ -1,11 +1,34 @@
+import { createHash } from "node:crypto";
 import {
   ASSISTANT_EXECUTION_LANES,
+  ASSISTANT_TURN_OUTPUT_STATES,
   ASSISTANT_TURN_PROGRESS_PHASES,
   type AssistantExecutionLaneV1,
   type AssistantTurnBudgetV1,
+  type AssistantTurnOutputInputV1,
+  type AssistantTurnOutputStateV1,
+  type AssistantTurnOutputV1,
   type AssistantTurnProgressInput,
   type AssistantTurnProgressV1,
 } from "./contracts.js";
+
+export const MAX_ASSISTANT_TURN_ANSWER_LENGTH = 12_000;
+export const MAX_ASSISTANT_TURN_OUTPUT_LENGTH = 12_800;
+
+const OUTPUT_TEXT_LIMITS = {
+  answer: MAX_ASSISTANT_TURN_ANSWER_LENGTH,
+  coverage_notice: 600,
+  next_action: 600,
+  question: 600,
+} as const;
+
+const OUTPUT_FIELDS = [
+  "answer",
+  "coverage_notice",
+  "next_action",
+  "question",
+  "state",
+] as const;
 
 const TURN_BUDGETS: Record<AssistantExecutionLaneV1, Omit<AssistantTurnBudgetV1, "schema_version" | "execution_lane">> = {
   ignore: { latency_budget_ms: 5_000, max_selected_capabilities: 0, max_tool_calls: 0 },
@@ -65,6 +88,163 @@ export function normalizeAssistantTurnProgress(
     sequence: input.sequence,
     status,
   };
+}
+
+/**
+ * Validates the exact user-facing output shape before it reaches a transport
+ * projector. The state rules prevent partial or blocked work from being labeled
+ * answered and keep non-display records out of the payload.
+ */
+export function normalizeAssistantTurnOutput(
+  value: unknown,
+): AssistantTurnOutputV1 {
+  const input = requireOutputObject(value);
+  requireExactOutputFields(input);
+  const state = requireOutputState(ownOutputField(input, "state"));
+  const answer = optionalOutputText(ownOutputField(input, "answer"), "answer");
+  const coverageNotice = optionalOutputText(
+    ownOutputField(input, "coverage_notice"),
+    "coverage_notice",
+  );
+  const nextAction = optionalOutputText(
+    ownOutputField(input, "next_action"),
+    "next_action",
+  );
+  const question = optionalOutputText(
+    ownOutputField(input, "question"),
+    "question",
+  );
+
+  validateOutputState(state, {
+    answer,
+    coverage_notice: coverageNotice,
+    next_action: nextAction,
+    question,
+  });
+  const outputLength = [answer, coverageNotice, nextAction, question]
+    .reduce((total, field) => total + codePointLength(field), 0);
+  if (outputLength > MAX_ASSISTANT_TURN_OUTPUT_LENGTH) {
+    throw new AssistantTurnInputError("Assistant output exceeds its total text bound.");
+  }
+
+  const content = {
+    ...(answer === undefined ? {} : { answer }),
+    ...(coverageNotice === undefined ? {} : { coverage_notice: coverageNotice }),
+    ...(nextAction === undefined ? {} : { next_action: nextAction }),
+    ...(question === undefined ? {} : { question }),
+    schema_version: "assistant-turn-output/v1" as const,
+    state,
+  };
+  return Object.freeze({
+    ...content,
+    content_digest: `sha256:${createHash("sha256")
+      .update(JSON.stringify(content), "utf8")
+      .digest("hex")}`,
+  });
+}
+
+function requireOutputObject(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new AssistantTurnInputError("Assistant output must be a plain object.");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new AssistantTurnInputError("Assistant output must be a plain object.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireExactOutputFields(input: Record<string, unknown>): void {
+  const allowed = new Set<string>(OUTPUT_FIELDS);
+  if (Object.keys(input).some((field) => !allowed.has(field))) {
+    throw new AssistantTurnInputError("Assistant output contains an unsupported field.");
+  }
+}
+
+function ownOutputField(
+  input: Record<string, unknown>,
+  field: (typeof OUTPUT_FIELDS)[number],
+): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(input, field);
+  if (descriptor === undefined) return undefined;
+  if (!("value" in descriptor)) {
+    throw new AssistantTurnInputError("Assistant output fields must be data fields.");
+  }
+  return descriptor.value;
+}
+
+function requireOutputState(value: unknown): AssistantTurnOutputStateV1 {
+  if (
+    typeof value !== "string"
+    || !ASSISTANT_TURN_OUTPUT_STATES.includes(value as AssistantTurnOutputStateV1)
+  ) {
+    throw new AssistantTurnInputError("The assistant output state is unsupported.");
+  }
+  return value as AssistantTurnOutputStateV1;
+}
+
+function optionalOutputText(
+  value: unknown,
+  field: keyof typeof OUTPUT_TEXT_LIMITS,
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new AssistantTurnInputError(`Assistant output ${field} must be text.`);
+  }
+  const normalized = value
+    .replace(/\r\n?/g, "\n")
+    .normalize("NFC")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+  if (
+    normalized.length === 0
+    || normalized.length > OUTPUT_TEXT_LIMITS[field] * 2
+    || codePointLength(normalized) > OUTPUT_TEXT_LIMITS[field]
+    || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(normalized)
+  ) {
+    throw new AssistantTurnInputError(`Assistant output ${field} is invalid.`);
+  }
+  return normalized;
+}
+
+function validateOutputState(
+  state: AssistantTurnOutputStateV1,
+  fields: Omit<AssistantTurnOutputInputV1, "state">,
+): void {
+  const { answer, coverage_notice: coverageNotice, next_action: nextAction, question } = fields;
+  if (state === "answered" && (answer === undefined || question !== undefined)) {
+    throw new AssistantTurnInputError("An answered output requires an answer and cannot ask a question.");
+  }
+  if (
+    state === "partial"
+    && (answer === undefined || coverageNotice === undefined || question !== undefined)
+  ) {
+    throw new AssistantTurnInputError(
+      "A partial output requires an answer and coverage notice and cannot ask a question.",
+    );
+  }
+  if (
+    state === "needs_input"
+    && (question === undefined || answer !== undefined || nextAction !== undefined)
+  ) {
+    throw new AssistantTurnInputError(
+      "A needs-input output requires one question and cannot include an answer or next action.",
+    );
+  }
+  if (
+    state === "blocked"
+    && (coverageNotice === undefined || answer !== undefined || question !== undefined)
+  ) {
+    throw new AssistantTurnInputError(
+      "A blocked output requires a coverage notice and cannot include an answer or question.",
+    );
+  }
+}
+
+function codePointLength(value: string | undefined): number {
+  return value === undefined ? 0 : Array.from(value).length;
 }
 
 function boundedLimit(configured: number | undefined, policy: number): number {

--- a/apps/slack-companion/test/assistant-turn.test.ts
+++ b/apps/slack-companion/test/assistant-turn.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   AssistantTurnInputError,
+  MAX_ASSISTANT_TURN_ANSWER_LENGTH,
   assistantTurnBudget,
+  normalizeAssistantTurnOutput,
   normalizeAssistantTurnProgress,
 } from "../src/index.js";
 
@@ -48,5 +50,134 @@ test("assistant progress is concrete, bounded, and safe to persist", () => {
   assert.throws(
     () => normalizeAssistantTurnProgress({ occurred_at: "bad", phase: "checking", sequence: 1, status: "Checking GitHub" }),
     AssistantTurnInputError,
+  );
+});
+
+test("assistant output normalizes deterministic user-facing answer content", () => {
+  const first = normalizeAssistantTurnOutput({
+    answer: "  First line\r\nSecond line  ",
+    next_action: "  Check the remaining item.  ",
+    state: "answered",
+  });
+  const replay = normalizeAssistantTurnOutput({
+    answer: "First line\nSecond line",
+    next_action: "Check the remaining item.",
+    state: "answered",
+  });
+
+  assert.deepEqual(first, replay);
+  assert.deepEqual(first, {
+    answer: "First line\nSecond line",
+    content_digest: first.content_digest,
+    next_action: "Check the remaining item.",
+    schema_version: "assistant-turn-output/v1",
+    state: "answered",
+  });
+  assert.match(first.content_digest, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(Object.isFrozen(first), true);
+});
+
+test("assistant output represents partial, input-required, and blocked truth explicitly", () => {
+  assert.deepEqual(
+    normalizeAssistantTurnOutput({
+      answer: "Two records matched.",
+      coverage_notice: "One source did not respond.",
+      state: "partial",
+    }).state,
+    "partial",
+  );
+  assert.deepEqual(
+    normalizeAssistantTurnOutput({
+      coverage_notice: "I can check either workspace.",
+      question: "Which workspace should I check?",
+      state: "needs_input",
+    }).state,
+    "needs_input",
+  );
+  assert.deepEqual(
+    normalizeAssistantTurnOutput({
+      coverage_notice: "The required source is unavailable.",
+      next_action: "Retry after the source recovers.",
+      state: "blocked",
+    }).state,
+    "blocked",
+  );
+});
+
+test("assistant output fails closed on invalid state combinations and extra records", () => {
+  assert.throws(
+    () => normalizeAssistantTurnOutput({ state: "answered" }),
+    /requires an answer/,
+  );
+  assert.throws(
+    () => normalizeAssistantTurnOutput({ answer: "Done.", state: "partial" }),
+    /coverage notice/,
+  );
+  assert.throws(
+    () => normalizeAssistantTurnOutput({
+      answer: "Done.",
+      question: "Continue?",
+      state: "needs_input",
+    }),
+    /cannot include an answer/,
+  );
+  assert.throws(
+    () => normalizeAssistantTurnOutput({
+      coverage_notice: "Unavailable.",
+      raw_result: { record: "not display content" },
+      state: "blocked",
+    }),
+    /unsupported field/,
+  );
+  assert.throws(
+    () => normalizeAssistantTurnOutput(new (class Output { state = "answered"; })()),
+    /plain object/,
+  );
+  let accessorCalled = false;
+  const accessorOutput: Record<string, unknown> = { answer: "Done." };
+  Object.defineProperty(accessorOutput, "state", {
+    enumerable: true,
+    get: () => {
+      accessorCalled = true;
+      return "answered";
+    },
+  });
+  assert.throws(
+    () => normalizeAssistantTurnOutput(accessorOutput),
+    /data fields/,
+  );
+  assert.equal(accessorCalled, false);
+});
+
+test("assistant output enforces code-point and control-character bounds", () => {
+  assert.equal(
+    normalizeAssistantTurnOutput({
+      answer: "🙂".repeat(MAX_ASSISTANT_TURN_ANSWER_LENGTH),
+      state: "answered",
+    }).answer?.length,
+    MAX_ASSISTANT_TURN_ANSWER_LENGTH * 2,
+  );
+  assert.throws(
+    () => normalizeAssistantTurnOutput({
+      answer: "🙂".repeat(MAX_ASSISTANT_TURN_ANSWER_LENGTH + 1),
+      state: "answered",
+    }),
+    /answer is invalid/,
+  );
+  assert.throws(
+    () => normalizeAssistantTurnOutput({
+      answer: "Visible\u0000hidden",
+      state: "answered",
+    }),
+    /answer is invalid/,
+  );
+  assert.throws(
+    () => normalizeAssistantTurnOutput({
+      answer: "a".repeat(MAX_ASSISTANT_TURN_ANSWER_LENGTH),
+      coverage_notice: "c".repeat(600),
+      next_action: "n".repeat(600),
+      state: "partial",
+    }),
+    /total text bound/,
   );
 });


### PR DESCRIPTION
## What changed

- Add a versioned output record for answered, partial, needs-input, and blocked assistant turns.
- Enforce state-coherent required and prohibited fields.
- Normalize and bound every display field before Slack projection.
- Reject accessors, unknown fields, unsafe controls, and non-plain values.
- Bind accepted output to a stable content digest.

## Why

Assistant execution needs one deterministic display boundary so incomplete or blocked work cannot be presented as a complete answer.

## Impact

Transport adapters receive a frozen, bounded output record or an explicit validation failure. Durable evidence, errors, persistence, and delivery remain outside this public record.

## Validation

- Seven focused output tests
- 333 Slack companion tests
- Workspace check, including 549 web tests and seven SDK tests
- OSS, workspace ownership, tenant-data, and secret scans
- Practice Registry final gate