### PR TITLE
docs: complete control-kernel public contracts

### DIFF
--- a/crates/control-kernel/src/identity.rs
+++ b/crates/control-kernel/src/identity.rs
@@ -4,19 +4,34 @@ use serde::{Deserialize, Serialize};
 
 const MAX_IDENTIFIER_BYTES: usize = 256;
 
+/// Reason a control-kernel identifier was rejected at its construction
+/// boundary.
+///
+/// Identifiers remain opaque strings after validation: the kernel enforces a
+/// bounded, unambiguous wire representation without imposing provider- or
+/// deployment-specific syntax.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum IdentifierError {
+    /// No identifier bytes were supplied.
     Empty {
+        /// Human-readable identifier class used in the error message.
         kind: &'static str,
     },
+    /// The UTF-8 representation exceeds the kernel's wire-size bound.
     TooLong {
+        /// Human-readable identifier class used in the error message.
         kind: &'static str,
+        /// Maximum accepted UTF-8 byte length.
         max_bytes: usize,
     },
+    /// The value would change if leading or trailing whitespace were removed.
     SurroundingWhitespace {
+        /// Human-readable identifier class used in the error message.
         kind: &'static str,
     },
+    /// The value contains a Unicode control character.
     ControlCharacter {
+        /// Human-readable identifier class used in the error message.
         kind: &'static str,
     },
 }
@@ -41,16 +56,23 @@ impl fmt::Display for IdentifierError {
 impl Error for IdentifierError {}
 
 macro_rules! identifier {
-    ($name:ident, $kind:literal) => {
+    ($name:ident, $kind:literal, $doc:literal) => {
+        #[doc = $doc]
+        ///
+        /// The value is serialized transparently as its validated string and
+        /// must be created through [`Self::parse`] or [`std::str::FromStr`].
         #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
         #[serde(transparent)]
         pub struct $name(String);
 
         impl $name {
+            /// Validates and constructs this identifier without normalizing
+            /// the caller's bytes.
             pub fn parse(value: impl Into<String>) -> Result<Self, IdentifierError> {
                 validate_identifier(value.into(), $kind).map(Self)
             }
 
+            /// Returns the exact validated wire value.
             pub fn as_str(&self) -> &str {
                 &self.0
             }
@@ -72,19 +94,71 @@ macro_rules! identifier {
     };
 }
 
-identifier!(TenantId, "tenant id");
-identifier!(MandateId, "mandate id");
-identifier!(MissionId, "mission id");
-identifier!(BeliefId, "belief id");
-identifier!(PlanId, "plan id");
-identifier!(CommitmentId, "commitment id");
-identifier!(WakeConditionId, "wake condition id");
-identifier!(ConversationId, "conversation id");
-identifier!(ActorId, "actor id");
-identifier!(GrantId, "grant id");
-identifier!(DecisionId, "decision id");
-identifier!(VerificationId, "verification id");
-identifier!(RequestId, "request id");
+identifier!(
+    TenantId,
+    "tenant id",
+    "Stable tenant boundary for every control-kernel record."
+);
+identifier!(
+    MandateId,
+    "mandate id",
+    "Stable identity of an operator-approved mandate."
+);
+identifier!(
+    MissionId,
+    "mission id",
+    "Stable identity of one durable mission lifecycle."
+);
+identifier!(
+    BeliefId,
+    "belief id",
+    "Stable identity of one revisable belief record."
+);
+identifier!(
+    PlanId,
+    "plan id",
+    "Stable identity shared by all revisions of one plan."
+);
+identifier!(
+    CommitmentId,
+    "commitment id",
+    "Stable identity of one plan-bound commitment."
+);
+identifier!(
+    WakeConditionId,
+    "wake condition id",
+    "Stable identity of one durable wake predicate."
+);
+identifier!(
+    ConversationId,
+    "conversation id",
+    "Stable identity of one ordered conversation."
+);
+identifier!(
+    ActorId,
+    "actor id",
+    "Stable identity of a human or machine actor."
+);
+identifier!(
+    GrantId,
+    "grant id",
+    "Stable identity of a bounded capability grant."
+);
+identifier!(
+    DecisionId,
+    "decision id",
+    "Stable identity of an authorization decision."
+);
+identifier!(
+    VerificationId,
+    "verification id",
+    "Stable identity of an independent verification receipt."
+);
+identifier!(
+    RequestId,
+    "request id",
+    "Stable identity of an idempotent protocol request."
+);
 
 fn validate_identifier(value: String, kind: &'static str) -> Result<String, IdentifierError> {
     if value.is_empty() {

--- a/crates/control-kernel/src/lib.rs
+++ b/crates/control-kernel/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 //! Durable control-plane primitives for Cerebro mandates and missions.
 //!

--- a/crates/control-kernel/src/protocol.rs
+++ b/crates/control-kernel/src/protocol.rs
@@ -217,19 +217,42 @@ impl ControlCommand {
 /// Provider-neutral result returned by a control-kernel host adapter.
 pub enum ControlResponse {
     /// Returns the latest mission snapshot.
-    Mission { mission: Mission },
+    Mission {
+        /// Mission after the requested transition or read.
+        mission: Mission,
+    },
     /// Returns a fail-closed capability decision.
-    Authorization { decision: AuthorizationDecision },
+    Authorization {
+        /// Decision bound to the exact authorization request.
+        decision: AuthorizationDecision,
+    },
     /// Returns deterministic encounter execution depth.
-    ExecutionDepth { depth: ExecutionDepth },
+    ExecutionDepth {
+        /// Maximum execution depth selected for the encounter.
+        depth: ExecutionDepth,
+    },
     /// Returns deterministic conversation-to-mission resolution.
-    Conversation { resolution: ConversationResolution },
+    Conversation {
+        /// Resolution describing whether to continue, open, or avoid a mission.
+        resolution: ConversationResolution,
+    },
     /// Returns the supervisor's next bounded mission action.
-    Directive { directive: MissionDirective },
+    Directive {
+        /// Pure directive selected from the supplied supervisor snapshot.
+        directive: MissionDirective,
+    },
     /// Confirms asynchronous acceptance under the supplied request identity.
-    Accepted { request_id: RequestId },
+    Accepted {
+        /// Idempotency identity under which the host accepted the command.
+        request_id: RequestId,
+    },
     /// Returns a bounded machine code and operator-readable failure.
-    Rejected { code: String, message: String },
+    Rejected {
+        /// Stable machine-readable rejection code.
+        code: String,
+        /// Bounded operator-readable explanation.
+        message: String,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/control-kernel/src/supervisor.rs
+++ b/crates/control-kernel/src/supervisor.rs
@@ -2,42 +2,81 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Commitment, CommitmentId, CommitmentState, MissionState, WakeConditionId};
 
+/// Minimal durable projection required to choose the mission's next action.
+///
+/// The supervisor is intentionally pure: callers assemble this snapshot from
+/// the authoritative mission, plan, commitment, and wake-condition records,
+/// then persist any resulting transition outside this module.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SupervisorSnapshot {
+    /// Current state of the mission lifecycle.
     pub mission_state: MissionState,
+    /// Whether the mission has a current plan revision eligible for execution.
     pub has_current_plan: bool,
+    /// Commitments in their deterministic plan order. When several records
+    /// share a state, the first record wins.
     pub commitments: Vec<Commitment>,
+    /// Wake conditions that remain armed for the mission.
     pub armed_wake_condition_ids: Vec<WakeConditionId>,
+    /// Wake conditions whose predicates have been durably satisfied.
     pub satisfied_wake_condition_ids: Vec<WakeConditionId>,
 }
 
+/// One bounded instruction emitted by the pure mission supervisor.
+///
+/// A directive describes the next control-plane action; it is not proof that
+/// the action ran. Hosts must still apply authorization, fencing, execution,
+/// persistence, and verification at their owning boundaries.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "directive", rename_all = "snake_case")]
 pub enum MissionDirective {
+    /// Resolve the mandate and subject before planning.
     ResolveScope,
+    /// Produce or revise the current plan.
     RevisePlan,
+    /// Obtain a durable decision for the named commitment.
     RequestDecision {
+        /// Commitment whose authority is incomplete.
         commitment_id: CommitmentId,
     },
+    /// Execute the named ready commitment.
     Execute {
+        /// Commitment selected for bounded execution.
         commitment_id: CommitmentId,
     },
+    /// Verify the named executing or verification-pending commitment.
     Verify {
+        /// Commitment whose expected effect requires fresh evidence.
         commitment_id: CommitmentId,
     },
+    /// Remain idle until at least one named armed condition is satisfied.
     Wait {
+        /// Exact conditions the host should continue observing.
         wake_condition_ids: Vec<WakeConditionId>,
     },
+    /// Re-enter planning using newly satisfied wake evidence.
     ReplanFromWake {
+        /// Conditions whose satisfaction triggered reconsideration.
         wake_condition_ids: Vec<WakeConditionId>,
     },
+    /// Stop automatic progress because the snapshot violates a supervisor
+    /// invariant or lacks the record required by its mission state.
     Blocked {
+        /// Stable machine-readable reason code.
         code: String,
     },
+    /// Close a verified mission.
     Close,
+    /// Perform no work for an already closed mission.
     NoAction,
 }
 
+/// Selects exactly one next directive from a mission projection.
+///
+/// Selection is deterministic. Satisfied wake conditions take precedence over
+/// armed conditions, and commitment work is ordered as approval, execution,
+/// then verification. Missing records fail closed through a stable `Blocked`
+/// code instead of guessing a recovery action.
 pub fn next_directive(snapshot: &SupervisorSnapshot) -> MissionDirective {
     match snapshot.mission_state {
         MissionState::Open | MissionState::ResolvingScope => MissionDirective::ResolveScope,
@@ -95,6 +134,9 @@ fn blocked(code: &str) -> MissionDirective {
 }
 
 fn next_commitment_directive(commitments: &[Commitment]) -> Option<MissionDirective> {
+    // Approval always wins so an executable sibling cannot let the mission
+    // run past an unresolved authority boundary. Ready work precedes
+    // verification only after no pending decision remains.
     commitments
         .iter()
         .find(|commitment| commitment.state == CommitmentState::WaitingOnApproval)

--- a/crates/control-kernel/src/wake.rs
+++ b/crates/control-kernel/src/wake.rs
@@ -6,74 +6,135 @@ use crate::{ConversationId, DecisionId, WakeConditionId};
 
 const MAX_TEXT_BYTES: usize = 4_096;
 
+/// A durable predicate that can make a waiting mission eligible for replanning.
+///
+/// Each variant names both the authority surface to observe and the exact
+/// baseline that must change. The kernel stores the predicate; a host adapter
+/// remains responsible for observing sources, clocks, conversations, and
+/// decisions and for presenting the corresponding [`WakeSignal`].
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum WakeConditionKind {
+    /// Wake after one authoritative source reports a revision other than the
+    /// revision recorded when the condition was armed.
     SourceRevisionChanged {
+        /// Stable URN of the source whose revision is authoritative.
         source_urn: String,
+        /// Exact revision already incorporated into the mission.
         baseline_revision: String,
     },
+    /// Wake after a specific event type is observed for a specific subject.
     EventObserved {
+        /// Canonical event type, such as `identity.offboarded`.
         event_type: String,
+        /// Stable URN of the subject to which the event must apply.
         subject_urn: String,
     },
+    /// Wake no earlier than an absolute Unix timestamp.
     DeadlineReached {
+        /// Inclusive lower bound, in Unix epoch milliseconds.
         not_before_unix_ms: u64,
     },
+    /// Wake after a durable conversation advances beyond a known sequence.
     ConversationAdvanced {
+        /// Conversation whose ordered record is being observed.
         conversation_id: ConversationId,
+        /// Last sequence already incorporated into the mission; a signal must
+        /// carry a strictly greater sequence.
         after_sequence: u64,
     },
+    /// Wake after the exact requested decision has been recorded.
     DecisionRecorded {
+        /// Decision identity bound to the pending authorization question.
         decision_id: DecisionId,
     },
 }
 
+/// One observation offered to an armed [`WakeCondition`].
+///
+/// Signals are facts, not commands: presenting one cannot mutate a condition
+/// unless its variant and bound identifiers satisfy the stored predicate.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "signal", rename_all = "snake_case")]
 pub enum WakeSignal {
+    /// Current revision reported by an authoritative source.
     SourceRevision {
+        /// Stable URN of the reporting source.
         source_urn: String,
+        /// Revision observed at evaluation time.
         revision: String,
     },
+    /// Event observed for a subject.
     Event {
+        /// Canonical observed event type.
         event_type: String,
+        /// Stable URN of the observed subject.
         subject_urn: String,
     },
+    /// Trusted clock observation.
     Clock {
+        /// Time observed by the host, in Unix epoch milliseconds.
         observed_at_unix_ms: u64,
     },
+    /// Durable conversation sequence observation.
     Conversation {
+        /// Conversation that advanced.
         conversation_id: ConversationId,
+        /// Latest durably recorded sequence.
         sequence: u64,
     },
+    /// Durable authorization-decision observation.
     Decision {
+        /// Decision that was recorded.
         decision_id: DecisionId,
     },
 }
 
+/// Lifecycle state of a wake condition.
+///
+/// `Satisfied` and `Cancelled` are terminal. A terminal condition must never
+/// be rearmed or reinterpreted in place; create a new condition identity for a
+/// new wait.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WakeConditionState {
+    /// The condition may accept one matching signal or be cancelled.
     Armed,
+    /// A matching signal was observed after the condition was armed.
     Satisfied,
+    /// The wait was explicitly retired without a matching signal.
     Cancelled,
 }
 
+/// Durable record of one bounded reason for resuming a waiting mission.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct WakeCondition {
+    /// Stable identity used by mission events and supervisor directives.
     pub wake_condition_id: WakeConditionId,
+    /// Predicate that a host observation must satisfy.
     pub kind: WakeConditionKind,
+    /// Current lifecycle state.
     pub state: WakeConditionState,
+    /// Trusted creation time, in Unix epoch milliseconds.
     pub armed_at_unix_ms: u64,
+    /// Trusted matching-observation time. Present exactly when `state` is
+    /// [`WakeConditionState::Satisfied`].
     pub satisfied_at_unix_ms: Option<u64>,
+    /// Bounded operator-readable reason for arming or cancelling the wait.
     pub reason: String,
 }
 
+/// Rejection returned when a wake-condition transition would violate its
+/// durable predicate or lifecycle.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WakeConditionError {
+    /// The condition contains a zero timestamp, empty or ambiguous text, an
+    /// invalid predicate bound, or another malformed input.
     InvalidCondition,
+    /// A caller attempted to satisfy or cancel a terminal condition.
     AlreadyTerminal,
+    /// The signal does not match the stored predicate, or its observation time
+    /// predates the condition.
     SignalMismatch,
 }
 
@@ -90,6 +151,11 @@ impl fmt::Display for WakeConditionError {
 impl Error for WakeConditionError {}
 
 impl WakeCondition {
+    /// Creates an armed condition after validating all predicate bounds.
+    ///
+    /// `armed_at_unix_ms` must be non-zero. Text fields are trimmed, bounded,
+    /// and free of control characters. Construction performs no observation;
+    /// only [`Self::satisfy`] can move the condition to `Satisfied`.
     pub fn arm(
         wake_condition_id: WakeConditionId,
         kind: WakeConditionKind,
@@ -109,6 +175,12 @@ impl WakeCondition {
         })
     }
 
+    /// Returns a satisfied copy when `signal` matches this armed condition.
+    ///
+    /// The original value is unchanged. `observed_at_unix_ms` is the durable
+    /// transition time and cannot precede `armed_at_unix_ms`. For deadline
+    /// conditions the clock carried inside the signal must also meet the
+    /// stored deadline.
     pub fn satisfy(
         &self,
         signal: &WakeSignal,
@@ -126,6 +198,11 @@ impl WakeCondition {
         Ok(next)
     }
 
+    /// Returns a cancelled copy with a replacement operator-readable reason.
+    ///
+    /// Cancellation is available only while armed and deliberately leaves
+    /// `satisfied_at_unix_ms` empty so cancellation cannot masquerade as
+    /// evidence that the predicate became true.
     pub fn cancel(&self, reason: String) -> Result<Self, WakeConditionError> {
         if self.state != WakeConditionState::Armed {
             return Err(WakeConditionError::AlreadyTerminal);
@@ -139,6 +216,7 @@ impl WakeCondition {
 }
 
 impl WakeConditionKind {
+    /// Validates bounds that are specific to each predicate variant.
     fn is_valid(&self) -> bool {
         match self {
             Self::SourceRevisionChanged {
@@ -155,6 +233,7 @@ impl WakeConditionKind {
         }
     }
 
+    /// Applies the stored identity and monotonicity constraints to one signal.
     fn matches(&self, signal: &WakeSignal) -> bool {
         match (self, signal) {
             (


### PR DESCRIPTION
## Summary
- document every public wake predicate, signal, lifecycle state, record field, transition, and failure mode
- document supervisor snapshot ownership, directive semantics, fail-closed states, and commitment-selection priority
- document all macro-generated identifier types and the exact validation boundary
- document the remaining control-response wire fields
- deny missing public documentation across the control-kernel crate

## Stack
This documentation-only PR is based on #2222 so it inherits the CI range and dependency-audit repairs without duplicating them. After #2222 merges, this PR can be retargeted to `main` with the same documentation diff.

## Validation
- `cargo fmt --all --check`
- `cargo test -p cerebro-control-kernel --all-targets` (28 passed)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p cerebro-control-kernel --no-deps`
- `cargo clippy -p cerebro-control-kernel --all-targets -- -D warnings`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/2223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->