### PR TITLE
Repair Okta connector validation family

### DIFF
--- a/internal/connectorvalidation/registry.yaml
+++ b/internal/connectorvalidation/registry.yaml
@@ -57,10 +57,10 @@ entries:
     evidence:
       - type: fixture
         ref: internal/connectorvalidation/testdata/cassettes/okta/users.json
-        resource_family: users
+        resource_family: user
         test: connector-contract-check
     resource_families:
-      - id: users
+      - id: user
         grade: fixture_validated
         evidence_refs:
           - internal/connectorvalidation/testdata/cassettes/okta/users.json


### PR DESCRIPTION
## Summary

- bind the Okta validation evidence to the current singular `user` resource family
- restore the fixture-backed connector contract check without changing the provider fixture or runtime mapping

## Verification

- `make connector-contract-check`
- `go test ./internal/connectorvalidation/... ./tools/connectorcontractcheck -count=1`
- `make catalog-check`
- `git diff --check`