### PR TITLE
Move scalar-scoped source collection into Rust

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -491,6 +491,8 @@ struct FamilyConfigWire {
 #[derive(Default, Deserialize)]
 struct FamilyReadWire {
     #[serde(default)]
+    path_param_config: BTreeMap<String, String>,
+    #[serde(default)]
     path_param_fanout: BTreeMap<String, String>,
 }
 
@@ -652,6 +654,24 @@ fn compile_family(
         .map(|read| &read.path_param_fanout)
         .cloned()
         .unwrap_or_default();
+    let explicit_path_config = family
+        .read
+        .as_ref()
+        .map(|read| &read.path_param_config)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(parameter) = explicit_path_config
+        .keys()
+        .find(|parameter| !path_parameter_names.contains(parameter.as_str()))
+    {
+        return invalid(
+            path,
+            &format!(
+                "family {} config binding references unknown path parameter {parameter}",
+                family.id
+            ),
+        );
+    }
     if let Some(parameter) = explicit_path_fanout
         .keys()
         .find(|parameter| !path_parameter_names.contains(parameter.as_str()))
@@ -664,10 +684,28 @@ fn compile_family(
             ),
         );
     }
+    if let Some(parameter) = explicit_path_config
+        .keys()
+        .find(|parameter| explicit_path_fanout.contains_key(*parameter))
+    {
+        return invalid(
+            path,
+            &format!(
+                "family {} path parameter {parameter} has both scalar config and fanout bindings",
+                family.id
+            ),
+        );
+    }
     let path_parameters = path_parameter_names
         .iter()
         .filter_map(|parameter| {
-            let binding = if let Some(field) = explicit_path_fanout.get(*parameter) {
+            let binding = if let Some(field) = explicit_path_config.get(*parameter) {
+                config_fields
+                    .contains(field.as_str())
+                    .then(|| PathParameterBinding::ScalarConfig {
+                        field: field.clone(),
+                    })
+            } else if let Some(field) = explicit_path_fanout.get(*parameter) {
                 config_fields
                     .contains(field.as_str())
                     .then(|| PathParameterBinding::CsvFanout {
@@ -1147,6 +1185,9 @@ mod tests {
             summary.sources,
             summary.authoritative_sources + summary.shadow_only_sources
         );
+        assert_eq!(summary.authoritative_sources, 48);
+        assert_eq!(summary.authoritative_families, 333);
+        assert_eq!(summary.shadow_only_sources, 746);
     }
 
     #[test]
@@ -1170,6 +1211,7 @@ mod tests {
             CollectionAuthority::Authoritative
         );
         for source_id in [
+            "airtable",
             "akeneo",
             "anchore",
             "apacta",
@@ -1192,11 +1234,6 @@ mod tests {
                 "{source_id} has verified parameterized provider paths"
             );
         }
-        assert_eq!(
-            catalog.get("airtable").unwrap().authority(),
-            CollectionAuthority::ShadowOnly,
-            "airtable has an unresolved request scope"
-        );
         assert_eq!(
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly
@@ -1299,6 +1336,31 @@ mod tests {
     }
 
     #[test]
+    fn explicit_scalar_binding_maps_airtable_provider_slot_to_runtime_config() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("airtable").unwrap();
+        assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+        for family_id in ["users", "audit_events"] {
+            let family = source
+                .families()
+                .iter()
+                .find(|family| family.id() == family_id)
+                .unwrap();
+            assert_eq!(
+                family.path_parameters().get("enterpriseAccountId"),
+                Some(&PathParameterBinding::ScalarConfig {
+                    field: "enterprise_account_id".to_owned()
+                })
+            );
+        }
+    }
+
+    #[test]
     fn bespoke_collection_does_not_block_a_verified_native_projection() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
@@ -1333,5 +1395,51 @@ mod tests {
         );
         assert_eq!(canonical_path_template("/accounts/prefix-{id}/users"), None);
         assert_eq!(canonical_path_template("/accounts/${config.id/users"), None);
+    }
+
+    #[test]
+    fn scalar_and_fanout_bindings_cannot_claim_the_same_path_parameter() {
+        let family = FamilyWire {
+            id: "users".to_owned(),
+            method: "GET".to_owned(),
+            path: "/v1/accounts/{account_id}/users".to_owned(),
+            record_selector: "$.items[*]".to_owned(),
+            list_key: String::new(),
+            id_field: "id".to_owned(),
+            name_field: String::new(),
+            static_query: BTreeMap::new(),
+            config_query: BTreeMap::new(),
+            config: None,
+            read: Some(FamilyReadWire {
+                path_param_config: BTreeMap::from([(
+                    "account_id".to_owned(),
+                    "account_id".to_owned(),
+                )]),
+                path_param_fanout: BTreeMap::from([(
+                    "account_id".to_owned(),
+                    "account_ids".to_owned(),
+                )]),
+            }),
+            pagination: None,
+            projection: Some(ProjectionWire {
+                template: "identity_user".to_owned(),
+                fields: BTreeMap::from([("user_id".to_owned(), "id".to_owned())]),
+                static_fields: BTreeMap::new(),
+            }),
+        };
+        let config_fields = BTreeSet::from(["account_id", "account_ids"]);
+        let error = compile_family(
+            Path::new("conflicting.yaml"),
+            family,
+            &BTreeSet::new(),
+            true,
+            &config_fields,
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("has both scalar config and fanout bindings")
+        );
     }
 }

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -227,6 +227,7 @@ pub struct CompiledFamily {
     id: String,
     method: HttpMethod,
     path: String,
+    base_url: Option<String>,
     record_selector: String,
     id_field: String,
     name_field: Option<String>,
@@ -251,6 +252,10 @@ impl CompiledFamily {
 
     pub fn path(&self) -> &str {
         &self.path
+    }
+
+    pub fn base_url(&self) -> Option<&str> {
+        self.base_url.as_deref()
     }
 
     pub fn record_selector(&self) -> &str {
@@ -483,7 +488,11 @@ struct FamilyWire {
 #[derive(Default, Deserialize)]
 struct FamilyConfigWire {
     #[serde(default)]
+    base_url: String,
+    #[serde(default)]
     config_query: BTreeMap<String, String>,
+    #[serde(default)]
+    required_config_query: BTreeMap<String, String>,
     #[serde(default)]
     config_attributes: BTreeMap<String, String>,
 }
@@ -718,13 +727,13 @@ fn compile_family(
         })
         .collect::<BTreeMap<_, _>>();
     let path_parameters_configured = path_parameters.len() == path_parameter_names.len();
-    let mut config_query_wire = family
+    let mut optional_config_query_wire = family
         .config
         .as_ref()
         .map(|config| config.config_query.clone())
         .unwrap_or_default();
     for (parameter, field) in &family.config_query {
-        if config_query_wire
+        if optional_config_query_wire
             .insert(parameter.clone(), field.clone())
             .is_some_and(|existing| existing != *field)
         {
@@ -737,14 +746,38 @@ fn compile_family(
             );
         }
     }
-    let config_query = config_query_wire
+    let required_config_query_wire = family
+        .config
+        .as_ref()
+        .map(|config| config.required_config_query.clone())
+        .unwrap_or_default();
+    if let Some(parameter) = required_config_query_wire
+        .keys()
+        .find(|parameter| optional_config_query_wire.contains_key(*parameter))
+    {
+        return invalid(
+            path,
+            &format!(
+                "family {} query parameter {parameter} has both optional and required config bindings",
+                family.id
+            ),
+        );
+    }
+    let mut config_query = optional_config_query_wire
         .iter()
         .filter_map(|(query_parameter, config_field)| {
             config_query_binding(config_field, config_fields)
                 .map(|binding| (query_parameter.clone(), binding))
         })
         .collect::<BTreeMap<_, _>>();
-    let config_query_configured = config_query.len() == config_query_wire.len();
+    config_query.extend(required_config_query_wire.iter().filter_map(
+        |(query_parameter, config_field)| {
+            config_binding(config_field, config_fields)
+                .map(|binding| (query_parameter.clone(), binding))
+        },
+    ));
+    let config_query_configured =
+        config_query.len() == optional_config_query_wire.len() + required_config_query_wire.len();
     let config_attributes_wire = family
         .config
         .as_ref()
@@ -760,7 +793,10 @@ fn compile_family(
         })
         .collect::<BTreeMap<_, _>>();
     let config_attributes_configured = config_attributes.len() == config_attributes_wire.len();
-    for (query_parameter, config_field) in &config_query_wire {
+    for (query_parameter, config_field) in optional_config_query_wire
+        .iter()
+        .chain(required_config_query_wire.iter())
+    {
         if let Some(binding) = config_query.get(query_parameter) {
             config_attributes
                 .entry(config_field.clone())
@@ -793,27 +829,39 @@ fn compile_family(
     } else {
         "$[*]".to_owned()
     };
-    let provider_contract_verified = canonical_path_template(&family.path).is_some_and(|path| {
-        verified.contains(&(
-            family.id.clone(),
-            match method {
-                HttpMethod::Get => "GET".to_owned(),
-                HttpMethod::Post => "POST".to_owned(),
-            },
-            path,
-        ))
-    });
+    let configured_base_url = family
+        .config
+        .as_ref()
+        .map(|config| config.base_url.trim())
+        .unwrap_or_default();
+    let base_url = (!configured_base_url.is_empty())
+        .then(|| static_https_base_url(configured_base_url))
+        .flatten();
+    let base_url_configured = configured_base_url.is_empty() || base_url.is_some();
+    let provider_contract_verified = provider_request_path(base_url.as_deref(), &family.path)
+        .is_some_and(|path| {
+            verified.contains(&(
+                family.id.clone(),
+                match method {
+                    HttpMethod::Get => "GET".to_owned(),
+                    HttpMethod::Post => "POST".to_owned(),
+                },
+                path,
+            ))
+        });
     Ok(CompiledFamily {
         authoritative: generic_runtime_supported
             && provider_contract_verified
             && path_parameters_configured
             && config_query_configured
-            && config_attributes_configured,
+            && config_attributes_configured
+            && base_url_configured,
         projection_authoritative: provider_contract_verified
             && projection_class.can_be_authoritative(),
         id: nonempty(path, "family id", family.id)?,
         method,
         path: family.path,
+        base_url,
         record_selector,
         id_field: nonempty(path, "family id_field", family.id_field)?,
         name_field: optional(family.name_field),
@@ -967,6 +1015,14 @@ fn verified_families(proof: Option<&ProofManifestWire>) -> BTreeSet<(String, Str
 }
 
 fn canonical_path_template(path: &str) -> Option<String> {
+    let absolute_path;
+    let path = if let Some(rest) = path.strip_prefix("https://") {
+        let (_, provider_path) = rest.split_once('/').unwrap_or((rest, ""));
+        absolute_path = format!("/{provider_path}");
+        absolute_path.as_str()
+    } else {
+        path
+    };
     let (path, query) = path
         .split_once('?')
         .map_or((path, None), |(path, query)| (path, Some(query)));
@@ -995,6 +1051,40 @@ fn canonical_path_template(path: &str) -> Option<String> {
         canonical.push_str(query);
     }
     Some(canonical)
+}
+
+fn static_https_base_url(value: &str) -> Option<String> {
+    let value = value.trim();
+    let rest = value.strip_prefix("https://")?;
+    if rest.is_empty()
+        || rest
+            .chars()
+            .any(|character| matches!(character, '{' | '}' | '?' | '#' | '\\'))
+        || rest.split('/').next().is_some_and(|authority| {
+            authority.is_empty()
+                || authority.contains('@')
+                || authority.chars().any(char::is_whitespace)
+        })
+    {
+        return None;
+    }
+    Some(format!("{}/", value.trim_end_matches('/')))
+}
+
+fn provider_request_path(base_url: Option<&str>, family_path: &str) -> Option<String> {
+    let Some(base_url) = base_url else {
+        return canonical_path_template(family_path);
+    };
+    let rest = base_url.strip_prefix("https://")?;
+    let (_, base_path) = rest.split_once('/').unwrap_or((rest, ""));
+    let base_path = base_path.trim_matches('/');
+    let family_path = family_path.trim_start_matches('/');
+    let path = if base_path.is_empty() {
+        format!("/{family_path}")
+    } else {
+        format!("/{base_path}/{family_path}")
+    };
+    canonical_path_template(&path)
 }
 
 fn path_parameter(segment: &str) -> Option<&str> {
@@ -1185,9 +1275,9 @@ mod tests {
             summary.sources,
             summary.authoritative_sources + summary.shadow_only_sources
         );
-        assert_eq!(summary.authoritative_sources, 48);
-        assert_eq!(summary.authoritative_families, 333);
-        assert_eq!(summary.shadow_only_sources, 746);
+        assert_eq!(summary.authoritative_sources, 49);
+        assert_eq!(summary.authoritative_families, 337);
+        assert_eq!(summary.shadow_only_sources, 745);
     }
 
     #[test]
@@ -1226,6 +1316,7 @@ mod tests {
             "jira",
             "onelogin",
             "qdrant_cloud",
+            "slack",
             "snyk",
         ] {
             assert_eq!(
@@ -1264,22 +1355,37 @@ mod tests {
     }
 
     #[test]
-    fn undeclared_query_scope_cannot_become_collection_authority() {
+    fn required_query_scope_is_declared_and_fail_closed() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
             root.join("internal/connectorcatalog/catalog"),
             root.join("sources"),
         )
         .unwrap();
-        let family = catalog
-            .get("slack")
-            .unwrap()
+        let source = catalog.get("slack").unwrap();
+        let shadow_families = source
+            .families()
+            .iter()
+            .filter(|family| !family.is_authoritative())
+            .map(CompiledFamily::id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            source.authority(),
+            CollectionAuthority::Authoritative,
+            "shadow families: {shadow_families:?}"
+        );
+        let family = source
             .families()
             .iter()
             .find(|family| family.id() == "channel_member")
             .unwrap();
-        assert!(!family.is_authoritative());
-        assert!(family.config_query().is_empty());
+        assert!(family.is_authoritative());
+        assert_eq!(
+            family.config_query().get("channel"),
+            Some(&PathParameterBinding::ScalarConfig {
+                field: "channel_id".to_owned()
+            })
+        );
     }
 
     #[test]
@@ -1441,5 +1547,65 @@ mod tests {
                 .to_string()
                 .contains("has both scalar config and fanout bindings")
         );
+    }
+
+    #[test]
+    fn optional_and_required_query_bindings_cannot_claim_the_same_parameter() {
+        let family = FamilyWire {
+            id: "members".to_owned(),
+            method: "GET".to_owned(),
+            path: "/v1/members".to_owned(),
+            record_selector: "$.items[*]".to_owned(),
+            list_key: String::new(),
+            id_field: "id".to_owned(),
+            name_field: String::new(),
+            static_query: BTreeMap::new(),
+            config_query: BTreeMap::from([("scope".to_owned(), "scope".to_owned())]),
+            config: Some(FamilyConfigWire {
+                required_config_query: BTreeMap::from([("scope".to_owned(), "scope".to_owned())]),
+                ..Default::default()
+            }),
+            read: None,
+            pagination: None,
+            projection: Some(ProjectionWire {
+                template: "identity_user".to_owned(),
+                fields: BTreeMap::from([("user_id".to_owned(), "id".to_owned())]),
+                static_fields: BTreeMap::new(),
+            }),
+        };
+        let config_fields = BTreeSet::from(["scope"]);
+        let error = compile_family(
+            Path::new("conflicting.yaml"),
+            family,
+            &BTreeSet::new(),
+            true,
+            &config_fields,
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("has both optional and required config bindings")
+        );
+    }
+
+    #[test]
+    fn static_family_base_urls_are_https_and_path_preserving() {
+        assert_eq!(
+            static_https_base_url("https://api.example.test/audit/v1"),
+            Some("https://api.example.test/audit/v1/".to_owned())
+        );
+        assert_eq!(
+            provider_request_path(Some("https://api.example.test/audit/v1/"), "/events"),
+            Some("/audit/v1/events".to_owned())
+        );
+        for invalid in [
+            "http://api.example.test",
+            "https://${config.host}",
+            "https://user@api.example.test",
+            "https://api.example.test/path?scope=all",
+        ] {
+            assert_eq!(static_https_base_url(invalid), None, "{invalid}");
+        }
     }
 }

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1171,6 +1171,7 @@ mod tests {
         );
         for source_id in [
             "akeneo",
+            "anchore",
             "apacta",
             "appwrite",
             "azure_openai",
@@ -1191,13 +1192,11 @@ mod tests {
                 "{source_id} has verified parameterized provider paths"
             );
         }
-        for source_id in ["airtable", "anchore"] {
-            assert_eq!(
-                catalog.get(source_id).unwrap().authority(),
-                CollectionAuthority::ShadowOnly,
-                "{source_id} has an unresolved request scope"
-            );
-        }
+        assert_eq!(
+            catalog.get("airtable").unwrap().authority(),
+            CollectionAuthority::ShadowOnly,
+            "airtable has an unresolved request scope"
+        );
         assert_eq!(
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly
@@ -1271,6 +1270,32 @@ mod tests {
             family.config_attributes().get("service"),
             family.path_parameters().get("service")
         );
+    }
+
+    #[test]
+    fn scalar_config_fields_bind_every_anchore_path_parameter() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("anchore").unwrap();
+        assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+        for family in source.families() {
+            assert_eq!(
+                family.path_parameters().get("app_id"),
+                Some(&PathParameterBinding::ScalarConfig {
+                    field: "app_id".to_owned()
+                })
+            );
+            assert_eq!(
+                family.path_parameters().get("version_id"),
+                Some(&PathParameterBinding::ScalarConfig {
+                    field: "version_id".to_owned()
+                })
+            );
+        }
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -184,6 +184,7 @@ impl HttpSourceConnector {
                 ))
             })?;
         validate_auth(source.auth(), &auth)?;
+        let base_url = family.base_url().unwrap_or(base_url);
         let mut base_url = Url::parse(base_url)
             .map_err(|error| HttpConnectorError::InvalidUrl(error.to_string()))?;
         if base_url.scheme() != "https" && !is_loopback(&base_url) {
@@ -486,8 +487,10 @@ impl SourceConnector for HttpSourceConnector {
                 let selected_count = selected.len();
                 for value in selected {
                     validate_record_scope(self.family.id(), &value, &record_attributes)?;
-                    let provider_id =
-                        scalar_at(&value, self.family.id_field()).ok_or_else(|| {
+                    let scalar_record = scalar(&value);
+                    let provider_id = scalar_at(&value, self.family.id_field())
+                        .or_else(|| scalar_record.clone())
+                        .ok_or_else(|| {
                             HttpConnectorError::InvalidResponse(format!(
                                 "family {} record is missing {}",
                                 self.family.id(),
@@ -495,6 +498,9 @@ impl SourceConnector for HttpSourceConnector {
                             ))
                         })?;
                     let mut fields = flatten_scalars(&value);
+                    if let Some(value) = scalar_record {
+                        fields.insert(self.family.id_field().to_owned(), value);
+                    }
                     fields.extend(record_attributes.clone());
                     records.push(SourceRecord {
                         observation_id: observation_id(
@@ -2005,6 +2011,105 @@ mod tests {
             .map(&batch)
             .unwrap();
         assert_eq!(delta.entities().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn required_query_scope_executes_scalar_slack_memberships() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /conversations.members?"));
+            assert!(request.contains("channel=C1"));
+            assert!(request.contains("authorization: Bearer token"));
+            let body = r#"{"members":["U1","U2"],"response_metadata":{"next_cursor":""}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("slack").unwrap().clone();
+        let mut connector = HttpSourceConnector::new(
+            source.clone(),
+            "channel_member",
+            &format!("http://{address}"),
+            BTreeMap::from([("channel_id".to_owned(), "C1".to_owned())]),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("slack-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 2);
+        assert_eq!(batch.records[0].provider_id, "U1");
+        assert_eq!(batch.records[0].fields["user_id"], "U1");
+        assert_eq!(batch.records[0].fields["channel_id"], "C1");
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.entities().len(), 3);
+        assert_eq!(delta.assertions().len(), 2);
+    }
+
+    #[test]
+    fn required_query_scope_rejects_missing_config_and_honors_family_base_url() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("slack").unwrap().clone();
+        let connector = HttpSourceConnector::new(
+            source.clone(),
+            "channel_member",
+            "https://slack.com/api",
+            BTreeMap::new(),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let error = connector.request_scopes().err().unwrap();
+        assert_eq!(error.to_string(), "request config channel_id is required");
+
+        let audit = HttpSourceConnector::new(
+            source,
+            "audit_log",
+            "https://slack.com/api",
+            BTreeMap::new(),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let scopes = audit.request_scopes().unwrap();
+        assert_eq!(
+            scopes[0].url.as_str(),
+            "https://api.slack.com/audit/v1/logs"
+        );
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1945,6 +1945,68 @@ mod tests {
         assert_eq!(delta.entities().len(), 1);
     }
 
+    #[tokio::test]
+    async fn explicit_scalar_path_binding_executes_airtable_collection() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /v0/meta/enterpriseAccounts/enterprise%2Fone/users?"));
+            assert!(request.contains("authorization: Bearer token"));
+            let body = r#"{"users":[{"id":"user-1","name":"User One","email":"user@example.test","state":"active"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("airtable").unwrap().clone();
+        let mut connector = HttpSourceConnector::new(
+            source.clone(),
+            "users",
+            &format!("http://{address}"),
+            BTreeMap::from([(
+                "enterprise_account_id".to_owned(),
+                "enterprise/one".to_owned(),
+            )]),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("airtable-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(
+            batch.records[0].fields["enterpriseAccountId"],
+            "enterprise/one"
+        );
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.entities().len(), 1);
+    }
+
     #[test]
     fn scalar_path_scope_rejects_missing_required_config() {
         let root = repository_root();
@@ -1965,10 +2027,7 @@ mod tests {
         )
         .unwrap();
         let error = connector.request_scopes().err().unwrap();
-        assert_eq!(
-            error.to_string(),
-            "request config version_id is required"
-        );
+        assert_eq!(error.to_string(), "request config version_id is required");
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1880,6 +1880,97 @@ mod tests {
         assert_eq!(scopes[1].record_attributes["service"], "postgres");
     }
 
+    #[tokio::test]
+    async fn scalar_path_scope_executes_anchore_collection_and_graph_mapping() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /apps/app%2Fone/versions/version%20one/assets?"));
+            assert!(
+                request
+                    .to_ascii_lowercase()
+                    .contains("\r\nauthorization: basic ")
+            );
+            let body = r#"{"items":[{"id":"asset-1","name":"Image One","type":"container"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("anchore").unwrap().clone();
+        let mut connector = HttpSourceConnector::new(
+            source.clone(),
+            "assets",
+            &format!("http://{address}"),
+            BTreeMap::from([
+                ("app_id".to_owned(), "app/one".to_owned()),
+                ("version_id".to_owned(), "version one".to_owned()),
+            ]),
+            ResolvedAuth::Basic {
+                username: "user".to_owned(),
+                password: "password".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("anchore-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].fields["app_id"], "app/one");
+        assert_eq!(batch.records[0].fields["version_id"], "version one");
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.entities().len(), 1);
+    }
+
+    #[test]
+    fn scalar_path_scope_rejects_missing_required_config() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let connector = HttpSourceConnector::new(
+            catalog.get("anchore").unwrap().clone(),
+            "assets",
+            "https://api.example.test",
+            BTreeMap::from([("app_id".to_owned(), "app-one".to_owned())]),
+            ResolvedAuth::Basic {
+                username: "user".to_owned(),
+                password: "password".to_owned(),
+            },
+        )
+        .unwrap();
+        let error = connector.request_scopes().err().unwrap();
+        assert_eq!(
+            error.to_string(),
+            "request config version_id is required"
+        );
+    }
+
     #[test]
     fn csv_fanout_rejects_empty_and_oversized_scope_sets() {
         let root = repository_root();

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -405,9 +405,11 @@ impl CatalogGraphMapper {
         builder: &mut GraphDeltaBuilder<Mode>,
     ) -> Result<(), CatalogMapperError> {
         let group_id =
-            first(&projected, &["group_id"]).ok_or_else(|| CatalogMapperError::MissingField {
-                family: family.id().to_owned(),
-                field: "group_id".to_owned(),
+            first(&projected, &["group_id", "channel_id", "usergroup_id"]).ok_or_else(|| {
+                CatalogMapperError::MissingField {
+                    family: family.id().to_owned(),
+                    field: "group_id".to_owned(),
+                }
             })?;
         let member_id = first(
             &projected,
@@ -437,7 +439,11 @@ impl CatalogGraphMapper {
             projected
                 .iter()
                 .filter(|(key, _)| {
-                    !key.starts_with("group_") && key.as_str() != "role" && key.as_str() != "id"
+                    !key.starts_with("group_")
+                        && key.as_str() != "role"
+                        && key.as_str() != "id"
+                        && key.as_str() != "channel_id"
+                        && key.as_str() != "usergroup_id"
                 })
                 .map(|(key, value)| (key.clone(), value.clone()))
                 .collect(),
@@ -446,7 +452,9 @@ impl CatalogGraphMapper {
             group,
             projected
                 .into_iter()
-                .filter(|(key, _)| !key.starts_with("member_") && key != "role" && key != "id")
+                .filter(|(key, _)| {
+                    !key.starts_with("member_") && key != "role" && key != "id" && key != "user_id"
+                })
                 .collect(),
         )?;
         let assertion = RelationshipAssertion::new(

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 46 sources and 328 families are authoritative; the other 748 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 47 sources and 331 families are authoritative; the other 747 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 47 sources and 331 families are authoritative; the other 747 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 48 sources and 333 families are authoritative; the other 746 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 48 sources and 333 families are authoritative; the other 746 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 49 sources and 337 families are authoritative; the other 745 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/collaboration-productivity/airtable.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/airtable.yaml
@@ -10,6 +10,11 @@ entries:
       categories:
         - saas
         - collaboration
+      config_fields:
+        - help: Airtable enterprise account identifier used to scope users and audit events.
+          key: enterprise_account_id
+          label: Enterprise account ID
+          required: true
       description: Collects enterprise users, bases, and audit log events from Airtable and maps them into the Cerebro graph as users, assets, and audit events for workspace, base, and collaboration context.
       display_name: Airtable
       id: builtin-airtable
@@ -43,6 +48,11 @@ entries:
               status: status|state|lifecycle_state
               user_id: id
             template: identity_user
+          read:
+            path_param_config:
+              enterpriseAccountId: enterprise_account_id
+            path_params:
+              - enterpriseAccountId
           record_selector: $.users[*]
         - coverage:
             - control_domains:
@@ -114,6 +124,11 @@ entries:
               event_type: action
               id: id
             template: audit_event
+          read:
+            path_param_config:
+              enterpriseAccountId: enterprise_account_id
+            path_params:
+              - enterpriseAccountId
           record_selector: $.events[*]
       schema_version: cerebro.integration/v1
       source_id: airtable

--- a/internal/connectorcatalog/catalog/collaboration-productivity/slack.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/slack.yaml
@@ -32,6 +32,15 @@ entries:
         - help: Slack Audit Logs API host. Keep the default unless using a test endpoint.
           key: audit_log_base_url
           label: Audit Logs API host
+        - help: Optional Unix timestamp upper bound for team access log entries.
+          key: before
+          label: Access logs before
+        - help: Channel identifier required when collecting channel memberships.
+          key: channel_id
+          label: Channel ID
+        - help: User group identifier required when collecting user group memberships.
+          key: usergroup_id
+          label: User group ID
       description: Collects Slack workspaces, users, channels, user groups, memberships, team access logs, and Enterprise Grid audit logs and projects them into the Cerebro graph for inventory, access review, membership review, login review, and collaboration audit context.
       display_name: Slack
       id: builtin_catalog-slack
@@ -230,8 +239,9 @@ entries:
             required_payload_fields: [channel_id, user_id]
             schema_ref: slack/channel_member/v1
             urn_kind: slack_channel_member
-          config_query:
-            channel: channel_id
+          config:
+            required_config_query:
+              channel: channel_id
           id: channel_member
           id_field: user_id
           label: Channel members
@@ -268,8 +278,9 @@ entries:
             required_payload_fields: [usergroup_id, user_id]
             schema_ref: slack/user_group_member/v1
             urn_kind: slack_user_group_member
-          config_query:
-            usergroup: usergroup_id
+          config:
+            required_config_query:
+              usergroup: usergroup_id
           id: user_group_member
           id_field: user_id
           label: User group members

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/anchore.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/anchore.yaml
@@ -12,6 +12,15 @@ entries:
       categories:
         - security
         - containers
+      config_fields:
+        - help: Anchore application identifier used to scope version data.
+          key: app_id
+          label: Application ID
+          required: true
+        - help: Anchore application version identifier used to scope assets and findings.
+          key: version_id
+          label: Version ID
+          required: true
       description: Collects assets, findings, and vulnerabilities from Anchore and projects them into the Cerebro graph as assets, findings, and vulnerabilities for asset exposure, vulnerability, finding, and remediation context.
       display_name: Anchore
       id: builtin-anchore

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -618,15 +618,15 @@ func TestBuiltinSlackMembershipFamiliesCarryContainerContext(t *testing.T) {
 		t.Fatal("BuiltinEntry(slack) ok = false, want true")
 	}
 	channelMember := catalogFamily(t, entry.Definition.ResourceFamilies, "channel_member")
-	if channelMember.ConfigQuery["channel"] != "channel_id" {
-		t.Fatalf("channel_member config_query = %#v, want channel from channel_id", channelMember.ConfigQuery)
+	if channelMember.Config == nil || channelMember.Config.RequiredConfigQuery["channel"] != "channel_id" {
+		t.Fatalf("channel_member config = %#v, want required channel from channel_id", channelMember.Config)
 	}
 	if channelMember.Read == nil || len(channelMember.Read.PathParams) != 1 || channelMember.Read.PathParams[0] != "channel_id" {
 		t.Fatalf("channel_member read = %#v, want channel_id path param", channelMember.Read)
 	}
 	userGroupMember := catalogFamily(t, entry.Definition.ResourceFamilies, "user_group_member")
-	if userGroupMember.ConfigQuery["usergroup"] != "usergroup_id" {
-		t.Fatalf("user_group_member config_query = %#v, want usergroup from usergroup_id", userGroupMember.ConfigQuery)
+	if userGroupMember.Config == nil || userGroupMember.Config.RequiredConfigQuery["usergroup"] != "usergroup_id" {
+		t.Fatalf("user_group_member config = %#v, want required usergroup from usergroup_id", userGroupMember.Config)
 	}
 	if userGroupMember.Read == nil || len(userGroupMember.Read.PathParams) != 1 || userGroupMember.Read.PathParams[0] != "usergroup_id" {
 		t.Fatalf("user_group_member read = %#v, want usergroup_id path param", userGroupMember.Read)

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -353,15 +353,16 @@ type ResourceReadSpec struct {
 
 // FamilyConfigSpec binds static and runtime config values into a resource-family request.
 type FamilyConfigSpec struct {
-	BaseURL          string            `json:"base_url,omitempty"`
-	AuthModel        string            `json:"auth_model,omitempty"`
-	StaticQuery      map[string]string `json:"static_query,omitempty"`
-	ConfigQuery      map[string]string `json:"config_query,omitempty"`
-	ConfigAttributes map[string]string `json:"config_attributes,omitempty"`
-	IDTemplate       string            `json:"id_template,omitempty"`
-	EncodeURNID      bool              `json:"encode_urn_id,omitempty"`
-	ResourceURNKind  string            `json:"resource_urn_kind,omitempty"`
-	IdentityKeys     []string          `json:"identity_keys,omitempty"`
+	BaseURL             string            `json:"base_url,omitempty"`
+	AuthModel           string            `json:"auth_model,omitempty"`
+	StaticQuery         map[string]string `json:"static_query,omitempty"`
+	ConfigQuery         map[string]string `json:"config_query,omitempty"`
+	RequiredConfigQuery map[string]string `json:"required_config_query,omitempty"`
+	ConfigAttributes    map[string]string `json:"config_attributes,omitempty"`
+	IDTemplate          string            `json:"id_template,omitempty"`
+	EncodeURNID         bool              `json:"encode_urn_id,omitempty"`
+	ResourceURNKind     string            `json:"resource_urn_kind,omitempty"`
+	IdentityKeys        []string          `json:"identity_keys,omitempty"`
 }
 
 // ScopeOption exposes a resource family as a selectable scope option in the UI.
@@ -927,10 +928,21 @@ func validateFamilyIntegrationFields(family ResourceFamily, configFields map[str
 	if family.Config != nil {
 		validateFamilyConfigMap(family.ID, "static_query", family.Config.StaticQuery, add)
 		validateFamilyConfigMap(family.ID, "config_query", family.Config.ConfigQuery, add)
+		validateFamilyConfigMap(family.ID, "required_config_query", family.Config.RequiredConfigQuery, add)
 		validateFamilyConfigMap(family.ID, "config_attributes", family.Config.ConfigAttributes, add)
 		for _, key := range family.Config.IdentityKeys {
 			if strings.TrimSpace(key) == "" {
 				add(blocking("identity_keys_"+family.ID, "Identity keys", "Identity keys must not contain empty values."))
+			}
+		}
+		for queryParam, configField := range family.Config.RequiredConfigQuery {
+			if _, ok := configFields[configField]; !ok {
+				add(blocking("required_config_query_field_"+family.ID+"_"+normalizeDefinitionID(queryParam), "Required query config", "Required query bindings must reference fields declared in definition.config_fields."))
+			}
+			_, topLevelOptional := family.ConfigQuery[queryParam]
+			_, nestedOptional := family.Config.ConfigQuery[queryParam]
+			if topLevelOptional || nestedOptional {
+				add(blocking("query_binding_"+family.ID+"_"+normalizeDefinitionID(queryParam), "Query binding", "A query parameter cannot use both optional and required config bindings."))
 			}
 		}
 	}
@@ -1389,11 +1401,12 @@ func normalizeFamilyConfigSpec(config *FamilyConfigSpec) *FamilyConfigSpec {
 	next.AuthModel = strings.TrimSpace(next.AuthModel)
 	next.StaticQuery = normalizeStringMap(next.StaticQuery)
 	next.ConfigQuery = normalizeStringMap(next.ConfigQuery)
+	next.RequiredConfigQuery = normalizeStringMap(next.RequiredConfigQuery)
 	next.ConfigAttributes = normalizeStringMap(next.ConfigAttributes)
 	next.IDTemplate = strings.TrimSpace(next.IDTemplate)
 	next.ResourceURNKind = strings.TrimSpace(next.ResourceURNKind)
 	next.IdentityKeys = normalizeStringList(next.IdentityKeys)
-	if next.BaseURL == "" && next.AuthModel == "" && len(next.StaticQuery) == 0 && len(next.ConfigQuery) == 0 && len(next.ConfigAttributes) == 0 && next.IDTemplate == "" && !next.EncodeURNID && next.ResourceURNKind == "" && len(next.IdentityKeys) == 0 {
+	if next.BaseURL == "" && next.AuthModel == "" && len(next.StaticQuery) == 0 && len(next.ConfigQuery) == 0 && len(next.RequiredConfigQuery) == 0 && len(next.ConfigAttributes) == 0 && next.IDTemplate == "" && !next.EncodeURNID && next.ResourceURNKind == "" && len(next.IdentityKeys) == 0 {
 		return nil
 	}
 	return &next

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -36,17 +36,18 @@ const (
 var (
 	ErrInvalidDefinition = errors.New("invalid connector definition")
 
-	idPattern           = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
-	entityTypePattern   = regexp.MustCompile(`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`)
-	definitionIDRun     = regexp.MustCompile(`[^a-z0-9_-]+`)
-	templateVar         = regexp.MustCompile(`\$\{([a-z]+)\.([a-z][a-z0-9_-]*)\}`)
-	statusIdentifier    = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
-	stageOrder          = []string{StageDraft, StageSandbox, StagePilot, StageApproved, StageCertified}
-	supportedMethods    = map[string]struct{}{"GET": {}, "POST": {}}
-	paginationTypes     = map[string]struct{}{"": {}, "none": {}, "cursor": {}, "page": {}, "offset": {}, "link": {}, "next_url": {}}
-	incrementalStates   = map[string]struct{}{"": {}, "high_watermark": {}, "opaque_cursor": {}}
-	ingestModes         = map[string]struct{}{IngestModePull: {}, IngestModeDeposit: {}}
-	projectionRelations = map[string]struct{}{
+	idPattern            = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+	pathParameterPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
+	entityTypePattern    = regexp.MustCompile(`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`)
+	definitionIDRun      = regexp.MustCompile(`[^a-z0-9_-]+`)
+	templateVar          = regexp.MustCompile(`\$\{([a-z]+)\.([a-z][a-z0-9_-]*)\}`)
+	statusIdentifier     = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	stageOrder           = []string{StageDraft, StageSandbox, StagePilot, StageApproved, StageCertified}
+	supportedMethods     = map[string]struct{}{"GET": {}, "POST": {}}
+	paginationTypes      = map[string]struct{}{"": {}, "none": {}, "cursor": {}, "page": {}, "offset": {}, "link": {}, "next_url": {}}
+	incrementalStates    = map[string]struct{}{"": {}, "high_watermark": {}, "opaque_cursor": {}}
+	ingestModes          = map[string]struct{}{IngestModePull: {}, IngestModeDeposit: {}}
+	projectionRelations  = map[string]struct{}{
 		"attached_to": {},
 		"belongs_to":  {},
 		"contains":    {},
@@ -343,6 +344,7 @@ type ResourceReadSpec struct {
 	DetailPath            string            `json:"detail_path,omitempty"`
 	AllowBareDetailRecord bool              `json:"allow_bare_detail_record,omitempty"`
 	PathParams            []string          `json:"path_params,omitempty"`
+	PathParamConfig       map[string]string `json:"path_param_config,omitempty"`
 	PathParamFanout       map[string]string `json:"path_param_fanout,omitempty"`
 	MapRecords            map[string]string `json:"map_records,omitempty"`
 	Singleton             bool              `json:"singleton,omitempty"`
@@ -881,13 +883,28 @@ func validateFamilyIntegrationFields(family ResourceFamily, configFields map[str
 			add(blocking("detail_path_"+family.ID, "Detail path", "Detail paths must be relative API paths such as /v1/assets/{id}."))
 		}
 		for _, param := range family.Read.PathParams {
-			if !idPattern.MatchString(strings.TrimSpace(param)) {
-				add(blocking("path_param_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter", "Path parameters must be lowercase identifiers."))
+			if !pathParameterPattern.MatchString(strings.TrimSpace(param)) {
+				add(blocking("path_param_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter", "Path parameters must be provider-safe identifiers."))
 			}
 		}
 		pathParams := map[string]struct{}{}
 		for _, param := range family.Read.PathParams {
 			pathParams[strings.TrimSpace(param)] = struct{}{}
+		}
+		for param, configField := range family.Read.PathParamConfig {
+			param = strings.TrimSpace(param)
+			configField = strings.TrimSpace(configField)
+			if _, ok := pathParams[param]; !ok {
+				add(blocking("path_param_config_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter config", "Config bindings must reference a declared path parameter."))
+			}
+			if !idPattern.MatchString(configField) {
+				add(blocking("path_param_config_field_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter config", "Config bindings must reference lowercase config field identifiers."))
+			} else if _, ok := configFields[configField]; !ok {
+				add(blocking("path_param_config_declared_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter config", "Config bindings must reference fields declared in definition.config_fields."))
+			}
+			if _, ok := family.Read.PathParamFanout[param]; ok {
+				add(blocking("path_param_binding_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter binding", "A path parameter cannot use both scalar config and fanout bindings."))
+			}
 		}
 		for param, configField := range family.Read.PathParamFanout {
 			param = strings.TrimSpace(param)
@@ -1354,9 +1371,10 @@ func normalizeResourceReadSpec(read *ResourceReadSpec) *ResourceReadSpec {
 	next := *read
 	next.DetailPath = strings.TrimSpace(next.DetailPath)
 	next.PathParams = normalizeOrderedStringList(next.PathParams)
+	next.PathParamConfig = normalizeStringMap(next.PathParamConfig)
 	next.PathParamFanout = normalizeStringMap(next.PathParamFanout)
 	next.MapRecords = normalizeStringMap(next.MapRecords)
-	if next.DetailPath == "" && len(next.PathParams) == 0 && len(next.PathParamFanout) == 0 && len(next.MapRecords) == 0 && !next.Singleton && !next.AllowBareDetailRecord && !next.DisablePageSize {
+	if next.DetailPath == "" && len(next.PathParams) == 0 && len(next.PathParamConfig) == 0 && len(next.PathParamFanout) == 0 && len(next.MapRecords) == 0 && !next.Singleton && !next.AllowBareDetailRecord && !next.DisablePageSize {
 		return nil
 	}
 	return &next

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -633,10 +633,14 @@ func TestValidateBlocksUnsafeDeclarativeRuntimeFields(t *testing.T) {
 			IDField:        "id",
 			Read: &ResourceReadSpec{
 				DetailPath: "//evil.example/users/{id}",
-				PathParams: []string{"account id", "AccountID"},
+				PathParams: []string{"account id", "1AccountID"},
+				PathParamConfig: map[string]string{
+					"missing_config": "missing",
+					"1AccountID":     "bad config",
+				},
 				PathParamFanout: map[string]string{
 					"missing_id": "account_ids",
-					"AccountID":  "bad config",
+					"1AccountID": "bad config",
 				},
 			},
 			Pagination: &PaginationSpec{
@@ -654,10 +658,13 @@ func TestValidateBlocksUnsafeDeclarativeRuntimeFields(t *testing.T) {
 	for _, want := range []string{
 		"detail_path_users",
 		"path_param_users_account-id",
-		"path_param_users_accountid",
+		"path_param_users_1accountid",
+		"path_param_config_users_missing_config",
+		"path_param_config_declared_users_missing_config",
+		"path_param_config_field_users_1accountid",
 		"path_param_fanout_users_missing_id",
 		"path_param_fanout_field_users_missing_id",
-		"path_param_fanout_config_users_accountid",
+		"path_param_fanout_config_users_1accountid",
 		"pagination_users",
 		"pagination_page_size_users",
 		"incremental_users",
@@ -666,6 +673,31 @@ func TestValidateBlocksUnsafeDeclarativeRuntimeFields(t *testing.T) {
 		if !hasBlockingCheck(definition.Validation.Checks, want) {
 			t.Fatalf("validation checks = %#v, want blocker %q", definition.Validation.Checks, want)
 		}
+	}
+}
+
+func TestValidateBlocksAmbiguousPathParameterBinding(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID:     "tenant-a",
+		SourceID:     "example",
+		Auth:         AuthSpec{Model: "none"},
+		ConfigFields: []Field{{Key: "account_id"}, {Key: "account_ids"}},
+		ResourceFamilies: []ResourceFamily{{
+			ID:      "users",
+			Path:    "/v1/accounts/{account_id}/users",
+			IDField: "id",
+			Read: &ResourceReadSpec{
+				PathParams:      []string{"account_id"},
+				PathParamConfig: map[string]string{"account_id": "account_id"},
+				PathParamFanout: map[string]string{"account_id": "account_ids"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if !hasBlockingCheck(definition.Validation.Checks, "path_param_binding_users_account_id") {
+		t.Fatalf("validation checks = %#v, want ambiguous binding blocker", definition.Validation.Checks)
 	}
 }
 
@@ -916,7 +948,7 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 		SourceID:      "example",
 		DisplayName:   "Example",
 		Categories:    []string{"identity", "identity", "audit"},
-		ConfigFields:  []Field{{Key: "account_ids"}},
+		ConfigFields:  []Field{{Key: "account_ids"}, {Key: "region"}},
 		//nolint:gosec // Test auth descriptor only; no credential value is stored.
 		Auth: AuthSpec{
 			Model:            "oauth_authorization_code",
@@ -942,12 +974,13 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 		},
 		ResourceFamilies: []ResourceFamily{{
 			ID:             "users",
-			Path:           "/v1/accounts/{account_id}/users",
+			Path:           "/v1/regions/{region_id}/accounts/{account_id}/users",
 			RecordSelector: "$.data[*]",
 			Read: &ResourceReadSpec{
 				DetailPath:            "/v1/users/{id}",
 				AllowBareDetailRecord: true,
-				PathParams:            []string{"account_id", "account_id"},
+				PathParams:            []string{"region_id", "account_id", "account_id"},
+				PathParamConfig:       map[string]string{" region_id ": " region ", "": "ignored"},
 				PathParamFanout:       map[string]string{" account_id ": " account_ids ", "": "ignored"},
 				MapRecords:            map[string]string{"": "ignored", "members": "items"},
 			},
@@ -1000,14 +1033,17 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 		t.Fatalf("coverage id = %q, want users_entity_family", got)
 	}
 	family := definition.ResourceFamilies[0]
-	if family.Read == nil || len(family.Read.PathParams) != 1 || family.Read.PathParams[0] != "account_id" {
-		t.Fatalf("read spec = %#v, want deduped account_id path param", family.Read)
+	if family.Read == nil || len(family.Read.PathParams) != 2 || family.Read.PathParams[0] != "region_id" || family.Read.PathParams[1] != "account_id" {
+		t.Fatalf("read spec = %#v, want ordered and deduped path params", family.Read)
 	}
 	if family.Read.MapRecords["members"] != "items" || len(family.Read.MapRecords) != 1 {
 		t.Fatalf("map records = %#v, want members->items", family.Read.MapRecords)
 	}
 	if family.Read.PathParamFanout["account_id"] != "account_ids" || len(family.Read.PathParamFanout) != 1 {
 		t.Fatalf("path param fanout = %#v, want account_id->account_ids", family.Read.PathParamFanout)
+	}
+	if family.Read.PathParamConfig["region_id"] != "region" || len(family.Read.PathParamConfig) != 1 {
+		t.Fatalf("path param config = %#v, want region_id->region", family.Read.PathParamConfig)
 	}
 	if family.Pagination == nil || len(family.Pagination.NextCursorKeys) != 1 || family.Pagination.NextCursorKeys[0] != "next_cursor" || family.Pagination.HasMoreKey != "has_more" {
 		t.Fatalf("pagination = %#v, want next cursor and has_more metadata", family.Pagination)

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -701,6 +701,35 @@ func TestValidateBlocksAmbiguousPathParameterBinding(t *testing.T) {
 	}
 }
 
+func TestValidateBlocksAmbiguousOrUndeclaredRequiredQueryBinding(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID:     "tenant-a",
+		SourceID:     "example",
+		Auth:         AuthSpec{Model: "none"},
+		ConfigFields: []Field{{Key: "scope"}},
+		ResourceFamilies: []ResourceFamily{{
+			ID:          "users",
+			Path:        "/v1/users",
+			IDField:     "id",
+			ConfigQuery: map[string]string{"scope": "scope"},
+			Config: &FamilyConfigSpec{
+				RequiredConfigQuery: map[string]string{"scope": "scope", "tenant": "tenant_id"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	for _, want := range []string{
+		"query_binding_users_scope",
+		"required_config_query_field_users_tenant",
+	} {
+		if !hasBlockingCheck(definition.Validation.Checks, want) {
+			t.Fatalf("validation checks = %#v, want blocker %q", definition.Validation.Checks, want)
+		}
+	}
+}
+
 func TestValidateBlocksUnsafeProjectionRelationships(t *testing.T) {
 	definition, err := Normalize(Definition{
 		TenantID: "tenant-a",
@@ -1000,9 +1029,10 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 				CursorField: "updated_at",
 			},
 			Config: &FamilyConfigSpec{
-				StaticQuery:      map[string]string{"include": "members", "empty": ""},
-				ConfigQuery:      map[string]string{"scope[]": "scopes"},
-				ConfigAttributes: map[string]string{"account_label": "account_label"},
+				StaticQuery:         map[string]string{"include": "members", "empty": ""},
+				ConfigQuery:         map[string]string{"scope[]": "scopes"},
+				RequiredConfigQuery: map[string]string{" region ": " region ", "": "ignored"},
+				ConfigAttributes:    map[string]string{"account_label": "account_label"},
 			},
 			Projection: &ProjectionSpec{
 				Template: "identity_user",
@@ -1044,6 +1074,9 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 	}
 	if family.Read.PathParamConfig["region_id"] != "region" || len(family.Read.PathParamConfig) != 1 {
 		t.Fatalf("path param config = %#v, want region_id->region", family.Read.PathParamConfig)
+	}
+	if family.Config.RequiredConfigQuery["region"] != "region" || len(family.Config.RequiredConfigQuery) != 1 {
+		t.Fatalf("required config query = %#v, want region->region", family.Config.RequiredConfigQuery)
 	}
 	if family.Pagination == nil || len(family.Pagination.NextCursorKeys) != 1 || family.Pagination.NextCursorKeys[0] != "next_cursor" || family.Pagination.HasMoreKey != "has_more" {
 		t.Fatalf("pagination = %#v, want next cursor and has_more metadata", family.Pagination)

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -843,7 +843,10 @@ func familyConfig(resource connectordefinitions.ResourceFamily) familyConfigData
 	}
 	config.BaseURL = strings.TrimSpace(resource.Config.BaseURL)
 	config.StaticQuery = mergeStringMaps(config.StaticQuery, resource.Config.StaticQuery)
-	config.ConfigQuery = mergeStringMaps(config.ConfigQuery, resource.Config.ConfigQuery)
+	config.ConfigQuery = mergeStringMaps(
+		config.ConfigQuery,
+		mergeStringMaps(resource.Config.ConfigQuery, resource.Config.RequiredConfigQuery),
+	)
 	config.ConfigAttributes = cloneStringMap(resource.Config.ConfigAttributes)
 	config.IdentityKeys = append([]string(nil), resource.Config.IdentityKeys...)
 	return config

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -1359,7 +1359,10 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 				ConfigQuery:    map[string]string{"author": "organization"},
 				StaticHeaders:  map[string]string{"Accept": "application/json;version=2"},
 				Config: &connectordefinitions.FamilyConfigSpec{
-					BaseURL:          "https://huggingface.co/api/models",
+					BaseURL: "https://huggingface.co/api/models",
+					RequiredConfigQuery: map[string]string{
+						"required_author": "organization",
+					},
 					ConfigAttributes: map[string]string{"owner": "organization"},
 					IdentityKeys:     []string{"id"},
 				},
@@ -1432,7 +1435,7 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 		`Config: jsonapi.FamilyConfig{`,
 		`BaseURL:          "https://huggingface.co/api/models"`,
 		`StaticQuery:      map[string]string{"full": "true"}`,
-		`ConfigQuery:      map[string]string{"author": "organization"}`,
+		`ConfigQuery:      map[string]string{"author": "organization", "required_author": "organization"}`,
 		`ConfigAttributes: map[string]string{"owner": "organization"}`,
 		`StaticHeaders:    map[string]string{"Accept": "application/json;version=2"}`,
 		`IdentityKeys:     []string{"id"}`,


### PR DESCRIPTION
## Summary

- add explicit scalar path bindings when provider slot names differ from runtime config names
- move scoped Airtable and Anchore collection through the native Rust HTTP runtime
- enforce exact catalog authority totals in the Rust catalog test

## Correctness

Scalar bindings must reference declared config fields and provider-safe path slots. A path slot cannot use both scalar and fanout bindings. Runtime values are encoded as one path segment, injected into observation scope, and rejected when the provider contradicts the request.

## Verification

- adversarial Go and Rust catalog validation tests
- local HTTP collection and graph-mapping tests for Airtable and Anchore
- complete source catalog and runtime Rust suites
- strict Rust clippy
- source generation, catalog fidelity, docs drift, and architecture checks