### PR TITLE
fix: harden Slack companion projections

### DIFF
--- a/apps/slack-companion/src/commands/operator-actions.ts
+++ b/apps/slack-companion/src/commands/operator-actions.ts
@@ -198,12 +198,30 @@ export function projectSlackAnswerFeedbackActions(
 export function projectSlackNextStepActions(
   input: SlackNextStepActionsInputV1,
 ): readonly SlackActionInputV1[] {
+  requireExactRecord(
+    input,
+    ["issued_at", "next_step_key", "steps"],
+    "Slack next-step actions input",
+  );
   const nextStepKey = requireSlackKey(input.next_step_key, "next-step key");
-  if (!Array.isArray(input.steps) || input.steps.length > 4) {
-    throw new SlackBlockProjectionError("Slack next-step actions are invalid.");
-  }
+  requirePlainArray(input.steps, 0, 4, "Slack next-step actions");
   const seen = new Set<SlackNextStepActionKindV1>();
-  return Object.freeze(input.steps.map((step) => {
+  return Object.freeze(input.steps.map((rawStep, index) => {
+    requireExactRecord(
+      rawStep,
+      ["kind", "subject_ref"],
+      `Slack next-step action ${index + 1}`,
+    );
+    const step = {
+      kind: rawStep.kind,
+      subject_ref: rawStep.subject_ref,
+    };
+    if (
+      !isNextStepActionKind(step.kind) ||
+      typeof step.subject_ref !== "string"
+    ) {
+      throw new SlackBlockProjectionError("Slack next-step actions are invalid.");
+    }
     const definition = NEXT_STEP_DEFINITIONS.find((candidate) =>
       candidate.kind === step.kind
     );
@@ -231,6 +249,10 @@ export function projectSlackNextStepActions(
   }));
 }
 
+function isNextStepActionKind(value: unknown): value is SlackNextStepActionKindV1 {
+  return NEXT_STEP_DEFINITIONS.some((definition) => definition.kind === value);
+}
+
 function feedbackIdempotencyKey(
   feedbackKey: string,
   subjectRef: string,
@@ -245,4 +267,62 @@ function nextStepIdempotencyKey(
   subjectRef: string,
 ): string {
   return `next:${sha256(JSON.stringify([nextStepKey, kind, subjectRef]))}`;
+}
+
+function requirePlainArray(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+  field: string,
+): asserts value is readonly Record<string, unknown>[] {
+  if (
+    !Array.isArray(value) ||
+    value.length < minimum ||
+    value.length > maximum ||
+    Object.getPrototypeOf(value) !== Array.prototype ||
+    Object.prototype.hasOwnProperty.call(value, "toJSON")
+  ) {
+    throw new SlackBlockProjectionError(`${field} must be a bounded plain array.`);
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.prototype.hasOwnProperty.call(value, index)) {
+      throw new SlackBlockProjectionError(`${field} must not be sparse.`);
+    }
+  }
+}
+
+function requireExactRecord(
+  value: unknown,
+  requiredKeys: readonly string[],
+  field: string,
+): asserts value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new SlackBlockProjectionError(`${field} is invalid.`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (
+    (prototype !== Object.prototype && prototype !== null) ||
+    Object.prototype.hasOwnProperty.call(value, "toJSON")
+  ) {
+    throw new SlackBlockProjectionError(`${field} must be a plain record.`);
+  }
+  let ownKeyCount = 0;
+  for (const key in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+    ownKeyCount += 1;
+    if (ownKeyCount > requiredKeys.length || !requiredKeys.includes(key)) {
+      throw new SlackBlockProjectionError(`${field} contains unsupported fields.`);
+    }
+  }
+  if (
+    ownKeyCount !== requiredKeys.length ||
+    requiredKeys.some((key) => {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      return descriptor === undefined ||
+        !("value" in descriptor) ||
+        descriptor.enumerable !== true;
+    })
+  ) {
+    throw new SlackBlockProjectionError(`${field} is incomplete.`);
+  }
 }

--- a/apps/slack-companion/src/delivery/contracts.ts
+++ b/apps/slack-companion/src/delivery/contracts.ts
@@ -6,6 +6,14 @@ import type {
 
 export type { DeliveryPartV1, DeliveryReceiptV1, WorkLeaseV1 };
 
+export type DeliveryPartWithRetryV1 = DeliveryPartV1 & {
+  next_attempt_at?: string;
+};
+
+export type DeliveryReceiptWithRetryV1 = Omit<DeliveryReceiptV1, "parts"> & {
+  readonly parts: DeliveryPartWithRetryV1[];
+};
+
 export interface DeliveryPayloadPart {
   payload_digest: string;
   payload_ref: string;

--- a/apps/slack-companion/src/delivery/reference-store.ts
+++ b/apps/slack-companion/src/delivery/reference-store.ts
@@ -195,6 +195,7 @@ export class ReferenceMemoryDeliveryStore implements DurableDeliveryPort {
         part.part_id,
         part.state === "delivering" ? "pending" : part.state,
       );
+      delete part.next_attempt_at;
       part.state = "paused";
     }
     stored.claims.clear();
@@ -221,6 +222,12 @@ export class ReferenceMemoryDeliveryStore implements DurableDeliveryPort {
         continue;
       }
       part.state = stored.pausedStates.get(part.part_id) ?? "pending";
+      if (part.state === "failed") {
+        const nextAttemptAt = stored.nextAttemptAt.get(part.part_id);
+        if (nextAttemptAt !== undefined) part.next_attempt_at = nextAttemptAt;
+      } else {
+        delete part.next_attempt_at;
+      }
     }
     stored.pausedStates.clear();
     stored.receipt.state = aggregate(stored);
@@ -240,6 +247,7 @@ export class ReferenceMemoryDeliveryStore implements DurableDeliveryPort {
     this.acceptLease(request.lease, request.occurred_at);
     for (const part of stored.receipt.parts) {
       if (part.state !== "delivered") {
+        delete part.next_attempt_at;
         part.state = "abandoned";
       }
     }

--- a/apps/slack-companion/src/delivery/reference-store.ts
+++ b/apps/slack-companion/src/delivery/reference-store.ts
@@ -7,6 +7,7 @@ import type {
   DeliveryPartClaim,
   DeliveryPlanResult,
   DeliveryReceiptV1,
+  DeliveryReceiptWithRetryV1,
   DeliveryRetryPolicyV1,
   DurableDeliveryPlan,
   WorkLeaseV1,
@@ -24,7 +25,7 @@ interface StoredDelivery {
   nextAttemptAt: Map<string, string>;
   pausedStates: Map<string, DeliveryReceiptV1["parts"][number]["state"]>;
   payloadFingerprint: string;
-  receipt: DeliveryReceiptV1;
+  receipt: DeliveryReceiptWithRetryV1;
   retryPolicy?: DeliveryRetryPolicyV1;
 }
 
@@ -168,6 +169,7 @@ export class ReferenceMemoryDeliveryStore implements DurableDeliveryPort {
     stored.attempts.set(part.part_id, claim.attempt);
     stored.claims.set(part.part_id, copy(claim));
     stored.nextAttemptAt.delete(part.part_id);
+    delete part.next_attempt_at;
     part.state = "delivering";
     stored.receipt.state = "delivering";
     stored.receipt.updated_at = request.now;
@@ -273,6 +275,7 @@ export class ReferenceMemoryDeliveryStore implements DurableDeliveryPort {
     this.requireClaim(stored, request.part_id, request.lease, request.accepted_at);
     part.delivered_at = request.accepted_at;
     part.destination_receipt = request.destination_receipt;
+    delete part.next_attempt_at;
     part.state = "delivered";
     stored.claims.delete(request.part_id);
     stored.receipt.updated_at = request.accepted_at;
@@ -290,7 +293,11 @@ export class ReferenceMemoryDeliveryStore implements DurableDeliveryPort {
       const nextAttemptAt = nextDeliveryAttemptAt(stored, part.part_id, request.failed_at);
       if (nextAttemptAt !== undefined) {
         stored.nextAttemptAt.set(part.part_id, nextAttemptAt);
+        part.next_attempt_at = nextAttemptAt;
       }
+    } else {
+      stored.nextAttemptAt.delete(part.part_id);
+      delete part.next_attempt_at;
     }
     stored.receipt.updated_at = request.failed_at;
     stored.receipt.state = aggregate(stored);
@@ -425,9 +432,9 @@ function aggregate(stored: StoredDelivery): DeliveryReceiptV1["state"] {
 }
 
 function requirePart(
-  receipt: DeliveryReceiptV1,
+  receipt: DeliveryReceiptWithRetryV1,
   partId: string,
-): DeliveryReceiptV1["parts"][number] {
+): DeliveryReceiptWithRetryV1["parts"][number] {
   const part = receipt.parts.find((candidate) => candidate.part_id === partId);
   if (part === undefined) {
     throw new DeliveryNotFoundError("The delivery part does not exist.");

--- a/apps/slack-companion/src/projections/messages.ts
+++ b/apps/slack-companion/src/projections/messages.ts
@@ -101,18 +101,124 @@ export function planSlackRichMessage(
   messageKey: string,
   input: SlackRichMessageInputV1,
 ): SlackMessagePlanV1 {
-  if (
-    input.schema_version !== "slack-rich-message-input/v1" ||
-    !Array.isArray(input.segments) ||
-    input.segments.length === 0 ||
-    input.segments.length > 32
-  ) {
-    throw new SlackMessageProjectionError("Slack rich message input is invalid.");
-  }
-  const rendered = input.segments.map((segment, index) =>
+  const snapshot = snapshotRichMessageInput(input);
+  const rendered = snapshot.segments.map((segment, index) =>
     renderRichSegment(segment, index + 1)
   ).join("\n\n");
   return planSlackMessage(messageKey, rendered);
+}
+
+function snapshotRichMessageInput(
+  input: SlackRichMessageInputV1,
+): SlackRichMessageInputV1 {
+  requireExactRecord(
+    input,
+    ["schema_version", "segments"],
+    "rich message input",
+  );
+  if (input.schema_version !== "slack-rich-message-input/v1") {
+    throw new SlackMessageProjectionError("Slack rich message input is invalid.");
+  }
+  requireJsonArray(input.segments, 1, 32, "rich message segments");
+  return Object.freeze({
+    schema_version: "slack-rich-message-input/v1",
+    segments: Object.freeze(input.segments.map((segment, index) =>
+      snapshotRichSegment(segment, index + 1)
+    )),
+  });
+}
+
+function snapshotRichSegment(
+  segment: unknown,
+  sequence: number,
+): SlackRichMessageSegmentV1 {
+  const type = richSegmentType(segment, sequence);
+  switch (type) {
+    case "text":
+      requireExactRecord(segment, ["text", "type"], `rich segment ${sequence}`);
+      if (typeof segment.text !== "string") {
+        throw new SlackMessageProjectionError("Slack rich text segment is invalid.");
+      }
+      return Object.freeze({ text: segment.text, type });
+    case "code": {
+      const keys = Object.prototype.hasOwnProperty.call(segment, "label")
+        ? ["code", "label", "type"]
+        : ["code", "type"];
+      requireExactRecord(segment, keys, `rich segment ${sequence}`);
+      if (
+        typeof segment.code !== "string" ||
+        (segment.label !== undefined && typeof segment.label !== "string")
+      ) {
+        throw new SlackMessageProjectionError("Slack rich code segment is invalid.");
+      }
+      return Object.freeze({
+        code: segment.code,
+        ...(segment.label === undefined ? {} : { label: segment.label }),
+        type,
+      });
+    }
+    case "citation":
+      requireExactRecord(
+        segment,
+        ["evidence_ref", "label", "type"],
+        `rich segment ${sequence}`,
+      );
+      if (
+        typeof segment.evidence_ref !== "string" ||
+        typeof segment.label !== "string"
+      ) {
+        throw new SlackMessageProjectionError("Slack rich citation segment is invalid.");
+      }
+      return Object.freeze({
+        evidence_ref: segment.evidence_ref,
+        label: segment.label,
+        type,
+      });
+    case "list": {
+      const keys = Object.prototype.hasOwnProperty.call(segment, "title")
+        ? ["items", "title", "type"]
+        : ["items", "type"];
+      requireExactRecord(segment, keys, `rich segment ${sequence}`);
+      requireJsonArray(segment.items, 1, 12, `rich segment ${sequence} items`);
+      if (
+        segment.items.some((item) => typeof item !== "string") ||
+        (segment.title !== undefined && typeof segment.title !== "string")
+      ) {
+        throw new SlackMessageProjectionError("Slack rich list segment is invalid.");
+      }
+      return Object.freeze({
+        items: Object.freeze([...segment.items] as string[]),
+        ...(segment.title === undefined ? {} : { title: segment.title }),
+        type,
+      });
+    }
+  }
+}
+
+function richSegmentType(
+  segment: unknown,
+  sequence: number,
+): SlackRichMessageSegmentV1["type"] {
+  if (segment === null || typeof segment !== "object" || Array.isArray(segment)) {
+    throw new SlackMessageProjectionError(`Slack rich segment ${sequence} is invalid.`);
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(segment, "type");
+  if (
+    descriptor === undefined ||
+    !("value" in descriptor) ||
+    descriptor.enumerable !== true
+  ) {
+    throw new SlackMessageProjectionError(`Slack rich segment ${sequence} is incomplete.`);
+  }
+  switch (descriptor.value) {
+    case "text":
+    case "code":
+    case "citation":
+    case "list":
+      return descriptor.value;
+    default:
+      throw new SlackMessageProjectionError("Slack rich message segment type is unsupported.");
+  }
 }
 
 /** Builds the payload bytes that must be stored before a durable delivery plan. */

--- a/apps/slack-companion/src/projections/multipart.ts
+++ b/apps/slack-companion/src/projections/multipart.ts
@@ -1,5 +1,9 @@
 import { createHash } from "node:crypto";
-import type { DeliveryPartV1, DeliveryReceiptV1 } from "../delivery/contracts.js";
+import type {
+  DeliveryPartV1,
+  DeliveryPartWithRetryV1,
+  DeliveryReceiptV1,
+} from "../delivery/contracts.js";
 
 export const MAX_SLACK_MULTIPART_PARTS = 40;
 
@@ -11,6 +15,7 @@ export interface SlackMultipartAcceptanceV1 {
 export interface SlackMultipartPartProjectionV1 {
   readonly acceptance?: SlackMultipartAcceptanceV1;
   readonly client_message_id: string;
+  readonly next_attempt_at?: string;
   readonly part_id: string;
   readonly payload_digest: string;
   readonly payload_ref: string;
@@ -146,10 +151,12 @@ function projectPart(
       "Undelivered Slack multipart parts cannot carry an acceptance receipt.",
     );
   }
+  const nextAttemptAt = retryTimestamp(part);
 
   return Object.freeze({
     ...(acceptance === undefined ? {} : { acceptance }),
     client_message_id: clientMessageId,
+    ...(nextAttemptAt === undefined ? {} : { next_attempt_at: nextAttemptAt }),
     part_id: partId,
     payload_digest: payloadDigest,
     payload_ref: payloadRef,
@@ -157,6 +164,17 @@ function projectPart(
     sequence: part.sequence,
     state: part.state,
   });
+}
+
+function retryTimestamp(part: DeliveryPartV1): string | undefined {
+  const nextAttemptAt = (part as DeliveryPartWithRetryV1).next_attempt_at;
+  if (nextAttemptAt === undefined) return undefined;
+  if (part.state !== "failed") {
+    throw new SlackMultipartProjectionError(
+      "Only failed Slack multipart parts can carry retry timing.",
+    );
+  }
+  return requiredTimestamp(nextAttemptAt, "next_attempt_at");
 }
 
 function validateAggregateState(

--- a/apps/slack-companion/test/delivery.test.ts
+++ b/apps/slack-companion/test/delivery.test.ts
@@ -15,6 +15,7 @@ import {
   DeliveryFenceError,
   ReferenceMemoryDeliveryStore,
 } from "../src/delivery/reference-store.js";
+import { projectSlackMultipartDelivery } from "../src/projections/multipart.js";
 
 const start = "2026-07-16T12:00:00.000Z";
 
@@ -337,6 +338,57 @@ describe("DeliveryCoordinator", () => {
     assert.equal(second.status, "retry_scheduled");
     assert.equal(second.receipt.state, "delivering");
     assert.equal(sender.callCount, 2);
+  });
+
+  test("clears retry timing when paused or abandoned and restores it on resume", async () => {
+    const clock = new MutableClock(start);
+    const store = new ReferenceMemoryDeliveryStore(1);
+    const sender = new IdempotentSender(clock);
+    sender.rejectAll = true;
+    const coordinator = makeCoordinator(clock, store, sender);
+    const planned = await coordinator.plan(
+      planRequest({
+        parts: [part(1)],
+        retry_policy: {
+          initial_delay_seconds: 5,
+          max_delay_seconds: 30,
+          multiplier: 2,
+          schema_version: "delivery-retry-policy/v1",
+        },
+      }),
+    );
+    const failed = await coordinator.deliverNext(planned.receipt.delivery_id, lease());
+    assert.equal(
+      (failed.receipt.parts[0] as { next_attempt_at?: string } | undefined)?.next_attempt_at,
+      "2026-07-16T12:00:05.000Z",
+    );
+
+    const paused = await coordinator.pause(planned.receipt.delivery_id, lease());
+    assert.equal(paused.parts[0]?.state, "paused");
+    assert.equal(
+      (paused.parts[0] as { next_attempt_at?: string } | undefined)?.next_attempt_at,
+      undefined,
+    );
+    assert.doesNotThrow(() => projectSlackMultipartDelivery(paused));
+
+    const resumed = await coordinator.resume(planned.receipt.delivery_id, lease());
+    assert.equal(resumed.parts[0]?.state, "failed");
+    assert.equal(
+      (resumed.parts[0] as { next_attempt_at?: string } | undefined)?.next_attempt_at,
+      "2026-07-16T12:00:05.000Z",
+    );
+    assert.equal(
+      projectSlackMultipartDelivery(resumed).parts[0]?.next_attempt_at,
+      "2026-07-16T12:00:05.000Z",
+    );
+
+    const abandoned = await coordinator.abandon(planned.receipt.delivery_id, lease());
+    assert.equal(abandoned.parts[0]?.state, "abandoned");
+    assert.equal(
+      (abandoned.parts[0] as { next_attempt_at?: string } | undefined)?.next_attempt_at,
+      undefined,
+    );
+    assert.doesNotThrow(() => projectSlackMultipartDelivery(abandoned));
   });
 
   test("pauses active work, fences stale resume, and resumes without duplicate send", async () => {

--- a/apps/slack-companion/test/delivery.test.ts
+++ b/apps/slack-companion/test/delivery.test.ts
@@ -328,6 +328,10 @@ describe("DeliveryCoordinator", () => {
     const second = await coordinator.deliverNext(planned.receipt.delivery_id, lease());
 
     assert.equal(first.status, "retry_scheduled");
+    assert.equal(
+      (first.receipt.parts[0] as { next_attempt_at?: string } | undefined)?.next_attempt_at,
+      "2026-07-16T12:00:05.000Z",
+    );
     assert.equal(waiting.status, "waiting_for_retry");
     assert.equal(waiting.next_attempt_at, "2026-07-16T12:00:05.000Z");
     assert.equal(second.status, "retry_scheduled");

--- a/apps/slack-companion/test/operator-actions.test.ts
+++ b/apps/slack-companion/test/operator-actions.test.ts
@@ -8,6 +8,7 @@ import {
   projectSlackNextStepActions,
   SLACK_OPERATOR_ACTION_CATALOG_V1,
   SLACK_OPERATOR_ACTION_REGISTRY,
+  SlackBlockProjectionError,
 } from "../src/index.js";
 
 const issuedAt = "2026-07-20T10:00:00.000Z";
@@ -160,4 +161,48 @@ test("projects deterministic next-step actions for watch, recheck, triage, and s
     ],
   });
   assert.equal(admitted.disposition, "admit");
+});
+
+test("next-step actions reject sparse, accessor-backed, and extra-field input shapes", () => {
+  const sparse = new Array<{ kind: "watch_answer"; subject_ref: string }>(1);
+  assert.throws(
+    () => projectSlackNextStepActions({
+      issued_at: issuedAt,
+      next_step_key: "turn-two:next",
+      steps: sparse,
+    }),
+    /must not be sparse/,
+  );
+
+  assert.throws(
+    () => projectSlackNextStepActions({
+      issued_at: issuedAt,
+      next_step_key: "turn-two:extra",
+      steps: [{
+        kind: "watch_answer",
+        subject_ref: "answer://delivered/123",
+        unexpected: true,
+      } as never],
+    }),
+    /unsupported fields/,
+  );
+
+  let invoked = 0;
+  const accessorStep = { kind: "watch_answer" };
+  Object.defineProperty(accessorStep, "subject_ref", {
+    enumerable: true,
+    get() {
+      invoked += 1;
+      throw new Error("caller accessor was invoked");
+    },
+  });
+  assert.throws(
+    () => projectSlackNextStepActions({
+      issued_at: issuedAt,
+      next_step_key: "turn-two:accessor",
+      steps: [accessorStep as never],
+    }),
+    SlackBlockProjectionError,
+  );
+  assert.equal(invoked, 0);
 });

--- a/apps/slack-companion/test/slack-message-projections.test.ts
+++ b/apps/slack-companion/test/slack-message-projections.test.ts
@@ -101,7 +101,52 @@ test("rich message planning rejects unsupported citation and list shapes", () =>
       schema_version: "slack-rich-message-input/v1",
       segments: [{ items: [], type: "list" }],
     }),
-    /rich list segment is invalid/,
+    /rich segment 1 items must be a bounded plain JSON array/,
+  );
+});
+
+test("rich message planning rejects caller-owned executable records before reading fields", () => {
+  let invoked = 0;
+  const executablePrototype = {
+    toJSON() {
+      invoked += 1;
+      throw new Error("caller prototype was invoked");
+    },
+  };
+  const inherited = {
+    schema_version: "slack-rich-message-input/v1" as const,
+    segments: [{ text: "hello", type: "text" as const }],
+  };
+  Object.setPrototypeOf(inherited.segments[0]!, executablePrototype);
+  assert.throws(
+    () => planSlackRichMessage("run-one:inherited-rich", inherited),
+    SlackMessageProjectionError,
+  );
+  assert.equal(invoked, 0);
+
+  const accessor = {
+    schema_version: "slack-rich-message-input/v1" as const,
+    segments: [{}],
+  };
+  Object.defineProperty(accessor.segments[0]!, "type", {
+    enumerable: true,
+    get() {
+      invoked += 1;
+      throw new Error("caller accessor was invoked");
+    },
+  });
+  assert.throws(
+    () => planSlackRichMessage("run-one:accessor-rich", accessor as never),
+    SlackMessageProjectionError,
+  );
+  assert.equal(invoked, 0);
+
+  assert.throws(
+    () => planSlackRichMessage("run-one:extra-rich", {
+      schema_version: "slack-rich-message-input/v1",
+      segments: [{ text: "hello", type: "text", unexpected: true }],
+    } as never),
+    /unsupported fields/,
   );
 });
 

--- a/apps/slack-companion/test/slack-multipart-projection.test.ts
+++ b/apps/slack-companion/test/slack-multipart-projection.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { DeliveryReceiptV1 } from "../src/delivery/contracts.js";
+import type {
+  DeliveryPartWithRetryV1,
+  DeliveryReceiptV1,
+} from "../src/delivery/contracts.js";
 import {
   MAX_SLACK_MULTIPART_PARTS,
   projectSlackMultipartDelivery,
@@ -57,6 +60,38 @@ test("multipart projections preserve retryable failed parts", () => {
   assert.equal(projection.state, "delivering");
   assert.equal(projection.parts[1]?.state, "failed");
   assert.equal(projection.undelivered_part_count, 1);
+});
+
+test("multipart projections expose retry timing for failed parts only", () => {
+  const receipt = deliveryReceipt();
+  const projection = projectSlackMultipartDelivery({
+    ...receipt,
+    parts: [
+      receipt.parts[0]!,
+      {
+        ...receipt.parts[1]!,
+        next_attempt_at: "2026-07-18T10:00:07.000Z",
+        state: "failed",
+      } as DeliveryPartWithRetryV1,
+    ],
+  });
+
+  assert.equal(projection.parts[1]?.state, "failed");
+  assert.equal(projection.parts[1]?.next_attempt_at, "2026-07-18T10:00:07.000Z");
+  assert.throws(
+    () =>
+      projectSlackMultipartDelivery({
+        ...receipt,
+        parts: [
+          receipt.parts[0]!,
+          {
+            ...receipt.parts[1]!,
+            next_attempt_at: "2026-07-18T10:00:07.000Z",
+          } as DeliveryPartWithRetryV1,
+        ],
+      }),
+    /Only failed Slack multipart parts can carry retry timing/,
+  );
 });
 
 test("multipart projection identities distinguish same-time state changes", () => {


### PR DESCRIPTION
## Summary

- Hardens rich Slack message and next-step action projections against malformed caller-owned records, sparse arrays, extra fields, and accessor/prototype-backed inputs.
- Carries delivery retry timing into durable receipt state and multipart projections so retry status can be surfaced after the delivery step returns.
- Adds focused regression coverage for projection hardening and retry timing behavior.

## Test Plan

- `npm --prefix /Users/jonathan/cerebro/apps/slack-companion test`
- `make -C /Users/jonathan/cerebro workspace-check`
- `make -C /Users/jonathan/cerebro workspace-build`

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Droid Review Context

- Fast local preflight: `make droid-review-preflight`.
- Focus review on Slack companion projection input boundaries, retry-state receipts, and multipart status projection.
- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.
- Land with `make land-pr PR=<number>` so Droid finishes before branch deletion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/2044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->