### PR TITLE
Preserve source coverage during Rust cutover

### DIFF
--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -118,10 +118,6 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
             message.double_ack().await.map_err(consumer_io)?;
             continue;
         };
-        if runtime.catalog.get(subject_source).is_none() {
-            message.double_ack().await.map_err(consumer_io)?;
-            continue;
-        }
         let event = match decode_event(&message.message.payload, subject_source, &subject) {
             Ok(event) => event,
             Err(error) => {

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -21,27 +21,27 @@ use cerebro_agent_context::{
 };
 use cerebro_organizational_graph::OrganizationalGraph;
 use cerebro_organizational_model::{
-    AssertionId, AssertionProvenance, CanonicalIdentity, CollectionId, CollectionReceipt,
-    CompleteCollection, Entity, EntityId, EntityKind, GraphAssertion, IdentityBindingAssertion,
-    IdentityBindingState, IdentityClaim, IdentityResolutionMethod, ModelError, ObservationId,
-    ObservationRef, ProviderIdentity, ProviderKind, RelationKind, RelationshipAssertion,
-    SourceRuntimeId, TenantId,
+    AssertionId, AssertionProvenance, CanonicalIdentity, CollectionId, CompleteCollection, Entity,
+    EntityId, EntityKind, GraphAssertion, IdentityBindingAssertion, IdentityBindingState,
+    IdentityClaim, IdentityResolutionMethod, ModelError, ObservationId, ObservationRef,
+    ProviderIdentity, ProviderKind, RelationKind, RelationshipAssertion, SourceRuntimeId, TenantId,
 };
 use cerebro_organizational_store::{
     DurableGraphStore, Neo4jProjector, PostgresLedger, ProjectionAuthority, StoreError,
 };
 use cerebro_source_catalog::{AuthModel, CatalogSummary, SourceCatalog};
 use cerebro_source_runtime_next::{
-    CatalogGraphMapper, CollectedBatch, CollectedScope, CollectionRequest, CommittedSourceEvent,
-    GraphMapper, GraphSink, HttpSourceConnector, ResolvedAuth, SourceRecord, SourceRuntime,
+    CatalogGraphMapper, CollectionRequest, CommittedSourceEvent, CommittedSourceInput, GraphMapper,
+    GraphSink, HttpSourceConnector, ResolvedAuth, SourceRuntime,
 };
 use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
 const TENANT_AUTH_HEADER: &str = "x-cerebro-tenant";
 const TENANT_AUTH_CONTEXT: &[u8] = b"cerebro-organizational-graph/tenant/v1\0";
+const MAX_LEGACY_DELTA_RECORDS: usize = 100_000;
 const MIN_SHARED_SECRET_BYTES: usize = 32;
 
 #[derive(Clone)]
@@ -183,6 +183,8 @@ fn bounded_operation(path: &str) -> &'static str {
         "/v1/graph/expand-batch" => "expand_batch",
         "/v1/graph/paths" => "paths",
         "/v1/projections/events" => "project_event",
+        "/v1/projections/legacy-deltas" => "record_legacy_projection",
+        "/v1/projections/collections" => "record_source_collection",
         "/v1/projections/authority" => "projection_authority",
         _ if path.starts_with("/v1/entities/") => "get_entity",
         _ if path.starts_with("/v1/assertions/") => "explain_assertion",
@@ -279,6 +281,10 @@ impl ProjectionRuntime {
         &self,
         event: CommittedSourceEvent,
     ) -> Result<ProjectEventResponse, ProjectionFailure> {
+        self.authority
+            .record_source_event(&event)
+            .await
+            .map_err(ProjectionFailure::Store)?;
         let authority = self
             .authority
             .projection_authority(
@@ -367,6 +373,68 @@ impl ProjectionRuntime {
             graph_revision: Some(receipt.graph_revision),
             entities_upserted: receipt.entities_upserted,
             assertions_upserted: receipt.assertions_upserted,
+        })
+    }
+
+    async fn record_legacy_projection(
+        &self,
+        tenant_id: &TenantId,
+        request: &LegacyProjectionRequest,
+    ) -> Result<LegacyProjectionResponse, StoreError> {
+        let delta_json = serde_json::to_value(&request.delta)?;
+        let delta_digest = json_digest(&delta_json);
+        self.authority
+            .record_legacy_projection(
+                tenant_id.as_str(),
+                request.event_id.trim(),
+                request.source_runtime_id.trim(),
+                request.source_id.trim(),
+                request.family_id.trim(),
+                request.observed_at_unix_ms,
+                request.delta.entities.len(),
+                request.delta.links.len(),
+                request.delta.entity_retractions.len(),
+                request.delta.link_retractions.len(),
+                request.delta.cleanup_requests.len(),
+                &delta_digest,
+                &delta_json,
+            )
+            .await?;
+        Ok(LegacyProjectionResponse {
+            recorded: true,
+            delta_digest,
+        })
+    }
+
+    async fn record_source_collection(
+        &self,
+        tenant_id: &TenantId,
+        request: &SourceCollectionRequest,
+    ) -> Result<SourceCollectionResponse, StoreError> {
+        let manifest_json = serde_json::to_value(request)?;
+        let manifest_digest = json_digest(&manifest_json);
+        self.authority
+            .record_source_collection(
+                tenant_id.as_str(),
+                request.collection_id.trim(),
+                request.source_runtime_id.trim(),
+                request.source_id.trim(),
+                request.started_at_unix_ms,
+                request.completed_at_unix_ms,
+                &request.status,
+                request.pages_read,
+                request.records_scanned,
+                request.records_accepted,
+                request.records_rejected,
+                request.entities_projected,
+                request.links_projected,
+                &manifest_digest,
+                &manifest_json,
+            )
+            .await?;
+        Ok(SourceCollectionResponse {
+            recorded: true,
+            manifest_digest,
         })
     }
 }
@@ -469,6 +537,10 @@ struct ProjectEventRequest {
     source_id: String,
     family_id: String,
     event_id: String,
+    #[serde(default)]
+    event_kind: String,
+    #[serde(default)]
+    schema_ref: String,
     observed_at_unix_ms: i64,
     append_log_committed: bool,
     #[serde(default)]
@@ -484,6 +556,112 @@ struct ProjectEventResponse {
     graph_revision: Option<u64>,
     entities_upserted: usize,
     assertions_upserted: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyEntityDeltaRecord {
+    urn: String,
+    tenant_id: String,
+    source_id: String,
+    runtime_id: String,
+    entity_type: String,
+    label: String,
+    #[serde(default)]
+    attributes: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyLinkDeltaRecord {
+    tenant_id: String,
+    source_id: String,
+    runtime_id: String,
+    from_urn: String,
+    to_urn: String,
+    relation: String,
+    #[serde(default)]
+    attributes: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyCleanupRequest {
+    tenant_id: String,
+    source_id: String,
+    runtime_id: String,
+    finding_id: String,
+    #[serde(default)]
+    entity_types: Vec<String>,
+    #[serde(default)]
+    urn_prefixes: Vec<String>,
+    only_isolated: bool,
+    limit: u32,
+    dry_run: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyProjectionDelta {
+    #[serde(default)]
+    entities: Vec<LegacyEntityDeltaRecord>,
+    #[serde(default)]
+    links: Vec<LegacyLinkDeltaRecord>,
+    #[serde(default)]
+    entity_retractions: Vec<String>,
+    #[serde(default)]
+    link_retractions: Vec<LegacyLinkDeltaRecord>,
+    #[serde(default)]
+    cleanup_requests: Vec<LegacyCleanupRequest>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyProjectionRequest {
+    tenant_id: String,
+    source_runtime_id: String,
+    source_id: String,
+    family_id: String,
+    event_id: String,
+    observed_at_unix_ms: i64,
+    append_log_committed: bool,
+    delta: LegacyProjectionDelta,
+}
+
+#[derive(Serialize)]
+struct LegacyProjectionResponse {
+    recorded: bool,
+    delta_digest: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SourceCollectionRequest {
+    collection_id: String,
+    tenant_id: String,
+    source_id: String,
+    source_runtime_id: String,
+    started_at_unix_ms: i64,
+    completed_at_unix_ms: i64,
+    status: String,
+    #[serde(default)]
+    incompleteness_reasons: Vec<String>,
+    #[serde(default)]
+    expected_family_ids: Vec<String>,
+    #[serde(default)]
+    observed_family_ids: Vec<String>,
+    pages_read: u32,
+    records_scanned: u32,
+    records_accepted: u32,
+    records_rejected: u32,
+    entities_projected: u32,
+    links_projected: u32,
+}
+
+#[derive(Serialize)]
+struct SourceCollectionResponse {
+    recorded: bool,
+    manifest_digest: String,
 }
 
 #[derive(Deserialize)]
@@ -701,6 +879,14 @@ fn router_with_backend(
         .route("/v1/graph/expand-batch", post(expand_batch))
         .route("/v1/graph/paths", post(find_paths))
         .route("/v1/projections/events", post(project_event))
+        .route(
+            "/v1/projections/legacy-deltas",
+            post(record_legacy_projection),
+        )
+        .route(
+            "/v1/projections/collections",
+            post(record_source_collection),
+        )
         .route("/v1/projections/authority", get(projection_authority))
         .route_layer(middleware::from_fn_with_state(
             tenant_auth,
@@ -782,83 +968,268 @@ async fn project_event(
         ));
     }
     let tenant_id = authorized_tenant(&authenticated, request.tenant_id)?;
-    let authority = runtime
-        .authority
-        .projection_authority(tenant_id.as_str(), &request.source_id, &request.family_id)
-        .await
-        .map_err(store_error)?;
-    if authority.authority == ProjectionAuthority::Legacy {
-        return Ok(Json(ProjectEventResponse {
-            authority: ProjectionAuthority::Legacy,
-            projected: false,
-            graph_revision: None,
-            entities_upserted: 0,
-            assertions_upserted: 0,
-        }));
-    }
-    let source = runtime
-        .catalog
-        .get(&request.source_id)
-        .ok_or_else(|| bad_request("unknown_source", "The source is not in the catalog."))?
-        .clone();
-    let family = source
-        .families()
-        .iter()
-        .find(|family| family.id() == request.family_id)
-        .ok_or_else(|| bad_request("unknown_family", "The source family is not in the catalog."))?;
-    let source_runtime_id =
-        SourceRuntimeId::parse(request.source_runtime_id).map_err(model_error)?;
-    let observation_id = ObservationId::parse(request.event_id.clone()).map_err(model_error)?;
-    let collection_id =
-        CollectionId::parse(format!("event:{}", request.event_id)).map_err(model_error)?;
-    let scope = CollectedScope::NonAuthoritative(
-        CollectionReceipt::incremental(
-            tenant_id.clone(),
-            source_runtime_id,
-            collection_id,
-            format!("{}.{}", request.source_id, request.family_id),
-            request.observed_at_unix_ms,
-        )
-        .map_err(model_error)?,
-    );
-    let provider_id = event_provider_id(&request.attributes, &request.event_id);
-    let batch = CollectedBatch {
-        scope,
-        records: vec![SourceRecord {
-            observation_id,
-            family: request.family_id.clone(),
-            provider_kind: format!("{}.{}", request.source_id, family.projection().template()),
-            provider_id,
-            fields: request.attributes,
-            payload: request.payload,
-        }],
-        next_cursor: None,
+    let source_id = request.source_id.trim().to_owned();
+    let family_id = request.family_id.trim().to_owned();
+    let event_kind = if request.event_kind.trim().is_empty() {
+        format!("{source_id}.{family_id}")
+    } else {
+        request.event_kind
     };
-    let identity_resolution = runtime
-        .authority
-        .identity_resolution_snapshot(&tenant_id)
+    let event = CommittedSourceEvent::from_input(CommittedSourceInput {
+        tenant_id,
+        source_runtime_id: SourceRuntimeId::parse(request.source_runtime_id)
+            .map_err(model_error)?,
+        observation_id: ObservationId::parse(request.event_id).map_err(model_error)?,
+        source_id,
+        family_id,
+        event_kind,
+        schema_ref: request.schema_ref,
+        observed_at_unix_ms: request.observed_at_unix_ms,
+        attributes: request.attributes,
+        payload: request.payload,
+    })
+    .map_err(|error| bad_request("invalid_source_event", error.to_string()))?;
+    runtime
+        .project_committed(event)
         .await
-        .map_err(store_error)?;
-    let mapper = CatalogGraphMapper::new(source, env!("CARGO_PKG_VERSION"))
-        .map_err(|error| bad_request("projection_mapping_failed", error.to_string()))?
-        .with_identity_resolution(identity_resolution);
-    let delta = mapper
-        .map(&batch)
-        .map_err(|error| bad_request("projection_mapping_failed", error.to_string()))?;
-    let receipt = runtime
-        .store
-        .lock()
+        .map(Json)
+        .map_err(|error| match error {
+            ProjectionFailure::Invalid(message) => {
+                bad_request("projection_mapping_failed", message)
+            }
+            ProjectionFailure::Store(error) => store_error(error),
+        })
+}
+
+async fn record_legacy_projection(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Json(request): Json<LegacyProjectionRequest>,
+) -> Result<Json<LegacyProjectionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let runtime = state.projection.ok_or_else(|| {
+        service_unavailable(
+            "projection_runtime_unavailable",
+            "The organizational projection runtime is not configured.",
+        )
+    })?;
+    if !request.append_log_committed {
+        return Err(bad_request(
+            "append_log_required",
+            "The source event must be committed to the append log before recording its legacy projection.",
+        ));
+    }
+    if request.observed_at_unix_ms <= 0 {
+        return Err(bad_request(
+            "invalid_observed_at",
+            "observed_at_unix_ms must be positive.",
+        ));
+    }
+    let tenant_id = authorized_tenant(&authenticated, request.tenant_id.clone())?;
+    validate_legacy_projection(&tenant_id, &request)?;
+    runtime
+        .record_legacy_projection(&tenant_id, &request)
         .await
-        .apply(&batch, delta)
+        .map(Json)
+        .map_err(store_error)
+}
+
+async fn record_source_collection(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Json(request): Json<SourceCollectionRequest>,
+) -> Result<Json<SourceCollectionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let runtime = state.projection.ok_or_else(|| {
+        service_unavailable(
+            "projection_runtime_unavailable",
+            "The organizational projection runtime is not configured.",
+        )
+    })?;
+    let tenant_id = authorized_tenant(&authenticated, request.tenant_id.clone())?;
+    validate_source_collection(&request)?;
+    runtime
+        .record_source_collection(&tenant_id, &request)
         .await
-        .map_err(store_error)?;
-    Ok(Json(ProjectEventResponse {
-        authority: ProjectionAuthority::Rust,
-        projected: true,
-        graph_revision: Some(receipt.graph_revision),
-        entities_upserted: receipt.entities_upserted,
-        assertions_upserted: receipt.assertions_upserted,
-    }))
+        .map(Json)
+        .map_err(store_error)
+}
+
+fn validate_source_collection(
+    request: &SourceCollectionRequest,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    CollectionId::parse(request.collection_id.clone()).map_err(model_error)?;
+    SourceRuntimeId::parse(request.source_runtime_id.clone()).map_err(model_error)?;
+    if request.source_id.trim().is_empty() {
+        return Err(bad_request(
+            "invalid_source_collection",
+            "source_id is required.",
+        ));
+    }
+    if request.started_at_unix_ms <= 0 || request.completed_at_unix_ms < request.started_at_unix_ms
+    {
+        return Err(bad_request(
+            "invalid_source_collection_time",
+            "Collection times must be positive and completed_at_unix_ms cannot precede started_at_unix_ms.",
+        ));
+    }
+    match request.status.as_str() {
+        "complete" if !request.incompleteness_reasons.is_empty() => {
+            return Err(bad_request(
+                "invalid_source_collection_status",
+                "A complete collection cannot contain incompleteness reasons.",
+            ));
+        }
+        "incomplete" if request.incompleteness_reasons.is_empty() => {
+            return Err(bad_request(
+                "invalid_source_collection_status",
+                "An incomplete collection must contain at least one reason.",
+            ));
+        }
+        "complete" | "incomplete" => {}
+        _ => {
+            return Err(bad_request(
+                "invalid_source_collection_status",
+                "status must be complete or incomplete.",
+            ));
+        }
+    }
+    if request
+        .records_accepted
+        .saturating_add(request.records_rejected)
+        > request.records_scanned
+    {
+        return Err(bad_request(
+            "invalid_source_collection_counts",
+            "Accepted and rejected records cannot exceed scanned records.",
+        ));
+    }
+    for values in [
+        &request.incompleteness_reasons,
+        &request.expected_family_ids,
+        &request.observed_family_ids,
+    ] {
+        if values.len() > 10_000
+            || values.iter().any(|value| value.trim().is_empty())
+            || values.windows(2).any(|pair| pair[0] >= pair[1])
+        {
+            return Err(bad_request(
+                "invalid_source_collection_values",
+                "Collection reason and family lists must be non-empty, unique, sorted, and bounded.",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_legacy_projection(
+    tenant_id: &TenantId,
+    request: &LegacyProjectionRequest,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    SourceRuntimeId::parse(request.source_runtime_id.clone()).map_err(model_error)?;
+    ObservationId::parse(request.event_id.clone()).map_err(model_error)?;
+    let source_id = request.source_id.trim();
+    let family_id = request.family_id.trim();
+    if source_id.is_empty() || family_id.is_empty() {
+        return Err(bad_request(
+            "invalid_legacy_projection",
+            "source_id and family_id are required.",
+        ));
+    }
+    let record_count = request
+        .delta
+        .entities
+        .len()
+        .saturating_add(request.delta.links.len())
+        .saturating_add(request.delta.entity_retractions.len())
+        .saturating_add(request.delta.link_retractions.len())
+        .saturating_add(request.delta.cleanup_requests.len());
+    if record_count > MAX_LEGACY_DELTA_RECORDS {
+        return Err(bad_request(
+            "legacy_projection_too_large",
+            format!(
+                "A legacy projection delta cannot contain more than {MAX_LEGACY_DELTA_RECORDS} records."
+            ),
+        ));
+    }
+    let expected_tenant = tenant_id.as_str();
+    let expected_runtime = request.source_runtime_id.trim();
+    for entity in &request.delta.entities {
+        if entity.tenant_id.trim() != expected_tenant
+            || entity.source_id.trim() != source_id
+            || entity.runtime_id.trim() != expected_runtime
+            || entity.urn.trim().is_empty()
+            || entity.entity_type.trim().is_empty()
+            || !legacy_urn_matches_tenant(expected_tenant, &entity.urn)
+        {
+            return Err(bad_request(
+                "legacy_projection_scope_mismatch",
+                "Every projected entity must match the request tenant, source, and runtime.",
+            ));
+        }
+    }
+    for link in request
+        .delta
+        .links
+        .iter()
+        .chain(request.delta.link_retractions.iter())
+    {
+        if link.tenant_id.trim() != expected_tenant
+            || link.source_id.trim() != source_id
+            || link.runtime_id.trim() != expected_runtime
+            || link.relation.trim().is_empty()
+            || !legacy_urn_matches_tenant(expected_tenant, &link.from_urn)
+            || !legacy_urn_matches_tenant(expected_tenant, &link.to_urn)
+        {
+            return Err(bad_request(
+                "legacy_projection_scope_mismatch",
+                "Every projected link must match the request tenant, source, and runtime.",
+            ));
+        }
+    }
+    if request
+        .delta
+        .entity_retractions
+        .iter()
+        .any(|urn| !legacy_urn_matches_tenant(expected_tenant, urn))
+    {
+        return Err(bad_request(
+            "legacy_projection_scope_mismatch",
+            "Every entity retraction must match the request tenant.",
+        ));
+    }
+    for cleanup in &request.delta.cleanup_requests {
+        if cleanup.tenant_id.trim() != expected_tenant
+            || cleanup.source_id.trim() != source_id
+            || cleanup.runtime_id.trim() != expected_runtime
+            || cleanup
+                .urn_prefixes
+                .iter()
+                .any(|urn| !legacy_urn_matches_tenant(expected_tenant, urn))
+        {
+            return Err(bad_request(
+                "legacy_projection_scope_mismatch",
+                "Every cleanup request must match the request tenant, source, and runtime.",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn legacy_urn_matches_tenant(tenant_id: &str, value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && (!value.starts_with("urn:cerebro:")
+            || value.starts_with(&format!("urn:cerebro:{tenant_id}:")))
+}
+
+fn json_digest(value: &serde_json::Value) -> String {
+    let bytes = serde_json::to_vec(value).expect("serializing a JSON value cannot fail");
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        write!(&mut output, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    output
 }
 
 async fn health() -> Json<HealthResponse> {
@@ -1565,6 +1936,68 @@ mod tests {
         ] {
             assert!(!auth.verify(&tenant, token), "token {token:?} was accepted");
         }
+    }
+
+    #[test]
+    fn source_collection_requires_consistent_status_counts_and_sorted_families() {
+        let mut request = SourceCollectionRequest {
+            collection_id: "collection-one".to_owned(),
+            tenant_id: "tenant-demo".to_owned(),
+            source_id: "box".to_owned(),
+            source_runtime_id: "box-runtime".to_owned(),
+            started_at_unix_ms: 100,
+            completed_at_unix_ms: 200,
+            status: "complete".to_owned(),
+            incompleteness_reasons: Vec::new(),
+            expected_family_ids: vec!["content_assets".to_owned(), "users".to_owned()],
+            observed_family_ids: vec!["content_assets".to_owned()],
+            pages_read: 1,
+            records_scanned: 2,
+            records_accepted: 2,
+            records_rejected: 0,
+            entities_projected: 2,
+            links_projected: 1,
+        };
+        assert!(validate_source_collection(&request).is_ok());
+
+        request.status = "incomplete".to_owned();
+        assert!(validate_source_collection(&request).is_err());
+        request.incompleteness_reasons = vec!["next_cursor_present".to_owned()];
+        assert!(validate_source_collection(&request).is_ok());
+        request.observed_family_ids = vec!["users".to_owned(), "content_assets".to_owned()];
+        assert!(validate_source_collection(&request).is_err());
+    }
+
+    #[test]
+    fn legacy_projection_rejects_cross_scope_records() {
+        let tenant_id = TenantId::parse("tenant-demo").unwrap();
+        let mut request = LegacyProjectionRequest {
+            tenant_id: tenant_id.as_str().to_owned(),
+            source_runtime_id: "box-runtime".to_owned(),
+            source_id: "box".to_owned(),
+            family_id: "content_assets".to_owned(),
+            event_id: "event-one".to_owned(),
+            observed_at_unix_ms: 100,
+            append_log_committed: true,
+            delta: LegacyProjectionDelta {
+                entities: vec![LegacyEntityDeltaRecord {
+                    urn: "urn:cerebro:tenant-demo:asset:one".to_owned(),
+                    tenant_id: tenant_id.as_str().to_owned(),
+                    source_id: "box".to_owned(),
+                    runtime_id: "box-runtime".to_owned(),
+                    entity_type: "box.asset".to_owned(),
+                    label: "One".to_owned(),
+                    attributes: BTreeMap::new(),
+                }],
+                links: Vec::new(),
+                entity_retractions: Vec::new(),
+                link_retractions: Vec::new(),
+                cleanup_requests: Vec::new(),
+            },
+        };
+        assert!(validate_legacy_projection(&tenant_id, &request).is_ok());
+        request.delta.entities[0].tenant_id = "tenant-other".to_owned();
+        assert!(validate_legacy_projection(&tenant_id, &request).is_err());
     }
 
     #[test]

--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -16,7 +16,10 @@ pub use parity::{
     MismatchSide, ParityError, ParityReceipt, ParityStatus, SemanticFact, SemanticFactKind,
     SemanticMismatch, SemanticSnapshot,
 };
-pub use postgres::{POSTGRES_SCHEMA, PostgresLedger};
+pub use postgres::{
+    LegacyProjectionReceipt, POSTGRES_SCHEMA, PostgresLedger, SourceCollectionReceipt,
+    SourceEventReceipt,
+};
 
 use std::{error::Error, fmt};
 

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -6,7 +6,9 @@ use cerebro_organizational_model::{
     IdentityBindingAssertion, IdentityBindingState, IdentityResolutionMethod, TenantId,
 };
 use cerebro_source_catalog::SourceCatalog;
-use cerebro_source_runtime_next::{CollectedBatch, IdentityResolutionSnapshot};
+use cerebro_source_runtime_next::{
+    CollectedBatch, CommittedSourceEvent, IdentityResolutionSnapshot,
+};
 use postgres_native_tls::MakeTlsConnector;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -51,6 +53,57 @@ CREATE TABLE IF NOT EXISTS organizational_observations (
   FOREIGN KEY (tenant_id, collection_id)
     REFERENCES organizational_collections (tenant_id, collection_id)
     DEFERRABLE INITIALLY DEFERRED
+);
+CREATE TABLE IF NOT EXISTS organizational_source_event_receipts (
+  tenant_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  source_runtime_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  family_id TEXT NOT NULL,
+  event_kind TEXT NOT NULL,
+  schema_ref TEXT NOT NULL,
+  observed_at_unix_ms BIGINT NOT NULL CHECK (observed_at_unix_ms > 0),
+  attributes_digest TEXT NOT NULL,
+  payload_digest TEXT NOT NULL,
+  record_digest TEXT NOT NULL,
+  PRIMARY KEY (tenant_id, event_id)
+);
+CREATE TABLE IF NOT EXISTS organizational_legacy_projection_receipts (
+  tenant_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  source_runtime_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  family_id TEXT NOT NULL,
+  observed_at_unix_ms BIGINT NOT NULL CHECK (observed_at_unix_ms > 0),
+  entity_count BIGINT NOT NULL CHECK (entity_count >= 0),
+  link_count BIGINT NOT NULL CHECK (link_count >= 0),
+  entity_retraction_count BIGINT NOT NULL CHECK (entity_retraction_count >= 0),
+  link_retraction_count BIGINT NOT NULL CHECK (link_retraction_count >= 0),
+  cleanup_request_count BIGINT NOT NULL CHECK (cleanup_request_count >= 0),
+  delta_digest TEXT NOT NULL,
+  delta_json JSONB NOT NULL,
+  PRIMARY KEY (tenant_id, event_id),
+  FOREIGN KEY (tenant_id, event_id)
+    REFERENCES organizational_source_event_receipts (tenant_id, event_id)
+    DEFERRABLE INITIALLY DEFERRED
+);
+CREATE TABLE IF NOT EXISTS organizational_source_collection_receipts (
+  tenant_id TEXT NOT NULL,
+  collection_id TEXT NOT NULL,
+  source_runtime_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  started_at_unix_ms BIGINT NOT NULL CHECK (started_at_unix_ms > 0),
+  completed_at_unix_ms BIGINT NOT NULL CHECK (completed_at_unix_ms >= started_at_unix_ms),
+  status TEXT NOT NULL CHECK (status IN ('complete', 'incomplete')),
+  pages_read BIGINT NOT NULL CHECK (pages_read >= 0),
+  records_scanned BIGINT NOT NULL CHECK (records_scanned >= 0),
+  records_accepted BIGINT NOT NULL CHECK (records_accepted >= 0),
+  records_rejected BIGINT NOT NULL CHECK (records_rejected >= 0),
+  entities_projected BIGINT NOT NULL CHECK (entities_projected >= 0),
+  links_projected BIGINT NOT NULL CHECK (links_projected >= 0),
+  manifest_digest TEXT NOT NULL,
+  manifest_json JSONB NOT NULL,
+  PRIMARY KEY (tenant_id, collection_id)
 );
 CREATE TABLE IF NOT EXISTS organizational_entities (
   tenant_id TEXT NOT NULL,
@@ -151,12 +204,21 @@ CREATE INDEX IF NOT EXISTS organizational_projection_pending_idx
 CREATE INDEX IF NOT EXISTS organizational_parity_latest_idx
   ON organizational_parity_receipts
     (tenant_id, source_id, family_id, compared_at_unix_ms DESC);
+CREATE INDEX IF NOT EXISTS organizational_source_collection_latest_idx
+  ON organizational_source_collection_receipts
+    (tenant_id, source_runtime_id, completed_at_unix_ms DESC);
 ALTER TABLE organizational_graph_revisions ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_graph_revisions FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_collections ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_collections FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_observations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_observations FORCE ROW LEVEL SECURITY;
+ALTER TABLE organizational_source_event_receipts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE organizational_source_event_receipts FORCE ROW LEVEL SECURITY;
+ALTER TABLE organizational_legacy_projection_receipts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE organizational_legacy_projection_receipts FORCE ROW LEVEL SECURITY;
+ALTER TABLE organizational_source_collection_receipts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE organizational_source_collection_receipts FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_entities ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_entities FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_assertions ENABLE ROW LEVEL SECURITY;
@@ -178,6 +240,9 @@ BEGIN
     'organizational_graph_revisions',
     'organizational_collections',
     'organizational_observations',
+    'organizational_source_event_receipts',
+    'organizational_legacy_projection_receipts',
+    'organizational_source_collection_receipts',
     'organizational_entities',
     'organizational_assertions',
     'organizational_identity_bindings',
@@ -389,6 +454,27 @@ pub(crate) struct CommittedCollection {
     pub pending_projection: Option<ProjectionCommit>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceEventReceipt {
+    pub tenant_id: String,
+    pub event_id: String,
+    pub record_digest: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LegacyProjectionReceipt {
+    pub tenant_id: String,
+    pub event_id: String,
+    pub delta_digest: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceCollectionReceipt {
+    pub tenant_id: String,
+    pub collection_id: String,
+    pub manifest_digest: String,
+}
+
 pub struct PostgresLedger {
     client: Mutex<Client>,
 }
@@ -423,6 +509,181 @@ impl PostgresLedger {
             .batch_execute(POSTGRES_SCHEMA)
             .await?;
         Ok(())
+    }
+
+    /// Records the rebuildable PostgreSQL receipt for one source event already
+    /// committed to JetStream. Replays are idempotent; an event ID reused for
+    /// different content fails closed.
+    pub async fn record_source_event(
+        &self,
+        event: &CommittedSourceEvent,
+    ) -> Result<SourceEventReceipt, StoreError> {
+        let tenant_id = event.tenant_id().as_str();
+        let event_id = event.observation_id().as_str();
+        let record_digest = event.record_digest();
+        let attributes_digest = event.attributes_digest();
+        let payload_digest = event.payload_digest();
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id).await?;
+        let row = transaction
+            .query_opt(
+                "INSERT INTO organizational_source_event_receipts (tenant_id, event_id, source_runtime_id, source_id, family_id, event_kind, schema_ref, observed_at_unix_ms, attributes_digest, payload_digest, record_digest) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) ON CONFLICT (tenant_id, event_id) DO UPDATE SET record_digest = EXCLUDED.record_digest WHERE organizational_source_event_receipts.record_digest = EXCLUDED.record_digest RETURNING record_digest",
+                &[
+                    &tenant_id,
+                    &event_id,
+                    &event.source_runtime_id().as_str(),
+                    &event.source_id(),
+                    &event.family_id(),
+                    &event.event_kind(),
+                    &event.schema_ref(),
+                    &event.observed_at_unix_ms(),
+                    &attributes_digest,
+                    &payload_digest,
+                    &record_digest,
+                ],
+            )
+            .await?;
+        if row.is_none() {
+            return Err(StoreError::Conflict(format!(
+                "source event {event_id} conflicts with the stored record"
+            )));
+        }
+        transaction.commit().await?;
+        Ok(SourceEventReceipt {
+            tenant_id: tenant_id.to_owned(),
+            event_id: event_id.to_owned(),
+            record_digest,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record_legacy_projection(
+        &self,
+        tenant_id: &str,
+        event_id: &str,
+        source_runtime_id: &str,
+        source_id: &str,
+        family_id: &str,
+        observed_at_unix_ms: i64,
+        entity_count: usize,
+        link_count: usize,
+        entity_retraction_count: usize,
+        link_retraction_count: usize,
+        cleanup_request_count: usize,
+        delta_digest: &str,
+        delta_json: &Value,
+    ) -> Result<LegacyProjectionReceipt, StoreError> {
+        let entity_count = i64::try_from(entity_count)
+            .map_err(|_| StoreError::Conflict("legacy entity count overflow".to_owned()))?;
+        let link_count = i64::try_from(link_count)
+            .map_err(|_| StoreError::Conflict("legacy link count overflow".to_owned()))?;
+        let entity_retraction_count = i64::try_from(entity_retraction_count).map_err(|_| {
+            StoreError::Conflict("legacy entity retraction count overflow".to_owned())
+        })?;
+        let link_retraction_count = i64::try_from(link_retraction_count).map_err(|_| {
+            StoreError::Conflict("legacy link retraction count overflow".to_owned())
+        })?;
+        let cleanup_request_count = i64::try_from(cleanup_request_count).map_err(|_| {
+            StoreError::Conflict("legacy cleanup request count overflow".to_owned())
+        })?;
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id).await?;
+        let row = transaction
+            .query_opt(
+                "INSERT INTO organizational_legacy_projection_receipts (tenant_id, event_id, source_runtime_id, source_id, family_id, observed_at_unix_ms, entity_count, link_count, entity_retraction_count, link_retraction_count, cleanup_request_count, delta_digest, delta_json) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) ON CONFLICT (tenant_id, event_id) DO UPDATE SET delta_digest = EXCLUDED.delta_digest WHERE organizational_legacy_projection_receipts.delta_digest = EXCLUDED.delta_digest AND organizational_legacy_projection_receipts.delta_json = EXCLUDED.delta_json RETURNING delta_digest",
+                &[
+                    &tenant_id,
+                    &event_id,
+                    &source_runtime_id,
+                    &source_id,
+                    &family_id,
+                    &observed_at_unix_ms,
+                    &entity_count,
+                    &link_count,
+                    &entity_retraction_count,
+                    &link_retraction_count,
+                    &cleanup_request_count,
+                    &delta_digest,
+                    &delta_json,
+                ],
+            )
+            .await?;
+        if row.is_none() {
+            return Err(StoreError::Conflict(format!(
+                "legacy projection for source event {event_id} conflicts with the stored record"
+            )));
+        }
+        transaction.commit().await?;
+        Ok(LegacyProjectionReceipt {
+            tenant_id: tenant_id.to_owned(),
+            event_id: event_id.to_owned(),
+            delta_digest: delta_digest.to_owned(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record_source_collection(
+        &self,
+        tenant_id: &str,
+        collection_id: &str,
+        source_runtime_id: &str,
+        source_id: &str,
+        started_at_unix_ms: i64,
+        completed_at_unix_ms: i64,
+        status: &str,
+        pages_read: u32,
+        records_scanned: u32,
+        records_accepted: u32,
+        records_rejected: u32,
+        entities_projected: u32,
+        links_projected: u32,
+        manifest_digest: &str,
+        manifest_json: &Value,
+    ) -> Result<SourceCollectionReceipt, StoreError> {
+        let pages_read = i64::from(pages_read);
+        let records_scanned = i64::from(records_scanned);
+        let records_accepted = i64::from(records_accepted);
+        let records_rejected = i64::from(records_rejected);
+        let entities_projected = i64::from(entities_projected);
+        let links_projected = i64::from(links_projected);
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id).await?;
+        let row = transaction
+            .query_opt(
+                "INSERT INTO organizational_source_collection_receipts (tenant_id, collection_id, source_runtime_id, source_id, started_at_unix_ms, completed_at_unix_ms, status, pages_read, records_scanned, records_accepted, records_rejected, entities_projected, links_projected, manifest_digest, manifest_json) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) ON CONFLICT (tenant_id, collection_id) DO UPDATE SET manifest_digest = EXCLUDED.manifest_digest WHERE organizational_source_collection_receipts.manifest_digest = EXCLUDED.manifest_digest AND organizational_source_collection_receipts.manifest_json = EXCLUDED.manifest_json RETURNING manifest_digest",
+                &[
+                    &tenant_id,
+                    &collection_id,
+                    &source_runtime_id,
+                    &source_id,
+                    &started_at_unix_ms,
+                    &completed_at_unix_ms,
+                    &status,
+                    &pages_read,
+                    &records_scanned,
+                    &records_accepted,
+                    &records_rejected,
+                    &entities_projected,
+                    &links_projected,
+                    &manifest_digest,
+                    &manifest_json,
+                ],
+            )
+            .await?;
+        if row.is_none() {
+            return Err(StoreError::Conflict(format!(
+                "source collection {collection_id} conflicts with the stored record"
+            )));
+        }
+        transaction.commit().await?;
+        Ok(SourceCollectionReceipt {
+            tenant_id: tenant_id.to_owned(),
+            collection_id: collection_id.to_owned(),
+            manifest_digest: manifest_digest.to_owned(),
+        })
     }
 
     pub async fn record_parity(&self, receipt: &ParityReceipt) -> Result<(), StoreError> {
@@ -1405,11 +1666,24 @@ mod tests {
             "PRIMARY KEY (tenant_id, claim_kind, claim_value)",
             "organizational_projection_outbox",
             "organizational_parity_receipts",
+            "organizational_source_event_receipts",
+            "organizational_legacy_projection_receipts",
+            "organizational_source_collection_receipts",
+            "organizational_source_collection_latest_idx",
             "current_setting(''cerebro.tenant_id'', true)",
             "DEFERRABLE INITIALLY DEFERRED",
         ] {
             assert!(POSTGRES_SCHEMA.contains(required), "missing {required}");
         }
+        let source_receipt_schema = POSTGRES_SCHEMA
+            .split("CREATE TABLE IF NOT EXISTS organizational_source_event_receipts")
+            .nth(1)
+            .and_then(|schema| schema.split("CREATE TABLE IF NOT EXISTS").next())
+            .expect("source event receipt schema");
+        assert!(source_receipt_schema.contains("attributes_digest TEXT NOT NULL"));
+        assert!(source_receipt_schema.contains("payload_digest TEXT NOT NULL"));
+        assert!(!source_receipt_schema.contains("attributes_json"));
+        assert!(!source_receipt_schema.contains("payload_json"));
         for required in [
             "entity_json = EXCLUDED.entity_json",
             "entity_json->'kind' = EXCLUDED.entity_json->'kind'",

--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -9,6 +9,7 @@ use cerebro_organizational_model::{
 };
 use prost::Message;
 use prost_types::Timestamp;
+use sha2::{Digest, Sha256};
 
 use crate::{CollectedBatch, CollectedScope, SourceRecord};
 
@@ -81,12 +82,54 @@ pub struct CommittedSourceEvent {
     observation_id: ObservationId,
     source_id: String,
     family_id: String,
+    event_kind: String,
+    schema_ref: String,
     observed_at_unix_ms: i64,
     attributes: BTreeMap<String, String>,
     payload: serde_json::Value,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct CommittedSourceInput {
+    pub tenant_id: TenantId,
+    pub source_runtime_id: SourceRuntimeId,
+    pub observation_id: ObservationId,
+    pub source_id: String,
+    pub family_id: String,
+    pub event_kind: String,
+    pub schema_ref: String,
+    pub observed_at_unix_ms: i64,
+    pub attributes: BTreeMap<String, String>,
+    pub payload: serde_json::Value,
+}
+
 impl CommittedSourceEvent {
+    pub fn from_input(input: CommittedSourceInput) -> Result<Self, AppendLogDecodeError> {
+        let source_id = required(&input.source_id, "source_id")?.to_owned();
+        let family_id = required(&input.family_id, "family_id")?.to_owned();
+        let event_kind = required(&input.event_kind, "event_kind")?.to_owned();
+        if event_kind != format!("{source_id}.{family_id}") {
+            return Err(AppendLogDecodeError::Missing(
+                "a source-owned kind in source.family form",
+            ));
+        }
+        if input.observed_at_unix_ms <= 0 {
+            return Err(AppendLogDecodeError::InvalidTimestamp);
+        }
+        Ok(Self {
+            tenant_id: input.tenant_id,
+            source_runtime_id: input.source_runtime_id,
+            observation_id: input.observation_id,
+            source_id,
+            family_id,
+            event_kind,
+            schema_ref: input.schema_ref.trim().to_owned(),
+            observed_at_unix_ms: input.observed_at_unix_ms,
+            attributes: input.attributes,
+            payload: input.payload,
+        })
+    }
+
     /// Decode a canonical append-log envelope.
     ///
     /// `Ok(None)` means the envelope is not a connector source event. Once an
@@ -133,6 +176,8 @@ impl CommittedSourceEvent {
             observation_id,
             source_id,
             family_id: kind[source_prefix.len()..].to_owned(),
+            event_kind: kind.to_owned(),
+            schema_ref: wire.schema_ref.trim().to_owned(),
             observed_at_unix_ms,
             attributes: wire.attributes.into_iter().collect(),
             payload,
@@ -159,6 +204,14 @@ impl CommittedSourceEvent {
         &self.family_id
     }
 
+    pub fn event_kind(&self) -> &str {
+        &self.event_kind
+    }
+
+    pub fn schema_ref(&self) -> &str {
+        &self.schema_ref
+    }
+
     pub fn observed_at_unix_ms(&self) -> i64 {
         self.observed_at_unix_ms
     }
@@ -169,6 +222,41 @@ impl CommittedSourceEvent {
 
     pub fn payload(&self) -> &serde_json::Value {
         &self.payload
+    }
+
+    pub fn record_digest(&self) -> String {
+        let mut hasher = Sha256::new();
+        hash_field(&mut hasher, self.tenant_id.as_str().as_bytes());
+        hash_field(&mut hasher, self.source_runtime_id.as_str().as_bytes());
+        hash_field(&mut hasher, self.observation_id.as_str().as_bytes());
+        hash_field(&mut hasher, self.source_id.as_bytes());
+        hash_field(&mut hasher, self.family_id.as_bytes());
+        hash_field(&mut hasher, self.event_kind.as_bytes());
+        hash_field(&mut hasher, self.schema_ref.as_bytes());
+        hash_field(&mut hasher, self.observed_at_unix_ms.to_string().as_bytes());
+        for (key, value) in &self.attributes {
+            hash_field(&mut hasher, key.as_bytes());
+            hash_field(&mut hasher, value.as_bytes());
+        }
+        let payload = canonical_payload_bytes(&self.payload);
+        hash_field(&mut hasher, &payload);
+        finish_digest(hasher)
+    }
+
+    pub fn attributes_digest(&self) -> String {
+        let mut hasher = Sha256::new();
+        for (key, value) in &self.attributes {
+            hash_field(&mut hasher, key.as_bytes());
+            hash_field(&mut hasher, value.as_bytes());
+        }
+        finish_digest(hasher)
+    }
+
+    pub fn payload_digest(&self) -> String {
+        let mut hasher = Sha256::new();
+        let payload = canonical_payload_bytes(&self.payload);
+        hash_field(&mut hasher, &payload);
+        finish_digest(hasher)
     }
 
     pub fn collection_id(&self) -> Result<CollectionId, AppendLogDecodeError> {
@@ -202,6 +290,43 @@ impl CommittedSourceEvent {
             next_cursor: None,
         })
     }
+}
+
+fn hash_field(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update(value.len().to_be_bytes());
+    hasher.update(value);
+}
+
+fn canonical_payload_bytes(value: &serde_json::Value) -> Vec<u8> {
+    fn canonicalize(value: &serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::Array(values) => {
+                serde_json::Value::Array(values.iter().map(canonicalize).collect())
+            }
+            serde_json::Value::Object(values) => {
+                let mut keys = values.keys().collect::<Vec<_>>();
+                keys.sort_unstable();
+                let mut canonical = serde_json::Map::new();
+                for key in keys {
+                    canonical.insert(key.clone(), canonicalize(&values[key]));
+                }
+                serde_json::Value::Object(canonical)
+            }
+            scalar => scalar.clone(),
+        }
+    }
+
+    serde_json::to_vec(&canonicalize(value)).expect("validated JSON payload must serialize")
+}
+
+fn finish_digest(hasher: Sha256) -> String {
+    let digest = hasher.finalize();
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        write!(&mut output, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    output
 }
 
 fn required<'a>(value: &'a str, field: &'static str) -> Result<&'a str, AppendLogDecodeError> {
@@ -266,6 +391,8 @@ mod tests {
         assert_eq!(event.observation_id().as_str(), "event-1");
         assert_eq!(event.source_id(), "box");
         assert_eq!(event.family_id(), "content_assets");
+        assert_eq!(event.event_kind(), "box.content_assets");
+        assert_eq!(event.schema_ref(), "box/content_assets/v1");
         assert_eq!(event.collection_id().unwrap().as_str(), "event:event-1");
         assert_eq!(event.observed_at_unix_ms(), 1_720_000_000_123);
         assert_eq!(event.attributes()["provider_id"], "file-1");
@@ -367,6 +494,57 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(event.payload(), &serde_json::json!({}));
+    }
+
+    #[test]
+    fn record_digest_is_stable_across_attribute_and_payload_key_order() {
+        let mut wire = source_wire();
+        wire.payload = br#"{"nested":{"z":1,"a":2},"id":"file-1","name":"board.pdf"}"#.to_vec();
+        let first = CommittedSourceEvent::decode(&encode(wire))
+            .unwrap()
+            .unwrap();
+        let input = CommittedSourceInput {
+            tenant_id: TenantId::parse("tenant-a").unwrap(),
+            source_runtime_id: SourceRuntimeId::parse("box-prod").unwrap(),
+            observation_id: ObservationId::parse("event-1").unwrap(),
+            source_id: "box".to_owned(),
+            family_id: "content_assets".to_owned(),
+            event_kind: "box.content_assets".to_owned(),
+            schema_ref: "box/content_assets/v1".to_owned(),
+            observed_at_unix_ms: 1_720_000_000_123,
+            attributes: BTreeMap::from([
+                ("provider_id".to_owned(), "file-1".to_owned()),
+                ("source_runtime_id".to_owned(), "box-prod".to_owned()),
+            ]),
+            payload: serde_json::json!({
+                "name": "board.pdf",
+                "id": "file-1",
+                "nested": {"a": 2, "z": 1}
+            }),
+        };
+        let second = CommittedSourceEvent::from_input(input).unwrap();
+        assert_eq!(first.record_digest(), second.record_digest());
+        assert_eq!(first.payload_digest(), second.payload_digest());
+    }
+
+    #[test]
+    fn direct_input_cannot_change_source_family_ownership() {
+        let input = CommittedSourceInput {
+            tenant_id: TenantId::parse("tenant-a").unwrap(),
+            source_runtime_id: SourceRuntimeId::parse("box-prod").unwrap(),
+            observation_id: ObservationId::parse("event-1").unwrap(),
+            source_id: "box".to_owned(),
+            family_id: "content_assets".to_owned(),
+            event_kind: "github.repositories".to_owned(),
+            schema_ref: "box/content_assets/v1".to_owned(),
+            observed_at_unix_ms: 1_720_000_000_123,
+            attributes: BTreeMap::new(),
+            payload: serde_json::json!({}),
+        };
+        assert!(matches!(
+            CommittedSourceEvent::from_input(input),
+            Err(AppendLogDecodeError::Missing(_))
+        ));
     }
 
     #[test]

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -6,7 +6,7 @@ mod append_log;
 mod http;
 mod mapper;
 
-pub use append_log::{AppendLogDecodeError, CommittedSourceEvent};
+pub use append_log::{AppendLogDecodeError, CommittedSourceEvent, CommittedSourceInput};
 pub use http::{HttpConnectorError, HttpSourceConnector, ResolvedAuth};
 pub use mapper::{CatalogGraphMapper, CatalogMapperError, IdentityResolutionSnapshot};
 

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -160,6 +160,27 @@ Repository conventions and review are not the security boundary. Store credentia
 
 Source migration is definition- and family-based, not package-by-package translation.
 
+The append log remains the source-event log of record throughout migration.
+Rust records every valid source event in a tenant-scoped, idempotent PostgreSQL
+receipt projection before it evaluates family authority. An event from a
+legacy or not-yet-cataloged family is retained and acknowledged as legacy; it
+is not silently discarded. Reusing an event ID with different content fails
+closed. The receipt contains event metadata and content digests, not a second
+copy of the raw payload or secret material.
+
+While a family remains legacy-authoritative, the shared Go projection boundary
+also sends Rust the exact normalized entities, links, entity retractions, link
+retractions, and scoped cleanup requests written for that event. These
+compatibility records preserve existing source coverage for parity and replay;
+they do not grant Rust graph-write authority and they are not another system of
+record.
+
+After each bounded source-runtime sync, the same boundary records a collection
+manifest with expected and observed families, page and record counts,
+projection counts, and deterministic incompleteness reasons. A completed sync
+receipt is coverage evidence only. It does not become an authoritative
+`CompleteCollection`, and therefore cannot enable missing-record retraction.
+
 For every existing source family, the parity corpus records:
 
 - provider request and pagination behavior;

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -118,6 +118,17 @@ type ProjectionResult struct {
 	LinksDeleted      uint32
 }
 
+// SourceProjectionDelta preserves the exact normalized compatibility output
+// produced for one append-log event while Rust assumes projection authority
+// one source family at a time.
+type SourceProjectionDelta struct {
+	Entities          []*ProjectedEntity
+	Links             []*ProjectedLink
+	EntityRetractions []string
+	LinkRetractions   []*ProjectedLink
+	CleanupRequests   []ProjectionCleanupRequest
+}
+
 // ProjectionCleanupRequest scopes opportunistic graph cleanup to one tenant/source/runtime boundary.
 type ProjectionCleanupRequest struct {
 	TenantID     string
@@ -263,4 +274,12 @@ type ProjectionAssertionMigrator interface {
 // SourceProjector materializes source events into current-state and graph stores.
 type SourceProjector interface {
 	Project(context.Context, *cerebrov1.EventEnvelope) (ProjectionResult, error)
+}
+
+// SourceProjectorWithDelta returns the compatibility records written for an
+// event. Callers use this optional interface to retain existing source coverage
+// without teaching the Rust authority every Go projector at once.
+type SourceProjectorWithDelta interface {
+	SourceProjector
+	ProjectWithDelta(context.Context, *cerebrov1.EventEnvelope) (ProjectionResult, SourceProjectionDelta, error)
 }

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -56,6 +56,33 @@ type SourceRuntimePageProjection struct {
 	LinksProjected    uint32
 }
 
+// SourceCollectionManifest records one bounded sync run without treating a
+// completed incremental run as an authoritative full snapshot.
+type SourceCollectionManifest struct {
+	CollectionID          string
+	TenantID              string
+	SourceID              string
+	RuntimeID             string
+	StartedAtUnixMS       int64
+	CompletedAtUnixMS     int64
+	Status                string
+	IncompletenessReasons []string
+	ExpectedFamilyIDs     []string
+	ObservedFamilyIDs     []string
+	PagesRead             uint32
+	RecordsScanned        uint32
+	RecordsAccepted       uint32
+	RecordsRejected       uint32
+	EntitiesProjected     uint32
+	LinksProjected        uint32
+}
+
+// SourceCollectionRecorder retains collection-level coverage and completeness
+// at the Rust migration boundary.
+type SourceCollectionRecorder interface {
+	RecordSourceCollection(context.Context, SourceCollectionManifest) error
+}
+
 // SourceRuntimePageLedgerStore durably records page commit state and outbox
 // events. CommitSourceRuntimePage must atomically persist runtime progress and
 // mark the page committed.

--- a/internal/sourcehttp/organizationalgraph/projection.go
+++ b/internal/sourcehttp/organizationalgraph/projection.go
@@ -67,6 +67,8 @@ type projectEventRequest struct {
 	SourceID           string            `json:"source_id"`
 	FamilyID           string            `json:"family_id"`
 	EventID            string            `json:"event_id"`
+	EventKind          string            `json:"event_kind"`
+	SchemaRef          string            `json:"schema_ref"`
 	ObservedAtUnixMS   int64             `json:"observed_at_unix_ms"`
 	AppendLogCommitted bool              `json:"append_log_committed"`
 	Attributes         map[string]string `json:"attributes"`
@@ -79,6 +81,86 @@ type projectEventResponse struct {
 	GraphRevision      *uint64 `json:"graph_revision"`
 	EntitiesUpserted   uint32  `json:"entities_upserted"`
 	AssertionsUpserted uint32  `json:"assertions_upserted"`
+}
+
+type legacyProjectedEntity struct {
+	URN        string            `json:"urn"`
+	TenantID   string            `json:"tenant_id"`
+	SourceID   string            `json:"source_id"`
+	RuntimeID  string            `json:"runtime_id"`
+	EntityType string            `json:"entity_type"`
+	Label      string            `json:"label"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+type legacyProjectedLink struct {
+	TenantID   string            `json:"tenant_id"`
+	SourceID   string            `json:"source_id"`
+	RuntimeID  string            `json:"runtime_id"`
+	FromURN    string            `json:"from_urn"`
+	ToURN      string            `json:"to_urn"`
+	Relation   string            `json:"relation"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+type legacyCleanupRequest struct {
+	TenantID     string   `json:"tenant_id"`
+	SourceID     string   `json:"source_id"`
+	RuntimeID    string   `json:"runtime_id"`
+	FindingID    string   `json:"finding_id"`
+	EntityTypes  []string `json:"entity_types"`
+	URNPrefixes  []string `json:"urn_prefixes"`
+	OnlyIsolated bool     `json:"only_isolated"`
+	Limit        uint32   `json:"limit"`
+	DryRun       bool     `json:"dry_run"`
+}
+
+type legacyProjectionDelta struct {
+	Entities          []legacyProjectedEntity `json:"entities"`
+	Links             []legacyProjectedLink   `json:"links"`
+	EntityRetractions []string                `json:"entity_retractions"`
+	LinkRetractions   []legacyProjectedLink   `json:"link_retractions"`
+	CleanupRequests   []legacyCleanupRequest  `json:"cleanup_requests"`
+}
+
+type legacyProjectionRequest struct {
+	TenantID           string                `json:"tenant_id"`
+	SourceRuntimeID    string                `json:"source_runtime_id"`
+	SourceID           string                `json:"source_id"`
+	FamilyID           string                `json:"family_id"`
+	EventID            string                `json:"event_id"`
+	ObservedAtUnixMS   int64                 `json:"observed_at_unix_ms"`
+	AppendLogCommitted bool                  `json:"append_log_committed"`
+	Delta              legacyProjectionDelta `json:"delta"`
+}
+
+type legacyProjectionResponse struct {
+	Recorded    bool   `json:"recorded"`
+	DeltaDigest string `json:"delta_digest"`
+}
+
+type sourceCollectionRequest struct {
+	CollectionID          string   `json:"collection_id"`
+	TenantID              string   `json:"tenant_id"`
+	SourceID              string   `json:"source_id"`
+	SourceRuntimeID       string   `json:"source_runtime_id"`
+	StartedAtUnixMS       int64    `json:"started_at_unix_ms"`
+	CompletedAtUnixMS     int64    `json:"completed_at_unix_ms"`
+	Status                string   `json:"status"`
+	IncompletenessReasons []string `json:"incompleteness_reasons"`
+	ExpectedFamilyIDs     []string `json:"expected_family_ids"`
+	ObservedFamilyIDs     []string `json:"observed_family_ids"`
+	PagesRead             uint32   `json:"pages_read"`
+	RecordsScanned        uint32   `json:"records_scanned"`
+	RecordsAccepted       uint32   `json:"records_accepted"`
+	RecordsRejected       uint32   `json:"records_rejected"`
+	EntitiesProjected     uint32   `json:"entities_projected"`
+	LinksProjected        uint32   `json:"links_projected"`
+}
+
+type sourceCollectionResponse struct {
+	Recorded       bool   `json:"recorded"`
+	ManifestDigest string `json:"manifest_digest"`
 }
 
 type authorityResponse struct {
@@ -113,6 +195,8 @@ func (c *ProjectionClient) project(ctx context.Context, event *cerebrov1.EventEn
 		SourceID:           strings.TrimSpace(event.GetSourceId()),
 		FamilyID:           familyID,
 		EventID:            strings.TrimSpace(event.GetId()),
+		EventKind:          strings.TrimSpace(event.GetKind()),
+		SchemaRef:          strings.TrimSpace(event.GetSchemaRef()),
 		ObservedAtUnixMS:   observedAt,
 		AppendLogCommitted: true,
 		Attributes:         cloneAttributes(event.GetAttributes()),
@@ -137,6 +221,87 @@ func (c *ProjectionClient) project(ctx context.Context, event *cerebrov1.EventEn
 		return projectEventResponse{}, fmt.Errorf("rust projection returned invalid authority %q", response.Authority)
 	}
 	return response, nil
+}
+
+func (c *ProjectionClient) recordLegacyProjection(ctx context.Context, event *cerebrov1.EventEnvelope, delta ports.SourceProjectionDelta) error {
+	familyID, err := eventFamily(event)
+	if err != nil {
+		return err
+	}
+	observedAt, err := observedAtUnixMS(event.GetOccurredAt())
+	if err != nil {
+		return err
+	}
+	runtimeID := strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID])
+	requestBody, err := json.Marshal(legacyProjectionRequest{
+		TenantID:           strings.TrimSpace(event.GetTenantId()),
+		SourceRuntimeID:    runtimeID,
+		SourceID:           strings.TrimSpace(event.GetSourceId()),
+		FamilyID:           familyID,
+		EventID:            strings.TrimSpace(event.GetId()),
+		ObservedAtUnixMS:   observedAt,
+		AppendLogCommitted: true,
+		Delta:              legacyDeltaRequest(delta),
+	})
+	if err != nil {
+		return fmt.Errorf("encode Rust legacy projection request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/projections/legacy-deltas", bytes.NewReader(requestBody))
+	if err != nil {
+		return fmt.Errorf("build Rust legacy projection request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	if err := c.auth.authorize(request, event.GetTenantId()); err != nil {
+		return err
+	}
+	var response legacyProjectionResponse
+	if err := c.doJSON(request, &response); err != nil {
+		return err
+	}
+	if !response.Recorded || strings.TrimSpace(response.DeltaDigest) == "" {
+		return errors.New("rust legacy projection receipt was not committed")
+	}
+	return nil
+}
+
+func (c *ProjectionClient) recordSourceCollection(ctx context.Context, manifest ports.SourceCollectionManifest) error {
+	requestBody, err := json.Marshal(sourceCollectionRequest{
+		CollectionID:          manifest.CollectionID,
+		TenantID:              manifest.TenantID,
+		SourceID:              manifest.SourceID,
+		SourceRuntimeID:       manifest.RuntimeID,
+		StartedAtUnixMS:       manifest.StartedAtUnixMS,
+		CompletedAtUnixMS:     manifest.CompletedAtUnixMS,
+		Status:                manifest.Status,
+		IncompletenessReasons: append([]string(nil), manifest.IncompletenessReasons...),
+		ExpectedFamilyIDs:     append([]string(nil), manifest.ExpectedFamilyIDs...),
+		ObservedFamilyIDs:     append([]string(nil), manifest.ObservedFamilyIDs...),
+		PagesRead:             manifest.PagesRead,
+		RecordsScanned:        manifest.RecordsScanned,
+		RecordsAccepted:       manifest.RecordsAccepted,
+		RecordsRejected:       manifest.RecordsRejected,
+		EntitiesProjected:     manifest.EntitiesProjected,
+		LinksProjected:        manifest.LinksProjected,
+	})
+	if err != nil {
+		return fmt.Errorf("encode Rust source collection request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/projections/collections", bytes.NewReader(requestBody))
+	if err != nil {
+		return fmt.Errorf("build Rust source collection request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	if err := c.auth.authorize(request, manifest.TenantID); err != nil {
+		return err
+	}
+	var response sourceCollectionResponse
+	if err := c.doJSON(request, &response); err != nil {
+		return err
+	}
+	if !response.Recorded || strings.TrimSpace(response.ManifestDigest) == "" {
+		return errors.New("rust source collection receipt was not committed")
+	}
+	return nil
 }
 
 func (c *ProjectionClient) authority(ctx context.Context, event *cerebrov1.EventEnvelope) (string, error) {
@@ -203,6 +368,15 @@ func NewAppendLogProjector(legacy ports.SourceProjector, rust *ProjectionClient)
 	return &AppendLogProjector{legacy: legacy, rust: rust}
 }
 
+// RecordSourceCollection retains coverage and completeness after the final
+// page of a bounded sync run is committed.
+func (p *AppendLogProjector) RecordSourceCollection(ctx context.Context, manifest ports.SourceCollectionManifest) error {
+	if p == nil || p.rust == nil {
+		return errors.New("rust projection client is required")
+	}
+	return p.rust.recordSourceCollection(ctx, manifest)
+}
+
 func (p *AppendLogProjector) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
 	response, err := p.rust.project(ctx, event)
 	if err != nil {
@@ -219,6 +393,16 @@ func (p *AppendLogProjector) Project(ctx context.Context, event *cerebrov1.Event
 	}
 	if p.legacy == nil {
 		return ports.ProjectionResult{}, nil
+	}
+	if projector, ok := p.legacy.(ports.SourceProjectorWithDelta); ok {
+		result, delta, err := projector.ProjectWithDelta(ctx, event)
+		if err != nil {
+			return ports.ProjectionResult{}, err
+		}
+		if err := p.rust.recordLegacyProjection(ctx, event, delta); err != nil {
+			return ports.ProjectionResult{}, err
+		}
+		return result, nil
 	}
 	return p.legacy.Project(ctx, event)
 }
@@ -275,4 +459,64 @@ func cloneAttributes(values map[string]string) map[string]string {
 		result[key] = value
 	}
 	return result
+}
+
+func legacyDeltaRequest(delta ports.SourceProjectionDelta) legacyProjectionDelta {
+	result := legacyProjectionDelta{
+		Entities:          make([]legacyProjectedEntity, 0, len(delta.Entities)),
+		Links:             make([]legacyProjectedLink, 0, len(delta.Links)),
+		EntityRetractions: append([]string(nil), delta.EntityRetractions...),
+		LinkRetractions:   make([]legacyProjectedLink, 0, len(delta.LinkRetractions)),
+		CleanupRequests:   make([]legacyCleanupRequest, 0, len(delta.CleanupRequests)),
+	}
+	for _, entity := range delta.Entities {
+		if entity == nil {
+			continue
+		}
+		result.Entities = append(result.Entities, legacyProjectedEntity{
+			URN:        entity.URN,
+			TenantID:   entity.TenantID,
+			SourceID:   entity.SourceID,
+			RuntimeID:  entity.RuntimeID,
+			EntityType: entity.EntityType,
+			Label:      entity.Label,
+			Attributes: cloneAttributes(entity.Attributes),
+		})
+	}
+	for _, link := range delta.Links {
+		if link != nil {
+			result.Links = append(result.Links, legacyLinkRequest(link))
+		}
+	}
+	for _, link := range delta.LinkRetractions {
+		if link != nil {
+			result.LinkRetractions = append(result.LinkRetractions, legacyLinkRequest(link))
+		}
+	}
+	for _, cleanup := range delta.CleanupRequests {
+		result.CleanupRequests = append(result.CleanupRequests, legacyCleanupRequest{
+			TenantID:     cleanup.TenantID,
+			SourceID:     cleanup.SourceID,
+			RuntimeID:    cleanup.RuntimeID,
+			FindingID:    cleanup.FindingID,
+			EntityTypes:  append([]string(nil), cleanup.EntityTypes...),
+			URNPrefixes:  append([]string(nil), cleanup.URNPrefixes...),
+			OnlyIsolated: cleanup.OnlyIsolated,
+			Limit:        cleanup.Limit,
+			DryRun:       cleanup.DryRun,
+		})
+	}
+	return result
+}
+
+func legacyLinkRequest(link *ports.ProjectedLink) legacyProjectedLink {
+	return legacyProjectedLink{
+		TenantID:   link.TenantID,
+		SourceID:   link.SourceID,
+		RuntimeID:  link.RuntimeID,
+		FromURN:    link.FromURN,
+		ToURN:      link.ToURN,
+		Relation:   link.Relation,
+		Attributes: cloneAttributes(link.Attributes),
+	}
 }

--- a/internal/sourcehttp/organizationalgraph/projection_test.go
+++ b/internal/sourcehttp/organizationalgraph/projection_test.go
@@ -23,6 +23,20 @@ type sourceProjectorStub struct {
 	err   error
 }
 
+type sourceProjectorWithDeltaStub struct {
+	calls int
+	delta ports.SourceProjectionDelta
+}
+
+func (s *sourceProjectorWithDeltaStub) Project(context.Context, *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
+	return ports.ProjectionResult{}, errors.New("Project must not be called when ProjectWithDelta is available")
+}
+
+func (s *sourceProjectorWithDeltaStub) ProjectWithDelta(context.Context, *cerebrov1.EventEnvelope) (ports.ProjectionResult, ports.SourceProjectionDelta, error) {
+	s.calls++
+	return ports.ProjectionResult{EntitiesProjected: 1}, s.delta, nil
+}
+
 func (s *sourceProjectorStub) Project(context.Context, *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -48,7 +62,11 @@ func TestAppendLogProjectorUsesExactlyOneAuthority(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 				t.Fatalf("decode request: %v", err)
 			}
-			if !request.AppendLogCommitted || request.FamilyID != "content_assets" || request.SourceRuntimeID != "box-runtime" {
+			if !request.AppendLogCommitted ||
+				request.FamilyID != "content_assets" ||
+				request.SourceRuntimeID != "box-runtime" ||
+				request.EventKind != "box.content_assets" ||
+				request.SchemaRef != "box/content_assets/v1" {
 				t.Fatalf("request = %#v", request)
 			}
 			response := projectEventResponse{Authority: authority}
@@ -97,6 +115,94 @@ func TestProjectionClientRequiresAFixedHTTPOrigin(t *testing.T) {
 		if _, err := NewProjectionClient(value, testSharedSecret, time.Second); err == nil {
 			t.Fatalf("NewProjectionClient(%q) error = nil", value)
 		}
+	}
+}
+
+func TestAppendLogProjectorRecordsExactLegacyDelta(t *testing.T) {
+	var deltaRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/projections/events":
+			_ = json.NewEncoder(w).Encode(projectEventResponse{Authority: projectionAuthorityLegacy})
+		case "/v1/projections/legacy-deltas":
+			deltaRequests++
+			var request legacyProjectionRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode legacy delta: %v", err)
+			}
+			if request.EventID != "event-1" ||
+				len(request.Delta.Entities) != 1 ||
+				request.Delta.Entities[0].URN != "urn:cerebro:tenant-a:asset:one" ||
+				request.Delta.Entities[0].RuntimeID != "box-runtime" {
+				t.Fatalf("legacy delta request = %#v", request)
+			}
+			_ = json.NewEncoder(w).Encode(legacyProjectionResponse{
+				Recorded:    true,
+				DeltaDigest: strings.Repeat("a", 64),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
+	legacy := &sourceProjectorWithDeltaStub{delta: ports.SourceProjectionDelta{
+		Entities: []*ports.ProjectedEntity{{
+			URN:        "urn:cerebro:tenant-a:asset:one",
+			TenantID:   "tenant-a",
+			SourceID:   "box",
+			RuntimeID:  "box-runtime",
+			EntityType: "box.asset",
+			Label:      "One",
+		}},
+	}}
+	result, err := NewAppendLogProjector(legacy, client).Project(context.Background(), projectionEvent())
+	if err != nil || result.EntitiesProjected != 1 || legacy.calls != 1 || deltaRequests != 1 {
+		t.Fatalf("Project() = %#v, %v legacy_calls=%d delta_requests=%d", result, err, legacy.calls, deltaRequests)
+	}
+}
+
+func TestAppendLogProjectorRecordsCollectionManifest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/projections/collections" {
+			http.NotFound(w, r)
+			return
+		}
+		var request sourceCollectionRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode collection: %v", err)
+		}
+		if request.CollectionID != "collection-1" ||
+			request.Status != "complete" ||
+			len(request.ObservedFamilyIDs) != 1 ||
+			request.ObservedFamilyIDs[0] != "content_assets" {
+			t.Fatalf("collection request = %#v", request)
+		}
+		_ = json.NewEncoder(w).Encode(sourceCollectionResponse{
+			Recorded:       true,
+			ManifestDigest: strings.Repeat("b", 64),
+		})
+	}))
+	defer server.Close()
+	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
+	err = NewAppendLogProjector(nil, client).RecordSourceCollection(context.Background(), ports.SourceCollectionManifest{
+		CollectionID:      "collection-1",
+		TenantID:          "tenant-a",
+		SourceID:          "box",
+		RuntimeID:         "box-runtime",
+		StartedAtUnixMS:   100,
+		CompletedAtUnixMS: 200,
+		Status:            "complete",
+		ObservedFamilyIDs: []string{"content_assets"},
+	})
+	if err != nil {
+		t.Fatalf("RecordSourceCollection() error = %v", err)
 	}
 }
 
@@ -157,6 +263,7 @@ func projectionEvent() *cerebrov1.EventEnvelope {
 		TenantId:   "tenant-a",
 		SourceId:   "box",
 		Kind:       "box.content_assets",
+		SchemaRef:  "box/content_assets/v1",
 		OccurredAt: timestamppb.New(time.Unix(100, 0)),
 		Payload:    []byte(`{"id":"asset-1"}`),
 		Attributes: map[string]string{

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -91,7 +91,14 @@ func (s *Service) RegisterConnectorDefinition(definition connectordefinitions.De
 }
 
 // Project applies one source event to the configured state and graph stores.
-func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (result ports.ProjectionResult, err error) {
+func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
+	result, _, err := s.ProjectWithDelta(ctx, event)
+	return result, err
+}
+
+// ProjectWithDelta applies one source event and returns the exact normalized
+// compatibility records used for the write.
+func (s *Service) ProjectWithDelta(ctx context.Context, event *cerebrov1.EventEnvelope) (result ports.ProjectionResult, delta ports.SourceProjectionDelta, err error) {
 	ctx = telemetry.EnsureTraceContext(ctx)
 	started := time.Now()
 	defer func() {
@@ -132,39 +139,46 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		})
 	}()
 	if event == nil {
-		return ports.ProjectionResult{}, fmt.Errorf("event is required")
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, fmt.Errorf("event is required")
 	}
 	if s == nil || (s.state == nil && s.graph == nil) {
-		return ports.ProjectionResult{}, nil
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, nil
 	}
 	entities, links, err := s.ProjectRecordsContext(ctx, event)
 	if err != nil {
-		return ports.ProjectionResult{}, err
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 	}
 	cleanupURNs, err := s.ProjectCleanupRecords(event)
 	if err != nil {
-		return ports.ProjectionResult{}, err
-	}
-	entitiesDeleted, err := s.deleteProjectedEntities(ctx, cleanupURNs)
-	if err != nil {
-		return ports.ProjectionResult{}, err
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 	}
 	cleanupRequests, err := s.ProjectCleanupRequests(event)
 	if err != nil {
-		return ports.ProjectionResult{}, err
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
+	}
+	retractedLinks, err := s.ProjectRetractions(event)
+	if err != nil {
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
+	}
+	delta = ports.SourceProjectionDelta{
+		Entities:          entities,
+		Links:             links,
+		EntityRetractions: cleanupURNs,
+		LinkRetractions:   retractedLinks,
+		CleanupRequests:   cleanupRequests,
+	}
+	entitiesDeleted, err := s.deleteProjectedEntities(ctx, cleanupURNs)
+	if err != nil {
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 	}
 	cleanupDeleted, err := s.cleanupProjectedEntities(ctx, cleanupRequests)
 	if err != nil {
-		return ports.ProjectionResult{}, err
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 	}
 	entitiesDeleted += cleanupDeleted.EntitiesDeleted
-	retractedLinks, err := s.ProjectRetractions(event)
-	if err != nil {
-		return ports.ProjectionResult{}, err
-	}
 	retractedLinksDeleted, err := s.deleteProjectedLinks(ctx, retractedLinks)
 	if err != nil {
-		return ports.ProjectionResult{}, err
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 	}
 	if len(retractedLinks) != 0 {
 		attrs := telemetry.Attrs(
@@ -184,29 +198,29 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	}
 	if conflictCategory, err := s.detectRuntimeEvidenceConflict(ctx, event, entities); err != nil {
 		emitRuntimeEvidenceTelemetry(ctx, event, entities, links, "conflict", conflictCategory)
-		return ports.ProjectionResult{}, err
+		return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 	}
 	for _, entity := range entities {
 		if s.state != nil {
 			if err := s.state.UpsertProjectedEntity(ctx, entity); err != nil {
-				return ports.ProjectionResult{}, err
+				return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 			}
 		}
 		if s.graph != nil {
 			if err := s.graph.UpsertProjectedEntity(ctx, entity); err != nil {
-				return ports.ProjectionResult{}, err
+				return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 			}
 		}
 	}
 	for _, link := range links {
 		if s.state != nil {
 			if err := s.state.UpsertProjectedLink(ctx, link); err != nil {
-				return ports.ProjectionResult{}, err
+				return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 			}
 		}
 		if s.graph != nil {
 			if err := s.graph.UpsertProjectedLink(ctx, link); err != nil {
-				return ports.ProjectionResult{}, err
+				return ports.ProjectionResult{}, ports.SourceProjectionDelta{}, err
 			}
 		}
 	}
@@ -216,7 +230,7 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		LinksProjected:    boundedUint32(len(links)),
 		EntitiesDeleted:   entitiesDeleted,
 		LinksDeleted:      cleanupDeleted.LinksDeleted + retractedLinksDeleted,
-	}, nil
+	}, delta, nil
 }
 
 func sourceProjectionDiagnosticContext(event *cerebrov1.EventEnvelope) observability.SourceProjectionDiagnosticContext {

--- a/internal/sourceruntime/collection_health.go
+++ b/internal/sourceruntime/collection_health.go
@@ -20,6 +20,7 @@ const (
 	CollectionIncompleteShortCircuitScopeExcluded         = "short_circuit_scope_excluded"
 	CollectionIncompleteShortCircuitResourceScopeFiltered = "short_circuit_resource_scope_filtered"
 	CollectionIncompleteShortCircuitUnknown               = "short_circuit_unknown"
+	CollectionIncompleteEventLimitReached                 = "event_limit_reached"
 )
 
 // CollectionIncompletenessReasons returns deterministic reason codes when a

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -316,6 +316,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		eventLimitReached      bool
 		shortCircuitReason     string
 		reconciliationReason   string
+		observedFamilies       = map[string]struct{}{}
 	)
 	defer func() {
 		if err != nil {
@@ -573,6 +574,11 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				eventsAppended++
 			}
 		}
+		for _, syncedEvent := range acceptedEvents {
+			if familyID := sourceEventFamilyID(syncedEvent); familyID != "" {
+				observedFamilies[familyID] = struct{}{}
+			}
+		}
 		if ledgerEnabled {
 			if err := ledger.MarkSourceRuntimePageAppended(ctx, attemptID); err != nil {
 				return nil, err
@@ -675,6 +681,37 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_runtime_watermark_lag_seconds", Value: lagSeconds})
 	}
 	emitSourceRuntimeContractProbe(ctx, runtime)
+	if recorder, ok := s.projector.(ports.SourceCollectionRecorder); ok {
+		reasons := CollectionIncompletenessReasons(runtime)
+		if eventLimitReached {
+			reasons = append(reasons, CollectionIncompleteEventLimitReached)
+		}
+		sort.Strings(reasons)
+		collectionStatus := "complete"
+		if len(reasons) != 0 {
+			collectionStatus = "incomplete"
+		}
+		if err := recorder.RecordSourceCollection(ctx, ports.SourceCollectionManifest{
+			CollectionID:          sourceRuntimeCollectionID(runtime.GetId(), started),
+			TenantID:              strings.TrimSpace(runtime.GetTenantId()),
+			SourceID:              strings.TrimSpace(runtime.GetSourceId()),
+			RuntimeID:             strings.TrimSpace(runtime.GetId()),
+			StartedAtUnixMS:       started.UTC().UnixMilli(),
+			CompletedAtUnixMS:     time.Now().UTC().UnixMilli(),
+			Status:                collectionStatus,
+			IncompletenessReasons: reasons,
+			ExpectedFamilyIDs:     expectedSourceFamilyIDs(runtime.GetSourceId(), eventContracts),
+			ObservedFamilyIDs:     sortedStringSet(observedFamilies),
+			PagesRead:             pagesRead,
+			RecordsScanned:        recordsScanned,
+			RecordsAccepted:       eventsAppended,
+			RecordsRejected:       recordsRejected,
+			EntitiesProjected:     entitiesProjected,
+			LinksProjected:        linksProjected,
+		}); err != nil {
+			return nil, fmt.Errorf("record source collection: %w", err)
+		}
+	}
 	return &cerebrov1.SyncSourceRuntimeResponse{
 		Runtime:              redactRuntime(runtime),
 		Source:               source.Spec(),
@@ -1499,6 +1536,47 @@ func sourceRuntimePageAttemptID(runtimeID string, pageNumber uint32, started tim
 	hash.Write([]byte{0})
 	hash.Write([]byte(strconv.FormatUint(uint64(pageNumber), 10)))
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func sourceRuntimeCollectionID(runtimeID string, started time.Time) string {
+	hash := sha256.New()
+	hash.Write([]byte(strings.TrimSpace(runtimeID)))
+	hash.Write([]byte{0})
+	hash.Write([]byte(started.UTC().Format(time.RFC3339Nano)))
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func sourceEventFamilyID(event *cerebrov1.EventEnvelope) string {
+	if event == nil {
+		return ""
+	}
+	sourceID := strings.TrimSpace(event.GetSourceId())
+	kind := strings.TrimSpace(event.GetKind())
+	prefix := sourceID + "."
+	if sourceID == "" || !strings.HasPrefix(kind, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(kind, prefix))
+}
+
+func expectedSourceFamilyIDs(sourceID string, contracts []sourcecdk.EventContract) []string {
+	families := map[string]struct{}{}
+	for _, contract := range contracts {
+		event := &cerebrov1.EventEnvelope{SourceId: sourceID, Kind: contract.Kind}
+		if familyID := sourceEventFamilyID(event); familyID != "" {
+			families[familyID] = struct{}{}
+		}
+	}
+	return sortedStringSet(families)
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func progressHashSensitiveConfigKey(key string) bool {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -305,6 +305,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		eventContracts         []sourcecdk.EventContract
 		contractConfigured     bool
 		runtimeLoadedForRun    bool
+		runtimeSyncCompleted   bool
 		eventsAppended         uint32
 		pagesRead              uint32
 		recordsScanned         uint32
@@ -323,7 +324,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			status = "failed"
 			spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "error_kind", Value: sourceRuntimeTelemetryErrorKind(err)})
 			telemetry.IncrementMain(ctx, "source_runtime.sync.error.count", 1)
-			if runtimeLoadedForRun {
+			if runtimeLoadedForRun && !runtimeSyncCompleted {
 				_ = s.recordRuntimeSyncFailure(context.WithoutCancel(ctx), runtime, err, contractConfigured)
 			}
 		}
@@ -661,6 +662,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		}
 		cursor = cloneCursor(pull.NextCursor)
 	}
+	runtimeSyncCompleted = true
 	status = "completed"
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "pages_read", Value: pagesRead})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "records_scanned", Value: recordsScanned})

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -210,9 +210,11 @@ func runtimeTestEvent(id string, sourceID string, kind string) *cerebrov1.EventE
 }
 
 type projector struct {
-	err    error
-	result ports.ProjectionResult
-	events []*cerebrov1.EventEnvelope
+	err         error
+	manifestErr error
+	result      ports.ProjectionResult
+	events      []*cerebrov1.EventEnvelope
+	manifests   []ports.SourceCollectionManifest
 }
 
 func (p *projector) Project(_ context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
@@ -221,6 +223,14 @@ func (p *projector) Project(_ context.Context, event *cerebrov1.EventEnvelope) (
 	}
 	p.events = append(p.events, proto.Clone(event).(*cerebrov1.EventEnvelope))
 	return p.result, nil
+}
+
+func (p *projector) RecordSourceCollection(_ context.Context, manifest ports.SourceCollectionManifest) error {
+	if p.manifestErr != nil {
+		return p.manifestErr
+	}
+	p.manifests = append(p.manifests, manifest)
+	return nil
 }
 
 type emptyPageSource struct{}
@@ -1547,6 +1557,19 @@ func TestSyncRuntimeUsesPageLedgerWhenStoreSupportsIt(t *testing.T) {
 	}
 	if len(log.events) != 1 || len(projector.events) != 1 {
 		t.Fatalf("append/project counts = %d/%d, want 1/1", len(log.events), len(projector.events))
+	}
+	if len(projector.manifests) != 1 {
+		t.Fatalf("collection manifests = %d, want 1", len(projector.manifests))
+	}
+	manifest := projector.manifests[0]
+	if manifest.Status != "complete" ||
+		manifest.RuntimeID != "writer-github" ||
+		manifest.PagesRead != 1 ||
+		manifest.RecordsScanned != 1 ||
+		manifest.RecordsAccepted != 1 ||
+		len(manifest.ObservedFamilyIDs) != 1 ||
+		manifest.ObservedFamilyIDs[0] != "pull_request" {
+		t.Fatalf("collection manifest = %#v", manifest)
 	}
 	if len(store.attempts) != 1 {
 		t.Fatalf("ledger attempts = %d, want 1", len(store.attempts))

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1583,6 +1583,44 @@ func TestSyncRuntimeUsesPageLedgerWhenStoreSupportsIt(t *testing.T) {
 	}
 }
 
+func TestSyncRuntimeManifestFailurePreservesCompletedRuntimeProgress(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				Config:   map[string]string{"token": "test"},
+			},
+		},
+	}
+	log := &appendLog{}
+	manifestFailure := errors.New("manifest unavailable")
+	projector := &projector{
+		manifestErr: manifestFailure,
+		result:      ports.ProjectionResult{EntitiesProjected: 1, LinksProjected: 2},
+	}
+	service := New(registry, store, log, projector)
+
+	_, err = service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-github"})
+	if !errors.Is(err, manifestFailure) {
+		t.Fatalf("Sync() error = %v, want %v", err, manifestFailure)
+	}
+	stored := store.runtimes["writer-github"]
+	if got := stored.GetConfig()[runtimeStatusConfigKey]; got != "completed" {
+		t.Fatalf("runtime status after manifest failure = %q, want completed", got)
+	}
+	if store.putCount != 1 {
+		t.Fatalf("PutSourceRuntime calls = %d, want only the completed page commit", store.putCount)
+	}
+	if len(log.events) != 1 || len(projector.events) != 1 {
+		t.Fatalf("append/project counts = %d/%d, want 1/1", len(log.events), len(projector.events))
+	}
+}
+
 func TestSyncRuntimeTelemetryClassifiesErrorsWithoutRawSecret(t *testing.T) {
 	secretErr := errors.New("upstream failed credential=fake-sensitive-value")
 	registry, err := sourcecdk.NewRegistry(failingSource{err: secretErr})


### PR DESCRIPTION
## Summary

- retain every valid append-log source event before family authority is evaluated
- record exact legacy projection deltas while existing source families remain Go-authoritative
- record bounded collection coverage and completeness receipts for migration accounting
- keep raw payloads in the append log; PostgreSQL receipts store metadata and content digests

## Test Plan

- `cargo test -p cerebro-source-runtime-next -p cerebro-organizational-store -p cerebro-platform --no-fail-fast`
- `cargo clippy -p cerebro-source-runtime-next -p cerebro-organizational-store -p cerebro-platform --all-targets -- -D warnings`
- `go test -p 2 ./internal/sourceruntime ./internal/sourceprojection ./internal/sourcehttp/organizationalgraph -count=1`

## Known Invariants

- JetStream remains the source-event log of record; PostgreSQL stores rebuildable receipts and current state.
- Legacy compatibility receipts do not grant Rust graph-write authority.
- A collection coverage receipt cannot become an authoritative complete collection or enable retraction.
- Source event IDs and compatibility records are idempotent and fail closed on conflicting content.
- Tenant, source, and runtime scope is validated before compatibility records are stored.
- Raw source payloads and secret material are not copied into source-event receipts.

## Droid Review Context

- Focus on the append-log acknowledgement boundary, tenant-scoped receipt writes, and the distinction between coverage evidence and projection authority.
- This changes source HTTP and graph migration state, so the hosted review should exercise the broad security and state-machine paths.