### PR TITLE
Add explicit Rust source fanout bindings

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -474,6 +474,8 @@ struct FamilyWire {
     config_query: BTreeMap<String, String>,
     #[serde(default)]
     config: Option<FamilyConfigWire>,
+    #[serde(default)]
+    read: Option<FamilyReadWire>,
     pagination: Option<PaginationWire>,
     projection: Option<ProjectionWire>,
 }
@@ -484,6 +486,12 @@ struct FamilyConfigWire {
     config_query: BTreeMap<String, String>,
     #[serde(default)]
     config_attributes: BTreeMap<String, String>,
+}
+
+#[derive(Default, Deserialize)]
+struct FamilyReadWire {
+    #[serde(default)]
+    path_param_fanout: BTreeMap<String, String>,
 }
 
 #[derive(Deserialize)]
@@ -638,11 +646,37 @@ fn compile_family(
         .split('/')
         .filter_map(path_parameter)
         .collect::<BTreeSet<_>>();
+    let explicit_path_fanout = family
+        .read
+        .as_ref()
+        .map(|read| &read.path_param_fanout)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(parameter) = explicit_path_fanout
+        .keys()
+        .find(|parameter| !path_parameter_names.contains(parameter.as_str()))
+    {
+        return invalid(
+            path,
+            &format!(
+                "family {} fanout binding references unknown path parameter {parameter}",
+                family.id
+            ),
+        );
+    }
     let path_parameters = path_parameter_names
         .iter()
         .filter_map(|parameter| {
-            config_binding(parameter, config_fields)
-                .map(|binding| ((*parameter).to_owned(), binding))
+            let binding = if let Some(field) = explicit_path_fanout.get(*parameter) {
+                config_fields
+                    .contains(field.as_str())
+                    .then(|| PathParameterBinding::CsvFanout {
+                        field: field.clone(),
+                    })
+            } else {
+                config_binding(parameter, config_fields)
+            };
+            binding.map(|binding| ((*parameter).to_owned(), binding))
         })
         .collect::<BTreeMap<_, _>>();
     let path_parameters_configured = path_parameters.len() == path_parameter_names.len();
@@ -682,7 +716,9 @@ fn compile_family(
     let mut config_attributes = config_attributes_wire
         .iter()
         .filter_map(|(attribute, config_field)| {
-            config_binding(config_field, config_fields).map(|binding| (attribute.clone(), binding))
+            config_binding(config_field, config_fields)
+                .or_else(|| path_parameters.get(config_field).cloned())
+                .map(|binding| (attribute.clone(), binding))
         })
         .collect::<BTreeMap<_, _>>();
     let config_attributes_configured = config_attributes.len() == config_attributes_wire.len();
@@ -1142,6 +1178,7 @@ mod tests {
             "box",
             "cloudflare_workers_ai",
             "elevenlabs",
+            "fivetran",
             "google_vertex_ai",
             "jira",
             "onelogin",
@@ -1154,7 +1191,7 @@ mod tests {
                 "{source_id} has verified parameterized provider paths"
             );
         }
-        for source_id in ["airtable", "anchore", "fivetran"] {
+        for source_id in ["airtable", "anchore"] {
             assert_eq!(
                 catalog.get(source_id).unwrap().authority(),
                 CollectionAuthority::ShadowOnly,
@@ -1207,6 +1244,33 @@ mod tests {
             .unwrap();
         assert!(!family.is_authoritative());
         assert!(family.config_query().is_empty());
+    }
+
+    #[test]
+    fn explicit_fanout_binding_maps_a_provider_slot_to_its_configured_list() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let family = catalog
+            .get("fivetran")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "connector_metadata_details")
+            .unwrap();
+        assert_eq!(
+            family.path_parameters().get("service"),
+            Some(&PathParameterBinding::CsvFanout {
+                field: "connector_services".to_owned()
+            })
+        );
+        assert_eq!(
+            family.config_attributes().get("service"),
+            family.path_parameters().get("service")
+        );
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1845,6 +1845,42 @@ mod tests {
     }
 
     #[test]
+    fn explicit_fanout_binding_drives_runtime_paths_and_record_scope() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let connector = HttpSourceConnector::new(
+            catalog.get("fivetran").unwrap().clone(),
+            "connector_metadata_details",
+            "https://api.example.test",
+            BTreeMap::from([(
+                "connector_services".to_owned(),
+                "snowflake,postgres".to_owned(),
+            )]),
+            ResolvedAuth::Basic {
+                username: "key".to_owned(),
+                password: "secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let scopes = connector.request_scopes().unwrap();
+        assert_eq!(scopes.len(), 2);
+        assert_eq!(
+            scopes[0].url.path(),
+            "/v1/metadata/connector-types/snowflake"
+        );
+        assert_eq!(
+            scopes[1].url.path(),
+            "/v1/metadata/connector-types/postgres"
+        );
+        assert_eq!(scopes[0].record_attributes["service"], "snowflake");
+        assert_eq!(scopes[1].record_attributes["service"], "postgres");
+    }
+
+    #[test]
     fn csv_fanout_rejects_empty_and_oversized_scope_sets() {
         let root = repository_root();
         let catalog = SourceCatalog::load(

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -210,7 +210,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 45 sources and 327 families are authoritative; the other 749 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 46 sources and 328 families are authoritative; the other 748 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/business-data-grc/fivetran.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/fivetran.yaml
@@ -1451,6 +1451,8 @@ entries:
             template: asset
           read:
             path_params: [service]
+            path_param_fanout:
+              service: connector_services
             singleton: true
             disable_page_size: true
           config:

--- a/internal/connectordefinitions/definition.go
+++ b/internal/connectordefinitions/definition.go
@@ -343,6 +343,7 @@ type ResourceReadSpec struct {
 	DetailPath            string            `json:"detail_path,omitempty"`
 	AllowBareDetailRecord bool              `json:"allow_bare_detail_record,omitempty"`
 	PathParams            []string          `json:"path_params,omitempty"`
+	PathParamFanout       map[string]string `json:"path_param_fanout,omitempty"`
 	MapRecords            map[string]string `json:"map_records,omitempty"`
 	Singleton             bool              `json:"singleton,omitempty"`
 	DisablePageSize       bool              `json:"disable_page_size,omitempty"`
@@ -535,6 +536,10 @@ func Validate(definition Definition) ValidationResult {
 	} else {
 		add(passing("resources", "Resource families", fmt.Sprintf("%d resource families are modeled.", len(definition.ResourceFamilies))))
 	}
+	runtimeConfigFields := map[string]struct{}{}
+	for _, field := range definition.ConfigFields {
+		runtimeConfigFields[strings.TrimSpace(field.Key)] = struct{}{}
+	}
 	for _, family := range definition.ResourceFamilies {
 		if !idPattern.MatchString(family.ID) {
 			add(blocking("family_"+family.ID, "Resource family ID", "Family ids must be lowercase identifiers."))
@@ -573,7 +578,7 @@ func Validate(definition Definition) ValidationResult {
 		if strings.ContainsAny(familyBaseURL, "\r\n\t\\") {
 			add(blocking("base_url_chars_"+family.ID, "Resource base URL", "Resource family base URL must not contain control characters or backslashes."))
 		}
-		validateFamilyIntegrationFields(family, add)
+		validateFamilyIntegrationFields(family, runtimeConfigFields, add)
 	}
 	status := ValidationReady
 	for _, check := range checks {
@@ -870,7 +875,7 @@ func isDepositResourceFamily(definition Definition, familyID string) bool {
 	return false
 }
 
-func validateFamilyIntegrationFields(family ResourceFamily, add func(ValidationCheck)) {
+func validateFamilyIntegrationFields(family ResourceFamily, configFields map[string]struct{}, add func(ValidationCheck)) {
 	if family.Read != nil {
 		if strings.TrimSpace(family.Read.DetailPath) != "" && !validRelativePath(family.Read.DetailPath) {
 			add(blocking("detail_path_"+family.ID, "Detail path", "Detail paths must be relative API paths such as /v1/assets/{id}."))
@@ -878,6 +883,22 @@ func validateFamilyIntegrationFields(family ResourceFamily, add func(ValidationC
 		for _, param := range family.Read.PathParams {
 			if !idPattern.MatchString(strings.TrimSpace(param)) {
 				add(blocking("path_param_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter", "Path parameters must be lowercase identifiers."))
+			}
+		}
+		pathParams := map[string]struct{}{}
+		for _, param := range family.Read.PathParams {
+			pathParams[strings.TrimSpace(param)] = struct{}{}
+		}
+		for param, configField := range family.Read.PathParamFanout {
+			param = strings.TrimSpace(param)
+			configField = strings.TrimSpace(configField)
+			if _, ok := pathParams[param]; !ok {
+				add(blocking("path_param_fanout_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter fanout", "Fanout bindings must reference a declared path parameter."))
+			}
+			if !idPattern.MatchString(configField) {
+				add(blocking("path_param_fanout_config_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter fanout", "Fanout config fields must be lowercase identifiers."))
+			} else if _, ok := configFields[configField]; !ok {
+				add(blocking("path_param_fanout_field_"+family.ID+"_"+normalizeDefinitionID(param), "Path parameter fanout", "Fanout config fields must be declared in definition.config_fields."))
 			}
 		}
 		for key, value := range family.Read.MapRecords {
@@ -1333,8 +1354,9 @@ func normalizeResourceReadSpec(read *ResourceReadSpec) *ResourceReadSpec {
 	next := *read
 	next.DetailPath = strings.TrimSpace(next.DetailPath)
 	next.PathParams = normalizeOrderedStringList(next.PathParams)
+	next.PathParamFanout = normalizeStringMap(next.PathParamFanout)
 	next.MapRecords = normalizeStringMap(next.MapRecords)
-	if next.DetailPath == "" && len(next.PathParams) == 0 && len(next.MapRecords) == 0 && !next.Singleton && !next.AllowBareDetailRecord && !next.DisablePageSize {
+	if next.DetailPath == "" && len(next.PathParams) == 0 && len(next.PathParamFanout) == 0 && len(next.MapRecords) == 0 && !next.Singleton && !next.AllowBareDetailRecord && !next.DisablePageSize {
 		return nil
 	}
 	return &next

--- a/internal/connectordefinitions/definition_test.go
+++ b/internal/connectordefinitions/definition_test.go
@@ -634,6 +634,10 @@ func TestValidateBlocksUnsafeDeclarativeRuntimeFields(t *testing.T) {
 			Read: &ResourceReadSpec{
 				DetailPath: "//evil.example/users/{id}",
 				PathParams: []string{"account id", "AccountID"},
+				PathParamFanout: map[string]string{
+					"missing_id": "account_ids",
+					"AccountID":  "bad config",
+				},
 			},
 			Pagination: &PaginationSpec{
 				Type:     "graphql",
@@ -651,6 +655,9 @@ func TestValidateBlocksUnsafeDeclarativeRuntimeFields(t *testing.T) {
 		"detail_path_users",
 		"path_param_users_account-id",
 		"path_param_users_accountid",
+		"path_param_fanout_users_missing_id",
+		"path_param_fanout_field_users_missing_id",
+		"path_param_fanout_config_users_accountid",
 		"pagination_users",
 		"pagination_page_size_users",
 		"incremental_users",
@@ -909,6 +916,7 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 		SourceID:      "example",
 		DisplayName:   "Example",
 		Categories:    []string{"identity", "identity", "audit"},
+		ConfigFields:  []Field{{Key: "account_ids"}},
 		//nolint:gosec // Test auth descriptor only; no credential value is stored.
 		Auth: AuthSpec{
 			Model:            "oauth_authorization_code",
@@ -940,6 +948,7 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 				DetailPath:            "/v1/users/{id}",
 				AllowBareDetailRecord: true,
 				PathParams:            []string{"account_id", "account_id"},
+				PathParamFanout:       map[string]string{" account_id ": " account_ids ", "": "ignored"},
 				MapRecords:            map[string]string{"": "ignored", "members": "items"},
 			},
 			IDField: "id",
@@ -996,6 +1005,9 @@ func TestNormalizeIntegrationDefinition(t *testing.T) {
 	}
 	if family.Read.MapRecords["members"] != "items" || len(family.Read.MapRecords) != 1 {
 		t.Fatalf("map records = %#v, want members->items", family.Read.MapRecords)
+	}
+	if family.Read.PathParamFanout["account_id"] != "account_ids" || len(family.Read.PathParamFanout) != 1 {
+		t.Fatalf("path param fanout = %#v, want account_id->account_ids", family.Read.PathParamFanout)
 	}
 	if family.Pagination == nil || len(family.Pagination.NextCursorKeys) != 1 || family.Pagination.NextCursorKeys[0] != "next_cursor" || family.Pagination.HasMoreKey != "has_more" {
 		t.Fatalf("pagination = %#v, want next cursor and has_more metadata", family.Pagination)


### PR DESCRIPTION
## Summary

- add a catalog-governed path-parameter fanout binding from a provider slot to a declared runtime config field
- validate bindings against declared path parameters and config fields before generation
- use the binding for native Fivetran connector-metadata collection

## Correctness

The Rust compiler and runtime keep the binding generic and fail closed. Fanout remains bounded and scope-preserving; provider records cannot contradict the requested service. No source-specific execution branch is introduced.

## Verification

- focused Go connector-definition tests
- source catalog and source runtime Rust tests
- strict Rust clippy
- source generation, catalog fidelity, docs drift, and architecture checks