### PR TITLE
Install the Rust TLS crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "prost",
  "prost-types",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ neo4rs = "0.8.0"
 native-tls = "0.2.18"
 postgres-native-tls = "0.5.3"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }
+rustls = { version = "0.23.42", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
 tokio = { version = "1.53.1", features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync"] }
 tokio-postgres = { version = "0.7.18", features = ["with-serde_json-1"] }
 tower = "0.5.3"

--- a/crates/cerebro-platform/Cargo.toml
+++ b/crates/cerebro-platform/Cargo.toml
@@ -33,6 +33,7 @@ futures-util.workspace = true
 hmac.workspace = true
 jsonwebtoken.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -1407,6 +1407,7 @@ struct ProjectionAuthorityQuery {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    install_tls_crypto_provider()?;
     match env::args().nth(1).as_deref() {
         None | Some("demo") => demo().await,
         Some("serve") => serve_memory(OrganizationalGraph::new()).await,
@@ -1431,6 +1432,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Some(other) => Err(format!("unknown command {other:?}").into()),
     }
+}
+
+fn install_tls_crypto_provider() -> Result<(), Box<dyn Error>> {
+    if rustls::crypto::CryptoProvider::get_default().is_some() {
+        return Ok(());
+    }
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .map_err(|_| "TLS crypto provider was initialized concurrently".into())
 }
 
 async fn serve_memory(graph: OrganizationalGraph) -> Result<(), Box<dyn Error>> {
@@ -3764,6 +3774,14 @@ mod tests {
     use super::*;
 
     const TEST_SHARED_SECRET: &str = "test-organizational-graph-secret-32-bytes";
+
+    #[test]
+    fn startup_installs_a_tls_crypto_provider() {
+        install_tls_crypto_provider().expect("TLS crypto provider should install");
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+        install_tls_crypto_provider()
+            .expect("TLS crypto provider installation should be idempotent");
+    }
 
     #[test]
     fn aws_secrets_manager_endpoint_requires_a_safe_transport() {


### PR DESCRIPTION
## What changed

- install the AWS-LC rustls crypto provider before any platform command initializes TLS
- make startup initialization idempotent
- add a regression test for provider installation

## Why

The platform binary could compile with both rustls crypto backends enabled through its dependency graph. Without an explicit process-level provider, TLS initialization panicked before the read-only graph service could start.

## Impact

Platform commands now select the repository's existing AWS-LC backend deterministically before creating TLS clients. Existing command behavior and graph authority are unchanged.

## Validation

- `cargo test -p cerebro-platform startup_installs_a_tls_crypto_provider -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -p cerebro-platform --all-targets -- -D warnings`
