### PR TITLE
feat(slack): add authenticated Archetype daily work

### DIFF
--- a/apps/slack-companion-host/README.md
+++ b/apps/slack-companion-host/README.md
@@ -21,3 +21,30 @@ npm start --workspace @writer/cerebro-slack-companion-host
 ```
 
 The process accepts configured Slack app mentions, preserves bounded thread context, sends governed Cerebro requests, and records durable delivery and outcome state. `/healthz` reports process health. `/readyz` opens after Slack and the outcome store are ready.
+
+## Archetype workspace
+
+Set `ARCHETYPE_WORKSPACE_ENABLED=true` to replace the static App Home with the
+signed-in operator's current Archetype work. The deployment must also provide:
+
+- `ARCHETYPE_BASE_URL`
+- `ARCHETYPE_ALLOWED_EMAIL_DOMAINS`
+- `OKTA_DOMAIN`
+- `OKTA_API_TOKEN`
+- optional `ARCHETYPE_REQUEST_TIMEOUT_MS`
+
+The Slack app must enable interactivity and grant `users:read` plus
+`users:read.email` so the host can resolve the actor behind a signed Slack
+event. Existing mention and App Home scopes remain required.
+
+The runtime reads the Slack user from the verified interaction, requires an
+allowed work email, resolves that exact account and its groups from Okta, and
+then sends the verified identity to the internal Archetype service. The daily
+brief comes from the actor-scoped Archetype digest. `Start work` creates a
+preview; only `Assign to me` executes the intent. Archetype rechecks permission,
+expiry, finding state, and the canonical active Okta assignee before recording
+the assignment.
+
+Do not configure a static Slack-to-user map for this path. Okta and Archetype
+source errors fail closed, and the runtime never substitutes local identity or
+finding data.

--- a/apps/slack-companion-host/src/archetype-client.ts
+++ b/apps/slack-companion-host/src/archetype-client.ts
@@ -1,0 +1,398 @@
+import {
+  parseArchetypeDailyDigest,
+  parseArchetypeFindingActionExecution,
+  parseArchetypeFindingActionIntent,
+  type ArchetypeDailyDigestV1,
+  type ArchetypeFindingActionExecutionV1,
+  type ArchetypeFindingActionIntentV1,
+} from "@writer/cerebro-slack-companion";
+
+const MAX_RESPONSE_BYTES = 2_000_000;
+const MAX_OKTA_GROUPS = 200;
+
+export interface ArchetypeWorkspaceClientOptions {
+  allowedEmailDomains: ReadonlySet<string>;
+  archetypeBaseUrl: string;
+  fetchImpl?: typeof fetch;
+  oktaApiToken: string;
+  oktaDomain: string;
+  timeoutMs: number;
+}
+
+export interface SlackUserLookupPort {
+  users: {
+    info(input: { user: string }): Promise<{
+      ok?: boolean;
+      user?: {
+        deleted?: boolean;
+        id?: string;
+        is_bot?: boolean;
+        profile?: {
+          display_name?: string;
+          email?: string;
+          real_name?: string;
+        };
+        team_id?: string;
+      };
+    }>;
+  };
+}
+
+export interface VerifiedArchetypeIdentity {
+  readonly displayName: string;
+  readonly email: string;
+  readonly groups: readonly string[];
+  readonly login: string;
+  readonly oktaUserId: string;
+  readonly slackTeamId: string;
+  readonly slackUserId: string;
+}
+
+export class ArchetypeWorkspaceClientError extends Error {
+  constructor(
+    message: string,
+    readonly state:
+      | "identity_unavailable"
+      | "identity_unverified"
+      | "source_rejected"
+      | "source_unavailable",
+  ) {
+    super(message);
+    this.name = "ArchetypeWorkspaceClientError";
+  }
+}
+
+export class ArchetypeWorkspaceClient {
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly options: ArchetypeWorkspaceClientOptions) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async resolveIdentity(input: {
+    slack: SlackUserLookupPort;
+    teamId: string;
+    userId: string;
+  }): Promise<VerifiedArchetypeIdentity> {
+    const slackUser = await input.slack.users.info({ user: input.userId });
+    const user = slackUser.user;
+    if (
+      slackUser.ok === false
+      || !user
+      || user.id !== input.userId
+      || user.team_id !== input.teamId
+      || user.deleted === true
+      || user.is_bot === true
+    ) {
+      throw new ArchetypeWorkspaceClientError(
+        "The Slack account could not be verified for this workspace.",
+        "identity_unverified",
+      );
+    }
+    const slackEmail = normalizedEmail(user.profile?.email);
+    if (!slackEmail || !this.allowedEmail(slackEmail)) {
+      throw new ArchetypeWorkspaceClientError(
+        "The Slack account does not have an allowed work email.",
+        "identity_unverified",
+      );
+    }
+    const oktaUser = await this.oktaRequest(
+      `/api/v1/users/${encodeURIComponent(slackEmail)}`,
+    );
+    const identity = parseOktaUser(oktaUser);
+    if (
+      identity.status !== "ACTIVE"
+      || identity.email.toLowerCase() !== slackEmail
+    ) {
+      throw new ArchetypeWorkspaceClientError(
+        "The Slack account does not match an active Okta user.",
+        "identity_unverified",
+      );
+    }
+    const groupResult = await this.oktaRequest(
+      `/api/v1/users/${encodeURIComponent(identity.id)}/groups`,
+    );
+    const groups = parseOktaGroups(groupResult);
+    return Object.freeze({
+      displayName: identity.displayName,
+      email: identity.email.toLowerCase(),
+      groups,
+      login: identity.login,
+      oktaUserId: identity.id,
+      slackTeamId: input.teamId,
+      slackUserId: input.userId,
+    });
+  }
+
+  async dailyDigest(
+    identity: VerifiedArchetypeIdentity,
+  ): Promise<ArchetypeDailyDigestV1> {
+    const digest = parseArchetypeDailyDigest(
+      await this.archetypeRequest("/api/v1/workspace/digest", identity),
+    );
+    if (digest.actor_id.toLowerCase() !== identity.email) {
+      throw new ArchetypeWorkspaceClientError(
+        "Archetype returned work for a different signed-in user.",
+        "source_rejected",
+      );
+    }
+    return digest;
+  }
+
+  async createStartWorkIntent(
+    identity: VerifiedArchetypeIdentity,
+    findingRef: string,
+  ): Promise<ArchetypeFindingActionIntentV1> {
+    return parseArchetypeFindingActionIntent(
+      await this.archetypeRequest(
+        "/api/v1/workspace/action-intents",
+        identity,
+        {
+          body: JSON.stringify({
+            action: "start_work",
+            finding_ref: findingRef,
+          }),
+          method: "POST",
+        },
+      ),
+    );
+  }
+
+  async executeStartWorkIntent(
+    identity: VerifiedArchetypeIdentity,
+    intentId: string,
+  ): Promise<ArchetypeFindingActionExecutionV1> {
+    return parseArchetypeFindingActionExecution(
+      await this.archetypeRequest(
+        `/api/v1/workspace/action-intents/${encodeURIComponent(intentId)}/execute`,
+        identity,
+        { body: "{}", method: "POST" },
+      ),
+    );
+  }
+
+  private async archetypeRequest(
+    path: string,
+    identity: VerifiedArchetypeIdentity,
+    init: { body?: string; method?: "GET" | "POST" } = {},
+  ): Promise<unknown> {
+    const headers = new Headers({
+      accept: "application/json",
+      "content-type": "application/json",
+      "x-okta-email": identityHeader(identity.email, "Okta email"),
+      "x-okta-name": safeIdentityHeader(identity.displayName, identity.email),
+      "x-okta-user": identityHeader(identity.login, "Okta login"),
+    });
+    if (identity.groups.length > 0) {
+      headers.set(
+        "x-archetype-groups",
+        identityHeader(identity.groups.join(","), "Okta groups", 6_000),
+      );
+    }
+    return this.request(
+      new URL(path, `${this.options.archetypeBaseUrl}/`),
+      {
+        body: init.body,
+        headers,
+        method: init.method ?? "GET",
+      },
+      "archetype",
+    );
+  }
+
+  private async oktaRequest(path: string): Promise<unknown> {
+    return this.request(
+      new URL(path, `${this.options.oktaDomain}/`),
+      {
+        headers: {
+          accept: "application/json",
+          authorization: `SSWS ${this.options.oktaApiToken}`,
+        },
+        method: "GET",
+      },
+      "okta",
+    );
+  }
+
+  private async request(
+    url: URL,
+    init: RequestInit,
+    source: "archetype" | "okta",
+  ): Promise<unknown> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        ...init,
+        redirect: "error",
+        signal: AbortSignal.timeout(this.options.timeoutMs),
+      });
+    } catch {
+      throw new ArchetypeWorkspaceClientError(
+        `${source === "okta" ? "Okta" : "Archetype"} is unavailable.`,
+        source === "okta" ? "identity_unavailable" : "source_unavailable",
+      );
+    }
+    if (!response.ok) {
+      throw new ArchetypeWorkspaceClientError(
+        `${source === "okta" ? "Okta" : "Archetype"} rejected the request.`,
+        response.status >= 500
+          ? source === "okta"
+            ? "identity_unavailable"
+            : "source_unavailable"
+          : source === "okta"
+            ? "identity_unverified"
+            : "source_rejected",
+      );
+    }
+    const length = Number(response.headers.get("content-length"));
+    if (Number.isFinite(length) && length > MAX_RESPONSE_BYTES) {
+      throw new ArchetypeWorkspaceClientError(
+        `${source === "okta" ? "Okta" : "Archetype"} returned an oversized response.`,
+        source === "okta" ? "identity_unavailable" : "source_unavailable",
+      );
+    }
+    const body = await response.text();
+    if (Buffer.byteLength(body, "utf8") > MAX_RESPONSE_BYTES) {
+      throw new ArchetypeWorkspaceClientError(
+        `${source === "okta" ? "Okta" : "Archetype"} returned an oversized response.`,
+        source === "okta" ? "identity_unavailable" : "source_unavailable",
+      );
+    }
+    try {
+      return JSON.parse(body) as unknown;
+    } catch {
+      throw new ArchetypeWorkspaceClientError(
+        `${source === "okta" ? "Okta" : "Archetype"} returned an invalid response.`,
+        source === "okta" ? "identity_unavailable" : "source_unavailable",
+      );
+    }
+  }
+
+  private allowedEmail(value: string): boolean {
+    const domain = value.slice(value.lastIndexOf("@") + 1);
+    return this.options.allowedEmailDomains.has(domain);
+  }
+}
+
+function parseOktaUser(value: unknown): {
+  displayName: string;
+  email: string;
+  id: string;
+  login: string;
+  status: string;
+} {
+  const user = record(value, "Okta user");
+  const profile = record(user.profile, "Okta user profile");
+  const firstName = optionalText(profile.firstName, 100);
+  const lastName = optionalText(profile.lastName, 100);
+  const email = normalizedEmail(profile.email);
+  const login = normalizedEmail(profile.login);
+  if (!email || !login) {
+    throw new ArchetypeWorkspaceClientError(
+      "Okta returned a user without a verified email.",
+      "identity_unverified",
+    );
+  }
+  return {
+    displayName: [firstName, lastName].filter(Boolean).join(" ") || email,
+    email,
+    id: requiredText(user.id, "Okta user id", 200),
+    login,
+    status: requiredText(user.status, "Okta user status", 50),
+  };
+}
+
+function parseOktaGroups(value: unknown): readonly string[] {
+  if (
+    !Array.isArray(value)
+    || value.length > MAX_OKTA_GROUPS
+    || Object.getPrototypeOf(value) !== Array.prototype
+  ) {
+    throw new ArchetypeWorkspaceClientError(
+      "Okta returned an invalid group list.",
+      "identity_unavailable",
+    );
+  }
+  const groups = value.flatMap((item, index) => {
+    const group = record(item, `Okta group ${index + 1}`);
+    const profile = record(group.profile, `Okta group ${index + 1} profile`);
+    const name = requiredText(
+      profile.name,
+      `Okta group ${index + 1} name`,
+      200,
+    );
+    return /^[A-Za-z0-9_.:-]+$/.test(name) ? [name] : [];
+  });
+  return Object.freeze([...new Set(groups)].sort());
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (
+    value === null
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new ArchetypeWorkspaceClientError(
+      `${field} is invalid.`,
+      "identity_unavailable",
+    );
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizedEmail(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalized)
+    && normalized.length <= 320
+    ? normalized
+    : undefined;
+}
+
+function optionalText(value: unknown, maximum: number): string | undefined {
+  if (value === undefined || value === null || typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized && normalized.length <= maximum ? normalized : undefined;
+}
+
+function requiredText(
+  value: unknown,
+  field: string,
+  maximum: number,
+): string {
+  const normalized = optionalText(value, maximum);
+  if (!normalized) {
+    throw new ArchetypeWorkspaceClientError(
+      `${field} is invalid.`,
+      "identity_unavailable",
+    );
+  }
+  return normalized;
+}
+
+function identityHeader(
+  value: string,
+  field: string,
+  maximum = 500,
+): string {
+  if (
+    value.length === 0
+    || value.length > maximum
+    || /[^\u0020-\u007e]/.test(value)
+  ) {
+    throw new ArchetypeWorkspaceClientError(
+      `${field} cannot be represented as a trusted identity header.`,
+      "identity_unverified",
+    );
+  }
+  return value;
+}
+
+function safeIdentityHeader(value: string, fallback: string): string {
+  return value.length <= 500 && /^[\u0020-\u007e]+$/.test(value)
+    ? value
+    : identityHeader(fallback, "Okta display name");
+}

--- a/apps/slack-companion-host/src/index.ts
+++ b/apps/slack-companion-host/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./activation.js";
+export * from "./archetype-client.js";
 export * from "./assistant-turn.js";
 export * from "./canonical-client.js";
 export * as evidenceRecheck from "./evidence-recheck/index.js";
@@ -7,3 +8,4 @@ export * from "./policy.js";
 export * from "./security-operations.js";
 export * from "./tools.js";
 export * from "./types.js";
+export * from "./runtime/archetype-workspace.js";

--- a/apps/slack-companion-host/src/main.ts
+++ b/apps/slack-companion-host/src/main.ts
@@ -1,3 +1,4 @@
+import { ArchetypeWorkspaceClient } from "./archetype-client.js";
 import { CerebroAskClient } from "./runtime/cerebro-ask-client.js";
 import { loadSlackRuntimeConfig } from "./runtime/config.js";
 import { FileOutcomeStore } from "./runtime/outcome-store.js";
@@ -6,6 +7,7 @@ import {
   createAssistantTurnHost,
   SlackCompanionRuntime,
 } from "./runtime/slack-runtime.js";
+import { ArchetypeSlackWorkspace } from "./runtime/archetype-workspace.js";
 
 async function main(): Promise<void> {
   const config = loadSlackRuntimeConfig();
@@ -16,7 +18,22 @@ async function main(): Promise<void> {
     baseUrl: config.cerebroBaseUrl,
     tenantId: config.cerebroTenantId,
   }));
-  const runtime = new SlackCompanionRuntime(config, host, questions, outcomes);
+  const archetype = config.archetype
+    ? new ArchetypeSlackWorkspace(new ArchetypeWorkspaceClient({
+      allowedEmailDomains: config.archetype.allowedEmailDomains,
+      archetypeBaseUrl: config.archetype.baseUrl,
+      oktaApiToken: config.archetype.oktaApiToken,
+      oktaDomain: config.archetype.oktaDomain,
+      timeoutMs: config.archetype.timeoutMs,
+    }))
+    : undefined;
+  const runtime = new SlackCompanionRuntime(
+    config,
+    host,
+    questions,
+    outcomes,
+    archetype,
+  );
   await runtime.start();
   process.stdout.write(`${JSON.stringify({
     component: "slack-runtime",

--- a/apps/slack-companion-host/src/runtime/archetype-workspace.ts
+++ b/apps/slack-companion-host/src/runtime/archetype-workspace.ts
@@ -1,0 +1,304 @@
+import type { HomeView, ModalView } from "@slack/types";
+import {
+  ARCHETYPE_SLACK_ACTION_REGISTRY,
+  decodeSlackActionEnvelope,
+  decideSlackAction,
+  projectArchetypeStartWorkConfirmation,
+  projectArchetypeToday,
+  type SlackActionEnvelopeV1,
+} from "@writer/cerebro-slack-companion";
+
+import {
+  ArchetypeWorkspaceClient,
+  ArchetypeWorkspaceClientError,
+  type SlackUserLookupPort,
+} from "../archetype-client.js";
+
+const ARCHETYPE_CAPABILITY = Object.freeze({
+  capability_id: "archetype.findings.assign_self",
+  level: "required" as const,
+  version: "v1",
+});
+
+export class ArchetypeSlackWorkspace {
+  constructor(private readonly client: ArchetypeWorkspaceClient) {}
+
+  async home(input: {
+    slack: SlackUserLookupPort;
+    teamId: string;
+    userId: string;
+  }): Promise<HomeView> {
+    const identity = await this.client.resolveIdentity(input);
+    const digest = await this.client.dailyDigest(identity);
+    const projection = projectArchetypeToday(digest);
+    return {
+      blocks: [...projection.blocks.blocks],
+      external_id: `archetype-today-${digestId([
+        input.userId,
+        projection.generated_at,
+      ].join(":"))}`,
+      type: "home",
+    };
+  }
+
+  async preview(input: {
+    actionValue: string;
+    slack: SlackUserLookupPort;
+    teamId: string;
+    userId: string;
+  }): Promise<ModalView> {
+    const action = admittedAction(
+      input.actionValue,
+      "archetype.start_work.preview",
+      "archetype_start_work_preview",
+    );
+    const findingRef = subjectIdentifier(
+      action,
+      "archetype-finding://",
+      "finding",
+    );
+    const identity = await this.client.resolveIdentity(input);
+    const intent = await this.client.createStartWorkIntent(identity, findingRef);
+    if (intent.finding_ref !== findingRef) {
+      throw new ArchetypeWorkspaceClientError(
+        "Archetype returned a preview for a different finding.",
+        "source_rejected",
+      );
+    }
+    const confirmation = projectArchetypeStartWorkConfirmation(intent);
+    return {
+      blocks: [
+        {
+          text: {
+            text: confirmation.summary,
+            type: "mrkdwn",
+          },
+          type: "section",
+        },
+        {
+          elements: [{
+            action_id: confirmation.action.action_key,
+            style: "primary",
+            text: {
+              emoji: true,
+              text: confirmation.action.label,
+              type: "plain_text",
+            },
+            type: "button",
+            value: confirmation.action.value,
+          }],
+          type: "actions",
+        },
+        {
+          elements: [{
+            text: `This confirmation expires ${confirmation.expires_at}.`,
+            type: "mrkdwn",
+          }],
+          type: "context",
+        },
+      ],
+      callback_id: "archetype_start_work_confirmation",
+      close: {
+        emoji: true,
+        text: "Cancel",
+        type: "plain_text",
+      },
+      title: {
+        emoji: true,
+        text: "Confirm assignment",
+        type: "plain_text",
+      },
+      type: "modal",
+    };
+  }
+
+  async confirm(input: {
+    actionValue: string;
+    slack: SlackUserLookupPort;
+    teamId: string;
+    userId: string;
+  }): Promise<ModalView> {
+    const action = admittedAction(
+      input.actionValue,
+      "archetype.start_work.confirm",
+      "archetype_start_work_confirm",
+    );
+    const intentId = subjectIdentifier(
+      action,
+      "archetype-intent://",
+      "action intent",
+    );
+    const identity = await this.client.resolveIdentity(input);
+    const execution = await this.client.executeStartWorkIntent(
+      identity,
+      intentId,
+    );
+    if (execution.intent.id !== intentId) {
+      throw new ArchetypeWorkspaceClientError(
+        "Archetype returned a different action result.",
+        "source_rejected",
+      );
+    }
+    const assignee = execution.finding.assignee;
+    if (
+      !assignee
+      || assignee.kind !== "user"
+      || assignee.source !== "okta"
+      || assignee.id !== identity.oktaUserId
+    ) {
+      throw new ArchetypeWorkspaceClientError(
+        "Archetype did not confirm the active Okta assignment.",
+        "source_rejected",
+      );
+    }
+    return statusModal(
+      "Assignment recorded",
+      `Assigned to ${assignee.display_name} in Archetype. Status: ${displayState(execution.finding.status)}.`,
+    );
+  }
+}
+
+export function archetypeLoadingModal(): ModalView {
+  return statusModal("Checking assignment", "Checking your current Okta identity and finding state.");
+}
+
+export function archetypeErrorModal(error: unknown): ModalView {
+  const state = archetypeErrorState(error);
+  return statusModal(state.title, state.message);
+}
+
+export function archetypeUnavailableHome(error: unknown): HomeView {
+  const state = archetypeErrorState(error);
+  return {
+    blocks: [
+      {
+        text: {
+          emoji: true,
+          text: "Archetype · Today",
+          type: "plain_text",
+        },
+        type: "header",
+      },
+      {
+        text: {
+          text: state.message,
+          type: "mrkdwn",
+        },
+        type: "section",
+      },
+    ],
+    type: "home",
+  };
+}
+
+function archetypeErrorState(error: unknown): {
+  message: string;
+  title: string;
+} {
+  if (error instanceof ArchetypeWorkspaceClientError) {
+    switch (error.state) {
+      case "identity_unavailable":
+        return {
+          message: "Okta could not verify your account. No finding changed.",
+          title: "Identity check unavailable",
+        };
+      case "identity_unverified":
+        return {
+          message: "Your signed-in Slack account does not map to an active allowed Okta user. No finding changed.",
+          title: "Account not verified",
+        };
+      case "source_rejected":
+        return {
+          message: "Archetype rejected the current identity or finding state. Refresh Today before trying again.",
+          title: "Action not accepted",
+        };
+      case "source_unavailable":
+        return {
+          message: "Archetype could not confirm the current finding state. No finding changed.",
+          title: "Archetype unavailable",
+        };
+    }
+  }
+  return {
+    message: "The assignment could not be prepared. No finding changed.",
+    title: "Action unavailable",
+  };
+}
+
+function admittedAction(
+  value: string,
+  expectedAction: string,
+  expectedCommand: string,
+): SlackActionEnvelopeV1 {
+  const action = decodeSlackActionEnvelope(value);
+  if (action.action !== expectedAction || action.command !== expectedCommand) {
+    throw new ArchetypeWorkspaceClientError(
+      "The Archetype action does not match the requested operation.",
+      "source_rejected",
+    );
+  }
+  const decision = decideSlackAction(ARCHETYPE_SLACK_ACTION_REGISTRY, {
+    action,
+    available_capabilities: [ARCHETYPE_CAPABILITY],
+  });
+  if (decision.disposition !== "admit") {
+    throw new ArchetypeWorkspaceClientError(
+      "The Archetype action is not authorized.",
+      "source_rejected",
+    );
+  }
+  return action;
+}
+
+function subjectIdentifier(
+  action: SlackActionEnvelopeV1,
+  prefix: string,
+  field: string,
+): string {
+  const subject = action.subject_ref;
+  if (!subject?.startsWith(prefix)) {
+    throw new ArchetypeWorkspaceClientError(
+      `The Archetype ${field} reference is invalid.`,
+      "source_rejected",
+    );
+  }
+  const id = subject.slice(prefix.length);
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id)) {
+    throw new ArchetypeWorkspaceClientError(
+      `The Archetype ${field} reference is invalid.`,
+      "source_rejected",
+    );
+  }
+  return id.toLowerCase();
+}
+
+function statusModal(title: string, message: string): ModalView {
+  return {
+    blocks: [{
+      text: {
+        text: message,
+        type: "mrkdwn",
+      },
+      type: "section",
+    }],
+    close: {
+      emoji: true,
+      text: "Close",
+      type: "plain_text",
+    },
+    title: {
+      emoji: true,
+      text: title,
+      type: "plain_text",
+    },
+    type: "modal",
+  };
+}
+
+function digestId(value: string): string {
+  return Buffer.from(value).toString("base64url").slice(0, 80);
+}
+
+function displayState(value: string): string {
+  return value.replaceAll("_", " ");
+}

--- a/apps/slack-companion-host/src/runtime/config.ts
+++ b/apps/slack-companion-host/src/runtime/config.ts
@@ -1,5 +1,14 @@
+export interface ArchetypeWorkspaceRuntimeConfig {
+  allowedEmailDomains: ReadonlySet<string>;
+  baseUrl: string;
+  oktaApiToken: string;
+  oktaDomain: string;
+  timeoutMs: number;
+}
+
 export interface SlackRuntimeConfig {
   allowedTeamIds: ReadonlySet<string>;
+  archetype?: ArchetypeWorkspaceRuntimeConfig;
   appToken: string;
   appName: string;
   botToken: string;
@@ -27,8 +36,10 @@ export function loadSlackRuntimeConfig(
     throw new SlackRuntimeConfigError("At least one Slack workspace must be allowed.");
   }
   const baseUrl = validatedBaseUrl(required(env.CEREBRO_BASE_URL));
+  const archetype = archetypeConfig(env);
   return Object.freeze({
     allowedTeamIds,
+    ...(archetype === undefined ? {} : { archetype }),
     appToken: required(env.SLACK_APP_TOKEN),
     appName: required(env.CEREBRO_SLACK_APP_NAME),
     botToken: required(env.SLACK_BOT_TOKEN),
@@ -43,11 +54,66 @@ export function loadSlackRuntimeConfig(
   });
 }
 
+function archetypeConfig(
+  env: NodeJS.ProcessEnv,
+): ArchetypeWorkspaceRuntimeConfig | undefined {
+  const enabled = optionalBooleanBinding(env.ARCHETYPE_WORKSPACE_ENABLED, false);
+  if (!enabled) {
+    const unexpected = [
+      env.ARCHETYPE_BASE_URL,
+      env.ARCHETYPE_ALLOWED_EMAIL_DOMAINS,
+      env.OKTA_DOMAIN,
+      env.OKTA_API_TOKEN,
+    ].some((value) => Boolean(value?.trim()));
+    if (unexpected) {
+      throw new SlackRuntimeConfigError(
+        "Archetype workspace bindings require ARCHETYPE_WORKSPACE_ENABLED=true.",
+      );
+    }
+    return undefined;
+  }
+  const allowedEmailDomains = new Set(
+    csv(required(env.ARCHETYPE_ALLOWED_EMAIL_DOMAINS))
+      .map((value) => value.toLowerCase()),
+  );
+  if (
+    allowedEmailDomains.size === 0
+    || [...allowedEmailDomains].some((domain) =>
+      !/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/.test(domain)
+    )
+  ) {
+    throw new SlackRuntimeConfigError(
+      "Archetype allowed email domains are invalid.",
+    );
+  }
+  return Object.freeze({
+    allowedEmailDomains,
+    baseUrl: validatedBaseUrl(required(env.ARCHETYPE_BASE_URL)),
+    oktaApiToken: required(env.OKTA_API_TOKEN),
+    oktaDomain: validatedBaseUrl(required(env.OKTA_DOMAIN)),
+    timeoutMs: positiveInteger(
+      env.ARCHETYPE_REQUEST_TIMEOUT_MS,
+      10_000,
+      1_000,
+      30_000,
+      "Archetype request timeout",
+    ),
+  });
+}
+
 function booleanBinding(value: string | undefined): boolean {
   const normalized = required(value);
   if (normalized === "true") return true;
   if (normalized === "false") return false;
   throw new SlackRuntimeConfigError("A required boolean runtime binding is invalid.");
+}
+
+function optionalBooleanBinding(
+  value: string | undefined,
+  fallback: boolean,
+): boolean {
+  if (value === undefined || value.trim() === "") return fallback;
+  return booleanBinding(value);
 }
 
 function required(value: string | undefined): string {
@@ -66,6 +132,24 @@ function port(value: string | undefined): number {
   const parsed = Number(value ?? "3000");
   if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 65_535) {
     throw new SlackRuntimeConfigError("The runtime port is invalid.");
+  }
+  return parsed;
+}
+
+function positiveInteger(
+  value: string | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  field: string,
+): number {
+  const parsed = Number(value ?? String(fallback));
+  if (
+    !Number.isSafeInteger(parsed)
+    || parsed < minimum
+    || parsed > maximum
+  ) {
+    throw new SlackRuntimeConfigError(`${field} is invalid.`);
   }
   return parsed;
 }

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -22,6 +22,12 @@ import {
   FileOutcomeStore,
   type PendingAssistantOutcome,
 } from "./outcome-store.js";
+import {
+  archetypeErrorModal,
+  archetypeLoadingModal,
+  ArchetypeSlackWorkspace,
+  archetypeUnavailableHome,
+} from "./archetype-workspace.js";
 
 const GRAPH_CAPABILITY = "cerebro:graph_read";
 const GRAPH_SOURCE_REF = "source/cerebro/grc-ask";
@@ -277,6 +283,7 @@ export class SlackCompanionRuntime {
     private readonly host: AssistantTurnHostAdapter,
     private readonly questions: AssistantQuestionService,
     private readonly outcomes: FileOutcomeStore,
+    private readonly archetype?: ArchetypeSlackWorkspace,
   ) {
     this.app = new App({
       appToken: config.appToken,
@@ -327,10 +334,107 @@ export class SlackCompanionRuntime {
   private registerRoutes(): void {
     this.app.event("app_home_opened", async ({ context, event, client }) => {
       if (!context.teamId || !this.config.allowedTeamIds.has(context.teamId)) return;
+      if (this.archetype) {
+        try {
+          const view = await this.archetype.home({
+            slack: client,
+            teamId: context.teamId,
+            userId: event.user,
+          });
+          await client.views.publish({ user_id: event.user, view });
+        } catch (error) {
+          logArchetypeFailure("home", error);
+          await client.views.publish({
+            user_id: event.user,
+            view: archetypeUnavailableHome(error),
+          });
+        }
+        return;
+      }
       await client.views.publish({
         user_id: event.user,
         view: environmentHomeView(this.config),
       });
+    });
+
+    this.app.action(/^archetype_start_work_[0-9a-f]+$/u, async ({
+      ack,
+      action,
+      body,
+      client,
+    }) => {
+      await ack();
+      if (!this.archetype || action.type !== "button" || !action.value) return;
+      const teamId = body.team?.id;
+      const userId = body.user.id;
+      const triggerId = "trigger_id" in body && typeof body.trigger_id === "string"
+        ? body.trigger_id
+        : undefined;
+      if (
+        !teamId
+        || !triggerId
+        || !this.config.allowedTeamIds.has(teamId)
+      ) return;
+      const opened = await client.views.open({
+        trigger_id: triggerId,
+        view: archetypeLoadingModal(),
+      });
+      const viewId = opened.view?.id;
+      if (!viewId) return;
+      try {
+        const view = await this.archetype.preview({
+          actionValue: action.value,
+          slack: client,
+          teamId,
+          userId,
+        });
+        await client.views.update({ view, view_id: viewId });
+      } catch (error) {
+        logArchetypeFailure("preview_start_work", error);
+        await client.views.update({
+          view: archetypeErrorModal(error),
+          view_id: viewId,
+        });
+      }
+    });
+
+    this.app.action(/^archetype_confirm_start_work_[0-9a-f]+$/u, async ({
+      ack,
+      action,
+      body,
+      client,
+    }) => {
+      await ack();
+      if (!this.archetype || action.type !== "button" || !action.value) return;
+      const teamId = body.team?.id;
+      const userId = body.user.id;
+      const actionView = "view" in body ? body.view : undefined;
+      const viewId = actionView?.id;
+      if (
+        !teamId
+        || !viewId
+        || !this.config.allowedTeamIds.has(teamId)
+      ) return;
+      await client.views.update({
+        hash: actionView?.hash,
+        view: archetypeLoadingModal(),
+        view_id: viewId,
+      });
+      try {
+        const view = await this.archetype.confirm({
+          actionValue: action.value,
+          slack: client,
+          teamId,
+          userId,
+        });
+        await client.views.update({ view, view_id: viewId });
+      } catch (error) {
+        logArchetypeFailure("confirm_start_work", error);
+        await client.views.update({
+          view: archetypeErrorModal(error),
+          view_id: viewId,
+        });
+      }
     });
 
     this.app.event("app_mention", async ({ context, event, client }) => {
@@ -372,6 +476,15 @@ export class SlackCompanionRuntime {
       })}\n`);
     }
   }
+}
+
+function logArchetypeFailure(operation: string, error: unknown): void {
+  process.stderr.write(`${JSON.stringify({
+    component: "archetype-slack-workspace",
+    error_kind: error instanceof Error ? error.name : "unknown",
+    operation,
+    state: "failed",
+  })}\n`);
 }
 
 export async function handleSlackMention(input: {

--- a/apps/slack-companion-host/test/archetype-runtime.test.ts
+++ b/apps/slack-companion-host/test/archetype-runtime.test.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { HomeView } from "@slack/types";
+
+import {
+  ArchetypeWorkspaceClient,
+  ArchetypeWorkspaceClientError,
+  type SlackUserLookupPort,
+} from "../src/archetype-client.js";
+import { loadSlackRuntimeConfig } from "../src/runtime/config.js";
+import { ArchetypeSlackWorkspace } from "../src/runtime/archetype-workspace.js";
+
+const finding = {
+  assignee: null,
+  description: "A reachable production dependency has a critical advisory.",
+  due_at: "2026-07-23T18:00:00.000Z",
+  finding_uuid: "018f6b96-a7b8-8c9d-8e0f-123456789abc",
+  fingerprint: "a".repeat(64),
+  priority_reasons: ["critical severity", "runtime reachable"],
+  priority_score: 98,
+  repository: "writer/service",
+  severity: "critical",
+  sla_state: "overdue",
+  status: "actionable",
+};
+
+const digest = {
+  actor_id: "person@writer.com",
+  date: "2026-07-23",
+  generated_at: "2026-07-23T16:00:00.000Z",
+  saved_views: [],
+  today: {
+    actor_id: "person@writer.com",
+    assigned_to_me: [],
+    counts: {
+      assigned_to_me: 0,
+      changed_last_24_hours: 1,
+      due_soon: 0,
+      overdue: 1,
+      unassigned_critical: 1,
+    },
+    generated_at: "2026-07-23T16:00:00.000Z",
+    needs_attention: [finding],
+    recent_changes: [],
+  },
+};
+
+const pendingIntent = {
+  action: "start_work",
+  created_at: "2026-07-23T16:05:00.000Z",
+  executed_at: null,
+  expires_at: "2026-07-23T16:20:00.000Z",
+  finding_ref: finding.finding_uuid,
+  id: "018f6b96-a7b8-8c9d-8e0f-123456789abe",
+  status: "pending",
+  summary: "Assign this finding to Person Writer and mark it in progress.",
+};
+
+const slack: SlackUserLookupPort = {
+  users: {
+    info: async ({ user }) => ({
+      ok: true,
+      user: {
+        id: user,
+        profile: {
+          display_name: "Person Writer",
+          email: "person@writer.com",
+          real_name: "Person Writer",
+        },
+        team_id: "T-ONE",
+      },
+    }),
+  },
+};
+
+test("runtime config activates Archetype only with complete private bindings", () => {
+  const base = {
+    CEREBRO_BASE_URL: "https://cerebro.example.com",
+    CEREBRO_READ_API_KEY: "bound-at-runtime",
+    CEREBRO_SLACK_APP_NAME: "Cerebro",
+    CEREBRO_SLACK_ENVIRONMENT_LABEL: "production",
+    CEREBRO_SLACK_PRODUCTION: "true",
+    CEREBRO_TENANT_ID: "writer",
+    SLACK_ALLOWED_TEAM_IDS: "T-ONE",
+    SLACK_APP_TOKEN: "bound-at-runtime",
+    SLACK_BOT_TOKEN: "bound-at-runtime",
+  };
+  assert.equal(loadSlackRuntimeConfig(base).archetype, undefined);
+
+  const config = loadSlackRuntimeConfig({
+    ...base,
+    ARCHETYPE_ALLOWED_EMAIL_DOMAINS: "writer.com",
+    ARCHETYPE_BASE_URL: "https://archetype.internal/",
+    ARCHETYPE_REQUEST_TIMEOUT_MS: "8000",
+    ARCHETYPE_WORKSPACE_ENABLED: "true",
+    OKTA_API_TOKEN: "bound-at-runtime",
+    OKTA_DOMAIN: "https://writer.okta.com/",
+  });
+  assert.equal(config.archetype?.baseUrl, "https://archetype.internal");
+  assert.equal(config.archetype?.oktaDomain, "https://writer.okta.com");
+  assert.equal(config.archetype?.timeoutMs, 8_000);
+  assert.deepEqual(
+    [...(config.archetype?.allowedEmailDomains ?? [])],
+    ["writer.com"],
+  );
+
+  assert.throws(
+    () => loadSlackRuntimeConfig({
+      ...base,
+      ARCHETYPE_BASE_URL: "https://archetype.internal",
+    }),
+    /require ARCHETYPE_WORKSPACE_ENABLED=true/,
+  );
+});
+
+test("uses the signed-in Slack actor, active Okta user, and actor-scoped Archetype work", async () => {
+  const requests: Request[] = [];
+  const workspace = new ArchetypeSlackWorkspace(new ArchetypeWorkspaceClient({
+    allowedEmailDomains: new Set(["writer.com"]),
+    archetypeBaseUrl: "https://archetype.internal",
+    fetchImpl: async (input, init) => {
+      const request = new Request(input, init);
+      requests.push(request);
+      switch (new URL(request.url).pathname) {
+        case "/api/v1/users/person%40writer.com":
+          return json({
+            id: "00u-active",
+            profile: {
+              email: "person@writer.com",
+              firstName: "Person",
+              lastName: "Writer",
+              login: "person@writer.com",
+            },
+            status: "ACTIVE",
+          });
+        case "/api/v1/users/00u-active/groups":
+          return json([{
+            id: "group-security",
+            profile: { name: "writer-okta-user" },
+          }]);
+        case "/api/v1/workspace/digest":
+          return json(digest);
+        case "/api/v1/workspace/action-intents":
+          assert.equal(request.method, "POST");
+          assert.deepEqual(await request.json(), {
+            action: "start_work",
+            finding_ref: finding.finding_uuid,
+          });
+          return json(pendingIntent, 201);
+        case `/api/v1/workspace/action-intents/${pendingIntent.id}/execute`:
+          assert.equal(request.method, "POST");
+          return json({
+            finding: {
+              ...finding,
+              assignee: {
+                display_name: "Person Writer",
+                email: "person@writer.com",
+                id: "00u-active",
+                kind: "user",
+                source: "okta",
+              },
+              status: "in_progress",
+            },
+            intent: {
+              ...pendingIntent,
+              executed_at: "2026-07-23T16:06:00.000Z",
+              status: "executed",
+            },
+          });
+        default:
+          return new Response("not found", { status: 404 });
+      }
+    },
+    oktaApiToken: "secret-not-logged",
+    oktaDomain: "https://writer.okta.com",
+    timeoutMs: 10_000,
+  }));
+
+  const home = await workspace.home({
+    slack,
+    teamId: "T-ONE",
+    userId: "U-ONE",
+  });
+  const previewValue = buttonValues(home)[0];
+  assert.ok(previewValue);
+  const preview = await workspace.preview({
+    actionValue: previewValue,
+    slack,
+    teamId: "T-ONE",
+    userId: "U-ONE",
+  });
+  const confirmValue = buttonValues(preview)[0];
+  assert.ok(confirmValue);
+  const result = await workspace.confirm({
+    actionValue: confirmValue,
+    slack,
+    teamId: "T-ONE",
+    userId: "U-ONE",
+  });
+
+  assert.match(JSON.stringify(home), /writer\/service/);
+  assert.match(JSON.stringify(preview), /Assign this finding/);
+  assert.match(JSON.stringify(result), /Assigned to Person Writer/);
+  const archetypeRequests = requests.filter((request) =>
+    new URL(request.url).hostname === "archetype.internal"
+  );
+  assert.equal(archetypeRequests.length, 3);
+  for (const request of archetypeRequests) {
+    assert.equal(request.headers.get("x-okta-email"), "person@writer.com");
+    assert.equal(request.headers.get("x-okta-user"), "person@writer.com");
+    assert.equal(
+      request.headers.get("x-archetype-groups"),
+      "writer-okta-user",
+    );
+    assert.equal(request.headers.has("authorization"), false);
+  }
+  const oktaRequest = requests.find((request) =>
+    new URL(request.url).hostname === "writer.okta.com"
+  );
+  assert.equal(oktaRequest?.headers.get("authorization"), "SSWS secret-not-logged");
+});
+
+test("fails closed when Slack does not map to the exact active Okta identity", async () => {
+  const client = new ArchetypeWorkspaceClient({
+    allowedEmailDomains: new Set(["writer.com"]),
+    archetypeBaseUrl: "https://archetype.internal",
+    fetchImpl: async (input) => {
+      const path = new URL(String(input)).pathname;
+      if (path.includes("/users/")) {
+        return json({
+          id: "00u-other",
+          profile: {
+            email: "other@writer.com",
+            login: "other@writer.com",
+          },
+          status: "ACTIVE",
+        });
+      }
+      return json([]);
+    },
+    oktaApiToken: "bound-at-runtime",
+    oktaDomain: "https://writer.okta.com",
+    timeoutMs: 10_000,
+  });
+  await assert.rejects(
+    () => client.resolveIdentity({
+      slack,
+      teamId: "T-ONE",
+      userId: "U-ONE",
+    }),
+    (error: unknown) =>
+      error instanceof ArchetypeWorkspaceClientError
+      && error.state === "identity_unverified",
+  );
+});
+
+function buttonValues(view: HomeView | {
+  blocks: HomeView["blocks"];
+}): string[] {
+  return view.blocks.flatMap((block) => {
+    if (
+      block.type !== "actions"
+      || !("elements" in block)
+      || !Array.isArray(block.elements)
+    ) return [];
+    return block.elements.flatMap((element: unknown) => {
+      if (
+        element === null
+        || typeof element !== "object"
+        || !("type" in element)
+        || element.type !== "button"
+        || !("value" in element)
+        || typeof element.value !== "string"
+      ) return [];
+      return [element.value];
+    });
+  });
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}

--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -121,6 +121,19 @@ Hosts implement `CanonicalWorkItemPort` with the public Cerebro SDK and provide
 a durable `DurableCanonicalWorkCasePort`. Credentials, endpoints, deployment
 configuration, and provider-specific stores are outside this workspace.
 
+## Archetype daily work
+
+`src/archetype/workspace.ts` validates an actor-scoped Archetype daily digest
+and projects the current assignments, urgent findings, recent lifecycle
+changes, and bounded `Start work` actions into Slack blocks. It rejects actor
+drift, malformed source records, oversized collections, and invalid counts.
+
+The first action creates an Archetype preview only. A second action carries the
+returned intent id and requires explicit confirmation. The host resolves the
+Slack actor and supplies provider adapters; Archetype remains authoritative for
+permissions, expiry, finding state, idempotency, and the canonical Okta
+assignment.
+
 ## Alert triage
 
 `src/triage` owns portable alert-triage, evidence, and suggestion lifecycles.

--- a/apps/slack-companion/src/archetype/workspace.ts
+++ b/apps/slack-companion/src/archetype/workspace.ts
@@ -1,0 +1,647 @@
+import { createHash } from "node:crypto";
+
+import { encodeSlackActionEnvelope } from "../commands/codec.js";
+import {
+  createSlackActionRegistry,
+  type SlackActionCatalogV1,
+} from "../commands/contracts.js";
+import {
+  contentBoundSlackIdentifier,
+  normalizeSlackText,
+  projectSlackBlocks,
+  slackPlainText,
+  stableSlackIdentifier,
+  type SlackActionInputV1,
+  type SlackBlockV1,
+  type SlackBlocksProjectionV1,
+} from "../projections/blocks.js";
+
+const MAX_FINDINGS = 25;
+const MAX_RECENT_CHANGES = 25;
+const MAX_SAVED_VIEWS = 20;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type ArchetypeSeverityV1 =
+  | "critical"
+  | "high"
+  | "info"
+  | "low"
+  | "medium";
+
+export interface ArchetypeAssigneeV1 {
+  readonly display_name: string;
+  readonly email?: string;
+  readonly id: string;
+  readonly kind: "team" | "user";
+  readonly source: string;
+}
+
+export interface ArchetypeTodayFindingV1 {
+  readonly assignee: ArchetypeAssigneeV1 | null;
+  readonly description: string;
+  readonly due_at: string | null;
+  readonly finding_uuid: string;
+  readonly fingerprint: string;
+  readonly priority_reasons: readonly string[];
+  readonly priority_score: number;
+  readonly repository: string;
+  readonly severity: ArchetypeSeverityV1;
+  readonly sla_state: "due_soon" | "not_applicable" | "on_track" | "overdue";
+  readonly status: string;
+}
+
+export interface ArchetypeRecentChangeV1 {
+  readonly actor: string;
+  readonly finding_ref: string;
+  readonly occurred_at: string;
+  readonly status: string;
+  readonly summary: string;
+}
+
+export interface ArchetypeDailyDigestV1 {
+  readonly actor_id: string;
+  readonly date: string;
+  readonly generated_at: string;
+  readonly saved_views: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly queue_mode: "evidence" | "investigations";
+  }[];
+  readonly today: {
+    readonly actor_id: string;
+    readonly assigned_to_me: readonly ArchetypeTodayFindingV1[];
+    readonly counts: {
+      readonly assigned_to_me: number;
+      readonly changed_last_24_hours: number;
+      readonly due_soon: number;
+      readonly overdue: number;
+      readonly unassigned_critical: number;
+    };
+    readonly generated_at: string;
+    readonly needs_attention: readonly ArchetypeTodayFindingV1[];
+    readonly recent_changes: readonly ArchetypeRecentChangeV1[];
+  };
+}
+
+export interface ArchetypeFindingActionIntentV1 {
+  readonly action: "start_work";
+  readonly created_at: string;
+  readonly executed_at: string | null;
+  readonly expires_at: string;
+  readonly finding_ref: string;
+  readonly id: string;
+  readonly status: "executed" | "expired" | "pending";
+  readonly summary: string;
+}
+
+export interface ArchetypeFindingActionExecutionV1 {
+  readonly finding: ArchetypeTodayFindingV1;
+  readonly intent: ArchetypeFindingActionIntentV1;
+}
+
+export interface ArchetypeTodayProjectionV1 {
+  readonly actor_id: string;
+  readonly blocks: SlackBlocksProjectionV1;
+  readonly fallback_text: string;
+  readonly generated_at: string;
+  readonly schema_version: "archetype-today-slack-projection/v1";
+}
+
+export class ArchetypeWorkspaceContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArchetypeWorkspaceContractError";
+  }
+}
+
+const ARCHETYPE_ACTION_CATALOG: SlackActionCatalogV1 = Object.freeze({
+  actions: Object.freeze([
+    Object.freeze({
+      action_id: "archetype.start_work.preview",
+      command: "archetype_start_work_preview",
+      parameters: Object.freeze([]),
+      required_capabilities: Object.freeze([{
+        capability_id: "archetype.findings.assign_self",
+        level: "required" as const,
+        version: "v1",
+      }]),
+      retry_policy: "idempotent" as const,
+      schema_version: "slack-action-contract/v1" as const,
+      subject_requirement: "required" as const,
+    }),
+    Object.freeze({
+      action_id: "archetype.start_work.confirm",
+      command: "archetype_start_work_confirm",
+      parameters: Object.freeze([]),
+      required_capabilities: Object.freeze([{
+        capability_id: "archetype.findings.assign_self",
+        level: "required" as const,
+        version: "v1",
+      }]),
+      retry_policy: "idempotent" as const,
+      schema_version: "slack-action-contract/v1" as const,
+      subject_requirement: "required" as const,
+    }),
+  ]),
+  catalog_id: "cerebro.slack.archetype_workspace",
+  revision: 1,
+  schema_version: "slack-action-catalog/v1",
+});
+
+export const ARCHETYPE_SLACK_ACTION_REGISTRY = createSlackActionRegistry(
+  ARCHETYPE_ACTION_CATALOG,
+);
+
+export function parseArchetypeDailyDigest(
+  value: unknown,
+): ArchetypeDailyDigestV1 {
+  const digest = record(value, "Archetype daily digest");
+  const actorId = text(digest.actor_id, "daily digest actor_id", 320);
+  const today = record(digest.today, "Archetype Today");
+  const todayActorId = text(today.actor_id, "Today actor_id", 320);
+  if (todayActorId !== actorId) {
+    throw new ArchetypeWorkspaceContractError(
+      "Archetype returned different actors for the digest and Today records.",
+    );
+  }
+  const counts = record(today.counts, "Archetype Today counts");
+  return Object.freeze({
+    actor_id: actorId,
+    date: date(digest.date, "daily digest date"),
+    generated_at: timestamp(digest.generated_at, "daily digest generated_at"),
+    saved_views: boundedArray(
+      digest.saved_views,
+      MAX_SAVED_VIEWS,
+      "saved views",
+    ).map(parseSavedView),
+    today: Object.freeze({
+      actor_id: todayActorId,
+      assigned_to_me: boundedArray(
+        today.assigned_to_me,
+        MAX_FINDINGS,
+        "assigned findings",
+      ).map((item, index) => parseFinding(item, `assigned finding ${index + 1}`)),
+      counts: Object.freeze({
+        assigned_to_me: count(counts.assigned_to_me, "assigned_to_me"),
+        changed_last_24_hours: count(
+          counts.changed_last_24_hours,
+          "changed_last_24_hours",
+        ),
+        due_soon: count(counts.due_soon, "due_soon"),
+        overdue: count(counts.overdue, "overdue"),
+        unassigned_critical: count(
+          counts.unassigned_critical,
+          "unassigned_critical",
+        ),
+      }),
+      generated_at: timestamp(today.generated_at, "Today generated_at"),
+      needs_attention: boundedArray(
+        today.needs_attention,
+        MAX_FINDINGS,
+        "findings needing attention",
+      ).map((item, index) =>
+        parseFinding(item, `finding needing attention ${index + 1}`)
+      ),
+      recent_changes: boundedArray(
+        today.recent_changes,
+        MAX_RECENT_CHANGES,
+        "recent finding changes",
+      ).map(parseRecentChange),
+    }),
+  });
+}
+
+export function parseArchetypeFindingActionIntent(
+  value: unknown,
+): ArchetypeFindingActionIntentV1 {
+  const intent = record(value, "Archetype finding action intent");
+  if (intent.action !== "start_work") {
+    throw new ArchetypeWorkspaceContractError(
+      "Archetype returned an unsupported finding action.",
+    );
+  }
+  if (
+    intent.status !== "pending"
+    && intent.status !== "executed"
+    && intent.status !== "expired"
+  ) {
+    throw new ArchetypeWorkspaceContractError(
+      "Archetype returned an unsupported finding action state.",
+    );
+  }
+  return Object.freeze({
+    action: "start_work",
+    created_at: timestamp(intent.created_at, "action intent created_at"),
+    executed_at: optionalTimestamp(intent.executed_at, "action intent executed_at"),
+    expires_at: timestamp(intent.expires_at, "action intent expires_at"),
+    finding_ref: text(intent.finding_ref, "action intent finding_ref", 512),
+    id: uuid(intent.id, "action intent id"),
+    status: intent.status,
+    summary: text(intent.summary, "action intent summary", 1_500),
+  });
+}
+
+export function parseArchetypeFindingActionExecution(
+  value: unknown,
+): ArchetypeFindingActionExecutionV1 {
+  const execution = record(value, "Archetype finding action execution");
+  const intent = parseArchetypeFindingActionIntent(execution.intent);
+  if (intent.status !== "executed") {
+    throw new ArchetypeWorkspaceContractError(
+      "Archetype did not return an executed finding action.",
+    );
+  }
+  return Object.freeze({
+    finding: parseFinding(execution.finding, "executed finding"),
+    intent,
+  });
+}
+
+export function projectArchetypeToday(
+  digest: ArchetypeDailyDigestV1,
+): ArchetypeTodayProjectionV1 {
+  const actions = digest.today.needs_attention
+    .filter((finding) =>
+      finding.assignee === null
+      && finding.status !== "in_progress"
+      && (finding.severity === "critical" || finding.severity === "high")
+    )
+    .slice(0, 5)
+    .map((finding) => projectStartWorkAction(finding, digest.generated_at));
+  const sections = [
+    countsLine(digest),
+    findingSection("Assigned to you", digest.today.assigned_to_me),
+    findingSection("Needs attention", digest.today.needs_attention),
+    recentChangesSection(digest.today.recent_changes),
+  ];
+  const projectionKey = `archetype-today:${sha256([
+    digest.actor_id,
+    digest.generated_at,
+  ].join(":"))}`;
+  const base = projectSlackBlocks({
+    projection_key: projectionKey,
+    sections,
+    title: "Archetype · Today",
+  });
+  const blocks = withArchetypeActions(base, projectionKey, actions);
+  return Object.freeze({
+    actor_id: digest.actor_id,
+    blocks,
+    fallback_text: `Archetype Today: ${countsLine(digest)}`,
+    generated_at: digest.generated_at,
+    schema_version: "archetype-today-slack-projection/v1",
+  });
+}
+
+function withArchetypeActions(
+  base: SlackBlocksProjectionV1,
+  projectionKey: string,
+  actions: readonly SlackActionInputV1[],
+): SlackBlocksProjectionV1 {
+  if (actions.length === 0) return base;
+  const elements = Object.freeze(actions.map((action) =>
+    Object.freeze({
+      action_id: action.action_key,
+      ...(action.style === undefined ? {} : { style: action.style }),
+      text: slackPlainText(action.label, "Archetype action label", 75),
+      type: "button" as const,
+      value: normalizeSlackText(
+        action.value,
+        "Archetype action value",
+        2_000,
+      ),
+    })
+  ));
+  const actionBlock = Object.freeze({
+    block_id: stableSlackIdentifier("archetype_actions", [
+      projectionKey,
+      JSON.stringify(elements),
+    ]),
+    elements,
+    type: "actions" as const,
+  });
+  const blocks = Object.freeze([
+    ...base.blocks,
+    actionBlock,
+  ]) as readonly SlackBlockV1[];
+  const truth = {
+    blocks,
+    schema_version: "slack-blocks-projection/v1" as const,
+  };
+  return Object.freeze({
+    ...truth,
+    projection_id: contentBoundSlackIdentifier(
+      "archetype_today",
+      projectionKey,
+      truth,
+    ),
+  });
+}
+
+export function projectArchetypeStartWorkConfirmation(
+  intent: ArchetypeFindingActionIntentV1,
+): {
+  readonly action: SlackActionInputV1;
+  readonly expires_at: string;
+  readonly summary: string;
+} {
+  if (intent.status !== "pending") {
+    throw new ArchetypeWorkspaceContractError(
+      "Only a pending Archetype action can be confirmed.",
+    );
+  }
+  return Object.freeze({
+    action: Object.freeze({
+      action_key: `archetype_confirm_start_work_${compactId(intent.id)}`,
+      label: "Assign to me",
+      style: "primary" as const,
+      value: encodeSlackActionEnvelope({
+        action: "archetype.start_work.confirm",
+        command: "archetype_start_work_confirm",
+        idempotency_key: `archetype-confirm:${sha256(intent.id)}`,
+        issued_at: intent.created_at,
+        schema_version: "slack-action-envelope/v1",
+        subject_ref: `archetype-intent://${intent.id}`,
+      }),
+    }),
+    expires_at: intent.expires_at,
+    summary: intent.summary,
+  });
+}
+
+function projectStartWorkAction(
+  finding: ArchetypeTodayFindingV1,
+  issuedAt: string,
+): SlackActionInputV1 {
+  return Object.freeze({
+    action_key: `archetype_start_work_${compactId(finding.finding_uuid)}`,
+    label: "Start work",
+    value: encodeSlackActionEnvelope({
+      action: "archetype.start_work.preview",
+      command: "archetype_start_work_preview",
+      idempotency_key: `archetype-preview:${sha256([
+        finding.finding_uuid,
+        issuedAt,
+      ].join(":"))}`,
+      issued_at: issuedAt,
+      schema_version: "slack-action-envelope/v1",
+      subject_ref: `archetype-finding://${finding.finding_uuid}`,
+    }),
+  });
+}
+
+function parseFinding(value: unknown, field: string): ArchetypeTodayFindingV1 {
+  const finding = record(value, field);
+  const severity = finding.severity;
+  if (
+    severity !== "critical"
+    && severity !== "high"
+    && severity !== "medium"
+    && severity !== "low"
+    && severity !== "info"
+  ) {
+    throw new ArchetypeWorkspaceContractError(`${field} severity is invalid.`);
+  }
+  const slaState = finding.sla_state;
+  if (
+    slaState !== "not_applicable"
+    && slaState !== "on_track"
+    && slaState !== "due_soon"
+    && slaState !== "overdue"
+  ) {
+    throw new ArchetypeWorkspaceContractError(`${field} SLA state is invalid.`);
+  }
+  return Object.freeze({
+    assignee: parseAssignee(finding.assignee, `${field} assignee`),
+    description: text(finding.description, `${field} description`, 2_000),
+    due_at: optionalTimestamp(finding.due_at, `${field} due_at`),
+    finding_uuid: uuid(finding.finding_uuid, `${field} finding_uuid`),
+    fingerprint: text(finding.fingerprint, `${field} fingerprint`, 512),
+    priority_reasons: boundedArray(
+      finding.priority_reasons,
+      20,
+      `${field} priority reasons`,
+    ).map((reason, index) =>
+      text(reason, `${field} priority reason ${index + 1}`, 500)
+    ),
+    priority_score: integer(
+      finding.priority_score,
+      `${field} priority score`,
+      -1_000_000,
+      1_000_000,
+    ),
+    repository: text(finding.repository, `${field} repository`, 300),
+    severity,
+    sla_state: slaState,
+    status: text(finding.status, `${field} status`, 80),
+  });
+}
+
+function parseAssignee(
+  value: unknown,
+  field: string,
+): ArchetypeAssigneeV1 | null {
+  if (value === null) return null;
+  const assignee = record(value, field);
+  if (assignee.kind !== "user" && assignee.kind !== "team") {
+    throw new ArchetypeWorkspaceContractError(`${field} kind is invalid.`);
+  }
+  return Object.freeze({
+    display_name: text(assignee.display_name, `${field} display_name`, 300),
+    ...(assignee.email === null || assignee.email === undefined
+      ? {}
+      : { email: email(assignee.email, `${field} email`) }),
+    id: text(assignee.id, `${field} id`, 300),
+    kind: assignee.kind,
+    source: text(assignee.source, `${field} source`, 80),
+  });
+}
+
+function parseRecentChange(value: unknown, index: number): ArchetypeRecentChangeV1 {
+  const field = `recent finding change ${index + 1}`;
+  const change = record(value, field);
+  return Object.freeze({
+    actor: text(change.actor, `${field} actor`, 320),
+    finding_ref: text(change.finding_ref, `${field} finding_ref`, 512),
+    occurred_at: timestamp(change.occurred_at, `${field} occurred_at`),
+    status: text(change.status, `${field} status`, 80),
+    summary: text(change.summary, `${field} summary`, 1_000),
+  });
+}
+
+function parseSavedView(value: unknown, index: number): {
+  readonly id: string;
+  readonly name: string;
+  readonly queue_mode: "evidence" | "investigations";
+} {
+  const field = `saved view ${index + 1}`;
+  const view = record(value, field);
+  if (view.queue_mode !== "evidence" && view.queue_mode !== "investigations") {
+    throw new ArchetypeWorkspaceContractError(`${field} queue mode is invalid.`);
+  }
+  return Object.freeze({
+    id: uuid(view.id, `${field} id`),
+    name: text(view.name, `${field} name`, 80),
+    queue_mode: view.queue_mode,
+  });
+}
+
+function countsLine(digest: ArchetypeDailyDigestV1): string {
+  const counts = digest.today.counts;
+  return [
+    `${counts.assigned_to_me} assigned`,
+    `${counts.overdue} overdue`,
+    `${counts.due_soon} due soon`,
+    `${counts.unassigned_critical} unassigned critical`,
+    `${counts.changed_last_24_hours} changed in 24h`,
+  ].join(" · ");
+}
+
+function findingSection(
+  title: string,
+  findings: readonly ArchetypeTodayFindingV1[],
+): string {
+  if (findings.length === 0) return `${title}\nNone.`;
+  return [
+    title,
+    ...findings.slice(0, 5).map((finding) => {
+      const ownership = finding.assignee?.display_name ?? "Unassigned";
+      const deadline = finding.sla_state === "overdue"
+        ? " · Overdue"
+        : finding.sla_state === "due_soon"
+          ? " · Due soon"
+          : "";
+      return `• ${finding.severity.toUpperCase()} · ${finding.repository} · ${ownership}${deadline}\n  ${finding.description}`;
+    }),
+    ...(findings.length > 5 ? [`${findings.length - 5} more in Archetype.`] : []),
+  ].join("\n");
+}
+
+function recentChangesSection(
+  changes: readonly ArchetypeRecentChangeV1[],
+): string {
+  if (changes.length === 0) return "Recent changes\nNone in the last 24 hours.";
+  return [
+    "Recent changes",
+    ...changes.slice(0, 5).map((change) => `• ${change.summary}`),
+    ...(changes.length > 5 ? [`${changes.length - 5} more in Archetype.`] : []),
+  ].join("\n");
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (
+    value === null
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || Object.getPrototypeOf(value) !== Object.prototype
+    || Object.prototype.hasOwnProperty.call(value, "toJSON")
+  ) {
+    throw new ArchetypeWorkspaceContractError(`${field} must be a plain record.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function boundedArray(
+  value: unknown,
+  maximum: number,
+  field: string,
+): readonly unknown[] {
+  if (
+    !Array.isArray(value)
+    || value.length > maximum
+    || Object.getPrototypeOf(value) !== Array.prototype
+    || Object.prototype.hasOwnProperty.call(value, "toJSON")
+  ) {
+    throw new ArchetypeWorkspaceContractError(`${field} must be a bounded array.`);
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.prototype.hasOwnProperty.call(value, index)) {
+      throw new ArchetypeWorkspaceContractError(`${field} must not be sparse.`);
+    }
+  }
+  return value;
+}
+
+function text(value: unknown, field: string, maximum: number): string {
+  if (typeof value !== "string") {
+    throw new ArchetypeWorkspaceContractError(`${field} must be text.`);
+  }
+  const normalized = value.replace(/\r\n?/g, "\n").normalize("NFC").trim();
+  if (
+    normalized.length === 0
+    || Array.from(normalized).length > maximum
+    || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(normalized)
+  ) {
+    throw new ArchetypeWorkspaceContractError(`${field} is invalid.`);
+  }
+  return normalized;
+}
+
+function uuid(value: unknown, field: string): string {
+  const normalized = text(value, field, 36);
+  if (!UUID_PATTERN.test(normalized)) {
+    throw new ArchetypeWorkspaceContractError(`${field} must be a UUID.`);
+  }
+  return normalized.toLowerCase();
+}
+
+function email(value: unknown, field: string): string {
+  const normalized = text(value, field, 320).toLowerCase();
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalized)) {
+    throw new ArchetypeWorkspaceContractError(`${field} must be an email address.`);
+  }
+  return normalized;
+}
+
+function timestamp(value: unknown, field: string): string {
+  const normalized = text(value, field, 64);
+  const parsed = Date.parse(normalized);
+  if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== normalized) {
+    throw new ArchetypeWorkspaceContractError(
+      `${field} must be a canonical timestamp.`,
+    );
+  }
+  return normalized;
+}
+
+function optionalTimestamp(value: unknown, field: string): string | null {
+  return value === null ? null : timestamp(value, field);
+}
+
+function date(value: unknown, field: string): string {
+  const normalized = text(value, field, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+    throw new ArchetypeWorkspaceContractError(`${field} must be a date.`);
+  }
+  return normalized;
+}
+
+function count(value: unknown, field: string): number {
+  return integer(value, field, 0, Number.MAX_SAFE_INTEGER);
+}
+
+function integer(
+  value: unknown,
+  field: string,
+  minimum: number,
+  maximum: number,
+): number {
+  if (
+    typeof value !== "number"
+    || !Number.isSafeInteger(value)
+    || value < minimum
+    || value > maximum
+  ) {
+    throw new ArchetypeWorkspaceContractError(`${field} must be an integer.`);
+  }
+  return value;
+}
+
+function compactId(value: string): string {
+  return value.replaceAll("-", "").slice(0, 16).toLowerCase();
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -30,6 +30,7 @@ export * from "./delivery/coordinator.js";
 export * from "./delivery/ports.js";
 export * from "./artifacts/contracts.js";
 export * from "./artifacts/policy.js";
+export * from "./archetype/workspace.js";
 export * from "./progress/contracts.js";
 export * from "./progress/policy.js";
 export * from "./reengagement/contracts.js";

--- a/apps/slack-companion/test/archetype-workspace.test.ts
+++ b/apps/slack-companion/test/archetype-workspace.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decodeSlackActionEnvelope,
+  parseArchetypeDailyDigest,
+  parseArchetypeFindingActionExecution,
+  parseArchetypeFindingActionIntent,
+  projectArchetypeStartWorkConfirmation,
+  projectArchetypeToday,
+} from "../src/index.js";
+
+const finding = {
+  assignee: null,
+  description: "The production dependency has a reachable critical advisory.",
+  due_at: "2026-07-23T18:00:00.000Z",
+  finding_uuid: "018f6b96-a7b8-8c9d-8e0f-123456789abc",
+  fingerprint: "a".repeat(64),
+  priority_reasons: ["critical severity", "runtime reachable"],
+  priority_score: 98,
+  repository: "writer/service",
+  severity: "critical",
+  sla_state: "overdue",
+  status: "actionable",
+};
+
+const digest = {
+  actor_id: "person@writer.com",
+  date: "2026-07-23",
+  generated_at: "2026-07-23T16:00:00.000Z",
+  saved_views: [{
+    id: "018f6b96-a7b8-8c9d-8e0f-123456789abd",
+    name: "Critical work",
+    queue_mode: "investigations",
+  }],
+  today: {
+    actor_id: "person@writer.com",
+    assigned_to_me: [],
+    counts: {
+      assigned_to_me: 0,
+      changed_last_24_hours: 1,
+      due_soon: 0,
+      overdue: 1,
+      unassigned_critical: 1,
+    },
+    generated_at: "2026-07-23T16:00:00.000Z",
+    needs_attention: [finding],
+    recent_changes: [{
+      actor: "security@writer.com",
+      finding_ref: finding.finding_uuid,
+      occurred_at: "2026-07-23T15:00:00.000Z",
+      status: "actionable",
+      summary: "The finding reopened after the latest scan.",
+    }],
+  },
+};
+
+test("parses a source-backed actor-scoped daily digest and projects exact work", () => {
+  const parsed = parseArchetypeDailyDigest(digest);
+  const projection = projectArchetypeToday(parsed);
+
+  assert.equal(parsed.actor_id, "person@writer.com");
+  assert.equal(parsed.today.needs_attention[0]?.priority_score, 98);
+  assert.match(projection.fallback_text, /1 overdue/);
+  assert.match(
+    projection.blocks.blocks.map((block) =>
+      "text" in block ? block.text.text : ""
+    ).join("\n"),
+    /writer\/service/,
+  );
+
+  const actionBlock = projection.blocks.blocks.find((block) =>
+    block.type === "actions"
+  );
+  assert.ok(actionBlock && actionBlock.type === "actions");
+  assert.equal(actionBlock.elements.length, 1);
+  assert.match(
+    actionBlock.elements[0]!.action_id,
+    /^archetype_start_work_[0-9a-f]+$/,
+  );
+  const envelope = decodeSlackActionEnvelope(actionBlock.elements[0]!.value);
+  assert.equal(envelope.action, "archetype.start_work.preview");
+  assert.equal(
+    envelope.subject_ref,
+    `archetype-finding://${finding.finding_uuid}`,
+  );
+});
+
+test("rejects actor drift, oversized source collections, and fabricated counts", () => {
+  assert.throws(
+    () => parseArchetypeDailyDigest({
+      ...digest,
+      today: { ...digest.today, actor_id: "other@writer.com" },
+    }),
+    /different actors/,
+  );
+  assert.throws(
+    () => parseArchetypeDailyDigest({
+      ...digest,
+      today: {
+        ...digest.today,
+        needs_attention: Array.from({ length: 26 }, () => finding),
+      },
+    }),
+    /bounded array/,
+  );
+  assert.throws(
+    () => parseArchetypeDailyDigest({
+      ...digest,
+      today: {
+        ...digest.today,
+        counts: { ...digest.today.counts, overdue: -1 },
+      },
+    }),
+    /must be an integer/,
+  );
+});
+
+test("projects preview and explicit confirmation without executing a finding", () => {
+  const intent = parseArchetypeFindingActionIntent({
+    action: "start_work",
+    created_at: "2026-07-23T16:05:00.000Z",
+    executed_at: null,
+    expires_at: "2026-07-23T16:20:00.000Z",
+    finding_ref: finding.finding_uuid,
+    id: "018f6b96-a7b8-8c9d-8e0f-123456789abe",
+    status: "pending",
+    summary: "Assign this finding to Person Writer and mark it in progress.",
+  });
+  const confirmation = projectArchetypeStartWorkConfirmation(intent);
+  const envelope = decodeSlackActionEnvelope(confirmation.action.value);
+
+  assert.equal(confirmation.action.label, "Assign to me");
+  assert.equal(envelope.action, "archetype.start_work.confirm");
+  assert.equal(
+    envelope.subject_ref,
+    "archetype-intent://018f6b96-a7b8-8c9d-8e0f-123456789abe",
+  );
+
+  const execution = parseArchetypeFindingActionExecution({
+    finding: {
+      ...finding,
+      assignee: {
+        display_name: "Person Writer",
+        email: "person@writer.com",
+        id: "00u-active",
+        kind: "user",
+        source: "okta",
+      },
+      status: "in_progress",
+    },
+    intent: {
+      ...intent,
+      executed_at: "2026-07-23T16:06:00.000Z",
+      status: "executed",
+    },
+  });
+  assert.equal(execution.finding.assignee?.source, "okta");
+  assert.equal(execution.intent.status, "executed");
+});


### PR DESCRIPTION
## What changed

- Projects actor-scoped daily finding work into Slack App Home.
- Resolves the signed Slack actor against an active directory identity before reading work.
- Uses a preview and explicit confirmation before assigning a finding.
- Fails closed on identity drift, stale finding state, malformed source records, and unavailable providers.

## Validation

- Portable Slack companion checks passed (487 tests).
- Slack host checks passed (53 tests).
- Public compatibility checks passed.
- Production dependency audit found zero vulnerabilities.
- Practice Registry final gate passed.

## Dependency

This change is stacked on the public Slack runtime boundary and should merge after that parent.
