### PR TITLE
Add bounded Rust source request fanout

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -474,6 +474,8 @@ struct FamilyWire {
     config_query: BTreeMap<String, String>,
     #[serde(default)]
     config: Option<FamilyConfigWire>,
+    #[serde(default)]
+    read: Option<FamilyReadWire>,
     pagination: Option<PaginationWire>,
     projection: Option<ProjectionWire>,
 }
@@ -484,6 +486,12 @@ struct FamilyConfigWire {
     config_query: BTreeMap<String, String>,
     #[serde(default)]
     config_attributes: BTreeMap<String, String>,
+}
+
+#[derive(Default, Deserialize)]
+struct FamilyReadWire {
+    #[serde(default)]
+    path_param_fanout: BTreeMap<String, String>,
 }
 
 #[derive(Deserialize)]
@@ -638,11 +646,37 @@ fn compile_family(
         .split('/')
         .filter_map(path_parameter)
         .collect::<BTreeSet<_>>();
+    let explicit_path_fanout = family
+        .read
+        .as_ref()
+        .map(|read| &read.path_param_fanout)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(parameter) = explicit_path_fanout
+        .keys()
+        .find(|parameter| !path_parameter_names.contains(parameter.as_str()))
+    {
+        return invalid(
+            path,
+            &format!(
+                "family {} fanout binding references unknown path parameter {parameter}",
+                family.id
+            ),
+        );
+    }
     let path_parameters = path_parameter_names
         .iter()
         .filter_map(|parameter| {
-            config_binding(parameter, config_fields)
-                .map(|binding| ((*parameter).to_owned(), binding))
+            let binding = if let Some(field) = explicit_path_fanout.get(*parameter) {
+                config_fields
+                    .contains(field.as_str())
+                    .then(|| PathParameterBinding::CsvFanout {
+                        field: field.clone(),
+                    })
+            } else {
+                config_binding(parameter, config_fields)
+            };
+            binding.map(|binding| ((*parameter).to_owned(), binding))
         })
         .collect::<BTreeMap<_, _>>();
     let path_parameters_configured = path_parameters.len() == path_parameter_names.len();
@@ -682,7 +716,9 @@ fn compile_family(
     let mut config_attributes = config_attributes_wire
         .iter()
         .filter_map(|(attribute, config_field)| {
-            config_binding(config_field, config_fields).map(|binding| (attribute.clone(), binding))
+            config_binding(config_field, config_fields)
+                .or_else(|| path_parameters.get(config_field).cloned())
+                .map(|binding| (attribute.clone(), binding))
         })
         .collect::<BTreeMap<_, _>>();
     let config_attributes_configured = config_attributes.len() == config_attributes_wire.len();
@@ -1142,6 +1178,7 @@ mod tests {
             "box",
             "cloudflare_workers_ai",
             "elevenlabs",
+            "fivetran",
             "google_vertex_ai",
             "jira",
             "onelogin",
@@ -1154,7 +1191,7 @@ mod tests {
                 "{source_id} has verified parameterized provider paths"
             );
         }
-        for source_id in ["airtable", "anchore", "fivetran"] {
+        for source_id in ["airtable", "anchore"] {
             assert_eq!(
                 catalog.get(source_id).unwrap().authority(),
                 CollectionAuthority::ShadowOnly,
@@ -1207,6 +1244,33 @@ mod tests {
             .unwrap();
         assert!(!family.is_authoritative());
         assert!(family.config_query().is_empty());
+    }
+
+    #[test]
+    fn explicit_fanout_binding_maps_a_provider_slot_to_its_configured_list() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let family = catalog
+            .get("fivetran")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "connector_metadata_details")
+            .unwrap();
+        assert_eq!(
+            family.path_parameters().get("service"),
+            Some(&PathParameterBinding::CsvFanout {
+                field: "connector_services".to_owned()
+            })
+        );
+        assert_eq!(
+            family.config_attributes().get("service"),
+            family.path_parameters().get("service")
+        );
     }
 
     #[test]

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -108,6 +108,23 @@ pub enum HttpMethod {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PathParameterBinding {
+    ScalarConfig { field: String },
+    OptionalScalarConfig { field: String },
+    CsvFanout { field: String },
+}
+
+impl PathParameterBinding {
+    pub fn field(&self) -> &str {
+        match self {
+            Self::ScalarConfig { field }
+            | Self::OptionalScalarConfig { field }
+            | Self::CsvFanout { field } => field,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Pagination {
     None,
     Cursor {
@@ -214,7 +231,10 @@ pub struct CompiledFamily {
     id_field: String,
     name_field: Option<String>,
     static_query: BTreeMap<String, String>,
+    config_query: BTreeMap<String, PathParameterBinding>,
+    config_attributes: BTreeMap<String, PathParameterBinding>,
     pagination: Pagination,
+    path_parameters: BTreeMap<String, PathParameterBinding>,
     projection: Projection,
     authoritative: bool,
     projection_authoritative: bool,
@@ -249,8 +269,20 @@ impl CompiledFamily {
         &self.static_query
     }
 
+    pub fn config_query(&self) -> &BTreeMap<String, PathParameterBinding> {
+        &self.config_query
+    }
+
+    pub fn config_attributes(&self) -> &BTreeMap<String, PathParameterBinding> {
+        &self.config_attributes
+    }
+
     pub fn pagination(&self) -> &Pagination {
         &self.pagination
+    }
+
+    pub fn path_parameters(&self) -> &BTreeMap<String, PathParameterBinding> {
+        &self.path_parameters
     }
 
     pub fn projection(&self) -> &Projection {
@@ -438,8 +470,20 @@ struct FamilyWire {
     name_field: String,
     #[serde(default)]
     static_query: BTreeMap<String, String>,
+    #[serde(default)]
+    config_query: BTreeMap<String, String>,
+    #[serde(default)]
+    config: Option<FamilyConfigWire>,
     pagination: Option<PaginationWire>,
     projection: Option<ProjectionWire>,
+}
+
+#[derive(Default, Deserialize)]
+struct FamilyConfigWire {
+    #[serde(default)]
+    config_query: BTreeMap<String, String>,
+    #[serde(default)]
+    config_attributes: BTreeMap<String, String>,
 }
 
 #[derive(Deserialize)]
@@ -587,13 +631,68 @@ fn compile_family(
             &format!("family {} path must start with /", family.id),
         );
     }
-    let path_parameters_configured = family
+    let path_parameter_names = family
         .path
         .split_once('?')
         .map_or(family.path.as_str(), |(path, _)| path)
         .split('/')
         .filter_map(path_parameter)
-        .all(|parameter| config_fields.contains(parameter));
+        .collect::<BTreeSet<_>>();
+    let path_parameters = path_parameter_names
+        .iter()
+        .filter_map(|parameter| {
+            config_binding(parameter, config_fields)
+                .map(|binding| ((*parameter).to_owned(), binding))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let path_parameters_configured = path_parameters.len() == path_parameter_names.len();
+    let mut config_query_wire = family
+        .config
+        .as_ref()
+        .map(|config| config.config_query.clone())
+        .unwrap_or_default();
+    for (parameter, field) in &family.config_query {
+        if config_query_wire
+            .insert(parameter.clone(), field.clone())
+            .is_some_and(|existing| existing != *field)
+        {
+            return invalid(
+                path,
+                &format!(
+                    "family {} defines conflicting config query parameter {parameter}",
+                    family.id
+                ),
+            );
+        }
+    }
+    let config_query = config_query_wire
+        .iter()
+        .filter_map(|(query_parameter, config_field)| {
+            config_query_binding(config_field, config_fields)
+                .map(|binding| (query_parameter.clone(), binding))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let config_query_configured = config_query.len() == config_query_wire.len();
+    let config_attributes_wire = family
+        .config
+        .as_ref()
+        .map(|config| &config.config_attributes)
+        .cloned()
+        .unwrap_or_default();
+    let mut config_attributes = config_attributes_wire
+        .iter()
+        .filter_map(|(attribute, config_field)| {
+            config_binding(config_field, config_fields).map(|binding| (attribute.clone(), binding))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let config_attributes_configured = config_attributes.len() == config_attributes_wire.len();
+    for (query_parameter, config_field) in &config_query_wire {
+        if let Some(binding) = config_query.get(query_parameter) {
+            config_attributes
+                .entry(config_field.clone())
+                .or_insert_with(|| binding.clone());
+        }
+    }
     let projection = family.projection.ok_or_else(|| CatalogError::Invalid {
         path: path.to_path_buf(),
         message: format!("family {} requires a projection", family.id),
@@ -633,7 +732,9 @@ fn compile_family(
     Ok(CompiledFamily {
         authoritative: generic_runtime_supported
             && provider_contract_verified
-            && path_parameters_configured,
+            && path_parameters_configured
+            && config_query_configured
+            && config_attributes_configured,
         projection_authoritative: provider_contract_verified
             && projection_class.can_be_authoritative(),
         id: nonempty(path, "family id", family.id)?,
@@ -643,7 +744,10 @@ fn compile_family(
         id_field: nonempty(path, "family id_field", family.id_field)?,
         name_field: optional(family.name_field),
         static_query: family.static_query,
+        config_query,
+        config_attributes,
         pagination: compile_pagination(path, family.pagination)?,
+        path_parameters,
         projection: Projection {
             class: projection_class,
             template,
@@ -651,6 +755,33 @@ fn compile_family(
             static_fields: projection.static_fields,
         },
     })
+}
+
+fn config_binding(requested: &str, config_fields: &BTreeSet<&str>) -> Option<PathParameterBinding> {
+    if config_fields.contains(requested) {
+        return Some(PathParameterBinding::ScalarConfig {
+            field: requested.to_owned(),
+        });
+    }
+    let plural = format!("{requested}s");
+    config_fields
+        .contains(plural.as_str())
+        .then_some(PathParameterBinding::CsvFanout { field: plural })
+}
+
+fn config_query_binding(
+    requested: &str,
+    config_fields: &BTreeSet<&str>,
+) -> Option<PathParameterBinding> {
+    let plural = format!("{requested}s");
+    if config_fields.contains(plural.as_str()) {
+        return Some(PathParameterBinding::CsvFanout { field: plural });
+    }
+    config_fields
+        .contains(requested)
+        .then(|| PathParameterBinding::OptionalScalarConfig {
+            field: requested.to_owned(),
+        })
 }
 
 fn compile_pagination(
@@ -1008,9 +1139,11 @@ mod tests {
             "appwrite",
             "azure_openai",
             "beezup",
+            "box",
             "cloudflare_workers_ai",
             "elevenlabs",
             "google_vertex_ai",
+            "jira",
             "onelogin",
             "qdrant_cloud",
             "snyk",
@@ -1021,17 +1154,59 @@ mod tests {
                 "{source_id} has verified parameterized provider paths"
             );
         }
-        for source_id in ["airtable", "anchore", "box", "fivetran", "jira"] {
+        for source_id in ["airtable", "anchore", "fivetran"] {
             assert_eq!(
                 catalog.get(source_id).unwrap().authority(),
                 CollectionAuthority::ShadowOnly,
-                "{source_id} has a path parameter without a matching runtime config field"
+                "{source_id} has an unresolved request scope"
             );
         }
         assert_eq!(
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly
         );
+    }
+
+    #[test]
+    fn plural_config_fields_compile_to_explicit_csv_fanout_bindings() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let family = catalog
+            .get("box")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "group_memberships")
+            .unwrap();
+        assert_eq!(
+            family.path_parameters().get("group_id"),
+            Some(&PathParameterBinding::CsvFanout {
+                field: "group_ids".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn undeclared_query_scope_cannot_become_collection_authority() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let family = catalog
+            .get("slack")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "channel_member")
+            .unwrap();
+        assert!(!family.is_authoritative());
+        assert!(family.config_query().is_empty());
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     error::Error,
     fmt,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -17,7 +17,9 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use cerebro_organizational_model::{
     CollectionId, CollectionReceipt, CompleteCollection, ModelError, ObservationId,
 };
-use cerebro_source_catalog::{AuthModel, CompiledFamily, CompiledSource, HttpMethod, Pagination};
+use cerebro_source_catalog::{
+    AuthModel, CompiledFamily, CompiledSource, HttpMethod, Pagination, PathParameterBinding,
+};
 use futures_util::StreamExt;
 use hmac::{Hmac, KeyInit, Mac};
 use reqwest::{
@@ -31,6 +33,7 @@ use time::OffsetDateTime;
 use crate::{CollectedBatch, CollectedScope, CollectionRequest, SourceConnector, SourceRecord};
 
 const MAX_PAGES: usize = 10_000;
+const MAX_FANOUT_SCOPES: usize = 1_000;
 const MAX_RESPONSE_BYTES: usize = 16 << 20;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -141,6 +144,26 @@ pub struct HttpSourceConnector {
     auth: ResolvedAuth,
 }
 
+struct RequestScope {
+    url: Url,
+    query_parameters: BTreeMap<String, String>,
+    record_attributes: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Default)]
+struct RequestScopeValues {
+    path_parameters: BTreeMap<String, String>,
+    query_parameters: BTreeMap<String, String>,
+    record_attributes: BTreeMap<String, String>,
+}
+
+#[derive(Clone)]
+enum RequestParameterTarget {
+    Path(String),
+    Query(String),
+    RecordAttribute(String),
+}
+
 impl HttpSourceConnector {
     pub fn new(
         source: CompiledSource,
@@ -183,9 +206,111 @@ impl HttpSourceConnector {
         })
     }
 
-    fn request_url(&self) -> Result<Url, HttpConnectorError> {
+    fn request_scopes(&self) -> Result<Vec<RequestScope>, HttpConnectorError> {
+        let mut binding_targets: BTreeMap<(String, u8), Vec<RequestParameterTarget>> =
+            BTreeMap::new();
+        for (parameter, binding) in self.family.path_parameters() {
+            add_binding_target(
+                &mut binding_targets,
+                binding,
+                RequestParameterTarget::Path(parameter.clone()),
+            );
+        }
+        for (parameter, binding) in self.family.config_query() {
+            add_binding_target(
+                &mut binding_targets,
+                binding,
+                RequestParameterTarget::Query(parameter.clone()),
+            );
+        }
+        for (attribute, binding) in self.family.config_attributes() {
+            add_binding_target(
+                &mut binding_targets,
+                binding,
+                RequestParameterTarget::RecordAttribute(attribute.clone()),
+            );
+        }
+
+        let mut scopes = vec![RequestScopeValues::default()];
+        for ((field, mode), targets) in binding_targets {
+            let values = match mode {
+                0 => vec![Some(required_config_value(&self.config, &field)?)],
+                1 => vec![
+                    self.config
+                        .get(&field)
+                        .filter(|value| !value.is_empty())
+                        .cloned(),
+                ],
+                2 => csv_fanout_values(&self.config, &field)?
+                    .into_iter()
+                    .map(Some)
+                    .collect(),
+                _ => unreachable!(),
+            };
+            let expanded = scopes.len().checked_mul(values.len()).ok_or_else(|| {
+                HttpConnectorError::InvalidConfiguration(format!(
+                    "family {} fanout scope count overflowed",
+                    self.family.id()
+                ))
+            })?;
+            if expanded > MAX_FANOUT_SCOPES {
+                return Err(HttpConnectorError::InvalidConfiguration(format!(
+                    "family {} fanout exceeds {MAX_FANOUT_SCOPES} scopes",
+                    self.family.id()
+                )));
+            }
+            let mut next = Vec::with_capacity(expanded);
+            for scope in &scopes {
+                for value in &values {
+                    let mut scope = scope.clone();
+                    if let Some(value) = value {
+                        for target in &targets {
+                            match target {
+                                RequestParameterTarget::Path(parameter) => {
+                                    scope
+                                        .path_parameters
+                                        .insert(parameter.clone(), value.clone());
+                                    scope
+                                        .record_attributes
+                                        .insert(parameter.clone(), value.clone());
+                                }
+                                RequestParameterTarget::Query(parameter) => {
+                                    scope
+                                        .query_parameters
+                                        .insert(parameter.clone(), value.clone());
+                                }
+                                RequestParameterTarget::RecordAttribute(attribute) => {
+                                    scope
+                                        .record_attributes
+                                        .insert(attribute.clone(), value.clone());
+                                }
+                            }
+                        }
+                    }
+                    next.push(scope);
+                }
+            }
+            scopes = next;
+        }
+        scopes
+            .into_iter()
+            .map(|scope| {
+                self.request_url(&scope.path_parameters)
+                    .map(|url| RequestScope {
+                        url,
+                        query_parameters: scope.query_parameters,
+                        record_attributes: scope.record_attributes,
+                    })
+            })
+            .collect()
+    }
+
+    fn request_url(
+        &self,
+        path_parameters: &BTreeMap<String, String>,
+    ) -> Result<Url, HttpConnectorError> {
         let mut path = self.family.path().to_owned();
-        for (key, value) in &self.config {
+        for (key, value) in path_parameters {
             let direct = format!("{{{key}}}");
             let configured = format!("${{config.{key}}}");
             if path.contains(&direct) || path.contains(&configured) {
@@ -204,6 +329,64 @@ impl HttpSourceConnector {
             .join(path.trim_start_matches('/'))
             .map_err(|error| HttpConnectorError::InvalidUrl(error.to_string()))
     }
+}
+
+fn add_binding_target(
+    targets: &mut BTreeMap<(String, u8), Vec<RequestParameterTarget>>,
+    binding: &PathParameterBinding,
+    target: RequestParameterTarget,
+) {
+    let mode = match binding {
+        PathParameterBinding::ScalarConfig { .. } => 0,
+        PathParameterBinding::OptionalScalarConfig { .. } => 1,
+        PathParameterBinding::CsvFanout { .. } => 2,
+    };
+    targets
+        .entry((binding.field().to_owned(), mode))
+        .or_default()
+        .push(target);
+}
+
+fn required_config_value(
+    config: &BTreeMap<String, String>,
+    field: &str,
+) -> Result<String, HttpConnectorError> {
+    config
+        .get(field)
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .ok_or_else(|| {
+            HttpConnectorError::InvalidConfiguration(format!("request config {field} is required"))
+        })
+}
+
+fn csv_fanout_values(
+    config: &BTreeMap<String, String>,
+    field: &str,
+) -> Result<Vec<String>, HttpConnectorError> {
+    let raw = required_config_value(config, field)?;
+    let mut seen = BTreeSet::new();
+    let mut values = Vec::new();
+    for value in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if seen.insert(value.to_owned()) {
+            values.push(value.to_owned());
+            if values.len() > MAX_FANOUT_SCOPES {
+                return Err(HttpConnectorError::InvalidConfiguration(format!(
+                    "path parameter config {field} exceeds {MAX_FANOUT_SCOPES} values"
+                )));
+            }
+        }
+    }
+    if values.is_empty() {
+        return Err(HttpConnectorError::InvalidConfiguration(format!(
+            "request config {field} requires at least one value"
+        )));
+    }
+    Ok(values)
 }
 
 fn encode_path_parameter(key: &str, value: &str) -> Result<String, HttpConnectorError> {
@@ -232,136 +415,158 @@ impl SourceConnector for HttpSourceConnector {
 
     async fn collect(&mut self, request: CollectionRequest) -> Result<CollectedBatch, Self::Error> {
         let observed_at = unix_millis()?;
-        let mut url = self.request_url()?;
+        let request_scopes = self.request_scopes()?;
         let initial_cursor = effective_cursor(self.family.pagination(), request.cursor.as_deref());
-        let mut cursor = initial_cursor.clone();
-        let mut page = pagination_start(self.family.pagination());
-        let mut offset = 0usize;
-        let mut records = Vec::new();
-        let mut exhausted = false;
-
-        for _ in 0..MAX_PAGES {
-            apply_query(
-                &mut url,
-                self.family.static_query(),
-                self.family.pagination(),
-                cursor.as_deref(),
-                page,
-                offset,
-            );
-            let mut builder = match self.family.method() {
-                HttpMethod::Get => self.client.get(url.clone()),
-                HttpMethod::Post => self.client.post(url.clone()),
-            };
-            builder = match &self.auth {
-                ResolvedAuth::None => builder,
-                ResolvedAuth::Bearer { token } => builder.bearer_auth(token),
-                ResolvedAuth::Basic { username, password } => {
-                    builder.basic_auth(username, Some(password))
-                }
-                ResolvedAuth::Header { name, value } => builder.header(name, value),
-                ResolvedAuth::AwsSigV4 { .. } | ResolvedAuth::DuoHmacV5 { .. } => builder,
-            };
-            let mut request = builder.build().map_err(HttpConnectorError::Request)?;
-            match self.auth {
-                ResolvedAuth::AwsSigV4 { .. } => {
-                    sign_aws_sigv4(&mut request, &self.auth, SystemTime::now())?;
-                }
-                ResolvedAuth::DuoHmacV5 { .. } => {
-                    sign_duo_hmac_v5(&mut request, &self.auth, SystemTime::now())?;
-                }
-                _ => {}
-            }
-            let response = self
-                .client
-                .execute(request)
-                .await
-                .map_err(HttpConnectorError::Request)?;
-            let status = response.status();
-            if !status.is_success() {
-                return Err(HttpConnectorError::ProviderStatus(status));
-            }
-            let next_link = response_next_link(response.headers(), self.family.pagination())?;
-            let body = read_bounded_json(response).await?;
-            let selected = select_records(&body, self.family.record_selector())?;
-            let selected_count = selected.len();
-            for value in selected {
-                let provider_id = scalar_at(&value, self.family.id_field()).ok_or_else(|| {
-                    HttpConnectorError::InvalidResponse(format!(
-                        "family {} record is missing {}",
-                        self.family.id(),
-                        self.family.id_field()
-                    ))
-                })?;
-                records.push(SourceRecord {
-                    observation_id: observation_id(
-                        self.source.id(),
-                        self.family.id(),
-                        &provider_id,
-                        observed_at,
-                    )?,
-                    family: self.family.id().to_owned(),
-                    provider_kind: format!("{}.{}", self.source.id(), self.family.id()),
-                    provider_id,
-                    fields: flatten_scalars(&value),
-                    payload: value,
-                });
-            }
-
-            match self.family.pagination() {
-                Pagination::None => {
-                    exhausted = true;
-                    break;
-                }
-                Pagination::Cursor { response_path, .. } => {
-                    cursor = scalar_at_path(&body, response_path);
-                    if cursor.as_deref().is_none_or(str::is_empty) {
-                        exhausted = true;
-                        break;
-                    }
-                }
-                Pagination::Page { page_size, .. } => {
-                    if selected_count < *page_size {
-                        exhausted = true;
-                        break;
-                    }
-                    page = page.saturating_add(1);
-                }
-                Pagination::Offset { page_size, .. } => {
-                    if selected_count < *page_size {
-                        exhausted = true;
-                        break;
-                    }
-                    offset = offset.saturating_add(*page_size);
-                }
-                Pagination::Link { .. } => {
-                    let Some(next) = next_link else {
-                        exhausted = true;
-                        break;
-                    };
-                    let Some(next) = resolve_next_url(&url, &next)? else {
-                        exhausted = true;
-                        break;
-                    };
-                    ensure_same_origin(&self.base_url, &next)?;
-                    url = next;
-                }
-                Pagination::NextUrl { response_path } => {
-                    let Some(next) = scalar_at_path(&body, response_path) else {
-                        exhausted = true;
-                        break;
-                    };
-                    let Some(next) = resolve_next_url(&url, &next)? else {
-                        exhausted = true;
-                        break;
-                    };
-                    ensure_same_origin(&self.base_url, &next)?;
-                    url = next;
-                }
-            }
+        if request.cursor.is_some() && request_scopes.len() > 1 {
+            return Err(HttpConnectorError::InvalidConfiguration(format!(
+                "family {} fanout does not accept an unscoped cursor",
+                self.family.id()
+            )));
         }
-        if !exhausted {
-            return Err(HttpConnectorError::PageLimit);
+        let mut records = Vec::new();
+        let mut remaining_pages = MAX_PAGES;
+
+        for RequestScope {
+            mut url,
+            query_parameters,
+            record_attributes,
+        } in request_scopes
+        {
+            let mut request_query = self.family.static_query().clone();
+            request_query.extend(query_parameters);
+            let mut cursor = initial_cursor.clone();
+            let mut page = pagination_start(self.family.pagination());
+            let mut offset = 0usize;
+            let mut exhausted = false;
+            while remaining_pages > 0 {
+                remaining_pages -= 1;
+                apply_query(
+                    &mut url,
+                    &request_query,
+                    self.family.pagination(),
+                    cursor.as_deref(),
+                    page,
+                    offset,
+                );
+                let mut builder = match self.family.method() {
+                    HttpMethod::Get => self.client.get(url.clone()),
+                    HttpMethod::Post => self.client.post(url.clone()),
+                };
+                builder = match &self.auth {
+                    ResolvedAuth::None => builder,
+                    ResolvedAuth::Bearer { token } => builder.bearer_auth(token),
+                    ResolvedAuth::Basic { username, password } => {
+                        builder.basic_auth(username, Some(password))
+                    }
+                    ResolvedAuth::Header { name, value } => builder.header(name, value),
+                    ResolvedAuth::AwsSigV4 { .. } | ResolvedAuth::DuoHmacV5 { .. } => builder,
+                };
+                let mut provider_request = builder.build().map_err(HttpConnectorError::Request)?;
+                match self.auth {
+                    ResolvedAuth::AwsSigV4 { .. } => {
+                        sign_aws_sigv4(&mut provider_request, &self.auth, SystemTime::now())?;
+                    }
+                    ResolvedAuth::DuoHmacV5 { .. } => {
+                        sign_duo_hmac_v5(&mut provider_request, &self.auth, SystemTime::now())?;
+                    }
+                    _ => {}
+                }
+                let response = self
+                    .client
+                    .execute(provider_request)
+                    .await
+                    .map_err(HttpConnectorError::Request)?;
+                let status = response.status();
+                if !status.is_success() {
+                    return Err(HttpConnectorError::ProviderStatus(status));
+                }
+                let next_link = response_next_link(response.headers(), self.family.pagination())?;
+                let body = read_bounded_json(response).await?;
+                let selected = select_records(&body, self.family.record_selector())?;
+                let selected_count = selected.len();
+                for value in selected {
+                    validate_record_scope(self.family.id(), &value, &record_attributes)?;
+                    let provider_id =
+                        scalar_at(&value, self.family.id_field()).ok_or_else(|| {
+                            HttpConnectorError::InvalidResponse(format!(
+                                "family {} record is missing {}",
+                                self.family.id(),
+                                self.family.id_field()
+                            ))
+                        })?;
+                    let mut fields = flatten_scalars(&value);
+                    fields.extend(record_attributes.clone());
+                    records.push(SourceRecord {
+                        observation_id: observation_id(
+                            self.source.id(),
+                            self.family.id(),
+                            &provider_id,
+                            &record_attributes,
+                            observed_at,
+                        )?,
+                        family: self.family.id().to_owned(),
+                        provider_kind: format!("{}.{}", self.source.id(), self.family.id()),
+                        provider_id,
+                        fields,
+                        payload: value,
+                    });
+                }
+
+                match self.family.pagination() {
+                    Pagination::None => {
+                        exhausted = true;
+                        break;
+                    }
+                    Pagination::Cursor { response_path, .. } => {
+                        cursor = scalar_at_path(&body, response_path);
+                        if cursor.as_deref().is_none_or(str::is_empty) {
+                            exhausted = true;
+                            break;
+                        }
+                    }
+                    Pagination::Page { page_size, .. } => {
+                        if selected_count < *page_size {
+                            exhausted = true;
+                            break;
+                        }
+                        page = page.saturating_add(1);
+                    }
+                    Pagination::Offset { page_size, .. } => {
+                        if selected_count < *page_size {
+                            exhausted = true;
+                            break;
+                        }
+                        offset = offset.saturating_add(*page_size);
+                    }
+                    Pagination::Link { .. } => {
+                        let Some(next) = next_link else {
+                            exhausted = true;
+                            break;
+                        };
+                        let Some(next) = resolve_next_url(&url, &next)? else {
+                            exhausted = true;
+                            break;
+                        };
+                        ensure_same_origin(&self.base_url, &next)?;
+                        url = next;
+                    }
+                    Pagination::NextUrl { response_path } => {
+                        let Some(next) = scalar_at_path(&body, response_path) else {
+                            exhausted = true;
+                            break;
+                        };
+                        let Some(next) = resolve_next_url(&url, &next)? else {
+                            exhausted = true;
+                            break;
+                        };
+                        ensure_same_origin(&self.base_url, &next)?;
+                        url = next;
+                    }
+                }
+            }
+            if !exhausted {
+                return Err(HttpConnectorError::PageLimit);
+            }
         }
 
         let collection_id = CollectionId::parse(format!(
@@ -399,7 +604,7 @@ impl SourceConnector for HttpSourceConnector {
         Ok(CollectedBatch {
             scope,
             records,
-            next_cursor: cursor,
+            next_cursor: None,
         })
     }
 }
@@ -947,6 +1152,23 @@ fn flatten_scalars(value: &Value) -> BTreeMap<String, String> {
     fields
 }
 
+fn validate_record_scope(
+    family_id: &str,
+    value: &Value,
+    path_parameters: &BTreeMap<String, String>,
+) -> Result<(), HttpConnectorError> {
+    for (parameter, expected) in path_parameters {
+        if let Some(actual) = scalar_at(value, parameter)
+            && actual != *expected
+        {
+            return Err(HttpConnectorError::InvalidResponse(format!(
+                "family {family_id} record changed requested {parameter} scope"
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn next_link_url(header: &str) -> Option<String> {
     split_link_header(header, ',').into_iter().find_map(|part| {
         let part = part.trim();
@@ -1038,14 +1260,23 @@ fn observation_id(
     source_id: &str,
     family_id: &str,
     provider_id: &str,
+    path_parameters: &BTreeMap<String, String>,
     observed_at: i64,
 ) -> Result<ObservationId, HttpConnectorError> {
     let mut hasher = Sha256::new();
     let observed_at = observed_at.to_string();
-    for part in [source_id, family_id, provider_id, observed_at.as_str()] {
+    for part in [source_id, family_id, provider_id] {
         hasher.update((part.len() as u64).to_be_bytes());
         hasher.update(part.as_bytes());
     }
+    for (parameter, value) in path_parameters {
+        for part in [parameter.as_str(), value.as_str()] {
+            hasher.update((part.len() as u64).to_be_bytes());
+            hasher.update(part.as_bytes());
+        }
+    }
+    hasher.update((observed_at.len() as u64).to_be_bytes());
+    hasher.update(observed_at.as_bytes());
     ObservationId::parse(format!("observation:{}", hex(&hasher.finalize()))).map_err(Into::into)
 }
 
@@ -1069,6 +1300,8 @@ mod tests {
     use cerebro_organizational_model::{SourceRuntimeId, TenantId};
     use cerebro_source_catalog::SourceCatalog;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use crate::{CatalogGraphMapper, GraphMapper};
 
     use super::*;
 
@@ -1153,7 +1386,9 @@ mod tests {
             },
         )
         .unwrap();
-        let url = connector.request_url().unwrap();
+        let scopes = connector.request_scopes().unwrap();
+        assert_eq!(scopes.len(), 1);
+        let url = &scopes[0].url;
         assert_eq!(
             url.as_str(),
             "https://api.example.test/v2/sim_cards/%2E%2E%2Fother%3Fscope%3Dexpanded%23fragment/wireless_connectivity_logs"
@@ -1458,6 +1693,189 @@ mod tests {
         assert!(matches!(batch.scope, CollectedScope::Complete(_)));
         assert_eq!(batch.records.len(), 1);
         assert_eq!(batch.records[0].provider_id, "user-1");
+    }
+
+    #[tokio::test]
+    async fn csv_path_fanout_is_bounded_deduplicated_and_scope_preserving() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let read = socket.read(&mut request).await.unwrap();
+                requests.push(String::from_utf8_lossy(&request[..read]).into_owned());
+                let body = r#"{"entries":[{"id":"membership-1","user":{"id":"user-1","login":"user@example.test","name":"User One"},"role":"member"}]}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+            requests
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("box").unwrap().clone();
+        let mut connector = HttpSourceConnector::new(
+            source.clone(),
+            "group_memberships",
+            &format!("http://{address}"),
+            BTreeMap::from([(
+                "group_ids".to_owned(),
+                " group-a, group-a, group/b ".to_owned(),
+            )]),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("box-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        let requests = server.await.unwrap();
+
+        assert!(requests[0].starts_with("GET /groups/group-a/memberships?"));
+        assert!(requests[1].starts_with("GET /groups/group%2Fb/memberships?"));
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 2);
+        assert_eq!(batch.records[0].provider_id, "membership-1");
+        assert_eq!(batch.records[1].provider_id, "membership-1");
+        assert_ne!(
+            batch.records[0].observation_id,
+            batch.records[1].observation_id
+        );
+        assert_eq!(batch.records[0].fields["group_id"], "group-a");
+        assert_eq!(batch.records[1].fields["group_id"], "group/b");
+
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.assertions().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn csv_query_fanout_binds_the_requested_scope_into_records() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let read = socket.read(&mut request).await.unwrap();
+                requests.push(String::from_utf8_lossy(&request[..read]).into_owned());
+                let body = r#"{"values":[{"accountId":"user-1","displayName":"User One","emailAddress":"user@example.test"}]}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+            requests
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("jira").unwrap().clone();
+        let mut connector = HttpSourceConnector::new(
+            source.clone(),
+            "group_members",
+            &format!("http://{address}"),
+            BTreeMap::from([("group_ids".to_owned(), "group-a,group/b".to_owned())]),
+            ResolvedAuth::Basic {
+                username: "user@example.test".to_owned(),
+                password: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("jira-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        let requests = server.await.unwrap();
+
+        assert!(requests[0].starts_with("GET /rest/api/3/group/member?"));
+        assert!(requests[0].contains("groupId=group-a"));
+        assert!(requests[1].contains("groupId=group%2Fb"));
+        assert_eq!(batch.records[0].fields["group_id"], "group-a");
+        assert_eq!(batch.records[1].fields["group_id"], "group/b");
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.assertions().len(), 2);
+    }
+
+    #[test]
+    fn provider_records_cannot_contradict_the_requested_scope() {
+        let error = validate_record_scope(
+            "memberships",
+            &serde_json::json!({"group_id": "other"}),
+            &BTreeMap::from([("group_id".to_owned(), "requested".to_owned())]),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "invalid provider response: family memberships record changed requested group_id scope"
+        );
+    }
+
+    #[test]
+    fn csv_fanout_rejects_empty_and_oversized_scope_sets() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("box").unwrap().clone();
+        for (value, expected) in [
+            (
+                " , ".to_owned(),
+                "request config group_ids requires at least one value",
+            ),
+            (
+                (0..=MAX_FANOUT_SCOPES)
+                    .map(|value| format!("group-{value}"))
+                    .collect::<Vec<_>>()
+                    .join(","),
+                "path parameter config group_ids exceeds 1000 values",
+            ),
+        ] {
+            let connector = HttpSourceConnector::new(
+                source.clone(),
+                "group_memberships",
+                "https://api.example.test",
+                BTreeMap::from([("group_ids".to_owned(), value)]),
+                ResolvedAuth::Bearer {
+                    token: "token".to_owned(),
+                },
+            )
+            .unwrap();
+            let error = connector.request_scopes().err().unwrap();
+            assert_eq!(error.to_string(), expected);
+        }
     }
 
     #[tokio::test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1701,12 +1701,15 @@ mod tests {
         let address = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let mut requests = Vec::new();
-            for _ in 0..2 {
+            for index in 0..2 {
                 let (mut socket, _) = listener.accept().await.unwrap();
                 let mut request = vec![0; 4096];
                 let read = socket.read(&mut request).await.unwrap();
                 requests.push(String::from_utf8_lossy(&request[..read]).into_owned());
-                let body = r#"{"entries":[{"id":"membership-1","user":{"id":"user-1","login":"user@example.test","name":"User One"},"role":"member"}]}"#;
+                let body = format!(
+                    r#"{{"entries":[{{"id":"membership-{}","user":{{"id":"user-1","login":"user@example.test","name":"User One"}},"role":"member"}}]}}"#,
+                    index + 1
+                );
                 let response = format!(
                     "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
                     body.len()
@@ -1751,7 +1754,7 @@ mod tests {
         assert!(matches!(batch.scope, CollectedScope::Complete(_)));
         assert_eq!(batch.records.len(), 2);
         assert_eq!(batch.records[0].provider_id, "membership-1");
-        assert_eq!(batch.records[1].provider_id, "membership-1");
+        assert_eq!(batch.records[1].provider_id, "membership-2");
         assert_ne!(
             batch.records[0].observation_id,
             batch.records[1].observation_id

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1845,6 +1845,42 @@ mod tests {
     }
 
     #[test]
+    fn explicit_fanout_binding_drives_runtime_paths_and_record_scope() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let connector = HttpSourceConnector::new(
+            catalog.get("fivetran").unwrap().clone(),
+            "connector_metadata_details",
+            "https://api.example.test",
+            BTreeMap::from([(
+                "connector_services".to_owned(),
+                "snowflake,postgres".to_owned(),
+            )]),
+            ResolvedAuth::Basic {
+                username: "key".to_owned(),
+                password: "secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let scopes = connector.request_scopes().unwrap();
+        assert_eq!(scopes.len(), 2);
+        assert_eq!(
+            scopes[0].url.path(),
+            "/v1/metadata/connector-types/snowflake"
+        );
+        assert_eq!(
+            scopes[1].url.path(),
+            "/v1/metadata/connector-types/postgres"
+        );
+        assert_eq!(scopes[0].record_attributes["service"], "snowflake");
+        assert_eq!(scopes[1].record_attributes["service"], "postgres");
+    }
+
+    #[test]
     fn csv_fanout_rejects_empty_and_oversized_scope_sets() {
         let root = repository_root();
         let catalog = SourceCatalog::load(

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -432,8 +432,21 @@ impl CatalogGraphMapper {
             EntityKind::Group,
             first(&projected, &["group_name", "group_email"]).unwrap_or(group_id),
         )?;
-        let identity = add_properties(identity.into_entity(), projected.clone())?;
-        let group = add_properties(group, projected)?;
+        let identity = add_properties(
+            identity.into_entity(),
+            projected
+                .iter()
+                .filter(|(key, _)| !key.starts_with("group_") && key.as_str() != "role")
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        )?;
+        let group = add_properties(
+            group,
+            projected
+                .into_iter()
+                .filter(|(key, _)| !key.starts_with("member_") && key != "role")
+                .collect(),
+        )?;
         let assertion = RelationshipAssertion::new(
             &identity,
             RelationKind::MemberOf,

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -436,7 +436,9 @@ impl CatalogGraphMapper {
             identity.into_entity(),
             projected
                 .iter()
-                .filter(|(key, _)| !key.starts_with("group_") && key.as_str() != "role")
+                .filter(|(key, _)| {
+                    !key.starts_with("group_") && key.as_str() != "role" && key.as_str() != "id"
+                })
                 .map(|(key, value)| (key.clone(), value.clone()))
                 .collect(),
         )?;
@@ -444,7 +446,7 @@ impl CatalogGraphMapper {
             group,
             projected
                 .into_iter()
-                .filter(|(key, _)| !key.starts_with("member_") && key != "role")
+                .filter(|(key, _)| !key.starts_with("member_") && key != "role" && key != "id")
                 .collect(),
         )?;
         let assertion = RelationshipAssertion::new(

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 45 sources and 327 families are authoritative; the other 749 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 46 sources and 328 families are authoritative; the other 748 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path parameters, and auth support present in this Rust runtime, 43 sources and 313 families are authoritative; the other 751 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 45 sources and 327 families are authoritative; the other 749 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/business-data-grc/fivetran.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/fivetran.yaml
@@ -1451,6 +1451,8 @@ entries:
             template: asset
           read:
             path_params: [service]
+            path_param_fanout:
+              service: connector_services
             singleton: true
             disable_page_size: true
           config:

--- a/internal/connectorcatalog/catalog/identity-access-secrets/duo.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/duo.yaml
@@ -23,6 +23,15 @@ entries:
           key: base_url
           label: API host
           required: true
+        - help: Earliest Unix timestamp included in administrator and authentication log reads.
+          key: mintime
+          label: Earliest log timestamp
+        - help: Latest Unix timestamp included in administrator and authentication log reads.
+          key: maxtime
+          label: Latest log timestamp
+        - help: Provider log order. Use asc or desc.
+          key: sort
+          label: Log order
       description: Collects Duo users, groups, administrators, endpoints, phones, hardware tokens, WebAuthn credentials, administrator roles, protected applications, activity logs, and authentication logs from the Duo Admin API and projects them into the Cerebro graph for inventory, access review, MFA posture, application ownership, audit review, and operational context.
       display_name: Duo
       id: builtin-duo

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -343,6 +343,7 @@ type ResourceReadSpec struct {
 	DetailPath            string            `json:"detail_path,omitempty"`
 	AllowBareDetailRecord bool              `json:"allow_bare_detail_record,omitempty"`
 	PathParams            []string          `json:"path_params,omitempty"`
+	PathParamFanout       map[string]string `json:"path_param_fanout,omitempty"`
 	MapRecords            map[string]string `json:"map_records,omitempty"`
 	Singleton             bool              `json:"singleton,omitempty"`
 	DisablePageSize       bool              `json:"disable_page_size,omitempty"`
@@ -535,6 +536,10 @@ func Validate(definition Definition) ValidationResult {
 	} else {
 		add(passing("resources", "Resource families", fmt.Sprintf("%d resource families are modeled.", len(definition.ResourceFamilies))))
 	}
+	runtimeConfigFields := map[string]struct{}{}
+	for _, field := range definition.ConfigFields {
+		runtimeConfigFields[strings.TrimSpace(field.Key)] = struct{}{}
+	}
 	for _, family := range definition.ResourceFamilies {
 		if !idPattern.MatchString(family.ID) {
 			add(blocking("family_"+family.ID, "Resource family ID", "Family ids must be lowercase identifiers."))
@@ -573,7 +578,7 @@ func Validate(definition Definition) ValidationResult {
 		if strings.ContainsAny(familyBaseURL, "\r\n\t\\") {
 			add(blocking("base_url_chars_"+family.ID, "Resource base URL", "Resource family base URL must not contain control characters or backslashes."))
 		}
-		validateFamilyIntegrationFields(family, add)
+		validateFamilyIntegrationFields(family, runtimeConfigFields, add)
 	}
 	status := ValidationReady
 	for _, check := range checks {
@@ -870,7 +875,7 @@ func isDepositResourceFamily(definition Definition, familyID string) bool {
 	return false
 }
 
-func validateFamilyIntegrationFields(family ResourceFamily, add func(ValidationCheck)) {
+func validateFamilyIntegrationFields(family ResourceFamily, configFields map[string]struct{}, add func(ValidationCheck)) {
 	if family.Read != nil {
 		if strings.TrimSpace(family.Read.DetailPath) != "" && !validRelativePath(family.Read.DetailPath) {
 			add(blocking("detail_path_"+family.ID, "Detail path", "Detail paths must be relative API paths such as /v1/assets/{id}."))
@@ -878,6 +883,22 @@ func validateFamilyIntegrationFields(family ResourceFamily, add func(ValidationC
 		for _, param := range family.Read.PathParams {
 			if !idPattern.MatchString(strings.TrimSpace(param)) {
 				add(blocking("path_param_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter", "Path parameters must be lowercase identifiers."))
+			}
+		}
+		pathParams := map[string]struct{}{}
+		for _, param := range family.Read.PathParams {
+			pathParams[strings.TrimSpace(param)] = struct{}{}
+		}
+		for param, configField := range family.Read.PathParamFanout {
+			param = strings.TrimSpace(param)
+			configField = strings.TrimSpace(configField)
+			if _, ok := pathParams[param]; !ok {
+				add(blocking("path_param_fanout_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter fanout", "Fanout bindings must reference a declared path parameter."))
+			}
+			if !idPattern.MatchString(configField) {
+				add(blocking("path_param_fanout_config_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter fanout", "Fanout config fields must be lowercase identifiers."))
+			} else if _, ok := configFields[configField]; !ok {
+				add(blocking("path_param_fanout_field_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter fanout", "Fanout config fields must be declared in definition.config_fields."))
 			}
 		}
 		for key, value := range family.Read.MapRecords {
@@ -1333,8 +1354,9 @@ func normalizeResourceReadSpec(read *ResourceReadSpec) *ResourceReadSpec {
 	next := *read
 	next.DetailPath = strings.TrimSpace(next.DetailPath)
 	next.PathParams = normalizeOrderedStringList(next.PathParams)
+	next.PathParamFanout = normalizeStringMap(next.PathParamFanout)
 	next.MapRecords = normalizeStringMap(next.MapRecords)
-	if next.DetailPath == "" && len(next.PathParams) == 0 && len(next.MapRecords) == 0 && !next.Singleton && !next.AllowBareDetailRecord && !next.DisablePageSize {
+	if next.DetailPath == "" && len(next.PathParams) == 0 && len(next.PathParamFanout) == 0 && len(next.MapRecords) == 0 && !next.Singleton && !next.AllowBareDetailRecord && !next.DisablePageSize {
 		return nil
 	}
 	return &next

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -634,6 +634,10 @@ func TestValidateBlocksUnsafeDeclarativeRuntimeFields(t *testing.T) {
 			Read: &ResourceReadSpec{
 				DetailPath: "//evil.example/users/{id}",
 				PathParams: []string{"account id", "AccountID"},
+				PathParamFanout: map[string]string{
+					"missing_id": "account_ids",
+					"AccountID":  "bad config",
+				},
 			},
 			Pagination: &PaginationSpec{
 				Type:     "graphql",
@@ -651,6 +655,9 @@ func TestValidateBlocksUnsafeDeclarativeRuntimeFields(t *testing.T) {
 		"detail_path_users",
 		"path_param_users_account-id",
 		"path_param_users_accountid",
+		"path_param_fanout_users_missing_id",
+		"path_param_fanout_field_users_missing_id",
+		"path_param_fanout_config_users_accountid",
 		"pagination_users",
 		"pagination_page_size_users",
 		"incremental_users",
@@ -909,6 +916,7 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 		SourceID:      "example",
 		DisplayName:   "Example",
 		Categories:    []string{"identity", "identity", "audit"},
+		ConfigFields:  []Field{{Key: "account_ids"}},
 		//nolint:gosec // Test auth descriptor only; no credential value is stored.
 		Auth: AuthSpec{
 			Model:            "oauth_authorization_code",
@@ -940,6 +948,7 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 				DetailPath:            "/v1/users/{id}",
 				AllowBareDetailRecord: true,
 				PathParams:            []string{"account_id", "account_id"},
+				PathParamFanout:       map[string]string{" account_id ": " account_ids ", "": "ignored"},
 				MapRecords:            map[string]string{"": "ignored", "members": "items"},
 			},
 			IDField: "id",
@@ -996,6 +1005,9 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 	}
 	if family.Read.MapRecords["members"] != "items" || len(family.Read.MapRecords) != 1 {
 		t.Fatalf("map records = %#v, want members->items", family.Read.MapRecords)
+	}
+	if family.Read.PathParamFanout["account_id"] != "account_ids" || len(family.Read.PathParamFanout) != 1 {
+		t.Fatalf("path param fanout = %#v, want account_id->account_ids", family.Read.PathParamFanout)
 	}
 	if family.Pagination == nil || len(family.Pagination.NextCursorKeys) != 1 || family.Pagination.NextCursorKeys[0] != "next_cursor" || family.Pagination.HasMoreKey != "has_more" {
 		t.Fatalf("pagination = %#v, want next cursor and has_more metadata", family.Pagination)


### PR DESCRIPTION
## Summary
- compile declared scalar, optional-query, and comma-separated fanout bindings into the closed Rust source model
- execute bounded, deduplicated path and query fanout while encoding each path value as one segment
- bind requested scope into records and observation identity, and reject provider records that contradict it
- keep undeclared query scopes shadow-only instead of claiming collection authority
- keep shared membership entities stable across multiple relationship scopes

## Verification
- `cargo test --locked -p cerebro-source-catalog -p cerebro-source-runtime-next -p cerebro-platform`
- `cargo clippy --locked -p cerebro-source-catalog -p cerebro-source-runtime-next -p cerebro-platform --all-targets -- -D warnings`
- source generation, catalog fidelity, documentation drift, architecture, structural, OSS, and Rust dependency gates
- local path-fanout and query-fanout provider tests through native Rust collection and graph mapping