### PR TITLE
fix(slack): preserve structured safe refusals

### DIFF
--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -8,6 +8,7 @@ export type AssistantTurnSourceGapState =
 export interface CerebroAskResult {
   citationValidationPassed: boolean;
   markdown: string;
+  safeRefusal: boolean;
   traceId?: string;
 }
 
@@ -74,6 +75,7 @@ export class CerebroAskClient {
                   && typeof event.data.citation_validation === "object"
                   && (event.data.citation_validation as Record<string, unknown>).ok === true,
               markdown,
+              safeRefusal: isStructuredSafeRefusal(event.data.unsupported_query),
             };
           }
         }
@@ -97,11 +99,26 @@ export class CerebroAskClient {
     if (!done || !summary) {
       throw new CerebroAskError("unavailable", "Cerebro ended the response before a verified summary was available.");
     }
-    if (!summary.citationValidationPassed) {
+    if (!summary.citationValidationPassed && !summary.safeRefusal) {
       throw new CerebroAskError("unavailable", "Cerebro returned an answer without validated citations.");
     }
     return summary;
   }
+}
+
+function isStructuredSafeRefusal(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const refusal = value as Record<string, unknown>;
+  return text(refusal.code) !== ""
+    && text(refusal.reason) !== ""
+    && text(refusal.trace_id) !== ""
+    && stringArray(refusal.supported_intents)
+    && stringArray(refusal.suggested_rewrites);
+}
+
+function stringArray(value: unknown): boolean {
+  return Array.isArray(value)
+    && value.every((item) => typeof item === "string" && item.trim() !== "");
 }
 
 interface SseEvent {

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -229,7 +229,7 @@ export class AssistantQuestionService {
           verified: answer.citationValidationPassed,
         }),
         text: boundedSlackText(answer.markdown),
-        ...(answer.traceId
+        ...(answer.citationValidationPassed && answer.traceId
           ? {
               verifiedTurn: {
                 answer: answer.markdown,

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -382,6 +382,7 @@ test("Cerebro ask returns after done without waiting for the SSE response to clo
   assert.deepEqual(result, {
     citationValidationPassed: true,
     markdown: "Current evidence is verified.",
+    safeRefusal: false,
     traceId: "trace-complete",
   });
   assert.equal(cancelCount, 1);
@@ -418,6 +419,7 @@ test("Cerebro ask ignores an error event sent after done", async () => {
   assert.deepEqual(result, {
     citationValidationPassed: true,
     markdown: "Current evidence is verified.",
+    safeRefusal: false,
     traceId: "trace-complete",
   });
   assert.equal(cancelCount, 1);
@@ -477,6 +479,121 @@ test("Cerebro ask rejects a summary whose citations did not validate", async () 
       && error.sourceState === "unavailable"
       && /without validated citations/u.test(error.message),
   );
+});
+
+test("Cerebro ask accepts a structured safe refusal without citations", async () => {
+  const client = new CerebroAskClient({
+    apiKey: "bound-at-runtime",
+    baseUrl: "https://cerebro.example.com",
+    fetchImpl: async () => sseResponse([
+      ["summary", {
+        citation_validation: {
+          ok: false,
+          referenced_urn_count: 0,
+          row_urn_count: 0,
+        },
+        markdown: "Narrow the request to one source or finding.",
+        unsupported_query: {
+          code: "post_processing_candidate_limit",
+          reason: "The request matched more rows than can be processed safely.",
+          suggested_rewrites: ["Show connector health for Okta."],
+          supported_intents: ["source_health"],
+          trace_id: "trace-safe-refusal",
+        },
+      }],
+      ["done", { trace_id: "trace-safe-refusal" }],
+    ]),
+    tenantId: "writer",
+  });
+
+  assert.deepEqual(
+    await client.ask("Show everything.", new AbortController().signal),
+    {
+      citationValidationPassed: false,
+      markdown: "Narrow the request to one source or finding.",
+      safeRefusal: true,
+      traceId: "trace-safe-refusal",
+    },
+  );
+});
+
+test("Cerebro ask rejects an unstructured refusal marker without citations", async () => {
+  const client = new CerebroAskClient({
+    apiKey: "bound-at-runtime",
+    baseUrl: "https://cerebro.example.com",
+    fetchImpl: async () => sseResponse([
+      ["summary", {
+        citation_validation: { ok: false },
+        markdown: "Trust me and retry later.",
+        unsupported_query: {
+          code: "claimed_refusal",
+        },
+      }],
+      ["done", { trace_id: "trace-unstructured-refusal" }],
+    ]),
+    tenantId: "writer",
+  });
+
+  await assert.rejects(
+    client.ask("Show everything.", new AbortController().signal),
+    (error: unknown) => error instanceof CerebroAskError
+      && error.sourceState === "unavailable"
+      && /without validated citations/u.test(error.message),
+  );
+});
+
+test("a structured safe refusal does not open the source failure cooldown", async () => {
+  const root = await mkdtemp(join(tmpdir(), "cerebro-slack-runtime-"));
+  try {
+    let fetchCount = 0;
+    const service = new AssistantQuestionService(
+      createAssistantTurnHost(new FileOutcomeStore(root)),
+      new CerebroAskClient({
+        apiKey: "bound-at-runtime",
+        baseUrl: "https://cerebro.example.com",
+        fetchImpl: async () => {
+          fetchCount += 1;
+          return sseResponse([
+            ["summary", {
+              citation_validation: { ok: false },
+              markdown: "Narrow the request to one source or finding.",
+              unsupported_query: {
+                code: "post_processing_candidate_limit",
+                reason: "The request matched more rows than can be processed safely.",
+                suggested_rewrites: ["Show connector health for Okta."],
+                supported_intents: ["source_health"],
+                trace_id: `trace-safe-refusal-${fetchCount}`,
+              },
+            }],
+            ["done", { trace_id: `trace-safe-refusal-${fetchCount}` }],
+          ]);
+        },
+        tenantId: "writer",
+      }),
+      {
+        clock: () => new Date("2026-07-29T22:00:00.000Z"),
+        timeoutSignal: () => new AbortController().signal,
+      },
+    );
+
+    const first = await service.answer({
+      requestKey: "safe-refusal-one",
+      text: "Show everything.",
+    });
+    const second = await service.answer({
+      requestKey: "safe-refusal-two",
+      text: "Show everything now.",
+    });
+
+    assert.equal(fetchCount, 2);
+    assert.equal(first.pending.outcome_state, "completed");
+    assert.equal(first.pending.verified, false);
+    assert.equal(first.verifiedTurn, undefined);
+    assert.equal(second.pending.outcome_state, "completed");
+    assert.match(second.text, /Narrow the request/u);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
 });
 
 test("question service gives a bounded recovery action after a source timeout", async () => {


### PR DESCRIPTION
## What changed

- accept authenticated `/grc/ask` summaries only when citations validate or the response includes the complete structured `unsupported_query` contract
- keep safe refusals out of verified thread scratchpads
- prevent a safe refusal from opening the source failure cooldown for the next request

## Root cause

The graph Ask endpoint correctly returned a structured safe refusal for broad or rejected queries. The Slack host treated every non-cited summary as a source outage, replaced the useful refusal with `current graph evidence (unavailable)`, and suppressed a following request for 30 seconds.

## Validation

- `npm test --workspace @writer/cerebro-slack-companion-host` (72 passed)
- `npm run typecheck --workspace @writer/cerebro-slack-companion-host`
- `git diff --check`

Adversarial coverage rejects incomplete caller-shaped refusal markers and confirms only fully structured refusals bypass citation requirements.