### PR TITLE
Correct AbuseIPDB Rust collection authority

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -229,6 +229,7 @@ pub struct CompiledFamily {
     path: String,
     record_selector: String,
     scalar_record_field: Option<String>,
+    id_template: Option<String>,
     id_field: String,
     name_field: Option<String>,
     static_query: BTreeMap<String, String>,
@@ -261,6 +262,10 @@ impl CompiledFamily {
 
     pub fn scalar_record_field(&self) -> Option<&str> {
         self.scalar_record_field.as_deref()
+    }
+
+    pub fn id_template(&self) -> Option<&str> {
+        self.id_template.as_deref()
     }
 
     pub fn id_field(&self) -> &str {
@@ -483,6 +488,8 @@ struct DefinitionWire {
 #[derive(Deserialize)]
 struct ConfigFieldWire {
     key: String,
+    #[serde(default)]
+    required: bool,
 }
 
 #[derive(Deserialize)]
@@ -538,6 +545,8 @@ struct FamilyConfigWire {
     config_query: BTreeMap<String, String>,
     #[serde(default)]
     config_attributes: BTreeMap<String, String>,
+    #[serde(default)]
+    id_template: String,
 }
 
 #[derive(Default, Deserialize)]
@@ -774,8 +783,8 @@ fn compile_source(
         .definition
         .config_fields
         .iter()
-        .map(|field| field.key.as_str())
-        .collect::<BTreeSet<_>>();
+        .map(|field| (field.key.as_str(), field.required))
+        .collect::<BTreeMap<_, _>>();
     let generic_runtime_supported = classifier_supported
         && auth.supports_generic_runtime()
         && (auth != AuthModel::ApiKey
@@ -844,7 +853,7 @@ fn compile_family(
     family: FamilyWire,
     verified: &BTreeSet<(String, String, String)>,
     generic_runtime_supported: bool,
-    config_fields: &BTreeSet<&str>,
+    config_fields: &BTreeMap<&str, bool>,
 ) -> Result<CompiledFamily, CatalogError> {
     let method = match family.method.trim() {
         "" | "GET" => HttpMethod::Get,
@@ -909,11 +918,11 @@ fn compile_family(
         .iter()
         .filter_map(|parameter| {
             let binding = if let Some(field) = explicit_path_fanout.get(*parameter) {
-                config_fields
-                    .contains(field.as_str())
-                    .then(|| PathParameterBinding::CsvFanout {
+                config_fields.contains_key(field.as_str()).then(|| {
+                    PathParameterBinding::CsvFanout {
                         field: field.clone(),
-                    })
+                    }
+                })
             } else {
                 config_binding(parameter, config_fields)
             };
@@ -969,6 +978,19 @@ fn compile_family(
                 .entry(config_field.clone())
                 .or_insert_with(|| binding.clone());
         }
+    }
+    let id_template = family
+        .config
+        .as_ref()
+        .and_then(|config| optional(config.id_template.clone()));
+    if id_template
+        .as_deref()
+        .is_some_and(|template| !valid_id_template(template))
+    {
+        return invalid(
+            path,
+            &format!("family {} id_template is invalid", family.id),
+        );
     }
     let projection = family.projection.ok_or_else(|| CatalogError::Invalid {
         path: path.to_path_buf(),
@@ -1031,6 +1053,7 @@ fn compile_family(
         path: family.path,
         record_selector,
         scalar_record_field,
+        id_template,
         id_field: nonempty(path, "family id_field", family.id_field)?,
         name_field: optional(family.name_field),
         static_query: family.static_query,
@@ -1048,31 +1071,77 @@ fn compile_family(
     })
 }
 
-fn config_binding(requested: &str, config_fields: &BTreeSet<&str>) -> Option<PathParameterBinding> {
-    if config_fields.contains(requested) {
+fn config_binding(
+    requested: &str,
+    config_fields: &BTreeMap<&str, bool>,
+) -> Option<PathParameterBinding> {
+    if config_fields.contains_key(requested) {
         return Some(PathParameterBinding::ScalarConfig {
             field: requested.to_owned(),
         });
     }
     let plural = format!("{requested}s");
     config_fields
-        .contains(plural.as_str())
+        .contains_key(plural.as_str())
         .then_some(PathParameterBinding::CsvFanout { field: plural })
 }
 
 fn config_query_binding(
     requested: &str,
-    config_fields: &BTreeSet<&str>,
+    config_fields: &BTreeMap<&str, bool>,
 ) -> Option<PathParameterBinding> {
     let plural = format!("{requested}s");
-    if config_fields.contains(plural.as_str()) {
+    if config_fields.contains_key(plural.as_str()) {
         return Some(PathParameterBinding::CsvFanout { field: plural });
     }
-    config_fields
-        .contains(requested)
-        .then(|| PathParameterBinding::OptionalScalarConfig {
-            field: requested.to_owned(),
-        })
+    config_fields.get(requested).map(|required| {
+        if *required {
+            PathParameterBinding::ScalarConfig {
+                field: requested.to_owned(),
+            }
+        } else {
+            PathParameterBinding::OptionalScalarConfig {
+                field: requested.to_owned(),
+            }
+        }
+    })
+}
+
+fn valid_id_template(template: &str) -> bool {
+    if template.is_empty()
+        || template.len() > 1_024
+        || template.trim() != template
+        || template.chars().any(char::is_control)
+    {
+        return false;
+    }
+    let mut rest = template;
+    let mut placeholders = 0usize;
+    while let Some(start) = rest.find("${") {
+        if rest[..start].contains('{') || rest[..start].contains('}') {
+            return false;
+        }
+        let field_start = start + 2;
+        let Some(relative_end) = rest[field_start..].find('}') else {
+            return false;
+        };
+        let field_end = field_start + relative_end;
+        let field = &rest[field_start..field_end];
+        if field.is_empty()
+            || field.len() > 128
+            || field.split('.').any(|part| {
+                part.is_empty()
+                    || !part
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            })
+        {
+            return false;
+        }
+        placeholders += 1;
+        rest = &rest[field_end + 1..];
+    }
+    placeholders > 0 && !rest.contains('{') && !rest.contains('}')
 }
 
 fn compile_pagination(
@@ -1935,6 +2004,56 @@ mod tests {
                 .map(String::as_str),
             Some("status.id|account.id|id")
         );
+        let abuseipdb = catalog.get("abuseipdb").unwrap();
+        let abuseipdb_reports = abuseipdb
+            .families()
+            .iter()
+            .find(|family| family.id() == "reports")
+            .unwrap();
+        assert_eq!(
+            abuseipdb_reports.pagination(),
+            &Pagination::Page {
+                parameter: "page".to_owned(),
+                start: 1,
+                page_size_parameter: Some("perPage".to_owned()),
+                page_size: 100,
+            }
+        );
+        assert_eq!(
+            abuseipdb_reports.id_template(),
+            Some("${reportedAt}:${reporterId}")
+        );
+        assert_eq!(
+            abuseipdb_reports.config_query().get("ipAddress"),
+            Some(&PathParameterBinding::ScalarConfig {
+                field: "ip_address".to_owned()
+            })
+        );
+        assert_eq!(
+            abuseipdb_reports.config_query().get("maxAgeInDays"),
+            Some(&PathParameterBinding::OptionalScalarConfig {
+                field: "max_age_in_days".to_owned()
+            })
+        );
+        assert!(
+            !abuseipdb_reports
+                .projection()
+                .fields()
+                .contains_key("finding_id")
+        );
+        let abuseipdb_blacklist = abuseipdb
+            .families()
+            .iter()
+            .find(|family| family.id() == "ip_addresses")
+            .unwrap();
+        assert_eq!(abuseipdb_blacklist.pagination(), &Pagination::None);
+        assert_eq!(
+            abuseipdb_blacklist.static_query(),
+            &BTreeMap::from([
+                ("confidenceMinimum".to_owned(), "90".to_owned()),
+                ("limit".to_owned(), "10000".to_owned()),
+            ])
+        );
         for family in catalog.get("akeyless").unwrap().families() {
             assert_eq!(
                 family.cursor_in_json_body(),
@@ -1966,6 +2085,7 @@ mod tests {
             CollectionAuthority::Authoritative
         );
         for source_id in [
+            "abuseipdb",
             "akeneo",
             "akeyless",
             "apacta",
@@ -2000,6 +2120,33 @@ mod tests {
             catalog.get("agiloft").unwrap().authority(),
             CollectionAuthority::ShadowOnly
         );
+    }
+
+    #[test]
+    fn composite_id_templates_are_closed_and_bounded() {
+        for valid in [
+            "${reportedAt}:${reporterId}",
+            "${namespace}/${name}",
+            "prefix-${nested.value}",
+        ] {
+            assert!(valid_id_template(valid), "{valid}");
+        }
+        for invalid in [
+            "",
+            "literal-only",
+            "${}",
+            "${missing",
+            "${bad field}",
+            "${nested..value}",
+            "${field}}",
+            " ${field}",
+        ] {
+            assert!(!valid_id_template(invalid), "{invalid}");
+        }
+        assert!(!valid_id_template(&format!(
+            "${{field}}{}",
+            "x".repeat(1_024)
+        )));
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -36,6 +36,7 @@ use crate::{CollectedBatch, CollectedScope, CollectionRequest, SourceConnector, 
 const MAX_PAGES: usize = 10_000;
 const MAX_FANOUT_SCOPES: usize = 1_000;
 const MAX_RESPONSE_BYTES: usize = 16 << 20;
+const MAX_PROVIDER_ID_BYTES: usize = 1 << 10;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -593,14 +594,17 @@ impl SourceConnector for HttpSourceConnector {
                     let value =
                         normalize_selected_record(value, self.family.scalar_record_field())?;
                     validate_record_scope(self.family.id(), &value, &record_attributes)?;
-                    let provider_id =
+                    let provider_id = if let Some(template) = self.family.id_template() {
+                        render_id_template(self.family.id(), template, &value, &record_attributes)?
+                    } else {
                         scalar_at(&value, self.family.id_field()).ok_or_else(|| {
                             HttpConnectorError::InvalidResponse(format!(
                                 "family {} record is missing {}",
                                 self.family.id(),
                                 self.family.id_field()
                             ))
-                        })?;
+                        })?
+                    };
                     let mut fields = flatten_scalars(&value);
                     fields.extend(record_attributes.clone());
                     records.push(SourceRecord {
@@ -1409,6 +1413,55 @@ fn scalar_at(value: &Value, field: &str) -> Option<String> {
     scalar_at_path(value, field)
 }
 
+fn render_id_template(
+    family_id: &str,
+    template: &str,
+    value: &Value,
+    record_attributes: &BTreeMap<String, String>,
+) -> Result<String, HttpConnectorError> {
+    let mut rendered = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("${") {
+        rendered.push_str(&rest[..start]);
+        let field_start = start + 2;
+        let field_end = rest[field_start..].find('}').ok_or_else(|| {
+            HttpConnectorError::InvalidConfiguration(format!(
+                "family {family_id} has an invalid id template"
+            ))
+        })? + field_start;
+        let field = &rest[field_start..field_end];
+        let field_value = scalar_at_path(value, field)
+            .or_else(|| record_attributes.get(field).cloned())
+            .ok_or_else(|| {
+                HttpConnectorError::InvalidResponse(format!(
+                    "family {family_id} id template is missing {field}"
+                ))
+            })?;
+        if field_value.trim().is_empty()
+            || field_value.trim() != field_value
+            || field_value.len() > MAX_PROVIDER_ID_BYTES
+            || field_value.chars().any(char::is_control)
+        {
+            return Err(HttpConnectorError::InvalidResponse(format!(
+                "family {family_id} id template has an invalid {field}"
+            )));
+        }
+        rendered.push_str(&field_value);
+        rest = &rest[field_end + 1..];
+    }
+    rendered.push_str(rest);
+    if rendered.trim().is_empty()
+        || rendered.trim() != rendered
+        || rendered.len() > MAX_PROVIDER_ID_BYTES
+        || rendered.chars().any(char::is_control)
+    {
+        return Err(HttpConnectorError::InvalidResponse(format!(
+            "family {family_id} rendered an invalid provider id"
+        )));
+    }
+    Ok(rendered)
+}
+
 fn scalar_at_path(value: &Value, path: &str) -> Option<String> {
     let path = path.trim().trim_start_matches("$.").trim_start_matches('$');
     value_at_path(value, path).and_then(scalar)
@@ -1650,6 +1703,41 @@ mod tests {
             normalize_selected_record(object.clone(), None).unwrap(),
             object
         );
+    }
+
+    #[test]
+    fn composite_provider_ids_require_every_bounded_scalar() {
+        let payload = serde_json::json!({
+            "reportedAt": "2026-07-29T00:00:00Z",
+            "reporter": {"id": 43121}
+        });
+        let attributes = BTreeMap::from([("scope".to_owned(), "tenant-a".to_owned())]);
+        assert_eq!(
+            render_id_template(
+                "reports",
+                "${reportedAt}:${reporter.id}:${scope}",
+                &payload,
+                &attributes,
+            )
+            .unwrap(),
+            "2026-07-29T00:00:00Z:43121:tenant-a"
+        );
+        assert!(matches!(
+            render_id_template("reports", "${reportedAt}:${missing}", &payload, &attributes),
+            Err(HttpConnectorError::InvalidResponse(_))
+        ));
+        for invalid in ["", " ", " padded", "line\nbreak"] {
+            let payload = serde_json::json!({"id": invalid});
+            assert!(matches!(
+                render_id_template("reports", "report:${id}", &payload, &BTreeMap::new()),
+                Err(HttpConnectorError::InvalidResponse(_))
+            ));
+        }
+        let oversized = serde_json::json!({"id": "x".repeat(MAX_PROVIDER_ID_BYTES + 1)});
+        assert!(matches!(
+            render_id_template("reports", "${id}", &oversized, &BTreeMap::new()),
+            Err(HttpConnectorError::InvalidResponse(_))
+        ));
     }
 
     #[test]
@@ -2200,6 +2288,204 @@ mod tests {
         server.await.unwrap();
         assert_eq!(batch.records.len(), 1);
         assert_eq!(batch.records[0].provider_id, "group-1");
+    }
+
+    #[tokio::test]
+    async fn abuseipdb_reports_use_required_scope_pages_and_composite_ids() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for page in 1..=2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let read = socket.read(&mut request).await.unwrap();
+                let request = String::from_utf8_lossy(&request[..read]);
+                let request_line = request.lines().next().unwrap();
+                assert!(request_line.starts_with("GET /reports?"));
+                assert!(request_line.contains("ipAddress=203.0.113.9"));
+                assert!(request_line.contains("maxAgeInDays=90"));
+                assert!(request_line.contains("perPage=100"));
+                assert!(request_line.contains(&format!("page={page}")));
+                assert!(
+                    request
+                        .lines()
+                        .any(|line| line.eq_ignore_ascii_case("key: abuseipdb-secret"))
+                );
+                let results = if page == 1 {
+                    (1..=100)
+                        .map(|reporter_id| {
+                            serde_json::json!({
+                                "reportedAt": "2026-07-29T00:00:00Z",
+                                "reporterId": reporter_id,
+                                "comment": format!("Report {reporter_id}")
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    vec![serde_json::json!({
+                        "reportedAt": "2026-07-29T00:00:00Z",
+                        "reporterId": 101,
+                        "comment": "Report 101"
+                    })]
+                };
+                let body = serde_json::json!({
+                    "data": {
+                        "page": page,
+                        "perPage": 100,
+                        "results": results
+                    }
+                })
+                .to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("abuseipdb")
+        .unwrap()
+        .clone();
+        assert_eq!(
+            source.authority(),
+            cerebro_source_catalog::CollectionAuthority::Authoritative
+        );
+        assert!(matches!(
+            HttpSourceConnector::new(
+                source.clone(),
+                "reports",
+                &format!("http://{address}"),
+                BTreeMap::new(),
+                ResolvedAuth::Header {
+                    name: "Key".to_owned(),
+                    value: "abuseipdb-secret".to_owned(),
+                },
+            )
+            .unwrap()
+            .request_scopes(),
+            Err(HttpConnectorError::InvalidConfiguration(_))
+        ));
+        let mut connector = HttpSourceConnector::new(
+            source.clone(),
+            "reports",
+            &format!("http://{address}"),
+            BTreeMap::from([
+                ("ip_address".to_owned(), "203.0.113.9".to_owned()),
+                ("max_age_in_days".to_owned(), "90".to_owned()),
+            ]),
+            ResolvedAuth::Header {
+                name: "Key".to_owned(),
+                value: "abuseipdb-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("abuseipdb-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 101);
+        assert_eq!(batch.records[0].provider_id, "2026-07-29T00:00:00Z:1");
+        assert_eq!(batch.records[99].provider_id, "2026-07-29T00:00:00Z:100");
+        assert_eq!(batch.records[100].provider_id, "2026-07-29T00:00:00Z:101");
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.entities().len(), 101);
+        assert_eq!(
+            delta
+                .entities()
+                .iter()
+                .map(|entity| entity.id())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            101
+        );
+    }
+
+    #[tokio::test]
+    async fn abuseipdb_blacklist_is_one_bounded_filtered_response() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            let request_line = request.lines().next().unwrap();
+            assert!(request_line.starts_with("GET /blacklist?"));
+            assert!(request_line.contains("confidenceMinimum=75"));
+            assert!(request_line.contains("ipVersion=6"));
+            assert!(request_line.contains("limit=10000"));
+            assert!(!request_line.contains("cursor="));
+            assert!(!request_line.contains("page="));
+            assert!(
+                request
+                    .lines()
+                    .any(|line| line.eq_ignore_ascii_case("key: abuseipdb-secret"))
+            );
+            let body = r#"{"meta":{"generatedAt":"2026-07-29T00:00:00Z"},"data":[{"ipAddress":"2607:ff10:c8:594::9","abuseConfidenceScore":100,"lastReportedAt":"2026-07-28T23:59:00Z"},{"ipAddress":"2001:db8::1","abuseConfidenceScore":99,"lastReportedAt":"2026-07-28T23:58:00Z"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("abuseipdb")
+        .unwrap()
+        .clone();
+        let mut connector = HttpSourceConnector::new(
+            source,
+            "ip_addresses",
+            &format!("http://{address}"),
+            BTreeMap::from([
+                ("confidence_minimum".to_owned(), "75".to_owned()),
+                ("ip_version".to_owned(), "6".to_owned()),
+            ]),
+            ResolvedAuth::Header {
+                name: "Key".to_owned(),
+                value: "abuseipdb-secret".to_owned(),
+            },
+        )
+        .unwrap();
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("abuseipdb-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(
+            batch
+                .records
+                .iter()
+                .map(|record| record.provider_id.as_str())
+                .collect::<Vec<_>>(),
+            ["2607:ff10:c8:594::9", "2001:db8::1"]
+        );
     }
 
     #[tokio::test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -78,6 +78,12 @@ also need separate Rust ownership work.
 API-key collection authority also requires an explicit checked-in header and
 scheme contract. A provider proof manifest does not make a source
 Rust-authoritative when credential placement is still implicit or bespoke.
+Required provider query scope is compiled from checked-in configuration and
+must resolve before Rust makes a provider request. Provider records may also
+use a checked-in composite identity template when the provider has no stable
+single-field identifier. Rust validates those templates at catalog load,
+requires every referenced record value, and rejects blank, control-bearing, or
+oversized rendered identities before mapping or graph admission.
 
 `cerebro-agent-context` exposes bounded search, lookup, expansion, path, and explanation operations. It does not expose Cypher or store mutation.
 

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/abuseipdb.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/abuseipdb.yaml
@@ -11,6 +11,20 @@ entries:
       categories:
         - threat_intel
         - security
+      config_fields:
+        - help: IP address whose report history will be collected.
+          key: ip_address
+          label: IP address
+          required: true
+        - help: Optional report lookback from 1 to 365 days.
+          key: max_age_in_days
+          label: Maximum age in days
+        - help: Optional blacklist confidence threshold from 25 to 100.
+          key: confidence_minimum
+          label: Confidence minimum
+        - help: Optional blacklist IP version, either 4 or 6.
+          key: ip_version
+          label: IP version
       description: Collects AbuseIPDB report history and blacklist IP reputation snapshots, then projects them into the Cerebro graph as findings and threat-intelligence assets for alert, incident, service health, and response context.
       display_name: AbuseIPDB
       id: builtin-abuseipdb
@@ -31,6 +45,7 @@ entries:
             kind: abuseipdb.reports
             required_payload_fields:
               - reportedAt
+              - reporterId
             schema_ref: abuseipdb/reports/v1
             urn_kind: abuseipdb_reports
           id: reports
@@ -38,17 +53,28 @@ entries:
           label: Reports
           method: GET
           pagination:
-            cursor_json_path: $.data.nextPageUrl
-            cursor_param: page
-            page_size: 25
+            page_param: page
+            page_size: 100
             page_size_param: perPage
-            type: cursor
+            start_page: 1
+            type: page
           path: /reports
+          config:
+            config_attributes:
+              resource_id: ip_address
+              resource_name: ip_address
+            config_query:
+              ipAddress: ip_address
+              maxAgeInDays: max_age_in_days
+            id_template: "${reportedAt}:${reporterId}"
           projection:
             fields:
               description: comment
-              finding_id: reportedAt
-              resource_id: ipAddress
+              title: comment
+            static_fields:
+              resource_type: abuseipdb_report
+              severity: reported
+              status: observed
             template: finding
           record_selector: $.data.results[*]
         - coverage:
@@ -74,19 +100,23 @@ entries:
           label: IP addresses
           method: GET
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
-            page_size: 100
-            page_size_param: limit
-            type: cursor
+            type: none
           path: /blacklist
+          config:
+            config_query:
+              confidenceMinimum: confidence_minimum
+              ipVersion: ip_version
           projection:
             fields:
               resource_id: ipAddress
-              resource_type: resource_type|type|kind
-              resource_urn: resource_urn|urn|metadata.resource_urn
+              resource_name: ipAddress
+            static_fields:
+              resource_type: ip_address
             template: asset
           record_selector: $.data[*]
+          static_query:
+            confidenceMinimum: "90"
+            limit: "10000"
       schema_version: cerebro.integration/v1
       source_id: abuseipdb
       tenant_id: builtin_catalog

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -829,6 +829,65 @@ func TestBuiltinMastodonPreservesProviderContracts(t *testing.T) {
 	}
 }
 
+func TestBuiltinAbuseIPDBPreservesProviderContracts(t *testing.T) {
+	entry, ok, err := BuiltinEntry("abuseipdb")
+	if err != nil {
+		t.Fatalf("BuiltinEntry(abuseipdb) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(abuseipdb) ok = false, want true")
+	}
+	if entry.Definition.Auth.Model != "api_key" ||
+		entry.Definition.Auth.TokenHeader != "Key" ||
+		entry.Definition.Auth.TokenScheme != "" {
+		t.Fatalf("abuseipdb auth = %#v, want exact Key header", entry.Definition.Auth)
+	}
+
+	reports := catalogFamily(t, entry.Definition.ResourceFamilies, "reports")
+	if reports.Pagination == nil ||
+		reports.Pagination.Type != "page" ||
+		reports.Pagination.PageParam != "page" ||
+		reports.Pagination.PageSizeParam != "perPage" ||
+		reports.Pagination.PageSize != 100 {
+		t.Fatalf("reports pagination = %#v, want page/perPage with 100 records", reports.Pagination)
+	}
+	if reports.Config == nil ||
+		reports.Config.ConfigQuery["ipAddress"] != "ip_address" ||
+		reports.Config.ConfigQuery["maxAgeInDays"] != "max_age_in_days" ||
+		reports.Config.ConfigAttributes["resource_id"] != "ip_address" ||
+		reports.Config.IDTemplate != "${reportedAt}:${reporterId}" {
+		t.Fatalf("reports config = %#v, want scoped query and composite identity", reports.Config)
+	}
+	if reports.Projection == nil ||
+		reports.Projection.Fields["title"] != "comment" ||
+		reports.Projection.StaticFields["status"] != "observed" ||
+		reports.Projection.StaticFields["severity"] != "reported" {
+		t.Fatalf("reports projection = %#v, want finding fields", reports.Projection)
+	}
+	if _, ok := reports.Projection.Fields["finding_id"]; ok {
+		t.Fatalf("reports projection = %#v, must not collapse findings by timestamp", reports.Projection)
+	}
+
+	blacklist := catalogFamily(t, entry.Definition.ResourceFamilies, "ip_addresses")
+	if blacklist.Pagination == nil || blacklist.Pagination.Type != "none" {
+		t.Fatalf("ip_addresses pagination = %#v, want one bounded response", blacklist.Pagination)
+	}
+	if blacklist.StaticQuery["confidenceMinimum"] != "90" || blacklist.StaticQuery["limit"] != "10000" {
+		t.Fatalf("ip_addresses static query = %#v, want bounded blacklist contract", blacklist.StaticQuery)
+	}
+	if blacklist.Config == nil ||
+		blacklist.Config.ConfigQuery["confidenceMinimum"] != "confidence_minimum" ||
+		blacklist.Config.ConfigQuery["ipVersion"] != "ip_version" {
+		t.Fatalf("ip_addresses config = %#v, want provider filters", blacklist.Config)
+	}
+	if blacklist.Projection == nil ||
+		blacklist.Projection.Fields["resource_id"] != "ipAddress" ||
+		blacklist.Projection.Fields["resource_name"] != "ipAddress" ||
+		blacklist.Projection.StaticFields["resource_type"] != "ip_address" {
+		t.Fatalf("ip_addresses projection = %#v, want IP resource fields", blacklist.Projection)
+	}
+}
+
 func TestBuiltinCatalogIncludesAdditionalGapEntries(t *testing.T) {
 	for sourceID, wantStatus := range map[string]string{
 		"checkr":        StatusGenerateable,

--- a/sources/abuseipdb/catalog.yaml
+++ b/sources/abuseipdb/catalog.yaml
@@ -15,16 +15,13 @@ kind_lifecycle:
 provider_api:
   status: verified
   basis: declared
-  verified_at: 2026-07-06T00:00:00Z
+  verified_at: 2026-07-29T00:00:00Z
   transport: rest
   auth: api_key
   auth_mechanics: key_header
   base_url: https://api.abuseipdb.com/api/v2
-  spec_url: https://raw.githubusercontent.com/api-evangelist/abuseipdb/main/openapi/abuseipdb-apiv2-openapi.yml
-  spec_kind: openapi
   references:
     - https://docs.abuseipdb.com/
-    - https://www.abuseipdb.com/api.html
   families:
     - id: ip_addresses
       method: GET
@@ -47,7 +44,7 @@ coverage_contract:
       evidence_types: [source_snapshot]
       control_domains: [asset_inventory]
       notes:
-        - Reads documented AbuseIPDB blacklist entries from GET /blacklist.
+        - Official API documentation verifies GET /blacklist, Key header authentication, the bounded limit response, optional confidence and IP-version filters, and stable ipAddress identity.
     - id: reports
       type: remediation_state
       title: "Reports"
@@ -57,7 +54,7 @@ coverage_contract:
       evidence_types: [remediation_state]
       control_domains: [remediation]
       notes:
-        - Reads documented AbuseIPDB report history for a configured IP address from GET /reports.
+        - Official API documentation verifies GET /reports, required ipAddress scope, numbered page and perPage pagination, and the reportedAt plus reporterId record identity.
     - id: incremental_sync
       type: incremental_sync
       title: Incremental cursor sync


### PR DESCRIPTION
## Why

The checked-in AbuseIPDB contract was marked Rust-authoritative but did not match the provider API:

- report history treated a provider URL as a page cursor and used only `reportedAt` as identity, so reports from different reporters at the same time could collapse
- blacklist collection invented cursor pagination even though the endpoint returns one bounded data array
- required report scope was not enforced before provider I/O

## What changed

- compile required query configuration separately from optional filters
- compile and validate bounded composite provider identity templates
- execute reports with required `ipAddress`, optional `maxAgeInDays`, and numbered `page` / `perPage` pagination
- identify each report by `reportedAt:reporterId` and carry that identity through Rust graph mapping
- execute blacklist collection once with the documented `Key` header, confidence/IP-version filters, and a 10,000-record bound
- update the provider proof manifest to the current official contract

This repairs an already-authoritative source. It does not increase the Rust-authoritative source count or claim authority for any other provider family.

## Verification

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./sources/abuseipdb -count=1`
- `cargo test -p cerebro-source-catalog`
- `cargo test -p cerebro-source-runtime-next -- --test-threads=1` (65 passed)
- strict `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- catalog, source-generation, fidelity, docs, structural, and architecture checks
- `make rust-coverage` (90.56% lines)

Adversarial runtime coverage proves missing report scope makes no provider request; blank, padded, control-bearing, missing, and oversized identity components fail closed; 101 same-timestamp reports produce 101 distinct graph entities; and blacklist collection sends no cursor or page parameter.

`make connector-contract-check` reaches the known base-branch Okta `users` versus `user` registry defect. The isolated correction is in #2143; no AbuseIPDB contract failure is present.