### PR TITLE
Commit Rust source runtime progress atomically

### DIFF
--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -823,7 +823,7 @@ WHERE id = $1
   AND runtime_json->>'tenant_id' = $2
   AND lease_owner = $3
   AND lease_generation = $4
-  AND lease_expires_at > NOW()
+  AND lease_expires_at > clock_timestamp()
 "#,
                 &[
                     &fence.source_runtime_id().as_str(),
@@ -1354,6 +1354,9 @@ WHERE id = $1
             ));
         }
         validate_observations(batch, delta)?;
+        if fence.is_some() {
+            validate_source_runtime_cursor(batch.next_cursor.as_deref())?;
+        }
 
         let mut client = self.client.lock().await;
         let transaction = client.transaction().await?;
@@ -1535,6 +1538,9 @@ WHERE id = $1
                 &[&tenant_id, &revision],
             )
             .await?;
+        if let Some(fence) = fence {
+            advance_source_runtime_progress(&transaction, batch, fence).await?;
+        }
         transaction.commit().await?;
         Ok(StoredCommit {
             receipt,
@@ -2194,7 +2200,7 @@ async fn require_source_runtime_lease(
     let row = transaction
         .query_opt(
             r#"
-SELECT lease_owner, lease_generation, lease_expires_at > NOW()
+SELECT lease_owner, lease_generation, lease_expires_at > clock_timestamp()
 FROM source_runtimes
 WHERE id = $1
   AND runtime_json->>'tenant_id' = $2
@@ -2214,6 +2220,95 @@ FOR UPDATE
     if !valid {
         return Err(StoreError::Conflict(
             "source runtime lease was lost before commit".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_source_runtime_cursor(cursor: Option<&str>) -> Result<(), StoreError> {
+    if cursor.is_some_and(|cursor| cursor.trim().is_empty() || cursor.len() > 64 * 1024) {
+        return Err(StoreError::Conflict(
+            "source runtime continuation cursor is invalid".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+async fn advance_source_runtime_progress(
+    transaction: &tokio_postgres::Transaction<'_>,
+    batch: &CollectedBatch,
+    fence: &SourceRuntimeLeaseFence,
+) -> Result<(), StoreError> {
+    let generation = storage_generation(fence.generation())?;
+    let next_cursor = batch
+        .next_cursor
+        .as_ref()
+        .map(|cursor| serde_json::json!({"opaque": cursor}));
+    let checkpoint_row = transaction
+        .query_opt(
+            "SELECT runtime_json->'checkpoint'->>'cursor_opaque'
+             FROM source_runtimes
+             WHERE id = $1 AND runtime_json->>'tenant_id' = $2",
+            &[
+                &fence.source_runtime_id().as_str(),
+                &fence.tenant_id().as_str(),
+            ],
+        )
+        .await?;
+    let Some(checkpoint_row) = checkpoint_row else {
+        return Err(StoreError::Conflict(
+            "source runtime was removed before progress commit".to_owned(),
+        ));
+    };
+    let checkpoint_cursor: Option<String> = checkpoint_row.get(0);
+    let clear_checkpoint_cursor = next_cursor.is_none()
+        && checkpoint_cursor
+            .as_deref()
+            .is_some_and(resumable_checkpoint_cursor);
+    let updated = transaction
+        .execute(
+            r#"
+UPDATE source_runtimes
+SET runtime_json = jsonb_set(
+      CASE
+        WHEN $5::jsonb IS NULL THEN
+          CASE
+            WHEN $6::BOOLEAN
+              AND jsonb_typeof(runtime_json->'checkpoint') = 'object' THEN
+              jsonb_set(
+                runtime_json - 'next_cursor',
+                '{checkpoint,cursor_opaque}',
+                '""'::jsonb,
+                TRUE
+              )
+            ELSE runtime_json - 'next_cursor'
+          END
+        ELSE jsonb_set(runtime_json, '{next_cursor}', $5::jsonb, TRUE)
+      END,
+      '{last_synced_at}',
+      to_jsonb(clock_timestamp()),
+      TRUE
+    ),
+    updated_at = clock_timestamp()
+WHERE id = $1
+  AND runtime_json->>'tenant_id' = $2
+  AND lease_owner = $3
+  AND lease_generation = $4
+  AND lease_expires_at > clock_timestamp()
+"#,
+            &[
+                &fence.source_runtime_id().as_str(),
+                &fence.tenant_id().as_str(),
+                &fence.owner(),
+                &generation,
+                &next_cursor,
+                &clear_checkpoint_cursor,
+            ],
+        )
+        .await?;
+    if updated != 1 {
+        return Err(StoreError::Conflict(
+            "source runtime lease was lost before progress commit".to_owned(),
         ));
     }
     Ok(())

--- a/crates/organizational-store/tests/source_runtime_lease_postgres.rs
+++ b/crates/organizational-store/tests/source_runtime_lease_postgres.rs
@@ -42,6 +42,10 @@ async fn source_runtime_lease_generation_fences_stale_and_cross_tenant_commits()
                         "base_url": "https://provider.example.test",
                         "token": "env:CEREBRO_SOURCE_FIXTURE_TOKEN"
                     },
+                    "checkpoint": {
+                        "watermark": "2026-07-28T00:00:00Z",
+                        "cursor_opaque": "{\"token\":\"page:1\",\"resumable_checkpoint\":true}"
+                    },
                     "next_cursor": {"opaque": "page:2"}
                 }),
             ],
@@ -234,10 +238,52 @@ async fn source_runtime_lease_generation_fences_stale_and_cross_tenant_commits()
         Err(StoreError::Conflict(message))
             if message == "source runtime lease was lost before commit"
     ));
+    let stale_progress: serde_json::Value = admin
+        .query_one(
+            "SELECT runtime_json FROM source_runtimes WHERE id = $1",
+            &[&runtime.as_str()],
+        )
+        .await?
+        .get(0);
+    assert_eq!(
+        stale_progress
+            .pointer("/next_cursor/opaque")
+            .and_then(serde_json::Value::as_str),
+        Some("page:2")
+    );
+    assert!(stale_progress.get("last_synced_at").is_none());
+
     let receipt = ledger
         .commit_pending_fenced(&batch, &delta, &successor)
         .await?;
     assert_eq!(receipt.tenant_id, tenant);
+    let committed_progress: serde_json::Value = admin
+        .query_one(
+            "SELECT runtime_json FROM source_runtimes WHERE id = $1",
+            &[&runtime.as_str()],
+        )
+        .await?
+        .get(0);
+    assert!(committed_progress.get("next_cursor").is_none());
+    assert_eq!(
+        committed_progress
+            .pointer("/checkpoint/cursor_opaque")
+            .and_then(serde_json::Value::as_str),
+        Some("")
+    );
+    assert_eq!(
+        committed_progress
+            .pointer("/checkpoint/watermark")
+            .and_then(serde_json::Value::as_str),
+        Some("2026-07-28T00:00:00Z")
+    );
+    assert!(
+        committed_progress
+            .get("last_synced_at")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|timestamp| timestamp.contains('T'))
+    );
+
     assert!(!ledger.release_source_runtime_lease(&first).await?);
     assert!(ledger.release_source_runtime_lease(&successor).await?);
     assert!(matches!(
@@ -247,5 +293,13 @@ async fn source_runtime_lease_generation_fences_stale_and_cross_tenant_commits()
         Err(StoreError::Conflict(message))
             if message == "source runtime lease was lost before commit"
     ));
+    let after_rejected_replay: serde_json::Value = admin
+        .query_one(
+            "SELECT runtime_json FROM source_runtimes WHERE id = $1",
+            &[&runtime.as_str()],
+        )
+        .await?
+        .get(0);
+    assert_eq!(after_rejected_replay, committed_progress);
     Ok(())
 }

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -54,17 +54,20 @@ lease before it makes a provider request. Go and Rust advance the same
 `lease_generation` whenever ownership changes. The Rust PostgreSQL graph
 transaction locks that runtime row and verifies the exact tenant, runtime,
 owner, unexpired lease, and generation before committing a collected batch.
-Renewal loss cancels collection, and a stale worker cannot commit or release a
-successor's lease. Rust loads the runtime's tenant, source, family, base URL,
-cursor, and config from the shared PostgreSQL runtime record instead of
-accepting parallel process arguments. Canonical and explicitly allowlisted
+Graph state, the projection outbox, terminal continuation cleanup, terminal
+resumable-checkpoint token cleanup, and `last_synced_at` advance in that same
+transaction.
+Renewal loss cancels collection, and a stale worker cannot commit progress or
+release a successor's lease. Rust loads the runtime's tenant, source, family,
+base URL, cursor, and config from the shared PostgreSQL runtime record instead
+of accepting parallel process arguments. Canonical and explicitly allowlisted
 `env:` references resolve in Rust without a Go fallback. Rust resolves
 `credential:` references directly from the shared connector vault with exact
 tenant, source, runtime, status, key, and authenticated-envelope checks.
 Successful use commits the existing throttled usage receipt without exposing
-credential material. Native secret-store references, cursor/checkpoint
-persistence, and legacy-family execution still need separate Rust ownership
-work.
+credential material. Native secret-store references, provider-specific
+checkpoint contents, and legacy-family execution still need separate Rust
+ownership work.
 
 API-key collection authority also requires an explicit checked-in header and
 scheme contract. A provider proof manifest does not make a source


### PR DESCRIPTION
## Summary
- commit graph state, projection outbox state, and source-runtime progress in one fenced PostgreSQL transaction
- remove a drained continuation cursor and only clear a resumable checkpoint token while preserving its watermark
- reject empty or oversized continuation cursors and use wall-clock lease expiry at commit time
- prove stale generations and released leases cannot change runtime progress

## Verification
- `cargo test --locked -p cerebro-organizational-store --no-fail-fast`
- `cargo clippy --locked -p cerebro-organizational-store --all-targets -- -D warnings`
- `make check-structural check-structural-test check-arch`
- `make rust-doc-check`
- disposable PostgreSQL stale-generation, successor-commit, cursor cleanup, checkpoint preservation, and released-lease replay test

Depends on #2131.