### PR TITLE
Stage Rust organizational graph authority and replay

### DIFF
--- a/.github/workflows/rust-graph-replacement.yml
+++ b/.github/workflows/rust-graph-replacement.yml
@@ -115,6 +115,11 @@ jobs:
             -e CEREBRO_NEO4J_PASSWORD=local-password \
             -e 'CEREBRO_POSTGRES_DSN=postgres://cerebro:cerebro@cerebro-rust-graph-postgres:5432/cerebro?sslmode=disable' \
             -e CEREBRO_JETSTREAM_URL=nats://cerebro-rust-graph-nats:4222 \
+            -e CEREBRO_ORGANIZATIONAL_CONSUMER_MODE=forward \
+            -e CEREBRO_ORGANIZATIONAL_CONSUMER_NAME=organizational-graph-v1 \
+            -e CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID=forward-organizational-graph-v1 \
+            -e CEREBRO_ORGANIZATIONAL_CONSUMER_DELIVER_POLICY=by_start_sequence \
+            -e CEREBRO_ORGANIZATIONAL_CONSUMER_START_SEQUENCE=1 \
             -e CEREBRO_RUST_BIND=0.0.0.0:8080 \
             -e CEREBRO_REPOSITORY_ROOT=/app \
             -e CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET="${GRAPH_SECRET}" \

--- a/cmd/cerebro/finding_rule_graph_evaluate.go
+++ b/cmd/cerebro/finding_rule_graph_evaluate.go
@@ -73,7 +73,7 @@ func runFindingRuleGraphEvaluate(args []string) error {
 		findingEvaluationRunStore(deps.StateStore),
 		findingEvidenceStore(deps.StateStore),
 		claimStore(deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(findingGraphQueryStore(deps.GraphStore)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog)
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(dependencyGraphQueryStore(deps)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog)
 	evaluation, err := service.EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
 		RuntimeID: options.RuntimeID,
 		RuleIDs:   []string{options.RuleID},

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -899,6 +899,21 @@ func sourceProjector(stateStore ports.StateStore, graphStore ports.GraphStore) p
 	return sourceprojection.New(state, graph)
 }
 
+func compatibilityGraphQueryStore(store ports.GraphStore) ports.GraphQueryStore {
+	queryStore, ok := store.(ports.GraphQueryStore)
+	if !ok {
+		return nil
+	}
+	return queryStore
+}
+
+func dependencyGraphQueryStore(deps bootstrap.Dependencies) ports.GraphQueryStore {
+	if deps.GraphQueries != nil {
+		return deps.GraphQueries
+	}
+	return compatibilityGraphQueryStore(deps.GraphStore)
+}
+
 func appendLogSourceProjector(deps bootstrap.Dependencies) ports.SourceProjector {
 	legacy := sourceProjector(deps.StateStore, deps.GraphStore)
 	if deps.OrganizationalProjector == nil {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -418,6 +418,20 @@ func TestPrepareGRCReadModelsSkipsStoresWithoutPreparer(t *testing.T) {
 	}
 }
 
+func TestDependencyGraphQueryStorePrefersConfiguredAuthority(t *testing.T) {
+	legacy := &graphTestStore{}
+	authority := &graphTestStore{}
+	deps := bootstrap.Dependencies{GraphStore: legacy, GraphQueries: authority}
+
+	if got := dependencyGraphQueryStore(deps); got != authority {
+		t.Fatalf("dependencyGraphQueryStore() = %#v, want configured authority", got)
+	}
+	deps.GraphQueries = nil
+	if got := dependencyGraphQueryStore(deps); got != legacy {
+		t.Fatalf("dependencyGraphQueryStore() fallback = %#v, want compatibility store", got)
+	}
+}
+
 func TestPrepareGRCReadModelsCallsPreparer(t *testing.T) {
 	store := &preparingStateStore{}
 	if err := prepareGRCReadModels(context.Background(), store); err != nil {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -392,7 +392,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		findingEvaluationRunStore(deps.StateStore),
 		findingEvidenceStore(deps.StateStore),
 		claimStore(deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(findingGraphQueryStore(deps.GraphStore)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout)).WithRuntimeIndexReplayPreparer(cfg.AppendLog.JetStreamRuntimeIndexEnabled, deps.AppendLog, deps.StateStore)
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(dependencyGraphQueryStore(deps)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout)).WithRuntimeIndexReplayPreparer(cfg.AppendLog.JetStreamRuntimeIndexEnabled, deps.AppendLog, deps.StateStore)
 	graphService := graphingest.New(
 		registry,
 		lister,
@@ -1586,11 +1586,6 @@ func findingEvidenceStore(store ports.StateStore) ports.FindingEvidenceStore {
 
 func claimStore(store ports.StateStore) ports.ClaimStore {
 	typed, _ := store.(ports.ClaimStore)
-	return typed
-}
-
-func findingGraphQueryStore(store ports.GraphStore) ports.GraphQueryStore {
-	typed, _ := store.(ports.GraphQueryStore)
 	return typed
 }
 

--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -1,11 +1,20 @@
-use std::{env, error::Error, io, sync::Arc, time::Duration};
+use std::{
+    env,
+    error::Error,
+    io,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 
 use async_nats::jetstream::{
     AckKind,
     consumer::{AckPolicy, DeliverPolicy, pull},
 };
+use cerebro_organizational_store::{ConsumerMessageOutcome, ConsumerRunProgress, PostgresLedger};
 use cerebro_source_runtime_next::CommittedSourceEvent;
 use futures_util::StreamExt;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use crate::{ProjectionAuthority, ProjectionRuntime};
 
@@ -14,6 +23,15 @@ const DEFAULT_SUBJECT_PREFIX: &str = "events";
 const DEFAULT_CONSUMER: &str = "organizational-graph-v1";
 const ACK_WAIT: Duration = Duration::from_secs(120);
 const RETRY_DELAY: Duration = Duration::from_secs(30);
+const DEFAULT_REPLAY_MAX_MESSAGES: u64 = 100_000;
+const DEFAULT_REPLAY_MAX_RUNTIME_SECONDS: u64 = 3_600;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ConsumerMode {
+    Forward,
+    Replay,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum FailureDisposition {
@@ -28,10 +46,24 @@ struct ConsumerConfig {
     subject_prefix: String,
     durable_name: String,
     deliver_policy: DeliverPolicy,
+    mode: ConsumerMode,
+    run_id: String,
+    end_sequence_override: Option<u64>,
+    max_messages: Option<u64>,
+    max_runtime: Option<Duration>,
 }
 
 impl ConsumerConfig {
     fn from_env() -> Result<Self, Box<dyn Error>> {
+        let mode = match optional("CEREBRO_ORGANIZATIONAL_CONSUMER_MODE", "forward").as_str() {
+            "forward" => ConsumerMode::Forward,
+            "replay" => ConsumerMode::Replay,
+            _ => {
+                return Err(
+                    "CEREBRO_ORGANIZATIONAL_CONSUMER_MODE must be forward or replay".into(),
+                );
+            }
+        };
         let deliver_policy = match optional("CEREBRO_ORGANIZATIONAL_CONSUMER_DELIVER_POLICY", "new")
             .as_str()
         {
@@ -48,13 +80,45 @@ impl ConsumerConfig {
             }
         };
         let durable_name = optional("CEREBRO_ORGANIZATIONAL_CONSUMER_NAME", DEFAULT_CONSUMER);
-        validate_delivery_identity(deliver_policy, &durable_name)?;
+        let run_id = match mode {
+            ConsumerMode::Forward => optional(
+                "CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID",
+                "forward-organizational-graph-v1",
+            ),
+            ConsumerMode::Replay => required("CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID")?,
+        };
+        let end_sequence_override =
+            optional_positive_u64("CEREBRO_ORGANIZATIONAL_CONSUMER_END_SEQUENCE")?;
+        if mode == ConsumerMode::Forward && end_sequence_override.is_some() {
+            return Err("CEREBRO_ORGANIZATIONAL_CONSUMER_END_SEQUENCE is replay-only".into());
+        }
+        validate_delivery_identity(mode, deliver_policy, &durable_name, &run_id)?;
         Ok(Self {
             nats_url: required("CEREBRO_JETSTREAM_URL")?,
             stream: optional("CEREBRO_JETSTREAM_STREAM_NAME", DEFAULT_STREAM),
             subject_prefix: optional("CEREBRO_JETSTREAM_SUBJECT_PREFIX", DEFAULT_SUBJECT_PREFIX),
             durable_name,
             deliver_policy,
+            mode,
+            run_id,
+            end_sequence_override,
+            max_messages: (mode == ConsumerMode::Replay)
+                .then(|| {
+                    optional_u64(
+                        "CEREBRO_ORGANIZATIONAL_CONSUMER_MAX_MESSAGES",
+                        DEFAULT_REPLAY_MAX_MESSAGES,
+                    )
+                })
+                .transpose()?,
+            max_runtime: (mode == ConsumerMode::Replay)
+                .then(|| {
+                    optional_u64(
+                        "CEREBRO_ORGANIZATIONAL_CONSUMER_MAX_RUNTIME_SECONDS",
+                        DEFAULT_REPLAY_MAX_RUNTIME_SECONDS,
+                    )
+                    .map(Duration::from_secs)
+                })
+                .transpose()?,
         })
     }
 
@@ -82,12 +146,36 @@ impl ConsumerConfig {
 }
 
 fn validate_delivery_identity(
+    mode: ConsumerMode,
     deliver_policy: DeliverPolicy,
     durable_name: &str,
+    run_id: &str,
 ) -> Result<(), Box<dyn Error>> {
-    if deliver_policy != DeliverPolicy::New && durable_name == DEFAULT_CONSUMER {
+    validate_identity("consumer name", durable_name)?;
+    validate_identity("consumer run id", run_id)?;
+    if mode == ConsumerMode::Replay && deliver_policy == DeliverPolicy::New {
+        return Err("replay mode requires all or by_start_sequence delivery".into());
+    }
+    if mode == ConsumerMode::Replay && durable_name == DEFAULT_CONSUMER {
         return Err(
             "replay delivery requires an explicit CEREBRO_ORGANIZATIONAL_CONSUMER_NAME".into(),
+        );
+    }
+    if mode == ConsumerMode::Forward && deliver_policy == DeliverPolicy::All {
+        return Err("forward mode does not permit all-history delivery".into());
+    }
+    Ok(())
+}
+
+fn validate_identity(label: &str, value: &str) -> Result<(), Box<dyn Error>> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(
+            format!("{label} must contain 1-128 letters, digits, hyphens, or underscores").into(),
         );
     }
     Ok(())
@@ -97,25 +185,185 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
     let config = ConsumerConfig::from_env()?;
     let client = async_nats::connect(&config.nats_url).await?;
     let jetstream = async_nats::jetstream::new(client);
-    let stream = jetstream.get_stream(&config.stream).await?;
+    let mut stream = jetstream.get_stream(&config.stream).await?;
+    let stream_state = stream.info().await?.state.clone();
+    let proposed_start_sequence = match config.deliver_policy {
+        DeliverPolicy::New => stream_state.last_sequence.saturating_add(1),
+        DeliverPolicy::All => stream_state.first_sequence,
+        DeliverPolicy::ByStartSequence { start_sequence } => start_sequence,
+        _ => return Err("organizational consumer delivery policy is unsupported".into()),
+    };
+    let proposed_end_sequence = (config.mode == ConsumerMode::Replay).then_some(
+        config
+            .end_sequence_override
+            .unwrap_or(stream_state.last_sequence),
+    );
+    if proposed_start_sequence == 0
+        || (config.mode == ConsumerMode::Replay
+            && proposed_start_sequence < stream_state.first_sequence)
+        || proposed_end_sequence.is_some_and(|end| end < proposed_start_sequence)
+        || proposed_end_sequence.is_some_and(|end| end > stream_state.last_sequence)
+    {
+        return Err("organizational replay fence does not contain retained messages".into());
+    }
+    let stored_fence = runtime
+        .authority
+        .start_consumer_run(
+            &config.durable_name,
+            &config.run_id,
+            mode_name(config.mode),
+            proposed_start_sequence,
+            proposed_end_sequence,
+        )
+        .await?;
+    let start_sequence = stored_fence.start_sequence;
+    let end_sequence = stored_fence.end_sequence;
+    let mut counters = ConsumerCounters::default();
+    let persisted = load_counters(&runtime, &config).await?;
+    let next_unprocessed =
+        next_unprocessed_sequence(start_sequence, persisted.last_delivered_sequence);
+    if retention_gap(stream_state.first_sequence, next_unprocessed, end_sequence) {
+        runtime
+            .authority
+            .finish_consumer_run(&config.durable_name, &config.run_id, "failed", None)
+            .await?;
+        return Err(format!(
+            "retention advanced to sequence {} before replay could resume at {}",
+            stream_state.first_sequence, next_unprocessed
+        )
+        .into());
+    }
+    emit_receipt(
+        "started",
+        &config,
+        start_sequence,
+        end_sequence,
+        persisted.covered_sequence,
+        &persisted,
+        None,
+    )?;
     let expected = config.pull_config();
     let consumer = stream
         .get_or_create_consumer(&config.durable_name, expected.clone())
         .await?;
     let actual = consumer.get_info().await?;
     validate_server_config(&actual.config, &expected)?;
+    let retained_after_consumer_create = stream.info().await?.state.first_sequence;
+    if retention_gap(
+        retained_after_consumer_create,
+        next_unprocessed,
+        end_sequence,
+    ) {
+        runtime
+            .authority
+            .finish_consumer_run(&config.durable_name, &config.run_id, "failed", None)
+            .await?;
+        return Err(format!(
+            "retention advanced to sequence {retained_after_consumer_create} before replay consumer creation completed at {next_unprocessed}"
+        )
+        .into());
+    }
     println!(
-        "organizational append-log consumer ready stream={} consumer={} filter={}",
+        "organizational append-log consumer ready stream={} consumer={} run_id={} filter={}",
         config.stream,
         config.durable_name,
+        config.run_id,
         config.filter_subject()
     );
     let mut messages = consumer.messages().await?;
-    while let Some(next) = messages.next().await {
+    let started = Instant::now();
+    let shutdown = shutdown_signal();
+    tokio::pin!(shutdown);
+    loop {
+        if config
+            .max_messages
+            .is_some_and(|limit| counters.messages_seen >= limit)
+            || config
+                .max_runtime
+                .is_some_and(|limit| started.elapsed() >= limit)
+        {
+            runtime
+                .authority
+                .finish_consumer_run(&config.durable_name, &config.run_id, "stopped", None)
+                .await?;
+            let persisted = load_counters(&runtime, &config).await?;
+            emit_receipt(
+                "stopped",
+                &config,
+                start_sequence,
+                end_sequence,
+                persisted.covered_sequence,
+                &persisted,
+                None,
+            )?;
+            return Ok(());
+        }
+        let next = tokio::select! {
+            next = messages.next() => next,
+            () = &mut shutdown => {
+                runtime
+                    .authority
+                    .finish_consumer_run(&config.durable_name, &config.run_id, "stopped", None)
+                    .await?;
+                let persisted = load_counters(&runtime, &config).await?;
+                emit_receipt(
+                    "stopped",
+                    &config,
+                    start_sequence,
+                    end_sequence,
+                    persisted.covered_sequence,
+                    &persisted,
+                    None,
+                )?;
+                return Ok(());
+            }
+        };
+        let Some(next) = next else {
+            runtime
+                .authority
+                .finish_consumer_run(&config.durable_name, &config.run_id, "failed", None)
+                .await?;
+            return Err("organizational append-log consumer stopped receiving messages".into());
+        };
         let message = next?;
+        let info = message.info().map_err(consumer_io)?;
+        let stream_sequence = info.stream_sequence;
+        let pending = info.pending;
+        if end_sequence.is_some_and(|end| stream_sequence > end) {
+            return finish_replay(
+                &runtime,
+                &config,
+                start_sequence,
+                end_sequence.expect("replay has an end fence"),
+                &counters,
+            )
+            .await;
+        }
         let subject = message.message.subject.to_string();
-        let Some(subject_source) = source_from_subject(&subject, &config.subject_prefix) else {
+        let Some((subject_source, subject_family)) =
+            source_family_from_subject(&subject, &config.subject_prefix)
+        else {
+            record_progress(
+                &runtime,
+                &config,
+                stream_sequence,
+                ConsumerMessageOutcome::Skipped,
+                None,
+                None,
+                &mut counters,
+            )
+            .await?;
             message.double_ack().await.map_err(consumer_io)?;
+            if replay_drained(&config, end_sequence, stream_sequence, pending) {
+                return finish_replay(
+                    &runtime,
+                    &config,
+                    start_sequence,
+                    end_sequence.expect("replay has an end fence"),
+                    &counters,
+                )
+                .await;
+            }
             continue;
         };
         let event = match decode_event(
@@ -127,17 +375,74 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
         ) {
             Ok(Some(event)) => event,
             Ok(None) => {
+                record_progress(
+                    &runtime,
+                    &config,
+                    stream_sequence,
+                    ConsumerMessageOutcome::Skipped,
+                    Some((subject_source, subject_family)),
+                    None,
+                    &mut counters,
+                )
+                .await?;
                 message.double_ack().await.map_err(consumer_io)?;
+                if replay_drained(&config, end_sequence, stream_sequence, pending) {
+                    return finish_replay(
+                        &runtime,
+                        &config,
+                        start_sequence,
+                        end_sequence.expect("replay has an end fence"),
+                        &counters,
+                    )
+                    .await;
+                }
                 continue;
             }
             Err(error) => {
                 eprintln!("organizational append-log message rejected: {error}");
+                record_progress(
+                    &runtime,
+                    &config,
+                    stream_sequence,
+                    ConsumerMessageOutcome::Rejected,
+                    Some((subject_source, subject_family)),
+                    None,
+                    &mut counters,
+                )
+                .await?;
                 message.double_ack().await.map_err(consumer_io)?;
+                if replay_drained(&config, end_sequence, stream_sequence, pending) {
+                    return finish_replay(
+                        &runtime,
+                        &config,
+                        start_sequence,
+                        end_sequence.expect("replay has an end fence"),
+                        &counters,
+                    )
+                    .await;
+                }
                 continue;
             }
         };
-        match runtime.project_committed(event).await {
+        let event_source = event.source_id().to_owned();
+        let event_family = event.family_id().to_owned();
+        match runtime.project_committed_shadow(event).await {
             Ok(response) => {
+                let outcome = if response.projected {
+                    ConsumerMessageOutcome::Projected
+                } else {
+                    ConsumerMessageOutcome::Skipped
+                };
+                record_progress(
+                    &runtime,
+                    &config,
+                    stream_sequence,
+                    outcome,
+                    Some((&event_source, &event_family)),
+                    response.graph_revision,
+                    &mut counters,
+                )
+                .await?;
                 message.double_ack().await.map_err(consumer_io)?;
                 if response.authority == ProjectionAuthority::Rust {
                     println!(
@@ -147,6 +452,16 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                         response.entities_upserted,
                         response.assertions_upserted
                     );
+                }
+                if replay_drained(&config, end_sequence, stream_sequence, pending) {
+                    return finish_replay(
+                        &runtime,
+                        &config,
+                        start_sequence,
+                        end_sequence.expect("replay has an end fence"),
+                        &counters,
+                    )
+                    .await;
                 }
             }
             Err(error) => match failure_disposition(error.is_retryable()) {
@@ -163,12 +478,345 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                     eprintln!(
                         "organizational append-log projection rejected subject={subject} error={error}"
                     );
+                    record_progress(
+                        &runtime,
+                        &config,
+                        stream_sequence,
+                        ConsumerMessageOutcome::Rejected,
+                        Some((&event_source, &event_family)),
+                        None,
+                        &mut counters,
+                    )
+                    .await?;
                     message.double_ack().await.map_err(consumer_io)?;
+                    if replay_drained(&config, end_sequence, stream_sequence, pending) {
+                        return finish_replay(
+                            &runtime,
+                            &config,
+                            start_sequence,
+                            end_sequence.expect("replay has an end fence"),
+                            &counters,
+                        )
+                        .await;
+                    }
                 }
             },
         }
     }
-    Err("organizational append-log consumer stopped receiving messages".into())
+}
+
+fn next_unprocessed_sequence(start_sequence: u64, last_delivered_sequence: u64) -> u64 {
+    if last_delivered_sequence == 0 {
+        start_sequence
+    } else {
+        last_delivered_sequence.saturating_add(1)
+    }
+}
+
+fn retention_gap(
+    first_retained_sequence: u64,
+    next_unprocessed_sequence: u64,
+    end_sequence: Option<u64>,
+) -> bool {
+    end_sequence.is_some_and(|end| {
+        next_unprocessed_sequence <= end && first_retained_sequence > next_unprocessed_sequence
+    })
+}
+
+pub(crate) async fn inspect() -> Result<(), Box<dyn Error>> {
+    let nats_url = required("CEREBRO_JETSTREAM_URL")?;
+    let stream_name = optional("CEREBRO_JETSTREAM_STREAM_NAME", DEFAULT_STREAM);
+    let subject_prefix = optional("CEREBRO_JETSTREAM_SUBJECT_PREFIX", DEFAULT_SUBJECT_PREFIX);
+    let client = async_nats::connect(&nats_url).await?;
+    let jetstream = async_nats::jetstream::new(client);
+    let mut stream = jetstream.get_stream(&stream_name).await?;
+    let state = stream.info().await?.state.clone();
+    println!(
+        "{}",
+        serde_json::json!({
+            "schema_version": "cerebro.organizational-consumer-fence/v1",
+            "stream": stream_name,
+            "filter_subject": format!("{subject_prefix}.>"),
+            "first_sequence": state.first_sequence,
+            "end_sequence": state.last_sequence,
+            "captured_messages": state.messages,
+        })
+    );
+    Ok(())
+}
+
+pub(crate) async fn inspect_run() -> Result<(), Box<dyn Error>> {
+    let consumer_name = required("CEREBRO_ORGANIZATIONAL_CONSUMER_NAME")?;
+    let run_id = required("CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID")?;
+    let ledger = PostgresLedger::connect_tls(&required("CEREBRO_POSTGRES_DSN")?).await?;
+    let inspection = ledger.inspect_consumer_run(&consumer_name, &run_id).await?;
+    let observed_source_families = inspection.families.len();
+    let projected_source_families = inspection
+        .families
+        .iter()
+        .filter(|family| family.messages_projected > 0)
+        .count();
+    let latest_graph_revision = inspection
+        .families
+        .iter()
+        .filter_map(|family| family.latest_graph_revision)
+        .max();
+    let inspected_at_unix_ms = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+    let payload = serde_json::json!({
+        "schema_version": "cerebro.organizational-materialization-receipt/v1",
+        "run": inspection,
+        "observed_source_families": observed_source_families,
+        "projected_source_families": projected_source_families,
+        "latest_graph_revision": latest_graph_revision,
+        "inspected_at_unix_ms": inspected_at_unix_ms,
+        "deployment_environment": optional("CEREBRO_DEPLOYMENT_ENVIRONMENT", "unknown"),
+        "image_tag": optional("CEREBRO_IMAGE_TAG", "unknown"),
+    });
+    let canonical = serde_json::to_vec(&payload)?;
+    let digest = Sha256::digest(canonical)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    println!(
+        "{}",
+        serde_json::json!({
+            "receipt": payload,
+            "receipt_sha256": digest,
+        })
+    );
+    Ok(())
+}
+
+#[derive(Default, Serialize)]
+struct ConsumerCounters {
+    last_delivered_sequence: u64,
+    covered_sequence: u64,
+    messages_seen: u64,
+    messages_projected: u64,
+    messages_skipped: u64,
+    messages_rejected: u64,
+}
+
+impl From<ConsumerRunProgress> for ConsumerCounters {
+    fn from(value: ConsumerRunProgress) -> Self {
+        Self {
+            last_delivered_sequence: value.last_delivered_sequence,
+            covered_sequence: value.covered_sequence,
+            messages_seen: value.messages_seen,
+            messages_projected: value.messages_projected,
+            messages_skipped: value.messages_skipped,
+            messages_rejected: value.messages_rejected,
+        }
+    }
+}
+
+async fn load_counters(
+    runtime: &ProjectionRuntime,
+    config: &ConsumerConfig,
+) -> Result<ConsumerCounters, Box<dyn Error>> {
+    Ok(runtime
+        .authority
+        .consumer_run_progress(&config.durable_name, &config.run_id)
+        .await?
+        .into())
+}
+
+async fn record_progress(
+    runtime: &ProjectionRuntime,
+    config: &ConsumerConfig,
+    stream_sequence: u64,
+    outcome: ConsumerMessageOutcome,
+    source_family: Option<(&str, &str)>,
+    graph_revision: Option<u64>,
+    counters: &mut ConsumerCounters,
+) -> Result<(), Box<dyn Error>> {
+    runtime
+        .authority
+        .record_consumer_progress(
+            &config.durable_name,
+            &config.run_id,
+            stream_sequence,
+            outcome,
+            source_family,
+            graph_revision,
+        )
+        .await?;
+    counters.covered_sequence = counters.covered_sequence.max(stream_sequence);
+    counters.last_delivered_sequence = counters.last_delivered_sequence.max(stream_sequence);
+    counters.messages_seen += 1;
+    match outcome {
+        ConsumerMessageOutcome::Projected => counters.messages_projected += 1,
+        ConsumerMessageOutcome::Skipped => counters.messages_skipped += 1,
+        ConsumerMessageOutcome::Rejected => counters.messages_rejected += 1,
+    }
+    Ok(())
+}
+
+fn replay_drained(
+    config: &ConsumerConfig,
+    end_sequence: Option<u64>,
+    stream_sequence: u64,
+    pending: u64,
+) -> bool {
+    config.mode == ConsumerMode::Replay
+        && (end_sequence.is_some_and(|end| stream_sequence >= end) || pending == 0)
+}
+
+async fn finish_replay(
+    runtime: &ProjectionRuntime,
+    config: &ConsumerConfig,
+    start_sequence: u64,
+    end_sequence: u64,
+    _counters: &ConsumerCounters,
+) -> Result<(), Box<dyn Error>> {
+    let persisted_before_finish = load_counters(runtime, config).await?;
+    if persisted_before_finish.last_delivered_sequence < end_sequence {
+        let first_retained_sequence = current_first_sequence(config).await?;
+        let next_unprocessed = next_unprocessed_sequence(
+            start_sequence,
+            persisted_before_finish.last_delivered_sequence,
+        );
+        if retention_gap(
+            first_retained_sequence,
+            next_unprocessed,
+            Some(end_sequence),
+        ) {
+            runtime
+                .authority
+                .finish_consumer_run(&config.durable_name, &config.run_id, "failed", None)
+                .await?;
+            emit_receipt(
+                "failed",
+                config,
+                start_sequence,
+                Some(end_sequence),
+                persisted_before_finish.covered_sequence,
+                &persisted_before_finish,
+                Some("retention_gap"),
+            )?;
+            return Err(format!(
+                "retention advanced to sequence {first_retained_sequence} before replay covered {next_unprocessed}"
+            )
+            .into());
+        }
+    }
+    let completion_basis = if persisted_before_finish.last_delivered_sequence >= end_sequence {
+        "delivered_end_sequence"
+    } else {
+        "zero_eligible_pending"
+    };
+    let status = if persisted_before_finish.messages_rejected == 0
+        && persisted_before_finish.messages_projected > 0
+    {
+        "completed"
+    } else {
+        "failed"
+    };
+    runtime
+        .authority
+        .finish_consumer_run(
+            &config.durable_name,
+            &config.run_id,
+            status,
+            (status == "completed").then_some(end_sequence),
+        )
+        .await?;
+    let persisted = load_counters(runtime, config).await?;
+    emit_receipt(
+        status,
+        config,
+        start_sequence,
+        Some(end_sequence),
+        if status == "completed" {
+            end_sequence
+        } else {
+            persisted.covered_sequence
+        },
+        &persisted,
+        Some(completion_basis),
+    )?;
+    if status == "completed" {
+        Ok(())
+    } else {
+        Err("organizational replay reached its fence without clean projected coverage".into())
+    }
+}
+
+async fn current_first_sequence(config: &ConsumerConfig) -> Result<u64, Box<dyn Error>> {
+    let client = async_nats::connect(&config.nats_url).await?;
+    let jetstream = async_nats::jetstream::new(client);
+    let mut stream = jetstream.get_stream(&config.stream).await?;
+    Ok(stream.info().await?.state.first_sequence)
+}
+
+#[derive(Serialize)]
+struct ConsumerReceipt<'a> {
+    schema_version: &'static str,
+    status: &'a str,
+    mode: ConsumerMode,
+    stream: &'a str,
+    filter_subject: String,
+    consumer_name: &'a str,
+    run_id: &'a str,
+    start_sequence: u64,
+    end_sequence: Option<u64>,
+    covered_sequence: u64,
+    last_delivered_sequence: u64,
+    completion_basis: Option<&'a str>,
+    counters: &'a ConsumerCounters,
+}
+
+fn emit_receipt(
+    status: &str,
+    config: &ConsumerConfig,
+    start_sequence: u64,
+    end_sequence: Option<u64>,
+    covered_sequence: u64,
+    counters: &ConsumerCounters,
+    completion_basis: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    println!(
+        "{}",
+        serde_json::to_string(&ConsumerReceipt {
+            schema_version: "cerebro.organizational-consumer-run/v1",
+            status,
+            mode: config.mode,
+            stream: &config.stream,
+            filter_subject: config.filter_subject(),
+            consumer_name: &config.durable_name,
+            run_id: &config.run_id,
+            start_sequence,
+            end_sequence,
+            covered_sequence,
+            last_delivered_sequence: counters.last_delivered_sequence,
+            completion_basis,
+            counters,
+        })?
+    );
+    Ok(())
+}
+
+fn mode_name(mode: ConsumerMode) -> &'static str {
+    match mode {
+        ConsumerMode::Forward => "forward",
+        ConsumerMode::Replay => "replay",
+    }
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut terminate = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = terminate.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 fn decode_event(
@@ -233,13 +881,13 @@ fn validate_server_config(
     Ok(())
 }
 
-fn source_from_subject<'a>(subject: &'a str, prefix: &str) -> Option<&'a str> {
+fn source_family_from_subject<'a>(subject: &'a str, prefix: &str) -> Option<(&'a str, &'a str)> {
     let remainder = subject.strip_prefix(prefix)?.strip_prefix('.')?;
     let (source, family) = remainder.split_once('.')?;
     if source.is_empty() || family.is_empty() {
         None
     } else {
-        Some(source)
+        Some((source, family))
     }
 }
 
@@ -263,6 +911,20 @@ fn optional(name: &str, default: &str) -> String {
 fn required_u64(name: &str) -> Result<u64, Box<dyn Error>> {
     let value = required(name)?;
     parse_required_u64(name, &value)
+}
+
+fn optional_u64(name: &str, default: u64) -> Result<u64, Box<dyn Error>> {
+    match env::var(name) {
+        Ok(value) if !value.trim().is_empty() => parse_required_u64(name, &value),
+        _ => Ok(default),
+    }
+}
+
+fn optional_positive_u64(name: &str) -> Result<Option<u64>, Box<dyn Error>> {
+    match env::var(name) {
+        Ok(value) if !value.trim().is_empty() => parse_required_u64(name, &value).map(Some),
+        _ => Ok(None),
+    }
 }
 
 fn parse_required_u64(name: &str, value: &str) -> Result<u64, Box<dyn Error>> {
@@ -332,6 +994,11 @@ mod tests {
             subject_prefix: DEFAULT_SUBJECT_PREFIX.to_owned(),
             durable_name: DEFAULT_CONSUMER.to_owned(),
             deliver_policy: DeliverPolicy::New,
+            mode: ConsumerMode::Forward,
+            run_id: "forward-organizational-graph-v1".to_owned(),
+            end_sequence_override: None,
+            max_messages: None,
+            max_runtime: None,
         };
         let pull = config.pull_config();
         assert_eq!(pull.durable_name.as_deref(), Some(DEFAULT_CONSUMER));
@@ -346,16 +1013,19 @@ mod tests {
     #[test]
     fn subject_parser_claims_only_source_family_subjects() {
         assert_eq!(
-            source_from_subject("events.box.content_assets", "events"),
-            Some("box")
+            source_family_from_subject("events.box.content_assets", "events"),
+            Some(("box", "content_assets"))
         );
         assert_eq!(
-            source_from_subject("events.google_workspace.users", "events"),
-            Some("google_workspace")
+            source_family_from_subject("events.google_workspace.users", "events"),
+            Some(("google_workspace", "users"))
         );
-        assert_eq!(source_from_subject("events.box", "events"), None);
-        assert_eq!(source_from_subject("sec.findings.v1", "events"), None);
-        assert_eq!(source_from_subject("events..users", "events"), None);
+        assert_eq!(source_family_from_subject("events.box", "events"), None);
+        assert_eq!(
+            source_family_from_subject("sec.findings.v1", "events"),
+            None
+        );
+        assert_eq!(source_family_from_subject("events..users", "events"), None);
     }
 
     #[test]
@@ -366,6 +1036,11 @@ mod tests {
             subject_prefix: DEFAULT_SUBJECT_PREFIX.to_owned(),
             durable_name: DEFAULT_CONSUMER.to_owned(),
             deliver_policy: DeliverPolicy::New,
+            mode: ConsumerMode::Forward,
+            run_id: "forward-organizational-graph-v1".to_owned(),
+            end_sequence_override: None,
+            max_messages: None,
+            max_runtime: None,
         }
         .pull_config();
         let mut actual = async_nats::jetstream::consumer::Config {
@@ -455,6 +1130,11 @@ mod tests {
             subject_prefix: DEFAULT_SUBJECT_PREFIX.to_owned(),
             durable_name: "organizational-graph-bootstrap".to_owned(),
             deliver_policy: DeliverPolicy::All,
+            mode: ConsumerMode::Replay,
+            run_id: "bootstrap-20260729".to_owned(),
+            end_sequence_override: None,
+            max_messages: Some(100),
+            max_runtime: Some(Duration::from_secs(60)),
         }
         .pull_config();
         assert_eq!(all.deliver_policy, DeliverPolicy::All);
@@ -465,17 +1145,41 @@ mod tests {
             subject_prefix: DEFAULT_SUBJECT_PREFIX.to_owned(),
             durable_name: "organizational-graph-replay-42".to_owned(),
             deliver_policy: DeliverPolicy::ByStartSequence { start_sequence: 42 },
+            mode: ConsumerMode::Replay,
+            run_id: "replay-42".to_owned(),
+            end_sequence_override: Some(50),
+            max_messages: Some(100),
+            max_runtime: Some(Duration::from_secs(60)),
         }
         .pull_config();
         assert_eq!(
             from_sequence.deliver_policy,
             DeliverPolicy::ByStartSequence { start_sequence: 42 }
         );
-        assert!(validate_delivery_identity(DeliverPolicy::All, DEFAULT_CONSUMER).is_err());
         assert!(
             validate_delivery_identity(
+                ConsumerMode::Replay,
+                DeliverPolicy::All,
+                DEFAULT_CONSUMER,
+                "bootstrap-20260729",
+            )
+            .is_err()
+        );
+        assert!(
+            validate_delivery_identity(
+                ConsumerMode::Replay,
                 DeliverPolicy::ByStartSequence { start_sequence: 42 },
                 "organizational-graph-replay-42",
+                "replay-42",
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_delivery_identity(
+                ConsumerMode::Forward,
+                DeliverPolicy::ByStartSequence { start_sequence: 43 },
+                "organizational-graph-forward-v1",
+                "forward-handoff-42",
             )
             .is_ok()
         );
@@ -491,5 +1195,67 @@ mod tests {
         assert!(
             parse_required_u64("CEREBRO_ORGANIZATIONAL_CONSUMER_START_SEQUENCE", " 0 ").is_err()
         );
+    }
+
+    #[test]
+    fn replay_completion_accepts_filtered_sequence_gaps_only_after_consumer_drain() {
+        let config = ConsumerConfig {
+            nats_url: "nats://localhost:4222".to_owned(),
+            stream: DEFAULT_STREAM.to_owned(),
+            subject_prefix: DEFAULT_SUBJECT_PREFIX.to_owned(),
+            durable_name: "organizational-graph-replay".to_owned(),
+            deliver_policy: DeliverPolicy::All,
+            mode: ConsumerMode::Replay,
+            run_id: "replay-gap-proof".to_owned(),
+            end_sequence_override: Some(50),
+            max_messages: Some(100),
+            max_runtime: Some(Duration::from_secs(60)),
+        };
+        assert!(!replay_drained(&config, Some(50), 41, 1));
+        assert!(replay_drained(&config, Some(50), 41, 0));
+        assert!(replay_drained(&config, Some(50), 50, 10));
+    }
+
+    #[test]
+    fn replay_resume_rejects_expired_unprocessed_sequences() {
+        assert_eq!(next_unprocessed_sequence(10, 0), 10);
+        assert_eq!(next_unprocessed_sequence(10, 41), 42);
+        assert!(retention_gap(43, 42, Some(50)));
+        assert!(!retention_gap(42, 42, Some(50)));
+        assert!(!retention_gap(51, 51, Some(50)));
+        assert!(!retention_gap(43, 42, None));
+    }
+
+    #[test]
+    fn run_receipt_is_machine_readable_and_accounts_for_skips() {
+        let counters = ConsumerCounters {
+            last_delivered_sequence: 41,
+            covered_sequence: 41,
+            messages_seen: 3,
+            messages_projected: 1,
+            messages_skipped: 2,
+            messages_rejected: 0,
+        };
+        let receipt = ConsumerReceipt {
+            schema_version: "cerebro.organizational-consumer-run/v1",
+            status: "completed",
+            mode: ConsumerMode::Replay,
+            stream: DEFAULT_STREAM,
+            filter_subject: "events.>".to_owned(),
+            consumer_name: "organizational-graph-replay",
+            run_id: "replay-gap-proof",
+            start_sequence: 1,
+            end_sequence: Some(50),
+            covered_sequence: 50,
+            last_delivered_sequence: 41,
+            completion_basis: Some("zero_eligible_pending"),
+            counters: &counters,
+        };
+        let value = serde_json::to_value(receipt).unwrap();
+        assert_eq!(value["status"], "completed");
+        assert_eq!(value["end_sequence"], 50);
+        assert_eq!(value["covered_sequence"], 50);
+        assert_eq!(value["counters"]["messages_skipped"], 2);
+        assert_eq!(value["counters"]["messages_rejected"], 0);
     }
 }

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -759,9 +759,17 @@ impl std::fmt::Display for ProjectionFailure {
 impl Error for ProjectionFailure {}
 
 impl ProjectionRuntime {
-    async fn project_committed(
+    async fn project_committed_shadow(
         &self,
         event: CommittedSourceEvent,
+    ) -> Result<ProjectEventResponse, ProjectionFailure> {
+        self.project_committed_with_intent(event, true).await
+    }
+
+    async fn project_committed_with_intent(
+        &self,
+        event: CommittedSourceEvent,
+        materialize_shadow: bool,
     ) -> Result<ProjectEventResponse, ProjectionFailure> {
         self.authority
             .record_source_event(&event)
@@ -782,7 +790,7 @@ impl ProjectionRuntime {
             )
             .await
             .map_err(ProjectionFailure::Store)?;
-        if authority.authority == ProjectionAuthority::Legacy {
+        if !should_materialize(authority.authority, materialize_shadow) {
             return Ok(ProjectEventResponse {
                 authority: ProjectionAuthority::Legacy,
                 projected: false,
@@ -856,7 +864,7 @@ impl ProjectionRuntime {
             .await
             .map_err(ProjectionFailure::Store)?;
         Ok(ProjectEventResponse {
-            authority: ProjectionAuthority::Rust,
+            authority: authority.authority,
             projected: true,
             graph_revision: Some(receipt.graph_revision),
             entities_upserted: receipt.entities_upserted,
@@ -1005,6 +1013,10 @@ impl ProjectionRuntime {
             assertions_upserted: receipt.assertions_upserted,
         })
     }
+}
+
+fn should_materialize(authority: ProjectionAuthority, materialize_shadow: bool) -> bool {
+    authority == ProjectionAuthority::Rust || materialize_shadow
 }
 
 #[derive(Serialize)]
@@ -1416,6 +1428,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some("serve-neo4j") => serve_neo4j().await,
         Some("serve-neo4j-consumer") => serve_neo4j_consumer().await,
         Some("consume-append-log") => consume_append_log().await,
+        Some("inspect-append-log") => append_log_consumer::inspect().await,
+        Some("inspect-consumer-run") => append_log_consumer::inspect_run().await,
         Some("migrate-stores") => migrate_stores().await,
         Some("rebuild-lifecycle-projection") => rebuild_lifecycle_projection().await,
         Some("sync-source") => sync_source().await,
@@ -1426,7 +1440,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some("show-authority") => cutover_command::show_authority().await,
         Some("--help" | "-h") => {
             println!(
-                "cerebro-platform <demo|serve|serve-demo|serve-neo4j-readonly|serve-neo4j|serve-neo4j-consumer|consume-append-log|migrate-stores|rebuild-lifecycle-projection|sync-source|catalog-summary|compare-projection|evaluate-family|promote-family|show-authority>"
+                "cerebro-platform <demo|serve|serve-demo|serve-neo4j-readonly|serve-neo4j|serve-neo4j-consumer|consume-append-log|inspect-append-log|inspect-consumer-run|migrate-stores|rebuild-lifecycle-projection|sync-source|catalog-summary|compare-projection|evaluate-family|promote-family|show-authority>"
             );
             Ok(())
         }
@@ -6113,7 +6127,7 @@ mod tests {
         });
         let resource_urn = format!("urn:cerebro:{tenant_id}:runtime_file:asset-1");
         let response = runtime
-            .project_committed(
+            .project_committed_with_intent(
                 CommittedSourceEvent::from_input(
                     cerebro_source_runtime_next::CommittedSourceInput {
                         tenant_id: TenantId::parse(tenant_id.clone()).unwrap(),
@@ -6139,6 +6153,7 @@ mod tests {
                     },
                 )
                 .unwrap(),
+                false,
             )
             .await
             .unwrap();
@@ -6147,5 +6162,12 @@ mod tests {
         let entity = graph.resolve(&tenant, &resource_urn).await.unwrap();
         assert_eq!(entity.label, "Architecture");
         assert_eq!(entity.properties.get("resource_urn"), Some(&resource_urn));
+    }
+
+    #[test]
+    fn replay_materializes_shadow_without_promoting_family_authority() {
+        assert!(should_materialize(ProjectionAuthority::Legacy, true));
+        assert!(!should_materialize(ProjectionAuthority::Legacy, false));
+        assert!(should_materialize(ProjectionAuthority::Rust, false));
     }
 }

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -115,6 +115,8 @@ fn replacement_proof_is_a_native_rust_product_path() {
         "test ! -e /usr/bin/go",
         "test ! -e /bin/go",
         "--entrypoint /usr/local/bin/organizational-graph-e2e",
+        "CEREBRO_ORGANIZATIONAL_CONSUMER_DELIVER_POLICY=by_start_sequence",
+        "CEREBRO_ORGANIZATIONAL_CONSUMER_START_SEQUENCE=1",
         "docker restart cerebro-rust-graph-platform",
         "receipt.json)\" -eq 14",
     ] {

--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -18,8 +18,9 @@ pub use parity::{
     SemanticMismatch, SemanticSnapshot,
 };
 pub use postgres::{
-    LegacyProjectionReceipt, POSTGRES_SCHEMA, PostgresLedger, SourceCollectionReceipt,
-    SourceEventReceipt, StoredSourceRuntime,
+    ConsumerFamilyProgress, ConsumerMessageOutcome, ConsumerRunFence, ConsumerRunInspection,
+    ConsumerRunProgress, LegacyProjectionReceipt, POSTGRES_SCHEMA, PostgresLedger,
+    SourceCollectionReceipt, SourceEventReceipt, StoredSourceRuntime,
 };
 
 use std::{error::Error, fmt};

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -290,6 +290,46 @@ CREATE TABLE IF NOT EXISTS organizational_projection_authority (
     (authority = 'rust' AND promoted_at_unix_ms > 0)
   )
 );
+CREATE TABLE IF NOT EXISTS organizational_consumer_runs (
+  consumer_name TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('forward', 'replay')),
+  start_sequence BIGINT NOT NULL CHECK (start_sequence > 0),
+  end_sequence BIGINT,
+  last_delivered_sequence BIGINT NOT NULL DEFAULT 0 CHECK (last_delivered_sequence >= 0),
+  covered_sequence BIGINT NOT NULL DEFAULT 0 CHECK (covered_sequence >= 0),
+  messages_seen BIGINT NOT NULL DEFAULT 0 CHECK (messages_seen >= 0),
+  messages_projected BIGINT NOT NULL DEFAULT 0 CHECK (messages_projected >= 0),
+  messages_skipped BIGINT NOT NULL DEFAULT 0 CHECK (messages_skipped >= 0),
+  messages_rejected BIGINT NOT NULL DEFAULT 0 CHECK (messages_rejected >= 0),
+  status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'stopped', 'failed')),
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  PRIMARY KEY (consumer_name, run_id),
+  CHECK (end_sequence IS NULL OR end_sequence >= start_sequence),
+  CHECK (
+    (mode = 'forward' AND end_sequence IS NULL) OR
+    (mode = 'replay' AND end_sequence IS NOT NULL)
+  )
+);
+CREATE TABLE IF NOT EXISTS organizational_consumer_family_progress (
+  consumer_name TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  family_id TEXT NOT NULL,
+  messages_seen BIGINT NOT NULL DEFAULT 0 CHECK (messages_seen >= 0),
+  messages_projected BIGINT NOT NULL DEFAULT 0 CHECK (messages_projected >= 0),
+  messages_skipped BIGINT NOT NULL DEFAULT 0 CHECK (messages_skipped >= 0),
+  messages_rejected BIGINT NOT NULL DEFAULT 0 CHECK (messages_rejected >= 0),
+  last_sequence BIGINT NOT NULL CHECK (last_sequence > 0),
+  latest_graph_revision BIGINT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (consumer_name, run_id, source_id, family_id),
+  FOREIGN KEY (consumer_name, run_id)
+    REFERENCES organizational_consumer_runs (consumer_name, run_id)
+    ON DELETE CASCADE
+);
 CREATE INDEX IF NOT EXISTS organizational_projection_pending_idx
   ON organizational_projection_outbox (graph_revision)
   WHERE projected_at IS NULL;
@@ -299,6 +339,9 @@ CREATE INDEX IF NOT EXISTS organizational_parity_latest_idx
 CREATE INDEX IF NOT EXISTS organizational_source_collection_latest_idx
   ON organizational_source_collection_receipts
     (tenant_id, source_runtime_id, completed_at_unix_ms DESC);
+CREATE INDEX IF NOT EXISTS organizational_consumer_runs_readiness_idx
+  ON organizational_consumer_runs
+    (consumer_name, status, covered_sequence DESC, updated_at DESC);
 ALTER TABLE organizational_graph_revisions ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_graph_revisions FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_collections ENABLE ROW LEVEL SECURITY;
@@ -573,6 +616,56 @@ pub struct SourceEventReceipt {
     pub record_digest: String,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConsumerMessageOutcome {
+    Projected,
+    Skipped,
+    Rejected,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ConsumerRunFence {
+    pub start_sequence: u64,
+    pub end_sequence: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConsumerRunProgress {
+    pub last_delivered_sequence: u64,
+    pub covered_sequence: u64,
+    pub messages_seen: u64,
+    pub messages_projected: u64,
+    pub messages_skipped: u64,
+    pub messages_rejected: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConsumerFamilyProgress {
+    pub source_id: String,
+    pub family_id: String,
+    pub messages_seen: u64,
+    pub messages_projected: u64,
+    pub messages_skipped: u64,
+    pub messages_rejected: u64,
+    pub last_sequence: u64,
+    pub latest_graph_revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConsumerRunInspection {
+    pub consumer_name: String,
+    pub run_id: String,
+    pub mode: String,
+    pub start_sequence: u64,
+    pub end_sequence: Option<u64>,
+    pub status: String,
+    pub started_at_unix_ms: u64,
+    pub updated_at_unix_ms: u64,
+    pub completed_at_unix_ms: Option<u64>,
+    pub progress: ConsumerRunProgress,
+    pub families: Vec<ConsumerFamilyProgress>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LegacyProjectionReceipt {
     pub tenant_id: String,
@@ -597,6 +690,16 @@ pub struct StoredSourceRuntime {
     source_id: String,
     config: BTreeMap<String, String>,
     cursor: Option<String>,
+}
+
+fn sequence_i64(sequence: u64) -> Result<i64, StoreError> {
+    if sequence == 0 {
+        return Err(StoreError::Conflict(
+            "consumer stream sequence must be greater than zero".to_owned(),
+        ));
+    }
+    i64::try_from(sequence)
+        .map_err(|_| StoreError::Conflict("consumer stream sequence overflow".to_owned()))
 }
 
 impl StoredSourceRuntime {
@@ -676,6 +779,238 @@ impl PostgresLedger {
             .batch_execute(POSTGRES_SCHEMA)
             .await?;
         Ok(())
+    }
+
+    pub async fn start_consumer_run(
+        &self,
+        consumer_name: &str,
+        run_id: &str,
+        mode: &str,
+        start_sequence: u64,
+        end_sequence: Option<u64>,
+    ) -> Result<ConsumerRunFence, StoreError> {
+        let start_sequence = sequence_i64(start_sequence)?;
+        let end_sequence = end_sequence.map(sequence_i64).transpose()?;
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        let row = transaction
+            .query_opt(
+                "INSERT INTO organizational_consumer_runs (consumer_name, run_id, mode, start_sequence, end_sequence, status) VALUES ($1, $2, $3, $4, $5, 'running') ON CONFLICT (consumer_name, run_id) DO UPDATE SET status = 'running', updated_at = NOW(), completed_at = NULL WHERE organizational_consumer_runs.mode = EXCLUDED.mode AND (organizational_consumer_runs.mode = 'replay' OR organizational_consumer_runs.start_sequence = EXCLUDED.start_sequence) AND organizational_consumer_runs.status IN ('running', 'stopped', 'failed') RETURNING start_sequence, end_sequence",
+                &[&consumer_name, &run_id, &mode, &start_sequence, &end_sequence],
+            )
+            .await?;
+        let Some(row) = row else {
+            return Err(StoreError::Conflict(format!(
+                "consumer run {consumer_name}/{run_id} is complete or has another fence"
+            )));
+        };
+        transaction.commit().await?;
+        let stored_start: i64 = row.get(0);
+        let stored_end: Option<i64> = row.get(1);
+        Ok(ConsumerRunFence {
+            start_sequence: u64::try_from(stored_start).map_err(|_| {
+                StoreError::Conflict("stored consumer start sequence is invalid".to_owned())
+            })?,
+            end_sequence: stored_end.map(u64::try_from).transpose().map_err(|_| {
+                StoreError::Conflict("stored consumer end sequence is invalid".to_owned())
+            })?,
+        })
+    }
+
+    pub async fn record_consumer_progress(
+        &self,
+        consumer_name: &str,
+        run_id: &str,
+        stream_sequence: u64,
+        outcome: ConsumerMessageOutcome,
+        source_family: Option<(&str, &str)>,
+        graph_revision: Option<u64>,
+    ) -> Result<(), StoreError> {
+        let stream_sequence = sequence_i64(stream_sequence)?;
+        let graph_revision = graph_revision.map(sequence_i64).transpose()?;
+        let (projected, skipped, rejected): (i64, i64, i64) = match outcome {
+            ConsumerMessageOutcome::Projected => (1, 0, 0),
+            ConsumerMessageOutcome::Skipped => (0, 1, 0),
+            ConsumerMessageOutcome::Rejected => (0, 0, 1),
+        };
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        let changed = transaction
+            .execute(
+                "UPDATE organizational_consumer_runs SET last_delivered_sequence = $3, covered_sequence = $3, messages_seen = messages_seen + 1, messages_projected = messages_projected + $4, messages_skipped = messages_skipped + $5, messages_rejected = messages_rejected + $6, updated_at = NOW() WHERE consumer_name = $1 AND run_id = $2 AND status = 'running' AND last_delivered_sequence < $3 AND (end_sequence IS NULL OR $3 <= end_sequence)",
+                &[
+                    &consumer_name,
+                    &run_id,
+                    &stream_sequence,
+                    &projected,
+                    &skipped,
+                    &rejected,
+                ],
+            )
+            .await?;
+        if changed == 0 {
+            let already_covered = transaction
+                .query_opt(
+                    "SELECT 1 FROM organizational_consumer_runs WHERE consumer_name = $1 AND run_id = $2 AND status = 'running' AND last_delivered_sequence >= $3",
+                    &[&consumer_name, &run_id, &stream_sequence],
+                )
+                .await?
+                .is_some();
+            if !already_covered {
+                return Err(StoreError::Conflict(format!(
+                    "consumer run {consumer_name}/{run_id} rejected sequence {stream_sequence}"
+                )));
+            }
+        } else if let Some((source_id, family_id)) = source_family {
+            transaction
+                .execute(
+                    "INSERT INTO organizational_consumer_family_progress (consumer_name, run_id, source_id, family_id, messages_seen, messages_projected, messages_skipped, messages_rejected, last_sequence, latest_graph_revision) VALUES ($1, $2, $3, $4, 1, $5, $6, $7, $8, $9) ON CONFLICT (consumer_name, run_id, source_id, family_id) DO UPDATE SET messages_seen = organizational_consumer_family_progress.messages_seen + 1, messages_projected = organizational_consumer_family_progress.messages_projected + EXCLUDED.messages_projected, messages_skipped = organizational_consumer_family_progress.messages_skipped + EXCLUDED.messages_skipped, messages_rejected = organizational_consumer_family_progress.messages_rejected + EXCLUDED.messages_rejected, last_sequence = EXCLUDED.last_sequence, latest_graph_revision = COALESCE(EXCLUDED.latest_graph_revision, organizational_consumer_family_progress.latest_graph_revision), updated_at = NOW() WHERE organizational_consumer_family_progress.last_sequence < EXCLUDED.last_sequence",
+                    &[
+                        &consumer_name,
+                        &run_id,
+                        &source_id,
+                        &family_id,
+                        &projected,
+                        &skipped,
+                        &rejected,
+                        &stream_sequence,
+                        &graph_revision,
+                    ],
+                )
+                .await?;
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    pub async fn finish_consumer_run(
+        &self,
+        consumer_name: &str,
+        run_id: &str,
+        status: &str,
+        covered_sequence: Option<u64>,
+    ) -> Result<(), StoreError> {
+        if !matches!(status, "completed" | "stopped" | "failed") {
+            return Err(StoreError::Conflict(
+                "consumer terminal status is invalid".to_owned(),
+            ));
+        }
+        let covered_sequence = covered_sequence.map(sequence_i64).transpose()?;
+        let changed = self
+            .client
+            .lock()
+            .await
+            .execute(
+                "UPDATE organizational_consumer_runs SET status = $3, covered_sequence = GREATEST(covered_sequence, COALESCE($4, covered_sequence)), updated_at = NOW(), completed_at = CASE WHEN $3 = 'completed' THEN NOW() ELSE NULL END WHERE consumer_name = $1 AND run_id = $2 AND status = 'running' AND ($3 <> 'completed' OR ((end_sequence IS NULL OR $4 >= end_sequence) AND messages_projected > 0 AND messages_rejected = 0))",
+                &[&consumer_name, &run_id, &status, &covered_sequence],
+            )
+            .await?;
+        if changed == 0 {
+            return Err(StoreError::Conflict(format!(
+                "consumer run {consumer_name}/{run_id} cannot transition to {status}"
+            )));
+        }
+        Ok(())
+    }
+
+    pub async fn consumer_run_progress(
+        &self,
+        consumer_name: &str,
+        run_id: &str,
+    ) -> Result<ConsumerRunProgress, StoreError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                "SELECT last_delivered_sequence, covered_sequence, messages_seen, messages_projected, messages_skipped, messages_rejected FROM organizational_consumer_runs WHERE consumer_name = $1 AND run_id = $2",
+                &[&consumer_name, &run_id],
+            )
+            .await?
+            .ok_or_else(|| StoreError::Conflict("consumer run was not found".to_owned()))?;
+        Ok(ConsumerRunProgress {
+            last_delivered_sequence: stored_u64(&row, 0, "last_delivered_sequence")?,
+            covered_sequence: stored_u64(&row, 1, "covered_sequence")?,
+            messages_seen: stored_u64(&row, 2, "messages_seen")?,
+            messages_projected: stored_u64(&row, 3, "messages_projected")?,
+            messages_skipped: stored_u64(&row, 4, "messages_skipped")?,
+            messages_rejected: stored_u64(&row, 5, "messages_rejected")?,
+        })
+    }
+
+    pub async fn inspect_consumer_run(
+        &self,
+        consumer_name: &str,
+        run_id: &str,
+    ) -> Result<ConsumerRunInspection, StoreError> {
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        let row = transaction
+            .query_opt(
+                "SELECT mode, start_sequence, end_sequence, status, (EXTRACT(EPOCH FROM started_at) * 1000)::BIGINT, (EXTRACT(EPOCH FROM updated_at) * 1000)::BIGINT, (EXTRACT(EPOCH FROM completed_at) * 1000)::BIGINT, last_delivered_sequence, covered_sequence, messages_seen, messages_projected, messages_skipped, messages_rejected FROM organizational_consumer_runs WHERE consumer_name = $1 AND run_id = $2",
+                &[&consumer_name, &run_id],
+            )
+            .await?
+            .ok_or_else(|| StoreError::Conflict("consumer run was not found".to_owned()))?;
+        let family_rows = transaction
+            .query(
+                "SELECT source_id, family_id, messages_seen, messages_projected, messages_skipped, messages_rejected, last_sequence, latest_graph_revision FROM organizational_consumer_family_progress WHERE consumer_name = $1 AND run_id = $2 ORDER BY source_id, family_id",
+                &[&consumer_name, &run_id],
+            )
+            .await?;
+        transaction.commit().await?;
+        let families = family_rows
+            .into_iter()
+            .map(|family| {
+                let revision: Option<i64> = family.get(7);
+                Ok(ConsumerFamilyProgress {
+                    source_id: family.get(0),
+                    family_id: family.get(1),
+                    messages_seen: stored_u64(&family, 2, "family messages_seen")?,
+                    messages_projected: stored_u64(&family, 3, "family messages_projected")?,
+                    messages_skipped: stored_u64(&family, 4, "family messages_skipped")?,
+                    messages_rejected: stored_u64(&family, 5, "family messages_rejected")?,
+                    last_sequence: stored_u64(&family, 6, "family last_sequence")?,
+                    latest_graph_revision: revision.map(u64::try_from).transpose().map_err(
+                        |_| {
+                            StoreError::Conflict(
+                                "stored family graph revision is invalid".to_owned(),
+                            )
+                        },
+                    )?,
+                })
+            })
+            .collect::<Result<Vec<_>, StoreError>>()?;
+        let end_sequence: Option<i64> = row.get(2);
+        Ok(ConsumerRunInspection {
+            consumer_name: consumer_name.to_owned(),
+            run_id: run_id.to_owned(),
+            mode: row.get(0),
+            start_sequence: stored_u64(&row, 1, "start_sequence")?,
+            end_sequence: end_sequence
+                .map(u64::try_from)
+                .transpose()
+                .map_err(|_| StoreError::Conflict("stored end sequence is invalid".to_owned()))?,
+            status: row.get(3),
+            started_at_unix_ms: stored_u64(&row, 4, "started_at_unix_ms")?,
+            updated_at_unix_ms: stored_u64(&row, 5, "updated_at_unix_ms")?,
+            completed_at_unix_ms: row
+                .get::<_, Option<i64>>(6)
+                .map(u64::try_from)
+                .transpose()
+                .map_err(|_| {
+                    StoreError::Conflict("stored completed timestamp is invalid".to_owned())
+                })?,
+            progress: ConsumerRunProgress {
+                last_delivered_sequence: stored_u64(&row, 7, "last_delivered_sequence")?,
+                covered_sequence: stored_u64(&row, 8, "covered_sequence")?,
+                messages_seen: stored_u64(&row, 9, "messages_seen")?,
+                messages_projected: stored_u64(&row, 10, "messages_projected")?,
+                messages_skipped: stored_u64(&row, 11, "messages_skipped")?,
+                messages_rejected: stored_u64(&row, 12, "messages_rejected")?,
+            },
+            families,
+        })
     }
 
     /// Load one durable runtime definition. Runtime identity comes only from
@@ -2478,6 +2813,11 @@ fn stored_count(row: &tokio_postgres::Row, index: usize, field: &str) -> Result<
         .map_err(|_| StoreError::Conflict(format!("stored {field} count is invalid")))
 }
 
+fn stored_u64(row: &tokio_postgres::Row, index: usize, field: &str) -> Result<u64, StoreError> {
+    let value: i64 = row.get(index);
+    u64::try_from(value).map_err(|_| StoreError::Conflict(format!("stored {field} is invalid")))
+}
+
 #[cfg(test)]
 mod tests {
     use std::env;
@@ -2500,11 +2840,16 @@ mod tests {
             "organizational_legacy_projection_receipts",
             "organizational_source_collection_receipts",
             "organizational_source_collection_latest_idx",
+            "organizational_consumer_runs",
+            "organizational_consumer_family_progress",
+            "last_delivered_sequence BIGINT NOT NULL DEFAULT 0",
             "current_setting(''cerebro.tenant_id'', true)",
             "DEFERRABLE INITIALLY DEFERRED",
         ] {
             assert!(POSTGRES_SCHEMA.contains(required), "missing {required}");
         }
+        assert!(include_str!("postgres.rs").contains("messages_projected > 0"));
+        assert!(include_str!("postgres.rs").contains("messages_rejected = 0"));
         let source_receipt_schema = POSTGRES_SCHEMA
             .split("CREATE TABLE IF NOT EXISTS organizational_source_event_receipts")
             .nth(1)

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -297,12 +297,39 @@ Go projector                Rust mapper
 
 `cerebro-platform serve-neo4j-readonly` opens only the bounded Neo4j read plane. It does not connect to PostgreSQL, run store migrations, expose a projection runtime, or consume the append log. Use this process for pre-cutover shadow and read canaries. `serve-neo4j` adds the projection API, while `serve-neo4j-consumer` also starts append-log consumption.
 
-Read promotion uses three explicit states. `shadow` always returns Go and
-compares a stable sample with Rust. `canary` assigns each tenant to Rust or Go
-with a stable hash; a Rust-tenant failure fails closed and never retries
-against Go. `authority` returns Rust for every typed read. Raw Cypher is not
-part of the canary surface and must be removed before the Go graph store can be
-retired.
+Read promotion uses four explicit states. `legacy` is the retained-Go rollback
+state and does not call Rust. `shadow` always returns Go and compares a stable
+sample with Rust. `canary` assigns each tenant to Rust or Go with a stable
+hash; readiness requires both authorities, and a Rust-tenant failure fails
+closed without retrying against Go. `authority` returns Rust for every typed
+read and does not depend on Go health.
+
+The promotion sequence is `legacy` or `shadow` -> `canary` -> `authority`.
+Moving forward requires all of these receipts against the same candidate and
+stream fence:
+
+- a completed bounded replay using the original persisted upper fence;
+- a nonzero Rust materialization count, zero rejected messages, and a durable
+  forward-consumer checkpoint at or beyond that fence;
+- a separate receipt proving the compatibility deltas were materialized into
+  the Rust `OrganizationalEntity` and assertion projection;
+- a fresh, nonzero typed-read comparison window with zero mismatches, Rust
+  errors, encoding errors, or dropped comparisons;
+- the exact task definition and image rollout receipt; and
+- a tested rollback receipt naming `legacy` as the expected read mode.
+
+Process liveness, Neo4j connectivity, consumer acknowledgement, and an empty
+projection are not authority evidence. A failed Rust request in `canary` or
+`authority` remains failed; the router never retries it through Go.
+
+Raw Cypher is a separate compatibility port. It remains delegated to the Go
+Neo4j reader until each caller has a typed Rust operation. The Go
+`GetEntityNeighborhood` and `GetEntityNeighborhoods` implementation may be
+deleted after the authority burn-in because typed neighborhood reads no longer
+need it; `ExecuteReadCypher` and `ExplainReadCypher` stay until their callers
+are migrated. After that deletion, rollback uses the last retained-Go image in
+`legacy` mode rather than pretending the current image still contains a Go
+typed reader.
 
 The canary percentage controls tenant allocation, not a random share of
 requests. Monitor `cerebro.organizational_graph.canary.routes` by `authority`,

--- a/docs/operations/hosting.md
+++ b/docs/operations/hosting.md
@@ -278,8 +278,13 @@ Use managed Postgres or an operationally equivalent deployment for shared enviro
 | `CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET` | Secret used to sign tenant-bound graph requests. Required with any Rust graph origin and must be at least 32 bytes. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT` | Rust graph request timeout. Defaults to `1s`. |
 | `CEREBRO_ORGANIZATIONAL_CONSUMER_NAME` | Durable JetStream consumer identity. Replay and rebuild modes require a new explicit name. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_MODE` | `forward` for the durable handoff consumer or `replay` for a bounded retained-history run. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID` | Stable receipt identity. Reuse it with the same durable name across bounded replay invocations. |
 | `CEREBRO_ORGANIZATIONAL_CONSUMER_DELIVER_POLICY` | `new` for forward processing, `all` for a complete retained-history rebuild, or `by_start_sequence` for a fenced handoff. |
 | `CEREBRO_ORGANIZATIONAL_CONSUMER_START_SEQUENCE` | Positive JetStream stream sequence required by `by_start_sequence`. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_END_SEQUENCE` | Optional immutable replay upper fence. Capture it with `inspect-append-log`; forward mode rejects it. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_MAX_MESSAGES` | Per-invocation replay safety bound. Defaults to `100000`; cumulative run progress survives a bounded stop. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_MAX_RUNTIME_SECONDS` | Per-invocation replay time bound. Defaults to `3600`; cumulative run progress survives a bounded stop. |
 
 Monitor graph ingest health, query latency, index health, and storage growth. Keep graph credentials scoped to the required database.
 

--- a/docs/operations/organizational-projection-replay.md
+++ b/docs/operations/organizational-projection-replay.md
@@ -1,0 +1,136 @@
+# Organizational projection replay
+
+The Rust organizational graph is a rebuildable projection. JetStream source
+events remain the replay input, PostgreSQL stores the Rust current-state ledger
+and projection receipts, and Neo4j stores the rebuildable graph.
+
+Replay does not promote a source family from legacy write authority. The replay
+and forward consumer materialize Rust shadow state so parity can be measured
+before promotion.
+
+## Required configuration
+
+Both replay and forward consumption require:
+
+- `CEREBRO_JETSTREAM_URL`
+- `CEREBRO_JETSTREAM_STREAM_NAME`
+- `CEREBRO_JETSTREAM_SUBJECT_PREFIX`
+- `CEREBRO_POSTGRES_DSN`
+- `CEREBRO_NEO4J_URI`
+- `CEREBRO_NEO4J_USERNAME`
+- `CEREBRO_NEO4J_PASSWORD`
+
+Consumer names and run IDs contain only letters, digits, hyphens, and
+underscores. A replay never uses the forward consumer name.
+
+## Capture the fence
+
+Run this from the same network and NATS account as the consumer:
+
+```sh
+cerebro-platform inspect-append-log
+```
+
+Save the emitted `cerebro.organizational-consumer-fence/v1` JSON. Its
+`first_sequence` is the first retained stream sequence and `end_sequence` is
+the immutable upper fence for this replay. Do not substitute a later stream
+sequence after a replay run starts.
+
+## Run bounded replay batches
+
+Use one replay consumer name and run ID for every bounded invocation:
+
+```sh
+CEREBRO_ORGANIZATIONAL_CONSUMER_MODE=replay \
+CEREBRO_ORGANIZATIONAL_CONSUMER_NAME=organizational-graph-replay-<change-id> \
+CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID=<change-id> \
+CEREBRO_ORGANIZATIONAL_CONSUMER_DELIVER_POLICY=all \
+CEREBRO_ORGANIZATIONAL_CONSUMER_END_SEQUENCE=<end_sequence> \
+CEREBRO_ORGANIZATIONAL_CONSUMER_MAX_MESSAGES=100000 \
+CEREBRO_ORGANIZATIONAL_CONSUMER_MAX_RUNTIME_SECONDS=3600 \
+cerebro-platform consume-append-log
+```
+
+The first invocation persists the fence before it creates or reads the
+consumer. Later invocations reuse the stored fence and durable checkpoint.
+Message and projection counters remain cumulative. A safety-bound stop records
+`stopped`, exits zero for trusted resume automation, and never emits
+`completed`. Configuration, retention, rejected-message, and projection
+failures exit nonzero.
+
+SIGTERM or Ctrl-C records `stopped` before exit. Stopping the ECS task is the
+rollback control; restarting the same task resumes from the durable checkpoint.
+Do not delete the durable consumer or change the run ID during a replay.
+
+Do not run the forward projector at the same time. Historical replay after a
+newer forward event could regress current state; event-receipt idempotency does
+not prove stale-event rejection.
+
+## Start the forward durable after replay
+
+After the replay receipt is `completed`, capture the stream state again. Fail
+closed if the current `first_sequence` is greater than `end_sequence + 1`;
+retention has removed part of the handoff range.
+
+Then start the long-running service with a distinct durable consumer at
+`end_sequence + 1`:
+
+```sh
+CEREBRO_ORGANIZATIONAL_CONSUMER_MODE=forward \
+CEREBRO_ORGANIZATIONAL_CONSUMER_NAME=organizational-graph-forward-v1 \
+CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID=forward-from-<end_sequence> \
+CEREBRO_ORGANIZATIONAL_CONSUMER_DELIVER_POLICY=by_start_sequence \
+CEREBRO_ORGANIZATIONAL_CONSUMER_START_SEQUENCE=<end_sequence+1> \
+cerebro-platform serve-neo4j-consumer
+```
+
+JetStream retains the forward checkpoint. Restart the service with the same
+consumer name, run ID, and start sequence.
+
+## Completion and authority prerequisite
+
+The process emits `cerebro.organizational-consumer-run/v1` JSON and persists the
+same progress in `organizational_consumer_runs`.
+
+A replay is materialization-complete only when all of these are true:
+
+- `status = 'completed'`;
+- `covered_sequence = end_sequence`;
+- `messages_projected > 0`;
+- `messages_rejected = 0`;
+- the forward run is `running`, uses a different consumer name, and has
+  `start_sequence = end_sequence + 1`.
+- the replay `completed_at` precedes the forward run `started_at`.
+
+`messages_skipped` is explicit. It includes retained events outside the
+portable organizational projection contract and must be reviewed before using
+the replay as parity evidence. Service health, Neo4j connectivity, messages
+seen, or a drained consumer alone are not authority-readiness signals.
+
+Emit the inspection payload from the same candidate:
+
+```sh
+CEREBRO_ORGANIZATIONAL_CONSUMER_NAME=organizational-graph-replay-<change-id> \
+CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID=<change-id> \
+cerebro-platform inspect-consumer-run
+```
+
+The output includes the materialization receipt and its SHA-256 digest. Typed
+read parity remains the semantic comparison; raw relation or assertion counts
+are not interchangeable.
+
+Use this query for the durable receipt:
+
+```sql
+SELECT consumer_name, run_id, mode, start_sequence, end_sequence,
+       last_delivered_sequence, covered_sequence, messages_seen, messages_projected,
+       messages_skipped, messages_rejected, status, updated_at, completed_at
+FROM organizational_consumer_runs
+WHERE (consumer_name, run_id) IN (
+  ('organizational-graph-replay-<change-id>', '<change-id>'),
+  ('organizational-graph-forward-v1', 'forward-from-<end_sequence>')
+);
+```
+
+Do not promote read or write authority until this receipt, projection parity,
+and the separate cutover gates all pass.

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -71,7 +71,7 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_ORGANIZATIONAL_GRAPH_URL` | unset | Legacy combined Rust graph origin. Prefer the separate read and projection origins so observing reads cannot activate a writer path. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL` | unset | Rust bounded graph read origin. This does not configure Rust projection writes. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_PROJECTION_URL` | unset | Rust family-authority and projection origin. Leave unset until the Rust writer path is intentionally enabled. |
-| `CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE` | `authority` | `shadow` returns the legacy result and compares sampled Rust reads; `canary` returns Rust for a stable sample; `authority` returns the Rust result and fails closed. |
+| `CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE` | `authority` | `legacy` keeps Go product reads authoritative without calling Rust; `shadow` returns the Go result and compares sampled Rust reads; `canary` assigns a stable tenant sample to Rust; `authority` returns Rust results and fails closed. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT` | `0` | Stable percentage from 1 through 100 of typed reads compared in shadow mode. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_AUTHORITY_PERCENT` | `0` | Stable percentage from 1 through 99 of tenants assigned to Rust for typed reads in canary mode. This is tenant allocation, not exact request share; measure actual Go and Rust request volume with `cerebro.organizational_graph.canary.routes`. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_CANARY_VERIFY_PERCENT` | `0` | Stable percentage from 0 through 100 of Rust-authority canary reads also compared with Go. Verification uses bounded background work, records parity evidence, and never delays or changes authority. |

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -77,5 +77,13 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_ORGANIZATIONAL_GRAPH_CANARY_VERIFY_PERCENT` | `0` | Stable percentage from 0 through 100 of Rust-authority canary reads also compared with Go. Verification uses bounded background work, records parity evidence, and never delays or changes authority. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET` | unset | Shared secret used to sign tenant-bound requests to the Rust organizational graph service. Required with any Rust graph origin; minimum 32 bytes. |
 | `CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT` | `1s` | Timeout for Rust organizational graph reads and projection-authority requests. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_MODE` | `forward` | `forward` for durable projection or `replay` for a bounded retained-history run. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_NAME` | `organizational-graph-v1` | Durable JetStream consumer identity. Replay requires a distinct explicit name. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_RUN_ID` | mode-specific | Stable PostgreSQL receipt identity reused across bounded invocations. Replay requires it. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_DELIVER_POLICY` | `new` | `new`, `all`, or `by_start_sequence`; replay rejects `new` and forward rejects `all`. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_START_SEQUENCE` | unset | Positive stream sequence required by `by_start_sequence`. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_END_SEQUENCE` | captured stream head | Immutable replay upper fence; rejected in forward mode. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_MAX_MESSAGES` | `100000` | Replay messages processed per invocation before a resumable stopped receipt. |
+| `CEREBRO_ORGANIZATIONAL_CONSUMER_MAX_RUNTIME_SECONDS` | `3600` | Replay seconds per invocation before a resumable stopped receipt. |
 
 `CEREBRO_KUZU_PATH` is rejected. Kuzu is no longer a supported graph backend.

--- a/internal/bootstrap/compliance_impact_runtime.go
+++ b/internal/bootstrap/compliance_impact_runtime.go
@@ -24,8 +24,8 @@ func (a *App) newComplianceImpactServices(jobs *platformjobs.Service, assessment
 	}
 
 	projectionStore, projectionOK := a.deps.GraphStore.(ports.ProjectionGraphStore)
-	queryStore, queryOK := a.deps.GraphStore.(ports.GraphQueryStore)
-	if !projectionOK || !queryOK || isNilInterface(projectionStore) || isNilInterface(queryStore) {
+	queryStore := dependencyGraphQueryStore(a.deps)
+	if !projectionOK || isNilInterface(projectionStore) || isNilInterface(queryStore) {
 		return monitorService, nil, nil
 	}
 	projector, err := complianceimpact.NewGraphProjector(projectionStore)

--- a/internal/bootstrap/compliance_impact_runtime_test.go
+++ b/internal/bootstrap/compliance_impact_runtime_test.go
@@ -35,6 +35,21 @@ func TestComplianceImpactServiceComposition(t *testing.T) {
 	}
 }
 
+func TestComplianceImpactUsesConfiguredReadAuthority(t *testing.T) {
+	t.Parallel()
+	app := &App{deps: Dependencies{
+		StateStore:   &monitorStateStub{},
+		GraphStore:   &projectionOnlyImpactGraphStub{},
+		GraphQueries: &queryOnlyImpactGraphStub{},
+		AppendLog:    bootstrapAppendOnlyLog{},
+	}}
+
+	monitors, projector, scheduler := app.newComplianceImpactServices(nil, nil)
+	if monitors == nil || projector == nil || scheduler == nil {
+		t.Fatalf("configured authority composition monitors=%v projector=%v scheduler=%v", monitors != nil, projector != nil, scheduler != nil)
+	}
+}
+
 func TestScheduledAssessmentRequesterCreatesCanonicalRun(t *testing.T) {
 	t.Parallel()
 	store := newAssessmentHTTPStore()
@@ -85,3 +100,15 @@ type impactGraphStub struct {
 }
 
 func (*impactGraphStub) Ping(context.Context) error { return nil }
+
+type projectionOnlyImpactGraphStub struct {
+	ports.ProjectionGraphStore
+}
+
+func (*projectionOnlyImpactGraphStub) Ping(context.Context) error { return nil }
+
+type queryOnlyImpactGraphStub struct {
+	ports.GraphQueryStore
+}
+
+func (*queryOnlyImpactGraphStub) Ping(context.Context) error { return nil }

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -104,12 +104,16 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 		deps.SourceCollectionReceipts = projectionClient
 	}
 	if readBaseURL != "" {
-		var compatibility ports.GraphQueryStore
-		if primary, ok := deps.GraphStore.(ports.GraphQueryStore); ok && !isNilInterface(primary) {
-			compatibility = primary
+		var compatibility ports.GraphNeighborhoodStore
+		if reader, ok := deps.GraphStore.(ports.GraphNeighborhoodStore); ok && !isNilInterface(reader) {
+			compatibility = reader
 		}
-		queryStore, err := organizationalgraph.NewConfiguredQueryStore(
-			compatibility, readBaseURL, cfg.OrganizationalGraph.SharedSecret,
+		var rawCypher ports.RawCypherQueryStore
+		if reader, ok := deps.GraphStore.(ports.RawCypherQueryStore); ok && !isNilInterface(reader) {
+			rawCypher = reader
+		}
+		queryStore, err := organizationalgraph.NewConfiguredQueryStoreWithCompatibility(
+			compatibility, rawCypher, readBaseURL, cfg.OrganizationalGraph.SharedSecret,
 			cfg.OrganizationalGraph.Timeout, cfg.OrganizationalGraph.ReadMode,
 			cfg.OrganizationalGraph.ShadowPercent, cfg.OrganizationalGraph.AuthorityPercent,
 			cfg.OrganizationalGraph.CanaryVerifyPercent,

--- a/internal/bootstrap/feature_dependencies_test.go
+++ b/internal/bootstrap/feature_dependencies_test.go
@@ -1,6 +1,10 @@
 package bootstrap
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/graphagent"
+)
 
 func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
 	deps := Dependencies{}
@@ -37,5 +41,31 @@ func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
 	}
 	if got := newGraphReasoningFeatureDeps(deps); got.GraphQueries != nil || got.GraphAgentLLM != nil || got.TrajectoryStore != nil {
 		t.Fatalf("newGraphReasoningFeatureDeps() = %#v, want nil dependencies", got)
+	}
+}
+
+func TestProductReadDependencyBundlesPreferConfiguredAuthority(t *testing.T) {
+	legacy := &stubGraphStore{}
+	authority := &stubGraphStore{}
+	deps := Dependencies{
+		GraphStore:    legacy,
+		GraphQueries:  authority,
+		GraphAgentLLM: graphagent.NewStubLLMClient(),
+	}
+
+	if got := newReportFeatureDeps(deps).GraphQueries; got != authority {
+		t.Fatalf("report graph queries = %#v, want configured authority", got)
+	}
+	if got := newFindingFeatureDeps(deps).GraphQueries; got != authority {
+		t.Fatalf("finding graph queries = %#v, want configured authority", got)
+	}
+	if got := newKnowledgeFeatureDeps(deps).GraphQueries; got != authority {
+		t.Fatalf("knowledge graph queries = %#v, want configured authority", got)
+	}
+	if got := newGraphQueryFeatureDeps(deps).GraphQueries; got != authority {
+		t.Fatalf("graph query service = %#v, want configured authority", got)
+	}
+	if got := newGraphReasoningFeatureDeps(deps).GraphQueries; got != authority {
+		t.Fatalf("graph reasoning queries = %#v, want configured authority", got)
 	}
 }

--- a/internal/bootstrap/policy_candidates.go
+++ b/internal/bootstrap/policy_candidates.go
@@ -181,10 +181,7 @@ func (a *App) policyCandidateService() policycandidate.Service {
 	store, _ := a.deps.StateStore.(policycandidate.Store)
 	experiments, _ := a.deps.StateStore.(policycandidate.ExperimentStore)
 	datasets, _ := a.deps.StateStore.(policycandidate.PolicyEvaluationDatasetStore)
-	var graph ports.GraphQueryStore
-	if candidate, ok := a.deps.GraphStore.(ports.GraphQueryStore); ok {
-		graph = candidate
-	}
+	graph := dependencyGraphQueryStore(a.deps)
 	var author *agentauthoring.Service
 	if a.deps.PolicyAuthoring != nil {
 		copy := *a.deps.PolicyAuthoring

--- a/internal/bootstrap/policy_candidates_test.go
+++ b/internal/bootstrap/policy_candidates_test.go
@@ -1,14 +1,42 @@
 package bootstrap
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/writer/cerebro/internal/agentauthoring"
 	"github.com/writer/cerebro/internal/policycandidate"
 	policyauthor "github.com/writer/cerebro/internal/testauthor/policy"
 )
+
+func TestPolicyCandidateReadsUseConfiguredAuthority(t *testing.T) {
+	legacy := &policyGraphStoreStub{stubGraphStore: &stubGraphStore{}}
+	authority := &stubGraphStore{}
+	app := &App{deps: Dependencies{
+		GraphStore:      legacy,
+		GraphQueries:    authority,
+		PolicyAuthoring: &agentauthoring.Service{},
+	}}
+
+	service := app.policyCandidateService()
+	if service.Graph != authority {
+		t.Fatalf("policy candidate graph = %#v, want configured authority", service.Graph)
+	}
+	if service.Author == nil || any(service.Author.PolicyGraphStore) != any(legacy) {
+		t.Fatalf("policy fixture store = %#v, want explicit compatibility store", service.Author)
+	}
+}
+
+type policyGraphStoreStub struct {
+	*stubGraphStore
+}
+
+func (*policyGraphStoreStub) DeleteProjectedEntity(context.Context, string) error {
+	return nil
+}
 
 func TestPolicyCandidateViewOmitsPrivateOriginAndRawEvidence(t *testing.T) {
 	candidate := &policycandidate.Candidate{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -697,10 +697,12 @@ func Load() (Config, error) {
 	if cfg.OrganizationalGraph.ReadMode == "" {
 		cfg.OrganizationalGraph.ReadMode = "authority"
 	}
-	if cfg.OrganizationalGraph.ReadMode != "authority" &&
+	explicitOrganizationalGraphReadMode := strings.TrimSpace(os.Getenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE")) != ""
+	if cfg.OrganizationalGraph.ReadMode != "legacy" &&
+		cfg.OrganizationalGraph.ReadMode != "authority" &&
 		cfg.OrganizationalGraph.ReadMode != "shadow" &&
 		cfg.OrganizationalGraph.ReadMode != "canary" {
-		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE must be authority, shadow, or canary")
+		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE must be legacy, shadow, canary, or authority")
 	}
 	if cfg.OrganizationalGraph.ShadowPercent, err = parseIntEnv("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT", 0); err != nil {
 		return Config{}, err
@@ -713,6 +715,11 @@ func Load() (Config, error) {
 	}
 	if cfg.OrganizationalGraph.ReadMode == "canary" && cfg.OrganizationalGraph.ReadBaseURL == "" {
 		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL is required in canary mode")
+	}
+	if explicitOrganizationalGraphReadMode &&
+		cfg.OrganizationalGraph.ReadMode == "authority" &&
+		cfg.OrganizationalGraph.ReadBaseURL == "" {
+		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL is required in authority mode")
 	}
 	if cfg.OrganizationalGraph.ReadMode == "shadow" && cfg.OrganizationalGraph.ShadowPercent == 0 {
 		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT must be greater than zero in shadow mode")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -247,6 +247,32 @@ func TestLoadAcceptsBoundedRustGraphCanaryConfiguration(t *testing.T) {
 	}
 }
 
+func TestLoadAcceptsExplicitLegacyGraphRollbackMode(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL", "http://127.0.0.1:8081")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE", "legacy")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET", "test-organizational-graph-secret-32-bytes")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.OrganizationalGraph.ReadMode != "legacy" ||
+		cfg.OrganizationalGraph.ShadowPercent != 0 ||
+		cfg.OrganizationalGraph.AuthorityPercent != 0 {
+		t.Fatalf("OrganizationalGraph = %#v", cfg.OrganizationalGraph)
+	}
+}
+
+func TestLoadRejectsExplicitRustAuthorityWithoutReadEndpoint(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE", "authority")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
 func TestLoadRejectsUnsafeRustGraphCanaryConfiguration(t *testing.T) {
 	for name, value := range map[string]string{
 		"missing endpoint": "10",

--- a/internal/ports/graphquery.go
+++ b/internal/ports/graphquery.go
@@ -62,11 +62,25 @@ type CypherPlanNode struct {
 // MaxCypherQueryRows caps the number of rows the graph store will return for one read query.
 const MaxCypherQueryRows = 3000
 
-// GraphQueryStore exposes bounded graph neighborhood reads and read-only Cypher.
-type GraphQueryStore interface {
+// GraphNeighborhoodStore exposes bounded product graph reads.
+type GraphNeighborhoodStore interface {
 	GraphStore
 	GetEntityNeighborhood(context.Context, string, int) (*EntityNeighborhood, error)
+}
+
+// RawCypherQueryStore is the retained compatibility surface for callers that
+// have not migrated to bounded typed Rust operations.
+type RawCypherQueryStore interface {
+	GraphStore
 	ExecuteReadCypher(context.Context, CypherQueryRequest) ([]CypherRow, error)
+}
+
+// GraphQueryStore is the transitional composite consumed by existing product
+// packages. The authority adapter serves typed reads from Rust and delegates
+// only raw Cypher through RawCypherQueryStore.
+type GraphQueryStore interface {
+	GraphNeighborhoodStore
+	RawCypherQueryStore
 }
 
 // GraphNeighborhoodBatchStore exposes batched bounded graph neighborhood reads.

--- a/internal/sourcehttp/organizationalgraph/query.go
+++ b/internal/sourcehttp/organizationalgraph/query.go
@@ -50,13 +50,15 @@ const (
 	readModeAuthority readMode = iota
 	readModeShadow
 	readModeCanary
+	readModeLegacy
 )
 
 // QueryStore serves bounded product reads from Rust. When a compatibility
 // reader is present, callers not yet moved from raw Cypher can still use it.
 // Without one, those callers fail explicitly instead of falling back.
 type QueryStore struct {
-	compatibility ports.GraphQueryStore
+	compatibility ports.GraphNeighborhoodStore
+	rawCypher     ports.RawCypherQueryStore
 	baseURL       string
 	httpClient    *http.Client
 	graph         cerebrographv1connect.OrganizationalGraphServiceClient
@@ -78,19 +80,82 @@ func ReadinessStore(compatibility, authority ports.GraphStore) ports.GraphStore 
 }
 
 func NewQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration) (*QueryStore, error) {
-	return newQueryStore(compatibility, baseURL, sharedSecret, timeout, readModeAuthority, 100)
+	return newQueryStore(compatibility, compatibility, baseURL, sharedSecret, timeout, readModeAuthority, 100)
 }
 
 // NewConfiguredQueryStore selects one validated deployment read strategy.
 func NewConfiguredQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration, mode string, shadowPercent, authorityPercent, canaryVerifyPercent int) (*QueryStore, error) {
+	return NewConfiguredQueryStoreWithCompatibility(
+		compatibility,
+		compatibility,
+		baseURL,
+		sharedSecret,
+		timeout,
+		mode,
+		shadowPercent,
+		authorityPercent,
+		canaryVerifyPercent,
+	)
+}
+
+// NewConfiguredQueryStoreWithCompatibility keeps typed Go rollback reads
+// separate from raw Cypher compatibility. Authority mode needs only the raw
+// compatibility port; legacy, shadow, and canary also require typed Go reads.
+func NewConfiguredQueryStoreWithCompatibility(
+	compatibility ports.GraphNeighborhoodStore,
+	rawCypher ports.RawCypherQueryStore,
+	baseURL, sharedSecret string,
+	timeout time.Duration,
+	mode string,
+	shadowPercent, authorityPercent, canaryVerifyPercent int,
+) (*QueryStore, error) {
 	switch mode {
+	case "legacy":
+		if compatibility == nil {
+			return nil, errors.New("legacy graph reads require the compatibility store")
+		}
+		return newQueryStore(compatibility, rawCypher, baseURL, sharedSecret, timeout, readModeLegacy, 0)
 	case "shadow":
-		return NewShadowQueryStore(compatibility, baseURL, sharedSecret, timeout, shadowPercent)
+		if compatibility == nil {
+			return nil, errors.New("shadow graph reads require the legacy compatibility store")
+		}
+		if shadowPercent <= 0 || shadowPercent > 100 {
+			return nil, errors.New("shadow graph read percent must be between 1 and 100")
+		}
+		return newQueryStore(compatibility, rawCypher, baseURL, sharedSecret, timeout, readModeShadow, uint32(shadowPercent)) // #nosec G115 -- validated above.
 	case "canary":
-		return NewVerifiedCanaryQueryStore(compatibility, baseURL, sharedSecret, timeout, authorityPercent, canaryVerifyPercent)
+		if compatibility == nil {
+			return nil, errors.New("canary graph reads require the legacy compatibility store")
+		}
+		if authorityPercent <= 0 || authorityPercent >= 100 {
+			return nil, errors.New("canary graph read percent must be between 1 and 99")
+		}
+		if canaryVerifyPercent < 0 || canaryVerifyPercent > 100 {
+			return nil, errors.New("canary graph verification percent must be between 0 and 100")
+		}
+		store, err := newQueryStore(compatibility, rawCypher, baseURL, sharedSecret, timeout, readModeCanary, uint32(authorityPercent)) // #nosec G115 -- validated above.
+		if err != nil {
+			return nil, err
+		}
+		store.verifyPercent = uint32(canaryVerifyPercent) // #nosec G115 -- validated above.
+		return store, nil
+	case "", "authority":
+		// Config.Load normalizes an omitted mode to authority. Accept the zero
+		// value here as well for callers that construct Config directly.
+		return newQueryStore(compatibility, rawCypher, baseURL, sharedSecret, timeout, readModeAuthority, 100)
 	default:
-		return NewQueryStore(compatibility, baseURL, sharedSecret, timeout)
+		return nil, fmt.Errorf("unsupported organizational graph read mode %q", mode)
 	}
+}
+
+// NewLegacyQueryStore keeps Go as the explicit product-read authority while a
+// deployment rolls back or completes Rust qualification. It does not call the
+// Rust read plane.
+func NewLegacyQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration) (*QueryStore, error) {
+	if compatibility == nil {
+		return nil, errors.New("legacy graph reads require the compatibility store")
+	}
+	return newQueryStore(compatibility, compatibility, baseURL, sharedSecret, timeout, readModeLegacy, 0)
 }
 
 func NewShadowQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration, shadowPercent int) (*QueryStore, error) {
@@ -100,7 +165,7 @@ func NewShadowQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSec
 	if shadowPercent <= 0 || shadowPercent > 100 {
 		return nil, errors.New("shadow graph read percent must be between 1 and 100")
 	}
-	return newQueryStore(compatibility, baseURL, sharedSecret, timeout, readModeShadow, uint32(shadowPercent)) // #nosec G115 -- validated above.
+	return newQueryStore(compatibility, compatibility, baseURL, sharedSecret, timeout, readModeShadow, uint32(shadowPercent)) // #nosec G115 -- validated above.
 }
 
 // NewCanaryQueryStore returns Rust responses for one stable sample of typed
@@ -123,7 +188,7 @@ func NewVerifiedCanaryQueryStore(compatibility ports.GraphQueryStore, baseURL, s
 	if verifyPercent < 0 || verifyPercent > 100 {
 		return nil, errors.New("canary graph verification percent must be between 0 and 100")
 	}
-	store, err := newQueryStore(compatibility, baseURL, sharedSecret, timeout, readModeCanary, uint32(authorityPercent)) // #nosec G115 -- validated above.
+	store, err := newQueryStore(compatibility, compatibility, baseURL, sharedSecret, timeout, readModeCanary, uint32(authorityPercent)) // #nosec G115 -- validated above.
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +196,7 @@ func NewVerifiedCanaryQueryStore(compatibility ports.GraphQueryStore, baseURL, s
 	return store, nil
 }
 
-func newQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration, mode readMode, samplePercent uint32) (*QueryStore, error) {
+func newQueryStore(compatibility ports.GraphNeighborhoodStore, rawCypher ports.RawCypherQueryStore, baseURL, sharedSecret string, timeout time.Duration, mode readMode, samplePercent uint32) (*QueryStore, error) {
 	baseURL, err := normalizeBaseURL(baseURL)
 	if err != nil {
 		return nil, err
@@ -146,6 +211,7 @@ func newQueryStore(compatibility ports.GraphQueryStore, baseURL, sharedSecret st
 	httpClient := &http.Client{Timeout: timeout}
 	return &QueryStore{
 		compatibility: compatibility,
+		rawCypher:     rawCypher,
 		baseURL:       baseURL,
 		httpClient:    httpClient,
 		graph:         cerebrographv1connect.NewOrganizationalGraphServiceClient(httpClient, baseURL),
@@ -215,18 +281,37 @@ func (s *QueryStore) ResolveSecurityLifecycleFinding(ctx context.Context, tenant
 }
 
 func (s *QueryStore) Ping(ctx context.Context) (err error) {
-	if s.compatibility != nil {
-		if err := s.compatibility.Ping(ctx); err != nil {
-			return fmt.Errorf("compatibility graph health: %w", err)
+	switch s.mode {
+	case readModeAuthority:
+		return s.pingRust(ctx)
+	case readModeLegacy:
+		return s.pingCompatibility(ctx)
+	case readModeShadow:
+		if err := s.pingCompatibility(ctx); err != nil {
+			return err
 		}
-	}
-	if s.mode == readModeShadow || s.mode == readModeCanary {
 		s.scheduleShadowComparison(ctx, "readiness", nil, func(comparisonCtx context.Context) (any, error) {
 			return nil, s.pingRust(comparisonCtx)
 		})
 		return nil
+	case readModeCanary:
+		if err := s.pingCompatibility(ctx); err != nil {
+			return err
+		}
+		return s.pingRust(ctx)
+	default:
+		return errors.New("organizational graph read mode is invalid")
 	}
-	return s.pingRust(ctx)
+}
+
+func (s *QueryStore) pingCompatibility(ctx context.Context) error {
+	if s.compatibility == nil {
+		return errors.New("compatibility graph is unavailable")
+	}
+	if err := s.compatibility.Ping(ctx); err != nil {
+		return fmt.Errorf("compatibility graph health: %w", err)
+	}
+	return nil
 }
 
 func (s *QueryStore) pingRust(ctx context.Context) (err error) {
@@ -252,6 +337,9 @@ func (s *QueryStore) pingRust(ctx context.Context) (err error) {
 }
 
 func (s *QueryStore) GetEntityNeighborhood(ctx context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
+	if s.mode == readModeLegacy {
+		return s.compatibility.GetEntityNeighborhood(ctx, rootURN, limit)
+	}
 	if s.mode == readModeCanary {
 		tenantID := cerebrourn.TenantID(strings.TrimSpace(rootURN))
 		if tenantID == "" {
@@ -317,6 +405,9 @@ func (s *QueryStore) getRustEntityNeighborhood(ctx context.Context, rootURN stri
 }
 
 func (s *QueryStore) GetEntityNeighborhoods(ctx context.Context, rootURNs []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
+	if s.mode == readModeLegacy {
+		return legacyNeighborhoods(ctx, s.compatibility, rootURNs, limit)
+	}
 	sampleKey := strings.Join(rootURNs, "\x00")
 	if s.mode == readModeCanary {
 		tenantID, err := graphRootsTenant(rootURNs)
@@ -432,7 +523,7 @@ func graphRootsTenant(rootURNs []string) (string, error) {
 	return tenantID, nil
 }
 
-func legacyNeighborhoods(ctx context.Context, store ports.GraphQueryStore, roots []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
+func legacyNeighborhoods(ctx context.Context, store ports.GraphNeighborhoodStore, roots []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
 	if batch, ok := store.(ports.GraphNeighborhoodBatchStore); ok {
 		return batch.GetEntityNeighborhoods(ctx, roots, limit)
 	}
@@ -703,17 +794,17 @@ func digestBytes(value []byte) string {
 }
 
 func (s *QueryStore) ExecuteReadCypher(ctx context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
-	if s.compatibility == nil {
+	if s.rawCypher == nil {
 		return nil, ports.ErrGraphTypedOperationRequired
 	}
-	return s.compatibility.ExecuteReadCypher(ctx, request)
+	return s.rawCypher.ExecuteReadCypher(ctx, request)
 }
 
 func (s *QueryStore) CountProjectedLinksMissingAssertions(ctx context.Context, tenantID string, relations []string) (uint32, error) {
-	if s.compatibility == nil {
+	if s.rawCypher == nil {
 		return 0, ports.ErrGraphTypedOperationRequired
 	}
-	store, ok := s.compatibility.(ports.ProjectionAssertionCoverageStore)
+	store, ok := s.rawCypher.(ports.ProjectionAssertionCoverageStore)
 	if !ok {
 		return 0, errors.New("compatibility graph store does not support projection assertion coverage")
 	}
@@ -721,10 +812,10 @@ func (s *QueryStore) CountProjectedLinksMissingAssertions(ctx context.Context, t
 }
 
 func (s *QueryStore) MigrateProjectedLinkAssertions(ctx context.Context, request ports.ProjectionAssertionMigrationRequest) (ports.ProjectionAssertionMigrationResult, error) {
-	if s.compatibility == nil {
+	if s.rawCypher == nil {
 		return ports.ProjectionAssertionMigrationResult{}, ports.ErrGraphTypedOperationRequired
 	}
-	store, ok := s.compatibility.(ports.ProjectionAssertionMigrator)
+	store, ok := s.rawCypher.(ports.ProjectionAssertionMigrator)
 	if !ok {
 		return ports.ProjectionAssertionMigrationResult{}, errors.New("compatibility graph store does not support projection assertion migration")
 	}

--- a/internal/sourcehttp/organizationalgraph/query.go
+++ b/internal/sourcehttp/organizationalgraph/query.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"go.opentelemetry.io/otel/trace"
 
 	cerebrographv1 "github.com/writer/cerebro/gen/cerebro/graph/v1"
 	"github.com/writer/cerebro/gen/cerebro/graph/v1/cerebrographv1connect"
@@ -27,6 +26,7 @@ import (
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/observability"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
 
@@ -630,9 +630,7 @@ func (s *QueryStore) recordCanaryRoute(ctx context.Context, operation, authority
 
 func (s *QueryStore) recordCanaryVerification(ctx context.Context, operation string, legacy any, legacyErr error, rust any, started time.Time) {
 	status := comparisonStatus(legacy, legacyErr, rust, nil)
-	if status != "match" {
-		logComparisonReceipt(ctx, operation, status, legacy, rust, legacyErr)
-	}
+	logComparisonReceipt(ctx, operation, status, legacy, rust, legacyErr)
 	observability.RecordOrganizationalGraphCanaryVerification(ctx, observability.OrganizationalGraphCanaryVerificationMetrics{
 		Operation: operation,
 		Status:    status,
@@ -642,9 +640,7 @@ func (s *QueryStore) recordCanaryVerification(ctx context.Context, operation str
 
 func (s *QueryStore) recordComparison(ctx context.Context, operation string, legacy, rust any, rustErr error, started time.Time) {
 	status := comparisonStatus(legacy, nil, rust, rustErr)
-	if status != "match" {
-		logComparisonReceipt(ctx, operation, status, legacy, rust, rustErr)
-	}
+	logComparisonReceipt(ctx, operation, status, legacy, rust, rustErr)
 	observability.RecordOrganizationalGraphShadow(ctx, observability.OrganizationalGraphShadowMetrics{
 		Operation: operation,
 		Status:    status,
@@ -677,20 +673,15 @@ func logComparisonReceipt(ctx context.Context, operation, status string, legacy,
 	if comparisonErr != nil {
 		errorDigest = digestString(comparisonErr.Error())
 	}
-	traceID := trace.SpanContextFromContext(ctx).TraceID().String()
-	// #nosec G706 -- operation and status use closed vocabularies; trace IDs
-	// and every receipt value are locally generated hex, counts, or type names.
-	log.Printf(
-		"organizational graph parity operation=%s status=%s trace_id=%s legacy_sha256=%s rust_sha256=%s legacy_shape=%q rust_shape=%q error_sha256=%s",
-		operation,
-		status,
-		traceID,
-		legacyDigest,
-		rustDigest,
-		legacyShape,
-		rustShape,
-		errorDigest,
-	)
+	telemetry.Event(ctx, "organizational_graph.parity_receipt", telemetry.Attrs(
+		telemetry.Field{Key: "operation", Value: operation},
+		telemetry.Field{Key: "status", Value: status},
+		telemetry.Field{Key: "legacy_sha256", Value: legacyDigest},
+		telemetry.Field{Key: "rust_sha256", Value: rustDigest},
+		telemetry.Field{Key: "legacy_shape", Value: legacyShape},
+		telemetry.Field{Key: "rust_shape", Value: rustShape},
+		telemetry.Field{Key: "error_sha256", Value: errorDigest},
+	))
 }
 
 func comparisonReceipt(value any) (string, string) {

--- a/internal/sourcehttp/organizationalgraph/query_test.go
+++ b/internal/sourcehttp/organizationalgraph/query_test.go
@@ -26,6 +26,10 @@ type queryStoreStub struct {
 	err          error
 }
 
+type rawCypherOnlyStub struct {
+	rows []ports.CypherRow
+}
+
 type countingQueryStoreStub struct {
 	queryStoreStub
 	requests atomic.Int64
@@ -70,6 +74,12 @@ func newGraphTestServer(t *testing.T, service graphServiceStub) *httptest.Server
 }
 
 func (s queryStoreStub) Ping(context.Context) error { return s.err }
+
+func (s rawCypherOnlyStub) Ping(context.Context) error { return nil }
+
+func (s rawCypherOnlyStub) ExecuteReadCypher(context.Context, ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	return s.rows, nil
+}
 
 func (s queryStoreStub) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
 	return s.neighborhood, nil
@@ -181,6 +191,65 @@ func TestQueryStoreReturnsRustNeighborhoodAndDelegatesRawCypher(t *testing.T) {
 	rows, err := store.ExecuteReadCypher(context.Background(), ports.CypherQueryRequest{Query: "RETURN 1"})
 	if err != nil || len(rows) != 1 || rows[0].Values["authority"] != "go" {
 		t.Fatalf("ExecuteReadCypher() = %#v, %v", rows, err)
+	}
+}
+
+func TestAuthorityKeepsRawCypherWithoutGoTypedReads(t *testing.T) {
+	server := newGraphTestServer(t, graphServiceStub{
+		expand: func(_ context.Context, request *connect.Request[cerebrographv1.ExpandRequest]) (*connect.Response[cerebrographv1.ExpandResponse], error) {
+			return connect.NewResponse(&cerebrographv1.ExpandResponse{
+				TenantId: request.Msg.GetTenantId(),
+				Root: &cerebrographv1.GraphEntity{
+					EntityId:   "rust-root",
+					AgentKey:   request.Msg.GetRootKey(),
+					EntityKind: "resource",
+					Label:      "Rust",
+				},
+			}), nil
+		},
+	})
+	defer server.Close()
+
+	raw := rawCypherOnlyStub{rows: []ports.CypherRow{{Values: map[string]any{"compatibility": "go"}}}}
+	store, err := NewConfiguredQueryStoreWithCompatibility(
+		nil,
+		raw,
+		server.URL,
+		testSharedSecret,
+		time.Second,
+		"authority",
+		0,
+		0,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("NewConfiguredQueryStoreWithCompatibility() error = %v", err)
+	}
+	root := "urn:cerebro:tenant-a:resource:one"
+	neighborhood, err := store.GetEntityNeighborhood(context.Background(), root, 10)
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+	if neighborhood.Root == nil || neighborhood.Root.URN != root || neighborhood.Root.Label != "Rust" {
+		t.Fatalf("GetEntityNeighborhood() = %#v", neighborhood)
+	}
+	rows, err := store.ExecuteReadCypher(context.Background(), ports.CypherQueryRequest{Query: "RETURN 1"})
+	if err != nil || len(rows) != 1 || rows[0].Values["compatibility"] != "go" {
+		t.Fatalf("ExecuteReadCypher() = %#v, %v", rows, err)
+	}
+
+	if _, err := NewConfiguredQueryStoreWithCompatibility(
+		nil,
+		raw,
+		server.URL,
+		testSharedSecret,
+		time.Second,
+		"legacy",
+		0,
+		0,
+		0,
+	); err == nil {
+		t.Fatal("legacy mode without Go typed reads error = nil")
 	}
 }
 
@@ -654,26 +723,31 @@ func TestCanaryQueryStoreRequiresCompatibilityAndBoundedSampling(t *testing.T) {
 	}
 }
 
-func TestCanaryQueryStoreReadinessUsesCompatibilityAuthority(t *testing.T) {
+func TestCanaryQueryStoreReadinessRequiresBothAuthorities(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
 	store, err := NewCanaryQueryStore(
 		queryStoreStub{},
-		"http://127.0.0.1:1",
+		server.URL,
 		testSharedSecret,
-		10*time.Millisecond,
+		time.Second,
 		50,
 	)
 	if err != nil {
 		t.Fatalf("NewCanaryQueryStore() error = %v", err)
 	}
 	if err := store.Ping(context.Background()); err != nil {
-		t.Fatalf("Ping() error = %v, canary readiness must keep the compatibility cohort available", err)
+		t.Fatalf("Ping() error = %v, canary readiness requires both cohorts", err)
 	}
 
 	store, err = NewCanaryQueryStore(
 		queryStoreStub{err: errors.New("compatibility unavailable")},
-		"http://127.0.0.1:1",
+		server.URL,
 		testSharedSecret,
-		10*time.Millisecond,
+		time.Second,
 		50,
 	)
 	if err != nil {
@@ -705,7 +779,7 @@ func waitForRequestCount(t *testing.T, store *countingQueryStoreStub, want int) 
 	}
 }
 
-func TestQueryStoreHealthRequiresRustAndChecksCompatibilityWhenPresent(t *testing.T) {
+func TestAuthorityHealthRequiresOnlyRust(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
@@ -747,11 +821,11 @@ func TestQueryStoreHealthRequiresRustAndChecksCompatibilityWhenPresent(t *testin
 	if err != nil {
 		t.Fatalf("NewQueryStore(failing compatibility) error = %v", err)
 	}
-	if err := store.Ping(context.Background()); err == nil {
-		t.Fatal("Ping(failing compatibility) error = nil")
+	if err := store.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping(failing compatibility) error = %v, Rust authority must not depend on Go health", err)
 	}
-	if requests != 2 {
-		t.Fatalf("health requests after compatibility failure = %d, want 2", requests)
+	if requests != 3 {
+		t.Fatalf("health requests after compatibility failure = %d, want 3", requests)
 	}
 
 	compatibility := queryStoreStub{}
@@ -760,6 +834,76 @@ func TestQueryStoreHealthRequiresRustAndChecksCompatibilityWhenPresent(t *testin
 	}
 	if got := ReadinessStore(compatibility, store); got != store {
 		t.Fatalf("ReadinessStore(compatibility, authority) = %#v", got)
+	}
+}
+
+func TestLegacyModeIsExplicitGoAuthorityAndDoesNotCallRust(t *testing.T) {
+	rustRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		rustRequests++
+		http.Error(w, "must not be called", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	legacy := &countingQueryStoreStub{
+		queryStoreStub: queryStoreStub{
+			neighborhood: &ports.EntityNeighborhood{Root: &ports.NeighborhoodNode{URN: "legacy"}},
+		},
+	}
+	store, err := NewConfiguredQueryStore(
+		legacy,
+		server.URL,
+		testSharedSecret,
+		time.Second,
+		"legacy",
+		0,
+		0,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("NewConfiguredQueryStore(legacy) error = %v", err)
+	}
+	if err := store.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping(legacy) error = %v", err)
+	}
+	got, err := store.GetEntityNeighborhood(context.Background(), "urn:cerebro:tenant-a:resource:one", 10)
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood(legacy) error = %v", err)
+	}
+	if got == nil || got.Root == nil || got.Root.URN != "legacy" {
+		t.Fatalf("GetEntityNeighborhood(legacy) = %#v", got)
+	}
+	if legacy.requestCount() != 1 || rustRequests != 0 {
+		t.Fatalf("legacy requests = %d, Rust requests = %d", legacy.requestCount(), rustRequests)
+	}
+}
+
+func TestCanaryHealthFailsClosedWhenEitherAuthorityIsUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	store, err := NewCanaryQueryStore(queryStoreStub{}, server.URL, testSharedSecret, time.Second, 10)
+	if err != nil {
+		t.Fatalf("NewCanaryQueryStore() error = %v", err)
+	}
+	if err := store.Ping(context.Background()); err == nil {
+		t.Fatal("Ping(canary with Rust unavailable) error = nil")
+	}
+
+	store, err = NewCanaryQueryStore(
+		queryStoreStub{err: errors.New("compatibility unavailable")},
+		server.URL,
+		testSharedSecret,
+		time.Second,
+		10,
+	)
+	if err != nil {
+		t.Fatalf("NewCanaryQueryStore(failing compatibility) error = %v", err)
+	}
+	if err := store.Ping(context.Background()); err == nil {
+		t.Fatal("Ping(canary with compatibility unavailable) error = nil")
 	}
 }
 

--- a/internal/sourcehttp/organizationalgraph/query_test.go
+++ b/internal/sourcehttp/organizationalgraph/query_test.go
@@ -2,8 +2,10 @@ package organizationalgraph
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1191,6 +1193,46 @@ func TestComparisonIgnoresSetOrderingButDetectsContentChanges(t *testing.T) {
 	rust.Neighbors[0] = &ports.NeighborhoodNode{URN: nodeTwo.URN, Label: "Changed"}
 	if status := comparisonStatus(legacy, nil, rust, nil); status != "mismatch" {
 		t.Fatalf("comparisonStatus(changed) = %q, want mismatch", status)
+	}
+}
+
+func TestComparisonReceiptEmitsSuccessfulBoundedEvidence(t *testing.T) {
+	oldStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	value := &ports.EntityNeighborhood{
+		Root: &ports.NeighborhoodNode{URN: "urn:cerebro:tenant-a:resource:root"},
+	}
+	logComparisonReceipt(context.Background(), "expand", "match", value, value, nil)
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(encoded, &receipt); err != nil {
+		t.Fatalf("unmarshal receipt %q: %v", encoded, err)
+	}
+	if receipt["kind"] != "event" || receipt["name"] != "organizational_graph.parity_receipt" {
+		t.Fatalf("unexpected receipt identity: %#v", receipt)
+	}
+	if receipt["operation"] != "expand" || receipt["status"] != "match" {
+		t.Fatalf("unexpected receipt scope: %#v", receipt)
+	}
+	if receipt["legacy_sha256"] == "" || receipt["legacy_sha256"] != receipt["rust_sha256"] {
+		t.Fatalf("unexpected receipt digests: %#v", receipt)
+	}
+	if _, found := receipt["tenant_id"]; found {
+		t.Fatalf("receipt must not contain tenant identifiers: %#v", receipt)
 	}
 }
 

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -135,7 +135,7 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	for _, required := range []string{
 		"NewOrganizationalGraphServiceClient",
 		".ExpandBatch(ctx, request)",
-		"compatibility.ExecuteReadCypher",
+		"rawCypher.ExecuteReadCypher",
 		"ErrGraphTypedOperationRequired",
 		"maxBatchRoots",
 		"GetAgentKey",
@@ -161,6 +161,27 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	} {
 		if !strings.Contains(queryAdapter, required) {
 			t.Errorf("bounded shadow comparison missing enforced safety boundary %q", required)
+		}
+	}
+
+	for _, productionPath := range []string{
+		"internal/bootstrap/compliance_impact_runtime.go",
+		"internal/bootstrap/policy_candidates.go",
+		"cmd/cerebro/orchestrator.go",
+		"cmd/cerebro/finding_rule_graph_evaluate.go",
+	} {
+		source := readText(t, filepath.Join(root, filepath.FromSlash(productionPath)))
+		if !strings.Contains(source, "dependencyGraphQueryStore(") {
+			t.Errorf("%s bypasses configured Rust graph authority", productionPath)
+		}
+	}
+	for _, bootstrapPath := range []string{
+		"internal/bootstrap/compliance_impact_runtime.go",
+		"internal/bootstrap/policy_candidates.go",
+	} {
+		source := readText(t, filepath.Join(root, filepath.FromSlash(bootstrapPath)))
+		if strings.Contains(source, "deps.GraphStore.(ports.GraphQueryStore)") {
+			t.Errorf("%s restored direct Go product-read authority", bootstrapPath)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- add explicit legacy, shadow, canary, and authority routing for organizational graph reads
- add a resumable, fenced Rust projection replay and forward-consumer handoff
- require durable projection and parity evidence before authority promotion

## Validation

- Rust platform and organizational store tests
- Rust clippy with warnings denied
- affected Go package tests
- structural and architecture checks
- public disclosure, documentation drift, and contract checks

## Compatibility

Legacy authority remains the default. Promotion states fail closed when the Rust authority or its persisted cutover evidence is unavailable.