### PR TITLE
Align Rust candidate catalog count

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -179,7 +179,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 794
-          test "$(jq -r .families <<<"${summary}")" -eq 3891
+          test "$(jq -r .families <<<"${summary}")" -eq 3892
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -247,7 +247,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"794 sources and 3891 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"794 sources and 3892 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp


### PR DESCRIPTION
## State

Native Okta membership projection changed the compiled catalog, but Rust-only candidate E2E still asserted the prior catalog contract and therefore failed closed.

## Change

- align Rust-only candidate E2E with the current compiled catalog
- bind the same catalog contract into candidate receipt evidence

The no-Go-binary, native entrypoint, signature, attestation, and runtime checks remain unchanged.

## Validation

- `cargo test -p cerebro-platform --test rust_only_runtime_contract`
- `actionlint .github/workflows/rust-only-candidate.yml`
- `git diff --check`
