### PR TITLE
Land Rust security-path authority on main

### DIFF
--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -360,8 +360,7 @@ func (a *App) runSourceRuntimeOrchestrateJob(ctx context.Context, job *ports.Job
 		RuntimeID: runtimeID, SourcePageLimit: uint32Payload(job.Payload, "page_limit"), GraphPageLimit: uint32Payload(job.Payload, "graph_page_limit"),
 		RuleIDs: stringSlicePayload(job.Payload, "rule_ids"), EventLimit: uint32Payload(job.Payload, "event_limit"),
 		CaptureSecurityPathDelta: boolPayload(job.Payload, "capture_security_path_delta"), SecurityPathAccountID: stringPayload(job.Payload, "security_path_account_id", ""),
-		SecurityPathRustShadow: boolPayload(job.Payload, "security_path_rust_shadow"),
-		ObservationID:          strings.TrimSpace(job.ID), LeaseOwner: "security-path-delta:" + strings.TrimSpace(job.ID),
+		ObservationID: strings.TrimSpace(job.ID), LeaseOwner: "security-path-delta:" + strings.TrimSpace(job.ID),
 	})
 	payload, refs, mapErr := orchestration.JobPayload()
 	if mapErr != nil {

--- a/internal/runtimeorchestration/orchestration.go
+++ b/internal/runtimeorchestration/orchestration.go
@@ -26,7 +26,6 @@ type OrchestrationRequest struct {
 	RuleIDs                  []string
 	EventLimit               uint32
 	CaptureSecurityPathDelta bool
-	SecurityPathRustShadow   bool
 	SecurityPathAccountID    string
 	ObservationID            string
 	LeaseOwner               string
@@ -50,14 +49,14 @@ type JobPayload struct {
 // SecurityPathJobPayload records comparison and verification outputs from one
 // orchestrated security-path capture.
 type SecurityPathJobPayload struct {
-	Before                  securitypathdelta.Snapshot           `json:"before"`
-	After                   securitypathdelta.Snapshot           `json:"after"`
-	Delta                   securitypathdelta.Delta              `json:"delta"`
-	RustShadow              []securitypathdelta.RustShadowResult `json:"rust_shadow,omitempty"`
-	VerificationGraphIngest *graphingest.RunResult               `json:"verification_graph_ingest,omitempty"`
-	VerificationGraphRuns   []RuntimeGraphRun                    `json:"verification_graph_ingests,omitempty"`
-	VerificationSnapshot    *securitypathdelta.Snapshot          `json:"verification_snapshot,omitempty"`
-	Verification            *securitypathdelta.Verification      `json:"verification,omitempty"`
+	Before                  securitypathdelta.Snapshot               `json:"before"`
+	After                   securitypathdelta.Snapshot               `json:"after"`
+	Delta                   securitypathdelta.Delta                  `json:"delta"`
+	RustAuthority           []securitypathdelta.RustAuthorityReceipt `json:"rust_authority"`
+	VerificationGraphIngest *graphingest.RunResult                   `json:"verification_graph_ingest,omitempty"`
+	VerificationGraphRuns   []RuntimeGraphRun                        `json:"verification_graph_ingests,omitempty"`
+	VerificationSnapshot    *securitypathdelta.Snapshot              `json:"verification_snapshot,omitempty"`
+	Verification            *securitypathdelta.Verification          `json:"verification,omitempty"`
 }
 
 // JobResult is the storage shape accepted by the platform job service.
@@ -85,7 +84,7 @@ func (s *SecurityPathService) Orchestrate(ctx context.Context, evaluator finding
 	if request.CaptureSecurityPathDelta {
 		capture, captureErr := s.Capture(ctx, SecurityPathRequest{
 			RuntimeID: request.RuntimeID, AccountID: request.SecurityPathAccountID, ObservationID: request.ObservationID,
-			SourcePageLimit: request.SourcePageLimit, GraphPageLimit: request.GraphPageLimit, LeaseOwner: request.LeaseOwner, RustShadow: request.SecurityPathRustShadow,
+			SourcePageLimit: request.SourcePageLimit, GraphPageLimit: request.GraphPageLimit, LeaseOwner: request.LeaseOwner,
 		})
 		result.Sync, result.Graph, result.SecurityPath = capture.Sync, capture.Graph, &capture
 		if result.Graph != nil && evaluator != nil {
@@ -147,7 +146,7 @@ func (result OrchestrationResult) JobPayload() (JobPayload, map[string]string, e
 	capture := result.SecurityPath
 	securityPath := &SecurityPathJobPayload{
 		Before: capture.Before, After: capture.After, Delta: capture.Delta,
-		RustShadow: capture.RustShadow,
+		RustAuthority: capture.RustAuthority,
 	}
 	payload.SecurityPathDelta = securityPath
 	refs["security_path_delta_id"] = capture.Delta.ID

--- a/internal/runtimeorchestration/rust_shadow_wiring_test.go
+++ b/internal/runtimeorchestration/rust_shadow_wiring_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/writer/cerebro/internal/securitypathdelta"
 )
 
-func TestJobPayloadIncludesBoundedRustShadowEvidence(t *testing.T) {
+func TestJobPayloadIncludesBoundRustAuthorityReceipts(t *testing.T) {
 	t.Parallel()
 	result := OrchestrationResult{SecurityPath: &SecurityPathResult{
 		Delta: securitypathdelta.Delta{ID: "delta-a", Digest: "digest-a"},
-		RustShadow: []securitypathdelta.RustShadowResult{{
-			Operation: "compare", Status: securitypathdelta.RustShadowMatch,
-			GoDigest: "go-digest", RustDigest: "rust-digest",
+		RustAuthority: []securitypathdelta.RustAuthorityReceipt{{
+			Operation: "compare", SchemaVersion: "security-path-decision-input/v1",
+			InputDigest: "input-digest", DecisionDigest: "decision-digest",
 		}},
 	}}
 	payload, _, err := result.JobPayload()
@@ -24,9 +24,9 @@ func TestJobPayloadIncludesBoundedRustShadowEvidence(t *testing.T) {
 	if securityPath == nil {
 		t.Fatalf("security_path_delta = %#v", payload.SecurityPathDelta)
 	}
-	shadow := securityPath.RustShadow
-	if len(shadow) != 1 || shadow[0].Status != securitypathdelta.RustShadowMatch {
-		t.Fatalf("rust_shadow = %#v", shadow)
+	authority := securityPath.RustAuthority
+	if len(authority) != 1 || authority[0].Operation != "compare" {
+		t.Fatalf("rust_authority = %#v", authority)
 	}
 	encoded, err := json.Marshal(payload.Result())
 	if err != nil {
@@ -40,7 +40,7 @@ func TestJobPayloadIncludesBoundedRustShadowEvidence(t *testing.T) {
 	if !ok {
 		t.Fatalf("wire security_path_delta = %#v", wire["security_path_delta"])
 	}
-	if _, ok := securityPathWire["rust_shadow"].([]any); !ok {
-		t.Fatalf("wire rust_shadow = %#v", securityPathWire["rust_shadow"])
+	if _, ok := securityPathWire["rust_authority"].([]any); !ok {
+		t.Fatalf("wire rust_authority = %#v", securityPathWire["rust_authority"])
 	}
 }

--- a/internal/runtimeorchestration/security_path_orchestrator.go
+++ b/internal/runtimeorchestration/security_path_orchestrator.go
@@ -19,7 +19,6 @@ type SecurityPathRequest struct {
 	SourcePageLimit uint32
 	GraphPageLimit  uint32
 	LeaseOwner      string
-	RustShadow      bool
 }
 
 type RuntimeGraphRun struct {
@@ -28,16 +27,16 @@ type RuntimeGraphRun struct {
 }
 
 type SecurityPathResult struct {
-	Sync                    *cerebrov1.SyncSourceRuntimeResponse `json:"sync,omitempty"`
-	Graph                   *graphingest.RunResult               `json:"graph_ingest,omitempty"`
-	Before                  securitypathdelta.Snapshot           `json:"before"`
-	After                   securitypathdelta.Snapshot           `json:"after"`
-	Delta                   securitypathdelta.Delta              `json:"delta"`
-	VerificationGraphIngest *graphingest.RunResult               `json:"verification_graph_ingest,omitempty"`
-	VerificationGraphRuns   []RuntimeGraphRun                    `json:"verification_graph_ingests,omitempty"`
-	VerificationSnapshot    *securitypathdelta.Snapshot          `json:"verification_snapshot,omitempty"`
-	Verification            *securitypathdelta.Verification      `json:"verification,omitempty"`
-	RustShadow              []securitypathdelta.RustShadowResult `json:"rust_shadow,omitempty"`
+	Sync                    *cerebrov1.SyncSourceRuntimeResponse     `json:"sync,omitempty"`
+	Graph                   *graphingest.RunResult                   `json:"graph_ingest,omitempty"`
+	Before                  securitypathdelta.Snapshot               `json:"before"`
+	After                   securitypathdelta.Snapshot               `json:"after"`
+	Delta                   securitypathdelta.Delta                  `json:"delta"`
+	VerificationGraphIngest *graphingest.RunResult                   `json:"verification_graph_ingest,omitempty"`
+	VerificationGraphRuns   []RuntimeGraphRun                        `json:"verification_graph_ingests,omitempty"`
+	VerificationSnapshot    *securitypathdelta.Snapshot              `json:"verification_snapshot,omitempty"`
+	Verification            *securitypathdelta.Verification          `json:"verification,omitempty"`
+	RustAuthority           []securitypathdelta.RustAuthorityReceipt `json:"rust_authority"`
 }
 
 func (s *SecurityPathService) Capture(ctx context.Context, request SecurityPathRequest) (result SecurityPathResult, runErr error) {
@@ -110,12 +109,14 @@ func (s *SecurityPathService) Capture(ctx context.Context, request SecurityPathR
 	if err != nil {
 		return result, err
 	}
-	result.Delta, err = securitypathdelta.Compare(&result.Before, result.After)
-	if err == nil && request.RustShadow {
-		result.RustShadow = append(result.RustShadow, securitypathdelta.CompareRustShadow(ctx, &result.Before, result.After, result.Delta))
-	}
-	if err != nil || len(result.Delta.NoLongerObserved) == 0 {
+	var deltaAuthority securitypathdelta.RustAuthorityReceipt
+	result.Delta, deltaAuthority, err = securitypathdelta.CompareRustAuthority(ctx, &result.Before, result.After)
+	if err != nil {
 		return result, err
+	}
+	result.RustAuthority = append(result.RustAuthority, deltaAuthority)
+	if len(result.Delta.NoLongerObserved) == 0 {
+		return result, nil
 	}
 
 	requestedPathIDs := make([]string, 0, len(result.Delta.NoLongerObserved))
@@ -146,11 +147,7 @@ func (s *SecurityPathService) Capture(ctx context.Context, request SecurityPathR
 	}
 	if verification.Verification.ID != "" {
 		result.Verification = &verification.Verification
-		if request.RustShadow && result.VerificationSnapshot != nil {
-			result.RustShadow = append(result.RustShadow, securitypathdelta.VerifyObservedAbsentRustShadow(
-				ctx, result.Before, *result.VerificationSnapshot, requestedPathIDs, verification.Verification,
-			))
-		}
+		result.RustAuthority = append(result.RustAuthority, verification.Authority)
 	}
 	return result, err
 }
@@ -171,6 +168,7 @@ type verificationResult struct {
 	GraphRuns    []RuntimeGraphRun
 	Snapshot     securitypathdelta.Snapshot
 	Verification securitypathdelta.Verification
+	Authority    securitypathdelta.RustAuthorityReceipt
 }
 
 func (s *SecurityPathService) collectVerification(ctx context.Context, request verificationRequest) (result verificationResult, runErr error) {
@@ -256,7 +254,12 @@ func (s *SecurityPathService) collectVerification(ctx context.Context, request v
 	if !result.Snapshot.ObservedAt.After(request.Current.ObservedAt) {
 		return result, errors.New("security path verification observation did not follow the delta observation")
 	}
-	result.Verification, err = securitypathdelta.VerifyObservedAbsent(request.Reference, result.Snapshot, request.RequestedPathIDs)
+	result.Verification, result.Authority, err = securitypathdelta.VerifyObservedAbsentRustAuthority(
+		leaseCtx,
+		request.Reference,
+		result.Snapshot,
+		request.RequestedPathIDs,
+	)
 	return result, err
 }
 

--- a/internal/securitypathdelta/rust_authority.go
+++ b/internal/securitypathdelta/rust_authority.go
@@ -1,0 +1,311 @@
+package securitypathdelta
+
+import (
+	"context"
+	"fmt"
+	"slices"
+)
+
+// RustAuthorityReceipt binds a security-path decision to the exact input and
+// source snapshots evaluated by the embedded Rust kernel.
+type RustAuthorityReceipt struct {
+	Operation             string   `json:"operation"`
+	SchemaVersion         string   `json:"schema_version"`
+	InputDigest           string   `json:"input_digest"`
+	SourceSnapshotDigests []string `json:"source_snapshot_digests"`
+	DecisionDigest        string   `json:"decision_digest"`
+}
+
+// CompareRustAuthority obtains the comparison decision from the embedded Rust
+// kernel. Go only hydrates the existing API record from source snapshots after
+// validating every returned reference; evaluator failure has no Go fallback.
+func CompareRustAuthority(ctx context.Context, before *Snapshot, after Snapshot) (Delta, RustAuthorityReceipt, error) {
+	var response rustComparisonResponse
+	receipt, err := evaluateRustSecurityPath(ctx, rustComparisonRequest{
+		Operation: "compare",
+		Before:    rustSnapshotPointer(before),
+		After:     rustSnapshotFromSnapshot(after),
+	}, &response)
+	if err != nil {
+		return Delta{}, RustAuthorityReceipt{}, err
+	}
+	if response.Operation != "compare" {
+		return Delta{}, RustAuthorityReceipt{}, fmt.Errorf("%w: unexpected comparison operation", ErrRustEvaluatorUnavailable)
+	}
+	if response.Result.Digest == "" || response.Result.Digest != rustComparisonDecisionDigest(response.Result) {
+		return Delta{}, RustAuthorityReceipt{}, fmt.Errorf("%w: comparison decision digest mismatch", ErrRustEvaluatorUnavailable)
+	}
+	delta, err := hydrateRustComparison(before, after, response.Result)
+	if err != nil {
+		return Delta{}, RustAuthorityReceipt{}, err
+	}
+	return delta, authorityReceipt("compare", receipt, response.Result.Digest), nil
+}
+
+// VerifyObservedAbsentRustAuthority obtains the verification decision from the
+// embedded Rust kernel and fails closed when the decision cannot be bound back
+// to the supplied snapshots.
+func VerifyObservedAbsentRustAuthority(
+	ctx context.Context,
+	reference Snapshot,
+	after Snapshot,
+	requestedPathIDs []string,
+) (Verification, RustAuthorityReceipt, error) {
+	var response rustVerificationResponse
+	receipt, err := evaluateRustSecurityPath(ctx, rustVerificationRequest{
+		Operation:        "verify_observed_absent",
+		Reference:        rustSnapshotFromSnapshot(reference),
+		After:            rustSnapshotFromSnapshot(after),
+		RequestedPathIDs: normalizedStrings(requestedPathIDs),
+	}, &response)
+	if err != nil {
+		return Verification{}, RustAuthorityReceipt{}, err
+	}
+	if response.Operation != "verify_observed_absent" {
+		return Verification{}, RustAuthorityReceipt{}, fmt.Errorf("%w: unexpected verification operation", ErrRustEvaluatorUnavailable)
+	}
+	if response.Result.Digest == "" || response.Result.Digest != rustVerificationDecisionDigest(response.Result) {
+		return Verification{}, RustAuthorityReceipt{}, fmt.Errorf("%w: verification decision digest mismatch", ErrRustEvaluatorUnavailable)
+	}
+	verification, err := hydrateRustVerification(reference, after, response.Result)
+	if err != nil {
+		return Verification{}, RustAuthorityReceipt{}, err
+	}
+	return verification, authorityReceipt("verify_observed_absent", receipt, response.Result.Digest), nil
+}
+
+func authorityReceipt(operation string, receipt rustDecisionReceipt, decisionDigest string) RustAuthorityReceipt {
+	return RustAuthorityReceipt{
+		Operation:             operation,
+		SchemaVersion:         receipt.SchemaVersion,
+		InputDigest:           receipt.InputDigest,
+		SourceSnapshotDigests: append([]string(nil), receipt.SourceSnapshotDigests...),
+		DecisionDigest:        decisionDigest,
+	}
+}
+
+func hydrateRustComparison(before *Snapshot, after Snapshot, decision rustComparisonDecision) (Delta, error) {
+	state := DeltaState(decision.State)
+	switch state {
+	case DeltaStateInitial, DeltaStateCompared, DeltaStateIndeterminate:
+	default:
+		return Delta{}, fmt.Errorf("%w: unknown Rust comparison state %q", ErrRustEvaluatorUnavailable, decision.State)
+	}
+	afterPaths, err := pathsByID(after.Paths)
+	if err != nil {
+		return Delta{}, err
+	}
+	beforePaths := map[string]SecurityPath{}
+	beforeID := ""
+	beforeRef := SnapshotRef{}
+	if before != nil {
+		beforePaths, err = pathsByID(before.Paths)
+		if err != nil {
+			return Delta{}, err
+		}
+		beforeID = before.ID
+		beforeRef = snapshotRef(*before)
+	}
+	newlyObserved, err := hydratePathIDs("newly observed", decision.NewlyObservedPathIDs, afterPaths)
+	if err != nil {
+		return Delta{}, err
+	}
+	noLongerObserved, err := hydratePathIDs("no longer observed", decision.NoLongerObservedPathIDs, beforePaths)
+	if err != nil {
+		return Delta{}, err
+	}
+	var proofChanged []ProofChange
+	if len(decision.ProofChanged) != 0 {
+		proofChanged = make([]ProofChange, 0, len(decision.ProofChanged))
+	}
+	for _, change := range decision.ProofChanged {
+		beforeChanged, err := hydratePathIDs("changed before", change.BeforePathIDs, beforePaths)
+		if err != nil {
+			return Delta{}, err
+		}
+		afterChanged, err := hydratePathIDs("changed after", change.AfterPathIDs, afterPaths)
+		if err != nil {
+			return Delta{}, err
+		}
+		if !pathsShareRoute(beforeChanged, change.RouteID) || !pathsShareRoute(afterChanged, change.RouteID) {
+			return Delta{}, fmt.Errorf("%w: Rust proof change references the wrong route", ErrRustEvaluatorUnavailable)
+		}
+		proofChanged = append(proofChanged, ProofChange{
+			RouteID:     change.RouteID,
+			BeforePaths: beforeChanged,
+			AfterPaths:  afterChanged,
+		})
+	}
+	cuts, err := hydrateCandidateCuts(decision.CandidateEdgeCuts, newlyObserved)
+	if err != nil {
+		return Delta{}, err
+	}
+	delta := Delta{
+		TenantID:          after.TenantID,
+		ScopeID:           after.ScopeID,
+		DetectorID:        after.DetectorID,
+		DetectorRevision:  after.DetectorRevision,
+		State:             state,
+		Before:            beforeRef,
+		After:             snapshotRef(after),
+		NewlyObserved:     newlyObserved,
+		NoLongerObserved:  noLongerObserved,
+		ProofChanged:      proofChanged,
+		UnchangedRoutes:   decision.UnchangedRoutes,
+		CandidateEdgeCuts: cuts,
+	}
+	delta.ID = digestStrings(
+		"security-path-delta/v1",
+		after.TenantID,
+		after.ScopeID,
+		after.DetectorID,
+		after.DetectorRevision,
+		beforeID,
+		after.ID,
+	)
+	delta.Digest, err = digestValue(delta)
+	if err != nil {
+		return Delta{}, err
+	}
+	return delta, nil
+}
+
+func hydrateRustVerification(reference Snapshot, after Snapshot, decision rustVerificationDecision) (Verification, error) {
+	state := VerificationState(decision.State)
+	switch state {
+	case VerificationObservedAbsent, VerificationStillObserved, VerificationIndeterminate:
+	default:
+		return Verification{}, fmt.Errorf("%w: unknown Rust verification state %q", ErrRustEvaluatorUnavailable, decision.State)
+	}
+	afterPaths, err := pathsByID(after.Paths)
+	if err != nil {
+		return Verification{}, err
+	}
+	stillObserved, err := hydratePathIDs("still observed", decision.StillObservedPathIDs, afterPaths)
+	if err != nil {
+		return Verification{}, err
+	}
+	cuts, err := hydrateCandidateCuts(decision.CandidateEdgeCuts, stillObserved)
+	if err != nil {
+		return Verification{}, err
+	}
+	verification := Verification{
+		TenantID:          after.TenantID,
+		ScopeID:           after.ScopeID,
+		DetectorID:        after.DetectorID,
+		DetectorRevision:  after.DetectorRevision,
+		Reference:         snapshotRef(reference),
+		After:             snapshotRef(after),
+		RequestedPathIDs:  append([]string(nil), decision.RequestedPathIDs...),
+		RequestedRouteIDs: append([]string(nil), decision.RequestedRouteIDs...),
+		State:             state,
+		Reasons:           append([]string(nil), decision.Reasons...),
+		StillObserved:     stillObserved,
+		CandidateEdgeCuts: cuts,
+	}
+	verification.ID = digestStrings(
+		"security-path-verification/v1",
+		after.TenantID,
+		after.ScopeID,
+		after.DetectorID,
+		after.DetectorRevision,
+		reference.ID,
+		after.ID,
+		digestStrings(decision.RequestedPathIDs...),
+	)
+	verification.Digest, err = digestValue(verification)
+	if err != nil {
+		return Verification{}, err
+	}
+	return verification, nil
+}
+
+func pathsByID(paths []SecurityPath) (map[string]SecurityPath, error) {
+	result := make(map[string]SecurityPath, len(paths))
+	for _, path := range paths {
+		if _, exists := result[path.ID]; exists {
+			return nil, fmt.Errorf("%w: duplicate security path ID %q", ErrRustEvaluatorUnavailable, path.ID)
+		}
+		result[path.ID] = path
+	}
+	return result, nil
+}
+
+func hydratePathIDs(label string, ids []string, available map[string]SecurityPath) ([]SecurityPath, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	result := make([]SecurityPath, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, duplicate := seen[id]; duplicate {
+			return nil, fmt.Errorf("%w: duplicate Rust %s path ID %q", ErrRustEvaluatorUnavailable, label, id)
+		}
+		path, ok := available[id]
+		if !ok {
+			return nil, fmt.Errorf("%w: unknown Rust %s path ID %q", ErrRustEvaluatorUnavailable, label, id)
+		}
+		seen[id] = struct{}{}
+		result = append(result, path)
+	}
+	sortSecurityPaths(result)
+	return result, nil
+}
+
+func pathsShareRoute(paths []SecurityPath, routeID string) bool {
+	if routeID == "" || len(paths) == 0 {
+		return false
+	}
+	for _, path := range paths {
+		if path.RouteID != routeID {
+			return false
+		}
+	}
+	return true
+}
+
+func hydrateCandidateCuts(cuts []CandidateEdgeCut, paths []SecurityPath) ([]CandidateEdgeCut, error) {
+	if len(cuts) == 0 {
+		return nil, nil
+	}
+	edges := make(map[string]ProofEdge)
+	pathRoutes := make(map[string]string, len(paths))
+	for _, path := range paths {
+		pathRoutes[path.ID] = path.RouteID
+		for _, edge := range path.ProofEdges {
+			if _, exists := edges[edge.ID]; exists {
+				continue
+			}
+			edges[edge.ID] = edge
+		}
+	}
+	result := make([]CandidateEdgeCut, len(cuts))
+	for index, cut := range cuts {
+		edge, ok := edges[cut.Edge.ID]
+		if !ok || edge.Relation != cut.Edge.Relation || edge.SourceRuntimeID != cut.Edge.SourceRuntimeID ||
+			!slices.Equal(edge.AssertionRuntimeIDs, cut.Edge.AssertionRuntimeIDs) {
+			return nil, fmt.Errorf("%w: Rust candidate edge %q is not bound to an eligible path", ErrRustEvaluatorUnavailable, cut.Edge.ID)
+		}
+		if cut.Rank != index+1 || cut.RouteCoverage != len(cut.CoveredRouteIDs) || cut.PathCoverage != len(cut.CoveredPathIDs) {
+			return nil, fmt.Errorf("%w: Rust candidate cut coverage is inconsistent", ErrRustEvaluatorUnavailable)
+		}
+		coveredRoutes := make(map[string]struct{}, len(cut.CoveredRouteIDs))
+		for _, routeID := range cut.CoveredRouteIDs {
+			coveredRoutes[routeID] = struct{}{}
+		}
+		for _, pathID := range cut.CoveredPathIDs {
+			routeID, ok := pathRoutes[pathID]
+			if !ok {
+				return nil, fmt.Errorf("%w: Rust candidate cut references unknown path %q", ErrRustEvaluatorUnavailable, pathID)
+			}
+			if _, ok := coveredRoutes[routeID]; !ok {
+				return nil, fmt.Errorf("%w: Rust candidate cut omits covered route %q", ErrRustEvaluatorUnavailable, routeID)
+			}
+		}
+		result[index] = cut
+		result[index].Edge = edge
+		result[index].CoveredRouteIDs = append([]string(nil), cut.CoveredRouteIDs...)
+		result[index].CoveredPathIDs = append([]string(nil), cut.CoveredPathIDs...)
+	}
+	return result, nil
+}

--- a/internal/securitypathdelta/rust_authority_test.go
+++ b/internal/securitypathdelta/rust_authority_test.go
@@ -1,0 +1,103 @@
+package securitypathdelta
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRustComparisonAuthorityPreservesTheExistingResultContract(t *testing.T) {
+	t.Parallel()
+	beforeAt := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	before := mustSnapshot(t, snapshotInput("before", beforeAt, true,
+		testPath("removed", "principal-a", "permission-a", "runs_as", "before", beforeAt),
+	))
+	after := mustSnapshot(t, snapshotInput("after", beforeAt.Add(5*time.Minute), true,
+		testPath("new-a", "principal-b", "permission-b", "can_assume", "after-a", beforeAt.Add(5*time.Minute)),
+		testPath("new-b", "principal-b", "permission-b", "can_assume", "after-b", beforeAt.Add(5*time.Minute)),
+	))
+	legacy, err := Compare(&before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authoritative, receipt, err := CompareRustAuthority(context.Background(), &before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(authoritative, legacy) {
+		t.Fatalf("Rust authority changed the compatibility record\nRust: %#v\nlegacy: %#v", authoritative, legacy)
+	}
+	if receipt.Operation != "compare" || receipt.SchemaVersion != securityPathDecisionInputV1 ||
+		receipt.InputDigest == "" || receipt.DecisionDigest == "" ||
+		!reflect.DeepEqual(receipt.SourceSnapshotDigests, []string{before.Digest, after.Digest}) {
+		t.Fatalf("Rust authority receipt = %#v", receipt)
+	}
+}
+
+func TestRustVerificationAuthorityPreservesTheExistingResultContract(t *testing.T) {
+	t.Parallel()
+	referenceAt := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	reference := mustSnapshot(t, snapshotInput("reference", referenceAt, true,
+		testPath("resource-a", "principal-a", "permission-a", "can_assume", "reference", referenceAt),
+	))
+	after := mustSnapshot(t, snapshotInput("after", referenceAt.Add(5*time.Minute), true))
+	requested := []string{reference.Paths[0].ID}
+	legacy, err := VerifyObservedAbsent(reference, after, requested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authoritative, receipt, err := VerifyObservedAbsentRustAuthority(
+		context.Background(),
+		reference,
+		after,
+		requested,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(authoritative, legacy) {
+		t.Fatalf("Rust authority changed the compatibility record\nRust: %#v\nlegacy: %#v", authoritative, legacy)
+	}
+	if receipt.Operation != "verify_observed_absent" || receipt.InputDigest == "" ||
+		receipt.DecisionDigest == "" ||
+		!reflect.DeepEqual(receipt.SourceSnapshotDigests, []string{reference.Digest, after.Digest}) {
+		t.Fatalf("Rust authority receipt = %#v", receipt)
+	}
+}
+
+func TestRustAuthorityRejectsUnboundOutputReferences(t *testing.T) {
+	t.Parallel()
+	observedAt := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	after := mustSnapshot(t, snapshotInput("after", observedAt, true))
+	_, err := hydrateRustComparison(nil, after, rustComparisonDecision{
+		State:                string(DeltaStateInitial),
+		NewlyObservedPathIDs: []string{"path:not-in-snapshot"},
+	})
+	if err == nil {
+		t.Fatal("unknown Rust path reference hydrated successfully")
+	}
+
+	_, err = hydrateCandidateCuts([]CandidateEdgeCut{{
+		Rank: 1,
+		Edge: ProofEdge{ID: "edge:not-in-paths"},
+	}}, nil)
+	if err == nil {
+		t.Fatal("unbound Rust candidate edge hydrated successfully")
+	}
+}
+
+func TestRustAuthorityHasNoGoFallbackWhenEvaluationIsCanceled(t *testing.T) {
+	t.Parallel()
+	observedAt := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	after := mustSnapshot(t, snapshotInput("after", observedAt, true))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	delta, receipt, err := CompareRustAuthority(ctx, nil, after)
+	if err == nil {
+		t.Fatal("canceled Rust evaluation unexpectedly succeeded")
+	}
+	if delta.ID != "" || receipt.InputDigest != "" {
+		t.Fatalf("failed Rust evaluation returned authority output: delta=%#v receipt=%#v", delta, receipt)
+	}
+}


### PR DESCRIPTION
## Summary
- land the already-reviewed Rust security-path authority change on `main`
- make Rust authoritative for comparison, candidate-cut, and observed-absence decisions with no Go fallback
- retain the existing compatibility result shape and bound Rust authority receipts

## Root cause
PR #2099 was merged into its original stacked base branch after PR #2098 had already merged to `main`. GitHub did not retarget the stacked PR, so #2099's commit never entered `main`.

This PR contains exactly #2099's source tree applied to the #2098 merge tree; the two parent trees were identical before the commit was replayed.

## Verification
- repaired tree equals the original #2099 head tree
- `go test ./internal/securitypathdelta ./internal/runtimeorchestration ./internal/bootstrap`
- Rust authority adversarial suite repeated 10 times
- `cargo test -p cerebro-security-path-kernel`
- `git diff --check`
