### PR TITLE
feat(slack): add portable agent fleet protocol

### DIFF
--- a/apps/slack-companion/src/fleet/contracts.ts
+++ b/apps/slack-companion/src/fleet/contracts.ts
@@ -1,0 +1,183 @@
+import type {
+  CapabilityCompatibilityDecision,
+  CapabilityManifestV1,
+  CheckpointV1,
+  SchemaCompatibility,
+  ServiceAvailabilityState,
+  WorkLeaseV1,
+} from "@writer/cerebro-sdk";
+import type { DistributedWorkPacketV1 } from "../distributed/contracts.js";
+import type { CapacityPermitV1 } from "../execution/capacity.js";
+
+export type {
+  CapabilityCompatibilityDecision,
+  CapabilityManifestV1,
+  CapacityPermitV1,
+  CheckpointV1,
+  DistributedWorkPacketV1,
+  SchemaCompatibility,
+  WorkLeaseV1,
+};
+
+export const AGENT_FLEET_PROTOCOL_VERSION = "agent-fleet/v1" as const;
+export const AGENT_FLEET_MEMBER_SCHEMA_VERSION =
+  "agent-fleet-member/v1" as const;
+export const AGENT_FLEET_MESSAGE_SCHEMA_VERSION =
+  "agent-fleet-message/v1" as const;
+export const AGENT_FLEET_ADMISSION_RECEIPT_SCHEMA_VERSION =
+  "agent-fleet-admission-receipt/v1" as const;
+export const AGENT_FLEET_EXECUTION_BINDING_SCHEMA_VERSION =
+  "agent-fleet-execution-binding/v1" as const;
+
+export const MAX_AGENT_FLEET_PAYLOAD_BYTES = 65_536;
+export const MAX_AGENT_FLEET_MEMBERS = 1_024;
+
+/**
+ * Fleet membership projects the portable service lifecycle. `retired` is the
+ * permanent terminal projection of a retired deployment generation.
+ */
+export type AgentFleetMemberState =
+  | Extract<
+      ServiceAvailabilityState,
+      "ready" | "degraded" | "draining" | "offline" | "recovering"
+    >
+  | "retired";
+
+/**
+ * One addressable worker generation. It contains no route, credential,
+ * infrastructure, or provider configuration.
+ */
+export interface AgentFleetMemberV1 {
+  capability_manifest: CapabilityManifestV1;
+  capacity_resource_ref: string;
+  generation: number;
+  member_id: string;
+  protocol_version: typeof AGENT_FLEET_PROTOCOL_VERSION;
+  registered_at: string;
+  revision: number;
+  schema_compatibility: SchemaCompatibility;
+  schema_version: typeof AGENT_FLEET_MEMBER_SCHEMA_VERSION;
+  service_id: string;
+  state: AgentFleetMemberState;
+  updated_at: string;
+  valid_until: string;
+}
+
+/** A logical content-addressed reference to already-redacted message input. */
+export interface AgentFleetPayloadReferenceV1 {
+  byte_length: number;
+  media_type: "application/json" | "text/plain";
+  payload_digest: string;
+  payload_ref: string;
+  redaction_receipt_digest: string;
+  redaction_receipt_ref: string;
+}
+
+/** Resume material is referenced, never copied into a mailbox message. */
+export interface AgentFleetResumeReferenceV1 {
+  checkpoint_digest: string;
+  checkpoint_ref: string;
+  handoff_digest: string;
+  handoff_ref: string;
+}
+
+export interface AgentFleetMessageIdentityInput {
+  created_at: string;
+  idempotency_key: string;
+  message_sequence: number;
+  packet_id: string;
+  payload: AgentFleetPayloadReferenceV1;
+  protocol_version: typeof AGENT_FLEET_PROTOCOL_VERSION;
+  resume?: AgentFleetResumeReferenceV1;
+  run_id: string;
+  sender_generation: number;
+  sender_member_id: string;
+}
+
+/**
+ * Immutable mailbox input tied to the canonical distributed-work packet and
+ * child run. Execution state remains on RunReceiptV1 and WorkLeaseV1.
+ */
+export interface AgentFleetMessageV1 extends AgentFleetMessageIdentityInput {
+  message_id: string;
+  schema_version: typeof AGENT_FLEET_MESSAGE_SCHEMA_VERSION;
+}
+
+/** Committed proof that allows the caller to acknowledge its input transport. */
+export interface AgentFleetAdmissionReceiptV1 {
+  admitted_at: string;
+  idempotency_key: string;
+  message_id: string;
+  packet_id: string;
+  payload_digest: string;
+  receipt_id: string;
+  run_id: string;
+  schema_version: typeof AGENT_FLEET_ADMISSION_RECEIPT_SCHEMA_VERSION;
+}
+
+export interface AgentFleetPeerCompatibility {
+  decision: CapabilityCompatibilityDecision;
+  member_id: string;
+  negotiated_write_version?: string;
+  reasons: string[];
+}
+
+export interface AgentFleetPeerCandidate {
+  compatibility: AgentFleetPeerCompatibility;
+  member: AgentFleetMemberV1;
+  rank: string;
+}
+
+export interface AgentFleetPeerRejection {
+  member_id: string;
+  reasons: string[];
+}
+
+export interface AgentFleetPeerRanking {
+  compatible: AgentFleetPeerCandidate[];
+  rejected: AgentFleetPeerRejection[];
+}
+
+export type AgentFleetCapacityAttempt =
+  | {
+      member_id: string;
+      reason: "capacity" | "cooldown" | "reconciliation_required";
+      status: "unavailable";
+    }
+  | {
+      member_id: string;
+      permit: CapacityPermitV1;
+      replayed: boolean;
+      status: "acquired";
+    };
+
+export type AgentFleetReservationResult =
+  | {
+      attempts: AgentFleetCapacityAttempt[];
+      candidate: AgentFleetPeerCandidate;
+      permit: CapacityPermitV1;
+      status: "reserved";
+    }
+  | {
+      attempts: AgentFleetCapacityAttempt[];
+      ranking: AgentFleetPeerRanking;
+      status: "unavailable";
+    };
+
+/**
+ * Fenced proof that a selected member may execute one mailbox message. It is a
+ * binding receipt over existing lease, capacity, and checkpoint records.
+ */
+export interface AgentFleetExecutionBindingV1 {
+  bound_at: string;
+  capacity_permit_id: string;
+  checkpoint_ref?: string;
+  fencing_token: number;
+  generation: number;
+  handoff_ref?: string;
+  lease_ref: string;
+  member_id: string;
+  message_id: string;
+  run_id: string;
+  schema_version: typeof AGENT_FLEET_EXECUTION_BINDING_SCHEMA_VERSION;
+}

--- a/apps/slack-companion/src/fleet/coordinator.ts
+++ b/apps/slack-companion/src/fleet/coordinator.ts
@@ -1,0 +1,253 @@
+import { createHash } from "node:crypto";
+import type { DurableCapacityPort } from "../execution/capacity-ports.js";
+import type {
+  AgentFleetAdmissionReceiptV1,
+  AgentFleetCapacityAttempt,
+  AgentFleetExecutionBindingV1,
+  AgentFleetMessageV1,
+  AgentFleetReservationResult,
+  CapacityPermitV1,
+  CheckpointV1,
+  DistributedWorkPacketV1,
+  WorkLeaseV1,
+} from "./contracts.js";
+import type { DurableAgentFleetPort } from "./ports.js";
+import {
+  rankCompatibleAgentFleetPeers,
+} from "./selection.js";
+import {
+  AgentFleetContractError,
+  createAgentFleetExecutionBinding,
+  validateAgentFleetAdmissionReceipt,
+  validateAgentFleetMessageForPacket,
+} from "./validation.js";
+
+export interface AgentFleetCoordinatorOptions {
+  capacity: DurableCapacityPort;
+  fleet: DurableAgentFleetPort;
+}
+
+export interface AgentFleetMailboxAcknowledgement {
+  acknowledgement_permitted: true;
+  duplicate: boolean;
+  message: AgentFleetMessageV1;
+  receipt: AgentFleetAdmissionReceiptV1;
+  run_id: string;
+}
+
+export interface AgentFleetReservationInput {
+  acquired_at: string;
+  expires_at: string;
+  permit_limits: Readonly<Record<string, number>>;
+  reservation_key: string;
+}
+
+export interface AgentFleetExecutionBindingInput {
+  bound_at: string;
+  checkpoint?: CheckpointV1;
+  lease: WorkLeaseV1;
+  member_id: string;
+  message_id: string;
+  permit: CapacityPermitV1;
+}
+
+/**
+ * Portable fleet ordering only. Discovery, persistence engines, timers,
+ * credentials, transport acknowledgement, and deployment placement are ports.
+ */
+export class AgentFleetCoordinator {
+  private readonly capacity: DurableCapacityPort;
+  private readonly fleet: DurableAgentFleetPort;
+
+  constructor(options: AgentFleetCoordinatorOptions) {
+    this.capacity = options.capacity;
+    this.fleet = options.fleet;
+  }
+
+  /** The caller may acknowledge its transport only after this method returns. */
+  async admit(
+    message: AgentFleetMessageV1,
+    packet: DistributedWorkPacketV1,
+  ): Promise<AgentFleetMailboxAcknowledgement> {
+    validateAgentFleetMessageForPacket(message, packet);
+    const committed = await this.fleet.admitMailboxAndEnqueue({
+      message,
+      packet,
+    });
+    validateAgentFleetAdmissionReceipt(
+      committed.receipt,
+      committed.message,
+      committed.packet,
+    );
+    if (
+      committed.message.message_id !== message.message_id ||
+      committed.packet.packet_id !== packet.packet_id
+    ) {
+      throw new AgentFleetCoordinatorError(
+        "durable admission returned different mailbox input",
+      );
+    }
+    return {
+      acknowledgement_permitted: true,
+      duplicate: !committed.created,
+      message: committed.message,
+      receipt: committed.receipt,
+      run_id: committed.packet.child_run.run_id,
+    };
+  }
+
+  /**
+   * Ranks compatible peers, then acquires the existing durable capacity permit
+   * for the first available candidate. Exact retries replay the same permits.
+   */
+  async reserveCompatiblePeer(
+    messageId: string,
+    input: AgentFleetReservationInput,
+  ): Promise<AgentFleetReservationResult> {
+    requireBoundedOpaque(input.reservation_key, "reservation_key");
+    requireCanonicalTime(input.acquired_at, "acquired_at");
+    requireCanonicalTime(input.expires_at, "expires_at");
+    if (Date.parse(input.expires_at) <= Date.parse(input.acquired_at)) {
+      throw new AgentFleetCoordinatorError("capacity expiry must follow acquisition");
+    }
+
+    const context = await this.requireMessageContext(messageId);
+    const ranking = rankCompatibleAgentFleetPeers({
+      candidates: context.members,
+      message: context.message,
+      observed_at: input.acquired_at,
+      packet: context.packet,
+      sender: context.sender,
+    });
+    const attempts: AgentFleetCapacityAttempt[] = [];
+    for (const candidate of ranking.compatible) {
+      const permitLimit = input.permit_limits[candidate.member.member_id];
+      if (!Number.isSafeInteger(permitLimit) || (permitLimit ?? 0) < 1) {
+        throw new AgentFleetCoordinatorError(
+          "every compatible member requires a positive capacity policy",
+        );
+      }
+      const identity = reservationIdentity(
+        input.reservation_key,
+        context.message.message_id,
+        candidate.member.member_id,
+      );
+      const acquired = await this.capacity.acquire({
+        acquired_at: input.acquired_at,
+        acquisition_key: `agent-fleet-capacity-acquisition://${identity}`,
+        expires_at: input.expires_at,
+        generation: candidate.member.generation,
+        owner_id: candidate.member.member_id,
+        permit_id: `agent-fleet-capacity-permit://${identity}`,
+        permit_limit: permitLimit!,
+        resource_ref: candidate.member.capacity_resource_ref,
+        run_id: context.packet.child_run.run_id,
+      });
+      if (acquired.status === "unavailable") {
+        attempts.push({
+          member_id: candidate.member.member_id,
+          reason: acquired.reason,
+          status: "unavailable",
+        });
+        continue;
+      }
+      attempts.push({
+        member_id: candidate.member.member_id,
+        permit: acquired.permit,
+        replayed: acquired.replayed,
+        status: "acquired",
+      });
+      return {
+        attempts,
+        candidate,
+        permit: acquired.permit,
+        status: "reserved",
+      };
+    }
+    return { attempts, ranking, status: "unavailable" };
+  }
+
+  /** Binds current lease, capacity, and optional checkpoint proofs. */
+  async bindExecution(
+    input: AgentFleetExecutionBindingInput,
+  ): Promise<AgentFleetExecutionBindingV1> {
+    const context = await this.requireMessageContext(input.message_id);
+    const member = await this.fleet.readMember(input.member_id);
+    if (member === undefined) {
+      throw new AgentFleetCoordinatorError("execution member is not registered");
+    }
+    return createAgentFleetExecutionBinding({
+      bound_at: input.bound_at,
+      checkpoint: input.checkpoint,
+      lease: input.lease,
+      member,
+      message: context.message,
+      packet: context.packet,
+      permit: input.permit,
+    });
+  }
+
+  private async requireMessageContext(messageId: string): Promise<{
+    members: Awaited<ReturnType<DurableAgentFleetPort["listMembers"]>>;
+    message: AgentFleetMessageV1;
+    packet: DistributedWorkPacketV1;
+    sender: Awaited<ReturnType<DurableAgentFleetPort["readMember"]>> & object;
+  }> {
+    const message = await this.fleet.readMailboxMessage(messageId);
+    if (message === undefined) {
+      throw new AgentFleetCoordinatorError("mailbox message is not admitted");
+    }
+    const packet = await this.fleet.readPacket(message.packet_id);
+    const receipt = await this.fleet.readMailboxAdmissionReceipt(messageId);
+    const sender = await this.fleet.readMember(message.sender_member_id);
+    if (packet === undefined || receipt === undefined || sender === undefined) {
+      throw new AgentFleetCoordinatorError(
+        "mailbox message is missing durable admission context",
+      );
+    }
+    validateAgentFleetAdmissionReceipt(receipt, message, packet);
+    return {
+      members: await this.fleet.listMembers(),
+      message,
+      packet,
+      sender,
+    };
+  }
+}
+
+export class AgentFleetCoordinatorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentFleetCoordinatorError";
+  }
+}
+
+function reservationIdentity(
+  reservationKey: string,
+  messageId: string,
+  memberId: string,
+): string {
+  return createHash("sha256")
+    .update(`${reservationKey}\u0000${messageId}\u0000${memberId}`)
+    .digest("hex");
+}
+
+function requireBoundedOpaque(value: string, field: string): void {
+  if (
+    value.length < 1 ||
+    value.length > 256 ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    throw new AgentFleetContractError(`${field} must be a bounded opaque value`);
+  }
+}
+
+function requireCanonicalTime(value: string, field: string): void {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== value) {
+    throw new AgentFleetCoordinatorError(
+      `${field} must be a canonical ISO-8601 timestamp`,
+    );
+  }
+}

--- a/apps/slack-companion/src/fleet/index.ts
+++ b/apps/slack-companion/src/fleet/index.ts
@@ -1,0 +1,6 @@
+export * from "./contracts.js";
+export * from "./coordinator.js";
+export * from "./ports.js";
+export * from "./reference-store.js";
+export * from "./selection.js";
+export * from "./validation.js";

--- a/apps/slack-companion/src/fleet/ports.ts
+++ b/apps/slack-companion/src/fleet/ports.ts
@@ -1,0 +1,60 @@
+import type { DurableDistributedWorkPort } from "../distributed/ports.js";
+import type {
+  AgentFleetAdmissionReceiptV1,
+  AgentFleetMemberV1,
+  AgentFleetMessageV1,
+  DistributedWorkPacketV1,
+} from "./contracts.js";
+
+export interface AgentFleetMemberRegistrationResult {
+  created: boolean;
+  member: AgentFleetMemberV1;
+}
+
+export interface AgentFleetMemberUpdateCommit {
+  expected_revision: number;
+  member: AgentFleetMemberV1;
+}
+
+export interface AgentFleetMailboxAdmissionCommit {
+  message: AgentFleetMessageV1;
+  packet: DistributedWorkPacketV1;
+}
+
+export interface AgentFleetMailboxAdmissionResult {
+  created: boolean;
+  message: AgentFleetMessageV1;
+  packet: DistributedWorkPacketV1;
+  receipt: AgentFleetAdmissionReceiptV1;
+}
+
+/**
+ * Durable membership and mailbox boundary. A production implementation must
+ * commit a message, packet, child run, queue entry, idempotency mapping, and
+ * admission receipt atomically before returning from admitMailboxAndEnqueue.
+ */
+export interface DurableAgentFleetPort extends DurableDistributedWorkPort {
+  registerMember(
+    member: AgentFleetMemberV1,
+  ): Promise<AgentFleetMemberRegistrationResult>;
+
+  updateMember(
+    commit: AgentFleetMemberUpdateCommit,
+  ): Promise<AgentFleetMemberV1>;
+
+  readMember(memberId: string): Promise<AgentFleetMemberV1 | undefined>;
+
+  listMembers(): Promise<AgentFleetMemberV1[]>;
+
+  admitMailboxAndEnqueue(
+    commit: AgentFleetMailboxAdmissionCommit,
+  ): Promise<AgentFleetMailboxAdmissionResult>;
+
+  readMailboxMessage(
+    messageId: string,
+  ): Promise<AgentFleetMessageV1 | undefined>;
+
+  readMailboxAdmissionReceipt(
+    messageId: string,
+  ): Promise<AgentFleetAdmissionReceiptV1 | undefined>;
+}

--- a/apps/slack-companion/src/fleet/reference-store.ts
+++ b/apps/slack-companion/src/fleet/reference-store.ts
@@ -1,0 +1,284 @@
+import type {
+  DistributedWorkAdmissionCommit,
+  DistributedWorkAdmissionResult,
+  DistributedWorkReceiptCommit,
+  DistributedWorkReceiptCommitResult,
+} from "../distributed/ports.js";
+import { ReferenceMemoryDistributedWorkStore } from "../distributed/reference-store.js";
+import type { DistributedWorkReceiptV1 } from "../distributed/contracts.js";
+import type {
+  AgentFleetAdmissionReceiptV1,
+  AgentFleetMemberV1,
+  AgentFleetMessageV1,
+  DistributedWorkPacketV1,
+} from "./contracts.js";
+import type {
+  AgentFleetMailboxAdmissionCommit,
+  AgentFleetMailboxAdmissionResult,
+  AgentFleetMemberRegistrationResult,
+  AgentFleetMemberUpdateCommit,
+  DurableAgentFleetPort,
+} from "./ports.js";
+import {
+  AgentFleetContractError,
+  createAgentFleetAdmissionReceipt,
+  validateAgentFleetAdmissionReceipt,
+  validateAgentFleetMember,
+  validateAgentFleetMemberUpdate,
+  validateAgentFleetMessageForPacket,
+  validateAgentFleetSender,
+} from "./validation.js";
+
+/**
+ * In-memory conformance fixture. Production adapters must implement the same
+ * atomic boundaries with durable storage; this class is not a runtime fallback.
+ */
+export class ReferenceMemoryAgentFleetStore implements DurableAgentFleetPort {
+  readonly distributedWork = new ReferenceMemoryDistributedWorkStore();
+
+  private readonly admissionReceipts = new Map<
+    string,
+    AgentFleetAdmissionReceiptV1
+  >();
+  private readonly memberById = new Map<string, AgentFleetMemberV1>();
+  private readonly messageIdByIdempotencyKey = new Map<string, string>();
+  private readonly messageIdByPacketSequence = new Map<string, string>();
+  private readonly messages = new Map<string, AgentFleetMessageV1>();
+
+  registerMember(
+    member: AgentFleetMemberV1,
+  ): Promise<AgentFleetMemberRegistrationResult> {
+    validateAgentFleetMember(member);
+    const prior = this.memberById.get(member.member_id);
+    if (prior !== undefined) {
+      if (!sameValue(prior, member)) {
+        return Promise.reject(
+          new AgentFleetStoreConflictError(
+            "member identity already belongs to another generation record",
+          ),
+        );
+      }
+      return Promise.resolve({
+        created: false,
+        member: structuredClone(prior),
+      });
+    }
+    const stored = structuredClone(member);
+    this.memberById.set(stored.member_id, stored);
+    return Promise.resolve({ created: true, member: structuredClone(stored) });
+  }
+
+  updateMember(commit: AgentFleetMemberUpdateCommit): Promise<AgentFleetMemberV1> {
+    const current = this.memberById.get(commit.member.member_id);
+    if (current === undefined) {
+      return Promise.reject(
+        new AgentFleetStoreConflictError("fleet member does not exist"),
+      );
+    }
+    if (current.revision !== commit.expected_revision) {
+      return Promise.reject(new StaleAgentFleetMemberError());
+    }
+    validateAgentFleetMemberUpdate(current, commit.member);
+    const stored = structuredClone(commit.member);
+    this.memberById.set(stored.member_id, stored);
+    return Promise.resolve(structuredClone(stored));
+  }
+
+  readMember(memberId: string): Promise<AgentFleetMemberV1 | undefined> {
+    const member = this.memberById.get(memberId);
+    return Promise.resolve(
+      member === undefined ? undefined : structuredClone(member),
+    );
+  }
+
+  listMembers(): Promise<AgentFleetMemberV1[]> {
+    return Promise.resolve(
+      [...this.memberById.values()]
+        .sort((left, right) => left.member_id.localeCompare(right.member_id))
+        .map((member) => structuredClone(member)),
+    );
+  }
+
+  async admitMailboxAndEnqueue(
+    commit: AgentFleetMailboxAdmissionCommit,
+  ): Promise<AgentFleetMailboxAdmissionResult> {
+    validateAgentFleetMessageForPacket(commit.message, commit.packet);
+    const sender = this.memberById.get(commit.message.sender_member_id);
+    if (sender === undefined) {
+      throw new AgentFleetStoreConflictError(
+        "mailbox message sender is not registered",
+      );
+    }
+    validateAgentFleetSender(commit.message, sender, commit.message.created_at);
+
+    const priorMessageId = this.messageIdByIdempotencyKey.get(
+      commit.message.idempotency_key,
+    );
+    if (priorMessageId !== undefined) {
+      return this.replayAdmission(priorMessageId, commit);
+    }
+    const sequenceKey = packetSequenceKey(commit.message);
+    const sequenceOwner = this.messageIdByPacketSequence.get(sequenceKey);
+    if (
+      sequenceOwner !== undefined ||
+      this.messages.has(commit.message.message_id)
+    ) {
+      throw new AgentFleetStoreConflictError(
+        "mailbox message identity or packet sequence already belongs to another input",
+      );
+    }
+
+    const admitted = await this.distributedWork.admitAndEnqueue({
+      packet: commit.packet,
+    });
+    if (!sameValue(admitted.packet, commit.packet)) {
+      throw new AgentFleetStoreConflictError(
+        "distributed admission returned a different packet",
+      );
+    }
+    const message = structuredClone(commit.message);
+    const receipt = createAgentFleetAdmissionReceipt(message, admitted.packet);
+
+    // These mutations model one atomic mailbox, packet, run, queue, and receipt
+    // commit. No caller acknowledgement is permitted before this method returns.
+    this.messages.set(message.message_id, message);
+    this.admissionReceipts.set(message.message_id, receipt);
+    this.messageIdByIdempotencyKey.set(
+      message.idempotency_key,
+      message.message_id,
+    );
+    this.messageIdByPacketSequence.set(sequenceKey, message.message_id);
+    return {
+      created: true,
+      message: structuredClone(message),
+      packet: structuredClone(admitted.packet),
+      receipt: structuredClone(receipt),
+    };
+  }
+
+  readMailboxMessage(
+    messageId: string,
+  ): Promise<AgentFleetMessageV1 | undefined> {
+    const message = this.messages.get(messageId);
+    return Promise.resolve(
+      message === undefined ? undefined : structuredClone(message),
+    );
+  }
+
+  readMailboxAdmissionReceipt(
+    messageId: string,
+  ): Promise<AgentFleetAdmissionReceiptV1 | undefined> {
+    const receipt = this.admissionReceipts.get(messageId);
+    return Promise.resolve(
+      receipt === undefined ? undefined : structuredClone(receipt),
+    );
+  }
+
+  admitAndEnqueue(
+    commit: DistributedWorkAdmissionCommit,
+  ): Promise<DistributedWorkAdmissionResult> {
+    return this.distributedWork.admitAndEnqueue(commit);
+  }
+
+  readPacket(packetId: string): Promise<DistributedWorkPacketV1 | undefined> {
+    return this.distributedWork.readPacket(packetId);
+  }
+
+  readReceipt(
+    packetId: string,
+  ): Promise<DistributedWorkReceiptV1 | undefined> {
+    return this.distributedWork.readReceipt(packetId);
+  }
+
+  commitReceipt(
+    commit: DistributedWorkReceiptCommit,
+  ): Promise<DistributedWorkReceiptCommitResult> {
+    return this.distributedWork.commitReceipt(commit);
+  }
+
+  private async replayAdmission(
+    priorMessageId: string,
+    commit: AgentFleetMailboxAdmissionCommit,
+  ): Promise<AgentFleetMailboxAdmissionResult> {
+    const prior = this.requireMessage(priorMessageId);
+    const receipt = this.requireAdmissionReceipt(priorMessageId);
+    const packet = await this.distributedWork.readPacket(prior.packet_id);
+    if (
+      packet === undefined ||
+      !sameValue(prior, commit.message) ||
+      !sameValue(packet, commit.packet)
+    ) {
+      throw new AgentFleetIdempotencyConflictError();
+    }
+    validateAgentFleetAdmissionReceipt(receipt, prior, packet);
+    return {
+      created: false,
+      message: structuredClone(prior),
+      packet: structuredClone(packet),
+      receipt: structuredClone(receipt),
+    };
+  }
+
+  private requireMessage(messageId: string): AgentFleetMessageV1 {
+    const message = this.messages.get(messageId);
+    if (message === undefined) {
+      throw new AgentFleetContractError("mailbox message does not exist");
+    }
+    return message;
+  }
+
+  private requireAdmissionReceipt(
+    messageId: string,
+  ): AgentFleetAdmissionReceiptV1 {
+    const receipt = this.admissionReceipts.get(messageId);
+    if (receipt === undefined) {
+      throw new AgentFleetContractError(
+        "mailbox admission receipt does not exist",
+      );
+    }
+    return receipt;
+  }
+}
+
+export class AgentFleetStoreConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentFleetStoreConflictError";
+  }
+}
+
+export class AgentFleetIdempotencyConflictError extends Error {
+  constructor() {
+    super("fleet mailbox idempotency key belongs to different input");
+    this.name = "AgentFleetIdempotencyConflictError";
+  }
+}
+
+export class StaleAgentFleetMemberError extends Error {
+  constructor() {
+    super("fleet member revision is stale");
+    this.name = "StaleAgentFleetMemberError";
+  }
+}
+
+function packetSequenceKey(message: AgentFleetMessageV1): string {
+  return `${message.packet_id}\u0000${message.message_sequence}`;
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/apps/slack-companion/src/fleet/selection.ts
+++ b/apps/slack-companion/src/fleet/selection.ts
@@ -1,0 +1,205 @@
+import { createHash } from "node:crypto";
+import { assessCompatibility } from "../operations/compatibility.js";
+import { MAX_AGENT_FLEET_MEMBERS } from "./contracts.js";
+import type {
+  AgentFleetMemberV1,
+  AgentFleetMessageV1,
+  AgentFleetPeerCandidate,
+  AgentFleetPeerCompatibility,
+  AgentFleetPeerRanking,
+  DistributedWorkPacketV1,
+} from "./contracts.js";
+import {
+  AgentFleetContractError,
+  validateAgentFleetMember,
+  validateAgentFleetMessageForPacket,
+  validateAgentFleetSender,
+} from "./validation.js";
+
+export interface AgentFleetPeerSelectionInput {
+  candidates: readonly AgentFleetMemberV1[];
+  excluded_member_ids?: readonly string[];
+  message: AgentFleetMessageV1;
+  observed_at: string;
+  packet: DistributedWorkPacketV1;
+  sender: AgentFleetMemberV1;
+}
+
+/**
+ * Returns one deterministic order over compatible ready and degraded peers.
+ * Capacity is deliberately excluded; callers reserve it atomically through
+ * DurableCapacityPort after this pure policy step.
+ */
+export function rankCompatibleAgentFleetPeers(
+  input: AgentFleetPeerSelectionInput,
+): AgentFleetPeerRanking {
+  validateAgentFleetMessageForPacket(input.message, input.packet);
+  validateAgentFleetSender(input.message, input.sender, input.observed_at);
+  const observedAt = Date.parse(input.observed_at);
+  const excluded = new Set(input.excluded_member_ids ?? []);
+  const seen = new Set<string>();
+  const compatible: AgentFleetPeerCandidate[] = [];
+  const rejected: AgentFleetPeerRanking["rejected"] = [];
+
+  if (input.candidates.length > MAX_AGENT_FLEET_MEMBERS) {
+    throw new AgentFleetContractError("fleet candidate set exceeds its bound");
+  }
+  for (const member of input.candidates) {
+    validateAgentFleetMember(member);
+    if (seen.has(member.member_id)) {
+      throw new AgentFleetContractError("fleet candidate set has duplicate members");
+    }
+    seen.add(member.member_id);
+
+    const lifecycleReasons: string[] = [];
+    if (member.member_id === input.sender.member_id) {
+      lifecycleReasons.push("sender_is_not_a_peer");
+    }
+    if (excluded.has(member.member_id)) {
+      lifecycleReasons.push("member_excluded");
+    }
+    if (member.state !== "ready" && member.state !== "degraded") {
+      lifecycleReasons.push(`member_${member.state}`);
+    }
+    if (Date.parse(member.valid_until) <= observedAt) {
+      lifecycleReasons.push("member_presence_expired");
+    }
+    if (lifecycleReasons.length > 0) {
+      rejected.push({ member_id: member.member_id, reasons: lifecycleReasons });
+      continue;
+    }
+
+    const compatibility = assessPeerCompatibility(
+      input.sender,
+      member,
+      input.packet,
+    );
+    if (
+      compatibility.decision === "blocked" ||
+      compatibility.decision === "incompatible"
+    ) {
+      rejected.push({
+        member_id: member.member_id,
+        reasons: [...compatibility.reasons],
+      });
+      continue;
+    }
+    compatible.push({
+      compatibility,
+      member: structuredClone(member),
+      rank: peerRank(input.message.message_id, member.member_id),
+    });
+  }
+
+  compatible.sort(compareCandidates);
+  rejected.sort((left, right) => left.member_id.localeCompare(right.member_id));
+  return { compatible, rejected };
+}
+
+export function selectCompatibleAgentFleetPeer(
+  input: AgentFleetPeerSelectionInput,
+): AgentFleetPeerCandidate | undefined {
+  return rankCompatibleAgentFleetPeers(input).compatible[0];
+}
+
+function assessPeerCompatibility(
+  sender: AgentFleetMemberV1,
+  member: AgentFleetMemberV1,
+  packet: DistributedWorkPacketV1,
+): AgentFleetPeerCompatibility {
+  if (
+    !sender.capability_manifest.contract_versions.includes(
+      sender.protocol_version,
+    ) ||
+    !member.capability_manifest.contract_versions.includes(
+      sender.protocol_version,
+    )
+  ) {
+    return {
+      decision: "incompatible",
+      member_id: member.member_id,
+      reasons: ["fleet_protocol_version_not_shared"],
+    };
+  }
+
+  const assessed = assessCompatibility({
+    companion_manifest: sender.capability_manifest,
+    companion_schema: sender.schema_compatibility,
+    core_manifest: member.capability_manifest,
+    core_schema: member.schema_compatibility,
+  });
+  const reasons = assessed.reasons.map(normalizeCompatibilityReason);
+  const requiredMissing = packet.required_capabilities
+    .filter((requirement) => requirement.level === "required")
+    .filter(
+      (requirement) =>
+        !member.capability_manifest.capabilities.some(
+          (offered) =>
+            offered.capability_id === requirement.capability_id &&
+            offered.version === requirement.version,
+        ),
+    )
+    .map(
+      (requirement) =>
+        `peer_missing_${requirement.capability_id}@${requirement.version}`,
+    );
+  if (requiredMissing.length > 0) {
+    return {
+      decision: "blocked",
+      member_id: member.member_id,
+      negotiated_write_version: assessed.negotiated_write_version,
+      reasons: [...reasons, ...requiredMissing],
+    };
+  }
+
+  const optionalMissing = packet.required_capabilities
+    .filter((requirement) => requirement.level === "optional")
+    .filter(
+      (requirement) =>
+        !member.capability_manifest.capabilities.some(
+          (offered) =>
+            offered.capability_id === requirement.capability_id &&
+            offered.version === requirement.version,
+        ),
+    )
+    .map(
+      (requirement) =>
+        `peer_optional_${requirement.capability_id}@${requirement.version}`,
+    );
+  const decision =
+    assessed.decision === "supported" && optionalMissing.length > 0
+      ? "degraded"
+      : assessed.decision;
+  return {
+    decision,
+    member_id: member.member_id,
+    negotiated_write_version: assessed.negotiated_write_version,
+    reasons: [...reasons, ...optionalMissing],
+  };
+}
+
+function normalizeCompatibilityReason(reason: string): string {
+  return reason
+    .replace(/^companion_/, "requester_")
+    .replace(/^core_/, "peer_")
+    .replace(/^manifest_/, "fleet_manifest_");
+}
+
+function peerRank(messageId: string, memberId: string): string {
+  return createHash("sha256")
+    .update(`${messageId}\u0000${memberId}`)
+    .digest("hex");
+}
+
+function compareCandidates(
+  left: AgentFleetPeerCandidate,
+  right: AgentFleetPeerCandidate,
+): number {
+  if (left.member.state !== right.member.state) {
+    return left.member.state === "ready" ? -1 : 1;
+  }
+  const byRank = right.rank.localeCompare(left.rank);
+  return byRank !== 0
+    ? byRank
+    : left.member.member_id.localeCompare(right.member.member_id);
+}

--- a/apps/slack-companion/src/fleet/validation.ts
+++ b/apps/slack-companion/src/fleet/validation.ts
@@ -1,0 +1,786 @@
+import { createHash } from "node:crypto";
+import {
+  distributedWorkLeaseReference,
+  validateDistributedWorkPacket,
+} from "../distributed/validation.js";
+import { assertCapacityPermit } from "../execution/capacity.js";
+import {
+  AGENT_FLEET_ADMISSION_RECEIPT_SCHEMA_VERSION,
+  AGENT_FLEET_EXECUTION_BINDING_SCHEMA_VERSION,
+  AGENT_FLEET_MEMBER_SCHEMA_VERSION,
+  AGENT_FLEET_MESSAGE_SCHEMA_VERSION,
+  AGENT_FLEET_PROTOCOL_VERSION,
+  MAX_AGENT_FLEET_PAYLOAD_BYTES,
+} from "./contracts.js";
+import type {
+  AgentFleetAdmissionReceiptV1,
+  AgentFleetExecutionBindingV1,
+  AgentFleetMemberState,
+  AgentFleetMemberV1,
+  AgentFleetMessageIdentityInput,
+  AgentFleetMessageV1,
+  AgentFleetPayloadReferenceV1,
+  AgentFleetResumeReferenceV1,
+  CapacityPermitV1,
+  CheckpointV1,
+  DistributedWorkPacketV1,
+  WorkLeaseV1,
+} from "./contracts.js";
+
+const SHA256_DIGEST = /^sha256:[a-f0-9]{64}$/;
+const FLEET_MESSAGE = /^agent-fleet-message:\/\/sha256\/[a-f0-9]{64}$/;
+const FLEET_RECEIPT =
+  /^agent-fleet-admission-receipt:\/\/sha256\/[a-f0-9]{64}$/;
+const FLEET_PAYLOAD = /^agent-fleet-payload:\/\/sha256\/[a-f0-9]{64}$/;
+const REDACTION_RECEIPT =
+  /^agent-fleet-redaction-receipt:\/\/sha256\/[a-f0-9]{64}$/;
+const CHECKPOINT_REFERENCE =
+  /^agent-fleet-checkpoint:\/\/sha256\/[a-f0-9]{64}$/;
+const HANDOFF_REFERENCE =
+  /^agent-fleet-handoff:\/\/sha256\/[a-f0-9]{64}$/;
+const CAPACITY_REFERENCE = /^capacity:\/\/[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+$/;
+const MAX_IDENTIFIER_LENGTH = 256;
+
+const memberStates = new Set<AgentFleetMemberState>([
+  "ready",
+  "degraded",
+  "draining",
+  "offline",
+  "recovering",
+  "retired",
+]);
+
+const memberTransitions: Readonly<Record<AgentFleetMemberState, readonly AgentFleetMemberState[]>> = {
+  ready: ["degraded", "draining", "offline"],
+  degraded: ["ready", "draining", "offline"],
+  draining: ["offline"],
+  offline: ["recovering", "retired"],
+  recovering: ["ready", "degraded", "draining", "offline"],
+  retired: [],
+};
+
+export class AgentFleetContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentFleetContractError";
+  }
+}
+
+export function createAgentFleetPayloadReference(input: {
+  byte_length: number;
+  media_type: AgentFleetPayloadReferenceV1["media_type"];
+  payload_digest: string;
+  redaction_receipt_digest: string;
+}): AgentFleetPayloadReferenceV1 {
+  const reference: AgentFleetPayloadReferenceV1 = {
+    byte_length: input.byte_length,
+    media_type: input.media_type,
+    payload_digest: input.payload_digest,
+    payload_ref: digestReference("agent-fleet-payload", input.payload_digest),
+    redaction_receipt_digest: input.redaction_receipt_digest,
+    redaction_receipt_ref: digestReference(
+      "agent-fleet-redaction-receipt",
+      input.redaction_receipt_digest,
+    ),
+  };
+  validateAgentFleetPayloadReference(reference);
+  return reference;
+}
+
+export function createAgentFleetResumeReference(
+  checkpoint: CheckpointV1,
+  handoffDigest: string,
+): AgentFleetResumeReferenceV1 {
+  validateCheckpoint(checkpoint);
+  requireDigest(handoffDigest, "handoff_digest");
+  const checkpointDigest = sha256(stableStringify(checkpoint));
+  return {
+    checkpoint_digest: checkpointDigest,
+    checkpoint_ref: digestReference(
+      "agent-fleet-checkpoint",
+      checkpointDigest,
+    ),
+    handoff_digest: handoffDigest,
+    handoff_ref: digestReference("agent-fleet-handoff", handoffDigest),
+  };
+}
+
+export function agentFleetMessageIdentity(
+  input: AgentFleetMessageIdentityInput,
+): string {
+  validateMessageIdentityInput(input);
+  return digestReference(
+    "agent-fleet-message",
+    sha256(stableStringify(canonicalMessageIdentity(input))),
+  );
+}
+
+export function createAgentFleetMessage(
+  input: AgentFleetMessageIdentityInput,
+): AgentFleetMessageV1 {
+  requireExactKeys(input, [
+    "created_at",
+    "idempotency_key",
+    "message_sequence",
+    "packet_id",
+    "payload",
+    "protocol_version",
+    "resume",
+    "run_id",
+    "sender_generation",
+    "sender_member_id",
+  ], "fleet message input", ["resume"]);
+  const message: AgentFleetMessageV1 = {
+    created_at: input.created_at,
+    idempotency_key: input.idempotency_key,
+    message_id: agentFleetMessageIdentity(input),
+    message_sequence: input.message_sequence,
+    packet_id: input.packet_id,
+    payload: structuredClone(input.payload),
+    protocol_version: input.protocol_version,
+    resume:
+      input.resume === undefined ? undefined : structuredClone(input.resume),
+    run_id: input.run_id,
+    schema_version: AGENT_FLEET_MESSAGE_SCHEMA_VERSION,
+    sender_generation: input.sender_generation,
+    sender_member_id: input.sender_member_id,
+  };
+  validateAgentFleetMessage(message);
+  return message;
+}
+
+export function agentFleetAdmissionReceiptIdentity(messageId: string): string {
+  requirePattern(messageId, FLEET_MESSAGE, "message_id");
+  return digestReference(
+    "agent-fleet-admission-receipt",
+    sha256(messageId),
+  );
+}
+
+export function createAgentFleetAdmissionReceipt(
+  message: AgentFleetMessageV1,
+  packet: DistributedWorkPacketV1,
+): AgentFleetAdmissionReceiptV1 {
+  validateAgentFleetMessageForPacket(message, packet);
+  return {
+    admitted_at: packet.child_run.admitted_at,
+    idempotency_key: message.idempotency_key,
+    message_id: message.message_id,
+    packet_id: packet.packet_id,
+    payload_digest: message.payload.payload_digest,
+    receipt_id: agentFleetAdmissionReceiptIdentity(message.message_id),
+    run_id: packet.child_run.run_id,
+    schema_version: AGENT_FLEET_ADMISSION_RECEIPT_SCHEMA_VERSION,
+  };
+}
+
+export function validateAgentFleetAdmissionReceipt(
+  receipt: AgentFleetAdmissionReceiptV1,
+  message: AgentFleetMessageV1,
+  packet: DistributedWorkPacketV1,
+): void {
+  requireExactKeys(receipt, [
+    "admitted_at",
+    "idempotency_key",
+    "message_id",
+    "packet_id",
+    "payload_digest",
+    "receipt_id",
+    "run_id",
+    "schema_version",
+  ], "admission receipt");
+  if (receipt.schema_version !== AGENT_FLEET_ADMISSION_RECEIPT_SCHEMA_VERSION) {
+    throw new AgentFleetContractError("admission receipt schema is unsupported");
+  }
+  requireCanonicalTime(receipt.admitted_at, "receipt.admitted_at");
+  requirePattern(receipt.receipt_id, FLEET_RECEIPT, "receipt_id");
+  const expected = createAgentFleetAdmissionReceipt(message, packet);
+  if (!sameValue(receipt, expected)) {
+    throw new AgentFleetContractError(
+      "admission receipt does not match the mailbox message and run",
+    );
+  }
+}
+
+export function validateAgentFleetMember(member: AgentFleetMemberV1): void {
+  requireExactKeys(member, [
+    "capability_manifest",
+    "capacity_resource_ref",
+    "generation",
+    "member_id",
+    "protocol_version",
+    "registered_at",
+    "revision",
+    "schema_compatibility",
+    "schema_version",
+    "service_id",
+    "state",
+    "updated_at",
+    "valid_until",
+  ], "fleet member");
+  if (member.schema_version !== AGENT_FLEET_MEMBER_SCHEMA_VERSION) {
+    throw new AgentFleetContractError("fleet member schema is unsupported");
+  }
+  if (member.protocol_version !== AGENT_FLEET_PROTOCOL_VERSION) {
+    throw new AgentFleetContractError("fleet protocol version is unsupported");
+  }
+  requireIdentifier(member.member_id, "member_id");
+  requireIdentifier(member.service_id, "service_id");
+  requirePositiveInteger(member.generation, "generation");
+  requirePositiveInteger(member.revision, "revision");
+  requirePattern(
+    member.capacity_resource_ref,
+    CAPACITY_REFERENCE,
+    "capacity_resource_ref",
+  );
+  if (!memberStates.has(member.state)) {
+    throw new AgentFleetContractError("fleet member state is unsupported");
+  }
+  requireCanonicalTime(member.registered_at, "registered_at");
+  requireCanonicalTime(member.updated_at, "updated_at");
+  requireCanonicalTime(member.valid_until, "valid_until");
+  if (
+    Date.parse(member.updated_at) < Date.parse(member.registered_at) ||
+    Date.parse(member.valid_until) <= Date.parse(member.updated_at)
+  ) {
+    throw new AgentFleetContractError("fleet member timestamps are inconsistent");
+  }
+
+  const manifest = member.capability_manifest;
+  if (
+    manifest.schema_version !== "capability-manifest/v1" ||
+    manifest.service_id !== member.service_id ||
+    manifest.generation !== member.generation
+  ) {
+    throw new AgentFleetContractError(
+      "capability manifest does not belong to the member generation",
+    );
+  }
+  requireDigest(manifest.digest, "capability_manifest.digest");
+  requireCanonicalTime(manifest.produced_at, "capability_manifest.produced_at");
+  if (Date.parse(manifest.produced_at) > Date.parse(member.updated_at)) {
+    throw new AgentFleetContractError(
+      "capability manifest cannot be produced after the member update",
+    );
+  }
+  if (!manifest.contract_versions.includes(AGENT_FLEET_PROTOCOL_VERSION)) {
+    throw new AgentFleetContractError(
+      "capability manifest does not advertise the fleet protocol",
+    );
+  }
+  validateStringSet(manifest.contract_versions, "contract_versions");
+  validateCapabilities(manifest.capabilities);
+  validateSchemaCompatibility(member.schema_compatibility);
+}
+
+export function validateAgentFleetMemberUpdate(
+  current: AgentFleetMemberV1,
+  next: AgentFleetMemberV1,
+): void {
+  validateAgentFleetMember(current);
+  validateAgentFleetMember(next);
+  if (
+    current.member_id !== next.member_id ||
+    current.service_id !== next.service_id ||
+    current.capacity_resource_ref !== next.capacity_resource_ref ||
+    current.protocol_version !== next.protocol_version ||
+    current.registered_at !== next.registered_at ||
+    next.revision !== current.revision + 1 ||
+    Date.parse(next.updated_at) <= Date.parse(current.updated_at)
+  ) {
+    throw new AgentFleetContractError(
+      "fleet member update changed immutable identity or revision order",
+    );
+  }
+  const presenceRefresh =
+    current.state === next.state && current.state !== "retired";
+  if (!presenceRefresh && !memberTransitions[current.state].includes(next.state)) {
+    throw new AgentFleetContractError(
+      `fleet member transition ${current.state}->${next.state} is not allowed`,
+    );
+  }
+
+  if (next.generation === current.generation) {
+    if (
+      next.capability_manifest.digest !== current.capability_manifest.digest ||
+      !sameValue(next.schema_compatibility, current.schema_compatibility)
+    ) {
+      throw new AgentFleetContractError(
+        "one member generation cannot change its compatibility manifest",
+      );
+    }
+    return;
+  }
+  if (
+    current.state !== "offline" ||
+    next.state !== "recovering" ||
+    next.generation !== current.generation + 1
+  ) {
+    throw new AgentFleetContractError(
+      "a new member generation must advance offline to recovering by one",
+    );
+  }
+}
+
+export function validateAgentFleetMessage(message: AgentFleetMessageV1): void {
+  requireExactKeys(message, [
+    "created_at",
+    "idempotency_key",
+    "message_id",
+    "message_sequence",
+    "packet_id",
+    "payload",
+    "protocol_version",
+    "resume",
+    "run_id",
+    "schema_version",
+    "sender_generation",
+    "sender_member_id",
+  ], "fleet message", ["resume"]);
+  if (message.schema_version !== AGENT_FLEET_MESSAGE_SCHEMA_VERSION) {
+    throw new AgentFleetContractError("fleet message schema is unsupported");
+  }
+  requirePattern(message.message_id, FLEET_MESSAGE, "message_id");
+  validateMessageIdentityInput(message);
+  if (message.message_id !== agentFleetMessageIdentity(message)) {
+    throw new AgentFleetContractError(
+      "fleet message identity does not match its immutable input",
+    );
+  }
+}
+
+export function validateAgentFleetMessageForPacket(
+  message: AgentFleetMessageV1,
+  packet: DistributedWorkPacketV1,
+): void {
+  validateAgentFleetMessage(message);
+  validateDistributedWorkPacket(packet);
+  if (
+    message.packet_id !== packet.packet_id ||
+    message.run_id !== packet.child_run.run_id ||
+    message.payload.payload_ref !== packet.objective_ref ||
+    message.payload.payload_digest !== packet.objective_digest
+  ) {
+    throw new AgentFleetContractError(
+      "fleet message does not match its distributed work packet and run",
+    );
+  }
+}
+
+export function validateAgentFleetSender(
+  message: AgentFleetMessageV1,
+  sender: AgentFleetMemberV1,
+  observedAt: string,
+): void {
+  validateAgentFleetMessage(message);
+  validateAgentFleetMember(sender);
+  requireCanonicalTime(observedAt, "observed_at");
+  if (
+    sender.member_id !== message.sender_member_id ||
+    sender.generation !== message.sender_generation
+  ) {
+    throw new AgentFleetContractError(
+      "fleet message sender does not match the member generation",
+    );
+  }
+  if (
+    sender.state === "retired" ||
+    sender.state === "offline" ||
+    Date.parse(sender.valid_until) <= Date.parse(observedAt)
+  ) {
+    throw new AgentFleetContractError("fleet message sender is not present");
+  }
+}
+
+export function createAgentFleetExecutionBinding(input: {
+  bound_at: string;
+  checkpoint?: CheckpointV1;
+  lease: WorkLeaseV1;
+  member: AgentFleetMemberV1;
+  message: AgentFleetMessageV1;
+  packet: DistributedWorkPacketV1;
+  permit: CapacityPermitV1;
+}): AgentFleetExecutionBindingV1 {
+  validateAgentFleetMessageForPacket(input.message, input.packet);
+  validateAgentFleetMember(input.member);
+  requireCanonicalTime(input.bound_at, "bound_at");
+  validateExecutionProof(input);
+  const resume = input.message.resume;
+  return {
+    bound_at: input.bound_at,
+    capacity_permit_id: input.permit.permit_id,
+    checkpoint_ref: resume?.checkpoint_ref,
+    fencing_token: input.lease.fencing_token,
+    generation: input.lease.generation,
+    handoff_ref: resume?.handoff_ref,
+    lease_ref: distributedWorkLeaseReference(input.lease),
+    member_id: input.member.member_id,
+    message_id: input.message.message_id,
+    run_id: input.packet.child_run.run_id,
+    schema_version: AGENT_FLEET_EXECUTION_BINDING_SCHEMA_VERSION,
+  };
+}
+
+function validateExecutionProof(input: {
+  bound_at: string;
+  checkpoint?: CheckpointV1;
+  lease: WorkLeaseV1;
+  member: AgentFleetMemberV1;
+  message: AgentFleetMessageV1;
+  packet: DistributedWorkPacketV1;
+  permit: CapacityPermitV1;
+}): void {
+  const { bound_at: boundAt, checkpoint, lease, member, message, packet, permit } = input;
+  if (
+    member.state !== "ready" &&
+    member.state !== "degraded" &&
+    member.state !== "recovering"
+  ) {
+    throw new AgentFleetContractError("member cannot own existing work");
+  }
+  if (Date.parse(member.valid_until) <= Date.parse(boundAt)) {
+    throw new AgentFleetContractError("member presence expired before execution");
+  }
+  requireCanonicalTime(lease.heartbeat_at, "lease.heartbeat_at");
+  requireCanonicalTime(lease.lease_expires_at, "lease.lease_expires_at");
+  if (
+    lease.schema_version !== "work-lease/v1" ||
+    lease.run_id !== packet.child_run.run_id ||
+    lease.owner_id !== member.member_id ||
+    lease.generation !== member.generation ||
+    Date.parse(lease.heartbeat_at) > Date.parse(boundAt) ||
+    Date.parse(lease.lease_expires_at) <= Date.parse(boundAt)
+  ) {
+    throw new AgentFleetContractError("work lease does not fence this member and run");
+  }
+  requirePositiveInteger(lease.fencing_token, "lease.fencing_token");
+  assertCapacityPermit(permit);
+  if (
+    permit.state !== "active" ||
+    permit.owner_id !== member.member_id ||
+    permit.generation !== member.generation ||
+    permit.run_id !== packet.child_run.run_id ||
+    permit.resource_ref !== member.capacity_resource_ref ||
+    Date.parse(permit.acquired_at) > Date.parse(boundAt) ||
+    Date.parse(permit.expires_at) <= Date.parse(boundAt)
+  ) {
+    throw new AgentFleetContractError(
+      "capacity permit does not fence this member and run",
+    );
+  }
+
+  if (message.resume === undefined) {
+    if (checkpoint !== undefined) {
+      throw new AgentFleetContractError(
+        "an initial fleet message cannot bind a resume checkpoint",
+      );
+    }
+    return;
+  }
+  if (checkpoint === undefined) {
+    throw new AgentFleetContractError(
+      "a resumed fleet message requires its durable checkpoint",
+    );
+  }
+  validateCheckpoint(checkpoint);
+  const expected = createAgentFleetResumeReference(
+    checkpoint,
+    message.resume.handoff_digest,
+  );
+  if (
+    checkpoint.run_id !== packet.child_run.run_id ||
+    checkpoint.generation > lease.generation ||
+    !sameValue(expected, message.resume)
+  ) {
+    throw new AgentFleetContractError(
+      "resume references do not match the run checkpoint and handoff",
+    );
+  }
+}
+
+function validateMessageIdentityInput(input: AgentFleetMessageIdentityInput): void {
+  if (input.protocol_version !== AGENT_FLEET_PROTOCOL_VERSION) {
+    throw new AgentFleetContractError("fleet protocol version is unsupported");
+  }
+  requireCanonicalTime(input.created_at, "created_at");
+  requireIdentifier(input.idempotency_key, "idempotency_key");
+  requirePositiveInteger(input.message_sequence, "message_sequence");
+  requireIdentifier(input.packet_id, "packet_id");
+  requireIdentifier(input.run_id, "run_id");
+  requirePositiveInteger(input.sender_generation, "sender_generation");
+  requireIdentifier(input.sender_member_id, "sender_member_id");
+  validateAgentFleetPayloadReference(input.payload);
+  if (input.message_sequence === 1 && input.resume !== undefined) {
+    throw new AgentFleetContractError(
+      "the initial fleet message cannot contain resume references",
+    );
+  }
+  if (input.message_sequence > 1 && input.resume === undefined) {
+    throw new AgentFleetContractError(
+      "a later fleet message requires checkpoint and handoff references",
+    );
+  }
+  if (input.resume !== undefined) {
+    validateAgentFleetResumeReference(input.resume);
+  }
+}
+
+function validateAgentFleetPayloadReference(
+  payload: AgentFleetPayloadReferenceV1,
+): void {
+  requireExactKeys(payload, [
+    "byte_length",
+    "media_type",
+    "payload_digest",
+    "payload_ref",
+    "redaction_receipt_digest",
+    "redaction_receipt_ref",
+  ], "fleet payload reference");
+  if (
+    !Number.isSafeInteger(payload.byte_length) ||
+    payload.byte_length < 1 ||
+    payload.byte_length > MAX_AGENT_FLEET_PAYLOAD_BYTES
+  ) {
+    throw new AgentFleetContractError("payload byte length exceeds its bound");
+  }
+  if (
+    payload.media_type !== "application/json" &&
+    payload.media_type !== "text/plain"
+  ) {
+    throw new AgentFleetContractError("payload media type is unsupported");
+  }
+  requireDigest(payload.payload_digest, "payload_digest");
+  requireDigest(payload.redaction_receipt_digest, "redaction_receipt_digest");
+  requirePattern(payload.payload_ref, FLEET_PAYLOAD, "payload_ref");
+  requirePattern(
+    payload.redaction_receipt_ref,
+    REDACTION_RECEIPT,
+    "redaction_receipt_ref",
+  );
+  if (
+    payload.payload_ref !==
+      digestReference("agent-fleet-payload", payload.payload_digest) ||
+    payload.redaction_receipt_ref !==
+      digestReference(
+        "agent-fleet-redaction-receipt",
+        payload.redaction_receipt_digest,
+      )
+  ) {
+    throw new AgentFleetContractError(
+      "fleet payload references are not content addressed",
+    );
+  }
+}
+
+function validateAgentFleetResumeReference(
+  resume: AgentFleetResumeReferenceV1,
+): void {
+  requireExactKeys(resume, [
+    "checkpoint_digest",
+    "checkpoint_ref",
+    "handoff_digest",
+    "handoff_ref",
+  ], "fleet resume reference");
+  requireDigest(resume.checkpoint_digest, "checkpoint_digest");
+  requireDigest(resume.handoff_digest, "handoff_digest");
+  requirePattern(resume.checkpoint_ref, CHECKPOINT_REFERENCE, "checkpoint_ref");
+  requirePattern(resume.handoff_ref, HANDOFF_REFERENCE, "handoff_ref");
+  if (
+    resume.checkpoint_ref !==
+      digestReference("agent-fleet-checkpoint", resume.checkpoint_digest) ||
+    resume.handoff_ref !==
+      digestReference("agent-fleet-handoff", resume.handoff_digest)
+  ) {
+    throw new AgentFleetContractError(
+      "fleet resume references are not content addressed",
+    );
+  }
+}
+
+function validateCheckpoint(checkpoint: CheckpointV1): void {
+  if (checkpoint.schema_version !== "checkpoint/v1") {
+    throw new AgentFleetContractError("checkpoint schema is unsupported");
+  }
+  requireIdentifier(checkpoint.checkpoint_id, "checkpoint_id");
+  requireIdentifier(checkpoint.run_id, "checkpoint.run_id");
+  requirePositiveInteger(checkpoint.generation, "checkpoint.generation");
+  requirePositiveInteger(checkpoint.run_revision, "checkpoint.run_revision");
+  requirePositiveInteger(checkpoint.sequence, "checkpoint.sequence");
+  requireDigest(checkpoint.payload_digest, "checkpoint.payload_digest");
+  requireCanonicalTime(checkpoint.created_at, "checkpoint.created_at");
+}
+
+function validateCapabilities(
+  capabilities: AgentFleetMemberV1["capability_manifest"]["capabilities"],
+): void {
+  if (capabilities.length > 64) {
+    throw new AgentFleetContractError("capability manifest exceeds its bound");
+  }
+  const identities = new Set<string>();
+  for (const capability of capabilities) {
+    requireIdentifier(capability.capability_id, "capability_id");
+    requireIdentifier(capability.version, "capability.version");
+    if (capability.level !== "required" && capability.level !== "optional") {
+      throw new AgentFleetContractError("capability level is unsupported");
+    }
+    const identity = `${capability.capability_id}\u0000${capability.version}`;
+    if (identities.has(identity)) {
+      throw new AgentFleetContractError("capability manifest has duplicates");
+    }
+    identities.add(identity);
+  }
+}
+
+function validateSchemaCompatibility(
+  compatibility: AgentFleetMemberV1["schema_compatibility"],
+): void {
+  requireIdentifier(compatibility.current_version, "current_version");
+  requireIdentifier(compatibility.rolling_upgrade_rule, "rolling_upgrade_rule");
+  validateStringSet(compatibility.read_versions, "read_versions");
+  validateStringSet(compatibility.write_versions, "write_versions");
+  const decisions = new Set(compatibility.capability_decisions);
+  if (
+    decisions.size < 1 ||
+    decisions.size > 4 ||
+    decisions.size !== compatibility.capability_decisions.length ||
+    [...decisions].some(
+      (decision) =>
+        decision !== "supported" &&
+        decision !== "degraded" &&
+        decision !== "blocked" &&
+        decision !== "incompatible",
+    )
+  ) {
+    throw new AgentFleetContractError(
+      "schema compatibility has unsupported capability decisions",
+    );
+  }
+  if (
+    !compatibility.read_versions.includes(compatibility.current_version) ||
+    !compatibility.write_versions.includes(compatibility.current_version)
+  ) {
+    throw new AgentFleetContractError(
+      "schema compatibility must read and write its current version",
+    );
+  }
+}
+
+function validateStringSet(values: string[], field: string): void {
+  if (values.length < 1 || values.length > 16) {
+    throw new AgentFleetContractError(`${field} exceeds its bound`);
+  }
+  const seen = new Set<string>();
+  for (const value of values) {
+    requireIdentifier(value, field);
+    if (seen.has(value)) {
+      throw new AgentFleetContractError(`${field} has duplicates`);
+    }
+    seen.add(value);
+  }
+}
+
+function canonicalMessageIdentity(input: AgentFleetMessageIdentityInput) {
+  return {
+    created_at: input.created_at,
+    idempotency_key: input.idempotency_key,
+    message_sequence: input.message_sequence,
+    packet_id: input.packet_id,
+    payload: input.payload,
+    protocol_version: input.protocol_version,
+    resume: input.resume,
+    run_id: input.run_id,
+    sender_generation: input.sender_generation,
+    sender_member_id: input.sender_member_id,
+  };
+}
+
+function digestReference(scheme: string, digest: string): string {
+  requireDigest(digest, `${scheme}_digest`);
+  return `${scheme}://sha256/${digest.slice("sha256:".length)}`;
+}
+
+function requireDigest(value: string, field: string): void {
+  requirePattern(value, SHA256_DIGEST, field);
+}
+
+function requirePattern(
+  value: string,
+  pattern: RegExp,
+  field: string,
+): void {
+  if (!pattern.test(value)) {
+    throw new AgentFleetContractError(`${field} has an invalid format`);
+  }
+}
+
+function requireIdentifier(value: string, field: string): void {
+  if (
+    value.length < 1 ||
+    value.length > MAX_IDENTIFIER_LENGTH ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    throw new AgentFleetContractError(`${field} must be a bounded opaque value`);
+  }
+}
+
+function requirePositiveInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new AgentFleetContractError(`${field} must be a positive integer`);
+  }
+}
+
+function requireCanonicalTime(value: string, field: string): void {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== value) {
+    throw new AgentFleetContractError(
+      `${field} must be a canonical ISO-8601 timestamp`,
+    );
+  }
+}
+
+function requireExactKeys(
+  value: object,
+  allowed: readonly string[],
+  label: string,
+  optional: readonly string[] = [],
+): void {
+  if (Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new AgentFleetContractError(`${label} must be a plain record`);
+  }
+  const keys = Object.keys(value).sort();
+  const allowedSet = new Set(allowed);
+  if (keys.some((key) => !allowedSet.has(key))) {
+    throw new AgentFleetContractError(`${label} contains unsupported fields`);
+  }
+  const optionalSet = new Set(optional);
+  if (
+    allowed.some(
+      (key) => !optionalSet.has(key) && !Object.prototype.hasOwnProperty.call(value, key),
+    )
+  ) {
+    throw new AgentFleetContractError(`${label} is missing required fields`);
+  }
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return stableStringify(left) === stableStringify(right);
+}

--- a/apps/slack-companion/test/agent-fleet-protocol.test.ts
+++ b/apps/slack-companion/test/agent-fleet-protocol.test.ts
@@ -1,0 +1,680 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { describe, test } from "node:test";
+import type {
+  CapabilityRequirement,
+  RunReceiptV1,
+  WorkLeaseV1,
+} from "@writer/cerebro-sdk";
+import {
+  DISTRIBUTED_WORK_PACKET_SCHEMA_VERSION,
+} from "../src/distributed/contracts.js";
+import type {
+  DistributedWorkPacketIdentityInput,
+  DistributedWorkPacketV1,
+} from "../src/distributed/contracts.js";
+import {
+  distributedWorkIntentDigest,
+  distributedWorkPacketIdentity,
+} from "../src/distributed/validation.js";
+import { ReferenceMemoryCapacityStore } from "../src/execution/capacity-reference-store.js";
+import type {
+  CapacityPermitV1,
+  CheckpointV1,
+} from "../src/fleet/contracts.js";
+import { AGENT_FLEET_PROTOCOL_VERSION } from "../src/fleet/contracts.js";
+import {
+  AgentFleetCoordinator,
+} from "../src/fleet/coordinator.js";
+import type {
+  AgentFleetMailboxAdmissionCommit,
+  AgentFleetMailboxAdmissionResult,
+} from "../src/fleet/ports.js";
+import {
+  AgentFleetIdempotencyConflictError,
+  ReferenceMemoryAgentFleetStore,
+  StaleAgentFleetMemberError,
+} from "../src/fleet/reference-store.js";
+import {
+  rankCompatibleAgentFleetPeers,
+} from "../src/fleet/selection.js";
+import {
+  AgentFleetContractError,
+  agentFleetMessageIdentity,
+  createAgentFleetMessage,
+  createAgentFleetPayloadReference,
+  createAgentFleetResumeReference,
+  validateAgentFleetMessage,
+} from "../src/fleet/validation.js";
+import type {
+  AgentFleetMemberV1,
+  AgentFleetMessageV1,
+  AgentFleetPayloadReferenceV1,
+} from "../src/fleet/contracts.js";
+
+const NOW = "2026-07-18T12:00:00.000Z";
+const NEXT = "2026-07-18T12:01:00.000Z";
+const LATER = "2026-07-18T12:02:00.000Z";
+const EXPIRES = "2026-07-18T13:00:00.000Z";
+
+describe("topology-neutral agent fleet protocol", () => {
+  test("enforces member lifecycle revisions, generations, and terminal retirement", async () => {
+    const store = new ReferenceMemoryAgentFleetStore();
+    const initial = member("worker-a", "ready", 1, 1, NOW);
+    assert.equal((await store.registerMember(initial)).created, true);
+    assert.equal((await store.registerMember(structuredClone(initial))).created, false);
+
+    const refreshed = await store.updateMember({
+      expected_revision: 1,
+      member: {
+        ...transition(initial, "ready", NEXT),
+        valid_until: time(120),
+      },
+    });
+    assert.equal(refreshed.state, "ready");
+    assert.equal(refreshed.valid_until, time(120));
+
+    await assert.rejects(
+      async () =>
+        store.updateMember({
+          expected_revision: 2,
+          member: transition(refreshed, "recovering", LATER),
+        }),
+      AgentFleetContractError,
+    );
+
+    const draining = await store.updateMember({
+      expected_revision: 2,
+      member: transition(refreshed, "draining", LATER),
+    });
+    const offline = await store.updateMember({
+      expected_revision: 3,
+      member: transition(draining, "offline", time(3)),
+    });
+    await assert.rejects(
+      store.updateMember({
+        expected_revision: 3,
+        member: transition(offline, "retired", time(4)),
+      }),
+      StaleAgentFleetMemberError,
+    );
+
+    const recovering = await store.updateMember({
+      expected_revision: 4,
+      member: transition(offline, "recovering", time(4), 2),
+    });
+    assert.equal(recovering.generation, 2);
+    assert.equal(recovering.capability_manifest.generation, 2);
+    const ready = await store.updateMember({
+      expected_revision: 5,
+      member: transition(recovering, "ready", time(5)),
+    });
+    const forcedOffline = await store.updateMember({
+      expected_revision: 6,
+      member: transition(ready, "offline", time(6)),
+    });
+    const retired = await store.updateMember({
+      expected_revision: 7,
+      member: transition(forcedOffline, "retired", time(7)),
+    });
+    assert.equal(retired.state, "retired");
+    await assert.rejects(
+      async () =>
+        store.updateMember({
+          expected_revision: retired.revision,
+          member: transition(retired, "recovering", time(8), 3),
+        }),
+      /retired->recovering is not allowed/,
+    );
+  });
+
+  test("selects the same compatible ready peer for every candidate order", () => {
+    const fixture = mailboxFixture();
+    const readyA = member("worker-a", "ready", 1, 1, NOW);
+    const readyB = member("worker-b", "ready", 1, 1, NOW);
+    const degraded = member("worker-c", "degraded", 1, 1, NOW);
+    const offline = member("worker-d", "offline", 1, 1, NOW);
+    const missing = member("worker-e", "ready", 1, 1, NOW, []);
+    const incompatible = member("worker-f", "ready", 1, 1, NOW, undefined, "v2");
+
+    const first = rankCompatibleAgentFleetPeers({
+      candidates: [readyA, degraded, missing, readyB, offline, incompatible],
+      message: fixture.message,
+      observed_at: NOW,
+      packet: fixture.packet,
+      sender: fixture.sender,
+    });
+    const reversed = rankCompatibleAgentFleetPeers({
+      candidates: [incompatible, offline, readyB, missing, degraded, readyA],
+      message: fixture.message,
+      observed_at: NOW,
+      packet: fixture.packet,
+      sender: fixture.sender,
+    });
+
+    assert.deepEqual(
+      first.compatible.map((candidate) => candidate.member.member_id),
+      reversed.compatible.map((candidate) => candidate.member.member_id),
+    );
+    assert.deepEqual(
+      first.compatible.slice(0, 2).map((candidate) => candidate.member.state),
+      ["ready", "ready"],
+    );
+    assert.equal(first.compatible.at(-1)?.member.member_id, "worker-c");
+    assert.ok(
+      first.rejected.some(
+        (candidate) =>
+          candidate.member_id === "worker-e" &&
+          candidate.reasons.some((reason) => reason.includes("knowledge.read@v1")),
+      ),
+    );
+    assert.ok(
+      first.rejected.some(
+        (candidate) =>
+          candidate.member_id === "worker-f" &&
+          candidate.reasons.includes("contract_version_not_readable"),
+      ),
+    );
+    assert.ok(
+      first.rejected.some(
+        (candidate) => candidate.member_id === "worker-d",
+      ),
+    );
+  });
+
+  test("accepts only bounded content-addressed redacted payload references", () => {
+    const fixture = mailboxFixture();
+    assert.doesNotThrow(() => validateAgentFleetMessage(fixture.message));
+    assert.equal(
+      fixture.message.message_id,
+      agentFleetMessageIdentity(fixture.message),
+    );
+    assert.match(
+      fixture.message.payload.payload_ref,
+      /^agent-fleet-payload:\/\/sha256\//,
+    );
+    assert.equal("payload" in fixture.message, true);
+    assert.equal("raw_payload" in fixture.message, false);
+
+    assert.throws(
+      () =>
+        createAgentFleetPayloadReference({
+          byte_length: 65_537,
+          media_type: "text/plain",
+          payload_digest: digest("payload"),
+          redaction_receipt_digest: digest("redaction"),
+        }),
+      /payload byte length exceeds its bound/,
+    );
+    assert.throws(
+      () =>
+        createAgentFleetMessage({
+          ...messageInput(fixture.packet, fixture.sender, fixture.payload),
+          raw_payload: "unredacted input",
+        } as ReturnType<typeof messageInput>),
+      /unsupported fields/,
+    );
+    assert.throws(
+      () =>
+        createAgentFleetMessage({
+          ...messageInput(fixture.packet, fixture.sender, fixture.payload),
+          message_sequence: 2,
+        }),
+      /requires checkpoint and handoff references/,
+    );
+  });
+
+  test("permits acknowledgement only after durable mailbox and run admission", async () => {
+    const store = new GatedAgentFleetStore();
+    const capacity = new ReferenceMemoryCapacityStore();
+    const coordinator = new AgentFleetCoordinator({ capacity, fleet: store });
+    const fixture = mailboxFixture();
+    await store.registerMember(fixture.sender);
+
+    store.holdAdmission();
+    let acknowledged = false;
+    const pending = coordinator.admit(fixture.message, fixture.packet).then((result) => {
+      acknowledged = result.acknowledgement_permitted;
+      return result;
+    });
+    await Promise.resolve();
+    assert.equal(acknowledged, false);
+    assert.equal(await store.readMailboxMessage(fixture.message.message_id), undefined);
+    assert.equal(await store.readPacket(fixture.packet.packet_id), undefined);
+
+    store.releaseAdmission();
+    const admitted = await pending;
+    assert.equal(admitted.acknowledgement_permitted, true);
+    assert.equal(admitted.duplicate, false);
+    assert.equal(
+      store.distributedWork.hasRunnableRun(fixture.packet.child_run.run_id),
+      true,
+    );
+    assert.equal(store.distributedWork.readRun(fixture.packet.child_run.run_id)?.state, "queued");
+
+    const retry = await coordinator.admit(
+      structuredClone(fixture.message),
+      structuredClone(fixture.packet),
+    );
+    assert.equal(retry.duplicate, true);
+    assert.equal(retry.receipt.receipt_id, admitted.receipt.receipt_id);
+
+    const changed = createAgentFleetMessage({
+      ...messageInput(fixture.packet, fixture.sender, fixture.payload),
+      created_at: NEXT,
+    });
+    await assert.rejects(
+      coordinator.admit(changed, fixture.packet),
+      AgentFleetIdempotencyConflictError,
+    );
+  });
+
+  test("uses durable capacity permits after deterministic compatibility ranking", async () => {
+    const store = new ReferenceMemoryAgentFleetStore();
+    const capacity = new ReferenceMemoryCapacityStore();
+    const coordinator = new AgentFleetCoordinator({ capacity, fleet: store });
+    const fixture = mailboxFixture();
+    const candidates = [
+      member("worker-a", "ready", 1, 1, NOW),
+      member("worker-b", "ready", 1, 1, NOW),
+    ];
+    await store.registerMember(fixture.sender);
+    for (const candidate of candidates) await store.registerMember(candidate);
+    await coordinator.admit(fixture.message, fixture.packet);
+
+    const ranking = rankCompatibleAgentFleetPeers({
+      candidates,
+      message: fixture.message,
+      observed_at: NOW,
+      packet: fixture.packet,
+      sender: fixture.sender,
+    });
+    const first = ranking.compatible[0]?.member;
+    const second = ranking.compatible[1]?.member;
+    assert.ok(first !== undefined && second !== undefined);
+    await capacity.acquire({
+      acquired_at: NOW,
+      acquisition_key: "preexisting-capacity",
+      expires_at: EXPIRES,
+      generation: first.generation,
+      owner_id: "other-owner",
+      permit_id: "preexisting-permit",
+      permit_limit: 1,
+      resource_ref: first.capacity_resource_ref,
+      run_id: "other-run",
+    });
+
+    const reservation = await coordinator.reserveCompatiblePeer(
+      fixture.message.message_id,
+      {
+        acquired_at: NOW,
+        expires_at: EXPIRES,
+        permit_limits: {
+          [first.member_id]: 1,
+          [second.member_id]: 1,
+        },
+        reservation_key: "attempt",
+      },
+    );
+    assert.equal(reservation.status, "reserved");
+    if (reservation.status !== "reserved") assert.fail("expected reservation");
+    assert.equal(reservation.attempts[0]?.status, "unavailable");
+    assert.equal(reservation.candidate.member.member_id, second.member_id);
+    assert.equal(reservation.permit.owner_id, second.member_id);
+    assert.equal(reservation.permit.run_id, fixture.packet.child_run.run_id);
+
+    const replay = await coordinator.reserveCompatiblePeer(
+      fixture.message.message_id,
+      {
+        acquired_at: NOW,
+        expires_at: EXPIRES,
+        permit_limits: {
+          [first.member_id]: 1,
+          [second.member_id]: 1,
+        },
+        reservation_key: "attempt",
+      },
+    );
+    assert.equal(replay.status, "reserved");
+    if (replay.status !== "reserved") assert.fail("expected replay");
+    assert.equal(replay.permit.permit_id, reservation.permit.permit_id);
+    const replayedAttempt = replay.attempts.at(-1);
+    assert.equal(replayedAttempt?.status, "acquired");
+    assert.equal(
+      replayedAttempt?.status === "acquired"
+        ? replayedAttempt.replayed
+        : undefined,
+      true,
+    );
+  });
+
+  test("binds execution to current generation, fence, checkpoint, and handoff", async () => {
+    const store = new ReferenceMemoryAgentFleetStore();
+    const capacity = new ReferenceMemoryCapacityStore();
+    const coordinator = new AgentFleetCoordinator({ capacity, fleet: store });
+    const fixture = mailboxFixture();
+    const worker = member("worker-a", "ready", 2, 1, NOW);
+    await store.registerMember(fixture.sender);
+    await store.registerMember(worker);
+    await coordinator.admit(fixture.message, fixture.packet);
+    const reservation = await coordinator.reserveCompatiblePeer(
+      fixture.message.message_id,
+      {
+        acquired_at: NOW,
+        expires_at: EXPIRES,
+        permit_limits: { [worker.member_id]: 1 },
+        reservation_key: "execution-1",
+      },
+    );
+    assert.equal(reservation.status, "reserved");
+    if (reservation.status !== "reserved") assert.fail("expected reservation");
+    const lease = workLease(fixture.packet, worker);
+    const initial = await coordinator.bindExecution({
+      bound_at: NEXT,
+      lease,
+      member_id: worker.member_id,
+      message_id: fixture.message.message_id,
+      permit: reservation.permit,
+    });
+    assert.equal(initial.generation, worker.generation);
+    assert.equal(initial.fencing_token, lease.fencing_token);
+    assert.equal(initial.checkpoint_ref, undefined);
+
+    await assert.rejects(
+      coordinator.bindExecution({
+        bound_at: NEXT,
+        lease: { ...lease, generation: 1 },
+        member_id: worker.member_id,
+        message_id: fixture.message.message_id,
+        permit: reservation.permit,
+      }),
+      /work lease does not fence this member and run/,
+    );
+
+    const checkpoint = checkpointFixture(fixture.packet, 1);
+    const resume = createAgentFleetResumeReference(
+      checkpoint,
+      digest("handoff-1"),
+    );
+    const handoff = createAgentFleetMessage({
+      ...messageInput(fixture.packet, fixture.sender, fixture.payload),
+      created_at: LATER,
+      idempotency_key: "mailbox-idempotency-2",
+      message_sequence: 2,
+      resume,
+    });
+    await coordinator.admit(handoff, fixture.packet);
+    const resumed = await coordinator.bindExecution({
+      bound_at: time(3),
+      checkpoint,
+      lease,
+      member_id: worker.member_id,
+      message_id: handoff.message_id,
+      permit: reservation.permit,
+    });
+    assert.equal(resumed.checkpoint_ref, resume.checkpoint_ref);
+    assert.equal(resumed.handoff_ref, resume.handoff_ref);
+
+    await assert.rejects(
+      coordinator.bindExecution({
+        bound_at: time(3),
+        checkpoint: { ...checkpoint, sequence: 2 },
+        lease,
+        member_id: worker.member_id,
+        message_id: handoff.message_id,
+        permit: reservation.permit,
+      }),
+      /resume references do not match/,
+    );
+  });
+});
+
+class GatedAgentFleetStore extends ReferenceMemoryAgentFleetStore {
+  private gate?: Deferred;
+
+  holdAdmission(): void {
+    this.gate = deferred();
+  }
+
+  releaseAdmission(): void {
+    this.gate?.resolve();
+    this.gate = undefined;
+  }
+
+  async admitMailboxAndEnqueue(
+    commit: AgentFleetMailboxAdmissionCommit,
+  ): Promise<AgentFleetMailboxAdmissionResult> {
+    await this.gate?.promise;
+    return super.admitMailboxAndEnqueue(commit);
+  }
+}
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve(): void;
+}
+
+function deferred(): Deferred {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function mailboxFixture(): {
+  message: AgentFleetMessageV1;
+  packet: DistributedWorkPacketV1;
+  payload: AgentFleetPayloadReferenceV1;
+  sender: AgentFleetMemberV1;
+} {
+  const payload = createAgentFleetPayloadReference({
+    byte_length: 128,
+    media_type: "application/json",
+    payload_digest: digest("redacted-payload"),
+    redaction_receipt_digest: digest("redaction-receipt"),
+  });
+  const packet = packetFixture(payload);
+  const sender = member("sender", "ready", 1, 1, NOW);
+  return {
+    message: createAgentFleetMessage(messageInput(packet, sender, payload)),
+    packet,
+    payload,
+    sender,
+  };
+}
+
+function messageInput(
+  packet: DistributedWorkPacketV1,
+  sender: AgentFleetMemberV1,
+  payload: AgentFleetPayloadReferenceV1,
+) {
+  return {
+    created_at: NOW,
+    idempotency_key: "mailbox-idempotency-1",
+    message_sequence: 1,
+    packet_id: packet.packet_id,
+    payload,
+    protocol_version: AGENT_FLEET_PROTOCOL_VERSION,
+    run_id: packet.child_run.run_id,
+    sender_generation: sender.generation,
+    sender_member_id: sender.member_id,
+  };
+}
+
+function packetFixture(
+  payload: AgentFleetPayloadReferenceV1,
+): DistributedWorkPacketV1 {
+  const input: DistributedWorkPacketIdentityInput = {
+    child_run_kind: "interactive",
+    correlation_id: "fleet-correlation-1",
+    deliverables: [
+      {
+        deliverable_id: "deliverable-1",
+        requirement_digest: digest("deliverable-1"),
+        requirement_ref: "deliverable-requirement://opaque/1",
+        sequence: 1,
+      },
+    ],
+    idempotency_key: "distributed-work-idempotency-1",
+    objective_digest: payload.payload_digest,
+    objective_ref: payload.payload_ref,
+    parent_run_id: "parent-run-1",
+    parent_subject_ref: "parent-subject-1",
+    required_capabilities: capabilities(),
+    retention_policy_ref: "retention-policy://standard/1",
+    tenant_id: "tenant-opaque-1",
+    thread_ref: "thread-binding://opaque/1",
+    turn_ref: "turn-receipt://opaque/1",
+  };
+  const packetId = distributedWorkPacketIdentity(input);
+  const intentDigest = distributedWorkIntentDigest(input);
+  return {
+    ...input,
+    child_run: runReceipt(input, packetId, intentDigest),
+    created_at: NOW,
+    intent_digest: intentDigest,
+    packet_id: packetId,
+    schema_version: DISTRIBUTED_WORK_PACKET_SCHEMA_VERSION,
+  };
+}
+
+function runReceipt(
+  input: DistributedWorkPacketIdentityInput,
+  packetId: string,
+  intentDigest: string,
+): RunReceiptV1 {
+  return {
+    admitted_at: NOW,
+    binding_id: "binding-opaque-1",
+    idempotency_key: input.idempotency_key,
+    input_digest: intentDigest,
+    receipt_id: "run-receipt-1",
+    received_at: NOW,
+    required_capabilities: structuredClone(input.required_capabilities),
+    retention_policy_ref: input.retention_policy_ref,
+    revision: 1,
+    run_id: "fleet-run-1",
+    run_kind: input.child_run_kind,
+    schema_version: "run-receipt/v1",
+    state: "queued",
+    subject_ref: packetId,
+    tenant_id: input.tenant_id,
+    updated_at: NOW,
+  };
+}
+
+function member(
+  memberId: string,
+  state: AgentFleetMemberV1["state"],
+  generation: number,
+  revision: number,
+  updatedAt: string,
+  memberCapabilities: CapabilityRequirement[] | undefined = capabilities(),
+  schemaVersion = "v1",
+): AgentFleetMemberV1 {
+  return {
+    capability_manifest: {
+      capabilities: structuredClone(memberCapabilities),
+      contract_versions: [AGENT_FLEET_PROTOCOL_VERSION],
+      digest: digest(`manifest:${memberId}:${generation}:${schemaVersion}`),
+      generation,
+      produced_at: updatedAt,
+      schema_version: "capability-manifest/v1",
+      service_id: `service-${memberId}`,
+    },
+    capacity_resource_ref: `capacity://fleet/${memberId}`,
+    generation,
+    member_id: memberId,
+    protocol_version: AGENT_FLEET_PROTOCOL_VERSION,
+    registered_at: NOW,
+    revision,
+    schema_compatibility: {
+      capability_decisions: ["supported", "degraded", "blocked", "incompatible"],
+      current_version: schemaVersion,
+      read_versions: [schemaVersion],
+      rolling_upgrade_rule: "read current and previous; write current",
+      write_versions: [schemaVersion],
+    },
+    schema_version: "agent-fleet-member/v1",
+    service_id: `service-${memberId}`,
+    state,
+    updated_at: updatedAt,
+    valid_until: EXPIRES,
+  };
+}
+
+function transition(
+  current: AgentFleetMemberV1,
+  state: AgentFleetMemberV1["state"],
+  updatedAt: string,
+  generation = current.generation,
+): AgentFleetMemberV1 {
+  const next = structuredClone(current);
+  next.state = state;
+  next.revision += 1;
+  next.updated_at = updatedAt;
+  next.generation = generation;
+  next.capability_manifest.generation = generation;
+  next.capability_manifest.produced_at = updatedAt;
+  if (generation !== current.generation) {
+    next.capability_manifest.digest = digest(
+      `manifest:${current.member_id}:${generation}:v1`,
+    );
+  }
+  return next;
+}
+
+function workLease(
+  packet: DistributedWorkPacketV1,
+  worker: AgentFleetMemberV1,
+): WorkLeaseV1 {
+  return {
+    fencing_token: 7,
+    generation: worker.generation,
+    heartbeat_at: NEXT,
+    lease_expires_at: EXPIRES,
+    lease_token: "fleet-lease-token-1",
+    owner_id: worker.member_id,
+    run_id: packet.child_run.run_id,
+    schema_version: "work-lease/v1",
+  };
+}
+
+function checkpointFixture(
+  packet: DistributedWorkPacketV1,
+  generation: number,
+): CheckpointV1 {
+  return {
+    checkpoint_id: "checkpoint-1",
+    completed_step_ids: ["step-1"],
+    created_at: NEXT,
+    effect_receipt_ids: [],
+    generation,
+    payload_digest: digest("checkpoint-payload"),
+    payload_ref: "checkpoint-payload://opaque/1",
+    resume_cursor: "step-2",
+    run_id: packet.child_run.run_id,
+    run_revision: 2,
+    schema_version: "checkpoint/v1",
+    sequence: 1,
+  };
+}
+
+function capabilities(): CapabilityRequirement[] {
+  return [
+    {
+      capability_id: "knowledge.read",
+      level: "required",
+      version: "v1",
+    },
+  ];
+}
+
+function digest(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function time(minutes: number): string {
+  return new Date(Date.parse(NOW) + minutes * 60_000).toISOString();
+}


### PR DESCRIPTION
Adds a topology-neutral fleet protocol for durable peer admission, compatibility-aware selection, fenced execution binding, and permanent retirement. The implementation composes the existing run, lease, checkpoint, capacity, and distributed-work contracts, keeps message content behind bounded digest references, and includes a conformance-only durable store plus focused tests.