### PR TITLE
Add Rust AWS SigV4 source authority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +167,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sigv4"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.2",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,8 +282,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -195,8 +313,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -225,6 +343,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -313,6 +441,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -526,6 +664,12 @@ name = "cerebro-source-runtime-next"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
  "cerebro-organizational-graph",
  "cerebro-organizational-model",
  "cerebro-source-catalog",
@@ -712,8 +856,8 @@ dependencies = [
  "bytes",
  "flate2",
  "futures",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project",
@@ -1039,7 +1183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1279,7 +1423,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -1321,12 +1465,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1341,12 +1502,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1357,8 +1529,8 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -1394,8 +1566,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -1411,7 +1583,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1430,8 +1602,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "hyper",
  "ipnet",
  "libc",
@@ -1891,6 +2063,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2162,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -2117,6 +2304,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -2311,7 +2504,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2439,8 +2632,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -2514,7 +2707,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2594,7 +2787,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3011,7 +3204,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3218,7 +3411,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.2",
  "httparse",
  "rand 0.8.7",
  "ring",
@@ -3255,8 +3448,8 @@ dependencies = [
  "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -3404,6 +3597,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3591,7 +3790,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,12 @@ license = "Apache-2.0"
 axum = "0.8.9"
 async-nats = "0.50.0"
 async-trait = "0.1.91"
+aws-credential-types = "=1.2.14"
+aws-sigv4 = { version = "=1.4.5", default-features = false, features = ["http1", "sign-http"] }
+aws-smithy-async = "=1.2.14"
+aws-smithy-runtime-api = { version = "=1.12.3", features = ["client"] }
+aws-smithy-runtime-api-macros = "=1.0.0"
+aws-smithy-types = "=1.5.0"
 buffa = { version = "=0.9.1", features = ["json"] }
 buffa-types = { version = "=0.9.1", features = ["json"] }
 cerebro-agent-context = { version = "0.1.0", path = "crates/agent-context" }

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -1266,12 +1266,12 @@ async fn sync_source() -> Result<(), Box<dyn Error>> {
         .get(&source_id)
         .ok_or_else(|| format!("source {source_id} is not in the catalog"))?
         .clone();
-    let auth = resolved_auth(source.auth())?;
-    let config = env::var("CEREBRO_SOURCE_CONFIG_JSON")
+    let mut config = env::var("CEREBRO_SOURCE_CONFIG_JSON")
         .ok()
         .map(|value| serde_json::from_str::<BTreeMap<String, String>>(&value))
         .transpose()?
         .unwrap_or_default();
+    let auth = resolved_auth(source.auth(), &mut config)?;
     let connector = HttpSourceConnector::new(
         source.clone(),
         &family_id,
@@ -1308,7 +1308,10 @@ async fn connect_neo4j() -> Result<Neo4jProjector, Box<dyn Error>> {
     .await?)
 }
 
-fn resolved_auth(model: &AuthModel) -> Result<ResolvedAuth, Box<dyn Error>> {
+fn resolved_auth(
+    model: &AuthModel,
+    config: &mut BTreeMap<String, String>,
+) -> Result<ResolvedAuth, Box<dyn Error>> {
     Ok(match model {
         AuthModel::None => ResolvedAuth::None,
         AuthModel::Basic => ResolvedAuth::Basic {
@@ -1319,13 +1322,43 @@ fn resolved_auth(model: &AuthModel) -> Result<ResolvedAuth, Box<dyn Error>> {
             name: required_env("CEREBRO_SOURCE_AUTH_HEADER")?,
             value: required_env("CEREBRO_SOURCE_AUTH_VALUE")?,
         },
-        AuthModel::DuoHmac | AuthModel::DuoHmacV5 | AuthModel::Signature | AuthModel::AwsSigV4 => {
+        AuthModel::AwsSigV4 => ResolvedAuth::AwsSigV4 {
+            access_key_id: take_required_config(config, "access_key")?,
+            secret_access_key: take_required_config(config, "secret_key")?,
+            session_token: remove_nonempty(config, "session_token"),
+            region: required_config(config, "region")?,
+            service: required_config(config, "service")?,
+        },
+        AuthModel::DuoHmac | AuthModel::DuoHmacV5 | AuthModel::Signature => {
             return Err("source auth requires a bespoke Rust connector".into());
         }
         _ => ResolvedAuth::Bearer {
             token: required_env("CEREBRO_SOURCE_TOKEN")?,
         },
     })
+}
+
+fn required_config(config: &BTreeMap<String, String>, key: &str) -> Result<String, Box<dyn Error>> {
+    config
+        .get(key)
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("CEREBRO_SOURCE_CONFIG_JSON.{key} is required").into())
+}
+
+fn take_required_config(
+    config: &mut BTreeMap<String, String>,
+    key: &str,
+) -> Result<String, Box<dyn Error>> {
+    remove_nonempty(config, key)
+        .ok_or_else(|| format!("CEREBRO_SOURCE_CONFIG_JSON.{key} is required").into())
+}
+
+fn remove_nonempty(config: &mut BTreeMap<String, String>, key: &str) -> Option<String> {
+    config
+        .remove(key)
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
 }
 
 async fn serve(
@@ -2483,6 +2516,39 @@ mod tests {
     use super::*;
 
     const TEST_SHARED_SECRET: &str = "test-organizational-graph-secret-32-bytes";
+
+    #[test]
+    fn aws_sigv4_resolution_scrubs_secrets_but_preserves_runtime_config() {
+        let mut config = BTreeMap::from([
+            ("access_key".to_owned(), "access-example".to_owned()),
+            ("secret_key".to_owned(), "secret-example".to_owned()),
+            ("session_token".to_owned(), "session-example".to_owned()),
+            ("region".to_owned(), "us-east-1".to_owned()),
+            ("service".to_owned(), "bedrock".to_owned()),
+            ("account".to_owned(), "account-a".to_owned()),
+        ]);
+        let auth = resolved_auth(&AuthModel::AwsSigV4, &mut config).unwrap();
+        assert!(matches!(
+            auth,
+            ResolvedAuth::AwsSigV4 {
+                ref access_key_id,
+                ref secret_access_key,
+                session_token: Some(ref session_token),
+                ref region,
+                ref service,
+            } if access_key_id == "access-example"
+                && secret_access_key == "secret-example"
+                && session_token == "session-example"
+                && region == "us-east-1"
+                && service == "bedrock"
+        ));
+        for secret_key in ["access_key", "secret_key", "session_token"] {
+            assert!(!config.contains_key(secret_key));
+        }
+        assert_eq!(config.get("region").map(String::as_str), Some("us-east-1"));
+        assert_eq!(config.get("service").map(String::as_str), Some("bedrock"));
+        assert_eq!(config.get("account").map(String::as_str), Some("account-a"));
+    }
 
     struct UnavailableGraph;
     struct UnreachableActionAuthority;

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -95,6 +95,7 @@ impl AuthModel {
                 | Self::OauthClientCredentials
                 | Self::TwoStep
                 | Self::Jwt
+                | Self::AwsSigV4
         )
     }
 }
@@ -915,6 +916,10 @@ mod tests {
         .unwrap();
         assert_eq!(
             catalog.get("box").unwrap().authority(),
+            CollectionAuthority::Authoritative
+        );
+        assert_eq!(
+            catalog.get("aws_bedrock").unwrap().authority(),
             CollectionAuthority::Authoritative
         );
         assert_eq!(

--- a/crates/source-runtime-next/Cargo.toml
+++ b/crates/source-runtime-next/Cargo.toml
@@ -8,6 +8,12 @@ publish = false
 
 [dependencies]
 async-trait.workspace = true
+aws-credential-types.workspace = true
+aws-sigv4.workspace = true
+aws-smithy-async.workspace = true
+aws-smithy-runtime-api.workspace = true
+aws-smithy-runtime-api-macros.workspace = true
+aws-smithy-types.workspace = true
 cerebro-organizational-graph.workspace = true
 cerebro-organizational-model.workspace = true
 cerebro-source-catalog.workspace = true

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -6,14 +6,21 @@ use std::{
 };
 
 use async_trait::async_trait;
+use aws_credential_types::Credentials;
+use aws_sigv4::{
+    http_request::{
+        SignableBody, SignableRequest, SigningParams, SigningSettings, sign as sign_http_request,
+    },
+    sign::v4,
+};
 use cerebro_organizational_model::{
     CollectionId, CollectionReceipt, CompleteCollection, ModelError, ObservationId,
 };
 use cerebro_source_catalog::{AuthModel, CompiledFamily, CompiledSource, HttpMethod, Pagination};
 use futures_util::StreamExt;
 use reqwest::{
-    Client, Response, StatusCode, Url,
-    header::{HeaderMap, HeaderName},
+    Client, Request, Response, StatusCode, Url,
+    header::{HeaderMap, HeaderName, HeaderValue},
 };
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -25,12 +32,55 @@ const MAX_RESPONSE_BYTES: usize = 16 << 20;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum ResolvedAuth {
     None,
-    Bearer { token: String },
-    Basic { username: String, password: String },
-    Header { name: String, value: String },
+    Bearer {
+        token: String,
+    },
+    Basic {
+        username: String,
+        password: String,
+    },
+    Header {
+        name: String,
+        value: String,
+    },
+    AwsSigV4 {
+        access_key_id: String,
+        secret_access_key: String,
+        session_token: Option<String>,
+        region: String,
+        service: String,
+    },
+}
+
+impl fmt::Debug for ResolvedAuth {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::None => formatter.write_str("None"),
+            Self::Bearer { .. } => formatter.write_str("Bearer { token: [REDACTED] }"),
+            Self::Basic { .. } => {
+                formatter.write_str("Basic { username: [REDACTED], password: [REDACTED] }")
+            }
+            Self::Header { name, .. } => formatter
+                .debug_struct("Header")
+                .field("name", name)
+                .field("value", &"[REDACTED]")
+                .finish(),
+            Self::AwsSigV4 { session_token, .. } => formatter
+                .debug_struct("AwsSigV4")
+                .field("access_key_id", &"[REDACTED]")
+                .field("secret_access_key", &"[REDACTED]")
+                .field(
+                    "session_token",
+                    &session_token.as_ref().map(|_| "[REDACTED]"),
+                )
+                .field("region", &"[CONFIGURED]")
+                .field("service", &"[CONFIGURED]")
+                .finish(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -173,8 +223,17 @@ impl SourceConnector for HttpSourceConnector {
                     builder.basic_auth(username, Some(password))
                 }
                 ResolvedAuth::Header { name, value } => builder.header(name, value),
+                ResolvedAuth::AwsSigV4 { .. } => builder,
             };
-            let response = builder.send().await.map_err(HttpConnectorError::Request)?;
+            let mut request = builder.build().map_err(HttpConnectorError::Request)?;
+            if matches!(self.auth, ResolvedAuth::AwsSigV4 { .. }) {
+                sign_aws_sigv4(&mut request, &self.auth, SystemTime::now())?;
+            }
+            let response = self
+                .client
+                .execute(request)
+                .await
+                .map_err(HttpConnectorError::Request)?;
             let status = response.status();
             if !status.is_success() {
                 return Err(HttpConnectorError::ProviderStatus(status));
@@ -364,9 +423,8 @@ fn validate_auth(expected: &AuthModel, actual: &ResolvedAuth) -> Result<(), Http
             actual,
             ResolvedAuth::Bearer { .. } | ResolvedAuth::Header { .. }
         ),
-        AuthModel::Signature | AuthModel::AwsSigV4 | AuthModel::DuoHmac | AuthModel::DuoHmacV5 => {
-            false
-        }
+        AuthModel::AwsSigV4 => matches!(actual, ResolvedAuth::AwsSigV4 { .. }),
+        AuthModel::Signature | AuthModel::DuoHmac | AuthModel::DuoHmacV5 => false,
     };
     if valid {
         Ok(())
@@ -375,6 +433,121 @@ fn validate_auth(expected: &AuthModel, actual: &ResolvedAuth) -> Result<(), Http
             "resolved credential does not match the source auth model".to_owned(),
         ))
     }
+}
+
+fn sign_aws_sigv4(
+    request: &mut Request,
+    auth: &ResolvedAuth,
+    time: SystemTime,
+) -> Result<(), HttpConnectorError> {
+    let ResolvedAuth::AwsSigV4 {
+        access_key_id,
+        secret_access_key,
+        session_token,
+        region,
+        service,
+    } = auth
+    else {
+        return Err(HttpConnectorError::InvalidConfiguration(
+            "AWS SigV4 signing requires AWS credentials".to_owned(),
+        ));
+    };
+    for (field, value) in [
+        ("access key ID", access_key_id.as_str()),
+        ("secret access key", secret_access_key.as_str()),
+        ("region", region.as_str()),
+        ("service", service.as_str()),
+    ] {
+        if value.trim().is_empty() {
+            return Err(HttpConnectorError::InvalidConfiguration(format!(
+                "AWS SigV4 {field} is required"
+            )));
+        }
+    }
+    let body = request
+        .body()
+        .and_then(reqwest::Body::as_bytes)
+        .unwrap_or_default();
+    if request.body().is_some() && request.body().and_then(reqwest::Body::as_bytes).is_none() {
+        return Err(HttpConnectorError::InvalidConfiguration(
+            "AWS SigV4 requires a replayable request body".to_owned(),
+        ));
+    }
+    let header_values = request
+        .headers()
+        .iter()
+        .map(|(name, value)| {
+            value
+                .to_str()
+                .map(|value| (name.as_str(), value))
+                .map_err(|_| {
+                    HttpConnectorError::InvalidConfiguration(format!(
+                        "AWS SigV4 cannot sign non-text header {}",
+                        name.as_str()
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let credentials = Credentials::new(
+        access_key_id,
+        secret_access_key,
+        session_token.clone(),
+        None,
+        "cerebro-source-runtime",
+    );
+    let identity = credentials.into();
+    let params: SigningParams<'_> = v4::SigningParams::builder()
+        .identity(&identity)
+        .region(region)
+        .name(service)
+        .time(time)
+        .settings(SigningSettings::default())
+        .build()
+        .map_err(|error| {
+            HttpConnectorError::InvalidConfiguration(format!(
+                "build AWS SigV4 signing parameters: {error}"
+            ))
+        })?
+        .into();
+    let signable = SignableRequest::new(
+        request.method().as_str(),
+        request.url().as_str(),
+        header_values.into_iter(),
+        SignableBody::Bytes(body),
+    )
+    .map_err(|error| {
+        HttpConnectorError::InvalidConfiguration(format!("build AWS SigV4 request: {error}"))
+    })?;
+    let (instructions, _) = sign_http_request(signable, &params)
+        .map_err(|error| {
+            HttpConnectorError::InvalidConfiguration(format!("sign AWS SigV4 request: {error}"))
+        })?
+        .into_parts();
+    let (headers, query) = instructions.into_parts();
+    if !query.is_empty() {
+        return Err(HttpConnectorError::InvalidConfiguration(
+            "AWS SigV4 unexpectedly returned query signing instructions".to_owned(),
+        ));
+    }
+    for header in headers {
+        let name = HeaderName::from_bytes(header.name().as_bytes()).map_err(|error| {
+            HttpConnectorError::InvalidConfiguration(format!(
+                "invalid AWS SigV4 header name: {error}"
+            ))
+        })?;
+        let mut value = HeaderValue::from_str(header.value()).map_err(|error| {
+            HttpConnectorError::InvalidConfiguration(format!(
+                "invalid AWS SigV4 header value: {error}"
+            ))
+        })?;
+        value.set_sensitive(
+            header.sensitive()
+                || name == reqwest::header::AUTHORIZATION
+                || name.as_str() == "x-amz-security-token",
+        );
+        request.headers_mut().insert(name, value);
+    }
+    Ok(())
 }
 
 fn is_loopback(url: &Url) -> bool {
@@ -662,7 +835,7 @@ fn hex(bytes: &[u8]) -> String {
 mod tests {
     use std::{
         path::{Path, PathBuf},
-        time::Duration,
+        time::{Duration, UNIX_EPOCH},
     };
 
     use cerebro_organizational_model::{SourceRuntimeId, TenantId};
@@ -828,6 +1001,74 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn aws_sigv4_signing_is_deterministic_and_covers_the_query() {
+        let auth = ResolvedAuth::AwsSigV4 {
+            access_key_id: "AKIDEXAMPLE".to_owned(),
+            secret_access_key: "secret-example".to_owned(),
+            session_token: Some("session-example".to_owned()),
+            region: "us-east-1".to_owned(),
+            service: "bedrock".to_owned(),
+        };
+        let time = UNIX_EPOCH + Duration::from_secs(1_440_938_160);
+        let client = Client::new();
+        let mut first = client
+            .get("https://bedrock.us-east-1.amazonaws.com/foundation-models?maxResults=10")
+            .build()
+            .unwrap();
+        let mut same = first.try_clone().unwrap();
+        let mut changed_query = client
+            .get("https://bedrock.us-east-1.amazonaws.com/foundation-models?maxResults=11")
+            .build()
+            .unwrap();
+
+        sign_aws_sigv4(&mut first, &auth, time).unwrap();
+        sign_aws_sigv4(&mut same, &auth, time).unwrap();
+        sign_aws_sigv4(&mut changed_query, &auth, time).unwrap();
+
+        let authorization = first.headers()["authorization"].to_str().unwrap();
+        assert!(authorization.starts_with("AWS4-HMAC-SHA256 "));
+        assert!(
+            authorization
+                .contains("Credential=AKIDEXAMPLE/20150830/us-east-1/bedrock/aws4_request")
+        );
+        assert!(authorization.contains("SignedHeaders=host;x-amz-date;x-amz-security-token"));
+        assert_eq!(first.headers()["x-amz-date"], "20150830T123600Z");
+        assert_eq!(first.headers()["x-amz-security-token"], "session-example");
+        assert!(first.headers()["authorization"].is_sensitive());
+        assert!(first.headers()["x-amz-security-token"].is_sensitive());
+        assert_eq!(
+            first.headers()["authorization"],
+            same.headers()["authorization"]
+        );
+        assert_ne!(
+            first.headers()["authorization"],
+            changed_query.headers()["authorization"]
+        );
+        let debug = format!("{auth:?}");
+        for secret in ["AKIDEXAMPLE", "secret-example", "session-example"] {
+            assert!(!debug.contains(secret));
+        }
+    }
+
+    #[test]
+    fn aws_sigv4_rejects_empty_signing_scope() {
+        let mut request = Client::new()
+            .get("https://bedrock.us-east-1.amazonaws.com/foundation-models")
+            .build()
+            .unwrap();
+        let auth = ResolvedAuth::AwsSigV4 {
+            access_key_id: "access".to_owned(),
+            secret_access_key: "secret".to_owned(),
+            session_token: None,
+            region: " ".to_owned(),
+            service: "bedrock".to_owned(),
+        };
+        let error = sign_aws_sigv4(&mut request, &auth, UNIX_EPOCH).unwrap_err();
+        assert_eq!(error.to_string(), "AWS SigV4 region is required");
+        assert!(!request.headers().contains_key("authorization"));
     }
 
     #[tokio::test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof and auth support present in this Rust runtime, 33 sources and 238 families are authoritative; the other 761 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof and auth support present in this Rust runtime, 34 sources and 251 families are authoritative; the other 760 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 


### PR DESCRIPTION
## Summary

- sign provider requests in the Rust source runtime with AWS Signature Version 4, including temporary session credentials
- fail closed on missing signing scope, non-replayable bodies, non-text headers, and unexpected query-signing instructions
- scrub signing credentials from runtime configuration before connector construction and redact every credential-bearing auth variant in debug output
- promote an existing fully proved source only after the Rust runtime can execute its auth model
- pin the AWS signing dependency family to versions compatible with the repository Rust toolchain

## Authority boundary

This diff adds one Rust auth execution capability and promotes only sources whose existing proof manifests match every runtime family by exact method and path. It does not infer provider proof, promote partial family matches, add Duo signing, replace an external secret injector, or claim full source-runtime cutover.

## Verification

- `cargo test --locked -p cerebro-source-catalog -p cerebro-source-runtime-next`
- `cargo test --locked -p cerebro-platform`
- strict Clippy for the source catalog, source runtime, and platform
- `make rust-deny`
- `make docs-drift-check readme-check check-structural check-arch oss-audit`
- deterministic and adversarial SigV4 tests for query coverage, session tokens, redaction, missing scope, and secret scrubbing

Exact head: `7e50d18e37d32d0027dcbd07811834e970f1dfd8`

Stacked on #2114.