### PR TITLE
Allow bounded source request timeouts

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -40,7 +40,7 @@ A Deep source is exempt from the flat LOC ceiling but is instead held to the **D
 | `grc` | 1195 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2254 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 763 | Separate request plumbing from emitted record construction. |
-| `sentinelone` | 2112 | Extract API paging, agent/application readers, and shared response normalization. |
+| `sentinelone` | 2108 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1002 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -121,7 +121,7 @@ func ParseRequestTimeout(sourceID, raw string, defaultTimeout time.Duration) (ti
 	}
 	timeout, err := time.ParseDuration(raw)
 	if err != nil {
-		return 0, fmt.Errorf("%w: %s request_timeout must be a duration: %v", sourcecdk.ErrInvalidConfig, sourceID, err)
+		return 0, fmt.Errorf("%w: %s request_timeout must be a duration: %w", sourcecdk.ErrInvalidConfig, sourceID, err)
 	}
 	if timeout < time.Second || timeout > MaxConfigurableRequestTimeout {
 		return 0, fmt.Errorf(

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/telemetry"
 )
 
@@ -22,6 +23,7 @@ const DefaultTimeout = 30 * time.Second
 const DefaultRetryMaxAttempts = 3
 const DefaultRetryBackoff = 250 * time.Millisecond
 const MaxRetryAfter = 5 * time.Second
+const MaxConfigurableRequestTimeout = 5 * time.Minute
 
 var ErrTransportPinningUnsupported = errors.New("source transport must support pinned host dialing")
 var ErrUnsafeHostAddress = errors.New("source host must not target unsafe addresses")
@@ -108,6 +110,28 @@ func firstDuration(values ...time.Duration) time.Duration {
 		}
 	}
 	return 0
+}
+
+// ParseRequestTimeout keeps source-specific timeout overrides bounded while
+// preserving the shared default when the runtime does not configure one.
+func ParseRequestTimeout(sourceID, raw string, defaultTimeout time.Duration) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultTimeout, nil
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s request_timeout must be a duration: %v", sourcecdk.ErrInvalidConfig, sourceID, err)
+	}
+	if timeout < time.Second || timeout > MaxConfigurableRequestTimeout {
+		return 0, fmt.Errorf(
+			"%w: %s request_timeout must be between 1s and %s",
+			sourcecdk.ErrInvalidConfig,
+			sourceID,
+			MaxConfigurableRequestTimeout,
+		)
+	}
+	return timeout, nil
 }
 
 // NormalizeBaseURL validates source-configured API origins before credentials are

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -456,3 +456,28 @@ func TestSafeResolvedHostAddrsRejectsLoopbackAndLinkLocalEvenWhenAllowlisted(t *
 		})
 	}
 }
+
+func TestParseRequestTimeout(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "default", want: 30 * time.Second},
+		{name: "configured", raw: "2m", want: 2 * time.Minute},
+		{name: "too short", raw: "500ms", wantErr: true},
+		{name: "too long", raw: "6m", wantErr: true},
+		{name: "invalid", raw: "later", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseRequestTimeout("example", test.raw, 30*time.Second)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ParseRequestTimeout() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if !test.wantErr && got != test.want {
+				t.Fatalf("ParseRequestTimeout() = %s, want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/sources/evidencecas/source.go
+++ b/sources/evidencecas/source.go
@@ -145,6 +145,13 @@ func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebro
 
 func (s *Source) configForInner(cfg sourcecdk.Config) (sourcecdk.Config, error) {
 	values := cfg.Values()
+	if _, err := sourcehttp.ParseRequestTimeout(
+		sourceID,
+		values["request_timeout"],
+		sourcehttp.DefaultTimeout,
+	); err != nil {
+		return sourcecdk.Config{}, err
+	}
 	if strings.TrimSpace(values["path"]) == "" && strings.TrimSpace(values[familyObject+"_path"]) == "" {
 		bucket := strings.TrimSpace(values["bucket"])
 		if bucket == "" {
@@ -233,7 +240,7 @@ func (s *Source) getControlJSON(ctx context.Context, cfg sourcecdk.Config, path 
 		SourceID:                 sourceID,
 		AllowLoopback:            s != nil && s.allowLoopback,
 		PrivateEndpointAllowlist: privateEndpointAllowlist,
-		Timeout:                  10 * time.Second,
+		Timeout:                  controlRequestTimeout(cfg),
 	})
 	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
 	if err != nil {
@@ -246,6 +253,15 @@ func (s *Source) getControlJSON(ctx context.Context, cfg sourcecdk.Config, path 
 		return fmt.Errorf("decode %s control response: %w", sourceID, err)
 	}
 	return nil
+}
+
+func controlRequestTimeout(cfg sourcecdk.Config) time.Duration {
+	timeout, _ := sourcehttp.ParseRequestTimeout(
+		sourceID,
+		sourcecdk.ConfigValue(cfg, "request_timeout"),
+		10*time.Second,
+	)
+	return timeout
 }
 
 func loadSpec() (*cerebrov1.SourceSpec, error) {

--- a/sources/evidencecas/source_test.go
+++ b/sources/evidencecas/source_test.go
@@ -402,3 +402,16 @@ func TestRejectsUnsafeBucket(t *testing.T) {
 		t.Fatal("Read() error = nil, want invalid bucket error")
 	}
 }
+
+func TestRejectsUnboundedRequestTimeout(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = source.configForInner(sourcecdk.NewConfig(map[string]string{
+		"request_timeout": "10m",
+	}))
+	if err == nil {
+		t.Fatal("configForInner() error = nil, want bounded timeout rejection")
+	}
+}

--- a/sources/internal/jsonapi/auth.go
+++ b/sources/internal/jsonapi/auth.go
@@ -210,15 +210,7 @@ func (s *Source) twoStepAccessToken(ctx context.Context, settings settings) (str
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	client := s.client
-	if client == nil {
-		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
-			SourceID:                 s.options.SourceID,
-			AllowLoopback:            s.AllowLoopbackBaseURL,
-			PrivateEndpointAllowlist: settings.privateEndpointAllowlist,
-			LookupIPAddrs:            lookupIPAddrs(s),
-		})
-	}
+	client := s.requestClient(settings)
 	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
 	if err != nil {
 		return "", fmt.Errorf("%s two_step token exchange: %w", s.options.SourceID, err)
@@ -352,15 +344,7 @@ func (s *Source) exchangeOAuthToken(ctx context.Context, settings settings, gran
 	default:
 		return "", "", time.Time{}, fmt.Errorf("%s token_request_auth_method %q is not supported", s.options.SourceID, settings.oauthTokenRequestMethod)
 	}
-	client := s.client
-	if client == nil {
-		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
-			SourceID:                 s.options.SourceID,
-			AllowLoopback:            s.AllowLoopbackBaseURL,
-			PrivateEndpointAllowlist: settings.privateEndpointAllowlist,
-			LookupIPAddrs:            lookupIPAddrs(s),
-		})
-	}
+	client := s.requestClient(settings)
 	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
 	if err != nil {
 		return "", "", time.Time{}, err

--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -430,6 +430,7 @@ func (s *Source) doRequest(ctx context.Context, settings settings, path string, 
 	if client == nil {
 		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
 			SourceID:                 s.options.SourceID,
+			Timeout:                  settings.requestTimeout,
 			AllowLoopback:            s.AllowLoopbackBaseURL,
 			PrivateEndpointAllowlist: settings.privateEndpointAllowlist,
 			LookupIPAddrs:            lookupIPAddrs(s),

--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -430,7 +430,7 @@ func (s *Source) doRequest(ctx context.Context, settings settings, path string, 
 	if client == nil {
 		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
 			SourceID:                 s.options.SourceID,
-			Timeout:                  settings.requestTimeout,
+			Timeout:                  settings.request.timeout,
 			AllowLoopback:            s.AllowLoopbackBaseURL,
 			PrivateEndpointAllowlist: settings.privateEndpointAllowlist,
 			LookupIPAddrs:            lookupIPAddrs(s),

--- a/sources/internal/jsonapi/http.go
+++ b/sources/internal/jsonapi/http.go
@@ -426,16 +426,7 @@ func (s *Source) doRequest(ctx context.Context, settings settings, path string, 
 	if err := s.authorizeRequest(ctx, settings, req); err != nil {
 		return nil, err
 	}
-	client := s.client
-	if client == nil {
-		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
-			SourceID:                 s.options.SourceID,
-			Timeout:                  settings.request.timeout,
-			AllowLoopback:            s.AllowLoopbackBaseURL,
-			PrivateEndpointAllowlist: settings.privateEndpointAllowlist,
-			LookupIPAddrs:            lookupIPAddrs(s),
-		})
-	}
+	client := s.requestClient(settings)
 	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{})
 	if err != nil {
 		return nil, err
@@ -463,6 +454,20 @@ func (s *Source) doRequest(ctx context.Context, settings settings, path string, 
 		return resp.Header, fmt.Errorf("decode %s response: %w", s.options.SourceID, err)
 	}
 	return resp.Header, nil
+}
+
+func (s *Source) requestClient(settings settings) *http.Client {
+	client := sourcehttp.HardenClient(s.client, sourcehttp.ClientOptions{
+		SourceID:                 s.options.SourceID,
+		Timeout:                  settings.request.timeout,
+		AllowLoopback:            s.AllowLoopbackBaseURL,
+		PrivateEndpointAllowlist: settings.privateEndpointAllowlist,
+		LookupIPAddrs:            lookupIPAddrs(s),
+	})
+	// A supplied client may already carry a timeout. The source configuration is
+	// authoritative for every request in this source, including auth exchanges.
+	client.Timeout = settings.request.timeout
+	return client
 }
 
 func requestEndpoint(sourceID string, baseURL string, defaultPath string, path string) (string, error) {

--- a/sources/internal/jsonapi/settings.go
+++ b/sources/internal/jsonapi/settings.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
@@ -41,6 +42,7 @@ type settings struct {
 	region                   string
 	service                  string
 	familyMethod             string
+	requestTimeout           time.Duration
 }
 
 type requestSettings struct {
@@ -76,6 +78,14 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		region:                  sourcecdk.ConfigValue(cfg, "region"),
 		service:                 sourcecdk.ConfigValue(cfg, "service"),
 		apiKey:                  sourcecdk.ConfigValue(cfg, "api_key"),
+	}
+	resolved.requestTimeout, err = sourcehttp.ParseRequestTimeout(
+		s.options.SourceID,
+		sourcecdk.ConfigValue(cfg, "request_timeout"),
+		sourcehttp.DefaultTimeout,
+	)
+	if err != nil {
+		return resolved, err
 	}
 	if resolved.family == "" {
 		resolved.family = strings.TrimSpace(s.options.DefaultFamily)

--- a/sources/internal/jsonapi/settings.go
+++ b/sources/internal/jsonapi/settings.go
@@ -42,7 +42,6 @@ type settings struct {
 	region                   string
 	service                  string
 	familyMethod             string
-	requestTimeout           time.Duration
 }
 
 type requestSettings struct {
@@ -51,6 +50,7 @@ type requestSettings struct {
 	configAttributes map[string]string
 	query            url.Values
 	jsonBody         map[string]any
+	timeout          time.Duration
 }
 
 func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
@@ -79,7 +79,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		service:                 sourcecdk.ConfigValue(cfg, "service"),
 		apiKey:                  sourcecdk.ConfigValue(cfg, "api_key"),
 	}
-	resolved.requestTimeout, err = sourcehttp.ParseRequestTimeout(
+	resolved.request.timeout, err = sourcehttp.ParseRequestTimeout(
 		s.options.SourceID,
 		sourcecdk.ConfigValue(cfg, "request_timeout"),
 		sourcehttp.DefaultTimeout,

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -2816,6 +2816,22 @@ func TestPrivateEndpointAllowlistAllowsConfiguredJSONAPISource(t *testing.T) {
 	}
 }
 
+func TestParseSettingsAcceptsBoundedRequestTimeout(t *testing.T) {
+	source := newTestSource(t, "https://example.com")
+	settings, err := source.parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":       "writer",
+		"token":           "token-1",
+		"base_url":        "https://example.com",
+		"request_timeout": "2m",
+	}))
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
+	}
+	if settings.requestTimeout != 2*time.Minute {
+		t.Fatalf("requestTimeout = %s, want 2m", settings.requestTimeout)
+	}
+}
+
 func TestSafeRoundTripperPinsValidatedHostnameAddress(t *testing.T) {
 	var dialed string
 	rt := sourcehttp.SafeRoundTripper{

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -2832,6 +2832,25 @@ func TestParseSettingsAcceptsBoundedRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestRequestClientAppliesConfiguredTimeoutToSuppliedClient(t *testing.T) {
+	source := newTestSource(t, "https://example.com")
+	source.client = &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	settings := settings{
+		request: requestSettings{timeout: 2 * time.Minute},
+	}
+
+	client := source.requestClient(settings)
+
+	if client.Timeout != 2*time.Minute {
+		t.Fatalf("client timeout = %s, want 2m", client.Timeout)
+	}
+	if source.client.Timeout != 10*time.Second {
+		t.Fatalf("supplied client timeout mutated to %s, want 10s", source.client.Timeout)
+	}
+}
+
 func TestSafeRoundTripperPinsValidatedHostnameAddress(t *testing.T) {
 	var dialed string
 	rt := sourcehttp.SafeRoundTripper{

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -2827,8 +2827,8 @@ func TestParseSettingsAcceptsBoundedRequestTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseSettings() error = %v", err)
 	}
-	if settings.requestTimeout != 2*time.Minute {
-		t.Fatalf("requestTimeout = %s, want 2m", settings.requestTimeout)
+	if settings.request.timeout != 2*time.Minute {
+		t.Fatalf("request timeout = %s, want 2m", settings.request.timeout)
 	}
 }
 

--- a/sources/sentinelone/http.go
+++ b/sources/sentinelone/http.go
@@ -64,12 +64,10 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "ApiToken "+settings.token)
 
-	client := s.client
-	if client == nil {
-		client = httpClientNoRedirect(nil, s != nil && s.allowLoopbackBaseURL, lookupIPAddrs(s))
-	} else {
-		client = httpClientNoRedirect(client, s != nil && s.allowLoopbackBaseURL, lookupIPAddrs(s))
-	}
+	client := sourcehttp.HardenSourceClient(
+		s.client, "sentinelone", settings.requestTimeout,
+		s != nil && s.allowLoopbackBaseURL, lookupIPAddrs(s),
+	)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("request %s: %w", requestPath, err)
@@ -92,10 +90,6 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 		return fmt.Errorf("decode %s response: %w", requestPath, err)
 	}
 	return nil
-}
-
-func httpClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
-	return sourcehttp.HardenSourceClient(client, "sentinelone", httpTimeout, allowLoopback, lookupIPAddrs)
 }
 
 func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/sources/sentinelone/http.go
+++ b/sources/sentinelone/http.go
@@ -66,7 +66,7 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 
 	client := sourcehttp.HardenSourceClient(
 		s.client, "sentinelone", settings.requestTimeout,
-		s != nil && s.allowLoopbackBaseURL, lookupIPAddrs(s),
+		s.allowLoopbackBaseURL, lookupIPAddrs(s),
 	)
 	resp, err := client.Do(req)
 	if err != nil {

--- a/sources/sentinelone/settings.go
+++ b/sources/sentinelone/settings.go
@@ -5,8 +5,10 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 const (
@@ -24,17 +26,11 @@ const (
 )
 
 type settings struct {
-	family   string
-	baseURL  string
-	host     string
-	token    string
-	siteID   string
-	groupID  string
-	agentID  string
-	since    string
-	until    string
-	activity string
-	perPage  int
+	family, baseURL, host, token string
+	siteID, groupID, agentID     string
+	since, until, activity       string
+	perPage                      int
+	requestTimeout               time.Duration
 }
 
 func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
@@ -54,6 +50,11 @@ func parseSettings(cfg sourcecdk.Config, allowLoopbackBaseURL bool) (settings, e
 		activity: sourcecdk.ConfigValue(cfg, "activity_type"),
 		perPage:  defaultPageSize,
 	}
+	timeout, err := sourcehttp.ParseRequestTimeout("sentinelone", sourcecdk.ConfigValue(cfg, "request_timeout"), httpTimeout)
+	if err != nil {
+		return resolved, err
+	}
+	resolved.requestTimeout = timeout
 	if resolved.family == "" {
 		resolved.family = defaultFamily
 	}

--- a/sources/sentinelone/source_test.go
+++ b/sources/sentinelone/source_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
@@ -90,6 +92,19 @@ func TestParseSettingsRejectsUnknownFamily(t *testing.T) {
 	}))
 	if err == nil {
 		t.Fatal("Check(unknown) error = nil, want non-nil")
+	}
+}
+
+func TestParseSettingsAcceptsBoundedRequestTimeout(t *testing.T) {
+	settings, err := parseSettings(
+		sourcecdk.NewConfig(newFixtureConfig("threat", map[string]string{"request_timeout": "2m"})),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
+	}
+	if settings.requestTimeout != 2*time.Minute {
+		t.Fatalf("requestTimeout = %s, want 2m", settings.requestTimeout)
 	}
 }
 
@@ -620,12 +635,12 @@ func TestGetJSONDoesNotFollowRedirects(t *testing.T) {
 
 func TestHTTPClientRejectsHostsResolvingToPrivateIPs(t *testing.T) {
 	called := false
-	client := httpClientNoRedirect(&http.Client{
+	client := sourcehttp.HardenSourceClient(&http.Client{
 		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
 			called = true
 			return nil, errors.New("unexpected round trip")
 		}),
-	}, false, func(context.Context, string) ([]net.IPAddr, error) {
+	}, "sentinelone", httpTimeout, false, func(context.Context, string) ([]net.IPAddr, error) {
 		return []net.IPAddr{{IP: net.ParseIP("169.254.169.254")}}, nil
 	})
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://attacker.example/web/api/v2.1/threats", nil)
@@ -646,12 +661,12 @@ func TestHTTPClientRejectsHostsResolvingToPrivateIPs(t *testing.T) {
 
 func TestHTTPClientFailsClosedWhenHostResolutionFails(t *testing.T) {
 	called := false
-	client := httpClientNoRedirect(&http.Client{
+	client := sourcehttp.HardenSourceClient(&http.Client{
 		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
 			called = true
 			return nil, errors.New("unexpected round trip")
 		}),
-	}, false, func(context.Context, string) ([]net.IPAddr, error) {
+	}, "sentinelone", httpTimeout, false, func(context.Context, string) ([]net.IPAddr, error) {
 		return nil, errors.New("dns failed")
 	})
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://attacker.example/web/api/v2.1/threats", nil)

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -38,7 +38,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"grc":             1195,
 	"okta":            2254,
 	"panopticon":      763,
-	"sentinelone":     2112,
+	"sentinelone":     2108,
 	"vulnview":        1002,
 }
 


### PR DESCRIPTION
## Summary
- add an optional bounded `request_timeout` runtime setting while preserving the 30-second default
- apply the setting to JSON API sources, Evidence CAS control probes, and SentinelOne requests
- keep configured values between 1 second and 5 minutes and reject invalid configuration

## Verification
- `go test ./internal/sourcehttp ./sources/internal/jsonapi ./sources/evidencecas ./sources/sentinelone ./tools/archtests`
- `git diff --check`