### PR TITLE
Measure Slack working-state hillclimb

### DIFF
--- a/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
+++ b/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
@@ -161,6 +161,100 @@ test("file scratchpad removes expired notes during retrieval", async () => {
   }
 });
 
+test("blocked Slack turns are visible through the runtime scratchpad command path", async () => {
+  const root = await mkdtemp(join(tmpdir(), "cerebro-slack-scratchpad-"));
+  try {
+    let postSequence = 0;
+    const delivered: string[] = [];
+    const outcomes = new FileOutcomeStore(root, { log: () => undefined });
+    const scratchpads = new FileThreadScratchpadStore(root);
+    const host = createAssistantTurnHost(outcomes);
+    const questions = new AssistantQuestionService(
+      host,
+      new CerebroAskClient({
+        apiKey: "bound-at-runtime",
+        baseUrl: "https://cerebro.example.com",
+        fetchImpl: async () => new Response("unavailable", { status: 503 }),
+        tenantId: "writer",
+      }),
+      { timeoutSignal: () => new AbortController().signal },
+    );
+    const client = {
+      chat: {
+        postMessage: async (input: { text: string }) => {
+          delivered.push(input.text);
+          postSequence += 1;
+          return { ts: `1710000000.00000${postSequence}` };
+        },
+        update: async (input: { text: string }) => {
+          delivered.push(input.text);
+        },
+      },
+      conversations: {
+        replies: async () => ({ messages: [] }),
+      },
+    };
+    const config = loadSlackRuntimeConfig({
+      CEREBRO_BASE_URL: "https://cerebro.example.com",
+      CEREBRO_READ_API_KEY: "bound-at-runtime",
+      CEREBRO_SLACK_APP_NAME: "Cerebro Development",
+      CEREBRO_SLACK_ENVIRONMENT_LABEL: "development",
+      CEREBRO_SLACK_PRODUCTION: "false",
+      CEREBRO_TENANT_ID: "writer",
+      SLACK_ALLOWED_TEAM_IDS: "T-ONE",
+      SLACK_APP_TOKEN: "bound-at-runtime",
+      SLACK_BOT_TOKEN: "bound-at-runtime",
+    });
+    const baseEvent = {
+      channel: "C-ONE",
+      teamId: "T-ONE",
+      threadTs: "1710000000.000001",
+      userId: "U-ONE",
+    };
+
+    assert.equal(await handleSlackMention({
+      client,
+      config,
+      event: {
+        ...baseEvent,
+        eventTs: "1710000000.000001",
+        hasThreadContext: false,
+        text: "<@BOT> identify the top current security risk",
+      },
+      host,
+      outcomes,
+      questions,
+      scratchpads,
+    }), true);
+    assert.match(delivered.at(-1) ?? "", /current graph evidence \(unavailable\)/u);
+
+    assert.equal(await handleSlackMention({
+      client,
+      config,
+      event: {
+        ...baseEvent,
+        eventTs: "1710000000.000002",
+        hasThreadContext: true,
+        text: "<@BOT> scratchpad",
+      },
+      host,
+      outcomes,
+      questions,
+      scratchpads,
+    }), true);
+    const renderedScratchpad = delivered.at(-1) ?? "";
+    assert.match(renderedScratchpad, /Working state — unverified context/u);
+    assert.match(
+      renderedScratchpad,
+      /identify the top current security risk/u,
+    );
+    assert.match(renderedScratchpad, /Last outcome: blocked/u);
+    assert.match(renderedScratchpad, /Last blocker: Graph evidence was unavailable\./u);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
 test("Slack remember saves a note that the next question uses only in that thread", async () => {
   const root = await mkdtemp(join(tmpdir(), "cerebro-slack-scratchpad-"));
   try {

--- a/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
+++ b/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
@@ -185,6 +185,7 @@ test("blocked Slack turns are visible through the runtime scratchpad command pat
     const questions = new AssistantQuestionService(
       host,
       new CerebroAskClient({
+        answerAuthority: testAnswerAuthority,
         apiKey: "bound-at-runtime",
         baseUrl: "https://cerebro.example.com",
         fetchImpl: async () => new Response("unavailable", { status: 503 }),

--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -100,6 +100,26 @@ follow-ups without treating the thread as authority. It contains no hidden
 reasoning, tool credentials, or new evidence; the storage boundary applies the
 same redaction and expiry policy as saved notes.
 
+### Working-state hillclimb
+
+`npm run eval:hillclimb` replays the prior no-state policy and the working-state
+candidate against the same public-safe corpus. The corpus has separate held-out
+and shadow partitions and includes continuation, repeated retry, expiry, and
+bounded-eviction cases. The command prints a machine-readable receipt and exits
+non-zero unless the candidate:
+
+- recalls every required governing request, outcome, and blocker;
+- reduces the measured restatement-risk proxy to zero with at least a 0.50
+  recall gain over baseline;
+- keeps working state explicitly unverified;
+- introduces no case regression or context-size violation; and
+- builds context within a 5 ms p95 budget.
+
+The corpus measures whether the reasoning boundary receives the state needed to
+resolve a follow-up. It does not claim that a language-model answer is correct.
+Delivered-answer quality remains gated by the independent assistant-turn
+evaluation and outcome receipts described above.
+
 Durable schedule definitions keep a stable schedule identity, revision, work
 digest, cadence anchor, and misfire policy. The portable planner derives the
 same due times after a restart or topology change and materializes occurrences

--- a/apps/slack-companion/package.json
+++ b/apps/slack-companion/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "npm run typecheck && npm test",
+    "eval:hillclimb": "npm run build --silent && node dist/src/scratchpad/run-hillclimb.js",
     "test": "npm run build && node --test dist/test/*.test.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -114,6 +114,8 @@ export * from "./risk-attestation/policy.js";
 export * from "./security/redaction.js";
 export * from "./safety/policy.js";
 export * from "./scratchpad/contracts.js";
+export * from "./scratchpad/hillclimb.js";
+export * from "./scratchpad/hillclimb-corpus.js";
 export * from "./scratchpad/policy.js";
 export * from "./thread-binding.js";
 export * from "./tools/catalog.js";

--- a/apps/slack-companion/src/scratchpad/hillclimb-corpus.ts
+++ b/apps/slack-companion/src/scratchpad/hillclimb-corpus.ts
@@ -1,0 +1,291 @@
+import type { SlackWorkingStateEvalCaseV1 } from "./hillclimb.js";
+
+function continuationCase(
+  caseRef: string,
+  partition: "held_out" | "shadow",
+  rootRequest: string,
+  currentRequest: string,
+  requiredFragment: string,
+  blocker: string,
+): SlackWorkingStateEvalCaseV1 {
+  return Object.freeze({
+    case_ref: caseRef,
+    current_request: currentRequest,
+    forbidden_context: Object.freeze([]),
+    partition,
+    prior_turns: Object.freeze([Object.freeze({
+      blocker,
+      outcome: "blocked" as const,
+      request: rootRequest,
+    })]),
+    required_context: Object.freeze([
+      requiredFragment,
+      "Last outcome: blocked.",
+      `Last blocker: ${blocker}.`,
+    ]),
+    schema_version: "slack-working-state-eval-case/v1" as const,
+  });
+}
+
+/**
+ * Public-safe abstractions of observed continuation failures. Held-out cases
+ * preserve the failure shape without workspace names, people, ids, or data.
+ * Shadow cases use separately written tasks and wording.
+ */
+export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEvalCaseV1[] =
+  Object.freeze([
+    continuationCase(
+      "case://held-out/ranked-projects",
+      "held_out",
+      "Rank three remediation projects using current evidence.",
+      "Keep going.",
+      "Rank three remediation projects",
+      "The evidence query timed out",
+    ),
+    continuationCase(
+      "case://held-out/next-risk",
+      "held_out",
+      "Identify the most material risk and support it with current evidence.",
+      "Give me another.",
+      "Identify the most material risk",
+      "The source check did not finish",
+    ),
+    continuationCase(
+      "case://held-out/control-summary",
+      "held_out",
+      "Summarize the control gaps for this service.",
+      "Continue until completion.",
+      "Summarize the control gaps",
+      "The graph request exceeded its budget",
+    ),
+    continuationCase(
+      "case://held-out/plan-comparison",
+      "held_out",
+      "Compare the two proposed response plans.",
+      "Proceed.",
+      "Compare the two proposed response plans",
+      "One evidence source was unavailable",
+    ),
+    continuationCase(
+      "case://held-out/source-health",
+      "held_out",
+      "Report connector health for Source A.",
+      "Try again.",
+      "Report connector health for Source A",
+      "The connector status request timed out",
+    ),
+    continuationCase(
+      "case://held-out/finding-owners",
+      "held_out",
+      "List the owners of the open priority findings.",
+      "Finish the request.",
+      "List the owners of the open priority findings",
+      "The owner lookup was interrupted",
+    ),
+    continuationCase(
+      "case://held-out/evidence-ranking",
+      "held_out",
+      "Rank the response options by verified impact.",
+      "Resume.",
+      "Rank the response options by verified impact",
+      "The impact query did not complete",
+    ),
+    Object.freeze({
+      case_ref: "case://held-out/repeated-continuation",
+      current_request: "Keep working.",
+      forbidden_context: Object.freeze([]),
+      partition: "held_out",
+      prior_turns: Object.freeze([
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Build a prioritized remediation sequence.",
+        }),
+        Object.freeze({
+          blocker: "The first attempt timed out",
+          outcome: "blocked" as const,
+          request: "Keep going.",
+        }),
+        Object.freeze({
+          blocker: "The second attempt timed out",
+          outcome: "blocked" as const,
+          request: "Continue until completion.",
+        }),
+      ]),
+      required_context: Object.freeze([
+        "Build a prioritized remediation sequence.",
+        "Last outcome: blocked.",
+        "Last blocker: The second attempt timed out.",
+      ]),
+      schema_version: "slack-working-state-eval-case/v1",
+    }),
+    Object.freeze({
+      case_ref: "case://held-out/expired-state",
+      current_request: "Start a separate assessment.",
+      forbidden_context: Object.freeze(["Assess the retired service."]),
+      partition: "held_out",
+      prior_turns: Object.freeze([Object.freeze({
+        outcome: "completed" as const,
+        request: "Assess the retired service.",
+      })]),
+      read_after_ms: 8 * 24 * 60 * 60 * 1_000,
+      required_context: Object.freeze([]),
+      schema_version: "slack-working-state-eval-case/v1",
+    }),
+    Object.freeze({
+      case_ref: "case://held-out/bounded-eviction",
+      current_request: "Continue the latest task.",
+      forbidden_context: Object.freeze(["Review obsolete task zero."]),
+      partition: "held_out",
+      prior_turns: Object.freeze([
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Review obsolete task zero.",
+        }),
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Review active task one.",
+        }),
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Review active task two.",
+        }),
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Review active task three.",
+        }),
+      ]),
+      required_context: Object.freeze([
+        "Review active task one.",
+        "Review active task two.",
+        "Review active task three.",
+      ]),
+      schema_version: "slack-working-state-eval-case/v1",
+    }),
+    continuationCase(
+      "case://shadow/ranked-actions",
+      "shadow",
+      "Return four containment actions ordered by expected risk reduction.",
+      "Carry on.",
+      "Return four containment actions",
+      "The risk calculation stopped early",
+    ),
+    continuationCase(
+      "case://shadow/next-exposure",
+      "shadow",
+      "Find the largest current exposure and cite its supporting records.",
+      "Show the next one.",
+      "Find the largest current exposure",
+      "The record search was incomplete",
+    ),
+    continuationCase(
+      "case://shadow/policy-gaps",
+      "shadow",
+      "Explain the unresolved policy gaps for this workload.",
+      "Complete that.",
+      "Explain the unresolved policy gaps",
+      "The policy evidence fetch timed out",
+    ),
+    continuationCase(
+      "case://shadow/option-review",
+      "shadow",
+      "Review the available mitigation options against the stated constraints.",
+      "Go ahead.",
+      "Review the available mitigation options",
+      "A required source was temporarily unavailable",
+    ),
+    continuationCase(
+      "case://shadow/collector-status",
+      "shadow",
+      "Check collection health for Feed B.",
+      "Retry it.",
+      "Check collection health for Feed B",
+      "The collection status call exceeded its deadline",
+    ),
+    continuationCase(
+      "case://shadow/accountability",
+      "shadow",
+      "Map each unresolved action to its accountable role.",
+      "Continue the work.",
+      "Map each unresolved action",
+      "The accountability query did not finish",
+    ),
+    continuationCase(
+      "case://shadow/impact-order",
+      "shadow",
+      "Order the proposed fixes by measured impact.",
+      "Pick this back up.",
+      "Order the proposed fixes by measured impact",
+      "The measurement lookup was interrupted",
+    ),
+    Object.freeze({
+      case_ref: "case://shadow/repeated-retry",
+      current_request: "Take the next step.",
+      forbidden_context: Object.freeze([]),
+      partition: "shadow",
+      prior_turns: Object.freeze([
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Produce an evidence-backed recovery plan.",
+        }),
+        Object.freeze({
+          blocker: "The initial source check timed out",
+          outcome: "blocked" as const,
+          request: "Continue.",
+        }),
+        Object.freeze({
+          blocker: "The retry also timed out",
+          outcome: "blocked" as const,
+          request: "Keep going until done.",
+        }),
+      ]),
+      required_context: Object.freeze([
+        "Produce an evidence-backed recovery plan.",
+        "Last outcome: blocked.",
+        "Last blocker: The retry also timed out.",
+      ]),
+      schema_version: "slack-working-state-eval-case/v1",
+    }),
+    Object.freeze({
+      case_ref: "case://shadow/expired-state",
+      current_request: "Begin a new independent review.",
+      forbidden_context: Object.freeze(["Inspect the decommissioned collector."]),
+      partition: "shadow",
+      prior_turns: Object.freeze([Object.freeze({
+        outcome: "completed" as const,
+        request: "Inspect the decommissioned collector.",
+      })]),
+      read_after_ms: 8 * 24 * 60 * 60 * 1_000,
+      required_context: Object.freeze([]),
+      schema_version: "slack-working-state-eval-case/v1",
+    }),
+    Object.freeze({
+      case_ref: "case://shadow/bounded-eviction",
+      current_request: "Resume the current sequence.",
+      forbidden_context: Object.freeze(["Trace superseded sequence zero."]),
+      partition: "shadow",
+      prior_turns: Object.freeze([
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Trace superseded sequence zero.",
+        }),
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Trace current sequence one.",
+        }),
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Trace current sequence two.",
+        }),
+        Object.freeze({
+          outcome: "completed" as const,
+          request: "Trace current sequence three.",
+        }),
+      ]),
+      required_context: Object.freeze([
+        "Trace current sequence one.",
+        "Trace current sequence two.",
+        "Trace current sequence three.",
+      ]),
+      schema_version: "slack-working-state-eval-case/v1",
+    }),
+  ]);

--- a/apps/slack-companion/src/scratchpad/hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hillclimb.ts
@@ -1,0 +1,364 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import type {
+  SlackThreadWorkingOutcome,
+  SlackThreadWorkingStateV1,
+} from "./contracts.js";
+import {
+  formatSlackThreadScratchpadContext,
+  recordSlackThreadWorkingTurn,
+  validateSlackThreadScratchpad,
+} from "./policy.js";
+
+export type SlackWorkingStateEvalPartition = "held_out" | "shadow";
+export type SlackWorkingStatePolicy = "baseline" | "candidate";
+
+export interface SlackWorkingStateEvalTurn {
+  readonly blocker?: string;
+  readonly outcome: SlackThreadWorkingOutcome;
+  readonly request: string;
+}
+
+export interface SlackWorkingStateEvalCaseV1 {
+  readonly case_ref: string;
+  readonly current_request: string;
+  readonly forbidden_context: readonly string[];
+  readonly partition: SlackWorkingStateEvalPartition;
+  readonly prior_turns: readonly SlackWorkingStateEvalTurn[];
+  readonly read_after_ms?: number;
+  readonly required_context: readonly string[];
+  readonly schema_version: "slack-working-state-eval-case/v1";
+}
+
+export interface SlackWorkingStateEvalResultV1 {
+  readonly blockers: readonly string[];
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly context_build_ms: number;
+  readonly context_utf8_bytes: number;
+  readonly passed: boolean;
+  readonly partition: SlackWorkingStateEvalPartition;
+  readonly policy_ref: string;
+  readonly recalled_required_count: number;
+  readonly required_context_count: number;
+  readonly schema_version: "slack-working-state-eval-result/v1";
+}
+
+export interface SlackWorkingStateEvalSummaryV1 {
+  readonly authority_boundary_rate: number;
+  readonly byte_limit_violation_count: number;
+  readonly case_count: number;
+  readonly case_pass_rate: number;
+  readonly context_recall_rate: number;
+  readonly held_out_case_count: number;
+  readonly p95_context_build_ms: number;
+  readonly policy_ref: string;
+  readonly restatement_risk_rate: number;
+  readonly shadow_case_count: number;
+}
+
+export interface SlackWorkingStateHillclimbReceiptV1 {
+  readonly baseline: SlackWorkingStateEvalSummaryV1;
+  readonly candidate: SlackWorkingStateEvalSummaryV1;
+  readonly corpus_digest: string;
+  readonly evaluated_at: string;
+  readonly goal: {
+    readonly candidate_context_recall_rate: number;
+    readonly maximum_candidate_p95_context_build_ms: number;
+    readonly maximum_candidate_restatement_risk_rate: number;
+    readonly minimum_context_recall_gain: number;
+    readonly required_authority_boundary_rate: number;
+  };
+  readonly promotion: {
+    readonly blockers: readonly string[];
+    readonly context_recall_gain: number;
+    readonly promotion_ready: boolean;
+    readonly regression_count: number;
+  };
+  readonly results: {
+    readonly baseline: readonly SlackWorkingStateEvalResultV1[];
+    readonly candidate: readonly SlackWorkingStateEvalResultV1[];
+  };
+  readonly schema_version: "slack-working-state-hillclimb-receipt/v1";
+}
+
+const THREAD_REF = "slack-scratchpad://sha256/eval-thread";
+const BASELINE_POLICY_REF = "policy://slack-working-state/baseline-no-automatic-state";
+const CANDIDATE_POLICY_REF = "policy://slack-working-state/candidate-expiring-state-v1";
+const MAXIMUM_CONTEXT_BYTES = 8_000;
+const MINIMUM_PARTITION_CASES = 8;
+const MINIMUM_RECALL_GAIN = 0.5;
+const REQUIRED_CANDIDATE_RECALL = 1;
+const MAXIMUM_RESTATEMENT_RISK = 0;
+const MAXIMUM_P95_BUILD_MS = 5;
+
+export function runSlackWorkingStateHillclimb(
+  cases: readonly SlackWorkingStateEvalCaseV1[],
+  evaluatedAt = new Date(),
+): SlackWorkingStateHillclimbReceiptV1 {
+  validateCorpus(cases);
+  const baselineResults = cases.map((evalCase) =>
+    evaluateSlackWorkingStateCase(evalCase, "baseline")
+  );
+  const candidateResults = cases.map((evalCase) =>
+    evaluateSlackWorkingStateCase(evalCase, "candidate")
+  );
+  const baseline = summarize(baselineResults);
+  const candidate = summarize(candidateResults);
+  const regressionCount = baselineResults.reduce((count, baselineResult, index) =>
+    count + (
+      baselineResult.passed && !candidateResults[index]!.passed
+        ? 1
+        : 0
+    ), 0);
+  const contextRecallGain = round(
+    candidate.context_recall_rate - baseline.context_recall_rate,
+  );
+  const blockers = [
+    contextRecallGain < MINIMUM_RECALL_GAIN ? "context_recall_gain_below_goal" : undefined,
+    candidate.context_recall_rate < REQUIRED_CANDIDATE_RECALL
+      ? "candidate_context_recall_below_goal"
+      : undefined,
+    candidate.restatement_risk_rate > MAXIMUM_RESTATEMENT_RISK
+      ? "candidate_restatement_risk_above_goal"
+      : undefined,
+    candidate.authority_boundary_rate < 1
+      ? "candidate_authority_boundary_regressed"
+      : undefined,
+    candidate.byte_limit_violation_count > 0
+      ? "candidate_context_byte_limit_exceeded"
+      : undefined,
+    candidate.p95_context_build_ms > MAXIMUM_P95_BUILD_MS
+      ? "candidate_context_build_latency_exceeded"
+      : undefined,
+    regressionCount > 0 ? "case_regression_present" : undefined,
+  ].filter((value): value is string => value !== undefined);
+
+  return Object.freeze({
+    baseline,
+    candidate,
+    corpus_digest: digest(cases),
+    evaluated_at: evaluatedAt.toISOString(),
+    goal: Object.freeze({
+      candidate_context_recall_rate: REQUIRED_CANDIDATE_RECALL,
+      maximum_candidate_p95_context_build_ms: MAXIMUM_P95_BUILD_MS,
+      maximum_candidate_restatement_risk_rate: MAXIMUM_RESTATEMENT_RISK,
+      minimum_context_recall_gain: MINIMUM_RECALL_GAIN,
+      required_authority_boundary_rate: 1,
+    }),
+    promotion: Object.freeze({
+      blockers: Object.freeze(blockers),
+      context_recall_gain: contextRecallGain,
+      promotion_ready: blockers.length === 0,
+      regression_count: regressionCount,
+    }),
+    results: Object.freeze({
+      baseline: Object.freeze(baselineResults),
+      candidate: Object.freeze(candidateResults),
+    }),
+    schema_version: "slack-working-state-hillclimb-receipt/v1",
+  });
+}
+
+export function evaluateSlackWorkingStateCase(
+  evalCase: SlackWorkingStateEvalCaseV1,
+  policy: SlackWorkingStatePolicy,
+): SlackWorkingStateEvalResultV1 {
+  validateCase(evalCase);
+  const startedAt = performance.now();
+  const context = policy === "candidate"
+    ? candidateContext(evalCase.prior_turns, evalCase.read_after_ms ?? 0)
+    : undefined;
+  const contextBuildMs = performance.now() - startedAt;
+  const rendered = context ?? "";
+  const recalledRequiredCount = evalCase.required_context.filter((fragment) =>
+    rendered.includes(fragment)
+  ).length;
+  const forbiddenMatches = evalCase.forbidden_context.filter((fragment) =>
+    rendered.includes(fragment)
+  );
+  const authorityBoundaryPresent = context === undefined
+    || rendered.includes("Current working state (unverified; context only):");
+  const contextBytes = Buffer.byteLength(rendered, "utf8");
+  const blockers = [
+    recalledRequiredCount < evalCase.required_context.length
+      ? "required_context_missing"
+      : undefined,
+    forbiddenMatches.length > 0 ? "forbidden_context_retained" : undefined,
+    !authorityBoundaryPresent ? "authority_boundary_missing" : undefined,
+    contextBytes > MAXIMUM_CONTEXT_BYTES ? "context_byte_limit_exceeded" : undefined,
+  ].filter((value): value is string => value !== undefined);
+  return Object.freeze({
+    blockers: Object.freeze(blockers),
+    case_digest: digest(evalCase),
+    case_ref: evalCase.case_ref,
+    context_build_ms: roundMilliseconds(contextBuildMs),
+    context_utf8_bytes: contextBytes,
+    passed: blockers.length === 0,
+    partition: evalCase.partition,
+    policy_ref: policy === "candidate" ? CANDIDATE_POLICY_REF : BASELINE_POLICY_REF,
+    recalled_required_count: recalledRequiredCount,
+    required_context_count: evalCase.required_context.length,
+    schema_version: "slack-working-state-eval-result/v1",
+  });
+}
+
+function candidateContext(
+  turns: readonly SlackWorkingStateEvalTurn[],
+  readAfterMs: number,
+): string | undefined {
+  let state: SlackThreadWorkingStateV1 | undefined;
+  for (const [index, turn] of turns.entries()) {
+    state = recordSlackThreadWorkingTurn(state, {
+      ...(turn.blocker === undefined ? {} : { blocker: turn.blocker }),
+      currentRequest: turn.request,
+      now: new Date(Date.UTC(2026, 6, 1, 0, index, 0)),
+      outcome: turn.outcome,
+      threadRef: THREAD_REF,
+    });
+  }
+  const lastTurnAt = Date.UTC(2026, 6, 1, 0, turns.length - 1, 0);
+  const scratchpad = validateSlackThreadScratchpad({
+    notes: [],
+    schema_version: "slack-thread-scratchpad/v1",
+    thread_ref: THREAD_REF,
+    ...(state === undefined ? {} : { working_state: state }),
+  }, new Date(lastTurnAt + readAfterMs));
+  return formatSlackThreadScratchpadContext(scratchpad);
+}
+
+function summarize(
+  results: readonly SlackWorkingStateEvalResultV1[],
+): SlackWorkingStateEvalSummaryV1 {
+  const requiredCount = sum(results.map((result) => result.required_context_count));
+  const recalledCount = sum(results.map((result) => result.recalled_required_count));
+  const recallRate = ratio(recalledCount, requiredCount);
+  const authorityBoundaryPasses = results.filter((result) =>
+    !result.blockers.includes("authority_boundary_missing")
+  ).length;
+  const sortedLatencies = results
+    .map((result) => result.context_build_ms)
+    .sort((left, right) => left - right);
+  return Object.freeze({
+    authority_boundary_rate: ratio(authorityBoundaryPasses, results.length),
+    byte_limit_violation_count: results.filter((result) =>
+      result.blockers.includes("context_byte_limit_exceeded")
+    ).length,
+    case_count: results.length,
+    case_pass_rate: ratio(
+      results.filter((result) => result.passed).length,
+      results.length,
+    ),
+    context_recall_rate: recallRate,
+    held_out_case_count: results.filter((result) =>
+      result.partition === "held_out"
+    ).length,
+    p95_context_build_ms: percentile(sortedLatencies, 0.95),
+    policy_ref: results[0]!.policy_ref,
+    restatement_risk_rate: round(1 - recallRate),
+    shadow_case_count: results.filter((result) =>
+      result.partition === "shadow"
+    ).length,
+  });
+}
+
+function validateCorpus(cases: readonly SlackWorkingStateEvalCaseV1[]): void {
+  if (cases.length === 0) throw new Error("The hillclimb corpus is empty.");
+  const refs = new Set<string>();
+  const digests = new Set<string>();
+  let heldOut = 0;
+  let shadow = 0;
+  for (const evalCase of cases) {
+    validateCase(evalCase);
+    const caseDigest = digest(evalCase);
+    if (refs.has(evalCase.case_ref) || digests.has(caseDigest)) {
+      throw new Error("Hillclimb cases must have distinct identities and content.");
+    }
+    refs.add(evalCase.case_ref);
+    digests.add(caseDigest);
+    if (evalCase.partition === "held_out") heldOut += 1;
+    else shadow += 1;
+  }
+  if (heldOut < MINIMUM_PARTITION_CASES || shadow < MINIMUM_PARTITION_CASES) {
+    throw new Error(
+      `Hillclimb promotion needs at least ${MINIMUM_PARTITION_CASES} held-out and shadow cases.`,
+    );
+  }
+}
+
+function validateCase(evalCase: SlackWorkingStateEvalCaseV1): void {
+  if (
+    evalCase.schema_version !== "slack-working-state-eval-case/v1"
+    || !/^case:\/\/[a-z0-9][a-z0-9._/-]*$/u.test(evalCase.case_ref)
+    || (evalCase.partition !== "held_out" && evalCase.partition !== "shadow")
+    || evalCase.prior_turns.length === 0
+    || evalCase.prior_turns.length > 4
+    || !evalCase.current_request.trim()
+    || (
+      evalCase.read_after_ms !== undefined
+      && (
+        !Number.isSafeInteger(evalCase.read_after_ms)
+        || evalCase.read_after_ms < 0
+        || evalCase.read_after_ms > 30 * 24 * 60 * 60 * 1_000
+      )
+    )
+  ) {
+    throw new Error("The hillclimb case is invalid.");
+  }
+  for (const value of [
+    evalCase.current_request,
+    ...evalCase.required_context,
+    ...evalCase.forbidden_context,
+    ...evalCase.prior_turns.flatMap((turn) => [
+      turn.request,
+      ...(turn.blocker === undefined ? [] : [turn.blocker]),
+    ]),
+  ]) {
+    if (!value.trim() || Buffer.byteLength(value, "utf8") > 900) {
+      throw new Error("Hillclimb case text is empty or unbounded.");
+    }
+  }
+}
+
+function digest(value: unknown): string {
+  return `sha256:${createHash("sha256")
+    .update(canonicalStringify(value), "utf8")
+    .digest("hex")}`;
+}
+
+function canonicalStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalStringify(item)).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${canonicalStringify(
+        (value as Record<string, unknown>)[key],
+      )}`
+    ).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function ratio(numerator: number, denominator: number): number {
+  return denominator === 0 ? 1 : round(numerator / denominator);
+}
+
+function percentile(values: readonly number[], percentileValue: number): number {
+  if (values.length === 0) return 0;
+  const index = Math.max(0, Math.ceil(percentileValue * values.length) - 1);
+  return values[index]!;
+}
+
+function sum(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function round(value: number): number {
+  return Math.round(value * 10_000) / 10_000;
+}
+
+function roundMilliseconds(value: number): number {
+  return Math.round(value * 1_000) / 1_000;
+}

--- a/apps/slack-companion/src/scratchpad/run-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/run-hillclimb.ts
@@ -1,0 +1,10 @@
+import {
+  SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
+} from "./hillclimb-corpus.js";
+import { runSlackWorkingStateHillclimb } from "./hillclimb.js";
+
+const receipt = runSlackWorkingStateHillclimb(
+  SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
+);
+process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+if (!receipt.promotion.promotion_ready) process.exitCode = 1;

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  evaluateSlackWorkingStateCase,
+  runSlackWorkingStateHillclimb,
+  SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
+} from "../src/index.js";
+
+test("working-state candidate clears the sealed hillclimb goal", () => {
+  const receipt = runSlackWorkingStateHillclimb(
+    SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
+    new Date("2026-07-29T12:00:00.000Z"),
+  );
+
+  assert.equal(receipt.baseline.context_recall_rate, 0);
+  assert.equal(receipt.baseline.restatement_risk_rate, 1);
+  assert.equal(receipt.candidate.context_recall_rate, 1);
+  assert.equal(receipt.candidate.restatement_risk_rate, 0);
+  assert.equal(receipt.candidate.authority_boundary_rate, 1);
+  assert.equal(receipt.candidate.byte_limit_violation_count, 0);
+  assert.equal(receipt.promotion.context_recall_gain, 1);
+  assert.equal(receipt.promotion.regression_count, 0);
+  assert.deepEqual(receipt.promotion.blockers, []);
+  assert.equal(receipt.promotion.promotion_ready, true);
+  assert.equal(receipt.baseline.held_out_case_count, 10);
+  assert.equal(receipt.baseline.shadow_case_count, 10);
+});
+
+test("hillclimb rejects a corpus without independently partitioned coverage", () => {
+  assert.throws(
+    () => runSlackWorkingStateHillclimb(
+      SLACK_WORKING_STATE_HILLCLIMB_CORPUS.filter((evalCase) =>
+        evalCase.partition === "held_out"
+      ),
+    ),
+    /at least 8 held-out and shadow cases/u,
+  );
+});
+
+test("baseline and candidate are evaluated against one exact case digest", () => {
+  const evalCase = SLACK_WORKING_STATE_HILLCLIMB_CORPUS[0]!;
+  const baseline = evaluateSlackWorkingStateCase(evalCase, "baseline");
+  const candidate = evaluateSlackWorkingStateCase(evalCase, "candidate");
+
+  assert.equal(baseline.case_digest, candidate.case_digest);
+  assert.equal(baseline.case_ref, candidate.case_ref);
+  assert.notEqual(baseline.policy_ref, candidate.policy_ref);
+  assert.deepEqual(baseline.blockers, ["required_context_missing"]);
+  assert.deepEqual(candidate.blockers, []);
+});


### PR DESCRIPTION
## What changed

- Add an executable baseline-versus-candidate evaluation for Slack thread working state.
- Replay one exact public-safe corpus with 10 held-out and 10 separately worded shadow cases.
- Cover continuation, repeated retry, expiry, bounded eviction, and the runtime mention-to-scratchpad command path.
- Emit a machine-readable goal and promotion receipt, and fail the command when any gate is missed.

## Goal and measured result

Promotion requires 100% candidate context recall, 0% restatement risk, at least 50 percentage points of recall gain, 100% authority-boundary compliance, no byte-limit violations or case regressions, and context construction below 5 ms p95.

- Baseline case pass rate: 10%
- Candidate case pass rate: 100%
- Baseline required-context recall: 0%
- Candidate required-context recall: 100%
- Restatement-risk proxy: 100% to 0%
- Candidate context construction: 0.321 ms p95 against a 5 ms ceiling
- Candidate regressions: 0
- Promotion blockers: 0

The receipt measures whether the reasoning boundary receives the governing request, last outcome, and blocker. It does not claim that a model-generated answer is correct; delivered outcomes remain subject to the existing independent assistant-turn evaluation.

## Validation

- `npm run eval:hillclimb`
- `npm run check --workspace @writer/cerebro-slack-companion`
- `npm run check --workspace @writer/cerebro-slack-companion-host`
- Slack companion: 507/507 tests passed
- Slack companion host: 77/77 tests passed, including a blocked turn replayed through the runtime mention, Rust answer-authority binding, and scratchpad command handlers
- Steady-state sec-dev Slack canary retained the originating request and terminal outcome in the thread scratchpad
- `git diff --check`
