### PR TITLE
Parallelize native candidate image builds

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -198,10 +198,9 @@ jobs:
           include-hidden-files: true
 
   image:
-    runs-on: ubuntu-latest
-    needs: [resolve, binaries]
+    runs-on: ${{ matrix.runner }}
+    needs: resolve
     permissions:
-      actions: read
       contents: read
       packages: write
     strategy:
@@ -210,33 +209,36 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
+            runner: ubuntu-24.04
           - arch: arm64
             platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve.outputs.sha }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          name: candidate-binaries-${{ needs.resolve.outputs.sha }}
-          path: candidate-binaries
-      - name: Prepare runtime binary
+          go-version-file: go.mod
+      - name: Build runtime binary
         shell: bash
         env:
           ARCH: ${{ matrix.arch }}
+          CANDIDATE_SHA: ${{ needs.resolve.outputs.sha }}
           SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
         run: |
+          set -euo pipefail
           mkdir -p .dist
-          tar -xzf "candidate-binaries/cerebro_candidate-${SHORT_SHA}_linux_${ARCH}.tar.gz" \
-            --strip-components=1 -C .dist
-          chmod +x .dist/cerebro
+          build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          ldflags="-s -w -X github.com/writer/cerebro/internal/buildinfo.Version=candidate-${SHORT_SHA} -X github.com/writer/cerebro/internal/buildinfo.Commit=${CANDIDATE_SHA} -X github.com/writer/cerebro/internal/buildinfo.BuildDate=${build_date}"
+          CGO_ENABLED=0 GOOS=linux GOARCH="${ARCH}" \
+            go build -trimpath -ldflags "${ldflags}" -o .dist/cerebro ./cmd/cerebro
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build and publish candidate image
         shell: bash

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -245,6 +245,32 @@ func TestReleaseWorkflowsKeepCandidateAndStableBoundaries(t *testing.T) {
 	if !strings.Contains(receipt, "    permissions:\n      actions: read\n      contents: read\n") {
 		t.Fatal("candidate receipt job must allow artifact discovery with actions: read")
 	}
+	imageStart := strings.Index(candidate, "\n  image:\n")
+	manifestStart := strings.Index(candidate, "\n  manifest:\n")
+	if imageStart < 0 || manifestStart <= imageStart {
+		t.Fatal("candidate workflow must define image and manifest jobs")
+	}
+	imageJob := candidate[imageStart:manifestStart]
+	for _, required := range []string{
+		"runs-on: ${{ matrix.runner }}",
+		"needs: resolve",
+		"runner: ubuntu-24.04",
+		"runner: ubuntu-24.04-arm",
+		"name: Build runtime binary",
+	} {
+		if !strings.Contains(imageJob, required) {
+			t.Fatalf("candidate image job must contain %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"needs: [resolve, binaries]",
+		"actions/download-artifact",
+		"docker/setup-qemu-action",
+	} {
+		if strings.Contains(imageJob, forbidden) {
+			t.Fatalf("candidate image job must not contain serialized or emulated build step %q", forbidden)
+		}
+	}
 	makefile, err := os.ReadFile(filepath.Join(root, "Makefile"))
 	if err != nil {
 		t.Fatalf("read Makefile: %v", err)


### PR DESCRIPTION
## What changed

- Start runtime image builds after candidate resolution instead of waiting for all four portable archives.
- Build the runtime Go binary inside each image job with the same candidate version metadata.
- Run the ARM64 image on a native ARM64 runner and remove QEMU from the runtime image path.
- Enforce the parallel, native image path in packaging guardrails.

## Measured reason

Candidate Build run 30061434515 exposed two serial bottlenecks:

- Darwin AMD64 archive: 15m34s before image jobs could start.
- AMD64 image: 5m07s native.
- ARM64 image: still compiling after 22 minutes under QEMU.

This lets both images build while portable archives finish and removes emulation from the slow ARM path.

## Verification

- `actionlint .github/workflows/cut-release.yml`
- `go test ./tools/archtests`
- `python3 -m unittest scripts.tests.test_release_consumer_boundary scripts.tests.test_release_workflow_serialization scripts.tests.test_release_manifest_visibility`
- `git diff --check`