### PR TITLE
Promote Mastodon collection authority to Rust

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -229,6 +229,7 @@ pub struct CompiledFamily {
     path: String,
     record_selector: String,
     scalar_record_field: Option<String>,
+    id_template: Option<String>,
     id_field: String,
     name_field: Option<String>,
     static_query: BTreeMap<String, String>,
@@ -261,6 +262,10 @@ impl CompiledFamily {
 
     pub fn scalar_record_field(&self) -> Option<&str> {
         self.scalar_record_field.as_deref()
+    }
+
+    pub fn id_template(&self) -> Option<&str> {
+        self.id_template.as_deref()
     }
 
     pub fn id_field(&self) -> &str {
@@ -483,6 +488,8 @@ struct DefinitionWire {
 #[derive(Deserialize)]
 struct ConfigFieldWire {
     key: String,
+    #[serde(default)]
+    required: bool,
 }
 
 #[derive(Deserialize)]
@@ -538,6 +545,8 @@ struct FamilyConfigWire {
     config_query: BTreeMap<String, String>,
     #[serde(default)]
     config_attributes: BTreeMap<String, String>,
+    #[serde(default)]
+    id_template: String,
 }
 
 #[derive(Default, Deserialize)]
@@ -774,8 +783,8 @@ fn compile_source(
         .definition
         .config_fields
         .iter()
-        .map(|field| field.key.as_str())
-        .collect::<BTreeSet<_>>();
+        .map(|field| (field.key.as_str(), field.required))
+        .collect::<BTreeMap<_, _>>();
     let generic_runtime_supported = classifier_supported
         && auth.supports_generic_runtime()
         && (auth != AuthModel::ApiKey
@@ -844,7 +853,7 @@ fn compile_family(
     family: FamilyWire,
     verified: &BTreeSet<(String, String, String)>,
     generic_runtime_supported: bool,
-    config_fields: &BTreeSet<&str>,
+    config_fields: &BTreeMap<&str, bool>,
 ) -> Result<CompiledFamily, CatalogError> {
     let method = match family.method.trim() {
         "" | "GET" => HttpMethod::Get,
@@ -909,11 +918,11 @@ fn compile_family(
         .iter()
         .filter_map(|parameter| {
             let binding = if let Some(field) = explicit_path_fanout.get(*parameter) {
-                config_fields
-                    .contains(field.as_str())
-                    .then(|| PathParameterBinding::CsvFanout {
+                config_fields.contains_key(field.as_str()).then(|| {
+                    PathParameterBinding::CsvFanout {
                         field: field.clone(),
-                    })
+                    }
+                })
             } else {
                 config_binding(parameter, config_fields)
             };
@@ -969,6 +978,19 @@ fn compile_family(
                 .entry(config_field.clone())
                 .or_insert_with(|| binding.clone());
         }
+    }
+    let id_template = family
+        .config
+        .as_ref()
+        .and_then(|config| optional(config.id_template.clone()));
+    if id_template
+        .as_deref()
+        .is_some_and(|template| !valid_id_template(template))
+    {
+        return invalid(
+            path,
+            &format!("family {} id_template is invalid", family.id),
+        );
     }
     let projection = family.projection.ok_or_else(|| CatalogError::Invalid {
         path: path.to_path_buf(),
@@ -1031,6 +1053,7 @@ fn compile_family(
         path: family.path,
         record_selector,
         scalar_record_field,
+        id_template,
         id_field: nonempty(path, "family id_field", family.id_field)?,
         name_field: optional(family.name_field),
         static_query: family.static_query,
@@ -1048,31 +1071,77 @@ fn compile_family(
     })
 }
 
-fn config_binding(requested: &str, config_fields: &BTreeSet<&str>) -> Option<PathParameterBinding> {
-    if config_fields.contains(requested) {
+fn config_binding(
+    requested: &str,
+    config_fields: &BTreeMap<&str, bool>,
+) -> Option<PathParameterBinding> {
+    if config_fields.contains_key(requested) {
         return Some(PathParameterBinding::ScalarConfig {
             field: requested.to_owned(),
         });
     }
     let plural = format!("{requested}s");
     config_fields
-        .contains(plural.as_str())
+        .contains_key(plural.as_str())
         .then_some(PathParameterBinding::CsvFanout { field: plural })
 }
 
 fn config_query_binding(
     requested: &str,
-    config_fields: &BTreeSet<&str>,
+    config_fields: &BTreeMap<&str, bool>,
 ) -> Option<PathParameterBinding> {
     let plural = format!("{requested}s");
-    if config_fields.contains(plural.as_str()) {
+    if config_fields.contains_key(plural.as_str()) {
         return Some(PathParameterBinding::CsvFanout { field: plural });
     }
-    config_fields
-        .contains(requested)
-        .then(|| PathParameterBinding::OptionalScalarConfig {
-            field: requested.to_owned(),
-        })
+    config_fields.get(requested).map(|required| {
+        if *required {
+            PathParameterBinding::ScalarConfig {
+                field: requested.to_owned(),
+            }
+        } else {
+            PathParameterBinding::OptionalScalarConfig {
+                field: requested.to_owned(),
+            }
+        }
+    })
+}
+
+fn valid_id_template(template: &str) -> bool {
+    if template.is_empty()
+        || template.len() > 1_024
+        || template.trim() != template
+        || template.chars().any(char::is_control)
+    {
+        return false;
+    }
+    let mut rest = template;
+    let mut placeholders = 0usize;
+    while let Some(start) = rest.find("${") {
+        if rest[..start].contains('{') || rest[..start].contains('}') {
+            return false;
+        }
+        let field_start = start + 2;
+        let Some(relative_end) = rest[field_start..].find('}') else {
+            return false;
+        };
+        let field_end = field_start + relative_end;
+        let field = &rest[field_start..field_end];
+        if field.is_empty()
+            || field.len() > 128
+            || field.split('.').any(|part| {
+                part.is_empty()
+                    || !part
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            })
+        {
+            return false;
+        }
+        placeholders += 1;
+        rest = &rest[field_end + 1..];
+    }
+    placeholders > 0 && !rest.contains('{') && !rest.contains('}')
 }
 
 fn compile_pagination(
@@ -1935,6 +2004,56 @@ mod tests {
                 .map(String::as_str),
             Some("status.id|account.id|id")
         );
+        let abuseipdb = catalog.get("abuseipdb").unwrap();
+        let abuseipdb_reports = abuseipdb
+            .families()
+            .iter()
+            .find(|family| family.id() == "reports")
+            .unwrap();
+        assert_eq!(
+            abuseipdb_reports.pagination(),
+            &Pagination::Page {
+                parameter: "page".to_owned(),
+                start: 1,
+                page_size_parameter: Some("perPage".to_owned()),
+                page_size: 100,
+            }
+        );
+        assert_eq!(
+            abuseipdb_reports.id_template(),
+            Some("${reportedAt}:${reporterId}")
+        );
+        assert_eq!(
+            abuseipdb_reports.config_query().get("ipAddress"),
+            Some(&PathParameterBinding::ScalarConfig {
+                field: "ip_address".to_owned()
+            })
+        );
+        assert_eq!(
+            abuseipdb_reports.config_query().get("maxAgeInDays"),
+            Some(&PathParameterBinding::OptionalScalarConfig {
+                field: "max_age_in_days".to_owned()
+            })
+        );
+        assert!(
+            !abuseipdb_reports
+                .projection()
+                .fields()
+                .contains_key("finding_id")
+        );
+        let abuseipdb_blacklist = abuseipdb
+            .families()
+            .iter()
+            .find(|family| family.id() == "ip_addresses")
+            .unwrap();
+        assert_eq!(abuseipdb_blacklist.pagination(), &Pagination::None);
+        assert_eq!(
+            abuseipdb_blacklist.static_query(),
+            &BTreeMap::from([
+                ("confidenceMinimum".to_owned(), "90".to_owned()),
+                ("limit".to_owned(), "10000".to_owned()),
+            ])
+        );
         for family in catalog.get("akeyless").unwrap().families() {
             assert_eq!(
                 family.cursor_in_json_body(),
@@ -1966,6 +2085,7 @@ mod tests {
             CollectionAuthority::Authoritative
         );
         for source_id in [
+            "abuseipdb",
             "akeneo",
             "akeyless",
             "apacta",
@@ -2000,6 +2120,33 @@ mod tests {
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly
         );
+    }
+
+    #[test]
+    fn composite_id_templates_are_closed_and_bounded() {
+        for valid in [
+            "${reportedAt}:${reporterId}",
+            "${namespace}/${name}",
+            "prefix-${nested.value}",
+        ] {
+            assert!(valid_id_template(valid), "{valid}");
+        }
+        for invalid in [
+            "",
+            "literal-only",
+            "${}",
+            "${missing",
+            "${bad field}",
+            "${nested..value}",
+            "${field}}",
+            " ${field}",
+        ] {
+            assert!(!valid_id_template(invalid), "{invalid}");
+        }
+        assert!(!valid_id_template(&format!(
+            "${{field}}{}",
+            "x".repeat(1_024)
+        )));
     }
 
     #[test]

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1842,6 +1842,99 @@ mod tests {
                 ..
             } if parameter == "size"
         ));
+        let mastodon = catalog.get("mastodon").unwrap();
+        let mastodon_account = mastodon
+            .families()
+            .iter()
+            .find(|family| family.id() == "account")
+            .unwrap();
+        assert_eq!(
+            mastodon_account.pagination(),
+            &Pagination::Link {
+                header: "Link".to_owned()
+            }
+        );
+        assert_eq!(
+            mastodon_account.static_query(),
+            &BTreeMap::from([("limit".to_owned(), "80".to_owned())])
+        );
+        assert_eq!(
+            mastodon_account
+                .projection()
+                .fields()
+                .get("user_id")
+                .map(String::as_str),
+            Some("id")
+        );
+        let mastodon_activity = mastodon
+            .families()
+            .iter()
+            .find(|family| family.id() == "activity")
+            .unwrap();
+        assert_eq!(mastodon_activity.id_field(), "week");
+        assert_eq!(
+            mastodon_activity
+                .projection()
+                .fields()
+                .get("provider_id")
+                .map(String::as_str),
+            Some("week")
+        );
+        assert_eq!(
+            mastodon_activity
+                .projection()
+                .static_fields()
+                .get("event_type")
+                .map(String::as_str),
+            Some("instance_activity")
+        );
+        let mastodon_credential = mastodon
+            .families()
+            .iter()
+            .find(|family| family.id() == "verify_credential")
+            .unwrap();
+        assert_eq!(mastodon_credential.record_selector(), "$");
+        assert_eq!(mastodon_credential.id_field(), "id");
+        assert_eq!(mastodon_credential.projection().template(), "identity_user");
+        assert_eq!(
+            mastodon_credential
+                .projection()
+                .fields()
+                .get("login")
+                .map(String::as_str),
+            Some("acct|username")
+        );
+        let mastodon_notification = mastodon
+            .families()
+            .iter()
+            .find(|family| family.id() == "notification")
+            .unwrap();
+        assert_eq!(
+            mastodon_notification.pagination(),
+            &Pagination::Link {
+                header: "Link".to_owned()
+            }
+        );
+        assert_eq!(
+            mastodon_notification.static_query(),
+            &BTreeMap::from([("limit".to_owned(), "80".to_owned())])
+        );
+        assert_eq!(
+            mastodon_notification
+                .projection()
+                .fields()
+                .get("alert_source")
+                .map(String::as_str),
+            Some("status.url|account.url")
+        );
+        assert_eq!(
+            mastodon_notification
+                .projection()
+                .fields()
+                .get("resource_id")
+                .map(String::as_str),
+            Some("status.id|account.id|id")
+        );
         for family in catalog.get("akeyless").unwrap().families() {
             assert_eq!(
                 family.cursor_in_json_body(),
@@ -1891,6 +1984,7 @@ mod tests {
             "fivetran",
             "google_vertex_ai",
             "jira",
+            "mastodon",
             "meraki",
             "onelogin",
             "qdrant_cloud",

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -36,6 +36,7 @@ use crate::{CollectedBatch, CollectedScope, CollectionRequest, SourceConnector, 
 const MAX_PAGES: usize = 10_000;
 const MAX_FANOUT_SCOPES: usize = 1_000;
 const MAX_RESPONSE_BYTES: usize = 16 << 20;
+const MAX_PROVIDER_ID_BYTES: usize = 1 << 10;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -593,14 +594,17 @@ impl SourceConnector for HttpSourceConnector {
                     let value =
                         normalize_selected_record(value, self.family.scalar_record_field())?;
                     validate_record_scope(self.family.id(), &value, &record_attributes)?;
-                    let provider_id =
+                    let provider_id = if let Some(template) = self.family.id_template() {
+                        render_id_template(self.family.id(), template, &value, &record_attributes)?
+                    } else {
                         scalar_at(&value, self.family.id_field()).ok_or_else(|| {
                             HttpConnectorError::InvalidResponse(format!(
                                 "family {} record is missing {}",
                                 self.family.id(),
                                 self.family.id_field()
                             ))
-                        })?;
+                        })?
+                    };
                     let mut fields = flatten_scalars(&value);
                     fields.extend(record_attributes.clone());
                     records.push(SourceRecord {
@@ -1409,6 +1413,55 @@ fn scalar_at(value: &Value, field: &str) -> Option<String> {
     scalar_at_path(value, field)
 }
 
+fn render_id_template(
+    family_id: &str,
+    template: &str,
+    value: &Value,
+    record_attributes: &BTreeMap<String, String>,
+) -> Result<String, HttpConnectorError> {
+    let mut rendered = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("${") {
+        rendered.push_str(&rest[..start]);
+        let field_start = start + 2;
+        let field_end = rest[field_start..].find('}').ok_or_else(|| {
+            HttpConnectorError::InvalidConfiguration(format!(
+                "family {family_id} has an invalid id template"
+            ))
+        })? + field_start;
+        let field = &rest[field_start..field_end];
+        let field_value = scalar_at_path(value, field)
+            .or_else(|| record_attributes.get(field).cloned())
+            .ok_or_else(|| {
+                HttpConnectorError::InvalidResponse(format!(
+                    "family {family_id} id template is missing {field}"
+                ))
+            })?;
+        if field_value.trim().is_empty()
+            || field_value.trim() != field_value
+            || field_value.len() > MAX_PROVIDER_ID_BYTES
+            || field_value.chars().any(char::is_control)
+        {
+            return Err(HttpConnectorError::InvalidResponse(format!(
+                "family {family_id} id template has an invalid {field}"
+            )));
+        }
+        rendered.push_str(&field_value);
+        rest = &rest[field_end + 1..];
+    }
+    rendered.push_str(rest);
+    if rendered.trim().is_empty()
+        || rendered.trim() != rendered
+        || rendered.len() > MAX_PROVIDER_ID_BYTES
+        || rendered.chars().any(char::is_control)
+    {
+        return Err(HttpConnectorError::InvalidResponse(format!(
+            "family {family_id} rendered an invalid provider id"
+        )));
+    }
+    Ok(rendered)
+}
+
 fn scalar_at_path(value: &Value, path: &str) -> Option<String> {
     let path = path.trim().trim_start_matches("$.").trim_start_matches('$');
     value_at_path(value, path).and_then(scalar)
@@ -1650,6 +1703,41 @@ mod tests {
             normalize_selected_record(object.clone(), None).unwrap(),
             object
         );
+    }
+
+    #[test]
+    fn composite_provider_ids_require_every_bounded_scalar() {
+        let payload = serde_json::json!({
+            "reportedAt": "2026-07-29T00:00:00Z",
+            "reporter": {"id": 43121}
+        });
+        let attributes = BTreeMap::from([("scope".to_owned(), "tenant-a".to_owned())]);
+        assert_eq!(
+            render_id_template(
+                "reports",
+                "${reportedAt}:${reporter.id}:${scope}",
+                &payload,
+                &attributes,
+            )
+            .unwrap(),
+            "2026-07-29T00:00:00Z:43121:tenant-a"
+        );
+        assert!(matches!(
+            render_id_template("reports", "${reportedAt}:${missing}", &payload, &attributes),
+            Err(HttpConnectorError::InvalidResponse(_))
+        ));
+        for invalid in ["", " ", " padded", "line\nbreak"] {
+            let payload = serde_json::json!({"id": invalid});
+            assert!(matches!(
+                render_id_template("reports", "report:${id}", &payload, &BTreeMap::new()),
+                Err(HttpConnectorError::InvalidResponse(_))
+            ));
+        }
+        let oversized = serde_json::json!({"id": "x".repeat(MAX_PROVIDER_ID_BYTES + 1)});
+        assert!(matches!(
+            render_id_template("reports", "${id}", &oversized, &BTreeMap::new()),
+            Err(HttpConnectorError::InvalidResponse(_))
+        ));
     }
 
     #[test]
@@ -2200,6 +2288,204 @@ mod tests {
         server.await.unwrap();
         assert_eq!(batch.records.len(), 1);
         assert_eq!(batch.records[0].provider_id, "group-1");
+    }
+
+    #[tokio::test]
+    async fn abuseipdb_reports_use_required_scope_pages_and_composite_ids() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for page in 1..=2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let read = socket.read(&mut request).await.unwrap();
+                let request = String::from_utf8_lossy(&request[..read]);
+                let request_line = request.lines().next().unwrap();
+                assert!(request_line.starts_with("GET /reports?"));
+                assert!(request_line.contains("ipAddress=203.0.113.9"));
+                assert!(request_line.contains("maxAgeInDays=90"));
+                assert!(request_line.contains("perPage=100"));
+                assert!(request_line.contains(&format!("page={page}")));
+                assert!(
+                    request
+                        .lines()
+                        .any(|line| line.eq_ignore_ascii_case("key: abuseipdb-secret"))
+                );
+                let results = if page == 1 {
+                    (1..=100)
+                        .map(|reporter_id| {
+                            serde_json::json!({
+                                "reportedAt": "2026-07-29T00:00:00Z",
+                                "reporterId": reporter_id,
+                                "comment": format!("Report {reporter_id}")
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    vec![serde_json::json!({
+                        "reportedAt": "2026-07-29T00:00:00Z",
+                        "reporterId": 101,
+                        "comment": "Report 101"
+                    })]
+                };
+                let body = serde_json::json!({
+                    "data": {
+                        "page": page,
+                        "perPage": 100,
+                        "results": results
+                    }
+                })
+                .to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("abuseipdb")
+        .unwrap()
+        .clone();
+        assert_eq!(
+            source.authority(),
+            cerebro_source_catalog::CollectionAuthority::Authoritative
+        );
+        assert!(matches!(
+            HttpSourceConnector::new(
+                source.clone(),
+                "reports",
+                &format!("http://{address}"),
+                BTreeMap::new(),
+                ResolvedAuth::Header {
+                    name: "Key".to_owned(),
+                    value: "abuseipdb-secret".to_owned(),
+                },
+            )
+            .unwrap()
+            .request_scopes(),
+            Err(HttpConnectorError::InvalidConfiguration(_))
+        ));
+        let mut connector = HttpSourceConnector::new(
+            source.clone(),
+            "reports",
+            &format!("http://{address}"),
+            BTreeMap::from([
+                ("ip_address".to_owned(), "203.0.113.9".to_owned()),
+                ("max_age_in_days".to_owned(), "90".to_owned()),
+            ]),
+            ResolvedAuth::Header {
+                name: "Key".to_owned(),
+                value: "abuseipdb-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("abuseipdb-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 101);
+        assert_eq!(batch.records[0].provider_id, "2026-07-29T00:00:00Z:1");
+        assert_eq!(batch.records[99].provider_id, "2026-07-29T00:00:00Z:100");
+        assert_eq!(batch.records[100].provider_id, "2026-07-29T00:00:00Z:101");
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.entities().len(), 101);
+        assert_eq!(
+            delta
+                .entities()
+                .iter()
+                .map(|entity| entity.id())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            101
+        );
+    }
+
+    #[tokio::test]
+    async fn abuseipdb_blacklist_is_one_bounded_filtered_response() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            let request_line = request.lines().next().unwrap();
+            assert!(request_line.starts_with("GET /blacklist?"));
+            assert!(request_line.contains("confidenceMinimum=75"));
+            assert!(request_line.contains("ipVersion=6"));
+            assert!(request_line.contains("limit=10000"));
+            assert!(!request_line.contains("cursor="));
+            assert!(!request_line.contains("page="));
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("key: abuseipdb-secret"))
+            );
+            let body = r#"{"meta":{"generatedAt":"2026-07-29T00:00:00Z"},"data":[{"ipAddress":"2607:ff10:c8:594::9","abuseConfidenceScore":100,"lastReportedAt":"2026-07-28T23:59:00Z"},{"ipAddress":"2001:db8::1","abuseConfidenceScore":99,"lastReportedAt":"2026-07-28T23:58:00Z"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("abuseipdb")
+        .unwrap()
+        .clone();
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "ip_addresses",
+            &format!("http://{address}"),
+            BTreeMap::from([
+                ("confidence_minimum".to_owned(), "75".to_owned()),
+                ("ip_version".to_owned(), "6".to_owned()),
+            ]),
+            ResolvedAuth::Header {
+                name: "Key".to_owned(),
+                value: "abuseipdb-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("abuseipdb-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(
+            batch
+                .records
+                .iter()
+                .map(|record| record.provider_id.as_str())
+                .collect::<Vec<_>>(),
+            ["2607:ff10:c8:594::9", "2001:db8::1"]
+        );
     }
 
     #[tokio::test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -2285,6 +2285,232 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mastodon_verify_credentials_collects_the_single_authenticated_account() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /api/v1/accounts/verify_credentials HTTP/1.1\r\n"));
+            assert!(!request.lines().next().unwrap().contains('?'));
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("authorization: Bearer mastodon-secret"))
+            );
+            let body = include_str!(
+                "../../../sources/mastodon/testdata/api/verify_credential/verify_credentials/response.json"
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("mastodon")
+        .unwrap()
+        .clone();
+        assert_eq!(
+            source.authority(),
+            cerebro_source_catalog::CollectionAuthority::Authoritative
+        );
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "verify_credential",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            ResolvedAuth::Bearer {
+                token: "mastodon-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("mastodon-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].provider_id, "116387031229467654");
+        assert_eq!(
+            batch.records[0].payload.get("acct").and_then(Value::as_str),
+            Some("mastodonpy_test")
+        );
+        assert!(batch.records[0].payload.get("emojis").unwrap().is_array());
+    }
+
+    #[tokio::test]
+    async fn mastodon_activity_uses_week_instead_of_login_count_as_provider_id() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /api/v1/instance/activity HTTP/1.1\r\n"));
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("authorization: Bearer mastodon-secret"))
+            );
+            let body = include_str!(
+                "../../../sources/mastodon/testdata/api/activity/instance_activity/response.json"
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("mastodon")
+        .unwrap()
+        .clone();
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "activity",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            ResolvedAuth::Bearer {
+                token: "mastodon-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("mastodon-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(batch.records.len(), 12);
+        assert_eq!(batch.records[0].provider_id, "1775949325");
+        assert!(batch.records.iter().all(|record| record.provider_id != "4"));
+        assert_eq!(
+            batch
+                .records
+                .iter()
+                .map(|record| record.provider_id.as_str())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            12
+        );
+    }
+
+    #[tokio::test]
+    async fn mastodon_notifications_follow_provider_links_without_page_numbers() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for page in 1..=2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let read = socket.read(&mut request).await.unwrap();
+                let request = String::from_utf8_lossy(&request[..read]);
+                let request_line = request.lines().next().unwrap();
+                assert!(request_line.starts_with("GET /api/v1/notifications?"));
+                assert!(request_line.contains("limit=80"));
+                assert!(!request_line.contains("page="));
+                assert_eq!(request_line.contains("max_id=24"), page == 2);
+                assert!(request.lines().any(|line| {
+                    line.eq_ignore_ascii_case("authorization: Bearer mastodon-secret")
+                }));
+                let body = if page == 1 {
+                    r#"[{"id":"24","type":"mention","group_key":"ungrouped-24","account":{"id":"116387030920493064","acct":"admin","url":"https://mastodon.example/@admin"},"status":{"id":"status-24","url":"https://mastodon.example/@admin/24"}}]"#
+                } else {
+                    r#"[{"id":"23","type":"follow","group_key":"ungrouped-23","account":{"id":"116387031229467654","acct":"mastodonpy_test","url":"https://mastodon.example/@mastodonpy_test"},"status":null}]"#
+                };
+                let link = if page == 1 {
+                    format!(
+                        "link: <http://{address}/api/v1/notifications?max_id=24&limit=80>; rel=\"next\"\r\n"
+                    )
+                } else {
+                    String::new()
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n{link}content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("mastodon")
+        .unwrap()
+        .clone();
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "notification",
+            &format!("http://{address}"),
+            BTreeMap::new(),
+            ResolvedAuth::Bearer {
+                token: "mastodon-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("mastodon-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(
+            batch
+                .records
+                .iter()
+                .map(|record| record.provider_id.as_str())
+                .collect::<Vec<_>>(),
+            ["24", "23"]
+        );
+        assert_eq!(
+            batch.records[0]
+                .payload
+                .pointer("/status/id")
+                .and_then(Value::as_str),
+            Some("status-24")
+        );
+        assert_eq!(
+            batch.records[1]
+                .payload
+                .pointer("/account/id")
+                .and_then(Value::as_str),
+            Some("116387031229467654")
+        );
+    }
+
+    #[tokio::test]
     async fn meraki_v1_access_policy_uses_the_proven_path_and_bearer_header() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -78,6 +78,12 @@ also need separate Rust ownership work.
 API-key collection authority also requires an explicit checked-in header and
 scheme contract. A provider proof manifest does not make a source
 Rust-authoritative when credential placement is still implicit or bespoke.
+Required provider query scope is compiled from checked-in configuration and
+must resolve before Rust makes a provider request. Provider records may also
+use a checked-in composite identity template when the provider has no stable
+single-field identifier. Rust validates those templates at catalog load,
+requires every referenced record value, and rejects blank, control-bearing, or
+oversized rendered identities before mapping or graph admission.
 
 `cerebro-agent-context` exposes bounded search, lookup, expansion, path, and explanation operations. It does not expose Cypher or store mutation.
 

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -240,7 +240,7 @@ The current checked-in catalog compiles to 794 sources and 3,891 families:
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 51 sources and 347 families are authoritative; the other 743 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 52 sources and 351 families are authoritative; the other 742 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/internal/connectorcatalog/catalog/collaboration-productivity/mastodon.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/mastodon.yaml
@@ -79,6 +79,7 @@ entries:
         kind: mastodon.activity
         required_payload_fields:
         - logins
+        - week
         schema_ref: mastodon/activity/v1
         urn_kind: mastodon_activity
       event_kind: activity

--- a/internal/connectorcatalog/catalog/collaboration-productivity/mastodon.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/mastodon.yaml
@@ -17,7 +17,7 @@ entries:
       key: id
       label: Id
       required: true
-    description: "Collects account, activity, verify credential, and notification from Mastodon and projects them into the Cerebro graph as users, audit events, secrets, and alerts for workspace, document, message, and collaboration context."
+    description: "Collects list accounts, instance activity, the authenticated account, and notifications from Mastodon and projects them into the Cerebro graph as users, audit events, and alerts."
     display_name: Mastodon
     id: builtin_catalog-mastodon
     resource_families:
@@ -47,9 +47,8 @@ entries:
       method: GET
       name_field: display_name
       pagination:
-        page_size: 100
-        page_size_param: limit
-        type: page
+        link_header: Link
+        type: link
       path: "/api/v1/lists/${config.id}/accounts"
       permissions_needed:
       - bearerAuth
@@ -58,8 +57,11 @@ entries:
           id: id
           name: display_name
           provider_id: id
+          user_id: id
         template: identity_user
       record_selector: "$[*]"
+      static_query:
+        limit: "80"
     - coverage:
       - families:
         - activity
@@ -81,18 +83,21 @@ entries:
         urn_kind: mastodon_activity
       event_kind: activity
       id: activity
-      id_field: logins
+      id_field: week
       label: Activity
       method: GET
-      name_field: logins
+      name_field: week
       pagination:
         type: none
       path: "/api/v1/instance/activity"
       projection:
         fields:
-          id: logins
-          name: logins
-          provider_id: logins
+          id: week
+          name: week
+          provider_id: week
+        static_fields:
+          actor_id: mastodon_instance
+          event_type: instance_activity
         template: audit_event
       record_selector: "$[*]"
     - coverage:
@@ -111,16 +116,15 @@ entries:
       event:
         kind: mastodon.verify_credential
         required_payload_fields:
-        - category
+        - id
         schema_ref: mastodon/verify_credential/v1
         urn_kind: mastodon_verify_credential
       event_kind: verify_credential
       id: verify_credential
-      id_field: category
+      id_field: id
       label: Verify Credential
-      list_key: emojis
       method: GET
-      name_field: url
+      name_field: display_name
       pagination:
         type: none
       path: "/api/v1/accounts/verify_credentials"
@@ -128,13 +132,14 @@ entries:
       - bearerAuth
       projection:
         fields:
-          id: category
-          name: url
-          secret_id: category
-          secret_name: url
-          secret_type: verify_credential
-        template: secret
-      record_selector: "$.emojis[*]"
+          display_name: display_name|username|acct
+          id: id
+          login: acct|username
+          name: display_name|username|acct
+          provider_id: id
+          user_id: id
+        template: identity_user
+      record_selector: "$"
     - coverage:
       - families:
         - notification
@@ -160,24 +165,27 @@ entries:
       id_field: id
       label: Notification
       method: GET
-      name_field: account
+      name_field: type
       pagination:
-        page_size: 100
-        page_size_param: limit
-        type: page
+        link_header: Link
+        type: link
       path: "/api/v1/notifications"
       permissions_needed:
       - bearerAuth
       projection:
         fields:
           alert_id: id
-          alert_name: account
-          alert_severity: account
-          alert_status: status
+          alert_name: type|group_key
+          alert_source: status.url|account.url
+          alert_type: type
           id: id
-          name: account
+          name: type|group_key
+          resource_id: status.id|account.id|id
+          resource_name: status.url|account.acct|type
         template: alert
       record_selector: "$[*]"
+      static_query:
+        limit: "80"
     schema_version: cerebro.integration/v1
     scope_options:
     - default_enabled: true

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/abuseipdb.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/abuseipdb.yaml
@@ -11,6 +11,20 @@ entries:
       categories:
         - threat_intel
         - security
+      config_fields:
+        - help: IP address whose report history will be collected.
+          key: ip_address
+          label: IP address
+          required: true
+        - help: Optional report lookback from 1 to 365 days.
+          key: max_age_in_days
+          label: Maximum age in days
+        - help: Optional blacklist confidence threshold from 25 to 100.
+          key: confidence_minimum
+          label: Confidence minimum
+        - help: Optional blacklist IP version, either 4 or 6.
+          key: ip_version
+          label: IP version
       description: Collects AbuseIPDB report history and blacklist IP reputation snapshots, then projects them into the Cerebro graph as findings and threat-intelligence assets for alert, incident, service health, and response context.
       display_name: AbuseIPDB
       id: builtin-abuseipdb
@@ -31,6 +45,7 @@ entries:
             kind: abuseipdb.reports
             required_payload_fields:
               - reportedAt
+              - reporterId
             schema_ref: abuseipdb/reports/v1
             urn_kind: abuseipdb_reports
           id: reports
@@ -38,17 +53,28 @@ entries:
           label: Reports
           method: GET
           pagination:
-            cursor_json_path: $.data.nextPageUrl
-            cursor_param: page
-            page_size: 25
+            page_param: page
+            page_size: 100
             page_size_param: perPage
-            type: cursor
+            start_page: 1
+            type: page
           path: /reports
+          config:
+            config_attributes:
+              resource_id: ip_address
+              resource_name: ip_address
+            config_query:
+              ipAddress: ip_address
+              maxAgeInDays: max_age_in_days
+            id_template: "${reportedAt}:${reporterId}"
           projection:
             fields:
               description: comment
-              finding_id: reportedAt
-              resource_id: ipAddress
+              title: comment
+            static_fields:
+              resource_type: abuseipdb_report
+              severity: reported
+              status: observed
             template: finding
           record_selector: $.data.results[*]
         - coverage:
@@ -74,19 +100,23 @@ entries:
           label: IP addresses
           method: GET
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
-            page_size: 100
-            page_size_param: limit
-            type: cursor
+            type: none
           path: /blacklist
+          config:
+            config_query:
+              confidenceMinimum: confidence_minimum
+              ipVersion: ip_version
           projection:
             fields:
               resource_id: ipAddress
-              resource_type: resource_type|type|kind
-              resource_urn: resource_urn|urn|metadata.resource_urn
+              resource_name: ipAddress
+            static_fields:
+              resource_type: ip_address
             template: asset
           record_selector: $.data[*]
+          static_query:
+            confidenceMinimum: "90"
+            limit: "10000"
       schema_version: cerebro.integration/v1
       source_id: abuseipdb
       tenant_id: builtin_catalog

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -829,6 +829,65 @@ func TestBuiltinMastodonPreservesProviderContracts(t *testing.T) {
 	}
 }
 
+func TestBuiltinAbuseIPDBPreservesProviderContracts(t *testing.T) {
+	entry, ok, err := BuiltinEntry("abuseipdb")
+	if err != nil {
+		t.Fatalf("BuiltinEntry(abuseipdb) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(abuseipdb) ok = false, want true")
+	}
+	if entry.Definition.Auth.Model != "api_key" ||
+		entry.Definition.Auth.TokenHeader != "Key" ||
+		entry.Definition.Auth.TokenScheme != "" {
+		t.Fatalf("abuseipdb auth = %#v, want exact Key header", entry.Definition.Auth)
+	}
+
+	reports := catalogFamily(t, entry.Definition.ResourceFamilies, "reports")
+	if reports.Pagination == nil ||
+		reports.Pagination.Type != "page" ||
+		reports.Pagination.PageParam != "page" ||
+		reports.Pagination.PageSizeParam != "perPage" ||
+		reports.Pagination.PageSize != 100 {
+		t.Fatalf("reports pagination = %#v, want page/perPage with 100 records", reports.Pagination)
+	}
+	if reports.Config == nil ||
+		reports.Config.ConfigQuery["ipAddress"] != "ip_address" ||
+		reports.Config.ConfigQuery["maxAgeInDays"] != "max_age_in_days" ||
+		reports.Config.ConfigAttributes["resource_id"] != "ip_address" ||
+		reports.Config.IDTemplate != "${reportedAt}:${reporterId}" {
+		t.Fatalf("reports config = %#v, want scoped query and composite identity", reports.Config)
+	}
+	if reports.Projection == nil ||
+		reports.Projection.Fields["title"] != "comment" ||
+		reports.Projection.StaticFields["status"] != "observed" ||
+		reports.Projection.StaticFields["severity"] != "reported" {
+		t.Fatalf("reports projection = %#v, want finding fields", reports.Projection)
+	}
+	if _, ok := reports.Projection.Fields["finding_id"]; ok {
+		t.Fatalf("reports projection = %#v, must not collapse findings by timestamp", reports.Projection)
+	}
+
+	blacklist := catalogFamily(t, entry.Definition.ResourceFamilies, "ip_addresses")
+	if blacklist.Pagination == nil || blacklist.Pagination.Type != "none" {
+		t.Fatalf("ip_addresses pagination = %#v, want one bounded response", blacklist.Pagination)
+	}
+	if blacklist.StaticQuery["confidenceMinimum"] != "90" || blacklist.StaticQuery["limit"] != "10000" {
+		t.Fatalf("ip_addresses static query = %#v, want bounded blacklist contract", blacklist.StaticQuery)
+	}
+	if blacklist.Config == nil ||
+		blacklist.Config.ConfigQuery["confidenceMinimum"] != "confidence_minimum" ||
+		blacklist.Config.ConfigQuery["ipVersion"] != "ip_version" {
+		t.Fatalf("ip_addresses config = %#v, want provider filters", blacklist.Config)
+	}
+	if blacklist.Projection == nil ||
+		blacklist.Projection.Fields["resource_id"] != "ipAddress" ||
+		blacklist.Projection.Fields["resource_name"] != "ipAddress" ||
+		blacklist.Projection.StaticFields["resource_type"] != "ip_address" {
+		t.Fatalf("ip_addresses projection = %#v, want IP resource fields", blacklist.Projection)
+	}
+}
+
 func TestBuiltinCatalogIncludesAdditionalGapEntries(t *testing.T) {
 	for sourceID, wantStatus := range map[string]string{
 		"checkr":        StatusGenerateable,

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -759,6 +759,76 @@ func TestBuiltinBotifyPreservesScalarRecordAndPageSizeContracts(t *testing.T) {
 	}
 }
 
+func TestBuiltinMastodonPreservesProviderContracts(t *testing.T) {
+	entry, ok, err := BuiltinEntry("mastodon")
+	if err != nil {
+		t.Fatalf("BuiltinEntry(mastodon) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(mastodon) ok = false, want true")
+	}
+	if entry.Definition.Auth.Model != "bearer_token" {
+		t.Fatalf("mastodon auth = %#v, want bearer_token", entry.Definition.Auth)
+	}
+
+	account := catalogFamily(t, entry.Definition.ResourceFamilies, "account")
+	if account.Pagination == nil || account.Pagination.Type != "link" || account.Pagination.LinkHeader != "Link" {
+		t.Fatalf("account pagination = %#v, want Link header pagination", account.Pagination)
+	}
+	if account.StaticQuery["limit"] != "80" || account.IDField != "id" {
+		t.Fatalf("account contract = %#v, want limit=80 and id_field=id", account)
+	}
+	if account.Projection == nil || account.Projection.Fields["user_id"] != "id" {
+		t.Fatalf("account projection = %#v, want user_id=id", account.Projection)
+	}
+
+	activity := catalogFamily(t, entry.Definition.ResourceFamilies, "activity")
+	if activity.IDField != "week" || activity.NameField != "week" {
+		t.Fatalf("activity identity = %#v, want week", activity)
+	}
+	if activity.Projection == nil ||
+		activity.Projection.Fields["id"] != "week" ||
+		activity.Projection.Fields["provider_id"] != "week" ||
+		activity.Projection.StaticFields["actor_id"] != "mastodon_instance" ||
+		activity.Projection.StaticFields["event_type"] != "instance_activity" {
+		t.Fatalf("activity projection = %#v, want stable weekly activity fields", activity.Projection)
+	}
+
+	credential := catalogFamily(t, entry.Definition.ResourceFamilies, "verify_credential")
+	if credential.RecordSelector != "$" || credential.IDField != "id" {
+		t.Fatalf("verify_credential contract = %#v, want singleton root account identified by id", credential)
+	}
+	if len(credential.Event.RequiredPayloadFields) != 1 || credential.Event.RequiredPayloadFields[0] != "id" {
+		t.Fatalf("verify_credential required payload = %#v, want id", credential.Event.RequiredPayloadFields)
+	}
+	if credential.Projection == nil ||
+		credential.Projection.Template != "identity_user" ||
+		credential.Projection.Fields["user_id"] != "id" ||
+		credential.Projection.Fields["login"] != "acct|username" {
+		t.Fatalf("verify_credential projection = %#v, want authenticated identity mapping", credential.Projection)
+	}
+
+	notification := catalogFamily(t, entry.Definition.ResourceFamilies, "notification")
+	if notification.Pagination == nil || notification.Pagination.Type != "link" || notification.Pagination.LinkHeader != "Link" {
+		t.Fatalf("notification pagination = %#v, want Link header pagination", notification.Pagination)
+	}
+	if notification.StaticQuery["limit"] != "80" || notification.NameField != "type" {
+		t.Fatalf("notification contract = %#v, want limit=80 and scalar name field", notification)
+	}
+	if notification.Projection == nil ||
+		notification.Projection.Fields["alert_type"] != "type" ||
+		notification.Projection.Fields["alert_source"] != "status.url|account.url" ||
+		notification.Projection.Fields["resource_id"] != "status.id|account.id|id" {
+		t.Fatalf("notification projection = %#v, want nested scalar notification fields", notification.Projection)
+	}
+	if _, ok := notification.Projection.Fields["alert_severity"]; ok {
+		t.Fatalf("notification projection = %#v, must not map an account object to severity", notification.Projection)
+	}
+	if _, ok := notification.Projection.Fields["alert_status"]; ok {
+		t.Fatalf("notification projection = %#v, must not map a status object to state", notification.Projection)
+	}
+}
+
 func TestBuiltinCatalogIncludesAdditionalGapEntries(t *testing.T) {
 	for sourceID, wantStatus := range map[string]string{
 		"checkr":        StatusGenerateable,

--- a/sources/abuseipdb/catalog.yaml
+++ b/sources/abuseipdb/catalog.yaml
@@ -15,16 +15,13 @@ kind_lifecycle:
 provider_api:
   status: verified
   basis: declared
-  verified_at: 2026-07-06T00:00:00Z
+  verified_at: 2026-07-29T00:00:00Z
   transport: rest
   auth: api_key
   auth_mechanics: key_header
   base_url: https://api.abuseipdb.com/api/v2
-  spec_url: https://raw.githubusercontent.com/api-evangelist/abuseipdb/main/openapi/abuseipdb-apiv2-openapi.yml
-  spec_kind: openapi
   references:
     - https://docs.abuseipdb.com/
-    - https://www.abuseipdb.com/api.html
   families:
     - id: ip_addresses
       method: GET
@@ -47,7 +44,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Reads documented AbuseIPDB blacklist entries from GET /blacklist.
+        - Official API documentation verifies GET /blacklist, Key header authentication, the bounded limit response, optional confidence and IP-version filters, and stable ipAddress identity.
     - id: reports
       type: remediation_state
       title: "Reports"
@@ -57,7 +54,7 @@ coverage_contract:
       evidence_types: [remediation_state]
       control_domains: [remediation]
       notes:
-        - Reads documented AbuseIPDB report history for a configured IP address from GET /reports.
+        - Official API documentation verifies GET /reports, required ipAddress scope, numbered page and perPage pagination, and the reportedAt plus reporterId record identity.
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync

--- a/sources/abuseipdb/catalog.yaml
+++ b/sources/abuseipdb/catalog.yaml
@@ -73,6 +73,7 @@ event_contracts:
       - status
     required_payload_fields:
       - reportedAt
+      - reporterId
   - kind: abuseipdb.ip_addresses
     schema_ref: abuseipdb/ip_addresses/v1
     required_attributes:

--- a/sources/mastodon/catalog.yaml
+++ b/sources/mastodon/catalog.yaml
@@ -11,6 +11,38 @@ runtime_families:
   - activity
   - notification
   - verify_credential
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-07-29T00:00:00Z
+  transport: rest
+  auth: bearer_token
+  auth_mechanics: authorization_bearer_header
+  base_url: https://mastodon.social
+  references:
+    - https://docs.joinmastodon.org/methods/lists/
+    - https://docs.joinmastodon.org/methods/instance/
+    - https://docs.joinmastodon.org/methods/accounts/
+    - https://docs.joinmastodon.org/methods/notifications/
+  auth_evidence:
+    - https://docs.joinmastodon.org/api/oauth-tokens/
+  families:
+    - id: account
+      method: GET
+      path: /api/v1/lists/{id}/accounts
+      operation: getListAccounts
+    - id: activity
+      method: GET
+      path: /api/v1/instance/activity
+      operation: getInstanceActivity
+    - id: verify_credential
+      method: GET
+      path: /api/v1/accounts/verify_credentials
+      operation: verifyAccountCredentials
+    - id: notification
+      method: GET
+      path: /api/v1/notifications
+      operation: getNotifications
 kind_lifecycle:
   - kind: mastodon.account
     status: active
@@ -33,7 +65,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Official API documentation and the captured provider response verify the list-scoped path, Link pagination, Account selector, and account identifier.
     - id: activity
       type: audit_event
       title: "Activity"
@@ -43,7 +75,7 @@ coverage_contract:
       evidence_types: [logging_configuration]
       control_domains: [logging_monitoring]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Official API documentation and the captured provider response verify the weekly activity path, array response, and week identifier.
     - id: verify_credential
       type: entity_family
       title: "Verify Credential"
@@ -53,7 +85,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Official API documentation and the captured provider response verify the singleton CredentialAccount response and account identifier.
     - id: notification
       type: alert_state
       title: "Notification"
@@ -63,7 +95,7 @@ coverage_contract:
       evidence_types: [security_monitoring]
       control_domains: [logging_monitoring, security_operations]
       notes:
-        - Generated Source Runtime SDK mapping requires provider field review before certification.
+        - Official API documentation and the captured provider response verify Link pagination, notification identifiers, types, and nested account and status fields.
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync

--- a/sources/mastodon/catalog.yaml
+++ b/sources/mastodon/catalog.yaml
@@ -120,6 +120,7 @@ event_contracts:
       - actor_id
     required_payload_fields:
       - logins
+      - week
   - kind: mastodon.verify_credential
     schema_ref: mastodon/verify_credential/v1
     required_attributes:


### PR DESCRIPTION
## Summary

- verify the four current Mastodon collection contracts and promote them only through the native Rust catalog and HTTP runtime
- follow provider `Link` cursors for list accounts and notifications with the bounded `limit=80` contract
- identify weekly activity by `week`, collect the root credential account by account ID, and map nested notification fields to scalar alert attributes
- advance the authority ledger to 52 sources and 351 families, leaving 742 sources shadow-only

## Authority boundary

This marks these four families authoritative because their exact paths, bearer authentication, selectors, pagination, identifiers, and native projection templates are proven and executable in Rust. It does not claim that the remaining shadow sources or compatibility routes are Rust-owned.

## Verification

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./sources/mastodon -count=1`
- `cargo test -p cerebro-source-catalog`
- `cargo test -p cerebro-source-runtime-next -- --test-threads=1`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make catalog-check sourcegen-check connector-catalog-fidelity-check`
- `make docs-drift-check check-structural check-structural-test check-arch`
- `make rust-coverage` - 90.30 percent line coverage
- `cargo fmt --all -- --check`
- `git diff --check`

The exact base also contains a stale Okta fixture-family reference. That independent validation defect is repaired in #2143; this PR does not change Okta validation state.