### PR TITLE
fix(slack): expand lookup response budget

### DIFF
--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -127,6 +127,7 @@ test("question service preflights one governed graph lookup and returns its veri
   const root = await mkdtemp(join(tmpdir(), "cerebro-slack-runtime-"));
   try {
     let request: Request | undefined;
+    let timeoutMs: number | undefined;
     const askClient = new CerebroAskClient({
       apiKey: "bound-at-runtime",
       baseUrl: "https://cerebro.example.com",
@@ -153,7 +154,10 @@ test("question service preflights one governed graph lookup and returns its veri
       askClient,
       {
         clock: () => clockValues.shift() ?? new Date("2026-07-18T10:00:01.000Z"),
-        timeoutSignal: () => new AbortController().signal,
+        timeoutSignal: (milliseconds) => {
+          timeoutMs = milliseconds;
+          return new AbortController().signal;
+        },
       },
     );
 
@@ -167,6 +171,7 @@ test("question service preflights one governed graph lookup and returns its veri
     assert.equal(result.pending.verified, true);
     assert.equal(request?.url, "https://cerebro.example.com/grc/ask");
     assert.equal(request?.headers.get("x-cerebro-tenant"), "writer");
+    assert.equal(timeoutMs, 59_900);
     assert.deepEqual(await request?.json(), {
       question: "Which current findings are open?",
       tenant_id: "writer",

--- a/apps/slack-companion/src/assistant-turn/policy.ts
+++ b/apps/slack-companion/src/assistant-turn/policy.ts
@@ -34,7 +34,7 @@ const TURN_BUDGETS: Record<AssistantExecutionLaneV1, Omit<AssistantTurnBudgetV1,
   ignore: { latency_budget_ms: 5_000, max_selected_capabilities: 0, max_tool_calls: 0 },
   converse: { latency_budget_ms: 5_000, max_selected_capabilities: 0, max_tool_calls: 0 },
   continue: { latency_budget_ms: 5_000, max_selected_capabilities: 0, max_tool_calls: 0 },
-  lookup: { latency_budget_ms: 30_000, max_selected_capabilities: 4, max_tool_calls: 3 },
+  lookup: { latency_budget_ms: 60_000, max_selected_capabilities: 4, max_tool_calls: 3 },
   investigate: { latency_budget_ms: 180_000, max_selected_capabilities: 10, max_tool_calls: 8 },
   act: { latency_budget_ms: 300_000, max_selected_capabilities: 12, max_tool_calls: 12 },
 };

--- a/apps/slack-companion/test/assistant-turn-preflight.test.ts
+++ b/apps/slack-companion/test/assistant-turn-preflight.test.ts
@@ -39,8 +39,8 @@ test("preflight allows one healthy authorized invocation inside the lane", () =>
   assert.deepEqual(result, {
     allowed: true,
     blockers: [],
-    cutoff_ms: 24_000,
-    remaining_ms: 20_000,
+    cutoff_ms: 48_000,
+    remaining_ms: 50_000,
     schema_version: "assistant-turn-plan-preflight/v1",
     tool_calls_after_start: 1,
   });
@@ -51,7 +51,7 @@ test("preflight stops new tools at 80 percent of the lane budget", () => {
     budget: assistantTurnBudget("lookup"),
     catalog,
     completed_tool_calls: 1,
-    elapsed_ms: 24_000,
+    elapsed_ms: 48_000,
     invocation: invocation(),
     observed_at: "2026-07-21T12:00:01.000Z",
     replan_count: 1,
@@ -69,7 +69,7 @@ test("preflight rejects blocked plans before execution", () => {
     budget: assistantTurnBudget("lookup"),
     catalog,
     completed_tool_calls: 3,
-    elapsed_ms: 25_000,
+    elapsed_ms: 50_000,
     invocation: {
       ...planned,
       authority: { ...planned.authority!, request_digest: `sha256:${"b".repeat(64)}` },

--- a/apps/slack-companion/test/assistant-turn.test.ts
+++ b/apps/slack-companion/test/assistant-turn.test.ts
@@ -16,7 +16,13 @@ test("assistant turn budgets bind model-selected lanes to proportional work", ()
     max_tool_calls: 0,
     schema_version: "assistant-turn-budget/v1",
   });
-  assert.equal(assistantTurnBudget("lookup").max_tool_calls, 3);
+  assert.deepEqual(assistantTurnBudget("lookup"), {
+    execution_lane: "lookup",
+    latency_budget_ms: 60_000,
+    max_selected_capabilities: 4,
+    max_tool_calls: 3,
+    schema_version: "assistant-turn-budget/v1",
+  });
   assert.equal(assistantTurnBudget("investigate").max_tool_calls, 8);
   assert.equal(assistantTurnBudget("act").max_tool_calls, 12);
 });


### PR DESCRIPTION
## What changed

- expand the governed Slack lookup lane from 30 seconds to 60 seconds
- update cutoff expectations to preserve the existing 80 percent tool-start boundary
- verify the host passes the expanded remaining budget to the Cerebro request deadline

## Why

Verified graph answers can require more than 30 seconds to finish citation validation. The previous ceiling could abort a successful lookup before its validated summary arrived.

## Validation

- `npm run check --workspace @writer/cerebro-slack-companion`
- `npm run check --workspace @writer/cerebro-slack-companion-host`
- `git diff --check`