### PR TITLE
Bind scoped source paths in Rust

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1222,6 +1222,8 @@ mod tests {
             "akeneo",
             "apacta",
             "appwrite",
+            "airtable",
+            "anchore",
             "azure_openai",
             "beezup",
             "box",
@@ -1240,13 +1242,6 @@ mod tests {
                 "{source_id} has verified parameterized provider paths"
             );
         }
-        for source_id in ["airtable", "anchore"] {
-            assert_eq!(
-                catalog.get(source_id).unwrap().authority(),
-                CollectionAuthority::ShadowOnly,
-                "{source_id} has an unresolved request scope"
-            );
-        }
         for source_id in ["airbrake", "akeyless", "alchemer"] {
             assert_eq!(
                 catalog.get(source_id).unwrap().authority(),
@@ -1258,6 +1253,49 @@ mod tests {
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly
         );
+    }
+
+    #[test]
+    fn scoped_provider_paths_bind_only_declared_runtime_config() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+
+        let airtable = catalog.get("airtable").unwrap();
+        assert_eq!(airtable.authority(), CollectionAuthority::Authoritative);
+        for family_id in ["users", "audit_events"] {
+            let family = airtable
+                .families()
+                .iter()
+                .find(|family| family.id() == family_id)
+                .unwrap();
+            assert_eq!(
+                family.path_parameters().get("enterprise_account_id"),
+                Some(&PathParameterBinding::ScalarConfig {
+                    field: "enterprise_account_id".to_owned()
+                })
+            );
+        }
+
+        let anchore = catalog.get("anchore").unwrap();
+        assert_eq!(anchore.authority(), CollectionAuthority::Authoritative);
+        for family in anchore.families() {
+            assert_eq!(
+                family.path_parameters().get("app_id"),
+                Some(&PathParameterBinding::ScalarConfig {
+                    field: "app_id".to_owned()
+                })
+            );
+            assert_eq!(
+                family.path_parameters().get("version_id"),
+                Some(&PathParameterBinding::ScalarConfig {
+                    field: "version_id".to_owned()
+                })
+            );
+        }
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1430,6 +1430,71 @@ mod tests {
     }
 
     #[test]
+    fn promoted_source_paths_require_and_encode_exact_runtime_scope() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+
+        let missing_airtable_scope = HttpSourceConnector::new(
+            catalog.get("airtable").unwrap().clone(),
+            "users",
+            "https://api.airtable.com",
+            BTreeMap::new(),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap()
+        .request_scopes()
+        .err()
+        .unwrap();
+        assert!(matches!(
+            missing_airtable_scope,
+            HttpConnectorError::InvalidConfiguration(_)
+        ));
+
+        let airtable = HttpSourceConnector::new(
+            catalog.get("airtable").unwrap().clone(),
+            "audit_events",
+            "https://api.airtable.com",
+            BTreeMap::from([(
+                "enterprise_account_id".to_owned(),
+                "../other?scope=expanded#fragment".to_owned(),
+            )]),
+            ResolvedAuth::Bearer {
+                token: "token".to_owned(),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            airtable.request_scopes().unwrap()[0].url.as_str(),
+            "https://api.airtable.com/v0/meta/enterpriseAccounts/%2E%2E%2Fother%3Fscope%3Dexpanded%23fragment/auditLogEvents"
+        );
+
+        let anchore = HttpSourceConnector::new(
+            catalog.get("anchore").unwrap().clone(),
+            "vulnerabilities",
+            "https://anchore.example/v2",
+            BTreeMap::from([
+                ("app_id".to_owned(), "orders/api".to_owned()),
+                ("version_id".to_owned(), "../production".to_owned()),
+            ]),
+            ResolvedAuth::Basic {
+                username: "runtime-user".to_owned(),
+                password: "runtime-password".to_owned(),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            anchore.request_scopes().unwrap()[0].url.as_str(),
+            "https://anchore.example/v2/apps/orders%2Fapi/versions/%2E%2E%2Fproduction/vulnerabilities"
+        );
+    }
+
+    #[test]
     fn only_cursor_pagination_accepts_a_collection_cursor() {
         let requested = Some("resume-here");
         let cursor = Pagination::Cursor {

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -240,7 +240,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 46 sources and 328 families are authoritative; the other 748 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 45 sources and 314 families are authoritative; the other 749 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/collaboration-productivity/airtable.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/airtable.yaml
@@ -10,6 +10,11 @@ entries:
       categories:
         - saas
         - collaboration
+      config_fields:
+        - help: Enterprise account ID used to scope user and audit-log requests.
+          key: enterprise_account_id
+          label: Enterprise account ID
+          required: true
       description: Collects enterprise users, bases, and audit log events from Airtable and maps them into the Cerebro graph as users, assets, and audit events for workspace, base, and collaboration context.
       display_name: Airtable
       id: builtin-airtable
@@ -36,7 +41,7 @@ entries:
           id_field: id
           label: Users
           method: GET
-          path: /v0/meta/enterpriseAccounts/{enterpriseAccountId}/users
+          path: /v0/meta/enterpriseAccounts/${config.enterprise_account_id}/users
           projection:
             fields:
               email: email|primary_email|profile.email
@@ -106,7 +111,7 @@ entries:
             page_size: 100
             page_size_param: pageSize
             type: cursor
-          path: /v0/meta/enterpriseAccounts/{enterpriseAccountId}/auditLogEvents
+          path: /v0/meta/enterpriseAccounts/${config.enterprise_account_id}/auditLogEvents
           projection:
             fields:
               actor_email: actor.user.email

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/anchore.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/anchore.yaml
@@ -12,6 +12,19 @@ entries:
       categories:
         - security
         - containers
+      config_fields:
+        - help: Anchore Enterprise host used as the provider API origin.
+          key: enterprise_url
+          label: Enterprise host
+          required: true
+        - help: Application ID used to scope application-version requests.
+          key: app_id
+          label: Application ID
+          required: true
+        - help: Application version ID used to scope asset, finding, and vulnerability requests.
+          key: version_id
+          label: Version ID
+          required: true
       description: Collects assets, findings, and vulnerabilities from Anchore and projects them into the Cerebro graph as assets, findings, and vulnerabilities for asset exposure, vulnerability, finding, and remediation context.
       display_name: Anchore
       id: builtin-anchore


### PR DESCRIPTION
## What changed

- bind Airtable enterprise-account requests to the stored `enterprise_account_id`
- bind Anchore asset, finding, and vulnerability requests to stored `app_id` and `version_id` values
- encode every configured path segment so scope values cannot alter the provider origin, query, or fragment
- fail before any provider request when a required scope value is missing
- promote Airtable and Anchore only after every provider-proven family has a resolvable Rust request path
- update the compiler-backed coverage total to 45 authoritative sources and 314 authoritative families

## Verification

- `cargo test -p cerebro-source-catalog -- --nocapture`
- `cargo test -p cerebro-source-runtime-next promoted_source_paths_require_and_encode_exact_runtime_scope -- --nocapture`
- `cargo clippy -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `make sourcegen-check`
- `go test ./internal/connectordefinitions ./internal/sourcegen ./internal/connectorcatalog -count=1`
- `make check-structural check-arch docs-drift-check rust-doc-check`

## Authority boundary

This moves six Airtable and Anchore families under full Rust source authority. Other sources remain shadow-only until their provider proof, request scope, auth mechanics, and mapper requirements are complete.