### PR TITLE
Post JSON body credentials in Rust

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -1492,6 +1492,7 @@ async fn sync_source() -> Result<(), Box<dyn Error>> {
         source.token_header(),
         source.token_scheme(),
         source.auth_query_parameters(),
+        source.auth_json_body_parameters(),
         &mut config,
     )?;
     let connector = HttpSourceConnector::new(source.clone(), &family_id, &base_url, config, auth)?;
@@ -1648,6 +1649,7 @@ fn resolved_auth(
     token_header: &str,
     token_scheme: &str,
     query_parameters: &BTreeMap<String, String>,
+    json_body_parameters: &BTreeMap<String, String>,
     config: &mut BTreeMap<String, String>,
 ) -> Result<ResolvedAuth, Box<dyn Error>> {
     Ok(match model {
@@ -1656,6 +1658,16 @@ fn resolved_auth(
             username: take_required_config(config, "username")?,
             password: take_required_config(config, "password")?,
         },
+        AuthModel::ApiKey if !json_body_parameters.is_empty() => {
+            let mut parameters = BTreeMap::new();
+            for (parameter, credential_field) in json_body_parameters {
+                parameters.insert(
+                    parameter.clone(),
+                    take_required_config(config, credential_field)?,
+                );
+            }
+            ResolvedAuth::JsonBodyParameters { parameters }
+        }
         AuthModel::ApiKey if !query_parameters.is_empty() => {
             let mut parameters = BTreeMap::new();
             for (parameter, credential_field) in query_parameters {
@@ -3679,8 +3691,15 @@ mod tests {
             ("service".to_owned(), "bedrock".to_owned()),
             ("account".to_owned(), "account-a".to_owned()),
         ]);
-        let auth =
-            resolved_auth(&AuthModel::AwsSigV4, "", "", &BTreeMap::new(), &mut config).unwrap();
+        let auth = resolved_auth(
+            &AuthModel::AwsSigV4,
+            "",
+            "",
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &mut config,
+        )
+        .unwrap();
         assert!(matches!(
             auth,
             ResolvedAuth::AwsSigV4 {
@@ -3710,8 +3729,15 @@ mod tests {
             ("client_secret".to_owned(), "secret-example".to_owned()),
             ("base_url".to_owned(), "https://api.example.test".to_owned()),
         ]);
-        let auth =
-            resolved_auth(&AuthModel::DuoHmacV5, "", "", &BTreeMap::new(), &mut config).unwrap();
+        let auth = resolved_auth(
+            &AuthModel::DuoHmacV5,
+            "",
+            "",
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &mut config,
+        )
+        .unwrap();
         assert!(matches!(
             auth,
             ResolvedAuth::DuoHmacV5 {
@@ -3740,6 +3766,7 @@ mod tests {
                 "",
                 "",
                 &BTreeMap::new(),
+                &BTreeMap::new(),
                 &mut basic
             )
             .unwrap(),
@@ -3760,6 +3787,7 @@ mod tests {
                 &AuthModel::ApiKey,
                 "X-API-Key",
                 "Token",
+                &BTreeMap::new(),
                 &BTreeMap::new(),
                 &mut api_key
             )
@@ -3788,6 +3816,7 @@ mod tests {
                         "api_token_secret".to_owned()
                     ),
                 ]),
+                &BTreeMap::new(),
                 &mut query_api_key
             )
             .unwrap(),
@@ -3802,6 +3831,29 @@ mod tests {
             query_api_key.get("family").map(String::as_str),
             Some("surveys")
         );
+
+        let mut body_api_key = BTreeMap::from([
+            ("api_token".to_owned(), "token-example".to_owned()),
+            ("family".to_owned(), "items".to_owned()),
+        ]);
+        assert!(matches!(
+            resolved_auth(
+                &AuthModel::ApiKey,
+                "",
+                "",
+                &BTreeMap::new(),
+                &BTreeMap::from([("token".to_owned(), "api_token".to_owned())]),
+                &mut body_api_key
+            )
+            .unwrap(),
+            ResolvedAuth::JsonBodyParameters { ref parameters }
+                if parameters.get("token").map(String::as_str) == Some("token-example")
+        ));
+        assert!(!body_api_key.contains_key("api_token"));
+        assert_eq!(
+            body_api_key.get("family").map(String::as_str),
+            Some("items")
+        );
     }
 
     #[test]
@@ -3815,6 +3867,7 @@ mod tests {
                 &AuthModel::BearerToken,
                 "",
                 "",
+                &BTreeMap::new(),
                 &BTreeMap::new(),
                 &mut config
             )

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -234,6 +234,7 @@ pub struct CompiledFamily {
     config_query: BTreeMap<String, PathParameterBinding>,
     config_attributes: BTreeMap<String, PathParameterBinding>,
     pagination: Pagination,
+    cursor_in_json_body: bool,
     path_parameters: BTreeMap<String, PathParameterBinding>,
     projection: Projection,
     authoritative: bool,
@@ -281,6 +282,10 @@ impl CompiledFamily {
         &self.pagination
     }
 
+    pub fn cursor_in_json_body(&self) -> bool {
+        self.cursor_in_json_body
+    }
+
     pub fn path_parameters(&self) -> &BTreeMap<String, PathParameterBinding> {
         &self.path_parameters
     }
@@ -312,6 +317,7 @@ pub struct CompiledSource {
     token_header: String,
     token_scheme: String,
     auth_query_parameters: BTreeMap<String, String>,
+    auth_json_body_parameters: BTreeMap<String, String>,
     authority: CollectionAuthority,
     families: Vec<CompiledFamily>,
 }
@@ -339,6 +345,10 @@ impl CompiledSource {
 
     pub fn auth_query_parameters(&self) -> &BTreeMap<String, String> {
         &self.auth_query_parameters
+    }
+
+    pub fn auth_json_body_parameters(&self) -> &BTreeMap<String, String> {
+        &self.auth_json_body_parameters
     }
 
     pub fn authority(&self) -> CollectionAuthority {
@@ -476,6 +486,8 @@ struct AuthWire {
     token_scheme: String,
     #[serde(default)]
     query_parameters: BTreeMap<String, String>,
+    #[serde(default)]
+    json_body_parameters: BTreeMap<String, String>,
 }
 
 #[derive(Deserialize)]
@@ -548,6 +560,8 @@ struct PaginationWire {
     start_page: usize,
     #[serde(default)]
     page_size: usize,
+    #[serde(default)]
+    cursor_in_json_body: bool,
 }
 
 #[derive(Deserialize)]
@@ -648,16 +662,49 @@ fn compile_source(
     if auth_query_parameters.len() > 16 {
         return invalid(path, "auth query parameters exceed the 16-parameter limit");
     }
-    if !auth_query_parameters.is_empty() && auth != AuthModel::ApiKey {
+    let mut auth_json_body_parameters = BTreeMap::new();
+    for (parameter, credential_field) in entry.definition.auth.json_body_parameters {
+        let parameter = parameter.trim();
+        let credential_field = credential_field.trim();
+        if parameter.is_empty()
+            || parameter.len() > 128
+            || !parameter.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~')
+            })
+        {
+            return invalid(path, "auth JSON body parameter name is invalid");
+        }
+        if credential_field.is_empty() || !credential_fields.contains(credential_field) {
+            return invalid(
+                path,
+                &format!(
+                    "auth JSON body parameter {parameter} references undeclared credential field {credential_field}"
+                ),
+            );
+        }
+        auth_json_body_parameters.insert(parameter.to_owned(), credential_field.to_owned());
+    }
+    if auth_json_body_parameters.len() > 16 {
         return invalid(
             path,
-            "auth query parameters are supported only for api_key authentication",
+            "auth JSON body parameters exceed the 16-parameter limit",
         );
     }
-    if !auth_query_parameters.is_empty() && !token_header.is_empty() {
+    if (!auth_query_parameters.is_empty() || !auth_json_body_parameters.is_empty())
+        && auth != AuthModel::ApiKey
+    {
         return invalid(
             path,
-            "api_key authentication cannot use both token_header and query_parameters",
+            "auth request parameters are supported only for api_key authentication",
+        );
+    }
+    let api_key_placements = usize::from(!token_header.is_empty())
+        + usize::from(!auth_query_parameters.is_empty())
+        + usize::from(!auth_json_body_parameters.is_empty());
+    if api_key_placements > 1 {
+        return invalid(
+            path,
+            "api_key authentication must use exactly one credential placement",
         );
     }
     let config_fields = entry
@@ -670,7 +717,8 @@ fn compile_source(
         && auth.supports_generic_runtime()
         && (auth != AuthModel::ApiKey
             || !token_header.is_empty()
-            || !auth_query_parameters.is_empty());
+            || !auth_query_parameters.is_empty()
+            || !auth_json_body_parameters.is_empty());
     let verified_families = verified_families(proofs.get(&id));
     let mut family_ids = BTreeSet::new();
     let mut families = Vec::with_capacity(entry.definition.resource_families.len());
@@ -685,6 +733,24 @@ fn compile_source(
             generic_runtime_supported,
             &config_fields,
         )?);
+    }
+    if !auth_json_body_parameters.is_empty()
+        && families
+            .iter()
+            .any(|family| family.method() != HttpMethod::Post)
+    {
+        return invalid(
+            path,
+            "JSON body authentication requires POST for every source family",
+        );
+    }
+    if auth_json_body_parameters.is_empty()
+        && families.iter().any(CompiledFamily::cursor_in_json_body)
+    {
+        return invalid(
+            path,
+            "JSON body cursor placement requires JSON body authentication",
+        );
     }
     if families.is_empty() {
         return invalid(path, "at least one resource family is required");
@@ -702,6 +768,7 @@ fn compile_source(
         token_header,
         token_scheme,
         auth_query_parameters,
+        auth_json_body_parameters,
         authority,
         families,
     })
@@ -724,6 +791,24 @@ fn compile_family(
             );
         }
     };
+    let cursor_in_json_body = family
+        .pagination
+        .as_ref()
+        .is_some_and(|pagination| pagination.cursor_in_json_body);
+    if cursor_in_json_body
+        && (method != HttpMethod::Post
+            || family.pagination.as_ref().is_none_or(|pagination| {
+                pagination.r#type != "cursor" || !pagination.page_size_param.is_empty()
+            }))
+    {
+        return invalid(
+            path,
+            &format!(
+                "family {} JSON-body cursor requires POST cursor pagination without a page-size parameter",
+                family.id
+            ),
+        );
+    }
     if !family.path.starts_with('/') {
         return invalid(
             path,
@@ -874,6 +959,7 @@ fn compile_family(
         config_query,
         config_attributes,
         pagination: compile_pagination(path, family.pagination)?,
+        cursor_in_json_body,
         path_parameters,
         projection: Projection {
             class: projection_class,
@@ -1193,6 +1279,127 @@ mod tests {
             .unwrap()
     }
 
+    fn compile_auth_fixture(
+        model: &str,
+        auth_fields: &str,
+        method: &str,
+        pagination: &str,
+    ) -> Result<CompiledSource, CatalogError> {
+        let yaml = format!(
+            r#"entries:
+- classifier_output: supported
+  definition:
+    id: builtin-test
+    source_id: test
+    display_name: Test
+    auth:
+      model: {model}
+      credential_fields:
+      - key: api_token
+{auth_fields}
+    resource_families:
+    - id: items
+      method: {method}
+      path: /items
+      id_field: id
+      pagination:
+{pagination}
+      projection:
+        template: asset
+"#
+        );
+        let mut file: EntryFileWire = serde_saphyr::from_slice(yaml.as_bytes()).unwrap();
+        compile_source(
+            Path::new("auth-fixture.yaml"),
+            file.entries.remove(0),
+            &BTreeMap::new(),
+        )
+    }
+
+    fn invalid_message(result: Result<CompiledSource, CatalogError>) -> String {
+        match result.unwrap_err() {
+            CatalogError::Invalid { message, .. } => message,
+            error => panic!("unexpected error: {error}"),
+        }
+    }
+
+    #[test]
+    fn request_auth_grammar_rejects_unsafe_ambiguous_and_unbound_bodies() {
+        let invalid_name = compile_auth_fixture(
+            "api_key",
+            "      json_body_parameters:\n        \"bad name\": api_token",
+            "POST",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(invalid_name),
+            "auth JSON body parameter name is invalid"
+        );
+
+        let undeclared = compile_auth_fixture(
+            "api_key",
+            "      json_body_parameters:\n        token: missing",
+            "POST",
+            "        type: none",
+        );
+        assert!(invalid_message(undeclared).contains("undeclared credential field missing"));
+
+        let wrong_model = compile_auth_fixture(
+            "bearer_token",
+            "      json_body_parameters:\n        token: api_token",
+            "POST",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(wrong_model),
+            "auth request parameters are supported only for api_key authentication"
+        );
+
+        let ambiguous = compile_auth_fixture(
+            "api_key",
+            "      query_parameters:\n        key: api_token\n      json_body_parameters:\n        token: api_token",
+            "POST",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(ambiguous),
+            "api_key authentication must use exactly one credential placement"
+        );
+
+        let get_body = compile_auth_fixture(
+            "api_key",
+            "      json_body_parameters:\n        token: api_token",
+            "GET",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(get_body),
+            "JSON body authentication requires POST for every source family"
+        );
+
+        let page_body_cursor = compile_auth_fixture(
+            "api_key",
+            "      json_body_parameters:\n        token: api_token",
+            "POST",
+            "        type: page\n        cursor_in_json_body: true",
+        );
+        assert!(
+            invalid_message(page_body_cursor)
+                .contains("JSON-body cursor requires POST cursor pagination")
+        );
+
+        let unbound_body_cursor = compile_auth_fixture(
+            "api_key",
+            "      token_header: X-API-Key",
+            "POST",
+            "        type: cursor\n        cursor_in_json_body: true",
+        );
+        assert_eq!(
+            invalid_message(unbound_body_cursor),
+            "JSON body cursor placement requires JSON body authentication"
+        );
+    }
+
     #[test]
     fn compiles_the_complete_checked_in_catalog() {
         let root = repository_root();
@@ -1245,6 +1452,7 @@ mod tests {
                     && source.auth() == &AuthModel::ApiKey
                     && source.token_header().is_empty()
                     && source.auth_query_parameters().is_empty()
+                    && source.auth_json_body_parameters().is_empty()
             })
             .map(CompiledSource::id)
             .collect::<Vec<_>>();
@@ -1269,6 +1477,18 @@ mod tests {
                 ("api_token_secret".to_owned(), "api_token_secret".to_owned()),
             ])
         );
+        assert_eq!(
+            catalog.get("akeyless").unwrap().auth_json_body_parameters(),
+            &BTreeMap::from([("token".to_owned(), "api_token".to_owned())])
+        );
+        for family in catalog.get("akeyless").unwrap().families() {
+            assert_eq!(
+                family.cursor_in_json_body(),
+                family.id() != "analytics",
+                "{} JSON-body cursor placement",
+                family.id()
+            );
+        }
     }
 
     #[test]
@@ -1293,6 +1513,7 @@ mod tests {
         );
         for source_id in [
             "akeneo",
+            "akeyless",
             "apacta",
             "appwrite",
             "airbrake",
@@ -1317,11 +1538,6 @@ mod tests {
                 "{source_id} has verified parameterized provider paths"
             );
         }
-        assert_eq!(
-            catalog.get("akeyless").unwrap().authority(),
-            CollectionAuthority::ShadowOnly,
-            "akeyless requires bespoke Rust authentication"
-        );
         assert_eq!(
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -56,6 +56,9 @@ pub enum ResolvedAuth {
     QueryParameters {
         parameters: BTreeMap<String, String>,
     },
+    JsonBodyParameters {
+        parameters: BTreeMap<String, String>,
+    },
     AwsSigV4 {
         access_key_id: String,
         secret_access_key: String,
@@ -84,6 +87,11 @@ impl fmt::Debug for ResolvedAuth {
                 .finish(),
             Self::QueryParameters { parameters } => formatter
                 .debug_struct("QueryParameters")
+                .field("names", &parameters.keys().collect::<Vec<_>>())
+                .field("values", &"[REDACTED]")
+                .finish(),
+            Self::JsonBodyParameters { parameters } => formatter
+                .debug_struct("JsonBodyParameters")
                 .field("names", &parameters.keys().collect::<Vec<_>>())
                 .field("values", &"[REDACTED]")
                 .finish(),
@@ -118,6 +126,11 @@ impl Drop for ResolvedAuth {
             }
             Self::Header { value, .. } => value.zeroize(),
             Self::QueryParameters { parameters } => {
+                for value in parameters.values_mut() {
+                    value.zeroize();
+                }
+            }
+            Self::JsonBodyParameters { parameters } => {
                 for value in parameters.values_mut() {
                     value.zeroize();
                 }
@@ -230,7 +243,7 @@ impl HttpSourceConnector {
                     source.id()
                 ))
             })?;
-        validate_auth(source.auth(), &auth)?;
+        validate_auth(&source, &auth)?;
         let mut base_url = Url::parse(base_url)
             .map_err(|error| HttpConnectorError::InvalidUrl(error.to_string()))?;
         if base_url.scheme() != "https" && !is_loopback(&base_url) {
@@ -487,11 +500,14 @@ impl SourceConnector for HttpSourceConnector {
             let mut exhausted = false;
             while remaining_pages > 0 {
                 remaining_pages -= 1;
+                let query_cursor = (!self.family.cursor_in_json_body())
+                    .then_some(cursor.as_deref())
+                    .flatten();
                 apply_query(
                     &mut url,
                     &request_query,
                     self.family.pagination(),
-                    cursor.as_deref(),
+                    query_cursor,
                     page,
                     offset,
                 );
@@ -507,9 +523,19 @@ impl SourceConnector for HttpSourceConnector {
                     }
                     ResolvedAuth::Header { name, value } => builder.header(name, value),
                     ResolvedAuth::QueryParameters { .. }
+                    | ResolvedAuth::JsonBodyParameters { .. }
                     | ResolvedAuth::AwsSigV4 { .. }
                     | ResolvedAuth::DuoHmacV5 { .. } => builder,
                 };
+                if let ResolvedAuth::JsonBodyParameters { parameters } = &self.auth {
+                    let body = json_auth_body(
+                        parameters,
+                        self.family.cursor_in_json_body(),
+                        self.family.pagination(),
+                        cursor.as_deref(),
+                    )?;
+                    builder = builder.json(&body);
+                }
                 let sensitive_query = matches!(self.auth, ResolvedAuth::QueryParameters { .. });
                 let mut provider_request = builder.build().map_err(|error| {
                     if sensitive_query {
@@ -723,14 +749,17 @@ fn response_too_large(max_response_bytes: usize) -> HttpConnectorError {
     ))
 }
 
-fn validate_auth(expected: &AuthModel, actual: &ResolvedAuth) -> Result<(), HttpConnectorError> {
-    let valid = match expected {
+fn validate_auth(source: &CompiledSource, actual: &ResolvedAuth) -> Result<(), HttpConnectorError> {
+    let valid = match source.auth() {
         AuthModel::None => matches!(actual, ResolvedAuth::None),
         AuthModel::Basic => matches!(actual, ResolvedAuth::Basic { .. }),
-        AuthModel::ApiKey => matches!(
-            actual,
-            ResolvedAuth::Header { .. } | ResolvedAuth::QueryParameters { .. }
-        ),
+        AuthModel::ApiKey if !source.auth_json_body_parameters().is_empty() => {
+            matches!(actual, ResolvedAuth::JsonBodyParameters { .. })
+        }
+        AuthModel::ApiKey if !source.auth_query_parameters().is_empty() => {
+            matches!(actual, ResolvedAuth::QueryParameters { .. })
+        }
+        AuthModel::ApiKey => matches!(actual, ResolvedAuth::Header { .. }),
         AuthModel::BearerToken
         | AuthModel::OauthAuthorizationCode
         | AuthModel::OauthClientCredentials
@@ -799,6 +828,44 @@ fn valid_auth_query_parameter_name(name: &str) -> bool {
         && name
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~'))
+}
+
+fn json_auth_body(
+    parameters: &BTreeMap<String, String>,
+    cursor_in_json_body: bool,
+    pagination: &Pagination,
+    cursor: Option<&str>,
+) -> Result<BTreeMap<String, String>, HttpConnectorError> {
+    if parameters.is_empty() || parameters.len() > 16 {
+        return Err(HttpConnectorError::InvalidConfiguration(
+            "JSON body authentication requires 1 to 16 parameters".to_owned(),
+        ));
+    }
+    let mut body = BTreeMap::new();
+    for (name, value) in parameters {
+        if !valid_auth_query_parameter_name(name) || value.is_empty() {
+            return Err(HttpConnectorError::InvalidConfiguration(
+                "JSON body authentication parameters are invalid".to_owned(),
+            ));
+        }
+        body.insert(name.clone(), value.clone());
+    }
+    if cursor_in_json_body {
+        let Pagination::Cursor { parameter, .. } = pagination else {
+            return Err(HttpConnectorError::InvalidConfiguration(
+                "JSON body cursor requires cursor pagination".to_owned(),
+            ));
+        };
+        if body.contains_key(parameter) {
+            return Err(HttpConnectorError::InvalidConfiguration(
+                "JSON body cursor conflicts with an authentication parameter".to_owned(),
+            ));
+        }
+        if let Some(cursor) = cursor.filter(|value| !value.is_empty()) {
+            body.insert(parameter.clone(), cursor.to_owned());
+        }
+    }
+    Ok(body)
 }
 
 fn sign_duo_hmac_v5(
@@ -1161,6 +1228,10 @@ fn apply_query(
         query.clear();
         query.extend_pairs(retained);
         query.extend_pairs(static_query);
+        drop(query);
+        if url.query().is_some_and(str::is_empty) {
+            url.set_query(None);
+        }
         return;
     }
 
@@ -1202,6 +1273,10 @@ fn apply_query(
             query.append_pair(parameter, &offset.to_string());
             query.append_pair(limit_parameter, &page_size.to_string());
         }
+    }
+    drop(query);
+    if url.query().is_some_and(str::is_empty) {
+        url.set_query(None);
     }
 }
 
@@ -1906,6 +1981,22 @@ mod tests {
             root.join("sources"),
         )
         .unwrap();
+        let wrong_placement = HttpSourceConnector::new(
+            catalog.get("alchemer").unwrap().clone(),
+            "account",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            ResolvedAuth::Header {
+                name: "X-API-Key".to_owned(),
+                value: "secret".to_owned(),
+            },
+        )
+        .err()
+        .unwrap();
+        assert!(matches!(
+            wrong_placement,
+            HttpConnectorError::InvalidConfiguration(_)
+        ));
         let auth = ResolvedAuth::QueryParameters {
             parameters: BTreeMap::from([
                 ("api_token".to_owned(), "token&admin=true".to_owned()),
@@ -1998,6 +2089,94 @@ mod tests {
         assert_eq!(error.to_string(), "provider request failed");
         assert!(!format!("{error:?}").contains("token&admin=true"));
         assert!(!format!("{error:?}").contains("secret#fragment"));
+    }
+
+    #[tokio::test]
+    async fn json_body_credentials_and_cursor_are_posted_without_query_fallback() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for page in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let read = socket.read(&mut request).await.unwrap();
+                let request = String::from_utf8_lossy(&request[..read]);
+                assert!(request.starts_with("POST /list-items HTTP/1.1\r\n"));
+                assert!(request.contains("content-type: application/json"));
+                let body = request.split("\r\n\r\n").nth(1).unwrap();
+                let body: Value = serde_json::from_str(body).unwrap();
+                assert_eq!(
+                    body.get("token").and_then(Value::as_str),
+                    Some("body-secret")
+                );
+                if page == 0 {
+                    assert!(body.get("pagination-token").is_none());
+                } else {
+                    assert_eq!(
+                        body.get("pagination-token").and_then(Value::as_str),
+                        Some("cursor-2")
+                    );
+                }
+                let response_body = if page == 0 {
+                    r#"{"items":[{"item_id":"item-1","item_name":"First"}],"next_page":"cursor-2"}"#
+                } else {
+                    r#"{"items":[{"item_id":"item-2","item_name":"Second"}],"next_page":""}"#
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let wrong_placement = HttpSourceConnector::new(
+            catalog.get("akeyless").unwrap().clone(),
+            "items",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            ResolvedAuth::Header {
+                name: "X-API-Key".to_owned(),
+                value: "secret".to_owned(),
+            },
+        )
+        .err()
+        .unwrap();
+        assert!(matches!(
+            wrong_placement,
+            HttpConnectorError::InvalidConfiguration(_)
+        ));
+        let auth = ResolvedAuth::JsonBodyParameters {
+            parameters: BTreeMap::from([("token".to_owned(), "body-secret".to_owned())]),
+        };
+        assert!(!format!("{auth:?}").contains("body-secret"));
+        let mut connector = HttpSourceConnector::new(
+            catalog.get("akeyless").unwrap().clone(),
+            "items",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            auth,
+        )
+        .unwrap();
+        assert!(connector.config.is_empty());
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("akeyless-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(batch.records.len(), 2);
+        assert_eq!(batch.records[0].provider_id, "item-1");
+        assert_eq!(batch.records[1].provider_id, "item-2");
     }
 
     #[tokio::test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -240,7 +240,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 47 sources and 325 families are authoritative; the other 747 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 48 sources and 329 families are authoritative; the other 746 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/identity-access-secrets/akeyless.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/akeyless.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        json_body_parameters:
+          token: api_token
       categories:
         - identity
         - secrets
@@ -37,6 +39,7 @@ entries:
           label: Items
           method: POST
           pagination:
+            cursor_in_json_body: true
             cursor_json_path: $.next_page
             cursor_param: pagination-token
             page_size: 100
@@ -72,6 +75,7 @@ entries:
           label: Auth methods
           method: POST
           pagination:
+            cursor_in_json_body: true
             cursor_json_path: $.next_page
             cursor_param: pagination-token
             page_size: 100
@@ -107,6 +111,7 @@ entries:
           label: Roles
           method: POST
           pagination:
+            cursor_in_json_body: true
             cursor_json_path: $.next_page
             cursor_param: pagination-token
             page_size: 100


### PR DESCRIPTION
## What changed

- compile bounded API-key credential placement in JSON POST bodies
- require JSON-body authentication only on POST families
- bind cursor pagination to the JSON body only when the catalog declares it
- require runtime credentials to match the source's exact header, query, or body placement
- zeroize and redact resolved body credential values
- remove empty query markers instead of sending `/path?`
- promote Akeyless after its token and pagination mechanics become executable in Rust

## Authority boundary

This moves Akeyless and four provider-proven families from shadow-only collection to Rust authority. The catalog now reports 48 authoritative sources and 329 authoritative families; 746 sources remain shadow-only.

## Verification

- `cargo test -p cerebro-source-catalog -- --nocapture`
- `cargo test -p cerebro-source-runtime-next -- --nocapture` (53 passed)
- `cargo test -p cerebro-platform -- --nocapture` (68 passed, 1 disposable-database test ignored; 5 Rust-only contract tests passed)
- `cargo clippy -p cerebro-source-catalog -p cerebro-source-runtime-next -p cerebro-platform --all-targets -- -D warnings`
- `make sourcegen-check`
- `make check-structural check-arch`
- `make docs-drift-check rust-doc-check`
