### PR TITLE
docs: explain Rust action and graph invariants

### DIFF
--- a/crates/action-catalog/src/lib.rs
+++ b/crates/action-catalog/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 //! Closed, content-addressed Action definitions.
 //!
@@ -6,6 +7,11 @@
 //! is generated as a compatibility consumer. New Action proposals must bind one
 //! exact generated definition; stored historical operations retain their
 //! original digest.
+//!
+//! [`validate_proposal`] is the admission boundary between caller-authored
+//! intent and executable action policy. It rejects unknown action kinds,
+//! definition drift, effect drift, and effects aimed at any target other than
+//! the proposal's authorized target.
 
 mod generated;
 
@@ -18,18 +24,31 @@ use sha2::{Digest, Sha256};
 const ACTION_DEFINITION_DIGEST_SCHEMA: &str = "cerebro.action-definition.v1";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+/// Immutable generated policy for one executable action kind.
 pub struct ActionDefinition<'a> {
+    /// Stable action kind used by proposals and durable operations.
     pub id: &'a str,
+    /// Provider adapter responsible for executing the action.
     pub provider: &'a str,
+    /// Provider-native operation selected by the adapter.
     pub provider_action: &'a str,
+    /// Kind of identifier the target resolver must authorize.
     pub target_kind: &'a str,
+    /// Effect kind every proposal effect must declare.
     pub effect: &'a str,
+    /// Whether execution changes provider state.
     pub destructive: bool,
+    /// Registered action kind that reverses this action, or an empty string.
     pub reversible_by: &'a str,
+    /// Content digest of every executable policy field in this definition.
     pub definition_digest: &'a str,
 }
 
 impl ActionDefinition<'_> {
+    /// Recomputes the canonical definition digest for drift detection.
+    ///
+    /// `definition_digest` itself is excluded from the digest material so the
+    /// generated value can be independently verified.
     pub fn computed_digest(&self) -> Result<String, serde_json::Error> {
         #[derive(Serialize)]
         struct DigestMaterial<'a> {
@@ -64,12 +83,27 @@ impl ActionDefinition<'_> {
 }
 
 #[derive(Debug)]
+/// A proposal cannot be bound to the closed action catalog.
 pub enum ActionCatalogError {
+    /// The proposal failed its transport-neutral structural validation.
     InvalidProposal(SdkError),
+    /// No generated definition exists for the requested action kind.
     UnknownActionKind(String),
-    DefinitionDigestMismatch { action_kind: String },
-    EffectMismatch { action_kind: String },
-    EffectTargetMismatch { action_kind: String },
+    /// The proposal was authored against different executable policy.
+    DefinitionDigestMismatch {
+        /// Action kind whose bound digest drifted.
+        action_kind: String,
+    },
+    /// A proposed expected effect differs from the registered effect kind.
+    EffectMismatch {
+        /// Action kind whose effect contract was violated.
+        action_kind: String,
+    },
+    /// A proposed expected effect points at a different target.
+    EffectTargetMismatch {
+        /// Action kind whose target binding was violated.
+        action_kind: String,
+    },
 }
 
 impl fmt::Display for ActionCatalogError {
@@ -109,10 +143,12 @@ impl From<SdkError> for ActionCatalogError {
     }
 }
 
+/// Returns the complete generated catalog in deterministic order.
 pub fn definitions() -> &'static [ActionDefinition<'static>] {
     generated::ACTION_DEFINITIONS
 }
 
+/// Resolves one exact action kind without aliases or fallback matching.
 pub fn lookup(action_kind: &str) -> Result<&'static ActionDefinition<'static>, ActionCatalogError> {
     definitions()
         .iter()
@@ -120,6 +156,11 @@ pub fn lookup(action_kind: &str) -> Result<&'static ActionDefinition<'static>, A
         .ok_or_else(|| ActionCatalogError::UnknownActionKind(action_kind.to_owned()))
 }
 
+/// Binds a proposal to its exact catalog definition.
+///
+/// Successful validation proves that the proposal's definition digest, every
+/// expected effect kind, and every effect target match current generated policy.
+/// It does not confer approval or execute the action.
 pub fn validate_proposal(
     proposal: &ActionProposal,
 ) -> Result<&'static ActionDefinition<'static>, ActionCatalogError> {

--- a/crates/action-provider/src/cerebro_device.rs
+++ b/crates/action-provider/src/cerebro_device.rs
@@ -16,6 +16,11 @@ const RECEIPT_SCHEMA: &str = "cerebro.device-action-receipt.v1";
 const EXTERNAL_PREFIX: &str = "cerebro-device:revoke:";
 
 #[derive(Clone)]
+/// PostgreSQL-backed adapter for first-party Cerebro device revocation.
+///
+/// The device record is both the mutation target and the source for later
+/// observation. Tenant binding comes from the durable [`ActionDispatch`]; an
+/// external receipt identifier cannot select a different device.
 pub struct CerebroDeviceClient {
     store: Arc<dyn CerebroDeviceStore>,
 }
@@ -39,6 +44,7 @@ struct PostgresCerebroDeviceStore {
 }
 
 impl CerebroDeviceClient {
+    /// Connects to the device store using native TLS and starts the connection driver.
     pub async fn connect_tls(connection_string: &str) -> Result<Self, ProviderError> {
         if connection_string.trim().is_empty() || connection_string.trim() != connection_string {
             return Err(ProviderError::InvalidConfiguration(
@@ -69,6 +75,10 @@ impl CerebroDeviceClient {
         Self { store }
     }
 
+    /// Idempotently revokes the tenant-bound device selected by `dispatch`.
+    ///
+    /// A database error is ambiguous because the update may have committed
+    /// before the connection failed; callers reconcile instead of retrying.
     pub async fn dispatch(
         &self,
         dispatch: &ActionDispatch,
@@ -78,6 +88,8 @@ impl CerebroDeviceClient {
         receipt(dispatch, state, None)
     }
 
+    /// Reads the device's current state after proving `expected_external_id`
+    /// names the same target as the durable dispatch.
     pub async fn observe(
         &self,
         dispatch: &ActionDispatch,

--- a/crates/action-provider/src/lib.rs
+++ b/crates/action-provider/src/lib.rs
@@ -1,9 +1,15 @@
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 //! Bounded provider clients for durable Rust Action dispatches.
 //!
 //! A provider response is execution evidence, not finding closure. This crate
 //! never retries a mutation and never manufactures an observed-effect digest.
+//! Dispatch validates a durable [`ActionDispatch`], sends one bounded mutation,
+//! and classifies any uncertain outcome as [`ProviderError::DispatchAmbiguous`]
+//! so an upstream coordinator reconciles instead of replaying the mutation.
+//! Observation is read-only and binds the returned receipt to the original
+//! tenant, finding, target, idempotency key, and external identifier.
 
 mod cerebro_device;
 
@@ -29,13 +35,18 @@ const MAX_SUCCESS_BODY_BYTES: usize = 1 << 20;
 const MAX_ERROR_BODY_BYTES: usize = 4 << 10;
 
 #[derive(Clone)]
+/// Configuration for the access-approvals HTTP adapter.
 pub struct AccessApprovalsConfig {
+    /// Absolute HTTPS endpoint, with loopback HTTP permitted for local tests.
     pub base_url: String,
+    /// Bearer credential sent to the provider; it must never be logged.
     pub bearer_token: String,
+    /// End-to-end request timeout, constrained to 100 milliseconds through 60 seconds.
     pub timeout: Duration,
 }
 
 impl AccessApprovalsConfig {
+    /// Creates configuration with the default ten-second timeout.
     pub fn new(base_url: impl Into<String>, bearer_token: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
@@ -46,6 +57,10 @@ impl AccessApprovalsConfig {
 }
 
 #[derive(Clone)]
+/// Bounded HTTP client for access-approval user lifecycle actions.
+///
+/// The client rejects redirects, bounds response bodies, and performs no
+/// automatic mutation retry. Clone shares the underlying connection pool.
 pub struct AccessApprovalsClient {
     base_url: Url,
     bearer_token: String,
@@ -53,17 +68,26 @@ pub struct AccessApprovalsClient {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Normalized asynchronous state reported by an action provider.
 pub enum ProviderStatus {
+    /// The provider accepted the operation but has not queued it.
     Pending,
+    /// The operation is waiting for provider execution.
     Queued,
+    /// The provider is actively executing the operation.
     Running,
+    /// The provider reports successful execution.
     Succeeded,
+    /// The provider reports terminal failure.
     Failed,
+    /// The provider reports terminal cancellation.
     Cancelled,
+    /// Automation must stop and hand the operation to a human.
     NeedsAttention,
 }
 
 impl ProviderStatus {
+    /// Returns the stable wire value stored in action state.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Pending => "pending",
@@ -76,6 +100,10 @@ impl ProviderStatus {
         }
     }
 
+    /// Reports whether automated provider polling should stop.
+    ///
+    /// `NeedsAttention` is terminal for automation even though human work may
+    /// continue outside the provider loop.
     pub const fn is_terminal(self) -> bool {
         matches!(
             self,
@@ -102,16 +130,28 @@ impl TryFrom<&str> for ProviderStatus {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Validated execution evidence returned by a provider adapter.
+///
+/// A receipt can advance action state but cannot prove that the intended effect
+/// remains true. Independent observation supplies that later evidence.
 pub struct ProviderReceipt {
+    /// Provider-owned identifier used for later observation.
     pub external_id: OpaqueId,
+    /// Normalized provider lifecycle state.
     pub status: ProviderStatus,
+    /// Digest of the exact mutation request, present only for dispatch receipts.
     pub request_digest: Option<ContentDigest>,
+    /// Digest of the bounded provider response used to build this receipt.
     pub response_digest: ContentDigest,
+    /// Provider-reported last update time in Unix seconds, when available.
     pub updated_at_unix_s: Option<u64>,
+    /// Provider-reported completion time in Unix seconds, when available.
     pub completed_at_unix_s: Option<u64>,
 }
 
 impl ProviderReceipt {
+    /// Converts an initial dispatch receipt into the engine command that records
+    /// provider acceptance without asserting independent verification.
     pub fn record_command(
         &self,
         executor_actor_id: ActorId,
@@ -126,6 +166,7 @@ impl ProviderReceipt {
         }
     }
 
+    /// Converts a later read-only observation into a reconciliation command.
     pub fn observation_command(
         &self,
         reconciler_actor_id: ActorId,
@@ -141,14 +182,26 @@ impl ProviderReceipt {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Fail-closed provider boundary errors.
 pub enum ProviderError {
+    /// Static client configuration is malformed or unsafe.
     InvalidConfiguration(&'static str),
+    /// A durable dispatch does not match the adapter's provider contract.
     InvalidDispatch(&'static str),
-    DispatchRejected { status: u16 },
+    /// The provider definitively rejected the mutation.
+    DispatchRejected {
+        /// HTTP status returned by the provider.
+        status: u16,
+    },
+    /// The mutation may have reached the provider, so automatic retry is unsafe.
     DispatchAmbiguous,
+    /// A read-only receipt lookup could not produce usable evidence.
     ObservationUnavailable,
+    /// A provider attempted to redirect a bounded request.
     RedirectRejected,
+    /// A provider body exceeded the configured evidence limit.
     ResponseTooLarge,
+    /// A provider response violated a field or binding invariant.
     InvalidResponse(&'static str),
 }
 
@@ -214,6 +267,7 @@ struct UserActionResponse {
 }
 
 impl AccessApprovalsClient {
+    /// Validates configuration and builds a redirect-free bounded HTTP client.
     pub fn new(config: AccessApprovalsConfig) -> Result<Self, ProviderError> {
         let base_url = validate_base_url(&config.base_url)?;
         let bearer_token = validate_bearer_token(config.bearer_token)?;
@@ -232,6 +286,12 @@ impl AccessApprovalsClient {
         })
     }
 
+    /// Sends one mutation for a validated durable dispatch.
+    ///
+    /// Transport failure, redirect, an ambiguous HTTP status, an oversized
+    /// success body, or a malformed success receipt all return
+    /// [`ProviderError::DispatchAmbiguous`]. The caller must reconcile by the
+    /// idempotency key rather than blindly retrying.
     pub async fn dispatch(
         &self,
         dispatch: &ActionDispatch,
@@ -266,6 +326,8 @@ impl AccessApprovalsClient {
             .await
     }
 
+    /// Reads the provider receipt linked to `external_id` and revalidates its
+    /// tenant, finding, target, action, and idempotency bindings.
     pub async fn observe(
         &self,
         dispatch: &ActionDispatch,
@@ -291,6 +353,9 @@ impl AccessApprovalsClient {
         dispatch: &ActionDispatch,
         request_digest: ContentDigest,
     ) -> Result<ProviderReceipt, ProviderError> {
+        // A redirect after a mutation does not prove whether the original
+        // endpoint committed the action. Preserve that uncertainty for the
+        // coordinator instead of following or classifying it as rejection.
         if response.status().is_redirection() {
             return Err(ProviderError::DispatchAmbiguous);
         }

--- a/crates/action-store/src/lib.rs
+++ b/crates/action-store/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 //! Authoritative, tenant-scoped persistence for Action operations.
 //!
@@ -21,6 +22,8 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio_postgres::{Client, Row, Transaction};
 
+/// PostgreSQL schema for tenant-isolated current operations, immutable event
+/// history, provider dispatches, and reconciliation leases.
 pub const POSTGRES_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS finding_validation_receipts (
   tenant_id TEXT NOT NULL CHECK (char_length(tenant_id) BETWEEN 1 AND 256),
@@ -355,16 +358,27 @@ END $$;
 "#;
 
 #[derive(Debug)]
+/// Durable action-ledger failures.
 pub enum ActionStoreError {
+    /// PostgreSQL rejected or could not complete an operation.
     Postgres(tokio_postgres::Error),
+    /// A durable record could not be encoded or decoded.
     Serialization(serde_json::Error),
+    /// A platform SDK value failed validation.
     Invalid(SdkError),
+    /// A proposal violated the closed action catalog.
     Catalog(ActionCatalogError),
+    /// A finding validation receipt violated the policy catalog.
     PolicyCatalog(PolicyCatalogError),
+    /// Current state, optimistic version, authority time, or identity conflicts.
     Conflict(String),
+    /// The requested tenant-scoped record does not exist.
     NotFound(String),
+    /// Stored content, history, or a cross-record binding failed validation.
     Corrupt(String),
+    /// A pagination cursor could not be decoded or validated.
     InvalidPageToken,
+    /// A numeric request cannot be represented within the storage contract.
     OutOfRange(&'static str),
 }
 
@@ -433,18 +447,28 @@ impl From<PolicyCatalogError> for ActionStoreError {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// One immutable version in an action operation's append-only history.
 pub struct ActionEvent {
+    /// Authenticated actor responsible for the version transition.
     pub actor_id: ActorId,
+    /// Stable command name, or `proposed` for the initial version.
     pub event_kind: String,
+    /// Digest of the transition command, absent for the initial proposal.
     pub command_digest: Option<ContentDigest>,
+    /// Digest of the complete resulting operation state.
     pub operation_digest: ContentDigest,
+    /// Authority commit time in Unix milliseconds.
     pub committed_at_unix_ms: u64,
+    /// Validated operation snapshot at this version.
     pub operation: ActionOperation,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// Stable page of current action operations.
 pub struct ActionPage {
+    /// Operations in descending update-time and ascending operation-ID order.
     pub actions: Vec<ActionOperation>,
+    /// Opaque continuation token for the next page, when more records exist.
     pub next_page_token: Option<String>,
 }
 
@@ -452,25 +476,49 @@ const ACTION_DISPATCH_DIGEST_SCHEMA: &str = "cerebro.action-dispatch.v1";
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
+/// Immutable provider request derived from a start-execution transition.
+///
+/// Every authority and routing field is copied from the validated proposal and
+/// closed catalog definition. Providers receive this record rather than raw
+/// caller input so a later adapter cannot widen the authorized target or effect.
 pub struct ActionDispatch {
+    /// Tenant authority inherited from the proposal.
     pub tenant_id: String,
+    /// Durable operation identifier.
     pub operation_id: String,
+    /// Operation version that created this dispatch.
     pub operation_version: u64,
+    /// Digest of the admitted proposal.
     pub proposal_digest: String,
+    /// Finding that authorized the operation.
     pub finding_id: String,
+    /// Exact finding revision considered during authorization.
     pub finding_revision_digest: String,
+    /// Committed validation receipt used to admit the proposal.
     pub finding_validation_receipt_digest: String,
+    /// Graph revision against which authorization was evaluated.
     pub graph_revision: u64,
+    /// Catalog action kind.
     pub action_kind: String,
+    /// Exact catalog definition digest bound by the proposal.
     pub action_definition_digest: String,
+    /// Registered provider adapter.
     pub provider: String,
+    /// Provider-native mutation name.
     pub provider_action: String,
+    /// Registered target identifier kind.
     pub target_kind: String,
+    /// Finding-authorized provider target.
     pub target_id: String,
+    /// Expected effect kind.
     pub effect: String,
+    /// Stable provider idempotency key.
     pub idempotency_key: String,
+    /// Authenticated execution claimant.
     pub requested_by: String,
+    /// Authority time at which execution began, in Unix milliseconds.
     pub requested_at_unix_ms: u64,
+    /// Digest binding every preceding dispatch field.
     pub dispatch_digest: String,
 }
 
@@ -520,6 +568,7 @@ impl ActionDispatch {
         Ok(dispatch)
     }
 
+    /// Recomputes the content digest that seals every routing and authority field.
     pub fn computed_digest(&self) -> Result<ContentDigest, ActionStoreError> {
         #[derive(Serialize)]
         struct DigestMaterial<'a> {
@@ -568,6 +617,7 @@ impl ActionDispatch {
         Ok(ContentDigest::of_bytes(serde_json::to_vec(&material)?))
     }
 
+    /// Validates field shapes, the closed catalog binding, and the content digest.
     pub fn validate(&self) -> Result<(), ActionStoreError> {
         if self.operation_version <= 1
             || self.requested_at_unix_ms == 0
@@ -642,26 +692,47 @@ impl ActionDispatch {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// Bounded set of provider dispatches that still require work.
 pub struct ActionDispatchPage {
+    /// Validated dispatch records.
     pub dispatches: Vec<ActionDispatch>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// One exclusively leased provider-reconciliation unit.
 pub struct ActionReconciliationJob {
+    /// Current durable operation state.
     pub operation: ActionOperation,
+    /// Immutable dispatch whose receipt must be observed.
     pub dispatch: ActionDispatch,
+    /// Number of times this job has been leased, including the current lease.
     pub attempt_count: u64,
+    /// Exclusive lease deadline in Unix milliseconds.
     pub lease_expires_at_unix_ms: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Scheduler decision recorded after one reconciliation attempt.
 pub enum ActionReconciliationDisposition {
-    PollAgain { next_attempt_at_unix_ms: u64 },
-    Terminal { provider_status: String },
+    /// Release the lease and make the job eligible at a future authority time.
+    PollAgain {
+        /// Earliest next claim time in Unix milliseconds.
+        next_attempt_at_unix_ms: u64,
+    },
+    /// Stop polling because the provider reached a terminal status.
+    Terminal {
+        /// Normalized provider status already recorded on the operation.
+        provider_status: String,
+    },
 }
 
 const MAX_RECONCILIATION_LEASE_MS: u64 = 5 * 60 * 1_000;
 
+/// PostgreSQL authority for validated action state, history, and reconciliation.
+///
+/// Every public operation opens a tenant-scoped transaction. Mutations lock the
+/// current operation, apply optimistic-version and authority-time checks, append
+/// immutable history, and update current state in the same commit.
 pub struct PostgresActionLedger {
     client: Mutex<Client>,
 }
@@ -679,6 +750,7 @@ impl PostgresActionLedger {
         }
     }
 
+    /// Connects with native TLS and starts the PostgreSQL connection driver.
     pub async fn connect_tls(connection_string: &str) -> Result<Self, ActionStoreError> {
         let tls = native_tls::TlsConnector::builder()
             .build()
@@ -695,6 +767,7 @@ impl PostgresActionLedger {
         Ok(Self::from_client(client))
     }
 
+    /// Applies the idempotent action-ledger schema and tenant-isolation policies.
     pub async fn migrate(&self) -> Result<(), ActionStoreError> {
         self.client
             .lock()
@@ -704,11 +777,14 @@ impl PostgresActionLedger {
         Ok(())
     }
 
+    /// Verifies that the configured PostgreSQL connection can execute a query.
     pub async fn health(&self) -> Result<(), ActionStoreError> {
         self.client.lock().await.simple_query("SELECT 1").await?;
         Ok(())
     }
 
+    /// Commits an immutable finding-validation receipt while it is current at
+    /// authority commit time. A reused digest must contain identical content.
     pub async fn record_finding_validation(
         &self,
         receipt: FindingValidationReceipt,
@@ -769,6 +845,7 @@ impl PostgresActionLedger {
         Ok(stored)
     }
 
+    /// Reads one tenant-scoped finding-validation receipt by content digest.
     pub async fn get_finding_validation(
         &self,
         tenant_id: &TenantId,
@@ -785,6 +862,10 @@ impl PostgresActionLedger {
         Ok(receipt)
     }
 
+    /// Admits a catalog-bound action proposal as version one.
+    ///
+    /// The referenced finding-validation receipt must already be committed,
+    /// match the proposal, and remain valid at `committed_at_unix_ms`.
     pub async fn propose(
         &self,
         proposal: ActionProposal,
@@ -897,6 +978,7 @@ impl PostgresActionLedger {
         Ok(operation)
     }
 
+    /// Reads and validates the current version of one action operation.
     pub async fn get(
         &self,
         tenant_id: &TenantId,
@@ -920,6 +1002,7 @@ impl PostgresActionLedger {
         Ok(operation.operation)
     }
 
+    /// Lists current operations using a stable keyset cursor.
     pub async fn list(
         &self,
         tenant_id: &TenantId,
@@ -973,6 +1056,10 @@ impl PostgresActionLedger {
         })
     }
 
+    /// Applies one authenticated, optimistic state transition atomically.
+    ///
+    /// Starting execution also seals the provider dispatch. Recording the first
+    /// provider receipt schedules reconciliation in the same transaction.
     pub async fn transition(
         &self,
         tenant_id: &TenantId,
@@ -1136,6 +1223,7 @@ impl PostgresActionLedger {
         Ok(next)
     }
 
+    /// Reads a dispatch and revalidates it against the start-execution event.
     pub async fn get_dispatch(
         &self,
         tenant_id: &TenantId,
@@ -1158,6 +1246,7 @@ impl PostgresActionLedger {
         Ok(dispatch)
     }
 
+    /// Lists dispatches whose operations may still require provider work.
     pub async fn list_open_dispatches(
         &self,
         tenant_id: &TenantId,
@@ -1185,6 +1274,10 @@ impl PostgresActionLedger {
         Ok(ActionDispatchPage { dispatches })
     }
 
+    /// Exclusively leases the next due reconciliation job.
+    ///
+    /// PostgreSQL `SKIP LOCKED` lets concurrent workers claim different jobs.
+    /// Expired leases may be reclaimed; a lease may not exceed five minutes.
     pub async fn claim_due_reconciliation(
         &self,
         tenant_id: &TenantId,
@@ -1264,6 +1357,8 @@ impl PostgresActionLedger {
         }))
     }
 
+    /// Completes a reconciliation lease if worker, lease, operation version,
+    /// and terminal provider status still match current durable state.
     pub async fn finish_reconciliation(
         &self,
         tenant_id: &TenantId,
@@ -1336,6 +1431,10 @@ impl PostgresActionLedger {
         Ok(())
     }
 
+    /// Returns the complete validated operation history in version order.
+    ///
+    /// Gaps, non-monotonic commit times, digest mismatches, or a final event that
+    /// differs from current state are reported as corruption.
     pub async fn history(
         &self,
         tenant_id: &TenantId,

--- a/crates/organizational-graph/src/lib.rs
+++ b/crates/organizational-graph/src/lib.rs
@@ -1,6 +1,14 @@
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 //! Rust-owned admission and current-state graph engine.
+//!
+//! The graph accepts only [`GraphDelta`] values that have already crossed the
+//! sealed model's admission boundary. [`OrganizationalGraph::apply`] validates
+//! the complete candidate tenant state before replacing current state, so a
+//! failed entity, identity, claim, or retraction check cannot partially mutate
+//! the graph. The graph is a current-state projection; durable replay and
+//! persistence belong to the organizational-store crate.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -15,26 +23,44 @@ use cerebro_organizational_model::{
 use serde::Serialize;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// A candidate graph delta violated an identity or ownership invariant.
 pub enum GraphError {
+    /// An incoming entity reused an ID with different stable identity fields.
     EntityConflict(EntityId),
+    /// An assertion references an entity absent from both current and incoming state.
     MissingEntity(EntityId),
+    /// A provider identity is already confirmed against another canonical identity.
     IdentityAlreadyBound {
+        /// The provider-owned identity being rebound.
         provider_identity: EntityId,
+        /// The canonical identity already confirmed for the provider identity.
         existing_canonical_identity: EntityId,
+        /// The different canonical identity requested by the candidate delta.
         requested_canonical_identity: EntityId,
     },
+    /// A normalized identity claim is already confirmed against another identity.
     IdentityClaimAlreadyBound {
+        /// The namespace of the conflicting claim.
         claim_kind: IdentityClaimKind,
+        /// The normalized claim value.
         claim_value: String,
+        /// The canonical identity already confirmed for the claim.
         existing_canonical_identity: EntityId,
+        /// The different canonical identity requested by the candidate delta.
         requested_canonical_identity: EntityId,
     },
+    /// A canonical identity lacks the authoritative employee anchor required for binding.
     CanonicalIdentityUnanchored(EntityId),
+    /// A proposed binding cites no confirmed claim for the requested identity.
     IdentityClaimNotFound {
+        /// The namespace of the missing claim.
         claim_kind: IdentityClaimKind,
+        /// The normalized claim value.
         claim_value: String,
+        /// The canonical identity the claim was expected to anchor.
         requested_canonical_identity: EntityId,
     },
+    /// A collection attempted to retract an assertion owned by another runtime.
     RetractionSourceMismatch(AssertionId),
 }
 
@@ -87,12 +113,22 @@ impl fmt::Display for GraphError {
 impl Error for GraphError {}
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// Receipt for one atomically accepted graph delta.
+///
+/// Counts describe writes in the submitted delta, while `graph_revision`
+/// identifies the resulting tenant projection revision.
 pub struct GraphWriteReceipt {
+    /// Tenant whose projection changed.
     pub tenant_id: TenantId,
+    /// Monotonic in-memory revision after the accepted write.
     pub graph_revision: u64,
+    /// Content digest committed by the validated delta.
     pub delta_digest: String,
+    /// Number of entities inserted or refreshed.
     pub entities_upserted: usize,
+    /// Number of assertions inserted or refreshed.
     pub assertions_upserted: usize,
+    /// Number of existing assertions removed by owned retractions.
     pub assertions_retracted: usize,
 }
 
@@ -107,11 +143,17 @@ struct TenantGraph {
 }
 
 #[derive(Clone, Debug, Default)]
+/// Tenant-partitioned current-state organizational graph.
+///
+/// This type is an in-process projection engine, not a durable store. Clone-on-
+/// validate admission preserves atomicity before the accepted candidate state
+/// replaces a tenant's current assertion and identity indexes.
 pub struct OrganizationalGraph {
     tenants: BTreeMap<TenantId, TenantGraph>,
 }
 
 impl OrganizationalGraph {
+    /// Creates an empty graph with no tenant projections.
     pub fn new() -> Self {
         Self::default()
     }
@@ -171,6 +213,9 @@ impl OrganizationalGraph {
             }
         }
 
+        // Rebuild every identity index from the complete candidate assertion
+        // set. Incremental index mutation could leave stale bindings when the
+        // same delta retracts and replaces identity evidence.
         let mut identity_candidate = TenantGraph {
             assertions: candidate_assertions,
             ..TenantGraph::default()
@@ -332,10 +377,18 @@ impl TenantGraph {
     }
 }
 
+/// Read-only organizational graph capability used by agents and product views.
+///
+/// Implementations return owned values so callers cannot mutate projection
+/// state through a read handle.
 pub trait GraphRead {
+    /// Returns the current tenant revision, or zero when no tenant graph exists.
     fn graph_revision(&self, tenant_id: &TenantId) -> u64;
+    /// Returns one entity from the tenant projection.
     fn entity(&self, tenant_id: &TenantId, entity_id: &EntityId) -> Option<Entity>;
+    /// Returns all tenant entities in stable ID order.
     fn entities(&self, tenant_id: &TenantId) -> Vec<Entity>;
+    /// Returns all tenant assertions in stable assertion-ID order.
     fn assertions(&self, tenant_id: &TenantId) -> Vec<GraphAssertion>;
 }
 


### PR DESCRIPTION
## Summary

- document Rust organizational graph admission, identity conflicts, atomic projection, and read contracts
- document closed action catalog binding, provider dispatch ambiguity, receipt semantics, and target authority
- document durable action history, dispatch sealing, optimistic transitions, and reconciliation leases
- enable missing-documentation warnings for the four completed Rust crates

## Validation

- `cargo test -p cerebro-action-catalog -p cerebro-action-provider -p cerebro-action-store -p cerebro-organizational-graph`
- `cargo clippy -p cerebro-action-catalog -p cerebro-action-provider -p cerebro-action-store -p cerebro-organizational-graph --all-targets -- -D warnings`
- `RUSTDOCFLAGS=-Dmissing_docs cargo doc` for each documented crate
- `make rust-doc-check`
- `make rust-fmt-check`
- `git diff --check`