### PR TITLE
Add image input to Cerebro chat

### DIFF
--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -45,6 +45,12 @@ The same shape applies to longer-running work. Slack-visible status can show que
 
 Hosts should record the message parts Slack accepted, not an internal draft. Evaluation and conversation continuity then describe what the person actually received, including partial and failed deliveries.
 
+### Image questions
+
+`planSlackQuestionImageInput` accepts host-projected Slack file references and produces a durable, byte-free image manifest. Image-only mentions receive a concrete inspection question. Captioned images preserve the person's question. The plan requires both `slack.files.read` and `agent.input.image` capabilities.
+
+`resolveQuestionImageInput` asks a host-owned resolver for authenticated private file bytes and returns model-ready image content. The host owns Slack authorization, trusted download hosts, redirect policy, and network access. Portable policy accepts PNG, JPEG, WebP, and GIF, with at most four images, 4 MB per image, and 8 MB total. Resolved bytes must match the declared media type and are never part of durable question work.
+
 `evaluateAssistantTurn` scores one text-free observation derived from durable delivery, claim, source, feedback, and outcome records. An unwanted response, missed response, incomplete delivery, omitted required action, ungrounded or subject-misbound claim, unused available source, missing coverage boundary, hidden source failure, exposed internal machinery, redundant tool call, unnecessary clarification, user correction, or negative feedback is explicit in the receipt. `decideAssistantTurnPromotion` compares one candidate with its exact baseline on at least eight sealed static cases and eight independently generated shadow cases. Duplicate case content cannot count in both partitions. Promotion requires a strict score gain, no blocker increase, fewer blockers when the baseline has any, no material case regression, and no new per-case blocker.
 
 `ImprovementCoordinator.recordOutcomeEvidence` is the only path that can make evaluation, shadow, and promotion evidence fresh. It binds the baseline rows to the pre-authoring head, binds candidate rows to the authored head, runs the promotion decision, and records those three evidence classes only when the decision passes. Generic CI and canary receipts cannot bypass the outcome gate. A candidate becomes ready only when all five exact-head evidence classes are fresh.

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -87,6 +87,7 @@ export * from "./projections/status.js";
 export * from "./question-work/contracts.js";
 export * from "./question-work/coordinator.js";
 export * from "./question-work/dispatch-policy.js";
+export * from "./question-work/image-input.js";
 export * from "./question-work/ports.js";
 export * from "./question-work/reference-store.js";
 export * from "./recheck/contracts.js";

--- a/apps/slack-companion/src/question-work/image-input.ts
+++ b/apps/slack-companion/src/question-work/image-input.ts
@@ -1,0 +1,209 @@
+import { Buffer } from "node:buffer";
+
+export const QUESTION_IMAGE_INPUT_LIMITS = {
+  max_images: 4,
+  max_image_bytes: 4 * 1024 * 1024,
+  max_total_bytes: 8 * 1024 * 1024,
+} as const;
+
+export const QUESTION_IMAGE_CAPABILITY_REFS = [
+  "agent.input.image",
+  "slack.files.read",
+] as const;
+
+export type QuestionImageMimeType =
+  | "image/gif"
+  | "image/jpeg"
+  | "image/png"
+  | "image/webp";
+
+/** Host-projected Slack metadata. file_ref stays opaque to portable code. */
+export interface SlackQuestionImageFile {
+  file_ref: string;
+  mime_type: string;
+  name?: string;
+  size_bytes?: number;
+}
+
+export interface QuestionImageReferenceV1 {
+  declared_bytes?: number;
+  file_ref: string;
+  mime_type: QuestionImageMimeType;
+  name?: string;
+}
+
+/** Durable input contains references and bounds, never private image bytes. */
+export interface QuestionImageInputManifestV1 {
+  images: QuestionImageReferenceV1[];
+  schema_version: "question-image-input/v1";
+  total_declared_bytes: number;
+}
+
+export interface QuestionImagePlanV1 {
+  manifest?: QuestionImageInputManifestV1;
+  question: string;
+  required_capability_refs: string[];
+  schema_version: "question-image-plan/v1";
+}
+
+export interface QuestionImageReadResult {
+  bytes: Uint8Array;
+  mime_type: string;
+}
+
+/**
+ * The host resolves one authenticated Slack file reference. It must not follow
+ * an untrusted redirect or return more than max_bytes.
+ */
+export interface QuestionImageResolverPort {
+  readImage(
+    reference: QuestionImageReferenceV1,
+    max_bytes: number,
+  ): Promise<QuestionImageReadResult>;
+}
+
+/** Model-ready image content for Pi, Flue, or an equivalent vision runtime. */
+export interface QuestionModelImageInput {
+  data: string;
+  mimeType: QuestionImageMimeType;
+  type: "image";
+}
+
+export class QuestionImageInputError extends Error {}
+
+export function planSlackQuestionImageInput(input: {
+  files?: readonly SlackQuestionImageFile[];
+  question?: string;
+}): QuestionImagePlanV1 {
+  const images = (input.files ?? []).flatMap((file) => {
+    const mimeType = normalizeMimeType(file.mime_type);
+    if (!mimeType.startsWith("image/")) return [];
+    if (!isSupportedMimeType(mimeType)) {
+      throw new QuestionImageInputError("Cerebro can inspect PNG, JPEG, WebP, and GIF images in Slack.");
+    }
+    requireReference(file.file_ref, "image file_ref");
+    const declaredBytes = optionalBoundedBytes(file.size_bytes);
+    const name = optionalName(file.name);
+    return [{
+      ...(declaredBytes === undefined ? {} : { declared_bytes: declaredBytes }),
+      file_ref: file.file_ref,
+      mime_type: mimeType,
+      ...(name === undefined ? {} : { name }),
+    } satisfies QuestionImageReferenceV1];
+  });
+  validateImageReferences(images);
+  const question = input.question?.replace(/\s+/g, " ").trim()
+    || (images.length > 0 ? "Inspect the attached image and explain what it shows." : "");
+  if (!question) throw new QuestionImageInputError("A Slack question needs text or an image.");
+  const manifest = images.length > 0 ? {
+    images,
+    schema_version: "question-image-input/v1" as const,
+    total_declared_bytes: images.reduce((total, image) => total + (image.declared_bytes ?? 0), 0),
+  } : undefined;
+  return {
+    ...(manifest === undefined ? {} : { manifest }),
+    question,
+    required_capability_refs: manifest ? [...QUESTION_IMAGE_CAPABILITY_REFS] : [],
+    schema_version: "question-image-plan/v1",
+  };
+}
+
+export async function resolveQuestionImageInput(
+  manifest: QuestionImageInputManifestV1,
+  resolver: QuestionImageResolverPort,
+): Promise<QuestionModelImageInput[]> {
+  validateManifest(manifest);
+  const resolved: QuestionModelImageInput[] = [];
+  let totalBytes = 0;
+  for (const reference of manifest.images) {
+    const result = await resolver.readImage(reference, QUESTION_IMAGE_INPUT_LIMITS.max_image_bytes);
+    if (!(result.bytes instanceof Uint8Array) || result.bytes.byteLength === 0) {
+      throw new QuestionImageInputError("The Slack image is empty or unavailable.");
+    }
+    if (result.bytes.byteLength > QUESTION_IMAGE_INPUT_LIMITS.max_image_bytes) {
+      throw new QuestionImageInputError("Each Slack image must be 4 MB or smaller.");
+    }
+    const resolvedMimeType = normalizeMimeType(result.mime_type);
+    if (!isSupportedMimeType(resolvedMimeType) || resolvedMimeType !== reference.mime_type) {
+      throw new QuestionImageInputError("The downloaded Slack image type does not match its file metadata.");
+    }
+    totalBytes += result.bytes.byteLength;
+    if (totalBytes > QUESTION_IMAGE_INPUT_LIMITS.max_total_bytes) {
+      throw new QuestionImageInputError("Slack images must total 8 MB or less.");
+    }
+    resolved.push({
+      data: Buffer.from(result.bytes).toString("base64"),
+      mimeType: reference.mime_type,
+      type: "image",
+    });
+  }
+  return resolved;
+}
+
+function validateManifest(manifest: QuestionImageInputManifestV1): void {
+  if (manifest.schema_version !== "question-image-input/v1") {
+    throw new QuestionImageInputError("The question image manifest version is unsupported.");
+  }
+  validateImageReferences(manifest.images);
+  const declared = manifest.images.reduce((total, image) => total + (image.declared_bytes ?? 0), 0);
+  if (manifest.total_declared_bytes !== declared) {
+    throw new QuestionImageInputError("The question image manifest byte total does not match its images.");
+  }
+}
+
+function validateImageReferences(images: readonly QuestionImageReferenceV1[]): void {
+  if (images.length > QUESTION_IMAGE_INPUT_LIMITS.max_images) {
+    throw new QuestionImageInputError("Attach up to 4 images at a time.");
+  }
+  const refs = new Set<string>();
+  let totalBytes = 0;
+  for (const image of images) {
+    requireReference(image.file_ref, "image file_ref");
+    if (refs.has(image.file_ref)) throw new QuestionImageInputError("Slack image references must be distinct.");
+    refs.add(image.file_ref);
+    if (!isSupportedMimeType(image.mime_type)) {
+      throw new QuestionImageInputError("Cerebro can inspect PNG, JPEG, WebP, and GIF images in Slack.");
+    }
+    if (image.declared_bytes !== undefined) {
+      optionalBoundedBytes(image.declared_bytes);
+      totalBytes += image.declared_bytes;
+    }
+  }
+  if (totalBytes > QUESTION_IMAGE_INPUT_LIMITS.max_total_bytes) {
+    throw new QuestionImageInputError("Slack images must total 8 MB or less.");
+  }
+}
+
+function optionalBoundedBytes(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new QuestionImageInputError("Slack image size must be a positive integer.");
+  }
+  if (value > QUESTION_IMAGE_INPUT_LIMITS.max_image_bytes) {
+    throw new QuestionImageInputError("Each Slack image must be 4 MB or smaller.");
+  }
+  return value;
+}
+
+function optionalName(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new QuestionImageInputError("Slack image names must be text.");
+  const name = value.trim();
+  if (!name || name.length > 500) throw new QuestionImageInputError("Slack image names must be 500 characters or fewer.");
+  return name;
+}
+
+function normalizeMimeType(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.split(";", 1)[0]!.trim().toLowerCase();
+}
+
+function isSupportedMimeType(value: string): value is QuestionImageMimeType {
+  return value === "image/gif" || value === "image/jpeg" || value === "image/png" || value === "image/webp";
+}
+
+function requireReference(value: string, label: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 2_048) {
+    throw new QuestionImageInputError(`${label} must be a non-empty opaque reference within 2,048 characters.`);
+  }
+}

--- a/apps/slack-companion/test/question-image-input.test.ts
+++ b/apps/slack-companion/test/question-image-input.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  planSlackQuestionImageInput,
+  QuestionImageInputError,
+  resolveQuestionImageInput,
+} from "../src/question-work/image-input.js";
+
+describe("Slack question image input", () => {
+  it("plans captioned and image-only questions without persisting image bytes", () => {
+    const captioned = planSlackQuestionImageInput({
+      question: "  What is wrong in this screenshot? ",
+      files: [{ file_ref: "slack-file://F1", mime_type: "image/png", name: "error.png", size_bytes: 1024 }],
+    });
+    assert.deepEqual(captioned, {
+      manifest: {
+        images: [{ declared_bytes: 1024, file_ref: "slack-file://F1", mime_type: "image/png", name: "error.png" }],
+        schema_version: "question-image-input/v1",
+        total_declared_bytes: 1024,
+      },
+      question: "What is wrong in this screenshot?",
+      required_capability_refs: ["agent.input.image", "slack.files.read"],
+      schema_version: "question-image-plan/v1",
+    });
+    assert.equal(JSON.stringify(captioned).includes("base64"), false);
+
+    const imageOnly = planSlackQuestionImageInput({
+      files: [{ file_ref: "slack-file://F2", mime_type: "image/jpeg" }],
+    });
+    assert.equal(imageOnly.question, "Inspect the attached image and explain what it shows.");
+  });
+
+  it("resolves authenticated host bytes into model-ready image content", async () => {
+    const plan = planSlackQuestionImageInput({
+      question: "Read this screenshot.",
+      files: [{ file_ref: "slack-file://F1", mime_type: "image/png", size_bytes: 4 }],
+    });
+    const calls: unknown[][] = [];
+    const readImage = async (...args: Parameters<import("../src/question-work/image-input.js").QuestionImageResolverPort["readImage"]>) => {
+      calls.push(args);
+      return {
+      bytes: new Uint8Array([137, 80, 78, 71]),
+      mime_type: "image/png",
+      };
+    };
+
+    const images = await resolveQuestionImageInput(plan.manifest!, { readImage });
+
+    assert.deepEqual(calls, [[plan.manifest!.images[0], 4 * 1024 * 1024]]);
+    assert.deepEqual(images, [{ data: "iVBORw==", mimeType: "image/png", type: "image" }]);
+  });
+
+  it("rejects unsupported, oversized, mismatched, and empty host results", async () => {
+    assert.throws(
+      () => planSlackQuestionImageInput({
+        question: "Inspect this.",
+        files: [{ file_ref: "slack-file://F1", mime_type: "image/svg+xml", size_bytes: 100 }],
+      }),
+      new QuestionImageInputError("Cerebro can inspect PNG, JPEG, WebP, and GIF images in Slack."),
+    );
+
+    assert.throws(
+      () => planSlackQuestionImageInput({
+        question: "Inspect this.",
+        files: [{ file_ref: "slack-file://F1", mime_type: "image/png", size_bytes: 4 * 1024 * 1024 + 1 }],
+      }),
+      new QuestionImageInputError("Each Slack image must be 4 MB or smaller."),
+    );
+
+    const plan = planSlackQuestionImageInput({
+      question: "Inspect this.",
+      files: [{ file_ref: "slack-file://F1", mime_type: "image/png" }],
+    });
+    await assert.rejects(resolveQuestionImageInput(plan.manifest!, {
+      readImage: async () => ({ bytes: new Uint8Array([1]), mime_type: "image/jpeg" }),
+    }), /does not match its file metadata/);
+    await assert.rejects(resolveQuestionImageInput(plan.manifest!, {
+      readImage: async () => ({ bytes: new Uint8Array(), mime_type: "image/png" }),
+    }), /empty or unavailable/);
+  });
+});

--- a/apps/web/src/app/api/agent/ask/route.test.ts
+++ b/apps/web/src/app/api/agent/ask/route.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { buildAgentInstructions, buildRuntimeAgentInstructions, forwardLegacyAskBody } from "./route";
+import { buildAgentInput, buildAgentInstructions, buildRuntimeAgentInstructions, forwardLegacyAskBody } from "./route";
 
 const originalProducerCatalog = process.env.CEREBRO_SECURITY_PRODUCERS_JSON;
 
@@ -10,6 +10,29 @@ afterEach(() => {
 });
 
 describe("agent instructions", () => {
+  it("passes attached images to the model as image content", () => {
+    const input = buildAgentInput({
+      question: "What is risky in this screenshot?",
+      tenant_id: "portable-tenant",
+      images: [{
+        id: "image-1",
+        name: "risk.png",
+        media_type: "image/png",
+        data_url: "data:image/png;base64,iVBORw==",
+        size_bytes: 4,
+      }],
+    });
+
+    expect(input).toHaveLength(1);
+    expect(input[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "input_text", text: expect.stringContaining("What is risky in this screenshot?") },
+        { type: "input_image", image: "data:image/png;base64,iVBORw==", detail: "auto" },
+      ],
+    });
+  });
+
   it("keeps request metadata on quoted single lines", () => {
     const instructions = buildAgentInstructions({
       question: "What changed?",

--- a/apps/web/src/app/api/agent/ask/route.test.ts
+++ b/apps/web/src/app/api/agent/ask/route.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { buildAgentInput, buildAgentInstructions, buildRuntimeAgentInstructions, forwardLegacyAskBody } from "./route";
+import { agentPayloadError, buildAgentInput, buildAgentInstructions, buildRuntimeAgentInstructions, forwardLegacyAskBody } from "./route";
 
 const originalProducerCatalog = process.env.CEREBRO_SECURITY_PRODUCERS_JSON;
 
@@ -10,6 +10,20 @@ afterEach(() => {
 });
 
 describe("agent instructions", () => {
+  it("reports invalid image bounds separately from an empty question", () => {
+    expect(agentPayloadError({
+      question: "What is risky in these screenshots?",
+      images: Array.from({ length: 5 }, (_, index) => ({
+        id: `image-${index + 1}`,
+        name: `risk-${index + 1}.png`,
+        media_type: "image/png",
+        data_url: "data:image/png;base64,iVBORw==",
+      })),
+    })).toBe("Attach up to 4 PNG, JPEG, WebP, or GIF images, 4 MB each and 8 MB total.");
+    expect(agentPayloadError({ question: "  ", images: [] }))
+      .toBe("Ask requires a non-empty question.");
+  });
+
   it("passes attached images to the model as image content", () => {
     const input = buildAgentInput({
       question: "What is risky in this screenshot?",

--- a/apps/web/src/app/api/agent/ask/route.ts
+++ b/apps/web/src/app/api/agent/ask/route.ts
@@ -78,6 +78,16 @@ const instructionMetadata = (value: unknown, fallback = "unknown", maxLength = 5
 const quotedInstructionMetadata = (value: unknown, fallback = "unknown", maxLength = 512) =>
   JSON.stringify(instructionMetadata(value, fallback, maxLength));
 
+export const agentPayloadError = (payload: unknown) => {
+  if (!payload || typeof payload !== "object") return "Ask requires a non-empty question.";
+  const source = payload as Record<string, unknown>;
+  if (!trimString(source.question)) return "Ask requires a non-empty question.";
+  if (!normalizeAskImages(source.images)) {
+    return "Attach up to 4 PNG, JPEG, WebP, or GIF images, 4 MB each and 8 MB total.";
+  }
+  return null;
+};
+
 const normalizePayload = (payload: unknown): NormalizedAgentRequest | null => {
   if (!payload || typeof payload !== "object") return null;
   const source = payload as Record<string, unknown>;
@@ -141,14 +151,15 @@ export async function POST(request: NextRequest) {
     return tracedAuthorizationError(decision, span);
   }
 
-  const payload = normalizePayload(rawPayload);
+  const payloadError = agentPayloadError(rawPayload);
+  const payload = payloadError ? null : normalizePayload(rawPayload);
   if (!payload) {
     span.end("completed", {
       payload_valid: false,
       "http.response.status_code": 400,
     });
     const response = NextResponse.json(
-      { error: "Ask requires a non-empty question." },
+      { error: payloadError ?? "Ask requires a non-empty question." },
       { status: 400 },
     );
     response.headers.set("x-cerebro-web-trace-id", span.traceId);

--- a/apps/web/src/app/api/agent/ask/route.ts
+++ b/apps/web/src/app/api/agent/ask/route.ts
@@ -2,6 +2,7 @@ import {
   Agent,
   MCPServerStreamableHttp,
   Runner,
+  type AgentInputItem,
   type RunStreamEvent,
 } from "@openai/agents";
 import { NextRequest, NextResponse } from "next/server";
@@ -20,6 +21,7 @@ import {
 } from "@/lib/ask";
 import { mcpUrlFromApiBase } from "@/lib/ask-agent-config";
 import { ASK_AGENT_FALLBACK_STATUS } from "@/lib/ask-agent-status";
+import { normalizeAskImages } from "@/lib/ask-images";
 import {
   resolveSecurityProducerGuidance,
   securityProducerResponseCandidateHint,
@@ -81,6 +83,8 @@ const normalizePayload = (payload: unknown): NormalizedAgentRequest | null => {
   const source = payload as Record<string, unknown>;
   const question = trimString(source.question);
   if (!question) return null;
+  const images = normalizeAskImages(source.images);
+  if (!images) return null;
   return {
     ...source,
     question,
@@ -91,6 +95,7 @@ const normalizePayload = (payload: unknown): NormalizedAgentRequest | null => {
     context: normalizeContext(source.context),
     surface: trimString(source.surface) || "agent",
     conversation_id: trimString(source.conversation_id) || undefined,
+    images,
   };
 };
 
@@ -165,6 +170,12 @@ export async function POST(request: NextRequest) {
       try {
         if (canRunAgent) {
           await streamAgentRun(controller, request, payload, span);
+        } else if (payload.images?.length) {
+          controller.enqueue(sse("error", normalizeAskError(
+            "image_input_unavailable",
+            "Image analysis is unavailable because the agent runtime is not configured.",
+            true,
+          )));
         } else {
           await streamLegacyAsk(controller, request, payload, span);
         }
@@ -178,7 +189,7 @@ export async function POST(request: NextRequest) {
           component: "agent-ask-route",
           operation: canRunAgent ? "agent_stream" : "legacy_stream",
         });
-        if (canRunAgent && isAgentStartupConfigurationError(error)) {
+        if (canRunAgent && !payload.images?.length && isAgentStartupConfigurationError(error)) {
           span.annotate({
             agent_startup_configuration_fallback: true,
           });
@@ -585,18 +596,29 @@ const contextStringList = (context: AskAgentContext | undefined, key: string) =>
   return [];
 };
 
-const buildAgentInput = (payload: NormalizedAgentRequest) => {
+export const buildAgentInput = (payload: NormalizedAgentRequest): AgentInputItem[] => {
   const context = payload.context
     ? JSON.stringify(payload.context, null, 2)
     : "{}";
   const history = payload.history?.length
     ? payload.history.slice(-8).map((entry) => `${entry.role}: ${entry.content}`).join("\n")
     : "none";
-  return [
+  const text = [
     `Question: ${payload.question}`,
     `Context JSON:\n${context}`,
     `Recent conversation:\n${history}`,
   ].join("\n\n");
+  return [{
+    role: "user",
+    content: [
+      { type: "input_text", text },
+      ...(payload.images ?? []).map((image) => ({
+        type: "input_image" as const,
+        image: image.data_url,
+        detail: "auto",
+      })),
+    ],
+  }];
 };
 
 const contextLabel = (payload: NormalizedAgentRequest) => {
@@ -776,6 +798,7 @@ function agentPayloadSpanAttributes(payload: NormalizedAgentRequest) {
     context_has_scope_urn: Boolean(payload.context?.scopeUrn || payload.scope_urn),
     context_route_family: routeFamily(payload.context?.route),
     conversation_present: Boolean(payload.conversation_id),
+    image_count: payload.images?.length ?? 0,
     history_count: payload.history?.length ?? 0,
     payload_valid: true,
     question_chars: payload.question.length,

--- a/apps/web/src/app/ask/page.tsx
+++ b/apps/web/src/app/ask/page.tsx
@@ -5,7 +5,7 @@ import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "rea
 
 import { useApiKey } from "@/components/providers";
 import { PageHeader } from "@/components/grc/Primitives";
-import AskInput from "@/components/ask/AskInput";
+import AskInput, { type AskInputSubmission } from "@/components/ask/AskInput";
 import AskThread from "@/components/ask/AskThread";
 import SavedQuestions, { type SavedQuestionDraft } from "@/components/ask/SavedQuestions";
 import type { AskAgentReadiness } from "@/lib/ask-agent-status";
@@ -74,7 +74,7 @@ function AskPageInner() {
   }, [activeTurnId]);
 
   const runAsk = useCallback(
-    async (input: { question: string; model: string; tenantId: string; scopeUrn: string }) => {
+    async (input: AskInputSubmission) => {
       const controller = new AbortController();
       abortRef.current?.abort();
       abortRef.current = controller;
@@ -89,6 +89,7 @@ function AskPageInner() {
         model,
         tenantId,
         scopeUrn: input.scopeUrn || undefined,
+        images: input.images,
       });
       setTurns((prev) => [...prev, initial]);
       setActiveTurnId(turnId);
@@ -108,6 +109,7 @@ function AskPageInner() {
           ],
         },
         surface: "ask_page",
+        images: input.images,
       };
       try {
         for await (const event of streamAgentAsk(request, apiKey, controller.signal)) {
@@ -152,6 +154,7 @@ function AskPageInner() {
         model: normalizeAskModel(turn.model),
         tenantId: turn.tenantId ?? "writer",
         scopeUrn: turn.scopeUrn ?? "",
+        images: turn.images ?? [],
       });
     },
     [runAsk],
@@ -222,6 +225,7 @@ function AskPageInner() {
         model: normalizeAskModel(query.model ?? ""),
         tenantId: query.tenant_id || "",
         scopeUrn: query.scope_urn ?? "",
+        images: [],
       });
     },
     [runAsk],
@@ -264,6 +268,7 @@ function AskPageInner() {
         model: seededModel || defaultAskModel,
         tenantId: seededTenant,
         scopeUrn: seededScope,
+        images: [],
       });
     }, 0);
     return () => window.clearTimeout(timer);
@@ -334,7 +339,7 @@ function AskPageInner() {
                 key={sample}
                 type="button"
                 onClick={() =>
-                  void runAsk({ question: sample, model: defaultAskModel, tenantId: "", scopeUrn: "" })
+                  void runAsk({ question: sample, model: defaultAskModel, tenantId: "", scopeUrn: "", images: [] })
                 }
                 className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[13px] text-slate-700 transition hover:border-indigo-300 hover:text-indigo-700"
               >

--- a/apps/web/src/components/agent/CerebroAgentPanel.tsx
+++ b/apps/web/src/components/agent/CerebroAgentPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { type KeyboardEvent, useMemo } from "react";
 import {
   Activity,
@@ -20,6 +21,7 @@ import {
 } from "lucide-react";
 
 import MarkdownSummary from "@/components/ask/MarkdownSummary";
+import ImageAttachments from "@/components/ask/ImageAttachments";
 import { useCerebroAgent } from "@/components/agent/CerebroAgentProvider";
 import { type AskAgentTimelineEvent, type AskTurnState, shortUrn } from "@/lib/ask";
 
@@ -127,10 +129,12 @@ export default function CerebroAgentPanel() {
     clearThread,
     draft,
     isOpen,
+    images,
     openAgent,
     pageContext,
     retryTurn,
     setDraft,
+    setImages,
     setOpen,
     stopActiveTurn,
     submitDraft,
@@ -301,6 +305,7 @@ export default function CerebroAgentPanel() {
 
         <footer className="border-t border-slate-200 bg-white p-3">
           <div className="rounded-lg border border-slate-200 bg-white shadow-sm focus-within:border-indigo-300 focus-within:ring-2 focus-within:ring-indigo-100">
+            <ImageAttachments images={images} onChange={setImages} disabled={Boolean(activeTurnId)} />
             <textarea
               value={draft}
               onChange={(event) => setDraft(event.target.value)}
@@ -314,7 +319,7 @@ export default function CerebroAgentPanel() {
                 <button
                   type="button"
                   onClick={clearThread}
-                  disabled={!turns.length && !draft}
+                  disabled={!turns.length && !draft && !images.length}
                   className="rounded-md p-2 text-slate-400 transition hover:bg-slate-50 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-40"
                   title="Clear"
                 >
@@ -378,6 +383,13 @@ function AgentTurnCard({
           </div>
           <p className="min-w-0 flex-1 text-[13px] font-medium leading-5 text-slate-900">{turn.question}</p>
         </div>
+        {turn.images?.length ? (
+          <div className="mt-3 flex flex-wrap gap-2 pl-10">
+            {turn.images.map((image) => (
+              <Image key={image.id} src={image.data_url} alt={image.name} width={56} height={56} unoptimized className="h-14 w-14 rounded-md border border-slate-200 object-cover" />
+            ))}
+          </div>
+        ) : null}
       </header>
 
       <div className="space-y-3 px-4 py-3">

--- a/apps/web/src/components/agent/CerebroAgentProvider.tsx
+++ b/apps/web/src/components/agent/CerebroAgentProvider.tsx
@@ -24,6 +24,7 @@ import {
   streamAgentAsk,
 } from "@/lib/ask";
 import { routeLabelForPath } from "@/lib/route-labels";
+import type { AskImageAttachment } from "@/lib/ask-images";
 
 type RunAgentInput = {
   question: string;
@@ -32,6 +33,7 @@ type RunAgentInput = {
   model?: string;
   context?: AskAgentContext;
   surface?: string;
+  images?: AskImageAttachment[];
 };
 
 type OpenAgentOptions = {
@@ -46,6 +48,8 @@ type CerebroAgentContextValue = {
   setOpen: (value: boolean) => void;
   draft: string;
   setDraft: (value: string) => void;
+  images: AskImageAttachment[];
+  setImages: (value: AskImageAttachment[]) => void;
   turns: AskTurnState[];
   activeTurnId: string | null;
   pageContext: AskAgentContext;
@@ -139,6 +143,7 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
   const { apiKey } = useApiKey();
   const [isOpen, setOpen] = useState(false);
   const [draft, setDraft] = useState("");
+  const [images, setImages] = useState<AskImageAttachment[]>([]);
   const [turns, setTurns] = useState<AskTurnState[]>([]);
   const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
   const [pageContext, setPageContext] = useState<AskAgentContext>(() => ({
@@ -204,6 +209,7 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
       setPageContext(context);
       setOpen(true);
       setDraft("");
+      setImages([]);
 
       const controller = new AbortController();
       abortRef.current?.abort();
@@ -218,6 +224,7 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
         model,
         tenantId,
         scopeUrn: scopeUrn || undefined,
+        images: input.images,
       });
       setTurns((prev) => [...prev, initial]);
       setActiveTurnId(turnId);
@@ -231,6 +238,7 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
         context,
         surface: input.surface ?? "agent_panel",
         conversation_id: getConversationId(),
+        images: input.images,
       };
 
       try {
@@ -298,6 +306,7 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
         scopeUrn: turn.scopeUrn,
         context: pageContext,
         surface: "agent_panel_retry",
+        images: turn.images,
       });
     },
     [pageContext, runAgent],
@@ -309,6 +318,7 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
     setTurns([]);
     setActiveTurnId(null);
     setDraft("");
+    setImages([]);
     conversationIdRef.current = null;
   }, []);
 
@@ -318,8 +328,9 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
       question: draft,
       context: pageContext,
       surface: "agent_panel",
+      images,
     });
-  }, [activeTurnId, draft, pageContext, runAgent]);
+  }, [activeTurnId, draft, images, pageContext, runAgent]);
 
   const value = useMemo<CerebroAgentContextValue>(
     () => ({
@@ -327,6 +338,8 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
       setOpen,
       draft,
       setDraft,
+      images,
+      setImages,
       turns,
       activeTurnId,
       pageContext,
@@ -342,6 +355,7 @@ export function CerebroAgentProvider({ children }: { children: React.ReactNode }
       clearThread,
       draft,
       isOpen,
+      images,
       openAgent,
       pageContext,
       retryTurn,

--- a/apps/web/src/components/ask/AskInput.tsx
+++ b/apps/web/src/components/ask/AskInput.tsx
@@ -1,13 +1,23 @@
 "use client";
 
 import { useForm } from "@tanstack/react-form";
-import { type KeyboardEvent, useEffect } from "react";
+import { type KeyboardEvent, useEffect, useState } from "react";
 
+import ImageAttachments from "@/components/ask/ImageAttachments";
 import type { AskAgentReadiness } from "@/lib/ask-agent-status";
 import { askModelOptions, defaultAskModel } from "@/lib/ask";
+import type { AskImageAttachment } from "@/lib/ask-images";
+
+export type AskInputSubmission = {
+  question: string;
+  model: string;
+  tenantId: string;
+  scopeUrn: string;
+  images: AskImageAttachment[];
+};
 
 type Props = {
-  onSubmit: (input: { question: string; model: string; tenantId: string; scopeUrn: string }) => void;
+  onSubmit: (input: AskInputSubmission) => void;
   disabled?: boolean;
   initialScopeUrn?: string;
   onSaveQuestion?: (input: { question: string; model: string; tenantId: string; scopeUrn: string }) => void;
@@ -37,6 +47,7 @@ export default function AskInput({
   readiness,
   readinessLoading = false,
 }: Props) {
+  const [images, setImages] = useState<AskImageAttachment[]>([]);
   const form = useForm({
     defaultValues: {
       model: defaultAskModel,
@@ -47,8 +58,9 @@ export default function AskInput({
     onSubmit: ({ value }) => {
       const input = normalizeAskInput(value);
       if (!input.question || disabled) return;
-      onSubmit(input);
+      onSubmit({ ...input, images });
       form.setFieldValue("question", "");
+      setImages([]);
     },
   });
 
@@ -110,6 +122,7 @@ export default function AskInput({
           />
         )}
       </form.Field>
+      <ImageAttachments images={images} onChange={setImages} disabled={disabled} />
       <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-slate-100 pt-3 text-xs">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <form.Field name="tenantId">

--- a/apps/web/src/components/ask/AskThread.tsx
+++ b/apps/web/src/components/ask/AskThread.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useEffect, useState } from "react";
 
 import { type AskTurnState } from "@/lib/ask";
@@ -44,6 +45,7 @@ const guidanceForError = (turn: AskTurnState) => {
   const code = turn.error?.code ?? "";
   if (code === "aborted") return "Stopped locally. Retry when you are ready to continue.";
   if (code === "stream_incomplete") return "The stream ended early. Retry usually fixes transient upstream disconnects.";
+  if (code === "image_input_unavailable") return "Configure the agent runtime before asking Cerebro to analyze images.";
   if (code === "http_401" || code === "http_403") return "Check your API key and tenant scope.";
   if (code === "http_408" || code === "http_429" || code.startsWith("http_5")) return "This looks retryable. Try again or narrow the scope.";
   return "Review the trace and retry with a narrower question if needed.";
@@ -113,6 +115,21 @@ export default function AskThread({ turns, activeTurnId, onRetry, onStop }: Prop
                   Question
                 </div>
                 <p className="mt-1 text-base font-semibold text-slate-900">{turn.question}</p>
+                {turn.images?.length ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {turn.images.map((image) => (
+                      <Image
+                        key={image.id}
+                        src={image.data_url}
+                        alt={image.name}
+                        width={72}
+                        height={72}
+                        unoptimized
+                        className="h-[72px] w-[72px] rounded-md border border-slate-200 object-cover"
+                      />
+                    ))}
+                  </div>
+                ) : null}
                 <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-slate-500">
                   <span>Model {turn.model ?? "default"}</span>
                   <span>Tenant {turn.tenantId ?? "writer"}</span>

--- a/apps/web/src/components/ask/ImageAttachments.tsx
+++ b/apps/web/src/components/ask/ImageAttachments.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Image from "next/image";
+import { ImagePlus, X } from "lucide-react";
+import { useRef, useState } from "react";
+
+import { addAskImageFiles, type AskImageAttachment } from "@/lib/ask-images";
+
+export default function ImageAttachments({
+  disabled = false,
+  images,
+  onChange,
+}: {
+  disabled?: boolean;
+  images: AskImageAttachment[];
+  onChange: (images: AskImageAttachment[]) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const addFiles = async (files: File[]) => {
+    const result = await addAskImageFiles(images, files);
+    onChange(result.images);
+    setError(result.error);
+  };
+
+  return (
+    <div className="space-y-2">
+      {images.length > 0 && (
+        <div className="flex flex-wrap gap-2 px-3 pt-2">
+          {images.map((image) => (
+            <div key={image.id} className="group relative h-16 w-16 overflow-hidden rounded-md border border-slate-200 bg-slate-50">
+              <Image src={image.data_url} alt={image.name} fill unoptimized className="object-cover" />
+              <button
+                type="button"
+                onClick={() => onChange(images.filter((candidate) => candidate.id !== image.id))}
+                disabled={disabled}
+                aria-label={`Remove ${image.name}`}
+                className="absolute right-1 top-1 grid h-5 w-5 place-items-center rounded-full bg-slate-950/80 text-white opacity-0 transition group-hover:opacity-100 focus:opacity-100 disabled:hidden"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-2 px-3 pb-1">
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp,image/gif"
+          multiple
+          className="sr-only"
+          disabled={disabled}
+          onChange={(event) => {
+            void addFiles(Array.from(event.target.files ?? []));
+            event.target.value = "";
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={disabled}
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[12px] font-medium text-slate-500 transition hover:bg-slate-50 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <ImagePlus className="h-4 w-4" />
+          Add images
+        </button>
+        <span className="text-[11px] text-slate-400">PNG, JPEG, WebP, or GIF. 4 MB each.</span>
+      </div>
+      {error && <p role="alert" className="px-3 pb-1 text-[12px] text-rose-700">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/lib/ask-images.test.ts
+++ b/apps/web/src/lib/ask-images.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ASK_IMAGE_MAX_BYTES,
+  normalizeAskImages,
+  parseAskImageDataURL,
+} from "./ask-images";
+
+describe("Ask image inputs", () => {
+  it("normalizes supported inline images from their encoded bytes", () => {
+    expect(normalizeAskImages([{
+      id: " screenshot ",
+      name: "risk.png",
+      media_type: "image/png",
+      data_url: "data:image/png;base64,iVBORw==",
+      size_bytes: 999,
+    }])).toEqual([{
+      id: "screenshot",
+      name: "risk.png",
+      media_type: "image/png",
+      data_url: "data:image/png;base64,iVBORw==",
+      size_bytes: 4,
+    }]);
+  });
+
+  it("rejects remote URLs, mismatched media types, and too many images", () => {
+    expect(normalizeAskImages([{
+      media_type: "image/png",
+      data_url: "https://example.com/risk.png",
+    }])).toBeNull();
+    expect(normalizeAskImages([{
+      media_type: "image/jpeg",
+      data_url: "data:image/png;base64,iVBORw==",
+    }])).toBeNull();
+    expect(normalizeAskImages(Array.from({ length: 5 }, () => ({
+      media_type: "image/png",
+      data_url: "data:image/png;base64,iVBORw==",
+    })))).toBeNull();
+  });
+
+  it("rejects decoded images above the per-image limit", () => {
+    const encoded = "A".repeat(Math.ceil((ASK_IMAGE_MAX_BYTES + 1) / 3) * 4);
+    expect(parseAskImageDataURL(`data:image/png;base64,${encoded}`)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/ask-images.ts
+++ b/apps/web/src/lib/ask-images.ts
@@ -1,0 +1,106 @@
+export const ASK_IMAGE_MAX_COUNT = 4;
+export const ASK_IMAGE_MAX_BYTES = 4 * 1024 * 1024;
+export const ASK_IMAGE_TOTAL_MAX_BYTES = 8 * 1024 * 1024;
+export const ASK_AGENT_REQUEST_MAX_BYTES = 12 * 1024 * 1024;
+
+export const ASK_IMAGE_MEDIA_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+] as const;
+
+export type AskImageMediaType = (typeof ASK_IMAGE_MEDIA_TYPES)[number];
+
+export type AskImageAttachment = {
+  id: string;
+  name: string;
+  media_type: AskImageMediaType;
+  data_url: string;
+  size_bytes: number;
+};
+
+const mediaTypes = new Set<string>(ASK_IMAGE_MEDIA_TYPES);
+const dataURLPattern = /^data:(image\/(?:png|jpeg|webp|gif));base64,([A-Za-z0-9+/]+={0,2})$/;
+
+const decodedBase64Size = (value: string) => {
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  return Math.floor((value.length * 3) / 4) - padding;
+};
+
+export const askImageError = (file: Pick<File, "name" | "size" | "type">) => {
+  if (!mediaTypes.has(file.type)) return "Select a PNG, JPEG, WebP, or GIF image.";
+  if (file.size > ASK_IMAGE_MAX_BYTES) return "Select an image 4 MB or smaller.";
+  if (file.size <= 0) return "Select an image that is not empty.";
+  return null;
+};
+
+export const parseAskImageDataURL = (value: unknown) => {
+  if (typeof value !== "string") return null;
+  const match = dataURLPattern.exec(value);
+  if (!match) return null;
+  const sizeBytes = decodedBase64Size(match[2]);
+  if (sizeBytes <= 0 || sizeBytes > ASK_IMAGE_MAX_BYTES) return null;
+  return {
+    mediaType: match[1] as AskImageMediaType,
+    sizeBytes,
+  };
+};
+
+export const normalizeAskImages = (value: unknown): AskImageAttachment[] | null => {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > ASK_IMAGE_MAX_COUNT) return null;
+  let totalBytes = 0;
+  const images: AskImageAttachment[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") return null;
+    const source = item as Record<string, unknown>;
+    const parsed = parseAskImageDataURL(source.data_url);
+    if (!parsed || source.media_type !== parsed.mediaType) return null;
+    totalBytes += parsed.sizeBytes;
+    if (totalBytes > ASK_IMAGE_TOTAL_MAX_BYTES) return null;
+    images.push({
+      id: typeof source.id === "string" && source.id.trim() ? source.id.trim().slice(0, 128) : `image-${images.length + 1}`,
+      name: typeof source.name === "string" && source.name.trim() ? source.name.trim().slice(0, 255) : `image-${images.length + 1}`,
+      media_type: parsed.mediaType,
+      data_url: source.data_url as string,
+      size_bytes: parsed.sizeBytes,
+    });
+  }
+  return images;
+};
+
+const readFileAsDataURL = (file: File) => new Promise<string>((resolve, reject) => {
+  const reader = new FileReader();
+  reader.onerror = () => reject(new Error("The image could not be read."));
+  reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
+  reader.readAsDataURL(file);
+});
+
+export const addAskImageFiles = async (
+  current: AskImageAttachment[],
+  selected: File[],
+): Promise<{ images: AskImageAttachment[]; error: string | null }> => {
+  if (current.length + selected.length > ASK_IMAGE_MAX_COUNT) {
+    return { images: current, error: "Attach up to 4 images." };
+  }
+  const invalid = selected.map(askImageError).find(Boolean);
+  if (invalid) return { images: current, error: invalid };
+  const selectedBytes = selected.reduce((total, file) => total + file.size, 0);
+  const currentBytes = current.reduce((total, image) => total + image.size_bytes, 0);
+  if (currentBytes + selectedBytes > ASK_IMAGE_TOTAL_MAX_BYTES) {
+    return { images: current, error: "Keep attached images under 8 MB total." };
+  }
+  try {
+    const additions = await Promise.all(selected.map(async (file, index) => ({
+      id: typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `image-${Date.now()}-${index}`,
+      name: file.name,
+      media_type: file.type as AskImageMediaType,
+      data_url: await readFileAsDataURL(file),
+      size_bytes: file.size,
+    })));
+    return { images: [...current, ...additions], error: null };
+  } catch (error) {
+    return { images: current, error: error instanceof Error ? error.message : "The image could not be read." };
+  }
+};

--- a/apps/web/src/lib/ask.ts
+++ b/apps/web/src/lib/ask.ts
@@ -1,4 +1,5 @@
 import type { GRCGraph } from "@/lib/grc";
+import type { AskImageAttachment } from "@/lib/ask-images";
 
 export type AskRole = "user" | "assistant";
 export type AskTurnStatus = "streaming" | "completed" | "error" | "aborted";
@@ -17,6 +18,7 @@ export type AskRequest = {
   context?: AskAgentContext;
   surface?: string;
   conversation_id?: string;
+  images?: AskImageAttachment[];
 };
 
 export type AskAgentContextChip = {
@@ -155,6 +157,7 @@ export type AskTurnState = {
   model?: string;
   tenantId?: string;
   scopeUrn?: string;
+  images?: AskImageAttachment[];
   rationale?: string;
   queryPlan?: AskQueryPlanEvent;
   cypher?: AskCypherEvent;

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
 
 import { GRC_UPLOAD_MAX_BYTES } from "./lib/grc-upload-limits";
+import { ASK_AGENT_REQUEST_MAX_BYTES } from "./lib/ask-images";
 import { config, proxy } from "./proxy";
 
 const request = (method: string, path: string, headers?: Record<string, string>) =>
@@ -37,6 +38,22 @@ describe("proxy", () => {
   it("rejects oversized POST requests to API routes", () => {
     const response = proxy(request("POST", "/api/cerebro/grc/ask", {
       "content-length": String(10 * 1024 * 1024),
+    }));
+    expect(response.status).toBe(413);
+  });
+
+  it("allows image-bearing agent requests up to the image request limit", () => {
+    const response = proxy(request("POST", "/api/agent/ask", {
+      "content-length": String(ASK_AGENT_REQUEST_MAX_BYTES - 1024),
+      "content-type": "application/json",
+    }));
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects agent requests above the image request limit", () => {
+    const response = proxy(request("POST", "/api/agent/ask", {
+      "content-length": String(ASK_AGENT_REQUEST_MAX_BYTES + 1),
+      "content-type": "application/json",
     }));
     expect(response.status).toBe(413);
   });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { GRC_UPLOAD_MAX_BYTES, GRC_UPLOAD_MAX_LABEL } from "./lib/grc-upload-limits";
+import { ASK_AGENT_REQUEST_MAX_BYTES } from "./lib/ask-images";
 
 const MAX_API_BODY_BYTES = 2 * 1024 * 1024; // 2 MB
 
@@ -47,6 +48,13 @@ export function proxy(request: NextRequest) {
 function maxBodyBytesForRequest(request: NextRequest) {
   if (
     request.method === "POST" &&
+    request.nextUrl.pathname === "/api/agent/ask" &&
+    (request.headers.get("content-type") ?? "").toLowerCase().includes("application/json")
+  ) {
+    return ASK_AGENT_REQUEST_MAX_BYTES;
+  }
+  if (
+    request.method === "POST" &&
     GRC_UPLOAD_PATHS.has(request.nextUrl.pathname) &&
     (request.headers.get("content-type") ?? "").toLowerCase().includes("multipart/form-data")
   ) {
@@ -56,6 +64,9 @@ function maxBodyBytesForRequest(request: NextRequest) {
 }
 
 function bodyTooLargeMessage(maxBytes: number) {
+  if (maxBytes === ASK_AGENT_REQUEST_MAX_BYTES) {
+    return "Ask request is larger than 12 MB.";
+  }
   if (maxBytes === GRC_UPLOAD_MAX_BYTES) {
     return `Upload is larger than ${GRC_UPLOAD_MAX_LABEL}.`;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,13 +1055,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck:workspaces": "npm run typecheck --workspaces --if-present"
   },
   "overrides": {
+    "@hono/node-server": "2.0.11",
     "postcss": "8.5.19"
   }
 }


### PR DESCRIPTION
## What changed

- add image attachment, preview, removal, and submitted-image rendering to Cerebro Ask
- send validated PNG, JPEG, WebP, and GIF data to the agent as vision input
- add the portable Slack image manifest and authenticated resolver boundary
- keep raw Slack image bytes out of durable question work
- return explicit errors when image analysis is unavailable or input exceeds its bounds

## Why

Cerebro chat accepted text only, so screenshots and other visual evidence were dropped before model execution. Slack also lacked a portable contract for carrying private file references through durable work and resolving them at the model boundary.

## User impact

People can attach up to four images, with a 4 MB per-image and 8 MB total limit. Web chat shows previews and includes the images in the conversation. Slack hosts can admit image-only or captioned questions, resolve authenticated private files, and pass model-ready image content without persisting the bytes.

## Validation

- `make workspace-check workspace-build`
- Slack companion: 433 tests passed
- Web: 556 tests passed
- TypeScript SDK: 7 tests passed
- production Next.js build passed
- desktop and mobile browser QA passed for attach, preview, submit, and image rendering

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/2052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->