### PR TITLE
feat(slack): move answer acceptance authority to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,7 @@ dependencies = [
  "cerebro-platform-sdk",
  "cerebro-policy-catalog",
  "cerebro-security-lifecycle",
+ "cerebro-slack-authority",
  "cerebro-source-catalog",
  "cerebro-source-runtime-next",
  "connectrpc",
@@ -999,6 +1000,14 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "time",
+]
+
+[[package]]
+name = "cerebro-slack-authority"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/platform-sdk",
     "crates/policy-catalog",
     "crates/security-lifecycle",
+    "crates/slack-authority",
     "crates/source-catalog",
     "crates/security-path-kernel",
     "crates/source-runtime-next",
@@ -61,6 +62,7 @@ cerebro-platform-engine = { version = "0.1.0", path = "crates/platform-engine" }
 cerebro-platform-sdk = { version = "0.1.0", path = "crates/platform-sdk" }
 cerebro-policy-catalog = { version = "0.1.0", path = "crates/policy-catalog" }
 cerebro-security-lifecycle = { version = "0.1.0", path = "crates/security-lifecycle" }
+cerebro-slack-authority = { version = "0.1.0", path = "crates/slack-authority" }
 cerebro-source-catalog = { version = "0.1.0", path = "crates/source-catalog" }
 cerebro-source-runtime-next = { version = "0.1.0", path = "crates/source-runtime-next" }
 cerebro-wasm-guest = { version = "0.1.0", path = "internal/wasmguest" }

--- a/apps/slack-companion-host/src/main.ts
+++ b/apps/slack-companion-host/src/main.ts
@@ -3,6 +3,7 @@ import { CerebroAskClient } from "./runtime/cerebro-ask-client.js";
 import { loadSlackRuntimeConfig } from "./runtime/config.js";
 import { FileOutcomeStore } from "./runtime/outcome-store.js";
 import { FileThreadScratchpadStore } from "./runtime/thread-scratchpad-store.js";
+import { SlackAnswerAuthorityClient } from "./runtime/slack-answer-authority-client.js";
 import {
   AssistantQuestionService,
   createAssistantTurnHost,
@@ -16,6 +17,9 @@ async function main(): Promise<void> {
   const scratchpads = new FileThreadScratchpadStore(config.memoryDirectory);
   const host = createAssistantTurnHost(outcomes);
   const questions = new AssistantQuestionService(host, new CerebroAskClient({
+    answerAuthority: new SlackAnswerAuthorityClient({
+      baseUrl: config.slackAnswerAuthorityUrl,
+    }),
     apiKey: config.cerebroReadApiKey,
     baseUrl: config.cerebroBaseUrl,
     tenantId: config.cerebroTenantId,

--- a/apps/slack-companion-host/src/preview-main.ts
+++ b/apps/slack-companion-host/src/preview-main.ts
@@ -1,6 +1,7 @@
 import { createServer, type Server } from "node:http";
 
 import { CerebroAskClient } from "./runtime/cerebro-ask-client.js";
+import { SlackAnswerAuthorityClient } from "./runtime/slack-answer-authority-client.js";
 
 const port = boundedPort(process.env.PORT);
 let ready = false;
@@ -17,6 +18,12 @@ const server = createServer((request, response) => {
 async function main(): Promise<void> {
   await listen(server, port);
   const client = new CerebroAskClient({
+    answerAuthority: new SlackAnswerAuthorityClient({
+      baseUrl: validatedLoopbackUrl(
+        process.env.CEREBRO_SLACK_ANSWER_AUTHORITY_URL?.trim()
+          || "http://127.0.0.1:8091",
+      ),
+    }),
     apiKey: required(process.env.CEREBRO_READ_API_KEY),
     baseUrl: validatedBaseUrl(required(process.env.CEREBRO_BASE_URL)),
     tenantId: required(process.env.CEREBRO_TENANT_ID),
@@ -63,6 +70,15 @@ function validatedBaseUrl(value: string): string {
   parsed.search = "";
   parsed.hash = "";
   return parsed.toString().replace(/\/$/, "");
+}
+
+function validatedLoopbackUrl(value: string): string {
+  const baseUrl = validatedBaseUrl(value);
+  const parsed = new URL(baseUrl);
+  if (parsed.protocol !== "http:" || (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost")) {
+    throw new Error("The Rust Slack answer authority must use a loopback HTTP binding.");
+  }
+  return baseUrl;
 }
 
 function boundedPort(value: string | undefined): number {

--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -13,6 +13,7 @@ export interface CerebroAskResult {
 }
 
 export interface CerebroAskClientOptions {
+  answerAuthority: SlackAnswerAuthorityPort;
   apiKey: string;
   baseUrl: string;
   fetchImpl?: typeof fetch;
@@ -61,28 +62,28 @@ export class CerebroAskClient {
       throw new CerebroAskError(sourceState(response.status), `Cerebro ask failed with status ${response.status}.`);
     }
 
-    let summary: CerebroAskResult | undefined;
+    let summary: Omit<SlackAnswerCandidate, "completed" | "schema_version" | "trace_id"> | undefined;
     let done = false;
+    let traceId = "";
     try {
       for await (const event of readSse(response.body)) {
         if (event.name === "summary") {
           const markdown = text(event.data.markdown);
           if (markdown) {
             summary = {
-              citationValidationPassed: event.data.citation_validation === undefined
-                ? false
-                : event.data.citation_validation !== null
-                  && typeof event.data.citation_validation === "object"
-                  && (event.data.citation_validation as Record<string, unknown>).ok === true,
+              ...(citationValidation(event.data.citation_validation) === undefined
+                ? {}
+                : { citation_validation: citationValidation(event.data.citation_validation) }),
               markdown,
-              safeRefusal: isStructuredSafeRefusal(event.data.unsupported_query),
+              ...(unsupportedQuery(event.data.unsupported_query) === undefined
+                ? {}
+                : { unsupported_query: unsupportedQuery(event.data.unsupported_query) }),
             };
           }
         }
         if (event.name === "done") {
           done = true;
-          const traceId = text(event.data.trace_id);
-          if (summary && traceId) summary.traceId = traceId;
+          traceId = text(event.data.trace_id);
           break;
         }
         if (event.name === "error") {
@@ -96,29 +97,80 @@ export class CerebroAskClient {
       }
       throw new CerebroAskError("unavailable", errorMessage(error));
     }
-    if (!done || !summary) {
+    if (!done || !summary || !traceId) {
       throw new CerebroAskError("unavailable", "Cerebro ended the response before a verified summary was available.");
     }
-    if (!summary.citationValidationPassed && !summary.safeRefusal) {
-      throw new CerebroAskError("unavailable", "Cerebro returned an answer without validated citations.");
+    let decision;
+    try {
+      decision = await this.options.answerAuthority.validate({
+        ...summary,
+        completed: true,
+        schema_version: "slack-answer-candidate/v1",
+        trace_id: traceId,
+      });
+    } catch (error: unknown) {
+      throw new CerebroAskError("unavailable", errorMessage(error));
     }
-    return summary;
+    return {
+      citationValidationPassed: decision.verified,
+      markdown: summary.markdown,
+      safeRefusal: decision.disposition === "safe_refusal",
+      traceId: decision.trace_id,
+    };
   }
 }
 
-function isStructuredSafeRefusal(value: unknown): boolean {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const refusal = value as Record<string, unknown>;
-  return text(refusal.code) !== ""
-    && text(refusal.reason) !== ""
-    && text(refusal.trace_id) !== ""
-    && stringArray(refusal.supported_intents)
-    && stringArray(refusal.suggested_rewrites);
+function citationValidation(
+  value: unknown,
+): SlackAnswerCandidate["citation_validation"] | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const validation = value as Record<string, unknown>;
+  if (
+    typeof validation.ok !== "boolean"
+    || !nonNegativeInteger(validation.referenced_urn_count)
+    || !nonNegativeInteger(validation.row_urn_count)
+  ) {
+    return undefined;
+  }
+  return {
+    ok: validation.ok,
+    referenced_urn_count: validation.referenced_urn_count,
+    row_urn_count: validation.row_urn_count,
+  };
 }
 
-function stringArray(value: unknown): boolean {
-  return Array.isArray(value)
-    && value.every((item) => typeof item === "string" && item.trim() !== "");
+function unsupportedQuery(
+  value: unknown,
+): SlackAnswerCandidate["unsupported_query"] | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const refusal = value as Record<string, unknown>;
+  const supportedIntents = stringArray(refusal.supported_intents);
+  const suggestedRewrites = stringArray(refusal.suggested_rewrites);
+  const code = text(refusal.code);
+  const reason = text(refusal.reason);
+  const traceId = text(refusal.trace_id);
+  if (!code || !reason || !traceId || !supportedIntents || !suggestedRewrites) return undefined;
+  return {
+    code,
+    reason,
+    suggested_rewrites: suggestedRewrites,
+    supported_intents: supportedIntents,
+    trace_id: traceId,
+  };
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (
+    !Array.isArray(value)
+    || value.some((item) => typeof item !== "string" || item.trim() === "")
+  ) {
+    return undefined;
+  }
+  return value.map((item) => (item as string).trim());
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
 }
 
 interface SseEvent {
@@ -201,3 +253,7 @@ function errorMessage(value: unknown): string {
 function isAbortError(value: unknown): boolean {
   return value instanceof DOMException && (value.name === "AbortError" || value.name === "TimeoutError");
 }
+import {
+  type SlackAnswerAuthorityPort,
+  type SlackAnswerCandidate,
+} from "./slack-answer-authority-client.js";

--- a/apps/slack-companion-host/src/runtime/config.ts
+++ b/apps/slack-companion-host/src/runtime/config.ts
@@ -15,6 +15,7 @@ export interface SlackRuntimeConfig {
   cerebroBaseUrl: string;
   cerebroReadApiKey: string;
   cerebroTenantId: string;
+  slackAnswerAuthorityUrl: string;
   environmentLabel: string;
   learningTableName?: string;
   lifecycleChannelIds: ReadonlySet<string>;
@@ -73,6 +74,9 @@ export function loadSlackRuntimeConfig(
     cerebroBaseUrl: baseUrl,
     cerebroReadApiKey: required(env.CEREBRO_READ_API_KEY),
     cerebroTenantId: required(env.CEREBRO_TENANT_ID),
+    slackAnswerAuthorityUrl: validatedLoopbackUrl(
+      env.CEREBRO_SLACK_ANSWER_AUTHORITY_URL?.trim() || "http://127.0.0.1:8091",
+    ),
     environmentLabel: required(env.CEREBRO_SLACK_ENVIRONMENT_LABEL),
     ...(learningTableName ? { learningTableName } : {}),
     lifecycleChannelIds,
@@ -251,6 +255,16 @@ function validatedBaseUrl(value: string): string {
   parsed.pathname = parsed.pathname.replace(/\/$/, "");
   parsed.search = "";
   parsed.hash = "";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function validatedLoopbackUrl(value: string): string {
+  const parsed = new URL(validatedBaseUrl(value));
+  if (parsed.protocol !== "http:" || (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost")) {
+    throw new SlackRuntimeConfigError(
+      "The Rust Slack answer authority must use a loopback HTTP binding.",
+    );
+  }
   return parsed.toString().replace(/\/$/, "");
 }
 

--- a/apps/slack-companion-host/src/runtime/slack-answer-authority-client.ts
+++ b/apps/slack-companion-host/src/runtime/slack-answer-authority-client.ts
@@ -1,0 +1,101 @@
+export interface SlackAnswerCandidate {
+  citation_validation?: {
+    ok: boolean;
+    referenced_urn_count: number;
+    row_urn_count: number;
+  };
+  completed: boolean;
+  markdown: string;
+  schema_version: "slack-answer-candidate/v1";
+  trace_id: string;
+  unsupported_query?: {
+    code: string;
+    reason: string;
+    suggested_rewrites: string[];
+    supported_intents: string[];
+    trace_id: string;
+  };
+}
+
+export interface SlackAnswerDecision {
+  disposition: "grounded" | "safe_refusal";
+  schema_version: "slack-answer-decision/v1";
+  trace_id: string;
+  verified: boolean;
+}
+
+export interface SlackAnswerAuthorityPort {
+  validate(candidate: SlackAnswerCandidate): Promise<SlackAnswerDecision>;
+}
+
+export interface SlackAnswerAuthorityClientOptions {
+  baseUrl: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class SlackAnswerAuthorityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SlackAnswerAuthorityError";
+  }
+}
+
+export class SlackAnswerAuthorityClient implements SlackAnswerAuthorityPort {
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly options: SlackAnswerAuthorityClientOptions) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async validate(candidate: SlackAnswerCandidate): Promise<SlackAnswerDecision> {
+    const response = await this.fetchImpl(
+      `${this.options.baseUrl}/v1/answers/validate`,
+      {
+        body: JSON.stringify(candidate),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        signal: AbortSignal.timeout(2_000),
+      },
+    ).catch((error: unknown) => {
+      throw new SlackAnswerAuthorityError(errorMessage(error));
+    });
+    if (!response.ok) {
+      throw new SlackAnswerAuthorityError(
+        `Rust Slack answer authority rejected the candidate with status ${response.status}.`,
+      );
+    }
+    const decision: unknown = await response.json().catch(() => undefined);
+    if (!validDecision(decision, candidate.trace_id)) {
+      throw new SlackAnswerAuthorityError(
+        "Rust Slack answer authority returned an invalid decision.",
+      );
+    }
+    return decision;
+  }
+}
+
+function validDecision(
+  value: unknown,
+  expectedTraceId: string,
+): value is SlackAnswerDecision {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const decision = value as Record<string, unknown>;
+  if (
+    decision.schema_version !== "slack-answer-decision/v1"
+    || decision.trace_id !== expectedTraceId
+    || (decision.disposition !== "grounded" && decision.disposition !== "safe_refusal")
+    || typeof decision.verified !== "boolean"
+  ) {
+    return false;
+  }
+  return decision.disposition === "grounded"
+    ? decision.verified
+    : !decision.verified;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Rust Slack answer authority is unavailable.";
+}

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -8,6 +8,10 @@ import { CerebroAskClient, CerebroAskError } from "../src/runtime/cerebro-ask-cl
 import { loadSlackRuntimeConfig, SlackRuntimeConfigError } from "../src/runtime/config.js";
 import { FileOutcomeStore } from "../src/runtime/outcome-store.js";
 import {
+  SlackAnswerAuthorityClient,
+  type SlackAnswerAuthorityPort,
+} from "../src/runtime/slack-answer-authority-client.js";
+import {
   AssistantQuestionService,
   closeHealthServer,
   contextualQuestion,
@@ -19,6 +23,28 @@ import {
   readSlackThreadContext,
   slackDeliveryReferences,
 } from "../src/runtime/slack-runtime.js";
+
+const testAnswerAuthority: SlackAnswerAuthorityPort = {
+  async validate(candidate) {
+    if (candidate.unsupported_query) {
+      return {
+        disposition: "safe_refusal",
+        schema_version: "slack-answer-decision/v1",
+        trace_id: candidate.trace_id,
+        verified: false,
+      };
+    }
+    if (candidate.citation_validation?.ok) {
+      return {
+        disposition: "grounded",
+        schema_version: "slack-answer-decision/v1",
+        trace_id: candidate.trace_id,
+        verified: true,
+      };
+    }
+    throw new Error("Rust authority rejected the candidate.");
+  },
+};
 
 test("health server cleanup is safe before listen succeeds", async () => {
   const server = createServer();
@@ -41,11 +67,46 @@ test("runtime config accepts environment-held bindings and an allowlisted worksp
   });
 
   assert.equal(config.cerebroBaseUrl, "https://cerebro.example.com");
+  assert.equal(config.slackAnswerAuthorityUrl, "http://127.0.0.1:8091");
   assert.equal(config.environmentLabel, "development");
   assert.equal(config.production, false);
   assert.equal(config.port, 3100);
   assert.equal(config.lifecycleNoticesEnabled, false);
   assert.deepEqual([...config.allowedTeamIds], ["T-ONE", "T-TWO"]);
+});
+
+test("runtime config keeps the Rust Slack authority on loopback", () => {
+  const base = {
+    CEREBRO_BASE_URL: "https://cerebro.example.com",
+    CEREBRO_READ_API_KEY: "bound-at-runtime",
+    CEREBRO_SLACK_APP_NAME: "Cerebro Development",
+    CEREBRO_SLACK_ENVIRONMENT_LABEL: "development",
+    CEREBRO_SLACK_PRODUCTION: "false",
+    CEREBRO_TENANT_ID: "tenant-one",
+    SLACK_ALLOWED_TEAM_IDS: "T-ONE",
+    SLACK_APP_TOKEN: "bound-at-runtime",
+    SLACK_BOT_TOKEN: "bound-at-runtime",
+  };
+
+  assert.equal(
+    loadSlackRuntimeConfig({
+      ...base,
+      CEREBRO_SLACK_ANSWER_AUTHORITY_URL: "http://localhost:8191/",
+    }).slackAnswerAuthorityUrl,
+    "http://localhost:8191",
+  );
+  for (const authorityUrl of [
+    "https://authority.example.com",
+    "http://10.0.0.4:8091",
+  ]) {
+    assert.throws(
+      () => loadSlackRuntimeConfig({
+        ...base,
+        CEREBRO_SLACK_ANSWER_AUTHORITY_URL: authorityUrl,
+      }),
+      SlackRuntimeConfigError,
+    );
+  }
 });
 
 test("runtime config requires durable destinations for enabled lifecycle notices", () => {
@@ -128,13 +189,18 @@ test("question service preflights one governed graph lookup and returns its veri
   try {
     let request: Request | undefined;
     const askClient = new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
       apiKey: "bound-at-runtime",
       baseUrl: "https://cerebro.example.com",
       fetchImpl: async (input, init) => {
         request = new Request(input, init);
         return sseResponse([
           ["summary", {
-            citation_validation: { ok: true },
+            citation_validation: {
+              ok: true,
+              referenced_urn_count: 1,
+              row_urn_count: 1,
+            },
             markdown: "One current finding is open.",
           }],
           ["done", { trace_id: "trace-one" }],
@@ -183,6 +249,7 @@ test("empty threaded mentions request a question without invoking Cerebro", asyn
     const service = new AssistantQuestionService(
       createAssistantTurnHost(new FileOutcomeStore(root)),
       new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
         apiKey: "bound-at-runtime",
         baseUrl: "https://cerebro.example.com",
         fetchImpl: async () => {
@@ -294,6 +361,7 @@ test("question service returns an exact source gap when Cerebro is unavailable",
     const service = new AssistantQuestionService(
       createAssistantTurnHost(store),
       new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
         apiKey: "bound-at-runtime",
         baseUrl: "https://cerebro.example.com",
         fetchImpl: async () => {
@@ -334,6 +402,7 @@ test("Cerebro ask cancels and unlocks an unfinished SSE response after an error 
     },
   });
   const client = new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
     apiKey: "bound-at-runtime",
     baseUrl: "https://cerebro.example.com",
     fetchImpl: async () => new Response(body, {
@@ -362,12 +431,13 @@ test("Cerebro ask returns after done without waiting for the SSE response to clo
     },
     start(controller) {
       controller.enqueue(new TextEncoder().encode(
-        'event: summary\ndata: {"citation_validation":{"ok":true},"markdown":"Current evidence is verified."}\n\n'
+        'event: summary\ndata: {"citation_validation":{"ok":true,"referenced_urn_count":1,"row_urn_count":1},"markdown":"Current evidence is verified."}\n\n'
           + 'event: done\ndata: {"trace_id":"trace-complete"}\n\n',
       ));
     },
   });
   const client = new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
     apiKey: "bound-at-runtime",
     baseUrl: "https://cerebro.example.com",
     fetchImpl: async () => new Response(body, {
@@ -398,13 +468,14 @@ test("Cerebro ask ignores an error event sent after done", async () => {
     },
     start(controller) {
       controller.enqueue(new TextEncoder().encode(
-        'event: summary\ndata: {"citation_validation":{"ok":true},"markdown":"Current evidence is verified."}\n\n'
+        'event: summary\ndata: {"citation_validation":{"ok":true,"referenced_urn_count":1,"row_urn_count":1},"markdown":"Current evidence is verified."}\n\n'
           + 'event: done\ndata: {"trace_id":"trace-complete"}\n\n'
           + 'event: error\ndata: {"message":"post-completion cleanup failed"}\n\n',
       ));
     },
   });
   const client = new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
     apiKey: "bound-at-runtime",
     baseUrl: "https://cerebro.example.com",
     fetchImpl: async () => new Response(body, {
@@ -440,6 +511,7 @@ test("Cerebro ask classifies a mid-stream deadline as timed out", async () => {
     },
   });
   const client = new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
     apiKey: "bound-at-runtime",
     baseUrl: "https://cerebro.example.com",
     fetchImpl: async () => new Response(body, {
@@ -461,6 +533,7 @@ test("Cerebro ask classifies a mid-stream deadline as timed out", async () => {
 
 test("Cerebro ask rejects a summary whose citations did not validate", async () => {
   const client = new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
     apiKey: "bound-at-runtime",
     baseUrl: "https://cerebro.example.com",
     fetchImpl: async () => sseResponse([
@@ -477,12 +550,90 @@ test("Cerebro ask rejects a summary whose citations did not validate", async () 
     client.ask("Are we clear?", new AbortController().signal),
     (error: unknown) => error instanceof CerebroAskError
       && error.sourceState === "unavailable"
-      && /without validated citations/u.test(error.message),
+      && /Rust authority rejected/u.test(error.message),
   );
+});
+
+test("Rust Slack answer authority receives the bounded candidate and binds the trace", async () => {
+  let body: unknown;
+  const authority = new SlackAnswerAuthorityClient({
+    baseUrl: "http://127.0.0.1:8091",
+    fetchImpl: async (_input, init) => {
+      body = JSON.parse(String(init?.body));
+      return Response.json({
+        disposition: "grounded",
+        schema_version: "slack-answer-decision/v1",
+        trace_id: "trace-grounded",
+        verified: true,
+      });
+    },
+  });
+
+  const decision = await authority.validate({
+    citation_validation: {
+      ok: true,
+      referenced_urn_count: 2,
+      row_urn_count: 2,
+    },
+    completed: true,
+    markdown: "Current evidence is verified.",
+    schema_version: "slack-answer-candidate/v1",
+    trace_id: "trace-grounded",
+  });
+
+  assert.equal(decision.disposition, "grounded");
+  assert.deepEqual(body, {
+    citation_validation: {
+      ok: true,
+      referenced_urn_count: 2,
+      row_urn_count: 2,
+    },
+    completed: true,
+    markdown: "Current evidence is verified.",
+    schema_version: "slack-answer-candidate/v1",
+    trace_id: "trace-grounded",
+  });
+});
+
+test("Rust Slack answer authority rejects a cross-trace or contradictory decision", async () => {
+  for (const responseBody of [
+    {
+      disposition: "grounded",
+      schema_version: "slack-answer-decision/v1",
+      trace_id: "other-trace",
+      verified: true,
+    },
+    {
+      disposition: "safe_refusal",
+      schema_version: "slack-answer-decision/v1",
+      trace_id: "trace-grounded",
+      verified: true,
+    },
+  ]) {
+    const authority = new SlackAnswerAuthorityClient({
+      baseUrl: "http://127.0.0.1:8091",
+      fetchImpl: async () => Response.json(responseBody),
+    });
+    await assert.rejects(
+      authority.validate({
+        citation_validation: {
+          ok: true,
+          referenced_urn_count: 1,
+          row_urn_count: 1,
+        },
+        completed: true,
+        markdown: "Current evidence is verified.",
+        schema_version: "slack-answer-candidate/v1",
+        trace_id: "trace-grounded",
+      }),
+      /invalid decision/u,
+    );
+  }
 });
 
 test("Cerebro ask accepts a structured safe refusal without citations", async () => {
   const client = new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
     apiKey: "bound-at-runtime",
     baseUrl: "https://cerebro.example.com",
     fetchImpl: async () => sseResponse([
@@ -519,6 +670,7 @@ test("Cerebro ask accepts a structured safe refusal without citations", async ()
 
 test("Cerebro ask rejects an unstructured refusal marker without citations", async () => {
   const client = new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
     apiKey: "bound-at-runtime",
     baseUrl: "https://cerebro.example.com",
     fetchImpl: async () => sseResponse([
@@ -538,7 +690,7 @@ test("Cerebro ask rejects an unstructured refusal marker without citations", asy
     client.ask("Show everything.", new AbortController().signal),
     (error: unknown) => error instanceof CerebroAskError
       && error.sourceState === "unavailable"
-      && /without validated citations/u.test(error.message),
+      && /Rust authority rejected/u.test(error.message),
   );
 });
 
@@ -549,6 +701,7 @@ test("a structured safe refusal does not open the source failure cooldown", asyn
     const service = new AssistantQuestionService(
       createAssistantTurnHost(new FileOutcomeStore(root)),
       new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
         apiKey: "bound-at-runtime",
         baseUrl: "https://cerebro.example.com",
         fetchImpl: async () => {
@@ -604,6 +757,7 @@ test("question service gives a bounded recovery action after a source timeout", 
     const service = new AssistantQuestionService(
       createAssistantTurnHost(new FileOutcomeStore(root)),
       new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
         apiKey: "bound-at-runtime",
         baseUrl: "https://cerebro.example.com",
         fetchImpl: async (_input, init) => {
@@ -636,6 +790,7 @@ test("failed claimed mentions persist a blocked outcome before retries are suppr
     const questions = new AssistantQuestionService(
       host,
       new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
         apiKey: "bound-at-runtime",
         baseUrl: "https://cerebro.example.com",
         fetchImpl: async () => sseResponse([]),

--- a/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
+++ b/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
@@ -10,12 +10,25 @@ import {
 import { CerebroAskClient } from "../src/runtime/cerebro-ask-client.js";
 import { loadSlackRuntimeConfig } from "../src/runtime/config.js";
 import { FileOutcomeStore } from "../src/runtime/outcome-store.js";
+import type { SlackAnswerAuthorityPort } from "../src/runtime/slack-answer-authority-client.js";
 import {
   AssistantQuestionService,
   createAssistantTurnHost,
   handleSlackMention,
 } from "../src/runtime/slack-runtime.js";
 import { FileThreadScratchpadStore } from "../src/runtime/thread-scratchpad-store.js";
+
+const testAnswerAuthority: SlackAnswerAuthorityPort = {
+  async validate(candidate) {
+    if (!candidate.citation_validation?.ok) throw new Error("candidate rejected");
+    return {
+      disposition: "grounded",
+      schema_version: "slack-answer-decision/v1",
+      trace_id: candidate.trace_id,
+      verified: true,
+    };
+  },
+};
 
 test("file scratchpad stores idempotent thread notes and clears them", async () => {
   const root = await mkdtemp(join(tmpdir(), "cerebro-slack-scratchpad-"));
@@ -125,6 +138,7 @@ test("Slack remember saves a note that the next question uses only in that threa
     const questions = new AssistantQuestionService(
       host,
       new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
         apiKey: "bound-at-runtime",
         baseUrl: "https://cerebro.example.com",
         fetchImpl: async (_input, init) => {
@@ -133,7 +147,11 @@ test("Slack remember saves a note that the next question uses only in that threa
           );
           return sseResponse([
             ["summary", {
-              citation_validation: { ok: true },
+              citation_validation: {
+                ok: true,
+                referenced_urn_count: 1,
+                row_urn_count: 1,
+              },
               markdown: "The current owner is Security Operations.",
             }],
             ["done", { trace_id: "trace-scratchpad" }],

--- a/crates/cerebro-platform/Cargo.toml
+++ b/crates/cerebro-platform/Cargo.toml
@@ -26,6 +26,7 @@ cerebro-platform-engine.workspace = true
 cerebro-platform-sdk.workspace = true
 cerebro-policy-catalog.workspace = true
 cerebro-security-lifecycle.workspace = true
+cerebro-slack-authority.workspace = true
 cerebro-source-catalog.workspace = true
 cerebro-source-runtime-next.workspace = true
 connectrpc.workspace = true

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -5,6 +5,7 @@ mod cutover_command;
 mod oidc;
 mod parity_command;
 mod rpc;
+mod slack_authority;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -1412,6 +1413,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some("serve") => serve_memory(OrganizationalGraph::new()).await,
         Some("serve-demo") => serve_memory(demo_graph()?.0).await,
         Some("serve-neo4j-readonly") => serve_neo4j_readonly().await,
+        Some("serve-slack-authority") => slack_authority::serve().await,
         Some("serve-neo4j") => serve_neo4j().await,
         Some("serve-neo4j-consumer") => serve_neo4j_consumer().await,
         Some("consume-append-log") => consume_append_log().await,
@@ -1425,7 +1427,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some("show-authority") => cutover_command::show_authority().await,
         Some("--help" | "-h") => {
             println!(
-                "cerebro-platform <demo|serve|serve-demo|serve-neo4j-readonly|serve-neo4j|serve-neo4j-consumer|consume-append-log|migrate-stores|rebuild-lifecycle-projection|sync-source|catalog-summary|compare-projection|evaluate-family|promote-family|show-authority>"
+                "cerebro-platform <demo|serve|serve-demo|serve-neo4j-readonly|serve-slack-authority|serve-neo4j|serve-neo4j-consumer|consume-append-log|migrate-stores|rebuild-lifecycle-projection|sync-source|catalog-summary|compare-projection|evaluate-family|promote-family|show-authority>"
             );
             Ok(())
         }

--- a/crates/cerebro-platform/src/slack_authority.rs
+++ b/crates/cerebro-platform/src/slack_authority.rs
@@ -1,0 +1,138 @@
+use std::{env, error::Error, net::SocketAddr};
+
+use axum::{
+    Json, Router,
+    extract::DefaultBodyLimit,
+    http::StatusCode,
+    routing::{get, post},
+};
+use cerebro_slack_authority::{AnswerCandidate, AnswerDecision, validate_answer};
+use serde::Serialize;
+
+const DEFAULT_BIND: &str = "127.0.0.1:8091";
+const MAX_REQUEST_BYTES: usize = 96 * 1024;
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    code: &'static str,
+    message: String,
+}
+
+pub async fn serve() -> Result<(), Box<dyn Error>> {
+    let bind = env::var("CEREBRO_SLACK_AUTHORITY_BIND").unwrap_or_else(|_| DEFAULT_BIND.to_owned());
+    let address: SocketAddr = bind.parse()?;
+    require_loopback(address)?;
+    let listener = tokio::net::TcpListener::bind(address).await?;
+    axum::serve(listener, router()).await?;
+    Ok(())
+}
+
+fn router() -> Router {
+    Router::new()
+        .route("/healthz", get(|| async { StatusCode::NO_CONTENT }))
+        .route("/v1/answers/validate", post(validate_answer_route))
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
+}
+
+async fn validate_answer_route(
+    Json(candidate): Json<AnswerCandidate>,
+) -> Result<Json<AnswerDecision>, (StatusCode, Json<ErrorResponse>)> {
+    validate_answer(candidate).map(Json).map_err(|error| {
+        (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse {
+                code: "answer_rejected",
+                message: error.to_string(),
+            }),
+        )
+    })
+}
+
+fn require_loopback(address: SocketAddr) -> Result<(), Box<dyn Error>> {
+    if !address.ip().is_loopback() {
+        return Err("Slack answer authority must bind to a loopback address".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, header::CONTENT_TYPE},
+    };
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[test]
+    fn rejects_non_loopback_bindings() {
+        assert!(require_loopback("127.0.0.1:8091".parse().unwrap()).is_ok());
+        assert!(require_loopback("[::1]:8091".parse().unwrap()).is_ok());
+        assert!(require_loopback("0.0.0.0:8091".parse().unwrap()).is_err());
+        assert!(require_loopback("10.0.0.4:8091".parse().unwrap()).is_err());
+    }
+
+    #[tokio::test]
+    async fn route_returns_the_rust_authority_decision() {
+        let response = router()
+            .oneshot(
+                Request::post("/v1/answers/validate")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{
+                          "schema_version":"slack-answer-candidate/v1",
+                          "completed":true,
+                          "markdown":"Narrow the request to one source.",
+                          "trace_id":"trace-refusal",
+                          "citation_validation":null,
+                          "unsupported_query":{
+                            "code":"post_processing_candidate_limit",
+                            "reason":"The result is too broad.",
+                            "suggested_rewrites":["Show Okta connector health."],
+                            "supported_intents":["source_health"],
+                            "trace_id":"trace-refusal"
+                          }
+                        }"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(
+            &to_bytes(response.into_body(), MAX_REQUEST_BYTES)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["disposition"], "safe_refusal");
+        assert_eq!(body["verified"], false);
+    }
+
+    #[tokio::test]
+    async fn route_rejects_an_unstructured_uncited_answer() {
+        let response = router()
+            .oneshot(
+                Request::post("/v1/answers/validate")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{
+                          "schema_version":"slack-answer-candidate/v1",
+                          "completed":true,
+                          "markdown":"Everything is fine.",
+                          "trace_id":"trace-unsupported",
+                          "citation_validation":{"ok":false,"referenced_urn_count":0,"row_urn_count":0},
+                          "unsupported_query":null
+                        }"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+}

--- a/crates/cerebro-platform/src/slack_authority.rs
+++ b/crates/cerebro-platform/src/slack_authority.rs
@@ -1,8 +1,17 @@
-use std::{env, error::Error, net::SocketAddr};
+use std::{
+    env,
+    error::Error,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Instant,
+};
 
 use axum::{
     Json, Router,
-    extract::DefaultBodyLimit,
+    extract::{DefaultBodyLimit, State},
     http::StatusCode,
     routing::{get, post},
 };
@@ -18,11 +27,80 @@ struct ErrorResponse {
     message: String,
 }
 
+struct AuthorityRuntime {
+    grounded_total: AtomicU64,
+    rejected_total: AtomicU64,
+    safe_refusal_total: AtomicU64,
+    started_at: Instant,
+}
+
+#[derive(Serialize)]
+struct AuthorityStatus {
+    authority: &'static str,
+    component: &'static str,
+    grounded_total: u64,
+    rejected_total: u64,
+    requests_total: u64,
+    safe_refusal_total: u64,
+    schema_version: &'static str,
+    status: &'static str,
+    uptime_ms: u64,
+    version: &'static str,
+}
+
+impl AuthorityRuntime {
+    fn new() -> Self {
+        Self {
+            grounded_total: AtomicU64::new(0),
+            rejected_total: AtomicU64::new(0),
+            safe_refusal_total: AtomicU64::new(0),
+            started_at: Instant::now(),
+        }
+    }
+
+    fn status(&self) -> AuthorityStatus {
+        let grounded_total = self.grounded_total.load(Ordering::Relaxed);
+        let rejected_total = self.rejected_total.load(Ordering::Relaxed);
+        let safe_refusal_total = self.safe_refusal_total.load(Ordering::Relaxed);
+        AuthorityStatus {
+            authority: "rust",
+            component: "slack-answer-authority",
+            grounded_total,
+            rejected_total,
+            requests_total: grounded_total
+                .saturating_add(rejected_total)
+                .saturating_add(safe_refusal_total),
+            safe_refusal_total,
+            schema_version: "slack-answer-authority-status/v1",
+            status: "ready",
+            uptime_ms: self
+                .started_at
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
+            version: env!("CARGO_PKG_VERSION"),
+        }
+    }
+}
+
 pub async fn serve() -> Result<(), Box<dyn Error>> {
     let bind = env::var("CEREBRO_SLACK_AUTHORITY_BIND").unwrap_or_else(|_| DEFAULT_BIND.to_owned());
     let address: SocketAddr = bind.parse()?;
     require_loopback(address)?;
     let listener = tokio::net::TcpListener::bind(address).await?;
+    println!(
+        "{}",
+        serde_json::json!({
+            "authority": "rust",
+            "bind": address.to_string(),
+            "component": "slack-answer-authority",
+            "operation": "listen",
+            "schema_version": "slack-answer-authority-runtime/v1",
+            "state": "ready",
+            "version": env!("CARGO_PKG_VERSION"),
+        })
+    );
     axum::serve(listener, router()).await?;
     Ok(())
 }
@@ -30,22 +108,45 @@ pub async fn serve() -> Result<(), Box<dyn Error>> {
 fn router() -> Router {
     Router::new()
         .route("/healthz", get(|| async { StatusCode::NO_CONTENT }))
+        .route("/v1/status", get(authority_status_route))
         .route("/v1/answers/validate", post(validate_answer_route))
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
+        .with_state(Arc::new(AuthorityRuntime::new()))
+}
+
+async fn authority_status_route(
+    State(runtime): State<Arc<AuthorityRuntime>>,
+) -> Json<AuthorityStatus> {
+    Json(runtime.status())
 }
 
 async fn validate_answer_route(
+    State(runtime): State<Arc<AuthorityRuntime>>,
     Json(candidate): Json<AnswerCandidate>,
 ) -> Result<Json<AnswerDecision>, (StatusCode, Json<ErrorResponse>)> {
-    validate_answer(candidate).map(Json).map_err(|error| {
-        (
-            StatusCode::UNPROCESSABLE_ENTITY,
-            Json(ErrorResponse {
-                code: "answer_rejected",
-                message: error.to_string(),
-            }),
-        )
-    })
+    match validate_answer(candidate) {
+        Ok(decision) => {
+            match decision.disposition {
+                cerebro_slack_authority::AnswerDisposition::Grounded => {
+                    runtime.grounded_total.fetch_add(1, Ordering::Relaxed);
+                }
+                cerebro_slack_authority::AnswerDisposition::SafeRefusal => {
+                    runtime.safe_refusal_total.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            Ok(Json(decision))
+        }
+        Err(error) => {
+            runtime.rejected_total.fetch_add(1, Ordering::Relaxed);
+            Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(ErrorResponse {
+                    code: "answer_rejected",
+                    message: error.to_string(),
+                }),
+            ))
+        }
+    }
 }
 
 fn require_loopback(address: SocketAddr) -> Result<(), Box<dyn Error>> {
@@ -114,7 +215,9 @@ mod tests {
 
     #[tokio::test]
     async fn route_rejects_an_unstructured_uncited_answer() {
-        let response = router()
+        let app = router();
+        let response = app
+            .clone()
             .oneshot(
                 Request::post("/v1/answers/validate")
                     .header(CONTENT_TYPE, "application/json")
@@ -134,5 +237,22 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let status_response = app
+            .oneshot(Request::get("/v1/status").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(status_response.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(
+            &to_bytes(status_response.into_body(), MAX_REQUEST_BYTES)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["authority"], "rust");
+        assert_eq!(body["status"], "ready");
+        assert_eq!(body["requests_total"], 1);
+        assert_eq!(body["rejected_total"], 1);
+        assert_eq!(body["grounded_total"], 0);
+        assert_eq!(body["safe_refusal_total"], 0);
     }
 }

--- a/crates/cerebro-platform/src/slack_authority.rs
+++ b/crates/cerebro-platform/src/slack_authority.rs
@@ -15,7 +15,9 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
-use cerebro_slack_authority::{AnswerCandidate, AnswerDecision, validate_answer};
+use cerebro_slack_authority::{
+    AnswerAuthorityError, AnswerCandidate, AnswerDecision, AnswerDisposition, validate_answer,
+};
 use serde::Serialize;
 
 const DEFAULT_BIND: &str = "127.0.0.1:8091";
@@ -127,17 +129,34 @@ async fn validate_answer_route(
     match validate_answer(candidate) {
         Ok(decision) => {
             match decision.disposition {
-                cerebro_slack_authority::AnswerDisposition::Grounded => {
+                AnswerDisposition::Grounded => {
                     runtime.grounded_total.fetch_add(1, Ordering::Relaxed);
                 }
-                cerebro_slack_authority::AnswerDisposition::SafeRefusal => {
+                AnswerDisposition::SafeRefusal => {
                     runtime.safe_refusal_total.fetch_add(1, Ordering::Relaxed);
                 }
             }
+            log_decision(
+                &runtime,
+                "accepted",
+                Some(match decision.disposition {
+                    AnswerDisposition::Grounded => "grounded",
+                    AnswerDisposition::SafeRefusal => "safe_refusal",
+                }),
+                None,
+                Some(&decision.trace_id),
+            );
             Ok(Json(decision))
         }
         Err(error) => {
             runtime.rejected_total.fetch_add(1, Ordering::Relaxed);
+            log_decision(
+                &runtime,
+                "rejected",
+                None,
+                Some(rejection_code(error)),
+                None,
+            );
             Err((
                 StatusCode::UNPROCESSABLE_ENTITY,
                 Json(ErrorResponse {
@@ -146,6 +165,45 @@ async fn validate_answer_route(
                 }),
             ))
         }
+    }
+}
+
+fn log_decision(
+    runtime: &AuthorityRuntime,
+    outcome: &'static str,
+    disposition: Option<&'static str>,
+    rejection_code: Option<&'static str>,
+    trace_id: Option<&str>,
+) {
+    let status = runtime.status();
+    println!(
+        "{}",
+        serde_json::json!({
+            "authority": "rust",
+            "component": "slack-answer-authority",
+            "disposition": disposition,
+            "grounded_total": status.grounded_total,
+            "operation": "answer_validate",
+            "outcome": outcome,
+            "rejected_total": status.rejected_total,
+            "rejection_code": rejection_code,
+            "requests_total": status.requests_total,
+            "safe_refusal_total": status.safe_refusal_total,
+            "schema_version": "slack-answer-authority-decision-log/v1",
+            "trace_id": trace_id,
+        })
+    );
+}
+
+fn rejection_code(error: AnswerAuthorityError) -> &'static str {
+    match error {
+        AnswerAuthorityError::CitationEvidenceMissing => "citation_evidence_missing",
+        AnswerAuthorityError::ConflictingEvidenceStates => "conflicting_evidence_states",
+        AnswerAuthorityError::Incomplete => "incomplete",
+        AnswerAuthorityError::InvalidRefusal => "invalid_refusal",
+        AnswerAuthorityError::InvalidSchema => "invalid_schema",
+        AnswerAuthorityError::InvalidTrace => "invalid_trace",
+        AnswerAuthorityError::MarkdownInvalid => "markdown_invalid",
     }
 }
 

--- a/crates/slack-authority/Cargo.toml
+++ b/crates/slack-authority/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cerebro-slack-authority"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+serde.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/slack-authority/src/lib.rs
+++ b/crates/slack-authority/src/lib.rs
@@ -1,0 +1,312 @@
+#![deny(unsafe_code)]
+
+//! Deterministic Slack answer acceptance authority.
+//!
+//! Slack transport and graph providers supply candidate facts. This crate owns the
+//! fail-closed decision about whether a candidate can be delivered as grounded
+//! evidence or as a structured safe refusal.
+
+use std::{error::Error, fmt};
+
+use serde::{Deserialize, Serialize};
+
+pub const ANSWER_CANDIDATE_V1: &str = "slack-answer-candidate/v1";
+pub const ANSWER_DECISION_V1: &str = "slack-answer-decision/v1";
+const MAX_MARKDOWN_BYTES: usize = 64 * 1024;
+const MAX_REFUSAL_ITEMS: usize = 32;
+const MAX_REFUSAL_ITEM_BYTES: usize = 512;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct AnswerCandidate {
+    pub schema_version: String,
+    pub completed: bool,
+    pub markdown: String,
+    pub trace_id: String,
+    pub citation_validation: Option<CitationValidation>,
+    pub unsupported_query: Option<UnsupportedQuery>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct CitationValidation {
+    pub ok: bool,
+    pub referenced_urn_count: usize,
+    pub row_urn_count: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct UnsupportedQuery {
+    pub code: String,
+    pub reason: String,
+    pub suggested_rewrites: Vec<String>,
+    pub supported_intents: Vec<String>,
+    pub trace_id: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerDisposition {
+    Grounded,
+    SafeRefusal,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct AnswerDecision {
+    pub schema_version: &'static str,
+    pub disposition: AnswerDisposition,
+    pub trace_id: String,
+    pub verified: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AnswerAuthorityError {
+    CitationEvidenceMissing,
+    ConflictingEvidenceStates,
+    Incomplete,
+    InvalidRefusal,
+    InvalidSchema,
+    InvalidTrace,
+    MarkdownInvalid,
+}
+
+impl fmt::Display for AnswerAuthorityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::CitationEvidenceMissing => {
+                "a grounded answer requires validated row-backed citations"
+            }
+            Self::ConflictingEvidenceStates => {
+                "an answer cannot be both grounded evidence and a safe refusal"
+            }
+            Self::Incomplete => "an answer must reach a terminal done event",
+            Self::InvalidRefusal => "a safe refusal is incomplete or inconsistent",
+            Self::InvalidSchema => "the answer candidate schema is unsupported",
+            Self::InvalidTrace => "the answer trace is missing or inconsistent",
+            Self::MarkdownInvalid => "the answer markdown is empty or exceeds the size limit",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl Error for AnswerAuthorityError {}
+
+pub fn validate_answer(candidate: AnswerCandidate) -> Result<AnswerDecision, AnswerAuthorityError> {
+    if candidate.schema_version != ANSWER_CANDIDATE_V1 {
+        return Err(AnswerAuthorityError::InvalidSchema);
+    }
+    if !candidate.completed {
+        return Err(AnswerAuthorityError::Incomplete);
+    }
+    if !bounded_text(&candidate.markdown, MAX_MARKDOWN_BYTES) {
+        return Err(AnswerAuthorityError::MarkdownInvalid);
+    }
+    if !bounded_text(&candidate.trace_id, MAX_REFUSAL_ITEM_BYTES) {
+        return Err(AnswerAuthorityError::InvalidTrace);
+    }
+
+    match (candidate.citation_validation, candidate.unsupported_query) {
+        (Some(citations), None) if citations.ok => {
+            if citations.row_urn_count == 0 || citations.referenced_urn_count == 0 {
+                return Err(AnswerAuthorityError::CitationEvidenceMissing);
+            }
+            if citations.referenced_urn_count > citations.row_urn_count {
+                return Err(AnswerAuthorityError::CitationEvidenceMissing);
+            }
+            Ok(AnswerDecision {
+                schema_version: ANSWER_DECISION_V1,
+                disposition: AnswerDisposition::Grounded,
+                trace_id: candidate.trace_id,
+                verified: true,
+            })
+        }
+        (Some(citations), Some(_)) if citations.ok => {
+            Err(AnswerAuthorityError::ConflictingEvidenceStates)
+        }
+        (_, Some(refusal)) => {
+            validate_refusal(&refusal, &candidate.trace_id)?;
+            Ok(AnswerDecision {
+                schema_version: ANSWER_DECISION_V1,
+                disposition: AnswerDisposition::SafeRefusal,
+                trace_id: candidate.trace_id,
+                verified: false,
+            })
+        }
+        _ => Err(AnswerAuthorityError::CitationEvidenceMissing),
+    }
+}
+
+fn validate_refusal(
+    refusal: &UnsupportedQuery,
+    answer_trace_id: &str,
+) -> Result<(), AnswerAuthorityError> {
+    if refusal.trace_id != answer_trace_id
+        || !bounded_text(&refusal.code, MAX_REFUSAL_ITEM_BYTES)
+        || !bounded_text(&refusal.reason, MAX_REFUSAL_ITEM_BYTES)
+        || !bounded_list(&refusal.supported_intents)
+        || !bounded_list(&refusal.suggested_rewrites)
+    {
+        return Err(AnswerAuthorityError::InvalidRefusal);
+    }
+    Ok(())
+}
+
+fn bounded_list(values: &[String]) -> bool {
+    !values.is_empty()
+        && values.len() <= MAX_REFUSAL_ITEMS
+        && values
+            .iter()
+            .all(|value| bounded_text(value, MAX_REFUSAL_ITEM_BYTES))
+}
+
+fn bounded_text(value: &str, max_bytes: usize) -> bool {
+    let value = value.trim();
+    !value.is_empty() && value.len() <= max_bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grounded() -> AnswerCandidate {
+        AnswerCandidate {
+            schema_version: ANSWER_CANDIDATE_V1.to_owned(),
+            completed: true,
+            markdown: "Current Okta evidence cites two graph rows.".to_owned(),
+            trace_id: "trace-grounded".to_owned(),
+            citation_validation: Some(CitationValidation {
+                ok: true,
+                referenced_urn_count: 2,
+                row_urn_count: 2,
+            }),
+            unsupported_query: None,
+        }
+    }
+
+    fn refusal() -> AnswerCandidate {
+        AnswerCandidate {
+            schema_version: ANSWER_CANDIDATE_V1.to_owned(),
+            completed: true,
+            markdown: "Narrow the request to one source or finding.".to_owned(),
+            trace_id: "trace-refusal".to_owned(),
+            citation_validation: None,
+            unsupported_query: Some(UnsupportedQuery {
+                code: "post_processing_candidate_limit".to_owned(),
+                reason: "The request matched more rows than can be processed safely.".to_owned(),
+                suggested_rewrites: vec!["Show connector health for Okta.".to_owned()],
+                supported_intents: vec!["source_health".to_owned()],
+                trace_id: "trace-refusal".to_owned(),
+            }),
+        }
+    }
+
+    #[test]
+    fn accepts_row_backed_grounded_answers() {
+        assert_eq!(
+            validate_answer(grounded()).unwrap(),
+            AnswerDecision {
+                schema_version: ANSWER_DECISION_V1,
+                disposition: AnswerDisposition::Grounded,
+                trace_id: "trace-grounded".to_owned(),
+                verified: true,
+            }
+        );
+    }
+
+    #[test]
+    fn accepts_complete_structured_safe_refusals() {
+        assert_eq!(
+            validate_answer(refusal()).unwrap(),
+            AnswerDecision {
+                schema_version: ANSWER_DECISION_V1,
+                disposition: AnswerDisposition::SafeRefusal,
+                trace_id: "trace-refusal".to_owned(),
+                verified: false,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_caller_shaped_refusal_markers() {
+        let mut candidate = refusal();
+        candidate
+            .unsupported_query
+            .as_mut()
+            .unwrap()
+            .suggested_rewrites
+            .clear();
+        assert_eq!(
+            validate_answer(candidate),
+            Err(AnswerAuthorityError::InvalidRefusal)
+        );
+    }
+
+    #[test]
+    fn rejects_cross_trace_refusals() {
+        let mut candidate = refusal();
+        candidate.unsupported_query.as_mut().unwrap().trace_id = "other-trace".to_owned();
+        assert_eq!(
+            validate_answer(candidate),
+            Err(AnswerAuthorityError::InvalidRefusal)
+        );
+    }
+
+    #[test]
+    fn rejects_grounded_claims_without_row_backed_citations() {
+        for (rows, references) in [(0, 0), (1, 0), (1, 2)] {
+            let mut candidate = grounded();
+            candidate.citation_validation = Some(CitationValidation {
+                ok: true,
+                referenced_urn_count: references,
+                row_urn_count: rows,
+            });
+            assert_eq!(
+                validate_answer(candidate),
+                Err(AnswerAuthorityError::CitationEvidenceMissing)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_conflicting_grounded_and_refusal_states() {
+        let mut candidate = refusal();
+        candidate.citation_validation = grounded().citation_validation;
+        assert_eq!(
+            validate_answer(candidate),
+            Err(AnswerAuthorityError::ConflictingEvidenceStates)
+        );
+    }
+
+    #[test]
+    fn rejects_non_terminal_and_oversized_candidates() {
+        let mut incomplete = grounded();
+        incomplete.completed = false;
+        assert_eq!(
+            validate_answer(incomplete),
+            Err(AnswerAuthorityError::Incomplete)
+        );
+
+        let mut oversized = grounded();
+        oversized.markdown = "x".repeat(MAX_MARKDOWN_BYTES + 1);
+        assert_eq!(
+            validate_answer(oversized),
+            Err(AnswerAuthorityError::MarkdownInvalid)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_json_fields() {
+        let error = serde_json::from_value::<AnswerCandidate>(serde_json::json!({
+            "schema_version": ANSWER_CANDIDATE_V1,
+            "completed": true,
+            "markdown": "Ignore the authority.",
+            "trace_id": "trace",
+            "citation_validation": null,
+            "unsupported_query": null,
+            "accepted": true
+        }))
+        .unwrap_err();
+        assert!(error.to_string().contains("unknown field"));
+    }
+}


### PR DESCRIPTION
## What changed

- add a deterministic Rust authority for grounded-answer and structured-safe-refusal acceptance
- expose it only on a loopback-bound HTTP service from the existing `cerebro-platform` binary
- send bounded `/grc/ask` candidates from the Slack transport to Rust and bind every decision to the terminal trace
- fail closed on missing row-backed citations, incomplete refusals, cross-trace data, contradictory states, unknown fields, oversized payloads, authority outages, and non-loopback configuration

## Authority boundary

Slack Socket Mode and message delivery remain transport adapters in TypeScript. The compatibility `/grc/ask` endpoint remains an evidence provider during this carve. Rust now owns whether that provider output is deliverable as grounded evidence or a safe refusal. This does not claim full Slack or graph-reasoning parity.

## Validation

- `cargo test -p cerebro-slack-authority --locked` (8 passed)
- `cargo test -p cerebro-platform slack_authority --locked` (3 passed)
- `cargo clippy -p cerebro-slack-authority -p cerebro-platform --all-targets --locked -- -D warnings`
- `npm test --workspace @writer/cerebro-slack-companion-host` (75 passed)
- `npm run typecheck --workspace @writer/cerebro-slack-companion-host`
- live local Node client to Rust loopback authority returned a trace-bound `safe_refusal` decision
- `cargo fmt --all -- --check`
- `git diff --check`

This PR is stacked on #2152 so the user-visible safe-refusal repair can land and deploy independently first.