### PR TITLE
Bridge lifecycle findings into durable GRC records

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5566,6 +5566,39 @@ paths:
             text/markdown:
               schema:
                 type: string
+  /grc/findings/{findingID}/security-lifecycle/reconcile:
+    post:
+      operationId: reconcileSecurityLifecycleFinding
+      summary: Reconcile one lifecycle finding against current source evidence
+      tags:
+        - GRC
+      parameters:
+        - $ref: '#/components/parameters/findingID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - tenant_id
+              properties:
+                tenant_id:
+                  type: string
+                  description: Authorized tenant that owns the lifecycle finding.
+      responses:
+        '200':
+          description: Durable finding state after an open observation or verified closure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityLifecycleFindingReconcileResponse'
+        '202':
+          description: Verification is pending because current provenance or source coverage is incomplete.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityLifecycleFindingReconcileResponse'
   /grc/findings/{findingID}/audit-preview:
     get:
       operationId: previewGRCAuditPacket
@@ -9712,6 +9745,25 @@ components:
           items:
             type: object
             additionalProperties: true
+    SecurityLifecycleFindingReconcileResponse:
+      type: object
+      required: [finding_id, status, verification, audit_preview_url]
+      properties:
+        finding_id:
+          type: string
+          description: Stable lifecycle finding URN.
+        status:
+          type: string
+          enum: [open, resolved]
+        verification:
+          type: string
+          description: Current reconciliation outcome.
+        reason:
+          type: string
+          description: Operator action or evidence condition when verification is pending.
+        audit_preview_url:
+          type: string
+          description: Live audit-preview path for this exact durable finding.
     GRCFindingsResponse:
       type: object
       required: [findings, meta, generated_at]

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -201,6 +201,7 @@ fn bounded_operation(path: &str) -> &'static str {
         "/v1/projections/events" => "project_event",
         "/v1/projections/legacy-deltas" => "record_legacy_projection",
         "/v1/projections/collections" => "record_source_collection",
+        _ if path.starts_with("/v1/projections/collections/") => "get_source_collection",
         "/v1/projections/authority" => "projection_authority",
         _ if path.starts_with("/v1/entities/") => "get_entity",
         _ if path.starts_with("/v1/assertions/") => "explain_assertion",
@@ -460,6 +461,24 @@ impl ProjectionRuntime {
         })
     }
 
+    async fn source_collection(
+        &self,
+        tenant_id: &TenantId,
+        source_runtime_id: &SourceRuntimeId,
+        collection_id: &CollectionId,
+    ) -> Result<Option<SourceCollectionRequest>, StoreError> {
+        self.authority
+            .source_collection_manifest(
+                tenant_id.as_str(),
+                source_runtime_id.as_str(),
+                collection_id.as_str(),
+            )
+            .await?
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(StoreError::from)
+    }
+
     async fn project_security_lifecycle(
         &self,
         event: CommittedSourceEvent,
@@ -538,6 +557,12 @@ struct ErrorResponse {
 #[derive(Deserialize)]
 struct TenantQuery {
     tenant_id: String,
+}
+
+#[derive(Deserialize)]
+struct SourceCollectionQuery {
+    tenant_id: String,
+    source_runtime_id: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1064,6 +1089,10 @@ fn router_with_backend(
             "/v1/projections/collections",
             post(record_source_collection),
         )
+        .route(
+            "/v1/projections/collections/{collection_id}",
+            get(get_source_collection),
+        )
         .route("/v1/projections/authority", get(projection_authority))
         .route_layer(middleware::from_fn_with_state(
             tenant_auth,
@@ -1229,6 +1258,37 @@ async fn record_source_collection(
         .await
         .map(Json)
         .map_err(store_error)
+}
+
+async fn get_source_collection(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Path(collection_id): Path<String>,
+    Query(query): Query<SourceCollectionQuery>,
+) -> Result<Json<SourceCollectionRequest>, (StatusCode, Json<ErrorResponse>)> {
+    let runtime = state.projection.ok_or_else(|| {
+        service_unavailable(
+            "projection_runtime_unavailable",
+            "The organizational projection runtime is not configured.",
+        )
+    })?;
+    let tenant_id = authorized_tenant(&authenticated, query.tenant_id)?;
+    let source_runtime_id = SourceRuntimeId::parse(query.source_runtime_id).map_err(model_error)?;
+    let collection_id = CollectionId::parse(collection_id).map_err(model_error)?;
+    runtime
+        .source_collection(&tenant_id, &source_runtime_id, &collection_id)
+        .await
+        .map_err(store_error)?
+        .map(Json)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    code: "source_collection_not_found",
+                    message: "The source collection receipt was not found.".to_owned(),
+                }),
+            )
+        })
 }
 
 fn validate_source_collection(

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -262,6 +262,8 @@ BEGIN
 END $$;
 "#;
 
+const SOURCE_COLLECTION_MANIFEST_QUERY: &str = "SELECT manifest_json FROM organizational_source_collection_receipts WHERE tenant_id = $1 AND source_runtime_id = $2 AND collection_id = $3";
+
 const IDENTITY_CLAIM_REPLACEMENT_QUERY: &str = r#"
 SELECT assertion_id
 FROM organizational_assertions
@@ -702,6 +704,25 @@ impl PostgresLedger {
             collection_id: collection_id.to_owned(),
             manifest_digest: manifest_digest.to_owned(),
         })
+    }
+
+    pub async fn source_collection_manifest(
+        &self,
+        tenant_id: &str,
+        source_runtime_id: &str,
+        collection_id: &str,
+    ) -> Result<Option<Value>, StoreError> {
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id).await?;
+        let row = transaction
+            .query_opt(
+                SOURCE_COLLECTION_MANIFEST_QUERY,
+                &[&tenant_id, &source_runtime_id, &collection_id],
+            )
+            .await?;
+        transaction.commit().await?;
+        Ok(row.map(|row| row.get("manifest_json")))
     }
 
     pub async fn record_parity(&self, receipt: &ParityReceipt) -> Result<(), StoreError> {
@@ -1821,6 +1842,20 @@ mod tests {
             assert!(
                 IDENTITY_CLAIM_REPLACEMENT_QUERY.contains(required),
                 "claim replacement query missing {required}"
+            );
+        }
+    }
+
+    #[test]
+    fn source_collection_manifest_lookup_requires_exact_provenance_tuple() {
+        for required in [
+            "tenant_id = $1",
+            "source_runtime_id = $2",
+            "collection_id = $3",
+        ] {
+            assert!(
+                SOURCE_COLLECTION_MANIFEST_QUERY.contains(required),
+                "source collection lookup omitted {required}"
             );
         }
     }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -77,7 +77,8 @@ type Dependencies struct {
 	StateStore                  ports.StateStore
 	GraphStore                  ports.GraphStore
 	GraphQueries                ports.GraphQueryStore
-	SecurityLifecycleQueries    *organizationalgraph.QueryStore
+	SecurityLifecycleQueries    securityLifecycleQueryReader
+	SourceCollectionReceipts    ports.SourceCollectionReader
 	OrganizationalProjector     *organizationalgraph.ProjectionClient
 	GraphAgentLLM               graphagent.LLMClient
 	QueryCache                  querycache.Cache

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -157,6 +157,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/grc/policy-lifecycle/uploads", Scope: scopeGRCPolicyLifecycleWrite, Static: true},
 	{Method: http.MethodPost, Prefix: "/grc/policy-lifecycle/uploads/", Suffix: "/replay", Scope: scopeGRCPolicyLifecycleWrite},
 	{Method: http.MethodPost, Exact: "/grc/findings/triage", Scope: scopeFindingLifecycleWrite, Static: true},
+	{Method: http.MethodPost, Prefix: "/grc/findings/", Suffix: "/security-lifecycle/reconcile", Scope: scopeFindingLifecycleWrite},
 	{Method: http.MethodPost, Exact: "/grc/inventory/resource-scope", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/accountability", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/asset-reports", Scope: scopeGRCInventoryWrite, Static: true},

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -101,6 +101,7 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 			return fail(fmt.Errorf("open Rust organizational graph projection: %w", err))
 		}
 		deps.OrganizationalProjector = projectionClient
+		deps.SourceCollectionReceipts = projectionClient
 	}
 	if readBaseURL != "" {
 		var compatibility ports.GraphQueryStore

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -216,6 +216,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/remediation-plans/{planID}", routeSurfacePlatformHTTP, app.handleGetComplianceRemediationPlan)
 	registerHTTPRoute(mux, "POST /grc/remediation-plans/{planID}/commands", routeSurfacePlatformHTTP, app.handleComplianceRemediationCommand)
 	registerHTTPRoute(mux, "POST /grc/findings/triage", routeSurfacePlatformHTTP, app.handleUpdateGRCFindingDispositions)
+	registerHTTPRoute(mux, "POST /grc/findings/{findingID}/security-lifecycle/reconcile", routeSurfacePlatformHTTP, app.handleReconcileSecurityLifecycleFinding)
 	registerHTTPRoute(mux, "GET /grc/findings/export", routeSurfacePlatformHTTP, app.handleGRCFindingsExport)
 	registerHTTPRoute(mux, "GET /grc/controls", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("controls", time.Minute, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCControls))
 	registerHTTPRoute(mux, "GET /grc/controls/export", routeSurfacePlatformHTTP, app.handleGRCControlsExport)

--- a/internal/bootstrap/security_lifecycle.go
+++ b/internal/bootstrap/security_lifecycle.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -11,6 +12,11 @@ import (
 	"github.com/writer/cerebro/internal/securitylifecyclehttp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+type securityLifecycleQueryReader interface {
+	ListSecurityLifecycle(context.Context, *cerebrov1.SecurityLifecycleQuery) (*cerebrov1.SecurityLifecycleQueryResult, error)
+	ResolveSecurityLifecycleFinding(context.Context, string, string) (*cerebrov1.ResolveSecurityLifecycleFindingResponse, error)
+}
 
 func (a *App) handleListSecurityLifecycle(w http.ResponseWriter, r *http.Request) {
 	if a.deps.SecurityLifecycleQueries == nil {

--- a/internal/bootstrap/security_lifecycle_findings.go
+++ b/internal/bootstrap/security_lifecycle_findings.go
@@ -1,0 +1,366 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/sourcehttp/organizationalgraph"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const maxSecurityLifecycleReconcileBodyBytes = 4 << 10
+
+type securityLifecycleReconcileRequest struct {
+	TenantID string `json:"tenant_id"`
+}
+
+type securityLifecycleReconcileResponse struct {
+	FindingID       string `json:"finding_id"`
+	Status          string `json:"status"`
+	Verification    string `json:"verification"`
+	Reason          string `json:"reason,omitempty"`
+	AuditPreviewURL string `json:"audit_preview_url"`
+}
+
+func (a *App) handleReconcileSecurityLifecycleFinding(w http.ResponseWriter, r *http.Request) {
+	if a.deps.SecurityLifecycleQueries == nil {
+		http.Error(w, "Security lifecycle finding reads are unavailable.", http.StatusServiceUnavailable)
+		return
+	}
+	var request securityLifecycleReconcileRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxSecurityLifecycleReconcileBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeGRCError(w, fmt.Errorf("%w: decode security lifecycle reconcile request: %w", errInvalidHTTPRequest, err))
+		return
+	}
+	tenantID, err := effectiveTenantFilter(r.Context(), request.TenantID)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	findingID := strings.TrimSpace(r.PathValue("findingID"))
+	if findingID == "" {
+		writeGRCError(w, fmt.Errorf("%w: finding id is required", errInvalidHTTPRequest))
+		return
+	}
+
+	resolved, err := a.deps.SecurityLifecycleQueries.ResolveSecurityLifecycleFinding(r.Context(), tenantID, findingID)
+	if err == nil {
+		observation, mapErr := lifecycleOpenObservation(tenantID, findingID, resolved)
+		if mapErr != nil {
+			writeGRCError(w, mapErr)
+			return
+		}
+		finding, recordErr := a.findingService().RecordSecurityLifecycleFinding(r.Context(), observation)
+		if recordErr != nil {
+			writeGRCError(w, recordErr)
+			return
+		}
+		verification := "source_collection_linked"
+		reason := ""
+		if observation.SourceCollectionID == "" {
+			verification = "provenance_pending"
+			reason = "The current lifecycle row does not identify its final source collection. A later source sync is required before verified closure."
+		}
+		a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeFindings, grcCacheScopeEvidence)
+		writeJSON(w, http.StatusOK, securityLifecycleReconcileResponse{
+			FindingID:       finding.ID,
+			Status:          finding.Status,
+			Verification:    verification,
+			Reason:          reason,
+			AuditPreviewURL: lifecycleAuditPreviewURL(finding.ID),
+		})
+		return
+	}
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		writeSecurityLifecycleDependencyError(w, err)
+		return
+	}
+
+	response, status, reconcileErr := a.reconcileClosedSecurityLifecycleFinding(r, tenantID, findingID)
+	if reconcileErr != nil {
+		if status != 0 {
+			http.Error(w, "Security lifecycle verification dependency failed.", status)
+			return
+		}
+		writeGRCError(w, reconcileErr)
+		return
+	}
+	writeJSON(w, status, response)
+}
+
+func (a *App) reconcileClosedSecurityLifecycleFinding(r *http.Request, tenantID, findingID string) (securityLifecycleReconcileResponse, int, error) {
+	current, err := a.findingService().GetFinding(r.Context(), findingID)
+	if err != nil {
+		return securityLifecycleReconcileResponse{}, 0, err
+	}
+	if current.TenantID != tenantID {
+		return securityLifecycleReconcileResponse{}, 0, errTenantForbidden
+	}
+	locator, ok := findings.SecurityLifecycleLocatorForFinding(current)
+	if !ok {
+		return securityLifecycleReconcileResponse{}, 0, fmt.Errorf("%w: finding is not a projected security lifecycle finding", errInvalidHTTPRequest)
+	}
+	subjectKind, ok := lifecycleSubjectKind(locator.SubjectKind)
+	if !ok {
+		return lifecyclePendingResponse(findingID, "subject_locator_unavailable", "The stored lifecycle finding does not contain a recognized subject kind. Run a fresh source sync."), http.StatusAccepted, nil
+	}
+	result, err := a.deps.SecurityLifecycleQueries.ListSecurityLifecycle(r.Context(), &cerebrov1.SecurityLifecycleQuery{
+		TenantId: tenantID,
+		Limit:    2,
+		SubjectLocator: &cerebrov1.SecurityLifecycleSubjectLocator{
+			SubjectKind:   subjectKind,
+			AuthorityId:   locator.AuthorityID,
+			StableLocator: locator.StableLocator,
+		},
+	})
+	if err != nil {
+		return securityLifecycleReconcileResponse{}, lifecycleDependencyStatus(err), fmt.Errorf("read exact lifecycle subject: %w", err)
+	}
+	if len(result.GetRecords()) != 1 {
+		return lifecyclePendingResponse(findingID, "exact_observation_unavailable", "The exact lifecycle subject does not have one current observation. Run a fresh source sync before retrying verification."), http.StatusAccepted, nil
+	}
+	record := result.GetRecords()[0]
+	observation := record.GetObservation()
+	if observation == nil ||
+		observation.GetSubjectRef().GetId() != locator.SubjectURN ||
+		observation.GetAuthorityId() != locator.AuthorityID ||
+		observation.GetStableLocator() != locator.StableLocator ||
+		observation.GetSubjectKind() != subjectKind {
+		return lifecyclePendingResponse(findingID, "subject_identity_mismatch", "The current lifecycle observation does not match the finding subject. The finding remains open."), http.StatusAccepted, nil
+	}
+	if strings.TrimSpace(record.GetSourceRuntimeId()) == "" || strings.TrimSpace(record.GetSourceCollectionId()) == "" {
+		return lifecyclePendingResponse(findingID, "provenance_pending", "The current lifecycle row does not identify its source runtime and final collection. The finding remains open."), http.StatusAccepted, nil
+	}
+	if record.GetSourceRuntimeId() != locator.SourceRuntimeID {
+		return lifecyclePendingResponse(findingID, "runtime_mismatch", "The current lifecycle observation came from a different source runtime. The finding remains open."), http.StatusAccepted, nil
+	}
+	evaluation, ok := lifecyclePolicyEvaluation(record, locator.PolicyID)
+	if !ok {
+		return lifecyclePendingResponse(findingID, "policy_observation_unavailable", "The current lifecycle row does not contain the finding policy evaluation. The finding remains open."), http.StatusAccepted, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(evaluation.GetState()), "compliant") {
+		return lifecyclePendingResponse(findingID, "policy_still_matches", "The current lifecycle policy is not compliant. Provider execution alone does not close this finding."), http.StatusAccepted, nil
+	}
+	metadata := result.GetMetadata()
+	coverage := metadata.GetCoverage()
+	freshness := metadata.GetFreshness()
+	if metadata == nil || coverage == nil || freshness == nil ||
+		!coverage.GetComplete() || coverage.GetTruncated() || metadata.GetPageTruncated() {
+		return lifecyclePendingResponse(findingID, "source_coverage_incomplete", "The exact lifecycle read is incomplete or truncated. The finding remains open until a complete source observation is available."), http.StatusAccepted, nil
+	}
+	if a.deps.SourceCollectionReceipts == nil {
+		return lifecyclePendingResponse(findingID, "collection_receipt_unavailable", "The final source collection receipt is unavailable. The finding remains open."), http.StatusAccepted, nil
+	}
+	manifest, err := a.deps.SourceCollectionReceipts.GetSourceCollection(
+		r.Context(),
+		tenantID,
+		record.GetSourceRuntimeId(),
+		record.GetSourceCollectionId(),
+	)
+	if errors.Is(err, organizationalgraph.ErrSourceCollectionNotFound) {
+		return lifecyclePendingResponse(findingID, "collection_receipt_pending", "The matching final source collection receipt is not available. The finding remains open."), http.StatusAccepted, nil
+	}
+	if err != nil {
+		return securityLifecycleReconcileResponse{}, http.StatusBadGateway, fmt.Errorf("load exact source collection receipt: %w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(manifest.Status), "complete") || len(manifest.IncompletenessReasons) != 0 {
+		return lifecyclePendingResponse(findingID, "collection_incomplete", "The matching source collection is incomplete. The finding remains open."), http.StatusAccepted, nil
+	}
+
+	updated, err := a.findingService().ResolveSecurityLifecycleFindingAfterObservation(r.Context(), findings.SecurityLifecycleClosureObservation{
+		FindingURN:                      findingID,
+		SourceRuntimeID:                 record.GetSourceRuntimeId(),
+		SourceCollectionID:              record.GetSourceCollectionId(),
+		SubjectURN:                      observation.GetSubjectRef().GetId(),
+		AuthorityID:                     observation.GetAuthorityId(),
+		StableLocator:                   observation.GetStableLocator(),
+		PolicyState:                     evaluation.GetState(),
+		ObservedAt:                      timestampTime(observation.GetObservedAt()),
+		FreshnessAsOf:                   timestampTime(freshness.GetAsOf()),
+		CoverageComplete:                coverage.GetComplete(),
+		CoverageTruncated:               coverage.GetTruncated(),
+		PageTruncated:                   metadata.GetPageTruncated(),
+		CollectionReceiptTenantID:       manifest.TenantID,
+		CollectionReceiptRuntimeID:      manifest.RuntimeID,
+		CollectionReceiptID:             manifest.CollectionID,
+		CollectionReceiptStatus:         manifest.Status,
+		CollectionReceiptCompletedAt:    time.UnixMilli(manifest.CompletedAtUnixMS).UTC(),
+		CollectionIncompletenessReasons: append([]string(nil), manifest.IncompletenessReasons...),
+		EvidenceClaimRefs:               lifecycleEvidenceRefs(observation, evaluation, nil),
+	})
+	if err != nil {
+		return securityLifecycleReconcileResponse{}, 0, err
+	}
+	a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeFindings, grcCacheScopeEvidence)
+	return securityLifecycleReconcileResponse{
+		FindingID:       updated.ID,
+		Status:          updated.Status,
+		Verification:    "verified_closed",
+		Reason:          "A later complete source collection observed the exact subject as compliant.",
+		AuditPreviewURL: lifecycleAuditPreviewURL(updated.ID),
+	}, http.StatusOK, nil
+}
+
+func lifecycleOpenObservation(tenantID, findingID string, resolved *cerebrov1.ResolveSecurityLifecycleFindingResponse) (findings.SecurityLifecycleFindingObservation, error) {
+	if resolved == nil || resolved.GetRecord() == nil {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the record", findings.ErrInvalidRequest)
+	}
+	record := resolved.GetRecord()
+	if resolved.GetGraphRevision() == 0 {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the durable graph revision", findings.ErrInvalidRequest)
+	}
+	if strings.TrimSpace(record.GetSourceRuntimeId()) == "" ||
+		record.GetSourceRuntimeId() != resolved.GetSourceRuntimeId() ||
+		record.GetSourceCollectionId() != resolved.GetSourceCollectionId() {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver provenance aliases do not match the record", findings.ErrInvalidRequest)
+	}
+	observation := record.GetObservation()
+	if observation == nil || observation.GetSubjectRef() == nil {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the observation subject", findings.ErrInvalidRequest)
+	}
+	var binding *cerebrov1.SecurityLifecycleFindingBinding
+	for _, candidate := range record.GetFindings() {
+		if candidate.GetFindingRef().GetId() == findingID {
+			if binding != nil {
+				return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver returned duplicate finding bindings", findings.ErrInvalidRequest)
+			}
+			binding = candidate
+		}
+	}
+	if binding == nil || !strings.EqualFold(strings.TrimSpace(binding.GetStatus()), "open") ||
+		binding.GetSubjectRef().GetId() != observation.GetSubjectRef().GetId() {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver did not return the requested open finding binding", findings.ErrInvalidRequest)
+	}
+	if len(record.GetPolicyEvaluations()) != 1 {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver did not return one exact policy evaluation", findings.ErrInvalidRequest)
+	}
+	evaluation := record.GetPolicyEvaluations()[0]
+	if evaluation.GetSubjectRef().GetId() != observation.GetSubjectRef().GetId() {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle policy evaluation subject does not match the observation", findings.ErrInvalidRequest)
+	}
+	subjectKind, ok := lifecycleSubjectKindName(observation.GetSubjectKind())
+	if !ok {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver returned an unsupported subject kind", findings.ErrInvalidRequest)
+	}
+	return findings.SecurityLifecycleFindingObservation{
+		TenantID:           tenantID,
+		FindingURN:         findingID,
+		SourceRuntimeID:    record.GetSourceRuntimeId(),
+		SourceCollectionID: record.GetSourceCollectionId(),
+		SubjectURN:         observation.GetSubjectRef().GetId(),
+		SubjectKind:        subjectKind,
+		AuthorityID:        observation.GetAuthorityId(),
+		StableLocator:      observation.GetStableLocator(),
+		MaterialRevision:   observation.GetSubjectRef().GetRevision(),
+		Provider:           observation.GetProvider(),
+		DisplayName:        observation.GetDisplayName(),
+		OwnerURN:           observation.GetOwnerUrn(),
+		ObservedState:      lifecycleStateName(observation.GetState()),
+		PolicyState:        evaluation.GetState(),
+		PolicyID:           evaluation.GetPolicyId(),
+		PolicyVersion:      evaluation.GetPolicyVersion(),
+		ObservedAt:         timestampTime(observation.GetObservedAt()),
+		ExpiresAt:          timestampTime(observation.GetExpiresAt()),
+		GraphRevision:      resolved.GetGraphRevision(),
+		EvidenceClaimRefs:  lifecycleEvidenceRefs(observation, evaluation, binding),
+	}, nil
+}
+
+func lifecyclePolicyEvaluation(record *cerebrov1.SecurityLifecycleRecord, policyID string) (*cerebrov1.SecurityLifecyclePolicyEvaluation, bool) {
+	var matched *cerebrov1.SecurityLifecyclePolicyEvaluation
+	for _, evaluation := range record.GetPolicyEvaluations() {
+		if strings.TrimSpace(evaluation.GetPolicyId()) != strings.TrimSpace(policyID) {
+			continue
+		}
+		if matched != nil {
+			return nil, false
+		}
+		matched = evaluation
+	}
+	return matched, matched != nil
+}
+
+func lifecycleEvidenceRefs(observation *cerebrov1.SecurityLifecycleObservation, evaluation *cerebrov1.SecurityLifecyclePolicyEvaluation, binding *cerebrov1.SecurityLifecycleFindingBinding) []string {
+	refs := make([]string, 0)
+	appendRefs := func(values []*cerebrov1.ResourceRef) {
+		for _, ref := range values {
+			if value := strings.TrimSpace(ref.GetId()); value != "" {
+				refs = append(refs, value)
+			}
+		}
+	}
+	appendRefs(observation.GetEvidenceClaimRefs())
+	appendRefs(evaluation.GetEvidenceClaimRefs())
+	if binding != nil {
+		appendRefs(binding.GetEvidenceClaimRefs())
+	}
+	return refs
+}
+
+func lifecycleSubjectKind(value string) (cerebrov1.SecurityLifecycleSubjectKind, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "credential":
+		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL, true
+	case "certificate":
+		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CERTIFICATE, true
+	default:
+		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_UNSPECIFIED, false
+	}
+}
+
+func lifecycleSubjectKindName(value cerebrov1.SecurityLifecycleSubjectKind) (string, bool) {
+	switch value {
+	case cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL:
+		return "credential", true
+	case cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CERTIFICATE:
+		return "certificate", true
+	default:
+		return "", false
+	}
+}
+
+func lifecycleStateName(value cerebrov1.SecurityLifecycleState) string {
+	return strings.ToLower(strings.TrimPrefix(value.String(), "SECURITY_LIFECYCLE_STATE_"))
+}
+
+func timestampTime(value *timestamppb.Timestamp) time.Time {
+	if value == nil || value.CheckValid() != nil {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
+}
+
+func lifecyclePendingResponse(findingID, verification, reason string) securityLifecycleReconcileResponse {
+	return securityLifecycleReconcileResponse{
+		FindingID:       findingID,
+		Status:          "open",
+		Verification:    verification,
+		Reason:          reason,
+		AuditPreviewURL: lifecycleAuditPreviewURL(findingID),
+	}
+}
+
+func lifecycleAuditPreviewURL(findingID string) string {
+	return "/grc/findings/" + url.PathEscape(strings.TrimSpace(findingID)) + "/audit-preview"
+}
+
+func writeSecurityLifecycleDependencyError(w http.ResponseWriter, err error) {
+	http.Error(w, "Security lifecycle finding read failed.", lifecycleDependencyStatus(err))
+}
+
+func lifecycleDependencyStatus(err error) int {
+	if connect.CodeOf(err) == connect.CodeUnavailable {
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusBadGateway
+}

--- a/internal/bootstrap/security_lifecycle_findings.go
+++ b/internal/bootstrap/security_lifecycle_findings.go
@@ -7,13 +7,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"connectrpc.com/connect"
-	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
-	"github.com/writer/cerebro/internal/findings"
-	"github.com/writer/cerebro/internal/sourcehttp/organizationalgraph"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	"github.com/writer/cerebro/internal/securitylifecyclefindings"
 )
 
 const maxSecurityLifecycleReconcileBodyBytes = 4 << 10
@@ -31,10 +27,6 @@ type securityLifecycleReconcileResponse struct {
 }
 
 func (a *App) handleReconcileSecurityLifecycleFinding(w http.ResponseWriter, r *http.Request) {
-	if a.deps.SecurityLifecycleQueries == nil {
-		http.Error(w, "Security lifecycle finding reads are unavailable.", http.StatusServiceUnavailable)
-		return
-	}
 	var request securityLifecycleReconcileRequest
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxSecurityLifecycleReconcileBodyBytes))
 	decoder.DisallowUnknownFields()
@@ -52,315 +44,42 @@ func (a *App) handleReconcileSecurityLifecycleFinding(w http.ResponseWriter, r *
 		writeGRCError(w, fmt.Errorf("%w: finding id is required", errInvalidHTTPRequest))
 		return
 	}
-
-	resolved, err := a.deps.SecurityLifecycleQueries.ResolveSecurityLifecycleFinding(r.Context(), tenantID, findingID)
-	if err == nil {
-		observation, mapErr := lifecycleOpenObservation(tenantID, findingID, resolved)
-		if mapErr != nil {
-			writeGRCError(w, mapErr)
-			return
-		}
-		finding, recordErr := a.findingService().RecordSecurityLifecycleFinding(r.Context(), observation)
-		if recordErr != nil {
-			writeGRCError(w, recordErr)
-			return
-		}
-		verification := "source_collection_linked"
-		reason := ""
-		if observation.SourceCollectionID == "" {
-			verification = "provenance_pending"
-			reason = "The current lifecycle row does not identify its final source collection. A later source sync is required before verified closure."
-		}
-		a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeFindings, grcCacheScopeEvidence)
-		writeJSON(w, http.StatusOK, securityLifecycleReconcileResponse{
-			FindingID:       finding.ID,
-			Status:          finding.Status,
-			Verification:    verification,
-			Reason:          reason,
-			AuditPreviewURL: lifecycleAuditPreviewURL(finding.ID),
-		})
-		return
-	}
-	if connect.CodeOf(err) != connect.CodeNotFound {
-		writeSecurityLifecycleDependencyError(w, err)
-		return
-	}
-
-	response, status, reconcileErr := a.reconcileClosedSecurityLifecycleFinding(r, tenantID, findingID)
-	if reconcileErr != nil {
-		if status != 0 {
+	result, err := securitylifecyclefindings.New(
+		a.findingService(),
+		a.deps.SecurityLifecycleQueries,
+		a.deps.SourceCollectionReceipts,
+	).Reconcile(r.Context(), tenantID, findingID)
+	if err != nil {
+		switch {
+		case errors.Is(err, securitylifecyclefindings.ErrTenantForbidden):
+			writeGRCError(w, errTenantForbidden)
+		case errors.Is(err, securitylifecyclefindings.ErrDependency):
+			status := http.StatusBadGateway
+			if connect.CodeOf(err) == connect.CodeUnavailable {
+				status = http.StatusServiceUnavailable
+			}
 			http.Error(w, "Security lifecycle verification dependency failed.", status)
-			return
+		default:
+			writeGRCError(w, err)
 		}
-		writeGRCError(w, reconcileErr)
 		return
 	}
-	writeJSON(w, status, response)
-}
-
-func (a *App) reconcileClosedSecurityLifecycleFinding(r *http.Request, tenantID, findingID string) (securityLifecycleReconcileResponse, int, error) {
-	current, err := a.findingService().GetFinding(r.Context(), findingID)
-	if err != nil {
-		return securityLifecycleReconcileResponse{}, 0, err
+	if result.Changed {
+		a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeFindings, grcCacheScopeEvidence)
 	}
-	if current.TenantID != tenantID {
-		return securityLifecycleReconcileResponse{}, 0, errTenantForbidden
+	status := http.StatusOK
+	if result.Pending {
+		status = http.StatusAccepted
 	}
-	locator, ok := findings.SecurityLifecycleLocatorForFinding(current)
-	if !ok {
-		return securityLifecycleReconcileResponse{}, 0, fmt.Errorf("%w: finding is not a projected security lifecycle finding", errInvalidHTTPRequest)
-	}
-	subjectKind, ok := lifecycleSubjectKind(locator.SubjectKind)
-	if !ok {
-		return lifecyclePendingResponse(findingID, "subject_locator_unavailable", "The stored lifecycle finding does not contain a recognized subject kind. Run a fresh source sync."), http.StatusAccepted, nil
-	}
-	result, err := a.deps.SecurityLifecycleQueries.ListSecurityLifecycle(r.Context(), &cerebrov1.SecurityLifecycleQuery{
-		TenantId: tenantID,
-		Limit:    2,
-		SubjectLocator: &cerebrov1.SecurityLifecycleSubjectLocator{
-			SubjectKind:   subjectKind,
-			AuthorityId:   locator.AuthorityID,
-			StableLocator: locator.StableLocator,
-		},
+	writeJSON(w, status, securityLifecycleReconcileResponse{
+		FindingID:       result.FindingID,
+		Status:          result.Status,
+		Verification:    result.Verification,
+		Reason:          result.Reason,
+		AuditPreviewURL: lifecycleAuditPreviewURL(result.FindingID),
 	})
-	if err != nil {
-		return securityLifecycleReconcileResponse{}, lifecycleDependencyStatus(err), fmt.Errorf("read exact lifecycle subject: %w", err)
-	}
-	if len(result.GetRecords()) != 1 {
-		return lifecyclePendingResponse(findingID, "exact_observation_unavailable", "The exact lifecycle subject does not have one current observation. Run a fresh source sync before retrying verification."), http.StatusAccepted, nil
-	}
-	record := result.GetRecords()[0]
-	observation := record.GetObservation()
-	if observation == nil ||
-		observation.GetSubjectRef().GetId() != locator.SubjectURN ||
-		observation.GetAuthorityId() != locator.AuthorityID ||
-		observation.GetStableLocator() != locator.StableLocator ||
-		observation.GetSubjectKind() != subjectKind {
-		return lifecyclePendingResponse(findingID, "subject_identity_mismatch", "The current lifecycle observation does not match the finding subject. The finding remains open."), http.StatusAccepted, nil
-	}
-	if strings.TrimSpace(record.GetSourceRuntimeId()) == "" || strings.TrimSpace(record.GetSourceCollectionId()) == "" {
-		return lifecyclePendingResponse(findingID, "provenance_pending", "The current lifecycle row does not identify its source runtime and final collection. The finding remains open."), http.StatusAccepted, nil
-	}
-	if record.GetSourceRuntimeId() != locator.SourceRuntimeID {
-		return lifecyclePendingResponse(findingID, "runtime_mismatch", "The current lifecycle observation came from a different source runtime. The finding remains open."), http.StatusAccepted, nil
-	}
-	evaluation, ok := lifecyclePolicyEvaluation(record, locator.PolicyID)
-	if !ok {
-		return lifecyclePendingResponse(findingID, "policy_observation_unavailable", "The current lifecycle row does not contain the finding policy evaluation. The finding remains open."), http.StatusAccepted, nil
-	}
-	if !strings.EqualFold(strings.TrimSpace(evaluation.GetState()), "compliant") {
-		return lifecyclePendingResponse(findingID, "policy_still_matches", "The current lifecycle policy is not compliant. Provider execution alone does not close this finding."), http.StatusAccepted, nil
-	}
-	metadata := result.GetMetadata()
-	coverage := metadata.GetCoverage()
-	freshness := metadata.GetFreshness()
-	if metadata == nil || coverage == nil || freshness == nil ||
-		!coverage.GetComplete() || coverage.GetTruncated() || metadata.GetPageTruncated() {
-		return lifecyclePendingResponse(findingID, "source_coverage_incomplete", "The exact lifecycle read is incomplete or truncated. The finding remains open until a complete source observation is available."), http.StatusAccepted, nil
-	}
-	if a.deps.SourceCollectionReceipts == nil {
-		return lifecyclePendingResponse(findingID, "collection_receipt_unavailable", "The final source collection receipt is unavailable. The finding remains open."), http.StatusAccepted, nil
-	}
-	manifest, err := a.deps.SourceCollectionReceipts.GetSourceCollection(
-		r.Context(),
-		tenantID,
-		record.GetSourceRuntimeId(),
-		record.GetSourceCollectionId(),
-	)
-	if errors.Is(err, organizationalgraph.ErrSourceCollectionNotFound) {
-		return lifecyclePendingResponse(findingID, "collection_receipt_pending", "The matching final source collection receipt is not available. The finding remains open."), http.StatusAccepted, nil
-	}
-	if err != nil {
-		return securityLifecycleReconcileResponse{}, http.StatusBadGateway, fmt.Errorf("load exact source collection receipt: %w", err)
-	}
-	if !strings.EqualFold(strings.TrimSpace(manifest.Status), "complete") || len(manifest.IncompletenessReasons) != 0 {
-		return lifecyclePendingResponse(findingID, "collection_incomplete", "The matching source collection is incomplete. The finding remains open."), http.StatusAccepted, nil
-	}
-
-	updated, err := a.findingService().ResolveSecurityLifecycleFindingAfterObservation(r.Context(), findings.SecurityLifecycleClosureObservation{
-		FindingURN:                      findingID,
-		SourceRuntimeID:                 record.GetSourceRuntimeId(),
-		SourceCollectionID:              record.GetSourceCollectionId(),
-		SubjectURN:                      observation.GetSubjectRef().GetId(),
-		AuthorityID:                     observation.GetAuthorityId(),
-		StableLocator:                   observation.GetStableLocator(),
-		PolicyState:                     evaluation.GetState(),
-		ObservedAt:                      timestampTime(observation.GetObservedAt()),
-		FreshnessAsOf:                   timestampTime(freshness.GetAsOf()),
-		CoverageComplete:                coverage.GetComplete(),
-		CoverageTruncated:               coverage.GetTruncated(),
-		PageTruncated:                   metadata.GetPageTruncated(),
-		CollectionReceiptTenantID:       manifest.TenantID,
-		CollectionReceiptRuntimeID:      manifest.RuntimeID,
-		CollectionReceiptID:             manifest.CollectionID,
-		CollectionReceiptStatus:         manifest.Status,
-		CollectionReceiptCompletedAt:    time.UnixMilli(manifest.CompletedAtUnixMS).UTC(),
-		CollectionIncompletenessReasons: append([]string(nil), manifest.IncompletenessReasons...),
-		EvidenceClaimRefs:               lifecycleEvidenceRefs(observation, evaluation, nil),
-	})
-	if err != nil {
-		return securityLifecycleReconcileResponse{}, 0, err
-	}
-	a.bumpGRCCacheVersions(r.Context(), tenantID, grcCacheScopeFindings, grcCacheScopeEvidence)
-	return securityLifecycleReconcileResponse{
-		FindingID:       updated.ID,
-		Status:          updated.Status,
-		Verification:    "verified_closed",
-		Reason:          "A later complete source collection observed the exact subject as compliant.",
-		AuditPreviewURL: lifecycleAuditPreviewURL(updated.ID),
-	}, http.StatusOK, nil
-}
-
-func lifecycleOpenObservation(tenantID, findingID string, resolved *cerebrov1.ResolveSecurityLifecycleFindingResponse) (findings.SecurityLifecycleFindingObservation, error) {
-	if resolved == nil || resolved.GetRecord() == nil {
-		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the record", findings.ErrInvalidRequest)
-	}
-	record := resolved.GetRecord()
-	if resolved.GetGraphRevision() == 0 {
-		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the durable graph revision", findings.ErrInvalidRequest)
-	}
-	if strings.TrimSpace(record.GetSourceRuntimeId()) == "" ||
-		record.GetSourceRuntimeId() != resolved.GetSourceRuntimeId() ||
-		record.GetSourceCollectionId() != resolved.GetSourceCollectionId() {
-		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver provenance aliases do not match the record", findings.ErrInvalidRequest)
-	}
-	observation := record.GetObservation()
-	if observation == nil || observation.GetSubjectRef() == nil {
-		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the observation subject", findings.ErrInvalidRequest)
-	}
-	var binding *cerebrov1.SecurityLifecycleFindingBinding
-	for _, candidate := range record.GetFindings() {
-		if candidate.GetFindingRef().GetId() == findingID {
-			if binding != nil {
-				return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver returned duplicate finding bindings", findings.ErrInvalidRequest)
-			}
-			binding = candidate
-		}
-	}
-	if binding == nil || !strings.EqualFold(strings.TrimSpace(binding.GetStatus()), "open") ||
-		binding.GetSubjectRef().GetId() != observation.GetSubjectRef().GetId() {
-		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver did not return the requested open finding binding", findings.ErrInvalidRequest)
-	}
-	if len(record.GetPolicyEvaluations()) != 1 {
-		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver did not return one exact policy evaluation", findings.ErrInvalidRequest)
-	}
-	evaluation := record.GetPolicyEvaluations()[0]
-	if evaluation.GetSubjectRef().GetId() != observation.GetSubjectRef().GetId() {
-		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle policy evaluation subject does not match the observation", findings.ErrInvalidRequest)
-	}
-	subjectKind, ok := lifecycleSubjectKindName(observation.GetSubjectKind())
-	if !ok {
-		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver returned an unsupported subject kind", findings.ErrInvalidRequest)
-	}
-	return findings.SecurityLifecycleFindingObservation{
-		TenantID:           tenantID,
-		FindingURN:         findingID,
-		SourceRuntimeID:    record.GetSourceRuntimeId(),
-		SourceCollectionID: record.GetSourceCollectionId(),
-		SubjectURN:         observation.GetSubjectRef().GetId(),
-		SubjectKind:        subjectKind,
-		AuthorityID:        observation.GetAuthorityId(),
-		StableLocator:      observation.GetStableLocator(),
-		MaterialRevision:   observation.GetSubjectRef().GetRevision(),
-		Provider:           observation.GetProvider(),
-		DisplayName:        observation.GetDisplayName(),
-		OwnerURN:           observation.GetOwnerUrn(),
-		ObservedState:      lifecycleStateName(observation.GetState()),
-		PolicyState:        evaluation.GetState(),
-		PolicyID:           evaluation.GetPolicyId(),
-		PolicyVersion:      evaluation.GetPolicyVersion(),
-		ObservedAt:         timestampTime(observation.GetObservedAt()),
-		ExpiresAt:          timestampTime(observation.GetExpiresAt()),
-		GraphRevision:      resolved.GetGraphRevision(),
-		EvidenceClaimRefs:  lifecycleEvidenceRefs(observation, evaluation, binding),
-	}, nil
-}
-
-func lifecyclePolicyEvaluation(record *cerebrov1.SecurityLifecycleRecord, policyID string) (*cerebrov1.SecurityLifecyclePolicyEvaluation, bool) {
-	var matched *cerebrov1.SecurityLifecyclePolicyEvaluation
-	for _, evaluation := range record.GetPolicyEvaluations() {
-		if strings.TrimSpace(evaluation.GetPolicyId()) != strings.TrimSpace(policyID) {
-			continue
-		}
-		if matched != nil {
-			return nil, false
-		}
-		matched = evaluation
-	}
-	return matched, matched != nil
-}
-
-func lifecycleEvidenceRefs(observation *cerebrov1.SecurityLifecycleObservation, evaluation *cerebrov1.SecurityLifecyclePolicyEvaluation, binding *cerebrov1.SecurityLifecycleFindingBinding) []string {
-	refs := make([]string, 0)
-	appendRefs := func(values []*cerebrov1.ResourceRef) {
-		for _, ref := range values {
-			if value := strings.TrimSpace(ref.GetId()); value != "" {
-				refs = append(refs, value)
-			}
-		}
-	}
-	appendRefs(observation.GetEvidenceClaimRefs())
-	appendRefs(evaluation.GetEvidenceClaimRefs())
-	if binding != nil {
-		appendRefs(binding.GetEvidenceClaimRefs())
-	}
-	return refs
-}
-
-func lifecycleSubjectKind(value string) (cerebrov1.SecurityLifecycleSubjectKind, bool) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "credential":
-		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL, true
-	case "certificate":
-		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CERTIFICATE, true
-	default:
-		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_UNSPECIFIED, false
-	}
-}
-
-func lifecycleSubjectKindName(value cerebrov1.SecurityLifecycleSubjectKind) (string, bool) {
-	switch value {
-	case cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL:
-		return "credential", true
-	case cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CERTIFICATE:
-		return "certificate", true
-	default:
-		return "", false
-	}
-}
-
-func lifecycleStateName(value cerebrov1.SecurityLifecycleState) string {
-	return strings.ToLower(strings.TrimPrefix(value.String(), "SECURITY_LIFECYCLE_STATE_"))
-}
-
-func timestampTime(value *timestamppb.Timestamp) time.Time {
-	if value == nil || value.CheckValid() != nil {
-		return time.Time{}
-	}
-	return value.AsTime().UTC()
-}
-
-func lifecyclePendingResponse(findingID, verification, reason string) securityLifecycleReconcileResponse {
-	return securityLifecycleReconcileResponse{
-		FindingID:       findingID,
-		Status:          "open",
-		Verification:    verification,
-		Reason:          reason,
-		AuditPreviewURL: lifecycleAuditPreviewURL(findingID),
-	}
 }
 
 func lifecycleAuditPreviewURL(findingID string) string {
 	return "/grc/findings/" + url.PathEscape(strings.TrimSpace(findingID)) + "/audit-preview"
-}
-
-func writeSecurityLifecycleDependencyError(w http.ResponseWriter, err error) {
-	http.Error(w, "Security lifecycle finding read failed.", lifecycleDependencyStatus(err))
-}
-
-func lifecycleDependencyStatus(err error) int {
-	if connect.CodeOf(err) == connect.CodeUnavailable {
-		return http.StatusServiceUnavailable
-	}
-	return http.StatusBadGateway
 }

--- a/internal/bootstrap/security_lifecycle_findings_test.go
+++ b/internal/bootstrap/security_lifecycle_findings_test.go
@@ -1,0 +1,366 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type lifecycleFindingQueryStub struct {
+	resolveResponses []*cerebrov1.ResolveSecurityLifecycleFindingResponse
+	resolveErrors    []error
+	resolveCalls     int
+	listResult       *cerebrov1.SecurityLifecycleQueryResult
+	listQueries      []*cerebrov1.SecurityLifecycleQuery
+}
+
+func (s *lifecycleFindingQueryStub) ResolveSecurityLifecycleFinding(_ context.Context, _, _ string) (*cerebrov1.ResolveSecurityLifecycleFindingResponse, error) {
+	index := s.resolveCalls
+	s.resolveCalls++
+	if index < len(s.resolveErrors) && s.resolveErrors[index] != nil {
+		return nil, s.resolveErrors[index]
+	}
+	if index >= len(s.resolveResponses) {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("lifecycle finding is not open"))
+	}
+	return s.resolveResponses[index], nil
+}
+
+func (s *lifecycleFindingQueryStub) ListSecurityLifecycle(_ context.Context, query *cerebrov1.SecurityLifecycleQuery) (*cerebrov1.SecurityLifecycleQueryResult, error) {
+	s.listQueries = append(s.listQueries, query)
+	return s.listResult, nil
+}
+
+type lifecycleReceiptStub struct {
+	manifests []ports.SourceCollectionManifest
+	calls     [][3]string
+}
+
+func (s *lifecycleReceiptStub) GetSourceCollection(_ context.Context, tenantID, runtimeID, collectionID string) (ports.SourceCollectionManifest, error) {
+	s.calls = append(s.calls, [3]string{tenantID, runtimeID, collectionID})
+	if len(s.manifests) == 0 {
+		return ports.SourceCollectionManifest{}, errors.New("unexpected source collection lookup")
+	}
+	manifest := s.manifests[0]
+	s.manifests = s.manifests[1:]
+	return manifest, nil
+}
+
+func TestSecurityLifecycleFindingReconcileUsesDurableFindingAndAuditAuthorities(t *testing.T) {
+	const (
+		tenantID   = "tenant-a"
+		runtimeID  = "runtime-lifecycle"
+		findingURN = "urn:cerebro:tenant-a:finding:urn%3Acerebro%3Atenant-a%3Acredential%3Aauthority-a%3Adeploy-signing"
+		subjectURN = "urn:cerebro:tenant-a:credential:authority-a:deploy-signing"
+	)
+	openedAt := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	providerAt := openedAt.Add(5 * time.Minute)
+	verifiedAt := openedAt.Add(15 * time.Minute)
+	query := &lifecycleFindingQueryStub{
+		resolveResponses: []*cerebrov1.ResolveSecurityLifecycleFindingResponse{
+			lifecycleResolverResponse(findingURN, subjectURN, runtimeID, "collection-open", "material-1", "expiring", openedAt, "urn:cerebro:tenant-a:evidence:open"),
+			lifecycleResolverResponse(findingURN, subjectURN, runtimeID, "collection-provider-success", "material-2", "expiring", providerAt, "urn:cerebro:tenant-a:evidence:provider-success"),
+		},
+		resolveErrors: []error{
+			nil,
+			nil,
+			connect.NewError(connect.CodeNotFound, errors.New("lifecycle finding is not open")),
+			connect.NewError(connect.CodeNotFound, errors.New("lifecycle finding is not open")),
+		},
+		listResult: lifecycleCompliantResult(subjectURN, runtimeID, "collection-verified", verifiedAt),
+	}
+	receipt := &lifecycleReceiptStub{manifests: []ports.SourceCollectionManifest{
+		{
+			CollectionID:          "collection-verified",
+			TenantID:              tenantID,
+			RuntimeID:             runtimeID,
+			Status:                "incomplete",
+			CompletedAtUnixMS:     verifiedAt.Add(time.Minute).UnixMilli(),
+			IncompletenessReasons: []string{"page_limit_reached"},
+		},
+		{
+			CollectionID:      "collection-verified",
+			TenantID:          tenantID,
+			RuntimeID:         runtimeID,
+			Status:            "complete",
+			CompletedAtUnixMS: verifiedAt.Add(time.Minute).UnixMilli(),
+		},
+	}}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:       runtimeID,
+				TenantId: tenantID,
+				SourceId: "security-lifecycle-source",
+			},
+		},
+		findings:        map[string]*ports.FindingRecord{},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{},
+	}
+	log := &recordingAppendLog{}
+	app := &App{deps: Dependencies{
+		AppendLog:                log,
+		StateStore:               store,
+		SecurityLifecycleQueries: query,
+		SourceCollectionReceipts: receipt,
+	}}
+
+	first := reconcileLifecycleFinding(t, app, findingURN)
+	if first.code != http.StatusOK || first.body.Status != "open" || first.body.FindingID != findingURN {
+		t.Fatalf("first reconcile = %#v", first)
+	}
+	stored := store.findings[findingURN]
+	if stored == nil || stored.RuntimeID != runtimeID {
+		t.Fatalf("durable finding = %#v, want actual runtime %q", stored, runtimeID)
+	}
+	if stored.Fingerprint == "" {
+		t.Fatal("durable finding fingerprint is empty")
+	}
+	openFingerprint := stored.Fingerprint
+
+	previewRequest := tenantRequest(httptest.NewRequest(http.MethodGet, lifecycleAuditPreviewURL(findingURN), nil), tenantID)
+	preview, err := app.buildGRCAuditPreview(previewRequest, findingURN)
+	if err != nil {
+		t.Fatalf("buildGRCAuditPreview(open) error = %v", err)
+	}
+	if preview.Finding.ID != findingURN || preview.FindingRecord.RuntimeID != runtimeID {
+		t.Fatalf("audit preview finding/runtime = %q/%q", preview.Finding.ID, preview.FindingRecord.RuntimeID)
+	}
+
+	second := reconcileLifecycleFinding(t, app, findingURN)
+	if second.code != http.StatusOK || second.body.Status != "open" {
+		t.Fatalf("provider-success reconcile = %#v", second)
+	}
+	if got := store.findings[findingURN]; got.Status != "open" || got.Fingerprint != openFingerprint {
+		t.Fatalf("finding after provider success = %#v, want stable open finding", got)
+	}
+
+	incomplete := reconcileLifecycleFinding(t, app, findingURN)
+	if incomplete.code != http.StatusAccepted ||
+		incomplete.body.Verification != "collection_incomplete" ||
+		store.findings[findingURN].Status != "open" {
+		t.Fatalf("incomplete reconcile = %#v finding=%#v", incomplete, store.findings[findingURN])
+	}
+
+	verified := reconcileLifecycleFinding(t, app, findingURN)
+	if verified.code != http.StatusOK ||
+		verified.body.Status != "resolved" ||
+		verified.body.Verification != "verified_closed" {
+		t.Fatalf("verified reconcile = %#v", verified)
+	}
+	if got := store.findings[findingURN]; got.Status != "resolved" {
+		t.Fatalf("finding after verified observation = %#v", got)
+	}
+	if len(receipt.calls) != 2 {
+		t.Fatalf("receipt lookups = %d, want incomplete and complete checks", len(receipt.calls))
+	}
+	for _, call := range receipt.calls {
+		if call != [3]string{tenantID, runtimeID, "collection-verified"} {
+			t.Fatalf("receipt lookup = %#v, want exact tenant/runtime/collection", call)
+		}
+	}
+	if len(query.listQueries) != 2 {
+		t.Fatalf("exact subject queries = %d, want two closure attempts", len(query.listQueries))
+	}
+	for _, exact := range query.listQueries {
+		locator := exact.GetSubjectLocator()
+		if locator.GetAuthorityId() != "authority-a" ||
+			locator.GetStableLocator() != "deploy-signing" ||
+			exact.GetLimit() != 2 {
+			t.Fatalf("exact subject query = %#v", exact)
+		}
+	}
+
+	preview, err = app.buildGRCAuditPreview(previewRequest, findingURN)
+	if err != nil {
+		t.Fatalf("buildGRCAuditPreview(resolved) error = %v", err)
+	}
+	if preview.Finding.ID != findingURN || preview.Finding.Status != "RESOLVED" {
+		t.Fatalf("resolved audit preview finding = %#v", preview.Finding)
+	}
+	if len(preview.Evidence) != 3 {
+		t.Fatalf("resolved audit preview evidence = %d, want open, provider-success, and verified observations", len(preview.Evidence))
+	}
+}
+
+func TestLifecycleOpenObservationRequiresMatchingResolverProvenanceAliases(t *testing.T) {
+	const (
+		findingURN = "urn:cerebro:tenant-a:finding:urn%3Acerebro%3Atenant-a%3Acredential%3Aauthority-a%3Adeploy-signing"
+		subjectURN = "urn:cerebro:tenant-a:credential:authority-a:deploy-signing"
+	)
+	response := lifecycleResolverResponse(
+		findingURN,
+		subjectURN,
+		"runtime-lifecycle",
+		"",
+		"material-1",
+		"expiring",
+		time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC),
+		"urn:cerebro:tenant-a:evidence:open",
+	)
+	observation, err := lifecycleOpenObservation("tenant-a", findingURN, response)
+	if err != nil {
+		t.Fatalf("lifecycleOpenObservation(pending collection) error = %v", err)
+	}
+	if observation.SourceCollectionID != "" {
+		t.Fatalf("pending source collection = %q, want empty", observation.SourceCollectionID)
+	}
+
+	response.SourceRuntimeId = "other-runtime"
+	if _, err := lifecycleOpenObservation("tenant-a", findingURN, response); err == nil {
+		t.Fatal("lifecycleOpenObservation(runtime alias mismatch) succeeded")
+	}
+	response.SourceRuntimeId = response.GetRecord().GetSourceRuntimeId()
+	response.SourceCollectionId = "other-collection"
+	if _, err := lifecycleOpenObservation("tenant-a", findingURN, response); err == nil {
+		t.Fatal("lifecycleOpenObservation(collection alias mismatch) succeeded")
+	}
+}
+
+func TestSecurityLifecycleReconcileRouteRequiresFindingWriteScope(t *testing.T) {
+	path := "/grc/findings/lifecycle-finding/security-lifecycle/reconcile"
+	policy := httpRoutePolicyFor(http.MethodPost, path)
+	if policy.Scope != scopeFindingLifecycleWrite {
+		t.Fatalf("POST %s scope = %q, want %q", path, policy.Scope, scopeFindingLifecycleWrite)
+	}
+	viewer := authPrincipal{Roles: []string{roleCerebroViewer}}
+	if err := authorizePrincipalHTTPPolicy(viewer, policy); err == nil {
+		t.Fatal("viewer authorized for lifecycle finding reconcile")
+	}
+	manager := authPrincipal{Roles: []string{roleCerebroFindingManager}}
+	if err := authorizePrincipalHTTPPolicy(manager, policy); err != nil {
+		t.Fatalf("finding manager rejected for lifecycle finding reconcile: %v", err)
+	}
+}
+
+type lifecycleReconcileResult struct {
+	code int
+	body securityLifecycleReconcileResponse
+}
+
+func reconcileLifecycleFinding(t *testing.T, app *App, findingID string) lifecycleReconcileResult {
+	t.Helper()
+	const tenantID = "tenant-a"
+	body, err := json.Marshal(securityLifecycleReconcileRequest{TenantID: tenantID})
+	if err != nil {
+		t.Fatalf("marshal reconcile request: %v", err)
+	}
+	request := tenantRequest(
+		httptest.NewRequest(http.MethodPost, "/grc/findings/lifecycle/security-lifecycle/reconcile", bytes.NewReader(body)),
+		tenantID,
+	)
+	request.SetPathValue("findingID", findingID)
+	response := httptest.NewRecorder()
+	app.handleReconcileSecurityLifecycleFinding(response, request)
+	var decoded securityLifecycleReconcileResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode reconcile response status=%d body=%q: %v", response.Code, response.Body.String(), err)
+	}
+	return lifecycleReconcileResult{code: response.Code, body: decoded}
+}
+
+func tenantRequest(request *http.Request, tenantID string) *http.Request {
+	return request.WithContext(context.WithValue(
+		request.Context(),
+		authContextKey{},
+		authContext{principal: authPrincipal{TenantID: tenantID}},
+	))
+}
+
+func lifecycleResolverResponse(findingURN, subjectURN, runtimeID, collectionID, revision, policyState string, observedAt time.Time, evidenceURN string) *cerebrov1.ResolveSecurityLifecycleFindingResponse {
+	subject := &cerebrov1.ResourceRef{Kind: "credential", Id: subjectURN, Revision: revision}
+	evidence := &cerebrov1.ResourceRef{Kind: "evidence", Id: evidenceURN}
+	record := &cerebrov1.SecurityLifecycleRecord{
+		Observation: &cerebrov1.SecurityLifecycleObservation{
+			SubjectRef:        subject,
+			SubjectKind:       cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL,
+			Provider:          "provider-a",
+			AuthorityId:       "authority-a",
+			StableLocator:     "deploy-signing",
+			DisplayName:       "Deploy signing credential",
+			State:             cerebrov1.SecurityLifecycleState_SECURITY_LIFECYCLE_STATE_ACTIVE,
+			ObservedAt:        timestamppb.New(observedAt),
+			ExpiresAt:         timestamppb.New(openedExpiry(observedAt)),
+			OwnerUrn:          "urn:cerebro:tenant-a:team:security",
+			EvidenceClaimRefs: []*cerebrov1.ResourceRef{evidence},
+		},
+		PolicyEvaluations: []*cerebrov1.SecurityLifecyclePolicyEvaluation{{
+			PolicyId:          "security.lifecycle.expiry",
+			PolicyVersion:     "1",
+			SubjectRef:        subject,
+			State:             policyState,
+			EvaluatedAt:       timestamppb.New(observedAt),
+			EvidenceClaimRefs: []*cerebrov1.ResourceRef{evidence},
+		}},
+		Findings: []*cerebrov1.SecurityLifecycleFindingBinding{{
+			FindingRef:        &cerebrov1.ResourceRef{Kind: "finding", Id: findingURN, State: "open"},
+			SubjectRef:        subject,
+			FindingKind:       "credential_expiry",
+			Status:            "open",
+			EvidenceClaimRefs: []*cerebrov1.ResourceRef{evidence},
+		}},
+		SourceRuntimeId:    runtimeID,
+		SourceCollectionId: collectionID,
+	}
+	return &cerebrov1.ResolveSecurityLifecycleFindingResponse{
+		Record:             record,
+		GraphRevision:      42,
+		SourceRuntimeId:    runtimeID,
+		SourceCollectionId: collectionID,
+	}
+}
+
+func lifecycleCompliantResult(subjectURN, runtimeID, collectionID string, observedAt time.Time) *cerebrov1.SecurityLifecycleQueryResult {
+	subject := &cerebrov1.ResourceRef{Kind: "credential", Id: subjectURN, Revision: "material-3"}
+	return &cerebrov1.SecurityLifecycleQueryResult{
+		Records: []*cerebrov1.SecurityLifecycleRecord{{
+			Observation: &cerebrov1.SecurityLifecycleObservation{
+				SubjectRef:        subject,
+				SubjectKind:       cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL,
+				Provider:          "provider-a",
+				AuthorityId:       "authority-a",
+				StableLocator:     "deploy-signing",
+				DisplayName:       "Deploy signing credential",
+				State:             cerebrov1.SecurityLifecycleState_SECURITY_LIFECYCLE_STATE_ACTIVE,
+				ObservedAt:        timestamppb.New(observedAt),
+				ExpiresAt:         timestamppb.New(openedExpiry(observedAt)),
+				EvidenceClaimRefs: []*cerebrov1.ResourceRef{{Kind: "evidence", Id: "urn:cerebro:tenant-a:evidence:verified-observation"}},
+			},
+			PolicyEvaluations: []*cerebrov1.SecurityLifecyclePolicyEvaluation{{
+				PolicyId:          "security.lifecycle.expiry",
+				PolicyVersion:     "1",
+				SubjectRef:        subject,
+				State:             "compliant",
+				EvaluatedAt:       timestamppb.New(observedAt),
+				EvidenceClaimRefs: []*cerebrov1.ResourceRef{{Kind: "evidence", Id: "urn:cerebro:tenant-a:evidence:verified-observation"}},
+			}},
+			SourceRuntimeId:    runtimeID,
+			SourceCollectionId: collectionID,
+		}},
+		Metadata: &cerebrov1.SecurityLifecycleQueryMetadata{
+			Coverage: &cerebrov1.SecurityLifecycleCoverage{
+				Complete: true,
+				Reason:   cerebrov1.SecurityLifecycleCoverageReason_SECURITY_LIFECYCLE_COVERAGE_REASON_COMPLETE,
+			},
+			Freshness: &cerebrov1.SecurityLifecycleFreshness{
+				AsOf:             timestamppb.New(observedAt.Add(time.Minute)),
+				OldestObservedAt: timestamppb.New(observedAt),
+				NewestObservedAt: timestamppb.New(observedAt),
+			},
+		},
+	}
+}
+
+func openedExpiry(observedAt time.Time) time.Time {
+	return observedAt.Add(90 * 24 * time.Hour)
+}

--- a/internal/bootstrap/security_lifecycle_findings_test.go
+++ b/internal/bootstrap/security_lifecycle_findings_test.go
@@ -13,6 +13,7 @@ import (
 	"connectrpc.com/connect"
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securitylifecyclefindings"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -115,7 +116,7 @@ func TestSecurityLifecycleFindingReconcileUsesDurableFindingAndAuditAuthorities(
 		SourceCollectionReceipts: receipt,
 	}}
 
-	first := reconcileLifecycleFinding(t, app, findingURN)
+	first := reconcileLifecycleFinding(t, app)
 	if first.code != http.StatusOK || first.body.Status != "open" || first.body.FindingID != findingURN {
 		t.Fatalf("first reconcile = %#v", first)
 	}
@@ -137,7 +138,7 @@ func TestSecurityLifecycleFindingReconcileUsesDurableFindingAndAuditAuthorities(
 		t.Fatalf("audit preview finding/runtime = %q/%q", preview.Finding.ID, preview.FindingRecord.RuntimeID)
 	}
 
-	second := reconcileLifecycleFinding(t, app, findingURN)
+	second := reconcileLifecycleFinding(t, app)
 	if second.code != http.StatusOK || second.body.Status != "open" {
 		t.Fatalf("provider-success reconcile = %#v", second)
 	}
@@ -145,14 +146,14 @@ func TestSecurityLifecycleFindingReconcileUsesDurableFindingAndAuditAuthorities(
 		t.Fatalf("finding after provider success = %#v, want stable open finding", got)
 	}
 
-	incomplete := reconcileLifecycleFinding(t, app, findingURN)
+	incomplete := reconcileLifecycleFinding(t, app)
 	if incomplete.code != http.StatusAccepted ||
 		incomplete.body.Verification != "collection_incomplete" ||
 		store.findings[findingURN].Status != "open" {
 		t.Fatalf("incomplete reconcile = %#v finding=%#v", incomplete, store.findings[findingURN])
 	}
 
-	verified := reconcileLifecycleFinding(t, app, findingURN)
+	verified := reconcileLifecycleFinding(t, app)
 	if verified.code != http.StatusOK ||
 		verified.body.Status != "resolved" ||
 		verified.body.Verification != "verified_closed" {
@@ -208,22 +209,22 @@ func TestLifecycleOpenObservationRequiresMatchingResolverProvenanceAliases(t *te
 		time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC),
 		"urn:cerebro:tenant-a:evidence:open",
 	)
-	observation, err := lifecycleOpenObservation("tenant-a", findingURN, response)
+	observation, err := securitylifecyclefindings.ObservationFromResolved("tenant-a", findingURN, response)
 	if err != nil {
-		t.Fatalf("lifecycleOpenObservation(pending collection) error = %v", err)
+		t.Fatalf("ObservationFromResolved(pending collection) error = %v", err)
 	}
 	if observation.SourceCollectionID != "" {
 		t.Fatalf("pending source collection = %q, want empty", observation.SourceCollectionID)
 	}
 
 	response.SourceRuntimeId = "other-runtime"
-	if _, err := lifecycleOpenObservation("tenant-a", findingURN, response); err == nil {
-		t.Fatal("lifecycleOpenObservation(runtime alias mismatch) succeeded")
+	if _, err := securitylifecyclefindings.ObservationFromResolved("tenant-a", findingURN, response); err == nil {
+		t.Fatal("ObservationFromResolved(runtime alias mismatch) succeeded")
 	}
 	response.SourceRuntimeId = response.GetRecord().GetSourceRuntimeId()
 	response.SourceCollectionId = "other-collection"
-	if _, err := lifecycleOpenObservation("tenant-a", findingURN, response); err == nil {
-		t.Fatal("lifecycleOpenObservation(collection alias mismatch) succeeded")
+	if _, err := securitylifecyclefindings.ObservationFromResolved("tenant-a", findingURN, response); err == nil {
+		t.Fatal("ObservationFromResolved(collection alias mismatch) succeeded")
 	}
 }
 
@@ -248,9 +249,12 @@ type lifecycleReconcileResult struct {
 	body securityLifecycleReconcileResponse
 }
 
-func reconcileLifecycleFinding(t *testing.T, app *App, findingID string) lifecycleReconcileResult {
+func reconcileLifecycleFinding(t *testing.T, app *App) lifecycleReconcileResult {
 	t.Helper()
-	const tenantID = "tenant-a"
+	const (
+		tenantID  = "tenant-a"
+		findingID = "urn:cerebro:tenant-a:finding:urn%3Acerebro%3Atenant-a%3Acredential%3Aauthority-a%3Adeploy-signing"
+	)
 	body, err := json.Marshal(securityLifecycleReconcileRequest{TenantID: tenantID})
 	if err != nil {
 		t.Fatalf("marshal reconcile request: %v", err)

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -500,7 +500,13 @@ func findingWorkflowEventScopeValid(tenantID string, sourceID string, finding *p
 }
 
 func findingGraphFindingURN(tenantID string, finding *ports.FindingRecord) string {
-	return fmt.Sprintf("urn:cerebro:%s:finding:%s", strings.TrimSpace(tenantID), strings.TrimSpace(finding.ID))
+	tenantID = strings.TrimSpace(tenantID)
+	findingID := strings.TrimSpace(finding.ID)
+	canonicalPrefix := fmt.Sprintf("urn:cerebro:%s:finding:", tenantID)
+	if strings.HasPrefix(findingID, canonicalPrefix) {
+		return findingID
+	}
+	return canonicalPrefix + findingID
 }
 
 func findingGraphTicketURN(tenantID string, ticketURL string) string {

--- a/internal/findings/security_lifecycle_bridge.go
+++ b/internal/findings/security_lifecycle_bridge.go
@@ -1,0 +1,338 @@
+package findings
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findingevidence"
+	"github.com/writer/cerebro/internal/ports"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
+	"github.com/writer/cerebro/internal/workflowevents"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	securityLifecycleFindingRuleID = "security-lifecycle-expiry"
+
+	securityLifecycleAttributeAuthorityID   = "security_lifecycle_authority_id"
+	securityLifecycleAttributeStableLocator = "security_lifecycle_stable_locator"
+	securityLifecycleAttributeSubjectKind   = "security_lifecycle_subject_kind"
+	securityLifecycleAttributeProvider      = "security_lifecycle_provider"
+	securityLifecycleAttributeGraphRevision = "security_lifecycle_graph_revision"
+	securityLifecycleAttributeCollectionID  = "security_lifecycle_source_collection_id"
+	securityLifecycleAttributeProvenance    = "security_lifecycle_provenance"
+)
+
+// SecurityLifecycleFindingObservation is the metadata-only input accepted from
+// the Rust lifecycle resolver. AuthorityID and StableLocator are the durable
+// identity; MaterialRevision is evidence and never participates in identity.
+type SecurityLifecycleFindingObservation struct {
+	TenantID           string
+	FindingURN         string
+	SourceRuntimeID    string
+	SourceCollectionID string
+	SubjectURN         string
+	SubjectKind        string
+	AuthorityID        string
+	StableLocator      string
+	MaterialRevision   string
+	Provider           string
+	DisplayName        string
+	OwnerURN           string
+	ObservedState      string
+	PolicyState        string
+	PolicyID           string
+	PolicyVersion      string
+	ObservedAt         time.Time
+	ExpiresAt          time.Time
+	GraphRevision      uint64
+	EvidenceClaimRefs  []string
+}
+
+// SecurityLifecycleClosureObservation is proof from a later exact-subject
+// lifecycle query. Provider dispatch or execution receipts do not satisfy it.
+type SecurityLifecycleClosureObservation struct {
+	FindingURN                      string
+	SourceRuntimeID                 string
+	SourceCollectionID              string
+	SubjectURN                      string
+	AuthorityID                     string
+	StableLocator                   string
+	PolicyState                     string
+	ObservedAt                      time.Time
+	FreshnessAsOf                   time.Time
+	CoverageComplete                bool
+	CoverageTruncated               bool
+	PageTruncated                   bool
+	CollectionReceiptTenantID       string
+	CollectionReceiptRuntimeID      string
+	CollectionReceiptID             string
+	CollectionReceiptStatus         string
+	CollectionReceiptCompletedAt    time.Time
+	CollectionIncompletenessReasons []string
+	EvidenceClaimRefs               []string
+}
+
+// RecordSecurityLifecycleFinding projects one currently-open Rust lifecycle
+// finding into the existing FindingRecord and FindingEvidence authorities.
+func (s *Service) RecordSecurityLifecycleFinding(ctx context.Context, observation SecurityLifecycleFindingObservation) (*ports.FindingRecord, error) {
+	normalized, err := normalizeSecurityLifecycleFindingObservation(observation)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil || s.runtimeStore == nil || s.store == nil || s.evidenceStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, normalized.SourceRuntimeID)
+	if err != nil {
+		return nil, fmt.Errorf("load security lifecycle source runtime %q: %w", normalized.SourceRuntimeID, err)
+	}
+	if strings.TrimSpace(runtime.GetTenantId()) != normalized.TenantID {
+		return nil, fmt.Errorf("%w: lifecycle source runtime tenant does not match the resolver tenant", ErrInvalidRequest)
+	}
+
+	record := securityLifecycleFindingRecord(normalized)
+	stored, _, err := s.upsertFindingWithRiskAndNewness(ctx, record, nil, normalized.ObservedAt)
+	if err != nil {
+		return nil, fmt.Errorf("persist security lifecycle finding %q: %w", normalized.FindingURN, err)
+	}
+	evidence := securityLifecycleFindingEvidence(stored, normalized.SourceCollectionID, normalized.ObservedAt, normalized.EvidenceClaimRefs)
+	if err := s.evidenceStore.PutFindingEvidence(ctx, evidence); err != nil {
+		return nil, fmt.Errorf("persist security lifecycle finding %q evidence: %w", normalized.FindingURN, err)
+	}
+	if err := s.projectFindingAnchor(ctx, stored); err != nil {
+		return nil, fmt.Errorf("record security lifecycle finding %q workflow event: %w", normalized.FindingURN, err)
+	}
+	return stored, nil
+}
+
+// ResolveSecurityLifecycleFindingAfterObservation closes one lifecycle finding
+// only when a later exact-subject observation is complete, non-truncated, and
+// proves the expiry policy no longer matches.
+func (s *Service) ResolveSecurityLifecycleFindingAfterObservation(ctx context.Context, proof SecurityLifecycleClosureObservation) (*ports.FindingRecord, error) {
+	if s == nil || s.store == nil || s.evidenceStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	findingID := strings.TrimSpace(proof.FindingURN)
+	if findingID == "" {
+		return nil, fmt.Errorf("%w: lifecycle finding urn is required", ErrInvalidRequest)
+	}
+	if !proof.CoverageComplete || proof.CoverageTruncated || proof.PageTruncated {
+		return nil, fmt.Errorf("%w: lifecycle closure requires complete, non-truncated source coverage", ErrInvalidRequest)
+	}
+	if securityLifecyclePolicyMatches(proof.PolicyState) {
+		return nil, fmt.Errorf("%w: lifecycle policy still matches", ErrInvalidRequest)
+	}
+	if !strings.EqualFold(strings.TrimSpace(proof.PolicyState), "compliant") {
+		return nil, fmt.Errorf("%w: lifecycle closure requires a compliant policy observation", ErrInvalidRequest)
+	}
+
+	current, err := s.store.GetFinding(ctx, findingID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(current.Attributes[securityLifecycleAttributeAuthorityID]) != strings.TrimSpace(proof.AuthorityID) ||
+		strings.TrimSpace(current.Attributes[securityLifecycleAttributeStableLocator]) != strings.TrimSpace(proof.StableLocator) {
+		return nil, fmt.Errorf("%w: lifecycle closure subject does not match the persisted finding", ErrInvalidRequest)
+	}
+	if subjectURN := strings.TrimSpace(proof.SubjectURN); subjectURN == "" || !containsString(current.ResourceURNs, subjectURN) {
+		return nil, fmt.Errorf("%w: lifecycle closure resource does not match the persisted finding", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(proof.SourceRuntimeID) == "" || strings.TrimSpace(proof.SourceRuntimeID) != strings.TrimSpace(current.RuntimeID) {
+		return nil, fmt.Errorf("%w: lifecycle closure runtime does not match the persisted finding", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(proof.SourceCollectionID) == "" ||
+		strings.TrimSpace(proof.CollectionReceiptID) != strings.TrimSpace(proof.SourceCollectionID) ||
+		strings.TrimSpace(proof.CollectionReceiptTenantID) != strings.TrimSpace(current.TenantID) ||
+		strings.TrimSpace(proof.CollectionReceiptRuntimeID) != strings.TrimSpace(current.RuntimeID) ||
+		!strings.EqualFold(strings.TrimSpace(proof.CollectionReceiptStatus), "complete") ||
+		len(uniqueSortedStrings(proof.CollectionIncompletenessReasons)) != 0 {
+		return nil, fmt.Errorf("%w: lifecycle closure requires the matching complete source collection receipt", ErrInvalidRequest)
+	}
+	if openCollectionID := strings.TrimSpace(current.Attributes[securityLifecycleAttributeCollectionID]); openCollectionID != "" && openCollectionID == strings.TrimSpace(proof.SourceCollectionID) {
+		return nil, fmt.Errorf("%w: lifecycle closure requires an independent later source collection", ErrInvalidRequest)
+	}
+	observedAt := proof.ObservedAt.UTC()
+	if observedAt.IsZero() || !observedAt.After(current.LastObservedAt.UTC()) {
+		return nil, fmt.Errorf("%w: lifecycle closure observation must be newer than the open finding", ErrInvalidRequest)
+	}
+	if freshnessAsOf := proof.FreshnessAsOf.UTC(); freshnessAsOf.IsZero() || freshnessAsOf.Before(observedAt) {
+		return nil, fmt.Errorf("%w: lifecycle closure requires freshness through the exact observation", ErrInvalidRequest)
+	}
+	if completedAt := proof.CollectionReceiptCompletedAt.UTC(); completedAt.IsZero() || completedAt.Before(observedAt) {
+		return nil, fmt.Errorf("%w: lifecycle collection receipt must complete after the observation", ErrInvalidRequest)
+	}
+
+	evidence := securityLifecycleFindingEvidence(current, proof.SourceCollectionID, observedAt, proof.EvidenceClaimRefs)
+	if err := s.evidenceStore.PutFindingEvidence(ctx, evidence); err != nil {
+		return nil, fmt.Errorf("persist security lifecycle closure evidence for %q: %w", findingID, err)
+	}
+	updated, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{
+		FindingID:          findingID,
+		Status:             findingStatusResolved,
+		Reason:             workflowevents.FindingStatusReasonVerifiedObservation,
+		UpdatedAt:          observedAt,
+		ExpectedStatus:     findingStatusOpen,
+		LastObservedBefore: observedAt,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolve security lifecycle finding %q: %w", findingID, err)
+	}
+	if err := s.recordFindingStatusWorkflow(ctx, updated, workflowevents.FindingStatusSourceVerifiedObservation); err != nil {
+		return nil, fmt.Errorf("record security lifecycle finding %q verified closure: %w", findingID, err)
+	}
+	return updated, nil
+}
+
+func normalizeSecurityLifecycleFindingObservation(input SecurityLifecycleFindingObservation) (SecurityLifecycleFindingObservation, error) {
+	input.TenantID = strings.TrimSpace(input.TenantID)
+	input.FindingURN = strings.TrimSpace(input.FindingURN)
+	input.SourceRuntimeID = strings.TrimSpace(input.SourceRuntimeID)
+	input.SourceCollectionID = strings.TrimSpace(input.SourceCollectionID)
+	input.SubjectURN = strings.TrimSpace(input.SubjectURN)
+	input.SubjectKind = strings.ToLower(strings.TrimSpace(input.SubjectKind))
+	input.AuthorityID = strings.TrimSpace(input.AuthorityID)
+	input.StableLocator = strings.TrimSpace(input.StableLocator)
+	input.MaterialRevision = strings.TrimSpace(input.MaterialRevision)
+	input.Provider = strings.TrimSpace(input.Provider)
+	input.DisplayName = strings.TrimSpace(input.DisplayName)
+	input.OwnerURN = strings.TrimSpace(input.OwnerURN)
+	input.ObservedState = strings.ToLower(strings.TrimSpace(input.ObservedState))
+	input.PolicyState = strings.ToLower(strings.TrimSpace(input.PolicyState))
+	input.PolicyID = strings.TrimSpace(input.PolicyID)
+	input.PolicyVersion = strings.TrimSpace(input.PolicyVersion)
+	input.ObservedAt = input.ObservedAt.UTC()
+	input.ExpiresAt = input.ExpiresAt.UTC()
+	input.EvidenceClaimRefs = uniqueSortedStrings(input.EvidenceClaimRefs)
+	findingURN, findingURNErr := cerebrourn.Parse(input.FindingURN)
+	subjectURN, subjectURNErr := cerebrourn.Parse(input.SubjectURN)
+	switch {
+	case input.TenantID == "":
+		return input, fmt.Errorf("%w: lifecycle tenant id is required", ErrInvalidRequest)
+	case input.FindingURN == "":
+		return input, fmt.Errorf("%w: lifecycle finding urn is required", ErrInvalidRequest)
+	case findingURNErr != nil || findingURN.Kind != "finding" || findingURN.TenantID != input.TenantID:
+		return input, fmt.Errorf("%w: lifecycle finding urn must identify a finding in the resolver tenant", ErrInvalidRequest)
+	case input.SourceRuntimeID == "":
+		return input, fmt.Errorf("%w: lifecycle source runtime id is required", ErrInvalidRequest)
+	case input.SubjectURN == "":
+		return input, fmt.Errorf("%w: lifecycle subject urn is required", ErrInvalidRequest)
+	case subjectURNErr != nil || subjectURN.TenantID != input.TenantID:
+		return input, fmt.Errorf("%w: lifecycle subject urn is outside the tenant", ErrInvalidRequest)
+	case input.AuthorityID == "":
+		return input, fmt.Errorf("%w: lifecycle authority id is required", ErrInvalidRequest)
+	case input.StableLocator == "":
+		return input, fmt.Errorf("%w: lifecycle stable locator is required", ErrInvalidRequest)
+	case input.ObservedAt.IsZero():
+		return input, fmt.Errorf("%w: lifecycle observed_at is required", ErrInvalidRequest)
+	case !securityLifecyclePolicyMatches(input.PolicyState):
+		return input, fmt.Errorf("%w: lifecycle resolver did not return an open expiry policy state", ErrInvalidRequest)
+	}
+	return input, nil
+}
+
+func securityLifecycleFindingRecord(input SecurityLifecycleFindingObservation) *ports.FindingRecord {
+	identity := securityLifecycleDigest(input.TenantID, input.AuthorityID, input.StableLocator, input.SubjectKind)
+	titleSubject := firstNonEmpty(input.DisplayName, input.SubjectKind, "Resource")
+	state := strings.ToLower(strings.TrimSpace(input.PolicyState))
+	title := fmt.Sprintf("%s expires within the policy window", titleSubject)
+	summary := "The latest lifecycle observation matches the configured expiry policy."
+	severity := "MEDIUM"
+	if state == "expired" {
+		title = fmt.Sprintf("%s is expired", titleSubject)
+		summary = "The latest lifecycle observation shows that the resource is expired."
+		severity = "HIGH"
+	}
+	attributes := map[string]string{
+		"primary_resource_urn":                  input.SubjectURN,
+		securityLifecycleAttributeAuthorityID:   input.AuthorityID,
+		securityLifecycleAttributeStableLocator: input.StableLocator,
+		securityLifecycleAttributeSubjectKind:   input.SubjectKind,
+		securityLifecycleAttributeProvider:      input.Provider,
+		securityLifecycleAttributeGraphRevision: fmt.Sprintf("%d", input.GraphRevision),
+		securityLifecycleAttributeCollectionID:  input.SourceCollectionID,
+		"security_lifecycle_observed_state":     input.ObservedState,
+		"security_lifecycle_policy_state":       input.PolicyState,
+		"security_lifecycle_policy_version":     input.PolicyVersion,
+		"security_lifecycle_material_revision":  input.MaterialRevision,
+	}
+	if input.SourceCollectionID == "" {
+		attributes[securityLifecycleAttributeProvenance] = "pending_source_collection"
+	} else {
+		attributes[securityLifecycleAttributeProvenance] = "source_collection_linked"
+	}
+	trimEmptyAttributes(attributes)
+	return &ports.FindingRecord{
+		ID:                input.FindingURN,
+		Fingerprint:       identity,
+		TenantID:          input.TenantID,
+		RuntimeID:         input.SourceRuntimeID,
+		RuleID:            securityLifecycleFindingRuleID,
+		Title:             title,
+		Severity:          severity,
+		Status:            findingStatusOpen,
+		Summary:           summary,
+		ResourceURNs:      []string{input.SubjectURN},
+		ObservedPolicyIDs: []string{input.PolicyID},
+		PolicyID:          input.PolicyID,
+		PolicyName:        "Security lifecycle expiry",
+		CheckID:           securityLifecycleFindingRuleID,
+		CheckName:         "Security lifecycle expiry",
+		FindingWorkflow: ports.FindingWorkflow{
+			Assignee: input.OwnerURN,
+			DueAt:    input.ExpiresAt,
+		},
+		Attributes:      attributes,
+		FirstObservedAt: input.ObservedAt,
+		LastObservedAt:  input.ObservedAt,
+	}
+}
+
+func securityLifecycleFindingEvidence(finding *ports.FindingRecord, sourceCollectionID string, observedAt time.Time, claimRefs []string) *cerebrov1.FindingEvidence {
+	claimRefs = uniqueSortedStrings(claimRefs)
+	resourceURNs := uniqueSortedStrings(finding.ResourceURNs)
+	evidence := &cerebrov1.FindingEvidence{
+		Id:             "lifecycle-evidence-" + securityLifecycleDigest(finding.ID, sourceCollectionID, strings.Join(claimRefs, "\x00")),
+		RuntimeId:      strings.TrimSpace(finding.RuntimeID),
+		RuleId:         strings.TrimSpace(finding.RuleID),
+		FindingId:      strings.TrimSpace(finding.ID),
+		ClaimIds:       claimRefs,
+		GraphRootUrns:  resourceURNs,
+		CreatedAt:      timestamppb.New(observedAt.UTC()),
+		LastObservedAt: timestamppb.New(observedAt.UTC()),
+		Attributes: map[string]string{
+			"evidence_kind":        "security_lifecycle_observation",
+			"source_runtime_id":    strings.TrimSpace(finding.RuntimeID),
+			"source_collection_id": strings.TrimSpace(sourceCollectionID),
+		},
+	}
+	trimEmptyAttributes(evidence.Attributes)
+	if observation := findingevidence.ObservationFor(evidence); observation != nil {
+		evidence.Observations = []*cerebrov1.FindingEvidenceObservation{observation}
+		evidence.ObservationCount = 1
+	}
+	return evidence
+}
+
+func securityLifecyclePolicyMatches(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "expiring", "expired":
+		return true
+	default:
+		return false
+	}
+}
+
+func securityLifecycleDigest(values ...string) string {
+	hash := sha256.New()
+	for _, value := range values {
+		_, _ = hash.Write([]byte(strings.TrimSpace(value)))
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/internal/findings/security_lifecycle_bridge.go
+++ b/internal/findings/security_lifecycle_bridge.go
@@ -78,6 +78,40 @@ type SecurityLifecycleClosureObservation struct {
 	EvidenceClaimRefs               []string
 }
 
+// SecurityLifecycleFindingLocator is the stable exact-subject selector stored
+// with a projected lifecycle finding.
+type SecurityLifecycleFindingLocator struct {
+	SubjectURN       string
+	SubjectKind      string
+	AuthorityID      string
+	StableLocator    string
+	SourceRuntimeID  string
+	SourceCollection string
+	PolicyID         string
+}
+
+// SecurityLifecycleLocatorForFinding returns the exact selector and
+// provenance stored by this bridge without exposing its storage keys.
+func SecurityLifecycleLocatorForFinding(finding *ports.FindingRecord) (SecurityLifecycleFindingLocator, bool) {
+	if finding == nil || strings.TrimSpace(finding.RuleID) != securityLifecycleFindingRuleID {
+		return SecurityLifecycleFindingLocator{}, false
+	}
+	locator := SecurityLifecycleFindingLocator{
+		SubjectURN:       firstString(finding.ResourceURNs),
+		SubjectKind:      strings.TrimSpace(finding.Attributes[securityLifecycleAttributeSubjectKind]),
+		AuthorityID:      strings.TrimSpace(finding.Attributes[securityLifecycleAttributeAuthorityID]),
+		StableLocator:    strings.TrimSpace(finding.Attributes[securityLifecycleAttributeStableLocator]),
+		SourceRuntimeID:  strings.TrimSpace(finding.RuntimeID),
+		SourceCollection: strings.TrimSpace(finding.Attributes[securityLifecycleAttributeCollectionID]),
+		PolicyID:         strings.TrimSpace(finding.PolicyID),
+	}
+	if locator.SubjectURN == "" || locator.SubjectKind == "" || locator.AuthorityID == "" ||
+		locator.StableLocator == "" || locator.SourceRuntimeID == "" || locator.PolicyID == "" {
+		return SecurityLifecycleFindingLocator{}, false
+	}
+	return locator, true
+}
+
 // RecordSecurityLifecycleFinding projects one currently-open Rust lifecycle
 // finding into the existing FindingRecord and FindingEvidence authorities.
 func (s *Service) RecordSecurityLifecycleFinding(ctx context.Context, observation SecurityLifecycleFindingObservation) (*ports.FindingRecord, error) {
@@ -335,4 +369,13 @@ func securityLifecycleDigest(values ...string) string {
 		_, _ = hash.Write([]byte{0})
 	}
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func firstString(values []string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/internal/findings/security_lifecycle_bridge_test.go
+++ b/internal/findings/security_lifecycle_bridge_test.go
@@ -96,6 +96,14 @@ func TestSecurityLifecycleFindingBridgeRequiresRealRuntimeAndVerifiedClosure(t *
 	if got := store.findings[findingURN].Status; got != findingStatusOpen {
 		t.Fatalf("status after incomplete observation = %q, want open", got)
 	}
+	missingProvenance := incomplete
+	missingProvenance.SourceCollectionID = ""
+	missingProvenance.CollectionReceiptID = ""
+	missingProvenance.CollectionReceiptStatus = "complete"
+	missingProvenance.CollectionIncompletenessReasons = nil
+	if _, err := service.ResolveSecurityLifecycleFindingAfterObservation(context.Background(), missingProvenance); err == nil {
+		t.Fatal("ResolveSecurityLifecycleFindingAfterObservation(missing collection provenance) succeeded, want pending refusal")
+	}
 
 	verifiedAt := openedAt.Add(15 * time.Minute)
 	staleFreshness := SecurityLifecycleClosureObservation{

--- a/internal/findings/security_lifecycle_bridge_test.go
+++ b/internal/findings/security_lifecycle_bridge_test.go
@@ -2,7 +2,7 @@ package findings
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"testing"
 	"time"
 
@@ -37,7 +37,7 @@ func TestSecurityLifecycleFindingBridgeRequiresRealRuntimeAndVerifiedClosure(t *
 	).WithAppendLog(appendLog)
 
 	withoutRuntime := lifecycleOpenObservation(tenantID, "", findingURN, subjectURN, openedAt)
-	if _, err := service.RecordSecurityLifecycleFinding(context.Background(), withoutRuntime); err == nil || !strings.Contains(err.Error(), "source runtime id is required") {
+	if _, err := service.RecordSecurityLifecycleFinding(context.Background(), withoutRuntime); !errors.Is(err, ErrInvalidRequest) {
 		t.Fatalf("RecordSecurityLifecycleFinding() without runtime error = %v, want source runtime requirement", err)
 	}
 

--- a/internal/findings/security_lifecycle_bridge_test.go
+++ b/internal/findings/security_lifecycle_bridge_test.go
@@ -1,0 +1,188 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestSecurityLifecycleFindingBridgeRequiresRealRuntimeAndVerifiedClosure(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tenantID   = "tenant-a"
+		runtimeID  = "runtime-lifecycle-source"
+		findingURN = "urn:cerebro:tenant-a:finding:lifecycle-expiry-1"
+		subjectURN = "urn:cerebro:tenant-a:credential:deploy-signing"
+	)
+	openedAt := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{},
+		evidence: map[string]*cerebrov1.FindingEvidence{},
+	}
+	appendLog := &recordingAppendLog{}
+	service := New(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {Id: runtimeID, TenantId: tenantID, SourceId: "lifecycle-source"},
+		}},
+		nil,
+		store,
+		store,
+		store,
+		store,
+	).WithAppendLog(appendLog)
+
+	withoutRuntime := lifecycleOpenObservation(tenantID, "", findingURN, subjectURN, openedAt)
+	if _, err := service.RecordSecurityLifecycleFinding(context.Background(), withoutRuntime); err == nil || !strings.Contains(err.Error(), "source runtime id is required") {
+		t.Fatalf("RecordSecurityLifecycleFinding() without runtime error = %v, want source runtime requirement", err)
+	}
+
+	open := lifecycleOpenObservation(tenantID, runtimeID, findingURN, subjectURN, openedAt)
+	stored, err := service.RecordSecurityLifecycleFinding(context.Background(), open)
+	if err != nil {
+		t.Fatalf("RecordSecurityLifecycleFinding(open) error = %v", err)
+	}
+	if stored.ID != findingURN {
+		t.Fatalf("finding id = %q, want exact resolver urn %q", stored.ID, findingURN)
+	}
+	if stored.RuntimeID != runtimeID {
+		t.Fatalf("runtime id = %q, want resolver provenance %q", stored.RuntimeID, runtimeID)
+	}
+	openFingerprint := stored.Fingerprint
+
+	// A provider execution receipt is supporting evidence only. The resolver
+	// still reports the same policy match, so the durable finding remains open.
+	afterProviderSuccess := open
+	afterProviderSuccess.MaterialRevision = "material-revision-2"
+	afterProviderSuccess.ObservedAt = openedAt.Add(5 * time.Minute)
+	afterProviderSuccess.EvidenceClaimRefs = append(afterProviderSuccess.EvidenceClaimRefs, "urn:cerebro:tenant-a:evidence:provider-execution-success")
+	stored, err = service.RecordSecurityLifecycleFinding(context.Background(), afterProviderSuccess)
+	if err != nil {
+		t.Fatalf("RecordSecurityLifecycleFinding(provider success) error = %v", err)
+	}
+	if stored.Status != findingStatusOpen {
+		t.Fatalf("status after provider success = %q, want open", stored.Status)
+	}
+	if stored.Fingerprint != openFingerprint {
+		t.Fatalf("fingerprint after material rotation = %q, want stable %q", stored.Fingerprint, openFingerprint)
+	}
+
+	incomplete := SecurityLifecycleClosureObservation{
+		FindingURN:                      findingURN,
+		SourceRuntimeID:                 runtimeID,
+		SourceCollectionID:              "collection-incomplete",
+		SubjectURN:                      subjectURN,
+		AuthorityID:                     open.AuthorityID,
+		StableLocator:                   open.StableLocator,
+		PolicyState:                     "compliant",
+		ObservedAt:                      openedAt.Add(10 * time.Minute),
+		FreshnessAsOf:                   openedAt.Add(11 * time.Minute),
+		CoverageComplete:                true,
+		CoverageTruncated:               false,
+		CollectionReceiptTenantID:       tenantID,
+		CollectionReceiptRuntimeID:      runtimeID,
+		CollectionReceiptID:             "collection-incomplete",
+		CollectionReceiptStatus:         "incomplete",
+		CollectionReceiptCompletedAt:    openedAt.Add(11 * time.Minute),
+		CollectionIncompletenessReasons: []string{"page_limit_reached"},
+	}
+	if _, err := service.ResolveSecurityLifecycleFindingAfterObservation(context.Background(), incomplete); err == nil {
+		t.Fatal("ResolveSecurityLifecycleFindingAfterObservation(incomplete receipt) succeeded, want refusal")
+	}
+	if got := store.findings[findingURN].Status; got != findingStatusOpen {
+		t.Fatalf("status after incomplete observation = %q, want open", got)
+	}
+
+	verifiedAt := openedAt.Add(15 * time.Minute)
+	staleFreshness := SecurityLifecycleClosureObservation{
+		FindingURN:                   findingURN,
+		SourceRuntimeID:              runtimeID,
+		SourceCollectionID:           "collection-stale-freshness",
+		SubjectURN:                   subjectURN,
+		AuthorityID:                  open.AuthorityID,
+		StableLocator:                open.StableLocator,
+		PolicyState:                  "compliant",
+		ObservedAt:                   verifiedAt,
+		FreshnessAsOf:                verifiedAt.Add(-time.Second),
+		CoverageComplete:             true,
+		CollectionReceiptTenantID:    tenantID,
+		CollectionReceiptRuntimeID:   runtimeID,
+		CollectionReceiptID:          "collection-stale-freshness",
+		CollectionReceiptStatus:      "complete",
+		CollectionReceiptCompletedAt: verifiedAt.Add(time.Minute),
+	}
+	if _, err := service.ResolveSecurityLifecycleFindingAfterObservation(context.Background(), staleFreshness); err == nil {
+		t.Fatal("ResolveSecurityLifecycleFindingAfterObservation(stale freshness) succeeded, want refusal")
+	}
+
+	resolved, err := service.ResolveSecurityLifecycleFindingAfterObservation(context.Background(), SecurityLifecycleClosureObservation{
+		FindingURN:                   findingURN,
+		SourceRuntimeID:              runtimeID,
+		SourceCollectionID:           "collection-verified",
+		SubjectURN:                   subjectURN,
+		AuthorityID:                  open.AuthorityID,
+		StableLocator:                open.StableLocator,
+		PolicyState:                  "compliant",
+		ObservedAt:                   verifiedAt,
+		FreshnessAsOf:                verifiedAt.Add(time.Minute),
+		CoverageComplete:             true,
+		CollectionReceiptTenantID:    tenantID,
+		CollectionReceiptRuntimeID:   runtimeID,
+		CollectionReceiptID:          "collection-verified",
+		CollectionReceiptStatus:      "complete",
+		CollectionReceiptCompletedAt: verifiedAt.Add(time.Minute),
+		EvidenceClaimRefs:            []string{"urn:cerebro:tenant-a:evidence:independent-observation"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveSecurityLifecycleFindingAfterObservation(verified) error = %v", err)
+	}
+	if resolved.Status != findingStatusResolved {
+		t.Fatalf("verified status = %q, want resolved", resolved.Status)
+	}
+	if !resolved.StatusUpdatedAt.Equal(verifiedAt) {
+		t.Fatalf("status updated at = %s, want observation time %s", resolved.StatusUpdatedAt, verifiedAt)
+	}
+
+	evidence, err := service.ListEvidence(context.Background(), ListEvidenceRequest{
+		RuntimeID: runtimeID,
+		FindingID: findingURN,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListEvidence(exact finding) error = %v", err)
+	}
+	if got := len(evidence.Evidence); got != 3 {
+		t.Fatalf("exact finding evidence rows = %d, want open, provider, and verification observations", got)
+	}
+	if got := len(appendLog.events); got != 3 {
+		t.Fatalf("workflow events = %d, want two recorded and one verified status event", got)
+	}
+}
+
+func lifecycleOpenObservation(tenantID, runtimeID, findingURN, subjectURN string, observedAt time.Time) SecurityLifecycleFindingObservation {
+	return SecurityLifecycleFindingObservation{
+		TenantID:           tenantID,
+		FindingURN:         findingURN,
+		SourceRuntimeID:    runtimeID,
+		SourceCollectionID: "collection-open",
+		SubjectURN:         subjectURN,
+		SubjectKind:        "credential",
+		AuthorityID:        "authority-prod",
+		StableLocator:      "deploy/signing",
+		MaterialRevision:   "material-revision-1",
+		Provider:           "provider-a",
+		DisplayName:        "Deploy signing credential",
+		ObservedState:      "active",
+		PolicyState:        "expiring",
+		PolicyID:           "credential-expiry-30d",
+		PolicyVersion:      "v1",
+		ObservedAt:         observedAt,
+		ExpiresAt:          observedAt.Add(7 * 24 * time.Hour),
+		GraphRevision:      42,
+		EvidenceClaimRefs:  []string{"urn:cerebro:tenant-a:evidence:lifecycle-observation"},
+	}
+}

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -10,7 +10,12 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-const EventAttributeSourceRuntimeID = "source_runtime_id"
+const (
+	EventAttributeSourceRuntimeID = "source_runtime_id"
+	// EventAttributeSourceCollectionID joins every normalized event from one
+	// sync to the final durable SourceCollectionManifest for that exact sync.
+	EventAttributeSourceCollectionID = "source_collection_id"
+)
 const EventAttributeJobID = "job_id"
 
 var ErrAppendLogDeadLetterNotFound = errors.New("append log dead letter not found")

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -86,7 +86,7 @@ type SourceCollectionRecorder interface {
 // SourceCollectionReader loads the exact durable final manifest used to prove
 // collection completeness. Missing receipts are not inferred from graph state.
 type SourceCollectionReader interface {
-	GetSourceCollection(context.Context, string, string, string) (SourceCollectionManifest, error)
+	GetSourceCollection(ctx context.Context, tenantID, runtimeID, collectionID string) (SourceCollectionManifest, error)
 }
 
 // SourceRuntimePageLedgerStore durably records page commit state and outbox

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -83,6 +83,12 @@ type SourceCollectionRecorder interface {
 	RecordSourceCollection(context.Context, SourceCollectionManifest) error
 }
 
+// SourceCollectionReader loads the exact durable final manifest used to prove
+// collection completeness. Missing receipts are not inferred from graph state.
+type SourceCollectionReader interface {
+	GetSourceCollection(context.Context, string, string, string) (SourceCollectionManifest, error)
+}
+
 // SourceRuntimePageLedgerStore durably records page commit state and outbox
 // events. CommitSourceRuntimePage must atomically persist runtime progress and
 // mark the page committed.

--- a/internal/securitylifecyclefindings/reconciler.go
+++ b/internal/securitylifecyclefindings/reconciler.go
@@ -1,0 +1,333 @@
+package securitylifecyclefindings
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcehttp/organizationalgraph"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	ErrDependency      = errors.New("security lifecycle verification dependency failed")
+	ErrTenantForbidden = errors.New("security lifecycle finding belongs to another tenant")
+)
+
+type QueryReader interface {
+	ListSecurityLifecycle(context.Context, *cerebrov1.SecurityLifecycleQuery) (*cerebrov1.SecurityLifecycleQueryResult, error)
+	ResolveSecurityLifecycleFinding(context.Context, string, string) (*cerebrov1.ResolveSecurityLifecycleFindingResponse, error)
+}
+
+type Result struct {
+	FindingID    string
+	Status       string
+	Verification string
+	Reason       string
+	Pending      bool
+	Changed      bool
+}
+
+type Reconciler struct {
+	findings *findings.Service
+	queries  QueryReader
+	receipts ports.SourceCollectionReader
+}
+
+func New(findingsService *findings.Service, queries QueryReader, receipts ports.SourceCollectionReader) *Reconciler {
+	return &Reconciler{findings: findingsService, queries: queries, receipts: receipts}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, tenantID, findingID string) (Result, error) {
+	tenantID = strings.TrimSpace(tenantID)
+	findingID = strings.TrimSpace(findingID)
+	if r == nil || r.queries == nil {
+		return Result{}, fmt.Errorf("%w: lifecycle query reader is unavailable", ErrDependency)
+	}
+	if tenantID == "" || findingID == "" {
+		return Result{}, fmt.Errorf("%w: tenant and finding are required", findings.ErrInvalidRequest)
+	}
+	resolved, err := r.queries.ResolveSecurityLifecycleFinding(ctx, tenantID, findingID)
+	if err == nil {
+		observation, mapErr := ObservationFromResolved(tenantID, findingID, resolved)
+		if mapErr != nil {
+			return Result{}, mapErr
+		}
+		finding, recordErr := r.findings.RecordSecurityLifecycleFinding(ctx, observation)
+		if recordErr != nil {
+			return Result{}, recordErr
+		}
+		result := Result{
+			FindingID:    finding.ID,
+			Status:       finding.Status,
+			Verification: "source_collection_linked",
+			Changed:      true,
+		}
+		if observation.SourceCollectionID == "" {
+			result.Verification = "provenance_pending"
+			result.Reason = "The current lifecycle row does not identify its final source collection. A later source sync is required before verified closure."
+		}
+		return result, nil
+	}
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		return Result{}, fmt.Errorf("%w: resolve open lifecycle finding: %w", ErrDependency, err)
+	}
+	return r.reconcileClosed(ctx, tenantID, findingID)
+}
+
+func (r *Reconciler) reconcileClosed(ctx context.Context, tenantID, findingID string) (Result, error) {
+	current, err := r.findings.GetFinding(ctx, findingID)
+	if err != nil {
+		return Result{}, err
+	}
+	if current.TenantID != tenantID {
+		return Result{}, ErrTenantForbidden
+	}
+	locator, ok := findings.SecurityLifecycleLocatorForFinding(current)
+	if !ok {
+		return Result{}, fmt.Errorf("%w: finding is not a projected security lifecycle finding", findings.ErrInvalidRequest)
+	}
+	subjectKind, ok := lifecycleSubjectKind(locator.SubjectKind)
+	if !ok {
+		return pendingResult(findingID, "subject_locator_unavailable", "The stored lifecycle finding does not contain a recognized subject kind. Run a fresh source sync."), nil
+	}
+	result, err := r.queries.ListSecurityLifecycle(ctx, &cerebrov1.SecurityLifecycleQuery{
+		TenantId: tenantID,
+		Limit:    2,
+		SubjectLocator: &cerebrov1.SecurityLifecycleSubjectLocator{
+			SubjectKind:   subjectKind,
+			AuthorityId:   locator.AuthorityID,
+			StableLocator: locator.StableLocator,
+		},
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: read exact lifecycle subject: %w", ErrDependency, err)
+	}
+	if len(result.GetRecords()) != 1 {
+		return pendingResult(findingID, "exact_observation_unavailable", "The exact lifecycle subject does not have one current observation. Run a fresh source sync before retrying verification."), nil
+	}
+	record := result.GetRecords()[0]
+	observation := record.GetObservation()
+	if observation == nil ||
+		observation.GetSubjectRef().GetId() != locator.SubjectURN ||
+		observation.GetAuthorityId() != locator.AuthorityID ||
+		observation.GetStableLocator() != locator.StableLocator ||
+		observation.GetSubjectKind() != subjectKind {
+		return pendingResult(findingID, "subject_identity_mismatch", "The current lifecycle observation does not match the finding subject. The finding remains open."), nil
+	}
+	if strings.TrimSpace(record.GetSourceRuntimeId()) == "" || strings.TrimSpace(record.GetSourceCollectionId()) == "" {
+		return pendingResult(findingID, "provenance_pending", "The current lifecycle row does not identify its source runtime and final collection. The finding remains open."), nil
+	}
+	if record.GetSourceRuntimeId() != locator.SourceRuntimeID {
+		return pendingResult(findingID, "runtime_mismatch", "The current lifecycle observation came from a different source runtime. The finding remains open."), nil
+	}
+	evaluation, ok := lifecyclePolicyEvaluation(record, locator.PolicyID)
+	if !ok {
+		return pendingResult(findingID, "policy_observation_unavailable", "The current lifecycle row does not contain the finding policy evaluation. The finding remains open."), nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(evaluation.GetState()), "compliant") {
+		return pendingResult(findingID, "policy_still_matches", "The current lifecycle policy is not compliant. Provider execution alone does not close this finding."), nil
+	}
+	metadata := result.GetMetadata()
+	coverage := metadata.GetCoverage()
+	freshness := metadata.GetFreshness()
+	if metadata == nil || coverage == nil || freshness == nil ||
+		!coverage.GetComplete() || coverage.GetTruncated() || metadata.GetPageTruncated() {
+		return pendingResult(findingID, "source_coverage_incomplete", "The exact lifecycle read is incomplete or truncated. The finding remains open until a complete source observation is available."), nil
+	}
+	if r.receipts == nil {
+		return pendingResult(findingID, "collection_receipt_unavailable", "The final source collection receipt is unavailable. The finding remains open."), nil
+	}
+	manifest, err := r.receipts.GetSourceCollection(
+		ctx,
+		tenantID,
+		record.GetSourceRuntimeId(),
+		record.GetSourceCollectionId(),
+	)
+	if errors.Is(err, organizationalgraph.ErrSourceCollectionNotFound) {
+		return pendingResult(findingID, "collection_receipt_pending", "The matching final source collection receipt is not available. The finding remains open."), nil
+	}
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: load exact source collection receipt: %w", ErrDependency, err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(manifest.Status), "complete") || len(manifest.IncompletenessReasons) != 0 {
+		return pendingResult(findingID, "collection_incomplete", "The matching source collection is incomplete. The finding remains open."), nil
+	}
+
+	updated, err := r.findings.ResolveSecurityLifecycleFindingAfterObservation(ctx, findings.SecurityLifecycleClosureObservation{
+		FindingURN:                      findingID,
+		SourceRuntimeID:                 record.GetSourceRuntimeId(),
+		SourceCollectionID:              record.GetSourceCollectionId(),
+		SubjectURN:                      observation.GetSubjectRef().GetId(),
+		AuthorityID:                     observation.GetAuthorityId(),
+		StableLocator:                   observation.GetStableLocator(),
+		PolicyState:                     evaluation.GetState(),
+		ObservedAt:                      timestampTime(observation.GetObservedAt()),
+		FreshnessAsOf:                   timestampTime(freshness.GetAsOf()),
+		CoverageComplete:                coverage.GetComplete(),
+		CoverageTruncated:               coverage.GetTruncated(),
+		PageTruncated:                   metadata.GetPageTruncated(),
+		CollectionReceiptTenantID:       manifest.TenantID,
+		CollectionReceiptRuntimeID:      manifest.RuntimeID,
+		CollectionReceiptID:             manifest.CollectionID,
+		CollectionReceiptStatus:         manifest.Status,
+		CollectionReceiptCompletedAt:    time.UnixMilli(manifest.CompletedAtUnixMS).UTC(),
+		CollectionIncompletenessReasons: append([]string(nil), manifest.IncompletenessReasons...),
+		EvidenceClaimRefs:               lifecycleEvidenceRefs(observation, evaluation, nil),
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		FindingID:    updated.ID,
+		Status:       updated.Status,
+		Verification: "verified_closed",
+		Reason:       "A later complete source collection observed the exact subject as compliant.",
+		Changed:      true,
+	}, nil
+}
+
+func ObservationFromResolved(tenantID, findingID string, resolved *cerebrov1.ResolveSecurityLifecycleFindingResponse) (findings.SecurityLifecycleFindingObservation, error) {
+	if resolved == nil || resolved.GetRecord() == nil {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the record", findings.ErrInvalidRequest)
+	}
+	record := resolved.GetRecord()
+	if resolved.GetGraphRevision() == 0 {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the durable graph revision", findings.ErrInvalidRequest)
+	}
+	if strings.TrimSpace(record.GetSourceRuntimeId()) == "" ||
+		record.GetSourceRuntimeId() != resolved.GetSourceRuntimeId() ||
+		record.GetSourceCollectionId() != resolved.GetSourceCollectionId() {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver provenance aliases do not match the record", findings.ErrInvalidRequest)
+	}
+	observation := record.GetObservation()
+	if observation == nil || observation.GetSubjectRef() == nil {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver omitted the observation subject", findings.ErrInvalidRequest)
+	}
+	var binding *cerebrov1.SecurityLifecycleFindingBinding
+	for _, candidate := range record.GetFindings() {
+		if candidate.GetFindingRef().GetId() == findingID {
+			if binding != nil {
+				return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver returned duplicate finding bindings", findings.ErrInvalidRequest)
+			}
+			binding = candidate
+		}
+	}
+	if binding == nil || !strings.EqualFold(strings.TrimSpace(binding.GetStatus()), "open") ||
+		binding.GetSubjectRef().GetId() != observation.GetSubjectRef().GetId() {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver did not return the requested open finding binding", findings.ErrInvalidRequest)
+	}
+	if len(record.GetPolicyEvaluations()) != 1 {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver did not return one exact policy evaluation", findings.ErrInvalidRequest)
+	}
+	evaluation := record.GetPolicyEvaluations()[0]
+	if evaluation.GetSubjectRef().GetId() != observation.GetSubjectRef().GetId() {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle policy evaluation subject does not match the observation", findings.ErrInvalidRequest)
+	}
+	subjectKind, ok := lifecycleSubjectKindName(observation.GetSubjectKind())
+	if !ok {
+		return findings.SecurityLifecycleFindingObservation{}, fmt.Errorf("%w: lifecycle resolver returned an unsupported subject kind", findings.ErrInvalidRequest)
+	}
+	return findings.SecurityLifecycleFindingObservation{
+		TenantID:           tenantID,
+		FindingURN:         findingID,
+		SourceRuntimeID:    record.GetSourceRuntimeId(),
+		SourceCollectionID: record.GetSourceCollectionId(),
+		SubjectURN:         observation.GetSubjectRef().GetId(),
+		SubjectKind:        subjectKind,
+		AuthorityID:        observation.GetAuthorityId(),
+		StableLocator:      observation.GetStableLocator(),
+		MaterialRevision:   observation.GetSubjectRef().GetRevision(),
+		Provider:           observation.GetProvider(),
+		DisplayName:        observation.GetDisplayName(),
+		OwnerURN:           observation.GetOwnerUrn(),
+		ObservedState:      lifecycleStateName(observation.GetState()),
+		PolicyState:        evaluation.GetState(),
+		PolicyID:           evaluation.GetPolicyId(),
+		PolicyVersion:      evaluation.GetPolicyVersion(),
+		ObservedAt:         timestampTime(observation.GetObservedAt()),
+		ExpiresAt:          timestampTime(observation.GetExpiresAt()),
+		GraphRevision:      resolved.GetGraphRevision(),
+		EvidenceClaimRefs:  lifecycleEvidenceRefs(observation, evaluation, binding),
+	}, nil
+}
+
+func lifecyclePolicyEvaluation(record *cerebrov1.SecurityLifecycleRecord, policyID string) (*cerebrov1.SecurityLifecyclePolicyEvaluation, bool) {
+	var matched *cerebrov1.SecurityLifecyclePolicyEvaluation
+	for _, evaluation := range record.GetPolicyEvaluations() {
+		if strings.TrimSpace(evaluation.GetPolicyId()) != strings.TrimSpace(policyID) {
+			continue
+		}
+		if matched != nil {
+			return nil, false
+		}
+		matched = evaluation
+	}
+	return matched, matched != nil
+}
+
+func lifecycleEvidenceRefs(observation *cerebrov1.SecurityLifecycleObservation, evaluation *cerebrov1.SecurityLifecyclePolicyEvaluation, binding *cerebrov1.SecurityLifecycleFindingBinding) []string {
+	refs := make([]string, 0)
+	appendRefs := func(values []*cerebrov1.ResourceRef) {
+		for _, ref := range values {
+			if value := strings.TrimSpace(ref.GetId()); value != "" {
+				refs = append(refs, value)
+			}
+		}
+	}
+	appendRefs(observation.GetEvidenceClaimRefs())
+	appendRefs(evaluation.GetEvidenceClaimRefs())
+	if binding != nil {
+		appendRefs(binding.GetEvidenceClaimRefs())
+	}
+	return refs
+}
+
+func lifecycleSubjectKind(value string) (cerebrov1.SecurityLifecycleSubjectKind, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "credential":
+		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL, true
+	case "certificate":
+		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CERTIFICATE, true
+	default:
+		return cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_UNSPECIFIED, false
+	}
+}
+
+func lifecycleSubjectKindName(value cerebrov1.SecurityLifecycleSubjectKind) (string, bool) {
+	switch value {
+	case cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL:
+		return "credential", true
+	case cerebrov1.SecurityLifecycleSubjectKind_SECURITY_LIFECYCLE_SUBJECT_KIND_CERTIFICATE:
+		return "certificate", true
+	default:
+		return "", false
+	}
+}
+
+func lifecycleStateName(value cerebrov1.SecurityLifecycleState) string {
+	return strings.ToLower(strings.TrimPrefix(value.String(), "SECURITY_LIFECYCLE_STATE_"))
+}
+
+func timestampTime(value *timestamppb.Timestamp) time.Time {
+	if value == nil || value.CheckValid() != nil {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
+}
+
+func pendingResult(findingID, verification, reason string) Result {
+	return Result{
+		FindingID:    findingID,
+		Status:       "open",
+		Verification: verification,
+		Reason:       reason,
+		Pending:      true,
+	}
+}

--- a/internal/sourcehttp/organizationalgraph/projection.go
+++ b/internal/sourcehttp/organizationalgraph/projection.go
@@ -23,7 +23,10 @@ const (
 	projectionAuthorityRust   = "rust"
 )
 
-var ErrSourceCollectionNotFound = errors.New("source collection receipt not found")
+var (
+	ErrSourceCollectionNotFound           = errors.New("source collection receipt not found")
+	ErrSourceCollectionProvenanceMismatch = errors.New("source collection receipt provenance mismatch")
+)
 
 // ProjectionClient talks only to the Rust projection authority boundary.
 type ProjectionClient struct {
@@ -359,7 +362,7 @@ func (c *ProjectionClient) GetSourceCollection(ctx context.Context, tenantID, ru
 	if strings.TrimSpace(decoded.TenantID) != tenantID ||
 		strings.TrimSpace(decoded.SourceRuntimeID) != runtimeID ||
 		strings.TrimSpace(decoded.CollectionID) != collectionID {
-		return manifest, errors.New("rust source collection response provenance does not match the requested tenant, runtime, and collection")
+		return manifest, fmt.Errorf("%w: response does not match the requested tenant, runtime, and collection", ErrSourceCollectionProvenanceMismatch)
 	}
 	return ports.SourceCollectionManifest{
 		CollectionID:          decoded.CollectionID,

--- a/internal/sourcehttp/organizationalgraph/projection.go
+++ b/internal/sourcehttp/organizationalgraph/projection.go
@@ -23,6 +23,8 @@ const (
 	projectionAuthorityRust   = "rust"
 )
 
+var ErrSourceCollectionNotFound = errors.New("source collection receipt not found")
+
 // ProjectionClient talks only to the Rust projection authority boundary.
 type ProjectionClient struct {
 	baseURL string
@@ -163,6 +165,8 @@ type sourceCollectionResponse struct {
 	ManifestDigest string `json:"manifest_digest"`
 }
 
+type sourceCollectionManifestResponse = sourceCollectionRequest
+
 type authorityResponse struct {
 	Authority string `json:"authority"`
 }
@@ -302,6 +306,79 @@ func (c *ProjectionClient) recordSourceCollection(ctx context.Context, manifest 
 		return errors.New("rust source collection receipt was not committed")
 	}
 	return nil
+}
+
+// GetSourceCollection loads one exact final collection manifest from the Rust
+// projection ledger. It does not infer completeness from graph coverage.
+func (c *ProjectionClient) GetSourceCollection(ctx context.Context, tenantID, runtimeID, collectionID string) (manifest ports.SourceCollectionManifest, err error) {
+	tenantID = strings.TrimSpace(tenantID)
+	runtimeID = strings.TrimSpace(runtimeID)
+	collectionID = strings.TrimSpace(collectionID)
+	if tenantID == "" || runtimeID == "" || collectionID == "" {
+		return manifest, errors.New("tenant id, source runtime id, and source collection id are required")
+	}
+	query := url.Values{
+		"tenant_id":         {tenantID},
+		"source_runtime_id": {runtimeID},
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		c.baseURL+"/v1/projections/collections/"+url.PathEscape(collectionID)+"?"+query.Encode(),
+		nil,
+	)
+	if err != nil {
+		return manifest, fmt.Errorf("build Rust source collection read: %w", err)
+	}
+	if err := c.auth.authorize(request, tenantID); err != nil {
+		return manifest, err
+	}
+	// #nosec G704 -- NewProjectionClient validates and freezes the HTTP(S)
+	// origin; the collection ID is one escaped path segment.
+	response, err := c.client.Do(request)
+	if err != nil {
+		return manifest, fmt.Errorf("call Rust projection: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, response.Body.Close())
+	}()
+	if response.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxResponseBytes))
+		return manifest, ErrSourceCollectionNotFound
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maxResponseBytes))
+		return manifest, fmt.Errorf("rust projection returned %s", response.Status)
+	}
+	var decoded sourceCollectionManifestResponse
+	decoder := json.NewDecoder(io.LimitReader(response.Body, maxResponseBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&decoded); err != nil {
+		return manifest, fmt.Errorf("decode Rust source collection response: %w", err)
+	}
+	if strings.TrimSpace(decoded.TenantID) != tenantID ||
+		strings.TrimSpace(decoded.SourceRuntimeID) != runtimeID ||
+		strings.TrimSpace(decoded.CollectionID) != collectionID {
+		return manifest, errors.New("rust source collection response provenance does not match the requested tenant, runtime, and collection")
+	}
+	return ports.SourceCollectionManifest{
+		CollectionID:          decoded.CollectionID,
+		TenantID:              decoded.TenantID,
+		SourceID:              decoded.SourceID,
+		RuntimeID:             decoded.SourceRuntimeID,
+		StartedAtUnixMS:       decoded.StartedAtUnixMS,
+		CompletedAtUnixMS:     decoded.CompletedAtUnixMS,
+		Status:                decoded.Status,
+		IncompletenessReasons: append([]string(nil), decoded.IncompletenessReasons...),
+		ExpectedFamilyIDs:     append([]string(nil), decoded.ExpectedFamilyIDs...),
+		ObservedFamilyIDs:     append([]string(nil), decoded.ObservedFamilyIDs...),
+		PagesRead:             decoded.PagesRead,
+		RecordsScanned:        decoded.RecordsScanned,
+		RecordsAccepted:       decoded.RecordsAccepted,
+		RecordsRejected:       decoded.RecordsRejected,
+		EntitiesProjected:     decoded.EntitiesProjected,
+		LinksProjected:        decoded.LinksProjected,
+	}, nil
 }
 
 func (c *ProjectionClient) authority(ctx context.Context, event *cerebrov1.EventEnvelope) (string, error) {

--- a/internal/sourcehttp/organizationalgraph/projection_test.go
+++ b/internal/sourcehttp/organizationalgraph/projection_test.go
@@ -206,6 +206,118 @@ func TestAppendLogProjectorRecordsCollectionManifest(t *testing.T) {
 	}
 }
 
+func TestProjectionClientReadsExactSourceCollectionManifest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet ||
+			r.URL.Path != "/v1/projections/collections/collection-verified" ||
+			r.URL.Query().Get("tenant_id") != "tenant-a" ||
+			r.URL.Query().Get("source_runtime_id") != "box-runtime" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get(tenantAuthHeader) != "tenant-a" {
+			t.Fatalf("tenant authentication header = %q, want tenant-a", r.Header.Get(tenantAuthHeader))
+		}
+		_ = json.NewEncoder(w).Encode(sourceCollectionManifestResponse{
+			CollectionID:          "collection-verified",
+			TenantID:              "tenant-a",
+			SourceID:              "box",
+			SourceRuntimeID:       "box-runtime",
+			StartedAtUnixMS:       100,
+			CompletedAtUnixMS:     200,
+			Status:                "complete",
+			IncompletenessReasons: []string{},
+			ExpectedFamilyIDs:     []string{"content_assets"},
+			ObservedFamilyIDs:     []string{"content_assets"},
+			PagesRead:             1,
+			RecordsScanned:        1,
+			RecordsAccepted:       1,
+		})
+	}))
+	defer server.Close()
+	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
+	manifest, err := client.GetSourceCollection(context.Background(), "tenant-a", "box-runtime", "collection-verified")
+	if err != nil {
+		t.Fatalf("GetSourceCollection() error = %v", err)
+	}
+	if manifest.CollectionID != "collection-verified" ||
+		manifest.TenantID != "tenant-a" ||
+		manifest.RuntimeID != "box-runtime" ||
+		manifest.Status != "complete" ||
+		manifest.CompletedAtUnixMS != 200 {
+		t.Fatalf("GetSourceCollection() = %#v", manifest)
+	}
+}
+
+func TestProjectionClientReportsMissingSourceCollection(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
+	_, err = client.GetSourceCollection(context.Background(), "tenant-a", "box-runtime", "collection-missing")
+	if !errors.Is(err, ErrSourceCollectionNotFound) {
+		t.Fatalf("GetSourceCollection() error = %v, want ErrSourceCollectionNotFound", err)
+	}
+}
+
+func TestProjectionClientScopesSourceCollectionLookupByTenantAndRuntime(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("tenant_id") != "tenant-a" ||
+			r.URL.Query().Get("source_runtime_id") != "runtime-a" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(sourceCollectionManifestResponse{
+			CollectionID:    "collection-shared",
+			TenantID:        "tenant-a",
+			SourceRuntimeID: "runtime-a",
+			Status:          "complete",
+		})
+	}))
+	defer server.Close()
+	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
+	for _, scope := range []struct {
+		tenantID string
+		runtime  string
+	}{
+		{tenantID: "tenant-b", runtime: "runtime-a"},
+		{tenantID: "tenant-a", runtime: "runtime-b"},
+	} {
+		_, err := client.GetSourceCollection(context.Background(), scope.tenantID, scope.runtime, "collection-shared")
+		if !errors.Is(err, ErrSourceCollectionNotFound) {
+			t.Fatalf("GetSourceCollection(%q, %q) error = %v, want ErrSourceCollectionNotFound", scope.tenantID, scope.runtime, err)
+		}
+	}
+}
+
+func TestProjectionClientRejectsMismatchedSourceCollectionProvenance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(sourceCollectionManifestResponse{
+			CollectionID:    "collection-verified",
+			TenantID:        "tenant-a",
+			SourceRuntimeID: "other-runtime",
+			Status:          "complete",
+		})
+	}))
+	defer server.Close()
+	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
+	_, err = client.GetSourceCollection(context.Background(), "tenant-a", "box-runtime", "collection-verified")
+	if err == nil || !strings.Contains(err.Error(), "provenance does not match") {
+		t.Fatalf("GetSourceCollection() error = %v, want provenance mismatch", err)
+	}
+}
+
 func TestLegacyWriteGuardSuppressesGoAfterPromotion(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(authorityResponse{Authority: projectionAuthorityRust})

--- a/internal/sourcehttp/organizationalgraph/projection_test.go
+++ b/internal/sourcehttp/organizationalgraph/projection_test.go
@@ -313,7 +313,7 @@ func TestProjectionClientRejectsMismatchedSourceCollectionProvenance(t *testing.
 		t.Fatalf("NewProjectionClient() error = %v", err)
 	}
 	_, err = client.GetSourceCollection(context.Background(), "tenant-a", "box-runtime", "collection-verified")
-	if err == nil || !strings.Contains(err.Error(), "provenance does not match") {
+	if !errors.Is(err, ErrSourceCollectionProvenanceMismatch) {
 		t.Fatalf("GetSourceCollection() error = %v, want provenance mismatch", err)
 	}
 }

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -414,6 +414,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	contractConfigured = len(eventContracts) > 0
 	sourceConfig := sourcecdk.NewConfig(runtimeConfig)
 	originalCheckpoint := cloneCheckpoint(runtime.GetCheckpoint())
+	collectionID := sourceRuntimeCollectionID(runtime.GetId(), started)
 	for i := uint32(0); i < pageLimit; i++ {
 		pull, err := readSourcePull(ctx, source, sourceConfig, cursor, originalCheckpoint)
 		if err != nil {
@@ -431,7 +432,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		eventsRead := boundedUint32(len(pull.Events))
 		materializedEvents := make([]*cerebrov1.EventEnvelope, 0, len(pull.Events))
 		for _, event := range pull.Events {
-			syncedEvent := materializeEvent(runtime, event)
+			syncedEvent := materializeEvent(runtime, collectionID, event)
 			if syncedEvent == nil {
 				continue
 			}
@@ -694,7 +695,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			collectionStatus = "incomplete"
 		}
 		if err := recorder.RecordSourceCollection(ctx, ports.SourceCollectionManifest{
-			CollectionID:          sourceRuntimeCollectionID(runtime.GetId(), started),
+			CollectionID:          collectionID,
 			TenantID:              strings.TrimSpace(runtime.GetTenantId()),
 			SourceID:              strings.TrimSpace(runtime.GetSourceId()),
 			RuntimeID:             strings.TrimSpace(runtime.GetId()),
@@ -1388,7 +1389,7 @@ func boundedUint32(value int) uint32 {
 	return uint32(value)
 }
 
-func materializeEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) *cerebrov1.EventEnvelope {
+func materializeEvent(runtime *cerebrov1.SourceRuntime, collectionID string, event *cerebrov1.EventEnvelope) *cerebrov1.EventEnvelope {
 	if event == nil {
 		return nil
 	}
@@ -1403,9 +1404,13 @@ func materializeEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEn
 		if cloned.Attributes == nil {
 			cloned.Attributes = make(map[string]string)
 		}
-		if strings.TrimSpace(cloned.Attributes[ports.EventAttributeSourceRuntimeID]) == "" {
-			cloned.Attributes[ports.EventAttributeSourceRuntimeID] = strings.TrimSpace(runtime.GetId())
+		cloned.Attributes[ports.EventAttributeSourceRuntimeID] = strings.TrimSpace(runtime.GetId())
+	}
+	if collectionID = strings.TrimSpace(collectionID); collectionID != "" {
+		if cloned.Attributes == nil {
+			cloned.Attributes = make(map[string]string)
 		}
+		cloned.Attributes[ports.EventAttributeSourceCollectionID] = collectionID
 	}
 	return cloned
 }

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1376,6 +1376,9 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	if got := log.events[0].GetAttributes()[ports.EventAttributeSourceRuntimeID]; got != "writer-github" {
 		t.Fatalf("appended event source_runtime_id = %q, want %q", got, "writer-github")
 	}
+	if got := log.events[0].GetAttributes()[ports.EventAttributeSourceCollectionID]; got == "" {
+		t.Fatal("appended event source_collection_id is empty")
+	}
 	if got := log.events[0].GetAttributes()["trace_id"]; got != "" {
 		t.Fatalf("appended event trace_id = %q, want omitted", got)
 	}
@@ -1394,6 +1397,64 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	}
 	if store.putCount != 1 {
 		t.Fatalf("PutSourceRuntime calls = %d, want 1", store.putCount)
+	}
+}
+
+func TestMaterializeEventPinsSyncCollectionProvenance(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 7, 27, 10, 30, 0, 0, time.UTC)
+	collectionID := sourceRuntimeCollectionID("runtime-authority", started)
+	event := &cerebrov1.EventEnvelope{
+		Attributes: map[string]string{
+			ports.EventAttributeSourceRuntimeID:    "provider-runtime",
+			ports.EventAttributeSourceCollectionID: "provider-collection",
+		},
+	}
+	materialized := materializeEvent(&cerebrov1.SourceRuntime{
+		Id:       "runtime-authority",
+		TenantId: "tenant-a",
+	}, collectionID, event)
+	if got := materialized.GetAttributes()[ports.EventAttributeSourceRuntimeID]; got != "runtime-authority" {
+		t.Fatalf("source_runtime_id = %q, want runtime authority", got)
+	}
+	if got := materialized.GetAttributes()[ports.EventAttributeSourceCollectionID]; got != sourceRuntimeCollectionID("runtime-authority", started) {
+		t.Fatalf("source_collection_id = %q, want runtime-owned collection id %q", got, collectionID)
+	}
+	if got := event.GetAttributes()[ports.EventAttributeSourceCollectionID]; got != "provider-collection" {
+		t.Fatalf("input source_collection_id mutated to %q", got)
+	}
+}
+
+func TestSyncRuntimeOverwritesProviderSourceCollectionIDBeforePersistence(t *testing.T) {
+	event := runtimeTestEvent("spoofed-collection-event", "reserved_collection", "reserved_collection.event")
+	event.Attributes[ports.EventAttributeSourceCollectionID] = "provider-controlled-collection"
+	source := admissionTestSource{id: "reserved_collection", events: []*cerebrov1.EventEnvelope{event}}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-authority": {
+			Id:       "runtime-authority",
+			SourceId: source.id,
+			TenantId: "writer",
+		},
+	}}
+	log := &appendLog{}
+	projector := &projector{}
+	service := New(registry, store, log, projector)
+
+	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-authority"}); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if len(log.events) != 1 || len(projector.manifests) != 1 {
+		t.Fatalf("persisted events/manifests = %d/%d, want 1/1", len(log.events), len(projector.manifests))
+	}
+	got := log.events[0].GetAttributes()[ports.EventAttributeSourceCollectionID]
+	want := projector.manifests[0].CollectionID
+	if got != want || got == "provider-controlled-collection" {
+		t.Fatalf("persisted source_collection_id = %q, want runtime-owned manifest %q", got, want)
 	}
 }
 
@@ -1570,6 +1631,9 @@ func TestSyncRuntimeUsesPageLedgerWhenStoreSupportsIt(t *testing.T) {
 		len(manifest.ObservedFamilyIDs) != 1 ||
 		manifest.ObservedFamilyIDs[0] != "pull_request" {
 		t.Fatalf("collection manifest = %#v", manifest)
+	}
+	if got := log.events[0].GetAttributes()[ports.EventAttributeSourceCollectionID]; got != manifest.CollectionID {
+		t.Fatalf("appended event source_collection_id = %q, want final manifest %q", got, manifest.CollectionID)
 	}
 	if len(store.attempts) != 1 {
 		t.Fatalf("ledger attempts = %d, want 1", len(store.attempts))

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -214,7 +214,7 @@ var errTenantScopedFingerprintBackfillRetry = errors.New("retry tenant-scoped fi
 // every iteration.
 //
 // A resolved row reopens in place on a fresh open emit only when it was auto-resolved by the
-// lifecycle (TTL expiry or a remediation counter-event) or when the rule opts into TTL reopen
+// lifecycle (TTL expiry, a remediation counter-event, or a later verified observation) or when the rule opts into TTL reopen
 // via $37; analyst/manual resolutions keep their stored status so deliberate closures are not
 // reverted. The 'closed_by_counter_event' literal must stay in sync with
 // workflowevents.FindingStatusReasonClosedByCounterEvent.
@@ -238,7 +238,7 @@ DO UPDATE SET
   status = CASE
     WHEN findings.tombstoned THEN findings.status
     WHEN findings.status = 'suppressed' THEN findings.status
-    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT findings.tombstoned AND (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR $37::boolean) THEN EXCLUDED.status
+    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT findings.tombstoned AND (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR (findings.rule_id = 'security-lifecycle-expiry' AND BTRIM(findings.status_reason) = 'verified_by_fresh_complete_observation') OR $37::boolean) THEN EXCLUDED.status
     WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' THEN findings.status
     ELSE EXCLUDED.status
   END,
@@ -280,13 +280,13 @@ DO UPDATE SET
   status_reason = CASE
     WHEN findings.tombstoned THEN findings.status_reason
     WHEN findings.status = 'suppressed' THEN findings.status_reason
-    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR $37::boolean) THEN findings.status_reason
+    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR (findings.rule_id = 'security-lifecycle-expiry' AND BTRIM(findings.status_reason) = 'verified_by_fresh_complete_observation') OR $37::boolean) THEN findings.status_reason
     ELSE EXCLUDED.status_reason
   END,
   status_updated_at = CASE
     WHEN findings.tombstoned THEN findings.status_updated_at
     WHEN findings.status = 'suppressed' THEN findings.status_updated_at
-    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR $37::boolean) THEN findings.status_updated_at
+    WHEN findings.status = 'resolved' AND EXCLUDED.status = 'open' AND NOT (BTRIM(findings.status_reason) LIKE 'ttl_expired:%' OR BTRIM(findings.status_reason) = 'closed_by_counter_event' OR (findings.rule_id = 'security-lifecycle-expiry' AND BTRIM(findings.status_reason) = 'verified_by_fresh_complete_observation') OR $37::boolean) THEN findings.status_updated_at
     ELSE EXCLUDED.status_updated_at
   END,
   first_observed_at = LEAST(findings.first_observed_at, EXCLUDED.first_observed_at),

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -216,8 +216,9 @@ var errTenantScopedFingerprintBackfillRetry = errors.New("retry tenant-scoped fi
 // A resolved row reopens in place on a fresh open emit only when it was auto-resolved by the
 // lifecycle (TTL expiry, a remediation counter-event, or a later verified observation) or when the rule opts into TTL reopen
 // via $37; analyst/manual resolutions keep their stored status so deliberate closures are not
-// reverted. The 'closed_by_counter_event' literal must stay in sync with
-// workflowevents.FindingStatusReasonClosedByCounterEvent.
+// reverted. The auto-resolution reason literals must stay in sync with
+// workflowevents.FindingStatusReasonClosedByCounterEvent and
+// workflowevents.FindingStatusReasonVerifiedObservation.
 const upsertFindingStatement = `
 INSERT INTO findings (
   id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -1088,6 +1088,44 @@ func TestUpsertFinding_ReopensTTLResolvedOnOpenEmit(t *testing.T) {
 	}
 }
 
+func TestUpsertFinding_ReopensVerifiedObservationResolvedOnOpenEmit(t *testing.T) {
+	ctx := context.Background()
+	store := tombstoneStoreFromEnv(t)
+	resetTombstoneSchema(t, ctx, store)
+	ensureTombstoneSchema(t, ctx, store)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	fp := fmt.Sprintf("fp-verified-observation-%d", now.UnixNano())
+	baseID := fmt.Sprintf("finding-verified-observation-%d", now.UnixNano())
+
+	open := newUpsertFinding(baseID, fp, "open", now.Add(-time.Hour))
+	open.RuleID = "security-lifecycle-expiry"
+	if _, err := store.UpsertFinding(ctx, open); err != nil {
+		t.Fatalf("seed finding: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE findings SET status = 'resolved', status_reason = 'verified_by_fresh_complete_observation', status_updated_at = $2 WHERE id = $1`,
+		baseID, now.Add(-30*time.Minute)); err != nil {
+		t.Fatalf("verified observation resolve: %v", err)
+	}
+
+	reemit := newUpsertFinding(baseID, fp, "open", now)
+	reemit.RuleID = "security-lifecycle-expiry"
+	reopened, err := store.UpsertFinding(ctx, reemit)
+	if err != nil {
+		t.Fatalf("verified-observation reopen upsert: %v", err)
+	}
+	if reopened.Status != "open" {
+		t.Fatalf("post-emit status = %q, want open", reopened.Status)
+	}
+	if reopened.StatusReason != "" {
+		t.Fatalf("post-emit status_reason = %q, want empty after reopen", reopened.StatusReason)
+	}
+	if reopened.ID != baseID {
+		t.Fatalf("post-emit id = %q, want %q", reopened.ID, baseID)
+	}
+}
+
 func TestUpsertFinding_ReopensTTLEvidenceRuleResolvedOnOpenEmit(t *testing.T) {
 	ctx := context.Background()
 	store := tombstoneStoreFromEnv(t)

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -40,9 +40,11 @@ const DecisionTrustAuthenticatedPacket = "authenticated_packet_workflow"
 const (
 	FindingStatusReasonNoLongerEmitted      = "No longer emitted by latest rule evaluation."
 	FindingStatusReasonClosedByCounterEvent = "closed_by_counter_event"
+	FindingStatusReasonVerifiedObservation  = "verified_by_fresh_complete_observation"
 	FindingStatusReasonTTLExpired           = "ttl_expired"
 	FindingStatusSourceManual               = "manual"
 	FindingStatusSourceStaleEvaluation      = "stale_rule_evaluation"
+	FindingStatusSourceVerifiedObservation  = "verified_observation"
 )
 
 const (

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -1609,7 +1609,13 @@ func metadataJSON(value map[string]any) string {
 }
 
 func findingURN(tenantID string, findingID string) string {
-	return fmt.Sprintf("urn:cerebro:%s:finding:%s", strings.TrimSpace(tenantID), strings.TrimSpace(findingID))
+	tenantID = strings.TrimSpace(tenantID)
+	findingID = strings.TrimSpace(findingID)
+	canonicalPrefix := fmt.Sprintf("urn:cerebro:%s:finding:", tenantID)
+	if strings.HasPrefix(findingID, canonicalPrefix) {
+		return findingID
+	}
+	return canonicalPrefix + findingID
 }
 
 func findingAnnotationURN(tenantID string, findingID string, noteID string, body string, createdAt string) string {

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -613,6 +613,18 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 }
 
+func TestFindingURNPreservesCanonicalFindingIdentity(t *testing.T) {
+	t.Parallel()
+
+	const canonical = "urn:cerebro:writer:finding:lifecycle-expiry-1"
+	if got := findingURN("writer", canonical); got != canonical {
+		t.Fatalf("findingURN(canonical) = %q, want %q", got, canonical)
+	}
+	if got := findingURN("writer", "finding-1"); got != "urn:cerebro:writer:finding:finding-1" {
+		t.Fatalf("findingURN(local id) = %q, want canonical local finding urn", got)
+	}
+}
+
 func TestProjectFindingRecordedLinksPrimaryResourceWhenResourceURNsEmpty(t *testing.T) {
 	graph := &projectionRecorder{}
 	service := New(graph)

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -5031,6 +5031,14 @@ export type SecurityLifecycleAggregates = {
   subject_kind_counts: ({ count?: number; subject_kind?: "SECURITY_LIFECYCLE_SUBJECT_KIND_CREDENTIAL" | "SECURITY_LIFECYCLE_SUBJECT_KIND_CERTIFICATE" })[];
 };
 
+export type SecurityLifecycleFindingReconcileResponse = {
+  audit_preview_url: string;
+  finding_id: string;
+  reason?: string;
+  status: "open" | "resolved";
+  verification: string;
+};
+
 export type SecurityLifecycleQueryMetadata = {
   coverage: { complete?: boolean; graph_revision?: number; lifecycle_entities?: number; reason?: "SECURITY_LIFECYCLE_COVERAGE_REASON_COMPLETE" | "SECURITY_LIFECYCLE_COVERAGE_REASON_SCAN_LIMIT" | "SECURITY_LIFECYCLE_COVERAGE_REASON_GRAPH_CHANGED"; scanned_entities?: number; truncated?: boolean };
   freshness: { as_of?: string; newest_observed_at?: string; oldest_observed_at?: string };

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -172,7 +172,11 @@ import (
 // Security lifecycle reads add only route/auth/dependency wiring and bounded
 // HTTP request/response mapping over the generated Connect client. Identity,
 // policy, pagination, finding, and verification behavior remain Rust-owned.
-const bootstrapProductionGoLineBudget = 29734
+// Durable lifecycle finding reconciliation adds bounded request decoding,
+// tenant authorization, dependency wiring, response mapping, and cache
+// invalidation. Resolver mapping, receipt verification, and closure decisions
+// remain in internal/securitylifecyclefindings and internal/findings.
+const bootstrapProductionGoLineBudget = 29817
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- bind every source event to its runtime-owned final collection manifest and read receipts by exact tenant, runtime, and collection
- project open Rust lifecycle findings into the existing FindingRecord, evidence, workflow-event, and affects authorities
- reconcile only after the resolver no longer reports the finding open, an exact-subject read is compliant, and a later complete, non-truncated source collection proves it
- expose an authorized reconcile endpoint with exact live audit-preview behavior

## Safety
- provider-supplied runtime and collection attributes are overwritten before append-log persistence
- missing or older provenance, incomplete coverage, truncated reads, absent receipts, and incomplete collections keep the finding open
- provider dispatch or execution success is evidence only and never closes the finding
- records remain metadata-only; no provider command or secret value is persisted

## Validation
- `go test -p 1 ./internal/bootstrap ./internal/securitylifecyclefindings ./internal/findings ./internal/sourcehttp/organizationalgraph ./internal/sourceruntime ./internal/workflowprojection ./internal/statestore/postgres -count=1`
- `golangci-lint run ./internal/bootstrap ./internal/securitylifecyclefindings ./internal/findings ./internal/sourcehttp/organizationalgraph ./internal/sourceruntime ./internal/workflowprojection ./internal/statestore/postgres`
- `make check-structural check-structural-test check-arch openapi-check openapi-lint`
- `go build ./cmd/cerebro`
- `cargo fmt --all -- --check`
- `cargo test -p cerebro-organizational-store source_collection_manifest_lookup_requires_exact_provenance_tuple --lib`
- `cargo check -p cerebro-platform -p cerebro-organizational-store`
- `git diff --check origin/agent/rust-lifecycle-scale...HEAD`

## Stack
- Base includes merged #2082 at `b445deb292b6cc3e62c0b9c5e9f887fe763f05e1`.