### PR TITLE
Normalize bare Okta runtime domains

### DIFF
--- a/apps/slack-companion-host/src/runtime/config.ts
+++ b/apps/slack-companion-host/src/runtime/config.ts
@@ -149,7 +149,7 @@ function archetypeConfig(
     allowedEmailDomains,
     baseUrl: validatedBaseUrl(required(env.ARCHETYPE_BASE_URL)),
     oktaApiToken: required(env.OKTA_API_TOKEN),
-    oktaDomain: validatedBaseUrl(required(env.OKTA_DOMAIN)),
+    oktaDomain: validatedOktaDomain(required(env.OKTA_DOMAIN)),
     timeoutMs: positiveInteger(
       env.ARCHETYPE_REQUEST_TIMEOUT_MS,
       10_000,
@@ -229,4 +229,11 @@ function validatedBaseUrl(value: string): string {
   parsed.search = "";
   parsed.hash = "";
   return parsed.toString().replace(/\/$/, "");
+}
+
+function validatedOktaDomain(value: string): string {
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//iu.test(value)
+    ? value
+    : `https://${value}`;
+  return validatedBaseUrl(candidate);
 }

--- a/apps/slack-companion-host/src/runtime/config.ts
+++ b/apps/slack-companion-host/src/runtime/config.ts
@@ -74,9 +74,10 @@ function computerSandboxGateways(
   } catch {
     throw new SlackRuntimeConfigError("Computer sandbox gateway configuration is invalid.");
   }
-  if (!Array.isArray(parsed) || parsed.length === 0 || parsed.length > 8) {
+  if (!Array.isArray(parsed) || parsed.length > 8) {
     throw new SlackRuntimeConfigError("Computer sandbox gateway configuration is invalid.");
   }
+  if (parsed.length === 0) return Object.freeze([]);
   const providerIds = new Set<string>();
   const bindings = parsed.map((item) => {
     if (

--- a/apps/slack-companion-host/test/archetype-runtime.test.ts
+++ b/apps/slack-companion-host/test/archetype-runtime.test.ts
@@ -105,6 +105,28 @@ test("runtime config activates Archetype only with complete private bindings", (
     ["writer.com"],
   );
 
+  const bareDomain = loadSlackRuntimeConfig({
+    ...base,
+    ARCHETYPE_ALLOWED_EMAIL_DOMAINS: "writer.com",
+    ARCHETYPE_BASE_URL: "https://archetype.internal",
+    ARCHETYPE_WORKSPACE_ENABLED: "true",
+    OKTA_API_TOKEN: "bound-at-runtime",
+    OKTA_DOMAIN: "writer.okta.com",
+  });
+  assert.equal(bareDomain.archetype?.oktaDomain, "https://writer.okta.com");
+
+  assert.throws(
+    () => loadSlackRuntimeConfig({
+      ...base,
+      ARCHETYPE_ALLOWED_EMAIL_DOMAINS: "writer.com",
+      ARCHETYPE_BASE_URL: "https://archetype.internal",
+      ARCHETYPE_WORKSPACE_ENABLED: "true",
+      OKTA_API_TOKEN: "bound-at-runtime",
+      OKTA_DOMAIN: "http://writer.okta.com",
+    }),
+    /Cerebro service binding is invalid/,
+  );
+
   assert.throws(
     () => loadSlackRuntimeConfig({
       ...base,

--- a/apps/slack-companion-host/test/computer-sandbox-gateway.test.ts
+++ b/apps/slack-companion-host/test/computer-sandbox-gateway.test.ts
@@ -76,6 +76,13 @@ test("gateway adapter sends bounded authenticated protocol requests", async () =
 
 test("empty gateway configuration leaves computer access disabled", () => {
   assert.equal(createComputerSandboxRuntime([]), undefined);
+  assert.deepEqual(
+    loadSlackRuntimeConfig({
+      ...baseEnv(),
+      CEREBRO_COMPUTER_SANDBOX_GATEWAYS_JSON: "[]",
+    }).computerSandboxGateways,
+    [],
+  );
 });
 
 test("gateway adapter bounds streamed responses without content length", async () => {


### PR DESCRIPTION
## Summary

- accept a bare Okta hostname at the Slack host runtime boundary
- normalize it to an HTTPS origin while continuing to reject insecure URL schemes
- cover both compatibility and fail-closed behavior with focused tests

## Verification

- `npm test --workspace @writer/cerebro-slack-companion-host` (59 passed)
- `git diff --check`