### PR TITLE
Accept positional family arguments in the cutover commands

### DIFF
--- a/crates/cerebro-platform/src/cutover_command.rs
+++ b/crates/cerebro-platform/src/cutover_command.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     error::Error,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -23,11 +24,60 @@ fn promotion_request(
     )?)
 }
 
+/// Resolve one family-scope identifier from a positional argument or, when no
+/// argument is supplied, an environment variable. A positional argument takes
+/// precedence so the cutover commands can be driven over a batch of families
+/// (for example the output of `list-catalog-families`); the environment
+/// variable remains the fallback so existing invocations stay valid.
+fn family_scope_identifier(
+    argument: Option<String>,
+    environment: Option<String>,
+    env_name: &str,
+    label: &str,
+) -> Result<String, Box<dyn Error>> {
+    if let Some(argument) = argument {
+        let trimmed = argument.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_owned());
+        }
+    }
+    match environment.map(|value| value.trim().to_owned()) {
+        Some(value) if !value.is_empty() => Ok(value),
+        _ => Err(format!(
+            "family {label} is required: pass it as a positional argument or set {env_name}"
+        )
+        .into()),
+    }
+}
+
+/// Read the `(tenant, source, family)` cutover scope from positional arguments
+/// after the subcommand, falling back to the existing environment variables.
+fn family_scope() -> Result<(String, String, String), Box<dyn Error>> {
+    let mut args = env::args().skip(2);
+    let tenant_id = family_scope_identifier(
+        args.next(),
+        env::var("CEREBRO_TENANT_ID").ok(),
+        "CEREBRO_TENANT_ID",
+        "tenant",
+    )?;
+    let source_id = family_scope_identifier(
+        args.next(),
+        env::var("CEREBRO_SOURCE_ID").ok(),
+        "CEREBRO_SOURCE_ID",
+        "source",
+    )?;
+    let family_id = family_scope_identifier(
+        args.next(),
+        env::var("CEREBRO_SOURCE_FAMILY").ok(),
+        "CEREBRO_SOURCE_FAMILY",
+        "family",
+    )?;
+    Ok((tenant_id, source_id, family_id))
+}
+
 async fn ledger_and_request() -> Result<(PostgresLedger, ProjectionPromotionRequest), Box<dyn Error>>
 {
-    let tenant_id = required_env("CEREBRO_TENANT_ID")?;
-    let source_id = required_env("CEREBRO_SOURCE_ID")?;
-    let family_id = required_env("CEREBRO_SOURCE_FAMILY")?;
+    let (tenant_id, source_id, family_id) = family_scope()?;
     let connection_string = required_env("CEREBRO_POSTGRES_DSN")?;
     let ledger = PostgresLedger::connect_tls(&connection_string).await?;
     ledger.migrate().await?;
@@ -60,9 +110,7 @@ pub(crate) async fn promote_family() -> Result<(), Box<dyn Error>> {
 }
 
 pub(crate) async fn show_authority() -> Result<(), Box<dyn Error>> {
-    let tenant_id = required_env("CEREBRO_TENANT_ID")?;
-    let source_id = required_env("CEREBRO_SOURCE_ID")?;
-    let family_id = required_env("CEREBRO_SOURCE_FAMILY")?;
+    let (tenant_id, source_id, family_id) = family_scope()?;
     let connection_string = required_env("CEREBRO_POSTGRES_DSN")?;
     let ledger = PostgresLedger::connect_tls(&connection_string).await?;
     ledger.migrate().await?;
@@ -91,5 +139,57 @@ mod tests {
         assert_eq!(request.source_id(), "box");
         assert_eq!(request.family_id(), "users");
         assert_eq!(request.projection_lag(), 0);
+    }
+
+    #[test]
+    fn family_scope_identifier_prefers_argument_then_environment() {
+        // A positional argument wins over an environment variable.
+        assert_eq!(
+            family_scope_identifier(
+                Some("tenant-a".to_owned()),
+                Some("env-tenant".to_owned()),
+                "CEREBRO_TENANT_ID",
+                "tenant",
+            )
+            .unwrap(),
+            "tenant-a",
+        );
+        // Without an argument, the environment variable is used.
+        assert_eq!(
+            family_scope_identifier(
+                None,
+                Some("env-tenant".to_owned()),
+                "CEREBRO_TENANT_ID",
+                "tenant",
+            )
+            .unwrap(),
+            "env-tenant",
+        );
+        // A blank argument falls through to the environment variable.
+        assert_eq!(
+            family_scope_identifier(
+                Some("   ".to_owned()),
+                Some("env-tenant".to_owned()),
+                "CEREBRO_TENANT_ID",
+                "tenant",
+            )
+            .unwrap(),
+            "env-tenant",
+        );
+        // Surrounding whitespace is trimmed from either source.
+        assert_eq!(
+            family_scope_identifier(
+                Some("  tenant-a  ".to_owned()),
+                None,
+                "CEREBRO_TENANT_ID",
+                "tenant",
+            )
+            .unwrap(),
+            "tenant-a",
+        );
+        // Neither source present fails closed and names the missing variable.
+        let missing =
+            family_scope_identifier(None, None, "CEREBRO_TENANT_ID", "tenant").unwrap_err();
+        assert!(missing.to_string().contains("CEREBRO_TENANT_ID"));
     }
 }


### PR DESCRIPTION
## Summary

`evaluate-family`, `promote-family`, and `show-authority` now accept the `(tenant, source, family)` scope as positional arguments after the subcommand, falling back to the existing `CEREBRO_TENANT_ID`, `CEREBRO_SOURCE_ID`, and `CEREBRO_SOURCE_FAMILY` environment variables when no argument is supplied. `CEREBRO_POSTGRES_DSN` remains environment-only.

## Rationale

A positional argument takes precedence so the commands can be driven over a batch of families emitted by `list-catalog-families`, while existing env-only invocations stay valid. Identifiers are trimmed and validated; a missing scope fails closed and names the missing variable.

## Tests

`cargo test -p cerebro-platform` (`family_scope_identifier_prefers_argument_then_environment`).
