### PR TITLE
Align Okta membership and Rust candidate contracts

### DIFF
--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -253,7 +253,7 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 		{id: "user_lifecycle", dimensionType: "lifecycle_state", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "dormant_user"},
 		{id: "mfa_posture", dimensionType: "app_entitlement", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "mfa"},
 		{id: "external_accounts", dimensionType: "entity_family", support: "partial", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "external_user"},
-		{id: "group_memberships", dimensionType: "relationship", support: "partial", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "group_membership"},
+		{id: "group_memberships", dimensionType: "relationship", support: "supported", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "group_membership"},
 		{id: "admin_membership", dimensionType: "relationship", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "privileged_role"},
 		{id: "app_access", dimensionType: "app_entitlement", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "app_assignment"},
 		{id: "identity_audit_events", dimensionType: "audit_event", support: "partial", evidenceType: "logging_configuration", controlDomain: "logging_monitoring", requiredFamily: "session"},
@@ -276,7 +276,7 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 		}
 	}
 	groupMemberships := dimensions["group_memberships"]
-	if !hasString(groupMemberships.Notes, "The declarative groups endpoint does not enumerate memberships; dedicated okta.group_membership events in the hand-written Okta source runtime provide full membership projection support.") {
+	if !hasString(groupMemberships.Notes, "The hand-written Okta runtime supplies the group identifier while reading each group's members.") {
 		t.Fatalf("group_memberships notes = %#v, want source projection support note", groupMemberships.Notes)
 	}
 }


### PR DESCRIPTION
## State

Native Okta membership projection changed the catalog coverage contract, but a Go test still asserted the former support state.

## Change

- require supported Okta membership coverage
- require the active hand-written runtime evidence note

## Validation

- `go test ./internal/connectorcatalog`
- `go test -race ./internal/connectorcatalog`
- `git diff --check`
