### PR TITLE
Promote Meraki collection to Rust

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1481,6 +1481,139 @@ mod tests {
             catalog.get("akeyless").unwrap().auth_json_body_parameters(),
             &BTreeMap::from([("token".to_owned(), "api_token".to_owned())])
         );
+        assert_eq!(
+            catalog.get("meraki").unwrap().token_header(),
+            "Authorization"
+        );
+        assert_eq!(catalog.get("meraki").unwrap().token_scheme(), "Bearer");
+        let meraki_event_type = catalog
+            .get("meraki")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "eventtype")
+            .unwrap();
+        assert_eq!(meraki_event_type.id_field(), "type");
+        assert_eq!(
+            meraki_event_type
+                .projection()
+                .fields()
+                .get("id")
+                .map(String::as_str),
+            Some("type")
+        );
+        assert_eq!(
+            meraki_event_type
+                .projection()
+                .fields()
+                .get("provider_id")
+                .map(String::as_str),
+            Some("type")
+        );
+        assert_eq!(
+            meraki_event_type
+                .projection()
+                .fields()
+                .get("event_type")
+                .map(String::as_str),
+            Some("type")
+        );
+        let meraki_organization = catalog
+            .get("meraki")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "organization")
+            .unwrap();
+        assert_eq!(
+            meraki_organization.pagination(),
+            &Pagination::Link {
+                header: "Link".to_owned()
+            }
+        );
+        assert_eq!(
+            meraki_organization.static_query(),
+            &BTreeMap::from([("perPage".to_owned(), "9000".to_owned())])
+        );
+        assert_eq!(
+            meraki_organization
+                .projection()
+                .fields()
+                .get("group_id")
+                .map(String::as_str),
+            Some("id")
+        );
+        assert_eq!(
+            meraki_organization
+                .projection()
+                .fields()
+                .get("group_name")
+                .map(String::as_str),
+            Some("name")
+        );
+        let meraki_auth_user = catalog
+            .get("meraki")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "merakiauthuser")
+            .unwrap();
+        assert_eq!(
+            meraki_auth_user
+                .projection()
+                .fields()
+                .get("user_id")
+                .map(String::as_str),
+            Some("id")
+        );
+        assert_eq!(
+            meraki_auth_user
+                .projection()
+                .fields()
+                .get("display_name")
+                .map(String::as_str),
+            Some("name")
+        );
+        assert_eq!(
+            meraki_auth_user
+                .projection()
+                .fields()
+                .get("email")
+                .map(String::as_str),
+            Some("email")
+        );
+        let meraki_access_policy = catalog
+            .get("meraki")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "accesspolicy")
+            .unwrap();
+        assert_eq!(meraki_access_policy.id_field(), "accessPolicyNumber");
+        assert_eq!(
+            meraki_access_policy
+                .projection()
+                .fields()
+                .get("id")
+                .map(String::as_str),
+            Some("accessPolicyNumber")
+        );
+        assert_eq!(
+            meraki_access_policy
+                .projection()
+                .fields()
+                .get("policy_id")
+                .map(String::as_str),
+            Some("accessPolicyNumber")
+        );
+        assert_eq!(
+            meraki_access_policy
+                .projection()
+                .fields()
+                .get("policy_name")
+                .map(String::as_str),
+            Some("name")
+        );
         for family in catalog.get("akeyless").unwrap().families() {
             assert_eq!(
                 family.cursor_in_json_body(),
@@ -1528,6 +1661,7 @@ mod tests {
             "fivetran",
             "google_vertex_ai",
             "jira",
+            "meraki",
             "onelogin",
             "qdrant_cloud",
             "snyk",

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -759,7 +759,23 @@ fn validate_auth(source: &CompiledSource, actual: &ResolvedAuth) -> Result<(), H
         AuthModel::ApiKey if !source.auth_query_parameters().is_empty() => {
             matches!(actual, ResolvedAuth::QueryParameters { .. })
         }
-        AuthModel::ApiKey => matches!(actual, ResolvedAuth::Header { .. }),
+        AuthModel::ApiKey => match actual {
+            ResolvedAuth::Header { name, value } => {
+                let expected_header = source.token_header();
+                let expected_scheme = source.token_scheme();
+                !expected_header.is_empty()
+                    && name.eq_ignore_ascii_case(expected_header)
+                    && if expected_scheme.is_empty() {
+                        !value.is_empty()
+                    } else {
+                        value
+                            .strip_prefix(expected_scheme)
+                            .and_then(|value| value.strip_prefix(' '))
+                            .is_some_and(|value| !value.is_empty())
+                    }
+            }
+            _ => false,
+        },
         AuthModel::BearerToken
         | AuthModel::OauthAuthorizationCode
         | AuthModel::OauthClientCredentials
@@ -1950,6 +1966,297 @@ mod tests {
         assert!(matches!(batch.scope, CollectedScope::Complete(_)));
         assert_eq!(batch.records.len(), 1);
         assert_eq!(batch.records[0].provider_id, "user-1");
+    }
+
+    #[tokio::test]
+    async fn meraki_v1_access_policy_uses_the_proven_path_and_bearer_header() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(
+                request.starts_with("GET /networks/network-1/switch/accessPolicies HTTP/1.1\r\n")
+            );
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("authorization: Bearer meraki-secret"))
+            );
+            assert!(!request.lines().next().unwrap().contains('?'));
+            let body = r#"[{"accessPolicyNumber":"1234","name":"Guest WiFi"}]"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("meraki").unwrap().clone();
+        assert_eq!(
+            source.authority(),
+            cerebro_source_catalog::CollectionAuthority::Authoritative
+        );
+        for invalid_auth in [
+            ResolvedAuth::Header {
+                name: "X-Cisco-Meraki-API-Key".to_owned(),
+                value: "meraki-secret".to_owned(),
+            },
+            ResolvedAuth::Header {
+                name: "Authorization".to_owned(),
+                value: "Token meraki-secret".to_owned(),
+            },
+            ResolvedAuth::Header {
+                name: "Authorization".to_owned(),
+                value: "Bearer ".to_owned(),
+            },
+        ] {
+            assert!(matches!(
+                HttpSourceConnector::new(
+                    source.clone(),
+                    "accesspolicy",
+                    &format!("http://{address}"),
+                    BTreeMap::from([("networkid".to_owned(), "network-1".to_owned())]),
+                    invalid_auth,
+                ),
+                Err(HttpConnectorError::InvalidConfiguration(_))
+            ));
+        }
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "accesspolicy",
+            &format!("http://{address}"),
+            BTreeMap::from([("networkid".to_owned(), "network-1".to_owned())]),
+            ResolvedAuth::Header {
+                name: "Authorization".to_owned(),
+                value: "Bearer meraki-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("meraki-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].provider_id, "1234");
+    }
+
+    #[tokio::test]
+    async fn meraki_v1_event_type_uses_type_as_the_provider_id() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /networks/network-1/events/eventTypes HTTP/1.1\r\n"));
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("authorization: Bearer meraki-secret"))
+            );
+            let body = r#"[{"category":"802.11","type":"association","description":"802.11 association"}]"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("meraki")
+        .unwrap()
+        .clone();
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "eventtype",
+            &format!("http://{address}"),
+            BTreeMap::from([("networkid".to_owned(), "network-1".to_owned())]),
+            ResolvedAuth::Header {
+                name: "Authorization".to_owned(),
+                value: "Bearer meraki-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("meraki-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].provider_id, "association");
+    }
+
+    #[tokio::test]
+    async fn meraki_v1_organizations_follow_the_provider_link_header() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for page in 1..=2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let read = socket.read(&mut request).await.unwrap();
+                let request = String::from_utf8_lossy(&request[..read]);
+                let request_line = request.lines().next().unwrap();
+                assert!(request_line.starts_with("GET /organizations?"));
+                assert!(request_line.contains("perPage=9000"));
+                assert_eq!(request_line.contains("startingAfter=2930418"), page == 2);
+                assert!(
+                    request.lines().any(
+                        |line| line.eq_ignore_ascii_case("authorization: Bearer meraki-secret")
+                    )
+                );
+                let body = if page == 1 {
+                    r#"[{"id":"2930418","name":"First organization"}]"#
+                } else {
+                    r#"[{"id":"2930419","name":"Second organization"}]"#
+                };
+                let link = if page == 1 {
+                    format!(
+                        "link: <http://{address}/organizations?startingAfter=2930418>; rel=\"next\"\r\n"
+                    )
+                } else {
+                    String::new()
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n{link}content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("meraki")
+        .unwrap()
+        .clone();
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "organization",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            ResolvedAuth::Header {
+                name: "Authorization".to_owned(),
+                value: "Bearer meraki-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("meraki-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(
+            batch
+                .records
+                .iter()
+                .map(|record| record.provider_id.as_str())
+                .collect::<Vec<_>>(),
+            ["2930418", "2930419"]
+        );
+    }
+
+    #[tokio::test]
+    async fn meraki_v1_auth_user_preserves_provider_identity_fields() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /networks/network-1/merakiAuthUsers HTTP/1.1\r\n"));
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("authorization: Bearer meraki-secret"))
+            );
+            let body = r#"[{"id":"aGlAaGkuY29t","email":"miles@meraki.com","name":"Miles Meraki","accountType":"802.1X","isAdmin":false}]"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("meraki")
+        .unwrap()
+        .clone();
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "merakiauthuser",
+            &format!("http://{address}"),
+            BTreeMap::from([("networkid".to_owned(), "network-1".to_owned())]),
+            ResolvedAuth::Header {
+                name: "Authorization".to_owned(),
+                value: "Bearer meraki-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("meraki-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].provider_id, "aGlAaGkuY29t");
+        assert_eq!(
+            batch.records[0]
+                .payload
+                .get("name")
+                .and_then(serde_json::Value::as_str),
+            Some("Miles Meraki"),
+        );
+        assert_eq!(
+            batch.records[0]
+                .payload
+                .get("email")
+                .and_then(serde_json::Value::as_str),
+            Some("miles@meraki.com"),
+        );
     }
 
     #[tokio::test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -240,7 +240,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 48 sources and 329 families are authoritative; the other 746 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 49 sources and 333 families are authoritative; the other 745 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/devops-ci-cd/meraki.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/meraki.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Bearer
     categories:
     - saas
     config_fields:
@@ -37,12 +39,12 @@ entries:
       event:
         kind: meraki.eventtype
         required_payload_fields:
-        - id
+        - type
         schema_ref: meraki/eventtype/v1
         urn_kind: meraki_eventtype
       event_kind: eventtype
       id: eventtype
-      id_field: id
+      id_field: type
       label: Eventtype
       method: GET
       pagination:
@@ -52,8 +54,11 @@ entries:
       - meraki_api_key
       projection:
         fields:
-          id: id
-          provider_id: id
+          description: description
+          event_type: type
+          id: type
+          provider_id: type
+          resource_name: description
         template: audit_event
       record_selector: "$[*]"
     - coverage:
@@ -81,16 +86,22 @@ entries:
       label: Organization
       method: GET
       pagination:
-        type: none
+        link_header: Link
+        type: link
       path: "/organizations"
       permissions_needed:
       - meraki_api_key
       projection:
         fields:
+          group_id: id
+          group_name: name
           id: id
+          name: name
           provider_id: id
         template: identity_group
       record_selector: "$[*]"
+      static_query:
+        perPage: "9000"
     - coverage:
       - families:
         - merakiauthuser
@@ -122,8 +133,12 @@ entries:
       - meraki_api_key
       projection:
         fields:
+          display_name: name
+          email: email
           id: id
+          name: name
           provider_id: id
+          user_id: id
         template: identity_user
       record_selector: "$[*]"
     - coverage:
@@ -142,24 +157,24 @@ entries:
       event:
         kind: meraki.accesspolicy
         required_payload_fields:
-        - id
+        - accessPolicyNumber
         schema_ref: meraki/accesspolicy/v1
         urn_kind: meraki_accesspolicy
       event_kind: accesspolicy
       id: accesspolicy
-      id_field: id
+      id_field: accessPolicyNumber
       label: Accesspolicy
       method: GET
       pagination:
         type: none
-      path: "/networks/${config.networkid}/accessPolicies"
+      path: "/networks/${config.networkid}/switch/accessPolicies"
       permissions_needed:
       - meraki_api_key
       projection:
         fields:
-          id: id
-          policy_id: id
-          policy_name: id
+          id: accessPolicyNumber
+          policy_id: accessPolicyNumber
+          policy_name: name
           policy_type: accesspolicy
         template: policy
       record_selector: "$[*]"
@@ -188,7 +203,7 @@ entries:
     source_id: meraki
     tenant_id: builtin_catalog
     transport:
-      base_url: https://api.meraki.com/api/v0
+      base_url: https://api.meraki.com/api/v1
       retry:
         backoff: exponential
         max_attempts: 3

--- a/sources/meraki/catalog.yaml
+++ b/sources/meraki/catalog.yaml
@@ -26,12 +26,16 @@ provider_api:
   verified_at: 2026-07-04T00:00:00Z
   transport: rest
   auth: api_key
-  auth_mechanics: x_cisco_meraki_api_key_header
+  auth_mechanics: bearer_authorization_header
   base_url: https://api.meraki.com/api/v1
   spec_url: https://api.meraki.com/api/v1/openapiSpec
   spec_kind: openapi
   references:
     - https://developer.cisco.com/meraki/api-v1/
+    - https://developer.cisco.com/meraki/api-v1/get-network-events-event-types/
+    - https://developer.cisco.com/meraki/api-v1/get-organizations/
+    - https://developer.cisco.com/meraki/api-v1/get-network-meraki-auth-users/
+    - https://developer.cisco.com/meraki/api-v1/get-network-switch-access-policies/
     - https://api.meraki.com/api/v1/openapiSpec
   auth_evidence:
     - https://developer.cisco.com/meraki/api-v1/authorization/
@@ -61,7 +65,7 @@ coverage_contract:
       evidence_types: [logging_configuration]
       control_domains: [logging_monitoring]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Provider path, auth, response identity, and projection are verified against Meraki Dashboard API v1.
     - id: organization
       type: entity_family
       title: "Organization"
@@ -71,7 +75,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Provider path, pagination, response identity, and group projection are verified against Meraki Dashboard API v1.
     - id: merakiauthuser
       type: entity_family
       title: "Merakiauthuser"
@@ -81,7 +85,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Provider path, response identity, and user projection are verified against Meraki Dashboard API v1.
     - id: accesspolicy
       type: lifecycle_state
       title: "Accesspolicy"
@@ -91,7 +95,7 @@ coverage_contract:
       evidence_types: [configuration_state]
       control_domains: [security_operations]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Provider path, response identity, and policy projection are verified against Meraki Dashboard API v1.
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync
@@ -107,7 +111,7 @@ event_contracts:
       - event_type
       - actor_id
     required_payload_fields:
-      - id
+      - type
   - kind: meraki.organization
     schema_ref: meraki/organization/v1
     required_attributes:
@@ -132,4 +136,4 @@ event_contracts:
       - policy_id
       - policy_name
     required_payload_fields:
-      - id
+      - accessPolicyNumber

--- a/sources/meraki/testdata/read_accesspolicy.json
+++ b/sources/meraki/testdata/read_accesspolicy.json
@@ -2,7 +2,7 @@
   {
     "attributes": {
       "api_method": "GET",
-      "api_path": "/networks/${config.networkid}/accessPolicies",
+      "api_path": "/networks/${config.networkid}/switch/accessPolicies",
       "evidence_cas_commit_id": "evidence-cas-commit-id-source-meraki-accesspolicy-1",
       "evidence_cas_digest": "sha256:test",
       "evidence_cas_merkle_root": "evidence-cas-merkle-root-source-meraki-accesspolicy-1",
@@ -38,7 +38,8 @@
     "payload": {
       "accesspolicy": "accesspolicy",
       "api_method": "GET",
-      "api_path": "/networks/${config.networkid}/accessPolicies",
+      "accessPolicyNumber": "source-meraki-accesspolicy-1",
+      "api_path": "/networks/${config.networkid}/switch/accessPolicies",
       "created_at": "2026-06-01T00:00:00Z",
       "description": "Meraki Accesspolicy Fixture policy",
       "event_id": "source-meraki-accesspolicy-1",

--- a/sources/meraki/testdata/read_eventtype.json
+++ b/sources/meraki/testdata/read_eventtype.json
@@ -65,6 +65,7 @@
       "schema_ref": "meraki/eventtype/v1",
       "source_id": "meraki",
       "tenant_id": "tenant",
+      "type": "association",
       "updated_at": "2026-06-01T00:00:00Z"
     },
     "schema_ref": "meraki/eventtype/v1",


### PR DESCRIPTION
## What changed

- move the Meraki definition from the retired v0 base URL to the current v1 provider contract
- use the proven switch access-policy path and `Authorization: Bearer` credential placement
- use the provider's real stable identifiers: `type` for event types and `accessPolicyNumber` for switch access policies
- follow organization `Link` pagination with `perPage=9000` so a complete collection cannot silently stop at the first page
- preserve organization group names and Meraki-auth user names and email addresses in Rust graph projections
- reject wrong API-key header names, schemes, and empty scheme values before provider I/O
- promote all four Meraki families to Rust collection authority with exact current-response fixtures

## Provider contract

- https://developer.cisco.com/meraki/api-v1/get-network-events-event-types/
- https://developer.cisco.com/meraki/api-v1/get-organizations/
- https://developer.cisco.com/meraki/api-v1/get-network-meraki-auth-users/
- https://developer.cisco.com/meraki/api-v1/get-network-switch-access-policies/
- https://developer.cisco.com/meraki/api-v1/authorization/

## Verification

- `cargo test -p cerebro-source-catalog` (9 passed)
- `cargo test -p cerebro-source-runtime-next -- --test-threads=1` (57 passed)
- `cargo test -p cerebro-platform` (68 passed, 1 disposable-database test ignored; 5 Rust-only contract tests passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `go test ./internal/connectordefinitions ./internal/connectorcatalog ./sources/meraki`
- `make sourcegen-check sourcegen-test`
- `make source-fixture-check`
- `make check-structural check-structural-test check-arch docs-drift-check`
