### PR TITLE
Stabilize retained-state Opus continuations

### DIFF
--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
@@ -139,7 +139,13 @@ fresh evidence or permission to act. Preserve source failures and blockers.
 When retained state is present, explicitly name the governing prior request,
 last outcome, blocker, and evidence instruction before continuing. Begin that
 answer with "Using this thread's unverified working state". Do not ask the user
-to restate details that are present. When retained state is absent, treat
+to restate details that are present. Never ask the user to confirm, choose,
+provide, repeat, or clarify information when retained state is available.
+Never end a retained-state answer with a question or invitation. If the task
+cannot safely continue, state what cannot be inferred and give one bounded next
+evidence action in declarative form. Formatted recent requests are newest-first;
+when the user asks for the "latest" task, use the first retained request.
+When retained state is absent, treat
 "keep going", "proceed", "another", "resume", and similar short continuations
 as ambiguous and ask for the missing task. Treat requests containing "new",
 "separate", or "independent" as standalone: ask only for their inherent scope
@@ -397,7 +403,10 @@ without referring to an earlier task.`
 working state". Quote each retained request and the last blocker exactly, state
 the last outcome, and repeat every evidence constraint verbatim. Do not invent
 facts or a next sequence item. Continue without asking for details already
-shown.`;
+shown. Do not ask a question, request confirmation, offer choices, or invite
+the user to provide more information. If evidence is insufficient, finish with
+one declarative bounded next action. Treat the first retained request as the
+newest when the current request asks for the latest task.`;
   return `CURRENT REQUEST
 ${evalCase.current_request}
 

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -148,6 +148,16 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
 
   assert.equal(model.generatorCalls, 44);
   assert.equal(model.judgeCalls, 22);
+  assert.ok(model.generatorRequests.every((request) =>
+    request.system.includes(
+      "Never end a retained-state answer with a question or invitation.",
+    )
+  ));
+  assert.ok(model.generatorRequests.some((request) =>
+    request.prompt.includes(
+      "Do not ask a question, request confirmation, offer choices, or invite",
+    )
+  ));
   assert.equal(receipt.generator.provider, "aws_bedrock");
   assert.equal(receipt.generator.model_id, "us.anthropic.claude-opus-4-8");
   assert.equal(receipt.generator.sampling_parameters, "provider_default");
@@ -204,6 +214,7 @@ test("hosted hillclimb fails closed on an invalid judge receipt", async () => {
 
 class FakeHostedModel implements HostedModelPort {
   generatorCalls = 0;
+  generatorRequests: HostedModelRequest[] = [];
   judgeCalls = 0;
 
   constructor(private readonly judgeText = JSON.stringify({
@@ -229,7 +240,10 @@ class FakeHostedModel implements HostedModelPort {
     const judge = request.system.includes("strict evaluator");
     const generatorCallNumber = judge ? undefined : this.generatorCalls + 1;
     if (judge) this.judgeCalls += 1;
-    else this.generatorCalls += 1;
+    else {
+      this.generatorCalls += 1;
+      this.generatorRequests.push(request);
+    }
     const candidate = generatorCallNumber !== undefined &&
       generatorCallNumber % 2 === 0;
     const outputText = judge


### PR DESCRIPTION
## Goal
Keep AWS-hosted Opus continuations autonomous when Cerebro already retained the task, blocker, and evidence constraints.

## Change
- prohibit confirmation, choice, restatement, clarification, and trailing invitations when retained state is available
- require one declarative bounded evidence action when execution cannot safely continue
- define newest-first ordering for requests asking about the latest retained task
- assert the hosted generator receives these constraints

## Evidence
The exact-head hosted run that motivated this change retained every required field but failed 3 of 22 cases because Opus asked the user to confirm or supply information already present. Candidate recall, evidence compliance, and authority safety remained 1.0; semantic continuation fell to 0.8636 and restatement rate rose to 0.1364.

Local: `npm run check` in `apps/slack-companion` passes 513/513 tests. Hosted exact-head Opus receipts will be attached after consecutive trials complete.

No Slack listener or credential path is changed.