### PR TITLE
Run candidate builds in parallel with CI

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -14,8 +14,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: stable-release-tag-reservation
-  cancel-in-progress: false
+  # Candidate builds no longer use the stable release reservation:
+  # group: stable-release-tag-reservation
+  # cancel-in-progress: false
+  group: candidate-build-main
+  cancel-in-progress: true
 
 jobs:
   resolve:
@@ -52,11 +55,18 @@ jobs:
             echo "image_tag=candidate-${sha}"
           } >> "${GITHUB_OUTPUT}"
 
+  ci-gate:
+    runs-on: ubuntu-latest
+    needs: resolve
+    permissions:
+      actions: read
+      contents: read
+    steps:
       - name: Require successful CI for candidate commit
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
+          CANDIDATE_SHA: ${{ needs.resolve.outputs.sha }}
         run: |
           set -euo pipefail
           deadline=$((SECONDS + 1800))
@@ -121,6 +131,17 @@ jobs:
         env:
           RUST_TARGET: ${{ matrix.rust_target }}
         run: rustup toolchain install 1.93.1 --profile minimal --target "${RUST_TARGET}"
+      - name: Restore Rust build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: candidate-${{ runner.os }}-${{ runner.arch }}-${{ matrix.rust_target }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', '**/Cargo.toml') }}
+          restore-keys: |
+            candidate-${{ runner.os }}-${{ runner.arch }}-${{ matrix.rust_target }}-
       - name: Install Linux musl toolchain
         if: matrix.os == 'linux'
         shell: bash
@@ -249,6 +270,8 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx build --platform "${PLATFORM}" -f Dockerfile.runtime \
+            --cache-from "type=gha,scope=candidate-runtime-${ARCH}" \
+            --cache-to "type=gha,mode=max,ignore-error=true,scope=candidate-runtime-${ARCH}" \
             --tag "${IMAGE}" --provenance=mode=max --sbom=true --push .
 
   manifest:
@@ -322,6 +345,17 @@ jobs:
           ref: ${{ needs.resolve.outputs.sha }}
       - name: Install Rust toolchain
         run: rustup toolchain install 1.93.1 --profile minimal
+      - name: Restore Rust E2E build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: candidate-rust-e2e-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', '**/Cargo.toml') }}
+          restore-keys: |
+            candidate-rust-e2e-${{ runner.os }}-${{ runner.arch }}-
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -502,6 +536,8 @@ jobs:
           docker buildx build --platform "${PLATFORM}" -f apps/web/Dockerfile \
             --build-arg SOURCE_REVISION="${CANDIDATE_SHA}" \
             --build-arg NEXT_PUBLIC_CEREBRO_WEB_VERSION="candidate-${CANDIDATE_SHA}" \
+            --cache-from "type=gha,scope=candidate-web-${{ matrix.arch }}" \
+            --cache-to "type=gha,mode=max,ignore-error=true,scope=candidate-web-${{ matrix.arch }}" \
             --tag "${IMAGE}" --provenance=mode=max --sbom=true --push .
 
   web-manifest:
@@ -710,7 +746,7 @@ jobs:
 
   receipt:
     runs-on: ubuntu-latest
-    needs: [resolve, binaries, manifest, rust-organizational-e2e, web-manifest, scan-images, product-release]
+    needs: [resolve, ci-gate, binaries, manifest, rust-organizational-e2e, web-manifest, scan-images, product-release]
     permissions:
       actions: read
       contents: read

--- a/docs/operations/release-contract.md
+++ b/docs/operations/release-contract.md
@@ -20,7 +20,7 @@ candidate-<40-character-commit>
 ghcr.io/writer/cerebro@sha256:<digest>
 ```
 
-The Candidate Build workflow waits for CI, builds the binary archives, runtime image, and web image once, packs the portable Slack companion and TypeScript SDK, writes checksums and a dependency inventory, verifies the exact image platform set, scans both images, attaches provenance, signs the images and product manifest, and stores a `cerebro.release-candidate/v1` receipt. Candidate builds do not create Git tags, GitHub releases, stable semantic-version image tags, `latest`, or consumer events.
+The Candidate Build workflow resolves the commit, starts its binary and image builds while the commit's CI run finishes, and requires CI success before it writes the candidate receipt. Stale candidate runs are cancelled when a newer `main` commit arrives. BuildKit and Cargo caches are shared only across matching architecture and dependency inputs. The workflow builds the binary archives, runtime image, and web image once, packs the portable Slack companion and TypeScript SDK, writes checksums and a dependency inventory, verifies the exact image platform set, scans both images, attaches provenance, signs the images and product manifest, and stores a `cerebro.release-candidate/v1` receipt. Candidate builds do not create Git tags, GitHub releases, stable semantic-version image tags, `latest`, or consumer events.
 
 Stable releases are promoted from a successful Candidate Build run through the `stable-release` GitHub environment. The operator supplies the candidate run ID, stable tag, completed release notes, and a successful smoke receipt URL. The workflow verifies the candidate bundle checksums, commit, run ID, image digest, and image signature before it assigns stable tags.
 

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -242,8 +242,27 @@ func TestReleaseWorkflowsKeepCandidateAndStableBoundaries(t *testing.T) {
 		t.Fatal("candidate workflow must define the receipt job")
 	}
 	receipt := candidate[receiptIndex:]
-	if !strings.Contains(receipt, "needs: [resolve, binaries, manifest, rust-organizational-e2e, web-manifest, scan-images, product-release]") {
-		t.Fatal("candidate receipt must wait for both image scans and the exact-image Rust proof")
+	if !strings.Contains(receipt, "needs: [resolve, ci-gate, binaries, manifest, rust-organizational-e2e, web-manifest, scan-images, product-release]") {
+		t.Fatal("candidate receipt must wait for CI, both image scans, and the exact-image Rust proof")
+	}
+	if !strings.Contains(candidate, "group: candidate-build-main") ||
+		!strings.Contains(candidate, "cancel-in-progress: true") {
+		t.Fatal("candidate workflow must cancel stale main builds")
+	}
+	resolveIndex := strings.Index(candidate, "  resolve:\n")
+	ciGateIndex := strings.Index(candidate, "  ci-gate:\n")
+	binaryIndex := strings.Index(candidate, "  binary:\n")
+	if resolveIndex == -1 || ciGateIndex <= resolveIndex || binaryIndex <= ciGateIndex {
+		t.Fatal("candidate workflow must define resolve, CI gate, and binary jobs in order")
+	}
+	resolveJob := candidate[resolveIndex:ciGateIndex]
+	ciGateJob := candidate[ciGateIndex:binaryIndex]
+	if strings.Contains(resolveJob, "Require successful CI") {
+		t.Fatal("candidate resolution must not wait for CI before builds can start")
+	}
+	if !strings.Contains(ciGateJob, "needs: resolve") ||
+		!strings.Contains(ciGateJob, "Require successful CI") {
+		t.Fatal("candidate workflow must enforce CI in a parallel gate")
 	}
 	if !strings.Contains(receipt, "    permissions:\n      actions: read\n      contents: read\n") {
 		t.Fatal("candidate receipt job must allow artifact discovery with actions: read")


### PR DESCRIPTION
## What changed

- start candidate archives and images as soon as the main commit is resolved
- keep CI as a hard gate on the signed candidate receipt
- cancel stale candidate runs when a newer main commit arrives
- reuse architecture-scoped Cargo and BuildKit caches

## Why

Candidate builds previously waited for the full CI run before starting the same commit build. This removes that serialized wait without weakening the candidate receipt, image scan, provenance, or exact-image Rust proof.

## Verification

- `actionlint .github/workflows/cut-release.yml`
- `make check-arch script-test` (201 script tests)
- `make oss-audit`
- `git diff --check`