### PR TITLE
docs: explain Rust source runtime boundaries

### DIFF
--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -1,3 +1,9 @@
+//! Decoding and projection helpers for committed source append-log events.
+//!
+//! The decoder authenticates the envelope shape before exposing a source
+//! event, preserves portable lifecycle payloads as protobuf bytes, and derives
+//! deterministic digests and incremental collection identities for storage.
+
 use std::{
     collections::{BTreeMap, HashMap},
     error::Error,
@@ -40,11 +46,17 @@ struct CommittedSourceWire {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// A committed append-log envelope could not cross the source-runtime boundary.
 pub enum AppendLogDecodeError {
+    /// The bytes are not a valid committed-source protobuf message.
     Protobuf(String),
+    /// A required field or cross-field invariant is absent.
     Missing(&'static str),
+    /// The event timestamp is invalid or outside the supported representation.
     InvalidTimestamp,
+    /// A catalog event payload is not valid JSON.
     InvalidPayload(String),
+    /// A decoded identifier violates an organizational-model invariant.
     InvalidModel(String),
 }
 
@@ -97,20 +109,32 @@ pub struct CommittedSourceEvent {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+/// Validated fields for constructing a committed source event without protobuf.
 pub struct CommittedSourceInput {
+    /// Tenant that owns the source observation.
     pub tenant_id: TenantId,
+    /// Concrete connector runtime that produced the observation.
     pub source_runtime_id: SourceRuntimeId,
+    /// Globally stable identifier for this observation.
     pub observation_id: ObservationId,
+    /// Catalog source identifier, such as `github` or `okta`.
     pub source_id: String,
+    /// Source-owned family identifier within the catalog.
     pub family_id: String,
+    /// Fully qualified event kind, normally `source.family`.
     pub event_kind: String,
+    /// Schema that gives the payload its portable meaning.
     pub schema_ref: String,
+    /// Authoritative observation time as Unix milliseconds.
     pub observed_at_unix_ms: i64,
+    /// Bounded envelope metadata carried into the source record.
     pub attributes: BTreeMap<String, String>,
+    /// Decoded catalog payload used by ordinary graph mappers.
     pub payload: serde_json::Value,
 }
 
 impl CommittedSourceEvent {
+    /// Validate already decoded fields and construct a committed event.
     pub fn from_input(input: CommittedSourceInput) -> Result<Self, AppendLogDecodeError> {
         let source_id = required(&input.source_id, "source_id")?.to_owned();
         let family_id = required(&input.family_id, "family_id")?.to_owned();
@@ -209,46 +233,60 @@ impl CommittedSourceEvent {
         }))
     }
 
+    /// Return the tenant that owns this observation.
     pub fn tenant_id(&self) -> &TenantId {
         &self.tenant_id
     }
 
+    /// Return the connector runtime that produced this observation.
     pub fn source_runtime_id(&self) -> &SourceRuntimeId {
         &self.source_runtime_id
     }
 
+    /// Return the stable observation identifier from the append log.
     pub fn observation_id(&self) -> &ObservationId {
         &self.observation_id
     }
 
+    /// Return the catalog source identifier.
     pub fn source_id(&self) -> &str {
         &self.source_id
     }
 
+    /// Return the source-owned family or portable lifecycle event kind.
     pub fn family_id(&self) -> &str {
         &self.family_id
     }
 
+    /// Return the fully qualified event kind from the envelope.
     pub fn event_kind(&self) -> &str {
         &self.event_kind
     }
 
+    /// Return the payload schema reference supplied by the producer.
     pub fn schema_ref(&self) -> &str {
         &self.schema_ref
     }
 
+    /// Return the authoritative observation time as Unix milliseconds.
     pub fn observed_at_unix_ms(&self) -> i64 {
         self.observed_at_unix_ms
     }
 
+    /// Return the sorted source-event attributes.
     pub fn attributes(&self) -> &BTreeMap<String, String> {
         &self.attributes
     }
 
+    /// Return the decoded JSON payload used by catalog mappers.
     pub fn payload(&self) -> &serde_json::Value {
         &self.payload
     }
 
+    /// Hash all identity, time, metadata, and canonical payload fields.
+    ///
+    /// Length-prefixing each field prevents concatenation ambiguity. The
+    /// resulting lowercase SHA-256 digest is stable across map insertion order.
     pub fn record_digest(&self) -> String {
         let mut hasher = Sha256::new();
         hash_field(&mut hasher, self.tenant_id.as_str().as_bytes());
@@ -268,6 +306,7 @@ impl CommittedSourceEvent {
         finish_digest(hasher)
     }
 
+    /// Hash only the sorted event attributes.
     pub fn attributes_digest(&self) -> String {
         let mut hasher = Sha256::new();
         for (key, value) in &self.attributes {
@@ -277,6 +316,7 @@ impl CommittedSourceEvent {
         finish_digest(hasher)
     }
 
+    /// Hash only the canonical JSON payload.
     pub fn payload_digest(&self) -> String {
         let mut hasher = Sha256::new();
         let payload = canonical_payload_bytes(&self.payload);
@@ -284,10 +324,15 @@ impl CommittedSourceEvent {
         finish_digest(hasher)
     }
 
+    /// Return the original protobuf payload bytes.
+    ///
+    /// Ordinary catalog events expose their JSON through [`Self::payload`];
+    /// portable lifecycle projectors consume these preserved bytes instead.
     pub fn raw_payload(&self) -> &[u8] {
         &self.raw_payload
     }
 
+    /// Return whether this event is an accepted portable security lifecycle event.
     pub fn is_portable_security_lifecycle(&self) -> bool {
         matches!(
             (self.event_kind.as_str(), self.schema_ref.as_str()),
@@ -296,10 +341,15 @@ impl CommittedSourceEvent {
         )
     }
 
+    /// Derive the incremental collection identity for this observation.
     pub fn collection_id(&self) -> Result<CollectionId, AppendLogDecodeError> {
         CollectionId::parse(format!("event:{}", self.observation_id)).map_err(model_error)
     }
 
+    /// Convert this event into a one-record, non-authoritative collection batch.
+    ///
+    /// Provider kind and ID are supplied by the family-specific caller because
+    /// the generic append-log envelope does not own that interpretation.
     pub fn into_batch(
         self,
         provider_kind: String,

--- a/crates/source-runtime-next/src/aws_secret_store.rs
+++ b/crates/source-runtime-next/src/aws_secret_store.rs
@@ -1,3 +1,9 @@
+//! Metadata-bounded AWS Secrets Manager references for source runtimes.
+//!
+//! Resolution authorizes every reference against the tenant/source/runtime
+//! naming scope, groups backend reads, redacts backend failures, and zeroizes
+//! owned secret material when it leaves scope.
+
 use std::collections::{BTreeMap, btree_map::Entry};
 
 use async_trait::async_trait;
@@ -36,6 +42,7 @@ impl Drop for SensitiveValues {
     }
 }
 
+/// Parsed `aws-sm:` address with an optional region and JSON field selector.
 pub struct AwsSecretReference {
     region: Option<String>,
     secret_id: String,
@@ -43,26 +50,36 @@ pub struct AwsSecretReference {
 }
 
 impl AwsSecretReference {
+    /// Return the explicit AWS region, when the reference includes one.
     pub fn region(&self) -> Option<&str> {
         self.region.as_deref()
     }
 
+    /// Return the secret name or full Secrets Manager ARN.
     pub fn secret_id(&self) -> &str {
         &self.secret_id
     }
 
+    /// Return the selected JSON object field, when present.
     pub fn field(&self) -> Option<&str> {
         self.field.as_deref()
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// A secret reference failed validation, authorization, reading, or extraction.
 pub enum AwsSecretResolutionError {
+    /// The named configuration key contains a malformed `aws-sm:` reference.
     InvalidReference(String),
+    /// Tenant, source, or runtime IDs cannot form an authorized secret scope.
     InvalidRuntimeScope,
+    /// The named key addresses a secret outside its runtime-owned prefix.
     ReferenceOutsideRuntime(String),
+    /// The backend read failed; the error deliberately omits the secret address.
     BackendUnavailable(String),
+    /// The backend returned an empty, oversized, or undecodable secret value.
     InvalidSecretValue(String),
+    /// The requested field is absent from the secret JSON object.
     MissingSecretField(String),
 }
 
@@ -103,7 +120,9 @@ impl std::error::Error for AwsSecretResolutionError {}
 /// A secret value returned by the backend. This type deliberately does not
 /// implement `Debug` or `Clone`, and clears its owned bytes when dropped.
 pub enum AwsSecretValue {
+    /// UTF-8 secret text owned and zeroized by this value.
     String(String),
+    /// Binary secret bytes owned and zeroized by this value.
     Binary(Vec<u8>),
 }
 
@@ -117,10 +136,13 @@ impl Drop for AwsSecretValue {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Redacted backend read failure with no secret identifier or provider detail.
 pub struct AwsSecretReadError;
 
 #[async_trait]
+/// Minimal Secrets Manager boundary supplied by the host runtime.
 pub trait AwsSecretReader: Send + Sync {
+    /// Read one authorized secret without interpreting its optional JSON field.
     async fn read_secret(
         &self,
         region: Option<&str>,
@@ -128,12 +150,18 @@ pub trait AwsSecretReader: Send + Sync {
     ) -> Result<AwsSecretValue, AwsSecretReadError>;
 }
 
+/// Return whether any stored value begins with the exact `aws-sm:` scheme.
 pub fn contains_aws_secret_references(values: &BTreeMap<String, String>) -> bool {
     values
         .values()
         .any(|value| value.trim().starts_with(AWS_SECRET_PREFIX))
 }
 
+/// Parse a bounded AWS secret reference without performing a backend read.
+///
+/// Returns `Ok(None)` for values outside the `aws-sm:` scheme. Accepted forms
+/// include a name, `region:name`, or Secrets Manager ARN, plus optional
+/// `#field` selection.
 pub fn parse_aws_secret_reference(
     value: &str,
 ) -> Result<Option<AwsSecretReference>, AwsSecretResolutionError> {
@@ -211,6 +239,11 @@ fn parse_secrets_manager_arn_region(secret_id: &str) -> Option<&str> {
     .then_some(region)
 }
 
+/// Resolve and replace authorized `aws-sm:` values for one source runtime.
+///
+/// References may address only the runtime secret or a hyphen-suffixed child.
+/// Reads are grouped by region and secret ID, and all owned values are zeroized
+/// on failure or after transfer to the returned configuration map.
 pub async fn resolve_aws_secret_references<Reader>(
     tenant_id: &str,
     source_id: &str,

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1,3 +1,10 @@
+//! Bounded HTTP execution for compiled source-catalog families.
+//!
+//! The connector owns URL construction, authentication, pagination, fanout,
+//! response-size limits, and conversion into tenant-scoped source records.
+//! Secret-bearing authentication values are redacted in diagnostics and
+//! zeroized when the connector is dropped.
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     error::Error,
@@ -41,37 +48,65 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Eq, PartialEq)]
+/// Fully resolved authentication material for one source connector.
+///
+/// This type redacts [`Debug`](fmt::Debug) output and zeroizes every owned
+/// credential value on drop.
 pub enum ResolvedAuth {
+    /// Send no provider authentication.
     None,
+    /// Send an OAuth-style bearer token.
     Bearer {
+        /// Token placed in the `Authorization` header.
         token: String,
     },
+    /// Send HTTP Basic credentials.
     Basic {
+        /// Basic-auth username.
         username: String,
+        /// Basic-auth password.
         password: String,
     },
+    /// Send one source-defined sensitive header.
     Header {
+        /// Validated HTTP header name.
         name: String,
+        /// Sensitive header value.
         value: String,
     },
+    /// Send multiple sensitive source-defined headers.
     HeaderParameters {
+        /// Header names and their sensitive values.
         parameters: BTreeMap<String, String>,
     },
+    /// Add sensitive authentication parameters to the request query.
     QueryParameters {
+        /// Query names and their sensitive values.
         parameters: BTreeMap<String, String>,
     },
+    /// Add sensitive authentication parameters to a JSON request body.
     JsonBodyParameters {
+        /// JSON property names and their sensitive values.
         parameters: BTreeMap<String, String>,
     },
+    /// Sign each request with AWS Signature Version 4.
     AwsSigV4 {
+        /// AWS access-key identifier.
         access_key_id: String,
+        /// AWS secret access key.
         secret_access_key: String,
+        /// Optional temporary-credential session token.
         session_token: Option<String>,
+        /// AWS signing region.
         region: String,
+        /// AWS signing service name.
         service: String,
     },
+    /// Sign each request with the Duo Admin API HMAC v5 contract.
     DuoHmacV5 {
+        /// Duo integration key used as the request identity.
         integration_key: String,
+        /// Duo secret key used for HMAC signing.
         secret_key: String,
     },
 }
@@ -171,14 +206,23 @@ impl Drop for ResolvedAuth {
 }
 
 #[derive(Debug)]
+/// The generic HTTP connector could not safely complete collection.
 pub enum HttpConnectorError {
+    /// Compiled catalog, runtime config, or authentication is inconsistent.
     InvalidConfiguration(String),
+    /// A configured or provider-supplied URL is invalid.
     InvalidUrl(String),
+    /// A request failed without containing sensitive request material.
     Request(reqwest::Error),
+    /// A sensitive request failed and only a redacted error may cross the boundary.
     RedactedRequest,
+    /// The provider returned a non-success HTTP status.
     ProviderStatus(StatusCode),
+    /// Provider bytes violate the family response contract.
     InvalidResponse(String),
+    /// Collection receipt or identifier construction violates the domain model.
     Domain(ModelError),
+    /// Pagination exceeded the runtime page limit.
     PageLimit,
 }
 
@@ -239,6 +283,10 @@ enum RequestParameterTarget {
 }
 
 impl HttpSourceConnector {
+    /// Build a connector for one compiled source family and provider base URL.
+    ///
+    /// Construction verifies family existence, authentication-model parity,
+    /// HTTPS transport outside loopback tests, and bounded client timeouts.
     pub fn new(
         source: CompiledSource,
         family_id: &str,

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 //! Rust-native source collection and graph admission boundary.
 
@@ -31,9 +32,13 @@ use cerebro_organizational_model::{
 use serde::Serialize;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// Tenant-scoped instruction passed to a source connector for one collection.
 pub struct CollectionRequest {
+    /// Tenant whose provider data may be returned.
     pub tenant_id: TenantId,
+    /// Durable source-runtime instance executing the collection.
     pub source_runtime_id: SourceRuntimeId,
+    /// Provider cursor from the preceding batch, when collection is paginated.
     pub cursor: Option<String>,
 }
 
@@ -52,6 +57,7 @@ pub struct SourceRuntimeLeaseFence {
 }
 
 impl SourceRuntimeLeaseFence {
+    /// Construct a positive-generation fence for one tenant and runtime owner.
     pub fn new(
         tenant_id: TenantId,
         source_runtime_id: SourceRuntimeId,
@@ -77,41 +83,56 @@ impl SourceRuntimeLeaseFence {
         })
     }
 
+    /// Return the tenant protected by this fence.
     pub fn tenant_id(&self) -> &TenantId {
         &self.tenant_id
     }
 
+    /// Return the source-runtime instance protected by this fence.
     pub fn source_runtime_id(&self) -> &SourceRuntimeId {
         &self.source_runtime_id
     }
 
+    /// Return the validated lease-owner identity.
     pub fn owner(&self) -> &str {
         &self.owner
     }
 
+    /// Return the database generation that must still own the runtime row.
     pub fn generation(&self) -> u64 {
         self.generation
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// One normalized provider record emitted by a source connector.
 pub struct SourceRecord {
+    /// Stable source observation that supports this record.
     pub observation_id: ObservationId,
+    /// Catalog family that determines projection behavior.
     pub family: String,
+    /// Provider-specific resource kind.
     pub provider_kind: String,
+    /// Provider-owned identifier within that kind.
     pub provider_id: String,
+    /// Sorted scalar fields selected by the source catalog.
     pub fields: BTreeMap<String, String>,
+    /// Structured provider payload retained for family-specific mapping.
     pub payload: serde_json::Value,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(tag = "collection_mode", rename_all = "snake_case")]
+/// Authority carried by a collected batch.
 pub enum CollectedScope {
+    /// A complete authoritative collection may close absent provider facts.
     Complete(CompleteCollection),
+    /// An incremental collection may add observations but cannot prove absence.
     NonAuthoritative(CollectionReceipt),
 }
 
 impl CollectedScope {
+    /// Return the collection receipt shared by either authority mode.
     pub fn receipt(&self) -> &CollectionReceipt {
         match self {
             Self::Complete(value) => value.receipt(),
@@ -121,20 +142,29 @@ impl CollectedScope {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// A bounded connector result and the cursor for its next provider page.
 pub struct CollectedBatch {
+    /// Completeness authority for every record in this batch.
     pub scope: CollectedScope,
+    /// Normalized source records collected under the receipt.
     pub records: Vec<SourceRecord>,
+    /// Cursor to resume provider collection, or `None` at the terminal page.
     pub next_cursor: Option<String>,
 }
 
 #[async_trait]
+/// Provider adapter that collects one tenant-scoped batch.
 pub trait SourceConnector: Send {
+    /// Connector-specific collection failure.
     type Error: Error + Send + Sync + 'static;
 
+    /// Collect the requested page without widening its tenant or runtime scope.
     async fn collect(&mut self, request: CollectionRequest) -> Result<CollectedBatch, Self::Error>;
 }
 
+/// Deterministic projection from validated source records into graph mutations.
 pub trait GraphMapper {
+    /// Mapper-specific projection or domain-validation failure.
     type Error: Error + Send + Sync + 'static;
 
     /// Mapping returns a domain-validated `GraphDelta`. No unvalidated entity
@@ -143,9 +173,12 @@ pub trait GraphMapper {
 }
 
 #[async_trait]
+/// Durable graph commit boundary for a collected batch.
 pub trait GraphSink: Send {
+    /// Storage-specific commit failure.
     type Error: Error + Send + Sync + 'static;
 
+    /// Atomically apply a validated graph delta for `batch`.
     async fn apply(
         &mut self,
         batch: &CollectedBatch,
@@ -154,6 +187,7 @@ pub trait GraphSink: Send {
 }
 
 #[async_trait]
+/// Graph sink that verifies durable lease ownership inside the commit path.
 pub trait FencedGraphSink: GraphSink {
     /// Commit only while the exact durable source-runtime lease still exists.
     async fn apply_fenced(
@@ -178,13 +212,19 @@ impl GraphSink for OrganizationalGraph {
 }
 
 #[derive(Debug)]
+/// Failure stage for one source-runtime synchronization.
 pub enum RuntimeError<CollectError, MapError, StoreError> {
+    /// Provider collection failed before mapping.
     Collect(CollectError),
+    /// Connector, mapper, request, or fence tenant/runtime scopes disagree.
     ScopeMismatch,
+    /// Source records could not be projected into a valid graph delta.
     Map(MapError),
+    /// Durable graph commit failed.
     Store(StoreError),
 }
 
+/// Concrete synchronization error derived from a connector, mapper, and sink.
 pub type SyncError<Connector, Mapper, Store> = RuntimeError<
     <Connector as SourceConnector>::Error,
     <Mapper as GraphMapper>::Error,
@@ -218,6 +258,7 @@ where
 {
 }
 
+/// Executes collect, scope validation, mapping, and durable graph commit.
 pub struct SourceRuntime<Connector, Mapper, Store> {
     connector: Connector,
     mapper: Mapper,
@@ -230,6 +271,7 @@ where
     Mapper: GraphMapper,
     Store: GraphSink,
 {
+    /// Assemble a runtime from its provider connector, mapper, and graph sink.
     pub fn new(connector: Connector, mapper: Mapper, store: Store) -> Self {
         Self {
             connector,
@@ -238,6 +280,7 @@ where
         }
     }
 
+    /// Collect and commit one batch after checking every tenant/runtime boundary.
     pub async fn sync(
         &mut self,
         request: CollectionRequest,
@@ -307,6 +350,7 @@ where
             .map_err(RuntimeError::Store)
     }
 
+    /// Consume the runtime and return its graph sink.
     pub fn into_store(self) -> Store {
         self.store
     }

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -1,3 +1,9 @@
+//! Catalog-driven projection from connector records into the sealed graph model.
+//!
+//! Mapping is tenant scoped and deterministic. Catalog templates select the
+//! permitted graph shape, while identity bindings can resolve only against a
+//! caller-supplied snapshot of already accepted canonical claims.
+
 use std::{collections::BTreeMap, error::Error, fmt};
 
 use cerebro_organizational_model::{
@@ -12,11 +18,22 @@ use serde_json::Value;
 use crate::{CollectedBatch, CollectedScope, GraphMapper, SourceRecord};
 
 #[derive(Debug)]
+/// A catalog record could not be projected into a valid graph delta.
 pub enum CatalogMapperError {
+    /// The batch names a family absent from the compiled source catalog.
     UnknownFamily(String),
-    MissingField { family: String, field: String },
+    /// A projection requires a field that the source record did not provide.
+    MissingField {
+        /// Catalog family being projected.
+        family: String,
+        /// Required projected field that was absent.
+        field: String,
+    },
+    /// The catalog selected a template without a generic Rust mapper.
     UnsupportedTemplate(String),
+    /// The projected value violates an organizational-model invariant.
     Domain(ModelError),
+    /// One verified claim points at two different canonical identities.
     IdentityConflict(String),
 }
 
@@ -72,6 +89,7 @@ pub struct IdentityResolutionSnapshot {
 }
 
 impl IdentityResolutionSnapshot {
+    /// Create an empty snapshot restricted to `tenant_id`.
     pub fn new(tenant_id: TenantId) -> Self {
         Self {
             tenant_id: Some(tenant_id),
@@ -79,6 +97,10 @@ impl IdentityResolutionSnapshot {
         }
     }
 
+    /// Add a verified email claim and its previously accepted canonical identity.
+    ///
+    /// Repeating the same binding is idempotent. A conflicting binding fails
+    /// rather than letting connector order choose the canonical person.
     pub fn add_verified_email(
         &mut self,
         email: impl Into<String>,
@@ -139,6 +161,10 @@ struct FamilyPlan {
 }
 
 impl CatalogGraphMapper {
+    /// Compile the catalog families and provider kinds used for projection.
+    ///
+    /// `producer_version` becomes assertion provenance and must be a stable,
+    /// non-empty version owned by the mapper deployment.
     pub fn new(
         source: CompiledSource,
         producer_version: impl Into<String>,
@@ -207,6 +233,7 @@ impl CatalogGraphMapper {
         })
     }
 
+    /// Attach the durable identity snapshot used to resolve verified claims.
     pub fn with_identity_resolution(
         mut self,
         identity_resolution: IdentityResolutionSnapshot,

--- a/crates/source-runtime-next/src/runtime_config.rs
+++ b/crates/source-runtime-next/src/runtime_config.rs
@@ -1,3 +1,10 @@
+//! Validation and resolution for persisted connector runtime configuration.
+//!
+//! Stored values are treated as untrusted control-plane input. This module
+//! bounds their size, resolves only explicitly authorized environment
+//! references, validates portable credential references, and fails closed for
+//! secret-store schemes without a native Rust resolver.
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     error::Error,
@@ -19,18 +26,50 @@ const CREDENTIAL_PREFIX: &str = "credential:";
 const AWS_SECRET_PREFIX: &str = "aws-sm:";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// A fail-closed reason that stored runtime configuration could not be used.
 pub enum RuntimeConfigError {
+    /// The source supplied more entries than the bounded runtime accepts.
     TooManyEntries,
+    /// A configuration key is empty, untrimmed, oversized, or contains controls.
     InvalidKey,
+    /// The named configuration value exceeds the per-value byte limit.
     ValueTooLong(String),
+    /// The named key contains `env:` without an environment-variable name.
     EmptyEnvironmentReference(String),
-    DisallowedEnvironmentReference { key: String, name: String },
-    MissingEnvironmentReference { key: String, name: String },
+    /// The key references an environment variable outside its allowlist.
+    DisallowedEnvironmentReference {
+        /// Stored configuration key containing the reference.
+        key: String,
+        /// Environment-variable name that was not authorized.
+        name: String,
+    },
+    /// An authorized environment variable is not set.
+    MissingEnvironmentReference {
+        /// Stored configuration key containing the reference.
+        key: String,
+        /// Authorized environment-variable name that was not set.
+        name: String,
+    },
+    /// A sensitive key resolved to an empty value.
     EmptySensitiveEnvironmentValue(String),
+    /// A `credential:` reference does not have the closed ID-and-field shape.
     InvalidCredentialReference(String),
+    /// An `aws-sm:` reference is malformed.
     InvalidAwsSecretReference(String),
-    NativeReferenceRequiresEnvProjection { key: String, prefix: &'static str },
-    InvalidOpaqueReference { key: String, prefix: &'static str },
+    /// A recognized secret-store scheme requires deployment-time env projection.
+    NativeReferenceRequiresEnvProjection {
+        /// Stored configuration key containing the reference.
+        key: String,
+        /// Recognized secret-store prefix without a Rust resolver.
+        prefix: &'static str,
+    },
+    /// A recognized opaque reference has no secret identifier.
+    InvalidOpaqueReference {
+        /// Stored configuration key containing the malformed reference.
+        key: String,
+        /// Recognized opaque secret-store prefix.
+        prefix: &'static str,
+    },
 }
 
 impl fmt::Display for RuntimeConfigError {


### PR DESCRIPTION
## Summary
- document the complete public API of the Rust source-runtime crate
- explain collection authority, lease fencing, graph admission, append-log decoding, and deterministic digests
- document AWS secret scoping, redaction, zeroization, and HTTP authentication behavior
- enable missing-doc warnings for future public runtime additions

## Validation
- 67 source-runtime tests passed
- Clippy passed for all source-runtime targets with warnings denied
- rustdoc passed with warnings denied and zero missing public items
- cargo fmt check passed
- git diff --check passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/2214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->