### PR TITLE
fix: paginate Archetype scans without gaps

### DIFF
--- a/internal/sourcecdk/descending_id.go
+++ b/internal/sourcecdk/descending_id.go
@@ -1,0 +1,124 @@
+package sourcecdk
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// DescendingIDPage tracks a bounded walk from the newest provider record back
+// to the last durable ID without advancing that checkpoint between pages.
+type DescendingIDPage struct {
+	BaselineID    int64
+	BeforeID      int64
+	HighID        int64
+	HighWatermark time.Time
+}
+
+// DescendingIDPageFrom restores a descending-ID page walk. Legacy numeric
+// cursors and checkpoints remain valid as durable baseline IDs.
+func DescendingIDPageFrom(cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, source, mode string) (DescendingIDPage, error) {
+	state := DescendingIDPage{BaselineID: descendingCheckpointID(checkpoint.GetCursorOpaque())}
+	opaque := strings.TrimSpace(cursor.GetOpaque())
+	if opaque == "" {
+		return state, nil
+	}
+	envelope, ok := DecodeCursorEnvelope(opaque)
+	if !ok || envelope.Source != strings.TrimSpace(source) || envelope.Mode != strings.TrimSpace(mode) {
+		state.BaselineID = descendingCheckpointID(opaque)
+		return state, nil
+	}
+	var err error
+	if state.BaselineID, err = nonNegativeCursorInt(envelope.Extra["baseline_id"], "baseline_id"); err != nil {
+		return DescendingIDPage{}, err
+	}
+	if state.BeforeID, err = positiveCursorInt64(envelope.Token, "before_id"); err != nil {
+		return DescendingIDPage{}, err
+	}
+	if state.HighID, err = positiveCursorInt64(envelope.Extra["high_id"], "high_id"); err != nil {
+		return DescendingIDPage{}, err
+	}
+	state.HighWatermark = CursorWatermark(envelope)
+	if state.HighWatermark.IsZero() {
+		return DescendingIDPage{}, fmt.Errorf("%w: descending id cursor high watermark is required", ErrInvalidConfig)
+	}
+	if state.BeforeID > state.HighID || state.BaselineID >= state.BeforeID {
+		return DescendingIDPage{}, fmt.Errorf("%w: descending id cursor bounds are invalid", ErrInvalidConfig)
+	}
+	return state, nil
+}
+
+// CaptureHigh records the immutable upper bound from the first provider page.
+func (p *DescendingIDPage) CaptureHigh(id int64, watermark time.Time) {
+	if p == nil || p.HighID != 0 || id <= p.BaselineID || watermark.IsZero() {
+		return
+	}
+	p.HighID = id
+	p.HighWatermark = watermark.UTC()
+}
+
+// ContinuationCursor returns a cursor for the next older provider page when
+// the current full page can still contain IDs above the durable baseline.
+func (p DescendingIDPage) ContinuationCursor(returned, limit int, oldestID int64, source, family, mode string) (*cerebrov1.SourceCursor, bool, error) {
+	if returned != limit || oldestID <= p.BaselineID+1 {
+		return nil, false, nil
+	}
+	envelope := CursorEnvelope{
+		Version: 1,
+		Source:  source,
+		Family:  family,
+		Mode:    mode,
+		Token:   strconv.FormatInt(oldestID, 10),
+		Extra: map[string]string{
+			"baseline_id": strconv.FormatInt(p.BaselineID, 10),
+			"high_id":     strconv.FormatInt(p.HighID, 10),
+		},
+	}
+	SetCursorWatermark(&envelope, p.HighWatermark)
+	opaque, err := EncodeCursorEnvelope(envelope)
+	if err != nil {
+		return nil, false, err
+	}
+	return &cerebrov1.SourceCursor{Opaque: opaque}, true, nil
+}
+
+// ProgressCheckpoint returns the captured high ID only after the walk reaches
+// its terminal page. Callers keep the existing checkpoint on continuation pages.
+func (p DescendingIDPage) ProgressCheckpoint() *cerebrov1.SourceCheckpoint {
+	if p.HighID <= p.BaselineID || p.HighWatermark.IsZero() {
+		return nil
+	}
+	return &cerebrov1.SourceCheckpoint{
+		CursorOpaque: strconv.FormatInt(p.HighID, 10),
+		Watermark:    timestamppb.New(p.HighWatermark),
+	}
+}
+
+func descendingCheckpointID(opaque string) int64 {
+	trimmed := strings.TrimSpace(opaque)
+	if envelope, ok := DecodeCursorEnvelope(trimmed); ok {
+		trimmed = envelope.Token
+	}
+	id, _ := strconv.ParseInt(trimmed, 10, 64)
+	return id
+}
+
+func positiveCursorInt64(raw, field string) (int64, error) {
+	value, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%w: descending id cursor %s must be a positive integer", ErrInvalidConfig, field)
+	}
+	return value, nil
+}
+
+func nonNegativeCursorInt(raw, field string) (int64, error) {
+	value, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("%w: descending id cursor %s must be a non-negative integer", ErrInvalidConfig, field)
+	}
+	return value, nil
+}

--- a/internal/sourcecdk/descending_id_test.go
+++ b/internal/sourcecdk/descending_id_test.go
@@ -1,0 +1,68 @@
+package sourcecdk
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestDescendingIDPageRoundTripPreservesDurableBounds(t *testing.T) {
+	watermark := time.Date(2026, 7, 1, 4, 0, 0, 0, time.UTC)
+	page := DescendingIDPage{BaselineID: 50}
+	page.CaptureHigh(205, watermark)
+	cursor, more, err := page.ContinuationCursor(100, 100, 106, "archetype", "scan", "scan_id_desc")
+	if err != nil {
+		t.Fatalf("ContinuationCursor() error = %v", err)
+	}
+	if !more {
+		t.Fatal("ContinuationCursor() more = false")
+	}
+
+	restored, err := DescendingIDPageFrom(cursor, &cerebrov1.SourceCheckpoint{CursorOpaque: "50"}, "archetype", "scan_id_desc")
+	if err != nil {
+		t.Fatalf("DescendingIDPageFrom() error = %v", err)
+	}
+	if restored.BaselineID != 50 || restored.BeforeID != 106 || restored.HighID != 205 {
+		t.Fatalf("restored = %#v", restored)
+	}
+	if !restored.HighWatermark.Equal(watermark) {
+		t.Fatalf("HighWatermark = %v, want %v", restored.HighWatermark, watermark)
+	}
+	if got := restored.ProgressCheckpoint().GetCursorOpaque(); got != "205" {
+		t.Fatalf("ProgressCheckpoint() = %q, want 205", got)
+	}
+}
+
+func TestDescendingIDPageStopsAtContiguousBaseline(t *testing.T) {
+	page := DescendingIDPage{
+		BaselineID:    0,
+		HighID:        100,
+		HighWatermark: time.Date(2026, 7, 1, 4, 0, 0, 0, time.UTC),
+	}
+	cursor, more, err := page.ContinuationCursor(100, 100, 1, "archetype", "scan", "scan_id_desc")
+	if err != nil {
+		t.Fatalf("ContinuationCursor() error = %v", err)
+	}
+	if more || cursor != nil {
+		t.Fatalf("ContinuationCursor() = %#v, %v, want terminal", cursor, more)
+	}
+}
+
+func TestDescendingIDPageRejectsInvalidContinuationBounds(t *testing.T) {
+	opaque, err := EncodeCursorEnvelope(CursorEnvelope{
+		Source:    "archetype",
+		Mode:      "scan_id_desc",
+		Token:     "50",
+		Watermark: "2026-07-01T04:00:00Z",
+		Extra:     map[string]string{"baseline_id": "50", "high_id": "205"},
+	})
+	if err != nil {
+		t.Fatalf("EncodeCursorEnvelope() error = %v", err)
+	}
+	_, err = DescendingIDPageFrom(&cerebrov1.SourceCursor{Opaque: opaque}, nil, "archetype", "scan_id_desc")
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("DescendingIDPageFrom() error = %v, want ErrInvalidConfig", err)
+	}
+}

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -29,6 +29,7 @@ const sourceID = "archetype"
 const (
 	defaultFanoutConcurrency = 4
 	maxFanoutConcurrency     = 16
+	scanPageLimit            = 100
 )
 
 type Source struct {
@@ -68,7 +69,7 @@ func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	if err != nil {
 		return err
 	}
-	return archetypeclient.Get(ctx, s.clientSettings(st), "/scans", new([]scanRecord))
+	return archetypeclient.GetWithQuery(ctx, s.clientSettings(st), "/scans", url.Values{"limit": {"1"}}, new([]scanRecord))
 }
 func (s *Source) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return nil, nil
@@ -81,20 +82,33 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
+	pageState, err := sourcecdk.DescendingIDPageFrom(cursor, checkpoint, sourceID, "scan_id_desc")
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
 	var scans []scanRecord
 	clientSettings := s.clientSettings(st)
-	if err := archetypeclient.Get(ctx, clientSettings, "/scans", &scans); err != nil {
+	query := url.Values{"limit": {strconv.Itoa(scanPageLimit)}}
+	if pageState.BeforeID > 0 {
+		query.Set("before_id", strconv.FormatInt(pageState.BeforeID, 10))
+	}
+	if err := archetypeclient.GetWithQuery(ctx, clientSettings, "/scans", query, &scans); err != nil {
 		return sourcecdk.Pull{}, err
 	}
 	sort.Slice(scans, func(i, j int) bool { return scans[i].ID < scans[j].ID })
-	last := lastScanID(cursor, checkpoint)
+	if len(scans) > 0 {
+		pageState.CaptureHigh(int64(scans[len(scans)-1].ID), archetypeclient.ScanTime(scans[len(scans)-1], time.Now().UTC()))
+	}
 	newScans := make([]scanRecord, 0, len(scans))
 	for _, scan := range scans {
-		if scan.ID > last {
+		if int64(scan.ID) > pageState.BaselineID {
 			newScans = append(newScans, scan)
 		}
 	}
 	if len(newScans) == 0 {
+		if next := pageState.ProgressCheckpoint(); next != nil {
+			return sourcecdk.Pull{Checkpoint: next}, nil
+		}
 		return sourcecdk.NotModifiedPull(checkpoint), nil
 	}
 	repos := archetypeclient.Repositories(ctx, clientSettings)
@@ -132,8 +146,18 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 	if len(events) == 0 {
 		return sourcecdk.NotModifiedPull(checkpoint), nil
 	}
-	next := strconv.Itoa(scans[len(scans)-1].ID)
-	return sourcecdk.Pull{Events: events, Checkpoint: &cerebrov1.SourceCheckpoint{CursorOpaque: next, Watermark: events[len(events)-1].OccurredAt}}, nil
+	pull := sourcecdk.Pull{Events: events}
+	next, more, err := pageState.ContinuationCursor(len(scans), scanPageLimit, int64(scans[0].ID), sourceID, st.family, "scan_id_desc")
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	if more {
+		pull.NextCursor = next
+		pull.Checkpoint = checkpoint
+		return pull, nil
+	}
+	pull.Checkpoint = pageState.ProgressCheckpoint()
+	return pull, nil
 }
 func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 	st := settings{
@@ -199,11 +223,11 @@ func parseFanoutConcurrency(raw string) (int, error) {
 }
 func scanEvent(st settings, scan scanRecord, repo repositoryRecord) *primitives.Event {
 	attrs := map[string]string{"scan_id": strconv.Itoa(scan.ID), "repository_id": strconv.Itoa(scan.RepositoryID), "status": scan.Status, "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
-	return event(st, "archetype.scan", "archetype-scan-"+strconv.Itoa(scan.ID), "archetype/scan/v1", scanTime(scan), attrs, scan)
+	return event(st, "archetype.scan", "archetype-scan-"+strconv.Itoa(scan.ID), "archetype/scan/v1", archetypeclient.ScanTime(scan, time.Now().UTC()), attrs, scan)
 }
 func vulnerabilityEvent(st settings, scan scanRecord, vuln vulnerabilityRecord, repo repositoryRecord) *primitives.Event {
 	attrs := map[string]string{"vulnerability_id": strconv.Itoa(vuln.ID), "scan_id": strconv.Itoa(vuln.ScanID), "repository_id": strconv.Itoa(scan.RepositoryID), "severity": vuln.Severity, "category": vuln.Category, "file_path": vuln.FilePath, "line_number": strconv.Itoa(vuln.LineNumber), "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
-	return event(st, "archetype.vulnerability", "archetype-vulnerability-"+strconv.Itoa(vuln.ID), "archetype/vulnerability/v1", parseTime(vuln.CreatedAt, scanTime(scan)), attrs, vuln)
+	return event(st, "archetype.vulnerability", "archetype-vulnerability-"+strconv.Itoa(vuln.ID), "archetype/vulnerability/v1", archetypeclient.ParseTime(vuln.CreatedAt, archetypeclient.ScanTime(scan, time.Now().UTC())), attrs, vuln)
 }
 func libraryNoteEvent(st settings, scan scanRecord, entry knowledgeEntryRecord, repo repositoryRecord) *primitives.Event {
 	entry.Slug = first(entry.Slug)
@@ -236,26 +260,13 @@ func libraryNoteEvent(st settings, scan scanRecord, entry knowledgeEntryRecord, 
 		"repo":              entry.RepositoryName,
 	}
 	eventID := "archetype-library-" + strconv.Itoa(entry.RepositoryID) + "-" + url.QueryEscape(entry.Slug)
-	return event(st, "archetype.library_note", eventID, "archetype/library-note/v1", scanTime(scan), attrs, entry)
+	return event(st, "archetype.library_note", eventID, "archetype/library-note/v1", archetypeclient.ScanTime(scan, time.Now().UTC()), attrs, entry)
 }
 func event(st settings, kind, id, schema string, at time.Time, attrs map[string]string, payload any) *primitives.Event {
 	body, _ := json.Marshal(payload)
 	return &cerebrov1.EventEnvelope{Id: id, TenantId: st.tenantID, SourceId: sourceID, Kind: kind, SchemaRef: schema, OccurredAt: timestamppb.New(at), Payload: body, Attributes: compact(attrs)}
 }
-func lastScanID(cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint) int {
-	value := first(sourcecdk.CursorToken(cursor), checkpoint.GetCursorOpaque())
-	id, _ := strconv.Atoi(value)
-	return id
-}
-func scanTime(scan scanRecord) time.Time {
-	return parseTime(first(scan.CompletedAt, scan.StartedAt, scan.CreatedAt), time.Now().UTC())
-}
-func parseTime(value string, fallback time.Time) time.Time {
-	if at, err := time.Parse(time.RFC3339, strings.TrimSpace(value)); err == nil {
-		return at.UTC()
-	}
-	return fallback.UTC()
-}
+
 func first(values ...string) string {
 	for _, value := range values {
 		if strings.TrimSpace(value) != "" {

--- a/sources/archetype/source_test.go
+++ b/sources/archetype/source_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -76,6 +77,252 @@ func TestSourceReadEmitsScanAndVulnerabilityEvents(t *testing.T) {
 	}
 	if got := pull.Checkpoint.GetCursorOpaque(); got != "1" {
 		t.Fatalf("checkpoint cursor = %q, want 1", got)
+	}
+}
+
+func TestSourceReadPaginatesScansWithoutSkippingCheckpointRange(t *testing.T) {
+	var scanRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			scanRequests++
+			if got := r.URL.Query().Get("limit"); got != strconv.Itoa(scanPageLimit) {
+				t.Fatalf("limit = %q, want %d", got, scanPageLimit)
+			}
+			before := 206
+			if raw := r.URL.Query().Get("before_id"); raw != "" {
+				var err error
+				before, err = strconv.Atoi(raw)
+				if err != nil {
+					t.Fatalf("before_id = %q: %v", raw, err)
+				}
+			}
+			scans := make([]map[string]any, 0, scanPageLimit)
+			for id := before - 1; id > 0 && len(scans) < scanPageLimit; id-- {
+				scans = append(scans, map[string]any{
+					"id":            id,
+					"repository_id": 7,
+					"status":        "completed",
+					"completed_at":  time.Date(2026, 7, 1, 0, id, 0, 0, time.UTC).Format(time.RFC3339),
+				})
+			}
+			writeJSON(t, w, scans)
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"family":    "scan",
+	})
+	var (
+		cursor     *cerebrov1.SourceCursor
+		checkpoint *cerebrov1.SourceCheckpoint
+		seen       = map[int]bool{}
+	)
+	for page := 0; page < 3; page++ {
+		pull, err := source.ReadWithCheckpoint(context.Background(), cfg, cursor, checkpoint)
+		if err != nil {
+			t.Fatalf("page %d ReadWithCheckpoint() error = %v", page+1, err)
+		}
+		for _, event := range pull.Events {
+			id, err := strconv.Atoi(event.GetAttributes()["scan_id"])
+			if err != nil {
+				t.Fatalf("page %d scan_id = %q: %v", page+1, event.GetAttributes()["scan_id"], err)
+			}
+			if seen[id] {
+				t.Fatalf("page %d repeated scan_id %d", page+1, id)
+			}
+			seen[id] = true
+		}
+		if page < 2 {
+			if pull.NextCursor == nil {
+				t.Fatalf("page %d NextCursor = nil", page+1)
+			}
+			if pull.Checkpoint != nil {
+				t.Fatalf("page %d checkpoint = %#v, want unadvanced", page+1, pull.Checkpoint)
+			}
+		} else {
+			if pull.NextCursor != nil {
+				t.Fatalf("terminal NextCursor = %#v, want nil", pull.NextCursor)
+			}
+			if got := pull.Checkpoint.GetCursorOpaque(); got != "205" {
+				t.Fatalf("terminal checkpoint = %q, want 205", got)
+			}
+		}
+		cursor = pull.NextCursor
+	}
+	if scanRequests != 3 {
+		t.Fatalf("scan requests = %d, want 3", scanRequests)
+	}
+	if len(seen) != 205 {
+		t.Fatalf("unique scans = %d, want 205", len(seen))
+	}
+	for id := 1; id <= 205; id++ {
+		if !seen[id] {
+			t.Fatalf("scan_id %d was skipped", id)
+		}
+	}
+}
+
+func TestSourceReadPaginationKeepsInitialHighWatermarkWhenNewScansArrive(t *testing.T) {
+	first, more, err := (sourcecdk.DescendingIDPage{
+		BaselineID:    50,
+		HighID:        205,
+		HighWatermark: time.Date(2026, 7, 1, 4, 0, 0, 0, time.UTC),
+	}).ContinuationCursor(scanPageLimit, scanPageLimit, 106, sourceID, "scan", "scan_id_desc")
+	if err != nil {
+		t.Fatalf("ContinuationCursor() error = %v", err)
+	}
+	if !more {
+		t.Fatal("ContinuationCursor() more = false")
+	}
+	state, err := sourcecdk.DescendingIDPageFrom(first, &cerebrov1.SourceCheckpoint{CursorOpaque: "50"}, sourceID, "scan_id_desc")
+	if err != nil {
+		t.Fatalf("DescendingIDPageFrom() error = %v", err)
+	}
+	if state.BaselineID != 50 || state.BeforeID != 106 || state.HighID != 205 {
+		t.Fatalf("state = %#v, want baseline 50, before 106, high 205", state)
+	}
+	if got := state.HighWatermark; !got.Equal(time.Date(2026, 7, 1, 4, 0, 0, 0, time.UTC)) {
+		t.Fatalf("high watermark = %v", got)
+	}
+}
+
+func TestSourceReadTreatsFullPageEndingAtBaselineAsTerminal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			scans := make([]map[string]any, 0, scanPageLimit)
+			for id := scanPageLimit; id > 0; id-- {
+				scans = append(scans, map[string]any{
+					"id":            id,
+					"repository_id": 7,
+					"status":        "completed",
+					"completed_at":  "2026-07-01T04:00:00Z",
+				})
+			}
+			writeJSON(t, w, scans)
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"family":    "scan",
+	}), nil, nil)
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if pull.NextCursor != nil {
+		t.Fatalf("NextCursor = %#v, want terminal page", pull.NextCursor)
+	}
+	if got := pull.Checkpoint.GetCursorOpaque(); got != strconv.Itoa(scanPageLimit) {
+		t.Fatalf("checkpoint = %q, want %d", got, scanPageLimit)
+	}
+}
+
+func TestSourceReadFinalizesHighWatermarkAfterEmptyGapPage(t *testing.T) {
+	highWatermark := time.Date(2026, 7, 1, 4, 0, 0, 0, time.UTC)
+	cursor, more, err := (sourcecdk.DescendingIDPage{
+		BaselineID:    50,
+		HighID:        205,
+		HighWatermark: highWatermark,
+	}).ContinuationCursor(scanPageLimit, scanPageLimit, 75, sourceID, "scan", "scan_id_desc")
+	if err != nil {
+		t.Fatalf("ContinuationCursor() error = %v", err)
+	}
+	if !more {
+		t.Fatal("ContinuationCursor() more = false")
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/scans" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSON(t, w, []map[string]any{{"id": 49, "repository_id": 7, "status": "completed"}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"family":    "scan",
+	}), cursor, &cerebrov1.SourceCheckpoint{CursorOpaque: "50"})
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 0 || pull.NextCursor != nil {
+		t.Fatalf("pull = %#v, want terminal checkpoint-only page", pull)
+	}
+	if got := pull.Checkpoint.GetCursorOpaque(); got != "205" {
+		t.Fatalf("checkpoint = %q, want 205", got)
+	}
+	if got := pull.Checkpoint.GetWatermark().AsTime(); !got.Equal(highWatermark) {
+		t.Fatalf("checkpoint watermark = %v, want %v", got, highWatermark)
+	}
+}
+
+func TestSourceReadAdvancesExistingCheckpointToNewestScan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{
+				{"id": 52, "repository_id": 7, "status": "completed", "completed_at": "2026-07-01T04:02:00Z"},
+				{"id": 51, "repository_id": 7, "status": "completed", "completed_at": "2026-07-01T04:01:00Z"},
+				{"id": 50, "repository_id": 7, "status": "completed", "completed_at": "2026-07-01T04:00:00Z"},
+			})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.ReadWithCheckpoint(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"family":    "scan",
+	}), nil, &cerebrov1.SourceCheckpoint{CursorOpaque: "50"})
+	if err != nil {
+		t.Fatalf("ReadWithCheckpoint() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("events = %d, want scans 51 and 52", len(pull.Events))
+	}
+	if got := pull.Checkpoint.GetCursorOpaque(); got != "52" {
+		t.Fatalf("checkpoint = %q, want 52", got)
 	}
 }
 

--- a/sources/internal/archetypeclient/client.go
+++ b/sources/internal/archetypeclient/client.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -70,7 +73,27 @@ type Repository struct {
 	Name  string `json:"name"`
 }
 
+func ScanTime(scan Scan, fallback time.Time) time.Time {
+	for _, value := range []string{scan.CompletedAt, scan.StartedAt, scan.CreatedAt} {
+		if strings.TrimSpace(value) != "" {
+			return ParseTime(value, fallback)
+		}
+	}
+	return fallback.UTC()
+}
+
+func ParseTime(value string, fallback time.Time) time.Time {
+	if at, err := time.Parse(time.RFC3339, strings.TrimSpace(value)); err == nil {
+		return at.UTC()
+	}
+	return fallback.UTC()
+}
+
 func Get(ctx context.Context, st Settings, path string, out JSONTarget) error {
+	return GetWithQuery(ctx, st, path, nil, out)
+}
+
+func GetWithQuery(ctx context.Context, st Settings, path string, query url.Values, out JSONTarget) error {
 	requestPath, err := sourcehttp.NormalizeRequestPath(st.SourceID, st.APIPrefix+path)
 	if err != nil {
 		return err
@@ -79,6 +102,7 @@ func Get(ctx context.Context, st Settings, path string, out JSONTarget) error {
 	if err != nil {
 		return err
 	}
+	req.URL.RawQuery = query.Encode()
 	if st.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+st.Token)
 	}


### PR DESCRIPTION
## Summary

- bound Archetype scan discovery to 100 records per request
- walk the descending scan ID API without advancing the durable checkpoint until every page is committed
- preserve the initial high-water mark when new scans arrive during a paginated run
- add a reusable descending-ID pagination primitive to the Source CDK

## Validation

- `go test ./sources/archetype ./sources/internal/archetypeclient ./internal/sourcecdk ./tools/archtests`
- targeted lint: 0 issues
- `go test ./internal/bootstrap`
- full `make test` passed all changed and source packages; its first run exposed the LOC ratchet, which this revision fixes; a subsequent unrelated bootstrap flake passed in isolation