### PR TITLE
feat(rust): separate Action reconciliation authority

### DIFF
--- a/apps/web/scripts/authenticated-rust-e2e.mjs
+++ b/apps/web/scripts/authenticated-rust-e2e.mjs
@@ -413,6 +413,7 @@ async function startPostgres(containerName, deadlineAt) {
 
 async function startAccessApprovalsProvider(bearerToken) {
   let providerStatus = "queued";
+  let observationCount = 0;
   const requests = [];
   const server = http.createServer((request, response) => {
     const reject = (status, message) => {
@@ -452,6 +453,7 @@ async function startAccessApprovalsProvider(bearerToken) {
       request.method === "GET" &&
       request.url === "/admin/okta-jail/actions/provider-action:rust-e2e"
     ) {
+      observationCount += 1;
       const payload = requests[0];
       if (!payload) {
         reject(404, "provider action not found");
@@ -473,6 +475,7 @@ async function startAccessApprovalsProvider(bearerToken) {
   return {
     baseURL: `http://127.0.0.1:${port}`,
     dispatchCount: () => requests.length,
+    observationCount: () => observationCount,
     requests,
     markSucceeded: () => {
       providerStatus = "succeeded";
@@ -547,6 +550,10 @@ async function executeSignedActionLifecycle({
   const workerBearer = token(
     fixture.worker_id,
     "cerebro:read cerebro:actions:write identity:read cerebro:actions:execute",
+  );
+  const reconcilerBearer = token(
+    "reconciler:rust-e2e",
+    "cerebro:actions:write cerebro:actions:reconcile",
   );
   const actionURL = `${webBase}/api/cerebro/v1/actions/${encodeURIComponent(fixture.operation_id)}`;
   const commandURL = `${actionURL}/commands`;
@@ -649,6 +656,19 @@ async function executeSignedActionLifecycle({
 
   provider.markSucceeded();
   response = await postJSON(`${actionURL}/provider-observation`, workerBearer, {});
+  expect(
+    response.status === 403,
+    `Rust accepted provider reconciliation from the executor (${response.status})`,
+  );
+  expect(
+    provider.observationCount() === 0,
+    "Rejected executor reconciliation reached the provider",
+  );
+  response = await postJSON(
+    `${actionURL}/provider-observation`,
+    reconcilerBearer,
+    {},
+  );
   expect(response.status === 200, `Provider observation returned ${response.status}: ${response.body}`);
   operation = parsedJSON(response, "Provider observation");
   expect(operation.state === "dispatched", "Provider success completed the Action without effect evidence");
@@ -657,6 +677,10 @@ async function executeSignedActionLifecycle({
   expect(operation.observed_effect_digest === null, "Provider status manufactured an observed effect");
   expect(operation.executed_at_unix_ms === null, "Provider status manufactured execution completion");
   expect(provider.dispatchCount() === 1, "Provider observation retried the mutation");
+  expect(
+    provider.observationCount() === 1,
+    "Rust performed an unexpected number of provider observations",
+  );
 
   response = await request(actionURL, {
     headers: { authorization: `Bearer ${workerBearer}` },

--- a/crates/action-provider/src/lib.rs
+++ b/crates/action-provider/src/lib.rs
@@ -122,10 +122,15 @@ impl ProviderReceipt {
         }
     }
 
-    pub fn observation_command(&self, observed_at_unix_ms: u64) -> ActionCommand {
+    pub fn observation_command(
+        &self,
+        reconciler_actor_id: ActorId,
+        observed_at_unix_ms: u64,
+    ) -> ActionCommand {
         ActionCommand::ObserveProviderReceipt {
             provider_receipt_digest: self.response_digest.clone(),
             provider_status: self.status.as_str().to_owned(),
+            reconciler_actor_id,
             observed_at_unix_ms,
         }
     }

--- a/crates/action-provider/tests/access_approvals.rs
+++ b/crates/action-provider/tests/access_approvals.rs
@@ -131,13 +131,15 @@ async fn observation_requires_the_same_external_action_and_dispatch_bindings() {
     assert!(receipt.status.is_terminal());
     assert_eq!(receipt.completed_at_unix_s, Some(43));
     assert_eq!(receipt.request_digest, None);
+    let reconciler = ActorId::parse("reconciler:one").expect("reconciler actor");
     assert!(matches!(
-        receipt.observation_command(43_000),
+        receipt.observation_command(reconciler.clone(), 43_000),
         ActionCommand::ObserveProviderReceipt {
             provider_status,
+            reconciler_actor_id,
             observed_at_unix_ms: 43_000,
             ..
-        } if provider_status == "succeeded"
+        } if provider_status == "succeeded" && reconciler_actor_id == reconciler
     ));
     server.abort();
 }

--- a/crates/action-store/src/lib.rs
+++ b/crates/action-store/src/lib.rs
@@ -1373,10 +1373,13 @@ fn command_actor_matches(
         ActionCommand::Reconcile {
             executor_actor_id, ..
         } => executor_actor_id == actor_id,
+        ActionCommand::ObserveProviderReceipt {
+            reconciler_actor_id,
+            ..
+        } => reconciler_actor_id == actor_id,
         ActionCommand::Verify { receipt } => receipt.receipt.verifier_actor_id == *actor_id,
         ActionCommand::RenewClaim { .. }
         | ActionCommand::StartExecution { .. }
-        | ActionCommand::ObserveProviderReceipt { .. }
         | ActionCommand::MarkOutcomeUnknown => owns_claim(),
         // Any signed executor may recover an unstarted claim after the engine
         // verifies its recorded lease has expired. The releasing actor remains
@@ -1823,6 +1826,7 @@ mod tests {
             &ActionCommand::ObserveProviderReceipt {
                 provider_receipt_digest: ContentDigest::of_bytes("running"),
                 provider_status: "running".to_owned(),
+                reconciler_actor_id: actor.clone(),
                 observed_at_unix_ms: 12,
             }
         ));
@@ -1832,6 +1836,17 @@ mod tests {
             &ActionCommand::ObserveProviderReceipt {
                 provider_receipt_digest: ContentDigest::of_bytes("running"),
                 provider_status: "running".to_owned(),
+                reconciler_actor_id: actor.clone(),
+                observed_at_unix_ms: 12,
+            }
+        ));
+        assert!(command_actor_matches(
+            &other,
+            Some(&claim),
+            &ActionCommand::ObserveProviderReceipt {
+                provider_receipt_digest: ContentDigest::of_bytes("running"),
+                provider_status: "running".to_owned(),
+                reconciler_actor_id: other.clone(),
                 observed_at_unix_ms: 12,
             }
         ));

--- a/crates/action-store/tests/live_ledger.rs
+++ b/crates/action-store/tests/live_ledger.rs
@@ -139,6 +139,7 @@ async fn durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only(
         )
         .await?;
     let worker = ActorId::parse("worker:live:one")?;
+    let reconciler = ActorId::parse("reconciler:live:one")?;
     let claimed = ledger
         .transition(
             &tenant,
@@ -221,11 +222,12 @@ async fn durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only(
         .transition(
             &tenant,
             &operation_id,
-            &worker,
+            &reconciler,
             dispatched.version,
             ActionCommand::ObserveProviderReceipt {
                 provider_receipt_digest: ContentDigest::of_bytes("provider running"),
                 provider_status: "running".to_owned(),
+                reconciler_actor_id: reconciler.clone(),
                 observed_at_unix_ms: 44,
             },
             44,
@@ -238,11 +240,12 @@ async fn durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only(
             .transition(
                 &tenant,
                 &operation_id,
-                &worker,
+                &reconciler,
                 running.version,
                 ActionCommand::ObserveProviderReceipt {
                     provider_receipt_digest: ContentDigest::of_bytes("provider replay"),
                     provider_status: "running".to_owned(),
+                    reconciler_actor_id: reconciler.clone(),
                     observed_at_unix_ms: 44,
                 },
                 45,

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -80,6 +80,7 @@ const ACTION_PROPOSE_SCOPE: &str = "cerebro:actions:propose";
 const ACTION_SIMULATE_SCOPE: &str = "cerebro:actions:simulate";
 const ACTION_APPROVE_SCOPE: &str = "cerebro:actions:approve";
 const ACTION_EXECUTE_SCOPE: &str = "cerebro:actions:execute";
+const ACTION_RECONCILE_SCOPE: &str = "cerebro:actions:reconcile";
 const ACTION_VERIFY_SCOPE: &str = "cerebro:actions:verify";
 const FINDING_VALIDATE_SCOPE: &str = "cerebro:findings:validate";
 
@@ -2143,7 +2144,7 @@ async fn observe_action_provider_route(
     Extension(identity): Extension<AuthenticatedIdentity>,
     Path(operation_id): Path<String>,
 ) -> Result<Json<ActionOperation>, (StatusCode, Json<ErrorResponse>)> {
-    require_action_scope(&identity, ACTION_EXECUTE_SCOPE)?;
+    require_action_scope(&identity, ACTION_RECONCILE_SCOPE)?;
     let actor_id = authenticated_action_actor(&identity)?;
     let operation_id = ActionOperationId::parse(operation_id)
         .map_err(|error| bad_request("invalid_action_operation_id", error.to_string()))?;
@@ -2191,7 +2192,7 @@ async fn observe_action_provider_route(
             &operation_id,
             &actor_id,
             operation.version,
-            receipt.observation_command(observed_at),
+            receipt.observation_command(actor_id.clone(), observed_at),
             observed_at,
         )
         .await
@@ -4174,6 +4175,20 @@ mod tests {
         assert_eq!(error.0, StatusCode::FORBIDDEN);
         assert_eq!(error.1.0.code, "permission_denied");
 
+        let mut executor_identity = action_identity("tenant:http:one", "executor:http:one");
+        executor_identity
+            .scopes
+            .insert(ACTION_EXECUTE_SCOPE.to_owned());
+        let error = observe_action_provider_route(
+            State(state.clone()),
+            Extension(executor_identity),
+            Path("operation:http:one".to_owned()),
+        )
+        .await
+        .expect_err("execution authority must not grant reconciliation authority");
+        assert_eq!(error.0, StatusCode::FORBIDDEN);
+        assert_eq!(error.1.0.code, "permission_denied");
+
         let error = list_action_dispatches(
             State(state.clone()),
             Extension(identity.clone()),
@@ -4252,6 +4267,7 @@ mod tests {
         };
         let mut identity = action_identity("tenant:http:one", "actor:http:one");
         identity.scopes.insert(ACTION_EXECUTE_SCOPE.to_owned());
+        identity.scopes.insert(ACTION_RECONCILE_SCOPE.to_owned());
         let error = transition_action_route(
             State(state.clone()),
             Extension(identity.clone()),

--- a/crates/platform-engine/src/action.rs
+++ b/crates/platform-engine/src/action.rs
@@ -41,6 +41,7 @@ pub enum ActionCommand {
     ObserveProviderReceipt {
         provider_receipt_digest: ContentDigest,
         provider_status: String,
+        reconciler_actor_id: ActorId,
         observed_at_unix_ms: u64,
     },
     MarkOutcomeUnknown,
@@ -190,6 +191,7 @@ pub fn transition_action(
                 provider_receipt_digest,
                 provider_status,
                 observed_at_unix_ms,
+                ..
             },
         ) => {
             if operation

--- a/crates/platform-engine/tests/engine.rs
+++ b/crates/platform-engine/tests/engine.rs
@@ -349,6 +349,7 @@ fn action_transitions_are_optimistic_and_fail_closed() {
         ActionCommand::ObserveProviderReceipt {
             provider_receipt_digest: digest("provider-running"),
             provider_status: "running".to_owned(),
+            reconciler_actor_id: actor("reconciler:one"),
             observed_at_unix_ms: 13,
         },
     )
@@ -360,6 +361,7 @@ fn action_transitions_are_optimistic_and_fail_closed() {
             ActionCommand::ObserveProviderReceipt {
                 provider_receipt_digest: digest("provider-replay"),
                 provider_status: "running".to_owned(),
+                reconciler_actor_id: actor("reconciler:one"),
                 observed_at_unix_ms: 12,
             },
         )

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -296,9 +296,12 @@ dispatch through the Rust client. A bound provider receipt becomes a second
 durable Rust transition. Any unsuccessful or unbound response moves the Action
 to `outcome_unknown`; the handler does not retry the mutation. Provider receipt,
 outcome, completion, and reconciliation commands are not accepted from the
-public HTTP command schema. A signed execution principal can ask the Rust
-runtime to refresh an existing provider receipt; the runtime performs the GET,
-revalidates every dispatch binding, and commits the observation itself.
+public HTTP command schema. A signed execution principal can start the provider
+mutation. A separate signed reconciliation principal with
+`cerebro:actions:reconcile` can ask the Rust runtime to refresh an existing
+provider receipt; the runtime performs the GET, revalidates every dispatch
+binding, and commits the observation itself. Execution authority does not grant
+reconciliation authority.
 
 This code path does not by itself prove deployment cutover. Until deployment
 receipts show the Rust handler serves Action execution traffic,


### PR DESCRIPTION
## Summary
- require `cerebro:actions:reconcile` before the Rust runtime fetches or commits a provider observation
- bind each internal provider-observation command to the authenticated reconciler actor without requiring execution-claim ownership\n- keep execution and reconciliation identities separate in the signed browser-to-Rust Action lifecycle
- prove an executor-only identity receives `403` before the provider or Action store is touched
- count provider reads in the harness so rejected reconciliation cannot hide an outbound request

## Local verification
- `cargo test --locked -p cerebro-platform` (60 passed, 1 infrastructure test ignored)
- `cargo clippy --locked -p cerebro-platform --all-targets -- -D warnings`
- targeted Action page and authenticated Rust harness tests (6 passed)
- targeted JavaScript lint
- `make docs-drift-check readme-check`
- `cargo fmt --all -- --check`
- `git diff --check`

## Hosted verification
Exact-head checks for `a635f2b273643692917ae4db76ff4025c87a8e4d` are running. The dedicated `web-rust-integration` result is required before this head is considered proven.

## Authority boundary
This separates Rust provider execution from Rust provider reconciliation. It does not claim automated reconciliation scheduling, independent effect observation, finding closure, deployment cutover, or removal of the legacy Go route.