### PR TITLE
Move device Action execution into Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,16 +479,20 @@ dependencies = [
 name = "cerebro-action-provider"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "cerebro-action-catalog",
  "cerebro-action-store",
  "cerebro-platform-engine",
  "cerebro-platform-sdk",
  "futures-util",
+ "native-tls",
+ "postgres-native-tls",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]

--- a/crates/action-provider/Cargo.toml
+++ b/crates/action-provider/Cargo.toml
@@ -7,18 +7,22 @@ license.workspace = true
 publish = false
 
 [dependencies]
+async-trait.workspace = true
 cerebro-action-store.workspace = true
 cerebro-platform-engine.workspace = true
 cerebro-platform-sdk.workspace = true
 futures-util.workspace = true
+native-tls.workspace = true
+postgres-native-tls.workspace = true
 reqwest = { workspace = true, features = ["stream"] }
 serde.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
+tokio-postgres.workspace = true
 
 [dev-dependencies]
 axum.workspace = true
 cerebro-action-catalog.workspace = true
-tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/action-provider/src/cerebro_device.rs
+++ b/crates/action-provider/src/cerebro_device.rs
@@ -1,0 +1,433 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cerebro_action_store::ActionDispatch;
+use cerebro_platform_sdk::{ContentDigest, OpaqueId};
+use postgres_native_tls::MakeTlsConnector;
+use serde::Serialize;
+use tokio::sync::Mutex;
+use tokio_postgres::Client as PostgresClient;
+
+use crate::{ProviderError, ProviderReceipt, ProviderStatus};
+
+const PROVIDER: &str = "cerebro-device-auth";
+const PROVIDER_ACTION: &str = "revoke";
+const RECEIPT_SCHEMA: &str = "cerebro.device-action-receipt.v1";
+const EXTERNAL_PREFIX: &str = "cerebro-device:revoke:";
+
+#[derive(Clone)]
+pub struct CerebroDeviceClient {
+    store: Arc<dyn CerebroDeviceStore>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CerebroDeviceState {
+    status: String,
+    revoked_at_unix_ms: Option<u64>,
+}
+
+#[async_trait]
+trait CerebroDeviceStore: Send + Sync {
+    async fn revoke(&self, dispatch: &ActionDispatch) -> Result<CerebroDeviceState, ProviderError>;
+
+    async fn observe(&self, dispatch: &ActionDispatch)
+    -> Result<CerebroDeviceState, ProviderError>;
+}
+
+struct PostgresCerebroDeviceStore {
+    client: Mutex<PostgresClient>,
+}
+
+impl CerebroDeviceClient {
+    pub async fn connect_tls(connection_string: &str) -> Result<Self, ProviderError> {
+        if connection_string.trim().is_empty() || connection_string.trim() != connection_string {
+            return Err(ProviderError::InvalidConfiguration(
+                "device PostgreSQL connection",
+            ));
+        }
+        let tls = native_tls::TlsConnector::builder()
+            .build()
+            .map_err(|_| ProviderError::InvalidConfiguration("device PostgreSQL TLS"))?;
+        let (client, connection) =
+            tokio_postgres::connect(connection_string, MakeTlsConnector::new(tls))
+                .await
+                .map_err(|_| ProviderError::InvalidConfiguration("device PostgreSQL connection"))?;
+        tokio::spawn(async move {
+            if let Err(error) = connection.await {
+                eprintln!("Action device PostgreSQL connection closed: {error}");
+            }
+        });
+        Ok(Self {
+            store: Arc::new(PostgresCerebroDeviceStore {
+                client: Mutex::new(client),
+            }),
+        })
+    }
+
+    #[cfg(test)]
+    fn from_store(store: Arc<dyn CerebroDeviceStore>) -> Self {
+        Self { store }
+    }
+
+    pub async fn dispatch(
+        &self,
+        dispatch: &ActionDispatch,
+    ) -> Result<ProviderReceipt, ProviderError> {
+        validate_dispatch(dispatch)?;
+        let state = self.store.revoke(dispatch).await?;
+        receipt(dispatch, state, None)
+    }
+
+    pub async fn observe(
+        &self,
+        dispatch: &ActionDispatch,
+        expected_external_id: &OpaqueId,
+    ) -> Result<ProviderReceipt, ProviderError> {
+        validate_dispatch(dispatch)?;
+        let expected = external_id(&dispatch.target_id)?;
+        if expected_external_id != &expected {
+            return Err(ProviderError::InvalidResponse("external id"));
+        }
+        let state = self.store.observe(dispatch).await?;
+        receipt(dispatch, state, Some(expected_external_id))
+    }
+}
+
+#[async_trait]
+impl CerebroDeviceStore for PostgresCerebroDeviceStore {
+    async fn revoke(&self, dispatch: &ActionDispatch) -> Result<CerebroDeviceState, ProviderError> {
+        let requested_at = i64::try_from(dispatch.requested_at_unix_ms)
+            .map_err(|_| ProviderError::InvalidDispatch("request time"))?;
+        let reason = format!("Action {}", dispatch.operation_id);
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+WITH updated AS (
+  UPDATE device_records
+  SET status = 'revoked',
+      revoked_at = COALESCE(
+        revoked_at,
+        TO_TIMESTAMP($3::BIGINT::DOUBLE PRECISION / 1000.0)
+      ),
+      revoked_reason = CASE
+        WHEN status = 'revoked' THEN revoked_reason
+        ELSE $4
+      END,
+      updated_at = CASE
+        WHEN status = 'revoked' THEN updated_at
+        ELSE TO_TIMESTAMP($3::BIGINT::DOUBLE PRECISION / 1000.0)
+      END
+  WHERE device_id = $1 AND tenant_id = $2
+  RETURNING status, revoked_at
+)
+SELECT
+  status,
+  (EXTRACT(EPOCH FROM revoked_at) * 1000)::BIGINT AS revoked_at_unix_ms
+FROM updated
+"#,
+                &[
+                    &dispatch.target_id,
+                    &dispatch.tenant_id,
+                    &requested_at,
+                    &reason,
+                ],
+            )
+            .await
+            .map_err(|_| ProviderError::DispatchAmbiguous)?;
+        row.map(state_from_row)
+            .transpose()?
+            .ok_or(ProviderError::DispatchRejected { status: 404 })
+    }
+
+    async fn observe(
+        &self,
+        dispatch: &ActionDispatch,
+    ) -> Result<CerebroDeviceState, ProviderError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+SELECT
+  status,
+  (EXTRACT(EPOCH FROM revoked_at) * 1000)::BIGINT AS revoked_at_unix_ms
+FROM device_records
+WHERE device_id = $1 AND tenant_id = $2
+"#,
+                &[&dispatch.target_id, &dispatch.tenant_id],
+            )
+            .await
+            .map_err(|_| ProviderError::ObservationUnavailable)?;
+        row.map(state_from_row)
+            .transpose()?
+            .ok_or(ProviderError::ObservationUnavailable)
+    }
+}
+
+fn state_from_row(row: tokio_postgres::Row) -> Result<CerebroDeviceState, ProviderError> {
+    let revoked_at = row
+        .try_get::<_, Option<i64>>("revoked_at_unix_ms")
+        .map_err(|_| ProviderError::InvalidResponse("device timestamp"))?
+        .map(|value| {
+            u64::try_from(value).map_err(|_| ProviderError::InvalidResponse("device timestamp"))
+        })
+        .transpose()?;
+    Ok(CerebroDeviceState {
+        status: row
+            .try_get("status")
+            .map_err(|_| ProviderError::InvalidResponse("device status"))?,
+        revoked_at_unix_ms: revoked_at,
+    })
+}
+
+fn validate_dispatch(dispatch: &ActionDispatch) -> Result<(), ProviderError> {
+    dispatch
+        .validate()
+        .map_err(|_| ProviderError::InvalidDispatch("content digest"))?;
+    if dispatch.provider != PROVIDER {
+        return Err(ProviderError::InvalidDispatch("provider"));
+    }
+    if dispatch.provider_action != PROVIDER_ACTION {
+        return Err(ProviderError::InvalidDispatch("provider action"));
+    }
+    Ok(())
+}
+
+fn external_id(target_id: &str) -> Result<OpaqueId, ProviderError> {
+    OpaqueId::parse(format!("{EXTERNAL_PREFIX}{target_id}"))
+        .map_err(|_| ProviderError::InvalidDispatch("target"))
+}
+
+fn receipt(
+    dispatch: &ActionDispatch,
+    state: CerebroDeviceState,
+    expected_external_id: Option<&OpaqueId>,
+) -> Result<ProviderReceipt, ProviderError> {
+    let external_id = external_id(&dispatch.target_id)?;
+    if expected_external_id.is_some_and(|expected| expected != &external_id) {
+        return Err(ProviderError::InvalidResponse("external id"));
+    }
+    let status = if state.status == "revoked" && state.revoked_at_unix_ms.is_some() {
+        ProviderStatus::Succeeded
+    } else {
+        ProviderStatus::NeedsAttention
+    };
+    #[derive(Serialize)]
+    struct DeviceReceipt<'a> {
+        schema: &'static str,
+        external_id: &'a str,
+        action: &'a str,
+        status: &'static str,
+        target: &'a str,
+        tenant_id: &'a str,
+        finding_id: &'a str,
+        idempotency_key: &'a str,
+        device_status: &'a str,
+        revoked_at_unix_ms: Option<u64>,
+    }
+    let bytes = serde_json::to_vec(&DeviceReceipt {
+        schema: RECEIPT_SCHEMA,
+        external_id: external_id.as_str(),
+        action: &dispatch.provider_action,
+        status: status.as_str(),
+        target: &dispatch.target_id,
+        tenant_id: &dispatch.tenant_id,
+        finding_id: &dispatch.finding_id,
+        idempotency_key: &dispatch.idempotency_key,
+        device_status: &state.status,
+        revoked_at_unix_ms: state.revoked_at_unix_ms,
+    })
+    .map_err(|_| ProviderError::InvalidResponse("device receipt"))?;
+    Ok(ProviderReceipt {
+        external_id,
+        status,
+        request_digest: Some(
+            ContentDigest::parse(dispatch.dispatch_digest.clone())
+                .map_err(|_| ProviderError::InvalidDispatch("dispatch digest"))?,
+        ),
+        response_digest: ContentDigest::of_bytes(bytes),
+        updated_at_unix_s: state.revoked_at_unix_ms.map(|value| value / 1_000),
+        completed_at_unix_s: if status.is_terminal() {
+            state.revoked_at_unix_ms.map(|value| value / 1_000)
+        } else {
+            None
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use cerebro_action_catalog::lookup;
+
+    use super::*;
+
+    struct MemoryDeviceStore {
+        tenant_id: String,
+        target_id: String,
+        state: Mutex<CerebroDeviceState>,
+        revocations: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl CerebroDeviceStore for MemoryDeviceStore {
+        async fn revoke(
+            &self,
+            dispatch: &ActionDispatch,
+        ) -> Result<CerebroDeviceState, ProviderError> {
+            if dispatch.tenant_id != self.tenant_id || dispatch.target_id != self.target_id {
+                return Err(ProviderError::DispatchRejected { status: 404 });
+            }
+            self.revocations.fetch_add(1, Ordering::SeqCst);
+            let mut state = self.state.lock().await;
+            if state.status != "revoked" {
+                state.status = "revoked".to_owned();
+                state.revoked_at_unix_ms = Some(dispatch.requested_at_unix_ms);
+            }
+            Ok(state.clone())
+        }
+
+        async fn observe(
+            &self,
+            dispatch: &ActionDispatch,
+        ) -> Result<CerebroDeviceState, ProviderError> {
+            if dispatch.tenant_id != self.tenant_id || dispatch.target_id != self.target_id {
+                return Err(ProviderError::ObservationUnavailable);
+            }
+            Ok(self.state.lock().await.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_is_tenant_scoped_idempotent_and_receipt_bound() {
+        let store = Arc::new(MemoryDeviceStore {
+            tenant_id: "tenant:one".to_owned(),
+            target_id: "device:one".to_owned(),
+            state: Mutex::new(CerebroDeviceState {
+                status: "active".to_owned(),
+                revoked_at_unix_ms: None,
+            }),
+            revocations: AtomicUsize::new(0),
+        });
+        let client = CerebroDeviceClient::from_store(store.clone());
+        let dispatch = device_dispatch();
+
+        let first = client.dispatch(&dispatch).await.expect("first dispatch");
+        let second = client.dispatch(&dispatch).await.expect("idempotent replay");
+        assert_eq!(first, second);
+        assert_eq!(first.status, ProviderStatus::Succeeded);
+        assert_eq!(
+            first.external_id.as_str(),
+            "cerebro-device:revoke:device:one"
+        );
+        assert_eq!(store.revocations.load(Ordering::SeqCst), 2);
+
+        let observed = client
+            .observe(&dispatch, &first.external_id)
+            .await
+            .expect("bound observation");
+        assert_eq!(observed.response_digest, first.response_digest);
+        assert_eq!(observed.status, ProviderStatus::Succeeded);
+    }
+
+    #[tokio::test]
+    async fn dispatch_does_not_disclose_or_mutate_another_tenant() {
+        let store = Arc::new(MemoryDeviceStore {
+            tenant_id: "tenant:other".to_owned(),
+            target_id: "device:one".to_owned(),
+            state: Mutex::new(CerebroDeviceState {
+                status: "active".to_owned(),
+                revoked_at_unix_ms: None,
+            }),
+            revocations: AtomicUsize::new(0),
+        });
+        let client = CerebroDeviceClient::from_store(store.clone());
+
+        assert_eq!(
+            client.dispatch(&device_dispatch()).await,
+            Err(ProviderError::DispatchRejected { status: 404 })
+        );
+        assert_eq!(store.revocations.load(Ordering::SeqCst), 0);
+        assert_eq!(store.state.lock().await.status, "active");
+    }
+
+    #[tokio::test]
+    async fn observation_rejects_a_receipt_from_another_target() {
+        let store = Arc::new(MemoryDeviceStore {
+            tenant_id: "tenant:one".to_owned(),
+            target_id: "device:one".to_owned(),
+            state: Mutex::new(CerebroDeviceState {
+                status: "revoked".to_owned(),
+                revoked_at_unix_ms: Some(42),
+            }),
+            revocations: AtomicUsize::new(0),
+        });
+        let client = CerebroDeviceClient::from_store(store);
+        let wrong = OpaqueId::parse("cerebro-device:revoke:device:other").unwrap();
+
+        assert_eq!(
+            client.observe(&device_dispatch(), &wrong).await,
+            Err(ProviderError::InvalidResponse("external id"))
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_rejects_a_tampered_catalog_binding_before_mutation() {
+        let store = Arc::new(MemoryDeviceStore {
+            tenant_id: "tenant:one".to_owned(),
+            target_id: "device:one".to_owned(),
+            state: Mutex::new(CerebroDeviceState {
+                status: "active".to_owned(),
+                revoked_at_unix_ms: None,
+            }),
+            revocations: AtomicUsize::new(0),
+        });
+        let client = CerebroDeviceClient::from_store(store.clone());
+        let mut dispatch = device_dispatch();
+        dispatch.provider = "access-approvals".to_owned();
+
+        assert!(matches!(
+            client.dispatch(&dispatch).await,
+            Err(ProviderError::InvalidDispatch(_))
+        ));
+        assert_eq!(store.revocations.load(Ordering::SeqCst), 0);
+    }
+
+    fn device_dispatch() -> ActionDispatch {
+        let definition =
+            lookup("endpoint.cerebro.revoke_device").expect("generated Action definition");
+        let mut dispatch = ActionDispatch {
+            tenant_id: "tenant:one".to_owned(),
+            operation_id: "operation:one".to_owned(),
+            operation_version: 6,
+            proposal_digest: ContentDigest::of_bytes("proposal").to_string(),
+            finding_id: "finding:one".to_owned(),
+            finding_revision_digest: ContentDigest::of_bytes("finding revision").to_string(),
+            finding_validation_receipt_digest: ContentDigest::of_bytes("finding validation")
+                .to_string(),
+            graph_revision: 1,
+            action_kind: definition.id.to_owned(),
+            action_definition_digest: definition.definition_digest.to_owned(),
+            provider: definition.provider.to_owned(),
+            provider_action: definition.provider_action.to_owned(),
+            target_kind: definition.target_kind.to_owned(),
+            target_id: "device:one".to_owned(),
+            effect: definition.effect.to_owned(),
+            idempotency_key: "idempotency:one".to_owned(),
+            requested_by: "worker:one".to_owned(),
+            requested_at_unix_ms: 42,
+            dispatch_digest: ContentDigest::of_bytes("dispatch").to_string(),
+        };
+        dispatch.dispatch_digest = dispatch.computed_digest().unwrap().to_string();
+        dispatch.validate().unwrap();
+        dispatch
+    }
+}

--- a/crates/action-provider/src/lib.rs
+++ b/crates/action-provider/src/lib.rs
@@ -5,6 +5,10 @@
 //! A provider response is execution evidence, not finding closure. This crate
 //! never retries a mutation and never manufactures an observed-effect digest.
 
+mod cerebro_device;
+
+pub use cerebro_device::CerebroDeviceClient;
+
 use std::{error::Error, fmt, net::IpAddr, time::Duration};
 
 use cerebro_action_store::ActionDispatch;

--- a/crates/action-provider/tests/cerebro_device_postgres.rs
+++ b/crates/action-provider/tests/cerebro_device_postgres.rs
@@ -1,0 +1,135 @@
+use cerebro_action_catalog::lookup;
+use cerebro_action_provider::{CerebroDeviceClient, ProviderError, ProviderStatus};
+use cerebro_action_store::ActionDispatch;
+use cerebro_platform_sdk::ContentDigest;
+use tokio_postgres::NoTls;
+
+#[tokio::test]
+#[ignore = "requires disposable PostgreSQL"]
+async fn device_revocation_is_tenant_scoped_idempotent_and_observable() {
+    let dsn = std::env::var("CEREBRO_TEST_POSTGRES_DSN")
+        .expect("CEREBRO_TEST_POSTGRES_DSN is required for this ignored test");
+    let (admin, connection) = tokio_postgres::connect(&dsn, NoTls).await.unwrap();
+    tokio::spawn(async move { connection.await.unwrap() });
+    admin
+        .batch_execute(
+            r#"
+CREATE TABLE IF NOT EXISTS device_records (
+  device_id TEXT PRIMARY KEY,
+  hardware_uuid TEXT NOT NULL,
+  serial_number TEXT NOT NULL DEFAULT '',
+  hostname TEXT NOT NULL DEFAULT '',
+  tenant_id TEXT NOT NULL,
+  os_type TEXT NOT NULL DEFAULT '',
+  os_version TEXT NOT NULL DEFAULT '',
+  agent_version TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'active',
+  enrolled_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  revoked_reason TEXT NOT NULL DEFAULT '',
+  metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+"#,
+        )
+        .await
+        .unwrap();
+
+    let target = format!("device:rust-provider:{}", std::process::id());
+    admin
+        .execute(
+            "DELETE FROM device_records WHERE device_id = $1",
+            &[&target],
+        )
+        .await
+        .unwrap();
+    admin
+        .execute(
+            "INSERT INTO device_records (device_id, hardware_uuid, tenant_id, enrolled_at, last_seen_at) VALUES ($1, $2, 'tenant:one', NOW(), NOW())",
+            &[&target, &format!("hardware:{}", std::process::id())],
+        )
+        .await
+        .unwrap();
+
+    let provider = CerebroDeviceClient::connect_tls(&dsn).await.unwrap();
+    let mut wrong_tenant = dispatch(&target);
+    wrong_tenant.tenant_id = "tenant:other".to_owned();
+    wrong_tenant.dispatch_digest = wrong_tenant.computed_digest().unwrap().to_string();
+    assert_eq!(
+        provider.dispatch(&wrong_tenant).await,
+        Err(ProviderError::DispatchRejected { status: 404 })
+    );
+    assert_eq!(
+        admin
+            .query_one(
+                "SELECT status FROM device_records WHERE device_id = $1",
+                &[&target],
+            )
+            .await
+            .unwrap()
+            .get::<_, String>(0),
+        "active"
+    );
+
+    let dispatch = dispatch(&target);
+    let first = provider.dispatch(&dispatch).await.unwrap();
+    let replay = provider.dispatch(&dispatch).await.unwrap();
+    assert_eq!(first, replay);
+    assert_eq!(first.status, ProviderStatus::Succeeded);
+    assert_eq!(
+        provider
+            .observe(&dispatch, &first.external_id)
+            .await
+            .unwrap()
+            .response_digest,
+        first.response_digest
+    );
+    let row = admin
+        .query_one(
+            "SELECT tenant_id, status, revoked_reason FROM device_records WHERE device_id = $1",
+            &[&target],
+        )
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, String>(0), "tenant:one");
+    assert_eq!(row.get::<_, String>(1), "revoked");
+    assert_eq!(row.get::<_, String>(2), "Action operation:one");
+
+    admin
+        .execute(
+            "DELETE FROM device_records WHERE device_id = $1",
+            &[&target],
+        )
+        .await
+        .unwrap();
+}
+
+fn dispatch(target: &str) -> ActionDispatch {
+    let definition = lookup("endpoint.cerebro.revoke_device").unwrap();
+    let mut dispatch = ActionDispatch {
+        tenant_id: "tenant:one".to_owned(),
+        operation_id: "operation:one".to_owned(),
+        operation_version: 6,
+        proposal_digest: ContentDigest::of_bytes("proposal").to_string(),
+        finding_id: "finding:one".to_owned(),
+        finding_revision_digest: ContentDigest::of_bytes("finding revision").to_string(),
+        finding_validation_receipt_digest: ContentDigest::of_bytes("finding validation")
+            .to_string(),
+        graph_revision: 1,
+        action_kind: definition.id.to_owned(),
+        action_definition_digest: definition.definition_digest.to_owned(),
+        provider: definition.provider.to_owned(),
+        provider_action: definition.provider_action.to_owned(),
+        target_kind: definition.target_kind.to_owned(),
+        target_id: target.to_owned(),
+        effect: definition.effect.to_owned(),
+        idempotency_key: "idempotency:one".to_owned(),
+        requested_by: "worker:one".to_owned(),
+        requested_at_unix_ms: 42_000,
+        dispatch_digest: ContentDigest::of_bytes("dispatch").to_string(),
+    };
+    dispatch.dispatch_digest = dispatch.computed_digest().unwrap().to_string();
+    dispatch
+}

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -28,7 +28,10 @@ use cerebro_action_catalog::{
     ActionCatalogError, definitions as action_definitions, lookup as lookup_action,
     validate_proposal,
 };
-use cerebro_action_provider::{AccessApprovalsClient, AccessApprovalsConfig, ProviderError};
+use cerebro_action_provider::{
+    AccessApprovalsClient, AccessApprovalsConfig, CerebroDeviceClient, ProviderError,
+    ProviderReceipt,
+};
 use cerebro_action_store::{
     ActionDispatch, ActionDispatchPage, ActionEvent, ActionPage, ActionReconciliationDisposition,
     ActionReconciliationJob, ActionStoreError, PostgresActionLedger,
@@ -87,12 +90,18 @@ const ACTION_RECONCILIATION_POLL_DELAY_MS: u64 = 15 * 1_000;
 
 #[derive(Clone)]
 struct AppState {
-    access_approvals: Option<AccessApprovalsClient>,
+    action_providers: ActionProviders,
     actions: Option<Arc<dyn ActionAuthority>>,
     graph: Arc<dyn AgentGraph>,
     catalog_summary: Option<CatalogSummary>,
     projection: Option<Arc<ProjectionRuntime>>,
     metrics: PlatformMetrics,
+}
+
+#[derive(Clone, Default)]
+struct ActionProviders {
+    access_approvals: Option<AccessApprovalsClient>,
+    cerebro_device: Option<CerebroDeviceClient>,
 }
 
 #[async_trait]
@@ -1441,16 +1450,24 @@ async fn serve(
         OidcConfiguration::Disabled => None,
         OidcConfiguration::Configured(authenticator) => Some(authenticator),
     };
-    let actions: Option<Arc<dyn ActionAuthority>> = match env::var("CEREBRO_POSTGRES_DSN") {
+    let (actions, cerebro_device): (
+        Option<Arc<dyn ActionAuthority>>,
+        Option<CerebroDeviceClient>,
+    ) = match env::var("CEREBRO_POSTGRES_DSN") {
         Ok(connection_string) => {
             let ledger = PostgresActionLedger::connect_tls(&connection_string).await?;
             ledger.migrate().await?;
-            Some(Arc::new(ledger))
+            let device = CerebroDeviceClient::connect_tls(&connection_string).await?;
+            (Some(Arc::new(ledger)), Some(device))
         }
-        Err(env::VarError::NotPresent) => None,
+        Err(env::VarError::NotPresent) => (None, None),
         Err(error) => return Err(error.into()),
     };
     let access_approvals = access_approvals_from_env()?;
+    let action_providers = ActionProviders {
+        access_approvals,
+        cerebro_device,
+    };
     let listener = tokio::net::TcpListener::bind(&bind).await?;
     println!("cerebro Rust platform listening on {bind}");
     axum::serve(
@@ -1460,7 +1477,7 @@ async fn serve(
             load_catalog_summary().ok(),
             projection,
             actions,
-            access_approvals,
+            action_providers,
             tenant_auth,
             oidc,
         ),
@@ -1476,7 +1493,7 @@ fn router(graph: OrganizationalGraph) -> Router {
         None,
         None,
         None,
-        None,
+        ActionProviders::default(),
         TenantRequestAuth::new("test-organizational-graph-secret-32-bytes".to_owned()).unwrap(),
         None,
     )
@@ -1487,7 +1504,7 @@ fn router_with_backend(
     catalog_summary: Option<CatalogSummary>,
     projection: Option<Arc<ProjectionRuntime>>,
     actions: Option<Arc<dyn ActionAuthority>>,
-    access_approvals: Option<AccessApprovalsClient>,
+    action_providers: ActionProviders,
     tenant_auth: TenantRequestAuth,
     oidc: Option<OidcAuthenticator>,
 ) -> Router {
@@ -1562,7 +1579,7 @@ fn router_with_backend(
         .merge(protected)
         .fallback_service(connect.into_axum_service())
         .with_state(AppState {
-            access_approvals,
+            action_providers,
             actions,
             graph,
             catalog_summary,
@@ -2038,25 +2055,22 @@ async fn transition_action_route(
     let starts_execution = matches!(&request.command, HttpActionCommand::StartExecution { .. });
     let authority = action_authority(&state)?.clone();
     let provider = if starts_execution {
-        let provider = state.access_approvals.clone().ok_or_else(|| {
-            service_unavailable(
+        if state.action_providers.access_approvals.is_none()
+            && state.action_providers.cerebro_device.is_none()
+        {
+            return Err(service_unavailable(
                 "action_provider_unavailable",
-                "The access-approvals provider is not configured in the Rust runtime.",
-            )
-        })?;
+                "No Action provider is configured in the Rust runtime.",
+            ));
+        }
         let current = authority
             .get(&identity.tenant, &operation_id)
             .await
             .map_err(action_store_error)?;
         let definition =
             lookup_action(&current.proposal.action_kind).map_err(action_catalog_error)?;
-        if definition.provider != "access-approvals" {
-            return Err(service_unavailable(
-                "action_provider_unavailable",
-                "The Action provider is not available in the Rust runtime.",
-            ));
-        }
-        Some(provider)
+        require_configured_action_provider(&state, definition.provider)?;
+        Some(definition.provider)
     } else {
         None
     };
@@ -2076,7 +2090,7 @@ async fn transition_action_route(
         )
         .await
         .map_err(action_store_error)?;
-    let Some(provider) = provider else {
+    let Some(_provider) = provider else {
         return Ok(Json(operation));
     };
 
@@ -2084,7 +2098,7 @@ async fn transition_action_route(
         .get_dispatch(&identity.tenant, &operation_id)
         .await
         .map_err(action_store_error)?;
-    let provider_result = provider.dispatch(&dispatch).await;
+    let provider_result = dispatch_action_provider(&state, &dispatch).await;
     if let Err(error) = &provider_result {
         eprintln!(
             "Action provider dispatch returned no receipt: operation_id={operation_id} error={error}"
@@ -2111,12 +2125,6 @@ async fn run_action_reconciliation(
 ) -> Result<Json<ActionReconciliationRun>, (StatusCode, Json<ErrorResponse>)> {
     require_action_scope(&identity, ACTION_RECONCILE_SCOPE)?;
     let actor_id = authenticated_action_actor(&identity)?;
-    let provider = state.access_approvals.clone().ok_or_else(|| {
-        service_unavailable(
-            "action_provider_unavailable",
-            "The access-approvals provider is not configured in the Rust runtime.",
-        )
-    })?;
     let authority = action_authority(&state)?.clone();
     let mut result = ActionReconciliationRun {
         claimed: 0,
@@ -2142,11 +2150,7 @@ async fn run_action_reconciliation(
                 "Action reconciliation job has no provider receipt".to_owned(),
             ))
         })?;
-        let receipt = if job.dispatch.provider == "access-approvals" {
-            provider.observe(&job.dispatch, external_id).await
-        } else {
-            Err(ProviderError::ObservationUnavailable)
-        };
+        let receipt = observe_action_provider(&state, &job.dispatch, external_id).await;
         let receipt = match receipt {
             Ok(receipt) => receipt,
             Err(_) => {
@@ -2230,12 +2234,14 @@ async fn observe_action_provider_route(
     let actor_id = authenticated_action_actor(&identity)?;
     let operation_id = ActionOperationId::parse(operation_id)
         .map_err(|error| bad_request("invalid_action_operation_id", error.to_string()))?;
-    let provider = state.access_approvals.clone().ok_or_else(|| {
-        service_unavailable(
+    if state.action_providers.access_approvals.is_none()
+        && state.action_providers.cerebro_device.is_none()
+    {
+        return Err(service_unavailable(
             "action_provider_unavailable",
-            "The access-approvals provider is not configured in the Rust runtime.",
-        )
-    })?;
+            "No Action provider is configured in the Rust runtime.",
+        ));
+    }
     let authority = action_authority(&state)?.clone();
     let operation = authority
         .get(&identity.tenant, &operation_id)
@@ -2253,8 +2259,8 @@ async fn observe_action_provider_route(
         .get_dispatch(&identity.tenant, &operation_id)
         .await
         .map_err(action_store_error)?;
-    let receipt = provider
-        .observe(&dispatch, external_id)
+    require_configured_action_provider(&state, &dispatch.provider)?;
+    let receipt = observe_action_provider(&state, &dispatch, external_id)
         .await
         .map_err(action_provider_error)?;
     let observed_at = next_provider_observation_time(previous_observation, current_unix_millis()?)
@@ -2300,8 +2306,82 @@ fn action_clock_overflow() -> (StatusCode, Json<ErrorResponse>) {
     )
 }
 
+fn require_configured_action_provider(
+    state: &AppState,
+    provider: &str,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let configured = match provider {
+        "access-approvals" => state.action_providers.access_approvals.is_some(),
+        "cerebro-device-auth" => state.action_providers.cerebro_device.is_some(),
+        _ => false,
+    };
+    if configured {
+        Ok(())
+    } else {
+        Err(service_unavailable(
+            "action_provider_unavailable",
+            "The Action provider is not configured in the Rust runtime.",
+        ))
+    }
+}
+
+async fn dispatch_action_provider(
+    state: &AppState,
+    dispatch: &ActionDispatch,
+) -> Result<ProviderReceipt, ProviderError> {
+    match dispatch.provider.as_str() {
+        "access-approvals" => {
+            state
+                .action_providers
+                .access_approvals
+                .as_ref()
+                .ok_or(ProviderError::InvalidConfiguration("access-approvals"))?
+                .dispatch(dispatch)
+                .await
+        }
+        "cerebro-device-auth" => {
+            state
+                .action_providers
+                .cerebro_device
+                .as_ref()
+                .ok_or(ProviderError::InvalidConfiguration("cerebro-device-auth"))?
+                .dispatch(dispatch)
+                .await
+        }
+        _ => Err(ProviderError::InvalidDispatch("provider")),
+    }
+}
+
+async fn observe_action_provider(
+    state: &AppState,
+    dispatch: &ActionDispatch,
+    external_id: &OpaqueId,
+) -> Result<ProviderReceipt, ProviderError> {
+    match dispatch.provider.as_str() {
+        "access-approvals" => {
+            state
+                .action_providers
+                .access_approvals
+                .as_ref()
+                .ok_or(ProviderError::ObservationUnavailable)?
+                .observe(dispatch, external_id)
+                .await
+        }
+        "cerebro-device-auth" => {
+            state
+                .action_providers
+                .cerebro_device
+                .as_ref()
+                .ok_or(ProviderError::ObservationUnavailable)?
+                .observe(dispatch, external_id)
+                .await
+        }
+        _ => Err(ProviderError::ObservationUnavailable),
+    }
+}
+
 fn provider_dispatch_command(
-    result: Result<cerebro_action_provider::ProviderReceipt, ProviderError>,
+    result: Result<ProviderReceipt, ProviderError>,
     actor_id: ActorId,
     observed_at_unix_ms: u64,
 ) -> ActionCommand {
@@ -3901,7 +3981,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            ActionProviders::default(),
             TenantRequestAuth::new(TEST_SHARED_SECRET.to_owned()).unwrap(),
             None,
         );
@@ -4237,7 +4317,7 @@ mod tests {
 
         let (graph, _, _) = demo_graph().unwrap();
         let state = AppState {
-            access_approvals: None,
+            action_providers: ActionProviders::default(),
             actions: Some(Arc::new(UnreachableActionAuthority)),
             graph: Arc::new(MemoryAgentGraph::new(graph)),
             catalog_summary: None,
@@ -4366,7 +4446,7 @@ mod tests {
         );
         let (graph, _, _) = demo_graph().unwrap();
         let state = AppState {
-            access_approvals: None,
+            action_providers: ActionProviders::default(),
             actions: Some(Arc::new(UnreachableActionAuthority)),
             graph: Arc::new(MemoryAgentGraph::new(graph)),
             catalog_summary: None,
@@ -4480,7 +4560,7 @@ mod tests {
     async fn start_execution_fails_before_storage_when_rust_provider_is_unconfigured() {
         let (graph, _, _) = demo_graph().unwrap();
         let state = AppState {
-            access_approvals: None,
+            action_providers: ActionProviders::default(),
             actions: Some(Arc::new(UnreachableActionAuthority)),
             graph: Arc::new(MemoryAgentGraph::new(graph)),
             catalog_summary: None,
@@ -4521,7 +4601,7 @@ mod tests {
     async fn action_proposals_reject_spoofed_tenants_and_actors_before_storage() {
         let (graph, _, _) = demo_graph().unwrap();
         let state = AppState {
-            access_approvals: None,
+            action_providers: ActionProviders::default(),
             actions: Some(Arc::new(UnreachableActionAuthority)),
             graph: Arc::new(MemoryAgentGraph::new(graph)),
             catalog_summary: None,
@@ -4550,7 +4630,7 @@ mod tests {
     async fn action_proposals_reject_unregistered_or_tampered_definitions_before_storage() {
         let (graph, _, _) = demo_graph().unwrap();
         let state = AppState {
-            access_approvals: None,
+            action_providers: ActionProviders::default(),
             actions: Some(Arc::new(UnreachableActionAuthority)),
             graph: Arc::new(MemoryAgentGraph::new(graph)),
             catalog_summary: None,
@@ -4609,7 +4689,7 @@ mod tests {
     async fn finding_validation_rejects_unknown_or_tampered_policies_before_storage() {
         let (graph, _, _) = demo_graph().unwrap();
         let state = AppState {
-            access_approvals: None,
+            action_providers: ActionProviders::default(),
             actions: Some(Arc::new(UnreachableActionAuthority)),
             graph: Arc::new(MemoryAgentGraph::new(graph)),
             catalog_summary: None,
@@ -4643,7 +4723,7 @@ mod tests {
     async fn finding_validation_rejects_spoofed_identity_before_storage() {
         let (graph, _, _) = demo_graph().unwrap();
         let state = AppState {
-            access_approvals: None,
+            action_providers: ActionProviders::default(),
             actions: Some(Arc::new(UnreachableActionAuthority)),
             graph: Arc::new(MemoryAgentGraph::new(graph)),
             catalog_summary: None,
@@ -4934,7 +5014,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            ActionProviders::default(),
             TenantRequestAuth::new(TEST_SHARED_SECRET.to_owned()).unwrap(),
             None,
         );


### PR DESCRIPTION
## Summary
- execute and observe the built-in device revocation Action in the Rust provider plane
- route Rust Action dispatch and reconciliation through the provider recorded by the closed catalog
- add tenant-isolation, idempotency, receipt-binding, and disposable PostgreSQL coverage

## Verification
- `make graph-action-check`
- `make contracts-check`
- `make check-structural check-structural-test check-arch`
- `go test ./internal/bootstrap -run 'GraphAction' -count=1`\n- disposable PostgreSQL provider integration test