### PR TITLE
Make parameterized Rust source authority fail closed

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -408,7 +408,14 @@ struct DefinitionWire {
     display_name: String,
     auth: AuthWire,
     #[serde(default)]
+    config_fields: Vec<ConfigFieldWire>,
+    #[serde(default)]
     resource_families: Vec<FamilyWire>,
+}
+
+#[derive(Deserialize)]
+struct ConfigFieldWire {
+    key: String,
 }
 
 #[derive(Deserialize)]
@@ -517,6 +524,12 @@ fn compile_source(
             message: format!("unsupported auth model {}", entry.definition.auth.model),
         }
     })?;
+    let config_fields = entry
+        .definition
+        .config_fields
+        .iter()
+        .map(|field| field.key.as_str())
+        .collect::<BTreeSet<_>>();
     let generic_runtime_supported = classifier_supported && auth.supports_generic_runtime();
     let verified_families = verified_families(proofs.get(&id));
     let mut family_ids = BTreeSet::new();
@@ -530,6 +543,7 @@ fn compile_source(
             family,
             &verified_families,
             generic_runtime_supported,
+            &config_fields,
         )?);
     }
     if families.is_empty() {
@@ -555,6 +569,7 @@ fn compile_family(
     family: FamilyWire,
     verified: &BTreeSet<(String, String, String)>,
     generic_runtime_supported: bool,
+    config_fields: &BTreeSet<&str>,
 ) -> Result<CompiledFamily, CatalogError> {
     let method = match family.method.trim() {
         "" | "GET" => HttpMethod::Get,
@@ -572,6 +587,13 @@ fn compile_family(
             &format!("family {} path must start with /", family.id),
         );
     }
+    let path_parameters_configured = family
+        .path
+        .split_once('?')
+        .map_or(family.path.as_str(), |(path, _)| path)
+        .split('/')
+        .filter_map(path_parameter)
+        .all(|parameter| config_fields.contains(parameter));
     let projection = family.projection.ok_or_else(|| CatalogError::Invalid {
         path: path.to_path_buf(),
         message: format!("family {} requires a projection", family.id),
@@ -598,16 +620,20 @@ fn compile_family(
     } else {
         "$[*]".to_owned()
     };
-    let provider_contract_verified = verified.contains(&(
-        family.id.clone(),
-        match method {
-            HttpMethod::Get => "GET".to_owned(),
-            HttpMethod::Post => "POST".to_owned(),
-        },
-        family.path.clone(),
-    ));
+    let provider_contract_verified = canonical_path_template(&family.path).is_some_and(|path| {
+        verified.contains(&(
+            family.id.clone(),
+            match method {
+                HttpMethod::Get => "GET".to_owned(),
+                HttpMethod::Post => "POST".to_owned(),
+            },
+            path,
+        ))
+    });
     Ok(CompiledFamily {
-        authoritative: generic_runtime_supported && provider_contract_verified,
+        authoritative: generic_runtime_supported
+            && provider_contract_verified
+            && path_parameters_configured,
         projection_authoritative: provider_contract_verified
             && projection_class.can_be_authoritative(),
         id: nonempty(path, "family id", family.id)?,
@@ -719,18 +745,67 @@ fn verified_families(proof: Option<&ProofManifestWire>) -> BTreeSet<(String, Str
                 && !family.path.is_empty()
                 && (family.method.is_empty() || family.method == "GET" || family.method == "POST")
         })
-        .map(|family| {
-            (
-                family.id.clone(),
-                if family.method.is_empty() {
-                    "GET".to_owned()
-                } else {
-                    family.method.clone()
-                },
-                family.path.clone(),
-            )
+        .filter_map(|family| {
+            canonical_path_template(&family.path).map(|path| {
+                (
+                    family.id.clone(),
+                    if family.method.is_empty() {
+                        "GET".to_owned()
+                    } else {
+                        family.method.clone()
+                    },
+                    path,
+                )
+            })
         })
         .collect()
+}
+
+fn canonical_path_template(path: &str) -> Option<String> {
+    let (path, query) = path
+        .split_once('?')
+        .map_or((path, None), |(path, query)| (path, Some(query)));
+    if !path.starts_with('/') {
+        return None;
+    }
+    let mut canonical = String::with_capacity(path.len());
+    for (index, segment) in path.split('/').enumerate() {
+        if index > 0 {
+            canonical.push('/');
+        }
+        if path_parameter(segment).is_some() {
+            canonical.push_str("{}");
+        } else {
+            if segment.contains('{') || segment.contains('}') {
+                return None;
+            }
+            canonical.push_str(segment);
+        }
+    }
+    if let Some(query) = query {
+        if query.contains('{') || query.contains('}') {
+            return None;
+        }
+        canonical.push('?');
+        canonical.push_str(query);
+    }
+    Some(canonical)
+}
+
+fn path_parameter(segment: &str) -> Option<&str> {
+    let parameter = segment
+        .strip_prefix("${config.")
+        .and_then(|value| value.strip_suffix('}'))
+        .or_else(|| {
+            segment
+                .strip_prefix('{')
+                .and_then(|value| value.strip_suffix('}'))
+        })?;
+    (!parameter.is_empty()
+        && parameter
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')))
+    .then_some(parameter)
 }
 
 fn load_proofs(root: &Path) -> Result<BTreeMap<String, ProofManifestWire>, CatalogError> {
@@ -916,10 +991,6 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            catalog.get("box").unwrap().authority(),
-            CollectionAuthority::Authoritative
-        );
-        assert_eq!(
             catalog.get("aws_bedrock").unwrap().authority(),
             CollectionAuthority::Authoritative
         );
@@ -927,6 +998,36 @@ mod tests {
             catalog.get("duo").unwrap().authority(),
             CollectionAuthority::Authoritative
         );
+        assert_eq!(
+            catalog.get("telnyx").unwrap().authority(),
+            CollectionAuthority::Authoritative
+        );
+        for source_id in [
+            "akeneo",
+            "apacta",
+            "appwrite",
+            "azure_openai",
+            "beezup",
+            "cloudflare_workers_ai",
+            "elevenlabs",
+            "google_vertex_ai",
+            "onelogin",
+            "qdrant_cloud",
+            "snyk",
+        ] {
+            assert_eq!(
+                catalog.get(source_id).unwrap().authority(),
+                CollectionAuthority::Authoritative,
+                "{source_id} has verified parameterized provider paths"
+            );
+        }
+        for source_id in ["airtable", "anchore", "box", "fivetran", "jira"] {
+            assert_eq!(
+                catalog.get(source_id).unwrap().authority(),
+                CollectionAuthority::ShadowOnly,
+                "{source_id} has a path parameter without a matching runtime config field"
+            );
+        }
         assert_eq!(
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly
@@ -950,5 +1051,23 @@ mod tests {
             .unwrap();
         assert!(!grants.is_authoritative());
         assert!(grants.is_projection_authoritative());
+    }
+
+    #[test]
+    fn provider_path_templates_match_slots_but_not_literal_scope() {
+        assert_eq!(
+            canonical_path_template("/sim_cards/{id}/wireless_connectivity_logs"),
+            Some("/sim_cards/{}/wireless_connectivity_logs".to_owned())
+        );
+        assert_eq!(
+            canonical_path_template("/sim_cards/${config.sim_card_id}/wireless_connectivity_logs"),
+            Some("/sim_cards/{}/wireless_connectivity_logs".to_owned())
+        );
+        assert_ne!(
+            canonical_path_template("/accounts/{id}/users"),
+            canonical_path_template("/organizations/{id}/users")
+        );
+        assert_eq!(canonical_path_template("/accounts/prefix-{id}/users"), None);
+        assert_eq!(canonical_path_template("/accounts/${config.id/users"), None);
     }
 }

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -186,8 +186,13 @@ impl HttpSourceConnector {
     fn request_url(&self) -> Result<Url, HttpConnectorError> {
         let mut path = self.family.path().to_owned();
         for (key, value) in &self.config {
-            path = path.replace(&format!("{{{key}}}"), value);
-            path = path.replace(&format!("${{config.{key}}}"), value);
+            let direct = format!("{{{key}}}");
+            let configured = format!("${{config.{key}}}");
+            if path.contains(&direct) || path.contains(&configured) {
+                let encoded = encode_path_parameter(key, value)?;
+                path = path.replace(&direct, &encoded);
+                path = path.replace(&configured, &encoded);
+            }
         }
         if path.contains('{') || path.contains("${") {
             return Err(HttpConnectorError::InvalidConfiguration(format!(
@@ -199,6 +204,26 @@ impl HttpSourceConnector {
             .join(path.trim_start_matches('/'))
             .map_err(|error| HttpConnectorError::InvalidUrl(error.to_string()))
     }
+}
+
+fn encode_path_parameter(key: &str, value: &str) -> Result<String, HttpConnectorError> {
+    if value.is_empty() {
+        return Err(HttpConnectorError::InvalidConfiguration(format!(
+            "path parameter {key} is required"
+        )));
+    }
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+            encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    Ok(encoded)
 }
 
 #[async_trait]
@@ -1105,6 +1130,36 @@ mod tests {
                 Some("configured")
             );
         }
+    }
+
+    #[test]
+    fn dynamic_catalog_path_values_cannot_expand_provider_scope() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let connector = HttpSourceConnector::new(
+            catalog.get("telnyx").unwrap().clone(),
+            "wireless_connectivity_log",
+            "https://api.example.test/v2",
+            BTreeMap::from([(
+                "sim_card_id".to_owned(),
+                "../other?scope=expanded#fragment".to_owned(),
+            )]),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let url = connector.request_url().unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://api.example.test/v2/sim_cards/%2E%2E%2Fother%3Fscope%3Dexpanded%23fragment/wireless_connectivity_logs"
+        );
+        assert!(url.query().is_none());
+        assert!(url.fragment().is_none());
     }
 
     #[test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof and auth support present in this Rust runtime, 35 sources and 262 families are authoritative; the other 759 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path parameters, and auth support present in this Rust runtime, 43 sources and 313 families are authoritative; the other 751 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 


### PR DESCRIPTION
## Summary
- normalize only complete provider path slots while preserving literal path, method, and query boundaries
- require every runtime path slot to have a declared configuration field before granting collection authority
- percent-encode configured values as one path segment and keep unresolved fan-out families shadow-only
- add catalog and runtime tests for scope injection, missing configuration, and current authority decisions

One audited parameterized family follows the provider's documented `GET /sim_cards/{id}/wireless_connectivity_logs` contract: https://developers.telnyx.com/api-reference/sim-cards/list-wireless-connectivity-logs

## Verification
- `cargo test --locked -p cerebro-source-catalog -p cerebro-source-runtime-next -p cerebro-platform`
- `cargo clippy --locked -p cerebro-source-catalog -p cerebro-source-runtime-next -p cerebro-platform --all-targets -- -D warnings`
- source generation, catalog fidelity, documentation drift, architecture, structural, OSS, and Rust dependency gates
- adversarial runtime URL test with path traversal, query, and fragment characters