### PR TITLE
feat(web): interactive entity chips in ask answers

### DIFF
--- a/apps/web/src/components/ask/AskThread.tsx
+++ b/apps/web/src/components/ask/AskThread.tsx
@@ -7,6 +7,7 @@ import { type AskTurnState } from "@/lib/ask";
 import GraphViewer from "@/components/grc/LazyGraphViewer";
 import { EmptyBlock, ErrorBlock, LoadingBlock } from "@/components/grc/Primitives";
 import CypherBlock from "./CypherBlock";
+import EntityChip from "./EntityChip";
 import MarkdownSummary from "./MarkdownSummary";
 import RowsTable from "./RowsTable";
 import TraceDrawer from "./TraceDrawer";
@@ -276,7 +277,7 @@ export default function AskThread({ turns, activeTurnId, onRetry, onStop }: Prop
                   {turn.rows.graph?.root && (
                     <GraphViewer graph={turn.rows.graph} />
                   )}
-                  <RowsTable rows={turn.rows.rows} execMs={turn.rows.exec_ms} />
+                  <RowsTable rows={turn.rows.rows} execMs={turn.rows.exec_ms} graph={turn.rows.graph} />
                   {turn.rows.rows.length === 0 && isTerminal && (
                     <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-[13px] text-slate-600">
                       No rows came back. Try a broader scope, remove a strict filter, or ask for available entities first.
@@ -294,6 +295,7 @@ export default function AskThread({ turns, activeTurnId, onRetry, onStop }: Prop
                     <MarkdownSummary
                       markdown={displayedSummary.markdown}
                       citations={displayedSummary.citations}
+                      graph={turn.rows?.graph}
                     />
                   </div>
                   {sources.length > 0 && (
@@ -301,13 +303,11 @@ export default function AskThread({ turns, activeTurnId, onRetry, onStop }: Prop
                       <div className="text-[10px] uppercase tracking-[0.22em] text-slate-400">Sources</div>
                       <div className="mt-2 flex flex-wrap gap-2">
                         {sources.map((source) => (
-                          <a
+                          <EntityChip
                             key={source.urn}
-                            href={`/impact?root_urn=${encodeURIComponent(source.urn)}`}
-                            className="rounded-md border border-indigo-100 bg-indigo-50 px-2 py-1 font-mono text-[11px] text-indigo-700 transition hover:border-indigo-300 hover:text-indigo-900"
-                          >
-                            {source.urn}
-                          </a>
+                            urn={source.urn}
+                            graph={turn.rows?.graph}
+                          />
                         ))}
                       </div>
                     </div>

--- a/apps/web/src/components/ask/EntityChip.test.tsx
+++ b/apps/web/src/components/ask/EntityChip.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GRCGraph } from "@/lib/grc";
+
+const mocks = vi.hoisted(() => ({
+  openAgent: vi.fn(),
+}));
+
+vi.mock("@/components/agent/CerebroAgentProvider", () => ({
+  useCerebroAgent: () => ({ openAgent: mocks.openAgent }),
+}));
+
+import EntityChip from "./EntityChip";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+const flushUpdates = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const urn = "urn:cerebro:writer:okta_user:jdoe";
+
+const graph: GRCGraph = {
+  root: {
+    urn,
+    entity_type: "okta_user",
+    label: "J. Doe",
+    attributes: { risk_score: "88" },
+  },
+};
+
+describe("EntityChip", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    mocks.openAgent.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await flushUpdates();
+    });
+    container.remove();
+  });
+
+  const render = async (element: React.ReactElement) => {
+    await act(async () => {
+      root.render(element);
+      await flushUpdates();
+    });
+  };
+
+  const chipButton = () =>
+    container.querySelector<HTMLButtonElement>(`button[data-urn="${urn}"]`);
+
+  it("renders the cited label on the chip", async () => {
+    await render(<EntityChip urn={urn} label="the user" />);
+    expect(chipButton()?.textContent).toContain("the user");
+    expect(chipButton()?.getAttribute("title")).toBe(urn);
+  });
+
+  it("opens a peek with type, risk, and entity actions on click", async () => {
+    await render(<EntityChip urn={urn} graph={graph} />);
+    expect(container.textContent).not.toContain("Blast radius");
+
+    await act(async () => {
+      chipButton()?.click();
+      await flushUpdates();
+    });
+
+    expect(container.textContent).toContain("J. Doe");
+    expect(container.textContent).toContain("identity");
+    expect(container.textContent).toContain("Risk critical · 88");
+
+    const blastRadius = Array.from(container.querySelectorAll("a")).find(
+      (link) => link.textContent === "Blast radius",
+    );
+    expect(blastRadius?.getAttribute("href")).toBe(
+      `/impact?root_urn=${encodeURIComponent(urn)}`,
+    );
+    const open = Array.from(container.querySelectorAll("a")).find(
+      (link) => link.textContent === "Open",
+    );
+    expect(open?.getAttribute("href")).toBe(`/inventory/${encodeURIComponent(urn)}`);
+  });
+
+  it("pivots by seeding a scoped agent question", async () => {
+    await render(<EntityChip urn={urn} graph={graph} />);
+    await act(async () => {
+      chipButton()?.click();
+      await flushUpdates();
+    });
+
+    const pivot = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Pivot here",
+    );
+    await act(async () => {
+      pivot?.click();
+      await flushUpdates();
+    });
+
+    expect(mocks.openAgent).toHaveBeenCalledWith({
+      question: "Explore what connects to jdoe",
+      scopeUrn: urn,
+      autoSubmit: true,
+    });
+  });
+
+  it("notes when details come from the urn alone", async () => {
+    await render(<EntityChip urn="urn:cerebro:writer:finding:f-1" />);
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button[data-urn]")?.click();
+      await flushUpdates();
+    });
+    expect(container.textContent).toContain("Details from URN only");
+  });
+});

--- a/apps/web/src/components/ask/EntityChip.tsx
+++ b/apps/web/src/components/ask/EntityChip.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+import { useCerebroAgent } from "@/components/agent/CerebroAgentProvider";
+import type { GRCGraph } from "@/lib/grc";
+import {
+  entityDetailHref,
+  entityImpactHref,
+  entityPivotQuestion,
+  entityTypeLabel,
+  resolveEntityPeek,
+  type EntityTypeKey,
+} from "@/lib/entity-chip";
+
+type Props = {
+  urn: string;
+  /** Preferred chip label, e.g. the cited span text. Falls back to graph label, then URN tail. */
+  label?: string;
+  /** Turn graph, used to enrich the peek with label, type, and risk when the entity is present. */
+  graph?: GRCGraph | null;
+  className?: string;
+};
+
+const TYPE_DOT: Record<EntityTypeKey, string> = {
+  finding: "bg-red-500",
+  identity: "bg-blue-500",
+  asset: "bg-emerald-500",
+  package: "bg-amber-500",
+  threat: "bg-pink-500",
+  default: "bg-slate-400",
+};
+
+const RISK_BADGE: Record<string, string> = {
+  critical: "border-[var(--severity-critical)] text-[var(--severity-critical)]",
+  high: "border-[var(--severity-high)] text-[var(--severity-high)]",
+  medium: "border-[var(--severity-medium)] text-[var(--severity-medium)]",
+  low: "border-[var(--severity-low)] text-[var(--severity-low)]",
+};
+
+export default function EntityChip({ urn, label, graph, className }: Props) {
+  const { openAgent } = useCerebroAgent();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const peek = resolveEntityPeek(urn, { graph, label });
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const pivot = () => {
+    setOpen(false);
+    openAgent({
+      question: entityPivotQuestion(urn),
+      scopeUrn: urn,
+      autoSubmit: true,
+    });
+  };
+
+  return (
+    <span ref={containerRef} className="relative inline-block align-baseline">
+      <button
+        type="button"
+        data-urn={urn}
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        title={urn}
+        className={`inline-flex items-center gap-1 rounded-md border border-[var(--primary)] bg-[var(--primary-soft)] px-1 font-mono text-[12px] text-[var(--primary)] transition hover:border-[var(--primary-hover)] hover:text-[var(--primary-hover)] ${className ?? ""}`}
+      >
+        <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${TYPE_DOT[peek.typeKey]}`} />
+        {peek.label}
+      </button>
+      {open && (
+        <span className="absolute left-0 z-30 mt-1 block w-72 rounded-lg border border-slate-200 bg-white p-3 text-left shadow-lg">
+          <span className="flex items-center justify-between gap-2">
+            <span className="truncate text-[13px] font-semibold text-slate-900">{peek.label}</span>
+            <span className="shrink-0 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+              {entityTypeLabel(peek.typeKey)}
+            </span>
+          </span>
+          <span className="mt-1 block break-all font-mono text-[11px] text-slate-500">{urn}</span>
+          <span className="mt-2 flex items-center gap-2">
+            {peek.risk !== undefined ? (
+              <span
+                className={`rounded-full border bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${RISK_BADGE[peek.riskLevel] ?? "border-slate-200 text-slate-500"}`}
+              >
+                Risk {peek.riskLevel} · {peek.risk}
+              </span>
+            ) : (
+              <span className="text-[11px] text-slate-400">
+                {peek.source === "graph" ? "No risk score on this entity" : "Details from URN only"}
+              </span>
+            )}
+          </span>
+          <span className="mt-3 flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3">
+            <button
+              type="button"
+              onClick={pivot}
+              className="rounded-md border border-[var(--primary)] bg-[var(--primary-soft)] px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-[var(--primary)] transition hover:border-[var(--primary-hover)] hover:text-[var(--primary-hover)]"
+            >
+              Pivot here
+            </button>
+            <Link
+              href={entityImpactHref(urn)}
+              onClick={() => setOpen(false)}
+              className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+            >
+              Blast radius
+            </Link>
+            <Link
+              href={entityDetailHref(urn)}
+              onClick={() => setOpen(false)}
+              className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+            >
+              Open
+            </Link>
+          </span>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/components/ask/MarkdownSummary.test.tsx
+++ b/apps/web/src/components/ask/MarkdownSummary.test.tsx
@@ -1,5 +1,9 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/agent/CerebroAgentProvider", () => ({
+  useCerebroAgent: () => ({ openAgent: vi.fn() }),
+}));
 
 import MarkdownSummary from "./MarkdownSummary";
 
@@ -20,8 +24,8 @@ describe("MarkdownSummary", () => {
     );
 
     expect(html).toContain("Second paragraph cites");
-    expect(html).toContain("/impact?root_urn=urn%3Acerebro%3Awriter%3Arepo%3Asecurity-agent-platform");
-    expect(html).toContain(">repo</a>");
+    expect(html).toContain('data-urn="urn:cerebro:writer:repo:security-agent-platform"');
+    expect(html).toContain(">repo</button>");
   });
 
   it("renders cited bullet lines without shifting offsets", () => {
@@ -39,6 +43,7 @@ describe("MarkdownSummary", () => {
       />,
     );
 
-    expect(html).toContain(">Connector</a>");
+    expect(html).toContain('data-urn="urn:cerebro:writer:connector:local-github"');
+    expect(html).toContain(">Connector</button>");
   });
 });

--- a/apps/web/src/components/ask/MarkdownSummary.tsx
+++ b/apps/web/src/components/ask/MarkdownSummary.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import Link from "next/link";
 import { Fragment, type ReactNode } from "react";
 
 import type { AskCitation } from "@/lib/ask";
 import { shortUrn } from "@/lib/ask";
+import type { GRCGraph } from "@/lib/grc";
+
+import EntityChip from "./EntityChip";
 
 type Props = {
   markdown: string;
   citations?: AskCitation[] | null;
+  /** Turn graph, used to enrich cited entity chips with labels and risk. */
+  graph?: GRCGraph | null;
 };
 
 const INLINE_TOKEN = /(\*\*[^*]+\*\*|`[^`]+`)/g;
@@ -39,6 +43,7 @@ const renderWithCitations = (
   markdown: string,
   citations?: AskCitation[] | null,
   baseOffset = 0,
+  graph?: GRCGraph | null,
 ): ReactNode[] => {
   const safeCitations = citations ?? [];
   if (!safeCitations.length) {
@@ -58,14 +63,12 @@ const renderWithCitations = (
     }
     const label = markdown.slice(start, end) || shortUrn(citation.urn);
     result.push(
-      <Link
+      <EntityChip
         key={`citation-${index}`}
-        href={`/impact?root_urn=${encodeURIComponent(citation.urn)}`}
-        title={citation.urn}
-        className="rounded-md border border-indigo-200 bg-indigo-50 px-1 font-mono text-[12px] text-indigo-700 transition hover:border-indigo-400 hover:text-indigo-900"
-      >
-        {label}
-      </Link>,
+        urn={citation.urn}
+        label={label}
+        graph={graph}
+      />,
     );
     cursor = end;
   });
@@ -91,7 +94,7 @@ const markdownBlocks = (markdown: string): Array<{ text: string; offset: number 
   return blocks;
 };
 
-export default function MarkdownSummary({ markdown, citations }: Props) {
+export default function MarkdownSummary({ markdown, citations, graph }: Props) {
   const blocks = markdownBlocks(markdown);
   return (
     <div className="space-y-3 text-[13px] leading-relaxed text-slate-800">
@@ -108,14 +111,14 @@ export default function MarkdownSummary({ markdown, citations }: Props) {
                 lineOffset += line.length + 1;
                 return (
                   <li key={lineIndex}>
-                    {renderWithCitations(content, citations, contentOffset)}
+                    {renderWithCitations(content, citations, contentOffset, graph)}
                   </li>
                 );
               })}
             </ul>
           );
         }
-        return <p key={index}>{renderWithCitations(block.text, citations, block.offset)}</p>;
+        return <p key={index}>{renderWithCitations(block.text, citations, block.offset, graph)}</p>;
       })}
     </div>
   );

--- a/apps/web/src/components/ask/RowsTable.tsx
+++ b/apps/web/src/components/ask/RowsTable.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
 
 import { looksLikeUrn, shortUrn } from "@/lib/ask";
 import { pluralize } from "@/lib/format";
+import type { GRCGraph } from "@/lib/grc";
+
+import EntityChip from "./EntityChip";
 
 type Row = Record<string, unknown>;
 
 type Props = {
   rows: Row[];
   execMs: number;
+  /** Turn graph, used to enrich URN cells with labels and risk. */
+  graph?: GRCGraph | null;
 };
 
 type SortState = {
@@ -43,7 +47,7 @@ const cellLabel = (value: unknown): string => {
   return String(value);
 };
 
-export default function RowsTable({ rows, execMs }: Props) {
+export default function RowsTable({ rows, execMs, graph }: Props) {
   const columns = useMemo(() => {
     const set = new Set<string>();
     rows.forEach((row) => Object.keys(row).forEach((key) => set.add(key)));
@@ -141,12 +145,7 @@ export default function RowsTable({ rows, execMs }: Props) {
                       <details>
                         <summary className="cursor-pointer list-none">
                           {looksLikeUrn(value) ? (
-                            <Link
-                              href={`/impact?root_urn=${encodeURIComponent(value)}`}
-                              className="font-mono text-[11px] text-indigo-700 hover:text-indigo-900"
-                            >
-                              {shortUrn(value)}
-                            </Link>
+                            <EntityChip urn={value} label={shortUrn(value)} graph={graph} />
                           ) : (
                             <span className="break-words">{cellLabel(value)}</span>
                           )}

--- a/apps/web/src/lib/entity-chip.test.ts
+++ b/apps/web/src/lib/entity-chip.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import type { GRCGraph } from "@/lib/grc";
+
+import {
+  entityDetailHref,
+  entityExploreHref,
+  entityImpactHref,
+  entityPivotQuestion,
+  entityTypeKey,
+  entityTypeLabel,
+  parseEntityUrn,
+  resolveEntityPeek,
+} from "./entity-chip";
+
+describe("parseEntityUrn", () => {
+  it("splits tenant, entity type, and id", () => {
+    expect(parseEntityUrn("urn:cerebro:writer:github_repo:writer/cerebro")).toEqual({
+      tenant: "writer",
+      entityType: "github_repo",
+      id: "writer/cerebro",
+    });
+  });
+
+  it("keeps colons inside the id segment", () => {
+    expect(parseEntityUrn("urn:cerebro:writer:aws_role:arn:aws:iam::123:role/deploy")).toEqual({
+      tenant: "writer",
+      entityType: "aws_role",
+      id: "arn:aws:iam::123:role/deploy",
+    });
+  });
+
+  it("rejects non-cerebro values and incomplete urns", () => {
+    expect(parseEntityUrn("not-a-urn")).toBeNull();
+    expect(parseEntityUrn("urn:cerebro:writer")).toBeNull();
+    expect(parseEntityUrn("urn:cerebro:writer:repo:")).toBeNull();
+    expect(parseEntityUrn("")).toBeNull();
+  });
+});
+
+describe("entityTypeKey", () => {
+  it("maps entity types onto the graph palette families", () => {
+    expect(entityTypeKey("finding")).toBe("finding");
+    expect(entityTypeKey("okta_user")).toBe("identity");
+    expect(entityTypeKey("aws_account")).toBe("identity");
+    expect(entityTypeKey("endpoint")).toBe("asset");
+    expect(entityTypeKey("github_repository")).toBe("asset");
+    expect(entityTypeKey("npm_package")).toBe("package");
+    expect(entityTypeKey("cve")).toBe("package");
+    expect(entityTypeKey("malware_threat")).toBe("threat");
+    expect(entityTypeKey("control")).toBe("default");
+  });
+
+  it("labels the default family as entity", () => {
+    expect(entityTypeLabel("default")).toBe("entity");
+    expect(entityTypeLabel("identity")).toBe("identity");
+  });
+});
+
+describe("entity hrefs", () => {
+  const urn = "urn:cerebro:writer:repo:writer/cerebro";
+  const encoded = encodeURIComponent(urn);
+
+  it("builds detail, impact, and explore links", () => {
+    expect(entityDetailHref(urn)).toBe(`/inventory/${encoded}`);
+    expect(entityImpactHref(urn)).toBe(`/impact?root_urn=${encoded}`);
+    expect(entityExploreHref(urn)).toBe(`/explore?root_urn=${encoded}`);
+  });
+
+  it("builds a pivot question from the urn tail", () => {
+    expect(entityPivotQuestion(urn)).toBe("Explore what connects to writer/cerebro");
+  });
+});
+
+describe("resolveEntityPeek", () => {
+  const graph: GRCGraph = {
+    root: {
+      urn: "urn:cerebro:writer:okta_user:jdoe",
+      entity_type: "okta_user",
+      label: "J. Doe",
+      attributes: { risk_score: "88" },
+    },
+    neighbors: [
+      {
+        urn: "urn:cerebro:writer:aws_s3_bucket:customer-data",
+        entity_type: "aws_s3_bucket",
+        label: "customer-data",
+        attributes: {},
+      },
+    ],
+  };
+
+  it("prefers graph node label, type, and risk when present", () => {
+    const peek = resolveEntityPeek("urn:cerebro:writer:okta_user:jdoe", { graph });
+    expect(peek).toMatchObject({
+      label: "J. Doe",
+      entityType: "okta_user",
+      typeKey: "identity",
+      risk: 88,
+      riskLevel: "critical",
+      source: "graph",
+    });
+  });
+
+  it("reads neighbors as well as the root", () => {
+    const peek = resolveEntityPeek("urn:cerebro:writer:aws_s3_bucket:customer-data", { graph });
+    expect(peek).toMatchObject({
+      label: "customer-data",
+      typeKey: "default",
+      risk: undefined,
+      riskLevel: "unknown",
+      source: "graph",
+    });
+  });
+
+  it("falls back to urn parts when the entity is not in the graph", () => {
+    const peek = resolveEntityPeek("urn:cerebro:writer:finding:f-1", { graph });
+    expect(peek).toMatchObject({
+      label: "f-1",
+      entityType: "finding",
+      typeKey: "finding",
+      risk: undefined,
+      source: "urn",
+    });
+  });
+
+  it("keeps an explicit label override ahead of graph and urn labels", () => {
+    const peek = resolveEntityPeek("urn:cerebro:writer:okta_user:jdoe", {
+      graph,
+      label: "the user",
+    });
+    expect(peek.label).toBe("the user");
+  });
+
+  it("ignores non-numeric risk scores", () => {
+    const noisy: GRCGraph = {
+      root: {
+        urn: "urn:cerebro:writer:endpoint:host-01",
+        entity_type: "endpoint",
+        label: "host-01",
+        attributes: { risk_score: "n/a" },
+      },
+    };
+    const peek = resolveEntityPeek("urn:cerebro:writer:endpoint:host-01", { graph: noisy });
+    expect(peek.risk).toBeUndefined();
+    expect(peek.riskLevel).toBe("unknown");
+  });
+});

--- a/apps/web/src/lib/entity-chip.ts
+++ b/apps/web/src/lib/entity-chip.ts
@@ -1,0 +1,131 @@
+import { shortUrn } from "@/lib/ask";
+import { type GRCGraph, type GRCGraphNode, riskLevelFromScore } from "@/lib/grc";
+
+export type EntityUrnParts = {
+  tenant: string;
+  entityType: string;
+  id: string;
+};
+
+const URN_PREFIX = "urn:cerebro:";
+
+export const parseEntityUrn = (urn: string): EntityUrnParts | null => {
+  if (!urn.startsWith(URN_PREFIX)) return null;
+  const rest = urn.slice(URN_PREFIX.length);
+  const separator = rest.indexOf(":");
+  if (separator <= 0) return null;
+  const remainder = rest.slice(separator + 1);
+  const nextSeparator = remainder.indexOf(":");
+  if (nextSeparator <= 0) return null;
+  const tenant = rest.slice(0, separator);
+  const entityType = remainder.slice(0, nextSeparator);
+  const id = remainder.slice(nextSeparator + 1);
+  if (!tenant || !entityType || !id) return null;
+  return { tenant, entityType, id };
+};
+
+export type EntityTypeKey =
+  | "finding"
+  | "identity"
+  | "asset"
+  | "package"
+  | "threat"
+  | "default";
+
+export const entityTypeKey = (entityType: string): EntityTypeKey => {
+  const normalized = entityType.toLowerCase();
+  if (normalized.includes("finding")) return "finding";
+  if (
+    normalized.includes("user") ||
+    normalized.includes("identity") ||
+    normalized.includes("account") ||
+    normalized.includes("group")
+  ) {
+    return "identity";
+  }
+  if (
+    normalized.includes("asset") ||
+    normalized.includes("agent") ||
+    normalized.includes("endpoint") ||
+    normalized.includes("device") ||
+    normalized.includes("repository")
+  ) {
+    return "asset";
+  }
+  if (
+    normalized.includes("package") ||
+    normalized.includes("vuln") ||
+    normalized.includes("cve")
+  ) {
+    return "package";
+  }
+  if (
+    normalized.includes("threat") ||
+    normalized.includes("malware") ||
+    normalized.includes("infection")
+  ) {
+    return "threat";
+  }
+  return "default";
+};
+
+export const entityTypeLabel = (key: EntityTypeKey): string =>
+  key === "default" ? "entity" : key;
+
+export const entityDetailHref = (urn: string): string =>
+  `/inventory/${encodeURIComponent(urn)}`;
+
+export const entityImpactHref = (urn: string): string =>
+  `/impact?root_urn=${encodeURIComponent(urn)}`;
+
+export const entityExploreHref = (urn: string): string =>
+  `/explore?root_urn=${encodeURIComponent(urn)}`;
+
+export const entityPivotQuestion = (urn: string): string =>
+  `Explore what connects to ${shortUrn(urn)}`;
+
+const findGraphNode = (
+  graph: GRCGraph | null | undefined,
+  urn: string,
+): GRCGraphNode | null => {
+  if (!graph) return null;
+  if (graph.root?.urn === urn) return graph.root;
+  return graph.neighbors?.find((node) => node.urn === urn) ?? null;
+};
+
+const parseRiskScore = (attributes?: Record<string, string>): number | undefined => {
+  const raw = attributes?.risk_score;
+  if (!raw) return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+};
+
+export type EntityPeekData = {
+  urn: string;
+  label: string;
+  entityType: string;
+  typeKey: EntityTypeKey;
+  risk?: number;
+  riskLevel: ReturnType<typeof riskLevelFromScore>;
+  /** "graph" when label/type/risk came from a graph node, "urn" when derived from the URN alone. */
+  source: "graph" | "urn";
+};
+
+export const resolveEntityPeek = (
+  urn: string,
+  options?: { graph?: GRCGraph | null; label?: string },
+): EntityPeekData => {
+  const node = findGraphNode(options?.graph, urn);
+  const parsed = parseEntityUrn(urn);
+  const entityType = node?.entity_type || parsed?.entityType || "entity";
+  const risk = parseRiskScore(node?.attributes);
+  return {
+    urn,
+    label: options?.label || node?.label || parsed?.id || shortUrn(urn),
+    entityType,
+    typeKey: entityTypeKey(entityType),
+    risk,
+    riskLevel: riskLevelFromScore(risk),
+    source: node ? "graph" : "urn",
+  };
+};


### PR DESCRIPTION
## Summary

Entity references in ask answers are now live `EntityChip`s instead of static text links. Each chip carries a type glyph and opens a peek popover with the entity label, type, and risk badge (when the turn graph includes a risk score), plus three actions:

- **Pivot here** seeds a new agent question scoped to the entity
- **Blast radius** opens the entity on the impact map
- **Open** navigates to the entity detail page

Wired into the three places answers mention entities: summary citations (`MarkdownSummary`), URN cells in result rows (`RowsTable`), and the sources list (`AskThread`). Peek data resolves from the turn graph when available and falls back to parsing the URN. URN parsing, type mapping, and link builders live in `lib/entity-chip.ts` as pure, unit-tested helpers.

No backend or contract changes; the `graph` prop is optional everywhere so existing usages are unaffected.

## Tests

- `npm run lint` / `npm test` (web): 18 new or updated tests pass; one pre-existing failure in `grc-client.test.tsx` also fails on unmodified `main` and is unrelated
- `npm run build` (web) passes
- `npm run e2e:web:fixtures` passes (10 route contracts, Chromium)