### PR TITLE
sdk: add reusable Rust platform and cutover contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cerebro-platform-sdk"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cerebro-agent-context",
+ "cerebro-control-kernel",
+ "cerebro-organizational-model",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "cerebro-security-path-kernel"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cerebro-platform-engine"
+version = "0.1.0"
+dependencies = [
+ "cerebro-platform-sdk",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cerebro-platform-sdk"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/organizational-graph",
     "crates/organizational-model",
     "crates/organizational-store",
+    "crates/platform-engine",
     "crates/platform-sdk",
     "crates/source-catalog",
     "crates/security-path-kernel",
@@ -37,6 +38,7 @@ cerebro-control-kernel = { version = "0.1.0", path = "crates/control-kernel" }
 cerebro-organizational-graph = { version = "0.1.0", path = "crates/organizational-graph" }
 cerebro-organizational-model = { version = "0.1.0", path = "crates/organizational-model" }
 cerebro-organizational-store = { version = "0.1.0", path = "crates/organizational-store" }
+cerebro-platform-engine = { version = "0.1.0", path = "crates/platform-engine" }
 cerebro-platform-sdk = { version = "0.1.0", path = "crates/platform-sdk" }
 cerebro-source-catalog = { version = "0.1.0", path = "crates/source-catalog" }
 cerebro-source-runtime-next = { version = "0.1.0", path = "crates/source-runtime-next" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/organizational-graph",
     "crates/organizational-model",
     "crates/organizational-store",
+    "crates/platform-sdk",
     "crates/source-catalog",
     "crates/security-path-kernel",
     "crates/source-runtime-next",
@@ -32,9 +33,11 @@ async-trait = "0.1.91"
 buffa = { version = "=0.9.1", features = ["json"] }
 buffa-types = { version = "=0.9.1", features = ["json"] }
 cerebro-agent-context = { version = "0.1.0", path = "crates/agent-context" }
+cerebro-control-kernel = { version = "0.1.0", path = "crates/control-kernel" }
 cerebro-organizational-graph = { version = "0.1.0", path = "crates/organizational-graph" }
 cerebro-organizational-model = { version = "0.1.0", path = "crates/organizational-model" }
 cerebro-organizational-store = { version = "0.1.0", path = "crates/organizational-store" }
+cerebro-platform-sdk = { version = "0.1.0", path = "crates/platform-sdk" }
 cerebro-source-catalog = { version = "0.1.0", path = "crates/source-catalog" }
 cerebro-source-runtime-next = { version = "0.1.0", path = "crates/source-runtime-next" }
 cerebro-wasm-guest = { version = "0.1.0", path = "internal/wasmguest" }

--- a/Makefile
+++ b/Makefile
@@ -527,6 +527,11 @@ rust-coverage: ## Enforce the Rust workspace line-coverage floor with the pinned
 	# and process entrypoints are exercised by live integration tests.
 	$(CARGO) llvm-cov --workspace --all-features --locked --ignore-filename-regex '(^|/)(wasm_abi\.rs|crates/cerebro-platform/src/(generated/.*|main|append_log_consumer|cutover_command|parity_command)\.rs|crates/organizational-store/src/(lib|neo4j|postgres)\.rs|crates/source-runtime-next/src/http\.rs)$$' --fail-under-lines 90 --summary-only
 
+rust-platform-engine-coverage: ## Enforce focused coverage for reusable platform engines.
+	@actual="$$($(CARGO) llvm-cov --version 2>/dev/null || true)"; \
+		test "$$actual" = "cargo-llvm-cov 0.8.7" || { echo "rust-platform-engine-coverage: install cargo-llvm-cov 0.8.7 with 'cargo install cargo-llvm-cov --version 0.8.7 --locked'"; exit 1; }
+	$(CARGO) llvm-cov -p cerebro-platform-engine --all-features --locked --fail-under-lines 90 --summary-only
+
 rust-benchmark-smoke: ## Run bounded embedded Wasm host benchmarks and record their output.
 	@mkdir -p tmp
 	@go test ./internal/wasmhost ./internal/graphagent ./internal/sourcecoverage ./internal/mitre ./internal/sourceprojection ./internal/sourceruntime/eventadmission -run '^$$' -bench '^(BenchmarkRuntimeRun|BenchmarkStaticValidator|BenchmarkCoverageEvaluator|BenchmarkContextEvaluator|BenchmarkPanopticonResourceExtractor|BenchmarkAdmissionSmoke)$$' -benchtime=20x -count=1 > tmp/rust-wasm-benchmark.txt 2>&1; status=$$?; cat tmp/rust-wasm-benchmark.txt; exit $$status
@@ -542,6 +547,10 @@ rust-organizational-platform-benchmark: ## Compare the Go and Rust organizationa
 	@mkdir -p tmp
 	@GOMAXPROCS=1 go test ./internal/graphrebuild ./internal/sourceruntime -run '^TestOrganizationalPlatform.*BenchmarkCorpus$$' -bench '^BenchmarkOrganizationalPlatformGo' -benchmem -benchtime=$(ORGANIZATIONAL_BENCH_SAMPLE_MS)ms -count=$(ORGANIZATIONAL_BENCH_SAMPLES) -cpu=1 > tmp/organizational-platform-go-benchmark.txt 2>&1; status=$$?; cat tmp/organizational-platform-go-benchmark.txt; test $$status -eq 0
 	@ORGANIZATIONAL_BENCH_SAMPLE_MS=$(ORGANIZATIONAL_BENCH_SAMPLE_MS) ORGANIZATIONAL_BENCH_SAMPLES=$(ORGANIZATIONAL_BENCH_SAMPLES) $(CARGO) bench --locked -p cerebro-source-runtime-next --bench organizational_platform > tmp/organizational-platform-rust-benchmark.txt 2>&1; status=$$?; cat tmp/organizational-platform-rust-benchmark.txt; exit $$status
+
+rust-platform-engine-benchmark: ## Measure reusable platform diff, assertion, and simulation engines.
+	@mkdir -p tmp
+	@$(CARGO) bench --locked -p cerebro-platform-engine --bench platform_engine > tmp/rust-platform-engine-benchmark.txt 2>&1; status=$$?; cat tmp/rust-platform-engine-benchmark.txt; exit $$status
 
 rust-organizational-store-benchmark: ## Measure durable commits, recovery, traversal, and tenant concurrency against disposable stores.
 	@test -n "$(CEREBRO_TEST_POSTGRES_DSN)" || { echo "CEREBRO_TEST_POSTGRES_DSN is required" >&2; exit 2; }

--- a/crates/cerebro-platform/src/cutover_command.rs
+++ b/crates/cerebro-platform/src/cutover_command.rs
@@ -7,27 +7,52 @@ use cerebro_organizational_store::{CutoverPolicy, PostgresLedger, ProjectionProm
 
 use crate::{load_catalog, required_env};
 
-pub(crate) async fn promote_family() -> Result<(), Box<dyn Error>> {
+fn promotion_request(
+    tenant_id: String,
+    source_id: String,
+    family_id: String,
+    promoted_at_unix_ms: i64,
+) -> Result<ProjectionPromotionRequest, Box<dyn Error>> {
+    Ok(ProjectionPromotionRequest::new(
+        tenant_id,
+        source_id,
+        family_id,
+        CutoverPolicy::new(3, 0)?,
+        0,
+        promoted_at_unix_ms,
+    )?)
+}
+
+async fn ledger_and_request() -> Result<(PostgresLedger, ProjectionPromotionRequest), Box<dyn Error>>
+{
     let tenant_id = required_env("CEREBRO_TENANT_ID")?;
     let source_id = required_env("CEREBRO_SOURCE_ID")?;
     let family_id = required_env("CEREBRO_SOURCE_FAMILY")?;
     let connection_string = required_env("CEREBRO_POSTGRES_DSN")?;
     let ledger = PostgresLedger::connect_tls(&connection_string).await?;
     ledger.migrate().await?;
-    let promoted_at_unix_ms =
+    let evaluated_at_unix_ms =
         i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())?;
+    Ok((
+        ledger,
+        promotion_request(tenant_id, source_id, family_id, evaluated_at_unix_ms)?,
+    ))
+}
+
+pub(crate) async fn evaluate_family() -> Result<(), Box<dyn Error>> {
+    let (ledger, request) = ledger_and_request().await?;
+    let decision = ledger
+        .evaluate_projection_authority(&load_catalog()?, &request)
+        .await?;
+    serde_json::to_writer(std::io::stdout(), &decision)?;
+    println!();
+    Ok(())
+}
+
+pub(crate) async fn promote_family() -> Result<(), Box<dyn Error>> {
+    let (ledger, request) = ledger_and_request().await?;
     let authority = ledger
-        .evaluate_and_promote_projection_authority(
-            &load_catalog()?,
-            &ProjectionPromotionRequest::new(
-                tenant_id,
-                source_id,
-                family_id,
-                CutoverPolicy::new(3, 0)?,
-                0,
-                promoted_at_unix_ms,
-            )?,
-        )
+        .evaluate_and_promote_projection_authority(&load_catalog()?, &request)
         .await?;
     serde_json::to_writer(std::io::stdout(), &authority)?;
     println!();
@@ -47,4 +72,24 @@ pub(crate) async fn show_authority() -> Result<(), Box<dyn Error>> {
     serde_json::to_writer(std::io::stdout(), &authority)?;
     println!();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn promotion_request_keeps_the_production_gate_strict() {
+        let request = promotion_request(
+            "tenant-a".to_owned(),
+            "box".to_owned(),
+            "users".to_owned(),
+            1,
+        )
+        .unwrap();
+        assert_eq!(request.tenant_id(), "tenant-a");
+        assert_eq!(request.source_id(), "box");
+        assert_eq!(request.family_id(), "users");
+        assert_eq!(request.projection_lag(), 0);
+    }
 }

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -5,14 +5,14 @@ mod cutover_command;
 mod parity_command;
 mod rpc;
 
-use std::{collections::BTreeMap, env, error::Error, path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, env, error::Error, path::PathBuf, sync::Arc, time::Instant};
 
 use axum::{
     Extension, Json, Router,
     extract::{Path, Query, Request, State},
     http::{StatusCode, header::AUTHORIZATION},
     middleware::{self, Next},
-    response::Response,
+    response::{IntoResponse, Response},
     routing::{get, post},
 };
 use cerebro_agent_context::{
@@ -49,7 +49,21 @@ struct AppState {
     graph: Arc<dyn AgentGraph>,
     catalog_summary: Option<CatalogSummary>,
     projection: Option<Arc<ProjectionRuntime>>,
+    metrics: PlatformMetrics,
 }
+
+#[derive(Clone, Default)]
+struct PlatformMetrics(Arc<Mutex<BTreeMap<&'static str, RequestSeries>>>);
+
+#[derive(Default)]
+struct RequestSeries {
+    successes: u64,
+    failures: u64,
+    duration_sum_seconds: f64,
+    duration_buckets: [u64; 8],
+}
+
+const LATENCY_BUCKETS_SECONDS: [f64; 8] = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0];
 
 #[derive(Clone)]
 struct TenantRequestAuth {
@@ -137,6 +151,98 @@ async fn authenticate_tenant(
     };
     request.extensions_mut().insert(AuthenticatedTenant(tenant));
     Ok(next.run(request).await)
+}
+
+async fn record_request(
+    State(metrics): State<PlatformMetrics>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let operation = bounded_operation(request.uri().path());
+    let started = Instant::now();
+    let response = next.run(request).await;
+    metrics
+        .record(
+            operation,
+            response.status(),
+            started.elapsed().as_secs_f64(),
+        )
+        .await;
+    response
+}
+
+fn bounded_operation(path: &str) -> &'static str {
+    match path {
+        "/healthz" => "healthz",
+        "/readyz" => "readyz",
+        "/metrics" => "metrics",
+        "/v1/sources/summary" => "source_summary",
+        "/platform/graph/neighborhood" => "neighborhood",
+        "/v1/graph/search" => "search",
+        "/v1/graph/expand" => "expand",
+        "/v1/graph/expand-batch" => "expand_batch",
+        "/v1/graph/paths" => "paths",
+        "/v1/projections/events" => "project_event",
+        "/v1/projections/authority" => "projection_authority",
+        _ if path.starts_with("/v1/entities/") => "get_entity",
+        _ if path.starts_with("/v1/assertions/") => "explain_assertion",
+        _ if path.starts_with("/cerebro.graph.v1.OrganizationalGraphService/") => "connect_rpc",
+        _ => "other",
+    }
+}
+
+impl PlatformMetrics {
+    async fn record(&self, operation: &'static str, status: StatusCode, elapsed_seconds: f64) {
+        let mut metrics = self.0.lock().await;
+        let series = metrics.entry(operation).or_default();
+        if status.is_success() {
+            series.successes += 1;
+        } else {
+            series.failures += 1;
+        }
+        series.duration_sum_seconds += elapsed_seconds;
+        for (index, upper_bound) in LATENCY_BUCKETS_SECONDS.iter().enumerate() {
+            if elapsed_seconds <= *upper_bound {
+                series.duration_buckets[index] += 1;
+            }
+        }
+    }
+
+    async fn render(&self) -> String {
+        let metrics = self.0.lock().await;
+        let mut output = String::from(
+            "# HELP cerebro_rust_http_requests_total Bounded Rust platform HTTP requests.\n\
+             # TYPE cerebro_rust_http_requests_total counter\n\
+             # HELP cerebro_rust_http_request_duration_seconds Rust platform request latency.\n\
+             # TYPE cerebro_rust_http_request_duration_seconds histogram\n",
+        );
+        for (operation, series) in metrics.iter() {
+            output.push_str(&format!(
+                "cerebro_rust_http_requests_total{{operation=\"{operation}\",status_class=\"success\"}} {}\n",
+                series.successes
+            ));
+            output.push_str(&format!(
+                "cerebro_rust_http_requests_total{{operation=\"{operation}\",status_class=\"failure\"}} {}\n",
+                series.failures
+            ));
+            for (upper_bound, count) in LATENCY_BUCKETS_SECONDS
+                .iter()
+                .zip(series.duration_buckets.iter())
+            {
+                output.push_str(&format!(
+                    "cerebro_rust_http_request_duration_seconds_bucket{{operation=\"{operation}\",le=\"{upper_bound}\"}} {count}\n"
+                ));
+            }
+            let count = series.successes + series.failures;
+            output.push_str(&format!(
+                "cerebro_rust_http_request_duration_seconds_bucket{{operation=\"{operation}\",le=\"+Inf\"}} {count}\n\
+                 cerebro_rust_http_request_duration_seconds_sum{{operation=\"{operation}\"}} {}\n\
+                 cerebro_rust_http_request_duration_seconds_count{{operation=\"{operation}\"}} {count}\n",
+                series.duration_sum_seconds
+            ));
+        }
+        output
+    }
 }
 
 struct ProjectionRuntime {
@@ -393,6 +499,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         None | Some("demo") => demo().await,
         Some("serve") => serve_memory(OrganizationalGraph::new()).await,
         Some("serve-demo") => serve_memory(demo_graph()?.0).await,
+        Some("serve-neo4j-readonly") => serve_neo4j_readonly().await,
         Some("serve-neo4j") => serve_neo4j().await,
         Some("serve-neo4j-consumer") => serve_neo4j_consumer().await,
         Some("consume-append-log") => consume_append_log().await,
@@ -400,11 +507,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some("sync-source") => sync_source().await,
         Some("catalog-summary") => catalog_summary(),
         Some("compare-projection") => parity_command::compare_projection().await,
+        Some("evaluate-family") => cutover_command::evaluate_family().await,
         Some("promote-family") => cutover_command::promote_family().await,
         Some("show-authority") => cutover_command::show_authority().await,
         Some("--help" | "-h") => {
             println!(
-                "cerebro-platform <demo|serve|serve-demo|serve-neo4j|serve-neo4j-consumer|consume-append-log|migrate-stores|sync-source|catalog-summary|compare-projection|promote-family|show-authority>"
+                "cerebro-platform <demo|serve|serve-demo|serve-neo4j-readonly|serve-neo4j|serve-neo4j-consumer|consume-append-log|migrate-stores|sync-source|catalog-summary|compare-projection|evaluate-family|promote-family|show-authority>"
             );
             Ok(())
         }
@@ -414,6 +522,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 async fn serve_memory(graph: OrganizationalGraph) -> Result<(), Box<dyn Error>> {
     serve(Arc::new(MemoryAgentGraph::new(graph)), None).await
+}
+
+async fn serve_neo4j_readonly() -> Result<(), Box<dyn Error>> {
+    let graph = Neo4jProjector::connect(
+        &required_env("CEREBRO_NEO4J_URI")?,
+        &required_env("CEREBRO_NEO4J_USERNAME")?,
+        &required_env("CEREBRO_NEO4J_PASSWORD")?,
+    )
+    .await?;
+    serve(Arc::new(graph), None).await
 }
 
 async fn serve_neo4j() -> Result<(), Box<dyn Error>> {
@@ -569,6 +687,7 @@ fn router_with_backend(
     projection: Option<Arc<ProjectionRuntime>>,
     tenant_auth: TenantRequestAuth,
 ) -> Router {
+    let platform_metrics = PlatformMetrics::default();
     let connect = rpc::router(graph.clone(), catalog_summary.clone(), tenant_auth.clone());
     let protected = Router::new()
         .route(
@@ -590,6 +709,7 @@ fn router_with_backend(
     Router::new()
         .route("/healthz", get(health))
         .route("/readyz", get(readiness))
+        .route("/metrics", get(metrics))
         .route("/v1/sources/summary", get(source_summary))
         .merge(protected)
         .fallback_service(connect.into_axum_service())
@@ -597,7 +717,22 @@ fn router_with_backend(
             graph,
             catalog_summary,
             projection,
+            metrics: platform_metrics.clone(),
         })
+        .layer(middleware::from_fn_with_state(
+            platform_metrics,
+            record_request,
+        ))
+}
+
+async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        state.metrics.render().await,
+    )
 }
 
 async fn projection_authority(
@@ -1837,6 +1972,30 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(readiness.status(), StatusCode::OK);
+
+        let metrics = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(metrics.status(), StatusCode::OK);
+        let metrics = axum::body::to_bytes(metrics.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        let metrics = String::from_utf8(metrics.to_vec()).unwrap();
+        assert!(metrics.contains(
+            "cerebro_rust_http_requests_total{operation=\"healthz\",status_class=\"success\"} 1"
+        ));
+        assert!(
+            metrics.contains(
+                "cerebro_rust_http_request_duration_seconds_count{operation=\"readyz\"} 1"
+            )
+        );
 
         let request = serde_json::json!({
             "tenant_id": "tenant-demo",

--- a/crates/organizational-store/src/cutover.rs
+++ b/crates/organizational-store/src/cutover.rs
@@ -62,15 +62,15 @@ impl ProjectionPromotionRequest {
         })
     }
 
-    pub(crate) fn tenant_id(&self) -> &str {
+    pub fn tenant_id(&self) -> &str {
         &self.tenant_id
     }
 
-    pub(crate) fn source_id(&self) -> &str {
+    pub fn source_id(&self) -> &str {
         &self.source_id
     }
 
-    pub(crate) fn family_id(&self) -> &str {
+    pub fn family_id(&self) -> &str {
         &self.family_id
     }
 
@@ -78,7 +78,7 @@ impl ProjectionPromotionRequest {
         self.policy
     }
 
-    pub(crate) fn projection_lag(&self) -> u64 {
+    pub fn projection_lag(&self) -> u64 {
         self.projection_lag
     }
 

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -559,6 +559,22 @@ impl PostgresLedger {
         catalog: &SourceCatalog,
         request: &ProjectionPromotionRequest,
     ) -> Result<ProjectionAuthorityRecord, StoreError> {
+        let decision = self.evaluate_projection_authority(catalog, request).await?;
+        self.promote_projection_authority(
+            request.tenant_id(),
+            &decision,
+            request.promoted_at_unix_ms(),
+        )
+        .await
+    }
+
+    /// Evaluate the durable cutover evidence without changing projection
+    /// authority. Operators use this before the irreversible promotion step.
+    pub async fn evaluate_projection_authority(
+        &self,
+        catalog: &SourceCatalog,
+        request: &ProjectionPromotionRequest,
+    ) -> Result<CutoverDecision, StoreError> {
         let receipts = self
             .parity_receipts(
                 request.tenant_id(),
@@ -575,12 +591,7 @@ impl PostgresLedger {
                 request.projection_lag(),
             )
             .map_err(|error| StoreError::Conflict(error.to_string()))?;
-        self.promote_projection_authority(
-            request.tenant_id(),
-            &decision,
-            request.promoted_at_unix_ms(),
-        )
-        .await
+        Ok(decision)
     }
 
     async fn promote_projection_authority(

--- a/crates/organizational-store/tests/live_cutover.rs
+++ b/crates/organizational-store/tests/live_cutover.rs
@@ -47,18 +47,28 @@ async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible(
         root.join("internal/connectorcatalog/catalog"),
         root.join("sources"),
     )?;
+    let request = ProjectionPromotionRequest::new(
+        tenant_id.clone(),
+        "box",
+        "users",
+        CutoverPolicy::new(3, 0)?,
+        0,
+        100,
+    )?;
+    let decision = ledger
+        .evaluate_projection_authority(&catalog, &request)
+        .await?;
+    assert!(decision.is_allowed());
+    assert_eq!(
+        ledger
+            .projection_authority(&tenant_id, "box", "users")
+            .await?
+            .authority,
+        ProjectionAuthority::Legacy,
+        "evaluation must not change authority"
+    );
     let authority = ledger
-        .evaluate_and_promote_projection_authority(
-            &catalog,
-            &ProjectionPromotionRequest::new(
-                tenant_id.clone(),
-                "box",
-                "users",
-                CutoverPolicy::new(3, 0)?,
-                0,
-                100,
-            )?,
-        )
+        .evaluate_and_promote_projection_authority(&catalog, &request)
         .await?;
     assert_eq!(authority.authority, ProjectionAuthority::Rust);
     assert_eq!(

--- a/crates/platform-engine/Cargo.toml
+++ b/crates/platform-engine/Cargo.toml
@@ -11,5 +11,9 @@ cerebro-platform-sdk.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
+[[bench]]
+name = "platform_engine"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/platform-engine/Cargo.toml
+++ b/crates/platform-engine/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cerebro-platform-engine"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+cerebro-platform-sdk.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/platform-engine/benches/platform_engine.rs
+++ b/crates/platform-engine/benches/platform_engine.rs
@@ -1,0 +1,194 @@
+use std::collections::BTreeSet;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use cerebro_platform_engine::{
+    RevisionSnapshot, SimulationRelationship, SimulationTopology, SnapshotKey, SnapshotValue,
+    assertion_definition_digest, compile_assertion, diff_snapshots, evaluate_assertion,
+    simulate_topology,
+};
+use cerebro_platform_sdk::{
+    AssertionCondition, AssertionDefinition, AssertionDefinitionId, ContentDigest, EntityId,
+    EvaluationTrigger, EvidenceQuality, FactQuery, GraphDiffRequest, GraphRevision, ProposedChange,
+    QueryNode, QueryResult, RelationKind, RevisionSelector, SimulationId, SimulationRequest,
+    TenantId,
+};
+
+fn main() {
+    let (request, before, after) = diff_fixture();
+    report("diff_500_changes", 200, || {
+        black_box(diff_snapshots(&request, &before, &after).expect("benchmark diff"));
+    });
+
+    let (compiled, query_result, quality) = assertion_fixture();
+    report("evaluate_assertion", 10_000, || {
+        black_box(
+            evaluate_assertion(&compiled, &query_result, &quality, 10)
+                .expect("benchmark assertion"),
+        );
+    });
+
+    let (simulation_request, topology) = simulation_fixture();
+    report("simulate_100_relationship_removals", 200, || {
+        black_box(
+            simulate_topology(&simulation_request, &topology, Vec::new())
+                .expect("benchmark simulation"),
+        );
+    });
+}
+
+fn report(name: &str, iterations: u32, operation: impl Fn()) {
+    for _ in 0..10 {
+        operation();
+    }
+    let started = Instant::now();
+    for _ in 0..iterations {
+        operation();
+    }
+    let elapsed = started.elapsed() / iterations;
+    println!("{name}: {} ns/op", nanos(elapsed));
+}
+
+fn nanos(duration: Duration) -> u128 {
+    duration.as_nanos()
+}
+
+fn tenant() -> TenantId {
+    TenantId::parse("tenant-a").expect("valid tenant")
+}
+
+fn revision(value: u64) -> GraphRevision {
+    GraphRevision::new(value).expect("valid revision")
+}
+
+fn digest(value: impl AsRef<[u8]>) -> ContentDigest {
+    ContentDigest::of_bytes(value)
+}
+
+fn diff_fixture() -> (GraphDiffRequest, RevisionSnapshot, RevisionSnapshot) {
+    let before_values = (0..500)
+        .map(|index| {
+            (
+                SnapshotKey::Entity(
+                    EntityId::parse(format!("repository:{index:03}")).expect("valid entity"),
+                ),
+                SnapshotValue {
+                    digest: digest(format!("before-{index}")),
+                    observed_at_unix_millis: 1,
+                },
+            )
+        })
+        .collect();
+    let after_values = (0..500)
+        .map(|index| {
+            (
+                SnapshotKey::Entity(
+                    EntityId::parse(format!("repository:{index:03}")).expect("valid entity"),
+                ),
+                SnapshotValue {
+                    digest: digest(format!("after-{index}")),
+                    observed_at_unix_millis: 2,
+                },
+            )
+        })
+        .collect();
+    (
+        GraphDiffRequest {
+            tenant_id: tenant(),
+            from_revision: revision(1),
+            to_revision: RevisionSelector::Exact(revision(2)),
+            limit: 500,
+            cursor: None,
+        },
+        RevisionSnapshot {
+            tenant_id: tenant(),
+            revision: revision(1),
+            values: before_values,
+        },
+        RevisionSnapshot {
+            tenant_id: tenant(),
+            revision: revision(2),
+            values: after_values,
+        },
+    )
+}
+
+fn assertion_fixture() -> (
+    cerebro_platform_engine::CompiledAssertion,
+    QueryResult,
+    EvidenceQuality,
+) {
+    let query = FactQuery::new(
+        vec![QueryNode {
+            variable: "repository".to_owned(),
+            kinds: vec!["repository".to_owned()],
+            keys: vec!["repository:one".to_owned()],
+        }],
+        Vec::new(),
+        Vec::new(),
+        10,
+    )
+    .expect("valid query");
+    let mut definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:one")
+            .expect("valid assertion"),
+        tenant_id: tenant(),
+        name: "Repository exists".to_owned(),
+        query,
+        condition: AssertionCondition::AtLeastOneMatch,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("placeholder"),
+    };
+    definition.definition_digest =
+        assertion_definition_digest(&definition).expect("definition digest");
+    (
+        compile_assertion(definition).expect("compiled assertion"),
+        QueryResult {
+            tenant_id: tenant(),
+            graph_revision: 2,
+            matches: Vec::new(),
+            truncated: false,
+        },
+        EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("valid quality"),
+    )
+}
+
+fn simulation_fixture() -> (SimulationRequest, SimulationTopology) {
+    let entities = (0..101)
+        .map(|index| EntityId::parse(format!("repository:{index:03}")).expect("valid entity"))
+        .collect::<BTreeSet<_>>();
+    let relationships = (0..100)
+        .map(|index| SimulationRelationship {
+            from_entity_id: EntityId::parse(format!("repository:{index:03}"))
+                .expect("valid entity"),
+            relation: RelationKind::DependsOn,
+            to_entity_id: EntityId::parse(format!("repository:{:03}", index + 1))
+                .expect("valid entity"),
+        })
+        .collect::<BTreeSet<_>>();
+    let changes = relationships
+        .iter()
+        .map(|relationship| ProposedChange::RemoveRelationship {
+            from_entity_id: relationship.from_entity_id.clone(),
+            relation: relationship.relation,
+            to_entity_id: relationship.to_entity_id.clone(),
+        })
+        .collect();
+    (
+        SimulationRequest {
+            simulation_id: SimulationId::parse("simulation:benchmark").expect("valid simulation"),
+            tenant_id: tenant(),
+            base_revision: revision(1),
+            changes,
+            assertions: Vec::new(),
+            max_affected_entities: 101,
+        },
+        SimulationTopology {
+            tenant_id: tenant(),
+            entities,
+            relationships,
+        },
+    )
+}

--- a/crates/platform-engine/src/action.rs
+++ b/crates/platform-engine/src/action.rs
@@ -29,6 +29,22 @@ pub fn transition_action(
     expected_version: u64,
     command: ActionCommand,
 ) -> Result<ActionOperation, SdkError> {
+    operation.proposal.validate()?;
+    if operation.version == 0 {
+        return Err(SdkError::OutOfRange("action operation version"));
+    }
+    if matches!(
+        operation.state,
+        ActionState::Claimed
+            | ActionState::Executing
+            | ActionState::OutcomeUnknown
+            | ActionState::Completed
+            | ActionState::Reconciled
+            | ActionState::Verified
+    ) && operation.claimed_by.is_none()
+    {
+        return Err(SdkError::Invalid("action operation claimant"));
+    }
     if operation.version != expected_version {
         return Err(SdkError::Conflict(
             "stale action operation version".to_owned(),

--- a/crates/platform-engine/src/action.rs
+++ b/crates/platform-engine/src/action.rs
@@ -1,0 +1,117 @@
+use cerebro_platform_sdk::{
+    ActionOperation, ActionState, ContentDigest, OpaqueId, SdkError, VerificationState,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ActionCommand {
+    RecordSimulation,
+    RequestApproval,
+    Claim {
+        worker_id: OpaqueId,
+    },
+    StartExecution,
+    MarkOutcomeUnknown,
+    Complete {
+        external_receipt_ref: OpaqueId,
+        observed_effect_digest: ContentDigest,
+    },
+    Reconcile {
+        observed_effect_digest: ContentDigest,
+    },
+    Verify,
+    RejectVerification,
+    Fail,
+    RollBack,
+}
+
+pub fn transition_action(
+    operation: &ActionOperation,
+    expected_version: u64,
+    command: ActionCommand,
+) -> Result<ActionOperation, SdkError> {
+    if operation.version != expected_version {
+        return Err(SdkError::Conflict(
+            "stale action operation version".to_owned(),
+        ));
+    }
+    let mut next = operation.clone();
+    match (&operation.state, command) {
+        (ActionState::Proposed, ActionCommand::RecordSimulation) => {
+            next.state = ActionState::Simulated;
+        }
+        (ActionState::Simulated, ActionCommand::RequestApproval) => {
+            next.state = ActionState::WaitingForApproval;
+        }
+        (ActionState::WaitingForApproval, ActionCommand::Claim { worker_id }) => {
+            next.state = ActionState::Claimed;
+            next.claimed_by = Some(worker_id);
+        }
+        (ActionState::Claimed, ActionCommand::StartExecution) => {
+            next.state = ActionState::Executing;
+        }
+        (ActionState::Executing, ActionCommand::MarkOutcomeUnknown) => {
+            next.state = ActionState::OutcomeUnknown;
+        }
+        (
+            ActionState::Executing,
+            ActionCommand::Complete {
+                external_receipt_ref,
+                observed_effect_digest,
+            },
+        ) => {
+            next.state = ActionState::Completed;
+            next.external_receipt_ref = Some(external_receipt_ref);
+            next.observed_effect_digest = Some(observed_effect_digest);
+        }
+        (
+            ActionState::OutcomeUnknown,
+            ActionCommand::Reconcile {
+                observed_effect_digest,
+            },
+        ) => {
+            next.state = ActionState::Reconciled;
+            next.observed_effect_digest = Some(observed_effect_digest);
+        }
+        (ActionState::Completed | ActionState::Reconciled, ActionCommand::Verify) => {
+            next.state = ActionState::Verified;
+            next.verification_state = VerificationState::Verified;
+        }
+        (ActionState::Completed | ActionState::Reconciled, ActionCommand::RejectVerification) => {
+            next.state = ActionState::Failed;
+            next.verification_state = VerificationState::Rejected;
+        }
+        (
+            ActionState::Proposed
+            | ActionState::Simulated
+            | ActionState::WaitingForApproval
+            | ActionState::Claimed
+            | ActionState::Executing
+            | ActionState::OutcomeUnknown
+            | ActionState::Completed
+            | ActionState::Reconciled,
+            ActionCommand::Fail,
+        ) => {
+            next.state = ActionState::Failed;
+        }
+        (
+            ActionState::Completed
+            | ActionState::Reconciled
+            | ActionState::Verified
+            | ActionState::Failed,
+            ActionCommand::RollBack,
+        ) => {
+            next.state = ActionState::RolledBack;
+            next.verification_state = VerificationState::Stale;
+        }
+        _ => {
+            return Err(SdkError::Conflict(
+                "invalid action state transition".to_owned(),
+            ));
+        }
+    }
+    next.version = next
+        .version
+        .checked_add(1)
+        .ok_or(SdkError::OutOfRange("action operation version"))?;
+    Ok(next)
+}

--- a/crates/platform-engine/src/assertion.rs
+++ b/crates/platform-engine/src/assertion.rs
@@ -1,0 +1,92 @@
+use cerebro_platform_sdk::{
+    AssertionCondition, AssertionDefinition, AssertionEvaluation, AssertionState, ContentDigest,
+    EvidenceQuality, FactQuery, GraphRevision, QueryResult, SdkError, TenantId,
+};
+use serde::Serialize;
+
+use crate::canonical;
+
+#[derive(Serialize)]
+struct AssertionMaterial<'a> {
+    tenant_id: &'a TenantId,
+    name: &'a str,
+    query: &'a FactQuery,
+    condition: AssertionCondition,
+    triggers: &'a [cerebro_platform_sdk::EvaluationTrigger],
+    evidence_max_age_seconds: u64,
+    enabled: bool,
+}
+
+pub fn assertion_definition_digest(
+    definition: &AssertionDefinition,
+) -> Result<ContentDigest, SdkError> {
+    canonical::digest(&AssertionMaterial {
+        tenant_id: &definition.tenant_id,
+        name: &definition.name,
+        query: &definition.query,
+        condition: definition.condition,
+        triggers: &definition.triggers,
+        evidence_max_age_seconds: definition.evidence_max_age_seconds,
+        enabled: definition.enabled,
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompiledAssertion {
+    definition: AssertionDefinition,
+}
+
+impl CompiledAssertion {
+    pub fn definition(&self) -> &AssertionDefinition {
+        &self.definition
+    }
+}
+
+pub fn compile_assertion(definition: AssertionDefinition) -> Result<CompiledAssertion, SdkError> {
+    definition.validate()?;
+    if assertion_definition_digest(&definition)? != definition.definition_digest {
+        return Err(SdkError::Invalid("assertion definition digest"));
+    }
+    Ok(CompiledAssertion { definition })
+}
+
+pub fn evaluate_assertion(
+    compiled: &CompiledAssertion,
+    result: &QueryResult,
+    quality: &EvidenceQuality,
+    evaluated_at_unix_millis: i64,
+) -> Result<AssertionEvaluation, SdkError> {
+    let definition = compiled.definition();
+    if result.tenant_id != definition.tenant_id {
+        return Err(SdkError::Invalid("assertion query tenant"));
+    }
+    let graph_revision = GraphRevision::new(result.graph_revision)?;
+    if result.matches.len() > definition.query.limit() {
+        return Err(SdkError::OutOfRange("assertion query matches"));
+    }
+    let matching_paths = u32::try_from(result.matches.len())
+        .map_err(|_| SdkError::OutOfRange("assertion query matches"))?;
+    let (state, reason_codes) = if !definition.enabled {
+        (AssertionState::Indeterminate, vec!["assertion_disabled"])
+    } else if result.truncated {
+        (AssertionState::Indeterminate, vec!["query_truncated"])
+    } else if quality.conflicting {
+        (AssertionState::Indeterminate, vec!["evidence_conflicting"])
+    } else if quality.minimum_score() == 0 {
+        (AssertionState::Indeterminate, vec!["evidence_incomplete"])
+    } else if definition.condition.evaluate(matching_paths) {
+        (AssertionState::Satisfied, Vec::new())
+    } else {
+        (AssertionState::Violated, vec!["condition_not_met"])
+    };
+    let evidence_digest = canonical::digest(&(result, quality))?;
+    Ok(AssertionEvaluation {
+        assertion_id: definition.assertion_id.clone(),
+        graph_revision,
+        state,
+        evaluated_at_unix_millis,
+        matching_paths,
+        reason_codes: reason_codes.into_iter().map(str::to_owned).collect(),
+        evidence_digest,
+    })
+}

--- a/crates/platform-engine/src/assertion.rs
+++ b/crates/platform-engine/src/assertion.rs
@@ -8,6 +8,7 @@ use crate::canonical;
 
 #[derive(Serialize)]
 struct AssertionMaterial<'a> {
+    assertion_id: &'a cerebro_platform_sdk::AssertionDefinitionId,
     tenant_id: &'a TenantId,
     name: &'a str,
     query: &'a FactQuery,
@@ -21,6 +22,7 @@ pub fn assertion_definition_digest(
     definition: &AssertionDefinition,
 ) -> Result<ContentDigest, SdkError> {
     canonical::digest(&AssertionMaterial {
+        assertion_id: &definition.assertion_id,
         tenant_id: &definition.tenant_id,
         name: &definition.name,
         query: &definition.query,

--- a/crates/platform-engine/src/canonical.rs
+++ b/crates/platform-engine/src/canonical.rs
@@ -1,0 +1,8 @@
+use cerebro_platform_sdk::{ContentDigest, SdkError};
+use serde::Serialize;
+
+pub(crate) fn digest<T: Serialize>(value: &T) -> Result<ContentDigest, SdkError> {
+    serde_json::to_vec(value)
+        .map(ContentDigest::of_bytes)
+        .map_err(|error| SdkError::Backend(format!("canonical serialization failed: {error}")))
+}

--- a/crates/platform-engine/src/incident.rs
+++ b/crates/platform-engine/src/incident.rs
@@ -1,0 +1,55 @@
+use cerebro_platform_sdk::{
+    ContentDigest, GraphRevision, IncidentSnapshot, IncidentSnapshotId, IncidentSnapshotManifest,
+    OpaqueId, SdkError, TenantId,
+};
+use serde::Serialize;
+
+use crate::canonical;
+
+#[derive(Serialize)]
+struct ManifestMaterial<'a> {
+    snapshot_id: &'a IncidentSnapshotId,
+    tenant_id: &'a TenantId,
+    graph_revision: GraphRevision,
+    created_at_unix_millis: i64,
+    entity_ids: &'a [cerebro_platform_sdk::EntityId],
+    source_receipt_digests: &'a [ContentDigest],
+    policy_digests: &'a [ContentDigest],
+    mission_ids: &'a [OpaqueId],
+    verification_receipt_digests: &'a [ContentDigest],
+}
+
+pub fn incident_manifest_digest(
+    manifest: &IncidentSnapshotManifest,
+) -> Result<ContentDigest, SdkError> {
+    canonical::digest(&ManifestMaterial {
+        snapshot_id: &manifest.snapshot_id,
+        tenant_id: &manifest.tenant_id,
+        graph_revision: manifest.graph_revision,
+        created_at_unix_millis: manifest.created_at_unix_millis,
+        entity_ids: &manifest.entity_ids,
+        source_receipt_digests: &manifest.source_receipt_digests,
+        policy_digests: &manifest.policy_digests,
+        mission_ids: &manifest.mission_ids,
+        verification_receipt_digests: &manifest.verification_receipt_digests,
+    })
+}
+
+pub fn package_incident_snapshot(
+    manifest: IncidentSnapshotManifest,
+    canonical_payload: Vec<u8>,
+    signature: Vec<u8>,
+) -> Result<IncidentSnapshot, SdkError> {
+    manifest.validate()?;
+    if incident_manifest_digest(&manifest)? != manifest.manifest_digest {
+        return Err(SdkError::Invalid("incident snapshot manifest digest"));
+    }
+    let snapshot = IncidentSnapshot {
+        payload_digest: ContentDigest::of_bytes(&canonical_payload),
+        manifest,
+        canonical_payload,
+        signature,
+    };
+    snapshot.validate()?;
+    Ok(snapshot)
+}

--- a/crates/platform-engine/src/lib.rs
+++ b/crates/platform-engine/src/lib.rs
@@ -1,0 +1,34 @@
+#![forbid(unsafe_code)]
+
+//! Deterministic, storage-neutral engines for Cerebro platform capabilities.
+//!
+//! This crate contains pure compilation, evaluation, filtering, planning, and
+//! state-transition logic. It deliberately has no persistence or network
+//! implementation and therefore cannot act as a production fallback.
+
+mod action;
+mod assertion;
+mod canonical;
+mod incident;
+mod plugin;
+mod provenance;
+mod query;
+mod recovery;
+mod simulation;
+mod subscription;
+mod temporal;
+mod view;
+
+pub use action::{ActionCommand, transition_action};
+pub use assertion::{
+    CompiledAssertion, assertion_definition_digest, compile_assertion, evaluate_assertion,
+};
+pub use incident::{incident_manifest_digest, package_incident_snapshot};
+pub use plugin::validate_plugin_execution;
+pub use provenance::assemble_provenance;
+pub use query::{QueryExecutionPlan, QueryStrategy, plan_query};
+pub use recovery::build_recovery_report;
+pub use simulation::{SimulationRelationship, SimulationTopology, simulate_topology};
+pub use subscription::event_matches;
+pub use temporal::{RevisionSnapshot, SnapshotKey, SnapshotValue, diff_snapshots};
+pub use view::materialize_view;

--- a/crates/platform-engine/src/plugin.rs
+++ b/crates/platform-engine/src/plugin.rs
@@ -1,0 +1,17 @@
+use cerebro_platform_sdk::{AnalysisPluginManifest, ResourceBudget, ResourceUsage, SdkError};
+
+pub fn validate_plugin_execution(
+    manifest: &AnalysisPluginManifest,
+    budget: &ResourceBudget,
+    usage: &ResourceUsage,
+) -> Result<(), SdkError> {
+    manifest.validate()?;
+    if manifest.limits.memory_bytes > budget.max_plugin_memory_bytes
+        || manifest.limits.execution_millis > budget.max_plugin_millis
+    {
+        return Err(SdkError::OutOfRange("plugin manifest budget"));
+    }
+    usage
+        .validate(budget)
+        .map_err(|_| SdkError::OutOfRange("plugin execution budget"))
+}

--- a/crates/platform-engine/src/plugin.rs
+++ b/crates/platform-engine/src/plugin.rs
@@ -8,8 +8,10 @@ pub fn validate_plugin_execution(
     manifest.validate()?;
     if manifest.limits.memory_bytes > budget.max_plugin_memory_bytes
         || manifest.limits.execution_millis > budget.max_plugin_millis
+        || usage.plugin_memory_bytes > manifest.limits.memory_bytes
+        || usage.plugin_millis > manifest.limits.execution_millis
     {
-        return Err(SdkError::OutOfRange("plugin manifest budget"));
+        return Err(SdkError::OutOfRange("plugin execution budget"));
     }
     usage
         .validate(budget)

--- a/crates/platform-engine/src/provenance.rs
+++ b/crates/platform-engine/src/provenance.rs
@@ -1,0 +1,40 @@
+use cerebro_platform_sdk::{
+    AssertionId, EntityId, EvidenceQuality, EvidenceReference, GraphRevision,
+    ProvenanceExplanation, SdkError, TenantId,
+};
+
+use crate::canonical;
+
+pub fn assemble_provenance(
+    tenant_id: TenantId,
+    graph_revision: GraphRevision,
+    entity_id: Option<EntityId>,
+    assertion_id: Option<AssertionId>,
+    mut evidence: Vec<EvidenceReference>,
+    quality: EvidenceQuality,
+) -> Result<ProvenanceExplanation, SdkError> {
+    evidence.sort_by(|left, right| {
+        left.evidence_id
+            .cmp(&right.evidence_id)
+            .then_with(|| left.event_id.cmp(&right.event_id))
+    });
+    let explanation_digest = canonical::digest(&(
+        &tenant_id,
+        graph_revision,
+        &entity_id,
+        &assertion_id,
+        &evidence,
+        &quality,
+    ))?;
+    let explanation = ProvenanceExplanation {
+        tenant_id,
+        graph_revision,
+        entity_id,
+        assertion_id,
+        evidence,
+        quality,
+        explanation_digest,
+    };
+    explanation.validate()?;
+    Ok(explanation)
+}

--- a/crates/platform-engine/src/query.rs
+++ b/crates/platform-engine/src/query.rs
@@ -1,0 +1,48 @@
+use cerebro_platform_sdk::{FactQuery, ResourceBudget, SdkError};
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryStrategy {
+    StableKeyLookup,
+    BoundedTraversal,
+    BoundedProjectionScan,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct QueryExecutionPlan {
+    pub strategy: QueryStrategy,
+    pub max_rows: u32,
+    pub max_depth: u8,
+    pub deadline_millis: u32,
+}
+
+pub fn plan_query(
+    query: &FactQuery,
+    budget: &ResourceBudget,
+) -> Result<QueryExecutionPlan, SdkError> {
+    let requested_rows =
+        u32::try_from(query.limit()).map_err(|_| SdkError::OutOfRange("query result limit"))?;
+    if requested_rows > budget.max_query_results {
+        return Err(SdkError::OutOfRange("query result limit"));
+    }
+    let depth =
+        u8::try_from(query.edges().len()).map_err(|_| SdkError::OutOfRange("query depth"))?;
+    if depth > budget.max_query_depth {
+        return Err(SdkError::OutOfRange("query depth"));
+    }
+    let has_stable_keys = query.nodes().iter().all(|node| !node.keys.is_empty());
+    let strategy = if has_stable_keys {
+        QueryStrategy::StableKeyLookup
+    } else if !query.edges().is_empty() {
+        QueryStrategy::BoundedTraversal
+    } else {
+        QueryStrategy::BoundedProjectionScan
+    };
+    Ok(QueryExecutionPlan {
+        strategy,
+        max_rows: requested_rows,
+        max_depth: depth,
+        deadline_millis: budget.max_query_millis,
+    })
+}

--- a/crates/platform-engine/src/recovery.rs
+++ b/crates/platform-engine/src/recovery.rs
@@ -1,0 +1,55 @@
+use cerebro_platform_sdk::{
+    ContentDigest, GraphRevision, RecoveryCheck, RecoveryReport, RecoveryState, SdkError, TenantId,
+};
+
+use crate::canonical;
+
+pub fn build_recovery_report(
+    tenant_id: TenantId,
+    append_log_sequence: u64,
+    postgres_revision: GraphRevision,
+    neo4j_revision: GraphRevision,
+    mut checks: Vec<RecoveryCheck>,
+) -> Result<RecoveryReport, SdkError> {
+    if checks.is_empty() {
+        return Err(SdkError::Empty("recovery checks"));
+    }
+    checks.sort_by(|left, right| left.name.cmp(&right.name));
+    if checks
+        .iter()
+        .any(|check| check.name.is_empty() || check.name.trim() != check.name)
+    {
+        return Err(SdkError::Invalid("recovery check name"));
+    }
+    let state = if checks
+        .iter()
+        .any(|check| check.state == RecoveryState::Failed)
+    {
+        RecoveryState::Failed
+    } else if postgres_revision != neo4j_revision
+        || checks
+            .iter()
+            .any(|check| check.state == RecoveryState::Indeterminate)
+    {
+        RecoveryState::Indeterminate
+    } else {
+        RecoveryState::Passed
+    };
+    let report_digest: ContentDigest = canonical::digest(&(
+        &tenant_id,
+        append_log_sequence,
+        postgres_revision,
+        neo4j_revision,
+        &checks,
+        state,
+    ))?;
+    Ok(RecoveryReport {
+        tenant_id,
+        append_log_sequence,
+        postgres_revision,
+        neo4j_revision,
+        checks,
+        state,
+        report_digest,
+    })
+}

--- a/crates/platform-engine/src/simulation.rs
+++ b/crates/platform-engine/src/simulation.rs
@@ -1,0 +1,112 @@
+use std::collections::BTreeSet;
+
+use cerebro_platform_sdk::{
+    EntityId, ProposedChange, RelationKind, SdkError, SimulationFinding, SimulationRequest,
+    SimulationResult, TenantId,
+};
+use serde::Serialize;
+
+use crate::canonical;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct SimulationRelationship {
+    pub from_entity_id: EntityId,
+    pub relation: RelationKind,
+    pub to_entity_id: EntityId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SimulationTopology {
+    pub tenant_id: TenantId,
+    pub entities: BTreeSet<EntityId>,
+    pub relationships: BTreeSet<SimulationRelationship>,
+}
+
+pub fn simulate_topology(
+    request: &SimulationRequest,
+    topology: &SimulationTopology,
+    assertion_results: Vec<SimulationFinding>,
+) -> Result<SimulationResult, SdkError> {
+    request.validate()?;
+    if request.tenant_id != topology.tenant_id {
+        return Err(SdkError::Invalid("simulation tenant"));
+    }
+    let mut projected = topology.clone();
+    let mut affected = BTreeSet::new();
+    let max_affected = usize::try_from(request.max_affected_entities)
+        .map_err(|_| SdkError::OutOfRange("simulation affected entity limit"))?;
+    for change in &request.changes {
+        match change {
+            ProposedChange::RemoveEntity { entity_id } => {
+                if !projected.entities.remove(entity_id) {
+                    return Err(SdkError::NotFound(format!("simulation entity {entity_id}")));
+                }
+                affected.insert(entity_id.clone());
+                projected.relationships.retain(|relationship| {
+                    let retained = relationship.from_entity_id != *entity_id
+                        && relationship.to_entity_id != *entity_id;
+                    if !retained {
+                        affected.insert(relationship.from_entity_id.clone());
+                        affected.insert(relationship.to_entity_id.clone());
+                    }
+                    retained
+                });
+            }
+            ProposedChange::RemoveRelationship {
+                from_entity_id,
+                relation,
+                to_entity_id,
+            } => {
+                let relationship = SimulationRelationship {
+                    from_entity_id: from_entity_id.clone(),
+                    relation: *relation,
+                    to_entity_id: to_entity_id.clone(),
+                };
+                if !projected.relationships.remove(&relationship) {
+                    return Err(SdkError::NotFound("simulation relationship".to_owned()));
+                }
+                affected.extend([from_entity_id.clone(), to_entity_id.clone()]);
+            }
+            ProposedChange::AddRelationship {
+                from_entity_id,
+                relation,
+                to_entity_id,
+            } => {
+                if !projected.entities.contains(from_entity_id)
+                    || !projected.entities.contains(to_entity_id)
+                {
+                    return Err(SdkError::NotFound(
+                        "simulation relationship endpoint".to_owned(),
+                    ));
+                }
+                let relationship = SimulationRelationship {
+                    from_entity_id: from_entity_id.clone(),
+                    relation: *relation,
+                    to_entity_id: to_entity_id.clone(),
+                };
+                if !projected.relationships.insert(relationship) {
+                    return Err(SdkError::Conflict(
+                        "simulation relationship already exists".to_owned(),
+                    ));
+                }
+                affected.extend([from_entity_id.clone(), to_entity_id.clone()]);
+            }
+        }
+        if affected.len() > max_affected {
+            return Err(SdkError::OutOfRange("simulation affected entity limit"));
+        }
+    }
+    let affected_entities = affected.into_iter().collect::<Vec<_>>();
+    let result_digest =
+        canonical::digest(&(request, &affected_entities, &assertion_results, &projected))?;
+    Ok(SimulationResult {
+        simulation_id: request.simulation_id.clone(),
+        tenant_id: request.tenant_id.clone(),
+        base_revision: request.base_revision,
+        applied_changes: request.changes.clone(),
+        affected_entities,
+        assertion_results,
+        truncated: false,
+        result_digest,
+    })
+}

--- a/crates/platform-engine/src/subscription.rs
+++ b/crates/platform-engine/src/subscription.rs
@@ -1,0 +1,20 @@
+use cerebro_platform_sdk::{PlatformEvent, SubscriptionEventFilter};
+
+pub fn event_matches(filter: &SubscriptionEventFilter, event: &PlatformEvent) -> bool {
+    (filter.event_kinds.is_empty() || filter.event_kinds.contains(&event.kind))
+        && (filter.entity_kinds.is_empty()
+            || event
+                .entity_kind
+                .as_ref()
+                .is_some_and(|kind| filter.entity_kinds.contains(kind)))
+        && (filter.entity_ids.is_empty()
+            || event
+                .entity_id
+                .as_ref()
+                .is_some_and(|id| filter.entity_ids.contains(id)))
+        && (filter.assertion_ids.is_empty()
+            || event
+                .assertion_id
+                .as_ref()
+                .is_some_and(|id| filter.assertion_ids.contains(id)))
+}

--- a/crates/platform-engine/src/temporal.rs
+++ b/crates/platform-engine/src/temporal.rs
@@ -59,7 +59,12 @@ pub fn diff_snapshots(
         .into_iter()
         .filter_map(|key| change_for_key(&key, before.values.get(&key), after.values.get(&key)))
         .collect::<Vec<_>>();
-    let full_digest = canonical::digest(&changes)?;
+    let full_digest = canonical::digest(&(
+        &request.tenant_id,
+        before.revision,
+        after.revision,
+        &changes,
+    ))?;
     let offset = parse_cursor(request.cursor.as_deref(), &full_digest)?;
     if offset > changes.len() {
         return Err(SdkError::Invalid("graph diff cursor"));
@@ -71,7 +76,7 @@ pub fn diff_snapshots(
     let page = changes.drain(offset..offset + page_len).collect::<Vec<_>>();
     let next_offset = offset + page_len;
     let truncated = next_offset < offset + remaining;
-    let next_cursor = truncated.then(|| format!("{next_offset}:{}", &full_digest.as_str()[..16]));
+    let next_cursor = truncated.then(|| format!("{next_offset}:{full_digest}"));
     Ok(GraphDiff {
         tenant_id: request.tenant_id.clone(),
         from_revision: before.revision,
@@ -90,7 +95,7 @@ fn parse_cursor(cursor: Option<&str>, digest: &ContentDigest) -> Result<usize, S
     let (offset, binding) = cursor
         .split_once(':')
         .ok_or(SdkError::Invalid("graph diff cursor"))?;
-    if binding != &digest.as_str()[..16] {
+    if binding != digest.as_str() {
         return Err(SdkError::Invalid("graph diff cursor"));
     }
     offset

--- a/crates/platform-engine/src/temporal.rs
+++ b/crates/platform-engine/src/temporal.rs
@@ -1,0 +1,141 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use cerebro_platform_sdk::{
+    AssertionId, ContentDigest, EntityId, GraphChange, GraphChangeKind, GraphDiff,
+    GraphDiffRequest, GraphRevision, RevisionSelector, SdkError, TenantId,
+};
+use serde::Serialize;
+
+use crate::canonical;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "id")]
+pub enum SnapshotKey {
+    Entity(EntityId),
+    Assertion(AssertionId),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SnapshotValue {
+    pub digest: ContentDigest,
+    pub observed_at_unix_millis: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RevisionSnapshot {
+    pub tenant_id: TenantId,
+    pub revision: GraphRevision,
+    pub values: BTreeMap<SnapshotKey, SnapshotValue>,
+}
+
+pub fn diff_snapshots(
+    request: &GraphDiffRequest,
+    before: &RevisionSnapshot,
+    after: &RevisionSnapshot,
+) -> Result<GraphDiff, SdkError> {
+    request.validate()?;
+    if request.tenant_id != before.tenant_id || request.tenant_id != after.tenant_id {
+        return Err(SdkError::Invalid("graph diff tenant"));
+    }
+    if request.from_revision != before.revision {
+        return Err(SdkError::Invalid("graph diff starting revision"));
+    }
+    if let RevisionSelector::Exact(revision) = request.to_revision
+        && revision != after.revision
+    {
+        return Err(SdkError::Invalid("graph diff ending revision"));
+    }
+    if after.revision <= before.revision {
+        return Err(SdkError::Invalid("graph diff revision window"));
+    }
+
+    let keys = before
+        .values
+        .keys()
+        .chain(after.values.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut changes = keys
+        .into_iter()
+        .filter_map(|key| change_for_key(&key, before.values.get(&key), after.values.get(&key)))
+        .collect::<Vec<_>>();
+    let full_digest = canonical::digest(&changes)?;
+    let offset = parse_cursor(request.cursor.as_deref(), &full_digest)?;
+    if offset > changes.len() {
+        return Err(SdkError::Invalid("graph diff cursor"));
+    }
+    let limit =
+        usize::try_from(request.limit).map_err(|_| SdkError::OutOfRange("graph diff limit"))?;
+    let remaining = changes.len() - offset;
+    let page_len = remaining.min(limit);
+    let page = changes.drain(offset..offset + page_len).collect::<Vec<_>>();
+    let next_offset = offset + page_len;
+    let truncated = next_offset < offset + remaining;
+    let next_cursor = truncated.then(|| format!("{next_offset}:{}", &full_digest.as_str()[..16]));
+    Ok(GraphDiff {
+        tenant_id: request.tenant_id.clone(),
+        from_revision: before.revision,
+        to_revision: after.revision,
+        changes: page,
+        next_cursor,
+        truncated,
+        digest: full_digest,
+    })
+}
+
+fn parse_cursor(cursor: Option<&str>, digest: &ContentDigest) -> Result<usize, SdkError> {
+    let Some(cursor) = cursor else {
+        return Ok(0);
+    };
+    let (offset, binding) = cursor
+        .split_once(':')
+        .ok_or(SdkError::Invalid("graph diff cursor"))?;
+    if binding != &digest.as_str()[..16] {
+        return Err(SdkError::Invalid("graph diff cursor"));
+    }
+    offset
+        .parse()
+        .map_err(|_| SdkError::Invalid("graph diff cursor"))
+}
+
+fn change_for_key(
+    key: &SnapshotKey,
+    before: Option<&SnapshotValue>,
+    after: Option<&SnapshotValue>,
+) -> Option<GraphChange> {
+    if before.map(|value| &value.digest) == after.map(|value| &value.digest) {
+        return None;
+    }
+    let (entity_id, assertion_id, added, updated, retracted) = match key {
+        SnapshotKey::Entity(id) => (
+            Some(id.clone()),
+            None,
+            GraphChangeKind::EntityAdded,
+            GraphChangeKind::EntityUpdated,
+            GraphChangeKind::EntityRetracted,
+        ),
+        SnapshotKey::Assertion(id) => (
+            None,
+            Some(id.clone()),
+            GraphChangeKind::AssertionAdded,
+            GraphChangeKind::AssertionUpdated,
+            GraphChangeKind::AssertionRetracted,
+        ),
+    };
+    let kind = match (before, after) {
+        (None, Some(_)) => added,
+        (Some(_), Some(_)) => updated,
+        (Some(_), None) => retracted,
+        (None, None) => return None,
+    };
+    Some(GraphChange {
+        kind,
+        entity_id,
+        assertion_id,
+        before_digest: before.map(|value| value.digest.clone()),
+        after_digest: after.map(|value| value.digest.clone()),
+        observed_at_unix_millis: after
+            .or(before)
+            .map_or(0, |value| value.observed_at_unix_millis),
+    })
+}

--- a/crates/platform-engine/src/view.rs
+++ b/crates/platform-engine/src/view.rs
@@ -27,6 +27,10 @@ pub fn materialize_view(
         row_count,
         state: ViewRefreshState::Current,
         refreshed_at_unix_millis,
-        result_digest: canonical::digest(result)?,
+        result_digest: canonical::digest(&(
+            &definition.view_id,
+            &definition.definition_digest,
+            result,
+        ))?,
     })
 }

--- a/crates/platform-engine/src/view.rs
+++ b/crates/platform-engine/src/view.rs
@@ -1,0 +1,32 @@
+use cerebro_platform_sdk::{
+    GraphRevision, MaterializedViewDefinition, MaterializedViewSnapshot, QueryResult, SdkError,
+    ViewRefreshState,
+};
+
+use crate::canonical;
+
+pub fn materialize_view(
+    definition: &MaterializedViewDefinition,
+    result: &QueryResult,
+    refreshed_at_unix_millis: i64,
+) -> Result<MaterializedViewSnapshot, SdkError> {
+    definition.validate()?;
+    if definition.tenant_id != result.tenant_id {
+        return Err(SdkError::Invalid("materialized view tenant"));
+    }
+    if result.truncated || result.matches.len() > definition.max_rows as usize {
+        return Err(SdkError::OutOfRange("materialized view rows"));
+    }
+    let graph_revision = GraphRevision::new(result.graph_revision)?;
+    let row_count = u32::try_from(result.matches.len())
+        .map_err(|_| SdkError::OutOfRange("materialized view rows"))?;
+    Ok(MaterializedViewSnapshot {
+        view_id: definition.view_id.clone(),
+        tenant_id: definition.tenant_id.clone(),
+        graph_revision,
+        row_count,
+        state: ViewRefreshState::Current,
+        refreshed_at_unix_millis,
+        result_digest: canonical::digest(result)?,
+    })
+}

--- a/crates/platform-engine/tests/engine.rs
+++ b/crates/platform-engine/tests/engine.rs
@@ -2,18 +2,21 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use cerebro_platform_engine::{
     ActionCommand, RevisionSnapshot, SimulationTopology, SnapshotKey, SnapshotValue,
-    assertion_definition_digest, build_recovery_report, compile_assertion, diff_snapshots,
-    evaluate_assertion, event_matches, incident_manifest_digest, package_incident_snapshot,
-    plan_query, simulate_topology, transition_action,
+    assemble_provenance, assertion_definition_digest, build_recovery_report, compile_assertion,
+    diff_snapshots, evaluate_assertion, event_matches, incident_manifest_digest, materialize_view,
+    package_incident_snapshot, plan_query, simulate_topology, transition_action,
+    validate_plugin_execution,
 };
 use cerebro_platform_sdk::{
     ActionEffect, ActionOperation, ActionOperationId, ActionProposal, ActionState,
-    AssertionCondition, AssertionDefinition, AssertionDefinitionId, AssertionState, ContentDigest,
-    EntityId, EvaluationTrigger, EvidenceQuality, FactQuery, GraphDiffRequest, GraphRevision,
-    IncidentSnapshotId, IncidentSnapshotManifest, OpaqueId, PlatformEvent, PlatformEventKind,
-    ProposedChange, QueryNode, QueryResult, RecoveryCheck, RecoveryState, ResourceBudget,
-    RevisionSelector, SimulationId, SimulationRequest, SubscriptionEventFilter, TenantId,
-    VerificationState,
+    AnalysisPluginManifest, AssertionCondition, AssertionDefinition, AssertionDefinitionId,
+    AssertionState, ContentDigest, EntityId, EntityKind, EvaluationTrigger, EvidenceAuthority,
+    EvidenceQuality, EvidenceReference, FactQuery, GraphDiffRequest, GraphRevision,
+    IncidentSnapshotId, IncidentSnapshotManifest, MaterializedViewDefinition, OpaqueId,
+    PlatformEvent, PlatformEventKind, PluginCapability, PluginId, PluginLimits, ProposedChange,
+    QueryEdge, QueryNode, QueryResult, RecoveryCheck, RecoveryState, RelationKind, ResourceBudget,
+    ResourceUsage, RevisionSelector, SimulationId, SimulationRequest, SourceRuntimeId,
+    SubscriptionEventFilter, TenantId, VerificationState, ViewId,
 };
 
 fn tenant() -> TenantId {
@@ -175,6 +178,49 @@ fn action_transitions_are_optimistic_and_fail_closed() {
     assert_eq!(simulated.state, ActionState::Simulated);
     assert_eq!(simulated.version, 2);
     assert!(transition_action(&operation, 0, ActionCommand::RecordSimulation).is_err());
+    let waiting =
+        transition_action(&simulated, 2, ActionCommand::RequestApproval).expect("transition");
+    let claimed = transition_action(
+        &waiting,
+        3,
+        ActionCommand::Claim {
+            worker_id: OpaqueId::parse("worker:one").expect("valid worker"),
+        },
+    )
+    .expect("transition");
+    let executing =
+        transition_action(&claimed, 4, ActionCommand::StartExecution).expect("transition");
+    let completed = transition_action(
+        &executing,
+        5,
+        ActionCommand::Complete {
+            external_receipt_ref: OpaqueId::parse("receipt:one").expect("valid receipt"),
+            observed_effect_digest: digest("observed"),
+        },
+    )
+    .expect("transition");
+    let verified = transition_action(&completed, 6, ActionCommand::Verify).expect("transition");
+    assert_eq!(verified.state, ActionState::Verified);
+    assert_eq!(verified.verification_state, VerificationState::Verified);
+    assert_eq!(verified.version, 7);
+    assert!(transition_action(&verified, 7, ActionCommand::StartExecution).is_err());
+
+    let uncertain =
+        transition_action(&executing, 5, ActionCommand::MarkOutcomeUnknown).expect("transition");
+    let reconciled = transition_action(
+        &uncertain,
+        6,
+        ActionCommand::Reconcile {
+            observed_effect_digest: digest("reconciled"),
+        },
+    )
+    .expect("transition");
+    assert_eq!(reconciled.state, ActionState::Reconciled);
+
+    let failed = transition_action(&simulated, 2, ActionCommand::Fail).expect("transition");
+    let rolled_back = transition_action(&failed, 3, ActionCommand::RollBack).expect("transition");
+    assert_eq!(rolled_back.state, ActionState::RolledBack);
+    assert_eq!(rolled_back.verification_state, VerificationState::Stale);
 }
 
 #[test]
@@ -237,4 +283,473 @@ fn incident_packages_bind_manifest_payload_and_signature() {
     let snapshot =
         package_incident_snapshot(manifest, b"canonical".to_vec(), vec![1]).expect("snapshot");
     assert_eq!(snapshot.payload_digest, digest("canonical"));
+}
+
+#[test]
+fn assertion_definition_digest_binds_the_assertion_identity() {
+    let definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:one")
+            .expect("valid assertion"),
+        tenant_id: tenant(),
+        name: "Repository exists".to_owned(),
+        query: query(10),
+        condition: AssertionCondition::AtLeastOneMatch,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("placeholder"),
+    };
+    let changed_id = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:two")
+            .expect("valid assertion"),
+        ..definition.clone()
+    };
+    assert_ne!(
+        assertion_definition_digest(&definition).expect("digest"),
+        assertion_definition_digest(&changed_id).expect("digest")
+    );
+}
+
+#[test]
+fn temporal_pagination_reconstructs_the_complete_ordered_diff() {
+    let before = RevisionSnapshot {
+        tenant_id: tenant(),
+        revision: revision(1),
+        values: BTreeMap::new(),
+    };
+    let values = (0..31)
+        .map(|index| {
+            (
+                SnapshotKey::Entity(
+                    EntityId::parse(format!("repository:{index:02}")).expect("valid entity"),
+                ),
+                SnapshotValue {
+                    digest: digest(&format!("value-{index}")),
+                    observed_at_unix_millis: i64::from(index),
+                },
+            )
+        })
+        .collect();
+    let after = RevisionSnapshot {
+        tenant_id: tenant(),
+        revision: revision(2),
+        values,
+    };
+    let mut cursor = None;
+    let mut changes = Vec::new();
+    let mut complete_digest = None;
+    loop {
+        let page = diff_snapshots(
+            &GraphDiffRequest {
+                tenant_id: tenant(),
+                from_revision: revision(1),
+                to_revision: RevisionSelector::Exact(revision(2)),
+                limit: 7,
+                cursor,
+            },
+            &before,
+            &after,
+        )
+        .expect("graph diff page");
+        if let Some(expected) = &complete_digest {
+            assert_eq!(expected, &page.digest);
+        } else {
+            complete_digest = Some(page.digest.clone());
+        }
+        changes.extend(page.changes);
+        if !page.truncated {
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+    assert_eq!(changes.len(), 31);
+    assert!(
+        changes
+            .windows(2)
+            .all(|pair| pair[0].entity_id < pair[1].entity_id)
+    );
+}
+
+#[test]
+fn simulation_failure_is_atomic_for_multi_change_requests() {
+    let entity = EntityId::parse("repository:one").expect("valid entity");
+    let topology = SimulationTopology {
+        tenant_id: tenant(),
+        entities: BTreeSet::from([entity.clone()]),
+        relationships: BTreeSet::new(),
+    };
+    let request = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:failure").expect("valid simulation"),
+        tenant_id: tenant(),
+        base_revision: revision(1),
+        changes: vec![
+            ProposedChange::RemoveEntity {
+                entity_id: entity.clone(),
+            },
+            ProposedChange::RemoveEntity {
+                entity_id: EntityId::parse("repository:missing").expect("valid entity"),
+            },
+        ],
+        assertions: Vec::new(),
+        max_affected_entities: 10,
+    };
+    assert!(simulate_topology(&request, &topology, Vec::new()).is_err());
+    assert_eq!(topology.entities, BTreeSet::from([entity]));
+}
+
+#[test]
+fn materialized_results_bind_the_view_definition() {
+    let result = QueryResult {
+        tenant_id: tenant(),
+        graph_revision: 3,
+        matches: Vec::new(),
+        truncated: false,
+    };
+    let definition = MaterializedViewDefinition {
+        view_id: ViewId::parse("view:one").expect("valid view"),
+        tenant_id: tenant(),
+        name: "Repositories".to_owned(),
+        query: query(10),
+        max_rows: 10,
+        definition_digest: digest("definition-one"),
+    };
+    let changed = MaterializedViewDefinition {
+        view_id: ViewId::parse("view:two").expect("valid view"),
+        definition_digest: digest("definition-two"),
+        ..definition.clone()
+    };
+    assert_ne!(
+        materialize_view(&definition, &result, 10)
+            .expect("materialized view")
+            .result_digest,
+        materialize_view(&changed, &result, 10)
+            .expect("materialized view")
+            .result_digest
+    );
+}
+
+#[test]
+fn plugin_execution_obeys_manifest_limits_below_tenant_limits() {
+    let manifest = AnalysisPluginManifest {
+        plugin_id: PluginId::parse("plugin:one").expect("valid plugin"),
+        abi_version: "v1".to_owned(),
+        artifact_digest: digest("plugin"),
+        capabilities: vec![PluginCapability::AssertionEvaluation],
+        limits: PluginLimits {
+            memory_bytes: 512,
+            execution_millis: 50,
+            input_bytes: 1_024,
+            output_bytes: 1_024,
+        },
+        zero_imports_required: true,
+        deterministic_output_required: true,
+    };
+    let budget =
+        ResourceBudget::new(100, 6, 2_000, 8, 100, 10_000, 1_024, 100).expect("valid budget");
+    let usage = ResourceUsage {
+        query_results: 0,
+        query_depth: 0,
+        query_millis: 0,
+        concurrent_queries: 0,
+        subscription_batch: 0,
+        snapshot_entities: 0,
+        plugin_memory_bytes: 513,
+        plugin_millis: 50,
+    };
+    assert!(validate_plugin_execution(&manifest, &budget, &usage).is_err());
+    let valid_usage = ResourceUsage {
+        plugin_memory_bytes: 512,
+        ..usage
+    };
+    assert!(validate_plugin_execution(&manifest, &budget, &valid_usage).is_ok());
+    let oversized_manifest = AnalysisPluginManifest {
+        limits: PluginLimits {
+            memory_bytes: 2_048,
+            ..manifest.limits.clone()
+        },
+        ..manifest
+    };
+    assert!(validate_plugin_execution(&oversized_manifest, &budget, &valid_usage).is_err());
+}
+
+#[test]
+fn recovery_digest_is_independent_of_check_input_order() {
+    let checks = vec![
+        RecoveryCheck {
+            name: "projection".to_owned(),
+            state: RecoveryState::Passed,
+            expected_digest: Some(digest("projection")),
+            observed_digest: Some(digest("projection")),
+            reason_code: None,
+        },
+        RecoveryCheck {
+            name: "ledger".to_owned(),
+            state: RecoveryState::Passed,
+            expected_digest: Some(digest("ledger")),
+            observed_digest: Some(digest("ledger")),
+            reason_code: None,
+        },
+    ];
+    let mut reversed = checks.clone();
+    reversed.reverse();
+    let first =
+        build_recovery_report(tenant(), 10, revision(3), revision(3), checks).expect("report");
+    let second =
+        build_recovery_report(tenant(), 10, revision(3), revision(3), reversed).expect("report");
+    assert_eq!(first.report_digest, second.report_digest);
+}
+
+#[test]
+fn provenance_is_sorted_bound_to_one_target_and_digest_stable() {
+    let evidence = |id: &str| EvidenceReference {
+        evidence_id: OpaqueId::parse(id).expect("valid evidence"),
+        source_runtime_id: SourceRuntimeId::parse("runtime:one").expect("valid runtime"),
+        event_id: OpaqueId::parse(format!("event:{id}")).expect("valid event"),
+        observed_at_unix_millis: 10,
+        authority: EvidenceAuthority::Authoritative,
+        content_digest: digest(id),
+    };
+    let quality = EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("quality");
+    let explanation = assemble_provenance(
+        tenant(),
+        revision(2),
+        Some(EntityId::parse("repository:one").expect("valid entity")),
+        None,
+        vec![evidence("two"), evidence("one")],
+        quality.clone(),
+    )
+    .expect("provenance");
+    assert_eq!(explanation.evidence[0].evidence_id.as_str(), "one");
+    assert_eq!(explanation.evidence[1].evidence_id.as_str(), "two");
+    assert!(
+        assemble_provenance(
+            tenant(),
+            revision(2),
+            None,
+            None,
+            vec![evidence("one")],
+            quality,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn simulation_adds_and_removes_relationships_with_endpoint_checks() {
+    let left = EntityId::parse("repository:left").expect("valid entity");
+    let right = EntityId::parse("repository:right").expect("valid entity");
+    let relationship = cerebro_platform_engine::SimulationRelationship {
+        from_entity_id: left.clone(),
+        relation: RelationKind::DependsOn,
+        to_entity_id: right.clone(),
+    };
+    let empty = SimulationTopology {
+        tenant_id: tenant(),
+        entities: BTreeSet::from([left.clone(), right.clone()]),
+        relationships: BTreeSet::new(),
+    };
+    let add = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:add").expect("valid simulation"),
+        tenant_id: tenant(),
+        base_revision: revision(1),
+        changes: vec![ProposedChange::AddRelationship {
+            from_entity_id: left.clone(),
+            relation: RelationKind::DependsOn,
+            to_entity_id: right.clone(),
+        }],
+        assertions: Vec::new(),
+        max_affected_entities: 2,
+    };
+    assert_eq!(
+        simulate_topology(&add, &empty, Vec::new())
+            .expect("simulation")
+            .affected_entities,
+        vec![left.clone(), right.clone()]
+    );
+
+    let connected = SimulationTopology {
+        relationships: BTreeSet::from([relationship]),
+        ..empty.clone()
+    };
+    let remove = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:remove").expect("valid simulation"),
+        changes: vec![ProposedChange::RemoveRelationship {
+            from_entity_id: left,
+            relation: RelationKind::DependsOn,
+            to_entity_id: right,
+        }],
+        ..add
+    };
+    assert!(simulate_topology(&remove, &connected, Vec::new()).is_ok());
+    assert!(simulate_topology(&remove, &empty, Vec::new()).is_err());
+}
+
+#[test]
+fn subscription_filters_fail_each_nonmatching_dimension() {
+    let event = PlatformEvent {
+        cursor: cerebro_platform_sdk::DurableCursor::new(1),
+        tenant_id: tenant(),
+        kind: PlatformEventKind::GraphChanged,
+        graph_revision: Some(revision(1)),
+        entity_kind: Some(EntityKind::Repository),
+        entity_id: Some(EntityId::parse("repository:one").expect("valid entity")),
+        assertion_id: Some(
+            AssertionDefinitionId::parse("assertion-definition:one").expect("valid assertion"),
+        ),
+        occurred_at_unix_millis: 1,
+        payload_digest: digest("event"),
+    };
+    let base = SubscriptionEventFilter {
+        event_kinds: vec![PlatformEventKind::GraphChanged],
+        entity_kinds: vec![EntityKind::Repository],
+        entity_ids: vec![EntityId::parse("repository:one").expect("valid entity")],
+        assertion_ids: vec![
+            AssertionDefinitionId::parse("assertion-definition:one").expect("valid assertion"),
+        ],
+    };
+    assert!(event_matches(&base, &event));
+    assert!(!event_matches(
+        &SubscriptionEventFilter {
+            event_kinds: vec![PlatformEventKind::ActionChanged],
+            ..base.clone()
+        },
+        &event
+    ));
+    assert!(!event_matches(
+        &SubscriptionEventFilter {
+            entity_kinds: vec![EntityKind::Person],
+            ..base.clone()
+        },
+        &event
+    ));
+    assert!(!event_matches(
+        &SubscriptionEventFilter {
+            entity_ids: vec![EntityId::parse("repository:two").expect("valid entity")],
+            ..base.clone()
+        },
+        &event
+    ));
+    assert!(!event_matches(
+        &SubscriptionEventFilter {
+            assertion_ids: vec![
+                AssertionDefinitionId::parse("assertion-definition:two").expect("valid assertion"),
+            ],
+            ..base
+        },
+        &event
+    ));
+}
+
+#[test]
+fn query_planner_selects_bounded_scan_and_traversal_and_rejects_budget_overflow() {
+    let budget =
+        ResourceBudget::new(100, 6, 2_000, 8, 100, 10_000, 1_024, 100).expect("valid budget");
+    let scan = FactQuery::new(
+        vec![QueryNode {
+            variable: "repository".to_owned(),
+            kinds: vec!["repository".to_owned()],
+            keys: Vec::new(),
+        }],
+        Vec::new(),
+        Vec::new(),
+        10,
+    )
+    .expect("query");
+    assert_eq!(
+        plan_query(&scan, &budget).expect("plan").strategy,
+        cerebro_platform_engine::QueryStrategy::BoundedProjectionScan
+    );
+    let traversal = FactQuery::new(
+        vec![
+            QueryNode {
+                variable: "repository".to_owned(),
+                kinds: vec!["repository".to_owned()],
+                keys: Vec::new(),
+            },
+            QueryNode {
+                variable: "service".to_owned(),
+                kinds: vec!["service".to_owned()],
+                keys: Vec::new(),
+            },
+        ],
+        vec![QueryEdge {
+            variable: "dependency".to_owned(),
+            from_variable: "repository".to_owned(),
+            relation: "depends_on".to_owned(),
+            to_variable: "service".to_owned(),
+        }],
+        Vec::new(),
+        10,
+    )
+    .expect("query");
+    assert_eq!(
+        plan_query(&traversal, &budget).expect("plan").strategy,
+        cerebro_platform_engine::QueryStrategy::BoundedTraversal
+    );
+    assert!(plan_query(&query(101), &budget).is_err());
+}
+
+#[test]
+fn assertion_evaluation_is_indeterminate_for_truncation_conflict_and_disabled_policy() {
+    let mut definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:indeterminate")
+            .expect("valid assertion"),
+        tenant_id: tenant(),
+        name: "Repository exists".to_owned(),
+        query: query(10),
+        condition: AssertionCondition::AtLeastOneMatch,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("placeholder"),
+    };
+    definition.definition_digest =
+        assertion_definition_digest(&definition).expect("definition digest");
+    let compiled = compile_assertion(definition.clone()).expect("compiled");
+    let result = QueryResult {
+        tenant_id: tenant(),
+        graph_revision: 2,
+        matches: Vec::new(),
+        truncated: true,
+    };
+    let quality = EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("quality");
+    assert_eq!(
+        evaluate_assertion(&compiled, &result, &quality, 10)
+            .expect("evaluation")
+            .state,
+        AssertionState::Indeterminate
+    );
+    let conflict = EvidenceQuality::new(100, 100, 100, 100, 100, true).expect("quality");
+    assert_eq!(
+        evaluate_assertion(
+            &compiled,
+            &QueryResult {
+                truncated: false,
+                ..result.clone()
+            },
+            &conflict,
+            10,
+        )
+        .expect("evaluation")
+        .state,
+        AssertionState::Indeterminate
+    );
+    definition.enabled = false;
+    definition.definition_digest =
+        assertion_definition_digest(&definition).expect("definition digest");
+    let disabled = compile_assertion(definition).expect("compiled");
+    assert_eq!(
+        evaluate_assertion(
+            &disabled,
+            &QueryResult {
+                truncated: false,
+                ..result
+            },
+            &quality,
+            10,
+        )
+        .expect("evaluation")
+        .state,
+        AssertionState::Indeterminate
+    );
 }

--- a/crates/platform-engine/tests/engine.rs
+++ b/crates/platform-engine/tests/engine.rs
@@ -1,0 +1,240 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use cerebro_platform_engine::{
+    ActionCommand, RevisionSnapshot, SimulationTopology, SnapshotKey, SnapshotValue,
+    assertion_definition_digest, build_recovery_report, compile_assertion, diff_snapshots,
+    evaluate_assertion, event_matches, incident_manifest_digest, package_incident_snapshot,
+    plan_query, simulate_topology, transition_action,
+};
+use cerebro_platform_sdk::{
+    ActionEffect, ActionOperation, ActionOperationId, ActionProposal, ActionState,
+    AssertionCondition, AssertionDefinition, AssertionDefinitionId, AssertionState, ContentDigest,
+    EntityId, EvaluationTrigger, EvidenceQuality, FactQuery, GraphDiffRequest, GraphRevision,
+    IncidentSnapshotId, IncidentSnapshotManifest, OpaqueId, PlatformEvent, PlatformEventKind,
+    ProposedChange, QueryNode, QueryResult, RecoveryCheck, RecoveryState, ResourceBudget,
+    RevisionSelector, SimulationId, SimulationRequest, SubscriptionEventFilter, TenantId,
+    VerificationState,
+};
+
+fn tenant() -> TenantId {
+    TenantId::parse("tenant-a").expect("valid tenant")
+}
+
+fn revision(value: u64) -> GraphRevision {
+    GraphRevision::new(value).expect("valid revision")
+}
+
+fn digest(value: &str) -> ContentDigest {
+    ContentDigest::of_bytes(value)
+}
+
+fn query(limit: usize) -> FactQuery {
+    FactQuery::new(
+        vec![QueryNode {
+            variable: "repository".to_owned(),
+            kinds: vec!["repository".to_owned()],
+            keys: vec!["repository:one".to_owned()],
+        }],
+        Vec::new(),
+        Vec::new(),
+        limit,
+    )
+    .expect("valid query")
+}
+
+#[test]
+fn typed_assertions_compile_and_evaluate_without_transport_state() {
+    let mut definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:one")
+            .expect("valid assertion"),
+        tenant_id: tenant(),
+        name: "Repository exists".to_owned(),
+        query: query(10),
+        condition: AssertionCondition::AtLeastOneMatch,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("placeholder"),
+    };
+    definition.definition_digest =
+        assertion_definition_digest(&definition).expect("definition digest");
+    let compiled = compile_assertion(definition).expect("compiled assertion");
+    let result = QueryResult {
+        tenant_id: tenant(),
+        graph_revision: 3,
+        matches: Vec::new(),
+        truncated: false,
+    };
+    let quality = EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("valid quality");
+    let evaluation =
+        evaluate_assertion(&compiled, &result, &quality, 10).expect("assertion evaluation");
+    assert_eq!(evaluation.state, AssertionState::Violated);
+    assert_eq!(evaluation.reason_codes, vec!["condition_not_met"]);
+}
+
+#[test]
+fn temporal_diff_is_stable_bounded_and_cursor_bound() {
+    let entity = EntityId::parse("repository:one").expect("valid entity");
+    let before = RevisionSnapshot {
+        tenant_id: tenant(),
+        revision: revision(1),
+        values: BTreeMap::from([(
+            SnapshotKey::Entity(entity.clone()),
+            SnapshotValue {
+                digest: digest("before"),
+                observed_at_unix_millis: 1,
+            },
+        )]),
+    };
+    let after = RevisionSnapshot {
+        tenant_id: tenant(),
+        revision: revision(2),
+        values: BTreeMap::from([(
+            SnapshotKey::Entity(entity),
+            SnapshotValue {
+                digest: digest("after"),
+                observed_at_unix_millis: 2,
+            },
+        )]),
+    };
+    let request = GraphDiffRequest {
+        tenant_id: tenant(),
+        from_revision: revision(1),
+        to_revision: RevisionSelector::Exact(revision(2)),
+        limit: 1,
+        cursor: None,
+    };
+    let result = diff_snapshots(&request, &before, &after).expect("graph diff");
+    assert_eq!(result.changes.len(), 1);
+    assert!(!result.truncated);
+}
+
+#[test]
+fn subscriptions_match_every_declared_dimension() {
+    let filter = SubscriptionEventFilter {
+        event_kinds: vec![PlatformEventKind::GraphChanged],
+        entity_kinds: Vec::new(),
+        entity_ids: vec![EntityId::parse("repository:one").expect("valid entity")],
+        assertion_ids: Vec::new(),
+    };
+    let event = PlatformEvent {
+        cursor: cerebro_platform_sdk::DurableCursor::new(1),
+        tenant_id: tenant(),
+        kind: PlatformEventKind::GraphChanged,
+        graph_revision: Some(revision(1)),
+        entity_kind: None,
+        entity_id: Some(EntityId::parse("repository:one").expect("valid entity")),
+        assertion_id: None,
+        occurred_at_unix_millis: 1,
+        payload_digest: digest("event"),
+    };
+    assert!(event_matches(&filter, &event));
+}
+
+#[test]
+fn adaptive_plans_respect_tenant_budgets() {
+    let budget =
+        ResourceBudget::new(100, 6, 2_000, 8, 100, 10_000, 1_024, 100).expect("valid budget");
+    let plan = plan_query(&query(10), &budget).expect("query plan");
+    assert_eq!(
+        plan.strategy,
+        cerebro_platform_engine::QueryStrategy::StableKeyLookup
+    );
+    assert_eq!(plan.max_rows, 10);
+}
+
+#[test]
+fn action_transitions_are_optimistic_and_fail_closed() {
+    let proposal = ActionProposal {
+        operation_id: ActionOperationId::parse("operation:one").expect("valid operation"),
+        tenant_id: tenant(),
+        graph_revision: revision(1),
+        action_kind: "revoke_access".to_owned(),
+        target_id: OpaqueId::parse("grant:one").expect("valid target"),
+        expected_effects: vec![ActionEffect {
+            target_id: OpaqueId::parse("grant:one").expect("valid target"),
+            effect_kind: "access_removed".to_owned(),
+            expected_state_digest: digest("expected"),
+        }],
+        rollback_ref: OpaqueId::parse("rollback:one").expect("valid rollback"),
+        idempotency_key: OpaqueId::parse("idempotency:one").expect("valid key"),
+        simulation_digest: digest("simulation"),
+        proposal_digest: digest("proposal"),
+    };
+    let operation = ActionOperation {
+        proposal,
+        state: ActionState::Proposed,
+        version: 1,
+        claimed_by: None,
+        external_receipt_ref: None,
+        observed_effect_digest: None,
+        verification_state: VerificationState::Pending,
+    };
+    let simulated =
+        transition_action(&operation, 1, ActionCommand::RecordSimulation).expect("transition");
+    assert_eq!(simulated.state, ActionState::Simulated);
+    assert_eq!(simulated.version, 2);
+    assert!(transition_action(&operation, 0, ActionCommand::RecordSimulation).is_err());
+}
+
+#[test]
+fn recovery_reports_fail_on_any_failed_proof() {
+    let report = build_recovery_report(
+        tenant(),
+        10,
+        revision(3),
+        revision(3),
+        vec![RecoveryCheck {
+            name: "ledger replay".to_owned(),
+            state: RecoveryState::Failed,
+            expected_digest: Some(digest("expected")),
+            observed_digest: Some(digest("observed")),
+            reason_code: Some("digest_mismatch".to_owned()),
+        }],
+    )
+    .expect("recovery report");
+    assert_eq!(report.state, RecoveryState::Failed);
+}
+
+#[test]
+fn counterfactual_simulation_does_not_mutate_the_input_topology() {
+    let entity = EntityId::parse("repository:one").expect("valid entity");
+    let topology = SimulationTopology {
+        tenant_id: tenant(),
+        entities: BTreeSet::from([entity.clone()]),
+        relationships: BTreeSet::new(),
+    };
+    let request = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:one").expect("valid simulation"),
+        tenant_id: tenant(),
+        base_revision: revision(1),
+        changes: vec![ProposedChange::RemoveEntity {
+            entity_id: entity.clone(),
+        }],
+        assertions: Vec::new(),
+        max_affected_entities: 10,
+    };
+    let result = simulate_topology(&request, &topology, Vec::new()).expect("simulation");
+    assert_eq!(result.affected_entities, vec![entity.clone()]);
+    assert!(topology.entities.contains(&entity));
+}
+
+#[test]
+fn incident_packages_bind_manifest_payload_and_signature() {
+    let mut manifest = IncidentSnapshotManifest {
+        snapshot_id: IncidentSnapshotId::parse("snapshot:one").expect("valid snapshot"),
+        tenant_id: tenant(),
+        graph_revision: revision(1),
+        created_at_unix_millis: 10,
+        entity_ids: vec![EntityId::parse("repository:one").expect("valid entity")],
+        source_receipt_digests: vec![digest("source-receipt")],
+        policy_digests: vec![digest("policy")],
+        mission_ids: Vec::new(),
+        verification_receipt_digests: Vec::new(),
+        manifest_digest: digest("placeholder"),
+    };
+    manifest.manifest_digest = incident_manifest_digest(&manifest).expect("manifest digest");
+    let snapshot =
+        package_incident_snapshot(manifest, b"canonical".to_vec(), vec![1]).expect("snapshot");
+    assert_eq!(snapshot.payload_digest, digest("canonical"));
+}

--- a/crates/platform-sdk/Cargo.toml
+++ b/crates/platform-sdk/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cerebro-platform-sdk"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+async-trait.workspace = true
+cerebro-agent-context.workspace = true
+cerebro-control-kernel.workspace = true
+cerebro-organizational-model.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+
+[lints]
+workspace = true

--- a/crates/platform-sdk/src/action.rs
+++ b/crates/platform-sdk/src/action.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::BTreeSet;
 
 use crate::{
     ActionOperationId, ContentDigest, GraphRevision, OpaqueId, SdkError, TenantId,
@@ -61,6 +62,24 @@ impl ActionProposal {
         }
         if self.expected_effects.is_empty() || self.expected_effects.len() > 100 {
             return Err(SdkError::OutOfRange("action expected effects"));
+        }
+        let mut effects = BTreeSet::new();
+        for effect in &self.expected_effects {
+            if effect.effect_kind.is_empty()
+                || effect.effect_kind.len() > 128
+                || effect.effect_kind.trim() != effect.effect_kind
+                || !effect
+                    .effect_kind
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/".contains(&byte))
+            {
+                return Err(SdkError::Invalid("action effect kind"));
+            }
+            if !effects.insert((&effect.target_id, effect.effect_kind.as_str())) {
+                return Err(SdkError::Conflict(
+                    "duplicate action expected effect".to_owned(),
+                ));
+            }
         }
         Ok(())
     }

--- a/crates/platform-sdk/src/action.rs
+++ b/crates/platform-sdk/src/action.rs
@@ -1,0 +1,87 @@
+use serde::Serialize;
+
+use crate::{
+    ActionOperationId, ContentDigest, GraphRevision, OpaqueId, SdkError, TenantId,
+    VerificationReceipt,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionState {
+    Proposed,
+    Simulated,
+    WaitingForApproval,
+    Claimed,
+    Executing,
+    OutcomeUnknown,
+    Completed,
+    Reconciled,
+    Verified,
+    Failed,
+    RolledBack,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationState {
+    Pending,
+    Verified,
+    Rejected,
+    Stale,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ActionEffect {
+    pub target_id: OpaqueId,
+    pub effect_kind: String,
+    pub expected_state_digest: ContentDigest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ActionProposal {
+    pub operation_id: ActionOperationId,
+    pub tenant_id: TenantId,
+    pub graph_revision: GraphRevision,
+    pub action_kind: String,
+    pub target_id: OpaqueId,
+    pub expected_effects: Vec<ActionEffect>,
+    pub rollback_ref: OpaqueId,
+    pub idempotency_key: OpaqueId,
+    pub simulation_digest: ContentDigest,
+    pub proposal_digest: ContentDigest,
+}
+
+impl ActionProposal {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.action_kind.trim() != self.action_kind || self.action_kind.is_empty() {
+            return Err(SdkError::Invalid("action kind"));
+        }
+        if self.action_kind.len() > 128 {
+            return Err(SdkError::TooLong("action kind"));
+        }
+        if self.expected_effects.is_empty() || self.expected_effects.len() > 100 {
+            return Err(SdkError::OutOfRange("action expected effects"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ActionOperation {
+    pub proposal: ActionProposal,
+    pub state: ActionState,
+    pub version: u64,
+    pub claimed_by: Option<OpaqueId>,
+    pub external_receipt_ref: Option<OpaqueId>,
+    pub observed_effect_digest: Option<ContentDigest>,
+    pub verification_state: VerificationState,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ActionReceipt {
+    pub operation_id: ActionOperationId,
+    pub state: ActionState,
+    pub version: u64,
+    pub execution_receipt_digest: ContentDigest,
+    pub verification_receipt: Option<VerificationReceipt>,
+}

--- a/crates/platform-sdk/src/assertion.rs
+++ b/crates/platform-sdk/src/assertion.rs
@@ -1,0 +1,61 @@
+use serde::Serialize;
+
+use crate::{AssertionDefinitionId, ContentDigest, FactQuery, GraphRevision, SdkError, TenantId};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvaluationTrigger {
+    GraphChange,
+    EvidenceFreshness,
+    ScheduledReconciliation,
+    Manual,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssertionState {
+    Satisfied,
+    Violated,
+    Indeterminate,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct AssertionDefinition {
+    pub assertion_id: AssertionDefinitionId,
+    pub tenant_id: TenantId,
+    pub name: String,
+    pub query: FactQuery,
+    pub triggers: Vec<EvaluationTrigger>,
+    pub evidence_max_age_seconds: u64,
+    pub enabled: bool,
+    pub definition_digest: ContentDigest,
+}
+
+impl AssertionDefinition {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.name.trim() != self.name || self.name.is_empty() {
+            return Err(SdkError::Invalid("assertion name"));
+        }
+        if self.name.len() > 256 {
+            return Err(SdkError::TooLong("assertion name"));
+        }
+        if self.triggers.is_empty() {
+            return Err(SdkError::Empty("assertion triggers"));
+        }
+        if self.evidence_max_age_seconds == 0 {
+            return Err(SdkError::OutOfRange("assertion evidence max age"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct AssertionEvaluation {
+    pub assertion_id: AssertionDefinitionId,
+    pub graph_revision: GraphRevision,
+    pub state: AssertionState,
+    pub evaluated_at_unix_millis: i64,
+    pub matching_paths: u32,
+    pub reason_codes: Vec<String>,
+    pub evidence_digest: ContentDigest,
+}

--- a/crates/platform-sdk/src/assertion.rs
+++ b/crates/platform-sdk/src/assertion.rs
@@ -19,12 +19,40 @@ pub enum AssertionState {
     Indeterminate,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "count")]
+pub enum AssertionCondition {
+    NoMatches,
+    AtLeastOneMatch,
+    MatchCountAtMost(u32),
+    MatchCountAtLeast(u32),
+}
+
+impl AssertionCondition {
+    pub fn evaluate(self, matching_paths: u32) -> bool {
+        match self {
+            Self::NoMatches => matching_paths == 0,
+            Self::AtLeastOneMatch => matching_paths > 0,
+            Self::MatchCountAtMost(maximum) => matching_paths <= maximum,
+            Self::MatchCountAtLeast(minimum) => matching_paths >= minimum,
+        }
+    }
+
+    fn validate(self) -> Result<(), SdkError> {
+        if matches!(self, Self::MatchCountAtLeast(0)) {
+            return Err(SdkError::OutOfRange("assertion minimum match count"));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct AssertionDefinition {
     pub assertion_id: AssertionDefinitionId,
     pub tenant_id: TenantId,
     pub name: String,
     pub query: FactQuery,
+    pub condition: AssertionCondition,
     pub triggers: Vec<EvaluationTrigger>,
     pub evidence_max_age_seconds: u64,
     pub enabled: bool,
@@ -45,7 +73,7 @@ impl AssertionDefinition {
         if self.evidence_max_age_seconds == 0 {
             return Err(SdkError::OutOfRange("assertion evidence max age"));
         }
-        Ok(())
+        self.condition.validate()
     }
 }
 

--- a/crates/platform-sdk/src/budget.rs
+++ b/crates/platform-sdk/src/budget.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BudgetError {
     Zero(&'static str),
+    ExceedsMaximum(&'static str),
     UsageExceedsLimit(&'static str),
 }
 
@@ -42,6 +43,24 @@ impl ResourceBudget {
         ] {
             if value == 0 {
                 return Err(BudgetError::Zero(field));
+            }
+        }
+        for (value, maximum, field) in [
+            (u64::from(max_query_results), 500, "max query results"),
+            (u64::from(max_query_depth), 6, "max query depth"),
+            (
+                u64::from(max_subscription_batch),
+                500,
+                "max subscription batch",
+            ),
+            (
+                u64::from(max_snapshot_entities),
+                10_000,
+                "max snapshot entities",
+            ),
+        ] {
+            if value > maximum {
+                return Err(BudgetError::ExceedsMaximum(field));
             }
         }
         Ok(Self {

--- a/crates/platform-sdk/src/budget.rs
+++ b/crates/platform-sdk/src/budget.rs
@@ -1,0 +1,122 @@
+use serde::Serialize;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BudgetError {
+    Zero(&'static str),
+    UsageExceedsLimit(&'static str),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ResourceBudget {
+    pub max_query_results: u32,
+    pub max_query_depth: u8,
+    pub max_query_millis: u32,
+    pub max_concurrent_queries: u16,
+    pub max_subscription_batch: u16,
+    pub max_snapshot_entities: u32,
+    pub max_plugin_memory_bytes: u64,
+    pub max_plugin_millis: u32,
+}
+
+impl ResourceBudget {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        max_query_results: u32,
+        max_query_depth: u8,
+        max_query_millis: u32,
+        max_concurrent_queries: u16,
+        max_subscription_batch: u16,
+        max_snapshot_entities: u32,
+        max_plugin_memory_bytes: u64,
+        max_plugin_millis: u32,
+    ) -> Result<Self, BudgetError> {
+        for (value, field) in [
+            (u64::from(max_query_results), "max query results"),
+            (u64::from(max_query_depth), "max query depth"),
+            (u64::from(max_query_millis), "max query millis"),
+            (u64::from(max_concurrent_queries), "max concurrent queries"),
+            (u64::from(max_subscription_batch), "max subscription batch"),
+            (u64::from(max_snapshot_entities), "max snapshot entities"),
+            (max_plugin_memory_bytes, "max plugin memory bytes"),
+            (u64::from(max_plugin_millis), "max plugin millis"),
+        ] {
+            if value == 0 {
+                return Err(BudgetError::Zero(field));
+            }
+        }
+        Ok(Self {
+            max_query_results,
+            max_query_depth,
+            max_query_millis,
+            max_concurrent_queries,
+            max_subscription_batch,
+            max_snapshot_entities,
+            max_plugin_memory_bytes,
+            max_plugin_millis,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ResourceUsage {
+    pub query_results: u32,
+    pub query_depth: u8,
+    pub query_millis: u32,
+    pub concurrent_queries: u16,
+    pub subscription_batch: u16,
+    pub snapshot_entities: u32,
+    pub plugin_memory_bytes: u64,
+    pub plugin_millis: u32,
+}
+
+impl ResourceUsage {
+    pub fn validate(&self, budget: &ResourceBudget) -> Result<(), BudgetError> {
+        for (usage, limit, field) in [
+            (
+                u64::from(self.query_results),
+                u64::from(budget.max_query_results),
+                "query results",
+            ),
+            (
+                u64::from(self.query_depth),
+                u64::from(budget.max_query_depth),
+                "query depth",
+            ),
+            (
+                u64::from(self.query_millis),
+                u64::from(budget.max_query_millis),
+                "query millis",
+            ),
+            (
+                u64::from(self.concurrent_queries),
+                u64::from(budget.max_concurrent_queries),
+                "concurrent queries",
+            ),
+            (
+                u64::from(self.subscription_batch),
+                u64::from(budget.max_subscription_batch),
+                "subscription batch",
+            ),
+            (
+                u64::from(self.snapshot_entities),
+                u64::from(budget.max_snapshot_entities),
+                "snapshot entities",
+            ),
+            (
+                self.plugin_memory_bytes,
+                budget.max_plugin_memory_bytes,
+                "plugin memory bytes",
+            ),
+            (
+                u64::from(self.plugin_millis),
+                u64::from(budget.max_plugin_millis),
+                "plugin millis",
+            ),
+        ] {
+            if usage > limit {
+                return Err(BudgetError::UsageExceedsLimit(field));
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/platform-sdk/src/diagnostics.rs
+++ b/crates/platform-sdk/src/diagnostics.rs
@@ -1,0 +1,40 @@
+use serde::Serialize;
+
+use crate::{GraphRevision, TenantId};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityState {
+    Healthy,
+    Degraded,
+    Blocked,
+    Rebuilding,
+    Unavailable,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CapabilityHealth {
+    pub capability: String,
+    pub state: CapabilityState,
+    pub reason_code: Option<String>,
+    pub observed_at_unix_millis: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProjectionLag {
+    pub graph_revision: GraphRevision,
+    pub pending_outbox_records: u64,
+    pub oldest_pending_age_millis: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct OperationalDiagnostics {
+    pub tenant_id: TenantId,
+    pub append_log_sequence: u64,
+    pub graph_revision: GraphRevision,
+    pub projection_lag: ProjectionLag,
+    pub rejected_deltas: u64,
+    pub parity_mismatches: u64,
+    pub budget_exhaustions: u64,
+    pub capabilities: Vec<CapabilityHealth>,
+}

--- a/crates/platform-sdk/src/error.rs
+++ b/crates/platform-sdk/src/error.rs
@@ -1,0 +1,32 @@
+use std::{error::Error, fmt};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SdkError {
+    Empty(&'static str),
+    Invalid(&'static str),
+    TooLong(&'static str),
+    OutOfRange(&'static str),
+    Conflict(String),
+    NotFound(String),
+    CapabilityUnavailable(String),
+    Backend(String),
+}
+
+impl fmt::Display for SdkError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty(field) => write!(formatter, "{field} is required"),
+            Self::Invalid(field) => write!(formatter, "{field} is invalid"),
+            Self::TooLong(field) => write!(formatter, "{field} exceeds its size limit"),
+            Self::OutOfRange(field) => write!(formatter, "{field} is outside its allowed range"),
+            Self::Conflict(message) => write!(formatter, "platform conflict: {message}"),
+            Self::NotFound(message) => write!(formatter, "platform value not found: {message}"),
+            Self::CapabilityUnavailable(message) => {
+                write!(formatter, "platform capability unavailable: {message}")
+            }
+            Self::Backend(message) => write!(formatter, "platform backend failed: {message}"),
+        }
+    }
+}
+
+impl Error for SdkError {}

--- a/crates/platform-sdk/src/identity.rs
+++ b/crates/platform-sdk/src/identity.rs
@@ -1,0 +1,130 @@
+use std::{fmt, fmt::Write as _};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::SdkError;
+
+const MAX_ID_BYTES: usize = 256;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct OpaqueId(String);
+
+impl OpaqueId {
+    pub fn parse(value: impl Into<String>) -> Result<Self, SdkError> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(SdkError::Empty("platform id"));
+        }
+        if value.trim() != value
+            || value.len() > MAX_ID_BYTES
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/".contains(&byte))
+        {
+            return Err(SdkError::Invalid("platform id"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for OpaqueId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+macro_rules! typed_id {
+    ($name:ident) => {
+        #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(OpaqueId);
+
+        impl $name {
+            pub fn parse(value: impl Into<String>) -> Result<Self, SdkError> {
+                Ok(Self(OpaqueId::parse(value)?))
+            }
+
+            pub fn as_str(&self) -> &str {
+                self.0.as_str()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Display::fmt(&self.0, formatter)
+            }
+        }
+    };
+}
+
+typed_id!(ActionOperationId);
+typed_id!(AssertionDefinitionId);
+typed_id!(IncidentSnapshotId);
+typed_id!(PluginId);
+typed_id!(SimulationId);
+typed_id!(SubscriptionId);
+typed_id!(ViewId);
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct ContentDigest(String);
+
+impl ContentDigest {
+    pub fn parse(value: impl Into<String>) -> Result<Self, SdkError> {
+        let value = value.into();
+        if value.len() != 64
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(SdkError::Invalid("content digest"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn of_bytes(value: impl AsRef<[u8]>) -> Self {
+        let digest = Sha256::digest(value.as_ref());
+        let mut encoded = String::with_capacity(64);
+        for byte in digest {
+            write!(&mut encoded, "{byte:02x}").expect("writing to a string cannot fail");
+        }
+        Self(encoded)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ContentDigest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ContentDigest, OpaqueId};
+
+    #[test]
+    fn ids_reject_whitespace_and_unbounded_values() {
+        assert!(OpaqueId::parse("valid-id").is_ok());
+        assert!(OpaqueId::parse(" invalid").is_err());
+        assert!(OpaqueId::parse("invalid?").is_err());
+        assert!(OpaqueId::parse("x".repeat(257)).is_err());
+    }
+
+    #[test]
+    fn content_digests_are_canonical_lowercase_sha256() {
+        let digest = ContentDigest::of_bytes("cerebro");
+        assert_eq!(digest.as_str().len(), 64);
+        assert!(ContentDigest::parse(digest.to_string()).is_ok());
+        assert!(ContentDigest::parse("A".repeat(64)).is_err());
+    }
+}

--- a/crates/platform-sdk/src/incident.rs
+++ b/crates/platform-sdk/src/incident.rs
@@ -4,6 +4,9 @@ use crate::{
     ContentDigest, EntityId, GraphRevision, IncidentSnapshotId, OpaqueId, SdkError, TenantId,
 };
 
+const MAX_INCIDENT_SNAPSHOT_ENTITIES: usize = 10_000;
+const MAX_INCIDENT_SNAPSHOT_REFERENCES: usize = 10_000;
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct IncidentSnapshotManifest {
     pub snapshot_id: IncidentSnapshotId,
@@ -20,11 +23,27 @@ pub struct IncidentSnapshotManifest {
 
 impl IncidentSnapshotManifest {
     pub fn validate(&self) -> Result<(), SdkError> {
-        if self.entity_ids.is_empty() || self.entity_ids.len() > 10_000 {
+        if self.entity_ids.is_empty() || self.entity_ids.len() > MAX_INCIDENT_SNAPSHOT_ENTITIES {
             return Err(SdkError::OutOfRange("incident snapshot entity count"));
         }
         if self.source_receipt_digests.is_empty() {
             return Err(SdkError::Empty("incident snapshot source receipts"));
+        }
+        for (references, field) in [
+            (
+                self.source_receipt_digests.len(),
+                "incident snapshot source receipt count",
+            ),
+            (self.policy_digests.len(), "incident snapshot policy count"),
+            (self.mission_ids.len(), "incident snapshot mission count"),
+            (
+                self.verification_receipt_digests.len(),
+                "incident snapshot verification receipt count",
+            ),
+        ] {
+            if references > MAX_INCIDENT_SNAPSHOT_REFERENCES {
+                return Err(SdkError::OutOfRange(field));
+            }
         }
         Ok(())
     }

--- a/crates/platform-sdk/src/incident.rs
+++ b/crates/platform-sdk/src/incident.rs
@@ -1,0 +1,55 @@
+use serde::Serialize;
+
+use crate::{
+    ContentDigest, EntityId, GraphRevision, IncidentSnapshotId, OpaqueId, SdkError, TenantId,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct IncidentSnapshotManifest {
+    pub snapshot_id: IncidentSnapshotId,
+    pub tenant_id: TenantId,
+    pub graph_revision: GraphRevision,
+    pub created_at_unix_millis: i64,
+    pub entity_ids: Vec<EntityId>,
+    pub source_receipt_digests: Vec<ContentDigest>,
+    pub policy_digests: Vec<ContentDigest>,
+    pub mission_ids: Vec<OpaqueId>,
+    pub verification_receipt_digests: Vec<ContentDigest>,
+    pub manifest_digest: ContentDigest,
+}
+
+impl IncidentSnapshotManifest {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.entity_ids.is_empty() || self.entity_ids.len() > 10_000 {
+            return Err(SdkError::OutOfRange("incident snapshot entity count"));
+        }
+        if self.source_receipt_digests.is_empty() {
+            return Err(SdkError::Empty("incident snapshot source receipts"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct IncidentSnapshot {
+    pub manifest: IncidentSnapshotManifest,
+    pub canonical_payload: Vec<u8>,
+    pub payload_digest: ContentDigest,
+    pub signature: Vec<u8>,
+}
+
+impl IncidentSnapshot {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        self.manifest.validate()?;
+        if self.canonical_payload.is_empty() {
+            return Err(SdkError::Empty("incident snapshot payload"));
+        }
+        if ContentDigest::of_bytes(&self.canonical_payload) != self.payload_digest {
+            return Err(SdkError::Invalid("incident snapshot payload digest"));
+        }
+        if self.signature.is_empty() {
+            return Err(SdkError::Empty("incident snapshot signature"));
+        }
+        Ok(())
+    }
+}

--- a/crates/platform-sdk/src/lib.rs
+++ b/crates/platform-sdk/src/lib.rs
@@ -38,7 +38,9 @@ pub use cerebro_control_kernel::{
     AuthorizationDecision, AuthorizationRequest, CapabilityGrant, DecisionReceipt, Mandate,
     Mission, MissionEvent, MissionEventEnvelope, VerificationReceipt,
 };
-pub use cerebro_organizational_model::{AssertionId, EntityId, EntityKind, RelationKind, TenantId};
+pub use cerebro_organizational_model::{
+    AssertionId, EntityId, EntityKind, RelationKind, SourceRuntimeId, TenantId,
+};
 pub use diagnostics::{CapabilityHealth, CapabilityState, OperationalDiagnostics, ProjectionLag};
 pub use error::SdkError;
 pub use identity::{

--- a/crates/platform-sdk/src/lib.rs
+++ b/crates/platform-sdk/src/lib.rs
@@ -27,7 +27,9 @@ mod view;
 pub use action::{
     ActionEffect, ActionOperation, ActionProposal, ActionReceipt, ActionState, VerificationState,
 };
-pub use assertion::{AssertionDefinition, AssertionEvaluation, AssertionState, EvaluationTrigger};
+pub use assertion::{
+    AssertionCondition, AssertionDefinition, AssertionEvaluation, AssertionState, EvaluationTrigger,
+};
 pub use budget::{BudgetError, ResourceBudget, ResourceUsage};
 pub use cerebro_agent_context::{
     FactQuery, QueryAbsentEdge, QueryDirection, QueryEdge, QueryMatch, QueryNode, QueryResult,

--- a/crates/platform-sdk/src/lib.rs
+++ b/crates/platform-sdk/src/lib.rs
@@ -1,0 +1,64 @@
+#![forbid(unsafe_code)]
+
+//! Reusable, transport-neutral contracts for Cerebro platform capabilities.
+//!
+//! This crate owns validation and stable request and response shapes. It does
+//! not own networking, persistence, provider access, graph writes, scheduling,
+//! or model execution. Adapters implement [`PlatformApi`] against the existing
+//! JetStream, Postgres, Neo4j, HTTP, Connect, Go, TypeScript, and Python
+//! boundaries.
+
+mod action;
+mod assertion;
+mod budget;
+mod diagnostics;
+mod error;
+mod identity;
+mod incident;
+mod plugin;
+mod provenance;
+mod recovery;
+mod simulation;
+mod subscription;
+mod temporal;
+mod traits;
+mod view;
+
+pub use action::{
+    ActionEffect, ActionOperation, ActionProposal, ActionReceipt, ActionState, VerificationState,
+};
+pub use assertion::{AssertionDefinition, AssertionEvaluation, AssertionState, EvaluationTrigger};
+pub use budget::{BudgetError, ResourceBudget, ResourceUsage};
+pub use cerebro_agent_context::{
+    FactQuery, QueryAbsentEdge, QueryDirection, QueryEdge, QueryMatch, QueryNode, QueryResult,
+};
+pub use cerebro_control_kernel::{
+    AuthorizationDecision, AuthorizationRequest, CapabilityGrant, DecisionReceipt, Mandate,
+    Mission, MissionEvent, MissionEventEnvelope, VerificationReceipt,
+};
+pub use cerebro_organizational_model::{AssertionId, EntityId, EntityKind, RelationKind, TenantId};
+pub use diagnostics::{CapabilityHealth, CapabilityState, OperationalDiagnostics, ProjectionLag};
+pub use error::SdkError;
+pub use identity::{
+    ActionOperationId, AssertionDefinitionId, ContentDigest, IncidentSnapshotId, OpaqueId,
+    PluginId, SimulationId, SubscriptionId, ViewId,
+};
+pub use incident::{IncidentSnapshot, IncidentSnapshotManifest};
+pub use plugin::{AnalysisPluginManifest, PluginCapability, PluginLimits};
+pub use provenance::{
+    EvidenceAuthority, EvidenceQuality, EvidenceReference, ProvenanceExplanation,
+};
+pub use recovery::{RecoveryCheck, RecoveryReport, RecoveryState};
+pub use simulation::{ProposedChange, SimulationFinding, SimulationRequest, SimulationResult};
+pub use subscription::{
+    DurableCursor, PlatformEvent, PlatformEventKind, SubscriptionDefinition,
+    SubscriptionEventFilter, SubscriptionPage,
+};
+pub use temporal::{
+    GraphChange, GraphChangeKind, GraphDiff, GraphDiffRequest, GraphRevision, RevisionSelector,
+};
+pub use traits::PlatformApi;
+pub use view::{MaterializedViewDefinition, MaterializedViewSnapshot, ViewRefreshState};
+
+/// Stable schema revision for the reusable SDK contracts.
+pub const SCHEMA_VERSION: &str = "cerebro.platform-sdk.v1";

--- a/crates/platform-sdk/src/plugin.rs
+++ b/crates/platform-sdk/src/plugin.rs
@@ -1,0 +1,59 @@
+use serde::Serialize;
+
+use crate::{ContentDigest, PluginId, SdkError};
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginCapability {
+    GraphSnapshotRead,
+    FactQueryEvaluation,
+    AssertionEvaluation,
+    SimulationScoring,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PluginLimits {
+    pub memory_bytes: u64,
+    pub execution_millis: u32,
+    pub input_bytes: u32,
+    pub output_bytes: u32,
+}
+
+impl PluginLimits {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.memory_bytes == 0
+            || self.execution_millis == 0
+            || self.input_bytes == 0
+            || self.output_bytes == 0
+        {
+            return Err(SdkError::OutOfRange("plugin limits"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct AnalysisPluginManifest {
+    pub plugin_id: PluginId,
+    pub abi_version: String,
+    pub artifact_digest: ContentDigest,
+    pub capabilities: Vec<PluginCapability>,
+    pub limits: PluginLimits,
+    pub zero_imports_required: bool,
+    pub deterministic_output_required: bool,
+}
+
+impl AnalysisPluginManifest {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.abi_version.trim() != self.abi_version || self.abi_version.is_empty() {
+            return Err(SdkError::Invalid("plugin ABI version"));
+        }
+        if self.capabilities.is_empty() {
+            return Err(SdkError::Empty("plugin capabilities"));
+        }
+        if !self.zero_imports_required || !self.deterministic_output_required {
+            return Err(SdkError::Invalid("plugin safety requirements"));
+        }
+        self.limits.validate()
+    }
+}

--- a/crates/platform-sdk/src/plugin.rs
+++ b/crates/platform-sdk/src/plugin.rs
@@ -2,6 +2,8 @@ use serde::Serialize;
 
 use crate::{ContentDigest, PluginId, SdkError};
 
+const MAX_PLUGIN_ABI_VERSION_BYTES: usize = 128;
+
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginCapability {
@@ -47,6 +49,9 @@ impl AnalysisPluginManifest {
     pub fn validate(&self) -> Result<(), SdkError> {
         if self.abi_version.trim() != self.abi_version || self.abi_version.is_empty() {
             return Err(SdkError::Invalid("plugin ABI version"));
+        }
+        if self.abi_version.len() > MAX_PLUGIN_ABI_VERSION_BYTES {
+            return Err(SdkError::TooLong("plugin ABI version"));
         }
         if self.capabilities.is_empty() {
             return Err(SdkError::Empty("plugin capabilities"));

--- a/crates/platform-sdk/src/provenance.rs
+++ b/crates/platform-sdk/src/provenance.rs
@@ -5,6 +5,8 @@ use crate::{
     TenantId,
 };
 
+const MAX_PROVENANCE_EVIDENCE_REFERENCES: usize = 10_000;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceAuthority {
@@ -97,6 +99,9 @@ impl ProvenanceExplanation {
         }
         if self.evidence.is_empty() {
             return Err(SdkError::Empty("provenance evidence"));
+        }
+        if self.evidence.len() > MAX_PROVENANCE_EVIDENCE_REFERENCES {
+            return Err(SdkError::OutOfRange("provenance evidence count"));
         }
         Ok(())
     }

--- a/crates/platform-sdk/src/provenance.rs
+++ b/crates/platform-sdk/src/provenance.rs
@@ -1,0 +1,100 @@
+use serde::Serialize;
+
+use crate::{AssertionId, ContentDigest, EntityId, GraphRevision, OpaqueId, SdkError, TenantId};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceAuthority {
+    Authoritative,
+    Corroborating,
+    Proposed,
+    Untrusted,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct EvidenceQuality {
+    pub freshness: u8,
+    pub completeness: u8,
+    pub source_authority: u8,
+    pub identity_confidence: u8,
+    pub verification_independence: u8,
+    pub conflicting: bool,
+}
+
+impl EvidenceQuality {
+    pub fn new(
+        freshness: u8,
+        completeness: u8,
+        source_authority: u8,
+        identity_confidence: u8,
+        verification_independence: u8,
+        conflicting: bool,
+    ) -> Result<Self, SdkError> {
+        if [
+            freshness,
+            completeness,
+            source_authority,
+            identity_confidence,
+            verification_independence,
+        ]
+        .into_iter()
+        .any(|score| score > 100)
+        {
+            return Err(SdkError::OutOfRange("evidence quality score"));
+        }
+        Ok(Self {
+            freshness,
+            completeness,
+            source_authority,
+            identity_confidence,
+            verification_independence,
+            conflicting,
+        })
+    }
+
+    pub fn minimum_score(&self) -> u8 {
+        [
+            self.freshness,
+            self.completeness,
+            self.source_authority,
+            self.identity_confidence,
+            self.verification_independence,
+        ]
+        .into_iter()
+        .min()
+        .unwrap_or_default()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct EvidenceReference {
+    pub evidence_id: OpaqueId,
+    pub source_runtime_id: String,
+    pub event_id: String,
+    pub observed_at_unix_millis: i64,
+    pub authority: EvidenceAuthority,
+    pub content_digest: ContentDigest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProvenanceExplanation {
+    pub tenant_id: TenantId,
+    pub graph_revision: GraphRevision,
+    pub entity_id: Option<EntityId>,
+    pub assertion_id: Option<AssertionId>,
+    pub evidence: Vec<EvidenceReference>,
+    pub quality: EvidenceQuality,
+    pub explanation_digest: ContentDigest,
+}
+
+impl ProvenanceExplanation {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.entity_id.is_some() == self.assertion_id.is_some() {
+            return Err(SdkError::Invalid("provenance target"));
+        }
+        if self.evidence.is_empty() {
+            return Err(SdkError::Empty("provenance evidence"));
+        }
+        Ok(())
+    }
+}

--- a/crates/platform-sdk/src/provenance.rs
+++ b/crates/platform-sdk/src/provenance.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 
-use crate::{AssertionId, ContentDigest, EntityId, GraphRevision, OpaqueId, SdkError, TenantId};
+use crate::{
+    AssertionId, ContentDigest, EntityId, GraphRevision, OpaqueId, SdkError, SourceRuntimeId,
+    TenantId,
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -69,8 +72,8 @@ impl EvidenceQuality {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct EvidenceReference {
     pub evidence_id: OpaqueId,
-    pub source_runtime_id: String,
-    pub event_id: String,
+    pub source_runtime_id: SourceRuntimeId,
+    pub event_id: OpaqueId,
     pub observed_at_unix_millis: i64,
     pub authority: EvidenceAuthority,
     pub content_digest: ContentDigest,

--- a/crates/platform-sdk/src/recovery.rs
+++ b/crates/platform-sdk/src/recovery.rs
@@ -1,0 +1,31 @@
+use serde::Serialize;
+
+use crate::{ContentDigest, GraphRevision, TenantId};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryState {
+    Passed,
+    Failed,
+    Indeterminate,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RecoveryCheck {
+    pub name: String,
+    pub state: RecoveryState,
+    pub expected_digest: Option<ContentDigest>,
+    pub observed_digest: Option<ContentDigest>,
+    pub reason_code: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RecoveryReport {
+    pub tenant_id: TenantId,
+    pub append_log_sequence: u64,
+    pub postgres_revision: GraphRevision,
+    pub neo4j_revision: GraphRevision,
+    pub checks: Vec<RecoveryCheck>,
+    pub state: RecoveryState,
+    pub report_digest: ContentDigest,
+}

--- a/crates/platform-sdk/src/simulation.rs
+++ b/crates/platform-sdk/src/simulation.rs
@@ -5,6 +5,9 @@ use crate::{
     SimulationId, TenantId,
 };
 
+const MAX_SIMULATION_CHANGES: usize = 100;
+const MAX_SIMULATION_ASSERTIONS: usize = 100;
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum ProposedChange {
@@ -38,8 +41,11 @@ impl SimulationRequest {
         if self.changes.is_empty() {
             return Err(SdkError::Empty("simulation changes"));
         }
-        if self.changes.len() > 100 {
+        if self.changes.len() > MAX_SIMULATION_CHANGES {
             return Err(SdkError::OutOfRange("simulation changes"));
+        }
+        if self.assertions.len() > MAX_SIMULATION_ASSERTIONS {
+            return Err(SdkError::OutOfRange("simulation assertions"));
         }
         if self.max_affected_entities == 0 || self.max_affected_entities > 10_000 {
             return Err(SdkError::OutOfRange("simulation affected entity limit"));

--- a/crates/platform-sdk/src/simulation.rs
+++ b/crates/platform-sdk/src/simulation.rs
@@ -1,8 +1,8 @@
 use serde::Serialize;
 
 use crate::{
-    AssertionDefinitionId, ContentDigest, EntityId, GraphChange, GraphRevision, RelationKind,
-    SdkError, SimulationId, TenantId,
+    AssertionDefinitionId, ContentDigest, EntityId, GraphRevision, RelationKind, SdkError,
+    SimulationId, TenantId,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -61,7 +61,7 @@ pub struct SimulationResult {
     pub simulation_id: SimulationId,
     pub tenant_id: TenantId,
     pub base_revision: GraphRevision,
-    pub changes: Vec<GraphChange>,
+    pub applied_changes: Vec<ProposedChange>,
     pub affected_entities: Vec<EntityId>,
     pub assertion_results: Vec<SimulationFinding>,
     pub truncated: bool,

--- a/crates/platform-sdk/src/simulation.rs
+++ b/crates/platform-sdk/src/simulation.rs
@@ -1,0 +1,69 @@
+use serde::Serialize;
+
+use crate::{
+    AssertionDefinitionId, ContentDigest, EntityId, GraphChange, GraphRevision, RelationKind,
+    SdkError, SimulationId, TenantId,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ProposedChange {
+    RemoveEntity {
+        entity_id: EntityId,
+    },
+    RemoveRelationship {
+        from_entity_id: EntityId,
+        relation: RelationKind,
+        to_entity_id: EntityId,
+    },
+    AddRelationship {
+        from_entity_id: EntityId,
+        relation: RelationKind,
+        to_entity_id: EntityId,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SimulationRequest {
+    pub simulation_id: SimulationId,
+    pub tenant_id: TenantId,
+    pub base_revision: GraphRevision,
+    pub changes: Vec<ProposedChange>,
+    pub assertions: Vec<AssertionDefinitionId>,
+    pub max_affected_entities: u32,
+}
+
+impl SimulationRequest {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.changes.is_empty() {
+            return Err(SdkError::Empty("simulation changes"));
+        }
+        if self.changes.len() > 100 {
+            return Err(SdkError::OutOfRange("simulation changes"));
+        }
+        if self.max_affected_entities == 0 || self.max_affected_entities > 10_000 {
+            return Err(SdkError::OutOfRange("simulation affected entity limit"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SimulationFinding {
+    pub assertion_id: AssertionDefinitionId,
+    pub before_state: String,
+    pub after_state: String,
+    pub reason_codes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SimulationResult {
+    pub simulation_id: SimulationId,
+    pub tenant_id: TenantId,
+    pub base_revision: GraphRevision,
+    pub changes: Vec<GraphChange>,
+    pub affected_entities: Vec<EntityId>,
+    pub assertion_results: Vec<SimulationFinding>,
+    pub truncated: bool,
+    pub result_digest: ContentDigest,
+}

--- a/crates/platform-sdk/src/subscription.rs
+++ b/crates/platform-sdk/src/subscription.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::BTreeSet;
 
 use crate::{
     AssertionDefinitionId, ContentDigest, EntityId, EntityKind, GraphRevision, SdkError,
@@ -64,8 +65,29 @@ impl SubscriptionDefinition {
         if self.batch_limit == 0 || self.batch_limit > 500 {
             return Err(SdkError::OutOfRange("subscription batch limit"));
         }
+        if self.filter.event_kinds.len() > 6
+            || self.filter.entity_kinds.len() > 29
+            || self.filter.entity_ids.len() > 500
+            || self.filter.assertion_ids.len() > 500
+        {
+            return Err(SdkError::OutOfRange("subscription filter"));
+        }
+        if has_duplicates(&self.filter.event_kinds)
+            || has_duplicates(&self.filter.entity_kinds)
+            || has_duplicates(&self.filter.entity_ids)
+            || has_duplicates(&self.filter.assertion_ids)
+        {
+            return Err(SdkError::Conflict(
+                "duplicate subscription filter value".to_owned(),
+            ));
+        }
         Ok(())
     }
+}
+
+fn has_duplicates<T: Ord>(values: &[T]) -> bool {
+    let mut seen = BTreeSet::new();
+    values.iter().any(|value| !seen.insert(value))
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]

--- a/crates/platform-sdk/src/subscription.rs
+++ b/crates/platform-sdk/src/subscription.rs
@@ -74,6 +74,9 @@ pub struct PlatformEvent {
     pub tenant_id: TenantId,
     pub kind: PlatformEventKind,
     pub graph_revision: Option<GraphRevision>,
+    pub entity_kind: Option<EntityKind>,
+    pub entity_id: Option<EntityId>,
+    pub assertion_id: Option<AssertionDefinitionId>,
     pub occurred_at_unix_millis: i64,
     pub payload_digest: ContentDigest,
 }

--- a/crates/platform-sdk/src/subscription.rs
+++ b/crates/platform-sdk/src/subscription.rs
@@ -1,0 +1,87 @@
+use serde::Serialize;
+
+use crate::{
+    AssertionDefinitionId, ContentDigest, EntityId, EntityKind, GraphRevision, SdkError,
+    SubscriptionId, TenantId,
+};
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlatformEventKind {
+    GraphChanged,
+    AssertionChanged,
+    EvidenceBecameStale,
+    MissionWakeConditionMet,
+    ActionChanged,
+    ProjectionLagChanged,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct DurableCursor(u64);
+
+impl DurableCursor {
+    pub fn new(sequence: u64) -> Self {
+        Self(sequence)
+    }
+
+    pub fn sequence(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SubscriptionEventFilter {
+    pub event_kinds: Vec<PlatformEventKind>,
+    pub entity_kinds: Vec<EntityKind>,
+    pub entity_ids: Vec<EntityId>,
+    pub assertion_ids: Vec<AssertionDefinitionId>,
+}
+
+impl SubscriptionEventFilter {
+    pub fn is_empty(&self) -> bool {
+        self.event_kinds.is_empty()
+            && self.entity_kinds.is_empty()
+            && self.entity_ids.is_empty()
+            && self.assertion_ids.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SubscriptionDefinition {
+    pub subscription_id: SubscriptionId,
+    pub tenant_id: TenantId,
+    pub filter: SubscriptionEventFilter,
+    pub batch_limit: u16,
+    pub definition_digest: ContentDigest,
+}
+
+impl SubscriptionDefinition {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.filter.is_empty() {
+            return Err(SdkError::Empty("subscription filter"));
+        }
+        if self.batch_limit == 0 || self.batch_limit > 500 {
+            return Err(SdkError::OutOfRange("subscription batch limit"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct PlatformEvent {
+    pub cursor: DurableCursor,
+    pub tenant_id: TenantId,
+    pub kind: PlatformEventKind,
+    pub graph_revision: Option<GraphRevision>,
+    pub occurred_at_unix_millis: i64,
+    pub payload_digest: ContentDigest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SubscriptionPage {
+    pub subscription_id: SubscriptionId,
+    pub events: Vec<PlatformEvent>,
+    pub next_cursor: DurableCursor,
+    pub caught_up: bool,
+}

--- a/crates/platform-sdk/src/temporal.rs
+++ b/crates/platform-sdk/src/temporal.rs
@@ -1,0 +1,122 @@
+use serde::Serialize;
+
+use crate::{AssertionId, ContentDigest, EntityId, SdkError, TenantId};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct GraphRevision(u64);
+
+impl GraphRevision {
+    pub fn new(value: u64) -> Result<Self, SdkError> {
+        if value == 0 {
+            return Err(SdkError::OutOfRange("graph revision"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RevisionSelector {
+    Current,
+    Exact(GraphRevision),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphChangeKind {
+    EntityAdded,
+    EntityUpdated,
+    EntityRetracted,
+    AssertionAdded,
+    AssertionUpdated,
+    AssertionRetracted,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GraphChange {
+    pub kind: GraphChangeKind,
+    pub entity_id: Option<EntityId>,
+    pub assertion_id: Option<AssertionId>,
+    pub before_digest: Option<ContentDigest>,
+    pub after_digest: Option<ContentDigest>,
+    pub observed_at_unix_millis: i64,
+}
+
+impl GraphChange {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        let entity_change = matches!(
+            self.kind,
+            GraphChangeKind::EntityAdded
+                | GraphChangeKind::EntityUpdated
+                | GraphChangeKind::EntityRetracted
+        );
+        if entity_change != self.entity_id.is_some() || entity_change == self.assertion_id.is_some()
+        {
+            return Err(SdkError::Invalid("graph change target"));
+        }
+        match self.kind {
+            GraphChangeKind::EntityAdded | GraphChangeKind::AssertionAdded => {
+                if self.before_digest.is_some() || self.after_digest.is_none() {
+                    return Err(SdkError::Invalid("graph change digest"));
+                }
+            }
+            GraphChangeKind::EntityUpdated | GraphChangeKind::AssertionUpdated => {
+                if self.before_digest.is_none() || self.after_digest.is_none() {
+                    return Err(SdkError::Invalid("graph change digest"));
+                }
+            }
+            GraphChangeKind::EntityRetracted | GraphChangeKind::AssertionRetracted => {
+                if self.before_digest.is_none() || self.after_digest.is_some() {
+                    return Err(SdkError::Invalid("graph change digest"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GraphDiffRequest {
+    pub tenant_id: TenantId,
+    pub from_revision: GraphRevision,
+    pub to_revision: RevisionSelector,
+    pub limit: u32,
+    pub cursor: Option<String>,
+}
+
+impl GraphDiffRequest {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.limit == 0 || self.limit > 500 {
+            return Err(SdkError::OutOfRange("graph diff limit"));
+        }
+        if let RevisionSelector::Exact(to_revision) = self.to_revision
+            && to_revision <= self.from_revision
+        {
+            return Err(SdkError::Invalid("graph diff revision window"));
+        }
+        if self
+            .cursor
+            .as_ref()
+            .is_some_and(|cursor| cursor.is_empty() || cursor.len() > 512)
+        {
+            return Err(SdkError::Invalid("graph diff cursor"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GraphDiff {
+    pub tenant_id: TenantId,
+    pub from_revision: GraphRevision,
+    pub to_revision: GraphRevision,
+    pub changes: Vec<GraphChange>,
+    pub next_cursor: Option<String>,
+    pub truncated: bool,
+    pub digest: ContentDigest,
+}

--- a/crates/platform-sdk/src/traits.rs
+++ b/crates/platform-sdk/src/traits.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+
+use crate::{
+    ActionOperation, ActionOperationId, ActionProposal, ActionReceipt, AssertionDefinition,
+    AssertionDefinitionId, AssertionEvaluation, DurableCursor, EntityId, GraphDiff,
+    GraphDiffRequest, IncidentSnapshot, IncidentSnapshotId, MaterializedViewDefinition,
+    MaterializedViewSnapshot, OperationalDiagnostics, PlatformEvent, ProvenanceExplanation,
+    RecoveryReport, SdkError, SimulationRequest, SimulationResult, SubscriptionDefinition,
+    SubscriptionId, SubscriptionPage, TenantId, ViewId,
+};
+
+/// Transport-neutral capability surface implemented by in-process, Connect,
+/// HTTP, and test adapters. Implementations may expose only capabilities their
+/// deployment owns; unsupported calls return [`SdkError::CapabilityUnavailable`].
+#[async_trait]
+pub trait PlatformApi: Send + Sync {
+    async fn graph_diff(&self, request: GraphDiffRequest) -> Result<GraphDiff, SdkError>;
+
+    async fn explain_entity(
+        &self,
+        tenant_id: &TenantId,
+        entity_id: &EntityId,
+    ) -> Result<ProvenanceExplanation, SdkError>;
+
+    async fn put_assertion(
+        &self,
+        definition: AssertionDefinition,
+    ) -> Result<AssertionDefinition, SdkError>;
+
+    async fn evaluate_assertion(
+        &self,
+        tenant_id: &TenantId,
+        assertion_id: &AssertionDefinitionId,
+    ) -> Result<AssertionEvaluation, SdkError>;
+
+    async fn simulate(&self, request: SimulationRequest) -> Result<SimulationResult, SdkError>;
+
+    async fn put_subscription(
+        &self,
+        definition: SubscriptionDefinition,
+    ) -> Result<SubscriptionDefinition, SdkError>;
+
+    async fn poll_subscription(
+        &self,
+        tenant_id: &TenantId,
+        subscription_id: &SubscriptionId,
+        cursor: DurableCursor,
+    ) -> Result<SubscriptionPage, SdkError>;
+
+    async fn acknowledge_event(
+        &self,
+        tenant_id: &TenantId,
+        subscription_id: &SubscriptionId,
+        event: &PlatformEvent,
+    ) -> Result<(), SdkError>;
+
+    async fn put_materialized_view(
+        &self,
+        definition: MaterializedViewDefinition,
+    ) -> Result<MaterializedViewDefinition, SdkError>;
+
+    async fn get_materialized_view(
+        &self,
+        tenant_id: &TenantId,
+        view_id: &ViewId,
+    ) -> Result<MaterializedViewSnapshot, SdkError>;
+
+    async fn create_incident_snapshot(
+        &self,
+        tenant_id: &TenantId,
+        entity_ids: Vec<EntityId>,
+    ) -> Result<IncidentSnapshot, SdkError>;
+
+    async fn get_incident_snapshot(
+        &self,
+        tenant_id: &TenantId,
+        snapshot_id: &IncidentSnapshotId,
+    ) -> Result<IncidentSnapshot, SdkError>;
+
+    async fn propose_action(&self, proposal: ActionProposal) -> Result<ActionOperation, SdkError>;
+
+    async fn get_action(
+        &self,
+        tenant_id: &TenantId,
+        operation_id: &ActionOperationId,
+    ) -> Result<ActionOperation, SdkError>;
+
+    async fn reconcile_action(
+        &self,
+        tenant_id: &TenantId,
+        operation_id: &ActionOperationId,
+    ) -> Result<ActionReceipt, SdkError>;
+
+    async fn diagnostics(&self, tenant_id: &TenantId) -> Result<OperationalDiagnostics, SdkError>;
+
+    async fn verify_recovery(&self, tenant_id: &TenantId) -> Result<RecoveryReport, SdkError>;
+}

--- a/crates/platform-sdk/src/view.rs
+++ b/crates/platform-sdk/src/view.rs
@@ -1,0 +1,48 @@
+use serde::Serialize;
+
+use crate::{ContentDigest, FactQuery, GraphRevision, SdkError, TenantId, ViewId};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ViewRefreshState {
+    Current,
+    Pending,
+    Rebuilding,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MaterializedViewDefinition {
+    pub view_id: ViewId,
+    pub tenant_id: TenantId,
+    pub name: String,
+    pub query: FactQuery,
+    pub max_rows: u32,
+    pub definition_digest: ContentDigest,
+}
+
+impl MaterializedViewDefinition {
+    pub fn validate(&self) -> Result<(), SdkError> {
+        if self.name.trim() != self.name || self.name.is_empty() {
+            return Err(SdkError::Invalid("materialized view name"));
+        }
+        if self.name.len() > 256 {
+            return Err(SdkError::TooLong("materialized view name"));
+        }
+        if self.max_rows == 0 || self.max_rows > 10_000 {
+            return Err(SdkError::OutOfRange("materialized view max rows"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MaterializedViewSnapshot {
+    pub view_id: ViewId,
+    pub tenant_id: TenantId,
+    pub graph_revision: GraphRevision,
+    pub row_count: u32,
+    pub state: ViewRefreshState,
+    pub refreshed_at_unix_millis: i64,
+    pub result_digest: ContentDigest,
+}

--- a/crates/platform-sdk/src/view.rs
+++ b/crates/platform-sdk/src/view.rs
@@ -29,7 +29,8 @@ impl MaterializedViewDefinition {
         if self.name.len() > 256 {
             return Err(SdkError::TooLong("materialized view name"));
         }
-        if self.max_rows == 0 || self.max_rows > 10_000 {
+        if self.max_rows == 0 || self.max_rows > 500 || self.max_rows as usize > self.query.limit()
+        {
             return Err(SdkError::OutOfRange("materialized view max rows"));
         }
         Ok(())

--- a/crates/platform-sdk/tests/contracts.rs
+++ b/crates/platform-sdk/tests/contracts.rs
@@ -1,0 +1,155 @@
+use cerebro_platform_sdk::{
+    AnalysisPluginManifest, AssertionDefinitionId, BudgetError, ContentDigest, EntityId,
+    EvidenceQuality, GraphChange, GraphChangeKind, GraphDiffRequest, GraphRevision, OpaqueId,
+    PluginCapability, PluginId, PluginLimits, ProposedChange, ResourceBudget, ResourceUsage,
+    RevisionSelector, SimulationId, SimulationRequest, SubscriptionDefinition,
+    SubscriptionEventFilter, SubscriptionId, TenantId,
+};
+
+fn tenant() -> TenantId {
+    TenantId::parse("tenant-a").expect("valid tenant")
+}
+
+fn digest(value: &str) -> ContentDigest {
+    ContentDigest::of_bytes(value)
+}
+
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(500, 6, 2_000, 8, 100, 10_000, 64 * 1024 * 1024, 1_000)
+        .expect("valid budget")
+}
+
+#[test]
+fn resource_budgets_reject_zero_limits_and_excess_usage() {
+    assert_eq!(
+        ResourceBudget::new(0, 6, 2_000, 8, 100, 10_000, 64 * 1024 * 1024, 1_000),
+        Err(BudgetError::Zero("max query results"))
+    );
+
+    let usage = ResourceUsage {
+        query_results: 501,
+        query_depth: 6,
+        query_millis: 2_000,
+        concurrent_queries: 8,
+        subscription_batch: 100,
+        snapshot_entities: 10_000,
+        plugin_memory_bytes: 64 * 1024 * 1024,
+        plugin_millis: 1_000,
+    };
+    assert_eq!(
+        usage.validate(&budget()),
+        Err(BudgetError::UsageExceedsLimit("query results"))
+    );
+}
+
+#[test]
+fn graph_diffs_require_a_forward_bounded_window() {
+    let revision = GraphRevision::new(10).expect("valid revision");
+    let request = GraphDiffRequest {
+        tenant_id: tenant(),
+        from_revision: revision,
+        to_revision: RevisionSelector::Exact(revision),
+        limit: 500,
+        cursor: None,
+    };
+    assert!(request.validate().is_err());
+
+    let valid = GraphDiffRequest {
+        to_revision: RevisionSelector::Exact(GraphRevision::new(11).expect("valid revision")),
+        ..request
+    };
+    assert!(valid.validate().is_ok());
+}
+
+#[test]
+fn graph_changes_require_one_target_and_kind_specific_digests() {
+    let change = GraphChange {
+        kind: GraphChangeKind::EntityAdded,
+        entity_id: Some(EntityId::parse("repository:one").expect("valid entity")),
+        assertion_id: None,
+        before_digest: None,
+        after_digest: Some(digest("after")),
+        observed_at_unix_millis: 1,
+    };
+    assert!(change.validate().is_ok());
+
+    let invalid = GraphChange {
+        after_digest: None,
+        ..change
+    };
+    assert!(invalid.validate().is_err());
+}
+
+#[test]
+fn evidence_quality_is_bounded_and_conservative() {
+    let quality = EvidenceQuality::new(90, 80, 70, 60, 50, false).expect("valid quality");
+    assert_eq!(quality.minimum_score(), 50);
+    assert!(EvidenceQuality::new(101, 80, 70, 60, 50, false).is_err());
+}
+
+#[test]
+fn simulations_are_read_only_and_bounded() {
+    let request = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:one").expect("valid simulation"),
+        tenant_id: tenant(),
+        base_revision: GraphRevision::new(1).expect("valid revision"),
+        changes: vec![ProposedChange::RemoveEntity {
+            entity_id: EntityId::parse("repository:one").expect("valid entity"),
+        }],
+        assertions: vec![
+            AssertionDefinitionId::parse("assertion-definition:one")
+                .expect("valid assertion definition"),
+        ],
+        max_affected_entities: 10_000,
+    };
+    assert!(request.validate().is_ok());
+}
+
+#[test]
+fn subscriptions_require_a_filter_and_bounded_batches() {
+    let empty_filter = SubscriptionEventFilter {
+        event_kinds: Vec::new(),
+        entity_kinds: Vec::new(),
+        entity_ids: Vec::new(),
+        assertion_ids: Vec::new(),
+    };
+    let subscription = SubscriptionDefinition {
+        subscription_id: SubscriptionId::parse("subscription:one").expect("valid subscription"),
+        tenant_id: tenant(),
+        filter: empty_filter,
+        batch_limit: 100,
+        definition_digest: digest("subscription"),
+    };
+    assert!(subscription.validate().is_err());
+}
+
+#[test]
+fn first_party_plugins_require_deterministic_zero_import_execution() {
+    let manifest = AnalysisPluginManifest {
+        plugin_id: PluginId::parse("plugin:one").expect("valid plugin"),
+        abi_version: "v1".to_owned(),
+        artifact_digest: digest("plugin"),
+        capabilities: vec![PluginCapability::AssertionEvaluation],
+        limits: PluginLimits {
+            memory_bytes: 64 * 1024 * 1024,
+            execution_millis: 1_000,
+            input_bytes: 1024,
+            output_bytes: 1024,
+        },
+        zero_imports_required: true,
+        deterministic_output_required: true,
+    };
+    assert!(manifest.validate().is_ok());
+
+    let unsafe_manifest = AnalysisPluginManifest {
+        zero_imports_required: false,
+        ..manifest
+    };
+    assert!(unsafe_manifest.validate().is_err());
+}
+
+#[test]
+fn opaque_ids_reject_display_labels() {
+    assert!(OpaqueId::parse("mission:one").is_ok());
+    assert!(OpaqueId::parse("Mission One").is_err());
+}

--- a/crates/platform-sdk/tests/contracts.rs
+++ b/crates/platform-sdk/tests/contracts.rs
@@ -124,7 +124,7 @@ fn assertion_conditions_have_explicit_match_semantics() {
 
 #[test]
 fn simulations_are_read_only_and_bounded() {
-    let request = SimulationRequest {
+    let mut request = SimulationRequest {
         simulation_id: SimulationId::parse("simulation:one").expect("valid simulation"),
         tenant_id: tenant(),
         base_revision: GraphRevision::new(1).expect("valid revision"),
@@ -138,6 +138,15 @@ fn simulations_are_read_only_and_bounded() {
         max_affected_entities: 10_000,
     };
     assert!(request.validate().is_ok());
+    request.assertions = vec![
+        AssertionDefinitionId::parse("assertion-definition:one")
+            .expect("valid assertion definition");
+        101
+    ];
+    assert_eq!(
+        request.validate(),
+        Err(SdkError::OutOfRange("simulation assertions"))
+    );
 }
 
 #[test]
@@ -190,11 +199,17 @@ fn first_party_plugins_require_deterministic_zero_import_execution() {
     };
     assert!(manifest.validate().is_ok());
 
-    let unsafe_manifest = AnalysisPluginManifest {
+    let mut unsafe_manifest = AnalysisPluginManifest {
         zero_imports_required: false,
         ..manifest
     };
     assert!(unsafe_manifest.validate().is_err());
+    unsafe_manifest.zero_imports_required = true;
+    unsafe_manifest.abi_version = "v".repeat(129);
+    assert_eq!(
+        unsafe_manifest.validate(),
+        Err(SdkError::TooLong("plugin ABI version"))
+    );
 }
 
 #[test]
@@ -344,6 +359,12 @@ fn incident_snapshots_require_receipts_payload_integrity_and_signatures() {
     assert_eq!(
         invalid_manifest.validate(),
         Err(SdkError::Empty("incident snapshot source receipts"))
+    );
+    invalid_manifest.source_receipt_digests = vec![digest("source receipt")];
+    invalid_manifest.policy_digests = vec![digest("policy"); 10_001];
+    assert_eq!(
+        invalid_manifest.validate(),
+        Err(SdkError::OutOfRange("incident snapshot policy count"))
     );
 
     let mut invalid = snapshot.clone();

--- a/crates/platform-sdk/tests/contracts.rs
+++ b/crates/platform-sdk/tests/contracts.rs
@@ -1,10 +1,13 @@
 use cerebro_platform_sdk::{
     ActionEffect, ActionOperationId, ActionProposal, AnalysisPluginManifest, AssertionCondition,
-    AssertionDefinitionId, BudgetError, ContentDigest, EntityId, EvidenceQuality, GraphChange,
-    GraphChangeKind, GraphDiffRequest, GraphRevision, OpaqueId, PlatformEventKind,
-    PluginCapability, PluginId, PluginLimits, ProposedChange, ResourceBudget, ResourceUsage,
-    RevisionSelector, SimulationId, SimulationRequest, SubscriptionDefinition,
-    SubscriptionEventFilter, SubscriptionId, TenantId,
+    AssertionDefinition, AssertionDefinitionId, BudgetError, ContentDigest, EntityId,
+    EvaluationTrigger, EvidenceAuthority, EvidenceQuality, EvidenceReference, FactQuery,
+    GraphChange, GraphChangeKind, GraphDiffRequest, GraphRevision, IncidentSnapshot,
+    IncidentSnapshotId, IncidentSnapshotManifest, MaterializedViewDefinition, OpaqueId,
+    PlatformEventKind, PluginCapability, PluginId, PluginLimits, ProposedChange,
+    ProvenanceExplanation, QueryNode, ResourceBudget, ResourceUsage, RevisionSelector, SdkError,
+    SimulationId, SimulationRequest, SourceRuntimeId, SubscriptionDefinition,
+    SubscriptionEventFilter, SubscriptionId, TenantId, ViewId,
 };
 
 fn tenant() -> TenantId {
@@ -18,6 +21,20 @@ fn digest(value: &str) -> ContentDigest {
 fn budget() -> ResourceBudget {
     ResourceBudget::new(500, 6, 2_000, 8, 100, 10_000, 64 * 1024 * 1024, 1_000)
         .expect("valid budget")
+}
+
+fn query(limit: usize) -> FactQuery {
+    FactQuery::new(
+        vec![QueryNode {
+            variable: "repository".to_owned(),
+            kinds: vec!["repository".to_owned()],
+            keys: Vec::new(),
+        }],
+        Vec::new(),
+        Vec::new(),
+        limit,
+    )
+    .expect("valid query")
 }
 
 #[test]
@@ -216,4 +233,200 @@ fn action_proposals_reject_duplicate_or_untyped_effects() {
         ..proposal
     };
     assert!(invalid_kind.validate().is_err());
+}
+
+#[test]
+fn sdk_errors_preserve_specific_operator_messages() {
+    let cases = [
+        (SdkError::Empty("value"), "value is required"),
+        (SdkError::Invalid("value"), "value is invalid"),
+        (SdkError::TooLong("value"), "value exceeds its size limit"),
+        (
+            SdkError::OutOfRange("value"),
+            "value is outside its allowed range",
+        ),
+        (
+            SdkError::Conflict("revision".to_owned()),
+            "platform conflict: revision",
+        ),
+        (
+            SdkError::NotFound("entity".to_owned()),
+            "platform value not found: entity",
+        ),
+        (
+            SdkError::CapabilityUnavailable("diff".to_owned()),
+            "platform capability unavailable: diff",
+        ),
+        (
+            SdkError::Backend("postgres".to_owned()),
+            "platform backend failed: postgres",
+        ),
+    ];
+    for (error, expected) in cases {
+        assert_eq!(error.to_string(), expected);
+    }
+}
+
+#[test]
+fn assertion_definitions_validate_names_triggers_freshness_and_conditions() {
+    let definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:one")
+            .expect("valid assertion definition"),
+        tenant_id: tenant(),
+        name: "Repository ownership remains explicit".to_owned(),
+        query: query(25),
+        condition: AssertionCondition::NoMatches,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("assertion"),
+    };
+    assert!(definition.validate().is_ok());
+
+    let mut invalid = definition.clone();
+    invalid.name = " padded ".to_owned();
+    assert_eq!(invalid.validate(), Err(SdkError::Invalid("assertion name")));
+    invalid.name = "x".repeat(257);
+    assert_eq!(invalid.validate(), Err(SdkError::TooLong("assertion name")));
+    invalid.name = "valid".to_owned();
+    invalid.triggers.clear();
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::Empty("assertion triggers"))
+    );
+    invalid.triggers.push(EvaluationTrigger::Manual);
+    invalid.evidence_max_age_seconds = 0;
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::OutOfRange("assertion evidence max age"))
+    );
+    invalid.evidence_max_age_seconds = 1;
+    invalid.condition = AssertionCondition::MatchCountAtLeast(0);
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::OutOfRange("assertion minimum match count"))
+    );
+}
+
+#[test]
+fn incident_snapshots_require_receipts_payload_integrity_and_signatures() {
+    let manifest = IncidentSnapshotManifest {
+        snapshot_id: IncidentSnapshotId::parse("incident-snapshot:one").expect("valid snapshot"),
+        tenant_id: tenant(),
+        graph_revision: GraphRevision::new(1).expect("valid revision"),
+        created_at_unix_millis: 1,
+        entity_ids: vec![EntityId::parse("repository:one").expect("valid entity")],
+        source_receipt_digests: vec![digest("source receipt")],
+        policy_digests: vec![digest("policy")],
+        mission_ids: vec![OpaqueId::parse("mission:one").expect("valid mission")],
+        verification_receipt_digests: vec![digest("verification receipt")],
+        manifest_digest: digest("manifest"),
+    };
+    let payload = b"canonical incident snapshot".to_vec();
+    let snapshot = IncidentSnapshot {
+        manifest: manifest.clone(),
+        payload_digest: ContentDigest::of_bytes(&payload),
+        canonical_payload: payload,
+        signature: vec![1, 2, 3],
+    };
+    assert!(snapshot.validate().is_ok());
+
+    let mut invalid_manifest = manifest;
+    invalid_manifest.entity_ids.clear();
+    assert_eq!(
+        invalid_manifest.validate(),
+        Err(SdkError::OutOfRange("incident snapshot entity count"))
+    );
+    invalid_manifest
+        .entity_ids
+        .push(EntityId::parse("repository:one").expect("valid entity"));
+    invalid_manifest.source_receipt_digests.clear();
+    assert_eq!(
+        invalid_manifest.validate(),
+        Err(SdkError::Empty("incident snapshot source receipts"))
+    );
+
+    let mut invalid = snapshot.clone();
+    invalid.canonical_payload.clear();
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::Empty("incident snapshot payload"))
+    );
+    invalid = snapshot.clone();
+    invalid.payload_digest = digest("wrong");
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::Invalid("incident snapshot payload digest"))
+    );
+    invalid = snapshot;
+    invalid.signature.clear();
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::Empty("incident snapshot signature"))
+    );
+}
+
+#[test]
+fn materialized_views_cannot_escape_query_or_platform_bounds() {
+    let view = MaterializedViewDefinition {
+        view_id: ViewId::parse("view:one").expect("valid view"),
+        tenant_id: tenant(),
+        name: "High-risk repositories".to_owned(),
+        query: query(100),
+        max_rows: 100,
+        definition_digest: digest("view"),
+    };
+    assert!(view.validate().is_ok());
+
+    let mut invalid = view.clone();
+    invalid.name = String::new();
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::Invalid("materialized view name"))
+    );
+    invalid.name = "x".repeat(257);
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::TooLong("materialized view name"))
+    );
+    invalid.name = "valid".to_owned();
+    invalid.max_rows = 101;
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::OutOfRange("materialized view max rows"))
+    );
+}
+
+#[test]
+fn provenance_requires_one_target_and_at_least_one_evidence_reference() {
+    let explanation = ProvenanceExplanation {
+        tenant_id: tenant(),
+        graph_revision: GraphRevision::new(1).expect("valid revision"),
+        entity_id: Some(EntityId::parse("repository:one").expect("valid entity")),
+        assertion_id: None,
+        evidence: vec![EvidenceReference {
+            evidence_id: OpaqueId::parse("evidence:one").expect("valid evidence"),
+            source_runtime_id: SourceRuntimeId::parse("github-prod").expect("valid runtime"),
+            event_id: OpaqueId::parse("event:one").expect("valid event"),
+            observed_at_unix_millis: 1,
+            authority: EvidenceAuthority::Authoritative,
+            content_digest: digest("evidence"),
+        }],
+        quality: EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("valid quality"),
+        explanation_digest: digest("explanation"),
+    };
+    assert!(explanation.validate().is_ok());
+
+    let mut invalid = explanation.clone();
+    invalid.entity_id = None;
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::Invalid("provenance target"))
+    );
+    invalid = explanation;
+    invalid.evidence.clear();
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::Empty("provenance evidence"))
+    );
 }

--- a/crates/platform-sdk/tests/contracts.rs
+++ b/crates/platform-sdk/tests/contracts.rs
@@ -1,8 +1,9 @@
 use cerebro_platform_sdk::{
-    AnalysisPluginManifest, AssertionCondition, AssertionDefinitionId, BudgetError, ContentDigest,
-    EntityId, EvidenceQuality, GraphChange, GraphChangeKind, GraphDiffRequest, GraphRevision,
-    OpaqueId, PluginCapability, PluginId, PluginLimits, ProposedChange, ResourceBudget,
-    ResourceUsage, RevisionSelector, SimulationId, SimulationRequest, SubscriptionDefinition,
+    ActionEffect, ActionOperationId, ActionProposal, AnalysisPluginManifest, AssertionCondition,
+    AssertionDefinitionId, BudgetError, ContentDigest, EntityId, EvidenceQuality, GraphChange,
+    GraphChangeKind, GraphDiffRequest, GraphRevision, OpaqueId, PlatformEventKind,
+    PluginCapability, PluginId, PluginLimits, ProposedChange, ResourceBudget, ResourceUsage,
+    RevisionSelector, SimulationId, SimulationRequest, SubscriptionDefinition,
     SubscriptionEventFilter, SubscriptionId, TenantId,
 };
 
@@ -39,6 +40,14 @@ fn resource_budgets_reject_zero_limits_and_excess_usage() {
     assert_eq!(
         usage.validate(&budget()),
         Err(BudgetError::UsageExceedsLimit("query results"))
+    );
+    assert_eq!(
+        ResourceBudget::new(501, 6, 2_000, 8, 100, 10_000, 64 * 1024 * 1024, 1_000),
+        Err(BudgetError::ExceedsMaximum("max query results"))
+    );
+    assert_eq!(
+        ResourceBudget::new(500, 7, 2_000, 8, 100, 10_000, 64 * 1024 * 1024, 1_000),
+        Err(BudgetError::ExceedsMaximum("max query depth"))
     );
 }
 
@@ -130,6 +139,20 @@ fn subscriptions_require_a_filter_and_bounded_batches() {
         definition_digest: digest("subscription"),
     };
     assert!(subscription.validate().is_err());
+
+    let duplicate = SubscriptionDefinition {
+        filter: SubscriptionEventFilter {
+            event_kinds: vec![
+                PlatformEventKind::GraphChanged,
+                PlatformEventKind::GraphChanged,
+            ],
+            entity_kinds: Vec::new(),
+            entity_ids: Vec::new(),
+            assertion_ids: Vec::new(),
+        },
+        ..subscription
+    };
+    assert!(duplicate.validate().is_err());
 }
 
 #[test]
@@ -161,4 +184,36 @@ fn first_party_plugins_require_deterministic_zero_import_execution() {
 fn opaque_ids_reject_display_labels() {
     assert!(OpaqueId::parse("mission:one").is_ok());
     assert!(OpaqueId::parse("Mission One").is_err());
+}
+
+#[test]
+fn action_proposals_reject_duplicate_or_untyped_effects() {
+    let effect = ActionEffect {
+        target_id: OpaqueId::parse("grant:one").expect("valid target"),
+        effect_kind: "access_removed".to_owned(),
+        expected_state_digest: digest("expected"),
+    };
+    let proposal = ActionProposal {
+        operation_id: ActionOperationId::parse("operation:one").expect("valid operation"),
+        tenant_id: tenant(),
+        graph_revision: GraphRevision::new(1).expect("valid revision"),
+        action_kind: "revoke_access".to_owned(),
+        target_id: OpaqueId::parse("grant:one").expect("valid target"),
+        expected_effects: vec![effect.clone(), effect],
+        rollback_ref: OpaqueId::parse("rollback:one").expect("valid rollback"),
+        idempotency_key: OpaqueId::parse("idempotency:one").expect("valid key"),
+        simulation_digest: digest("simulation"),
+        proposal_digest: digest("proposal"),
+    };
+    assert!(proposal.validate().is_err());
+
+    let invalid_kind = ActionProposal {
+        expected_effects: vec![ActionEffect {
+            target_id: OpaqueId::parse("grant:one").expect("valid target"),
+            effect_kind: "Access removed".to_owned(),
+            expected_state_digest: digest("expected"),
+        }],
+        ..proposal
+    };
+    assert!(invalid_kind.validate().is_err());
 }

--- a/crates/platform-sdk/tests/contracts.rs
+++ b/crates/platform-sdk/tests/contracts.rs
@@ -1,8 +1,8 @@
 use cerebro_platform_sdk::{
-    AnalysisPluginManifest, AssertionDefinitionId, BudgetError, ContentDigest, EntityId,
-    EvidenceQuality, GraphChange, GraphChangeKind, GraphDiffRequest, GraphRevision, OpaqueId,
-    PluginCapability, PluginId, PluginLimits, ProposedChange, ResourceBudget, ResourceUsage,
-    RevisionSelector, SimulationId, SimulationRequest, SubscriptionDefinition,
+    AnalysisPluginManifest, AssertionCondition, AssertionDefinitionId, BudgetError, ContentDigest,
+    EntityId, EvidenceQuality, GraphChange, GraphChangeKind, GraphDiffRequest, GraphRevision,
+    OpaqueId, PluginCapability, PluginId, PluginLimits, ProposedChange, ResourceBudget,
+    ResourceUsage, RevisionSelector, SimulationId, SimulationRequest, SubscriptionDefinition,
     SubscriptionEventFilter, SubscriptionId, TenantId,
 };
 
@@ -85,6 +85,15 @@ fn evidence_quality_is_bounded_and_conservative() {
     let quality = EvidenceQuality::new(90, 80, 70, 60, 50, false).expect("valid quality");
     assert_eq!(quality.minimum_score(), 50);
     assert!(EvidenceQuality::new(101, 80, 70, 60, 50, false).is_err());
+}
+
+#[test]
+fn assertion_conditions_have_explicit_match_semantics() {
+    assert!(AssertionCondition::NoMatches.evaluate(0));
+    assert!(!AssertionCondition::NoMatches.evaluate(1));
+    assert!(AssertionCondition::AtLeastOneMatch.evaluate(1));
+    assert!(AssertionCondition::MatchCountAtMost(2).evaluate(2));
+    assert!(AssertionCondition::MatchCountAtLeast(2).evaluate(3));
 }
 
 #[test]

--- a/crates/platform-sdk/tests/contracts.rs
+++ b/crates/platform-sdk/tests/contracts.rs
@@ -444,10 +444,15 @@ fn provenance_requires_one_target_and_at_least_one_evidence_reference() {
         invalid.validate(),
         Err(SdkError::Invalid("provenance target"))
     );
-    invalid = explanation;
+    invalid = explanation.clone();
     invalid.evidence.clear();
     assert_eq!(
         invalid.validate(),
         Err(SdkError::Empty("provenance evidence"))
+    );
+    invalid.evidence = vec![explanation.evidence[0].clone(); 10_001];
+    assert_eq!(
+        invalid.validate(),
+        Err(SdkError::OutOfRange("provenance evidence count"))
     );
 }

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -146,6 +146,11 @@ Language-level constraints prevent accidental bypass inside Rust. Production aut
    restarts the Rust service, and reads the recovered graph through both the
    generated agent RPC and the native product HTTP route.
 
+Before a read family changes authority, the Go API may remain the temporary
+read authority while a bounded sample is compared with Rust. That adapter must
+return the Go result, tolerate Rust unavailability, emit only bounded comparison
+labels, and must not receive graph-write credentials or project graph changes.
+
 Repository conventions and review are not the security boundary. Store credentials and workload identity are.
 
 ## Source coverage migration

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -206,7 +206,11 @@ Go projector                Rust mapper
                          Neo4j outbox apply
 ```
 
-`cerebro-platform promote-family` evaluates stored parity receipts and records Rust authority. `cerebro-platform show-authority` reads the effective record. Both use `CEREBRO_POSTGRES_DSN` plus `CEREBRO_TENANT_ID`, `CEREBRO_SOURCE_ID`, and `CEREBRO_SOURCE_FAMILY`.
+`cerebro-platform evaluate-family` evaluates stored parity receipts without changing authority. `cerebro-platform promote-family` repeats that evaluation and records Rust authority. `cerebro-platform show-authority` reads the effective record. These commands use `CEREBRO_POSTGRES_DSN` plus `CEREBRO_TENANT_ID`, `CEREBRO_SOURCE_ID`, and `CEREBRO_SOURCE_FAMILY`.
+
+`cerebro-platform serve-neo4j-readonly` opens only the bounded Neo4j read plane. It does not connect to PostgreSQL, run store migrations, expose a projection runtime, or consume the append log. Use this process for pre-cutover shadow and read canaries. `serve-neo4j` adds the projection API, while `serve-neo4j-consumer` also starts append-log consumption.
+
+Every server mode exposes Prometheus request counters and latency histograms on `/metrics`. Operation labels come from a fixed route vocabulary; tenant IDs, entity IDs, request paths, and evidence do not enter metric labels.
 
 ## Performance shape
 

--- a/docs/engineering/rust-platform-sdk.md
+++ b/docs/engineering/rust-platform-sdk.md
@@ -1,0 +1,79 @@
+# Rust Platform SDK
+
+## Decision
+
+Cerebro exposes one reusable, transport-neutral Rust SDK for platform
+capabilities. The SDK composes the existing sealed organizational model,
+bounded fact-query model, and control kernel. It does not copy their types or
+reimplement their validation rules.
+
+The SDK owns:
+
+- validated platform capability identifiers and content digests;
+- graph revision selectors and bounded temporal diff contracts;
+- evidence quality and provenance explanation contracts;
+- continuous assertion definitions and evaluations;
+- counterfactual simulation requests and results;
+- durable subscription filters, cursors, and event pages;
+- materialized-view definitions and revision-bound snapshots;
+- signed incident snapshot manifests;
+- governed action proposals, operation state, and receipts;
+- per-tenant resource budgets and operational diagnostics;
+- disaster-recovery verification reports;
+- first-party, zero-import deterministic analysis-plugin manifests; and
+- one adapter trait implemented by in-process, Connect, HTTP, and test clients.
+
+The SDK does not own transport, storage, graph mutation, provider access,
+scheduling, deployment, or model execution.
+
+## Reuse boundary
+
+```text
+cerebro-organizational-model
+        |
+cerebro-agent-context     cerebro-control-kernel
+        |                         |
+        +------ cerebro-platform-sdk ------+
+                                             |
+                      +----------------------+------------------+
+                      |                      |                  |
+                in-process adapter      Connect adapter    test adapter
+                      |
+          JetStream + Postgres + Neo4j authorities
+```
+
+`cerebro-platform-sdk` is the only handwritten semantic contract for these
+capabilities. Generated Connect, Go, TypeScript, and Python clients adapt the
+versioned wire contract to the SDK vocabulary. They do not independently
+decide limits, lifecycle state, authority, evidence quality, or verification
+semantics.
+
+## Non-goal alignment
+
+- JetStream remains the log of record, Postgres remains current state, and
+  Neo4j remains a rebuildable projection. The SDK introduces no store.
+- Temporal queries reconstruct bounded history from the ledger and log. They
+  do not make Neo4j authoritative.
+- Simulations are read-only. Mutations use governed Action contracts.
+- Subscriptions use durable cursors and typed filters. They do not expose
+  arbitrary Cypher.
+- Analysis plugins remain first-party, release-provenanced, zero-import,
+  deterministic Wasm modules with fixed limits. This is not a plugin
+  marketplace.
+- The mission surface composes the reviewed native control-kernel carve. It
+  does not expand the Go action engine into a generic workflow runtime.
+
+## Delivery order
+
+1. SDK identities, revisions, digests, limits, contracts, and adapter trait.
+2. Postgres temporal ledger reads and provenance assembly.
+3. Pure continuous-assertion and counterfactual-simulation engines.
+4. JetStream subscription adapter and Postgres materialized-view projection.
+5. Incident snapshot packaging and verification.
+6. Governed action and mission adapters over the existing durable workflows.
+7. Diagnostics, tenant budgets, and disaster-recovery verification.
+8. Fixed-ABI first-party analysis plugin adapter.
+9. Generated Connect, Go, TypeScript, and Python clients plus conformance tests.
+
+Each layer must retain the same SDK types and fail closed when its required
+authority is unavailable.

--- a/docs/operations/hosting.md
+++ b/docs/operations/hosting.md
@@ -268,8 +268,12 @@ Use managed Postgres or an operationally equivalent deployment for shared enviro
 | `CEREBRO_NEO4J_PASSWORD` | Graph database password. Store as a secret. |
 | `CEREBRO_NEO4J_DATABASE` | Optional database name. Leave unset to use the server default. |
 | `CEREBRO_NEO4J_QUERY_TIMEOUT` | Optional timeout for read transactions. |
-| `CEREBRO_ORGANIZATIONAL_GRAPH_URL` | Rust organizational graph service origin. Setting it enables bounded shadow reads and family-level projection authority. |
-| `CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET` | Secret used to sign tenant-bound graph requests. Required with the graph URL and must be at least 32 bytes. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_URL` | Legacy combined Rust graph origin. Prefer the separate read and projection origins. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL` | Rust bounded-read origin. It can be enabled without configuring projection writes. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_PROJECTION_URL` | Rust family-authority and projection origin. Keep it unset during read-only staging. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE` | `shadow` keeps Go authoritative and compares sampled Rust reads; `authority` returns Rust reads and fails closed. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT` | Stable sampled-read percentage for shadow mode. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET` | Secret used to sign tenant-bound graph requests. Required with any Rust graph origin and must be at least 32 bytes. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT` | Rust graph request timeout. Defaults to `1s`. |
 
 Monitor graph ingest health, query latency, index health, and storage growth. Keep graph credentials scoped to the required database.

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -68,8 +68,12 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_NEO4J_PASSWORD` | unset | Neo4j/Aura password. |
 | `CEREBRO_NEO4J_DATABASE` | unset | Optional Neo4j database name. |
 | `CEREBRO_NEO4J_QUERY_TIMEOUT` | unset | Optional timeout applied to Neo4j read transactions. |
-| `CEREBRO_ORGANIZATIONAL_GRAPH_URL` | unset | Rust organizational graph service origin. When set, bounded graph reads run in shadow and source projection uses the persisted family authority. |
-| `CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET` | unset | Shared secret used to sign tenant-bound requests to the Rust organizational graph service. Required with `CEREBRO_ORGANIZATIONAL_GRAPH_URL`; minimum 32 bytes. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_URL` | unset | Legacy combined Rust graph origin. Prefer the separate read and projection origins so observing reads cannot activate a writer path. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL` | unset | Rust bounded graph read origin. This does not configure Rust projection writes. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_PROJECTION_URL` | unset | Rust family-authority and projection origin. Leave unset until the Rust writer path is intentionally enabled. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE` | `authority` | `shadow` returns the legacy result and compares sampled Rust reads; `authority` returns the Rust result and fails closed. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT` | `0` | Stable percentage from 1 through 100 of typed reads compared in shadow mode. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET` | unset | Shared secret used to sign tenant-bound requests to the Rust organizational graph service. Required with any Rust graph origin; minimum 32 bytes. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT` | `1s` | Timeout for Rust organizational graph reads and projection-authority requests. |
 
 `CEREBRO_KUZU_PATH` is rejected. Kuzu is no longer a supported graph backend.

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -87,17 +87,44 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	default:
 		return fail(fmt.Errorf("unsupported graph store driver %q", cfg.GraphStore.Driver))
 	}
-	if cfg.OrganizationalGraph.BaseURL != "" {
-		projectionClient, err := organizationalgraph.NewProjectionClient(cfg.OrganizationalGraph.BaseURL, cfg.OrganizationalGraph.SharedSecret, cfg.OrganizationalGraph.Timeout)
+	projectionBaseURL := cfg.OrganizationalGraph.ProjectionBaseURL
+	if projectionBaseURL == "" {
+		projectionBaseURL = cfg.OrganizationalGraph.BaseURL
+	}
+	readBaseURL := cfg.OrganizationalGraph.ReadBaseURL
+	if readBaseURL == "" {
+		readBaseURL = cfg.OrganizationalGraph.BaseURL
+	}
+	if projectionBaseURL != "" {
+		projectionClient, err := organizationalgraph.NewProjectionClient(projectionBaseURL, cfg.OrganizationalGraph.SharedSecret, cfg.OrganizationalGraph.Timeout)
 		if err != nil {
 			return fail(fmt.Errorf("open Rust organizational graph projection: %w", err))
 		}
 		deps.OrganizationalProjector = projectionClient
+	}
+	if readBaseURL != "" {
 		var compatibility ports.GraphQueryStore
 		if primary, ok := deps.GraphStore.(ports.GraphQueryStore); ok && !isNilInterface(primary) {
 			compatibility = primary
 		}
-		queryStore, err := organizationalgraph.NewQueryStore(compatibility, cfg.OrganizationalGraph.BaseURL, cfg.OrganizationalGraph.SharedSecret, cfg.OrganizationalGraph.Timeout)
+		var queryStore ports.GraphQueryStore
+		var err error
+		if cfg.OrganizationalGraph.ReadMode == "shadow" {
+			queryStore, err = organizationalgraph.NewShadowQueryStore(
+				compatibility,
+				readBaseURL,
+				cfg.OrganizationalGraph.SharedSecret,
+				cfg.OrganizationalGraph.Timeout,
+				cfg.OrganizationalGraph.ShadowPercent,
+			)
+		} else {
+			queryStore, err = organizationalgraph.NewQueryStore(
+				compatibility,
+				readBaseURL,
+				cfg.OrganizationalGraph.SharedSecret,
+				cfg.OrganizationalGraph.Timeout,
+			)
+		}
 		if err != nil {
 			return fail(fmt.Errorf("open Rust organizational graph reads: %w", err))
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,9 +149,15 @@ type GraphStoreConfig struct {
 
 // OrganizationalGraphConfig controls the Rust-owned bounded graph read plane.
 type OrganizationalGraphConfig struct {
-	BaseURL      string
-	SharedSecret string
-	Timeout      time.Duration
+	// BaseURL is the legacy combined endpoint. Prefer separate read and
+	// projection endpoints so pre-cutover reads cannot activate a writer.
+	BaseURL           string
+	ReadBaseURL       string
+	ProjectionBaseURL string
+	ReadMode          string
+	ShadowPercent     int
+	SharedSecret      string
+	Timeout           time.Duration
 }
 
 // CacheConfig controls optional shared query/response caching.
@@ -493,7 +499,16 @@ func Load() (Config, error) {
 			Neo4jDatabase: strings.TrimSpace(os.Getenv("CEREBRO_NEO4J_DATABASE")),
 		},
 		OrganizationalGraph: OrganizationalGraphConfig{
-			BaseURL:      strings.TrimRight(strings.TrimSpace(os.Getenv("CEREBRO_ORGANIZATIONAL_GRAPH_URL")), "/"),
+			BaseURL: strings.TrimRight(strings.TrimSpace(os.Getenv("CEREBRO_ORGANIZATIONAL_GRAPH_URL")), "/"),
+			ReadBaseURL: strings.TrimRight(
+				strings.TrimSpace(os.Getenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL")),
+				"/",
+			),
+			ProjectionBaseURL: strings.TrimRight(
+				strings.TrimSpace(os.Getenv("CEREBRO_ORGANIZATIONAL_GRAPH_PROJECTION_URL")),
+				"/",
+			),
+			ReadMode:     strings.ToLower(strings.TrimSpace(os.Getenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE"))),
 			SharedSecret: organizationalGraphSharedSecret,
 		},
 		Cache: CacheConfig{
@@ -671,16 +686,51 @@ func Load() (Config, error) {
 	if cfg.OrganizationalGraph.Timeout <= 0 {
 		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT must be greater than zero")
 	}
-	if cfg.OrganizationalGraph.BaseURL != "" {
-		if len([]byte(cfg.OrganizationalGraph.SharedSecret)) < 32 {
-			return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET must be at least 32 bytes when CEREBRO_ORGANIZATIONAL_GRAPH_URL is set")
+	if cfg.OrganizationalGraph.ReadBaseURL == "" {
+		cfg.OrganizationalGraph.ReadBaseURL = cfg.OrganizationalGraph.BaseURL
+	}
+	if cfg.OrganizationalGraph.ProjectionBaseURL == "" {
+		cfg.OrganizationalGraph.ProjectionBaseURL = cfg.OrganizationalGraph.BaseURL
+	}
+	if cfg.OrganizationalGraph.ReadMode == "" {
+		cfg.OrganizationalGraph.ReadMode = "authority"
+	}
+	if cfg.OrganizationalGraph.ReadMode != "authority" && cfg.OrganizationalGraph.ReadMode != "shadow" {
+		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE must be authority or shadow")
+	}
+	if cfg.OrganizationalGraph.ShadowPercent, err = parseIntEnv("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.OrganizationalGraph.ShadowPercent < 0 || cfg.OrganizationalGraph.ShadowPercent > 100 {
+		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT must be between 0 and 100")
+	}
+	if cfg.OrganizationalGraph.ReadMode == "shadow" && cfg.OrganizationalGraph.ReadBaseURL == "" {
+		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL is required in shadow mode")
+	}
+	if cfg.OrganizationalGraph.ReadMode == "shadow" && cfg.OrganizationalGraph.ShadowPercent == 0 {
+		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT must be greater than zero in shadow mode")
+	}
+	for _, configured := range []struct {
+		name     string
+		endpoint string
+	}{
+		{"CEREBRO_ORGANIZATIONAL_GRAPH_URL", cfg.OrganizationalGraph.BaseURL},
+		{"CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL", cfg.OrganizationalGraph.ReadBaseURL},
+		{"CEREBRO_ORGANIZATIONAL_GRAPH_PROJECTION_URL", cfg.OrganizationalGraph.ProjectionBaseURL},
+	} {
+		name, endpoint := configured.name, configured.endpoint
+		if endpoint == "" {
+			continue
 		}
-		parsed, parseErr := url.Parse(cfg.OrganizationalGraph.BaseURL)
+		if len([]byte(cfg.OrganizationalGraph.SharedSecret)) < 32 {
+			return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET must be at least 32 bytes when %s is set", name)
+		}
+		parsed, parseErr := url.Parse(endpoint)
 		if parseErr != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil {
-			return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_URL must be an http or https origin without credentials")
+			return Config{}, fmt.Errorf("%s must be an http or https origin without credentials", name)
 		}
 		if parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
-			return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_URL must not include a path, query, or fragment")
+			return Config{}, fmt.Errorf("%s must not include a path, query, or fragment", name)
 		}
 	}
 	if cfg.GraphAgentLLM.Temperature, err = parseFloatEnv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", 0); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,6 +55,10 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_NEO4J_PROJECTION_BATCH_SIZE", "")
 	t.Setenv("CEREBRO_NEO4J_PROJECTION_WRITE_CONCURRENCY", "")
 	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_URL", "")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL", "")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_PROJECTION_URL", "")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE", "")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT", "")
 	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET", "")
 	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT", "")
 	clearGraphAgentEnv(t)
@@ -176,6 +180,49 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.Auth.DeviceAuth.RefreshTTL != defaultDeviceAuthRefreshTTL {
 		t.Fatalf("DeviceAuth.RefreshTTL = %v, want %v", cfg.Auth.DeviceAuth.RefreshTTL, defaultDeviceAuthRefreshTTL)
+	}
+}
+
+func TestLoadSeparatesRustGraphReadAndProjectionEndpoints(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL", "http://127.0.0.1:8081")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE", "shadow")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT", "25")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET", "test-organizational-graph-secret-32-bytes")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.OrganizationalGraph.ReadBaseURL != "http://127.0.0.1:8081" {
+		t.Fatalf("ReadBaseURL = %q", cfg.OrganizationalGraph.ReadBaseURL)
+	}
+	if cfg.OrganizationalGraph.ProjectionBaseURL != "" {
+		t.Fatalf("ProjectionBaseURL = %q, want disabled", cfg.OrganizationalGraph.ProjectionBaseURL)
+	}
+	if cfg.OrganizationalGraph.ReadMode != "shadow" || cfg.OrganizationalGraph.ShadowPercent != 25 {
+		t.Fatalf("OrganizationalGraph = %#v", cfg.OrganizationalGraph)
+	}
+}
+
+func TestLoadRejectsUnsafeRustGraphShadowConfiguration(t *testing.T) {
+	for name, value := range map[string]string{
+		"missing endpoint": "",
+		"zero sampling":    "0",
+		"excess sampling":  "101",
+	} {
+		t.Run(name, func(t *testing.T) {
+			clearDependencyEnv(t)
+			t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE", "shadow")
+			t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET", "test-organizational-graph-secret-32-bytes")
+			if name != "missing endpoint" {
+				t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL", "http://127.0.0.1:8081")
+			}
+			t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT", value)
+			if _, err := Load(); err == nil {
+				t.Fatal("Load() error = nil")
+			}
+		})
 	}
 }
 

--- a/internal/observability/domain_metrics.go
+++ b/internal/observability/domain_metrics.go
@@ -118,6 +118,23 @@ func otelGraphRuleRecords() otelmetric.Int64Counter {
 	return instrument
 }
 
+func otelOrganizationalGraphShadowComparisons() otelmetric.Int64Counter {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
+		"cerebro.organizational_graph.shadow.comparisons",
+		otelmetric.WithDescription("Sampled legacy and Rust organizational graph read comparisons."),
+	)
+	return instrument
+}
+
+func otelOrganizationalGraphShadowDuration() otelmetric.Float64Histogram {
+	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Float64Histogram(
+		"cerebro.organizational_graph.shadow.duration",
+		otelmetric.WithDescription("Rust side of sampled organizational graph read comparisons."),
+		otelmetric.WithUnit("s"),
+	)
+	return instrument
+}
+
 func otelNeo4jOperations() otelmetric.Int64Counter {
 	instrument, _ := otel.Meter("github.com/writer/cerebro/internal/observability").Int64Counter(
 		"cerebro.neo4j.operations",
@@ -437,6 +454,27 @@ func RecordNeo4jOperation(ctx context.Context, metrics Neo4jOperationMetrics) {
 	otelNeo4jOperations().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
 	if metrics.Duration >= 0 {
 		otelNeo4jOperationDuration().Record(ctx, metrics.Duration.Seconds(), otelmetric.WithAttributes(attrs...))
+	}
+}
+
+type OrganizationalGraphShadowMetrics struct {
+	Operation string
+	Status    string
+	Duration  time.Duration
+}
+
+func RecordOrganizationalGraphShadow(ctx context.Context, metrics OrganizationalGraphShadowMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("operation", boundedMetricValue(metrics.Operation, "unknown")),
+		attribute.String("status", boundedMetricValue(metrics.Status, "unknown")),
+	}
+	otelOrganizationalGraphShadowComparisons().Add(ctx, 1, otelmetric.WithAttributes(attrs...))
+	if metrics.Duration >= 0 {
+		otelOrganizationalGraphShadowDuration().Record(
+			ctx,
+			metrics.Duration.Seconds(),
+			otelmetric.WithAttributes(attrs...),
+		)
 	}
 }
 

--- a/internal/observability/domain_metrics_test.go
+++ b/internal/observability/domain_metrics_test.go
@@ -68,6 +68,30 @@ func TestRecordContentPackSelectionMetricsAreLowCardinality(t *testing.T) {
 	assertMetricHasAttribute(t, metric, "status", "embedded_fallback")
 }
 
+func TestRecordOrganizationalGraphShadowMetricsAreLowCardinality(t *testing.T) {
+	reader, shutdown := installManualMetricReader(t)
+	RecordOrganizationalGraphShadow(context.Background(), OrganizationalGraphShadowMetrics{
+		Operation: "Expand Batch",
+		Status:    "Mismatch",
+		Duration:  20 * time.Millisecond,
+	})
+	t.Cleanup(shutdown)
+
+	metrics := collectMetrics(t, reader)
+	for _, name := range []string{
+		"cerebro.organizational_graph.shadow.comparisons",
+		"cerebro.organizational_graph.shadow.duration",
+	} {
+		metric, ok := metrics[name]
+		if !ok {
+			t.Fatalf("metric %q missing from %#v", name, metricNames(metrics))
+		}
+		assertNoForbiddenMetricAttributes(t, metric)
+		assertMetricHasAttribute(t, metric, "operation", "expand_batch")
+		assertMetricHasAttribute(t, metric, "status", "mismatch")
+	}
+}
+
 func TestRecordSourceProjectionMetricsAreLowCardinality(t *testing.T) {
 	reader, shutdown := installManualMetricReader(t)
 	RecordSourceProjection(context.Background(), SourceProjectionMetrics{

--- a/internal/sourcehttp/organizationalgraph/query.go
+++ b/internal/sourcehttp/organizationalgraph/query.go
@@ -4,7 +4,11 @@
 package organizationalgraph
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +20,7 @@ import (
 
 	cerebrographv1 "github.com/writer/cerebro/gen/cerebro/graph/v1"
 	"github.com/writer/cerebro/gen/cerebro/graph/v1/cerebrographv1connect"
+	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
 	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
@@ -34,6 +39,8 @@ type QueryStore struct {
 	httpClient    *http.Client
 	graph         cerebrographv1connect.OrganizationalGraphServiceClient
 	auth          tenantAuthenticator
+	shadow        bool
+	shadowPercent uint32
 }
 
 // ReadinessStore selects the product read authority when configured.
@@ -45,6 +52,20 @@ func ReadinessStore(compatibility, authority ports.GraphStore) ports.GraphStore 
 }
 
 func NewQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration) (*QueryStore, error) {
+	return newQueryStore(compatibility, baseURL, sharedSecret, timeout, false, 0)
+}
+
+func NewShadowQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration, shadowPercent int) (*QueryStore, error) {
+	if compatibility == nil {
+		return nil, errors.New("shadow graph reads require the legacy compatibility store")
+	}
+	if shadowPercent <= 0 || shadowPercent > 100 {
+		return nil, errors.New("shadow graph read percent must be between 1 and 100")
+	}
+	return newQueryStore(compatibility, baseURL, sharedSecret, timeout, true, uint32(shadowPercent)) // #nosec G115 -- validated above.
+}
+
+func newQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration, shadow bool, shadowPercent uint32) (*QueryStore, error) {
 	baseURL, err := normalizeBaseURL(baseURL)
 	if err != nil {
 		return nil, err
@@ -63,6 +84,8 @@ func NewQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret st
 		httpClient:    httpClient,
 		graph:         cerebrographv1connect.NewOrganizationalGraphServiceClient(httpClient, baseURL),
 		auth:          auth,
+		shadow:        shadow,
+		shadowPercent: shadowPercent,
 	}, nil
 }
 
@@ -72,6 +95,24 @@ func (s *QueryStore) Ping(ctx context.Context) (err error) {
 			return fmt.Errorf("compatibility graph health: %w", err)
 		}
 	}
+	if s.shadow {
+		started := time.Now()
+		err := s.pingRust(ctx)
+		status := "match"
+		if err != nil {
+			status = "rust_error"
+		}
+		observability.RecordOrganizationalGraphShadow(ctx, observability.OrganizationalGraphShadowMetrics{
+			Operation: "readiness",
+			Status:    status,
+			Duration:  time.Since(started),
+		})
+		return nil
+	}
+	return s.pingRust(ctx)
+}
+
+func (s *QueryStore) pingRust(ctx context.Context) (err error) {
 	// #nosec G704 -- normalizeBaseURL validates and freezes the operator-set
 	// HTTP(S) origin; this package supplies the constant request path.
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, s.baseURL+"/readyz", nil)
@@ -94,6 +135,20 @@ func (s *QueryStore) Ping(ctx context.Context) (err error) {
 }
 
 func (s *QueryStore) GetEntityNeighborhood(ctx context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
+	if !s.shadow {
+		return s.getRustEntityNeighborhood(ctx, rootURN, limit)
+	}
+	legacy, err := s.compatibility.GetEntityNeighborhood(ctx, rootURN, limit)
+	if err != nil || !s.sample(rootURN) {
+		return legacy, err
+	}
+	started := time.Now()
+	rust, rustErr := s.getRustEntityNeighborhood(ctx, rootURN, limit)
+	s.recordComparison(ctx, "expand", legacy, rust, rustErr, started)
+	return legacy, nil
+}
+
+func (s *QueryStore) getRustEntityNeighborhood(ctx context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
 	rootURN = strings.TrimSpace(rootURN)
 	if cerebrourn.TenantID(rootURN) == "" {
 		return nil, errors.New("root is not a tenant-scoped Cerebro URN")
@@ -125,6 +180,20 @@ func (s *QueryStore) GetEntityNeighborhood(ctx context.Context, rootURN string, 
 }
 
 func (s *QueryStore) GetEntityNeighborhoods(ctx context.Context, rootURNs []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
+	if !s.shadow {
+		return s.getRustEntityNeighborhoods(ctx, rootURNs, limit)
+	}
+	legacy, err := legacyNeighborhoods(ctx, s.compatibility, rootURNs, limit)
+	if err != nil || !s.sample(strings.Join(rootURNs, "\x00")) {
+		return legacy, err
+	}
+	started := time.Now()
+	rust, rustErr := s.getRustEntityNeighborhoods(ctx, rootURNs, limit)
+	s.recordComparison(ctx, "expand_batch", legacy, rust, rustErr, started)
+	return legacy, nil
+}
+
+func (s *QueryStore) getRustEntityNeighborhoods(ctx context.Context, rootURNs []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
 	if len(rootURNs) == 0 {
 		return map[string]*ports.EntityNeighborhood{}, nil
 	}
@@ -181,6 +250,49 @@ func (s *QueryStore) GetEntityNeighborhoods(ctx context.Context, rootURNs []stri
 		result[rootURN] = product
 	}
 	return result, nil
+}
+
+func legacyNeighborhoods(ctx context.Context, store ports.GraphQueryStore, roots []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
+	if batch, ok := store.(ports.GraphNeighborhoodBatchStore); ok {
+		return batch.GetEntityNeighborhoods(ctx, roots, limit)
+	}
+	result := make(map[string]*ports.EntityNeighborhood, len(roots))
+	for _, root := range roots {
+		if _, exists := result[root]; exists {
+			continue
+		}
+		neighborhood, err := store.GetEntityNeighborhood(ctx, root, limit)
+		if err != nil {
+			return nil, err
+		}
+		result[root] = neighborhood
+	}
+	return result, nil
+}
+
+func (s *QueryStore) sample(key string) bool {
+	digest := sha256.Sum256([]byte(key))
+	return binary.BigEndian.Uint32(digest[:4])%100 < s.shadowPercent
+}
+
+func (s *QueryStore) recordComparison(ctx context.Context, operation string, legacy, rust any, rustErr error, started time.Time) {
+	status := "match"
+	if rustErr != nil {
+		status = "rust_error"
+	} else {
+		legacyJSON, legacyErr := json.Marshal(legacy)
+		rustJSON, rustMarshalErr := json.Marshal(rust)
+		if legacyErr != nil || rustMarshalErr != nil {
+			status = "comparison_error"
+		} else if !bytes.Equal(legacyJSON, rustJSON) {
+			status = "mismatch"
+		}
+	}
+	observability.RecordOrganizationalGraphShadow(ctx, observability.OrganizationalGraphShadowMetrics{
+		Operation: operation,
+		Status:    status,
+		Duration:  time.Since(started),
+	})
 }
 
 func (s *QueryStore) ExecuteReadCypher(ctx context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {

--- a/internal/sourcehttp/organizationalgraph/query_test.go
+++ b/internal/sourcehttp/organizationalgraph/query_test.go
@@ -158,6 +158,45 @@ func TestQueryStoreFailsClosedWhenRustIsUnavailable(t *testing.T) {
 	}
 }
 
+func TestShadowQueryStoreReturnsLegacyWhenRustIsUnavailable(t *testing.T) {
+	rootURN := "urn:cerebro:tenant-a:runtime_file:asset-1"
+	legacy := &ports.EntityNeighborhood{
+		Root: &ports.NeighborhoodNode{URN: rootURN, Label: "Legacy"},
+	}
+	store, err := NewShadowQueryStore(
+		queryStoreStub{neighborhood: legacy},
+		"http://127.0.0.1:1",
+		testSharedSecret,
+		10*time.Millisecond,
+		100,
+	)
+	if err != nil {
+		t.Fatalf("NewShadowQueryStore() error = %v", err)
+	}
+	got, err := store.GetEntityNeighborhood(context.Background(), rootURN, 10)
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+	if got != legacy {
+		t.Fatalf("GetEntityNeighborhood() = %#v, want legacy response", got)
+	}
+	if err := store.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping() error = %v, shadow readiness must use legacy authority", err)
+	}
+}
+
+func TestShadowQueryStoreRequiresCompatibilityAndBoundedSampling(t *testing.T) {
+	if _, err := NewShadowQueryStore(nil, "http://127.0.0.1:1", testSharedSecret, time.Second, 100); err == nil {
+		t.Fatal("NewShadowQueryStore(nil) error = nil")
+	}
+	if _, err := NewShadowQueryStore(queryStoreStub{}, "http://127.0.0.1:1", testSharedSecret, time.Second, 0); err == nil {
+		t.Fatal("NewShadowQueryStore(0%) error = nil")
+	}
+	if _, err := NewShadowQueryStore(queryStoreStub{}, "http://127.0.0.1:1", testSharedSecret, time.Second, 101); err == nil {
+		t.Fatal("NewShadowQueryStore(101%) error = nil")
+	}
+}
+
 func TestQueryStoreHealthRequiresRustAndChecksCompatibilityWhenPresent(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -164,11 +164,12 @@ import (
 // tenant resolution, safe error mapping, and state-store capability wiring.
 // Query bounds, cursors, and response allowlisting stay in auditevents.
 // Rust organizational graph migration adds only dependency construction,
-// family-authority routing, and read-store selection. Projection decisions,
+// separate read/projection endpoint selection, family-authority routing, and
+// read-store selection. Shadow sampling, comparison, projection decisions,
 // graph mapping, and HTTP transport stay behind organizational-store and
 // internal/sourcehttp/organizationalgraph as documented in
 // docs/engineering/rust-organizational-platform.md.
-const bootstrapProductionGoLineBudget = 29607
+const bootstrapProductionGoLineBudget = 29627
 
 type bootstrapFileLineCount struct {
 	path  string

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -151,8 +151,14 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 			t.Errorf("Rust graph read adapter restored handwritten wire contract %q", forbidden)
 		}
 	}
-	if strings.Contains(queryAdapter, "ShadowQueryStore") {
-		t.Error("bounded product graph reads must not restore the Go-primary shadow adapter")
+	for _, required := range []string{
+		"NewShadowQueryStore",
+		"return legacy, nil",
+		"RecordOrganizationalGraphShadow",
+	} {
+		if !strings.Contains(queryAdapter, required) {
+			t.Errorf("bounded shadow comparison missing enforced safety boundary %q", required)
+		}
 	}
 
 	replacementWorkflow := readText(t, filepath.Join(root, ".github/workflows/rust-graph-replacement.yml"))


### PR DESCRIPTION
## Summary

- add transport-neutral Rust SDK and deterministic engine crates for temporal graph, assertions, provenance, simulation, subscriptions, materialized views, incidents, governed actions, diagnostics, recovery, budgets, and bounded plugins
- reuse the organizational model, bounded query, and control-kernel contracts instead of defining parallel domain types
- separate Rust graph read and projection endpoints so read-only staging cannot activate a writer path
- add sampled shadow reads that keep Go authoritative and emit bounded match, mismatch, and error metrics
- add `serve-neo4j-readonly`, which does not connect to PostgreSQL, run migrations, expose projection writes, or consume JetStream
- add `evaluate-family` to inspect the exact durable promotion decision without changing irreversible authority
- expose low-cardinality Rust request counters and latency histograms on `/metrics`

## Authority boundary

- JetStream remains the event log of record
- PostgreSQL remains authoritative current state
- Neo4j remains a rebuildable projection
- `CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL` configures only reads
- `CEREBRO_ORGANIZATIONAL_GRAPH_PROJECTION_URL` remains unset during pre-cutover staging
- shadow mode always returns the legacy result; authority mode returns Rust and fails closed
- family promotion still requires catalog proof, a native mapper, three consecutive parity matches, latest-corpus matches, and zero projection lag

## Validation

- `make rust-fmt-check rust-clippy rust-test`
- `make projection-parity-test`
- focused Go config, bootstrap, observability, and organizational graph tests
- disposable PostgreSQL cutover evaluation and irreversible promotion test
- disposable PostgreSQL and Neo4j durable store/rebuild test
- disposable durable benchmark at 100 and 1,000-record batches plus bounded one-hop, multi-hop, typed fact, batched, and concurrent-tenant reads
- `python3 scripts/docs_drift_check.py`
