### PR TITLE
Fix Rust candidate runtime proof boundary

### DIFF
--- a/.github/workflows/rust-graph-replacement.yml
+++ b/.github/workflows/rust-graph-replacement.yml
@@ -85,6 +85,14 @@ jobs:
           runtime_image_id="$(docker image inspect --format '{{.Id}}' "${image}")"
           [[ "${runtime_image_id}" =~ ^sha256:[0-9a-f]{64}$ ]]
           echo "CEREBRO_TEST_RUNTIME_IMAGE_ID=${runtime_image_id}" >>"${GITHUB_ENV}"
+          docker run --rm --entrypoint /bin/sh "${image}" -euc '
+            test ! -e /usr/local/bin/cerebro
+            test ! -e /usr/local/go/bin/go
+            test ! -e /usr/bin/go
+            test ! -e /bin/go
+            test -x /usr/local/bin/cerebro-platform
+            test -x /usr/local/bin/organizational-graph-e2e
+          '
           docker run -d --name cerebro-rust-graph-platform --network cerebro-rust-graph-replacement \
             -p 18080:8080 \
             -e CEREBRO_NEO4J_URI=bolt://cerebro-rust-graph-neo4j:7687 \

--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -171,6 +171,9 @@ jobs:
           test "$(jq -c '.[0].Config.Cmd' <<<"${config}")" = '["serve-neo4j-consumer"]'
           docker run --rm --entrypoint /bin/sh "${CANDIDATE_IMAGE}" -euc '
             test ! -e /usr/local/bin/cerebro
+            test ! -e /usr/local/go/bin/go
+            test ! -e /usr/bin/go
+            test ! -e /bin/go
             test -x /usr/local/bin/cerebro-platform
             test -x /usr/local/bin/cerebro-event-admission-worker
           '

--- a/crates/cerebro-platform/examples/organizational_graph_e2e.rs
+++ b/crates/cerebro-platform/examples/organizational_graph_e2e.rs
@@ -337,8 +337,6 @@ async fn verify(config: &Config) -> Result<(), Box<dyn Error>> {
     );
     let product = product_neighborhood(config, &product_root).await?;
     require_product_neighborhood(&product, &product_root, "represents")?;
-    prove_rust_only_runtime()?;
-
     let replay = initial_events()?.remove(0);
     publish(&jetstream, replay).await?;
     wait_for_drain(&mut consumer).await?;
@@ -411,8 +409,8 @@ async fn verify(config: &Config) -> Result<(), Box<dyn Error>> {
                 ),
             ),
             passed(
-                "rust_only_runtime",
-                "replacement image contains the Rust platform and proof driver but no Go server or Go toolchain",
+                "rust_service_runtime",
+                "the Rust platform served the product graph contract through restart and recovery",
             ),
             passed(
                 "multi_hop_path",
@@ -1128,33 +1126,6 @@ fn require_product_neighborhood(
             "product neighborhood did not contain one {relation} identity edge: {body}"
         )
         .into());
-    }
-    Ok(())
-}
-
-fn prove_rust_only_runtime() -> Result<(), Box<dyn Error>> {
-    for forbidden in [
-        "/usr/local/bin/cerebro",
-        "/usr/local/go/bin/go",
-        "/usr/bin/go",
-        "/bin/go",
-    ] {
-        if Path::new(forbidden).exists() {
-            return Err(format!(
-                "replacement image contains forbidden Go runtime path {forbidden}"
-            )
-            .into());
-        }
-    }
-    for required in [
-        "/usr/local/bin/cerebro-platform",
-        "/usr/local/bin/organizational-graph-e2e",
-    ] {
-        if !Path::new(required).is_file() {
-            return Err(
-                format!("replacement image is missing required Rust binary {required}").into(),
-            );
-        }
     }
     Ok(())
 }

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -74,6 +74,9 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "file: Dockerfile.rust",
         "ghcr.io/${{ github.repository_owner }}/cerebro-rust",
         "Assert the candidate contains no Go server",
+        "test ! -e /usr/local/go/bin/go",
+        "test ! -e /usr/bin/go",
+        "test ! -e /bin/go",
         "Run the candidate through its declared Rust entrypoint",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
@@ -107,6 +110,10 @@ fn replacement_proof_is_a_native_rust_product_path() {
     for required in [
         "name: Rust-only persisted product read",
         "--target replacement-test-runtime",
+        "test ! -e /usr/local/bin/cerebro",
+        "test ! -e /usr/local/go/bin/go",
+        "test ! -e /usr/bin/go",
+        "test ! -e /bin/go",
         "--entrypoint /usr/local/bin/organizational-graph-e2e",
         "docker restart cerebro-rust-graph-platform",
         "receipt.json)\" -eq 14",
@@ -130,15 +137,28 @@ fn replacement_proof_is_a_native_rust_product_path() {
     }
     for required in [
         "product_http_contract",
-        "rust_only_runtime",
-        "/usr/local/bin/cerebro-platform",
-        "/usr/local/bin/organizational-graph-e2e",
-        "/usr/local/bin/cerebro",
+        "rust_service_runtime",
         "require_product_neighborhood",
     ] {
         assert!(
             REPLACEMENT_DRIVER.contains(required),
             "Rust replacement driver is missing runtime assertion {required:?}"
+        );
+    }
+}
+
+#[test]
+fn functional_recovery_driver_does_not_inspect_the_runner_runtime() {
+    for forbidden in [
+        "prove_rust_only_runtime",
+        "\"/usr/local/bin/cerebro\"",
+        "\"/usr/local/go/bin/go\"",
+        "\"/usr/bin/go\"",
+        "\"/bin/go\"",
+    ] {
+        assert!(
+            !REPLACEMENT_DRIVER.contains(forbidden),
+            "functional recovery driver inspects its execution host via {forbidden:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- keep functional restart and recovery checks independent of the machine that runs the proof driver
- inspect Rust-only runtime paths inside the candidate image
- retain separate Rust service and Rust-only image assertions
- add a regression test that rejects host filesystem checks in the functional driver

The release-candidate proof previously inspected absolute paths on the GitHub Actions runner. That made the result depend on runner contents instead of the candidate image.

## Validation

- `cargo +1.93.1 test --locked -p cerebro-platform --all-targets`
- `cargo +1.93.1 clippy --locked -p cerebro-platform --all-targets --all-features -- -D warnings`
- `cargo +1.93.1 fmt --all -- --check`
- `go test ./tools/archtests -run 'Rust|Packaging' -count=1`
- `actionlint .github/workflows/rust-graph-replacement.yml .github/workflows/rust-only-candidate.yml .github/workflows/cut-release.yml`
