### PR TITLE
docs: define durable projection contracts

### DIFF
--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -1,6 +1,28 @@
 #![forbid(unsafe_code)]
 
-//! Durable organizational ledger and Neo4j current-state projection.
+//! Durable organizational ledger and rebuildable current-state projections.
+//!
+//! PostgreSQL is the source of truth for admitted graph revisions, source
+//! collection receipts, and the projection outbox. Neo4j is a derived read
+//! model. [`DurableGraphStore`] commits a delta and its exact projection payload
+//! atomically to the ledger before attempting Neo4j, so a projection outage
+//! cannot erase or cause a source collection to be repeated.
+//!
+//! # Commit outcomes
+//!
+//! A successful graph-sink call means both the ledger commit and its immediate
+//! projection completed. [`StoreError::ProjectionPending`] means the ledger
+//! commit succeeded but Neo4j did not: its embedded [`GraphWriteReceipt`] is the
+//! durable commit receipt, and the outbox must be replayed rather than collecting
+//! the provider again. [`DurableGraphStore::replay_pending`] and
+//! [`DurableGraphStore::resume_collection`] perform that recovery.
+//!
+//! # Read authority
+//!
+//! Lifecycle reads are served only when the projection declares the expected
+//! schema and exactly matches the ledger graph revision. Stale, rebuilding, or
+//! absent projection state returns [`StoreError::LifecycleProjectionUnavailable`]
+//! instead of presenting derived data as current truth.
 
 mod credential_vault;
 mod cutover;
@@ -34,17 +56,31 @@ use cerebro_source_runtime_next::{
 };
 
 #[derive(Debug)]
+/// A durable ledger, projection, or stored-contract failure.
 pub enum StoreError {
+    /// PostgreSQL rejected or could not complete a ledger operation.
     Postgres(tokio_postgres::Error),
+    /// Neo4j rejected or could not complete a projection operation.
     Neo4j(::neo4rs::Error),
+    /// A validated commit could not be encoded for durable storage.
     Serialization(serde_json::Error),
+    /// Stored or supplied values violated an organizational-store invariant.
     Conflict(String),
+    /// The lifecycle read projection is not current at the ledger revision.
     LifecycleProjectionUnavailable {
+        /// Authoritative graph revision the read would need to represent.
         graph_revision: u64,
+        /// Revision currently projected, or `None` when no ready revision exists.
         projection_revision: Option<u64>,
     },
+    /// The ledger committed successfully but immediate projection failed.
+    ///
+    /// Callers must retain the receipt and replay the outbox; retrying source
+    /// collection would mistake a projection failure for an uncommitted write.
     ProjectionPending {
+        /// Receipt proving the durable ledger commit.
         receipt: GraphWriteReceipt,
+        /// Projection failure detail suitable for operational diagnosis.
         message: String,
     },
 }
@@ -78,6 +114,12 @@ impl fmt::Display for StoreError {
 impl Error for StoreError {}
 
 impl StoreError {
+    /// Returns whether retrying the failed storage or projection operation is safe.
+    ///
+    /// Serialization and invariant conflicts are permanent for the supplied
+    /// input. Backend failures, stale projection reads, and pending projections
+    /// may succeed after recovery. A pending projection must be replayed from
+    /// its durable outbox entry, not recollected from the provider.
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
@@ -116,10 +158,21 @@ pub struct DurableGraphStore {
 }
 
 impl DurableGraphStore {
+    /// Combines an authoritative PostgreSQL ledger with its Neo4j projector.
     pub fn new(ledger: PostgresLedger, projector: Neo4jProjector) -> Self {
         Self { ledger, projector }
     }
 
+    /// Projects up to `limit` oldest pending outbox commits for one tenant.
+    ///
+    /// Each outbox row is marked projected only after Neo4j accepts its exact
+    /// durable payload. Processing stops at the first error, leaving that and
+    /// later rows available for another replay.
+    ///
+    /// # Errors
+    ///
+    /// Returns a backend or stored-contract error while loading, projecting, or
+    /// marking an outbox commit.
     pub async fn replay_pending(&self, tenant_id: &str, limit: usize) -> Result<usize, StoreError> {
         let pending = self.ledger.pending(tenant_id, limit).await?;
         let mut projected = 0;
@@ -133,8 +186,16 @@ impl DurableGraphStore {
         Ok(projected)
     }
 
-    /// Returns an existing collection receipt and, when necessary, projects
-    /// the exact durable outbox payload originally committed with it.
+    /// Resumes an already committed collection without recollecting its source.
+    ///
+    /// Returns `None` when no matching durable collection exists. When its
+    /// projection is pending, this method projects the exact stored outbox
+    /// payload, marks that revision projected, and returns the original receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns a backend or stored-contract error while loading or completing
+    /// the collection's projection.
     pub async fn resume_collection(
         &self,
         tenant_id: &TenantId,

--- a/crates/organizational-store/src/neo4j.rs
+++ b/crates/organizational-store/src/neo4j.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use std::{collections::BTreeMap, time::Duration};
 
 use async_trait::async_trait;
@@ -320,29 +322,52 @@ const NEO4J_SCHEMA: &[&str] = &[
 ];
 
 #[derive(Clone)]
+/// Rebuildable Neo4j projection and tenant-consistent graph reader.
+///
+/// This type never owns graph truth. Writes must already have a durable ledger
+/// receipt, and lifecycle reads fail closed unless the projection is ready at
+/// the current authoritative graph revision.
 pub struct Neo4jProjector {
     graph: Graph,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// A lifecycle finding resolved to its affected resource and source coordinates.
 pub struct ResolvedLifecycleFinding {
+    /// Affected lifecycle resource reconstructed from the projection.
     pub resource: ProjectedResource,
+    /// Graph revision at which the finding and resource were resolved.
     pub graph_revision: u64,
+    /// Runtime that supplied the finding relationship and lifecycle entity.
     pub source_runtime_id: String,
+    /// Source collection that supplied the projected lifecycle records.
     pub source_collection_id: String,
 }
 
 impl Neo4jProjector {
+    /// Wraps an existing Neo4j client graph.
     pub fn from_graph(graph: Graph) -> Self {
         Self { graph }
     }
 
+    /// Connects to a Neo4j endpoint with the supplied database credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Neo4j`] when the client cannot connect.
     pub async fn connect(uri: &str, username: &str, password: &str) -> Result<Self, StoreError> {
         Ok(Self {
             graph: Graph::new(uri, username, password).await?,
         })
     }
 
+    /// Idempotently creates the projection constraints and indexes.
+    ///
+    /// This does not rebuild data or mark a lifecycle projection ready.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Neo4j`] when any schema statement fails.
     pub async fn migrate(&self) -> Result<(), StoreError> {
         for statement in NEO4J_SCHEMA {
             self.graph.run(query(statement)).await?;
@@ -350,6 +375,18 @@ impl Neo4jProjector {
         Ok(())
     }
 
+    /// Executes a prepared lifecycle query against a current tenant projection.
+    ///
+    /// Before reading, the method requires a ready schema-v1 lifecycle projection
+    /// at the current graph revision. It checks the revision again before return;
+    /// [`IndexedLifecyclePage::graph_changed`] reports a concurrent revision so
+    /// clients can discard or restart pagination.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::LifecycleProjectionUnavailable`] for absent, stale,
+    /// or rebuilding projection state. Backend failures and malformed projected
+    /// records are returned as other [`StoreError`] variants.
     pub async fn query_lifecycle(
         &self,
         tenant_id: &TenantId,
@@ -700,6 +737,17 @@ LIMIT $row_limit
         })
     }
 
+    /// Rebuilds one tenant's lifecycle read model from organizational entities.
+    ///
+    /// The projection is marked unavailable before batches are rebuilt and ready
+    /// only after the starting graph revision is rechecked. `batch_size` is
+    /// clamped to `1..=1_000`. The return value is the number of entities rebuilt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Conflict`] if the graph revision changes before,
+    /// during, or while publishing rebuild readiness. Neo4j failures are returned
+    /// as [`StoreError::Neo4j`]. A failed rebuild remains unavailable to readers.
     pub async fn rebuild_lifecycle_projection(
         &self,
         tenant_id: &TenantId,
@@ -874,6 +922,17 @@ LIMIT $row_limit
         Ok(rebuilt)
     }
 
+    /// Resolves a tenant-scoped lifecycle finding to exactly one affected resource.
+    ///
+    /// The finding URN must use the tenant's canonical lifecycle prefix. The
+    /// projection must remain ready at one graph revision for the entire read;
+    /// no match returns `Ok(None)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::LifecycleProjectionUnavailable`] for stale or
+    /// rebuilding state, [`StoreError::Conflict`] for invalid or ambiguous
+    /// projected data, and [`StoreError::Neo4j`] for backend failures.
     pub async fn resolve_lifecycle_finding(
         &self,
         tenant_id: &TenantId,
@@ -1065,6 +1124,16 @@ LIMIT $row_limit
             ))
     }
 
+    /// Projects an admitted delta under its matching durable write receipt.
+    ///
+    /// Tenant identity and delta digest must match the receipt before any Neo4j
+    /// mutation begins. Projection is idempotent at graph revision boundaries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Conflict`] when the receipt does not identify the
+    /// delta or projected provenance is ambiguous, and [`StoreError::Neo4j`] for
+    /// transaction failures.
     pub async fn project(
         &self,
         delta: &GraphDelta,


### PR DESCRIPTION
## Summary
- document PostgreSQL as the authoritative organizational ledger and Neo4j as a rebuildable read projection
- distinguish durable commit success with pending projection from an uncommitted source collection
- document outbox replay, collection resume, lifecycle projection readiness, rebuild revision fencing, and receipt-bound projection
- deny missing public documentation inside the Neo4j projection module

## Validation
- `cargo fmt --all --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p cerebro-organizational-store --no-deps`
- `cargo test -p cerebro-organizational-store --all-targets` (21 passed; 8 infrastructure-dependent tests ignored by fixture contract)
- `cargo clippy -p cerebro-organizational-store --all-targets -- -D warnings`
- `git diff --check`

## DDESK readiness
- installed the missing Ubuntu `pkg-config` and `libssl-dev` build prerequisites on the active development desk before running the crate gates