### PR TITLE
Add verified access action read model

### DIFF
--- a/internal/statestore/postgres/verified_access_actions.go
+++ b/internal/statestore/postgres/verified_access_actions.go
@@ -129,7 +129,7 @@ func (s *Store) ListAccessActionsByFinding(
 SELECT record_json::text
 FROM verified_access_actions
 WHERE tenant_id = $1 AND finding_id = $2
-ORDER BY updated_at DESC, action_id DESC
+ORDER BY proposed_at DESC, action_id DESC
 LIMIT $3`, tenantID, findingID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query verified access actions by finding: %w", err)

--- a/internal/statestore/postgres/verified_access_actions.go
+++ b/internal/statestore/postgres/verified_access_actions.go
@@ -36,11 +36,12 @@ func (s *Store) CreateAccessAction(ctx context.Context, outcome verifiedaccessac
 	defer func() { _ = tx.Rollback() }()
 	result, err := tx.ExecContext(ctx, `
 INSERT INTO verified_access_actions (
-  tenant_id, action_id, idempotency_key, status, record_digest,
+  tenant_id, action_id, finding_id, idempotency_key, status, record_digest,
   last_transition_digest, record_json, proposed_at, updated_at
-) VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9)
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10)
 ON CONFLICT DO NOTHING`,
-		outcome.Record.TenantID, outcome.Record.ID, outcome.Record.IdempotencyKey,
+		outcome.Record.TenantID, outcome.Record.ID, outcome.Record.FindingID,
+		outcome.Record.IdempotencyKey,
 		outcome.Record.Status, outcome.Record.Digest, outcome.Record.LastTransitionDigest,
 		recordJSON, outcome.Record.ProposedAt, outcome.Transition.OccurredAt)
 	if err != nil {
@@ -105,6 +106,51 @@ WHERE tenant_id = $1 AND action_id = $2`, tenantID, actionID).Scan(&recordJSON)
 		return verifiedaccessaction.Record{}, fmt.Errorf("query verified access action: %w", err)
 	}
 	return decodeVerifiedAccessActionRecord(recordJSON)
+}
+
+func (s *Store) ListAccessActionsByFinding(
+	ctx context.Context,
+	tenantID string,
+	findingID string,
+	limit int,
+) ([]verifiedaccessaction.Record, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	tenantID, findingID = strings.TrimSpace(tenantID), strings.TrimSpace(findingID)
+	if tenantID == "" || findingID == "" ||
+		limit <= 0 || limit > verifiedaccessaction.MaxListLimit {
+		return nil, verifiedaccessaction.ErrInvalid
+	}
+	if err := s.ensureVerifiedAccessActionTables(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT record_json::text
+FROM verified_access_actions
+WHERE tenant_id = $1 AND finding_id = $2
+ORDER BY updated_at DESC, action_id DESC
+LIMIT $3`, tenantID, findingID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query verified access actions by finding: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make([]verifiedaccessaction.Record, 0)
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return nil, fmt.Errorf("scan verified access action: %w", err)
+		}
+		record, err := decodeVerifiedAccessActionRecord(payload)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate verified access actions by finding: %w", err)
+	}
+	return result, nil
 }
 
 func (s *Store) AppendAccessAction(ctx context.Context, outcome verifiedaccessaction.Outcome) (bool, error) {

--- a/internal/statestore/postgres/verified_access_actions_schema.go
+++ b/internal/statestore/postgres/verified_access_actions_schema.go
@@ -21,8 +21,8 @@ var ensureVerifiedAccessActionStatements = []string{
 ADD COLUMN IF NOT EXISTS finding_id TEXT NOT NULL DEFAULT ''`,
 	`CREATE INDEX IF NOT EXISTS verified_access_actions_tenant_status_updated_idx
 ON verified_access_actions (tenant_id, status, updated_at DESC, action_id)`,
-	`CREATE INDEX IF NOT EXISTS verified_access_actions_tenant_finding_updated_idx
-ON verified_access_actions (tenant_id, finding_id, updated_at DESC, action_id)`,
+	`CREATE INDEX IF NOT EXISTS verified_access_actions_tenant_finding_proposed_idx
+ON verified_access_actions (tenant_id, finding_id, proposed_at DESC, action_id)`,
 	`CREATE TABLE IF NOT EXISTS verified_access_action_transitions (
   tenant_id TEXT NOT NULL,
   action_id TEXT NOT NULL,

--- a/internal/statestore/postgres/verified_access_actions_schema.go
+++ b/internal/statestore/postgres/verified_access_actions_schema.go
@@ -6,6 +6,7 @@ var ensureVerifiedAccessActionStatements = []string{
 	`CREATE TABLE IF NOT EXISTS verified_access_actions (
   tenant_id TEXT NOT NULL,
   action_id TEXT NOT NULL,
+  finding_id TEXT NOT NULL,
   idempotency_key TEXT NOT NULL,
   status TEXT NOT NULL,
   record_digest TEXT NOT NULL,
@@ -16,8 +17,12 @@ var ensureVerifiedAccessActionStatements = []string{
   PRIMARY KEY (tenant_id, action_id),
   UNIQUE (tenant_id, idempotency_key)
 )`,
+	`ALTER TABLE verified_access_actions
+ADD COLUMN IF NOT EXISTS finding_id TEXT NOT NULL DEFAULT ''`,
 	`CREATE INDEX IF NOT EXISTS verified_access_actions_tenant_status_updated_idx
 ON verified_access_actions (tenant_id, status, updated_at DESC, action_id)`,
+	`CREATE INDEX IF NOT EXISTS verified_access_actions_tenant_finding_updated_idx
+ON verified_access_actions (tenant_id, finding_id, updated_at DESC, action_id)`,
 	`CREATE TABLE IF NOT EXISTS verified_access_action_transitions (
   tenant_id TEXT NOT NULL,
   action_id TEXT NOT NULL,

--- a/internal/statestore/postgres/verified_access_actions_test.go
+++ b/internal/statestore/postgres/verified_access_actions_test.go
@@ -31,7 +31,7 @@ func TestVerifiedAccessActionSchemaIsTenantScopedAndCASReady(t *testing.T) {
 		"UNIQUE (tenant_id, transition_digest)",
 		"FOREIGN KEY (tenant_id, action_id)",
 		"finding_id TEXT NOT NULL",
-		"(tenant_id, finding_id, updated_at DESC, action_id)",
+		"(tenant_id, finding_id, proposed_at DESC, action_id)",
 		"previous_transition_digest TEXT NOT NULL",
 	} {
 		if !strings.Contains(joined, fragment) {

--- a/internal/statestore/postgres/verified_access_actions_test.go
+++ b/internal/statestore/postgres/verified_access_actions_test.go
@@ -30,6 +30,8 @@ func TestVerifiedAccessActionSchemaIsTenantScopedAndCASReady(t *testing.T) {
 		"UNIQUE (tenant_id, idempotency_key)",
 		"UNIQUE (tenant_id, transition_digest)",
 		"FOREIGN KEY (tenant_id, action_id)",
+		"finding_id TEXT NOT NULL",
+		"(tenant_id, finding_id, updated_at DESC, action_id)",
 		"previous_transition_digest TEXT NOT NULL",
 	} {
 		if !strings.Contains(joined, fragment) {
@@ -114,6 +116,20 @@ func TestVerifiedAccessActionPostgresGrantsOneExecutionClaim(t *testing.T) {
 	}
 	if len(transitions) != 4 {
 		t.Fatalf("transition count = %d, want 4", len(transitions))
+	}
+	records, err := store.ListAccessActionsByFinding(ctx, tenantID, "finding-one", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].ID != proposed.Record.ID {
+		t.Fatalf("finding actions = %+v", records)
+	}
+	foreign, err := store.ListAccessActionsByFinding(ctx, tenantID+"-other", "finding-one", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(foreign) != 0 {
+		t.Fatalf("cross-tenant finding actions = %+v", foreign)
 	}
 }
 

--- a/internal/verifiedaccessaction/store.go
+++ b/internal/verifiedaccessaction/store.go
@@ -4,17 +4,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 )
+
+const MaxListLimit = 100
+
+// Reader exposes tenant-qualified current state without mutation authority.
+type Reader interface {
+	GetAccessAction(context.Context, string, string) (Record, error)
+	ListAccessActionsByFinding(context.Context, string, string, int) ([]Record, error)
+	ListAccessActionTransitions(context.Context, string, string) ([]TransitionReceipt, error)
+}
 
 // Store persists the current record and its immutable transition chain.
 // The applied result is true only for the caller that advances the record.
 // Executors must not call a provider when AppendAccessAction returns false.
 type Store interface {
+	Reader
 	CreateAccessAction(context.Context, Outcome) (bool, error)
-	GetAccessAction(context.Context, string, string) (Record, error)
 	AppendAccessAction(context.Context, Outcome) (bool, error)
-	ListAccessActionTransitions(context.Context, string, string) ([]TransitionReceipt, error)
 }
 
 // MemoryStore provides the same compare-and-swap behavior as the durable store
@@ -73,6 +82,39 @@ func (s *MemoryStore) GetAccessAction(_ context.Context, tenantID, actionID stri
 		return Record{}, ErrNotFound
 	}
 	return cloneRecord(record), nil
+}
+
+func (s *MemoryStore) ListAccessActionsByFinding(
+	_ context.Context,
+	tenantID string,
+	findingID string,
+	limit int,
+) ([]Record, error) {
+	if s == nil {
+		return nil, ErrState
+	}
+	tenantID, findingID = clean(tenantID), clean(findingID)
+	if tenantID == "" || findingID == "" || limit <= 0 || limit > MaxListLimit {
+		return nil, ErrInvalid
+	}
+	s.mu.RLock()
+	result := make([]Record, 0)
+	for _, record := range s.records {
+		if record.TenantID == tenantID && record.FindingID == findingID {
+			result = append(result, cloneRecord(record))
+		}
+	}
+	s.mu.RUnlock()
+	sort.Slice(result, func(left, right int) bool {
+		if result[left].ProposedAt.Equal(result[right].ProposedAt) {
+			return result[left].ID > result[right].ID
+		}
+		return result[left].ProposedAt.After(result[right].ProposedAt)
+	})
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
 }
 
 func (s *MemoryStore) AppendAccessAction(_ context.Context, outcome Outcome) (bool, error) {

--- a/internal/verifiedaccessaction/store_test.go
+++ b/internal/verifiedaccessaction/store_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestMemoryStorePersistsImmutableTransitionChain(t *testing.T) {
@@ -51,6 +52,54 @@ func TestMemoryStorePersistsImmutableTransitionChain(t *testing.T) {
 	if len(transitions) != 3 ||
 		transitions[2].PreviousTransitionDigest != transitions[1].Digest {
 		t.Fatalf("transitions = %#v", transitions)
+	}
+}
+
+func TestMemoryStoreListsBoundedFindingActionsWithinTenant(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore()
+	ctx := context.Background()
+	for index, fixture := range []struct {
+		tenantID  string
+		findingID string
+	}{
+		{tenantID: "tenant-one", findingID: "finding-one"},
+		{tenantID: "tenant-one", findingID: "finding-one"},
+		{tenantID: "tenant-one", findingID: "finding-two"},
+		{tenantID: "tenant-two", findingID: "finding-one"},
+	} {
+		input := proposalInput()
+		input.TenantID = fixture.tenantID
+		input.FindingID = fixture.findingID
+		input.IdempotencyKey = input.IdempotencyKey + "-" + string(rune('a'+index))
+		input.ProposedAt = input.ProposedAt.Add(time.Duration(index) * time.Minute)
+		outcome, err := Propose(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if applied, createErr := store.CreateAccessAction(ctx, outcome); createErr != nil || !applied {
+			t.Fatalf("CreateAccessAction() = %t, %v", applied, createErr)
+		}
+	}
+
+	records, err := store.ListAccessActionsByFinding(ctx, "tenant-one", "finding-one", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 ||
+		records[0].TenantID != "tenant-one" ||
+		records[0].FindingID != "finding-one" ||
+		records[0].IdempotencyKey != "access-revocation-one-b" {
+		t.Fatalf("records = %+v", records)
+	}
+	if _, err := store.ListAccessActionsByFinding(
+		ctx,
+		"tenant-one",
+		"finding-one",
+		MaxListLimit+1,
+	); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("oversized list error = %v, want ErrInvalid", err)
 	}
 }
 

--- a/internal/verifiedaccessaction/summary.go
+++ b/internal/verifiedaccessaction/summary.go
@@ -1,0 +1,107 @@
+package verifiedaccessaction
+
+import "time"
+
+const (
+	BlockerPreflightRequired       = "preflight_required"
+	BlockerHumanApprovalRequired   = "human_approval_required"
+	BlockerExecutionClaimRequired  = "execution_claim_required"
+	BlockerProviderResultPending   = "provider_result_pending"
+	BlockerProviderReconcile       = "provider_reconciliation_required"
+	BlockerFreshVerification       = "fresh_verification_required"
+	BlockerFreshVerificationFailed = "fresh_verification_failed"
+)
+
+// Summary is the bounded read model exposed to operators. It omits action
+// parameters, rollback instructions, actor identifiers, and receipt bodies.
+type Summary struct {
+	ActionID             string     `json:"action_id"`
+	FindingID            string     `json:"finding_id"`
+	Action               string     `json:"action"`
+	Provider             string     `json:"provider"`
+	Status               string     `json:"status"`
+	BlockerCode          string     `json:"blocker_code,omitempty"`
+	RecordDigest         string     `json:"record_digest"`
+	TransitionDigest     string     `json:"transition_digest"`
+	ProviderExternalID   string     `json:"provider_external_id,omitempty"`
+	ProviderStatus       string     `json:"provider_status,omitempty"`
+	ProviderSucceeded    bool       `json:"provider_succeeded"`
+	VerifiedClosed       bool       `json:"verified_closed"`
+	AttentionRequired    bool       `json:"attention_required"`
+	ProposedAt           time.Time  `json:"proposed_at"`
+	ApprovedAt           *time.Time `json:"approved_at,omitempty"`
+	ExecutionClaimedAt   *time.Time `json:"execution_claimed_at,omitempty"`
+	SubmissionObservedAt *time.Time `json:"submission_observed_at,omitempty"`
+	NextReconcileAt      *time.Time `json:"next_reconcile_at,omitempty"`
+	ExecutedAt           *time.Time `json:"executed_at,omitempty"`
+	VerifiedAt           *time.Time `json:"verified_at,omitempty"`
+}
+
+// Summarize verifies the canonical record before producing its operator read
+// model. Provider success remains distinct from independent verification.
+func Summarize(record Record) (Summary, error) {
+	if err := VerifyRecord(record); err != nil {
+		return Summary{}, err
+	}
+	result := Summary{
+		ActionID:         record.ID,
+		FindingID:        record.FindingID,
+		Action:           record.Definition.Metadata.ID,
+		Provider:         record.Definition.Metadata.Provider,
+		Status:           record.Status,
+		BlockerCode:      blockerCode(record.Status),
+		RecordDigest:     record.Digest,
+		TransitionDigest: record.LastTransitionDigest,
+		ProposedAt:       record.ProposedAt,
+		AttentionRequired: record.Status == StatusUnknown ||
+			record.Status == StatusReopened,
+	}
+	if record.Approval != nil {
+		result.ApprovedAt = timePointer(record.Approval.ApprovedAt)
+	}
+	if record.ExecutionClaim != nil {
+		result.ExecutionClaimedAt = timePointer(record.ExecutionClaim.ClaimedAt)
+	}
+	if record.SubmissionUnknown != nil {
+		result.SubmissionObservedAt = timePointer(record.SubmissionUnknown.ObservedAt)
+		result.NextReconcileAt = timePointer(record.SubmissionUnknown.NextReconcileAt)
+	}
+	if record.Execution != nil {
+		action := record.Execution.GraphAction
+		result.ProviderExternalID = action.ExternalID
+		result.ProviderStatus = first(action.ExternalStatus, action.Status)
+		result.ProviderSucceeded = true
+		result.ExecutedAt = timePointer(record.Execution.OccurredAt)
+	}
+	if record.Verification != nil {
+		result.VerifiedAt = timePointer(record.Verification.VerifiedAt)
+	}
+	result.VerifiedClosed = record.Status == StatusClosed
+	return result, nil
+}
+
+func blockerCode(status string) string {
+	switch status {
+	case StatusProposed:
+		return BlockerPreflightRequired
+	case StatusPreflighted:
+		return BlockerHumanApprovalRequired
+	case StatusApproved:
+		return BlockerExecutionClaimRequired
+	case StatusClaimed:
+		return BlockerProviderResultPending
+	case StatusUnknown:
+		return BlockerProviderReconcile
+	case StatusExecuted:
+		return BlockerFreshVerification
+	case StatusReopened:
+		return BlockerFreshVerificationFailed
+	default:
+		return ""
+	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	value = value.UTC()
+	return &value
+}

--- a/internal/verifiedaccessaction/summary_test.go
+++ b/internal/verifiedaccessaction/summary_test.go
@@ -1,0 +1,65 @@
+package verifiedaccessaction
+
+import "testing"
+
+func TestSummarizeKeepsProviderSuccessSeparateFromVerifiedClosure(t *testing.T) {
+	t.Parallel()
+
+	proposal := mustPropose(t)
+	preflight := mustPreflight(t, proposal.Record)
+	approval := mustApprove(t, proposal.Record.Digest, preflight.Record)
+	execution := mustExecute(t, proposal.Record.Digest, approval.Record)
+
+	summary, err := Summarize(execution.Record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !summary.ProviderSucceeded || summary.VerifiedClosed {
+		t.Fatalf(
+			"provider_succeeded=%t verified_closed=%t, want true and false",
+			summary.ProviderSucceeded,
+			summary.VerifiedClosed,
+		)
+	}
+	if summary.BlockerCode != BlockerFreshVerification {
+		t.Fatalf("blocker_code = %q, want %q", summary.BlockerCode, BlockerFreshVerification)
+	}
+	if summary.ProviderExternalID == "" || summary.ExecutedAt == nil {
+		t.Fatalf("provider receipt fields are missing: %+v", summary)
+	}
+
+	closed := mustVerify(t, execution.Record)
+	closedSummary, err := Summarize(closed.Record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !closedSummary.ProviderSucceeded || !closedSummary.VerifiedClosed ||
+		closedSummary.BlockerCode != "" || closedSummary.VerifiedAt == nil {
+		t.Fatalf("closed summary = %+v", closedSummary)
+	}
+}
+
+func TestSummarizeMarksUnknownSubmissionForAttention(t *testing.T) {
+	t.Parallel()
+
+	proposal := mustPropose(t)
+	preflight := mustPreflight(t, proposal.Record)
+	approval := mustApprove(t, proposal.Record.Digest, preflight.Record)
+	claim := mustClaim(t, proposal.Record.Digest, approval.Record)
+	unknown, err := RecordSubmissionUnknown(claim.Record, submissionUnknownInput(claim.Record))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := Summarize(unknown.Record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !summary.AttentionRequired ||
+		summary.BlockerCode != BlockerProviderReconcile ||
+		summary.NextReconcileAt == nil ||
+		summary.ProviderSucceeded ||
+		summary.VerifiedClosed {
+		t.Fatalf("unknown summary = %+v", summary)
+	}
+}


### PR DESCRIPTION
## Summary

- add a bounded summary model for verified access actions attached to one finding
- keep provider success separate from independent verification
- return stable blocker codes for preflight, approval, execution, reconciliation, and fresh verification
- add tenant- and finding-qualified store reads with a maximum page size of 100
- omit parameters, rollback instructions, actor identifiers, and receipt bodies from the read model

## Validation

- `go test ./... -count=1`
- `go test -race ./internal/verifiedaccessaction ./internal/verifiedaccessactionexecution ./internal/statestore/postgres -count=1`
- `make openapi-check openapi-lint docs-drift-check check-structural check-structural-test check-arch`
- `make lint-shard LINT_PACKAGES='./internal/...' LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=1`

## Stack

Depends on #2065 for claim-before-provider execution and #2064 for the durable lifecycle store.

Progresses #1760.