### PR TITLE
Bound multi-runtime Postgres reads

### DIFF
--- a/internal/statestore/postgres/findingevaluationruns.go
+++ b/internal/statestore/postgres/findingevaluationruns.go
@@ -28,6 +28,7 @@ var ensureFindingEvaluationRunStatements = []string{
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 	`CREATE INDEX IF NOT EXISTS finding_evaluation_runs_runtime_idx ON finding_evaluation_runs (runtime_id, started_at DESC)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evaluation_runs_runtime_latest_idx ON finding_evaluation_runs (runtime_id, started_at DESC, id DESC)`,
 	`CREATE INDEX IF NOT EXISTS finding_evaluation_runs_rule_idx ON finding_evaluation_runs (rule_id, started_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS finding_evaluation_runs_status_idx ON finding_evaluation_runs (status, started_at DESC)`,
 }
@@ -169,6 +170,9 @@ func findingEvaluationRunListQuery(request ports.ListFindingEvaluationRunsReques
 	if len(runtimeIDs) == 0 {
 		return "", nil, errors.New("finding evaluation runtime id is required")
 	}
+	if request.LatestByRuntime {
+		return findingEvaluationLatestByRuntimeQuery(request, runtimeIDs)
+	}
 	clauses := []string{}
 	args := []any{}
 	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
@@ -178,16 +182,43 @@ func findingEvaluationRunListQuery(request ports.ListFindingEvaluationRunsReques
 		args = append(args, request.FinishedAtOrBefore.UTC())
 		clauses = append(clauses, fmt.Sprintf("finished_at <= $%d", len(args)))
 	}
-	selectClause := "SELECT finding_evaluation_run_json::text"
-	orderClause := "ORDER BY finished_at DESC NULLS LAST, started_at DESC, id"
-	if request.LatestByRuntime {
-		selectClause = "SELECT DISTINCT ON (runtime_id) finding_evaluation_run_json::text"
-		orderClause = "ORDER BY runtime_id, started_at DESC, id DESC"
-	}
-	query := "\n" + selectClause + `
+	query := `
+SELECT finding_evaluation_run_json::text
 FROM finding_evaluation_runs
 WHERE ` + strings.Join(clauses, " AND ") + `
-` + orderClause
+ORDER BY finished_at DESC NULLS LAST, started_at DESC, id`
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
+func findingEvaluationLatestByRuntimeQuery(request ports.ListFindingEvaluationRunsRequest, runtimeIDs []string) (string, []any, error) {
+	args := make([]any, 0, len(runtimeIDs)+4)
+	requestedRows := make([]string, 0, len(runtimeIDs))
+	for ordinal, runtimeID := range runtimeIDs {
+		args = append(args, runtimeID)
+		requestedRows = append(requestedRows, fmt.Sprintf("($%d::text, %d)", len(args), ordinal))
+	}
+	clauses := []string{"run.runtime_id = requested.runtime_id"}
+	addFindingEvaluationRunFilter(&clauses, &args, "run.rule_id", request.RuleID)
+	addFindingEvaluationRunFilter(&clauses, &args, "run.status", request.Status)
+	if !request.FinishedAtOrBefore.IsZero() {
+		args = append(args, request.FinishedAtOrBefore.UTC())
+		clauses = append(clauses, fmt.Sprintf("run.finished_at <= $%d", len(args)))
+	}
+	query := `
+SELECT latest.finding_evaluation_run_json::text
+FROM (VALUES ` + strings.Join(requestedRows, ", ") + `) AS requested(runtime_id, ordinal)
+CROSS JOIN LATERAL (
+	SELECT run.finding_evaluation_run_json
+	FROM finding_evaluation_runs AS run
+	WHERE ` + strings.Join(clauses, " AND ") + `
+	ORDER BY run.started_at DESC, run.id DESC
+	LIMIT 1
+) AS latest
+ORDER BY requested.ordinal`
 	if request.Limit != 0 {
 		args = append(args, int64(request.Limit))
 		query += fmt.Sprintf(" LIMIT $%d", len(args))

--- a/internal/statestore/postgres/findingevaluationruns_test.go
+++ b/internal/statestore/postgres/findingevaluationruns_test.go
@@ -106,9 +106,12 @@ func TestFindingEvaluationRunListQuerySelectsLatestForEachRuntime(t *testing.T) 
 		t.Fatalf("findingEvaluationRunListQuery() error = %v", err)
 	}
 	for _, fragment := range []string{
-		"SELECT DISTINCT ON (runtime_id)",
-		"runtime_id IN ($1, $2)",
-		"ORDER BY runtime_id, started_at DESC, id DESC",
+		"FROM (VALUES ($1::text, 0), ($2::text, 1)) AS requested(runtime_id, ordinal)",
+		"CROSS JOIN LATERAL",
+		"run.runtime_id = requested.runtime_id",
+		"ORDER BY run.started_at DESC, run.id DESC",
+		"LIMIT 1",
+		"ORDER BY requested.ordinal",
 		"LIMIT $3",
 	} {
 		if !strings.Contains(query, fragment) {
@@ -117,5 +120,43 @@ func TestFindingEvaluationRunListQuerySelectsLatestForEachRuntime(t *testing.T) 
 	}
 	if len(args) != 3 || args[0] != "runtime-b" || args[1] != "runtime-a" || args[2] != int64(2) {
 		t.Fatalf("findingEvaluationRunListQuery().args = %#v", args)
+	}
+}
+
+func TestFindingEvaluationRunListQueryAppliesLatestFiltersInsideRuntimeProbe(t *testing.T) {
+	cutoff := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	query, args, err := findingEvaluationRunListQuery(ports.ListFindingEvaluationRunsRequest{
+		RuntimeIDs:         []string{"runtime-a", "runtime-b"},
+		RuleID:             "rule-a",
+		Status:             "completed",
+		FinishedAtOrBefore: cutoff,
+		LatestByRuntime:    true,
+	})
+	if err != nil {
+		t.Fatalf("findingEvaluationRunListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"run.rule_id = $3",
+		"run.status = $4",
+		"run.finished_at <= $5",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvaluationRunListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if len(args) != 5 || args[2] != "rule-a" || args[3] != "completed" || args[4] != cutoff {
+		t.Fatalf("findingEvaluationRunListQuery().args = %#v", args)
+	}
+}
+
+func TestFindingEvaluationRunSchemaIncludesLatestRuntimeIndex(t *testing.T) {
+	joined := strings.Join(ensureFindingEvaluationRunStatements, "\n")
+	for _, fragment := range []string{
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evaluation_runs_runtime_latest_idx",
+		"(runtime_id, started_at DESC, id DESC)",
+	} {
+		if !strings.Contains(joined, fragment) {
+			t.Fatalf("finding evaluation run schema missing %q:\n%s", fragment, joined)
+		}
 	}
 }

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -434,7 +434,8 @@ func findingEvidenceUsesRuntimeTopN(request ports.ListFindingEvidenceRequest) bo
 	if len(runtimeIDs) < 2 {
 		return false
 	}
-	return len(normalizedNonEmptyStrings(append(append([]string(nil), request.FindingIDs...), request.FindingID))) == 0 &&
+	return request.FindingIDs == nil &&
+		strings.TrimSpace(request.FindingID) == "" &&
 		strings.TrimSpace(request.RunID) == "" &&
 		strings.TrimSpace(request.RuleID) == "" &&
 		strings.TrimSpace(request.ClaimID) == "" &&

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -61,6 +61,7 @@ var ensureFindingEvidenceStatements = []string{
 	`CREATE INDEX IF NOT EXISTS finding_evidence_attributes_gin_idx ON finding_evidence USING GIN (attributes_json)`,
 	`CREATE INDEX IF NOT EXISTS finding_evidence_last_observed_idx ON finding_evidence (runtime_id, last_observed_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS finding_evidence_runtime_observed_id_idx ON finding_evidence (runtime_id, last_observed_at DESC, created_at DESC, id)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_created_id_idx ON finding_evidence (runtime_id, created_at DESC, id)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_observed_idx ON finding_evidence (runtime_id, finding_id, last_observed_at DESC, created_at DESC, id)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_created_idx ON finding_evidence (runtime_id, finding_id, created_at DESC, id)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_rule_observed_idx ON finding_evidence (runtime_id, rule_id, last_observed_at DESC, created_at DESC, id)`,
@@ -393,6 +394,9 @@ func (s *Store) ensureFindingEvidenceTables(ctx context.Context) error {
 }
 
 func findingEvidenceListQuery(request ports.ListFindingEvidenceRequest) (string, []any, error) {
+	if findingEvidenceUsesRuntimeTopN(request) {
+		return findingEvidenceRuntimeTopNQuery(request, false)
+	}
 	clauses, args, err := findingEvidenceFilterClauses(request)
 	if err != nil {
 		return "", nil, err
@@ -408,6 +412,9 @@ ORDER BY ` + findingEvidenceListOrder(request)
 }
 
 func findingEvidenceHeaderListQuery(request ports.ListFindingEvidenceRequest) (string, []any, error) {
+	if findingEvidenceUsesRuntimeTopN(request) {
+		return findingEvidenceRuntimeTopNQuery(request, true)
+	}
 	clauses, args, err := findingEvidenceFilterClauses(request)
 	if err != nil {
 		return "", nil, err
@@ -419,6 +426,56 @@ WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingEvidenceListOrder(request)
 	args = append(args, int64(findingEvidenceListLimit(request.Limit)))
 	query += fmt.Sprintf(" LIMIT $%d", len(args))
+	return query, args, nil
+}
+
+func findingEvidenceUsesRuntimeTopN(request ports.ListFindingEvidenceRequest) bool {
+	runtimeIDs := normalizedNonEmptyStrings(append(append([]string(nil), request.RuntimeIDs...), request.RuntimeID))
+	if len(runtimeIDs) < 2 {
+		return false
+	}
+	return len(normalizedNonEmptyStrings(append(append([]string(nil), request.FindingIDs...), request.FindingID))) == 0 &&
+		strings.TrimSpace(request.RunID) == "" &&
+		strings.TrimSpace(request.RuleID) == "" &&
+		strings.TrimSpace(request.ClaimID) == "" &&
+		strings.TrimSpace(request.EventID) == "" &&
+		strings.TrimSpace(request.GraphRootURN) == "" &&
+		strings.TrimSpace(request.GraphPathURN) == ""
+}
+
+func findingEvidenceRuntimeTopNQuery(request ports.ListFindingEvidenceRequest, headerOnly bool) (string, []any, error) {
+	runtimeIDs := normalizedNonEmptyStrings(append(append([]string(nil), request.RuntimeIDs...), request.RuntimeID))
+	if len(runtimeIDs) == 0 {
+		return "", nil, errors.New("finding evidence runtime id is required")
+	}
+	args := make([]any, 0, len(runtimeIDs)+1)
+	requestedRows := make([]string, 0, len(runtimeIDs))
+	for _, runtimeID := range runtimeIDs {
+		args = append(args, runtimeID)
+		requestedRows = append(requestedRows, fmt.Sprintf("($%d::text)", len(args)))
+	}
+	args = append(args, int64(findingEvidenceListLimit(request.Limit)))
+	limitPlaceholder := fmt.Sprintf("$%d", len(args))
+	candidateOrder := findingEvidenceListOrderWithAlias(request, "evidence")
+	resultOrder := findingEvidenceListOrderWithAlias(request, "candidate")
+	candidateProjection := "evidence.finding_evidence_json, evidence.last_observed_at, evidence.created_at, evidence.id"
+	resultProjection := "candidate.finding_evidence_json::text"
+	if headerOnly {
+		candidateProjection = "evidence.id, evidence.runtime_id, evidence.rule_id, evidence.finding_id, evidence.run_id, evidence.claim_ids_json, evidence.event_ids_json, evidence.graph_root_urns_json, evidence.last_observed_at, evidence.created_at"
+		resultProjection = "candidate.id, candidate.runtime_id, candidate.rule_id, candidate.finding_id, candidate.run_id, candidate.claim_ids_json::text, candidate.event_ids_json::text, candidate.graph_root_urns_json::text, candidate.created_at"
+	}
+	query := `
+SELECT ` + resultProjection + `
+FROM (VALUES ` + strings.Join(requestedRows, ", ") + `) AS requested(runtime_id)
+CROSS JOIN LATERAL (
+	SELECT ` + candidateProjection + `
+	FROM finding_evidence AS evidence
+	WHERE evidence.runtime_id = requested.runtime_id
+	ORDER BY ` + candidateOrder + `
+	LIMIT ` + limitPlaceholder + `
+) AS candidate
+ORDER BY ` + resultOrder + `
+LIMIT ` + limitPlaceholder
 	return query, args, nil
 }
 
@@ -527,10 +584,20 @@ func findingStringSliceFromJSON(payload string) ([]string, error) {
 }
 
 func findingEvidenceListOrder(request ports.ListFindingEvidenceRequest) string {
-	if request.CreatedOrder {
-		return "created_at DESC, id"
+	return findingEvidenceListOrderWithAlias(request, "")
+}
+
+func findingEvidenceListOrderWithAlias(request ports.ListFindingEvidenceRequest, alias string) string {
+	column := func(name string) string {
+		if alias == "" {
+			return name
+		}
+		return alias + "." + name
 	}
-	return "last_observed_at DESC, created_at DESC, id"
+	if request.CreatedOrder {
+		return column("created_at") + " DESC, " + column("id")
+	}
+	return column("last_observed_at") + " DESC, " + column("created_at") + " DESC, " + column("id")
 }
 
 func addFindingEvidenceRunFilter(clauses *[]string, args *[]any, runID string) {

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -230,6 +230,31 @@ func TestFindingEvidenceHeaderListQueryBoundsEachRuntimeBeforeGlobalSort(t *test
 	}
 }
 
+func TestFindingEvidenceListQueriesPreserveExplicitEmptyFindingBatch(t *testing.T) {
+	request := ports.ListFindingEvidenceRequest{
+		RuntimeIDs: []string{"runtime-alpha", "runtime-beta"},
+		FindingIDs: []string{},
+		Limit:      25,
+	}
+	for name, buildQuery := range map[string]func(ports.ListFindingEvidenceRequest) (string, []any, error){
+		"full":   findingEvidenceListQuery,
+		"header": findingEvidenceHeaderListQuery,
+	} {
+		t.Run(name, func(t *testing.T) {
+			query, _, err := buildQuery(request)
+			if err != nil {
+				t.Fatalf("build query: %v", err)
+			}
+			if strings.Contains(query, "CROSS JOIN LATERAL") {
+				t.Fatalf("explicit empty finding batch used runtime top-N query: %s", query)
+			}
+			if !strings.Contains(query, "FALSE") {
+				t.Fatalf("explicit empty finding batch query missing FALSE clause: %s", query)
+			}
+		})
+	}
+}
+
 func TestFindingEvidenceListQuerySupportsFindingBatches(t *testing.T) {
 	query, args, err := findingEvidenceListQuery(ports.ListFindingEvidenceRequest{
 		RuntimeIDs:   []string{"runtime-alpha", "runtime-beta"},

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -2,6 +2,8 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -173,8 +176,11 @@ func TestFindingEvidenceListQuerySupportsRuntimeBatches(t *testing.T) {
 		t.Fatalf("findingEvidenceListQuery() error = %v", err)
 	}
 	for _, fragment := range []string{
-		"runtime_id IN ($1, $2)",
-		"ORDER BY last_observed_at DESC, created_at DESC, id",
+		"FROM (VALUES ($1::text), ($2::text)) AS requested(runtime_id)",
+		"CROSS JOIN LATERAL",
+		"evidence.runtime_id = requested.runtime_id",
+		"ORDER BY evidence.last_observed_at DESC, evidence.created_at DESC, evidence.id",
+		"ORDER BY candidate.last_observed_at DESC, candidate.created_at DESC, candidate.id",
 		"LIMIT $3",
 	} {
 		if !strings.Contains(query, fragment) {
@@ -192,6 +198,35 @@ func TestFindingEvidenceListQuerySupportsRuntimeBatches(t *testing.T) {
 	}
 	if got := args[2]; got != int64(25) {
 		t.Fatalf("findingEvidenceListQuery().args[2] = %#v, want 25", got)
+	}
+}
+
+func TestFindingEvidenceHeaderListQueryBoundsEachRuntimeBeforeGlobalSort(t *testing.T) {
+	query, args, err := findingEvidenceHeaderListQuery(ports.ListFindingEvidenceRequest{
+		RuntimeIDs:   []string{"runtime-alpha", "runtime-beta"},
+		Limit:        25,
+		CreatedOrder: true,
+	})
+	if err != nil {
+		t.Fatalf("findingEvidenceHeaderListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"SELECT candidate.id, candidate.runtime_id",
+		"FROM (VALUES ($1::text), ($2::text)) AS requested(runtime_id)",
+		"CROSS JOIN LATERAL",
+		"ORDER BY evidence.created_at DESC, evidence.id",
+		"LIMIT $3",
+		"ORDER BY candidate.created_at DESC, candidate.id",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvidenceHeaderListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if strings.Contains(query, "finding_evidence_json") {
+		t.Fatalf("findingEvidenceHeaderListQuery() selected full payload: %s", query)
+	}
+	if got := len(args); got != 3 {
+		t.Fatalf("len(findingEvidenceHeaderListQuery().args) = %d, want 3", got)
 	}
 }
 
@@ -236,8 +271,9 @@ func TestFindingEvidenceListQuerySupportsCreatedOrder(t *testing.T) {
 		t.Fatalf("findingEvidenceListQuery() error = %v", err)
 	}
 	for _, fragment := range []string{
-		"runtime_id IN ($1, $2)",
-		"ORDER BY created_at DESC, id",
+		"FROM (VALUES ($1::text), ($2::text)) AS requested(runtime_id)",
+		"ORDER BY evidence.created_at DESC, evidence.id",
+		"ORDER BY candidate.created_at DESC, candidate.id",
 		"LIMIT $3",
 	} {
 		if !strings.Contains(query, fragment) {
@@ -298,6 +334,9 @@ func TestFindingEvidenceSchemaPersistsEnrichedEvidence(t *testing.T) {
 		"finding_evidence_graph_path_urns_gin_idx",
 		"finding_evidence_run_ids_gin_idx",
 		"finding_evidence_attributes_gin_idx",
+		"finding_evidence_runtime_created_id_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_created_id_idx",
+		"runtime_id, created_at DESC, id",
 		"finding_evidence_runtime_finding_observed_idx",
 		"CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_observed_idx",
 		"runtime_id, finding_id, last_observed_at DESC, created_at DESC, id",
@@ -310,6 +349,100 @@ func TestFindingEvidenceSchemaPersistsEnrichedEvidence(t *testing.T) {
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("finding evidence schema missing %q:\n%s", fragment, joined)
+		}
+	}
+}
+
+func TestRuntimeTopNQueriesPostgresIntegration(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN"))
+	if dsn == "" {
+		t.Skip("set CEREBRO_POSTGRES_DSN to run runtime top-N query integration test")
+	}
+	store, err := Open(config.StateStoreConfig{Driver: config.StateStoreDriverPostgres, PostgresDSN: dsn})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	ctx := context.Background()
+	if err := store.ensureFindingEvaluationRunTables(ctx); err != nil {
+		t.Fatalf("ensure finding evaluation run tables: %v", err)
+	}
+	if err := store.ensureFindingEvidenceTables(ctx); err != nil {
+		t.Fatalf("ensure finding evidence tables: %v", err)
+	}
+	prefix := fmt.Sprintf("runtime-top-n-%d", time.Now().UnixNano())
+	runtimeIDs := []string{prefix + "-a", prefix + "-b"}
+	cleanup := func() {
+		_, _ = store.db.ExecContext(context.Background(), `DELETE FROM finding_evidence WHERE runtime_id IN ($1, $2)`, runtimeIDs[0], runtimeIDs[1])
+		_, _ = store.db.ExecContext(context.Background(), `DELETE FROM finding_evaluation_runs WHERE runtime_id IN ($1, $2)`, runtimeIDs[0], runtimeIDs[1])
+	}
+	cleanup()
+	t.Cleanup(func() {
+		cleanup()
+		_ = store.Close()
+	})
+
+	startedAt := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	for _, runtimeID := range runtimeIDs {
+		for _, suffix := range []string{"a", "z"} {
+			run := &cerebrov1.FindingEvaluationRun{
+				Id:        runtimeID + "-" + suffix,
+				RuntimeId: runtimeID,
+				RuleId:    "rule-a",
+				Status:    "completed",
+				StartedAt: timestamppb.New(startedAt),
+			}
+			if err := store.PutFindingEvaluationRun(ctx, run); err != nil {
+				t.Fatalf("PutFindingEvaluationRun(%q) error = %v", run.GetId(), err)
+			}
+		}
+	}
+	runs, err := store.ListFindingEvaluationRuns(ctx, ports.ListFindingEvaluationRunsRequest{
+		RuntimeIDs:      runtimeIDs,
+		Limit:           uint32(len(runtimeIDs)),
+		LatestByRuntime: true,
+	})
+	if err != nil {
+		t.Fatalf("ListFindingEvaluationRuns() error = %v", err)
+	}
+	if len(runs) != len(runtimeIDs) {
+		t.Fatalf("ListFindingEvaluationRuns() returned %d runs, want %d", len(runs), len(runtimeIDs))
+	}
+	for _, run := range runs {
+		if !strings.HasSuffix(run.GetId(), "-z") {
+			t.Fatalf("ListFindingEvaluationRuns() returned non-latest run %q", run.GetId())
+		}
+	}
+
+	evidenceTimes := []time.Time{startedAt.Add(time.Minute), startedAt.Add(3 * time.Minute), startedAt.Add(2 * time.Minute), startedAt.Add(4 * time.Minute)}
+	for index, observedAt := range evidenceTimes {
+		runtimeID := runtimeIDs[index%len(runtimeIDs)]
+		evidence := &cerebrov1.FindingEvidence{
+			Id:             fmt.Sprintf("%s-evidence-%d", runtimeID, index),
+			RuntimeId:      runtimeID,
+			RuleId:         "rule-a",
+			FindingId:      "finding-a",
+			RunId:          "run-a",
+			CreatedAt:      timestamppb.New(observedAt),
+			LastObservedAt: timestamppb.New(observedAt),
+		}
+		if err := store.PutFindingEvidence(ctx, evidence); err != nil {
+			t.Fatalf("PutFindingEvidence(%q) error = %v", evidence.GetId(), err)
+		}
+	}
+	evidence, err := store.ListGRCFindingEvidence(ctx, ports.ListFindingEvidenceRequest{
+		RuntimeIDs:   runtimeIDs,
+		Limit:        3,
+		CreatedOrder: true,
+	})
+	if err != nil {
+		t.Fatalf("ListGRCFindingEvidence() error = %v", err)
+	}
+	if len(evidence) != 3 {
+		t.Fatalf("ListGRCFindingEvidence() returned %d records, want 3", len(evidence))
+	}
+	for index := 1; index < len(evidence); index++ {
+		if evidence[index-1].GetCreatedAt().AsTime().Before(evidence[index].GetCreatedAt().AsTime()) {
+			t.Fatalf("ListGRCFindingEvidence() records are not globally newest-first: %#v", evidence)
 		}
 	}
 }

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -398,7 +398,7 @@ func TestRuntimeTopNQueriesPostgresIntegration(t *testing.T) {
 	}
 	runs, err := store.ListFindingEvaluationRuns(ctx, ports.ListFindingEvaluationRunsRequest{
 		RuntimeIDs:      runtimeIDs,
-		Limit:           uint32(len(runtimeIDs)),
+		Limit:           2,
 		LatestByRuntime: true,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- replace global latest-run scans with bounded per-runtime index probes
- bound multi-runtime evidence candidates before the global result sort
- add exact indexes and PostgreSQL integration coverage for ordering and tie behavior

## Validation
- go test ./internal/statestore/postgres ./internal/sourcehealth ./internal/bootstrap -count=1
- CEREBRO_POSTGRES_DSN=<local-postgres> go test ./internal/statestore/postgres -run TestRuntimeTopNQueriesPostgresIntegration -count=1 -v
- git diff --check