### PR TITLE
Serve the Action queue from Rust

### DIFF
--- a/.github/workflows/rust-graph-replacement.yml
+++ b/.github/workflows/rust-graph-replacement.yml
@@ -8,6 +8,7 @@ on:
       - "Makefile"
       - "Cargo.lock"
       - "Cargo.toml"
+      - "crates/action-store/**"
       - "crates/agent-context/**"
       - "crates/cerebro-platform/**"
       - "crates/organizational-graph/**"
@@ -74,6 +75,18 @@ jobs:
             nats --server nats://cerebro-rust-graph-nats:4222 stream add CEREBRO_EVENTS \
               --subjects "events.>" --storage file --retention limits --discard old \
               --replicas 1 --dupe-window 2m --defaults
+
+      - name: Prove the durable Rust Action ledger
+        env:
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          docker run --rm --network cerebro-rust-graph-replacement \
+            -e 'CEREBRO_TEST_POSTGRES_DSN=postgres://cerebro:cerebro@cerebro-rust-graph-postgres:5432/cerebro?sslmode=disable' \
+            --entrypoint /usr/local/bin/action-ledger-live-test \
+            "cerebro-rust-graph-replacement:${CANDIDATE_SHA}" \
+            --ignored --exact durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only \
+            --nocapture
 
       - name: Start the Rust graph service
         env:

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -31,10 +31,20 @@ RUN --mount=type=cache,id=cerebro-rust-only-cargo-registry,target=/usr/local/car
       -p cerebro-sourceruntime-eventadmission --bin cerebro-event-admission-worker \
       -p cerebro-platform --bin cerebro-platform \
       -p cerebro-platform --example organizational_graph_e2e && \
+    cargo test --locked --release -p cerebro-action-store --test live_ledger --no-run && \
+    action_ledger_test="" && \
+    for candidate in /app/target/release/deps/live_ledger-*; do \
+      if [ -f "${candidate}" ] && [ -x "${candidate}" ]; then \
+        action_ledger_test="${candidate}"; \
+        break; \
+      fi; \
+    done && \
+    test -n "${action_ledger_test}" && \
     install -Dm0755 /app/target/release/cerebro-event-admission-worker /out/cerebro-event-admission-worker && \
     install -Dm0755 /app/target/release/cerebro-platform /out/cerebro-platform && \
     install -Dm0755 /app/target/release/examples/organizational_graph_e2e \
-      /out/organizational-graph-e2e
+      /out/organizational-graph-e2e && \
+    install -Dm0755 "${action_ledger_test}" /out/action-ledger-live-test
 
 FROM alpine:3.24 AS organizational-catalog
 COPY --from=source /src/internal/connectorcatalog/catalog /app/internal/connectorcatalog/catalog
@@ -68,6 +78,7 @@ CMD ["serve-neo4j-consumer"]
 
 FROM runtime AS replacement-test-runtime
 COPY --from=builder --chmod=0755 /out/organizational-graph-e2e /usr/local/bin/organizational-graph-e2e
+COPY --from=builder --chmod=0755 /out/action-ledger-live-test /usr/local/bin/action-ledger-live-test
 
 # Keep the default production image free of replacement-test tooling.
 FROM runtime AS final

--- a/apps/web/src/app/actions/[operationID]/page.tsx
+++ b/apps/web/src/app/actions/[operationID]/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMemo } from "react";
+
+import { Badge, ErrorBlock, LoadingBlock, MetricCard, PageHeader, Panel } from "@/components/grc/Primitives";
+import { actionStateLabel, actionTimeLabel, type ActionEvent, type ActionOperation } from "@/lib/actions";
+import { useGRCQuery } from "@/lib/grc-client";
+
+function DetailRow({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="grid gap-1 border-b border-[color:var(--border)] py-2.5 last:border-0 sm:grid-cols-[12rem_1fr]">
+      <dt className="text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">{label}</dt>
+      <dd className={`break-all text-[12px] text-[var(--text-secondary)] ${mono ? "font-mono text-[11px]" : ""}`}>{value}</dd>
+    </div>
+  );
+}
+
+export default function ActionDetailPage() {
+  const params = useParams<{ operationID: string }>();
+  const operationID = typeof params.operationID === "string" ? params.operationID : "";
+  const encodedOperationID = encodeURIComponent(operationID);
+  const actionQuery = useGRCQuery<ActionOperation>(operationID ? `/v1/actions/${encodedOperationID}` : null);
+  const historyQuery = useGRCQuery<ActionEvent[]>(operationID ? `/v1/actions/${encodedOperationID}/history` : null);
+  const action = actionQuery.data;
+  const history = useMemo(() => historyQuery.data ?? [], [historyQuery.data]);
+  const error = actionQuery.error || historyQuery.error;
+
+  if ((actionQuery.loading || historyQuery.loading) && !action) {
+    return <LoadingBlock label="Loading Action authority records..." />;
+  }
+  if (error || !action) {
+    return (
+      <ErrorBlock
+        error={error || "The Action was not returned by the Rust authority."}
+        onRetry={() => {
+          void actionQuery.reload();
+          void historyQuery.reload();
+        }}
+        recoveryDetail="Confirm the operation ID and signed tenant identity, then try again."
+      />
+    );
+  }
+
+  const proposal = action.proposal;
+  const approval = action.approval_receipt;
+  const verification = action.verification_receipt?.receipt;
+
+  return (
+    <div>
+      <PageHeader
+        title={proposal.action_kind.replaceAll("_", " ")}
+        description={`Action ${proposal.operation_id} is bound to finding revision ${proposal.finding_revision_digest.slice(0, 12)} and graph revision ${proposal.graph_revision}.`}
+        contractId="rust-action-detail"
+        action={<Link href="/actions" className="secondary-button px-3 py-2 text-[12px]">Back to Actions</Link>}
+      />
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard label="State" value={actionStateLabel(action.state)} detail={`Version ${action.version}`} intent={action.state === "verified" ? "success" : action.state === "failed" || action.state === "outcome_unknown" ? "danger" : "neutral"} />
+        <MetricCard label="Verification" value={actionStateLabel(action.verification_state)} detail={verification ? actionTimeLabel(verification.verified_at_unix_ms) : "No verification receipt"} intent={action.verification_state === "verified" ? "success" : action.verification_state === "rejected" || action.verification_state === "stale" ? "warning" : "neutral"} />
+        <MetricCard label="Approval" value={approval?.approved ? "Approved" : approval ? "Rejected" : "Not recorded"} detail={approval ? `By ${approval.decided_by}` : "Signed decision required"} intent={approval?.approved ? "success" : approval ? "danger" : "neutral"} />
+        <MetricCard label="Execution" value={action.executed_at_unix_ms ? "Receipt recorded" : action.claimed_by ? "Claimed" : "Not started"} detail={action.executor_actor_id || action.claimed_by || "No executor"} intent={action.state === "outcome_unknown" ? "danger" : action.executed_at_unix_ms ? "success" : "neutral"} />
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-2">
+        <Panel title="Finding and target">
+          <dl>
+            <DetailRow label="Finding" value={proposal.finding_id} mono />
+            <DetailRow label="Finding revision" value={proposal.finding_revision_digest} mono />
+            <DetailRow label="Validation receipt" value={proposal.finding_validation_receipt_digest} mono />
+            <DetailRow label="Graph revision" value={String(proposal.graph_revision)} />
+            <DetailRow label="Target" value={proposal.target_id} mono />
+            <DetailRow label="Expected effects" value={proposal.expected_effects.map((effect) => `${effect.effect_kind} on ${effect.target_id}`).join(", ")} />
+          </dl>
+        </Panel>
+
+        <Panel title="Proposal authority">
+          <dl>
+            <DetailRow label="Proposed by" value={proposal.proposed_by} mono />
+            <DetailRow label="Proposed" value={actionTimeLabel(proposal.proposed_at_unix_ms)} />
+            <DetailRow label="Expires" value={actionTimeLabel(proposal.proposal_expires_at_unix_ms)} />
+            <DetailRow label="Proposal digest" value={proposal.proposal_digest} mono />
+            <DetailRow label="Action definition" value={proposal.action_definition_digest} mono />
+            <DetailRow label="Simulation" value={proposal.simulation_digest} mono />
+            <DetailRow label="Verification plan" value={proposal.verification_plan_digest} mono />
+            <DetailRow label="Idempotency key" value={proposal.idempotency_key} mono />
+          </dl>
+        </Panel>
+
+        <Panel title="Execution receipt">
+          <dl>
+            <DetailRow label="Claimed by" value={action.claimed_by || "Not claimed"} mono={Boolean(action.claimed_by)} />
+            <DetailRow label="Claimed" value={actionTimeLabel(action.claimed_at_unix_ms)} />
+            <DetailRow label="Executor" value={action.executor_actor_id || "No executor receipt"} mono={Boolean(action.executor_actor_id)} />
+            <DetailRow label="Executed" value={actionTimeLabel(action.executed_at_unix_ms)} />
+            <DetailRow label="External receipt" value={action.external_receipt_ref || "Not recorded"} mono={Boolean(action.external_receipt_ref)} />
+            <DetailRow label="Observed effect" value={action.observed_effect_digest || "Not recorded"} mono={Boolean(action.observed_effect_digest)} />
+          </dl>
+        </Panel>
+
+        <Panel title="Independent verification">
+          <dl>
+            <DetailRow label="State" value={actionStateLabel(action.verification_state)} />
+            <DetailRow label="Verifier" value={verification?.verifier_actor_id || "No verifier receipt"} mono={Boolean(verification?.verifier_actor_id)} />
+            <DetailRow label="Previous source revision" value={verification?.previous_source_revision || "Not recorded"} mono={Boolean(verification?.previous_source_revision)} />
+            <DetailRow label="Observed source revision" value={verification?.observed_source_revision || "Not recorded"} mono={Boolean(verification?.observed_source_revision)} />
+            <DetailRow label="Effective" value={verification ? (verification.effective ? "Confirmed" : "Not confirmed") : "Not verified"} />
+            <DetailRow label="Verified" value={actionTimeLabel(verification?.verified_at_unix_ms)} />
+            <DetailRow label="Evidence" value={verification?.evidence_urns.join(", ") || "No verification evidence"} mono={Boolean(verification?.evidence_urns.length)} />
+          </dl>
+        </Panel>
+      </div>
+
+      <div className="mt-4">
+        <Panel
+          title="Authority history"
+          action={<span className="text-[11px] text-[var(--text-muted)]">{history.length} committed versions</span>}
+        >
+          <div className="overflow-auto">
+            <table className="w-full min-w-[900px] text-left text-[12px]">
+              <thead className="border-b border-[color:var(--border)] bg-[var(--surface-muted)] text-[11px] uppercase tracking-wider text-[var(--text-muted)]">
+                <tr>
+                  <th className="px-3 py-2 font-semibold">Version</th>
+                  <th className="px-3 py-2 font-semibold">Event</th>
+                  <th className="px-3 py-2 font-semibold">State</th>
+                  <th className="px-3 py-2 font-semibold">Actor</th>
+                  <th className="px-3 py-2 font-semibold">Committed</th>
+                  <th className="px-3 py-2 font-semibold">Operation digest</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[color:var(--border)]">
+                {history.map((event) => (
+                  <tr key={`${event.operation.version}:${event.operation_digest}`}>
+                    <td className="px-3 py-3 text-[var(--text-secondary)]">{event.operation.version}</td>
+                    <td className="px-3 py-3"><Badge value={event.event_kind} /></td>
+                    <td className="px-3 py-3"><Badge value={event.operation.state} /></td>
+                    <td className="px-3 py-3 font-mono text-[11px] text-[var(--text-secondary)]">{event.actor_id}</td>
+                    <td className="px-3 py-3 text-[var(--text-secondary)]">{actionTimeLabel(event.committed_at_unix_ms)}</td>
+                    <td className="max-w-[18rem] truncate px-3 py-3 font-mono text-[10px] text-[var(--text-muted)]" title={event.operation_digest}>{event.operation_digest}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+      </div>
+
+      <div className="mt-4 rounded-md border border-[color:var(--border)] bg-[var(--surface-muted)] px-4 py-3 text-[12px] text-[var(--text-secondary)]">
+        Submit approval, execution, and verification commands through clients that hold the corresponding signed Action scopes. Each command must use the current version shown above.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import { Badge, EmptyBlock, ErrorBlock, LoadingBlock, MetricCard, PageHeader, Panel } from "@/components/grc/Primitives";
+import { actionTimeLabel, summarizeActionPage, type ActionPage } from "@/lib/actions";
+import { grcPath, useGRCQuery } from "@/lib/grc-client";
+
+const PAGE_SIZE = 50;
+
+export default function ActionsPage() {
+  const [pageTokens, setPageTokens] = useState<string[]>([""]);
+  const pageToken = pageTokens.at(-1) ?? "";
+  const path = grcPath("/v1/actions", {
+    limit: PAGE_SIZE,
+    ...(pageToken ? { page_token: pageToken } : {}),
+  });
+  const query = useGRCQuery<ActionPage>(path);
+  const actions = useMemo(() => query.data?.actions ?? [], [query.data?.actions]);
+  const summary = useMemo(() => summarizeActionPage(actions), [actions]);
+  const nextPageToken = query.data?.next_page_token ?? "";
+
+  return (
+    <div>
+      <PageHeader
+        title="Actions"
+        description="Remediation work for confirmed findings. Rust owns every state transition, actor binding, approval receipt, execution receipt, and verification receipt shown here."
+        contractId="rust-actions"
+      />
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard label="Waiting for approval" value={summary.waitingForApproval} detail="Current page" intent={summary.waitingForApproval > 0 ? "warning" : "neutral"} state={query.state} />
+        <MetricCard label="In execution" value={summary.inExecution} detail="Claimed, executing, or outcome unknown" intent={summary.inExecution > 0 ? "warning" : "neutral"} state={query.state} />
+        <MetricCard label="Verified" value={summary.verified} detail="Current page" intent={summary.verified > 0 ? "success" : "neutral"} state={query.state} />
+        <MetricCard label="Failed or rolled back" value={summary.failedOrRolledBack} detail="Current page" intent={summary.failedOrRolledBack > 0 ? "danger" : "neutral"} state={query.state} />
+      </div>
+
+      <div className="mt-4">
+        {query.loading && !query.data ? <LoadingBlock label="Loading Actions from the Rust authority..." /> : null}
+        {query.error ? <ErrorBlock error={query.error} onRetry={() => void query.reload()} recoveryDetail="Check the Rust Action authority and signed browser identity, then try again." /> : null}
+        {!query.loading && !query.error && actions.length === 0 ? <EmptyBlock label="No Actions are recorded for this tenant." /> : null}
+        {actions.length > 0 ? (
+          <Panel
+            title="Action queue"
+            action={<span className="text-[11px] text-[var(--text-muted)]">Newest authority updates first</span>}
+          >
+            <div className="overflow-auto">
+              <table className="w-full min-w-[1080px] text-left text-[12px]">
+                <thead className="border-b border-[color:var(--border)] bg-[var(--surface-muted)] text-[11px] uppercase tracking-wider text-[var(--text-muted)]">
+                  <tr>
+                    <th className="px-3 py-2 font-semibold">Action</th>
+                    <th className="px-3 py-2 font-semibold">Finding</th>
+                    <th className="px-3 py-2 font-semibold">Target</th>
+                    <th className="px-3 py-2 font-semibold">State</th>
+                    <th className="px-3 py-2 font-semibold">Verification</th>
+                    <th className="px-3 py-2 font-semibold">Version</th>
+                    <th className="px-3 py-2 font-semibold">Proposed</th>
+                    <th className="px-3 py-2 font-semibold"><span className="sr-only">Open</span></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[color:var(--border)]">
+                  {actions.map((action) => (
+                    <tr key={action.proposal.operation_id} className="align-top">
+                      <td className="px-3 py-3">
+                        <div className="font-semibold text-[var(--text-primary)]">{action.proposal.action_kind.replaceAll("_", " ")}</div>
+                        <div className="mt-1 max-w-[18rem] truncate font-mono text-[10px] text-[var(--text-muted)]" title={action.proposal.operation_id}>{action.proposal.operation_id}</div>
+                      </td>
+                      <td className="px-3 py-3 font-mono text-[11px] text-[var(--text-secondary)]">{action.proposal.finding_id}</td>
+                      <td className="px-3 py-3 font-mono text-[11px] text-[var(--text-secondary)]">{action.proposal.target_id}</td>
+                      <td className="px-3 py-3"><Badge value={action.state} /></td>
+                      <td className="px-3 py-3"><Badge value={action.verification_state} /></td>
+                      <td className="px-3 py-3 text-[var(--text-secondary)]">{action.version}</td>
+                      <td className="px-3 py-3 text-[var(--text-secondary)]">
+                        <div>{actionTimeLabel(action.proposal.proposed_at_unix_ms)}</div>
+                        <div className="mt-1 text-[11px] text-[var(--text-muted)]">{action.proposal.proposed_by}</div>
+                      </td>
+                      <td className="px-3 py-3 text-right">
+                        <Link href={`/actions/${encodeURIComponent(action.proposal.operation_id)}`} className="secondary-button inline-flex px-3 py-1.5 text-[12px]">
+                          Open
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="mt-4 flex items-center justify-between">
+              <button
+                type="button"
+                className="secondary-button px-3 py-2 text-[12px]"
+                disabled={pageTokens.length === 1}
+                onClick={() => setPageTokens((tokens) => tokens.slice(0, -1))}
+              >
+                Previous page
+              </button>
+              <span className="text-[11px] text-[var(--text-muted)]">Page {pageTokens.length}</span>
+              <button
+                type="button"
+                className="secondary-button px-3 py-2 text-[12px]"
+                disabled={!nextPageToken}
+                onClick={() => {
+                  if (nextPageToken) setPageTokens((tokens) => [...tokens, nextPageToken]);
+                }}
+              >
+                Next page
+              </button>
+            </div>
+          </Panel>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -47,10 +47,10 @@ describe("isSidebarLinkActive", () => {
     ]);
   });
 
-  it("keeps issues, Compliance, and Ask in the visible sidebar", () => {
+  it("keeps issues, Actions, Compliance, and Ask in the visible sidebar", () => {
     const sidebarHrefs = sidebarNavLinks.map((link) => link.href);
 
-    expect(sidebarPrimaryLinks.map((link) => link.href)).toEqual(["/", "/risk-inbox"]);
+    expect(sidebarPrimaryLinks.map((link) => link.href)).toEqual(["/", "/risk-inbox", "/actions"]);
     expect(sidebarHrefs).toContain("/grc");
     expect(sidebarSupportLinks.map((link) => link.href)).toEqual(["/ask"]);
     expect(hasSidebarIcon("/grc")).toBe(true);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import { operatorNavLinks, utilityLinks, type NavigationEntry } from "@/lib/navi
 const icons: Record<string, ReactNode> = {
   "/": <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />,
   "/risk-inbox": <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />,
+  "/actions": <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-9.75-6h13.5A2.25 2.25 0 0 1 21 6v12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 18V6a2.25 2.25 0 0 1 2.25-2.25Z" />,
   "/grc": <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M4.5 6.75h15M4.5 12h2.25m10.5 0h2.25M4.5 17.25h15M6.75 3.75h10.5A2.25 2.25 0 0 1 19.5 6v12A2.25 2.25 0 0 1 17.25 20.25H6.75A2.25 2.25 0 0 1 4.5 18V6A2.25 2.25 0 0 1 6.75 3.75Z" />,
   "/trends": <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941" />,
   "/trends/dashboards": <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25A2.25 2.25 0 0 1 6 3h12a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 18 21H6a2.25 2.25 0 0 1-2.25-2.25V5.25ZM7.5 8.25h3.75m-3.75 3h3.75m-3.75 3h3.75m3-6h2.25m-2.25 3h2.25m-2.25 3h2.25" />,
@@ -49,7 +50,7 @@ const linksFor = (hrefs: string[]) =>
     return link ? [link] : [];
   });
 
-export const sidebarPrimaryLinks = linksFor(["/", "/risk-inbox"]);
+export const sidebarPrimaryLinks = linksFor(["/", "/risk-inbox", "/actions"]);
 export const sidebarSupportLinks = linksFor(["/ask"]);
 
 export const sidebarNavGroups: SidebarNavGroup[] = [

--- a/apps/web/src/lib/actions.test.ts
+++ b/apps/web/src/lib/actions.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  actionStateIntent,
+  actionStateLabel,
+  actionTimeLabel,
+  summarizeActionPage,
+  type ActionOperation,
+  type ActionState,
+} from "./actions";
+
+const operation = (state: ActionState): ActionOperation => ({
+  proposal: {
+    operation_id: `operation:${state}`,
+    tenant_id: "tenant:one",
+    finding_id: "finding:one",
+    finding_revision_digest: "a".repeat(64),
+    finding_validation_receipt_digest: "b".repeat(64),
+    graph_revision: 1,
+    action_kind: "revoke_access",
+    action_definition_digest: "c".repeat(64),
+    target_id: "grant:one",
+    expected_effects: [],
+    rollback_ref: "rollback:one",
+    idempotency_key: `idempotency:${state}`,
+    simulation_digest: "d".repeat(64),
+    verification_plan_digest: "e".repeat(64),
+    proposed_by: "operator:one",
+    proposed_at_unix_ms: 1,
+    proposal_expires_at_unix_ms: 2,
+    proposal_digest: "f".repeat(64),
+  },
+  state,
+  version: 1,
+  verification_state: "pending",
+});
+
+describe("Action UI state", () => {
+  it("uses the exact authority state for labels and intent", () => {
+    expect(actionStateLabel("waiting_for_approval")).toBe("Waiting For Approval");
+    expect(actionStateIntent("verified")).toBe("success");
+    expect(actionStateIntent("outcome_unknown")).toBe("danger");
+    expect(actionStateIntent("waiting_for_approval")).toBe("warning");
+  });
+
+  it("summarizes only the operations in the current bounded page", () => {
+    expect(summarizeActionPage([
+      operation("waiting_for_approval"),
+      operation("executing"),
+      operation("outcome_unknown"),
+      operation("verified"),
+      operation("failed"),
+      operation("rolled_back"),
+    ])).toEqual({
+      waitingForApproval: 1,
+      inExecution: 2,
+      verified: 1,
+      failedOrRolledBack: 2,
+    });
+  });
+
+  it("does not render invalid authority timestamps as real dates", () => {
+    expect(actionTimeLabel()).toBe("Not recorded");
+    expect(actionTimeLabel(0)).toBe("Not recorded");
+    expect(actionTimeLabel(Number.MAX_SAFE_INTEGER + 1)).toBe("Not recorded");
+  });
+});

--- a/apps/web/src/lib/actions.ts
+++ b/apps/web/src/lib/actions.ts
@@ -1,0 +1,123 @@
+export type ActionState =
+  | "proposed"
+  | "simulated"
+  | "waiting_for_approval"
+  | "approved"
+  | "claimed"
+  | "executing"
+  | "outcome_unknown"
+  | "completed"
+  | "reconciled"
+  | "verified"
+  | "failed"
+  | "rolled_back";
+
+export type ActionOperation = {
+  proposal: {
+    operation_id: string;
+    tenant_id: string;
+    finding_id: string;
+    finding_revision_digest: string;
+    finding_validation_receipt_digest: string;
+    graph_revision: number;
+    action_kind: string;
+    action_definition_digest: string;
+    target_id: string;
+    expected_effects: Array<{
+      target_id: string;
+      effect_kind: string;
+      expected_state_digest: string;
+    }>;
+    rollback_ref: string;
+    idempotency_key: string;
+    simulation_digest: string;
+    verification_plan_digest: string;
+    proposed_by: string;
+    proposed_at_unix_ms: number;
+    proposal_expires_at_unix_ms: number;
+    proposal_digest: string;
+  };
+  state: ActionState;
+  version: number;
+  approval_receipt?: {
+    decision_id: string;
+    proposal_digest: string;
+    approved: boolean;
+    decided_by: string;
+    decided_at_unix_ms: number;
+  } | null;
+  claimed_by?: string | null;
+  claimed_at_unix_ms?: number | null;
+  executor_actor_id?: string | null;
+  executed_at_unix_ms?: number | null;
+  external_receipt_ref?: string | null;
+  observed_effect_digest?: string | null;
+  verification_state: "pending" | "verified" | "rejected" | "stale";
+  verification_receipt?: {
+    operation_id: string;
+    proposal_digest: string;
+    observed_effect_digest: string;
+    receipt: {
+      verification_id: string;
+      executor_actor_id: string;
+      verifier_actor_id: string;
+      previous_source_revision: string;
+      observed_source_revision: string;
+      effective: boolean;
+      evidence_urns: string[];
+      verified_at_unix_ms: number;
+    };
+  } | null;
+};
+
+export type ActionPage = {
+  actions: ActionOperation[];
+  next_page_token?: string | null;
+};
+
+export type ActionEvent = {
+  actor_id: string;
+  event_kind: string;
+  command_digest?: string | null;
+  operation_digest: string;
+  committed_at_unix_ms: number;
+  operation: ActionOperation;
+};
+
+export const actionStateLabel = (state: string) =>
+  state
+    .split("_")
+    .map((part) => part ? part[0].toUpperCase() + part.slice(1) : part)
+    .join(" ");
+
+export const actionTimeLabel = (unixMillis?: number | null) => {
+  if (!unixMillis || !Number.isSafeInteger(unixMillis) || unixMillis < 1) return "Not recorded";
+  const value = new Date(unixMillis);
+  if (Number.isNaN(value.getTime())) return "Not recorded";
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(value);
+};
+
+export const actionStateIntent = (state: ActionState) => {
+  if (state === "verified") return "success" as const;
+  if (state === "failed" || state === "outcome_unknown") return "danger" as const;
+  if (state === "waiting_for_approval" || state === "rolled_back") return "warning" as const;
+  return "neutral" as const;
+};
+
+export const summarizeActionPage = (actions: ActionOperation[]) =>
+  actions.reduce(
+    (summary, action) => {
+      if (action.state === "waiting_for_approval") summary.waitingForApproval += 1;
+      if (["claimed", "executing", "outcome_unknown"].includes(action.state)) summary.inExecution += 1;
+      if (action.state === "verified") summary.verified += 1;
+      if (action.state === "failed" || action.state === "rolled_back") summary.failedOrRolledBack += 1;
+      return summary;
+    },
+    { waitingForApproval: 0, inExecution: 0, verified: 0, failedOrRolledBack: 0 },
+  );

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -23,6 +23,7 @@ describe("navigation entries", () => {
     const hrefs = operatorNavLinks.map((e) => e.href);
     expect(hrefs).toContain("/");
     expect(hrefs).toContain("/risk-inbox");
+    expect(hrefs).toContain("/actions");
     expect(hrefs).toContain("/grc");
     expect(hrefs).toContain("/ask");
     expect(hrefs).toContain("/controls");
@@ -30,12 +31,15 @@ describe("navigation entries", () => {
     expect(hrefs).toContain("/credential-stores");
   });
 
-  it("uses operator labels for issues and compliance", () => {
+  it("uses operator labels for issues, Actions, and compliance", () => {
     expect(operatorNavLinks.find((entry) => entry.href === "/risk-inbox")).toMatchObject({
       label: "Issues",
     });
     expect(operatorNavLinks.find((entry) => entry.href === "/grc")).toMatchObject({
       label: "Compliance",
+    });
+    expect(operatorNavLinks.find((entry) => entry.href === "/actions")).toMatchObject({
+      label: "Actions",
     });
   });
 

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -24,6 +24,13 @@ export const operatorNavLinks: NavigationEntry[] = [
     keywords: ["issues", "findings", "risk", "sla", "triage", "owner", "framework", ...supportedGRCFrameworkNames],
   },
   {
+    label: "Actions",
+    href: "/actions",
+    description: "Remediation proposals, approvals, execution receipts, and independent verification.",
+    section: "Operator",
+    keywords: ["actions", "remediation", "approval", "execution", "verification", "rollback"],
+  },
+  {
     label: "Credentials",
     href: "/security/lifecycle",
     description: "Credential and certificate expiry, ownership, findings, and approved rotation routes.",

--- a/crates/action-store/src/lib.rs
+++ b/crates/action-store/src/lib.rs
@@ -75,6 +75,8 @@ CREATE TABLE IF NOT EXISTS action_operation_events (
 );
 CREATE INDEX IF NOT EXISTS action_operation_events_committed_idx
   ON action_operation_events (tenant_id, committed_at_unix_ms DESC);
+CREATE INDEX IF NOT EXISTS action_operations_queue_idx
+  ON action_operations (tenant_id, updated_at_unix_ms DESC, operation_id);
 CREATE OR REPLACE FUNCTION reject_action_operation_event_mutation()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -118,6 +120,7 @@ pub enum ActionStoreError {
     Conflict(String),
     NotFound(String),
     Corrupt(String),
+    InvalidPageToken,
     OutOfRange(&'static str),
 }
 
@@ -134,6 +137,7 @@ impl fmt::Display for ActionStoreError {
             Self::Corrupt(message) => {
                 write!(formatter, "Action ledger record is corrupt: {message}")
             }
+            Self::InvalidPageToken => write!(formatter, "Action page token is invalid"),
             Self::OutOfRange(field) => write!(formatter, "{field} is outside its storage range"),
         }
     }
@@ -170,6 +174,12 @@ pub struct ActionEvent {
     pub operation_digest: ContentDigest,
     pub committed_at_unix_ms: u64,
     pub operation: ActionOperation,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ActionPage {
+    pub actions: Vec<ActionOperation>,
+    pub next_page_token: Option<String>,
 }
 
 pub struct PostgresActionLedger {
@@ -329,6 +339,59 @@ impl PostgresActionLedger {
             .ok_or_else(|| ActionStoreError::NotFound(operation_id.to_string()))?;
         transaction.commit().await?;
         Ok(operation.operation)
+    }
+
+    pub async fn list(
+        &self,
+        tenant_id: &TenantId,
+        limit: usize,
+        page_token: Option<&str>,
+    ) -> Result<ActionPage, ActionStoreError> {
+        if !(1..=100).contains(&limit) {
+            return Err(ActionStoreError::OutOfRange("Action page limit"));
+        }
+        let anchor = page_token.map(decode_page_token).transpose()?;
+        let (anchor_updated_at, anchor_operation_id) = match anchor.as_ref() {
+            Some((updated_at, operation_id)) => (
+                Some(storage_i64(*updated_at, "Action page token timestamp")?),
+                Some(operation_id.as_str()),
+            ),
+            None => (None, None),
+        };
+        let fetch_limit = i64::try_from(limit + 1)
+            .map_err(|_| ActionStoreError::OutOfRange("Action page limit"))?;
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id.as_str()).await?;
+        let rows = transaction
+            .query(
+                "SELECT operation_id, idempotency_key, proposal_digest, state, version, operation_json, created_at_unix_ms, updated_at_unix_ms FROM action_operations WHERE tenant_id = $1 AND ($2::BIGINT IS NULL OR updated_at_unix_ms < $2 OR (updated_at_unix_ms = $2 AND operation_id > $3)) ORDER BY updated_at_unix_ms DESC, operation_id ASC LIMIT $4",
+                &[
+                    &tenant_id.as_str(),
+                    &anchor_updated_at,
+                    &anchor_operation_id,
+                    &fetch_limit,
+                ],
+            )
+            .await?;
+        let truncated = rows.len() > limit;
+        let mut current = rows
+            .iter()
+            .map(validate_current_row)
+            .collect::<Result<Vec<_>, _>>()?;
+        current.truncate(limit);
+        let next_page_token = truncated.then(|| current.last()).flatten().map(|action| {
+            encode_page_token(
+                action.updated_at_unix_ms,
+                &action.operation.proposal.operation_id,
+            )
+        });
+        let actions = current.into_iter().map(|action| action.operation).collect();
+        transaction.commit().await?;
+        Ok(ActionPage {
+            actions,
+            next_page_token,
+        })
     }
 
     pub async fn transition(
@@ -688,6 +751,46 @@ fn storage_i64(value: u64, field: &'static str) -> Result<i64, ActionStoreError>
     i64::try_from(value).map_err(|_| ActionStoreError::OutOfRange(field))
 }
 
+fn encode_page_token(updated_at_unix_ms: u64, operation_id: &ActionOperationId) -> String {
+    let raw = format!("{updated_at_unix_ms}\0{}", operation_id.as_str());
+    let mut encoded = String::with_capacity(3 + raw.len() * 2);
+    encoded.push_str("v1.");
+    for byte in raw.as_bytes() {
+        use std::fmt::Write as _;
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
+fn decode_page_token(token: &str) -> Result<(u64, ActionOperationId), ActionStoreError> {
+    let encoded = token
+        .strip_prefix("v1.")
+        .filter(|encoded| !encoded.is_empty() && encoded.len() <= 554 && encoded.len() % 2 == 0)
+        .ok_or(ActionStoreError::InvalidPageToken)?;
+    let bytes = encoded
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            std::str::from_utf8(pair)
+                .ok()
+                .and_then(|value| u8::from_str_radix(value, 16).ok())
+                .ok_or(ActionStoreError::InvalidPageToken)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let raw = String::from_utf8(bytes).map_err(|_| ActionStoreError::InvalidPageToken)?;
+    let (updated_at, operation_id) = raw
+        .split_once('\0')
+        .ok_or(ActionStoreError::InvalidPageToken)?;
+    let updated_at = updated_at
+        .parse::<u64>()
+        .ok()
+        .filter(|updated_at| *updated_at > 0 && *updated_at <= i64::MAX as u64)
+        .ok_or(ActionStoreError::InvalidPageToken)?;
+    let operation_id = ActionOperationId::parse(operation_id.to_owned())
+        .map_err(|_| ActionStoreError::InvalidPageToken)?;
+    Ok((updated_at, operation_id))
+}
+
 async fn set_tenant(
     transaction: &Transaction<'_>,
     tenant_id: &str,
@@ -719,6 +822,7 @@ mod tests {
             "version > 1 AND event_kind <> 'proposed'",
             "CREATE TRIGGER action_operation_events_append_only",
             "BEFORE UPDATE OR DELETE ON action_operation_events",
+            "action_operations_queue_idx",
         ] {
             assert!(POSTGRES_SCHEMA.contains(required), "missing {required}");
         }
@@ -731,6 +835,33 @@ mod tests {
         assert!(storage_i64(0, "test").is_err());
         assert!(storage_i64(u64::MAX, "test").is_err());
         assert_eq!(storage_i64(i64::MAX as u64, "test").unwrap(), i64::MAX);
+    }
+
+    #[test]
+    fn queue_page_tokens_are_bounded_composite_cursors() {
+        let operation_id = ActionOperationId::parse("operation:queue:one").unwrap();
+        let token = encode_page_token(42, &operation_id);
+        assert_ne!(token, operation_id.as_str());
+        assert_eq!(
+            decode_page_token(&token).unwrap(),
+            (42, operation_id.clone())
+        );
+        for invalid in [
+            "",
+            "v2.00",
+            "v1.not-hex",
+            "v1.00",
+            &encode_page_token(0, &operation_id),
+        ] {
+            assert!(matches!(
+                decode_page_token(invalid),
+                Err(ActionStoreError::InvalidPageToken)
+            ));
+        }
+        assert!(matches!(
+            decode_page_token(&format!("v1.{}", "00".repeat(278))),
+            Err(ActionStoreError::InvalidPageToken)
+        ));
     }
 
     #[test]

--- a/crates/action-store/tests/live_ledger.rs
+++ b/crates/action-store/tests/live_ledger.rs
@@ -105,6 +105,38 @@ async fn durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only(
     assert!(history[0].command_digest.is_none());
     assert!(history[1].command_digest.is_some());
 
+    let second = proposal("operation:live:second", "idempotency:live:second");
+    ledger.propose(second.clone(), 40).await?;
+    let mut other_tenant_proposal = proposal("operation:live:other", "idempotency:live:other");
+    other_tenant_proposal.tenant_id = other_tenant.clone();
+    other_tenant_proposal
+        .bind_computed_digest()
+        .expect("bind other tenant proposal");
+    ledger.propose(other_tenant_proposal.clone(), 41).await?;
+
+    let first_page = ledger.list(&tenant, 1, None).await?;
+    assert_eq!(
+        first_page.actions,
+        vec![ledger.get(&tenant, &second.operation_id).await?]
+    );
+    let second_page = ledger
+        .list(&tenant, 1, first_page.next_page_token.as_deref())
+        .await?;
+    assert_eq!(second_page.actions, vec![waiting]);
+    assert!(second_page.next_page_token.is_none());
+    assert_eq!(
+        ledger.list(&other_tenant, 10, None).await?.actions,
+        vec![
+            ledger
+                .get(&other_tenant, &other_tenant_proposal.operation_id)
+                .await?
+        ]
+    );
+    assert!(matches!(
+        ledger.list(&tenant, 10, Some("v1.invalid")).await,
+        Err(ActionStoreError::InvalidPageToken)
+    ));
+
     let (mut mutation_client, mutation_connection) = tokio_postgres::connect(&dsn, NoTls).await?;
     tokio::spawn(async move {
         mutation_connection

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -12,12 +12,12 @@ use async_trait::async_trait;
 use axum::{
     Extension, Json, Router,
     extract::{Path, Query, Request, State},
-    http::{StatusCode, header::AUTHORIZATION},
+    http::{Method, StatusCode, header::AUTHORIZATION},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
-use cerebro_action_store::{ActionEvent, ActionStoreError, PostgresActionLedger};
+use cerebro_action_store::{ActionEvent, ActionPage, ActionStoreError, PostgresActionLedger};
 use cerebro_agent_context::{
     AgentContext, AgentGraph, ContextEntity, ContextError, GraphPath, MemoryAgentGraph,
     Neighborhood,
@@ -90,6 +90,13 @@ trait ActionAuthority: Send + Sync {
         operation_id: &ActionOperationId,
     ) -> Result<ActionOperation, ActionStoreError>;
 
+    async fn list(
+        &self,
+        tenant_id: &TenantId,
+        limit: usize,
+        page_token: Option<&str>,
+    ) -> Result<ActionPage, ActionStoreError>;
+
     async fn transition(
         &self,
         tenant_id: &TenantId,
@@ -127,6 +134,15 @@ impl ActionAuthority for PostgresActionLedger {
         operation_id: &ActionOperationId,
     ) -> Result<ActionOperation, ActionStoreError> {
         self.get(tenant_id, operation_id).await
+    }
+
+    async fn list(
+        &self,
+        tenant_id: &TenantId,
+        limit: usize,
+        page_token: Option<&str>,
+    ) -> Result<ActionPage, ActionStoreError> {
+        self.list(tenant_id, limit, page_token).await
     }
 
     async fn transition(
@@ -295,7 +311,7 @@ async fn authenticate_oidc(
             ));
         }
     };
-    let required_scope = oidc_scope_for_route(request.uri().path());
+    let required_scope = oidc_scope_for_route(request.method(), request.uri().path());
     if !identity.has_scope(required_scope) {
         return Err((
             StatusCode::FORBIDDEN,
@@ -312,9 +328,10 @@ async fn authenticate_oidc(
     Ok(next.run(request).await)
 }
 
-fn oidc_scope_for_route(path: &str) -> &'static str {
+fn oidc_scope_for_route(method: &Method, path: &str) -> &'static str {
     match path {
         "/v1/me" => "identity:read",
+        "/v1/actions" if method == Method::GET => "cerebro:actions:read",
         "/v1/actions" => "cerebro:actions:write",
         _ if path.starts_with("/v1/actions/") && path.ends_with("/commands") => {
             "cerebro:actions:write"
@@ -332,7 +349,7 @@ async fn record_request(
     request: Request,
     next: Next,
 ) -> Response {
-    let operation = bounded_operation(request.uri().path());
+    let operation = bounded_operation(request.method(), request.uri().path());
     let started = Instant::now();
     let response = next.run(request).await;
     metrics
@@ -345,7 +362,7 @@ async fn record_request(
     response
 }
 
-fn bounded_operation(path: &str) -> &'static str {
+fn bounded_operation(method: &Method, path: &str) -> &'static str {
     match path {
         "/healthz" => "healthz",
         "/readyz" => "readyz",
@@ -358,6 +375,7 @@ fn bounded_operation(path: &str) -> &'static str {
         "/v1/graph/expand-batch" => "expand_batch",
         "/v1/graph/paths" => "paths",
         "/v1/security/lifecycle" => "security_lifecycle",
+        "/v1/actions" if method == Method::GET => "list_actions",
         "/v1/actions" => "propose_action",
         "/v1/projections/events" => "project_event",
         "/v1/projections/legacy-deltas" => "record_legacy_projection",
@@ -703,6 +721,15 @@ struct ErrorResponse {
 #[derive(Deserialize)]
 struct TenantQuery {
     tenant_id: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ActionListQuery {
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    page_token: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1384,7 +1411,7 @@ fn router_with_backend(
     let protected = if let Some(oidc) = oidc {
         protected
             .route("/v1/me", get(current_user))
-            .route("/v1/actions", post(propose_action))
+            .route("/v1/actions", get(list_actions).post(propose_action))
             .route("/v1/actions/{operation_id}", get(get_action))
             .route(
                 "/v1/actions/{operation_id}/history",
@@ -1794,6 +1821,25 @@ async fn propose_action(
     let committed_at = current_unix_millis()?;
     action_authority(&state)?
         .propose(proposal, committed_at)
+        .await
+        .map(Json)
+        .map_err(action_store_error)
+}
+
+async fn list_actions(
+    State(state): State<AppState>,
+    Extension(identity): Extension<AuthenticatedIdentity>,
+    Query(query): Query<ActionListQuery>,
+) -> Result<Json<ActionPage>, (StatusCode, Json<ErrorResponse>)> {
+    let limit = query.limit.unwrap_or(25);
+    if !(1..=100).contains(&limit) {
+        return Err(bad_request(
+            "invalid_action_query",
+            "limit must be between 1 and 100.",
+        ));
+    }
+    action_authority(&state)?
+        .list(&identity.tenant, limit, query.page_token.as_deref())
         .await
         .map(Json)
         .map_err(action_store_error)
@@ -2308,6 +2354,10 @@ fn action_store_error(error: ActionStoreError) -> (StatusCode, Json<ErrorRespons
                 "The stored Action failed authority validation.",
             )
         }
+        ActionStoreError::InvalidPageToken => bad_request(
+            "invalid_action_page_token",
+            "The Action page token is invalid.",
+        ),
     }
 }
 
@@ -2509,6 +2559,15 @@ mod tests {
             _tenant_id: &TenantId,
             _operation_id: &ActionOperationId,
         ) -> Result<ActionOperation, ActionStoreError> {
+            panic!("spoofed request reached the Action authority")
+        }
+
+        async fn list(
+            &self,
+            _tenant_id: &TenantId,
+            _limit: usize,
+            _page_token: Option<&str>,
+        ) -> Result<ActionPage, ActionStoreError> {
             panic!("spoofed request reached the Action authority")
         }
 
@@ -3297,38 +3356,62 @@ mod tests {
     #[test]
     fn lifecycle_requests_have_a_bounded_metrics_operation() {
         assert_eq!(
-            bounded_operation("/v1/security/lifecycle"),
+            bounded_operation(&Method::GET, "/v1/security/lifecycle"),
             "security_lifecycle"
         );
         assert_eq!(
-            bounded_operation("/cerebro.v1.SecurityLifecycleService/ListSecurityLifecycle"),
+            bounded_operation(
+                &Method::POST,
+                "/cerebro.v1.SecurityLifecycleService/ListSecurityLifecycle"
+            ),
             "security_lifecycle"
+        );
+        assert_eq!(
+            bounded_operation(&Method::GET, "/v1/actions"),
+            "list_actions"
+        );
+        assert_eq!(
+            bounded_operation(&Method::POST, "/v1/actions"),
+            "propose_action"
         );
     }
 
     #[test]
     fn oidc_authorization_scopes_cover_reads_identity_and_mutations() {
-        assert_eq!(oidc_scope_for_route("/v1/me"), "identity:read");
         assert_eq!(
-            oidc_scope_for_route("/v1/security/lifecycle"),
+            oidc_scope_for_route(&Method::GET, "/v1/me"),
+            "identity:read"
+        );
+        assert_eq!(
+            oidc_scope_for_route(&Method::GET, "/v1/security/lifecycle"),
             "cerebro:read"
         );
-        assert_eq!(oidc_scope_for_route("/v1/graph/search"), "cerebro:read");
         assert_eq!(
-            oidc_scope_for_route("/v1/projections/events"),
+            oidc_scope_for_route(&Method::POST, "/v1/graph/search"),
+            "cerebro:read"
+        );
+        assert_eq!(
+            oidc_scope_for_route(&Method::POST, "/v1/projections/events"),
             "cerebro:write"
         );
-        assert_eq!(oidc_scope_for_route("/v1/actions"), "cerebro:actions:write");
         assert_eq!(
-            oidc_scope_for_route("/v1/actions/operation:one"),
+            oidc_scope_for_route(&Method::GET, "/v1/actions"),
             "cerebro:actions:read"
         );
         assert_eq!(
-            oidc_scope_for_route("/v1/actions/operation:one/history"),
+            oidc_scope_for_route(&Method::POST, "/v1/actions"),
+            "cerebro:actions:write"
+        );
+        assert_eq!(
+            oidc_scope_for_route(&Method::GET, "/v1/actions/operation:one"),
             "cerebro:actions:read"
         );
         assert_eq!(
-            oidc_scope_for_route("/v1/actions/operation:one/commands"),
+            oidc_scope_for_route(&Method::GET, "/v1/actions/operation:one/history"),
+            "cerebro:actions:read"
+        );
+        assert_eq!(
+            oidc_scope_for_route(&Method::POST, "/v1/actions/operation:one/commands"),
             "cerebro:actions:write"
         );
     }
@@ -3369,6 +3452,40 @@ mod tests {
             request.command.into_domain().unwrap(),
             ActionCommand::RecordSimulation
         ));
+    }
+
+    #[tokio::test]
+    async fn action_queue_rejects_unknown_and_unbounded_queries_before_storage() {
+        assert!(
+            serde_json::from_value::<ActionListQuery>(serde_json::json!({
+                "limit": 25,
+                "tenant_id": "tenant:http:other"
+            }))
+            .is_err()
+        );
+
+        let (graph, _, _) = demo_graph().unwrap();
+        let state = AppState {
+            actions: Some(Arc::new(UnreachableActionAuthority)),
+            graph: Arc::new(MemoryAgentGraph::new(graph)),
+            catalog_summary: None,
+            projection: None,
+            metrics: PlatformMetrics::default(),
+        };
+        for limit in [0, 101, usize::MAX] {
+            let error = list_actions(
+                State(state.clone()),
+                Extension(action_identity("tenant:http:one", "actor:http:one")),
+                Query(ActionListQuery {
+                    limit: Some(limit),
+                    page_token: None,
+                }),
+            )
+            .await
+            .expect_err("unbounded query must fail before storage");
+            assert_eq!(error.0, StatusCode::BAD_REQUEST);
+            assert_eq!(error.1.0.code, "invalid_action_query");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- add a tenant-scoped `GET /v1/actions` endpoint backed by the durable Rust Action ledger
- use a fixed 1-100 page bound and an opaque composite cursor over update time and operation ID
- distinguish read and write scopes and metrics for the shared Action collection route
- add a tenant/update index, validate every stored row before returning it, and reject malformed or oversized cursors
- extend the disposable PostgreSQL test with tenant isolation, deterministic ordering, pagination, and invalid-cursor coverage

## Why

The web Action queue needs a bounded Rust-owned read model before it can stop depending on non-authoritative backend paths. Signed identity selects the tenant; the request cannot provide or override a tenant ID.

## Verification

- `cargo test -p cerebro-action-store -p cerebro-platform --all-targets --locked`
- `cargo clippy -p cerebro-action-store -p cerebro-platform --all-targets --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p cerebro-action-store -p cerebro-platform --no-deps --locked`
- `cargo deny check`
- `make rust-coverage` (90.14% line coverage)
- `git diff --check`

The disposable PostgreSQL test remains ignored locally because no PostgreSQL or Docker daemon is available in this checkout. Hosted integration coverage is the live database gate.

## Boundary

This adds the Rust Action queue API required by the web shell. It does not claim provider execution, verification collection, deployment cutover, or complete Action UI parity.