### PR TITLE
Claim approved access actions before execution

### DIFF
--- a/internal/statestore/postgres/verified_access_actions_test.go
+++ b/internal/statestore/postgres/verified_access_actions_test.go
@@ -121,7 +121,8 @@ func postgresTestProposal(t *testing.T, tenantID string) verifiedaccessaction.Ou
 	t.Helper()
 	at := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
 	outcome, err := verifiedaccessaction.Propose(verifiedaccessaction.ProposalInput{
-		TenantID: tenantID,
+		TenantID:  tenantID,
+		FindingID: "finding-one",
 		Definition: verifiedaccessaction.ActionDefinition{
 			Metadata: graphactions.ActionMetadata{
 				ID:             graphactions.ActionIdentityOktaSuspendUser,

--- a/internal/verifiedaccessaction/lifecycle.go
+++ b/internal/verifiedaccessaction/lifecycle.go
@@ -16,7 +16,7 @@ func Propose(input ProposalInput) (Outcome, error) {
 		return Outcome{}, err
 	}
 	record := Record{
-		SchemaVersion: SchemaVersion, ID: actionID(input), TenantID: clean(input.TenantID), Status: StatusProposed,
+		SchemaVersion: SchemaVersion, ID: actionID(input), TenantID: clean(input.TenantID), FindingID: clean(input.FindingID), Status: StatusProposed,
 		Definition: input.Definition, Binding: input.Binding, Parameters: cloneMap(input.Parameters), Proposer: input.Proposer,
 		IdempotencyKey: clean(input.IdempotencyKey), Rollback: cloneRollback(input.Rollback), Reason: clean(input.Reason), ProposedAt: input.ProposedAt.UTC(),
 	}
@@ -202,7 +202,7 @@ func Reverify(record Record, input VerificationInput) (Outcome, error) {
 
 func validateProposal(input ProposalInput) error {
 	metadata, binding := input.Definition.Metadata, input.Binding
-	if clean(input.TenantID) == "" || clean(input.Definition.Version) == "" || clean(metadata.ID) == "" || clean(metadata.Provider) == "" || clean(metadata.ProviderAction) == "" || clean(metadata.TargetKind) == "" || !metadata.Destructive || (clean(metadata.Effect) != "deny_access" && clean(metadata.Effect) != "remove_privilege") || clean(metadata.ReversibleBy) == "" {
+	if clean(input.TenantID) == "" || clean(input.FindingID) == "" || clean(input.Definition.Version) == "" || clean(metadata.ID) == "" || clean(metadata.Provider) == "" || clean(metadata.ProviderAction) == "" || clean(metadata.TargetKind) == "" || !metadata.Destructive || (clean(metadata.Effect) != "deny_access" && clean(metadata.Effect) != "remove_privilege") || clean(metadata.ReversibleBy) == "" {
 		return fmt.Errorf("%w: action must be a versioned, reversible access denial or privilege removal", ErrInvalid)
 	}
 	if clean(binding.TargetID) == "" || clean(binding.SubjectURN) == "" || clean(binding.SubjectRevision) == "" || clean(binding.ResourceURN) == "" || clean(binding.ResourceRevision) == "" || clean(binding.SourceRuntimeID) == "" || clean(binding.SourceRevision) == "" {
@@ -367,7 +367,7 @@ func digestValue(value any) string {
 }
 
 func actionID(input ProposalInput) string {
-	return "verified-access-action-" + shortDigest(digestValue([]string{clean(input.TenantID), clean(input.Definition.Metadata.ID), clean(input.Definition.Version), clean(input.Binding.SubjectURN), clean(input.Binding.ResourceURN), clean(input.Binding.SourceRevision), clean(input.IdempotencyKey)}))
+	return "verified-access-action-" + shortDigest(digestValue([]string{clean(input.TenantID), clean(input.FindingID), clean(input.Definition.Metadata.ID), clean(input.Definition.Version), clean(input.Binding.SubjectURN), clean(input.Binding.ResourceURN), clean(input.Binding.SourceRevision), clean(input.IdempotencyKey)}))
 }
 
 func shortDigest(value string) string { return strings.TrimPrefix(value, "sha256:")[:32] }

--- a/internal/verifiedaccessaction/lifecycle_test.go
+++ b/internal/verifiedaccessaction/lifecycle_test.go
@@ -338,6 +338,7 @@ func proposalInput() ProposalInput {
 	at := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
 	return ProposalInput{
 		TenantID:   "tenant-one",
+		FindingID:  "finding-one",
 		Definition: ActionDefinition{Metadata: graphactions.ActionMetadata{ID: graphactions.ActionIdentityOktaSuspendUser, Provider: graphactions.ProviderAccessApprovals, ProviderAction: graphactions.AccessApprovalsActionSuspend, TargetKind: graphactions.TargetKindOktaUser, Effect: "deny_access", Destructive: true, ReversibleBy: graphactions.ActionIdentityOktaUnsuspendUser}, Version: "2026-07-14"},
 		Binding:    TargetBinding{TargetID: "provider-user-1", SubjectURN: "urn:cerebro:tenant-one:identity:user-1", SubjectRevision: "subject-revision-1", ResourceURN: "urn:cerebro:tenant-one:application:one", ResourceRevision: "resource-revision-1", SourceRuntimeID: "runtime-one", SourceRevision: "source-revision-1"},
 		Parameters: map[string]string{"session_policy": "revoke_active"}, Proposer: Actor{Type: "human", ID: "operator-one"}, IdempotencyKey: "access-revocation-one",

--- a/internal/verifiedaccessaction/model.go
+++ b/internal/verifiedaccessaction/model.go
@@ -77,6 +77,7 @@ type RollbackPlan struct {
 
 type ProposalInput struct {
 	TenantID       string            `json:"tenant_id"`
+	FindingID      string            `json:"finding_id"`
 	Definition     ActionDefinition  `json:"definition"`
 	Binding        TargetBinding     `json:"binding"`
 	Parameters     map[string]string `json:"parameters"`
@@ -92,6 +93,7 @@ type Record struct {
 	ID                   string                    `json:"id"`
 	Digest               string                    `json:"digest"`
 	TenantID             string                    `json:"tenant_id"`
+	FindingID            string                    `json:"finding_id"`
 	Status               string                    `json:"status"`
 	Definition           ActionDefinition          `json:"definition"`
 	Binding              TargetBinding             `json:"binding"`

--- a/internal/verifiedaccessactionexecution/service.go
+++ b/internal/verifiedaccessactionexecution/service.go
@@ -18,6 +18,7 @@ var (
 	ErrNotConfigured     = errors.New("verified access action execution is not configured")
 	ErrInvalidRequest    = errors.New("invalid verified access action execution request")
 	ErrClaimNotAcquired  = errors.New("verified access action execution claim was not acquired")
+	ErrProviderReceipt   = errors.New("verified access action provider receipt was rejected")
 	ErrSubmissionUnknown = errors.New("verified access action provider submission is unknown")
 )
 
@@ -121,7 +122,7 @@ func (s Service) Execute(ctx context.Context, input Input) (*Result, error) {
 		)
 	}
 	action := cloneGraphAction(execution.Action)
-	bindActionMetadata(action, claim.Record)
+	bindMissingActionMetadata(action, claim.Record)
 	occurredAt := time.Unix(action.CompletedAtUnix, 0).UTC()
 	executedBy := verifiedaccessaction.Actor{
 		Type: strings.TrimSpace(action.ActorType),
@@ -142,7 +143,7 @@ func (s Service) Execute(ctx context.Context, input Input) (*Result, error) {
 		OccurredAt:            occurredAt,
 	})
 	if err != nil {
-		return nil, s.recordUnknown(ctx, claim.Record, input.Worker, err)
+		return &Result{Record: claim.Record, Action: action}, errors.Join(ErrProviderReceipt, err)
 	}
 	applied, err = s.Store.AppendAccessAction(ctx, outcome)
 	if err != nil {
@@ -216,7 +217,7 @@ func submissionErrorClass(err error) string {
 	}
 }
 
-func bindActionMetadata(action *graphactions.GraphAction, record verifiedaccessaction.Record) {
+func bindMissingActionMetadata(action *graphactions.GraphAction, record verifiedaccessaction.Record) {
 	if action.Metadata == nil {
 		action.Metadata = map[string]string{}
 	}
@@ -228,7 +229,9 @@ func bindActionMetadata(action *graphactions.GraphAction, record verifiedaccessa
 		"source_revision":    record.Binding.SourceRevision,
 		"definition_version": record.Definition.Version,
 	} {
-		action.Metadata[key] = value
+		if strings.TrimSpace(action.Metadata[key]) == "" {
+			action.Metadata[key] = value
+		}
 	}
 }
 

--- a/internal/verifiedaccessactionexecution/service.go
+++ b/internal/verifiedaccessactionexecution/service.go
@@ -1,0 +1,254 @@
+// Package verifiedaccessactionexecution bridges durable verified access action
+// authority to the existing graph action executor.
+package verifiedaccessactionexecution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/graphactions"
+	"github.com/writer/cerebro/internal/verifiedaccessaction"
+)
+
+var (
+	ErrNotConfigured     = errors.New("verified access action execution is not configured")
+	ErrInvalidRequest    = errors.New("invalid verified access action execution request")
+	ErrClaimNotAcquired  = errors.New("verified access action execution claim was not acquired")
+	ErrSubmissionUnknown = errors.New("verified access action provider submission is unknown")
+)
+
+type GraphActionExecutor interface {
+	Execute(context.Context, graphactions.Input) (*graphactions.Result, error)
+}
+
+type Clock func() time.Time
+
+type Service struct {
+	Store          verifiedaccessaction.Store
+	Executor       GraphActionExecutor
+	Clock          Clock
+	ReconcileDelay time.Duration
+}
+
+type Input struct {
+	TenantID       string
+	ActionID       string
+	ProposalDigest string
+	Worker         verifiedaccessaction.Actor
+}
+
+type Result struct {
+	Record verifiedaccessaction.Record
+	Action *graphactions.GraphAction
+}
+
+// Execute claims one approved action before invoking the existing provider
+// executor. The legacy Approved field is set only after the durable claim is
+// committed; it is transport compatibility, not approval authority.
+func (s Service) Execute(ctx context.Context, input Input) (*Result, error) {
+	if s.Store == nil || s.Executor == nil {
+		return nil, ErrNotConfigured
+	}
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.ActionID = strings.TrimSpace(input.ActionID)
+	input.ProposalDigest = strings.TrimSpace(input.ProposalDigest)
+	if input.TenantID == "" || input.ActionID == "" ||
+		input.ProposalDigest == "" || !validActor(input.Worker) {
+		return nil, ErrInvalidRequest
+	}
+	record, err := s.Store.GetAccessAction(ctx, input.TenantID, input.ActionID)
+	if err != nil {
+		return nil, err
+	}
+	if record.Status != verifiedaccessaction.StatusApproved ||
+		record.Preflight == nil || record.Approval == nil {
+		return nil, verifiedaccessaction.ErrState
+	}
+	proposalDigest, err := verifiedaccessaction.ProposalRecordDigest(record)
+	if err != nil {
+		return nil, err
+	}
+	if proposalDigest != input.ProposalDigest {
+		return nil, verifiedaccessaction.ErrStale
+	}
+	claimedAt := s.now().UTC().Truncate(time.Second)
+	claim, err := verifiedaccessaction.ClaimExecution(record, verifiedaccessaction.ExecutionClaimInput{
+		ProposalDigest:    input.ProposalDigest,
+		PreflightDigest:   record.Preflight.Digest,
+		ApprovalDigest:    record.Approval.Digest,
+		ParametersDigest:  verifiedaccessaction.ParametersDigest(record.Parameters),
+		Binding:           record.Binding,
+		DefinitionVersion: record.Definition.Version,
+		Actor:             input.Worker,
+		ClaimedAt:         claimedAt,
+	})
+	if err != nil {
+		return nil, err
+	}
+	applied, err := s.Store.AppendAccessAction(ctx, claim)
+	if err != nil {
+		if errors.Is(err, verifiedaccessaction.ErrConflict) {
+			return nil, ErrClaimNotAcquired
+		}
+		return nil, err
+	}
+	if !applied {
+		return nil, ErrClaimNotAcquired
+	}
+
+	execution, executeErr := s.Executor.Execute(ctx, graphactions.Input{
+		FindingID:      record.FindingID,
+		Action:         record.Definition.Metadata.ID,
+		Target:         record.Binding.TargetID,
+		Reason:         record.Reason,
+		IdempotencyKey: record.IdempotencyKey,
+		Parameters:     cloneParameters(record.Parameters),
+		Approved:       true,
+	})
+	if executeErr != nil {
+		return nil, s.recordUnknown(ctx, claim.Record, input.Worker, executeErr)
+	}
+	if execution == nil || execution.Action == nil {
+		return nil, s.recordUnknown(
+			ctx,
+			claim.Record,
+			input.Worker,
+			fmt.Errorf("%w: executor returned no action", graphactions.ErrRemote),
+		)
+	}
+	action := cloneGraphAction(execution.Action)
+	bindActionMetadata(action, claim.Record)
+	occurredAt := time.Unix(action.CompletedAtUnix, 0).UTC()
+	executedBy := verifiedaccessaction.Actor{
+		Type: strings.TrimSpace(action.ActorType),
+		ID:   strings.TrimSpace(action.ActorSubject),
+	}
+	outcome, err := verifiedaccessaction.IngestExecution(claim.Record, verifiedaccessaction.ExecutionInput{
+		GraphAction:           *action,
+		ExecutionClaimDigest:  claim.Record.ExecutionClaim.Digest,
+		DefinitionVersion:     claim.Record.Definition.Version,
+		ProposalDigest:        input.ProposalDigest,
+		PreflightDigest:       claim.Record.Preflight.Digest,
+		ApprovalDigest:        claim.Record.Approval.Digest,
+		ParametersDigest:      verifiedaccessaction.ParametersDigest(claim.Record.Parameters),
+		Binding:               claim.Record.Binding,
+		ExecutedBy:            executedBy,
+		IngestedBy:            input.Worker,
+		ProviderReceiptDigest: verifiedaccessaction.GraphActionReceiptDigest(*action),
+		OccurredAt:            occurredAt,
+	})
+	if err != nil {
+		return nil, s.recordUnknown(ctx, claim.Record, input.Worker, err)
+	}
+	applied, err = s.Store.AppendAccessAction(ctx, outcome)
+	if err != nil {
+		return nil, errors.Join(ErrSubmissionUnknown, err)
+	}
+	if !applied {
+		return nil, errors.Join(ErrSubmissionUnknown, ErrClaimNotAcquired)
+	}
+	return &Result{Record: outcome.Record, Action: action}, nil
+}
+
+func (s Service) recordUnknown(
+	ctx context.Context,
+	record verifiedaccessaction.Record,
+	worker verifiedaccessaction.Actor,
+	cause error,
+) error {
+	observedAt := s.now().UTC().Truncate(time.Second)
+	if observedAt.Before(record.ExecutionClaim.ClaimedAt) {
+		observedAt = record.ExecutionClaim.ClaimedAt
+	}
+	outcome, err := verifiedaccessaction.RecordSubmissionUnknown(
+		record,
+		verifiedaccessaction.SubmissionUnknownInput{
+			ExecutionClaimDigest: record.ExecutionClaim.Digest,
+			ProviderRequestID:    record.IdempotencyKey,
+			ErrorClass:           submissionErrorClass(cause),
+			Actor:                worker,
+			ObservedAt:           observedAt,
+			NextReconcileAt:      observedAt.Add(s.reconcileDelay()),
+		},
+	)
+	if err != nil {
+		return errors.Join(ErrSubmissionUnknown, cause, err)
+	}
+	applied, err := s.Store.AppendAccessAction(ctx, outcome)
+	if err != nil {
+		return errors.Join(ErrSubmissionUnknown, cause, err)
+	}
+	if !applied {
+		return errors.Join(ErrSubmissionUnknown, cause, ErrClaimNotAcquired)
+	}
+	return errors.Join(ErrSubmissionUnknown, cause)
+}
+
+func (s Service) now() time.Time {
+	if s.Clock != nil {
+		return s.Clock()
+	}
+	return time.Now()
+}
+
+func (s Service) reconcileDelay() time.Duration {
+	if s.ReconcileDelay > 0 {
+		return s.ReconcileDelay
+	}
+	return 5 * time.Minute
+}
+
+func submissionErrorClass(err error) string {
+	var networkError net.Error
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return verifiedaccessaction.SubmissionErrorTransportTimeout
+	case errors.As(err, &networkError) && networkError.Timeout():
+		return verifiedaccessaction.SubmissionErrorTransportTimeout
+	case errors.As(err, &networkError):
+		return verifiedaccessaction.SubmissionErrorConnectionReset
+	default:
+		return verifiedaccessaction.SubmissionErrorResponseLost
+	}
+}
+
+func bindActionMetadata(action *graphactions.GraphAction, record verifiedaccessaction.Record) {
+	if action.Metadata == nil {
+		action.Metadata = map[string]string{}
+	}
+	for key, value := range map[string]string{
+		"tenant_id":          record.TenantID,
+		"subject_urn":        record.Binding.SubjectURN,
+		"resource_urn":       record.Binding.ResourceURN,
+		"source_runtime_id":  record.Binding.SourceRuntimeID,
+		"source_revision":    record.Binding.SourceRevision,
+		"definition_version": record.Definition.Version,
+	} {
+		action.Metadata[key] = value
+	}
+}
+
+func cloneGraphAction(action *graphactions.GraphAction) *graphactions.GraphAction {
+	if action == nil {
+		return nil
+	}
+	result := *action
+	result.Metadata = cloneParameters(action.Metadata)
+	return &result
+}
+
+func cloneParameters(values map[string]string) map[string]string {
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = value
+	}
+	return result
+}
+
+func validActor(actor verifiedaccessaction.Actor) bool {
+	return strings.TrimSpace(actor.Type) != "" && strings.TrimSpace(actor.ID) != ""
+}

--- a/internal/verifiedaccessactionexecution/service_test.go
+++ b/internal/verifiedaccessactionexecution/service_test.go
@@ -1,0 +1,294 @@
+package verifiedaccessactionexecution
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/graphactions"
+	"github.com/writer/cerebro/internal/verifiedaccessaction"
+)
+
+func TestExecuteClaimsBeforeCallingProvider(t *testing.T) {
+	t.Parallel()
+
+	store, record, proposalDigest := approvedAction(t)
+	clock := record.Approval.ApprovedAt.Add(time.Minute)
+	executor := &stubExecutor{execute: successfulExecution(clock.Add(time.Minute))}
+	service := Service{Store: store, Executor: executor, Clock: func() time.Time { return clock }}
+	input := executionRequest(record, proposalDigest)
+
+	const contenders = 50
+	start := make(chan struct{})
+	results := make(chan *Result, contenders)
+	errs := make(chan error, contenders)
+	var wait sync.WaitGroup
+	for range contenders {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			result, err := service.Execute(context.Background(), input)
+			results <- result
+			errs <- err
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(errs)
+
+	successes := 0
+	for result := range results {
+		if result != nil {
+			successes++
+			if result.Record.Status != verifiedaccessaction.StatusExecuted {
+				t.Errorf("status = %q, want %q", result.Record.Status, verifiedaccessaction.StatusExecuted)
+			}
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful callers = %d, want 1", successes)
+	}
+	for err := range errs {
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, ErrClaimNotAcquired) &&
+			!errors.Is(err, verifiedaccessaction.ErrState) {
+			t.Errorf("losing caller error = %v", err)
+		}
+	}
+	if calls := executor.calls.Load(); calls != 1 {
+		t.Fatalf("provider calls = %d, want 1", calls)
+	}
+	if !executor.lastInput.Approved {
+		t.Fatal("provider transport did not receive the post-claim approval marker")
+	}
+	if executor.lastInput.FindingID != record.FindingID {
+		t.Fatalf("finding_id = %q, want %q", executor.lastInput.FindingID, record.FindingID)
+	}
+
+	persisted, err := store.GetAccessAction(context.Background(), record.TenantID, record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Status != verifiedaccessaction.StatusExecuted ||
+		persisted.ExecutionClaim == nil || persisted.Execution == nil {
+		t.Fatalf("persisted record did not retain claim and execution receipts: %+v", persisted)
+	}
+}
+
+func TestExecuteRecordsAmbiguousSubmissionForReconciliation(t *testing.T) {
+	t.Parallel()
+
+	store, record, proposalDigest := approvedAction(t)
+	clock := record.Approval.ApprovedAt.Add(time.Minute)
+	executor := &stubExecutor{err: context.DeadlineExceeded}
+	service := Service{
+		Store:          store,
+		Executor:       executor,
+		Clock:          func() time.Time { return clock },
+		ReconcileDelay: 10 * time.Minute,
+	}
+
+	result, err := service.Execute(context.Background(), executionRequest(record, proposalDigest))
+	if result != nil {
+		t.Fatalf("result = %+v, want nil", result)
+	}
+	if !errors.Is(err, ErrSubmissionUnknown) ||
+		!errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Execute() error = %v, want submission unknown and deadline exceeded", err)
+	}
+	if calls := executor.calls.Load(); calls != 1 {
+		t.Fatalf("provider calls = %d, want 1", calls)
+	}
+
+	persisted, getErr := store.GetAccessAction(context.Background(), record.TenantID, record.ID)
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if persisted.Status != verifiedaccessaction.StatusUnknown ||
+		persisted.ExecutionClaim == nil || persisted.SubmissionUnknown == nil {
+		t.Fatalf("persisted record did not retain the ambiguous submission: %+v", persisted)
+	}
+	if persisted.SubmissionUnknown.ErrorClass != verifiedaccessaction.SubmissionErrorTransportTimeout {
+		t.Fatalf(
+			"error_class = %q, want %q",
+			persisted.SubmissionUnknown.ErrorClass,
+			verifiedaccessaction.SubmissionErrorTransportTimeout,
+		)
+	}
+	wantReconcileAt := clock.Add(10 * time.Minute)
+	if !persisted.SubmissionUnknown.NextReconcileAt.Equal(wantReconcileAt) {
+		t.Fatalf(
+			"next_reconcile_at = %s, want %s",
+			persisted.SubmissionUnknown.NextReconcileAt,
+			wantReconcileAt,
+		)
+	}
+}
+
+func TestExecuteRejectsStaleProposalBeforeCallingProvider(t *testing.T) {
+	t.Parallel()
+
+	store, record, _ := approvedAction(t)
+	executor := &stubExecutor{}
+	service := Service{
+		Store:    store,
+		Executor: executor,
+		Clock:    func() time.Time { return record.Approval.ApprovedAt.Add(time.Minute) },
+	}
+	input := executionRequest(record, "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	result, err := service.Execute(context.Background(), input)
+	if result != nil {
+		t.Fatalf("result = %+v, want nil", result)
+	}
+	if !errors.Is(err, verifiedaccessaction.ErrStale) {
+		t.Fatalf("Execute() error = %v, want ErrStale", err)
+	}
+	if calls := executor.calls.Load(); calls != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls)
+	}
+}
+
+type stubExecutor struct {
+	calls     atomic.Int64
+	mu        sync.Mutex
+	lastInput graphactions.Input
+	execute   *graphactions.Result
+	err       error
+}
+
+func (s *stubExecutor) Execute(_ context.Context, input graphactions.Input) (*graphactions.Result, error) {
+	s.calls.Add(1)
+	s.mu.Lock()
+	s.lastInput = input
+	s.mu.Unlock()
+	return s.execute, s.err
+}
+
+func successfulExecution(completedAt time.Time) *graphactions.Result {
+	return &graphactions.Result{Action: &graphactions.GraphAction{
+		ID:              "provider-receipt-one",
+		ExternalID:      "provider-receipt-one",
+		Action:          graphactions.ActionIdentityOktaSuspendUser,
+		Provider:        graphactions.ProviderAccessApprovals,
+		Status:          graphactions.ActionStatusSucceeded,
+		ExternalStatus:  graphactions.ActionStatusSucceeded,
+		Target:          "provider-user-1",
+		IdempotencyKey:  "access-revocation-one",
+		ActorType:       "service",
+		ActorSubject:    "provider-executor",
+		CreatedAtUnix:   completedAt.Add(-time.Minute).Unix(),
+		UpdatedAtUnix:   completedAt.Unix(),
+		CompletedAtUnix: completedAt.Unix(),
+	}}
+}
+
+func executionRequest(record verifiedaccessaction.Record, proposalDigest string) Input {
+	return Input{
+		TenantID:       record.TenantID,
+		ActionID:       record.ID,
+		ProposalDigest: proposalDigest,
+		Worker:         verifiedaccessaction.Actor{Type: "service", ID: "action-worker"},
+	}
+}
+
+func approvedAction(
+	t *testing.T,
+) (*verifiedaccessaction.MemoryStore, verifiedaccessaction.Record, string) {
+	t.Helper()
+
+	at := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	proposal, err := verifiedaccessaction.Propose(verifiedaccessaction.ProposalInput{
+		TenantID:  "tenant-one",
+		FindingID: "finding-one",
+		Definition: verifiedaccessaction.ActionDefinition{
+			Metadata: graphactions.ActionMetadata{
+				ID:             graphactions.ActionIdentityOktaSuspendUser,
+				Provider:       graphactions.ProviderAccessApprovals,
+				ProviderAction: graphactions.AccessApprovalsActionSuspend,
+				TargetKind:     graphactions.TargetKindOktaUser,
+				Effect:         "deny_access",
+				Destructive:    true,
+				ReversibleBy:   graphactions.ActionIdentityOktaUnsuspendUser,
+			},
+			Version: "2026-07-25",
+		},
+		Binding: verifiedaccessaction.TargetBinding{
+			TargetID:         "provider-user-1",
+			SubjectURN:       "urn:cerebro:tenant-one:identity:user-1",
+			SubjectRevision:  "subject-revision-1",
+			ResourceURN:      "urn:cerebro:tenant-one:application:one",
+			ResourceRevision: "resource-revision-1",
+			SourceRuntimeID:  "runtime-one",
+			SourceRevision:   "source-revision-1",
+		},
+		Parameters:     map[string]string{"session_policy": "revoke_active"},
+		Proposer:       verifiedaccessaction.Actor{Type: "human", ID: "operator-one"},
+		IdempotencyKey: "access-revocation-one",
+		Rollback: verifiedaccessaction.RollbackPlan{
+			ActionID:          graphactions.ActionIdentityOktaUnsuspendUser,
+			DefinitionVersion: "2026-07-25",
+			Parameters:        map[string]string{"restore": "previous_state"},
+			Steps:             []string{"Confirm the original access decision remains valid.", "Restore the provider account state."},
+		},
+		Reason:     "Confirmed offboarding access remains active.",
+		ProposedAt: at,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	proposalDigest := proposal.Record.Digest
+	store := verifiedaccessaction.NewMemoryStore()
+	if applied, createErr := store.CreateAccessAction(context.Background(), proposal); createErr != nil || !applied {
+		t.Fatalf("CreateAccessAction() = %t, %v", applied, createErr)
+	}
+
+	preflight, err := verifiedaccessaction.Preflight(
+		proposal.Record,
+		verifiedaccessaction.PreflightInput{
+			ProposalDigest:   proposalDigest,
+			Binding:          proposal.Record.Binding,
+			ParametersDigest: verifiedaccessaction.ParametersDigest(proposal.Record.Parameters),
+			RollbackDigest:   verifiedaccessaction.RollbackPlanDigest(proposal.Record.Rollback),
+			Actor:            verifiedaccessaction.Actor{Type: "service", ID: "access-preflight"},
+			ExpectedEffect:   proposal.Record.Definition.Metadata.Effect,
+			TargetExists:     true,
+			WouldChange:      true,
+			SourceHealthy:    true,
+			ProviderMutation: false,
+			SimulatedAt:      at.Add(time.Minute),
+			ValidUntil:       at.Add(time.Hour),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied, appendErr := store.AppendAccessAction(context.Background(), preflight); appendErr != nil || !applied {
+		t.Fatalf("AppendAccessAction(preflight) = %t, %v", applied, appendErr)
+	}
+
+	approval, err := verifiedaccessaction.Approve(
+		preflight.Record,
+		verifiedaccessaction.ApprovalInput{
+			ProposalDigest:  proposalDigest,
+			PreflightDigest: preflight.Record.Preflight.Digest,
+			Actor:           verifiedaccessaction.Actor{Type: "human", ID: "approver-one"},
+			Reason:          "The exact target, change, and rollback were reviewed.",
+			ApprovedAt:      at.Add(2 * time.Minute),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied, appendErr := store.AppendAccessAction(context.Background(), approval); appendErr != nil || !applied {
+		t.Fatalf("AppendAccessAction(approval) = %t, %v", applied, appendErr)
+	}
+	return store, approval.Record, proposalDigest
+}

--- a/internal/verifiedaccessactionexecution/service_test.go
+++ b/internal/verifiedaccessactionexecution/service_test.go
@@ -132,6 +132,88 @@ func TestExecuteRecordsAmbiguousSubmissionForReconciliation(t *testing.T) {
 	}
 }
 
+func TestExecuteReturnsDefinitiveProviderFailureWithoutRecordingAmbiguity(t *testing.T) {
+	t.Parallel()
+
+	store, record, proposalDigest := approvedAction(t)
+	clock := record.Approval.ApprovedAt.Add(time.Minute)
+	execution := successfulExecution(clock.Add(time.Minute))
+	execution.Action.Status = graphactions.ActionStatusFailed
+	execution.Action.ExternalStatus = graphactions.ActionStatusFailed
+	execution.Action.ExternalStatusReason = "provider denied the request"
+	execution.Action.LastError = "account is protected"
+	service := Service{
+		Store:    store,
+		Executor: &stubExecutor{execute: execution},
+		Clock:    func() time.Time { return clock },
+	}
+
+	result, err := service.Execute(
+		context.Background(),
+		executionRequest(record, proposalDigest),
+	)
+	if result == nil || result.Action == nil {
+		t.Fatalf("result = %+v, want the rejected provider receipt", result)
+	}
+	if !errors.Is(err, ErrProviderReceipt) ||
+		!errors.Is(err, verifiedaccessaction.ErrVerificationMismatch) ||
+		errors.Is(err, ErrSubmissionUnknown) {
+		t.Fatalf("Execute() error = %v, want rejected receipt without submission ambiguity", err)
+	}
+	if result.Action.ExternalStatusReason != "provider denied the request" ||
+		result.Action.LastError != "account is protected" {
+		t.Fatalf("provider failure details were not preserved: %+v", result.Action)
+	}
+
+	persisted, getErr := store.GetAccessAction(context.Background(), record.TenantID, record.ID)
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if persisted.Status != verifiedaccessaction.StatusClaimed ||
+		persisted.SubmissionUnknown != nil {
+		t.Fatalf("definitive failure was persisted as ambiguous: %+v", persisted)
+	}
+}
+
+func TestExecuteRejectsMismatchedProviderMetadataBeforeFillingDefaults(t *testing.T) {
+	t.Parallel()
+
+	store, record, proposalDigest := approvedAction(t)
+	clock := record.Approval.ApprovedAt.Add(time.Minute)
+	execution := successfulExecution(clock.Add(time.Minute))
+	execution.Action.Metadata = map[string]string{"tenant_id": "tenant-other"}
+	service := Service{
+		Store:    store,
+		Executor: &stubExecutor{execute: execution},
+		Clock:    func() time.Time { return clock },
+	}
+
+	result, err := service.Execute(
+		context.Background(),
+		executionRequest(record, proposalDigest),
+	)
+	if result == nil || result.Action == nil {
+		t.Fatalf("result = %+v, want the rejected provider receipt", result)
+	}
+	if !errors.Is(err, ErrProviderReceipt) ||
+		!errors.Is(err, verifiedaccessaction.ErrStale) {
+		t.Fatalf("Execute() error = %v, want stale provider metadata", err)
+	}
+	if result.Action.Metadata["tenant_id"] != "tenant-other" {
+		t.Fatalf("provider tenant metadata was overwritten: %+v", result.Action.Metadata)
+	}
+
+	persisted, getErr := store.GetAccessAction(context.Background(), record.TenantID, record.ID)
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if persisted.Status != verifiedaccessaction.StatusClaimed ||
+		persisted.Execution != nil ||
+		persisted.SubmissionUnknown != nil {
+		t.Fatalf("mismatched receipt changed durable state: %+v", persisted)
+	}
+}
+
 func TestExecuteRejectsStaleProposalBeforeCallingProvider(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- require every approved access action to bind the finding consumed by the graph action executor
- commit the durable execution claim before the provider executor can run
- accept only a successful, approval-bound provider receipt as executed
- preserve timeouts and lost responses as submission_unknown with a reconciliation deadline
- reject definitive provider failures without misclassifying them as lost responses
- preserve provider-supplied binding metadata and reject mismatches before filling omitted compatibility fields

## Safety properties

- concurrent workers can produce only one provider call
- a stale proposal digest cannot reach the provider
- definitive provider failures remain distinct from transport ambiguity
- provider metadata mismatches cannot be overwritten into valid bindings
- the graph executor approved transport field is set only after the durable claim is committed

## Validation

- go test ./... -count=1
- go test -race ./internal/verifiedaccessaction ./internal/verifiedaccessactionexecution ./internal/statestore/postgres -count=1

## Stack

Depends on #2064, which adds the durable lifecycle and compare-and-swap store used here. Replaces #2065 after its stacked base was corrected.

Progresses #1760.