### PR TITLE
fix: bound GRC dashboard latency

### DIFF
--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -30,11 +30,10 @@ type ProbeResult = {
   status: number;
 };
 
-const STATUS_TIMEOUT_MS = 5000;
+const STATUS_TIMEOUT_MS = 3000;
 const STATUS_PROBES = [
-  { key: "health", label: "API health", path: "/api/cerebro/health" },
-  { key: "healthz", label: "API healthz", path: "/api/cerebro/healthz" },
-  { key: "dashboard", label: "Dashboard proxy", path: "/api/cerebro/grc/dashboard?limit=1&view=summary" },
+  { key: "healthz", label: "API liveness", path: "/api/cerebro/healthz" },
+  { key: "health", label: "API readiness", path: "/api/cerebro/health" },
 ];
 
 const parseStatus = async (response: Response): Promise<Record<string, unknown>> => {

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -78,6 +78,9 @@ describe("product UI contract", () => {
     expect(identityPanelSource).toContain("Write Stamps");
     expect(identityPanelSource).toContain("currentUserWriteFieldForPath");
     expect(statusSource).toContain("Runtime Health");
+    expect(statusSource).toContain("API liveness");
+    expect(statusSource).toContain("API readiness");
+    expect(statusSource).not.toContain("/api/cerebro/grc/dashboard");
     expect(primitivesSource).toContain("DataStateBanner");
     expect(primitivesSource).toContain("data-grc-data-state");
     expect(primitivesSource).toContain("RuntimeRecoveryBlock");

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -22,6 +21,7 @@ import (
 	"github.com/writer/cerebro/internal/grctrends"
 	"github.com/writer/cerebro/internal/grcupload"
 	"github.com/writer/cerebro/internal/grcvendor"
+	"github.com/writer/cerebro/internal/operationtelemetry"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	questionnairehttp "github.com/writer/cerebro/internal/sourcehttp/questionnaire"
@@ -154,54 +154,60 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	findingIDs := grcFindingIDs(findings)
+	generatedAt := time.Now().UTC()
 	var (
-		evidence       []*cerebrov1.FindingEvidence
-		findingSummary *ports.FindingSummary
-		evidenceCount  *int
-		aggregate      *ports.GRCDashboardAggregate
-		wg             sync.WaitGroup
-		errs           = make(chan error, 3)
+		evidence        []*cerebrov1.FindingEvidence
+		findingSummary  *ports.FindingSummary
+		evidenceCount   *int
+		aggregate       *ports.GRCDashboardAggregate
+		sourceSummaries []sourceRuntimeHealthSummary
+		coverage        []sourcecoverage.Record
 	)
-	wg.Add(2)
-	go func(parent context.Context) {
-		defer wg.Done()
+	group, groupCtx := errgroup.WithContext(r.Context())
+	group.Go(func() error {
 		var err error
-		ctx, evidenceSpan := telemetry.Start(parent, "grc.dashboard.evidence", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}))
-		evidenceRequest := r.WithContext(ctx)
-		evidence, err = a.grcListEvidenceRecords(evidenceRequest, runtimes, grcEvidenceFilter{FindingIDs: findingIDs, Limit: previewLimit})
-		evidenceAttrs := telemetry.Attrs(telemetry.Field{Key: "evidence_count", Value: len(evidence)})
-		telemetry.AnnotateMainPhase(ctx, "grc.dashboard.evidence", grcTelemetryStatus(err), evidenceAttrs)
-		telemetry.End(evidenceSpan, grcTelemetryStatus(err), evidenceAttrs)
-		if err != nil {
-			errs <- err
-		}
-	}(r.Context())
-	go func(parent context.Context) {
-		defer wg.Done()
+		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.evidence", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}), func(ctx context.Context) (telemetry.Attributes, error) {
+			evidence, err = a.grcListEvidenceRecords(r.WithContext(ctx), runtimes, grcEvidenceFilter{FindingIDs: findingIDs, Limit: previewLimit})
+			return telemetry.Attrs(telemetry.Field{Key: "evidence_count", Value: len(evidence)}), err
+		})
+	})
+	group.Go(func() error {
 		var err error
-		ctx, aggregateSpan := telemetry.Start(parent, "grc.dashboard.aggregate", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}))
-		aggregateRequest := r.WithContext(ctx)
-		aggregate, err = a.grcDashboardAggregate(aggregateRequest, runtimes, grcFindingFilter{Status: "open"}, grcEvidenceFilter{})
-		if err == nil && aggregate == nil {
-			findingSummary, err = a.grcFindingSummary(aggregateRequest, runtimes, grcFindingFilter{Status: "open"})
-			if err == nil {
-				evidenceCount, err = a.grcEvidenceCount(aggregateRequest, runtimes, grcEvidenceFilter{FindingIDs: findingIDs})
+		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.aggregate", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}), func(ctx context.Context) (telemetry.Attributes, error) {
+			request := r.WithContext(ctx)
+			aggregate, err = a.grcDashboardAggregate(request, runtimes, grcFindingFilter{Status: "open"}, grcEvidenceFilter{})
+			if err == nil && aggregate == nil {
+				findingSummary, err = a.grcFindingSummary(request, runtimes, grcFindingFilter{Status: "open"})
+				if err == nil {
+					evidenceCount, err = a.grcEvidenceCount(request, runtimes, grcEvidenceFilter{FindingIDs: findingIDs})
+				}
 			}
-		}
-		attrs := telemetry.Attrs()
-		if aggregate != nil {
-			attrs = attrs.WithField(telemetry.Field{Key: "evidence_count", Value: aggregate.EvidenceCount})
-			attrs = attrs.WithField(telemetry.Field{Key: "open_findings", Value: aggregate.FindingSummary.OpenFindings})
-		}
-		telemetry.AnnotateMainPhase(ctx, "grc.dashboard.aggregate", grcTelemetryStatus(err), attrs)
-		telemetry.End(aggregateSpan, grcTelemetryStatus(err), attrs)
-		if err != nil {
-			errs <- err
-		}
-	}(r.Context())
-	wg.Wait()
-	close(errs)
-	if err := joinGRCErrors(errs); err != nil {
+			attrs := telemetry.Attrs()
+			if aggregate != nil {
+				attrs = attrs.WithField(telemetry.Field{Key: "evidence_count", Value: aggregate.EvidenceCount}).
+					WithField(telemetry.Field{Key: "open_findings", Value: aggregate.FindingSummary.OpenFindings})
+			}
+			return attrs, err
+		})
+	})
+	group.Go(func() error {
+		var err error
+		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.runtime_health", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
+			sourceSummaries, err = a.grcSourceRuntimeHealthSummaries(ctx, runtimes, generatedAt)
+			return telemetry.Attrs(telemetry.Field{Key: "source_summary_count", Value: len(sourceSummaries)}), err
+		})
+	})
+	group.Go(func() error {
+		var err error
+		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.coverage", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
+			coverage, err = a.sourceCoverageRecordsScoped(ctx, runtimes, ports.SourceRuntimeFilter{
+				RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID,
+				SourceID: scope.SourceID, Limit: scope.Limit,
+			}, generatedAt, coverageScope)
+			return telemetry.Attrs(telemetry.Field{Key: "coverage_record_count", Value: len(coverage)}), err
+		})
+	})
+	if err := group.Wait(); err != nil {
 		statusCode = grcHTTPStatusCode(err)
 		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, err)
@@ -219,21 +225,6 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	findingItems := grcFindingItems(findings, runtimeSourceIDs, evidenceCounts)
 	evidenceItems := grcEvidenceItems(evidence, grcFindingTitleMap(findings))
 	controls := grcControlItems(findingItems, evidenceItems)
-	generatedAt := time.Now().UTC()
-	sourceSummaries, err := a.grcSourceRuntimeHealthSummaries(r.Context(), runtimes, generatedAt)
-	if err != nil {
-		statusCode = grcHTTPStatusCode(err)
-		status, endAttrs = grcTelemetryError(endAttrs, err)
-		writeGRCError(w, err)
-		return
-	}
-	coverage, err := a.sourceCoverageRecordsScoped(r.Context(), runtimes, ports.SourceRuntimeFilter{RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID, SourceID: scope.SourceID, Limit: scope.Limit}, generatedAt, coverageScope)
-	if err != nil {
-		statusCode = grcHTTPStatusCode(err)
-		status, endAttrs = grcTelemetryError(endAttrs, err)
-		writeGRCError(w, err)
-		return
-	}
 	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
 	serializedCoverageBlindSpots := coverageBlindSpots
 	productAreas := grcproductareas.BuildCoverageViews(coverage)
@@ -271,14 +262,6 @@ func grcDashboardPreviewLimitFor(limit uint32) uint32 {
 		return grcDashboardPreviewLimit
 	}
 	return limit
-}
-
-func joinGRCErrors(errs <-chan error) error {
-	var joined error
-	for err := range errs {
-		joined = errors.Join(joined, err)
-	}
-	return joined
 }
 
 const (

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -16,7 +16,6 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
-	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/grcaudit"
 	"github.com/writer/cerebro/internal/grcauditpacket"
 	"github.com/writer/cerebro/internal/grcfindings"
@@ -28,23 +27,6 @@ import (
 	"github.com/writer/cerebro/internal/workflowevents"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-func TestJoinGRCErrorsPreservesAllFailures(t *testing.T) {
-	errA := fmt.Errorf("%w: evidence", graphquery.ErrRuntimeUnavailable)
-	errB := fmt.Errorf("%w: aggregate", ports.ErrFindingNotFound)
-	errs := make(chan error, 2)
-	errs <- errA
-	errs <- errB
-	close(errs)
-
-	err := joinGRCErrors(errs)
-	if !errors.Is(err, graphquery.ErrRuntimeUnavailable) {
-		t.Fatalf("joined error = %v, want runtime unavailable", err)
-	}
-	if !errors.Is(err, ports.ErrFindingNotFound) {
-		t.Fatalf("joined error = %v, want finding not found", err)
-	}
-}
 
 func TestGRCQuestionnaireRuntimeUnavailableMapsToServiceUnavailable(t *testing.T) {
 	if got := grcHTTPStatusCode(questionnairehttp.ErrRuntimeUnavailable); got != http.StatusServiceUnavailable {
@@ -360,6 +342,20 @@ func TestGRCDashboardEmitsLatencyTelemetry(t *testing.T) {
 	}
 	if _, ok := payload["duration_ms"].(float64); !ok {
 		t.Fatalf("telemetry duration_ms = %#v, want number; payload=%#v", payload["duration_ms"], payload)
+	}
+	for _, name := range []string{
+		"grc.dashboard.runtime_health",
+		"grc.dashboard.coverage",
+		"sourcehealth.latest_graph_runs",
+		"sourcehealth.latest_finding_runs",
+	} {
+		phasePayload := decodeBootstrapTelemetryPayload(t, stderr, name)
+		if phasePayload["status"] != "completed" {
+			t.Fatalf("%s status = %#v, want completed; payload=%#v", name, phasePayload["status"], phasePayload)
+		}
+		if _, ok := phasePayload["duration_ms"].(float64); !ok {
+			t.Fatalf("%s duration_ms = %#v, want number; payload=%#v", name, phasePayload["duration_ms"], phasePayload)
+		}
 	}
 }
 

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/nhicoverage"
+	"github.com/writer/cerebro/internal/operationtelemetry"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecoverage"
 	"github.com/writer/cerebro/internal/sourcehealth"
@@ -622,27 +623,29 @@ func (a *App) sourceRuntimeHealthRecords(ctx context.Context, runtimes []*cerebr
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		runStore, ok := a.deps.GraphStore.(graphingest.RunStore)
-		if !ok || isNilInterface(runStore) {
+		configured := ok && !isNilInterface(runStore)
+		return operationtelemetry.Run(groupCtx, "sourcehealth.latest_graph_runs", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimeIDs)}), func(ctx context.Context) (telemetry.Attributes, error) {
+			var err error
 			graphRuns = map[string]*graphstore.IngestRun{}
-			return nil
-		}
-		var loadErr error
-		graphRuns, loadErr = sourcehealth.LatestGraphIngestRuns(groupCtx, runStore, runtimeIDs)
-		return loadErr
+			if configured {
+				graphRuns, err = sourcehealth.LatestGraphIngestRuns(ctx, runStore, runtimeIDs)
+			}
+			return telemetry.Attrs(telemetry.Field{Key: "run_count", Value: len(graphRuns)}, telemetry.Field{Key: "store_configured", Value: configured}), err
+		})
 	})
 	group.Go(func() error {
 		runStore := findingEvaluationRunStore(a.deps.StateStore)
-		if runStore == nil {
+		return operationtelemetry.Run(groupCtx, "sourcehealth.latest_finding_runs", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimeIDs)}), func(ctx context.Context) (telemetry.Attributes, error) {
 			findingRuns = map[string]*cerebrov1.FindingEvaluationRun{}
-			return nil
-		}
-		var loadErr error
-		findingRuns, loadErr = sourcehealth.LatestFindingEvaluationRuns(groupCtx, runStore, runtimeIDs)
-		if errors.Is(loadErr, findings.ErrRuntimeUnavailable) {
-			findingRuns = map[string]*cerebrov1.FindingEvaluationRun{}
-			return nil
-		}
-		return loadErr
+			var err error
+			if runStore != nil {
+				findingRuns, err = sourcehealth.LatestFindingEvaluationRuns(ctx, runStore, runtimeIDs)
+				if errors.Is(err, findings.ErrRuntimeUnavailable) {
+					findingRuns, err = map[string]*cerebrov1.FindingEvaluationRun{}, nil
+				}
+			}
+			return telemetry.Attrs(telemetry.Field{Key: "run_count", Value: len(findingRuns)}, telemetry.Field{Key: "store_configured", Value: runStore != nil}), err
+		})
 	})
 	if err := group.Wait(); err != nil {
 		return nil, err

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -2375,34 +2375,9 @@ func (s *Store) ListIngestRuns(ctx context.Context, filter IngestRunFilter) (_ [
 	if limit < 0 || limit > 500 {
 		return nil, fmt.Errorf("ingest run limit must be between 1 and 500")
 	}
-	where := make([]string, 0, 2)
-	params := map[string]any{}
-	runtimeIDs := normalizedNonEmptyStrings(append(filter.RuntimeIDs, filter.RuntimeID))
-	if len(runtimeIDs) == 1 {
-		where = append(where, "r.runtime_id = $runtime_id")
-		params["runtime_id"] = runtimeIDs[0]
-	} else if len(runtimeIDs) > 1 {
-		where = append(where, "r.runtime_id IN $runtime_ids")
-		params["runtime_ids"] = runtimeIDs
-	}
-	if status := strings.TrimSpace(filter.Status); status != "" {
-		if !validIngestRunStatus(status) {
-			return nil, fmt.Errorf("unsupported ingest run status %q", status)
-		}
-		where = append(where, "r.status = $status")
-		params["status"] = status
-	}
-	prefix := "MATCH (r:IngestRun)"
-	if len(where) > 0 {
-		prefix += " WHERE " + strings.Join(where, " AND ")
-	}
-	query := ingestRunReturnQuery(prefix) + fmt.Sprintf(" ORDER BY coalesce(r.started_at, '') DESC, r.id DESC LIMIT %d", limit)
-	if filter.LatestByRuntime {
-		query = prefix + `
-WITH coalesce(r.runtime_id, r.id) AS runtime_key, r
-ORDER BY runtime_key ASC, coalesce(r.started_at, '') DESC, r.id DESC
-WITH runtime_key, collect(r)[0] AS r
-` + ingestRunReturnQuery("WITH r") + fmt.Sprintf(" ORDER BY coalesce(r.started_at, '') DESC, r.id DESC LIMIT %d", limit)
+	query, params, err := ingestRunListQuery(filter, limit)
+	if err != nil {
+		return nil, err
 	}
 	var runs []IngestRun
 	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
@@ -2423,6 +2398,59 @@ WITH runtime_key, collect(r)[0] AS r
 		return nil, fmt.Errorf("list ingest runs: %w", err)
 	}
 	return runs, nil
+}
+
+func ingestRunListQuery(filter IngestRunFilter, limit int) (string, map[string]any, error) {
+	where := make([]string, 0, 2)
+	params := map[string]any{}
+	runtimeIDs := normalizedNonEmptyStrings(append(filter.RuntimeIDs, filter.RuntimeID))
+	status := strings.TrimSpace(filter.Status)
+	if status != "" && !validIngestRunStatus(status) {
+		return "", nil, fmt.Errorf("unsupported ingest run status %q", status)
+	}
+	if filter.LatestByRuntime && len(runtimeIDs) > 0 {
+		params["runtime_ids"] = runtimeIDs
+		statusPredicate := ""
+		if status != "" {
+			params["status"] = status
+			statusPredicate = "\nWHERE r.status = $status"
+		}
+		query := `
+UNWIND $runtime_ids AS runtime_id
+CALL {
+  WITH runtime_id
+  MATCH (r:IngestRun {runtime_id: runtime_id})` + statusPredicate + `
+  RETURN r
+  ORDER BY r.started_at DESC, r.id DESC
+  LIMIT 1
+}
+` + ingestRunReturnQuery("WITH r") + fmt.Sprintf(" ORDER BY r.started_at DESC, r.id DESC LIMIT %d", limit)
+		return query, params, nil
+	}
+	if len(runtimeIDs) == 1 {
+		where = append(where, "r.runtime_id = $runtime_id")
+		params["runtime_id"] = runtimeIDs[0]
+	} else if len(runtimeIDs) > 1 {
+		where = append(where, "r.runtime_id IN $runtime_ids")
+		params["runtime_ids"] = runtimeIDs
+	}
+	if status != "" {
+		where = append(where, "r.status = $status")
+		params["status"] = status
+	}
+	prefix := "MATCH (r:IngestRun)"
+	if len(where) > 0 {
+		prefix += " WHERE " + strings.Join(where, " AND ")
+	}
+	query := ingestRunReturnQuery(prefix) + fmt.Sprintf(" ORDER BY coalesce(r.started_at, '') DESC, r.id DESC LIMIT %d", limit)
+	if filter.LatestByRuntime {
+		query = prefix + `
+WITH coalesce(r.runtime_id, r.id) AS runtime_key, r
+ORDER BY runtime_key ASC, coalesce(r.started_at, '') DESC, r.id DESC
+WITH runtime_key, collect(r)[0] AS r
+` + ingestRunReturnQuery("WITH r") + fmt.Sprintf(" ORDER BY coalesce(r.started_at, '') DESC, r.id DESC LIMIT %d", limit)
+	}
+	return query, params, nil
 }
 
 func normalizedNonEmptyStrings(values []string) []string {
@@ -2458,10 +2486,28 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	if s.schemaReady {
 		return nil
 	}
-	statements := []string{
+	statements := neo4jSchemaStatements()
+	if _, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		for _, statement := range statements {
+			if _, err := consume(ctx, tx, statement, nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}); err != nil {
+		return fmt.Errorf("ensure neo4j schema: %w", err)
+	}
+	s.schemaReady = true
+	return nil
+}
+
+func neo4jSchemaStatements() []string {
+	return []string{
 		"CREATE CONSTRAINT cerebro_entity_urn IF NOT EXISTS FOR (e:Entity) REQUIRE e.urn IS UNIQUE",
 		"CREATE CONSTRAINT cerebro_checkpoint_id IF NOT EXISTS FOR (c:IngestCheckpoint) REQUIRE c.id IS UNIQUE",
 		"CREATE CONSTRAINT cerebro_ingest_run_id IF NOT EXISTS FOR (r:IngestRun) REQUIRE r.id IS UNIQUE",
+		"CREATE INDEX cerebro_ingest_run_runtime IF NOT EXISTS FOR (r:IngestRun) ON (r.runtime_id)",
+		"CREATE INDEX cerebro_ingest_run_runtime_started IF NOT EXISTS FOR (r:IngestRun) ON (r.runtime_id, r.started_at)",
 		"CREATE INDEX cerebro_entity_tenant_runtime IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.runtime_id)",
 		"CREATE INDEX cerebro_entity_tenant_type IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.entity_type)",
 		"CREATE INDEX cerebro_entity_tenant_source IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.source_id)",
@@ -2476,18 +2522,6 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 		"CREATE INDEX cerebro_relation_assertion_identity IF NOT EXISTS FOR ()-[a:RELATION_ASSERTION]-() ON (a.tenant_id, a.relation, a.source_id, a.runtime_id)",
 		"CREATE FULLTEXT INDEX cerebro_entity_inventory_fulltext IF NOT EXISTS FOR (e:Entity) ON EACH [e.urn, e.label, e.entity_type, e.attributes_json]",
 	}
-	if _, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
-		for _, statement := range statements {
-			if _, err := consume(ctx, tx, statement, nil); err != nil {
-				return nil, err
-			}
-		}
-		return nil, nil
-	}); err != nil {
-		return fmt.Errorf("ensure neo4j schema: %w", err)
-	}
-	s.schemaReady = true
-	return nil
 }
 
 func (s *Store) projectionBatchSizeOrDefault() int {

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -104,6 +104,52 @@ func TestScanIngestRunRecordPreservesMissingLegacyCheckpointTerminalState(t *tes
 	}
 }
 
+func TestIngestRunListQueryBoundsLatestRunsByRequestedRuntime(t *testing.T) {
+	query, params, err := ingestRunListQuery(graphstore.IngestRunFilter{
+		RuntimeIDs:      []string{"runtime-b", "runtime-a", "runtime-b"},
+		Status:          graphstore.IngestRunStatusCompleted,
+		LatestByRuntime: true,
+	}, 2)
+	if err != nil {
+		t.Fatalf("ingestRunListQuery() error = %v", err)
+	}
+	for _, want := range []string{
+		"UNWIND $runtime_ids AS runtime_id",
+		"MATCH (r:IngestRun {runtime_id: runtime_id})",
+		"WHERE r.status = $status",
+		"ORDER BY r.started_at DESC, r.id DESC",
+		"LIMIT 1",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("ingestRunListQuery() missing %q:\n%s", want, query)
+		}
+	}
+	for _, rejected := range []string{"collect(r)[0]", "r.runtime_id IN $runtime_ids"} {
+		if strings.Contains(query, rejected) {
+			t.Fatalf("ingestRunListQuery() contains unbounded shape %q:\n%s", rejected, query)
+		}
+	}
+	gotRuntimeIDs, ok := params["runtime_ids"].([]string)
+	if !ok || strings.Join(gotRuntimeIDs, ",") != "runtime-b,runtime-a" {
+		t.Fatalf("runtime_ids = %#v, want normalized stable input order", params["runtime_ids"])
+	}
+	if params["status"] != graphstore.IngestRunStatusCompleted {
+		t.Fatalf("status = %#v, want %q", params["status"], graphstore.IngestRunStatusCompleted)
+	}
+}
+
+func TestNeo4jSchemaIndexesIngestRunLookupShape(t *testing.T) {
+	statements := strings.Join(neo4jSchemaStatements(), "\n")
+	for _, want := range []string{
+		"cerebro_ingest_run_runtime IF NOT EXISTS FOR (r:IngestRun) ON (r.runtime_id)",
+		"cerebro_ingest_run_runtime_started IF NOT EXISTS FOR (r:IngestRun) ON (r.runtime_id, r.started_at)",
+	} {
+		if !strings.Contains(statements, want) {
+			t.Fatalf("neo4jSchemaStatements() missing %q:\n%s", want, statements)
+		}
+	}
+}
+
 func TestUpsertProjectedEntityRejectsCrossTenantCerebroURNBeforeConnection(t *testing.T) {
 	store := &Store{}
 	err := store.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{

--- a/internal/operationtelemetry/operation.go
+++ b/internal/operationtelemetry/operation.go
@@ -1,0 +1,33 @@
+package operationtelemetry
+
+import (
+	"context"
+
+	"github.com/writer/cerebro/internal/telemetry"
+)
+
+type Work func(context.Context) (telemetry.Attributes, error)
+
+func Run(ctx context.Context, name string, start telemetry.Attributes, work Work) error {
+	spanCtx, span := telemetry.Start(ctx, name, start)
+	attrs, err := work(spanCtx)
+	attrs = start.With(attrs)
+	status := "completed"
+	if err != nil {
+		status = "failed"
+	}
+	telemetry.End(span, status, attrs)
+	return err
+}
+
+func RunMainPhase(ctx context.Context, name string, start telemetry.Attributes, work Work) error {
+	return Run(ctx, name, start, func(spanCtx context.Context) (telemetry.Attributes, error) {
+		attrs, err := work(spanCtx)
+		status := "completed"
+		if err != nil {
+			status = "failed"
+		}
+		telemetry.AnnotateMainPhase(spanCtx, name, status, attrs)
+		return attrs, err
+	})
+}


### PR DESCRIPTION
## Summary
- resolve latest ingest runs with one indexed lookup per requested runtime instead of globally sorting and collecting all ingest runs
- add managed Neo4j indexes for runtime and runtime/start-time lookup
- run dashboard evidence, aggregate, runtime-health, and coverage work concurrently and emit latency spans for each hidden phase
- keep the developer runtime panel on liveness and readiness probes instead of issuing a dashboard query

## Verification
- `go test ./internal/bootstrap ./internal/graphstore/neo4j -count=1`
- `npm run lint --workspace @writer/cerebro-web`
- `npm test --workspace @writer/cerebro-web -- --run src/lib/ui-contract.test.ts`
- `make verify` progressed through the repository suite; an initial local run exposed and led to a fixed variable-shadowing regression. The full web suite has one pre-existing Node 26 localStorage runtime failure; the changed web contract tests pass.