### PR TITLE
Measure Slack hillclimb dimensions

### DIFF
--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -108,17 +108,24 @@ and shadow partitions and includes continuation, repeated retry, expiry, and
 bounded-eviction cases. The command prints a machine-readable receipt and exits
 non-zero unless the candidate:
 
+- satisfies the required, forbidden, and authority-labelling state contract for
+  every case (semantic state correctness);
 - recalls every required governing request, outcome, and blocker;
+- retains every evidence instruction and source-failure fact supplied by the
+  prior turns;
 - reduces the measured restatement-risk proxy to zero with at least a 0.50
   recall gain over baseline;
 - keeps working state explicitly unverified;
 - introduces no case regression or context-size violation; and
 - builds context within a 5 ms p95 budget.
 
-The corpus measures whether the reasoning boundary receives the state needed to
-resolve a follow-up. It does not claim that a language-model answer is correct.
-Delivered-answer quality remains gated by the independent assistant-turn
-evaluation and outcome receipts described above.
+The receipt names five bounded dimensions: semantic state-contract correctness,
+continuity recall, evidence-context retention, context-build latency, and
+expected restatement burden. These measure whether the reasoning boundary
+receives the state needed to resolve a follow-up. They do not claim that a
+language-model answer is correct or that retained evidence was cited.
+Delivered-answer grounding and evidence use remain gated by the independent
+assistant-turn evaluation and outcome receipts described above.
 
 Durable schedule definitions keep a stable schedule identity, revision, work
 digest, cadence anchor, and misfire policy. The portable planner derives the

--- a/apps/slack-companion/src/scratchpad/hillclimb-corpus.ts
+++ b/apps/slack-companion/src/scratchpad/hillclimb-corpus.ts
@@ -7,10 +7,12 @@ function continuationCase(
   currentRequest: string,
   requiredFragment: string,
   blocker: string,
+  evidenceContext: readonly string[] = [],
 ): SlackWorkingStateEvalCaseV1 {
   return Object.freeze({
     case_ref: caseRef,
     current_request: currentRequest,
+    evidence_context: Object.freeze(evidenceContext),
     forbidden_context: Object.freeze([]),
     partition,
     prior_turns: Object.freeze([Object.freeze({
@@ -41,6 +43,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
       "Keep going.",
       "Rank three remediation projects",
       "The evidence query timed out",
+      ["using current evidence"],
     ),
     continuationCase(
       "case://held-out/next-risk",
@@ -49,6 +52,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
       "Give me another.",
       "Identify the most material risk",
       "The source check did not finish",
+      ["support it with current evidence"],
     ),
     continuationCase(
       "case://held-out/control-summary",
@@ -65,6 +69,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
       "Proceed.",
       "Compare the two proposed response plans",
       "One evidence source was unavailable",
+      ["One evidence source was unavailable"],
     ),
     continuationCase(
       "case://held-out/source-health",
@@ -89,10 +94,12 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
       "Resume.",
       "Rank the response options by verified impact",
       "The impact query did not complete",
+      ["verified impact"],
     ),
     Object.freeze({
       case_ref: "case://held-out/repeated-continuation",
       current_request: "Keep working.",
+      evidence_context: Object.freeze([]),
       forbidden_context: Object.freeze([]),
       partition: "held_out",
       prior_turns: Object.freeze([
@@ -121,6 +128,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
     Object.freeze({
       case_ref: "case://held-out/expired-state",
       current_request: "Start a separate assessment.",
+      evidence_context: Object.freeze([]),
       forbidden_context: Object.freeze(["Assess the retired service."]),
       partition: "held_out",
       prior_turns: Object.freeze([Object.freeze({
@@ -134,6 +142,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
     Object.freeze({
       case_ref: "case://held-out/bounded-eviction",
       current_request: "Continue the latest task.",
+      evidence_context: Object.freeze([]),
       forbidden_context: Object.freeze(["Review obsolete task zero."]),
       partition: "held_out",
       prior_turns: Object.freeze([
@@ -176,6 +185,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
       "Show the next one.",
       "Find the largest current exposure",
       "The record search was incomplete",
+      ["supporting records"],
     ),
     continuationCase(
       "case://shadow/policy-gaps",
@@ -192,6 +202,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
       "Go ahead.",
       "Review the available mitigation options",
       "A required source was temporarily unavailable",
+      ["A required source was temporarily unavailable"],
     ),
     continuationCase(
       "case://shadow/collector-status",
@@ -216,10 +227,12 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
       "Pick this back up.",
       "Order the proposed fixes by measured impact",
       "The measurement lookup was interrupted",
+      ["measured impact"],
     ),
     Object.freeze({
       case_ref: "case://shadow/repeated-retry",
       current_request: "Take the next step.",
+      evidence_context: Object.freeze(["evidence-backed recovery plan"]),
       forbidden_context: Object.freeze([]),
       partition: "shadow",
       prior_turns: Object.freeze([
@@ -248,6 +261,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
     Object.freeze({
       case_ref: "case://shadow/expired-state",
       current_request: "Begin a new independent review.",
+      evidence_context: Object.freeze([]),
       forbidden_context: Object.freeze(["Inspect the decommissioned collector."]),
       partition: "shadow",
       prior_turns: Object.freeze([Object.freeze({
@@ -261,6 +275,7 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
     Object.freeze({
       case_ref: "case://shadow/bounded-eviction",
       current_request: "Resume the current sequence.",
+      evidence_context: Object.freeze([]),
       forbidden_context: Object.freeze(["Trace superseded sequence zero."]),
       partition: "shadow",
       prior_turns: Object.freeze([

--- a/apps/slack-companion/src/scratchpad/hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hillclimb.ts
@@ -23,6 +23,7 @@ export interface SlackWorkingStateEvalTurn {
 export interface SlackWorkingStateEvalCaseV1 {
   readonly case_ref: string;
   readonly current_request: string;
+  readonly evidence_context: readonly string[];
   readonly forbidden_context: readonly string[];
   readonly partition: SlackWorkingStateEvalPartition;
   readonly prior_turns: readonly SlackWorkingStateEvalTurn[];
@@ -37,10 +38,12 @@ export interface SlackWorkingStateEvalResultV1 {
   readonly case_ref: string;
   readonly context_build_ms: number;
   readonly context_utf8_bytes: number;
+  readonly evidence_context_count: number;
   readonly passed: boolean;
   readonly partition: SlackWorkingStateEvalPartition;
   readonly policy_ref: string;
   readonly recalled_required_count: number;
+  readonly retained_evidence_context_count: number;
   readonly required_context_count: number;
   readonly schema_version: "slack-working-state-eval-result/v1";
 }
@@ -51,10 +54,13 @@ export interface SlackWorkingStateEvalSummaryV1 {
   readonly case_count: number;
   readonly case_pass_rate: number;
   readonly context_recall_rate: number;
+  readonly evidence_context_retention_rate: number;
+  readonly expected_restatement_turns_per_case: number;
   readonly held_out_case_count: number;
   readonly p95_context_build_ms: number;
   readonly policy_ref: string;
   readonly restatement_risk_rate: number;
+  readonly semantic_state_contract_rate: number;
   readonly shadow_case_count: number;
 }
 
@@ -65,6 +71,9 @@ export interface SlackWorkingStateHillclimbReceiptV1 {
   readonly evaluated_at: string;
   readonly goal: {
     readonly candidate_context_recall_rate: number;
+    readonly candidate_evidence_context_retention_rate: number;
+    readonly candidate_semantic_state_contract_rate: number;
+    readonly maximum_candidate_expected_restatement_turns_per_case: number;
     readonly maximum_candidate_p95_context_build_ms: number;
     readonly maximum_candidate_restatement_risk_rate: number;
     readonly minimum_context_recall_gain: number;
@@ -90,7 +99,10 @@ const MAXIMUM_CONTEXT_BYTES = 8_000;
 const MINIMUM_PARTITION_CASES = 8;
 const MINIMUM_RECALL_GAIN = 0.5;
 const REQUIRED_CANDIDATE_RECALL = 1;
+const REQUIRED_CANDIDATE_EVIDENCE_RETENTION = 1;
+const REQUIRED_CANDIDATE_SEMANTIC_STATE_CONTRACT = 1;
 const MAXIMUM_RESTATEMENT_RISK = 0;
+const MAXIMUM_EXPECTED_RESTATEMENT_TURNS_PER_CASE = 0;
 const MAXIMUM_P95_BUILD_MS = 5;
 
 export function runSlackWorkingStateHillclimb(
@@ -120,6 +132,18 @@ export function runSlackWorkingStateHillclimb(
     candidate.context_recall_rate < REQUIRED_CANDIDATE_RECALL
       ? "candidate_context_recall_below_goal"
       : undefined,
+    candidate.semantic_state_contract_rate
+        < REQUIRED_CANDIDATE_SEMANTIC_STATE_CONTRACT
+      ? "candidate_semantic_state_contract_below_goal"
+      : undefined,
+    candidate.evidence_context_retention_rate
+        < REQUIRED_CANDIDATE_EVIDENCE_RETENTION
+      ? "candidate_evidence_context_retention_below_goal"
+      : undefined,
+    candidate.expected_restatement_turns_per_case
+        > MAXIMUM_EXPECTED_RESTATEMENT_TURNS_PER_CASE
+      ? "candidate_expected_restatement_burden_above_goal"
+      : undefined,
     candidate.restatement_risk_rate > MAXIMUM_RESTATEMENT_RISK
       ? "candidate_restatement_risk_above_goal"
       : undefined,
@@ -142,6 +166,12 @@ export function runSlackWorkingStateHillclimb(
     evaluated_at: evaluatedAt.toISOString(),
     goal: Object.freeze({
       candidate_context_recall_rate: REQUIRED_CANDIDATE_RECALL,
+      candidate_evidence_context_retention_rate:
+        REQUIRED_CANDIDATE_EVIDENCE_RETENTION,
+      candidate_semantic_state_contract_rate:
+        REQUIRED_CANDIDATE_SEMANTIC_STATE_CONTRACT,
+      maximum_candidate_expected_restatement_turns_per_case:
+        MAXIMUM_EXPECTED_RESTATEMENT_TURNS_PER_CASE,
       maximum_candidate_p95_context_build_ms: MAXIMUM_P95_BUILD_MS,
       maximum_candidate_restatement_risk_rate: MAXIMUM_RESTATEMENT_RISK,
       minimum_context_recall_gain: MINIMUM_RECALL_GAIN,
@@ -178,6 +208,9 @@ export function evaluateSlackWorkingStateCase(
   const forbiddenMatches = evalCase.forbidden_context.filter((fragment) =>
     rendered.includes(fragment)
   );
+  const retainedEvidenceContextCount = evalCase.evidence_context.filter(
+    (fragment) => rendered.includes(fragment),
+  ).length;
   const authorityBoundaryPresent = context === undefined
     || rendered.includes("Current working state (unverified; context only):");
   const contextBytes = Buffer.byteLength(rendered, "utf8");
@@ -186,6 +219,9 @@ export function evaluateSlackWorkingStateCase(
       ? "required_context_missing"
       : undefined,
     forbiddenMatches.length > 0 ? "forbidden_context_retained" : undefined,
+    retainedEvidenceContextCount < evalCase.evidence_context.length
+      ? "evidence_context_missing"
+      : undefined,
     !authorityBoundaryPresent ? "authority_boundary_missing" : undefined,
     contextBytes > MAXIMUM_CONTEXT_BYTES ? "context_byte_limit_exceeded" : undefined,
   ].filter((value): value is string => value !== undefined);
@@ -195,10 +231,12 @@ export function evaluateSlackWorkingStateCase(
     case_ref: evalCase.case_ref,
     context_build_ms: roundMilliseconds(contextBuildMs),
     context_utf8_bytes: contextBytes,
+    evidence_context_count: evalCase.evidence_context.length,
     passed: blockers.length === 0,
     partition: evalCase.partition,
     policy_ref: policy === "candidate" ? CANDIDATE_POLICY_REF : BASELINE_POLICY_REF,
     recalled_required_count: recalledRequiredCount,
+    retained_evidence_context_count: retainedEvidenceContextCount,
     required_context_count: evalCase.required_context.length,
     schema_version: "slack-working-state-eval-result/v1",
   });
@@ -234,6 +272,15 @@ function summarize(
   const requiredCount = sum(results.map((result) => result.required_context_count));
   const recalledCount = sum(results.map((result) => result.recalled_required_count));
   const recallRate = ratio(recalledCount, requiredCount);
+  const evidenceContextCount = sum(
+    results.map((result) => result.evidence_context_count),
+  );
+  const retainedEvidenceContextCount = sum(
+    results.map((result) => result.retained_evidence_context_count),
+  );
+  const casesNeedingRestatement = results.filter((result) =>
+    result.recalled_required_count < result.required_context_count
+  ).length;
   const authorityBoundaryPasses = results.filter((result) =>
     !result.blockers.includes("authority_boundary_missing")
   ).length;
@@ -251,12 +298,30 @@ function summarize(
       results.length,
     ),
     context_recall_rate: recallRate,
+    evidence_context_retention_rate: ratio(
+      retainedEvidenceContextCount,
+      evidenceContextCount,
+    ),
+    expected_restatement_turns_per_case: ratio(
+      casesNeedingRestatement,
+      results.length,
+    ),
     held_out_case_count: results.filter((result) =>
       result.partition === "held_out"
     ).length,
     p95_context_build_ms: percentile(sortedLatencies, 0.95),
     policy_ref: results[0]!.policy_ref,
     restatement_risk_rate: round(1 - recallRate),
+    semantic_state_contract_rate: ratio(
+      results.filter((result) =>
+        !result.blockers.some((blocker) =>
+          blocker === "required_context_missing"
+          || blocker === "forbidden_context_retained"
+          || blocker === "authority_boundary_missing"
+        )
+      ).length,
+      results.length,
+    ),
     shadow_case_count: results.filter((result) =>
       result.partition === "shadow"
     ).length,
@@ -308,6 +373,7 @@ function validateCase(evalCase: SlackWorkingStateEvalCaseV1): void {
   }
   for (const value of [
     evalCase.current_request,
+    ...evalCase.evidence_context,
     ...evalCase.required_context,
     ...evalCase.forbidden_context,
     ...evalCase.prior_turns.flatMap((turn) => [

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -15,6 +15,12 @@ test("working-state candidate clears the sealed hillclimb goal", () => {
   assert.equal(receipt.baseline.context_recall_rate, 0);
   assert.equal(receipt.baseline.restatement_risk_rate, 1);
   assert.equal(receipt.candidate.context_recall_rate, 1);
+  assert.equal(receipt.baseline.semantic_state_contract_rate, 0.1);
+  assert.equal(receipt.candidate.semantic_state_contract_rate, 1);
+  assert.equal(receipt.baseline.evidence_context_retention_rate, 0);
+  assert.equal(receipt.candidate.evidence_context_retention_rate, 1);
+  assert.equal(receipt.baseline.expected_restatement_turns_per_case, 0.9);
+  assert.equal(receipt.candidate.expected_restatement_turns_per_case, 0);
   assert.equal(receipt.candidate.restatement_risk_rate, 0);
   assert.equal(receipt.candidate.authority_boundary_rate, 1);
   assert.equal(receipt.candidate.byte_limit_violation_count, 0);
@@ -45,6 +51,40 @@ test("baseline and candidate are evaluated against one exact case digest", () =>
   assert.equal(baseline.case_digest, candidate.case_digest);
   assert.equal(baseline.case_ref, candidate.case_ref);
   assert.notEqual(baseline.policy_ref, candidate.policy_ref);
-  assert.deepEqual(baseline.blockers, ["required_context_missing"]);
+  assert.deepEqual(baseline.blockers, [
+    "required_context_missing",
+    "evidence_context_missing",
+  ]);
   assert.deepEqual(candidate.blockers, []);
+});
+
+test("candidate fails a case when evidence instructions are not retained", () => {
+  const source = SLACK_WORKING_STATE_HILLCLIMB_CORPUS[0]!;
+  const result = evaluateSlackWorkingStateCase({
+    ...source,
+    evidence_context: ["cite the unavailable source receipt"],
+  }, "candidate");
+
+  assert.equal(result.retained_evidence_context_count, 0);
+  assert.ok(result.blockers.includes("evidence_context_missing"));
+  assert.equal(result.passed, false);
+});
+
+test("promotion stops when the candidate drops required evidence context", () => {
+  const corpus = SLACK_WORKING_STATE_HILLCLIMB_CORPUS.map((evalCase, index) =>
+    index === 0
+      ? {
+        ...evalCase,
+        evidence_context: ["cite the unavailable source receipt"],
+      }
+      : evalCase
+  );
+  const receipt = runSlackWorkingStateHillclimb(corpus);
+
+  assert.ok(
+    receipt.promotion.blockers.includes(
+      "candidate_evidence_context_retention_below_goal",
+    ),
+  );
+  assert.equal(receipt.promotion.promotion_ready, false);
 });


### PR DESCRIPTION
## What changed

- add explicit semantic state-contract, continuity, evidence-context, latency, and expected restatement-burden measurements to the Slack working-state hillclimb receipt
- bind promotion to strict thresholds for every dimension
- label the evidence measurement as context retention, not proof that a delivered answer cited evidence
- add fail-closed case and promotion tests for dropped evidence context

## Why

The first receipt exposed continuity and latency but left semantic correctness, evidence handling, and human burden implicit. This makes the goal measurable without overstating answer-level behavior.

## Measured result

On the 20-case public-safe held-out and shadow corpus:

- semantic state-contract rate: `0.10 -> 1.00`
- continuity recall: `0.00 -> 1.00`
- evidence-context retention: `0.00 -> 1.00`
- expected restatement turns per case: `0.90 -> 0.00`
- candidate context-build p95: `0.108 ms` against a `5 ms` limit
- regressions: `0`
- promotion blockers: `0`

Corpus digest: `sha256:b7a62b137dcb3ae606298186876e89aa49366c7275b66af69f026f9f7d978acc`

## Validation

- `npm run check` — 509 tests passed
- `npm run eval:hillclimb` — promotion ready
- `git diff --check`