### PR TITLE
Restore Slack release receipt notifications

### DIFF
--- a/apps/slack-companion-host/package.json
+++ b/apps/slack-companion-host/package.json
@@ -32,6 +32,8 @@
     }
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "3.1098.0",
+    "@aws-sdk/lib-dynamodb": "3.1098.0",
     "@slack/bolt": "4.7.3",
     "@writer/cerebro-sdk": "0.1.0",
     "@writer/cerebro-slack-companion": "0.1.0"

--- a/apps/slack-companion-host/src/runtime/config.ts
+++ b/apps/slack-companion-host/src/runtime/config.ts
@@ -16,6 +16,9 @@ export interface SlackRuntimeConfig {
   cerebroReadApiKey: string;
   cerebroTenantId: string;
   environmentLabel: string;
+  learningTableName?: string;
+  lifecycleChannelIds: ReadonlySet<string>;
+  lifecycleNoticesEnabled: boolean;
   memoryDirectory: string;
   port: number;
   production: boolean;
@@ -45,6 +48,22 @@ export function loadSlackRuntimeConfig(
   }
   const baseUrl = validatedBaseUrl(required(env.CEREBRO_BASE_URL));
   const archetype = archetypeConfig(env);
+  const lifecycleNoticesEnabled = optionalBooleanBinding(
+    env.SLACK_LIFECYCLE_NOTICES_ENABLED,
+    false,
+  );
+  const lifecycleChannelIds = new Set(
+    csv(env.SLACK_LIFECYCLE_CHANNEL_IDS?.trim() ?? ""),
+  );
+  const learningTableName = env.SECURITY_LEARNING_TABLE_NAME?.trim();
+  if (
+    lifecycleNoticesEnabled
+    && (lifecycleChannelIds.size === 0 || !learningTableName)
+  ) {
+    throw new SlackRuntimeConfigError(
+      "Slack lifecycle notices require a learning table and at least one channel.",
+    );
+  }
   return Object.freeze({
     allowedTeamIds,
     ...(archetype === undefined ? {} : { archetype }),
@@ -55,6 +74,9 @@ export function loadSlackRuntimeConfig(
     cerebroReadApiKey: required(env.CEREBRO_READ_API_KEY),
     cerebroTenantId: required(env.CEREBRO_TENANT_ID),
     environmentLabel: required(env.CEREBRO_SLACK_ENVIRONMENT_LABEL),
+    ...(learningTableName ? { learningTableName } : {}),
+    lifecycleChannelIds,
+    lifecycleNoticesEnabled,
     memoryDirectory: env.CEREBRO_SLACK_RUNTIME_MEMORY_DIR?.trim()
       || "/memory/slack-runtime",
     port: port(env.PORT),

--- a/apps/slack-companion-host/src/runtime/release-notifier.ts
+++ b/apps/slack-companion-host/src/runtime/release-notifier.ts
@@ -1,0 +1,516 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+const RELEASE_PARTITION_SUFFIX = "#release-receipts";
+const MAX_LINK_LENGTH = 300;
+const MAX_TEXT_LENGTH = 300;
+
+export type ReleaseStatus =
+  | "deploying"
+  | "failed"
+  | "rolled_back"
+  | "superseded"
+  | "verified";
+
+export interface ReleaseReceipt {
+  changedFileCount: number;
+  checks: { slack: { status: string } };
+  commitSubject?: string;
+  commitUrl: string;
+  components: readonly string[];
+  deployMode: "ecs" | "pulumi";
+  deployRunUrl: string;
+  failedChecks: readonly string[];
+  notificationClaims: Readonly<Record<string, number>>;
+  notifications: Readonly<Record<string, string>>;
+  previousVersion?: string;
+  pullRequestUrl?: string;
+  runningVersion?: string;
+  status: ReleaseStatus;
+  statusDetail: string;
+  threadTsByChannel: Readonly<Record<string, string>>;
+  version: string;
+}
+
+export interface ReleaseNoticeStore {
+  activeReceipt(): Promise<ReleaseReceipt | undefined>;
+  claim(input: {
+    channelId: string;
+    leaseSeconds: number;
+    state: string;
+    version: string;
+  }): Promise<boolean>;
+  complete(input: {
+    channelId: string;
+    state: string;
+    threadTs?: string;
+    version: string;
+  }): Promise<void>;
+  markSlackPassed(version: string, detail: string): Promise<void>;
+}
+
+export interface ReleaseNoticeSlackClient {
+  chat: {
+    postMessage(input: {
+      channel: string;
+      text: string;
+      thread_ts?: string;
+      unfurl_links?: boolean;
+      unfurl_media?: boolean;
+    }): Promise<{ ts?: string }>;
+  };
+}
+
+export interface ReleaseNoticeMonitor {
+  stop(): void;
+}
+
+export function createReleaseNoticeStore(input: {
+  tableName: string;
+  tenantId: string;
+}): ReleaseNoticeStore {
+  return new DynamoReleaseNoticeStore(
+    DynamoDBDocumentClient.from(new DynamoDBClient({})),
+    input.tableName,
+    releasePartition(input.tenantId),
+  );
+}
+
+export function startReleaseNoticeMonitor(input: {
+  channels: ReadonlySet<string>;
+  client: ReleaseNoticeSlackClient;
+  intervalMs?: number;
+  onError?: (error: unknown) => void;
+  store: ReleaseNoticeStore;
+}): ReleaseNoticeMonitor {
+  let stopped = false;
+  let running = false;
+  const tick = async (): Promise<void> => {
+    if (stopped || running) return;
+    running = true;
+    try {
+      const receipt = await input.store.activeReceipt();
+      if (receipt) {
+        await postReleaseState(
+          input.store,
+          input.client,
+          receipt,
+          [...input.channels],
+          input.onError,
+        );
+      }
+    } catch (error) {
+      input.onError?.(error);
+    } finally {
+      running = false;
+    }
+  };
+  const timer = setInterval(
+    () => void tick(),
+    Math.max(1_000, input.intervalMs ?? 10_000),
+  );
+  timer.unref();
+  void tick();
+  return {
+    stop(): void {
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}
+
+export async function postReleaseState(
+  store: ReleaseNoticeStore,
+  client: ReleaseNoticeSlackClient,
+  receipt: ReleaseReceipt,
+  channels: readonly string[],
+  onError?: (error: unknown) => void,
+): Promise<void> {
+  let connectedChannels = 0;
+  await Promise.all(channels.map(async (channel) => {
+    let threadTs = receipt.threadTsByChannel[channel];
+    if (!threadTs) {
+      const claimed = await store.claim({
+        channelId: channel,
+        leaseSeconds: 15,
+        state: "started",
+        version: receipt.version,
+      });
+      if (claimed) {
+        try {
+          const response = await client.chat.postMessage({
+            channel,
+            text: releaseStartedText(receipt),
+            unfurl_links: false,
+            unfurl_media: false,
+          });
+          if (!response.ts) throw new Error("Slack did not return a message timestamp.");
+          threadTs = response.ts;
+          await store.complete({
+            channelId: channel,
+            state: "started",
+            threadTs,
+            version: receipt.version,
+          });
+        } catch (error) {
+          onError?.(error);
+          return;
+        }
+      }
+    }
+    if (!threadTs) return;
+    connectedChannels += 1;
+    if (receipt.status === "deploying") return;
+    const claimed = await store.claim({
+      channelId: channel,
+      leaseSeconds: 120,
+      state: receipt.status,
+      version: receipt.version,
+    });
+    if (!claimed) return;
+    try {
+      await client.chat.postMessage({
+        channel,
+        text: releaseTerminalText(receipt),
+        thread_ts: threadTs,
+        unfurl_links: false,
+        unfurl_media: false,
+      });
+      await store.complete({
+        channelId: channel,
+        state: receipt.status,
+        version: receipt.version,
+      });
+    } catch (error) {
+      onError?.(error);
+      return;
+    }
+  }));
+  if (
+    receipt.status === "deploying"
+    && connectedChannels === channels.length
+    && receipt.checks.slack.status !== "passed"
+  ) {
+    await store.markSlackPassed(
+      receipt.version,
+      `Release thread created in ${connectedChannels}/${channels.length} configured channel(s).`,
+    );
+  }
+}
+
+export function releaseStartedText(receipt: ReleaseReceipt): string {
+  const subject = safeText(receipt.commitSubject, 160)?.replace(/[.!?]+$/u, "");
+  const commit = subject
+    ? `commit ${safeText(receipt.version, 80)}: ${subject}`
+    : `version ${safeText(receipt.version, 80)}`;
+  const mode = receipt.deployMode === "pulumi"
+    ? "infrastructure update"
+    : "ECS application update";
+  const components = receipt.components
+    .map((item) => safeText(item, 80))
+    .filter(Boolean)
+    .join(", ") || "companion runtime";
+  return [
+    `Deployment started for ${commit}.`,
+    `Mode: ${mode}. Components: ${components}. Changed files: ${receipt.changedFileCount}.`,
+    "Checks running: Slack release message, ECS image, runtime configuration, and Cerebro API.",
+    releaseLinks(receipt),
+  ].filter(Boolean).join("\n");
+}
+
+export function releaseTerminalText(receipt: ReleaseReceipt): string {
+  const links = releaseLinks(receipt);
+  if (receipt.status === "verified") {
+    return [
+      `Deployment verified. Running version ${safeText(receipt.runningVersion ?? receipt.version, 80)}.`,
+      "Checks passed: Slack release message, ECS image, runtime configuration, and Cerebro API.",
+      links,
+    ].filter(Boolean).join("\n");
+  }
+  if (receipt.status === "superseded") {
+    return [
+      `Deployment superseded. Running version: ${safeText(receipt.runningVersion, 80) ?? "unknown"}.`,
+      safeText(receipt.statusDetail, MAX_TEXT_LENGTH),
+      links,
+    ].filter(Boolean).join("\n");
+  }
+  const failed = receipt.failedChecks
+    .map((item) => safeText(item, 80))
+    .filter(Boolean)
+    .join(", ") || "deployment verification";
+  if (receipt.status === "rolled_back") {
+    return [
+      `Deployment rolled back. Restored version ${safeText(receipt.runningVersion ?? receipt.previousVersion, 80) ?? "unknown"}.`,
+      `Failed checks: ${failed}.`,
+      safeText(receipt.statusDetail, MAX_TEXT_LENGTH),
+      links,
+    ].filter(Boolean).join("\n");
+  }
+  return [
+    `Deployment failed verification. Running version: ${safeText(receipt.runningVersion, 80) ?? "unknown"}.`,
+    `Failed checks: ${failed}.`,
+    safeText(receipt.statusDetail, MAX_TEXT_LENGTH),
+    links,
+  ].filter(Boolean).join("\n");
+}
+
+class DynamoReleaseNoticeStore implements ReleaseNoticeStore {
+  constructor(
+    private readonly dynamo: DynamoDBDocumentClient,
+    private readonly tableName: string,
+    private readonly partitionKey: string,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async activeReceipt(): Promise<ReleaseReceipt | undefined> {
+    const pointerResponse = await this.dynamo.send(new GetCommand({
+      ConsistentRead: true,
+      Key: { pk: this.partitionKey, sk: "current" },
+      TableName: this.tableName,
+    }));
+    const version = stringValue(pointerResponse.Item?.version, 80);
+    if (!version) return undefined;
+    const receiptResponse = await this.dynamo.send(new GetCommand({
+      ConsistentRead: true,
+      Key: { pk: this.partitionKey, sk: `release#${cleanKey(version, 80)}` },
+      TableName: this.tableName,
+    }));
+    return releaseReceiptFrom(receiptResponse.Item);
+  }
+
+  async claim(input: {
+    channelId: string;
+    leaseSeconds: number;
+    state: string;
+    version: string;
+  }): Promise<boolean> {
+    const notice = noticeKey(input.channelId, input.state);
+    const nowSeconds = Math.floor(this.now().getTime() / 1_000);
+    try {
+      await this.dynamo.send(new UpdateCommand({
+        ConditionExpression:
+          "attribute_exists(pk) AND attribute_not_exists(#notifications.#notice) AND (attribute_not_exists(#claims.#notice) OR #claims.#notice < :now)",
+        ExpressionAttributeNames: {
+          "#claims": "notificationClaims",
+          "#notice": notice,
+          "#notifications": "notifications",
+        },
+        ExpressionAttributeValues: {
+          ":lease": nowSeconds + Math.max(10, input.leaseSeconds),
+          ":now": nowSeconds,
+        },
+        Key: {
+          pk: this.partitionKey,
+          sk: `release#${cleanKey(input.version, 80)}`,
+        },
+        TableName: this.tableName,
+        UpdateExpression: "SET #claims.#notice = :lease",
+      }));
+      return true;
+    } catch (error) {
+      if (isConditionalCheckFailure(error)) return false;
+      throw error;
+    }
+  }
+
+  async complete(input: {
+    channelId: string;
+    state: string;
+    threadTs?: string;
+    version: string;
+  }): Promise<void> {
+    const notice = noticeKey(input.channelId, input.state);
+    const names: Record<string, string> = {
+      "#claims": "notificationClaims",
+      "#notice": notice,
+      "#notifications": "notifications",
+    };
+    const values: Record<string, unknown> = {
+      ":sentAt": this.now().toISOString(),
+    };
+    let update = "SET #notifications.#notice = :sentAt REMOVE #claims.#notice";
+    if (input.threadTs) {
+      names["#channel"] = cleanKey(input.channelId, 120);
+      names["#threads"] = "threadTsByChannel";
+      values[":threadTs"] = input.threadTs;
+      update =
+        "SET #notifications.#notice = :sentAt, #threads.#channel = :threadTs REMOVE #claims.#notice";
+    }
+    await this.dynamo.send(new UpdateCommand({
+      ExpressionAttributeNames: names,
+      ExpressionAttributeValues: values,
+      Key: {
+        pk: this.partitionKey,
+        sk: `release#${cleanKey(input.version, 80)}`,
+      },
+      TableName: this.tableName,
+      UpdateExpression: update,
+    }));
+  }
+
+  async markSlackPassed(version: string, detail: string): Promise<void> {
+    await this.dynamo.send(new UpdateCommand({
+      ExpressionAttributeNames: {
+        "#checks": "checks",
+        "#slack": "slack",
+      },
+      ExpressionAttributeValues: {
+        ":check": {
+          detail: detail.replace(/\s+/gu, " ").slice(0, MAX_TEXT_LENGTH),
+          status: "passed",
+        },
+        ":updatedAt": this.now().toISOString(),
+      },
+      Key: {
+        pk: this.partitionKey,
+        sk: `release#${cleanKey(version, 80)}`,
+      },
+      TableName: this.tableName,
+      UpdateExpression: "SET #checks.#slack = :check, updatedAt = :updatedAt",
+    }));
+  }
+}
+
+function releaseReceiptFrom(value: unknown): ReleaseReceipt | undefined {
+  if (!record(value)) return undefined;
+  const status = value.status;
+  if (
+    value.schemaVersion !== 1
+    || value.recordType !== "companion_release_receipt"
+    || !releaseStatus(status)
+    || !record(value.checks)
+    || !record(value.checks.slack)
+  ) return undefined;
+  const version = stringValue(value.version, 80);
+  const commitUrl = safeUrl(value.commitUrl);
+  const deployRunUrl = safeUrl(value.deployRunUrl);
+  if (!version || !commitUrl || !deployRunUrl) return undefined;
+  return {
+    changedFileCount: boundedNumber(value.changedFileCount),
+    checks: {
+      slack: { status: stringValue(value.checks.slack.status, 30) ?? "pending" },
+    },
+    commitSubject: stringValue(value.commitSubject, 200),
+    commitUrl,
+    components: stringArray(value.components, 12, 80),
+    deployMode: value.deployMode === "pulumi" ? "pulumi" : "ecs",
+    deployRunUrl,
+    failedChecks: stringArray(value.failedChecks, 12, 80),
+    notificationClaims: numberRecord(value.notificationClaims),
+    notifications: stringRecord(value.notifications),
+    previousVersion: stringValue(value.previousVersion, 80),
+    pullRequestUrl: safeUrl(value.pullRequestUrl),
+    runningVersion: stringValue(value.runningVersion, 80),
+    status,
+    statusDetail: stringValue(value.statusDetail, MAX_TEXT_LENGTH) ?? "",
+    threadTsByChannel: stringRecord(value.threadTsByChannel),
+    version,
+  };
+}
+
+function releasePartition(tenantId: string): string {
+  return `tenant#${cleanKey(tenantId, 80)}${RELEASE_PARTITION_SUFFIX}`;
+}
+
+function releaseLinks(receipt: ReleaseReceipt): string {
+  return [
+    slackLink(receipt.deployRunUrl, "Deploy run"),
+    slackLink(receipt.commitUrl, "Commit"),
+    slackLink(receipt.pullRequestUrl, "Pull request"),
+  ].filter(Boolean).join(" · ");
+}
+
+function slackLink(value: string | undefined, label: string): string | undefined {
+  const url = safeUrl(value);
+  return url ? `<${url}|${label}>` : undefined;
+}
+
+function safeUrl(value: unknown): string | undefined {
+  const normalized = stringValue(value, MAX_LINK_LENGTH);
+  if (!normalized) return undefined;
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") return undefined;
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function safeText(value: unknown, maximum: number): string | undefined {
+  return stringValue(value, maximum)
+    ?.replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;");
+}
+
+function stringValue(value: unknown, maximum: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value
+    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return normalized ? normalized.slice(0, maximum).trimEnd() : undefined;
+}
+
+function stringArray(
+  value: unknown,
+  maximumItems: number,
+  maximumLength: number,
+): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, maximumItems)
+    .map((item) => stringValue(item, maximumLength))
+    .filter((item): item is string => Boolean(item));
+}
+
+function stringRecord(value: unknown): Record<string, string> {
+  if (!record(value)) return {};
+  return Object.fromEntries(Object.entries(value).slice(0, 300).flatMap(
+    ([key, item]) => {
+      const clean = stringValue(item, 120);
+      return clean ? [[cleanKey(key, 120), clean]] : [];
+    },
+  ));
+}
+
+function numberRecord(value: unknown): Record<string, number> {
+  if (!record(value)) return {};
+  return Object.fromEntries(Object.entries(value).slice(0, 300).flatMap(
+    ([key, item]) => Number.isFinite(item) ? [[cleanKey(key, 120), Number(item)]] : [],
+  ));
+}
+
+function boundedNumber(value: unknown): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? Math.min(value, 1_000_000)
+    : 0;
+}
+
+function cleanKey(value: string, maximum: number): string {
+  return value.replace(/[^A-Za-z0-9_.:-]+/gu, "_").slice(0, maximum);
+}
+
+function noticeKey(channelId: string, state: string): string {
+  return `${cleanKey(channelId, 60)}:${cleanKey(state, 50)}`;
+}
+
+function releaseStatus(value: unknown): value is ReleaseStatus {
+  return value === "deploying"
+    || value === "failed"
+    || value === "rolled_back"
+    || value === "superseded"
+    || value === "verified";
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isConditionalCheckFailure(error: unknown): boolean {
+  return record(error) && error.name === "ConditionalCheckFailedException";
+}

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -31,6 +31,11 @@ import {
   type PendingAssistantOutcome,
 } from "./outcome-store.js";
 import {
+  createReleaseNoticeStore,
+  type ReleaseNoticeMonitor,
+  startReleaseNoticeMonitor,
+} from "./release-notifier.js";
+import {
   archetypeErrorModal,
   archetypeLoadingModal,
   ArchetypeSlackWorkspace,
@@ -304,6 +309,7 @@ export class SlackCompanionRuntime {
   private readonly app: App;
   private healthServer?: Server;
   private outcomeTimer?: NodeJS.Timeout;
+  private releaseNoticeMonitor?: ReleaseNoticeMonitor;
   private ready = false;
 
   constructor(
@@ -343,6 +349,28 @@ export class SlackCompanionRuntime {
       this.healthServer?.listen(this.config.port, "0.0.0.0", resolve);
     });
     this.ready = true;
+    if (
+      this.config.lifecycleNoticesEnabled
+      && this.config.learningTableName
+      && this.config.lifecycleChannelIds.size > 0
+    ) {
+      this.releaseNoticeMonitor = startReleaseNoticeMonitor({
+        channels: this.config.lifecycleChannelIds,
+        client: this.app.client,
+        onError: (error) => {
+          process.stderr.write(`${JSON.stringify({
+            component: "slack-release-notifier",
+            error_kind: error instanceof Error ? error.name : "unknown",
+            operation: "poll",
+            state: "failed",
+          })}\n`);
+        },
+        store: createReleaseNoticeStore({
+          tableName: this.config.learningTableName,
+          tenantId: this.config.cerebroTenantId,
+        }),
+      });
+    }
     await this.assessOutcomes();
     this.outcomeTimer = setInterval(() => void this.assessOutcomes(), 60 * 60 * 1_000);
     this.outcomeTimer.unref();
@@ -350,6 +378,7 @@ export class SlackCompanionRuntime {
 
   async stop(): Promise<void> {
     this.ready = false;
+    this.releaseNoticeMonitor?.stop();
     if (this.outcomeTimer) clearInterval(this.outcomeTimer);
     await Promise.all([
       this.app.stop(),

--- a/apps/slack-companion-host/test/release-notifier.test.ts
+++ b/apps/slack-companion-host/test/release-notifier.test.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  postReleaseState,
+  type ReleaseNoticeSlackClient,
+  type ReleaseNoticeStore,
+  type ReleaseReceipt,
+  releaseStartedText,
+  releaseTerminalText,
+} from "../src/runtime/release-notifier.js";
+
+class MemoryReleaseStore implements ReleaseNoticeStore {
+  readonly claims: Array<{ channelId: string; state: string; version: string }> = [];
+  readonly completions: Array<{
+    channelId: string;
+    state: string;
+    threadTs?: string;
+    version: string;
+  }> = [];
+  readonly passed: Array<{ detail: string; version: string }> = [];
+  claimResult = true;
+
+  async activeReceipt(): Promise<ReleaseReceipt | undefined> {
+    return undefined;
+  }
+
+  async claim(input: {
+    channelId: string;
+    leaseSeconds: number;
+    state: string;
+    version: string;
+  }): Promise<boolean> {
+    this.claims.push(input);
+    return this.claimResult;
+  }
+
+  async complete(input: {
+    channelId: string;
+    state: string;
+    threadTs?: string;
+    version: string;
+  }): Promise<void> {
+    this.completions.push(input);
+  }
+
+  async markSlackPassed(version: string, detail: string): Promise<void> {
+    this.passed.push({ detail, version });
+  }
+}
+
+function receipt(
+  overrides: Partial<ReleaseReceipt> = {},
+): ReleaseReceipt {
+  return {
+    changedFileCount: 2,
+    checks: { slack: { status: "pending" } },
+    commitSubject: "Repair <runtime> & lifecycle.",
+    commitUrl: "https://github.com/writer/cerebro/commit/abc",
+    components: ["Slack runtime"],
+    deployMode: "ecs",
+    deployRunUrl: "https://github.com/WriterInternal/cerebro/actions/runs/1",
+    failedChecks: [],
+    notificationClaims: {},
+    notifications: {},
+    status: "deploying",
+    statusDetail: "Deployment checks are running.",
+    threadTsByChannel: {},
+    version: "sha-abc",
+    ...overrides,
+  };
+}
+
+function slackClient(): {
+  client: ReleaseNoticeSlackClient;
+  messages: Array<{
+    channel: string;
+    text: string;
+    thread_ts?: string;
+  }>;
+} {
+  const messages: Array<{
+    channel: string;
+    text: string;
+    thread_ts?: string;
+  }> = [];
+  return {
+    client: {
+      chat: {
+        async postMessage(input) {
+          messages.push(input);
+          return { ts: "1785000000.000001" };
+        },
+      },
+    },
+    messages,
+  };
+}
+
+test("deploying release creates one claimed thread and passes the Slack check", async () => {
+  const store = new MemoryReleaseStore();
+  const slack = slackClient();
+  await postReleaseState(store, slack.client, receipt(), ["C-ONE"]);
+
+  assert.deepEqual(store.claims.map(({ channelId, state }) => ({
+    channelId,
+    state,
+  })), [{ channelId: "C-ONE", state: "started" }]);
+  assert.equal(slack.messages.length, 1);
+  assert.equal(slack.messages[0]?.thread_ts, undefined);
+  assert.deepEqual(store.completions, [{
+    channelId: "C-ONE",
+    state: "started",
+    threadTs: "1785000000.000001",
+    version: "sha-abc",
+  }]);
+  assert.deepEqual(store.passed, [{
+    detail: "Release thread created in 1/1 configured channel(s).",
+    version: "sha-abc",
+  }]);
+});
+
+test("an existing release thread receives one terminal reply", async () => {
+  const store = new MemoryReleaseStore();
+  const slack = slackClient();
+  await postReleaseState(store, slack.client, receipt({
+    checks: { slack: { status: "passed" } },
+    runningVersion: "sha-abc",
+    status: "verified",
+    statusDetail: "All checks passed.",
+    threadTsByChannel: { "C-ONE": "1785000000.000001" },
+  }), ["C-ONE"]);
+
+  assert.deepEqual(store.claims.map(({ state }) => state), ["verified"]);
+  assert.equal(slack.messages[0]?.thread_ts, "1785000000.000001");
+  assert.match(slack.messages[0]?.text ?? "", /Deployment verified/u);
+  assert.deepEqual(store.completions[0], {
+    channelId: "C-ONE",
+    state: "verified",
+    version: "sha-abc",
+  });
+  assert.deepEqual(store.passed, []);
+});
+
+test("a competing worker lease prevents duplicate Slack messages", async () => {
+  const store = new MemoryReleaseStore();
+  store.claimResult = false;
+  const slack = slackClient();
+  await postReleaseState(store, slack.client, receipt(), ["C-ONE"]);
+
+  assert.equal(slack.messages.length, 0);
+  assert.deepEqual(store.completions, []);
+  assert.deepEqual(store.passed, []);
+});
+
+test("an unconfirmed Slack post is observable and cannot pass the release check", async () => {
+  const store = new MemoryReleaseStore();
+  const errors: unknown[] = [];
+  const client: ReleaseNoticeSlackClient = {
+    chat: {
+      async postMessage() {
+        return {};
+      },
+    },
+  };
+  await postReleaseState(
+    store,
+    client,
+    receipt(),
+    ["C-ONE"],
+    (error) => errors.push(error),
+  );
+
+  assert.equal(errors.length, 1);
+  assert.deepEqual(store.completions, []);
+  assert.deepEqual(store.passed, []);
+});
+
+test("release copy escapes Slack control text and rejects non-GitHub links", () => {
+  const unsafe = receipt({
+    commitSubject: "Ship <@U123> & verify",
+    commitUrl: "https://attacker.example/commit/abc",
+  });
+  const started = releaseStartedText(unsafe);
+  const terminal = releaseTerminalText({
+    ...unsafe,
+    failedChecks: ["runtime <check>"],
+    runningVersion: "sha-failed",
+    status: "failed",
+    statusDetail: "A <failure> & retry.",
+  });
+
+  assert.doesNotMatch(started, /attacker/u);
+  assert.match(started, /&lt;@U123&gt; &amp; verify/u);
+  assert.match(terminal, /runtime &lt;check&gt;/u);
+  assert.match(terminal, /A &lt;failure&gt; &amp; retry/u);
+});

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -44,7 +44,31 @@ test("runtime config accepts environment-held bindings and an allowlisted worksp
   assert.equal(config.environmentLabel, "development");
   assert.equal(config.production, false);
   assert.equal(config.port, 3100);
+  assert.equal(config.lifecycleNoticesEnabled, false);
   assert.deepEqual([...config.allowedTeamIds], ["T-ONE", "T-TWO"]);
+});
+
+test("runtime config requires durable destinations for enabled lifecycle notices", () => {
+  const base = {
+    CEREBRO_BASE_URL: "https://cerebro.example.com",
+    CEREBRO_READ_API_KEY: "bound-at-runtime",
+    CEREBRO_SLACK_APP_NAME: "Cerebro Development",
+    CEREBRO_SLACK_ENVIRONMENT_LABEL: "development",
+    CEREBRO_SLACK_PRODUCTION: "false",
+    CEREBRO_TENANT_ID: "tenant-one",
+    SLACK_ALLOWED_TEAM_IDS: "T-ONE",
+    SLACK_APP_TOKEN: "bound-at-runtime",
+    SLACK_BOT_TOKEN: "bound-at-runtime",
+    SLACK_LIFECYCLE_NOTICES_ENABLED: "true",
+  };
+  assert.throws(() => loadSlackRuntimeConfig(base), SlackRuntimeConfigError);
+  const config = loadSlackRuntimeConfig({
+    ...base,
+    SECURITY_LEARNING_TABLE_NAME: "companion-learning",
+    SLACK_LIFECYCLE_CHANNEL_IDS: "C-ONE,C-TWO",
+  });
+  assert.equal(config.learningTableName, "companion-learning");
+  assert.deepEqual([...config.lifecycleChannelIds], ["C-ONE", "C-TWO"]);
 });
 
 test("runtime config rejects a missing workspace allowlist", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "3.1098.0",
+        "@aws-sdk/lib-dynamodb": "3.1098.0",
         "@slack/bolt": "4.7.3",
         "@writer/cerebro-sdk": "0.1.0",
         "@writer/cerebro-slack-companion": "0.1.0"
@@ -351,6 +353,358 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1098.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1098.0.tgz",
+      "integrity": "sha512-7o/3jD4/F8fo5BE9uMgsbIoaArlcnCNv6Bu11zUeF4Bgm6hYskQIGTK4UMTJ+qawez+FZ0Sg1E69woGd6gDabA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/credential-provider-node": "^3.972.75",
+        "@aws-sdk/dynamodb-codec": "^3.973.38",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.27",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.3.tgz",
+      "integrity": "sha512-6YZTpF5Zzl0KdSrztM0l6ErKdnXrnnodIDYfayHE9SFfZU8Ubxls7H2XnfWT121jgwiG+WP1z5kyfVDsH5V4qA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.64.tgz",
+      "integrity": "sha512-14kkR5aj1c7D+cYCrEcG2W3xw87wMYAEUeB/tMiQ2j0RVKzzdewd4mJw1+Q0JVLr4IFU1JHGDCyj0WqLrtIixg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.66.tgz",
+      "integrity": "sha512-BrZxoXScBZ+nTOYy388zHkz1n5cS8C+uGFMozD4w9OKEWMq39Cu/9l/k385Hb54dtv0VIeh12f8h67o3xDNH9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.9.tgz",
+      "integrity": "sha512-d/mMvS+sQjSWNA6+JCldK1YB/jQmtoWM8Izj10mrOZdRCeWNVb8IYQuuyHHKKKXcpGo5Pd0LIK6onHbLvlhuVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/credential-provider-env": "^3.972.64",
+        "@aws-sdk/credential-provider-http": "^3.972.66",
+        "@aws-sdk/credential-provider-login": "^3.972.71",
+        "@aws-sdk/credential-provider-process": "^3.972.64",
+        "@aws-sdk/credential-provider-sso": "^3.973.8",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.70",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.71.tgz",
+      "integrity": "sha512-l93922lXnTs5RjM3QrMCXSmXiEgLFLaQ0Lco9F3tJ08o0mzGdAj6m2nAXDuTMHoUuL0u7RKmrhm+Z8/7GCilyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.75.tgz",
+      "integrity": "sha512-sdFhR4E3HWZefGL6OsBhxqXdqtFvxGOh8VLfiu9yttPgVNcpEozEDPmrTYmXA3CIf6npUETVLveQPGQ7GBzVhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.64",
+        "@aws-sdk/credential-provider-http": "^3.972.66",
+        "@aws-sdk/credential-provider-ini": "^3.973.9",
+        "@aws-sdk/credential-provider-process": "^3.972.64",
+        "@aws-sdk/credential-provider-sso": "^3.973.8",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.70",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.64.tgz",
+      "integrity": "sha512-Q5noG5vfFo++bUaLGcjj8OHX5tmwa1O/5nDVMeaSSZgjzgvWbW6tgu/gSa+aENwcJXjoXDQh+8TRZR2zHds/aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.8.tgz",
+      "integrity": "sha512-37okeZyRdVkGrU6nyKBPGqQvyl/7CEiMpUVOb0+BCNCIR0VAuBxNgjMb0mnsR1EXm8dqQFfQZOJ5YW/0sBfa1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/token-providers": "3.1098.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.70.tgz",
+      "integrity": "sha512-Ps/f9USafScb6CSQTRPNMzdKL5x5XRwDIRgFvnuFWfClGZe7/fI7iCFqXdxKjc9LBxP28E7iUgNloGgfgw406w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.38.tgz",
+      "integrity": "sha512-0iN2lkG6TQACJt+JPXBd5JyqLg0jfzoDn4HK3I/COHTKIZmnkClTf/OPurlrKurGy0r7gdf6ngE9YoyMBKfqXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
+      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1098.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1098.0.tgz",
+      "integrity": "sha512-Xzb0UeL/x6cDQdtEruF8/jlYgduSgB/bgpsIopiqHGh+eNQmLxbAZaND/9a6qRUeXsde72n5Wpj6jefj/rbqNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/util-dynamodb": "^3.996.7",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1098.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.27.tgz",
+      "integrity": "sha512-5AJlxrsg27IGGiQauWOdVyqK55EN0EMIwXndkVHhBiPT4CtdSaz89/sAENSw+GP4KF+BOWcgycZFNjkOLmfo1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.9",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.38.tgz",
+      "integrity": "sha512-jQDs+nxnmgo4+WPOmY373HIC8jx4KyYYMYDI74FWrzX3Ba9fYsV0dSA+7PNYNkhRbbRCRLre83tQ31F1ACCHkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1098.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1098.0.tgz",
+      "integrity": "sha512-6cFAviffeqYGjrXn4FqGbWcTxB3nbpBpQXUm6MvnrWZThJaVBTHHnespHgSUh4yVLfzhipSh9H/XjzkHQd9P4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
+      "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1088.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2480,6 +2834,87 @@
       "engines": {
         "node": ">= 18",
         "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -4711,6 +5146,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
@@ -8466,6 +8907,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8725,6 +9175,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/obug": {
       "version": "2.1.4",


### PR DESCRIPTION
## Summary

- monitor Slack companion release records from the current host
- claim each release channel with conditional DynamoDB leases
- persist the Slack thread binding before marking notification delivery complete
- post terminal verified, failed, rolled-back, or superseded states in the same thread
- keep release notification disabled unless the learning table and release channels are configured

## Live defect reproduced

The current host was healthy and answered an authenticated Slack question, but its release receipt recorded zero channel claims and zero notifications. The image, runtime, and Cerebro checks passed while the Slack check timed out.

## Verification

- `npm run check --workspace @writer/cerebro-slack-companion-host` — 65 tests passed
- `npm audit` — 0 vulnerabilities
- `git diff --check`