### PR TITLE
Route Slack questions through Rust authority

### DIFF
--- a/apps/slack-companion-host/src/preview-main.ts
+++ b/apps/slack-companion-host/src/preview-main.ts
@@ -29,6 +29,7 @@ async function main(): Promise<void> {
     tenantId: required(process.env.CEREBRO_TENANT_ID),
   });
   const result = await client.ask(
+    "preview-request",
     "Which security sources are configured and healthy? Use read-only evidence and state any evidence gaps.",
     AbortSignal.timeout(120_000),
   );

--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -7,6 +7,7 @@ export type AssistantTurnSourceGapState =
 
 export interface CerebroAskResult {
   citationValidationPassed: boolean;
+  executionLane: "converse" | "lookup";
   markdown: string;
   safeRefusal: boolean;
   traceId?: string;
@@ -47,17 +48,26 @@ export class CerebroAskClient {
     question: string,
     signal: AbortSignal,
     history: readonly CerebroAskHistoryMessage[] = [],
+    authorizedQuestion?: SlackQuestionDecision,
   ): Promise<CerebroAskResult> {
-    try {
-      await this.options.answerAuthority.authorizeQuestion({
-        history: history.map((message) => ({ ...message })),
-        question,
-        request_id: requestId,
-        schema_version: "slack-question-candidate/v1",
-        tenant_id: this.options.tenantId,
-      });
-    } catch (error: unknown) {
-      throw new CerebroAskError("unauthorized", errorMessage(error));
+    const questionDecision = authorizedQuestion
+      ?? await this.authorizeQuestion(requestId, question, history);
+    if (
+      questionDecision.request_id !== requestId
+      || questionDecision.tenant_id !== this.options.tenantId
+    ) {
+      throw new CerebroAskError(
+        "unauthorized",
+        "Rust Slack authority returned a decision for another question request.",
+      );
+    }
+    if (questionDecision.execution_lane === "converse") {
+      return {
+        citationValidationPassed: false,
+        executionLane: "converse",
+        markdown: questionDecision.answer,
+        safeRefusal: false,
+      };
     }
     const response = await this.fetchImpl(`${this.options.baseUrl}/grc/ask`, {
       method: "POST",
@@ -135,10 +145,29 @@ export class CerebroAskClient {
     }
     return {
       citationValidationPassed: decision.verified,
+      executionLane: "lookup",
       markdown: summary.markdown,
       safeRefusal: decision.disposition === "safe_refusal",
       traceId: decision.trace_id,
     };
+  }
+
+  async authorizeQuestion(
+    requestId: string,
+    question: string,
+    history: readonly CerebroAskHistoryMessage[] = [],
+  ): Promise<SlackQuestionDecision> {
+    try {
+      return await this.options.answerAuthority.authorizeQuestion({
+        history: history.map((message) => ({ ...message })),
+        question,
+        request_id: requestId,
+        schema_version: "slack-question-candidate/v1",
+        tenant_id: this.options.tenantId,
+      });
+    } catch (error: unknown) {
+      throw new CerebroAskError("unauthorized", errorMessage(error));
+    }
   }
 }
 
@@ -278,4 +307,5 @@ function isAbortError(value: unknown): boolean {
 import {
   type SlackAnswerAuthorityPort,
   type SlackAnswerCandidate,
+  type SlackQuestionDecision,
 } from "./slack-answer-authority-client.js";

--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -43,10 +43,22 @@ export class CerebroAskClient {
   }
 
   async ask(
+    requestId: string,
     question: string,
     signal: AbortSignal,
     history: readonly CerebroAskHistoryMessage[] = [],
   ): Promise<CerebroAskResult> {
+    try {
+      await this.options.answerAuthority.authorizeQuestion({
+        history: history.map((message) => ({ ...message })),
+        question,
+        request_id: requestId,
+        schema_version: "slack-question-candidate/v1",
+        tenant_id: this.options.tenantId,
+      });
+    } catch (error: unknown) {
+      throw new CerebroAskError("unauthorized", errorMessage(error));
+    }
     const response = await this.fetchImpl(`${this.options.baseUrl}/grc/ask`, {
       method: "POST",
       headers: {

--- a/apps/slack-companion-host/src/runtime/slack-answer-authority-client.ts
+++ b/apps/slack-companion-host/src/runtime/slack-answer-authority-client.ts
@@ -24,7 +24,26 @@ export interface SlackAnswerDecision {
   verified: boolean;
 }
 
+export interface SlackQuestionCandidate {
+  history: {
+    content: string;
+    role: "assistant" | "user";
+  }[];
+  question: string;
+  request_id: string;
+  schema_version: "slack-question-candidate/v1";
+  tenant_id: string;
+}
+
+export interface SlackQuestionDecision {
+  authorized: true;
+  request_id: string;
+  schema_version: "slack-question-decision/v1";
+  tenant_id: string;
+}
+
 export interface SlackAnswerAuthorityPort {
+  authorizeQuestion(candidate: SlackQuestionCandidate): Promise<SlackQuestionDecision>;
   validate(candidate: SlackAnswerCandidate): Promise<SlackAnswerDecision>;
 }
 
@@ -47,21 +66,24 @@ export class SlackAnswerAuthorityClient implements SlackAnswerAuthorityPort {
     this.fetchImpl = options.fetchImpl ?? fetch;
   }
 
+  async authorizeQuestion(candidate: SlackQuestionCandidate): Promise<SlackQuestionDecision> {
+    const response = await this.post("/v1/questions/authorize", candidate);
+    if (!response.ok) {
+      throw new SlackAnswerAuthorityError(
+        `Rust Slack authority rejected the question with status ${response.status}.`,
+      );
+    }
+    const decision: unknown = await response.json().catch(() => undefined);
+    if (!validQuestionDecision(decision, candidate)) {
+      throw new SlackAnswerAuthorityError(
+        "Rust Slack authority returned an invalid question decision.",
+      );
+    }
+    return decision;
+  }
+
   async validate(candidate: SlackAnswerCandidate): Promise<SlackAnswerDecision> {
-    const response = await this.fetchImpl(
-      `${this.options.baseUrl}/v1/answers/validate`,
-      {
-        body: JSON.stringify(candidate),
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-        signal: AbortSignal.timeout(2_000),
-      },
-    ).catch((error: unknown) => {
-      throw new SlackAnswerAuthorityError(errorMessage(error));
-    });
+    const response = await this.post("/v1/answers/validate", candidate);
     if (!response.ok) {
       throw new SlackAnswerAuthorityError(
         `Rust Slack answer authority rejected the candidate with status ${response.status}.`,
@@ -75,6 +97,32 @@ export class SlackAnswerAuthorityClient implements SlackAnswerAuthorityPort {
     }
     return decision;
   }
+
+  private async post(path: string, body: unknown): Promise<Response> {
+    return this.fetchImpl(`${this.options.baseUrl}${path}`, {
+      body: JSON.stringify(body),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      signal: AbortSignal.timeout(2_000),
+    }).catch((error: unknown) => {
+      throw new SlackAnswerAuthorityError(errorMessage(error));
+    });
+  }
+}
+
+function validQuestionDecision(
+  value: unknown,
+  candidate: SlackQuestionCandidate,
+): value is SlackQuestionDecision {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const decision = value as Record<string, unknown>;
+  return decision.schema_version === "slack-question-decision/v1"
+    && decision.authorized === true
+    && decision.request_id === candidate.request_id
+    && decision.tenant_id === candidate.tenant_id;
 }
 
 function validDecision(

--- a/apps/slack-companion-host/src/runtime/slack-answer-authority-client.ts
+++ b/apps/slack-companion-host/src/runtime/slack-answer-authority-client.ts
@@ -35,12 +35,22 @@ export interface SlackQuestionCandidate {
   tenant_id: string;
 }
 
-export interface SlackQuestionDecision {
-  authorized: true;
-  request_id: string;
-  schema_version: "slack-question-decision/v1";
-  tenant_id: string;
-}
+export type SlackQuestionDecision =
+  | {
+      answer: string;
+      authorized: true;
+      execution_lane: "converse";
+      request_id: string;
+      schema_version: "slack-question-decision/v1";
+      tenant_id: string;
+    }
+  | {
+      authorized: true;
+      execution_lane: "lookup";
+      request_id: string;
+      schema_version: "slack-question-decision/v1";
+      tenant_id: string;
+    };
 
 export interface SlackAnswerAuthorityPort {
   authorizeQuestion(candidate: SlackQuestionCandidate): Promise<SlackQuestionDecision>;
@@ -121,6 +131,17 @@ function validQuestionDecision(
   const decision = value as Record<string, unknown>;
   return decision.schema_version === "slack-question-decision/v1"
     && decision.authorized === true
+    && (
+      (
+        decision.execution_lane === "lookup"
+        && decision.answer === undefined
+      )
+      || (
+        decision.execution_lane === "converse"
+        && typeof decision.answer === "string"
+        && decision.answer.trim() !== ""
+      )
+    )
     && decision.request_id === candidate.request_id
     && decision.tenant_id === candidate.tenant_id;
 }

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -164,15 +164,16 @@ export class AssistantQuestionService {
     const openedAt = this.clock();
     const requestId = `slack-request-${digest(input.requestKey)}`;
     const currentRequest = normalizedSlackText(input.text);
-    const budget = this.host.enforceBudget({
-      execution_lane: "lookup",
-      planned_tool_call_count: 1,
-      selected_capability_count: 1,
-    });
     if (!currentRequest) {
+      const emptyBudget = this.host.enforceBudget({
+        execution_lane: "converse",
+        planned_tool_call_count: 0,
+        selected_capability_count: 0,
+      });
       return {
         pending: pendingOutcome({
-          budgetMs: budget.latency_budget_ms,
+          budgetMs: emptyBudget.latency_budget_ms,
+          executionLane: "converse",
           openedAt,
           outcomeState: "needs_user",
           requestId,
@@ -185,7 +186,74 @@ export class AssistantQuestionService {
       input.threadContext,
       input.scratchpadContext,
     );
+    let questionDecision;
+    try {
+      questionDecision = await this.askClient.authorizeQuestion(
+        input.requestKey,
+        currentRequest,
+        history,
+      );
+    } catch (error) {
+      const state = error instanceof CerebroAskError ? error.sourceState : "unauthorized";
+      const authorityBudget = this.host.enforceBudget({
+        execution_lane: "converse",
+        planned_tool_call_count: 0,
+        selected_capability_count: 0,
+      });
+      return {
+        pending: pendingOutcome({
+          budgetMs: authorityBudget.latency_budget_ms,
+          executionLane: "converse",
+          openedAt,
+          outcomeState: "blocked",
+          requestId,
+          verified: false,
+        }),
+        text: "Cerebro could not authorize this Slack request. Retry after the request authority is healthy.",
+        workingTurn: {
+          blocker: `Request authority was ${state.replaceAll("_", " ")}.`,
+          currentRequest,
+          outcome: "blocked",
+        },
+      };
+    }
+    if (questionDecision.execution_lane === "converse") {
+      const converseBudget = this.host.enforceBudget({
+        execution_lane: "converse",
+        planned_tool_call_count: 0,
+        selected_capability_count: 0,
+      });
+      const answer = await this.askClient.ask(
+        input.requestKey,
+        currentRequest,
+        this.timeoutSignal(converseBudget.latency_budget_ms),
+        history,
+        questionDecision,
+      );
+      const usefulAnswerAt = this.clock();
+      return {
+        pending: pendingOutcome({
+          budgetMs: converseBudget.latency_budget_ms,
+          executionLane: "converse",
+          openedAt,
+          outcomeState: "completed",
+          requestId,
+          usefulAnswerAt,
+          verified: true,
+        }),
+        text: boundedSlackText(answer.markdown),
+        workingTurn: {
+          currentRequest,
+          outcome: "completed",
+        },
+      };
+    }
 
+    const budget = this.host.enforceBudget({
+      execution_lane: "lookup",
+      planned_tool_call_count: 1,
+      selected_capability_count: 1,
+    });
     const observedAt = this.clock();
     const preflight = this.host.preflightInvocation(preflightInput(
       currentRequest,
@@ -230,12 +298,14 @@ export class AssistantQuestionService {
         currentRequest,
         this.timeoutSignal(Math.max(1, preflight.remaining_ms)),
         history,
+        questionDecision,
       );
       const usefulAnswerAt = this.clock();
       this.recordSourceResult(true, Math.max(0, usefulAnswerAt.getTime() - sourceStartedAt));
       return {
         pending: pendingOutcome({
           budgetMs: budget.latency_budget_ms,
+          executionLane: answer.executionLane,
           openedAt,
           outcomeState: "completed",
           requestId,
@@ -949,6 +1019,7 @@ function preflightInput(
 
 function pendingOutcome(input: {
   budgetMs: number;
+  executionLane?: "converse" | "lookup";
   openedAt: Date;
   outcomeState: PendingAssistantOutcome["outcome_state"];
   requestId: string;
@@ -956,7 +1027,7 @@ function pendingOutcome(input: {
   verified: boolean;
 }): Omit<PendingAssistantOutcome, "delivered_message_ts"> {
   return {
-    execution_lane: "lookup",
+    execution_lane: input.executionLane ?? "lookup",
     latency_budget_ms: input.budgetMs,
     negative_feedback_count: 0,
     opened_at: input.openedAt.toISOString(),

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -226,6 +226,7 @@ export class AssistantQuestionService {
     try {
       const sourceStartedAt = this.clock().getTime();
       const answer = await this.askClient.ask(
+        input.requestKey,
         currentRequest,
         this.timeoutSignal(Math.max(1, preflight.remaining_ms)),
         history,

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -25,6 +25,14 @@ import {
 } from "../src/runtime/slack-runtime.js";
 
 const testAnswerAuthority: SlackAnswerAuthorityPort = {
+  async authorizeQuestion(candidate) {
+    return {
+      authorized: true,
+      request_id: candidate.request_id,
+      schema_version: "slack-question-decision/v1",
+      tenant_id: candidate.tenant_id,
+    };
+  },
   async validate(candidate) {
     if (candidate.unsupported_query) {
       return {
@@ -428,7 +436,7 @@ test("Cerebro ask cancels and unlocks an unfinished SSE response after an error 
   });
 
   await assert.rejects(
-    client.ask("What changed?", new AbortController().signal),
+    client.ask("request-error", "What changed?", new AbortController().signal),
     (error: unknown) => error instanceof CerebroAskError
       && error.sourceState === "unavailable"
       && error.message === "source failed",
@@ -462,7 +470,11 @@ test("Cerebro ask returns after done without waiting for the SSE response to clo
     tenantId: "writer",
   });
 
-  const result = await client.ask("What changed?", new AbortController().signal);
+  const result = await client.ask(
+    "request-complete",
+    "What changed?",
+    new AbortController().signal,
+  );
 
   assert.deepEqual(result, {
     citationValidationPassed: true,
@@ -500,7 +512,11 @@ test("Cerebro ask ignores an error event sent after done", async () => {
     tenantId: "writer",
   });
 
-  const result = await client.ask("What changed?", new AbortController().signal);
+  const result = await client.ask(
+    "request-ignore-after-done",
+    "What changed?",
+    new AbortController().signal,
+  );
 
   assert.deepEqual(result, {
     citationValidationPassed: true,
@@ -536,7 +552,7 @@ test("Cerebro ask classifies a mid-stream deadline as timed out", async () => {
     tenantId: "writer",
   });
 
-  const result = client.ask("What changed?", controller.signal);
+  const result = client.ask("request-timeout", "What changed?", controller.signal);
   controller.abort(new DOMException("deadline", "TimeoutError"));
   await assert.rejects(
     result,
@@ -562,7 +578,7 @@ test("Cerebro ask rejects a summary whose citations did not validate", async () 
   });
 
   await assert.rejects(
-    client.ask("Are we clear?", new AbortController().signal),
+    client.ask("request-unverified", "Are we clear?", new AbortController().signal),
     (error: unknown) => error instanceof CerebroAskError
       && error.sourceState === "unavailable"
       && /Rust authority rejected/u.test(error.message),
@@ -608,6 +624,73 @@ test("Rust Slack answer authority receives the bounded candidate and binds the t
     schema_version: "slack-answer-candidate/v1",
     trace_id: "trace-grounded",
   });
+});
+
+test("Rust Slack authority receives the tenant-bound question and binds its decision", async () => {
+  let body: unknown;
+  const authority = new SlackAnswerAuthorityClient({
+    baseUrl: "http://127.0.0.1:8091",
+    fetchImpl: async (input, init) => {
+      assert.equal(String(input), "http://127.0.0.1:8091/v1/questions/authorize");
+      body = JSON.parse(String(init?.body));
+      return Response.json({
+        authorized: true,
+        request_id: "C0B2VJDFJ5N:1753830794.123",
+        schema_version: "slack-question-decision/v1",
+        tenant_id: "writer",
+      });
+    },
+  });
+
+  const decision = await authority.authorizeQuestion({
+    history: [{ content: "Which source?", role: "assistant" }],
+    question: "Show connector health for Okta.",
+    request_id: "C0B2VJDFJ5N:1753830794.123",
+    schema_version: "slack-question-candidate/v1",
+    tenant_id: "writer",
+  });
+
+  assert.equal(decision.authorized, true);
+  assert.deepEqual(body, {
+    history: [{ content: "Which source?", role: "assistant" }],
+    question: "Show connector health for Okta.",
+    request_id: "C0B2VJDFJ5N:1753830794.123",
+    schema_version: "slack-question-candidate/v1",
+    tenant_id: "writer",
+  });
+});
+
+test("Rust question rejection prevents a request to the Go compatibility endpoint", async () => {
+  let upstreamFetchCount = 0;
+  const client = new CerebroAskClient({
+    answerAuthority: {
+      async authorizeQuestion() {
+        throw new Error("tenant mismatch");
+      },
+      async validate() {
+        throw new Error("answer validation must not run");
+      },
+    },
+    apiKey: "bound-at-runtime",
+    baseUrl: "https://cerebro.example.com",
+    fetchImpl: async () => {
+      upstreamFetchCount += 1;
+      throw new Error("Go compatibility endpoint must not be called");
+    },
+    tenantId: "writer",
+  });
+
+  await assert.rejects(
+    client.ask(
+      "C0B2VJDFJ5N:1753830794.123",
+      "Show connector health for Okta.",
+      new AbortController().signal,
+    ),
+    (error: unknown) => error instanceof CerebroAskError
+      && error.sourceState === "unauthorized"
+      && error.message === "tenant mismatch",
+  );
+  assert.equal(upstreamFetchCount, 0);
 });
 
 test("Rust Slack answer authority rejects a cross-trace or contradictory decision", async () => {
@@ -673,7 +756,11 @@ test("Cerebro ask accepts a structured safe refusal without citations", async ()
   });
 
   assert.deepEqual(
-    await client.ask("Show everything.", new AbortController().signal),
+    await client.ask(
+      "request-safe-refusal",
+      "Show everything.",
+      new AbortController().signal,
+    ),
     {
       citationValidationPassed: false,
       markdown: "Narrow the request to one source or finding.",
@@ -702,7 +789,11 @@ test("Cerebro ask rejects an unstructured refusal marker without citations", asy
   });
 
   await assert.rejects(
-    client.ask("Show everything.", new AbortController().signal),
+    client.ask(
+      "request-unstructured-refusal",
+      "Show everything.",
+      new AbortController().signal,
+    ),
     (error: unknown) => error instanceof CerebroAskError
       && error.sourceState === "unavailable"
       && /Rust authority rejected/u.test(error.message),

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -28,6 +28,7 @@ const testAnswerAuthority: SlackAnswerAuthorityPort = {
   async authorizeQuestion(candidate) {
     return {
       authorized: true,
+      execution_lane: "lookup",
       request_id: candidate.request_id,
       schema_version: "slack-question-decision/v1",
       tenant_id: candidate.tenant_id,
@@ -265,6 +266,57 @@ test("question service preflights one governed graph lookup and returns its veri
   }
 });
 
+test("question service keeps self status on the Rust conversational lane", async () => {
+  const root = await mkdtemp(join(tmpdir(), "cerebro-slack-runtime-"));
+  try {
+    let upstreamFetchCount = 0;
+    const service = new AssistantQuestionService(
+      createAssistantTurnHost(new FileOutcomeStore(root)),
+      new CerebroAskClient({
+        answerAuthority: {
+          async authorizeQuestion(candidate) {
+            return {
+              answer: "I’m Cerebro. I don’t have a verified cross-thread work log in this request.",
+              authorized: true,
+              execution_lane: "converse",
+              request_id: candidate.request_id,
+              schema_version: "slack-question-decision/v1",
+              tenant_id: candidate.tenant_id,
+            };
+          },
+          async validate() {
+            throw new Error("answer validation must not run");
+          },
+        },
+        apiKey: "bound-at-runtime",
+        baseUrl: "https://cerebro.example.com",
+        fetchImpl: async () => {
+          upstreamFetchCount += 1;
+          throw new Error("Graph endpoint must not be called");
+        },
+        tenantId: "writer",
+      }),
+      {
+        clock: () => new Date("2026-07-29T18:25:00.000Z"),
+        timeoutSignal: () => new AbortController().signal,
+      },
+    );
+
+    const result = await service.answer({
+      requestKey: "T-ONE:C-ONE:thread-one:event-self",
+      text: "<@BOT> What can you tell me about yourself and your work today?",
+    });
+
+    assert.equal(result.pending.execution_lane, "converse");
+    assert.equal(result.pending.outcome_state, "completed");
+    assert.equal(result.pending.verified, true);
+    assert.match(result.text, /verified cross-thread work log/u);
+    assert.equal(upstreamFetchCount, 0);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
 test("empty threaded mentions request a question without invoking Cerebro", async () => {
   const root = await mkdtemp(join(tmpdir(), "cerebro-slack-runtime-"));
   try {
@@ -478,6 +530,7 @@ test("Cerebro ask returns after done without waiting for the SSE response to clo
 
   assert.deepEqual(result, {
     citationValidationPassed: true,
+    executionLane: "lookup",
     markdown: "Current evidence is verified.",
     safeRefusal: false,
     traceId: "trace-complete",
@@ -520,6 +573,7 @@ test("Cerebro ask ignores an error event sent after done", async () => {
 
   assert.deepEqual(result, {
     citationValidationPassed: true,
+    executionLane: "lookup",
     markdown: "Current evidence is verified.",
     safeRefusal: false,
     traceId: "trace-complete",
@@ -635,6 +689,7 @@ test("Rust Slack authority receives the tenant-bound question and binds its deci
       body = JSON.parse(String(init?.body));
       return Response.json({
         authorized: true,
+        execution_lane: "lookup",
         request_id: "C0B2VJDFJ5N:1753830794.123",
         schema_version: "slack-question-decision/v1",
         tenant_id: "writer",
@@ -651,6 +706,7 @@ test("Rust Slack authority receives the tenant-bound question and binds its deci
   });
 
   assert.equal(decision.authorized, true);
+  assert.equal(decision.execution_lane, "lookup");
   assert.deepEqual(body, {
     history: [{ content: "Which source?", role: "assistant" }],
     question: "Show connector health for Okta.",
@@ -658,6 +714,45 @@ test("Rust Slack authority receives the tenant-bound question and binds its deci
     schema_version: "slack-question-candidate/v1",
     tenant_id: "writer",
   });
+});
+
+test("Rust routes self status questions without calling the graph endpoint", async () => {
+  let upstreamFetchCount = 0;
+  const client = new CerebroAskClient({
+    answerAuthority: {
+      async authorizeQuestion(candidate) {
+        return {
+          answer: "I’m Cerebro. I don’t have a verified cross-thread work log in this request.",
+          authorized: true,
+          execution_lane: "converse",
+          request_id: candidate.request_id,
+          schema_version: "slack-question-decision/v1",
+          tenant_id: candidate.tenant_id,
+        };
+      },
+      async validate() {
+        throw new Error("answer validation must not run");
+      },
+    },
+    apiKey: "bound-at-runtime",
+    baseUrl: "https://cerebro.example.com",
+    fetchImpl: async () => {
+      upstreamFetchCount += 1;
+      throw new Error("Graph endpoint must not be called");
+    },
+    tenantId: "writer",
+  });
+
+  const result = await client.ask(
+    "C0B2VJDFJ5N:1753830794.124",
+    "What can you tell me about yourself and your work today?",
+    new AbortController().signal,
+  );
+
+  assert.equal(result.executionLane, "converse");
+  assert.match(result.markdown, /verified cross-thread work log/u);
+  assert.equal(result.citationValidationPassed, false);
+  assert.equal(upstreamFetchCount, 0);
 });
 
 test("Rust question rejection prevents a request to the Go compatibility endpoint", async () => {
@@ -763,6 +858,7 @@ test("Cerebro ask accepts a structured safe refusal without citations", async ()
     ),
     {
       citationValidationPassed: false,
+      executionLane: "lookup",
       markdown: "Narrow the request to one source or finding.",
       safeRefusal: true,
       traceId: "trace-safe-refusal",

--- a/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
+++ b/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
@@ -22,6 +22,7 @@ const testAnswerAuthority: SlackAnswerAuthorityPort = {
   async authorizeQuestion(candidate) {
     return {
       authorized: true,
+      execution_lane: "lookup",
       request_id: candidate.request_id,
       schema_version: "slack-question-decision/v1",
       tenant_id: candidate.tenant_id,

--- a/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
+++ b/apps/slack-companion-host/test/thread-scratchpad-store.test.ts
@@ -19,6 +19,14 @@ import {
 import { FileThreadScratchpadStore } from "../src/runtime/thread-scratchpad-store.js";
 
 const testAnswerAuthority: SlackAnswerAuthorityPort = {
+  async authorizeQuestion(candidate) {
+    return {
+      authorized: true,
+      request_id: candidate.request_id,
+      schema_version: "slack-question-decision/v1",
+      tenant_id: candidate.tenant_id,
+    };
+  },
   async validate(candidate) {
     if (!candidate.citation_validation?.ok) throw new Error("candidate rejected");
     return {

--- a/crates/cerebro-platform/src/slack_authority.rs
+++ b/crates/cerebro-platform/src/slack_authority.rs
@@ -17,8 +17,8 @@ use axum::{
 };
 use cerebro_slack_authority::{
     AnswerAuthorityError, AnswerCandidate, AnswerDecision, AnswerDisposition,
-    QuestionAuthorityError, QuestionCandidate, QuestionDecision, QuestionPolicy,
-    authorize_question, validate_answer,
+    QuestionAuthorityError, QuestionCandidate, QuestionDecision, QuestionExecutionLane,
+    QuestionPolicy, authorize_question, validate_answer,
 };
 use serde::Serialize;
 
@@ -145,7 +145,16 @@ async fn authorize_question_route(
             runtime
                 .question_authorized_total
                 .fetch_add(1, Ordering::Relaxed);
-            log_question_decision(&runtime, "authorized", None, Some(&decision.request_id));
+            log_question_decision(
+                &runtime,
+                "authorized",
+                Some(match decision.execution_lane {
+                    QuestionExecutionLane::Converse => "converse",
+                    QuestionExecutionLane::Lookup => "lookup",
+                }),
+                None,
+                Some(&decision.request_id),
+            );
             Ok(Json(decision))
         }
         Err(error) => {
@@ -155,6 +164,7 @@ async fn authorize_question_route(
             log_question_decision(
                 &runtime,
                 "rejected",
+                None,
                 Some(question_rejection_code(error)),
                 None,
             );
@@ -251,6 +261,7 @@ fn log_decision(
 fn log_question_decision(
     runtime: &AuthorityRuntime,
     outcome: &'static str,
+    execution_lane: Option<&'static str>,
     rejection_code: Option<&'static str>,
     request_id: Option<&str>,
 ) {
@@ -260,6 +271,7 @@ fn log_question_decision(
         serde_json::json!({
             "authority": "rust",
             "component": "slack-answer-authority",
+            "execution_lane": execution_lane,
             "operation": "question_authorize",
             "outcome": outcome,
             "question_authorized_total": status.question_authorized_total,
@@ -430,6 +442,47 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(authorized.status(), StatusCode::OK);
+        let authorized_body: Value = serde_json::from_slice(
+            &to_bytes(authorized.into_body(), MAX_REQUEST_BYTES)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(authorized_body["execution_lane"], "lookup");
+        assert!(authorized_body.get("answer").is_none());
+
+        let conversational = app
+            .clone()
+            .oneshot(
+                Request::post("/v1/questions/authorize")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{
+                          "schema_version":"slack-question-candidate/v1",
+                          "tenant_id":"writer-sec-dev",
+                          "request_id":"C0B2VJDFJ5N:1753830794.124",
+                          "question":"What can you tell me about yourself and your work today?",
+                          "history":[]
+                        }"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(conversational.status(), StatusCode::OK);
+        let conversational_body: Value = serde_json::from_slice(
+            &to_bytes(conversational.into_body(), MAX_REQUEST_BYTES)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(conversational_body["execution_lane"], "converse");
+        assert!(
+            conversational_body["answer"]
+                .as_str()
+                .unwrap()
+                .contains("verified cross-thread work log")
+        );
 
         let rejected = app
             .clone()
@@ -461,8 +514,8 @@ mod tests {
                 .unwrap(),
         )
         .unwrap();
-        assert_eq!(body["question_authorized_total"], 1);
+        assert_eq!(body["question_authorized_total"], 2);
         assert_eq!(body["question_rejected_total"], 1);
-        assert_eq!(body["requests_total"], 2);
+        assert_eq!(body["requests_total"], 3);
     }
 }

--- a/crates/cerebro-platform/src/slack_authority.rs
+++ b/crates/cerebro-platform/src/slack_authority.rs
@@ -16,7 +16,9 @@ use axum::{
     routing::{get, post},
 };
 use cerebro_slack_authority::{
-    AnswerAuthorityError, AnswerCandidate, AnswerDecision, AnswerDisposition, validate_answer,
+    AnswerAuthorityError, AnswerCandidate, AnswerDecision, AnswerDisposition,
+    QuestionAuthorityError, QuestionCandidate, QuestionDecision, QuestionPolicy,
+    authorize_question, validate_answer,
 };
 use serde::Serialize;
 
@@ -30,6 +32,9 @@ struct ErrorResponse {
 }
 
 struct AuthorityRuntime {
+    question_authorized_total: AtomicU64,
+    question_rejected_total: AtomicU64,
+    question_policy: QuestionPolicy,
     grounded_total: AtomicU64,
     rejected_total: AtomicU64,
     safe_refusal_total: AtomicU64,
@@ -41,6 +46,8 @@ struct AuthorityStatus {
     authority: &'static str,
     component: &'static str,
     grounded_total: u64,
+    question_authorized_total: u64,
+    question_rejected_total: u64,
     rejected_total: u64,
     requests_total: u64,
     safe_refusal_total: u64,
@@ -51,12 +58,15 @@ struct AuthorityStatus {
 }
 
 impl AuthorityRuntime {
-    fn new() -> Self {
+    fn new(question_policy: QuestionPolicy) -> Self {
         Self {
+            question_authorized_total: AtomicU64::new(0),
+            question_rejected_total: AtomicU64::new(0),
             grounded_total: AtomicU64::new(0),
             rejected_total: AtomicU64::new(0),
             safe_refusal_total: AtomicU64::new(0),
             started_at: Instant::now(),
+            question_policy,
         }
     }
 
@@ -64,14 +74,20 @@ impl AuthorityRuntime {
         let grounded_total = self.grounded_total.load(Ordering::Relaxed);
         let rejected_total = self.rejected_total.load(Ordering::Relaxed);
         let safe_refusal_total = self.safe_refusal_total.load(Ordering::Relaxed);
+        let question_authorized_total = self.question_authorized_total.load(Ordering::Relaxed);
+        let question_rejected_total = self.question_rejected_total.load(Ordering::Relaxed);
         AuthorityStatus {
             authority: "rust",
             component: "slack-answer-authority",
             grounded_total,
+            question_authorized_total,
+            question_rejected_total,
             rejected_total,
             requests_total: grounded_total
                 .saturating_add(rejected_total)
-                .saturating_add(safe_refusal_total),
+                .saturating_add(safe_refusal_total)
+                .saturating_add(question_authorized_total)
+                .saturating_add(question_rejected_total),
             safe_refusal_total,
             schema_version: "slack-answer-authority-status/v1",
             status: "ready",
@@ -90,6 +106,9 @@ pub async fn serve() -> Result<(), Box<dyn Error>> {
     let bind = env::var("CEREBRO_SLACK_AUTHORITY_BIND").unwrap_or_else(|_| DEFAULT_BIND.to_owned());
     let address: SocketAddr = bind.parse()?;
     require_loopback(address)?;
+    let tenant_id = env::var("CEREBRO_SLACK_AUTHORITY_TENANT_ID")
+        .map_err(|_| "CEREBRO_SLACK_AUTHORITY_TENANT_ID is required")?;
+    let question_policy = QuestionPolicy::new(tenant_id)?;
     let listener = tokio::net::TcpListener::bind(address).await?;
     println!(
         "{}",
@@ -103,17 +122,51 @@ pub async fn serve() -> Result<(), Box<dyn Error>> {
             "version": env!("CARGO_PKG_VERSION"),
         })
     );
-    axum::serve(listener, router()).await?;
+    axum::serve(listener, router(question_policy)).await?;
     Ok(())
 }
 
-fn router() -> Router {
+fn router(question_policy: QuestionPolicy) -> Router {
     Router::new()
         .route("/healthz", get(|| async { StatusCode::NO_CONTENT }))
         .route("/v1/status", get(authority_status_route))
+        .route("/v1/questions/authorize", post(authorize_question_route))
         .route("/v1/answers/validate", post(validate_answer_route))
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
-        .with_state(Arc::new(AuthorityRuntime::new()))
+        .with_state(Arc::new(AuthorityRuntime::new(question_policy)))
+}
+
+async fn authorize_question_route(
+    State(runtime): State<Arc<AuthorityRuntime>>,
+    Json(candidate): Json<QuestionCandidate>,
+) -> Result<Json<QuestionDecision>, (StatusCode, Json<ErrorResponse>)> {
+    match authorize_question(&runtime.question_policy, candidate) {
+        Ok(decision) => {
+            runtime
+                .question_authorized_total
+                .fetch_add(1, Ordering::Relaxed);
+            log_question_decision(&runtime, "authorized", None, Some(&decision.request_id));
+            Ok(Json(decision))
+        }
+        Err(error) => {
+            runtime
+                .question_rejected_total
+                .fetch_add(1, Ordering::Relaxed);
+            log_question_decision(
+                &runtime,
+                "rejected",
+                Some(question_rejection_code(error)),
+                None,
+            );
+            Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(ErrorResponse {
+                    code: "question_rejected",
+                    message: error.to_string(),
+                }),
+            ))
+        }
+    }
 }
 
 async fn authority_status_route(
@@ -195,6 +248,30 @@ fn log_decision(
     );
 }
 
+fn log_question_decision(
+    runtime: &AuthorityRuntime,
+    outcome: &'static str,
+    rejection_code: Option<&'static str>,
+    request_id: Option<&str>,
+) {
+    let status = runtime.status();
+    println!(
+        "{}",
+        serde_json::json!({
+            "authority": "rust",
+            "component": "slack-answer-authority",
+            "operation": "question_authorize",
+            "outcome": outcome,
+            "question_authorized_total": status.question_authorized_total,
+            "question_rejected_total": status.question_rejected_total,
+            "rejection_code": rejection_code,
+            "request_id": request_id,
+            "requests_total": status.requests_total,
+            "schema_version": "slack-question-authority-decision-log/v1",
+        })
+    );
+}
+
 fn rejection_code(error: AnswerAuthorityError) -> &'static str {
     match error {
         AnswerAuthorityError::CitationEvidenceMissing => "citation_evidence_missing",
@@ -204,6 +281,17 @@ fn rejection_code(error: AnswerAuthorityError) -> &'static str {
         AnswerAuthorityError::InvalidSchema => "invalid_schema",
         AnswerAuthorityError::InvalidTrace => "invalid_trace",
         AnswerAuthorityError::MarkdownInvalid => "markdown_invalid",
+    }
+}
+
+fn question_rejection_code(error: QuestionAuthorityError) -> &'static str {
+    match error {
+        QuestionAuthorityError::HistoryInvalid => "history_invalid",
+        QuestionAuthorityError::InvalidPolicy => "invalid_policy",
+        QuestionAuthorityError::InvalidRequest => "invalid_request",
+        QuestionAuthorityError::InvalidSchema => "invalid_schema",
+        QuestionAuthorityError::QuestionInvalid => "question_invalid",
+        QuestionAuthorityError::TenantMismatch => "tenant_mismatch",
     }
 }
 
@@ -225,6 +313,10 @@ mod tests {
 
     use super::*;
 
+    fn test_router() -> Router {
+        router(QuestionPolicy::new("writer-sec-dev".to_owned()).unwrap())
+    }
+
     #[test]
     fn rejects_non_loopback_bindings() {
         assert!(require_loopback("127.0.0.1:8091".parse().unwrap()).is_ok());
@@ -235,7 +327,7 @@ mod tests {
 
     #[tokio::test]
     async fn route_returns_the_rust_authority_decision() {
-        let response = router()
+        let response = test_router()
             .oneshot(
                 Request::post("/v1/answers/validate")
                     .header(CONTENT_TYPE, "application/json")
@@ -273,7 +365,7 @@ mod tests {
 
     #[tokio::test]
     async fn route_rejects_an_unstructured_uncited_answer() {
-        let app = router();
+        let app = test_router();
         let response = app
             .clone()
             .oneshot(
@@ -312,5 +404,65 @@ mod tests {
         assert_eq!(body["rejected_total"], 1);
         assert_eq!(body["grounded_total"], 0);
         assert_eq!(body["safe_refusal_total"], 0);
+        assert_eq!(body["question_authorized_total"], 0);
+        assert_eq!(body["question_rejected_total"], 0);
+    }
+
+    #[tokio::test]
+    async fn question_route_authorizes_only_the_configured_tenant() {
+        let app = test_router();
+        let authorized = app
+            .clone()
+            .oneshot(
+                Request::post("/v1/questions/authorize")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{
+                          "schema_version":"slack-question-candidate/v1",
+                          "tenant_id":"writer-sec-dev",
+                          "request_id":"C0B2VJDFJ5N:1753830794.123",
+                          "question":"Show connector health for Okta.",
+                          "history":[]
+                        }"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(authorized.status(), StatusCode::OK);
+
+        let rejected = app
+            .clone()
+            .oneshot(
+                Request::post("/v1/questions/authorize")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{
+                          "schema_version":"slack-question-candidate/v1",
+                          "tenant_id":"other-tenant",
+                          "request_id":"request-2",
+                          "question":"Show connector health for Okta.",
+                          "history":[]
+                        }"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        let status_response = app
+            .oneshot(Request::get("/v1/status").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(
+            &to_bytes(status_response.into_body(), MAX_REQUEST_BYTES)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["question_authorized_total"], 1);
+        assert_eq!(body["question_rejected_total"], 1);
+        assert_eq!(body["requests_total"], 2);
     }
 }

--- a/crates/slack-authority/src/lib.rs
+++ b/crates/slack-authority/src/lib.rs
@@ -23,6 +23,7 @@ const MAX_REFUSAL_ITEMS: usize = 32;
 const MAX_REFUSAL_ITEM_BYTES: usize = 512;
 const MAX_REQUEST_ID_BYTES: usize = 512;
 const MAX_TENANT_ID_BYTES: usize = 256;
+const SELF_CONTEXT_ANSWER: &str = "I’m Cerebro, Writer’s security operations assistant. I read governed Cerebro evidence for findings, assets, identities, controls, owners, and connector health.\n\nI don’t have a verified cross-thread work log in this request, so I can’t claim a complete list of today’s work. Run `@Cerebro scratchpad` in this thread to see retained requests, outcomes, and blockers, or ask me about one current security task.";
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -68,6 +69,16 @@ pub struct QuestionDecision {
     pub tenant_id: String,
     pub request_id: String,
     pub authorized: bool,
+    pub execution_lane: QuestionExecutionLane,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answer: Option<&'static str>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuestionExecutionLane {
+    Converse,
+    Lookup,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -120,12 +131,46 @@ pub fn authorize_question(
     {
         return Err(QuestionAuthorityError::HistoryInvalid);
     }
+    let execution_lane = question_execution_lane(&candidate.question);
     Ok(QuestionDecision {
         schema_version: QUESTION_DECISION_V1,
         tenant_id: candidate.tenant_id,
         request_id: candidate.request_id,
         authorized: true,
+        execution_lane,
+        answer: match execution_lane {
+            QuestionExecutionLane::Converse => Some(SELF_CONTEXT_ANSWER),
+            QuestionExecutionLane::Lookup => None,
+        },
     })
+}
+
+fn question_execution_lane(question: &str) -> QuestionExecutionLane {
+    let normalized = question
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    let identity_question = normalized.trim_matches(|character: char| {
+        character.is_ascii_punctuation() || character.is_whitespace()
+    });
+    let asks_identity = normalized.contains("about yourself")
+        || normalized.contains("tell me about you")
+        || matches!(identity_question, "who are you" | "what are you");
+    let asks_work = [
+        "your work today",
+        "what have you done today",
+        "what did you do today",
+        "what are you working on",
+        "what have you worked on",
+    ]
+    .iter()
+    .any(|phrase| normalized.contains(phrase));
+    if asks_identity || asks_work {
+        QuestionExecutionLane::Converse
+    } else {
+        QuestionExecutionLane::Lookup
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -332,8 +377,36 @@ mod tests {
                 tenant_id: "writer-sec-dev".to_owned(),
                 request_id: "C0B2VJDFJ5N:1753830794.123".to_owned(),
                 authorized: true,
+                execution_lane: QuestionExecutionLane::Lookup,
+                answer: None,
             }
         );
+    }
+
+    #[test]
+    fn routes_self_and_work_status_questions_without_a_graph_lookup() {
+        let policy = QuestionPolicy::new("writer-sec-dev".to_owned()).unwrap();
+        for text in [
+            "What can you tell me about yourself and your work today?",
+            "Who are you?",
+            "What are you working on?",
+        ] {
+            let mut candidate = question();
+            candidate.question = text.to_owned();
+            let decision = authorize_question(&policy, candidate).unwrap();
+            assert_eq!(decision.execution_lane, QuestionExecutionLane::Converse);
+            assert_eq!(decision.answer, Some(SELF_CONTEXT_ANSWER));
+        }
+
+        let lookup = authorize_question(&policy, question()).unwrap();
+        assert_eq!(lookup.execution_lane, QuestionExecutionLane::Lookup);
+        assert_eq!(lookup.answer, None);
+
+        let mut evidence_question = question();
+        evidence_question.question = "What are you seeing in Okta right now?".to_owned();
+        let lookup = authorize_question(&policy, evidence_question).unwrap();
+        assert_eq!(lookup.execution_lane, QuestionExecutionLane::Lookup);
+        assert_eq!(lookup.answer, None);
     }
 
     #[test]

--- a/crates/slack-authority/src/lib.rs
+++ b/crates/slack-authority/src/lib.rs
@@ -1,10 +1,11 @@
 #![deny(unsafe_code)]
 
-//! Deterministic Slack answer acceptance authority.
+//! Deterministic Slack request and answer authority.
 //!
-//! Slack transport and graph providers supply candidate facts. This crate owns the
-//! fail-closed decision about whether a candidate can be delivered as grounded
-//! evidence or as a structured safe refusal.
+//! Slack transport supplies tenant-bound questions and graph providers supply
+//! candidate facts. This crate owns the fail-closed decisions about whether a
+//! request can be sent upstream and whether a candidate can be delivered as
+//! grounded evidence or as a structured safe refusal.
 
 use std::{error::Error, fmt};
 
@@ -12,9 +13,120 @@ use serde::{Deserialize, Serialize};
 
 pub const ANSWER_CANDIDATE_V1: &str = "slack-answer-candidate/v1";
 pub const ANSWER_DECISION_V1: &str = "slack-answer-decision/v1";
+pub const QUESTION_CANDIDATE_V1: &str = "slack-question-candidate/v1";
+pub const QUESTION_DECISION_V1: &str = "slack-question-decision/v1";
+const MAX_HISTORY_ITEMS: usize = 16;
+const MAX_HISTORY_ITEM_BYTES: usize = 8 * 1024;
 const MAX_MARKDOWN_BYTES: usize = 64 * 1024;
+const MAX_QUESTION_BYTES: usize = 32 * 1024;
 const MAX_REFUSAL_ITEMS: usize = 32;
 const MAX_REFUSAL_ITEM_BYTES: usize = 512;
+const MAX_REQUEST_ID_BYTES: usize = 512;
+const MAX_TENANT_ID_BYTES: usize = 256;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct QuestionCandidate {
+    pub schema_version: String,
+    pub tenant_id: String,
+    pub request_id: String,
+    pub question: String,
+    pub history: Vec<QuestionHistoryMessage>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct QuestionHistoryMessage {
+    pub content: String,
+    pub role: QuestionHistoryRole,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum QuestionHistoryRole {
+    Assistant,
+    User,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuestionPolicy {
+    tenant_id: String,
+}
+
+impl QuestionPolicy {
+    pub fn new(tenant_id: String) -> Result<Self, QuestionAuthorityError> {
+        if !bounded_identifier(&tenant_id, MAX_TENANT_ID_BYTES) {
+            return Err(QuestionAuthorityError::InvalidPolicy);
+        }
+        Ok(Self { tenant_id })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct QuestionDecision {
+    pub schema_version: &'static str,
+    pub tenant_id: String,
+    pub request_id: String,
+    pub authorized: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum QuestionAuthorityError {
+    HistoryInvalid,
+    InvalidPolicy,
+    InvalidRequest,
+    InvalidSchema,
+    QuestionInvalid,
+    TenantMismatch,
+}
+
+impl fmt::Display for QuestionAuthorityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::HistoryInvalid => "the question history is invalid or exceeds the size limit",
+            Self::InvalidPolicy => "the configured tenant policy is invalid",
+            Self::InvalidRequest => "the Slack request identity is invalid",
+            Self::InvalidSchema => "the question candidate schema is unsupported",
+            Self::QuestionInvalid => "the question is empty or exceeds the size limit",
+            Self::TenantMismatch => "the question tenant does not match the configured tenant",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl Error for QuestionAuthorityError {}
+
+pub fn authorize_question(
+    policy: &QuestionPolicy,
+    candidate: QuestionCandidate,
+) -> Result<QuestionDecision, QuestionAuthorityError> {
+    if candidate.schema_version != QUESTION_CANDIDATE_V1 {
+        return Err(QuestionAuthorityError::InvalidSchema);
+    }
+    if candidate.tenant_id != policy.tenant_id {
+        return Err(QuestionAuthorityError::TenantMismatch);
+    }
+    if !bounded_identifier(&candidate.request_id, MAX_REQUEST_ID_BYTES) {
+        return Err(QuestionAuthorityError::InvalidRequest);
+    }
+    if !bounded_text(&candidate.question, MAX_QUESTION_BYTES) {
+        return Err(QuestionAuthorityError::QuestionInvalid);
+    }
+    if candidate.history.len() > MAX_HISTORY_ITEMS
+        || candidate
+            .history
+            .iter()
+            .any(|message| !bounded_text(&message.content, MAX_HISTORY_ITEM_BYTES))
+    {
+        return Err(QuestionAuthorityError::HistoryInvalid);
+    }
+    Ok(QuestionDecision {
+        schema_version: QUESTION_DECISION_V1,
+        tenant_id: candidate.tenant_id,
+        request_id: candidate.request_id,
+        authorized: true,
+    })
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -162,7 +274,20 @@ fn bounded_list(values: &[String]) -> bool {
 
 fn bounded_text(value: &str, max_bytes: usize) -> bool {
     let value = value.trim();
-    !value.is_empty() && value.len() <= max_bytes
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && !value.chars().any(|character| {
+            character.is_control() && character != '\n' && character != '\r' && character != '\t'
+        })
+}
+
+fn bounded_identifier(value: &str, max_bytes: usize) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
 }
 
 #[cfg(test)]
@@ -182,6 +307,84 @@ mod tests {
             }),
             unsupported_query: None,
         }
+    }
+
+    fn question() -> QuestionCandidate {
+        QuestionCandidate {
+            schema_version: QUESTION_CANDIDATE_V1.to_owned(),
+            tenant_id: "writer-sec-dev".to_owned(),
+            request_id: "C0B2VJDFJ5N:1753830794.123".to_owned(),
+            question: "Show connector health for Okta.".to_owned(),
+            history: vec![QuestionHistoryMessage {
+                content: "Which source should I inspect?".to_owned(),
+                role: QuestionHistoryRole::Assistant,
+            }],
+        }
+    }
+
+    #[test]
+    fn authorizes_a_tenant_bound_question() {
+        let policy = QuestionPolicy::new("writer-sec-dev".to_owned()).unwrap();
+        assert_eq!(
+            authorize_question(&policy, question()).unwrap(),
+            QuestionDecision {
+                schema_version: QUESTION_DECISION_V1,
+                tenant_id: "writer-sec-dev".to_owned(),
+                request_id: "C0B2VJDFJ5N:1753830794.123".to_owned(),
+                authorized: true,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_cross_tenant_and_caller_authorized_questions() {
+        let policy = QuestionPolicy::new("writer-sec-dev".to_owned()).unwrap();
+        let mut cross_tenant = question();
+        cross_tenant.tenant_id = "other-tenant".to_owned();
+        assert_eq!(
+            authorize_question(&policy, cross_tenant),
+            Err(QuestionAuthorityError::TenantMismatch)
+        );
+        let error = serde_json::from_value::<QuestionCandidate>(serde_json::json!({
+            "schema_version": QUESTION_CANDIDATE_V1,
+            "tenant_id": "writer-sec-dev",
+            "request_id": "request-1",
+            "question": "Show connector health for Okta.",
+            "history": [],
+            "authorized": true
+        }))
+        .unwrap_err();
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_malformed_and_oversized_question_inputs() {
+        let policy = QuestionPolicy::new("writer-sec-dev".to_owned()).unwrap();
+        for invalid_request_id in ["", "request with spaces", "request\nid"] {
+            let mut candidate = question();
+            candidate.request_id = invalid_request_id.to_owned();
+            assert_eq!(
+                authorize_question(&policy, candidate),
+                Err(QuestionAuthorityError::InvalidRequest)
+            );
+        }
+        let mut oversized_question = question();
+        oversized_question.question = "x".repeat(MAX_QUESTION_BYTES + 1);
+        assert_eq!(
+            authorize_question(&policy, oversized_question),
+            Err(QuestionAuthorityError::QuestionInvalid)
+        );
+        let mut oversized_history = question();
+        oversized_history.history = (0..=MAX_HISTORY_ITEMS)
+            .map(|_| QuestionHistoryMessage {
+                content: "bounded".to_owned(),
+                role: QuestionHistoryRole::User,
+            })
+            .collect();
+        assert_eq!(
+            authorize_question(&policy, oversized_history),
+            Err(QuestionAuthorityError::HistoryInvalid)
+        );
     }
 
     fn refusal() -> AnswerCandidate {


### PR DESCRIPTION
## Summary

- authorize each outbound Slack question in the loopback Rust authority before the compatibility request starts
- bind authorization to the configured tenant, immutable Slack request identity, bounded question text, and bounded conversation history
- have Rust choose `converse` or `lookup` before the host starts graph work
- answer Cerebro self and work-status questions on the conversational lane without calling the graph endpoint
- expose content-free authorization counters and decision logs through the Rust status endpoint
- fail closed when Rust rejects the request, returns a mismatched decision, or is unavailable

## Root cause

The Slack host treated every non-command mention as a graph lookup. A conversational question about Cerebro itself could therefore produce a valid but irrelevant aggregate graph answer.

## Behavior

Self and work-status questions now receive an authority-rendered response that states Cerebro’s concrete security operations scope, does not invent a complete cross-thread activity history, and points to the thread scratchpad for retained requests, outcomes, and blockers. Evidence questions continue through the governed graph lookup and terminal answer-validation path.

## Authority boundary

Rust owns request admission, execution-lane selection for this bounded conversational case, and terminal answer acceptance. The TypeScript host owns Slack transport and SSE parsing. The Go `/grc/ask` compatibility endpoint supplies evidence and reasoning only after Rust authorizes a lookup. This PR does not claim full Rust Slack or web parity.

## Verification

- `cargo test -p cerebro-slack-authority`
- `cargo test -p cerebro-platform slack_authority`
- `cargo clippy -p cerebro-slack-authority -p cerebro-platform --all-targets -- -D warnings`
- `npm run check --prefix apps/slack-companion-host`
- `cargo fmt --all -- --check`
- `git diff --check`

Regression coverage proves the reported self/work-status question stays on `converse` and makes zero calls to the graph endpoint. A counterexample proves evidence questions such as current Okta observations remain on `lookup`.