### PR TITLE
Fix Okta replay projection compatibility

### DIFF
--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -995,18 +995,10 @@ fn replay_legacy_projection_skip(
     mode: ConsumerMode,
     source_id: &str,
     family_id: &str,
-    error: &crate::ProjectionFailure,
+    _error: &crate::ProjectionFailure,
 ) -> Option<&'static str> {
-    if mode == ConsumerMode::Replay
-        && source_id == "okta"
-        && family_id == "threat_insight"
-        && matches!(
-            error,
-            crate::ProjectionFailure::Invalid(message)
-                if message == "family okta.threat_insight is not in the compiled catalog"
-        )
-    {
-        Some("legacy_family_not_in_compiled_catalog")
+    if mode == ConsumerMode::Replay && source_id == "okta" && family_id == "threat_insight" {
+        Some("legacy_retired_family_projection_incompatible")
     } else {
         None
     }
@@ -1338,30 +1330,47 @@ mod tests {
     }
 
     #[test]
-    fn replay_skips_only_the_observed_missing_okta_catalog_family() {
-        let observed = crate::ProjectionFailure::Invalid(
+    fn replay_skips_permanent_failures_only_for_the_retired_okta_family() {
+        let missing_catalog = crate::ProjectionFailure::Invalid(
             "family okta.threat_insight is not in the compiled catalog".to_owned(),
+        );
+        let historical_shape = crate::ProjectionFailure::Invalid(
+            "historical threat insight shape cannot be projected".to_owned(),
         );
         assert_eq!(
             replay_legacy_projection_skip(
                 ConsumerMode::Replay,
                 "okta",
                 "threat_insight",
-                &observed,
+                &missing_catalog,
             ),
-            Some("legacy_family_not_in_compiled_catalog")
+            Some("legacy_retired_family_projection_incompatible")
+        );
+        assert_eq!(
+            replay_legacy_projection_skip(
+                ConsumerMode::Replay,
+                "okta",
+                "threat_insight",
+                &historical_shape,
+            ),
+            Some("legacy_retired_family_projection_incompatible")
         );
         assert_eq!(
             replay_legacy_projection_skip(
                 ConsumerMode::Forward,
                 "okta",
                 "threat_insight",
-                &observed,
+                &missing_catalog,
             ),
             None
         );
         assert_eq!(
-            replay_legacy_projection_skip(ConsumerMode::Replay, "okta", "users", &observed,),
+            replay_legacy_projection_skip(
+                ConsumerMode::Replay,
+                "okta",
+                "group_membership",
+                &missing_catalog,
+            ),
             None
         );
     }

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1679,7 +1679,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 794);
-        assert_eq!(summary.families, 3_891);
+        assert_eq!(summary.families, 3_892);
         assert_eq!(
             summary.projection_classes.values().sum::<usize>(),
             summary.families
@@ -1736,6 +1736,33 @@ mod tests {
         );
         assert_eq!(catalog.get("snyk").unwrap().token_header(), "Authorization");
         assert_eq!(catalog.get("snyk").unwrap().token_scheme(), "Token");
+        let okta_group_membership = catalog
+            .get("okta")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "group_membership")
+            .unwrap();
+        assert_eq!(
+            okta_group_membership.projection().template(),
+            "group_membership"
+        );
+        assert_eq!(
+            okta_group_membership
+                .projection()
+                .fields()
+                .get("group_id")
+                .map(String::as_str),
+            Some("group_id")
+        );
+        assert_eq!(
+            okta_group_membership
+                .projection()
+                .fields()
+                .get("member_id")
+                .map(String::as_str),
+            Some("member_id|member_user_id|user_id|id")
+        );
         assert_eq!(
             catalog.get("airbrake").unwrap().auth_query_parameters(),
             &BTreeMap::from([("key".to_owned(), "token".to_owned())])

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -752,6 +752,56 @@ mod tests {
     }
 
     #[test]
+    fn okta_runtime_membership_becomes_a_native_typed_edge() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("okta").unwrap().clone();
+        let collection = CompleteCollection::new(
+            TenantId::parse("tenant-a").unwrap(),
+            SourceRuntimeId::parse("okta-prod").unwrap(),
+            CollectionId::parse("collection-okta-membership-1").unwrap(),
+            "okta.group_membership",
+            10,
+        )
+        .unwrap();
+        let batch = CollectedBatch {
+            scope: CollectedScope::Complete(collection),
+            records: vec![SourceRecord {
+                observation_id: ObservationId::parse("observation-okta-membership-1").unwrap(),
+                family: "group_membership".to_owned(),
+                provider_kind: "okta.group_membership".to_owned(),
+                provider_id: "membership-1".to_owned(),
+                fields: BTreeMap::from([
+                    ("group_id".to_owned(), "group-1".to_owned()),
+                    ("member_email".to_owned(), "user@example.test".to_owned()),
+                    ("member_id".to_owned(), "user-1".to_owned()),
+                    ("member_name".to_owned(), "User One".to_owned()),
+                    ("member_status".to_owned(), "ACTIVE".to_owned()),
+                    ("member_type".to_owned(), "user".to_owned()),
+                    ("member_user_id".to_owned(), "user-1".to_owned()),
+                    ("user_id".to_owned(), "user-1".to_owned()),
+                ]),
+                payload: serde_json::json!({"id": "user-1"}),
+            }],
+            next_cursor: None,
+        };
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+        assert_eq!(delta.entities().len(), 2);
+        assert_eq!(delta.assertions().len(), 1);
+        let GraphAssertion::Relationship(assertion) = &delta.assertions()[0] else {
+            panic!("expected relationship")
+        };
+        assert_eq!(assertion.relation(), RelationKind::MemberOf);
+    }
+
+    #[test]
     fn application_grant_becomes_an_application_to_resource_access_edge() {
         let root = repository_root();
         let catalog = SourceCatalog::load(

--- a/docs/operations/organizational-projection-replay.md
+++ b/docs/operations/organizational-projection-replay.md
@@ -77,10 +77,13 @@ Replay recognizes a bounded set of pre-canonical historical records as explicit
 skips: the legacy `asset.data_sensitivity` kind, invalid historical observation
 IDs for `gcp.iam_role_assignment`, `gcp.effective_permission`, and
 `aws.public_endpoint`, the catalog-owned `cerebro.health.jetstream_canary`
-without a source envelope, and the retired `okta.threat_insight` family. This
-compatibility applies only in replay mode. The forward consumer continues to
-reject every one of these shapes. Inspect the completed run and review the
-per-source-family skipped counters as the durable evidence for these records.
+without a source envelope, and permanent projection failures for the retired
+`okta.threat_insight` family. The active `okta.group_membership` family is not a
+compatibility skip: its hand-written collector events project through the
+compiled native relationship template. Replay compatibility applies only in
+replay mode. The forward consumer continues to reject every legacy shape.
+Inspect the completed run and review the per-source-family skipped counters as
+the durable evidence for these records.
 
 ## Start the forward durable after replay
 

--- a/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
@@ -170,6 +170,53 @@ entries:
           record_selector: $.data[*]
         - coverage:
             - control_domains:
+                - identity_access
+              evidence_types:
+                - access_review
+                - identity_configuration
+              families:
+                - group_membership
+              high_value: true
+              id: group_memberships
+              notes:
+                - The hand-written Okta runtime supplies the group identifier while reading each group's members.
+              support: supported
+              title: Group memberships
+              type: relationship
+          default_enabled: false
+          event:
+            kind: okta.group_membership
+            required_payload_fields:
+              - id
+              - group_id
+            schema_ref: okta/group_membership/v1
+            urn_kind: okta_group_membership
+          id: group_membership
+          id_field: id
+          label: Group memberships
+          method: GET
+          name_field: profile.login
+          pagination:
+            link_header: Link
+            type: link
+          path: /api/v1/groups/{group_id}/users
+          projection:
+            fields:
+              group_id: group_id
+              member_email: member_email|profile.email
+              member_id: member_id|member_user_id|user_id|id
+              member_name: member_name|profile.login
+              member_status: member_status|status
+              member_type: member_type
+              member_user_id: member_user_id|user_id|id
+              user_id: user_id|id
+            template: group_membership
+          read:
+            path_params:
+              - group_id
+          record_selector: $[*]
+        - coverage:
+            - control_domains:
                 - access_review
               evidence_types:
                 - source_snapshot


### PR DESCRIPTION
## State

Rust replay found compatibility gaps between committed Okta events and the native projection catalog. Go remains authoritative until replay, forward projection, parity, and rollback evidence satisfy the private host's cutover gate.

## Change

- add native projection support for Okta group membership events
- project provider entities and a typed membership edge
- keep declarative collection disabled for the hand-written runtime family
- apply replay-only compatibility to permanent failures from the retired threat-insight family
- preserve forward-mode rejection for legacy shapes
- document the active-family and retired-family boundary

## Validation

- affected Rust package tests
- strict Clippy across the affected packages
- formatting and diff checks
