### PR TITLE
docs: explain core fact and evidence lifecycles

### DIFF
--- a/internal/evidenceledger/doc.go
+++ b/internal/evidenceledger/doc.go
@@ -1,0 +1,17 @@
+// Package evidenceledger records immutable evidence versions and the scoped
+// claims made about them.
+//
+// Artifact metadata names the logical evidence object. EvidenceVersion records
+// immutable content, provenance, governance, subjects, and validity. An
+// EvidenceClaim then states how one version supports one objective,
+// implementation revision, and requirement for a bounded period and subject
+// set. Review and invalidation update the claim aggregate; they never rewrite
+// the underlying evidence version.
+//
+// Writes are append-first. The service appends a versioned workflow event and
+// only then projects it into the ledger store. Callers must therefore treat an
+// append failure as no accepted write and a projection failure as an accepted
+// event that still needs replay or operational recovery. Validation is
+// fail-closed across review state, quarantine, revocation, expiry, period,
+// subject coverage, and conflicting claims.
+package evidenceledger

--- a/internal/evidenceledger/legacy_finding_adapter.go
+++ b/internal/evidenceledger/legacy_finding_adapter.go
@@ -20,6 +20,8 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
+// ErrInvalidLegacyEvidenceBinding means a legacy record or its caller-supplied
+// canonical scope is insufficient to create ledger records without guessing.
 var ErrInvalidLegacyEvidenceBinding = errors.New("invalid legacy finding evidence binding")
 
 // LegacyFindingEvidenceBinding supplies the canonical scope that the legacy
@@ -50,10 +52,17 @@ type LegacyFindingEvidenceProjection struct {
 	Claim   CreateClaimRequest
 }
 
+// AdaptLegacyFindingEvidence deterministically converts a legacy protobuf into
+// an immutable version plus a pending-review claim. The binding must supply all
+// canonical scope, proof, governance, and actor fields absent from the legacy
+// record. Repeating the conversion with semantically identical input yields the
+// same artifact, version, and claim identifiers.
 func AdaptLegacyFindingEvidence(source *cerebrov1.FindingEvidence, binding LegacyFindingEvidenceBinding) (LegacyFindingEvidenceProjection, error) {
 	if err := validateLegacyBinding(source, binding); err != nil {
 		return LegacyFindingEvidenceProjection{}, err
 	}
+	// Normalize unordered repeated data before deterministic protobuf encoding;
+	// otherwise equivalent legacy records could mint different version IDs.
 	normalized := normalizeLegacyFindingEvidence(source)
 	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(normalized)
 	if err != nil {

--- a/internal/evidenceledger/service.go
+++ b/internal/evidenceledger/service.go
@@ -18,24 +18,36 @@ import (
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
+// ErrInvalidEvidence identifies malformed requests and unavailable ledger
+// capabilities. Store conflicts and access denials use the typed port errors.
 var ErrInvalidEvidence = errors.New("invalid evidence ledger request")
 
+// Service coordinates append-only evidence events with their query projection.
 type Service struct {
 	store ports.EvidenceLedgerStore
 	log   ports.AppendLog
 	now   func() time.Time
 }
 
+// New constructs an evidence ledger. Writes require both store and log; read
+// methods require the store. The service owns its UTC clock for deterministic
+// tests and consistent millisecond timestamps.
 func New(store ports.EvidenceLedgerStore, log ports.AppendLog) *Service {
 	return &Service{store: store, log: log, now: func() time.Time { return time.Now().UTC() }}
 }
 
+// RegisterVersionRequest supplies the logical artifact, one immutable version,
+// and the actor responsible for registering it.
 type RegisterVersionRequest struct {
 	Artifact ports.EvidenceArtifact
 	Version  ports.EvidenceVersion
 	ActorID  string
 }
 
+// RegisterVersion normalizes and validates an immutable evidence version,
+// appends its aggregate event, and projects that event into the ledger store.
+// A missing source-proof revision does not discard the record: it quarantines
+// the version in validation_failed so provenance gaps remain observable.
 func (s *Service) RegisterVersion(ctx context.Context, request RegisterVersionRequest) (ports.EvidenceVersion, error) {
 	if s == nil || s.store == nil || s.log == nil {
 		return ports.EvidenceVersion{}, fmt.Errorf("%w: ledger capability unavailable", ErrInvalidEvidence)
@@ -73,6 +85,8 @@ func (s *Service) RegisterVersion(ctx context.Context, request RegisterVersionRe
 	}
 	version = normalizeVersion(version)
 	artifact = normalizeArtifact(artifact)
+	// Provenance failure is recorded as ledger state instead of rejected before
+	// append. This preserves the submitted evidence and makes repair auditable.
 	if strings.TrimSpace(version.Provenance.SourceProofRevisionID) == "" {
 		version.State = ports.EvidenceStateValidationFailed
 		version.QuarantineReason = "source_proof_unverified"
@@ -114,6 +128,8 @@ func (s *Service) RegisterVersion(ctx context.Context, request RegisterVersionRe
 	if err != nil {
 		return ports.EvidenceVersion{}, err
 	}
+	// The append log is authoritative. Projection happens second and must be
+	// replayable from this event if the materialized store is unavailable.
 	if err := s.log.Append(ctx, event); err != nil {
 		return ports.EvidenceVersion{}, fmt.Errorf("append evidence version: %w", err)
 	}
@@ -123,11 +139,16 @@ func (s *Service) RegisterVersion(ctx context.Context, request RegisterVersionRe
 	return version, nil
 }
 
+// CreateClaimRequest supplies a scoped assertion over an existing evidence
+// version and the actor creating it.
 type CreateClaimRequest struct {
 	Claim   ports.EvidenceClaim
 	ActorID string
 }
 
+// CreateClaim records a new pending-review claim over an existing immutable
+// evidence version. Approval fields supplied by a caller are intentionally
+// discarded; only ReviewClaim may produce an approved or rejected decision.
 func (s *Service) CreateClaim(ctx context.Context, request CreateClaimRequest) (ports.EvidenceClaim, error) {
 	if s == nil || s.store == nil || s.log == nil {
 		return ports.EvidenceClaim{}, fmt.Errorf("%w: ledger capability unavailable", ErrInvalidEvidence)
@@ -165,6 +186,9 @@ func (s *Service) CreateClaim(ctx context.Context, request CreateClaimRequest) (
 	return s.appendClaim(ctx, workflowevents.EventKindComplianceEvidenceClaimRecorded, "claim_recorded", claim, 0, actorID)
 }
 
+// ReviewClaim approves or rejects a claim using optimistic concurrency.
+// expectedVersion must equal the current aggregate version, and every decision
+// requires both an identified reviewer and a non-empty reason.
 func (s *Service) ReviewClaim(ctx context.Context, tenantID, claimID, reviewerID, state, reason string, expectedVersion uint64) (ports.EvidenceClaim, error) {
 	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(claimID))
 	if err != nil {
@@ -188,6 +212,9 @@ func (s *Service) ReviewClaim(ctx context.Context, tenantID, claimID, reviewerID
 	return s.appendClaim(ctx, workflowevents.EventKindComplianceEvidenceClaimReviewed, "claim_reviewed", claim, expectedVersion, reviewerID)
 }
 
+// InvalidateClaim makes a reviewed or pending claim unusable without deleting
+// its history. expectedVersion prevents a stale actor from overwriting a newer
+// review or invalidation decision.
 func (s *Service) InvalidateClaim(ctx context.Context, tenantID, claimID, actorID, reason string, expectedVersion uint64) (ports.EvidenceClaim, error) {
 	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(claimID))
 	if err != nil {

--- a/internal/evidenceledger/validation.go
+++ b/internal/evidenceledger/validation.go
@@ -23,6 +23,8 @@ const (
 	reasonSubjectMismatch    = "evidence_subject_mismatch"
 )
 
+// ValidateClaimRequest describes the subject set, period, and evaluation time
+// for which a caller wants to rely on an evidence claim.
 type ValidateClaimRequest struct {
 	TenantID    string
 	ClaimID     string
@@ -32,6 +34,8 @@ type ValidateClaimRequest struct {
 	At          time.Time
 }
 
+// CompatibilityRequest asks whether one claim may satisfy a target proof
+// obligation as well as the source obligation for which it was collected.
 type CompatibilityRequest struct {
 	TenantID string
 	ClaimID  string
@@ -40,6 +44,8 @@ type CompatibilityRequest struct {
 	At       time.Time
 }
 
+// CompatibilityDecision combines structural proof reuse with current ledger
+// validity. Reusable is true only when neither side fails closed.
 type CompatibilityDecision struct {
 	Reusable        bool                          `json:"reusable"`
 	Reuse           compliance.ReuseDecision      `json:"reuse"`
@@ -47,6 +53,7 @@ type CompatibilityDecision struct {
 	ReasonCodes     []string                      `json:"reason_codes"`
 }
 
+// ReadClaim returns the current projection of a claim aggregate.
 func (s *Service) ReadClaim(ctx context.Context, tenantID, claimID string) (ports.EvidenceClaim, error) {
 	if s == nil || s.store == nil {
 		return ports.EvidenceClaim{}, ErrInvalidEvidence
@@ -54,6 +61,7 @@ func (s *Service) ReadClaim(ctx context.Context, tenantID, claimID string) (port
 	return s.store.GetEvidenceClaim(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(claimID))
 }
 
+// ReadArtifact returns the logical artifact metadata, not a version's content.
 func (s *Service) ReadArtifact(ctx context.Context, tenantID, artifactID string) (ports.EvidenceArtifact, error) {
 	if s == nil || s.store == nil {
 		return ports.EvidenceArtifact{}, ErrInvalidEvidence
@@ -61,6 +69,9 @@ func (s *Service) ReadArtifact(ctx context.Context, tenantID, artifactID string)
 	return s.store.GetEvidenceArtifact(ctx, strings.TrimSpace(tenantID), strings.TrimSpace(artifactID))
 }
 
+// EvaluateCompatibility checks proof-obligation reuse and then validates the
+// claim for the target period. ReasonCodes include both ledger validity failures
+// and individual failed reuse predicates.
 func (s *Service) EvaluateCompatibility(ctx context.Context, request CompatibilityRequest) (CompatibilityDecision, error) {
 	tenantID := strings.TrimSpace(request.TenantID)
 	claim, err := s.ReadClaim(ctx, tenantID, request.ClaimID)
@@ -94,6 +105,9 @@ func (s *Service) EvaluateCompatibility(ctx context.Context, request Compatibili
 	}, nil
 }
 
+// ValidateClaim evaluates whether a claim is safe to rely on now. Validation is
+// cumulative: every failed predicate contributes a reason and next action so a
+// caller can repair all known gaps in one pass.
 func (s *Service) ValidateClaim(ctx context.Context, request ValidateClaimRequest) (ports.EvidenceClaimValidation, error) {
 	claim, err := s.store.GetEvidenceClaim(ctx, strings.TrimSpace(request.TenantID), strings.TrimSpace(request.ClaimID))
 	if err != nil {
@@ -104,6 +118,8 @@ func (s *Service) ValidateClaim(ctx context.Context, request ValidateClaimReques
 		return ports.EvidenceClaimValidation{}, err
 	}
 	result := ports.EvidenceClaimValidation{Valid: true, ReasonCodes: []string{reasonApproved}, NextActions: []string{"none"}}
+	// The first failure removes the optimistic approved/none pair. Later
+	// failures accumulate and are normalized before returning.
 	addInvalid := func(reason, action string) {
 		if result.Valid {
 			result.ReasonCodes = nil
@@ -149,6 +165,8 @@ func (s *Service) ValidateClaim(ctx context.Context, request ValidateClaimReques
 	if !subjectsCover(claim.Scope.Subjects, normalizeSubjects(request.Subjects)) || !subjectsCover(version.Subjects, normalizeSubjects(request.Subjects)) {
 		addInvalid(reasonSubjectMismatch, "collect_evidence")
 	}
+	// Conflicts are evaluated last because they depend on sibling claims over the
+	// same immutable version, not only the selected claim and version.
 	claims, err := s.store.ListEvidenceClaimsByVersion(ctx, claim.TenantID, claim.ArtifactVersionID)
 	if err != nil {
 		return ports.EvidenceClaimValidation{}, err
@@ -192,6 +210,9 @@ func sameEvidenceClaimScope(left, right ports.EvidenceClaimScope) bool {
 	return true
 }
 
+// ReadVersion enforces actor, purpose, and maximum-sensitivity checks before
+// returning immutable content metadata. Unknown purposes and sensitivity labels
+// fail closed with ErrEvidenceAccessDenied.
 func (s *Service) ReadVersion(ctx context.Context, access ports.EvidenceAccessRequest, versionID string) (ports.EvidenceVersion, error) {
 	version, err := s.store.GetEvidenceVersion(ctx, strings.TrimSpace(access.TenantID), strings.TrimSpace(versionID))
 	if err != nil {

--- a/internal/graphactions/access_approvals_provider.go
+++ b/internal/graphactions/access_approvals_provider.go
@@ -6,10 +6,14 @@ import (
 	"strings"
 )
 
+// AccessApprovalsProvider adapts the access-approvals user lifecycle API to the
+// provider-neutral graph-action interface.
 type AccessApprovalsProvider struct {
 	Client AccessApprovalsClient
 }
 
+// ExecuteGraphAction dispatches a registered suspend or unsuspend operation and
+// maps the resulting access-approvals receipt into GraphAction.
 func (p AccessApprovalsProvider) ExecuteGraphAction(ctx context.Context, spec ActionSpec, request ProviderActionRequest) (*GraphAction, error) {
 	if p.Client == nil {
 		return nil, ErrNotConfigured
@@ -47,6 +51,7 @@ func (p AccessApprovalsProvider) ExecuteGraphAction(ctx context.Context, spec Ac
 	return GraphActionFromAccessApprovals(spec.ID, externalAction, p.Client.ActionURL(externalAction.ID), request.Target), nil
 }
 
+// GetGraphAction retrieves and normalizes the current access-approvals receipt.
 func (p AccessApprovalsProvider) GetGraphAction(ctx context.Context, externalID string) (*GraphAction, error) {
 	if p.Client == nil {
 		return nil, ErrNotConfigured

--- a/internal/graphactions/cerebro_device_provider.go
+++ b/internal/graphactions/cerebro_device_provider.go
@@ -12,16 +12,21 @@ import (
 
 const cerebroDeviceRevokeExternalPrefix = "cerebro-device:revoke:"
 
+// CerebroDeviceService is the narrow device-auth capability required to revoke
+// a device and retrieve its current state.
 type CerebroDeviceService interface {
 	LookupDevice(context.Context, string) (deviceauth.DeviceRecord, error)
 	Revoke(context.Context, string, string) error
 }
 
+// CerebroDeviceProvider adapts Cerebro device revocation to graph actions.
 type CerebroDeviceProvider struct {
 	Service CerebroDeviceService
 	Now     func() time.Time
 }
 
+// ExecuteGraphAction revokes the finding-authorized device and returns a
+// provider-neutral receipt. Other device mutations are rejected by the spec.
 func (p CerebroDeviceProvider) ExecuteGraphAction(ctx context.Context, spec ActionSpec, request ProviderActionRequest) (*GraphAction, error) {
 	if p.Service == nil {
 		return nil, ErrNotConfigured
@@ -48,6 +53,8 @@ func (p CerebroDeviceProvider) ExecuteGraphAction(ctx context.Context, spec Acti
 	return GraphActionFromCerebroDevice(spec.ID, device, request, ActionStatusSucceeded, "revoked", ""), nil
 }
 
+// GetGraphAction reconstructs the current receipt from the device record named
+// by externalID.
 func (p CerebroDeviceProvider) GetGraphAction(ctx context.Context, externalID string) (*GraphAction, error) {
 	if p.Service == nil {
 		return nil, ErrNotConfigured
@@ -97,10 +104,14 @@ func (p CerebroDeviceProvider) now() time.Time {
 	return time.Now().UTC()
 }
 
+// CerebroDeviceExternalID creates the provider receipt identifier used for
+// reconciliation without introducing a separate remote action record.
 func CerebroDeviceExternalID(deviceID string) string {
 	return cerebroDeviceRevokeExternalPrefix + strings.TrimSpace(deviceID)
 }
 
+// CerebroDeviceTargetFromExternalID extracts a validated device ID from a
+// Cerebro device receipt identifier.
 func CerebroDeviceTargetFromExternalID(externalID string) (string, bool) {
 	externalID = strings.TrimSpace(externalID)
 	if !strings.HasPrefix(externalID, cerebroDeviceRevokeExternalPrefix) {
@@ -113,6 +124,8 @@ func CerebroDeviceTargetFromExternalID(externalID string) (string, bool) {
 	return target, true
 }
 
+// GraphActionFromCerebroDevice maps a device record and operation outcome into
+// the provider-neutral receipt contract.
 func GraphActionFromCerebroDevice(action string, device deviceauth.DeviceRecord, request ProviderActionRequest, status string, externalStatus string, statusReason string) *GraphAction {
 	target := strings.TrimSpace(device.DeviceID)
 	updatedAt := time.Now().UTC()

--- a/internal/graphactions/contract.go
+++ b/internal/graphactions/contract.go
@@ -12,6 +12,8 @@ const (
 	ActionStatusNeedsAttention = "needs_attention"
 )
 
+// ActionMetadata is the serializable, behavior-free description of an action.
+// DefinitionDigest binds callers to the exact generated catalog definition.
 type ActionMetadata struct {
 	ID               string `json:"id"`
 	Provider         string `json:"provider"`
@@ -23,6 +25,7 @@ type ActionMetadata struct {
 	DefinitionDigest string `json:"definition_digest"`
 }
 
+// Metadata returns the normalized public metadata for an action specification.
 func (s ActionSpec) Metadata() ActionMetadata {
 	return ActionMetadata{
 		ID:               strings.TrimSpace(s.ID),
@@ -36,10 +39,14 @@ func (s ActionSpec) Metadata() ActionMetadata {
 	}
 }
 
+// NormalizeActionStatus converts provider status text to Cerebro's comparison
+// form without deciding whether the result is supported.
 func NormalizeActionStatus(status string) string {
 	return strings.ToLower(strings.TrimSpace(status))
 }
 
+// KnownActionStatuses returns a new slice containing every asynchronous status
+// accepted from providers. Dry-run is local planning state and is not included.
 func KnownActionStatuses() []string {
 	return []string{
 		ActionStatusPending,
@@ -52,6 +59,7 @@ func KnownActionStatuses() []string {
 	}
 }
 
+// ActionStatusKnown reports whether status is in the provider lifecycle.
 func ActionStatusKnown(status string) bool {
 	switch NormalizeActionStatus(status) {
 	case ActionStatusPending,
@@ -67,6 +75,9 @@ func ActionStatusKnown(status string) bool {
 	}
 }
 
+// ActionStatusTerminal reports whether provider polling can stop. The
+// needs_attention state is terminal for automation even though a human may
+// perform follow-up work.
 func ActionStatusTerminal(status string) bool {
 	switch NormalizeActionStatus(status) {
 	case ActionStatusSucceeded, ActionStatusFailed, ActionStatusCancelled, ActionStatusNeedsAttention:

--- a/internal/graphactions/doc.go
+++ b/internal/graphactions/doc.go
@@ -1,0 +1,16 @@
+// Package graphactions turns an authorized finding into a bounded provider
+// action and links the provider receipt back to that finding.
+//
+// The registry is the policy boundary. Each ActionSpec fixes the provider,
+// provider operation, target kind, eligibility check, target resolver, and
+// optional reversal. A caller-supplied target is only a selector: the resolver
+// must prove that the normalized target is present in the finding's verified
+// identifiers before execution can proceed.
+//
+// Execute always plans before it mutates. Dry runs return the exact normalized
+// target and provider request metadata without calling a provider. Live runs
+// require explicit approval, normalize the provider response, and persist an
+// external reference on the finding. Reconcile only follows an external ID
+// already linked to that finding, preventing arbitrary provider records from
+// being attached after the fact.
+package graphactions

--- a/internal/graphactions/registry.go
+++ b/internal/graphactions/registry.go
@@ -7,9 +7,15 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+// TargetResolver derives an authorized provider target from a finding and an
+// optional caller selector. Implementations must reject selectors not evidenced
+// by the finding.
 type TargetResolver func(*ports.FindingRecord, string) (string, error)
+
+// EligibilityChecker enforces action-specific finding preconditions.
 type EligibilityChecker func(string, *ports.FindingRecord) error
 
+// ActionSpec is the executable policy for one registered graph action.
 type ActionSpec struct {
 	ID               string
 	DefinitionDigest string
@@ -23,10 +29,13 @@ type ActionSpec struct {
 	CheckEligibility EligibilityChecker
 }
 
+// Registry indexes immutable action specifications by canonical action ID.
 type Registry struct {
 	actions map[string]ActionSpec
 }
 
+// Lookup returns the immutable specification for action after normalizing its
+// identifier. Unknown actions fail closed with ErrInvalidRequest.
 func (r Registry) Lookup(action string) (ActionSpec, error) {
 	action = strings.TrimSpace(action)
 	if len(r.actions) == 0 {
@@ -39,6 +48,7 @@ func (r Registry) Lookup(action string) (ActionSpec, error) {
 	return spec, nil
 }
 
+// TargetForAction resolves and authorizes a target using the default catalog.
 func TargetForAction(action string, finding *ports.FindingRecord, explicit string) (string, error) {
 	spec, err := DefaultRegistry().Lookup(action)
 	if err != nil {
@@ -47,6 +57,9 @@ func TargetForAction(action string, finding *ports.FindingRecord, explicit strin
 	return TargetForActionSpec(spec, finding, explicit)
 }
 
+// TargetForActionSpec resolves and authorizes a target using spec. A missing
+// resolver is an invalid action contract, not permission to accept the caller's
+// target directly.
 func TargetForActionSpec(spec ActionSpec, finding *ports.FindingRecord, explicit string) (string, error) {
 	if spec.ResolveTarget == nil {
 		return "", fmt.Errorf("%w: action %q has no target resolver", ErrInvalidRequest, spec.ID)
@@ -54,6 +67,8 @@ func TargetForActionSpec(spec ActionSpec, finding *ports.FindingRecord, explicit
 	return spec.ResolveTarget(finding, explicit)
 }
 
+// ValidateActionForFinding returns the default spec only when the finding
+// satisfies its eligibility policy.
 func ValidateActionForFinding(action string, finding *ports.FindingRecord) (ActionSpec, error) {
 	spec, err := DefaultRegistry().Lookup(action)
 	if err != nil {
@@ -68,6 +83,8 @@ func ValidateActionForFinding(action string, finding *ports.FindingRecord) (Acti
 	return spec, nil
 }
 
+// FindingAllowsAction checks whether finding advertises action and whether the
+// action's generated eligibility policy accepts its current attributes.
 func FindingAllowsAction(action string, finding *ports.FindingRecord) error {
 	action = strings.TrimSpace(action)
 	if action == "" {

--- a/internal/graphactions/remediation_plan.go
+++ b/internal/graphactions/remediation_plan.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// ReversibleRemediationPlan is a non-executable review packet for a mutating
+// action and its registered reversal. CanExecute remains false because planning
+// never confers approval.
 type ReversibleRemediationPlan struct {
 	Action            ActionMetadata `json:"action"`
 	Reversal          ActionMetadata `json:"reversal"`
@@ -18,6 +21,8 @@ type ReversibleRemediationPlan struct {
 	VerificationSteps []string       `json:"verification_steps,omitempty"`
 }
 
+// PlanReversibleRemediation performs the same eligibility and target resolution
+// as Execute but forces dry-run mode and requires a registered reversal.
 func (s Service) PlanReversibleRemediation(ctx context.Context, input Input) (*ReversibleRemediationPlan, error) {
 	input.DryRun = true
 	input.Approved = false

--- a/internal/graphactions/service.go
+++ b/internal/graphactions/service.go
@@ -35,11 +35,17 @@ const (
 )
 
 var (
-	ErrNotConfigured  = errors.New("graph action executor is not configured")
+	// ErrNotConfigured means an execution dependency or provider is unavailable.
+	ErrNotConfigured = errors.New("graph action executor is not configured")
+	// ErrInvalidRequest means the request failed local authorization or shape validation.
 	ErrInvalidRequest = errors.New("invalid graph action request")
-	ErrRemote         = errors.New("graph action remote error")
+	// ErrRemote means a provider response violated the registered action contract.
+	ErrRemote = errors.New("graph action remote error")
 )
 
+// AccessApprovalsUserActionRequest is the legacy access-approvals provider
+// request. Finding and URN fields preserve the authorization evidence used to
+// choose the target.
 type AccessApprovalsUserActionRequest struct {
 	EmailOrUserID  string `json:"email_or_user_id"`
 	Reason         string `json:"reason,omitempty"`
@@ -53,6 +59,8 @@ type AccessApprovalsUserActionRequest struct {
 	SubjectURN     string `json:"subject_urn,omitempty"`
 }
 
+// AccessApprovalsUserAction is the provider receipt for a user suspension state
+// change. ID is the provider-owned identifier used for later reconciliation.
 type AccessApprovalsUserAction struct {
 	ID              string `json:"id"`
 	Action          string `json:"action"`
@@ -77,6 +85,9 @@ type AccessApprovalsUserAction struct {
 	LastError       string `json:"last_error,omitempty"`
 }
 
+// GraphAction is Cerebro's provider-neutral execution receipt. External fields
+// preserve provider identity and status while Metadata carries bounded context
+// needed for reconciliation and finding linkage.
 type GraphAction struct {
 	ID                   string            `json:"id"`
 	Action               string            `json:"action"`
@@ -100,6 +111,8 @@ type GraphAction struct {
 	Metadata             map[string]string `json:"metadata,omitempty"`
 }
 
+// AccessApprovalsClient is the legacy provider client adapted by
+// AccessApprovalsProvider.
 type AccessApprovalsClient interface {
 	SuspendOktaUser(context.Context, AccessApprovalsUserActionRequest) (*AccessApprovalsUserAction, error)
 	UnsuspendOktaUser(context.Context, AccessApprovalsUserActionRequest) (*AccessApprovalsUserAction, error)
@@ -107,6 +120,8 @@ type AccessApprovalsClient interface {
 	ActionURL(string) string
 }
 
+// ProviderActionRequest is the normalized, authorized request passed to an
+// ActionProvider. Target has already been proven against the finding.
 type ProviderActionRequest struct {
 	Target         string
 	Reason         string
@@ -120,16 +135,21 @@ type ProviderActionRequest struct {
 	SubjectURN     string
 }
 
+// ActionProvider executes registered action specifications and reads their
+// asynchronous provider receipts.
 type ActionProvider interface {
 	ExecuteGraphAction(context.Context, ActionSpec, ProviderActionRequest) (*GraphAction, error)
 	GetGraphAction(context.Context, string) (*GraphAction, error)
 }
 
+// FindingWorkflow supplies the finding authority used to plan an action and to
+// attach the resulting external receipt.
 type FindingWorkflow interface {
 	GetFinding(context.Context, string) (*ports.FindingRecord, error)
 	LinkFindingExternalRef(context.Context, string, ports.FindingExternalRef) (*ports.FindingRecord, error)
 }
 
+// Service plans, executes, and reconciles graph actions.
 type Service struct {
 	Findings   FindingWorkflow
 	Client     AccessApprovalsClient
@@ -138,6 +158,8 @@ type Service struct {
 	BeforeLink func(context.Context, *ports.FindingRecord, *GraphAction, string) error
 }
 
+// Input requests an action for one finding. Approved gates only live mutation;
+// DryRun always takes precedence and never calls the provider.
 type Input struct {
 	FindingID      string
 	Action         string
@@ -151,11 +173,14 @@ type Input struct {
 	Approved       bool
 }
 
+// ReconcileInput identifies a finding and one provider action already linked to it.
 type ReconcileInput struct {
 	FindingID  string
 	ExternalID string
 }
 
+// Result returns the normalized provider action and the finding projection
+// after linkage. ExternalRef is empty for dry runs.
 type Result struct {
 	Finding     *ports.FindingRecord
 	Action      *GraphAction
@@ -171,6 +196,8 @@ type executionPlan struct {
 	Target  string
 }
 
+// Execute plans an authorized action, optionally returns a dry run, or performs
+// the approved provider mutation and links its receipt to the finding.
 func (s Service) Execute(ctx context.Context, input Input) (*Result, error) {
 	findingID := strings.TrimSpace(input.FindingID)
 	if findingID == "" {
@@ -191,6 +218,8 @@ func (s Service) Execute(ctx context.Context, input Input) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Dry-run exits with the fully resolved target and request metadata before
+	// the approval gate or any provider call.
 	if input.DryRun {
 		return &Result{
 			Finding: plan.Finding,
@@ -215,6 +244,9 @@ func (s Service) Execute(ctx context.Context, input Input) (*Result, error) {
 	if strings.TrimSpace(graphAction.ExternalID) == "" {
 		return nil, fmt.Errorf("%w: response missing action external_id", ErrRemote)
 	}
+	// A successful remote mutation is not considered linked until the finding
+	// projection records the provider receipt. BeforeLink supports an owning
+	// runtime's durable handoff immediately before that projection.
 	var ref ports.FindingExternalRef
 	updated := plan.Finding
 	if plan.Finding != nil {
@@ -282,6 +314,9 @@ func (s Service) plan(ctx context.Context, input Input, spec ActionSpec, finding
 	}, nil
 }
 
+// Reconcile refreshes one provider receipt already linked to a finding. It
+// rechecks provider ownership, tenant binding, action eligibility, and target
+// authorization before updating the link.
 func (s Service) Reconcile(ctx context.Context, input ReconcileInput) (*Result, error) {
 	if s.Findings == nil {
 		return nil, ErrNotConfigured
@@ -531,6 +566,9 @@ func graphActionIDFromAccessApprovals(action string) (string, error) {
 	}
 }
 
+// OktaUserTargetForFinding derives an Okta user ID or email from verified
+// finding fields. An explicit selector is accepted only when the same normalized
+// identity is present in the finding.
 func OktaUserTargetForFinding(finding *ports.FindingRecord, explicit string) (string, error) {
 	explicit = strings.TrimSpace(explicit)
 	if explicit != "" {
@@ -552,6 +590,8 @@ func OktaUserTargetForFinding(finding *ports.FindingRecord, explicit string) (st
 	return "", fmt.Errorf("%w: email_or_user_id is required or no Okta user target could be derived from finding", ErrInvalidRequest)
 }
 
+// CerebroDeviceTargetForFinding derives a device ID from verified finding
+// fields. An explicit selector cannot introduce a device absent from the finding.
 func CerebroDeviceTargetForFinding(finding *ports.FindingRecord, explicit string) (string, error) {
 	explicit = strings.TrimSpace(explicit)
 	if explicit != "" {
@@ -573,6 +613,8 @@ func CerebroDeviceTargetForFinding(finding *ports.FindingRecord, explicit string
 	return "", fmt.Errorf("%w: device_id is required or no Cerebro device target could be derived from finding", ErrInvalidRequest)
 }
 
+// NormalizeDeviceTarget validates an opaque device identifier without changing
+// its case. Delimiters and whitespace that could alter routing are rejected.
 func NormalizeDeviceTarget(target string) (string, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
@@ -778,6 +820,8 @@ func stringFromNestedMap(values map[string]any, parent string, key string) strin
 	return stringFromMap(value, key)
 }
 
+// NormalizeTarget validates a user target as either a provider user ID or an
+// email address. Parsed email display names are discarded.
 func NormalizeTarget(target string) (string, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
@@ -798,6 +842,8 @@ func NormalizeTarget(target string) (string, error) {
 	return target, nil
 }
 
+// Reason returns a bounded provider audit reason. When explicit is empty, it
+// derives a stable explanation from the finding ID and title.
 func Reason(finding *ports.FindingRecord, explicit string) (string, error) {
 	reason := strings.TrimSpace(explicit)
 	if reason == "" && finding != nil {
@@ -812,6 +858,7 @@ func Reason(finding *ports.FindingRecord, explicit string) (string, error) {
 	return reason, nil
 }
 
+// TicketURL validates an optional absolute HTTP(S) audit link.
 func TicketURL(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -827,11 +874,15 @@ func TicketURL(raw string) (string, error) {
 	return raw, nil
 }
 
+// IdempotencyKey binds a retry key to the normalized action, finding, and
+// target. NUL separators prevent ambiguous concatenations.
 func IdempotencyKey(action string, findingID string, target string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(action) + "\x00" + strings.TrimSpace(findingID) + "\x00" + strings.ToLower(strings.TrimSpace(target))))
 	return "cerebro:graph-action:" + strings.TrimSpace(action) + ":" + hex.EncodeToString(sum[:])
 }
 
+// GraphActionFromAccessApprovals maps a legacy provider receipt into the
+// provider-neutral GraphAction contract.
 func GraphActionFromAccessApprovals(action string, external *AccessApprovalsUserAction, actionURL string, fallbackTarget string) *GraphAction {
 	if external == nil {
 		return nil
@@ -888,6 +939,7 @@ func GraphActionFromAccessApprovals(action string, external *AccessApprovalsUser
 	}
 }
 
+// ExternalRef creates the finding linkage for a provider action receipt.
 func ExternalRef(action *GraphAction) ports.FindingExternalRef {
 	if action == nil {
 		return ports.FindingExternalRef{}

--- a/internal/graphfacts/doc.go
+++ b/internal/graphfacts/doc.go
@@ -1,0 +1,13 @@
+// Package graphfacts exposes the claim store as a read-only fact model.
+//
+// A fact is a normalized claim about a subject. It may point to another URN,
+// carry a scalar value, or both. The service deliberately keeps fact lookup
+// separate from graph traversal: List selects stored claims, Explain derives a
+// human-readable edge and freshness view for one claim, and Trace groups claims
+// that share the anchor subject. None of these operations mutate graph state.
+//
+// TenantID and RuntimeID are authority boundaries, not optional search hints.
+// Every list operation requires at least one of them. Pagination uses the
+// store's stable observed-at, updated-at, and claim-ID ordering so callers can
+// continue a scan without relying on offsets in a changing dataset.
+package graphfacts

--- a/internal/graphfacts/service.go
+++ b/internal/graphfacts/service.go
@@ -19,15 +19,22 @@ const (
 )
 
 var (
+	// ErrRuntimeUnavailable means the service has no claim-store capability.
 	ErrRuntimeUnavailable = errors.New("graph facts runtime is unavailable")
-	ErrInvalidRequest     = errors.New("invalid graph facts request")
-	ErrFactNotFound       = errors.New("graph fact not found")
+	// ErrInvalidRequest means a selector, cursor, or limit is malformed.
+	ErrInvalidRequest = errors.New("invalid graph facts request")
+	// ErrFactNotFound means no claim matched an otherwise valid selector.
+	ErrFactNotFound = errors.New("graph fact not found")
 )
 
+// Service provides read-only fact views over a ClaimStore.
 type Service struct {
 	store ports.ClaimStore
 }
 
+// ListRequest selects a page of facts. TenantID or RuntimeID is required.
+// Filters are combined, not unioned. Compact and OmitAttributes only change
+// response shape; IncludeEvidence adds evidence parsed from claim attributes.
 type ListRequest struct {
 	TenantID        string
 	RuntimeID       string
@@ -47,6 +54,8 @@ type ListRequest struct {
 	Compact         bool
 }
 
+// ExplainRequest identifies exactly one fact by FactID or by a complete edge
+// selector consisting of subject, predicate, and object URN or scalar value.
 type ExplainRequest struct {
 	TenantID    string
 	RuntimeID   string
@@ -57,6 +66,8 @@ type ExplainRequest struct {
 	ObjectValue string
 }
 
+// TraceRequest selects an anchor fact and controls the bounded set of sibling
+// facts returned for the same subject. Trace is not a recursive graph walk.
 type TraceRequest struct {
 	TenantID        string
 	RuntimeID       string
@@ -71,12 +82,17 @@ type TraceRequest struct {
 	EvidenceLimit   uint32
 }
 
+// ListResponse contains one stable page of facts and an opaque continuation
+// cursor. NextCursor is set only when HasMore is true.
 type ListResponse struct {
 	Facts      []Fact `json:"facts"`
 	NextCursor string `json:"next_cursor,omitempty"`
 	HasMore    bool   `json:"has_more"`
 }
 
+// ExplainResponse combines the stored fact with views derived from it. Edge is
+// present only for object-URN facts; scalar facts still include freshness,
+// evidence, and a textual explanation.
 type ExplainResponse struct {
 	Fact        Fact       `json:"fact"`
 	Edge        *FactEdge  `json:"edge,omitempty"`
@@ -85,6 +101,8 @@ type ExplainResponse struct {
 	Explanation string     `json:"explanation"`
 }
 
+// TraceResponse contains the explained anchor and other facts that share its
+// subject. RelatedMore reflects truncation of that sibling set.
 type TraceResponse struct {
 	Anchor       ExplainResponse `json:"anchor"`
 	RelatedFacts []Fact          `json:"related_facts,omitempty"`
@@ -92,12 +110,16 @@ type TraceResponse struct {
 	RelatedMore  bool            `json:"related_more"`
 }
 
+// TraceStep is a presentation-ready statement in the explanation sequence.
 type TraceStep struct {
 	Kind        string `json:"kind"`
 	Description string `json:"description"`
 	FactID      string `json:"fact_id,omitempty"`
 }
 
+// Fact is the API representation of a stored claim. ObjectURN and ObjectValue
+// are distinct because a relationship and a scalar assertion have different
+// graph semantics even when their serialized text happens to match.
 type Fact struct {
 	ID            string            `json:"id"`
 	RuntimeID     string            `json:"runtime_id,omitempty"`
@@ -117,6 +139,7 @@ type Fact struct {
 	Evidence      []Evidence        `json:"evidence,omitempty"`
 }
 
+// FactEdge is the relationship view derived from a fact with an ObjectURN.
 type FactEdge struct {
 	FromURN  string            `json:"from_urn"`
 	Relation string            `json:"relation"`
@@ -125,12 +148,14 @@ type FactEdge struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
+// Evidence identifies a source record cited by a fact.
 type Evidence struct {
 	URN    string `json:"urn"`
 	Kind   string `json:"kind"`
 	Source string `json:"source,omitempty"`
 }
 
+// Freshness summarizes the observation and validity window of a fact.
 type Freshness struct {
 	ObservedAt string `json:"observed_at,omitempty"`
 	ValidFrom  string `json:"valid_from,omitempty"`
@@ -138,10 +163,15 @@ type Freshness struct {
 	Status     string `json:"status"`
 }
 
+// New constructs a read-only graph-facts service over store. A nil store is
+// accepted at construction time and reported as ErrRuntimeUnavailable on use.
 func New(store ports.ClaimStore) *Service {
 	return &Service{store: store}
 }
 
+// List returns a stable, bounded page of facts matching request. It does not
+// guarantee a snapshot across pages; records created between calls can appear
+// according to the ClaimStore ordering contract.
 func (s *Service) List(ctx context.Context, request ListRequest) (ListResponse, error) {
 	if s == nil || s.store == nil {
 		return ListResponse{}, ErrRuntimeUnavailable
@@ -154,6 +184,8 @@ func (s *Service) List(ctx context.Context, request ListRequest) (ListResponse, 
 	if err != nil {
 		return ListResponse{}, err
 	}
+	// Ask the store for one extra row. This proves whether another page exists
+	// without issuing a count query against a potentially changing claim set.
 	records, err := s.store.ListClaims(ctx, ports.ListClaimsRequest{
 		RuntimeID:       strings.TrimSpace(request.RuntimeID),
 		TenantID:        strings.TrimSpace(request.TenantID),
@@ -188,11 +220,16 @@ func (s *Service) List(ctx context.Context, request ListRequest) (ListResponse, 
 	}
 	nextCursor := ""
 	if hasMore && len(records) != 0 {
+		// The cursor captures the final store record rather than the shaped API
+		// fact because UpdatedAt is intentionally not exposed in the response.
 		nextCursor = encodeCursor(records[len(records)-1])
 	}
 	return ListResponse{Facts: facts, NextCursor: nextCursor, HasMore: hasMore}, nil
 }
 
+// Explain resolves one fact and derives its edge, evidence, freshness, and
+// human-readable statement. If a broad selector matches multiple records, the
+// first record in stable store order is returned.
 func (s *Service) Explain(ctx context.Context, request ExplainRequest) (ExplainResponse, error) {
 	if strings.TrimSpace(request.FactID) == "" &&
 		(strings.TrimSpace(request.SubjectURN) == "" || strings.TrimSpace(request.Predicate) == "" ||
@@ -225,6 +262,8 @@ func (s *Service) Explain(ctx context.Context, request ExplainRequest) (ExplainR
 	}, nil
 }
 
+// Trace explains one anchor and returns other facts for the same subject. It is
+// intended to show local provenance context, not to replace graph path queries.
 func (s *Service) Trace(ctx context.Context, request TraceRequest) (TraceResponse, error) {
 	anchor, err := s.Explain(ctx, ExplainRequest{
 		TenantID:    request.TenantID,

--- a/internal/urn/doc.go
+++ b/internal/urn/doc.go
@@ -1,0 +1,8 @@
+// Package urn parses and mints tenant-scoped Cerebro resource names.
+//
+// Cerebro URNs use the form urn:cerebro:<tenant>:<kind>:<parts...>. Provider
+// identifiers must be passed through EncodeSegment before they become parts;
+// Mint validates structure but cannot infer which inputs are provider
+// controlled. StableExternalID is available when the source identifier should
+// not be disclosed or cannot safely serve as a path segment.
+package urn

--- a/internal/urn/urn.go
+++ b/internal/urn/urn.go
@@ -8,8 +8,11 @@ import (
 	"strings"
 )
 
+// Prefix identifies URNs owned by Cerebro's canonical namespace.
 const Prefix = "urn:cerebro:"
 
+// URN is the parsed representation of a canonical Cerebro resource name.
+// Parts excludes the fixed urn:cerebro prefix, tenant, and kind segments.
 type URN struct {
 	Raw      string
 	TenantID string
@@ -17,10 +20,14 @@ type URN struct {
 	Parts    []string
 }
 
+// String returns the validated URN without decoding or reformatting segments.
 func (u URN) String() string {
 	return u.Raw
 }
 
+// Parse validates raw as a Cerebro URN and separates its authority fields.
+// It preserves encoded path segments exactly; callers decode provider values
+// only when their domain contract explicitly requires it.
 func Parse(raw string) (URN, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
@@ -53,6 +60,9 @@ func Parse(raw string) (URN, error) {
 	return parsed, nil
 }
 
+// Mint builds and validates a tenant-scoped Cerebro URN. Empty optional parts
+// are omitted. Callers must EncodeSegment for provider-controlled values before
+// passing them to Mint so delimiters cannot change the URN structure.
 func Mint(tenantID string, kind string, parts ...string) (string, error) {
 	tenant := strings.TrimSpace(tenantID)
 	entityKind := strings.TrimSpace(kind)
@@ -77,6 +87,8 @@ func Mint(tenantID string, kind string, parts ...string) (string, error) {
 	return raw, nil
 }
 
+// TenantID returns the tenant authority in raw, or an empty string when raw is
+// not a valid Cerebro URN.
 func TenantID(raw string) string {
 	parsed, err := Parse(raw)
 	if err != nil {
@@ -85,6 +97,7 @@ func TenantID(raw string) string {
 	return parsed.TenantID
 }
 
+// SameTenant reports whether raw is valid and belongs to the non-empty tenant.
 func SameTenant(raw string, tenantID string) bool {
 	tenant := strings.TrimSpace(tenantID)
 	return tenant != "" && TenantID(raw) == tenant
@@ -96,6 +109,9 @@ func EncodeSegment(value string) string {
 	return strings.ReplaceAll(escaped, ":", "%3A")
 }
 
+// StableExternalID returns a deterministic, opaque identifier derived from a
+// provider value. Only the first 128 digest bits are exposed. If value is empty,
+// emptyFallback is returned unchanged so the caller controls missing-ID policy.
 func StableExternalID(value string, emptyFallback string) string {
 	normalized := strings.TrimSpace(value)
 	if normalized == "" {


### PR DESCRIPTION
## Summary

- add package documentation for graph facts, evidence ledger, graph actions, and canonical URNs
- document exported API contracts, authority boundaries, failure semantics, and recovery behavior
- clarify stable pagination, append-before-projection ordering, action target authorization, and reconciliation invariants without changing runtime behavior

## Validation

- `go test ./internal/graphfacts ./internal/evidenceledger ./internal/graphactions ./internal/urn -count=1`
- `go vet ./internal/graphfacts ./internal/evidenceledger ./internal/graphactions ./internal/urn`
- `make docs-drift-check`
- `go doc` for all four documented packages
- `git diff --check`