### PR TITLE
Prove and grade persistent Slack context

### DIFF
--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -128,7 +128,9 @@ export class CerebroAskClient {
       body: JSON.stringify({
         actor_ref: input.actorRef,
         assessment_at: input.assessmentAt,
-        context_scope_ref: input.contextScopeRef ?? null,
+        ...(input.contextScopeRef === undefined
+          ? {}
+          : { context_scope_ref: input.contextScopeRef }),
         effect_authorizations: (input.effectAuthorizations ?? []).map((authorization) => ({
           actor_ref: input.actorRef,
           approval_ref: authorization.approvalRef,

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -227,6 +227,7 @@ test("Slack acknowledges a pending Rust response only after transport delivery",
   const result = await client.runAgentTurn({
     actorRef: "slack-user:U-ONE",
     assessmentAt: "2026-07-31T20:00:00Z",
+    contextScopeRef: `slack-context-scope://sha256/${"a".repeat(64)}`,
     question: "Investigate the connector failure.",
     requestId: "request-pending",
     signal: new AbortController().signal,
@@ -234,6 +235,10 @@ test("Slack acknowledges a pending Rust response only after transport delivery",
   });
   assert.equal(result.deliveryAckRequired, true);
   assert.equal(requests.length, 1);
+  assert.equal(
+    (await requests[0]?.clone().json()).context_scope_ref,
+    `slack-context-scope://sha256/${"a".repeat(64)}`,
+  );
 
   await client.recordAgentTurnDelivery({
     deliveredAt: "2026-07-31T20:01:00Z",

--- a/crates/cerebro-platform/src/slack_agent_eval.rs
+++ b/crates/cerebro-platform/src/slack_agent_eval.rs
@@ -427,6 +427,8 @@ struct ConversationLabReceipt {
     selected_scenario_count: usize,
     declared_scenario_count: usize,
     targeted_regression_passed: bool,
+    latency_gate_passed: bool,
+    advisory_semantic_gate_passed: bool,
     promotion_ready: bool,
     suite_passed: bool,
     scenarios: Vec<ConversationLabScenarioReceipt>,
@@ -2733,8 +2735,6 @@ async fn run_conversation_lab(
     model: Arc<ConfiguredModel>,
     judge: Arc<ConfiguredModel>,
 ) -> Result<(), Box<dyn Error>> {
-    preflight_judge(judge.as_ref()).await?;
-    calibrate_blind_judge(judge.as_ref()).await?;
     let blinding_salt = env::var("CEREBRO_SLACK_AGENT_EVAL_BLINDING_SALT")?;
     if blinding_salt.len() < 16 {
         return Err(
@@ -2751,6 +2751,8 @@ async fn run_conversation_lab(
     {
         return Err("external holdouts require the session_v2 runtime".into());
     }
+    preflight_judge(judge.as_ref()).await?;
+    calibrate_blind_judge(judge.as_ref()).await?;
     let use_session_v2 = runtime == ConversationRuntime::SessionV2;
     let declared_scenario_count = selection.declared_scenario_count;
     let selected_scenario_count = selection.scenarios.len();
@@ -2913,17 +2915,22 @@ async fn run_conversation_lab(
                     role: ConversationRole::Assistant,
                     content: markdown.clone(),
                 });
-                Some(
-                    simulate_operator(
-                        judge.as_ref(),
-                        &scenario,
-                        turn_index + 1,
-                        &transcript,
-                        &observations,
-                        &interaction_kinds,
-                    )
-                    .await?,
+                match simulate_operator(
+                    judge.as_ref(),
+                    &scenario,
+                    turn_index + 1,
+                    &transcript,
+                    &observations,
+                    &interaction_kinds,
                 )
+                .await
+                {
+                    Ok(decision) => Some(decision),
+                    Err(_) => {
+                        terminal_failure = true;
+                        None
+                    }
+                }
             } else {
                 terminal_failure = true;
                 None
@@ -3076,7 +3083,16 @@ async fn run_conversation_lab(
     }
 
     let targeted_regression_passed = receipts.iter().all(|receipt| receipt.review_ready);
-    let suite_passed = full_suite && targeted_regression_passed;
+    let latency_gate_passed = receipts.iter().all(|receipt| receipt.latency_slo_passed);
+    let advisory_semantic_gate_passed = receipts
+        .iter()
+        .all(|receipt| receipt.internal_judge_advisory_excellent);
+    let suite_passed = conversation_suite_passed(
+        full_suite,
+        targeted_regression_passed,
+        latency_gate_passed,
+        advisory_semantic_gate_passed,
+    );
     let blind_review_bundle = blind_review_bundle(&selection.source, &receipts);
     let blind_review_bytes = serde_json::to_vec_pretty(&blind_review_bundle)?;
     validate_blind_review_bytes(
@@ -3088,7 +3104,7 @@ async fn run_conversation_lab(
         fs::write(path, &blind_review_bytes)?;
     }
     let receipt = ConversationLabReceipt {
-        schema_version: "cerebro-rust-slack-agent-conversation-lab/v5",
+        schema_version: "cerebro-rust-slack-agent-conversation-lab/v6",
         commit_sha,
         evaluated_at,
         provider: "aws_bedrock",
@@ -3110,16 +3126,27 @@ async fn run_conversation_lab(
         selected_scenario_count,
         declared_scenario_count,
         targeted_regression_passed,
+        latency_gate_passed,
+        advisory_semantic_gate_passed,
         promotion_ready: false,
         suite_passed,
         scenarios: receipts,
     };
     println!("{}", serde_json::to_string_pretty(&receipt)?);
-    if targeted_regression_passed {
+    if suite_passed {
         Ok(())
     } else {
-        Err("the exact-head Rust conversation lab did not meet its trajectory goal".into())
+        Err("the exact-head Rust conversation lab did not meet every automated quality gate".into())
     }
+}
+
+fn conversation_suite_passed(
+    full_suite: bool,
+    targeted_regression_passed: bool,
+    latency_gate_passed: bool,
+    advisory_semantic_gate_passed: bool,
+) -> bool {
+    full_suite && targeted_regression_passed && latency_gate_passed && advisory_semantic_gate_passed
 }
 
 async fn preflight_judge(model: &ConfiguredModel) -> Result<(), AgentRuntimeError> {
@@ -4616,6 +4643,15 @@ mod tests {
         assert!(autonomy_suite_passed(true, true));
         assert!(!autonomy_suite_passed(true, false));
         assert!(!autonomy_suite_passed(false, true));
+    }
+
+    #[test]
+    fn conversation_suite_requires_every_automated_quality_gate() {
+        assert!(conversation_suite_passed(true, true, true, true));
+        assert!(!conversation_suite_passed(false, true, true, true));
+        assert!(!conversation_suite_passed(true, false, true, true));
+        assert!(!conversation_suite_passed(true, true, false, true));
+        assert!(!conversation_suite_passed(true, true, true, false));
     }
 
     #[test]

--- a/crates/cerebro-platform/src/slack_agent_session.rs
+++ b/crates/cerebro-platform/src/slack_agent_session.rs
@@ -1355,6 +1355,195 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires CEREBRO_TEST_POSTGRES_DSN"]
+    async fn postgres_completed_thread_context_recall_is_actor_and_scope_isolated() {
+        let Ok(dsn) = std::env::var("CEREBRO_TEST_POSTGRES_DSN") else {
+            return;
+        };
+        let source_session_ref = "agent-session:postgres-context-completed";
+        let pending_session_ref = "agent-session:postgres-context-pending";
+        let tenant_id = "tenant:postgres-context";
+        let actor_ref = "slack-user:postgres-context-owner";
+        let other_actor_ref = "slack-user:postgres-context-other";
+        let context_scope_ref = format!("slack-context-scope://sha256/{}", "a".repeat(64));
+        let other_scope_ref = format!("slack-context-scope://sha256/{}", "b".repeat(64));
+        let store = PostgresAgentSessionStore::connect(&dsn).await.unwrap();
+        for session_ref in [source_session_ref, pending_session_ref] {
+            store
+                .client
+                .lock()
+                .await
+                .execute(
+                    "DELETE FROM cerebro_agent_sessions WHERE session_ref = $1",
+                    &[&session_ref],
+                )
+                .await
+                .unwrap();
+        }
+
+        let completed = context_test_session(
+            source_session_ref,
+            "slack-thread://postgres-context/completed",
+            tenant_id,
+            actor_ref,
+            &context_scope_ref,
+            "completed-request",
+            "Remember the completed source-thread decision.",
+            "I will retain that completed decision for this channel.",
+            false,
+        );
+        store.create(&completed).await.unwrap();
+        let pending = context_test_session(
+            pending_session_ref,
+            "slack-thread://postgres-context/pending",
+            tenant_id,
+            actor_ref,
+            &context_scope_ref,
+            "pending-request",
+            "This pending message must not be recalled.",
+            "This delivery has not been acknowledged.",
+            true,
+        );
+        store.create(&pending).await.unwrap();
+        drop(store);
+
+        let restarted = PostgresAgentSessionStore::connect(&dsn).await.unwrap();
+        let recalled = restarted
+            .recall_thread_contexts(
+                tenant_id,
+                actor_ref,
+                &context_scope_ref,
+                "agent-session:postgres-context-target",
+                12,
+            )
+            .await
+            .unwrap();
+        assert_eq!(recalled.len(), 1);
+        assert!(
+            recalled[0]
+                .statement
+                .contains("completed source-thread decision")
+        );
+        assert!(!recalled[0].statement.contains("pending message"));
+        assert!(
+            restarted
+                .recall_thread_contexts(
+                    tenant_id,
+                    other_actor_ref,
+                    &context_scope_ref,
+                    "agent-session:postgres-context-target",
+                    12,
+                )
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            restarted
+                .recall_thread_contexts(
+                    tenant_id,
+                    actor_ref,
+                    &other_scope_ref,
+                    "agent-session:postgres-context-target",
+                    12,
+                )
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        for session_ref in [source_session_ref, pending_session_ref] {
+            restarted
+                .client
+                .lock()
+                .await
+                .execute(
+                    "DELETE FROM cerebro_agent_sessions WHERE session_ref = $1",
+                    &[&session_ref],
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    fn context_test_session(
+        session_ref: &str,
+        thread_ref: &str,
+        tenant_id: &str,
+        actor_ref: &str,
+        context_scope_ref: &str,
+        request_id: &str,
+        user_text: &str,
+        assistant_text: &str,
+        pending_delivery: bool,
+    ) -> AgentSession {
+        let mission = MissionState {
+            mission_ref: format!("mission:{request_id}"),
+            objective: "Preserve bounded Slack continuity.".into(),
+            desired_outcome: "Recall only completed context for the same actor and channel.".into(),
+            resolved_scope: Vec::new(),
+            scope_assumptions: Vec::new(),
+            acceptance_criteria: vec!["Actor and scope boundaries remain exact.".into()],
+            commitments: Vec::new(),
+            open_loops: Vec::new(),
+            status: SessionStatus::Completed,
+        };
+        let user_message = SessionMessage {
+            role: SessionMessageRole::User,
+            message_ref: format!("operator:{request_id}"),
+            actor_ref: actor_ref.into(),
+            text: user_text.into(),
+            received_at: "2026-07-31T00:00:00Z".into(),
+        };
+        let assistant_message = SessionMessage {
+            role: SessionMessageRole::Assistant,
+            message_ref: format!("assistant:{request_id}"),
+            actor_ref: "cerebro".into(),
+            text: assistant_text.into(),
+            received_at: "2026-07-31T00:00:01Z".into(),
+        };
+        let draft = GroundedDraft {
+            state: FinalState::Answered,
+            delivery: DeliveryDisposition::Visible,
+            message: assistant_text.into(),
+            claims: Vec::new(),
+            coverage_notice: None,
+            question: None,
+            mission: mission.clone(),
+            memory_updates: Vec::new(),
+            presentation_ready: true,
+        };
+        AgentSession {
+            schema_version: cerebro_agent_runtime::session::AGENT_SESSION_V2.into(),
+            session_ref: session_ref.into(),
+            tenant_id: tenant_id.into(),
+            thread_ref: thread_ref.into(),
+            context_scope_ref: Some(context_scope_ref.into()),
+            mission,
+            messages: vec![user_message, assistant_message],
+            events: vec![SessionEventRecord {
+                schema_version: AGENT_SESSION_EVENT_V2.into(),
+                session_ref: session_ref.into(),
+                sequence: 1,
+                occurred_at: "2026-07-31T00:00:02Z".into(),
+                event: SessionEvent::TurnCompleted {
+                    request_id: request_id.into(),
+                    state: FinalState::Answered,
+                },
+            }],
+            effect_authorizations: Vec::new(),
+            pending_delivery: pending_delivery.then_some(
+                cerebro_agent_runtime::session::PendingDelivery {
+                    request_id: request_id.into(),
+                    draft,
+                    produced_at: "2026-07-31T00:00:01Z".into(),
+                },
+            ),
+            memories: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires CEREBRO_TEST_POSTGRES_DSN"]
     async fn postgres_wake_claim_is_fenced_until_exact_delivery() {
         let Ok(dsn) = std::env::var("CEREBRO_TEST_POSTGRES_DSN") else {
             return;

--- a/crates/cerebro-platform/src/slack_agent_session.rs
+++ b/crates/cerebro-platform/src/slack_agent_session.rs
@@ -1380,29 +1380,29 @@ mod tests {
                 .unwrap();
         }
 
-        let completed = context_test_session(
-            source_session_ref,
-            "slack-thread://postgres-context/completed",
+        let completed = context_test_session(ContextTestSessionInput {
+            session_ref: source_session_ref,
+            thread_ref: "slack-thread://postgres-context/completed",
             tenant_id,
             actor_ref,
-            &context_scope_ref,
-            "completed-request",
-            "Remember the completed source-thread decision.",
-            "I will retain that completed decision for this channel.",
-            false,
-        );
+            context_scope_ref: &context_scope_ref,
+            request_id: "completed-request",
+            user_text: "Remember the completed source-thread decision.",
+            assistant_text: "I will retain that completed decision for this channel.",
+            pending_delivery: false,
+        });
         store.create(&completed).await.unwrap();
-        let pending = context_test_session(
-            pending_session_ref,
-            "slack-thread://postgres-context/pending",
+        let pending = context_test_session(ContextTestSessionInput {
+            session_ref: pending_session_ref,
+            thread_ref: "slack-thread://postgres-context/pending",
             tenant_id,
             actor_ref,
-            &context_scope_ref,
-            "pending-request",
-            "This pending message must not be recalled.",
-            "This delivery has not been acknowledged.",
-            true,
-        );
+            context_scope_ref: &context_scope_ref,
+            request_id: "pending-request",
+            user_text: "This pending message must not be recalled.",
+            assistant_text: "This delivery has not been acknowledged.",
+            pending_delivery: true,
+        });
         store.create(&pending).await.unwrap();
         drop(store);
 
@@ -1465,17 +1465,30 @@ mod tests {
         }
     }
 
-    fn context_test_session(
-        session_ref: &str,
-        thread_ref: &str,
-        tenant_id: &str,
-        actor_ref: &str,
-        context_scope_ref: &str,
-        request_id: &str,
-        user_text: &str,
-        assistant_text: &str,
+    struct ContextTestSessionInput<'a> {
+        session_ref: &'a str,
+        thread_ref: &'a str,
+        tenant_id: &'a str,
+        actor_ref: &'a str,
+        context_scope_ref: &'a str,
+        request_id: &'a str,
+        user_text: &'a str,
+        assistant_text: &'a str,
         pending_delivery: bool,
-    ) -> AgentSession {
+    }
+
+    fn context_test_session(input: ContextTestSessionInput<'_>) -> AgentSession {
+        let ContextTestSessionInput {
+            session_ref,
+            thread_ref,
+            tenant_id,
+            actor_ref,
+            context_scope_ref,
+            request_id,
+            user_text,
+            assistant_text,
+            pending_delivery,
+        } = input;
         let mission = MissionState {
             mission_ref: format!("mission:{request_id}"),
             objective: "Preserve bounded Slack continuity.".into(),


### PR DESCRIPTION
## What changed

- exercise completed cross-thread recall through a real Postgres restart
- assert actor, channel-scope, and pending-delivery isolation
- require structural, latency, and advisory semantic gates before the automated conversation suite passes
- preserve partial evaluation evidence when the simulated operator fails

## Validation

- `cargo test -p cerebro-platform --bin cerebro-platform completed_context_is_attributed_to_the_exact_turn_actor`
- `cargo test -p cerebro-platform --bin cerebro-platform schema_has_isolated_event_and_wake_records`
- `cargo test -p cerebro-platform --bin cerebro-platform prior_thread_context_text_is_utf8_safe_and_bounded`
- disposable Postgres 16: `postgres_completed_thread_context_recall_is_actor_and_scope_isolated -- --ignored`
- `cargo test -p cerebro-platform --bin cerebro-platform conversation_suite_requires_every_automated_quality_gate`