### PR TITLE
Trust AWS RDS roots in the Rust runtime

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -54,7 +54,33 @@ RUN find /app/sources -mindepth 2 -type f ! -name catalog.yaml -delete
 
 FROM ${RUNTIME_BASE_IMAGE} AS runtime
 
+ADD --checksum=sha256:e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3 \
+    https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+    /tmp/aws-rds-global-bundle.pem
+
 RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates openssl && \
+    awk '\
+      /-----BEGIN CERTIFICATE-----/ { certificate += 1 } \
+      certificate > 0 { \
+        print > sprintf("/usr/local/share/ca-certificates/aws-rds-root-%03d.crt", certificate) \
+      } \
+      END { if (certificate != 108) exit 1 } \
+    ' /tmp/aws-rds-global-bundle.pem && \
+    for certificate in /usr/local/share/ca-certificates/aws-rds-root-*.crt; do \
+      subject="$(openssl x509 -in "${certificate}" -noout -subject -nameopt RFC2253)"; \
+      issuer="$(openssl x509 -in "${certificate}" -noout -issuer -nameopt RFC2253)"; \
+      test "${subject#subject=}" = "${issuer#issuer=}"; \
+      openssl verify -CAfile "${certificate}" "${certificate}"; \
+      case "${subject}" in \
+        *"CN=Amazon RDS "*" Root CA RSA2048 G1"*) ;; \
+        *"CN=Amazon RDS "*" Root CA RSA4096 G1"*) ;; \
+        *"CN=Amazon RDS "*" Root CA ECC384 G1"*) ;; \
+        *) exit 1 ;; \
+      esac; \
+    done && \
+    update-ca-certificates && \
+    rm /tmp/aws-rds-global-bundle.pem && \
     addgroup -S cerebro && \
     adduser -S -G cerebro -u 10001 cerebro
 

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -68,10 +68,10 @@ RUN apk upgrade --no-cache && \
       END { if (certificate != 108) exit 1 } \
     ' /tmp/aws-rds-global-bundle.pem && \
     for certificate in /usr/local/share/ca-certificates/aws-rds-root-*.crt; do \
-      subject="$(openssl x509 -in "${certificate}" -noout -subject -nameopt RFC2253)"; \
-      issuer="$(openssl x509 -in "${certificate}" -noout -issuer -nameopt RFC2253)"; \
-      test "${subject#subject=}" = "${issuer#issuer=}"; \
-      openssl verify -CAfile "${certificate}" "${certificate}"; \
+      subject="$(openssl x509 -in "${certificate}" -noout -subject -nameopt RFC2253)" || exit 1; \
+      issuer="$(openssl x509 -in "${certificate}" -noout -issuer -nameopt RFC2253)" || exit 1; \
+      test "${subject#subject=}" = "${issuer#issuer=}" || exit 1; \
+      openssl verify -CAfile "${certificate}" "${certificate}" || exit 1; \
       case "${subject}" in \
         *"CN=Amazon RDS "*" Root CA RSA2048 G1"*) ;; \
         *"CN=Amazon RDS "*" Root CA RSA4096 G1"*) ;; \

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -37,8 +37,8 @@ fn rust_runtime_image_has_no_go_executable_path() {
         "apk add --no-cache ca-certificates openssl",
         "/usr/local/share/ca-certificates/aws-rds-root-%03d.crt",
         "if (certificate != 108) exit 1",
-        "test \"${subject#subject=}\" = \"${issuer#issuer=}\"",
-        "openssl verify -CAfile \"${certificate}\" \"${certificate}\"",
+        "test \"${subject#subject=}\" = \"${issuer#issuer=}\" || exit 1",
+        "openssl verify -CAfile \"${certificate}\" \"${certificate}\" || exit 1",
         "CN=Amazon RDS \"*\" Root CA RSA2048 G1",
         "CN=Amazon RDS \"*\" Root CA RSA4096 G1",
         "CN=Amazon RDS \"*\" Root CA ECC384 G1",
@@ -64,6 +64,11 @@ fn rust_runtime_image_has_no_go_executable_path() {
             "Rust runtime Dockerfile weakens TLS verification with {forbidden:?}"
         );
     }
+    assert_eq!(
+        DOCKERFILE.matches("-nameopt RFC2253)\" || exit 1").count(),
+        2,
+        "Rust runtime must fail closed when either certificate identity cannot be parsed"
+    );
 }
 
 fn contains_word_pair(input: &str, first: &str, second: &str) -> bool {

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -32,6 +32,17 @@ fn rust_runtime_image_has_no_go_executable_path() {
     );
     for required in [
         "cerebro-platform --bin cerebro-platform",
+        "ADD --checksum=sha256:e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3",
+        "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+        "apk add --no-cache ca-certificates openssl",
+        "/usr/local/share/ca-certificates/aws-rds-root-%03d.crt",
+        "if (certificate != 108) exit 1",
+        "test \"${subject#subject=}\" = \"${issuer#issuer=}\"",
+        "openssl verify -CAfile \"${certificate}\" \"${certificate}\"",
+        "CN=Amazon RDS \"*\" Root CA RSA2048 G1",
+        "CN=Amazon RDS \"*\" Root CA RSA4096 G1",
+        "CN=Amazon RDS \"*\" Root CA ECC384 G1",
+        "update-ca-certificates",
         "/usr/local/bin/cerebro-event-admission-worker",
         "/usr/local/bin/cerebro-platform",
         "ENTRYPOINT [\"/usr/local/bin/cerebro-platform\"]",
@@ -41,6 +52,16 @@ fn rust_runtime_image_has_no_go_executable_path() {
         assert!(
             DOCKERFILE.contains(required),
             "Rust runtime Dockerfile is missing {required:?}"
+        );
+    }
+    for forbidden in [
+        "danger_accept_invalid_certs",
+        "danger_accept_invalid_hostnames",
+        "sslmode=disable",
+    ] {
+        assert!(
+            !DOCKERFILE.contains(forbidden),
+            "Rust runtime Dockerfile weakens TLS verification with {forbidden:?}"
         );
     }
 }

--- a/scripts/qualify-rust-graph.sh
+++ b/scripts/qualify-rust-graph.sh
@@ -286,7 +286,7 @@ assert_status 200 graph-canary-go-after-restart \
 
 rust_container="$(docker compose "${compose_files[@]}" ps -q rust-platform)"
 docker stop "${rust_container}" >/dev/null
-assert_status 200 readiness-canary-without-rust \
+assert_status 503 readiness-canary-without-rust \
   "${output_dir}/readiness.json" http://127.0.0.1:8080/health
 assert_status 200 graph-canary-go-without-rust \
   "${output_dir}/canary-go-response.json" "${go_canary_url}" go-canary-key
@@ -363,7 +363,7 @@ jq \
        {
          name: "canary_legacy_isolation",
          status: "passed",
-         evidence: "Go readiness and the non-sampled Go read stayed available while Rust was stopped"
+         evidence: "global readiness failed closed while the non-sampled Go read stayed available with Rust stopped"
        },
        {
          name: "canary_rust_fail_closed",


### PR DESCRIPTION
## What changed

- install the checksum-pinned AWS RDS global root bundle in the Rust-only runtime trust store
- fail the image build unless every bundled certificate is a self-signed Amazon RDS root with an expected algorithm generation
- keep TLS certificate and hostname verification enabled
- align disposable canary qualification with fail-closed readiness when the Rust cohort is unavailable

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-platform --test rust_only_runtime_contract`
- `go test ./internal/sourcehttp/organizationalgraph -run TestCanaryQueryStoreReadinessRequiresBothAuthorities -count=1`
- `bash -n scripts/qualify-rust-graph.sh`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

The local container daemon was unavailable; hosted image and ephemeral checks exercise the BuildKit, Alpine trust-store, and canary qualification paths.