### PR TITLE
Add the Rust Action queue UI

### DIFF
--- a/apps/web/src/app/actions/[operationID]/page.tsx
+++ b/apps/web/src/app/actions/[operationID]/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMemo } from "react";
+
+import { Badge, ErrorBlock, LoadingBlock, MetricCard, PageHeader, Panel } from "@/components/grc/Primitives";
+import { actionStateLabel, actionTimeLabel, type ActionEvent, type ActionOperation } from "@/lib/actions";
+import { useGRCQuery } from "@/lib/grc-client";
+
+function DetailRow({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="grid gap-1 border-b border-[color:var(--border)] py-2.5 last:border-0 sm:grid-cols-[12rem_1fr]">
+      <dt className="text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">{label}</dt>
+      <dd className={`break-all text-[12px] text-[var(--text-secondary)] ${mono ? "font-mono text-[11px]" : ""}`}>{value}</dd>
+    </div>
+  );
+}
+
+export default function ActionDetailPage() {
+  const params = useParams<{ operationID: string }>();
+  const operationID = typeof params.operationID === "string" ? params.operationID : "";
+  const encodedOperationID = encodeURIComponent(operationID);
+  const actionQuery = useGRCQuery<ActionOperation>(operationID ? `/v1/actions/${encodedOperationID}` : null);
+  const historyQuery = useGRCQuery<ActionEvent[]>(operationID ? `/v1/actions/${encodedOperationID}/history` : null);
+  const action = actionQuery.data;
+  const history = useMemo(() => historyQuery.data ?? [], [historyQuery.data]);
+  const error = actionQuery.error || historyQuery.error;
+
+  if ((actionQuery.loading || historyQuery.loading) && !action) {
+    return <LoadingBlock label="Loading Action authority records..." />;
+  }
+  if (error || !action) {
+    return (
+      <ErrorBlock
+        error={error || "The Action was not returned by the Rust authority."}
+        onRetry={() => {
+          void actionQuery.reload();
+          void historyQuery.reload();
+        }}
+        recoveryDetail="Confirm the operation ID and signed tenant identity, then try again."
+      />
+    );
+  }
+
+  const proposal = action.proposal;
+  const approval = action.approval_receipt;
+  const verification = action.verification_receipt?.receipt;
+
+  return (
+    <div>
+      <PageHeader
+        title={proposal.action_kind.replaceAll("_", " ")}
+        description={`Action ${proposal.operation_id} is bound to finding revision ${proposal.finding_revision_digest.slice(0, 12)} and graph revision ${proposal.graph_revision}.`}
+        contractId="rust-action-detail"
+        action={<Link href="/actions" className="secondary-button px-3 py-2 text-[12px]">Back to Actions</Link>}
+      />
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard label="State" value={actionStateLabel(action.state)} detail={`Version ${action.version}`} intent={action.state === "verified" ? "success" : action.state === "failed" || action.state === "outcome_unknown" ? "danger" : "neutral"} />
+        <MetricCard label="Verification" value={actionStateLabel(action.verification_state)} detail={verification ? actionTimeLabel(verification.verified_at_unix_ms) : "No verification receipt"} intent={action.verification_state === "verified" ? "success" : action.verification_state === "rejected" || action.verification_state === "stale" ? "warning" : "neutral"} />
+        <MetricCard label="Approval" value={approval?.approved ? "Approved" : approval ? "Rejected" : "Not recorded"} detail={approval ? `By ${approval.decided_by}` : "Signed decision required"} intent={approval?.approved ? "success" : approval ? "danger" : "neutral"} />
+        <MetricCard label="Execution" value={action.executed_at_unix_ms ? "Receipt recorded" : action.claimed_by ? "Claimed" : "Not started"} detail={action.executor_actor_id || action.claimed_by || "No executor"} intent={action.state === "outcome_unknown" ? "danger" : action.executed_at_unix_ms ? "success" : "neutral"} />
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-2">
+        <Panel title="Finding and target">
+          <dl>
+            <DetailRow label="Finding" value={proposal.finding_id} mono />
+            <DetailRow label="Finding revision" value={proposal.finding_revision_digest} mono />
+            <DetailRow label="Validation receipt" value={proposal.finding_validation_receipt_digest} mono />
+            <DetailRow label="Graph revision" value={String(proposal.graph_revision)} />
+            <DetailRow label="Target" value={proposal.target_id} mono />
+            <DetailRow label="Expected effects" value={proposal.expected_effects.map((effect) => `${effect.effect_kind} on ${effect.target_id}`).join(", ")} />
+          </dl>
+        </Panel>
+
+        <Panel title="Proposal authority">
+          <dl>
+            <DetailRow label="Proposed by" value={proposal.proposed_by} mono />
+            <DetailRow label="Proposed" value={actionTimeLabel(proposal.proposed_at_unix_ms)} />
+            <DetailRow label="Expires" value={actionTimeLabel(proposal.proposal_expires_at_unix_ms)} />
+            <DetailRow label="Proposal digest" value={proposal.proposal_digest} mono />
+            <DetailRow label="Action definition" value={proposal.action_definition_digest} mono />
+            <DetailRow label="Simulation" value={proposal.simulation_digest} mono />
+            <DetailRow label="Verification plan" value={proposal.verification_plan_digest} mono />
+            <DetailRow label="Idempotency key" value={proposal.idempotency_key} mono />
+          </dl>
+        </Panel>
+
+        <Panel title="Execution receipt">
+          <dl>
+            <DetailRow label="Claimed by" value={action.claimed_by || "Not claimed"} mono={Boolean(action.claimed_by)} />
+            <DetailRow label="Claimed" value={actionTimeLabel(action.claimed_at_unix_ms)} />
+            <DetailRow label="Executor" value={action.executor_actor_id || "No executor receipt"} mono={Boolean(action.executor_actor_id)} />
+            <DetailRow label="Executed" value={actionTimeLabel(action.executed_at_unix_ms)} />
+            <DetailRow label="External receipt" value={action.external_receipt_ref || "Not recorded"} mono={Boolean(action.external_receipt_ref)} />
+            <DetailRow label="Observed effect" value={action.observed_effect_digest || "Not recorded"} mono={Boolean(action.observed_effect_digest)} />
+          </dl>
+        </Panel>
+
+        <Panel title="Independent verification">
+          <dl>
+            <DetailRow label="State" value={actionStateLabel(action.verification_state)} />
+            <DetailRow label="Verifier" value={verification?.verifier_actor_id || "No verifier receipt"} mono={Boolean(verification?.verifier_actor_id)} />
+            <DetailRow label="Previous source revision" value={verification?.previous_source_revision || "Not recorded"} mono={Boolean(verification?.previous_source_revision)} />
+            <DetailRow label="Observed source revision" value={verification?.observed_source_revision || "Not recorded"} mono={Boolean(verification?.observed_source_revision)} />
+            <DetailRow label="Effective" value={verification ? (verification.effective ? "Confirmed" : "Not confirmed") : "Not verified"} />
+            <DetailRow label="Verified" value={actionTimeLabel(verification?.verified_at_unix_ms)} />
+            <DetailRow label="Evidence" value={verification?.evidence_urns.join(", ") || "No verification evidence"} mono={Boolean(verification?.evidence_urns.length)} />
+          </dl>
+        </Panel>
+      </div>
+
+      <div className="mt-4">
+        <Panel
+          title="Authority history"
+          action={<span className="text-[11px] text-[var(--text-muted)]">{history.length} committed versions</span>}
+        >
+          <div className="overflow-auto">
+            <table className="w-full min-w-[900px] text-left text-[12px]">
+              <thead className="border-b border-[color:var(--border)] bg-[var(--surface-muted)] text-[11px] uppercase tracking-wider text-[var(--text-muted)]">
+                <tr>
+                  <th className="px-3 py-2 font-semibold">Version</th>
+                  <th className="px-3 py-2 font-semibold">Event</th>
+                  <th className="px-3 py-2 font-semibold">State</th>
+                  <th className="px-3 py-2 font-semibold">Actor</th>
+                  <th className="px-3 py-2 font-semibold">Committed</th>
+                  <th className="px-3 py-2 font-semibold">Operation digest</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[color:var(--border)]">
+                {history.map((event) => (
+                  <tr key={`${event.operation.version}:${event.operation_digest}`}>
+                    <td className="px-3 py-3 text-[var(--text-secondary)]">{event.operation.version}</td>
+                    <td className="px-3 py-3"><Badge value={event.event_kind} /></td>
+                    <td className="px-3 py-3"><Badge value={event.operation.state} /></td>
+                    <td className="px-3 py-3 font-mono text-[11px] text-[var(--text-secondary)]">{event.actor_id}</td>
+                    <td className="px-3 py-3 text-[var(--text-secondary)]">{actionTimeLabel(event.committed_at_unix_ms)}</td>
+                    <td className="max-w-[18rem] truncate px-3 py-3 font-mono text-[10px] text-[var(--text-muted)]" title={event.operation_digest}>{event.operation_digest}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+      </div>
+
+      <div className="mt-4 rounded-md border border-[color:var(--border)] bg-[var(--surface-muted)] px-4 py-3 text-[12px] text-[var(--text-secondary)]">
+        Submit approval, execution, and verification commands through clients that hold the corresponding signed Action scopes. Each command must use the current version shown above.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import { Badge, EmptyBlock, ErrorBlock, LoadingBlock, MetricCard, PageHeader, Panel } from "@/components/grc/Primitives";
+import { actionTimeLabel, summarizeActionPage, type ActionPage } from "@/lib/actions";
+import { grcPath, useGRCQuery } from "@/lib/grc-client";
+
+const PAGE_SIZE = 50;
+
+export default function ActionsPage() {
+  const [pageTokens, setPageTokens] = useState<string[]>([""]);
+  const pageToken = pageTokens.at(-1) ?? "";
+  const path = grcPath("/v1/actions", {
+    limit: PAGE_SIZE,
+    ...(pageToken ? { page_token: pageToken } : {}),
+  });
+  const query = useGRCQuery<ActionPage>(path);
+  const actions = useMemo(() => query.data?.actions ?? [], [query.data?.actions]);
+  const summary = useMemo(() => summarizeActionPage(actions), [actions]);
+  const nextPageToken = query.data?.next_page_token ?? "";
+
+  return (
+    <div>
+      <PageHeader
+        title="Actions"
+        description="Remediation work for confirmed findings. Rust owns every state transition, actor binding, approval receipt, execution receipt, and verification receipt shown here."
+        contractId="rust-actions"
+      />
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard label="Waiting for approval" value={summary.waitingForApproval} detail="Current page" intent={summary.waitingForApproval > 0 ? "warning" : "neutral"} state={query.state} />
+        <MetricCard label="In execution" value={summary.inExecution} detail="Claimed, executing, or outcome unknown" intent={summary.inExecution > 0 ? "warning" : "neutral"} state={query.state} />
+        <MetricCard label="Verified" value={summary.verified} detail="Current page" intent={summary.verified > 0 ? "success" : "neutral"} state={query.state} />
+        <MetricCard label="Failed or rolled back" value={summary.failedOrRolledBack} detail="Current page" intent={summary.failedOrRolledBack > 0 ? "danger" : "neutral"} state={query.state} />
+      </div>
+
+      <div className="mt-4">
+        {query.loading && !query.data ? <LoadingBlock label="Loading Actions from the Rust authority..." /> : null}
+        {query.error ? <ErrorBlock error={query.error} onRetry={() => void query.reload()} recoveryDetail="Check the Rust Action authority and signed browser identity, then try again." /> : null}
+        {!query.loading && !query.error && actions.length === 0 ? <EmptyBlock label="No Actions are recorded for this tenant." /> : null}
+        {actions.length > 0 ? (
+          <Panel
+            title="Action queue"
+            action={<span className="text-[11px] text-[var(--text-muted)]">Newest authority updates first</span>}
+          >
+            <div className="overflow-auto">
+              <table className="w-full min-w-[1080px] text-left text-[12px]">
+                <thead className="border-b border-[color:var(--border)] bg-[var(--surface-muted)] text-[11px] uppercase tracking-wider text-[var(--text-muted)]">
+                  <tr>
+                    <th className="px-3 py-2 font-semibold">Action</th>
+                    <th className="px-3 py-2 font-semibold">Finding</th>
+                    <th className="px-3 py-2 font-semibold">Target</th>
+                    <th className="px-3 py-2 font-semibold">State</th>
+                    <th className="px-3 py-2 font-semibold">Verification</th>
+                    <th className="px-3 py-2 font-semibold">Version</th>
+                    <th className="px-3 py-2 font-semibold">Proposed</th>
+                    <th className="px-3 py-2 font-semibold"><span className="sr-only">Open</span></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[color:var(--border)]">
+                  {actions.map((action) => (
+                    <tr key={action.proposal.operation_id} className="align-top">
+                      <td className="px-3 py-3">
+                        <div className="font-semibold text-[var(--text-primary)]">{action.proposal.action_kind.replaceAll("_", " ")}</div>
+                        <div className="mt-1 max-w-[18rem] truncate font-mono text-[10px] text-[var(--text-muted)]" title={action.proposal.operation_id}>{action.proposal.operation_id}</div>
+                      </td>
+                      <td className="px-3 py-3 font-mono text-[11px] text-[var(--text-secondary)]">{action.proposal.finding_id}</td>
+                      <td className="px-3 py-3 font-mono text-[11px] text-[var(--text-secondary)]">{action.proposal.target_id}</td>
+                      <td className="px-3 py-3"><Badge value={action.state} /></td>
+                      <td className="px-3 py-3"><Badge value={action.verification_state} /></td>
+                      <td className="px-3 py-3 text-[var(--text-secondary)]">{action.version}</td>
+                      <td className="px-3 py-3 text-[var(--text-secondary)]">
+                        <div>{actionTimeLabel(action.proposal.proposed_at_unix_ms)}</div>
+                        <div className="mt-1 text-[11px] text-[var(--text-muted)]">{action.proposal.proposed_by}</div>
+                      </td>
+                      <td className="px-3 py-3 text-right">
+                        <Link href={`/actions/${encodeURIComponent(action.proposal.operation_id)}`} className="secondary-button inline-flex px-3 py-1.5 text-[12px]">
+                          Open
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="mt-4 flex items-center justify-between">
+              <button
+                type="button"
+                className="secondary-button px-3 py-2 text-[12px]"
+                disabled={pageTokens.length === 1}
+                onClick={() => setPageTokens((tokens) => tokens.slice(0, -1))}
+              >
+                Previous page
+              </button>
+              <span className="text-[11px] text-[var(--text-muted)]">Page {pageTokens.length}</span>
+              <button
+                type="button"
+                className="secondary-button px-3 py-2 text-[12px]"
+                disabled={!nextPageToken}
+                onClick={() => {
+                  if (nextPageToken) setPageTokens((tokens) => [...tokens, nextPageToken]);
+                }}
+              >
+                Next page
+              </button>
+            </div>
+          </Panel>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -47,10 +47,10 @@ describe("isSidebarLinkActive", () => {
     ]);
   });
 
-  it("keeps issues, Compliance, and Ask in the visible sidebar", () => {
+  it("keeps issues, Actions, Compliance, and Ask in the visible sidebar", () => {
     const sidebarHrefs = sidebarNavLinks.map((link) => link.href);
 
-    expect(sidebarPrimaryLinks.map((link) => link.href)).toEqual(["/", "/risk-inbox"]);
+    expect(sidebarPrimaryLinks.map((link) => link.href)).toEqual(["/", "/risk-inbox", "/actions"]);
     expect(sidebarHrefs).toContain("/grc");
     expect(sidebarSupportLinks.map((link) => link.href)).toEqual(["/ask"]);
     expect(hasSidebarIcon("/grc")).toBe(true);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import { operatorNavLinks, utilityLinks, type NavigationEntry } from "@/lib/navi
 const icons: Record<string, ReactNode> = {
   "/": <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />,
   "/risk-inbox": <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />,
+  "/actions": <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-9.75-6h13.5A2.25 2.25 0 0 1 21 6v12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 18V6a2.25 2.25 0 0 1 2.25-2.25Z" />,
   "/grc": <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M4.5 6.75h15M4.5 12h2.25m10.5 0h2.25M4.5 17.25h15M6.75 3.75h10.5A2.25 2.25 0 0 1 19.5 6v12A2.25 2.25 0 0 1 17.25 20.25H6.75A2.25 2.25 0 0 1 4.5 18V6A2.25 2.25 0 0 1 6.75 3.75Z" />,
   "/trends": <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941" />,
   "/trends/dashboards": <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25A2.25 2.25 0 0 1 6 3h12a2.25 2.25 0 0 1 2.25 2.25v13.5A2.25 2.25 0 0 1 18 21H6a2.25 2.25 0 0 1-2.25-2.25V5.25ZM7.5 8.25h3.75m-3.75 3h3.75m-3.75 3h3.75m3-6h2.25m-2.25 3h2.25m-2.25 3h2.25" />,
@@ -49,7 +50,7 @@ const linksFor = (hrefs: string[]) =>
     return link ? [link] : [];
   });
 
-export const sidebarPrimaryLinks = linksFor(["/", "/risk-inbox"]);
+export const sidebarPrimaryLinks = linksFor(["/", "/risk-inbox", "/actions"]);
 export const sidebarSupportLinks = linksFor(["/ask"]);
 
 export const sidebarNavGroups: SidebarNavGroup[] = [

--- a/apps/web/src/lib/actions.test.ts
+++ b/apps/web/src/lib/actions.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  actionStateIntent,
+  actionStateLabel,
+  actionTimeLabel,
+  summarizeActionPage,
+  type ActionOperation,
+  type ActionState,
+} from "./actions";
+
+const operation = (state: ActionState): ActionOperation => ({
+  proposal: {
+    operation_id: `operation:${state}`,
+    tenant_id: "tenant:one",
+    finding_id: "finding:one",
+    finding_revision_digest: "a".repeat(64),
+    finding_validation_receipt_digest: "b".repeat(64),
+    graph_revision: 1,
+    action_kind: "revoke_access",
+    action_definition_digest: "c".repeat(64),
+    target_id: "grant:one",
+    expected_effects: [],
+    rollback_ref: "rollback:one",
+    idempotency_key: `idempotency:${state}`,
+    simulation_digest: "d".repeat(64),
+    verification_plan_digest: "e".repeat(64),
+    proposed_by: "operator:one",
+    proposed_at_unix_ms: 1,
+    proposal_expires_at_unix_ms: 2,
+    proposal_digest: "f".repeat(64),
+  },
+  state,
+  version: 1,
+  verification_state: "pending",
+});
+
+describe("Action UI state", () => {
+  it("uses the exact authority state for labels and intent", () => {
+    expect(actionStateLabel("waiting_for_approval")).toBe("Waiting For Approval");
+    expect(actionStateIntent("verified")).toBe("success");
+    expect(actionStateIntent("outcome_unknown")).toBe("danger");
+    expect(actionStateIntent("waiting_for_approval")).toBe("warning");
+  });
+
+  it("summarizes only the operations in the current bounded page", () => {
+    expect(summarizeActionPage([
+      operation("waiting_for_approval"),
+      operation("executing"),
+      operation("outcome_unknown"),
+      operation("verified"),
+      operation("failed"),
+      operation("rolled_back"),
+    ])).toEqual({
+      waitingForApproval: 1,
+      inExecution: 2,
+      verified: 1,
+      failedOrRolledBack: 2,
+    });
+  });
+
+  it("does not render invalid authority timestamps as real dates", () => {
+    expect(actionTimeLabel()).toBe("Not recorded");
+    expect(actionTimeLabel(0)).toBe("Not recorded");
+    expect(actionTimeLabel(Number.MAX_SAFE_INTEGER + 1)).toBe("Not recorded");
+  });
+});

--- a/apps/web/src/lib/actions.ts
+++ b/apps/web/src/lib/actions.ts
@@ -1,0 +1,123 @@
+export type ActionState =
+  | "proposed"
+  | "simulated"
+  | "waiting_for_approval"
+  | "approved"
+  | "claimed"
+  | "executing"
+  | "outcome_unknown"
+  | "completed"
+  | "reconciled"
+  | "verified"
+  | "failed"
+  | "rolled_back";
+
+export type ActionOperation = {
+  proposal: {
+    operation_id: string;
+    tenant_id: string;
+    finding_id: string;
+    finding_revision_digest: string;
+    finding_validation_receipt_digest: string;
+    graph_revision: number;
+    action_kind: string;
+    action_definition_digest: string;
+    target_id: string;
+    expected_effects: Array<{
+      target_id: string;
+      effect_kind: string;
+      expected_state_digest: string;
+    }>;
+    rollback_ref: string;
+    idempotency_key: string;
+    simulation_digest: string;
+    verification_plan_digest: string;
+    proposed_by: string;
+    proposed_at_unix_ms: number;
+    proposal_expires_at_unix_ms: number;
+    proposal_digest: string;
+  };
+  state: ActionState;
+  version: number;
+  approval_receipt?: {
+    decision_id: string;
+    proposal_digest: string;
+    approved: boolean;
+    decided_by: string;
+    decided_at_unix_ms: number;
+  } | null;
+  claimed_by?: string | null;
+  claimed_at_unix_ms?: number | null;
+  executor_actor_id?: string | null;
+  executed_at_unix_ms?: number | null;
+  external_receipt_ref?: string | null;
+  observed_effect_digest?: string | null;
+  verification_state: "pending" | "verified" | "rejected" | "stale";
+  verification_receipt?: {
+    operation_id: string;
+    proposal_digest: string;
+    observed_effect_digest: string;
+    receipt: {
+      verification_id: string;
+      executor_actor_id: string;
+      verifier_actor_id: string;
+      previous_source_revision: string;
+      observed_source_revision: string;
+      effective: boolean;
+      evidence_urns: string[];
+      verified_at_unix_ms: number;
+    };
+  } | null;
+};
+
+export type ActionPage = {
+  actions: ActionOperation[];
+  next_page_token?: string | null;
+};
+
+export type ActionEvent = {
+  actor_id: string;
+  event_kind: string;
+  command_digest?: string | null;
+  operation_digest: string;
+  committed_at_unix_ms: number;
+  operation: ActionOperation;
+};
+
+export const actionStateLabel = (state: string) =>
+  state
+    .split("_")
+    .map((part) => part ? part[0].toUpperCase() + part.slice(1) : part)
+    .join(" ");
+
+export const actionTimeLabel = (unixMillis?: number | null) => {
+  if (!unixMillis || !Number.isSafeInteger(unixMillis) || unixMillis < 1) return "Not recorded";
+  const value = new Date(unixMillis);
+  if (Number.isNaN(value.getTime())) return "Not recorded";
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(value);
+};
+
+export const actionStateIntent = (state: ActionState) => {
+  if (state === "verified") return "success" as const;
+  if (state === "failed" || state === "outcome_unknown") return "danger" as const;
+  if (state === "waiting_for_approval" || state === "rolled_back") return "warning" as const;
+  return "neutral" as const;
+};
+
+export const summarizeActionPage = (actions: ActionOperation[]) =>
+  actions.reduce(
+    (summary, action) => {
+      if (action.state === "waiting_for_approval") summary.waitingForApproval += 1;
+      if (["claimed", "executing", "outcome_unknown"].includes(action.state)) summary.inExecution += 1;
+      if (action.state === "verified") summary.verified += 1;
+      if (action.state === "failed" || action.state === "rolled_back") summary.failedOrRolledBack += 1;
+      return summary;
+    },
+    { waitingForApproval: 0, inExecution: 0, verified: 0, failedOrRolledBack: 0 },
+  );

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -23,6 +23,7 @@ describe("navigation entries", () => {
     const hrefs = operatorNavLinks.map((e) => e.href);
     expect(hrefs).toContain("/");
     expect(hrefs).toContain("/risk-inbox");
+    expect(hrefs).toContain("/actions");
     expect(hrefs).toContain("/grc");
     expect(hrefs).toContain("/ask");
     expect(hrefs).toContain("/controls");
@@ -30,12 +31,15 @@ describe("navigation entries", () => {
     expect(hrefs).toContain("/credential-stores");
   });
 
-  it("uses operator labels for issues and compliance", () => {
+  it("uses operator labels for issues, Actions, and compliance", () => {
     expect(operatorNavLinks.find((entry) => entry.href === "/risk-inbox")).toMatchObject({
       label: "Issues",
     });
     expect(operatorNavLinks.find((entry) => entry.href === "/grc")).toMatchObject({
       label: "Compliance",
+    });
+    expect(operatorNavLinks.find((entry) => entry.href === "/actions")).toMatchObject({
+      label: "Actions",
     });
   });
 

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -24,6 +24,13 @@ export const operatorNavLinks: NavigationEntry[] = [
     keywords: ["issues", "findings", "risk", "sla", "triage", "owner", "framework", ...supportedGRCFrameworkNames],
   },
   {
+    label: "Actions",
+    href: "/actions",
+    description: "Remediation proposals, approvals, execution receipts, and independent verification.",
+    section: "Operator",
+    keywords: ["actions", "remediation", "approval", "execution", "verification", "rollback"],
+  },
+  {
     label: "Credentials",
     href: "/security/lifecycle",
     description: "Credential and certificate expiry, ownership, findings, and approved rotation routes.",


### PR DESCRIPTION
## What changed

- add an Actions queue backed by the Rust `GET /v1/actions` authority endpoint
- add read-only Action detail and append-only authority history views
- show the exact finding, target, proposal, approval, execution, and verification bindings returned by Rust
- add bounded cursor navigation and label every page-local count as current-page data
- add Actions to operator navigation and command discovery

## Why

Operators need to see the durable Rust remediation state before scoped command controls can safely replace older paths. This view does not synthesize state or treat provider execution as verification.

## Verification

- focused Vitest: 17 tests passed
- full web Vitest: 582 tests passed
- ESLint passed
- Next production build and TypeScript passed; 49 pages generated, including `/actions` and `/actions/[operationID]`
- `git diff --check`

`npm ci` continues to report the repository dependency tree existing 9 high-severity advisories; this PR does not change dependencies.

## Boundary

This is read-only UI parity over Rust authority. Approval, claim, execution, and verification controls remain out of scope until their signed receipts and provider coordination are wired end to end. It does not claim deployment cutover or full Rust UI parity.