### PR TITLE
fix: preserve batched runtime identifiers

### DIFF
--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -2403,7 +2403,7 @@ func (s *Store) ListIngestRuns(ctx context.Context, filter IngestRunFilter) (_ [
 func ingestRunListQuery(filter IngestRunFilter, limit int) (string, map[string]any, error) {
 	where := make([]string, 0, 2)
 	params := map[string]any{}
-	runtimeIDs := normalizedNonEmptyStrings(append(filter.RuntimeIDs, filter.RuntimeID))
+	runtimeIDs := normalizedNonEmptyStrings(append(slices.Clone(filter.RuntimeIDs), filter.RuntimeID))
 	status := strings.TrimSpace(filter.Status)
 	if status != "" && !validIngestRunStatus(status) {
 		return "", nil, fmt.Errorf("unsupported ingest run status %q", status)

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -138,6 +138,26 @@ func TestIngestRunListQueryBoundsLatestRunsByRequestedRuntime(t *testing.T) {
 	}
 }
 
+func TestIngestRunListQueryDoesNotMutateRuntimeIDBackingArray(t *testing.T) {
+	backing := []string{"runtime-a", "runtime-b", "next-batch-runtime"}
+	runtimeIDs := backing[:2]
+
+	_, params, err := ingestRunListQuery(graphstore.IngestRunFilter{
+		RuntimeIDs:      runtimeIDs,
+		LatestByRuntime: true,
+	}, 2)
+	if err != nil {
+		t.Fatalf("ingestRunListQuery() error = %v", err)
+	}
+	if backing[2] != "next-batch-runtime" {
+		t.Fatalf("ingestRunListQuery() mutated caller backing array: %#v", backing)
+	}
+	gotRuntimeIDs, ok := params["runtime_ids"].([]string)
+	if !ok || strings.Join(gotRuntimeIDs, ",") != "runtime-a,runtime-b" {
+		t.Fatalf("runtime_ids = %#v, want caller values only", params["runtime_ids"])
+	}
+}
+
 func TestNeo4jSchemaIndexesIngestRunLookupShape(t *testing.T) {
 	statements := strings.Join(neo4jSchemaStatements(), "\n")
 	for _, want := range []string{


### PR DESCRIPTION
## Summary
- clone runtime identifier filters before appending the singular filter
- add regression coverage for caller-owned backing arrays

## Verification
- `go test ./internal/graphstore/neo4j ./internal/sourcehealth -count=1`
- `git diff --check`