### PR TITLE
Bound dashboard and web startup work

### DIFF
--- a/apps/web/src/app/api/openapi/route.test.ts
+++ b/apps/web/src/app/api/openapi/route.test.ts
@@ -51,6 +51,7 @@ describe("OpenAPI document parsing", () => {
     }));
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, max-age=300");
     await expect(response.json()).resolves.toMatchObject({ openapi: "3.1.0" });
   });
 });

--- a/apps/web/src/app/api/openapi/route.test.ts
+++ b/apps/web/src/app/api/openapi/route.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { NextRequest } from "next/server";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -26,6 +29,12 @@ describe("OpenAPI document parsing", () => {
   it("rejects malformed and non-document YAML", () => {
     expect(parseOpenApiDocument("openapi: [unterminated")).toBeNull();
     expect(parseOpenApiDocument("plain scalar")).toBeNull();
+  });
+
+  it("keeps the shared upstream load independent of one client connection", () => {
+    const source = readFileSync(join(process.cwd(), "src/app/api/openapi/route.ts"), "utf8");
+
+    expect(source).not.toContain("signal: request.signal");
   });
 
   it("rejects schema requests without a trusted identity", async () => {

--- a/apps/web/src/app/api/openapi/route.ts
+++ b/apps/web/src/app/api/openapi/route.ts
@@ -40,7 +40,6 @@ const loadOpenApi = async (request: NextRequest) => {
     const response = await fetchCerebro(buildCerebroUrl("openapi.yaml"), {
       cache: "no-store",
       headers: authHeadersFor(request),
-      signal: request.signal,
     });
     if (!response.ok) return { spec: null, status: response.status };
     const spec = parseOpenApiDocument(await response.text());

--- a/apps/web/src/app/api/openapi/route.ts
+++ b/apps/web/src/app/api/openapi/route.ts
@@ -6,6 +6,11 @@ import { authHeadersFor, buildCerebroUrl, fetchCerebro, proxyFetchError } from "
 import { cerebroFixtureResponseFor } from "@/lib/cerebro-fixtures";
 import { resolveCurrentUserFromHeadersWithFallback } from "@/lib/identity";
 
+const OPENAPI_CACHE_TTL_MS = 5 * 60_000;
+let cachedOpenApi: { expiresAt: number; spec: Record<string, unknown> } | null = null;
+type OpenApiLoadResult = { spec: Record<string, unknown> | null; status: number };
+let openApiInflight: Promise<OpenApiLoadResult> | null = null;
+
 export const parseOpenApiDocument = (raw: string): Record<string, unknown> | null => {
   try {
     const parsed = parse(raw);
@@ -21,6 +26,33 @@ const invalidOpenApiResponse = () => NextResponse.json(
   { error: "The OpenAPI specification is invalid." },
   { status: 502 },
 );
+
+const openApiResponse = (spec: Record<string, unknown>) => NextResponse.json(spec, {
+  headers: { "cache-control": "private, max-age=300" },
+});
+
+const loadOpenApi = async (request: NextRequest) => {
+  if (cachedOpenApi && cachedOpenApi.expiresAt > Date.now()) {
+    return { spec: cachedOpenApi.spec, status: 200 };
+  }
+  if (openApiInflight) return openApiInflight;
+  openApiInflight = (async () => {
+    const response = await fetchCerebro(buildCerebroUrl("openapi.yaml"), {
+      cache: "no-store",
+      headers: authHeadersFor(request),
+      signal: request.signal,
+    });
+    if (!response.ok) return { spec: null, status: response.status };
+    const spec = parseOpenApiDocument(await response.text());
+    if (spec) cachedOpenApi = { expiresAt: Date.now() + OPENAPI_CACHE_TTL_MS, spec };
+    return { spec, status: spec ? 200 : 502 };
+  })();
+  try {
+    return await openApiInflight;
+  } finally {
+    openApiInflight = null;
+  }
+};
 
 export async function GET(request: NextRequest) {
   const currentUser = await resolveCurrentUserFromHeadersWithFallback(request.headers);
@@ -43,29 +75,22 @@ export async function GET(request: NextRequest) {
   });
   if (fixture) {
     const spec = parseOpenApiDocument(fixture.body);
-    return spec ? NextResponse.json(spec) : invalidOpenApiResponse();
+    return spec ? openApiResponse(spec) : invalidOpenApiResponse();
   }
 
-  let response: Response;
+  let loaded: OpenApiLoadResult;
   try {
-    response = await fetchCerebro(buildCerebroUrl("openapi.yaml"), {
-      cache: "no-store",
-      headers: authHeadersFor(request),
-    });
+    loaded = await loadOpenApi(request);
   } catch (error) {
     return proxyFetchError(error);
   }
 
-  if (!response.ok) {
+  if (!loaded.spec) {
     return NextResponse.json(
-      { error: `Failed to load OpenAPI (${response.status})` },
-      { status: response.status },
+      { error: "Failed to load OpenAPI." },
+      { status: loaded.status },
     );
   }
 
-  const raw = await response.text();
-  const spec = parseOpenApiDocument(raw);
-  if (!spec) return invalidOpenApiResponse();
-
-  return NextResponse.json(spec);
+  return openApiResponse(loaded.spec);
 }

--- a/apps/web/src/app/developer/page.tsx
+++ b/apps/web/src/app/developer/page.tsx
@@ -42,7 +42,7 @@ export default function DeveloperPage() {
       <Panel title="Developer Utilities">
         <div className="grid gap-3 lg:grid-cols-2">
           {developerLinks.map((link) => (
-            <Link key={link.href} href={link.href} className="rounded-md border border-slate-200 bg-slate-50 p-4 transition hover:border-slate-300 hover:bg-white">
+            <Link key={link.href} href={link.href} prefetch={false} className="rounded-md border border-slate-200 bg-slate-50 p-4 transition hover:border-slate-300 hover:bg-white">
               <div className="text-[13px] font-semibold text-slate-900">{link.label}</div>
               <div className="mt-1 text-[12px] text-slate-500">{link.description}</div>
             </Link>
@@ -55,7 +55,7 @@ export default function DeveloperPage() {
         {status === "error" && <div className="text-[13px] text-red-600">{error}</div>}
         <div className="grid gap-3 lg:grid-cols-3">
           {model?.tags.map((tag) => (
-            <Link key={tag.name} href={`/resources/${tagSlug(tag.name)}`} className="rounded-md border border-slate-200 bg-slate-50 p-4 transition hover:border-slate-300 hover:bg-white">
+            <Link key={tag.name} href={`/resources/${tagSlug(tag.name)}`} prefetch={false} className="rounded-md border border-slate-200 bg-slate-50 p-4 transition hover:border-slate-300 hover:bg-white">
               <div className="text-[13px] font-semibold text-slate-900">{tag.name}</div>
               <div className="mt-1 text-[12px] text-slate-500">{tag.description ?? "OpenAPI-defined resource group."}</div>
               <div className="mt-2 inline-flex rounded-md bg-white px-2.5 py-0.5 text-[11px] font-medium text-slate-600 ring-1 ring-inset ring-slate-200">{operationsByTag.get(tag.name) ?? 0} endpoints</div>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,7 +7,7 @@ import "./globals.css";
 import CerebroAgentPanelShell from "@/components/agent/CerebroAgentPanelShell";
 import { CerebroAgentProvider } from "@/components/agent/CerebroAgentProvider";
 import CommandPaletteShell from "@/components/CommandPaletteShell";
-import { ApiKeyProvider, CommandPaletteProvider, CurrentUserProvider, GRCQueryProvider, SidebarProvider, ThemeProvider, UserPreferencesProvider } from "@/components/providers";
+import { ApiKeyProvider, CommandPaletteProvider, ConsoleConfigProvider, CurrentUserProvider, GRCQueryProvider, SidebarProvider, ThemeProvider, UserPreferencesProvider } from "@/components/providers";
 import { SecurityProducerCatalogProvider } from "@/components/SecurityProducerCatalogProvider";
 import Sidebar from "@/components/Sidebar";
 import Topbar from "@/components/Topbar";
@@ -41,29 +41,31 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <ApiKeyProvider>
             <GRCQueryProvider>
               <CurrentUserProvider>
-                <SecurityProducerCatalogProvider>
-                  <UserPreferencesProvider>
-                    <ThemeProvider>
-                      <CerebroAgentProvider>
-                        <CommandPaletteProvider>
-                          <SidebarProvider>
-                            <div className="flex h-screen max-w-full overflow-hidden bg-[var(--app-bg)]">
-                              <Sidebar />
-                              <div className="flex min-w-0 flex-1 flex-col overflow-x-hidden">
-                                <Topbar />
-                                <main className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto bg-[var(--app-bg)] px-8 py-6 max-md:px-4">
-                                  <Suspense fallback={null}>{children}</Suspense>
-                                </main>
+                <ConsoleConfigProvider>
+                  <SecurityProducerCatalogProvider>
+                    <UserPreferencesProvider>
+                      <ThemeProvider>
+                        <CerebroAgentProvider>
+                          <CommandPaletteProvider>
+                            <SidebarProvider>
+                              <div className="flex h-screen max-w-full overflow-hidden bg-[var(--app-bg)]">
+                                <Sidebar />
+                                <div className="flex min-w-0 flex-1 flex-col overflow-x-hidden">
+                                  <Topbar />
+                                  <main className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto bg-[var(--app-bg)] px-8 py-6 max-md:px-4">
+                                    <Suspense fallback={null}>{children}</Suspense>
+                                  </main>
+                                </div>
                               </div>
-                            </div>
-                            <CommandPaletteShell />
-                            <CerebroAgentPanelShell />
-                          </SidebarProvider>
-                        </CommandPaletteProvider>
-                      </CerebroAgentProvider>
-                    </ThemeProvider>
-                  </UserPreferencesProvider>
-                </SecurityProducerCatalogProvider>
+                              <CommandPaletteShell />
+                              <CerebroAgentPanelShell />
+                            </SidebarProvider>
+                          </CommandPaletteProvider>
+                        </CerebroAgentProvider>
+                      </ThemeProvider>
+                    </UserPreferencesProvider>
+                  </SecurityProducerCatalogProvider>
+                </ConsoleConfigProvider>
               </CurrentUserProvider>
             </GRCQueryProvider>
           </ApiKeyProvider>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -144,6 +144,7 @@ export default function Sidebar() {
       <Link
         key={link.href}
         href={link.href}
+        prefetch={false}
         title={link.label}
         className={`relative flex items-center gap-2.5 rounded-lg px-2.5 py-[8px] text-[13px] font-medium transition ${
           active
@@ -174,7 +175,7 @@ export default function Sidebar() {
           } max-md:justify-center`}
         >
           {groupHref ? (
-            <Link href={groupHref} title={group.label} className="flex min-w-0 flex-1 items-center gap-2.5">
+            <Link href={groupHref} prefetch={false} title={group.label} className="flex min-w-0 flex-1 items-center gap-2.5">
               <NavIcon href={group.iconHref} />
               <span className="max-md:hidden">{group.label}</span>
             </Link>

--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -2,16 +2,11 @@
 
 import { useCallback, useEffect, useState } from "react";
 
-import { useApiKey, useCurrentUser } from "@/components/providers";
+import { useApiKey, useConsoleConfig, useCurrentUser } from "@/components/providers";
 import { identityPosture } from "@/lib/identity";
 import { RuntimeState, runtimeStateCopy, runtimeStateForError, runtimeStateLabel } from "@/lib/runtime-state";
 
 type StatusState = {
-  config?: {
-    apiBase?: string;
-    forwardRequestAuth?: boolean;
-    serverAuthConfigured?: boolean;
-  };
   health?: Record<string, unknown>;
   healthz?: Record<string, unknown>;
   probes?: ProbeResult[];
@@ -66,6 +61,7 @@ const stateClass = (state: RuntimeState) => {
 
 export default function StatusPanel() {
   const { apiKey } = useApiKey();
+  const { config } = useConsoleConfig();
   const { error: identityError, loading: identityLoading, user } = useCurrentUser();
   const [state, setState] = useState<StatusState>({});
   const [loading, setLoading] = useState(true);
@@ -111,17 +107,11 @@ export default function StatusPanel() {
     };
 
     try {
-      const configPromise = fetch("/api/config", { cache: "no-store", signal })
-        .then((response) => response.ok ? response.json() as Promise<StatusState["config"]> : undefined)
-        .catch(() => undefined);
-      const [configJson, probes] = await Promise.all([
-        configPromise,
-        Promise.all(STATUS_PROBES.map(runProbe)),
-      ]);
+      const probes = await Promise.all(STATUS_PROBES.map(runProbe));
       if (signal?.aborted) return;
       const health = probes.find((probe) => probe.key === "health")?.data;
       const healthz = probes.find((probe) => probe.key === "healthz")?.data;
-      setState({ checkedAt: new Date().toISOString(), config: configJson, health, healthz, probes });
+      setState({ checkedAt: new Date().toISOString(), health, healthz, probes });
     } catch (err) {
       if (!signal?.aborted) setState({ error: err instanceof Error ? err.message : "Unable to reach API" });
     } finally {
@@ -164,8 +154,8 @@ export default function StatusPanel() {
             {[
               { label: "Web app", value: loading ? "Checking" : "Ready", detail: "Local UI is responding" },
               { label: "Identity", value: identity.label, detail: identity.sourceLabel },
-              { label: "API base", value: state.config?.apiBase ?? "Unknown", detail: state.config?.serverAuthConfigured ? "server auth configured" : "server auth not configured" },
-              { label: "Auth forwarding", value: state.config?.forwardRequestAuth ? "Enabled" : "Disabled", detail: apiKey ? "API key present" : "no API key in browser" },
+              { label: "API base", value: config?.apiBase ?? "Unknown", detail: config?.serverAuthConfigured ? "server auth configured" : "server auth not configured" },
+              { label: "Auth forwarding", value: config?.forwardRequestAuth ? "Enabled" : "Disabled", detail: apiKey ? "API key present" : "no API key in browser" },
             ].map((item) => (
               <div key={item.label} className="rounded-lg border border-[color:var(--border)] bg-[var(--surface-muted)] p-3">
                 <div className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">{item.label}</div>

--- a/apps/web/src/components/Topbar.tsx
+++ b/apps/web/src/components/Topbar.tsx
@@ -63,6 +63,7 @@ export default function Topbar() {
   const [showConnection, setShowConnection] = useState(false);
   const [showIdentity, setShowIdentity] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
+  const [notificationsRequested, setNotificationsRequested] = useState(false);
   const { config } = useConsoleConfig();
   const [shareStatus, setShareStatus] = useState<ShareStatus>("idle");
   const [shareURL, setShareURL] = useState("");
@@ -150,10 +151,10 @@ export default function Topbar() {
   }, [shareStatus, shareURL]);
 
   const notificationsQuery = useGRCQuery<GRCDashboard>(
-    showNotifications ? grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT }) : null,
+    notificationsRequested ? grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT }) : null,
   );
   const reportRunsQuery = useGRCQuery<ReportRunListResponse>(
-    showNotifications ? grcPath("/report-runs", { limit: 5 }) : null,
+    notificationsRequested ? grcPath("/report-runs", { limit: 5 }) : null,
   );
   const notificationsLoading = notificationsQuery.loading || reportRunsQuery.loading;
   const notifications = useMemo(
@@ -232,7 +233,10 @@ export default function Topbar() {
         </button>
         <button
           type="button"
+          onFocus={() => setNotificationsRequested(true)}
+          onMouseEnter={() => setNotificationsRequested(true)}
           onClick={() => {
+            setNotificationsRequested(true);
             setShowNotifications((prev) => !prev);
             setShowIdentity(false);
             setShowConnection(false);

--- a/apps/web/src/components/Topbar.tsx
+++ b/apps/web/src/components/Topbar.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { Check, Settings2, Share2, UsersRound } from "lucide-react";
 
 import { API_BASE } from "@/lib/api";
-import { useApiKey, useCommandPalette, useCurrentUser, useTheme, useUserPreferences } from "@/components/providers";
+import { useApiKey, useCommandPalette, useConsoleConfig, useCurrentUser, useTheme, useUserPreferences } from "@/components/providers";
 import { countLabel } from "@/lib/format";
 import type { GRCDashboard } from "@/lib/grc";
 import { DASHBOARD_FINDING_LIMIT, grcDashboardPath, grcPath, useGRCQuery } from "@/lib/grc-client";
@@ -16,12 +16,6 @@ import { authorizationRoleLabelsForUser, effectiveAuthorizationPermissionsForUse
 import type { ReportRunListResponse } from "@/lib/report-schedules";
 import { usePopoverDismissal } from "@/lib/use-popover-dismissal";
 import { HOME_SECTION_IDS, HOME_SECTION_LABELS, userPreferencesShareURL, type DisplayDensity, type ThemePreference, type UserPreferences } from "@/lib/user-preferences";
-
-type ConsoleConfig = {
-  apiBase: string;
-  serverAuthConfigured: boolean;
-  forwardRequestAuth: boolean;
-};
 
 const displayValues = (values: string[] | undefined) => values?.filter(Boolean).join(", ") || "—";
 
@@ -69,25 +63,9 @@ export default function Topbar() {
   const [showConnection, setShowConnection] = useState(false);
   const [showIdentity, setShowIdentity] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
-  const [config, setConfig] = useState<ConsoleConfig | null>(null);
+  const { config } = useConsoleConfig();
   const [shareStatus, setShareStatus] = useState<ShareStatus>("idle");
   const [shareURL, setShareURL] = useState("");
-
-  useEffect(() => {
-    let mounted = true;
-    const loadConfig = async () => {
-      try {
-        const response = await fetch("/api/config", { cache: "no-store" });
-        if (!response.ok) return;
-        const nextConfig = (await response.json()) as ConsoleConfig;
-        if (mounted) setConfig(nextConfig);
-      } catch {
-        return;
-      }
-    };
-    void loadConfig();
-    return () => { mounted = false; };
-  }, []);
 
   const serverAuthConfigured = config?.serverAuthConfigured ?? false;
   const clientKeyEnabled = config?.forwardRequestAuth ?? false;
@@ -171,8 +149,13 @@ export default function Topbar() {
     return () => window.clearTimeout(timeout);
   }, [shareStatus, shareURL]);
 
-  const notificationsQuery = useGRCQuery<GRCDashboard>(grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT }));
-  const reportRunsQuery = useGRCQuery<ReportRunListResponse>(grcPath("/report-runs", { limit: 5 }));
+  const notificationsQuery = useGRCQuery<GRCDashboard>(
+    showNotifications ? grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT }) : null,
+  );
+  const reportRunsQuery = useGRCQuery<ReportRunListResponse>(
+    showNotifications ? grcPath("/report-runs", { limit: 5 }) : null,
+  );
+  const notificationsLoading = notificationsQuery.loading || reportRunsQuery.loading;
   const notifications = useMemo(
     () => [...buildNotifications(notificationsQuery.data), ...reportRunNotifications(reportRunsQuery.data?.runs)],
     [notificationsQuery.data, reportRunsQuery.data?.runs],
@@ -302,7 +285,9 @@ export default function Topbar() {
             <div>
               <div className="text-[14px] font-semibold text-[var(--text-primary)]">Notifications</div>
               <div className="mt-0.5 text-[12px] text-[var(--text-muted)]">
-                {notifications.length === 0
+                {notificationsLoading
+                  ? "Loading current alerts..."
+                  : notifications.length === 0
                   ? "Nothing needs attention right now."
                   : unreadCount > 0
                     ? countLabel(unreadCount, "unread alert")
@@ -319,7 +304,9 @@ export default function Topbar() {
               }`}
             />
           </div>
-          {notifications.length === 0 ? (
+          {notificationsLoading ? (
+            <div className="py-8 text-center text-[13px] text-[var(--text-muted)]">Loading notifications...</div>
+          ) : notifications.length === 0 ? (
             <div className="py-8 text-center text-[13px] text-[var(--text-muted)]">No notifications</div>
           ) : (
             <div className="max-h-[320px] divide-y divide-[color:var(--border)] overflow-y-auto">

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -45,6 +45,17 @@ type CurrentUserContextValue = {
   user: CurrentUser | null;
 };
 
+export type ConsoleConfig = {
+  apiBase: string;
+  serverAuthConfigured: boolean;
+  forwardRequestAuth: boolean;
+};
+
+type ConsoleConfigContextValue = {
+  config: ConsoleConfig | null;
+  loading: boolean;
+};
+
 type UserPreferencesContextValue = {
   error: string | null;
   loading: boolean;
@@ -71,6 +82,7 @@ const CommandPaletteContext = createContext<CommandPaletteContextValue | undefin
 const SidebarContext = createContext<SidebarContextValue | undefined>(undefined);
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 const CurrentUserContext = createContext<CurrentUserContextValue | undefined>(undefined);
+const ConsoleConfigContext = createContext<ConsoleConfigContextValue | undefined>(undefined);
 const UserPreferencesContext = createContext<UserPreferencesContextValue | undefined>(undefined);
 
 const STORAGE_KEY = "cerebro.apiKey";
@@ -280,6 +292,35 @@ export function CurrentUserProvider({ children }: { children: React.ReactNode })
   );
 }
 
+export function ConsoleConfigProvider({ children }: { children: React.ReactNode }) {
+  const [config, setConfig] = useState<ConsoleConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const loadConfig = async () => {
+      try {
+        const response = await fetch("/api/config", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        if (response.ok) {
+          setConfig((await response.json()) as ConsoleConfig);
+        }
+      } catch (error) {
+        if (!(error instanceof Error && error.name === "AbortError")) setConfig(null);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    };
+    void loadConfig();
+    return () => controller.abort();
+  }, []);
+
+  const contextValue = useMemo(() => ({ config, loading }), [config, loading]);
+  return <ConsoleConfigContext.Provider value={contextValue}>{children}</ConsoleConfigContext.Provider>;
+}
+
 export function UserPreferencesProvider({ children }: { children: React.ReactNode }) {
   const { apiKey } = useApiKey();
   const { actor, loading: userLoading } = useCurrentUser();
@@ -476,6 +517,14 @@ export function useCurrentUser() {
   const context = useContext(CurrentUserContext);
   if (!context) {
     throw new Error("useCurrentUser must be used within CurrentUserProvider");
+  }
+  return context;
+}
+
+export function useConsoleConfig() {
+  const context = useContext(ConsoleConfigContext);
+  if (!context) {
+    throw new Error("useConsoleConfig must be used within ConsoleConfigProvider");
   }
   return context;
 }

--- a/apps/web/src/lib/cerebro-proxy.test.ts
+++ b/apps/web/src/lib/cerebro-proxy.test.ts
@@ -9,6 +9,7 @@ import {
   isCacheableCerebroPath,
   responseHeadersFor,
   rustOwnsWebAuthority,
+  shouldRetryUpstreamResponse,
   shouldBypassCerebroProxyCache,
   withCerebroCacheBypassHeader,
 } from "./cerebro-proxy";
@@ -105,6 +106,26 @@ describe("cerebro proxy cache headers", () => {
       "x-cerebro-web-trace-id": "web-trace-123",
       "x-request-id": "req-123",
     });
+  });
+
+  it("does not amplify an unqualified unavailable response", () => {
+    expect(shouldRetryUpstreamResponse(new Response(null, { status: 503 }))).toBe(false);
+    expect(shouldRetryUpstreamResponse(new Response(null, {
+      status: 503,
+      headers: { "retry-after": "1" },
+    }))).toBe(true);
+    expect(shouldRetryUpstreamResponse(new Response(null, { status: 502 }))).toBe(true);
+    expect(shouldRetryUpstreamResponse(new Response(null, { status: 504 }))).toBe(true);
+  });
+
+  it("returns an unqualified unavailable response after one upstream attempt", async () => {
+    const upstreamFetch = vi.fn(async () => new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", upstreamFetch);
+
+    const response = await fetchCerebro(new URL("https://api.example.com/grc/dashboard"));
+
+    expect(response.status).toBe(503);
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
   });
 
   it("caches program readiness so audit readiness can stale-serve through transient backend failures", () => {

--- a/apps/web/src/lib/cerebro-proxy.ts
+++ b/apps/web/src/lib/cerebro-proxy.ts
@@ -55,7 +55,11 @@ const PROXY_TIMEOUT_MS = Number.isFinite(proxyTimeoutMs) && proxyTimeoutMs > 0 ?
 const PROXY_CACHE_TTL_MS = parseNonNegativeMs(process.env.CEREBRO_PROXY_CACHE_TTL_MS, 60000);
 const PROXY_CACHE_STALE_MS = parseNonNegativeMs(process.env.CEREBRO_PROXY_CACHE_STALE_MS, 300000);
 const PROXY_CACHE_MAX_ENTRIES = 400;
-const RETRY_STATUSES = new Set([502, 503, 504]);
+const RETRY_STATUSES = new Set([502, 504]);
+
+export const shouldRetryUpstreamResponse = (response: Response) =>
+  RETRY_STATUSES.has(response.status)
+  || (response.status === 503 && Boolean(response.headers.get("retry-after")));
 
 type CachedProxyResponse = {
   status: number;
@@ -291,7 +295,7 @@ export const fetchCerebro = async (target: URL, init: RequestInit = {}) => {
         signal: controller.signal,
       });
 
-      if (attempt < maxAttempts && RETRY_STATUSES.has(response.status)) {
+      if (attempt < maxAttempts && shouldRetryUpstreamResponse(response)) {
         span.increment("upstream.retry.count");
         span.event("cerebro.upstream.retry", {
           attempt,

--- a/apps/web/src/lib/openapi-store.ts
+++ b/apps/web/src/lib/openapi-store.ts
@@ -31,7 +31,7 @@ const loadOpenApi = async () => {
   try {
     const apiKey = window.localStorage.getItem(API_KEY_STORAGE) ?? "";
     const response = await fetch("/api/openapi", {
-      cache: "no-store",
+      cache: "default",
       headers: apiKey ? { "X-API-Key": apiKey } : {},
     });
     if (!response.ok) {

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -63,6 +63,22 @@ describe("product UI contract", () => {
     expect(source).not.toMatch(/const\s+userInitials\s*=\s*["'`](CB|JH)["'`]/);
   });
 
+  it("keeps global startup work bounded until the operator requests it", () => {
+    const developerSource = readProjectFile("src/app/developer/page.tsx");
+    const providersSource = readProjectFile("src/components/providers.tsx");
+    const sidebarSource = readProjectFile("src/components/Sidebar.tsx");
+    const statusSource = readProjectFile("src/components/StatusPanel.tsx");
+    const topbarSource = readProjectFile("src/components/Topbar.tsx");
+
+    expect(topbarSource).toContain("showNotifications ? grcDashboardPath");
+    expect(topbarSource).toContain("showNotifications ? grcPath");
+    expect(topbarSource).not.toContain('fetch("/api/config"');
+    expect(statusSource).not.toContain('fetch("/api/config"');
+    expect(providersSource.match(/fetch\("\/api\/config"/g)).toHaveLength(1);
+    expect(sidebarSource).toContain("prefetch={false}");
+    expect(developerSource.match(/prefetch=\{false\}/g)).toHaveLength(2);
+  });
+
   it("keeps identity and API recovery diagnostics in developer-owned surfaces", () => {
     expect(existsSync(projectPath("src/app/developer/identity/page.tsx"))).toBe(true);
     expect(existsSync(projectPath("src/lib/identity.ts"))).toBe(true);

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -70,8 +70,12 @@ describe("product UI contract", () => {
     const statusSource = readProjectFile("src/components/StatusPanel.tsx");
     const topbarSource = readProjectFile("src/components/Topbar.tsx");
 
-    expect(topbarSource).toContain("showNotifications ? grcDashboardPath");
-    expect(topbarSource).toContain("showNotifications ? grcPath");
+    expect(topbarSource).toContain("notificationsRequested ? grcDashboardPath");
+    expect(topbarSource).toContain("notificationsRequested ? grcPath");
+    expect(topbarSource).toContain("onFocus={() => setNotificationsRequested(true)}");
+    expect(topbarSource).toContain("onMouseEnter={() => setNotificationsRequested(true)}");
+    expect(topbarSource).not.toContain("showNotifications ? grcDashboardPath");
+    expect(topbarSource).not.toContain("showNotifications ? grcPath");
     expect(topbarSource).not.toContain('fetch("/api/config"');
     expect(statusSource).not.toContain('fetch("/api/config"');
     expect(providersSource.match(/fetch\("\/api\/config"/g)).toHaveLength(1);

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -1359,11 +1360,24 @@ func healthResponse(ctx context.Context, cfg config.Config, deps Dependencies) *
 }
 
 func publicHealthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHealthResponse {
-	components := []*cerebrov1.ComponentStatus{
-		componentStatus(ctx, "append_log", deps.AppendLog),
-		componentStatus(ctx, "state_store", deps.StateStore),
-		componentStatus(ctx, "graph_store", organizationalgraph.ReadinessStore(deps.GraphStore, deps.GraphQueries)),
+	checks := []struct {
+		name       string
+		dependency pinger
+	}{
+		{name: "append_log", dependency: deps.AppendLog},
+		{name: "state_store", dependency: deps.StateStore},
+		{name: "graph_store", dependency: organizationalgraph.ReadinessStore(deps.GraphStore, deps.GraphQueries)},
 	}
+	components := make([]*cerebrov1.ComponentStatus, len(checks))
+	var wg sync.WaitGroup
+	wg.Add(len(checks))
+	for index, check := range checks {
+		go func() {
+			defer wg.Done()
+			components[index] = componentStatus(ctx, check.name, check.dependency)
+		}()
+	}
+	wg.Wait()
 	status := "ready"
 	for _, component := range components {
 		if component.Status == "error" {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -619,6 +619,42 @@ type stubStore struct {
 
 func (s stubStore) Ping(context.Context) error { return s.err }
 
+type healthCheckBarrier struct {
+	mu      sync.Mutex
+	started int
+	release chan struct{}
+}
+
+func (b *healthCheckBarrier) wait() {
+	b.mu.Lock()
+	b.started++
+	if b.started == 2 {
+		close(b.release)
+	}
+	b.mu.Unlock()
+	<-b.release
+}
+
+type barrierAppendLog struct {
+	barrier *healthCheckBarrier
+}
+
+func (s barrierAppendLog) Ping(context.Context) error {
+	s.barrier.wait()
+	return nil
+}
+
+func (s barrierAppendLog) Append(context.Context, *cerebrov1.EventEnvelope) error { return nil }
+
+type barrierStore struct {
+	barrier *healthCheckBarrier
+}
+
+func (s barrierStore) Ping(context.Context) error {
+	s.barrier.wait()
+	return nil
+}
+
 type deadlineAwareStore struct {
 	sawDeadline bool
 }
@@ -4595,6 +4631,21 @@ func TestBootstrapHealthDegradesWhenRustGraphReadAuthorityIsUnavailable(t *testi
 	}
 	if component.GetDetail() != "unhealthy" || component.GetDetail() == rawDependencyError {
 		t.Fatalf("authoritative graph detail = %q, want sanitized detail", component.GetDetail())
+	}
+}
+
+func TestPublicHealthChecksDependenciesConcurrently(t *testing.T) {
+	barrier := &healthCheckBarrier{release: make(chan struct{})}
+	response := publicHealthResponse(context.Background(), Dependencies{
+		AppendLog:  barrierAppendLog{barrier: barrier},
+		StateStore: barrierStore{barrier: barrier},
+	})
+
+	if response.GetStatus() != "ready" {
+		t.Fatalf("health status = %q, want ready", response.GetStatus())
+	}
+	if barrier.started != 2 {
+		t.Fatalf("concurrent health checks started = %d, want 2", barrier.started)
 	}
 }
 

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -96,6 +96,63 @@ var ensureFindingStatements = []string{
 	`CREATE INDEX IF NOT EXISTS findings_event_ids_gin_idx ON findings USING GIN (event_ids_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_observed_policy_ids_gin_idx ON findings USING GIN (observed_policy_ids_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_control_refs_gin_idx ON findings USING GIN (control_refs_json)`,
+	`CREATE TABLE IF NOT EXISTS finding_control_refs (
+        finding_id TEXT NOT NULL REFERENCES findings(id) ON DELETE CASCADE,
+        framework_name TEXT NOT NULL,
+        control_id TEXT NOT NULL,
+        PRIMARY KEY (finding_id, framework_name, control_id)
+    )`,
+	`CREATE INDEX IF NOT EXISTS finding_control_refs_control_idx
+        ON finding_control_refs (framework_name, control_id, finding_id)`,
+	`CREATE OR REPLACE FUNCTION sync_finding_control_refs() RETURNS trigger AS $$
+BEGIN
+    DELETE FROM finding_control_refs WHERE finding_id = NEW.id;
+    INSERT INTO finding_control_refs (finding_id, framework_name, control_id)
+    SELECT DISTINCT
+        NEW.id,
+        COALESCE(NULLIF(BTRIM(ref.framework_name), ''), 'Unmapped'),
+        COALESCE(NULLIF(BTRIM(ref.control_id), ''), 'Needs mapping')
+    FROM jsonb_to_recordset(
+        CASE
+            WHEN jsonb_array_length(NEW.control_refs_json) = 0
+                THEN '[{"framework_name":"Unmapped","control_id":"Needs mapping"}]'::jsonb
+            ELSE NEW.control_refs_json
+        END
+    ) AS ref(framework_name TEXT, control_id TEXT);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql`,
+	`DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'findings_control_refs_sync'
+          AND tgrelid = 'findings'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        CREATE TRIGGER findings_control_refs_sync
+            AFTER INSERT OR UPDATE OF control_refs_json ON findings
+            FOR EACH ROW EXECUTE FUNCTION sync_finding_control_refs();
+    END IF;
+END $$`,
+	`INSERT INTO finding_control_refs (finding_id, framework_name, control_id)
+    SELECT DISTINCT
+        finding.id,
+        COALESCE(NULLIF(BTRIM(ref.framework_name), ''), 'Unmapped'),
+        COALESCE(NULLIF(BTRIM(ref.control_id), ''), 'Needs mapping')
+    FROM findings AS finding
+    CROSS JOIN LATERAL jsonb_to_recordset(
+        CASE
+            WHEN jsonb_array_length(finding.control_refs_json) = 0
+                THEN '[{"framework_name":"Unmapped","control_id":"Needs mapping"}]'::jsonb
+            ELSE finding.control_refs_json
+        END
+    ) AS ref(framework_name TEXT, control_id TEXT)
+    WHERE NOT EXISTS (
+        SELECT 1 FROM finding_control_refs AS existing WHERE existing.finding_id = finding.id
+    )
+    ON CONFLICT DO NOTHING`,
 	`CREATE INDEX IF NOT EXISTS findings_notes_gin_idx ON findings USING GIN (notes_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_tickets_gin_idx ON findings USING GIN (tickets_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_external_refs_gin_idx ON findings USING GIN (external_refs_json)`,

--- a/internal/statestore/postgres/grc_dashboard.go
+++ b/internal/statestore/postgres/grc_dashboard.go
@@ -130,7 +130,7 @@ func grcDashboardAggregateQuery(request ports.GRCDashboardAggregateRequest) (str
 	effectiveSeverity := findingEffectiveSeveritySQL()
 	query := `
 WITH finding_scope AS (
-  SELECT id, status, ` + effectiveSeverity + ` AS effective_severity, due_at, assignee, control_refs_json
+  SELECT id, status, ` + effectiveSeverity + ` AS effective_severity, due_at, assignee
   FROM findings
   WHERE ` + whereFindings + `
 ),
@@ -145,17 +145,11 @@ summary AS (
 ),
 control_refs AS (
   SELECT DISTINCT
-    COALESCE(NULLIF(TRIM(ref->>'framework_name'), ''), 'Unmapped') AS framework_name,
-    COALESCE(NULLIF(TRIM(ref->>'control_id'), ''), 'Needs mapping') AS control_id
-  FROM finding_scope
-  LEFT JOIN LATERAL jsonb_array_elements(
-    CASE
-      WHEN jsonb_array_length(control_refs_json) = 0
-        THEN '[{"framework_name":"Unmapped","control_id":"Needs mapping"}]'::jsonb
-      ELSE control_refs_json
-    END
-  ) AS ref ON TRUE
-  WHERE LOWER(status) = 'open'
+    ref.framework_name,
+    ref.control_id
+  FROM finding_scope AS finding
+  JOIN finding_control_refs AS ref ON ref.finding_id = finding.id
+  WHERE LOWER(finding.status) = 'open'
 ),
 evidence_summary AS (
   SELECT

--- a/internal/statestore/postgres/grc_dashboard_test.go
+++ b/internal/statestore/postgres/grc_dashboard_test.go
@@ -25,7 +25,7 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 		"WITH finding_scope AS",
 		"SELECT id, status,",
 		"COUNT(*) FILTER (WHERE LOWER(status) = 'open') AS open_findings",
-		"jsonb_array_elements",
+		"JOIN finding_control_refs AS ref ON ref.finding_id = finding.id",
 		"jsonb_build_object('framework_name', framework_name, 'control_id', control_id)",
 		"evidence_summary AS",
 		"jsonb_object_agg(finding_id, evidence_count)",
@@ -40,13 +40,29 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 	}
 	// The dashboard evidence total must follow finding_scope (all open findings),
 	// not a windowed preview finding-id list, so no positional finding_id filter.
-	for _, forbidden := range []string{`E'\x00'`, `|| E'`, "control_key", "finding_id IN ($7"} {
+	for _, forbidden := range []string{`E'\x00'`, `|| E'`, "control_key", "finding_id IN ($7", "jsonb_array_elements"} {
 		if strings.Contains(query, forbidden) {
 			t.Fatalf("aggregate query must not contain %q:\n%s", forbidden, query)
 		}
 	}
 	if len(args) != 6 {
 		t.Fatalf("aggregate query args len = %d, want 6 (%v)", len(args), args)
+	}
+}
+
+func TestFindingControlReferenceProjectionStaysInSync(t *testing.T) {
+	statements := strings.Join(ensureFindingStatements, "\n")
+	for _, fragment := range []string{
+		"CREATE TABLE IF NOT EXISTS finding_control_refs",
+		"PRIMARY KEY (finding_id, framework_name, control_id)",
+		"CREATE INDEX IF NOT EXISTS finding_control_refs_control_idx",
+		"CREATE OR REPLACE FUNCTION sync_finding_control_refs()",
+		"AFTER INSERT OR UPDATE OF control_refs_json ON findings",
+		"WHERE NOT EXISTS",
+	} {
+		if !strings.Contains(statements, fragment) {
+			t.Fatalf("finding control-reference projection missing %q", fragment)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- defer optional notification reads and disable eager navigation prefetch
- share console configuration, cache parsed OpenAPI metadata, and avoid duplicate unavailable retries
- run readiness dependency checks concurrently
- maintain indexed finding control references for dashboard aggregates

## Validation
- full Go test suite
- `go test -race ./internal/bootstrap ./internal/statestore/postgres -count=1`
- `make lint-bootstrap`
- all web tests on CI Node version
- web ESLint and production build
- `git diff --check`