### PR TITLE
Update chatbot to GPT-5.6 Sol

### DIFF
--- a/apps/web/src/app/api/agent/ask/route.test.ts
+++ b/apps/web/src/app/api/agent/ask/route.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { agentPayloadError, buildAgentInput, buildAgentInstructions, buildRuntimeAgentInstructions, forwardLegacyAskBody } from "./route";
+import {
+  DEFAULT_AGENT_MODEL,
+  agentPayloadError,
+  buildAgentInput,
+  buildAgentInstructions,
+  buildRuntimeAgentInstructions,
+  forwardLegacyAskBody,
+} from "./route";
 
 const originalProducerCatalog = process.env.CEREBRO_SECURITY_PRODUCERS_JSON;
 
@@ -10,6 +17,10 @@ afterEach(() => {
 });
 
 describe("agent instructions", () => {
+  it("uses GPT-5.6 Sol by default", () => {
+    expect(DEFAULT_AGENT_MODEL).toBe("gpt-5.6-sol");
+  });
+
   it("reports invalid image bounds separately from an empty question", () => {
     expect(agentPayloadError({
       question: "What is risky in these screenshots?",

--- a/apps/web/src/app/api/agent/ask/route.ts
+++ b/apps/web/src/app/api/agent/ask/route.ts
@@ -41,7 +41,8 @@ export const runtime = "nodejs";
 export const maxDuration = 300;
 
 const encoder = new TextEncoder();
-const AGENT_MODEL = process.env.CEREBRO_AGENT_MODEL ?? "gpt-5.4-mini";
+export const DEFAULT_AGENT_MODEL = "gpt-5.6-sol";
+const AGENT_MODEL = process.env.CEREBRO_AGENT_MODEL ?? DEFAULT_AGENT_MODEL;
 
 type NormalizedAgentRequest = AskRequest & {
   question: string;


### PR DESCRIPTION
## What changed

- use `gpt-5.6-sol` as the default Cerebro chatbot model
- preserve `CEREBRO_AGENT_MODEL` as the deployment override
- add a regression assertion for the default model

## Why

The chatbot should use GPT-5.6 Sol for its default agent runs while retaining explicit environment-level model selection.

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage npm run check --workspace apps/web`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build --workspace apps/web`
- `git diff --check`
