### PR TITLE
Fence Rust source runtime commits

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -64,14 +64,14 @@ use cerebro_security_lifecycle::{
 use cerebro_source_catalog::{AuthModel, CatalogSummary, SourceCatalog};
 use cerebro_source_runtime_next::{
     CatalogGraphMapper, CollectionRequest, CommittedSourceEvent, GraphMapper, GraphSink,
-    HttpSourceConnector, ResolvedAuth, SourceRuntime,
+    HttpSourceConnector, ResolvedAuth, SourceRuntime, SourceRuntimeLeaseFence,
 };
 use hmac::{Hmac, KeyInit, Mac};
 use oidc::{AuthenticatedIdentity, AuthenticationError, OidcAuthenticator, OidcConfiguration};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, oneshot};
 
 const TENANT_AUTH_HEADER: &str = "x-cerebro-tenant";
 const TENANT_AUTH_CONTEXT: &[u8] = b"cerebro-organizational-graph/tenant/v1\0";
@@ -87,6 +87,8 @@ const FINDING_VALIDATE_SCOPE: &str = "cerebro:findings:validate";
 const ACTION_RECONCILIATION_BATCH_LIMIT: usize = 10;
 const ACTION_RECONCILIATION_LEASE_MS: u64 = 2 * 60 * 1_000;
 const ACTION_RECONCILIATION_POLL_DELAY_MS: u64 = 15 * 1_000;
+const DEFAULT_SOURCE_RUNTIME_LEASE_TTL_MS: u64 = 30 * 60 * 1_000;
+const MAX_SOURCE_RUNTIME_LEASE_RENEWAL_INTERVAL_MS: u64 = 5 * 60 * 1_000;
 
 #[derive(Clone)]
 struct AppState {
@@ -1349,7 +1351,14 @@ async fn sync_source() -> Result<(), Box<dyn Error>> {
         config,
         auth,
     )?;
-    let ledger = PostgresLedger::connect_tls(&required_env("CEREBRO_POSTGRES_DSN")?).await?;
+    let postgres_dsn = required_env("CEREBRO_POSTGRES_DSN")?;
+    let runtime_id = SourceRuntimeId::parse(required_env("CEREBRO_SOURCE_RUNTIME_ID")?)?;
+    let lease_ledger = Arc::new(PostgresLedger::connect_tls(&postgres_dsn).await?);
+    lease_ledger.migrate().await?;
+    let lease_ttl_millis = source_runtime_lease_ttl_millis()?;
+    let lease_owner = source_runtime_lease_owner();
+
+    let ledger = PostgresLedger::connect_tls(&postgres_dsn).await?;
     ledger.migrate().await?;
     let identity_resolution = ledger.identity_resolution_snapshot(&tenant_id).await?;
     let mapper = CatalogGraphMapper::new(source, env!("CARGO_PKG_VERSION"))?
@@ -1358,15 +1367,116 @@ async fn sync_source() -> Result<(), Box<dyn Error>> {
     projector.migrate().await?;
     let store = DurableGraphStore::new(ledger, projector);
     let mut runtime = SourceRuntime::new(connector, mapper, store);
-    let receipt = runtime
-        .sync(CollectionRequest {
-            tenant_id,
-            source_runtime_id: SourceRuntimeId::parse(required_env("CEREBRO_SOURCE_RUNTIME_ID")?)?,
-            cursor: env::var("CEREBRO_SOURCE_CURSOR").ok(),
-        })
-        .await?;
+    let fence = lease_ledger
+        .acquire_source_runtime_lease(&tenant_id, &runtime_id, &lease_owner, lease_ttl_millis)
+        .await?
+        .ok_or("source runtime is missing, belongs to another tenant, or is already leased")?;
+    let request = CollectionRequest {
+        tenant_id,
+        source_runtime_id: runtime_id,
+        cursor: env::var("CEREBRO_SOURCE_CURSOR").ok(),
+    };
+    let (stop_renewal, renewal_failure, renewal_task) =
+        start_source_runtime_lease_renewal(lease_ledger.clone(), fence.clone(), lease_ttl_millis);
+    let mut renewal_failure = renewal_failure;
+    let outcome = {
+        let sync = runtime.sync_fenced(request, &fence);
+        tokio::pin!(sync);
+        tokio::select! {
+            biased;
+            result = &mut sync => result.map_err(|error| error.to_string()),
+            failure = &mut renewal_failure => Err(
+                failure.unwrap_or_else(|_| {
+                    "source runtime lease renewal stopped unexpectedly".to_owned()
+                })
+            ),
+        }
+    };
+    let _ = stop_renewal.send(());
+    if let Err(error) = renewal_task.await {
+        eprintln!("source runtime lease renewal task failed after commit: {error}");
+    }
+    match lease_ledger.release_source_runtime_lease(&fence).await {
+        Ok(true) => {}
+        Ok(false) => {
+            eprintln!(
+                "source runtime lease changed before release; the successor lease was preserved"
+            )
+        }
+        Err(error) => eprintln!("source runtime lease release failed after commit: {error}"),
+    }
+    let receipt = outcome.map_err(|error| -> Box<dyn Error> { error.into() })?;
     println!("{}", serde_json::to_string_pretty(&receipt)?);
     Ok(())
+}
+
+fn source_runtime_lease_ttl_millis() -> Result<u64, Box<dyn Error>> {
+    let value = env::var("CEREBRO_SOURCE_LEASE_TTL_MS")
+        .ok()
+        .map(|value| value.parse())
+        .transpose()?
+        .unwrap_or(DEFAULT_SOURCE_RUNTIME_LEASE_TTL_MS);
+    if value == 0 {
+        return Err("CEREBRO_SOURCE_LEASE_TTL_MS must be positive".into());
+    }
+    Ok(value)
+}
+
+fn source_runtime_lease_owner() -> String {
+    env::var("CEREBRO_SOURCE_LEASE_OWNER")
+        .ok()
+        .filter(|owner| !owner.trim().is_empty())
+        .unwrap_or_else(|| {
+            format!(
+                "cerebro-rust-source:{}:{}",
+                std::process::id(),
+                OffsetDateTime::now_utc().unix_timestamp_nanos()
+            )
+        })
+}
+
+fn start_source_runtime_lease_renewal(
+    ledger: Arc<PostgresLedger>,
+    fence: SourceRuntimeLeaseFence,
+    ttl_millis: u64,
+) -> (
+    oneshot::Sender<()>,
+    oneshot::Receiver<String>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (stop_sender, mut stop_receiver) = oneshot::channel();
+    let (failure_sender, failure_receiver) = oneshot::channel();
+    let interval = Duration::from_millis(
+        (ttl_millis / 2).clamp(1, MAX_SOURCE_RUNTIME_LEASE_RENEWAL_INTERVAL_MS),
+    );
+    let task = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await;
+        loop {
+            tokio::select! {
+                _ = &mut stop_receiver => return,
+                _ = ticker.tick() => {
+                    match ledger.renew_source_runtime_lease(&fence, ttl_millis).await {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            let _ = failure_sender.send(
+                                "source runtime lease was lost during collection".to_owned(),
+                            );
+                            return;
+                        }
+                        Err(error) => {
+                            let _ = failure_sender.send(format!(
+                                "source runtime lease renewal failed: {error}"
+                            ));
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    });
+    (stop_sender, failure_receiver, task)
 }
 
 async fn connect_neo4j() -> Result<Neo4jProjector, Box<dyn Error>> {

--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -26,7 +26,9 @@ use std::{error::Error, fmt};
 use async_trait::async_trait;
 use cerebro_organizational_graph::GraphWriteReceipt;
 use cerebro_organizational_model::{GraphDelta, TenantId};
-use cerebro_source_runtime_next::{CollectedBatch, GraphSink};
+use cerebro_source_runtime_next::{
+    CollectedBatch, FencedGraphSink, GraphSink, SourceRuntimeLeaseFence,
+};
 
 #[derive(Debug)]
 pub enum StoreError {
@@ -133,18 +135,11 @@ impl DurableGraphStore {
         }
         Ok(Some(committed.receipt))
     }
-}
 
-#[async_trait]
-impl GraphSink for DurableGraphStore {
-    type Error = StoreError;
-
-    async fn apply(
-        &mut self,
-        batch: &CollectedBatch,
-        delta: GraphDelta,
-    ) -> Result<GraphWriteReceipt, Self::Error> {
-        let commit = self.ledger.commit(batch, &delta).await?;
+    async fn project_commit(
+        &self,
+        commit: postgres::StoredCommit,
+    ) -> Result<GraphWriteReceipt, StoreError> {
         if let Err(error) = self.projector.project_wire(&commit.projection).await {
             return Err(StoreError::ProjectionPending {
                 receipt: commit.receipt,
@@ -158,6 +153,33 @@ impl GraphSink for DurableGraphStore {
             )
             .await?;
         Ok(commit.receipt)
+    }
+}
+
+#[async_trait]
+impl GraphSink for DurableGraphStore {
+    type Error = StoreError;
+
+    async fn apply(
+        &mut self,
+        batch: &CollectedBatch,
+        delta: GraphDelta,
+    ) -> Result<GraphWriteReceipt, Self::Error> {
+        let commit = self.ledger.commit(batch, &delta).await?;
+        self.project_commit(commit).await
+    }
+}
+
+#[async_trait]
+impl FencedGraphSink for DurableGraphStore {
+    async fn apply_fenced(
+        &mut self,
+        batch: &CollectedBatch,
+        delta: GraphDelta,
+        fence: &SourceRuntimeLeaseFence,
+    ) -> Result<GraphWriteReceipt, Self::Error> {
+        let commit = self.ledger.commit_fenced(batch, &delta, fence).await?;
+        self.project_commit(commit).await
     }
 }
 

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -7,7 +7,7 @@ use cerebro_organizational_model::{
 };
 use cerebro_source_catalog::SourceCatalog;
 use cerebro_source_runtime_next::{
-    CollectedBatch, CommittedSourceEvent, IdentityResolutionSnapshot,
+    CollectedBatch, CommittedSourceEvent, IdentityResolutionSnapshot, SourceRuntimeLeaseFence,
 };
 use postgres_native_tls::MakeTlsConnector;
 use serde::{Deserialize, Serialize};
@@ -21,7 +21,20 @@ use crate::{
     ProjectionAuthorityRecord, ProjectionPromotionRequest,
 };
 
+const MAX_SOURCE_RUNTIME_LEASE_TTL_MILLIS: u64 = 24 * 60 * 60 * 1_000;
+
 pub const POSTGRES_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS source_runtimes (
+  id TEXT PRIMARY KEY,
+  runtime_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_owner TEXT;
+ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ;
+ALTER TABLE source_runtimes
+  ADD COLUMN IF NOT EXISTS lease_generation BIGINT NOT NULL DEFAULT 0
+  CHECK (lease_generation >= 0);
 CREATE TABLE IF NOT EXISTS organizational_graph_revisions (
   tenant_id TEXT PRIMARY KEY,
   revision BIGINT NOT NULL CHECK (revision >= 0)
@@ -511,6 +524,137 @@ impl PostgresLedger {
         Ok(())
     }
 
+    /// Acquire the shared source-runtime lease and return its durable fencing
+    /// generation. A missing runtime, tenant mismatch, or active competing
+    /// owner all return `None` without disclosing which condition matched.
+    pub async fn acquire_source_runtime_lease(
+        &self,
+        tenant_id: &TenantId,
+        source_runtime_id: &cerebro_organizational_model::SourceRuntimeId,
+        owner: &str,
+        ttl_millis: u64,
+    ) -> Result<Option<SourceRuntimeLeaseFence>, StoreError> {
+        validate_lease_request(owner, ttl_millis)?;
+        let ttl_millis = i64::try_from(ttl_millis)
+            .map_err(|_| StoreError::Conflict("source runtime lease TTL overflow".to_owned()))?;
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        let row = transaction
+            .query_opt(
+                r#"
+UPDATE source_runtimes
+SET lease_generation = CASE
+      WHEN lease_owner = $3
+       AND lease_expires_at > NOW()
+       AND lease_generation > 0
+      THEN lease_generation
+      ELSE lease_generation + 1
+    END,
+    lease_owner = $3,
+    lease_expires_at = NOW() + ($4::BIGINT * INTERVAL '1 millisecond'),
+    updated_at = NOW()
+WHERE id = $1
+  AND runtime_json->>'tenant_id' = $2
+  AND (
+    lease_expires_at IS NULL
+    OR lease_expires_at <= NOW()
+    OR lease_owner = $3
+  )
+RETURNING lease_generation
+"#,
+                &[
+                    &source_runtime_id.as_str(),
+                    &tenant_id.as_str(),
+                    &owner,
+                    &ttl_millis,
+                ],
+            )
+            .await?;
+        transaction.commit().await?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let generation = positive_generation(row.get(0))?;
+        Ok(Some(
+            SourceRuntimeLeaseFence::new(
+                tenant_id.clone(),
+                source_runtime_id.clone(),
+                owner,
+                generation,
+            )
+            .map_err(|message| StoreError::Conflict(message.to_owned()))?,
+        ))
+    }
+
+    /// Renew only the exact, still-live fencing generation.
+    pub async fn renew_source_runtime_lease(
+        &self,
+        fence: &SourceRuntimeLeaseFence,
+        ttl_millis: u64,
+    ) -> Result<bool, StoreError> {
+        validate_lease_request(fence.owner(), ttl_millis)?;
+        let generation = storage_generation(fence.generation())?;
+        let ttl_millis = i64::try_from(ttl_millis)
+            .map_err(|_| StoreError::Conflict("source runtime lease TTL overflow".to_owned()))?;
+        let changed = self
+            .client
+            .lock()
+            .await
+            .execute(
+                r#"
+UPDATE source_runtimes
+SET lease_expires_at = NOW() + ($5::BIGINT * INTERVAL '1 millisecond')
+WHERE id = $1
+  AND runtime_json->>'tenant_id' = $2
+  AND lease_owner = $3
+  AND lease_generation = $4
+  AND lease_expires_at > NOW()
+"#,
+                &[
+                    &fence.source_runtime_id().as_str(),
+                    &fence.tenant_id().as_str(),
+                    &fence.owner(),
+                    &generation,
+                    &ttl_millis,
+                ],
+            )
+            .await?;
+        Ok(changed == 1)
+    }
+
+    /// Release only the exact fencing generation. A stale worker cannot
+    /// release a successor's lease.
+    pub async fn release_source_runtime_lease(
+        &self,
+        fence: &SourceRuntimeLeaseFence,
+    ) -> Result<bool, StoreError> {
+        let generation = storage_generation(fence.generation())?;
+        let changed = self
+            .client
+            .lock()
+            .await
+            .execute(
+                r#"
+UPDATE source_runtimes
+SET lease_owner = NULL,
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND runtime_json->>'tenant_id' = $2
+  AND lease_owner = $3
+  AND lease_generation = $4
+"#,
+                &[
+                    &fence.source_runtime_id().as_str(),
+                    &fence.tenant_id().as_str(),
+                    &fence.owner(),
+                    &generation,
+                ],
+            )
+            .await?;
+        Ok(changed == 1)
+    }
+
     /// Records the rebuildable PostgreSQL receipt for one source event already
     /// committed to JetStream. Replays are idempotent; an event ID reused for
     /// different content fails closed.
@@ -954,10 +1098,39 @@ impl PostgresLedger {
         Ok(self.commit(batch, delta).await?.receipt)
     }
 
+    /// Commit current state under the exact source-runtime lease generation
+    /// without applying the rebuildable Neo4j projection.
+    pub async fn commit_pending_fenced(
+        &self,
+        batch: &CollectedBatch,
+        delta: &GraphDelta,
+        fence: &SourceRuntimeLeaseFence,
+    ) -> Result<GraphWriteReceipt, StoreError> {
+        Ok(self.commit_fenced(batch, delta, fence).await?.receipt)
+    }
+
     pub(crate) async fn commit(
         &self,
         batch: &CollectedBatch,
         delta: &GraphDelta,
+    ) -> Result<StoredCommit, StoreError> {
+        self.commit_with_fence(batch, delta, None).await
+    }
+
+    pub(crate) async fn commit_fenced(
+        &self,
+        batch: &CollectedBatch,
+        delta: &GraphDelta,
+        fence: &SourceRuntimeLeaseFence,
+    ) -> Result<StoredCommit, StoreError> {
+        self.commit_with_fence(batch, delta, Some(fence)).await
+    }
+
+    async fn commit_with_fence(
+        &self,
+        batch: &CollectedBatch,
+        delta: &GraphDelta,
+        fence: Option<&SourceRuntimeLeaseFence>,
     ) -> Result<StoredCommit, StoreError> {
         let tenant_id = delta.collection().tenant_id().as_str();
         if batch.scope.receipt() != delta.collection() {
@@ -970,6 +1143,9 @@ impl PostgresLedger {
         let mut client = self.client.lock().await;
         let transaction = client.transaction().await?;
         set_tenant(&transaction, tenant_id).await?;
+        if let Some(fence) = fence {
+            require_source_runtime_lease(&transaction, delta, fence).await?;
+        }
 
         if let Some(row) = transaction
             .query_opt(
@@ -1644,6 +1820,82 @@ fn enum_name<T: Serialize>(value: &T) -> Result<String, StoreError> {
     }
 }
 
+fn validate_lease_request(owner: &str, ttl_millis: u64) -> Result<(), StoreError> {
+    if owner.is_empty()
+        || owner.trim() != owner
+        || owner.len() > 255
+        || owner.chars().any(char::is_control)
+    {
+        return Err(StoreError::Conflict(
+            "source runtime lease owner is invalid".to_owned(),
+        ));
+    }
+    if ttl_millis == 0 || ttl_millis > MAX_SOURCE_RUNTIME_LEASE_TTL_MILLIS {
+        return Err(StoreError::Conflict(
+            "source runtime lease TTL is outside the supported range".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn positive_generation(value: i64) -> Result<u64, StoreError> {
+    let generation = u64::try_from(value).map_err(|_| {
+        StoreError::Conflict("source runtime lease generation is invalid".to_owned())
+    })?;
+    if generation == 0 {
+        return Err(StoreError::Conflict(
+            "source runtime lease generation is invalid".to_owned(),
+        ));
+    }
+    Ok(generation)
+}
+
+fn storage_generation(value: u64) -> Result<i64, StoreError> {
+    i64::try_from(value)
+        .map_err(|_| StoreError::Conflict("source runtime lease generation overflow".to_owned()))
+}
+
+async fn require_source_runtime_lease(
+    transaction: &tokio_postgres::Transaction<'_>,
+    delta: &GraphDelta,
+    fence: &SourceRuntimeLeaseFence,
+) -> Result<(), StoreError> {
+    if fence.tenant_id() != delta.collection().tenant_id()
+        || fence.source_runtime_id() != delta.collection().source_runtime_id()
+    {
+        return Err(StoreError::Conflict(
+            "source runtime lease does not match the collected scope".to_owned(),
+        ));
+    }
+    let generation = storage_generation(fence.generation())?;
+    let row = transaction
+        .query_opt(
+            r#"
+SELECT lease_owner, lease_generation, lease_expires_at > NOW()
+FROM source_runtimes
+WHERE id = $1
+  AND runtime_json->>'tenant_id' = $2
+FOR UPDATE
+"#,
+            &[
+                &fence.source_runtime_id().as_str(),
+                &fence.tenant_id().as_str(),
+            ],
+        )
+        .await?;
+    let valid = row.is_some_and(|row| {
+        row.get::<_, Option<String>>(0).as_deref() == Some(fence.owner())
+            && row.get::<_, i64>(1) == generation
+            && row.get::<_, Option<bool>>(2) == Some(true)
+    });
+    if !valid {
+        return Err(StoreError::Conflict(
+            "source runtime lease was lost before commit".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
 fn stored_count(row: &tokio_postgres::Row, index: usize, field: &str) -> Result<usize, StoreError> {
     let value: i64 = row.get(index);
     usize::try_from(value)
@@ -1661,6 +1913,8 @@ mod tests {
     #[test]
     fn schema_enforces_tenant_scope_identity_uniqueness_and_outbox() {
         for required in [
+            "CREATE TABLE IF NOT EXISTS source_runtimes",
+            "lease_generation BIGINT NOT NULL DEFAULT 0",
             "FORCE ROW LEVEL SECURITY",
             "PRIMARY KEY (tenant_id, provider_identity_id)",
             "PRIMARY KEY (tenant_id, claim_kind, claim_value)",

--- a/crates/organizational-store/tests/source_runtime_lease_postgres.rs
+++ b/crates/organizational-store/tests/source_runtime_lease_postgres.rs
@@ -1,0 +1,130 @@
+use std::{collections::BTreeMap, env, error::Error};
+
+use cerebro_organizational_model::{
+    CollectionId, CompleteCollection, Entity, EntityId, EntityKind, ObservationId, SourceRuntimeId,
+    TenantId,
+};
+use cerebro_organizational_store::{PostgresLedger, StoreError};
+use cerebro_source_runtime_next::{CollectedBatch, CollectedScope, SourceRecord};
+use tokio_postgres::NoTls;
+
+#[tokio::test]
+#[ignore = "requires disposable PostgreSQL"]
+async fn source_runtime_lease_generation_fences_stale_and_cross_tenant_commits()
+-> Result<(), Box<dyn Error>> {
+    let dsn = env::var("CEREBRO_TEST_POSTGRES_DSN")?;
+    let (admin, admin_connection) = tokio_postgres::connect(&dsn, NoTls).await?;
+    tokio::spawn(async move {
+        admin_connection.await.expect("PostgreSQL admin connection");
+    });
+    let (client, connection) = tokio_postgres::connect(&dsn, NoTls).await?;
+    tokio::spawn(async move {
+        connection.await.expect("PostgreSQL ledger connection");
+    });
+    let ledger = PostgresLedger::from_client(client);
+    ledger.migrate().await?;
+
+    let suffix = std::process::id();
+    let tenant = TenantId::parse(format!("tenant-rust-lease-{suffix}"))?;
+    let other_tenant = TenantId::parse(format!("tenant-rust-lease-other-{suffix}"))?;
+    let runtime = SourceRuntimeId::parse(format!("runtime-rust-lease-{suffix}"))?;
+    admin
+        .execute(
+            "INSERT INTO source_runtimes (id, runtime_json) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET runtime_json = EXCLUDED.runtime_json, lease_owner = NULL, lease_expires_at = NULL, lease_generation = 0",
+            &[
+                &runtime.as_str(),
+                &serde_json::json!({
+                    "id": runtime.as_str(),
+                    "tenant_id": tenant.as_str(),
+                    "source_id": "fixture"
+                }),
+            ],
+        )
+        .await?;
+
+    assert!(
+        ledger
+            .acquire_source_runtime_lease(&other_tenant, &runtime, "worker:wrong-tenant", 60_000)
+            .await?
+            .is_none()
+    );
+    let first = ledger
+        .acquire_source_runtime_lease(&tenant, &runtime, "worker:one", 60_000)
+        .await?
+        .expect("first lease");
+    let replay = ledger
+        .acquire_source_runtime_lease(&tenant, &runtime, "worker:one", 60_000)
+        .await?
+        .expect("same owner reacquires its lease");
+    assert_eq!(replay.generation(), first.generation());
+    assert!(
+        ledger
+            .acquire_source_runtime_lease(&tenant, &runtime, "worker:two", 60_000)
+            .await?
+            .is_none()
+    );
+    assert!(ledger.renew_source_runtime_lease(&first, 60_000).await?);
+
+    admin
+        .execute(
+            "UPDATE source_runtimes SET lease_expires_at = NOW() - INTERVAL '1 second' WHERE id = $1",
+            &[&runtime.as_str()],
+        )
+        .await?;
+    assert!(!ledger.renew_source_runtime_lease(&first, 60_000).await?);
+    let successor = ledger
+        .acquire_source_runtime_lease(&tenant, &runtime, "worker:two", 60_000)
+        .await?
+        .expect("successor lease");
+    assert!(successor.generation() > first.generation());
+
+    let collection = CompleteCollection::new(
+        tenant.clone(),
+        runtime.clone(),
+        CollectionId::parse(format!("collection-rust-lease-{suffix}"))?,
+        "fixture.resources",
+        10,
+    )?;
+    let observation_id = ObservationId::parse(format!("observation-rust-lease-{suffix}"))?;
+    let entity = Entity::canonical(
+        tenant.clone(),
+        EntityId::parse(format!("resource-rust-lease-{suffix}"))?,
+        EntityKind::Resource,
+        "Fenced resource",
+    )?;
+    let mut builder = collection.clone().begin_delta();
+    builder.add_entity(entity)?;
+    let delta = builder.build();
+    let batch = CollectedBatch {
+        scope: CollectedScope::Complete(collection),
+        records: vec![SourceRecord {
+            observation_id,
+            family: "resources".to_owned(),
+            provider_kind: "fixture.resource".to_owned(),
+            provider_id: format!("provider-resource-{suffix}"),
+            fields: BTreeMap::new(),
+            payload: serde_json::json!({"id": format!("provider-resource-{suffix}")}),
+        }],
+        next_cursor: None,
+    };
+
+    assert!(matches!(
+        ledger.commit_pending_fenced(&batch, &delta, &first).await,
+        Err(StoreError::Conflict(message))
+            if message == "source runtime lease was lost before commit"
+    ));
+    let receipt = ledger
+        .commit_pending_fenced(&batch, &delta, &successor)
+        .await?;
+    assert_eq!(receipt.tenant_id, tenant);
+    assert!(!ledger.release_source_runtime_lease(&first).await?);
+    assert!(ledger.release_source_runtime_lease(&successor).await?);
+    assert!(matches!(
+        ledger
+            .commit_pending_fenced(&batch, &delta, &successor)
+            .await,
+        Err(StoreError::Conflict(message))
+            if message == "source runtime lease was lost before commit"
+    ));
+    Ok(())
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -26,6 +26,63 @@ pub struct CollectionRequest {
     pub cursor: Option<String>,
 }
 
+/// A durable database fence for one source-runtime execution.
+///
+/// The generation changes whenever lease ownership changes. A provider result
+/// may commit only while the exact tenant, runtime, owner, and generation still
+/// hold the source-runtime row. The database remains the authority; this value
+/// contains no credential material.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceRuntimeLeaseFence {
+    tenant_id: TenantId,
+    source_runtime_id: SourceRuntimeId,
+    owner: String,
+    generation: u64,
+}
+
+impl SourceRuntimeLeaseFence {
+    pub fn new(
+        tenant_id: TenantId,
+        source_runtime_id: SourceRuntimeId,
+        owner: impl Into<String>,
+        generation: u64,
+    ) -> Result<Self, &'static str> {
+        let owner = owner.into();
+        if owner.is_empty()
+            || owner.trim() != owner
+            || owner.len() > 255
+            || owner.chars().any(char::is_control)
+        {
+            return Err("source runtime lease owner is invalid");
+        }
+        if generation == 0 {
+            return Err("source runtime lease generation must be positive");
+        }
+        Ok(Self {
+            tenant_id,
+            source_runtime_id,
+            owner,
+            generation,
+        })
+    }
+
+    pub fn tenant_id(&self) -> &TenantId {
+        &self.tenant_id
+    }
+
+    pub fn source_runtime_id(&self) -> &SourceRuntimeId {
+        &self.source_runtime_id
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct SourceRecord {
     pub observation_id: ObservationId,
@@ -82,6 +139,17 @@ pub trait GraphSink: Send {
         &mut self,
         batch: &CollectedBatch,
         delta: GraphDelta,
+    ) -> Result<GraphWriteReceipt, Self::Error>;
+}
+
+#[async_trait]
+pub trait FencedGraphSink: GraphSink {
+    /// Commit only while the exact durable source-runtime lease still exists.
+    async fn apply_fenced(
+        &mut self,
+        batch: &CollectedBatch,
+        delta: GraphDelta,
+        fence: &SourceRuntimeLeaseFence,
     ) -> Result<GraphWriteReceipt, Self::Error>;
 }
 
@@ -187,6 +255,47 @@ where
             .map_err(RuntimeError::Store)
     }
 
+    /// Collect and commit under one database-checked source-runtime lease.
+    ///
+    /// The fence is checked before provider I/O and again inside the durable
+    /// graph transaction. Losing the lease therefore prevents a stale worker
+    /// from committing provider results after another worker takes ownership.
+    pub async fn sync_fenced(
+        &mut self,
+        request: CollectionRequest,
+        fence: &SourceRuntimeLeaseFence,
+    ) -> Result<GraphWriteReceipt, SyncError<Connector, Mapper, Store>>
+    where
+        Store: FencedGraphSink,
+    {
+        let requested_tenant = request.tenant_id.clone();
+        let requested_runtime = request.source_runtime_id.clone();
+        if fence.tenant_id() != &requested_tenant || fence.source_runtime_id() != &requested_runtime
+        {
+            return Err(RuntimeError::ScopeMismatch);
+        }
+        let batch = self
+            .connector
+            .collect(request)
+            .await
+            .map_err(RuntimeError::Collect)?;
+        if batch.scope.receipt().tenant_id() != &requested_tenant
+            || batch.scope.receipt().source_runtime_id() != &requested_runtime
+        {
+            return Err(RuntimeError::ScopeMismatch);
+        }
+        let delta = self.mapper.map(&batch).map_err(RuntimeError::Map)?;
+        if delta.collection().tenant_id() != &requested_tenant
+            || delta.collection().source_runtime_id() != &requested_runtime
+        {
+            return Err(RuntimeError::ScopeMismatch);
+        }
+        self.store
+            .apply_fenced(&batch, delta, fence)
+            .await
+            .map_err(RuntimeError::Store)
+    }
+
     pub fn into_store(self) -> Store {
         self.store
     }
@@ -194,7 +303,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{convert::Infallible, error::Error};
+    use std::{
+        convert::Infallible,
+        error::Error,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use cerebro_organizational_model::{
         CollectionId, Entity, EntityId, EntityKind, GraphAssertion, ModelError, ObservationId,
@@ -269,6 +385,94 @@ mod tests {
             builder.add_assertion(GraphAssertion::Relationship(assertion))?;
             Ok(builder.build())
         }
+    }
+
+    struct CountingSource(Arc<AtomicUsize>);
+
+    #[async_trait]
+    impl SourceConnector for CountingSource {
+        type Error = Infallible;
+
+        async fn collect(
+            &mut self,
+            request: CollectionRequest,
+        ) -> Result<CollectedBatch, Self::Error> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            let mut source = FixtureSource;
+            source.collect(request).await
+        }
+    }
+
+    struct FencedFixtureStore;
+
+    #[async_trait]
+    impl GraphSink for FencedFixtureStore {
+        type Error = Infallible;
+
+        async fn apply(
+            &mut self,
+            _batch: &CollectedBatch,
+            _delta: GraphDelta,
+        ) -> Result<GraphWriteReceipt, Self::Error> {
+            unreachable!("scope mismatch must fail before the store")
+        }
+    }
+
+    #[async_trait]
+    impl FencedGraphSink for FencedFixtureStore {
+        async fn apply_fenced(
+            &mut self,
+            _batch: &CollectedBatch,
+            _delta: GraphDelta,
+            _fence: &SourceRuntimeLeaseFence,
+        ) -> Result<GraphWriteReceipt, Self::Error> {
+            unreachable!("scope mismatch must fail before the store")
+        }
+    }
+
+    #[test]
+    fn source_runtime_lease_fence_rejects_unbounded_identity() {
+        let tenant = TenantId::parse("tenant-a").unwrap();
+        let runtime = SourceRuntimeId::parse("runtime-a").unwrap();
+        assert!(SourceRuntimeLeaseFence::new(tenant.clone(), runtime.clone(), "", 1).is_err());
+        assert!(
+            SourceRuntimeLeaseFence::new(tenant.clone(), runtime.clone(), " owner", 1).is_err()
+        );
+        assert!(SourceRuntimeLeaseFence::new(tenant.clone(), runtime.clone(), "owner", 0).is_err());
+        assert_eq!(
+            SourceRuntimeLeaseFence::new(tenant, runtime, "worker:one", 7)
+                .unwrap()
+                .generation(),
+            7
+        );
+    }
+
+    #[tokio::test]
+    async fn mismatched_lease_fence_fails_before_provider_collection() {
+        let collections = Arc::new(AtomicUsize::new(0));
+        let mut runtime = SourceRuntime::new(
+            CountingSource(collections.clone()),
+            FixtureMapper,
+            FencedFixtureStore,
+        );
+        let result = runtime
+            .sync_fenced(
+                CollectionRequest {
+                    tenant_id: TenantId::parse("tenant-a").unwrap(),
+                    source_runtime_id: SourceRuntimeId::parse("runtime-a").unwrap(),
+                    cursor: None,
+                },
+                &SourceRuntimeLeaseFence::new(
+                    TenantId::parse("tenant-b").unwrap(),
+                    SourceRuntimeId::parse("runtime-a").unwrap(),
+                    "worker:one",
+                    1,
+                )
+                .unwrap(),
+            )
+            .await;
+        assert!(matches!(result, Err(RuntimeError::ScopeMismatch)));
+        assert_eq!(collections.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -49,6 +49,16 @@ cerebro-source-catalog --> cerebro-source-runtime-next
 
 During migration, the Go source runtime may still collect legacy families and publish their events, but it cannot submit an event payload to the Rust projector. The Rust runtime consumes committed events directly from JetStream. Go asks Rust only for the persisted family authority: a legacy family returns to the Go projector and records a bounded compatibility delta, while a Rust-authoritative family returns no Go projection result and is committed only by the Rust consumer. Replay, refetch, device, CLI, and orchestrator paths use the same authority check, so an alternate Go entry point cannot restore a retired writer. The remaining projection HTTP routes accept legacy parity deltas, collection manifests, and authority reads; they do not provide a Rust-authoritative event write path.
 
+The Rust-native provider sync also requires the stored source runtime's durable
+lease before it makes a provider request. Go and Rust advance the same
+`lease_generation` whenever ownership changes. The Rust PostgreSQL graph
+transaction locks that runtime row and verifies the exact tenant, runtime,
+owner, unexpired lease, and generation before committing a collected batch.
+Renewal loss cancels collection, and a stale worker cannot commit or release a
+successor's lease. This fences the Rust collection write path; stored runtime
+configuration, secret-reference resolution, cursor/checkpoint persistence, and
+legacy-family execution still need separate Rust ownership work.
+
 `cerebro-agent-context` exposes bounded search, lookup, expansion, path, and explanation operations. It does not expose Cypher or store mutation.
 
 `cerebro-platform` serves the bounded agent graph API against Neo4j in production and the in-memory graph in local demos. Web, Slack, MCP, reports, and the graph agent use this API as the authority for bounded neighborhood reads. One-hop requests, including batches of up to 100 roots, execute as one tenant-scoped Neo4j query. Go deployments can omit the graph store and every Neo4j credential once their callers use typed Rust operations. Any remaining raw Cypher caller then fails with `typed Rust graph operation required`; it cannot fall back to another graph reader. Raw Cypher is not exposed by the Rust API.

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -22,6 +22,7 @@ var ensureSourceRuntimeStatements = []string{`CREATE TABLE IF NOT EXISTS source_
 )`,
 	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_owner TEXT`,
 	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ`,
+	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_generation BIGINT NOT NULL DEFAULT 0 CHECK (lease_generation >= 0)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), updated_at ASC, id ASC)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_source_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), (runtime_json->>'source_id'), updated_at ASC, id ASC)`,
 }
@@ -200,7 +201,14 @@ func (s *Store) AcquireSourceRuntimeLease(ctx context.Context, runtimeID string,
 	}
 	result, err := s.db.ExecContext(ctx, `
 UPDATE source_runtimes
-SET lease_owner = $2,
+SET lease_generation = CASE
+      WHEN lease_owner = $2
+       AND lease_expires_at > NOW()
+       AND lease_generation > 0
+      THEN lease_generation
+      ELSE lease_generation + 1
+    END,
+    lease_owner = $2,
     lease_expires_at = NOW() + $3::interval,
     updated_at = NOW()
 WHERE id = $1
@@ -229,7 +237,8 @@ func (s *Store) RenewSourceRuntimeLease(ctx context.Context, runtimeID string, o
 UPDATE source_runtimes
 SET lease_expires_at = NOW() + $3::interval
 WHERE id = $1
-  AND lease_owner = $2`, id, leaseOwner, sourceRuntimeLeaseInterval(ttl))
+  AND lease_owner = $2
+  AND lease_expires_at > NOW()`, id, leaseOwner, sourceRuntimeLeaseInterval(ttl))
 	if err != nil {
 		return false, fmt.Errorf("renew source runtime lease %q: %w", id, err)
 	}

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -68,6 +68,7 @@ func TestSourceRuntimeListOrderRotatesRecentlyUpdatedRows(t *testing.T) {
 func TestSourceRuntimeSchemaIndexesDashboardFilters(t *testing.T) {
 	joined := strings.Join(ensureSourceRuntimeStatements, "\n")
 	for _, fragment := range []string{
+		"lease_generation BIGINT NOT NULL DEFAULT 0",
 		"source_runtimes_tenant_updated_idx",
 		"CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_updated_idx",
 		"(runtime_json->>'tenant_id'), updated_at ASC, id ASC",


### PR DESCRIPTION
## Summary
- coordinate Rust source collection with the durable source-runtime lease
- fence PostgreSQL graph commits by tenant, runtime, owner, generation, and expiry
- advance the shared generation from compatibility lease writers during migration
- add stale-worker, cross-tenant, renewal, and disposable PostgreSQL coverage

## Verification
- `cargo test --locked -p cerebro-source-runtime-next -p cerebro-organizational-store -p cerebro-platform --no-fail-fast`
- `cargo clippy --locked -p cerebro-source-runtime-next -p cerebro-organizational-store -p cerebro-platform --all-targets -- -D warnings`
- `go test ./internal/statestore/postgres ./internal/sourceruntime -count=1`
- `make check-structural check-structural-test check-arch`
- `make contracts-check`
- `make rust-doc-check`
- `make rust-deny`
- disposable PostgreSQL lease-fencing integration test
