### PR TITLE
Resolve query-authenticated sources in Rust

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -1491,6 +1491,7 @@ async fn sync_source() -> Result<(), Box<dyn Error>> {
         source.auth(),
         source.token_header(),
         source.token_scheme(),
+        source.auth_query_parameters(),
         &mut config,
     )?;
     let connector = HttpSourceConnector::new(source.clone(), &family_id, &base_url, config, auth)?;
@@ -1646,6 +1647,7 @@ fn resolved_auth(
     model: &AuthModel,
     token_header: &str,
     token_scheme: &str,
+    query_parameters: &BTreeMap<String, String>,
     config: &mut BTreeMap<String, String>,
 ) -> Result<ResolvedAuth, Box<dyn Error>> {
     Ok(match model {
@@ -1654,6 +1656,16 @@ fn resolved_auth(
             username: take_required_config(config, "username")?,
             password: take_required_config(config, "password")?,
         },
+        AuthModel::ApiKey if !query_parameters.is_empty() => {
+            let mut parameters = BTreeMap::new();
+            for (parameter, credential_field) in query_parameters {
+                parameters.insert(
+                    parameter.clone(),
+                    take_required_config(config, credential_field)?,
+                );
+            }
+            ResolvedAuth::QueryParameters { parameters }
+        }
         AuthModel::ApiKey => ResolvedAuth::Header {
             name: nonempty_catalog_auth_value(token_header, "token_header")?,
             value: apply_auth_scheme(
@@ -3667,7 +3679,8 @@ mod tests {
             ("service".to_owned(), "bedrock".to_owned()),
             ("account".to_owned(), "account-a".to_owned()),
         ]);
-        let auth = resolved_auth(&AuthModel::AwsSigV4, "", "", &mut config).unwrap();
+        let auth =
+            resolved_auth(&AuthModel::AwsSigV4, "", "", &BTreeMap::new(), &mut config).unwrap();
         assert!(matches!(
             auth,
             ResolvedAuth::AwsSigV4 {
@@ -3697,7 +3710,8 @@ mod tests {
             ("client_secret".to_owned(), "secret-example".to_owned()),
             ("base_url".to_owned(), "https://api.example.test".to_owned()),
         ]);
-        let auth = resolved_auth(&AuthModel::DuoHmacV5, "", "", &mut config).unwrap();
+        let auth =
+            resolved_auth(&AuthModel::DuoHmacV5, "", "", &BTreeMap::new(), &mut config).unwrap();
         assert!(matches!(
             auth,
             ResolvedAuth::DuoHmacV5 {
@@ -3721,7 +3735,14 @@ mod tests {
             ("family".to_owned(), "users".to_owned()),
         ]);
         assert!(matches!(
-            resolved_auth(&AuthModel::Basic, "", "", &mut basic).unwrap(),
+            resolved_auth(
+                &AuthModel::Basic,
+                "",
+                "",
+                &BTreeMap::new(),
+                &mut basic
+            )
+            .unwrap(),
             ResolvedAuth::Basic {
                 ref username,
                 ref password,
@@ -3735,13 +3756,52 @@ mod tests {
             ("family".to_owned(), "resources".to_owned()),
         ]);
         assert!(matches!(
-            resolved_auth(&AuthModel::ApiKey, "X-API-Key", "Token", &mut api_key).unwrap(),
+            resolved_auth(
+                &AuthModel::ApiKey,
+                "X-API-Key",
+                "Token",
+                &BTreeMap::new(),
+                &mut api_key
+            )
+            .unwrap(),
             ResolvedAuth::Header {
                 ref name,
                 ref value,
             } if name == "X-API-Key" && value == "Token secret-example"
         ));
         assert!(!api_key.contains_key("token"));
+
+        let mut query_api_key = BTreeMap::from([
+            ("api_token".to_owned(), "token-example".to_owned()),
+            ("api_token_secret".to_owned(), "secret-example".to_owned()),
+            ("family".to_owned(), "surveys".to_owned()),
+        ]);
+        assert!(matches!(
+            resolved_auth(
+                &AuthModel::ApiKey,
+                "",
+                "",
+                &BTreeMap::from([
+                    ("api_token".to_owned(), "api_token".to_owned()),
+                    (
+                        "api_token_secret".to_owned(),
+                        "api_token_secret".to_owned()
+                    ),
+                ]),
+                &mut query_api_key
+            )
+            .unwrap(),
+            ResolvedAuth::QueryParameters { ref parameters }
+                if parameters.get("api_token").map(String::as_str) == Some("token-example")
+                    && parameters.get("api_token_secret").map(String::as_str)
+                        == Some("secret-example")
+        ));
+        assert!(!query_api_key.contains_key("api_token"));
+        assert!(!query_api_key.contains_key("api_token_secret"));
+        assert_eq!(
+            query_api_key.get("family").map(String::as_str),
+            Some("surveys")
+        );
     }
 
     #[test]
@@ -3751,7 +3811,14 @@ mod tests {
             ("family".to_owned(), "resources".to_owned()),
         ]);
         assert!(matches!(
-            resolved_auth(&AuthModel::BearerToken, "", "", &mut config).unwrap(),
+            resolved_auth(
+                &AuthModel::BearerToken,
+                "",
+                "",
+                &BTreeMap::new(),
+                &mut config
+            )
+            .unwrap(),
             ResolvedAuth::Bearer { ref token } if token == "secret-example"
         ));
         assert!(!config.contains_key("token"));

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -311,6 +311,7 @@ pub struct CompiledSource {
     auth: AuthModel,
     token_header: String,
     token_scheme: String,
+    auth_query_parameters: BTreeMap<String, String>,
     authority: CollectionAuthority,
     families: Vec<CompiledFamily>,
 }
@@ -334,6 +335,10 @@ impl CompiledSource {
 
     pub fn token_scheme(&self) -> &str {
         &self.token_scheme
+    }
+
+    pub fn auth_query_parameters(&self) -> &BTreeMap<String, String> {
+        &self.auth_query_parameters
     }
 
     pub fn authority(&self) -> CollectionAuthority {
@@ -464,9 +469,18 @@ struct ConfigFieldWire {
 struct AuthWire {
     model: String,
     #[serde(default)]
+    credential_fields: Vec<CredentialFieldWire>,
+    #[serde(default)]
     token_header: String,
     #[serde(default)]
     token_scheme: String,
+    #[serde(default)]
+    query_parameters: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct CredentialFieldWire {
+    key: String,
 }
 
 #[derive(Deserialize)]
@@ -602,6 +616,50 @@ fn compile_source(
     if token_scheme.len() > 64 || token_scheme.chars().any(char::is_control) {
         return invalid(path, "auth token_scheme is invalid");
     }
+    let credential_fields = entry
+        .definition
+        .auth
+        .credential_fields
+        .iter()
+        .map(|field| field.key.trim())
+        .collect::<BTreeSet<_>>();
+    let mut auth_query_parameters = BTreeMap::new();
+    for (parameter, credential_field) in entry.definition.auth.query_parameters {
+        let parameter = parameter.trim();
+        let credential_field = credential_field.trim();
+        if parameter.is_empty()
+            || parameter.len() > 128
+            || !parameter.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~')
+            })
+        {
+            return invalid(path, "auth query parameter name is invalid");
+        }
+        if credential_field.is_empty() || !credential_fields.contains(credential_field) {
+            return invalid(
+                path,
+                &format!(
+                    "auth query parameter {parameter} references undeclared credential field {credential_field}"
+                ),
+            );
+        }
+        auth_query_parameters.insert(parameter.to_owned(), credential_field.to_owned());
+    }
+    if auth_query_parameters.len() > 16 {
+        return invalid(path, "auth query parameters exceed the 16-parameter limit");
+    }
+    if !auth_query_parameters.is_empty() && auth != AuthModel::ApiKey {
+        return invalid(
+            path,
+            "auth query parameters are supported only for api_key authentication",
+        );
+    }
+    if !auth_query_parameters.is_empty() && !token_header.is_empty() {
+        return invalid(
+            path,
+            "api_key authentication cannot use both token_header and query_parameters",
+        );
+    }
     let config_fields = entry
         .definition
         .config_fields
@@ -610,7 +668,9 @@ fn compile_source(
         .collect::<BTreeSet<_>>();
     let generic_runtime_supported = classifier_supported
         && auth.supports_generic_runtime()
-        && (auth != AuthModel::ApiKey || !token_header.is_empty());
+        && (auth != AuthModel::ApiKey
+            || !token_header.is_empty()
+            || !auth_query_parameters.is_empty());
     let verified_families = verified_families(proofs.get(&id));
     let mut family_ids = BTreeSet::new();
     let mut families = Vec::with_capacity(entry.definition.resource_families.len());
@@ -641,6 +701,7 @@ fn compile_source(
         auth,
         token_header,
         token_scheme,
+        auth_query_parameters,
         authority,
         families,
     })
@@ -1177,18 +1238,19 @@ mod tests {
             summary.sources,
             summary.authoritative_sources + summary.shadow_only_sources
         );
-        let missing_api_key_headers = catalog
+        let unresolved_api_key_placement = catalog
             .sources()
             .filter(|source| {
                 source.authority() == CollectionAuthority::Authoritative
                     && source.auth() == &AuthModel::ApiKey
                     && source.token_header().is_empty()
+                    && source.auth_query_parameters().is_empty()
             })
             .map(CompiledSource::id)
             .collect::<Vec<_>>();
         assert!(
-            missing_api_key_headers.is_empty(),
-            "authoritative API-key sources have no token header: {missing_api_key_headers:?}"
+            unresolved_api_key_placement.is_empty(),
+            "authoritative API-key sources have no credential placement: {unresolved_api_key_placement:?}"
         );
         assert_eq!(
             catalog.get("elevenlabs").unwrap().token_header(),
@@ -1196,6 +1258,17 @@ mod tests {
         );
         assert_eq!(catalog.get("snyk").unwrap().token_header(), "Authorization");
         assert_eq!(catalog.get("snyk").unwrap().token_scheme(), "Token");
+        assert_eq!(
+            catalog.get("airbrake").unwrap().auth_query_parameters(),
+            &BTreeMap::from([("key".to_owned(), "token".to_owned())])
+        );
+        assert_eq!(
+            catalog.get("alchemer").unwrap().auth_query_parameters(),
+            &BTreeMap::from([
+                ("api_token".to_owned(), "api_token".to_owned()),
+                ("api_token_secret".to_owned(), "api_token_secret".to_owned()),
+            ])
+        );
     }
 
     #[test]
@@ -1222,6 +1295,8 @@ mod tests {
             "akeneo",
             "apacta",
             "appwrite",
+            "airbrake",
+            "alchemer",
             "airtable",
             "anchore",
             "azure_openai",
@@ -1242,13 +1317,11 @@ mod tests {
                 "{source_id} has verified parameterized provider paths"
             );
         }
-        for source_id in ["airbrake", "akeyless", "alchemer"] {
-            assert_eq!(
-                catalog.get(source_id).unwrap().authority(),
-                CollectionAuthority::ShadowOnly,
-                "{source_id} has no closed Rust API-key placement"
-            );
-        }
+        assert_eq!(
+            catalog.get("akeyless").unwrap().authority(),
+            CollectionAuthority::ShadowOnly,
+            "akeyless requires bespoke Rust authentication"
+        );
         assert_eq!(
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -53,6 +53,9 @@ pub enum ResolvedAuth {
         name: String,
         value: String,
     },
+    QueryParameters {
+        parameters: BTreeMap<String, String>,
+    },
     AwsSigV4 {
         access_key_id: String,
         secret_access_key: String,
@@ -78,6 +81,11 @@ impl fmt::Debug for ResolvedAuth {
                 .debug_struct("Header")
                 .field("name", name)
                 .field("value", &"[REDACTED]")
+                .finish(),
+            Self::QueryParameters { parameters } => formatter
+                .debug_struct("QueryParameters")
+                .field("names", &parameters.keys().collect::<Vec<_>>())
+                .field("values", &"[REDACTED]")
                 .finish(),
             Self::AwsSigV4 { session_token, .. } => formatter
                 .debug_struct("AwsSigV4")
@@ -109,6 +117,11 @@ impl Drop for ResolvedAuth {
                 password.zeroize();
             }
             Self::Header { value, .. } => value.zeroize(),
+            Self::QueryParameters { parameters } => {
+                for value in parameters.values_mut() {
+                    value.zeroize();
+                }
+            }
             Self::AwsSigV4 {
                 access_key_id,
                 secret_access_key,
@@ -135,6 +148,7 @@ pub enum HttpConnectorError {
     InvalidConfiguration(String),
     InvalidUrl(String),
     Request(reqwest::Error),
+    RedactedRequest,
     ProviderStatus(StatusCode),
     InvalidResponse(String),
     Domain(ModelError),
@@ -147,6 +161,7 @@ impl fmt::Display for HttpConnectorError {
             Self::InvalidConfiguration(message) => formatter.write_str(message),
             Self::InvalidUrl(message) => write!(formatter, "invalid provider URL: {message}"),
             Self::Request(error) => write!(formatter, "provider request failed: {error}"),
+            Self::RedactedRequest => formatter.write_str("provider request failed"),
             Self::ProviderStatus(status) => write!(formatter, "provider returned HTTP {status}"),
             Self::InvalidResponse(message) => {
                 write!(formatter, "invalid provider response: {message}")
@@ -491,9 +506,21 @@ impl SourceConnector for HttpSourceConnector {
                         builder.basic_auth(username, Some(password))
                     }
                     ResolvedAuth::Header { name, value } => builder.header(name, value),
-                    ResolvedAuth::AwsSigV4 { .. } | ResolvedAuth::DuoHmacV5 { .. } => builder,
+                    ResolvedAuth::QueryParameters { .. }
+                    | ResolvedAuth::AwsSigV4 { .. }
+                    | ResolvedAuth::DuoHmacV5 { .. } => builder,
                 };
-                let mut provider_request = builder.build().map_err(HttpConnectorError::Request)?;
+                let sensitive_query = matches!(self.auth, ResolvedAuth::QueryParameters { .. });
+                let mut provider_request = builder.build().map_err(|error| {
+                    if sensitive_query {
+                        HttpConnectorError::RedactedRequest
+                    } else {
+                        HttpConnectorError::Request(error)
+                    }
+                })?;
+                if sensitive_query {
+                    apply_auth_query_parameters(&mut provider_request, &self.auth)?;
+                }
                 match self.auth {
                     ResolvedAuth::AwsSigV4 { .. } => {
                         sign_aws_sigv4(&mut provider_request, &self.auth, SystemTime::now())?;
@@ -507,7 +534,13 @@ impl SourceConnector for HttpSourceConnector {
                     .client
                     .execute(provider_request)
                     .await
-                    .map_err(HttpConnectorError::Request)?;
+                    .map_err(|error| {
+                        if sensitive_query {
+                            HttpConnectorError::RedactedRequest
+                        } else {
+                            HttpConnectorError::Request(error)
+                        }
+                    })?;
                 let status = response.status();
                 if !status.is_success() {
                     return Err(HttpConnectorError::ProviderStatus(status));
@@ -694,7 +727,10 @@ fn validate_auth(expected: &AuthModel, actual: &ResolvedAuth) -> Result<(), Http
     let valid = match expected {
         AuthModel::None => matches!(actual, ResolvedAuth::None),
         AuthModel::Basic => matches!(actual, ResolvedAuth::Basic { .. }),
-        AuthModel::ApiKey => matches!(actual, ResolvedAuth::Header { .. }),
+        AuthModel::ApiKey => matches!(
+            actual,
+            ResolvedAuth::Header { .. } | ResolvedAuth::QueryParameters { .. }
+        ),
         AuthModel::BearerToken
         | AuthModel::OauthAuthorizationCode
         | AuthModel::OauthClientCredentials
@@ -714,6 +750,55 @@ fn validate_auth(expected: &AuthModel, actual: &ResolvedAuth) -> Result<(), Http
             "resolved credential does not match the source auth model".to_owned(),
         ))
     }
+}
+
+fn apply_auth_query_parameters(
+    request: &mut Request,
+    auth: &ResolvedAuth,
+) -> Result<(), HttpConnectorError> {
+    let ResolvedAuth::QueryParameters { parameters } = auth else {
+        return Err(HttpConnectorError::InvalidConfiguration(
+            "query authentication requires query parameters".to_owned(),
+        ));
+    };
+    if parameters.is_empty() {
+        return Err(HttpConnectorError::InvalidConfiguration(
+            "query authentication requires at least one parameter".to_owned(),
+        ));
+    }
+    if parameters.len() > 16 {
+        return Err(HttpConnectorError::InvalidConfiguration(
+            "query authentication exceeds the 16-parameter limit".to_owned(),
+        ));
+    }
+    for (name, value) in parameters {
+        if !valid_auth_query_parameter_name(name) || value.is_empty() {
+            return Err(HttpConnectorError::InvalidConfiguration(
+                "query authentication parameters are invalid".to_owned(),
+            ));
+        }
+    }
+    let retained = request
+        .url()
+        .query_pairs()
+        .filter(|(name, _)| !parameters.contains_key(name.as_ref()))
+        .map(|(name, value)| (name.into_owned(), value.into_owned()))
+        .collect::<Vec<_>>();
+    let mut query = request.url_mut().query_pairs_mut();
+    query.clear();
+    query.extend_pairs(retained);
+    for (name, value) in parameters {
+        query.append_pair(name, value);
+    }
+    Ok(())
+}
+
+fn valid_auth_query_parameter_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~'))
 }
 
 fn sign_duo_hmac_v5(
@@ -1790,6 +1875,129 @@ mod tests {
         assert!(matches!(batch.scope, CollectedScope::Complete(_)));
         assert_eq!(batch.records.len(), 1);
         assert_eq!(batch.records[0].provider_id, "user-1");
+    }
+
+    #[tokio::test]
+    async fn query_credentials_are_encoded_redacted_and_never_stored_in_runtime_config() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            let request_line = request.lines().next().unwrap();
+            assert!(request_line.starts_with("GET /v5/account?"));
+            assert!(request_line.contains("api_token=token%26admin%3Dtrue"));
+            assert!(request_line.contains("api_token_secret=secret%23fragment"));
+            assert!(!request_line.contains("&admin=true"));
+            assert!(!request_line.contains("#fragment"));
+            let body = r#"{"data":{"id":"account-1","organization":"Example"}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let auth = ResolvedAuth::QueryParameters {
+            parameters: BTreeMap::from([
+                ("api_token".to_owned(), "token&admin=true".to_owned()),
+                ("api_token_secret".to_owned(), "secret#fragment".to_owned()),
+            ]),
+        };
+        let debug = format!("{auth:?}");
+        assert!(!debug.contains("token&admin=true"));
+        assert!(!debug.contains("secret#fragment"));
+        let mut shadowed = Client::new()
+            .get("https://api.example.test/v5/account?api_token=attacker&public=kept")
+            .build()
+            .unwrap();
+        apply_auth_query_parameters(&mut shadowed, &auth).unwrap();
+        let query = shadowed
+            .url()
+            .query_pairs()
+            .map(|(name, value)| (name.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+        let api_token_values = query
+            .iter()
+            .filter(|(name, _)| name == "api_token")
+            .map(|(_, value)| value.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(api_token_values, vec!["token&admin=true"]);
+        assert!(query.contains(&("public".to_owned(), "kept".to_owned())));
+
+        let mut invalid_name = Client::new()
+            .get("https://api.example.test/v5/account")
+            .build()
+            .unwrap();
+        assert!(matches!(
+            apply_auth_query_parameters(
+                &mut invalid_name,
+                &ResolvedAuth::QueryParameters {
+                    parameters: BTreeMap::from([(
+                        "api_token&admin".to_owned(),
+                        "secret".to_owned()
+                    )]),
+                }
+            ),
+            Err(HttpConnectorError::InvalidConfiguration(_))
+        ));
+        assert!(invalid_name.url().query().is_none());
+        let mut connector = HttpSourceConnector::new(
+            catalog.get("alchemer").unwrap().clone(),
+            "account",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            auth,
+        )
+        .unwrap();
+        assert!(connector.config.is_empty());
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("alchemer-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].provider_id, "account-1");
+
+        let closed_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let closed_address = closed_listener.local_addr().unwrap();
+        drop(closed_listener);
+        let mut failing = HttpSourceConnector::new(
+            catalog.get("alchemer").unwrap().clone(),
+            "account",
+            &format!("http://{closed_address}"),
+            BTreeMap::new(),
+            ResolvedAuth::QueryParameters {
+                parameters: BTreeMap::from([
+                    ("api_token".to_owned(), "token&admin=true".to_owned()),
+                    ("api_token_secret".to_owned(), "secret#fragment".to_owned()),
+                ]),
+            },
+        )
+        .unwrap();
+        let error = failing
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("alchemer-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.to_string(), "provider request failed");
+        assert!(!format!("{error:?}").contains("token&admin=true"));
+        assert!(!format!("{error:?}").contains("secret#fragment"));
     }
 
     #[tokio::test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -240,7 +240,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 45 sources and 314 families are authoritative; the other 749 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 47 sources and 325 families are authoritative; the other 747 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/business-data-grc/alchemer.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/alchemer.yaml
@@ -14,6 +14,9 @@ entries:
             required: true
             secret: true
         model: api_key
+        query_parameters:
+          api_token: api_token
+          api_token_secret: api_token_secret
         requires_references: true
       categories:
         - saas

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/airbrake.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/airbrake.yaml
@@ -9,6 +9,8 @@ entries:
             required: true
             secret: true
         model: api_key
+        query_parameters:
+          key: token
         requires_references: true
       categories:
         - saas


### PR DESCRIPTION
## What changed

- compile declared API-key query parameters only when they reference checked-in credential fields
- resolve query credentials out of the stored runtime config before connector construction
- append credentials only to the outbound provider request after pagination and public query construction
- percent-encode credential values and redact request failures that could otherwise expose provider URLs
- zeroize resolved query credential values on drop
- promote Airbrake and Alchemer after their provider-proven authentication mechanics become executable in Rust

## Authority boundary

This moves two sources and eleven families from shadow-only collection to Rust authority. The catalog now reports 47 authoritative sources and 325 authoritative families; 747 sources remain shadow-only. Akeyless remains shadow-only because its token exchange requires a bespoke Rust connector.

## Verification

- `cargo test -p cerebro-source-catalog -- --nocapture`
- `cargo test -p cerebro-source-runtime-next query_credentials_are_encoded_redacted_and_never_stored_in_runtime_config -- --nocapture`
- `cargo test -p cerebro-platform stored_basic_and_api_key_auth_scrub_credentials_from_connector_config -- --nocapture`
- `cargo clippy -p cerebro-source-catalog -p cerebro-source-runtime-next -p cerebro-platform --all-targets -- -D warnings`
- `make sourcegen-check`
- `make check-structural check-arch`
- `make docs-drift-check rust-doc-check`
