### PR TITLE
fix: scope Archetype vulnerability identity by scan

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -5623,7 +5623,7 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 
 	repoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/Archetype"
 	scanURN := "urn:cerebro:writer:archetype_scan:1"
-	findingURN := "urn:cerebro:writer:archetype_finding:10"
+	findingURN := "urn:cerebro:writer:archetype_finding:1:10"
 	noteURN := "urn:cerebro:writer:archetype_library_note:WriterInternal/Archetype:repository-commit-learning"
 	if entity := graphStore.entities[findingURN]; entity == nil || entity.EntityType != "archetype.finding" {
 		t.Fatalf("projected finding entity = %#v, want archetype.finding", entity)

--- a/internal/findings/archetype_vulnerability_rule.go
+++ b/internal/findings/archetype_vulnerability_rule.go
@@ -8,6 +8,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
 
 const (
@@ -72,20 +73,29 @@ func (r *archetypeVulnerabilityActiveRule) RuleMetadata() RuleDefinition {
 }
 
 func (r *archetypeVulnerabilityActiveRule) OpenAnchor(attributes map[string]string) string {
+	vulnerabilityURN := strings.TrimSpace(attributes["archetype_vulnerability_urn"])
+	// Findings written before scan-scoped identity retained both provider IDs.
+	// Normalize their anchor so the matching scan-scoped counter-event can
+	// still close them after the identity correction is deployed.
+	if tenantID := cerebrourn.TenantID(vulnerabilityURN); tenantID != "" {
+		if canonicalURN := archetypeVulnerabilityURN(tenantID, attributes["scan_id"], attributes["vulnerability_id"]); canonicalURN != "" {
+			vulnerabilityURN = canonicalURN
+		}
+	}
 	return identityCounterEventAnchor(map[string]string{
-		"archetype_vulnerability_urn": strings.TrimSpace(attributes["archetype_vulnerability_urn"]),
+		"archetype_vulnerability_urn": vulnerabilityURN,
 	}, "archetype_vulnerability_urn")
 }
 
 func (r *archetypeVulnerabilityActiveRule) CloseOnEvent(event Event) (string, bool) {
-	if !archetypeVulnerabilityActiveKindMatcher(event) || !hasRequiredAttributes(event, "vulnerability_id", "severity") {
+	if !archetypeVulnerabilityActiveKindMatcher(event) || !hasRequiredAttributes(event, "vulnerability_id", "scan_id", "severity") {
 		return "", false
 	}
 	attributes := eventAttributes(event)
 	if trivyVulnerabilitySeverityActionable(attributes["severity"]) {
 		return "", false
 	}
-	vulnerabilityURN := archetypeVulnerabilityURN(event.GetTenantId(), attributes["vulnerability_id"])
+	vulnerabilityURN := archetypeVulnerabilityURN(event.GetTenantId(), attributes["scan_id"], attributes["vulnerability_id"])
 	anchor := r.OpenAnchor(map[string]string{"archetype_vulnerability_urn": vulnerabilityURN})
 	return anchor, anchor != ""
 }
@@ -100,27 +110,30 @@ func matchesArchetypeVulnerabilityActive(event *cerebrov1.EventEnvelope) bool {
 func archetypeVulnerabilityActiveFinding(event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
 	attrs := event.GetAttributes()
 	tenantID := strings.TrimSpace(event.GetTenantId())
+	scanID := strings.TrimSpace(attrs["scan_id"])
 	vulnerabilityID := strings.TrimSpace(attrs["vulnerability_id"])
-	vulnerabilityURN := archetypeVulnerabilityURN(tenantID, vulnerabilityID)
+	vulnerabilityURN := archetypeVulnerabilityURN(tenantID, scanID, vulnerabilityID)
 	if vulnerabilityURN == "" {
 		return nil, nil
 	}
 	repositoryURN := archetypeRepositoryURN(tenantID, attrs["owner"], attrs["repo"])
 	attributes := map[string]string{
-		"archetype_vulnerability_urn": vulnerabilityURN,
-		"archetype_repository_urn":    repositoryURN,
-		"primary_resource_urn":        vulnerabilityURN,
-		"vulnerability_id":            vulnerabilityID,
-		"scan_id":                     strings.TrimSpace(attrs["scan_id"]),
-		"repository_id":               strings.TrimSpace(attrs["repository_id"]),
-		"owner":                       strings.TrimSpace(attrs["owner"]),
-		"repo":                        strings.TrimSpace(attrs["repo"]),
-		"file_path":                   strings.TrimSpace(attrs["file_path"]),
-		"line_number":                 strings.TrimSpace(attrs["line_number"]),
-		"category":                    strings.TrimSpace(attrs["category"]),
-		"severity":                    strings.TrimSpace(attrs["severity"]),
-		"event_id":                    strings.TrimSpace(event.GetId()),
-		"source_runtime_id":           strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]),
+		"archetype_vulnerability_urn":     vulnerabilityURN,
+		"archetype_repository_urn":        repositoryURN,
+		"primary_resource_urn":            vulnerabilityURN,
+		"vulnerability_id":                vulnerabilityID,
+		"scan_id":                         scanID,
+		"repository_id":                   strings.TrimSpace(attrs["repository_id"]),
+		"owner":                           strings.TrimSpace(attrs["owner"]),
+		"repo":                            strings.TrimSpace(attrs["repo"]),
+		"file_path":                       strings.TrimSpace(attrs["file_path"]),
+		"line_number":                     strings.TrimSpace(attrs["line_number"]),
+		"category":                        strings.TrimSpace(attrs["category"]),
+		"severity":                        strings.TrimSpace(attrs["severity"]),
+		"event_id":                        strings.TrimSpace(event.GetId()),
+		"source_runtime_id":               strings.TrimSpace(attrs[ports.EventAttributeSourceRuntimeID]),
+		findingAttributeLegacyID:          hashFindingFingerprint(archetypeVulnerabilityActiveRuleID, archetypeLegacyVulnerabilityURN(tenantID, vulnerabilityID)),
+		findingAttributeLegacyMatchFields: "scan_id,vulnerability_id",
 	}
 	for key, value := range archetypeVulnerabilityActiveDefinition.AttributeMap() {
 		attributes["rule_"+key] = value
@@ -147,7 +160,7 @@ func archetypeVulnerabilityActiveFinding(event *cerebrov1.EventEnvelope, runtime
 		Summary:         archetypeVulnerabilityActiveSummary(attrs),
 		ResourceURNs:    resourceURNs,
 		EventIDs:        []string{strings.TrimSpace(event.GetId())},
-		PolicyID:        vulnerabilityID,
+		PolicyID:        vulnerabilityURN,
 		PolicyName:      strings.TrimSpace(attrs["category"]),
 		CheckID:         archetypeVulnerabilityActiveCheckID,
 		CheckName:       archetypeVulnerabilityActiveCheckName,
@@ -158,7 +171,26 @@ func archetypeVulnerabilityActiveFinding(event *cerebrov1.EventEnvelope, runtime
 	}, nil
 }
 
-func archetypeVulnerabilityURN(tenantID string, vulnerabilityID string) string {
+func archetypeVulnerabilityURN(tenantID string, scanID string, vulnerabilityID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	scanID = strings.TrimSpace(scanID)
+	vulnerabilityID = strings.TrimSpace(vulnerabilityID)
+	if tenantID == "" || scanID == "" || vulnerabilityID == "" {
+		return ""
+	}
+	value, err := cerebrourn.Mint(
+		tenantID,
+		"archetype_finding",
+		cerebrourn.EncodeSegment(scanID),
+		cerebrourn.EncodeSegment(vulnerabilityID),
+	)
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+func archetypeLegacyVulnerabilityURN(tenantID string, vulnerabilityID string) string {
 	tenantID = strings.TrimSpace(tenantID)
 	vulnerabilityID = strings.TrimSpace(vulnerabilityID)
 	if tenantID == "" || vulnerabilityID == "" {

--- a/internal/findings/archetype_vulnerability_rule_test.go
+++ b/internal/findings/archetype_vulnerability_rule_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -28,16 +29,18 @@ func TestArchetypeVulnerabilityActiveRuleClosesOnDowngradedSeverity(t *testing.T
 	}
 	downgraded := archetypeVulnerabilityEvent("downgraded", map[string]string{
 		"vulnerability_id": "123",
+		"scan_id":          "456",
 		"severity":         "medium",
 	})
 	anchor, closes := counterRule.CloseOnEvent(downgraded)
-	wantAnchor := counterRule.OpenAnchor(map[string]string{"archetype_vulnerability_urn": "urn:cerebro:writer:archetype_finding:123"})
+	wantAnchor := counterRule.OpenAnchor(map[string]string{"archetype_vulnerability_urn": "urn:cerebro:writer:archetype_finding:456:123"})
 	if !closes || anchor != wantAnchor {
 		t.Fatalf("CloseOnEvent(downgraded) = %q/%v, want %q/true", anchor, closes, wantAnchor)
 	}
 
 	stillActionable := archetypeVulnerabilityEvent("critical", map[string]string{
 		"vulnerability_id": "123",
+		"scan_id":          "456",
 		"severity":         "critical",
 	})
 	if anchor, closes := counterRule.CloseOnEvent(stillActionable); closes || anchor != "" {
@@ -47,6 +50,24 @@ func TestArchetypeVulnerabilityActiveRuleClosesOnDowngradedSeverity(t *testing.T
 	missingIdentity := archetypeVulnerabilityEvent("missing-identity", map[string]string{"severity": "medium"})
 	if anchor, closes := counterRule.CloseOnEvent(missingIdentity); closes || anchor != "" {
 		t.Fatalf("CloseOnEvent(missing identity) = %q/%v, want empty/false", anchor, closes)
+	}
+
+	missingScan := archetypeVulnerabilityEvent("missing-scan", map[string]string{
+		"vulnerability_id": "123",
+		"severity":         "medium",
+	})
+	if anchor, closes := counterRule.CloseOnEvent(missingScan); closes || anchor != "" {
+		t.Fatalf("CloseOnEvent(missing scan) = %q/%v, want empty/false", anchor, closes)
+	}
+
+	otherScan := archetypeVulnerabilityEvent("other-scan", map[string]string{
+		"vulnerability_id": "123",
+		"scan_id":          "789",
+		"severity":         "medium",
+	})
+	otherAnchor, closes := counterRule.CloseOnEvent(otherScan)
+	if !closes || otherAnchor == "" || otherAnchor == wantAnchor {
+		t.Fatalf("CloseOnEvent(other scan) = %q/%v, want distinct non-empty anchor from %q", otherAnchor, closes, wantAnchor)
 	}
 }
 
@@ -79,8 +100,14 @@ func TestArchetypeVulnerabilityActiveRuleEmitsStableFinding(t *testing.T) {
 	if finding.Severity != "CRITICAL" {
 		t.Fatalf("Severity = %q, want CRITICAL", finding.Severity)
 	}
-	if got := finding.Attributes["archetype_vulnerability_urn"]; got != "urn:cerebro:writer:archetype_finding:123" {
+	if got := finding.Attributes["archetype_vulnerability_urn"]; got != "urn:cerebro:writer:archetype_finding:456:123" {
 		t.Fatalf("archetype_vulnerability_urn = %q", got)
+	}
+	if finding.PolicyID != "urn:cerebro:writer:archetype_finding:456:123" {
+		t.Fatalf("PolicyID = %q, want scan-scoped identity", finding.PolicyID)
+	}
+	if finding.Attributes[findingAttributeLegacyID] == "" {
+		t.Fatal("legacy_finding_id = empty, want bounded identity migration")
 	}
 	if got := finding.Attributes["archetype_repository_urn"]; got != "urn:cerebro:writer:github_code_repository:WriterInternal/cerebro" {
 		t.Fatalf("archetype_repository_urn = %q", got)
@@ -91,7 +118,7 @@ func TestArchetypeVulnerabilityActiveRuleEmitsStableFinding(t *testing.T) {
 
 	replayed := archetypeVulnerabilityEvent("event-2", map[string]string{
 		"vulnerability_id": "123",
-		"scan_id":          "789",
+		"scan_id":          "456",
 		"repository_id":    "7",
 		"severity":         "high",
 		"category":         "dependency",
@@ -109,6 +136,90 @@ func TestArchetypeVulnerabilityActiveRuleEmitsStableFinding(t *testing.T) {
 	}
 	if records[0].Fingerprint != finding.Fingerprint {
 		t.Fatalf("Fingerprint = %q, want stable %q", records[0].Fingerprint, finding.Fingerprint)
+	}
+
+	otherScan := archetypeVulnerabilityEvent("event-3", map[string]string{
+		"vulnerability_id": "123",
+		"scan_id":          "789",
+		"repository_id":    "7",
+		"severity":         "high",
+		"category":         "dependency",
+		"file_path":        "go.sum",
+		"line_number":      "45",
+		"owner":            "WriterInternal",
+		"repo":             "cerebro",
+	})
+	records, err = rule.Evaluate(context.Background(), runtime, otherScan)
+	if err != nil {
+		t.Fatalf("Evaluate(other scan) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Evaluate(other scan) emitted %d findings, want 1", len(records))
+	}
+	if records[0].Fingerprint == finding.Fingerprint {
+		t.Fatalf("other scan fingerprint = %q, want distinct from %q", records[0].Fingerprint, finding.Fingerprint)
+	}
+	if got := records[0].Attributes["archetype_vulnerability_urn"]; got != "urn:cerebro:writer:archetype_finding:789:123" {
+		t.Fatalf("other scan archetype_vulnerability_urn = %q", got)
+	}
+
+	legacy := &ports.FindingRecord{
+		ID:        finding.Attributes[findingAttributeLegacyID],
+		TenantID:  finding.TenantID,
+		RuntimeID: finding.RuntimeID,
+		RuleID:    finding.RuleID,
+		Attributes: map[string]string{
+			"scan_id":          "456",
+			"vulnerability_id": "123",
+		},
+	}
+	if !matchesLegacyFindingIdentity(finding, legacy) {
+		t.Fatal("legacy finding for the same scan did not migrate to the scan-scoped identity")
+	}
+	if matchesLegacyFindingIdentity(records[0], legacy) {
+		t.Fatal("legacy finding for one scan matched the same vulnerability ID from another scan")
+	}
+}
+
+func TestArchetypeVulnerabilityActiveRuleCanonicalizesProviderIdentityAndLegacyAnchor(t *testing.T) {
+	firstURN := archetypeVulnerabilityURN("writer", "scan:one", "vulnerability/two")
+	secondURN := archetypeVulnerabilityURN("writer", "scan", "one:vulnerability/two")
+	if firstURN != "urn:cerebro:writer:archetype_finding:scan%3Aone:vulnerability%2Ftwo" {
+		t.Fatalf("first canonical URN = %q", firstURN)
+	}
+	if secondURN != "urn:cerebro:writer:archetype_finding:scan:one%3Avulnerability%2Ftwo" {
+		t.Fatalf("second canonical URN = %q", secondURN)
+	}
+	if firstURN == secondURN {
+		t.Fatalf("canonical URNs collide: %q", firstURN)
+	}
+
+	rule := newArchetypeVulnerabilityActiveRule()
+	counterRule, ok := durableStateCounterEventRule(rule)
+	if !ok {
+		t.Fatal("archetype-vulnerability-active does not implement durable CounterEventRule")
+	}
+	legacyAttributes := map[string]string{
+		"archetype_vulnerability_urn": "urn:cerebro:writer:archetype_finding:123",
+		"scan_id":                     "456",
+		"vulnerability_id":            "123",
+	}
+	legacyAnchor := counterRule.OpenAnchor(legacyAttributes)
+	currentAnchor := counterRule.OpenAnchor(map[string]string{
+		"archetype_vulnerability_urn": "urn:cerebro:writer:archetype_finding:456:123",
+		"scan_id":                     "456",
+		"vulnerability_id":            "123",
+	})
+	if legacyAnchor == "" || legacyAnchor != currentAnchor {
+		t.Fatalf("legacy/current anchors = %q/%q, want same non-empty anchor", legacyAnchor, currentAnchor)
+	}
+	closeAnchor, closes := counterRule.CloseOnEvent(archetypeVulnerabilityEvent("downgraded", map[string]string{
+		"vulnerability_id": "123",
+		"scan_id":          "456",
+		"severity":         "medium",
+	}))
+	if !closes || closeAnchor != legacyAnchor {
+		t.Fatalf("CloseOnEvent(legacy identity) = %q/%v, want %q/true", closeAnchor, closes, legacyAnchor)
 	}
 }
 

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -35,6 +35,7 @@ const (
 
 	findingAttributeLegacyID          = "legacy_finding_id"
 	findingAttributeLegacyFingerprint = "legacy_fingerprint"
+	findingAttributeLegacyMatchFields = "legacy_finding_match_fields"
 )
 
 var (
@@ -1878,6 +1879,20 @@ func matchesLegacyFindingIdentity(incoming *ports.FindingRecord, legacy *ports.F
 	}
 	if strings.TrimSpace(incoming.RuleID) != strings.TrimSpace(legacy.RuleID) {
 		return false
+	}
+	if rawFields := strings.TrimSpace(incoming.Attributes[findingAttributeLegacyMatchFields]); rawFields != "" {
+		for _, rawField := range strings.Split(rawFields, ",") {
+			field := strings.TrimSpace(rawField)
+			if field == "" {
+				return false
+			}
+			incomingValue := strings.TrimSpace(incoming.Attributes[field])
+			legacyValue := strings.TrimSpace(legacy.Attributes[field])
+			if incomingValue == "" || legacyValue == "" || incomingValue != legacyValue {
+				return false
+			}
+		}
+		return true
 	}
 	if len(legacy.EventIDs) == 0 {
 		return true

--- a/internal/sourceprojection/archetype.go
+++ b/internal/sourceprojection/archetype.go
@@ -6,6 +6,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
 
 func archetypeScanProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -51,12 +52,13 @@ func archetypeVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports
 	}
 	attrs := event.GetAttributes()
 	vulnID := firstNonEmpty(attrs["vulnerability_id"], stringValue(payloadMap(event), "id"))
-	if vulnID == "" {
+	scanID := strings.TrimSpace(attrs["scan_id"])
+	if vulnID == "" || scanID == "" {
 		return nil, nil, nil
 	}
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
-	findingURN := projectionURN(tenantID, "archetype_finding", vulnID)
+	findingURN := projectionURN(tenantID, "archetype_finding", cerebrourn.EncodeSegment(scanID), cerebrourn.EncodeSegment(vulnID))
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        findingURN,
 		TenantID:   tenantID,
@@ -68,15 +70,15 @@ func archetypeVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports
 			"file_path":        attrs["file_path"],
 			"line_number":      attrs["line_number"],
 			"repository_id":    attrs["repository_id"],
-			"scan_id":          attrs["scan_id"],
+			"scan_id":          scanID,
 			"severity":         attrs["severity"],
 			"source_product":   "archetype",
 			"vulnerability_id": vulnID,
 			"at":               eventObservedAt(event),
 		}),
 	})
-	if scanURN := projectionURN(tenantID, "archetype_scan", attrs["scan_id"]); scanURN != "" {
-		addEntity(entities, &ports.ProjectedEntity{URN: scanURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "archetype.scan", Label: "Archetype scan " + attrs["scan_id"], Attributes: map[string]string{"scan_id": attrs["scan_id"]}})
+	if scanURN := projectionURN(tenantID, "archetype_scan", scanID); scanURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{URN: scanURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "archetype.scan", Label: "Archetype scan " + scanID, Attributes: map[string]string{"scan_id": scanID}})
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, scanURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 	}
 	if repoURN := archetypeRepoURN(tenantID, attrs); repoURN != "" {

--- a/internal/sourceprojection/archetype_test.go
+++ b/internal/sourceprojection/archetype_test.go
@@ -39,13 +39,93 @@ func TestProjectArchetypeVulnerabilityLinksRepoScanAndFinding(t *testing.T) {
 	}
 	repoURN := "urn:cerebro:writer:github_code_repository:WriterInternal/Archetype"
 	scanURN := "urn:cerebro:writer:archetype_scan:1"
-	findingURN := "urn:cerebro:writer:archetype_finding:10"
+	findingURN := "urn:cerebro:writer:archetype_finding:1:10"
 	if entity := state.entities[findingURN]; entity == nil || entity.EntityType != "archetype.finding" {
 		t.Fatalf("finding entity missing: %#v", entity)
 	}
 	assertProjectedLink(t, state, findingURN, relationBelongsTo, scanURN)
 	assertProjectedLink(t, state, repoURN, relationHasEvidence, findingURN)
 	assertProjectedLink(t, state, findingURN, relationAffects, repoURN)
+}
+
+func TestProjectArchetypeVulnerabilityScopesFindingToScan(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	project := func(eventID string, scanID string) {
+		t.Helper()
+		_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+			Id:       eventID,
+			TenantId: "writer",
+			SourceId: "archetype",
+			Kind:     "archetype.vulnerability",
+			Attributes: map[string]string{
+				"vulnerability_id": "10",
+				"scan_id":          scanID,
+				"repository_id":    "7",
+				"owner":            "WriterInternal",
+				"repo":             "Archetype",
+				"severity":         "high",
+				"category":         "ssrf",
+				"file_path":        "app/main.py",
+			},
+		})
+		if err != nil {
+			t.Fatalf("Project() error = %v", err)
+		}
+	}
+
+	project("archetype-vulnerability-1-10", "1")
+	project("archetype-vulnerability-1-10", "1")
+	project("archetype-vulnerability-2-10", "2")
+
+	firstURN := "urn:cerebro:writer:archetype_finding:1:10"
+	secondURN := "urn:cerebro:writer:archetype_finding:2:10"
+	if entity := state.entities[firstURN]; entity == nil || entity.Attributes["scan_id"] != "1" {
+		t.Fatalf("first scan finding entity missing: %#v", entity)
+	}
+	if entity := state.entities[secondURN]; entity == nil || entity.Attributes["scan_id"] != "2" {
+		t.Fatalf("second scan finding entity missing: %#v", entity)
+	}
+	findingCount := 0
+	for _, entity := range state.entities {
+		if entity.EntityType == "archetype.finding" {
+			findingCount++
+		}
+	}
+	if findingCount != 2 {
+		t.Fatalf("projected archetype finding entities = %d, want 2 after retry and second scan", findingCount)
+	}
+}
+
+func TestProjectArchetypeVulnerabilityCanonicalizesProviderIdentity(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	project := func(eventID string, scanID string, vulnerabilityID string) {
+		t.Helper()
+		_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+			Id:       eventID,
+			TenantId: "writer",
+			SourceId: "archetype",
+			Kind:     "archetype.vulnerability",
+			Attributes: map[string]string{
+				"vulnerability_id": vulnerabilityID,
+				"scan_id":          scanID,
+				"severity":         "high",
+			},
+		})
+		if err != nil {
+			t.Fatalf("Project() error = %v", err)
+		}
+	}
+
+	project("first", "scan:one", "vulnerability/two")
+	project("second", "scan", "one:vulnerability/two")
+
+	firstURN := "urn:cerebro:writer:archetype_finding:scan%3Aone:vulnerability%2Ftwo"
+	secondURN := "urn:cerebro:writer:archetype_finding:scan:one%3Avulnerability%2Ftwo"
+	if state.entities[firstURN] == nil || state.entities[secondURN] == nil {
+		t.Fatalf("canonical finding entities missing: first=%#v second=%#v", state.entities[firstURN], state.entities[secondURN])
+	}
 }
 
 func TestProjectArchetypeScanLinksRepositoryEvidence(t *testing.T) {

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -227,7 +227,7 @@ func scanEvent(st settings, scan scanRecord, repo repositoryRecord) *primitives.
 }
 func vulnerabilityEvent(st settings, scan scanRecord, vuln vulnerabilityRecord, repo repositoryRecord) *primitives.Event {
 	attrs := map[string]string{"vulnerability_id": strconv.Itoa(vuln.ID), "scan_id": strconv.Itoa(vuln.ScanID), "repository_id": strconv.Itoa(scan.RepositoryID), "severity": vuln.Severity, "category": vuln.Category, "file_path": vuln.FilePath, "line_number": strconv.Itoa(vuln.LineNumber), "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
-	return event(st, "archetype.vulnerability", "archetype-vulnerability-"+strconv.Itoa(vuln.ID), "archetype/vulnerability/v1", archetypeclient.ParseTime(vuln.CreatedAt, archetypeclient.ScanTime(scan, time.Now().UTC())), attrs, vuln)
+	return event(st, "archetype.vulnerability", "archetype-vulnerability-"+strconv.Itoa(scan.ID)+"-"+strconv.Itoa(vuln.ID), "archetype/vulnerability/v1", archetypeclient.ParseTime(vuln.CreatedAt, archetypeclient.ScanTime(scan, time.Now().UTC())), attrs, vuln)
 }
 func libraryNoteEvent(st settings, scan scanRecord, entry knowledgeEntryRecord, repo repositoryRecord) *primitives.Event {
 	entry.Slug = first(entry.Slug)

--- a/sources/archetype/source_test.go
+++ b/sources/archetype/source_test.go
@@ -80,6 +80,63 @@ func TestSourceReadEmitsScanAndVulnerabilityEvents(t *testing.T) {
 	}
 }
 
+func TestSourceReadScopesVulnerabilityEventIDsToScan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{
+				{"id": 2, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:06:00Z"},
+				{"id": 1, "repository_id": 7, "status": "completed", "completed_at": "2026-06-17T12:05:00Z"},
+			})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/1/vulnerabilities":
+			writeJSON(t, w, []map[string]any{{"id": 1, "scan_id": 1, "severity": "high", "category": "ssrf", "file_path": "app/one.py"}})
+		case "/api/v1/scans/2/vulnerabilities":
+			writeJSON(t, w, []map[string]any{{"id": 1, "scan_id": 2, "severity": "high", "category": "ssrf", "file_path": "app/two.py"}})
+		case "/api/v1/repositories/7/knowledge":
+			writeJSON(t, w, map[string]any{"entries": []map[string]any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+	})
+
+	readVulnerabilityIDs := func() []string {
+		pull, err := source.ReadWithCheckpoint(context.Background(), cfg, nil, nil)
+		if err != nil {
+			t.Fatalf("ReadWithCheckpoint() error = %v", err)
+		}
+		ids := make([]string, 0, 2)
+		for _, event := range pull.Events {
+			if event.GetKind() == "archetype.vulnerability" {
+				ids = append(ids, event.GetId())
+			}
+		}
+		return ids
+	}
+
+	first := readVulnerabilityIDs()
+	second := readVulnerabilityIDs()
+	want := []string{"archetype-vulnerability-1-1", "archetype-vulnerability-2-1"}
+	if len(first) != len(want) || first[0] != want[0] || first[1] != want[1] {
+		t.Fatalf("first vulnerability event ids = %q, want %q", first, want)
+	}
+	if len(second) != len(want) || second[0] != want[0] || second[1] != want[1] {
+		t.Fatalf("retry vulnerability event ids = %q, want %q", second, want)
+	}
+}
+
 func TestSourceReadPaginatesScansWithoutSkippingCheckpointRange(t *testing.T) {
 	var scanRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What changed

- scope Archetype vulnerability event, finding, policy, lifecycle, and graph identities to stable scan and vulnerability identifiers
- use the shared canonical URN encoder for provider-controlled identity segments
- migrate matching legacy findings by exact scan and vulnerability attributes while preserving close compatibility
- preserve deterministic identities when the same source data is retried

## Validation

- `go test ./internal/findings ./internal/sourceprojection ./internal/bootstrap ./sources/archetype ./sources/internal/archetypeclient -count=1`
- `make lint-internal lint-sources check-structural check-structural-test check-arch`
- `git diff --check`