### PR TITLE
ci: rehearse Rust shadow and authority cutover

### DIFF
--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -9,9 +9,17 @@ on:
   workflow_dispatch:
     inputs:
       candidate_sha:
-        description: Exact repository commit with successful standard and Rust-only candidate builds
+        description: Exact repository commit with successful CI and Rust replacement proof
         required: true
         type: string
+      image_source:
+        description: Build the exact commit in this run or use signed main candidate images
+        required: true
+        default: source
+        type: choice
+        options:
+          - source
+          - published
       soak_seconds:
         description: Sustained shadow-read exercise duration (60-1800 seconds)
         required: false
@@ -32,7 +40,7 @@ jobs:
     name: Go API with Rust graph authority
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -52,6 +60,7 @@ jobs:
         shell: bash
         env:
           REQUESTED_SHA: ${{ inputs.candidate_sha }}
+          IMAGE_SOURCE: ${{ inputs.image_source }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -59,6 +68,14 @@ jobs:
           git fetch origin "${REQUESTED_SHA}"
           git cat-file -e "${REQUESTED_SHA}^{commit}"
 
+          if [[ "${IMAGE_SOURCE}" == source ]]; then
+            {
+              echo "api_image=cerebro-source:${REQUESTED_SHA}"
+              echo "rust_image=cerebro-rust-source:${REQUESTED_SHA}"
+            } >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          [[ "${IMAGE_SOURCE}" == published ]]
           api_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/cerebro:candidate-${REQUESTED_SHA}"
           rust_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/cerebro-rust:candidate-${REQUESTED_SHA}"
           api_digest=""
@@ -81,7 +98,31 @@ jobs:
             echo "rust_image=${rust_image%@*}@${rust_digest}"
           } >>"${GITHUB_OUTPUT}"
 
+      - name: Build exact source images
+        if: inputs.image_source == 'source'
+        shell: bash
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          API_IMAGE: ${{ steps.candidate.outputs.api_image }}
+          RUST_IMAGE: ${{ steps.candidate.outputs.rust_image }}
+        run: |
+          set -euo pipefail
+          git worktree add --detach candidate-source "${CANDIDATE_SHA}"
+          docker buildx build \
+            --file candidate-source/Dockerfile \
+            --load \
+            --provenance=false \
+            --tag "${API_IMAGE}" \
+            candidate-source
+          docker buildx build \
+            --file candidate-source/Dockerfile.rust \
+            --load \
+            --provenance=false \
+            --tag "${RUST_IMAGE}" \
+            candidate-source
+
       - name: Verify candidate attestations
+        if: inputs.image_source == 'published'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -97,9 +138,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          IMAGE_SOURCE: ${{ inputs.image_source }}
         run: |
           set -euo pipefail
-          for workflow in rust-only-candidate.yml rust-graph-replacement.yml; do
+          workflows=(ci.yml rust-graph-replacement.yml)
+          if [[ "${IMAGE_SOURCE}" == published ]]; then
+            workflows+=(rust-only-candidate.yml)
+          fi
+          for workflow in "${workflows[@]}"; do
             conclusion="$(
               gh api --method GET \
                 "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs" \

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -9,9 +9,14 @@ on:
   workflow_dispatch:
     inputs:
       candidate_sha:
-        description: Main commit with successful standard and Rust-only candidate builds
+        description: Exact repository commit with successful standard and Rust-only candidate builds
         required: true
         type: string
+      soak_seconds:
+        description: Sustained shadow-read exercise duration (60-1800 seconds)
+        required: false
+        default: 60
+        type: number
 
 permissions:
   attestations: read
@@ -25,6 +30,7 @@ concurrency:
 jobs:
   topology:
     name: Go API with Rust graph authority
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     steps:
@@ -45,13 +51,13 @@ jobs:
         id: candidate
         shell: bash
         env:
-          REQUESTED_SHA: ${{ inputs.candidate_sha || github.event.pull_request.base.sha }}
+          REQUESTED_SHA: ${{ inputs.candidate_sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [[ "${REQUESTED_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          git fetch origin main
-          git merge-base --is-ancestor "${REQUESTED_SHA}" origin/main
+          git fetch origin "${REQUESTED_SHA}"
+          git cat-file -e "${REQUESTED_SHA}^{commit}"
 
           api_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/cerebro:candidate-${REQUESTED_SHA}"
           rust_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/cerebro-rust:candidate-${REQUESTED_SHA}"
@@ -86,6 +92,27 @@ jobs:
           gh attestation verify "oci://${API_IMAGE}" --repo "${GITHUB_REPOSITORY}"
           gh attestation verify "oci://${RUST_IMAGE}" --repo "${GITHUB_REPOSITORY}"
 
+      - name: Require exact-head replay and replacement proofs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          for workflow in rust-only-candidate.yml rust-graph-replacement.yml; do
+            conclusion="$(
+              gh api --method GET \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs" \
+                -f head_sha="${CANDIDATE_SHA}" \
+                -f per_page=20 \
+                --jq '[.workflow_runs[] | select(.event != "pull_request_target")] | sort_by(.created_at) | last | .conclusion // ""'
+            )"
+            if [[ "${conclusion}" != success ]]; then
+              echo "${workflow} has no successful exact-head proof for ${CANDIDATE_SHA}"
+              exit 1
+            fi
+          done
+
       - name: Start an isolated Cerebro
         shell: bash
         env:
@@ -101,8 +128,14 @@ jobs:
         env:
           API_KEY: local-dev-key
           COMPOSE_PROJECT_NAME: ephemeral-cerebro-${{ github.run_id }}
+          SOAK_SECONDS: ${{ inputs.soak_seconds || 60 }}
+          CEREBRO_RUST_READ_MODE: shadow
+          CEREBRO_RUST_SHADOW_PERCENT: 100
         run: |
           set -euo pipefail
+          [[ "${SOAK_SECONDS}" =~ ^[0-9]+$ ]]
+          test "${SOAK_SECONDS}" -ge 60
+          test "${SOAK_SECONDS}" -le 1800
           graph_url='http://127.0.0.1:8080/platform/graph/neighborhood?root_urn=urn%3Acerebro%3Alocal%3Aasset%3Amissing&limit=10'
           graph_status() {
             curl --max-time 10 --silent --show-error --output graph-response.json \
@@ -135,10 +168,27 @@ jobs:
 
           assert_status 200 readiness-before readiness_status
           assert_status 404 graph-before graph_status
+
+          deadline=$((SECONDS + SOAK_SECONDS))
+          request_count=0
+          while test "${SECONDS}" -lt "${deadline}"; do
+            seq 1 16 | xargs -P 8 -I{} curl \
+              --max-time 10 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --write-out '%{http_code}\n' \
+              --header "Authorization: Bearer ${API_KEY}" \
+              "${graph_url}" >>shadow-statuses.txt
+            request_count=$((request_count + 16))
+          done
+          test "$(grep -c '^404$' shadow-statuses.txt)" -eq "${request_count}"
+          echo "shadow soak: ${request_count} matching legacy-authority responses"
+
           rust_container="$(docker compose -f docker-compose.yml -f docker-compose.rust.yml ps -q rust-platform)"
           test -n "${rust_container}"
           docker stop "${rust_container}" >/dev/null
-          assert_status 503 readiness-without-rust readiness_status
+          assert_status 200 readiness-shadow-without-rust readiness_status
 
           docker start "${rust_container}" >/dev/null
           for attempt in $(seq 1 36); do
@@ -150,6 +200,14 @@ jobs:
           done
           assert_status 200 readiness-after-restart readiness_status
           assert_status 404 graph-after-restart graph_status
+
+          export CEREBRO_RUST_READ_MODE=authority
+          export CEREBRO_RUST_SHADOW_PERCENT=0
+          docker compose -f docker-compose.yml -f docker-compose.rust.yml up -d --force-recreate --wait cerebro
+          assert_status 200 readiness-authority readiness_status
+          assert_status 404 graph-authority graph_status
+          docker stop "${rust_container}" >/dev/null
+          assert_status 503 readiness-authority-without-rust readiness_status
 
       - name: Print service logs
         if: always()

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -1,6 +1,11 @@
 name: Ephemeral Cerebro
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/ephemeral-cerebro.yml"
+      - "docker-compose.yml"
+      - "docker-compose.rust.yml"
   workflow_dispatch:
     inputs:
       candidate_sha:
@@ -21,7 +26,7 @@ jobs:
   topology:
     name: Go API with Rust graph authority
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -40,7 +45,7 @@ jobs:
         id: candidate
         shell: bash
         env:
-          REQUESTED_SHA: ${{ inputs.candidate_sha }}
+          REQUESTED_SHA: ${{ inputs.candidate_sha || github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -50,8 +55,18 @@ jobs:
 
           api_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/cerebro:candidate-${REQUESTED_SHA}"
           rust_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/cerebro-rust:candidate-${REQUESTED_SHA}"
-          api_digest="$(docker buildx imagetools inspect "${api_image}" --format '{{.Manifest.Digest}}')"
-          rust_digest="$(docker buildx imagetools inspect "${rust_image}" --format '{{.Manifest.Digest}}')"
+          api_digest=""
+          rust_digest=""
+          for attempt in $(seq 1 90); do
+            api_digest="$(docker buildx imagetools inspect "${api_image}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+            rust_digest="$(docker buildx imagetools inspect "${rust_image}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+            if [[ "${api_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+              && [[ "${rust_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              break
+            fi
+            test "${attempt}" -lt 90
+            sleep 10
+          done
           [[ "${api_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
           [[ "${rust_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
 

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Exercise the Go-to-Rust boundary and recovery
         shell: bash
         env:
+          API_KEY: local-dev-key
           COMPOSE_PROJECT_NAME: ephemeral-cerebro-${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -106,7 +107,7 @@ jobs:
           graph_status() {
             curl --max-time 10 --silent --show-error --output graph-response.json \
               --write-out '%{http_code} %{time_total}' \
-              --header 'Authorization: Bearer local-dev-key' \
+              --header "Authorization: Bearer ${API_KEY}" \
               "${graph_url}"
           }
           readiness_status() {

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -218,17 +218,23 @@ jobs:
           deadline=$((SECONDS + SOAK_SECONDS))
           request_count=0
           while test "${SECONDS}" -lt "${deadline}"; do
-            seq 1 16 | xargs -P 8 -I{} curl \
+            seq 1 2 | xargs -P 2 -I{} curl \
               --max-time 10 \
               --silent \
               --show-error \
               --output /dev/null \
               --write-out '%{http_code}\n' \
               --header "Authorization: Bearer ${API_KEY}" \
-              "${graph_url}" >>shadow-statuses.txt
-            request_count=$((request_count + 16))
+              "${graph_url}" >>shadow-statuses.txt || true
+            request_count=$((request_count + 2))
+            sleep 1
           done
-          test "$(grep -c '^404$' shadow-statuses.txt)" -eq "${request_count}"
+          echo "shadow soak status distribution:"
+          sort shadow-statuses.txt | uniq -c
+          observed_count="$(wc -l <shadow-statuses.txt | tr -d ' ')"
+          test "${observed_count}" -eq "${request_count}"
+          matching_count="$(grep -c '^404$' shadow-statuses.txt || true)"
+          test "${matching_count}" -eq "${request_count}"
           echo "shadow soak: ${request_count} matching legacy-authority responses"
 
           rust_container="$(docker compose -f docker-compose.yml -f docker-compose.rust.yml ps -q rust-platform)"

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -27,6 +27,7 @@ on:
         type: number
 
 permissions:
+  actions: read
   attestations: read
   contents: read
   packages: read

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -1,0 +1,131 @@
+name: Ephemeral Cerebro
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Main commit with successful standard and Rust-only candidate builds
+        required: true
+        type: string
+
+permissions:
+  attestations: read
+  contents: read
+  packages: read
+
+concurrency:
+  group: ephemeral-cerebro-${{ inputs.candidate_sha }}
+  cancel-in-progress: false
+
+jobs:
+  topology:
+    name: Go API with Rust graph authority
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve candidate images
+        id: candidate
+        shell: bash
+        env:
+          REQUESTED_SHA: ${{ inputs.candidate_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "${REQUESTED_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          git fetch origin main
+          git merge-base --is-ancestor "${REQUESTED_SHA}" origin/main
+
+          api_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/cerebro:candidate-${REQUESTED_SHA}"
+          rust_image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/cerebro-rust:candidate-${REQUESTED_SHA}"
+          api_digest="$(docker buildx imagetools inspect "${api_image}" --format '{{.Manifest.Digest}}')"
+          rust_digest="$(docker buildx imagetools inspect "${rust_image}" --format '{{.Manifest.Digest}}')"
+          [[ "${api_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "${rust_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+          {
+            echo "api_image=${api_image%@*}@${api_digest}"
+            echo "rust_image=${rust_image%@*}@${rust_digest}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Verify candidate attestations
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          API_IMAGE: ${{ steps.candidate.outputs.api_image }}
+          RUST_IMAGE: ${{ steps.candidate.outputs.rust_image }}
+        run: |
+          set -euo pipefail
+          gh attestation verify "oci://${API_IMAGE}" --repo "${GITHUB_REPOSITORY}"
+          gh attestation verify "oci://${RUST_IMAGE}" --repo "${GITHUB_REPOSITORY}"
+
+      - name: Start an isolated Cerebro
+        shell: bash
+        env:
+          CEREBRO_IMAGE: ${{ steps.candidate.outputs.api_image }}
+          CEREBRO_RUST_IMAGE: ${{ steps.candidate.outputs.rust_image }}
+          COMPOSE_PROJECT_NAME: ephemeral-cerebro-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          docker compose -f docker-compose.yml -f docker-compose.rust.yml up -d --wait --wait-timeout 180
+
+      - name: Exercise the Go-to-Rust boundary and recovery
+        shell: bash
+        env:
+          COMPOSE_PROJECT_NAME: ephemeral-cerebro-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          graph_url='http://127.0.0.1:8080/platform/graph/neighborhood?root_urn=urn%3Acerebro%3Alocal%3Aasset%3Amissing&limit=10'
+          graph_status() {
+            curl --max-time 10 --silent --show-error --output response.json \
+              --write-out '%{http_code}' \
+              --header 'Authorization: Bearer local-dev-key' \
+              "${graph_url}"
+          }
+          readiness_status() {
+            curl --max-time 10 --silent --show-error --output readiness.json \
+              --write-out '%{http_code}' \
+              http://127.0.0.1:8080/health
+          }
+
+          test "$(readiness_status)" = 200
+          test "$(graph_status)" = 404
+          rust_container="$(docker compose -f docker-compose.yml -f docker-compose.rust.yml ps -q rust-platform)"
+          test -n "${rust_container}"
+          docker stop "${rust_container}" >/dev/null
+          test "$(readiness_status || true)" = 503
+
+          docker start "${rust_container}" >/dev/null
+          for attempt in $(seq 1 36); do
+            if docker inspect --format '{{.State.Health.Status}}' "${rust_container}" | grep -qx healthy; then
+              break
+            fi
+            test "${attempt}" -lt 36
+            sleep 5
+          done
+          test "$(readiness_status)" = 200
+          test "$(graph_status)" = 404
+
+      - name: Print service logs
+        if: always()
+        env:
+          COMPOSE_PROJECT_NAME: ephemeral-cerebro-${{ github.run_id }}
+        run: docker compose -f docker-compose.yml -f docker-compose.rust.yml logs --no-color
+
+      - name: Stop the isolated Cerebro
+        if: always()
+        env:
+          COMPOSE_PROJECT_NAME: ephemeral-cerebro-${{ github.run_id }}
+        run: docker compose -f docker-compose.yml -f docker-compose.rust.yml down --volumes --remove-orphans

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -173,6 +173,8 @@ jobs:
         shell: bash
         env:
           API_KEY: local-dev-key
+          CEREBRO_IMAGE: ${{ steps.candidate.outputs.api_image }}
+          CEREBRO_RUST_IMAGE: ${{ steps.candidate.outputs.rust_image }}
           COMPOSE_PROJECT_NAME: ephemeral-cerebro-${{ github.run_id }}
           SOAK_SECONDS: ${{ inputs.soak_seconds || 60 }}
           CEREBRO_RUST_READ_MODE: shadow

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -32,7 +32,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ephemeral-cerebro-${{ inputs.candidate_sha }}
+  group: ephemeral-cerebro-${{ inputs.candidate_sha || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ephemeral-cerebro.yml
+++ b/.github/workflows/ephemeral-cerebro.yml
@@ -104,23 +104,40 @@ jobs:
           set -euo pipefail
           graph_url='http://127.0.0.1:8080/platform/graph/neighborhood?root_urn=urn%3Acerebro%3Alocal%3Aasset%3Amissing&limit=10'
           graph_status() {
-            curl --max-time 10 --silent --show-error --output response.json \
-              --write-out '%{http_code}' \
+            curl --max-time 10 --silent --show-error --output graph-response.json \
+              --write-out '%{http_code} %{time_total}' \
               --header 'Authorization: Bearer local-dev-key' \
               "${graph_url}"
           }
           readiness_status() {
             curl --max-time 10 --silent --show-error --output readiness.json \
-              --write-out '%{http_code}' \
+              --write-out '%{http_code} %{time_total}' \
               http://127.0.0.1:8080/health
           }
+          assert_status() {
+            local expected="$1"
+            local label="$2"
+            shift 2
+            local receipt
+            receipt="$("$@" || true)"
+            echo "${label}: ${receipt}"
+            if [[ "${receipt%% *}" != "${expected}" ]]; then
+              echo "${label} body:"
+              if [[ "${label}" == graph* ]]; then
+                cat graph-response.json || true
+              else
+                cat readiness.json || true
+              fi
+              return 1
+            fi
+          }
 
-          test "$(readiness_status)" = 200
-          test "$(graph_status)" = 404
+          assert_status 200 readiness-before readiness_status
+          assert_status 404 graph-before graph_status
           rust_container="$(docker compose -f docker-compose.yml -f docker-compose.rust.yml ps -q rust-platform)"
           test -n "${rust_container}"
           docker stop "${rust_container}" >/dev/null
-          test "$(readiness_status || true)" = 503
+          assert_status 503 readiness-without-rust readiness_status
 
           docker start "${rust_container}" >/dev/null
           for attempt in $(seq 1 36); do
@@ -130,8 +147,8 @@ jobs:
             test "${attempt}" -lt 36
             sleep 5
           done
-          test "$(readiness_status)" = 200
-          test "$(graph_status)" = 404
+          assert_status 200 readiness-after-restart readiness_status
+          assert_status 404 graph-after-restart graph_status
 
       - name: Print service logs
         if: always()

--- a/docker-compose.rust.yml
+++ b/docker-compose.rust.yml
@@ -1,0 +1,42 @@
+# Run with docker-compose.yml to exercise the production Go-to-Rust graph
+# boundary against disposable local stores. This overlay never uses a shared
+# graph, database, or JetStream instance.
+services:
+  rust-platform:
+    image: ${CEREBRO_RUST_IMAGE:?set CEREBRO_RUST_IMAGE to an exact candidate}
+    environment:
+      CEREBRO_NEO4J_URI: bolt://neo4j:7687
+      CEREBRO_NEO4J_USERNAME: neo4j
+      CEREBRO_NEO4J_PASSWORD: local-password
+      CEREBRO_POSTGRES_DSN: postgres://${CEREBRO_LOCAL_POSTGRES_USER:-cerebro}:${CEREBRO_LOCAL_POSTGRES_PASSWORD:-cerebro}@postgres:5432/cerebro?sslmode=disable
+      CEREBRO_JETSTREAM_URL: nats://nats:4222
+      CEREBRO_JETSTREAM_STREAM_NAME: CEREBRO_EVENTS
+      CEREBRO_JETSTREAM_SUBJECT_PREFIX: events
+      CEREBRO_RUST_BIND: 0.0.0.0:8081
+      CEREBRO_REPOSITORY_ROOT: /app
+      CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: ephemeral-cerebro-graph-secret-32-bytes
+    depends_on:
+      nats:
+        condition: service_healthy
+      nats-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8081/readyz"]
+      interval: 5s
+      timeout: 3s
+      retries: 24
+      start_period: 20s
+
+  cerebro:
+    environment:
+      CEREBRO_API_KEYS: local-dev-key:ephemeral-cerebro:local
+      CEREBRO_ORGANIZATIONAL_GRAPH_URL: http://rust-platform:8081
+      CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: ephemeral-cerebro-graph-secret-32-bytes
+      CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT: 1s
+    depends_on:
+      rust-platform:
+        condition: service_healthy

--- a/docker-compose.rust.yml
+++ b/docker-compose.rust.yml
@@ -36,7 +36,9 @@ services:
       CEREBRO_API_KEYS: local-dev-key:ephemeral-cerebro:local
       CEREBRO_ORGANIZATIONAL_GRAPH_URL: http://rust-platform:8081
       CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: ephemeral-cerebro-graph-secret-32-bytes
-      CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT: 1s
+      # Keep this topology gate tolerant of a cold Neo4j page cache on shared
+      # hosted runners. Latency regression belongs in the benchmark workflow.
+      CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT: 5s
     depends_on:
       rust-platform:
         condition: service_healthy

--- a/docker-compose.rust.yml
+++ b/docker-compose.rust.yml
@@ -8,20 +8,11 @@ services:
       CEREBRO_NEO4J_URI: bolt://neo4j:7687
       CEREBRO_NEO4J_USERNAME: neo4j
       CEREBRO_NEO4J_PASSWORD: local-password
-      CEREBRO_POSTGRES_DSN: postgres://${CEREBRO_LOCAL_POSTGRES_USER:-cerebro}:${CEREBRO_LOCAL_POSTGRES_PASSWORD:-cerebro}@postgres:5432/cerebro?sslmode=disable
-      CEREBRO_JETSTREAM_URL: nats://nats:4222
-      CEREBRO_JETSTREAM_STREAM_NAME: CEREBRO_EVENTS
-      CEREBRO_JETSTREAM_SUBJECT_PREFIX: events
       CEREBRO_RUST_BIND: 0.0.0.0:8081
       CEREBRO_REPOSITORY_ROOT: /app
       CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: ephemeral-cerebro-graph-secret-32-bytes
+    command: ["serve-neo4j-readonly"]
     depends_on:
-      nats:
-        condition: service_healthy
-      nats-init:
-        condition: service_completed_successfully
-      postgres:
-        condition: service_healthy
       neo4j:
         condition: service_healthy
     healthcheck:
@@ -34,7 +25,9 @@ services:
   cerebro:
     environment:
       CEREBRO_API_KEYS: local-dev-key:ephemeral-cerebro:local
-      CEREBRO_ORGANIZATIONAL_GRAPH_URL: http://rust-platform:8081
+      CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL: http://rust-platform:8081
+      CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE: ${CEREBRO_RUST_READ_MODE:-shadow}
+      CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT: ${CEREBRO_RUST_SHADOW_PERCENT:-100}
       CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: ephemeral-cerebro-graph-secret-32-bytes
       # Keep this topology gate tolerant of a cold Neo4j page cache on shared
       # hosted runners. Latency regression belongs in the benchmark workflow.

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -38,6 +38,23 @@ Plain Compose initializes the local Postgres volume with the compose-file passwo
 
 Use `docker compose -f docker-compose.yml -f docker-compose.build.yml up --build -d` when you need the durable stack to run the current checkout instead of the published image.
 
+To run the Go API with a separate Rust graph authority, set exact candidate
+images and add the Rust overlay:
+
+```bash
+export CEREBRO_IMAGE='ghcr.io/writer/cerebro@sha256:<api-digest>'
+export CEREBRO_RUST_IMAGE='ghcr.io/writer/cerebro-rust@sha256:<rust-digest>'
+docker compose -f docker-compose.yml -f docker-compose.rust.yml up -d --wait
+```
+
+This stack creates its own Postgres, Neo4j, JetStream, and Docker volumes. Stop
+it with `docker compose -f docker-compose.yml -f docker-compose.rust.yml down --volumes`.
+The `Ephemeral Cerebro` GitHub workflow runs the same topology on an ARM64
+runner for a main commit with successful standard and Rust-only candidate
+builds. It verifies image attestations, Go-to-Rust graph reads, dependency
+failure, recovery, and complete volume removal. It does not connect to a shared
+development graph.
+
 The compose stack uses service-local `CEREBRO_*` variables. For a standalone local template, start from `.env.example`.
 
 ## Common Commands


### PR DESCRIPTION
## Summary

- provide a dispatchable ARM64 workflow for an exact Go and Rust repository commit
- support exact source builds before merge and signed published candidate images after merge
- require successful exact-head CI and Rust graph-replacement proof; published mode also requires the Rust-only candidate proof
- run Rust with `serve-neo4j-readonly` against disposable Neo4j, with no PostgreSQL or JetStream writer path
- exercise 100% sampled shadow reads while Go remains authoritative
- sustain concurrent typed reads for a bounded 60–1,800 second soak
- stop Rust and prove Go stays ready in shadow mode
- switch the same topology to Rust read authority, then stop Rust and prove the API fails closed
- always remove the disposable graph, database, stream, network, and volumes

## Safety

- the workflow accepts only a full repository commit SHA
- source mode builds that exact commit inside the run and never publishes its images
- published mode resolves both images to immutable manifest digests and verifies GitHub attestations
- the test never uses a shared dev graph, database, or stream
- deployment, read authority, and consumer authority remain separate states

## Validation

- `actionlint .github/workflows/ephemeral-cerebro.yml`
- merged Compose configuration validation with exact digest-shaped fixture images
- previous hosted isolated topology proof: run 30183134759
