### PR TITLE
feat: add Slack operator UX contracts

### DIFF
--- a/apps/slack-companion/src/commands/catalog.ts
+++ b/apps/slack-companion/src/commands/catalog.ts
@@ -33,6 +33,31 @@ export type ParsedSlackCommandV1 =
       readonly name: "remember";
       readonly remember: SlackRememberCommandV1;
       readonly schema_version: "slack-command-intent/v1";
+    }
+  | {
+      readonly command_id: "status";
+      readonly name: "status";
+      readonly schema_version: "slack-command-intent/v1";
+      readonly status_scope: "workspace" | "target";
+      readonly target_hint?: string;
+    }
+  | {
+      readonly command_id: "triage";
+      readonly name: "triage";
+      readonly schema_version: "slack-command-intent/v1";
+      readonly target_hint: string;
+    }
+  | {
+      readonly command_id: "watch";
+      readonly name: "watch";
+      readonly schema_version: "slack-command-intent/v1";
+      readonly target_hint: string;
+    }
+  | {
+      readonly command_id: "recheck";
+      readonly name: "recheck";
+      readonly schema_version: "slack-command-intent/v1";
+      readonly target_hint: string;
     };
 
 export interface SlackCommandCatalogEntryV1 {
@@ -68,6 +93,30 @@ const definitions: readonly SlackCommandDefinition<ParsedSlackCommandV1>[] = [
     usage: "/cerebro remember <note>",
     summary: "Record an explicit note after the host accepts it.",
     parse: ({ rawRest }) => rememberCommand(rawRest),
+  },
+  {
+    command: "status",
+    usage: "/cerebro status [target]",
+    summary: "Show companion and work status.",
+    parse: ({ rawRest }) => statusCommand(rawRest),
+  },
+  {
+    command: "triage",
+    usage: "/cerebro triage <alert-or-thread>",
+    summary: "Start portable alert triage for a host-resolved target.",
+    parse: ({ rawRest }) => targetCommand("triage", rawRest),
+  },
+  {
+    command: "watch",
+    usage: "/cerebro watch <answer-or-evidence>",
+    summary: "Watch a delivered answer or evidence binding for changes.",
+    parse: ({ rawRest }) => targetCommand("watch", rawRest),
+  },
+  {
+    command: "recheck",
+    usage: "/cerebro recheck <answer-or-evidence>",
+    summary: "Request a fresh check of a delivered evidence binding.",
+    parse: ({ rawRest }) => targetCommand("recheck", rawRest),
   },
 ];
 
@@ -144,6 +193,56 @@ function rememberCommand(content: string): ParsedSlackCommandV1 {
     remember,
     schema_version: "slack-command-intent/v1",
   });
+}
+
+function statusCommand(targetHint: string): ParsedSlackCommandV1 {
+  if (!targetHint) {
+    return Object.freeze({
+      command_id: "status",
+      name: "status",
+      schema_version: "slack-command-intent/v1",
+      status_scope: "workspace",
+    });
+  }
+  return Object.freeze({
+    command_id: "status",
+    name: "status",
+    schema_version: "slack-command-intent/v1",
+    status_scope: "target",
+    target_hint: targetHint,
+  });
+}
+
+function targetCommand(
+  name: "triage" | "watch" | "recheck",
+  targetHint: string,
+): ParsedSlackCommandV1 {
+  if (!targetHint) {
+    throw new SlackCommandParseError(`Add a target after /cerebro ${name}.`);
+  }
+  switch (name) {
+    case "triage":
+      return Object.freeze({
+        command_id: "triage",
+        name: "triage",
+        schema_version: "slack-command-intent/v1",
+        target_hint: targetHint,
+      });
+    case "watch":
+      return Object.freeze({
+        command_id: "watch",
+        name: "watch",
+        schema_version: "slack-command-intent/v1",
+        target_hint: targetHint,
+      });
+    case "recheck":
+      return Object.freeze({
+        command_id: "recheck",
+        name: "recheck",
+        schema_version: "slack-command-intent/v1",
+        target_hint: targetHint,
+      });
+  }
 }
 
 function normalizeCommandText(text: string): string {

--- a/apps/slack-companion/src/commands/operator-actions.ts
+++ b/apps/slack-companion/src/commands/operator-actions.ts
@@ -1,0 +1,118 @@
+import { encodeSlackActionEnvelope } from "./codec.js";
+import {
+  createSlackActionRegistry,
+  type SlackActionCatalogV1,
+} from "./contracts.js";
+import {
+  requireSlackKey,
+  requireSlackOpaqueRef,
+  sha256,
+  type SlackActionInputV1,
+} from "../projections/blocks.js";
+
+export type SlackAnswerFeedbackActionIdV1 =
+  | "answer.feedback.helpful"
+  | "answer.feedback.missed_source"
+  | "answer.feedback.wrong_owner"
+  | "answer.feedback.needs_followup";
+
+export interface SlackAnswerFeedbackActionsInputV1 {
+  readonly feedback_key: string;
+  readonly issued_at: string;
+  readonly subject_ref: string;
+}
+
+const FEEDBACK_COMMAND = "answer_feedback";
+const FEEDBACK_CAPABILITY = Object.freeze({
+  capability_id: "assistant.feedback",
+  level: "required" as const,
+  version: "v1",
+});
+
+const FEEDBACK_ACTIONS: readonly {
+  readonly action_id: SlackAnswerFeedbackActionIdV1;
+  readonly action_key: string;
+  readonly label: string;
+  readonly style?: SlackActionInputV1["style"];
+}[] = Object.freeze([
+  Object.freeze({
+    action_id: "answer.feedback.helpful",
+    action_key: "feedback_helpful",
+    label: "Helpful",
+    style: "primary" as const,
+  }),
+  Object.freeze({
+    action_id: "answer.feedback.missed_source",
+    action_key: "feedback_missed_source",
+    label: "Missed source",
+  }),
+  Object.freeze({
+    action_id: "answer.feedback.wrong_owner",
+    action_key: "feedback_wrong_owner",
+    label: "Wrong owner",
+  }),
+  Object.freeze({
+    action_id: "answer.feedback.needs_followup",
+    action_key: "feedback_needs_followup",
+    label: "Needs follow-up",
+  }),
+]);
+
+export const SLACK_OPERATOR_ACTION_CATALOG_V1: SlackActionCatalogV1 = Object.freeze({
+  actions: Object.freeze(
+    FEEDBACK_ACTIONS.map((action) =>
+      Object.freeze({
+        action_id: action.action_id,
+        command: FEEDBACK_COMMAND,
+        parameters: Object.freeze([]),
+        required_capabilities: Object.freeze([FEEDBACK_CAPABILITY]),
+        retry_policy: "idempotent" as const,
+        schema_version: "slack-action-contract/v1" as const,
+        subject_requirement: "required" as const,
+      }),
+    ),
+  ),
+  catalog_id: "cerebro.slack.operator_actions",
+  revision: 1,
+  schema_version: "slack-action-catalog/v1",
+});
+
+export const SLACK_OPERATOR_ACTION_REGISTRY = createSlackActionRegistry(
+  SLACK_OPERATOR_ACTION_CATALOG_V1,
+);
+
+export function projectSlackAnswerFeedbackActions(
+  input: SlackAnswerFeedbackActionsInputV1,
+): readonly SlackActionInputV1[] {
+  const feedbackKey = requireSlackKey(input.feedback_key, "feedback key");
+  const subjectRef = requireSlackOpaqueRef(input.subject_ref, "feedback subject_ref");
+  return Object.freeze(
+    FEEDBACK_ACTIONS.map((action) =>
+      Object.freeze({
+        action_key: action.action_key,
+        label: action.label,
+        ...(action.style === undefined ? {} : { style: action.style }),
+        value: encodeSlackActionEnvelope({
+          action: action.action_id,
+          command: FEEDBACK_COMMAND,
+          idempotency_key: feedbackIdempotencyKey(
+            feedbackKey,
+            subjectRef,
+            action.action_id,
+          ),
+          issued_at: input.issued_at,
+          schema_version: "slack-action-envelope/v1",
+          subject_ref: subjectRef,
+        }),
+      }),
+    ),
+  );
+}
+
+function feedbackIdempotencyKey(
+  feedbackKey: string,
+  subjectRef: string,
+  actionId: SlackAnswerFeedbackActionIdV1,
+): string {
+  return `feedback:${sha256(JSON.stringify([feedbackKey, subjectRef, actionId]))}`;
+}

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -14,6 +14,7 @@ export * from "./commands/contracts.js";
 export * from "./commands/catalog.js";
 export * from "./commands/registry.js";
 export * from "./commands/codec.js";
+export * from "./commands/operator-actions.js";
 export * from "./commands/remember.js";
 export * from "./canonical-work/contracts.js";
 export * from "./canonical-work/coordinator.js";

--- a/apps/slack-companion/test/command-catalog.test.ts
+++ b/apps/slack-companion/test/command-catalog.test.ts
@@ -7,10 +7,10 @@ import {
   SlackCommandParseError,
 } from "../src/index.js";
 
-test("exposes stable immutable help, ask, and remember command identities", () => {
+test("exposes stable immutable operator command identities", () => {
   assert.deepEqual(
     SLACK_COMMAND_CATALOG_V1.commands.map((command) => command.command_id),
-    ["help", "ask", "remember"],
+    ["help", "ask", "remember", "status", "triage", "watch", "recheck"],
   );
   assert.equal(SLACK_COMMAND_CATALOG_V1.schema_version, "slack-command-catalog/v1");
   assert.equal(Object.isFrozen(SLACK_COMMAND_CATALOG_V1), true);
@@ -53,6 +53,46 @@ test("parses remember through the shared registry and portable remember behavior
   assert.equal(parsed.remember.working_memory_target, "team");
   assert.equal(Object.isFrozen(parsed), true);
   assert.equal(Object.isFrozen(parsed.remember), true);
+});
+
+test("parses deterministic operator commands with host-resolved targets", () => {
+  assert.deepEqual(parseSlackCommand("status"), {
+    command_id: "status",
+    name: "status",
+    schema_version: "slack-command-intent/v1",
+    status_scope: "workspace",
+  });
+  assert.deepEqual(parseSlackCommand("status incident://case/123"), {
+    command_id: "status",
+    name: "status",
+    schema_version: "slack-command-intent/v1",
+    status_scope: "target",
+    target_hint: "incident://case/123",
+  });
+  assert.deepEqual(parseSlackCommand("triage <https://example.invalid/alert/123>"), {
+    command_id: "triage",
+    name: "triage",
+    schema_version: "slack-command-intent/v1",
+    target_hint: "<https://example.invalid/alert/123>",
+  });
+  assert.deepEqual(parseSlackCommand("watch the delivered answer above"), {
+    command_id: "watch",
+    name: "watch",
+    schema_version: "slack-command-intent/v1",
+    target_hint: "the delivered answer above",
+  });
+  assert.deepEqual(parseSlackCommand("recheck evidence://binding/abc"), {
+    command_id: "recheck",
+    name: "recheck",
+    schema_version: "slack-command-intent/v1",
+    target_hint: "evidence://binding/abc",
+  });
+});
+
+test("requires targets for target-bound operator commands", () => {
+  assert.throws(() => parseSlackCommand("triage"), /Add a target/);
+  assert.throws(() => parseSlackCommand("watch"), /Add a target/);
+  assert.throws(() => parseSlackCommand("recheck"), /Add a target/);
 });
 
 test("rejects empty explicit questions and command input outside fixed bounds", () => {

--- a/apps/slack-companion/test/operator-actions.test.ts
+++ b/apps/slack-companion/test/operator-actions.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decodeSlackActionEnvelope,
+  decideSlackAction,
+  projectSlackAnswerFeedbackActions,
+  SLACK_OPERATOR_ACTION_CATALOG_V1,
+  SLACK_OPERATOR_ACTION_REGISTRY,
+} from "../src/index.js";
+
+const issuedAt = "2026-07-20T10:00:00.000Z";
+
+test("exposes stable feedback action contracts for delivered answers", () => {
+  assert.equal(
+    SLACK_OPERATOR_ACTION_CATALOG_V1.catalog_id,
+    "cerebro.slack.operator_actions",
+  );
+  assert.deepEqual(
+    SLACK_OPERATOR_ACTION_REGISTRY.actions().map((action) => action.action_id),
+    [
+      "answer.feedback.helpful",
+      "answer.feedback.missed_source",
+      "answer.feedback.needs_followup",
+      "answer.feedback.wrong_owner",
+    ],
+  );
+  for (const action of SLACK_OPERATOR_ACTION_REGISTRY.actions()) {
+    assert.equal(action.command, "answer_feedback");
+    assert.deepEqual(action.parameters, []);
+    assert.equal(action.subject_requirement, "required");
+    assert.deepEqual(action.required_capabilities, [
+      {
+        capability_id: "assistant.feedback",
+        level: "required",
+        version: "v1",
+      },
+    ]);
+  }
+});
+
+test("projects deterministic feedback buttons with portable action envelopes", () => {
+  const actions = projectSlackAnswerFeedbackActions({
+    feedback_key: "delivery-123",
+    issued_at: issuedAt,
+    subject_ref: "delivery://assistant-turn/123",
+  });
+  assert.deepEqual(
+    actions.map((action) => action.action_key),
+    [
+      "feedback_helpful",
+      "feedback_missed_source",
+      "feedback_wrong_owner",
+      "feedback_needs_followup",
+    ],
+  );
+  assert.equal(actions[0]?.style, "primary");
+  assert.equal(Object.isFrozen(actions), true);
+  assert.equal(Object.isFrozen(actions[0]), true);
+
+  const decoded = actions.map((action) => decodeSlackActionEnvelope(action.value));
+  assert.deepEqual(
+    decoded.map((action) => action.action),
+    [
+      "answer.feedback.helpful",
+      "answer.feedback.missed_source",
+      "answer.feedback.wrong_owner",
+      "answer.feedback.needs_followup",
+    ],
+  );
+  for (const action of decoded) {
+    assert.equal(action.command, "answer_feedback");
+    assert.equal(action.issued_at, issuedAt);
+    assert.equal(action.subject_ref, "delivery://assistant-turn/123");
+    assert.match(action.idempotency_key, /^feedback:[a-f0-9]{64}$/);
+    assert.equal(action.parameters, undefined);
+    const decision = decideSlackAction(SLACK_OPERATOR_ACTION_REGISTRY, {
+      action,
+      available_capabilities: [
+        {
+          capability_id: "assistant.feedback",
+          level: "required",
+          version: "v1",
+        },
+      ],
+    });
+    assert.equal(decision.disposition, "admit");
+    assert.equal(decision.reason_code, "accepted");
+  }
+});
+
+test("feedback buttons fail closed without the feedback capability", () => {
+  const [button] = projectSlackAnswerFeedbackActions({
+    feedback_key: "delivery-123",
+    issued_at: issuedAt,
+    subject_ref: "delivery://assistant-turn/123",
+  });
+  assert.ok(button);
+  const decision = decideSlackAction(SLACK_OPERATOR_ACTION_REGISTRY, {
+    action: decodeSlackActionEnvelope(button.value),
+    available_capabilities: [],
+  });
+  assert.equal(decision.disposition, "reject");
+  assert.equal(decision.reason_code, "missing_capability");
+});


### PR DESCRIPTION
## Summary

- add portable Slack operator command intents for status, triage, watch, and recheck
- add deterministic answer feedback action contracts and button projections
- keep command/action parsing bounded and host-neutral

## Test Plan

- npm --prefix /Users/jonathan/cerebro run check --workspace @writer/cerebro-slack-companion

## Known Invariants

- Source connectors use internal/sourcehttp for outbound HTTP safety.
- Production body reads are bounded with io.LimitReader or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP htu, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: make droid-review-preflight.
- Focus review on changed behavior and the invariants above.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with make land-pr PR=<number> so Droid finishes before branch deletion.