### PR TITLE
Move required-query source collection into Rust

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -478,8 +478,6 @@ struct FamilyWire {
     #[serde(default)]
     config_query: BTreeMap<String, String>,
     #[serde(default)]
-    required_config_query: BTreeMap<String, String>,
-    #[serde(default)]
     config: Option<FamilyConfigWire>,
     #[serde(default)]
     read: Option<FamilyReadWire>,
@@ -493,6 +491,8 @@ struct FamilyConfigWire {
     base_url: String,
     #[serde(default)]
     config_query: BTreeMap<String, String>,
+    #[serde(default)]
+    required_config_query: BTreeMap<String, String>,
     #[serde(default)]
     config_attributes: BTreeMap<String, String>,
 }
@@ -746,8 +746,12 @@ fn compile_family(
             );
         }
     }
-    if let Some(parameter) = family
-        .required_config_query
+    let required_config_query_wire = family
+        .config
+        .as_ref()
+        .map(|config| config.required_config_query.clone())
+        .unwrap_or_default();
+    if let Some(parameter) = required_config_query_wire
         .keys()
         .find(|parameter| optional_config_query_wire.contains_key(*parameter))
     {
@@ -766,14 +770,14 @@ fn compile_family(
                 .map(|binding| (query_parameter.clone(), binding))
         })
         .collect::<BTreeMap<_, _>>();
-    config_query.extend(family.required_config_query.iter().filter_map(
+    config_query.extend(required_config_query_wire.iter().filter_map(
         |(query_parameter, config_field)| {
             config_binding(config_field, config_fields)
                 .map(|binding| (query_parameter.clone(), binding))
         },
     ));
     let config_query_configured =
-        config_query.len() == optional_config_query_wire.len() + family.required_config_query.len();
+        config_query.len() == optional_config_query_wire.len() + required_config_query_wire.len();
     let config_attributes_wire = family
         .config
         .as_ref()
@@ -791,7 +795,7 @@ fn compile_family(
     let config_attributes_configured = config_attributes.len() == config_attributes_wire.len();
     for (query_parameter, config_field) in optional_config_query_wire
         .iter()
-        .chain(family.required_config_query.iter())
+        .chain(required_config_query_wire.iter())
     {
         if let Some(binding) = config_query.get(query_parameter) {
             config_attributes
@@ -1511,7 +1515,6 @@ mod tests {
             name_field: String::new(),
             static_query: BTreeMap::new(),
             config_query: BTreeMap::new(),
-            required_config_query: BTreeMap::new(),
             config: None,
             read: Some(FamilyReadWire {
                 path_param_config: BTreeMap::from([(
@@ -1558,8 +1561,10 @@ mod tests {
             name_field: String::new(),
             static_query: BTreeMap::new(),
             config_query: BTreeMap::from([("scope".to_owned(), "scope".to_owned())]),
-            required_config_query: BTreeMap::from([("scope".to_owned(), "scope".to_owned())]),
-            config: None,
+            config: Some(FamilyConfigWire {
+                required_config_query: BTreeMap::from([("scope".to_owned(), "scope".to_owned())]),
+                ..Default::default()
+            }),
             read: None,
             pagination: None,
             projection: Some(ProjectionWire {

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -227,6 +227,7 @@ pub struct CompiledFamily {
     id: String,
     method: HttpMethod,
     path: String,
+    base_url: Option<String>,
     record_selector: String,
     id_field: String,
     name_field: Option<String>,
@@ -251,6 +252,10 @@ impl CompiledFamily {
 
     pub fn path(&self) -> &str {
         &self.path
+    }
+
+    pub fn base_url(&self) -> Option<&str> {
+        self.base_url.as_deref()
     }
 
     pub fn record_selector(&self) -> &str {
@@ -473,6 +478,8 @@ struct FamilyWire {
     #[serde(default)]
     config_query: BTreeMap<String, String>,
     #[serde(default)]
+    required_config_query: BTreeMap<String, String>,
+    #[serde(default)]
     config: Option<FamilyConfigWire>,
     #[serde(default)]
     read: Option<FamilyReadWire>,
@@ -482,6 +489,8 @@ struct FamilyWire {
 
 #[derive(Default, Deserialize)]
 struct FamilyConfigWire {
+    #[serde(default)]
+    base_url: String,
     #[serde(default)]
     config_query: BTreeMap<String, String>,
     #[serde(default)]
@@ -718,13 +727,13 @@ fn compile_family(
         })
         .collect::<BTreeMap<_, _>>();
     let path_parameters_configured = path_parameters.len() == path_parameter_names.len();
-    let mut config_query_wire = family
+    let mut optional_config_query_wire = family
         .config
         .as_ref()
         .map(|config| config.config_query.clone())
         .unwrap_or_default();
     for (parameter, field) in &family.config_query {
-        if config_query_wire
+        if optional_config_query_wire
             .insert(parameter.clone(), field.clone())
             .is_some_and(|existing| existing != *field)
         {
@@ -737,14 +746,34 @@ fn compile_family(
             );
         }
     }
-    let config_query = config_query_wire
+    if let Some(parameter) = family
+        .required_config_query
+        .keys()
+        .find(|parameter| optional_config_query_wire.contains_key(*parameter))
+    {
+        return invalid(
+            path,
+            &format!(
+                "family {} query parameter {parameter} has both optional and required config bindings",
+                family.id
+            ),
+        );
+    }
+    let mut config_query = optional_config_query_wire
         .iter()
         .filter_map(|(query_parameter, config_field)| {
             config_query_binding(config_field, config_fields)
                 .map(|binding| (query_parameter.clone(), binding))
         })
         .collect::<BTreeMap<_, _>>();
-    let config_query_configured = config_query.len() == config_query_wire.len();
+    config_query.extend(family.required_config_query.iter().filter_map(
+        |(query_parameter, config_field)| {
+            config_binding(config_field, config_fields)
+                .map(|binding| (query_parameter.clone(), binding))
+        },
+    ));
+    let config_query_configured =
+        config_query.len() == optional_config_query_wire.len() + family.required_config_query.len();
     let config_attributes_wire = family
         .config
         .as_ref()
@@ -760,7 +789,10 @@ fn compile_family(
         })
         .collect::<BTreeMap<_, _>>();
     let config_attributes_configured = config_attributes.len() == config_attributes_wire.len();
-    for (query_parameter, config_field) in &config_query_wire {
+    for (query_parameter, config_field) in optional_config_query_wire
+        .iter()
+        .chain(family.required_config_query.iter())
+    {
         if let Some(binding) = config_query.get(query_parameter) {
             config_attributes
                 .entry(config_field.clone())
@@ -793,27 +825,39 @@ fn compile_family(
     } else {
         "$[*]".to_owned()
     };
-    let provider_contract_verified = canonical_path_template(&family.path).is_some_and(|path| {
-        verified.contains(&(
-            family.id.clone(),
-            match method {
-                HttpMethod::Get => "GET".to_owned(),
-                HttpMethod::Post => "POST".to_owned(),
-            },
-            path,
-        ))
-    });
+    let configured_base_url = family
+        .config
+        .as_ref()
+        .map(|config| config.base_url.trim())
+        .unwrap_or_default();
+    let base_url = (!configured_base_url.is_empty())
+        .then(|| static_https_base_url(configured_base_url))
+        .flatten();
+    let base_url_configured = configured_base_url.is_empty() || base_url.is_some();
+    let provider_contract_verified = provider_request_path(base_url.as_deref(), &family.path)
+        .is_some_and(|path| {
+            verified.contains(&(
+                family.id.clone(),
+                match method {
+                    HttpMethod::Get => "GET".to_owned(),
+                    HttpMethod::Post => "POST".to_owned(),
+                },
+                path,
+            ))
+        });
     Ok(CompiledFamily {
         authoritative: generic_runtime_supported
             && provider_contract_verified
             && path_parameters_configured
             && config_query_configured
-            && config_attributes_configured,
+            && config_attributes_configured
+            && base_url_configured,
         projection_authoritative: provider_contract_verified
             && projection_class.can_be_authoritative(),
         id: nonempty(path, "family id", family.id)?,
         method,
         path: family.path,
+        base_url,
         record_selector,
         id_field: nonempty(path, "family id_field", family.id_field)?,
         name_field: optional(family.name_field),
@@ -967,6 +1011,14 @@ fn verified_families(proof: Option<&ProofManifestWire>) -> BTreeSet<(String, Str
 }
 
 fn canonical_path_template(path: &str) -> Option<String> {
+    let absolute_path;
+    let path = if let Some(rest) = path.strip_prefix("https://") {
+        let (_, provider_path) = rest.split_once('/').unwrap_or((rest, ""));
+        absolute_path = format!("/{provider_path}");
+        absolute_path.as_str()
+    } else {
+        path
+    };
     let (path, query) = path
         .split_once('?')
         .map_or((path, None), |(path, query)| (path, Some(query)));
@@ -995,6 +1047,40 @@ fn canonical_path_template(path: &str) -> Option<String> {
         canonical.push_str(query);
     }
     Some(canonical)
+}
+
+fn static_https_base_url(value: &str) -> Option<String> {
+    let value = value.trim();
+    let rest = value.strip_prefix("https://")?;
+    if rest.is_empty()
+        || rest
+            .chars()
+            .any(|character| matches!(character, '{' | '}' | '?' | '#' | '\\'))
+        || rest.split('/').next().is_some_and(|authority| {
+            authority.is_empty()
+                || authority.contains('@')
+                || authority.chars().any(char::is_whitespace)
+        })
+    {
+        return None;
+    }
+    Some(format!("{}/", value.trim_end_matches('/')))
+}
+
+fn provider_request_path(base_url: Option<&str>, family_path: &str) -> Option<String> {
+    let Some(base_url) = base_url else {
+        return canonical_path_template(family_path);
+    };
+    let rest = base_url.strip_prefix("https://")?;
+    let (_, base_path) = rest.split_once('/').unwrap_or((rest, ""));
+    let base_path = base_path.trim_matches('/');
+    let family_path = family_path.trim_start_matches('/');
+    let path = if base_path.is_empty() {
+        format!("/{family_path}")
+    } else {
+        format!("/{base_path}/{family_path}")
+    };
+    canonical_path_template(&path)
 }
 
 fn path_parameter(segment: &str) -> Option<&str> {
@@ -1185,9 +1271,9 @@ mod tests {
             summary.sources,
             summary.authoritative_sources + summary.shadow_only_sources
         );
-        assert_eq!(summary.authoritative_sources, 48);
-        assert_eq!(summary.authoritative_families, 333);
-        assert_eq!(summary.shadow_only_sources, 746);
+        assert_eq!(summary.authoritative_sources, 49);
+        assert_eq!(summary.authoritative_families, 337);
+        assert_eq!(summary.shadow_only_sources, 745);
     }
 
     #[test]
@@ -1226,6 +1312,7 @@ mod tests {
             "jira",
             "onelogin",
             "qdrant_cloud",
+            "slack",
             "snyk",
         ] {
             assert_eq!(
@@ -1264,22 +1351,37 @@ mod tests {
     }
 
     #[test]
-    fn undeclared_query_scope_cannot_become_collection_authority() {
+    fn required_query_scope_is_declared_and_fail_closed() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
             root.join("internal/connectorcatalog/catalog"),
             root.join("sources"),
         )
         .unwrap();
-        let family = catalog
-            .get("slack")
-            .unwrap()
+        let source = catalog.get("slack").unwrap();
+        let shadow_families = source
+            .families()
+            .iter()
+            .filter(|family| !family.is_authoritative())
+            .map(CompiledFamily::id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            source.authority(),
+            CollectionAuthority::Authoritative,
+            "shadow families: {shadow_families:?}"
+        );
+        let family = source
             .families()
             .iter()
             .find(|family| family.id() == "channel_member")
             .unwrap();
-        assert!(!family.is_authoritative());
-        assert!(family.config_query().is_empty());
+        assert!(family.is_authoritative());
+        assert_eq!(
+            family.config_query().get("channel"),
+            Some(&PathParameterBinding::ScalarConfig {
+                field: "channel_id".to_owned()
+            })
+        );
     }
 
     #[test]
@@ -1409,6 +1511,7 @@ mod tests {
             name_field: String::new(),
             static_query: BTreeMap::new(),
             config_query: BTreeMap::new(),
+            required_config_query: BTreeMap::new(),
             config: None,
             read: Some(FamilyReadWire {
                 path_param_config: BTreeMap::from([(
@@ -1441,5 +1544,63 @@ mod tests {
                 .to_string()
                 .contains("has both scalar config and fanout bindings")
         );
+    }
+
+    #[test]
+    fn optional_and_required_query_bindings_cannot_claim_the_same_parameter() {
+        let family = FamilyWire {
+            id: "members".to_owned(),
+            method: "GET".to_owned(),
+            path: "/v1/members".to_owned(),
+            record_selector: "$.items[*]".to_owned(),
+            list_key: String::new(),
+            id_field: "id".to_owned(),
+            name_field: String::new(),
+            static_query: BTreeMap::new(),
+            config_query: BTreeMap::from([("scope".to_owned(), "scope".to_owned())]),
+            required_config_query: BTreeMap::from([("scope".to_owned(), "scope".to_owned())]),
+            config: None,
+            read: None,
+            pagination: None,
+            projection: Some(ProjectionWire {
+                template: "identity_user".to_owned(),
+                fields: BTreeMap::from([("user_id".to_owned(), "id".to_owned())]),
+                static_fields: BTreeMap::new(),
+            }),
+        };
+        let config_fields = BTreeSet::from(["scope"]);
+        let error = compile_family(
+            Path::new("conflicting.yaml"),
+            family,
+            &BTreeSet::new(),
+            true,
+            &config_fields,
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("has both optional and required config bindings")
+        );
+    }
+
+    #[test]
+    fn static_family_base_urls_are_https_and_path_preserving() {
+        assert_eq!(
+            static_https_base_url("https://api.example.test/audit/v1"),
+            Some("https://api.example.test/audit/v1/".to_owned())
+        );
+        assert_eq!(
+            provider_request_path(Some("https://api.example.test/audit/v1/"), "/events"),
+            Some("/audit/v1/events".to_owned())
+        );
+        for invalid in [
+            "http://api.example.test",
+            "https://${config.host}",
+            "https://user@api.example.test",
+            "https://api.example.test/path?scope=all",
+        ] {
+            assert_eq!(static_https_base_url(invalid), None, "{invalid}");
+        }
     }
 }

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -184,6 +184,7 @@ impl HttpSourceConnector {
                 ))
             })?;
         validate_auth(source.auth(), &auth)?;
+        let base_url = family.base_url().unwrap_or(base_url);
         let mut base_url = Url::parse(base_url)
             .map_err(|error| HttpConnectorError::InvalidUrl(error.to_string()))?;
         if base_url.scheme() != "https" && !is_loopback(&base_url) {
@@ -486,8 +487,10 @@ impl SourceConnector for HttpSourceConnector {
                 let selected_count = selected.len();
                 for value in selected {
                     validate_record_scope(self.family.id(), &value, &record_attributes)?;
-                    let provider_id =
-                        scalar_at(&value, self.family.id_field()).ok_or_else(|| {
+                    let scalar_record = scalar(&value);
+                    let provider_id = scalar_at(&value, self.family.id_field())
+                        .or_else(|| scalar_record.clone())
+                        .ok_or_else(|| {
                             HttpConnectorError::InvalidResponse(format!(
                                 "family {} record is missing {}",
                                 self.family.id(),
@@ -495,6 +498,9 @@ impl SourceConnector for HttpSourceConnector {
                             ))
                         })?;
                     let mut fields = flatten_scalars(&value);
+                    if let Some(value) = scalar_record {
+                        fields.insert(self.family.id_field().to_owned(), value);
+                    }
                     fields.extend(record_attributes.clone());
                     records.push(SourceRecord {
                         observation_id: observation_id(
@@ -2005,6 +2011,105 @@ mod tests {
             .map(&batch)
             .unwrap();
         assert_eq!(delta.entities().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn required_query_scope_executes_scalar_slack_memberships() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /conversations.members?"));
+            assert!(request.contains("channel=C1"));
+            assert!(request.contains("authorization: Bearer token"));
+            let body = r#"{"members":["U1","U2"],"response_metadata":{"next_cursor":""}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("slack").unwrap().clone();
+        let mut connector = HttpSourceConnector::new(
+            source.clone(),
+            "channel_member",
+            &format!("http://{address}"),
+            BTreeMap::from([("channel_id".to_owned(), "C1".to_owned())]),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("slack-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 2);
+        assert_eq!(batch.records[0].provider_id, "U1");
+        assert_eq!(batch.records[0].fields["user_id"], "U1");
+        assert_eq!(batch.records[0].fields["channel_id"], "C1");
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.entities().len(), 3);
+        assert_eq!(delta.assertions().len(), 2);
+    }
+
+    #[test]
+    fn required_query_scope_rejects_missing_config_and_honors_family_base_url() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("slack").unwrap().clone();
+        let connector = HttpSourceConnector::new(
+            source.clone(),
+            "channel_member",
+            "https://slack.com/api",
+            BTreeMap::new(),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let error = connector.request_scopes().err().unwrap();
+        assert_eq!(error.to_string(), "request config channel_id is required");
+
+        let audit = HttpSourceConnector::new(
+            source,
+            "audit_log",
+            "https://slack.com/api",
+            BTreeMap::new(),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        let scopes = audit.request_scopes().unwrap();
+        assert_eq!(
+            scopes[0].url.as_str(),
+            "https://api.slack.com/audit/v1/logs"
+        );
     }
 
     #[test]

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -405,9 +405,11 @@ impl CatalogGraphMapper {
         builder: &mut GraphDeltaBuilder<Mode>,
     ) -> Result<(), CatalogMapperError> {
         let group_id =
-            first(&projected, &["group_id"]).ok_or_else(|| CatalogMapperError::MissingField {
-                family: family.id().to_owned(),
-                field: "group_id".to_owned(),
+            first(&projected, &["group_id", "channel_id", "usergroup_id"]).ok_or_else(|| {
+                CatalogMapperError::MissingField {
+                    family: family.id().to_owned(),
+                    field: "group_id".to_owned(),
+                }
             })?;
         let member_id = first(
             &projected,
@@ -437,7 +439,11 @@ impl CatalogGraphMapper {
             projected
                 .iter()
                 .filter(|(key, _)| {
-                    !key.starts_with("group_") && key.as_str() != "role" && key.as_str() != "id"
+                    !key.starts_with("group_")
+                        && key.as_str() != "role"
+                        && key.as_str() != "id"
+                        && key.as_str() != "channel_id"
+                        && key.as_str() != "usergroup_id"
                 })
                 .map(|(key, value)| (key.clone(), value.clone()))
                 .collect(),
@@ -446,7 +452,9 @@ impl CatalogGraphMapper {
             group,
             projected
                 .into_iter()
-                .filter(|(key, _)| !key.starts_with("member_") && key != "role" && key != "id")
+                .filter(|(key, _)| {
+                    !key.starts_with("member_") && key != "role" && key != "id" && key != "user_id"
+                })
                 .collect(),
         )?;
         let assertion = RelationshipAssertion::new(

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 48 sources and 333 families are authoritative; the other 746 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 49 sources and 337 families are authoritative; the other 745 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/collaboration-productivity/slack.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/slack.yaml
@@ -32,6 +32,15 @@ entries:
         - help: Slack Audit Logs API host. Keep the default unless using a test endpoint.
           key: audit_log_base_url
           label: Audit Logs API host
+        - help: Optional Unix timestamp upper bound for team access log entries.
+          key: before
+          label: Access logs before
+        - help: Channel identifier required when collecting channel memberships.
+          key: channel_id
+          label: Channel ID
+        - help: User group identifier required when collecting user group memberships.
+          key: usergroup_id
+          label: User group ID
       description: Collects Slack workspaces, users, channels, user groups, memberships, team access logs, and Enterprise Grid audit logs and projects them into the Cerebro graph for inventory, access review, membership review, login review, and collaboration audit context.
       display_name: Slack
       id: builtin_catalog-slack
@@ -230,7 +239,7 @@ entries:
             required_payload_fields: [channel_id, user_id]
             schema_ref: slack/channel_member/v1
             urn_kind: slack_channel_member
-          config_query:
+          required_config_query:
             channel: channel_id
           id: channel_member
           id_field: user_id
@@ -268,7 +277,7 @@ entries:
             required_payload_fields: [usergroup_id, user_id]
             schema_ref: slack/user_group_member/v1
             urn_kind: slack_user_group_member
-          config_query:
+          required_config_query:
             usergroup: usergroup_id
           id: user_group_member
           id_field: user_id

--- a/internal/connectorcatalog/catalog/collaboration-productivity/slack.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/slack.yaml
@@ -239,8 +239,9 @@ entries:
             required_payload_fields: [channel_id, user_id]
             schema_ref: slack/channel_member/v1
             urn_kind: slack_channel_member
-          required_config_query:
-            channel: channel_id
+          config:
+            required_config_query:
+              channel: channel_id
           id: channel_member
           id_field: user_id
           label: Channel members
@@ -277,8 +278,9 @@ entries:
             required_payload_fields: [usergroup_id, user_id]
             schema_ref: slack/user_group_member/v1
             urn_kind: slack_user_group_member
-          required_config_query:
-            usergroup: usergroup_id
+          config:
+            required_config_query:
+              usergroup: usergroup_id
           id: user_group_member
           id_field: user_id
           label: User group members

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -618,15 +618,15 @@ func TestBuiltinSlackMembershipFamiliesCarryContainerContext(t *testing.T) {
 		t.Fatal("BuiltinEntry(slack) ok = false, want true")
 	}
 	channelMember := catalogFamily(t, entry.Definition.ResourceFamilies, "channel_member")
-	if channelMember.ConfigQuery["channel"] != "channel_id" {
-		t.Fatalf("channel_member config_query = %#v, want channel from channel_id", channelMember.ConfigQuery)
+	if channelMember.Config == nil || channelMember.Config.RequiredConfigQuery["channel"] != "channel_id" {
+		t.Fatalf("channel_member config = %#v, want required channel from channel_id", channelMember.Config)
 	}
 	if channelMember.Read == nil || len(channelMember.Read.PathParams) != 1 || channelMember.Read.PathParams[0] != "channel_id" {
 		t.Fatalf("channel_member read = %#v, want channel_id path param", channelMember.Read)
 	}
 	userGroupMember := catalogFamily(t, entry.Definition.ResourceFamilies, "user_group_member")
-	if userGroupMember.ConfigQuery["usergroup"] != "usergroup_id" {
-		t.Fatalf("user_group_member config_query = %#v, want usergroup from usergroup_id", userGroupMember.ConfigQuery)
+	if userGroupMember.Config == nil || userGroupMember.Config.RequiredConfigQuery["usergroup"] != "usergroup_id" {
+		t.Fatalf("user_group_member config = %#v, want required usergroup from usergroup_id", userGroupMember.Config)
 	}
 	if userGroupMember.Read == nil || len(userGroupMember.Read.PathParams) != 1 || userGroupMember.Read.PathParams[0] != "usergroup_id" {
 		t.Fatalf("user_group_member read = %#v, want usergroup_id path param", userGroupMember.Read)

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -329,7 +329,6 @@ type ResourceFamily struct {
 	StaticQuery           map[string]string       `json:"static_query,omitempty"`
 	StaticHeaders         map[string]string       `json:"static_headers,omitempty"`
 	ConfigQuery           map[string]string       `json:"config_query,omitempty"`
-	RequiredConfigQuery   map[string]string       `json:"required_config_query,omitempty"`
 	Pagination            *PaginationSpec         `json:"pagination,omitempty"`
 	Incremental           *IncrementalSpec        `json:"incremental,omitempty"`
 	Config                *FamilyConfigSpec       `json:"config,omitempty"`
@@ -354,15 +353,16 @@ type ResourceReadSpec struct {
 
 // FamilyConfigSpec binds static and runtime config values into a resource-family request.
 type FamilyConfigSpec struct {
-	BaseURL          string            `json:"base_url,omitempty"`
-	AuthModel        string            `json:"auth_model,omitempty"`
-	StaticQuery      map[string]string `json:"static_query,omitempty"`
-	ConfigQuery      map[string]string `json:"config_query,omitempty"`
-	ConfigAttributes map[string]string `json:"config_attributes,omitempty"`
-	IDTemplate       string            `json:"id_template,omitempty"`
-	EncodeURNID      bool              `json:"encode_urn_id,omitempty"`
-	ResourceURNKind  string            `json:"resource_urn_kind,omitempty"`
-	IdentityKeys     []string          `json:"identity_keys,omitempty"`
+	BaseURL             string            `json:"base_url,omitempty"`
+	AuthModel           string            `json:"auth_model,omitempty"`
+	StaticQuery         map[string]string `json:"static_query,omitempty"`
+	ConfigQuery         map[string]string `json:"config_query,omitempty"`
+	RequiredConfigQuery map[string]string `json:"required_config_query,omitempty"`
+	ConfigAttributes    map[string]string `json:"config_attributes,omitempty"`
+	IDTemplate          string            `json:"id_template,omitempty"`
+	EncodeURNID         bool              `json:"encode_urn_id,omitempty"`
+	ResourceURNKind     string            `json:"resource_urn_kind,omitempty"`
+	IdentityKeys        []string          `json:"identity_keys,omitempty"`
 }
 
 // ScopeOption exposes a resource family as a selectable scope option in the UI.
@@ -928,25 +928,22 @@ func validateFamilyIntegrationFields(family ResourceFamily, configFields map[str
 	if family.Config != nil {
 		validateFamilyConfigMap(family.ID, "static_query", family.Config.StaticQuery, add)
 		validateFamilyConfigMap(family.ID, "config_query", family.Config.ConfigQuery, add)
+		validateFamilyConfigMap(family.ID, "required_config_query", family.Config.RequiredConfigQuery, add)
 		validateFamilyConfigMap(family.ID, "config_attributes", family.Config.ConfigAttributes, add)
 		for _, key := range family.Config.IdentityKeys {
 			if strings.TrimSpace(key) == "" {
 				add(blocking("identity_keys_"+family.ID, "Identity keys", "Identity keys must not contain empty values."))
 			}
 		}
-	}
-	validateFamilyConfigMap(family.ID, "required_config_query", family.RequiredConfigQuery, add)
-	for queryParam, configField := range family.RequiredConfigQuery {
-		if _, ok := configFields[configField]; !ok {
-			add(blocking("required_config_query_field_"+family.ID+"_"+normalizeDefinitionID(queryParam), "Required query config", "Required query bindings must reference fields declared in definition.config_fields."))
-		}
-		_, topLevelOptional := family.ConfigQuery[queryParam]
-		nestedOptional := false
-		if family.Config != nil {
-			_, nestedOptional = family.Config.ConfigQuery[queryParam]
-		}
-		if topLevelOptional || nestedOptional {
-			add(blocking("query_binding_"+family.ID+"_"+normalizeDefinitionID(queryParam), "Query binding", "A query parameter cannot use both optional and required config bindings."))
+		for queryParam, configField := range family.Config.RequiredConfigQuery {
+			if _, ok := configFields[configField]; !ok {
+				add(blocking("required_config_query_field_"+family.ID+"_"+normalizeDefinitionID(queryParam), "Required query config", "Required query bindings must reference fields declared in definition.config_fields."))
+			}
+			_, topLevelOptional := family.ConfigQuery[queryParam]
+			_, nestedOptional := family.Config.ConfigQuery[queryParam]
+			if topLevelOptional || nestedOptional {
+				add(blocking("query_binding_"+family.ID+"_"+normalizeDefinitionID(queryParam), "Query binding", "A query parameter cannot use both optional and required config bindings."))
+			}
 		}
 	}
 	validateFamilyConfigMap(family.ID, "static_headers", family.StaticHeaders, add)
@@ -1238,7 +1235,6 @@ func normalizeResourceFamilies(families []ResourceFamily) []ResourceFamily {
 		family.StaticQuery = normalizeStringMap(family.StaticQuery)
 		family.StaticHeaders = normalizeStringMap(family.StaticHeaders)
 		family.ConfigQuery = normalizeStringMap(family.ConfigQuery)
-		family.RequiredConfigQuery = normalizeStringMap(family.RequiredConfigQuery)
 		family.Pagination = normalizePaginationSpec(family.Pagination)
 		family.Incremental = normalizeIncrementalSpec(family.Incremental)
 		family.Config = normalizeFamilyConfigSpec(family.Config)
@@ -1405,11 +1401,12 @@ func normalizeFamilyConfigSpec(config *FamilyConfigSpec) *FamilyConfigSpec {
 	next.AuthModel = strings.TrimSpace(next.AuthModel)
 	next.StaticQuery = normalizeStringMap(next.StaticQuery)
 	next.ConfigQuery = normalizeStringMap(next.ConfigQuery)
+	next.RequiredConfigQuery = normalizeStringMap(next.RequiredConfigQuery)
 	next.ConfigAttributes = normalizeStringMap(next.ConfigAttributes)
 	next.IDTemplate = strings.TrimSpace(next.IDTemplate)
 	next.ResourceURNKind = strings.TrimSpace(next.ResourceURNKind)
 	next.IdentityKeys = normalizeStringList(next.IdentityKeys)
-	if next.BaseURL == "" && next.AuthModel == "" && len(next.StaticQuery) == 0 && len(next.ConfigQuery) == 0 && len(next.ConfigAttributes) == 0 && next.IDTemplate == "" && !next.EncodeURNID && next.ResourceURNKind == "" && len(next.IdentityKeys) == 0 {
+	if next.BaseURL == "" && next.AuthModel == "" && len(next.StaticQuery) == 0 && len(next.ConfigQuery) == 0 && len(next.RequiredConfigQuery) == 0 && len(next.ConfigAttributes) == 0 && next.IDTemplate == "" && !next.EncodeURNID && next.ResourceURNKind == "" && len(next.IdentityKeys) == 0 {
 		return nil
 	}
 	return &next

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -329,6 +329,7 @@ type ResourceFamily struct {
 	StaticQuery           map[string]string       `json:"static_query,omitempty"`
 	StaticHeaders         map[string]string       `json:"static_headers,omitempty"`
 	ConfigQuery           map[string]string       `json:"config_query,omitempty"`
+	RequiredConfigQuery   map[string]string       `json:"required_config_query,omitempty"`
 	Pagination            *PaginationSpec         `json:"pagination,omitempty"`
 	Incremental           *IncrementalSpec        `json:"incremental,omitempty"`
 	Config                *FamilyConfigSpec       `json:"config,omitempty"`
@@ -934,6 +935,20 @@ func validateFamilyIntegrationFields(family ResourceFamily, configFields map[str
 			}
 		}
 	}
+	validateFamilyConfigMap(family.ID, "required_config_query", family.RequiredConfigQuery, add)
+	for queryParam, configField := range family.RequiredConfigQuery {
+		if _, ok := configFields[configField]; !ok {
+			add(blocking("required_config_query_field_"+family.ID+"_"+normalizeDefinitionID(queryParam), "Required query config", "Required query bindings must reference fields declared in definition.config_fields."))
+		}
+		_, topLevelOptional := family.ConfigQuery[queryParam]
+		nestedOptional := false
+		if family.Config != nil {
+			_, nestedOptional = family.Config.ConfigQuery[queryParam]
+		}
+		if topLevelOptional || nestedOptional {
+			add(blocking("query_binding_"+family.ID+"_"+normalizeDefinitionID(queryParam), "Query binding", "A query parameter cannot use both optional and required config bindings."))
+		}
+	}
 	validateFamilyConfigMap(family.ID, "static_headers", family.StaticHeaders, add)
 	if family.Pagination != nil {
 		if _, ok := paginationTypes[family.Pagination.Type]; !ok {
@@ -1223,6 +1238,7 @@ func normalizeResourceFamilies(families []ResourceFamily) []ResourceFamily {
 		family.StaticQuery = normalizeStringMap(family.StaticQuery)
 		family.StaticHeaders = normalizeStringMap(family.StaticHeaders)
 		family.ConfigQuery = normalizeStringMap(family.ConfigQuery)
+		family.RequiredConfigQuery = normalizeStringMap(family.RequiredConfigQuery)
 		family.Pagination = normalizePaginationSpec(family.Pagination)
 		family.Incremental = normalizeIncrementalSpec(family.Incremental)
 		family.Config = normalizeFamilyConfigSpec(family.Config)

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -701,6 +701,33 @@ func TestValidateBlocksAmbiguousPathParameterBinding(t *testing.T) {
 	}
 }
 
+func TestValidateBlocksAmbiguousOrUndeclaredRequiredQueryBinding(t *testing.T) {
+	definition, err := Normalize(Definition{
+		TenantID:     "tenant-a",
+		SourceID:     "example",
+		Auth:         AuthSpec{Model: "none"},
+		ConfigFields: []Field{{Key: "scope"}},
+		ResourceFamilies: []ResourceFamily{{
+			ID:                  "users",
+			Path:                "/v1/users",
+			IDField:             "id",
+			ConfigQuery:         map[string]string{"scope": "scope"},
+			RequiredConfigQuery: map[string]string{"scope": "scope", "tenant": "tenant_id"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	for _, want := range []string{
+		"query_binding_users_scope",
+		"required_config_query_field_users_tenant",
+	} {
+		if !hasBlockingCheck(definition.Validation.Checks, want) {
+			t.Fatalf("validation checks = %#v, want blocker %q", definition.Validation.Checks, want)
+		}
+	}
+}
+
 func TestValidateBlocksUnsafeProjectionRelationships(t *testing.T) {
 	definition, err := Normalize(Definition{
 		TenantID: "tenant-a",
@@ -999,6 +1026,7 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 			Incremental: &IncrementalSpec{
 				CursorField: "updated_at",
 			},
+			RequiredConfigQuery: map[string]string{" region ": " region ", "": "ignored"},
 			Config: &FamilyConfigSpec{
 				StaticQuery:      map[string]string{"include": "members", "empty": ""},
 				ConfigQuery:      map[string]string{"scope[]": "scopes"},
@@ -1044,6 +1072,9 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 	}
 	if family.Read.PathParamConfig["region_id"] != "region" || len(family.Read.PathParamConfig) != 1 {
 		t.Fatalf("path param config = %#v, want region_id->region", family.Read.PathParamConfig)
+	}
+	if family.RequiredConfigQuery["region"] != "region" || len(family.RequiredConfigQuery) != 1 {
+		t.Fatalf("required config query = %#v, want region->region", family.RequiredConfigQuery)
 	}
 	if family.Pagination == nil || len(family.Pagination.NextCursorKeys) != 1 || family.Pagination.NextCursorKeys[0] != "next_cursor" || family.Pagination.HasMoreKey != "has_more" {
 		t.Fatalf("pagination = %#v, want next cursor and has_more metadata", family.Pagination)

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -708,11 +708,13 @@ func TestValidateBlocksAmbiguousOrUndeclaredRequiredQueryBinding(t *testing.T) {
 		Auth:         AuthSpec{Model: "none"},
 		ConfigFields: []Field{{Key: "scope"}},
 		ResourceFamilies: []ResourceFamily{{
-			ID:                  "users",
-			Path:                "/v1/users",
-			IDField:             "id",
-			ConfigQuery:         map[string]string{"scope": "scope"},
-			RequiredConfigQuery: map[string]string{"scope": "scope", "tenant": "tenant_id"},
+			ID:          "users",
+			Path:        "/v1/users",
+			IDField:     "id",
+			ConfigQuery: map[string]string{"scope": "scope"},
+			Config: &FamilyConfigSpec{
+				RequiredConfigQuery: map[string]string{"scope": "scope", "tenant": "tenant_id"},
+			},
 		}},
 	})
 	if err != nil {
@@ -1026,11 +1028,11 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 			Incremental: &IncrementalSpec{
 				CursorField: "updated_at",
 			},
-			RequiredConfigQuery: map[string]string{" region ": " region ", "": "ignored"},
 			Config: &FamilyConfigSpec{
-				StaticQuery:      map[string]string{"include": "members", "empty": ""},
-				ConfigQuery:      map[string]string{"scope[]": "scopes"},
-				ConfigAttributes: map[string]string{"account_label": "account_label"},
+				StaticQuery:         map[string]string{"include": "members", "empty": ""},
+				ConfigQuery:         map[string]string{"scope[]": "scopes"},
+				RequiredConfigQuery: map[string]string{" region ": " region ", "": "ignored"},
+				ConfigAttributes:    map[string]string{"account_label": "account_label"},
 			},
 			Projection: &ProjectionSpec{
 				Template: "identity_user",
@@ -1073,8 +1075,8 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 	if family.Read.PathParamConfig["region_id"] != "region" || len(family.Read.PathParamConfig) != 1 {
 		t.Fatalf("path param config = %#v, want region_id->region", family.Read.PathParamConfig)
 	}
-	if family.RequiredConfigQuery["region"] != "region" || len(family.RequiredConfigQuery) != 1 {
-		t.Fatalf("required config query = %#v, want region->region", family.RequiredConfigQuery)
+	if family.Config.RequiredConfigQuery["region"] != "region" || len(family.Config.RequiredConfigQuery) != 1 {
+		t.Fatalf("required config query = %#v, want region->region", family.Config.RequiredConfigQuery)
 	}
 	if family.Pagination == nil || len(family.Pagination.NextCursorKeys) != 1 || family.Pagination.NextCursorKeys[0] != "next_cursor" || family.Pagination.HasMoreKey != "has_more" {
 		t.Fatalf("pagination = %#v, want next cursor and has_more metadata", family.Pagination)

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -829,7 +829,7 @@ func pathParamsForResource(resource connectordefinitions.ResourceFamily) []strin
 func familyConfig(resource connectordefinitions.ResourceFamily) familyConfigData {
 	config := familyConfigData{
 		StaticQuery:   cloneStringMap(resource.StaticQuery),
-		ConfigQuery:   mergeStringMaps(resource.ConfigQuery, resource.RequiredConfigQuery),
+		ConfigQuery:   cloneStringMap(resource.ConfigQuery),
 		StaticHeaders: cloneStringMap(resource.StaticHeaders),
 	}
 	if resource.Read != nil {
@@ -843,7 +843,10 @@ func familyConfig(resource connectordefinitions.ResourceFamily) familyConfigData
 	}
 	config.BaseURL = strings.TrimSpace(resource.Config.BaseURL)
 	config.StaticQuery = mergeStringMaps(config.StaticQuery, resource.Config.StaticQuery)
-	config.ConfigQuery = mergeStringMaps(config.ConfigQuery, resource.Config.ConfigQuery)
+	config.ConfigQuery = mergeStringMaps(
+		config.ConfigQuery,
+		mergeStringMaps(resource.Config.ConfigQuery, resource.Config.RequiredConfigQuery),
+	)
 	config.ConfigAttributes = cloneStringMap(resource.Config.ConfigAttributes)
 	config.IdentityKeys = append([]string(nil), resource.Config.IdentityKeys...)
 	return config

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -829,7 +829,7 @@ func pathParamsForResource(resource connectordefinitions.ResourceFamily) []strin
 func familyConfig(resource connectordefinitions.ResourceFamily) familyConfigData {
 	config := familyConfigData{
 		StaticQuery:   cloneStringMap(resource.StaticQuery),
-		ConfigQuery:   cloneStringMap(resource.ConfigQuery),
+		ConfigQuery:   mergeStringMaps(resource.ConfigQuery, resource.RequiredConfigQuery),
 		StaticHeaders: cloneStringMap(resource.StaticHeaders),
 	}
 	if resource.Read != nil {

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -1357,7 +1357,10 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 				IDField:        "id",
 				StaticQuery:    map[string]string{"full": "true"},
 				ConfigQuery:    map[string]string{"author": "organization"},
-				StaticHeaders:  map[string]string{"Accept": "application/json;version=2"},
+				RequiredConfigQuery: map[string]string{
+					"required_author": "organization",
+				},
+				StaticHeaders: map[string]string{"Accept": "application/json;version=2"},
 				Config: &connectordefinitions.FamilyConfigSpec{
 					BaseURL:          "https://huggingface.co/api/models",
 					ConfigAttributes: map[string]string{"owner": "organization"},
@@ -1432,7 +1435,7 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 		`Config: jsonapi.FamilyConfig{`,
 		`BaseURL:          "https://huggingface.co/api/models"`,
 		`StaticQuery:      map[string]string{"full": "true"}`,
-		`ConfigQuery:      map[string]string{"author": "organization"}`,
+		`ConfigQuery:      map[string]string{"author": "organization", "required_author": "organization"}`,
 		`ConfigAttributes: map[string]string{"owner": "organization"}`,
 		`StaticHeaders:    map[string]string{"Accept": "application/json;version=2"}`,
 		`IdentityKeys:     []string{"id"}`,

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -1357,12 +1357,12 @@ func TestGenerateDefinitionSupportsFamilyQueryBindings(t *testing.T) {
 				IDField:        "id",
 				StaticQuery:    map[string]string{"full": "true"},
 				ConfigQuery:    map[string]string{"author": "organization"},
-				RequiredConfigQuery: map[string]string{
-					"required_author": "organization",
-				},
-				StaticHeaders: map[string]string{"Accept": "application/json;version=2"},
+				StaticHeaders:  map[string]string{"Accept": "application/json;version=2"},
 				Config: &connectordefinitions.FamilyConfigSpec{
-					BaseURL:          "https://huggingface.co/api/models",
+					BaseURL: "https://huggingface.co/api/models",
+					RequiredConfigQuery: map[string]string{
+						"required_author": "organization",
+					},
 					ConfigAttributes: map[string]string{"owner": "organization"},
 					IdentityKeys:     []string{"id"},
 				},


### PR DESCRIPTION
## Summary

- distinguish required provider query scope from optional filter configuration
- normalize scalar-array provider responses into typed source records
- honor verified static family API hosts in the Rust collector
- move Slack membership and audit collection through native Rust execution

## Correctness

Missing required scope fails before any provider request. Optional and required bindings cannot claim the same query parameter. Static family hosts require HTTPS and preserve the provider path used by proof matching. Membership mapping excludes relationship-specific identifiers from shared identity and group properties.

## Verification

- Go catalog validation and source-generation tests
- Rust compiler conflict and HTTPS-host tests
- local authenticated Slack membership collection through graph mapping
- missing-config and family-host adversarial tests
- complete source catalog and runtime Rust suites
- strict Rust clippy and catalog drift gates