### PR TITLE
Improve responsive inventory performance

### DIFF
--- a/apps/web/scripts/grc-scale-benchmark.mjs
+++ b/apps/web/scripts/grc-scale-benchmark.mjs
@@ -10,7 +10,9 @@ import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const webRoot = path.resolve(scriptDir, "..");
+const webRoot = process.env.CEREBRO_GRC_SCALE_WEB_ROOT
+  ? path.resolve(process.env.CEREBRO_GRC_SCALE_WEB_ROOT)
+  : path.resolve(scriptDir, "..");
 const args = process.argv.slice(2);
 const argSet = new Set(args);
 const quick = argSet.has("--quick");
@@ -35,7 +37,7 @@ let workDir;
 let currentWebProcess = null;
 let currentApiServer = null;
 
-const routeSpecs = [
+const allRouteSpecs = [
   {
     route: "/vendors",
     label: "Vendors",
@@ -123,6 +125,26 @@ const routeSpecs = [
     filterText: "asset 12",
   },
   {
+    route: `/inventory/${encodeURIComponent(`urn:cerebro:${tenantID}:aws.ec2.instance:asset-0`)}`,
+    label: "Inventory Detail",
+    readySelector: "text=Relationships",
+    interactions: [
+      {
+        label: "load relationships",
+        action: async (page) => {
+          const loadButton = page.getByRole("button", { name: "Load relationships" });
+          if (await loadButton.count()) await loadButton.click();
+        },
+        readySelector: '[role="img"][aria-label*="Impact graph"]',
+      },
+      {
+        label: "open reports",
+        action: async (page) => page.locator("button").filter({ hasText: /^Reports \(/ }).click(),
+        readySelector: "text=No data quality or curation reports",
+      },
+    ],
+  },
+  {
     route: `/impact?root_urn=${encodeURIComponent(impactRootURN)}`,
     label: "Impact Map",
     readySelector: 'input[placeholder="Search graph"]',
@@ -172,6 +194,9 @@ const routeSpecs = [
     filterText: "soc 2",
   },
 ];
+const routeSpecs = argSet.has("--inventory-only")
+  ? allRouteSpecs.filter((spec) => spec.label.startsWith("Inventory"))
+  : allRouteSpecs;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const step = (message) => console.log(`\n[grc-scale] ${message}`);
@@ -260,6 +285,7 @@ async function benchmarkRoutes({ scenario, webBase }) {
     const page = await context.newPage();
     const results = [];
     for (const spec of routeSpecs) {
+      await page.evaluate(() => performance.clearResourceTimings());
       const pageErrors = [];
       page.on("pageerror", (error) => pageErrors.push(error.message));
       page.on("console", (message) => {
@@ -280,6 +306,18 @@ async function benchmarkRoutes({ scenario, webBase }) {
       }
 
       const domNodes = await page.evaluate(() => document.querySelectorAll("*").length);
+      const resourceCosts = await page.evaluate(() => {
+        const entries = performance.getEntriesByType("resource");
+        const apiEntries = entries.filter((entry) => entry.name.includes("/api/cerebro"));
+        const scriptEntries = entries.filter((entry) => entry.initiatorType === "script");
+        return {
+          api_response_ms: apiEntries.length
+            ? Math.round(Math.max(...apiEntries.map((entry) => entry.responseEnd - entry.requestStart)))
+            : null,
+          js_decoded_kb: Math.round(scriptEntries.reduce((total, entry) => total + entry.decodedBodySize, 0) / 1024),
+          js_transfer_kb: Math.round(scriptEntries.reduce((total, entry) => total + entry.transferSize, 0) / 1024),
+        };
+      });
       const filterMs = await benchmarkFilter(page, spec);
       const interactions = [];
       for (const interaction of spec.interactions ?? []) {
@@ -297,13 +335,14 @@ async function benchmarkRoutes({ scenario, webBase }) {
         label: spec.label,
         usable_ms: usableMs,
         dom_nodes: domNodes,
+        ...resourceCosts,
         filter_ms: filterMs,
         interactions,
         passed: routePasses({ usableMs, domNodes, filterMs, interactions }),
       };
       results.push(routeResult);
       console.log(
-        `[grc-scale] ${scenario.name} ${spec.label}: usable ${usableMs}ms, dom ${domNodes}, filter ${formatDurationMs(filterMs)}`,
+        `[grc-scale] ${scenario.name} ${spec.label}: usable ${usableMs}ms, api ${formatDurationMs(resourceCosts.api_response_ms)}, dom ${domNodes}, js ${resourceCosts.js_decoded_kb}KB decoded, filter ${formatDurationMs(filterMs)}`,
       );
     }
     return results;
@@ -335,7 +374,7 @@ function printSummary(results) {
     for (const route of result.routes) {
       const status = route.passed ? "pass" : result.name === "stress" && !failOnStress ? "advisory" : "fail";
       console.log(
-        `[grc-scale] ${result.name.padEnd(7)} ${status.padEnd(8)} ${route.label.padEnd(16)} usable=${route.usable_ms}ms dom=${route.dom_nodes} filter=${formatDurationMs(route.filter_ms)}`,
+        `[grc-scale] ${result.name.padEnd(7)} ${status.padEnd(8)} ${route.label.padEnd(16)} usable=${route.usable_ms}ms api=${formatDurationMs(route.api_response_ms)} dom=${route.dom_nodes} js=${route.js_decoded_kb}KB filter=${formatDurationMs(route.filter_ms)}`,
       );
       if (!route.passed && (result.name !== "stress" || failOnStress)) {
         failed.push(`${result.name} ${route.label}`);
@@ -511,6 +550,11 @@ function createMockApi({ bounded, recordCount: count, stats }) {
           generated_at: generatedAt,
         });
       }
+      if (normalizedPath === "grc/inventory/assets/detail") {
+        const requestedURN = url.searchParams.get("urn")?.trim();
+        const asset = data.inventoryAssets.find((item) => item.urn === requestedURN) ?? data.inventoryAssets[0];
+        return sendJSON(response, stats, normalizedPath, inventoryAssetDetail(asset));
+      }
       if (/^grc\/entities\/[^/]+\/impact$/.test(normalizedPath)) {
         return sendJSON(response, stats, normalizedPath, entityImpactFixture(data, url.searchParams, bounded));
       }
@@ -548,6 +592,47 @@ function makeScaleData(count) {
   const identityOrganizations = Array.from({ length: count }, (_, index) => makeIdentityOrganization(index));
   const identityUsers = Array.from({ length: count }, (_, index) => makeIdentityUser(index));
   return { vendors, vendorDiscoveries, evidence, findings, policies, documents, riskRegister, governanceGaps, workQueue, documentWorkQueue, inventoryAssets, connectors, connectorRuntimes, connectorDefinitions, identityOrganizations, identityUsers };
+}
+
+function inventoryAssetDetail(asset) {
+  const neighbors = Array.from({ length: Math.min(recordCount, 120) }, (_, index) => {
+    const related = makeInventoryAsset(index + 1);
+    return {
+      urn: related.urn,
+      entity_type: related.entity_type,
+      label: related.label,
+      attributes: related.attributes,
+    };
+  });
+  return {
+    asset,
+    graph: {
+      root: { urn: asset.urn, entity_type: asset.entity_type, label: asset.label, attributes: asset.attributes },
+      neighbors,
+      relations: neighbors.map((neighbor, index) => ({
+        from_urn: asset.urn,
+        relation: index % 2 === 0 ? "depends_on" : "connected_to",
+        to_urn: neighbor.urn,
+      })),
+    },
+    findings: [],
+    evidence: [],
+    controls: [],
+    tests: [
+      { name: "Owner attestation", owner: asset.attributes?.owner || "Platform", status: "passing", due_at: isoDay(30), control_id: "CC6.1", framework: "SOC 2" },
+    ],
+    vulnerabilities: [
+      { id: "scale-vulnerability", title: "Scale benchmark vulnerability", severity: "medium", status: "open", source_id: asset.source_id },
+    ],
+    asset_reports: [],
+    timeline: [
+      { at: isoDay(-1), kind: "evidence", title: "Asset observed", description: "Deterministic scale benchmark event.", status: "observed" },
+    ],
+    actions: [
+      { title: "Review owner", description: "Confirm the current accountability owner.", priority: "medium", href: "/inventory" },
+    ],
+    generated_at: generatedAt,
+  };
 }
 
 function makeIdentityOrganization(index) {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -218,6 +218,79 @@ body {
   .data-table tbody tr:hover {
     background: var(--surface-hover);
   }
+
+  @media (max-width: 767px) {
+    .inventory-results {
+      display: block;
+      min-width: 0;
+      width: 100%;
+    }
+
+    .inventory-results thead {
+      display: none;
+    }
+
+    .inventory-results tbody {
+      display: grid;
+      gap: 0.75rem;
+      padding: 0.75rem;
+    }
+
+    .inventory-results tbody tr {
+      contain: layout paint style;
+      content-visibility: auto;
+      contain-intrinsic-size: auto 23rem;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      overflow: hidden;
+      position: relative;
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      background: var(--surface);
+    }
+
+    .inventory-results tbody tr:hover {
+      background: var(--surface);
+    }
+
+    .inventory-results td {
+      border: 0;
+      display: block;
+      min-width: 0;
+      padding: 0.75rem;
+      vertical-align: top;
+    }
+
+    .inventory-results td[data-label]::before {
+      color: var(--text-muted);
+      content: attr(data-label);
+      display: block;
+      font-size: 0.625rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      margin-bottom: 0.35rem;
+      text-transform: uppercase;
+    }
+
+    .inventory-results .inventory-select-cell {
+      padding: 1rem;
+      position: absolute;
+      right: 0;
+      top: 0;
+      z-index: 1;
+    }
+
+    .inventory-results .inventory-record-cell {
+      border-bottom: 1px solid var(--border);
+      grid-column: 1 / -1;
+      padding-right: 3.25rem;
+    }
+
+    .inventory-results .inventory-actions-cell {
+      border-top: 1px solid var(--border);
+      grid-column: 1 / -1;
+    }
+  }
 }
 
 .agent-surface {

--- a/apps/web/src/app/inventory/[urn]/page.tsx
+++ b/apps/web/src/app/inventory/[urn]/page.tsx
@@ -42,8 +42,10 @@ function TabButton({ label, active, onClick }: { label: string; active: boolean;
   return (
     <button
       type="button"
+      role="tab"
+      aria-selected={active}
       onClick={onClick}
-      className={`border-b-2 px-4 py-2 text-[13px] font-medium transition ${
+      className={`shrink-0 border-b-2 px-4 py-2 text-[13px] font-medium transition ${
         active ? "border-[var(--primary)] text-[var(--primary)]" : "border-transparent text-[var(--text-muted)] hover:border-[color:var(--border-strong)] hover:text-[var(--text-primary)]"
       }`}
     >
@@ -107,8 +109,8 @@ function OverviewPane({ data, setTab }: { data: GRCInventoryAssetDetail; setTab:
     scopeState(data.asset) === "out_of_scope" ? "is scoped out of compliance review" : "is in scope",
   ].join(", ");
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-      <div className="space-y-6">
+    <div className="grid min-w-0 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <div className="min-w-0 space-y-6">
         <section className="surface-panel overflow-hidden">
           <div className="p-5">
             <div className="flex flex-wrap items-center justify-between gap-3">
@@ -176,7 +178,7 @@ function OverviewPane({ data, setTab }: { data: GRCInventoryAssetDetail; setTab:
         </Panel>
 
         <Panel title="Relationships" action={<Link href={`/explore?root_urn=${encodeURIComponent(data.asset.urn)}`} className="text-[12px] font-medium text-indigo-600 hover:text-indigo-800">Open graph</Link>}>
-          <GraphViewer graph={data.graph} />
+          <RelationshipGraph graph={data.graph} />
         </Panel>
       </div>
       <aside>
@@ -197,6 +199,20 @@ function OverviewPane({ data, setTab }: { data: GRCInventoryAssetDetail; setTab:
           <DetailRow label="Source" value={data.asset.source_id || "Not set"} />
         </dl>
       </aside>
+    </div>
+  );
+}
+
+function RelationshipGraph({ graph }: { graph: GRCInventoryAssetDetail["graph"] }) {
+  const [open, setOpen] = useState(false);
+  if (open) return <GraphViewer graph={graph} />;
+  return (
+    <div className="rounded-lg border border-dashed border-[color:var(--border)] bg-[var(--surface-muted)] px-4 py-8 text-center">
+      <p className="text-[13px] font-medium text-[var(--text-primary)]">Relationships are not loaded</p>
+      <p className="mt-1 text-[12px] text-[var(--text-muted)]">Load relationships to inspect neighboring records.</p>
+      <button type="button" onClick={() => setOpen(true)} className="primary-button mt-4 px-3 py-1.5 text-[13px]">
+        Load relationships
+      </button>
     </div>
   );
 }
@@ -505,13 +521,15 @@ export default function InventoryAssetPage() {
             <span>Last refreshed: {displayDate(attr(asset, "updated_at", "last_seen_at", "last_synced_at"))}</span>
             <span>{scopeCopy(scopeState(data.asset))}</span>
           </div>
-          <div className="flex items-center gap-4 border-b border-[color:var(--border)]">
-            <TabButton label="Overview" active={tab === "overview"} onClick={() => setTab("overview")} />
-            <TabButton label="Vulnerabilities" active={tab === "vulnerabilities"} onClick={() => setTab("vulnerabilities")} />
-            <TabButton label={`Tests (${data.tests.length})`} active={tab === "tests"} onClick={() => setTab("tests")} />
-            <TabButton label="Framework scope" active={tab === "framework"} onClick={() => setTab("framework")} />
-            <TabButton label={`Reports (${data.asset_reports?.length ?? 0})`} active={tab === "reports"} onClick={() => setTab("reports")} />
-            <TabButton label={`Timeline (${data.timeline?.length ?? 0})`} active={tab === "timeline"} onClick={() => setTab("timeline")} />
+          <div className="overflow-x-auto border-b border-[color:var(--border)]" role="tablist" aria-label="Asset detail sections">
+            <div className="flex min-w-max items-center gap-1">
+              <TabButton label="Overview" active={tab === "overview"} onClick={() => setTab("overview")} />
+              <TabButton label="Vulnerabilities" active={tab === "vulnerabilities"} onClick={() => setTab("vulnerabilities")} />
+              <TabButton label={`Tests (${data.tests.length})`} active={tab === "tests"} onClick={() => setTab("tests")} />
+              <TabButton label="Framework scope" active={tab === "framework"} onClick={() => setTab("framework")} />
+              <TabButton label={`Reports (${data.asset_reports?.length ?? 0})`} active={tab === "reports"} onClick={() => setTab("reports")} />
+              <TabButton label={`Timeline (${data.timeline?.length ?? 0})`} active={tab === "timeline"} onClick={() => setTab("timeline")} />
+            </div>
           </div>
           {tab === "overview" && <OverviewPane data={data} setTab={setTab} />}
           {tab === "vulnerabilities" && <VulnerabilitiesPane vulnerabilities={data.vulnerabilities} />}

--- a/apps/web/src/app/inventory/page.tsx
+++ b/apps/web/src/app/inventory/page.tsx
@@ -958,8 +958,25 @@ export default function InventoryPage() {
             <div className="grid gap-6 min-[1800px]:grid-cols-[minmax(0,1fr)_340px]">
               <main className="space-y-4">
                 {!assetsQuery.loading && !assetsQuery.error && (
-                  <div className="surface-panel overflow-x-auto">
-                    <table className="data-table min-w-[1180px]">
+                  <div className="surface-panel overflow-hidden">
+                    <div className="flex items-center justify-between border-b border-[color:var(--border)] px-4 py-3 md:hidden">
+                      <span className="text-[12px] font-semibold text-[var(--text-secondary)]">
+                        {visibleAssets.length.toLocaleString()} records on this page
+                      </span>
+                      <label className="flex items-center gap-2 text-[12px] text-[var(--text-muted)]">
+                        <input
+                          type="checkbox"
+                          aria-label="Select current page assets"
+                          checked={allVisibleSelected}
+                          disabled={selectableVisibleAssets.length === 0}
+                          onChange={toggleAllVisible}
+                          className="h-4 w-4 rounded border-[color:var(--border)]"
+                        />
+                        Select page
+                      </label>
+                    </div>
+                    <div className="overflow-x-auto">
+                    <table className="data-table inventory-results min-w-0 md:min-w-[1180px]" data-testid="inventory-results">
                       <thead>
                         <tr>
                           <th className="w-10">
@@ -984,7 +1001,7 @@ export default function InventoryPage() {
                       <tbody>
                         {visibleAssets.map((asset) => (
                           <tr key={asset.urn} className={selectedAssetURNSet.has(asset.urn) ? "bg-[var(--surface-hover)]" : ""}>
-                            <td>
+                            <td className="inventory-select-cell">
                               <input
                                 type="checkbox"
                                 aria-label={`Select ${asset.label || shortEntity(asset.urn)}`}
@@ -994,7 +1011,7 @@ export default function InventoryPage() {
                                 className="h-4 w-4 rounded border-[color:var(--border)]"
                               />
                             </td>
-                            <td>
+                            <td className="inventory-record-cell">
                               <div className="flex items-center gap-3">
                                 <SourceMark asset={asset} />
                                 <div className="min-w-0">
@@ -1004,17 +1021,17 @@ export default function InventoryPage() {
                                 </div>
                               </div>
                             </td>
-                            <td>
+                            <td data-label="Review">
                               <div className="space-y-1">
                                 <ReviewBadge asset={asset} />
                                 <div className="max-w-[190px] text-[11px] leading-4 text-[var(--text-muted)]">{inventoryReviewDetail(asset)}</div>
                               </div>
                             </td>
-                            <td>
+                            <td data-label="Risk">
                               <RiskBadge score={asset.risk_score} level={asset.risk_level} />
                               {asset.risk_reasons && asset.risk_reasons.length > 0 && <div className="mt-1 max-w-[180px] text-[11px] leading-4 text-[var(--text-muted)]">{asset.risk_reasons.slice(0, 2).map(humanize).join(", ")}</div>}
                             </td>
-                            <td>
+                            <td data-label="Accountability">
                               <div className="max-w-[170px] truncate font-medium text-[var(--text-primary)]">{ownerDisplay(asset)}</div>
                               {isReviewableAsset(asset) && inventoryOwnerLabel(asset) === "Unassigned" && (
                                 <div className="mt-1 text-[11px] text-[var(--text-muted)]">
@@ -1025,7 +1042,7 @@ export default function InventoryPage() {
                                 <button type="button" onClick={() => openAccountabilityModal([asset], "known")} className="mt-1 text-[11px] font-semibold text-[var(--primary)] hover:text-[var(--primary-hover)]">Edit owner</button>
                               )}
                             </td>
-                            <td>
+                            <td data-label="Framework scope">
                               <div className="space-y-1">
                                 <Badge value={inventoryScopeCopy(inventoryScopeState(asset))} />
                                 {asset.scope_reason && <div className="max-w-[170px] truncate text-[11px] text-[var(--text-muted)]">{asset.scope_reason}</div>}
@@ -1037,8 +1054,8 @@ export default function InventoryPage() {
                                 ) : null}
                               </div>
                             </td>
-                            <td>{regionLabel(asset)}</td>
-                            <td>
+                            <td data-label="Account / region">{regionLabel(asset)}</td>
+                            <td className="inventory-actions-cell" data-label="Actions">
                               <div className="flex flex-wrap items-center gap-2">
                                 {isReviewableAsset(asset) && (
                                   <button type="button" onClick={() => void updateScope(asset, inventoryScopeState(asset) === "out_of_scope" ? "in_scope" : "out_of_scope")} disabled={scopeSavingURN === asset.urn} className="secondary-button px-2.5 py-1 text-[12px] disabled:opacity-50">
@@ -1055,6 +1072,7 @@ export default function InventoryPage() {
                         ))}
                       </tbody>
                     </table>
+                    </div>
                     {assets.length === 0 && <div className="flex items-center justify-center p-8 text-[13px] text-[var(--text-muted)]">No {recordNoun} match this view.</div>}
                     {assets.length > 0 && totalAssetPages > 1 && (
                       <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--border)] px-4 py-3 text-[12px] text-[var(--text-muted)]">

--- a/apps/web/src/components/grc/GraphViewer.tsx
+++ b/apps/web/src/components/grc/GraphViewer.tsx
@@ -706,7 +706,7 @@ export default function GraphViewer({
           </div>
           <div
             ref={containerRef}
-            className="h-[640px] min-w-[640px] bg-[var(--surface)]"
+            className="h-[480px] w-full min-w-0 bg-[var(--surface)] md:h-[640px]"
             role="img"
             aria-label={`Impact graph with ${view.nodes.length} nodes and ${view.edges.length} edges`}
           />

--- a/apps/web/src/lib/cerebro-fixtures.test.ts
+++ b/apps/web/src/lib/cerebro-fixtures.test.ts
@@ -86,6 +86,18 @@ describe("cerebro fixture proxy responses", () => {
     expect(payload.findings).toMatchObject([{ id: "demo-finding-high" }]);
   });
 
+  it("uses operator-readable plural labels for inventory categories", () => {
+    withFixtureMode();
+    const response = cerebroFixtureResponseFor({ method: "GET", path: "grc/inventory/categories" });
+    const payload = parseFixture(response!) as { categories: Array<{ id: string; label: string }> };
+
+    expect(payload.categories).toContainEqual(expect.objectContaining({
+      id: "repository",
+      label: "Repositories",
+    }));
+    expect(payload.categories.some((category) => category.label.includes("Repositorys"))).toBe(false);
+  });
+
   it("returns and filters vendor fixtures", () => {
     withFixtureMode();
     const response = cerebroFixtureResponseFor({ method: "GET", path: "grc/vendors" });

--- a/apps/web/src/lib/cerebro-fixtures.ts
+++ b/apps/web/src/lib/cerebro-fixtures.ts
@@ -1675,8 +1675,18 @@ const unassignedAssetCount = (items: typeof assets) => items.filter((asset) => a
 
 const inventoryCategoryID = (entityType: string) => entityType.replace(/\./g, "-");
 
-const inventoryCategoryLabel = (entityType: string) =>
-  `${entityType.replace(/[._-]/g, " ").split(" ").filter(Boolean).map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(" ")}s`;
+const pluralizeInventoryNoun = (noun: string) => {
+  if (/[^aeiou]y$/i.test(noun)) return `${noun.slice(0, -1)}ies`;
+  if (/(?:s|x|z|ch|sh)$/i.test(noun)) return `${noun}es`;
+  return `${noun}s`;
+};
+
+const inventoryCategoryLabel = (entityType: string) => {
+  const words = entityType.replace(/[._-]/g, " ").split(" ").filter(Boolean);
+  const titleWords = words.map((part) => part.charAt(0).toUpperCase() + part.slice(1));
+  const noun = titleWords.pop();
+  return noun ? [...titleWords, pluralizeInventoryNoun(noun)].join(" ") : "Records";
+};
 
 const inventorySummary = (items = assets) => ({
   total_assets: items.length,

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -134,6 +134,14 @@ describe("product UI contract", () => {
     expect(inventorySource).toContain("AppliedFilterChips");
     expect(inventorySource).toContain("metricValueForState");
     expect(inventorySource).toContain("metricDetailForState");
+    expect(inventorySource).toContain('data-testid="inventory-results"');
+    expect(inventorySource).toContain('data-label="Accountability"');
+    expect(inventorySource).toContain("Select page");
+
+    const inventoryDetailSource = readProjectFile("src/app/inventory/[urn]/page.tsx");
+    expect(inventoryDetailSource).toContain('role="tablist"');
+    expect(inventoryDetailSource).toContain("min-w-max");
+    expect(inventoryDetailSource).toContain("Load relationships");
 
     const reportsSource = readProjectFile("src/app/reports/page.tsx");
     expect(reportsSource).toContain("AppliedFilterChips");


### PR DESCRIPTION
## What changed

- Present inventory rows as compact, action-complete cards on narrow screens while preserving the dense desktop table.
- Keep asset detail tabs horizontally reachable and contain the relationship graph within the available width.
- Load the relationship graph only when requested.
- Correct inventory category pluralization and extend the deterministic web scale benchmark with inventory detail, API response, JavaScript, DOM, and interaction measurements.

## Why

Inventory and asset detail must remain usable on narrow screens without clipping, hidden tabs, or horizontal page overflow. Deferring the relationship graph also keeps the initial asset detail render focused on the record state and actions.

## Validation

- Web lint
- Full web test suite on Node 22
- Production web build and standalone packaging
- Deterministic GRC scale benchmark
- Browser QA at desktop and 390 px, including inventory filtering, record actions, asset detail tabs, relationship loading, and finding evidence/timeline

## Merge coordination

Land this change before the related lifecycle web follow-up because both update the scale benchmark.
