### PR TITLE
fix: throttle orchestrated graph ingest

### DIFF
--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -30,6 +30,7 @@ const (
 	MaxPageLimit                      = 100
 	DefaultStatusLimit                = 25
 	MaxStatusLimit                    = 500
+	defaultOrchestratorPageLimit      = 5
 	progressRunUpdateTimeout          = 15 * time.Second
 	terminalRunUpdateTimeout          = 15 * time.Second
 	defaultCleanupLimit               = 1000
@@ -273,6 +274,8 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (resul
 	if err != nil {
 		return nil, err
 	}
+	pageLimit = applyRuntimeBackpressureLimit(request, pageLimit)
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "effective_page_limit", Value: pageLimit})
 	startedAt := time.Now().UTC()
 	run := graphstore.IngestRun{
 		ID:                      ingestRunID(runtimeID, startedAt),
@@ -359,6 +362,13 @@ func (s *Service) acquireRuntimeLease(ctx context.Context, runtimeID string, alr
 		return ctx, noop, fmt.Errorf("%w: %s", sourceruntime.ErrSyncInProgress, runtimeID)
 	}
 	return leaseCtx, release, nil
+}
+
+func applyRuntimeBackpressureLimit(request RuntimeRequest, pageLimit uint32) uint32 {
+	if strings.TrimSpace(request.Trigger) == "orchestrator" && pageLimit > defaultOrchestratorPageLimit {
+		return defaultOrchestratorPageLimit
+	}
+	return pageLimit
 }
 
 func graphIngestTelemetryAttributes(attributes telemetry.Attributes, result *RunResult) telemetry.Attributes {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -135,6 +137,15 @@ type recordingProjectionGraphStore struct {
 	deletedEntities map[string]struct{}
 	deletedLinks    map[string]*ports.ProjectedLink
 	cleanupRequests []ports.ProjectionCleanupRequest
+}
+
+type checkpointProjectionRunStore struct {
+	stubRunStore
+	checkpointProjectionGraphStore
+}
+
+func (s *checkpointProjectionRunStore) Ping(ctx context.Context) error {
+	return s.stubRunStore.Ping(ctx)
 }
 
 func (s *recordingProjectionGraphStore) Ping(context.Context) error { return nil }
@@ -304,6 +315,75 @@ func TestRunRuntimeUsesCallerHeldRuntimeLease(t *testing.T) {
 	}
 }
 
+func TestRunRuntimeAppliesOrchestratorBackpressurePageLimit(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(&multiCursorPagedSource{
+		id:    "paged",
+		pages: graphIngestTestPages(8, "paged"),
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	runtimeStore := &graphingestRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"runtime-paged": {
+				Id:       "runtime-paged",
+				SourceId: "paged",
+				TenantId: "writer",
+			},
+		},
+	}
+	store := &checkpointProjectionRunStore{}
+	service := New(registry, runtimeStore, recordProjectorFunc(func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		return []*ports.ProjectedEntity{{
+			URN:        "urn:cerebro:writer:paged:" + event.GetId(),
+			TenantID:   event.GetTenantId(),
+			SourceID:   event.GetSourceId(),
+			RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+			EntityType: "paged.event",
+			Label:      event.GetId(),
+		}}, nil, nil
+	}), store)
+
+	orchestratorResult, err := service.RunRuntime(context.Background(), RuntimeRequest{
+		RuntimeID:        "runtime-paged",
+		PageLimit:        MaxPageLimit,
+		Trigger:          "orchestrator",
+		RuntimeLeaseHeld: true,
+	})
+	if err != nil {
+		t.Fatalf("RunRuntime(orchestrator) error = %v", err)
+	}
+	if orchestratorResult.Ingest == nil {
+		t.Fatal("RunRuntime(orchestrator) ingest = nil")
+	}
+	if orchestratorResult.Ingest.PagesRead != defaultOrchestratorPageLimit || orchestratorResult.Ingest.EventsRead != defaultOrchestratorPageLimit {
+		t.Fatalf("orchestrator pages/events = %d/%d, want %d/%d", orchestratorResult.Ingest.PagesRead, orchestratorResult.Ingest.EventsRead, defaultOrchestratorPageLimit, defaultOrchestratorPageLimit)
+	}
+	if orchestratorResult.Ingest.NextCursor != "page-5" {
+		t.Fatalf("orchestrator next cursor = %q, want page-5", orchestratorResult.Ingest.NextCursor)
+	}
+
+	manualResult, err := service.RunRuntime(context.Background(), RuntimeRequest{
+		RuntimeID:        "runtime-paged",
+		PageLimit:        6,
+		ResetCheckpoint:  true,
+		Trigger:          "manual",
+		RuntimeLeaseHeld: true,
+	})
+	if err != nil {
+		t.Fatalf("RunRuntime(manual) error = %v", err)
+	}
+	if manualResult.Ingest == nil {
+		t.Fatal("RunRuntime(manual) ingest = nil")
+	}
+	if manualResult.Ingest.PagesRead != 6 || manualResult.Ingest.EventsRead != 6 {
+		t.Fatalf("manual pages/events = %d/%d, want 6/6", manualResult.Ingest.PagesRead, manualResult.Ingest.EventsRead)
+	}
+	if manualResult.Ingest.NextCursor != "page-6" {
+		t.Fatalf("manual next cursor = %q, want page-6", manualResult.Ingest.NextCursor)
+	}
+}
+
 type singlePageSource struct {
 	id     string
 	events []*cerebrov1.EventEnvelope
@@ -334,6 +414,11 @@ type cursorPagedSource struct {
 	pages [][]*cerebrov1.EventEnvelope
 }
 
+type multiCursorPagedSource struct {
+	id    string
+	pages [][]*cerebrov1.EventEnvelope
+}
+
 func (s *cursorPagedSource) Spec() *cerebrov1.SourceSpec {
 	return &cerebrov1.SourceSpec{Id: s.id, Name: "Cursor Paged"}
 }
@@ -354,6 +439,46 @@ func (s *cursorPagedSource) Read(_ context.Context, _ sourcecdk.Config, cursor *
 		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: "page-1"}
 	}
 	return pull, nil
+}
+
+func (s *multiCursorPagedSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: s.id, Name: "Multi Cursor Paged"}
+}
+
+func (s *multiCursorPagedSource) Check(context.Context, sourcecdk.Config) error { return nil }
+
+func (s *multiCursorPagedSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *multiCursorPagedSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	page := 0
+	if cursor != nil {
+		index, err := strconv.Atoi(strings.TrimPrefix(cursor.GetOpaque(), "page-"))
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		page = index
+	}
+	if page < 0 || page >= len(s.pages) {
+		return sourcecdk.Pull{}, fmt.Errorf("page %d out of range", page)
+	}
+	pull := sourcecdk.Pull{Events: s.pages[page]}
+	if page+1 < len(s.pages) {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: fmt.Sprintf("page-%d", page+1)}
+	}
+	return pull, nil
+}
+
+func graphIngestTestPages(count int, sourceID string) [][]*cerebrov1.EventEnvelope {
+	pages := make([][]*cerebrov1.EventEnvelope, 0, count)
+	for index := 0; index < count; index++ {
+		pages = append(pages, []*cerebrov1.EventEnvelope{{
+			Id:       fmt.Sprintf("event-%d", index+1),
+			SourceId: sourceID,
+		}})
+	}
+	return pages
 }
 
 func (s *recordingProjectionGraphStore) DeleteProjectedEntity(_ context.Context, urn string) error {


### PR DESCRIPTION
## Summary

- cap orchestrator-triggered graph ingest to a conservative page limit per pass
- preserve existing manual/API graph ingest page limits
- expose the effective graph ingest page limit in telemetry

## Test Plan

- go -C /Users/jonathan/cerebro-ingest-fix test ./internal/graphingest -count=1
- go -C /Users/jonathan/cerebro-ingest-fix test ./internal/graphingest ./cmd/cerebro -count=1

## Known Invariants

- Source connectors use internal/sourcehttp for outbound HTTP safety.
- Production body reads are bounded with io.LimitReader or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP htu, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: make droid-review-preflight.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with make land-pr PR=<number> so Droid finishes before branch deletion.