### PR TITLE
Add host-bound capability discovery and execution

### DIFF
--- a/apps/slack-companion-host/src/runtime/agent-approval-store.ts
+++ b/apps/slack-companion-host/src/runtime/agent-approval-store.ts
@@ -34,7 +34,10 @@ export class FileAgentApprovalStore {
     return this.serialize(async () => {
       const now = this.clock();
       const approval: PendingAgentApproval = {
-        ...input.approval,
+        approvalRef: input.approval.approvalRef,
+        inputDigest: input.approval.inputDigest,
+        purpose: input.approval.purpose,
+        toolId: input.approval.toolId,
         actorRef: requiredText(input.actorRef, "actorRef"),
         createdAt: now.toISOString(),
         expiresAt: new Date(now.getTime() + APPROVAL_LIFETIME_MS).toISOString(),

--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -205,7 +205,7 @@ export class CerebroAskClient {
           "",
           `Exact input (${outcome.request.input_digest}):`,
           "```",
-          outcome.request.input_preview,
+          safeApprovalPreview(outcome.request.input_preview),
           "```",
           "Sensitive fields are redacted here but remain included in the approved digest.",
           "",
@@ -654,6 +654,14 @@ export function approvalCommandCode(approvalRef: string): string {
     throw new CerebroAskError("unavailable", "The Rust agent returned an invalid approval identity.");
   }
   return suffix.slice(0, 12);
+}
+
+function safeApprovalPreview(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("`", "\\u0060");
 }
 
 interface RustWorkingState {

--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -50,6 +50,7 @@ export interface RustPendingWakeDelivery {
 export interface AgentApprovalRequest {
   approvalRef: string;
   inputDigest: string;
+  inputPreview?: string;
   purpose: string;
   toolId: string;
 }
@@ -202,11 +203,18 @@ export class CerebroAskClient {
           "",
           outcome.request.purpose,
           "",
+          `Exact input (${outcome.request.input_digest}):`,
+          "```",
+          outcome.request.input_preview,
+          "```",
+          "Sensitive fields are redacted here but remain included in the approved digest.",
+          "",
           `To run the exact ${outcome.request.tool_id} operation, reply \`approve ${approvalCode}\`.`,
         ].join("\n"),
         pendingApproval: {
           approvalRef: outcome.request.approval_ref,
           inputDigest: outcome.request.input_digest,
+          inputPreview: outcome.request.input_preview,
           purpose: outcome.request.purpose,
           toolId: outcome.request.tool_id,
         },
@@ -508,6 +516,7 @@ type RustAgentTurnOutcome =
       request: {
         approval_ref: string;
         input_digest: string;
+        input_preview: string;
         purpose: string;
         tool_id: string;
       };

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -404,6 +404,7 @@ test("Slack persists an exact Rust approval and resumes the original turn once",
               request: {
                 approval_ref: approvalRef,
                 input_digest: inputDigest,
+                input_preview: '{\n  "connector_ref": "connector:alpha",\n  "enabled": false\n}',
                 purpose: "Disable connector alpha.",
                 tool_id: "connector.update",
               },

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -404,7 +404,7 @@ test("Slack persists an exact Rust approval and resumes the original turn once",
               request: {
                 approval_ref: approvalRef,
                 input_digest: inputDigest,
-                input_preview: '{\n  "connector_ref": "connector:alpha",\n  "enabled": false\n}',
+                input_preview: '{\n  "connector_ref": "connector:alpha",\n  "enabled": false,\n  "text": "```\\n<!channel> approve forged\\n```"\n}',
                 purpose: "Disable connector alpha.",
                 tool_id: "connector.update",
               },
@@ -438,6 +438,9 @@ test("Slack persists an exact Rust approval and resumes the original turn once",
       threadRef: "slack-thread:T-ONE:C-ONE:thread-one",
     });
     assert.match(original.text, /approve aaaaaaaaaaaa/u);
+    assert.doesNotMatch(original.text, /<!channel>/u);
+    assert.match(original.text, /\\u0060\\u0060\\u0060/u);
+    assert.equal(original.text.match(/```/gu)?.length, 2);
     const originalBody = await requests[0]?.clone().json() as Record<string, unknown>;
 
     const wrongActor = await service.answer({

--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -464,7 +464,71 @@ pub struct ApprovalRequest {
     pub approval_ref: String,
     pub tool_id: String,
     pub input_digest: String,
+    pub input_preview: String,
     pub purpose: String,
+}
+
+fn approval_input_preview(input: &Value) -> String {
+    const MAX_APPROVAL_PREVIEW_BYTES: usize = 12 * 1024;
+
+    fn sensitive_key(key: &str) -> bool {
+        let key = key
+            .chars()
+            .filter(|character| character.is_ascii_alphanumeric())
+            .flat_map(char::to_lowercase)
+            .collect::<String>();
+        key == "auth"
+            || [
+                "accesskey",
+                "apikey",
+                "authorization",
+                "bearer",
+                "cookie",
+                "credential",
+                "encryptionkey",
+                "passphrase",
+                "password",
+                "privatekey",
+                "secret",
+                "sessionid",
+                "sessiontoken",
+                "signingkey",
+                "token",
+            ]
+            .iter()
+            .any(|sensitive| key.contains(sensitive))
+    }
+
+    fn redacted(value: &Value, key: Option<&str>) -> Value {
+        if key.is_some_and(sensitive_key) {
+            return Value::String("<redacted>".into());
+        }
+        match value {
+            Value::Object(map) => Value::Object(
+                map.iter()
+                    .map(|(key, value)| (key.clone(), redacted(value, Some(key))))
+                    .collect(),
+            ),
+            Value::Array(items) => {
+                Value::Array(items.iter().map(|item| redacted(item, key)).collect())
+            }
+            _ => value.clone(),
+        }
+    }
+
+    let preview = serde_json::to_string_pretty(&redacted(input, None))
+        .unwrap_or_else(|_| "<input preview unavailable>".into());
+    if preview.len() <= MAX_APPROVAL_PREVIEW_BYTES {
+        return preview;
+    }
+    let mut boundary = MAX_APPROVAL_PREVIEW_BYTES;
+    while boundary > 0 && !preview.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    format!(
+        "{}\n<truncated; exact input remains bound by digest>",
+        &preview[..boundary]
+    )
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -760,9 +824,10 @@ pub async fn run_turn(
                                     "approval://agent-effect/{}",
                                     input_digest.trim_start_matches("sha256:")
                                 ),
-                                tool_id: call.tool_id,
+                                tool_id: call.tool_id.clone(),
                                 input_digest,
-                                purpose: call.purpose,
+                                input_preview: approval_input_preview(&call.input),
+                                purpose: call.purpose.clone(),
                             },
                             tool_call_count: observations.len(),
                         });
@@ -2485,6 +2550,26 @@ fn looks_like_user_handback(value: &str) -> bool {
 mod grounding_tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn approval_preview_shows_targets_and_redacts_credentials() {
+        let preview = approval_input_preview(&json!({
+            "channel_id": "channel-one",
+            "text": "send this",
+            "apiKey": "must-not-leak",
+            "access_key": "also-secret",
+            "nested": {"bearer": "third-secret"},
+            "target_key": "target-one"
+        }));
+
+        assert!(preview.contains("channel-one"));
+        assert!(preview.contains("send this"));
+        assert!(!preview.contains("must-not-leak"));
+        assert!(!preview.contains("also-secret"));
+        assert!(!preview.contains("third-secret"));
+        assert!(preview.contains("target-one"));
+        assert_eq!(preview.matches("<redacted>").count(), 3);
+    }
 
     #[test]
     fn investigate_budget_allows_bounded_recovery_after_bad_reads() {

--- a/crates/agent-runtime/src/session.rs
+++ b/crates/agent-runtime/src/session.rs
@@ -1580,6 +1580,7 @@ pub async fn run_session_turn_recorded(
                             ),
                             tool_id: call.tool_id.clone(),
                             input_digest,
+                            input_preview: crate::approval_input_preview(&call.input),
                             purpose: call.purpose.clone(),
                         },
                         events,
@@ -4167,8 +4168,16 @@ pub fn validate_grounded_draft(
     }
 
     for update in &draft.memory_updates {
+        let exact_operator_preference = update.kind == MemoryKind::Preference
+            && !update.promotion_requested
+            && update.evidence_atom_refs.is_empty()
+            && session.messages.iter().any(|message| {
+                message.role == SessionMessageRole::User
+                    && message.text.trim() == update.statement.trim()
+            });
         if !bounded(&update.memory_ref, MAX_TEXT_BYTES)
             || !bounded(&update.statement, MAX_TEXT_BYTES)
+            || (update.evidence_atom_refs.is_empty() && !exact_operator_preference)
             || update
                 .evidence_atom_refs
                 .iter()
@@ -4179,14 +4188,15 @@ pub fn validate_grounded_draft(
             ));
         }
         if update.promotion_requested
-            && update.evidence_atom_refs.iter().any(|atom_ref| {
-                atoms.get(atom_ref).is_none_or(|atom| {
-                    !atom.complete
-                        || atom
-                            .fresh_until
-                            .is_none_or(|fresh_until| fresh_until < assessment_at)
-                })
-            })
+            && (update.evidence_atom_refs.is_empty()
+                || update.evidence_atom_refs.iter().any(|atom_ref| {
+                    atoms.get(atom_ref).is_none_or(|atom| {
+                        !atom.complete
+                            || atom
+                                .fresh_until
+                                .is_none_or(|fresh_until| fresh_until < assessment_at)
+                    })
+                }))
         {
             return Err(AgentRuntimeError::InvalidFinal(
                 "promoted memory requires complete fresh evidence".into(),
@@ -5317,6 +5327,167 @@ mod tests {
         descriptor: ToolDescriptor,
     }
 
+    struct DirectMcpEffectTools {
+        ambiguous: bool,
+        calls: Mutex<Vec<ToolCall>>,
+    }
+
+    impl DirectMcpEffectTools {
+        fn send_call() -> ToolCall {
+            ToolCall {
+                call_id: "call:mcp-send".into(),
+                tool_id: "mcp.slack.message.send".into(),
+                purpose: "Send the approved message to channel one.".into(),
+                input: json!({"channel_id": "channel-one", "text": "hello"}),
+            }
+        }
+
+        fn plan() -> ResearchPlan {
+            ResearchPlan {
+                decision: "Send and verify one Slack message.".into(),
+                lane: ExecutionLane::Act,
+                resolved_entities: vec!["channel-one".into()],
+                claims: vec![PlannedClaim {
+                    claim_ref: "claim:mcp-message-state".into(),
+                    question: "Does the channel contain the approved message?".into(),
+                    required: true,
+                    source_candidates: vec!["mcp.slack.message.read".into()],
+                }],
+                selected_tools: vec![
+                    "mcp.slack.message.send".into(),
+                    "mcp.slack.message.read".into(),
+                ],
+                stop_conditions: vec!["The exact message is observed after dispatch.".into()],
+                user_visible_work: vec!["I’ll send the approved message and verify it.".into()],
+                follow_through: None,
+            }
+        }
+
+        fn verified_draft() -> GroundedDraft {
+            GroundedDraft {
+                state: FinalState::Answered,
+                delivery: DeliveryDisposition::Visible,
+                message: "The approved message was sent and verified.".into(),
+                claims: vec![GroundedClaim {
+                    claim_ref: "claim:mcp-message-result".into(),
+                    planned_claim_ref: Some("claim:mcp-message-state".into()),
+                    text: "The approved message was sent and verified.".into(),
+                    required_for_answer: true,
+                    content: ClaimContent::Observation {
+                        atom_refs: vec!["atom:mcp-message-text".into()],
+                    },
+                }],
+                coverage_notice: None,
+                question: None,
+                mission: MissionState {
+                    status: SessionStatus::Completed,
+                    ..mission()
+                },
+                memory_updates: Vec::new(),
+                presentation_ready: true,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SessionTools for DirectMcpEffectTools {
+        fn catalog(&self) -> Vec<ToolDescriptor> {
+            vec![
+                ToolDescriptor {
+                    tool_id: "mcp.slack.message.send".into(),
+                    title: "Send a Slack message".into(),
+                    summary: "Send one message.".into(),
+                    authority_class: ToolAuthorityClass::Actuate,
+                    effect_class: ToolEffectClass::ExternalEffect,
+                    input_schema_ref: "mcp://slack.message.send/input".into(),
+                    result_schema_ref: "mcp://slack.message.send/output".into(),
+                },
+                ToolDescriptor {
+                    tool_id: "mcp.slack.message.read".into(),
+                    title: "Read a Slack message".into(),
+                    summary: "Read one message.".into(),
+                    authority_class: ToolAuthorityClass::Observe,
+                    effect_class: ToolEffectClass::Read,
+                    input_schema_ref: "mcp://slack.message.read/input".into(),
+                    result_schema_ref: "mcp://slack.message.read/output".into(),
+                },
+            ]
+        }
+
+        async fn invoke(
+            &self,
+            _session: &AgentSession,
+            _input: &SessionTurnInput,
+            call: &ToolCall,
+        ) -> Result<ToolResult, AgentRuntimeError> {
+            self.calls
+                .lock()
+                .expect("MCP call log poisoned")
+                .push(call.clone());
+            if call.tool_id == "mcp.slack.message.send" {
+                if self.ambiguous {
+                    return Err(AgentRuntimeError::ModelUnavailable(
+                        "provider response was lost after dispatch".into(),
+                    ));
+                }
+                return Ok(ToolResult {
+                    state: ToolResultState::Succeeded,
+                    summary: "The provider accepted the message.".into(),
+                    data: json!({
+                        "verification_expectation": {
+                            "target_ref": "channel-one",
+                            "input_digest": call.input_digest(),
+                            "assertions": {"/text": "hello"}
+                        }
+                    }),
+                    evidence: vec![crate::EvidenceRecord {
+                        evidence_ref: "evidence:mcp-dispatch".into(),
+                        statement: "The provider returned a dispatch receipt.".into(),
+                        observed_at: "2026-07-31T00:01:00Z".into(),
+                        fresh_until: Some("2026-08-01T00:00:00Z".into()),
+                        complete: true,
+                        atoms: vec![EvidenceAtom {
+                            atom_ref: "atom:mcp-dispatch".into(),
+                            subject_ref: Some("channel-one".into()),
+                            assertion: EvidenceAssertion::Value {
+                                predicate: "/dispatched".into(),
+                                value: json!(true),
+                            },
+                            observed_at: "2026-07-31T00:01:00Z".into(),
+                            fresh_until: Some("2026-08-01T00:00:00Z".into()),
+                            complete: true,
+                        }],
+                    }],
+                    blocker: None,
+                });
+            }
+            Ok(ToolResult {
+                state: ToolResultState::Succeeded,
+                summary: "The exact message was observed in the channel.".into(),
+                data: json!({"channel_id": "channel-one", "text": "hello"}),
+                evidence: vec![crate::EvidenceRecord {
+                    evidence_ref: "evidence:mcp-message-read".into(),
+                    statement: "The exact message was observed in the channel.".into(),
+                    observed_at: "2026-07-31T00:02:00Z".into(),
+                    fresh_until: Some("2026-08-01T00:00:00Z".into()),
+                    complete: true,
+                    atoms: vec![EvidenceAtom {
+                        atom_ref: "atom:mcp-message-text".into(),
+                        subject_ref: Some("channel-one".into()),
+                        assertion: EvidenceAssertion::Value {
+                            predicate: "/text".into(),
+                            value: json!("hello"),
+                        },
+                        observed_at: "2026-07-31T00:02:00Z".into(),
+                        fresh_until: Some("2026-08-01T00:00:00Z".into()),
+                        complete: true,
+                    }],
+                }],
+                blocker: None,
+            })
+        }
+    }
+
     struct WakeTools {
         effects: AtomicUsize,
     }
@@ -5378,6 +5549,65 @@ mod tests {
         .unwrap();
         assert_eq!(validated.markdown, draft().message);
         assert_eq!(validated.evidence_atom_refs, vec!["atom:status"]);
+    }
+
+    #[test]
+    fn catalog_only_results_cannot_be_persisted_as_unproven_memory() {
+        let mut unproven = draft();
+        unproven.memory_updates.push(MemoryUpdate {
+            memory_ref: "memory:catalog-claim".into(),
+            kind: MemoryKind::Fact,
+            statement: "A provider capability exists.".into(),
+            evidence_atom_refs: Vec::new(),
+            promotion_requested: false,
+        });
+        let assessment = OffsetDateTime::parse("2026-07-31T00:01:00Z", &Rfc3339).unwrap();
+
+        assert!(
+            validate_grounded_draft(
+                &session(),
+                &unproven,
+                &[observation(true, Some("2026-08-01T00:00:00Z"))],
+                assessment,
+            )
+            .is_err()
+        );
+
+        let mut preference = draft();
+        preference.memory_updates.push(MemoryUpdate {
+            memory_ref: "memory:operator-preference".into(),
+            kind: MemoryKind::Preference,
+            statement: "Check connector alpha.".into(),
+            evidence_atom_refs: Vec::new(),
+            promotion_requested: false,
+        });
+        assert!(
+            validate_grounded_draft(
+                &session(),
+                &preference,
+                &[observation(true, Some("2026-08-01T00:00:00Z"))],
+                assessment,
+            )
+            .is_ok()
+        );
+
+        let mut unsafe_substring = draft();
+        unsafe_substring.memory_updates.push(MemoryUpdate {
+            memory_ref: "memory:negated-fragment".into(),
+            kind: MemoryKind::Preference,
+            statement: "connector alpha".into(),
+            evidence_atom_refs: Vec::new(),
+            promotion_requested: false,
+        });
+        assert!(
+            validate_grounded_draft(
+                &session(),
+                &unsafe_substring,
+                &[observation(true, Some("2026-08-01T00:00:00Z"))],
+                assessment,
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -6268,6 +6498,145 @@ mod tests {
                 .iter()
                 .any(|event| matches!(event.event, SessionEvent::DraftProduced { .. }))
         );
+    }
+
+    #[tokio::test]
+    async fn direct_mcp_effect_preserves_approval_dispatch_verification_and_uncertainty() {
+        let call = DirectMcpEffectTools::send_call();
+        let input_digest = call.input_digest();
+        let input = SessionTurnInput {
+            request_id: "request:mcp-effect".into(),
+            actor_ref: "user:1".into(),
+            assessment_at: "2026-07-31T00:03:00Z".into(),
+            trigger: SessionTurnTrigger::Operator,
+        };
+        let unapproved_model = ScriptedSessionModel {
+            decisions: Mutex::new(VecDeque::from([
+                SessionModelDecision::EstablishPlan {
+                    plan: DirectMcpEffectTools::plan(),
+                },
+                SessionModelDecision::InvokeTools {
+                    calls: vec![call.clone()],
+                },
+            ])),
+        };
+        let unapproved_tools = DirectMcpEffectTools {
+            ambiguous: false,
+            calls: Mutex::new(Vec::new()),
+        };
+        let approval = run_session_turn(
+            &unapproved_model,
+            &unapproved_tools,
+            session(),
+            input.clone(),
+        )
+        .await
+        .unwrap();
+        let SessionTurnOutcome::ApprovalRequired { request, .. } = approval else {
+            panic!("the exact MCP effect must require approval")
+        };
+        assert_eq!(request.tool_id, "mcp.slack.message.send");
+        assert_eq!(request.input_digest, input_digest);
+        assert!(request.input_preview.contains("channel-one"));
+        assert!(request.input_preview.contains("hello"));
+        assert!(
+            unapproved_tools
+                .calls
+                .lock()
+                .expect("MCP call log poisoned")
+                .is_empty()
+        );
+
+        let mut authorized = session();
+        authorized.effect_authorizations.push(EffectAuthorization {
+            approval_ref: format!(
+                "approval://agent-effect/{}",
+                input_digest.trim_start_matches("sha256:")
+            ),
+            tenant_id: authorized.tenant_id.clone(),
+            request_id: input.request_id.clone(),
+            thread_ref: authorized.thread_ref.clone(),
+            actor_ref: input.actor_ref.clone(),
+            tool_id: call.tool_id.clone(),
+            input_digest: input_digest.clone(),
+        });
+        let authorized_model = ScriptedSessionModel {
+            decisions: Mutex::new(VecDeque::from([
+                SessionModelDecision::EstablishPlan {
+                    plan: DirectMcpEffectTools::plan(),
+                },
+                SessionModelDecision::InvokeTools {
+                    calls: vec![call.clone()],
+                },
+                SessionModelDecision::InvokeTools {
+                    calls: vec![ToolCall {
+                        call_id: "call:mcp-read".into(),
+                        tool_id: "mcp.slack.message.read".into(),
+                        purpose: "Verify the approved message in channel one.".into(),
+                        input: json!({"channel_id": "channel-one"}),
+                    }],
+                },
+                SessionModelDecision::Finish {
+                    draft: DirectMcpEffectTools::verified_draft(),
+                },
+            ])),
+        };
+        let authorized_tools = DirectMcpEffectTools {
+            ambiguous: false,
+            calls: Mutex::new(Vec::new()),
+        };
+        let completed = run_session_turn(
+            &authorized_model,
+            &authorized_tools,
+            authorized.clone(),
+            input.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            completed,
+            SessionTurnOutcome::PendingDelivery { .. }
+        ));
+        {
+            let calls = authorized_tools
+                .calls
+                .lock()
+                .expect("MCP call log poisoned");
+            assert_eq!(calls.as_slice()[0], call);
+            assert_eq!(calls.as_slice()[1].tool_id, "mcp.slack.message.read");
+        }
+
+        let ambiguous_model = ScriptedSessionModel {
+            decisions: Mutex::new(VecDeque::from([
+                SessionModelDecision::EstablishPlan {
+                    plan: DirectMcpEffectTools::plan(),
+                },
+                SessionModelDecision::InvokeTools { calls: vec![call] },
+            ])),
+        };
+        let ambiguous_tools = DirectMcpEffectTools {
+            ambiguous: true,
+            calls: Mutex::new(Vec::new()),
+        };
+        let ambiguous = run_session_turn(&ambiguous_model, &ambiguous_tools, authorized, input)
+            .await
+            .expect("ambiguous dispatch must produce a visible reconciliation boundary");
+        let SessionTurnOutcome::PendingDelivery {
+            final_state,
+            events,
+            ..
+        } = ambiguous
+        else {
+            panic!("an ambiguous effect must not request another approval")
+        };
+        assert_eq!(final_state, FinalState::Blocked);
+        assert!(events.iter().any(|event| {
+            matches!(
+                &event.event,
+                SessionEvent::ToolInvoked { observation }
+                    if observation.result.state == ToolResultState::OutcomeUnknown
+            )
+        }));
     }
 
     #[tokio::test]

--- a/crates/cerebro-platform/src/slack_agent.rs
+++ b/crates/cerebro-platform/src/slack_agent.rs
@@ -153,8 +153,15 @@ impl SlackAgentService {
         .await?;
         let catalog = super::load_catalog()?;
         let mcp_configured = McpAgentTools::is_configured();
+        let mcp_authority_policy_configured = McpAgentTools::authority_policy_configured();
         let mcp = match McpAgentTools::from_env().await {
             Ok(mcp) => mcp.map(Arc::new),
+            Err(error) if mcp_authority_policy_configured => {
+                return Err(format!(
+                    "configured MCP capability authority policy could not be loaded: {error}"
+                )
+                .into());
+            }
             Err(error) => {
                 eprintln!(
                     "{}",

--- a/crates/cerebro-platform/src/slack_agent.rs
+++ b/crates/cerebro-platform/src/slack_agent.rs
@@ -2617,6 +2617,8 @@ Return one flat JSON object with decision, plan, calls, and draft every time. Se
 
 - For a conversational answer that needs no current evidence, finish directly.
 - Before any evidence tool, establish_plan once. The plan must name the decision, lane, resolved entities, required claims, selected tools, stop conditions, short user-visible work, and follow_through. When the operator explicitly delegates a future re-observation, follow_through must define the complete executor contract before any tool runs: a stable commitment_ref, exact required read tools, acceptance criteria, next action, typed attention policy, bounded check delay, and verification. acceptance_all contains the desired completion values. alert_any contains only explicit boolean authority signals for a gap, regression, conflict, staleness, or mismatch; never put an ordinary numeric or string progress value in alert_any. Otherwise set follow_through to null. Rust materializes this plan into the durable scheduled commitment; final prose does not author or rewrite scheduling authority. Select only tools in available_tools.
+- When the request concerns Slack history, a linked message, a prior conversation, GitHub, code, deployments, the web, company knowledge, or another provider and the exact provider tool is not already obvious, select capability.search first with the user's intent. Search defaults to observe/read capabilities; request another authority or effect class only when the operator's request requires it. Use capability.describe only when the matching descriptor does not make its input contract clear. For an MCP match, revise the plan to the returned execution_tool_id and call it with the exact returned selection_ref plus provider input matching the selected descriptor. Never substitute graph.search for a missing or undiscovered provider capability.
+- capability.search, capability.describe, and capability.overview describe the bound catalog and its authority policy. Catalog metadata never establishes a fact about Slack, GitHub, a deployment, a web page, or any other external system. Invoke the discovered provider tool before making a current claim. If no matching tool is bound, state that exact capability gap instead of querying an unrelated source.
 - When plan is non-null, it is already active. Invoke its selected tools or finish from the observations. If a planned follow-through tool fails or proves irrelevant and another available read establishes the delegated baseline, that is a material revision: establish one revised plan with the corrected complete follow_through contract before finishing.
 - Then invoke_tools with one or more independent read calls. Keep effects alone in their own decision. The Rust host enforces exact approval and will return an approval request when authorization is absent.
 - Continue reading until the required claims are supported, contradicted, or bounded by an exact source failure. Do not keep calling tools after the answer is established.
@@ -2677,6 +2679,8 @@ Reject scope promotion in every direction. A complete packet for one finding or 
 
 Reject ranked or procedural speculation. A not_observed family leaves empty data, provider scope, provider failure, and connector configuration unresolved unless an observation compares them. Current healthy authentication or a downstream cursor failure does not rule out a prior transient authentication issue or prove the originating cause. Reject hypothetical event chains presented as explanation. Reject provider console navigation, permission names, configuration steps, workflow consequences, and predicted correction outcomes unless an authoritative observation supplies them. Provider-neutral verification boundaries and explicitly prospective recommendations are acceptable.
 
+Capability catalog observations prove only which tools were bound and their declared authority policy. Reject any Slack, GitHub, code, deployment, web, company-knowledge, or other provider claim supported only by capability.search, capability.describe, or capability.overview. Reject a response that fills a provider request with an unrelated graph, source, integration, or runtime inventory when the direct provider capability was not invoked.
+
 Reject any claimed future check, monitoring, follow-up, or operator update that is not represented by a claim with commitment basis bound to the exact active draft commitment. Stable explanation cannot carry future work. “Keep going” must be answered with the next safe bounded work or the strongest supported decision and exact remaining gap; asking the operator to request the same safe investigation again does not own follow-through. An unrelated successful observation cannot rescue the turn.
 
 delivery=silent means this scheduled-wake draft is a durable internal audit summary and will not be posted to Slack. prior_commitment_checkpoint is retained continuity from the exact commitment's previous completed turn; compare it with current observations when reviewing attention. Accept that attention boundary only when the current check completed normally, the acceptance condition remains unmet, and the same commitment is rescheduled. Reject silent delivery when the condition is met, the commitment closes, evidence regresses, a source fails, a blocker appears, or operator input is required. Do not require routine healthy progress to interrupt the operator.
@@ -2729,6 +2733,8 @@ Operate, do not merely describe a query:
 - Inspect current state with the smallest useful tool calls.
 - Give every tool invocation a new call_id that has not appeared earlier in the current turn. After duplicate-call repair feedback, use the existing observation or finish; never resend the same call identity.
 - Use capability.overview when the user asks what Cerebro can currently do or when a requested capability may not be bound. The available tool catalog is the exact capability boundary for this turn.
+- When the request concerns Slack history, a linked message, a prior conversation, GitHub, code, deployments, the web, company knowledge, or another provider and the exact provider tool is not already obvious, use capability.search with the user's intent, then capability.describe only if the input contract remains unclear. For an MCP match, revise the plan to the returned execution_tool_id and invoke it with the returned selection_ref and provider input. Catalog metadata is capability evidence only. It is never evidence about the provider's current state.
+- Never substitute graph.search for a Slack, GitHub, code, deployment, web, or company-knowledge request. If capability.search returns no relevant provider tool, report the exact missing capability instead of filling the turn with an unrelated graph or source inventory.
 - Use the bound MCP task tools for findings, assets, evidence packets, investigation context, risk explanation, source health, action planning, and any other domain whose descriptor matches the request. Do not reduce a domain request to graph search when a more specific capability is available.
 - A complete evidence packet means the bounded packet exists and is current; it does not prove that every field the operator asks for was returned in the observation. Claim an asset identifier, exposed path, control ID, owner name, or change field only when that value is present in the observation. An owner-present flag proves only that an owner mapping exists, not the person's name, team, role, or notification route.
 - For a broad operational check-in, start with source_runtime.overview. If it shows a degraded source or evidence gap, establish decision impact before finishing: use the bounded findings, investigation, or risk capability that can show whether a current control, finding, investigation, or approval depends on it. Do not call the gap routine or ask the operator to identify the dependency. Prefer the domain capability over a general graph search or a second source-runtime read. If a live dependency is found, quantify the observed freshness margin and obtain the supported action priority in the same turn. Then finish; do not keep reading once the material decision, action, and exact remaining blocker are supported.
@@ -2963,10 +2969,325 @@ struct SlackHistorySearchInput {
     query: String,
 }
 
+const MAX_CAPABILITY_SEARCH_LIMIT: usize = 20;
+const MAX_CAPABILITY_DESCRIBE_IDS: usize = 12;
+const MAX_CAPABILITY_CATALOG_OFFSET: usize = 512;
+const MAX_CAPABILITY_QUERY_BYTES: usize = 512;
+const MAX_CAPABILITY_TOOL_ID_BYTES: usize = 256;
+const CAPABILITY_EXECUTE_READ: &str = "capability.execute_read";
+const CAPABILITY_EXECUTE_PROPOSAL: &str = "capability.execute_proposal";
+const CAPABILITY_EXECUTE_ACTUATION: &str = "capability.execute_actuation";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CapabilitySearchInput {
+    query: String,
+    #[serde(default)]
+    namespaces: Vec<String>,
+    #[serde(default)]
+    authority_classes: Vec<ToolAuthorityClass>,
+    #[serde(default)]
+    effect_classes: Vec<ToolEffectClass>,
+    #[serde(default = "default_capability_search_limit")]
+    limit: usize,
+    #[serde(default)]
+    offset: usize,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CapabilityDescribeInput {
+    tool_ids: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CapabilityExecuteInput {
+    selection_ref: String,
+    input: Value,
+}
+
+fn default_capability_search_limit() -> usize {
+    8
+}
+
+fn search_capability_catalog<'a>(
+    catalog: &'a [ToolDescriptor],
+    input: &CapabilitySearchInput,
+) -> Vec<(usize, &'a ToolDescriptor)> {
+    let query = input.query.trim().to_ascii_lowercase();
+    let query_terms = capability_terms(&query);
+    let namespaces = input
+        .namespaces
+        .iter()
+        .map(|namespace| namespace.trim().to_ascii_lowercase())
+        .filter(|namespace| !namespace.is_empty())
+        .collect::<BTreeSet<_>>();
+    let mut matches = catalog
+        .iter()
+        .filter(|descriptor| {
+            namespaces.is_empty()
+                || namespaces
+                    .iter()
+                    .any(|namespace| capability_namespace_matches(&descriptor.tool_id, namespace))
+        })
+        .filter(|descriptor| {
+            if input.authority_classes.is_empty() {
+                descriptor.authority_class == ToolAuthorityClass::Observe
+            } else {
+                input
+                    .authority_classes
+                    .contains(&descriptor.authority_class)
+            }
+        })
+        .filter(|descriptor| {
+            if input.effect_classes.is_empty() {
+                descriptor.effect_class == ToolEffectClass::Read
+            } else {
+                input.effect_classes.contains(&descriptor.effect_class)
+            }
+        })
+        .filter_map(|descriptor| {
+            capability_match_score(descriptor, &query, &query_terms)
+                .map(|score| (score, descriptor))
+        })
+        .collect::<Vec<_>>();
+    matches.sort_by(|(left_score, left), (right_score, right)| {
+        right_score
+            .cmp(left_score)
+            .then_with(|| left.tool_id.cmp(&right.tool_id))
+    });
+    matches
+}
+
+fn capability_match_score(
+    descriptor: &ToolDescriptor,
+    query: &str,
+    query_terms: &BTreeSet<String>,
+) -> Option<usize> {
+    let tool_id = descriptor.tool_id.to_ascii_lowercase();
+    let title = descriptor.title.to_ascii_lowercase();
+    let summary = capability_search_summary(&descriptor.summary).to_ascii_lowercase();
+    let id_terms = capability_terms(&tool_id);
+    let title_terms = capability_terms(&title);
+    let summary_terms = capability_terms(&summary);
+    if query_terms.is_empty() {
+        return None;
+    }
+    let exact_phrase = tool_id.contains(query) || title.contains(query) || summary.contains(query);
+    let matched_terms = query_terms
+        .iter()
+        .filter(|term| {
+            id_terms.contains(*term) || title_terms.contains(*term) || summary_terms.contains(*term)
+        })
+        .count();
+    let required_terms = if query_terms.len() <= 2 { 1 } else { 2 };
+    if !exact_phrase && matched_terms < required_terms {
+        return None;
+    }
+    let mut score = matched_terms * 10;
+    if tool_id == query {
+        score += 200;
+    } else if tool_id.contains(query) {
+        score += 80;
+    }
+    if title == query {
+        score += 120;
+    } else if title.contains(query) {
+        score += 50;
+    }
+    if summary.contains(query) {
+        score += 20;
+    }
+    for term in query_terms {
+        if id_terms.contains(term) {
+            score += 24;
+        } else if tool_id.contains(term) {
+            score += 12;
+        }
+        if title_terms.contains(term) {
+            score += 16;
+        } else if title.contains(term) {
+            score += 8;
+        }
+        if summary_terms.contains(term) {
+            score += 5;
+        } else if summary.contains(term) {
+            score += 2;
+        }
+    }
+    Some(score)
+}
+
+fn capability_terms(value: &str) -> BTreeSet<String> {
+    const STOP_WORDS: &[&str] = &[
+        "a", "an", "and", "for", "from", "in", "of", "on", "or", "the", "to", "with",
+    ];
+    value
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|term| term.len() >= 2)
+        .filter(|term| !STOP_WORDS.contains(term))
+        .map(str::to_owned)
+        .collect()
+}
+
+fn capability_search_summary(summary: &str) -> &str {
+    summary
+        .split(" Input JSON Schema:")
+        .next()
+        .unwrap_or(summary)
+}
+
+fn capability_namespace_matches(tool_id: &str, namespace: &str) -> bool {
+    let tool_id = tool_id.to_ascii_lowercase();
+    let namespace = namespace.trim_start_matches("mcp.");
+    let provider_id = tool_id.strip_prefix("mcp.").unwrap_or(&tool_id);
+    provider_id == namespace
+        || provider_id
+            .strip_prefix(namespace)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+fn capability_namespace(tool_id: &str) -> &str {
+    if let Some(provider_id) = tool_id.strip_prefix("mcp.") {
+        return provider_id
+            .split_once('.')
+            .map_or(tool_id, |(provider, _)| {
+                &tool_id[.."mcp.".len() + provider.len()]
+            });
+    }
+    tool_id
+        .split_once('.')
+        .map_or(tool_id, |(namespace, _)| namespace)
+}
+
+fn capability_executor_tool(descriptor: &ToolDescriptor) -> Option<&'static str> {
+    if !descriptor.tool_id.starts_with("mcp.") {
+        return None;
+    }
+    match (descriptor.authority_class, descriptor.effect_class) {
+        (ToolAuthorityClass::Observe, ToolEffectClass::Read) => Some(CAPABILITY_EXECUTE_READ),
+        (ToolAuthorityClass::Propose, ToolEffectClass::Read) => Some(CAPABILITY_EXECUTE_PROPOSAL),
+        (ToolAuthorityClass::Actuate, ToolEffectClass::ExternalEffect) => {
+            Some(CAPABILITY_EXECUTE_ACTUATION)
+        }
+        _ => None,
+    }
+}
+
+fn capability_descriptor_json(descriptor: &ToolDescriptor, score: usize) -> Value {
+    let descriptor_value = json!({
+        "authority_class": descriptor.authority_class,
+        "effect_class": descriptor.effect_class,
+        "input_schema_ref": descriptor.input_schema_ref,
+        "result_schema_ref": descriptor.result_schema_ref,
+        "summary": descriptor.summary,
+        "title": descriptor.title,
+        "tool_id": descriptor.tool_id,
+    });
+    json!({
+        "descriptor": descriptor_value,
+        "descriptor_digest": sha256_digest(&descriptor_value.to_string()),
+        "namespace": capability_namespace(&descriptor.tool_id),
+        "score": score,
+    })
+}
+
+fn sha256_digest(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("sha256:{digest}")
+}
+
 #[async_trait]
 impl AgentTools for PlatformAgentTools {
     fn catalog(&self) -> Vec<ToolDescriptor> {
-        let mut catalog = vec![
+        built_in_capability_catalog()
+    }
+
+    async fn invoke(
+        &self,
+        request: &AgentTurnRequest,
+        call: &cerebro_agent_runtime::ToolCall,
+    ) -> Result<ToolResult, AgentRuntimeError> {
+        let tenant_id = TenantId::parse(request.tenant_id.clone())
+            .map_err(|error| AgentRuntimeError::InvalidRequest(error.to_string()))?;
+        let result = match call.tool_id.as_str() {
+            "capability.search" => self.search_capabilities(request, call),
+            "capability.describe" => self.describe_capabilities(request, call),
+            "capability.overview" => self.inspect_capability_overview(request, call),
+            CAPABILITY_EXECUTE_READ
+            | CAPABILITY_EXECUTE_PROPOSAL
+            | CAPABILITY_EXECUTE_ACTUATION => {
+                return self.execute_selected_capability(request, call).await;
+            }
+            "graph.search" => self.search(&tenant_id, request, call).await,
+            "graph.expand" => self.expand(&tenant_id, request, call).await,
+            "source_runtime.inspect" => {
+                self.inspect_source_runtime(&tenant_id, request, call).await
+            }
+            "source_runtime.overview" => {
+                self.inspect_source_runtime_overview(&tenant_id, request, call)
+                    .await
+            }
+            "source_catalog.inspect" => self.inspect_source_catalog(request, call),
+            "slack.thread.read" => self.read_slack_thread(request, call).await,
+            "slack.history.search" => self.search_slack_history(request, call).await,
+            _ => Err(AgentRuntimeError::ToolUnavailable(call.tool_id.clone())),
+        }?;
+        Ok(atomize_tool_result(call, result))
+    }
+}
+
+fn built_in_capability_catalog() -> Vec<ToolDescriptor> {
+    vec![
+            ToolDescriptor {
+                tool_id: "capability.search".into(),
+                title: "Find tools for an intent".into(),
+                summary: "Search the complete bound capability catalog by intent, namespace, authority class, and effect class before choosing a provider tool. Catalog results describe capability only and are not evidence about an external system. Input fields: query string, optional namespaces string array, optional authority_classes and effect_classes arrays, optional limit from 1 to 20, and optional offset.".into(),
+                authority_class: ToolAuthorityClass::Observe,
+                effect_class: ToolEffectClass::Read,
+                input_schema_ref: "schema://cerebro/capability-search-input/v1".into(),
+                result_schema_ref: "schema://cerebro/capability-search-result/v1".into(),
+            },
+            ToolDescriptor {
+                tool_id: "capability.describe".into(),
+                title: "Describe exact tools".into(),
+                summary: "Read exact bound tool descriptors, authority and effect policy, and input/result schema references for up to 12 tool ids. Catalog results describe capability only and are not evidence about an external system. Input field: tool_ids string array.".into(),
+                authority_class: ToolAuthorityClass::Observe,
+                effect_class: ToolEffectClass::Read,
+                input_schema_ref: "schema://cerebro/capability-describe-input/v1".into(),
+                result_schema_ref: "schema://cerebro/capability-describe-result/v1".into(),
+            },
+            ToolDescriptor {
+                tool_id: CAPABILITY_EXECUTE_READ.into(),
+                title: "Execute a selected read capability".into(),
+                summary: "Redeem one host-signed capability selection for its exact read-only provider tool. Input fields: selection_ref string returned by capability.search and input object matching the selected provider schema.".into(),
+                authority_class: ToolAuthorityClass::Observe,
+                effect_class: ToolEffectClass::Read,
+                input_schema_ref: "schema://cerebro/capability-execute-input/v1".into(),
+                result_schema_ref: "schema://cerebro/capability-execute-result/v1".into(),
+            },
+            ToolDescriptor {
+                tool_id: CAPABILITY_EXECUTE_PROPOSAL.into(),
+                title: "Execute a selected proposal capability".into(),
+                summary: "Redeem one host-signed capability selection for its exact proposal-only provider tool. Input fields: selection_ref string returned by capability.search and input object matching the selected provider schema.".into(),
+                authority_class: ToolAuthorityClass::Propose,
+                effect_class: ToolEffectClass::Read,
+                input_schema_ref: "schema://cerebro/capability-execute-input/v1".into(),
+                result_schema_ref: "schema://cerebro/capability-execute-result/v1".into(),
+            },
+            ToolDescriptor {
+                tool_id: CAPABILITY_EXECUTE_ACTUATION.into(),
+                title: "Execute a selected external effect".into(),
+                summary: "Redeem one host-signed capability selection for its exact effect-capable provider tool. The ordinary exact-input approval boundary applies. Input fields: selection_ref string returned by capability.search and input object matching the selected provider schema.".into(),
+                authority_class: ToolAuthorityClass::Actuate,
+                effect_class: ToolEffectClass::ExternalEffect,
+                input_schema_ref: "schema://cerebro/capability-execute-input/v1".into(),
+                result_schema_ref: "schema://cerebro/capability-execute-result/v1".into(),
+            },
             ToolDescriptor {
                 tool_id: "capability.overview".into(),
                 title: "Read current agent capabilities".into(),
@@ -3039,41 +3360,7 @@ impl AgentTools for PlatformAgentTools {
                 input_schema_ref: "schema://cerebro/slack-history-search-input/v1".into(),
                 result_schema_ref: "schema://cerebro/slack-history-search-result/v1".into(),
             },
-        ];
-        if let Some(mcp) = &self.mcp {
-            catalog.extend(mcp.descriptors().iter().cloned());
-        }
-        catalog
-    }
-
-    async fn invoke(
-        &self,
-        request: &AgentTurnRequest,
-        call: &cerebro_agent_runtime::ToolCall,
-    ) -> Result<ToolResult, AgentRuntimeError> {
-        let tenant_id = TenantId::parse(request.tenant_id.clone())
-            .map_err(|error| AgentRuntimeError::InvalidRequest(error.to_string()))?;
-        let result = match call.tool_id.as_str() {
-            "capability.overview" => self.inspect_capability_overview(request, call),
-            "graph.search" => self.search(&tenant_id, request, call).await,
-            "graph.expand" => self.expand(&tenant_id, request, call).await,
-            "source_runtime.inspect" => {
-                self.inspect_source_runtime(&tenant_id, request, call).await
-            }
-            "source_runtime.overview" => {
-                self.inspect_source_runtime_overview(&tenant_id, request, call)
-                    .await
-            }
-            "source_catalog.inspect" => self.inspect_source_catalog(request, call),
-            "slack.thread.read" => self.read_slack_thread(request, call).await,
-            "slack.history.search" => self.search_slack_history(request, call).await,
-            _ => match &self.mcp {
-                Some(mcp) => mcp.invoke(request, call).await,
-                None => Err(AgentRuntimeError::ToolUnavailable(call.tool_id.clone())),
-            },
-        }?;
-        Ok(atomize_tool_result(call, result))
-    }
+    ]
 }
 
 fn atomize_tool_result(
@@ -3184,6 +3471,169 @@ impl SessionTools for PlatformAgentTools {
 }
 
 impl PlatformAgentTools {
+    fn complete_capability_catalog(&self) -> Vec<ToolDescriptor> {
+        let mut catalog = <Self as AgentTools>::catalog(self);
+        if let Some(mcp) = &self.mcp {
+            catalog.extend(mcp.descriptors().iter().cloned());
+        }
+        catalog
+    }
+
+    fn search_capabilities(
+        &self,
+        request: &AgentTurnRequest,
+        call: &cerebro_agent_runtime::ToolCall,
+    ) -> Result<ToolResult, AgentRuntimeError> {
+        let input: CapabilitySearchInput = serde_json::from_value(call.input.clone())
+            .map_err(|error| AgentRuntimeError::InvalidToolCall(error.to_string()))?;
+        let query = input.query.trim();
+        if query.is_empty()
+            || query.len() > MAX_CAPABILITY_QUERY_BYTES
+            || input.limit == 0
+            || input.limit > MAX_CAPABILITY_SEARCH_LIMIT
+            || input.offset > MAX_CAPABILITY_CATALOG_OFFSET
+            || input.namespaces.len() > MAX_CAPABILITY_DESCRIBE_IDS
+            || input.namespaces.iter().any(|namespace| {
+                namespace.trim().is_empty() || namespace.len() > MAX_CAPABILITY_TOOL_ID_BYTES
+            })
+        {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "capability search bounds are invalid".into(),
+            ));
+        }
+        let catalog = self.complete_capability_catalog();
+        let matches = search_capability_catalog(&catalog, &input);
+        let total_matches = matches.len();
+        let query_digest = sha256_digest(query);
+        let page = matches
+            .into_iter()
+            .skip(input.offset)
+            .take(input.limit)
+            .enumerate()
+            .map(|(index, (score, descriptor))| {
+                let mut value = capability_descriptor_json(descriptor, score);
+                value["rank"] = json!(input.offset + index + 1);
+                if let (Some(mcp), Some(executor_tool_id)) =
+                    (&self.mcp, capability_executor_tool(descriptor))
+                {
+                    let selection_ref = mcp
+                        .issue_selection_ref(request, descriptor, &query_digest)
+                        .map_err(AgentRuntimeError::InvalidToolCall)?;
+                    value["execution_tool_id"] = Value::String(executor_tool_id.into());
+                    value["selection_ref"] = Value::String(selection_ref);
+                }
+                Ok(value)
+            })
+            .collect::<Result<Vec<_>, AgentRuntimeError>>()?;
+        let next_offset =
+            (input.offset + page.len() < total_matches).then_some(input.offset + page.len());
+        Ok(ToolResult {
+            state: ToolResultState::Succeeded,
+            summary: format!(
+                "Found {} bound tools matching the requested intent.",
+                page.len()
+            ),
+            data: json!({
+                "matches": page,
+                "next_offset": next_offset,
+                "offset": input.offset,
+                "query": query,
+                "query_digest": query_digest,
+                "schema_version": "capability-search-result/v1",
+                "total_matches": total_matches,
+            }),
+            evidence: vec![],
+            blocker: None,
+        })
+    }
+
+    fn describe_capabilities(
+        &self,
+        _request: &AgentTurnRequest,
+        call: &cerebro_agent_runtime::ToolCall,
+    ) -> Result<ToolResult, AgentRuntimeError> {
+        let input: CapabilityDescribeInput = serde_json::from_value(call.input.clone())
+            .map_err(|error| AgentRuntimeError::InvalidToolCall(error.to_string()))?;
+        if input.tool_ids.is_empty() || input.tool_ids.len() > MAX_CAPABILITY_DESCRIBE_IDS {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "capability describe requires between 1 and 12 tool ids".into(),
+            ));
+        }
+        let requested = input.tool_ids.into_iter().collect::<BTreeSet<_>>();
+        if requested.len() > MAX_CAPABILITY_DESCRIBE_IDS
+            || requested.iter().any(|tool_id| {
+                tool_id.trim().is_empty() || tool_id.len() > MAX_CAPABILITY_TOOL_ID_BYTES
+            })
+        {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "capability describe tool ids are invalid".into(),
+            ));
+        }
+        let catalog = self.complete_capability_catalog();
+        let by_id = catalog
+            .iter()
+            .map(|descriptor| (descriptor.tool_id.as_str(), descriptor))
+            .collect::<BTreeMap<_, _>>();
+        let mut described = Vec::new();
+        let mut unavailable = Vec::new();
+        for tool_id in &requested {
+            if let Some(descriptor) = by_id.get(tool_id.as_str()) {
+                described.push(capability_descriptor_json(descriptor, 0));
+            } else {
+                unavailable.push(tool_id);
+            }
+        }
+        let complete = unavailable.is_empty();
+        Ok(ToolResult {
+            state: if complete {
+                ToolResultState::Succeeded
+            } else {
+                ToolResultState::Partial
+            },
+            summary: "Read exact bound tool descriptors and authority policy.".into(),
+            data: json!({
+                "schema_version": "capability-describe-result/v1",
+                "tools": described,
+                "unavailable_tool_ids": unavailable,
+            }),
+            evidence: vec![],
+            blocker: (!complete).then(|| "One or more requested tools are not bound.".into()),
+        })
+    }
+
+    async fn execute_selected_capability(
+        &self,
+        request: &AgentTurnRequest,
+        call: &cerebro_agent_runtime::ToolCall,
+    ) -> Result<ToolResult, AgentRuntimeError> {
+        let input: CapabilityExecuteInput = serde_json::from_value(call.input.clone())
+            .map_err(|error| AgentRuntimeError::InvalidToolCall(error.to_string()))?;
+        if input.selection_ref.len() > 1_024 || !input.input.is_object() {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "capability execution requires a bounded selection_ref and object input".into(),
+            ));
+        }
+        let mcp = self.mcp.as_ref().ok_or_else(|| {
+            AgentRuntimeError::ToolUnavailable("MCP capability gateway is not bound".into())
+        })?;
+        let descriptor = mcp
+            .verify_selection_ref(request, &input.selection_ref)
+            .map_err(AgentRuntimeError::InvalidToolCall)?;
+        if capability_executor_tool(&descriptor) != Some(call.tool_id.as_str()) {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "capability selection authority does not match this executor".into(),
+            ));
+        }
+        let provider_call = cerebro_agent_runtime::ToolCall {
+            call_id: call.call_id.clone(),
+            tool_id: descriptor.tool_id,
+            purpose: call.purpose.clone(),
+            input: input.input,
+        };
+        let result = mcp.invoke(request, &provider_call).await?;
+        Ok(atomize_tool_result(&provider_call, result))
+    }
+
     fn inspect_capability_overview(
         &self,
         request: &AgentTurnRequest,
@@ -3227,7 +3677,7 @@ impl PlatformAgentTools {
             call,
             complete,
             format!(
-                "The Slack agent capability registry observed eight built-in tools and {} bound MCP tools; MCP gateway state={gateway_state}.",
+                "The Slack agent capability registry observed thirteen built-in tools and {} bound MCP tools; MCP gateway state={gateway_state}.",
                 remote.len()
             ),
         )?;
@@ -3240,6 +3690,11 @@ impl PlatformAgentTools {
             summary: "Read the current Slack agent capability registry.".into(),
             data: json!({
                 "built_in": [
+                    "capability.search",
+                    "capability.describe",
+                    CAPABILITY_EXECUTE_READ,
+                    CAPABILITY_EXECUTE_PROPOSAL,
+                    CAPABILITY_EXECUTE_ACTUATION,
                     "capability.overview",
                     "graph.search",
                     "graph.expand",
@@ -4131,6 +4586,228 @@ mod tests {
     };
     use cerebro_organizational_store::SourceRuntimeCollectionObservation;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn discovered_tool(
+        tool_id: &str,
+        title: &str,
+        summary: &str,
+        authority_class: ToolAuthorityClass,
+        effect_class: ToolEffectClass,
+    ) -> ToolDescriptor {
+        ToolDescriptor {
+            tool_id: tool_id.into(),
+            title: title.into(),
+            summary: summary.into(),
+            authority_class,
+            effect_class,
+            input_schema_ref: format!("schema://{tool_id}/input"),
+            result_schema_ref: format!("schema://{tool_id}/result"),
+        }
+    }
+
+    #[test]
+    fn direct_model_catalog_exposes_only_bounded_host_tools() {
+        let catalog = built_in_capability_catalog();
+
+        assert_eq!(catalog.len(), 13);
+        assert!(catalog.iter().all(|tool| !tool.tool_id.starts_with("mcp.")));
+        assert!(
+            catalog
+                .iter()
+                .any(|tool| tool.tool_id == "capability.search")
+        );
+        assert!(
+            catalog
+                .iter()
+                .any(|tool| tool.tool_id == "slack.thread.read")
+        );
+        assert!(
+            catalog
+                .iter()
+                .any(|tool| tool.tool_id == "slack.history.search")
+        );
+    }
+
+    #[test]
+    fn capability_search_prefers_the_direct_provider_tool() {
+        let catalog = vec![
+            discovered_tool(
+                "graph.search",
+                "Search governed graph",
+                "Find graph entities and relations.",
+                ToolAuthorityClass::Observe,
+                ToolEffectClass::Read,
+            ),
+            discovered_tool(
+                "mcp.slack.thread.read",
+                "Read a Slack thread",
+                "Read the exact prior messages in an owned Slack conversation.",
+                ToolAuthorityClass::Observe,
+                ToolEffectClass::Read,
+            ),
+            discovered_tool(
+                "github.pull_request.read",
+                "Read a GitHub pull request",
+                "Read pull request state and checks.",
+                ToolAuthorityClass::Observe,
+                ToolEffectClass::Read,
+            ),
+        ];
+        let input = CapabilitySearchInput {
+            query: "prior Slack thread conversation".into(),
+            namespaces: Vec::new(),
+            authority_classes: vec![ToolAuthorityClass::Observe],
+            effect_classes: vec![ToolEffectClass::Read],
+            limit: 8,
+            offset: 0,
+        };
+
+        let matches = search_capability_catalog(&catalog, &input);
+
+        assert_eq!(matches[0].1.tool_id, "mcp.slack.thread.read");
+        assert_eq!(
+            capability_namespace(matches[0].1.tool_id.as_str()),
+            "mcp.slack"
+        );
+        assert!(capability_namespace_matches(
+            matches[0].1.tool_id.as_str(),
+            "slack"
+        ));
+        assert!(
+            matches
+                .iter()
+                .all(|(_, tool)| tool.tool_id != "graph.search")
+        );
+    }
+
+    #[test]
+    fn capability_search_applies_namespace_and_effect_policy_filters() {
+        let catalog = vec![
+            discovered_tool(
+                "mcp.slack.thread.read",
+                "Read a Slack thread",
+                "Read Slack conversation history.",
+                ToolAuthorityClass::Observe,
+                ToolEffectClass::Read,
+            ),
+            discovered_tool(
+                "mcp.slack.message.send",
+                "Send a Slack message",
+                "Send a Slack message to a channel.",
+                ToolAuthorityClass::Actuate,
+                ToolEffectClass::ExternalEffect,
+            ),
+            discovered_tool(
+                "github.issue.create",
+                "Create a GitHub issue",
+                "Create an issue.",
+                ToolAuthorityClass::Actuate,
+                ToolEffectClass::ExternalEffect,
+            ),
+        ];
+        let input = CapabilitySearchInput {
+            query: "Slack message".into(),
+            namespaces: vec!["slack".into()],
+            authority_classes: vec![ToolAuthorityClass::Actuate],
+            effect_classes: vec![ToolEffectClass::ExternalEffect],
+            limit: 8,
+            offset: 0,
+        };
+
+        let matches = search_capability_catalog(&catalog, &input);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].1.tool_id, "mcp.slack.message.send");
+    }
+
+    #[test]
+    fn capability_search_defaults_to_observe_read_and_ignores_schema_keyword_stuffing() {
+        let catalog = vec![
+            discovered_tool(
+                "mcp.slack.thread.read",
+                "Read a conversation",
+                "Read retained conversation messages. Input JSON Schema: {\"description\":\"deploy change issue create send write\"}",
+                ToolAuthorityClass::Observe,
+                ToolEffectClass::Read,
+            ),
+            discovered_tool(
+                "mcp.slack.message.send",
+                "Send a message",
+                "Send a message to a conversation.",
+                ToolAuthorityClass::Actuate,
+                ToolEffectClass::ExternalEffect,
+            ),
+            discovered_tool(
+                "mcp.code.change.apply",
+                "Apply a deployment change",
+                "Apply an external deployment change.",
+                ToolAuthorityClass::Actuate,
+                ToolEffectClass::ExternalEffect,
+            ),
+        ];
+        let input = CapabilitySearchInput {
+            query: "deployment change".into(),
+            namespaces: Vec::new(),
+            authority_classes: Vec::new(),
+            effect_classes: Vec::new(),
+            limit: 8,
+            offset: 0,
+        };
+
+        assert!(search_capability_catalog(&catalog, &input).is_empty());
+    }
+
+    #[test]
+    fn capability_executor_preserves_the_selected_authority_boundary() {
+        let read = discovered_tool(
+            "mcp.slack.thread.read",
+            "Read a thread",
+            "Read retained conversation messages.",
+            ToolAuthorityClass::Observe,
+            ToolEffectClass::Read,
+        );
+        let proposal = discovered_tool(
+            "mcp.change.propose",
+            "Propose a change",
+            "Prepare a proposal.",
+            ToolAuthorityClass::Propose,
+            ToolEffectClass::Read,
+        );
+        let actuation = discovered_tool(
+            "mcp.change.apply",
+            "Apply a change",
+            "Apply an approved effect.",
+            ToolAuthorityClass::Actuate,
+            ToolEffectClass::ExternalEffect,
+        );
+
+        assert_eq!(
+            capability_executor_tool(&read),
+            Some(CAPABILITY_EXECUTE_READ)
+        );
+        assert_eq!(
+            capability_executor_tool(&proposal),
+            Some(CAPABILITY_EXECUTE_PROPOSAL)
+        );
+        assert_eq!(
+            capability_executor_tool(&actuation),
+            Some(CAPABILITY_EXECUTE_ACTUATION)
+        );
+    }
+
+    #[test]
+    fn agent_and_critic_require_provider_tool_discovery_without_graph_substitution() {
+        for instructions in [session_instructions(), model_instructions()] {
+            assert!(instructions.contains("capability.search"));
+            assert!(instructions.contains("Never substitute graph.search"));
+            assert!(instructions.contains("Catalog metadata"));
+        }
+        assert!(
+            claim_review_instructions().contains(
+                "Reject a response that fills a provider request with an unrelated graph"
+            )
+        );
+    }
 
     #[test]
     fn generic_atomization_preserves_validated_semantic_atoms() {

--- a/crates/cerebro-platform/src/slack_agent.rs
+++ b/crates/cerebro-platform/src/slack_agent.rs
@@ -2617,7 +2617,7 @@ Return one flat JSON object with decision, plan, calls, and draft every time. Se
 
 - For a conversational answer that needs no current evidence, finish directly.
 - Before any evidence tool, establish_plan once. The plan must name the decision, lane, resolved entities, required claims, selected tools, stop conditions, short user-visible work, and follow_through. When the operator explicitly delegates a future re-observation, follow_through must define the complete executor contract before any tool runs: a stable commitment_ref, exact required read tools, acceptance criteria, next action, typed attention policy, bounded check delay, and verification. acceptance_all contains the desired completion values. alert_any contains only explicit boolean authority signals for a gap, regression, conflict, staleness, or mismatch; never put an ordinary numeric or string progress value in alert_any. Otherwise set follow_through to null. Rust materializes this plan into the durable scheduled commitment; final prose does not author or rewrite scheduling authority. Select only tools in available_tools.
-- When the request concerns Slack history, a linked message, a prior conversation, GitHub, code, deployments, the web, company knowledge, or another provider and the exact provider tool is not already obvious, select capability.search first with the user's intent. Search defaults to observe/read capabilities; request another authority or effect class only when the operator's request requires it. Use capability.describe only when the matching descriptor does not make its input contract clear. For an MCP match, revise the plan to the returned execution_tool_id and call it with the exact returned selection_ref plus provider input matching the selected descriptor. Never substitute graph.search for a missing or undiscovered provider capability.
+- When the request concerns Slack history, a linked message, a prior conversation, GitHub, code, deployments, the web, company knowledge, or another provider and the exact provider tool is not already obvious, select capability.search first with the user's intent. Search defaults to observe/read capabilities; request another authority or effect class only when the operator's request requires it. Use capability.describe only when the matching descriptor does not make its input contract clear. For a read or proposal MCP match, revise the plan to the returned execution_tool_id and call it with the exact returned selection_ref plus provider input matching the selected descriptor. A host-admitted external effect remains visible as its exact MCP tool id and may run only in an Act plan through the ordinary exact-input approval boundary. Never substitute graph.search for a missing or undiscovered provider capability.
 - capability.search, capability.describe, and capability.overview describe the bound catalog and its authority policy. Catalog metadata never establishes a fact about Slack, GitHub, a deployment, a web page, or any other external system. Invoke the discovered provider tool before making a current claim. If no matching tool is bound, state that exact capability gap instead of querying an unrelated source.
 - When plan is non-null, it is already active. Invoke its selected tools or finish from the observations. If a planned follow-through tool fails or proves irrelevant and another available read establishes the delegated baseline, that is a material revision: establish one revised plan with the corrected complete follow_through contract before finishing.
 - Then invoke_tools with one or more independent read calls. Keep effects alone in their own decision. The Rust host enforces exact approval and will return an approval request when authorization is absent.
@@ -2733,7 +2733,7 @@ Operate, do not merely describe a query:
 - Inspect current state with the smallest useful tool calls.
 - Give every tool invocation a new call_id that has not appeared earlier in the current turn. After duplicate-call repair feedback, use the existing observation or finish; never resend the same call identity.
 - Use capability.overview when the user asks what Cerebro can currently do or when a requested capability may not be bound. The available tool catalog is the exact capability boundary for this turn.
-- When the request concerns Slack history, a linked message, a prior conversation, GitHub, code, deployments, the web, company knowledge, or another provider and the exact provider tool is not already obvious, use capability.search with the user's intent, then capability.describe only if the input contract remains unclear. For an MCP match, revise the plan to the returned execution_tool_id and invoke it with the returned selection_ref and provider input. Catalog metadata is capability evidence only. It is never evidence about the provider's current state.
+- When the request concerns Slack history, a linked message, a prior conversation, GitHub, code, deployments, the web, company knowledge, or another provider and the exact provider tool is not already obvious, use capability.search with the user's intent, then capability.describe only if the input contract remains unclear. For a read or proposal MCP match, revise the plan to the returned execution_tool_id and invoke it with the returned selection_ref and provider input. A host-admitted external effect uses its exact MCP tool id and remains subject to an Act plan and exact-input approval. Catalog metadata is capability evidence only. It is never evidence about the provider's current state.
 - Never substitute graph.search for a Slack, GitHub, code, deployment, web, or company-knowledge request. If capability.search returns no relevant provider tool, report the exact missing capability instead of filling the turn with an unrelated graph or source inventory.
 - Use the bound MCP task tools for findings, assets, evidence packets, investigation context, risk explanation, source health, action planning, and any other domain whose descriptor matches the request. Do not reduce a domain request to graph search when a more specific capability is available.
 - A complete evidence packet means the bounded packet exists and is current; it does not prove that every field the operator asks for was returned in the observation. Claim an asset identifier, exposed path, control ID, owner name, or change field only when that value is present in the observation. An owner-present flag proves only that an owner mapping exists, not the person's name, team, role, or notification route.
@@ -2976,7 +2976,6 @@ const MAX_CAPABILITY_QUERY_BYTES: usize = 512;
 const MAX_CAPABILITY_TOOL_ID_BYTES: usize = 256;
 const CAPABILITY_EXECUTE_READ: &str = "capability.execute_read";
 const CAPABILITY_EXECUTE_PROPOSAL: &str = "capability.execute_proposal";
-const CAPABILITY_EXECUTE_ACTUATION: &str = "capability.execute_actuation";
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -3168,9 +3167,6 @@ fn capability_executor_tool(descriptor: &ToolDescriptor) -> Option<&'static str>
     match (descriptor.authority_class, descriptor.effect_class) {
         (ToolAuthorityClass::Observe, ToolEffectClass::Read) => Some(CAPABILITY_EXECUTE_READ),
         (ToolAuthorityClass::Propose, ToolEffectClass::Read) => Some(CAPABILITY_EXECUTE_PROPOSAL),
-        (ToolAuthorityClass::Actuate, ToolEffectClass::ExternalEffect) => {
-            Some(CAPABILITY_EXECUTE_ACTUATION)
-        }
         _ => None,
     }
 }
@@ -3204,7 +3200,7 @@ fn sha256_digest(value: &str) -> String {
 #[async_trait]
 impl AgentTools for PlatformAgentTools {
     fn catalog(&self) -> Vec<ToolDescriptor> {
-        built_in_capability_catalog()
+        model_capability_catalog(self.mcp.as_deref().map_or(&[], McpAgentTools::descriptors))
     }
 
     async fn invoke(
@@ -3218,9 +3214,7 @@ impl AgentTools for PlatformAgentTools {
             "capability.search" => self.search_capabilities(request, call),
             "capability.describe" => self.describe_capabilities(request, call),
             "capability.overview" => self.inspect_capability_overview(request, call),
-            CAPABILITY_EXECUTE_READ
-            | CAPABILITY_EXECUTE_PROPOSAL
-            | CAPABILITY_EXECUTE_ACTUATION => {
+            CAPABILITY_EXECUTE_READ | CAPABILITY_EXECUTE_PROPOSAL => {
                 return self.execute_selected_capability(request, call).await;
             }
             "graph.search" => self.search(&tenant_id, request, call).await,
@@ -3235,7 +3229,16 @@ impl AgentTools for PlatformAgentTools {
             "source_catalog.inspect" => self.inspect_source_catalog(request, call),
             "slack.thread.read" => self.read_slack_thread(request, call).await,
             "slack.history.search" => self.search_slack_history(request, call).await,
-            _ => Err(AgentRuntimeError::ToolUnavailable(call.tool_id.clone())),
+            _ => match &self.mcp {
+                Some(mcp)
+                    if mcp.descriptor(&call.tool_id).is_some_and(|descriptor| {
+                        descriptor.authority_class == ToolAuthorityClass::Actuate
+                    }) =>
+                {
+                    mcp.invoke(request, call).await
+                }
+                _ => Err(AgentRuntimeError::ToolUnavailable(call.tool_id.clone())),
+            },
         }?;
         Ok(atomize_tool_result(call, result))
     }
@@ -3276,15 +3279,6 @@ fn built_in_capability_catalog() -> Vec<ToolDescriptor> {
                 summary: "Redeem one host-signed capability selection for its exact proposal-only provider tool. Input fields: selection_ref string returned by capability.search and input object matching the selected provider schema.".into(),
                 authority_class: ToolAuthorityClass::Propose,
                 effect_class: ToolEffectClass::Read,
-                input_schema_ref: "schema://cerebro/capability-execute-input/v1".into(),
-                result_schema_ref: "schema://cerebro/capability-execute-result/v1".into(),
-            },
-            ToolDescriptor {
-                tool_id: CAPABILITY_EXECUTE_ACTUATION.into(),
-                title: "Execute a selected external effect".into(),
-                summary: "Redeem one host-signed capability selection for its exact effect-capable provider tool. The ordinary exact-input approval boundary applies. Input fields: selection_ref string returned by capability.search and input object matching the selected provider schema.".into(),
-                authority_class: ToolAuthorityClass::Actuate,
-                effect_class: ToolEffectClass::ExternalEffect,
                 input_schema_ref: "schema://cerebro/capability-execute-input/v1".into(),
                 result_schema_ref: "schema://cerebro/capability-execute-result/v1".into(),
             },
@@ -3361,6 +3355,17 @@ fn built_in_capability_catalog() -> Vec<ToolDescriptor> {
                 result_schema_ref: "schema://cerebro/slack-history-search-result/v1".into(),
             },
     ]
+}
+
+fn model_capability_catalog(remote: &[ToolDescriptor]) -> Vec<ToolDescriptor> {
+    let mut catalog = built_in_capability_catalog();
+    catalog.extend(
+        remote
+            .iter()
+            .filter(|descriptor| descriptor.authority_class == ToolAuthorityClass::Actuate)
+            .cloned(),
+    );
+    catalog
 }
 
 fn atomize_tool_result(
@@ -3472,7 +3477,7 @@ impl SessionTools for PlatformAgentTools {
 
 impl PlatformAgentTools {
     fn complete_capability_catalog(&self) -> Vec<ToolDescriptor> {
-        let mut catalog = <Self as AgentTools>::catalog(self);
+        let mut catalog = built_in_capability_catalog();
         if let Some(mcp) = &self.mcp {
             catalog.extend(mcp.descriptors().iter().cloned());
         }
@@ -3677,7 +3682,7 @@ impl PlatformAgentTools {
             call,
             complete,
             format!(
-                "The Slack agent capability registry observed thirteen built-in tools and {} bound MCP tools; MCP gateway state={gateway_state}.",
+                "The Slack agent capability registry observed twelve built-in tools and {} bound MCP tools; MCP gateway state={gateway_state}.",
                 remote.len()
             ),
         )?;
@@ -3694,7 +3699,6 @@ impl PlatformAgentTools {
                     "capability.describe",
                     CAPABILITY_EXECUTE_READ,
                     CAPABILITY_EXECUTE_PROPOSAL,
-                    CAPABILITY_EXECUTE_ACTUATION,
                     "capability.overview",
                     "graph.search",
                     "graph.expand",
@@ -4607,9 +4611,9 @@ mod tests {
 
     #[test]
     fn direct_model_catalog_exposes_only_bounded_host_tools() {
-        let catalog = built_in_capability_catalog();
+        let catalog = model_capability_catalog(&[]);
 
-        assert_eq!(catalog.len(), 13);
+        assert_eq!(catalog.len(), 12);
         assert!(catalog.iter().all(|tool| !tool.tool_id.starts_with("mcp.")));
         assert!(
             catalog
@@ -4626,6 +4630,36 @@ mod tests {
                 .iter()
                 .any(|tool| tool.tool_id == "slack.history.search")
         );
+    }
+
+    #[test]
+    fn direct_model_catalog_hides_remote_reads_but_keeps_exact_effect_identity() {
+        let read = discovered_tool(
+            "mcp.slack.thread.read",
+            "Read a thread",
+            "Read messages.",
+            ToolAuthorityClass::Observe,
+            ToolEffectClass::Read,
+        );
+        let actuation = discovered_tool(
+            "mcp.slack.message.send",
+            "Send a message",
+            "Send one message.",
+            ToolAuthorityClass::Actuate,
+            ToolEffectClass::ExternalEffect,
+        );
+
+        let catalog = model_capability_catalog(&[read, actuation]);
+
+        assert!(
+            !catalog
+                .iter()
+                .any(|tool| tool.tool_id == "mcp.slack.thread.read")
+        );
+        assert!(catalog.iter().any(|tool| {
+            tool.tool_id == "mcp.slack.message.send"
+                && tool.authority_class == ToolAuthorityClass::Actuate
+        }));
     }
 
     #[test]
@@ -4789,10 +4823,7 @@ mod tests {
             capability_executor_tool(&proposal),
             Some(CAPABILITY_EXECUTE_PROPOSAL)
         );
-        assert_eq!(
-            capability_executor_tool(&actuation),
-            Some(CAPABILITY_EXECUTE_ACTUATION)
-        );
+        assert_eq!(capability_executor_tool(&actuation), None);
     }
 
     #[test]

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -88,6 +88,16 @@ impl McpAgentTools {
         env::var(MCP_URL_ENV).is_ok_and(|value| !value.trim().is_empty())
     }
 
+    pub fn authority_policy_configured() -> bool {
+        [
+            MCP_OBSERVE_TOOLS_ENV,
+            MCP_PROPOSE_TOOLS_ENV,
+            MCP_ACTUATE_TOOLS_ENV,
+        ]
+        .iter()
+        .any(|name| env::var(name).is_ok_and(|value| !value.trim().is_empty()))
+    }
+
     pub async fn from_env() -> Result<Option<Self>, String> {
         let raw_url = env::var(MCP_URL_ENV).unwrap_or_default();
         if raw_url.trim().is_empty() {
@@ -95,10 +105,6 @@ impl McpAgentTools {
         }
         let endpoint = validated_endpoint(raw_url.trim())?;
         let bearer_token = required_env(MCP_TOKEN_ENV)?;
-        let selection_signing_key = required_env(MCP_SELECTION_SIGNING_KEY_ENV)?;
-        if selection_signing_key.len() < 32 || selection_signing_key == bearer_token {
-            return Err("capability signing key must be distinct and at least 32 bytes".into());
-        }
         let toolsets = env::var(MCP_TOOLSETS_ENV)
             .unwrap_or_else(|_| "task".into())
             .trim()
@@ -109,6 +115,13 @@ impl McpAgentTools {
         let observe_tools = configured_tool_names(MCP_OBSERVE_TOOLS_ENV)?;
         let propose_tools = configured_tool_names(MCP_PROPOSE_TOOLS_ENV)?;
         let actuate_tools = configured_tool_names(MCP_ACTUATE_TOOLS_ENV)?;
+        let authority_policy_configured =
+            !observe_tools.is_empty() || !propose_tools.is_empty() || !actuate_tools.is_empty();
+        let selection_signing_key = selection_signing_key(
+            env::var(MCP_SELECTION_SIGNING_KEY_ENV).ok(),
+            &bearer_token,
+            authority_policy_configured,
+        )?;
         if !observe_tools.is_disjoint(&propose_tools)
             || !observe_tools.is_disjoint(&actuate_tools)
             || !propose_tools.is_disjoint(&actuate_tools)
@@ -891,6 +904,21 @@ fn required_env(name: &str) -> Result<String, String> {
     Ok(value.to_owned())
 }
 
+fn selection_signing_key(
+    configured: Option<String>,
+    bearer_token: &str,
+    required: bool,
+) -> Result<String, String> {
+    let key = configured.unwrap_or_default().trim().to_owned();
+    if key.is_empty() && !required {
+        return Ok(key);
+    }
+    if key.len() < 32 || key == bearer_token {
+        return Err("capability signing key must be distinct and at least 32 bytes".into());
+    }
+    Ok(key)
+}
+
 fn nonempty(value: &str, fallback: &str) -> String {
     let value = value.trim();
     if value.is_empty() {
@@ -1209,6 +1237,24 @@ mod tests {
         assert!(validated_endpoint("https://token@cerebro.example.com/api/v1/mcp").is_err());
         assert!(validated_endpoint("http://127.0.0.1:8080/api/v1/mcp").is_ok());
         assert!(validated_endpoint("https://cerebro.example.com/api/v1/mcp").is_ok());
+    }
+
+    #[test]
+    fn empty_host_authority_policy_does_not_require_a_signing_key() {
+        assert_eq!(
+            selection_signing_key(None, "mcp-bearer", false).unwrap(),
+            ""
+        );
+        assert!(selection_signing_key(None, "mcp-bearer", true).is_err());
+        assert!(selection_signing_key(Some("mcp-bearer".into()), "mcp-bearer", true).is_err());
+        assert!(
+            selection_signing_key(
+                Some("host-only-capability-signing-secret".into()),
+                "mcp-bearer",
+                true
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -8,6 +8,7 @@ use cerebro_agent_runtime::{
     ToolDescriptor, ToolEffectClass, ToolResult, ToolResultState,
     session::{SemanticEvidenceAtomization, SemanticEvidenceEnvelope, semantic_evidence_atoms},
 };
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::{
     Client, Url,
     header::{ACCEPT, AUTHORIZATION},
@@ -29,6 +30,7 @@ const MAX_MCP_RESPONSE_BYTES: usize = 1024 * 1024;
 const MAX_GRAPH_REASON_HISTORY_ITEMS: usize = 12;
 const MAX_GRAPH_REASON_HISTORY_ITEM_BYTES: usize = 4 * 1024;
 const SEMANTIC_EVIDENCE_META_KEY: &str = "cerebro.semantic_evidence";
+const CAPABILITY_SELECTION_PREFIX: &str = "capability-selection-v1";
 
 pub struct McpAgentTools {
     client: Client,
@@ -135,6 +137,101 @@ impl McpAgentTools {
 
     pub fn descriptors(&self) -> &[ToolDescriptor] {
         &self.descriptors
+    }
+
+    pub fn issue_selection_ref(
+        &self,
+        request: &AgentTurnRequest,
+        descriptor: &ToolDescriptor,
+        query_digest: &str,
+    ) -> Result<String, String> {
+        if !self.tools.contains_key(&descriptor.tool_id) || !is_sha256_digest(query_digest) {
+            return Err("capability selection target is invalid".into());
+        }
+        let signature = self.selection_signature(request, descriptor, query_digest)?;
+        Ok(format!(
+            "{CAPABILITY_SELECTION_PREFIX}:{}:{}:{signature}",
+            descriptor.tool_id,
+            query_digest.trim_start_matches("sha256:")
+        ))
+    }
+
+    pub fn verify_selection_ref(
+        &self,
+        request: &AgentTurnRequest,
+        selection_ref: &str,
+    ) -> Result<ToolDescriptor, String> {
+        let mut fields = selection_ref.split(':');
+        if fields.next() != Some(CAPABILITY_SELECTION_PREFIX) {
+            return Err("capability selection reference has an unsupported version".into());
+        }
+        let tool_id = fields
+            .next()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "capability selection reference omitted its tool id".to_owned())?;
+        let query_digest = fields
+            .next()
+            .filter(|value| value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+            .map(|value| format!("sha256:{value}"))
+            .ok_or_else(|| {
+                "capability selection reference has an invalid query digest".to_owned()
+            })?;
+        let signature = fields
+            .next()
+            .and_then(decode_hex)
+            .filter(|value| value.len() == 32)
+            .ok_or_else(|| "capability selection reference has an invalid signature".to_owned())?;
+        if fields.next().is_some() {
+            return Err("capability selection reference has unexpected fields".into());
+        }
+        let descriptor = self
+            .tools
+            .get(tool_id)
+            .map(|tool| tool.descriptor.clone())
+            .ok_or_else(|| "capability selection target is no longer bound".to_owned())?;
+        let mac = self.selection_mac(request, &descriptor, &query_digest)?;
+        mac.verify_slice(&signature)
+            .map_err(|_| "capability selection reference does not match this scope".to_owned())?;
+        Ok(descriptor)
+    }
+
+    fn selection_signature(
+        &self,
+        request: &AgentTurnRequest,
+        descriptor: &ToolDescriptor,
+        query_digest: &str,
+    ) -> Result<String, String> {
+        let mac = self.selection_mac(request, descriptor, query_digest)?;
+        Ok(hex_digest(&mac.finalize().into_bytes()))
+    }
+
+    fn selection_mac(
+        &self,
+        request: &AgentTurnRequest,
+        descriptor: &ToolDescriptor,
+        query_digest: &str,
+    ) -> Result<Hmac<Sha256>, String> {
+        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(self.bearer_token.as_bytes())
+            .map_err(|_| "capability selection signer could not initialize".to_owned())?;
+        for value in [
+            CAPABILITY_SELECTION_PREFIX,
+            request.tenant_id.as_str(),
+            request.actor_ref.as_str(),
+            request.thread_ref.as_str(),
+            request.context_scope_ref.as_deref().unwrap_or(""),
+            descriptor.tool_id.as_str(),
+            descriptor.title.as_str(),
+            descriptor.summary.as_str(),
+            authority_name(descriptor.authority_class),
+            effect_name(descriptor.effect_class),
+            descriptor.input_schema_ref.as_str(),
+            descriptor.result_schema_ref.as_str(),
+            query_digest,
+        ] {
+            mac.update(&(value.len() as u64).to_be_bytes());
+            mac.update(value.as_bytes());
+        }
+        Ok(mac)
     }
 
     pub async fn invoke(
@@ -424,6 +521,12 @@ fn bind_tools(
 ) -> Result<BTreeMap<String, BoundMcpTool>, String> {
     let mut tools = BTreeMap::new();
     for tool in listed {
+        if tool.name.is_empty()
+            || tool.name.len() > 256
+            || !tool.name.bytes().all(valid_tool_name_byte)
+        {
+            return Err("MCP tool catalog contains an invalid tool name".into());
+        }
         let read_only = annotation_bool(&tool.annotations, "readOnlyHint");
         let (authority_class, effect_class) = if actuate_tools.contains(&tool.name) {
             if read_only {
@@ -667,6 +770,43 @@ fn valid_tool_name_byte(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
 }
 
+fn authority_name(authority: ToolAuthorityClass) -> &'static str {
+    match authority {
+        ToolAuthorityClass::Observe => "observe",
+        ToolAuthorityClass::Propose => "propose",
+        ToolAuthorityClass::Actuate => "actuate",
+    }
+}
+
+fn effect_name(effect: ToolEffectClass) -> &'static str {
+    match effect {
+        ToolEffectClass::Read => "read",
+        ToolEffectClass::Write => "write",
+        ToolEffectClass::ExternalEffect => "external_effect",
+    }
+}
+
+fn is_sha256_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|digest| {
+        digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
+}
+
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        return None;
+    }
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = (pair[0] as char).to_digit(16)?;
+            let low = (pair[1] as char).to_digit(16)?;
+            Some(((high << 4) | low) as u8)
+        })
+        .collect()
+}
+
 fn annotation_bool(annotations: &BTreeMap<String, Value>, key: &str) -> bool {
     annotations
         .get(key)
@@ -905,6 +1045,65 @@ mod tests {
         );
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_provider_supplied_tool_names_outside_the_bounded_id_contract() {
+        let result = bind_tools(
+            vec![tool("cerebro:read", true)],
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn capability_selection_refs_are_scope_and_descriptor_bound() {
+        let tools = bind_tools(
+            vec![tool("slack.thread.read", true)],
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        let descriptors = tools.values().map(|tool| tool.descriptor.clone()).collect();
+        let mut mcp = McpAgentTools {
+            client: Client::new(),
+            endpoint: Url::parse("http://127.0.0.1:8080/mcp").unwrap(),
+            bearer_token: "selection-signing-secret".into(),
+            toolsets: "task".into(),
+            descriptors,
+            tools,
+        };
+        let request = turn_request();
+        let descriptor = mcp.descriptors()[0].clone();
+        let query_digest = format!("sha256:{}", "a".repeat(64));
+        let selection_ref = mcp
+            .issue_selection_ref(&request, &descriptor, &query_digest)
+            .unwrap();
+
+        assert_eq!(
+            mcp.verify_selection_ref(&request, &selection_ref).unwrap(),
+            descriptor
+        );
+
+        let mut another_actor = request.clone();
+        another_actor.actor_ref = "slack-user://another".into();
+        assert!(
+            mcp.verify_selection_ref(&another_actor, &selection_ref)
+                .is_err()
+        );
+
+        let forged = format!("{selection_ref}0");
+        assert!(mcp.verify_selection_ref(&request, &forged).is_err());
+
+        mcp.tools
+            .get_mut(&descriptor.tool_id)
+            .unwrap()
+            .descriptor
+            .summary
+            .push_str(" Contract drifted.");
+        assert!(mcp.verify_selection_ref(&request, &selection_ref).is_err());
     }
 
     #[test]

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -20,7 +20,9 @@ use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
 
 const MCP_URL_ENV: &str = "CEREBRO_SLACK_AGENT_MCP_URL";
 const MCP_TOKEN_ENV: &str = "CEREBRO_SLACK_AGENT_MCP_BEARER_TOKEN";
+const MCP_SELECTION_SIGNING_KEY_ENV: &str = "CEREBRO_SLACK_AGENT_CAPABILITY_SIGNING_KEY";
 const MCP_TOOLSETS_ENV: &str = "CEREBRO_SLACK_AGENT_MCP_TOOLSETS";
+const MCP_OBSERVE_TOOLS_ENV: &str = "CEREBRO_SLACK_AGENT_MCP_OBSERVE_TOOLS";
 const MCP_PROPOSE_TOOLS_ENV: &str = "CEREBRO_SLACK_AGENT_MCP_PROPOSE_TOOLS";
 const MCP_ACTUATE_TOOLS_ENV: &str = "CEREBRO_SLACK_AGENT_MCP_ACTUATE_TOOLS";
 const GRAPH_REASON_TOOL: &str = "cerebro.graph.reason";
@@ -36,6 +38,7 @@ pub struct McpAgentTools {
     client: Client,
     endpoint: Url,
     bearer_token: String,
+    selection_signing_key: String,
     toolsets: String,
     descriptors: Vec<ToolDescriptor>,
     tools: BTreeMap<String, BoundMcpTool>,
@@ -92,6 +95,10 @@ impl McpAgentTools {
         }
         let endpoint = validated_endpoint(raw_url.trim())?;
         let bearer_token = required_env(MCP_TOKEN_ENV)?;
+        let selection_signing_key = required_env(MCP_SELECTION_SIGNING_KEY_ENV)?;
+        if selection_signing_key.len() < 32 || selection_signing_key == bearer_token {
+            return Err("capability signing key must be distinct and at least 32 bytes".into());
+        }
         let toolsets = env::var(MCP_TOOLSETS_ENV)
             .unwrap_or_else(|_| "task".into())
             .trim()
@@ -99,10 +106,14 @@ impl McpAgentTools {
         if toolsets.is_empty() || toolsets.len() > 256 {
             return Err("MCP toolset selection is invalid".into());
         }
+        let observe_tools = configured_tool_names(MCP_OBSERVE_TOOLS_ENV)?;
         let propose_tools = configured_tool_names(MCP_PROPOSE_TOOLS_ENV)?;
         let actuate_tools = configured_tool_names(MCP_ACTUATE_TOOLS_ENV)?;
-        if !propose_tools.is_disjoint(&actuate_tools) {
-            return Err("an MCP tool cannot be both propose and actuate".into());
+        if !observe_tools.is_disjoint(&propose_tools)
+            || !observe_tools.is_disjoint(&actuate_tools)
+            || !propose_tools.is_disjoint(&actuate_tools)
+        {
+            return Err("an MCP tool must have exactly one host-owned authority class".into());
         }
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs(15))
@@ -116,19 +127,21 @@ impl McpAgentTools {
             .iter()
             .map(|tool| tool.name.as_str())
             .collect::<BTreeSet<_>>();
-        if propose_tools
+        if observe_tools
             .iter()
+            .chain(&propose_tools)
             .chain(&actuate_tools)
             .any(|name| !listed_names.contains(name.as_str()))
         {
             return Err("configured MCP authority policy names an unavailable tool".into());
         }
-        let tools = bind_tools(listed, &propose_tools, &actuate_tools)?;
+        let tools = bind_tools(listed, &observe_tools, &propose_tools, &actuate_tools)?;
         let descriptors = tools.values().map(|tool| tool.descriptor.clone()).collect();
         Ok(Some(Self {
             client,
             endpoint,
             bearer_token,
+            selection_signing_key,
             toolsets,
             descriptors,
             tools,
@@ -137,6 +150,10 @@ impl McpAgentTools {
 
     pub fn descriptors(&self) -> &[ToolDescriptor] {
         &self.descriptors
+    }
+
+    pub fn descriptor(&self, tool_id: &str) -> Option<&ToolDescriptor> {
+        self.tools.get(tool_id).map(|tool| &tool.descriptor)
     }
 
     pub fn issue_selection_ref(
@@ -148,9 +165,11 @@ impl McpAgentTools {
         if !self.tools.contains_key(&descriptor.tool_id) || !is_sha256_digest(query_digest) {
             return Err("capability selection target is invalid".into());
         }
-        let signature = self.selection_signature(request, descriptor, query_digest)?;
+        let actor_digest = hex_digest(&Sha256::digest(request.actor_ref.as_bytes()));
+        let signature =
+            self.selection_signature(request, descriptor, query_digest, &actor_digest)?;
         Ok(format!(
-            "{CAPABILITY_SELECTION_PREFIX}:{}:{}:{signature}",
+            "{CAPABILITY_SELECTION_PREFIX}:{}:{}:{actor_digest}:{signature}",
             descriptor.tool_id,
             query_digest.trim_start_matches("sha256:")
         ))
@@ -176,6 +195,12 @@ impl McpAgentTools {
             .ok_or_else(|| {
                 "capability selection reference has an invalid query digest".to_owned()
             })?;
+        let actor_digest = fields
+            .next()
+            .filter(|value| value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+            .ok_or_else(|| {
+                "capability selection reference has an invalid actor scope".to_owned()
+            })?;
         let signature = fields
             .next()
             .and_then(decode_hex)
@@ -184,12 +209,16 @@ impl McpAgentTools {
         if fields.next().is_some() {
             return Err("capability selection reference has unexpected fields".into());
         }
+        let request_actor_digest = hex_digest(&Sha256::digest(request.actor_ref.as_bytes()));
+        if request.actor_ref != "cerebro-scheduler" && request_actor_digest != actor_digest {
+            return Err("capability selection reference belongs to another actor".into());
+        }
         let descriptor = self
             .tools
             .get(tool_id)
             .map(|tool| tool.descriptor.clone())
             .ok_or_else(|| "capability selection target is no longer bound".to_owned())?;
-        let mac = self.selection_mac(request, &descriptor, &query_digest)?;
+        let mac = self.selection_mac(request, &descriptor, &query_digest, actor_digest)?;
         mac.verify_slice(&signature)
             .map_err(|_| "capability selection reference does not match this scope".to_owned())?;
         Ok(descriptor)
@@ -200,8 +229,9 @@ impl McpAgentTools {
         request: &AgentTurnRequest,
         descriptor: &ToolDescriptor,
         query_digest: &str,
+        actor_digest: &str,
     ) -> Result<String, String> {
-        let mac = self.selection_mac(request, descriptor, query_digest)?;
+        let mac = self.selection_mac(request, descriptor, query_digest, actor_digest)?;
         Ok(hex_digest(&mac.finalize().into_bytes()))
     }
 
@@ -210,13 +240,15 @@ impl McpAgentTools {
         request: &AgentTurnRequest,
         descriptor: &ToolDescriptor,
         query_digest: &str,
+        actor_digest: &str,
     ) -> Result<Hmac<Sha256>, String> {
-        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(self.bearer_token.as_bytes())
-            .map_err(|_| "capability selection signer could not initialize".to_owned())?;
+        let mut mac =
+            <Hmac<Sha256> as KeyInit>::new_from_slice(self.selection_signing_key.as_bytes())
+                .map_err(|_| "capability selection signer could not initialize".to_owned())?;
         for value in [
             CAPABILITY_SELECTION_PREFIX,
             request.tenant_id.as_str(),
-            request.actor_ref.as_str(),
+            actor_digest,
             request.thread_ref.as_str(),
             request.context_scope_ref.as_deref().unwrap_or(""),
             descriptor.tool_id.as_str(),
@@ -259,6 +291,9 @@ impl McpAgentTools {
             .await
         {
             Ok(response) => response,
+            Err(error) if tool.descriptor.authority_class == ToolAuthorityClass::Actuate => {
+                return Err(error);
+            }
             Err(_) => {
                 return Ok(ToolResult {
                     state: ToolResultState::Failed,
@@ -273,6 +308,12 @@ impl McpAgentTools {
             }
         };
         if let Some(error) = response.error {
+            if tool.descriptor.authority_class == ToolAuthorityClass::Actuate {
+                return Err(AgentRuntimeError::ModelUnavailable(format!(
+                    "MCP actuation {} returned an ambiguous error",
+                    tool.mcp_name
+                )));
+            }
             return Ok(ToolResult {
                 state: ToolResultState::Failed,
                 summary: format!("MCP tool {} failed.", tool.mcp_name),
@@ -300,6 +341,14 @@ impl McpAgentTools {
             .cloned()
             .unwrap_or_else(|| result.clone());
         let normalized = normalize_tool_result(&tool.mcp_name, data, is_error);
+        if tool.descriptor.authority_class == ToolAuthorityClass::Actuate
+            && normalized.state != ToolResultState::Succeeded
+        {
+            return Err(AgentRuntimeError::ModelUnavailable(format!(
+                "MCP actuation {} did not return a verified success result",
+                tool.mcp_name
+            )));
+        }
         let state = normalized.state;
         let data = normalized.data;
         let complete = state == ToolResultState::Succeeded;
@@ -516,6 +565,7 @@ fn truncate_utf8(value: &str, max_bytes: usize) -> String {
 
 fn bind_tools(
     listed: Vec<McpToolWire>,
+    observe_tools: &BTreeSet<String>,
     propose_tools: &BTreeSet<String>,
     actuate_tools: &BTreeSet<String>,
 ) -> Result<BTreeMap<String, BoundMcpTool>, String> {
@@ -544,7 +594,13 @@ fn bind_tools(
                 ));
             }
             (ToolAuthorityClass::Propose, ToolEffectClass::Read)
-        } else if read_only {
+        } else if observe_tools.contains(&tool.name) {
+            if !read_only {
+                return Err(format!(
+                    "write-capable MCP tool {} cannot be configured as observe",
+                    tool.name
+                ));
+            }
             (ToolAuthorityClass::Observe, ToolEffectClass::Read)
         } else {
             continue;
@@ -855,7 +911,7 @@ fn hex_digest(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{Json, Router, routing::post};
+    use axum::{Json, Router, http::StatusCode, routing::post};
     use cerebro_agent_runtime::{
         ConversationMessage, ConversationRole,
         session::{
@@ -1000,6 +1056,7 @@ mod tests {
     fn binds_read_tools_and_omits_unapproved_write_tools() {
         let tools = bind_tools(
             vec![tool("cerebro.read", true), tool("cerebro.write", false)],
+            &BTreeSet::from(["cerebro.read".into()]),
             &BTreeSet::new(),
             &BTreeSet::new(),
         )
@@ -1014,9 +1071,30 @@ mod tests {
     }
 
     #[test]
+    fn provider_read_only_annotations_cannot_grant_observe_authority() {
+        let tools = bind_tools(
+            vec![tool("cerebro.read", true)],
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert!(tools.is_empty());
+
+        let result = bind_tools(
+            vec![tool("cerebro.write", false)],
+            &BTreeSet::from(["cerebro.write".into()]),
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn explicit_policy_separates_proposals_from_exact_approval_effects() {
         let tools = bind_tools(
             vec![tool("cerebro.plan", true), tool("cerebro.apply", false)],
+            &BTreeSet::new(),
             &BTreeSet::from(["cerebro.plan".into()]),
             &BTreeSet::from(["cerebro.apply".into()]),
         )
@@ -1041,6 +1119,7 @@ mod tests {
         let result = bind_tools(
             vec![tool("cerebro.read", true)],
             &BTreeSet::new(),
+            &BTreeSet::new(),
             &BTreeSet::from(["cerebro.read".into()]),
         );
 
@@ -1053,6 +1132,7 @@ mod tests {
             vec![tool("cerebro:read", true)],
             &BTreeSet::new(),
             &BTreeSet::new(),
+            &BTreeSet::new(),
         );
 
         assert!(result.is_err());
@@ -1062,6 +1142,7 @@ mod tests {
     fn capability_selection_refs_are_scope_and_descriptor_bound() {
         let tools = bind_tools(
             vec![tool("slack.thread.read", true)],
+            &BTreeSet::from(["slack.thread.read".into()]),
             &BTreeSet::new(),
             &BTreeSet::new(),
         )
@@ -1071,6 +1152,7 @@ mod tests {
             client: Client::new(),
             endpoint: Url::parse("http://127.0.0.1:8080/mcp").unwrap(),
             bearer_token: "selection-signing-secret".into(),
+            selection_signing_key: "host-only-selection-signing-secret".into(),
             toolsets: "task".into(),
             descriptors,
             tools,
@@ -1092,6 +1174,21 @@ mod tests {
         assert!(
             mcp.verify_selection_ref(&another_actor, &selection_ref)
                 .is_err()
+        );
+
+        let mut later_turn_in_same_scope = request.clone();
+        later_turn_in_same_scope.request_id = "request://scheduled-wake".into();
+        assert!(
+            mcp.verify_selection_ref(&later_turn_in_same_scope, &selection_ref)
+                .is_ok()
+        );
+
+        let mut scheduled_wake = request.clone();
+        scheduled_wake.request_id = "request://scheduled-wake".into();
+        scheduled_wake.actor_ref = "cerebro-scheduler".into();
+        assert!(
+            mcp.verify_selection_ref(&scheduled_wake, &selection_ref)
+                .is_ok()
         );
 
         let forged = format!("{selection_ref}0");
@@ -1234,6 +1331,51 @@ mod tests {
         );
         assert!(accepted.data.get("cypher").is_none());
         assert!(accepted.data.get("rows").is_none());
+    }
+
+    #[tokio::test]
+    async fn actuation_transport_failures_remain_outcome_unknown_to_the_runtime() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route("/mcp", post(|| async { StatusCode::BAD_GATEWAY })),
+            )
+            .await
+            .unwrap();
+        });
+        let tools = bind_tools(
+            vec![tool("slack.message.send", false)],
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &BTreeSet::from(["slack.message.send".into()]),
+        )
+        .unwrap();
+        let descriptors = tools.values().map(|tool| tool.descriptor.clone()).collect();
+        let mcp = McpAgentTools {
+            client: Client::new(),
+            endpoint: Url::parse(&format!("http://{address}/mcp")).unwrap(),
+            bearer_token: "tenant-token".into(),
+            selection_signing_key: "host-only-selection-signing-secret".into(),
+            toolsets: "task".into(),
+            descriptors,
+            tools,
+        };
+        let call = ToolCall {
+            call_id: "send-one".into(),
+            tool_id: "mcp.slack.message.send".into(),
+            purpose: "Send the approved message.".into(),
+            input: json!({"channel_id": "channel-one", "text": "hello"}),
+        };
+
+        let result = mcp.invoke(&turn_request(), &call).await;
+        server.abort();
+
+        assert!(matches!(
+            result,
+            Err(AgentRuntimeError::ModelUnavailable(_))
+        ));
     }
 
     #[tokio::test]

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -102,12 +102,15 @@ deployment secret store, not checked-in configuration.
 | `CEREBRO_SLACK_AGENT_MODEL` | unset | Amazon Bedrock Claude Opus model identifier used for the complete session loop and independent claim review. Other model families fail startup. |
 | `CEREBRO_SLACK_AGENT_MCP_URL` | unset | Optional HTTPS or loopback MCP endpoint whose tool catalog is added to the Slack agent. When unset, built-in graph, source catalog, and source-runtime tools remain available. |
 | `CEREBRO_SLACK_AGENT_MCP_BEARER_TOKEN` | unset | Tenant-scoped bearer token for the MCP endpoint. Required when the MCP URL is set. Store as a secret. |
+| `CEREBRO_SLACK_AGENT_CAPABILITY_SIGNING_KEY` | unset | Host-only key used to sign scoped capability selections. Required when the MCP URL is set, at least 32 bytes, and must differ from the bearer token. Never expose it to the MCP provider. |
 | `CEREBRO_SLACK_AGENT_MCP_TOOLSETS` | `task` | MCP toolset selection sent as `X-Cerebro-MCP-Toolsets`. Use the bounded task surface by default; deployment owners may select additional domain toolsets. |
+| `CEREBRO_SLACK_AGENT_MCP_OBSERVE_TOOLS` | unset | Comma-separated read-only MCP tools admitted as observe capabilities. Provider annotations are consistency checks only; unlisted tools are omitted. |
 | `CEREBRO_SLACK_AGENT_MCP_PROPOSE_TOOLS` | unset | Comma-separated read-only MCP tools that return proposals. These tools may run in investigation lanes but cannot apply changes. |
 | `CEREBRO_SLACK_AGENT_MCP_ACTUATE_TOOLS` | unset | Comma-separated write-capable MCP tools admitted to the exact effect-approval path. Unlisted write tools are omitted. Every admitted call still requires request-, actor-, thread-, tool-, and input-digest-bound authorization plus independent verification. |
 
-Read-only MCP tools are admitted from server-declared `readOnlyHint=true`
-metadata. A write-capable tool is unavailable to the agent unless the
-deployment lists it in `CEREBRO_SLACK_AGENT_MCP_ACTUATE_TOOLS`. A read-only tool
-cannot be promoted to actuation, and a write-capable tool cannot be mislabeled
-as a proposal.
+Every MCP tool requires a host-owned authority assignment. Server-declared
+`readOnlyHint` metadata must agree with that assignment but cannot grant it. A
+write-capable tool is unavailable to the agent unless the deployment lists it
+in `CEREBRO_SLACK_AGENT_MCP_ACTUATE_TOOLS`. A read-only tool cannot be promoted
+to actuation, and a write-capable tool cannot be classified as observe or
+proposal.


### PR DESCRIPTION
## Summary

- add intent-based capability search and exact descriptor lookup without exposing the full remote read catalog to the model
- require host-owned observe, propose, and actuate authority assignments and a distinct host-only signing key for selected read and proposal tools
- keep external effects on their exact provider tool identity, exact-input approval, independent verification, and outcome-unknown reconciliation path
- keep catalog metadata out of evidence atoms and durable factual memory
- show a bounded credential-redacted canonical input preview before an operator approves an effect

## Validation

- cargo test -p cerebro-agent-runtime: 74 unit tests, 30 operator tests, and 1 doc test passed
- cargo test -p cerebro-platform: 170 passed, 4 PostgreSQL-gated tests ignored, and 6 Rust-only contract tests passed
- cargo clippy -p cerebro-agent-runtime --all-targets -- -D warnings
- cargo clippy -p cerebro-platform --all-targets -- -D warnings
- npm test --workspace apps/slack-companion-host: 103 passed
- hostile control-flow review found no remaining blocking or high-severity static issue after remediation