### PR TITLE
Run the Slack hillclimb offline

### DIFF
--- a/apps/slack-companion/README.md
+++ b/apps/slack-companion/README.md
@@ -102,11 +102,20 @@ same redaction and expiry policy as saved notes.
 
 ### Working-state hillclimb
 
-`npm run eval:hillclimb` replays the prior no-state policy and the working-state
-candidate against the same public-safe corpus. The corpus has separate held-out
-and shadow partitions and includes continuation, repeated retry, expiry, and
+`npm run --silent eval:hillclimb` runs offline and emits only its JSON receipt.
+It builds locally, starts the evaluator
+with Node's permission boundary, grants read access only to the package, and
+denies network access, child processes, workers, native addons, and filesystem
+writes. A runtime guard covers Node versions whose permission model does not
+deny network access directly. The command probes fetch, DNS, TCP, TLS, HTTP,
+HTTP/2, datagram, and child-process access before loading the corpus or
+candidate, then records the result in `offline_execution`.
+
+The evaluator replays the prior no-state policy and the working-state candidate
+against the same public-safe corpus. The corpus has separate held-out and shadow
+partitions and includes continuation, repeated retry, expiry, and
 bounded-eviction cases. The command prints a machine-readable receipt and exits
-non-zero unless the candidate:
+non-zero unless the offline boundary is active and the candidate:
 
 - satisfies the required, forbidden, and authority-labelling state contract for
   every case (semantic state correctness);

--- a/apps/slack-companion/package.json
+++ b/apps/slack-companion/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "npm run typecheck && npm test",
-    "eval:hillclimb": "npm run build --silent && node dist/src/scratchpad/run-hillclimb.js",
+    "eval:hillclimb": "npm run build --silent && node --permission --allow-fs-read=. dist/src/scratchpad/run-hillclimb-offline.js",
     "test": "npm run build && node --test dist/test/*.test.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/apps/slack-companion/src/scratchpad/hillclimb-corpus.ts
+++ b/apps/slack-companion/src/scratchpad/hillclimb-corpus.ts
@@ -170,6 +170,22 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
       ]),
       schema_version: "slack-working-state-eval-case/v1",
     }),
+    Object.freeze({
+      case_ref: "case://held-out/self-status-follow-up",
+      current_request: "What else can you verify?",
+      evidence_context: Object.freeze(["your work today"]),
+      forbidden_context: Object.freeze([]),
+      partition: "held_out",
+      prior_turns: Object.freeze([Object.freeze({
+        outcome: "completed" as const,
+        request: "what can you tell me about yourself and your work today?",
+      })]),
+      required_context: Object.freeze([
+        "what can you tell me about yourself and your work today?",
+        "Last outcome: completed.",
+      ]),
+      schema_version: "slack-working-state-eval-case/v1",
+    }),
     continuationCase(
       "case://shadow/ranked-actions",
       "shadow",
@@ -300,6 +316,22 @@ export const SLACK_WORKING_STATE_HILLCLIMB_CORPUS: readonly SlackWorkingStateEva
         "Trace current sequence one.",
         "Trace current sequence two.",
         "Trace current sequence three.",
+      ]),
+      schema_version: "slack-working-state-eval-case/v1",
+    }),
+    Object.freeze({
+      case_ref: "case://shadow/self-status-follow-up",
+      current_request: "Continue with only what you can support.",
+      evidence_context: Object.freeze(["work you can verify from today"]),
+      forbidden_context: Object.freeze([]),
+      partition: "shadow",
+      prior_turns: Object.freeze([Object.freeze({
+        outcome: "completed" as const,
+        request: "Describe your role and the work you can verify from today.",
+      })]),
+      required_context: Object.freeze([
+        "Describe your role and the work you can verify from today.",
+        "Last outcome: completed.",
       ]),
       schema_version: "slack-working-state-eval-case/v1",
     }),

--- a/apps/slack-companion/src/scratchpad/offline-guard.ts
+++ b/apps/slack-companion/src/scratchpad/offline-guard.ts
@@ -1,0 +1,179 @@
+import childProcess from "node:child_process";
+import dgram from "node:dgram";
+import dns from "node:dns";
+import dnsPromises from "node:dns/promises";
+import http from "node:http";
+import http2 from "node:http2";
+import https from "node:https";
+import { syncBuiltinESMExports } from "node:module";
+import net from "node:net";
+import tls from "node:tls";
+
+const OFFLINE_ERROR_CODE = "CEREBRO_OFFLINE_ACCESS_DENIED";
+
+export interface SlackWorkingStateOfflineExecutionV1 {
+  readonly child_process_access: "denied";
+  readonly filesystem_write_access: "denied";
+  readonly native_addon_access: "denied";
+  readonly network_access: "denied";
+  readonly network_probe: "passed";
+  readonly schema_version: "slack-working-state-offline-execution/v1";
+  readonly worker_access: "denied";
+}
+
+interface PermissionApi {
+  has(scope: string, reference?: string): boolean;
+}
+
+export class OfflineHarnessAccessError extends Error {
+  readonly code = OFFLINE_ERROR_CODE;
+
+  constructor(resource: string) {
+    super(`Offline hillclimb denied ${resource}.`);
+    this.name = "OfflineHarnessAccessError";
+  }
+}
+
+export function installOfflineNetworkGuard(): void {
+  const deny = (resource: string) =>
+    function denyOfflineAccess(): never {
+      throw new OfflineHarnessAccessError(resource);
+    };
+  const replace = (
+    target: object,
+    property: string,
+    resource: string,
+  ): void => {
+    Object.defineProperty(target, property, {
+      configurable: true,
+      value: deny(resource),
+      writable: true,
+    });
+  };
+
+  for (const property of ["lookup", "lookupService", "resolve", "resolve4",
+    "resolve6", "resolveAny", "resolveCaa", "resolveCname", "resolveMx",
+    "resolveNaptr", "resolveNs", "resolvePtr", "resolveSoa", "resolveSrv",
+    "resolveTxt", "reverse"]) {
+    replace(dns, property, `DNS ${property}`);
+    replace(dnsPromises, property, `DNS promises ${property}`);
+  }
+  for (const resolver of [
+    dns.Resolver.prototype,
+    dnsPromises.Resolver.prototype,
+  ]) {
+    for (const property of ["resolve", "resolve4", "resolve6", "resolveAny",
+      "resolveCaa", "resolveCname", "resolveMx", "resolveNaptr", "resolveNs",
+      "resolvePtr", "resolveSoa", "resolveSrv", "resolveTxt", "reverse"]) {
+      replace(resolver, property, `DNS resolver ${property}`);
+    }
+  }
+  for (const property of ["connect", "createConnection", "createServer"]) {
+    replace(net, property, `network ${property}`);
+  }
+  replace(net.Socket.prototype, "connect", "socket connection");
+  replace(net.Server.prototype, "listen", "network listener");
+
+  for (const property of ["connect", "createServer"]) {
+    replace(tls, property, `TLS ${property}`);
+  }
+  replace(tls.TLSSocket.prototype, "connect", "TLS socket connection");
+  replace(dgram, "createSocket", "datagram socket");
+
+  for (const [target, label] of [
+    [http, "HTTP"],
+    [https, "HTTPS"],
+  ] as const) {
+    for (const property of ["get", "request", "createServer"]) {
+      replace(target, property, `${label} ${property}`);
+    }
+  }
+  for (const property of ["connect", "createServer", "createSecureServer"]) {
+    replace(http2, property, `HTTP/2 ${property}`);
+  }
+
+  replace(childProcess, "exec", "child process");
+  replace(childProcess, "execFile", "child process");
+  replace(childProcess, "fork", "child process");
+  replace(childProcess, "spawn", "child process");
+
+  replace(globalThis, "fetch", "fetch");
+  if ("WebSocket" in globalThis) {
+    replace(globalThis, "WebSocket", "WebSocket");
+  }
+  if ("EventSource" in globalThis) {
+    replace(globalThis, "EventSource", "EventSource");
+  }
+  syncBuiltinESMExports();
+}
+
+export async function proveOfflineExecution():
+  Promise<SlackWorkingStateOfflineExecutionV1> {
+  const permission = (process as typeof process & {
+    permission?: PermissionApi;
+  }).permission;
+  if (permission === undefined) {
+    throw new Error("Offline hillclimb requires the Node permission model.");
+  }
+  for (const [scope, label] of [
+    ["child", "child processes"],
+    ["worker", "workers"],
+    ["addons", "native addons"],
+  ] as const) {
+    if (permission.has(scope)) {
+      throw new Error(`Offline hillclimb must deny ${label}.`);
+    }
+  }
+  if (permission.has("fs.write", process.cwd())) {
+    throw new Error("Offline hillclimb must deny filesystem writes.");
+  }
+
+  await Promise.all([
+    expectOfflineDenial("fetch", () =>
+      fetch("https://offline-probe.invalid/")),
+    expectOfflineDenial("DNS", () =>
+      dnsPromises.lookup("offline-probe.invalid")),
+    expectOfflineDenial("TCP", () =>
+      net.connect(443, "offline-probe.invalid")),
+    expectOfflineDenial("TLS", () =>
+      tls.connect(443, "offline-probe.invalid")),
+    expectOfflineDenial("HTTP", () =>
+      http.get("http://offline-probe.invalid/")),
+    expectOfflineDenial("HTTPS", () =>
+      https.get("https://offline-probe.invalid/")),
+    expectOfflineDenial("HTTP/2", () =>
+      http2.connect("https://offline-probe.invalid/")),
+    expectOfflineDenial("datagram", () =>
+      dgram.createSocket("udp4")),
+    expectOfflineDenial("child process", () =>
+      childProcess.spawn(process.execPath, ["--version"])),
+  ]);
+
+  return Object.freeze({
+    child_process_access: "denied",
+    filesystem_write_access: "denied",
+    native_addon_access: "denied",
+    network_access: "denied",
+    network_probe: "passed",
+    schema_version: "slack-working-state-offline-execution/v1",
+    worker_access: "denied",
+  });
+}
+
+async function expectOfflineDenial(
+  label: string,
+  operation: () => unknown,
+): Promise<void> {
+  let probeError: unknown;
+  try {
+    await operation();
+  } catch (error) {
+    probeError = error;
+  }
+  if (
+    !(probeError instanceof OfflineHarnessAccessError)
+    || probeError.code !== OFFLINE_ERROR_CODE
+  ) {
+    throw new Error(`Offline hillclimb ${label} denial probe failed.`);
+  }
+}

--- a/apps/slack-companion/src/scratchpad/run-hillclimb-offline.ts
+++ b/apps/slack-companion/src/scratchpad/run-hillclimb-offline.ts
@@ -1,0 +1,24 @@
+import {
+  installOfflineNetworkGuard,
+  proveOfflineExecution,
+} from "./offline-guard.js";
+
+installOfflineNetworkGuard();
+const offlineExecution = await proveOfflineExecution();
+const [
+  { SLACK_WORKING_STATE_HILLCLIMB_CORPUS },
+  { runSlackWorkingStateHillclimb },
+] = await Promise.all([
+  import("./hillclimb-corpus.js"),
+  import("./hillclimb.js"),
+]);
+const evaluation = runSlackWorkingStateHillclimb(
+  SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
+);
+const receipt = Object.freeze({
+  ...evaluation,
+  offline_execution: offlineExecution,
+});
+
+process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+if (!receipt.promotion.promotion_ready) process.exitCode = 1;

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -1,10 +1,50 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   evaluateSlackWorkingStateCase,
   runSlackWorkingStateHillclimb,
   SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
 } from "../src/index.js";
+
+test("hillclimb CLI runs inside the enforced offline boundary", () => {
+  const runner = fileURLToPath(
+    new URL("../src/scratchpad/run-hillclimb-offline.js", import.meta.url),
+  );
+  const result = spawnSync(process.execPath, [
+    "--permission",
+    "--allow-fs-read=.",
+    runner,
+  ], {
+    cwd: fileURLToPath(new URL("..", import.meta.url)),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const receipt = JSON.parse(result.stdout) as {
+    offline_execution: {
+      child_process_access: string;
+      filesystem_write_access: string;
+      native_addon_access: string;
+      network_access: string;
+      network_probe: string;
+      schema_version: string;
+      worker_access: string;
+    };
+    promotion: { promotion_ready: boolean };
+  };
+  assert.deepEqual(receipt.offline_execution, {
+    child_process_access: "denied",
+    filesystem_write_access: "denied",
+    native_addon_access: "denied",
+    network_access: "denied",
+    network_probe: "passed",
+    schema_version: "slack-working-state-offline-execution/v1",
+    worker_access: "denied",
+  });
+  assert.equal(receipt.promotion.promotion_ready, true);
+});
 
 test("working-state candidate clears the sealed hillclimb goal", () => {
   const receipt = runSlackWorkingStateHillclimb(
@@ -15,11 +55,11 @@ test("working-state candidate clears the sealed hillclimb goal", () => {
   assert.equal(receipt.baseline.context_recall_rate, 0);
   assert.equal(receipt.baseline.restatement_risk_rate, 1);
   assert.equal(receipt.candidate.context_recall_rate, 1);
-  assert.equal(receipt.baseline.semantic_state_contract_rate, 0.1);
+  assert.equal(receipt.baseline.semantic_state_contract_rate, 0.0909);
   assert.equal(receipt.candidate.semantic_state_contract_rate, 1);
   assert.equal(receipt.baseline.evidence_context_retention_rate, 0);
   assert.equal(receipt.candidate.evidence_context_retention_rate, 1);
-  assert.equal(receipt.baseline.expected_restatement_turns_per_case, 0.9);
+  assert.equal(receipt.baseline.expected_restatement_turns_per_case, 0.9091);
   assert.equal(receipt.candidate.expected_restatement_turns_per_case, 0);
   assert.equal(receipt.candidate.restatement_risk_rate, 0);
   assert.equal(receipt.candidate.authority_boundary_rate, 1);
@@ -28,8 +68,8 @@ test("working-state candidate clears the sealed hillclimb goal", () => {
   assert.equal(receipt.promotion.regression_count, 0);
   assert.deepEqual(receipt.promotion.blockers, []);
   assert.equal(receipt.promotion.promotion_ready, true);
-  assert.equal(receipt.baseline.held_out_case_count, 10);
-  assert.equal(receipt.baseline.shadow_case_count, 10);
+  assert.equal(receipt.baseline.held_out_case_count, 11);
+  assert.equal(receipt.baseline.shadow_case_count, 11);
 });
 
 test("hillclimb rejects a corpus without independently partitioned coverage", () => {


### PR DESCRIPTION
## What changed

- run the working-state hillclimb inside a read-only Node permission boundary
- deny network APIs and subprocess escape paths before loading the corpus or candidate
- probe the offline boundary and include its result in the JSON receipt
- add the self-status regression prompt and an independently worded shadow case to the public-safe corpus

## Why

The evaluation harness should be reproducible without Slack, Cerebro services, hosted models, credentials, or network access. The command now fails before evaluation if its offline boundary is not active.

## Validation

- `npm run check` in `apps/slack-companion` (510 tests)
- `npm run check` in `apps/slack-companion-host` (81 tests)
- `npm run --silent eval:hillclimb` (22 cases, zero blockers)
- constrained receipt on Node 22.22.0 and Node 26.5.0
- `git diff --check`