### PR TITLE
Add durable Rust Action claim leases

### DIFF
--- a/apps/web/src/app/actions/[operationID]/page.test.tsx
+++ b/apps/web/src/app/actions/[operationID]/page.test.tsx
@@ -54,6 +54,7 @@ const action: ActionOperation = {
   approval_receipt: null,
   claimed_by: null,
   claimed_at_unix_ms: null,
+  claim_expires_at_unix_ms: null,
   executor_actor_id: null,
   executed_at_unix_ms: null,
   external_receipt_ref: null,

--- a/apps/web/src/app/actions/[operationID]/page.tsx
+++ b/apps/web/src/app/actions/[operationID]/page.tsx
@@ -90,6 +90,7 @@ export default function ActionDetailPage() {
           <dl>
             <DetailRow label="Claimed by" value={action.claimed_by || "Not claimed"} mono={Boolean(action.claimed_by)} />
             <DetailRow label="Claimed" value={actionTimeLabel(action.claimed_at_unix_ms)} />
+            <DetailRow label="Claim expires" value={actionTimeLabel(action.claim_expires_at_unix_ms)} />
             <DetailRow label="Executor" value={action.executor_actor_id || "No executor receipt"} mono={Boolean(action.executor_actor_id)} />
             <DetailRow label="Executed" value={actionTimeLabel(action.executed_at_unix_ms)} />
             <DetailRow label="External receipt" value={action.external_receipt_ref || "Not recorded"} mono={Boolean(action.external_receipt_ref)} />

--- a/apps/web/src/lib/actions.ts
+++ b/apps/web/src/lib/actions.ts
@@ -48,6 +48,7 @@ export type ActionOperation = {
   } | null;
   claimed_by?: string | null;
   claimed_at_unix_ms?: number | null;
+  claim_expires_at_unix_ms?: number | null;
   executor_actor_id?: string | null;
   executed_at_unix_ms?: number | null;
   external_receipt_ref?: string | null;

--- a/crates/action-store/src/lib.rs
+++ b/crates/action-store/src/lib.rs
@@ -252,6 +252,7 @@ impl PostgresActionLedger {
             approval_receipt: None,
             claimed_by: None,
             claimed_at_unix_ms: None,
+            claim_expires_at_unix_ms: None,
             executor_actor_id: None,
             executed_at_unix_ms: None,
             external_receipt_ref: None,
@@ -437,6 +438,16 @@ impl PostgresActionLedger {
         if committed_at_unix_ms < current.updated_at_unix_ms {
             return Err(ActionStoreError::Conflict(
                 "Action commit time predates the current version".to_owned(),
+            ));
+        }
+        if !command_valid_at_authority_time(
+            current.operation.proposal.proposal_expires_at_unix_ms,
+            current.operation.claim_expires_at_unix_ms,
+            &command,
+            committed_at_unix_ms,
+        ) {
+            return Err(ActionStoreError::Conflict(
+                "Action command is not valid at the authority commit time".to_owned(),
             ));
         }
         if !command_actor_matches(actor_id, current.operation.claimed_by.as_ref(), &command) {
@@ -698,9 +709,42 @@ fn command_actor_matches(
             executor_actor_id, ..
         } => executor_actor_id == actor_id,
         ActionCommand::Verify { receipt } => receipt.receipt.verifier_actor_id == *actor_id,
-        ActionCommand::StartExecution | ActionCommand::MarkOutcomeUnknown => owns_claim(),
+        ActionCommand::RenewClaim { .. }
+        | ActionCommand::StartExecution { .. }
+        | ActionCommand::MarkOutcomeUnknown => owns_claim(),
+        // Any signed executor may recover an unstarted claim after the engine
+        // verifies its recorded lease has expired. The releasing actor remains
+        // part of the append-only event history.
         ActionCommand::RecordSimulation
         | ActionCommand::RequestApproval
+        | ActionCommand::ReleaseExpiredClaim { .. }
+        | ActionCommand::RejectVerification
+        | ActionCommand::Fail
+        | ActionCommand::RollBack => true,
+    }
+}
+
+fn command_valid_at_authority_time(
+    proposal_expires_at_unix_ms: u64,
+    claim_expires_at_unix_ms: Option<u64>,
+    command: &ActionCommand,
+    committed_at_unix_ms: u64,
+) -> bool {
+    match command {
+        ActionCommand::Claim { .. } => committed_at_unix_ms < proposal_expires_at_unix_ms,
+        ActionCommand::RenewClaim { .. } | ActionCommand::StartExecution { .. } => {
+            claim_expires_at_unix_ms
+                .is_some_and(|claim_expires_at| committed_at_unix_ms < claim_expires_at)
+        }
+        ActionCommand::ReleaseExpiredClaim { .. } => claim_expires_at_unix_ms
+            .is_some_and(|claim_expires_at| committed_at_unix_ms >= claim_expires_at),
+        ActionCommand::RecordSimulation
+        | ActionCommand::RequestApproval
+        | ActionCommand::RecordApproval { .. }
+        | ActionCommand::MarkOutcomeUnknown
+        | ActionCommand::Complete { .. }
+        | ActionCommand::Reconcile { .. }
+        | ActionCommand::Verify { .. }
         | ActionCommand::RejectVerification
         | ActionCommand::Fail
         | ActionCommand::RollBack => true,
@@ -722,6 +766,13 @@ fn command_observed_at(command: &ActionCommand) -> Option<u64> {
         ActionCommand::Claim {
             claimed_at_unix_ms, ..
         } => Some(*claimed_at_unix_ms),
+        ActionCommand::RenewClaim {
+            renewed_at_unix_ms, ..
+        } => Some(*renewed_at_unix_ms),
+        ActionCommand::ReleaseExpiredClaim {
+            observed_at_unix_ms,
+        } => Some(*observed_at_unix_ms),
+        ActionCommand::StartExecution { started_at_unix_ms } => Some(*started_at_unix_ms),
         ActionCommand::Complete {
             executed_at_unix_ms,
             ..
@@ -733,7 +784,6 @@ fn command_observed_at(command: &ActionCommand) -> Option<u64> {
         ActionCommand::Verify { receipt } => Some(receipt.receipt.verified_at_unix_ms),
         ActionCommand::RecordSimulation
         | ActionCommand::RequestApproval
-        | ActionCommand::StartExecution
         | ActionCommand::MarkOutcomeUnknown
         | ActionCommand::RejectVerification
         | ActionCommand::Fail
@@ -881,10 +931,16 @@ mod tests {
             command_observed_at(&ActionCommand::Claim {
                 worker_id: cerebro_platform_sdk::OpaqueId::parse("worker:one").unwrap(),
                 claimed_at_unix_ms: 21,
+                claim_expires_at_unix_ms: 30,
             }),
             Some(21)
         );
-        assert_eq!(command_observed_at(&ActionCommand::StartExecution), None);
+        assert_eq!(
+            command_observed_at(&ActionCommand::StartExecution {
+                started_at_unix_ms: 22,
+            }),
+            Some(22)
+        );
     }
 
     #[test]
@@ -902,6 +958,7 @@ mod tests {
             &ActionCommand::Claim {
                 worker_id: cerebro_platform_sdk::OpaqueId::parse(actor.as_str()).unwrap(),
                 claimed_at_unix_ms: 10,
+                claim_expires_at_unix_ms: 20,
             }
         ));
         assert!(!command_actor_matches(
@@ -910,18 +967,46 @@ mod tests {
             &ActionCommand::Claim {
                 worker_id: cerebro_platform_sdk::OpaqueId::parse(actor.as_str()).unwrap(),
                 claimed_at_unix_ms: 10,
+                claim_expires_at_unix_ms: 20,
             }
         ));
         let claim = cerebro_platform_sdk::OpaqueId::parse(actor.as_str()).unwrap();
         assert!(command_actor_matches(
             &actor,
             Some(&claim),
-            &ActionCommand::StartExecution
+            &ActionCommand::StartExecution {
+                started_at_unix_ms: 11,
+            }
         ));
         assert!(!command_actor_matches(
             &other,
             Some(&claim),
-            &ActionCommand::StartExecution
+            &ActionCommand::StartExecution {
+                started_at_unix_ms: 11,
+            }
+        ));
+        assert!(command_actor_matches(
+            &actor,
+            Some(&claim),
+            &ActionCommand::RenewClaim {
+                renewed_at_unix_ms: 11,
+                claim_expires_at_unix_ms: 20,
+            }
+        ));
+        assert!(!command_actor_matches(
+            &other,
+            Some(&claim),
+            &ActionCommand::RenewClaim {
+                renewed_at_unix_ms: 11,
+                claim_expires_at_unix_ms: 20,
+            }
+        ));
+        assert!(command_actor_matches(
+            &other,
+            Some(&claim),
+            &ActionCommand::ReleaseExpiredClaim {
+                observed_at_unix_ms: 20,
+            }
         ));
         assert!(!command_actor_matches(
             &actor,
@@ -958,5 +1043,44 @@ mod tests {
                 executed_at_unix_ms: 11,
             }
         ));
+    }
+
+    #[test]
+    fn authority_commit_time_cannot_revive_an_expired_claim() {
+        let start = ActionCommand::StartExecution {
+            started_at_unix_ms: 19,
+        };
+        assert!(command_valid_at_authority_time(30, Some(20), &start, 19));
+        assert!(
+            !command_valid_at_authority_time(30, Some(20), &start, 20),
+            "a backdated start must fail at the exclusive authority deadline"
+        );
+
+        let renew = ActionCommand::RenewClaim {
+            renewed_at_unix_ms: 19,
+            claim_expires_at_unix_ms: 30,
+        };
+        assert!(command_valid_at_authority_time(30, Some(20), &renew, 19));
+        assert!(
+            !command_valid_at_authority_time(30, Some(20), &renew, 21),
+            "a backdated renewal must not revive an expired claim"
+        );
+
+        let release = ActionCommand::ReleaseExpiredClaim {
+            observed_at_unix_ms: 20,
+        };
+        assert!(!command_valid_at_authority_time(30, Some(20), &release, 19));
+        assert!(command_valid_at_authority_time(30, Some(20), &release, 20));
+
+        let claim = ActionCommand::Claim {
+            worker_id: cerebro_platform_sdk::OpaqueId::parse("worker:one").unwrap(),
+            claimed_at_unix_ms: 29,
+            claim_expires_at_unix_ms: 30,
+        };
+        assert!(command_valid_at_authority_time(30, None, &claim, 29));
+        assert!(
+            !command_valid_at_authority_time(30, None, &claim, 30),
+            "a backdated claim must not commit after proposal expiry"
+        );
     }
 }

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -833,8 +833,18 @@ enum HttpActionCommand {
     Claim {
         worker_id: String,
         claimed_at_unix_ms: u64,
+        claim_expires_at_unix_ms: u64,
     },
-    StartExecution {},
+    RenewClaim {
+        renewed_at_unix_ms: u64,
+        claim_expires_at_unix_ms: u64,
+    },
+    ReleaseExpiredClaim {
+        observed_at_unix_ms: u64,
+    },
+    StartExecution {
+        started_at_unix_ms: u64,
+    },
     MarkOutcomeUnknown {},
     Complete {
         external_receipt_ref: String,
@@ -894,7 +904,9 @@ impl HttpActionCommand {
             Self::RequestApproval {} => ACTION_PROPOSE_SCOPE,
             Self::RecordApproval { .. } => ACTION_APPROVE_SCOPE,
             Self::Claim { .. }
-            | Self::StartExecution {}
+            | Self::RenewClaim { .. }
+            | Self::ReleaseExpiredClaim { .. }
+            | Self::StartExecution { .. }
             | Self::MarkOutcomeUnknown {}
             | Self::Complete { .. }
             | Self::Reconcile { .. }
@@ -914,11 +926,27 @@ impl HttpActionCommand {
             Self::Claim {
                 worker_id,
                 claimed_at_unix_ms,
+                claim_expires_at_unix_ms,
             } => ActionCommand::Claim {
                 worker_id: OpaqueId::parse(worker_id).map_err(|error| error.to_string())?,
                 claimed_at_unix_ms,
+                claim_expires_at_unix_ms,
             },
-            Self::StartExecution {} => ActionCommand::StartExecution,
+            Self::RenewClaim {
+                renewed_at_unix_ms,
+                claim_expires_at_unix_ms,
+            } => ActionCommand::RenewClaim {
+                renewed_at_unix_ms,
+                claim_expires_at_unix_ms,
+            },
+            Self::ReleaseExpiredClaim {
+                observed_at_unix_ms,
+            } => ActionCommand::ReleaseExpiredClaim {
+                observed_at_unix_ms,
+            },
+            Self::StartExecution { started_at_unix_ms } => {
+                ActionCommand::StartExecution { started_at_unix_ms }
+            }
             Self::MarkOutcomeUnknown {} => ActionCommand::MarkOutcomeUnknown,
             Self::Complete {
                 external_receipt_ref,
@@ -3441,6 +3469,19 @@ mod tests {
             serde_json::from_value::<ActionTransitionRequest>(invalid).expect("request shape");
         assert!(request.command.into_domain().is_err());
 
+        let claim_without_expiry = serde_json::json!({
+            "expected_version": 1,
+            "command": {
+                "command": "claim",
+                "worker_id": "worker:one",
+                "claimed_at_unix_ms": 10
+            }
+        });
+        assert!(
+            serde_json::from_value::<ActionTransitionRequest>(claim_without_expiry).is_err(),
+            "the HTTP boundary must not create an unbounded claim"
+        );
+
         let valid = serde_json::json!({
             "expected_version": 1,
             "command": {"command": "record_simulation"}
@@ -3499,7 +3540,25 @@ mod tests {
             ACTION_PROPOSE_SCOPE
         );
         assert_eq!(
-            HttpActionCommand::StartExecution {}.required_scope(),
+            HttpActionCommand::StartExecution {
+                started_at_unix_ms: 10,
+            }
+            .required_scope(),
+            ACTION_EXECUTE_SCOPE
+        );
+        assert_eq!(
+            HttpActionCommand::RenewClaim {
+                renewed_at_unix_ms: 10,
+                claim_expires_at_unix_ms: 20,
+            }
+            .required_scope(),
+            ACTION_EXECUTE_SCOPE
+        );
+        assert_eq!(
+            HttpActionCommand::ReleaseExpiredClaim {
+                observed_at_unix_ms: 20,
+            }
+            .required_scope(),
             ACTION_EXECUTE_SCOPE
         );
         assert_eq!(
@@ -3523,7 +3582,9 @@ mod tests {
             Path("operation:http:one".to_owned()),
             Json(ActionTransitionRequest {
                 expected_version: 1,
-                command: HttpActionCommand::StartExecution {},
+                command: HttpActionCommand::StartExecution {
+                    started_at_unix_ms: 10,
+                },
             }),
         )
         .await

--- a/crates/platform-engine/src/action.rs
+++ b/crates/platform-engine/src/action.rs
@@ -1,6 +1,6 @@
 use cerebro_platform_sdk::{
     ActionOperation, ActionState, ActionVerificationReceipt, ActorId, ContentDigest,
-    DecisionReceipt, OpaqueId, SdkError, VerificationState,
+    DecisionReceipt, MAX_ACTION_CLAIM_LEASE_MS, OpaqueId, SdkError, VerificationState,
 };
 use serde::Serialize;
 
@@ -15,8 +15,22 @@ pub enum ActionCommand {
     Claim {
         worker_id: OpaqueId,
         claimed_at_unix_ms: u64,
+        claim_expires_at_unix_ms: u64,
     },
-    StartExecution,
+    /// Extends the dispatch lease before execution starts. Once execution
+    /// starts, uncertain outcomes must use reconciliation instead of takeover.
+    RenewClaim {
+        renewed_at_unix_ms: u64,
+        claim_expires_at_unix_ms: u64,
+    },
+    /// Returns an unstarted Action to the approved queue after its dispatch
+    /// lease expires so another executor can claim it.
+    ReleaseExpiredClaim {
+        observed_at_unix_ms: u64,
+    },
+    StartExecution {
+        started_at_unix_ms: u64,
+    },
     MarkOutcomeUnknown,
     Complete {
         external_receipt_ref: OpaqueId,
@@ -65,6 +79,7 @@ pub fn transition_action(
             ActionCommand::Claim {
                 worker_id,
                 claimed_at_unix_ms,
+                claim_expires_at_unix_ms,
             },
         ) => {
             let approval = operation
@@ -73,14 +88,67 @@ pub fn transition_action(
                 .ok_or(SdkError::Invalid("action approval receipt"))?;
             if claimed_at_unix_ms < approval.decided_at_unix_ms
                 || claimed_at_unix_ms >= operation.proposal.proposal_expires_at_unix_ms
+                || claim_expires_at_unix_ms <= claimed_at_unix_ms
+                || claim_expires_at_unix_ms > operation.proposal.proposal_expires_at_unix_ms
+                || claim_expires_at_unix_ms - claimed_at_unix_ms > MAX_ACTION_CLAIM_LEASE_MS
             {
                 return Err(SdkError::Invalid("action execution claim"));
             }
             next.state = ActionState::Claimed;
             next.claimed_by = Some(worker_id);
             next.claimed_at_unix_ms = Some(claimed_at_unix_ms);
+            next.claim_expires_at_unix_ms = Some(claim_expires_at_unix_ms);
         }
-        (ActionState::Claimed, ActionCommand::StartExecution) => {
+        (
+            ActionState::Claimed,
+            ActionCommand::RenewClaim {
+                renewed_at_unix_ms,
+                claim_expires_at_unix_ms,
+            },
+        ) => {
+            let current_expiry = operation
+                .claim_expires_at_unix_ms
+                .ok_or(SdkError::Invalid("action execution claim"))?;
+            if renewed_at_unix_ms < operation.claimed_at_unix_ms.unwrap_or(u64::MAX)
+                || renewed_at_unix_ms >= current_expiry
+                || claim_expires_at_unix_ms <= current_expiry
+                || claim_expires_at_unix_ms <= renewed_at_unix_ms
+                || claim_expires_at_unix_ms > operation.proposal.proposal_expires_at_unix_ms
+                || claim_expires_at_unix_ms - renewed_at_unix_ms > MAX_ACTION_CLAIM_LEASE_MS
+            {
+                return Err(SdkError::Invalid("action claim renewal"));
+            }
+            next.claim_expires_at_unix_ms = Some(claim_expires_at_unix_ms);
+        }
+        (
+            ActionState::Claimed,
+            ActionCommand::ReleaseExpiredClaim {
+                observed_at_unix_ms,
+            },
+        ) => {
+            if operation
+                .claim_expires_at_unix_ms
+                .is_none_or(|claim_expires_at| observed_at_unix_ms < claim_expires_at)
+            {
+                return Err(SdkError::Conflict(
+                    "action execution claim has not expired".to_owned(),
+                ));
+            }
+            next.state = ActionState::Approved;
+            next.claimed_by = None;
+            next.claimed_at_unix_ms = None;
+            next.claim_expires_at_unix_ms = None;
+        }
+        (ActionState::Claimed, ActionCommand::StartExecution { started_at_unix_ms }) => {
+            if started_at_unix_ms < operation.claimed_at_unix_ms.unwrap_or(u64::MAX)
+                || operation
+                    .claim_expires_at_unix_ms
+                    .is_none_or(|claim_expires_at| started_at_unix_ms >= claim_expires_at)
+            {
+                return Err(SdkError::Conflict(
+                    "action execution claim expired before execution started".to_owned(),
+                ));
+            }
             next.state = ActionState::Executing;
         }
         (ActionState::Executing, ActionCommand::MarkOutcomeUnknown) => {

--- a/crates/platform-engine/tests/engine.rs
+++ b/crates/platform-engine/tests/engine.rs
@@ -188,6 +188,7 @@ fn action_transitions_are_optimistic_and_fail_closed() {
         approval_receipt: None,
         claimed_by: None,
         claimed_at_unix_ms: None,
+        claim_expires_at_unix_ms: None,
         executor_actor_id: None,
         executed_at_unix_ms: None,
         external_receipt_ref: None,
@@ -209,6 +210,7 @@ fn action_transitions_are_optimistic_and_fail_closed() {
             ActionCommand::Claim {
                 worker_id: OpaqueId::parse("worker:one").expect("valid worker"),
                 claimed_at_unix_ms: 11,
+                claim_expires_at_unix_ms: 20,
             },
         )
         .is_err()
@@ -233,11 +235,97 @@ fn action_transitions_are_optimistic_and_fail_closed() {
         ActionCommand::Claim {
             worker_id: OpaqueId::parse("worker:one").expect("valid worker"),
             claimed_at_unix_ms: 11,
+            claim_expires_at_unix_ms: 20,
         },
     )
     .expect("transition");
-    let executing =
-        transition_action(&claimed, 5, ActionCommand::StartExecution).expect("transition");
+    assert!(
+        transition_action(
+            &claimed,
+            5,
+            ActionCommand::StartExecution {
+                started_at_unix_ms: 20,
+            },
+        )
+        .is_err(),
+        "a worker cannot start execution at the exclusive lease deadline"
+    );
+    assert!(
+        transition_action(
+            &claimed,
+            5,
+            ActionCommand::ReleaseExpiredClaim {
+                observed_at_unix_ms: 19,
+            },
+        )
+        .is_err(),
+        "a live claim cannot be taken over"
+    );
+    let released = transition_action(
+        &claimed,
+        5,
+        ActionCommand::ReleaseExpiredClaim {
+            observed_at_unix_ms: 20,
+        },
+    )
+    .expect("expired claim release");
+    assert_eq!(released.state, ActionState::Approved);
+    assert!(released.claimed_by.is_none());
+    assert!(released.claim_expires_at_unix_ms.is_none());
+    let reclaimed = transition_action(
+        &released,
+        6,
+        ActionCommand::Claim {
+            worker_id: OpaqueId::parse("worker:recovery").expect("valid worker"),
+            claimed_at_unix_ms: 21,
+            claim_expires_at_unix_ms: 30,
+        },
+    )
+    .expect("reclaim after expiry");
+    assert_eq!(
+        reclaimed.claimed_by.as_ref().map(OpaqueId::as_str),
+        Some("worker:recovery")
+    );
+    assert!(
+        transition_action(
+            &claimed,
+            5,
+            ActionCommand::RenewClaim {
+                renewed_at_unix_ms: 20,
+                claim_expires_at_unix_ms: 30,
+            },
+        )
+        .is_err(),
+        "an expired claim cannot be renewed"
+    );
+    let renewed = transition_action(
+        &claimed,
+        5,
+        ActionCommand::RenewClaim {
+            renewed_at_unix_ms: 15,
+            claim_expires_at_unix_ms: 25,
+        },
+    )
+    .expect("claim renewal");
+    assert_eq!(renewed.claim_expires_at_unix_ms, Some(25));
+    assert!(
+        transition_action(
+            &renewed,
+            6,
+            ActionCommand::StartExecution {
+                started_at_unix_ms: 24,
+            },
+        )
+        .is_ok()
+    );
+    let executing = transition_action(
+        &claimed,
+        5,
+        ActionCommand::StartExecution {
+            started_at_unix_ms: 12,
+        },
+    )
+    .expect("transition");
     let completed = transition_action(
         &executing,
         6,
@@ -261,7 +349,16 @@ fn action_transitions_are_optimistic_and_fail_closed() {
     assert_eq!(verified.verification_state, VerificationState::Verified);
     assert_eq!(verified.version, 8);
     assert!(verified.verification_receipt.is_some());
-    assert!(transition_action(&verified, 8, ActionCommand::StartExecution).is_err());
+    assert!(
+        transition_action(
+            &verified,
+            8,
+            ActionCommand::StartExecution {
+                started_at_unix_ms: 13,
+            },
+        )
+        .is_err()
+    );
 
     let uncertain =
         transition_action(&executing, 6, ActionCommand::MarkOutcomeUnknown).expect("transition");
@@ -319,6 +416,7 @@ fn action_authority_rejects_forged_approval_and_verification_receipts() {
         approval_receipt: None,
         claimed_by: None,
         claimed_at_unix_ms: None,
+        claim_expires_at_unix_ms: None,
         executor_actor_id: None,
         executed_at_unix_ms: None,
         external_receipt_ref: None,
@@ -417,6 +515,7 @@ fn action_authority_rejects_forged_approval_and_verification_receipts() {
             ActionCommand::Claim {
                 worker_id: OpaqueId::parse("worker:expired").expect("valid worker"),
                 claimed_at_unix_ms: approved.proposal.proposal_expires_at_unix_ms,
+                claim_expires_at_unix_ms: approved.proposal.proposal_expires_at_unix_ms,
             },
         )
         .is_err()
@@ -427,11 +526,18 @@ fn action_authority_rejects_forged_approval_and_verification_receipts() {
         ActionCommand::Claim {
             worker_id: OpaqueId::parse("worker:receipt-check").expect("valid worker"),
             claimed_at_unix_ms: 11,
+            claim_expires_at_unix_ms: 20,
         },
     )
     .expect("claim");
-    let executing =
-        transition_action(&claimed, 5, ActionCommand::StartExecution).expect("execution");
+    let executing = transition_action(
+        &claimed,
+        5,
+        ActionCommand::StartExecution {
+            started_at_unix_ms: 12,
+        },
+    )
+    .expect("execution");
     let completed = transition_action(
         &executing,
         6,

--- a/crates/platform-sdk/src/action.rs
+++ b/crates/platform-sdk/src/action.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 const ACTION_PROPOSAL_DIGEST_SCHEMA: &str = "cerebro.action-proposal.v1";
+pub const MAX_ACTION_CLAIM_LEASE_MS: u64 = 5 * 60 * 1_000;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -167,6 +168,7 @@ pub struct ActionOperation {
     pub approval_receipt: Option<DecisionReceipt>,
     pub claimed_by: Option<OpaqueId>,
     pub claimed_at_unix_ms: Option<u64>,
+    pub claim_expires_at_unix_ms: Option<u64>,
     pub executor_actor_id: Option<ActorId>,
     pub executed_at_unix_ms: Option<u64>,
     pub external_receipt_ref: Option<OpaqueId>,
@@ -206,14 +208,21 @@ impl ActionOperation {
         } else {
             false
         };
-        let has_claim = match (&self.claimed_by, self.claimed_at_unix_ms) {
-            (None, None) => false,
-            (Some(_), Some(claimed_at)) => {
+        let has_claim = match (
+            &self.claimed_by,
+            self.claimed_at_unix_ms,
+            self.claim_expires_at_unix_ms,
+        ) {
+            (None, None, None) => false,
+            (Some(_), Some(claimed_at), Some(claim_expires_at)) => {
                 let Some(approval) = self.approval_receipt.as_ref() else {
                     return Err(SdkError::Invalid("action operation claimant"));
                 };
                 if claimed_at < approval.decided_at_unix_ms
                     || claimed_at >= self.proposal.proposal_expires_at_unix_ms
+                    || claim_expires_at <= claimed_at
+                    || claim_expires_at > self.proposal.proposal_expires_at_unix_ms
+                    || claim_expires_at - claimed_at > MAX_ACTION_CLAIM_LEASE_MS
                 {
                     return Err(SdkError::Invalid("action operation claimant"));
                 }
@@ -399,6 +408,7 @@ struct StoredActionOperation {
     approval_receipt: Option<StoredDecisionReceipt>,
     claimed_by: Option<String>,
     claimed_at_unix_ms: Option<u64>,
+    claim_expires_at_unix_ms: Option<u64>,
     executor_actor_id: Option<String>,
     executed_at_unix_ms: Option<u64>,
     external_receipt_ref: Option<String>,
@@ -418,6 +428,7 @@ impl TryFrom<StoredActionOperation> for ActionOperation {
             approval_receipt: stored.approval_receipt.map(TryInto::try_into).transpose()?,
             claimed_by: stored.claimed_by.map(OpaqueId::parse).transpose()?,
             claimed_at_unix_ms: stored.claimed_at_unix_ms,
+            claim_expires_at_unix_ms: stored.claim_expires_at_unix_ms,
             executor_actor_id: stored.executor_actor_id.map(parse_actor_id).transpose()?,
             executed_at_unix_ms: stored.executed_at_unix_ms,
             external_receipt_ref: stored
@@ -616,6 +627,7 @@ mod tests {
         let mut dormant_claim = serde_json::to_value(operation()).expect("serialize operation");
         dormant_claim["claimed_by"] = serde_json::json!("worker:attacker");
         dormant_claim["claimed_at_unix_ms"] = serde_json::json!(2);
+        dormant_claim["claim_expires_at_unix_ms"] = serde_json::json!(3);
         assert!(serde_json::from_value::<ActionOperation>(dormant_claim).is_err());
     }
 
@@ -652,6 +664,7 @@ mod tests {
             approval_receipt: None,
             claimed_by: None,
             claimed_at_unix_ms: None,
+            claim_expires_at_unix_ms: None,
             executor_actor_id: None,
             executed_at_unix_ms: None,
             external_receipt_ref: None,

--- a/crates/platform-sdk/src/lib.rs
+++ b/crates/platform-sdk/src/lib.rs
@@ -26,7 +26,7 @@ mod view;
 
 pub use action::{
     ActionEffect, ActionOperation, ActionProposal, ActionReceipt, ActionState,
-    ActionVerificationReceipt, VerificationState,
+    ActionVerificationReceipt, MAX_ACTION_CLAIM_LEASE_MS, VerificationState,
 };
 pub use assertion::{
     AssertionCondition, AssertionDefinition, AssertionEvaluation, AssertionState, EvaluationTrigger,


### PR DESCRIPTION
## Summary
- add bounded, expiring dispatch claims to the Rust Action authority
- let the current executor renew a live claim and let any execute-scoped recovery worker release it only after expiry
- reject backdated claims, renewals, and execution starts at the durable authority commit boundary
- expose the claim deadline through the Rust HTTP contract and the Action detail page

## Authority boundary
The lease ends when execution starts. An executing Action cannot be taken over; an uncertain execution moves to `outcome_unknown` and follows the existing reconciliation path.

## Verification
- `cargo fmt --all --check`
- `cargo test -p cerebro-platform-sdk -p cerebro-platform-engine -p cerebro-action-store -p cerebro-platform`
- web focused tests: 2 files, 4 tests
- web full suite: 99 files, 583 tests
- web production build and ESLint
- `git diff --check`

The live PostgreSQL ledger test remains intentionally ignored unless a disposable PostgreSQL instance is provided.
