### PR TITLE
feat(rust): schedule provider reconciliation

### DIFF
--- a/apps/web/scripts/authenticated-rust-e2e.mjs
+++ b/apps/web/scripts/authenticated-rust-e2e.mjs
@@ -655,22 +655,35 @@ async function executeSignedActionLifecycle({
   );
 
   provider.markSucceeded();
-  response = await postJSON(`${actionURL}/provider-observation`, workerBearer, {});
+  const reconciliationURL =
+    `${webBase}/api/cerebro/v1/action-reconciliation-runs`;
+  response = await postJSON(reconciliationURL, workerBearer, {});
   expect(
     response.status === 403,
-    `Rust accepted provider reconciliation from the executor (${response.status})`,
+    `Rust accepted a reconciliation run from the executor (${response.status})`,
   );
   expect(
     provider.observationCount() === 0,
     "Rejected executor reconciliation reached the provider",
   );
-  response = await postJSON(
-    `${actionURL}/provider-observation`,
-    reconcilerBearer,
-    {},
+  response = await postJSON(reconciliationURL, reconcilerBearer, {});
+  expect(
+    response.status === 200,
+    `Reconciliation run returned ${response.status}: ${response.body}`,
   );
-  expect(response.status === 200, `Provider observation returned ${response.status}: ${response.body}`);
-  operation = parsedJSON(response, "Provider observation");
+  const reconciliation = parsedJSON(response, "Reconciliation run");
+  expect(
+    reconciliation.claimed === 1 &&
+      reconciliation.observed === 1 &&
+      reconciliation.terminal === 1 &&
+      reconciliation.provider_unavailable === 0,
+    `Rust returned an unexpected reconciliation receipt: ${response.body}`,
+  );
+  response = await request(actionURL, {
+    headers: { authorization: `Bearer ${readBearer}` },
+  });
+  expect(response.status === 200, `Reconciled Action read returned ${response.status}`);
+  operation = parsedJSON(response, "Reconciled Action read");
   expect(operation.state === "dispatched", "Provider success completed the Action without effect evidence");
   expect(operation.provider_status === "succeeded", "Rust did not persist the provider observation");
   expect(operation.version === 8, `Provider observation committed version ${operation.version}`);
@@ -680,6 +693,19 @@ async function executeSignedActionLifecycle({
   expect(
     provider.observationCount() === 1,
     "Rust performed an unexpected number of provider observations",
+  );
+  response = await postJSON(reconciliationURL, reconcilerBearer, {});
+  expect(
+    response.status === 200,
+    `Terminal reconciliation replay returned ${response.status}: ${response.body}`,
+  );
+  expect(
+    parsedJSON(response, "Terminal reconciliation replay").claimed === 0,
+    "Rust reclaimed a terminal provider reconciliation job",
+  );
+  expect(
+    provider.observationCount() === 1,
+    "Terminal reconciliation replay reached the provider",
   );
 
   response = await request(actionURL, {

--- a/crates/action-store/src/lib.rs
+++ b/crates/action-store/src/lib.rs
@@ -225,6 +225,44 @@ CREATE TABLE IF NOT EXISTS action_dispatches (
   CHECK ((dispatch_json->>'requested_by') IS NOT DISTINCT FROM requested_by),
   CHECK ((dispatch_json->>'requested_at_unix_ms')::BIGINT IS NOT DISTINCT FROM requested_at_unix_ms)
 );
+CREATE TABLE IF NOT EXISTS action_reconciliation_jobs (
+  tenant_id TEXT NOT NULL CHECK (char_length(tenant_id) BETWEEN 1 AND 256),
+  operation_id TEXT NOT NULL CHECK (char_length(operation_id) BETWEEN 1 AND 256),
+  dispatch_digest TEXT NOT NULL CHECK (dispatch_digest ~ '^[0-9a-f]{64}$'),
+  state TEXT NOT NULL CHECK (state IN ('scheduled', 'leased', 'terminal')),
+  next_attempt_at_unix_ms BIGINT,
+  attempt_count BIGINT NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  lease_owner TEXT CHECK (lease_owner IS NULL OR char_length(lease_owner) BETWEEN 1 AND 256),
+  lease_expires_at_unix_ms BIGINT,
+  terminal_provider_status TEXT CHECK (
+    terminal_provider_status IS NULL
+    OR char_length(terminal_provider_status) BETWEEN 1 AND 64
+  ),
+  updated_at_unix_ms BIGINT NOT NULL CHECK (updated_at_unix_ms > 0),
+  PRIMARY KEY (tenant_id, operation_id),
+  FOREIGN KEY (tenant_id, operation_id)
+    REFERENCES action_dispatches (tenant_id, operation_id)
+    DEFERRABLE INITIALLY DEFERRED,
+  CHECK (
+    (state = 'scheduled'
+      AND next_attempt_at_unix_ms IS NOT NULL
+      AND lease_owner IS NULL
+      AND lease_expires_at_unix_ms IS NULL
+      AND terminal_provider_status IS NULL)
+    OR
+    (state = 'leased'
+      AND next_attempt_at_unix_ms IS NOT NULL
+      AND lease_owner IS NOT NULL
+      AND lease_expires_at_unix_ms IS NOT NULL
+      AND terminal_provider_status IS NULL)
+    OR
+    (state = 'terminal'
+      AND next_attempt_at_unix_ms IS NULL
+      AND lease_owner IS NULL
+      AND lease_expires_at_unix_ms IS NULL
+      AND terminal_provider_status IS NOT NULL)
+  )
+);
 CREATE INDEX IF NOT EXISTS action_operation_events_committed_idx
   ON action_operation_events (tenant_id, committed_at_unix_ms DESC);
 CREATE INDEX IF NOT EXISTS action_operations_queue_idx
@@ -235,6 +273,13 @@ CREATE INDEX IF NOT EXISTS action_dispatches_requested_idx
   ON action_dispatches (tenant_id, requested_at_unix_ms, operation_id);
 CREATE INDEX IF NOT EXISTS action_dispatches_finding_idx
   ON action_dispatches (tenant_id, finding_id, requested_at_unix_ms, operation_id);
+CREATE INDEX IF NOT EXISTS action_reconciliation_jobs_due_idx
+  ON action_reconciliation_jobs (
+    tenant_id,
+    state,
+    next_attempt_at_unix_ms,
+    operation_id
+  );
 CREATE INDEX IF NOT EXISTS finding_validation_receipts_finding_idx
   ON finding_validation_receipts (tenant_id, finding_id, validated_at_unix_ms DESC);
 CREATE INDEX IF NOT EXISTS finding_validation_receipts_policy_idx
@@ -286,6 +331,8 @@ ALTER TABLE action_operation_events ENABLE ROW LEVEL SECURITY;
 ALTER TABLE action_operation_events FORCE ROW LEVEL SECURITY;
 ALTER TABLE action_dispatches ENABLE ROW LEVEL SECURITY;
 ALTER TABLE action_dispatches FORCE ROW LEVEL SECURITY;
+ALTER TABLE action_reconciliation_jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE action_reconciliation_jobs FORCE ROW LEVEL SECURITY;
 DO $$
 DECLARE table_name TEXT;
 BEGIN
@@ -293,7 +340,8 @@ BEGIN
     'finding_validation_receipts',
     'action_operations',
     'action_operation_events',
-    'action_dispatches'
+    'action_dispatches',
+    'action_reconciliation_jobs'
   ] LOOP
     BEGIN
       EXECUTE format(
@@ -597,6 +645,22 @@ impl ActionDispatch {
 pub struct ActionDispatchPage {
     pub dispatches: Vec<ActionDispatch>,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActionReconciliationJob {
+    pub operation: ActionOperation,
+    pub dispatch: ActionDispatch,
+    pub attempt_count: u64,
+    pub lease_expires_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ActionReconciliationDisposition {
+    PollAgain { next_attempt_at_unix_ms: u64 },
+    Terminal { provider_status: String },
+}
+
+const MAX_RECONCILIATION_LEASE_MS: u64 = 5 * 60 * 1_000;
 
 pub struct PostgresActionLedger {
     client: Mutex<Client>,
@@ -920,6 +984,8 @@ impl PostgresActionLedger {
     ) -> Result<ActionOperation, ActionStoreError> {
         let expected_version_i64 = storage_i64(expected_version, "Action expected version")?;
         let committed_at = storage_i64(committed_at_unix_ms, "Action commit time")?;
+        let schedules_provider_reconciliation =
+            matches!(&command, ActionCommand::RecordProviderReceipt { .. });
         let command_json = serde_json::to_value(&command)?;
         let command_digest = digest_json(&command_json)?;
         let event_kind = command_json
@@ -1053,6 +1119,19 @@ impl PostgresActionLedger {
                 ],
             )
             .await?;
+        if schedules_provider_reconciliation {
+            let scheduled = transaction
+                .execute(
+                    "INSERT INTO action_reconciliation_jobs (tenant_id, operation_id, dispatch_digest, state, next_attempt_at_unix_ms, attempt_count, lease_owner, lease_expires_at_unix_ms, terminal_provider_status, updated_at_unix_ms) SELECT tenant_id, operation_id, dispatch_digest, 'scheduled', $3, 0, NULL, NULL, NULL, $3 FROM action_dispatches WHERE tenant_id = $1 AND operation_id = $2 ON CONFLICT DO NOTHING",
+                    &[&tenant_id.as_str(), &operation_id.as_str(), &committed_at],
+                )
+                .await?;
+            if scheduled != 1 {
+                return Err(ActionStoreError::Conflict(
+                    "Action provider reconciliation was not scheduled".to_owned(),
+                ));
+            }
+        }
         transaction.commit().await?;
         Ok(next)
     }
@@ -1104,6 +1183,157 @@ impl PostgresActionLedger {
             .collect::<Result<Vec<_>, _>>()?;
         transaction.commit().await?;
         Ok(ActionDispatchPage { dispatches })
+    }
+
+    pub async fn claim_due_reconciliation(
+        &self,
+        tenant_id: &TenantId,
+        worker_id: &ActorId,
+        claimed_at_unix_ms: u64,
+        lease_expires_at_unix_ms: u64,
+    ) -> Result<Option<ActionReconciliationJob>, ActionStoreError> {
+        if lease_expires_at_unix_ms <= claimed_at_unix_ms
+            || lease_expires_at_unix_ms - claimed_at_unix_ms > MAX_RECONCILIATION_LEASE_MS
+        {
+            return Err(ActionStoreError::OutOfRange("Action reconciliation lease"));
+        }
+        let claimed_at = storage_i64(claimed_at_unix_ms, "Action reconciliation claim time")?;
+        let lease_expires = storage_i64(
+            lease_expires_at_unix_ms,
+            "Action reconciliation lease expiry",
+        )?;
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id.as_str()).await?;
+        let candidate = transaction
+            .query_opt(
+                "SELECT job.operation_id, job.dispatch_digest FROM action_reconciliation_jobs AS job INNER JOIN action_operations AS operation ON operation.tenant_id = job.tenant_id AND operation.operation_id = job.operation_id WHERE job.tenant_id = $1 AND operation.state = 'dispatched' AND ((job.state = 'scheduled' AND job.next_attempt_at_unix_ms <= $2) OR (job.state = 'leased' AND job.lease_expires_at_unix_ms <= $2)) ORDER BY job.next_attempt_at_unix_ms, job.operation_id FOR UPDATE OF job SKIP LOCKED LIMIT 1",
+                &[&tenant_id.as_str(), &claimed_at],
+            )
+            .await?;
+        let Some(candidate) = candidate else {
+            transaction.commit().await?;
+            return Ok(None);
+        };
+        let operation_id = ActionOperationId::parse(candidate.get::<_, String>(0))
+            .map_err(|error| ActionStoreError::Corrupt(error.to_string()))?;
+        let scheduled_dispatch_digest = ContentDigest::parse(candidate.get::<_, String>(1))
+            .map_err(|error| ActionStoreError::Corrupt(error.to_string()))?;
+        let leased = transaction
+            .query_one(
+                "UPDATE action_reconciliation_jobs SET state = 'leased', attempt_count = attempt_count + 1, lease_owner = $3, lease_expires_at_unix_ms = $4, updated_at_unix_ms = $2 WHERE tenant_id = $1 AND operation_id = $5 RETURNING attempt_count",
+                &[
+                    &tenant_id.as_str(),
+                    &claimed_at,
+                    &worker_id.as_str(),
+                    &lease_expires,
+                    &operation_id.as_str(),
+                ],
+            )
+            .await?;
+        let attempt_count = u64::try_from(leased.get::<_, i64>(0)).map_err(|_| {
+            ActionStoreError::Corrupt("Action reconciliation attempt count is invalid".to_owned())
+        })?;
+        let operation = transaction
+            .query_one(
+                "SELECT operation_id, idempotency_key, proposal_digest, state, version, operation_json, created_at_unix_ms, updated_at_unix_ms FROM action_operations WHERE tenant_id = $1 AND operation_id = $2 FOR SHARE",
+                &[&tenant_id.as_str(), &operation_id.as_str()],
+            )
+            .await
+            .map_err(ActionStoreError::from)
+            .and_then(|row| validate_current_row(&row).map(|current| current.operation))?;
+        let dispatch = transaction
+            .query_one(
+                "SELECT dispatch.dispatch_json, event.actor_id AS event_actor_id, event.event_kind, event.command_json, event.operation_json FROM action_dispatches AS dispatch INNER JOIN action_operation_events AS event ON event.tenant_id = dispatch.tenant_id AND event.operation_id = dispatch.operation_id AND event.version = dispatch.operation_version WHERE dispatch.tenant_id = $1 AND dispatch.operation_id = $2",
+                &[&tenant_id.as_str(), &operation_id.as_str()],
+            )
+            .await
+            .map_err(ActionStoreError::from)
+            .and_then(|row| decode_dispatch_row(&row))?;
+        if dispatch.dispatch_digest != scheduled_dispatch_digest.as_str() {
+            return Err(ActionStoreError::Corrupt(
+                "Action reconciliation job does not match its dispatch".to_owned(),
+            ));
+        }
+        transaction.commit().await?;
+        Ok(Some(ActionReconciliationJob {
+            operation,
+            dispatch,
+            attempt_count,
+            lease_expires_at_unix_ms,
+        }))
+    }
+
+    pub async fn finish_reconciliation(
+        &self,
+        tenant_id: &TenantId,
+        operation_id: &ActionOperationId,
+        worker_id: &ActorId,
+        expected_operation_version: u64,
+        finished_at_unix_ms: u64,
+        disposition: ActionReconciliationDisposition,
+    ) -> Result<(), ActionStoreError> {
+        let expected_version =
+            storage_i64(expected_operation_version, "Action reconciliation version")?;
+        let finished_at =
+            storage_i64(finished_at_unix_ms, "Action reconciliation completion time")?;
+        let (state, next_attempt, terminal_status) = match disposition {
+            ActionReconciliationDisposition::PollAgain {
+                next_attempt_at_unix_ms,
+            } => {
+                if next_attempt_at_unix_ms <= finished_at_unix_ms {
+                    return Err(ActionStoreError::OutOfRange(
+                        "Action reconciliation next attempt",
+                    ));
+                }
+                (
+                    "scheduled",
+                    Some(storage_i64(
+                        next_attempt_at_unix_ms,
+                        "Action reconciliation next attempt",
+                    )?),
+                    None,
+                )
+            }
+            ActionReconciliationDisposition::Terminal { provider_status } => {
+                if provider_status.is_empty()
+                    || provider_status.len() > 64
+                    || !provider_status
+                        .bytes()
+                        .all(|byte| byte.is_ascii_lowercase() || byte == b'_')
+                {
+                    return Err(ActionStoreError::Corrupt(
+                        "Action reconciliation terminal status is invalid".to_owned(),
+                    ));
+                }
+                ("terminal", None, Some(provider_status))
+            }
+        };
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id.as_str()).await?;
+        let updated = transaction
+            .execute(
+                "UPDATE action_reconciliation_jobs AS job SET state = $1, next_attempt_at_unix_ms = $2, lease_owner = NULL, lease_expires_at_unix_ms = NULL, terminal_provider_status = $3, updated_at_unix_ms = $4 FROM action_operations AS operation WHERE job.tenant_id = $5 AND job.operation_id = $6 AND job.state = 'leased' AND job.lease_owner = $7 AND job.lease_expires_at_unix_ms >= $4 AND operation.tenant_id = job.tenant_id AND operation.operation_id = job.operation_id AND operation.version = $8 AND ($3::TEXT IS NULL OR operation.operation_json->>'provider_status' = $3)",
+                &[
+                    &state,
+                    &next_attempt,
+                    &terminal_status,
+                    &finished_at,
+                    &tenant_id.as_str(),
+                    &operation_id.as_str(),
+                    &worker_id.as_str(),
+                    &expected_version,
+                ],
+            )
+            .await?;
+        if updated != 1 {
+            return Err(ActionStoreError::Conflict(
+                "Action reconciliation lease or operation version changed".to_owned(),
+            ));
+        }
+        transaction.commit().await?;
+        Ok(())
     }
 
     pub async fn history(
@@ -1595,6 +1825,10 @@ mod tests {
             "VALIDATE CONSTRAINT action_operations_state_values",
             "action_dispatches_requested_idx",
             "action_dispatches_finding_idx",
+            "CREATE TABLE IF NOT EXISTS action_reconciliation_jobs",
+            "action_reconciliation_jobs_due_idx",
+            "FOREIGN KEY (tenant_id, operation_id)\n    REFERENCES action_dispatches",
+            "'scheduled', 'leased', 'terminal'",
         ] {
             assert!(POSTGRES_SCHEMA.contains(required), "missing {required}");
         }

--- a/crates/action-store/tests/live_ledger.rs
+++ b/crates/action-store/tests/live_ledger.rs
@@ -1,7 +1,9 @@
 use std::{env, error::Error};
 
 use cerebro_action_catalog::lookup;
-use cerebro_action_store::{ActionStoreError, PostgresActionLedger};
+use cerebro_action_store::{
+    ActionReconciliationDisposition, ActionStoreError, PostgresActionLedger,
+};
 use cerebro_platform_engine::ActionCommand;
 use cerebro_platform_sdk::{
     ActionEffect, ActionOperationId, ActionProposal, ActionState, ActorId, ContentDigest,
@@ -218,6 +220,66 @@ async fn durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only(
         vec![dispatch.clone()],
         "provider acceptance must keep the immutable dispatch open"
     );
+    let reconciliation = ledger
+        .claim_due_reconciliation(&tenant, &reconciler, 44, 100)
+        .await?
+        .expect("scheduled reconciliation");
+    assert_eq!(reconciliation.operation, dispatched);
+    assert_eq!(reconciliation.dispatch, dispatch);
+    assert_eq!(reconciliation.attempt_count, 1);
+    assert!(
+        ledger
+            .claim_due_reconciliation(&tenant, &worker, 44, 100)
+            .await?
+            .is_none(),
+        "an active reconciliation lease cannot be claimed twice"
+    );
+    assert!(
+        ledger
+            .claim_due_reconciliation(&other_tenant, &reconciler, 44, 100)
+            .await?
+            .is_none(),
+        "tenant RLS must hide reconciliation work"
+    );
+    assert!(matches!(
+        ledger
+            .finish_reconciliation(
+                &tenant,
+                &operation_id,
+                &worker,
+                dispatched.version,
+                44,
+                ActionReconciliationDisposition::PollAgain {
+                    next_attempt_at_unix_ms: 50,
+                },
+            )
+            .await,
+        Err(ActionStoreError::Conflict(_))
+    ));
+    ledger
+        .finish_reconciliation(
+            &tenant,
+            &operation_id,
+            &reconciler,
+            dispatched.version,
+            44,
+            ActionReconciliationDisposition::PollAgain {
+                next_attempt_at_unix_ms: 50,
+            },
+        )
+        .await?;
+    assert!(
+        ledger
+            .claim_due_reconciliation(&tenant, &reconciler, 49, 100)
+            .await?
+            .is_none(),
+        "the ledger, not the wake-up caller, owns the next due time"
+    );
+    let reconciliation = ledger
+        .claim_due_reconciliation(&tenant, &reconciler, 50, 100)
+        .await?
+        .expect("due reconciliation");
+    assert_eq!(reconciliation.attempt_count, 2);
     let running = ledger
         .transition(
             &tenant,
@@ -228,9 +290,9 @@ async fn durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only(
                 provider_receipt_digest: ContentDigest::of_bytes("provider running"),
                 provider_status: "running".to_owned(),
                 reconciler_actor_id: reconciler.clone(),
-                observed_at_unix_ms: 44,
+                observed_at_unix_ms: 51,
             },
-            44,
+            51,
         )
         .await?;
     assert_eq!(running.state, ActionState::Dispatched);
@@ -246,13 +308,64 @@ async fn durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only(
                     provider_receipt_digest: ContentDigest::of_bytes("provider replay"),
                     provider_status: "running".to_owned(),
                     reconciler_actor_id: reconciler.clone(),
-                    observed_at_unix_ms: 44,
+                    observed_at_unix_ms: 51,
                 },
-                45,
+                52,
             )
             .await,
         Err(ActionStoreError::Conflict(_))
     ));
+    ledger
+        .finish_reconciliation(
+            &tenant,
+            &operation_id,
+            &reconciler,
+            running.version,
+            52,
+            ActionReconciliationDisposition::PollAgain {
+                next_attempt_at_unix_ms: 60,
+            },
+        )
+        .await?;
+    let reconciliation = ledger
+        .claim_due_reconciliation(&tenant, &reconciler, 60, 100)
+        .await?
+        .expect("terminal reconciliation attempt");
+    assert_eq!(reconciliation.attempt_count, 3);
+    let succeeded = ledger
+        .transition(
+            &tenant,
+            &operation_id,
+            &reconciler,
+            running.version,
+            ActionCommand::ObserveProviderReceipt {
+                provider_receipt_digest: ContentDigest::of_bytes("provider succeeded"),
+                provider_status: "succeeded".to_owned(),
+                reconciler_actor_id: reconciler.clone(),
+                observed_at_unix_ms: 61,
+            },
+            61,
+        )
+        .await?;
+    ledger
+        .finish_reconciliation(
+            &tenant,
+            &operation_id,
+            &reconciler,
+            succeeded.version,
+            61,
+            ActionReconciliationDisposition::Terminal {
+                provider_status: "succeeded".to_owned(),
+            },
+        )
+        .await?;
+    assert!(
+        ledger
+            .claim_due_reconciliation(&tenant, &reconciler, 100, 200)
+            .await?
+            .is_none(),
+        "terminal provider evidence must retire the polling job"
+    );
 
     let second = proposal(
         "operation:live:second",
@@ -272,7 +385,7 @@ async fn durable_actions_are_tenant_scoped_idempotent_versioned_and_append_only(
     ledger.propose(other_tenant_proposal.clone(), 42).await?;
 
     let first_page = ledger.list(&tenant, 1, None).await?;
-    assert_eq!(first_page.actions, vec![running]);
+    assert_eq!(first_page.actions, vec![succeeded]);
     let second_page = ledger
         .list(&tenant, 1, first_page.next_page_token.as_deref())
         .await?;

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -30,8 +30,8 @@ use cerebro_action_catalog::{
 };
 use cerebro_action_provider::{AccessApprovalsClient, AccessApprovalsConfig, ProviderError};
 use cerebro_action_store::{
-    ActionDispatch, ActionDispatchPage, ActionEvent, ActionPage, ActionStoreError,
-    PostgresActionLedger,
+    ActionDispatch, ActionDispatchPage, ActionEvent, ActionPage, ActionReconciliationDisposition,
+    ActionReconciliationJob, ActionStoreError, PostgresActionLedger,
 };
 use cerebro_agent_context::{
     AgentContext, AgentGraph, ContextEntity, ContextError, GraphPath, MemoryAgentGraph,
@@ -83,6 +83,9 @@ const ACTION_EXECUTE_SCOPE: &str = "cerebro:actions:execute";
 const ACTION_RECONCILE_SCOPE: &str = "cerebro:actions:reconcile";
 const ACTION_VERIFY_SCOPE: &str = "cerebro:actions:verify";
 const FINDING_VALIDATE_SCOPE: &str = "cerebro:findings:validate";
+const ACTION_RECONCILIATION_BATCH_LIMIT: usize = 10;
+const ACTION_RECONCILIATION_LEASE_MS: u64 = 2 * 60 * 1_000;
+const ACTION_RECONCILIATION_POLL_DELAY_MS: u64 = 15 * 1_000;
 
 #[derive(Clone)]
 struct AppState {
@@ -156,6 +159,24 @@ trait ActionAuthority: Send + Sync {
         tenant_id: &TenantId,
         limit: usize,
     ) -> Result<ActionDispatchPage, ActionStoreError>;
+
+    async fn claim_due_reconciliation(
+        &self,
+        tenant_id: &TenantId,
+        worker_id: &ActorId,
+        claimed_at_unix_ms: u64,
+        lease_expires_at_unix_ms: u64,
+    ) -> Result<Option<ActionReconciliationJob>, ActionStoreError>;
+
+    async fn finish_reconciliation(
+        &self,
+        tenant_id: &TenantId,
+        operation_id: &ActionOperationId,
+        worker_id: &ActorId,
+        expected_operation_version: u64,
+        finished_at_unix_ms: u64,
+        disposition: ActionReconciliationDisposition,
+    ) -> Result<(), ActionStoreError>;
 }
 
 #[async_trait]
@@ -248,6 +269,42 @@ impl ActionAuthority for PostgresActionLedger {
         limit: usize,
     ) -> Result<ActionDispatchPage, ActionStoreError> {
         self.list_open_dispatches(tenant_id, limit).await
+    }
+
+    async fn claim_due_reconciliation(
+        &self,
+        tenant_id: &TenantId,
+        worker_id: &ActorId,
+        claimed_at_unix_ms: u64,
+        lease_expires_at_unix_ms: u64,
+    ) -> Result<Option<ActionReconciliationJob>, ActionStoreError> {
+        self.claim_due_reconciliation(
+            tenant_id,
+            worker_id,
+            claimed_at_unix_ms,
+            lease_expires_at_unix_ms,
+        )
+        .await
+    }
+
+    async fn finish_reconciliation(
+        &self,
+        tenant_id: &TenantId,
+        operation_id: &ActionOperationId,
+        worker_id: &ActorId,
+        expected_operation_version: u64,
+        finished_at_unix_ms: u64,
+        disposition: ActionReconciliationDisposition,
+    ) -> Result<(), ActionStoreError> {
+        self.finish_reconciliation(
+            tenant_id,
+            operation_id,
+            worker_id,
+            expected_operation_version,
+            finished_at_unix_ms,
+            disposition,
+        )
+        .await
     }
 }
 
@@ -412,6 +469,7 @@ fn oidc_scope_for_route(method: &Method, path: &str) -> &'static str {
         _ if path.starts_with("/v1/finding-validations/") => "cerebro:read",
         "/v1/action-dispatches" => "cerebro:actions:read",
         _ if path.starts_with("/v1/action-dispatches/") => "cerebro:actions:read",
+        "/v1/action-reconciliation-runs" => "cerebro:actions:write",
         "/v1/actions" if method == Method::GET => "cerebro:actions:read",
         "/v1/actions" => "cerebro:actions:write",
         _ if path.starts_with("/v1/actions/") && path.ends_with("/provider-observation") => {
@@ -456,6 +514,7 @@ fn bounded_operation(method: &Method, path: &str) -> &'static str {
         "/v1/action-definitions" => "action_definitions",
         "/v1/policy-definitions" => "policy_definitions",
         "/v1/action-dispatches" => "list_action_dispatches",
+        "/v1/action-reconciliation-runs" => "run_action_reconciliation",
         "/v1/sources/summary" => "source_summary",
         "/platform/graph/neighborhood" => "neighborhood",
         "/v1/graph/search" => "search",
@@ -823,6 +882,14 @@ struct ActionListQuery {
     limit: Option<usize>,
     #[serde(default)]
     page_token: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct ActionReconciliationRun {
+    claimed: usize,
+    observed: usize,
+    terminal: usize,
+    provider_unavailable: usize,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1512,6 +1579,10 @@ fn router_with_backend(
             .route("/v1/policy-definitions", get(list_policy_definitions))
             .route("/v1/action-dispatches", get(list_action_dispatches))
             .route(
+                "/v1/action-reconciliation-runs",
+                post(run_action_reconciliation),
+            )
+            .route(
                 "/v1/action-dispatches/{operation_id}",
                 get(get_action_dispatch),
             )
@@ -2144,6 +2215,122 @@ async fn transition_action_route(
         .map_err(action_store_error)
 }
 
+async fn run_action_reconciliation(
+    State(state): State<AppState>,
+    Extension(identity): Extension<AuthenticatedIdentity>,
+) -> Result<Json<ActionReconciliationRun>, (StatusCode, Json<ErrorResponse>)> {
+    require_action_scope(&identity, ACTION_RECONCILE_SCOPE)?;
+    let actor_id = authenticated_action_actor(&identity)?;
+    let provider = state.access_approvals.clone().ok_or_else(|| {
+        service_unavailable(
+            "action_provider_unavailable",
+            "The access-approvals provider is not configured in the Rust runtime.",
+        )
+    })?;
+    let authority = action_authority(&state)?.clone();
+    let mut result = ActionReconciliationRun {
+        claimed: 0,
+        observed: 0,
+        terminal: 0,
+        provider_unavailable: 0,
+    };
+    for _ in 0..ACTION_RECONCILIATION_BATCH_LIMIT {
+        let claimed_at = current_unix_millis()?;
+        let lease_expires_at = claimed_at
+            .checked_add(ACTION_RECONCILIATION_LEASE_MS)
+            .ok_or_else(action_clock_overflow)?;
+        let Some(job) = authority
+            .claim_due_reconciliation(&identity.tenant, &actor_id, claimed_at, lease_expires_at)
+            .await
+            .map_err(action_store_error)?
+        else {
+            break;
+        };
+        result.claimed += 1;
+        let external_id = job.operation.external_receipt_ref.as_ref().ok_or_else(|| {
+            action_store_error(ActionStoreError::Corrupt(
+                "Action reconciliation job has no provider receipt".to_owned(),
+            ))
+        })?;
+        let receipt = if job.dispatch.provider == "access-approvals" {
+            provider.observe(&job.dispatch, external_id).await
+        } else {
+            Err(ProviderError::ObservationUnavailable)
+        };
+        let receipt = match receipt {
+            Ok(receipt) => receipt,
+            Err(_) => {
+                let finished_at = current_unix_millis()?;
+                let next_attempt_at = finished_at
+                    .checked_add(ACTION_RECONCILIATION_POLL_DELAY_MS)
+                    .ok_or_else(action_clock_overflow)?;
+                authority
+                    .finish_reconciliation(
+                        &identity.tenant,
+                        &job.operation.proposal.operation_id,
+                        &actor_id,
+                        job.operation.version,
+                        finished_at,
+                        ActionReconciliationDisposition::PollAgain {
+                            next_attempt_at_unix_ms: next_attempt_at,
+                        },
+                    )
+                    .await
+                    .map_err(action_store_error)?;
+                result.provider_unavailable += 1;
+                continue;
+            }
+        };
+        let previous_observation = job.operation.provider_observed_at_unix_ms.ok_or_else(|| {
+            action_store_error(ActionStoreError::Corrupt(
+                "Action reconciliation job has no provider observation time".to_owned(),
+            ))
+        })?;
+        let observed_at =
+            next_provider_observation_time(previous_observation, current_unix_millis()?)
+                .ok_or_else(action_clock_overflow)?;
+        let operation = authority
+            .transition(
+                &identity.tenant,
+                &job.operation.proposal.operation_id,
+                &actor_id,
+                job.operation.version,
+                receipt.observation_command(actor_id.clone(), observed_at),
+                observed_at,
+            )
+            .await
+            .map_err(action_store_error)?;
+        let terminal = receipt.status.is_terminal();
+        let disposition = if terminal {
+            ActionReconciliationDisposition::Terminal {
+                provider_status: receipt.status.as_str().to_owned(),
+            }
+        } else {
+            ActionReconciliationDisposition::PollAgain {
+                next_attempt_at_unix_ms: observed_at
+                    .checked_add(ACTION_RECONCILIATION_POLL_DELAY_MS)
+                    .ok_or_else(action_clock_overflow)?,
+            }
+        };
+        authority
+            .finish_reconciliation(
+                &identity.tenant,
+                &operation.proposal.operation_id,
+                &actor_id,
+                operation.version,
+                observed_at,
+                disposition,
+            )
+            .await
+            .map_err(action_store_error)?;
+        result.observed += 1;
+        if terminal {
+            result.terminal += 1;
+        }
+    }
+    Ok(Json(result))
+}
+
 async fn observe_action_provider_route(
     State(state): State<AppState>,
     Extension(identity): Extension<AuthenticatedIdentity>,
@@ -2207,6 +2394,13 @@ async fn observe_action_provider_route(
 
 fn next_provider_observation_time(previous: u64, current: u64) -> Option<u64> {
     previous.checked_add(1).map(|minimum| current.max(minimum))
+}
+
+fn action_clock_overflow() -> (StatusCode, Json<ErrorResponse>) {
+    service_unavailable(
+        "action_clock_unavailable",
+        "The Action reconciliation schedule cannot advance.",
+    )
 }
 
 fn provider_dispatch_command(
@@ -3056,6 +3250,28 @@ mod tests {
         ) -> Result<ActionDispatchPage, ActionStoreError> {
             panic!("spoofed request reached the Action authority")
         }
+
+        async fn claim_due_reconciliation(
+            &self,
+            _tenant_id: &TenantId,
+            _worker_id: &ActorId,
+            _claimed_at_unix_ms: u64,
+            _lease_expires_at_unix_ms: u64,
+        ) -> Result<Option<ActionReconciliationJob>, ActionStoreError> {
+            panic!("spoofed request reached the Action authority")
+        }
+
+        async fn finish_reconciliation(
+            &self,
+            _tenant_id: &TenantId,
+            _operation_id: &ActionOperationId,
+            _worker_id: &ActorId,
+            _expected_operation_version: u64,
+            _finished_at_unix_ms: u64,
+            _disposition: ActionReconciliationDisposition,
+        ) -> Result<(), ActionStoreError> {
+            panic!("spoofed request reached the Action authority")
+        }
     }
 
     fn unavailable() -> ContextError {
@@ -3878,6 +4094,10 @@ mod tests {
             ),
             "observe_action_provider"
         );
+        assert_eq!(
+            bounded_operation(&Method::POST, "/v1/action-reconciliation-runs"),
+            "run_action_reconciliation"
+        );
     }
 
     #[test]
@@ -3950,6 +4170,10 @@ mod tests {
                 &Method::POST,
                 "/v1/actions/operation:one/provider-observation"
             ),
+            "cerebro:actions:write"
+        );
+        assert_eq!(
+            oidc_scope_for_route(&Method::POST, "/v1/action-reconciliation-runs"),
             "cerebro:actions:write"
         );
     }
@@ -4186,11 +4410,17 @@ mod tests {
             .insert(ACTION_EXECUTE_SCOPE.to_owned());
         let error = observe_action_provider_route(
             State(state.clone()),
-            Extension(executor_identity),
+            Extension(executor_identity.clone()),
             Path("operation:http:one".to_owned()),
         )
         .await
         .expect_err("execution authority must not grant reconciliation authority");
+        assert_eq!(error.0, StatusCode::FORBIDDEN);
+        assert_eq!(error.1.0.code, "permission_denied");
+
+        let error = run_action_reconciliation(State(state.clone()), Extension(executor_identity))
+            .await
+            .expect_err("execution authority must not wake reconciliation work");
         assert_eq!(error.0, StatusCode::FORBIDDEN);
         assert_eq!(error.1.0.code, "permission_denied");
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -303,11 +303,20 @@ provider receipt; the runtime performs the GET, revalidates every dispatch
 binding, and commits the observation itself. Execution authority does not grant
 reconciliation authority.
 
+The provider-receipt commit also creates a tenant-scoped reconciliation job in
+the same PostgreSQL transaction. A signed call to
+`POST /v1/action-reconciliation-runs` does not name an Action. Rust claims at
+most ten due jobs using expiring leases and `SKIP LOCKED`, performs each
+provider read, and owns the next poll time. Transient provider failures return
+the job to the durable schedule; terminal provider status retires the polling
+job. A terminal provider status remains evidence only: it does not manufacture
+an observed effect or complete the Action.
+
 This code path does not by itself prove deployment cutover. Until deployment
 receipts show the Rust handler serves Action execution traffic,
 `internal/graphactions` remains a legacy provider network path. Rust provider
-reconciliation scheduling, first-party device mutation, independent effect
-observation, and removal of the Go route remain separate boundaries.
+reconciliation wake-up deployment, first-party device mutation, independent
+effect observation, and removal of the Go route remain separate boundaries.
 
 A2A discovery, outbound event subscription metadata, and public idempotency
 semantics also live in `internal/agentplatform`. The bootstrap budget includes


### PR DESCRIPTION
## Summary

- create tenant-scoped provider reconciliation jobs in the same PostgreSQL transaction as the bound provider receipt
- let Rust claim due work with expiring leases and `SKIP LOCKED`, then own retry timing and terminal retirement
- expose a fixed-size signed wake-up route that cannot select an Action or submit provider evidence
- keep terminal provider status as evidence only; no effect digest, completion, or verification is manufactured

## Authority boundary

The external caller can wake a tenant reconciliation run but cannot select an operation, set a due time, claim a lease, or supply provider status. Rust/PostgreSQL own those decisions. This does not establish independent effect observation, production scheduler deployment, traffic cutover, or Go route retirement.

## Verification

- `cargo test --locked -p cerebro-action-store -p cerebro-action-provider -p cerebro-platform`
- `cargo clippy --locked -p cerebro-action-store -p cerebro-action-provider -p cerebro-platform --all-targets -- -D warnings`
- `npm test --workspace @writer/cerebro-web -- --run scripts/authenticated-rust-e2e.test.mjs`
- `npm run lint --workspace @writer/cerebro-web -- --quiet scripts/authenticated-rust-e2e.mjs scripts/authenticated-rust-e2e.test.mjs`
- signed local browser -> Next -> Rust/PostgreSQL/provider lifecycle: executor denied; one due job claimed; one provider GET; terminal replay claimed zero jobs; Action remained uncompleted at version 8

Exact head: `6ac214e31fc2057085cfb117c04069cd5fd16953`
