### PR TITLE
docs: define Slack authority contracts

### DIFF
--- a/crates/slack-authority/src/lib.rs
+++ b/crates/slack-authority/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(unsafe_code)]
+#![deny(missing_docs)]
 
 //! Deterministic Slack request and answer authority.
 //!
@@ -6,14 +7,30 @@
 //! candidate facts. This crate owns the fail-closed decisions about whether a
 //! request can be sent upstream and whether a candidate can be delivered as
 //! grounded evidence or as a structured safe refusal.
+//!
+//! The authority has two independent boundaries:
+//!
+//! 1. [`authorize_question`] validates tenant, request, question, and bounded
+//!    history before selecting a deterministic execution lane.
+//! 2. [`validate_answer`] accepts only a terminal answer with either validated,
+//!    row-backed citations or a complete, trace-bound safe refusal.
+//!
+//! Callers cannot assert authorization, verification, or refusal state through
+//! extra JSON fields because all candidate records reject unknown fields. This
+//! crate does not authenticate Slack, query the graph, generate prose, validate
+//! citation contents, or persist traces; those remain host responsibilities.
 
 use std::{error::Error, fmt};
 
 use serde::{Deserialize, Serialize};
 
+/// Supported schema for an untrusted answer submitted to [`validate_answer`].
 pub const ANSWER_CANDIDATE_V1: &str = "slack-answer-candidate/v1";
+/// Schema emitted for an authoritative [`AnswerDecision`].
 pub const ANSWER_DECISION_V1: &str = "slack-answer-decision/v1";
+/// Supported schema for an untrusted question submitted to [`authorize_question`].
 pub const QUESTION_CANDIDATE_V1: &str = "slack-question-candidate/v1";
+/// Schema emitted for an authoritative [`QuestionDecision`].
 pub const QUESTION_DECISION_V1: &str = "slack-question-decision/v1";
 const MAX_HISTORY_ITEMS: usize = 16;
 const MAX_HISTORY_ITEM_BYTES: usize = 8 * 1024;
@@ -27,34 +44,63 @@ const SELF_CONTEXT_ANSWER: &str = "I’m Cerebro, Writer’s security operations
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+/// Untrusted, tenant-labelled question supplied by the Slack transport host.
+///
+/// Deserialization rejects unknown fields so a caller cannot smuggle an
+/// `authorized` flag or another authority-bearing claim into the boundary.
 pub struct QuestionCandidate {
+    /// Candidate schema; must equal [`QUESTION_CANDIDATE_V1`].
     pub schema_version: String,
+    /// Tenant claimed by the transport and checked against [`QuestionPolicy`].
     pub tenant_id: String,
+    /// Bounded transport correlation identifier for this request.
     pub request_id: String,
+    /// Non-empty user question routed by the authority.
     pub question: String,
+    /// Bounded prior messages supplied only as conversational context.
     pub history: Vec<QuestionHistoryMessage>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+/// One bounded conversational message preceding a question.
 pub struct QuestionHistoryMessage {
+    /// Non-empty message text; control characters other than whitespace are rejected.
     pub content: String,
+    /// Speaker that produced the message.
     pub role: QuestionHistoryRole,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
+/// Allowed speakers in question history.
 pub enum QuestionHistoryRole {
+    /// A prior message produced by Cerebro.
     Assistant,
+    /// A prior message produced by the Slack user.
     User,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Server-owned tenant constraint used to authorize Slack questions.
+///
+/// The tenant is private so candidates cannot mutate policy after construction.
 pub struct QuestionPolicy {
     tenant_id: String,
 }
 
 impl QuestionPolicy {
+    /// Constructs a policy for one bounded tenant identifier.
+    ///
+    /// Identifiers may contain ASCII letters, digits, `-`, `_`, `:`, and `.`.
+    /// Leading or trailing whitespace does not make an otherwise empty or
+    /// oversized identifier valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QuestionAuthorityError::InvalidPolicy`] when `tenant_id` is
+    /// empty, oversized, contains whitespace, or contains another character
+    /// outside the identifier alphabet.
     pub fn new(tenant_id: String) -> Result<Self, QuestionAuthorityError> {
         if !bounded_identifier(&tenant_id, MAX_TENANT_ID_BYTES) {
             return Err(QuestionAuthorityError::InvalidPolicy);
@@ -64,30 +110,54 @@ impl QuestionPolicy {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// Authoritative routing result for one accepted question.
+///
+/// A successful decision always has `authorized == true`. Rejected candidates
+/// return [`QuestionAuthorityError`] instead of a serializable denial that a
+/// caller could accidentally treat as executable.
 pub struct QuestionDecision {
+    /// Decision schema; always [`QUESTION_DECISION_V1`].
     pub schema_version: &'static str,
+    /// Tenant copied from the candidate after policy equality is proven.
     pub tenant_id: String,
+    /// Validated transport correlation identifier.
     pub request_id: String,
+    /// Positive authorization produced only after every request check passes.
     pub authorized: bool,
+    /// Host action permitted for this question.
     pub execution_lane: QuestionExecutionLane,
+    /// Authority-owned response for [`QuestionExecutionLane::Converse`].
+    ///
+    /// Lookup decisions omit this field because the host must obtain governed
+    /// evidence before it can produce an answer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub answer: Option<&'static str>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
+/// Permitted execution path for an authorized question.
 pub enum QuestionExecutionLane {
+    /// Return the authority-owned self/work-status answer without a graph query.
     Converse,
+    /// Query governed evidence before constructing an answer candidate.
     Lookup,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Fail-closed rejection at the question authority boundary.
 pub enum QuestionAuthorityError {
+    /// History contains too many messages or an invalid message body.
     HistoryInvalid,
+    /// Server-owned tenant policy is malformed.
     InvalidPolicy,
+    /// Transport request identifier is malformed or oversized.
     InvalidRequest,
+    /// Candidate schema is not supported by this build.
     InvalidSchema,
+    /// Question text is empty, invalid, or oversized.
     QuestionInvalid,
+    /// Candidate tenant differs from the server-owned policy tenant.
     TenantMismatch,
 }
 
@@ -107,6 +177,17 @@ impl fmt::Display for QuestionAuthorityError {
 
 impl Error for QuestionAuthorityError {}
 
+/// Authorizes and deterministically routes one tenant-bound Slack question.
+///
+/// Self-identification and work-status questions use the `converse` lane and
+/// receive a fixed answer that does not claim unavailable cross-thread state.
+/// Every other accepted question uses `lookup`; this function does not infer
+/// that evidence exists and does not authorize arbitrary graph queries.
+///
+/// # Errors
+///
+/// Returns [`QuestionAuthorityError`] when the schema, tenant, request identity,
+/// question, or bounded history fails validation.
 pub fn authorize_question(
     policy: &QuestionPolicy,
     candidate: QuestionCandidate,
@@ -175,56 +256,98 @@ fn question_execution_lane(question: &str) -> QuestionExecutionLane {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+/// Untrusted terminal answer submitted for delivery authorization.
+///
+/// Exactly one evidence state must be supportable: validated citations for a
+/// grounded answer, or a structured [`UnsupportedQuery`] for a safe refusal.
 pub struct AnswerCandidate {
+    /// Candidate schema; must equal [`ANSWER_CANDIDATE_V1`].
     pub schema_version: String,
+    /// Whether the upstream stream reached its terminal done event.
     pub completed: bool,
+    /// Non-empty bounded Slack markdown proposed for delivery.
     pub markdown: String,
+    /// Trace identifier shared with a structured refusal, when present.
     pub trace_id: String,
+    /// Host-produced summary of row-backed citation validation.
     pub citation_validation: Option<CitationValidation>,
+    /// Structured reason the governed query could not be answered safely.
     pub unsupported_query: Option<UnsupportedQuery>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+/// Host-produced counts proving that answer citations resolve to returned rows.
+///
+/// This crate checks the state and counts but does not inspect citation contents;
+/// the host that owns the result rows remains responsible for that validation.
 pub struct CitationValidation {
+    /// Whether host citation validation completed successfully.
     pub ok: bool,
+    /// Number of distinct row URNs referenced by the proposed answer.
     pub referenced_urn_count: usize,
+    /// Number of distinct citable URNs present in the returned rows.
     pub row_urn_count: usize,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+/// Structured, actionable refusal produced when a query cannot run safely.
 pub struct UnsupportedQuery {
+    /// Stable machine-readable reason code.
     pub code: String,
+    /// Bounded operator-facing explanation of the limitation.
     pub reason: String,
+    /// One or more bounded questions likely to fit the supported boundary.
     pub suggested_rewrites: Vec<String>,
+    /// One or more stable intent identifiers that the runtime supports.
     pub supported_intents: Vec<String>,
+    /// Trace identifier that must equal [`AnswerCandidate::trace_id`].
     pub trace_id: String,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
+/// Delivery class authorized for a validated answer.
 pub enum AnswerDisposition {
+    /// Answer is backed by validated citations to returned graph rows.
     Grounded,
+    /// Answer contains a complete, trace-bound explanation of unsupported scope.
     SafeRefusal,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// Authoritative delivery decision for a terminal answer candidate.
 pub struct AnswerDecision {
+    /// Decision schema; always [`ANSWER_DECISION_V1`].
     pub schema_version: &'static str,
+    /// Evidence state the host is permitted to deliver.
     pub disposition: AnswerDisposition,
+    /// Validated trace identifier copied from the candidate.
     pub trace_id: String,
+    /// Whether delivery is supported by validated row-backed citations.
+    ///
+    /// This is `true` only for [`AnswerDisposition::Grounded`]; a safe refusal is
+    /// authorized for delivery but is not verified evidence about the environment.
     pub verified: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Fail-closed rejection at the answer authority boundary.
 pub enum AnswerAuthorityError {
+    /// A purported grounded answer lacks valid, non-zero row-backed citations.
     CitationEvidenceMissing,
+    /// Candidate simultaneously claims grounded evidence and a safe refusal.
     ConflictingEvidenceStates,
+    /// Upstream answer stream did not reach a terminal event.
     Incomplete,
+    /// Structured refusal is empty, inconsistent, oversized, or cross-trace.
     InvalidRefusal,
+    /// Candidate schema is not supported by this build.
     InvalidSchema,
+    /// Candidate trace identifier is empty, invalid, oversized, or inconsistent.
     InvalidTrace,
+    /// Proposed Slack markdown is empty, invalid, or oversized.
     MarkdownInvalid,
 }
 
@@ -249,6 +372,19 @@ impl fmt::Display for AnswerAuthorityError {
 
 impl Error for AnswerAuthorityError {}
 
+/// Validates whether a terminal answer may be delivered to Slack.
+///
+/// Grounded delivery requires successful citation validation, at least one row
+/// URN, at least one referenced URN, and no more referenced URNs than the result
+/// contains. Safe-refusal delivery requires a matching trace plus non-empty,
+/// bounded reason, rewrite, and supported-intent fields. A refusal never sets
+/// [`AnswerDecision::verified`].
+///
+/// # Errors
+///
+/// Returns [`AnswerAuthorityError`] when the schema, terminal state, markdown,
+/// trace, citation evidence, or refusal structure fails validation, or when the
+/// candidate presents conflicting grounded and refusal states.
 pub fn validate_answer(candidate: AnswerCandidate) -> Result<AnswerDecision, AnswerAuthorityError> {
     if candidate.schema_version != ANSWER_CANDIDATE_V1 {
         return Err(AnswerAuthorityError::InvalidSchema);


### PR DESCRIPTION
## Summary

- document the tenant-bound question authorization contract and deterministic execution lanes
- document grounded-answer and safe-refusal evidence states, trace binding, and host ownership boundaries
- document every public schema, record, field, enum, error, constructor, and decision function
- deny missing public documentation so future authority APIs must preserve the contract

## Verification

- `cargo fmt --all --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p cerebro-slack-authority --no-deps`
- `cargo test -p cerebro-slack-authority --all-targets` (12 passed)
- `cargo clippy -p cerebro-slack-authority --all-targets -- -D warnings`