### PR TITLE
Promote API2Cart collection to Rust

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -1491,6 +1491,7 @@ async fn sync_source() -> Result<(), Box<dyn Error>> {
         source.auth(),
         source.token_header(),
         source.token_scheme(),
+        source.auth_header_parameters(),
         source.auth_query_parameters(),
         source.auth_json_body_parameters(),
         &mut config,
@@ -1648,6 +1649,7 @@ fn resolved_auth(
     model: &AuthModel,
     token_header: &str,
     token_scheme: &str,
+    header_parameters: &BTreeMap<String, String>,
     query_parameters: &BTreeMap<String, String>,
     json_body_parameters: &BTreeMap<String, String>,
     config: &mut BTreeMap<String, String>,
@@ -1658,6 +1660,16 @@ fn resolved_auth(
             username: take_required_config(config, "username")?,
             password: take_required_config(config, "password")?,
         },
+        AuthModel::ApiKey if !header_parameters.is_empty() => {
+            let mut parameters = BTreeMap::new();
+            for (header, credential_field) in header_parameters {
+                parameters.insert(
+                    header.clone(),
+                    take_required_config(config, credential_field)?,
+                );
+            }
+            ResolvedAuth::HeaderParameters { parameters }
+        }
         AuthModel::ApiKey if !json_body_parameters.is_empty() => {
             let mut parameters = BTreeMap::new();
             for (parameter, credential_field) in json_body_parameters {
@@ -3697,6 +3709,7 @@ mod tests {
             "",
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &BTreeMap::new(),
             &mut config,
         )
         .unwrap();
@@ -3735,6 +3748,7 @@ mod tests {
             "",
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &BTreeMap::new(),
             &mut config,
         )
         .unwrap();
@@ -3767,6 +3781,7 @@ mod tests {
                 "",
                 &BTreeMap::new(),
                 &BTreeMap::new(),
+                &BTreeMap::new(),
                 &mut basic
             )
             .unwrap(),
@@ -3789,6 +3804,7 @@ mod tests {
                 "Token",
                 &BTreeMap::new(),
                 &BTreeMap::new(),
+                &BTreeMap::new(),
                 &mut api_key
             )
             .unwrap(),
@@ -3798,6 +3814,37 @@ mod tests {
             } if name == "X-API-Key" && value == "Token secret-example"
         ));
         assert!(!api_key.contains_key("token"));
+
+        let mut header_api_keys = BTreeMap::from([
+            ("api_key".to_owned(), "account-secret".to_owned()),
+            ("store_key".to_owned(), "store-secret".to_owned()),
+            ("family".to_owned(), "attributes".to_owned()),
+        ]);
+        assert!(matches!(
+            resolved_auth(
+                &AuthModel::ApiKey,
+                "",
+                "",
+                &BTreeMap::from([
+                    ("x-api-key".to_owned(), "api_key".to_owned()),
+                    ("x-store-key".to_owned(), "store_key".to_owned()),
+                ]),
+                &BTreeMap::new(),
+                &BTreeMap::new(),
+                &mut header_api_keys
+            )
+            .unwrap(),
+            ResolvedAuth::HeaderParameters { ref parameters }
+                if parameters.get("x-api-key").map(String::as_str) == Some("account-secret")
+                    && parameters.get("x-store-key").map(String::as_str)
+                        == Some("store-secret")
+        ));
+        assert!(!header_api_keys.contains_key("api_key"));
+        assert!(!header_api_keys.contains_key("store_key"));
+        assert_eq!(
+            header_api_keys.get("family").map(String::as_str),
+            Some("attributes")
+        );
 
         let mut query_api_key = BTreeMap::from([
             ("api_token".to_owned(), "token-example".to_owned()),
@@ -3809,6 +3856,7 @@ mod tests {
                 &AuthModel::ApiKey,
                 "",
                 "",
+                &BTreeMap::new(),
                 &BTreeMap::from([
                     ("api_token".to_owned(), "api_token".to_owned()),
                     (
@@ -3842,6 +3890,7 @@ mod tests {
                 "",
                 "",
                 &BTreeMap::new(),
+                &BTreeMap::new(),
                 &BTreeMap::from([("token".to_owned(), "api_token".to_owned())]),
                 &mut body_api_key
             )
@@ -3867,6 +3916,7 @@ mod tests {
                 &AuthModel::BearerToken,
                 "",
                 "",
+                &BTreeMap::new(),
                 &BTreeMap::new(),
                 &BTreeMap::new(),
                 &mut config

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -316,6 +316,7 @@ pub struct CompiledSource {
     auth: AuthModel,
     token_header: String,
     token_scheme: String,
+    auth_header_parameters: BTreeMap<String, String>,
     auth_query_parameters: BTreeMap<String, String>,
     auth_json_body_parameters: BTreeMap<String, String>,
     authority: CollectionAuthority,
@@ -341,6 +342,10 @@ impl CompiledSource {
 
     pub fn token_scheme(&self) -> &str {
         &self.token_scheme
+    }
+
+    pub fn auth_header_parameters(&self) -> &BTreeMap<String, String> {
+        &self.auth_header_parameters
     }
 
     pub fn auth_query_parameters(&self) -> &BTreeMap<String, String> {
@@ -484,6 +489,8 @@ struct AuthWire {
     token_header: String,
     #[serde(default)]
     token_scheme: String,
+    #[serde(default)]
+    header_parameters: BTreeMap<String, String>,
     #[serde(default)]
     query_parameters: BTreeMap<String, String>,
     #[serde(default)]
@@ -637,6 +644,52 @@ fn compile_source(
         .iter()
         .map(|field| field.key.trim())
         .collect::<BTreeSet<_>>();
+    let mut auth_header_parameters = BTreeMap::new();
+    let mut normalized_header_names = BTreeSet::new();
+    for (header, credential_field) in entry.definition.auth.header_parameters {
+        let header = header.trim();
+        let credential_field = credential_field.trim();
+        if header.is_empty()
+            || header.len() > 128
+            || !header.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric()
+                    || matches!(
+                        byte,
+                        b'!' | b'#'
+                            | b'$'
+                            | b'%'
+                            | b'&'
+                            | b'\''
+                            | b'*'
+                            | b'+'
+                            | b'-'
+                            | b'.'
+                            | b'^'
+                            | b'_'
+                            | b'`'
+                            | b'|'
+                            | b'~'
+                    )
+            })
+        {
+            return invalid(path, "auth header parameter name is invalid");
+        }
+        if !normalized_header_names.insert(header.to_ascii_lowercase()) {
+            return invalid(path, "auth header parameter names must be unique");
+        }
+        if credential_field.is_empty() || !credential_fields.contains(credential_field) {
+            return invalid(
+                path,
+                &format!(
+                    "auth header {header} references undeclared credential field {credential_field}"
+                ),
+            );
+        }
+        auth_header_parameters.insert(header.to_owned(), credential_field.to_owned());
+    }
+    if auth_header_parameters.len() > 16 {
+        return invalid(path, "auth header parameters exceed the 16-header limit");
+    }
     let mut auth_query_parameters = BTreeMap::new();
     for (parameter, credential_field) in entry.definition.auth.query_parameters {
         let parameter = parameter.trim();
@@ -690,7 +743,9 @@ fn compile_source(
             "auth JSON body parameters exceed the 16-parameter limit",
         );
     }
-    if (!auth_query_parameters.is_empty() || !auth_json_body_parameters.is_empty())
+    if (!auth_header_parameters.is_empty()
+        || !auth_query_parameters.is_empty()
+        || !auth_json_body_parameters.is_empty())
         && auth != AuthModel::ApiKey
     {
         return invalid(
@@ -699,6 +754,7 @@ fn compile_source(
         );
     }
     let api_key_placements = usize::from(!token_header.is_empty())
+        + usize::from(!auth_header_parameters.is_empty())
         + usize::from(!auth_query_parameters.is_empty())
         + usize::from(!auth_json_body_parameters.is_empty());
     if api_key_placements > 1 {
@@ -717,6 +773,7 @@ fn compile_source(
         && auth.supports_generic_runtime()
         && (auth != AuthModel::ApiKey
             || !token_header.is_empty()
+            || !auth_header_parameters.is_empty()
             || !auth_query_parameters.is_empty()
             || !auth_json_body_parameters.is_empty());
     let verified_families = verified_families(proofs.get(&id));
@@ -767,6 +824,7 @@ fn compile_source(
         auth,
         token_header,
         token_scheme,
+        auth_header_parameters,
         auth_query_parameters,
         auth_json_body_parameters,
         authority,
@@ -1285,6 +1343,22 @@ mod tests {
         method: &str,
         pagination: &str,
     ) -> Result<CompiledSource, CatalogError> {
+        compile_auth_fixture_with_credential_fields(
+            model,
+            "      - key: api_token",
+            auth_fields,
+            method,
+            pagination,
+        )
+    }
+
+    fn compile_auth_fixture_with_credential_fields(
+        model: &str,
+        credential_fields: &str,
+        auth_fields: &str,
+        method: &str,
+        pagination: &str,
+    ) -> Result<CompiledSource, CatalogError> {
         let yaml = format!(
             r#"entries:
 - classifier_output: supported
@@ -1295,7 +1369,7 @@ mod tests {
     auth:
       model: {model}
       credential_fields:
-      - key: api_token
+{credential_fields}
 {auth_fields}
     resource_families:
     - id: items
@@ -1401,6 +1475,101 @@ mod tests {
     }
 
     #[test]
+    fn request_auth_grammar_rejects_unsafe_ambiguous_and_unbound_headers() {
+        let invalid_name = compile_auth_fixture(
+            "api_key",
+            "      header_parameters:\n        \"bad header\": api_token",
+            "GET",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(invalid_name),
+            "auth header parameter name is invalid"
+        );
+
+        let non_ascii_name = compile_auth_fixture(
+            "api_key",
+            "      header_parameters:\n        X-Api-Kéy: api_token",
+            "GET",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(non_ascii_name),
+            "auth header parameter name is invalid"
+        );
+
+        let duplicate_name = compile_auth_fixture(
+            "api_key",
+            "      header_parameters:\n        X-API-Key: api_token\n        x-api-key: api_token",
+            "GET",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(duplicate_name),
+            "auth header parameter names must be unique"
+        );
+
+        let undeclared = compile_auth_fixture(
+            "api_key",
+            "      header_parameters:\n        X-API-Key: missing",
+            "GET",
+            "        type: none",
+        );
+        assert!(
+            invalid_message(undeclared).contains("references undeclared credential field missing")
+        );
+
+        let empty_credential_field = compile_auth_fixture_with_credential_fields(
+            "api_key",
+            "      - key: \"\"",
+            "      header_parameters:\n        X-API-Key: \"\"",
+            "GET",
+            "        type: none",
+        );
+        assert!(
+            invalid_message(empty_credential_field)
+                .contains("references undeclared credential field")
+        );
+
+        let wrong_model = compile_auth_fixture(
+            "bearer_token",
+            "      header_parameters:\n        X-API-Key: api_token",
+            "GET",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(wrong_model),
+            "auth request parameters are supported only for api_key authentication"
+        );
+
+        let ambiguous = compile_auth_fixture(
+            "api_key",
+            "      token_header: X-API-Key\n      header_parameters:\n        X-Store-Key: api_token",
+            "GET",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(ambiguous),
+            "api_key authentication must use exactly one credential placement"
+        );
+
+        let too_many_headers = (0..17)
+            .map(|index| format!("        X-Key-{index}: api_token"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let over_limit = compile_auth_fixture(
+            "api_key",
+            &format!("      header_parameters:\n{too_many_headers}"),
+            "GET",
+            "        type: none",
+        );
+        assert_eq!(
+            invalid_message(over_limit),
+            "auth header parameters exceed the 16-header limit"
+        );
+    }
+
+    #[test]
     fn compiles_the_complete_checked_in_catalog() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
@@ -1451,6 +1620,7 @@ mod tests {
                 source.authority() == CollectionAuthority::Authoritative
                     && source.auth() == &AuthModel::ApiKey
                     && source.token_header().is_empty()
+                    && source.auth_header_parameters().is_empty()
                     && source.auth_query_parameters().is_empty()
                     && source.auth_json_body_parameters().is_empty()
             })
@@ -1614,6 +1784,13 @@ mod tests {
                 .map(String::as_str),
             Some("name")
         );
+        assert_eq!(
+            catalog.get("api2cart").unwrap().auth_header_parameters(),
+            &BTreeMap::from([
+                ("x-api-key".to_owned(), "api_key".to_owned()),
+                ("x-store-key".to_owned(), "store_key".to_owned()),
+            ])
+        );
         for family in catalog.get("akeyless").unwrap().families() {
             assert_eq!(
                 family.cursor_in_json_body(),
@@ -1653,6 +1830,7 @@ mod tests {
             "alchemer",
             "airtable",
             "anchore",
+            "api2cart",
             "azure_openai",
             "beezup",
             "box",

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -53,6 +53,9 @@ pub enum ResolvedAuth {
         name: String,
         value: String,
     },
+    HeaderParameters {
+        parameters: BTreeMap<String, String>,
+    },
     QueryParameters {
         parameters: BTreeMap<String, String>,
     },
@@ -84,6 +87,11 @@ impl fmt::Debug for ResolvedAuth {
                 .debug_struct("Header")
                 .field("name", name)
                 .field("value", &"[REDACTED]")
+                .finish(),
+            Self::HeaderParameters { parameters } => formatter
+                .debug_struct("HeaderParameters")
+                .field("names", &parameters.keys().collect::<Vec<_>>())
+                .field("values", &"[REDACTED]")
                 .finish(),
             Self::QueryParameters { parameters } => formatter
                 .debug_struct("QueryParameters")
@@ -125,6 +133,11 @@ impl Drop for ResolvedAuth {
                 password.zeroize();
             }
             Self::Header { value, .. } => value.zeroize(),
+            Self::HeaderParameters { parameters } => {
+                for value in parameters.values_mut() {
+                    value.zeroize();
+                }
+            }
             Self::QueryParameters { parameters } => {
                 for value in parameters.values_mut() {
                     value.zeroize();
@@ -521,7 +534,7 @@ impl SourceConnector for HttpSourceConnector {
                     ResolvedAuth::Basic { username, password } => {
                         builder.basic_auth(username, Some(password))
                     }
-                    ResolvedAuth::Header { name, value } => builder.header(name, value),
+                    ResolvedAuth::Header { .. } | ResolvedAuth::HeaderParameters { .. } => builder,
                     ResolvedAuth::QueryParameters { .. }
                     | ResolvedAuth::JsonBodyParameters { .. }
                     | ResolvedAuth::AwsSigV4 { .. }
@@ -544,6 +557,7 @@ impl SourceConnector for HttpSourceConnector {
                         HttpConnectorError::Request(error)
                     }
                 })?;
+                apply_auth_headers(&mut provider_request, &self.auth)?;
                 if sensitive_query {
                     apply_auth_query_parameters(&mut provider_request, &self.auth)?;
                 }
@@ -759,6 +773,24 @@ fn validate_auth(source: &CompiledSource, actual: &ResolvedAuth) -> Result<(), H
         AuthModel::ApiKey if !source.auth_query_parameters().is_empty() => {
             matches!(actual, ResolvedAuth::QueryParameters { .. })
         }
+        AuthModel::ApiKey if !source.auth_header_parameters().is_empty() => match actual {
+            ResolvedAuth::HeaderParameters { parameters } => {
+                parameters.len() == source.auth_header_parameters().len()
+                    && parameters.values().all(|value| !value.is_empty())
+                    && parameters.keys().all(|actual| {
+                        source
+                            .auth_header_parameters()
+                            .keys()
+                            .any(|expected| actual.eq_ignore_ascii_case(expected))
+                    })
+                    && source.auth_header_parameters().keys().all(|expected| {
+                        parameters
+                            .keys()
+                            .any(|actual| actual.eq_ignore_ascii_case(expected))
+                    })
+            }
+            _ => false,
+        },
         AuthModel::ApiKey => match actual {
             ResolvedAuth::Header { name, value } => {
                 let expected_header = source.token_header();
@@ -795,6 +827,42 @@ fn validate_auth(source: &CompiledSource, actual: &ResolvedAuth) -> Result<(), H
             "resolved credential does not match the source auth model".to_owned(),
         ))
     }
+}
+
+fn apply_auth_headers(
+    request: &mut Request,
+    auth: &ResolvedAuth,
+) -> Result<(), HttpConnectorError> {
+    match auth {
+        ResolvedAuth::Header { name, value } => insert_sensitive_header(request, name, value),
+        ResolvedAuth::HeaderParameters { parameters } => {
+            for (name, value) in parameters {
+                insert_sensitive_header(request, name, value)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn insert_sensitive_header(
+    request: &mut Request,
+    name: &str,
+    value: &str,
+) -> Result<(), HttpConnectorError> {
+    let name = HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
+        HttpConnectorError::InvalidConfiguration(
+            "resolved credential contains an invalid header name".to_owned(),
+        )
+    })?;
+    let mut value = HeaderValue::from_str(value).map_err(|_| {
+        HttpConnectorError::InvalidConfiguration(
+            "resolved credential contains an invalid header value".to_owned(),
+        )
+    })?;
+    value.set_sensitive(true);
+    request.headers_mut().insert(name, value);
+    Ok(())
 }
 
 fn apply_auth_query_parameters(
@@ -1966,6 +2034,128 @@ mod tests {
         assert!(matches!(batch.scope, CollectedScope::Complete(_)));
         assert_eq!(batch.records.len(), 1);
         assert_eq!(batch.records[0].provider_id, "user-1");
+    }
+
+    #[tokio::test]
+    async fn api2cart_uses_exact_sensitive_headers_and_offset_pagination() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            let request_line = request.lines().next().unwrap();
+            assert!(request_line.starts_with("GET /attribute.group.list.json?"));
+            assert!(request_line.contains("start=0"));
+            assert!(request_line.contains("count=100"));
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("x-api-key: account-secret"))
+            );
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("x-store-key: store-secret"))
+            );
+            let body = r#"{"result":[{"id":"group-1","name":"Default"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("api2cart").unwrap().clone();
+        assert_eq!(
+            source.authority(),
+            cerebro_source_catalog::CollectionAuthority::Authoritative
+        );
+        let incomplete = HttpSourceConnector::new(
+            source.clone(),
+            "attribute_group_list_json",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            ResolvedAuth::HeaderParameters {
+                parameters: BTreeMap::from([("x-api-key".to_owned(), "account-secret".to_owned())]),
+            },
+        )
+        .err()
+        .unwrap();
+        assert!(matches!(
+            incomplete,
+            HttpConnectorError::InvalidConfiguration(_)
+        ));
+
+        let malformed_auth = ResolvedAuth::HeaderParameters {
+            parameters: BTreeMap::from([
+                (
+                    "x-api-key".to_owned(),
+                    "account-secret\r\nx-leak: yes".to_owned(),
+                ),
+                ("x-store-key".to_owned(), "store-secret".to_owned()),
+            ]),
+        };
+        assert!(!format!("{malformed_auth:?}").contains("account-secret"));
+        let mut malformed = HttpSourceConnector::new(
+            source.clone(),
+            "attribute_group_list_json",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            malformed_auth,
+        )
+        .unwrap();
+        assert!(matches!(
+            malformed
+                .collect(CollectionRequest {
+                    tenant_id: TenantId::parse("tenant-a").unwrap(),
+                    source_runtime_id: SourceRuntimeId::parse("api2cart-malformed").unwrap(),
+                    cursor: None,
+                })
+                .await,
+            Err(HttpConnectorError::InvalidConfiguration(_))
+        ));
+
+        let auth = ResolvedAuth::HeaderParameters {
+            parameters: BTreeMap::from([
+                ("x-api-key".to_owned(), "account-secret".to_owned()),
+                ("x-store-key".to_owned(), "store-secret".to_owned()),
+            ]),
+        };
+        let mut request = Client::new()
+            .get("https://api.example.test/resource")
+            .build()
+            .unwrap();
+        apply_auth_headers(&mut request, &auth).unwrap();
+        assert!(request.headers()["x-api-key"].is_sensitive());
+        assert!(request.headers()["x-store-key"].is_sensitive());
+
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "attribute_group_list_json",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            auth,
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("api2cart-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].provider_id, "group-1");
     }
 
     #[tokio::test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -240,7 +240,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 49 sources and 333 families are authoritative; the other 745 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 50 sources and 335 families are authoritative; the other 744 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/business-data-grc/api2cart.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/api2cart.yaml
@@ -8,6 +8,14 @@ entries:
         reference_only: true
         required: true
         secret: true
+      - key: store_key
+        label: Store key
+        reference_only: true
+        required: true
+        secret: true
+      header_parameters:
+        x-api-key: api_key
+        x-store-key: store_key
       model: api_key
       requires_references: true
     categories:
@@ -43,9 +51,10 @@ entries:
       method: GET
       name_field: name
       pagination:
+        limit_param: count
+        offset_param: start
         page_size: 100
-        page_size_param: count
-        type: page
+        type: offset
       path: "/attribute.group.list.json"
       permissions_needed:
       - api_key
@@ -78,9 +87,10 @@ entries:
       method: GET
       name_field: name
       pagination:
+        limit_param: count
+        offset_param: start
         page_size: 100
-        page_size_param: count
-        type: page
+        type: offset
       path: "/attribute.attributeset.list.json"
       permissions_needed:
       - api_key

--- a/sources/api2cart/catalog.yaml
+++ b/sources/api2cart/catalog.yaml
@@ -14,15 +14,16 @@ kind_lifecycle:
     status: active
 provider_api:
   status: verified
-  basis: discovered
+  basis: declared
   verified_at: 2026-07-04T00:00:00Z
   transport: rest
   auth: api_key
-  auth_mechanics: token_authorization_header
+  auth_mechanics: x_api_key_and_x_store_key_headers
   base_url: https://api.api2cart.com/v1.1
   spec_url: https://api.apis.guru/v2/specs/api2cart.com/1.1/openapi.json
   spec_kind: openapi
   references:
+    - https://api2cart.com/docs/response-fields-filtering/
     - https://api.apis.guru/v2/specs/api2cart.com/1.1/openapi.json
     - https://app.api2cart.com/default/index/swagger-json
   families:


### PR DESCRIPTION
## What changed

- add bounded multi-header API-key credentials to the Rust source catalog and runtime
- resolve and scrub each declared credential before collection
- validate the exact case-insensitive header set and reject empty, malformed, duplicate, non-ASCII, ambiguous, undeclared, or oversized declarations and bindings before provider I/O
- send provider credentials as sensitive request headers and redact or zeroize retained values
- correct API2Cart pagination to `start` and `count`
- promote both API2Cart families only after exact request and response proof

## Provider contract

API2Cart documents `x-api-key` and `x-store-key` request headers:
https://api2cart.com/docs/response-fields-filtering/

## Authority change

This promotes API2Cart from shadow-only to Rust-authoritative collection.

After this stack lands, Rust owns 50 sources and 335 provider families. The remaining 744 sources stay shadow-only.

## Verification

- complete `cerebro-source-catalog` suite: 10 passed
- complete `cerebro-source-runtime-next` suite: 58 passed
- complete `cerebro-platform` suite: 68 passed, 1 disposable PostgreSQL test ignored
- Rust-only contract suite: 5 passed
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `make rust-coverage`: 90.24% lines
- `make sourcegen-check check-structural check-structural-test check-arch docs-drift-check`
- `go test ./internal/connectordefinitions ./internal/connectorcatalog ./sources/api2cart`

