### PR TITLE
Retain bounded Slack turn working state

### DIFF
--- a/apps/slack-companion-host/README.md
+++ b/apps/slack-companion-host/README.md
@@ -43,6 +43,13 @@ holds at most 20 notes and 8 KB of text. Credential-shaped values are redacted
 before storage, and saved text is treated as untrusted context: it cannot grant
 tool authority or override current Cerebro evidence.
 
+After each delivered question, the host also updates one expiring working-state
+record for that thread. It keeps up to three recent requests, the last outcome,
+and the last bounded source blocker. This lets a later request such as “give me
+another” retain the operation and subject from the prior turn. The record is
+unverified context, uses the same credential redaction as notes, and does not
+store model reasoning.
+
 Scratchpads use `CEREBRO_SLACK_RUNTIME_MEMORY_DIR` alongside the durable outcome
 store. The deployment must mount that directory on persistent storage if notes
 must survive a task or container replacement.

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -18,6 +18,7 @@ import {
   verifiedTurnScratchpadContent,
   type SlackThreadScratchpadCommandV1,
   type SlackThreadScratchpadPort,
+  type SlackThreadWorkingOutcome,
 } from "@writer/cerebro-slack-companion";
 import {
   AssistantTurnHostAdapter,
@@ -129,6 +130,11 @@ export interface AssistantQuestionResult {
     question: string;
     traceId: string;
   };
+  workingTurn?: {
+    blocker?: string;
+    currentRequest: string;
+    outcome: SlackThreadWorkingOutcome;
+  };
 }
 
 export interface AssistantQuestionServiceOptions {
@@ -209,6 +215,11 @@ export class AssistantQuestionService {
           verified: false,
         }),
         text: renderOutput(output),
+        workingTurn: {
+          blocker: "Request authority or source health did not pass preflight.",
+          currentRequest,
+          outcome: "blocked",
+        },
       };
     }
 
@@ -231,6 +242,10 @@ export class AssistantQuestionService {
           verified: answer.citationValidationPassed,
         }),
         text: boundedSlackText(answer.markdown),
+        workingTurn: {
+          currentRequest,
+          outcome: "completed",
+        },
         ...(answer.citationValidationPassed && answer.traceId
           ? {
               verifiedTurn: {
@@ -263,6 +278,11 @@ export class AssistantQuestionService {
           verified: false,
         }),
         text: renderOutput(output),
+        workingTurn: {
+          blocker: `Graph evidence was ${state.replaceAll("_", " ")}.`,
+          currentRequest,
+          outcome: "blocked",
+        },
       };
     }
   }
@@ -771,6 +791,25 @@ export async function handleSlackMention(input: {
       state: "completed",
       updated_at: deliveredAt,
     });
+    if (input.scratchpads && result.workingTurn) {
+      try {
+        await input.scratchpads.recordWorkingTurn({
+          ...(result.workingTurn.blocker === undefined
+            ? {}
+            : { blocker: result.workingTurn.blocker }),
+          current_request: result.workingTurn.currentRequest,
+          outcome: result.workingTurn.outcome,
+          thread_ref: scratchpadRef,
+        });
+      } catch (error) {
+        process.stderr.write(`${JSON.stringify({
+          component: "slack-scratchpad",
+          error_kind: error instanceof Error ? error.name : "unknown",
+          operation: "record_working_turn",
+          state: "failed",
+        })}\n`);
+      }
+    }
     if (input.scratchpads && result.verifiedTurn) {
       try {
         await input.scratchpads.add({
@@ -1001,7 +1040,7 @@ export function contextualHistory(
   const context = [
     threadContext ? "Earlier messages in the same thread:" : undefined,
     threadContext,
-    scratchpadContext ? "Explicit notes saved in this thread's scratchpad:" : undefined,
+    scratchpadContext ? "Thread scratchpad context:" : undefined,
     scratchpadContext,
   ].filter((value): value is string => Boolean(value)).join("\n\n");
   if (!context) return [];
@@ -1060,19 +1099,32 @@ async function executeScratchpadCommand(
     const cleared = await scratchpads.clear(context.threadRef);
     return cleared === 0
       ? "This thread's scratchpad is already empty."
-      : `Cleared ${cleared} ${cleared === 1 ? "note" : "notes"} from this thread's scratchpad.`;
+      : `Cleared ${cleared} ${cleared === 1 ? "entry" : "entries"} from this thread's scratchpad.`;
   }
   const scratchpad = await scratchpads.read(context.threadRef);
-  if (scratchpad.notes.length === 0) {
+  if (scratchpad.notes.length === 0 && scratchpad.working_state === undefined) {
     return "This thread's scratchpad is empty. Use `@Cerebro remember <note>` to add one.";
   }
   return [
     "*This thread's scratchpad*",
+    ...(scratchpad.working_state === undefined
+      ? []
+      : [
+          "*Working state — unverified context*",
+          `Recent requests:\n${scratchpad.working_state.recent_requests.map((request, index) =>
+            `${index + 1}. ${escapeSlackText(request)}`
+          ).join("\n")}`,
+          `Last outcome: ${scratchpad.working_state.last_outcome}`,
+          ...(scratchpad.working_state.blocker === undefined
+            ? []
+            : [`Last blocker: ${escapeSlackText(scratchpad.working_state.blocker)}`]),
+        ]),
+    ...(scratchpad.notes.length === 0 ? [] : ["*Saved notes*"]),
     ...scratchpad.notes.map((note, index) =>
       `${index + 1}. *${note.source === "cerebro" ? "Cerebro" : "Thread"}:* ${escapeSlackText(note.content)}`
     ),
     "",
-    "Notes expire 7 days after they are saved. Use `@Cerebro clear scratchpad` to remove them now.",
+    "Entries expire after 7 days. Use `@Cerebro clear scratchpad` to remove them now.",
   ].join("\n\n");
 }
 

--- a/apps/slack-companion-host/src/runtime/thread-scratchpad-store.ts
+++ b/apps/slack-companion-host/src/runtime/thread-scratchpad-store.ts
@@ -4,15 +4,20 @@ import { mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promise
 import { dirname, join } from "node:path";
 import {
   normalizeScratchpadContent,
+  recordSlackThreadWorkingTurn,
   SLACK_THREAD_SCRATCHPAD_LIMITS,
   SlackThreadScratchpadError,
   validateSlackThreadScratchpad,
   type AddSlackThreadScratchpadNote,
   type AddSlackThreadScratchpadNoteResult,
+  type RecordSlackThreadWorkingTurn,
   type SlackThreadScratchpadNoteV1,
   type SlackThreadScratchpadPort,
   type SlackThreadScratchpadV1,
+  type SlackThreadWorkingStateV1,
 } from "@writer/cerebro-slack-companion";
+
+const WORKING_STATE_FILE = "working-state.json";
 
 export interface FileThreadScratchpadStoreOptions {
   clock?: () => Date;
@@ -81,6 +86,14 @@ export class FileThreadScratchpadStore implements SlackThreadScratchpadPort {
         source: input.source,
         thread_ref: input.thread_ref,
       });
+      validateSlackThreadScratchpad({
+        notes: [...scratchpad.notes, note],
+        schema_version: "slack-thread-scratchpad/v1",
+        thread_ref: input.thread_ref,
+        ...(scratchpad.working_state === undefined
+          ? {}
+          : { working_state: scratchpad.working_state }),
+      }, createdAt);
       await this.atomicWrite(this.notePath(input.thread_ref, note.note_id), note);
       return { created: true, note, redacted };
     });
@@ -90,7 +103,37 @@ export class FileThreadScratchpadStore implements SlackThreadScratchpadPort {
     return this.serialize(async () => {
       const scratchpad = await this.read(threadRef);
       await rm(this.threadDirectory(threadRef), { force: true, recursive: true });
-      return scratchpad.notes.length;
+      return scratchpad.notes.length + (scratchpad.working_state === undefined ? 0 : 1);
+    });
+  }
+
+  async recordWorkingTurn(
+    input: RecordSlackThreadWorkingTurn,
+  ): Promise<SlackThreadWorkingStateV1> {
+    return this.serialize(async () => {
+      const scratchpad = await this.read(input.thread_ref);
+      const now = this.clock();
+      const state = recordSlackThreadWorkingTurn(
+        scratchpad.working_state,
+        {
+          ...(input.blocker === undefined ? {} : { blocker: input.blocker }),
+          currentRequest: input.current_request,
+          now,
+          outcome: input.outcome,
+          threadRef: input.thread_ref,
+        },
+      );
+      validateSlackThreadScratchpad({
+        notes: scratchpad.notes,
+        schema_version: "slack-thread-scratchpad/v1",
+        thread_ref: input.thread_ref,
+        working_state: state,
+      }, now);
+      await this.atomicWrite(
+        join(this.threadDirectory(input.thread_ref), WORKING_STATE_FILE),
+        state,
+      );
+      return state;
     });
   }
 
@@ -98,7 +141,9 @@ export class FileThreadScratchpadStore implements SlackThreadScratchpadPort {
     const directory = this.threadDirectory(threadRef);
     let files: string[];
     try {
-      files = (await readdir(directory)).filter((file) => file.endsWith(".json"));
+      files = (await readdir(directory)).filter((file) =>
+        file.endsWith(".json") && file !== WORKING_STATE_FILE
+      );
     } catch (error) {
       if (errorCode(error) === "ENOENT") return emptyScratchpad(threadRef);
       throw error;
@@ -119,11 +164,25 @@ export class FileThreadScratchpadStore implements SlackThreadScratchpadPort {
       }
       notes.push(candidate.notes[0]!);
     }
-    return validateSlackThreadScratchpad({
+    const workingStatePath = join(directory, WORKING_STATE_FILE);
+    let workingState: SlackThreadWorkingStateV1 | undefined;
+    try {
+      workingState = JSON.parse(
+        await readFile(workingStatePath, "utf8"),
+      ) as SlackThreadWorkingStateV1;
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+    }
+    const scratchpad = validateSlackThreadScratchpad({
       notes,
       schema_version: "slack-thread-scratchpad/v1",
       thread_ref: threadRef,
+      ...(workingState === undefined ? {} : { working_state: workingState }),
     }, now);
+    if (workingState !== undefined && scratchpad.working_state === undefined) {
+      await rm(workingStatePath, { force: true });
+    }
+    return scratchpad;
   }
 
   private async atomicWrite(path: string, value: unknown): Promise<void> {

--- a/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
+++ b/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
@@ -82,6 +82,53 @@ test("file scratchpad redacts credential-shaped content before persistence", asy
   }
 });
 
+test("file scratchpad updates one working state without replacing saved notes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "cerebro-slack-scratchpad-"));
+  try {
+    let now = new Date("2026-07-29T10:00:00.000Z");
+    const store = new FileThreadScratchpadStore(root, { clock: () => now });
+    const threadRef = slackThreadScratchpadRef(
+      "T-ONE",
+      "C-ONE",
+      "1710000000.000001",
+    );
+    await store.add({
+      author_ref: slackScratchpadAuthorRef("T-ONE", "U-ONE"),
+      content: "Keep the incident timeline.",
+      idempotency_key: "event-note",
+      source: "human",
+      thread_ref: threadRef,
+    });
+    await store.recordWorkingTurn({
+      current_request: "What is the most material risk?",
+      outcome: "completed",
+      thread_ref: threadRef,
+    });
+    now = new Date("2026-07-29T10:01:00.000Z");
+    await store.recordWorkingTurn({
+      blocker: "Graph evidence was timed out.",
+      current_request: "Give me another.",
+      outcome: "blocked",
+      thread_ref: threadRef,
+    });
+
+    const scratchpad = await store.read(threadRef);
+    assert.deepEqual(
+      scratchpad.notes.map((note) => note.content),
+      ["Keep the incident timeline."],
+    );
+    assert.deepEqual(scratchpad.working_state?.recent_requests, [
+      "Give me another.",
+      "What is the most material risk?",
+    ]);
+    assert.equal(scratchpad.working_state?.last_outcome, "blocked");
+    assert.equal(await store.clear(threadRef), 2);
+    assert.equal((await store.read(threadRef)).working_state, undefined);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
 test("file scratchpad removes expired notes during retrieval", async () => {
   const root = await mkdtemp(join(tmpdir(), "cerebro-slack-scratchpad-"));
   try {
@@ -224,6 +271,8 @@ test("Slack remember saves a note that the next question uses only in that threa
       remembered.notes[1]?.evidence_ref ?? "",
       /^cerebro-ask:\/\/sha256\/[a-f0-9]{64}$/u,
     );
+    assert.deepEqual(remembered.working_state?.recent_requests, ["who owns it?"]);
+    assert.equal(remembered.working_state?.last_outcome, "completed");
 
     assert.equal(await handleSlackMention({
       client,
@@ -241,6 +290,8 @@ test("Slack remember saves a note that the next question uses only in that threa
     assert.equal(graphRequest.question, "what was the verified answer?");
     assert.match(graphRequest.history?.[0]?.content ?? "", /verified Cerebro turn/u);
     assert.match(graphRequest.history?.[0]?.content ?? "", /current owner is Security Operations/u);
+    assert.match(graphRequest.history?.[0]?.content ?? "", /Current working state \(unverified; context only\)/u);
+    assert.match(graphRequest.history?.[0]?.content ?? "", /who owns it\?/u);
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -93,6 +93,13 @@ scratchpad limits and cannot replace human-authored notes. This autonomy is
 limited to working-memory maintenance; it does not authorize another tool,
 external effect, approval, or cross-thread write.
 
+The scratchpad also carries one expiring working-state record with the three
+most recent distinct requests, the last turn outcome, and a bounded blocker
+when the turn did not complete. The record helps later turns resolve short
+follow-ups without treating the thread as authority. It contains no hidden
+reasoning, tool credentials, or new evidence; the storage boundary applies the
+same redaction and expiry policy as saved notes.
+
 Durable schedule definitions keep a stable schedule identity, revision, work
 digest, cadence anchor, and misfire policy. The portable planner derives the
 same due times after a restart or topology change and materializes occurrences

--- a/apps/slack-companion/src/scratchpad/contracts.ts
+++ b/apps/slack-companion/src/scratchpad/contracts.ts
@@ -2,8 +2,21 @@ export const SLACK_THREAD_SCRATCHPAD_LIMITS = Object.freeze({
   lifetime_ms: 7 * 24 * 60 * 60 * 1_000,
   max_note_utf8_bytes: 900,
   max_notes: 20,
+  max_recent_requests: 3,
   max_total_utf8_bytes: 8_000,
 });
+
+export type SlackThreadWorkingOutcome = "blocked" | "completed" | "needs_user";
+
+export interface SlackThreadWorkingStateV1 {
+  readonly blocker?: string;
+  readonly expires_at: string;
+  readonly last_outcome: SlackThreadWorkingOutcome;
+  readonly recent_requests: readonly string[];
+  readonly schema_version: "slack-thread-working-state/v1";
+  readonly thread_ref: string;
+  readonly updated_at: string;
+}
 
 export interface SlackThreadScratchpadNoteV1 {
   readonly author_ref: string;
@@ -21,6 +34,7 @@ export interface SlackThreadScratchpadV1 {
   readonly notes: readonly SlackThreadScratchpadNoteV1[];
   readonly schema_version: "slack-thread-scratchpad/v1";
   readonly thread_ref: string;
+  readonly working_state?: SlackThreadWorkingStateV1;
 }
 
 export interface AddSlackThreadScratchpadNote {
@@ -38,9 +52,17 @@ export interface AddSlackThreadScratchpadNoteResult {
   readonly redacted: boolean;
 }
 
+export interface RecordSlackThreadWorkingTurn {
+  readonly blocker?: string;
+  readonly current_request: string;
+  readonly outcome: SlackThreadWorkingOutcome;
+  readonly thread_ref: string;
+}
+
 export interface SlackThreadScratchpadPort {
   add(input: AddSlackThreadScratchpadNote): Promise<AddSlackThreadScratchpadNoteResult>;
   clear(threadRef: string): Promise<number>;
+  recordWorkingTurn(input: RecordSlackThreadWorkingTurn): Promise<SlackThreadWorkingStateV1>;
   read(threadRef: string): Promise<SlackThreadScratchpadV1>;
 }
 

--- a/apps/slack-companion/src/scratchpad/policy.ts
+++ b/apps/slack-companion/src/scratchpad/policy.ts
@@ -5,6 +5,8 @@ import {
   SlackThreadScratchpadError,
   type SlackThreadScratchpadNoteV1,
   type SlackThreadScratchpadV1,
+  type SlackThreadWorkingStateV1,
+  type SlackThreadWorkingOutcome,
 } from "./contracts.js";
 import { redactSecurityText } from "../security/redaction.js";
 
@@ -126,9 +128,23 @@ export function validateSlackThreadScratchpad(
       left.created_at.localeCompare(right.created_at)
       || left.note_id.localeCompare(right.note_id)
     );
+  const workingState = scratchpad.working_state === undefined
+    ? undefined
+    : validateSlackThreadWorkingState(
+        scratchpad.working_state,
+        scratchpad.thread_ref,
+        now,
+      );
   const totalBytes = notes.reduce(
     (total, note) => total + Buffer.byteLength(note.content, "utf8"),
     0,
+  ) + (workingState?.recent_requests ?? []).reduce(
+    (total, request) => total + Buffer.byteLength(request, "utf8"),
+    0,
+  ) + (
+    workingState?.blocker === undefined
+      ? 0
+      : Buffer.byteLength(workingState.blocker, "utf8")
   );
   if (totalBytes > SLACK_THREAD_SCRATCHPAD_LIMITS.max_total_utf8_bytes) {
     throw new SlackThreadScratchpadError("The thread scratchpad exceeds its storage limit.");
@@ -137,18 +153,69 @@ export function validateSlackThreadScratchpad(
     notes: Object.freeze(notes),
     schema_version: "slack-thread-scratchpad/v1",
     thread_ref: scratchpad.thread_ref,
+    ...(workingState === undefined ? {} : { working_state: workingState }),
   });
 }
 
 export function formatSlackThreadScratchpadContext(
   scratchpad: SlackThreadScratchpadV1,
 ): string | undefined {
-  if (scratchpad.notes.length === 0) return undefined;
-  return scratchpad.notes
+  const workingState = scratchpad.working_state === undefined
+    ? []
+    : [
+        "Current working state (unverified; context only):",
+        ...scratchpad.working_state.recent_requests.map((request, index) =>
+          `${index + 1}. ${request}`
+        ),
+        `Last outcome: ${scratchpad.working_state.last_outcome}.`,
+        ...(scratchpad.working_state.blocker === undefined
+          ? []
+          : [`Last blocker: ${scratchpad.working_state.blocker}.`]),
+      ];
+  const notes = scratchpad.notes
     .map((note, index) =>
       `${index + 1}. [${note.source === "cerebro" ? "verified Cerebro turn" : "thread note"}] ${note.content}`
-    )
-    .join("\n");
+    );
+  if (workingState.length === 0 && notes.length === 0) return undefined;
+  return [
+    ...workingState,
+    ...(workingState.length > 0 && notes.length > 0 ? ["Saved notes:"] : []),
+    ...notes,
+  ].join("\n");
+}
+
+export function recordSlackThreadWorkingTurn(
+  prior: SlackThreadWorkingStateV1 | undefined,
+  input: {
+    blocker?: string;
+    currentRequest: string;
+    now: Date;
+    outcome: SlackThreadWorkingOutcome;
+    threadRef: string;
+  },
+): SlackThreadWorkingStateV1 {
+  const validPrior = prior === undefined
+    ? undefined
+    : validateSlackThreadWorkingState(prior, input.threadRef, input.now);
+  const currentRequest = normalizeScratchpadContent(input.currentRequest);
+  const blocker = input.blocker === undefined
+    ? undefined
+    : normalizeScratchpadContent(input.blocker);
+  const recentRequests = [
+    currentRequest,
+    ...(validPrior?.recent_requests ?? []).filter((request) => request !== currentRequest),
+  ].slice(0, SLACK_THREAD_SCRATCHPAD_LIMITS.max_recent_requests);
+  return Object.freeze({
+    ...(blocker === undefined ? {} : { blocker }),
+    expires_at: new Date(
+      input.now.getTime() + SLACK_THREAD_SCRATCHPAD_LIMITS.lifetime_ms,
+    ).toISOString(),
+    last_outcome: input.outcome,
+    recent_requests: Object.freeze(recentRequests),
+    schema_version: "slack-thread-working-state/v1",
+    thread_ref: input.threadRef,
+    updated_at: input.now.toISOString(),
+  });
 }
 
 export function verifiedTurnScratchpadContent(
@@ -187,6 +254,42 @@ function validateNote(note: SlackThreadScratchpadNoteV1, threadRef: string): voi
   ) {
     throw new SlackThreadScratchpadError("The thread scratchpad note is invalid.");
   }
+}
+
+function validateSlackThreadWorkingState(
+  state: SlackThreadWorkingStateV1,
+  threadRef: string,
+  now: Date,
+): SlackThreadWorkingStateV1 | undefined {
+  if (
+    state.schema_version !== "slack-thread-working-state/v1"
+    || state.thread_ref !== threadRef
+    || !Array.isArray(state.recent_requests)
+    || state.recent_requests.length === 0
+    || state.recent_requests.length > SLACK_THREAD_SCRATCHPAD_LIMITS.max_recent_requests
+    || !workingOutcome(state.last_outcome)
+    || state.recent_requests.some((request) =>
+      normalizeScratchpadContent(request) !== request
+    )
+    || (
+      state.blocker !== undefined
+      && normalizeScratchpadContent(state.blocker) !== state.blocker
+    )
+    || !canonicalTimestamp(state.updated_at)
+    || !canonicalTimestamp(state.expires_at)
+    || Date.parse(state.expires_at) <= Date.parse(state.updated_at)
+  ) {
+    throw new SlackThreadScratchpadError("The thread working state is invalid.");
+  }
+  if (Date.parse(state.expires_at) <= now.getTime()) return undefined;
+  return Object.freeze({
+    ...state,
+    recent_requests: Object.freeze([...state.recent_requests]),
+  });
+}
+
+function workingOutcome(value: string): value is SlackThreadWorkingOutcome {
+  return value === "blocked" || value === "completed" || value === "needs_user";
 }
 
 function compactText(value: string): string {

--- a/apps/slack-companion/test/scratchpad-policy.test.ts
+++ b/apps/slack-companion/test/scratchpad-policy.test.ts
@@ -5,6 +5,7 @@ import {
   formatSlackThreadScratchpadContext,
   normalizeScratchpadContent,
   parseSlackThreadScratchpadCommand,
+  recordSlackThreadWorkingTurn,
   slackScratchpadAuthorRef,
   slackThreadScratchpadRef,
   validateSlackThreadScratchpad,
@@ -87,4 +88,69 @@ test("verified turns become bounded autonomous working memory", () => {
   assert.match(content, /^Question: Who owns the checkout finding\? Verified answer:/u);
   assert.ok(Buffer.byteLength(content, "utf8") <= 900);
   assert.match(content, /\.\.\.$/u);
+});
+
+test("working state preserves recent requests and the last bounded outcome", () => {
+  const threadRef = "slack-scratchpad://sha256/thread";
+  const first = recordSlackThreadWorkingTurn(undefined, {
+    currentRequest: "What is the most material risk this week?",
+    now: new Date("2026-07-29T10:00:00.000Z"),
+    outcome: "completed",
+    threadRef,
+  });
+  const second = recordSlackThreadWorkingTurn(first, {
+    blocker: "Graph evidence was timed out.",
+    currentRequest: "Give me another.",
+    now: new Date("2026-07-29T10:01:00.000Z"),
+    outcome: "blocked",
+    threadRef,
+  });
+
+  assert.deepEqual(second.recent_requests, [
+    "Give me another.",
+    "What is the most material risk this week?",
+  ]);
+  assert.equal(second.last_outcome, "blocked");
+  assert.equal(second.blocker, "Graph evidence was timed out.");
+  assert.match(
+    formatSlackThreadScratchpadContext({
+      notes: [],
+      schema_version: "slack-thread-scratchpad/v1",
+      thread_ref: threadRef,
+      working_state: second,
+    }) ?? "",
+    /Current working state \(unverified; context only\):[\s\S]*Give me another\.[\s\S]*most material risk[\s\S]*Last outcome: blocked\.[\s\S]*Last blocker: Graph evidence was timed out\./u,
+  );
+});
+
+test("working state redacts secrets and retains only three distinct requests", () => {
+  const threadRef = "slack-scratchpad://sha256/thread";
+  let state = recordSlackThreadWorkingTurn(undefined, {
+    currentRequest: "first request",
+    now: new Date("2026-07-29T10:00:00.000Z"),
+    outcome: "completed",
+    threadRef,
+  });
+  for (const [index, request] of ["second request", "third request", "fourth request"].entries()) {
+    state = recordSlackThreadWorkingTurn(state, {
+      currentRequest: request,
+      now: new Date(`2026-07-29T10:0${index + 1}:00.000Z`),
+      outcome: "completed",
+      threadRef,
+    });
+  }
+  const credential = ["xoxb", "fixture", "value"].join("-");
+  state = recordSlackThreadWorkingTurn(state, {
+    currentRequest: `inspect token=${credential}`,
+    now: new Date("2026-07-29T10:04:00.000Z"),
+    outcome: "needs_user",
+    threadRef,
+  });
+
+  assert.deepEqual(state.recent_requests, [
+    "inspect token=[redacted_secret]",
+    "fourth request",
+    "third request",
+  ]);
+  assert.doesNotMatch(JSON.stringify(state), new RegExp(credential, "u"));
 });


### PR DESCRIPTION
## What changed

- Add one expiring per-thread working-state record containing up to three recent requests, the last turn outcome, and a bounded blocker.
- Feed that record into later questions as redacted, unverified context so short follow-ups retain the prior operation and subject.
- Keep citation-validated answers separate from working state and expose both through the existing scratchpad commands.
- Add coverage for bounded retention, secret redaction, expiry, clearing, saved-note isolation, and runtime context reuse.

## Why

Short follow-ups can lose their intended operation after a blocked source check or when older thread messages leave the bounded context window. The runtime now keeps enough explicit state to continue coherently without storing model reasoning or granting new authority.

## Validation

- `npm run check --workspace @writer/cerebro-slack-companion`
- `npm run check --workspace @writer/cerebro-slack-companion-host`
- `npm run check:workspaces` with the Node test runtime's local-storage backing enabled
- `git diff --check`
