### PR TITLE
platform: add deterministic Rust capability engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cerebro-platform-engine"
+version = "0.1.0"
+dependencies = [
+ "cerebro-platform-sdk",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cerebro-platform-sdk"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/organizational-graph",
     "crates/organizational-model",
     "crates/organizational-store",
+    "crates/platform-engine",
     "crates/platform-sdk",
     "crates/source-catalog",
     "crates/security-path-kernel",
@@ -37,6 +38,7 @@ cerebro-control-kernel = { version = "0.1.0", path = "crates/control-kernel" }
 cerebro-organizational-graph = { version = "0.1.0", path = "crates/organizational-graph" }
 cerebro-organizational-model = { version = "0.1.0", path = "crates/organizational-model" }
 cerebro-organizational-store = { version = "0.1.0", path = "crates/organizational-store" }
+cerebro-platform-engine = { version = "0.1.0", path = "crates/platform-engine" }
 cerebro-platform-sdk = { version = "0.1.0", path = "crates/platform-sdk" }
 cerebro-source-catalog = { version = "0.1.0", path = "crates/source-catalog" }
 cerebro-source-runtime-next = { version = "0.1.0", path = "crates/source-runtime-next" }

--- a/Makefile
+++ b/Makefile
@@ -527,6 +527,11 @@ rust-coverage: ## Enforce the Rust workspace line-coverage floor with the pinned
 	# and process entrypoints are exercised by live integration tests.
 	$(CARGO) llvm-cov --workspace --all-features --locked --ignore-filename-regex '(^|/)(wasm_abi\.rs|crates/cerebro-platform/src/(generated/.*|main|append_log_consumer|cutover_command|parity_command)\.rs|crates/organizational-store/src/(lib|neo4j|postgres)\.rs|crates/source-runtime-next/src/http\.rs)$$' --fail-under-lines 90 --summary-only
 
+rust-platform-engine-coverage: ## Enforce focused coverage for reusable platform engines.
+	@actual="$$($(CARGO) llvm-cov --version 2>/dev/null || true)"; \
+		test "$$actual" = "cargo-llvm-cov 0.8.7" || { echo "rust-platform-engine-coverage: install cargo-llvm-cov 0.8.7 with 'cargo install cargo-llvm-cov --version 0.8.7 --locked'"; exit 1; }
+	$(CARGO) llvm-cov -p cerebro-platform-engine --all-features --locked --fail-under-lines 90 --summary-only
+
 rust-benchmark-smoke: ## Run bounded embedded Wasm host benchmarks and record their output.
 	@mkdir -p tmp
 	@go test ./internal/wasmhost ./internal/graphagent ./internal/sourcecoverage ./internal/mitre ./internal/sourceprojection ./internal/sourceruntime/eventadmission -run '^$$' -bench '^(BenchmarkRuntimeRun|BenchmarkStaticValidator|BenchmarkCoverageEvaluator|BenchmarkContextEvaluator|BenchmarkPanopticonResourceExtractor|BenchmarkAdmissionSmoke)$$' -benchtime=20x -count=1 > tmp/rust-wasm-benchmark.txt 2>&1; status=$$?; cat tmp/rust-wasm-benchmark.txt; exit $$status
@@ -542,6 +547,10 @@ rust-organizational-platform-benchmark: ## Compare the Go and Rust organizationa
 	@mkdir -p tmp
 	@GOMAXPROCS=1 go test ./internal/graphrebuild ./internal/sourceruntime -run '^TestOrganizationalPlatform.*BenchmarkCorpus$$' -bench '^BenchmarkOrganizationalPlatformGo' -benchmem -benchtime=$(ORGANIZATIONAL_BENCH_SAMPLE_MS)ms -count=$(ORGANIZATIONAL_BENCH_SAMPLES) -cpu=1 > tmp/organizational-platform-go-benchmark.txt 2>&1; status=$$?; cat tmp/organizational-platform-go-benchmark.txt; test $$status -eq 0
 	@ORGANIZATIONAL_BENCH_SAMPLE_MS=$(ORGANIZATIONAL_BENCH_SAMPLE_MS) ORGANIZATIONAL_BENCH_SAMPLES=$(ORGANIZATIONAL_BENCH_SAMPLES) $(CARGO) bench --locked -p cerebro-source-runtime-next --bench organizational_platform > tmp/organizational-platform-rust-benchmark.txt 2>&1; status=$$?; cat tmp/organizational-platform-rust-benchmark.txt; exit $$status
+
+rust-platform-engine-benchmark: ## Measure reusable platform diff, assertion, and simulation engines.
+	@mkdir -p tmp
+	@$(CARGO) bench --locked -p cerebro-platform-engine --bench platform_engine > tmp/rust-platform-engine-benchmark.txt 2>&1; status=$$?; cat tmp/rust-platform-engine-benchmark.txt; exit $$status
 
 rust-organizational-store-benchmark: ## Measure durable commits, recovery, traversal, and tenant concurrency against disposable stores.
 	@test -n "$(CEREBRO_TEST_POSTGRES_DSN)" || { echo "CEREBRO_TEST_POSTGRES_DSN is required" >&2; exit 2; }

--- a/crates/platform-engine/Cargo.toml
+++ b/crates/platform-engine/Cargo.toml
@@ -11,5 +11,9 @@ cerebro-platform-sdk.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
+[[bench]]
+name = "platform_engine"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/platform-engine/Cargo.toml
+++ b/crates/platform-engine/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cerebro-platform-engine"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+cerebro-platform-sdk.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/platform-engine/benches/platform_engine.rs
+++ b/crates/platform-engine/benches/platform_engine.rs
@@ -1,0 +1,194 @@
+use std::collections::BTreeSet;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use cerebro_platform_engine::{
+    RevisionSnapshot, SimulationRelationship, SimulationTopology, SnapshotKey, SnapshotValue,
+    assertion_definition_digest, compile_assertion, diff_snapshots, evaluate_assertion,
+    simulate_topology,
+};
+use cerebro_platform_sdk::{
+    AssertionCondition, AssertionDefinition, AssertionDefinitionId, ContentDigest, EntityId,
+    EvaluationTrigger, EvidenceQuality, FactQuery, GraphDiffRequest, GraphRevision, ProposedChange,
+    QueryNode, QueryResult, RelationKind, RevisionSelector, SimulationId, SimulationRequest,
+    TenantId,
+};
+
+fn main() {
+    let (request, before, after) = diff_fixture();
+    report("diff_500_changes", 200, || {
+        black_box(diff_snapshots(&request, &before, &after).expect("benchmark diff"));
+    });
+
+    let (compiled, query_result, quality) = assertion_fixture();
+    report("evaluate_assertion", 10_000, || {
+        black_box(
+            evaluate_assertion(&compiled, &query_result, &quality, 10)
+                .expect("benchmark assertion"),
+        );
+    });
+
+    let (simulation_request, topology) = simulation_fixture();
+    report("simulate_100_relationship_removals", 200, || {
+        black_box(
+            simulate_topology(&simulation_request, &topology, Vec::new())
+                .expect("benchmark simulation"),
+        );
+    });
+}
+
+fn report(name: &str, iterations: u32, operation: impl Fn()) {
+    for _ in 0..10 {
+        operation();
+    }
+    let started = Instant::now();
+    for _ in 0..iterations {
+        operation();
+    }
+    let elapsed = started.elapsed() / iterations;
+    println!("{name}: {} ns/op", nanos(elapsed));
+}
+
+fn nanos(duration: Duration) -> u128 {
+    duration.as_nanos()
+}
+
+fn tenant() -> TenantId {
+    TenantId::parse("tenant-a").expect("valid tenant")
+}
+
+fn revision(value: u64) -> GraphRevision {
+    GraphRevision::new(value).expect("valid revision")
+}
+
+fn digest(value: impl AsRef<[u8]>) -> ContentDigest {
+    ContentDigest::of_bytes(value)
+}
+
+fn diff_fixture() -> (GraphDiffRequest, RevisionSnapshot, RevisionSnapshot) {
+    let before_values = (0..500)
+        .map(|index| {
+            (
+                SnapshotKey::Entity(
+                    EntityId::parse(format!("repository:{index:03}")).expect("valid entity"),
+                ),
+                SnapshotValue {
+                    digest: digest(format!("before-{index}")),
+                    observed_at_unix_millis: 1,
+                },
+            )
+        })
+        .collect();
+    let after_values = (0..500)
+        .map(|index| {
+            (
+                SnapshotKey::Entity(
+                    EntityId::parse(format!("repository:{index:03}")).expect("valid entity"),
+                ),
+                SnapshotValue {
+                    digest: digest(format!("after-{index}")),
+                    observed_at_unix_millis: 2,
+                },
+            )
+        })
+        .collect();
+    (
+        GraphDiffRequest {
+            tenant_id: tenant(),
+            from_revision: revision(1),
+            to_revision: RevisionSelector::Exact(revision(2)),
+            limit: 500,
+            cursor: None,
+        },
+        RevisionSnapshot {
+            tenant_id: tenant(),
+            revision: revision(1),
+            values: before_values,
+        },
+        RevisionSnapshot {
+            tenant_id: tenant(),
+            revision: revision(2),
+            values: after_values,
+        },
+    )
+}
+
+fn assertion_fixture() -> (
+    cerebro_platform_engine::CompiledAssertion,
+    QueryResult,
+    EvidenceQuality,
+) {
+    let query = FactQuery::new(
+        vec![QueryNode {
+            variable: "repository".to_owned(),
+            kinds: vec!["repository".to_owned()],
+            keys: vec!["repository:one".to_owned()],
+        }],
+        Vec::new(),
+        Vec::new(),
+        10,
+    )
+    .expect("valid query");
+    let mut definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:one")
+            .expect("valid assertion"),
+        tenant_id: tenant(),
+        name: "Repository exists".to_owned(),
+        query,
+        condition: AssertionCondition::AtLeastOneMatch,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("placeholder"),
+    };
+    definition.definition_digest =
+        assertion_definition_digest(&definition).expect("definition digest");
+    (
+        compile_assertion(definition).expect("compiled assertion"),
+        QueryResult {
+            tenant_id: tenant(),
+            graph_revision: 2,
+            matches: Vec::new(),
+            truncated: false,
+        },
+        EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("valid quality"),
+    )
+}
+
+fn simulation_fixture() -> (SimulationRequest, SimulationTopology) {
+    let entities = (0..101)
+        .map(|index| EntityId::parse(format!("repository:{index:03}")).expect("valid entity"))
+        .collect::<BTreeSet<_>>();
+    let relationships = (0..100)
+        .map(|index| SimulationRelationship {
+            from_entity_id: EntityId::parse(format!("repository:{index:03}"))
+                .expect("valid entity"),
+            relation: RelationKind::DependsOn,
+            to_entity_id: EntityId::parse(format!("repository:{:03}", index + 1))
+                .expect("valid entity"),
+        })
+        .collect::<BTreeSet<_>>();
+    let changes = relationships
+        .iter()
+        .map(|relationship| ProposedChange::RemoveRelationship {
+            from_entity_id: relationship.from_entity_id.clone(),
+            relation: relationship.relation,
+            to_entity_id: relationship.to_entity_id.clone(),
+        })
+        .collect();
+    (
+        SimulationRequest {
+            simulation_id: SimulationId::parse("simulation:benchmark").expect("valid simulation"),
+            tenant_id: tenant(),
+            base_revision: revision(1),
+            changes,
+            assertions: Vec::new(),
+            max_affected_entities: 101,
+        },
+        SimulationTopology {
+            tenant_id: tenant(),
+            entities,
+            relationships,
+        },
+    )
+}

--- a/crates/platform-engine/src/action.rs
+++ b/crates/platform-engine/src/action.rs
@@ -29,6 +29,22 @@ pub fn transition_action(
     expected_version: u64,
     command: ActionCommand,
 ) -> Result<ActionOperation, SdkError> {
+    operation.proposal.validate()?;
+    if operation.version == 0 {
+        return Err(SdkError::OutOfRange("action operation version"));
+    }
+    if matches!(
+        operation.state,
+        ActionState::Claimed
+            | ActionState::Executing
+            | ActionState::OutcomeUnknown
+            | ActionState::Completed
+            | ActionState::Reconciled
+            | ActionState::Verified
+    ) && operation.claimed_by.is_none()
+    {
+        return Err(SdkError::Invalid("action operation claimant"));
+    }
     if operation.version != expected_version {
         return Err(SdkError::Conflict(
             "stale action operation version".to_owned(),

--- a/crates/platform-engine/src/action.rs
+++ b/crates/platform-engine/src/action.rs
@@ -1,0 +1,117 @@
+use cerebro_platform_sdk::{
+    ActionOperation, ActionState, ContentDigest, OpaqueId, SdkError, VerificationState,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ActionCommand {
+    RecordSimulation,
+    RequestApproval,
+    Claim {
+        worker_id: OpaqueId,
+    },
+    StartExecution,
+    MarkOutcomeUnknown,
+    Complete {
+        external_receipt_ref: OpaqueId,
+        observed_effect_digest: ContentDigest,
+    },
+    Reconcile {
+        observed_effect_digest: ContentDigest,
+    },
+    Verify,
+    RejectVerification,
+    Fail,
+    RollBack,
+}
+
+pub fn transition_action(
+    operation: &ActionOperation,
+    expected_version: u64,
+    command: ActionCommand,
+) -> Result<ActionOperation, SdkError> {
+    if operation.version != expected_version {
+        return Err(SdkError::Conflict(
+            "stale action operation version".to_owned(),
+        ));
+    }
+    let mut next = operation.clone();
+    match (&operation.state, command) {
+        (ActionState::Proposed, ActionCommand::RecordSimulation) => {
+            next.state = ActionState::Simulated;
+        }
+        (ActionState::Simulated, ActionCommand::RequestApproval) => {
+            next.state = ActionState::WaitingForApproval;
+        }
+        (ActionState::WaitingForApproval, ActionCommand::Claim { worker_id }) => {
+            next.state = ActionState::Claimed;
+            next.claimed_by = Some(worker_id);
+        }
+        (ActionState::Claimed, ActionCommand::StartExecution) => {
+            next.state = ActionState::Executing;
+        }
+        (ActionState::Executing, ActionCommand::MarkOutcomeUnknown) => {
+            next.state = ActionState::OutcomeUnknown;
+        }
+        (
+            ActionState::Executing,
+            ActionCommand::Complete {
+                external_receipt_ref,
+                observed_effect_digest,
+            },
+        ) => {
+            next.state = ActionState::Completed;
+            next.external_receipt_ref = Some(external_receipt_ref);
+            next.observed_effect_digest = Some(observed_effect_digest);
+        }
+        (
+            ActionState::OutcomeUnknown,
+            ActionCommand::Reconcile {
+                observed_effect_digest,
+            },
+        ) => {
+            next.state = ActionState::Reconciled;
+            next.observed_effect_digest = Some(observed_effect_digest);
+        }
+        (ActionState::Completed | ActionState::Reconciled, ActionCommand::Verify) => {
+            next.state = ActionState::Verified;
+            next.verification_state = VerificationState::Verified;
+        }
+        (ActionState::Completed | ActionState::Reconciled, ActionCommand::RejectVerification) => {
+            next.state = ActionState::Failed;
+            next.verification_state = VerificationState::Rejected;
+        }
+        (
+            ActionState::Proposed
+            | ActionState::Simulated
+            | ActionState::WaitingForApproval
+            | ActionState::Claimed
+            | ActionState::Executing
+            | ActionState::OutcomeUnknown
+            | ActionState::Completed
+            | ActionState::Reconciled,
+            ActionCommand::Fail,
+        ) => {
+            next.state = ActionState::Failed;
+        }
+        (
+            ActionState::Completed
+            | ActionState::Reconciled
+            | ActionState::Verified
+            | ActionState::Failed,
+            ActionCommand::RollBack,
+        ) => {
+            next.state = ActionState::RolledBack;
+            next.verification_state = VerificationState::Stale;
+        }
+        _ => {
+            return Err(SdkError::Conflict(
+                "invalid action state transition".to_owned(),
+            ));
+        }
+    }
+    next.version = next
+        .version
+        .checked_add(1)
+        .ok_or(SdkError::OutOfRange("action operation version"))?;
+    Ok(next)
+}

--- a/crates/platform-engine/src/assertion.rs
+++ b/crates/platform-engine/src/assertion.rs
@@ -1,0 +1,92 @@
+use cerebro_platform_sdk::{
+    AssertionCondition, AssertionDefinition, AssertionEvaluation, AssertionState, ContentDigest,
+    EvidenceQuality, FactQuery, GraphRevision, QueryResult, SdkError, TenantId,
+};
+use serde::Serialize;
+
+use crate::canonical;
+
+#[derive(Serialize)]
+struct AssertionMaterial<'a> {
+    tenant_id: &'a TenantId,
+    name: &'a str,
+    query: &'a FactQuery,
+    condition: AssertionCondition,
+    triggers: &'a [cerebro_platform_sdk::EvaluationTrigger],
+    evidence_max_age_seconds: u64,
+    enabled: bool,
+}
+
+pub fn assertion_definition_digest(
+    definition: &AssertionDefinition,
+) -> Result<ContentDigest, SdkError> {
+    canonical::digest(&AssertionMaterial {
+        tenant_id: &definition.tenant_id,
+        name: &definition.name,
+        query: &definition.query,
+        condition: definition.condition,
+        triggers: &definition.triggers,
+        evidence_max_age_seconds: definition.evidence_max_age_seconds,
+        enabled: definition.enabled,
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompiledAssertion {
+    definition: AssertionDefinition,
+}
+
+impl CompiledAssertion {
+    pub fn definition(&self) -> &AssertionDefinition {
+        &self.definition
+    }
+}
+
+pub fn compile_assertion(definition: AssertionDefinition) -> Result<CompiledAssertion, SdkError> {
+    definition.validate()?;
+    if assertion_definition_digest(&definition)? != definition.definition_digest {
+        return Err(SdkError::Invalid("assertion definition digest"));
+    }
+    Ok(CompiledAssertion { definition })
+}
+
+pub fn evaluate_assertion(
+    compiled: &CompiledAssertion,
+    result: &QueryResult,
+    quality: &EvidenceQuality,
+    evaluated_at_unix_millis: i64,
+) -> Result<AssertionEvaluation, SdkError> {
+    let definition = compiled.definition();
+    if result.tenant_id != definition.tenant_id {
+        return Err(SdkError::Invalid("assertion query tenant"));
+    }
+    let graph_revision = GraphRevision::new(result.graph_revision)?;
+    if result.matches.len() > definition.query.limit() {
+        return Err(SdkError::OutOfRange("assertion query matches"));
+    }
+    let matching_paths = u32::try_from(result.matches.len())
+        .map_err(|_| SdkError::OutOfRange("assertion query matches"))?;
+    let (state, reason_codes) = if !definition.enabled {
+        (AssertionState::Indeterminate, vec!["assertion_disabled"])
+    } else if result.truncated {
+        (AssertionState::Indeterminate, vec!["query_truncated"])
+    } else if quality.conflicting {
+        (AssertionState::Indeterminate, vec!["evidence_conflicting"])
+    } else if quality.minimum_score() == 0 {
+        (AssertionState::Indeterminate, vec!["evidence_incomplete"])
+    } else if definition.condition.evaluate(matching_paths) {
+        (AssertionState::Satisfied, Vec::new())
+    } else {
+        (AssertionState::Violated, vec!["condition_not_met"])
+    };
+    let evidence_digest = canonical::digest(&(result, quality))?;
+    Ok(AssertionEvaluation {
+        assertion_id: definition.assertion_id.clone(),
+        graph_revision,
+        state,
+        evaluated_at_unix_millis,
+        matching_paths,
+        reason_codes: reason_codes.into_iter().map(str::to_owned).collect(),
+        evidence_digest,
+    })
+}

--- a/crates/platform-engine/src/assertion.rs
+++ b/crates/platform-engine/src/assertion.rs
@@ -8,6 +8,7 @@ use crate::canonical;
 
 #[derive(Serialize)]
 struct AssertionMaterial<'a> {
+    assertion_id: &'a cerebro_platform_sdk::AssertionDefinitionId,
     tenant_id: &'a TenantId,
     name: &'a str,
     query: &'a FactQuery,
@@ -21,6 +22,7 @@ pub fn assertion_definition_digest(
     definition: &AssertionDefinition,
 ) -> Result<ContentDigest, SdkError> {
     canonical::digest(&AssertionMaterial {
+        assertion_id: &definition.assertion_id,
         tenant_id: &definition.tenant_id,
         name: &definition.name,
         query: &definition.query,

--- a/crates/platform-engine/src/canonical.rs
+++ b/crates/platform-engine/src/canonical.rs
@@ -1,0 +1,8 @@
+use cerebro_platform_sdk::{ContentDigest, SdkError};
+use serde::Serialize;
+
+pub(crate) fn digest<T: Serialize>(value: &T) -> Result<ContentDigest, SdkError> {
+    serde_json::to_vec(value)
+        .map(ContentDigest::of_bytes)
+        .map_err(|error| SdkError::Backend(format!("canonical serialization failed: {error}")))
+}

--- a/crates/platform-engine/src/incident.rs
+++ b/crates/platform-engine/src/incident.rs
@@ -1,0 +1,55 @@
+use cerebro_platform_sdk::{
+    ContentDigest, GraphRevision, IncidentSnapshot, IncidentSnapshotId, IncidentSnapshotManifest,
+    OpaqueId, SdkError, TenantId,
+};
+use serde::Serialize;
+
+use crate::canonical;
+
+#[derive(Serialize)]
+struct ManifestMaterial<'a> {
+    snapshot_id: &'a IncidentSnapshotId,
+    tenant_id: &'a TenantId,
+    graph_revision: GraphRevision,
+    created_at_unix_millis: i64,
+    entity_ids: &'a [cerebro_platform_sdk::EntityId],
+    source_receipt_digests: &'a [ContentDigest],
+    policy_digests: &'a [ContentDigest],
+    mission_ids: &'a [OpaqueId],
+    verification_receipt_digests: &'a [ContentDigest],
+}
+
+pub fn incident_manifest_digest(
+    manifest: &IncidentSnapshotManifest,
+) -> Result<ContentDigest, SdkError> {
+    canonical::digest(&ManifestMaterial {
+        snapshot_id: &manifest.snapshot_id,
+        tenant_id: &manifest.tenant_id,
+        graph_revision: manifest.graph_revision,
+        created_at_unix_millis: manifest.created_at_unix_millis,
+        entity_ids: &manifest.entity_ids,
+        source_receipt_digests: &manifest.source_receipt_digests,
+        policy_digests: &manifest.policy_digests,
+        mission_ids: &manifest.mission_ids,
+        verification_receipt_digests: &manifest.verification_receipt_digests,
+    })
+}
+
+pub fn package_incident_snapshot(
+    manifest: IncidentSnapshotManifest,
+    canonical_payload: Vec<u8>,
+    signature: Vec<u8>,
+) -> Result<IncidentSnapshot, SdkError> {
+    manifest.validate()?;
+    if incident_manifest_digest(&manifest)? != manifest.manifest_digest {
+        return Err(SdkError::Invalid("incident snapshot manifest digest"));
+    }
+    let snapshot = IncidentSnapshot {
+        payload_digest: ContentDigest::of_bytes(&canonical_payload),
+        manifest,
+        canonical_payload,
+        signature,
+    };
+    snapshot.validate()?;
+    Ok(snapshot)
+}

--- a/crates/platform-engine/src/lib.rs
+++ b/crates/platform-engine/src/lib.rs
@@ -1,0 +1,34 @@
+#![forbid(unsafe_code)]
+
+//! Deterministic, storage-neutral engines for Cerebro platform capabilities.
+//!
+//! This crate contains pure compilation, evaluation, filtering, planning, and
+//! state-transition logic. It deliberately has no persistence or network
+//! implementation and therefore cannot act as a production fallback.
+
+mod action;
+mod assertion;
+mod canonical;
+mod incident;
+mod plugin;
+mod provenance;
+mod query;
+mod recovery;
+mod simulation;
+mod subscription;
+mod temporal;
+mod view;
+
+pub use action::{ActionCommand, transition_action};
+pub use assertion::{
+    CompiledAssertion, assertion_definition_digest, compile_assertion, evaluate_assertion,
+};
+pub use incident::{incident_manifest_digest, package_incident_snapshot};
+pub use plugin::validate_plugin_execution;
+pub use provenance::assemble_provenance;
+pub use query::{QueryExecutionPlan, QueryStrategy, plan_query};
+pub use recovery::build_recovery_report;
+pub use simulation::{SimulationRelationship, SimulationTopology, simulate_topology};
+pub use subscription::event_matches;
+pub use temporal::{RevisionSnapshot, SnapshotKey, SnapshotValue, diff_snapshots};
+pub use view::materialize_view;

--- a/crates/platform-engine/src/plugin.rs
+++ b/crates/platform-engine/src/plugin.rs
@@ -1,0 +1,17 @@
+use cerebro_platform_sdk::{AnalysisPluginManifest, ResourceBudget, ResourceUsage, SdkError};
+
+pub fn validate_plugin_execution(
+    manifest: &AnalysisPluginManifest,
+    budget: &ResourceBudget,
+    usage: &ResourceUsage,
+) -> Result<(), SdkError> {
+    manifest.validate()?;
+    if manifest.limits.memory_bytes > budget.max_plugin_memory_bytes
+        || manifest.limits.execution_millis > budget.max_plugin_millis
+    {
+        return Err(SdkError::OutOfRange("plugin manifest budget"));
+    }
+    usage
+        .validate(budget)
+        .map_err(|_| SdkError::OutOfRange("plugin execution budget"))
+}

--- a/crates/platform-engine/src/plugin.rs
+++ b/crates/platform-engine/src/plugin.rs
@@ -8,8 +8,10 @@ pub fn validate_plugin_execution(
     manifest.validate()?;
     if manifest.limits.memory_bytes > budget.max_plugin_memory_bytes
         || manifest.limits.execution_millis > budget.max_plugin_millis
+        || usage.plugin_memory_bytes > manifest.limits.memory_bytes
+        || usage.plugin_millis > manifest.limits.execution_millis
     {
-        return Err(SdkError::OutOfRange("plugin manifest budget"));
+        return Err(SdkError::OutOfRange("plugin execution budget"));
     }
     usage
         .validate(budget)

--- a/crates/platform-engine/src/provenance.rs
+++ b/crates/platform-engine/src/provenance.rs
@@ -1,0 +1,40 @@
+use cerebro_platform_sdk::{
+    AssertionId, EntityId, EvidenceQuality, EvidenceReference, GraphRevision,
+    ProvenanceExplanation, SdkError, TenantId,
+};
+
+use crate::canonical;
+
+pub fn assemble_provenance(
+    tenant_id: TenantId,
+    graph_revision: GraphRevision,
+    entity_id: Option<EntityId>,
+    assertion_id: Option<AssertionId>,
+    mut evidence: Vec<EvidenceReference>,
+    quality: EvidenceQuality,
+) -> Result<ProvenanceExplanation, SdkError> {
+    evidence.sort_by(|left, right| {
+        left.evidence_id
+            .cmp(&right.evidence_id)
+            .then_with(|| left.event_id.cmp(&right.event_id))
+    });
+    let explanation_digest = canonical::digest(&(
+        &tenant_id,
+        graph_revision,
+        &entity_id,
+        &assertion_id,
+        &evidence,
+        &quality,
+    ))?;
+    let explanation = ProvenanceExplanation {
+        tenant_id,
+        graph_revision,
+        entity_id,
+        assertion_id,
+        evidence,
+        quality,
+        explanation_digest,
+    };
+    explanation.validate()?;
+    Ok(explanation)
+}

--- a/crates/platform-engine/src/query.rs
+++ b/crates/platform-engine/src/query.rs
@@ -1,0 +1,48 @@
+use cerebro_platform_sdk::{FactQuery, ResourceBudget, SdkError};
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryStrategy {
+    StableKeyLookup,
+    BoundedTraversal,
+    BoundedProjectionScan,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct QueryExecutionPlan {
+    pub strategy: QueryStrategy,
+    pub max_rows: u32,
+    pub max_depth: u8,
+    pub deadline_millis: u32,
+}
+
+pub fn plan_query(
+    query: &FactQuery,
+    budget: &ResourceBudget,
+) -> Result<QueryExecutionPlan, SdkError> {
+    let requested_rows =
+        u32::try_from(query.limit()).map_err(|_| SdkError::OutOfRange("query result limit"))?;
+    if requested_rows > budget.max_query_results {
+        return Err(SdkError::OutOfRange("query result limit"));
+    }
+    let depth =
+        u8::try_from(query.edges().len()).map_err(|_| SdkError::OutOfRange("query depth"))?;
+    if depth > budget.max_query_depth {
+        return Err(SdkError::OutOfRange("query depth"));
+    }
+    let has_stable_keys = query.nodes().iter().all(|node| !node.keys.is_empty());
+    let strategy = if has_stable_keys {
+        QueryStrategy::StableKeyLookup
+    } else if !query.edges().is_empty() {
+        QueryStrategy::BoundedTraversal
+    } else {
+        QueryStrategy::BoundedProjectionScan
+    };
+    Ok(QueryExecutionPlan {
+        strategy,
+        max_rows: requested_rows,
+        max_depth: depth,
+        deadline_millis: budget.max_query_millis,
+    })
+}

--- a/crates/platform-engine/src/recovery.rs
+++ b/crates/platform-engine/src/recovery.rs
@@ -1,0 +1,55 @@
+use cerebro_platform_sdk::{
+    ContentDigest, GraphRevision, RecoveryCheck, RecoveryReport, RecoveryState, SdkError, TenantId,
+};
+
+use crate::canonical;
+
+pub fn build_recovery_report(
+    tenant_id: TenantId,
+    append_log_sequence: u64,
+    postgres_revision: GraphRevision,
+    neo4j_revision: GraphRevision,
+    mut checks: Vec<RecoveryCheck>,
+) -> Result<RecoveryReport, SdkError> {
+    if checks.is_empty() {
+        return Err(SdkError::Empty("recovery checks"));
+    }
+    checks.sort_by(|left, right| left.name.cmp(&right.name));
+    if checks
+        .iter()
+        .any(|check| check.name.is_empty() || check.name.trim() != check.name)
+    {
+        return Err(SdkError::Invalid("recovery check name"));
+    }
+    let state = if checks
+        .iter()
+        .any(|check| check.state == RecoveryState::Failed)
+    {
+        RecoveryState::Failed
+    } else if postgres_revision != neo4j_revision
+        || checks
+            .iter()
+            .any(|check| check.state == RecoveryState::Indeterminate)
+    {
+        RecoveryState::Indeterminate
+    } else {
+        RecoveryState::Passed
+    };
+    let report_digest: ContentDigest = canonical::digest(&(
+        &tenant_id,
+        append_log_sequence,
+        postgres_revision,
+        neo4j_revision,
+        &checks,
+        state,
+    ))?;
+    Ok(RecoveryReport {
+        tenant_id,
+        append_log_sequence,
+        postgres_revision,
+        neo4j_revision,
+        checks,
+        state,
+        report_digest,
+    })
+}

--- a/crates/platform-engine/src/simulation.rs
+++ b/crates/platform-engine/src/simulation.rs
@@ -1,0 +1,112 @@
+use std::collections::BTreeSet;
+
+use cerebro_platform_sdk::{
+    EntityId, ProposedChange, RelationKind, SdkError, SimulationFinding, SimulationRequest,
+    SimulationResult, TenantId,
+};
+use serde::Serialize;
+
+use crate::canonical;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct SimulationRelationship {
+    pub from_entity_id: EntityId,
+    pub relation: RelationKind,
+    pub to_entity_id: EntityId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SimulationTopology {
+    pub tenant_id: TenantId,
+    pub entities: BTreeSet<EntityId>,
+    pub relationships: BTreeSet<SimulationRelationship>,
+}
+
+pub fn simulate_topology(
+    request: &SimulationRequest,
+    topology: &SimulationTopology,
+    assertion_results: Vec<SimulationFinding>,
+) -> Result<SimulationResult, SdkError> {
+    request.validate()?;
+    if request.tenant_id != topology.tenant_id {
+        return Err(SdkError::Invalid("simulation tenant"));
+    }
+    let mut projected = topology.clone();
+    let mut affected = BTreeSet::new();
+    let max_affected = usize::try_from(request.max_affected_entities)
+        .map_err(|_| SdkError::OutOfRange("simulation affected entity limit"))?;
+    for change in &request.changes {
+        match change {
+            ProposedChange::RemoveEntity { entity_id } => {
+                if !projected.entities.remove(entity_id) {
+                    return Err(SdkError::NotFound(format!("simulation entity {entity_id}")));
+                }
+                affected.insert(entity_id.clone());
+                projected.relationships.retain(|relationship| {
+                    let retained = relationship.from_entity_id != *entity_id
+                        && relationship.to_entity_id != *entity_id;
+                    if !retained {
+                        affected.insert(relationship.from_entity_id.clone());
+                        affected.insert(relationship.to_entity_id.clone());
+                    }
+                    retained
+                });
+            }
+            ProposedChange::RemoveRelationship {
+                from_entity_id,
+                relation,
+                to_entity_id,
+            } => {
+                let relationship = SimulationRelationship {
+                    from_entity_id: from_entity_id.clone(),
+                    relation: *relation,
+                    to_entity_id: to_entity_id.clone(),
+                };
+                if !projected.relationships.remove(&relationship) {
+                    return Err(SdkError::NotFound("simulation relationship".to_owned()));
+                }
+                affected.extend([from_entity_id.clone(), to_entity_id.clone()]);
+            }
+            ProposedChange::AddRelationship {
+                from_entity_id,
+                relation,
+                to_entity_id,
+            } => {
+                if !projected.entities.contains(from_entity_id)
+                    || !projected.entities.contains(to_entity_id)
+                {
+                    return Err(SdkError::NotFound(
+                        "simulation relationship endpoint".to_owned(),
+                    ));
+                }
+                let relationship = SimulationRelationship {
+                    from_entity_id: from_entity_id.clone(),
+                    relation: *relation,
+                    to_entity_id: to_entity_id.clone(),
+                };
+                if !projected.relationships.insert(relationship) {
+                    return Err(SdkError::Conflict(
+                        "simulation relationship already exists".to_owned(),
+                    ));
+                }
+                affected.extend([from_entity_id.clone(), to_entity_id.clone()]);
+            }
+        }
+        if affected.len() > max_affected {
+            return Err(SdkError::OutOfRange("simulation affected entity limit"));
+        }
+    }
+    let affected_entities = affected.into_iter().collect::<Vec<_>>();
+    let result_digest =
+        canonical::digest(&(request, &affected_entities, &assertion_results, &projected))?;
+    Ok(SimulationResult {
+        simulation_id: request.simulation_id.clone(),
+        tenant_id: request.tenant_id.clone(),
+        base_revision: request.base_revision,
+        applied_changes: request.changes.clone(),
+        affected_entities,
+        assertion_results,
+        truncated: false,
+        result_digest,
+    })
+}

--- a/crates/platform-engine/src/subscription.rs
+++ b/crates/platform-engine/src/subscription.rs
@@ -1,0 +1,20 @@
+use cerebro_platform_sdk::{PlatformEvent, SubscriptionEventFilter};
+
+pub fn event_matches(filter: &SubscriptionEventFilter, event: &PlatformEvent) -> bool {
+    (filter.event_kinds.is_empty() || filter.event_kinds.contains(&event.kind))
+        && (filter.entity_kinds.is_empty()
+            || event
+                .entity_kind
+                .as_ref()
+                .is_some_and(|kind| filter.entity_kinds.contains(kind)))
+        && (filter.entity_ids.is_empty()
+            || event
+                .entity_id
+                .as_ref()
+                .is_some_and(|id| filter.entity_ids.contains(id)))
+        && (filter.assertion_ids.is_empty()
+            || event
+                .assertion_id
+                .as_ref()
+                .is_some_and(|id| filter.assertion_ids.contains(id)))
+}

--- a/crates/platform-engine/src/temporal.rs
+++ b/crates/platform-engine/src/temporal.rs
@@ -59,7 +59,12 @@ pub fn diff_snapshots(
         .into_iter()
         .filter_map(|key| change_for_key(&key, before.values.get(&key), after.values.get(&key)))
         .collect::<Vec<_>>();
-    let full_digest = canonical::digest(&changes)?;
+    let full_digest = canonical::digest(&(
+        &request.tenant_id,
+        before.revision,
+        after.revision,
+        &changes,
+    ))?;
     let offset = parse_cursor(request.cursor.as_deref(), &full_digest)?;
     if offset > changes.len() {
         return Err(SdkError::Invalid("graph diff cursor"));
@@ -71,7 +76,7 @@ pub fn diff_snapshots(
     let page = changes.drain(offset..offset + page_len).collect::<Vec<_>>();
     let next_offset = offset + page_len;
     let truncated = next_offset < offset + remaining;
-    let next_cursor = truncated.then(|| format!("{next_offset}:{}", &full_digest.as_str()[..16]));
+    let next_cursor = truncated.then(|| format!("{next_offset}:{full_digest}"));
     Ok(GraphDiff {
         tenant_id: request.tenant_id.clone(),
         from_revision: before.revision,
@@ -90,7 +95,7 @@ fn parse_cursor(cursor: Option<&str>, digest: &ContentDigest) -> Result<usize, S
     let (offset, binding) = cursor
         .split_once(':')
         .ok_or(SdkError::Invalid("graph diff cursor"))?;
-    if binding != &digest.as_str()[..16] {
+    if binding != digest.as_str() {
         return Err(SdkError::Invalid("graph diff cursor"));
     }
     offset

--- a/crates/platform-engine/src/temporal.rs
+++ b/crates/platform-engine/src/temporal.rs
@@ -1,0 +1,141 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use cerebro_platform_sdk::{
+    AssertionId, ContentDigest, EntityId, GraphChange, GraphChangeKind, GraphDiff,
+    GraphDiffRequest, GraphRevision, RevisionSelector, SdkError, TenantId,
+};
+use serde::Serialize;
+
+use crate::canonical;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "id")]
+pub enum SnapshotKey {
+    Entity(EntityId),
+    Assertion(AssertionId),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SnapshotValue {
+    pub digest: ContentDigest,
+    pub observed_at_unix_millis: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RevisionSnapshot {
+    pub tenant_id: TenantId,
+    pub revision: GraphRevision,
+    pub values: BTreeMap<SnapshotKey, SnapshotValue>,
+}
+
+pub fn diff_snapshots(
+    request: &GraphDiffRequest,
+    before: &RevisionSnapshot,
+    after: &RevisionSnapshot,
+) -> Result<GraphDiff, SdkError> {
+    request.validate()?;
+    if request.tenant_id != before.tenant_id || request.tenant_id != after.tenant_id {
+        return Err(SdkError::Invalid("graph diff tenant"));
+    }
+    if request.from_revision != before.revision {
+        return Err(SdkError::Invalid("graph diff starting revision"));
+    }
+    if let RevisionSelector::Exact(revision) = request.to_revision
+        && revision != after.revision
+    {
+        return Err(SdkError::Invalid("graph diff ending revision"));
+    }
+    if after.revision <= before.revision {
+        return Err(SdkError::Invalid("graph diff revision window"));
+    }
+
+    let keys = before
+        .values
+        .keys()
+        .chain(after.values.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut changes = keys
+        .into_iter()
+        .filter_map(|key| change_for_key(&key, before.values.get(&key), after.values.get(&key)))
+        .collect::<Vec<_>>();
+    let full_digest = canonical::digest(&changes)?;
+    let offset = parse_cursor(request.cursor.as_deref(), &full_digest)?;
+    if offset > changes.len() {
+        return Err(SdkError::Invalid("graph diff cursor"));
+    }
+    let limit =
+        usize::try_from(request.limit).map_err(|_| SdkError::OutOfRange("graph diff limit"))?;
+    let remaining = changes.len() - offset;
+    let page_len = remaining.min(limit);
+    let page = changes.drain(offset..offset + page_len).collect::<Vec<_>>();
+    let next_offset = offset + page_len;
+    let truncated = next_offset < offset + remaining;
+    let next_cursor = truncated.then(|| format!("{next_offset}:{}", &full_digest.as_str()[..16]));
+    Ok(GraphDiff {
+        tenant_id: request.tenant_id.clone(),
+        from_revision: before.revision,
+        to_revision: after.revision,
+        changes: page,
+        next_cursor,
+        truncated,
+        digest: full_digest,
+    })
+}
+
+fn parse_cursor(cursor: Option<&str>, digest: &ContentDigest) -> Result<usize, SdkError> {
+    let Some(cursor) = cursor else {
+        return Ok(0);
+    };
+    let (offset, binding) = cursor
+        .split_once(':')
+        .ok_or(SdkError::Invalid("graph diff cursor"))?;
+    if binding != &digest.as_str()[..16] {
+        return Err(SdkError::Invalid("graph diff cursor"));
+    }
+    offset
+        .parse()
+        .map_err(|_| SdkError::Invalid("graph diff cursor"))
+}
+
+fn change_for_key(
+    key: &SnapshotKey,
+    before: Option<&SnapshotValue>,
+    after: Option<&SnapshotValue>,
+) -> Option<GraphChange> {
+    if before.map(|value| &value.digest) == after.map(|value| &value.digest) {
+        return None;
+    }
+    let (entity_id, assertion_id, added, updated, retracted) = match key {
+        SnapshotKey::Entity(id) => (
+            Some(id.clone()),
+            None,
+            GraphChangeKind::EntityAdded,
+            GraphChangeKind::EntityUpdated,
+            GraphChangeKind::EntityRetracted,
+        ),
+        SnapshotKey::Assertion(id) => (
+            None,
+            Some(id.clone()),
+            GraphChangeKind::AssertionAdded,
+            GraphChangeKind::AssertionUpdated,
+            GraphChangeKind::AssertionRetracted,
+        ),
+    };
+    let kind = match (before, after) {
+        (None, Some(_)) => added,
+        (Some(_), Some(_)) => updated,
+        (Some(_), None) => retracted,
+        (None, None) => return None,
+    };
+    Some(GraphChange {
+        kind,
+        entity_id,
+        assertion_id,
+        before_digest: before.map(|value| value.digest.clone()),
+        after_digest: after.map(|value| value.digest.clone()),
+        observed_at_unix_millis: after
+            .or(before)
+            .map_or(0, |value| value.observed_at_unix_millis),
+    })
+}

--- a/crates/platform-engine/src/view.rs
+++ b/crates/platform-engine/src/view.rs
@@ -27,6 +27,10 @@ pub fn materialize_view(
         row_count,
         state: ViewRefreshState::Current,
         refreshed_at_unix_millis,
-        result_digest: canonical::digest(result)?,
+        result_digest: canonical::digest(&(
+            &definition.view_id,
+            &definition.definition_digest,
+            result,
+        ))?,
     })
 }

--- a/crates/platform-engine/src/view.rs
+++ b/crates/platform-engine/src/view.rs
@@ -1,0 +1,32 @@
+use cerebro_platform_sdk::{
+    GraphRevision, MaterializedViewDefinition, MaterializedViewSnapshot, QueryResult, SdkError,
+    ViewRefreshState,
+};
+
+use crate::canonical;
+
+pub fn materialize_view(
+    definition: &MaterializedViewDefinition,
+    result: &QueryResult,
+    refreshed_at_unix_millis: i64,
+) -> Result<MaterializedViewSnapshot, SdkError> {
+    definition.validate()?;
+    if definition.tenant_id != result.tenant_id {
+        return Err(SdkError::Invalid("materialized view tenant"));
+    }
+    if result.truncated || result.matches.len() > definition.max_rows as usize {
+        return Err(SdkError::OutOfRange("materialized view rows"));
+    }
+    let graph_revision = GraphRevision::new(result.graph_revision)?;
+    let row_count = u32::try_from(result.matches.len())
+        .map_err(|_| SdkError::OutOfRange("materialized view rows"))?;
+    Ok(MaterializedViewSnapshot {
+        view_id: definition.view_id.clone(),
+        tenant_id: definition.tenant_id.clone(),
+        graph_revision,
+        row_count,
+        state: ViewRefreshState::Current,
+        refreshed_at_unix_millis,
+        result_digest: canonical::digest(result)?,
+    })
+}

--- a/crates/platform-engine/tests/engine.rs
+++ b/crates/platform-engine/tests/engine.rs
@@ -2,18 +2,21 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use cerebro_platform_engine::{
     ActionCommand, RevisionSnapshot, SimulationTopology, SnapshotKey, SnapshotValue,
-    assertion_definition_digest, build_recovery_report, compile_assertion, diff_snapshots,
-    evaluate_assertion, event_matches, incident_manifest_digest, package_incident_snapshot,
-    plan_query, simulate_topology, transition_action,
+    assemble_provenance, assertion_definition_digest, build_recovery_report, compile_assertion,
+    diff_snapshots, evaluate_assertion, event_matches, incident_manifest_digest, materialize_view,
+    package_incident_snapshot, plan_query, simulate_topology, transition_action,
+    validate_plugin_execution,
 };
 use cerebro_platform_sdk::{
     ActionEffect, ActionOperation, ActionOperationId, ActionProposal, ActionState,
-    AssertionCondition, AssertionDefinition, AssertionDefinitionId, AssertionState, ContentDigest,
-    EntityId, EvaluationTrigger, EvidenceQuality, FactQuery, GraphDiffRequest, GraphRevision,
-    IncidentSnapshotId, IncidentSnapshotManifest, OpaqueId, PlatformEvent, PlatformEventKind,
-    ProposedChange, QueryNode, QueryResult, RecoveryCheck, RecoveryState, ResourceBudget,
-    RevisionSelector, SimulationId, SimulationRequest, SubscriptionEventFilter, TenantId,
-    VerificationState,
+    AnalysisPluginManifest, AssertionCondition, AssertionDefinition, AssertionDefinitionId,
+    AssertionState, ContentDigest, EntityId, EntityKind, EvaluationTrigger, EvidenceAuthority,
+    EvidenceQuality, EvidenceReference, FactQuery, GraphDiffRequest, GraphRevision,
+    IncidentSnapshotId, IncidentSnapshotManifest, MaterializedViewDefinition, OpaqueId,
+    PlatformEvent, PlatformEventKind, PluginCapability, PluginId, PluginLimits, ProposedChange,
+    QueryEdge, QueryNode, QueryResult, RecoveryCheck, RecoveryState, RelationKind, ResourceBudget,
+    ResourceUsage, RevisionSelector, SimulationId, SimulationRequest, SourceRuntimeId,
+    SubscriptionEventFilter, TenantId, VerificationState, ViewId,
 };
 
 fn tenant() -> TenantId {
@@ -175,6 +178,49 @@ fn action_transitions_are_optimistic_and_fail_closed() {
     assert_eq!(simulated.state, ActionState::Simulated);
     assert_eq!(simulated.version, 2);
     assert!(transition_action(&operation, 0, ActionCommand::RecordSimulation).is_err());
+    let waiting =
+        transition_action(&simulated, 2, ActionCommand::RequestApproval).expect("transition");
+    let claimed = transition_action(
+        &waiting,
+        3,
+        ActionCommand::Claim {
+            worker_id: OpaqueId::parse("worker:one").expect("valid worker"),
+        },
+    )
+    .expect("transition");
+    let executing =
+        transition_action(&claimed, 4, ActionCommand::StartExecution).expect("transition");
+    let completed = transition_action(
+        &executing,
+        5,
+        ActionCommand::Complete {
+            external_receipt_ref: OpaqueId::parse("receipt:one").expect("valid receipt"),
+            observed_effect_digest: digest("observed"),
+        },
+    )
+    .expect("transition");
+    let verified = transition_action(&completed, 6, ActionCommand::Verify).expect("transition");
+    assert_eq!(verified.state, ActionState::Verified);
+    assert_eq!(verified.verification_state, VerificationState::Verified);
+    assert_eq!(verified.version, 7);
+    assert!(transition_action(&verified, 7, ActionCommand::StartExecution).is_err());
+
+    let uncertain =
+        transition_action(&executing, 5, ActionCommand::MarkOutcomeUnknown).expect("transition");
+    let reconciled = transition_action(
+        &uncertain,
+        6,
+        ActionCommand::Reconcile {
+            observed_effect_digest: digest("reconciled"),
+        },
+    )
+    .expect("transition");
+    assert_eq!(reconciled.state, ActionState::Reconciled);
+
+    let failed = transition_action(&simulated, 2, ActionCommand::Fail).expect("transition");
+    let rolled_back = transition_action(&failed, 3, ActionCommand::RollBack).expect("transition");
+    assert_eq!(rolled_back.state, ActionState::RolledBack);
+    assert_eq!(rolled_back.verification_state, VerificationState::Stale);
 }
 
 #[test]
@@ -237,4 +283,473 @@ fn incident_packages_bind_manifest_payload_and_signature() {
     let snapshot =
         package_incident_snapshot(manifest, b"canonical".to_vec(), vec![1]).expect("snapshot");
     assert_eq!(snapshot.payload_digest, digest("canonical"));
+}
+
+#[test]
+fn assertion_definition_digest_binds_the_assertion_identity() {
+    let definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:one")
+            .expect("valid assertion"),
+        tenant_id: tenant(),
+        name: "Repository exists".to_owned(),
+        query: query(10),
+        condition: AssertionCondition::AtLeastOneMatch,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("placeholder"),
+    };
+    let changed_id = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:two")
+            .expect("valid assertion"),
+        ..definition.clone()
+    };
+    assert_ne!(
+        assertion_definition_digest(&definition).expect("digest"),
+        assertion_definition_digest(&changed_id).expect("digest")
+    );
+}
+
+#[test]
+fn temporal_pagination_reconstructs_the_complete_ordered_diff() {
+    let before = RevisionSnapshot {
+        tenant_id: tenant(),
+        revision: revision(1),
+        values: BTreeMap::new(),
+    };
+    let values = (0..31)
+        .map(|index| {
+            (
+                SnapshotKey::Entity(
+                    EntityId::parse(format!("repository:{index:02}")).expect("valid entity"),
+                ),
+                SnapshotValue {
+                    digest: digest(&format!("value-{index}")),
+                    observed_at_unix_millis: i64::from(index),
+                },
+            )
+        })
+        .collect();
+    let after = RevisionSnapshot {
+        tenant_id: tenant(),
+        revision: revision(2),
+        values,
+    };
+    let mut cursor = None;
+    let mut changes = Vec::new();
+    let mut complete_digest = None;
+    loop {
+        let page = diff_snapshots(
+            &GraphDiffRequest {
+                tenant_id: tenant(),
+                from_revision: revision(1),
+                to_revision: RevisionSelector::Exact(revision(2)),
+                limit: 7,
+                cursor,
+            },
+            &before,
+            &after,
+        )
+        .expect("graph diff page");
+        if let Some(expected) = &complete_digest {
+            assert_eq!(expected, &page.digest);
+        } else {
+            complete_digest = Some(page.digest.clone());
+        }
+        changes.extend(page.changes);
+        if !page.truncated {
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+    assert_eq!(changes.len(), 31);
+    assert!(
+        changes
+            .windows(2)
+            .all(|pair| pair[0].entity_id < pair[1].entity_id)
+    );
+}
+
+#[test]
+fn simulation_failure_is_atomic_for_multi_change_requests() {
+    let entity = EntityId::parse("repository:one").expect("valid entity");
+    let topology = SimulationTopology {
+        tenant_id: tenant(),
+        entities: BTreeSet::from([entity.clone()]),
+        relationships: BTreeSet::new(),
+    };
+    let request = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:failure").expect("valid simulation"),
+        tenant_id: tenant(),
+        base_revision: revision(1),
+        changes: vec![
+            ProposedChange::RemoveEntity {
+                entity_id: entity.clone(),
+            },
+            ProposedChange::RemoveEntity {
+                entity_id: EntityId::parse("repository:missing").expect("valid entity"),
+            },
+        ],
+        assertions: Vec::new(),
+        max_affected_entities: 10,
+    };
+    assert!(simulate_topology(&request, &topology, Vec::new()).is_err());
+    assert_eq!(topology.entities, BTreeSet::from([entity]));
+}
+
+#[test]
+fn materialized_results_bind_the_view_definition() {
+    let result = QueryResult {
+        tenant_id: tenant(),
+        graph_revision: 3,
+        matches: Vec::new(),
+        truncated: false,
+    };
+    let definition = MaterializedViewDefinition {
+        view_id: ViewId::parse("view:one").expect("valid view"),
+        tenant_id: tenant(),
+        name: "Repositories".to_owned(),
+        query: query(10),
+        max_rows: 10,
+        definition_digest: digest("definition-one"),
+    };
+    let changed = MaterializedViewDefinition {
+        view_id: ViewId::parse("view:two").expect("valid view"),
+        definition_digest: digest("definition-two"),
+        ..definition.clone()
+    };
+    assert_ne!(
+        materialize_view(&definition, &result, 10)
+            .expect("materialized view")
+            .result_digest,
+        materialize_view(&changed, &result, 10)
+            .expect("materialized view")
+            .result_digest
+    );
+}
+
+#[test]
+fn plugin_execution_obeys_manifest_limits_below_tenant_limits() {
+    let manifest = AnalysisPluginManifest {
+        plugin_id: PluginId::parse("plugin:one").expect("valid plugin"),
+        abi_version: "v1".to_owned(),
+        artifact_digest: digest("plugin"),
+        capabilities: vec![PluginCapability::AssertionEvaluation],
+        limits: PluginLimits {
+            memory_bytes: 512,
+            execution_millis: 50,
+            input_bytes: 1_024,
+            output_bytes: 1_024,
+        },
+        zero_imports_required: true,
+        deterministic_output_required: true,
+    };
+    let budget =
+        ResourceBudget::new(100, 6, 2_000, 8, 100, 10_000, 1_024, 100).expect("valid budget");
+    let usage = ResourceUsage {
+        query_results: 0,
+        query_depth: 0,
+        query_millis: 0,
+        concurrent_queries: 0,
+        subscription_batch: 0,
+        snapshot_entities: 0,
+        plugin_memory_bytes: 513,
+        plugin_millis: 50,
+    };
+    assert!(validate_plugin_execution(&manifest, &budget, &usage).is_err());
+    let valid_usage = ResourceUsage {
+        plugin_memory_bytes: 512,
+        ..usage
+    };
+    assert!(validate_plugin_execution(&manifest, &budget, &valid_usage).is_ok());
+    let oversized_manifest = AnalysisPluginManifest {
+        limits: PluginLimits {
+            memory_bytes: 2_048,
+            ..manifest.limits.clone()
+        },
+        ..manifest
+    };
+    assert!(validate_plugin_execution(&oversized_manifest, &budget, &valid_usage).is_err());
+}
+
+#[test]
+fn recovery_digest_is_independent_of_check_input_order() {
+    let checks = vec![
+        RecoveryCheck {
+            name: "projection".to_owned(),
+            state: RecoveryState::Passed,
+            expected_digest: Some(digest("projection")),
+            observed_digest: Some(digest("projection")),
+            reason_code: None,
+        },
+        RecoveryCheck {
+            name: "ledger".to_owned(),
+            state: RecoveryState::Passed,
+            expected_digest: Some(digest("ledger")),
+            observed_digest: Some(digest("ledger")),
+            reason_code: None,
+        },
+    ];
+    let mut reversed = checks.clone();
+    reversed.reverse();
+    let first =
+        build_recovery_report(tenant(), 10, revision(3), revision(3), checks).expect("report");
+    let second =
+        build_recovery_report(tenant(), 10, revision(3), revision(3), reversed).expect("report");
+    assert_eq!(first.report_digest, second.report_digest);
+}
+
+#[test]
+fn provenance_is_sorted_bound_to_one_target_and_digest_stable() {
+    let evidence = |id: &str| EvidenceReference {
+        evidence_id: OpaqueId::parse(id).expect("valid evidence"),
+        source_runtime_id: SourceRuntimeId::parse("runtime:one").expect("valid runtime"),
+        event_id: OpaqueId::parse(format!("event:{id}")).expect("valid event"),
+        observed_at_unix_millis: 10,
+        authority: EvidenceAuthority::Authoritative,
+        content_digest: digest(id),
+    };
+    let quality = EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("quality");
+    let explanation = assemble_provenance(
+        tenant(),
+        revision(2),
+        Some(EntityId::parse("repository:one").expect("valid entity")),
+        None,
+        vec![evidence("two"), evidence("one")],
+        quality.clone(),
+    )
+    .expect("provenance");
+    assert_eq!(explanation.evidence[0].evidence_id.as_str(), "one");
+    assert_eq!(explanation.evidence[1].evidence_id.as_str(), "two");
+    assert!(
+        assemble_provenance(
+            tenant(),
+            revision(2),
+            None,
+            None,
+            vec![evidence("one")],
+            quality,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn simulation_adds_and_removes_relationships_with_endpoint_checks() {
+    let left = EntityId::parse("repository:left").expect("valid entity");
+    let right = EntityId::parse("repository:right").expect("valid entity");
+    let relationship = cerebro_platform_engine::SimulationRelationship {
+        from_entity_id: left.clone(),
+        relation: RelationKind::DependsOn,
+        to_entity_id: right.clone(),
+    };
+    let empty = SimulationTopology {
+        tenant_id: tenant(),
+        entities: BTreeSet::from([left.clone(), right.clone()]),
+        relationships: BTreeSet::new(),
+    };
+    let add = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:add").expect("valid simulation"),
+        tenant_id: tenant(),
+        base_revision: revision(1),
+        changes: vec![ProposedChange::AddRelationship {
+            from_entity_id: left.clone(),
+            relation: RelationKind::DependsOn,
+            to_entity_id: right.clone(),
+        }],
+        assertions: Vec::new(),
+        max_affected_entities: 2,
+    };
+    assert_eq!(
+        simulate_topology(&add, &empty, Vec::new())
+            .expect("simulation")
+            .affected_entities,
+        vec![left.clone(), right.clone()]
+    );
+
+    let connected = SimulationTopology {
+        relationships: BTreeSet::from([relationship]),
+        ..empty.clone()
+    };
+    let remove = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:remove").expect("valid simulation"),
+        changes: vec![ProposedChange::RemoveRelationship {
+            from_entity_id: left,
+            relation: RelationKind::DependsOn,
+            to_entity_id: right,
+        }],
+        ..add
+    };
+    assert!(simulate_topology(&remove, &connected, Vec::new()).is_ok());
+    assert!(simulate_topology(&remove, &empty, Vec::new()).is_err());
+}
+
+#[test]
+fn subscription_filters_fail_each_nonmatching_dimension() {
+    let event = PlatformEvent {
+        cursor: cerebro_platform_sdk::DurableCursor::new(1),
+        tenant_id: tenant(),
+        kind: PlatformEventKind::GraphChanged,
+        graph_revision: Some(revision(1)),
+        entity_kind: Some(EntityKind::Repository),
+        entity_id: Some(EntityId::parse("repository:one").expect("valid entity")),
+        assertion_id: Some(
+            AssertionDefinitionId::parse("assertion-definition:one").expect("valid assertion"),
+        ),
+        occurred_at_unix_millis: 1,
+        payload_digest: digest("event"),
+    };
+    let base = SubscriptionEventFilter {
+        event_kinds: vec![PlatformEventKind::GraphChanged],
+        entity_kinds: vec![EntityKind::Repository],
+        entity_ids: vec![EntityId::parse("repository:one").expect("valid entity")],
+        assertion_ids: vec![
+            AssertionDefinitionId::parse("assertion-definition:one").expect("valid assertion"),
+        ],
+    };
+    assert!(event_matches(&base, &event));
+    assert!(!event_matches(
+        &SubscriptionEventFilter {
+            event_kinds: vec![PlatformEventKind::ActionChanged],
+            ..base.clone()
+        },
+        &event
+    ));
+    assert!(!event_matches(
+        &SubscriptionEventFilter {
+            entity_kinds: vec![EntityKind::Person],
+            ..base.clone()
+        },
+        &event
+    ));
+    assert!(!event_matches(
+        &SubscriptionEventFilter {
+            entity_ids: vec![EntityId::parse("repository:two").expect("valid entity")],
+            ..base.clone()
+        },
+        &event
+    ));
+    assert!(!event_matches(
+        &SubscriptionEventFilter {
+            assertion_ids: vec![
+                AssertionDefinitionId::parse("assertion-definition:two").expect("valid assertion"),
+            ],
+            ..base
+        },
+        &event
+    ));
+}
+
+#[test]
+fn query_planner_selects_bounded_scan_and_traversal_and_rejects_budget_overflow() {
+    let budget =
+        ResourceBudget::new(100, 6, 2_000, 8, 100, 10_000, 1_024, 100).expect("valid budget");
+    let scan = FactQuery::new(
+        vec![QueryNode {
+            variable: "repository".to_owned(),
+            kinds: vec!["repository".to_owned()],
+            keys: Vec::new(),
+        }],
+        Vec::new(),
+        Vec::new(),
+        10,
+    )
+    .expect("query");
+    assert_eq!(
+        plan_query(&scan, &budget).expect("plan").strategy,
+        cerebro_platform_engine::QueryStrategy::BoundedProjectionScan
+    );
+    let traversal = FactQuery::new(
+        vec![
+            QueryNode {
+                variable: "repository".to_owned(),
+                kinds: vec!["repository".to_owned()],
+                keys: Vec::new(),
+            },
+            QueryNode {
+                variable: "service".to_owned(),
+                kinds: vec!["service".to_owned()],
+                keys: Vec::new(),
+            },
+        ],
+        vec![QueryEdge {
+            variable: "dependency".to_owned(),
+            from_variable: "repository".to_owned(),
+            relation: "depends_on".to_owned(),
+            to_variable: "service".to_owned(),
+        }],
+        Vec::new(),
+        10,
+    )
+    .expect("query");
+    assert_eq!(
+        plan_query(&traversal, &budget).expect("plan").strategy,
+        cerebro_platform_engine::QueryStrategy::BoundedTraversal
+    );
+    assert!(plan_query(&query(101), &budget).is_err());
+}
+
+#[test]
+fn assertion_evaluation_is_indeterminate_for_truncation_conflict_and_disabled_policy() {
+    let mut definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:indeterminate")
+            .expect("valid assertion"),
+        tenant_id: tenant(),
+        name: "Repository exists".to_owned(),
+        query: query(10),
+        condition: AssertionCondition::AtLeastOneMatch,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("placeholder"),
+    };
+    definition.definition_digest =
+        assertion_definition_digest(&definition).expect("definition digest");
+    let compiled = compile_assertion(definition.clone()).expect("compiled");
+    let result = QueryResult {
+        tenant_id: tenant(),
+        graph_revision: 2,
+        matches: Vec::new(),
+        truncated: true,
+    };
+    let quality = EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("quality");
+    assert_eq!(
+        evaluate_assertion(&compiled, &result, &quality, 10)
+            .expect("evaluation")
+            .state,
+        AssertionState::Indeterminate
+    );
+    let conflict = EvidenceQuality::new(100, 100, 100, 100, 100, true).expect("quality");
+    assert_eq!(
+        evaluate_assertion(
+            &compiled,
+            &QueryResult {
+                truncated: false,
+                ..result.clone()
+            },
+            &conflict,
+            10,
+        )
+        .expect("evaluation")
+        .state,
+        AssertionState::Indeterminate
+    );
+    definition.enabled = false;
+    definition.definition_digest =
+        assertion_definition_digest(&definition).expect("definition digest");
+    let disabled = compile_assertion(definition).expect("compiled");
+    assert_eq!(
+        evaluate_assertion(
+            &disabled,
+            &QueryResult {
+                truncated: false,
+                ..result
+            },
+            &quality,
+            10,
+        )
+        .expect("evaluation")
+        .state,
+        AssertionState::Indeterminate
+    );
 }

--- a/crates/platform-engine/tests/engine.rs
+++ b/crates/platform-engine/tests/engine.rs
@@ -1,0 +1,240 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use cerebro_platform_engine::{
+    ActionCommand, RevisionSnapshot, SimulationTopology, SnapshotKey, SnapshotValue,
+    assertion_definition_digest, build_recovery_report, compile_assertion, diff_snapshots,
+    evaluate_assertion, event_matches, incident_manifest_digest, package_incident_snapshot,
+    plan_query, simulate_topology, transition_action,
+};
+use cerebro_platform_sdk::{
+    ActionEffect, ActionOperation, ActionOperationId, ActionProposal, ActionState,
+    AssertionCondition, AssertionDefinition, AssertionDefinitionId, AssertionState, ContentDigest,
+    EntityId, EvaluationTrigger, EvidenceQuality, FactQuery, GraphDiffRequest, GraphRevision,
+    IncidentSnapshotId, IncidentSnapshotManifest, OpaqueId, PlatformEvent, PlatformEventKind,
+    ProposedChange, QueryNode, QueryResult, RecoveryCheck, RecoveryState, ResourceBudget,
+    RevisionSelector, SimulationId, SimulationRequest, SubscriptionEventFilter, TenantId,
+    VerificationState,
+};
+
+fn tenant() -> TenantId {
+    TenantId::parse("tenant-a").expect("valid tenant")
+}
+
+fn revision(value: u64) -> GraphRevision {
+    GraphRevision::new(value).expect("valid revision")
+}
+
+fn digest(value: &str) -> ContentDigest {
+    ContentDigest::of_bytes(value)
+}
+
+fn query(limit: usize) -> FactQuery {
+    FactQuery::new(
+        vec![QueryNode {
+            variable: "repository".to_owned(),
+            kinds: vec!["repository".to_owned()],
+            keys: vec!["repository:one".to_owned()],
+        }],
+        Vec::new(),
+        Vec::new(),
+        limit,
+    )
+    .expect("valid query")
+}
+
+#[test]
+fn typed_assertions_compile_and_evaluate_without_transport_state() {
+    let mut definition = AssertionDefinition {
+        assertion_id: AssertionDefinitionId::parse("assertion-definition:one")
+            .expect("valid assertion"),
+        tenant_id: tenant(),
+        name: "Repository exists".to_owned(),
+        query: query(10),
+        condition: AssertionCondition::AtLeastOneMatch,
+        triggers: vec![EvaluationTrigger::GraphChange],
+        evidence_max_age_seconds: 300,
+        enabled: true,
+        definition_digest: digest("placeholder"),
+    };
+    definition.definition_digest =
+        assertion_definition_digest(&definition).expect("definition digest");
+    let compiled = compile_assertion(definition).expect("compiled assertion");
+    let result = QueryResult {
+        tenant_id: tenant(),
+        graph_revision: 3,
+        matches: Vec::new(),
+        truncated: false,
+    };
+    let quality = EvidenceQuality::new(100, 100, 100, 100, 100, false).expect("valid quality");
+    let evaluation =
+        evaluate_assertion(&compiled, &result, &quality, 10).expect("assertion evaluation");
+    assert_eq!(evaluation.state, AssertionState::Violated);
+    assert_eq!(evaluation.reason_codes, vec!["condition_not_met"]);
+}
+
+#[test]
+fn temporal_diff_is_stable_bounded_and_cursor_bound() {
+    let entity = EntityId::parse("repository:one").expect("valid entity");
+    let before = RevisionSnapshot {
+        tenant_id: tenant(),
+        revision: revision(1),
+        values: BTreeMap::from([(
+            SnapshotKey::Entity(entity.clone()),
+            SnapshotValue {
+                digest: digest("before"),
+                observed_at_unix_millis: 1,
+            },
+        )]),
+    };
+    let after = RevisionSnapshot {
+        tenant_id: tenant(),
+        revision: revision(2),
+        values: BTreeMap::from([(
+            SnapshotKey::Entity(entity),
+            SnapshotValue {
+                digest: digest("after"),
+                observed_at_unix_millis: 2,
+            },
+        )]),
+    };
+    let request = GraphDiffRequest {
+        tenant_id: tenant(),
+        from_revision: revision(1),
+        to_revision: RevisionSelector::Exact(revision(2)),
+        limit: 1,
+        cursor: None,
+    };
+    let result = diff_snapshots(&request, &before, &after).expect("graph diff");
+    assert_eq!(result.changes.len(), 1);
+    assert!(!result.truncated);
+}
+
+#[test]
+fn subscriptions_match_every_declared_dimension() {
+    let filter = SubscriptionEventFilter {
+        event_kinds: vec![PlatformEventKind::GraphChanged],
+        entity_kinds: Vec::new(),
+        entity_ids: vec![EntityId::parse("repository:one").expect("valid entity")],
+        assertion_ids: Vec::new(),
+    };
+    let event = PlatformEvent {
+        cursor: cerebro_platform_sdk::DurableCursor::new(1),
+        tenant_id: tenant(),
+        kind: PlatformEventKind::GraphChanged,
+        graph_revision: Some(revision(1)),
+        entity_kind: None,
+        entity_id: Some(EntityId::parse("repository:one").expect("valid entity")),
+        assertion_id: None,
+        occurred_at_unix_millis: 1,
+        payload_digest: digest("event"),
+    };
+    assert!(event_matches(&filter, &event));
+}
+
+#[test]
+fn adaptive_plans_respect_tenant_budgets() {
+    let budget =
+        ResourceBudget::new(100, 6, 2_000, 8, 100, 10_000, 1_024, 100).expect("valid budget");
+    let plan = plan_query(&query(10), &budget).expect("query plan");
+    assert_eq!(
+        plan.strategy,
+        cerebro_platform_engine::QueryStrategy::StableKeyLookup
+    );
+    assert_eq!(plan.max_rows, 10);
+}
+
+#[test]
+fn action_transitions_are_optimistic_and_fail_closed() {
+    let proposal = ActionProposal {
+        operation_id: ActionOperationId::parse("operation:one").expect("valid operation"),
+        tenant_id: tenant(),
+        graph_revision: revision(1),
+        action_kind: "revoke_access".to_owned(),
+        target_id: OpaqueId::parse("grant:one").expect("valid target"),
+        expected_effects: vec![ActionEffect {
+            target_id: OpaqueId::parse("grant:one").expect("valid target"),
+            effect_kind: "access_removed".to_owned(),
+            expected_state_digest: digest("expected"),
+        }],
+        rollback_ref: OpaqueId::parse("rollback:one").expect("valid rollback"),
+        idempotency_key: OpaqueId::parse("idempotency:one").expect("valid key"),
+        simulation_digest: digest("simulation"),
+        proposal_digest: digest("proposal"),
+    };
+    let operation = ActionOperation {
+        proposal,
+        state: ActionState::Proposed,
+        version: 1,
+        claimed_by: None,
+        external_receipt_ref: None,
+        observed_effect_digest: None,
+        verification_state: VerificationState::Pending,
+    };
+    let simulated =
+        transition_action(&operation, 1, ActionCommand::RecordSimulation).expect("transition");
+    assert_eq!(simulated.state, ActionState::Simulated);
+    assert_eq!(simulated.version, 2);
+    assert!(transition_action(&operation, 0, ActionCommand::RecordSimulation).is_err());
+}
+
+#[test]
+fn recovery_reports_fail_on_any_failed_proof() {
+    let report = build_recovery_report(
+        tenant(),
+        10,
+        revision(3),
+        revision(3),
+        vec![RecoveryCheck {
+            name: "ledger replay".to_owned(),
+            state: RecoveryState::Failed,
+            expected_digest: Some(digest("expected")),
+            observed_digest: Some(digest("observed")),
+            reason_code: Some("digest_mismatch".to_owned()),
+        }],
+    )
+    .expect("recovery report");
+    assert_eq!(report.state, RecoveryState::Failed);
+}
+
+#[test]
+fn counterfactual_simulation_does_not_mutate_the_input_topology() {
+    let entity = EntityId::parse("repository:one").expect("valid entity");
+    let topology = SimulationTopology {
+        tenant_id: tenant(),
+        entities: BTreeSet::from([entity.clone()]),
+        relationships: BTreeSet::new(),
+    };
+    let request = SimulationRequest {
+        simulation_id: SimulationId::parse("simulation:one").expect("valid simulation"),
+        tenant_id: tenant(),
+        base_revision: revision(1),
+        changes: vec![ProposedChange::RemoveEntity {
+            entity_id: entity.clone(),
+        }],
+        assertions: Vec::new(),
+        max_affected_entities: 10,
+    };
+    let result = simulate_topology(&request, &topology, Vec::new()).expect("simulation");
+    assert_eq!(result.affected_entities, vec![entity.clone()]);
+    assert!(topology.entities.contains(&entity));
+}
+
+#[test]
+fn incident_packages_bind_manifest_payload_and_signature() {
+    let mut manifest = IncidentSnapshotManifest {
+        snapshot_id: IncidentSnapshotId::parse("snapshot:one").expect("valid snapshot"),
+        tenant_id: tenant(),
+        graph_revision: revision(1),
+        created_at_unix_millis: 10,
+        entity_ids: vec![EntityId::parse("repository:one").expect("valid entity")],
+        source_receipt_digests: vec![digest("source-receipt")],
+        policy_digests: vec![digest("policy")],
+        mission_ids: Vec::new(),
+        verification_receipt_digests: Vec::new(),
+        manifest_digest: digest("placeholder"),
+    };
+    manifest.manifest_digest = incident_manifest_digest(&manifest).expect("manifest digest");
+    let snapshot =
+        package_incident_snapshot(manifest, b"canonical".to_vec(), vec![1]).expect("snapshot");
+    assert_eq!(snapshot.payload_digest, digest("canonical"));
+}


### PR DESCRIPTION
## Summary

- add storage-neutral engines for typed assertion compilation and evaluation, temporal graph diffs, provenance assembly, subscription filtering, and adaptive query planning
- add read-only counterfactual topology simulation, deterministic materialized-view results, signed incident packaging, bounded analysis-plugin execution checks, recovery verdicts, and governed-action state transitions
- bind canonical digests to definitions, evidence, snapshots, reports, and cursor windows
- keep the implementation pure so durable Postgres, Neo4j, JetStream, Connect, and HTTP adapters can reuse it without an in-memory production fallback

## Safety properties

- every query, diff, simulation, view, and plugin execution is hard bounded
- tenant and revision mismatches fail closed
- action transitions use optimistic versions and an explicit state machine
- simulations clone their input topology and cannot mutate authoritative state
- temporal cursors are bound to the complete diff digest
- recovery fails if any required proof fails and remains indeterminate while projections disagree

## Validation

- `make rust-fmt-check`
- `make rust-clippy`
- `make rust-test`
- `make rust-doc-check`
- `make rust-platform-engine-coverage` (90.17% line coverage)
- `make rust-platform-engine-benchmark`
- `python3 scripts/rust_workspace_policy.py`

Release benchmark receipt from the development machine:

- 500-change temporal diff: 501,624 ns/op
- assertion evaluation: 1,080 ns/op
- 100-relationship simulation: 83,080 ns/op

## Dependency

- stacked on #2068
