### PR TITLE
fix: harden Slack block projections

### DIFF
--- a/apps/slack-companion/src/projections/blocks.ts
+++ b/apps/slack-companion/src/projections/blocks.ts
@@ -133,31 +133,14 @@ export function projectSlackEphemeralResponse(
 export function projectSlackBlocks(
   input: SlackBlocksInputV1,
 ): SlackBlocksProjectionV1 {
+  const snapshot = snapshotBlocksInput(input);
   const projectionKey = requireSlackKey(
-    input.projection_key,
+    snapshot.projection_key,
     "block projection key",
   );
-  if (!Array.isArray(input.sections)) {
-    throw new SlackBlockProjectionError(
-      "Slack block sections must be an array.",
-    );
-  }
-  if (input.actions !== undefined && !Array.isArray(input.actions)) {
-    throw new SlackBlockProjectionError(
-      "Slack block actions must be an array.",
-    );
-  }
-  if (
-    input.actions !== undefined
-    && input.actions.length > MAX_SLACK_ACTIONS
-  ) {
-    throw new SlackBlockProjectionError(
-      `Slack block actions cannot exceed ${MAX_SLACK_ACTIONS}.`,
-    );
-  }
-  const actions = input.actions === undefined ? [] : [...input.actions];
-  const blockCount = input.sections.length
-    + (input.title === undefined ? 0 : 1)
+  const actions = snapshot.actions ?? [];
+  const blockCount = snapshot.sections.length
+    + (snapshot.title === undefined ? 0 : 1)
     + (actions.length === 0 ? 0 : 1);
   if (blockCount === 0 || blockCount > MAX_SLACK_BLOCKS) {
     throw new SlackBlockProjectionError(
@@ -166,8 +149,8 @@ export function projectSlackBlocks(
   }
 
   const blocks: SlackBlockV1[] = [];
-  if (input.title !== undefined) {
-    const text = slackPlainText(input.title, "block title", 150);
+  if (snapshot.title !== undefined) {
+    const text = slackPlainText(snapshot.title, "block title", 150);
     blocks.push(
       Object.freeze({
         block_id: stableSlackIdentifier("header", [
@@ -179,7 +162,7 @@ export function projectSlackBlocks(
       }),
     );
   }
-  for (const [index, section] of input.sections.entries()) {
+  for (const [index, section] of snapshot.sections.entries()) {
     const text = slackPlainText(
       section,
       `block section ${index + 1}`,
@@ -249,6 +232,88 @@ export function projectSlackBlocks(
       projectionKey,
       truth,
     ),
+  });
+}
+
+function snapshotBlocksInput(input: SlackBlocksInputV1): SlackBlocksInputV1 {
+  requireExactInputRecord(
+    input,
+    ["actions", "projection_key", "sections", "title"],
+    "Slack blocks input",
+  );
+  if (typeof input.projection_key !== "string") {
+    throw new SlackBlockProjectionError("Slack block projection key is invalid.");
+  }
+  if (!Array.isArray(input.sections)) {
+    throw new SlackBlockProjectionError(
+      "Slack block sections must be an array.",
+    );
+  }
+  requirePlainInputArray(
+    input.sections,
+    MAX_SLACK_BLOCKS + 1,
+    "Slack block sections",
+  );
+  if (input.sections.some((section) => typeof section !== "string")) {
+    throw new SlackBlockProjectionError("Slack block sections are invalid.");
+  }
+  if (input.title !== undefined && typeof input.title !== "string") {
+    throw new SlackBlockProjectionError("Slack block title is invalid.");
+  }
+
+  let actions: readonly SlackActionInputV1[] | undefined;
+  if (input.actions !== undefined) {
+    if (!Array.isArray(input.actions)) {
+      throw new SlackBlockProjectionError(
+        "Slack block actions must be an array.",
+      );
+    }
+    if (input.actions.length > MAX_SLACK_ACTIONS) {
+      throw new SlackBlockProjectionError(
+        `Slack block actions cannot exceed ${MAX_SLACK_ACTIONS}.`,
+      );
+    }
+    requirePlainInputArray(
+      input.actions,
+      MAX_SLACK_ACTIONS,
+      "Slack block actions",
+    );
+    actions = Object.freeze(
+      input.actions.map((action, index) =>
+        snapshotActionInput(action, index + 1),
+      ),
+    );
+  }
+
+  return Object.freeze({
+    ...(actions === undefined ? {} : { actions }),
+    projection_key: input.projection_key,
+    sections: Object.freeze([...input.sections]),
+    ...(input.title === undefined ? {} : { title: input.title }),
+  });
+}
+
+function snapshotActionInput(
+  action: SlackActionInputV1,
+  sequence: number,
+): SlackActionInputV1 {
+  const keys = Object.prototype.hasOwnProperty.call(action, "style")
+    ? ["action_key", "label", "style", "value"]
+    : ["action_key", "label", "value"];
+  requireExactInputRecord(action, keys, `Slack block action ${sequence}`);
+  if (
+    typeof action.action_key !== "string" ||
+    typeof action.label !== "string" ||
+    typeof action.value !== "string" ||
+    (action.style !== undefined && typeof action.style !== "string")
+  ) {
+    throw new SlackBlockProjectionError("Slack block action is invalid.");
+  }
+  return Object.freeze({
+    action_key: action.action_key,
+    label: action.label,
+    ...(action.style === undefined ? {} : { style: action.style }),
+    value: action.value,
   });
 }
 
@@ -361,6 +426,40 @@ function requireExactInputRecord(
       || descriptor.set !== undefined
     ) {
       throw new SlackBlockProjectionError(`${field} must contain data fields.`);
+    }
+  }
+}
+
+function requirePlainInputArray(
+  value: readonly unknown[],
+  maximum: number,
+  field: string,
+): void {
+  if (
+    value.length > maximum ||
+    Object.getPrototypeOf(value) !== Array.prototype ||
+    Object.prototype.hasOwnProperty.call(value, "toJSON")
+  ) {
+    throw new SlackBlockProjectionError(`${field} must be a bounded plain array.`);
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (
+      descriptor === undefined ||
+      !("value" in descriptor) ||
+      descriptor.enumerable !== true
+    ) {
+      throw new SlackBlockProjectionError(`${field} must be dense data.`);
+    }
+  }
+  for (const key of Reflect.ownKeys(value)) {
+    if (key === "length") continue;
+    if (typeof key !== "string" || !/^(0|[1-9][0-9]*)$/.test(key)) {
+      throw new SlackBlockProjectionError(`${field} contains unsupported fields.`);
+    }
+    const index = Number(key);
+    if (!Number.isSafeInteger(index) || index >= value.length) {
+      throw new SlackBlockProjectionError(`${field} contains unsupported fields.`);
     }
   }
 }

--- a/apps/slack-companion/src/projections/blocks.ts
+++ b/apps/slack-companion/src/projections/blocks.ts
@@ -297,6 +297,11 @@ function snapshotActionInput(
   action: SlackActionInputV1,
   sequence: number,
 ): SlackActionInputV1 {
+  if (typeof action !== "object" || action === null) {
+    throw new SlackBlockProjectionError(
+      `Slack block action ${sequence} must be a plain record.`,
+    );
+  }
   const keys = Object.prototype.hasOwnProperty.call(action, "style")
     ? ["action_key", "label", "style", "value"]
     : ["action_key", "label", "value"];

--- a/apps/slack-companion/test/slack-block-projections.test.ts
+++ b/apps/slack-companion/test/slack-block-projections.test.ts
@@ -123,6 +123,70 @@ test("block projections reject malformed, duplicate, and oversized input", () =>
   );
 });
 
+test("block projections reject sparse and executable caller-owned input", () => {
+  const sparseSections = new Array<string>(1);
+  assert.throws(
+    () => projectSlackBlocks({
+      projection_key: "run-one:sparse",
+      sections: sparseSections,
+    }),
+    /sections must be dense data/,
+  );
+
+  const extraAction = {
+    action_key: "open_result",
+    label: "Open result",
+    unexpected: true,
+    value: "result://run/one",
+  };
+  assert.throws(
+    () => projectSlackBlocks({
+      actions: [extraAction as never],
+      projection_key: "run-one:extra-action",
+      sections: ["Choose an action."],
+    }),
+    /unsupported fields/,
+  );
+
+  let invoked = 0;
+  const accessorAction = {
+    action_key: "open_result",
+    label: "Open result",
+  };
+  Object.defineProperty(accessorAction, "value", {
+    enumerable: true,
+    get() {
+      invoked += 1;
+      throw new Error("caller accessor was invoked");
+    },
+  });
+  assert.throws(
+    () => projectSlackBlocks({
+      actions: [accessorAction as never],
+      projection_key: "run-one:accessor-action",
+      sections: ["Choose an action."],
+    }),
+    SlackBlockProjectionError,
+  );
+  assert.equal(invoked, 0);
+
+  const accessorInput = {
+    sections: ["Status"],
+  };
+  Object.defineProperty(accessorInput, "projection_key", {
+    enumerable: true,
+    get() {
+      invoked += 1;
+      throw new Error("caller accessor was invoked");
+    },
+  });
+  assert.throws(
+    () => projectSlackBlocks(accessorInput as never),
+    SlackBlockProjectionError,
+  );
+  assert.equal(invoked, 0);
+});
+
 test("ephemeral command responses are deterministic bounded projections", () => {
   const input = {
     actions: [{

--- a/apps/slack-companion/test/slack-block-projections.test.ts
+++ b/apps/slack-companion/test/slack-block-projections.test.ts
@@ -147,6 +147,16 @@ test("block projections reject sparse and executable caller-owned input", () => 
     }),
     /unsupported fields/,
   );
+  for (const action of [null, undefined]) {
+    assert.throws(
+      () => projectSlackBlocks({
+        actions: [action as never],
+        projection_key: "run-one:nullish-action",
+        sections: ["Choose an action."],
+      }),
+      SlackBlockProjectionError,
+    );
+  }
 
   let invoked = 0;
   const accessorAction = {


### PR DESCRIPTION
## Summary
- snapshot and validate Slack block projection inputs before reading caller-owned values
- reject sparse arrays, accessor-backed fields, and unsupported action fields with SlackBlockProjectionError
- add regression coverage for malformed block projection inputs

## Test plan
- npm --prefix /Users/jonathan/cerebro/apps/slack-companion test
- make -C /Users/jonathan/cerebro workspace-check
- make -C /Users/jonathan/cerebro workspace-build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/2045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->