### PR TITLE
Run candidate web images on native runners

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -501,7 +501,8 @@ jobs:
           if-no-files-found: error
 
   web-image:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     needs: resolve
     permissions:
       contents: read
@@ -512,8 +513,10 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
+            runner: ubuntu-24.04
           - arch: arm64
             platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -524,7 +527,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build and publish candidate web image
         env:

--- a/scripts/tests/test_release_workflow_serialization.py
+++ b/scripts/tests/test_release_workflow_serialization.py
@@ -24,6 +24,18 @@ class ReleaseWorkflowSerializationTest(unittest.TestCase):
         self.assertIn("cancel-in-progress: false", workflow)
         self.assertNotIn("group: cut-release-${{", workflow)
 
+    def test_candidate_web_images_use_native_architecture_runners(self) -> None:
+        workflow = CUT_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        web_image = workflow.split("  web-image:\n", 1)[1].split(
+            "\n  web-manifest:", 1
+        )[0]
+
+        self.assertIn("runs-on: ${{ matrix.runner }}", web_image)
+        self.assertIn("timeout-minutes: 30", web_image)
+        self.assertIn("runner: ubuntu-24.04", web_image)
+        self.assertIn("runner: ubuntu-24.04-arm", web_image)
+        self.assertNotIn("docker/setup-qemu-action", web_image)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- run each candidate web image on a matching native GitHub-hosted architecture
- remove QEMU from the candidate web image build
- bound the web image job to 30 minutes
- add a regression test for the runner and timeout contract

## Why

The ARM64 candidate web image used an x86 runner with emulation and had no job timeout. A stalled image build could therefore block the candidate publication indefinitely.

## Validation

- `python3 -m unittest scripts.tests.test_release_workflow_serialization`
- `python3 -m unittest discover -s scripts/tests` (203 tests)
- `actionlint .github/workflows/cut-release.yml`
- `git diff --check`
